### PR TITLE
refactor(server): URL /run/ → /reports/ 跟 Report 语义对齐

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ### Changed
 
+- **⚠️ BREAKING:report server URL 从 `/run/<id>` 改为 `/reports/<id>`**:命名跟 codebase 内一致语义(`Report` 类型 / `~/.oh-my-knowledge/reports/` 目录 / `omk bench report` CLI 命令)对齐。`/run/` 是 omk 内部把 "evaluation run" 当 entity 的旧叫法,但用户打开 URL 是来"看报告"的——`/reports/` 直接匹配心智。同步改:`/api/run/<id>` → `/api/reports/<id>`,`/api/runs` → `/api/reports`。**直接删旧路径,不留兼容 alias**(omk 0-1 阶段)。已有书签需要更新。
+
 - **⚠️ BREAKING-COMPARABILITY:`bench run` / `bench gate` 默认对 baseline-kind variant 启用 skill isolation**(`--strict-baseline` default true)。这是 omk 测量学严谨性的根本承诺补全:之前 baseline 通过 Claude Agent SDK 的 skill auto-discovery 拿到 `~/.claude/skills/` 全部 skill,导致 baseline-vs-skill 比较 construct invalid——具体证据是 N=20 WCC 评测里 baseline 平均 13 次 `Skill` 工具调用 + 输出含 `@alipay/wealth-chart-components` 私有 import,verdict NOISE 实为污染。本版默认开启隔离(双堵 main session skills + subagent Skill 工具调用),baseline 真正干净。
 
   改动范围:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -667,7 +667,7 @@ async function handleRun(argv: string[]): Promise<void> {
           const { createReportServer } = await import('./server/report-server.js');
           const server: ReportServer = createReportServer({ reportsDir: config.outputDir });
           const serverUrl: string = await server.start();
-          const reportUrl: string = `${serverUrl}/run/${report.id}`;
+          const reportUrl: string = `${serverUrl}/reports/${report.id}`;
           process.stderr.write(tCli('cli.run.report_server_running', lang, { url: serverUrl }));
           process.stderr.write(tCli('cli.run.report_server_view', lang, { url: reportUrl }));
           process.stderr.write(tCli('cli.run.report_server_stop', lang));
@@ -740,7 +740,7 @@ async function handleRun(argv: string[]): Promise<void> {
           reportsDir: config.outputDir,
         });
         const serverUrl: string = await server.start();
-        const reportUrl: string = `${serverUrl}/run/${report.id}`;
+        const reportUrl: string = `${serverUrl}/reports/${report.id}`;
         process.stderr.write(tCli('cli.run.report_server_running', lang, { url: serverUrl }));
         process.stderr.write(tCli('cli.run.report_server_view', lang, { url: reportUrl }));
         process.stderr.write(tCli('cli.run.report_server_stop', lang));

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -86,7 +86,7 @@ export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string
     } catch { /* skip pill on this row */ }
 
     return `<tr>
-      <td>${statusPill}<a href="/run/${e(run.id)}"><span style="color:var(--text-primary)">${e(run.id)}${badges}</span><br><span style="font-size:0.6875rem;color:var(--text-muted)">${(() => {
+      <td>${statusPill}<a href="/reports/${e(run.id)}"><span style="color:var(--text-primary)">${e(run.id)}${badges}</span><br><span style="font-size:0.6875rem;color:var(--text-muted)">${(() => {
         // Extract date/time from report ID: ...-YYYYMMDD-HHmm
         const idMatch = run.id.match(/(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})$/);
         if (idMatch) return `${idMatch[2]}/${idMatch[3]} ${idMatch[4]}:${idMatch[5]}`;
@@ -178,7 +178,7 @@ export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string
     function deleteRun(id, btn) {
       var lang = document.documentElement.dataset.lang || '${DEFAULT_LANG}';
       if (!confirm(I18N[lang].deleteConfirm + ' ' + id + ' ?')) return;
-      fetch('/api/run/' + encodeURIComponent(id), { method: 'DELETE' })
+      fetch('/api/reports/' + encodeURIComponent(id), { method: 'DELETE' })
         .then(function(r) { return r.json(); })
         .then(function(d) {
           if (d.ok) { btn.closest('tr').remove(); }

--- a/src/renderer/trends.ts
+++ b/src/renderer/trends.ts
@@ -93,7 +93,7 @@ function renderTable(variantName: string, runs: Report[], lang: Lang): string {
     }
 
     return `<tr>
