### PR TITLE
chore: 清测试名 + 代码注释里的 Phase / v0.X 时点 tag (39 处)

### DIFF
--- a/src/analysis/saturation.ts
+++ b/src/analysis/saturation.ts
@@ -7,7 +7,7 @@
  * is "is N=30 enough, or should I keep running?". Without a principled
  * answer, users either over-pay (running 200 when 50 was enough) or
  * under-pay (calling skill effects null at N=30 when N=80 would have
- * shown clearly significant — Bootstrap CI from Phase 1 just hasn't
+ * shown clearly significant — Bootstrap CI just hasn't
  * converged yet).
  *
  * Saturation analysis fits the right tool to the question: track a
@@ -19,7 +19,7 @@
  *    checkpoints. Easy to explain. Fragile to outlier samples.
  *  - **bootstrap-ci-width** (default): CI shrinks as O(1/√N); when its
  *    decay rate flattens, more samples buy little. Statistically
- *    grounded; pairs naturally with Phase 1.
+ *    grounded; pairs naturally with the Bootstrap CI module.
  *  - **plateau-height**: range of mean across the last K checkpoints.
  *    Conservative — slow to declare saturation, hard to fool.
  *

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -276,7 +276,7 @@ async function handleRun(argv: string[]): Promise<void> {
     };
   }
 
