### PR TITLE
chore(deps): dependabot 指向 develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # npm 依赖周更,limit=5 防 PR 队列爆炸
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -14,6 +15,7 @@ updates:
   # GitHub Actions 工作流也跟着更新
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## 目的

修正 Dependabot 默认向 `main` 开 PR 的问题。仓库采用 Gitflow，普通依赖更新应进入 `develop`，`main` 只用于发布版本。

## 变更

- npm 依赖更新添加 `target-branch: "develop"`。
- GitHub Actions 依赖更新添加 `target-branch: "develop"`。

## 测试

- [x] `git diff --check` 通过
- [x] `yarn lint` 通过
- [x] `yarn build` 通过
- [x] `yarn test` 通过
- [x] 配置变更，无需新增测试

## Checklist

- [x] 已阅读 `CLAUDE.md`
- [x] 分支符合 Gitflow 前缀要求
- [x] 目标分支符合 `CLAUDE.md` / `CONTRIBUTING.md` 的分支策略
- [x] Commit message 符合仓库约定
- [x] 无需更新 `CHANGELOG.md`，仅调整维护配置
- [x] Diff 中无 secrets / 内部 URL / 个人数据
- [x] README / docs 无需更新

## 补充信息

这会避免 Dependabot 后续再次向 `main` 创建普通依赖升级 PR。