### PR TITLE
fix(server): listen 失败错误文案区分 port 0 / 权限 / 占用三种情况

### DIFF
--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -390,6 +390,47 @@ function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+// Returns Error to throw, or null when caller should fall through to the
+// EADDRINUSE / omk-takeover flow. Splits "occupancy" from "permission" /
+// "ephemeral-bind-rejected" so users see a fix path that matches the cause.
+export function formatListenError(p: number, err: unknown): Error | null {
+  const errno = (err as NodeJS.ErrnoException | undefined)?.code;
+
+  // p === 0 asks the OS to pick an ephemeral port; "already in use" is
+  // semantically wrong here. Failures are almost always sandbox / restricted
+  // network environments rather than occupancy.
+  if (p === 0) {
+    return new Error(
+      `cannot bind ephemeral port (--port 0): ${errno ?? 'unknown error'}.\n` +
+      `  likely cause: sandboxed / restricted network environment ` +
+      `(Docker without --net=host, container without bind permission).\n` +
+      `  try a fixed port: omk bench report --port 8080`
+    );
+  }
+
+  // EACCES / EPERM: permission, not occupancy. Common on privileged ports
+  // (<1024 without root) or sandbox / container restrictions.
+  if (errno === 'EACCES' || errno === 'EPERM') {
+    return new Error(
+      `cannot bind port ${p}: permission denied (${errno}).\n` +
+      `  ports < 1024 require root on Unix; sandboxed environments may block all binds.\n` +
+      `  pick a higher port: omk bench report --port 8080`
+    );
+  }
+
+  // Any other syscall errno that isn't EADDRINUSE: surface it directly,
+  // don't try the omk-takeover flow.
+  if (errno && errno !== 'EADDRINUSE') {
+    return new Error(
+      `cannot bind port ${p}: ${errno} (${getErrorMessage(err)}).\n` +
+      `  pick another port: omk bench report --port 8080`
+    );
+  }
+
+  // EADDRINUSE or unknown — let caller try the omk-takeover flow.
+  return null;
+}
+
 export function createReportServer({ port, reportsDir = DEFAULT_REPORTS_DIR, analysesDir = DEFAULT_ANALYSES_DIR, jobsDir = DEFAULT_JOBS_DIR, store, jobStore }: ReportServerOptions = {}): ReportServer {
   let server: Server | null = null;
   let serverUrl: string | null = null;
@@ -635,8 +676,11 @@ export function createReportServer({ port, reportsDir = DEFAULT_REPORTS_DIR, ana
 
     try {
       server = await boot(p);
-    } catch {
-      // Port occupied — check if it's an existing omk service
+    } catch (err: unknown) {
+      const formatted = formatListenError(p, err);
+      if (formatted) throw formatted;
+
+      // EADDRINUSE — check if it's an existing omk service we can take over
       const url = `http://${host}:${p}`;
       let isOmk = false;
       try {

--- a/test/server/format-listen-error.test.ts
+++ b/test/server/format-listen-error.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { formatListenError } from '../../src/server/report-server.js';
+
+function nodeErr(code: string, message = `${code}: synthetic`): NodeJS.ErrnoException {
+  const err = new Error(message) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+describe('formatListenError', () => {
+  it('p=0 + any errno → ephemeral-port message, never "already in use"', () => {
+    const out = formatListenError(0, nodeErr('EACCES'));
+    assert.ok(out, 'should return an Error for p=0');
+    assert.match(out.message, /ephemeral port/);
+    assert.doesNotMatch(out.message, /already in use/);
+  });
+
+  it('p=0 + EADDRINUSE (synthetic) → still ephemeral-port message, not occupancy', () => {
+    // EADDRINUSE on port 0 doesn't actually happen (OS picks free ephemeral),
+    // but if it ever surfaced we still must not call it "already in use".
+    const out = formatListenError(0, nodeErr('EADDRINUSE'));
+    assert.ok(out);
+    assert.match(out.message, /ephemeral port/);
+  });
+
+  it('p=0 + no errno → ephemeral-port message with "unknown error"', () => {
+    const out = formatListenError(0, new Error('weird'));
+    assert.ok(out);
+    assert.match(out.message, /ephemeral port/);
+    assert.match(out.message, /unknown error/);
+  });
+
+  it('p=80 + EACCES → permission-denied message, suggests higher port', () => {
+    const out = formatListenError(80, nodeErr('EACCES'));
+    assert.ok(out);
+    assert.match(out.message, /permission denied/);
+    assert.match(out.message, /port 80/);
+    assert.match(out.message, /pick a higher port/);
+    assert.doesNotMatch(out.message, /already in use/);
+  });
+
+  it('p=80 + EPERM → permission-denied message', () => {
+    const out = formatListenError(80, nodeErr('EPERM'));
+    assert.ok(out);
+    assert.match(out.message, /permission denied \(EPERM\)/);
+  });
+
+  it('p=8080 + EADDRINUSE → null (caller should run omk-takeover flow)', () => {
+    const out = formatListenError(8080, nodeErr('EADDRINUSE'));
+    assert.equal(out, null);
+  });
+
+  it('p=8080 + ENETUNREACH → fallback message naming the errno', () => {
+    const out = formatListenError(8080, nodeErr('ENETUNREACH'));
+    assert.ok(out);
+    assert.match(out.message, /ENETUNREACH/);
+    assert.match(out.message, /pick another port/);
+    assert.doesNotMatch(out.message, /already in use/);
+    assert.doesNotMatch(out.message, /permission denied/);
+  });
+
+  it('p=8080 + no errno → null (fall through to takeover, surfaces unknown via takeover error path)', () => {
+    const out = formatListenError(8080, new Error('weird'));
+    assert.equal(out, null);
+  });
+
+  it('error-message format includes a port-fix suggestion in every branch', () => {
+    const cases = [
+      formatListenError(0, nodeErr('EACCES')),
+      formatListenError(80, nodeErr('EACCES')),
+      formatListenError(8080, nodeErr('ENETUNREACH')),
+    ];
+    for (const out of cases) {
+      assert.ok(out);
+      assert.match(out.message, /--port \d+|pick another port|pick a higher port/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

修 \`omk bench report\` 的 report server 启动失败时,无论真实原因都报"端口占用"导致用户走错修复路径的问题。Roadmap v0.26 优先项之一(\`docs/zh/roadmap.md\` L60)。

## 触发场景

旧逻辑里 \`start()\` 的 catch 块是 \`catch {}\` 完全 swallow 错误:

\`\`\`ts
try {
  server = await boot(p);
} catch {
  // 不论真实 errno,直接进"端口占用"诊断
  ...
  throw new Error(\`port \${p} is already in use by another process.\`);
}
\`\`\`

后果:

- \`omk bench report --port 0\` 在沙盒 / 容器 / 无 bind 权限的环境里失败时,误报 \`port 0 is already in use\` — port 0 是 OS 分配 ephemeral port 的语义,根本不存在"占用"概念
- \`omk bench report --port 80\` 在非 root 用户失败(EACCES)时,误报"端口占用",修复建议(\`lsof -i:80 / kill\`)指错方向
- ENETUNREACH / EAFNOSUPPORT 等任何非占用错误都被 fold 进同一文案

## 修复

抽出 \`formatListenError(p, err): Error | null\` 纯函数,按 errno 和 port 分类:

- \`p === 0\`:不论 errno,文案"cannot bind ephemeral port",建议改用固定 port + 检查沙盒 / 容器 bind 权限
- \`EACCES / EPERM\`:文案"permission denied",建议挑 >= 1024 的端口或 check 权限
- 其他非 EADDRINUSE errno:surface 原 errno + 建议换端口
- \`EADDRINUSE / unknown\`:返回 null,让 caller 走原 omk-takeover 逻辑(check \`/health\`、shutdown 旧实例、retry)

抽纯函数让单测可达。EADDRINUSE 的 takeover 路径仍在 \`start()\` 里没 mock 单测——那是另一份工作。

## 改动

- \`src/server/report-server.ts\`:加 \`formatListenError\` export + \`start()\` catch 用它分流
- \`test/server/format-listen-error.test.ts\`(新):9 个 case 覆盖 port 0 / 权限 / 兜底 / EADDRINUSE pass-through

## 验证

- \`yarn test\` 79 files / **1042 tests**(从 1033 → 1042 = +9 新测试)全绿
- \`yarn typecheck\` 绿
- \`yarn lint\` 绿
- 没碰测量学不变量(\`judge-hash-frozen.test.ts\` / Report schema / 5 层评分管道 / Bootstrap CI / Krippendorff α 都没动)

## Test plan

- [x] formatListenError 9 个 case 全过
- [x] 全套 1042 tests 全绿
- [ ] 实际在 Docker without --net=host 跑 \`omk bench report --port 0\`,验证看到 "ephemeral port" 文案而不是 "already in use"
- [ ] 在非 root 用户跑 \`omk bench report --port 80\`,验证看到 "permission denied (EACCES)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)