### PR TITLE
feat(eval-core): 增加 executor runtime 指纹

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!--
 Thanks for the contribution! Filling in each section helps reviewers understand the change quickly.
-See CONTRIBUTING.md for the branch model (Gitflow) and commit message convention (Chinese or English both fine).
+Before opening a PR, read CLAUDE.md plus CONTRIBUTING.md for the current branch model,
+commit-message convention, changelog policy, and validation requirements.
 -->
 
 ## Purpose
@@ -19,14 +20,17 @@ See CONTRIBUTING.md for the branch model (Gitflow) and commit message convention
 <!-- How did you verify this works? -->
 
 - [ ] `yarn lint` passes
-- [ ] `yarn test` passes (all 442+ tests)
+- [ ] `yarn build` passes
+- [ ] `yarn test` passes
 - [ ] Added / updated tests covering new behavior (or explained why none needed)
 - [ ] Manually exercised the feature end-to-end if it touches CLI / reports
 
 ## Checklist
 
+- [ ] Read `CLAUDE.md`
 - [ ] Branch is `feat/*`, `fix/*`, `docs/*`, `chore/*`, `release/*`, or `hotfix/*` (Gitflow)
-- [ ] Target branch is `develop` (for features/fixes) or `main` (only for release/hotfix merges)
+- [ ] Target branch follows the current branch strategy in `CLAUDE.md` / `CONTRIBUTING.md`
+- [ ] Commit message follows the repo convention (`type(scope): subject`)
 - [ ] `CHANGELOG.md` `[Unreleased]` section updated if this is user-visible
 - [ ] No secrets / internal URLs / personal data in the diff
 - [ ] README / docs updated if behavior or CLI surface changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 - **codex-cli executor**(`--executor codex`):接入 OpenAI Codex CLI 当被测 / 评委,跟 Claude Code 同类 agent CLI 对位。token 统计齐全,best-effort 抽 codex 事件流到 omk trace。skill isolation 仅 cwd 一条 channel(codex 没 SDK skill 等价物),`allowedSkills=[]` 强制 cwd 非空。EXECUTOR_REGISTRY 加 `'codex'` 跟 `'claude'` 对齐。详见 #31。
 - **codex-sdk executor**(`--executor codex-sdk`):接入 `@openai/codex-sdk` 自带的 `@openai/codex` binary 和 SDK 事件流,复用 codex trace / token 解析。cost 仍按 Codex runtime 能力标记为未报告。文档补充 `codex`(PATH binary) vs `codex-sdk`(bundled binary) 的 construct-validity 边界。详见 #36。
+- **executor runtime 指纹写入 report**:`meta.executorRuntime` / `meta.judgeRuntime` 记录 binary 或 SDK 版本、模型和能力快照(system prompt / cost / trace / isolation)。HTML 报告展示指纹,`bench diff` / `bench verdict` 在缺失或不一致时提示 strict comparability 风险。详见 #36。
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 ### Added
 
 - **codex-cli executor**(`--executor codex`):接入 OpenAI Codex CLI 当被测 / 评委,跟 Claude Code 同类 agent CLI 对位。token 统计齐全,best-effort 抽 codex 事件流到 omk trace。skill isolation 仅 cwd 一条 channel(codex 没 SDK skill 等价物),`allowedSkills=[]` 强制 cwd 非空。EXECUTOR_REGISTRY 加 `'codex'` 跟 `'claude'` 对齐。详见 #31。
+- **codex-sdk executor**(`--executor codex-sdk`):接入 `@openai/codex-sdk` 自带的 `@openai/codex` binary 和 SDK 事件流,复用 codex trace / token 解析。cost 仍按 Codex runtime 能力标记为未报告。文档补充 `codex`(PATH binary) vs `codex-sdk`(bundled binary) 的 construct-validity 边界。详见 #36。
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,43 +1,47 @@
-# CLAUDE.md — 协作者(包括 AI agent)入场必读
+# CLAUDE.md - Agent 入场清单
 
-omk 是 LLM 评测框架,主打**统计严谨性**(Bootstrap CI / Krippendorff α / Length-debias / Saturation curves)+ verdict / RAG / budget 决策面。两条底线:**测量学不变量不能动**,**分支操作走 gitflow**。
+omk 是 LLM 评测框架。所有改动都要优先保护测量可比性。
 
-## 开工前
+## 开工先做
 
-- 看 [CHANGELOG.md](./CHANGELOG.md) `[Unreleased]` 段了解在做什么版本
-- 改完跑 `yarn lint && yarn build && yarn test`
-- 分支模型 / 发版细节 / commit 风格全在 [CONTRIBUTING.md](./CONTRIBUTING.md)
+- 改代码前先看 `CHANGELOG.md` 的 `[Unreleased]`。
+- 涉及 commit、PR、分支或发版时，先看 `CONTRIBUTING.md`。
+- 交付前默认跑 `yarn lint && yarn build && yarn test`，除非用户明确要求只做更窄验证。
 
-## 分支策略
+## 硬规则
 
-严格 gitflow:`feat/* | fix/* | docs/* | chore/*` → `develop` → `main`(release)。
+- 遵守 `CONTRIBUTING.md` 的 Gitflow：普通 feature / fix / docs / chore PR 进 `develop`；release / hotfix 走专门路径。
+- 不要直接在 `main` 或 `develop` 上提交。
+- commit 格式：`type(scope): 中文 subject`。scope 用稳定模块名，如 `cli` / `i18n` / `judge` / `renderer` / `eval-core` / `eval-workflows` / `inputs` / `executors` / `server` / `analysis` / `authoring` / `grading` / `release` / `claude-md`。
+- 用户可见、发版相关或影响 construct validity 的改动，要更新 `CHANGELOG.md` `[Unreleased]`。
+- 不要在给用户看的 URL 里硬编码 report server 端口；使用 `server.start()` 返回的实际 URL。
 
-PR base **永远是 develop**,绝不在 main / develop 直接 commit。release PR merge 后必须 fast-forward `develop = main`,否则 develop 永远落后一个 merge commit。
+## 测量学不变量
 
-## 测量学不变量(绝对不能动)
+这些是跨版本报告可比性的锚点，不要静默修改：
 
-这些是历史报告可比性的锚,改动会破坏跨版本对比:
+- `src/types/report.ts` 里的 Report JSON schema 字段语义。
+- `test/grading/judge-hash-frozen.test.ts` 冻结的 judge prompt hash。
+- 五层评分管道语义：assertion / llm / judge / dimension / composite。
+- Bootstrap CI 和 Krippendorff alpha 公式。
+- Length-debias toggle 语义：`--no-debias-length` 与 prompt v2/v3 的对应关系。
 
-- **Report JSON schema**:`src/types/report.ts` 里 `Report` / `ReportMeta` / `VariantResult` / `VariantSummary` 字段含义
-- **Judge Prompt Hash**:`v2-cot=fdc81b19c721` / `v3-cot-length=629bf3b8c41d`,由 `test/grading/judge-hash-frozen.test.ts` 字节级冻结。动 `src/grading/judge.ts` 的 prompt 文本会立即 fail
-- **五层评分管道**:assertion / llm / judge / dimension / composite 的算法和权重
-- **Bootstrap CI 公式**(`src/eval-core/bootstrap.ts`)、**Krippendorff α 公式**(`src/grading/human-gold.ts`)
-- **Length-debias toggle**(`--no-debias-length` 与 prompt v2/v3 的对应关系)
+确实需要改不变量时，必须在 `CHANGELOG.md` 标明 BREAKING-COMPARABILITY，并按 `CONTRIBUTING.md` 的版本规则处理。
 
-确需 bump 见 CONTRIBUTING,核心动作是 bump `JUDGE_PROMPT_VERSION_DEBIAS_*` + CHANGELOG 标 breaking-comparability。**不要悄悄改**。
+## 写作规则
 
-## 写代码约定
+- CLI / 报告 UI / 错误信息等 user-facing 文案中文优先。
+- LLM judge 译为 `评委`，不要译为 `判官`。
+- CHANGELOG 每条保持克制：3-5 行，写用户影响、迁移说明、construct-validity 或测量学 caveat，并链接 PR。不要写行号、测试用例清单或嵌套实现细节。
 
-- **commit message 前缀英文 + 正文中文**:type 走 Conventional Commits 标准(`feat` / `fix` / `refactor` / `docs` / `chore` / `test` / `ci` / `perf` / `style` / `build`),scope 用**稳定的代码模块名**(`cli` / `i18n` / `judge` / `renderer` / `eval-core` / `eval-workflows` / `inputs` / `executors` / `server` / `analysis` / `authoring` / `grading` / `release` / `claude-md` 等),**不用 plan 阶段编号**(`D.1.c` / `Phase B.4` 这种本地维护者 plan 内部编号外部不可读、发版后失效、也无法跨版本 grep 聚合)。subject 用中文写。例:`feat(cli-i18n): 接通 --lang flag 和 OMK_LANG 环境变量` / `chore(release): bump 0.20.1 → 0.20.2` / `docs(claude-md): commit message 规则改为英文前缀`。不追溯改历史 commit
-- **user-facing 文案中文优先**(报告 UI / CLI / 错误信息)。LLM judge 译为「**评委**」,不译「判官」,不中英混用
-- **CI gate 两个**:`test/grading/judge-hash-frozen.test.ts`(judge prompt 不变性)、`test/__snapshots__/html-renderer.test.ts.snap`(zh/en × list/detail UI 回归)。改 UI / judge 后 review snapshot diff,确认无误再 `vitest -u`
-- **CHANGELOG 写作克制原则**(AI 协作时代):`[Unreleased]` 每条改动收敛 3-5 行,**链 PR # 让需要细节的人去看,不在这里复述 commit / PR description 已有的内容**。保留:user-facing 影响、BREAKING / migration 指引、测量学不变量 callout(judge prompt hash / cacheKey 版本 / construct validity)。删:代码路径行号(`shared.ts:131-149` 这种 — 文件行号会随其他 PR 偏移)、测试 case 列举(用户不关心)、技术实现 bullet 嵌套(那是 PR description 的事)。Keep a Changelog 分类沿用(Added / Changed / Fixed / Removed / Internal)
-- **不要硬编码端口**:report server 默认请求 7799 但实际 bound 端口取自 `server.start()` 返回值(7799 被占会切 7800+),所有给用户看的 URL 都用 `serverUrl` 实参
+## UI / Judge 改动
 
