### PR TITLE
test(repo): 使用 it.each 优化表格驱动测试

### DIFF
--- a/test/analysis/gap-analyzer.test.ts
+++ b/test/analysis/gap-analyzer.test.ts
@@ -58,10 +58,8 @@ describe('isFailedSearchTool', () => {
     { name: 'Write or other non-search tools', call: tc('Write', { file_path: '/x.md' }, '', false), expected: false },
   ];
 
-  it('classifies failed search tool boundaries', () => {
-    for (const testCase of cases) {
-      assert.equal(isFailedSearchTool(testCase.call), testCase.expected, testCase.name);
-    }
+  it.each(cases)('$name', ({ call, expected }) => {
+    assert.equal(isFailedSearchTool(call), expected);
   });
 });
 
@@ -124,13 +122,11 @@ describe('extractMarkerSignals', () => {
     { name: 'empty string', text: '', expectedLength: 0 },
   ];
 
-  it('extracts explicit marker boundaries', () => {
-    for (const testCase of cases) {
-      const signals = extractMarkerSignals(testCase.text);
-      assert.equal(signals.length, testCase.expectedLength, testCase.name);
-      if (testCase.expectedLength > 0) {
-        assert.equal(signals[0].type, 'explicit_marker', testCase.name);
-      }
+  it.each(cases)('$name', ({ text, expectedLength }) => {
+    const signals = extractMarkerSignals(text);
+    assert.equal(signals.length, expectedLength);
+    if (expectedLength > 0) {
+      assert.equal(signals[0].type, 'explicit_marker');
     }
   });
 });
@@ -146,13 +142,11 @@ describe('extractHedgingSignals', () => {
     { name: 'clean text', text: '这是一个确定的答案', expectedLength: 0 },
   ];
 
-  it('extracts hedging boundaries', () => {
-    for (const testCase of cases) {
-      const signals = extractHedgingSignals(testCase.text);
-      assert.equal(signals.length, testCase.expectedLength, testCase.name);
-      if (testCase.expectedLength > 0) {
-        assert.equal(signals[0].type, 'hedging', testCase.name);
-      }
+  it.each(cases)('$name', ({ text, expectedLength }) => {
+    const signals = extractHedgingSignals(text);
+    assert.equal(signals.length, expectedLength);
+    if (expectedLength > 0) {
+      assert.equal(signals[0].type, 'hedging');
     }
   });
 });
@@ -224,14 +218,12 @@ describe('extractRepeatedFailureSignals', () => {
     { name: 'empty turns', turns: [], expectedLength: 0 },
   ];
 
-  it('extracts repeated failure boundaries', () => {
-    for (const testCase of cases) {
-      const signals = extractRepeatedFailureSignals(testCase.turns);
-      assert.equal(signals.length, testCase.expectedLength, testCase.name);
-      if (testCase.expectGrepContext) {
-        assert.equal(signals[0].type, 'repeated_failure', testCase.name);
-        assert.ok(signals[0].context.includes('Grep'), testCase.name);
-      }
+  it.each(cases)('$name', ({ turns, expectedLength, expectGrepContext }) => {
+    const signals = extractRepeatedFailureSignals(turns);
+    assert.equal(signals.length, expectedLength);
+    if (expectGrepContext) {
+      assert.equal(signals[0].type, 'repeated_failure');
+      assert.ok(signals[0].context.includes('Grep'));
     }
   });
 });

--- a/test/analysis/sample-diagnostics.test.ts
+++ b/test/analysis/sample-diagnostics.test.ts
@@ -264,13 +264,11 @@ describe('diagnoseSamples — rubric_clarity_low', () => {
     assert.equal(d.byKind.rubric_clarity_low, undefined);
   });
 
-  it('短 rubric 含原过宽词(分数 / 标准 / 应该)无评分语义 → 触发(收紧后)', () => {
+  it.each(['打 5 分数学题', '标准答案是', '你应该'])('短 rubric "%s" 无评分语义 → 触发(收紧后)', (fakeRubric) => {
     // 这些词在  review 后被剔除,避免"打 5 分数学题"/"标准答案"/"你应该"等误豁免
-    for (const fakeRubric of ['打 5 分数学题', '标准答案是', '你应该']) {
-      const { report, samples } = reportWithSample({ rubric: fakeRubric });
-      const d = diagnoseSamples(report, { samples });
-      assert.ok(d.byKind.rubric_clarity_low, `should fire on "${fakeRubric}" (overbroad keywords removed)`);
-    }
+    const { report, samples } = reportWithSample({ rubric: fakeRubric });
+    const d = diagnoseSamples(report, { samples });
+    assert.ok(d.byKind.rubric_clarity_low, `should fire on "${fakeRubric}" (overbroad keywords removed)`);
   });
 
   it('长 rubric 即使无关键词 → 不触发', () => {

--- a/test/cli/judge-models-validation.test.ts
+++ b/test/cli/judge-models-validation.test.ts
@@ -45,31 +45,29 @@ const CASES: Array<{ name: string; argv: string[] }> = [
 ];
 
 describe('--judge-models validation: CLI exits 2 with friendly error', () => {
-  for (const c of CASES) {
-    it(`omk ${c.name} --judge-models <duplicate> exits 2 with friendly error`, async () => {
-      await assert.rejects(
-        () => execFileAsync('node', [CLI, ...c.argv, '--judge-models', 'claude:haiku,claude:haiku']),
-        (err: unknown) => {
-          const e = err as ExecError;
-          assert.equal(e.code, 2, `expected exit 2, got ${e.code}; stderr: ${e.stderr.slice(0, 300)}`);
-          assert.ok(
-            e.stderr.startsWith('error:'),
-            `stderr should start with "error:", got: ${e.stderr.slice(0, 200)}`,
-          );
-          assert.ok(
-            e.stderr.includes('duplicate') && e.stderr.includes('claude:haiku'),
-            `stderr should mention duplicate entry: ${e.stderr.slice(0, 200)}`,
-          );
-          // 关键不变量:不能 leak Error stack trace。
-          assert.ok(
-            !/^\s*at\s/m.test(e.stderr),
-            `stderr should NOT include stack trace ("at " frame): ${e.stderr.slice(0, 400)}`,
-          );
-          return true;
-        },
-      );
-    });
-  }
+  it.each(CASES)('omk $name --judge-models <duplicate> exits 2 with friendly error', async ({ argv }) => {
+    await assert.rejects(
+      () => execFileAsync('node', [CLI, ...argv, '--judge-models', 'claude:haiku,claude:haiku']),
+      (err: unknown) => {
+        const e = err as ExecError;
+        assert.equal(e.code, 2, `expected exit 2, got ${e.code}; stderr: ${e.stderr.slice(0, 300)}`);
+        assert.ok(
+          e.stderr.startsWith('error:'),
+          `stderr should start with "error:", got: ${e.stderr.slice(0, 200)}`,
+        );
+        assert.ok(
+          e.stderr.includes('duplicate') && e.stderr.includes('claude:haiku'),
+          `stderr should mention duplicate entry: ${e.stderr.slice(0, 200)}`,
+        );
+        // 关键不变量:不能 leak Error stack trace。
+        assert.ok(
+          !/^\s*at\s/m.test(e.stderr),
+          `stderr should NOT include stack trace ("at " frame): ${e.stderr.slice(0, 400)}`,
+        );
+        return true;
+      },
+    );
+  });
 
   it('omk bench run --judge-models <missing executor> exits 2 with friendly error', async () => {
     await assert.rejects(

--- a/test/eval-config.test.ts
+++ b/test/eval-config.test.ts
@@ -72,40 +72,39 @@ variants:
     }
   });
 
-  it('rejects invalid required config shape', () => {
-    const cases = [
-      {
-        name: 'samples field missing',
-        yaml: `
+  const invalidRequiredConfigCases = [
+    {
+      name: 'samples field missing',
+      yaml: `
 variants:
   - name: v1
     role: control
     artifact: baseline
         `,
-        error: /'samples' is required/,
-      },
-      {
-        name: 'variants array is empty',
-        yaml: `
+      error: /'samples' is required/,
+    },
+    {
+      name: 'variants array is empty',
+      yaml: `
 samples: ./samples.json
 variants: []
         `,
-        error: /'variants' is required/,
-      },
-      {
-        name: 'variant role is invalid',
-        yaml: `
+      error: /'variants' is required/,
+    },
+    {
+      name: 'variant role is invalid',
+      yaml: `
 samples: ./samples.json
 variants:
   - name: v1
     role: baseline
     artifact: ./v1.md
         `,
-        error: /role must be 'control' or 'treatment'/,
-      },
-      {
-        name: 'variant names are duplicated',
-        yaml: `
+      error: /role must be 'control' or 'treatment'/,
+    },
+    {
+      name: 'variant names are duplicated',
+      yaml: `
 samples: ./samples.json
 variants:
   - name: v1
@@ -115,13 +114,12 @@ variants:
     role: treatment
     artifact: ./v1.md
         `,
-        error: /"v1" is duplicated/,
-      },
-    ];
+      error: /"v1" is duplicated/,
+    },
+  ];
 
-    for (const testCase of cases) {
-      assertYamlThrows(testCase.yaml, testCase.error, testCase.name);
-    }
+  it.each(invalidRequiredConfigCases)('rejects invalid required config shape: $name', ({ yaml, error, name }) => {
+    assertYamlThrows(yaml, error, name);
   });
 
   it('throws when --config file does not exist', () => {
@@ -236,42 +234,40 @@ budget:
     }
   });
 
-  it('rejects invalid budget values', () => {
-    const cases = [
-      {
-        name: 'negative budget value',
-        yaml: `
+  const invalidBudgetCases = [
+    {
+      name: 'negative budget value',
+      yaml: `
 samples: ./s.json
 ${minimalVariants}
 budget:
   totalUSD: -1
         `,
-        error: /totalUSD/,
-      },
-      {
-        name: 'non-numeric budget value',
-        yaml: `
+      error: /totalUSD/,
+    },
+    {
+      name: 'non-numeric budget value',
+      yaml: `
 samples: ./s.json
 ${minimalVariants}
 budget:
   totalUSD: "five"
         `,
-        error: /totalUSD/,
-      },
-      {
-        name: 'non-object budget value',
-        yaml: `
+      error: /totalUSD/,
+    },
+    {
+      name: 'non-object budget value',
+      yaml: `
 samples: ./s.json
 ${minimalVariants}
 budget: 5
         `,
-        error: /budget must be an object/,
-      },
-    ];
+      error: /budget must be an object/,
+    },
+  ];
 
-    for (const testCase of cases) {
-      assertYamlThrows(testCase.yaml, testCase.error, testCase.name);
-    }
+  it.each(invalidBudgetCases)('rejects invalid budget value: $name', ({ yaml, error, name }) => {
+    assertYamlThrows(yaml, error, name);
   });
 
   it('partial budget (only totalUSD) parses cleanly', () => {
@@ -358,58 +354,56 @@ judgeModels:
     }
   });
 
-  it('rejects invalid v0.2 experiment-design fields', () => {
-    const cases = [
-      {
-        name: 'repeat non-integer',
-        yaml: `samples: ./s.json\n${minimalVariants}\nrepeat: 1.5`,
-        error: /repeat must be a positive integer/,
-      },
-      {
-        name: 'repeat <= 0',
-        yaml: `samples: ./s.json\n${minimalVariants}\nrepeat: 0`,
-        error: /repeat must be a positive integer/,
-      },
-      {
-        name: 'bootstrapSamples < 100',
-        yaml: `samples: ./s.json\n${minimalVariants}\nbootstrapSamples: 50`,
-        error: /bootstrapSamples must be a number ≥ 100/,
-      },
-      {
-        name: 'judgeModels non-array',
-        yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels: "claude:opus"`,
-        error: /judgeModels must be an array/,
-      },
-      {
-        name: 'judgeModels entry missing model',
-        yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels:\n  - executor: claude`,
-        error: /judgeModels\[0\]\.model must be a non-empty string/,
-      },
-      {
-        name: 'judgeModels empty array',
-        yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels: []`,
-        error: /judgeModels must have ≥ 1 entry/,
-      },
-      {
-        name: 'judgeModels duplicate entry',
-        yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels:\n  - executor: claude\n    model: haiku\n  - executor: claude\n    model: haiku`,
-        error: /duplicate entry "claude:haiku"/,
-      },
-      {
-        name: 'legacy judgeModel field',
-        yaml: `samples: ./s.json\n${minimalVariants}\njudgeModel: haiku`,
-        error: /judgeModel.*were removed in v0\.25/,
-      },
-      {
-        name: 'legacy judgeExecutor field',
-        yaml: `samples: ./s.json\n${minimalVariants}\njudgeExecutor: claude`,
-        error: /judgeExecutor.*were removed in v0\.25/,
-      },
-    ];
+  const invalidExperimentDesignCases = [
+    {
+      name: 'repeat non-integer',
+      yaml: `samples: ./s.json\n${minimalVariants}\nrepeat: 1.5`,
+      error: /repeat must be a positive integer/,
+    },
+    {
+      name: 'repeat <= 0',
+      yaml: `samples: ./s.json\n${minimalVariants}\nrepeat: 0`,
+      error: /repeat must be a positive integer/,
+    },
+    {
+      name: 'bootstrapSamples < 100',
+      yaml: `samples: ./s.json\n${minimalVariants}\nbootstrapSamples: 50`,
+      error: /bootstrapSamples must be a number ≥ 100/,
+    },
+    {
+      name: 'judgeModels non-array',
+      yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels: "claude:opus"`,
+      error: /judgeModels must be an array/,
+    },
+    {
+      name: 'judgeModels entry missing model',
+      yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels:\n  - executor: claude`,
+      error: /judgeModels\[0\]\.model must be a non-empty string/,
+    },
+    {
+      name: 'judgeModels empty array',
+      yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels: []`,
+      error: /judgeModels must have ≥ 1 entry/,
+    },
+    {
+      name: 'judgeModels duplicate entry',
+      yaml: `samples: ./s.json\n${minimalVariants}\njudgeModels:\n  - executor: claude\n    model: haiku\n  - executor: claude\n    model: haiku`,
+      error: /duplicate entry "claude:haiku"/,
+    },
+    {
+      name: 'legacy judgeModel field',
+      yaml: `samples: ./s.json\n${minimalVariants}\njudgeModel: haiku`,
+      error: /judgeModel.*were removed in v0\.25/,
+    },
+    {
+      name: 'legacy judgeExecutor field',
+      yaml: `samples: ./s.json\n${minimalVariants}\njudgeExecutor: claude`,
+      error: /judgeExecutor.*were removed in v0\.25/,
+    },
+  ];
 
-    for (const testCase of cases) {
-      assertYamlThrows(testCase.yaml, testCase.error, testCase.name);
-    }
+  it.each(invalidExperimentDesignCases)('rejects invalid v0.2 experiment-design field: $name', ({ yaml, error, name }) => {
+    assertYamlThrows(yaml, error, name);
   });
 
   it('judgeModels 单条 = single judge (合法, 不进 ensemble)', () => {
@@ -478,11 +472,10 @@ variants:
     }
   });
 
-  it('rejects invalid allowedSkills shapes', () => {
-    const cases = [
-      {
-        name: 'empty YAML value parses as null',
-        yaml: `
+  const invalidAllowedSkillsCases = [
+    {
+      name: 'empty YAML value parses as null',
+      yaml: `
 samples: ./s.json
 variants:
   - name: baseline
@@ -490,11 +483,11 @@ variants:
     artifact: baseline
     allowedSkills:
         `,
-        error: /allowedSkills must be an array/,
-      },
-      {
-        name: 'string instead of array',
-        yaml: `
+      error: /allowedSkills must be an array/,
+    },
+    {
+      name: 'string instead of array',
+      yaml: `
 samples: ./s.json
 variants:
   - name: baseline
@@ -502,11 +495,11 @@ variants:
     artifact: baseline
     allowedSkills: "react"
         `,
-        error: /allowedSkills must be an array/,
-      },
-      {
-        name: 'array contains non-string element',
-        yaml: `
+      error: /allowedSkills must be an array/,
+    },
+    {
+      name: 'array contains non-string element',
+      yaml: `
 samples: ./s.json
 variants:
   - name: baseline
@@ -516,13 +509,12 @@ variants:
       - react
       - 123
         `,
-        error: /allowedSkills\[1\]/,
-      },
-    ];
+      error: /allowedSkills\[1\]/,
+    },
+  ];
 
-    for (const testCase of cases) {
-      assertYamlThrows(testCase.yaml, testCase.error, testCase.name);
-    }
+  it.each(invalidAllowedSkillsCases)('rejects invalid allowedSkills shape: $name', ({ yaml, error, name }) => {
+    assertYamlThrows(yaml, error, name);
   });
 
   it('absent allowedSkills 字段:variant.allowedSkills === undefined', () => {

--- a/test/evaluation/statistics.test.ts
+++ b/test/evaluation/statistics.test.ts
@@ -65,10 +65,8 @@ describe('tTest', () => {
     },
   ];
 
-  it('covers significance boundaries', () => {
-    for (const testCase of cases) {
-      testCase.check(tTest(testCase.a, testCase.b));
-    }
+  it.each(cases)('$name', ({ a, b, check }) => {
+    check(tTest(a, b));
   });
 });
 
@@ -156,9 +154,7 @@ describe('effectSize', () => {
     },
   ];
 
-  it('covers effect-size boundaries', () => {
-    for (const testCase of cases) {
-      testCase.check(effectSize(testCase.a, testCase.b));
-    }
+  it.each(cases)('$name', ({ a, b, check }) => {
+    check(effectSize(a, b));
   });
 });

--- a/test/grading/assertions-phase5.test.ts
+++ b/test/grading/assertions-phase5.test.ts
@@ -127,29 +127,27 @@ describe('assert-set combinator', () => {
     },
   ];
 
-  it('covers assert-set pass/fail boundaries', () => {
-    for (const testCase of cases) {
-      const r = runAssertions(testCase.output, [testCase.assertion]);
-      assert.equal(r.details[0].passed, testCase.expected, testCase.name);
-    }
+  it.each(cases)('$name', ({ output, assertion, expected }) => {
+    const r = runAssertions(output, [assertion]);
+    assert.equal(r.details[0].passed, expected);
   });
 });
 
 describe('rougeN', () => {
-  it('covers scoring boundaries', () => {
-    const cases = [
-      { name: 'identical strings', actual: rougeN('hello world', 'hello world', 1), expected: 1 },
-      { name: 'one-token swap', actual: rougeN('cat sat on the mat', 'cat sat on a mat', 1), expected: 0.8 },
-      { name: 'no overlap', actual: rougeN('xyz qwe', 'abc def', 1), expected: 0 },
-      { name: 'clipped repeated candidate n-grams', actual: rougeN('cat cat cat cat cat', 'the cat the cat', 1), expected: 0.5 },
-      { name: 'Chinese single-character tokenization', actual: rougeN('你好世界', '你好朋友', 1), expected: 0.5 },
-      { name: 'reference fewer tokens than n', actual: rougeN('a b c', 'a', 2), expected: 0 },
-    ];
+  const cases = [
+    { name: 'identical strings', actual: rougeN('hello world', 'hello world', 1), expected: 1 },
+    { name: 'one-token swap', actual: rougeN('cat sat on the mat', 'cat sat on a mat', 1), expected: 0.8 },
+    { name: 'no overlap', actual: rougeN('xyz qwe', 'abc def', 1), expected: 0 },
+    { name: 'clipped repeated candidate n-grams', actual: rougeN('cat cat cat cat cat', 'the cat the cat', 1), expected: 0.5 },
+    { name: 'Chinese single-character tokenization', actual: rougeN('你好世界', '你好朋友', 1), expected: 0.5 },
+    { name: 'reference fewer tokens than n', actual: rougeN('a b c', 'a', 2), expected: 0 },
+  ];
 
-    for (const testCase of cases) {
-      assert.ok(Math.abs(testCase.actual - testCase.expected) < 0.001, `${testCase.name}: expected ${testCase.expected}, got ${testCase.actual}`);
-    }
+  it.each(cases)('$name', ({ actual, expected }) => {
+    assert.ok(Math.abs(actual - expected) < 0.001, `expected ${expected}, got ${actual}`);
+  });
 
+  it('rouge-2 is lower than rouge-1 for one-token substitutions', () => {
     const r1 = rougeN('the quick brown fox', 'the quick red fox', 1);
     const r2 = rougeN('the quick brown fox', 'the quick red fox', 2);
     assert.ok(r2 < r1, `rouge-2 (${r2}) should be < rouge-1 (${r1})`);
@@ -157,20 +155,18 @@ describe('rougeN', () => {
 });
 
 describe('levenshtein', () => {
-  it('covers edit-distance boundaries', () => {
-    const cases = [
-      { name: 'identical strings', a: 'hello', b: 'hello', expected: 0 },
-      { name: 'left side empty', a: '', b: 'abc', expected: 3 },
-      { name: 'right side empty', a: 'abc', b: '', expected: 3 },
-      { name: 'classic kitten to sitting', a: 'kitten', b: 'sitting', expected: 3 },
-      { name: 'single-char swap', a: 'cat', b: 'bat', expected: 1 },
-      { name: 'Chinese deletion', a: '你好世界', b: '你好世', expected: 1 },
-      { name: 'Chinese replacement', a: '你好', b: '世界', expected: 2 },
-    ];
+  const cases = [
+    { name: 'identical strings', a: 'hello', b: 'hello', expected: 0 },
+    { name: 'left side empty', a: '', b: 'abc', expected: 3 },
+    { name: 'right side empty', a: 'abc', b: '', expected: 3 },
+    { name: 'classic kitten to sitting', a: 'kitten', b: 'sitting', expected: 3 },
+    { name: 'single-char swap', a: 'cat', b: 'bat', expected: 1 },
+    { name: 'Chinese deletion', a: '你好世界', b: '你好世', expected: 1 },
+    { name: 'Chinese replacement', a: '你好', b: '世界', expected: 2 },
+  ];
 
-    for (const testCase of cases) {
-      assert.equal(levenshtein(testCase.a, testCase.b), testCase.expected, testCase.name);
-    }
+  it.each(cases)('$name', ({ a, b, expected }) => {
+    assert.equal(levenshtein(a, b), expected);
   });
 });
 
@@ -226,10 +222,8 @@ describe('assertion integration', () => {
     },
   ];
 
-  it('covers deterministic metric assertion integration', () => {
-    for (const testCase of cases) {
-      const r = runAssertions(testCase.output, [testCase.assertion]);
-      assert.equal(r.details[0].passed, testCase.expected, testCase.name);
-    }
+  it.each(cases)('$name', ({ output, assertion, expected }) => {
+    const r = runAssertions(output, [assertion]);
+    assert.equal(r.details[0].passed, expected);
   });
 });

--- a/test/grading/gold-dataset.test.ts
+++ b/test/grading/gold-dataset.test.ts
@@ -68,74 +68,72 @@ annotations:
     assert.ok(issues[0].message.includes('not found') || issues[0].message.includes('unreadable'));
   });
 
-  it('reports invalid dataset shapes with specific issues', () => {
-    const cases = [
-      {
-        name: 'missing metadata',
-        setup: () => writeYaml('a.yaml', `annotations: [{ sample_id: x, score: 3 }]`),
-        check: (issues: ReturnType<typeof loadGoldDataset>['issues'], dataset: ReturnType<typeof loadGoldDataset>['dataset']) => {
-          assert.equal(dataset, undefined);
-          assert.ok(issues.some((i) => /metadata/.test(i.message)));
-        },
+  const invalidDatasetCases = [
+    {
+      name: 'missing metadata',
+      setup: () => writeYaml('a.yaml', `annotations: [{ sample_id: x, score: 3 }]`),
+      check: (issues: ReturnType<typeof loadGoldDataset>['issues'], dataset: ReturnType<typeof loadGoldDataset>['dataset']) => {
+        assert.equal(dataset, undefined);
+        assert.ok(issues.some((i) => /metadata/.test(i.message)));
       },
-      {
-        name: 'non-numeric score',
-        setup: () => writeYaml('a.yaml', `
+    },
+    {
+      name: 'non-numeric score',
+      setup: () => writeYaml('a.yaml', `
 metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1' }
 annotations:
   - { sample_id: ok, score: 4 }
   - { sample_id: bad, score: "five" }
 `),
-        check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
-          const scoreIssue = issues.find((i) => /score/.test(i.message));
-          assert.ok(scoreIssue, `expected a score issue, got ${JSON.stringify(issues)}`);
-          assert.equal(scoreIssue!.index, 1);
-        },
+      check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
+        const scoreIssue = issues.find((i) => /score/.test(i.message));
+        assert.ok(scoreIssue, `expected a score issue, got ${JSON.stringify(issues)}`);
+        assert.equal(scoreIssue!.index, 1);
       },
-      {
-        name: 'invalid scale',
-        setup: () => writeYaml('a.yaml', `
+    },
+    {
+      name: 'invalid scale',
+      setup: () => writeYaml('a.yaml', `
 metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1', scale: { min: 5, max: 1 } }
 annotations: [{ sample_id: a, score: 3 }]
 `),
-        check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
-          assert.ok(issues.some((i) => /scale/.test(i.message)));
-        },
+      check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
+        assert.ok(issues.some((i) => /scale/.test(i.message)));
       },
-      {
-        name: 'YAML parse error',
-        setup: () => writeYaml('bad.yaml', `metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1'\nannotations: [unclosed`),
-        check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
-          assert.ok(issues.some((i) => /YAML parse error/.test(i.message)),
-            `expected YAML parse error, got: ${JSON.stringify(issues)}`);
-        },
+    },
+    {
+      name: 'YAML parse error',
+      setup: () => writeYaml('bad.yaml', `metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1'\nannotations: [unclosed`),
+      check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
+        assert.ok(issues.some((i) => /YAML parse error/.test(i.message)),
+          `expected YAML parse error, got: ${JSON.stringify(issues)}`);
       },
-      {
-        name: 'metadata declared in multiple files',
-        setup: () => {
-          writeYaml('a.yaml', `metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1' }`);
-          writeYaml('b.yaml', `metadata: { annotator: y, annotatedAt: '2026-04-25', version: '1' }
+    },
+    {
+      name: 'metadata declared in multiple files',
+      setup: () => {
+        writeYaml('a.yaml', `metadata: { annotator: x, annotatedAt: '2026-04-25', version: '1' }`);
+        writeYaml('b.yaml', `metadata: { annotator: y, annotatedAt: '2026-04-25', version: '1' }
 annotations: [{ sample_id: s, score: 1 }]`);
-        },
-        check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
-          assert.ok(issues.some((i) => /multiple files/.test(i.message)));
-        },
       },
-      {
-        name: 'nested-but-empty directory',
-        setup: () => mkdirSync(join(dir, 'sub')),
-        check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
-          assert.ok(issues.some((i) => /no \.yaml files/.test(i.message)));
-        },
+      check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
+        assert.ok(issues.some((i) => /multiple files/.test(i.message)));
       },
-    ];
+    },
+    {
+      name: 'nested-but-empty directory',
+      setup: () => mkdirSync(join(dir, 'sub')),
+      check: (issues: ReturnType<typeof loadGoldDataset>['issues']) => {
+        assert.ok(issues.some((i) => /no \.yaml files/.test(i.message)));
+      },
+    },
+  ];
 
-    for (const testCase of cases) {
-      rmSync(dir, { recursive: true, force: true });
-      mkdirSync(dir, { recursive: true });
-      testCase.setup();
-      const { dataset, issues } = loadGoldDataset(dir);
-      testCase.check(issues, dataset);
-    }
+  it.each(invalidDatasetCases)('reports invalid dataset shape: $name', ({ setup, check }) => {
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir, { recursive: true });
+    setup();
+    const { dataset, issues } = loadGoldDataset(dir);
+    check(issues, dataset);
   });
 });

--- a/test/grading/rag-metrics.test.ts
+++ b/test/grading/rag-metrics.test.ts
@@ -37,19 +37,19 @@ describe('faithfulness', () => {
     context: 'The Eiffel Tower is in Paris and is 330 meters tall.',
   };
 
-  it('covers score threshold and context boundaries', async () => {
-    const cases = [
-      { name: 'passes when score >= threshold', assertion: { type: 'faithfulness' }, output: 'The Eiffel Tower is in Paris.', score: 5, expected: true },
-      { name: 'fails when score < threshold', assertion: { type: 'faithfulness' }, output: 'The Eiffel Tower is in London and is 100m tall.', score: 2, expected: false },
-      { name: 'respects custom threshold', assertion: { type: 'faithfulness', threshold: 4 }, output: 'mixed answer', score: 3, expected: false },
-      { name: 'uses assertion.reference when sample.context is absent', assertion: { type: 'faithfulness', reference: 'overridden context' }, sample: { sample_id: 's', prompt: 'Q?' }, expected: true },
-    ] satisfies Array<{ name: string; assertion: Assertion; output?: string; score?: number; sample?: Sample; expected: boolean }>;
+  const faithfulnessCases = [
+    { name: 'passes when score >= threshold', assertion: { type: 'faithfulness' }, output: 'The Eiffel Tower is in Paris.', score: 5, expected: true },
+    { name: 'fails when score < threshold', assertion: { type: 'faithfulness' }, output: 'The Eiffel Tower is in London and is 100m tall.', score: 2, expected: false },
+    { name: 'respects custom threshold', assertion: { type: 'faithfulness', threshold: 4 }, output: 'mixed answer', score: 3, expected: false },
+    { name: 'uses assertion.reference when sample.context is absent', assertion: { type: 'faithfulness', reference: 'overridden context' }, sample: { sample_id: 's', prompt: 'Q?' }, expected: true },
+  ] satisfies Array<{ name: string; assertion: Assertion; output?: string; score?: number; sample?: Sample; expected: boolean }>;
 
-    for (const testCase of cases) {
-      const r = await runSingle(testCase.sample ?? sample, testCase.assertion, testCase.output, testCase.score);
-      assert.equal(r.details[0].passed, testCase.expected, testCase.name);
-    }
+  it.each(faithfulnessCases)('$name', async (testCase) => {
+    const r = await runSingle(testCase.sample ?? sample, testCase.assertion, testCase.output, testCase.score);
+    assert.equal(r.details[0].passed, testCase.expected);
+  });
 
+  it('fails when both sample.context and assertion.reference are missing', async () => {
     const noCtx = await runSingle({ sample_id: 's', prompt: 'Q?' }, { type: 'faithfulness' });
     assert.equal(noCtx.details[0].passed, false);
     assert.match(noCtx.details[0].message ?? '', /缺少 sample.context/);
@@ -74,17 +74,15 @@ describe('answer_relevancy', () => {
     prompt: 'How tall is the Eiffel Tower?',
   };
 
-  it('covers score threshold and no-context behavior', async () => {
-    const cases = [
-      { name: 'passes when output answers the question', output: '330 meters tall.', score: 5, expected: true },
-      { name: 'fails when output dodges', output: 'Eiffel was an engineer.', score: 1, expected: false },
-      { name: 'does not require sample.context', output: '330m', score: 4, expected: true },
-    ];
+  const answerRelevancyCases = [
+    { name: 'passes when output answers the question', output: '330 meters tall.', score: 5, expected: true },
+    { name: 'fails when output dodges', output: 'Eiffel was an engineer.', score: 1, expected: false },
+    { name: 'does not require sample.context', output: '330m', score: 4, expected: true },
+  ];
 
-    for (const testCase of cases) {
-      const r = await runSingle(sample, { type: 'answer_relevancy' }, testCase.output, testCase.score);
-      assert.equal(r.details[0].passed, testCase.expected, testCase.name);
-    }
+  it.each(answerRelevancyCases)('$name', async ({ output, score, expected }) => {
+    const r = await runSingle(sample, { type: 'answer_relevancy' }, output, score);
+    assert.equal(r.details[0].passed, expected);
   });
 
   it('passes the user question into the judge prompt', async () => {
@@ -107,17 +105,17 @@ describe('context_recall', () => {
     context: 'Key fact A. Key fact B. Key fact C.',
   };
 
-  it('covers score threshold and missing-context behavior', async () => {
-    const cases = [
-      { name: 'passes when output covers gold facts', output: 'Output covers A B C.', score: 5, expected: true },
-      { name: 'fails when output ignores most gold facts', output: 'Only A.', score: 1, expected: false },
-    ];
+  const contextRecallCases = [
+    { name: 'passes when output covers gold facts', output: 'Output covers A B C.', score: 5, expected: true },
+    { name: 'fails when output ignores most gold facts', output: 'Only A.', score: 1, expected: false },
+  ];
 
-    for (const testCase of cases) {
-      const r = await runSingle(sample, { type: 'context_recall' }, testCase.output, testCase.score);
-      assert.equal(r.details[0].passed, testCase.expected, testCase.name);
-    }
+  it.each(contextRecallCases)('$name', async ({ output, score, expected }) => {
+    const r = await runSingle(sample, { type: 'context_recall' }, output, score);
+    assert.equal(r.details[0].passed, expected);
+  });
 
+  it('fails when sample.context is missing', async () => {
     const noCtxSample: Sample = { sample_id: 's', prompt: 'Q?' };
     const missing = await runSingle(noCtxSample, { type: 'context_recall' }, 'out');
     assert.equal(missing.details[0].passed, false);

--- a/test/inputs/load-samples.test.ts
+++ b/test/inputs/load-samples.test.ts
@@ -47,19 +47,17 @@ describe('loadSamples', () => {
     assert.equal(samples[1].prompt, 'world');
   });
 
-  it('rejects invalid sample file shapes', () => {
-    const cases = [
-      { name: 'empty array', file: 'empty.json', value: [], error: /invalid samples file/ },
-      { name: 'non-array content', file: 'invalid.json', value: 'not an array', error: /invalid samples file/ },
-      { name: 'missing sample_id', file: 'no-id.json', value: [{ prompt: 'hello' }], error: /required field: sample_id/ },
-      { name: 'missing prompt', file: 'no-prompt.json', value: [{ sample_id: 'x' }], error: /required field: prompt/ },
-      { name: 'non-string prompt', file: 'bad-prompt-type.json', value: [{ sample_id: 'x', prompt: 123 }], error: /invalid required field: prompt/ },
-    ];
+  const invalidShapeCases = [
+    { name: 'empty array', file: 'empty.json', value: [], error: /invalid samples file/ },
+    { name: 'non-array content', file: 'invalid.json', value: 'not an array', error: /invalid samples file/ },
+    { name: 'missing sample_id', file: 'no-id.json', value: [{ prompt: 'hello' }], error: /required field: sample_id/ },
+    { name: 'missing prompt', file: 'no-prompt.json', value: [{ sample_id: 'x' }], error: /required field: prompt/ },
+    { name: 'non-string prompt', file: 'bad-prompt-type.json', value: [{ sample_id: 'x', prompt: 123 }], error: /invalid required field: prompt/ },
+  ];
 
-    for (const testCase of cases) {
-      const p = writeJsonSamples(testCase.file, testCase.value);
-      assert.throws(() => loadSamples(p), testCase.error, testCase.name);
-    }
+  it.each(invalidShapeCases)('rejects invalid sample file shape: $name', ({ file, value, error }) => {
+    const p = writeJsonSamples(file, value);
+    assert.throws(() => loadSamples(p), error);
   });
 
   // sample design metadata fields validation
@@ -89,38 +87,36 @@ describe('loadSamples', () => {
       assert.equal(samples[0].provenance, undefined);
     });
 
-    it('rejects invalid sample design metadata', () => {
-      const cases = [
-        {
-          name: 'difficulty invalid value includes sample_id',
-          file: 'bad-difficulty.json',
-          value: [{ sample_id: 's7', prompt: 'p', difficulty: 'easy?' }],
-          error: /s7.*invalid difficulty.*easy\?.*easy, medium, hard/,
-        },
-        {
-          name: 'provenance invalid value',
-          file: 'bad-prov.json',
-          value: [{ sample_id: 's1', prompt: 'p', provenance: 'random' }],
-          error: /invalid provenance/,
-        },
-        {
-          name: 'capability single string',
-          file: 'bad-cap.json',
-          value: [{ sample_id: 's1', prompt: 'p', capability: 'api-selection' }],
-          error: /invalid capability.*string array/,
-        },
-        {
-          name: 'capability array contains non-string',
-          file: 'bad-cap-elem.json',
-          value: [{ sample_id: 's1', prompt: 'p', capability: ['ok', 123] }],
-          error: /capability\[1\] must be a non-empty string/,
-        },
-      ];
+    const invalidMetadataCases = [
+      {
+        name: 'difficulty invalid value includes sample_id',
+        file: 'bad-difficulty.json',
+        value: [{ sample_id: 's7', prompt: 'p', difficulty: 'easy?' }],
+        error: /s7.*invalid difficulty.*easy\?.*easy, medium, hard/,
+      },
+      {
+        name: 'provenance invalid value',
+        file: 'bad-prov.json',
+        value: [{ sample_id: 's1', prompt: 'p', provenance: 'random' }],
+        error: /invalid provenance/,
+      },
+      {
+        name: 'capability single string',
+        file: 'bad-cap.json',
+        value: [{ sample_id: 's1', prompt: 'p', capability: 'api-selection' }],
+        error: /invalid capability.*string array/,
+      },
+      {
+        name: 'capability array contains non-string',
+        file: 'bad-cap-elem.json',
+        value: [{ sample_id: 's1', prompt: 'p', capability: ['ok', 123] }],
+        error: /capability\[1\] must be a non-empty string/,
+      },
+    ];
 
-      for (const testCase of cases) {
-        const p = writeJsonSamples(testCase.file, testCase.value);
-        assert.throws(() => loadSamples(p), testCase.error, testCase.name);
-      }
+    it.each(invalidMetadataCases)('rejects invalid sample design metadata: $name', ({ file, value, error }) => {
+      const p = writeJsonSamples(file, value);
+      assert.throws(() => loadSamples(p), error);
     });
 
     it('construct 接受任意 string(允许自定义值)', () => {


### PR DESCRIPTION
## 用户影响

- 将表格驱动测试从单个 `it` 内循环改为 Vitest `it.each`。
- 单个 case 失败时会独立报告，不再被同一个测试里的 fail-fast 循环吞掉后续 case。
- 仅调整测试组织方式，不改生产代码或评测语义。

## 验证

- `yarn lint && yarn build && yarn test` 通过
- 全量测试: 78 files / 1033 tests

## 测量学 caveat

- 测试计数上升来自 Vitest case 展开，不代表覆盖语义变化。