### PR TITLE
feat(executors): 新增 codex-sdk 执行器

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 ### Added
 
 - **codex-cli executor**(`--executor codex`):接入 OpenAI Codex CLI 当被测 / 评委,跟 Claude Code 同类 agent CLI 对位。token 统计齐全,best-effort 抽 codex 事件流到 omk trace。skill isolation 仅 cwd 一条 channel(codex 没 SDK skill 等价物),`allowedSkills=[]` 强制 cwd 非空。EXECUTOR_REGISTRY 加 `'codex'` 跟 `'claude'` 对齐。详见 #31。
+- **codex-sdk executor**(`--executor codex-sdk`):接入 `@openai/codex-sdk` 自带的 `@openai/codex` binary 和 SDK 事件流,复用 codex trace / token 解析。cost 仍按 Codex runtime 能力标记为未报告。文档补充 `codex`(PATH binary) vs `codex-sdk`(bundled binary) 的 construct-validity 边界。详见 #36。
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 ### Added
 
 - **codex-cli executor**(`--executor codex`):接入 OpenAI Codex CLI 当被测 / 评委,跟 Claude Code 同类 agent CLI 对位。token 统计齐全,best-effort 抽 codex 事件流到 omk trace。skill isolation 仅 cwd 一条 channel(codex 没 SDK skill 等价物),`allowedSkills=[]` 强制 cwd 非空。EXECUTOR_REGISTRY 加 `'codex'` 跟 `'claude'` 对齐。详见 #31。
-- **codex-sdk executor**(`--executor codex-sdk`):接入 `@openai/codex-sdk` 自带的 `@openai/codex` binary 和 SDK 事件流,复用 codex trace / token 解析。cost 仍按 Codex runtime 能力标记为未报告。文档补充 `codex`(PATH binary) vs `codex-sdk`(bundled binary) 的 construct-validity 边界。详见 #36。
+- **codex-sdk executor**(`--executor codex-sdk`):接入 `@openai/codex-sdk` 自带的 `@openai/codex` binary 和 SDK 事件流,复用 codex trace / token / cost-not-reported 语义。Construct validity:CODEX_HOME 隔离到 per-process tmp 防 `~/.codex/config.toml` 渗入 eval(等价 codex CLI `--ephemeral` + `--ignore-user-config`,auth.json symlink 透传);SIGINT 联动 abortController 让 PR #33 的 nested-host orphan 修复对 SDK 子进程同样生效。详见 #36。
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -672,12 +672,14 @@ The command writes `~/.oh-my-knowledge/analyses/<timestamp>-skill-health.json`. 
 | `claude` | default | invokes `claude -p` via Claude CLI |
 | `claude-sdk` | structured output | uses Claude Agent SDK — no stdout parsing, avoids buffer truncation |
 | `codex` | OpenAI agent CLI | invokes `codex exec --json` (`@openai/codex` npm); best-effort tool trace; **costUSD not reported** (codex CLI does not emit USD; check usage externally) |
-| `openai` | cross-vendor comparison | invokes `openai api` CLI |
+| `codex-sdk` | OpenAI agent SDK | uses `@openai/codex-sdk` with its bundled `@openai/codex` binary and streamed SDK events; **costUSD not reported** |
 | `gemini` | cross-vendor comparison | invokes `gemini` CLI |
 | `anthropic-api` | no CLI needed | calls Anthropic HTTP API directly (needs `ANTHROPIC_API_KEY`) |
 | `openai-api` | no CLI needed | calls OpenAI HTTP API directly (needs `OPENAI_API_KEY`) |
 
 API-direct executors support custom base URLs via env: `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`.
+
+Codex construct-validity note: `codex` uses the `codex` binary found on `PATH`; `codex-sdk` uses the bundled `@openai/codex` binary resolved by `@openai/codex-sdk`. Strict comparisons between the two require recording both runtime versions (`codex --version` and the locked npm versions). If they differ, treat results as a comparison of executor runtimes, not only of prompt/template behavior.
 
 ### Custom executor
 

--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ The command writes `~/.oh-my-knowledge/analyses/<timestamp>-skill-health.json`. 
 
 API-direct executors support custom base URLs via env: `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`.
 
-Codex construct-validity note: `codex` uses the `codex` binary found on `PATH`; `codex-sdk` uses the bundled `@openai/codex` binary resolved by `@openai/codex-sdk`. Strict comparisons between the two require recording both runtime versions (`codex --version` and the locked npm versions). If they differ, treat results as a comparison of executor runtimes, not only of prompt/template behavior.
+Codex construct-validity notes: (1) `codex` uses the `codex` binary on `PATH`; `codex-sdk` uses the bundled `@openai/codex` binary resolved by `@openai/codex-sdk`. Record both runtime versions (`codex --version` and the locked npm version) when comparing — if they differ, treat results as an executor-runtime comparison, not only prompt/template behavior. (2) Both executors isolate user-level config: `codex` passes `--ephemeral` + `--ignore-user-config`; `codex-sdk` redirects `$CODEX_HOME` to a per-process tmp dir (auth.json symlinked through). User-level `~/.codex/config.toml` does not leak into eval runs in either case.
 
 ### Custom executor
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -672,7 +672,7 @@ omk analyze ~/.claude/projects/my-project --kb /path/to/project
 
 API 直调执行器支持通过环境变量自定义 Base URL：`ANTHROPIC_BASE_URL`、`OPENAI_BASE_URL`。
 
