### PR TITLE
chore(repo): 升级 tagline 加 LLM 知识输入定位 + prompt/RAG/skill/agent 例子

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 **omk** — The knowledge you give your LLM — what's it actually worth?
 omk answers with objective data, not gut feeling.
 
-**Fix the model, vary the knowledge artifact.**
+**Evaluation framework for LLM knowledge inputs** — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact.
 
 <a id="statistical-rigor"></a>
 > Built-in: Bootstrap CI · Krippendorff α (judge ↔ human) · length-debias · saturation curves · construct-validity isolation. [Why these matter →](docs/statistical-rigor.md)

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,7 +11,7 @@
 **omk** — 你给 LLM 的知识,价值在哪里?
 omk 帮你用客观数据回答,而不是凭感觉。
 
-**固定模型,只变知识载体。**
+**面向 LLM 知识输入(prompt / RAG / skill / agent)的评测框架** —— 固定模型,只变知识载体。
 
 <a id="statistical-rigor"></a>
 > 默认带:Bootstrap 置信区间 · Krippendorff α(评委 ↔ 人工)· 长度去偏 · 饱和曲线 · 用例隔离(construct validity)。[这些为什么重要 →](docs/zh/statistical-rigor.md)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-knowledge",
   "version": "0.25.0",
-  "description": "LLM evaluation framework with built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves. Native Claude Code skill / RAG / agent / prompt evaluation.",
+  "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",
   "bin": {
     "omk": "dist/src/cli/index.js"


### PR DESCRIPTION
## Summary

旧 tagline `LLM evaluation framework` 默认会被外部读者归类成 promptfoo / DeepEval / lm-eval-harness 这类 model-centric benchmark(评 model 谁好)。omk subject 反过来——固定 model,评 knowledge artifact(prompt / RAG / skill 谁好)。

新 tagline `Evaluation framework for LLM knowledge inputs` 用 `inputs` 这个词把 omk 跟 MMLU 类 model 内禀知识 benchmark 干净切开。后接 `prompts, RAG corpora, skills, agent workflows` 四个例子,降抽象度,SEO 覆盖多几个搜索词(`prompt evaluation` / `RAG evaluation` / `agent evaluation`)。

## 改动

3 处文件:

- `package.json` description
- `README.md` L14 positioning 行
- `README.zh.md` L14 positioning 行

## 配套

merge 后我会用 `gh repo edit` 把 GitHub repo description 也改了(metadata 不在 PR 里)。

`assets/social-preview.html` 副标题(英文 OG 图)也要改 + 重出 PNG,但 OG 图源在 PR #65 还没合,所以这部分加到 PR #65 那条 branch 上一起合,不放这个 PR。

## 字符数

新 description 233 char,在 npm 256 char 上限内、GitHub 350 char 上限内。

## Test plan

- [x] 3 处 diff 干净 / 字符数符合上限
- [ ] merge 后 npm + GitHub repo description 显示正确
- [ ] PR #65 同步带上 OG 图副标题改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)