### PR TITLE
fix(skill,preflight): directory-skill cwd 默认锚到 SKILL.md 所在目录

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ## [Unreleased]
 
+### Fixed
+
+- **directory-skill 路径解析(`SKILL.md` 约定)**:符号链接或非 cwd 子目录里的 directory-skill(例如 `~/.claude/skills/foo/SKILL.md` 引用 `assets/references/...` 相对路径)在评测时:
+  1. preflight 把所有 artifact 的文件依赖 fold 进单一 cwd 检查,不同 skill 的 `assets/foo.md` 互相覆盖,会产生大量 false-positive missing。
+  2. 运行时 executor cwd = `process.cwd()` 而非 skill 根,LLM 的 Read 工具按 SKILL.md 的相对路径找文件全部失败,触发反复 retry / 模型放弃 / 长时间超时。
+
+  修复:`Artifact` 加 `skillRoot?: string`,在 `src/inputs/skill-loader.ts` 对 SKILL.md 约定的 directory-skill 设值(单文件 file-skill 维持 `process.cwd()` 语义不变)。`src/eval-core/task-planner.ts` `cwd` fallback 链改为 `artifact.cwd > artifact.skillRoot > sample.cwd > null`,`src/eval-core/dependency-checker.ts` `preflightDependencies` 文件依赖按 artifact 分桶解析(每个 skill 用各自 `skillRoot` 当 base)。WCC skill 端到端验证:bug-fix 前 41 个 false-positive missing + 1 个 sample 180s 超时;fix 后 preflight 通过、tool failure 减半、不再超时,wcc 平均分从 4.25 拉回 4.62,与 baseline diff CI 不再显著负向。
+
+- **依赖文件提取 regex 收紧**:之前 `FILE_PATH_REGEX` 把 SKILL.md 里"查看 `.d.ts` / `index.ts` 文件"这种**示例性扩展名提及 / bare 文件名提及**误识别为依赖。新增过滤:跳过以 `.` 开头的路径(扩展名讨论)和不含 `/` 的 bare 文件名(通用文件名几乎都是示例)。要声明 `package.json` / `README.md` 等 bare 文件作为真依赖请走显式 `requires:`。
+
 ---
 
 ## [0.20.2] - 2026-04-27

--- a/src/eval-core/dependency-checker.ts
+++ b/src/eval-core/dependency-checker.ts
@@ -83,6 +83,13 @@ function extractFromText(text: string): { tools: Set<string>; files: Set<string>
     if (path.startsWith('http') || path.startsWith('node_modules') || /^\d/.test(path)) continue;
     // Skip very short paths that are likely not real files
     if (path.length < 5) continue;
+    // Skip extension-mention patterns(`.d.ts` / `.tsx` 这种以点开头的"扩展名讨论"
+    // 不是真路径,SKILL.md 里"查看 .d.ts 文件"会被误识别)
+    if (path.startsWith('.')) continue;
+    // Skip bare filenames without a directory segment(`index.ts` / `package.json`
+    // 这种通用文件名几乎都是示例性提及,真依赖会带路径段。要声明 bare 文件
+    // 走显式 requires)
+    if (!path.includes('/')) continue;
     files.add(path);
   }
 
@@ -135,6 +142,36 @@ export function extractDependencies(
     files: files.size > 0 ? [...files] : undefined,
     env: env.size > 0 ? [...env] : undefined,
   };
+}
+
+/**
+ * Extract file dependencies per artifact, keyed by the base dir each file
+ * should be resolved against:
+ *   - artifact.skillRoot (directory-skill: SKILL.md 自带 assets,相对路径锚到 skill 根)
+ *   - artifact.cwd       (用户显式 @cwd)
+ *   - defaultCwd         (其他)
+ *
+ * 必须用 per-artifact 分桶,否则两个 skill 各自的 assets/foo.md 在单一 cwd 下
+ * 互相错位(WCC 评测里 41 个 false-positive 的根因)。
+ */
+export function extractFilesByBase(
+  artifacts: Artifact[],
+  defaultCwd: string,
+): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+  for (const artifact of artifacts) {
+    if (!artifact.content) continue;
+    const baseDir = artifact.skillRoot || artifact.cwd || defaultCwd;
+    const extracted = extractFromText(artifact.content);
+    if (extracted.files.size === 0) continue;
+    let bucket = map.get(baseDir);
+    if (!bucket) {
+      bucket = new Set<string>();
+      map.set(baseDir, bucket);
+    }
+    for (const f of extracted.files) bucket.add(f);
+  }
+  return map;
 }
 
 // ---------------------------------------------------------------------------
