### PR TITLE
docs(readme): 前置报告截图

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ omk answers with objective data, not gut feeling.
 <a id="statistical-rigor"></a>
 > Built-in: Bootstrap CI · Krippendorff α (judge ↔ human) · length-debias · saturation curves · construct-validity isolation. [Why these matter →](docs/statistical-rigor.md)
 
+![omk report](./assets/screenshots/report-overview.png)
+
 ## Quick start
 
 ```bash
@@ -40,8 +42,6 @@ omk bench run    # → HTML report with verdict in 5 minutes
 omk bench run --lang en
 OMK_LANG=en omk bench report
 ```
-
-![omk report](./assets/screenshots/report-overview.png)
 
 ## Use inside Claude Code
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,6 +15,8 @@ omk 帮你用客观数据回答,而不是凭感觉。
 <a id="statistical-rigor"></a>
 > 默认带:Bootstrap 置信区间 · Krippendorff α(评委 ↔ 人工)· 长度去偏 · 饱和曲线 · 用例隔离(construct validity)。[这些为什么重要 →](docs/zh/statistical-rigor.md)
 
+![omk 报告](./assets/screenshots/report-overview-zh.png)
+
 ## 快速开始
 
 ```bash
@@ -40,8 +42,6 @@ omk bench run    # → 5 分钟出 HTML 报告 + verdict
 omk bench run --lang en
 OMK_LANG=en omk bench report
 ```
-
-![omk 报告](./assets/screenshots/report-overview-zh.png)
 
 ## 在 Claude Code 中使用
 


### PR DESCRIPTION
## 目的

README 首屏里报告截图出现得偏后，Quick start 代码块会把核心报告效果往下压。这个 PR 把中英文 README 的报告截图前移，让用户更早看到 OMK 能产出的评测报告。

## 变更

- 将英文 README 的报告截图移动到开头卖点 / 统计严谨性说明之后、Quick start 之前。
- 将中文 README 的报告截图做同样位置调整。
- 不改变截图文件、命令说明或功能文案。

## 测试

- [x] `git diff --check` 通过
- [x] `yarn lint` 通过
- [x] `yarn build` 通过
- [x] `yarn test` 通过
- [x] 文档变更，无需新增测试

## Checklist

- [x] 已阅读 `CLAUDE.md`
- [x] 分支符合 Gitflow 前缀要求
- [x] 目标分支符合 `CLAUDE.md` / `CONTRIBUTING.md` 的分支策略
- [x] Commit message 符合仓库约定
- [x] 无需更新 `CHANGELOG.md`，仅调整 README 展示顺序
- [x] Diff 中无 secrets / 内部 URL / 个人数据
- [x] README 已更新

## 补充信息

本次只调整截图位置，目的是让 README 更早展示评测报告效果。