-Codex construct-validity 说明：`codex` 使用 `PATH` 上找到的 `codex` binary；`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。两者严格横向比较时，需要记录两个 runtime 版本（`codex --version` 和 lockfile 中的 npm 版本）。如果版本不一致，结果应解释为 executor runtime 对比，而不只是 prompt/template 行为对比。
+Codex construct-validity 说明:(1) `codex` 使用 `PATH` 上找到的 `codex` binary;`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。两者严格横向比较时,记录两个 runtime 版本(`codex --version` 和 lockfile 中的 npm 版本)—— 版本不一致时,结果应解释为 executor runtime 对比,而不只是 prompt/template 行为对比。(2) 两个 executor 都隔离用户级 config:`codex` 传 `--ephemeral` + `--ignore-user-config`,`codex-sdk` 把 `$CODEX_HOME` 重定向到 per-process tmp 目录(auth.json 通过 symlink 透传)。用户的 `~/.codex/config.toml` 不会渗入任意一个 executor 的 eval。
 
 ### 自定义执行器
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -665,12 +665,14 @@ omk analyze ~/.claude/projects/my-project --kb /path/to/project
 | `claude` | 默认 | 通过 `claude -p` 调用 Claude CLI |
 | `claude-sdk` | 结构化输出 | 通过 Claude Agent SDK 调用，无 stdout 解析，避免 buffer 截断 |
 | `codex` | OpenAI agent CLI | 通过 `codex exec --json` 调用,需本地装好登录的 codex(`@openai/codex`);best-effort tool trace,**costUSD 不报**(codex 自身不输出 USD,需外部账单核算) |
-| `openai` | 跨厂商对比 | 通过 `openai api` CLI 调用 |
+| `codex-sdk` | OpenAI agent SDK | 通过 `@openai/codex-sdk` 调用其自带的 `@openai/codex` binary 和 SDK 事件流;**costUSD 不报** |
 | `gemini` | 跨厂商对比 | 通过 `gemini` CLI 调用 |
 | `anthropic-api` | 无需 CLI | 直接调用 Anthropic HTTP API（需 `ANTHROPIC_API_KEY`） |
 | `openai-api` | 无需 CLI | 直接调用 OpenAI HTTP API（需 `OPENAI_API_KEY`） |
 
 API 直调执行器支持通过环境变量自定义 Base URL：`ANTHROPIC_BASE_URL`、`OPENAI_BASE_URL`。