-## 发版
+- 改 judge prompt 文本前，先确认 `test/grading/judge-hash-frozen.test.ts` 的影响，不要随手更新 hash。
+- 改报告 UI 后，先 review `test/__snapshots__/html-renderer.test.ts.snap` diff，再决定是否更新 snapshot。
 
-push tag `v*` 触发 publish.yml 全自动:lint + build + test → `npm publish` → 从 CHANGELOG 抽对应 section 建 GitHub Release。维护者只 bump version + 改 CHANGELOG `[Unreleased]` → `[VERSION] - YYYY-MM-DD`。细节见 CONTRIBUTING。
+## 参考
 
-## 其他参考
-
-[README.md](./README.md) / [README.zh.md](./README.zh.md) 用户面文档,[SKILL.md](./SKILL.md) Claude Code skill 用法,[docs/](./docs/) 设计 spec(rag-metrics / knowledge-gap-signal / 等)。维护者本地 plan(不在仓库):`~/.claude/plans/iridescent-zooming-lynx.md`。
+- 用户文档：`README.md` / `README.zh.md`
+- Claude Code skill：`SKILL.md`
+- 设计 spec：`docs/`
+- 分支 / 发版 / 贡献细节：`CONTRIBUTING.md`

--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ The command writes `~/.oh-my-knowledge/analyses/<timestamp>-skill-health.json`. 
 
 API-direct executors support custom base URLs via env: `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`.
 
-Codex construct-validity note: `codex` uses the `codex` binary found on `PATH`; `codex-sdk` uses the bundled `@openai/codex` binary resolved by `@openai/codex-sdk`. Strict comparisons between the two require recording both runtime versions (`codex --version` and the locked npm versions). If they differ, treat results as a comparison of executor runtimes, not only of prompt/template behavior.
+Codex construct-validity note: `codex` uses the `codex` binary found on `PATH`; `codex-sdk` uses the bundled `@openai/codex` binary resolved by `@openai/codex-sdk`. Reports persist `meta.executorRuntime` / `meta.judgeRuntime` fingerprints (binary or SDK version + capability snapshot), and `bench diff` / `bench verdict` warn when strict comparability cannot be audited. If runtime fingerprints differ, treat results as a comparison of executor runtimes, not only of prompt/template behavior.
 
 ### Custom executor
 

--- a/README.md
+++ b/README.md
@@ -672,12 +672,14 @@ The command writes `~/.oh-my-knowledge/analyses/<timestamp>-skill-health.json`. 
 | `claude` | default | invokes `claude -p` via Claude CLI |
 | `claude-sdk` | structured output | uses Claude Agent SDK — no stdout parsing, avoids buffer truncation |
 | `codex` | OpenAI agent CLI | invokes `codex exec --json` (`@openai/codex` npm); best-effort tool trace; **costUSD not reported** (codex CLI does not emit USD; check usage externally) |
-| `openai` | cross-vendor comparison | invokes `openai api` CLI |
+| `codex-sdk` | OpenAI agent SDK | uses `@openai/codex-sdk` with its bundled `@openai/codex` binary and streamed SDK events; **costUSD not reported** |
 | `gemini` | cross-vendor comparison | invokes `gemini` CLI |
 | `anthropic-api` | no CLI needed | calls Anthropic HTTP API directly (needs `ANTHROPIC_API_KEY`) |
 | `openai-api` | no CLI needed | calls OpenAI HTTP API directly (needs `OPENAI_API_KEY`) |
 
 API-direct executors support custom base URLs via env: `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`.
+
+Codex construct-validity note: `codex` uses the `codex` binary found on `PATH`; `codex-sdk` uses the bundled `@openai/codex` binary resolved by `@openai/codex-sdk`. Strict comparisons between the two require recording both runtime versions (`codex --version` and the locked npm versions). If they differ, treat results as a comparison of executor runtimes, not only of prompt/template behavior.
 
 ### Custom executor
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -672,7 +672,7 @@ omk analyze ~/.claude/projects/my-project --kb /path/to/project
 
 API 直调执行器支持通过环境变量自定义 Base URL：`ANTHROPIC_BASE_URL`、`OPENAI_BASE_URL`。
 
-Codex construct-validity 说明：`codex` 使用 `PATH` 上找到的 `codex` binary；`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。两者严格横向比较时，需要记录两个 runtime 版本（`codex --version` 和 lockfile 中的 npm 版本）。如果版本不一致，结果应解释为 executor runtime 对比，而不只是 prompt/template 行为对比。
+Codex construct-validity 说明：`codex` 使用 `PATH` 上找到的 `codex` binary；`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。报告会持久化 `meta.executorRuntime` / `meta.judgeRuntime` 指纹（binary 或 SDK 版本 + 能力快照），`bench diff` / `bench verdict` 会在 strict comparability 无法审计时提示。如果 runtime 指纹不一致，结果应解释为 executor runtime 对比，而不只是 prompt/template 行为对比。
 
 ### 自定义执行器
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -665,12 +665,14 @@ omk analyze ~/.claude/projects/my-project --kb /path/to/project
 | `claude` | 默认 | 通过 `claude -p` 调用 Claude CLI |
 | `claude-sdk` | 结构化输出 | 通过 Claude Agent SDK 调用，无 stdout 解析，避免 buffer 截断 |
 | `codex` | OpenAI agent CLI | 通过 `codex exec --json` 调用,需本地装好登录的 codex(`@openai/codex`);best-effort tool trace,**costUSD 不报**(codex 自身不输出 USD,需外部账单核算) |
-| `openai` | 跨厂商对比 | 通过 `openai api` CLI 调用 |
+| `codex-sdk` | OpenAI agent SDK | 通过 `@openai/codex-sdk` 调用其自带的 `@openai/codex` binary 和 SDK 事件流;**costUSD 不报** |
 | `gemini` | 跨厂商对比 | 通过 `gemini` CLI 调用 |
 | `anthropic-api` | 无需 CLI | 直接调用 Anthropic HTTP API（需 `ANTHROPIC_API_KEY`） |
 | `openai-api` | 无需 CLI | 直接调用 OpenAI HTTP API（需 `OPENAI_API_KEY`） |
 
 API 直调执行器支持通过环境变量自定义 Base URL：`ANTHROPIC_BASE_URL`、`OPENAI_BASE_URL`。