-      <td><a href="/run/${e(r.id)}">${fmtLocalTime(m.timestamp)}</a></td>
+      <td><a href="/reports/${e(r.id)}">${fmtLocalTime(m.timestamp)}</a></td>
       <td>${s.avgCompositeScore ?? '-'}</td>
       <td>${gapCell}</td>
       <td>${s.avgFullNumTurns ?? s.avgNumTurns ?? '-'}</td>

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -419,7 +419,7 @@ export function createReportServer({ port, reportsDir = DEFAULT_REPORTS_DIR, ana
         return;
       }
 
-      if (path === '/api/runs') {
+      if (path === '/api/reports') {
         const runs = await queryRunList(reportStore);
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(runs));
@@ -548,15 +548,15 @@ export function createReportServer({ port, reportsDir = DEFAULT_REPORTS_DIR, ana
         return;
       }
 
-      const runApiMatch = path.match(/^\/api\/run\/(.+)$/);
-      if (runApiMatch) {
-        const id = decodeURIComponent(runApiMatch[1]);
+      const reportApiMatch = path.match(/^\/api\/reports\/(.+)$/);
+      if (reportApiMatch) {
+        const id = decodeURIComponent(reportApiMatch[1]);
 
         if (req.method === 'DELETE') {
           const removed = await reportStore.remove(id);
           if (!removed) {
             res.writeHead(404, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: 'run not found' }));
+            res.end(JSON.stringify({ error: 'report not found' }));
           } else {
             res.writeHead(200, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ ok: true }));
@@ -564,14 +564,14 @@ export function createReportServer({ port, reportsDir = DEFAULT_REPORTS_DIR, ana
           return;
         }
 
-        const run = await queryRun(reportStore, id);
-        if (!run) {
+        const report = await queryRun(reportStore, id);
+        if (!report) {
           res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'run not found' }));
+          res.end(JSON.stringify({ error: 'report not found' }));
           return;
         }
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(run));
+        res.end(JSON.stringify(report));
         return;
       }
 
