### PR TITLE
docs(readme): 澄清 Claude Code 与 Codex 的使用入口

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); version
 
 ## [Unreleased]
 
+### Changed
+
+- **README / comparison 文档澄清 Claude Code 与 Codex 用法**:把 `/omk ...` 明确限定为 Claude Code skill 入口,避免让读者误解 Codex 也原生支持 slash command。README 中补充 Codex 直接驱动 `omk` CLI 的用法,comparison 文档同步改成"Claude Code 工作流最原生,但 `omk` CLI 也可被其他 coding agent 驱动"。
+- **README 顶部新增 npm weekly downloads badge**:公开仓库前补充近期使用热度信号,与现有 npm version / CI / License / Node.js version 形成一组更完整的基础元信息。
+
 ## [0.24.0] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # oh-my-knowledge
 
 [![npm version](https://img.shields.io/npm/v/oh-my-knowledge.svg)](https://www.npmjs.com/package/oh-my-knowledge)
+[![npm weekly downloads](https://img.shields.io/npm/dw/oh-my-knowledge.svg)](https://www.npmjs.com/package/oh-my-knowledge)
 [![CI](https://github.com/lizhiyao/oh-my-knowledge/actions/workflows/ci.yml/badge.svg)](https://github.com/lizhiyao/oh-my-knowledge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Node.js Version](https://img.shields.io/node/v/oh-my-knowledge.svg)](https://nodejs.org)
@@ -43,17 +44,31 @@ omk bench run --lang en
 OMK_LANG=en omk bench report
 ```
 
-## Use inside Claude Code
+## Use inside AI Coding Agents
 
-After installing omk, talk to it in natural language from Claude Code:
+### Use inside Claude Code
 
-```
+When the `omk` skill is available in Claude Code, you can invoke it directly like this:
+
+```bash
 /omk eval              # evaluate the artifact(s) in the current project
 /omk evolve            # auto-iterate to improve an artifact
 /omk gen-samples       # generate test cases
 ```
 
-You can also just say "compare v1 vs v2 for me" or "improve this artifact" — omk picks the right command.
+You can also just say "compare v1 vs v2 for me" or "improve this artifact" and omk picks the right command.
+
+### Use inside Codex
+
+Codex does not support Claude Code style `/omk ...` slash commands by default. In Codex, the usual pattern is to ask the agent to run the `omk` CLI directly, for example:
+
+```bash
+omk bench run
+omk bench evolve
+omk bench gen-samples skills/my-skill.md
+```
+
+You can also describe the goal in natural language, such as "compare v1 vs v2" or "generate test cases for this skill".
 
 ## Why this tool
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,6 +1,7 @@
 # oh-my-knowledge
 
 [![npm version](https://img.shields.io/npm/v/oh-my-knowledge.svg)](https://www.npmjs.com/package/oh-my-knowledge)
+[![npm weekly downloads](https://img.shields.io/npm/dw/oh-my-knowledge.svg)](https://www.npmjs.com/package/oh-my-knowledge)
 [![CI](https://github.com/lizhiyao/oh-my-knowledge/actions/workflows/ci.yml/badge.svg)](https://github.com/lizhiyao/oh-my-knowledge/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Node.js Version](https://img.shields.io/node/v/oh-my-knowledge.svg)](https://nodejs.org)
@@ -43,17 +44,31 @@ omk bench run --lang en
 OMK_LANG=en omk bench report
 ```
 
-## 在 Claude Code 中使用
+## 在 AI Coding Agent 中使用
 
-安装 omk 后，在 Claude Code 中直接用自然语言交互：
+### 在 Claude Code 中使用
 
-```
+当 `omk` skill 已在 Claude Code 中可用时，可以直接这样调用：
+
+```bash
 /omk eval              # 评测当前项目的 artifact
 /omk evolve            # 自动迭代改进 artifact
 /omk gen-samples       # 生成测试用例
 ```
 
 或直接说"帮我评测 v1 和 v2 的差异"、"改进一下这个 artifact"，omk 会自动理解意图并调用对应命令。
+
+### 在 Codex 中使用
+
+Codex 默认不支持 `/omk ...` 这种 Claude Code 风格的 slash command。通常直接让 agent 执行 `omk` CLI，例如：
+
+```bash
+omk bench run
+omk bench evolve
+omk bench gen-samples skills/my-skill.md
+```
+
+也可以直接用自然语言描述目标，例如"比较 v1 和 v2 的评测差异"、"为这个 skill 生成测试用例"。
 
 ## 为什么需要这个工具
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -107,7 +107,7 @@ Three-layer isolation prevents single-axis regressions from being masked by comp
 
 **Chinese-speaking AI engineering teams.** omk has the only complete Chinese documentation set among the surveyed tools — README, CLI help, HTML report, terminology spec, gap-signal spec, RAG-metrics spec, all native Chinese (not machine-translated).
 
-**Claude Code users.** omk runs natively on Claude Code skills — `/omk eval` recognises your `skills/` directory automatically. promptfoo / DeepEval / others require shimming a custom executor.
+**Claude Code users.** omk has the most native workflow on Claude Code: it works as a Claude Code skill, and the underlying `omk` CLI can also be driven directly from Codex and other coding agents. promptfoo / DeepEval / others usually need a custom-executor shim to reach the same artifact-oriented workflow.
 
 ## When NOT to choose omk
 

--- a/docs/zh/comparison.md
+++ b/docs/zh/comparison.md
@@ -107,7 +107,7 @@ omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的
 
 **中文 AI 工程团队**。omk 是参与对比工具中**唯一**有完整中文文档的——README、CLI help、HTML 报告、术语规范、缺口信号规范、RAG metric 规范全部原生中文(非机翻)。
 
-**Claude Code 用户**。omk 原生跑 Claude Code skill —— `/omk eval` 自动识别你的 `skills/` 目录。promptfoo / DeepEval 等需要 shim 自定义 executor。
+**Claude Code 用户**。omk 在 Claude Code 里的工作流最原生:既可以作为 Claude Code skill 使用,底层 `omk` CLI 也能被 Codex 等 coding agent 直接驱动。promptfoo / DeepEval 等通常需要 shim 一层自定义 executor,才能接近这种面向 artifact 的工作流。
 
 ## 什么场景**不**选 omk
 


### PR DESCRIPTION
## Summary
- 澄清 README 中 Claude Code 与 Codex 的入口差异，避免把 `/omk ...` 误写成通用宿主命令
- 同步更新中英文 comparison 文档的宿主表述
- 在 CHANGELOG 的 `[Unreleased]` 记录这次文档调整，并补充 npm weekly downloads badge

## Validation
- yarn lint
- yarn build
- yarn test