+
+Codex construct-validity 说明：`codex` 使用 `PATH` 上找到的 `codex` binary；`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。两者严格横向比较时，需要记录两个 runtime 版本（`codex --version` 和 lockfile 中的 npm 版本）。如果版本不一致，结果应解释为 executor runtime 对比，而不只是 prompt/template 行为对比。
 
 ### 自定义执行器
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.89",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@openai/codex-sdk": "0.128.0",
     "ajv": "^8.18.0",
     "js-yaml": "^4.1.1",
     "simple-statistics": "^7.8.9"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -978,6 +978,10 @@ async function handleDiff(argv: string[]): Promise<void> {
     console.log(`  Git:  ${g1?.commitShort || '?'}${g1?.dirty ? '*' : ''} (${g1?.branch || '?'}) → ${g2?.commitShort || '?'}${g2?.dirty ? '*' : ''} (${g2?.branch || '?'})`);
   }
 
+  const { crossReportComparabilityWarnings, formatComparabilityWarnings } = await import('../eval-core/comparability.js');
+  const comparability = formatComparabilityWarnings(crossReportComparabilityWarnings(r1!, r2!), lang);
+  if (comparability) console.log(`\n${comparability}\n`);
+
   // Per-variant comparison
   const variants: string[] = [...new Set([...(r1!.meta?.variants || []), ...(r2!.meta?.variants || [])])];
   for (const v of variants) {
@@ -1435,6 +1439,9 @@ async function handleVerdict(argv: string[]): Promise<void> {
   }
 
   const { computeVerdict, formatVerdictText } = await import('../eval-core/verdict.js');
+  const { reportComparabilityWarnings, formatComparabilityWarnings } = await import('../eval-core/comparability.js');
+  const comparability = formatComparabilityWarnings(reportComparabilityWarnings(report!), lang);
+  if (comparability) process.stderr.write(`${comparability}\n`);
   const result = computeVerdict(report!, {
     gateThreshold: values.threshold != null ? Number(values.threshold) : undefined,
     triviallySmallDiff: values['trivial-diff'] != null ? Number(values['trivial-diff']) : undefined,

--- a/src/eval-core/comparability.ts
+++ b/src/eval-core/comparability.ts
@@ -1,0 +1,176 @@
+import type { Lang, Report, ExecutorRuntimeFingerprint } from '../types/index.js';
+
+export interface ComparabilityWarning {
+  code: string;
+  severity: 'warning';
+  zh: string;
+  en: string;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(stableStringify).join(',') + ']';
+  const entries = Object.keys(value as Record<string, unknown>).sort();
+  return '{' + entries.map((k) => JSON.stringify(k) + ':' + stableStringify((value as Record<string, unknown>)[k])).join(',') + '}';
+}
+
+function runtimeLabel(runtime: ExecutorRuntimeFingerprint | null | undefined): string {
+  if (!runtime) return 'missing';
+  const bits = [`${runtime.executor}:${runtime.model}`, `fp=${runtime.fingerprint}`];
+  if (runtime.binary?.version) bits.push(`binary=${runtime.binary.version}`);
+  if (runtime.sdk?.version) bits.push(`sdk=${runtime.sdk.version}`);
+  return bits.join(' ');
+}
+
+function push(warnings: ComparabilityWarning[], code: string, zh: string, en: string): void {
+  warnings.push({ code, severity: 'warning', zh, en });
+}
+
+function countSampleHashMismatches(a: Report, b: Report): { mismatched: number; missing: number; common: number } | null {
+  const ah = a.meta.sampleHashes;
+  const bh = b.meta.sampleHashes;
+  if (!ah || !bh) return null;
+  let mismatched = 0;
+  let missing = 0;
+  let common = 0;
+  const ids = new Set([...Object.keys(ah), ...Object.keys(bh)]);
+  for (const id of ids) {
+    if (ah[id] == null || bh[id] == null) {
+      missing++;
+      continue;
+    }
+    common++;
+    if (ah[id] !== bh[id]) mismatched++;
+  }
+  return { mismatched, missing, common };
+}
+
+export function reportComparabilityWarnings(report: Report): ComparabilityWarning[] {
+  const warnings: ComparabilityWarning[] = [];
+  if (!report.meta.executorRuntime) {
+    push(
+      warnings,
+      'executor_runtime_missing',
+      '报告缺少 executor runtime 指纹；无法审计 binary / SDK 版本，跨报告严格比较需谨慎。',
+      'Report is missing executor runtime fingerprint; binary / SDK versions cannot be audited for strict cross-report comparison.',
+    );
+  }
+  if (report.meta.judgeModel && !report.meta.judgeRuntime) {
+    push(
+      warnings,
+      'judge_runtime_missing',
+      '报告缺少评委 runtime 指纹；无法审计评委 executor 的 binary / SDK 版本。',
+      'Report is missing judge runtime fingerprint; judge executor binary / SDK versions cannot be audited.',
+    );
+  }
+  if (!report.meta.sampleHashes) {
+    push(
+      warnings,
+      'sample_hashes_missing',
+      '报告缺少用例指纹；无法确认不同 run 是否测的是同一组用例。',
+      'Report is missing sample fingerprints; runs cannot be verified to use the same test cases.',
+    );
+  }
+  if (!report.meta.skillIsolation) {
+    push(
+      warnings,
+      'skill_isolation_missing',
+      '报告缺少 skill isolation 快照；baseline 是否被 skill 污染不可审计。',
+      'Report is missing skill-isolation snapshot; baseline contamination cannot be audited.',
+    );
+  }
+  return warnings;
+}
+
+export function crossReportComparabilityWarnings(before: Report, after: Report): ComparabilityWarning[] {
+  const warnings: ComparabilityWarning[] = [];
+  const b = before.meta;
+  const a = after.meta;
+
+  if (b.model !== a.model) {
+    push(warnings, 'model_mismatch', `执行模型不同: ${b.model} → ${a.model}。`, `Execution model changed: ${b.model} → ${a.model}.`);
+  }
+  if (b.executor !== a.executor) {
+    push(warnings, 'executor_mismatch', `executor 不同: ${b.executor} → ${a.executor}。`, `Executor changed: ${b.executor} → ${a.executor}.`);
+  }
+  if (b.executorRuntime?.fingerprint && a.executorRuntime?.fingerprint) {
+    if (b.executorRuntime.fingerprint !== a.executorRuntime.fingerprint) {
+      push(
+        warnings,
+        'executor_runtime_mismatch',
+        `executor runtime 指纹不同: ${runtimeLabel(b.executorRuntime)} → ${runtimeLabel(a.executorRuntime)}。`,
+        `Executor runtime fingerprint changed: ${runtimeLabel(b.executorRuntime)} → ${runtimeLabel(a.executorRuntime)}.`,
+      );
+    }
+  } else {
+    push(
+      warnings,
+      'executor_runtime_missing',
+      '至少一份报告缺少 executor runtime 指纹；无法确认 binary / SDK 版本一致。',
+      'At least one report is missing executor runtime fingerprint; binary / SDK version parity cannot be verified.',
+    );
+  }
+
+  if ((b.judgeModel || a.judgeModel) && b.judgeModel !== a.judgeModel) {
+    push(warnings, 'judge_model_mismatch', `评委模型不同: ${b.judgeModel ?? 'none'} → ${a.judgeModel ?? 'none'}。`, `Judge model changed: ${b.judgeModel ?? 'none'} → ${a.judgeModel ?? 'none'}.`);
+  }
+  if (b.judgeRuntime?.fingerprint && a.judgeRuntime?.fingerprint) {
+    if (b.judgeRuntime.fingerprint !== a.judgeRuntime.fingerprint) {
+      push(
+        warnings,
+        'judge_runtime_mismatch',
+        `评委 runtime 指纹不同: ${runtimeLabel(b.judgeRuntime)} → ${runtimeLabel(a.judgeRuntime)}。`,
+        `Judge runtime fingerprint changed: ${runtimeLabel(b.judgeRuntime)} → ${runtimeLabel(a.judgeRuntime)}.`,
+      );
+    }
+  } else if (b.judgeModel || a.judgeModel) {
+    push(
+      warnings,
+      'judge_runtime_missing',
+      '至少一份报告缺少评委 runtime 指纹；无法确认评委 binary / SDK 版本一致。',
+      'At least one report is missing judge runtime fingerprint; judge binary / SDK version parity cannot be verified.',
+    );
+  }
+
+  if ((b.judgePromptHash || a.judgePromptHash) && b.judgePromptHash !== a.judgePromptHash) {
+    push(warnings, 'judge_prompt_hash_mismatch', `评委提示词指纹不同: ${b.judgePromptHash ?? 'missing'} → ${a.judgePromptHash ?? 'missing'}。`, `Judge prompt hash changed: ${b.judgePromptHash ?? 'missing'} → ${a.judgePromptHash ?? 'missing'}.`);
+  }
+  if ((b.evaluationFramework || a.evaluationFramework) && b.evaluationFramework !== a.evaluationFramework) {
+    push(warnings, 'evaluation_framework_mismatch', `统计框架不同: ${b.evaluationFramework ?? 'legacy'} → ${a.evaluationFramework ?? 'legacy'}。`, `Evaluation framework changed: ${b.evaluationFramework ?? 'legacy'} → ${a.evaluationFramework ?? 'legacy'}.`);
+  }
+  if (stableStringify(b.skillIsolation ?? null) !== stableStringify(a.skillIsolation ?? null)) {
+    push(
+      warnings,
+      'skill_isolation_mismatch',
+      'skill isolation 快照不同；baseline 污染边界不一致，严格比较需谨慎。',
+      'Skill-isolation snapshots differ; baseline contamination boundaries are not equivalent.',
+    );
+  }
+
+  const sampleHashDiff = countSampleHashMismatches(before, after);
+  if (!sampleHashDiff) {
+    push(
+      warnings,
+      'sample_hashes_missing',
+      '至少一份报告缺少用例指纹；无法确认两次 run 使用同一组用例。',
+      'At least one report is missing sample fingerprints; test-case parity cannot be verified.',
+    );
+  } else if (sampleHashDiff.mismatched > 0 || sampleHashDiff.missing > 0) {
+    push(
+      warnings,
+      'sample_hashes_mismatch',
+      `用例指纹不一致: ${sampleHashDiff.mismatched} 条内容变化，${sampleHashDiff.missing} 条只出现在其中一份报告。`,
+      `Sample fingerprints differ: ${sampleHashDiff.mismatched} content mismatches, ${sampleHashDiff.missing} samples only appear in one report.`,
+    );
+  }
+
+  return warnings;
+}
+
+export function formatComparabilityWarnings(warnings: ComparabilityWarning[], lang: Lang = 'zh'): string {
+  if (warnings.length === 0) return '';
+  const header = lang === 'zh'
+    ? '可比性提示: 以下差异会影响 strict comparison / construct validity'
+    : 'Comparability warnings: the following differences affect strict comparison / construct validity';
+  return [header, ...warnings.map((warning) => `  - ${lang === 'zh' ? warning.zh : warning.en}`)].join('\n');
+}

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -8,6 +8,7 @@ import { buildVariantSummary } from './schema.js';
 import { buildVariantConfig } from './execution-strategy.js';
 import { getJudgePromptHash } from '../grading/judge.js';
 import { bootstrapMeanCI, bootstrapDiffCI } from './bootstrap.js';
+import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
 import type {
   Artifact,
   Report,
@@ -174,6 +175,14 @@ export function aggregateReport({
   const judgeModelsList = request?.judgeModels && request.judgeModels.length >= 2
     ? request.judgeModels.map((jc) => `${jc.executor}:${jc.model}`)
     : undefined;
+  const effectiveJudgeExecutorName = request?.judgeExecutor || executorName;
+  const executorRuntime = getExecutorRuntimeFingerprint(executorName, model);
+  const judgeRuntime = noJudge ? null : getExecutorRuntimeFingerprint(effectiveJudgeExecutorName, judgeModel);
+  const judgeRuntimes = request?.judgeModels && request.judgeModels.length >= 2
+    ? Object.fromEntries(
+      request.judgeModels.map((jc) => [`${jc.executor}:${jc.model}`, getExecutorRuntimeFingerprint(jc.executor, jc.model)]),
+    )
+    : undefined;
   // v0.21 Phase 3a: length-debias is on by default; the request only sets it
   // false when the user passed --no-debias-length. The hash differs between
   // v3-cot-length (on) and v2-cot (off) so readers can detect the divergence.
@@ -197,6 +206,9 @@ export function aggregateReport({
       artifactHashes,
       sampleHashes,
       ...(noJudge ? {} : { judgePromptHash: getJudgePromptHash(lengthDebiasOn) }),
+      executorRuntime,
+      judgeRuntime,
+      ...(judgeRuntimes ? { judgeRuntimes } : {}),
       ...(judgeRepeat ? { judgeRepeat } : {}),
       ...(judgeModelsList ? { judgeModels: judgeModelsList } : {}),
       ...(debiasModeList.length > 0 ? { debiasMode: debiasModeList } : {}),

--- a/src/eval-workflows/each-evaluation-workflow.ts
+++ b/src/eval-workflows/each-evaluation-workflow.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import { DEFAULT_OUTPUT_DIR, generateRunId, persistReport } from '../eval-core/evaluation-reporting.js';
 import { buildEvaluationRequest, createEvaluationRun, createSucceededJob, finalizeEvaluationRun } from '../eval-core/evaluation-job.js';
+import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
 import { createFileJobStore, DEFAULT_JOBS_DIR } from '../server/job-store.js';
 import { resolveArtifacts } from '../inputs/skill-loader.js';
 import type { Artifact, JobStore, ProgressCallback, Report, VarianceData, VariantResult, VariantSummary } from '../types/index.js';
@@ -85,6 +86,7 @@ export function buildEachReport({
   timeoutMs,
   totalCostUSD,
   repeat,
+  judgeModels,
 }: {
   skillDir: string;
   skillEntries: Array<{ name: string; skillPath: string; samplesPath: string }>;
@@ -102,6 +104,7 @@ export function buildEachReport({
   timeoutMs?: number;
   totalCostUSD: number;
   repeat?: number;
+  judgeModels?: import('../types/index.js').JudgeConfig[];
 }) {
   const runId = generateRunId(['each']);
   const request = buildEvaluationRequest({
@@ -128,6 +131,7 @@ export function buildEachReport({
     owner,
     tags,
     repeat,
+    judgeModels,
     each: true,
   });
   const createdAt = new Date().toISOString();
@@ -163,6 +167,14 @@ export function buildEachReport({
         artifactHashes: Object.fromEntries(
           skillResults.map((skill) => [skill.name, skill.artifactHash || 'no-skill']),
         ),
+        executorRuntime: getExecutorRuntimeFingerprint(executorName, model),
+        judgeRuntime: noJudge ? null : getExecutorRuntimeFingerprint(judgeExecutorName || executorName, judgeModel),
+        ...(judgeModels && judgeModels.length >= 2 ? {
+          judgeModels: judgeModels.map((jc) => `${jc.executor}:${jc.model}`),
+          judgeRuntimes: Object.fromEntries(
+            judgeModels.map((jc) => [`${jc.executor}:${jc.model}`, getExecutorRuntimeFingerprint(jc.executor, jc.model)]),
+          ),
+        } : {}),
         request,
         run,
         job,
@@ -322,6 +334,7 @@ export async function executeEachEvaluationRuns({
     timeoutMs,
     totalCostUSD,
     repeat,
+    judgeModels,
   });
   const filePath = persistReport(combinedReport, outputDir);
   const resolvedJobStore = persistJob ? (jobStore ?? createFileJobStore(DEFAULT_JOBS_DIR)) : null;

--- a/src/executors/codex-cli.ts
+++ b/src/executors/codex-cli.ts
@@ -23,11 +23,11 @@ import {
 //   []                → 必须提供 cwd 非空(否则 throw),caller 应传一个
 //                       isolated 空目录(如 ~/.oh-my-knowledge/isolated-cwd/)
 //   [...] (length>0)  → throw,codex CLI 没有 partial 白名单 flag
-function isolateCodexCwd(allowedSkills: string[] | undefined, cwd: string | null | undefined): void {
+export function isolateCodexCwd(allowedSkills: string[] | undefined, cwd: string | null | undefined, executorName = 'codex-cli'): void {
   if (allowedSkills === undefined) return;
   if (allowedSkills.length > 0) {
     throw new Error(
-      `codex-cli executor 不支持 partial skill 白名单(allowedSkills=${JSON.stringify(allowedSkills)})。\n`
+      `${executorName} executor 不支持 partial skill 白名单(allowedSkills=${JSON.stringify(allowedSkills)})。\n`
       + `  仅支持 [](强制 cwd 隔离,需提供 cwd 非空)或 undefined(默认)。\n`
       + `  codex CLI 无 partial 白名单 flag,请改用其他 executor 或显式 cwd 隔离。`,
     );
@@ -35,7 +35,7 @@ function isolateCodexCwd(allowedSkills: string[] | undefined, cwd: string | null
   // allowedSkills === [] 时必须有 cwd(channel 3 cwd 隔离是 codex 唯一 channel)
   if (!cwd) {
     throw new Error(
-      'codex-cli executor allowedSkills=[] 需要提供 cwd 非空(channel 3 cwd 隔离)。\n'
+      `${executorName} executor allowedSkills=[] 需要提供 cwd 非空(channel 3 cwd 隔离)。\n`
       + '  codex 没有 SDK skill 自动发现 / subagent Skill 工具这两条 channel,\n'
       + '  cwd 文件系统隔离是它唯一能堵 AGENTS.md / .agents/skills/ 自动加载的途径。\n'
       + '  caller 应传一个 isolated 空目录(如 ~/.oh-my-knowledge/isolated-cwd/)。',
@@ -61,7 +61,7 @@ function parseCodexJsonl(stdout: string): CodexEvent[] {
   return events;
 }
 
-function extractCodexUsage(events: CodexEvent[]): { input: number; cached: number; output: number } {
+export function extractCodexUsage(events: CodexEvent[]): { input: number; cached: number; output: number } {
   let input = 0;
   let cached = 0;
   let output = 0;
@@ -91,7 +91,7 @@ export function extractCodexFinalOutput(events: CodexEvent[]): string {
   return allTexts.join('\n');
 }
 
-function extractCodexStopReason(events: CodexEvent[]): string {
+export function extractCodexStopReason(events: CodexEvent[]): string {
   const last = [...events].reverse().find((e) => isCodexResultEvent(e));
   if (!last) return 'unknown';
   if (last.type === 'turn.failed') return 'error';

--- a/src/executors/codex-sdk.ts
+++ b/src/executors/codex-sdk.ts
@@ -1,0 +1,192 @@
+import type { Codex, CodexOptions, ThreadEvent } from '@openai/codex-sdk';
+import type { ExecResult, ExecutorInput } from '../types/index.js';
+import { extractCodexTrace, isCodexResultEvent } from './codex-cli-trace.js';
+import type { CodexEvent } from './shared.js';
+import {
+  asErrorLike,
+  buildExecEnv,
+  DEFAULT_TIMEOUT_MS,
+  errorMessage,
+  timeoutExecResult,
+} from './shared.js';
+import {
+  extractCodexFinalOutput,
+  extractCodexStopReason,
+  extractCodexUsage,
+  isolateCodexCwd,
+  sumCodexElapsed,
+} from './codex-cli.js';
+
+type CodexSdkModule = typeof import('@openai/codex-sdk');
+
+let CodexCtor: CodexSdkModule['Codex'] | null = null;
+let hasWarnedSystem = false;
+let hasWarnedCost = false;
+
+async function getCodexCtor(): Promise<CodexSdkModule['Codex']> {
+  if (!CodexCtor) {
+    const sdk = await import('@openai/codex-sdk') as CodexSdkModule;
+    CodexCtor = sdk.Codex;
+  }
+  return CodexCtor;
+}
+
+export function buildCodexSdkThreadOptions({ model, cwd }: { model: string; cwd?: string | null }): {
+  model?: string;
+  sandboxMode: 'read-only';
+  workingDirectory?: string;
+  skipGitRepoCheck: true;
+  approvalPolicy: 'never';
+} {
+  return {
+    ...(model && { model }),
+    sandboxMode: 'read-only',
+    ...(cwd && { workingDirectory: cwd }),
+    skipGitRepoCheck: true,
+    approvalPolicy: 'never',
+  };
+}
+
+export function buildCodexSdkClientOptions(env: NodeJS.ProcessEnv): CodexOptions {
+  return {
+    // Leave codexPathOverride unset: the SDK should use its bundled @openai/codex
+    // binary, matching the SDK executor contract instead of delegating to PATH.
+    env: env as Record<string, string>,
+  };
+}
+
+export async function createCodexSdkClient(env: NodeJS.ProcessEnv): Promise<Codex> {
+  const CodexClient = await getCodexCtor();
+  return new CodexClient(buildCodexSdkClientOptions(env));
+}
+
+function normalizeSdkEvent(event: ThreadEvent): CodexEvent {
+  return event as CodexEvent;
+}
+
+export async function codexSdkExecutor({ model, system, prompt, cwd, skillDir, timeoutMs = DEFAULT_TIMEOUT_MS, allowedSkills, verbose }: ExecutorInput): Promise<ExecResult> {
+  isolateCodexCwd(allowedSkills, cwd, 'codex-sdk');
+
+  const finalPrompt = system ? `${system}\n\n---\n\n${prompt}` : prompt;
+  if (system && verbose && !hasWarnedSystem) {
+    process.stderr.write('[codex-sdk] system prompt prepended (codex CLI/SDK lacks a system-prompt option)\n');
+    hasWarnedSystem = true;
+  }
+  if (verbose && !hasWarnedCost) {
+    process.stderr.write('[codex-sdk] cost not reported by binary; costReportedByExecutor=false (renderer shows 「—」 instead of $0.0000)\n');
+    hasWarnedCost = true;
+  }
+
+  const env = buildExecEnv(skillDir);
+
+  const start = Date.now();
+  const abortController = new AbortController();
+  const timer = setTimeout(() => abortController.abort(), timeoutMs);
+  const events: CodexEvent[] = [];
+
+  try {
+    const codex = await createCodexSdkClient(env);
+    const thread = codex.startThread(buildCodexSdkThreadOptions({ model, cwd }));
+    const streamed = await thread.runStreamed(finalPrompt, { signal: abortController.signal });
+
+    for await (const event of streamed.events) {
+      events.push(normalizeSdkEvent(event));
+    }
+    clearTimeout(timer);
+
+    const durationMs = Date.now() - start;
+    const resultEvents = events.filter(isCodexResultEvent);
+    if (resultEvents.length === 0) {
+      return {
+        ok: false,
+        error: 'no turn.completed/turn.failed event in codex-sdk output',
+        durationMs,
+        durationApiMs: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        costUSD: 0,
+        costReportedByExecutor: false,
+        output: null,
+        stopReason: 'error',
+        numTurns: 0,
+      };
+    }
+
+    const last = resultEvents[resultEvents.length - 1];
+    const usage = extractCodexUsage(events);
+    const trace = extractCodexTrace(events);
+    const stopReason = extractCodexStopReason(events);
+    const finalOutput = extractCodexFinalOutput(events);
+    const ok = last.type !== 'turn.failed' && !last.error;
+
+    return {
+      ok,
+      durationMs: sumCodexElapsed(resultEvents, durationMs),
+      durationApiMs: 0,
+      inputTokens: usage.input,
+      outputTokens: usage.output,
+      cacheReadTokens: usage.cached,
+      cacheCreationTokens: 0,
+      costUSD: 0,
+      costReportedByExecutor: false,
+      output: finalOutput,
+      stopReason,
+      ...(!ok && { error: last.error?.message || 'codex-sdk turn.failed' }),
+      numTurns: resultEvents.length,
+      fullNumTurns: trace.fullNumTurns,
+      numSubAgents: trace.numSubAgents,
+      ...(trace.turns.length > 0 && { turns: trace.turns }),
+      ...(trace.toolCalls.length > 0 && { toolCalls: trace.toolCalls }),
+    };
+  } catch (err: unknown) {
+    clearTimeout(timer);
+    const durationMs = Date.now() - start;
+    const details = asErrorLike(err);
+    const isAbort = details.name === 'AbortError' || abortController.signal.aborted;
+    if (isAbort) return { ...timeoutExecResult(timeoutMs, durationMs), costReportedByExecutor: false };
+
+    const resultEvents = events.filter(isCodexResultEvent);
+    if (resultEvents.length > 0) {
+      const last = resultEvents[resultEvents.length - 1];
+      const usage = extractCodexUsage(events);
+      const trace = extractCodexTrace(events);
+      return {
+        ok: false,
+        error: last.error?.message || errorMessage(err),
+        durationMs: sumCodexElapsed(resultEvents, durationMs),
+        durationApiMs: 0,
+        inputTokens: usage.input,
+        outputTokens: usage.output,
+        cacheReadTokens: usage.cached,
+        cacheCreationTokens: 0,
+        costUSD: 0,
+        costReportedByExecutor: false,
+        output: extractCodexFinalOutput(events) || null,
+        stopReason: 'error',
+        numTurns: resultEvents.length,
+        fullNumTurns: trace.fullNumTurns,
+        numSubAgents: trace.numSubAgents,
+        ...(trace.turns.length > 0 && { turns: trace.turns }),
+        ...(trace.toolCalls.length > 0 && { toolCalls: trace.toolCalls }),
+      };
+    }
+
+    return {
+      ok: false,
+      error: errorMessage(err),
+      durationMs,
+      durationApiMs: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUSD: 0,
+      costReportedByExecutor: false,
+      output: null,
+      stopReason: 'error',
+      numTurns: 0,
+    };
+  }
+}

--- a/src/executors/index.ts
+++ b/src/executors/index.ts
@@ -4,6 +4,7 @@ import { claudeCliExecutor } from './claude-cli.js';
 import { claudeSdkExecutor } from './claude-sdk.js';
 import { extractAgentTrace } from './claude-sdk-trace.js';
 import { codexCliExecutor } from './codex-cli.js';
+import { codexSdkExecutor } from './codex-sdk.js';
 import { geminiExecutor } from './gemini.js';
 import { openAiApiExecutor } from './openai-api.js';
 import { createScriptExecutor } from './script.js';
@@ -16,6 +17,7 @@ const EXECUTOR_REGISTRY: Record<string, ExecutorFn> = {
   claude: claudeCliExecutor,
   'claude-sdk': claudeSdkExecutor,
   codex: codexCliExecutor,
+  'codex-sdk': codexSdkExecutor,
   gemini: geminiExecutor,
   'anthropic-api': anthropicApiExecutor,
   'openai-api': openAiApiExecutor,

--- a/src/executors/runtime-fingerprint.ts
+++ b/src/executors/runtime-fingerprint.ts
@@ -1,0 +1,230 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type {
+  ExecutorRuntimeBinary,
+  ExecutorRuntimeCapabilities,
+  ExecutorRuntimeFingerprint,
+  ExecutorRuntimeKind,
+  ExecutorRuntimePackage,
+} from '../types/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const RUNTIME_CACHE = new Map<string, ExecutorRuntimeFingerprint>();
+
+const UNKNOWN_CAPABILITIES: ExecutorRuntimeCapabilities = {
+  systemPrompt: 'unknown',
+  costUSD: 'unknown',
+  trace: 'unknown',
+  skillIsolation: 'unknown',
+};
+
+function hashString(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function canonicalStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalStringify).join(',') + ']';
+  const entries = Object.keys(value as Record<string, unknown>).sort();
+  return '{' + entries.map((k) => JSON.stringify(k) + ':' + canonicalStringify((value as Record<string, unknown>)[k])).join(',') + '}';
+}
+
+function packagePathSegments(packageName: string): string[] {
+  return packageName.split('/');
+}
+
+function findInstalledPackageJson(packageName: string): string | null {
+  const parts = packagePathSegments(packageName);
+  let dir = __dirname;
+  for (let i = 0; i < 10; i++) {
+    const candidate = join(dir, 'node_modules', ...parts, 'package.json');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function readPackage(packageName: string): ExecutorRuntimePackage {
+  const packageJson = findInstalledPackageJson(packageName);
+  if (!packageJson) {
+    return { name: packageName, error: 'package.json not found' };
+  }
+  try {
+    const pkg = JSON.parse(readFileSync(packageJson, 'utf-8')) as { version?: string };
+    return { name: packageName, ...(pkg.version ? { version: pkg.version } : {}) };
+  } catch (err) {
+    return { name: packageName, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function readPackageField<T = unknown>(packageName: string, field: string): T | undefined {
+  const packageJson = findInstalledPackageJson(packageName);
+  if (!packageJson) return undefined;
+  try {
+    const pkg = JSON.parse(readFileSync(packageJson, 'utf-8')) as Record<string, unknown>;
+    return pkg[field] as T | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readCommand(command: string, args: string[], timeout = 1000): { output?: string; error?: string } {
+  try {
+    const output = execFileSync(command, args, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout,
+    }).trim();
+    return { output };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function readPathBinary(command: string): ExecutorRuntimeBinary {
+  const version = readCommand(command, ['--version']);
+  const path = readCommand('which', [command]);
+  return {
+    name: command,
+    source: 'path',
+    ...(version.output ? { version: version.output.split('\n')[0].trim() } : {}),
+    ...(path.output ? { path: path.output.split('\n')[0].trim() } : {}),
+    ...(!version.output && version.error ? { error: version.error } : {}),
+  };
+}
+
+function withFingerprint(input: Omit<ExecutorRuntimeFingerprint, 'fingerprint'>): ExecutorRuntimeFingerprint {
+  const stablePayload = {
+    executor: input.executor,
+    model: input.model,
+    kind: input.kind,
+    binary: input.binary
+      ? {
+        name: input.binary.name,
+        source: input.binary.source,
+        version: input.binary.version,
+        package: input.binary.package
+          ? { name: input.binary.package.name, version: input.binary.package.version }
+          : undefined,
+      }
+      : undefined,
+    sdk: input.sdk ? { name: input.sdk.name, version: input.sdk.version } : undefined,
+    capabilities: input.capabilities,
+  };
+  return { ...input, fingerprint: hashString(canonicalStringify(stablePayload)) };
+}
+
+function runtime(
+  executor: string,
+  model: string,
+  kind: ExecutorRuntimeKind,
+  capabilities: ExecutorRuntimeCapabilities,
+  extra: Pick<ExecutorRuntimeFingerprint, 'binary' | 'sdk'> = {},
+): ExecutorRuntimeFingerprint {
+  return withFingerprint({
+    executor,
+    model,
+    kind,
+    capabilities,
+    ...extra,
+  });
+}
+
+export function getExecutorRuntimeFingerprint(executorName: string, model: string): ExecutorRuntimeFingerprint {
+  const cacheKey = `${executorName}\0${model}`;
+  const cached = RUNTIME_CACHE.get(cacheKey);
+  if (cached) return cached;
+
+  let fp: ExecutorRuntimeFingerprint;
+  switch (executorName) {
+    case 'claude': {
+      fp = runtime(executorName, model, 'agent-cli', {
+        systemPrompt: 'native',
+        costUSD: 'reported',
+        trace: 'native',
+        skillIsolation: 'full-no-partial',
+      }, { binary: readPathBinary('claude') });
+      break;
+    }
+    case 'claude-sdk': {
+      const sdk = readPackage('@anthropic-ai/claude-agent-sdk');
+      const claudeCodeVersion = readPackageField<string>('@anthropic-ai/claude-agent-sdk', 'claudeCodeVersion');
+      fp = runtime(executorName, model, 'agent-sdk', {
+        systemPrompt: 'native',
+        costUSD: 'reported',
+        trace: 'native',
+        skillIsolation: 'full',
+      }, {
+        sdk,
+        binary: {
+          name: 'claude-code',
+          source: 'bundled',
+          ...(claudeCodeVersion ? { version: claudeCodeVersion } : {}),
+          package: sdk,
+        },
+      });
+      break;
+    }
+    case 'codex': {
+      fp = runtime(executorName, model, 'agent-cli', {
+        systemPrompt: 'prepended',
+        costUSD: 'not-reported',
+        trace: 'best-effort',
+        skillIsolation: 'cwd-only',
+      }, { binary: readPathBinary('codex') });
+      break;
+    }
+    case 'codex-sdk': {
+      const sdk = readPackage('@openai/codex-sdk');
+      const bundledCodex = readPackage('@openai/codex');
+      fp = runtime(executorName, model, 'agent-sdk', {
+        systemPrompt: 'prepended',
+        costUSD: 'not-reported',
+        trace: 'best-effort',
+        skillIsolation: 'cwd-only',
+      }, {
+        sdk,
+        binary: {
+          name: 'codex',
+          source: 'bundled',
+          ...(bundledCodex.version ? { version: bundledCodex.version } : {}),
+          package: bundledCodex,
+        },
+      });
+      break;
+    }
+    case 'gemini': {
+      fp = runtime(executorName, model, 'agent-cli', {
+        systemPrompt: 'prepended',
+        costUSD: 'not-reported',
+        trace: 'none',
+        skillIsolation: 'none',
+      }, { binary: readPathBinary('gemini') });
+      break;
+    }
+    case 'anthropic-api':
+    case 'openai-api': {
+      fp = runtime(executorName, model, 'api', {
+        systemPrompt: 'native',
+        costUSD: 'not-reported',
+        trace: 'none',
+        skillIsolation: 'none',
+      }, { binary: { name: executorName, source: 'none' } });
+      break;
+    }
+    default: {
+      fp = runtime(executorName, model, executorName.includes(' ') ? 'script' : 'unknown', UNKNOWN_CAPABILITIES, {
+        binary: { name: executorName, source: 'unknown' },
+      });
+    }
+  }
+
+  RUNTIME_CACHE.set(cacheKey, fp);
+  return fp;
+}

--- a/src/executors/shared.ts
+++ b/src/executors/shared.ts
@@ -117,6 +117,7 @@ export interface CodexEvent {
     input_tokens?: number;
     cached_input_tokens?: number;
     output_tokens?: number;
+    reasoning_output_tokens?: number;
   };
   elapsed_ms?: number;
   stop_reason?: string;
@@ -134,6 +135,12 @@ export interface CodexEvent {
     content?: string;
     query?: string;
     results?: unknown[];
+    changes?: Array<{ path?: string; kind?: string }>;
+    server?: string;
+    tool?: string;
+    arguments?: unknown;
+    result?: unknown;
+    message?: string;
   };
   error?: { message?: string };
   ts?: number;

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -19,7 +19,7 @@ import {
 import { renderSampleTable } from './table.js';
 import { renderTrendsBody } from './trends.js';
 import { computeVerdict, type VerdictLevel } from '../eval-core/verdict.js';
-import type { Report, Lang } from '../types/index.js';
+import type { ExecutorRuntimeFingerprint, Report, Lang } from '../types/index.js';
 
 // v0.21 B.4 — 列表页 status pill 用的 dot. PROGRESS/REGRESS 实心(强信号),
 // CAUTIOUS 三角(警示),NOISE 空心圆(有信号但无效果),UNDERPOWERED 部分填充
@@ -38,6 +38,34 @@ function levelDot(level: VerdictLevel): string {
 type EachOverview = NonNullable<Report['overview']>;
 type EachOverviewArtifact = EachOverview['artifacts'][number];
 type EachArtifactReport = NonNullable<Report['artifacts']>[number];
+
+function renderRuntimeTag(runtime: ExecutorRuntimeFingerprint | null | undefined, label: string, lang: Lang): string {
+  if (!runtime) return '';
+  const versions: string[] = [];
+  if (runtime.binary?.version) versions.push(`binary ${runtime.binary.version}`);
+  if (runtime.sdk?.version) versions.push(`sdk ${runtime.sdk.version}`);
+  const versionText = versions.length > 0 ? ` · ${versions.map(e).join(' · ')}` : '';
+  const title = lang === 'zh'
+    ? [
+      `executor=${runtime.executor}`,
+      `model=${runtime.model}`,
+      `kind=${runtime.kind}`,
+      `system=${runtime.capabilities.systemPrompt}`,
+      `cost=${runtime.capabilities.costUSD}`,
+      `trace=${runtime.capabilities.trace}`,
+      `skillIsolation=${runtime.capabilities.skillIsolation}`,
+    ].join('; ')
+    : [
+      `executor=${runtime.executor}`,
+      `model=${runtime.model}`,
+      `kind=${runtime.kind}`,
+      `system=${runtime.capabilities.systemPrompt}`,
+      `cost=${runtime.capabilities.costUSD}`,
+      `trace=${runtime.capabilities.trace}`,
+      `skillIsolation=${runtime.capabilities.skillIsolation}`,
+    ].join('; ');
+  return `<span class="meta-tag" title="${e(title)}">${e(label)}: <code>${e(runtime.fingerprint)}</code>${versionText}</span>`;
+}
 
 export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string {
   const langQ = lang === DEFAULT_LANG ? '' : `?lang=${lang}`;
@@ -328,7 +356,7 @@ export function renderRunDetail(report: Report | null, lang: Lang = DEFAULT_LANG
       <span class="meta-tag"${execCostReported ? '' : ` title="${e(lang === 'zh' ? 'executor 不报 USD 成本(如 codex CLI),无法估算' : 'executor does not report USD cost (e.g. codex CLI); not measurable')}"`}>${t('cost', lang)}: ${fmtCost(totalExecCost, execCostReported)}</span>
       <span class="meta-tag">${lang === 'zh' ? '耗时' : 'duration'}: ${fmtDuration(totalDurationMs)}</span>
       ${m.gitInfo ? `<span class="meta-tag">commit: ${e(m.gitInfo.commitShort)}${m.gitInfo.dirty ? '*' : ''} (${e(m.gitInfo.branch)})</span>` : ''}
-      ${m.judgePromptHash ? `<span class="meta-tag" title="${t('judgePromptHashDesc', lang)}">${t('judgePromptHashLabel', lang)}: <code>${e(m.judgePromptHash)}</code></span>` : ''}
+      ${m.judgePromptHash ? `<span class="meta-tag" title="${t('judgePromptHashDesc', lang)}">${t('judgePromptHashLabel', lang)}: <code>${e(m.judgePromptHash)}</code></span>` : ''}${renderRuntimeTag(m.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang)}${renderRuntimeTag(m.judgeRuntime, lang === 'zh' ? '评委指纹' : 'Judge runtime', lang)}
       ${m.sampleHashes ? `<span class="meta-tag" style="color:var(--text-muted)" title="${t('sampleHashCountDesc', lang)}">${t('sampleHashCount', lang)}: ${Object.keys(m.sampleHashes).length}/${m.sampleCount}</span>` : ''}
       ${m.evaluationFramework ? `<span class="meta-tag" title="${t('evalFrameworkDesc', lang)}">${t('evalFrameworkLabel', lang)}: ${m.evaluationFramework === 'bootstrap' ? t('evalFrameworkBootstrap', lang) : m.evaluationFramework === 'both' ? t('evalFrameworkBoth', lang) : t('evalFrameworkTTest', lang)}</span>` : ''}
       ${m.debiasMode && m.debiasMode.length > 0 ? `<span class="meta-tag" style="color:var(--green)" title="${lang === 'zh' ? 'judge bias 校正模式 (Phase 3)：length=substance-not-length 提示;position=ensemble 顺序随机化' : 'Judge bias debias modes (Phase 3): length = substance-not-length prompt; position = randomized ensemble order'}">${lang === 'zh' ? '校正' : 'debias'}: ${m.debiasMode.join(' · ')}</span>` : ''}
@@ -438,6 +466,7 @@ export function renderEachRunDetail(report: Report | null, lang: Lang = DEFAULT_
       <span class="meta-tag">${t('model', lang)}: ${e(m.model)}</span>
       <span class="meta-tag">${t('judge', lang)}: ${e(m.judgeModel || 'none')}</span>
       <span class="meta-tag">${t('executor', lang)}: ${e(m.executor || 'claude')}</span>
+      ${renderRuntimeTag(m.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang)}${renderRuntimeTag(m.judgeRuntime, lang === 'zh' ? '评委指纹' : 'Judge runtime', lang)}
       <span class="meta-tag"${eachAllCostReported ? '' : ` title="${e(lang === 'zh' ? 'executor 不报 USD 成本(如 codex CLI),无法估算' : 'executor does not report USD cost (e.g. codex CLI); not measurable')}"`}>${t('cost', lang)}: ${fmtCost(m.totalCostUSD, eachAllCostReported)}</span>
     </div>
 

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -168,6 +168,48 @@ export interface ReportHumanAgreement {
   unscoredCount: number;
 }
 
+export type ExecutorRuntimeKind = 'agent-cli' | 'agent-sdk' | 'api' | 'script' | 'unknown';
+
+export type ExecutorSystemPromptMode = 'native' | 'prepended' | 'none' | 'unknown';
+
+export type ExecutorCostMode = 'reported' | 'not-reported' | 'unknown';
+
+export type ExecutorTraceMode = 'native' | 'best-effort' | 'none' | 'unknown';
+
+export type ExecutorSkillIsolationMode = 'full' | 'full-no-partial' | 'cwd-only' | 'none' | 'unknown';
+
+export interface ExecutorRuntimeCapabilities {
+  systemPrompt: ExecutorSystemPromptMode;
+  costUSD: ExecutorCostMode;
+  trace: ExecutorTraceMode;
+  skillIsolation: ExecutorSkillIsolationMode;
+}
+
+export interface ExecutorRuntimePackage {
+  name: string;
+  version?: string;
+  error?: string;
+}
+
+export interface ExecutorRuntimeBinary {
+  name: string;
+  source: 'path' | 'bundled' | 'none' | 'unknown';
+  version?: string;
+  path?: string;
+  package?: ExecutorRuntimePackage;
+  error?: string;
+}
+
+export interface ExecutorRuntimeFingerprint {
+  executor: string;
+  model: string;
+  kind: ExecutorRuntimeKind;
+  fingerprint: string;
+  binary?: ExecutorRuntimeBinary;
+  sdk?: ExecutorRuntimePackage;
+  capabilities: ExecutorRuntimeCapabilities;
+}
+
 export interface ReportMeta {
   variants: string[];
   model: string;
@@ -188,6 +230,14 @@ export interface ReportMeta {
   sampleHashes?: Record<string, string>;
   /** SHA256-12 of the LLM judge prompt template. Different hash = judge changed semantics. */
   judgePromptHash?: string;
+  /** Runtime fingerprint for the executor that produced tested outputs.
+   *  Captures binary / SDK package versions and capability caveats that affect
+   *  construct validity. Missing means legacy report; compare with caution. */
+  executorRuntime?: ExecutorRuntimeFingerprint;
+  /** Runtime fingerprint for the default judge executor, or null when no judge ran. */
+  judgeRuntime?: ExecutorRuntimeFingerprint | null;
+  /** Runtime fingerprints for multi-judge ensemble members, keyed by "executor:model". */
+  judgeRuntimes?: Record<string, ExecutorRuntimeFingerprint>;
   /** Number of times each sample was judged. 1 = single judge (default). */
   judgeRepeat?: number;
   /** Multi-judge ensemble configuration: ["claude:opus", "openai:gpt-4o", ...].

--- a/test/eval-core/comparability.test.ts
+++ b/test/eval-core/comparability.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  crossReportComparabilityWarnings,
+  formatComparabilityWarnings,
+  reportComparabilityWarnings,
+} from '../../src/eval-core/comparability.js';
+import type { ExecutorRuntimeFingerprint, Report } from '../../src/types/index.js';
+
+function runtime(executor: string, model: string, fingerprint: string): ExecutorRuntimeFingerprint {
+  return {
+    executor,
+    model,
+    kind: 'agent-sdk',
+    fingerprint,
+    binary: { name: executor, source: 'bundled', version: '1.0.0' },
+    sdk: { name: `${executor}-sdk`, version: '1.0.0' },
+    capabilities: {
+      systemPrompt: 'native',
+      costUSD: 'reported',
+      trace: 'native',
+      skillIsolation: 'full',
+    },
+  };
+}
+
+function report(overrides: Partial<Report['meta']> = {}): Report {
+  return {
+    id: 'r',
+    meta: {
+      variants: ['control', 'treatment'],
+      model: 'm',
+      judgeModel: 'j',
+      executor: 'claude-sdk',
+      sampleCount: 2,
+      taskCount: 4,
+      totalCostUSD: 0,
+      timestamp: '2026-05-01T00:00:00.000Z',
+      cliVersion: '0.23.0',
+      nodeVersion: 'v20.0.0',
+      artifactHashes: { control: 'a', treatment: 'b' },
+      sampleHashes: { s1: 'aaa111aaa111', s2: 'bbb222bbb222' },
+      judgePromptHash: 'judge1111111',
+      executorRuntime: runtime('claude-sdk', 'm', 'exec11111111'),
+      judgeRuntime: runtime('claude-sdk', 'j', 'judge111111'),
+      skillIsolation: { control: [], treatment: null },
+      ...overrides,
+    },
+    summary: {},
+    results: [],
+  };
+}
+
+describe('comparability warnings', () => {
+  it('single-report audit warns when runtime metadata is missing', () => {
+    const warnings = reportComparabilityWarnings(report({ executorRuntime: undefined }));
+    assert.ok(warnings.some((w) => w.code === 'executor_runtime_missing'));
+  });
+
+  it('cross-report audit detects runtime, judge prompt, sample, and isolation mismatch', () => {
+    const before = report();
+    const after = report({
+      executorRuntime: runtime('codex-sdk', 'm', 'exec22222222'),
+      judgePromptHash: 'judge2222222',
+      sampleHashes: { s1: 'changed11111', s3: 'ccc333ccc333' },
+      skillIsolation: { control: null, treatment: null },
+    });
+
+    const codes = crossReportComparabilityWarnings(before, after).map((w) => w.code);
+    assert.ok(codes.includes('executor_runtime_mismatch'));
+    assert.ok(codes.includes('judge_prompt_hash_mismatch'));
+    assert.ok(codes.includes('sample_hashes_mismatch'));
+    assert.ok(codes.includes('skill_isolation_mismatch'));
+  });
+
+  it('formats warnings in Chinese', () => {
+    const text = formatComparabilityWarnings(crossReportComparabilityWarnings(report(), report({ model: 'm2' })), 'zh');
+    assert.match(text, /可比性提示/);
+    assert.match(text, /执行模型不同/);
+  });
+});

--- a/test/evaluation/evaluation-reporting.test.ts
+++ b/test/evaluation/evaluation-reporting.test.ts
@@ -64,6 +64,26 @@ describe('aggregateReport — reproducibility metadata', () => {
     assert.match(report.meta.judgePromptHash!, /^[0-9a-f]{12}$/);
   });
 
+  it('writes executor runtime fingerprint', () => {
+    const report = aggregateReport({ ...baseOpts, executorName: 'codex-sdk', model: 'gpt-5', noJudge: true });
+    assert.equal(report.meta.executorRuntime?.executor, 'codex-sdk');
+    assert.equal(report.meta.executorRuntime?.model, 'gpt-5');
+    assert.equal(report.meta.executorRuntime?.kind, 'agent-sdk');
+    assert.match(report.meta.executorRuntime!.fingerprint, /^[0-9a-f]{12}$/);
+    assert.equal(report.meta.executorRuntime?.sdk?.name, '@openai/codex-sdk');
+    assert.equal(report.meta.executorRuntime?.binary?.source, 'bundled');
+    assert.equal(report.meta.executorRuntime?.binary?.package?.name, '@openai/codex');
+    assert.equal(report.meta.executorRuntime?.capabilities.costUSD, 'not-reported');
+    assert.equal(report.meta.judgeRuntime, null);
+  });
+
+  it('writes judge runtime fingerprint when judge runs', () => {
+    const report = aggregateReport(baseOpts);
+    assert.equal(report.meta.judgeRuntime?.executor, 'claude');
+    assert.equal(report.meta.judgeRuntime?.model, 'haiku');
+    assert.match(report.meta.judgeRuntime!.fingerprint, /^[0-9a-f]{12}$/);
+  });
+
   it('omits judgePromptHash when noJudge=true (no judge ran)', () => {
     const report = aggregateReport({ ...baseOpts, noJudge: true });
     assert.equal(report.meta.judgePromptHash, undefined);

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -13,6 +13,11 @@ describe('createExecutor', () => {
     assert.equal(typeof exec, 'function');
   });
 
+  it('returns a function for codex-sdk', () => {
+    const exec = createExecutor('codex-sdk');
+    assert.equal(typeof exec, 'function');
+  });
+
   it('returns a function for gemini', () => {
     const exec = createExecutor('gemini');
     assert.equal(typeof exec, 'function');

--- a/test/executors/codex-sdk.test.ts
+++ b/test/executors/codex-sdk.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { buildCodexSdkClientOptions, buildCodexSdkThreadOptions, codexSdkExecutor } from '../../src/executors/codex-sdk.js';
+
+describe('codex-sdk executor parity contract', () => {
+  it('uses the same eval-critical thread options as codex CLI executor', () => {
+    const opts = buildCodexSdkThreadOptions({ model: 'gpt-5-codex', cwd: '/tmp/iso' });
+    assert.equal(opts.model, 'gpt-5-codex');
+    assert.equal(opts.workingDirectory, '/tmp/iso');
+    assert.equal(opts.sandboxMode, 'read-only');
+    assert.equal(opts.skipGitRepoCheck, true);
+    assert.equal(opts.approvalPolicy, 'never');
+  });
+
+  it('omits workingDirectory when cwd is unset, matching codex CLI no -C behavior', () => {
+    const opts = buildCodexSdkThreadOptions({ model: 'gpt-5-codex', cwd: null });
+    assert.equal('workingDirectory' in opts, false);
+  });
+
+  it('uses the SDK bundled binary by leaving codexPathOverride unset', () => {
+    const opts = buildCodexSdkClientOptions({ PATH: '/bin' });
+    assert.equal('codexPathOverride' in opts, false);
+    assert.deepEqual(opts.env, { PATH: '/bin' });
+  });
+
+  it('partial allowedSkills still throws because codex has no skill whitelist flag', async () => {
+    await assert.rejects(
+      () => codexSdkExecutor({
+        model: 'gpt-5-codex',
+        prompt: 'hello',
+        cwd: '/tmp/iso',
+        allowedSkills: ['one'],
+      }),
+      /partial skill 白名单|codex-sdk executor/,
+    );
+  });
+
+  it('strict isolation [] without cwd still throws before invoking SDK', async () => {
+    await assert.rejects(
+      () => codexSdkExecutor({
+        model: 'gpt-5-codex',
+        prompt: 'hello',
+        cwd: undefined,
+        allowedSkills: [],
+      }),
+      /channel 3 cwd 隔离|cwd 非空/,
+    );
+  });
+});

--- a/test/html-renderer.test.ts
+++ b/test/html-renderer.test.ts
@@ -308,6 +308,34 @@ describe('renderRunDetail', () => {
     assert.ok(html.includes('质量'));
   });
 
+  it('renders executor runtime fingerprint meta tags', () => {
+    const runtimeReport = JSON.parse(JSON.stringify(SAMPLE_REPORT)) as Report;
+    runtimeReport.meta.executorRuntime = {
+      executor: 'codex-sdk',
+      model: 'gpt-5',
+      kind: 'agent-sdk',
+      fingerprint: 'abc123def456',
+      binary: { name: 'codex', source: 'bundled', version: '0.128.0' },
+      sdk: { name: '@openai/codex-sdk', version: '0.128.0' },
+      capabilities: { systemPrompt: 'prepended', costUSD: 'not-reported', trace: 'best-effort', skillIsolation: 'cwd-only' },
+    };
+    runtimeReport.meta.judgeRuntime = {
+      executor: 'claude-sdk',
+      model: 'haiku',
+      kind: 'agent-sdk',
+      fingerprint: 'def456abc123',
+      binary: { name: 'claude-code', source: 'bundled', version: '2.1.118' },
+      sdk: { name: '@anthropic-ai/claude-agent-sdk', version: '0.2.118' },
+      capabilities: { systemPrompt: 'native', costUSD: 'reported', trace: 'native', skillIsolation: 'full' },
+    };
+    const html = renderRunDetail(runtimeReport);
+    assert.ok(html.includes('执行器指纹'));
+    assert.ok(html.includes('abc123def456'));
+    assert.ok(html.includes('binary 0.128.0'));
+    assert.ok(html.includes('评委指纹'));
+    assert.ok(html.includes('def456abc123'));
+  });
+
   it('renders multi-judge ensemble agreement when summary has judgeAgreement', () => {
     const ensembleReport = JSON.parse(JSON.stringify(SAMPLE_REPORT));
     ensembleReport.meta.judgeModels = ['claude:opus', 'openai:gpt-4o'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,6 +212,55 @@
   dependencies:
     "@tybys/wasm-util" "^0.10.1"
 
+"@openai/codex-darwin-arm64@npm:@openai/codex@0.128.0-darwin-arm64":
+  version "0.128.0-darwin-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-darwin-arm64.tgz#3a0ce51b2661cb6f7edb9fe621176a166216fbc5"
+  integrity sha512-w+6zohfHx/kHBdles/CyFKaY57u9I3nK8QI9+NrdwMliKA0b7xn13yblRNkMpe09j6vL1oAWoxYsMOQ/vjBGug==
+
+"@openai/codex-darwin-x64@npm:@openai/codex@0.128.0-darwin-x64":
+  version "0.128.0-darwin-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-darwin-x64.tgz#2f6c3f96abdd56162f7e1b92b5deb2af01761100"
+  integrity sha512-SDbn6fO22Puy8xmMIbZi4f2znMrUEPwABApke4mo+4ihaauwuVjeqzXvW5SPJz5ty/bG11/mSupQgReT7T8BBw==
+
+"@openai/codex-linux-arm64@npm:@openai/codex@0.128.0-linux-arm64":
+  version "0.128.0-linux-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-linux-arm64.tgz#f9bae67cd7755eb48e152ed25e566ec7825432dc"
+  integrity sha512-+SvH73H60qvCXFuQGP/EsmR//s1hHMBR22PvJkXvM/hdnTIGucx+JqRUjAWdmmQ1IU6j3kgwVvdLW/6ICB+M6w==
+
+"@openai/codex-linux-x64@npm:@openai/codex@0.128.0-linux-x64":
+  version "0.128.0-linux-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-linux-x64.tgz#5346a4166e97b04330ac1c3b86ee0dd44e0f059b"
+  integrity sha512-2lnSPA05CRRuKAzFW8BCmmNCSieDcToLwfC2ALLbBYilGLgzhRibjlDglK9F1BkEzfohSSWJu4PBbRu/aG60lQ==
+
+"@openai/codex-sdk@0.128.0":
+  version "0.128.0"
+  resolved "https://registry.yarnpkg.com/@openai/codex-sdk/-/codex-sdk-0.128.0.tgz#105a80ba7c0623990da247f791abe3c215265b2a"
+  integrity sha512-Eao0LLA5x90qwU6SXYd21h4KxdCef1WpCvHFgKdbqzWMJ79lUvguGDGvx1RheP+zTdKGxJfJ6dulI5wSXoUBhQ==
+  dependencies:
+    "@openai/codex" "0.128.0"
+
+"@openai/codex-win32-arm64@npm:@openai/codex@0.128.0-win32-arm64":
+  version "0.128.0-win32-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-win32-arm64.tgz#12b838ade9b394583425cec90e8aceeeba74ba37"
+  integrity sha512-ECJvsqmYFdA9pn42xxK3Odp/G16AjmBW0BglX8L0PwPjqbstbmlew9bfHf7xvL+SNfNl4NmyotW0+RNo1phgaA==
+
+"@openai/codex-win32-x64@npm:@openai/codex@0.128.0-win32-x64":
+  version "0.128.0-win32-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0-win32-x64.tgz#a169e496b5052d4456267a2f5fbcadd9efced1d6"
+  integrity sha512-k3jmUAFrzkUtvjGTXvSKjQqJLLlzjxp/VoHJDYedgmXUn6j70HxK38IwapzmnYfiBiTuzETvGwjXHzZgzKjhoQ==
+
+"@openai/codex@0.128.0":
+  version "0.128.0"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.128.0.tgz#c88babe2494b8f9308f8d4673cf1fcf17b12be79"
+  integrity sha512-+xp6ODmFfBNnexIWRHApEaPXot2j6gyM8A5we/5IS/uY4eYHj4arETct4hQ5M4eO+MK7JY3ZU4xhuobhlysr0A==
+  optionalDependencies:
+    "@openai/codex-darwin-arm64" "npm:@openai/codex@0.128.0-darwin-arm64"
+    "@openai/codex-darwin-x64" "npm:@openai/codex@0.128.0-darwin-x64"
+    "@openai/codex-linux-arm64" "npm:@openai/codex@0.128.0-linux-arm64"
+    "@openai/codex-linux-x64" "npm:@openai/codex@0.128.0-linux-x64"
+    "@openai/codex-win32-arm64" "npm:@openai/codex@0.128.0-win32-arm64"
+    "@openai/codex-win32-x64" "npm:@openai/codex@0.128.0-win32-x64"
+
 "@oxc-project/types@=0.127.0":
   version "0.127.0"
   resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.127.0.tgz#8374fcdfb4a641861218daa5700c447c00b66663"


### PR DESCRIPTION
## 摘要
- 在 report meta 中新增 executorRuntime / judgeRuntime / judgeRuntimes，记录 executor / judge 的 binary 或 SDK 版本、模型和能力快照
- HTML 报告展示 runtime 指纹，方便审计本次评测实际使用的运行时
- 新增 comparability warning：bench diff 跨报告对比时检查 runtime、judge prompt、用例指纹、skill isolation 等是否一致；bench verdict 对 legacy report 缺失关键元数据给出提示
- README / README.zh / CHANGELOG 补充 runtime fingerprint 与 construct validity 说明

## 分支关系
- 这是 stacked PR，base 是 PR #36 的分支 chore/changelog-historical-trim
- PR #36 合并后，可将本 PR base retarget 到 develop

## 验证
- yarn typecheck
- yarn lint
- yarn build
- yarn test test/html-renderer.test.ts test/evaluation/evaluation-reporting.test.ts test/eval-core/comparability.test.ts
- yarn test