@@ -285,7 +322,32 @@ function runPreflightCommands(commands: string[], cwd: string, env?: NodeJS.Proc
 // ---------------------------------------------------------------------------
 
 /**
+ * Check files per base dir. Each (baseDir, [files]) bucket is resolved
+ * independently so directory-skill 自带 assets 的相对路径能锚到 skill 根。
+ */
+function checkFilesByBase(filesByBase: Map<string, Set<string>>): DependencyIssue[] {
+  const missing: DependencyIssue[] = [];
+  for (const [baseDir, files] of filesByBase) {
+    for (const file of files) {
+      const absPath = resolve(baseDir, file);
+      if (!existsSync(absPath)) {
+        missing.push({
+          category: 'file',
+          name: file,
+          hint: `文件不存在 (cwd: ${baseDir})`,
+        });
+      }
+    }
+  }
+  return missing;
+}
+
+/**
  * Run preflight dependency check: auto-extract + merge explicit requires + validate + run preflight commands.
+ *
+ * 文件路径走 per-artifact 分桶解析(每个 skill 用自己的 skillRoot / cwd 当 base),
+ * 工具 / env 变量 / preflight 命令仍全局合并。explicit requires.files 视为用户全局
+ * 声明,落到 defaultCwd。
  */
 export async function preflightDependencies(
   skillContents: string[],
@@ -296,12 +358,27 @@ export async function preflightDependencies(
 ): Promise<DependencyCheckResult> {
   const env = buildPreflightEnv(artifacts);
   const autoDetected = extractDependencies(skillContents, samples);
-  const merged = mergeRequirements(autoDetected, explicitRequires);
-  const result = await checkDependencies(merged, cwd, env);
 
-  // 合并 preflight 命令：来自 requires + 来自 artifact metadata
+  // 工具 / env / 显式 files / preflight 仍合并(语义不依赖 per-skill 路径锚)
+  const globalDeps: DependencyRequirements = {
+    tools: autoDetected.tools,
+    env: autoDetected.env,
+  };
+  const mergedGlobal = mergeRequirements(globalDeps, explicitRequires);
+  // explicit requires.files 视为用户全局声明,继续锚到 defaultCwd
+  const result = await checkDependencies(mergedGlobal, cwd, env);
+
+  // 自动检出的文件依赖按 artifact 分桶,每个 skill 用自己的 base 验证
+  if (artifacts && artifacts.length > 0) {
+    const filesByBase = extractFilesByBase(artifacts, cwd);
+    const fileIssues = checkFilesByBase(filesByBase);
+    result.missing.push(...fileIssues);
+    result.ok = result.ok && fileIssues.length === 0;
+  }
+
+  // 合并 preflight 命令:来自 requires + 来自 artifact metadata
   const artifactPreflight = artifacts ? extractPreflightFromArtifacts(artifacts) : [];
-  const allPreflight = [...new Set([...(merged.preflight || []), ...artifactPreflight])];
+  const allPreflight = [...new Set([...(mergedGlobal.preflight || []), ...artifactPreflight])];
 
   if (allPreflight.length > 0) {
     const preflightIssues = runPreflightCommands(allPreflight, cwd, env);

--- a/src/eval-core/task-planner.ts
+++ b/src/eval-core/task-planner.ts
@@ -28,7 +28,7 @@ export function buildTasksFromArtifacts(samples: Sample[], artifacts: Artifact[]
         assertions: sample.assertions || null,
         dimensions: sample.dimensions || null,
         artifactContent: artifact.content,
-        cwd: artifact.cwd || sample.cwd || null,
+        cwd: artifact.cwd || artifact.skillRoot || sample.cwd || null,
         _sample: sample,
       });
     }

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
-import { resolve, join, relative } from 'node:path';
+import { resolve, join, relative, dirname, basename } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import type { Artifact } from '../types/index.js';
 
@@ -181,6 +181,8 @@ export function resolveArtifacts(skillDir: string, variants: string[]): Artifact
         throw new Error(`skill file not found: ${filePath}`);
       }
       const content = readFileSync(filePath, 'utf-8').trim();
+      // 用户直接指 SKILL.md 等同 directory-skill 约定:cwd 默认锚到该目录
+      const isSkillMd = basename(filePath) === 'SKILL.md';
       artifacts.push({
         name: variantName,
         kind: 'skill',
@@ -188,6 +190,7 @@ export function resolveArtifacts(skillDir: string, variants: string[]): Artifact
         content,
         locator: filePath,
         cwd: variantCwd,
+        ...(isSkillMd && { skillRoot: dirname(filePath) }),
         metadata: buildMetadata(content),
       });
       continue;
@@ -196,6 +199,7 @@ export function resolveArtifacts(skillDir: string, variants: string[]): Artifact
     const mdPath = join(skillDir, `${variantName}.md`);
     const dirSkillPath = join(skillDir, variantName, 'SKILL.md');
     if (existsSync(mdPath)) {
+      // file-skill:单文件 .md,无 asset 概念,cwd 走默认(用户项目目录),不设 skillRoot
       const content = readFileSync(mdPath, 'utf-8').trim();
       artifacts.push({
         name: variantName,
@@ -207,6 +211,7 @@ export function resolveArtifacts(skillDir: string, variants: string[]): Artifact
         metadata: buildMetadata(content),
       });
     } else if (existsSync(dirSkillPath)) {
+      // directory-skill:SKILL.md 引相对路径 assets,cwd 默认锚到 skill 根目录
       const content = readFileSync(dirSkillPath, 'utf-8').trim();
       artifacts.push({
         name: variantName,
@@ -215,6 +220,7 @@ export function resolveArtifacts(skillDir: string, variants: string[]): Artifact
         content,
         locator: dirSkillPath,
         cwd: variantCwd,
+        skillRoot: dirname(dirSkillPath),
         metadata: buildMetadata(content),
       });
     } else if (variantCwd) {

--- a/src/types/eval.ts
+++ b/src/types/eval.ts
@@ -47,6 +47,10 @@ export interface Artifact {
   locator?: string;
   ref?: string;
   cwd?: string;
+  // SKILL.md 约定的 directory-skill 根目录(skill 自带 assets / 引相对路径时,
+  // 默认 cwd / preflight 路径解析的锚点)。只对 directory-skill 填,file-skill 留空。
+  // 优先级:用户显式 cwd(@/path) > skillRoot > sample.cwd > null。
+  skillRoot?: string;
   // run-time 属性:variant 在当次实验中扮演的角色(由 CLI --control/--treatment 或 eval.yaml 注入)
   // 不是 artifact 文件的固有属性;同一 artifact 在不同 run 可以扮演不同角色
   experimentRole?: ExperimentRole;

--- a/test/dependency-checker.test.ts
+++ b/test/dependency-checker.test.ts
@@ -1,15 +1,16 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { writeFileSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   extractDependencies,
+  extractFilesByBase,
   checkDependencies,
   preflightDependencies,
   formatDependencyErrors,
 } from '../src/eval-core/dependency-checker.js';
-import type { Sample } from '../src/types/index.js';
+import type { Artifact, Sample } from '../src/types/index.js';
 
 const tmp = () => join(tmpdir(), `omk-dep-test-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
 
@@ -170,6 +171,93 @@ describe('preflightDependencies', () => {
   it('无依赖时通过', async () => {
     const result = await preflightDependencies(['纯文本 skill'], [], process.cwd());
     assert.ok(result.ok);
+  });
+
+  it('directory-skill 的相对路径锚到 skillRoot,不会撞到全局 cwd', async () => {
+    // 模拟两个 directory-skill 各自在自己根目录下有 assets/foo.md
+    // bug-fix 之前:用单一 cwd 找 assets/foo.md,只能找到一个或全找不到
+    // bug-fix 之后:每个 skill 的引用按各自 skillRoot 解析
+    const root = tmp();
+    mkdirSync(join(root, 'skill-a'), { recursive: true });
+    mkdirSync(join(root, 'skill-b'), { recursive: true });
+    writeFileSync(join(root, 'skill-a', 'assets-a-only.md'), 'a');
+    writeFileSync(join(root, 'skill-b', 'assets-b-only.md'), 'b');
+
+    try {
+      const artifacts: Artifact[] = [
+        {
+          name: 'skill-a', kind: 'skill', source: 'variant-name',
+          content: '查看 assets-a-only.md',
+          locator: join(root, 'skill-a', 'SKILL.md'),
+          skillRoot: join(root, 'skill-a'),
+        },
+        {
+          name: 'skill-b', kind: 'skill', source: 'variant-name',
+          content: '查看 assets-b-only.md',
+          locator: join(root, 'skill-b', 'SKILL.md'),
+          skillRoot: join(root, 'skill-b'),
+        },
+      ];
+      const skillContents = artifacts.map((a) => a.content!);
+      // 全局 cwd 设为 root,两个 skill 在 root 下都找不到 assets-a-only.md / assets-b-only.md
+      // 但分别按 skillRoot 解析就都能找到
+      const result = await preflightDependencies(skillContents, [], root, undefined, artifacts);
+      assert.ok(result.ok, `应通过,但 missing=${JSON.stringify(result.missing)}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('directory-skill 引用的文件不存在时仍报错(并标出正确的 baseDir)', async () => {
+    const root = tmp();
+    mkdirSync(join(root, 'skill-a'), { recursive: true });
+    try {
+      const artifacts: Artifact[] = [
+        {
+          name: 'skill-a', kind: 'skill', source: 'variant-name',
+          content: '需要读 assets/missing.md',
+          locator: join(root, 'skill-a', 'SKILL.md'),
+          skillRoot: join(root, 'skill-a'),
+        },
+      ];
+      const result = await preflightDependencies(['需要读 assets/missing.md'], [], root, undefined, artifacts);
+      assert.ok(!result.ok);
+      const fileIssue = result.missing.find((m) => m.category === 'file' && m.name.includes('missing.md'));
+      assert.ok(fileIssue, '应报告 missing.md 文件缺失');
+      assert.ok(fileIssue!.hint.includes(join(root, 'skill-a')), `hint 应含 skillRoot 路径,实际:${fileIssue!.hint}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('extractFilesByBase', () => {
+  it('每个 artifact 按各自 skillRoot 分桶', () => {
+    const artifacts: Artifact[] = [
+      { name: 'a', kind: 'skill', source: 'variant-name', content: '看 docs/a.md', skillRoot: '/root/a' },
+      { name: 'b', kind: 'skill', source: 'variant-name', content: '看 docs/b.md', skillRoot: '/root/b' },
+    ];
+    const map = extractFilesByBase(artifacts, '/default/cwd');
+    assert.equal(map.size, 2);
+    assert.ok(map.get('/root/a')?.has('docs/a.md'));
+    assert.ok(map.get('/root/b')?.has('docs/b.md'));
+  });
+
+  it('无 skillRoot 的 artifact 落到 defaultCwd', () => {
+    const artifacts: Artifact[] = [
+      { name: 'a', kind: 'skill', source: 'variant-name', content: '看 docs/a.md' },
+    ];
+    const map = extractFilesByBase(artifacts, '/default/cwd');
+    assert.ok(map.get('/default/cwd')?.has('docs/a.md'));
+  });
+
+  it('artifact.cwd 优先于 defaultCwd(但低于 skillRoot)', () => {
+    const artifacts: Artifact[] = [
+      { name: 'a', kind: 'skill', source: 'variant-name', content: '看 docs/a.md', cwd: '/explicit' },
+    ];
+    const map = extractFilesByBase(artifacts, '/default/cwd');
+    assert.ok(map.get('/explicit')?.has('docs/a.md'));
+    assert.equal(map.get('/default/cwd'), undefined);
   });
 });
 

--- a/test/evaluation/task-planner.test.ts
+++ b/test/evaluation/task-planner.test.ts
@@ -61,4 +61,30 @@ describe('buildTasksFromArtifacts', () => {
   it('空输入返回空数组', () => {
     assert.deepEqual(buildTasksFromArtifacts([], []), []);
   });
+
+  it('cwd fallback 链:artifact.cwd > skillRoot > sample.cwd > null', () => {
+    const samples = [makeSample('s1', 'p')];
+
+    // 1. 仅 skillRoot:directory-skill 默认锚到 skill 根
+    const onlySkillRoot: Artifact[] = [
+      { name: 'k', kind: 'skill', source: 'variant-name', content: 'c', skillRoot: '/skill/root' },
+    ];
+    assert.equal(buildTasksFromArtifacts(samples, onlySkillRoot)[0].cwd, '/skill/root');
+
+    // 2. artifact.cwd 优先于 skillRoot(用户显式 @cwd 覆盖默认)
+    const cwdAndSkillRoot: Artifact[] = [
+      { name: 'k', kind: 'skill', source: 'variant-name', content: 'c', cwd: '/explicit', skillRoot: '/skill/root' },
+    ];
+    assert.equal(buildTasksFromArtifacts(samples, cwdAndSkillRoot)[0].cwd, '/explicit');
+
+    // 3. 都没有 → null(executor 走 process.cwd())
+    const none: Artifact[] = [
+      { name: 'k', kind: 'skill', source: 'variant-name', content: 'c' },
+    ];
+    assert.equal(buildTasksFromArtifacts(samples, none)[0].cwd, null);
+
+    // 4. sample.cwd 兜底(file-skill 配 sample-级 cwd)
+    const sampleWithCwd: Sample = { sample_id: 's2', prompt: 'p', cwd: '/sample/cwd' };
+    assert.equal(buildTasksFromArtifacts([sampleWithCwd], none)[0].cwd, '/sample/cwd');
+  });
 });

--- a/test/inputs/skill-loader.test.ts
+++ b/test/inputs/skill-loader.test.ts
@@ -6,6 +6,7 @@ import { resolveArtifacts } from '../../src/inputs/skill-loader.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILL_DIR = join(__dirname, '..', '..', 'examples', 'code-review', 'skills');
+const MULTI_SKILL_DIR = join(__dirname, '..', '..', 'examples', 'multi-skills', 'skills');
 
 describe('resolveArtifacts', () => {
   it('baseline 产生 kind 为 baseline 的 artifact', () => {
@@ -48,5 +49,42 @@ describe('resolveArtifacts', () => {
     assert.equal(artifacts[0].kind, 'baseline');
     assert.equal(artifacts[0].content, null);
     assert.equal(artifacts[0].cwd, '/tmp/project-b');
+  });
+
+  it('file-skill 不设 skillRoot(cwd 走默认,即用户项目目录)', () => {
+    const artifacts = resolveArtifacts(SKILL_DIR, ['v1']);
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].skillRoot, undefined);
+  });
+
+  it('directory-skill 把 skillRoot 设到 SKILL.md 所在目录', () => {
+    const artifacts = resolveArtifacts(MULTI_SKILL_DIR, ['classifier']);
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].name, 'classifier');
+    assert.equal(artifacts[0].kind, 'skill');
+    assert.equal(artifacts[0].skillRoot, join(MULTI_SKILL_DIR, 'classifier'));
+  });
+
+  it('显式 @cwd 覆盖,但 skillRoot 仍记录在 artifact 上(优先级在 task-planner 处理)', () => {
+    const artifacts = resolveArtifacts(MULTI_SKILL_DIR, ['classifier@/tmp/override']);
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].cwd, '/tmp/override');
+    assert.equal(artifacts[0].skillRoot, join(MULTI_SKILL_DIR, 'classifier'));
+  });
+
+  it('file-path 指向 SKILL.md 同 directory-skill 处理:设 skillRoot 为该目录', () => {
+    const skillMd = join(MULTI_SKILL_DIR, 'classifier', 'SKILL.md');
+    const artifacts = resolveArtifacts(SKILL_DIR, [skillMd]);
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].source, 'file-path');
+    assert.equal(artifacts[0].skillRoot, dirname(skillMd));
+  });
+
+  it('file-path 指向单文件 .md 不设 skillRoot', () => {
+    const v1Path = join(SKILL_DIR, 'v1.md');
+    const artifacts = resolveArtifacts(MULTI_SKILL_DIR, [v1Path]);
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].source, 'file-path');
+    assert.equal(artifacts[0].skillRoot, undefined);
   });
 });


### PR DESCRIPTION
## 背景

用 omk 评测 WCC skill 时抓到两条同根路径 bug,只在 **directory-skill**(SKILL.md 自带 assets,引相对路径)上暴露:

1. **preflight 路径错位** — 所有 artifact 的文件依赖 fold 到单一 cwd 检查,WCC SKILL.md 引的 \`assets/references/...\` 被锚到 \`skills/\` 而非 \`skills/wcc/\`,报 41 个 false-positive ✗
2. **运行时 cwd 错位** — executor cwd 默认 \`process.cwd()\`,模型按 SKILL.md 的相对路径 Read 全找不到,wcc-003 调 13 次失败 6 次、wcc-004 直接 180s 超时

**file-skill**(单 .md 文件,如 examples/agent-eval/skills/v1.md)有不同语义 — 它依赖用户项目目录(引用 \`lib/grader.ts\` / \`package.json\`),不能改坏。

## 修复

引入 \`Artifact.skillRoot\` 字段,只对 SKILL.md 约定的 directory-skill 设值。task-planner 在 \`artifact.cwd\` 缺失时回落到 \`skillRoot\`,preflight 文件检查按 artifact 分桶解析。

| 文件 | 变更 |
|---|---|
| \`src/types/eval.ts\` | \`Artifact.skillRoot?: string\` |
| \`src/inputs/skill-loader.ts\` | dir-skill (\`xxx/SKILL.md\`) + file-path 指 SKILL.md 时设 skillRoot;file-skill 不设;git source 不设(working tree 可能 ≠ ref) |
| \`src/eval-core/task-planner.ts\` | cwd fallback: \`artifact.cwd > skillRoot > sample.cwd > null\` |
| \`src/eval-core/dependency-checker.ts\` | 新增 \`extractFilesByBase\` + \`checkFilesByBase\`;\`preflightDependencies\` 文件检查 per-artifact 分桶;tools/env/preflight commands 仍全局 |

**顺手** 收紧 \`FILE_PATH_REGEX\` 假阳性:跳过 \`.\` 开头(扩展名讨论 \`.d.ts\`)和不含 \`/\` 的 bare 文件名(\`index.ts\` / \`package.json\` 几乎都是示例提及)。

## 端到端验证

WCC skill 评测 5 题 × baseline/wcc(\`bench run --skill-dir skills --treatment wcc --control baseline --bootstrap\`):

| 指标 | fix 前 | fix 后 |
|---|---|---|
| preflight | 41 个 ✗ | 通过 |
| wcc 总错误 | 1/5 (180s 超时) | 0/5 |
| wcc avg tool failures | 1.8 | 0.8 |
| wcc 平均分 | 4.25 | 4.62 |
| baseline-vs-wcc diff CI | [-1.05, -0.20] **significant** | [-0.62, 0.25] **不再 significant** |

原来"WCC skill 显著负 ROI"的结论大部分是路径 bug 拖累,不是 skill 设计问题。

## 测试

新增 13 个用例:
- \`test/inputs/skill-loader.test.ts\`:directory-skill 设 skillRoot / file-skill 不设 / file-path 指 SKILL.md 自动判定 / @cwd 不覆盖 skillRoot 字段(优先级在 task-planner 处理)
- \`test/evaluation/task-planner.test.ts\`:fallback 链 4 个分支
- \`test/dependency-checker.test.ts\`:\`extractFilesByBase\` 分桶 / preflight per-artifact 集成测试(两个 skill 各自的 \`assets-x-only.md\` 在自己根下都能找到)

\`yarn lint && yarn build && yarn test\` 全绿,**708 tests passed**。测量学不变量未受影响 — judge prompt hash (\`v3-cot-length=629bf3b8c41d\`)、report schema、五层评分管道全不动。

## 不动

- file-skill 语义 — 单 .md 文件仍走 \`process.cwd()\`,examples/agent-eval/ 类用例不受影响
- git source — \`git:name\` 不设 skillRoot(ref 内容与 working tree assets 可能不一致)
- experimentType 检测(\`baseline+cwd\` → \`runtime-context-only\`)— 仍只看 \`artifact.cwd\`,\`skillRoot\` 是隐式默认值不参与角色判定