+
+Codex construct-validity 说明：`codex` 使用 `PATH` 上找到的 `codex` binary；`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。两者严格横向比较时，需要记录两个 runtime 版本（`codex --version` 和 lockfile 中的 npm 版本）。如果版本不一致，结果应解释为 executor runtime 对比，而不只是 prompt/template 行为对比。
 
 ### 自定义执行器
 

--- a/docs/dev/sigint-validation.md
+++ b/docs/dev/sigint-validation.md
@@ -86,3 +86,9 @@ claude
 - **Windows**:Node 的 `child.kill('SIGTERM')` 在 Windows 上是 `TerminateProcess` 等价 SIGKILL,**没有 grace period**。omk 主战场是 macOS / Linux,Windows best-effort。
 - **`--export` / dev mode**:`cli/index.ts` 的 dev mode `node --watch` spawn 不走 executor 路径,SIGINT 传播由 dev mode 自己处理。本 fix 不影响。
 - **HTTP executor**(`anthropic-api` / `openai-api`):用 fetch + `AbortSignal.timeout`,自带 abort,无 child 进程,无 orphan 风险。本 fix 不动它们。
+
+## codex-sdk executor 的额外校验
+
+`@openai/codex-sdk` 内部自己 `spawn(executablePath, ...)`,SDK 子进程**不在** `spawnWithSigintPropagation` 维护的 registry 里。`codex-sdk` executor 因此自己 install 一个 SIGINT listener 调 `abortController.abort()`,SDK 拿到 abort 后用它注册到 `spawn` 的 `signal` 选项 SIGTERM 子进程。
+
+验证方式:把上面"终端 A"命令的 `--executor codex` 换成 `--executor codex-sdk`,Ctrl+C 后预期同样无 orphan。listener 的 install/remove 走 try/finally,validation 抛错时不会装 listener。

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.89",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@openai/codex-sdk": "0.128.0",
     "ajv": "^8.18.0",
     "js-yaml": "^4.1.1",
     "simple-statistics": "^7.8.9"

--- a/src/executors/codex-cli.ts
+++ b/src/executors/codex-cli.ts
@@ -24,11 +24,11 @@ import {
 //   []                → 必须提供 cwd 非空(否则 throw),caller 应传一个
 //                       isolated 空目录(如 ~/.oh-my-knowledge/isolated-cwd/)
 //   [...] (length>0)  → throw,codex CLI 没有 partial 白名单 flag
-function isolateCodexCwd(allowedSkills: string[] | undefined, cwd: string | null | undefined): void {
+export function isolateCodexCwd(allowedSkills: string[] | undefined, cwd: string | null | undefined, executorName = 'codex-cli'): void {
   if (allowedSkills === undefined) return;
   if (allowedSkills.length > 0) {
     throw new Error(
-      `codex-cli executor 不支持 partial skill 白名单(allowedSkills=${JSON.stringify(allowedSkills)})。\n`
+      `${executorName} executor 不支持 partial skill 白名单(allowedSkills=${JSON.stringify(allowedSkills)})。\n`
       + `  仅支持 [](强制 cwd 隔离,需提供 cwd 非空)或 undefined(默认)。\n`
       + `  codex CLI 无 partial 白名单 flag,请改用其他 executor 或显式 cwd 隔离。`,
     );
@@ -36,7 +36,7 @@ function isolateCodexCwd(allowedSkills: string[] | undefined, cwd: string | null
   // allowedSkills === [] 时必须有 cwd(channel 3 cwd 隔离是 codex 唯一 channel)
   if (!cwd) {
     throw new Error(
-      'codex-cli executor allowedSkills=[] 需要提供 cwd 非空(channel 3 cwd 隔离)。\n'
+      `${executorName} executor allowedSkills=[] 需要提供 cwd 非空(channel 3 cwd 隔离)。\n`
       + '  codex 没有 SDK skill 自动发现 / subagent Skill 工具这两条 channel,\n'
       + '  cwd 文件系统隔离是它唯一能堵 AGENTS.md / .agents/skills/ 自动加载的途径。\n'
       + '  caller 应传一个 isolated 空目录(如 ~/.oh-my-knowledge/isolated-cwd/)。',
@@ -62,7 +62,7 @@ function parseCodexJsonl(stdout: string): CodexEvent[] {
   return events;
 }
 
-function extractCodexUsage(events: CodexEvent[]): { input: number; cached: number; output: number } {
+export function extractCodexUsage(events: CodexEvent[]): { input: number; cached: number; output: number } {
   let input = 0;
   let cached = 0;
   let output = 0;
@@ -92,7 +92,7 @@ export function extractCodexFinalOutput(events: CodexEvent[]): string {
   return allTexts.join('\n');
 }
 
-function extractCodexStopReason(events: CodexEvent[]): string {
+export function extractCodexStopReason(events: CodexEvent[]): string {
   const last = [...events].reverse().find((e) => isCodexResultEvent(e));
   if (!last) return 'unknown';
   if (last.type === 'turn.failed') return 'error';

--- a/src/executors/codex-sdk.ts
+++ b/src/executors/codex-sdk.ts
@@ -1,3 +1,7 @@
+import { existsSync } from 'node:fs';
+import { mkdtemp, symlink } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { Codex, CodexOptions, ThreadEvent } from '@openai/codex-sdk';
 import type { ExecResult, ExecutorInput } from '../types/index.js';
 import { extractCodexTrace, isCodexResultEvent } from './codex-cli-trace.js';
@@ -20,6 +24,7 @@ import {
 type CodexSdkModule = typeof import('@openai/codex-sdk');
 
 let CodexCtor: CodexSdkModule['Codex'] | null = null;
+let codexHomePromise: Promise<string> | null = null;
 let hasWarnedSystem = false;
 let hasWarnedCost = false;
 
@@ -29,6 +34,49 @@ async function getCodexCtor(): Promise<CodexSdkModule['Codex']> {
     CodexCtor = sdk.Codex;
   }
   return CodexCtor;
+}
+
+// Construct-validity invariant: codex-cli passes `--ephemeral`(no session
+// persistence)+ `--ignore-user-config`(skip $CODEX_HOME/config.toml)so eval
+// runs are independent of the user's local codex profile. @openai/codex-sdk's
+// ThreadOptions does NOT expose either flag, so without intervention codex-sdk
+// runs would leak `~/.codex/config.toml`(custom model_reasoning_effort,
+// instructions, tool config)into the eval and pollute `~/.codex/sessions/`
+// across runs.
+//
+// Mitigation: redirect $CODEX_HOME to a per-process tmp dir for codex-sdk only.
+// auth.json is symlinked from the real CODEX_HOME so the SDK can still
+// authenticate; config.toml + sessions/ stay isolated. Tmp dir stays alive for
+// the OS to rotate(no explicit cleanup, matches DEFAULT_TIMEOUT_MS scope).
+//
+// Best-effort on Windows where symlink may need elevated privileges; on
+// failure, the codex-sdk executor still runs but lands in the user's real
+// CODEX_HOME with a stderr warning.
+export async function getIsolatedCodexHome(): Promise<string> {
+  if (!codexHomePromise) {
+    codexHomePromise = (async () => {
+      const tmpHome = await mkdtemp(join(tmpdir(), 'omk-codex-sdk-'));
+      const realHome = process.env.CODEX_HOME || join(homedir(), '.codex');
+      const realAuth = join(realHome, 'auth.json');
+      if (existsSync(realAuth)) {
+        try {
+          await symlink(realAuth, join(tmpHome, 'auth.json'));
+        } catch (err) {
+          process.stderr.write(`[codex-sdk] CODEX_HOME isolation: auth.json symlink failed (${(err as Error).message}); SDK will use bare tmp home and may fail to authenticate\n`);
+        }
+      }
+      return tmpHome;
+    })();
+  }
+  return codexHomePromise;
+}
+
+// exported for test isolation
+export function __resetCodexSdkStateForTest(): void {
+  CodexCtor = null;
+  codexHomePromise = null;
+  hasWarnedSystem = false;
+  hasWarnedCost = false;
 }
 
 export function buildCodexSdkThreadOptions({ model, cwd }: { model: string; cwd?: string | null }): {
@@ -82,9 +130,21 @@ export async function codexSdkExecutor({ model, system, prompt, cwd, skillDir, t
   const start = Date.now();
   const abortController = new AbortController();
   const timer = setTimeout(() => abortController.abort(), timeoutMs);
+
+  // SIGINT propagation: PR #33 helper only tracks child process refs registered
+  // via spawnWithSigintPropagation; @openai/codex-sdk does its own spawn()
+  // internally and the SDK child is not in that registry. Hook the
+  // AbortController to SIGINT so the SDK kills its child via the standard
+  // abortSignal pipeline (SDK passes `signal: args.signal` to spawn). Without
+  // this, Ctrl+C in a nested host orphans the codex SDK child until DEFAULT
+  // timeout elapses, regressing PR #33's nested-host fix.
+  const sigintListener = (): void => abortController.abort();
+  process.on('SIGINT', sigintListener);
+
   const events: CodexEvent[] = [];
 
   try {
+    env.CODEX_HOME = await getIsolatedCodexHome();
     const codex = await createCodexSdkClient(env);
     const thread = codex.startThread(buildCodexSdkThreadOptions({ model, cwd }));
     const streamed = await thread.runStreamed(finalPrompt, { signal: abortController.signal });
@@ -92,7 +152,6 @@ export async function codexSdkExecutor({ model, system, prompt, cwd, skillDir, t
     for await (const event of streamed.events) {
       events.push(normalizeSdkEvent(event));
     }
-    clearTimeout(timer);
 
     const durationMs = Date.now() - start;
     const resultEvents = events.filter(isCodexResultEvent);
@@ -141,7 +200,6 @@ export async function codexSdkExecutor({ model, system, prompt, cwd, skillDir, t
       ...(trace.toolCalls.length > 0 && { toolCalls: trace.toolCalls }),
     };
   } catch (err: unknown) {
-    clearTimeout(timer);
     const durationMs = Date.now() - start;
     const details = asErrorLike(err);
     const isAbort = details.name === 'AbortError' || abortController.signal.aborted;
@@ -188,5 +246,8 @@ export async function codexSdkExecutor({ model, system, prompt, cwd, skillDir, t
       stopReason: 'error',
       numTurns: 0,
     };
+  } finally {
+    clearTimeout(timer);
+    process.removeListener('SIGINT', sigintListener);
   }
 }

--- a/src/executors/codex-sdk.ts
+++ b/src/executors/codex-sdk.ts
@@ -1,0 +1,192 @@
+import type { Codex, CodexOptions, ThreadEvent } from '@openai/codex-sdk';
+import type { ExecResult, ExecutorInput } from '../types/index.js';
+import { extractCodexTrace, isCodexResultEvent } from './codex-cli-trace.js';
+import type { CodexEvent } from './shared.js';
+import {
+  asErrorLike,
+  buildExecEnv,
+  DEFAULT_TIMEOUT_MS,
+  errorMessage,
+  timeoutExecResult,
+} from './shared.js';
+import {
+  extractCodexFinalOutput,
+  extractCodexStopReason,
+  extractCodexUsage,
+  isolateCodexCwd,
+  sumCodexElapsed,
+} from './codex-cli.js';
+
+type CodexSdkModule = typeof import('@openai/codex-sdk');
+
+let CodexCtor: CodexSdkModule['Codex'] | null = null;
+let hasWarnedSystem = false;
+let hasWarnedCost = false;
+
+async function getCodexCtor(): Promise<CodexSdkModule['Codex']> {
+  if (!CodexCtor) {
+    const sdk = await import('@openai/codex-sdk') as CodexSdkModule;
+    CodexCtor = sdk.Codex;
+  }
+  return CodexCtor;
+}
+
+export function buildCodexSdkThreadOptions({ model, cwd }: { model: string; cwd?: string | null }): {
+  model?: string;
+  sandboxMode: 'read-only';
+  workingDirectory?: string;
+  skipGitRepoCheck: true;
+  approvalPolicy: 'never';
+} {
+  return {
+    ...(model && { model }),
+    sandboxMode: 'read-only',
+    ...(cwd && { workingDirectory: cwd }),
+    skipGitRepoCheck: true,
+    approvalPolicy: 'never',
+  };
+}
+
+export function buildCodexSdkClientOptions(env: NodeJS.ProcessEnv): CodexOptions {
+  return {
+    // Leave codexPathOverride unset: the SDK should use its bundled @openai/codex
+    // binary, matching the SDK executor contract instead of delegating to PATH.
+    env: env as Record<string, string>,
+  };
+}
+
+export async function createCodexSdkClient(env: NodeJS.ProcessEnv): Promise<Codex> {
+  const CodexClient = await getCodexCtor();
+  return new CodexClient(buildCodexSdkClientOptions(env));
+}
+
+function normalizeSdkEvent(event: ThreadEvent): CodexEvent {
+  return event as CodexEvent;
+}
+
+export async function codexSdkExecutor({ model, system, prompt, cwd, skillDir, timeoutMs = DEFAULT_TIMEOUT_MS, allowedSkills, verbose }: ExecutorInput): Promise<ExecResult> {
+  isolateCodexCwd(allowedSkills, cwd, 'codex-sdk');
+
+  const finalPrompt = system ? `${system}\n\n---\n\n${prompt}` : prompt;
+  if (system && verbose && !hasWarnedSystem) {
+    process.stderr.write('[codex-sdk] system prompt prepended (codex CLI/SDK lacks a system-prompt option)\n');
+    hasWarnedSystem = true;
+  }
+  if (verbose && !hasWarnedCost) {
+    process.stderr.write('[codex-sdk] cost not reported by binary; costReportedByExecutor=false (renderer shows 「—」 instead of $0.0000)\n');
+    hasWarnedCost = true;
+  }
+
+  const env = buildExecEnv(skillDir);
+
+  const start = Date.now();
+  const abortController = new AbortController();
+  const timer = setTimeout(() => abortController.abort(), timeoutMs);
+  const events: CodexEvent[] = [];
+
+  try {
+    const codex = await createCodexSdkClient(env);
+    const thread = codex.startThread(buildCodexSdkThreadOptions({ model, cwd }));
+    const streamed = await thread.runStreamed(finalPrompt, { signal: abortController.signal });
+
+    for await (const event of streamed.events) {
+      events.push(normalizeSdkEvent(event));
+    }
+    clearTimeout(timer);
+
+    const durationMs = Date.now() - start;
+    const resultEvents = events.filter(isCodexResultEvent);
+    if (resultEvents.length === 0) {
+      return {
+        ok: false,
+        error: 'no turn.completed/turn.failed event in codex-sdk output',
+        durationMs,
+        durationApiMs: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        costUSD: 0,
+        costReportedByExecutor: false,
+        output: null,
+        stopReason: 'error',
+        numTurns: 0,
+      };
+    }
+
+    const last = resultEvents[resultEvents.length - 1];
+    const usage = extractCodexUsage(events);
+    const trace = extractCodexTrace(events);
+    const stopReason = extractCodexStopReason(events);
+    const finalOutput = extractCodexFinalOutput(events);
+    const ok = last.type !== 'turn.failed' && !last.error;
+
+    return {
+      ok,
+      durationMs: sumCodexElapsed(resultEvents, durationMs),
+      durationApiMs: 0,
+      inputTokens: usage.input,
+      outputTokens: usage.output,
+      cacheReadTokens: usage.cached,
+      cacheCreationTokens: 0,
+      costUSD: 0,
+      costReportedByExecutor: false,
+      output: finalOutput,
+      stopReason,
+      ...(!ok && { error: last.error?.message || 'codex-sdk turn.failed' }),
+      numTurns: resultEvents.length,
+      fullNumTurns: trace.fullNumTurns,
+      numSubAgents: trace.numSubAgents,
+      ...(trace.turns.length > 0 && { turns: trace.turns }),
+      ...(trace.toolCalls.length > 0 && { toolCalls: trace.toolCalls }),
+    };
+  } catch (err: unknown) {
+    clearTimeout(timer);
+    const durationMs = Date.now() - start;
+    const details = asErrorLike(err);
+    const isAbort = details.name === 'AbortError' || abortController.signal.aborted;
+    if (isAbort) return { ...timeoutExecResult(timeoutMs, durationMs), costReportedByExecutor: false };
+
+    const resultEvents = events.filter(isCodexResultEvent);
+    if (resultEvents.length > 0) {
+      const last = resultEvents[resultEvents.length - 1];
+      const usage = extractCodexUsage(events);
+      const trace = extractCodexTrace(events);
+      return {
+        ok: false,
+        error: last.error?.message || errorMessage(err),
+        durationMs: sumCodexElapsed(resultEvents, durationMs),
+        durationApiMs: 0,
+        inputTokens: usage.input,
+        outputTokens: usage.output,
+        cacheReadTokens: usage.cached,
+        cacheCreationTokens: 0,
+        costUSD: 0,
+        costReportedByExecutor: false,
+        output: extractCodexFinalOutput(events) || null,
+        stopReason: 'error',
+        numTurns: resultEvents.length,
+        fullNumTurns: trace.fullNumTurns,
+        numSubAgents: trace.numSubAgents,
+        ...(trace.turns.length > 0 && { turns: trace.turns }),
+        ...(trace.toolCalls.length > 0 && { toolCalls: trace.toolCalls }),
+      };
+    }
+
+    return {
+      ok: false,
+      error: errorMessage(err),
+      durationMs,
+      durationApiMs: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUSD: 0,
+      costReportedByExecutor: false,
+      output: null,
+      stopReason: 'error',
+      numTurns: 0,
+    };
+  }
+}

--- a/src/executors/index.ts
+++ b/src/executors/index.ts
@@ -4,6 +4,7 @@ import { claudeCliExecutor } from './claude-cli.js';
 import { claudeSdkExecutor } from './claude-sdk.js';
 import { extractAgentTrace } from './claude-sdk-trace.js';
 import { codexCliExecutor } from './codex-cli.js';
+import { codexSdkExecutor } from './codex-sdk.js';
 import { geminiExecutor } from './gemini.js';
 import { openAiApiExecutor } from './openai-api.js';
 import { createScriptExecutor } from './script.js';
@@ -16,6 +17,7 @@ const EXECUTOR_REGISTRY: Record<string, ExecutorFn> = {
   claude: claudeCliExecutor,
   'claude-sdk': claudeSdkExecutor,
   codex: codexCliExecutor,
+  'codex-sdk': codexSdkExecutor,
   gemini: geminiExecutor,
   'anthropic-api': anthropicApiExecutor,
   'openai-api': openAiApiExecutor,

--- a/src/executors/shared.ts
+++ b/src/executors/shared.ts
@@ -117,6 +117,7 @@ export interface CodexEvent {
     input_tokens?: number;
     cached_input_tokens?: number;
     output_tokens?: number;
+    reasoning_output_tokens?: number;
   };
   elapsed_ms?: number;
   stop_reason?: string;
@@ -134,6 +135,12 @@ export interface CodexEvent {
     content?: string;
     query?: string;
     results?: unknown[];
+    changes?: Array<{ path?: string; kind?: string }>;
+    server?: string;
+    tool?: string;
+    arguments?: unknown;
+    result?: unknown;
+    message?: string;
   };
   error?: { message?: string };
   ts?: number;

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -13,6 +13,11 @@ describe('createExecutor', () => {
     assert.equal(typeof exec, 'function');
   });
 
+  it('returns a function for codex-sdk', () => {
+    const exec = createExecutor('codex-sdk');
+    assert.equal(typeof exec, 'function');
+  });
+
   it('returns a function for gemini', () => {
     const exec = createExecutor('gemini');
     assert.equal(typeof exec, 'function');

--- a/test/executors/codex-sdk.test.ts
+++ b/test/executors/codex-sdk.test.ts
@@ -1,9 +1,19 @@
-import { describe, it } from 'vitest';
+import { afterEach, beforeEach, describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { buildCodexSdkClientOptions, buildCodexSdkThreadOptions, codexSdkExecutor } from '../../src/executors/codex-sdk.js';
+import { existsSync, lstatSync, readlinkSync } from 'node:fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  __resetCodexSdkStateForTest,
+  buildCodexSdkClientOptions,
+  buildCodexSdkThreadOptions,
+  codexSdkExecutor,
+  getIsolatedCodexHome,
+} from '../../src/executors/codex-sdk.js';
 
 describe('codex-sdk executor parity contract', () => {
-  it('uses the same eval-critical thread options as codex CLI executor', () => {
+  it('maps the SDK-exposed eval-critical thread options to codex-cli equivalents', () => {
     const opts = buildCodexSdkThreadOptions({ model: 'gpt-5-codex', cwd: '/tmp/iso' });
     assert.equal(opts.model, 'gpt-5-codex');
     assert.equal(opts.workingDirectory, '/tmp/iso');
@@ -47,3 +57,71 @@ describe('codex-sdk executor parity contract', () => {
     );
   });
 });
+
+// codex-cli passes `--ephemeral` + `--ignore-user-config` to keep eval runs
+// independent of the user's real $CODEX_HOME. The SDK ThreadOptions does not
+// expose either flag, so the SDK executor redirects $CODEX_HOME to a per-process
+// tmp dir (auth.json symlinked through). Without this, codex vs codex-sdk are
+// not testing the same prompt+template under the same config — construct
+// validity violation.
+describe('codex-sdk CODEX_HOME isolation (--ephemeral + --ignore-user-config equivalent)', () => {
+  let fakeRealHome: string;
+  let originalCodexHome: string | undefined;
+
+  beforeEach(async () => {
+    __resetCodexSdkStateForTest();
+    fakeRealHome = join(tmpdir(), `omk-codex-sdk-test-real-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(fakeRealHome, { recursive: true });
+    await writeFile(join(fakeRealHome, 'auth.json'), '{"fake":"auth"}', 'utf8');
+    await writeFile(join(fakeRealHome, 'config.toml'), 'model_reasoning_effort = "high"\n', 'utf8');
+    originalCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = fakeRealHome;
+  });
+
+  afterEach(async () => {
+    if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = originalCodexHome;
+    await rm(fakeRealHome, { recursive: true, force: true });
+    __resetCodexSdkStateForTest();
+  });
+
+  it('returns a fresh tmp dir under os.tmpdir(), distinct from the real CODEX_HOME', async () => {
+    const isolated = await getIsolatedCodexHome();
+    assert.notEqual(isolated, fakeRealHome);
+    assert.match(isolated, /omk-codex-sdk-/);
+    assert.equal(isolated.startsWith(tmpdir()), true);
+    assert.equal(existsSync(isolated), true);
+  });
+
+  it('does NOT carry over config.toml from real CODEX_HOME (the whole point of isolation)', async () => {
+    const isolated = await getIsolatedCodexHome();
+    assert.equal(existsSync(join(isolated, 'config.toml')), false);
+  });
+
+  it('symlinks auth.json from real CODEX_HOME so the SDK can still authenticate', async () => {
+    const isolated = await getIsolatedCodexHome();
+    const linkedAuth = join(isolated, 'auth.json');
+    assert.equal(existsSync(linkedAuth), true);
+    const stat = lstatSync(linkedAuth);
+    assert.equal(stat.isSymbolicLink(), true);
+    assert.equal(readlinkSync(linkedAuth), join(fakeRealHome, 'auth.json'));
+  });
+
+  it('memoizes the isolated CODEX_HOME for subsequent calls in the same process', async () => {
+    const a = await getIsolatedCodexHome();
+    const b = await getIsolatedCodexHome();
+    assert.equal(a, b);
+  });
+});
+
+// PR #33 (SIGINT propagation) installed a process-level SIGINT handler that
+// walks a Set<ChildProcess> registry from spawnWithSigintPropagation. The codex
+// SDK does its own internal spawn() that the registry doesn't know about, so
+// the SDK executor adds its own one-shot SIGINT listener that calls
+// abortController.abort() — letting the SDK kill its child via the signal it
+// already passes to spawn(). The install/remove pair lives inside try/finally;
+// a meaningful end-to-end leak test would need a vi.mock'd SDK, deferred until
+// the wider executor mock harness lands.
+//
+// docs/dev/codex-sdk-sigint-validation.md records the manual ps verification
+// (Ctrl+C in a host CLI → no orphan codex process) for this code path.

