### PR TITLE
feat(eval-workflows): 拆分 each 批次索引报告

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 ### Changed
 
 - **cost 显示「—」 而非 `$0.0000`**(executor 不报 cost 时):`ExecResult` / `VariantResult` / `VariantSummary` / `GradeResult` 加 `costReportedByExecutor` / `execCostReported` / `judgeCostReported` 三层 flag,全可选缺位 ≡ true(老报告兼容)。Renderer(HTML detail / list / each / trends / variance chart / CLI bench diff / bench evolve)全部识别该 flag,not reported 时显示「—」+ tooltip 解释。详见 #31。
-- **⚠ BREAKING:`bench run --each` 产物改为 `EvaluationBatchIndex` + child `EvaluationReport`** —— 顶层 batch index 只保存批次索引和摘要,每个 skill vs baseline 单独持久化为可比较的原子报告。删除 `Report.each` / `overview` / `artifacts` 这类混合 schema,`bench diff` / `verdict` / `diagnose` 等命令现在只接受 child reportId。旧 each 报告不做兼容迁移。
+- **⚠ BREAKING:`bench run --each` 产物改为 `EvaluationBatchIndex` + child `EvaluationReport`** —— 顶层 batch index 只保存批次索引和摘要,每个 skill vs baseline 单独持久化为可比较的原子报告。child report 的 treatment variant 使用真实 skill 名,趋势页按 skill 名聚合,不再写 generic `skill`。删除 `Report.each` / `overview` / `artifacts` 这类混合 schema,`bench diff` / `verdict` / `diagnose` 等命令现在只接受 child reportId。旧 each 报告不做兼容迁移。详见 #40。
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 ### Changed
 
 - **cost 显示「—」 而非 `$0.0000`**(executor 不报 cost 时):`ExecResult` / `VariantResult` / `VariantSummary` / `GradeResult` 加 `costReportedByExecutor` / `execCostReported` / `judgeCostReported` 三层 flag,全可选缺位 ≡ true(老报告兼容)。Renderer(HTML detail / list / each / trends / variance chart / CLI bench diff / bench evolve)全部识别该 flag,not reported 时显示「—」+ tooltip 解释。详见 #31。
+- **⚠ BREAKING:`bench run --each` 产物改为 `EvaluationBatchIndex` + child `EvaluationReport`** —— 顶层 batch index 只保存批次索引和摘要,每个 skill vs baseline 单独持久化为可比较的原子报告。删除 `Report.each` / `overview` / `artifacts` 这类混合 schema,`bench diff` / `verdict` / `diagnose` 等命令现在只接受 child reportId。旧 each 报告不做兼容迁移。
 
 ### Fixed
 

