### PR TITLE
fix(ci): publish.yml release 创建改用 softprops/action-gh-release, 修 yaml 解析失败

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,29 +42,23 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    - name: Create GitHub Release
-      env:
-        GH_TOKEN: ${{ github.token }}
+    # 从 CHANGELOG.md 抽 ## [VERSION] section 到临时文件, 喂给下一步的 action 做 release body。
+    # sed 去掉单独行 `---` (CHANGELOG sections 之间的分隔符, 在 release notes 里没意义)。
+    - name: Extract CHANGELOG section
       run: |
-        TAG="${GITHUB_REF#refs/tags/}"
-        VERSION="${TAG#v}"
-        # 从 CHANGELOG.md 抽 ## [VERSION] section(到下一个 ## [ 之前)
-        # sed 去掉所有 `---` 单独行: CHANGELOG sections 之间用 --- 分隔, 抽出的
-        # section 末尾会带 trailing ---, 去掉避免和下面 footer 的 --- 撞两个.
-        # CHANGELOG section 内容本身不使用 --- 单独行做分隔, 此清理安全.
-        NOTES=$(awk "/^## \\[${VERSION}\\]/{flag=1; next} /^## \\[/{if(flag){exit}} flag" CHANGELOG.md | sed '/^---$/d')
-        if [ -z "$NOTES" ]; then
-          echo "::warning::no CHANGELOG section for v${VERSION}; falling back to auto-generated notes"
-          gh release create "$TAG" --title "$TAG" --generate-notes --verify-tag
-        else
-          # 找 prev tag (按创建时间排序, 当前 tag 的下一行就是上一个 release tag)
-          PREV_TAG=$(git tag --sort=-creatordate | grep -A 1 "^${TAG}$" | tail -1)
-          if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$TAG" ]; then
-            NOTES="${NOTES}
-
----
-
-**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
-          fi
-          gh release create "$TAG" --title "$TAG" --notes "$NOTES" --verify-tag
+        VERSION="${GITHUB_REF#refs/tags/v}"
+        awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{if(flag){exit}} flag" CHANGELOG.md | sed '/^---$/d' > /tmp/release-notes.md
+        if [ ! -s /tmp/release-notes.md ]; then
+          echo "::warning::no CHANGELOG section for v${VERSION}; release will use auto-generated notes only"
         fi
+
+    # softprops/action-gh-release 是行业通用 GitHub Release action (~17k stars)。
+    # body_path 提供我们手写的 CHANGELOG section, generate_release_notes 让 GitHub
+    # 自动 append "What's Changed" + "Full Changelog: compare URL" footer。
+    # 不再自己用 `gh release create` + 手拼 footer (PR #6 那套写法因 yaml 多行
+    # 字符串里的 `**` 被误读为 alias 整个 yml 加载失败)。
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        body_path: /tmp/release-notes.md
+        generate_release_notes: true


### PR DESCRIPTION
## Summary

**Hotfix for v0.20.2 release**:`v0.20.2` tag 在 GitHub 上已建但 npm 上没发出 0.20.2 也没 GitHub Release —— 根因是 PR #6 引入的 publish.yml release 段写法 broken。

## 根因

PR #6 的 release notes 自动化代码用 yaml block scalar 嵌多行 shell 字符串拼 `**Full Changelog**` footer:

```yaml
            NOTES="${NOTES}

---

**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
```

`---` / `**Full Changelog**` 这几行缩进 0,< `run: |` block scalar 的 base_indent 8,yaml parser 认为 block 在前一行结束,后续行作为外部 yaml 解析,markdown 强调语法 `**` 命中 yaml alias 引用语法触发 `unidentified alias *Full`。**整个 publish.yml 加载失败**:

- 每次 push(任何 branch / tag)都触发 publish.yml **0s failure run**(从 PR #6 merge 起所有 main / develop / feature push 都有 noise,看 [`gh run list`](https://github.com/lizhiyao/oh-my-knowledge/actions))
- **`v0.20.2` tag push 完全没触发 workflow** → npm 上没 0.20.2,GitHub 上也没 v0.20.2 Release(虽然 v0.20.2 tag 现已被删除,准备 hotfix 后重 push)

## 修复:不只是补 yaml escaping,改用行业通用做法

即便 single-line printf 能修 alias bug,自己写 shell + 拼 footer 这套本身 fragile。改用社区标准:

- 新 step **Extract CHANGELOG section**:awk 抽 `## [VERSION]` section 到 `/tmp/release-notes.md`(单独 run step,无字符串拼接,无 yaml escaping 风险)
- 新 step **Create GitHub Release**:用 [`softprops/action-gh-release@v2`](https://github.com/softprops/action-gh-release)(~17k stars,行业通用),`body_path` 喂上一步的文件,`generate_release_notes: true` 让 GitHub API 自动 append "What's Changed" + "Full Changelog: compare URL" footer

不再自己写 `gh release create` + 手拼字符串。任何"footer 渲染"的细节由 action / GitHub API 负责。

## Side benefit

GitHub 自动生成的 "What's Changed" 是 PR-list 风格(具体 PR 链接 + 贡献者),跟 CHANGELOG section(Keep a Changelog 风格 Added / Changed / Fixed)**互补**:

- CHANGELOG 给"用户视角的变更说明"
- PR list 给"具体 PR 链接和贡献者"

两层信息都有,release notes 比之前更丰富。

## Test plan

- [x] 本地 `js-yaml` 验证 publish.yml YAML 解析 OK,9 个 step 顺序正确
- [x] CHANGELOG.md 当前已含 `## [0.20.2] - 2026-04-27` section,awk 抽得出来
- [ ] **merge 后**:fast-forward `develop = main`(merge commit,因为 develop 已领先 main #10/#11 + 自身 sync commit)
- [ ] **fast-forward 后**:重新打 `git tag v0.20.2 && git push origin v0.20.2` → publish.yml 这次正确加载、跑 lint+build+test+npm publish+softprops 创建 release

## 为什么 base main 而不是 develop

这是 release 的 hotfix 性质,目的是让 0.20.2 实际发出去(npm tag + GitHub Release)。CLAUDE.md "PR base 永远是 develop,除非是 release PR" 的例外条款,本 PR 是 release-flow 的 follow-up。

🤖 Generated with [Claude Code](https://claude.com/claude-code)