### PR TITLE
docs: 加 CLAUDE.md(AI 协作者 / 新人入场必读)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,60 +1,43 @@
 # CLAUDE.md — 协作者(包括 AI agent)入场必读
 
-omk 是 LLM 评测框架,主打**统计严谨性**(Bootstrap CI / Krippendorff α / Length-debias / Saturation curves)+ verdict / RAG / budget 决策面。任何代码改动都要尊重测量学不变量,任何分支操作都要走 gitflow。
+omk 是 LLM 评测框架,主打**统计严谨性**(Bootstrap CI / Krippendorff α / Length-debias / Saturation curves)+ verdict / RAG / budget 决策面。两条底线:**测量学不变量不能动**,**分支操作走 gitflow**。
 
-## Session 启动 checklist(任何动手 edit 之前)
+## 开工前
 
-1. `git branch --show-current` —— 看当前 working branch
-2. **如果是 `main` 或 `develop`,必须先 `git checkout -b feat/<topic>` 再开始改**。绝不在 main / develop 直接 commit。
-3. 读 [CONTRIBUTING.md](./CONTRIBUTING.md) 第一遍(分支模型 / 发版流程 / commit 风格)
-4. 看 [CHANGELOG.md](./CHANGELOG.md) `[Unreleased]` 段了解在做什么版本
-5. 阅读相关文件,写代码,跑 `yarn lint && yarn build && yarn test`
-6. PR `--base develop`(只有 release PR 是 `--base main`)
+- 看 [CHANGELOG.md](./CHANGELOG.md) `[Unreleased]` 段了解在做什么版本
+- 改完跑 `yarn lint && yarn build && yarn test`
+- 分支模型 / 发版细节 / commit 风格全在 [CONTRIBUTING.md](./CONTRIBUTING.md)
 
-## 分支策略(详见 CONTRIBUTING.md)
+## 分支策略
 
-严格 gitflow,三层流:
+严格 gitflow:`feat/* | fix/* | docs/* | chore/*` → `develop` → `main`(release)。
 
-```
-feat/* / fix/* / docs/* / chore/*  →  develop  →  main(release)
-```
+PR base **永远是 develop**,绝不在 main / develop 直接 commit。release PR merge 后必须 fast-forward `develop = main`,否则 develop 永远落后一个 merge commit。
 
-PR base **永远是 develop**,除非是 release PR。release PR 由 `release/x.y.z` 分支或直接 develop → main 触发,merge 后**必须 fast-forward develop = main**(`git checkout develop && git merge --ff-only origin/main && git push`),否则 develop 永远落后 main 一个 merge commit。
+## 测量学不变量(绝对不能动)
 
-## 测量学不变量(绝对不能改)
+这些是历史报告可比性的锚,改动会破坏跨版本对比:
 
-这些字段 / 算法 / 哈希值是历史报告可比性的锚,任何改动都会破坏跨版本对比,违反 v0.21 测量学主线:
-
-- **Report JSON schema**(`src/types/report.ts` 里的 `Report` / `ReportMeta` / `VariantResult` / `VariantSummary` 字段含义)
-- **Judge Prompt Hash**:`v2-cot=fdc81b19c721` / `v3-cot-length=629bf3b8c41d`,由 `test/grading/judge-hash-frozen.test.ts` 字节级冻结。任何动 `src/grading/judge.ts` 的 prompt 文本会立即让这个测试 fail
+- **Report JSON schema**:`src/types/report.ts` 里 `Report` / `ReportMeta` / `VariantResult` / `VariantSummary` 字段含义
+- **Judge Prompt Hash**:`v2-cot=fdc81b19c721` / `v3-cot-length=629bf3b8c41d`,由 `test/grading/judge-hash-frozen.test.ts` 字节级冻结。动 `src/grading/judge.ts` 的 prompt 文本会立即 fail
 - **五层评分管道**:assertion / llm / judge / dimension / composite 的算法和权重