@@ -595,11 +595,11 @@ export function createReportServer({ port, reportsDir = DEFAULT_REPORTS_DIR, ana
         return;
       }
 
-      const runPageMatch = path.match(/^\/run\/(.+)$/);
-      if (runPageMatch) {
-        const run = await queryRun(reportStore, decodeURIComponent(runPageMatch[1]));
-        res.writeHead(run ? 200 : 404, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(run?.each ? renderEachRunDetail(run) : renderRunDetail(run));
+      const reportPageMatch = path.match(/^\/reports\/(.+)$/);
+      if (reportPageMatch) {
+        const report = await queryRun(reportStore, decodeURIComponent(reportPageMatch[1]));
+        res.writeHead(report ? 200 : 404, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(report?.each ? renderEachRunDetail(report) : renderRunDetail(report));
         return;
       }
 

--- a/test/__snapshots__/html-renderer.test.ts.snap
+++ b/test/__snapshots__/html-renderer.test.ts.snap
@@ -1529,7 +1529,7 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
         <th></th>
       </tr></thead>
       <tbody><tr>
-      <td><span class="run-status verdict-CAUTIOUS" title="Treatment slightly above control — small gap or layer below gate" aria-label="CAUTIOUS — Treatment slightly above control — small gap or layer below gate"><span class="run-status-dot" aria-hidden="true">▲</span>CAUTIOUS</span><a href="/run/test-run-20260325-1000"><span style="color:var(--text-primary)">test-run-20260325-1000</span><br><span style="font-size:0.6875rem;color:var(--text-muted)">03/25 10:00</span></a></td>
+      <td><span class="run-status verdict-CAUTIOUS" title="Treatment slightly above control — small gap or layer below gate" aria-label="CAUTIOUS — Treatment slightly above control — small gap or layer below gate"><span class="run-status-dot" aria-hidden="true">▲</span>CAUTIOUS</span><a href="/reports/test-run-20260325-1000"><span style="color:var(--text-primary)">test-run-20260325-1000</span><br><span style="font-size:0.6875rem;color:var(--text-muted)">03/25 10:00</span></a></td>
       <td>sonnet</td>
       <td>2</td>
       <td><div style="display:flex;align-items:center;gap:6px;margin:2px 0"><span title="v1" style="font-size:11px;color:var(--text-muted);width:56px;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex-shrink:0">v1</span><div style="width:64px;height:6px;background:var(--bg-surface);border-radius:3px;flex-shrink:0"><div style="width:80%;height:100%;background:var(--green);border-radius:3px"></div></div><span style="font-size:12px;font-weight:600;color:var(--green);min-width:24px">4</span></div><div style="display:flex;align-items:center;gap:6px;margin:2px 0"><span title="v2" style="font-size:11px;color:var(--text-muted);width:56px;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex-shrink:0">v2</span><div style="width:64px;height:6px;background:var(--bg-surface);border-radius:3px;flex-shrink:0"><div style="width:96%;height:100%;background:var(--green);border-radius:3px"></div></div><span style="font-size:12px;font-weight:600;color:var(--green);min-width:24px">4.8</span></div></td>
@@ -1556,7 +1556,7 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
     function deleteRun(id, btn) {
       var lang = document.documentElement.dataset.lang || 'zh';
       if (!confirm(I18N[lang].deleteConfirm + ' ' + id + ' ?')) return;
-      fetch('/api/run/' + encodeURIComponent(id), { method: 'DELETE' })
+      fetch('/api/reports/' + encodeURIComponent(id), { method: 'DELETE' })
         .then(function(r) { return r.json(); })
         .then(function(d) {
           if (d.ok) { btn.closest('tr').remove(); }
@@ -2013,7 +2013,7 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
         <th></th>
       </tr></thead>
       <tbody><tr>
-      <td><span class="run-status verdict-CAUTIOUS" title="实验组略优于对照组,但差距小或某层未达 gate" aria-label="略微进步 — 实验组略优于对照组,但差距小或某层未达 gate"><span class="run-status-dot" aria-hidden="true">▲</span>略微进步</span><a href="/run/test-run-20260325-1000"><span style="color:var(--text-primary)">test-run-20260325-1000</span><br><span style="font-size:0.6875rem;color:var(--text-muted)">03/25 10:00</span></a></td>
+      <td><span class="run-status verdict-CAUTIOUS" title="实验组略优于对照组,但差距小或某层未达 gate" aria-label="略微进步 — 实验组略优于对照组,但差距小或某层未达 gate"><span class="run-status-dot" aria-hidden="true">▲</span>略微进步</span><a href="/reports/test-run-20260325-1000"><span style="color:var(--text-primary)">test-run-20260325-1000</span><br><span style="font-size:0.6875rem;color:var(--text-muted)">03/25 10:00</span></a></td>
       <td>sonnet</td>
       <td>2</td>
       <td><div style="display:flex;align-items:center;gap:6px;margin:2px 0"><span title="v1" style="font-size:11px;color:var(--text-muted);width:56px;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex-shrink:0">v1</span><div style="width:64px;height:6px;background:var(--bg-surface);border-radius:3px;flex-shrink:0"><div style="width:80%;height:100%;background:var(--green);border-radius:3px"></div></div><span style="font-size:12px;font-weight:600;color:var(--green);min-width:24px">4</span></div><div style="display:flex;align-items:center;gap:6px;margin:2px 0"><span title="v2" style="font-size:11px;color:var(--text-muted);width:56px;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex-shrink:0">v2</span><div style="width:64px;height:6px;background:var(--bg-surface);border-radius:3px;flex-shrink:0"><div style="width:96%;height:100%;background:var(--green);border-radius:3px"></div></div><span style="font-size:12px;font-weight:600;color:var(--green);min-width:24px">4.8</span></div></td>
@@ -2040,7 +2040,7 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
     function deleteRun(id, btn) {
       var lang = document.documentElement.dataset.lang || 'zh';
       if (!confirm(I18N[lang].deleteConfirm + ' ' + id + ' ?')) return;
-      fetch('/api/run/' + encodeURIComponent(id), { method: 'DELETE' })
+      fetch('/api/reports/' + encodeURIComponent(id), { method: 'DELETE' })
         .then(function(r) { return r.json(); })
         .then(function(d) {
           if (d.ok) { btn.closest('tr').remove(); }

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -146,8 +146,8 @@ describe('report-server', () => {
     assert.equal(data.ok, true);
   });
 
-  it('GET /api/runs returns run list', async () => {
-    const res = await fetch(`${baseUrl}/api/runs`);
+  it('GET /api/reports returns run list', async () => {
+    const res = await fetch(`${baseUrl}/api/reports`);
     assert.equal(res.status, 200);
     const data = JSON.parse(res.body);
     assert.ok(Array.isArray(data));
@@ -188,16 +188,16 @@ describe('report-server', () => {
     assert.equal(data[0].jobId, 'job-test-run-001');
   });
 
-  it('GET /api/run/:id returns run detail', async () => {
-    const res = await fetch(`${baseUrl}/api/run/test-run-001`);
+  it('GET /api/reports/:id returns run detail', async () => {
+    const res = await fetch(`${baseUrl}/api/reports/test-run-001`);
     assert.equal(res.status, 200);
     const data = JSON.parse(res.body);
     assert.equal(data.id, 'test-run-001');
     assert.equal(data.meta.model, 'sonnet');
   });
 
-  it('GET /api/run/:id returns 404 for missing run', async () => {
-    const res = await fetch(`${baseUrl}/api/run/nonexistent`);
+  it('GET /api/reports/:id returns 404 for missing run', async () => {
+    const res = await fetch(`${baseUrl}/api/reports/nonexistent`);
     assert.equal(res.status, 404);
   });
 
@@ -208,27 +208,27 @@ describe('report-server', () => {
     assert.ok(res.body.includes('test-run-001'));
   });
 
-  it('GET /run/:id returns HTML detail page', async () => {
-    const res = await fetch(`${baseUrl}/run/test-run-001`);
+  it('GET /reports/:id returns HTML detail page', async () => {
+    const res = await fetch(`${baseUrl}/reports/test-run-001`);
     assert.equal(res.status, 200);
     assert.ok(res.headers['content-type']!.includes('text/html'));
     assert.ok(res.body.includes('test-run-001'));
   });
 
-  it('DELETE /api/run/:id removes report', async () => {
+  it('DELETE /api/reports/:id removes report', async () => {
     // Create a temp report to delete
     writeFileSync(join(TEST_DIR, 'to-delete.json'), JSON.stringify({ ...SAMPLE_REPORT, id: 'to-delete' }));
 
-    const res = await fetch(`${baseUrl}/api/run/to-delete`, { method: 'DELETE' });
+    const res = await fetch(`${baseUrl}/api/reports/to-delete`, { method: 'DELETE' });
     assert.equal(res.status, 200);
 
     // Verify it's gone
-    const check = await fetch(`${baseUrl}/api/run/to-delete`);
+    const check = await fetch(`${baseUrl}/api/reports/to-delete`);
     assert.equal(check.status, 404);
   });
 
-  it('DELETE /api/run/:id returns 404 for missing run', async () => {
-    const res = await fetch(`${baseUrl}/api/run/nonexistent`, { method: 'DELETE' });
+  it('DELETE /api/reports/:id returns 404 for missing run', async () => {
+    const res = await fetch(`${baseUrl}/api/reports/nonexistent`, { method: 'DELETE' });
     assert.equal(res.status, 404);
   });
 


### PR DESCRIPTION
omk 里类型 Report、目录 ~/.oh-my-knowledge/reports/、CLI omk bench report 都用 'report',但 server URL 用 /run/<id> — 唯一的不一致。/run/ 是 omk 内部 'evaluation run' 旧叫法,用户打开 URL 是来'看报告'的, /reports/ 直接匹配心智。

改动:server route /run/<id>→/reports/<id>、/api/run/<id>→/api/reports/<id>、/api/runs→/api/reports;client (html-renderer / trends / cli.ts) 5 处链接同步;test 路由测试 + html-renderer snapshot 重生。

⚠️ BREAKING: omk 0.x 不留 alias, /run/ 直接 404。书签需要更新。

720 tests passed, judge prompt frozen hash 不变。