### PR TITLE
feat(eval-core): 增加 executor runtime 指纹

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 ### Fixed
 
 - **SIGINT 传播到 spawn 出来的子进程**(嵌套 host CLI 下避免 child orphan):用户在 host CLI(codex / claude code)按 Ctrl+C 时,omk spawn 的内层 codex / claude / gemini / script 子进程之前会成 orphan 跑到 timeout。新 `spawnWithSigintPropagation` helper 统一 SIGINT / timeout / abortSignal 三条 kill 路径,SIGTERM + 500ms grace + SIGKILL 兜底。**行为变化**:gemini / script 加 10MB maxBuffer 上限(旧 spawn 实现无限制);timeout grace 多 500ms(120s 默认下不显著)。详见 #33。
+- **⚠ BREAKING-COMPARABILITY:`cacheKey()` 加 executor runtime 指纹,prefix `v3:` → `v4:`** —— 同 executor 换 binary / SDK 版本时旧 cache 不再误命中,避免报告写入新 runtime 指纹但输出来自旧 runtime。runtime 探测改用 executor 实际 `PATH` 形态,`codex-sdk` bundled `@openai/codex` 版本按 SDK 解析链读取。详见 #37。
 - **⚠ BREAKING-COMPARABILITY:`cacheKey()` 加 executor 名,prefix `v2:` → `v3:`** —— 同 model 名跨 executor(如 `gpt-4o` 走 `openai-api` vs `codex`)旧 v2 schema 互相污染缓存。旧 v2 cache 一次性失效,无数据丢失,首跑无 cache 加速(同 v0.22.0 加 allowedSkills 那次 pattern)。详见 #31。
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 - **codex-cli executor**(`--executor codex`):接入 OpenAI Codex CLI 当被测 / 评委,跟 Claude Code 同类 agent CLI 对位。token 统计齐全,best-effort 抽 codex 事件流到 omk trace。skill isolation 仅 cwd 一条 channel(codex 没 SDK skill 等价物),`allowedSkills=[]` 强制 cwd 非空。EXECUTOR_REGISTRY 加 `'codex'` 跟 `'claude'` 对齐。详见 #31。
 - **codex-sdk executor**(`--executor codex-sdk`):接入 `@openai/codex-sdk` 自带的 `@openai/codex` binary 和 SDK 事件流,复用 codex trace / token / cost-not-reported 语义。Construct validity:CODEX_HOME 隔离到 per-process tmp 防 `~/.codex/config.toml` 渗入 eval(等价 codex CLI `--ephemeral` + `--ignore-user-config`,auth.json symlink 透传);SIGINT 联动 abortController 让 PR #33 的 nested-host orphan 修复对 SDK 子进程同样生效。详见 #36。
+- **executor runtime 指纹写入 report**:`meta.executorRuntime` / `meta.judgeRuntime` 记录 binary 或 SDK 版本、模型和能力快照(system prompt / cost / trace / isolation)。HTML 报告展示指纹,`bench diff` / `bench verdict` 在缺失或不一致时提示 strict comparability 风险。详见 #37。
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 - **codex-cli executor**(`--executor codex`):接入 OpenAI Codex CLI 当被测 / 评委,跟 Claude Code 同类 agent CLI 对位。token 统计齐全,best-effort 抽 codex 事件流到 omk trace。skill isolation 仅 cwd 一条 channel(codex 没 SDK skill 等价物),`allowedSkills=[]` 强制 cwd 非空。EXECUTOR_REGISTRY 加 `'codex'` 跟 `'claude'` 对齐。详见 #31。
 - **codex-sdk executor**(`--executor codex-sdk`):接入 `@openai/codex-sdk` 自带的 `@openai/codex` binary 和 SDK 事件流,复用 codex trace / token / cost-not-reported 语义。Construct validity:CODEX_HOME 隔离到 per-process tmp 防 `~/.codex/config.toml` 渗入 eval(等价 codex CLI `--ephemeral` + `--ignore-user-config`,auth.json symlink 透传);SIGINT 联动 abortController 让 PR #33 的 nested-host orphan 修复对 SDK 子进程同样生效。详见 #36。
-- **executor runtime 指纹写入 report**:`meta.executorRuntime` / `meta.judgeRuntime` 记录 binary 或 SDK 版本、模型和能力快照(system prompt / cost / trace / isolation)。HTML 报告展示指纹,`bench diff` / `bench verdict` 在缺失或不一致时提示 strict comparability 风险。详见 #37。
+- **executor runtime 指纹写入 report**:`meta.executorRuntimes` 按 variant 记录实际执行环境,`meta.executorRuntime` / `meta.judgeRuntime` 保留总览。指纹包含 binary 或 SDK 版本、模型和能力快照(system prompt / cost / trace / isolation)。HTML 报告展示指纹,`bench diff` / `bench verdict` 在缺失或不一致时提示 strict comparability 风险。详见 #37。
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ The command writes `~/.oh-my-knowledge/analyses/<timestamp>-skill-health.json`. 
 
 API-direct executors support custom base URLs via env: `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`.
 
-Codex construct-validity notes: (1) `codex` uses the `codex` binary on `PATH`; `codex-sdk` uses the bundled `@openai/codex` binary resolved by `@openai/codex-sdk`. Reports persist `meta.executorRuntime` / `meta.judgeRuntime` fingerprints (binary or SDK version + capability snapshot), and `bench diff` / `bench verdict` warn when strict comparability cannot be audited. If runtime fingerprints differ, treat results as an executor-runtime comparison, not only prompt/template behavior. (2) Both executors isolate user-level config: `codex` passes `--ephemeral` + `--ignore-user-config`; `codex-sdk` redirects `$CODEX_HOME` to a per-process tmp dir (auth.json symlinked through). User-level `~/.codex/config.toml` does not leak into eval runs in either case.
+Codex construct-validity notes: (1) `codex` uses the `codex` binary on `PATH`; `codex-sdk` uses the bundled `@openai/codex` binary resolved by `@openai/codex-sdk`. Reports persist per-variant `meta.executorRuntimes` plus `meta.executorRuntime` / `meta.judgeRuntime` fingerprints (binary or SDK version + capability snapshot), and `bench diff` / `bench verdict` warn when strict comparability cannot be audited. If runtime fingerprints differ, treat results as an executor-runtime comparison, not only prompt/template behavior. (2) Both executors isolate user-level config: `codex` passes `--ephemeral` + `--ignore-user-config`; `codex-sdk` redirects `$CODEX_HOME` to a per-process tmp dir (auth.json symlinked through). User-level `~/.codex/config.toml` does not leak into eval runs in either case.
 
 ### Custom executor
 

--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ The command writes `~/.oh-my-knowledge/analyses/<timestamp>-skill-health.json`. 
 
 API-direct executors support custom base URLs via env: `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`.
 
-Codex construct-validity notes: (1) `codex` uses the `codex` binary on `PATH`; `codex-sdk` uses the bundled `@openai/codex` binary resolved by `@openai/codex-sdk`. Record both runtime versions (`codex --version` and the locked npm version) when comparing — if they differ, treat results as an executor-runtime comparison, not only prompt/template behavior. (2) Both executors isolate user-level config: `codex` passes `--ephemeral` + `--ignore-user-config`; `codex-sdk` redirects `$CODEX_HOME` to a per-process tmp dir (auth.json symlinked through). User-level `~/.codex/config.toml` does not leak into eval runs in either case.
+Codex construct-validity notes: (1) `codex` uses the `codex` binary on `PATH`; `codex-sdk` uses the bundled `@openai/codex` binary resolved by `@openai/codex-sdk`. Reports persist `meta.executorRuntime` / `meta.judgeRuntime` fingerprints (binary or SDK version + capability snapshot), and `bench diff` / `bench verdict` warn when strict comparability cannot be audited. If runtime fingerprints differ, treat results as an executor-runtime comparison, not only prompt/template behavior. (2) Both executors isolate user-level config: `codex` passes `--ephemeral` + `--ignore-user-config`; `codex-sdk` redirects `$CODEX_HOME` to a per-process tmp dir (auth.json symlinked through). User-level `~/.codex/config.toml` does not leak into eval runs in either case.
 
 ### Custom executor
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -672,7 +672,7 @@ omk analyze ~/.claude/projects/my-project --kb /path/to/project
 
 API 直调执行器支持通过环境变量自定义 Base URL：`ANTHROPIC_BASE_URL`、`OPENAI_BASE_URL`。
 
-Codex construct-validity 说明:(1) `codex` 使用 `PATH` 上找到的 `codex` binary;`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。两者严格横向比较时,记录两个 runtime 版本(`codex --version` 和 lockfile 中的 npm 版本)—— 版本不一致时,结果应解释为 executor runtime 对比,而不只是 prompt/template 行为对比。(2) 两个 executor 都隔离用户级 config:`codex` 传 `--ephemeral` + `--ignore-user-config`,`codex-sdk` 把 `$CODEX_HOME` 重定向到 per-process tmp 目录(auth.json 通过 symlink 透传)。用户的 `~/.codex/config.toml` 不会渗入任意一个 executor 的 eval。
+Codex construct-validity 说明:(1) `codex` 使用 `PATH` 上找到的 `codex` binary;`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。报告会持久化 `meta.executorRuntime` / `meta.judgeRuntime` 指纹(binary 或 SDK 版本 + 能力快照),`bench diff` / `bench verdict` 会在 strict comparability 无法审计时提示。runtime 指纹不一致时,结果应解释为 executor runtime 对比,而不只是 prompt/template 行为对比。(2) 两个 executor 都隔离用户级 config:`codex` 传 `--ephemeral` + `--ignore-user-config`,`codex-sdk` 把 `$CODEX_HOME` 重定向到 per-process tmp 目录(auth.json 通过 symlink 透传)。用户的 `~/.codex/config.toml` 不会渗入任意一个 executor 的 eval。
 
 ### 自定义执行器
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -672,7 +672,7 @@ omk analyze ~/.claude/projects/my-project --kb /path/to/project
 
 API 直调执行器支持通过环境变量自定义 Base URL：`ANTHROPIC_BASE_URL`、`OPENAI_BASE_URL`。
 
-Codex construct-validity 说明:(1) `codex` 使用 `PATH` 上找到的 `codex` binary;`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。报告会持久化 `meta.executorRuntime` / `meta.judgeRuntime` 指纹(binary 或 SDK 版本 + 能力快照),`bench diff` / `bench verdict` 会在 strict comparability 无法审计时提示。runtime 指纹不一致时,结果应解释为 executor runtime 对比,而不只是 prompt/template 行为对比。(2) 两个 executor 都隔离用户级 config:`codex` 传 `--ephemeral` + `--ignore-user-config`,`codex-sdk` 把 `$CODEX_HOME` 重定向到 per-process tmp 目录(auth.json 通过 symlink 透传)。用户的 `~/.codex/config.toml` 不会渗入任意一个 executor 的 eval。
+Codex construct-validity 说明:(1) `codex` 使用 `PATH` 上找到的 `codex` binary;`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。报告会持久化 per-variant `meta.executorRuntimes` 以及 `meta.executorRuntime` / `meta.judgeRuntime` 指纹(binary 或 SDK 版本 + 能力快照),`bench diff` / `bench verdict` 会在 strict comparability 无法审计时提示。runtime 指纹不一致时,结果应解释为 executor runtime 对比,而不只是 prompt/template 行为对比。(2) 两个 executor 都隔离用户级 config:`codex` 传 `--ephemeral` + `--ignore-user-config`,`codex-sdk` 把 `$CODEX_HOME` 重定向到 per-process tmp 目录(auth.json 通过 symlink 透传)。用户的 `~/.codex/config.toml` 不会渗入任意一个 executor 的 eval。
 
 ### 自定义执行器
 

--- a/docs/terminology-spec.md
+++ b/docs/terminology-spec.md
@@ -377,7 +377,7 @@ baseline-kind 默认 `[]`(strict),其他 kind 默认 `undefined`(SDK 全发现)�
 
 ### 5. cache key 版本
 