-- **Bootstrap CI 公式**(`src/eval-core/bootstrap.ts`)
-- **Krippendorff α 公式**(`src/grading/human-gold.ts`)
+- **Bootstrap CI 公式**(`src/eval-core/bootstrap.ts`)、**Krippendorff α 公式**(`src/grading/human-gold.ts`)
 - **Length-debias toggle**(`--no-debias-length` 与 prompt v2/v3 的对应关系)
 
-如果确需 bump,流程:bump `JUDGE_PROMPT_VERSION_DEBIAS_*` 字符串 → 旧 hash 自然失效 → CHANGELOG 显著标注 breaking-comparability change → 新版本号 bump。**不要悄悄改**。
-
-## 发版流程(自动化版,publish.yml 落地后)
-
-push tag `v*` → publish.yml 自动跑:
-
-1. yarn install + lint + build + test
-2. `npm publish --access public --provenance`
-3. **从 CHANGELOG.md 抽 `## [VERSION]` section 自动创建 GitHub Release**(PR #6 引入)
-
-所以维护者只要做:bump `package.json` version + 更新 CHANGELOG.md `[Unreleased]` → `[VERSION] - YYYY-MM-DD`,merge release PR 后打 tag + push tag。其他全自动。
+确需 bump 见 CONTRIBUTING,核心动作是 bump `JUDGE_PROMPT_VERSION_DEBIAS_*` + CHANGELOG 标 breaking-comparability。**不要悄悄改**。
 
 ## 写代码约定
 
-- **commit message 中文**(详见 git log 历史,前缀如 `重构(v0.21):` / `特性(v0.21 B.4):` / `测试:` / `修复:` / `chore(release):`)。Conventional Commits 风格但用中文写正文
-- **user-facing 文案中文优先**(报告 UI / CLI 输出 / 错误信息)。LLM judge 中文译为「**评委**」,不译「判官」,不要中英混用
-- **测试基线**:`test/grading/judge-hash-frozen.test.ts`(judge prompt 不变性)+ `test/__snapshots__/html-renderer.test.ts.snap`(zh/en × list/detail UI 回归)。这两个是 CI gate,改 UI / judge 时会自然失败,review snapshot diff 后 `vitest -u` 更新
-- **CHANGELOG 维护**:每个 feat / fix PR 顺手更新 `[Unreleased]` 子分类(Added / Changed / Fixed / Internal,Keep a Changelog 风格)。release PR 时把 `[Unreleased]` 改成 `[VERSION] - YYYY-MM-DD`
-- **不要硬编码端口**:report server 默认请求 7799 但实际 bound 端口取自 `server.start()` 返回值(可能被占而切到 7800+),所有显示 URL 给用户的代码都要用 `serverUrl` 实参
+- **commit message 中文**,Conventional Commits 风格但中文正文(前缀如 `重构(v0.21):` / `特性:` / `修复:`,见 git log)
+- **user-facing 文案中文优先**(报告 UI / CLI / 错误信息)。LLM judge 译为「**评委**」,不译「判官」,不中英混用
+- **CI gate 两个**:`test/grading/judge-hash-frozen.test.ts`(judge prompt 不变性)、`test/__snapshots__/html-renderer.test.ts.snap`(zh/en × list/detail UI 回归)。改 UI / judge 后 review snapshot diff,确认无误再 `vitest -u`
+- **顺手更新 CHANGELOG `[Unreleased]`**(Keep a Changelog 风格:Added / Changed / Fixed / Internal)
+- **不要硬编码端口**:report server 默认请求 7799 但实际 bound 端口取自 `server.start()` 返回值(7799 被占会切 7800+),所有给用户看的 URL 都用 `serverUrl` 实参
+
+## 发版
+
+push tag `v*` 触发 publish.yml 全自动:lint + build + test → `npm publish` → 从 CHANGELOG 抽对应 section 建 GitHub Release。维护者只 bump version + 改 CHANGELOG `[Unreleased]` → `[VERSION] - YYYY-MM-DD`。细节见 CONTRIBUTING。
 
 ## 其他参考
 
-- [README.md](./README.md) / [README.zh.md](./README.zh.md) — 用户面文档
-- [SKILL.md](./SKILL.md) — Claude Code skill 用法
-- [docs/](./docs/) — 设计 spec(rag-metrics / knowledge-gap-signal / 等)
-- 本地 plan(不在仓库,仅维护者本地):`~/.claude/plans/iridescent-zooming-lynx.md`
+[README.md](./README.md) / [README.zh.md](./README.zh.md) 用户面文档,[SKILL.md](./SKILL.md) Claude Code skill 用法,[docs/](./docs/) 设计 spec(rag-metrics / knowledge-gap-signal / 等)。维护者本地 plan(不在仓库):`~/.claude/plans/iridescent-zooming-lynx.md`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md — 协作者(包括 AI agent)入场必读
+
+omk 是 LLM 评测框架,主打**统计严谨性**(Bootstrap CI / Krippendorff α / Length-debias / Saturation curves)+ verdict / RAG / budget 决策面。任何代码改动都要尊重测量学不变量,任何分支操作都要走 gitflow。
+
+## Session 启动 checklist(任何动手 edit 之前)
+
+1. `git branch --show-current` —— 看当前 working branch
+2. **如果是 `main` 或 `develop`,必须先 `git checkout -b feat/<topic>` 再开始改**。绝不在 main / develop 直接 commit。
+3. 读 [CONTRIBUTING.md](./CONTRIBUTING.md) 第一遍(分支模型 / 发版流程 / commit 风格)
+4. 看 [CHANGELOG.md](./CHANGELOG.md) `[Unreleased]` 段了解在做什么版本
+5. 阅读相关文件,写代码,跑 `yarn lint && yarn build && yarn test`
+6. PR `--base develop`(只有 release PR 是 `--base main`)
+
+## 分支策略(详见 CONTRIBUTING.md)
+
+严格 gitflow,三层流:
+
+```
+feat/* / fix/* / docs/* / chore/*  →  develop  →  main(release)
+```
+
+PR base **永远是 develop**,除非是 release PR。release PR 由 `release/x.y.z` 分支或直接 develop → main 触发,merge 后**必须 fast-forward develop = main**(`git checkout develop && git merge --ff-only origin/main && git push`),否则 develop 永远落后 main 一个 merge commit。
+
+## 测量学不变量(绝对不能改)
+
+这些字段 / 算法 / 哈希值是历史报告可比性的锚,任何改动都会破坏跨版本对比,违反 v0.21 测量学主线:
+
+- **Report JSON schema**(`src/types/report.ts` 里的 `Report` / `ReportMeta` / `VariantResult` / `VariantSummary` 字段含义)
+- **Judge Prompt Hash**:`v2-cot=fdc81b19c721` / `v3-cot-length=629bf3b8c41d`,由 `test/grading/judge-hash-frozen.test.ts` 字节级冻结。任何动 `src/grading/judge.ts` 的 prompt 文本会立即让这个测试 fail
+- **五层评分管道**:assertion / llm / judge / dimension / composite 的算法和权重
+- **Bootstrap CI 公式**(`src/eval-core/bootstrap.ts`)
+- **Krippendorff α 公式**(`src/grading/human-gold.ts`)
+- **Length-debias toggle**(`--no-debias-length` 与 prompt v2/v3 的对应关系)
+
+如果确需 bump,流程:bump `JUDGE_PROMPT_VERSION_DEBIAS_*` 字符串 → 旧 hash 自然失效 → CHANGELOG 显著标注 breaking-comparability change → 新版本号 bump。**不要悄悄改**。
+
+## 发版流程(自动化版,publish.yml 落地后)
+
+push tag `v*` → publish.yml 自动跑:
+
+1. yarn install + lint + build + test
+2. `npm publish --access public --provenance`
+3. **从 CHANGELOG.md 抽 `## [VERSION]` section 自动创建 GitHub Release**(PR #6 引入)
+
+所以维护者只要做:bump `package.json` version + 更新 CHANGELOG.md `[Unreleased]` → `[VERSION] - YYYY-MM-DD`,merge release PR 后打 tag + push tag。其他全自动。
+
+## 写代码约定
+
+- **commit message 中文**(详见 git log 历史,前缀如 `重构(v0.21):` / `特性(v0.21 B.4):` / `测试:` / `修复:` / `chore(release):`)。Conventional Commits 风格但用中文写正文
+- **user-facing 文案中文优先**(报告 UI / CLI 输出 / 错误信息)。LLM judge 中文译为「**评委**」,不译「判官」,不要中英混用
+- **测试基线**:`test/grading/judge-hash-frozen.test.ts`(judge prompt 不变性)+ `test/__snapshots__/html-renderer.test.ts.snap`(zh/en × list/detail UI 回归)。这两个是 CI gate,改 UI / judge 时会自然失败,review snapshot diff 后 `vitest -u` 更新
+- **CHANGELOG 维护**:每个 feat / fix PR 顺手更新 `[Unreleased]` 子分类(Added / Changed / Fixed / Internal,Keep a Changelog 风格)。release PR 时把 `[Unreleased]` 改成 `[VERSION] - YYYY-MM-DD`
+- **不要硬编码端口**:report server 默认请求 7799 但实际 bound 端口取自 `server.start()` 返回值(可能被占而切到 7800+),所有显示 URL 给用户的代码都要用 `serverUrl` 实参
+
+## 其他参考
+
+- [README.md](./README.md) / [README.zh.md](./README.zh.md) — 用户面文档
+- [SKILL.md](./SKILL.md) — Claude Code skill 用法
+- [docs/](./docs/) — 设计 spec(rag-metrics / knowledge-gap-signal / 等)
+- 本地 plan(不在仓库,仅维护者本地):`~/.claude/plans/iridescent-zooming-lynx.md`


### PR DESCRIPTION
## Summary

2026-04-26 session 我连续两次违反 gitflow:
1. 直接在 main 上 commit 4 个 commit(没创 feat 分支)
2. PR base=main 绕过 develop

每次都被用户纠正,force push + 重做 PR 才修复。根因:没读 CONTRIBUTING.md(已经写好了 gitflow 规则),默认沿用 git status 显示的 working branch。

## 这个 PR 加什么

加 [CLAUDE.md](https://github.com/lizhiyao/oh-my-knowledge/blob/feat/claude-md-project-conventions/CLAUDE.md) 作为 AI / 新协作者入场必读文件。Claude Code 工具会自动把 CLAUDE.md 加载到每次 session 的 context,硬性约束行为。

内容(< 100 行,30 秒读完):

- **Session 启动 6 步 checklist** — 第 2 步硬性:working branch 是 main / develop 必须先 \`git checkout -b feat/<topic>\` 再开始改
- **分支策略一句话 + 指向 CONTRIBUTING.md**(不重复 CONTRIBUTING 内容)
- **测量学不变量** — Report schema / Judge prompt hash(\`v2-cot=fdc81b19c721\` / \`v3-cot-length=629bf3b8c41d\`)/ 五层评分 / Bootstrap CI / α / Length-debias 都标"绝对不能改"。CONTRIBUTING.md 没这块,这是项目级硬约束
- **发版流程**(自动化版,PR #6 落地后):push tag → publish.yml 全自动 npm + GitHub Release
- **写代码约定** — 中文 commit / 中文 UI / 评委不译判官 / 7799 不硬编码 / CHANGELOG 每 PR 顺手维护

## 不动的

- CONTRIBUTING.md 已有规则不重复(分支模型 / 发版步骤的 git 命令清单)
- 不破坏现有 commit 历史 / 测试

## Test plan

- [ ] CI 绿
- [ ] CLAUDE.md 阅读体验:30 秒能扫完,关键约束(不在 main commit / 不动 judge hash)一目了然
- [ ] CONTRIBUTING.md 链接可点

🤖 Generated with [Claude Code](https://claude.com/claude-code)