### PR TITLE
test(repo): 收敛重复测试并清理预期 stderr 噪声

### DIFF
--- a/test/analysis/gap-analyzer.test.ts
+++ b/test/analysis/gap-analyzer.test.ts
@@ -45,44 +45,23 @@ function vr(opts: Partial<VariantResult> & { ok?: boolean } = {}): VariantResult
 // ---------- isFailedSearchTool ----------
 
 describe('isFailedSearchTool', () => {
-  it('flags failed Read', () => {
-    assert.equal(isFailedSearchTool(tc('Read', { file_path: '/nope.md' }, 'File not found', false)), true);
-  });
+  const cases: Array<{ name: string; call: ToolCallInfo; expected: boolean }> = [
+    { name: 'failed Read', call: tc('Read', { file_path: '/nope.md' }, 'File not found', false), expected: true },
+    { name: 'successful Read', call: tc('Read', { file_path: '/x.md' }, 'file content', true), expected: false },
+    { name: 'failed Grep', call: tc('Grep', { pattern: 'foo' }, '', false), expected: true },
+    { name: 'successful Grep with empty output', call: tc('Grep', { pattern: 'foo' }, '', true), expected: true },
+    { name: 'Grep with "No matches found"', call: tc('Grep', { pattern: 'foo' }, 'No matches found', true), expected: true },
+    { name: 'successful Grep with actual matches', call: tc('Grep', { pattern: 'foo' }, 'src/foo.ts:10: foo', true), expected: false },
+    { name: 'Bash grep with empty output', call: tc('Bash', { command: 'grep -r foo /src' }, '', true), expected: true },
+    { name: 'Bash rg with failure', call: tc('Bash', { command: 'rg foo' }, '', false), expected: true },
+    { name: 'Bash without grep/rg/find', call: tc('Bash', { command: 'ls -la' }, '', false), expected: false },
+    { name: 'Write or other non-search tools', call: tc('Write', { file_path: '/x.md' }, '', false), expected: false },
+  ];
 
-  it('does not flag successful Read', () => {
-    assert.equal(isFailedSearchTool(tc('Read', { file_path: '/x.md' }, 'file content', true)), false);
-  });
-
-  it('flags failed Grep', () => {
-    assert.equal(isFailedSearchTool(tc('Grep', { pattern: 'foo' }, '', false)), true);
-  });
-
-  it('flags Grep with empty output even when success', () => {
-    assert.equal(isFailedSearchTool(tc('Grep', { pattern: 'foo' }, '', true)), true);
-  });
-
-  it('flags Grep with "No matches found"', () => {
-    assert.equal(isFailedSearchTool(tc('Grep', { pattern: 'foo' }, 'No matches found', true)), true);
-  });
-
-  it('does not flag successful Grep with actual matches', () => {
-    assert.equal(isFailedSearchTool(tc('Grep', { pattern: 'foo' }, 'src/foo.ts:10: foo', true)), false);
-  });
-
-  it('flags Bash grep with empty output', () => {
-    assert.equal(isFailedSearchTool(tc('Bash', { command: 'grep -r foo /src' }, '', true)), true);
-  });
-
-  it('flags Bash rg with failure', () => {
-    assert.equal(isFailedSearchTool(tc('Bash', { command: 'rg foo' }, '', false)), true);
-  });
-
-  it('does not flag Bash without grep/rg/find', () => {
-    assert.equal(isFailedSearchTool(tc('Bash', { command: 'ls -la' }, '', false)), false);
-  });
-
-  it('does not flag Write or other non-search tools', () => {
-    assert.equal(isFailedSearchTool(tc('Write', { file_path: '/x.md' }, '', false)), false);
+  it('classifies failed search tool boundaries', () => {
+    for (const testCase of cases) {
+      assert.equal(isFailedSearchTool(testCase.call), testCase.expected, testCase.name);
+    }
   });
 });
 
@@ -134,139 +113,126 @@ describe('extractFailedSearchSignals', () => {
 // ---------- extractMarkerSignals ----------
 
 describe('extractMarkerSignals', () => {
-  it('catches Chinese 【推断】 marker', () => {
-    const signals = extractMarkerSignals('这里我要【推断】一下，数据大概是这样');
-    assert.equal(signals.length, 1);
-    assert.equal(signals[0].type, 'explicit_marker');
-  });
+  const cases = [
+    { name: 'Chinese 【推断】 marker', text: '这里我要【推断】一下，数据大概是这样', expectedLength: 1 },
+    { name: 'Chinese 【知识缺口】 marker', text: '【知识缺口】这个接口没文档', expectedLength: 1 },
+    { name: 'Chinese 【未知】 marker', text: '价格字段【未知】', expectedLength: 1 },
+    { name: 'English [inferred] marker', text: 'The answer [INFERRED] from context.', expectedLength: 1 },
+    { name: 'English [unknown] marker', text: 'This field is [unknown].', expectedLength: 1 },
+    { name: 'multiple markers in the same text', text: '【推断】 first part, and then 【知识缺口】 next.', expectedLength: 2 },
+    { name: 'text without markers', text: 'normal agent output', expectedLength: 0 },
+    { name: 'empty string', text: '', expectedLength: 0 },
+  ];
 
-  it('catches 【知识缺口】 and 【未知】', () => {
-    const s1 = extractMarkerSignals('【知识缺口】这个接口没文档');
-    const s2 = extractMarkerSignals('价格字段【未知】');
-    assert.equal(s1.length, 1);
-    assert.equal(s2.length, 1);
-  });
-
-  it('catches English [inferred] and [unknown] (case-insensitive)', () => {
-    const s1 = extractMarkerSignals('The answer [INFERRED] from context.');
-    const s2 = extractMarkerSignals('This field is [unknown].');
-    assert.equal(s1.length, 1);
-    assert.equal(s2.length, 1);
-  });
-
-  it('catches multiple markers in the same text', () => {
-    const text = '【推断】 first part, and then 【知识缺口】 next.';
-    const signals = extractMarkerSignals(text);
-    assert.equal(signals.length, 2);
-  });
-
-  it('returns empty for text without markers', () => {
-    assert.equal(extractMarkerSignals('normal agent output').length, 0);
-  });
-
-  it('handles empty string', () => {
-    assert.equal(extractMarkerSignals('').length, 0);
+  it('extracts explicit marker boundaries', () => {
+    for (const testCase of cases) {
+      const signals = extractMarkerSignals(testCase.text);
+      assert.equal(signals.length, testCase.expectedLength, testCase.name);
+      if (testCase.expectedLength > 0) {
+        assert.equal(signals[0].type, 'explicit_marker', testCase.name);
+      }
+    }
   });
 });
 
 // ---------- extractHedgingSignals ----------
 
 describe('extractHedgingSignals', () => {
-  it('catches 我不确定', () => {
-    const signals = extractHedgingSignals('我不确定这个数据来自哪里');
-    assert.equal(signals.length, 1);
-    assert.equal(signals[0].type, 'hedging');
-  });
+  const cases = [
+    { name: '我不确定', text: '我不确定这个数据来自哪里', expectedLength: 1 },
+    { name: '需要查证', text: '这个需要查证一下', expectedLength: 1 },
+    { name: 'English "I am not sure"', text: "I'm not sure where this comes from", expectedLength: 1 },
+    { name: 'multiple hedges emit one signal', text: '我不确定这个数据，需要查证，无法确认', expectedLength: 1 },
+    { name: 'clean text', text: '这是一个确定的答案', expectedLength: 0 },
+  ];
 
-  it('catches 需要查证', () => {
-    assert.equal(extractHedgingSignals('这个需要查证一下').length, 1);
-  });
-
-  it("catches English \"I'm not sure\"", () => {
-    assert.equal(extractHedgingSignals("I'm not sure where this comes from").length, 1);
-  });
-
-  it('emits at most one hedging signal per text even with multiple hedges', () => {
-    const text = '我不确定这个数据，需要查证，无法确认';
-    const signals = extractHedgingSignals(text);
-    // Spec §4.3: one hedging signal per sample is enough
-    assert.equal(signals.length, 1);
-  });
-
-  it('returns empty for clean text', () => {
-    assert.equal(extractHedgingSignals('这是一个确定的答案').length, 0);
+  it('extracts hedging boundaries', () => {
+    for (const testCase of cases) {
+      const signals = extractHedgingSignals(testCase.text);
+      assert.equal(signals.length, testCase.expectedLength, testCase.name);
+      if (testCase.expectedLength > 0) {
+        assert.equal(signals[0].type, 'hedging', testCase.name);
+      }
+    }
   });
 });
 
 // ---------- extractRepeatedFailureSignals ----------
 
 describe('extractRepeatedFailureSignals', () => {
-  it('emits signal after 3 consecutive failed same-tool searches', () => {
-    const turns: TurnInfo[] = [
-      turn('assistant', '', [
-        tc('Grep', { pattern: 'a' }, '', false),
-        tc('Grep', { pattern: 'b' }, '', false),
-        tc('Grep', { pattern: 'c' }, '', false),
-      ]),
-    ];
-    const signals = extractRepeatedFailureSignals(turns);
-    assert.equal(signals.length, 1);
-    assert.equal(signals[0].type, 'repeated_failure');
-    assert.ok(signals[0].context.includes('Grep'));
-  });
+  const cases: Array<{ name: string; turns?: TurnInfo[]; expectedLength: number; expectGrepContext?: boolean }> = [
+    {
+      name: '3 consecutive failed same-tool searches',
+      turns: [
+        turn('assistant', '', [
+          tc('Grep', { pattern: 'a' }, '', false),
+          tc('Grep', { pattern: 'b' }, '', false),
+          tc('Grep', { pattern: 'c' }, '', false),
+        ]),
+      ],
+      expectedLength: 1,
+      expectGrepContext: true,
+    },
+    {
+      name: 'only 2 failures',
+      turns: [
+        turn('assistant', '', [
+          tc('Grep', { pattern: 'a' }, '', false),
+          tc('Grep', { pattern: 'b' }, '', false),
+        ]),
+      ],
+      expectedLength: 0,
+    },
+    {
+      name: 'different tool intervenes',
+      turns: [
+        turn('assistant', '', [
+          tc('Grep', { pattern: 'a' }, '', false),
+          tc('Grep', { pattern: 'b' }, '', false),
+          tc('Read', { file_path: '/x.md' }, 'ok', true),
+          tc('Grep', { pattern: 'c' }, '', false),
+        ]),
+      ],
+      expectedLength: 0,
+    },
+    {
+      name: 'success intervenes',
+      turns: [
+        turn('assistant', '', [
+          tc('Grep', { pattern: 'a' }, '', false),
+          tc('Grep', { pattern: 'b' }, 'match found', true),
+          tc('Grep', { pattern: 'c' }, '', false),
+          tc('Grep', { pattern: 'd' }, '', false),
+        ]),
+      ],
+      expectedLength: 0,
+    },
+    {
+      name: 'does not double-count within the same run',
+      turns: [
+        turn('assistant', '', [
+          tc('Grep', { pattern: 'a' }, '', false),
+          tc('Grep', { pattern: 'b' }, '', false),
+          tc('Grep', { pattern: 'c' }, '', false),
+          tc('Grep', { pattern: 'd' }, '', false),
+          tc('Grep', { pattern: 'e' }, '', false),
+        ]),
+      ],
+      expectedLength: 1,
+    },
+    { name: 'missing turns', turns: undefined, expectedLength: 0 },
+    { name: 'empty turns', turns: [], expectedLength: 0 },
+  ];
 
-  it('does not emit with only 2 failures', () => {
-    const turns: TurnInfo[] = [
-      turn('assistant', '', [
-        tc('Grep', { pattern: 'a' }, '', false),
-        tc('Grep', { pattern: 'b' }, '', false),
-      ]),
-    ];
-    assert.equal(extractRepeatedFailureSignals(turns).length, 0);
-  });
-
-  it('resets run when a different tool intervenes', () => {
-    const turns: TurnInfo[] = [
-      turn('assistant', '', [
-        tc('Grep', { pattern: 'a' }, '', false),
-        tc('Grep', { pattern: 'b' }, '', false),
-        tc('Read', { file_path: '/x.md' }, 'ok', true),
-        tc('Grep', { pattern: 'c' }, '', false),
-      ]),
-    ];
-    // Grep run of 2, then broken by Read, then 1 more — none reach 3
-    assert.equal(extractRepeatedFailureSignals(turns).length, 0);
-  });
-
-  it('resets run when a success intervenes', () => {
-    const turns: TurnInfo[] = [
-      turn('assistant', '', [
-        tc('Grep', { pattern: 'a' }, '', false),
-        tc('Grep', { pattern: 'b' }, 'match found', true), // success breaks run
-        tc('Grep', { pattern: 'c' }, '', false),
-        tc('Grep', { pattern: 'd' }, '', false),
-      ]),
-    ];
-    assert.equal(extractRepeatedFailureSignals(turns).length, 0);
-  });
-
-  it('does not double-count within the same run', () => {
-    const turns: TurnInfo[] = [
-      turn('assistant', '', [
-        tc('Grep', { pattern: 'a' }, '', false),
-        tc('Grep', { pattern: 'b' }, '', false),
-        tc('Grep', { pattern: 'c' }, '', false),
-        tc('Grep', { pattern: 'd' }, '', false),
-        tc('Grep', { pattern: 'e' }, '', false),
-      ]),
-    ];
-    // 5 consecutive failures should still emit exactly 1 signal
-    assert.equal(extractRepeatedFailureSignals(turns).length, 1);
-  });
-
-  it('handles empty/missing turns', () => {
-    assert.equal(extractRepeatedFailureSignals(undefined).length, 0);
-    assert.equal(extractRepeatedFailureSignals([]).length, 0);
+  it('extracts repeated failure boundaries', () => {
+    for (const testCase of cases) {
+      const signals = extractRepeatedFailureSignals(testCase.turns);
+      assert.equal(signals.length, testCase.expectedLength, testCase.name);
+      if (testCase.expectGrepContext) {
+        assert.equal(signals[0].type, 'repeated_failure', testCase.name);
+        assert.ok(signals[0].context.includes('Grep'), testCase.name);
+      }
+    }
   });
 });
 

--- a/test/analysis/hedging-classifier.test.ts
+++ b/test/analysis/hedging-classifier.test.ts
@@ -5,6 +5,7 @@ import {
   clearHedgingCache,
   type HedgingCandidate,
 } from '../../src/analysis/hedging-classifier.js';
+import { withCapturedStderr } from '../helpers/stderr.js';
 import type { ExecResult, ExecutorFn } from '../../src/types/index.js';
 
 function execOk(output: string, costUSD = 0.001): ExecResult {
@@ -97,11 +98,13 @@ describe('classifyHedgingCandidates', () => {
       { id: 2, isUncertainty: true, confidence: 0.8, reason: 'x' },
     ]);
     const m = makeExecutor([execOk(response)]);
-    const { verdicts, truncated } = await classifyHedgingCandidates(
+    const { result, stderr } = await withCapturedStderr(() => classifyHedgingCandidates(
       [cand('s1', 'A'), cand('s2', 'B'), cand('s3', 'C')],
       m.exec,
       { maxCandidates: 2, batchSize: 5 },
-    );
+    ));
+    const { verdicts, truncated } = result;
+    assert.match(stderr, /exceeds maxCandidates=2/);
     assert.equal(truncated, true);
     assert.equal(verdicts.length, 3);
     assert.equal(verdicts[0].isUncertainty, true);

--- a/test/eval-config.test.ts
+++ b/test/eval-config.test.ts
@@ -15,6 +15,22 @@ function writeYaml(dir: string, name: string, content: string): string {
   return path;
 }
 
+function withYaml<T>(content: string, fn: (path: string, dir: string) => T): T {
+  const dir = makeTmpDir();
+  try {
+    const path = writeYaml(dir, 'eval.yaml', content.trim());
+    return fn(path, dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function assertYamlThrows(content: string, expected: RegExp, message: string): void {
+  withYaml(content, (path) => {
+    assert.throws(() => loadEvalConfig(path), expected, message);
+  });
+}
+
 describe('loadEvalConfig', () => {
   it('parses a valid yaml config with control + treatment variants', () => {
     const dir = makeTmpDir();
@@ -56,54 +72,40 @@ variants:
     }
   });
 
-  it('throws when samples field missing', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `
+  it('rejects invalid required config shape', () => {
+    const cases = [
+      {
+        name: 'samples field missing',
+        yaml: `
 variants:
   - name: v1
     role: control
     artifact: baseline
-      `.trim());
-      assert.throws(() => loadEvalConfig(path), /'samples' is required/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('throws when variants array is empty', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `
+        `,
+        error: /'samples' is required/,
+      },
+      {
+        name: 'variants array is empty',
+        yaml: `
 samples: ./samples.json
 variants: []
-      `.trim());
-      assert.throws(() => loadEvalConfig(path), /'variants' is required/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('throws when variant role is invalid', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `
+        `,
+        error: /'variants' is required/,
+      },
+      {
+        name: 'variant role is invalid',
+        yaml: `
 samples: ./samples.json
 variants:
   - name: v1
     role: baseline
     artifact: ./v1.md
-      `.trim());
-      assert.throws(() => loadEvalConfig(path), /role must be 'control' or 'treatment'/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('throws when variant names are duplicated', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `
+        `,
+        error: /role must be 'control' or 'treatment'/,
+      },
+      {
+        name: 'variant names are duplicated',
+        yaml: `
 samples: ./samples.json
 variants:
   - name: v1
@@ -112,10 +114,13 @@ variants:
   - name: v1
     role: treatment
     artifact: ./v1.md
-      `.trim());
-      assert.throws(() => loadEvalConfig(path), /"v1" is duplicated/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
+        `,
+        error: /"v1" is duplicated/,
+      },
+    ];
+
+    for (const testCase of cases) {
+      assertYamlThrows(testCase.yaml, testCase.error, testCase.name);
     }
   });
 
@@ -231,47 +236,41 @@ budget:
     }
   });
 
-  it('rejects negative budget values', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `
+  it('rejects invalid budget values', () => {
+    const cases = [
+      {
+        name: 'negative budget value',
+        yaml: `
 samples: ./s.json
 ${minimalVariants}
 budget:
   totalUSD: -1
-`.trim());
-      assert.throws(() => loadEvalConfig(path), /totalUSD/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('rejects non-numeric budget values', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `
+        `,
+        error: /totalUSD/,
+      },
+      {
+        name: 'non-numeric budget value',
+        yaml: `
 samples: ./s.json
 ${minimalVariants}
 budget:
   totalUSD: "five"
-`.trim());
-      assert.throws(() => loadEvalConfig(path), /totalUSD/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('rejects non-object budget value', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `
+        `,
+        error: /totalUSD/,
+      },
+      {
+        name: 'non-object budget value',
+        yaml: `
 samples: ./s.json
 ${minimalVariants}
 budget: 5
-`.trim());
-      assert.throws(() => loadEvalConfig(path), /budget must be an object/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
+        `,
+        error: /budget must be an object/,
+      },
+    ];
+
+    for (const testCase of cases) {
+      assertYamlThrows(testCase.yaml, testCase.error, testCase.name);
     }
   });
 
@@ -359,53 +358,57 @@ judgeModels:
     }
   });
 
-  it('reject repeat 非整数', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `samples: ./s.json\n${minimalVariants}\nrepeat: 1.5`);
-      assert.throws(() => loadEvalConfig(path), /repeat must be a positive integer/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
+  it('rejects invalid v0.2 experiment-design fields', () => {
+    const cases = [
+      {
+        name: 'repeat non-integer',
+        yaml: `samples: ./s.json\n${minimalVariants}\nrepeat: 1.5`,
+        error: /repeat must be a positive integer/,
+      },
+      {
+        name: 'repeat <= 0',
+        yaml: `samples: ./s.json\n${minimalVariants}\nrepeat: 0`,
+        error: /repeat must be a positive integer/,
+      },
+      {
+        name: 'bootstrapSamples < 100',
+        yaml: `samples: ./s.json\n${minimalVariants}\nbootstrapSamples: 50`,
+        error: /bootstrapSamples must be a number ≥ 100/,
+      },
+      {
+        name: 'judgeModels non-array',
+        yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels: "claude:opus"`,
+        error: /judgeModels must be an array/,
+      },
+      {
+        name: 'judgeModels entry missing model',
+        yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels:\n  - executor: claude`,
+        error: /judgeModels\[0\]\.model must be a non-empty string/,
+      },
+      {
+        name: 'judgeModels empty array',
+        yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels: []`,
+        error: /judgeModels must have ≥ 1 entry/,
+      },
+      {
+        name: 'judgeModels duplicate entry',
+        yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels:\n  - executor: claude\n    model: haiku\n  - executor: claude\n    model: haiku`,
+        error: /duplicate entry "claude:haiku"/,
+      },
+      {
+        name: 'legacy judgeModel field',
+        yaml: `samples: ./s.json\n${minimalVariants}\njudgeModel: haiku`,
+        error: /judgeModel.*were removed in v0\.25/,
+      },
+      {
+        name: 'legacy judgeExecutor field',
+        yaml: `samples: ./s.json\n${minimalVariants}\njudgeExecutor: claude`,
+        error: /judgeExecutor.*were removed in v0\.25/,
+      },
+    ];
 
-  it('reject repeat ≤ 0', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `samples: ./s.json\n${minimalVariants}\nrepeat: 0`);
-      assert.throws(() => loadEvalConfig(path), /repeat must be a positive integer/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('reject bootstrapSamples < 100', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `samples: ./s.json\n${minimalVariants}\nbootstrapSamples: 50`);
-      assert.throws(() => loadEvalConfig(path), /bootstrapSamples must be a number ≥ 100/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('reject judgeModels 非数组', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `samples: ./s.json\n${minimalVariants}\njudgeModels: "claude:opus"`);
-      assert.throws(() => loadEvalConfig(path), /judgeModels must be an array/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('reject judgeModels[i] 缺 executor 或 model', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `samples: ./s.json\n${minimalVariants}\njudgeModels:\n  - executor: claude`);
-      assert.throws(() => loadEvalConfig(path), /judgeModels\[0\]\.model must be a non-empty string/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
+    for (const testCase of cases) {
+      assertYamlThrows(testCase.yaml, testCase.error, testCase.name);
     }
   });
 
@@ -415,47 +418,6 @@ judgeModels:
       const path = writeYaml(dir, 'eval.yaml', `samples: ./s.json\n${minimalVariants}\njudgeModels:\n  - executor: claude\n    model: haiku`);
       const cfg = loadEvalConfig(path);
       assert.deepEqual(cfg.judgeModels, [{ executor: 'claude', model: 'haiku' }]);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('reject judgeModels 空数组 (省字段反而清晰)', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `samples: ./s.json\n${minimalVariants}\njudgeModels: []`);
-      assert.throws(() => loadEvalConfig(path), /judgeModels must have ≥ 1 entry/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('reject judgeModels 重复 entry (ensemble 聚合按 executor:model 去重)', () => {
-    const dir = makeTmpDir();
-    try {
-      const yaml = `samples: ./s.json\n${minimalVariants}\njudgeModels:\n  - executor: claude\n    model: haiku\n  - executor: claude\n    model: haiku`;
-      const path = writeYaml(dir, 'eval.yaml', yaml);
-      assert.throws(() => loadEvalConfig(path), /duplicate entry "claude:haiku"/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('reject 旧字段 judgeModel (v0.25 已删, 引导改用 judgeModels)', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `samples: ./s.json\n${minimalVariants}\njudgeModel: haiku`);
-      assert.throws(() => loadEvalConfig(path), /judgeModel.*were removed in v0\.25/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('reject 旧字段 judgeExecutor', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `samples: ./s.json\n${minimalVariants}\njudgeExecutor: claude`);
-      assert.throws(() => loadEvalConfig(path), /judgeExecutor.*were removed in v0\.25/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -516,44 +478,35 @@ variants:
     }
   });
 
-  it('reject `allowedSkills:` 不写值(parse 成 null,语义不清)', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `
+  it('rejects invalid allowedSkills shapes', () => {
+    const cases = [
+      {
+        name: 'empty YAML value parses as null',
+        yaml: `
 samples: ./s.json
 variants:
   - name: baseline
     role: control
     artifact: baseline
     allowedSkills:
-`.trim());
-      assert.throws(() => loadEvalConfig(path), /allowedSkills must be an array/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('reject 非数组(string)', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `
+        `,
+        error: /allowedSkills must be an array/,
+      },
+      {
+        name: 'string instead of array',
+        yaml: `
 samples: ./s.json
 variants:
   - name: baseline
     role: control
     artifact: baseline
     allowedSkills: "react"
-`.trim());
-      assert.throws(() => loadEvalConfig(path), /allowedSkills must be an array/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('reject 数组里有非字符串元素', () => {
-    const dir = makeTmpDir();
-    try {
-      const path = writeYaml(dir, 'eval.yaml', `
+        `,
+        error: /allowedSkills must be an array/,
+      },
+      {
+        name: 'array contains non-string element',
+        yaml: `
 samples: ./s.json
 variants:
   - name: baseline
@@ -562,10 +515,13 @@ variants:
     allowedSkills:
       - react
       - 123
-`.trim());
-      assert.throws(() => loadEvalConfig(path), /allowedSkills\[1\]/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
+        `,
+        error: /allowedSkills\[1\]/,
+      },
+    ];
+
+    for (const testCase of cases) {
+      assertYamlThrows(testCase.yaml, testCase.error, testCase.name);
     }
   });
 

--- a/test/eval-core/budget.test.ts
+++ b/test/eval-core/budget.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { executeTasks } from '../../src/eval-core/evaluation-execution.js';
+import { withCapturedStderr } from '../helpers/stderr.js';
 import type { Artifact, ExecutorFn, Sample, Task } from '../../src/types/index.js';
 
 const sample = (id: string): Sample => ({
@@ -38,14 +39,15 @@ describe('executeTasks —  budget tracker', () => {
   it('aborts remaining tasks when totalUSD cap is exceeded', async () => {
     const tasks = ['s1', 's2', 's3', 's4', 's5'].map(task);
     const exec = makeExecutor(0.4); // each task costs $0.4
-    const r = await executeTasks({
+    const { result: r, stderr } = await withCapturedStderr(() => executeTasks({
       tasks, executor: exec,
       judgeModels: [{ executor: 'claude', model: 'j' }],
       judgeExecutors: { claude: judgeNoop },
       model: 'm', noJudge: true,
       samplesPath: './x.json', concurrency: 1, noCache: true, verbose: false,
       budget: { totalUSD: 1 }, // budget exhausted after 3 tasks
-    });
+    }));
+    assert.match(stderr, /budget exhausted/);
     assert.equal(r.budgetExhausted, true);
     // We don't pin the exact count — concurrency timing means the abort can
     // happen anywhere from task 3 onward — but we do require:

--- a/test/evaluation/statistics.test.ts
+++ b/test/evaluation/statistics.test.ts
@@ -3,131 +3,162 @@ import assert from 'node:assert/strict';
 import { mean, stddev, confidenceInterval, tTest, effectSize } from '../../src/eval-core/statistics.js';
 
 describe('mean', () => {
-  it('computes mean of numbers', () => {
+  it('computes numeric and empty-array boundaries', () => {
     assert.equal(mean([1, 2, 3, 4, 5]), 3);
-  });
-
-  it('returns 0 for empty array', () => {
     assert.equal(mean([]), 0);
   });
 });
 
 describe('stddev', () => {
-  it('computes sample standard deviation', () => {
-    // [2, 4, 4, 4, 5, 5, 7, 9] => mean=5, stddev≈2.138
+  it('computes sample and degenerate boundaries', () => {
     const sd = stddev([2, 4, 4, 4, 5, 5, 7, 9]);
     assert.ok(Math.abs(sd - 2.138) < 0.01);
-  });
-
-  it('returns 0 for single element', () => {
     assert.equal(stddev([5]), 0);
-  });
-
-  it('returns 0 for empty array', () => {
     assert.equal(stddev([]), 0);
   });
 });
 
 describe('confidenceInterval', () => {
-  it('computes 95% CI', () => {
+  it('computes interval and single-value boundaries', () => {
     const ci = confidenceInterval([3.5, 4.0, 3.8, 4.2, 3.9]);
     assert.ok(ci.mean > 3.8 && ci.mean < 4.0);
     assert.ok(ci.lower < ci.mean);
     assert.ok(ci.upper > ci.mean);
-  });
 
-  it('returns same value for single element', () => {
-    const ci = confidenceInterval([4.0]);
-    assert.equal(ci.mean, 4.0);
-    assert.equal(ci.lower, 4.0);
-    assert.equal(ci.upper, 4.0);
+    const single = confidenceInterval([4.0]);
+    assert.equal(single.mean, 4.0);
+    assert.equal(single.lower, 4.0);
+    assert.equal(single.upper, 4.0);
   });
 });
 
 describe('tTest', () => {
-  it('detects significant difference between very different groups', () => {
-    const a = [1.0, 1.1, 0.9, 1.2, 0.8];
-    const b = [5.0, 4.9, 5.1, 4.8, 5.2];
-    const result = tTest(a, b);
-    assert.ok(result.significant);
-    assert.ok(result.tStatistic < 0); // a < b
-  });
+  const cases: Array<{
+    name: string;
+    a: number[];
+    b: number[];
+    check: (result: ReturnType<typeof tTest>) => void;
+  }> = [
+    {
+      name: 'significant difference between very different groups',
+      a: [1.0, 1.1, 0.9, 1.2, 0.8],
+      b: [5.0, 4.9, 5.1, 4.8, 5.2],
+      check: (result) => {
+        assert.ok(result.significant);
+        assert.ok(result.tStatistic < 0);
+      },
+    },
+    {
+      name: 'no significant difference between similar groups',
+      a: [3.0, 3.1, 2.9, 3.0, 3.05],
+      b: [3.0, 3.0, 3.1, 2.95, 3.0],
+      check: (result) => assert.equal(result.significant, false),
+    },
+    {
+      name: 'single-element arrays',
+      a: [3],
+      b: [4],
+      check: (result) => {
+        assert.equal(result.tStatistic, 0);
+        assert.equal(result.significant, false);
+      },
+    },
+  ];
 
-  it('detects no significant difference between similar groups', () => {
-    const a = [3.0, 3.1, 2.9, 3.0, 3.05];
-    const b = [3.0, 3.0, 3.1, 2.95, 3.0];
-    const result = tTest(a, b);
-    assert.equal(result.significant, false);
-  });
-
-  it('handles single-element arrays gracefully', () => {
-    const result = tTest([3], [4]);
-    assert.equal(result.tStatistic, 0);
-    assert.equal(result.significant, false);
+  it('covers significance boundaries', () => {
+    for (const testCase of cases) {
+      testCase.check(tTest(testCase.a, testCase.b));
+    }
   });
 });
 
 describe('effectSize', () => {
-  it('returns none for insufficient data', () => {
-    const r = effectSize([3], [4]);
-    assert.equal(r.primary, 'none');
-    assert.equal(r.magnitude, 'none');
-    assert.equal(r.cohensD, 0);
-    assert.equal(r.hedgesG, 0);
-  });
+  const cases: Array<{
+    name: string;
+    a: number[];
+    b: number[];
+    check: (result: ReturnType<typeof effectSize>) => void;
+  }> = [
+    {
+      name: 'insufficient data',
+      a: [3],
+      b: [4],
+      check: (r) => {
+        assert.equal(r.primary, 'none');
+        assert.equal(r.magnitude, 'none');
+        assert.equal(r.cohensD, 0);
+        assert.equal(r.hedgesG, 0);
+      },
+    },
+    {
+      name: 'zero pooled stddev',
+      a: [4, 4, 4],
+      b: [3, 3, 3],
+      check: (r) => assert.equal(r.primary, 'none'),
+    },
+    {
+      name: 'large effect for clearly separated groups',
+      a: [1.0, 1.1, 0.9, 1.2, 0.8],
+      b: [5.0, 4.9, 5.1, 4.8, 5.2],
+      check: (r) => {
+        assert.ok(r.cohensD < -0.8, `expected large negative d, got ${r.cohensD}`);
+        assert.ok(r.hedgesG < -0.8);
+        assert.equal(r.magnitude, 'large');
+      },
+    },
+    {
+      name: 'prefers Hedges g when n1 + n2 < 20',
+      a: [3.0, 3.5, 4.0],
+      b: [3.5, 4.0, 4.5],
+      check: (r) => {
+        assert.equal(r.primary, 'g');
+        assert.ok(Math.abs(r.hedgesG) < Math.abs(r.cohensD));
+      },
+    },
+    {
+      name: 'prefers Cohen d when n1 + n2 >= 20',
+      a: Array.from({ length: 10 }, (_, i) => 3.0 + i * 0.05),
+      b: Array.from({ length: 10 }, (_, i) => 3.2 + i * 0.05),
+      check: (r) => {
+        assert.equal(r.primary, 'd');
+        assert.ok(Math.abs(r.cohensD - r.hedgesG) / Math.abs(r.cohensD) < 0.06);
+      },
+    },
+    {
+      name: 'negligible magnitude',
+      a: [3.0, 3.1, 2.9, 3.05, 2.95],
+      b: [3.02, 3.08, 2.92, 3.0, 2.98],
+      check: (r) => assert.equal(r.magnitude, 'negligible'),
+    },
+    {
+      name: 'medium magnitude',
+      a: [3.0, 3.1, 2.9, 3.05, 2.95],
+      b: [3.05, 3.15, 2.95, 3.10, 3.00],
+      check: (r) => assert.equal(r.magnitude, 'medium'),
+    },
+    {
+      name: 'Hedges g shrinks Cohen d without changing direction',
+      a: [2.0, 2.5, 3.0, 3.5],
+      b: [4.0, 4.5, 5.0, 5.5],
+      check: (r) => {
+        assert.ok(Math.abs(r.hedgesG) < Math.abs(r.cohensD));
+        assert.equal(Math.sign(r.hedgesG), Math.sign(r.cohensD));
+      },
+    },
+    {
+      name: 'reports n1 and n2',
+      a: [1, 2, 3],
+      b: [4, 5, 6, 7],
+      check: (r) => {
+        assert.equal(r.n1, 3);
+        assert.equal(r.n2, 4);
+      },
+    },
+  ];
 
-  it('returns none when pooled stddev is zero', () => {
-    // Both groups are constants — no variance
-    const r = effectSize([4, 4, 4], [3, 3, 3]);
-    assert.equal(r.primary, 'none');
-  });
-
-  it('computes large positive effect for clearly separated groups', () => {
-    // mean_a = 1, mean_b = 5, pooled stddev ≈ 0.13 → d ≈ -30 (huge)
-    const r = effectSize([1.0, 1.1, 0.9, 1.2, 0.8], [5.0, 4.9, 5.1, 4.8, 5.2]);
-    assert.ok(r.cohensD < -0.8, `expected large negative d, got ${r.cohensD}`);
-    assert.ok(r.hedgesG < -0.8);
-    assert.equal(r.magnitude, 'large');
-  });
-
-  it('prefers Hedges g when n1 + n2 < 20', () => {
-    const r = effectSize([3.0, 3.5, 4.0], [3.5, 4.0, 4.5]);
-    assert.equal(r.primary, 'g');
-    // Hedges correction shrinks magnitude, so |g| < |d|
-    assert.ok(Math.abs(r.hedgesG) < Math.abs(r.cohensD));
-  });
-
-  it('prefers Cohen d when n1 + n2 >= 20', () => {
-    const a = Array.from({ length: 10 }, (_, i) => 3.0 + i * 0.05);
-    const b = Array.from({ length: 10 }, (_, i) => 3.2 + i * 0.05);
-    const r = effectSize(a, b);
-    assert.equal(r.primary, 'd');
-    // d and g should be nearly identical at n1+n2=20 (correction < 5%)
-    assert.ok(Math.abs(r.cohensD - r.hedgesG) / Math.abs(r.cohensD) < 0.06);
-  });
-
-  it('classifies magnitude negligible for nearly identical groups', () => {
-    // mean diff ≈ 0, variance dominated → |g| < 0.2
-    const neg = effectSize([3.0, 3.1, 2.9, 3.05, 2.95], [3.02, 3.08, 2.92, 3.0, 2.98]);
-    assert.equal(neg.magnitude, 'negligible');
-  });
-
-  it('classifies magnitude medium for moderate separation', () => {
-    // Small mean gap but tiny variance → medium effect
-    const med = effectSize([3.0, 3.1, 2.9, 3.05, 2.95], [3.05, 3.15, 2.95, 3.10, 3.00]);
-    assert.equal(med.magnitude, 'medium');
-  });
-
-  it('Hedges g magnitude is smaller than Cohen d in absolute value', () => {
-    const r = effectSize([2.0, 2.5, 3.0, 3.5], [4.0, 4.5, 5.0, 5.5]);
-    assert.ok(Math.abs(r.hedgesG) < Math.abs(r.cohensD));
-    // Both should point in the same direction
-    assert.equal(Math.sign(r.hedgesG), Math.sign(r.cohensD));
-  });
-
-  it('reports n1 and n2 correctly', () => {
-    const r = effectSize([1, 2, 3], [4, 5, 6, 7]);
-    assert.equal(r.n1, 3);
-    assert.equal(r.n2, 4);
+  it('covers effect-size boundaries', () => {
+    for (const testCase of cases) {
+      testCase.check(effectSize(testCase.a, testCase.b));
+    }
   });
 });

--- a/test/grading-judge.test.ts
+++ b/test/grading-judge.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { llmJudge, llmJudgeRepeat, getJudgePromptHash, llmJudgeEnsemble, computeJudgeAgreement, judgeId } from '../src/grading/judge.js';
 import { grade } from '../src/grading/index.js';
+import { withCapturedStderr } from './helpers/stderr.js';
 import type { ExecResult, ExecutorFn, JudgeConfig, Sample } from '../src/types/index.js';
 
 /**
@@ -58,14 +59,15 @@ describe('llmJudgeRepeat', () => {
       numTurns: 1,
     });
 
-    const result = await llmJudge({
+    const { result, stderr } = await withCapturedStderr(() => llmJudge({
       output: 'answer',
       rubric: 'rubric',
       prompt: 'task',
       executor,
       model: 'haiku',
-    });
+    }));
 
+    assert.match(stderr, /malformed JSON salvaged/);
     assert.equal(result.score, 4);
     assert.equal(result.reason, 'judge returned malformed JSON; score salvaged');
     assert.equal(result.judgeCostUSD, 0.001);
@@ -86,14 +88,15 @@ describe('llmJudgeRepeat', () => {
       numTurns: 1,
     });
 
-    const result = await llmJudge({
+    const { result, stderr } = await withCapturedStderr(() => llmJudge({
       output: 'answer',
       rubric: 'rubric',
       prompt: 'task',
       executor,
       model: 'haiku',
-    });
+    }));
 
+    assert.match(stderr, /LLM judge parse error/);
     assert.equal(result.score, 0);
     assert.equal(result.reason, 'failed to parse judge response');
   });

--- a/test/grading/assertions-phase5.test.ts
+++ b/test/grading/assertions-phase5.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { runAssertions, rougeN, levenshtein, bleu } from '../../src/grading/assertions.js';
+import type { Assertion } from '../../src/types/index.js';
 
 describe('universal `not: true` field', () => {
-  it('not: true on contains inverts pass/fail', () => {
+  it('covers top-level not inversion behavior', () => {
     const r = runAssertions('hello world', [
       { type: 'contains', value: 'foo' },                  // raw fail
       { type: 'contains', value: 'foo', not: true },       // inverted → pass
@@ -17,143 +18,138 @@ describe('universal `not: true` field', () => {
     const a = runAssertions('hello', [{ type: 'contains', value: 'world', not: true }]);
     const b = runAssertions('hello', [{ type: 'not_contains', value: 'world' }]);
     assert.equal(a.details[0].passed, b.details[0].passed);
-  });
 
-  it('not: true on a regex assertion inverts', () => {
-    const r = runAssertions('output 42', [
+    const regex = runAssertions('output 42', [
       { type: 'regex', pattern: '\\d+', not: true },
     ]);
-    assert.equal(r.details[0].passed, false);
+    assert.equal(regex.details[0].passed, false);
   });
 });
 
 describe('assert-set combinator', () => {
-  it("'all' mode requires every child to pass", () => {
-    const r = runAssertions('hello world', [{
-      type: 'assert-set', mode: 'all',
-      children: [
-        { type: 'contains', value: 'hello' },
-        { type: 'contains', value: 'world' },
-      ],
-    }]);
-    assert.equal(r.details[0].passed, true);
-  });
+  const cases: Array<{ name: string; output: string; assertion: Assertion; expected: boolean }> = [
+    {
+      name: "'all' mode requires every child to pass",
+      output: 'hello world',
+      assertion: {
+        type: 'assert-set', mode: 'all',
+        children: [
+          { type: 'contains', value: 'hello' },
+          { type: 'contains', value: 'world' },
+        ],
+      },
+      expected: true,
+    },
+    {
+      name: "'all' mode fails when any child fails",
+      output: 'hello world',
+      assertion: {
+        type: 'assert-set', mode: 'all',
+        children: [
+          { type: 'contains', value: 'hello' },
+          { type: 'contains', value: 'absent' },
+        ],
+      },
+      expected: false,
+    },
+    {
+      name: "'any' mode passes when at least one child passes",
+      output: 'hello',
+      assertion: {
+        type: 'assert-set', mode: 'any',
+        children: [
+          { type: 'contains', value: 'foo' },
+          { type: 'contains', value: 'hello' },
+          { type: 'contains', value: 'bar' },
+        ],
+      },
+      expected: true,
+    },
+    {
+      name: "'any' mode fails when no child passes",
+      output: 'hello',
+      assertion: {
+        type: 'assert-set', mode: 'any',
+        children: [
+          { type: 'contains', value: 'foo' },
+          { type: 'contains', value: 'bar' },
+        ],
+      },
+      expected: false,
+    },
+    {
+      name: 'child not: true inside assert-set is honored',
+      output: 'hello',
+      assertion: {
+        type: 'assert-set', mode: 'all',
+        children: [
+          { type: 'contains', value: 'hello' },
+          { type: 'contains', value: 'forbidden', not: true },
+        ],
+      },
+      expected: true,
+    },
+    {
+      name: 'top-level not: true on assert-set inverts the whole set',
+      output: 'hello',
+      assertion: {
+        type: 'assert-set', mode: 'all', not: true,
+        children: [
+          { type: 'contains', value: 'hello' },
+          { type: 'contains', value: 'absent' },
+        ],
+      },
+      expected: true,
+    },
+    {
+      name: 'nested assert-set works',
+      output: 'the quick brown fox',
+      assertion: {
+        type: 'assert-set', mode: 'all',
+        children: [
+          { type: 'contains', value: 'fox' },
+          {
+            type: 'assert-set', mode: 'any',
+            children: [
+              { type: 'contains', value: 'quick' },
+              { type: 'contains', value: 'lazy' },
+            ],
+          },
+        ],
+      },
+      expected: true,
+    },
+    {
+      name: 'empty children array fails',
+      output: 'x',
+      assertion: { type: 'assert-set', mode: 'all', children: [] },
+      expected: false,
+    },
+  ];
 
-  it("'all' mode fails when any child fails", () => {
-    const r = runAssertions('hello world', [{
-      type: 'assert-set', mode: 'all',
-      children: [
-        { type: 'contains', value: 'hello' },
-        { type: 'contains', value: 'absent' },
-      ],
-    }]);
-    assert.equal(r.details[0].passed, false);
-  });
-
-  it("'any' mode passes when at least one child passes", () => {
-    const r = runAssertions('hello', [{
-      type: 'assert-set', mode: 'any',
-      children: [
-        { type: 'contains', value: 'foo' },
-        { type: 'contains', value: 'hello' },
-        { type: 'contains', value: 'bar' },
-      ],
-    }]);
-    assert.equal(r.details[0].passed, true);
-  });
-
-  it("'any' mode fails when no child passes", () => {
-    const r = runAssertions('hello', [{
-      type: 'assert-set', mode: 'any',
-      children: [
-        { type: 'contains', value: 'foo' },
-        { type: 'contains', value: 'bar' },
-      ],
-    }]);
-    assert.equal(r.details[0].passed, false);
-  });
-
-  it('child not: true inside assert-set is honored', () => {
-    const r = runAssertions('hello', [{
-      type: 'assert-set', mode: 'all',
-      children: [
-        { type: 'contains', value: 'hello' },
-        { type: 'contains', value: 'forbidden', not: true },
-      ],
-    }]);
-    assert.equal(r.details[0].passed, true);
-  });
-
-  it('top-level not: true on assert-set inverts the whole set', () => {
-    const r = runAssertions('hello', [{
-      type: 'assert-set', mode: 'all', not: true,
-      children: [
-        { type: 'contains', value: 'hello' },
-        { type: 'contains', value: 'absent' },
-      ],
-    }]);
-    // raw set returns false (one child fails); not: true → true.
-    assert.equal(r.details[0].passed, true);
-  });
-
-  it('nested assert-set works', () => {
-    const r = runAssertions('the quick brown fox', [{
-      type: 'assert-set', mode: 'all',
-      children: [
-        { type: 'contains', value: 'fox' },
-        {
-          type: 'assert-set', mode: 'any',
-          children: [
-            { type: 'contains', value: 'quick' },
-            { type: 'contains', value: 'lazy' },
-          ],
-        },
-      ],
-    }]);
-    assert.equal(r.details[0].passed, true);
-  });
-
-  it('empty children array fails', () => {
-    const r = runAssertions('x', [{ type: 'assert-set', mode: 'all', children: [] }]);
-    assert.equal(r.details[0].passed, false);
+  it('covers assert-set pass/fail boundaries', () => {
+    for (const testCase of cases) {
+      const r = runAssertions(testCase.output, [testCase.assertion]);
+      assert.equal(r.details[0].passed, testCase.expected, testCase.name);
+    }
   });
 });
 
 describe('rougeN', () => {
-  it('returns 1.0 for identical strings', () => {
-    assert.equal(rougeN('hello world', 'hello world', 1), 1);
-  });
+  it('covers scoring boundaries', () => {
+    const cases = [
+      { name: 'identical strings', actual: rougeN('hello world', 'hello world', 1), expected: 1 },
+      { name: 'one-token swap', actual: rougeN('cat sat on the mat', 'cat sat on a mat', 1), expected: 0.8 },
+      { name: 'no overlap', actual: rougeN('xyz qwe', 'abc def', 1), expected: 0 },
+      { name: 'clipped repeated candidate n-grams', actual: rougeN('cat cat cat cat cat', 'the cat the cat', 1), expected: 0.5 },
+      { name: 'Chinese single-character tokenization', actual: rougeN('你好世界', '你好朋友', 1), expected: 0.5 },
+      { name: 'reference fewer tokens than n', actual: rougeN('a b c', 'a', 2), expected: 0 },
+    ];
 
-  it('returns ~0.8 for one-token swap on a 5-token reference', () => {
-    // candidate: cat sat on the mat; reference: cat sat on a mat
-    // Overlap: cat, sat, on, mat → 4 of 5 reference unigrams = 0.8
-    const score = rougeN('cat sat on the mat', 'cat sat on a mat', 1);
-    assert.ok(Math.abs(score - 0.8) < 0.001, `expected 0.8, got ${score}`);
-  });
+    for (const testCase of cases) {
+      assert.ok(Math.abs(testCase.actual - testCase.expected) < 0.001, `${testCase.name}: expected ${testCase.expected}, got ${testCase.actual}`);
+    }
 
-  it('returns 0 for no overlap', () => {
-    assert.equal(rougeN('xyz qwe', 'abc def', 1), 0);
-  });
-
-  it('clips repeated candidate n-grams to reference count', () => {
-    // Candidate spams "cat" but reference has it only twice.
-    const score = rougeN('cat cat cat cat cat', 'the cat the cat', 1);
-    // Reference unigrams: the, cat, the, cat → 4 tokens. Overlap clipped at min(cand=5, ref=2) = 2.
-    // ROUGE-1 recall = 2 / 4 = 0.5
-    assert.ok(Math.abs(score - 0.5) < 0.001, `expected 0.5, got ${score}`);
-  });
-
-  it('handles Chinese single-character tokenization', () => {
-    // 你好世界 vs 你好朋友 — overlap on 你, 好 → 2 of 4 unigrams = 0.5
-    const score = rougeN('你好世界', '你好朋友', 1);
-    assert.ok(Math.abs(score - 0.5) < 0.001, `expected 0.5, got ${score}`);
-  });
-
-  it('returns 0 when reference has fewer tokens than n', () => {
-    assert.equal(rougeN('a b c', 'a', 2), 0);
-  });
-
-  it('rouge-2 (bigram) is stricter than rouge-1', () => {
     const r1 = rougeN('the quick brown fox', 'the quick red fox', 1);
     const r2 = rougeN('the quick brown fox', 'the quick red fox', 2);
     assert.ok(r2 < r1, `rouge-2 (${r2}) should be < rouge-1 (${r1})`);
@@ -161,49 +157,35 @@ describe('rougeN', () => {
 });
 
 describe('levenshtein', () => {
-  it('returns 0 for identical strings', () => {
-    assert.equal(levenshtein('hello', 'hello'), 0);
-  });
+  it('covers edit-distance boundaries', () => {
+    const cases = [
+      { name: 'identical strings', a: 'hello', b: 'hello', expected: 0 },
+      { name: 'left side empty', a: '', b: 'abc', expected: 3 },
+      { name: 'right side empty', a: 'abc', b: '', expected: 3 },
+      { name: 'classic kitten to sitting', a: 'kitten', b: 'sitting', expected: 3 },
+      { name: 'single-char swap', a: 'cat', b: 'bat', expected: 1 },
+      { name: 'Chinese deletion', a: '你好世界', b: '你好世', expected: 1 },
+      { name: 'Chinese replacement', a: '你好', b: '世界', expected: 2 },
+    ];
 
-  it('returns the length when one side is empty', () => {
-    assert.equal(levenshtein('', 'abc'), 3);
-    assert.equal(levenshtein('abc', ''), 3);
-  });
-
-  it('classic example: kitten → sitting is 3', () => {
-    assert.equal(levenshtein('kitten', 'sitting'), 3);
-  });
-
-  it('single-char swap is 1', () => {
-    assert.equal(levenshtein('cat', 'bat'), 1);
-  });
-
-  it('handles Chinese characters', () => {
-    assert.equal(levenshtein('你好世界', '你好世'), 1);
-    assert.equal(levenshtein('你好', '世界'), 2);
+    for (const testCase of cases) {
+      assert.equal(levenshtein(testCase.a, testCase.b), testCase.expected, testCase.name);
+    }
   });
 });
 
 describe('bleu', () => {
-  it('returns 1.0 for identical strings (long enough for 4-grams)', () => {
+  it('covers BLEU scoring boundaries', () => {
     const s = 'the quick brown fox jumps over the lazy dog';
     assert.ok(bleu(s, s) > 0.99);
-  });
 
-  it('returns 0 when no overlap', () => {
     assert.equal(bleu('xyz qwe rtt mno', 'abc def ghi jkl'), 0);
-  });
 
-  it('returns 0 when candidate too short for 4-grams (unsmoothed)', () => {
-    // BLEU-4 unsmoothed degenerates on short text — documented behavior.
     const score = bleu('cat sat', 'cat sat');
     assert.equal(score, 0, `BLEU-4 should be 0 for 2-token text, got ${score}`);
-  });
 
-  it('brevity penalty is < 1 when candidate is shorter than reference', () => {
     const long = 'one two three four five six seven eight nine ten';
     const short = 'one two three four five six seven eight';
-    // Both share many n-grams; BP makes short < 1 even with perfect precision.
     const sShort = bleu(short, long, 2);
     const sLong = bleu(long, long, 2);
     assert.ok(sShort < sLong, `bp should pull short candidate's score below the full match`);
@@ -211,38 +193,43 @@ describe('bleu', () => {
 });
 
 describe('assertion integration', () => {
-  it('rouge_n_min passes when score meets threshold', () => {
-    const r = runAssertions('cat sat on the mat', [
-      { type: 'rouge_n_min', reference: 'cat sat on a mat', n: 1, threshold: 0.7 },
-    ]);
-    assert.equal(r.details[0].passed, true);
-  });
+  const cases: Array<{ name: string; output: string; assertion: Assertion; expected: boolean }> = [
+    {
+      name: 'rouge_n_min passes when score meets threshold',
+      output: 'cat sat on the mat',
+      assertion: { type: 'rouge_n_min', reference: 'cat sat on a mat', n: 1, threshold: 0.7 },
+      expected: true,
+    },
+    {
+      name: 'rouge_n_min fails when below threshold',
+      output: 'cat sat on the mat',
+      assertion: { type: 'rouge_n_min', reference: 'a different sentence', n: 1, threshold: 0.5 },
+      expected: false,
+    },
+    {
+      name: 'levenshtein_max passes within tolerance',
+      output: 'kitten',
+      assertion: { type: 'levenshtein_max', reference: 'sitting', value: 5 },
+      expected: true,
+    },
+    {
+      name: 'levenshtein_max fails over tolerance',
+      output: 'kitten',
+      assertion: { type: 'levenshtein_max', reference: 'sitting', value: 2 },
+      expected: false,
+    },
+    {
+      name: 'bleu_min works in assertion form',
+      output: 'the quick brown fox jumps over the lazy dog',
+      assertion: { type: 'bleu_min', reference: 'the quick brown fox jumps over the lazy dog', threshold: 0.9 },
+      expected: true,
+    },
+  ];
 
-  it('rouge_n_min fails when below threshold', () => {
-    const r = runAssertions('cat sat on the mat', [
-      { type: 'rouge_n_min', reference: 'a different sentence', n: 1, threshold: 0.5 },
-    ]);
-    assert.equal(r.details[0].passed, false);
-  });
-
-  it('levenshtein_max passes within tolerance', () => {
-    const r = runAssertions('kitten', [
-      { type: 'levenshtein_max', reference: 'sitting', value: 5 },
-    ]);
-    assert.equal(r.details[0].passed, true);
-  });
-
-  it('levenshtein_max fails over tolerance', () => {
-    const r = runAssertions('kitten', [
-      { type: 'levenshtein_max', reference: 'sitting', value: 2 },
-    ]);
-    assert.equal(r.details[0].passed, false);
-  });
-
-  it('bleu_min works in assertion form', () => {
-    const r = runAssertions('the quick brown fox jumps over the lazy dog', [
-      { type: 'bleu_min', reference: 'the quick brown fox jumps over the lazy dog', threshold: 0.9 },
-    ]);
-    assert.equal(r.details[0].passed, true);
+  it('covers deterministic metric assertion integration', () => {
+    for (const testCase of cases) {
+      const r = runAssertions(testCase.output, [testCase.assertion]);
+      assert.equal(r.details[0].passed, testCase.expected, testCase.name);
+    }
   });
 });

--- a/test/grading/gold-dataset.test.ts
+++ b/test/grading/gold-dataset.test.ts
@@ -62,59 +62,80 @@ annotations:
     assert.ok(issues.some((i) => /duplicate sample_id/.test(i.message)));
   });
 
-  it('rejects missing metadata', () => {
-    writeYaml('a.yaml', `annotations: [{ sample_id: x, score: 3 }]`);
-    const { dataset, issues } = loadGoldDataset(dir);
-    assert.equal(dataset, undefined);
-    assert.ok(issues.some((i) => /metadata/.test(i.message)));
-  });
-
-  it('rejects non-numeric score with index pointing to the offending entry', () => {
-    writeYaml('a.yaml', `
-metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1' }
-annotations:
-  - { sample_id: ok, score: 4 }
-  - { sample_id: bad, score: "five" }
-`);
-    const { issues } = loadGoldDataset(dir);
-    const scoreIssue = issues.find((i) => /score/.test(i.message));
-    assert.ok(scoreIssue, `expected a score issue, got ${JSON.stringify(issues)}`);
-    assert.equal(scoreIssue!.index, 1);
-  });
-
-  it('rejects invalid scale', () => {
-    writeYaml('a.yaml', `
-metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1', scale: { min: 5, max: 1 } }
-annotations: [{ sample_id: a, score: 3 }]
-`);
-    const { issues } = loadGoldDataset(dir);
-    assert.ok(issues.some((i) => /scale/.test(i.message)));
-  });
-
   it('returns issues for missing directory without throwing', () => {
     const { dataset, issues } = loadGoldDataset(join(dir, 'does-not-exist'));
     assert.equal(dataset, undefined);
     assert.ok(issues[0].message.includes('not found') || issues[0].message.includes('unreadable'));
   });
 
-  it('reports YAML parse error with line number', () => {
-    writeYaml('bad.yaml', `metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1'\nannotations: [unclosed`);
-    const { issues } = loadGoldDataset(dir);
-    assert.ok(issues.some((i) => /YAML parse error/.test(i.message)),
-      `expected YAML parse error, got: ${JSON.stringify(issues)}`);
-  });
-
-  it('flags metadata declared in multiple files', () => {
-    writeYaml('a.yaml', `metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1' }`);
-    writeYaml('b.yaml', `metadata: { annotator: y, annotatedAt: '2026-04-25', version: '1' }
+  it('reports invalid dataset shapes with specific issues', () => {
+    const cases = [
+      {
+        name: 'missing metadata',
+        setup: () => writeYaml('a.yaml', `annotations: [{ sample_id: x, score: 3 }]`),
+        check: (issues: ReturnType<typeof loadGoldDataset>['issues'], dataset: ReturnType<typeof loadGoldDataset>['dataset']) => {
+          assert.equal(dataset, undefined);
+          assert.ok(issues.some((i) => /metadata/.test(i.message)));
+        },
+      },
+      {
+        name: 'non-numeric score',
+        setup: () => writeYaml('a.yaml', `
+metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1' }
+annotations:
+  - { sample_id: ok, score: 4 }
+  - { sample_id: bad, score: "five" }
+`),
+        check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
+          const scoreIssue = issues.find((i) => /score/.test(i.message));
+          assert.ok(scoreIssue, `expected a score issue, got ${JSON.stringify(issues)}`);
+          assert.equal(scoreIssue!.index, 1);
+        },
+      },
+      {
+        name: 'invalid scale',
+        setup: () => writeYaml('a.yaml', `
+metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1', scale: { min: 5, max: 1 } }
+annotations: [{ sample_id: a, score: 3 }]
+`),
+        check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
+          assert.ok(issues.some((i) => /scale/.test(i.message)));
+        },
+      },
+      {
+        name: 'YAML parse error',
+        setup: () => writeYaml('bad.yaml', `metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1'\nannotations: [unclosed`),
+        check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
+          assert.ok(issues.some((i) => /YAML parse error/.test(i.message)),
+            `expected YAML parse error, got: ${JSON.stringify(issues)}`);
+        },
+      },
+      {
+        name: 'metadata declared in multiple files',
+        setup: () => {
+          writeYaml('a.yaml', `metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1' }`);
+          writeYaml('b.yaml', `metadata: { annotator: y, annotatedAt: '2026-04-25', version: '1' }
 annotations: [{ sample_id: s, score: 1 }]`);
-    const { issues } = loadGoldDataset(dir);
-    assert.ok(issues.some((i) => /multiple files/.test(i.message)));
-  });
+        },
+        check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
+          assert.ok(issues.some((i) => /multiple files/.test(i.message)));
+        },
+      },
+      {
+        name: 'nested-but-empty directory',
+        setup: () => mkdirSync(join(dir, 'sub')),
+        check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
+          assert.ok(issues.some((i) => /no \.yaml files/.test(i.message)));
+        },
+      },
+    ];
 
-  it('handles nested-but-empty directory gracefully', () => {
-    mkdirSync(join(dir, 'sub'));
-    const { issues } = loadGoldDataset(dir);
-    assert.ok(issues.some((i) => /no \.yaml files/.test(i.message)));
+    for (const testCase of cases) {
+      rmSync(dir, { recursive: true, force: true });
+      mkdirSync(dir, { recursive: true });
+      testCase.setup();
+      const { dataset, issues } = loadGoldDataset(dir);
+      testCase.check(issues, dataset);
+    }
   });
 });

--- a/test/grading/rag-metrics.test.ts
+++ b/test/grading/rag-metrics.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { runAsyncAssertions, ASYNC_ASSERTION_TYPES } from '../../src/grading/assertions.js';
-import type { ExecutorFn, Sample } from '../../src/types/index.js';
+import type { Assertion, ExecutorFn, Sample } from '../../src/types/index.js';
 
 const ok = (output: string): Awaited<ReturnType<ExecutorFn>> => ({
   ok: true,
@@ -13,6 +13,14 @@ const ok = (output: string): Awaited<ReturnType<ExecutorFn>> => ({
 
 const mockJudge = (handler: (prompt: string) => number): ExecutorFn =>
   async ({ prompt }) => ok(JSON.stringify({ score: handler(prompt), reason: 'mock' }));
+
+async function runSingle(sample: Sample, assertion: Assertion, output = 'output', score = 5) {
+  return runAsyncAssertions(
+    output,
+    [assertion],
+    { executor: mockJudge(() => score), judgeModel: 'm', sample, samplesDir: '.' },
+  );
+}
 
 describe('RAG metrics registration', () => {
   it('all three RAG metrics are registered as async assertion types', () => {
@@ -29,57 +37,22 @@ describe('faithfulness', () => {
     context: 'The Eiffel Tower is in Paris and is 330 meters tall.',
   };
 
-  it('passes when score >= threshold (default 3)', async () => {
-    const judge = mockJudge(() => 5);
-    const r = await runAsyncAssertions(
-      'The Eiffel Tower is in Paris.',
-      [{ type: 'faithfulness' }],
-      { executor: judge, judgeModel: 'm', sample, samplesDir: '.' },
-    );
-    assert.equal(r.details[0].passed, true);
-  });
+  it('covers score threshold and context boundaries', async () => {
+    const cases = [
+      { name: 'passes when score >= threshold', assertion: { type: 'faithfulness' }, output: 'The Eiffel Tower is in Paris.', score: 5, expected: true },
+      { name: 'fails when score < threshold', assertion: { type: 'faithfulness' }, output: 'The Eiffel Tower is in London and is 100m tall.', score: 2, expected: false },
+      { name: 'respects custom threshold', assertion: { type: 'faithfulness', threshold: 4 }, output: 'mixed answer', score: 3, expected: false },
+      { name: 'uses assertion.reference when sample.context is absent', assertion: { type: 'faithfulness', reference: 'overridden context' }, sample: { sample_id: 's', prompt: 'Q?' }, expected: true },
+    ] satisfies Array<{ name: string; assertion: Assertion; output?: string; score?: number; sample?: Sample; expected: boolean }>;
 
-  it('fails when score < threshold', async () => {
-    const judge = mockJudge(() => 2);
-    const r = await runAsyncAssertions(
-      'The Eiffel Tower is in London and is 100m tall.',
-      [{ type: 'faithfulness' }],
-      { executor: judge, judgeModel: 'm', sample, samplesDir: '.' },
-    );
-    assert.equal(r.details[0].passed, false);
-  });
+    for (const testCase of cases) {
+      const r = await runSingle(testCase.sample ?? sample, testCase.assertion, testCase.output, testCase.score);
+      assert.equal(r.details[0].passed, testCase.expected, testCase.name);
+    }
 
-  it('respects custom threshold', async () => {
-    const judge = mockJudge(() => 3);
-    const r = await runAsyncAssertions(
-      'mixed answer',
-      [{ type: 'faithfulness', threshold: 4 }],
-      { executor: judge, judgeModel: 'm', sample, samplesDir: '.' },
-    );
-    assert.equal(r.details[0].passed, false);
-  });
-
-  it('fails fast when sample has no context and no reference override', async () => {
-    const judge = mockJudge(() => 5);
-    const noCtxSample: Sample = { sample_id: 's', prompt: 'Q?' };
-    const r = await runAsyncAssertions(
-      'output',
-      [{ type: 'faithfulness' }],
-      { executor: judge, judgeModel: 'm', sample: noCtxSample, samplesDir: '.' },
-    );
-    assert.equal(r.details[0].passed, false);
-    assert.match(r.details[0].message ?? '', /缺少 sample.context/);
-  });
-
-  it('uses assertion.reference as override when sample.context is absent', async () => {
-    const judge = mockJudge(() => 5);
-    const noCtxSample: Sample = { sample_id: 's', prompt: 'Q?' };
-    const r = await runAsyncAssertions(
-      'output',
-      [{ type: 'faithfulness', reference: 'overridden context' }],
-      { executor: judge, judgeModel: 'm', sample: noCtxSample, samplesDir: '.' },
-    );
-    assert.equal(r.details[0].passed, true);
+    const noCtx = await runSingle({ sample_id: 's', prompt: 'Q?' }, { type: 'faithfulness' });
+    assert.equal(noCtx.details[0].passed, false);
+    assert.match(noCtx.details[0].message ?? '', /缺少 sample.context/);
   });
 
   it('prompt includes the length-debias paragraph', async () => {
@@ -101,34 +74,17 @@ describe('answer_relevancy', () => {
     prompt: 'How tall is the Eiffel Tower?',
   };
 
-  it('passes when output answers the question', async () => {
-    const judge = mockJudge(() => 5);
-    const r = await runAsyncAssertions(
-      '330 meters tall.',
-      [{ type: 'answer_relevancy' }],
-      { executor: judge, judgeModel: 'm', sample, samplesDir: '.' },
-    );
-    assert.equal(r.details[0].passed, true);
-  });
+  it('covers score threshold and no-context behavior', async () => {
+    const cases = [
+      { name: 'passes when output answers the question', output: '330 meters tall.', score: 5, expected: true },
+      { name: 'fails when output dodges', output: 'Eiffel was an engineer.', score: 1, expected: false },
+      { name: 'does not require sample.context', output: '330m', score: 4, expected: true },
+    ];
 
-  it('fails when output dodges', async () => {
-    const judge = mockJudge(() => 1);
-    const r = await runAsyncAssertions(
-      "Eiffel was an engineer.",
-      [{ type: 'answer_relevancy' }],
-      { executor: judge, judgeModel: 'm', sample, samplesDir: '.' },
-    );
-    assert.equal(r.details[0].passed, false);
-  });
-
-  it('does not require sample.context', async () => {
-    const judge = mockJudge(() => 4);
-    const r = await runAsyncAssertions(
-      '330m',
-      [{ type: 'answer_relevancy' }],
-      { executor: judge, judgeModel: 'm', sample, samplesDir: '.' },
-    );
-    assert.equal(r.details[0].passed, true);
+    for (const testCase of cases) {
+      const r = await runSingle(sample, { type: 'answer_relevancy' }, testCase.output, testCase.score);
+      assert.equal(r.details[0].passed, testCase.expected, testCase.name);
+    }
   });
 
   it('passes the user question into the judge prompt', async () => {
@@ -151,24 +107,21 @@ describe('context_recall', () => {
     context: 'Key fact A. Key fact B. Key fact C.',
   };
 
-  it('passes when output covers gold facts', async () => {
-    const judge = mockJudge(() => 5);
-    const r = await runAsyncAssertions(
-      'Output covers A B C.',
-      [{ type: 'context_recall' }],
-      { executor: judge, judgeModel: 'm', sample, samplesDir: '.' },
-    );
-    assert.equal(r.details[0].passed, true);
-  });
+  it('covers score threshold and missing-context behavior', async () => {
+    const cases = [
+      { name: 'passes when output covers gold facts', output: 'Output covers A B C.', score: 5, expected: true },
+      { name: 'fails when output ignores most gold facts', output: 'Only A.', score: 1, expected: false },
+    ];
 
-  it('fails when output ignores most gold facts', async () => {
-    const judge = mockJudge(() => 1);
-    const r = await runAsyncAssertions(
-      'Only A.',
-      [{ type: 'context_recall' }],
-      { executor: judge, judgeModel: 'm', sample, samplesDir: '.' },
-    );
-    assert.equal(r.details[0].passed, false);
+    for (const testCase of cases) {
+      const r = await runSingle(sample, { type: 'context_recall' }, testCase.output, testCase.score);
+      assert.equal(r.details[0].passed, testCase.expected, testCase.name);
+    }
+
+    const noCtxSample: Sample = { sample_id: 's', prompt: 'Q?' };
+    const missing = await runSingle(noCtxSample, { type: 'context_recall' }, 'out');
+    assert.equal(missing.details[0].passed, false);
+    assert.match(missing.details[0].message ?? '', /缺少/);
   });
 
   it('uses assertion.reference when explicitly given (even if sample.context exists)', async () => {
@@ -195,17 +148,6 @@ describe('context_recall', () => {
     assert.match(captured, /Key fact A/);
   });
 
-  it('fails fast when neither reference nor sample.context is present', async () => {
-    const judge = mockJudge(() => 5);
-    const noCtxSample: Sample = { sample_id: 's', prompt: 'Q?' };
-    const r = await runAsyncAssertions(
-      'out',
-      [{ type: 'context_recall' }],
-      { executor: judge, judgeModel: 'm', sample: noCtxSample, samplesDir: '.' },
-    );
-    assert.equal(r.details[0].passed, false);
-    assert.match(r.details[0].message ?? '', /缺少/);
-  });
 });
 
 describe('judge cost is accumulated', () => {

--- a/test/helpers/stderr.ts
+++ b/test/helpers/stderr.ts
@@ -1,0 +1,37 @@
+// Not safe with Vitest `it.concurrent`: this patches process.stderr.write
+// process-wide and assumes no same-process tests need stderr simultaneously.
+type StderrWrite = typeof process.stderr.write;
+
+export interface CapturedStderr {
+  read(): string;
+  restore(): void;
+}
+
+export function captureStderr(): CapturedStderr {
+  const original = process.stderr.write;
+  let output = '';
+
+  process.stderr.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((err?: Error | null) => void), callback?: (err?: Error | null) => void): boolean => {
+    output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
+    const cb = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback;
+    cb?.();
+    return true;
+  }) as StderrWrite;
+
+  return {
+    read: () => output,
+    restore: () => {
+      process.stderr.write = original;
+    },
+  };
+}
+
+export async function withCapturedStderr<T>(fn: () => T | Promise<T>): Promise<{ result: T; stderr: string }> {
+  const capture = captureStderr();
+  try {
+    const result = await fn();
+    return { result, stderr: capture.read() };
+  } finally {
+    capture.restore();
+  }
+}

--- a/test/inputs/load-samples.test.ts
+++ b/test/inputs/load-samples.test.ts
@@ -10,6 +10,17 @@ const tmp = (name: string) => join(tmpdir(), `omk-test-${Date.now()}-${name}`);
 describe('loadSamples', () => {
   const cleanups: string[] = [];
 
+  function writeSampleFile(name: string, content: string): string {
+    const p = tmp(name);
+    cleanups.push(p);
+    writeFileSync(p, content);
+    return p;
+  }
+
+  function writeJsonSamples(name: string, value: unknown): string {
+    return writeSampleFile(name, JSON.stringify(value));
+  }
+
   afterEach(() => {
     for (const f of cleanups) {
       try { unlinkSync(f); } catch { /* ignore */ }
@@ -18,12 +29,10 @@ describe('loadSamples', () => {
   });
 
   it('加载 JSON 用例文件', () => {
-    const p = tmp('samples.json');
-    cleanups.push(p);
-    writeFileSync(p, JSON.stringify([
+    const p = writeJsonSamples('samples.json', [
       { sample_id: 's1', prompt: '你好' },
       { sample_id: 's2', prompt: '世界' },
-    ]));
+    ]);
     const { samples } = loadSamples(p);
     assert.equal(samples.length, 2);
     assert.equal(samples[0].sample_id, 's1');
@@ -31,64 +40,39 @@ describe('loadSamples', () => {
   });
 
   it('加载 YAML 用例文件', () => {
-    const p = tmp('samples.yaml');
-    cleanups.push(p);
-    writeFileSync(p, `- sample_id: y1\n  prompt: hello\n- sample_id: y2\n  prompt: world\n`);
+    const p = writeSampleFile('samples.yaml', `- sample_id: y1\n  prompt: hello\n- sample_id: y2\n  prompt: world\n`);
     const { samples } = loadSamples(p);
     assert.equal(samples.length, 2);
     assert.equal(samples[0].sample_id, 'y1');
     assert.equal(samples[1].prompt, 'world');
   });
 
-  it('空文件抛出异常', () => {
-    const p = tmp('empty.json');
-    cleanups.push(p);
-    writeFileSync(p, '[]');
-    assert.throws(() => loadSamples(p), /invalid samples file/);
-  });
+  it('rejects invalid sample file shapes', () => {
+    const cases = [
+      { name: 'empty array', file: 'empty.json', value: [], error: /invalid samples file/ },
+      { name: 'non-array content', file: 'invalid.json', value: 'not an array', error: /invalid samples file/ },
+      { name: 'missing sample_id', file: 'no-id.json', value: [{ prompt: 'hello' }], error: /required field: sample_id/ },
+      { name: 'missing prompt', file: 'no-prompt.json', value: [{ sample_id: 'x' }], error: /required field: prompt/ },
+      { name: 'non-string prompt', file: 'bad-prompt-type.json', value: [{ sample_id: 'x', prompt: 123 }], error: /invalid required field: prompt/ },
+    ];
 
-  it('无效内容抛出异常', () => {
-    const p = tmp('invalid.json');
-    cleanups.push(p);
-    writeFileSync(p, '"not an array"');
-    assert.throws(() => loadSamples(p), /invalid samples file/);
-  });
-
-  it('缺少 sample_id 抛出异常', () => {
-    const p = tmp('no-id.json');
-    cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{ prompt: 'hello' }]));
-    assert.throws(() => loadSamples(p), /required field: sample_id/);
-  });
-
-  it('缺少 prompt 抛出异常', () => {
-    const p = tmp('no-prompt.json');
-    cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{ sample_id: 'x' }]));
-    assert.throws(() => loadSamples(p), /required field: prompt/);
-  });
-
-  // UltraReview follow-up #6: typeof check for prompt
-  it('prompt 非字符串(数字)抛出异常', () => {
-    const p = tmp('bad-prompt-type.json');
-    cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{ sample_id: 'x', prompt: 123 }]));
-    assert.throws(() => loadSamples(p), /invalid required field: prompt/);
+    for (const testCase of cases) {
+      const p = writeJsonSamples(testCase.file, testCase.value);
+      assert.throws(() => loadSamples(p), testCase.error, testCase.name);
+    }
   });
 
   // sample design metadata fields validation
   describe('sample design metadata', () => {
     it('接受 capability / difficulty / construct / provenance 4 个新字段', () => {
-      const p = tmp('with-meta.json');
-      cleanups.push(p);
-      writeFileSync(p, JSON.stringify([{
+      const p = writeJsonSamples('with-meta.json', [{
         sample_id: 's1',
         prompt: 'p',
         capability: ['api-selection', 'error-diagnosis'],
         difficulty: 'medium',
         construct: 'necessity',
         provenance: 'human',
-      }]));
+      }]);
       const { samples } = loadSamples(p);
       assert.deepEqual(samples[0].capability, ['api-selection', 'error-diagnosis']);
       assert.equal(samples[0].difficulty, 'medium');
@@ -97,9 +81,7 @@ describe('loadSamples', () => {
     });
 
     it('老 sample(无新字段)仍正常解析', () => {
-      const p = tmp('legacy.json');
-      cleanups.push(p);
-      writeFileSync(p, JSON.stringify([{ sample_id: 's1', prompt: 'p' }]));
+      const p = writeJsonSamples('legacy.json', [{ sample_id: 's1', prompt: 'p' }]);
       const { samples } = loadSamples(p);
       assert.equal(samples[0].capability, undefined);
       assert.equal(samples[0].difficulty, undefined);
@@ -107,38 +89,42 @@ describe('loadSamples', () => {
       assert.equal(samples[0].provenance, undefined);
     });
 
-    it('difficulty 非法值 reject 含 sample_id 定位', () => {
-      const p = tmp('bad-difficulty.json');
-      cleanups.push(p);
-      writeFileSync(p, JSON.stringify([{ sample_id: 's7', prompt: 'p', difficulty: 'easy?' }]));
-      assert.throws(() => loadSamples(p), /s7.*invalid difficulty.*easy\?.*easy, medium, hard/);
-    });
+    it('rejects invalid sample design metadata', () => {
+      const cases = [
+        {
+          name: 'difficulty invalid value includes sample_id',
+          file: 'bad-difficulty.json',
+          value: [{ sample_id: 's7', prompt: 'p', difficulty: 'easy?' }],
+          error: /s7.*invalid difficulty.*easy\?.*easy, medium, hard/,
+        },
+        {
+          name: 'provenance invalid value',
+          file: 'bad-prov.json',
+          value: [{ sample_id: 's1', prompt: 'p', provenance: 'random' }],
+          error: /invalid provenance/,
+        },
+        {
+          name: 'capability single string',
+          file: 'bad-cap.json',
+          value: [{ sample_id: 's1', prompt: 'p', capability: 'api-selection' }],
+          error: /invalid capability.*string array/,
+        },
+        {
+          name: 'capability array contains non-string',
+          file: 'bad-cap-elem.json',
+          value: [{ sample_id: 's1', prompt: 'p', capability: ['ok', 123] }],
+          error: /capability\[1\] must be a non-empty string/,
+        },
+      ];
 
-    it('provenance 非法值 reject', () => {
-      const p = tmp('bad-prov.json');
-      cleanups.push(p);
-      writeFileSync(p, JSON.stringify([{ sample_id: 's1', prompt: 'p', provenance: 'random' }]));
-      assert.throws(() => loadSamples(p), /invalid provenance/);
-    });
-
-    it('capability 必须是 array(reject single string)', () => {
-      const p = tmp('bad-cap.json');
-      cleanups.push(p);
-      writeFileSync(p, JSON.stringify([{ sample_id: 's1', prompt: 'p', capability: 'api-selection' }]));
-      assert.throws(() => loadSamples(p), /invalid capability.*string array/);
-    });
-
-    it('capability 数组里非字符串 reject', () => {
-      const p = tmp('bad-cap-elem.json');
-      cleanups.push(p);
-      writeFileSync(p, JSON.stringify([{ sample_id: 's1', prompt: 'p', capability: ['ok', 123] }]));
-      assert.throws(() => loadSamples(p), /capability\[1\] must be a non-empty string/);
+      for (const testCase of cases) {
+        const p = writeJsonSamples(testCase.file, testCase.value);
+        assert.throws(() => loadSamples(p), testCase.error, testCase.name);
+      }
     });
 
     it('construct 接受任意 string(允许自定义值)', () => {
-      const p = tmp('custom-construct.json');
-      cleanups.push(p);
-      writeFileSync(p, JSON.stringify([{ sample_id: 's1', prompt: 'p', construct: 'my-custom-thing' }]));
+      const p = writeJsonSamples('custom-construct.json', [{ sample_id: 's1', prompt: 'p', construct: 'my-custom-thing' }]);
       const { samples } = loadSamples(p);
       assert.equal(samples[0].construct, 'my-custom-thing');
     });

--- a/test/inputs/mcp-resolver.test.ts
+++ b/test/inputs/mcp-resolver.test.ts
@@ -4,6 +4,7 @@ import { loadMcpConfig, resolveMcpUrls, stopAllServers } from '../../src/inputs/
 import { writeFileSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { withCapturedStderr } from '../helpers/stderr.js';
 import type { McpServers } from '../../src/types/index.js';
 
 describe('loadMcpConfig', () => {
@@ -18,11 +19,12 @@ describe('loadMcpConfig', () => {
     assert.equal(result, null);
   });
 
-  it('返回 null 当 JSON 格式错误', () => {
+  it('返回 null 当 JSON 格式错误', async () => {
     const configPath = join(tmpDir, '.mcp.json');
     writeFileSync(configPath, '{ invalid json }');
-    const result = loadMcpConfig(configPath);
+    const { result, stderr } = await withCapturedStderr(() => loadMcpConfig(configPath));
     assert.equal(result, null);
+    assert.match(stderr, /failed to parse MCP config file/);
   });
 
   it('返回 null 当没有符合条件的 server（缺少 urlPatterns）', () => {

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { afterEach, beforeEach, describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { runEvaluation, runBatchEvaluation } from '../src/eval-workflows/run-evaluation.js';
 import { executeBatchEvaluationRuns } from '../src/eval-workflows/batch-evaluation-workflow.js';
@@ -9,6 +9,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { captureStderr, type CapturedStderr } from './helpers/stderr.js';
 import type { Report, VariantSpec } from '../src/types/index.js';
 
 // Test helper: convert a list of variant names into VariantSpec[].
@@ -80,6 +81,20 @@ const AGENT_SKILL_DIR = join(__dirname, '..', 'examples', 'agent-eval', 'skills'
 const CUSTOM_EXECUTOR_SAMPLES = join(__dirname, '..', 'examples', 'custom-executor', 'eval-samples.json');
 const CUSTOM_EXECUTOR_SKILL_DIR = join(__dirname, '..', 'examples', 'custom-executor', 'skills');
 const CUSTOM_EXECUTOR_PATH = join(__dirname, '..', 'examples', 'custom-executor', 'echo-executor.sh');
+
+let stderrCapture: CapturedStderr;
+
+// Runner tests intentionally discard expected progress / warning noise
+// (power warnings, batch skip notices, git fixture misses). Individual specs
+// assert the resulting reports/errors; keeping stderr quiet makes real test
+// failures easier to read.
+beforeEach(() => {
+  stderrCapture = captureStderr();
+});
+
+afterEach(() => {
+  stderrCapture.restore();
+});
 
 describe('runEvaluation', () => {
   it('dry-run: experimentRole 从 variantSpecs 正确穿透到每个 task (非默认排序)', async () => {


### PR DESCRIPTION
## 变更说明
- 将重复的边界测试收敛为表驱动用例，减少低价值重复断言
- 捕获错误路径测试中的预期 stderr，让全绿测试输出保持干净
- 不改变生产代码行为，仅调整测试结构和测试隔离

## 验证
- yarn lint
- yarn build
- yarn test
- yarn typecheck