### PR TITLE
chore(repo): 加 FUNDING.yml + dependabot.yml + 开 Discussions

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# omk 的赞助渠道(GitHub Sponsors 是主入口;按钮本身就是项目可持续的信号)
+# 暂不接收赞助但开按钮:有按钮 = "项目活着"的视觉信号,star/discoverability 收益 > 0
+github: [lizhiyao]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # npm 依赖周更,limit=5 防 PR 队列爆炸
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  # GitHub Actions 工作流也跟着更新
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary

omk 增长方案 PR A — repo discoverability 信号补丁,跟 README 重写解耦先合。

- `.github/FUNDING.yml`:GitHub Sponsors 入口,按钮即"项目活着"信号(暂不接受赞助但开按钮)
- `.github/dependabot.yml`:npm + github-actions 周一周更,limit 5 / 3 防 PR 队列爆炸
- (随 PR push 同步操作)`gh repo edit --enable-discussions`:开 GitHub Discussions tab

## 为什么拆成独立 PR

跟后续 README 重定位 PR(PR B,docs/readme-positioning-rewrite)解耦:
- 这两个 YAML 即使 lint 出问题也不挡 README 内容改动
- Discussions 开了之后能立刻跑出来供路人看到,不用等 README PR review

## 验证

- [x] `node -e "require('js-yaml').load(...)"` 两个 YAML 都过 parse
- [x] `yarn lint && yarn build && yarn test`(904 tests / 68 files 全过)
- [x] FUNDING / dependabot 内容跟 plan 文件一致

## 待 merge 后操作

- [ ] `gh repo edit lizhiyao/oh-my-knowledge --enable-discussions`(repo 设置,不在 diff 里)
- [ ] Discussions 发一帖 "Welcome to omk discussions" pin 住,seed cold-start
- [ ] (可后置)review repo description 是否要跟新 hero 对齐

## 不在本 PR scope 内(单独走)

- README 重定位(PR B,正在准备 `docs/readme-positioning-rewrite`)
- statistical-rigor.md 抽取(PR B)
- 截图(PR B 后置)

🤖 Generated with [Claude Code](https://claude.com/claude-code)