### PR TITLE
fix(eval-core): VariantSummary.toolDistribution 修真实 call count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ## [Unreleased]
 
+### Fixed
+
+- **`VariantSummary.toolDistribution` 修真实 call count**:之前 aggregate 阶段按 `result.toolNames`(per-sample dedup 列表)累加,语义是"出现该 tool 的 sample 数",跟字段名"工具调用分布"不符 — 用户读 summary 看到 `Read: 5` 以为模型调了 5 次 Read,实际是"5 个样本里出现过 Read"。修法:`VariantResult` 加 per-sample `toolDistribution`(从 `toolCalls` reduce 得到真实 call count map),aggregate 时 sum per-sample 字段。旧报告 result 没 `toolDistribution` 字段时 fallback 到老 `toolNames` 语义保兼容。
+
 ### Changed
 
 - **⚠️ BREAKING:report server URL 从 `/run/<id>` 改为 `/reports/<id>`**:命名跟 codebase 内一致语义(`Report` 类型 / `~/.oh-my-knowledge/reports/` 目录 / `omk bench report` CLI 命令)对齐。`/run/` 是 omk 内部把 "evaluation run" 当 entity 的旧叫法,但用户打开 URL 是来"看报告"的——`/reports/` 直接匹配心智。同步改:`/api/run/<id>` → `/api/reports/<id>`,`/api/runs` → `/api/reports`。**直接删旧路径,不留兼容 alias**(omk 0-1 阶段)。已有书签需要更新。

--- a/src/eval-core/schema.ts
+++ b/src/eval-core/schema.ts
@@ -77,6 +77,10 @@ export function buildVariantResult(execResult: ExecResult, gradeResult: GradeRes
       numToolFailures,
       toolSuccessRate: Number((execResult.toolCalls.filter((tc) => tc.success).length / execResult.toolCalls.length).toFixed(2)),
       toolNames: [...new Set(execResult.toolCalls.map((tc) => tc.tool))],
+      toolDistribution: execResult.toolCalls.reduce<Record<string, number>>((d, tc) => {
+        d[tc.tool] = (d[tc.tool] || 0) + 1;
+        return d;
+      }, {}),
     }),
     traceCoverage,
     ...(execResult.error && { error: execResult.error }),
