### PR TITLE
release: v0.20.2 — CLI 双语 i18n + publish.yml 自动化

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # 创建 GitHub Release(npm publish 完成后自动建,从 CHANGELOG 抽 notes）
       id-token: write # 使工作流能够通过 OIDC 从 GitHub 获取凭证（npm provenance 必需）
 
     steps:
@@ -41,3 +41,30 @@ jobs:
       run: npm publish --access public --provenance
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        TAG="${GITHUB_REF#refs/tags/}"
+        VERSION="${TAG#v}"
+        # 从 CHANGELOG.md 抽 ## [VERSION] section(到下一个 ## [ 之前)
+        # sed 去掉所有 `---` 单独行: CHANGELOG sections 之间用 --- 分隔, 抽出的
+        # section 末尾会带 trailing ---, 去掉避免和下面 footer 的 --- 撞两个.
+        # CHANGELOG section 内容本身不使用 --- 单独行做分隔, 此清理安全.
+        NOTES=$(awk "/^## \\[${VERSION}\\]/{flag=1; next} /^## \\[/{if(flag){exit}} flag" CHANGELOG.md | sed '/^---$/d')
+        if [ -z "$NOTES" ]; then
+          echo "::warning::no CHANGELOG section for v${VERSION}; falling back to auto-generated notes"
+          gh release create "$TAG" --title "$TAG" --generate-notes --verify-tag
+        else
+          # 找 prev tag (按创建时间排序, 当前 tag 的下一行就是上一个 release tag)
+          PREV_TAG=$(git tag --sort=-creatordate | grep -A 1 "^${TAG}$" | tail -1)
+          if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$TAG" ]; then
+            NOTES="${NOTES}
+
+---
+
+**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
+          fi
+          gh release create "$TAG" --title "$TAG" --notes "$NOTES" --verify-tag
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ## [Unreleased]
 
