### PR TITLE
feat(run): pre-run 结构性预警(N / repeat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ## [Unreleased]
 
+### Added
+
+- **`bench run` 跑前结构性预警**:用例数偏少 / 单轮评测会让结论不可靠,但用户跑前不知道——`bench verdict` 的 `UNDERPOWERED` 是事后判定。本版加 pre-run stderr 提醒(dry-run 也包括,让用户**真花钱前**就能看到):
+  - `N < 5`:`⚠ exploration-only, any conclusion is unreliable, CI will be uselessly wide`
+  - `5 ≤ N < 20`:`⚠ large-effect-only (Cohen's d > 0.8), medium effects hard to detect`
+  - `--repeat=1`:`⚠ single-run cannot measure stability (CV will be marked "not measured")`
+
+  **不预测 MDE 数值**(σ 跑前不知道,正态假设套 bootstrap 自相矛盾)——纯**结构性 hard-floor**:n<5 / n<20 / repeat=1 三档。要严肃判"数据够不够"留给 `bench verdict` + saturation 曲线 post-hoc。`buildPowerWarnings(n, repeat): string[]` 抽为纯函数,9 个单测覆盖各档边界。
+
 ### Changed
 
 - **user-facing 中文文案统一用「用例」,不用「样本」**:`docs/terminology-spec.md` §6 加显式规则——代码 / API / 文件名 / CLI flag(`Sample` / `sample_id` / `eval-samples.json` / `--samples`)继续用 `sample`(开源 API + 英文圈通用术语),只 user-facing zh 切换。理由:omk 的 `eval-samples` 是开发者**手挑**的测试用例,不是从某分布**随机抽样**的统计样本——「样本」会暗示"再多跑就能扩大样本量"误导用户,实际是要补设计、补用例。

--- a/src/eval-workflows/evaluation-pipeline.ts
+++ b/src/eval-workflows/evaluation-pipeline.ts
@@ -190,6 +190,45 @@ function computeTestSetHash(samplesPath: string): string | null {
   }
 }
 
