### PR TITLE
refactor(ci-verdict): ci 内核统一为 verdict, 加 stability rationale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ## [Unreleased]
 
+### Changed
+
+- **`omk bench ci` 内核统一为 verdict**:之前 `ci` 只看三层平均分阈值(`evaluateCiGates`),用户花钱跑 `--bootstrap` 但 ci 退出码完全忽略 bootstrap diff CI、saturation、Krippendorff α——是个**隐性漏洞**。本版把 `handleCi` 重写为 `runEvaluation + computeVerdict + formatVerdictText`,exit code 与 `bench verdict` 对齐:**只有 PROGRESS / SOLO-pass 才 0**;`NOISE` / `UNDERPOWERED` / `CAUTIOUS` / `REGRESS` 全 1。**这是行为变更**:之前三层都过 3.5 即 PASS 的 underpowered run 现在会 FAIL——这正是 ci gate 应有的语义(数据不显著就不该进 deploy)。`--threshold` 继续生效作为三层 gate 阈值,新增 `--trivial-diff` 调"实际可忽略的小差距"门限。两个 CLI 表层(`ci` 一句话跑+判 / `verdict` 离线判已有报告)继续保留,内核共用。
+
+- **`computeVerdict` 加 `rationale.stability` 字段**:之前 verdict 不报告稳定性,导致单轮(`--repeat=1`)用户无法感知"测不到稳定性"这个盲区。现在三态:
+  - `--repeat ≥ 2` + variance 数据齐:报 `CV=X.X% (稳定/中等/不稳, runs=N)` 主指标(阈值参考 terminology-spec §5)
+  - `--repeat ≥ 2` 但 variance 缺失:标"variance 数据缺失"提示数据丢失
+  - `--repeat < 2`:**显式说**「稳定性未测量(单轮评测,需 --repeat ≥ 2 才能测 CV)」
+
+  `formatVerdictText` 同步打印 stability 行,SOLO 单 variant 路径也走同一逻辑。让用户感受到 single-run 的盲区,而不是默默不提让人误读为"稳"。
+
 ### Fixed
 
 - **directory-skill 路径解析(`SKILL.md` 约定)**:符号链接或非 cwd 子目录里的 directory-skill(例如 `~/.claude/skills/foo/SKILL.md` 引用 `assets/references/...` 相对路径)在评测时:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1199,6 +1199,7 @@ async function handleCi(argv: string[]): Promise<void> {
   const lang = langFromArgv(argv);
   const { values, config } = parseRunConfig(argv, {
     threshold: { type: 'string', default: '3.5' },
+    'trivial-diff': { type: 'string' },
   });
 
   const { runEvaluation } = await import('./eval-workflows/run-evaluation.js');
@@ -1208,18 +1209,31 @@ async function handleCi(argv: string[]): Promise<void> {
   try {
     const { report } = (await runEvaluation(config)) as EvalResult;
 
-    const threshold: number = Number(values.threshold);
-
     if ((report as Report & { dryRun?: boolean }).dryRun) {
       console.log('CI dry-run: no scores to check');
       process.exit(0);
     }
 
-    // three-gate 逻辑抽到 src/eval-core/ci-gates.ts 作纯函数,便于测试;此处只做 IO。
-    const { evaluateCiGates } = await import('./eval-core/ci-gates.js');
-    const { allPass, lines } = evaluateCiGates(report.summary || {}, threshold);
-    for (const line of lines) console.log(line);
-    process.exit(allPass ? 0 : 1);
+    // ci 内核统一为 verdict — 之前只看 three-layer threshold 漏掉 bootstrap diff /
+    // saturation / Krip α 等关键信号(用户花钱跑 --bootstrap 但 ci 不看 CI)。
+    // 现在 ci = run + verdict,自动用上 omk 全部决策维度。
+    const { computeVerdict, formatVerdictText } = await import('./eval-core/verdict.js');
+    const result = computeVerdict(report, {
+      ciThreshold: Number(values.threshold),
+      triviallySmallDiff: values['trivial-diff'] != null ? Number(values['trivial-diff']) : undefined,
+    });
+    console.log(formatVerdictText(result, { verbose: true }));
+
+    // exit code 与 handleVerdict 对齐:只有 PROGRESS / SOLO-pass 才 0,
+    // NOISE / UNDERPOWERED / CAUTIOUS / REGRESS 全 1。这样 CI pipeline 用
+    // `omk bench ci && deploy` 时,数据不显著就不会误 deploy。
+    if (result.level === 'PROGRESS') {
+      process.exit(0);
+    }
+    if (result.level === 'SOLO' && result.headline.includes('PASS')) {
+      process.exit(0);
+    }
+    process.exit(1);
   } catch (err: unknown) {
     console.error(`Error: ${(err as Error).message}`);
     process.exit(1);

--- a/src/eval-core/verdict.ts
+++ b/src/eval-core/verdict.ts
@@ -49,6 +49,9 @@ export interface VerdictResult {
     significance?: string;
     layerWinners?: string;
     sampleSize?: string;
+    /** Stability claim:CV / variance summary if --repeat ≥ 2, 否则显式说"未测量"
+     *  让用户感受到 single-run 的盲区,而不是默默不提。 */
+    stability?: string;
     judgeAgreement?: string;
     shipRecommendation?: string;
   };
@@ -88,6 +91,7 @@ export function computeVerdict(report: Report, options: VerdictOptions = {}): Ve
       rationale: {
         layerWinners: gate.lines.join('; '),
         sampleSize: `N=${sampleCount}`,
+        stability: formatStability(report),
       },
       variants,
     };
@@ -121,6 +125,7 @@ export function computeVerdict(report: Report, options: VerdictOptions = {}): Ve
 
   const layerWinners = formatLayerWinners(summary, variants);
   const sampleSize = formatSampleSize(report);
+  const stability = formatStability(report);
   const judgeAgreement = formatJudgeAgreement(report);
   const shipRecommendation = recommendation(topLevel, perPair);
 
@@ -134,6 +139,7 @@ export function computeVerdict(report: Report, options: VerdictOptions = {}): Ve
       significance,
       layerWinners,
       sampleSize,
+      stability,
       judgeAgreement,
       shipRecommendation,
     },
@@ -290,6 +296,40 @@ function formatSampleSize(report: Report): string {
   return `N=${n}, not yet saturated (${v.confidence} confidence)`;
 }
 
+/**
+ * Stability rationale. 三种状态:
+ *   - --repeat ≥ 2 + 有 variance 数据: 报告 CV (variation coefficient) 主指标
+ *   - --repeat ≥ 2 但 variance 缺失: 异常,标 "—" 提示数据丢失
+ *   - --repeat < 2: 显式说"未测量,需 --repeat ≥ 2",而不是默默不提
+ *
+ * 单轮场景关键:不是"稳定 = 100%"(常见误读),而是"测不到稳定性"。
+ * Verdict 必须诚实交代这个盲区,不能让用户以为没说就是 OK。
+ */
+function formatStability(report: Report): string {
+  const runs = report.variance?.runs ?? report.meta?.request?.repeat ?? 1;
+  if (runs < 2) {
+    return '稳定性未测量(单轮评测,需 --repeat ≥ 2 才能测 CV)';
+  }
+  const variance = report.variance?.perVariant;
+  if (!variance || Object.keys(variance).length === 0) {
+    return `runs=${runs} 但 variance 数据缺失`;
+  }
+  // CV = stddev / mean,取所有 variant 的中位数(单 variant 易有 NaN/0,聚合更稳)
+  const cvs: number[] = [];
+  for (const v of Object.values(variance)) {
+    if (typeof v.stddev === 'number' && typeof v.mean === 'number' && v.mean > 0) {
+      cvs.push(v.stddev / v.mean);
+    }
+  }
+  if (cvs.length === 0) return `runs=${runs}, CV 计算失败(stddev/mean 数据缺失)`;
+  cvs.sort((a, b) => a - b);
+  const median = cvs[Math.floor(cvs.length / 2)];
+  const cvPct = (median * 100).toFixed(1);
+  // 阈值参考 terminology-spec §5:<5% 稳 / 5-15% 中 / >15% 不稳
+  const verdict = median < 0.05 ? '稳定' : median < 0.15 ? '中等' : '不稳';
+  return `CV=${cvPct}% (${verdict}, runs=${runs}; 阈值 <5%=稳/5-15%=中/>15%=不稳)`;
+}
+
 function formatJudgeAgreement(report: Report): string | undefined {
   const a = report.meta?.humanAgreement;
   if (!a) return undefined;
@@ -329,6 +369,7 @@ export function formatVerdictText(result: VerdictResult, options: { verbose?: bo
   lines.push(`  ${result.headline}`);
   if (result.rationale.layerWinners) lines.push(`  Layer winners: ${result.rationale.layerWinners}`);
   if (result.rationale.sampleSize) lines.push(`  Sample size:   ${result.rationale.sampleSize}`);
+  if (result.rationale.stability) lines.push(`  Stability:     ${result.rationale.stability}`);
   if (result.rationale.judgeAgreement) lines.push(`  Judge α:       ${result.rationale.judgeAgreement}`);
   if (result.rationale.shipRecommendation) lines.push(`  ${result.rationale.shipRecommendation}`);
   if (options.verbose && result.perPair && result.perPair.length > 1) {

--- a/test/eval-core/verdict.test.ts
+++ b/test/eval-core/verdict.test.ts
@@ -189,7 +189,7 @@ describe('computeVerdict', () => {
     assert.equal(v.perPair?.length, 2);
   });
 
-  it('formatVerdictText stays under 6 lines for the headline path', () => {
+  it('formatVerdictText stays under 7 lines for the headline path (含 stability rationale)', () => {
     const r = buildReport({
       variants: ['baseline', 'skill'],
       perVariantAvg: {
@@ -204,6 +204,59 @@ describe('computeVerdict', () => {
     const v = computeVerdict(r);
     const text = formatVerdictText(v);
     const lines = text.split('\n');
-    assert.ok(lines.length <= 6, `expected ≤6 lines, got ${lines.length}: ${text}`);
+    assert.ok(lines.length <= 7, `expected ≤7 lines, got ${lines.length}: ${text}`);
+  });
+
+  it('rationale.stability 在单轮(无 variance)时显式说"未测量"', () => {
+    const r = buildReport({
+      variants: ['baseline', 'skill'],
+      perVariantAvg: {
+        baseline: { fact: 4, behavior: 4, judge: 4, composite: 4 },
+        skill:    { fact: 4.3, behavior: 4.3, judge: 4.3, composite: 4.3 },
+      },
+      pairs: [{
+        control: 'baseline', treatment: 'skill',
+        diffBootstrapCI: { low: 0.1, high: 0.5, estimate: 0.3, samples: 1000, significant: true },
+      }],
+    });
+    const v = computeVerdict(r);
+    assert.match(v.rationale.stability ?? '', /未测量/);
+    assert.match(v.rationale.stability ?? '', /--repeat/);
+  });
+
+  it('rationale.stability 在多轮 variance 数据齐时报 CV 主指标', () => {
+    const r = buildReport({
+      variants: ['baseline', 'skill'],
+      perVariantAvg: {
+        baseline: { fact: 4, behavior: 4, judge: 4, composite: 4 },
+        skill:    { fact: 4.3, behavior: 4.3, judge: 4.3, composite: 4.3 },
+      },
+      pairs: [{
+        control: 'baseline', treatment: 'skill',
+        diffBootstrapCI: { low: 0.1, high: 0.5, estimate: 0.3, samples: 1000, significant: true },
+      }],
+      variance: {
+        runs: 3,
+        perVariant: {
+          baseline: { scores: [4.0, 4.0, 4.0], mean: 4.0, lower: 4.0, upper: 4.0, stddev: 0 },
+          skill:    { scores: [4.3, 4.3, 4.3], mean: 4.3, lower: 4.3, upper: 4.3, stddev: 0 },
+        },
+        comparisons: [],
+      },
+    });
+    const v = computeVerdict(r);
+    assert.match(v.rationale.stability ?? '', /CV=0\.0%/);
+    assert.match(v.rationale.stability ?? '', /稳定/);
+    assert.match(v.rationale.stability ?? '', /runs=3/);
+  });
+
+  it('rationale.stability 单 variant SOLO 路径同样标"未测量"', () => {
+    const r = buildReport({
+      variants: ['solo'],
+      perVariantAvg: { solo: { fact: 4, behavior: 4, judge: 4, composite: 4 } },
+    });
+    const v = computeVerdict(r);
+    assert.equal(v.level, 'SOLO');
+    assert.match(v.rationale.stability ?? '', /未测量/);
   });
 });


### PR DESCRIPTION
## 背景

\`omk bench ci\` 之前只看 \`evaluateCiGates\` 三层平均分阈值,用户花钱跑 \`--bootstrap\` 但 ci 退出码**完全忽略 bootstrap diff CI / saturation / Krippendorff α**——隐性漏洞:数据 NOISE / UNDERPOWERED 也可能给 PASS 误导 deploy 决策。

同时 \`computeVerdict\` 之前不报稳定性,**单轮(\`--repeat=1\`)用户无从感知"测不到稳定性"这个盲区**——一个 single-run 报告读起来就像满分,容易误读成"稳",其实压根没测。

## 改了什么

**1. `ci` 内核统一为 verdict**
\`handleCi\` 重写为 \`runEvaluation + computeVerdict + formatVerdictText\`,exit code 与 \`bench verdict\` 对齐:**只有 PROGRESS / SOLO-pass 才 0**;\`NOISE\` / \`UNDERPOWERED\` / \`CAUTIOUS\` / \`REGRESS\` 全 1。两个 CLI 表层(\`ci\` 一句话跑+判 / \`verdict\` 离线判已有报告)继续保留,**内核共用**。

⚠️ **行为变更**:之前三层都过 3.5 即 PASS 的 underpowered run 现在会 FAIL——这正是 ci gate 应有的语义(数据不显著就不该进 deploy)。\`--threshold\` 继续生效作为三层 gate 阈值,新增 \`--trivial-diff\` 调"实际可忽略的小差距"门限。

**2. `computeVerdict` 加 `rationale.stability` 字段**

三态:
- \`--repeat ≥ 2\` + variance 数据齐:报 \`CV=X.X% (稳定/中等/不稳, runs=N)\` 主指标。阈值参考 terminology-spec §5(<5% 稳 / 5-15% 中 / >15% 不稳)
- \`--repeat ≥ 2\` 但 variance 缺失:标"variance 数据缺失"
- \`--repeat < 2\`:**显式说**「稳定性未测量(单轮评测,需 \`--repeat ≥ 2\` 才能测 CV)」

\`formatVerdictText\` 同步打印 Stability 行,SOLO 单 variant 路径也走同一逻辑——让用户**感受到** single-run 的盲区。

## 验证

- 11 个旧 verdict 用例不动,**新增 3 个**(单轮"未测量"/ 多轮 CV / SOLO 单 variant)
- \`formatVerdictText\` 行数上限从 ≤6 放宽到 ≤7(含新 stability 行)
- \`yarn lint && yarn build && yarn test\` 全绿,**711 tests passed**
- judge prompt frozen hash \`v3-cot-length=629bf3b8c41d\` 不变

## 不动

- \`evaluateCiGates\`(\`src/eval-core/ci-gates.ts\`)纯函数继续存在 — \`computeVerdict\` 仍调它做 layer-gate 子检测
- \`bench ci --threshold\` flag 行为不变(继续是三层 gate 阈值)
- 现有 \`bench verdict <id>\` 子命令完全不动