-  // --no-debias-length: opt out of v0.21 Phase 3a length-controlled prompt.
+  // --no-debias-length: opt out of length-controlled prompt.
   // Default behavior is debias-on (judge prompt v3-cot-length); flag flips it
   // off so historical reports (judgePromptHash from v2-cot era) can be reproduced.
   if (values['no-debias-length'] as boolean) {
@@ -1368,7 +1368,7 @@ async function handleGold(argv: string[]): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// handleDebiasValidate — measure length-debias prompt sensitivity (Phase 3a)
+// handleDebiasValidate — measure length-debias prompt sensitivity
 // ---------------------------------------------------------------------------
 
 async function handleDebiasValidate(argv: string[]): Promise<void> {

--- a/src/cli/parse-run-config.ts
+++ b/src/cli/parse-run-config.ts
@@ -46,7 +46,7 @@ export interface RunConfig {
   bootstrap?: boolean;
   /** --bootstrap-samples N. Bootstrap resamples count, default 1000. */
   bootstrapSamples?: number;
-  /** v0.21 Phase 3a length-debias toggle. Default true; --no-debias-length sets false. */
+  /** length-debias toggle. Default true; --no-debias-length sets false. */
   lengthDebias?: boolean;
   /** hard budget caps from CLI or config. */
   budget?: EvalBudget;

--- a/src/eval-core/bootstrap.ts
+++ b/src/eval-core/bootstrap.ts
@@ -170,7 +170,7 @@ export function bootstrapDiffCI(
 
 /**
  * Generic bootstrap CI for an arbitrary sample-level metric. Used by
- * saturation analysis (Phase 4) to get CI on metrics like stddev or
+ * saturation analysis to get CI on metrics like stddev or
  * agreement, not just mean.
  *
  * @param scores   Original sample.

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -243,7 +243,7 @@ export function aggregateReport({
       request.judgeModels.map((jc) => [`${jc.executor}:${jc.model}`, getExecutorRuntimeFingerprint(jc.executor, jc.model, runtimeOptions)]),
     )
     : undefined;
-  // v0.21 Phase 3a: length-debias is on by default; the request only sets it
+  // length-debias is on by default; the request only sets it
   // false when the user passed --no-debias-length. The hash differs between
   // v3-cot-length (on) and v2-cot (off) so readers can detect the divergence.
   const lengthDebiasOn = request?.lengthDebias !== false;

--- a/src/eval-workflows/batch-evaluation-workflow.ts
+++ b/src/eval-workflows/batch-evaluation-workflow.ts
@@ -40,7 +40,7 @@ interface RunSingleEvaluationOptions {
   judgeRepeat?: number;
   /** Forwarded to pipeline; >= 2 entries triggers multi-judge ensemble mode. */
   judgeModels?: import('../types/index.js').JudgeConfig[];
-  /** v0.21 Phase 3a length-debias toggle. Default true. */
+  /** length-debias toggle. Default true. */
   lengthDebias?: boolean;
 }
 

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -79,7 +79,7 @@ interface CommonEvaluationOptions {
   bootstrap?: boolean;
   /** --bootstrap-samples N. Default 1000. */
   bootstrapSamples?: number;
-  /** v0.21 Phase 3a length-debias toggle. Default true (judge prompt v3-cot-length).
+  /** length-debias toggle. Default true (judge prompt v3-cot-length).
    *  CLI passes false when --no-debias-length is set. */
   lengthDebias?: boolean;
   /** hard budget caps. */
@@ -371,7 +371,7 @@ export interface DryRunBatchReport extends DryRunBase {
 // Top-level (composite) extractor: feeds the legacy flat-field variance on
 // VariantVariance / VarianceComparison. Composite lives here for backward
 // compatibility with historical reports; layer-independent stats are attached
-// via byLayer (see LAYER_EXTRACTORS) starting v0.16 work item B / PR-2.
+// via byLayer (see LAYER_EXTRACTORS).
 const COMPOSITE_EXTRACTOR = (s: VariantSummary | undefined): number | undefined => s?.avgCompositeScore;
 
 // Non-quality metric extractors tracked in byMetric (cost + efficiency).

--- a/src/grading/assertions.ts
+++ b/src/grading/assertions.ts
@@ -50,7 +50,7 @@ export function ratioToScore(ratio: number): number {
 }
 
 // ===========================================================================
-// v0.21 Phase 5b — deterministic similarity metrics
+// Deterministic similarity metrics
 // ===========================================================================
 
 /** Tokenizer: Latin words/numbers as units; CJK chars as single-char units. */
@@ -155,9 +155,9 @@ export function validateJsonSchema(data: unknown, schema: Record<string, unknown
  * BEFORE applying `not`. Pulled out of `runAssertions` so `assert-set` can
  * recurse on children without rebuilding the context.
  *
- * v0.21 Phase 5a — added `not: true` (universal negation) and `assert-set`
- * (any/all combinator). Legacy `not_contains` / `not_equals` / etc. still
- * work; their negation is hard-coded inline as before.
+ * Universal negation (`not: true`) and `assert-set` (any/all combinator) are
+ * supported here. Legacy `not_contains` / `not_equals` / etc. still work;
+ * their negation is hard-coded inline as before.
  */
 function evalAssertion(
   output: string,

--- a/src/grading/human-gold.ts
+++ b/src/grading/human-gold.ts
@@ -3,7 +3,7 @@
  *
  * Why this module exists
  * ----------------------
- * Bootstrap CI (Phase 1) gives us *precision* — how stable the judge is across
+ * Bootstrap CI gives us *precision* — how stable the judge is across
  * resampled evaluations. It does not give us *validity* — whether the judge is
  * scoring the right thing at all. A judge can be extremely consistent (CI very
  * narrow) and yet systematically biased; that's an undetected failure mode.

--- a/src/grading/judge.ts
+++ b/src/grading/judge.ts
@@ -60,7 +60,7 @@ function salvageJudgeResponse(text: string): JudgeResponse | null {
  *                       Kept for `--no-debias-length` so users can reproduce historical
  *                       reports byte-for-byte.
  *  - 'v3-cot-length'  — adds a paragraph telling the judge that length is not a quality
- *                       signal. Default since v0.21 Phase 3a (research consistently shows
+ *                       signal. Default on (research consistently shows
  *                       LLM judges over-weight verbosity; explicit instruction mitigates).
  *
  * Bump when the prompt's intent or structure changes meaningfully — reports tagged
@@ -141,7 +141,7 @@ interface LlmJudgeOptions {
   model: string;
   traceSummary?: string | null;
   /**
-   * When true (default since v0.21), the judge prompt includes an explicit
+   * When true (default), the judge prompt includes an explicit
    * "length is not a quality signal" instruction. Pass false to fall back to
    * the legacy v2-cot prompt — only useful for reproducing pre-v0.21 reports
    * or running A/B comparisons inside `omk bench debias-validate length`.

--- a/src/types/eval.ts
+++ b/src/types/eval.ts
@@ -11,16 +11,16 @@ export interface Assertion {
   fn?: string;
   reference?: string;
   threshold?: number;
-  /** v0.21 Phase 5a — when true, the assertion's pass/fail is inverted. Works
-   *  with any type, including legacy `not_contains` (which becomes a redundant
-   *  but still supported double-negation). */
+  /** When true, the assertion's pass/fail is inverted. Works with any type,
+   *  including legacy `not_contains` (which becomes a redundant but still
+   *  supported double-negation). */
   not?: boolean;
-  /** v0.21 Phase 5a — only used by type='assert-set'. 'any' = at least one
-   *  child must pass; 'all' = every child must pass. Children may be any
-   *  assertion type, including nested assert-sets. */
+  /** Only used by type='assert-set'. 'any' = at least one child must pass;
+   *  'all' = every child must pass. Children may be any assertion type,
+   *  including nested assert-sets. */
   mode?: 'any' | 'all';
   children?: Assertion[];
-  /** v0.21 Phase 5b — for rouge_n_min: which n-gram order (default 1). */
+  /** For rouge_n_min: which n-gram order (default 1). */
   n?: number;
 }
 
@@ -191,7 +191,7 @@ export interface EvaluationRequest {
   bootstrap?: boolean;
   /** --bootstrap-samples N; bootstrap 重采样次数, 默认 1000. > 10000 时 stderr 警告. */
   bootstrapSamples?: number;
-  /** v0.21 Phase 3a length-debias toggle. Default true (judge prompt v3-cot-length).
+  /** length-debias toggle. Default true (judge prompt v3-cot-length).
    *  CLI flag --no-debias-length flips to false (legacy v2-cot prompt). The active
    *  value is reflected in ReportMeta.judgePromptHash and ReportMeta.debiasMode. */
   lengthDebias?: boolean;

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -258,7 +258,7 @@ export interface ReportMeta {
   /** Pairwise comparisons (treatment vs control) — populated when --bootstrap and
    *  multi-variant. Length = (variants.length - 1). */
   pairComparisons?: VariantPairComparison[];
-  /** v0.21 Phase 3 — which judge-bias debias modes were active for this run.
+  /** Which judge-bias debias modes were active for this run.
    *  Values: 'length' (substance-not-length prompt), 'position' (random ensemble
    *  order). Empty / absent means legacy default (no debias). The renderer shows
    *  this so readers can tell apples from oranges across reports. */
@@ -497,7 +497,7 @@ export interface VarianceComparisonMetric {
 // carry composite-score variance for backward compatibility with historical reports.
 export type VarianceMetricKey = 'cost' | 'efficiency';
 
-// Layer keys for the three-layer independent significance tests (v0.16 work item B / PR-2).
+// Layer keys for the three-layer independent significance tests.
 // fact / behavior / judge are independent dimensions of the composite score:
 // - fact: rule-verifiable factual claim assertions
 // - behavior: rule-verifiable execution / tool-call compliance assertions
@@ -522,7 +522,7 @@ export interface VarianceData {
   runs: number;
   perVariant: Record<string, VariantVariance>;
   comparisons: VarianceComparison[];
-  /** v0.21 Phase 4 — saturation curve data. Populated only when repeat ≥ 2.
+  /** Saturation curve data. Populated only when repeat ≥ 2.
    *  Per-variant cumulative score arrays at each repeat checkpoint, plus the
    *  saturation verdict (only computed when repeat ≥ 5). */
   saturation?: SaturationData;

--- a/test/analysis/gap-analyzer.test.ts
+++ b/test/analysis/gap-analyzer.test.ts
@@ -416,7 +416,7 @@ describe('computeGapReport', () => {
 
   // ---------- v0.2 严重度加权 (SIGNAL_WEIGHTS + weightedGapRate) ----------
 
-  it('v0.2: 每个 signal 自带 weight (strong 1.0 / weak 0.5)', () => {
+  it('每个 signal 自带 weight (strong 1.0 / weak 0.5)', () => {
     const results: ResultEntry[] = [
       {
         sample_id: 's001',
@@ -442,7 +442,7 @@ describe('computeGapReport', () => {
     assert.equal(byType.hedging, 0.5);
   });
 
-  it('v0.2: weightedGapRate 按用例最强信号聚合', () => {
+  it('weightedGapRate 按用例最强信号聚合', () => {
     // 3 个用例:1 个 failed_search(强,权重 1.0)、1 个 hedging(弱,权重 0.5)、1 个无信号
     // gapRate = 2/3 ≈ 0.6667
     // weightedGapRate = (1.0 + 0.5 + 0) / 3 ≈ 0.5000
@@ -467,7 +467,7 @@ describe('computeGapReport', () => {
     assert.ok(report.weightedGapRate <= report.gapRate);
   });
 
-  it('v0.2: 同一用例多信号时取最强权重(不是累加)', () => {
+  it('同一用例多信号时取最强权重(不是累加)', () => {
     // 一个用例同时有 hedging(0.5) + failed_search(1.0) → sample weight = 1.0 而不是 1.5
     const results: ResultEntry[] = [
       {
@@ -488,7 +488,7 @@ describe('computeGapReport', () => {
     assert.equal(report.weightedGapRate, 1.0);
   });
 
-  it('v0.2: 全弱信号时 weightedGapRate 显著低于 gapRate', () => {
+  it('全弱信号时 weightedGapRate 显著低于 gapRate', () => {
     // 4 个用例全是 hedging(弱,0.5)
     // gapRate = 4/4 = 1.0 (100% 触发信号)
     // weightedGapRate = 4*0.5 / 4 = 0.5 (加权严重度只到 50%)
@@ -502,7 +502,7 @@ describe('computeGapReport', () => {
     assert.equal(report.weightedGapRate, 0.5);
   });
 
-  it('v0.2: 空 report 时 weightedGapRate === 0 不崩', () => {
+  it('空 report 时 weightedGapRate === 0 不崩', () => {
     const report = computeGapReport([], 'v1');
     assert.equal(report.weightedGapRate, 0);
   });

--- a/test/grading/assertions-phase5.test.ts
+++ b/test/grading/assertions-phase5.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { runAssertions, rougeN, levenshtein, bleu } from '../../src/grading/assertions.js';
 
-describe('Phase 5a — universal `not: true` field', () => {
+describe('universal `not: true` field', () => {
   it('not: true on contains inverts pass/fail', () => {
     const r = runAssertions('hello world', [
       { type: 'contains', value: 'foo' },                  // raw fail
@@ -27,7 +27,7 @@ describe('Phase 5a — universal `not: true` field', () => {
   });
 });
 
-describe('Phase 5a — assert-set combinator', () => {
+describe('assert-set combinator', () => {
   it("'all' mode requires every child to pass", () => {
     const r = runAssertions('hello world', [{
       type: 'assert-set', mode: 'all',
@@ -119,7 +119,7 @@ describe('Phase 5a — assert-set combinator', () => {
   });
 });
 
-describe('Phase 5b — rougeN', () => {
+describe('rougeN', () => {
   it('returns 1.0 for identical strings', () => {
     assert.equal(rougeN('hello world', 'hello world', 1), 1);
   });
@@ -160,7 +160,7 @@ describe('Phase 5b — rougeN', () => {
   });
 });
 
-describe('Phase 5b — levenshtein', () => {
+describe('levenshtein', () => {
   it('returns 0 for identical strings', () => {
     assert.equal(levenshtein('hello', 'hello'), 0);
   });
@@ -184,7 +184,7 @@ describe('Phase 5b — levenshtein', () => {
   });
 });
 
-describe('Phase 5b — bleu', () => {
+describe('bleu', () => {
   it('returns 1.0 for identical strings (long enough for 4-grams)', () => {
     const s = 'the quick brown fox jumps over the lazy dog';
     assert.ok(bleu(s, s) > 0.99);
@@ -210,7 +210,7 @@ describe('Phase 5b — bleu', () => {
   });
 });
 
-describe('Phase 5b — assertion integration', () => {
+describe('assertion integration', () => {
   it('rouge_n_min passes when score meets threshold', () => {
     const r = runAssertions('cat sat on the mat', [
       { type: 'rouge_n_min', reference: 'cat sat on a mat', n: 1, threshold: 0.7 },

--- a/test/grading/judge-prompt-version.test.ts
+++ b/test/grading/judge-prompt-version.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { buildJudgePrompt, getJudgePromptHash } from '../../src/grading/judge.js';
 
-describe('judge prompt versioning (Phase 3a)', () => {
+describe('judge prompt versioning', () => {
   it('default builds the v3-cot-length prompt', () => {
     const text = buildJudgePrompt('p', 'r', 'o', null);
     assert.match(text, /v3-cot-length/);

--- a/test/grading/rag-metrics.test.ts
+++ b/test/grading/rag-metrics.test.ts
@@ -14,7 +14,7 @@ const ok = (output: string): Awaited<ReturnType<ExecutorFn>> => ({
 const mockJudge = (handler: (prompt: string) => number): ExecutorFn =>
   async ({ prompt }) => ok(JSON.stringify({ score: handler(prompt), reason: 'mock' }));
 
-describe('Phase 22.3 — RAG metrics registration', () => {
+describe('RAG metrics registration', () => {
   it('all three RAG metrics are registered as async assertion types', () => {
     assert.ok(ASYNC_ASSERTION_TYPES.has('faithfulness'));
     assert.ok(ASYNC_ASSERTION_TYPES.has('answer_relevancy'));
@@ -22,7 +22,7 @@ describe('Phase 22.3 — RAG metrics registration', () => {
   });
 });
 
-describe('Phase 22.3 — faithfulness', () => {
+describe('faithfulness', () => {
   const sample: Sample = {
     sample_id: 's1',
     prompt: 'Q?',
@@ -95,7 +95,7 @@ describe('Phase 22.3 — faithfulness', () => {
   });
 });
 
-describe('Phase 22.3 — answer_relevancy', () => {
+describe('answer_relevancy', () => {
   const sample: Sample = {
     sample_id: 's2',
     prompt: 'How tall is the Eiffel Tower?',
@@ -144,7 +144,7 @@ describe('Phase 22.3 — answer_relevancy', () => {
   });
 });
 
-describe('Phase 22.3 — context_recall', () => {
+describe('context_recall', () => {
   const sample: Sample = {
     sample_id: 's3',
     prompt: 'Summarize.',
@@ -208,7 +208,7 @@ describe('Phase 22.3 — context_recall', () => {
   });
 });
 
-describe('Phase 22.3 — judge cost is accumulated', () => {
+describe('judge cost is accumulated', () => {
   it('asyncCostUSD reflects all RAG metric calls', async () => {
     const sample: Sample = { sample_id: 's', prompt: 'Q?', context: 'ctx' };
     const judge = mockJudge(() => 5);


### PR DESCRIPTION
## Summary

按 \`feedback_test_naming\` 规则统一: 测试名 / 代码注释描述行为 / 语义, 不带引入时机 (\`Phase X\` / \`v0.X:\` / \`v0.X Phase\` 等) — 那些信息 git log 自带, 跨版本看 GitHub Releases。

memory \`project_test_naming_cleanup\` 标的是 18+ 处, 实测扫到测试 17 处 + 代码 22 处, 一次清完 = 39 处。

## Commits

1. **\`8055c40\` chore(test): 清测试名里的 Phase / v0.X tag** — 17 处 (4 个测试文件)
2. **\`<latest>\` chore(src): 清代码注释里的 Phase / v0.X tag** — 22 处 (12 个 src 文件)

## Categories

- **18 处纯前缀** — \`v0.21 Phase 3a length-debias toggle\` 这种, 直接删时点前缀, 语义不变
- **4 处 narrative reference** — \`Bootstrap CI (Phase 1)\` / \`saturation analysis (Phase 4)\`, 改成 feature 名让 self-explanatory
- **17 处测试 describe** — \`Phase 5a — universal not\` / \`v0.2: weightedGapRate\` 全部去前缀

## Kept

- \`test/executors/codex-sdk.test.ts:117\` 注释里的 \`PR #33 (SIGINT propagation)\` 是 PR 引用提供 context, 不是时点 tag
- \`assertions-phase5.test.ts\` 文件名保留 — 改文件名涉及 git history 追踪成本, describe 名清掉就够

## Test plan

- [x] grep \`(Phase [0-9]|v0\.[0-9]+:|v0\.[0-9]+ Phase|since v0\.)\` 全仓 0 hits
- [x] \`yarn ci\` 998/998 tests pass (6.4s)