+/**
+ * Compute structural power warnings (pure function, no I/O — for testing).
+ *
+ * Not MDE / power-analysis predictions (we don't have σ pre-run; predicting
+ * "CI half-width ~ ±0.4" before any data exists is hand-wave). These are
+ * **hard-floor + experience-based** thresholds:
+ *   - n < 5: any conclusion unreliable, CI uselessly wide
+ *   - 5 ≤ n < 20: only large effects (Cohen's d > 0.8) detectable
+ *   - repeat=1: stability cannot be measured at all
+ *
+ * Real power claims happen post-hoc via `bench verdict` UNDERPOWERED state +
+ * saturation curves. This is the upfront "you might be wasting the run"
+ * heads-up, not a gate.
+ */
+export function buildPowerWarnings(sampleCount: number, repeat: number): string[] {
+  const warnings: string[] = [];
+  if (sampleCount < 5) {
+    warnings.push(
+      `⚠ N=${sampleCount} < 5 (exploration-only): any conclusion is unreliable, CI will be uselessly wide. Decisions need ≥20 cases.`,
+    );
+  } else if (sampleCount < 20) {
+    warnings.push(
+      `⚠ N=${sampleCount} < 20 (large-effect-only, Cohen's d > 0.8): medium effects (d ≈ 0.5) hard to detect. For confident decisions consider ≥20 cases.`,
+    );
+  }
+  if (repeat < 2) {
+    warnings.push(
+      `⚠ --repeat=1: single-run cannot measure stability (CV will be marked "not measured"). Use --repeat 3+ to detect within-variant variance.`,
+    );
+  }
+  return warnings;
+}
+
+function emitPowerWarnings(sampleCount: number, repeat: number): void {
+  for (const w of buildPowerWarnings(sampleCount, repeat)) {
+    process.stderr.write(`${w}\n`);
+  }
+}
+
 function finalizeEvaluationReport({
   report,
   results,
@@ -372,6 +411,12 @@ export async function executeEvaluationPipeline({
         throw new Error(formatDependencyErrors(depResult.missing));
       }
     }
+
+    // Structural power warnings — print to stderr after preflight passes, before
+    // tasks start. These are *not* MDE / power-analysis predictions (we don't have
+    // σ before the run); they're hard-floor + experience-based thresholds. Verdict
+    // gate (computeVerdict) handles real power claims post-hoc.
+    emitPowerWarnings(samples.length, repeat ?? 1);
 
     // Pre-build a per-executor map for ensemble judges. Each unique executor name
     // gets one ExecutorFn, shared across all judges using that executor. The default

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -183,6 +183,12 @@ export async function runEvaluation({
   });
 
   if (dryRun) {
+    // Emit power warnings during dry-run too — this is exactly when users
+    // preview the run, the right moment to flag "you might be wasting it".
+    const { buildPowerWarnings } = await import('./evaluation-pipeline.js');
+    for (const w of buildPowerWarnings(samples.length, repeat ?? 1)) {
+      process.stderr.write(`${w}\n`);
+    }
     return {
       report: buildDryRunTaskReport({
         model,

--- a/test/eval-workflows/power-warnings.test.ts
+++ b/test/eval-workflows/power-warnings.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { buildPowerWarnings } from '../../src/eval-workflows/evaluation-pipeline.js';
+
+describe('buildPowerWarnings', () => {
+  it('n < 5: 探索级警告', () => {
+    const w = buildPowerWarnings(3, 1);
+    assert.equal(w.length, 2);  // n + repeat
+    assert.match(w[0], /N=3 < 5/);
+    assert.match(w[0], /exploration-only/);
+  });
+
+  it('5 ≤ n < 20: 大效应警告', () => {
+    const w = buildPowerWarnings(10, 1);
+    assert.equal(w.length, 2);
+    assert.match(w[0], /N=10 < 20/);
+    assert.match(w[0], /large-effect-only/);
+  });
+
+  it('n ≥ 20: 不报 n 警告(只剩 repeat=1)', () => {
+    const w = buildPowerWarnings(20, 1);
+    assert.equal(w.length, 1);
+    assert.match(w[0], /--repeat=1/);
+  });
+
+  it('repeat=1: 稳定性测不到警告', () => {
+    const w = buildPowerWarnings(30, 1);
+    assert.equal(w.length, 1);
+    assert.match(w[0], /single-run cannot measure stability/);
+  });
+
+  it('repeat ≥ 2: 不报 repeat 警告', () => {
+    const w = buildPowerWarnings(30, 3);
+    assert.equal(w.length, 0);
+  });
+
+  it('两条警告同时报(小 n + 单轮)', () => {
+    const w = buildPowerWarnings(3, 1);
+    assert.equal(w.length, 2);
+    assert.match(w[0], /N=3/);
+    assert.match(w[1], /--repeat=1/);
+  });
+
+  it('完美配置(n=30, repeat=3)无警告', () => {
+    const w = buildPowerWarnings(30, 3);
+    assert.equal(w.length, 0);
+  });
+
+  it('边界:n=4(<5) 触发探索级,n=5(≥5) 触发大效应级', () => {
+    assert.match(buildPowerWarnings(4, 3)[0], /< 5/);
+    assert.match(buildPowerWarnings(5, 3)[0], /< 20/);
+  });
+
+  it('边界:n=19(<20) 触发大效应级,n=20(≥20) 不报 n 警告', () => {
+    assert.equal(buildPowerWarnings(19, 3).length, 1);
+    assert.equal(buildPowerWarnings(20, 3).length, 0);
+  });
+});


### PR DESCRIPTION
## 背景

\`bench verdict\` 已经会判 \`UNDERPOWERED\`,但是 **post-hoc**——用户花钱跑完才发现"白跑了"。该把"用例数 / repeat 够不够"的提醒**前置到 run 之前**,让用户真花钱前就能看到。

## 改了什么

\`bench run\` 跑前 stderr 提醒(dry-run 也覆盖):

- \`N < 5\` → \`⚠ exploration-only, any conclusion is unreliable, CI uselessly wide\`
- \`5 ≤ N < 20\` → \`⚠ large-effect-only (Cohen's d > 0.8), medium effects hard to detect\`
- \`--repeat=1\` → \`⚠ single-run cannot measure stability (CV will be marked "not measured")\`

**不预测 MDE 数值** — σ 跑前不知道,拍脑袋写"CI 半宽 ±0.4 (按 stddev 0.3 估)"是 hand-wave,正态近似套 bootstrap 也自相矛盾。所以纯**结构性 hard-floor**,严肃 power 判定交给 \`bench verdict\` + saturation 曲线 post-hoc(那时有真实 σ)。

## 实现

- \`buildPowerWarnings(n, repeat): string[]\` 抽为纯函数(\`src/eval-workflows/evaluation-pipeline.ts\`)
- \`emitPowerWarnings\` 在 preflight 通过后、\`executeTasks\` 之前 stderr
- \`runEvaluation\` dry-run 路径也调一次,因为 dry-run 是用户真"预览"的时机

## 验证

WCC 配置(5 用例 / repeat=1)live 测:
\`\`\`
$ omk bench run --skill-dir skills --treatment wcc --control baseline --dry-run
⚠ N=5 < 20 (large-effect-only, Cohen's d > 0.8): medium effects (d ≈ 0.5) hard to detect. For confident decisions consider ≥20 cases.
⚠ --repeat=1: single-run cannot measure stability (CV will be marked "not measured"). Use --repeat 3+ to detect within-variant variance.
{ "dryRun": true, ... }
\`\`\`

9 个新单测(\`test/eval-workflows/power-warnings.test.ts\`)覆盖各档边界:
- n=4(<5)触发探索级 / n=5 触发大效应级
- n=19(<20)触发大效应级 / n=20(≥20)不报 n 警告
- repeat=1 触发 / repeat ≥ 2 不触发
- 双警告同时报(小 n + 单轮)
- 完美配置(n=30, repeat=3)0 警告

\`yarn lint && yarn build && yarn test\` 全绿,**717 tests passed**。lib 层文案保持英文(沿用 i18n 分层原则:cli 局部 i18n,lib stderr 英文)。