@@ -169,10 +173,19 @@ export function buildVariantSummary(entries: VariantResult[]): VariantSummary {
       if (withTools.length === 0) return {};
       const totalToolCalls = withTools.reduce((s, e) => s + (e.numToolCalls || 0), 0);
       const avgSuccessRate = withTools.reduce((s, e) => s + (e.toolSuccessRate || 0), 0) / withTools.length;
+      // v0.22 fix — sum per-sample toolDistribution(真实 call count),
+      // 不再用 dedup 后的 toolNames 累加(那只统计"出现该 tool 的 sample 数",不是调用次数)。
+      // 旧报告没 toolDistribution 字段时 fallback 到 toolNames 老语义,保兼容性。
       const dist: Record<string, number> = {};
       for (const e of withTools) {
-        for (const name of (e.toolNames || [])) {
-          dist[name] = (dist[name] || 0) + 1;
+        if (e.toolDistribution) {
+          for (const [name, count] of Object.entries(e.toolDistribution)) {
+            dist[name] = (dist[name] || 0) + count;
+          }
+        } else {
+          for (const name of (e.toolNames || [])) {
+            dist[name] = (dist[name] || 0) + 1;
+          }
         }
       }
       return {

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -23,6 +23,11 @@ export interface VariantResult {
   numToolFailures?: number;
   toolSuccessRate?: number;
   toolNames?: string[];
+  /** v0.22 — per-sample tool call distribution (tool name → call count).
+   *  Same shape as VariantSummary.toolDistribution but at sample granularity.
+   *  Aggregating these gives true call-count totals; aggregating toolNames
+   *  (deduped) only gives "samples-that-used-this-tool" counts. */
+  toolDistribution?: Record<string, number>;
   traceCoverage?: number;
   error?: string;
   compositeScore?: number;

--- a/test/eval-core/tool-distribution.test.ts
+++ b/test/eval-core/tool-distribution.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { buildVariantResult, buildVariantSummary } from '../../src/eval-core/schema.js';
+import type { ExecResult, ToolCallInfo, VariantResult } from '../../src/types/index.js';
+
+function mkToolCall(tool: string, success = true): ToolCallInfo {
+  return { tool, input: {}, output: 'ok', success };
+}
+
+function mkExec(toolCalls: ToolCallInfo[]): ExecResult {
+  return {
+    ok: true,
+    output: 'output',
+    durationMs: 100, durationApiMs: 80,
+    inputTokens: 10, outputTokens: 20,
+    cacheReadTokens: 0, cacheCreationTokens: 0,
+    costUSD: 0.001,
+    stopReason: 'end',
+    numTurns: 1,
+    toolCalls,
+  };
+}
+
+describe('VariantResult.toolDistribution (v0.22 fix)', () => {
+  it('single sample: per-sample toolDistribution counts each call(NOT dedup)', () => {
+    const exec = mkExec([
+      mkToolCall('Read'),
+      mkToolCall('Read'),
+      mkToolCall('Read'),
+      mkToolCall('Glob'),
+      mkToolCall('Bash'),
+    ]);
+    const r = buildVariantResult(exec, null);
+    assert.deepEqual(r.toolDistribution, { Read: 3, Glob: 1, Bash: 1 });
+    // toolNames 仍为 deduped 列表(用于 renderer 展示 + assertions ctx)
+    assert.deepEqual([...(r.toolNames || [])].sort(), ['Bash', 'Glob', 'Read']);
+    assert.equal(r.numToolCalls, 5);
+  });
+
+  it('no tool calls → toolDistribution 缺失(整个 tool 字段块 omit)', () => {
+    const exec = mkExec([]);
+    const r = buildVariantResult(exec, null);
+    assert.equal(r.toolDistribution, undefined);
+    assert.equal(r.numToolCalls, undefined);
+  });
+});
+
+describe('VariantSummary.toolDistribution aggregation (v0.22 fix)', () => {
+  function mkResult(td: Record<string, number>, numToolCalls: number, toolNames?: string[]): VariantResult {
+    return {
+      ok: true,
+      durationMs: 100, durationApiMs: 100,
+      inputTokens: 0, outputTokens: 0, totalTokens: 0,
+      cacheReadTokens: 0, cacheCreationTokens: 0,
+      execCostUSD: 0, judgeCostUSD: 0, costUSD: 0,
+      numTurns: 1, outputPreview: 'ok',
+      numToolCalls,
+      numToolFailures: 0,
+      toolSuccessRate: 1,
+      toolDistribution: td,
+      ...(toolNames !== undefined && { toolNames }),
+    };
+  }
+
+  it('aggregate sums real call counts across samples (NOT sample-presence count)', () => {
+    // sample 1: Read x3, Glob x1
+    // sample 2: Read x5, Bash x2
+    // 真 distribution: { Read: 8, Glob: 1, Bash: 2 }
+    // 老 bug 行为(toolNames dedup 累加): { Read: 2, Glob: 1, Bash: 1 }
+    const summary = buildVariantSummary([
+      mkResult({ Read: 3, Glob: 1 }, 4),
+      mkResult({ Read: 5, Bash: 2 }, 7),
+    ]);
+    assert.deepEqual(summary.toolDistribution, { Read: 8, Glob: 1, Bash: 2 },
+      'aggregate must sum real call counts, not sample-presence');
+  });
+
+  it('legacy report fallback: result with toolNames-only(无 toolDistribution)走老语义 sample-presence', () => {
+    // 模拟 v0.21 旧报告 result(没 toolDistribution 字段)— 仍按 toolNames dedup 累加,
+    // 不让兼容旧报告时 crash 或语义跳变。
+    const legacy = mkResult({}, 4, ['Read', 'Glob']);
+    delete legacy.toolDistribution; // 抹掉 v0.22 新字段模拟旧报告
+    const summary = buildVariantSummary([legacy]);
+    // 老语义:Read+1, Glob+1(每 sample 出现某 tool 各 +1)
+    assert.deepEqual(summary.toolDistribution, { Read: 1, Glob: 1 });
+  });
+
+  it('mixed new + legacy results: 新 result 用 distribution,老 result 走 fallback', () => {
+    const fresh = mkResult({ Read: 3 }, 3);
+    const legacy = mkResult({}, 2, ['Read', 'Bash']);
+    delete legacy.toolDistribution;
+    const summary = buildVariantSummary([fresh, legacy]);
+    // Read: 3 (fresh real count) + 1 (legacy presence) = 4
+    // Bash: 0 + 1 = 1
+    assert.deepEqual(summary.toolDistribution, { Read: 4, Bash: 1 });
+  });
+});


### PR DESCRIPTION
## Summary

- `VariantSummary.toolDistribution` 之前算的是"出现该 tool 的 sample 数",不是字段名暗示的"调用次数总和" — 命名跟语义不符,导致读报告的人按 call count 解读会高估或低估实际调用情况
- 修法:`VariantResult` 加 per-sample `toolDistribution`(从 `toolCalls` 真实 reduce),aggregate 时 sum 这些 per-sample 字段。旧报告 fallback 到老 `toolNames` 语义不破坏兼容
- 5 个单测锁住 per-sample / aggregate / legacy fallback / mixed 各情况

## Bug discovery

E2E 调试 PR #23 baseline skill isolation 时,我想从 summary 读"baseline 调了多少次 Skill 工具",发现数字跟手工 `vr.toolCalls.filter(t => t.tool === 'Skill').length` 对不上 — summary 只能告诉我"几个 sample 出现过 Skill",不能告诉我"总共调了几次"。最后只能 `node -e` 现算 toolCalls 数组,绕远路。

## Test plan

- [x] `yarn build && yarn lint && yarn test` — 762 测试全过(原 757 + 新加 5)
- [x] judge-hash-frozen 仍 pass(测量学锚点不动)
- [x] html-renderer snapshot 不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)