--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -213,6 +213,7 @@ export function mergeEvolveReports(
   const runId = `evolve-${skillName}-${generateRunId([skillName]).split('-').slice(-2).join('-')}`;
 
   const report: Report = {
+    kind: 'evaluation',
     id: runId,
     meta: {
       ...firstReport.meta,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,7 +13,9 @@ import {
 import { makeOnProgress } from './progress.js';
 import { checkUpdate } from './update-check.js';
 import type {
+  EvaluationReport,
   Report,
+  ReportDocument,
   VariantSummary,
   GitInfo,
   ReportStore,
@@ -49,7 +51,7 @@ interface RoundProgressInfo {
 }
 
 interface EvalResult {
-  report: Report;
+  report: ReportDocument;
   filePath: string | null;
 }
 
@@ -81,6 +83,20 @@ interface EvolveResult {
 interface GenerateSamplesResult {
   samples: unknown[];
   costUSD: number;
+}
+
+function requireEvaluationReport(report: ReportDocument | null, id: string, lang: CliLang): EvaluationReport {
+  if (!report) {
+    console.error(tCli('cli.common.report_not_found', lang, { id }));
+    process.exit(1);
+  }
+  if (report.kind === 'batch-index') {
+    console.error(lang === 'zh'
+      ? `报告 ${id} 是 each 批次索引。该命令需要单次 EvaluationReport；请使用索引里的 child reportId。`
+      : `Report ${id} is an each batch index. This command requires an EvaluationReport; use a child reportId from the index.`);
+    process.exit(1);
+  }
+  return report;
 }
 
 // ---------------------------------------------------------------------------
@@ -328,7 +344,7 @@ async function handleRun(argv: string[]): Promise<void> {
       filePath = null;
     } else {
       const result = (await runEvaluation(config)) as EvalResult;
-      report = result.report;
+      report = result.report as Report;
       filePath = result.filePath;
     }
 
@@ -429,15 +445,15 @@ async function handleReport(argv: string[]): Promise<void> {
 
   if (values.export) {
     const { createFileStore } = await import('../server/report-store.js');
-    const { renderRunDetail, renderEachRunDetail } = await import('../renderer/html-renderer.js');
+    const { renderReportDocumentDetail } = await import('../renderer/html-renderer.js');
     const { writeFileSync } = await import('node:fs');
     const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
-    const report: Report | null = await store.get(values.export as string);
+    const report: ReportDocument | null = await store.get(values.export as string);
     if (!report) {
       console.error(tCli('cli.common.report_not_found', lang, { id: values.export as string }));
       process.exit(1);
     }
-    const html: string = report!.each ? renderEachRunDetail(report) : renderRunDetail(report);
+    const html: string = renderReportDocumentDetail(report);
     const outPath: string = resolve(`${values.export}.html`);
     writeFileSync(outPath, html);
     console.log(`Exported to: ${outPath}`);
@@ -877,12 +893,13 @@ async function handleGate(argv: string[]): Promise<void> {
   config.onProgress = makeOnProgress(lang) as unknown as ProgressCallback;
 
   try {
-    const { report } = (await runEvaluation(config)) as EvalResult;
+    const { report: document } = (await runEvaluation(config)) as EvalResult;
 
-    if ((report as Report & { dryRun?: boolean }).dryRun) {
+    if ((document as ReportDocument & { dryRun?: boolean }).dryRun) {
       console.log('Gate dry-run: no scores to check');
       process.exit(0);
     }
+    const report = requireEvaluationReport(document, 'current run', lang);
 
     // gate 内核 = run + verdict, 自动覆盖 omk 全部决策维度(三层 layer-gate /
     // bootstrap diff CI / saturation / Krippendorff α)。computeVerdict 是单一
@@ -963,30 +980,27 @@ async function handleDiff(argv: string[]): Promise<void> {
   }
 
   const [id1, id2]: string[] = positional;
-  const r1: Report | null = await store.get(id1);
-  const r2: Report | null = await store.get(id2);
-
-  if (!r1) { console.error(tCli('cli.common.report_not_found', lang, { id: id1 })); process.exit(1); }
-  if (!r2) { console.error(tCli('cli.common.report_not_found', lang, { id: id2 })); process.exit(1); }
+  const r1 = requireEvaluationReport(await store.get(id1), id1, lang);
+  const r2 = requireEvaluationReport(await store.get(id2), id2, lang);
 
   console.log(`\n  Diff: ${id1} → ${id2}\n`);
 
   // Git info — r1/r2 are guaranteed non-null after process.exit() guards above
-  const g1: GitInfo | null | undefined = r1!.meta?.gitInfo;
-  const g2: GitInfo | null | undefined = r2!.meta?.gitInfo;
+  const g1: GitInfo | null | undefined = r1.meta?.gitInfo;
+  const g2: GitInfo | null | undefined = r2.meta?.gitInfo;
   if (g1 || g2) {
     console.log(`  Git:  ${g1?.commitShort || '?'}${g1?.dirty ? '*' : ''} (${g1?.branch || '?'}) → ${g2?.commitShort || '?'}${g2?.dirty ? '*' : ''} (${g2?.branch || '?'})`);
   }
 
   const { crossReportComparabilityWarnings, formatComparabilityWarnings } = await import('../eval-core/comparability.js');
-  const comparability = formatComparabilityWarnings(crossReportComparabilityWarnings(r1!, r2!), lang);
+  const comparability = formatComparabilityWarnings(crossReportComparabilityWarnings(r1, r2), lang);
   if (comparability) process.stderr.write(`\n${comparability}\n\n`);
 
   // Per-variant comparison
-  const variants: string[] = [...new Set([...(r1!.meta?.variants || []), ...(r2!.meta?.variants || [])])];
+  const variants: string[] = [...new Set([...(r1.meta?.variants || []), ...(r2.meta?.variants || [])])];
   for (const v of variants) {
-    const s1: VariantSummary | undefined = r1!.summary?.[v];
-    const s2: VariantSummary | undefined = r2!.summary?.[v];
+    const s1: VariantSummary | undefined = r1.summary?.[v];
+    const s2: VariantSummary | undefined = r2.summary?.[v];
     if (!s1 && !s2) continue;
 
     console.log(`\n  [${v}]`);
@@ -1024,8 +1038,8 @@ async function handleDiff(argv: string[]): Promise<void> {
     console.log(`    Cost:    ${fmt(cost1, reported1)} → ${fmt(cost2, reported2)}${costPct}`);
 
     // Skill hash change
-    const h1: string | undefined = r1!.meta?.artifactHashes?.[v];
-    const h2: string | undefined = r2!.meta?.artifactHashes?.[v];
+    const h1: string | undefined = r1.meta?.artifactHashes?.[v];
+    const h2: string | undefined = r2.meta?.artifactHashes?.[v];
     if (h1 && h2 && h1 !== h2) {
       console.log(`    Skill:   ${h1.slice(0, 8)} → ${h2.slice(0, 8)} (changed)`);
     }
@@ -1047,15 +1061,11 @@ async function runSampleLevelDiff(
   flags: Record<string, string | boolean | undefined>,
   lang: CliLang,
 ): Promise<void> {
-  const report: Report | null = await store.get(reportId);
-  if (!report) {
-    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
-    process.exit(1);
-  }
+  const report = requireEvaluationReport(await store.get(reportId), reportId, lang);
   const { reportComparabilityWarnings, formatComparabilityWarnings } = await import('../eval-core/comparability.js');
-  const comparability = formatComparabilityWarnings(reportComparabilityWarnings(report!), lang);
+  const comparability = formatComparabilityWarnings(reportComparabilityWarnings(report), lang);
   if (comparability) process.stderr.write(`\n${comparability}\n\n`);
-  const variants = report!.meta?.variants ?? [];
+  const variants = report.meta?.variants ?? [];
   if (variants.length < 2) {
     console.error('Sample-level diff needs at least 2 variants in the report.');
     process.exit(1);
@@ -1072,7 +1082,7 @@ async function runSampleLevelDiff(
   const topN = flags.top != null ? Math.max(1, Number(flags.top) || 0) : undefined;
 
   const rows: Array<{ id: string; cFact?: number; tFact?: number; cBeh?: number; tBeh?: number; cJudge?: number; tJudge?: number; cComp: number; tComp: number; delta: number }> = [];
-  for (const entry of report!.results ?? []) {
+  for (const entry of report.results ?? []) {
     const c = entry.variants?.[control];
     const t = entry.variants?.[treatment];
     if (!c || !t) continue;
@@ -1225,16 +1235,12 @@ async function handleGold(argv: string[]): Promise<void> {
     }
 
     const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
-    const report: Report | null = await store.get(reportId);
-    if (!report) {
-      console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
-      process.exit(1);
-    }
+    const report = requireEvaluationReport(await store.get(reportId), reportId, lang);
 
     const samples = Math.max(100, Number(values['bootstrap-samples']) || 1000);
     const seedVal = values.seed != null ? Number(values.seed) : undefined;
     const result = compareGoldToReport({
-      report: report!,
+      report,
       gold: dataset,
       variant: values.variant as string | undefined,
       samples,
@@ -1288,15 +1294,11 @@ async function handleDebiasValidate(argv: string[]): Promise<void> {
 
   const { createFileStore } = await import('../server/report-store.js');
   const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
-  const report: Report | null = await store.get(reportId);
-  if (!report) {
-    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
-    process.exit(1);
-  }
+  const report = requireEvaluationReport(await store.get(reportId), reportId, lang);
 
   // Resolve samples path: --samples overrides; otherwise read from report.meta.request.
   const samplesPath = (values.samples as string | undefined)
-    ?? report!.meta?.request?.samplesPath;
+    ?? report.meta?.request?.samplesPath;
   if (!samplesPath) {
     console.error('Cannot find samples path. Pass --samples <path> or ensure report has request.samplesPath.');
     process.exit(1);
@@ -1305,7 +1307,7 @@ async function handleDebiasValidate(argv: string[]): Promise<void> {
   const { samples } = loadSamples(samplesPath);
 
   const judgeModel = (values['judge-model'] as string | undefined)
-    ?? report!.meta?.judgeModel;
+    ?? report.meta?.judgeModel;
   if (!judgeModel) {
     console.error(tCli('cli.common.no_judge_model', lang));
     process.exit(1);
@@ -1320,7 +1322,7 @@ async function handleDebiasValidate(argv: string[]): Promise<void> {
   const seedVal = values.seed != null ? Number(values.seed) : undefined;
   const bsRaw = Number(values['bootstrap-samples']) || 1000;
   const result = await validateLengthDebias({
-    report: report!,
+    report,
     samples,
     judgeExecutor,
     judgeModel,
@@ -1358,13 +1360,9 @@ async function handleSaturation(argv: string[]): Promise<void> {
 
   const { createFileStore } = await import('../server/report-store.js');
   const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
-  const report: Report | null = await store.get(reportId);
-  if (!report) {
-    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
-    process.exit(1);
-  }
+  const report = requireEvaluationReport(await store.get(reportId), reportId, lang);
 
-  const saturation = report!.variance?.saturation;
+  const saturation = report.variance?.saturation;
   if (!saturation) {
     console.error(tCli('cli.saturation.no_data', lang));
     process.exit(1);
@@ -1376,7 +1374,7 @@ async function handleSaturation(argv: string[]): Promise<void> {
   // here — that would need raw scores, which would have to be persisted
   // by runMultiple. Future work: opt-in `--persist-saturation-raw` flag at
   // run time to enable post-hoc parameter sweeps.
-  const variants = report!.meta.variants ?? [];
+  const variants = report.meta.variants ?? [];
   const targetVariants = values.variant ? [values.variant as string] : variants;
 
   console.log(tCli('cli.saturation.verdict_header', lang));
@@ -1435,17 +1433,13 @@ async function handleVerdict(argv: string[]): Promise<void> {
 
   const { createFileStore } = await import('../server/report-store.js');
   const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
-  const report: Report | null = await store.get(reportId);
-  if (!report) {
-    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
-    process.exit(1);
-  }
+  const report = requireEvaluationReport(await store.get(reportId), reportId, lang);
 
   const { computeVerdict, formatVerdictText } = await import('../eval-core/verdict.js');
   const { reportComparabilityWarnings, formatComparabilityWarnings } = await import('../eval-core/comparability.js');
-  const comparability = formatComparabilityWarnings(reportComparabilityWarnings(report!), lang);
+  const comparability = formatComparabilityWarnings(reportComparabilityWarnings(report), lang);
   if (comparability) process.stderr.write(`${comparability}\n`);
-  const result = computeVerdict(report!, {
+  const result = computeVerdict(report, {
     gateThreshold: values.threshold != null ? Number(values.threshold) : undefined,
     triviallySmallDiff: values['trivial-diff'] != null ? Number(values['trivial-diff']) : undefined,
   });
@@ -1493,18 +1487,14 @@ async function handleDiagnose(argv: string[]): Promise<void> {
 
   const { createFileStore } = await import('../server/report-store.js');
   const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
-  const report: Report | null = await store.get(reportId);
-  if (!report) {
-    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
-    process.exit(1);
-  }
+  const report = requireEvaluationReport(await store.get(reportId), reportId, lang);
 
   // Try to read the samples file for near-duplicate detection. Source order:
   //  1. --samples <path> override
   //  2. report.meta.request.samplesPath (recorded at run time)
   // If neither resolves to a readable file, skip near-duplicate gracefully.
   let samples: import('../types/index.js').Sample[] | undefined;
-  const samplesPath = (values.samples as string | undefined) ?? report!.meta?.request?.samplesPath;
+  const samplesPath = (values.samples as string | undefined) ?? report.meta?.request?.samplesPath;
   if (samplesPath && existsSync(samplesPath)) {
     try {
       const { loadSamples } = await import('../inputs/load-samples.js');
@@ -1520,7 +1510,7 @@ async function handleDiagnose(argv: string[]): Promise<void> {
   const topN = Number.isFinite(topRaw) && topRaw > 0 ? topRaw : undefined;
 
   const { diagnoseSamples, formatSampleDiagnostics } = await import('../analysis/sample-diagnostics.js');
-  const diag = diagnoseSamples(report!, {
+  const diag = diagnoseSamples(report, {
     samples,
     duplicateRouge: values['duplicate-rouge'] != null ? Number(values['duplicate-rouge']) : undefined,
     ambiguousStddev: values['ambiguous-stddev'] != null ? Number(values['ambiguous-stddev']) : undefined,
@@ -1535,7 +1525,7 @@ async function handleDiagnose(argv: string[]): Promise<void> {
   // 跟 issue list 是不同视角的两件事。优先从 samples (现场加载) 算,fallback 到
   // report.analysis.sampleQuality(报告里持久化的数据)。
   const { renderSampleDesignCoverage } = await import('./coverage-renderer.js');
-  const coverageBlock = renderSampleDesignCoverage(samples, report!.analysis?.sampleQuality, lang);
+  const coverageBlock = renderSampleDesignCoverage(samples, report.analysis?.sampleQuality, lang);
   if (coverageBlock) console.log(coverageBlock);
 
   // Exit code: 0 if health ≥ 70 and no errors; 1 otherwise. CI-friendly.
@@ -1573,13 +1563,9 @@ async function handleFailures(argv: string[]): Promise<void> {
 
   const { createFileStore } = await import('../server/report-store.js');
   const store: ReportStore = createFileStore(resolve(values['reports-dir'] as string));
-  const report: Report | null = await store.get(reportId);
-  if (!report) {
-    console.error(tCli('cli.common.report_not_found', lang, { id: reportId }));
-    process.exit(1);
-  }
+  const report = requireEvaluationReport(await store.get(reportId), reportId, lang);
 
-  const judgeModel = (values['judge-model'] as string | undefined) ?? report!.meta?.judgeModel;
+  const judgeModel = (values['judge-model'] as string | undefined) ?? report.meta?.judgeModel;
   if (!judgeModel) {
     console.error(tCli('cli.common.no_judge_model', lang));
     process.exit(1);
@@ -1590,7 +1576,7 @@ async function handleFailures(argv: string[]): Promise<void> {
   const { clusterFailures, formatFailureClusterReport } = await import('../analysis/failure-clusterer.js');
 
   const out = await clusterFailures({
-    report: report!,
+    report,
     executor,
     judgeModel,
     maxClusters: Number(values['max-clusters']) || 5,

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -72,7 +72,11 @@ function hashSample(sample: Sample): string {
   return hashString(stableForm);
 }
 
-function getGitInfo(): GitInfo | null {
+export function getCliVersion(): string {
+  return PKG.version;
+}
+
+export function getGitInfo(): GitInfo | null {
   try {
     const commit = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim();
     const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf-8' }).trim();
@@ -246,6 +250,7 @@ export function aggregateReport({
   if (lengthDebiasOn) debiasModeList.push('length');
 
   return {
+    kind: 'evaluation',
     id: runId,
     meta: {
       variants,
@@ -256,7 +261,7 @@ export function aggregateReport({
       taskCount: tasks.length,
       totalCostUSD: Number(totalCostUSD.toFixed(6)),
       timestamp: new Date().toISOString(),
-      cliVersion: PKG.version,
+      cliVersion: getCliVersion(),
       nodeVersion: process.version,
       artifactHashes,
       sampleHashes,

--- a/src/eval-workflows/each-evaluation-workflow.ts
+++ b/src/eval-workflows/each-evaluation-workflow.ts
@@ -1,10 +1,19 @@
 import { dirname, resolve } from 'node:path';
-import { DEFAULT_OUTPUT_DIR, generateRunId, persistReport } from '../eval-core/evaluation-reporting.js';
+import { DEFAULT_OUTPUT_DIR, generateRunId, getCliVersion, getGitInfo, persistReport } from '../eval-core/evaluation-reporting.js';
 import { buildEvaluationRequest, createEvaluationRun, createSucceededJob, finalizeEvaluationRun } from '../eval-core/evaluation-job.js';
 import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
 import { createFileJobStore, DEFAULT_JOBS_DIR } from '../server/job-store.js';
 import { resolveArtifacts } from '../inputs/skill-loader.js';
-import type { Artifact, ExecutorRuntimeFingerprint, JobStore, ProgressCallback, Report, VarianceData, VariantResult, VariantSummary } from '../types/index.js';
+import type {
+  Artifact,
+  EvaluationBatchIndex,
+  EvaluationBatchIndexItem,
+  EvaluationReport,
+  ExecutorRuntimeFingerprint,
+  JobStore,
+  ProgressCallback,
+  VariantSummary,
+} from '../types/index.js';
 
 interface RunSingleEvaluationOptions {
   samplesPath: string;
@@ -12,7 +21,7 @@ interface RunSingleEvaluationOptions {
   artifacts: Artifact[];
   model: string;
   judgeModel: string;
-  outputDir: null;
+  outputDir: string | null;
   noJudge: boolean;
   concurrency: number;
   timeoutMs?: number;
@@ -24,32 +33,21 @@ interface RunSingleEvaluationOptions {
   skipPreflight: boolean;
   mcpConfig?: string;
   verbose: boolean;
-  /** Forwarded to grade(); each sample × dimension is judged N times. Default 1. */
+  runId?: string;
+  /** Forwarded to grade(); each sample x dimension is judged N times. Default 1. */
   judgeRepeat?: number;
-  /** Forwarded to pipeline; ≥ 2 entries triggers multi-judge ensemble mode. */
+  /** Forwarded to pipeline; >= 2 entries triggers multi-judge ensemble mode. */
   judgeModels?: import('../types/index.js').JudgeConfig[];
   /** v0.21 Phase 3a length-debias toggle. Default true. */
   lengthDebias?: boolean;
 }
 
-export interface EachSkillResult {
+interface CompletedEachSkillRun {
   name: string;
-  artifactHash: string;
+  skillPath: string;
   samplesPath: string;
-  sampleCount: number;
-  summary: Record<string, VariantSummary>;
-  /** repeat > 1 时由 runMultiple 聚合,承载三层独立 variance + t 检验 */
-  variance?: VarianceData;
-  /** Runtime fingerprints from the single skill-vs-baseline run. */
-  executorRuntimes?: Record<string, ExecutorRuntimeFingerprint>;
-  executorRuntime?: ExecutorRuntimeFingerprint;
-  results: Array<{
-    sample_id: string;
-    variants: {
-      baseline: VariantResult;
-      skill: VariantResult;
-    };
-  }>;
+  report: EvaluationReport;
+  filePath: string | null;
 }
 
 function commonRuntime(runtimes: Record<string, ExecutorRuntimeFingerprint>): ExecutorRuntimeFingerprint | undefined {
@@ -59,27 +57,62 @@ function commonRuntime(runtimes: Record<string, ExecutorRuntimeFingerprint>): Ex
   return values.every((runtime) => runtime.fingerprint === first.fingerprint) ? first : undefined;
 }
 
-function buildEachOverview(skillResults: EachSkillResult[], totalCostUSD: number) {
+function safeRunIdPart(value: string): string {
+  return value
+    .replaceAll(/[\\/:]/g, '-')
+    .replaceAll(/[^a-zA-Z0-9._@-]/g, '_')
+    .replace(/^_+|_+$/g, '')
+    || 'skill';
+}
+
+function reportSummarySnapshot(report: EvaluationReport): Record<string, VariantSummary> {
   return {
-    totalArtifacts: skillResults.length,
-    totalSamples: skillResults.reduce((sum, skill) => sum + skill.sampleCount, 0),
-    totalCostUSD: Number(totalCostUSD.toFixed(6)),
-    artifacts: skillResults.map((skill) => {
-      const baselineSummary = skill.summary.baseline;
-      const artifactSummary = skill.summary.skill;
-      const baselineScore = baselineSummary?.avgCompositeScore ?? baselineSummary?.avgLlmScore ?? null;
-      const artifactScore = artifactSummary?.avgCompositeScore ?? artifactSummary?.avgLlmScore ?? null;
-      if (typeof baselineScore !== 'number' || typeof artifactScore !== 'number' || baselineScore <= 0) {
-        return { name: skill.name, baselineScore, artifactScore, improvement: '-' };
-      }
-      const delta = ((artifactScore - baselineScore) / baselineScore * 100).toFixed(0);
-      const improvement = artifactScore >= baselineScore ? `+${delta}%` : `${delta}%`;
-      return { name: skill.name, baselineScore, artifactScore, improvement };
-    }),
+    baseline: report.summary.baseline || ({} as VariantSummary),
+    skill: report.summary.skill || ({} as VariantSummary),
   };
 }
 
-export function buildEachReport({
+function buildBatchItems(skillResults: CompletedEachSkillRun[]): EvaluationBatchIndexItem[] {
+  return skillResults.map(({ name, skillPath, samplesPath, report, filePath }) => ({
+    name,
+    skillPath,
+    samplesPath,
+    reportId: report.id,
+    reportPath: filePath,
+    status: 'completed',
+    sampleCount: report.meta.sampleCount,
+    totalCostUSD: report.meta.totalCostUSD,
+    artifactHash: report.meta.artifactHashes?.skill || null,
+    summary: reportSummarySnapshot(report),
+    ...(report.variance ? { variance: report.variance } : {}),
+  }));
+}
+
+function buildExecutorRuntimesBySkill({
+  skillDir,
+  skillResults,
+  executorName,
+  model,
+}: {
+  skillDir: string;
+  skillResults: CompletedEachSkillRun[];
+  executorName: string;
+  model: string;
+}): Record<string, ExecutorRuntimeFingerprint> {
+  const executorRuntimes: Record<string, ExecutorRuntimeFingerprint> = {};
+  for (const skill of skillResults) {
+    executorRuntimes[skill.name] =
+      skill.report.meta.executorRuntimes?.skill
+      ?? skill.report.meta.executorRuntime
+      ?? getExecutorRuntimeFingerprint(executorName, model, {
+        skillDir: skill.skillPath ? dirname(skill.skillPath) : skillDir,
+      });
+  }
+  return executorRuntimes;
+}
+
+export function buildEvaluationBatchIndex({
+  batchRunId,
   skillDir,
   skillEntries,
   skillResults,
@@ -91,16 +124,16 @@ export function buildEachReport({
   project,
   owner,
   tags,
-  dryRun,
   concurrency,
   timeoutMs,
   totalCostUSD,
   repeat,
   judgeModels,
 }: {
+  batchRunId: string;
   skillDir: string;
   skillEntries: Array<{ name: string; skillPath: string; samplesPath: string }>;
-  skillResults: EachSkillResult[];
+  skillResults: CompletedEachSkillRun[];
   model: string;
   judgeModel: string;
   noJudge: boolean;
@@ -109,14 +142,12 @@ export function buildEachReport({
   project?: string;
   owner?: string;
   tags?: string[];
-  dryRun: boolean;
   concurrency: number;
   timeoutMs?: number;
   totalCostUSD: number;
   repeat?: number;
   judgeModels?: import('../types/index.js').JudgeConfig[];
-}) {
-  const runId = generateRunId(['each']);
+}): { report: EvaluationBatchIndex; job: import('../types/index.js').EvaluationJob } {
   const request = buildEvaluationRequest({
     samplesPath: '',
     skillDir,
@@ -135,7 +166,7 @@ export function buildEachReport({
     concurrency,
     timeoutMs,
     noCache: false,
-    dryRun,
+    dryRun: false,
     blind: false,
     project,
     owner,
@@ -145,70 +176,59 @@ export function buildEachReport({
     each: true,
   });
   const createdAt = new Date().toISOString();
-  const { run: initialRun, startedAt } = createEvaluationRun(runId, createdAt);
+  const { run: initialRun, startedAt } = createEvaluationRun(batchRunId, createdAt);
   const finishedAt = new Date().toISOString();
   const run = finalizeEvaluationRun(initialRun, finishedAt);
   const job = createSucceededJob({
-    jobId: `job-${runId}`,
-    runId,
-    reportId: runId,
+    jobId: `job-${batchRunId}`,
+    runId: batchRunId,
+    reportId: batchRunId,
     request,
     createdAt,
     startedAt,
     finishedAt,
   });
-  const totalSampleCount = skillResults.reduce((sum, skill) => sum + skill.sampleCount, 0);
-  const executorRuntimes: Record<string, ExecutorRuntimeFingerprint> = {};
-  const entryByName = new Map(skillEntries.map((entry) => [entry.name, entry]));
-  for (const skill of skillResults) {
-    const entry = entryByName.get(skill.name);
-    executorRuntimes[skill.name] =
-      skill.executorRuntimes?.skill
-      ?? skill.executorRuntime
-      ?? getExecutorRuntimeFingerprint(executorName, model, {
-        skillDir: entry ? dirname(entry.skillPath) : skillDir,
-      });
-  }
-  const executorRuntime = commonRuntime(executorRuntimes) ?? Object.values(executorRuntimes)[0] ?? getExecutorRuntimeFingerprint(executorName, model, { skillDir });
+  const sampleCount = skillResults.reduce((sum, skill) => sum + skill.report.meta.sampleCount, 0);
+  const executorRuntimes = buildExecutorRuntimesBySkill({ skillDir, skillResults, executorName, model });
+  const executorRuntime = commonRuntime(executorRuntimes)
+    ?? Object.values(executorRuntimes)[0]
+    ?? getExecutorRuntimeFingerprint(executorName, model, { skillDir });
 
-  return {
-    report: {
-      id: runId,
-      each: true,
-      meta: {
-        variants: skillEntries.map((entry) => entry.name),
-        model,
-        judgeModel: noJudge ? null : judgeModel,
-        executor: executorName,
-        sampleCount: totalSampleCount,
-        taskCount: totalSampleCount * 2,
-        totalCostUSD: Number(totalCostUSD.toFixed(6)),
-        timestamp: new Date().toISOString(),
-        cliVersion: '',
-        nodeVersion: process.version,
-        artifactHashes: Object.fromEntries(
-          skillResults.map((skill) => [skill.name, skill.artifactHash || 'no-skill']),
+  const report: EvaluationBatchIndex = {
+    kind: 'batch-index',
+    id: batchRunId,
+    mode: 'each',
+    meta: {
+      mode: 'each',
+      model,
+      judgeModel: noJudge ? null : judgeModel,
+      executor: executorName,
+      skillDir,
+      sampleCount,
+      taskCount: sampleCount * 2,
+      totalArtifacts: skillResults.length,
+      totalCostUSD: Number(totalCostUSD.toFixed(6)),
+      timestamp: finishedAt,
+      cliVersion: getCliVersion(),
+      nodeVersion: process.version,
+      executorRuntime,
+      executorRuntimes,
+      judgeRuntime: noJudge ? null : getExecutorRuntimeFingerprint(judgeExecutorName || executorName, judgeModel, { skillDir }),
+      ...(judgeModels && judgeModels.length >= 2 ? {
+        judgeModels: judgeModels.map((jc) => `${jc.executor}:${jc.model}`),
+        judgeRuntimes: Object.fromEntries(
+          judgeModels.map((jc) => [`${jc.executor}:${jc.model}`, getExecutorRuntimeFingerprint(jc.executor, jc.model, { skillDir })]),
         ),
-        executorRuntime,
-        executorRuntimes,
-        judgeRuntime: noJudge ? null : getExecutorRuntimeFingerprint(judgeExecutorName || executorName, judgeModel, { skillDir }),
-        ...(judgeModels && judgeModels.length >= 2 ? {
-          judgeModels: judgeModels.map((jc) => `${jc.executor}:${jc.model}`),
-          judgeRuntimes: Object.fromEntries(
-            judgeModels.map((jc) => [`${jc.executor}:${jc.model}`, getExecutorRuntimeFingerprint(jc.executor, jc.model, { skillDir })]),
-          ),
-        } : {}),
-        request,
-        run,
-        job,
-      },
-      summary: {},
-      results: [],
-      overview: buildEachOverview(skillResults, totalCostUSD),
-      artifacts: skillResults,
-    } satisfies Report,
-    job,
+      } : {}),
+      request,
+      run,
+      job,
+      gitInfo: getGitInfo(),
+    },
+    items: buildBatchItems(skillResults),
   };
+
+  return { report, job };
 }
 
 export async function executeEachEvaluationRuns({
@@ -264,25 +284,21 @@ export async function executeEachEvaluationRuns({
   judgeRepeat?: number;
   judgeModels?: import('../types/index.js').JudgeConfig[];
   lengthDebias?: boolean;
-  /**  — strict-baseline default. Forwarded to per-skill resolveArtifacts so each
-   *  skill's baseline gets allowedSkills=[] when default true. */
+  /** strict-baseline default. Forwarded to per-skill resolveArtifacts. */
   strictBaseline?: boolean;
-  /**  — explicit per-variant allowedSkills override. each mode rarely uses this
-   *  (since it auto-pairs baseline + skill), but if user has yaml override on either
-   *  "baseline" or "skill" name, we honor it. */
+  /** explicit per-variant allowedSkills override. */
   variantAllowedSkills?: Record<string, string[]>;
-  runSingleEvaluation: (options: RunSingleEvaluationOptions) => Promise<{ report: Report; filePath: string | null }>;
-}): Promise<{ report: Report; filePath: string | null }> {
-  const skillResults: EachSkillResult[] = [];
+  runSingleEvaluation: (options: RunSingleEvaluationOptions) => Promise<{ report: EvaluationReport; filePath: string | null }>;
+}): Promise<{ report: EvaluationBatchIndex; filePath: string | null }> {
+  const batchRunId = generateRunId(['each']);
+  const skillResults: CompletedEachSkillRun[] = [];
   let totalCostUSD = 0;
 
   for (let i = 0; i < skillEntries.length; i++) {
     const entry = skillEntries[i];
     onSkillProgress?.({ phase: 'start', skill: entry.name, current: i + 1, total: skillEntries.length });
 
-    // each mode 的实验结构固定为"baseline (control) vs skill (treatment)"。
-    // 显式在 artifact 上填 experimentRole，下游 buildVariantConfig 直接读取。
-    //  — pass strictBaseline + variantAllowedSkills opts so isolation 默认生效。
+    // each mode 的实验结构固定为 "baseline (control) vs skill (treatment)"。
     const skillArtifacts = resolveArtifacts(
       resolve(skillDir),
       ['baseline', entry.skillPath],
@@ -293,13 +309,14 @@ export async function executeEachEvaluationRuns({
       }
       return { ...artifact, experimentRole: 'control' as const };
     });
-    const { report } = await runSingleEvaluation({
+    const childRunId = `${batchRunId}-${String(i + 1).padStart(2, '0')}-${safeRunIdPart(entry.name)}`;
+    const { report, filePath } = await runSingleEvaluation({
       samplesPath: entry.samplesPath,
       skillDir,
       artifacts: skillArtifacts,
       model,
       judgeModel,
-      outputDir: null,
+      outputDir,
       noJudge,
       concurrency,
       timeoutMs,
@@ -311,6 +328,7 @@ export async function executeEachEvaluationRuns({
       skipPreflight: skipPreflight || i > 0,
       mcpConfig,
       verbose,
+      runId: childRunId,
       judgeRepeat,
       judgeModels,
       lengthDebias,
@@ -318,31 +336,18 @@ export async function executeEachEvaluationRuns({
 
     skillResults.push({
       name: entry.name,
-      artifactHash: report.meta.artifactHashes?.skill || '',
+      skillPath: entry.skillPath,
       samplesPath: entry.samplesPath,
-      sampleCount: report.meta.sampleCount,
-      summary: {
-        baseline: report.summary.baseline || ({} as VariantSummary),
-        skill: (report.summary.skill || {}) as VariantSummary,
-      },
-      // runMultiple 跑 N 次后会把 variance 挂到 report.variance,这里搬到 skill 维度
-      ...(report.variance ? { variance: report.variance } : {}),
-      executorRuntimes: report.meta.executorRuntimes,
-      executorRuntime: report.meta.executorRuntime,
-      results: report.results.map((result) => ({
-        sample_id: result.sample_id,
-        variants: {
-          baseline: result.variants.baseline || result.variants['baseline'],
-          skill: result.variants.skill,
-        },
-      })),
+      report,
+      filePath,
     });
 
     totalCostUSD += report.meta.totalCostUSD;
     onSkillProgress?.({ phase: 'done', skill: entry.name, current: i + 1, total: skillEntries.length });
   }
 
-  const { report: combinedReport, job } = buildEachReport({
+  const { report: batchIndex, job } = buildEvaluationBatchIndex({
+    batchRunId,
     skillDir,
     skillEntries,
     skillResults,
@@ -354,15 +359,14 @@ export async function executeEachEvaluationRuns({
     project,
     owner,
     tags,
-    dryRun: false,
     concurrency,
     timeoutMs,
     totalCostUSD,
     repeat,
     judgeModels,
   });
-  const filePath = persistReport(combinedReport, outputDir);
+  const filePath = persistReport(batchIndex, outputDir);
   const resolvedJobStore = persistJob ? (jobStore ?? createFileJobStore(DEFAULT_JOBS_DIR)) : null;
   if (resolvedJobStore) await resolvedJobStore.save(job.jobId, job);
-  return { report: combinedReport, filePath };
+  return { report: batchIndex, filePath };
 }

--- a/src/eval-workflows/each-evaluation-workflow.ts
+++ b/src/eval-workflows/each-evaluation-workflow.ts
@@ -65,10 +65,10 @@ function safeRunIdPart(value: string): string {
     || 'skill';
 }
 
-function reportSummarySnapshot(report: EvaluationReport): Record<string, VariantSummary> {
+function reportSummarySnapshot(report: EvaluationReport, treatmentVariant: string): Record<string, VariantSummary> {
   return {
     baseline: report.summary.baseline || ({} as VariantSummary),
-    skill: report.summary.skill || ({} as VariantSummary),
+    [treatmentVariant]: report.summary[treatmentVariant] || ({} as VariantSummary),
   };
 }
 
@@ -82,8 +82,8 @@ function buildBatchItems(skillResults: CompletedEachSkillRun[]): EvaluationBatch
     status: 'completed',
     sampleCount: report.meta.sampleCount,
     totalCostUSD: report.meta.totalCostUSD,
-    artifactHash: report.meta.artifactHashes?.skill || null,
-    summary: reportSummarySnapshot(report),
+    artifactHash: report.meta.artifactHashes?.[name] || null,
+    summary: reportSummarySnapshot(report, name),
     ...(report.variance ? { variance: report.variance } : {}),
   }));
 }
@@ -102,7 +102,7 @@ function buildExecutorRuntimesBySkill({
   const executorRuntimes: Record<string, ExecutorRuntimeFingerprint> = {};
   for (const skill of skillResults) {
     executorRuntimes[skill.name] =
-      skill.report.meta.executorRuntimes?.skill
+      skill.report.meta.executorRuntimes?.[skill.name]
       ?? skill.report.meta.executorRuntime
       ?? getExecutorRuntimeFingerprint(executorName, model, {
         skillDir: skill.skillPath ? dirname(skill.skillPath) : skillDir,
@@ -298,14 +298,17 @@ export async function executeEachEvaluationRuns({
     const entry = skillEntries[i];
     onSkillProgress?.({ phase: 'start', skill: entry.name, current: i + 1, total: skillEntries.length });
 
-    // each mode 的实验结构固定为 "baseline (control) vs skill (treatment)"。
+    // each mode 的实验结构固定为 baseline control vs 当前 skill treatment。
+    const perSkillAllowedSkills = variantAllowedSkills?.[entry.name] !== undefined
+      ? { ...variantAllowedSkills, [entry.skillPath]: variantAllowedSkills[entry.name] }
+      : variantAllowedSkills;
     const skillArtifacts = resolveArtifacts(
       resolve(skillDir),
       ['baseline', entry.skillPath],
-      { strictBaseline, variantAllowedSkills },
+      { strictBaseline, variantAllowedSkills: perSkillAllowedSkills },
     ).map((artifact) => {
       if (artifact.name === entry.skillPath) {
-        return { ...artifact, name: 'skill', experimentRole: 'treatment' as const };
+        return { ...artifact, name: entry.name, experimentRole: 'treatment' as const };
       }
       return { ...artifact, experimentRole: 'control' as const };
     });

--- a/src/eval-workflows/evaluation-pipeline.ts
+++ b/src/eval-workflows/evaluation-pipeline.ts
@@ -379,6 +379,8 @@ export interface EvaluationPipelineOptions {
    *  isolation-disabled pre-flight warnings). True/undefined = default behavior
    *  (no warning); false = user explicitly disabled, warn if ~/.claude/skills/ has content. */
   strictBaseline?: boolean;
+  /** Explicit persisted run id. Used by batch workflows that need stable child ids. */
+  runId?: string;
 }
 
 export async function executeEvaluationPipeline({
@@ -420,6 +422,7 @@ export async function executeEvaluationPipeline({
   lengthDebias = true,
   budget,
   strictBaseline,
+  runId,
 }: EvaluationPipelineOptions): Promise<{ report: Report; filePath: string | null }> {
   const variantNames = artifacts.map((artifact) => artifact.name);
   const runState = await initializeEvaluationRunState({
@@ -438,7 +441,7 @@ export async function executeEvaluationPipeline({
     project,
     owner,
     tags,
-    runId: generateRunId(variantNames),
+    runId: runId ?? generateRunId(variantNames),
     jobStore,
     persistJob,
     repeat,

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -13,6 +13,8 @@ import { executeEvaluationPipeline } from './evaluation-pipeline.js';
 
 import type {
   Artifact,
+  EvaluationBatchIndex,
+  EvaluationReport,
   ExecutorFn,
   JobStore,
   ProgressCallback,
@@ -92,6 +94,8 @@ export interface RunEvaluationOptions extends CommonEvaluationOptions {
   noCache?: boolean;
   retry?: number;
   resume?: string;
+  /** Explicit persisted run id. Used by batch workflows that need stable child ids. */
+  runId?: string;
   /** strict-baseline default (CLI `--strict-baseline` default true).
    *  When undefined, treated as true. baseline-kind variants get allowedSkills=[]
    *  unless eval.yaml explicitly overrides per-variant. */
@@ -174,6 +178,7 @@ export async function runEvaluation({
   verbose = false,
   retry = 0,
   resume,
+  runId,
   layeredStats = false,
   repeat,
   each,
@@ -227,7 +232,7 @@ export async function runEvaluation({
     const { createFileStore } = await import('../server/report-store.js');
     const store = createFileStore(resolve(outputDir || DEFAULT_OUTPUT_DIR));
     const existing = await store.get(resume);
-    if (existing) {
+    if (existing?.kind === 'evaluation') {
       existingResults = {};
       for (const entry of existing.results || []) {
         existingResults[entry.sample_id] = entry.variants;
@@ -253,6 +258,8 @@ export async function runEvaluation({
           + `   新 entries 不隔离 → 与现有 entries 不可比。建议恢复默认 strict-baseline。\n`,
         );
       }
+    } else if (existing?.kind === 'batch-index') {
+      process.stderr.write(`\n⚠️  report ${resume} is an each batch index; resume needs a child EvaluationReport, starting from scratch\n`);
     } else {
       process.stderr.write(`\n⚠️  report ${resume} not found, starting from scratch\n`);
     }
@@ -299,6 +306,7 @@ export async function runEvaluation({
     lengthDebias,
     budget,
     strictBaseline,
+    runId,
   });
 }
 
@@ -540,7 +548,7 @@ export async function runEachEvaluation({
   lengthDebias,
   strictBaseline,
   variantAllowedSkills,
-}: RunEachEvaluationOptions): Promise<{ report: Report | DryRunEachReport; filePath: string | null }> {
+}: RunEachEvaluationOptions): Promise<{ report: EvaluationBatchIndex | DryRunEachReport; filePath: string | null }> {
   const skillEntries = discoverEachSkills(resolve(skillDir));
   if (skillEntries.length === 0) {
     throw new Error(`no skill with paired eval-samples found in: ${skillDir}`);
@@ -594,10 +602,10 @@ export async function runEachEvaluation({
       // repeat > 1 时走 runMultiple 做 variance; each=true 标记让 meta.request 如实反映
       if (repeat && repeat > 1) {
         const multi = await runMultiple({ ...options, repeat, each: true, judgeRepeat, judgeModels, lengthDebias });
-        return { report: multi.report, filePath: multi.filePath };
+        return { report: multi.report as EvaluationReport, filePath: multi.filePath };
       }
       const result = await runEvaluation({ ...options, each: true, judgeRepeat, judgeModels, lengthDebias });
-      return { report: result.report as Report, filePath: result.filePath };
+      return { report: result.report as EvaluationReport, filePath: result.filePath };
     },
   });
 }

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -19,7 +19,7 @@ import {
 import { renderSampleTable } from './table.js';
 import { renderTrendsBody } from './trends.js';
 import { computeVerdict, type VerdictLevel } from '../eval-core/verdict.js';
-import type { ExecutorRuntimeFingerprint, Report, Lang } from '../types/index.js';
+import type { EvaluationBatchIndex, EvaluationReport, ExecutorRuntimeFingerprint, Report, ReportDocument, Lang, VariantSummary } from '../types/index.js';
 
 // v0.21 B.4 — 列表页 status pill 用的 dot. PROGRESS/REGRESS 实心(强信号),
 // CAUTIOUS 三角(警示),NOISE 空心圆(有信号但无效果),UNDERPOWERED 部分填充
@@ -35,9 +35,21 @@ function levelDot(level: VerdictLevel): string {
   }
 }
 
-type EachOverview = NonNullable<Report['overview']>;
-type EachOverviewArtifact = EachOverview['artifacts'][number];
-type EachArtifactReport = NonNullable<Report['artifacts']>[number];
+type RuntimeMeta = Pick<EvaluationReport['meta'], 'executorRuntime' | 'executorRuntimes' | 'judgeRuntime' | 'judgeRuntimes'>;
+
+function isEvaluationReport(document: ReportDocument): document is EvaluationReport {
+  return document.kind === 'evaluation';
+}
+
+function scoreOf(summary: VariantSummary | undefined): number | null {
+  return summary?.avgCompositeScore ?? summary?.avgLlmScore ?? null;
+}
+
+function improvementOf(baselineScore: number | null, skillScore: number | null): string {
+  if (typeof baselineScore !== 'number' || typeof skillScore !== 'number' || baselineScore <= 0) return '-';
+  const delta = ((skillScore - baselineScore) / baselineScore * 100).toFixed(0);
+  return skillScore >= baselineScore ? `+${delta}%` : `${delta}%`;
+}
 
 function renderRuntimeTag(runtime: ExecutorRuntimeFingerprint | null | undefined, label: string, lang: Lang): string {
   if (!runtime) return '';
@@ -67,7 +79,7 @@ function renderRuntimeTag(runtime: ExecutorRuntimeFingerprint | null | undefined
   return `<span class="meta-tag" title="${e(title)}">${e(label)}: <code>${e(runtime.fingerprint)}</code>${versionText}</span>`;
 }
 
-function renderJudgeRuntimeTags(meta: Report['meta'], lang: Lang): string {
+function renderJudgeRuntimeTags(meta: RuntimeMeta, lang: Lang): string {
   if (meta.judgeRuntimes && Object.keys(meta.judgeRuntimes).length > 0) {
     return Object.entries(meta.judgeRuntimes)
       .sort(([a], [b]) => a.localeCompare(b))
@@ -81,7 +93,7 @@ function renderJudgeRuntimeTags(meta: Report['meta'], lang: Lang): string {
   return renderRuntimeTag(meta.judgeRuntime, lang === 'zh' ? '评委指纹' : 'Judge runtime', lang);
 }
 
-function renderExecutorRuntimeTags(meta: Report['meta'], lang: Lang): string {
+function renderExecutorRuntimeTags(meta: RuntimeMeta, lang: Lang): string {
   if (meta.executorRuntimes && Object.keys(meta.executorRuntimes).length > 0) {
     return Object.entries(meta.executorRuntimes)
       .sort(([a], [b]) => a.localeCompare(b))
@@ -95,7 +107,7 @@ function renderExecutorRuntimeTags(meta: Report['meta'], lang: Lang): string {
   return renderRuntimeTag(meta.executorRuntime, lang === 'zh' ? '执行器指纹' : 'Executor runtime', lang);
 }
 
-export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string {
+export function renderRunList(runs: ReportDocument[], lang: Lang = DEFAULT_LANG): string {
   const langQ = lang === DEFAULT_LANG ? '' : `?lang=${lang}`;
   const skillHealthLink = `<a href="/analyses${langQ}" style="color:var(--text-muted);font-size:12px;text-decoration:none;border:1px solid var(--border);padding:4px 10px;border-radius:var(--radius);display:inline-block">📊 <span data-i18n="skillHealthTitle">${t('skillHealthTitle', lang)}</span> →</a>`;
   if (!runs || runs.length === 0) {
@@ -110,6 +122,40 @@ export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string
   }
 
   const rows = runs.map((run) => {
+    if (run.kind === 'batch-index') {
+      const m = run.meta;
+      const scoreCol = run.items.length > 0
+        ? run.items.map((item) => {
+          const baselineScore = scoreOf(item.summary.baseline);
+          const skillScore = scoreOf(item.summary.skill);
+          const score = skillScore ?? baselineScore;
+          if (score == null) return `<span style="color:var(--text-muted)">${e(item.name)}: -</span>`;
+          const color = score >= 4 ? 'var(--green)' : score >= 3 ? 'var(--yellow)' : 'var(--red)';
+          const barW = Math.round((score / 5) * 100);
+          return `<div style="display:flex;align-items:center;gap:6px;margin:2px 0">` +
+            `<span title="${e(item.name)}" style="font-size:11px;color:var(--text-muted);width:56px;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex-shrink:0">${e(item.name)}</span>` +
+            `<div style="width:64px;height:6px;background:var(--bg-surface);border-radius:3px;flex-shrink:0">` +
+            `<div style="width:${barW}%;height:100%;background:${color};border-radius:3px"></div></div>` +
+            `<span style="font-size:12px;font-weight:600;color:${color};min-width:24px">${score.toFixed(2)}</span></div>`;
+        }).join('')
+        : '<div style="color:var(--text-faint);font-size:0.6875rem;text-align:center">no score</div>';
+      const allCostReported = run.items.every((item) =>
+        Object.values(item.summary || {}).every((v) => v.execCostReported !== false && v.judgeCostReported !== false));
+      const totalDurationMs = run.items.reduce((sum, item) => (
+        sum + Object.values(item.summary || {}).reduce((inner, v) => inner + (v.avgDurationMs || 0) * (v.successCount || 0), 0)
+      ), 0);
+      const statusPill = `<span class="run-status" title="${lang === 'zh' ? 'each 批次索引' : 'each batch index'}"><span class="run-status-dot" aria-hidden="true">◇</span>${lang === 'zh' ? '批次' : 'Batch'}</span>`;
+      return `<tr>
+      <td>${statusPill}<a href="/reports/${e(run.id)}"><span style="color:var(--text-primary)">${e(run.id)}</span><br><span style="font-size:0.6875rem;color:var(--text-muted)">${m.timestamp ? new Date(m.timestamp).toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' }) : e(run.id)}</span></a></td>
+      <td>${e(m.model || '-')}</td>
+      <td>${m.sampleCount || 0}</td>
+      <td>${scoreCol}</td>
+      <td>${fmtCost(m.totalCostUSD || 0, allCostReported)}</td>
+      <td>${fmtDuration(totalDurationMs)}</td>
+      <td style="white-space:nowrap"><button onclick="deleteRun('${e(run.id)}',this)" class="btn-danger" data-i18n="deleteBtnText">${t('deleteBtnText', lang)}</button></td>
+    </tr>`;
+    }
+
     const m = run.meta;
     const hasScores = Object.values(run.summary || {}).some((s) =>
       typeof s.avgCompositeScore === 'number' || typeof s.avgLlmScore === 'number'
@@ -131,9 +177,8 @@ export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string
 
     // v0.21 B.4 — 列表页 verdict pill: 一眼分辨 progress / regress / noise.
     // computeVerdict 是同步纯函数(report -> level),per row 跑成本 O(samples).
-    // each mode 或脏老报告会让 layer-gates 访问 undefined.avgFactScore 抛 NPE,
-    // try/catch 兜底, 失败的 row 不显示 pill(不要让一个坏 report 把整个列表
-    // 撤掉). verdict.ts 的 defensive 修复另立 task.
+    // 脏报告可能让 layer-gates 访问 undefined.avgFactScore 抛 NPE。
+    // try/catch 兜底,失败的 row 不显示 pill,避免一个坏 report 撤掉整页。
     let statusPill = '';
     try {
       const verdict = computeVerdict(run);
@@ -165,9 +210,10 @@ export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string
   // 列表累计:只 sum 那些"全 variant 都报告了 cost"的 run,跳过任一 variant not reported 的。
   // 排除 not reported(而不是把整体压成「—」)是因为列表常含数十个 run 仅 1-2 个是 codex,
   // 把全部 sum 抹成「—」会丢掉绝大多数有效成本信息。
-  const reportableRuns = runs.filter((r) =>
+  const evaluationRuns = runs.filter(isEvaluationReport);
+  const reportableRuns = evaluationRuns.filter((r) =>
     Object.values(r.summary || {}).every((v) => v.execCostReported !== false));
-  const unmeasuredRunsCount = runs.length - reportableRuns.length;
+  const unmeasuredRunsCount = evaluationRuns.length - reportableRuns.length;
   const totalCost = reportableRuns.reduce((s, r) => s + Object.values(r.summary || {}).reduce((sv, v) => sv + (v.totalExecCostUSD || 0), 0), 0);
   // partial:有 reported 就显示数字 + tooltip;全部 not reported 才显示「—」;
   // 全 reported(unmeasuredRunsCount=0)走老格式不包 span,保持 HTML snapshot 向后兼容。
@@ -181,14 +227,14 @@ export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string
     costLabel = `${baseLabel} ${costNumber}`;
   } else {
     const tip = lang === 'zh'
-      ? `${reportableRuns.length}/${runs.length} 次报告了 USD 成本;${unmeasuredRunsCount} 次 executor 不报(如 codex CLI),已从累计中排除`
-      : `${reportableRuns.length}/${runs.length} runs reported USD cost; ${unmeasuredRunsCount} excluded (executor doesn't report, e.g. codex CLI)`;
+      ? `${reportableRuns.length}/${evaluationRuns.length} 次单次报告了 USD 成本;${unmeasuredRunsCount} 次 executor 不报(如 codex CLI),batch index 不计入累计以避免重复`
+      : `${reportableRuns.length}/${evaluationRuns.length} evaluation reports reported USD cost; ${unmeasuredRunsCount} excluded (executor doesn't report, e.g. codex CLI); batch indexes are excluded to avoid double counting`;
     costLabel = `<span title="${e(tip)}">${baseLabel} ${costNumber}</span>`;
   }
 
   // Collect variants with ≥2 reports for trend links
   const variantCounts: Record<string, number> = {};
-  for (const run of runs) {
+  for (const run of evaluationRuns) {
     for (const v of (run.meta?.variants || [])) {
       if (v === 'baseline') continue;
       variantCounts[v] = (variantCounts[v] || 0) + 1;
@@ -254,7 +300,7 @@ export function renderRunList(runs: Report[], lang: Lang = DEFAULT_LANG): string
   `, lang);
 }
 
-export function renderRunDetail(report: Report | null, lang: Lang = DEFAULT_LANG): string {
+export function renderRunDetail(report: EvaluationReport | null, lang: Lang = DEFAULT_LANG): string {
   if (!report) {
     return layout(t('title', lang), `
       <main>
@@ -416,7 +462,7 @@ export function renderRunDetail(report: Report | null, lang: Lang = DEFAULT_LANG
   `, lang);
 }
 
-export function renderEachRunDetail(report: Report | null, lang: Lang = DEFAULT_LANG): string {
+export function renderBatchIndexDetail(report: EvaluationBatchIndex | null, lang: Lang = DEFAULT_LANG): string {
   if (!report) {
     return layout(t('title', lang), `
       <main>
@@ -427,80 +473,49 @@ export function renderEachRunDetail(report: Report | null, lang: Lang = DEFAULT_
   }
 
   const m = report.meta;
-  const overview: EachOverview | null = report.overview || null;
-  const eachArtifacts: EachArtifactReport[] = report.artifacts || [];
-
-  // Overview table
-  const overviewRows = (overview?.artifacts || []).map((sk: EachOverviewArtifact) => {
-    const bs = typeof sk.baselineScore === 'number' ? sk.baselineScore.toFixed(2) : '-';
-    const ss = typeof sk.artifactScore === 'number' ? sk.artifactScore.toFixed(2) : '-';
-    const imp = sk.improvement || '-';
-    const impColor = imp.startsWith('+') ? 'var(--green)' : imp.startsWith('-') ? 'var(--red)' : 'var(--text-muted)';
-    return `<tr>
-      <td><a href="#skill-${e(sk.name)}">${e(sk.name)}</a></td>
-      <td>${bs}</td>
-      <td>${ss}</td>
-      <td style="color:${impColor};font-weight:600">${imp}</td>
-    </tr>`;
-  }).join('');
-
-  // Per-artifact detail sections
-  const skillSections = eachArtifacts.map((sk) => {
-    const variants = ['baseline', 'skill'];
-    const summary = sk.summary || {};
-    // 传 sk.variance 给 summaryCards, 稳定性 CV 列才有数据 (非 each 模式是传 report.variance)
-    const cards = renderSummaryCards(variants, summary, lang, sk.variance);
-    const sampleTable = renderSampleTable(variants, sk.results, lang);
-    // --each --repeat N 时每个 skill 有自己的 variance; 复用 bench 的 renderVarianceComparisons
-    const varianceBlock = sk.variance
-      ? renderVarianceComparisons(sk.variance, lang, Boolean(report.meta.layeredStats), sk.summary)
-      : '';
-
-    const hashShort = sk.artifactHash ? e(sk.artifactHash).slice(0, 12) : '-';
-    const hashBlock = sk.artifactHash
-      ? `<span title="${t('artifactHashTooltip', lang)}"><span data-i18n="artifactHashLabel">${t('artifactHashLabel', lang)}</span>: <code style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace">${hashShort}</code></span>`
-      : '';
-    return `
-      <section id="skill-${e(sk.name)}" style="margin-top:36px;padding-top:20px;border-top:1px solid var(--border)">
-        <h2>${e(sk.name)}</h2>
-        <p style="font-size:12px;color:var(--text-muted)">${t('samples', lang)}: ${sk.sampleCount}${hashBlock ? ' &middot; ' + hashBlock : ''}</p>
-        ${cards}
-        ${varianceBlock}
-        ${sampleTable}
-      </section>
-    `;
-  }).join('');
-
-  // 轮次信息放总览。统一用 · 分隔(each 下 skills×samples 不是严格乘法,避免 × 的误导)
+  const allCostReported = report.items.every((item) =>
+    Object.values(item.summary || {}).every((v) =>
+      v.execCostReported !== false && v.judgeCostReported !== false));
   const repeatN = report.meta.request?.repeat;
   const repeatSegment = repeatN && repeatN > 1
     ? (lang === 'zh' ? ` · ${repeatN} 轮重复` : ` · ${repeatN} runs`)
     : '';
-  // each 模式 totalCostUSD 含 exec + judge 两块。任一 artifact 的任一 variant 任一边
-  // 未报告 → 整体不可信(显示「—」)。判 judge 是因为 codex 当 judge 时 judgeCostUSD=0
-  // 但实际真有 API 花费,total 看着是数字会误导。
-  const eachAllCostReported = eachArtifacts.every((sk) =>
-    Object.values(sk.summary || {}).every((v) =>
-      v.execCostReported !== false && v.judgeCostReported !== false));
   const overviewSubtitle = lang === 'zh'
-    ? `${overview?.totalArtifacts || 0} 个 Skill · ${overview?.totalSamples || 0} 个用例${repeatSegment} · ${fmtCost(overview?.totalCostUSD || 0, eachAllCostReported)}`
-    : `${overview?.totalArtifacts || 0} skills · ${overview?.totalSamples || 0} samples${repeatSegment} · ${fmtCost(overview?.totalCostUSD || 0, eachAllCostReported)}`;
+    ? `${m.totalArtifacts || report.items.length} 个 Skill · ${m.sampleCount || 0} 个用例${repeatSegment} · ${fmtCost(m.totalCostUSD || 0, allCostReported)}`
+    : `${m.totalArtifacts || report.items.length} skills · ${m.sampleCount || 0} samples${repeatSegment} · ${fmtCost(m.totalCostUSD || 0, allCostReported)}`;
+
+  const rows = report.items.map((item) => {
+    const baselineScore = scoreOf(item.summary.baseline);
+    const skillScore = scoreOf(item.summary.skill);
+    const improvement = improvementOf(baselineScore, skillScore);
+    const impColor = improvement.startsWith('+') ? 'var(--green)' : improvement.startsWith('-') ? 'var(--red)' : 'var(--text-muted)';
+    const hashShort = item.artifactHash ? e(item.artifactHash).slice(0, 12) : '-';
+    return `<tr>
+      <td><a href="/reports/${encodeURIComponent(item.reportId)}">${e(item.name)}</a></td>
+      <td>${typeof baselineScore === 'number' ? baselineScore.toFixed(2) : '-'}</td>
+      <td>${typeof skillScore === 'number' ? skillScore.toFixed(2) : '-'}</td>
+      <td style="color:${impColor};font-weight:600">${improvement}</td>
+      <td>${item.sampleCount}</td>
+      <td>${fmtCost(item.totalCostUSD, allCostReported)}</td>
+      <td><code style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace">${hashShort}</code></td>
+    </tr>`;
+  }).join('');
 
   return layout(`${t('reportTitle', lang)} - ${report.id}`, `
     <main>
     <nav class="nav"><a href="/" data-i18n="backToList">${t('backToList', lang)}</a></nav>
     <h1>${e(report.id)}</h1>
     <div class="meta-tags">
+      <span class="meta-tag">${lang === 'zh' ? '类型' : 'type'}: each batch index</span>
       <span class="meta-tag">${t('model', lang)}: ${e(m.model)}</span>
       <span class="meta-tag">${t('judge', lang)}: ${e(m.judgeModel || 'none')}</span>
       <span class="meta-tag">${t('executor', lang)}: ${e(m.executor || 'claude')}</span>
       ${renderExecutorRuntimeTags(m, lang)}${renderJudgeRuntimeTags(m, lang)}
-      <span class="meta-tag"${eachAllCostReported ? '' : ` title="${e(lang === 'zh' ? 'executor 不报 USD 成本(如 codex CLI),无法估算' : 'executor does not report USD cost (e.g. codex CLI); not measurable')}"`}>${t('cost', lang)}: ${fmtCost(m.totalCostUSD, eachAllCostReported)}</span>
+      <span class="meta-tag"${allCostReported ? '' : ` title="${e(lang === 'zh' ? 'executor 不报 USD 成本(如 codex CLI),无法估算' : 'executor does not report USD cost (e.g. codex CLI); not measurable')}"`}>${t('cost', lang)}: ${fmtCost(m.totalCostUSD, allCostReported)}</span>
     </div>
 
     <section>
     <h2>${t('eachOverview', lang)}</h2>
-
     <p style="font-size:13px;color:var(--text-muted)">${overviewSubtitle}</p>
     <div class="table-wrap">
     <table>
@@ -509,16 +524,24 @@ export function renderEachRunDetail(report: Report | null, lang: Lang = DEFAULT_
         <th>${t('eachBaseline', lang)}</th>
         <th>${t('eachWithSkill', lang)}</th>
         <th>${t('eachImprovement', lang)}</th>
+        <th>${t('samples', lang)}</th>
+        <th>${t('cost', lang)}</th>
+        <th>${t('artifactHashLabel', lang)}</th>
       </tr></thead>
-      <tbody>${overviewRows}</tbody>
+      <tbody>${rows}</tbody>
     </table>
     </div>
     </section>
 
-    ${skillSections}
-
     </main>
   `, lang);
+}
+
+export function renderReportDocumentDetail(report: ReportDocument | null, lang: Lang = DEFAULT_LANG): string {
+  if (!report) return renderRunDetail(null, lang);
+  return report.kind === 'batch-index'
+    ? renderBatchIndexDetail(report, lang)
+    : renderRunDetail(report, lang);
 }
 
 export function renderTrendsPage(variantName: string, runs: Report[], lang: Lang = DEFAULT_LANG): string {

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -127,7 +127,7 @@ export function renderRunList(runs: ReportDocument[], lang: Lang = DEFAULT_LANG)
       const scoreCol = run.items.length > 0
         ? run.items.map((item) => {
           const baselineScore = scoreOf(item.summary.baseline);
-          const skillScore = scoreOf(item.summary.skill);
+          const skillScore = scoreOf(item.summary[item.name]);
           const score = skillScore ?? baselineScore;
           if (score == null) return `<span style="color:var(--text-muted)">${e(item.name)}: -</span>`;
           const color = score >= 4 ? 'var(--green)' : score >= 3 ? 'var(--yellow)' : 'var(--red)';
@@ -486,7 +486,7 @@ export function renderBatchIndexDetail(report: EvaluationBatchIndex | null, lang
 
   const rows = report.items.map((item) => {
     const baselineScore = scoreOf(item.summary.baseline);
-    const skillScore = scoreOf(item.summary.skill);
+    const skillScore = scoreOf(item.summary[item.name]);
     const improvement = improvementOf(baselineScore, skillScore);
     const impColor = improvement.startsWith('+') ? 'var(--green)' : improvement.startsWith('-') ? 'var(--red)' : 'var(--text-muted)';
     const hashShort = item.artifactHash ? e(item.artifactHash).slice(0, 12) : '-';

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -2,7 +2,7 @@ import { createServer, IncomingMessage, ServerResponse, Server } from 'node:http
 import { existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { renderRunList, renderRunDetail, renderEachRunDetail, renderTrendsPage } from '../renderer/html-renderer.js';
+import { renderRunList, renderReportDocumentDetail, renderTrendsPage } from '../renderer/html-renderer.js';
 import { renderSkillHealthReport } from '../renderer/skill-health-renderer.js';
 import { DEFAULT_LANG, t, layout } from '../renderer/layout.js';
 import type { Lang } from '../types/index.js';
@@ -599,7 +599,7 @@ export function createReportServer({ port, reportsDir = DEFAULT_REPORTS_DIR, ana
       if (reportPageMatch) {
         const report = await queryRun(reportStore, decodeURIComponent(reportPageMatch[1]));
         res.writeHead(report ? 200 : 404, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(report?.each ? renderEachRunDetail(report) : renderRunDetail(report));
+        res.end(renderReportDocumentDetail(report));
         return;
       }
 

--- a/src/server/report-store.ts
+++ b/src/server/report-store.ts
@@ -6,7 +6,7 @@
 
 import { readdir, readFile, writeFile, unlink, access, mkdir, rename } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { EvaluationJob, JobStore, Report, ReportMeta, ReportStore, VariantSummary } from '../types/index.js';
+import type { EvaluationBatchIndex, EvaluationJob, EvaluationReport, JobStore, ReportDocument, ReportMeta, ReportStore, VariantSummary } from '../types/index.js';
 
 // Per-id in-memory mutex for safe read-modify-write.
 // Uses a queue to avoid the race window between checking and acquiring the lock.
@@ -39,7 +39,23 @@ export function createFileStore(dir: string): ReportStore {
     }
   }
 
-  async function list(): Promise<Report[]> {
+  function isReportDocument(data: unknown): data is ReportDocument {
+    if (!data || typeof data !== 'object') return false;
+    const record = data as Record<string, unknown>;
+    if (record.kind === 'evaluation') {
+      return Boolean(record.id && record.meta && record.summary && record.results);
+    }
+    if (record.kind === 'batch-index') {
+      return Boolean(record.id && record.meta && Array.isArray(record.items));
+    }
+    return false;
+  }
+
+  function isEvaluationReport(report: ReportDocument): report is EvaluationReport {
+    return report.kind === 'evaluation';
+  }
+
+  async function list(): Promise<ReportDocument[]> {
     try {
       await access(dir);
     } catch {
@@ -49,11 +65,11 @@ export function createFileStore(dir: string): ReportStore {
       .filter((f) => f.endsWith('.json'))
       .sort()
       .reverse();
-    const runs: Report[] = [];
+    const runs: ReportDocument[] = [];
     for (const file of files) {
       try {
         const data = JSON.parse(await readFile(join(dir, file), 'utf-8'));
-        if (data && data.meta) {
+        if (isReportDocument(data)) {
           if (!data.id) data.id = file.replace(/\.json$/, '');
           runs.push(data);
         }
@@ -67,17 +83,17 @@ export function createFileStore(dir: string): ReportStore {
     return runs;
   }
 
-  async function get(id: string): Promise<Report | null> {
+  async function get(id: string): Promise<ReportDocument | null> {
     try {
       const data = JSON.parse(await readFile(join(dir, `${id}.json`), 'utf-8'));
       if (!data.id) data.id = id;
-      return data;
+      return isReportDocument(data) ? data : null;
     } catch {
       return null;
     }
   }
 
-  async function save(id: string, report: Report): Promise<void> {
+  async function save(id: string, report: ReportDocument): Promise<void> {
     await ensureDir();
     const tmpPath = join(dir, `${id}.json.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`);
     await writeFile(tmpPath, JSON.stringify(report, null, 2));
@@ -88,7 +104,7 @@ export function createFileStore(dir: string): ReportStore {
    * Atomic read-modify-write with in-memory mutex.
    * Prevents concurrent updates from overwriting each other.
    */
-  async function update(id: string, mutator: (report: Report) => void): Promise<Report | null> {
+  async function update(id: string, mutator: (report: ReportDocument) => void): Promise<ReportDocument | null> {
     return withLock(id, async () => {
       const report = await get(id);
       if (!report) return null;
@@ -118,14 +134,14 @@ export function createFileStore(dir: string): ReportStore {
     }
   }
 
-  async function findByVariant(variantName: string): Promise<Report[]> {
+  async function findByVariant(variantName: string): Promise<EvaluationReport[]> {
     const all = await list();
-    return all.filter((r) => r.meta?.variants?.includes(variantName));
+    return all.filter(isEvaluationReport).filter((r) => r.meta?.variants?.includes(variantName));
   }
 
-  async function findByArtifactHash(hash: string): Promise<Report[]> {
+  async function findByArtifactHash(hash: string): Promise<EvaluationReport[]> {
     const all = await list();
-    return all.filter((r) => {
+    return all.filter(isEvaluationReport).filter((r) => {
       const hashes = r.meta?.artifactHashes || {};
       return Object.values(hashes).includes(hash);
     });
@@ -174,8 +190,10 @@ export async function queryJob(jobStore: JobStore, id: string): Promise<Evaluati
 
 export interface RunListItem {
   id: string;
-  meta: ReportMeta;
-  summary: Report['summary'];
+  kind: ReportDocument['kind'];
+  meta: ReportDocument['meta'];
+  summary?: EvaluationReport['summary'];
+  items?: EvaluationBatchIndex['items'];
 }
 
 export interface TrendPoint {
@@ -192,18 +210,19 @@ export interface TrendPoint {
 export interface TrendQueryResult {
   variant: string;
   points: TrendPoint[];
-  runs: Report[];
+  runs: EvaluationReport[];
 }
 
 export async function queryRunList(reportStore: ReportStore): Promise<RunListItem[]> {
   return (await reportStore.list()).map((report) => ({
     id: report.id,
+    kind: report.kind,
     meta: report.meta,
-    summary: report.summary,
+    ...(report.kind === 'evaluation' ? { summary: report.summary } : { items: report.items }),
   }));
 }
 
-export async function queryRun(reportStore: ReportStore, id: string): Promise<Report | null> {
+export async function queryRun(reportStore: ReportStore, id: string): Promise<ReportDocument | null> {
   return reportStore.get(id);
 }
 

--- a/src/server/report-store.ts
+++ b/src/server/report-store.ts
@@ -39,16 +39,33 @@ export function createFileStore(dir: string): ReportStore {
     }
   }
 
-  function isReportDocument(data: unknown): data is ReportDocument {
-    if (!data || typeof data !== 'object') return false;
+  function normalizeReportDocument(data: unknown, fallbackId: string): ReportDocument | null {
+    if (!data || typeof data !== 'object') return null;
     const record = data as Record<string, unknown>;
     if (record.kind === 'evaluation') {
-      return Boolean(record.id && record.meta && record.summary && record.results);
+      if (!record.meta || !record.summary || !Array.isArray(record.results)) return null;
+      return { ...record, id: typeof record.id === 'string' && record.id ? record.id : fallbackId } as unknown as ReportDocument;
     }
     if (record.kind === 'batch-index') {
-      return Boolean(record.id && record.meta && Array.isArray(record.items));
+      if (!record.meta || !Array.isArray(record.items)) return null;
+      return { ...record, id: typeof record.id === 'string' && record.id ? record.id : fallbackId } as unknown as ReportDocument;
     }
-    return false;
+    if (
+      record.kind === undefined
+      && !record.each
+      && record.overview === undefined
+      && record.artifacts === undefined
+      && record.meta
+      && record.summary
+      && Array.isArray(record.results)
+    ) {
+      return {
+        ...record,
+        kind: 'evaluation',
+        id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
+      } as unknown as ReportDocument;
+    }
+    return null;
   }
 
   function isEvaluationReport(report: ReportDocument): report is EvaluationReport {
@@ -69,10 +86,8 @@ export function createFileStore(dir: string): ReportStore {
     for (const file of files) {
       try {
         const data = JSON.parse(await readFile(join(dir, file), 'utf-8'));
-        if (isReportDocument(data)) {
-          if (!data.id) data.id = file.replace(/\.json$/, '');
-          runs.push(data);
-        }
+        const report = normalizeReportDocument(data, file.replace(/\.json$/, ''));
+        if (report) runs.push(report);
       } catch { /* skip corrupt files */ }
     }
     runs.sort((a, b) => {
@@ -86,8 +101,7 @@ export function createFileStore(dir: string): ReportStore {
   async function get(id: string): Promise<ReportDocument | null> {
     try {
       const data = JSON.parse(await readFile(join(dir, `${id}.json`), 'utf-8'));
-      if (!data.id) data.id = id;
-      return isReportDocument(data) ? data : null;
+      return normalizeReportDocument(data, id);
     } catch {
       return null;
     }

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -294,35 +294,66 @@ export interface ResultEntry {
   variants: Record<string, VariantResult>;
 }
 
-export interface Report {
+export interface EvaluationReport {
+  kind: 'evaluation';
   id: string;
   meta: ReportMeta;
   summary: Record<string, VariantSummary>;
   results: ResultEntry[];
   analysis?: AnalysisResult;
   variance?: VarianceData;
-  each?: boolean;
-  overview?: {
-    totalArtifacts: number;
-    totalSamples: number;
-    totalCostUSD: number;
-    artifacts: Array<{
-      name: string;
-      baselineScore: number | null;
-      artifactScore: number | null;
-      improvement: string;
-    }>;
-  };
-  artifacts?: Array<{
-    name: string;
-    sampleCount: number;
-    artifactHash: string | null;
-    summary: Record<string, VariantSummary>;
-    /** --each --repeat N 时由 runMultiple 聚合的三层独立 variance + t 检验 */
-    variance?: VarianceData;
-    results: ResultEntry[];
-  }>;
 }
+
+export type Report = EvaluationReport;
+
+export interface EvaluationBatchMeta {
+  mode: 'each';
+  model: string;
+  judgeModel: string | null;
+  executor: string;
+  skillDir: string;
+  sampleCount: number;
+  taskCount: number;
+  totalArtifacts: number;
+  totalCostUSD: number;
+  timestamp: string;
+  cliVersion: string;
+  nodeVersion: string;
+  executorRuntime?: ExecutorRuntimeFingerprint;
+  executorRuntimes?: Record<string, ExecutorRuntimeFingerprint>;
+  judgeRuntime?: ExecutorRuntimeFingerprint | null;
+  judgeRuntimes?: Record<string, ExecutorRuntimeFingerprint>;
+  judgeModels?: string[];
+  request?: EvaluationRequest;
+  run?: EvaluationRun;
+  job?: EvaluationJob;
+  gitInfo?: GitInfo | null;
+}
+
+export interface EvaluationBatchIndexItem {
+  name: string;
+  skillPath: string;
+  samplesPath: string;
+  reportId: string;
+  reportPath: string | null;
+  status: 'completed' | 'failed';
+  sampleCount: number;
+  totalCostUSD: number;
+  artifactHash: string | null;
+  summary: Record<string, VariantSummary>;
+  /** --each --repeat N 时由 child EvaluationReport 聚合的三层独立 variance + t 检验快照 */
+  variance?: VarianceData;
+}
+
+export interface EvaluationBatchIndex {
+  kind: 'batch-index';
+  id: string;
+  mode: 'each';
+  meta: EvaluationBatchMeta;
+  items: EvaluationBatchIndexItem[];
+}
+
+export type ReportDocument = EvaluationReport | EvaluationBatchIndex;
 
 export interface Insight {
   type: string;

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -331,6 +331,7 @@ export interface EvaluationBatchMeta {
 }
 
 export interface EvaluationBatchIndexItem {
+  /** Skill name; also the treatment variant key inside the child EvaluationReport. */
   name: string;
   skillPath: string;
   samplesPath: string;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,15 +1,15 @@
 import type { EvaluationJob } from './eval.js';
-import type { Report } from './report.js';
+import type { EvaluationReport, ReportDocument } from './report.js';
 
 export interface ReportStore {
-  list(): Promise<Report[]>;
-  get(id: string): Promise<Report | null>;
-  save(id: string, report: Report): Promise<void>;
-  update(id: string, mutator: (report: Report) => void): Promise<Report | null>;
+  list(): Promise<ReportDocument[]>;
+  get(id: string): Promise<ReportDocument | null>;
+  save(id: string, report: ReportDocument): Promise<void>;
+  update(id: string, mutator: (report: ReportDocument) => void): Promise<ReportDocument | null>;
   remove(id: string): Promise<boolean>;
   exists(id: string): Promise<boolean>;
-  findByVariant(variantName: string): Promise<Report[]>;
-  findByArtifactHash(hash: string): Promise<Report[]>;
+  findByVariant(variantName: string): Promise<EvaluationReport[]>;
+  findByArtifactHash(hash: string): Promise<EvaluationReport[]>;
 }
 
 export interface JobStore {

--- a/test/analysis/failure-clusterer.test.ts
+++ b/test/analysis/failure-clusterer.test.ts
@@ -13,6 +13,7 @@ const variantResult = (overrides: Partial<VariantResult> = {}): VariantResult =>
 });
 
 const buildReport = (entries: Array<{ id: string; perVariant: Record<string, Partial<VariantResult>> }>, variants: string[]): Report => ({
+  kind: 'evaluation',
   id: 'r',
   meta: {
     variants, model: 'm', judgeModel: 'j', executor: 'claude',

--- a/test/analysis/sample-diagnostics.test.ts
+++ b/test/analysis/sample-diagnostics.test.ts
@@ -13,6 +13,7 @@ const variantResult = (overrides: Partial<VariantResult> = {}): VariantResult =>
 });
 
 const buildReport = (entries: Array<{ id: string; perVariant: Record<string, Partial<VariantResult>> }>, variants: string[]): Report => ({
+  kind: 'evaluation',
   id: 'r',
   meta: {
     variants, model: 'm', judgeModel: 'j', executor: 'claude',

--- a/test/analysis/sample-quality-aggregate.test.ts
+++ b/test/analysis/sample-quality-aggregate.test.ts
@@ -91,6 +91,7 @@ describe('buildSampleQualityAggregate', () => {
 describe('analyzeResults — sampleQuality wiring', () => {
   function emptyReport(): Report {
     return {
+      kind: 'evaluation',
       id: 'r',
       meta: {
         variants: ['v1', 'v2'], model: 'm', judgeModel: 'j', executor: 'claude',

--- a/test/eval-core/comparability.test.ts
+++ b/test/eval-core/comparability.test.ts
@@ -26,6 +26,7 @@ function runtime(executor: string, model: string, fingerprint: string): Executor
 
 function report(overrides: Partial<Report['meta']> = {}): Report {
   return {
+    kind: 'evaluation',
     id: 'r',
     meta: {
       variants: ['control', 'treatment'],

--- a/test/eval-core/verdict.test.ts
+++ b/test/eval-core/verdict.test.ts
@@ -13,6 +13,7 @@ const summary = (avg: { fact?: number; behavior?: number; judge?: number; compos
 });
 
 const buildReport = (overrides: Partial<Report> & { variants: string[]; perVariantAvg: Record<string, Parameters<typeof summary>[0]>; pairs?: Report['meta']['pairComparisons'] }): Report => ({
+  kind: 'evaluation',
   id: 'r1',
   meta: {
     variants: overrides.variants,

--- a/test/evolver.test.ts
+++ b/test/evolver.test.ts
@@ -13,6 +13,7 @@ function makeSummary(avgScore: number): VariantSummary {
 
 function makeReport(variantName: string, sampleScores: Record<string, number>, avgScore: number): Report {
   return {
+    kind: 'evaluation',
     id: `${variantName}-id`,
     meta: {
       variants: [variantName],

--- a/test/grading/debias-validate.test.ts
+++ b/test/grading/debias-validate.test.ts
@@ -38,6 +38,7 @@ const buildReport = (
   rows: Array<{ sample_id: string; output: string; llmScore: number }>,
   debiasMode: Array<'length' | 'position'> = ['length'],
 ): Report => ({
+  kind: 'evaluation',
   id: 'r1',
   meta: {
     variants: [variant],

--- a/test/grading/gold-cli.test.ts
+++ b/test/grading/gold-cli.test.ts
@@ -34,6 +34,7 @@ const buildReport = (
   scoresById: Record<string, number>,
   judgeModel = 'claude-sonnet-4-6',
 ): Report => ({
+  kind: 'evaluation',
   id: 'r1',
   meta: {
     variants: [variant],

--- a/test/html-renderer.test.ts
+++ b/test/html-renderer.test.ts
@@ -10,6 +10,7 @@ function normalizeForSnapshot(html: string): string {
 }
 
 const SAMPLE_REPORT: Report = {
+  kind: 'evaluation',
   // 让 id 匹配 renderRunList 里的 YYYYMMDD-HHmm regex (html-renderer.ts:62),
   // 这样列表页 row 的时间从 id 直接提取 (deterministic), 不走 toLocaleString
   // — 后者本地时区敏感, 会让 snapshot 在 CI UTC 和本地 CST 之间不一致.

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -7,7 +7,7 @@ import { discoverVariants, discoverEachSkills, loadSkills } from '../src/inputs/
 import { generateRunId, persistReport } from '../src/eval-core/evaluation-reporting.js';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import type { Report, VariantSpec } from '../src/types/index.js';
 
@@ -589,11 +589,12 @@ describe('runEachEvaluation', () => {
         executorName: 'claude',
         persistJob: false,
         runSingleEvaluation: async (options) => {
+          const treatment = options.artifacts.find((artifact) => artifact.experimentRole === 'treatment')?.name ?? 'alpha';
           const report: Report = {
             kind: 'evaluation',
             id: options.runId!,
             meta: {
-              variants: ['baseline', 'skill'],
+              variants: ['baseline', treatment],
               model: options.model,
               judgeModel: null,
               executor: options.executorName,
@@ -603,9 +604,9 @@ describe('runEachEvaluation', () => {
               timestamp: '2026-05-01T00:00:00.000Z',
               cliVersion: 'test',
               nodeVersion: 'test',
-              artifactHashes: { baseline: 'no-skill', skill: 'hash-alpha' },
+              artifactHashes: { baseline: 'no-skill', [treatment]: 'hash-alpha' },
             },
-            summary: { baseline: summary(3), skill: summary(4) },
+            summary: { baseline: summary(3), [treatment]: summary(4) },
             results: [],
           };
           return { report, filePath: persistReport(report, options.outputDir) };
@@ -617,10 +618,18 @@ describe('runEachEvaluation', () => {
       assert.equal(result.report.items.length, 1);
       assert.equal(result.report.items[0].name, 'alpha');
       assert.equal(result.report.items[0].artifactHash, 'hash-alpha');
+      assert.ok(result.report.items[0].summary.alpha);
+      assert.equal(result.report.items[0].summary.skill, undefined);
       assert.ok(result.report.items[0].reportId.startsWith(`${result.report.id}-01-alpha`));
       assert.ok(result.filePath);
       assert.ok(existsSync(result.filePath!));
-      assert.ok(existsSync(join(outputDir, `${result.report.items[0].reportId}.json`)));
+      const childPath = join(outputDir, `${result.report.items[0].reportId}.json`);
+      assert.ok(existsSync(childPath));
+      const childReport = JSON.parse(readFileSync(childPath, 'utf-8')) as Report;
+      assert.deepEqual(childReport.meta.variants, ['baseline', 'alpha']);
+      assert.equal(childReport.meta.artifactHashes.alpha, 'hash-alpha');
+      assert.ok(childReport.summary.alpha);
+      assert.equal(childReport.summary.skill, undefined);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -1,11 +1,14 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { runEvaluation, runEachEvaluation } from '../src/eval-workflows/run-evaluation.js';
+import { executeEachEvaluationRuns } from '../src/eval-workflows/each-evaluation-workflow.js';
 import { buildTasks } from '../src/eval-core/task-planner.js';
 import { discoverVariants, discoverEachSkills, loadSkills } from '../src/inputs/skill-loader.js';
-import { generateRunId } from '../src/eval-core/evaluation-reporting.js';
+import { generateRunId, persistReport } from '../src/eval-core/evaluation-reporting.js';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import type { Report, VariantSpec } from '../src/types/index.js';
 
 // Test helper: convert a list of variant names into VariantSpec[].
@@ -547,6 +550,80 @@ describe('runEachEvaluation', () => {
     const report = asEachDryRunReport(result.report);
     const expectedTotal = report.artifacts.reduce((s: number, sk: { taskCount: number }) => s + sk.taskCount, 0);
     assert.equal(report.totalTasks, expectedTotal);
+  });
+
+  it('non-dry-run: returns batch index and persists child EvaluationReport', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'omk-each-index-'));
+    try {
+      const skillPath = join(tmpDir, 'alpha.md');
+      const samplesPath = join(tmpDir, 'alpha.eval-samples.json');
+      const outputDir = join(tmpDir, 'reports');
+      writeFileSync(skillPath, 'skill content');
+      writeFileSync(samplesPath, JSON.stringify([{ sample_id: 's1', prompt: 'p' }, { sample_id: 's2', prompt: 'p' }]));
+
+      const summary = (score: number): Report['summary'][string] => ({
+        totalSamples: 2,
+        successCount: 2,
+        errorCount: 0,
+        errorRate: 0,
+        avgDurationMs: 100,
+        avgInputTokens: 0,
+        avgOutputTokens: 0,
+        avgTotalTokens: 0,
+        totalCostUSD: 0,
+        totalExecCostUSD: 0,
+        totalJudgeCostUSD: 0,
+        avgCostPerSample: 0,
+        avgNumTurns: 1,
+        avgCompositeScore: score,
+      });
+
+      const result = await executeEachEvaluationRuns({
+        skillDir: tmpDir,
+        skillEntries: [{ name: 'alpha', skillPath, samplesPath }],
+        model: 'm',
+        judgeModel: 'j',
+        outputDir,
+        noJudge: true,
+        concurrency: 1,
+        executorName: 'claude',
+        persistJob: false,
+        runSingleEvaluation: async (options) => {
+          const report: Report = {
+            kind: 'evaluation',
+            id: options.runId!,
+            meta: {
+              variants: ['baseline', 'skill'],
+              model: options.model,
+              judgeModel: null,
+              executor: options.executorName,
+              sampleCount: 2,
+              taskCount: 4,
+              totalCostUSD: 0.01,
+              timestamp: '2026-05-01T00:00:00.000Z',
+              cliVersion: 'test',
+              nodeVersion: 'test',
+              artifactHashes: { baseline: 'no-skill', skill: 'hash-alpha' },
+            },
+            summary: { baseline: summary(3), skill: summary(4) },
+            results: [],
+          };
+          return { report, filePath: persistReport(report, options.outputDir) };
+        },
+      });
+
+      assert.equal(result.report.kind, 'batch-index');
+      assert.equal(result.report.mode, 'each');
+      assert.equal(result.report.items.length, 1);
+      assert.equal(result.report.items[0].name, 'alpha');
+      assert.equal(result.report.items[0].artifactHash, 'hash-alpha');
+      assert.ok(result.report.items[0].reportId.startsWith(`${result.report.id}-01-alpha`));
+      assert.ok(result.filePath);
+      assert.ok(existsSync(result.filePath!));
+      assert.ok(existsSync(join(outputDir, `${result.report.items[0].reportId}.json`)));
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/saturation-integration.test.ts
+++ b/test/saturation-integration.test.ts
@@ -19,6 +19,7 @@ const buildRun = (
   const variants = Object.keys(variantScores);
   const sampleCount = variantScores[variants[0]].length;
   return {
+    kind: 'evaluation',
     id: runId,
     meta: {
       variants,

--- a/test/server/query-reports.test.ts
+++ b/test/server/query-reports.test.ts
@@ -23,6 +23,7 @@ function makeReport(id: string, variant: string, timestamp: string, avgScore: nu
     },
   };
   return {
+    kind: 'evaluation',
     id,
     meta: {
       variants: [variant],

--- a/test/server/query-reports.test.ts
+++ b/test/server/query-reports.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { queryRunList, queryRun, queryTrend } from '../../src/server/report-store.js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createFileStore, queryRunList, queryRun, queryTrend } from '../../src/server/report-store.js';
 import type { Report, ReportStore, VariantSummary } from '../../src/types/index.js';
 
 function makeReport(id: string, variant: string, timestamp: string, avgScore: number | undefined): Report {
@@ -67,6 +70,46 @@ describe('queryRunList', () => {
     assert.ok(list[0].meta);
     assert.ok(list[0].summary);
     assert.equal(list[0].meta.model, 'sonnet');
+  });
+});
+
+describe('createFileStore legacy report loading', () => {
+  it('把无 kind 的历史普通报告归一化为 evaluation', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-report-'));
+    try {
+      const legacy = makeReport('legacy-run', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
+      delete legacy.kind;
+      delete legacy.id;
+      writeFileSync(join(dir, 'legacy-run.json'), JSON.stringify(legacy, null, 2));
+
+      const store = createFileStore(dir);
+      const report = await store.get('legacy-run');
+      assert.equal(report?.kind, 'evaluation');
+      assert.equal(report?.id, 'legacy-run');
+      const list = await store.list();
+      assert.equal(list.length, 1);
+      assert.equal(list[0].kind, 'evaluation');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('不把旧 each 混合报告误认为 evaluation', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-each-'));
+    try {
+      const legacyEach = makeReport('legacy-each', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
+      delete legacyEach.kind;
+      legacyEach.each = true;
+      legacyEach.overview = { totalArtifacts: 1, totalSamples: 1, totalCostUSD: 0, artifacts: [] };
+      legacyEach.artifacts = [];
+      writeFileSync(join(dir, 'legacy-each.json'), JSON.stringify(legacyEach, null, 2));
+
+      const store = createFileStore(dir);
+      assert.equal(await store.get('legacy-each'), null);
+      assert.deepEqual(await store.list(), []);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -10,6 +10,7 @@ const TEST_DIR = join(tmpdir(), `omk-test-reports-${Date.now()}`);
 const JOBS_DIR = join(tmpdir(), `omk-test-jobs-${Date.now()}`);
 
 const SAMPLE_REPORT = {
+  kind: 'evaluation',
   id: 'test-run-001',
   meta: {
     variants: ['v1', 'v2'],

--- a/test/variance-layers.test.ts
+++ b/test/variance-layers.test.ts
@@ -41,6 +41,7 @@ function makeRun(runId: string, perVariant: Record<string, LayerSeed>): Report {
     };
   }
   return {
+    kind: 'evaluation',
     id: runId,
     meta: {
       variants: Object.keys(perVariant),

--- a/test/variance-workflow.test.ts
+++ b/test/variance-workflow.test.ts
@@ -5,6 +5,7 @@ import type { Report, VariantSummary } from '../src/types/index.js';
 
 function makeReport(id: string, variantScores: Record<string, number>): Report {
   return {
+    kind: 'evaluation',
     id,
     meta: {
       variants: Object.keys(variantScores),


### PR DESCRIPTION
## Purpose

重构 `bench run --each` 的报告产物边界,避免单个 `Report` 同时表示原子评测和批次汇总。each 批次现在用 `EvaluationBatchIndex` 做索引,每个 skill vs baseline 单独落成可比较的 `EvaluationReport`。

## Changes

- 新增 `EvaluationReport | EvaluationBatchIndex` 的 `ReportDocument` 类型边界,删除 `Report.each` / `overview` / `artifacts` 混合 schema。
- `--each` 流程为每个 skill 生成 child reportId 并持久化 child `EvaluationReport`,顶层只保存 batch index 和摘要快照。
- report store / server / renderer 支持 batch index 展示,趋势和比较查询只消费 `EvaluationReport`。
- `bench diff` / `verdict` / `diagnose` 等命令遇到 batch index 时提示使用 child reportId。
- 更新 changelog 和相关测试 fixture,新增 each batch index 持久化测试。

## Testing

- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` passes
- [x] Added / updated tests covering new behavior
- [x] Manually exercised the affected report/type boundaries through targeted and full test runs

## Checklist

- [x] Read `CLAUDE.md`
- [x] Branch is `feat/*`, `fix/*`, `docs/*`, `chore/*`, `release/*`, or `hotfix/*` (Gitflow)
- [x] Target branch follows the current branch strategy in `CLAUDE.md` / `CONTRIBUTING.md`
- [x] Commit message follows the repo convention (`type(scope): subject`)
- [x] `CHANGELOG.md` `[Unreleased]` section updated if this is user-visible
- [x] No secrets / internal URLs / personal data in the diff
- [x] README / docs updated if behavior or CLI surface changed

## Additional context

Breaking change: old each reports are not migrated. Batch indexes are intentionally excluded from trend/comparison algorithms; use the child reportId for verdict/diff/diagnose.