### PR TITLE
docs(readme): 重定位 hero + Statistical rigor 抽到 docs/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 - **cost 显示「—」 而非 `$0.0000`**(executor 不报 cost 时):`ExecResult` / `VariantResult` / `VariantSummary` / `GradeResult` 加 `costReportedByExecutor` / `execCostReported` / `judgeCostReported` 三层 flag,全可选缺位 ≡ true(老报告兼容)。Renderer(HTML detail / list / each / trends / variance chart / CLI bench diff / bench evolve)全部识别该 flag,not reported 时显示「—」+ tooltip 解释。详见 #31。
 - **⚠ BREAKING:`bench run --each` 产物改为 `EvaluationBatchIndex` + child `EvaluationReport`** —— 顶层 batch index 只保存批次索引和摘要,每个 skill vs baseline 单独持久化为可比较的原子报告。child report 的 treatment variant 使用真实 skill 名,趋势页按 skill 名聚合,不再写 generic `skill`。删除 `Report.each` / `overview` / `artifacts` 这类混合 schema,`bench diff` / `verdict` / `diagnose` 等命令现在只接受 child reportId。旧 each 报告不做兼容迁移。详见 #40。
+- **README 重定位 + Statistical rigor 抽到 docs/**:hero 从"内置统计严谨性 + 一堆 jargon"改写为 outcome-first("你给 LLM 的知识,价值在哪里?omk 帮你用客观数据回答,而不是凭感觉"),Bootstrap CI / α / 长度去偏 / 饱和曲线 / 用例隔离 5 个不变量保留为 hero 下方 callout(visibility 不丢、SEO 不弱化)。Statistical rigor 章节迁移到 [docs/statistical-rigor.md](docs/statistical-rigor.md) / [docs/zh/statistical-rigor.md](docs/zh/statistical-rigor.md),README anchor `#statistical-rigor` 通过 `<a id>` redirect 兼容旧外链。Features 表行重排为 broad-appeal-first(Verdict / 六维 / 多 executor / 21+ 断言 在前)。详见 #PR-readme-rewrite。
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,49 +7,13 @@
 
 **English** | [简体中文](./README.zh.md)
 
-**omk** — LLM evaluation framework with built-in statistical rigor. Bootstrap CI / Krippendorff α / length-debias / saturation curves out of the box. Native support for Claude Code skills, prompts, agents, and RAG.
+**omk** — The knowledge you give your LLM — what's it actually worth?
+omk answers with objective data, not gut feeling.
 
-**Fix the model, vary the knowledge artifact, let the data speak.**
+**Fix the model, vary the knowledge artifact.**
 
-## Why this tool
-
-Teams doing knowledge engineering produce lots of knowledge artifacts (skills today, but also prompts, agents, workflows…). When someone asks "why is v2 better than v1", you need objective data instead of gut feeling. `oh-my-knowledge` solves this with controlled experiments: **same model, same test samples, only the knowledge artifact changes.**
-
-## Key features
-
-- **Controlled-variable offline bench** — fix the model and samples, vary only the artifact; works with Claude Code skills, CLAUDE.md prompts, RAG knowledge bases, or any markdown-based instruction
-- **Six-dimension scoring** — separate signals for Fact / Behavior / LLM-judge / Cost / Efficiency / Stability, so a regression in one axis isn't hidden by gains in another
-- **Production session observability** — parse Claude Code session JSONL traces, measure per-skill failure rate, latency, token cost, and knowledge-gap signals on real user sessions
-- **Knowledge-gap detection** — severity-weighted signals (explicit markers / failed searches / hedging language / repeated failures) quantify risk exposure instead of claiming completeness
-- **Pre-merge CI gate** — `omk bench gate` enforces three-layer all-pass (fact + behavior + llm-judge) semantics, catching single-layer regressions a composite score would hide
-- **One-line ship/no-ship verdict** — `omk bench verdict <reportId>` aggregates bootstrap CI / three-layer ci-gate / saturation / human α into a six-tier verdict (PROGRESS / CAUTIOUS / REGRESS / NOISE / UNDERPOWERED / SOLO) plus an action recommendation; the exit code reflects whether to ship
-
-### Statistical rigor
-
-The biggest LLM-eval failure mode is "confident bias" — narrow CIs around the wrong answer. omk's statistical layer ships four pieces so conclusions can be externally audited:
-
-- **Bootstrap CI** (`--bootstrap`) — distribution-free confidence intervals. The t-test breaks on ordinal LLM scores; bootstrap resamples raw observations and stays valid at small N (< 30) and on skewed data. Pairwise diff CI not crossing 0 = significant.
-- **Human Gold + Krippendorff α** (`--gold-dir`) — bring an external annotation as anchor. CI tells you "is the judge stable", α tells you "is the judge correct" — two complementary axes. omk warns when the gold annotator and the judge are the same model (would inflate α).
-- **Length-controlled judge prompt** (default ON) — research shows LLM judges over-weight verbosity. omk's judge prompt explicitly states "length is not a quality signal"; template hash is `v3-cot-length` so older reports (with the legacy hash) are visibly different. `omk bench debias-validate length <reportId>` re-judges with the opposite setting and reports the score shift.
-- **Saturation curve** — answers "have I run enough samples?". With `--repeat ≥ 5` we accumulate cumulative N → bootstrap CI; when CI shrink rate stays under 5% across 3 windows, more samples buy nothing. The HTML report inlines the SVG curve plus a verdict.
-
-## Why omk over alternatives
-
-| | omk | promptfoo | DeepEval | RAGAS | LangSmith |
-|--|--|--|--|--|--|
-| Bootstrap CI | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Krippendorff α (judge ↔ human) | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Length-debias judge prompt | ✓ default | ✗ | ✗ | ✗ | ✗ |
-| Saturation curve | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Three-layer scoring isolation | ✓ | ✗ | partial | ✗ | ✗ |
-| Per-variant skill isolation (construct validity) | ✓ default | ✗ | ✗ | ✗ | ✗ |
-| Native Claude Code skill | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Full Chinese docs | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Hosted SaaS dashboard | ✗ | ✗ | ✓ | ✗ | ✓ |
-
-omk's moat is **statistical rigor** — every conclusion is auditable by a researcher. If you need a hosted SaaS dashboard, choose LangSmith. If you want quick local prompt iteration without statistics, choose promptfoo. **If you ship to production and someone will ask "why should I trust this number?", choose omk**.
-
-Full comparison with 7 tools across 25+ dimensions: [docs/comparison.md](docs/comparison.md)
+<a id="statistical-rigor"></a>
+> Built-in: Bootstrap CI · Krippendorff α (judge ↔ human) · length-debias · saturation curves · construct-validity isolation. [Why these matter →](docs/statistical-rigor.md)
 
 ## Quick start
 
@@ -70,12 +34,14 @@ cd my-eval
 omk bench run --dry-run
 
 # run the evaluation (auto-discovers everything under skills/)
-omk bench run
+omk bench run    # → HTML report with verdict in 5 minutes
 
 # CLI output language: zh (default) / en — flag wins over env
 omk bench run --lang en
 OMK_LANG=en omk bench report
 ```
+
+![omk report](./assets/screenshots/report-overview.png)
 
 ## Use inside Claude Code
 
@@ -89,27 +55,57 @@ After installing omk, talk to it in natural language from Claude Code:
 
 You can also just say "compare v1 vs v2 for me" or "improve this artifact" — omk picks the right command.
 
+## Why this tool
+
+Teams doing knowledge engineering produce lots of knowledge artifacts (skills today, but also prompts, agents, workflows…). When someone asks "why is v2 better than v1", you need objective data instead of gut feeling. `oh-my-knowledge` solves this with controlled experiments: **same model, same test samples, only the knowledge artifact changes.**
+
+## Key features
+
+- **Controlled-variable offline bench** — fix the model and samples, vary only the artifact; works with Claude Code skills, CLAUDE.md prompts, RAG knowledge bases, or any markdown-based instruction
+- **Six-dimension scoring** — separate signals for Fact / Behavior / LLM-judge / Cost / Efficiency / Stability, so a regression in one axis isn't hidden by gains in another
+- **Production session observability** — parse Claude Code session JSONL traces, measure per-skill failure rate, latency, token cost, and knowledge-gap signals on real user sessions
+- **Knowledge-gap detection** — severity-weighted signals (explicit markers / failed searches / hedging language / repeated failures) quantify risk exposure instead of claiming completeness
+- **Pre-merge CI gate** — `omk bench gate` enforces three-layer all-pass (fact + behavior + llm-judge) semantics, catching single-layer regressions a composite score would hide
+- **One-line ship/no-ship verdict** — `omk bench verdict <reportId>` aggregates bootstrap CI / three-layer ci-gate / saturation / human α into a six-tier verdict (PROGRESS / CAUTIOUS / REGRESS / NOISE / UNDERPOWERED / SOLO) plus an action recommendation; the exit code reflects whether to ship
+
+## Why omk over alternatives
+
+| | omk | promptfoo | DeepEval | LangSmith |
+|--|--|--|--|--|
+| Bootstrap CI | ✓ default | ✗ | ✗ | ✗ |
+| Krippendorff α (judge ↔ human) | ✓ default | ✗ | ✗ | ✗ |
+| Length-debias judge prompt | ✓ default | ✗ | ✗ | ✗ |
+| Saturation curve | ✓ | ✗ | ✗ | ✗ |
+| Three-layer scoring isolation | ✓ | ✗ | partial | ✗ |
+| Per-variant skill isolation (construct validity) | ✓ default | ✗ | ✗ | ✗ |
+| Native Claude Code skill | ✓ | ✗ | ✗ | ✗ |
+| Hosted SaaS dashboard | ✗ | ✗ | ✓ | ✓ |
+
+omk's moat is **default-on safety net** — Bootstrap CI, judge ↔ human α, and length-debias aren't advanced flags; they're the default. Other tools let you opt into confidence intervals; omk makes them unavoidable. Need a hosted SaaS dashboard? Choose LangSmith. Want quick local prompt iteration without statistics? Choose promptfoo. **Shipping to production and someone will ask "why should I trust this number?" Choose omk.**
+
+RAG-specific evals: see RAGAS (separate niche, complementary to omk). Full comparison with 7 tools across 25+ dimensions: [docs/comparison.md](docs/comparison.md).
+
 ## Features
 
 | Feature | What it does |
 |---|---|
-| **21+ assertion types** | substring, regex, JSON Schema, ROUGE/BLEU/Levenshtein similarity, agent tool-call assertions, semantic similarity, custom JS, and more |
-| **Assertion negation + composition** | universal `not: true` field + `assert-set` (any/all) with arbitrary nesting |
-| **Six-dim evaluation** | Fact / Behavior / LLM-judge / Cost / Efficiency / Stability shown independently |
-| **Statistical rigor** | Bootstrap CI / Krippendorff α / length-debias / saturation curve |
-| **Construct-validity isolation** | `--strict-baseline` (default ON) cuts three contamination channels so baseline doesn't silently see the skill it's being compared against: (1) SDK skill auto-discovery, (2) subagent Skill tool, (3) cwd file-system access via the `skills/<name>/` symlink that's normally there for the treatment variant. eval.yaml `allowedSkills` for per-variant whitelists |
-| **Sample design science** | Sample schema with `capability` / `difficulty` / `construct` / `provenance` metadata fields (HF Dataset Cards style). `bench diagnose` shows coverage breakdown + flags `rubric_clarity_low` (short rubric without grading keywords) / `capability_thin` (capability supported by ≤ N×0.2 samples). `bench gen-samples` auto-stamps provenance. See [docs/sample-design-spec.md](docs/sample-design-spec.md) for the 8 industry-gap mapping |
 | **One-line verdict** | `omk bench verdict <id>` six-tier verdict + ship recommendation + exit-code routing; HTML pill shares the same rules |
-| **RAG metrics** | `faithfulness` / `answer_relevancy` / `context_recall` — anti-hallucination + answer relevance + context coverage; auto-inherits length-debias |
+| **Six-dim evaluation** | Fact / Behavior / LLM-judge / Cost / Efficiency / Stability shown independently |
+| **Multi-executor** | Claude CLI / Claude SDK / Codex CLI / Codex SDK / OpenAI / Gemini / any custom command |
+| **21+ assertion types** | substring, regex, JSON Schema, ROUGE/BLEU/Levenshtein similarity, agent tool-call assertions, semantic similarity, custom JS, and more |
+| **Statistical rigor** | Bootstrap CI / Krippendorff α / length-debias / saturation curve — all on by default. [Details →](docs/statistical-rigor.md) |
 | **Sample diagnostics** | `omk bench diagnose <id>` — 7 issue kinds (low discrimination / duplicates / ambiguous rubric / cost outliers / etc.) + 0-100 healthScore |
 | **Failure clustering** | `omk bench failures <id>` — single LLM call clusters failed samples and emits per-cluster fixes |
+| **RAG metrics** | `faithfulness` / `answer_relevancy` / `context_recall` — anti-hallucination + answer relevance + context coverage; auto-inherits length-debias |
 | **Hard budget caps** | `--budget-usd / --budget-per-sample-usd / --budget-per-sample-ms` — abort on total-cost overrun, flag per-sample overruns; partial report persisted |
-| **Multi-executor** | Claude CLI / Claude SDK / Codex CLI / OpenAI / Gemini / any custom command |
+| **Construct-validity isolation** | `--strict-baseline` (default ON) cuts three contamination channels so baseline doesn't silently see the skill it's being compared against: (1) SDK skill auto-discovery, (2) subagent Skill tool, (3) cwd file-system access via the `skills/<name>/` symlink that's normally there for the treatment variant. eval.yaml `allowedSkills` for per-variant whitelists |
+| **Sample design science** | Sample schema with `capability` / `difficulty` / `construct` / `provenance` metadata fields (HF Dataset Cards style). `bench diagnose` shows coverage breakdown + flags `rubric_clarity_low` (short rubric without grading keywords) / `capability_thin` (capability supported by ≤ N×0.2 samples). `bench gen-samples` auto-stamps provenance. See [docs/sample-design-spec.md](docs/sample-design-spec.md) for the 8 industry-gap mapping |
 | **Multi-judge ensemble** | `--judge-models claude:opus,openai:gpt-4o` cross-vendor scoring + agreement metrics |
 | **MCP URL fetching** | pull content from private-doc URLs via an MCP server (SSO-protected knowledge bases, etc.) |
 | **Blind A/B** | `--blind` hides variant names; HTML report has a reveal button |
-| **Parallel execution** | `--concurrency N` runs N tasks at once |
 | **Multi-run variance** | `--repeat N` repeats the eval and computes mean / SD / CI / t-test |
+| **Parallel execution** | `--concurrency N` runs N tasks at once |
+| **Assertion negation + composition** | universal `not: true` field + `assert-set` (any/all) with arbitrary nesting |
 | **Auto analysis** | detects low-discrimination assertions, flat scores, all-pass / all-fail, expensive samples |
 | **Traceability** | reports carry CLI version, Node version, artifact version fingerprint, judge prompt hash |
 | **EN / ZH switch** | one-click language toggle in the HTML report |

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,47 +7,13 @@
 
 [English](./README.md) | **简体中文**
 
-**omk** — 内置统计严谨性的 LLM 评测框架。Bootstrap CI / Krippendorff α / 长度偏差校正 / 饱和曲线开箱即用。原生支持 Claude Code skill、prompt、agent、RAG。
+**omk** — 你给 LLM 的知识,价值在哪里?
+omk 帮你用客观数据回答,而不是凭感觉。
 
-**固定模型，只变知识载体，数据说话。**
+**固定模型,只变知识载体。**
 
-## 为什么需要这个工具
-
-做知识工程的团队会产出大量知识载体（当前常见是 skill，也包括 prompt、agent、workflow 等）。当被问到"v2 比 v1 好在哪"时，需要客观数据而非主观判断。`oh-my-knowledge` 通过控制变量实验解决这个问题：相同模型、相同测试样本，只改变知识载体。
-
-## 核心能力
-
-- **控制变量离线评测** — 固定模型和样本，只变知识载体；兼容 Claude Code skill、CLAUDE.md prompt、RAG 知识库等任何 markdown 形式的指令
-- **六维独立打分** — Fact / Behavior / LLM-judge / Cost / Efficiency / Stability 分别出信号，单一维度的回退不会被其他维度的收益掩盖
-- **线上 session 观测** — 解析 Claude Code session JSONL，在真实用户会话上测量各 skill 的失败率、耗时、token 成本和知识缺口信号
-- **知识缺口识别** — 严重度加权的信号（显式标记 / 搜索失败 / hedging 用语 / 反复失败）量化风险敞口,不宣称完备性
-- **合并前 CI 门** — `omk bench gate` 强制三层 all-pass（fact + behavior + llm-judge），抓复合分掩盖的单层回退
-- **一行 ship/no-ship 结论** — `omk bench verdict <reportId>` 聚合 bootstrap CI / 三层 ci-gate / saturation / human α,给六档 verdict（PROGRESS / CAUTIOUS / REGRESS / NOISE / UNDERPOWERED / SOLO）+ 行动建议;exit code 反映是否可 ship
-
-### 统计严谨性
-LLM 评测最容易踩的坑是"自信的偏差"——CI 很窄但结论错。omk 的统计层做四件事让结论可被外部审计：
-
-- **Bootstrap CI** (`--bootstrap`) — 不假设分布的置信区间。t 检验在 LLM 序数评分上失效，bootstrap 直接重采样原始数据，对小 N（< 30）和偏态分布都稳。pairwise diff CI 不含 0 = 显著差异。
-- **Human Gold + Krippendorff α** (`--gold-dir`) — 引入外部标注作为锚点。CI 解决"评委稳不稳"，α 解决"评委对不对"——两个维度互补。omk 自动检测污染（gold annotator 与 judge 同模型时警告）。
-- **Length-controlled judge prompt** (默认开启) — 研究证实 LLM 评委隐性偏向更长的回答。omk 的 judge prompt 加显式段落"长度不是质量信号"，template hash 为 v3-cot-length，跟旧版本的报告 hash 肉眼可辨。`omk bench debias-validate length <reportId>` 重判检测偏差幅度。
-- **Saturation curve** — 回答"我跑够样本了吗"。`--repeat ≥ 5` 时累积 N → 均值 + bootstrap CI 序列，CI 宽度衰减率 < 5% 持续 3 个窗口判定饱和——再多样本对结论无实质收益。HTML 报告内联 SVG 曲线 + verdict。
-
-## 为什么选 omk
-
-| | omk | promptfoo | DeepEval | RAGAS | LangSmith |
-|--|--|--|--|--|--|
-| Bootstrap CI | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Krippendorff α(评委 ↔ 人工锚点） | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Length-debias 评委 prompt | ✓ 默认 | ✗ | ✗ | ✗ | ✗ |
-| 饱和曲线 | ✓ | ✗ | ✗ | ✗ | ✗ |
-| 三层独立评分 | ✓ | ✗ | 部分 | ✗ | ✗ |
-| 原生 Claude Code skill | ✓ | ✗ | ✗ | ✗ | ✗ |
-| 完整中文文档 | ✓ | ✗ | ✗ | ✗ | ✗ |
-| 托管 SaaS 看板 | ✗ | ✗ | ✓ | ✗ | ✓ |
-
-omk 的护城河是**统计严谨性** — 每条结论都能被研究者审计。需要托管 SaaS 看板?选 LangSmith。要本地快速 prompt 迭代不要统计层?选 promptfoo。**要 ship 到生产且会被问"为什么应该相信这个数字"?选 omk**。
-
-完整对比(7 个工具 × 25+ 维度): [docs/zh/comparison.md](docs/zh/comparison.md)
+<a id="statistical-rigor"></a>
+> 默认带:Bootstrap 置信区间 · Krippendorff α(评委 ↔ 人工)· 长度去偏 · 饱和曲线 · 用例隔离(construct validity)。[这些为什么重要 →](docs/zh/statistical-rigor.md)
 
 ## 快速开始
 
@@ -68,12 +34,14 @@ cd my-eval
 omk bench run --dry-run
 
 # 运行评测（自动发现 skills/ 目录下的所有 artifact）
-omk bench run
+omk bench run    # → 5 分钟出 HTML 报告 + verdict
 
 # CLI 输出语言: zh (默认) / en — flag 优先级高于环境变量
 omk bench run --lang en
 OMK_LANG=en omk bench report
 ```
+
+![omk 报告](./assets/screenshots/report-overview-zh.png)
 
 ## 在 Claude Code 中使用
 
@@ -87,28 +55,58 @@ OMK_LANG=en omk bench report
 
 或直接说"帮我评测 v1 和 v2 的差异"、"改进一下这个 artifact"，omk 会自动理解意图并调用对应命令。
 
+## 为什么需要这个工具
+
+做知识工程的团队会产出大量知识载体（当前常见是 skill，也包括 prompt、agent、workflow 等）。当被问到"v2 比 v1 好在哪"时，需要客观数据而非主观判断。`oh-my-knowledge` 通过控制变量实验解决这个问题：相同模型、相同测试用例，只改变知识载体。
+
+## 核心能力
+
+- **控制变量离线评测** — 固定模型和用例，只变知识载体；兼容 Claude Code skill、CLAUDE.md prompt、RAG 知识库等任何 markdown 形式的指令
+- **六维独立打分** — Fact / Behavior / LLM-judge / Cost / Efficiency / Stability 分别出信号，单一维度的回退不会被其他维度的收益掩盖
+- **线上 session 观测** — 解析 Claude Code session JSONL，在真实用户会话上测量各 skill 的失败率、耗时、token 成本和知识缺口信号
+- **知识缺口识别** — 严重度加权的信号（显式标记 / 搜索失败 / hedging 用语 / 反复失败）量化风险敞口,不宣称完备性
+- **合并前 CI 门** — `omk bench gate` 强制三层 all-pass（fact + behavior + llm-judge），抓复合分掩盖的单层回退
+- **一行 ship/no-ship 结论** — `omk bench verdict <reportId>` 聚合 bootstrap CI / 三层 ci-gate / saturation / human α,给六档 verdict(PROGRESS / CAUTIOUS / REGRESS / NOISE / UNDERPOWERED / SOLO)+ 行动建议;exit code 反映是否可 ship
+
+## 为什么选 omk
+
+| | omk | promptfoo | DeepEval | LangSmith |
+|--|--|--|--|--|
+| Bootstrap 置信区间 | ✓ 默认 | ✗ | ✗ | ✗ |
+| Krippendorff α(评委 ↔ 人工) | ✓ 默认 | ✗ | ✗ | ✗ |
+| 长度去偏的评委 prompt | ✓ 默认 | ✗ | ✗ | ✗ |
+| 饱和曲线 | ✓ | ✗ | ✗ | ✗ |
+| 三层独立评分 | ✓ | ✗ | 部分 | ✗ |
+| 用例隔离(construct validity) | ✓ 默认 | ✗ | ✗ | ✗ |
+| 原生 Claude Code skill | ✓ | ✗ | ✗ | ✗ |
+| 托管 SaaS 看板 | ✗ | ✗ | ✓ | ✓ |
+
+omk 的护城河是 **default-on 安全网** —— Bootstrap CI / 评委 ↔ 人工 α / 长度去偏不是 advanced flag,是默认行为。其他工具让你**手动**接置信区间;omk 让你**默认无法忽略**它。需要 SaaS 看板?选 LangSmith。要快速 prompt 迭代不要统计层?选 promptfoo。**要发到生产且会被问"为什么应该相信这个数字"?选 omk。**
+
+RAG 专项评测请看 RAGAS(独立 niche,跟 omk 互补)。完整对比(7 个工具 × 25+ 维度): [docs/zh/comparison.md](docs/zh/comparison.md)
+
 ## 特性
 
 | 特性 | 说明 |
 |------|------|
-| **21+ 种断言** | 包含子串、正则、JSON Schema、ROUGE/BLEU/Levenshtein 相似度、Agent 工具调用、语义相似度、自定义函数等 |
-| **断言取反 + 组合** | 通用 `not: true` 字段 + `assert-set` (any/all) 任意嵌套 |
-| **六维评估** | 事实 / 行为 / LLM 评价 / 成本 / 效率 / 稳定性独立展示 |
-| **统计严谨性** | Bootstrap CI / Krippendorff α / Length-debias / Saturation curve |
-| **用例隔离 (construct validity)** | `--strict-baseline` (默认开) 三堵 baseline 拿到被测 skill 的污染路径:(1) SDK skill auto-discovery (2) subagent Skill 工具调用 (3) cwd 文件系统(避免 baseline 顺 `skills/<name>/` symlink 直接 Read 到 SKILL.md)。eval.yaml `allowedSkills` 支持 per-variant 白名单 |
-| **用例设计科学性 (sample design science)** | Sample schema 加 `capability` / `difficulty` / `construct` / `provenance` 元数据字段(HF Dataset Cards 风)。`bench diagnose` 输出 coverage 分桶 + 检测 `rubric_clarity_low` / `capability_thin` 两类新 issue。`bench gen-samples` 自动给生成的 sample 打 provenance。详见 [docs/sample-design-spec.md](docs/sample-design-spec.md),含 8 条行业 gap(HELM / MMLU-Pro / Construct Validity / IRT / Dataset Cards / Adversarial)的 omk v1 映射 |
 | **Verdict 一行结论** | `omk bench verdict <id>` 六档判定 + ship 建议 + exit code 路由,与 HTML 报告 verdict pill 共享规则 |
-| **RAG metrics** | `faithfulness` / `answer_relevancy` / `context_recall` 三 metric — 反幻觉 + 切题度 + context 覆盖,自动继承 length-debias |
-| **样本质量诊断** | `omk bench diagnose <id>` 7 类 issue（区分度低 / 重复 / 歧义 / 成本异常 / 全 fail 等）+ healthScore 0-100 |
-| **失败聚类 + 根因** | `omk bench failures <id>` 单 LLM 调用聚类失败样本 + 每 cluster 给修复建议 |
-| **预算硬阈值** | `--budget-usd / --budget-per-sample-usd / --budget-per-sample-ms` 总成本 + 单样本成本/耗时上限,超出中止保留 partial report |
-| **多执行器** | 支持 Claude CLI / Claude SDK / Codex CLI / OpenAI / Gemini 及自定义命令 |
+| **六维评估** | 事实 / 行为 / LLM 评价 / 成本 / 效率 / 稳定性独立展示 |
+| **多执行器** | 支持 Claude CLI / Claude SDK / Codex CLI / Codex SDK / OpenAI / Gemini 及自定义命令 |
+| **21+ 种断言** | 包含子串、正则、JSON Schema、ROUGE/BLEU/Levenshtein 相似度、Agent 工具调用、语义相似度、自定义函数等 |
+| **统计严谨性** | Bootstrap CI / Krippendorff α / 长度去偏 / 饱和曲线 —— 全部默认开。[详情 →](docs/zh/statistical-rigor.md) |
+| **用例质量诊断** | `omk bench diagnose <id>` 7 类 issue(区分度低 / 重复 / 歧义 / 成本异常 / 全 fail 等)+ healthScore 0-100 |
+| **失败聚类 + 根因** | `omk bench failures <id>` 单 LLM 调用聚类失败用例 + 每 cluster 给修复建议 |
+| **RAG metrics** | `faithfulness` / `answer_relevancy` / `context_recall` 三 metric — 反幻觉 + 切题度 + context 覆盖,自动继承长度去偏 |
+| **预算硬阈值** | `--budget-usd / --budget-per-sample-usd / --budget-per-sample-ms` 总成本 + 单用例成本/耗时上限,超出中止保留 partial report |
+| **用例隔离 (construct validity)** | `--strict-baseline` (默认开) 三堵 baseline 拿到被测 skill 的污染路径:(1) SDK skill auto-discovery (2) subagent Skill 工具调用 (3) cwd 文件系统(避免 baseline 顺 `skills/<name>/` symlink 直接 Read 到 SKILL.md)。eval.yaml `allowedSkills` 支持 per-variant 白名单 |
+| **用例设计科学性 (sample design science)** | Sample schema 加 `capability` / `difficulty` / `construct` / `provenance` 元数据字段(HF Dataset Cards 风)。`bench diagnose` 输出 coverage 分桶 + 检测 `rubric_clarity_low` / `capability_thin` 两类新 issue。`bench gen-samples` 自动给生成的用例打 provenance。详见 [docs/sample-design-spec.md](docs/sample-design-spec.md),含 8 条行业 gap(HELM / MMLU-Pro / Construct Validity / IRT / Dataset Cards / Adversarial)的 omk v1 映射 |
 | **多评委 ensemble** | `--judge-models claude:opus,openai:gpt-4o` 跨厂商评分 + agreement 度量 |
 | **MCP URL 获取** | 通过 MCP Server 获取私有文档 URL 内容（SSO 保护的知识库等） |
 | **盲测 A/B** | `--blind` 隐藏变体名称，HTML 报告有揭晓按钮 |
-| **并行执行** | `--concurrency N` 并行 N 个任务 |
 | **多轮方差分析** | `--repeat N` 重复 N 次，计算均值/标准差/置信区间/t 检验 |
-| **自动分析** | 检测低区分度断言、均匀分数、全通过/全失败、高成本样本 |
+| **并行执行** | `--concurrency N` 并行 N 个任务 |
+| **断言取反 + 组合** | 通用 `not: true` 字段 + `assert-set` (any/all) 任意嵌套 |
+| **自动分析** | 检测低区分度断言、均匀分数、全通过/全失败、高成本用例 |
 | **可追溯性** | 报告含 CLI 版本、Node 版本、artifact 版本指纹、judge prompt hash |
 | **中英切换** | HTML 报告右上角一键切换语言 |
 

--- a/docs/statistical-rigor.md
+++ b/docs/statistical-rigor.md
@@ -1,0 +1,101 @@
+<!--
+title: Statistical rigor — Bootstrap CI, Krippendorff α, length-debias, saturation curves
+description: Why omk's eval results are auditable, not just claimed. Distribution-free CIs, judge ↔ human agreement, length-debiased scoring, saturation curves — all on by default.
+-->
+
+# Statistical rigor
+
+omk's job is to answer **"the knowledge you give your LLM — what's it actually worth?"** with objective data. The biggest LLM-eval failure mode is **confident bias** — narrow CIs around the wrong answer. omk ships four pieces by default so conclusions can be externally audited.
+
+This page is the depth reference. The README hero callout is the entry; come here for formulas, flags, and the why.
+
+## 1. Bootstrap CI(`--bootstrap`)
+
+**Distribution-free confidence intervals.**
+
+The t-test breaks on ordinal LLM scores (Likert-like buckets, not normal-distributed continuous values). Bootstrap directly resamples the raw observations and stays valid at small N (< 30) and on skewed distributions.
+
+- **Mean CI** per variant — resampled with replacement N times (default 5000)
+- **Pairwise diff CI** between two variants — diff of resampled means; if the CI does not cross 0, the difference is significant at the chosen α (default 0.05 → 95% CI)
+- **Output**: each `VariantResult.bootstrapCI` carries `[lo, hi]` for mean and pairwise; HTML report draws CI bands; CLI `bench verdict` consumes them in the 6-tier verdict logic
+
+**Reference**: Efron & Tibshirani (1993), "An Introduction to the Bootstrap". omk implementation: `src/eval-core/bootstrap.ts`. Frozen by `judge-hash-frozen.test.ts` to prevent silent formula drift.
+
+## 2. Human Gold + Krippendorff α(`--gold-dir`)
+
+**Judge ↔ human agreement, anchored externally.**
+
+CI tells you "is the judge stable across resamples". α tells you "is the judge agreeing with a human standard". Two complementary axes:
+
+- **Stable + low α** = judge is consistently wrong (systematic bias)
+- **Unstable + high α** = judge agrees with humans on average but is noisy
+- **Stable + high α** = trust the judge for this rubric
+- **Unstable + low α** = judge is broken
+
+omk auto-detects gold-judge collusion: if the gold annotator is the same model as the judge (e.g., both `claude-3.5-sonnet`), α inflates because both share the same biases. omk warns and reports adjusted α.
+
+**Formula**: standard Krippendorff α with ordinal distance metric. Implementation: `src/grading/human-gold.ts`. Inputs: `<gold-dir>/<sample_id>.json` files with human scores per dimension.
+
+## 3. Length-controlled judge prompt(default ON)
+
+**Research shows LLM judges over-weight verbosity.** Longer responses get higher scores, independent of quality. omk's judge prompt explicitly states "length is not a quality signal" + uses chain-of-thought + length normalization heuristics.
+
+- Template hash `v3-cot-length` — older reports use `v2-cot` (pre-debias), reports are visibly different by hash
+- `omk bench debias-validate length <reportId>` — re-judges with the opposite setting, reports the score shift; if shift > threshold, original report had measurable length bias
+- `--no-debias-length` opt-out for research / replication scenarios
+- Reference: Saito et al. (2023), "Verbosity Bias in Preference Labeling by Large Language Models"
+
+**Frozen by**: `test/grading/judge-hash-frozen.test.ts` — byte-level hash freeze prevents silent prompt drift across versions.
+
+## 4. Saturation curve
+
+**Answers "have I run enough samples?"**
+
+With `--repeat ≥ 5`, omk accumulates cumulative N → bootstrap CI sequence. When CI shrink rate stays under 5% across 3 windows, the eval is **saturated** — more samples buy nothing, additional cost is wasted.
+
+- HTML report inlines an SVG saturation curve + verdict label
+- `omk bench verdict` uses saturation as one input to the 6-tier verdict logic
+- Default window size: 3 consecutive measurements; threshold: 5% relative shrink in CI width
+- Reference: this is omk's own design, not a published method. Implementation: `src/eval-core/saturation.ts`
+
+## Why these four together
+
+Each piece guards a different failure mode:
+
+| Failure mode | Guard |
+|---|---|
+| "v2 looks better but it's within margin of error" | Bootstrap CI(pairwise diff CI not crossing 0) |
+| "Judge says v2 is better but I don't trust the judge" | Krippendorff α (judge ↔ human) |
+| "Judge is biased toward verbose answers" | Length-controlled judge prompt |
+| "I ran 10 samples and stopped — was that enough?" | Saturation curve |
+
+Skip any one and you have a hole. omk ships all four by default; you can opt out of length-debias for research replication, but the others are unconditional.
+
+## Construct-validity isolation(`--strict-baseline`, default ON)
+
+A fifth invariant, separate from the four above but also default-on:
+
+baseline gets the prompt **without** the skill being tested. omk cuts three contamination paths so baseline doesn't silently see the skill it's compared against:
+
+1. SDK skill auto-discovery
+2. subagent Skill tool
+3. cwd file-system access via the `skills/<name>/` symlink
+
+`eval.yaml` `allowedSkills` allows per-variant whitelists for advanced cases. Without isolation, any "v2 is better than baseline" claim is suspect because baseline may have been reading v2's own SKILL.md through one of the three channels.
+
+See: [docs/sample-design-spec.md](sample-design-spec.md) for related sample-design considerations.
+
+---
+
+## Reproducibility / audit trail
+
+Every report carries:
+- omk version (`reportMeta.cliVersion`)
+- Node version (`reportMeta.nodeVersion`)
+- Judge model + hash (`reportMeta.judgeModel`, `reportMeta.judgePromptHash`)
+- Executor runtime fingerprint (`reportMeta.executorRuntime`, `reportMeta.judgeRuntime`)
+- Sample fingerprints (`reportMeta.sampleHashes`)
+- Skill isolation snapshot (`reportMeta.skillIsolation`)
+- Schema version (`reportMeta.schemaVersion`)
+
+Cross-version comparability is enforced by `BREAKING-COMPARABILITY` callouts in [CHANGELOG](../CHANGELOG.md) — when a measurement invariant changes, you'll see it.

--- a/docs/zh/statistical-rigor.md
+++ b/docs/zh/statistical-rigor.md
@@ -1,0 +1,101 @@
+<!--
+title: 统计严谨性 — Bootstrap CI / Krippendorff α / 长度去偏 / 饱和曲线
+description: 为什么 omk 的评测结果可被审计而不是声称严谨。无分布假设的置信区间、评委 ↔ 人工一致性、长度去偏判分、饱和曲线 —— 都是默认开。
+-->
+
+# 统计严谨性
+
+omk 要回答的问题是 **"你给 LLM 的知识,价值在哪里?"** —— 用客观数据,不靠凭感觉。LLM 评测最常踩的坑是 **"自信的偏差"** —— CI 很窄但结论错。omk 默认带四件事让结论可被外部审计。
+
+本页是深度参考。README 顶部的 callout 是入口,公式 / flag / 设计动机来这里查。
+
+## 1. Bootstrap CI(`--bootstrap`)
+
+**不假设分布的置信区间。**
+
+t 检验在 LLM 序数评分(Likert 类离散桶,不是正态分布的连续值)上失效。Bootstrap 直接重采样原始观测值,对小 N(< 30)和偏态分布都稳。
+
+- **每个 variant 的均值 CI** —— 有放回重采样 N 次(默认 5000)
+- **两个 variant 之间的 pairwise diff CI** —— 重采样后的均值差;如果 CI 不跨 0,差异在选定 α(默认 0.05 → 95% CI)显著
+- **输出**:每个 `VariantResult.bootstrapCI` 含均值跟 pairwise 的 `[lo, hi]`;HTML 报告画 CI 带状区域;CLI `bench verdict` 在六档 verdict 逻辑里消费这些 CI
+
+**参考**:Efron & Tibshirani (1993), "An Introduction to the Bootstrap"。omk 实现:`src/eval-core/bootstrap.ts`。由 `judge-hash-frozen.test.ts` 冻结防止公式悄悄漂移。
+
+## 2. Human Gold + Krippendorff α(`--gold-dir`)
+
+**评委 ↔ 人工一致性,外部锚定。**
+
+CI 告诉你"评委在重采样里稳不稳"。α 告诉你"评委跟人工标准对不对"。两个互补维度:
+
+- **稳定 + α 低** = 评委稳定地错(系统性偏差)
+- **不稳定 + α 高** = 评委平均跟人工一致但波动大
+- **稳定 + α 高** = 这个 rubric 下评委可信
+- **不稳定 + α 低** = 评委坏了
+
+omk 自动检测 gold-judge 同源污染:如果 gold annotator 跟评委是同一个模型(比如都是 `claude-3.5-sonnet`),α 会被抬高(两者共享偏差)。omk 警告 + 报告调整后的 α。
+
+**公式**:标准 Krippendorff α + 序数距离度量。实现:`src/grading/human-gold.ts`。输入:`<gold-dir>/<sample_id>.json` per-用例每维度的人工评分。
+
+## 3. 长度去偏的评委 prompt(默认开启)
+
+**研究证实 LLM 评委隐性偏向更长的回答。** 越长分越高,跟质量无关。omk 的评委 prompt 显式声明"长度不是质量信号"+ chain-of-thought + 长度归一化启发式。
+
+- Template hash `v3-cot-length` —— 旧报告用 `v2-cot`(去偏前),报告 hash 肉眼可辨
+- `omk bench debias-validate length <reportId>` —— 用相反设置重判,报告分数偏移;如果偏移超阈值,原报告有可测量的长度偏差
+- `--no-debias-length` 给研究 / 复现场景留 opt-out 口子
+- 参考:Saito et al. (2023), "Verbosity Bias in Preference Labeling by Large Language Models"
+
+**冻结**:`test/grading/judge-hash-frozen.test.ts` 字节级 hash 冻结,防版本间 prompt 悄悄漂移。
+
+## 4. 饱和曲线
+
+**回答"我跑够样本了吗"。**
+
+`--repeat ≥ 5` 时,omk 累积 N → bootstrap CI 序列。当 CI 宽度衰减率 < 5% 持续 3 个窗口,评测**饱和** —— 再多样本对结论无实质收益,额外的成本是浪费。
+
+- HTML 报告内联 SVG 饱和曲线 + verdict 标签
+- `omk bench verdict` 把饱和度作为六档 verdict 逻辑的输入之一
+- 默认窗口大小:3 个连续测量;阈值:CI 宽度相对衰减 5%
+- 参考:omk 自有设计,不是已发表方法。实现:`src/eval-core/saturation.ts`
+
+## 四件事一起看
+
+每件事守住一个不同的失败模式:
+
+| 失败模式 | 守口 |
+|---|---|
+| "v2 看着更好但其实在误差范围内" | Bootstrap CI(pairwise diff CI 不跨 0) |
+| "评委说 v2 更好但我不信评委" | Krippendorff α(评委 ↔ 人工) |
+| "评委偏向冗长的回答" | 长度去偏的评委 prompt |
+| "我跑了 10 个用例就停了 —— 够吗?" | 饱和曲线 |
+
+少一件,洞就出来。omk 默认四件全开;长度去偏可为研究复现 opt out,其他三件无条件。
+
+## 用例隔离(`--strict-baseline`,默认开)
+
+跟上面四件并列、但也是默认开的第五件:
+
+baseline 拿到的 prompt **不应**包含被测 skill。omk 切断三条污染路径,防止 baseline 偷偷看到对照组的 skill:
+
+1. SDK skill auto-discovery
+2. subagent Skill 工具
+3. cwd 文件系统(顺 `skills/<name>/` symlink 直接 Read 到 SKILL.md)
+
+`eval.yaml` 的 `allowedSkills` 支持 per-variant 白名单给高级场景。没有隔离时,任何"v2 比 baseline 好"的结论都可疑 —— baseline 可能通过这三条路径之一已经看到 v2 的 SKILL.md。
+
+详见:[docs/sample-design-spec.md](../sample-design-spec.md) 的相关用例设计。
+
+---
+
+## 可复现 / 审计追溯
+
+每份报告携带:
+- omk 版本(`reportMeta.cliVersion`)
+- Node 版本(`reportMeta.nodeVersion`)
+- 评委模型 + hash(`reportMeta.judgeModel` / `reportMeta.judgePromptHash`)
+- Executor runtime 指纹(`reportMeta.executorRuntime` / `reportMeta.judgeRuntime`)
+- 用例指纹(`reportMeta.sampleHashes`)
+- skill 隔离快照(`reportMeta.skillIsolation`)
+- Schema 版本(`reportMeta.schemaVersion`)
+
+跨版本可比性由 [CHANGELOG](../../CHANGELOG.md) 中的 `BREAKING-COMPARABILITY` callout 强制 —— 测量学不变量改了,你能看到。


### PR DESCRIPTION
## Summary

omk 增长方案 PR B —— 重写 README zh/en 第一屏。把统计严谨性从"研究信用证"改写成"防忽悠 / 客观数据 vs 凭感觉"的用户外延框架,广开 TAM 的同时不掉调性。

跟 PR #43(dependabot.yml + Discussions 已开)是同一增长方案的续集。

## 新 hero

**EN**:
> The knowledge you give your LLM — what's it actually worth?
> omk answers with objective data, not gut feeling.

**ZH**:
> 你给 LLM 的知识,价值在哪里?
> omk 帮你用客观数据回答,而不是凭感觉。

紧跟 5 个测量学不变量 callout(visibility 不丢、SEO 不弱化):
> Built-in: Bootstrap CI · Krippendorff α (judge ↔ human) · length-debias · saturation curves · construct-validity isolation. [Why these matter →](docs/statistical-rigor.md)

## 主要改动

- **新建** `docs/statistical-rigor.md`(en) + `docs/zh/statistical-rigor.md`(zh):把现 README L27-34 stats 4 段抽过去 + 加深技术细节(Bootstrap CI 公式 / α 同源污染检测 / saturation 阈值 / 五件不变量串讲);带 SEO meta description
- **README.md** hero 重写 + Statistical rigor 段删除(改 callout 段保留 5 不变量名字)+ 加 `<a id=\"statistical-rigor\"></a>` redirect anchor 兼容旧外链
- **段落顺序**:Hero → Quick start(上提)→ Use inside Claude Code(上提)→ Why this tool → Key features → Why omk over alternatives(下移)→ Features 表 → How it works
- **Why omk over alternatives 表**:7 列 → 4 列(omk + promptfoo + DeepEval + LangSmith,删 RAGAS 行避免误导性比较),脚注一行 \"RAG-specific evals: see RAGAS\"
- **Features 表行重排**为 broad-appeal-first:Verdict / 六维 / 多 executor / 21+ 断言 / Statistical rigor 在前;construct-validity / sample design science 中段
- **README.zh.md** 同步重写;zh 文案 \"样本\" → \"用例\" 3 处统一(L102 / L103 / L111),按 CLAUDE.md 中文 user-facing 术语规则
- **CHANGELOG** [Unreleased] Changed 段加一行(链 PR,说明范围)

## 测量学不变量保护

- judge prompt hash / Bootstrap CI 公式 / α 公式 / Report JSON schema 等代码层不变量**不动**
- README 内容是 user-facing 表达层,改的是叙述顺序跟措辞,不改测量行为
- 5 个不变量名字仍在 README hero 下方 callout 里出现,SEO 关键词跟 GitHub topics 都保留

## 验证

- [x] \`yarn lint && yarn build && yarn test\`(907 tests / 68 files 全过)
- [x] cross-ref sweep:\`grep -rn '#statistical-rigor|#why-omk|#why-this-tool|#use-inside-claude' docs/ examples/ SKILL.md CONTRIBUTING.md\` 0 hit(无外部 anchor 引用要更新)
- [x] \`docs/comparison.md\` / \`docs/zh/comparison.md\` 自身 \`## Statistical rigor\` 章节(独立内容,跟 README 锚点无 alias 关系,不动)

## 后续 follow-up(不在本 PR scope)

- 截图 \`assets/screenshots/report-overview.png\` / \`-zh.png\`(README 里的 \`<img>\` 链接现指向不存在的图片,GitHub 会显示 broken image 几天直到截图补上)
- 跟新 hero 同步 GitHub repo description(可手动 \`gh repo edit --description\`)
- HN / r/ML 长文投稿(content 类,正交)
- 跟踪 4 周后 stars 走势,如未动启动 community engagement / 长文投稿

🤖 Generated with [Claude Code](https://claude.com/claude-code)