### PR TITLE
chore(repo): 加 dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # npm 依赖周更,limit=5 防 PR 队列爆炸
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  # GitHub Actions 工作流也跟着更新
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary

omk discoverability 补丁,接替之前 close 的 PR #41。

- `.github/dependabot.yml`:npm + github-actions 周一周更,limit 5 / 3 防 PR 队列爆炸,带 labels

## 跟 PR #41 的差别

PR #41 原本含 `.github/FUNDING.yml` + `.github/dependabot.yml` 两个文件,本 PR 只保留 dependabot.yml。FUNDING.yml(GitHub Sponsors signal-only)已决定不要,已从 scope 删掉。

## 验证

- [x] `node -e "require('js-yaml').load(...)"` YAML 过 parse
- [x] `yarn lint && yarn build` 全过

## 已生效(repo settings,跟本 PR 无关)

- ✅ Discussions tab 已开
- ✅ Welcome 帖在 #42(待手动 pin via UI,GitHub API 不暴露 pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)