--- a/test/executors/codex-sdk.test.ts
+++ b/test/executors/codex-sdk.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { buildCodexSdkClientOptions, buildCodexSdkThreadOptions, codexSdkExecutor } from '../../src/executors/codex-sdk.js';
+
+describe('codex-sdk executor parity contract', () => {
+  it('uses the same eval-critical thread options as codex CLI executor', () => {
+    const opts = buildCodexSdkThreadOptions({ model: 'gpt-5-codex', cwd: '/tmp/iso' });
+    assert.equal(opts.model, 'gpt-5-codex');
+    assert.equal(opts.workingDirectory, '/tmp/iso');
+    assert.equal(opts.sandboxMode, 'read-only');
+    assert.equal(opts.skipGitRepoCheck, true);
+    assert.equal(opts.approvalPolicy, 'never');
+  });
+
+  it('omits workingDirectory when cwd is unset, matching codex CLI no -C behavior', () => {
+    const opts = buildCodexSdkThreadOptions({ model: 'gpt-5-codex', cwd: null });
+    assert.equal('workingDirectory' in opts, false);
+  });
+
+  it('uses the SDK bundled binary by leaving codexPathOverride unset', () => {
+    const opts = buildCodexSdkClientOptions({ PATH: '/bin' });
+    assert.equal('codexPathOverride' in opts, false);
+    assert.deepEqual(opts.env, { PATH: '/bin' });
+  });
+
+  it('partial allowedSkills still throws because codex has no skill whitelist flag', async () => {
+    await assert.rejects(
+      () => codexSdkExecutor({
+        model: 'gpt-5-codex',
+        prompt: 'hello',
+        cwd: '/tmp/iso',
+        allowedSkills: ['one'],
+      }),
+      /partial skill 白名单|codex-sdk executor/,
+    );
+  });
+
+  it('strict isolation [] without cwd still throws before invoking SDK', async () => {
+    await assert.rejects(
+      () => codexSdkExecutor({
+        model: 'gpt-5-codex',
+        prompt: 'hello',
+        cwd: undefined,
+        allowedSkills: [],
+      }),
+      /channel 3 cwd 隔离|cwd 非空/,
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,6 +212,55 @@
   dependencies:
     "@tybys/wasm-util" "^0.10.1"
 
+"@openai/codex-darwin-arm64@npm:@openai/codex@0.128.0-darwin-arm64":
+  version "0.128.0-darwin-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-darwin-arm64.tgz#3a0ce51b2661cb6f7edb9fe621176a166216fbc5"
+  integrity sha512-w+6zohfHx/kHBdles/CyFKaY57u9I3nK8QI9+NrdwMliKA0b7xn13yblRNkMpe09j6vL1oAWoxYsMOQ/vjBGug==
+
+"@openai/codex-darwin-x64@npm:@openai/codex@0.128.0-darwin-x64":
+  version "0.128.0-darwin-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-darwin-x64.tgz#2f6c3f96abdd56162f7e1b92b5deb2af01761100"
+  integrity sha512-SDbn6fO22Puy8xmMIbZi4f2znMrUEPwABApke4mo+4ihaauwuVjeqzXvW5SPJz5ty/bG11/mSupQgReT7T8BBw==
+
+"@openai/codex-linux-arm64@npm:@openai/codex@0.128.0-linux-arm64":
+  version "0.128.0-linux-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-linux-arm64.tgz#f9bae67cd7755eb48e152ed25e566ec7825432dc"
+  integrity sha512-+SvH73H60qvCXFuQGP/EsmR//s1hHMBR22PvJkXvM/hdnTIGucx+JqRUjAWdmmQ1IU6j3kgwVvdLW/6ICB+M6w==
+
+"@openai/codex-linux-x64@npm:@openai/codex@0.128.0-linux-x64":
+  version "0.128.0-linux-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-linux-x64.tgz#5346a4166e97b04330ac1c3b86ee0dd44e0f059b"
+  integrity sha512-2lnSPA05CRRuKAzFW8BCmmNCSieDcToLwfC2ALLbBYilGLgzhRibjlDglK9F1BkEzfohSSWJu4PBbRu/aG60lQ==
+
+"@openai/codex-sdk@0.128.0":
+  version "0.128.0"
+  resolved "https://registry.yarnpkg.com/@openai/codex-sdk/-/codex-sdk-0.128.0.tgz#105a80ba7c0623990da247f791abe3c215265b2a"
+  integrity sha512-Eao0LLA5x90qwU6SXYd21h4KxdCef1WpCvHFgKdbqzWMJ79lUvguGDGvx1RheP+zTdKGxJfJ6dulI5wSXoUBhQ==
+  dependencies:
+    "@openai/codex" "0.128.0"
+
+"@openai/codex-win32-arm64@npm:@openai/codex@0.128.0-win32-arm64":
+  version "0.128.0-win32-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-win32-arm64.tgz#12b838ade9b394583425cec90e8aceeeba74ba37"
+  integrity sha512-ECJvsqmYFdA9pn42xxK3Odp/G16AjmBW0BglX8L0PwPjqbstbmlew9bfHf7xvL+SNfNl4NmyotW0+RNo1phgaA==
+
+"@openai/codex-win32-x64@npm:@openai/codex@0.128.0-win32-x64":
+  version "0.128.0-win32-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-win32-x64.tgz#a169e496b5052d4456267a2f5fbcadd9efced1d6"
+  integrity sha512-k3jmUAFrzkUtvjGTXvSKjQqJLLlzjxp/VoHJDYedgmXUn6j70HxK38IwapzmnYfiBiTuzETvGwjXHzZgzKjhoQ==
+
+"@openai/codex@0.128.0":
+  version "0.128.0"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0.tgz#c88babe2494b8f9308f8d4673cf1fcf17b12be79"
+  integrity sha512-+xp6ODmFfBNnexIWRHApEaPXot2j6gyM8A5we/5IS/uY4eYHj4arETct4hQ5M4eO+MK7JY3ZU4xhuobhlysr0A==
+  optionalDependencies:
+    "@openai/codex-darwin-arm64" "npm:@openai/codex@0.128.0-darwin-arm64"
+    "@openai/codex-darwin-x64" "npm:@openai/codex@0.128.0-darwin-x64"
+    "@openai/codex-linux-arm64" "npm:@openai/codex@0.128.0-linux-arm64"
+    "@openai/codex-linux-x64" "npm:@openai/codex@0.128.0-linux-x64"
+    "@openai/codex-win32-arm64" "npm:@openai/codex@0.128.0-win32-arm64"
+    "@openai/codex-win32-x64" "npm:@openai/codex@0.128.0-win32-x64"
+
 "@oxc-project/types@=0.127.0":
   version "0.127.0"
   resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.127.0.tgz#8374fcdfb4a641861218daa5700c447c00b66663"


### PR DESCRIPTION
## 摘要
- 新增基于 @openai/codex-sdk 内置 @openai/codex binary 的 codex-sdk executor
- 注册 --executor codex-sdk，并补充 Codex 运行时 construct validity 边界说明
- 复用 Codex CLI trace/usage 解析逻辑，保持 costReportedByExecutor=false
- 移除 README 中过时的 openai CLI executor 行

## 验证
- yarn typecheck
- yarn lint
- yarn test test/executors/codex-sdk.test.ts test/executors/codex-cli-isolation.test.ts test/executor.test.ts
- yarn test

## Smoke
- 开发过程中已手动真实运行 codex-sdk smoke，使用 Codex 默认模型成功完成一次 case