+### Added
+
+- **CLI 双语输出 (zh / en)**:`omk` 所有 CLI 输出现支持中英两种语言。优先级 `--lang` flag > `OMK_LANG` 环境变量 > 默认 `zh`。覆盖范围:
+  - `omk --help` 主帮助文档(140 行)+ 所有子命令 help(`gold` / `verdict` / `diagnose` / `failures` / `saturation` / `debias-validate` / `diff` / `analyze`)
+  - 实时进度反馈(预检 / 重试 / 执行中 / 评委评审 / 已完成 / 已跳过 / 错误)
+  - 评测完成提示 + report server 启动信息 + gold dataset 对比反馈
+  - 参数校验提示(`--repeat` / `--judge-repeat` / `--judge-models` / `--bootstrap-samples` / `--no-debias-length` 等)
+  - `bench gen-samples` / `bench evolve` / `bench gold` / `bench saturation` 等子命令的 runtime 反馈
+- **CLI i18n 基础设施**:`src/cli/i18n.ts`(`tCli` / `getCliLang` / `parseLangFromArgv` / `langFromArgv` / `makeOnProgress` factory)+ `src/cli/i18n-dict.ts`(~80 个 key,zh/en 双写,`Record` 类型强制对齐)。新增 `test/cli-i18n.test.ts`(10 用例)做 dict parity / placeholder 替换 / lang 优先级 runtime 校验。
+- **`src/cli/i18n-dict.ts` 头部翻译守则文档**(受 [lizhiyao/cc-viewer](https://github.com/lizhiyao/cc-viewer) i18n 方案启发):明确"保留原文白名单"(产品名 / 子命令名 / 业务术语 skill/variant/sample/judge / 技术参数 / 文件名 / 数学缩写) vs "必须翻译的内容"(动作 / 状态 / 引导文案 / 解释),后续维护者按守则审 dict。
+
+### Changed
+
+- **CLI 默认输出从英文混搭中文改为彻底双语化**:之前 `omk bench run` / `omk --help` / 进度反馈混合中英文(例如 "评测完成 done"),用户每次 review 报告或调试都要"切语境"。本版整体重写:中文用户读到的全是中文,英文用户读到的全是英文,无任何中英混搭。
+- **lib 层(非 cli)user-facing 错误统一英文**:遵循"对客表达层 i18n / 内部实现层统一英文"分层原则,把 `src/inputs/eval-config.ts`(16 处)/ `skill-loader.ts`(5 处)/ `load-samples.ts`(4 处)/ `eval-workflows/run-evaluation.ts`(3 处)/ `inputs/url-fetcher.ts`(2 处)/ `inputs/mcp-resolver.ts`(4 处)/ `executors/{anthropic,openai}-api.ts`(2 处)/ `eval-core/evaluation-execution.ts`(1 处)/ `server/report-server.ts`(2 处)/ `authoring/{generator,evolver}.ts`(6 处)/ `grading/gold-cli.ts`(1 处)的中文 `throw new Error` 和 `process.stderr.write` 改英文。zh 用户看到的最终输出形如"错误: skill file not found: /path"——前缀本地化(由 cli 层负责),内部错误细节是英文工程内容。
+- **`unknown` 提示文案更准**:`未知模块` → `未知顶层命令`,`未知 bench 子命令` → `未知子命令: bench {command}`(中文语序更自然)。
+- **`Skill 健康度日报` 中英混搭 bug 修复**:之前 HELP 主常量中文版混杂了中文短语 "skill 健康度日报",现在英文版改为 `skill health report`。
+
+### Internal
+
+- `src/cli.ts` 顶部 `const HELP` 142 行原英文模板字符串删除,内容完整迁到 dict。`HELP` 现通过 `tCli('cli.help.main', lang).trim()` 取得。
+- 13 处 `parseArgs options` 块统一 spread `COMMON_OPTIONS = { lang: { type: 'string' } }`,所有子命令都接收 `--lang` flag。
+- `defaultOnProgress` 改为 `makeOnProgress(lang)` factory:evaluation engine 异步回调时拿不到 argv,通过 closure 闭住 lang。每个 handler 入口通过 `langFromArgv(argv)` 一行拿到 lang 并传 factory。
+- 测量学不变量未受影响:`src/grading/judge.ts` prompt 文本字节级未动,`test/grading/judge-hash-frozen.test.ts` 仍冻结 `v2-cot=fdc81b19c721` / `v3-cot-length=629bf3b8c41d` 两个 hash。
+- 10 处测试 assertion regex 同步从中文更新为英文(`test/eval-config.test.ts` / `test/runner.test.ts` / `test/inputs/{load-samples,skill-loader}.test.ts` / `test/grading/gold-cli.test.ts`)。
+
+### Fixed
+
+- **(已知漏洞)CLI 中英混搭**:历史上 cli.ts / lib 层中混有大量"中文 stderr 嵌入英文 token / 英文 console.error 嵌入中文短语"。`grep -E "console\\.(log|error|warn).*[一-鿿]|process\\.stderr\\.write.*[一-鿿]|throw new Error.*[一-鿿]" src/` 现为 0 残留(除 `judge.ts` 测量学锚点不动)。
+
 ---
 
 ## [0.20.1] - 2026-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ## [Unreleased]
 
+---
+
+## [0.20.2] - 2026-04-27
+
+Patch — CLI 双语 i18n 全面落地 + 发版自动化(publish.yml 现自动从 CHANGELOG 抽 release notes 创建 GitHub Release)。
+
 ### Added
 
 - **CLI 双语输出 (zh / en)**:`omk` 所有 CLI 输出现支持中英两种语言。优先级 `--lang` flag > `OMK_LANG` 环境变量 > 默认 `zh`。覆盖范围:
@@ -28,6 +34,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ### Internal
 
+- **`publish.yml` 自动从 CHANGELOG 抽 release notes 创建 GitHub Release**:push tag `v*` 触发后,workflow 在 `npm publish` 之后自动找 CHANGELOG.md `## [VERSION]` section,用作 GitHub Release 的 body。维护者只需 bump `package.json` + 改 CHANGELOG `[Unreleased]` → `[VERSION] - YYYY-MM-DD`,merge release PR 后打 tag + push tag 即可,Release notes 不再手动写。
+- **协作者入场文档 `CLAUDE.md` 精简**(61 → 39 行,-36%):删除与 `CONTRIBUTING.md` 重复内容,目标"AI / 新人 90 秒读完不踩雷"。
 - `src/cli.ts` 顶部 `const HELP` 142 行原英文模板字符串删除,内容完整迁到 dict。`HELP` 现通过 `tCli('cli.help.main', lang).trim()` 取得。
 - 13 处 `parseArgs options` 块统一 spread `COMMON_OPTIONS = { lang: { type: 'string' } }`,所有子命令都接收 `--lang` flag。
 - `defaultOnProgress` 改为 `makeOnProgress(lang)` factory:evaluation engine 异步回调时拿不到 argv,通过 closure 闭住 lang。每个 handler 入口通过 `langFromArgv(argv)` 一行拿到 lang 并传 factory。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,60 +1,43 @@
 # CLAUDE.md — 协作者(包括 AI agent)入场必读
 
-omk 是 LLM 评测框架,主打**统计严谨性**(Bootstrap CI / Krippendorff α / Length-debias / Saturation curves)+ verdict / RAG / budget 决策面。任何代码改动都要尊重测量学不变量,任何分支操作都要走 gitflow。
+omk 是 LLM 评测框架,主打**统计严谨性**(Bootstrap CI / Krippendorff α / Length-debias / Saturation curves)+ verdict / RAG / budget 决策面。两条底线:**测量学不变量不能动**,**分支操作走 gitflow**。
 
-## Session 启动 checklist(任何动手 edit 之前)
+## 开工前
 
-1. `git branch --show-current` —— 看当前 working branch
-2. **如果是 `main` 或 `develop`,必须先 `git checkout -b feat/<topic>` 再开始改**。绝不在 main / develop 直接 commit。
-3. 读 [CONTRIBUTING.md](./CONTRIBUTING.md) 第一遍(分支模型 / 发版流程 / commit 风格)
-4. 看 [CHANGELOG.md](./CHANGELOG.md) `[Unreleased]` 段了解在做什么版本
-5. 阅读相关文件,写代码,跑 `yarn lint && yarn build && yarn test`
-6. PR `--base develop`(只有 release PR 是 `--base main`)
+- 看 [CHANGELOG.md](./CHANGELOG.md) `[Unreleased]` 段了解在做什么版本
+- 改完跑 `yarn lint && yarn build && yarn test`
+- 分支模型 / 发版细节 / commit 风格全在 [CONTRIBUTING.md](./CONTRIBUTING.md)
 
-## 分支策略(详见 CONTRIBUTING.md)
+## 分支策略
 
-严格 gitflow,三层流:
+严格 gitflow:`feat/* | fix/* | docs/* | chore/*` → `develop` → `main`(release)。
 
-```
-feat/* / fix/* / docs/* / chore/*  →  develop  →  main(release)
-```
+PR base **永远是 develop**,绝不在 main / develop 直接 commit。release PR merge 后必须 fast-forward `develop = main`,否则 develop 永远落后一个 merge commit。
 
-PR base **永远是 develop**,除非是 release PR。release PR 由 `release/x.y.z` 分支或直接 develop → main 触发,merge 后**必须 fast-forward develop = main**(`git checkout develop && git merge --ff-only origin/main && git push`),否则 develop 永远落后 main 一个 merge commit。
+## 测量学不变量(绝对不能动)
 
-## 测量学不变量(绝对不能改)
+这些是历史报告可比性的锚,改动会破坏跨版本对比:
 
-这些字段 / 算法 / 哈希值是历史报告可比性的锚,任何改动都会破坏跨版本对比,违反 v0.21 测量学主线:
-
-- **Report JSON schema**(`src/types/report.ts` 里的 `Report` / `ReportMeta` / `VariantResult` / `VariantSummary` 字段含义)
-- **Judge Prompt Hash**:`v2-cot=fdc81b19c721` / `v3-cot-length=629bf3b8c41d`,由 `test/grading/judge-hash-frozen.test.ts` 字节级冻结。任何动 `src/grading/judge.ts` 的 prompt 文本会立即让这个测试 fail
+- **Report JSON schema**:`src/types/report.ts` 里 `Report` / `ReportMeta` / `VariantResult` / `VariantSummary` 字段含义
+- **Judge Prompt Hash**:`v2-cot=fdc81b19c721` / `v3-cot-length=629bf3b8c41d`,由 `test/grading/judge-hash-frozen.test.ts` 字节级冻结。动 `src/grading/judge.ts` 的 prompt 文本会立即 fail
 - **五层评分管道**:assertion / llm / judge / dimension / composite 的算法和权重
-- **Bootstrap CI 公式**(`src/eval-core/bootstrap.ts`)
-- **Krippendorff α 公式**(`src/grading/human-gold.ts`)
+- **Bootstrap CI 公式**(`src/eval-core/bootstrap.ts`)、**Krippendorff α 公式**(`src/grading/human-gold.ts`)
 - **Length-debias toggle**(`--no-debias-length` 与 prompt v2/v3 的对应关系)
 
-如果确需 bump,流程:bump `JUDGE_PROMPT_VERSION_DEBIAS_*` 字符串 → 旧 hash 自然失效 → CHANGELOG 显著标注 breaking-comparability change → 新版本号 bump。**不要悄悄改**。
-
-## 发版流程(自动化版,publish.yml 落地后)
-
-push tag `v*` → publish.yml 自动跑:
-
-1. yarn install + lint + build + test
-2. `npm publish --access public --provenance`
-3. **从 CHANGELOG.md 抽 `## [VERSION]` section 自动创建 GitHub Release**(PR #6 引入)
-
-所以维护者只要做:bump `package.json` version + 更新 CHANGELOG.md `[Unreleased]` → `[VERSION] - YYYY-MM-DD`,merge release PR 后打 tag + push tag。其他全自动。
+确需 bump 见 CONTRIBUTING,核心动作是 bump `JUDGE_PROMPT_VERSION_DEBIAS_*` + CHANGELOG 标 breaking-comparability。**不要悄悄改**。
 
 ## 写代码约定
 
-- **commit message 中文**(详见 git log 历史,前缀如 `重构(v0.21):` / `特性(v0.21 B.4):` / `测试:` / `修复:` / `chore(release):`)。Conventional Commits 风格但用中文写正文
-- **user-facing 文案中文优先**(报告 UI / CLI 输出 / 错误信息)。LLM judge 中文译为「**评委**」,不译「判官」,不要中英混用
-- **测试基线**:`test/grading/judge-hash-frozen.test.ts`(judge prompt 不变性)+ `test/__snapshots__/html-renderer.test.ts.snap`(zh/en × list/detail UI 回归)。这两个是 CI gate,改 UI / judge 时会自然失败,review snapshot diff 后 `vitest -u` 更新
-- **CHANGELOG 维护**:每个 feat / fix PR 顺手更新 `[Unreleased]` 子分类(Added / Changed / Fixed / Internal,Keep a Changelog 风格)。release PR 时把 `[Unreleased]` 改成 `[VERSION] - YYYY-MM-DD`
-- **不要硬编码端口**:report server 默认请求 7799 但实际 bound 端口取自 `server.start()` 返回值(可能被占而切到 7800+),所有显示 URL 给用户的代码都要用 `serverUrl` 实参
+- **commit message 中文**,Conventional Commits 风格但中文正文(前缀如 `重构(v0.21):` / `特性:` / `修复:`,见 git log)
+- **user-facing 文案中文优先**(报告 UI / CLI / 错误信息)。LLM judge 译为「**评委**」,不译「判官」,不中英混用
+- **CI gate 两个**:`test/grading/judge-hash-frozen.test.ts`(judge prompt 不变性)、`test/__snapshots__/html-renderer.test.ts.snap`(zh/en × list/detail UI 回归)。改 UI / judge 后 review snapshot diff,确认无误再 `vitest -u`
+- **顺手更新 CHANGELOG `[Unreleased]`**(Keep a Changelog 风格:Added / Changed / Fixed / Internal)
+- **不要硬编码端口**:report server 默认请求 7799 但实际 bound 端口取自 `server.start()` 返回值(7799 被占会切 7800+),所有给用户看的 URL 都用 `serverUrl` 实参
+
+## 发版
+
+push tag `v*` 触发 publish.yml 全自动:lint + build + test → `npm publish` → 从 CHANGELOG 抽对应 section 建 GitHub Release。维护者只 bump version + 改 CHANGELOG `[Unreleased]` → `[VERSION] - YYYY-MM-DD`。细节见 CONTRIBUTING。
 
 ## 其他参考
 
-- [README.md](./README.md) / [README.zh.md](./README.zh.md) — 用户面文档
-- [SKILL.md](./SKILL.md) — Claude Code skill 用法
-- [docs/](./docs/) — 设计 spec(rag-metrics / knowledge-gap-signal / 等)
-- 本地 plan(不在仓库,仅维护者本地):`~/.claude/plans/iridescent-zooming-lynx.md`
+[README.md](./README.md) / [README.zh.md](./README.zh.md) 用户面文档,[SKILL.md](./SKILL.md) Claude Code skill 用法,[docs/](./docs/) 设计 spec(rag-metrics / knowledge-gap-signal / 等)。维护者本地 plan(不在仓库):`~/.claude/plans/iridescent-zooming-lynx.md`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md — 协作者(包括 AI agent)入场必读
+
+omk 是 LLM 评测框架,主打**统计严谨性**(Bootstrap CI / Krippendorff α / Length-debias / Saturation curves)+ verdict / RAG / budget 决策面。任何代码改动都要尊重测量学不变量,任何分支操作都要走 gitflow。
+
+## Session 启动 checklist(任何动手 edit 之前)
+
+1. `git branch --show-current` —— 看当前 working branch
+2. **如果是 `main` 或 `develop`,必须先 `git checkout -b feat/<topic>` 再开始改**。绝不在 main / develop 直接 commit。
+3. 读 [CONTRIBUTING.md](./CONTRIBUTING.md) 第一遍(分支模型 / 发版流程 / commit 风格)
+4. 看 [CHANGELOG.md](./CHANGELOG.md) `[Unreleased]` 段了解在做什么版本
+5. 阅读相关文件,写代码,跑 `yarn lint && yarn build && yarn test`
+6. PR `--base develop`(只有 release PR 是 `--base main`)
+
+## 分支策略(详见 CONTRIBUTING.md)
+
+严格 gitflow,三层流:
+
+```
+feat/* / fix/* / docs/* / chore/*  →  develop  →  main(release)
+```
+
+PR base **永远是 develop**,除非是 release PR。release PR 由 `release/x.y.z` 分支或直接 develop → main 触发,merge 后**必须 fast-forward develop = main**(`git checkout develop && git merge --ff-only origin/main && git push`),否则 develop 永远落后 main 一个 merge commit。
+
+## 测量学不变量(绝对不能改)
+
+这些字段 / 算法 / 哈希值是历史报告可比性的锚,任何改动都会破坏跨版本对比,违反 v0.21 测量学主线:
+
+- **Report JSON schema**(`src/types/report.ts` 里的 `Report` / `ReportMeta` / `VariantResult` / `VariantSummary` 字段含义)
+- **Judge Prompt Hash**:`v2-cot=fdc81b19c721` / `v3-cot-length=629bf3b8c41d`,由 `test/grading/judge-hash-frozen.test.ts` 字节级冻结。任何动 `src/grading/judge.ts` 的 prompt 文本会立即让这个测试 fail
+- **五层评分管道**:assertion / llm / judge / dimension / composite 的算法和权重
+- **Bootstrap CI 公式**(`src/eval-core/bootstrap.ts`)
+- **Krippendorff α 公式**(`src/grading/human-gold.ts`)
+- **Length-debias toggle**(`--no-debias-length` 与 prompt v2/v3 的对应关系)
+
+如果确需 bump,流程:bump `JUDGE_PROMPT_VERSION_DEBIAS_*` 字符串 → 旧 hash 自然失效 → CHANGELOG 显著标注 breaking-comparability change → 新版本号 bump。**不要悄悄改**。
+
+## 发版流程(自动化版,publish.yml 落地后)
+
+push tag `v*` → publish.yml 自动跑:
+
+1. yarn install + lint + build + test
+2. `npm publish --access public --provenance`
+3. **从 CHANGELOG.md 抽 `## [VERSION]` section 自动创建 GitHub Release**(PR #6 引入)
+
+所以维护者只要做:bump `package.json` version + 更新 CHANGELOG.md `[Unreleased]` → `[VERSION] - YYYY-MM-DD`,merge release PR 后打 tag + push tag。其他全自动。
+
+## 写代码约定
+
+- **commit message 中文**(详见 git log 历史,前缀如 `重构(v0.21):` / `特性(v0.21 B.4):` / `测试:` / `修复:` / `chore(release):`)。Conventional Commits 风格但用中文写正文
+- **user-facing 文案中文优先**(报告 UI / CLI 输出 / 错误信息)。LLM judge 中文译为「**评委**」,不译「判官」,不要中英混用
+- **测试基线**:`test/grading/judge-hash-frozen.test.ts`(judge prompt 不变性)+ `test/__snapshots__/html-renderer.test.ts.snap`(zh/en × list/detail UI 回归)。这两个是 CI gate,改 UI / judge 时会自然失败,review snapshot diff 后 `vitest -u` 更新
+- **CHANGELOG 维护**:每个 feat / fix PR 顺手更新 `[Unreleased]` 子分类(Added / Changed / Fixed / Internal,Keep a Changelog 风格)。release PR 时把 `[Unreleased]` 改成 `[VERSION] - YYYY-MM-DD`
+- **不要硬编码端口**:report server 默认请求 7799 但实际 bound 端口取自 `server.start()` 返回值(可能被占而切到 7800+),所有显示 URL 给用户的代码都要用 `serverUrl` 实参
+
+## 其他参考
+
+- [README.md](./README.md) / [README.zh.md](./README.zh.md) — 用户面文档
+- [SKILL.md](./SKILL.md) — Claude Code skill 用法
+- [docs/](./docs/) — 设计 spec(rag-metrics / knowledge-gap-signal / 等)
+- 本地 plan(不在仓库,仅维护者本地):`~/.claude/plans/iridescent-zooming-lynx.md`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ omk bench run --dry-run
 
 # run the evaluation (auto-discovers everything under skills/)
 omk bench run
+
+# CLI output language: zh (default) / en — flag wins over env
+omk bench run --lang en
+OMK_LANG=en omk bench report
 ```
 
 ## Use inside Claude Code

--- a/README.zh.md
+++ b/README.zh.md
@@ -69,6 +69,10 @@ omk bench run --dry-run
 
 # 运行评测（自动发现 skills/ 目录下的所有 artifact）
 omk bench run
+
+# CLI 输出语言: zh (默认) / en — flag 优先级高于环境变量
+omk bench run --lang en
+OMK_LANG=en omk bench report
 ```
 
 ## 在 Claude Code 中使用

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "LLM evaluation framework with built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves. Native Claude Code skill / RAG / agent / prompt evaluation.",
   "type": "module",
   "bin": {

--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -242,8 +242,8 @@ export async function evolveSkill({
   const skillName = readSkillName(absSkillPath) ?? (fileBaseName === 'SKILL' ? basename(skillDir) : fileBaseName);
   const evolveDir = join(skillDir, 'evolve');
 
-  if (!existsSync(absSkillPath)) throw new Error(`skill 文件未找到: ${absSkillPath}`);
-  if (!existsSync(absSamplesPath)) throw new Error(`样本文件未找到: ${absSamplesPath}`);
+  if (!existsSync(absSkillPath)) throw new Error(`skill file not found: ${absSkillPath}`);
+  if (!existsSync(absSamplesPath)) throw new Error(`samples file not found: ${absSamplesPath}`);
   mkdirSync(evolveDir, { recursive: true });
 
   // Save original as r0

--- a/src/authoring/generator.ts
+++ b/src/authoring/generator.ts
@@ -43,7 +43,7 @@ ${skillContent}
   const result = await executor({ model, system: SYSTEM_PROMPT, prompt });
 
   if (!result.ok) {
-    throw new Error(`生成失败: ${result.error || 'unknown error'}`);
+    throw new Error(`generation failed: ${result.error || 'unknown error'}`);
   }
 
   // Extract JSON from output (handle possible markdown code blocks)
@@ -57,17 +57,17 @@ ${skillContent}
   try {
     samples = JSON.parse(jsonStr);
   } catch {
-    throw new Error('生成的内容不是有效的 JSON，请重试');
+    throw new Error('generated content is not valid JSON, please retry');
   }
 
   if (!Array.isArray(samples) || samples.length === 0) {
-    throw new Error('生成结果为空，请重试');
+    throw new Error('generated result is empty, please retry');
   }
 
   // Validate required fields
   for (const [i, s] of samples.entries()) {
     if (!s.sample_id) s.sample_id = `s${String(i + 1).padStart(3, '0')}`;
-    if (!s.prompt) throw new Error(`samples[${i}] 缺少 prompt 字段`);
+    if (!s.prompt) throw new Error(`samples[${i}] missing required prompt field`);
   }
 
   return { samples, costUSD: result.costUSD };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
+import { tCli, getCliLang, parseLangFromArgv } from './cli/i18n.js';
 import { discoverVariants, parseVariantCwd } from './inputs/skill-loader.js';
 import { loadEvalConfig, configVariantsToSpecs } from './inputs/eval-config.js';
 import type {
@@ -152,7 +153,16 @@ const DEFAULT_REPORTS_DIR: string = join(homedir(), '.oh-my-knowledge', 'reports
 // Defaults are applied inside parseRunConfig (after config-file merge) so that
 // CLI `undefined` can be reliably distinguished from "user passed the default value".
 // Priority order resolved in parseRunConfig: CLI arg > --config file > hard-coded default.
+/**
+ * 所有子命令都接受的通用 flag。新增 --lang 让 parseArgs strict:false 模式下
+ * 仍能把值类型化到 values.lang 上(否则未声明的 flag 会被丢弃)。
+ */
+const COMMON_OPTIONS: ParseArgsConfig['options'] = {
+  lang: { type: 'string' },
+};
+
 const RUN_OPTIONS: ParseArgsConfig['options'] = {
+  ...COMMON_OPTIONS,
   samples: { type: 'string' },
   'skill-dir': { type: 'string' },
   control: { type: 'string' },
@@ -497,6 +507,7 @@ async function checkUpdate(): Promise<void> {
 
 async function main(): Promise<void> {
   checkUpdate();
+  const lang = getCliLang(parseLangFromArgv(process.argv));
   const [domain, command, ...rest]: string[] = process.argv.slice(2);
 
   if (!domain || domain === '--help' || domain === '-h') {
@@ -511,7 +522,7 @@ async function main(): Promise<void> {
   }
 
   if (domain !== 'bench') {
-    console.error(`Unknown domain: ${domain}. Use "omk bench <command>" or "omk analyze <dir>".`);
+    console.error(tCli('cli.common.unknown_domain', lang, { domain }));
     process.exit(1);
   }
 
@@ -561,7 +572,7 @@ async function main(): Promise<void> {
       await handleFailures(rest);
       break;
     default:
-      console.error(`Unknown command: bench ${command}. Use "run", "report", "ci", "init", "gen-samples", "evolve", "diff", "gold", "debias-validate", "saturation", "verdict", "diagnose", or "failures".`);
+      console.error(tCli('cli.common.unknown_bench_command', lang, { command }));
       process.exit(1);
   }
 }
@@ -844,6 +855,7 @@ async function handleReport(argv: string[]): Promise<void> {
   const { values } = parseArgs({
     args: argv,
     options: {
+      ...COMMON_OPTIONS,
       port: { type: 'string', default: '7799' },
       'reports-dir': { type: 'string', default: DEFAULT_REPORTS_DIR },
       export: { type: 'string' },
@@ -985,6 +997,7 @@ async function handleAnalyze(argv: string[]): Promise<void> {
     args: argv,
     allowPositionals: true,
     options: {
+      ...COMMON_OPTIONS,
       kb: { type: 'string' },
       last: { type: 'string' },
       from: { type: 'string' },
@@ -1077,6 +1090,7 @@ async function handleGenSamples(argv: string[]): Promise<void> {
   const { values } = parseArgs({
     args: argv,
     options: {
+      ...COMMON_OPTIONS,
       each: { type: 'boolean', default: false },
       count: { type: 'string', default: '5' },
       model: { type: 'string', default: 'sonnet' },
@@ -1190,6 +1204,7 @@ async function handleEvolve(argv: string[]): Promise<void> {
   const { values } = parseArgs({
     args: argv,
     options: {
+      ...COMMON_OPTIONS,
       rounds: { type: 'string', default: '5' },
       target: { type: 'string' },
       samples: { type: 'string', default: 'eval-samples.json' },
@@ -1342,6 +1357,7 @@ async function handleDiff(argv: string[]): Promise<void> {
   const { values } = parseArgs({
     args: flagArgs,
     options: {
+      ...COMMON_OPTIONS,
       'regressions-only': { type: 'boolean', default: false },
       threshold: { type: 'string' },
       variant: { type: 'string' },
@@ -1538,6 +1554,7 @@ async function handleGold(argv: string[]): Promise<void> {
     const { values } = parseArgs({
       args: rest,
       options: {
+        ...COMMON_OPTIONS,
         out: { type: 'string', default: './gold-dataset' },
         annotator: { type: 'string' },
       },
@@ -1584,6 +1601,7 @@ async function handleGold(argv: string[]): Promise<void> {
     const { values } = parseArgs({
       args: rest.slice(1),
       options: {
+        ...COMMON_OPTIONS,
         'gold-dir': { type: 'string' },
         variant: { type: 'string' },
         'reports-dir': { type: 'string', default: DEFAULT_REPORTS_DIR },
@@ -1678,6 +1696,7 @@ async function handleDebiasValidate(argv: string[]): Promise<void> {
   const { values } = parseArgs({
     args: rest.slice(1),
     options: {
+      ...COMMON_OPTIONS,
       'reports-dir': { type: 'string', default: DEFAULT_REPORTS_DIR },
       samples: { type: 'string' },
       variant: { type: 'string' },
@@ -1766,6 +1785,7 @@ async function handleSaturation(argv: string[]): Promise<void> {
   const { values } = parseArgs({
     args: argv.slice(1),
     options: {
+      ...COMMON_OPTIONS,
       'reports-dir': { type: 'string', default: DEFAULT_REPORTS_DIR },
       variant: { type: 'string' },
     },
@@ -1849,6 +1869,7 @@ async function handleVerdict(argv: string[]): Promise<void> {
   const { values } = parseArgs({
     args: argv.slice(1),
     options: {
+      ...COMMON_OPTIONS,
       'reports-dir': { type: 'string', default: DEFAULT_REPORTS_DIR },
       threshold: { type: 'string' },
       'trivial-diff': { type: 'string' },
@@ -1915,6 +1936,7 @@ async function handleDiagnose(argv: string[]): Promise<void> {
   const { values } = parseArgs({
     args: argv.slice(1),
     options: {
+      ...COMMON_OPTIONS,
       'reports-dir': { type: 'string', default: DEFAULT_REPORTS_DIR },
       samples: { type: 'string' },
       top: { type: 'string', default: '10' },
@@ -2000,6 +2022,7 @@ async function handleFailures(argv: string[]): Promise<void> {
   const { values } = parseArgs({
     args: argv.slice(1),
     options: {
+      ...COMMON_OPTIONS,
       'reports-dir': { type: 'string', default: DEFAULT_REPORTS_DIR },
       'judge-executor': { type: 'string', default: 'claude' },
       'judge-model': { type: 'string' },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
-import { tCli, getCliLang, parseLangFromArgv, langFromArgv } from './cli/i18n.js';
+import { tCli, getCliLang, parseLangFromArgv, langFromArgv, type CliLang } from './cli/i18n.js';
 import { discoverVariants, parseVariantCwd } from './inputs/skill-loader.js';
 import { loadEvalConfig, configVariantsToSpecs } from './inputs/eval-config.js';
 import type {
@@ -483,7 +483,7 @@ Examples:
 // Update check
 // ---------------------------------------------------------------------------
 
-async function checkUpdate(): Promise<void> {
+async function checkUpdate(lang: CliLang): Promise<void> {
   try {
     const { readFileSync } = await import('node:fs');
     const { fileURLToPath } = await import('node:url');
@@ -496,9 +496,11 @@ async function checkUpdate(): Promise<void> {
     if (!res.ok) return;
     const data = await res.json() as { version?: string };
     if (data.version && data.version !== pkg.version) {
-      process.stderr.write(`\n💡 新版本可用: ${pkg.version} → ${data.version}，运行 npm update ${pkg.name} -g 更新\n\n`);
+      process.stderr.write(tCli('cli.update.new_version_available', lang, {
+        old: pkg.version, new: data.version, pkg: pkg.name,
+      }));
     }
-  } catch { /* 静默失败，不影响正常使用 */ }
+  } catch { /* 静默失败,不影响正常使用 */ }
 }
 
 // ---------------------------------------------------------------------------
@@ -506,8 +508,8 @@ async function checkUpdate(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  checkUpdate();
   const lang = getCliLang(parseLangFromArgv(process.argv));
+  checkUpdate(lang);
   const [domain, command, ...rest]: string[] = process.argv.slice(2);
 
   if (!domain || domain === '--help' || domain === '-h') {
@@ -581,58 +583,74 @@ async function main(): Promise<void> {
 // Progress callback
 // ---------------------------------------------------------------------------
 
-function defaultOnProgress({
-  phase,
-  completed,
-  total,
-  sample_id,
-  variant,
-  durationMs,
-  inputTokens,
-  outputTokens,
-  costUSD,
-  score,
-  outputPreview,
-  judgePhase: _judgePhase,
-  judgeDim,
-  skipped,
-  attempt,
-  maxAttempts,
-  error,
-}: ProgressInfo): void {
-  if (phase === 'preflight') {
-    process.stderr.write('⏳ 预检模型连通性...\n');
-    return;
-  }
-  if (phase === 'retry') {
-    process.stderr.write(`[${completed}/${total}] ${sample_id}/${variant} 🔄 重试 ${attempt}/${maxAttempts}...\n`);
-    return;
-  }
-  if (phase === 'error') {
-    process.stderr.write(`[${completed}/${total}] ${sample_id}/${variant} ❌ ${error}\n`);
-    return;
-  }
-  if (phase === 'start') {
-    process.stderr.write(`[${completed}/${total}] ${sample_id}/${variant} ⏳ 执行中...\n`);
-  } else if (phase === 'exec_done') {
-    const costInfo: string = costUSD != null && costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
-    process.stderr.write(`[${completed}/${total}] ${sample_id}/${variant} 执行完成 ${durationMs}ms ${inputTokens}+${outputTokens} tokens${costInfo}\n`);
-    if (outputPreview) {
-      process.stderr.write(`  输出预览: ${outputPreview.slice(0, 150).replace(/\n/g, ' ')}\n`);
+/**
+ * Factory: 闭住 lang, 返回 onProgress callback。evaluation engine 回调时不传
+ * 上下文, 所以 lang 必须在 handler 入口处通过 closure 传进来。
+ */
+function makeOnProgress(lang: CliLang): (info: ProgressInfo) => void {
+  return ({
+    phase,
+    completed,
+    total,
+    sample_id,
+    variant,
+    durationMs,
+    inputTokens,
+    outputTokens,
+    costUSD,
+    score,
+    outputPreview,
+    judgePhase: _judgePhase,
+    judgeDim,
+    skipped,
+    attempt,
+    maxAttempts,
+    error,
+  }: ProgressInfo): void => {
+    const ctx = { i: completed ?? '', n: total ?? '', sample: sample_id ?? '', variant: variant ?? '' };
+    if (phase === 'preflight') {
+      process.stderr.write(tCli('cli.progress.preflight_starting', lang));
+      return;
     }
-  } else if (phase === 'grading') {
-    const dimInfo: string = judgeDim ? ` [${judgeDim}]` : '';
-    process.stderr.write(`[${completed}/${total}] ${sample_id}/${variant} 评审中${dimInfo}...\n`);
-  } else if (phase === 'judge_done') {
-    const dimInfo: string = judgeDim ? ` [${judgeDim}]` : '';
-    process.stderr.write(`[${completed}/${total}] ${sample_id}/${variant} 评审完成${dimInfo} score=${score}\n`);
-  } else if (phase === 'done' && skipped) {
-    if (sample_id) process.stderr.write(`[${completed}/${total}] ${sample_id}/${variant} ⏭ 已跳过（已有结果）\n`);
-  } else {
-    const costInfo: string = costUSD != null && costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
-    const scoreInfo: string = typeof score === 'number' ? ` score=${score}` : '';
-    process.stderr.write(`[${completed}/${total}] ${sample_id}/${variant} ✓ ${durationMs}ms ${inputTokens}+${outputTokens} tokens${costInfo}${scoreInfo}\n`);
-  }
+    if (phase === 'retry') {
+      process.stderr.write(tCli('cli.progress.sample_retry', lang, {
+        ...ctx, attempt: attempt ?? '', max: maxAttempts ?? '',
+      }));
+      return;
+    }
+    if (phase === 'error') {
+      process.stderr.write(tCli('cli.progress.sample_error', lang, { ...ctx, error: error ?? '' }));
+      return;
+    }
+    if (phase === 'start') {
+      process.stderr.write(tCli('cli.progress.sample_executing', lang, ctx));
+    } else if (phase === 'exec_done') {
+      const cost: string = costUSD != null && costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
+      process.stderr.write(tCli('cli.progress.sample_exec_done', lang, {
+        ...ctx, ms: durationMs ?? '', input: inputTokens ?? '', output: outputTokens ?? '', cost,
+      }));
+      if (outputPreview) {
+        process.stderr.write(tCli('cli.progress.output_preview', lang, {
+          preview: outputPreview.slice(0, 150).replace(/\n/g, ' '),
+        }));
+      }
+    } else if (phase === 'grading') {
+      const dim: string = judgeDim ? ` [${judgeDim}]` : '';
+      process.stderr.write(tCli('cli.progress.judging', lang, { ...ctx, dim }));
+    } else if (phase === 'judge_done') {
+      const dim: string = judgeDim ? ` [${judgeDim}]` : '';
+      process.stderr.write(tCli('cli.progress.judged', lang, { ...ctx, dim, score: score ?? '' }));
+    } else if (phase === 'done' && skipped) {
+      if (sample_id) process.stderr.write(tCli('cli.progress.skipped', lang, ctx));
+    } else {
+      const cost: string = costUSD != null && costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
+      const scoreInfo: string = typeof score === 'number' ? ` score=${score}` : '';
+      process.stderr.write(tCli('cli.progress.sample_done', lang, {
+        ...ctx, ms: durationMs ?? '', input: inputTokens ?? '', output: outputTokens ?? '',
+        cost, score: scoreInfo,
+      }));
+    }
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -640,6 +658,7 @@ function defaultOnProgress({
 // ---------------------------------------------------------------------------
 
 async function handleRun(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const { values, config } = parseRunConfig(argv, {
     blind: { type: 'boolean', default: false },
     repeat: { type: 'string', default: '1' },
@@ -657,28 +676,28 @@ async function handleRun(argv: string[]): Promise<void> {
   const { runEvaluation, runMultiple, runEachEvaluation } = await import('./eval-workflows/run-evaluation.js');
 
   config.blind = values.blind as boolean | undefined;
-  config.onProgress = defaultOnProgress as unknown as ProgressCallback;
+  config.onProgress = makeOnProgress(lang) as unknown as ProgressCallback;
 
-  // --repeat 诚实输入校验:非 ≥1 整数时提示并钳到 1,不静默掩盖用户错字/极端输入
-  // 提前到 --each 分支之前,保证 each 模式也能读到 repeat (曾经 bug: --each 吞 --repeat)
+  // --repeat 输入校验: 非 ≥1 整数时提示并钳到 1, 不静默掩盖用户错字 / 极端输入。
+  // 提前到 --each 分支之前, 保证 each 模式也能读到 repeat (曾经 bug: --each 吞 --repeat)。
   const repeatRaw = values.repeat as string | undefined;
   const parsedRepeat = repeatRaw !== undefined ? Number(repeatRaw) : 1;
   if (repeatRaw !== undefined && (!Number.isFinite(parsedRepeat) || parsedRepeat < 1)) {
-    process.stderr.write(`⚠ --repeat "${repeatRaw}" 无效(期望 ≥ 1 的整数),已按 1 次评测执行\n`);
+    process.stderr.write(tCli('cli.run.invalid_repeat', lang, { value: repeatRaw }));
   }
   const repeatCount: number = Math.max(1, Math.floor(parsedRepeat) || 1);
 
-  // --judge-repeat 同样的诚实校验:非 ≥1 整数时钳到 1
+  // --judge-repeat 同样校验: 非 ≥1 整数时钳到 1
   const judgeRepeatRaw = values['judge-repeat'] as string | undefined;
   const parsedJudgeRepeat = judgeRepeatRaw !== undefined ? Number(judgeRepeatRaw) : 1;
   if (judgeRepeatRaw !== undefined && (!Number.isFinite(parsedJudgeRepeat) || parsedJudgeRepeat < 1)) {
-    process.stderr.write(`⚠ --judge-repeat "${judgeRepeatRaw}" 无效(期望 ≥ 1 的整数),已按 1 次 judge 执行\n`);
+    process.stderr.write(tCli('cli.run.invalid_judge_repeat', lang, { value: judgeRepeatRaw }));
   }
   const judgeRepeatCount: number = Math.max(1, Math.floor(parsedJudgeRepeat) || 1);
   if (judgeRepeatCount > 1) config.judgeRepeat = judgeRepeatCount;
 
   // --judge-models executor:model,executor:model,... -> JudgeConfig[]
-  // 至少 2 个才进 ensemble 模式,1 个等同于 --judge-model
+  // 至少 2 个才进 ensemble 模式, 1 个等同于 --judge-model
   const judgeModelsRaw = values['judge-models'] as string | undefined;
   if (judgeModelsRaw) {
     const parts = judgeModelsRaw.split(',').map((s) => s.trim()).filter(Boolean);
@@ -686,15 +705,17 @@ async function handleRun(argv: string[]): Promise<void> {
       const [executor, ...modelParts] = p.split(':');
       const model = modelParts.join(':');
       if (!executor || !model) {
-        throw new Error(`--judge-models 格式错误: "${p}",应为 "executor:model" (如 claude:opus)`);
+        throw new Error(tCli('cli.run.invalid_judge_models_format', lang, { part: p }));
       }
       return { executor, model };
     });
     if (judges.length >= 2) {
       config.judgeModels = judges;
     } else if (judges.length === 1) {
-      // 单 judge 不走 ensemble,但允许这样写,等同于 --judge-model + --executor
-      process.stderr.write(`ℹ --judge-models 只指定 1 个 judge (${judges[0].executor}:${judges[0].model}),不触发 ensemble。如需 ensemble 至少给 2 个。\n`);
+      // 单 judge 不走 ensemble, 但允许这样写, 等同于 --judge-model + --executor
+      process.stderr.write(tCli('cli.run.judge_models_single_warning', lang, {
+        executor: judges[0].executor, model: judges[0].model,
+      }));
     }
   }
 
@@ -718,7 +739,7 @@ async function handleRun(argv: string[]): Promise<void> {
   // off so historical reports (judgePromptHash from v2-cot era) can be reproduced.
   if (values['no-debias-length'] as boolean) {
     config.lengthDebias = false;
-    process.stderr.write('ℹ --no-debias-length 已生效:judge prompt 退回 v2-cot,与 < v0.21 报告 hash 一致。\n');
+    process.stderr.write(tCli('cli.run.no_debias_length_active', lang));
   }
 
   // --bootstrap / --bootstrap-samples
@@ -727,11 +748,11 @@ async function handleRun(argv: string[]): Promise<void> {
     const bsRaw = values['bootstrap-samples'] as string | undefined;
     const parsedBs = bsRaw !== undefined ? Number(bsRaw) : 1000;
     if (bsRaw !== undefined && (!Number.isFinite(parsedBs) || parsedBs < 100)) {
-      process.stderr.write(`⚠ --bootstrap-samples "${bsRaw}" 无效(期望 ≥ 100 的整数),已按 1000 执行\n`);
+      process.stderr.write(tCli('cli.run.invalid_bootstrap_samples', lang, { value: bsRaw }));
     }
     const bsCount = Math.max(100, Math.floor(parsedBs) || 1000);
     if (bsCount > 10000) {
-      process.stderr.write(`⚠ --bootstrap-samples ${bsCount} 较大,可能耗时数秒。1000 是业内标准,通常已够用。\n`);
+      process.stderr.write(tCli('cli.run.bootstrap_samples_too_large', lang, { n: bsCount }));
     }
     config.bootstrapSamples = bsCount;
   }
@@ -1202,6 +1223,7 @@ async function handleGenSamples(argv: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleEvolve(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const { values } = parseArgs({
     args: argv,
     options: {
@@ -1250,7 +1272,7 @@ async function handleEvolve(argv: string[]): Promise<void> {
       concurrency: Math.max(1, Number(values.concurrency) || 1),
       timeoutMs: Math.max(1, Number(values.timeout) || 120) * 1000,
       skipPreflight: values['skip-preflight'] as boolean,
-      onProgress: defaultOnProgress as unknown as ProgressCallback,
+      onProgress: makeOnProgress(lang) as unknown as ProgressCallback,
       onRoundProgress({ round, totalRounds: _totalRounds, phase, score, delta, accepted, costUSD, error }: RoundProgressInfo): void {
         if (phase === 'baseline') {
           process.stderr.write(`Round 0 (baseline): score=${score!.toFixed(2)} ($${costUSD!.toFixed(4)})\n`);
@@ -1286,13 +1308,14 @@ async function handleEvolve(argv: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleCi(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const { values, config } = parseRunConfig(argv, {
     threshold: { type: 'string', default: '3.5' },
   });
 
   const { runEvaluation } = await import('./eval-workflows/run-evaluation.js');
 
-  config.onProgress = defaultOnProgress as unknown as ProgressCallback;
+  config.onProgress = makeOnProgress(lang) as unknown as ProgressCallback;
 
   try {
     const { report } = (await runEvaluation(config)) as EvalResult;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -879,6 +879,7 @@ async function handleRun(argv: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleReport(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const { values } = parseArgs({
     args: argv,
     options: {
@@ -917,7 +918,7 @@ async function handleReport(argv: string[]): Promise<void> {
     const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
     const report: Report | null = await store.get(values.export as string);
     if (!report) {
-      console.error(`Report not found: ${values.export}`);
+      console.error(tCli('cli.common.report_not_found', lang, { id: values.export as string }));
       process.exit(1);
     }
     const html: string = report!.each ? renderEachRunDetail(report) : renderRunDetail(report);
@@ -1116,6 +1117,7 @@ async function handleInit(argv: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleGenSamples(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const { values } = parseArgs({
     args: argv,
     options: {
@@ -1138,7 +1140,7 @@ async function handleGenSamples(argv: string[]): Promise<void> {
     // Batch mode: generate for all skills missing eval-samples
     const skillDir: string = resolve(values['skill-dir'] as string);
     if (!existsSync(skillDir)) {
-      console.error(`Skill directory not found: ${skillDir}`);
+      console.error(tCli('cli.common.skill_dir_not_found', lang, { path: skillDir }));
       process.exit(1);
     }
 
@@ -1167,39 +1169,44 @@ async function handleGenSamples(argv: string[]): Promise<void> {
       }
 
       if (existsSync(samplesPath)) {
-        process.stderr.write(`⏭️  ${name}: eval-samples 已存在，跳过\n`);
+        process.stderr.write(tCli('cli.gen.skill_skipped_existing', lang, { name }));
         continue;
       }
 
-      process.stderr.write(`🔄 ${name}: 正在生成 ${count} 个测试样本...\n`);
+      process.stderr.write(tCli('cli.gen.skill_generating', lang, { name, count }));
       try {
         const skillContent: string = readFileSync(skillPath, 'utf-8');
         const { samples, costUSD }: GenerateSamplesResult =
           await generateSamples({ skillContent, count, model });
         writeFileSync(samplesPath, JSON.stringify(samples, null, 2));
-        process.stderr.write(`✅ ${name}: 已生成 ${samples.length} 个样本 → ${samplesPath} (${costUSD > 0 ? `$${costUSD.toFixed(4)}` : ''})\n`);
+        const cost: string = costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
+        process.stderr.write(tCli('cli.gen.skill_done', lang, {
+          name, n: samples.length, path: samplesPath, cost,
+        }));
         generated++;
       } catch (err: unknown) {
-        process.stderr.write(`❌ ${name}: ${(err as Error).message}\n`);
+        process.stderr.write(tCli('cli.gen.skill_failed', lang, {
+          name, message: (err as Error).message,
+        }));
       }
     }
 
     if (generated === 0) {
-      console.log('没有需要生成的 eval-samples（所有 skill 已有配对文件）');
+      console.log(tCli('cli.gen.batch_none_needed', lang));
     } else {
-      console.log(`\n共生成 ${generated} 份 eval-samples，请审查后运行: omk bench run --each`);
+      console.log(tCli('cli.gen.batch_summary', lang, { n: generated }));
     }
   } else {
     // Single skill mode
     const skillPath: string | undefined = argv.find((a: string) => !a.startsWith('-'));
     if (!skillPath) {
-      console.error('请指定 skill 文件路径，例如: omk bench gen-samples skills/my-skill.md');
+      console.error(tCli('cli.gen.specify_skill_path', lang));
       process.exit(1);
     }
 
     const resolvedPath: string = resolve(skillPath);
     if (!existsSync(resolvedPath)) {
-      console.error(`Skill file not found: ${resolvedPath}`);
+      console.error(tCli('cli.common.skill_file_not_found', lang, { path: resolvedPath }));
       process.exit(1);
     }
 
@@ -1207,19 +1214,22 @@ async function handleGenSamples(argv: string[]): Promise<void> {
     const outputPath: string = resolve('eval-samples.json');
 
     if (existsSync(outputPath)) {
-      console.error(`eval-samples.json 已存在。如需覆盖请先删除。`);
+      console.error(tCli('cli.gen.samples_already_exists', lang));
       process.exit(1);
     }
 
-    process.stderr.write(`🔄 正在生成 ${count} 个测试样本...\n`);
+    process.stderr.write(tCli('cli.gen.single_generating', lang, { count }));
     try {
       const { samples, costUSD }: GenerateSamplesResult =
         await generateSamples({ skillContent, count, model });
       writeFileSync(outputPath, JSON.stringify(samples, null, 2));
-      process.stderr.write(`✅ 已生成 ${samples.length} 个样本 → ${outputPath} (${costUSD > 0 ? `$${costUSD.toFixed(4)}` : ''})\n`);
-      console.log('\n请审查生成的测试样本后运行: omk bench run');
+      const cost: string = costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
+      process.stderr.write(tCli('cli.gen.single_done', lang, {
+        n: samples.length, path: outputPath, cost,
+      }));
+      console.log(tCli('cli.gen.review_hint', lang));
     } catch (err: unknown) {
-      console.error(`生成失败: ${(err as Error).message}`);
+      console.error(tCli('cli.gen.failed', lang, { message: (err as Error).message }));
       process.exit(1);
     }
   }
@@ -1252,7 +1262,7 @@ async function handleEvolve(argv: string[]): Promise<void> {
 
   const skillPath: string | undefined = argv.find((a: string) => !a.startsWith('-'));
   if (!skillPath) {
-    console.error('请指定 skill 文件路径，例如: omk bench evolve skills/my-skill.md');
+    console.error(tCli('cli.evolve.specify_skill_path', lang));
     process.exit(1);
   }
 
@@ -1264,7 +1274,7 @@ async function handleEvolve(argv: string[]): Promise<void> {
 
   const { evolveSkill } = await import('./authoring/evolver.js');
 
-  process.stderr.write(`\n=== Evolution: ${skillPath} ===\n`);
+  process.stderr.write(tCli('cli.evolve.section_header', lang, { path: skillPath }));
 
   try {
     const result: EvolveResult = await evolveSkill({
@@ -1282,13 +1292,19 @@ async function handleEvolve(argv: string[]): Promise<void> {
       onProgress: makeOnProgress(lang) as unknown as ProgressCallback,
       onRoundProgress({ round, totalRounds: _totalRounds, phase, score, delta, accepted, costUSD, error }: RoundProgressInfo): void {
         if (phase === 'baseline') {
-          process.stderr.write(`Round 0 (baseline): score=${score!.toFixed(2)} ($${costUSD!.toFixed(4)})\n`);
+          process.stderr.write(tCli('cli.evolve.round_baseline', lang, {
+            score: score!.toFixed(2), cost: costUSD!.toFixed(4),
+          }));
         } else if (phase === 'error') {
-          process.stderr.write(`Round ${round}: ✗ 改进生成失败: ${error}\n`);
+          process.stderr.write(tCli('cli.evolve.round_error', lang, {
+            round, error: String(error ?? ''),
+          }));
         } else if (phase === 'done') {
-          const deltaStr: string = delta! >= 0 ? `+${delta!.toFixed(2)}` : delta!.toFixed(2);
+          const delta_: string = delta! >= 0 ? `+${delta!.toFixed(2)}` : delta!.toFixed(2);
           const status: string = accepted ? '✓ ACCEPT' : '✗ REJECT';
-          process.stderr.write(`Round ${round}: score=${score!.toFixed(2)} (${deltaStr}) ${status} ($${costUSD!.toFixed(4)})\n`);
+          process.stderr.write(tCli('cli.evolve.round_done', lang, {
+            round, score: score!.toFixed(2), delta: delta_, status, cost: costUSD!.toFixed(4),
+          }));
         }
       },
     });
@@ -1296,16 +1312,23 @@ async function handleEvolve(argv: string[]): Promise<void> {
     const improvement: string = result.startScore > 0
       ? ((result.finalScore - result.startScore) / result.startScore * 100).toFixed(1)
       : '0';
-    process.stderr.write(`\n✅ ${result.startScore.toFixed(2)} → ${result.finalScore.toFixed(2)} (+${improvement}%) | ${result.totalRounds} 轮 | $${result.totalCostUSD.toFixed(4)}\n`);
-    process.stderr.write(`Best: ${result.bestSkillPath} → ${resolve(skillPath)}\n`);
-    process.stderr.write(`所有版本保存在: ${join(resolve(skillPath, '..'), 'evolve')}/\n`);
+    process.stderr.write(tCli('cli.evolve.summary', lang, {
+      start: result.startScore.toFixed(2), final: result.finalScore.toFixed(2),
+      percent: improvement, rounds: result.totalRounds, cost: result.totalCostUSD.toFixed(4),
+    }));
+    process.stderr.write(tCli('cli.evolve.best_path', lang, {
+      best: result.bestSkillPath, target: resolve(skillPath),
+    }));
+    process.stderr.write(tCli('cli.evolve.versions_saved', lang, {
+      dir: join(resolve(skillPath, '..'), 'evolve'),
+    }));
     if (result.reportId) {
-      process.stderr.write(`📊 评测报告: omk bench report (ID: ${result.reportId})\n`);
+      process.stderr.write(tCli('cli.evolve.report_link', lang, { id: result.reportId }));
     }
 
     console.log(JSON.stringify(result, null, 2));
   } catch (err: unknown) {
-    console.error(`Error: ${(err as Error).message}`);
+    console.error(tCli('cli.common.error_prefix', lang, { message: (err as Error).message }));
     process.exit(1);
   }
 }
@@ -1350,6 +1373,7 @@ async function handleCi(argv: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleDiff(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   // Flag-aware split: separate positional report IDs from flags so we can support
   //   omk bench diff <id>                      — within-report sample-level (v0.22)
   //   omk bench diff <id1> <id2>               — cross-report variant-level (legacy)
@@ -1401,7 +1425,7 @@ async function handleDiff(argv: string[]): Promise<void> {
   const store: ReportStore = createFileStore(resolve(DEFAULT_REPORTS_DIR));
 
   if (positional.length === 1) {
-    await runSampleLevelDiff(positional[0], store, values);
+    await runSampleLevelDiff(positional[0], store, values, lang);
     return;
   }
 
@@ -1409,8 +1433,8 @@ async function handleDiff(argv: string[]): Promise<void> {
   const r1: Report | null = await store.get(id1);
   const r2: Report | null = await store.get(id2);
 
-  if (!r1) { console.error(`Report not found: ${id1}`); process.exit(1); }
-  if (!r2) { console.error(`Report not found: ${id2}`); process.exit(1); }
+  if (!r1) { console.error(tCli('cli.common.report_not_found', lang, { id: id1 })); process.exit(1); }
+  if (!r2) { console.error(tCli('cli.common.report_not_found', lang, { id: id2 })); process.exit(1); }
 
   console.log(`\n  Diff: ${id1} → ${id2}\n`);
 
@@ -1478,10 +1502,11 @@ async function runSampleLevelDiff(
   reportId: string,
   store: ReportStore,
   flags: Record<string, string | boolean | undefined>,
+  lang: CliLang,
 ): Promise<void> {
   const report: Report | null = await store.get(reportId);
   if (!report) {
-    console.error(`Report not found: ${reportId}`);
+    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
     process.exit(1);
   }
   const variants = report!.meta?.variants ?? [];
@@ -1563,6 +1588,7 @@ async function runSampleLevelDiff(
 // ---------------------------------------------------------------------------
 
 async function handleGold(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const sub = argv[0];
   const rest = argv.slice(1);
   if (!sub || sub === '--help' || sub === '-h') {
@@ -1596,9 +1622,11 @@ async function handleGold(argv: string[]): Promise<void> {
       const written = initGoldDataset(values.out as string, {
         annotator: values.annotator as string | undefined,
       });
-      console.log(`Created ${written.length} files in ${values.out}:`);
+      console.log(tCli('cli.gold.created_files', lang, {
+        n: written.length, dir: values.out as string,
+      }));
       for (const p of written) console.log(`  ${p}`);
-      console.log('\n下一步: 编辑 annotations.yaml 加入真实标注 → 跑 omk bench gold validate');
+      console.log(tCli('cli.gold.next_step_edit_annotations', lang));
     } catch (err) {
       console.error((err as Error).message);
       process.exit(1);
@@ -1609,13 +1637,13 @@ async function handleGold(argv: string[]): Promise<void> {
   if (sub === 'validate') {
     const dir = rest[0];
     if (!dir) {
-      console.error('Usage: omk bench gold validate <dir>');
+      console.error(tCli('cli.common.usage_gold_validate', lang));
       process.exit(1);
     }
     const { validateGoldDataset } = await import('./grading/gold-cli.js');
     const result = validateGoldDataset(dir);
     if (result.ok) {
-      console.log(`✓ gold dataset OK — ${result.sampleCount} 条标注`);
+      console.log(tCli('cli.gold.validate_ok', lang, { n: result.sampleCount }));
       return;
     }
     console.error(`✗ gold dataset has ${result.issues.length} issue(s):`);
@@ -1664,7 +1692,7 @@ async function handleGold(argv: string[]): Promise<void> {
     const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
     const report: Report | null = await store.get(reportId);
     if (!report) {
-      console.error(`Report not found: ${reportId}`);
+      console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
       process.exit(1);
     }
 
@@ -1690,6 +1718,7 @@ async function handleGold(argv: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleDebiasValidate(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const sub = argv[0];
   const rest = argv.slice(1);
   if (!sub || sub === '--help' || sub === '-h') {
@@ -1743,7 +1772,7 @@ async function handleDebiasValidate(argv: string[]): Promise<void> {
   const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
   const report: Report | null = await store.get(reportId);
   if (!report) {
-    console.error(`Report not found: ${reportId}`);
+    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
     process.exit(1);
   }
 
@@ -1760,11 +1789,11 @@ async function handleDebiasValidate(argv: string[]): Promise<void> {
   const judgeModel = (values['judge-model'] as string | undefined)
     ?? report!.meta?.judgeModel;
   if (!judgeModel) {
-    console.error('No judge model. Pass --judge-model <id> or ensure report has meta.judgeModel.');
+    console.error(tCli('cli.common.no_judge_model', lang));
     process.exit(1);
   }
 
-  process.stderr.write('\n⚠ debias-validate 会重判所有 (sample × variant),judge cost 大致翻倍。\n');
+  process.stderr.write(tCli('cli.debias.warn_cost_doubles', lang));
 
   const { createExecutor } = await import('./executors/index.js');
   const judgeExecutor = createExecutor(values['judge-executor'] as string);
@@ -1792,6 +1821,7 @@ async function handleDebiasValidate(argv: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleSaturation(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const reportId = argv[0];
   if (!reportId || reportId === '--help' || reportId === '-h') {
     console.log([
@@ -1827,13 +1857,13 @@ async function handleSaturation(argv: string[]): Promise<void> {
   const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
   const report: Report | null = await store.get(reportId);
   if (!report) {
-    console.error(`Report not found: ${reportId}`);
+    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
     process.exit(1);
   }
 
   const saturation = report!.variance?.saturation;
   if (!saturation) {
-    console.error('该 report 无 saturation 数据 (需要 --repeat ≥ 2 才会记录)。');
+    console.error(tCli('cli.saturation.no_data', lang));
     process.exit(1);
   }
 
@@ -1846,21 +1876,31 @@ async function handleSaturation(argv: string[]): Promise<void> {
   const variants = report!.meta.variants ?? [];
   const targetVariants = values.variant ? [values.variant as string] : variants;
 
-  console.log(`\n  Saturation verdict (复述持久化结果)\n`);
+  console.log(tCli('cli.saturation.verdict_header', lang));
   for (const variant of targetVariants) {
     const trace = saturation.perVariant[variant];
     if (!trace || trace.length === 0) {
-      console.log(`  ${variant}: 无 trace 数据`);
+      console.log(tCli('cli.saturation.variant_no_trace', lang, { variant }));
       continue;
     }
-    console.log(`  ${variant}:`);
-    console.log(`    checkpoints: ${trace.length} (N=${trace.map((p) => p.n).join(', ')})`);
-    console.log(`    最近一点 mean=${trace[trace.length - 1].mean.toFixed(3)}, CI=[${trace[trace.length - 1].ciLow.toFixed(3)}, ${trace[trace.length - 1].ciHigh.toFixed(3)}]`);
+    console.log(tCli('cli.saturation.variant_label', lang, { variant }));
+    console.log(tCli('cli.saturation.checkpoints', lang, {
+      n: trace.length, list: trace.map((p) => p.n).join(', '),
+    }));
+    const last = trace[trace.length - 1];
+    console.log(tCli('cli.saturation.last_point', lang, {
+      mean: last.mean.toFixed(3), lo: last.ciLow.toFixed(3), hi: last.ciHigh.toFixed(3),
+    }));
     if (saturation.verdicts?.[variant]) {
       const v = saturation.verdicts[variant];
-      console.log(`    持久化判定 (${v.method}): ${v.saturated ? `已饱和@N=${v.atN}` : '未饱和'} - ${v.reason}`);
+      const result = v.saturated
+        ? tCli('cli.saturation.persisted_verdict_saturated', lang, { n: v.atN ?? '?' })
+        : tCli('cli.saturation.persisted_verdict_unsaturated', lang);
+      console.log(tCli('cli.saturation.persisted_verdict', lang, {
+        method: v.method, result, reason: v.reason,
+      }));
     } else if (trace.length < 5) {
-      console.log(`    判定: 数据点 ${trace.length} < 5,跳过 (跑 --repeat 5 以上才输出)`);
+      console.log(tCli('cli.saturation.skipped_too_few_points', lang, { n: trace.length }));
     }
   }
   console.log('');
@@ -1871,6 +1911,7 @@ async function handleSaturation(argv: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleVerdict(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const reportId = argv[0];
   if (!reportId || reportId === '--help' || reportId === '-h') {
     console.log([
@@ -1913,7 +1954,7 @@ async function handleVerdict(argv: string[]): Promise<void> {
   const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
   const report: Report | null = await store.get(reportId);
   if (!report) {
-    console.error(`Report not found: ${reportId}`);
+    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
     process.exit(1);
   }
 
@@ -1941,6 +1982,7 @@ async function handleVerdict(argv: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleDiagnose(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const reportId = argv[0];
   if (!reportId || reportId === '--help' || reportId === '-h') {
     console.log([
@@ -1984,7 +2026,7 @@ async function handleDiagnose(argv: string[]): Promise<void> {
   const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
   const report: Report | null = await store.get(reportId);
   if (!report) {
-    console.error(`Report not found: ${reportId}`);
+    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
     process.exit(1);
   }
 
@@ -1999,7 +2041,9 @@ async function handleDiagnose(argv: string[]): Promise<void> {
       const { loadSamples } = await import('./inputs/load-samples.js');
       samples = loadSamples(samplesPath).samples;
     } catch (err) {
-      process.stderr.write(`warn: 加载 samples 文件失败 (${samplesPath}): ${(err as Error).message}\n`);
+      process.stderr.write(tCli('cli.common.warn_load_samples_failed', lang, {
+        path: samplesPath, message: (err as Error).message,
+      }));
     }
   }
 
@@ -2029,6 +2073,7 @@ async function handleDiagnose(argv: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleFailures(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const reportId = argv[0];
   if (!reportId || reportId === '--help' || reportId === '-h') {
     console.log([
@@ -2068,13 +2113,13 @@ async function handleFailures(argv: string[]): Promise<void> {
   const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
   const report: Report | null = await store.get(reportId);
   if (!report) {
-    console.error(`Report not found: ${reportId}`);
+    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
     process.exit(1);
   }
 
   const judgeModel = (values['judge-model'] as string | undefined) ?? report!.meta?.judgeModel;
   if (!judgeModel) {
-    console.error('No judge model. Pass --judge-model <id> or ensure report has meta.judgeModel.');
+    console.error(tCli('cli.common.no_judge_model', lang));
     process.exit(1);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -338,148 +338,6 @@ function parseRunConfig(
 }
 
 // ---------------------------------------------------------------------------
-// Help text
-// ---------------------------------------------------------------------------
-
-const HELP: string = `
-oh-my-knowledge — Knowledge artifact evaluation toolkit
-
-Usage:
-  omk bench run [options]     Run an evaluation
-  omk bench report [options]  Start the report server
-  omk bench ci [options]      Run evaluation and exit with pass/fail code
-  omk bench init [dir]        Scaffold a new eval project
-  omk bench gen-samples [skill]  Generate eval-samples from skill content
-  omk bench diff <id1> <id2>      Compare two evaluation reports
-  omk bench evolve <skill>       Self-improve a skill through iterative evaluation
-
-  omk analyze <dir>           Analyze cc session trace(s), produce skill 健康度日报 (v0.18)
-
-Options for "bench run":
-
-  --samples <path>       Sample file (default: eval-samples.json)
-  --skill-dir <path>     Skill definitions directory (default: skills)
-  --control <expr>       Control-group variant expression (experiment role = control)
-  --treatment <v1,v2>    Treatment-group variant expressions (comma-separated; role = treatment)
-                         Each variant expression resolves to an artifact and optional runtime context:
-                           "baseline"       — bare model, no artifact injected
-                           "git:name"       — artifact from last commit
-                           "git:ref:name"   — artifact from specific commit
-                           path with "/"    — artifact from file directly (e.g. ./v1.md)
-                           "name@/cwd"      — attach runtime context / cwd
-                         At least one of --control / --treatment must be provided.
-  --config <path>        YAML/JSON config file (evaluation-as-code).
-                         Declares samples + variants + model + executor in one file.
-                         CLI flags override config fields when both are provided.
-                         Relative paths inside the config are resolved against its directory.
-  --model <name>         Model under test (default: sonnet)
-  --judge-model <name>   Judge model (default: haiku)
-  --output-dir <path>    Report output directory (default: ~/.oh-my-knowledge/reports/)
-  --no-judge             Skip LLM judging
-  --no-cache             Disable result caching
-  --dry-run              Preview tasks without executing
-  --blind                Blind A/B mode: hide variant names in report
-  --concurrency <n>      Number of parallel tasks (default: 1)
-  --timeout <seconds>    Executor timeout per task in seconds (default: 120)
-  --repeat <n>           Run evaluation N times for variance analysis (default: 1)
-  --judge-repeat <n>     Call LLM judge N times per (sample × dimension) for self-
-                         consistency (default: 1). High stddev across runs = the
-                         judge is unstable on this rubric and the score is noisy.
-  --judge-models <list>  Multi-judge ensemble. Comma-separated executor:model pairs,
-                         e.g. claude:opus,openai:gpt-4o,gemini:pro. Each judge scores
-                         every (sample × dimension); report includes per-judge break-
-                         down + Pearson/MAD inter-judge agreement. Refutes "Claude
-                         judge Claude same-modality bias" critique. Combines with
-                         --judge-repeat. Cost ~ N_judges × N_repeat × N_samples.
-  --bootstrap            Compute bootstrap confidence intervals (distribution-free,
-                         preferred over t-interval for ordinal LLM scores). Adds
-                         per-variant CI on the mean + pairwise CI on treatment-vs-
-                         control difference (significant=0 outside CI). Reports both
-                         t-interval and bootstrap so old tooling still works.
-  --bootstrap-samples <n>  Number of bootstrap resamples (default 1000). N>10000
-                         triggers a stderr warning about runtime cost.
-  --retry <n>            Retry failed tasks up to N times with exponential backoff (default: 0)
-  --resume <report-id>   Resume from a previous report, skipping completed tasks
-  --executor <name>      Executor: claude, openai, gemini, anthropic-api, openai-api,
-                         or any shell command (e.g. "python my_provider.py")
-  --judge-executor <name> Executor for LLM judge (default: same as --executor)
-  --each                 Evaluate each skill independently against baseline
-                         Requires {name}.eval-samples.json paired with each skill
-  --skip-preflight       Skip model connectivity check before evaluation
-  --mcp-config <path>    MCP config file for URL fetching via MCP servers
-                         (default: .mcp.json in current directory)
-  --no-serve             Skip auto-starting report server after evaluation
-  --verbose              Print detailed progress for each sample (exec result, grading phases)
-  --layered-stats        Expand the three-layer (fact/behavior/judge) independent
-                         significance breakdown in the HTML report by default.
-                         Without this flag, the breakdown is collapsed behind a
-                         click-to-expand summary under each comparison.
-
-Options for "bench ci":
-  (same as "bench run", plus:)
-  --threshold <number>   Minimum score to pass, applied INDEPENDENTLY to each of
-                         the three layers (fact / behavior / LLM judge). ANY
-                         layer below threshold fails the gate — this prevents
-                         composite averaging from masking a single-layer collapse.
-                         Default: 3.5. If all three layers are absent (no
-                         assertions and no rubric defined in eval-samples), the
-                         gate FAILS with a configuration hint — no composite fallback.
-
-Options for "bench report":
-  --port <number>        Server port (default: 7799)
-  --reports-dir <path>   Reports directory (default: ~/.oh-my-knowledge/reports/)
-  --export <id>          Export report as standalone HTML file
-  --dev                  Dev mode: auto-restart on lib/ file changes
-
-Options for "bench gen-samples":
-  --each                 Generate for all skills missing eval-samples
-  --count <n>            Number of samples to generate per skill (default: 5)
-  --model <name>         Model for generation (default: sonnet)
-  --skill-dir <path>     Skill directory (default: skills), used with --each
-
-Options for "analyze":
-  <dir>                  Input: cc session JSONL file / dir (e.g. ~/.claude/projects/<slug>)
-  --kb <path>            Knowledge base root (default: auto-infer from trace cwd)
-  --last <duration>      Time window like "7d" / "30d" (default: all)
-  --from <iso>           Window start (ISO8601), takes precedence over --last
-  --to <iso>             Window end (ISO8601), takes precedence over --last
-  --skills <n1,n2,...>   Whitelist skills to analyze (default: all)
-  --output-dir <path>    Output dir (default: ~/.oh-my-knowledge/analyses/)
-
-Options for "bench evolve":
-  --rounds <n>           Maximum evolution rounds (default: 5)
-  --target <score>       Stop early when score reaches this threshold
-  --samples <path>       Sample file (default: eval-samples.json)
-  --model <name>         Model under test (default: sonnet)
-  --judge-model <name>   Judge model (default: haiku)
-  --improve-model <name> Model for generating improvements (default: sonnet)
-  --concurrency <n>      Parallel eval tasks (default: 1)
-  --timeout <seconds>    Executor timeout per task in seconds (default: 120)
-  --executor <name>      Executor to use (default: claude)
-
-Examples:
-  omk bench run --control v1 --treatment v2
-  omk bench run --control baseline --treatment my-skill
-  omk bench run --control git:my-skill --treatment my-skill
-  omk bench run --control ./old-skill.md --treatment ./new-skill.md
-  omk bench run --control baseline --treatment v1,v2,v3
-  omk bench run --config eval.yaml
-  omk bench run --config eval.yaml --model sonnet-4.6   # CLI overrides config
-  omk bench run --each
-  omk bench run --dry-run
-  omk bench report --port 8080
-  omk bench report --export v1-vs-v2-20260326-1832
-  omk bench init my-eval
-  omk bench gen-samples skills/my-skill.md
-  omk bench gen-samples --each
-  omk bench diff <report-id-1> <report-id-2>
-  omk bench evolve skills/my-skill.md --rounds 5
-  omk analyze ~/.claude/projects/-Users-lizhiyao-Documents-oh-my-knowledge
-  omk analyze ~/.claude/projects/my-project --last 7d --kb /path/to/project
-  omk analyze ~/.claude/projects/my-project --skills audit,polish
-`.trim();
-
-// ---------------------------------------------------------------------------
 // Update check
 // ---------------------------------------------------------------------------
 
@@ -513,7 +371,7 @@ async function main(): Promise<void> {
   const [domain, command, ...rest]: string[] = process.argv.slice(2);
 
   if (!domain || domain === '--help' || domain === '-h') {
-    console.log(HELP);
+    console.log(tCli('cli.help.main', lang).trim());
     process.exit(0);
   }
 
@@ -529,7 +387,7 @@ async function main(): Promise<void> {
   }
 
   if (!command || command === '--help' || command === '-h') {
-    console.log(HELP);
+    console.log(tCli('cli.help.main', lang).trim());
     process.exit(0);
   }
 
@@ -1037,7 +895,7 @@ async function handleAnalyze(argv: string[]): Promise<void> {
   });
   const dir = positionals[0];
   if (!dir) {
-    console.error('Usage: omk analyze <dir> [--kb <path>] [--last 7d] [--from ISO] [--to ISO] [--skills name1,name2]');
+    console.error(tCli('cli.help.analyze_usage', lang));
     process.exit(1);
   }
   const tracePath = resolve(dir);
@@ -1395,17 +1253,7 @@ async function handleDiff(argv: string[]): Promise<void> {
   }
 
   if (positional.length === 0) {
-    console.error([
-      'Usage:',
-      '  omk bench diff <reportId>                     within-report per-sample diff (v0.22)',
-      '  omk bench diff <reportId1> <reportId2>        cross-report variant-level diff',
-      '',
-      'Options:',
-      '  --regressions-only          只列 treatment < control 的样本',
-      '  --threshold <num>           regression 阈值 (default 0,即任一负 Δ 算回退)',
-      '  --variant <name>            within-report 模式下指定要钻取的 variant (default: variants[1])',
-      '  --top <n>                   只列差距最大的前 N 个样本',
-    ].join('\n'));
+    console.error(tCli('cli.help.diff_usage', lang));
     process.exit(positional.length === 0 ? 1 : 0);
   }
 
@@ -1592,18 +1440,7 @@ async function handleGold(argv: string[]): Promise<void> {
   const sub = argv[0];
   const rest = argv.slice(1);
   if (!sub || sub === '--help' || sub === '-h') {
-    console.log([
-      '',
-      'Usage: omk bench gold <subcommand>',
-      '',
-      'Subcommands:',
-      '  init [--out <dir>] [--annotator <id>]    生成空白 gold dataset 模板',
-      '  validate <dir>                           校验数据集结构',
-      '  compare <reportId> --gold-dir <dir>      与已有 report 计算 α/κ/Pearson',
-      '    [--variant <name>] [--reports-dir <d>]',
-      '    [--bootstrap-samples N] [--seed N]',
-      '',
-    ].join('\n'));
+    console.log(tCli('cli.help.gold', lang));
     process.exit(sub ? 0 : 1);
   }
 
@@ -1722,24 +1559,7 @@ async function handleDebiasValidate(argv: string[]): Promise<void> {
   const sub = argv[0];
   const rest = argv.slice(1);
   if (!sub || sub === '--help' || sub === '-h') {
-    console.log([
-      '',
-      'Usage: omk bench debias-validate <kind> <reportId> [options]',
-      '',
-      'Kinds:',
-      '  length    re-judge with the opposite length-debias setting and bootstrap CI',
-      '            on the score diff. Cost ~doubles vs the original judge pass.',
-      '',
-      'Options:',
-      '  --reports-dir <dir>          report store dir (default: ~/.oh-my-knowledge/reports)',
-      '  --samples <path>             override samples file (default: from report.meta.request)',
-      '  --variant <name>             which variant to validate (default: first)',
-      '  --judge-executor <name>      executor for judge calls (default: claude)',
-      '  --judge-model <model>        judge model id (default: from report)',
-      '  --bootstrap-samples N        bootstrap iterations (default 1000)',
-      '  --seed N                     deterministic CI seed',
-      '',
-    ].join('\n'));
+    console.log(tCli('cli.help.debias_validate', lang));
     process.exit(sub ? 0 : 1);
   }
 
@@ -1824,22 +1644,7 @@ async function handleSaturation(argv: string[]): Promise<void> {
   const lang = langFromArgv(argv);
   const reportId = argv[0];
   if (!reportId || reportId === '--help' || reportId === '-h') {
-    console.log([
-      '',
-      'Usage: omk bench saturation <reportId> [options]',
-      '',
-      '回答"我跑够样本了吗?"。复述已有 report 中持久化的饱和判定。',
-      '',
-      '注:本命令读取 run 时跑出的 verdict(运行时已用 method=bootstrap-ci-width',
-      '默认阈值 + 3 窗口 持续条件)。如要换 method/threshold 重新计算,需要重跑',
-      '`omk bench run --repeat ≥ 5`(运行时持久化的 trace 不含原始分数,无法',
-      '在事后用其他参数复算)。',
-      '',
-      'Options:',
-      '  --reports-dir <dir>   report store dir (default: ~/.oh-my-knowledge/reports)',
-      '  --variant <name>      只看一个 variant (default: all)',
-      '',
-    ].join('\n'));
+    console.log(tCli('cli.help.saturation', lang));
     process.exit(reportId ? 0 : 1);
   }
 
@@ -1914,27 +1719,7 @@ async function handleVerdict(argv: string[]): Promise<void> {
   const lang = langFromArgv(argv);
   const reportId = argv[0];
   if (!reportId || reportId === '--help' || reportId === '-h') {
-    console.log([
-      '',
-      'Usage: omk bench verdict <reportId> [options]',
-      '',
-      '聚合 bootstrap CI / 三层 ci-gate / saturation / human α 给出一行结论。',
-      '',
-      'Verdict 等级:',
-      '  PROGRESS      显著改进 + 三层全过',
-      '  CAUTIOUS      改进真实但有警告 (gate 破 / 幅度太小 / 控制组本身崩)',
-      '  REGRESS       显著回退 — 不要 ship',
-      '  NOISE         CI 跨 0,无法判定',
-      '  UNDERPOWERED  样本不足,需要扩 N 重测',
-      '  SOLO          单变体报告,无对比对象',
-      '',
-      'Options:',
-      '  --reports-dir <dir>      report store dir (default: ~/.oh-my-knowledge/reports)',
-      '  --threshold <num>        三层 gate 阈值 (default 3.5,匹配 omk bench ci)',
-      '  --trivial-diff <num>     "幅度太小"阈值 (default 0.1)',
-      '  --verbose                展开 per-pair 详情',
-      '',
-    ].join('\n'));
+    console.log(tCli('cli.help.verdict', lang));
     process.exit(reportId ? 0 : 1);
   }
 
@@ -1985,24 +1770,7 @@ async function handleDiagnose(argv: string[]): Promise<void> {
   const lang = langFromArgv(argv);
   const reportId = argv[0];
   if (!reportId || reportId === '--help' || reportId === '-h') {
-    console.log([
-      '',
-      'Usage: omk bench diagnose <reportId> [options]',
-      '',
-      '诊断样本集本身的质量问题:区分度低 / 重复 / 歧义 / 成本异常 / 全 fail。',
-      '回答"测评结论是否被坏样本污染"——与 omk bench verdict 互补。',
-      '',
-      'Options:',
-      '  --reports-dir <dir>      report store dir',
-      '  --samples <path>         样本文件路径 (用于 near-duplicate 检测;默认从 report.meta.request 读)',
-      '  --top <n>                每类只显示前 N 个 (默认 10,0=全部)',
-      '  --duplicate-rouge <num>  near-duplicate ROUGE-1 阈值 (默认 0.7)',
-      '  --ambiguous-stddev <num> 歧义阈值,judge stddev (默认 1.0,需要 --judge-repeat ≥ 2 数据)',
-      '  --cost-k <num>           成本异常倍数 vs median (默认 3)',
-      '  --latency-k <num>        耗时异常倍数 vs median (默认 3)',
-      '  --flat <num>             flat_scores 分差阈值 (默认 0.5)',
-      '',
-    ].join('\n'));
+    console.log(tCli('cli.help.diagnose', lang));
     process.exit(reportId ? 0 : 1);
   }
 
@@ -2076,22 +1844,7 @@ async function handleFailures(argv: string[]): Promise<void> {
   const lang = langFromArgv(argv);
   const reportId = argv[0];
   if (!reportId || reportId === '--help' || reportId === '-h') {
-    console.log([
-      '',
-      'Usage: omk bench failures <reportId> [options]',
-      '',
-      '把已有 report 的失败样本喂给一次 LLM 调用,自动聚类 + 给修复建议。',
-      '失败定义:compositeScore < threshold 或 ok=false。',
-      '',
-      'Options:',
-      '  --reports-dir <dir>      report store dir',
-      '  --judge-executor <name>  执行器 (default: claude)',
-      '  --judge-model <id>       聚类用的 model (default: 沿用 report.meta.judgeModel)',
-      '  --max-clusters <n>       最多多少 cluster (default 5)',
-      '  --threshold <num>        compositeScore < threshold 算失败 (default 3)',
-      '  --max-feed <n>           最多喂给 LLM 多少条 (default 50,超出取最差)',
-      '',
-    ].join('\n'));
+    console.log(tCli('cli.help.failures', lang));
     process.exit(reportId ? 0 : 1);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -765,31 +765,33 @@ async function handleRun(argv: string[]): Promise<void> {
         repeat: repeatCount,
         onSkillProgress({ phase, skill, current, total }: SkillProgressInfo): void {
           if (phase === 'start') {
-            process.stderr.write(`\n=== [${current}/${total}] Skill: ${skill} ===\n`);
+            process.stderr.write(tCli('cli.run.skill_section', lang, {
+              i: current ?? '', n: total ?? '', skill: skill ?? '',
+            }));
           }
         },
       }) as EvalResult;
       console.log(JSON.stringify(report, null, 2));
       if (filePath) {
-        process.stderr.write('\n✅ 批量评测完成\n');
-        process.stderr.write(`📄 Report saved to: ${filePath}\n`);
+        process.stderr.write(tCli('cli.run.batch_complete', lang));
+        process.stderr.write(tCli('cli.run.report_saved', lang, { path: filePath }));
 
         if (!values['no-serve'] && process.stdout.isTTY) {
           const { createReportServer } = await import('./server/report-server.js');
           const server: ReportServer = createReportServer({ reportsDir: config.outputDir });
           const serverUrl: string = await server.start();
           const reportUrl: string = `${serverUrl}/run/${report.id}`;
-          process.stderr.write(`\n📊 Report server running at ${serverUrl}\n`);
-          process.stderr.write(`👉 View report: ${reportUrl}\n`);
-          process.stderr.write('\nPress Ctrl+C to stop the server\n');
+          process.stderr.write(tCli('cli.run.report_server_running', lang, { url: serverUrl }));
+          process.stderr.write(tCli('cli.run.report_server_view', lang, { url: reportUrl }));
+          process.stderr.write(tCli('cli.run.report_server_stop', lang));
 
           const { platform } = await import('node:os');
           const openCmd: string = platform() === 'darwin' ? 'open' : platform() === 'win32' ? 'start' : 'xdg-open';
           const { execFile: execFileCb } = await import('node:child_process');
           execFileCb(openCmd, [reportUrl], () => { });
         } else if (!values['no-serve']) {
-          process.stderr.write('\n💡 非交互环境，已跳过 report server\n');
-          process.stderr.write(`   查看报告: omk bench report --reports-dir ${config.outputDir}\n`);
+          process.stderr.write(tCli('cli.run.no_serve_in_non_tty', lang));
+          process.stderr.write(tCli('cli.run.no_serve_view_hint', lang, { dir: config.outputDir }));
         }
       }
       return;
@@ -803,7 +805,7 @@ async function handleRun(argv: string[]): Promise<void> {
         ...config,
         repeat: repeatCount,
         onRepeatProgress({ run, total }: RepeatProgressInfo): void {
-          process.stderr.write(`\n=== Run ${run}/${total} ===\n`);
+          process.stderr.write(tCli('cli.run.run_section', lang, { i: run, n: total }));
         },
       }) as { report: Report };
       report = result.report;
@@ -827,18 +829,22 @@ async function handleRun(argv: string[]): Promise<void> {
       if (out.result && out.gold) {
         process.stderr.write(formatGoldCompare(out.result, out.gold));
         if (out.result.contaminationWarning) {
-          process.stderr.write(`\n⚠ ${out.result.contaminationWarning}\n`);
+          process.stderr.write(tCli('cli.run.contamination_warning', lang, {
+            warning: out.result.contaminationWarning,
+          }));
         }
       } else {
-        process.stderr.write(`\n⚠ gold dataset 加载失败 (${goldDir}):\n`);
-        for (const m of out.loadIssues) process.stderr.write(`  - ${m}\n`);
+        process.stderr.write(tCli('cli.run.gold_load_failed', lang, { dir: goldDir }));
+        for (const m of out.loadIssues) {
+          process.stderr.write(tCli('cli.run.gold_load_issue', lang, { message: m }));
+        }
       }
     }
 
     console.log(JSON.stringify(report, null, 2));
     if (filePath) {
-      process.stderr.write('\n✅ 评测完成\n');
-      process.stderr.write(`📄 Report saved to: ${filePath}\n`);
+      process.stderr.write(tCli('cli.run.eval_complete', lang));
+      process.stderr.write(tCli('cli.run.report_saved', lang, { path: filePath }));
 
       if (!values['no-serve'] && process.stdout.isTTY) {
         // Auto-start report server
@@ -848,9 +854,9 @@ async function handleRun(argv: string[]): Promise<void> {
         });
         const serverUrl: string = await server.start();
         const reportUrl: string = `${serverUrl}/run/${report.id}`;
-        process.stderr.write(`\n📊 Report server running at ${serverUrl}\n`);
-        process.stderr.write(`👉 View report: ${reportUrl}\n`);
-        process.stderr.write('\nPress Ctrl+C to stop the server\n');
+        process.stderr.write(tCli('cli.run.report_server_running', lang, { url: serverUrl }));
+        process.stderr.write(tCli('cli.run.report_server_view', lang, { url: reportUrl }));
+        process.stderr.write(tCli('cli.run.report_server_stop', lang));
 
         // Auto-open report in browser
         const { platform } = await import('node:os');
@@ -858,12 +864,12 @@ async function handleRun(argv: string[]): Promise<void> {
         const { execFile: execFileCb } = await import('node:child_process');
         execFileCb(openCmd, [reportUrl], () => { });
       } else if (!values['no-serve']) {
-        process.stderr.write('\n💡 非交互环境，已跳过 report server\n');
-        process.stderr.write(`   查看报告: omk bench report --reports-dir ${config.outputDir}\n`);
+        process.stderr.write(tCli('cli.run.no_serve_in_non_tty', lang));
+        process.stderr.write(tCli('cli.run.no_serve_view_hint', lang, { dir: config.outputDir }));
       }
     }
   } catch (err: unknown) {
-    console.error(`Error: ${(err as Error).message}`);
+    console.error(tCli('cli.common.error_prefix', lang, { message: (err as Error).message }));
     process.exit(1);
   }
 }
@@ -1014,6 +1020,7 @@ function parseLastWindow(spec: string): string | null {
 }
 
 async function handleAnalyze(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const { values, positionals } = parseArgs({
     args: argv,
     allowPositionals: true,
@@ -1083,7 +1090,7 @@ async function handleAnalyze(argv: string[]): Promise<void> {
   console.log(skillRows.join('\n'));
   console.log('');
   console.log(`report written to: ${jsonPath}`);
-  console.log(`view in browser: omk bench report  # 打开后点首页的 "📊 Skill 健康度日报"`);
+  console.log(tCli('cli.analyze.view_in_browser', lang));
 }
 
 async function handleInit(argv: string[]): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
-import { tCli, getCliLang, parseLangFromArgv } from './cli/i18n.js';
+import { tCli, getCliLang, parseLangFromArgv, langFromArgv } from './cli/i18n.js';
 import { discoverVariants, parseVariantCwd } from './inputs/skill-loader.js';
 import { loadEvalConfig, configVariantsToSpecs } from './inputs/eval-config.js';
 import type {
@@ -1066,6 +1066,7 @@ async function handleAnalyze(argv: string[]): Promise<void> {
 }
 
 async function handleInit(argv: string[]): Promise<void> {
+  const lang = langFromArgv(argv);
   const targetDir: string = resolve(argv[0] || '.');
   const { writeFileSync, mkdirSync } = await import('node:fs');
 
@@ -1074,12 +1075,12 @@ async function handleInit(argv: string[]): Promise<void> {
   writeFileSync(join(targetDir, 'skills', 'v1.md'), INIT_SKILL_V1);
   writeFileSync(join(targetDir, 'skills', 'v2.md'), INIT_SKILL_V2);
 
-  console.log(`Eval project scaffolded at: ${targetDir}`);
+  console.log(tCli('cli.init.scaffolded', lang, { dir: targetDir }));
   console.log('');
-  console.log('Next steps:');
-  console.log('  1. Edit eval-samples.json to add your test cases');
-  console.log('  2. Edit skills/v1.md and skills/v2.md with your skill versions');
-  console.log('  3. Run: omk bench run --control v1 --treatment v2');
+  console.log(tCli('cli.init.next_steps_title', lang));
+  console.log(tCli('cli.init.next_step_edit_samples', lang));
+  console.log(tCli('cli.init.next_step_edit_skills', lang));
+  console.log(tCli('cli.init.next_step_run', lang));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -80,7 +80,24 @@ export type CliMessageKey =
   | 'cli.run.judge_models_single_warning'
   | 'cli.run.no_debias_length_active'
   | 'cli.run.invalid_bootstrap_samples'
-  | 'cli.run.bootstrap_samples_too_large';
+  | 'cli.run.bootstrap_samples_too_large'
+  // bench run 完成 / 报告 server / gold compare / 错误
+  | 'cli.run.skill_section'
+  | 'cli.run.run_section'
+  | 'cli.run.batch_complete'
+  | 'cli.run.eval_complete'
+  | 'cli.run.report_saved'
+  | 'cli.run.report_server_running'
+  | 'cli.run.report_server_view'
+  | 'cli.run.report_server_stop'
+  | 'cli.run.no_serve_in_non_tty'
+  | 'cli.run.no_serve_view_hint'
+  | 'cli.run.gold_load_failed'
+  | 'cli.run.gold_load_issue'
+  | 'cli.run.contamination_warning'
+  | 'cli.common.error_prefix'
+  // bench analyze
+  | 'cli.analyze.view_in_browser';
 
 export interface CliMessage {
   zh: string;
@@ -195,5 +212,65 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
   'cli.run.bootstrap_samples_too_large': {
     zh: '⚠ --bootstrap-samples {n} 较大, 可能耗时数秒。1000 是业内标准, 通常已够用。\n',
     en: '⚠ --bootstrap-samples {n} is large and may take several seconds. 1000 is the industry standard and usually sufficient.\n',
+  },
+  'cli.run.skill_section': {
+    zh: '\n=== [{i}/{n}] Skill: {skill} ===\n',
+    en: '\n=== [{i}/{n}] Skill: {skill} ===\n',
+  },
+  'cli.run.run_section': {
+    zh: '\n=== 第 {i}/{n} 轮 ===\n',
+    en: '\n=== Run {i}/{n} ===\n',
+  },
+  'cli.run.batch_complete': {
+    zh: '\n✅ 批量评测完成\n',
+    en: '\n✅ Batch evaluation done\n',
+  },
+  'cli.run.eval_complete': {
+    zh: '\n✅ 评测完成\n',
+    en: '\n✅ Evaluation done\n',
+  },
+  'cli.run.report_saved': {
+    zh: '📄 报告已保存到: {path}\n',
+    en: '📄 Report saved to: {path}\n',
+  },
+  'cli.run.report_server_running': {
+    zh: '\n📊 报告服务已启动: {url}\n',
+    en: '\n📊 Report server running at {url}\n',
+  },
+  'cli.run.report_server_view': {
+    zh: '👉 查看报告: {url}\n',
+    en: '👉 View report: {url}\n',
+  },
+  'cli.run.report_server_stop': {
+    zh: '\n按 Ctrl+C 停止服务\n',
+    en: '\nPress Ctrl+C to stop the server\n',
+  },
+  'cli.run.no_serve_in_non_tty': {
+    zh: '\n💡 非交互环境, 已跳过 report server\n',
+    en: '\n💡 Non-interactive environment, skipping report server\n',
+  },
+  'cli.run.no_serve_view_hint': {
+    zh: '   查看报告: omk bench report --reports-dir {dir}\n',
+    en: '   View report: omk bench report --reports-dir {dir}\n',
+  },
+  'cli.run.gold_load_failed': {
+    zh: '\n⚠ gold dataset 加载失败 ({dir}):\n',
+    en: '\n⚠ Failed to load gold dataset ({dir}):\n',
+  },
+  'cli.run.gold_load_issue': {
+    zh: '  - {message}\n',
+    en: '  - {message}\n',
+  },
+  'cli.run.contamination_warning': {
+    zh: '\n⚠ {warning}\n',
+    en: '\n⚠ {warning}\n',
+  },
+  'cli.common.error_prefix': {
+    zh: '错误: {message}',
+    en: 'Error: {message}',
+  },
+  'cli.analyze.view_in_browser': {
+    zh: "在浏览器查看: omk bench report  # 打开后点首页的 \"📊 Skill 健康度日报\"",
+    en: "View in browser: omk bench report  # then click \"📊 Skill health report\" on the home page",
   },
 };

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -97,7 +97,54 @@ export type CliMessageKey =
   | 'cli.run.contamination_warning'
   | 'cli.common.error_prefix'
   // bench analyze
-  | 'cli.analyze.view_in_browser';
+  | 'cli.analyze.view_in_browser'
+  // 通用 not-found 错误
+  | 'cli.common.skill_dir_not_found'
+  | 'cli.common.skill_file_not_found'
+  | 'cli.common.report_not_found'
+  | 'cli.common.no_judge_model'
+  | 'cli.common.usage_gold_validate'
+  | 'cli.common.warn_load_samples_failed'
+  // bench gen-samples
+  | 'cli.gen.skill_skipped_existing'
+  | 'cli.gen.skill_generating'
+  | 'cli.gen.skill_done'
+  | 'cli.gen.skill_failed'
+  | 'cli.gen.batch_none_needed'
+  | 'cli.gen.batch_summary'
+  | 'cli.gen.specify_skill_path'
+  | 'cli.gen.samples_already_exists'
+  | 'cli.gen.single_generating'
+  | 'cli.gen.single_done'
+  | 'cli.gen.review_hint'
+  | 'cli.gen.failed'
+  // bench evolve
+  | 'cli.evolve.specify_skill_path'
+  | 'cli.evolve.section_header'
+  | 'cli.evolve.round_baseline'
+  | 'cli.evolve.round_error'
+  | 'cli.evolve.round_done'
+  | 'cli.evolve.summary'
+  | 'cli.evolve.best_path'
+  | 'cli.evolve.versions_saved'
+  | 'cli.evolve.report_link'
+  // bench gold
+  | 'cli.gold.created_files'
+  | 'cli.gold.next_step_edit_annotations'
+  | 'cli.gold.validate_ok'
+  // bench debias-validate
+  | 'cli.debias.warn_cost_doubles'
+  // bench saturation
+  | 'cli.saturation.no_data'
+  | 'cli.saturation.verdict_header'
+  | 'cli.saturation.variant_no_trace'
+  | 'cli.saturation.variant_label'
+  | 'cli.saturation.checkpoints'
+  | 'cli.saturation.last_point'
+  | 'cli.saturation.persisted_verdict'
+  | 'cli.saturation.persisted_verdict_saturated'
+  | 'cli.saturation.persisted_verdict_unsaturated'
+  | 'cli.saturation.skipped_too_few_points';
 
 export interface CliMessage {
   zh: string;
@@ -272,5 +319,169 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
   'cli.analyze.view_in_browser': {
     zh: "在浏览器查看: omk bench report  # 打开后点首页的 \"📊 Skill 健康度日报\"",
     en: "View in browser: omk bench report  # then click \"📊 Skill health report\" on the home page",
+  },
+  'cli.common.skill_dir_not_found': {
+    zh: '未找到 skill 目录: {path}',
+    en: 'Skill directory not found: {path}',
+  },
+  'cli.common.skill_file_not_found': {
+    zh: '未找到 skill 文件: {path}',
+    en: 'Skill file not found: {path}',
+  },
+  'cli.common.report_not_found': {
+    zh: '未找到 report: {id}',
+    en: 'Report not found: {id}',
+  },
+  'cli.common.no_judge_model': {
+    zh: '未指定评委模型。请加 --judge-model <id>, 或确保 report.meta.judgeModel 已写。',
+    en: 'No judge model. Pass --judge-model <id> or ensure report has meta.judgeModel.',
+  },
+  'cli.common.usage_gold_validate': {
+    zh: '用法: omk bench gold validate <dir>',
+    en: 'Usage: omk bench gold validate <dir>',
+  },
+  'cli.common.warn_load_samples_failed': {
+    zh: '⚠ 加载 samples 文件失败 ({path}): {message}\n',
+    en: '⚠ Failed to load samples file ({path}): {message}\n',
+  },
+  'cli.gen.skill_skipped_existing': {
+    zh: '⏭️  {name}: eval-samples 已存在, 跳过\n',
+    en: '⏭️  {name}: eval-samples already exists, skipping\n',
+  },
+  'cli.gen.skill_generating': {
+    zh: '🔄 {name}: 正在生成 {count} 条测评用例...\n',
+    en: '🔄 {name}: generating {count} test cases...\n',
+  },
+  'cli.gen.skill_done': {
+    zh: '✅ {name}: 已生成 {n} 条样本 → {path}{cost}\n',
+    en: '✅ {name}: generated {n} samples → {path}{cost}\n',
+  },
+  'cli.gen.skill_failed': {
+    zh: '❌ {name}: {message}\n',
+    en: '❌ {name}: {message}\n',
+  },
+  'cli.gen.batch_none_needed': {
+    zh: '没有需要生成的 eval-samples (所有 skill 都已有配对文件)',
+    en: 'No eval-samples need generating (all skills already have paired files)',
+  },
+  'cli.gen.batch_summary': {
+    zh: '\n共生成 {n} 份 eval-samples, 请审查后运行: omk bench run --each',
+    en: '\nGenerated {n} eval-samples files. Review them, then run: omk bench run --each',
+  },
+  'cli.gen.specify_skill_path': {
+    zh: '请指定 skill 文件路径, 例如: omk bench gen-samples skills/my-skill.md',
+    en: 'Please specify a skill file path, e.g.: omk bench gen-samples skills/my-skill.md',
+  },
+  'cli.gen.samples_already_exists': {
+    zh: 'eval-samples.json 已存在。如需覆盖请先删除该文件。',
+    en: 'eval-samples.json already exists. Delete it first if you want to overwrite.',
+  },
+  'cli.gen.single_generating': {
+    zh: '🔄 正在生成 {count} 条测评用例...\n',
+    en: '🔄 Generating {count} test cases...\n',
+  },
+  'cli.gen.single_done': {
+    zh: '✅ 已生成 {n} 条样本 → {path}{cost}\n',
+    en: '✅ Generated {n} samples → {path}{cost}\n',
+  },
+  'cli.gen.review_hint': {
+    zh: '\n请审查生成的测评用例后运行: omk bench run',
+    en: '\nReview the generated test cases, then run: omk bench run',
+  },
+  'cli.gen.failed': {
+    zh: '生成失败: {message}',
+    en: 'Generation failed: {message}',
+  },
+  'cli.evolve.specify_skill_path': {
+    zh: '请指定 skill 文件路径, 例如: omk bench evolve skills/my-skill.md',
+    en: 'Please specify a skill file path, e.g.: omk bench evolve skills/my-skill.md',
+  },
+  'cli.evolve.section_header': {
+    zh: '\n=== Evolution: {path} ===\n',
+    en: '\n=== Evolution: {path} ===\n',
+  },
+  'cli.evolve.round_baseline': {
+    zh: '第 0 轮 (基线): score={score} (${cost})\n',
+    en: 'Round 0 (baseline): score={score} (${cost})\n',
+  },
+  'cli.evolve.round_error': {
+    zh: '第 {round} 轮: ✗ 改进生成失败: {error}\n',
+    en: 'Round {round}: ✗ improvement generation failed: {error}\n',
+  },
+  'cli.evolve.round_done': {
+    zh: '第 {round} 轮: score={score} ({delta}) {status} (${cost})\n',
+    en: 'Round {round}: score={score} ({delta}) {status} (${cost})\n',
+  },
+  'cli.evolve.summary': {
+    zh: '\n✅ {start} → {final} (+{percent}%) | 共 {rounds} 轮 | ${cost}\n',
+    en: '\n✅ {start} → {final} (+{percent}%) | {rounds} rounds | ${cost}\n',
+  },
+  'cli.evolve.best_path': {
+    zh: '最优版本: {best} → {target}\n',
+    en: 'Best: {best} → {target}\n',
+  },
+  'cli.evolve.versions_saved': {
+    zh: '所有版本已保存在: {dir}/\n',
+    en: 'All versions saved at: {dir}/\n',
+  },
+  'cli.evolve.report_link': {
+    zh: '📊 评测报告: omk bench report (ID: {id})\n',
+    en: '📊 Report: omk bench report (ID: {id})\n',
+  },
+  'cli.gold.created_files': {
+    zh: '已在 {dir} 创建 {n} 个文件:',
+    en: 'Created {n} files in {dir}:',
+  },
+  'cli.gold.next_step_edit_annotations': {
+    zh: '\n下一步: 编辑 annotations.yaml 加入真实标注 → 跑 omk bench gold validate',
+    en: '\nNext step: edit annotations.yaml with real annotations → run omk bench gold validate',
+  },
+  'cli.gold.validate_ok': {
+    zh: '✓ gold dataset OK — 共 {n} 条标注',
+    en: '✓ gold dataset OK — {n} annotations',
+  },
+  'cli.debias.warn_cost_doubles': {
+    zh: '\n⚠ debias-validate 会重判所有 (sample × variant), judge 成本大约翻倍。\n',
+    en: '\n⚠ debias-validate will re-judge all (sample × variant) pairs; judge cost will roughly double.\n',
+  },
+  'cli.saturation.no_data': {
+    zh: '该 report 没有 saturation 数据 (需要 --repeat ≥ 2 才会记录)。',
+    en: 'This report has no saturation data (requires --repeat ≥ 2 to record).',
+  },
+  'cli.saturation.verdict_header': {
+    zh: '\n  Saturation verdict (复述持久化结果)\n',
+    en: '\n  Saturation verdict (replaying persisted result)\n',
+  },
+  'cli.saturation.variant_no_trace': {
+    zh: '  {variant}: 没有 trace 数据',
+    en: '  {variant}: no trace data',
+  },
+  'cli.saturation.variant_label': {
+    zh: '  {variant}:',
+    en: '  {variant}:',
+  },
+  'cli.saturation.checkpoints': {
+    zh: '    检查点: {n} (N={list})',
+    en: '    checkpoints: {n} (N={list})',
+  },
+  'cli.saturation.last_point': {
+    zh: '    最后一点 mean={mean}, CI=[{lo}, {hi}]',
+    en: '    last point mean={mean}, CI=[{lo}, {hi}]',
+  },
+  'cli.saturation.persisted_verdict': {
+    zh: '    持久化判定 ({method}): {result} - {reason}',
+    en: '    persisted verdict ({method}): {result} - {reason}',
+  },
+  'cli.saturation.persisted_verdict_saturated': {
+    zh: '已饱和@N={n}',
+    en: 'saturated@N={n}',
+  },
+  'cli.saturation.persisted_verdict_unsaturated': {
+    zh: '未饱和',
+    en: 'not saturated',
+  },
+  'cli.saturation.skipped_too_few_points': {
+    zh: '    判定: 数据点数 {n} < 5, 跳过 (需要跑 --repeat 5 以上才会输出)',
+    en: '    verdict: only {n} data points (< 5), skipping (need --repeat 5 or more)',
   },
 };

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -11,8 +11,9 @@
 export type CliMessageKey =
   // 通用 / 启动期
   | 'cli.common.lang_invalid_silent'
-  | 'cli.common.unknown_command'
-  | 'cli.common.help_hint';
+  | 'cli.common.help_hint'
+  | 'cli.common.unknown_domain'
+  | 'cli.common.unknown_bench_command';
 
 export interface CliMessage {
   zh: string;
@@ -24,12 +25,16 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
     zh: '无效的语言: {value} (仅支持 zh|en, 已退回默认 zh)',
     en: 'Invalid language: {value} (supported: zh|en, falling back to default zh)',
   },
-  'cli.common.unknown_command': {
-    zh: '未知子命令: {command}',
-    en: 'Unknown command: {command}',
-  },
   'cli.common.help_hint': {
     zh: "运行 'omk --help' 查看用法",
     en: "Run 'omk --help' to see usage",
+  },
+  'cli.common.unknown_domain': {
+    zh: "未知模块: {domain} (请用 'omk bench <command>' 或 'omk analyze <dir>')",
+    en: "Unknown domain: {domain} (use 'omk bench <command>' or 'omk analyze <dir>')",
+  },
+  'cli.common.unknown_bench_command': {
+    zh: "未知 bench 子命令: {command} (运行 'omk --help' 查看可用列表)",
+    en: "Unknown bench command: {command} (run 'omk --help' to see all commands)",
   },
 };

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -1,0 +1,35 @@
+/**
+ * CLI 文案字典。
+ *
+ * 命名约定: `cli.<command>.<event>` 或 `cli.common.<event>`。
+ * 占位符用 `{name}` 形式,在 tCli(params) 处替换。
+ *
+ * 新增 key 时**两边必须同时加**,Record 类型会强制,test/cli-i18n.test.ts
+ * 还会做 runtime 校验防止 zh/en 漏写。
+ */
+
+export type CliMessageKey =
+  // 通用 / 启动期
+  | 'cli.common.lang_invalid_silent'
+  | 'cli.common.unknown_command'
+  | 'cli.common.help_hint';
+
+export interface CliMessage {
+  zh: string;
+  en: string;
+}
+
+export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
+  'cli.common.lang_invalid_silent': {
+    zh: '无效的语言: {value} (仅支持 zh|en, 已退回默认 zh)',
+    en: 'Invalid language: {value} (supported: zh|en, falling back to default zh)',
+  },
+  'cli.common.unknown_command': {
+    zh: '未知子命令: {command}',
+    en: 'Unknown command: {command}',
+  },
+  'cli.common.help_hint': {
+    zh: "运行 'omk --help' 查看用法",
+    en: "Run 'omk --help' to see usage",
+  },
+};

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -144,7 +144,17 @@ export type CliMessageKey =
   | 'cli.saturation.persisted_verdict'
   | 'cli.saturation.persisted_verdict_saturated'
   | 'cli.saturation.persisted_verdict_unsaturated'
-  | 'cli.saturation.skipped_too_few_points';
+  | 'cli.saturation.skipped_too_few_points'
+  // 长段 help / usage 文案 (multi-line)
+  | 'cli.help.main'
+  | 'cli.help.diff_usage'
+  | 'cli.help.analyze_usage'
+  | 'cli.help.gold'
+  | 'cli.help.debias_validate'
+  | 'cli.help.saturation'
+  | 'cli.help.verdict'
+  | 'cli.help.diagnose'
+  | 'cli.help.failures';
 
 export interface CliMessage {
   zh: string;
@@ -483,5 +493,518 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
   'cli.saturation.skipped_too_few_points': {
     zh: '    判定: 数据点数 {n} < 5, 跳过 (需要跑 --repeat 5 以上才会输出)',
     en: '    verdict: only {n} data points (< 5), skipping (need --repeat 5 or more)',
+  },
+  'cli.help.main': {
+    zh: `
+oh-my-knowledge — 知识工件评测工具集
+
+用法:
+  omk bench run [options]              跑一轮评测
+  omk bench report [options]           启动报告 server
+  omk bench ci [options]               跑评测并按 pass/fail 退出码返回
+  omk bench init [dir]                 初始化一个评测项目
+  omk bench gen-samples [skill]        从 skill 内容生成 eval-samples
+  omk bench diff <id1> <id2>           对比两份评测报告
+  omk bench evolve <skill>             通过迭代评测自我改进 skill
+
+  omk analyze <dir>                    分析 cc session trace, 生成 skill 健康度日报 (v0.18)
+
+bench run 选项:
+
+  --samples <path>       样本文件 (默认: eval-samples.json)
+  --skill-dir <path>     skill 定义目录 (默认: skills)
+  --control <expr>       对照组 variant 表达式 (实验角色 = control)
+  --treatment <v1,v2>    实验组 variant 表达式 (逗号分隔; 角色 = treatment)
+                         每个 variant 表达式解析为一个 artifact 加上可选运行时上下文:
+                           "baseline"       — 裸模型, 不注入 artifact
+                           "git:name"       — 来自最后一次 commit 的 artifact
+                           "git:ref:name"   — 来自指定 commit 的 artifact
+                           带 "/" 的路径    — 直接来自文件 (例如 ./v1.md)
+                           "name@/cwd"      — 附加运行时上下文 / cwd
+                         --control 和 --treatment 至少要给一个。
+  --config <path>        YAML/JSON 配置文件 (evaluation-as-code)。
+                         在一个文件里声明 samples + variants + model + executor。
+                         CLI flag 会覆盖配置文件中的同名字段。
+                         配置中的相对路径相对于配置文件所在目录解析。
+  --model <name>         被测模型 (默认: sonnet)
+  --judge-model <name>   评委模型 (默认: haiku)
+  --output-dir <path>    报告输出目录 (默认: ~/.oh-my-knowledge/reports/)
+  --no-judge             跳过 LLM 评委
+  --no-cache             禁用结果缓存
+  --dry-run              预览任务但不执行
+  --blind                双盲 A/B 模式: 报告里隐藏 variant 名称
+  --concurrency <n>      并发任务数 (默认: 1)
+  --timeout <seconds>    单任务执行超时 (秒, 默认: 120)
+  --repeat <n>           跑 N 轮做方差分析 (默认: 1)
+  --judge-repeat <n>     每个 (sample × dimension) 调 LLM 评委 N 次评估
+                         自洽性 (默认: 1)。多轮间高 stddev = 评委在该评分维度
+                         上不稳定, 分数有噪声。
+  --judge-models <list>  多评委 ensemble。逗号分隔的 executor:model, 如
+                         claude:opus,openai:gpt-4o,gemini:pro。每个评委对所有
+                         (sample × dimension) 打分; 报告含每评委分布 + Pearson
+                         / MAD 评委间一致性。能反驳 "Claude 评委评 Claude 同
+                         模态偏置" 的质疑。可与 --judge-repeat 组合。
+                         成本 ~ N_judges × N_repeat × N_samples。
+  --bootstrap            计算 bootstrap 置信区间 (无分布假设, 对 LLM 序数评分
+                         比 t 区间更靠谱)。给出每个 variant 均值 CI + treatment
+                         vs control 差值的 pairwise CI (CI 不跨 0 即显著)。
+                         同时报告 t 区间和 bootstrap, 旧工具仍可用。
+  --bootstrap-samples <n>  bootstrap 重采样次数 (默认 1000)。N>10000 触发
+                         stderr 警告提示耗时。
+  --retry <n>            失败任务最多重试 N 次, 指数退避 (默认: 0)
+  --resume <report-id>   从历史报告恢复, 跳过已完成任务
+  --executor <name>      执行器: claude / openai / gemini / anthropic-api /
+                         openai-api, 或任意 shell 命令 (例如 "python my_provider.py")
+  --judge-executor <name> 评委执行器 (默认: 同 --executor)
+  --each                 对每个 skill 独立 vs baseline 评测
+                         需要每个 skill 有配对的 {name}.eval-samples.json
+  --skip-preflight       评测前跳过模型连通性预检
+  --mcp-config <path>    通过 MCP server 抓 URL 用的 MCP 配置文件
+                         (默认: 当前目录下的 .mcp.json)
+  --no-serve             评测后不自动启动报告 server
+  --verbose              打印每个样本的详细进度 (执行结果 / 评分阶段)
+  --layered-stats        默认在 HTML 报告里展开三层 (fact/behavior/judge) 独立
+                         显著性细分。不加这个 flag 时, 细分会折叠在每个对比下
+                         的 click-to-expand summary 里。
+
+bench ci 选项:
+  (与 bench run 相同, 额外加:)
+  --threshold <number>   通过分数下限, 独立应用到三层中的每一层 (fact /
+                         behavior / LLM judge)。任一层低于阈值即失败 — 防止
+                         合成均值掩盖单层崩塌。默认: 3.5。如果三层全空 (没有
+                         assertion 也没在 eval-samples 里定义 rubric), gate
+                         失败并提示配置问题, 不走合成 fallback。
+
+bench report 选项:
+  --port <number>        server 端口 (默认: 7799)
+  --reports-dir <path>   报告目录 (默认: ~/.oh-my-knowledge/reports/)
+  --export <id>          把报告导出为独立 HTML 文件
+  --dev                  开发模式: lib/ 文件改动时自动重启
+
+bench gen-samples 选项:
+  --each                 为所有还没 eval-samples 的 skill 生成
+  --count <n>            每个 skill 生成多少条样本 (默认: 5)
+  --model <name>         生成用的模型 (默认: sonnet)
+  --skill-dir <path>     skill 目录 (默认: skills), 配合 --each 用
+
+analyze 选项:
+  <dir>                  输入: cc session JSONL 文件 / 目录
+                         (例如 ~/.claude/projects/<slug>)
+  --kb <path>            知识库根路径 (默认: 从 trace cwd 自动推断)
+  --last <duration>      时间窗口, 例如 "7d" / "30d" (默认: 全部)
+  --from <iso>           窗口起点 (ISO8601), 优先级高于 --last
+  --to <iso>             窗口终点 (ISO8601), 优先级高于 --last
+  --skills <n1,n2,...>   白名单要分析的 skill (默认: 全部)
+  --output-dir <path>    输出目录 (默认: ~/.oh-my-knowledge/analyses/)
+
+bench evolve 选项:
+  --rounds <n>           最大演化轮数 (默认: 5)
+  --target <score>       达到该分数即提前停止
+  --samples <path>       样本文件 (默认: eval-samples.json)
+  --model <name>         被测模型 (默认: sonnet)
+  --judge-model <name>   评委模型 (默认: haiku)
+  --improve-model <name> 生成改进版的模型 (默认: sonnet)
+  --concurrency <n>      并发评测任务数 (默认: 1)
+  --timeout <seconds>    单任务执行超时 (秒, 默认: 120)
+  --executor <name>      执行器 (默认: claude)
+
+通用选项:
+  --lang <zh|en>         CLI 输出语言 (默认: zh, 也可设 OMK_LANG 环境变量)
+
+示例:
+  omk bench run --control v1 --treatment v2
+  omk bench run --control baseline --treatment my-skill
+  omk bench run --control git:my-skill --treatment my-skill
+  omk bench run --control ./old-skill.md --treatment ./new-skill.md
+  omk bench run --control baseline --treatment v1,v2,v3
+  omk bench run --config eval.yaml
+  omk bench run --config eval.yaml --model sonnet-4.6   # CLI 覆盖配置
+  omk bench run --each
+  omk bench run --dry-run
+  omk bench report --port 8080
+  omk bench report --export v1-vs-v2-20260326-1832
+  omk bench init my-eval
+  omk bench gen-samples skills/my-skill.md
+`,
+    en: `
+oh-my-knowledge — Knowledge artifact evaluation toolkit
+
+Usage:
+  omk bench run [options]              Run an evaluation
+  omk bench report [options]           Start the report server
+  omk bench ci [options]               Run evaluation and exit with pass/fail code
+  omk bench init [dir]                 Scaffold a new eval project
+  omk bench gen-samples [skill]        Generate eval-samples from skill content
+  omk bench diff <id1> <id2>           Compare two evaluation reports
+  omk bench evolve <skill>             Self-improve a skill through iterative evaluation
+
+  omk analyze <dir>                    Analyze cc session trace(s), produce skill health report (v0.18)
+
+Options for "bench run":
+
+  --samples <path>       Sample file (default: eval-samples.json)
+  --skill-dir <path>     Skill definitions directory (default: skills)
+  --control <expr>       Control-group variant expression (experiment role = control)
+  --treatment <v1,v2>    Treatment-group variant expressions (comma-separated; role = treatment)
+                         Each variant expression resolves to an artifact and optional runtime context:
+                           "baseline"       — bare model, no artifact injected
+                           "git:name"       — artifact from last commit
+                           "git:ref:name"   — artifact from specific commit
+                           path with "/"    — artifact from file directly (e.g. ./v1.md)
+                           "name@/cwd"      — attach runtime context / cwd
+                         At least one of --control / --treatment must be provided.
+  --config <path>        YAML/JSON config file (evaluation-as-code).
+                         Declares samples + variants + model + executor in one file.
+                         CLI flags override config fields when both are provided.
+                         Relative paths inside the config are resolved against its directory.
+  --model <name>         Model under test (default: sonnet)
+  --judge-model <name>   Judge model (default: haiku)
+  --output-dir <path>    Report output directory (default: ~/.oh-my-knowledge/reports/)
+  --no-judge             Skip LLM judging
+  --no-cache             Disable result caching
+  --dry-run              Preview tasks without executing
+  --blind                Blind A/B mode: hide variant names in report
+  --concurrency <n>      Number of parallel tasks (default: 1)
+  --timeout <seconds>    Executor timeout per task in seconds (default: 120)
+  --repeat <n>           Run evaluation N times for variance analysis (default: 1)
+  --judge-repeat <n>     Call LLM judge N times per (sample × dimension) for self-
+                         consistency (default: 1). High stddev across runs = the
+                         judge is unstable on this rubric and the score is noisy.
+  --judge-models <list>  Multi-judge ensemble. Comma-separated executor:model pairs,
+                         e.g. claude:opus,openai:gpt-4o,gemini:pro. Each judge scores
+                         every (sample × dimension); report includes per-judge break-
+                         down + Pearson/MAD inter-judge agreement. Refutes "Claude
+                         judge Claude same-modality bias" critique. Combines with
+                         --judge-repeat. Cost ~ N_judges × N_repeat × N_samples.
+  --bootstrap            Compute bootstrap confidence intervals (distribution-free,
+                         preferred over t-interval for ordinal LLM scores). Adds
+                         per-variant CI on the mean + pairwise CI on treatment-vs-
+                         control difference (significant=0 outside CI). Reports both
+                         t-interval and bootstrap so old tooling still works.
+  --bootstrap-samples <n>  Number of bootstrap resamples (default 1000). N>10000
+                         triggers a stderr warning about runtime cost.
+  --retry <n>            Retry failed tasks up to N times with exponential backoff (default: 0)
+  --resume <report-id>   Resume from a previous report, skipping completed tasks
+  --executor <name>      Executor: claude, openai, gemini, anthropic-api, openai-api,
+                         or any shell command (e.g. "python my_provider.py")
+  --judge-executor <name> Executor for LLM judge (default: same as --executor)
+  --each                 Evaluate each skill independently against baseline
+                         Requires {name}.eval-samples.json paired with each skill
+  --skip-preflight       Skip model connectivity check before evaluation
+  --mcp-config <path>    MCP config file for URL fetching via MCP servers
+                         (default: .mcp.json in current directory)
+  --no-serve             Skip auto-starting report server after evaluation
+  --verbose              Print detailed progress for each sample (exec result, grading phases)
+  --layered-stats        Expand the three-layer (fact/behavior/judge) independent
+                         significance breakdown in the HTML report by default.
+                         Without this flag, the breakdown is collapsed behind a
+                         click-to-expand summary under each comparison.
+
+Options for "bench ci":
+  (same as "bench run", plus:)
+  --threshold <number>   Minimum score to pass, applied INDEPENDENTLY to each of
+                         the three layers (fact / behavior / LLM judge). ANY
+                         layer below threshold fails the gate — this prevents
+                         composite averaging from masking a single-layer collapse.
+                         Default: 3.5. If all three layers are absent (no
+                         assertions and no rubric defined in eval-samples), the
+                         gate FAILS with a configuration hint — no composite fallback.
+
+Options for "bench report":
+  --port <number>        Server port (default: 7799)
+  --reports-dir <path>   Reports directory (default: ~/.oh-my-knowledge/reports/)
+  --export <id>          Export report as standalone HTML file
+  --dev                  Dev mode: auto-restart on lib/ file changes
+
+Options for "bench gen-samples":
+  --each                 Generate for all skills missing eval-samples
+  --count <n>            Number of samples to generate per skill (default: 5)
+  --model <name>         Model for generation (default: sonnet)
+  --skill-dir <path>     Skill directory (default: skills), used with --each
+
+Options for "analyze":
+  <dir>                  Input: cc session JSONL file / dir (e.g. ~/.claude/projects/<slug>)
+  --kb <path>            Knowledge base root (default: auto-infer from trace cwd)
+  --last <duration>      Time window like "7d" / "30d" (default: all)
+  --from <iso>           Window start (ISO8601), takes precedence over --last
+  --to <iso>             Window end (ISO8601), takes precedence over --last
+  --skills <n1,n2,...>   Whitelist skills to analyze (default: all)
+  --output-dir <path>    Output dir (default: ~/.oh-my-knowledge/analyses/)
+
+Options for "bench evolve":
+  --rounds <n>           Maximum evolution rounds (default: 5)
+  --target <score>       Stop early when score reaches this threshold
+  --samples <path>       Sample file (default: eval-samples.json)
+  --model <name>         Model under test (default: sonnet)
+  --judge-model <name>   Judge model (default: haiku)
+  --improve-model <name> Model for generating improvements (default: sonnet)
+  --concurrency <n>      Parallel eval tasks (default: 1)
+  --timeout <seconds>    Executor timeout per task in seconds (default: 120)
+  --executor <name>      Executor to use (default: claude)
+
+Common options:
+  --lang <zh|en>         CLI output language (default: zh, also via OMK_LANG env)
+
+Examples:
+  omk bench run --control v1 --treatment v2
+  omk bench run --control baseline --treatment my-skill
+  omk bench run --control git:my-skill --treatment my-skill
+  omk bench run --control ./old-skill.md --treatment ./new-skill.md
+  omk bench run --control baseline --treatment v1,v2,v3
+  omk bench run --config eval.yaml
+  omk bench run --config eval.yaml --model sonnet-4.6   # CLI overrides config
+  omk bench run --each
+  omk bench run --dry-run
+  omk bench report --port 8080
+  omk bench report --export v1-vs-v2-20260326-1832
+  omk bench init my-eval
+  omk bench gen-samples skills/my-skill.md
+`,
+  },
+  'cli.help.diff_usage': {
+    zh: [
+      '用法:',
+      '  omk bench diff <reportId>                     单 report 内 sample 级 diff (v0.22)',
+      '  omk bench diff <reportId1> <reportId2>        跨 report variant 级 diff',
+      '',
+      '选项:',
+      '  --regressions-only          只列 treatment < control 的样本',
+      '  --threshold <num>           回退判定阈值 (默认 0, 即任何负 Δ 都算回退)',
+      '  --variant <name>            within-report 模式下指定要钻取的 variant (默认: variants[1])',
+      '  --top <n>                   只列差距最大的前 N 个样本',
+    ].join('\n'),
+    en: [
+      'Usage:',
+      '  omk bench diff <reportId>                     within-report per-sample diff (v0.22)',
+      '  omk bench diff <reportId1> <reportId2>        cross-report variant-level diff',
+      '',
+      'Options:',
+      '  --regressions-only          show only samples where treatment < control',
+      '  --threshold <num>           regression threshold (default 0, any negative Δ counts)',
+      '  --variant <name>            within-report mode: which variant to drill (default: variants[1])',
+      '  --top <n>                   only show top N samples by absolute diff',
+    ].join('\n'),
+  },
+  'cli.help.analyze_usage': {
+    zh: '用法: omk analyze <dir> [--kb <path>] [--last 7d] [--from ISO] [--to ISO] [--skills name1,name2]',
+    en: 'Usage: omk analyze <dir> [--kb <path>] [--last 7d] [--from ISO] [--to ISO] [--skills name1,name2]',
+  },
+  'cli.help.gold': {
+    zh: [
+      '',
+      '用法: omk bench gold <subcommand>',
+      '',
+      '子命令:',
+      '  init [--out <dir>] [--annotator <id>]    生成空白 gold dataset 模板',
+      '  validate <dir>                           校验数据集结构',
+      '  compare <reportId> --gold-dir <dir>      与已有 report 计算 α / κ / Pearson',
+      '    [--variant <name>] [--reports-dir <d>]',
+      '    [--bootstrap-samples N] [--seed N]',
+      '',
+    ].join('\n'),
+    en: [
+      '',
+      'Usage: omk bench gold <subcommand>',
+      '',
+      'Subcommands:',
+      '  init [--out <dir>] [--annotator <id>]    create a blank gold dataset template',
+      '  validate <dir>                           validate dataset structure',
+      '  compare <reportId> --gold-dir <dir>      compute α / κ / Pearson against an existing report',
+      '    [--variant <name>] [--reports-dir <d>]',
+      '    [--bootstrap-samples N] [--seed N]',
+      '',
+    ].join('\n'),
+  },
+  'cli.help.debias_validate': {
+    zh: [
+      '',
+      '用法: omk bench debias-validate <kind> <reportId> [options]',
+      '',
+      '类别:',
+      '  length    用相反的长度去偏设置重新评判, 并对分数差出 bootstrap CI。',
+      '            judge 成本约为原评判的两倍。',
+      '',
+      '选项:',
+      '  --reports-dir <dir>          报告存储目录 (默认: ~/.oh-my-knowledge/reports)',
+      '  --samples <path>             覆盖样本文件 (默认: 从 report.meta.request 读)',
+      '  --variant <name>             校验哪个 variant (默认: 第一个)',
+      '  --judge-executor <name>      评委调用执行器 (默认: claude)',
+      '  --judge-model <model>        评委模型 ID (默认: 沿用 report)',
+      '  --bootstrap-samples N        bootstrap 迭代次数 (默认 1000)',
+      '  --seed N                     固定 CI 随机种子',
+      '',
+    ].join('\n'),
+    en: [
+      '',
+      'Usage: omk bench debias-validate <kind> <reportId> [options]',
+      '',
+      'Kinds:',
+      '  length    re-judge with the opposite length-debias setting and bootstrap CI',
+      '            on the score diff. Cost ~doubles vs the original judge pass.',
+      '',
+      'Options:',
+      '  --reports-dir <dir>          report store dir (default: ~/.oh-my-knowledge/reports)',
+      '  --samples <path>             override samples file (default: from report.meta.request)',
+      '  --variant <name>             which variant to validate (default: first)',
+      '  --judge-executor <name>      executor for judge calls (default: claude)',
+      '  --judge-model <model>        judge model id (default: from report)',
+      '  --bootstrap-samples N        bootstrap iterations (default 1000)',
+      '  --seed N                     deterministic CI seed',
+      '',
+    ].join('\n'),
+  },
+  'cli.help.saturation': {
+    zh: [
+      '',
+      '用法: omk bench saturation <reportId> [options]',
+      '',
+      '回答 "我跑够样本了吗?"。复述已有 report 中持久化的饱和判定。',
+      '',
+      '注: 本命令读取 run 时跑出的 verdict (运行时已用 method=bootstrap-ci-width',
+      '默认阈值 + 3 窗口持续条件)。如要换 method/threshold 重新计算, 需要重跑',
+      '`omk bench run --repeat ≥ 5` (运行时持久化的 trace 不含原始分数, 无法',
+      '在事后用其他参数复算)。',
+      '',
+      '选项:',
+      '  --reports-dir <dir>   报告存储目录 (默认: ~/.oh-my-knowledge/reports)',
+      '  --variant <name>      只看一个 variant (默认: 全部)',
+      '',
+    ].join('\n'),
+    en: [
+      '',
+      'Usage: omk bench saturation <reportId> [options]',
+      '',
+      'Answers "do I have enough samples?". Replays the saturation verdict',
+      'persisted in an existing report.',
+      '',
+      'Note: this command reads the verdict computed at run time (which used',
+      'method=bootstrap-ci-width with default threshold + 3-window sustained',
+      'condition). To re-compute with a different method/threshold, re-run',
+      '`omk bench run --repeat ≥ 5` (the persisted trace does not include raw',
+      'scores, so post-hoc parameter sweeps are not possible here).',
+      '',
+      'Options:',
+      '  --reports-dir <dir>   report store dir (default: ~/.oh-my-knowledge/reports)',
+      '  --variant <name>      only show one variant (default: all)',
+      '',
+    ].join('\n'),
+  },
+  'cli.help.verdict': {
+    zh: [
+      '',
+      '用法: omk bench verdict <reportId> [options]',
+      '',
+      '聚合 bootstrap CI / 三层 ci-gate / saturation / human α, 给出一行结论。',
+      '',
+      'Verdict 等级:',
+      '  PROGRESS      显著改进 + 三层全过',
+      '  CAUTIOUS      改进真实但有警告 (gate 破 / 幅度太小 / 控制组本身崩)',
+      '  REGRESS       显著回退 — 不要 ship',
+      '  NOISE         CI 跨 0, 无法判定',
+      '  UNDERPOWERED  样本不足, 需要扩 N 重测',
+      '  SOLO          单 variant 报告, 没有对比对象',
+      '',
+      '选项:',
+      '  --reports-dir <dir>      报告存储目录 (默认: ~/.oh-my-knowledge/reports)',
+      '  --threshold <num>        三层 gate 阈值 (默认 3.5, 与 omk bench ci 对齐)',
+      '  --trivial-diff <num>     "幅度太小" 阈值 (默认 0.1)',
+      '  --verbose                展开每个 pair 的详情',
+      '',
+    ].join('\n'),
+    en: [
+      '',
+      'Usage: omk bench verdict <reportId> [options]',
+      '',
+      'Aggregates bootstrap CI / 3-layer ci-gate / saturation / human α into a one-line verdict.',
+      '',
+      'Verdict levels:',
+      '  PROGRESS      significant improvement + all 3 layers pass',
+      '  CAUTIOUS      real improvement but with warnings (gate fails / diff too small / control collapsed)',
+      '  REGRESS       significant regression — do not ship',
+      '  NOISE         CI crosses 0, no verdict',
+      '  UNDERPOWERED  not enough samples, expand N and re-run',
+      '  SOLO          single-variant report, nothing to compare against',
+      '',
+      'Options:',
+      '  --reports-dir <dir>      report store dir (default: ~/.oh-my-knowledge/reports)',
+      '  --threshold <num>        3-layer gate threshold (default 3.5, matches omk bench ci)',
+      '  --trivial-diff <num>     "diff too small" threshold (default 0.1)',
+      '  --verbose                expand per-pair details',
+      '',
+    ].join('\n'),
+  },
+  'cli.help.diagnose': {
+    zh: [
+      '',
+      '用法: omk bench diagnose <reportId> [options]',
+      '',
+      '诊断样本集本身的质量问题: 区分度低 / 重复 / 歧义 / 成本异常 / 全 fail。',
+      '回答 "测评结论是否被坏样本污染" — 与 omk bench verdict 互补。',
+      '',
+      '选项:',
+      '  --reports-dir <dir>      报告存储目录',
+      '  --samples <path>         样本文件路径 (用于 near-duplicate 检测; 默认从 report.meta.request 读)',
+      '  --top <n>                每类只显示前 N 个 (默认 10, 0=全部)',
+      '  --duplicate-rouge <num>  near-duplicate ROUGE-1 阈值 (默认 0.7)',
+      '  --ambiguous-stddev <num> 歧义阈值, judge stddev (默认 1.0, 需要 --judge-repeat ≥ 2 数据)',
+      '  --cost-k <num>           成本异常倍数 vs 中位数 (默认 3)',
+      '  --latency-k <num>        耗时异常倍数 vs 中位数 (默认 3)',
+      '  --flat <num>             flat_scores 分差阈值 (默认 0.5)',
+      '',
+    ].join('\n'),
+    en: [
+      '',
+      'Usage: omk bench diagnose <reportId> [options]',
+      '',
+      'Diagnose quality issues in the sample set itself: low discrimination /',
+      'duplicates / ambiguity / cost anomalies / all-fail. Answers "is the verdict',
+      'tainted by bad samples?" — complements omk bench verdict.',
+      '',
+      'Options:',
+      '  --reports-dir <dir>      report store dir',
+      '  --samples <path>         sample file path (for near-duplicate detection; defaults to report.meta.request)',
+      '  --top <n>                top N per category (default 10, 0=all)',
+      '  --duplicate-rouge <num>  near-duplicate ROUGE-1 threshold (default 0.7)',
+      '  --ambiguous-stddev <num> ambiguity threshold, judge stddev (default 1.0, requires --judge-repeat ≥ 2)',
+      '  --cost-k <num>           cost-outlier multiplier vs median (default 3)',
+      '  --latency-k <num>        latency-outlier multiplier vs median (default 3)',
+      '  --flat <num>             flat_scores spread threshold (default 0.5)',
+      '',
+    ].join('\n'),
+  },
+  'cli.help.failures': {
+    zh: [
+      '',
+      '用法: omk bench failures <reportId> [options]',
+      '',
+      '把已有 report 的失败样本喂给一次 LLM 调用, 自动聚类并给出修复建议。',
+      '失败定义: compositeScore < threshold 或 ok=false。',
+      '',
+      '选项:',
+      '  --reports-dir <dir>      报告存储目录',
+      '  --judge-executor <name>  执行器 (默认: claude)',
+      '  --judge-model <id>       聚类用的模型 (默认: 沿用 report.meta.judgeModel)',
+      '  --max-clusters <n>       最多聚成几类 (默认 5)',
+      '  --threshold <num>        compositeScore < threshold 算失败 (默认 3)',
+      '  --max-feed <n>           最多喂给 LLM 多少条 (默认 50, 超出取最差)',
+      '',
+    ].join('\n'),
+    en: [
+      '',
+      'Usage: omk bench failures <reportId> [options]',
+      '',
+      'Feed failing samples from an existing report to a single LLM call, auto-cluster',
+      'them, and produce per-cluster fix suggestions.',
+      'Failure definition: compositeScore < threshold or ok=false.',
+      '',
+      'Options:',
+      '  --reports-dir <dir>      report store dir',
+      '  --judge-executor <name>  executor (default: claude)',
+      '  --judge-model <id>       model for clustering (default: from report.meta.judgeModel)',
+      '  --max-clusters <n>       max number of clusters (default 5)',
+      '  --threshold <num>        compositeScore < threshold counts as failure (default 3)',
+      '  --max-feed <n>           max samples to feed the LLM (default 50, takes the worst)',
+      '',
+    ].join('\n'),
   },
 };

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -59,7 +59,28 @@ export type CliMessageKey =
   | 'cli.init.next_steps_title'
   | 'cli.init.next_step_edit_samples'
   | 'cli.init.next_step_edit_skills'
-  | 'cli.init.next_step_run';
+  | 'cli.init.next_step_run'
+  // 启动期检查 (checkUpdate)
+  | 'cli.update.new_version_available'
+  // 实时进度 (defaultOnProgress)
+  | 'cli.progress.preflight_starting'
+  | 'cli.progress.sample_retry'
+  | 'cli.progress.sample_error'
+  | 'cli.progress.sample_executing'
+  | 'cli.progress.sample_exec_done'
+  | 'cli.progress.output_preview'
+  | 'cli.progress.judging'
+  | 'cli.progress.judged'
+  | 'cli.progress.skipped'
+  | 'cli.progress.sample_done'
+  // bench run 参数校验 (parseRunConfig)
+  | 'cli.run.invalid_repeat'
+  | 'cli.run.invalid_judge_repeat'
+  | 'cli.run.invalid_judge_models_format'
+  | 'cli.run.judge_models_single_warning'
+  | 'cli.run.no_debias_length_active'
+  | 'cli.run.invalid_bootstrap_samples'
+  | 'cli.run.bootstrap_samples_too_large';
 
 export interface CliMessage {
   zh: string;
@@ -102,5 +123,77 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
   'cli.init.next_step_run': {
     zh: '  3. 运行: omk bench run --control v1 --treatment v2',
     en: '  3. Run: omk bench run --control v1 --treatment v2',
+  },
+  'cli.update.new_version_available': {
+    zh: '\n💡 新版本可用: {old} → {new}, 运行 npm update {pkg} -g 升级\n\n',
+    en: '\n💡 New version available: {old} → {new}, run npm update {pkg} -g to upgrade\n\n',
+  },
+  'cli.progress.preflight_starting': {
+    zh: '⏳ 正在预检模型连通性...\n',
+    en: '⏳ Preflight: checking model connectivity...\n',
+  },
+  'cli.progress.sample_retry': {
+    zh: '[{i}/{n}] {sample}/{variant} 🔄 重试 {attempt}/{max}...\n',
+    en: '[{i}/{n}] {sample}/{variant} 🔄 retry {attempt}/{max}...\n',
+  },
+  'cli.progress.sample_error': {
+    zh: '[{i}/{n}] {sample}/{variant} ❌ {error}\n',
+    en: '[{i}/{n}] {sample}/{variant} ❌ {error}\n',
+  },
+  'cli.progress.sample_executing': {
+    zh: '[{i}/{n}] {sample}/{variant} ⏳ 执行中...\n',
+    en: '[{i}/{n}] {sample}/{variant} ⏳ running...\n',
+  },
+  'cli.progress.sample_exec_done': {
+    zh: '[{i}/{n}] {sample}/{variant} 执行完成 {ms}ms {input}+{output} tokens{cost}\n',
+    en: '[{i}/{n}] {sample}/{variant} done {ms}ms {input}+{output} tokens{cost}\n',
+  },
+  'cli.progress.output_preview': {
+    zh: '  输出预览: {preview}\n',
+    en: '  output preview: {preview}\n',
+  },
+  'cli.progress.judging': {
+    zh: '[{i}/{n}] {sample}/{variant} 评委评审中{dim}...\n',
+    en: '[{i}/{n}] {sample}/{variant} judging{dim}...\n',
+  },
+  'cli.progress.judged': {
+    zh: '[{i}/{n}] {sample}/{variant} 评委评审完成{dim} score={score}\n',
+    en: '[{i}/{n}] {sample}/{variant} judged{dim} score={score}\n',
+  },
+  'cli.progress.skipped': {
+    zh: '[{i}/{n}] {sample}/{variant} ⏭ 已跳过 (已有结果)\n',
+    en: '[{i}/{n}] {sample}/{variant} ⏭ skipped (cached)\n',
+  },
+  'cli.progress.sample_done': {
+    zh: '[{i}/{n}] {sample}/{variant} ✓ {ms}ms {input}+{output} tokens{cost}{score}\n',
+    en: '[{i}/{n}] {sample}/{variant} ✓ {ms}ms {input}+{output} tokens{cost}{score}\n',
+  },
+  'cli.run.invalid_repeat': {
+    zh: '⚠ --repeat "{value}" 无效 (期望 ≥ 1 的整数), 已按 1 次评测执行\n',
+    en: '⚠ --repeat "{value}" is invalid (expected an integer ≥ 1), falling back to 1 run\n',
+  },
+  'cli.run.invalid_judge_repeat': {
+    zh: '⚠ --judge-repeat "{value}" 无效 (期望 ≥ 1 的整数), 已按 1 次 judge 执行\n',
+    en: '⚠ --judge-repeat "{value}" is invalid (expected an integer ≥ 1), falling back to 1 judge call\n',
+  },
+  'cli.run.invalid_judge_models_format': {
+    zh: '--judge-models 格式错误: "{part}", 应为 "executor:model" (例如 claude:opus)',
+    en: '--judge-models format error: "{part}", expected "executor:model" (e.g. claude:opus)',
+  },
+  'cli.run.judge_models_single_warning': {
+    zh: 'ℹ --judge-models 只指定了 1 个 judge ({executor}:{model}), 不会进入 ensemble 模式。如需 ensemble, 至少配 2 个。\n',
+    en: 'ℹ --judge-models specified only 1 judge ({executor}:{model}); ensemble not triggered. Configure at least 2 for ensemble mode.\n',
+  },
+  'cli.run.no_debias_length_active': {
+    zh: 'ℹ --no-debias-length 已生效: judge prompt 退回 v2-cot, 与 < v0.21 报告 hash 一致。\n',
+    en: 'ℹ --no-debias-length is active: judge prompt reverts to v2-cot, matching < v0.21 report hashes.\n',
+  },
+  'cli.run.invalid_bootstrap_samples': {
+    zh: '⚠ --bootstrap-samples "{value}" 无效 (期望 ≥ 100 的整数), 已按 1000 执行\n',
+    en: '⚠ --bootstrap-samples "{value}" is invalid (expected an integer ≥ 100), falling back to 1000\n',
+  },
+  'cli.run.bootstrap_samples_too_large': {
+    zh: '⚠ --bootstrap-samples {n} 较大, 可能耗时数秒。1000 是业内标准, 通常已够用。\n',
+    en: '⚠ --bootstrap-samples {n} is large and may take several seconds. 1000 is the industry standard and usually sufficient.\n',
   },
 };

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -13,7 +13,13 @@ export type CliMessageKey =
   | 'cli.common.lang_invalid_silent'
   | 'cli.common.help_hint'
   | 'cli.common.unknown_domain'
-  | 'cli.common.unknown_bench_command';
+  | 'cli.common.unknown_bench_command'
+  // bench init
+  | 'cli.init.scaffolded'
+  | 'cli.init.next_steps_title'
+  | 'cli.init.next_step_edit_samples'
+  | 'cli.init.next_step_edit_skills'
+  | 'cli.init.next_step_run';
 
 export interface CliMessage {
   zh: string;
@@ -36,5 +42,25 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
   'cli.common.unknown_bench_command': {
     zh: "未知 bench 子命令: {command} (运行 'omk --help' 查看可用列表)",
     en: "Unknown bench command: {command} (run 'omk --help' to see all commands)",
+  },
+  'cli.init.scaffolded': {
+    zh: '已初始化测评项目: {dir}',
+    en: 'Eval project scaffolded at: {dir}',
+  },
+  'cli.init.next_steps_title': {
+    zh: '下一步:',
+    en: 'Next steps:',
+  },
+  'cli.init.next_step_edit_samples': {
+    zh: '  1. 编辑 eval-samples.json 添加你的测试样本',
+    en: '  1. Edit eval-samples.json to add your test cases',
+  },
+  'cli.init.next_step_edit_skills': {
+    zh: '  2. 编辑 skills/v1.md 和 skills/v2.md 写入 skill 不同版本',
+    en: '  2. Edit skills/v1.md and skills/v2.md with your skill versions',
+  },
+  'cli.init.next_step_run': {
+    zh: '  3. 运行: omk bench run --control v1 --treatment v2',
+    en: '  3. Run: omk bench run --control v1 --treatment v2',
   },
 };

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -4,8 +4,48 @@
  * 命名约定: `cli.<command>.<event>` 或 `cli.common.<event>`。
  * 占位符用 `{name}` 形式,在 tCli(params) 处替换。
  *
- * 新增 key 时**两边必须同时加**,Record 类型会强制,test/cli-i18n.test.ts
- * 还会做 runtime 校验防止 zh/en 漏写。
+ * ============================================================================
+ * 翻译守则 (受 cc-viewer i18n 方案启发)
+ * ============================================================================
+ *
+ * 1. **彻底本地化, 不接受中英混搭**
+ *    "中文用户读到的中文"和"英文用户读到的英文"必须是各自语言里自然的表达,
+ *    不能机械翻译, 不能在中文里塞英文短语解释术语。如果某个英文短语没有
+ *    自然的中文译法, 重新组织句子结构, 而不是混着写。
+ *
+ * 2. **保留原文的白名单 (产品术语 / 命令 / 文件名)**
+ *    以下 token 在两种语言里都保留原文, 不翻译:
+ *    - 产品名: omk, oh-my-knowledge, Claude, npm
+ *    - 子命令空间和命令名: bench, analyze, run, report, init, evolve, gold,
+ *      diff, ci, gen-samples, debias-validate, saturation, verdict,
+ *      diagnose, failures
+ *    - omk 核心业务术语: skill, variant, sample, judge, executor (出现在产品
+ *      UI 里时首字母可大写如 "Skill 评测", 描述句中保持小写)
+ *    - 技术参数: --lang, --control, --treatment, --bootstrap, --judge-repeat,
+ *      OMK_LANG, JUDGE_PROMPT_VERSION_*
+ *    - 文件名 / 路径: eval-samples.json, skills/v1.md, ~/.oh-my-knowledge/...
+ *    - 数学概念缩写: CI, α, RAG (其译法可在配套描述里说明, 但术语本身留原文)
+ *
+ * 3. **必须翻译的内容**
+ *    动作 (run / edit / scaffold / generate), 状态 (success / failed /
+ *    invalid), 引导文案 (next steps / try this / see also), 解释性描述。
+ *
+ * 4. **不要机械直译**
+ *    "Next steps:" 译 "下一步:" 而不是 "下一步骤:"。
+ *    "Run: ..." 译 "运行: ..." 而不是 "跑: ..."。
+ *    选用 omk 项目长期使用的中文措辞 (LLM judge 译"评委" 不译"判官", 见
+ *    feedback_ui_translation.md)。
+ *
+ * 5. **新增 key 流程**
+ *    a. 加到 CliMessageKey union 类型里
+ *    b. 在 CLI_DICT 里同时给出 zh / en (Record 类型强制 zh/en 双写, 漏写
+ *       tsc 直接报错)
+ *    c. 自查: 中文里有没有非白名单的英文? 英文里有没有中文?
+ *    d. 自查: 措辞自然度 — 把中文版念出来, 像不像中文项目的命令行输出?
+ *    e. test/cli-i18n.test.ts 会跑 runtime parity 检查
+ *
+ * 未来扩 Lang (zh-TW / ja / ko ...): 改 src/types/shared.ts 的 Lang union,
+ * Record 类型自动强制每 key 加新语言版本。
  */
 
 export type CliMessageKey =
@@ -28,19 +68,19 @@ export interface CliMessage {
 
 export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
   'cli.common.lang_invalid_silent': {
-    zh: '无效的语言: {value} (仅支持 zh|en, 已退回默认 zh)',
-    en: 'Invalid language: {value} (supported: zh|en, falling back to default zh)',
+    zh: '无效的语言代码: {value} (仅支持 zh / en, 已使用默认 zh)',
+    en: 'Invalid language code: {value} (supported: zh / en, using default zh)',
   },
   'cli.common.help_hint': {
     zh: "运行 'omk --help' 查看用法",
     en: "Run 'omk --help' to see usage",
   },
   'cli.common.unknown_domain': {
-    zh: "未知模块: {domain} (请用 'omk bench <command>' 或 'omk analyze <dir>')",
+    zh: "未知顶层命令: {domain} (请用 'omk bench <command>' 或 'omk analyze <dir>')",
     en: "Unknown domain: {domain} (use 'omk bench <command>' or 'omk analyze <dir>')",
   },
   'cli.common.unknown_bench_command': {
-    zh: "未知 bench 子命令: {command} (运行 'omk --help' 查看可用列表)",
+    zh: "未知子命令: bench {command} (运行 'omk --help' 查看可用列表)",
     en: "Unknown bench command: {command} (run 'omk --help' to see all commands)",
   },
   'cli.init.scaffolded': {
@@ -52,11 +92,11 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
     en: 'Next steps:',
   },
   'cli.init.next_step_edit_samples': {
-    zh: '  1. 编辑 eval-samples.json 添加你的测试样本',
+    zh: '  1. 编辑 eval-samples.json, 加入你要测的测评用例',
     en: '  1. Edit eval-samples.json to add your test cases',
   },
   'cli.init.next_step_edit_skills': {
-    zh: '  2. 编辑 skills/v1.md 和 skills/v2.md 写入 skill 不同版本',
+    zh: '  2. 编辑 skills/v1.md 和 skills/v2.md, 为两个 skill 版本填入实际内容',
     en: '  2. Edit skills/v1.md and skills/v2.md with your skill versions',
   },
   'cli.init.next_step_run': {

--- a/src/cli/i18n.ts
+++ b/src/cli/i18n.ts
@@ -7,6 +7,19 @@ const DEFAULT_LANG: CliLang = 'zh';
 const SUPPORTED: ReadonlySet<string> = new Set(['zh', 'en']);
 
 /**
+ * main() 在子命令 parseArgs 之前就需要拿到 lang(用于打印 unknown 提示)。
+ * 早期 scan argv,支持 `--lang en` 和 `--lang=en` 两种形式。
+ */
+export function parseLangFromArgv(argv: readonly string[]): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--lang' && i + 1 < argv.length) return argv[i + 1];
+    if (a && a.startsWith('--lang=')) return a.slice('--lang='.length);
+  }
+  return undefined;
+}
+
+/**
  * 优先级: --lang flag > OMK_LANG env > 默认 zh。
  * 不识别的值静默退回默认,避免在解析阶段抛错让用户卡住。
  */

--- a/src/cli/i18n.ts
+++ b/src/cli/i18n.ts
@@ -20,6 +20,14 @@ export function parseLangFromArgv(argv: readonly string[]): string | undefined {
 }
 
 /**
+ * handler 内一行拿到 lang。handler 收到的 argv 已被 main 切掉前 N 项,
+ * 但 --lang 选项位置无关, scan 即可。
+ */
+export function langFromArgv(argv: readonly string[]): CliLang {
+  return getCliLang(parseLangFromArgv(argv));
+}
+
+/**
  * 优先级: --lang flag > OMK_LANG env > 默认 zh。
  * 不识别的值静默退回默认,避免在解析阶段抛错让用户卡住。
  */

--- a/src/cli/i18n.ts
+++ b/src/cli/i18n.ts
@@ -1,0 +1,39 @@
+import type { Lang } from '../types/shared.js';
+import { CLI_DICT, type CliMessageKey } from './i18n-dict.js';
+
+export type CliLang = Lang;
+
+const DEFAULT_LANG: CliLang = 'zh';
+const SUPPORTED: ReadonlySet<string> = new Set(['zh', 'en']);
+
+/**
+ * 优先级: --lang flag > OMK_LANG env > 默认 zh。
+ * 不识别的值静默退回默认,避免在解析阶段抛错让用户卡住。
+ */
+export function getCliLang(flagValue?: string): CliLang {
+  const candidates = [flagValue, process.env.OMK_LANG];
+  for (const c of candidates) {
+    if (c && SUPPORTED.has(c)) return c as CliLang;
+  }
+  return DEFAULT_LANG;
+}
+
+/**
+ * 缺 key 时返回 key 本身,便于在 dev / CI 中肉眼/脚本发现遗漏。
+ * params 用 {name} 占位符做 string 替换。
+ */
+export function tCli(
+  key: CliMessageKey,
+  lang: CliLang = DEFAULT_LANG,
+  params?: Record<string, string | number>,
+): string {
+  const entry = CLI_DICT[key];
+  if (!entry) return key;
+  let text = entry[lang] ?? entry[DEFAULT_LANG] ?? key;
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      text = text.replaceAll(`{${k}}`, String(v));
+    }
+  }
+  return text;
+}

--- a/src/eval-core/evaluation-execution.ts
+++ b/src/eval-core/evaluation-execution.ts
@@ -298,6 +298,6 @@ export async function preflight(executor: ExecutorFn, model: string, timeoutMs: 
     timeoutMs,
   });
   if (!result.ok) {
-    throw new Error(`预检失败 [${model}]: ${result.error}`);
+    throw new Error(`preflight failed [${model}]: ${result.error}`);
   }
 }

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -210,10 +210,10 @@ export async function runEvaluation({
       }
       if (onProgress) {
         const count = Object.values(existingResults).reduce((sum, v) => sum + Object.values(v).filter((r) => r.ok).length, 0);
-        process.stderr.write(`\n📂 从报告 ${resume} 恢复了 ${count} 个已完成结果\n`);
+        process.stderr.write(`\n📂 resumed ${count} completed results from report ${resume}\n`);
       }
     } else {
-      process.stderr.write(`\n⚠️  报告 ${resume} 未找到，将从头执行\n`);
+      process.stderr.write(`\n⚠️  report ${resume} not found, starting from scratch\n`);
     }
   }
 
@@ -499,7 +499,7 @@ export async function runEachEvaluation({
 }: RunEachEvaluationOptions): Promise<{ report: Report | DryRunEachReport; filePath: string | null }> {
   const skillEntries = discoverEachSkills(resolve(skillDir));
   if (skillEntries.length === 0) {
-    throw new Error(`未发现带配对 eval-samples 的 skill：${skillDir}`);
+    throw new Error(`no skill with paired eval-samples found in: ${skillDir}`);
   }
 
   if (dryRun) {

--- a/src/executors/anthropic-api.ts
+++ b/src/executors/anthropic-api.ts
@@ -3,7 +3,7 @@ import { AnthropicResponse, asErrorLike, DEFAULT_TIMEOUT_MS, errorMessage } from
 
 export async function anthropicApiExecutor({ model, system, prompt, timeoutMs = DEFAULT_TIMEOUT_MS }: ExecutorInput): Promise<ExecResult> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error('ANTHROPIC_API_KEY 环境变量未设置');
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY environment variable is not set');
 
   const baseUrl = process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com';
   const reqBody: {

--- a/src/executors/openai-api.ts
+++ b/src/executors/openai-api.ts
@@ -3,7 +3,7 @@ import { asErrorLike, DEFAULT_TIMEOUT_MS, errorMessage, OpenAiResponse } from '.
 
 export async function openAiApiExecutor({ model, system, prompt, timeoutMs = DEFAULT_TIMEOUT_MS }: ExecutorInput): Promise<ExecResult> {
   const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) throw new Error('OPENAI_API_KEY 环境变量未设置');
+  if (!apiKey) throw new Error('OPENAI_API_KEY environment variable is not set');
 
   const baseUrl = process.env.OPENAI_BASE_URL || 'https://api.openai.com';
   const messages: Array<{ role: string; content: string }> = [];

--- a/src/grading/gold-cli.ts
+++ b/src/grading/gold-cli.ts
@@ -181,7 +181,7 @@ export function initGoldDataset(targetDir: string, options: { annotator?: string
   if (existsSync(abs)) {
     const present = readdirSync(abs).filter((f) => /\.ya?ml$/.test(f));
     if (present.length > 0) {
-      throw new Error(`目标目录已存在 YAML 文件 (${present.join(', ')})，避免覆盖请换目录`);
+      throw new Error(`target directory already contains YAML files (${present.join(', ')}); use a different directory to avoid overwriting`);
     }
   } else {
     mkdirSync(abs, { recursive: true });

--- a/src/inputs/eval-config.ts
+++ b/src/inputs/eval-config.ts
@@ -17,7 +17,7 @@ const VALID_ROLES: readonly ExperimentRole[] = ['control', 'treatment'];
 export function loadEvalConfig(configPath: string): EvalConfig {
   const absPath = resolve(configPath);
   if (!existsSync(absPath)) {
-    throw new Error(`--config 指定的文件不存在: ${absPath}`);
+    throw new Error(`--config file does not exist: ${absPath}`);
   }
   const raw = readFileSync(absPath, 'utf-8');
   const isJson = absPath.endsWith('.json');
@@ -41,15 +41,15 @@ export function configVariantsToSpecs(variants: EvalConfigVariant[]): VariantSpe
 
 function validateEvalConfig(parsed: unknown, configPath: string): EvalConfig {
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-    throw new Error(`${configPath}: 顶层必须是对象`);
+    throw new Error(`${configPath}: top level must be an object`);
   }
   const obj = parsed as Record<string, unknown>;
 
   if (typeof obj.samples !== 'string' || !obj.samples) {
-    throw new Error(`${configPath}: samples 字段必填，需为字符串`);
+    throw new Error(`${configPath}: 'samples' is required and must be a string`);
   }
   if (!Array.isArray(obj.variants) || obj.variants.length === 0) {
-    throw new Error(`${configPath}: variants 字段必填，需为非空数组`);
+    throw new Error(`${configPath}: 'variants' is required and must be a non-empty array`);
   }
 
   const variants: EvalConfigVariant[] = [];
@@ -58,25 +58,25 @@ function validateEvalConfig(parsed: unknown, configPath: string): EvalConfig {
 
   for (const [i, raw] of (obj.variants as unknown[]).entries()) {
     if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
-      throw new Error(`${configPath}: variants[${i}] 必须是对象`);
+      throw new Error(`${configPath}: variants[${i}] must be an object`);
     }
     const v = raw as Record<string, unknown>;
     if (typeof v.name !== 'string' || !v.name) {
-      throw new Error(`${configPath}: variants[${i}].name 必填，需为字符串`);
+      throw new Error(`${configPath}: variants[${i}].name is required and must be a string`);
     }
     if (typeof v.role !== 'string' || !VALID_ROLES.includes(v.role as ExperimentRole)) {
       throw new Error(
-        `${configPath}: variants[${i}].role 必须是 'control' 或 'treatment'（当前：${JSON.stringify(v.role)}）`,
+        `${configPath}: variants[${i}].role must be 'control' or 'treatment' (got: ${JSON.stringify(v.role)})`,
       );
     }
     if (typeof v.artifact !== 'string' || !v.artifact) {
-      throw new Error(`${configPath}: variants[${i}].artifact 必填，需为字符串`);
+      throw new Error(`${configPath}: variants[${i}].artifact is required and must be a string`);
     }
     if (v.cwd !== undefined && typeof v.cwd !== 'string') {
-      throw new Error(`${configPath}: variants[${i}].cwd 必须是字符串`);
+      throw new Error(`${configPath}: variants[${i}].cwd must be a string`);
     }
     if (seen.has(v.name)) {
-      throw new Error(`${configPath}: variants[${i}].name "${v.name}" 重复`);
+      throw new Error(`${configPath}: variants[${i}].name "${v.name}" is duplicated`);
     }
     seen.add(v.name);
     hasAnyRole = true;
@@ -89,32 +89,32 @@ function validateEvalConfig(parsed: unknown, configPath: string): EvalConfig {
   }
 
   if (!hasAnyRole) {
-    throw new Error(`${configPath}: variants 里至少要有一个 control 或 treatment`);
+    throw new Error(`${configPath}: variants must contain at least one control or treatment entry`);
   }
 
   const assertStringOpt = (key: string): void => {
     if (obj[key] !== undefined && typeof obj[key] !== 'string') {
-      throw new Error(`${configPath}: ${key} 必须是字符串`);
+      throw new Error(`${configPath}: ${key} must be a string`);
     }
   };
   const assertNumberOpt = (key: string): void => {
     if (obj[key] !== undefined && typeof obj[key] !== 'number') {
-      throw new Error(`${configPath}: ${key} 必须是数字`);
+      throw new Error(`${configPath}: ${key} must be a number`);
     }
   };
   const assertBoolOpt = (key: string): void => {
     if (obj[key] !== undefined && typeof obj[key] !== 'boolean') {
-      throw new Error(`${configPath}: ${key} 必须是布尔值`);
+      throw new Error(`${configPath}: ${key} must be a boolean`);
     }
   };
 
   assertStringOpt('executor');
   assertStringOpt('model');
   if (obj.judgeModel !== undefined && obj.judgeModel !== null && typeof obj.judgeModel !== 'string') {
-    throw new Error(`${configPath}: judgeModel 必须是字符串或 null`);
+    throw new Error(`${configPath}: judgeModel must be a string or null`);
   }
   if (obj.judgeExecutor !== undefined && obj.judgeExecutor !== null && typeof obj.judgeExecutor !== 'string') {
-    throw new Error(`${configPath}: judgeExecutor 必须是字符串或 null`);
+    throw new Error(`${configPath}: judgeExecutor must be a string or null`);
   }
   assertNumberOpt('concurrency');
   assertNumberOpt('timeoutMs');
@@ -126,12 +126,12 @@ function validateEvalConfig(parsed: unknown, configPath: string): EvalConfig {
   let budget: import('../types.js').EvalBudget | undefined;
   if (obj.budget !== undefined) {
     if (typeof obj.budget !== 'object' || obj.budget === null || Array.isArray(obj.budget)) {
-      throw new Error(`${configPath}: budget 必须是对象`);
+      throw new Error(`${configPath}: budget must be an object`);
     }
     const b = obj.budget as Record<string, unknown>;
     for (const k of ['totalUSD', 'perSampleUSD', 'perSampleMs']) {
       if (b[k] !== undefined && (typeof b[k] !== 'number' || b[k] as number < 0)) {
-        throw new Error(`${configPath}: budget.${k} 必须是非负数字`);
+        throw new Error(`${configPath}: budget.${k} must be a non-negative number`);
       }
     }
     budget = {

--- a/src/inputs/load-samples.ts
+++ b/src/inputs/load-samples.ts
@@ -49,16 +49,16 @@ export function loadSamples(samplesPath: string): LoadSamplesResult {
     samples = wrapper.samples;
     requires = wrapper.requires;
   } else {
-    throw new Error(`无效的样本文件格式: ${samplesPath}（期望数组或包含 samples 字段的对象）`);
+    throw new Error(`invalid samples file shape: ${samplesPath} (expected an array or an object with a 'samples' field)`);
   }
 
   if (!Array.isArray(samples) || samples.length === 0) {
-    throw new Error(`无效的样本文件: ${samplesPath}`);
+    throw new Error(`invalid samples file: ${samplesPath}`);
   }
 
   for (const [i, sample] of samples.entries()) {
-    if (!sample.sample_id) throw new Error(`samples[${i}] 缺少必填字段: sample_id`);
-    if (!sample.prompt) throw new Error(`samples[${i}] (${sample.sample_id}) 缺少必填字段: prompt`);
+    if (!sample.sample_id) throw new Error(`samples[${i}] missing required field: sample_id`);
+    if (!sample.prompt) throw new Error(`samples[${i}] (${sample.sample_id}) missing required field: prompt`);
   }
 
   return { samples, requires };

--- a/src/inputs/mcp-resolver.ts
+++ b/src/inputs/mcp-resolver.ts
@@ -97,7 +97,7 @@ export function loadMcpConfig(configPath?: string): McpServers | null {
   try {
     raw = JSON.parse(readFileSync(filePath, 'utf-8'));
   } catch (err: unknown) {
-    process.stderr.write(`⚠ MCP 配置文件解析失败: ${filePath}\n  ${getErrorMessage(err)}\n`);
+    process.stderr.write(`⚠ failed to parse MCP config file: ${filePath}\n  ${getErrorMessage(err)}\n`);
     return null;
   }
 
@@ -189,7 +189,7 @@ export async function resolveMcpUrls(samples: Sample[], mcpServers: McpServers |
     }
   }
   if (failCount > 0) {
-    process.stderr.write(`\n⚠ ${failCount} 个 URL 通过 MCP 获取失败，将尝试 HTTP 回退\n\n`);
+    process.stderr.write(`\n⚠ ${failCount} URL(s) failed via MCP, will retry with HTTP fallback\n\n`);
   }
 
   // 5. Inline successful results into samples
@@ -205,7 +205,7 @@ export async function resolveMcpUrls(samples: Sample[], mcpServers: McpServers |
   }
 
   if (successCount > 0) {
-    process.stderr.write(`✓ MCP: 成功获取 ${successCount} 个 URL 的内容\n\n`);
+    process.stderr.write(`✓ MCP: fetched content for ${successCount} URL(s)\n\n`);
   }
 
   return resolved;
@@ -220,7 +220,7 @@ export async function stopAllServers(): Promise<void> {
   for (const [name, client] of activeClients) {
     promises.push(
       client.close().catch((err: unknown) => {
-        process.stderr.write(`⚠ MCP server "${name}" 关闭异常: ${getErrorMessage(err)}\n`);
+        process.stderr.write(`⚠ MCP server "${name}" failed to close cleanly: ${getErrorMessage(err)}\n`);
       }),
     );
   }

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -103,7 +103,7 @@ export function discoverEachSkills(skillDir: string): Array<{ name: string; skil
   }
 
   for (const name of warned) {
-    process.stderr.write(`⚠️  跳过 ${name}：未找到配对的 eval-samples\n`);
+    process.stderr.write(`⚠️  skipping ${name}: paired eval-samples not found\n`);
   }
 
   skills.sort((a, b) => a.name.localeCompare(b.name));
@@ -132,7 +132,7 @@ export function resolveArtifacts(skillDir: string, variants: string[]): Artifact
     const { name: variantName, cwd: variantCwd } = parseVariantCwd(rawVariant);
 
     if (variantName === 'baseline' && variantCwd) {
-      throw new Error('baseline 不能绑定 cwd。若要表达项目级 runtime context，请使用自定义标签，例如 project-env@/path/to/project');
+      throw new Error('baseline cannot be bound to a cwd. To express a project-level runtime context, use a custom label such as project-env@/path/to/project');
     }
 
     if (variantName === 'baseline') {
@@ -161,7 +161,7 @@ export function resolveArtifacts(skillDir: string, variants: string[]): Artifact
       const content = gitShowFile(ref, join(gitRelDir, `${name}.md`))
         || gitShowFile(ref, join(gitRelDir, name, 'SKILL.md'));
       if (!content) {
-        throw new Error(`skill 在 git ${ref} 中未找到: ${name}.md 或 ${name}/SKILL.md`);
+        throw new Error(`skill not found in git ${ref}: ${name}.md or ${name}/SKILL.md`);
       }
       artifacts.push({
         name: variantName,
@@ -178,7 +178,7 @@ export function resolveArtifacts(skillDir: string, variants: string[]): Artifact
     if (variantName.includes('/')) {
       const filePath = resolve(variantName);
       if (!existsSync(filePath)) {
-        throw new Error(`skill 文件未找到: ${filePath}`);
+        throw new Error(`skill file not found: ${filePath}`);
       }
       const content = readFileSync(filePath, 'utf-8').trim();
       artifacts.push({
@@ -226,7 +226,7 @@ export function resolveArtifacts(skillDir: string, variants: string[]): Artifact
         cwd: variantCwd,
       });
     } else {
-      throw new Error(`skill 未找到: ${mdPath} 或 ${dirSkillPath}`);
+      throw new Error(`skill not found: ${mdPath} or ${dirSkillPath}`);
     }
   }
 

--- a/src/inputs/url-fetcher.ts
+++ b/src/inputs/url-fetcher.ts
@@ -72,7 +72,7 @@ export async function resolveUrls(samples: Sample[], skipUrls?: Set<string>): Pr
   const fetched = new Map<string, FetchResult>(); // url -> { ok, content, error }
   const entries = [...urlMap.keys()];
 
-  process.stderr.write(`ℹ 检测到 ${entries.length} 个 URL，正在获取内容:\n`);
+  process.stderr.write(`ℹ detected ${entries.length} URL(s), fetching content:\n`);
   for (const url of entries) {
     process.stderr.write(`    - ${url}\n`);
   }
@@ -102,7 +102,7 @@ export async function resolveUrls(samples: Sample[], skipUrls?: Set<string>): Pr
 
   const failCount = [...fetched.values()].filter((r) => !r.ok).length;
   if (failCount > 0) {
-    process.stderr.write(`\n⚠ ${failCount} 个 URL 抓取失败，将使用原始 URL 继续评测\n\n`);
+    process.stderr.write(`\n⚠ ${failCount} URL(s) failed to fetch, falling back to raw URLs for evaluation\n\n`);
   }
 
   // 4. Inline fetched content into samples (only successful ones)

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -652,14 +652,14 @@ export function createReportServer({ port, reportsDir = DEFAULT_REPORTS_DIR, ana
         try {
           server = await boot(p);
         } catch {
-          throw new Error(`端口 ${p} 仍被占用，请手动关闭后重试：lsof -ti:${p} | xargs kill`);
+          throw new Error(`port ${p} is still in use; close it manually and retry: lsof -ti:${p} | xargs kill`);
         }
       } else {
         throw new Error(
-          `端口 ${p} 已被其他程序占用。\n` +
-          `  查看占用进程：lsof -i:${p}\n` +
-          `  释放端口：lsof -ti:${p} | xargs kill\n` +
-          `  或指定其他端口：omk bench report --port 8080`
+          `port ${p} is already in use by another process.\n` +
+          `  inspect: lsof -i:${p}\n` +
+          `  release: lsof -ti:${p} | xargs kill\n` +
+          `  or pick another port: omk bench report --port 8080`
         );
       }
     }

--- a/test/cli-i18n.test.ts
+++ b/test/cli-i18n.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { CLI_DICT } from '../src/cli/i18n-dict.js';
+import { tCli, getCliLang } from '../src/cli/i18n.js';
+
+describe('CLI i18n dictionary parity (zh ↔ en)', () => {
+  it('every key has both zh and en, neither empty', () => {
+    for (const [key, entry] of Object.entries(CLI_DICT)) {
+      assert.equal(typeof entry.zh, 'string', `${key}.zh must be string`);
+      assert.equal(typeof entry.en, 'string', `${key}.en must be string`);
+      assert.notEqual(entry.zh, '', `${key}.zh is empty`);
+      assert.notEqual(entry.en, '', `${key}.en is empty`);
+    }
+  });
+});
+
+describe('tCli()', () => {
+  it('returns zh value by default when lang omitted', () => {
+    assert.equal(tCli('cli.common.help_hint'), CLI_DICT['cli.common.help_hint'].zh);
+  });
+
+  it('returns en value when lang=en', () => {
+    assert.equal(tCli('cli.common.help_hint', 'en'), CLI_DICT['cli.common.help_hint'].en);
+  });
+
+  it('substitutes {param} placeholders', () => {
+    const out = tCli('cli.common.unknown_command', 'en', { command: 'foo' });
+    assert.match(out, /foo/);
+    assert.doesNotMatch(out, /\{command\}/);
+  });
+
+  it('replaces all occurrences of a placeholder', () => {
+    const out = tCli('cli.common.lang_invalid_silent', 'zh', { value: 'fr' });
+    assert.match(out, /fr/);
+    assert.doesNotMatch(out, /\{value\}/);
+  });
+});
+
+describe('getCliLang()', () => {
+  let originalEnv: string | undefined;
+  beforeEach(() => {
+    originalEnv = process.env.OMK_LANG;
+    delete process.env.OMK_LANG;
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.OMK_LANG;
+    else process.env.OMK_LANG = originalEnv;
+  });
+
+  it('defaults to zh when no flag and no env', () => {
+    assert.equal(getCliLang(), 'zh');
+  });
+
+  it('reads OMK_LANG=en from env', () => {
+    process.env.OMK_LANG = 'en';
+    assert.equal(getCliLang(), 'en');
+  });
+
+  it('flag value beats env', () => {
+    process.env.OMK_LANG = 'en';
+    assert.equal(getCliLang('zh'), 'zh');
+  });
+
+  it('silently falls back to zh on unknown value', () => {
+    assert.equal(getCliLang('fr'), 'zh');
+    process.env.OMK_LANG = 'jp';
+    assert.equal(getCliLang(), 'zh');
+  });
+
+  it('empty string flag is ignored (falls through to env / default)', () => {
+    process.env.OMK_LANG = 'en';
+    assert.equal(getCliLang(''), 'en');
+  });
+});

--- a/test/cli-i18n.test.ts
+++ b/test/cli-i18n.test.ts
@@ -24,7 +24,7 @@ describe('tCli()', () => {
   });
 
   it('substitutes {param} placeholders', () => {
-    const out = tCli('cli.common.unknown_command', 'en', { command: 'foo' });
+    const out = tCli('cli.common.unknown_bench_command', 'en', { command: 'foo' });
     assert.match(out, /foo/);
     assert.doesNotMatch(out, /\{command\}/);
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -24,9 +24,9 @@ describe('CLI', () => {
     assert.ok(stdout.includes('oh-my-knowledge'));
   });
 
-  it('unknown domain exits with error', async () => {
+  it('unknown domain exits with error (--lang en)', async () => {
     await assert.rejects(
-      () => execFileAsync('node', [CLI, 'unknown']),
+      () => execFileAsync('node', [CLI, 'unknown', '--lang', 'en']),
       (err: unknown) => {
         assert.ok((err as { stderr: string }).stderr.includes('Unknown domain'));
         return true;
@@ -34,11 +34,21 @@ describe('CLI', () => {
     );
   });
 
-  it('unknown bench command exits with error', async () => {
+  it('unknown domain in zh (default) prints 中文', async () => {
     await assert.rejects(
-      () => execFileAsync('node', [CLI, 'bench', 'unknown']),
+      () => execFileAsync('node', [CLI, 'unknown']),
       (err: unknown) => {
-        assert.ok((err as { stderr: string }).stderr.includes('Unknown command'));
+        assert.ok((err as { stderr: string }).stderr.includes('未知模块'));
+        return true;
+      },
+    );
+  });
+
+  it('unknown bench command exits with error (--lang en)', async () => {
+    await assert.rejects(
+      () => execFileAsync('node', [CLI, 'bench', 'unknown', '--lang', 'en']),
+      (err: unknown) => {
+        assert.ok((err as { stderr: string }).stderr.includes('Unknown bench command'));
         return true;
       },
     );

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -38,7 +38,7 @@ describe('CLI', () => {
     await assert.rejects(
       () => execFileAsync('node', [CLI, 'unknown']),
       (err: unknown) => {
-        assert.ok((err as { stderr: string }).stderr.includes('未知模块'));
+        assert.ok((err as { stderr: string }).stderr.includes('未知顶层命令'));
         return true;
       },
     );

--- a/test/eval-config.test.ts
+++ b/test/eval-config.test.ts
@@ -65,7 +65,7 @@ variants:
     role: control
     artifact: baseline
       `.trim());
-      assert.throws(() => loadEvalConfig(path), /samples 字段必填/);
+      assert.throws(() => loadEvalConfig(path), /'samples' is required/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -78,7 +78,7 @@ variants:
 samples: ./samples.json
 variants: []
       `.trim());
-      assert.throws(() => loadEvalConfig(path), /variants 字段必填/);
+      assert.throws(() => loadEvalConfig(path), /'variants' is required/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -94,7 +94,7 @@ variants:
     role: baseline
     artifact: ./v1.md
       `.trim());
-      assert.throws(() => loadEvalConfig(path), /role 必须是 'control' 或 'treatment'/);
+      assert.throws(() => loadEvalConfig(path), /role must be 'control' or 'treatment'/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -113,7 +113,7 @@ variants:
     role: treatment
     artifact: ./v1.md
       `.trim());
-      assert.throws(() => loadEvalConfig(path), /"v1" 重复/);
+      assert.throws(() => loadEvalConfig(path), /"v1" is duplicated/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -122,7 +122,7 @@ variants:
   it('throws when --config file does not exist', () => {
     assert.throws(
       () => loadEvalConfig('/tmp/omk-nonexistent-config-xyz.yaml'),
-      /--config 指定的文件不存在/,
+      /--config file does not exist/,
     );
   });
 
@@ -269,7 +269,7 @@ samples: ./s.json
 ${minimalVariants}
 budget: 5
 `.trim());
-      assert.throws(() => loadEvalConfig(path), /budget 必须是对象/);
+      assert.throws(() => loadEvalConfig(path), /budget must be an object/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/grading/gold-cli.test.ts
+++ b/test/grading/gold-cli.test.ts
@@ -148,7 +148,7 @@ describe('initGoldDataset', () => {
 
   it('refuses to clobber existing yaml files', () => {
     writeYaml('keep', 'existing.yaml', 'foo: bar');
-    assert.throws(() => initGoldDataset(join(dir, 'keep')), /已存在/);
+    assert.throws(() => initGoldDataset(join(dir, 'keep')), /already contains YAML files/);
   });
 });
 

--- a/test/inputs/load-samples.test.ts
+++ b/test/inputs/load-samples.test.ts
@@ -44,27 +44,27 @@ describe('loadSamples', () => {
     const p = tmp('empty.json');
     cleanups.push(p);
     writeFileSync(p, '[]');
-    assert.throws(() => loadSamples(p), /无效的样本文件/);
+    assert.throws(() => loadSamples(p), /invalid samples file/);
   });
 
   it('无效内容抛出异常', () => {
     const p = tmp('invalid.json');
     cleanups.push(p);
     writeFileSync(p, '"not an array"');
-    assert.throws(() => loadSamples(p), /无效的样本文件/);
+    assert.throws(() => loadSamples(p), /invalid samples file/);
   });
 
   it('缺少 sample_id 抛出异常', () => {
     const p = tmp('no-id.json');
     cleanups.push(p);
     writeFileSync(p, JSON.stringify([{ prompt: 'hello' }]));
-    assert.throws(() => loadSamples(p), /缺少必填字段: sample_id/);
+    assert.throws(() => loadSamples(p), /missing required field: sample_id/);
   });
 
   it('缺少 prompt 抛出异常', () => {
     const p = tmp('no-prompt.json');
     cleanups.push(p);
     writeFileSync(p, JSON.stringify([{ sample_id: 'x' }]));
-    assert.throws(() => loadSamples(p), /缺少必填字段: prompt/);
+    assert.throws(() => loadSamples(p), /missing required field: prompt/);
   });
 });

--- a/test/inputs/skill-loader.test.ts
+++ b/test/inputs/skill-loader.test.ts
@@ -37,7 +37,7 @@ describe('resolveArtifacts', () => {
   it('baseline@cwd 不再受支持', () => {
     assert.throws(
       () => resolveArtifacts(SKILL_DIR, ['baseline@/tmp/project-a']),
-      /baseline 不能绑定 cwd/,
+      /baseline cannot be bound to a cwd/,
     );
   });
 

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -191,7 +191,7 @@ describe('runEvaluation', () => {
         skillDir: SKILL_DIR,
         variantSpecs: asSpecs(['v1', 'v99_nonexistent']),
       }),
-      /skill 未找到/,
+      /skill not found/,
     );
   });
 
@@ -248,7 +248,7 @@ describe('runEvaluation', () => {
           skillDir: SKILL_DIR,
           variantSpecs: asSpecs(['v1', 'v2']),
         }),
-        /缺少必填字段: sample_id/,
+        /missing required field: sample_id/,
       );
     } finally {
       try { unlinkSync(tmpSamples); } catch { /* ignore */ }
@@ -413,7 +413,7 @@ describe('git: variant', () => {
   it('loadSkills: git:name throws on missing skill', () => {
     assert.throws(
       () => loadSkills(SKILL_DIR, ['git:nonexistent']),
-      /skill 在 git HEAD 中未找到/,
+      /skill not found in git HEAD/,
     );
   });
 
@@ -455,7 +455,7 @@ describe('file path variant', () => {
   it('loadSkills: throws on missing file path', () => {
     assert.throws(
       () => loadSkills(SKILL_DIR, ['/nonexistent/skill.md']),
-      /skill 文件未找到/,
+      /skill file not found/,
     );
   });
 


### PR DESCRIPTION
## Summary

Patch release v0.20.2,内容已在 develop 落定,本 PR 走 develop → main 触发发版。

主要内容(完整 release notes 见 [CHANGELOG.md](./CHANGELOG.md#0202---2026-04-27)):

- **CLI 双语 i18n**:`--lang` flag + `OMK_LANG` env,优先级 flag > env > 默认 zh。覆盖 HELP / 所有子命令 help / 实时进度反馈 / 参数校验 / 错误兜底,无中英混搭。i18n 基础设施(`tCli` / `getCliLang` / `makeOnProgress` factory)+ 字典(~80 key zh/en 双写)+ runtime parity 测试。
- **lib 层 user-facing 文本统一英文**(39 处):按"对客层 i18n / 内部层英文"分层,zh 用户看到的最终输出形如"错误: skill file not found: /path"——前缀本地化,内部细节英文。
- **publish.yml 自动从 CHANGELOG 抽 release notes**:push tag 后自动创建 GitHub Release,维护者不再手动写 release notes。
- **CLAUDE.md 协作者入场文档精简**(61 → 39 行)。

测量学不变量未受影响:`src/grading/judge.ts` byte-frozen,`v2-cot=fdc81b19c721` / `v3-cot-length=629bf3b8c41d` 两个 hash 仍冻结。

## Release checklist

- [x] `package.json` version 0.20.1 → 0.20.2
- [x] CHANGELOG `[Unreleased]` → `[0.20.2] - 2026-04-27`,顶部新加空 `[Unreleased]`
- [x] `yarn lint && yarn build && yarn test --run` 全绿(697 测试)
- [x] judge hash 字节级冻结测试仍通过
- [ ] **merge 后**:fast-forward `develop = main`(`git checkout develop && git merge --ff-only origin/main && git push`)
- [ ] **fast-forward 后**:打 tag + push(`git tag v0.20.2 && git push origin v0.20.2`)→ publish.yml 自动跑 lint + build + test + npm publish + GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)