-cache key 升级到 `v2:` prefix,含 allowedSkills 入键 — 切换 strict / non-strict 不会误命中。
+cache key 当前为 `v4:` prefix,含 allowedSkills、executor 名和 executor runtime 指纹入键 — 切换 strict / non-strict、跨 executor 或 binary / SDK 版本变化都不会误命中旧输出。
 
 ### 6. executor 兼容
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -980,7 +980,7 @@ async function handleDiff(argv: string[]): Promise<void> {
 
   const { crossReportComparabilityWarnings, formatComparabilityWarnings } = await import('../eval-core/comparability.js');
   const comparability = formatComparabilityWarnings(crossReportComparabilityWarnings(r1!, r2!), lang);
-  if (comparability) console.log(`\n${comparability}\n`);
+  if (comparability) process.stderr.write(`\n${comparability}\n\n`);
 
   // Per-variant comparison
   const variants: string[] = [...new Set([...(r1!.meta?.variants || []), ...(r2!.meta?.variants || [])])];
@@ -1052,6 +1052,9 @@ async function runSampleLevelDiff(
     console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
     process.exit(1);
   }
+  const { reportComparabilityWarnings, formatComparabilityWarnings } = await import('../eval-core/comparability.js');
+  const comparability = formatComparabilityWarnings(reportComparabilityWarnings(report!), lang);
+  if (comparability) process.stderr.write(`\n${comparability}\n\n`);
   const variants = report!.meta?.variants ?? [];
   if (variants.length < 2) {
     console.error('Sample-level diff needs at least 2 variants in the report.');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -978,6 +978,10 @@ async function handleDiff(argv: string[]): Promise<void> {
     console.log(`  Git:  ${g1?.commitShort || '?'}${g1?.dirty ? '*' : ''} (${g1?.branch || '?'}) → ${g2?.commitShort || '?'}${g2?.dirty ? '*' : ''} (${g2?.branch || '?'})`);
   }
 
+  const { crossReportComparabilityWarnings, formatComparabilityWarnings } = await import('../eval-core/comparability.js');
+  const comparability = formatComparabilityWarnings(crossReportComparabilityWarnings(r1!, r2!), lang);
+  if (comparability) console.log(`\n${comparability}\n`);
+
   // Per-variant comparison
   const variants: string[] = [...new Set([...(r1!.meta?.variants || []), ...(r2!.meta?.variants || [])])];
   for (const v of variants) {
@@ -1435,6 +1439,9 @@ async function handleVerdict(argv: string[]): Promise<void> {
   }
 
   const { computeVerdict, formatVerdictText } = await import('../eval-core/verdict.js');
+  const { reportComparabilityWarnings, formatComparabilityWarnings } = await import('../eval-core/comparability.js');
+  const comparability = formatComparabilityWarnings(reportComparabilityWarnings(report!), lang);
+  if (comparability) process.stderr.write(`${comparability}\n`);
   const result = computeVerdict(report!, {
     gateThreshold: values.threshold != null ? Number(values.threshold) : undefined,
     triviallySmallDiff: values['trivial-diff'] != null ? Number(values['trivial-diff']) : undefined,

--- a/src/eval-core/cache.ts
+++ b/src/eval-core/cache.ts
@@ -2,12 +2,14 @@
  * Executor result cache.
  *
  * Caches successful executor results to disk to avoid redundant API calls.
- * Cache key v2 = "v2:" + sha256(model + system + prompt + cwd + allowedSkills).
+ * Cache key v4 = sha256(model + system + prompt + cwd + allowedSkills + executor + runtime).
  * Loaded into memory on init, flushed to disk on save().
  *
- * key prefix bump v1 → v2 invalidates pre-isolation cache entries
- * (otherwise a strict-baseline run could replay a non-isolated cached result
- * and silently keep the contamination).
+ * Prefix bumps intentionally invalidate old entries when construct-validity
+ * dimensions enter the key:
+ * - v2: allowedSkills / strict isolation
+ * - v3: executor name
+ * - v4: executor runtime fingerprint
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
@@ -64,17 +66,18 @@ export function cacheKey(
   cwd?: string | null,
   allowedSkills?: string[],
   executor?: string,
+  runtimeFingerprint?: string,
 ): string {
   // allowedSkills 序列化:undefined → "" / [] → "[]" / [...] → 排序后 JSON。
   // 排序保证 ["a","b"] 和 ["b","a"] 命中同一缓存(语义等价)。
   const isoStr = allowedSkills === undefined
     ? ''
     : JSON.stringify([...allowedSkills].sort());
-  // executor 进 cache key:同 model 名(如 'gpt-4o')走 openai-api vs codex 输出
-  // 不同,旧 v2 schema 不区分会污染。新版 v3 含 executor 名,跨 executor 必拿不同 key。
+  // executor + runtime 进 cache key:同 model 名走不同 executor 或同 executor
+  // 换 binary/SDK 版本时输出可能不同,旧 cache 不可复用。
   const hash = createHash('sha256')
-    .update(`${model || ''}\n${system || ''}\n${prompt || ''}\n${cwd || ''}\n${isoStr}\n${executor || ''}`)
+    .update(`${model || ''}\n${system || ''}\n${prompt || ''}\n${cwd || ''}\n${isoStr}\n${executor || ''}\n${runtimeFingerprint || ''}`)
     .digest('hex')
     .slice(0, 16);
-  return `v3:${hash}`;
+  return `v4:${hash}`;
 }

--- a/src/eval-core/comparability.ts
+++ b/src/eval-core/comparability.ts
@@ -1,4 +1,4 @@
-import type { Lang, Report, ExecutorRuntimeFingerprint } from '../types/index.js';
+import type { Lang, Report, ReportMeta, ExecutorRuntimeFingerprint, ExecutorRuntimePackage } from '../types/index.js';
 
 export interface ComparabilityWarning {
   code: string;
@@ -24,6 +24,73 @@ function runtimeLabel(runtime: ExecutorRuntimeFingerprint | null | undefined): s
 
 function push(warnings: ComparabilityWarning[], code: string, zh: string, en: string): void {
   warnings.push({ code, severity: 'warning', zh, en });
+}
+
+function sorted(values: string[] | undefined): string[] {
+  return [...(values ?? [])].sort();
+}
+
+function hasJudge(meta: ReportMeta): boolean {
+  return Boolean(meta.judgeModel || (meta.judgeModels && meta.judgeModels.length > 0));
+}
+
+function effectiveJudgeRepeat(meta: ReportMeta): number {
+  return meta.judgeRepeat ?? 1;
+}
+
+function packageReasons(pkg: ExecutorRuntimePackage | undefined, label: string): string[] {
+  if (!pkg) return [`${label} missing`];
+  const reasons: string[] = [];
+  if (pkg.error) reasons.push(`${label} probe failed`);
+  if (!pkg.version) reasons.push(`${label} version missing`);
+  return reasons;
+}
+
+function runtimeUnverifiableReasons(runtime: ExecutorRuntimeFingerprint): string[] {
+  const reasons: string[] = [];
+  if (runtime.kind === 'api') return reasons;
+
+  if (runtime.kind === 'agent-sdk') {
+    reasons.push(...packageReasons(runtime.sdk, 'sdk'));
+  }
+
+  const binary = runtime.binary;
+  if (!binary) {
+    reasons.push('binary missing');
+    return reasons;
+  }
+  if (binary.error) reasons.push('binary probe failed');
+
+  if (binary.source === 'path') {
+    if (!binary.path) reasons.push('binary path missing');
+    if (!binary.version) reasons.push('binary version missing');
+  } else if (binary.source === 'bundled') {
+    if (!binary.version && !binary.package?.version) reasons.push('bundled binary version missing');
+    if (binary.package) reasons.push(...packageReasons(binary.package, 'bundled package').filter((r) => r !== 'bundled package missing'));
+  } else if (binary.source === 'unknown') {
+    reasons.push('binary source unknown');
+  }
+
+  if (runtime.kind === 'unknown') reasons.push('runtime kind unknown');
+  return [...new Set(reasons)];
+}
+
+function pushRuntimeUnverifiable(
+  warnings: ComparabilityWarning[],
+  code: string,
+  zhSubject: string,
+  enSubject: string,
+  runtime: ExecutorRuntimeFingerprint | null | undefined,
+): void {
+  if (!runtime) return;
+  const reasons = runtimeUnverifiableReasons(runtime);
+  if (reasons.length === 0) return;
+  push(
+    warnings,
+    code,
+    `${zhSubject} runtime 指纹不可完全审计: ${runtimeLabel(runtime)} (${reasons.join('; ')})。`,
+    `${enSubject} runtime fingerprint is not fully verifiable: ${runtimeLabel(runtime)} (${reasons.join('; ')}).`,
+  );
 }
 
 function countSampleHashMismatches(a: Report, b: Report): { mismatched: number; missing: number; common: number } | null {
@@ -54,6 +121,16 @@ export function reportComparabilityWarnings(report: Report): ComparabilityWarnin
       '报告缺少 executor runtime 指纹；无法审计 binary / SDK 版本，跨报告严格比较需谨慎。',
       'Report is missing executor runtime fingerprint; binary / SDK versions cannot be audited for strict cross-report comparison.',
     );
+  } else {
+    pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', 'executor', 'Executor', report.meta.executorRuntime);
+  }
+  if (hasJudge(report.meta) && !report.meta.judgePromptHash) {
+    push(
+      warnings,
+      'judge_prompt_hash_missing',
+      '报告缺少评委提示词指纹；无法确认 LLM 评分语义是否一致。',
+      'Report is missing judge prompt fingerprint; LLM scoring semantics cannot be verified.',
+    );
   }
   if (report.meta.judgeModel && !report.meta.judgeRuntime) {
     push(
@@ -62,6 +139,32 @@ export function reportComparabilityWarnings(report: Report): ComparabilityWarnin
       '报告缺少评委 runtime 指纹；无法审计评委 executor 的 binary / SDK 版本。',
       'Report is missing judge runtime fingerprint; judge executor binary / SDK versions cannot be audited.',
     );
+  } else if (report.meta.judgeRuntime) {
+    pushRuntimeUnverifiable(warnings, 'judge_runtime_unverifiable', '评委', 'Judge', report.meta.judgeRuntime);
+  }
+  const judgeModels = sorted(report.meta.judgeModels);
+  if (judgeModels.length >= 2) {
+    if (!report.meta.judgeRuntimes) {
+      push(
+        warnings,
+        'judge_runtime_missing',
+        '报告缺少多评委 ensemble 的 runtime 指纹；无法审计每个评委 executor 的 binary / SDK 版本。',
+        'Report is missing multi-judge ensemble runtime fingerprints; each judge executor binary / SDK version cannot be audited.',
+      );
+    } else {
+      const missing = judgeModels.filter((model) => !report.meta.judgeRuntimes?.[model]);
+      if (missing.length > 0) {
+        push(
+          warnings,
+          'judge_runtime_missing',
+          `多评委 ensemble 缺少 runtime 指纹: ${missing.join(', ')}。`,
+          `Multi-judge ensemble is missing runtime fingerprints: ${missing.join(', ')}.`,
+        );
+      }
+      for (const key of judgeModels) {
+        pushRuntimeUnverifiable(warnings, 'judge_runtime_unverifiable', `评委 ${key}`, `Judge ${key}`, report.meta.judgeRuntimes[key]);
+      }
+    }
   }
   if (!report.meta.sampleHashes) {
     push(
@@ -110,11 +213,58 @@ export function crossReportComparabilityWarnings(before: Report, after: Report):
       'At least one report is missing executor runtime fingerprint; binary / SDK version parity cannot be verified.',
     );
   }
+  pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', 'before executor', 'Before executor', b.executorRuntime);
+  pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', 'after executor', 'After executor', a.executorRuntime);
 
   if ((b.judgeModel || a.judgeModel) && b.judgeModel !== a.judgeModel) {
     push(warnings, 'judge_model_mismatch', `评委模型不同: ${b.judgeModel ?? 'none'} → ${a.judgeModel ?? 'none'}。`, `Judge model changed: ${b.judgeModel ?? 'none'} → ${a.judgeModel ?? 'none'}.`);
   }
-  if (b.judgeRuntime?.fingerprint && a.judgeRuntime?.fingerprint) {
+  const bJudgeModels = sorted(b.judgeModels);
+  const aJudgeModels = sorted(a.judgeModels);
+  const ensembleInEither = bJudgeModels.length > 0 || aJudgeModels.length > 0;
+  if (ensembleInEither && stableStringify(bJudgeModels) !== stableStringify(aJudgeModels)) {
+    push(
+      warnings,
+      'judge_models_mismatch',
+      `多评委 ensemble 配置不同: ${bJudgeModels.join(', ') || 'none'} → ${aJudgeModels.join(', ') || 'none'}。`,
+      `Multi-judge ensemble changed: ${bJudgeModels.join(', ') || 'none'} → ${aJudgeModels.join(', ') || 'none'}.`,
+    );
+  }
+  if (effectiveJudgeRepeat(b) !== effectiveJudgeRepeat(a)) {
+    push(
+      warnings,
+      'judge_repeat_mismatch',
+      `每条用例评委评价次数不同: ${effectiveJudgeRepeat(b)} → ${effectiveJudgeRepeat(a)}。`,
+      `Judge repeat count changed: ${effectiveJudgeRepeat(b)} → ${effectiveJudgeRepeat(a)}.`,
+    );
+  }
+
+  if (ensembleInEither) {
+    const keys = sorted([...new Set([...bJudgeModels, ...aJudgeModels])]);
+    const missing = keys.filter((key) => !b.judgeRuntimes?.[key] || !a.judgeRuntimes?.[key]);
+    if (missing.length > 0) {
+      push(
+        warnings,
+        'judge_runtime_missing',
+        `至少一份报告缺少多评委 runtime 指纹: ${missing.join(', ')}。`,
+        `At least one report is missing multi-judge runtime fingerprints: ${missing.join(', ')}.`,
+      );
+    }
+    for (const key of keys) {
+      const beforeRuntime = b.judgeRuntimes?.[key];
+      const afterRuntime = a.judgeRuntimes?.[key];
+      if (beforeRuntime?.fingerprint && afterRuntime?.fingerprint && beforeRuntime.fingerprint !== afterRuntime.fingerprint) {
+        push(
+          warnings,
+          'judge_runtime_mismatch',
+          `评委 ${key} runtime 指纹不同: ${runtimeLabel(beforeRuntime)} → ${runtimeLabel(afterRuntime)}。`,
+          `Judge ${key} runtime fingerprint changed: ${runtimeLabel(beforeRuntime)} → ${runtimeLabel(afterRuntime)}.`,
+        );
+      }
+      pushRuntimeUnverifiable(warnings, 'judge_runtime_unverifiable', `before 评委 ${key}`, `Before judge ${key}`, beforeRuntime);
+      pushRuntimeUnverifiable(warnings, 'judge_runtime_unverifiable', `after 评委 ${key}`, `After judge ${key}`, afterRuntime);
+    }
+  } else if (b.judgeRuntime?.fingerprint && a.judgeRuntime?.fingerprint) {
     if (b.judgeRuntime.fingerprint !== a.judgeRuntime.fingerprint) {
       push(
         warnings,
@@ -131,8 +281,14 @@ export function crossReportComparabilityWarnings(before: Report, after: Report):
       'At least one report is missing judge runtime fingerprint; judge binary / SDK version parity cannot be verified.',
     );
   }
+  if (!ensembleInEither) {
+    pushRuntimeUnverifiable(warnings, 'judge_runtime_unverifiable', 'before 评委', 'Before judge', b.judgeRuntime);
+    pushRuntimeUnverifiable(warnings, 'judge_runtime_unverifiable', 'after 评委', 'After judge', a.judgeRuntime);
+  }
 
-  if ((b.judgePromptHash || a.judgePromptHash) && b.judgePromptHash !== a.judgePromptHash) {
+  if ((hasJudge(b) || hasJudge(a)) && (!b.judgePromptHash || !a.judgePromptHash)) {
+    push(warnings, 'judge_prompt_hash_missing', `至少一份报告缺少评委提示词指纹: ${b.judgePromptHash ?? 'missing'} → ${a.judgePromptHash ?? 'missing'}。`, `At least one report is missing judge prompt hash: ${b.judgePromptHash ?? 'missing'} → ${a.judgePromptHash ?? 'missing'}.`);
+  } else if ((b.judgePromptHash || a.judgePromptHash) && b.judgePromptHash !== a.judgePromptHash) {
     push(warnings, 'judge_prompt_hash_mismatch', `评委提示词指纹不同: ${b.judgePromptHash ?? 'missing'} → ${a.judgePromptHash ?? 'missing'}。`, `Judge prompt hash changed: ${b.judgePromptHash ?? 'missing'} → ${a.judgePromptHash ?? 'missing'}.`);
   }
   if ((b.evaluationFramework || a.evaluationFramework) && b.evaluationFramework !== a.evaluationFramework) {

--- a/src/eval-core/comparability.ts
+++ b/src/eval-core/comparability.ts
@@ -93,6 +93,49 @@ function pushRuntimeUnverifiable(
   );
 }
 
+function runtimeMapKeys(meta: ReportMeta): string[] {
+  return sorted(meta.executorRuntimes ? Object.keys(meta.executorRuntimes) : undefined);
+}
+
+function reportExecutorRuntimeWarnings(report: Report, warnings: ComparabilityWarning[]): void {
+  const runtimes = report.meta.executorRuntimes;
+  if (runtimes && Object.keys(runtimes).length > 0) {
+    const missing = report.meta.variants.filter((variant) => !runtimes[variant]);
+    if (missing.length > 0) {
+      push(
+        warnings,
+        'executor_runtime_missing',
+        `报告缺少部分 variant 的 executor runtime 指纹: ${missing.join(', ')}。`,
+        `Report is missing executor runtime fingerprints for variants: ${missing.join(', ')}.`,
+      );
+    }
+    for (const [variant, runtime] of Object.entries(runtimes)) {
+      pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', `variant ${variant} executor`, `Variant ${variant} executor`, runtime);
+    }
+    return;
+  }
+
+  if (!report.meta.executorRuntime) {
+    push(
+      warnings,
+      'executor_runtime_missing',
+      '报告缺少 executor runtime 指纹；无法审计 binary / SDK 版本，跨报告严格比较需谨慎。',
+      'Report is missing executor runtime fingerprint; binary / SDK versions cannot be audited for strict cross-report comparison.',
+    );
+    return;
+  }
+
+  if (report.meta.variants.length > 1) {
+    push(
+      warnings,
+      'executor_runtimes_missing',
+      '报告缺少 per-variant executor runtime 指纹；多 variant run 无法审计每个分组实际使用的 binary / SDK 版本。',
+      'Report is missing per-variant executor runtime fingerprints; multi-variant runs cannot audit each group’s actual binary / SDK version.',
+    );
+  }
+  pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', 'executor', 'Executor', report.meta.executorRuntime);
+}
+
 function countSampleHashMismatches(a: Report, b: Report): { mismatched: number; missing: number; common: number } | null {
   const ah = a.meta.sampleHashes;
   const bh = b.meta.sampleHashes;
@@ -114,16 +157,7 @@ function countSampleHashMismatches(a: Report, b: Report): { mismatched: number; 
 
 export function reportComparabilityWarnings(report: Report): ComparabilityWarning[] {
   const warnings: ComparabilityWarning[] = [];
-  if (!report.meta.executorRuntime) {
-    push(
-      warnings,
-      'executor_runtime_missing',
-      '报告缺少 executor runtime 指纹；无法审计 binary / SDK 版本，跨报告严格比较需谨慎。',
-      'Report is missing executor runtime fingerprint; binary / SDK versions cannot be audited for strict cross-report comparison.',
-    );
-  } else {
-    pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', 'executor', 'Executor', report.meta.executorRuntime);
-  }
+  reportExecutorRuntimeWarnings(report, warnings);
   if (hasJudge(report.meta) && !report.meta.judgePromptHash) {
     push(
       warnings,
@@ -196,7 +230,35 @@ export function crossReportComparabilityWarnings(before: Report, after: Report):
   if (b.executor !== a.executor) {
     push(warnings, 'executor_mismatch', `executor 不同: ${b.executor} → ${a.executor}。`, `Executor changed: ${b.executor} → ${a.executor}.`);
   }
-  if (b.executorRuntime?.fingerprint && a.executorRuntime?.fingerprint) {
+  const bExecutorRuntimeKeys = runtimeMapKeys(b);
+  const aExecutorRuntimeKeys = runtimeMapKeys(a);
+  const hasExecutorRuntimeMap = bExecutorRuntimeKeys.length > 0 || aExecutorRuntimeKeys.length > 0;
+  if (hasExecutorRuntimeMap) {
+    const keys = sorted([...new Set([...b.variants, ...a.variants, ...bExecutorRuntimeKeys, ...aExecutorRuntimeKeys])]);
+    const missing = keys.filter((key) => !b.executorRuntimes?.[key] || !a.executorRuntimes?.[key]);
+    if (missing.length > 0) {
+      push(
+        warnings,
+        'executor_runtime_missing',
+        `至少一份报告缺少 per-variant executor runtime 指纹: ${missing.join(', ')}。`,
+        `At least one report is missing per-variant executor runtime fingerprints: ${missing.join(', ')}.`,
+      );
+    }
+    for (const key of keys) {
+      const beforeRuntime = b.executorRuntimes?.[key];
+      const afterRuntime = a.executorRuntimes?.[key];
+      if (beforeRuntime?.fingerprint && afterRuntime?.fingerprint && beforeRuntime.fingerprint !== afterRuntime.fingerprint) {
+        push(
+          warnings,
+          'executor_runtime_mismatch',
+          `variant ${key} executor runtime 指纹不同: ${runtimeLabel(beforeRuntime)} → ${runtimeLabel(afterRuntime)}。`,
+          `Variant ${key} executor runtime fingerprint changed: ${runtimeLabel(beforeRuntime)} → ${runtimeLabel(afterRuntime)}.`,
+        );
+      }
+      pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', `before variant ${key} executor`, `Before variant ${key} executor`, beforeRuntime);
+      pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', `after variant ${key} executor`, `After variant ${key} executor`, afterRuntime);
+    }
+  } else if (b.executorRuntime?.fingerprint && a.executorRuntime?.fingerprint) {
     if (b.executorRuntime.fingerprint !== a.executorRuntime.fingerprint) {
       push(
         warnings,
@@ -213,8 +275,10 @@ export function crossReportComparabilityWarnings(before: Report, after: Report):
       'At least one report is missing executor runtime fingerprint; binary / SDK version parity cannot be verified.',
     );
   }
-  pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', 'before executor', 'Before executor', b.executorRuntime);
-  pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', 'after executor', 'After executor', a.executorRuntime);
+  if (!hasExecutorRuntimeMap) {
+    pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', 'before executor', 'Before executor', b.executorRuntime);
+    pushRuntimeUnverifiable(warnings, 'executor_runtime_unverifiable', 'after executor', 'After executor', a.executorRuntime);
+  }
 
   if ((b.judgeModel || a.judgeModel) && b.judgeModel !== a.judgeModel) {
     push(warnings, 'judge_model_mismatch', `评委模型不同: ${b.judgeModel ?? 'none'} → ${a.judgeModel ?? 'none'}。`, `Judge model changed: ${b.judgeModel ?? 'none'} → ${a.judgeModel ?? 'none'}.`);

--- a/src/eval-core/comparability.ts
+++ b/src/eval-core/comparability.ts
@@ -1,0 +1,176 @@
+import type { Lang, Report, ExecutorRuntimeFingerprint } from '../types/index.js';
+
+export interface ComparabilityWarning {
+  code: string;
+  severity: 'warning';
+  zh: string;
+  en: string;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(stableStringify).join(',') + ']';
+  const entries = Object.keys(value as Record<string, unknown>).sort();
+  return '{' + entries.map((k) => JSON.stringify(k) + ':' + stableStringify((value as Record<string, unknown>)[k])).join(',') + '}';
+}
+
+function runtimeLabel(runtime: ExecutorRuntimeFingerprint | null | undefined): string {
+  if (!runtime) return 'missing';
+  const bits = [`${runtime.executor}:${runtime.model}`, `fp=${runtime.fingerprint}`];
+  if (runtime.binary?.version) bits.push(`binary=${runtime.binary.version}`);
+  if (runtime.sdk?.version) bits.push(`sdk=${runtime.sdk.version}`);
+  return bits.join(' ');
+}
+
+function push(warnings: ComparabilityWarning[], code: string, zh: string, en: string): void {
+  warnings.push({ code, severity: 'warning', zh, en });
+}
+
+function countSampleHashMismatches(a: Report, b: Report): { mismatched: number; missing: number; common: number } | null {
+  const ah = a.meta.sampleHashes;
+  const bh = b.meta.sampleHashes;
+  if (!ah || !bh) return null;
+  let mismatched = 0;
+  let missing = 0;
+  let common = 0;
+  const ids = new Set([...Object.keys(ah), ...Object.keys(bh)]);
+  for (const id of ids) {
+    if (ah[id] == null || bh[id] == null) {
+      missing++;
+      continue;
+    }
+    common++;
+    if (ah[id] !== bh[id]) mismatched++;
+  }
+  return { mismatched, missing, common };
+}
+
+export function reportComparabilityWarnings(report: Report): ComparabilityWarning[] {
+  const warnings: ComparabilityWarning[] = [];
+  if (!report.meta.executorRuntime) {
+    push(
+      warnings,
+      'executor_runtime_missing',
+      '报告缺少 executor runtime 指纹；无法审计 binary / SDK 版本，跨报告严格比较需谨慎。',
+      'Report is missing executor runtime fingerprint; binary / SDK versions cannot be audited for strict cross-report comparison.',
+    );
+  }
+  if (report.meta.judgeModel && !report.meta.judgeRuntime) {
+    push(
+      warnings,
+      'judge_runtime_missing',
+      '报告缺少评委 runtime 指纹；无法审计评委 executor 的 binary / SDK 版本。',
+      'Report is missing judge runtime fingerprint; judge executor binary / SDK versions cannot be audited.',
+    );
+  }
+  if (!report.meta.sampleHashes) {
+    push(
+      warnings,
+      'sample_hashes_missing',
+      '报告缺少用例指纹；无法确认不同 run 是否测的是同一组用例。',
+      'Report is missing sample fingerprints; runs cannot be verified to use the same test cases.',
+    );
+  }
+  if (!report.meta.skillIsolation) {
+    push(
+      warnings,
+      'skill_isolation_missing',
+      '报告缺少 skill isolation 快照；baseline 是否被 skill 污染不可审计。',
+      'Report is missing skill-isolation snapshot; baseline contamination cannot be audited.',
+    );
+  }
+  return warnings;
+}
+
+export function crossReportComparabilityWarnings(before: Report, after: Report): ComparabilityWarning[] {
+  const warnings: ComparabilityWarning[] = [];
+  const b = before.meta;
+  const a = after.meta;
+
+  if (b.model !== a.model) {
+    push(warnings, 'model_mismatch', `执行模型不同: ${b.model} → ${a.model}。`, `Execution model changed: ${b.model} → ${a.model}.`);
+  }
+  if (b.executor !== a.executor) {
+    push(warnings, 'executor_mismatch', `executor 不同: ${b.executor} → ${a.executor}。`, `Executor changed: ${b.executor} → ${a.executor}.`);
+  }
+  if (b.executorRuntime?.fingerprint && a.executorRuntime?.fingerprint) {
+    if (b.executorRuntime.fingerprint !== a.executorRuntime.fingerprint) {
+      push(
+        warnings,
+        'executor_runtime_mismatch',
+        `executor runtime 指纹不同: ${runtimeLabel(b.executorRuntime)} → ${runtimeLabel(a.executorRuntime)}。`,
+        `Executor runtime fingerprint changed: ${runtimeLabel(b.executorRuntime)} → ${runtimeLabel(a.executorRuntime)}.`,
+      );
+    }
+  } else {
+    push(
+      warnings,
+      'executor_runtime_missing',
+      '至少一份报告缺少 executor runtime 指纹；无法确认 binary / SDK 版本一致。',
+      'At least one report is missing executor runtime fingerprint; binary / SDK version parity cannot be verified.',
+    );
+  }
+
+  if ((b.judgeModel || a.judgeModel) && b.judgeModel !== a.judgeModel) {
+    push(warnings, 'judge_model_mismatch', `评委模型不同: ${b.judgeModel ?? 'none'} → ${a.judgeModel ?? 'none'}。`, `Judge model changed: ${b.judgeModel ?? 'none'} → ${a.judgeModel ?? 'none'}.`);
+  }
+  if (b.judgeRuntime?.fingerprint && a.judgeRuntime?.fingerprint) {
+    if (b.judgeRuntime.fingerprint !== a.judgeRuntime.fingerprint) {
+      push(
+        warnings,
+        'judge_runtime_mismatch',
+        `评委 runtime 指纹不同: ${runtimeLabel(b.judgeRuntime)} → ${runtimeLabel(a.judgeRuntime)}。`,
+        `Judge runtime fingerprint changed: ${runtimeLabel(b.judgeRuntime)} → ${runtimeLabel(a.judgeRuntime)}.`,
+      );
+    }
+  } else if (b.judgeModel || a.judgeModel) {
+    push(
+      warnings,
+      'judge_runtime_missing',
+      '至少一份报告缺少评委 runtime 指纹；无法确认评委 binary / SDK 版本一致。',
+      'At least one report is missing judge runtime fingerprint; judge binary / SDK version parity cannot be verified.',
+    );
+  }
+
+  if ((b.judgePromptHash || a.judgePromptHash) && b.judgePromptHash !== a.judgePromptHash) {
+    push(warnings, 'judge_prompt_hash_mismatch', `评委提示词指纹不同: ${b.judgePromptHash ?? 'missing'} → ${a.judgePromptHash ?? 'missing'}。`, `Judge prompt hash changed: ${b.judgePromptHash ?? 'missing'} → ${a.judgePromptHash ?? 'missing'}.`);
+  }
+  if ((b.evaluationFramework || a.evaluationFramework) && b.evaluationFramework !== a.evaluationFramework) {
+    push(warnings, 'evaluation_framework_mismatch', `统计框架不同: ${b.evaluationFramework ?? 'legacy'} → ${a.evaluationFramework ?? 'legacy'}。`, `Evaluation framework changed: ${b.evaluationFramework ?? 'legacy'} → ${a.evaluationFramework ?? 'legacy'}.`);
+  }
+  if (stableStringify(b.skillIsolation ?? null) !== stableStringify(a.skillIsolation ?? null)) {
+    push(
+      warnings,
+      'skill_isolation_mismatch',
+      'skill isolation 快照不同；baseline 污染边界不一致，严格比较需谨慎。',
+      'Skill-isolation snapshots differ; baseline contamination boundaries are not equivalent.',
+    );
+  }
+
+  const sampleHashDiff = countSampleHashMismatches(before, after);
+  if (!sampleHashDiff) {
+    push(
+      warnings,
+      'sample_hashes_missing',
+      '至少一份报告缺少用例指纹；无法确认两次 run 使用同一组用例。',
+      'At least one report is missing sample fingerprints; test-case parity cannot be verified.',
+    );
+  } else if (sampleHashDiff.mismatched > 0 || sampleHashDiff.missing > 0) {
+    push(
+      warnings,
+      'sample_hashes_mismatch',
+      `用例指纹不一致: ${sampleHashDiff.mismatched} 条内容变化，${sampleHashDiff.missing} 条只出现在其中一份报告。`,
+      `Sample fingerprints differ: ${sampleHashDiff.mismatched} content mismatches, ${sampleHashDiff.missing} samples only appear in one report.`,
+    );
+  }
+
+  return warnings;
+}
+
+export function formatComparabilityWarnings(warnings: ComparabilityWarning[], lang: Lang = 'zh'): string {
+  if (warnings.length === 0) return '';
+  const header = lang === 'zh'
+    ? '可比性提示: 以下差异会影响 strict comparison / construct validity'
+    : 'Comparability warnings: the following differences affect strict comparison / construct validity';
+  return [header, ...warnings.map((warning) => `  - ${lang === 'zh' ? warning.zh : warning.en}`)].join('\n');
+}

--- a/src/eval-core/evaluation-execution.ts
+++ b/src/eval-core/evaluation-execution.ts
@@ -4,6 +4,7 @@ import { grade } from '../grading/index.js';
 import { checkFacts } from './fact-checker.js';
 import type { FactCheckResult } from './fact-checker.js';
 import { resolveExecutionStrategy } from './execution-strategy.js';
+import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
 import { resolve, join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import type {
@@ -150,17 +151,23 @@ export async function executeTasks({
     onProgress?.({ phase: 'start', completed: idx, total, sample_id: task.sample_id, variant: task.variant });
 
     const executionPlan = resolveExecutionStrategy(task, model, timeoutMs, verbose);
+    const effectiveExecutorName = executorName || 'claude';
+    const executorRuntime = getExecutorRuntimeFingerprint(effectiveExecutorName, model, {
+      skillDir: executionPlan.input.skillDir,
+    });
 
     let execResult: ExecResult;
     // include allowedSkills in cache key so isolation-on / isolation-off runs
-    // don't share cache entries (would otherwise replay contaminated baseline results).
+    // don't share cache entries, and include runtime fingerprint so a binary/SDK bump
+    // cannot replay old-runtime outputs under new-runtime report metadata.
     const key = cacheKey(
       model,
       executionPlan.cacheSystem,
       executionPlan.input.prompt,
       executionPlan.input.cwd,
       task.artifact.allowedSkills,
-      executorName,
+      effectiveExecutorName,
+      executorRuntime.fingerprint,
     );
     const cached = cache?.get(key);
     const execStart = Date.now();

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -176,11 +176,12 @@ export function aggregateReport({
     ? request.judgeModels.map((jc) => `${jc.executor}:${jc.model}`)
     : undefined;
   const effectiveJudgeExecutorName = request?.judgeExecutor || executorName;
-  const executorRuntime = getExecutorRuntimeFingerprint(executorName, model);
-  const judgeRuntime = noJudge ? null : getExecutorRuntimeFingerprint(effectiveJudgeExecutorName, judgeModel);
+  const runtimeOptions = { skillDir: request?.skillDir };
+  const executorRuntime = getExecutorRuntimeFingerprint(executorName, model, runtimeOptions);
+  const judgeRuntime = noJudge ? null : getExecutorRuntimeFingerprint(effectiveJudgeExecutorName, judgeModel, runtimeOptions);
   const judgeRuntimes = request?.judgeModels && request.judgeModels.length >= 2
     ? Object.fromEntries(
-      request.judgeModels.map((jc) => [`${jc.executor}:${jc.model}`, getExecutorRuntimeFingerprint(jc.executor, jc.model)]),
+      request.judgeModels.map((jc) => [`${jc.executor}:${jc.model}`, getExecutorRuntimeFingerprint(jc.executor, jc.model, runtimeOptions)]),
     )
     : undefined;
   // v0.21 Phase 3a: length-debias is on by default; the request only sets it

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -8,6 +8,7 @@ import { buildVariantSummary } from './schema.js';
 import { buildVariantConfig } from './execution-strategy.js';
 import { getJudgePromptHash } from '../grading/judge.js';
 import { bootstrapMeanCI, bootstrapDiffCI } from './bootstrap.js';
+import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
 import type {
   Artifact,
   Report,
@@ -174,6 +175,14 @@ export function aggregateReport({
   const judgeModelsList = request?.judgeModels && request.judgeModels.length >= 2
     ? request.judgeModels.map((jc) => `${jc.executor}:${jc.model}`)
     : undefined;
+  const effectiveJudgeExecutorName = request?.judgeExecutor || executorName;
+  const executorRuntime = getExecutorRuntimeFingerprint(executorName, model);
+  const judgeRuntime = noJudge ? null : getExecutorRuntimeFingerprint(effectiveJudgeExecutorName, judgeModel);
+  const judgeRuntimes = request?.judgeModels && request.judgeModels.length >= 2
+    ? Object.fromEntries(
+      request.judgeModels.map((jc) => [`${jc.executor}:${jc.model}`, getExecutorRuntimeFingerprint(jc.executor, jc.model)]),
+    )
+    : undefined;
   // v0.21 Phase 3a: length-debias is on by default; the request only sets it
   // false when the user passed --no-debias-length. The hash differs between
   // v3-cot-length (on) and v2-cot (off) so readers can detect the divergence.
@@ -197,6 +206,9 @@ export function aggregateReport({
       artifactHashes,
       sampleHashes,
       ...(noJudge ? {} : { judgePromptHash: getJudgePromptHash(lengthDebiasOn) }),
+      executorRuntime,
+      judgeRuntime,
+      ...(judgeRuntimes ? { judgeRuntimes } : {}),
       ...(judgeRepeat ? { judgeRepeat } : {}),
       ...(judgeModelsList ? { judgeModels: judgeModelsList } : {}),
       ...(debiasModeList.length > 0 ? { debiasMode: debiasModeList } : {}),

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -5,7 +5,7 @@ import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { buildVariantSummary } from './schema.js';
-import { buildVariantConfig } from './execution-strategy.js';
+import { buildVariantConfig, resolveExecutionStrategy } from './execution-strategy.js';
 import { getJudgePromptHash } from '../grading/judge.js';
 import { bootstrapMeanCI, bootstrapDiffCI } from './bootstrap.js';
 import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
@@ -81,6 +81,57 @@ function getGitInfo(): GitInfo | null {
   } catch {
     return null;
   }
+}
+
+function commonRuntime(runtimes: Record<string, ReturnType<typeof getExecutorRuntimeFingerprint>>): ReturnType<typeof getExecutorRuntimeFingerprint> | undefined {
+  const values = Object.values(runtimes);
+  if (values.length === 0) return undefined;
+  const first = values[0];
+  return values.every((runtime) => runtime.fingerprint === first.fingerprint) ? first : undefined;
+}
+
+function representativeRuntime(runtimes: Record<string, ReturnType<typeof getExecutorRuntimeFingerprint>>): ReturnType<typeof getExecutorRuntimeFingerprint> | undefined {
+  return Object.values(runtimes)[0];
+}
+
+function buildExecutorRuntimesByVariant({
+  variants,
+  model,
+  executorName,
+  tasks,
+  artifacts,
+  request,
+}: {
+  variants: string[];
+  model: string;
+  executorName: string;
+  tasks: Task[];
+  artifacts: Artifact[];
+  request?: EvaluationRequest;
+}): Record<string, ReturnType<typeof getExecutorRuntimeFingerprint>> {
+  const runtimes: Record<string, ReturnType<typeof getExecutorRuntimeFingerprint>> = {};
+  for (const task of tasks) {
+    if (runtimes[task.variant]) continue;
+    const executionPlan = resolveExecutionStrategy(task, model, request?.timeoutMs, false);
+    runtimes[task.variant] = getExecutorRuntimeFingerprint(executorName, model, {
+      skillDir: executionPlan.input.skillDir,
+    });
+  }
+
+  for (const variant of variants) {
+    if (runtimes[variant]) continue;
+    const artifact = artifacts.find((a) => a.name === variant);
+    const fallbackSkillDir = artifact?.kind === 'baseline'
+      ? null
+      : artifact?.locator && artifact.source !== 'git'
+        ? dirname(artifact.locator)
+        : request?.skillDir;
+    runtimes[variant] = getExecutorRuntimeFingerprint(executorName, model, {
+      skillDir: fallbackSkillDir,
+    });
+  }
+
+  return runtimes;
 }
 
 interface AggregateReportOptions {
@@ -177,7 +228,10 @@ export function aggregateReport({
     : undefined;
   const effectiveJudgeExecutorName = request?.judgeExecutor || executorName;
   const runtimeOptions = { skillDir: request?.skillDir };
-  const executorRuntime = getExecutorRuntimeFingerprint(executorName, model, runtimeOptions);
+  const executorRuntimes = buildExecutorRuntimesByVariant({ variants, model, executorName, tasks, artifacts, request });
+  const executorRuntime = commonRuntime(executorRuntimes)
+    ?? representativeRuntime(executorRuntimes)
+    ?? getExecutorRuntimeFingerprint(executorName, model, runtimeOptions);
   const judgeRuntime = noJudge ? null : getExecutorRuntimeFingerprint(effectiveJudgeExecutorName, judgeModel, runtimeOptions);
   const judgeRuntimes = request?.judgeModels && request.judgeModels.length >= 2
     ? Object.fromEntries(
@@ -208,6 +262,7 @@ export function aggregateReport({
       sampleHashes,
       ...(noJudge ? {} : { judgePromptHash: getJudgePromptHash(lengthDebiasOn) }),
       executorRuntime,
+      executorRuntimes,
       judgeRuntime,
       ...(judgeRuntimes ? { judgeRuntimes } : {}),
       ...(judgeRepeat ? { judgeRepeat } : {}),
@@ -257,6 +312,11 @@ export function applyBlindMode(report: Report, variants: string[], blindSeed: st
   report.meta.blind = true;
   report.meta.blindMap = blindMap;
   report.meta.variants = labels;
+  if (report.meta.executorRuntimes) {
+    report.meta.executorRuntimes = Object.fromEntries(
+      Object.entries(report.meta.executorRuntimes).map(([variant, runtime]) => [reverseMap[variant] ?? variant, runtime]),
+    );
+  }
 
   const newSummary: Record<string, VariantSummary> = {};
   for (const [variant, stats] of Object.entries(report.summary)) {

--- a/src/eval-workflows/each-evaluation-workflow.ts
+++ b/src/eval-workflows/each-evaluation-workflow.ts
@@ -1,10 +1,10 @@
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { DEFAULT_OUTPUT_DIR, generateRunId, persistReport } from '../eval-core/evaluation-reporting.js';
 import { buildEvaluationRequest, createEvaluationRun, createSucceededJob, finalizeEvaluationRun } from '../eval-core/evaluation-job.js';
 import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
 import { createFileJobStore, DEFAULT_JOBS_DIR } from '../server/job-store.js';
 import { resolveArtifacts } from '../inputs/skill-loader.js';
-import type { Artifact, JobStore, ProgressCallback, Report, VarianceData, VariantResult, VariantSummary } from '../types/index.js';
+import type { Artifact, ExecutorRuntimeFingerprint, JobStore, ProgressCallback, Report, VarianceData, VariantResult, VariantSummary } from '../types/index.js';
 
 interface RunSingleEvaluationOptions {
   samplesPath: string;
@@ -40,6 +40,9 @@ export interface EachSkillResult {
   summary: Record<string, VariantSummary>;
   /** repeat > 1 时由 runMultiple 聚合,承载三层独立 variance + t 检验 */
   variance?: VarianceData;
+  /** Runtime fingerprints from the single skill-vs-baseline run. */
+  executorRuntimes?: Record<string, ExecutorRuntimeFingerprint>;
+  executorRuntime?: ExecutorRuntimeFingerprint;
   results: Array<{
     sample_id: string;
     variants: {
@@ -47,6 +50,13 @@ export interface EachSkillResult {
       skill: VariantResult;
     };
   }>;
+}
+
+function commonRuntime(runtimes: Record<string, ExecutorRuntimeFingerprint>): ExecutorRuntimeFingerprint | undefined {
+  const values = Object.values(runtimes);
+  if (values.length === 0) return undefined;
+  const first = values[0];
+  return values.every((runtime) => runtime.fingerprint === first.fingerprint) ? first : undefined;
 }
 
 function buildEachOverview(skillResults: EachSkillResult[], totalCostUSD: number) {
@@ -148,6 +158,18 @@ export function buildEachReport({
     finishedAt,
   });
   const totalSampleCount = skillResults.reduce((sum, skill) => sum + skill.sampleCount, 0);
+  const executorRuntimes: Record<string, ExecutorRuntimeFingerprint> = {};
+  const entryByName = new Map(skillEntries.map((entry) => [entry.name, entry]));
+  for (const skill of skillResults) {
+    const entry = entryByName.get(skill.name);
+    executorRuntimes[skill.name] =
+      skill.executorRuntimes?.skill
+      ?? skill.executorRuntime
+      ?? getExecutorRuntimeFingerprint(executorName, model, {
+        skillDir: entry ? dirname(entry.skillPath) : skillDir,
+      });
+  }
+  const executorRuntime = commonRuntime(executorRuntimes) ?? Object.values(executorRuntimes)[0] ?? getExecutorRuntimeFingerprint(executorName, model, { skillDir });
 
   return {
     report: {
@@ -167,7 +189,8 @@ export function buildEachReport({
         artifactHashes: Object.fromEntries(
           skillResults.map((skill) => [skill.name, skill.artifactHash || 'no-skill']),
         ),
-        executorRuntime: getExecutorRuntimeFingerprint(executorName, model, { skillDir }),
+        executorRuntime,
+        executorRuntimes,
         judgeRuntime: noJudge ? null : getExecutorRuntimeFingerprint(judgeExecutorName || executorName, judgeModel, { skillDir }),
         ...(judgeModels && judgeModels.length >= 2 ? {
           judgeModels: judgeModels.map((jc) => `${jc.executor}:${jc.model}`),
@@ -304,6 +327,8 @@ export async function executeEachEvaluationRuns({
       },
       // runMultiple 跑 N 次后会把 variance 挂到 report.variance,这里搬到 skill 维度
       ...(report.variance ? { variance: report.variance } : {}),
+      executorRuntimes: report.meta.executorRuntimes,
+      executorRuntime: report.meta.executorRuntime,
       results: report.results.map((result) => ({
         sample_id: result.sample_id,
         variants: {

--- a/src/eval-workflows/each-evaluation-workflow.ts
+++ b/src/eval-workflows/each-evaluation-workflow.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import { DEFAULT_OUTPUT_DIR, generateRunId, persistReport } from '../eval-core/evaluation-reporting.js';
 import { buildEvaluationRequest, createEvaluationRun, createSucceededJob, finalizeEvaluationRun } from '../eval-core/evaluation-job.js';
+import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
 import { createFileJobStore, DEFAULT_JOBS_DIR } from '../server/job-store.js';
 import { resolveArtifacts } from '../inputs/skill-loader.js';
 import type { Artifact, JobStore, ProgressCallback, Report, VarianceData, VariantResult, VariantSummary } from '../types/index.js';
@@ -85,6 +86,7 @@ export function buildEachReport({
   timeoutMs,
   totalCostUSD,
   repeat,
+  judgeModels,
 }: {
   skillDir: string;
   skillEntries: Array<{ name: string; skillPath: string; samplesPath: string }>;
@@ -102,6 +104,7 @@ export function buildEachReport({
   timeoutMs?: number;
   totalCostUSD: number;
   repeat?: number;
+  judgeModels?: import('../types/index.js').JudgeConfig[];
 }) {
   const runId = generateRunId(['each']);
   const request = buildEvaluationRequest({
@@ -128,6 +131,7 @@ export function buildEachReport({
     owner,
     tags,
     repeat,
+    judgeModels,
     each: true,
   });
   const createdAt = new Date().toISOString();
@@ -163,6 +167,14 @@ export function buildEachReport({
         artifactHashes: Object.fromEntries(
           skillResults.map((skill) => [skill.name, skill.artifactHash || 'no-skill']),
         ),
+        executorRuntime: getExecutorRuntimeFingerprint(executorName, model),
+        judgeRuntime: noJudge ? null : getExecutorRuntimeFingerprint(judgeExecutorName || executorName, judgeModel),
+        ...(judgeModels && judgeModels.length >= 2 ? {
+          judgeModels: judgeModels.map((jc) => `${jc.executor}:${jc.model}`),
+          judgeRuntimes: Object.fromEntries(
+            judgeModels.map((jc) => [`${jc.executor}:${jc.model}`, getExecutorRuntimeFingerprint(jc.executor, jc.model)]),
+          ),
+        } : {}),
         request,
         run,
         job,
@@ -322,6 +334,7 @@ export async function executeEachEvaluationRuns({
     timeoutMs,
     totalCostUSD,
     repeat,
+    judgeModels,
   });
   const filePath = persistReport(combinedReport, outputDir);
   const resolvedJobStore = persistJob ? (jobStore ?? createFileJobStore(DEFAULT_JOBS_DIR)) : null;

--- a/src/eval-workflows/each-evaluation-workflow.ts
+++ b/src/eval-workflows/each-evaluation-workflow.ts
@@ -167,12 +167,12 @@ export function buildEachReport({
         artifactHashes: Object.fromEntries(
           skillResults.map((skill) => [skill.name, skill.artifactHash || 'no-skill']),
         ),
-        executorRuntime: getExecutorRuntimeFingerprint(executorName, model),
-        judgeRuntime: noJudge ? null : getExecutorRuntimeFingerprint(judgeExecutorName || executorName, judgeModel),
+        executorRuntime: getExecutorRuntimeFingerprint(executorName, model, { skillDir }),
+        judgeRuntime: noJudge ? null : getExecutorRuntimeFingerprint(judgeExecutorName || executorName, judgeModel, { skillDir }),
         ...(judgeModels && judgeModels.length >= 2 ? {
           judgeModels: judgeModels.map((jc) => `${jc.executor}:${jc.model}`),
           judgeRuntimes: Object.fromEntries(
-            judgeModels.map((jc) => [`${jc.executor}:${jc.model}`, getExecutorRuntimeFingerprint(jc.executor, jc.model)]),
+            judgeModels.map((jc) => [`${jc.executor}:${jc.model}`, getExecutorRuntimeFingerprint(jc.executor, jc.model, { skillDir })]),
           ),
         } : {}),
         request,

--- a/src/executors/runtime-fingerprint.ts
+++ b/src/executors/runtime-fingerprint.ts
@@ -1,8 +1,10 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import { delimiter, dirname, isAbsolute, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { buildExecEnv } from './shared.js';
 import type {
   ExecutorRuntimeBinary,
   ExecutorRuntimeCapabilities,
@@ -12,6 +14,7 @@ import type {
 } from '../types/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const requireFromHere = createRequire(import.meta.url);
 
 const RUNTIME_CACHE = new Map<string, ExecutorRuntimeFingerprint>();
 
@@ -50,8 +53,34 @@ function findInstalledPackageJson(packageName: string): string | null {
   return null;
 }
 
-function readPackage(packageName: string): ExecutorRuntimePackage {
-  const packageJson = findInstalledPackageJson(packageName);
+function findNearestPackageJson(fromPath: string): string | null {
+  let dir = dirname(fromPath);
+  for (let i = 0; i < 10; i++) {
+    const candidate = join(dir, 'package.json');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function resolvePackageJson(packageName: string, from?: string): string | null {
+  const req = from ? createRequire(from) : requireFromHere;
+  try {
+    try {
+      return req.resolve(`${packageName}/package.json`);
+    } catch {
+      const entry = req.resolve(packageName);
+      return findNearestPackageJson(entry);
+    }
+  } catch {
+    return findInstalledPackageJson(packageName);
+  }
+}
+
+function readPackage(packageName: string, from?: string): ExecutorRuntimePackage {
+  const packageJson = resolvePackageJson(packageName, from);
   if (!packageJson) {
     return { name: packageName, error: 'package.json not found' };
   }
@@ -63,8 +92,8 @@ function readPackage(packageName: string): ExecutorRuntimePackage {
   }
 }
 
-function readPackageField<T = unknown>(packageName: string, field: string): T | undefined {
-  const packageJson = findInstalledPackageJson(packageName);
+function readPackageField<T = unknown>(packageName: string, field: string, from?: string): T | undefined {
+  const packageJson = resolvePackageJson(packageName, from);
   if (!packageJson) return undefined;
   try {
     const pkg = JSON.parse(readFileSync(packageJson, 'utf-8')) as Record<string, unknown>;
@@ -74,10 +103,11 @@ function readPackageField<T = unknown>(packageName: string, field: string): T | 
   }
 }
 
-function readCommand(command: string, args: string[], timeout = 1000): { output?: string; error?: string } {
+function readCommand(command: string, args: string[], env: NodeJS.ProcessEnv, timeout = 1000): { output?: string; error?: string } {
   try {
     const output = execFileSync(command, args, {
       encoding: 'utf-8',
+      env,
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout,
     }).trim();
@@ -87,14 +117,29 @@ function readCommand(command: string, args: string[], timeout = 1000): { output?
   }
 }
 
-function readPathBinary(command: string): ExecutorRuntimeBinary {
-  const version = readCommand(command, ['--version']);
-  const path = readCommand('which', [command]);
+function resolvePathBinary(command: string, env: NodeJS.ProcessEnv): string | undefined {
+  if (isAbsolute(command) && existsSync(command)) return command;
+  const pathValue = env.PATH || '';
+  const pathExt = process.platform === 'win32'
+    ? (env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(';')
+    : [''];
+  for (const dir of pathValue.split(delimiter).filter(Boolean)) {
+    for (const ext of pathExt) {
+      const candidate = join(dir, process.platform === 'win32' && ext && !command.toUpperCase().endsWith(ext) ? `${command}${ext}` : command);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return undefined;
+}
+
+function readPathBinary(command: string, env: NodeJS.ProcessEnv): ExecutorRuntimeBinary {
+  const version = readCommand(command, ['--version'], env);
+  const path = resolvePathBinary(command, env);
   return {
     name: command,
     source: 'path',
     ...(version.output ? { version: version.output.split('\n')[0].trim() } : {}),
-    ...(path.output ? { path: path.output.split('\n')[0].trim() } : {}),
+    ...(path ? { path } : {}),
     ...(!version.output && version.error ? { error: version.error } : {}),
   };
 }
@@ -109,12 +154,23 @@ function withFingerprint(input: Omit<ExecutorRuntimeFingerprint, 'fingerprint'>)
         name: input.binary.name,
         source: input.binary.source,
         version: input.binary.version,
+        status: input.binary.version ? 'ok' : input.binary.error ? 'error' : 'missing',
         package: input.binary.package
-          ? { name: input.binary.package.name, version: input.binary.package.version }
+          ? {
+            name: input.binary.package.name,
+            version: input.binary.package.version,
+            status: input.binary.package.version ? 'ok' : input.binary.package.error ? 'error' : 'missing',
+          }
           : undefined,
       }
       : undefined,
-    sdk: input.sdk ? { name: input.sdk.name, version: input.sdk.version } : undefined,
+    sdk: input.sdk
+      ? {
+        name: input.sdk.name,
+        version: input.sdk.version,
+        status: input.sdk.version ? 'ok' : input.sdk.error ? 'error' : 'missing',
+      }
+      : undefined,
     capabilities: input.capabilities,
   };
   return { ...input, fingerprint: hashString(canonicalStringify(stablePayload)) };
@@ -136,8 +192,23 @@ function runtime(
   });
 }
 
-export function getExecutorRuntimeFingerprint(executorName: string, model: string): ExecutorRuntimeFingerprint {
-  const cacheKey = `${executorName}\0${model}`;
+export interface ExecutorRuntimeFingerprintOptions {
+  skillDir?: string | null;
+  env?: NodeJS.ProcessEnv;
+}
+
+function runtimeEnv(options: ExecutorRuntimeFingerprintOptions | undefined): NodeJS.ProcessEnv {
+  return options?.env ?? buildExecEnv(options?.skillDir);
+}
+
+export function getExecutorRuntimeFingerprint(
+  executorName: string,
+  model: string,
+  options: ExecutorRuntimeFingerprintOptions = {},
+): ExecutorRuntimeFingerprint {
+  const env = runtimeEnv(options);
+  const pathHash = hashString(env.PATH || '');
+  const cacheKey = `${executorName}\0${model}\0${pathHash}`;
   const cached = RUNTIME_CACHE.get(cacheKey);
   if (cached) return cached;
 
@@ -149,12 +220,13 @@ export function getExecutorRuntimeFingerprint(executorName: string, model: strin
         costUSD: 'reported',
         trace: 'native',
         skillIsolation: 'full-no-partial',
-      }, { binary: readPathBinary('claude') });
+      }, { binary: readPathBinary('claude', env) });
       break;
     }
     case 'claude-sdk': {
-      const sdk = readPackage('@anthropic-ai/claude-agent-sdk');
-      const claudeCodeVersion = readPackageField<string>('@anthropic-ai/claude-agent-sdk', 'claudeCodeVersion');
+      const sdkPackageJson = resolvePackageJson('@anthropic-ai/claude-agent-sdk');
+      const sdk = readPackage('@anthropic-ai/claude-agent-sdk', sdkPackageJson ?? undefined);
+      const claudeCodeVersion = readPackageField<string>('@anthropic-ai/claude-agent-sdk', 'claudeCodeVersion', sdkPackageJson ?? undefined);
       fp = runtime(executorName, model, 'agent-sdk', {
         systemPrompt: 'native',
         costUSD: 'reported',
@@ -177,12 +249,13 @@ export function getExecutorRuntimeFingerprint(executorName: string, model: strin
         costUSD: 'not-reported',
         trace: 'best-effort',
         skillIsolation: 'cwd-only',
-      }, { binary: readPathBinary('codex') });
+      }, { binary: readPathBinary('codex', env) });
       break;
     }
     case 'codex-sdk': {
-      const sdk = readPackage('@openai/codex-sdk');
-      const bundledCodex = readPackage('@openai/codex');
+      const sdkPackageJson = resolvePackageJson('@openai/codex-sdk');
+      const sdk = readPackage('@openai/codex-sdk', sdkPackageJson ?? undefined);
+      const bundledCodex = readPackage('@openai/codex', sdkPackageJson ?? undefined);
       fp = runtime(executorName, model, 'agent-sdk', {
         systemPrompt: 'prepended',
         costUSD: 'not-reported',
@@ -205,7 +278,7 @@ export function getExecutorRuntimeFingerprint(executorName: string, model: strin
         costUSD: 'not-reported',
         trace: 'none',
         skillIsolation: 'none',
-      }, { binary: readPathBinary('gemini') });
+      }, { binary: readPathBinary('gemini', env) });
       break;
     }
     case 'anthropic-api':
@@ -219,7 +292,7 @@ export function getExecutorRuntimeFingerprint(executorName: string, model: strin
       break;
     }
     default: {
-      fp = runtime(executorName, model, executorName.includes(' ') ? 'script' : 'unknown', UNKNOWN_CAPABILITIES, {
+      fp = runtime(executorName, model, 'script', UNKNOWN_CAPABILITIES, {
         binary: { name: executorName, source: 'unknown' },
       });
     }

--- a/src/executors/runtime-fingerprint.ts
+++ b/src/executors/runtime-fingerprint.ts
@@ -1,0 +1,230 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type {
+  ExecutorRuntimeBinary,
+  ExecutorRuntimeCapabilities,
+  ExecutorRuntimeFingerprint,
+  ExecutorRuntimeKind,
+  ExecutorRuntimePackage,
+} from '../types/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const RUNTIME_CACHE = new Map<string, ExecutorRuntimeFingerprint>();
+
+const UNKNOWN_CAPABILITIES: ExecutorRuntimeCapabilities = {
+  systemPrompt: 'unknown',
+  costUSD: 'unknown',
+  trace: 'unknown',
+  skillIsolation: 'unknown',
+};
+
+function hashString(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function canonicalStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalStringify).join(',') + ']';
+  const entries = Object.keys(value as Record<string, unknown>).sort();
+  return '{' + entries.map((k) => JSON.stringify(k) + ':' + canonicalStringify((value as Record<string, unknown>)[k])).join(',') + '}';
+}
+
+function packagePathSegments(packageName: string): string[] {
+  return packageName.split('/');
+}
+
+function findInstalledPackageJson(packageName: string): string | null {
+  const parts = packagePathSegments(packageName);
+  let dir = __dirname;
+  for (let i = 0; i < 10; i++) {
+    const candidate = join(dir, 'node_modules', ...parts, 'package.json');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function readPackage(packageName: string): ExecutorRuntimePackage {
+  const packageJson = findInstalledPackageJson(packageName);
+  if (!packageJson) {
+    return { name: packageName, error: 'package.json not found' };
+  }
+  try {
+    const pkg = JSON.parse(readFileSync(packageJson, 'utf-8')) as { version?: string };
+    return { name: packageName, ...(pkg.version ? { version: pkg.version } : {}) };
+  } catch (err) {
+    return { name: packageName, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function readPackageField<T = unknown>(packageName: string, field: string): T | undefined {
+  const packageJson = findInstalledPackageJson(packageName);
+  if (!packageJson) return undefined;
+  try {
+    const pkg = JSON.parse(readFileSync(packageJson, 'utf-8')) as Record<string, unknown>;
+    return pkg[field] as T | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readCommand(command: string, args: string[], timeout = 1000): { output?: string; error?: string } {
+  try {
+    const output = execFileSync(command, args, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout,
+    }).trim();
+    return { output };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function readPathBinary(command: string): ExecutorRuntimeBinary {
+  const version = readCommand(command, ['--version']);
+  const path = readCommand('which', [command]);
+  return {
+    name: command,
+    source: 'path',
+    ...(version.output ? { version: version.output.split('\n')[0].trim() } : {}),
+    ...(path.output ? { path: path.output.split('\n')[0].trim() } : {}),
+    ...(!version.output && version.error ? { error: version.error } : {}),
+  };
+}
+
+function withFingerprint(input: Omit<ExecutorRuntimeFingerprint, 'fingerprint'>): ExecutorRuntimeFingerprint {
+  const stablePayload = {
+    executor: input.executor,
+    model: input.model,
+    kind: input.kind,
+    binary: input.binary
+      ? {
+        name: input.binary.name,
+        source: input.binary.source,
+        version: input.binary.version,
+        package: input.binary.package
+          ? { name: input.binary.package.name, version: input.binary.package.version }
+          : undefined,
+      }
+      : undefined,
+    sdk: input.sdk ? { name: input.sdk.name, version: input.sdk.version } : undefined,
+    capabilities: input.capabilities,
+  };
+  return { ...input, fingerprint: hashString(canonicalStringify(stablePayload)) };
+}
+
+function runtime(
+  executor: string,
+  model: string,
+  kind: ExecutorRuntimeKind,
+  capabilities: ExecutorRuntimeCapabilities,
+  extra: Pick<ExecutorRuntimeFingerprint, 'binary' | 'sdk'> = {},
+): ExecutorRuntimeFingerprint {
+  return withFingerprint({
+    executor,
+    model,
+    kind,
+    capabilities,
+    ...extra,
+  });
+}
+
+export function getExecutorRuntimeFingerprint(executorName: string, model: string): ExecutorRuntimeFingerprint {
+  const cacheKey = `${executorName}\0${model}`;
+  const cached = RUNTIME_CACHE.get(cacheKey);
+  if (cached) return cached;
+
+  let fp: ExecutorRuntimeFingerprint;
+  switch (executorName) {
+    case 'claude': {
+      fp = runtime(executorName, model, 'agent-cli', {
+        systemPrompt: 'native',
+        costUSD: 'reported',
+        trace: 'native',
+        skillIsolation: 'full-no-partial',
+      }, { binary: readPathBinary('claude') });
+      break;
+    }
+    case 'claude-sdk': {
+      const sdk = readPackage('@anthropic-ai/claude-agent-sdk');
+      const claudeCodeVersion = readPackageField<string>('@anthropic-ai/claude-agent-sdk', 'claudeCodeVersion');
+      fp = runtime(executorName, model, 'agent-sdk', {
+        systemPrompt: 'native',
+        costUSD: 'reported',
+        trace: 'native',
+        skillIsolation: 'full',
+      }, {
+        sdk,
+        binary: {
+          name: 'claude-code',
+          source: 'bundled',
+          ...(claudeCodeVersion ? { version: claudeCodeVersion } : {}),
+          package: sdk,
+        },
+      });
+      break;
+    }
+    case 'codex': {
+      fp = runtime(executorName, model, 'agent-cli', {
+        systemPrompt: 'prepended',
+        costUSD: 'not-reported',
+        trace: 'best-effort',
+        skillIsolation: 'cwd-only',
+      }, { binary: readPathBinary('codex') });
+      break;
+    }
+    case 'codex-sdk': {
+      const sdk = readPackage('@openai/codex-sdk');
+      const bundledCodex = readPackage('@openai/codex');
+      fp = runtime(executorName, model, 'agent-sdk', {
+        systemPrompt: 'prepended',
+        costUSD: 'not-reported',
+        trace: 'best-effort',
+        skillIsolation: 'cwd-only',
+      }, {
+        sdk,
+        binary: {
+          name: 'codex',
+          source: 'bundled',
+          ...(bundledCodex.version ? { version: bundledCodex.version } : {}),
+          package: bundledCodex,
+        },
+      });
+      break;
+    }
+    case 'gemini': {
+      fp = runtime(executorName, model, 'agent-cli', {
+        systemPrompt: 'prepended',
+        costUSD: 'not-reported',
+        trace: 'none',
+        skillIsolation: 'none',
+      }, { binary: readPathBinary('gemini') });
+      break;
+    }
+    case 'anthropic-api':
+    case 'openai-api': {
+      fp = runtime(executorName, model, 'api', {
+        systemPrompt: 'native',
+        costUSD: 'not-reported',
+        trace: 'none',
+        skillIsolation: 'none',
+      }, { binary: { name: executorName, source: 'none' } });
+      break;
+    }
+    default: {
+      fp = runtime(executorName, model, executorName.includes(' ') ? 'script' : 'unknown', UNKNOWN_CAPABILITIES, {
+        binary: { name: executorName, source: 'unknown' },
+      });
+    }
+  }
+
+  RUNTIME_CACHE.set(cacheKey, fp);
+  return fp;
+}

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -81,6 +81,20 @@ function renderJudgeRuntimeTags(meta: Report['meta'], lang: Lang): string {
   return renderRuntimeTag(meta.judgeRuntime, lang === 'zh' ? '评委指纹' : 'Judge runtime', lang);
 }
 
+function renderExecutorRuntimeTags(meta: Report['meta'], lang: Lang): string {
+  if (meta.executorRuntimes && Object.keys(meta.executorRuntimes).length > 0) {
+    return Object.entries(meta.executorRuntimes)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, runtime]) => renderRuntimeTag(
+        runtime,
+        lang === 'zh' ? `执行器指纹 ${key}` : `Executor runtime ${key}`,
+        lang,
+      ))
+      .join('');
+  }
+  return renderRuntimeTag(meta.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang);
+}
+
 export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string {
   const langQ = lang === DEFAULT_LANG ? '' : `?lang=${lang}`;
   const skillHealthLink = `<a href="/analyses${langQ}" style="color:var(--text-muted);font-size:12px;text-decoration:none;border:1px solid var(--border);padding:4px 10px;border-radius:var(--radius);display:inline-block">📊 <span data-i18n="skillHealthTitle">${t('skillHealthTitle', lang)}</span> →</a>`;
@@ -370,7 +384,7 @@ export function renderRunDetail(report: Report | null, lang: Lang = DEFAULT_LANG
       <span class="meta-tag"${execCostReported ? '' : ` title="${e(lang === 'zh' ? 'executor 不报 USD 成本(如 codex CLI),无法估算' : 'executor does not report USD cost (e.g. codex CLI); not measurable')}"`}>${t('cost', lang)}: ${fmtCost(totalExecCost, execCostReported)}</span>
       <span class="meta-tag">${lang === 'zh' ? '耗时' : 'duration'}: ${fmtDuration(totalDurationMs)}</span>
       ${m.gitInfo ? `<span class="meta-tag">commit: ${e(m.gitInfo.commitShort)}${m.gitInfo.dirty ? '*' : ''} (${e(m.gitInfo.branch)})</span>` : ''}
-      ${m.judgePromptHash ? `<span class="meta-tag" title="${t('judgePromptHashDesc', lang)}">${t('judgePromptHashLabel', lang)}: <code>${e(m.judgePromptHash)}</code></span>` : ''}${renderRuntimeTag(m.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang)}${renderJudgeRuntimeTags(m, lang)}
+      ${m.judgePromptHash ? `<span class="meta-tag" title="${t('judgePromptHashDesc', lang)}">${t('judgePromptHashLabel', lang)}: <code>${e(m.judgePromptHash)}</code></span>` : ''}${renderExecutorRuntimeTags(m, lang)}${renderJudgeRuntimeTags(m, lang)}
       ${m.sampleHashes ? `<span class="meta-tag" style="color:var(--text-muted)" title="${t('sampleHashCountDesc', lang)}">${t('sampleHashCount', lang)}: ${Object.keys(m.sampleHashes).length}/${m.sampleCount}</span>` : ''}
       ${m.evaluationFramework ? `<span class="meta-tag" title="${t('evalFrameworkDesc', lang)}">${t('evalFrameworkLabel', lang)}: ${m.evaluationFramework === 'bootstrap' ? t('evalFrameworkBootstrap', lang) : m.evaluationFramework === 'both' ? t('evalFrameworkBoth', lang) : t('evalFrameworkTTest', lang)}</span>` : ''}
       ${m.debiasMode && m.debiasMode.length > 0 ? `<span class="meta-tag" style="color:var(--green)" title="${lang === 'zh' ? 'judge bias 校正模式 (Phase 3)：length=substance-not-length 提示;position=ensemble 顺序随机化' : 'Judge bias debias modes (Phase 3): length = substance-not-length prompt; position = randomized ensemble order'}">${lang === 'zh' ? '校正' : 'debias'}: ${m.debiasMode.join(' · ')}</span>` : ''}
@@ -480,7 +494,7 @@ export function renderEachRunDetail(report: Report | null, lang: Lang = DEFAULT_
       <span class="meta-tag">${t('model', lang)}: ${e(m.model)}</span>
       <span class="meta-tag">${t('judge', lang)}: ${e(m.judgeModel || 'none')}</span>
       <span class="meta-tag">${t('executor', lang)}: ${e(m.executor || 'claude')}</span>
-      ${renderRuntimeTag(m.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang)}${renderJudgeRuntimeTags(m, lang)}
+      ${renderExecutorRuntimeTags(m, lang)}${renderJudgeRuntimeTags(m, lang)}
       <span class="meta-tag"${eachAllCostReported ? '' : ` title="${e(lang === 'zh' ? 'executor 不报 USD 成本(如 codex CLI),无法估算' : 'executor does not report USD cost (e.g. codex CLI); not measurable')}"`}>${t('cost', lang)}: ${fmtCost(m.totalCostUSD, eachAllCostReported)}</span>
     </div>
 

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -19,7 +19,7 @@ import {
 import { renderSampleTable } from './table.js';
 import { renderTrendsBody } from './trends.js';
 import { computeVerdict, type VerdictLevel } from '../eval-core/verdict.js';
-import type { Report, Lang } from '../types/index.js';
+import type { ExecutorRuntimeFingerprint, Report, Lang } from '../types/index.js';
 
 // v0.21 B.4 — 列表页 status pill 用的 dot. PROGRESS/REGRESS 实心(强信号),
 // CAUTIOUS 三角(警示),NOISE 空心圆(有信号但无效果),UNDERPOWERED 部分填充
@@ -38,6 +38,34 @@ function levelDot(level: VerdictLevel): string {
 type EachOverview = NonNullable<Report['overview']>;
 type EachOverviewArtifact = EachOverview['artifacts'][number];
 type EachArtifactReport = NonNullable<Report['artifacts']>[number];
+
+function renderRuntimeTag(runtime: ExecutorRuntimeFingerprint | null | undefined, label: string, lang: Lang): string {
+  if (!runtime) return '';
+  const versions: string[] = [];
+  if (runtime.binary?.version) versions.push(`binary ${runtime.binary.version}`);
+  if (runtime.sdk?.version) versions.push(`sdk ${runtime.sdk.version}`);
+  const versionText = versions.length > 0 ? ` · ${versions.map(e).join(' · ')}` : '';
+  const title = lang === 'zh'
+    ? [
+      `executor=${runtime.executor}`,
+      `model=${runtime.model}`,
+      `kind=${runtime.kind}`,
+      `system=${runtime.capabilities.systemPrompt}`,
+      `cost=${runtime.capabilities.costUSD}`,
+      `trace=${runtime.capabilities.trace}`,
+      `skillIsolation=${runtime.capabilities.skillIsolation}`,
+    ].join('; ')
+    : [
+      `executor=${runtime.executor}`,
+      `model=${runtime.model}`,
+      `kind=${runtime.kind}`,
+      `system=${runtime.capabilities.systemPrompt}`,
+      `cost=${runtime.capabilities.costUSD}`,
+      `trace=${runtime.capabilities.trace}`,
+      `skillIsolation=${runtime.capabilities.skillIsolation}`,
+    ].join('; ');
+  return `<span class="meta-tag" title="${e(title)}">${e(label)}: <code>${e(runtime.fingerprint)}</code>${versionText}</span>`;
+}
 
 export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string {
   const langQ = lang === DEFAULT_LANG ? '' : `?lang=${lang}`;
@@ -328,7 +356,7 @@ export function renderRunDetail(report: Report | null, lang: Lang = DEFAULT_LANG
       <span class="meta-tag"${execCostReported ? '' : ` title="${e(lang === 'zh' ? 'executor 不报 USD 成本(如 codex CLI),无法估算' : 'executor does not report USD cost (e.g. codex CLI); not measurable')}"`}>${t('cost', lang)}: ${fmtCost(totalExecCost, execCostReported)}</span>
       <span class="meta-tag">${lang === 'zh' ? '耗时' : 'duration'}: ${fmtDuration(totalDurationMs)}</span>
       ${m.gitInfo ? `<span class="meta-tag">commit: ${e(m.gitInfo.commitShort)}${m.gitInfo.dirty ? '*' : ''} (${e(m.gitInfo.branch)})</span>` : ''}
-      ${m.judgePromptHash ? `<span class="meta-tag" title="${t('judgePromptHashDesc', lang)}">${t('judgePromptHashLabel', lang)}: <code>${e(m.judgePromptHash)}</code></span>` : ''}
+      ${m.judgePromptHash ? `<span class="meta-tag" title="${t('judgePromptHashDesc', lang)}">${t('judgePromptHashLabel', lang)}: <code>${e(m.judgePromptHash)}</code></span>` : ''}${renderRuntimeTag(m.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang)}${renderRuntimeTag(m.judgeRuntime, lang === 'zh' ? '评委指纹' : 'Judge runtime', lang)}
       ${m.sampleHashes ? `<span class="meta-tag" style="color:var(--text-muted)" title="${t('sampleHashCountDesc', lang)}">${t('sampleHashCount', lang)}: ${Object.keys(m.sampleHashes).length}/${m.sampleCount}</span>` : ''}
       ${m.evaluationFramework ? `<span class="meta-tag" title="${t('evalFrameworkDesc', lang)}">${t('evalFrameworkLabel', lang)}: ${m.evaluationFramework === 'bootstrap' ? t('evalFrameworkBootstrap', lang) : m.evaluationFramework === 'both' ? t('evalFrameworkBoth', lang) : t('evalFrameworkTTest', lang)}</span>` : ''}
       ${m.debiasMode && m.debiasMode.length > 0 ? `<span class="meta-tag" style="color:var(--green)" title="${lang === 'zh' ? 'judge bias 校正模式 (Phase 3)：length=substance-not-length 提示;position=ensemble 顺序随机化' : 'Judge bias debias modes (Phase 3): length = substance-not-length prompt; position = randomized ensemble order'}">${lang === 'zh' ? '校正' : 'debias'}: ${m.debiasMode.join(' · ')}</span>` : ''}
@@ -438,6 +466,7 @@ export function renderEachRunDetail(report: Report | null, lang: Lang = DEFAULT_
       <span class="meta-tag">${t('model', lang)}: ${e(m.model)}</span>
       <span class="meta-tag">${t('judge', lang)}: ${e(m.judgeModel || 'none')}</span>
       <span class="meta-tag">${t('executor', lang)}: ${e(m.executor || 'claude')}</span>
+      ${renderRuntimeTag(m.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang)}${renderRuntimeTag(m.judgeRuntime, lang === 'zh' ? '评委指纹' : 'Judge runtime', lang)}
       <span class="meta-tag"${eachAllCostReported ? '' : ` title="${e(lang === 'zh' ? 'executor 不报 USD 成本(如 codex CLI),无法估算' : 'executor does not report USD cost (e.g. codex CLI); not measurable')}"`}>${t('cost', lang)}: ${fmtCost(m.totalCostUSD, eachAllCostReported)}</span>
     </div>
 

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -67,6 +67,20 @@ function renderRuntimeTag(runtime: ExecutorRuntimeFingerprint | null | undefined
   return `<span class="meta-tag" title="${e(title)}">${e(label)}: <code>${e(runtime.fingerprint)}</code>${versionText}</span>`;
 }
 
+function renderJudgeRuntimeTags(meta: Report['meta'], lang: Lang): string {
+  if (meta.judgeRuntimes && Object.keys(meta.judgeRuntimes).length > 0) {
+    return Object.entries(meta.judgeRuntimes)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, runtime]) => renderRuntimeTag(
+        runtime,
+        lang === 'zh' ? `评委指纹 ${key}` : `Judge runtime ${key}`,
+        lang,
+      ))
+      .join('');
+  }
+  return renderRuntimeTag(meta.judgeRuntime, lang === 'zh' ? '评委指纹' : 'Judge runtime', lang);
+}
+
 export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string {
   const langQ = lang === DEFAULT_LANG ? '' : `?lang=${lang}`;
   const skillHealthLink = `<a href="/analyses${langQ}" style="color:var(--text-muted);font-size:12px;text-decoration:none;border:1px solid var(--border);padding:4px 10px;border-radius:var(--radius);display:inline-block">📊 <span data-i18n="skillHealthTitle">${t('skillHealthTitle', lang)}</span> →</a>`;
@@ -356,7 +370,7 @@ export function renderRunDetail(report: Report | null, lang: Lang = DEFAULT_LANG
       <span class="meta-tag"${execCostReported ? '' : ` title="${e(lang === 'zh' ? 'executor 不报 USD 成本(如 codex CLI),无法估算' : 'executor does not report USD cost (e.g. codex CLI); not measurable')}"`}>${t('cost', lang)}: ${fmtCost(totalExecCost, execCostReported)}</span>
       <span class="meta-tag">${lang === 'zh' ? '耗时' : 'duration'}: ${fmtDuration(totalDurationMs)}</span>
       ${m.gitInfo ? `<span class="meta-tag">commit: ${e(m.gitInfo.commitShort)}${m.gitInfo.dirty ? '*' : ''} (${e(m.gitInfo.branch)})</span>` : ''}
-      ${m.judgePromptHash ? `<span class="meta-tag" title="${t('judgePromptHashDesc', lang)}">${t('judgePromptHashLabel', lang)}: <code>${e(m.judgePromptHash)}</code></span>` : ''}${renderRuntimeTag(m.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang)}${renderRuntimeTag(m.judgeRuntime, lang === 'zh' ? '评委指纹' : 'Judge runtime', lang)}
+      ${m.judgePromptHash ? `<span class="meta-tag" title="${t('judgePromptHashDesc', lang)}">${t('judgePromptHashLabel', lang)}: <code>${e(m.judgePromptHash)}</code></span>` : ''}${renderRuntimeTag(m.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang)}${renderJudgeRuntimeTags(m, lang)}
       ${m.sampleHashes ? `<span class="meta-tag" style="color:var(--text-muted)" title="${t('sampleHashCountDesc', lang)}">${t('sampleHashCount', lang)}: ${Object.keys(m.sampleHashes).length}/${m.sampleCount}</span>` : ''}
       ${m.evaluationFramework ? `<span class="meta-tag" title="${t('evalFrameworkDesc', lang)}">${t('evalFrameworkLabel', lang)}: ${m.evaluationFramework === 'bootstrap' ? t('evalFrameworkBootstrap', lang) : m.evaluationFramework === 'both' ? t('evalFrameworkBoth', lang) : t('evalFrameworkTTest', lang)}</span>` : ''}
       ${m.debiasMode && m.debiasMode.length > 0 ? `<span class="meta-tag" style="color:var(--green)" title="${lang === 'zh' ? 'judge bias 校正模式 (Phase 3)：length=substance-not-length 提示;position=ensemble 顺序随机化' : 'Judge bias debias modes (Phase 3): length = substance-not-length prompt; position = randomized ensemble order'}">${lang === 'zh' ? '校正' : 'debias'}: ${m.debiasMode.join(' · ')}</span>` : ''}
@@ -466,7 +480,7 @@ export function renderEachRunDetail(report: Report | null, lang: Lang = DEFAULT_
       <span class="meta-tag">${t('model', lang)}: ${e(m.model)}</span>
       <span class="meta-tag">${t('judge', lang)}: ${e(m.judgeModel || 'none')}</span>
       <span class="meta-tag">${t('executor', lang)}: ${e(m.executor || 'claude')}</span>
-      ${renderRuntimeTag(m.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang)}${renderRuntimeTag(m.judgeRuntime, lang === 'zh' ? '评委指纹' : 'Judge runtime', lang)}
+      ${renderRuntimeTag(m.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang)}${renderJudgeRuntimeTags(m, lang)}
       <span class="meta-tag"${eachAllCostReported ? '' : ` title="${e(lang === 'zh' ? 'executor 不报 USD 成本(如 codex CLI),无法估算' : 'executor does not report USD cost (e.g. codex CLI); not measurable')}"`}>${t('cost', lang)}: ${fmtCost(m.totalCostUSD, eachAllCostReported)}</span>
     </div>
 

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -168,6 +168,48 @@ export interface ReportHumanAgreement {
   unscoredCount: number;
 }
 
+export type ExecutorRuntimeKind = 'agent-cli' | 'agent-sdk' | 'api' | 'script' | 'unknown';
+
+export type ExecutorSystemPromptMode = 'native' | 'prepended' | 'none' | 'unknown';
+
+export type ExecutorCostMode = 'reported' | 'not-reported' | 'unknown';
+
+export type ExecutorTraceMode = 'native' | 'best-effort' | 'none' | 'unknown';
+
+export type ExecutorSkillIsolationMode = 'full' | 'full-no-partial' | 'cwd-only' | 'none' | 'unknown';
+
+export interface ExecutorRuntimeCapabilities {
+  systemPrompt: ExecutorSystemPromptMode;
+  costUSD: ExecutorCostMode;
+  trace: ExecutorTraceMode;
+  skillIsolation: ExecutorSkillIsolationMode;
+}
+
+export interface ExecutorRuntimePackage {
+  name: string;
+  version?: string;
+  error?: string;
+}
+
+export interface ExecutorRuntimeBinary {
+  name: string;
+  source: 'path' | 'bundled' | 'none' | 'unknown';
+  version?: string;
+  path?: string;
+  package?: ExecutorRuntimePackage;
+  error?: string;
+}
+
+export interface ExecutorRuntimeFingerprint {
+  executor: string;
+  model: string;
+  kind: ExecutorRuntimeKind;
+  fingerprint: string;
+  binary?: ExecutorRuntimeBinary;
+  sdk?: ExecutorRuntimePackage;
+  capabilities: ExecutorRuntimeCapabilities;
+}
+
 export interface ReportMeta {
   variants: string[];
   model: string;
@@ -188,6 +230,14 @@ export interface ReportMeta {
   sampleHashes?: Record<string, string>;
   /** SHA256-12 of the LLM judge prompt template. Different hash = judge changed semantics. */
   judgePromptHash?: string;
+  /** Runtime fingerprint for the executor that produced tested outputs.
+   *  Captures binary / SDK package versions and capability caveats that affect
+   *  construct validity. Missing means legacy report; compare with caution. */
+  executorRuntime?: ExecutorRuntimeFingerprint;
+  /** Runtime fingerprint for the default judge executor, or null when no judge ran. */
+  judgeRuntime?: ExecutorRuntimeFingerprint | null;
+  /** Runtime fingerprints for multi-judge ensemble members, keyed by "executor:model". */
+  judgeRuntimes?: Record<string, ExecutorRuntimeFingerprint>;
   /** Number of times each sample was judged. 1 = single judge (default). */
   judgeRepeat?: number;
   /** Multi-judge ensemble configuration: ["claude:opus", "openai:gpt-4o", ...].

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -231,9 +231,14 @@ export interface ReportMeta {
   /** SHA256-12 of the LLM judge prompt template. Different hash = judge changed semantics. */
   judgePromptHash?: string;
   /** Runtime fingerprint for the executor that produced tested outputs.
-   *  Captures binary / SDK package versions and capability caveats that affect
-   *  construct validity. Missing means legacy report; compare with caution. */
+   *  Legacy/common field. Prefer executorRuntimes for variant-level audit; this
+   *  field is the common runtime when all variants match, otherwise a representative
+   *  runtime for older consumers. */
   executorRuntime?: ExecutorRuntimeFingerprint;
+  /** Runtime fingerprints for tested-output executors, keyed by variant name.
+   *  This is the strict construct-validity source because variants can resolve
+   *  different skillDir / PATH environments. */
+  executorRuntimes?: Record<string, ExecutorRuntimeFingerprint>;
   /** Runtime fingerprint for the default judge executor, or null when no judge ran. */
   judgeRuntime?: ExecutorRuntimeFingerprint | null;
   /** Runtime fingerprints for multi-judge ensemble members, keyed by "executor:model". */

--- a/test/eval-core/comparability.test.ts
+++ b/test/eval-core/comparability.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  crossReportComparabilityWarnings,
+  formatComparabilityWarnings,
+  reportComparabilityWarnings,
+} from '../../src/eval-core/comparability.js';
+import type { ExecutorRuntimeFingerprint, Report } from '../../src/types/index.js';
+
+function runtime(executor: string, model: string, fingerprint: string): ExecutorRuntimeFingerprint {
+  return {
+    executor,
+    model,
+    kind: 'agent-sdk',
+    fingerprint,
+    binary: { name: executor, source: 'bundled', version: '1.0.0' },
+    sdk: { name: `${executor}-sdk`, version: '1.0.0' },
+    capabilities: {
+      systemPrompt: 'native',
+      costUSD: 'reported',
+      trace: 'native',
+      skillIsolation: 'full',
+    },
+  };
+}
+
+function report(overrides: Partial<Report['meta']> = {}): Report {
+  return {
+    id: 'r',
+    meta: {
+      variants: ['control', 'treatment'],
+      model: 'm',
+      judgeModel: 'j',
+      executor: 'claude-sdk',
+      sampleCount: 2,
+      taskCount: 4,
+      totalCostUSD: 0,
+      timestamp: '2026-05-01T00:00:00.000Z',
+      cliVersion: '0.23.0',
+      nodeVersion: 'v20.0.0',
+      artifactHashes: { control: 'a', treatment: 'b' },
+      sampleHashes: { s1: 'aaa111aaa111', s2: 'bbb222bbb222' },
+      judgePromptHash: 'judge1111111',
+      executorRuntime: runtime('claude-sdk', 'm', 'exec11111111'),
+      judgeRuntime: runtime('claude-sdk', 'j', 'judge111111'),
+      skillIsolation: { control: [], treatment: null },
+      ...overrides,
+    },
+    summary: {},
+    results: [],
+  };
+}
+
+describe('comparability warnings', () => {
+  it('single-report audit warns when runtime metadata is missing', () => {
+    const warnings = reportComparabilityWarnings(report({ executorRuntime: undefined }));
+    assert.ok(warnings.some((w) => w.code === 'executor_runtime_missing'));
+  });
+
+  it('cross-report audit detects runtime, judge prompt, sample, and isolation mismatch', () => {
+    const before = report();
+    const after = report({
+      executorRuntime: runtime('codex-sdk', 'm', 'exec22222222'),
+      judgePromptHash: 'judge2222222',
+      sampleHashes: { s1: 'changed11111', s3: 'ccc333ccc333' },
+      skillIsolation: { control: null, treatment: null },
+    });
+
+    const codes = crossReportComparabilityWarnings(before, after).map((w) => w.code);
+    assert.ok(codes.includes('executor_runtime_mismatch'));
+    assert.ok(codes.includes('judge_prompt_hash_mismatch'));
+    assert.ok(codes.includes('sample_hashes_mismatch'));
+    assert.ok(codes.includes('skill_isolation_mismatch'));
+  });
+
+  it('formats warnings in Chinese', () => {
+    const text = formatComparabilityWarnings(crossReportComparabilityWarnings(report(), report({ model: 'm2' })), 'zh');
+    assert.match(text, /可比性提示/);
+    assert.match(text, /执行模型不同/);
+  });
+});

--- a/test/eval-core/comparability.test.ts
+++ b/test/eval-core/comparability.test.ts
@@ -57,6 +57,13 @@ describe('comparability warnings', () => {
     assert.ok(warnings.some((w) => w.code === 'executor_runtime_missing'));
   });
 
+  it('single-report audit warns when per-variant runtime metadata is incomplete', () => {
+    const warnings = reportComparabilityWarnings(report({
+      executorRuntimes: { control: runtime('claude-sdk', 'm', 'exec11111111') },
+    }));
+    assert.ok(warnings.some((w) => w.code === 'executor_runtime_missing'));
+  });
+
   it('single-report audit warns when runtime metadata is not verifiable', () => {
     const warnings = reportComparabilityWarnings(report({
       executorRuntime: {
@@ -91,6 +98,32 @@ describe('comparability warnings', () => {
     assert.ok(codes.includes('judge_prompt_hash_mismatch'));
     assert.ok(codes.includes('sample_hashes_mismatch'));
     assert.ok(codes.includes('skill_isolation_mismatch'));
+  });
+
+  it('cross-report audit checks per-variant executor runtime fingerprints', () => {
+    const before = report({
+      executorRuntimes: {
+        control: runtime('claude-sdk', 'm', 'exec11111111'),
+        treatment: runtime('claude-sdk', 'm', 'exec22222222'),
+      },
+    });
+    const after = report({
+      executorRuntimes: {
+        control: runtime('claude-sdk', 'm', 'exec11111111'),
+        treatment: runtime('claude-sdk', 'm', 'exec33333333'),
+      },
+    });
+
+    const codes = crossReportComparabilityWarnings(before, after).map((w) => w.code);
+    assert.ok(codes.includes('executor_runtime_mismatch'));
+  });
+
+  it('cross-report audit warns when per-variant executor runtime is missing on one side', () => {
+    const codes = crossReportComparabilityWarnings(
+      report({ executorRuntimes: { control: runtime('claude-sdk', 'm', 'exec11111111') } }),
+      report({ executorRuntimes: { control: runtime('claude-sdk', 'm', 'exec11111111'), treatment: runtime('claude-sdk', 'm', 'exec22222222') } }),
+    ).map((w) => w.code);
+    assert.ok(codes.includes('executor_runtime_missing'));
   });
 
   it('cross-report audit checks ensemble judge models, repeat, and per-judge runtime', () => {

--- a/test/eval-core/comparability.test.ts
+++ b/test/eval-core/comparability.test.ts
@@ -57,6 +57,26 @@ describe('comparability warnings', () => {
     assert.ok(warnings.some((w) => w.code === 'executor_runtime_missing'));
   });
 
+  it('single-report audit warns when runtime metadata is not verifiable', () => {
+    const warnings = reportComparabilityWarnings(report({
+      executorRuntime: {
+        ...runtime('codex', 'm', 'exec11111111'),
+        kind: 'agent-cli',
+        binary: { name: 'codex', source: 'path', error: 'not found' },
+        sdk: undefined,
+      },
+    }));
+    assert.ok(warnings.some((w) => w.code === 'executor_runtime_unverifiable'));
+  });
+
+  it('warns when a judged report lacks judgePromptHash even if both sides are missing it', () => {
+    const warnings = crossReportComparabilityWarnings(
+      report({ judgePromptHash: undefined }),
+      report({ judgePromptHash: undefined }),
+    );
+    assert.ok(warnings.some((w) => w.code === 'judge_prompt_hash_missing'));
+  });
+
   it('cross-report audit detects runtime, judge prompt, sample, and isolation mismatch', () => {
     const before = report();
     const after = report({
@@ -71,6 +91,38 @@ describe('comparability warnings', () => {
     assert.ok(codes.includes('judge_prompt_hash_mismatch'));
     assert.ok(codes.includes('sample_hashes_mismatch'));
     assert.ok(codes.includes('skill_isolation_mismatch'));
+  });
+
+  it('cross-report audit checks ensemble judge models, repeat, and per-judge runtime', () => {
+    const before = report({
+      judgeModels: ['claude:opus', 'openai:gpt-4o'],
+      judgeRepeat: 1,
+      judgeRuntimes: {
+        'claude:opus': runtime('claude', 'opus', 'judge111111'),
+        'openai:gpt-4o': runtime('openai-api', 'gpt-4o', 'judge222222'),
+      },
+    });
+    const after = report({
+      judgeModels: ['claude:opus', 'openai:gpt-4o'],
+      judgeRepeat: 3,
+      judgeRuntimes: {
+        'claude:opus': runtime('claude', 'opus', 'judge333333'),
+        'openai:gpt-4o': runtime('openai-api', 'gpt-4o', 'judge222222'),
+      },
+    });
+
+    const codes = crossReportComparabilityWarnings(before, after).map((w) => w.code);
+    assert.ok(codes.includes('judge_repeat_mismatch'));
+    assert.ok(codes.includes('judge_runtime_mismatch'));
+  });
+
+  it('cross-report audit checks ensemble judge model set', () => {
+    const codes = crossReportComparabilityWarnings(
+      report({ judgeModels: ['claude:opus', 'openai:gpt-4o'], judgeRuntimes: {} }),
+      report({ judgeModels: ['claude:opus', 'codex:gpt-5'], judgeRuntimes: {} }),
+    ).map((w) => w.code);
+    assert.ok(codes.includes('judge_models_mismatch'));
+    assert.ok(codes.includes('judge_runtime_missing'));
   });
 
   it('formats warnings in Chinese', () => {

--- a/test/evaluation/cache.test.ts
+++ b/test/evaluation/cache.test.ts
@@ -34,13 +34,13 @@ describe('cacheKey', () => {
     assert.equal(a, b);
   });
 
-  it('cache key 带 v3: 前缀(invalidates old v2 cache entries)', () => {
+  it('cache key 带 v4: 前缀(invalidates old runtime-blind cache entries)', () => {
     const key = cacheKey('sonnet', '', 'p', '/tmp/p');
-    assert.match(key, /^v3:/);
+    assert.match(key, /^v4:/);
   });
 
   // executor 进 cache key:同 model 名(如 'gpt-4o')走 openai-api vs codex 输出不同,
-  // 不区分会污染。新版 v3 含 executor 名,跨 executor 必拿不同 key。
+  // 不区分会污染。新版 key 含 executor 名,跨 executor 必拿不同 key。
   it('executor 进 cache key:不同 executor 同 model 不同键', () => {
     const codex = cacheKey('gpt-4o', '', 'p', '/tmp/p', undefined, 'codex');
     const openaiApi = cacheKey('gpt-4o', '', 'p', '/tmp/p', undefined, 'openai-api');
@@ -57,5 +57,11 @@ describe('cacheKey', () => {
     const a = cacheKey('sonnet', '', 'p', '/tmp/p', undefined, 'claude');
     const b = cacheKey('sonnet', '', 'p', '/tmp/p', undefined, 'claude');
     assert.equal(a, b);
+  });
+
+  it('runtime fingerprint 进 cache key:同 executor 换 runtime 不同键', () => {
+    const a = cacheKey('sonnet', '', 'p', '/tmp/p', undefined, 'claude', 'runtime111111');
+    const b = cacheKey('sonnet', '', 'p', '/tmp/p', undefined, 'claude', 'runtime222222');
+    assert.notEqual(a, b);
   });
 });

--- a/test/evaluation/evaluation-reporting.test.ts
+++ b/test/evaluation/evaluation-reporting.test.ts
@@ -64,6 +64,26 @@ describe('aggregateReport — reproducibility metadata', () => {
     assert.match(report.meta.judgePromptHash!, /^[0-9a-f]{12}$/);
   });
 
+  it('writes executor runtime fingerprint', () => {
+    const report = aggregateReport({ ...baseOpts, executorName: 'codex-sdk', model: 'gpt-5', noJudge: true });
+    assert.equal(report.meta.executorRuntime?.executor, 'codex-sdk');
+    assert.equal(report.meta.executorRuntime?.model, 'gpt-5');
+    assert.equal(report.meta.executorRuntime?.kind, 'agent-sdk');
+    assert.match(report.meta.executorRuntime!.fingerprint, /^[0-9a-f]{12}$/);
+    assert.equal(report.meta.executorRuntime?.sdk?.name, '@openai/codex-sdk');
+    assert.equal(report.meta.executorRuntime?.binary?.source, 'bundled');
+    assert.equal(report.meta.executorRuntime?.binary?.package?.name, '@openai/codex');
+    assert.equal(report.meta.executorRuntime?.capabilities.costUSD, 'not-reported');
+    assert.equal(report.meta.judgeRuntime, null);
+  });
+
+  it('writes judge runtime fingerprint when judge runs', () => {
+    const report = aggregateReport(baseOpts);
+    assert.equal(report.meta.judgeRuntime?.executor, 'claude');
+    assert.equal(report.meta.judgeRuntime?.model, 'haiku');
+    assert.match(report.meta.judgeRuntime!.fingerprint, /^[0-9a-f]{12}$/);
+  });
+
   it('omits judgePromptHash when noJudge=true (no judge ran)', () => {
     const report = aggregateReport({ ...baseOpts, noJudge: true });
     assert.equal(report.meta.judgePromptHash, undefined);

--- a/test/evaluation/evaluation-reporting.test.ts
+++ b/test/evaluation/evaluation-reporting.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { aggregateReport } from '../../src/eval-core/evaluation-reporting.js';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { aggregateReport, applyBlindMode } from '../../src/eval-core/evaluation-reporting.js';
 import type { Artifact, Sample, Task, VariantResult, EvaluationRequest } from '../../src/types/index.js';
 
 function makeArtifact(name: string, content: string): Artifact {
@@ -22,6 +25,31 @@ function makeVariantResult(): VariantResult {
     execCostUSD: 0.001, judgeCostUSD: 0, costUSD: 0.001,
     numTurns: 1, outputPreview: 'ok',
   };
+}
+
+function makeTask(variant: string, artifact: Artifact, sample: Sample): Task {
+  return {
+    sample_id: sample.sample_id,
+    variant,
+    artifact,
+    prompt: sample.prompt,
+    rubric: sample.rubric ?? null,
+    assertions: sample.assertions ?? null,
+    dimensions: sample.dimensions ?? null,
+    artifactContent: artifact.content,
+    cwd: null,
+    _sample: sample,
+  };
+}
+
+function writeFakeBinary(dir: string, name: string, output: string): void {
+  const fileName = process.platform === 'win32' ? `${name}.cmd` : name;
+  const filePath = join(dir, fileName);
+  const content = process.platform === 'win32'
+    ? `@echo off\r\necho ${output}\r\n`
+    : `#!/bin/sh\necho ${output}\n`;
+  writeFileSync(filePath, content);
+  if (process.platform !== 'win32') chmodSync(filePath, 0o755);
 }
 
 describe('aggregateReport — reproducibility metadata', () => {
@@ -75,6 +103,58 @@ describe('aggregateReport — reproducibility metadata', () => {
     assert.equal(report.meta.executorRuntime?.binary?.package?.name, '@openai/codex');
     assert.equal(report.meta.executorRuntime?.capabilities.costUSD, 'not-reported');
     assert.equal(report.meta.judgeRuntime, null);
+  });
+
+  it('writes per-variant executor runtime fingerprints from each task skillDir', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omk-runtime-report-'));
+    try {
+      const skillA = join(root, 'skill-a');
+      const skillB = join(root, 'skill-b');
+      for (const [dir, version] of [[skillA, 'codex-a'], [skillB, 'codex-b']] as const) {
+        mkdirSync(join(dir, 'node_modules', '.bin'), { recursive: true });
+        writeFakeBinary(join(dir, 'node_modules', '.bin'), 'codex', version);
+        writeFileSync(join(dir, 'SKILL.md'), `${version} skill`);
+      }
+      const artifactA: Artifact = { name: 'a', kind: 'skill', source: 'file-path', content: 'a skill', locator: join(skillA, 'SKILL.md'), experimentRole: 'control' };
+      const artifactB: Artifact = { name: 'b', kind: 'skill', source: 'file-path', content: 'b skill', locator: join(skillB, 'SKILL.md'), experimentRole: 'treatment' };
+      const sample = makeSample('s1', 'task');
+      const report = aggregateReport({
+        runId: 'run-1',
+        variants: ['a', 'b'],
+        model: 'gpt-5',
+        judgeModel: 'haiku',
+        noJudge: true,
+        executorName: 'codex',
+        samples: [sample],
+        tasks: [makeTask('a', artifactA, sample), makeTask('b', artifactB, sample)],
+        results: { s1: { a: makeVariantResult(), b: makeVariantResult() } },
+        totalCostUSD: 0,
+        artifacts: [artifactA, artifactB],
+      });
+
+      assert.equal(report.meta.executorRuntimes?.a.binary?.version, 'codex-a');
+      assert.equal(report.meta.executorRuntimes?.b.binary?.version, 'codex-b');
+      assert.notEqual(report.meta.executorRuntimes?.a.fingerprint, report.meta.executorRuntimes?.b.fingerprint);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('blind mode remaps per-variant executor runtime keys', () => {
+    const report = aggregateReport({
+      ...baseOpts,
+      variants: ['a', 'b'],
+      artifacts: [makeArtifact('a', 'a skill'), makeArtifact('b', 'b skill')],
+      results: { s1: { a: makeVariantResult(), b: makeVariantResult() } },
+    });
+    report.meta.executorRuntimes = {
+      a: { ...report.meta.executorRuntime!, fingerprint: 'runtimeaaaaaa' },
+      b: { ...report.meta.executorRuntime!, fingerprint: 'runtimebbbbbb' },
+    };
+
+    applyBlindMode(report, ['a', 'b'], 'seed');
+
+    assert.deepEqual(Object.keys(report.meta.executorRuntimes!).sort(), ['A', 'B']);
   });
 
   it('writes judge runtime fingerprint when judge runs', () => {

--- a/test/executors/runtime-fingerprint.test.ts
+++ b/test/executors/runtime-fingerprint.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { getExecutorRuntimeFingerprint } from '../../src/executors/runtime-fingerprint.js';
+
+function writeFakeBinary(dir: string, name: string, output: string): void {
+  const fileName = process.platform === 'win32' ? `${name}.cmd` : name;
+  const filePath = join(dir, fileName);
+  const content = process.platform === 'win32'
+    ? `@echo off\r\necho ${output}\r\n`
+    : `#!/bin/sh\necho ${output}\n`;
+  writeFileSync(filePath, content);
+  if (process.platform !== 'win32') chmodSync(filePath, 0o755);
+}
+
+describe('runtime fingerprint', () => {
+  it('probes PATH from the same env shape executors use', () => {
+    const dirA = mkdtempSync(join(tmpdir(), 'omk-runtime-a-'));
+    const dirB = mkdtempSync(join(tmpdir(), 'omk-runtime-b-'));
+    try {
+      writeFakeBinary(dirA, 'codex', 'codex-a');
+      writeFakeBinary(dirB, 'codex', 'codex-b');
+      const basePath = process.env.PATH || '';
+      const a = getExecutorRuntimeFingerprint('codex', 'gpt-5', {
+        env: { ...process.env, PATH: `${dirA}${delimiter}${basePath}` },
+      });
+      const b = getExecutorRuntimeFingerprint('codex', 'gpt-5', {
+        env: { ...process.env, PATH: `${dirB}${delimiter}${basePath}` },
+      });
+
+      assert.equal(a.binary?.version, 'codex-a');
+      assert.equal(b.binary?.version, 'codex-b');
+      assert.ok(a.binary?.path?.startsWith(dirA));
+      assert.ok(b.binary?.path?.startsWith(dirB));
+      assert.notEqual(a.fingerprint, b.fingerprint);
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/html-renderer.test.ts
+++ b/test/html-renderer.test.ts
@@ -341,6 +341,24 @@ describe('renderRunDetail', () => {
     ensembleReport.meta.judgeModels = ['claude:opus', 'openai:gpt-4o'];
     ensembleReport.meta.judgeRepeat = 3;
     ensembleReport.meta.judgePromptHash = 'abc123def456';
+    ensembleReport.meta.judgeRuntimes = {
+      'claude:opus': {
+        executor: 'claude',
+        model: 'opus',
+        kind: 'agent-cli',
+        fingerprint: 'judge1111111',
+        binary: { name: 'claude', source: 'path', version: '2.0.0' },
+        capabilities: { systemPrompt: 'native', costUSD: 'reported', trace: 'native', skillIsolation: 'full-no-partial' },
+      },
+      'openai:gpt-4o': {
+        executor: 'openai-api',
+        model: 'gpt-4o',
+        kind: 'api',
+        fingerprint: 'judge2222222',
+        binary: { name: 'openai-api', source: 'none' },
+        capabilities: { systemPrompt: 'native', costUSD: 'not-reported', trace: 'none', skillIsolation: 'none' },
+      },
+    };
     ensembleReport.summary.v1.judgeAgreement = { pearson: 0.85, meanAbsDiff: 0.6, pairCount: 1, sampleCount: 50 };
     ensembleReport.summary.v1.judgeModels = ['claude:opus', 'openai:gpt-4o'];
     const html = renderRunDetail(ensembleReport);
@@ -348,6 +366,8 @@ describe('renderRunDetail', () => {
     assert.ok(html.includes('claude:opus'), 'should mention claude:opus');
     assert.ok(html.includes('openai:gpt-4o'), 'should mention openai:gpt-4o');
     assert.ok(html.includes('abc123def456'), 'should show prompt hash');
+    assert.ok(html.includes('judge1111111'), 'should show claude judge runtime fingerprint');
+    assert.ok(html.includes('judge2222222'), 'should show openai judge runtime fingerprint');
     // Agreement table renders pearson + MAD numbers
     assert.ok(html.includes('0.85'), 'should show pearson value');
     assert.ok(html.includes('0.6'), 'should show MAD value');

--- a/test/html-renderer.test.ts
+++ b/test/html-renderer.test.ts
@@ -308,6 +308,34 @@ describe('renderRunDetail', () => {
     assert.ok(html.includes('质量'));
   });
 
+  it('renders executor runtime fingerprint meta tags', () => {
+    const runtimeReport = JSON.parse(JSON.stringify(SAMPLE_REPORT)) as Report;
+    runtimeReport.meta.executorRuntime = {
+      executor: 'codex-sdk',
+      model: 'gpt-5',
+      kind: 'agent-sdk',
+      fingerprint: 'abc123def456',
+      binary: { name: 'codex', source: 'bundled', version: '0.128.0' },
+      sdk: { name: '@openai/codex-sdk', version: '0.128.0' },
+      capabilities: { systemPrompt: 'prepended', costUSD: 'not-reported', trace: 'best-effort', skillIsolation: 'cwd-only' },
+    };
+    runtimeReport.meta.judgeRuntime = {
+      executor: 'claude-sdk',
+      model: 'haiku',
+      kind: 'agent-sdk',
+      fingerprint: 'def456abc123',
+      binary: { name: 'claude-code', source: 'bundled', version: '2.1.118' },
+      sdk: { name: '@anthropic-ai/claude-agent-sdk', version: '0.2.118' },
+      capabilities: { systemPrompt: 'native', costUSD: 'reported', trace: 'native', skillIsolation: 'full' },
+    };
+    const html = renderRunDetail(runtimeReport);
+    assert.ok(html.includes('执行器指纹'));
+    assert.ok(html.includes('abc123def456'));
+    assert.ok(html.includes('binary 0.128.0'));
+    assert.ok(html.includes('评委指纹'));
+    assert.ok(html.includes('def456abc123'));
+  });
+
   it('renders multi-judge ensemble agreement when summary has judgeAgreement', () => {
     const ensembleReport = JSON.parse(JSON.stringify(SAMPLE_REPORT));
     ensembleReport.meta.judgeModels = ['claude:opus', 'openai:gpt-4o'];

--- a/test/html-renderer.test.ts
+++ b/test/html-renderer.test.ts
@@ -319,6 +319,10 @@ describe('renderRunDetail', () => {
       sdk: { name: '@openai/codex-sdk', version: '0.128.0' },
       capabilities: { systemPrompt: 'prepended', costUSD: 'not-reported', trace: 'best-effort', skillIsolation: 'cwd-only' },
     };
+    runtimeReport.meta.executorRuntimes = {
+      v1: runtimeReport.meta.executorRuntime,
+      v2: { ...runtimeReport.meta.executorRuntime, fingerprint: 'abc123variant', binary: { name: 'codex', source: 'bundled', version: '0.129.0' } },
+    };
     runtimeReport.meta.judgeRuntime = {
       executor: 'claude-sdk',
       model: 'haiku',
@@ -329,8 +333,10 @@ describe('renderRunDetail', () => {
       capabilities: { systemPrompt: 'native', costUSD: 'reported', trace: 'native', skillIsolation: 'full' },
     };
     const html = renderRunDetail(runtimeReport);
-    assert.ok(html.includes('执行器指纹'));
+    assert.ok(html.includes('执行器指纹 v1'));
+    assert.ok(html.includes('执行器指纹 v2'));
     assert.ok(html.includes('abc123def456'));
+    assert.ok(html.includes('abc123variant'));
     assert.ok(html.includes('binary 0.128.0'));
     assert.ok(html.includes('评委指纹'));
     assert.ok(html.includes('def456abc123'));


### PR DESCRIPTION
## 摘要
- 在 report meta 中新增 per-variant `executorRuntimes`，按每个 variant 实际 executionPlan / skillDir 记录 executor binary 或 SDK 版本，修复 report-level runtime 误标风险。
- 保留 `executorRuntime` 作为 common / legacy 总览字段；新增 `judgeRuntime` / `judgeRuntimes` 记录评委运行时。
- cacheKey 升级到 v4，并纳入 executor runtime fingerprint，避免 binary / SDK 版本变化后误用旧 cache。
- runtime 指纹探测改用 executor 实际 PATH / skillDir 形态；codex-sdk bundled @openai/codex 版本按 SDK 解析链读取。
- comparability warning 覆盖 per-variant runtime、多评委 ensemble、judgeRepeat、缺失 judgePromptHash、runtime 不可审计；HTML / CLI 同步展示和提示。

## 分支关系
- 已基于最新 develop 重新整理分支。
- 原 PR #37 处于 closed 且 GitHub 不允许 reopen，本 PR 继续承接该 runtime fingerprint 修改和 review 高优先级修复。

## 验证
- yarn typecheck
- yarn lint
- yarn build
- yarn test test/evaluation/evaluation-reporting.test.ts test/eval-core/comparability.test.ts test/html-renderer.test.ts
- yarn test