### PR TITLE
feat(doctor)!: JSON schema 重构 — outcome enum / schemaVersion / ruleStats / 结构化依赖原因 (BREAKING: 删除 failed/warned 与 DependencyIssue.hint)

### DIFF
--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -180,6 +180,11 @@ export type CliMessageKey =
   | 'cli.doctor.dependencies.hint.tool'
   | 'cli.doctor.dependencies.hint.file'
   | 'cli.doctor.dependencies.hint.env'
+  | 'cli.doctor.dependencies.hint.preflight'
+  | 'cli.doctor.dependencies.issue.tool_not_found'
+  | 'cli.doctor.dependencies.issue.file_not_found'
+  | 'cli.doctor.dependencies.issue.env_not_set'
+  | 'cli.doctor.dependencies.issue.preflight_failed'
   | 'cli.doctor.skill_readable.hint.too_short'
   // doctor — skill_metadata rule
   | 'cli.doctor.skill_metadata.fail.frontmatter_invalid'
@@ -188,7 +193,6 @@ export type CliMessageKey =
   | 'cli.doctor.skill_metadata.hint.missing_skillmd'
   // doctor — dependencies rule
   | 'cli.doctor.dependencies.fail'
-  | 'cli.doctor.dependencies.hint'
   // doctor — samples_contract rule
   | 'cli.doctor.samples_contract.skipped'
   | 'cli.doctor.samples_contract.warn.empty'
@@ -1184,10 +1188,6 @@ Examples:
     zh: '前置依赖检查失败: {summary}',
     en: 'dependency check failed: {summary}',
   },
-  'cli.doctor.dependencies.hint': {
-    zh: '若依赖确实可用 (e.g. shim 化测试),修正 skill 引用方式;否则按下述提示补齐',
-    en: 'if these deps are actually present (e.g. shimmed in tests), adjust skill references; otherwise follow the per-category fix below',
-  },
   'cli.doctor.dependencies.hint.tool': {
     zh: '工具缺失: 安装到 PATH 或更新 skill 的 requires.tools 引用名',
     en: 'missing tool: install it on PATH or update skill\'s requires.tools entry',
@@ -1199,6 +1199,28 @@ Examples:
   'cli.doctor.dependencies.hint.env': {
     zh: '环境变量缺失: 在 .env / shell profile 里 export,或在 CI secrets 中配置',
     en: 'missing env: export it in .env / shell profile, or configure it in CI secrets',
+  },
+  'cli.doctor.dependencies.hint.preflight': {
+    zh: 'preflight 命令失败: 看上面 detail 里的 stderr 找根因,或调整 skill 的 preflight 命令',
+    en: 'preflight command failed: read the stderr in the detail above, or adjust the skill\'s preflight command',
+  },
+  // Per-issue translated lines. dep-checker emits structured reasonCode +
+  // reasonDetail (untranslated raw stderr / cwd) so doctor can localize per ctx.lang.
+  'cli.doctor.dependencies.issue.tool_not_found': {
+    zh: '工具 {name} 未找到 (不在 PATH 中)',
+    en: 'tool {name} not found on PATH',
+  },
+  'cli.doctor.dependencies.issue.file_not_found': {
+    zh: '文件 {name} 不存在 (cwd: {detail})',
+    en: 'file {name} not found (cwd: {detail})',
+  },
+  'cli.doctor.dependencies.issue.env_not_set': {
+    zh: '环境变量 {name} 未设置',
+    en: 'env var {name} not set',
+  },
+  'cli.doctor.dependencies.issue.preflight_failed': {
+    zh: 'preflight 命令 "{name}" 执行失败: {detail}',
+    en: 'preflight command "{name}" failed: {detail}',
   },
   // samples_contract
   'cli.doctor.samples_contract.skipped': {

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -1201,8 +1201,8 @@ Examples:
     en: 'missing env: export it in .env / shell profile, or configure it in CI secrets',
   },
   'cli.doctor.dependencies.hint.preflight': {
-    zh: 'preflight 命令失败: 看上面 detail 里的 stderr 找根因,或调整 skill 的 preflight 命令',
-    en: 'preflight command failed: read the stderr in the detail above, or adjust the skill\'s preflight command',
+    zh: 'preflight 命令失败: 看上面的失败原因定位根因,或调整 skill 的 preflight 命令',
+    en: 'preflight command failed: read the failure reason above, or adjust the skill\'s preflight command',
   },
   // Per-issue translated lines. dep-checker emits structured reasonCode +
   // reasonDetail (untranslated raw stderr / cwd) so doctor can localize per ctx.lang.
@@ -1267,7 +1267,7 @@ oh-my-knowledge — omk doctor 健康检查
 doctor 检查项(纯静态 / 零 LLM 调用):
   - skill 文件可读 + 内容有最小长度
   - skill 元数据合法 (front-matter 若有)
-  - 前置依赖完整 (引用的 CLI 工具 / 文件 / 环境变量)
+  - 前置依赖完整 (引用的 CLI 工具 / 文件 / 环境变量 / preflight 命令)
   - 用例 ↔ skill 输入约定 (warn 级, 仅传 samples 时跑)
 
 executor / judge 连通性由 evaluation preflight 负责, 不在 doctor 范围内。
@@ -1300,7 +1300,7 @@ Examples:
 Checks (pure static / zero LLM calls):
   - skill file readable + minimum content length
   - skill metadata valid (front-matter if present)
-  - dependencies present (referenced CLI tools / files / env vars)
+  - dependencies present (referenced CLI tools / files / env vars / preflight commands)
   - samples ↔ skill contract (warn-level, only when samples provided)
 
 executor / judge connectivity is handled by evaluation preflight, not doctor.

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -177,6 +177,9 @@ export type CliMessageKey =
   | 'cli.doctor.skill_readable.fail.empty'
   | 'cli.doctor.skill_readable.fail.too_short'
   | 'cli.doctor.skill_readable.hint.missing'
+  | 'cli.doctor.dependencies.hint.tool'
+  | 'cli.doctor.dependencies.hint.file'
+  | 'cli.doctor.dependencies.hint.env'
   | 'cli.doctor.skill_readable.hint.too_short'
   // doctor — skill_metadata rule
   | 'cli.doctor.skill_metadata.fail.frontmatter_invalid'
@@ -1152,8 +1155,8 @@ Examples:
     en: 'skill content too short ({length} chars, minimum 10)',
   },
   'cli.doctor.skill_readable.hint.missing': {
-    zh: '请确认 skill 文件路径正确,文件可读且非空',
-    en: 'verify skill file path is correct and the file is readable',
+    zh: 'skill 文件未读到内容(尝试路径: {path})。用 `ls -la {path}` 确认文件存在,用 `cat {path}` 确认可读且非空',
+    en: 'no content read from skill (tried path: {path}). Run `ls -la {path}` to verify it exists and `cat {path}` to confirm it is readable and non-empty',
   },
   'cli.doctor.skill_readable.hint.too_short': {
     zh: 'skill 至少需要写一句完整的指令,过短的内容评测出来无意义',
@@ -1182,8 +1185,20 @@ Examples:
     en: 'dependency check failed: {summary}',
   },
   'cli.doctor.dependencies.hint': {
-    zh: '安装缺失的工具或设置环境变量;若依赖确实可用 (e.g. shim 化测试),修正 skill 引用方式',
-    en: 'install missing tools or set required env vars; if deps are actually present (e.g. shimmed in tests), adjust skill references',
+    zh: '若依赖确实可用 (e.g. shim 化测试),修正 skill 引用方式;否则按下述提示补齐',
+    en: 'if these deps are actually present (e.g. shimmed in tests), adjust skill references; otherwise follow the per-category fix below',
+  },
+  'cli.doctor.dependencies.hint.tool': {
+    zh: '工具缺失: 安装到 PATH 或更新 skill 的 requires.tools 引用名',
+    en: 'missing tool: install it on PATH or update skill\'s requires.tools entry',
+  },
+  'cli.doctor.dependencies.hint.file': {
+    zh: '文件缺失: 检查路径是否相对 skill 目录正确,或更新 skill 的 requires.files 引用',
+    en: 'missing file: verify path is relative to skill dir, or update skill\'s requires.files entry',
+  },
+  'cli.doctor.dependencies.hint.env': {
+    zh: '环境变量缺失: 在 .env / shell profile 里 export,或在 CI secrets 中配置',
+    en: 'missing env: export it in .env / shell profile, or configure it in CI secrets',
   },
   // samples_contract
   'cli.doctor.samples_contract.skipped': {

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -1239,7 +1239,7 @@ oh-my-knowledge — omk doctor 健康检查
 
 示例:
   omk doctor examples/code-review/skills/v1.md
-  omk doctor examples/code-review/skills --json | jq .failed
+  omk doctor examples/code-review/skills --json | jq .outcome  # passed | warnings_only | failed
   omk doctor --gate; echo $?
 
 doctor 检查项(纯静态 / 零 LLM 调用):
@@ -1272,7 +1272,7 @@ Options:
 
 Examples:
   omk doctor examples/code-review/skills/v1.md
-  omk doctor examples/code-review/skills --json | jq .failed
+  omk doctor examples/code-review/skills --json | jq .outcome  # passed | warnings_only | failed
   omk doctor --gate; echo $?
 
 Checks (pure static / zero LLM calls):

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -633,7 +633,7 @@ async function handleDoctor(argv: string[]): Promise<void> {
     console.log(renderDoctorReportJson(report));
   } else if (isGate) {
     // gate 模式: 静默 stdout, fail 时简短 stderr 摘要(供 CI 抓 exit code)
-    if (report.failed) {
+    if (report.outcome === 'failed') {
       const summary = lang === 'zh'
         ? `doctor failed: ${report.totals.fail} 个 skill 未通过 (${report.totals.warn} warn / ${report.totals.pass} pass)`
         : `doctor failed: ${report.totals.fail} skills did not pass (${report.totals.warn} warn / ${report.totals.pass} pass)`;
@@ -643,7 +643,7 @@ async function handleDoctor(argv: string[]): Promise<void> {
     renderDoctorReportText(report, lang);
   }
 
-  process.exit(report.failed ? 1 : 0);
+  process.exit(report.outcome === 'failed' ? 1 : 0);
 }
 
 async function handleAnalyze(argv: string[]): Promise<void> {

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -4,7 +4,7 @@
  * runDoctor() 接受 target(单文件 / 目录 / null=cwd 默认),解析出 Artifact 列表,
  * 对每个 artifact 顺序跑全部 rules,聚合为 DoctorReport。
  *
- * fatal-fail 不中断后续 rule 执行(让用户一次看到全貌),但 report.failed=true,
+ * fatal-fail 不中断后续 rule 执行(让用户一次看到全貌),但 report.outcome='failed',
  * CLI 据此 exit 1 / abort bench run。
  */
 
@@ -197,11 +197,13 @@ export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
     }
   }
 
-  const failed = totals.fail > 0;
-  const warned = totals.warn > 0;
   // Single-enum verdict for CI / agent code. fatal-fail dominates;
   // warnings_only when no fatal-fail but at least one warn; otherwise passed.
-  const outcome: DoctorOutcome = failed ? 'failed' : (warned ? 'warnings_only' : 'passed');
+  const outcome: DoctorOutcome = totals.fail > 0
+    ? 'failed'
+    : totals.warn > 0
+      ? 'warnings_only'
+      : 'passed';
 
   return {
     kind: 'doctor',
@@ -214,8 +216,6 @@ export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
     model: opts.model,
     skills: skillReports,
     outcome,
-    failed,
-    warned,
     totals,
     ruleStats,
   };

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -14,6 +14,7 @@ import { discoverVariants, resolveArtifacts } from '../inputs/skill-loader.js';
 import type {
   Artifact,
   DoctorContext,
+  DoctorOutcome,
   DoctorReport,
   DoctorRule,
   DoctorRuleResult,
@@ -21,6 +22,7 @@ import type {
   DoctorSkillReport,
   DoctorSkillStatus,
 } from '../types/index.js';
+import { DOCTOR_REPORT_SCHEMA_VERSION } from '../types/doctor.js';
 import { getRegisteredRules } from './rules.js';
 
 // ---------------------------------------------------------------------------
@@ -177,6 +179,7 @@ export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
 
   const skillReports: DoctorSkillReport[] = [];
   const totals = { pass: 0, warn: 0, fail: 0 };
+  const ruleStats = { pass: 0, warn: 0, fail: 0, skipped: 0, total: 0 };
 
   for (const artifact of artifacts) {
     const results = await runRulesOnArtifact(artifact, effectiveRules, ctxBase);
@@ -188,10 +191,21 @@ export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
       status,
     });
     totals[status] += 1;
+    for (const r of results) {
+      ruleStats[r.status] += 1;
+      ruleStats.total += 1;
+    }
   }
+
+  const failed = totals.fail > 0;
+  const warned = totals.warn > 0;
+  // Single-enum verdict for CI / agent code. fatal-fail dominates;
+  // warnings_only when no fatal-fail but at least one warn; otherwise passed.
+  const outcome: DoctorOutcome = failed ? 'failed' : (warned ? 'warnings_only' : 'passed');
 
   return {
     kind: 'doctor',
+    schemaVersion: DOCTOR_REPORT_SCHEMA_VERSION,
     id: nextReportId(),
     timestamp: new Date().toISOString(),
     cliVersion: readCliVersion(),
@@ -199,8 +213,10 @@ export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
     executorName: opts.executorName,
     model: opts.model,
     skills: skillReports,
-    failed: totals.fail > 0,
-    warned: totals.warn > 0,
+    outcome,
+    failed,
+    warned,
     totals,
+    ruleStats,
   };
 }

--- a/src/doctor/rules.ts
+++ b/src/doctor/rules.ts
@@ -79,12 +79,17 @@ export const skillReadableRule: DoctorRule = {
   labelKey: 'cli.doctor.rule.skill_readable',
   async check(ctx: DoctorContext): Promise<DoctorRuleCheckOutcome> {
     const content = ctx.artifact.content;
+    // Echo the path that was tried, so the hint is concretely actionable
+    // (CI / agent and humans both see exactly where to look).
+    const triedPath = ctx.artifact.locator
+      ?? ctx.artifact.skillRoot
+      ?? `<inline:${ctx.artifact.name}>`;
     if (content === null || content === undefined) {
       return {
         status: 'fail',
         message: tCli('cli.doctor.skill_readable.fail.missing', ctx.lang),
-        hint: tCli('cli.doctor.skill_readable.hint.missing', ctx.lang),
-        detail: { length: 0 },
+        hint: tCli('cli.doctor.skill_readable.hint.missing', ctx.lang, { path: triedPath }),
+        detail: { length: 0, triedPath },
       };
     }
     const trimmed = content.trim();
@@ -92,8 +97,8 @@ export const skillReadableRule: DoctorRule = {
       return {
         status: 'fail',
         message: tCli('cli.doctor.skill_readable.fail.empty', ctx.lang),
-        hint: tCli('cli.doctor.skill_readable.hint.missing', ctx.lang),
-        detail: { length: 0 },
+        hint: tCli('cli.doctor.skill_readable.hint.missing', ctx.lang, { path: triedPath }),
+        detail: { length: 0, triedPath },
       };
     }
     if (trimmed.length < SKILL_MIN_LENGTH) {
@@ -162,10 +167,18 @@ export const dependenciesPresentRule: DoctorRule = {
     );
     if (!result.ok) {
       const summary = summarizeDependencyIssues(result.missing, ctx.lang);
+      // Build hint conditionally so users only see fix advice for categories
+      // that actually have missing items. Generic header + per-category lines.
+      const hintParts: string[] = [tCli('cli.doctor.dependencies.hint', ctx.lang)];
+      const counts = { tool: 0, file: 0, env: 0 };
+      for (const m of result.missing) counts[m.category] += 1;
+      if (counts.tool > 0) hintParts.push(tCli('cli.doctor.dependencies.hint.tool', ctx.lang));
+      if (counts.file > 0) hintParts.push(tCli('cli.doctor.dependencies.hint.file', ctx.lang));
+      if (counts.env > 0) hintParts.push(tCli('cli.doctor.dependencies.hint.env', ctx.lang));
       return {
         status: 'fail',
         message: tCli('cli.doctor.dependencies.fail', ctx.lang, { summary }),
-        hint: tCli('cli.doctor.dependencies.hint', ctx.lang),
+        hint: hintParts.join('; '),
         detail: { missing: result.missing },
       };
     }

--- a/src/doctor/rules.ts
+++ b/src/doctor/rules.ts
@@ -55,16 +55,32 @@ function checkFrontmatter(content: string): { ok: boolean; error?: string } {
 }
 
 function summarizeDependencyIssues(missing: DependencyIssue[], lang: 'zh' | 'en'): string {
-  const counts = { tool: 0, file: 0, env: 0 };
+  const counts = { tool: 0, file: 0, env: 0, preflight: 0 };
   for (const m of missing) counts[m.category] += 1;
   const parts: string[] = [];
   const labels = lang === 'zh'
-    ? { tool: '工具', file: '文件', env: '环境变量' }
-    : { tool: 'tool', file: 'file', env: 'env' };
+    ? { tool: '工具', file: '文件', env: '环境变量', preflight: 'preflight' }
+    : { tool: 'tool', file: 'file', env: 'env', preflight: 'preflight' };
   if (counts.tool > 0) parts.push(`${counts.tool} ${labels.tool}`);
   if (counts.file > 0) parts.push(`${counts.file} ${labels.file}`);
   if (counts.env > 0) parts.push(`${counts.env} ${labels.env}`);
+  if (counts.preflight > 0) parts.push(`${counts.preflight} ${labels.preflight}`);
   return parts.join(', ') || (lang === 'zh' ? '未知' : 'unknown');
+}
+
+function renderIssue(issue: DependencyIssue, lang: 'zh' | 'en'): string {
+  const params: Record<string, string | number> = { name: issue.name };
+  if (issue.reasonDetail) params.detail = issue.reasonDetail;
+  switch (issue.reasonCode) {
+    case 'tool_not_found':
+      return tCli('cli.doctor.dependencies.issue.tool_not_found', lang, params);
+    case 'file_not_found':
+      return tCli('cli.doctor.dependencies.issue.file_not_found', lang, params);
+    case 'env_not_set':
+      return tCli('cli.doctor.dependencies.issue.env_not_set', lang, params);
+    case 'preflight_failed':
+      return tCli('cli.doctor.dependencies.issue.preflight_failed', lang, params);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -167,20 +183,18 @@ export const dependenciesPresentRule: DoctorRule = {
     );
     if (!result.ok) {
       const summary = summarizeDependencyIssues(result.missing, ctx.lang);
-      // Build hint as: generic header + per-category fix advice + each issue's
-      // own specific hint when present. The per-issue hint matters most for
-      // preflight failures (dependency-checker tags them as category='tool' but
-      // attaches the actual command + stderr in DependencyIssue.hint) — generic
-      // "install on PATH" advice would mislead users away from the real cause.
-      const hintParts: string[] = [tCli('cli.doctor.dependencies.hint', ctx.lang)];
-      const counts = { tool: 0, file: 0, env: 0 };
+      // Hint composition: per-issue translated reason (carries the specific stderr /
+      // path / cmd via reasonDetail) + per-category fix advice. The per-issue line
+      // is what tells the user *what* failed; the category advice tells them *how*
+      // to fix the class of failure.
+      const hintParts: string[] = [];
+      for (const m of result.missing) hintParts.push(renderIssue(m, ctx.lang));
+      const counts = { tool: 0, file: 0, env: 0, preflight: 0 };
       for (const m of result.missing) counts[m.category] += 1;
       if (counts.tool > 0) hintParts.push(tCli('cli.doctor.dependencies.hint.tool', ctx.lang));
       if (counts.file > 0) hintParts.push(tCli('cli.doctor.dependencies.hint.file', ctx.lang));
       if (counts.env > 0) hintParts.push(tCli('cli.doctor.dependencies.hint.env', ctx.lang));
-      for (const m of result.missing) {
-        if (m.hint) hintParts.push(m.hint);
-      }
+      if (counts.preflight > 0) hintParts.push(tCli('cli.doctor.dependencies.hint.preflight', ctx.lang));
       return {
         status: 'fail',
         message: tCli('cli.doctor.dependencies.fail', ctx.lang, { summary }),

--- a/src/doctor/rules.ts
+++ b/src/doctor/rules.ts
@@ -11,7 +11,7 @@
  *   - samples_contract: 仅在传 samples 时跑,warn 级,校验 samples 非空 + 含 prompt
  *
  * fatal-fail 时 rule 引擎不中断后续 rule 执行(让用户一次看到全貌),
- * 但 DoctorReport.failed 会置 true。
+ * 但 DoctorReport.outcome 会置 'failed'。
  *
  * 扩展接口预留: registerRule() 允许业务方注入自定义 rule(v0.22 不暴露 CLI flag,
  * 仅作为 library API 占位)。

--- a/src/doctor/rules.ts
+++ b/src/doctor/rules.ts
@@ -167,14 +167,20 @@ export const dependenciesPresentRule: DoctorRule = {
     );
     if (!result.ok) {
       const summary = summarizeDependencyIssues(result.missing, ctx.lang);
-      // Build hint conditionally so users only see fix advice for categories
-      // that actually have missing items. Generic header + per-category lines.
+      // Build hint as: generic header + per-category fix advice + each issue's
+      // own specific hint when present. The per-issue hint matters most for
+      // preflight failures (dependency-checker tags them as category='tool' but
+      // attaches the actual command + stderr in DependencyIssue.hint) — generic
+      // "install on PATH" advice would mislead users away from the real cause.
       const hintParts: string[] = [tCli('cli.doctor.dependencies.hint', ctx.lang)];
       const counts = { tool: 0, file: 0, env: 0 };
       for (const m of result.missing) counts[m.category] += 1;
       if (counts.tool > 0) hintParts.push(tCli('cli.doctor.dependencies.hint.tool', ctx.lang));
       if (counts.file > 0) hintParts.push(tCli('cli.doctor.dependencies.hint.file', ctx.lang));
       if (counts.env > 0) hintParts.push(tCli('cli.doctor.dependencies.hint.env', ctx.lang));
+      for (const m of result.missing) {
+        if (m.hint) hintParts.push(m.hint);
+      }
       return {
         status: 'fail',
         message: tCli('cli.doctor.dependencies.fail', ctx.lang, { summary }),

--- a/src/eval-core/dependency-checker.ts
+++ b/src/eval-core/dependency-checker.ts
@@ -22,10 +22,22 @@ export interface DependencyRequirements {
   preflight?: string[];
 }
 
+export type DependencyReasonCode =
+  | 'tool_not_found'
+  | 'file_not_found'
+  | 'env_not_set'
+  | 'preflight_failed';
+
 export interface DependencyIssue {
-  category: 'tool' | 'file' | 'env';
+  category: 'tool' | 'file' | 'env' | 'preflight';
   name: string;
-  hint: string;
+  /** Stable enum so consumers (doctor, eval-pipeline) translate per their own lang.
+   *  The dep-checker itself never produces user-facing strings — it only carries facts. */
+  reasonCode: DependencyReasonCode;
+  /** Optional untranslated raw context: stderr line, cwd, command — surfaces at the
+   *  consumer's UI layer so the actual failure is visible without round-tripping the
+   *  process. Never localized; pass through verbatim. */
+  reasonDetail?: string;
 }
 
 export interface DependencyCheckResult {
@@ -221,7 +233,7 @@ export async function checkDependencies(
       missing.push({
         category: 'tool',
         name: tool,
-        hint: `未找到，请确认已安装并在 PATH 中`,
+        reasonCode: 'tool_not_found',
       });
     }
   }
@@ -233,7 +245,8 @@ export async function checkDependencies(
       missing.push({
         category: 'file',
         name: file,
-        hint: `文件不存在 (cwd: ${cwd})`,
+        reasonCode: 'file_not_found',
+        reasonDetail: cwd,
       });
     }
   }
@@ -244,7 +257,7 @@ export async function checkDependencies(
       missing.push({
         category: 'env',
         name: envVar,
-        hint: '未设置',
+        reasonCode: 'env_not_set',
       });
     }
   }
@@ -306,11 +319,18 @@ function runPreflightCommands(commands: string[], cwd: string, env?: NodeJS.Proc
         timeout: PREFLIGHT_TIMEOUT_MS,
       });
     } catch (err: unknown) {
-      const detail = err instanceof Error ? err.message.split('\n')[0] : 'unknown error';
+      // execSync error message is "Command failed: <cmd>\n<stderr>" — splitting by
+      // newline and keeping line 0 drops stderr. Prefer err.stderr directly so
+      // the actual failure cause (e.g. `BAD` from `sh -c "echo BAD >&2; exit 2"`)
+      // reaches the user.
+      const errObj = err as { stderr?: Buffer | string; message?: string };
+      const stderrText = errObj.stderr ? errObj.stderr.toString().trim() : '';
+      const reasonDetail = stderrText || (errObj.message ?? 'unknown error');
       issues.push({
-        category: 'tool',
+        category: 'preflight',
         name: cmd,
-        hint: `preflight 命令执行失败: ${detail}`,
+        reasonCode: 'preflight_failed',
+        reasonDetail,
       });
     }
   }
@@ -334,7 +354,8 @@ function checkFilesByBase(filesByBase: Map<string, Set<string>>): DependencyIssu
         missing.push({
           category: 'file',
           name: file,
-          hint: `文件不存在 (cwd: ${baseDir})`,
+          reasonCode: 'file_not_found',
+          reasonDetail: baseDir,
         });
       }
     }
@@ -389,28 +410,3 @@ export async function preflightDependencies(
   return result;
 }
 
-// ---------------------------------------------------------------------------
-// Formatting
-// ---------------------------------------------------------------------------
-
-export function formatDependencyErrors(missing: DependencyIssue[]): string {
-  const lines: string[] = ['前置依赖检查失败:\n'];
-
-  const byCategory = { tool: [] as DependencyIssue[], file: [] as DependencyIssue[], env: [] as DependencyIssue[] };
-  for (const issue of missing) {
-    byCategory[issue.category].push(issue);
-  }
-
-  const labels: Record<string, string> = { tool: '工具缺失', file: '文件缺失', env: '环境变量缺失' };
-  for (const [cat, issues] of Object.entries(byCategory)) {
-    if (issues.length === 0) continue;
-    lines.push(`  ${labels[cat]}:`);
-    for (const issue of issues) {
-      lines.push(`    ✗ ${issue.name} — ${issue.hint}`);
-    }
-    lines.push('');
-  }
-
-  lines.push('提示: 安装缺失的工具/文件/环境变量后重跑;依赖检查由 doctor 负责,无 skip flag。');
-  return lines.join('\n');
-}

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -239,7 +239,7 @@ export async function runEvaluation({
         timeoutMs: timeoutMs ?? 8000,
         lang,
       });
-      if (doctorReport.failed) {
+      if (doctorReport.outcome === 'failed') {
         renderDoctorReportText(doctorReport, lang);
         throw new Error(`doctor failed: ${tCli('cli.doctor.gate_blocked', lang)}`);
       }

--- a/src/types/doctor.ts
+++ b/src/types/doctor.ts
@@ -5,12 +5,10 @@ export type DoctorSeverity = 'fatal' | 'warn' | 'info';
 export type DoctorRuleStatus = 'pass' | 'warn' | 'fail' | 'skipped';
 export type DoctorSkillStatus = 'pass' | 'warn' | 'fail';
 
-/** Single-enum CI verdict. CI / agent code can switch on this directly instead
- *  of combining `failed` + `warned`. Mapping:
- *    'failed'        — at least one skill has fatal-fail
- *    'warnings_only' — no fatal-fail but at least one skill has warn
- *    'passed'        — all skills pass cleanly
- *  Coexists with the existing boolean flags for backward compat. */
+/** Single-enum CI verdict. Switch on this directly:
+ *    'failed'        — at least one skill has fatal-fail (CLI exits 1, bench run aborts)
+ *    'warnings_only' — no fatal-fail but at least one skill has warn (informational)
+ *    'passed'        — all skills pass cleanly */
 export type DoctorOutcome = 'passed' | 'warnings_only' | 'failed';
 
 /** Bumped whenever DoctorReport schema changes in a way CI consumers should
@@ -82,21 +80,15 @@ export interface DoctorReport {
   executorName: string;
   model: string;
   skills: DoctorSkillReport[];
-  /** Single-enum CI verdict. Prefer this over reading `failed` + `warned` separately. */
+  /** Single-enum CI verdict. CLI exits 1 iff `outcome === 'failed'`. */
   outcome: DoctorOutcome;
-  /** 至少一个 skill 有 fatal-fail。CLI exit 1 / bench run abort 的判断依据。
-   *  Kept for backward compat with consumers written before `outcome` existed. */
-  failed: boolean;
-  /** 至少一个 skill 有 warn(无 fail)。不阻断,仅提示。
-   *  Kept for backward compat. */
-  warned: boolean;
-  /** Per-skill outcome counts (each skill contributes exactly once).
+  /** Per-skill outcome counts (each skill contributes exactly once based on its worst rule).
    *  `skills.length === totals.pass + totals.warn + totals.fail`. */
   totals: { pass: number; warn: number; fail: number };
-  /** Per-rule outcome counts across all skills. Useful when CI wants to know
-   *  how much of the doctor surface actually ran (e.g. how many rules ended up
-   *  `skipped` because samples were not provided). `total` is provided for
-   *  convenience and equals pass+warn+fail+skipped. */
+  /** Per-rule outcome counts across all skills. Different granularity from `totals` —
+   *  CI uses this to know how much of the doctor surface actually ran (e.g. how many
+   *  rules ended up `skipped` because samples were not provided). `total` equals
+   *  pass+warn+fail+skipped. */
   ruleStats: { pass: number; warn: number; fail: number; skipped: number; total: number };
 }
 

--- a/src/types/doctor.ts
+++ b/src/types/doctor.ts
@@ -5,6 +5,18 @@ export type DoctorSeverity = 'fatal' | 'warn' | 'info';
 export type DoctorRuleStatus = 'pass' | 'warn' | 'fail' | 'skipped';
 export type DoctorSkillStatus = 'pass' | 'warn' | 'fail';
 
+/** Single-enum CI verdict. CI / agent code can switch on this directly instead
+ *  of combining `failed` + `warned`. Mapping:
+ *    'failed'        — at least one skill has fatal-fail
+ *    'warnings_only' — no fatal-fail but at least one skill has warn
+ *    'passed'        — all skills pass cleanly
+ *  Coexists with the existing boolean flags for backward compat. */
+export type DoctorOutcome = 'passed' | 'warnings_only' | 'failed';
+
+/** Bumped whenever DoctorReport schema changes in a way CI consumers should
+ *  be able to detect. CI can pin/check this when parsing the JSON. */
+export const DOCTOR_REPORT_SCHEMA_VERSION = '1.0.0';
+
 export interface DoctorRuleResult {
   ruleId: string;
   severity: DoctorSeverity;
@@ -60,6 +72,9 @@ export interface DoctorSkillReport {
 
 export interface DoctorReport {
   kind: 'doctor';
+  /** Schema version the JSON consumer can pin/check. Bumped on any
+   *  user-visible change to this report's shape. See DOCTOR_REPORT_SCHEMA_VERSION. */
+  schemaVersion: string;
   id: string;
   timestamp: string;
   cliVersion: string;
@@ -67,11 +82,22 @@ export interface DoctorReport {
   executorName: string;
   model: string;
   skills: DoctorSkillReport[];
-  /** 至少一个 skill 有 fatal-fail。CLI exit 1 / bench run abort 的判断依据。 */
+  /** Single-enum CI verdict. Prefer this over reading `failed` + `warned` separately. */
+  outcome: DoctorOutcome;
+  /** 至少一个 skill 有 fatal-fail。CLI exit 1 / bench run abort 的判断依据。
+   *  Kept for backward compat with consumers written before `outcome` existed. */
   failed: boolean;
-  /** 至少一个 skill 有 warn(无 fail)。不阻断,仅提示。 */
+  /** 至少一个 skill 有 warn(无 fail)。不阻断,仅提示。
+   *  Kept for backward compat. */
   warned: boolean;
+  /** Per-skill outcome counts (each skill contributes exactly once).
+   *  `skills.length === totals.pass + totals.warn + totals.fail`. */
   totals: { pass: number; warn: number; fail: number };
+  /** Per-rule outcome counts across all skills. Useful when CI wants to know
+   *  how much of the doctor surface actually ran (e.g. how many rules ended up
+   *  `skipped` because samples were not provided). `total` is provided for
+   *  convenience and equals pass+warn+fail+skipped. */
+  ruleStats: { pass: number; warn: number; fail: number; skipped: number; total: number };
 }
 
 export interface DoctorRunOptions {

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -45,7 +45,7 @@ describe('omk doctor CLI', () => {
     assert.equal(parsed.kind, 'doctor');
     assert.ok(Array.isArray(parsed.skills));
     assert.ok(parsed.skills.length >= 1);
-    assert.equal(parsed.failed, false);
+    assert.equal(parsed.outcome, 'passed');
   });
 
   it('--json on directory batches all skills', async () => {

--- a/test/dependency-checker.test.ts
+++ b/test/dependency-checker.test.ts
@@ -8,7 +8,6 @@ import {
   extractFilesByBase,
   checkDependencies,
   preflightDependencies,
-  formatDependencyErrors,
 } from '../src/eval-core/dependency-checker.js';
 import type { Artifact, Sample } from '../src/types/index.js';
 
@@ -224,7 +223,9 @@ describe('preflightDependencies', () => {
       assert.ok(!result.ok);
       const fileIssue = result.missing.find((m) => m.category === 'file' && m.name.includes('missing.md'));
       assert.ok(fileIssue, '应报告 missing.md 文件缺失');
-      assert.ok(fileIssue!.hint.includes(join(root, 'skill-a')), `hint 应含 skillRoot 路径,实际:${fileIssue!.hint}`);
+      assert.equal(fileIssue!.reasonCode, 'file_not_found');
+      assert.equal(fileIssue!.reasonDetail, join(root, 'skill-a'),
+        `reasonDetail 应是 skillRoot 路径,实际:${fileIssue!.reasonDetail}`);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -258,23 +259,6 @@ describe('extractFilesByBase', () => {
     const map = extractFilesByBase(artifacts, '/default/cwd');
     assert.ok(map.get('/explicit')?.has('docs/a.md'));
     assert.equal(map.get('/default/cwd'), undefined);
-  });
-});
-
-describe('formatDependencyErrors', () => {
-  it('格式化输出包含分类标题和提示', () => {
-    const output = formatDependencyErrors([
-      { category: 'tool', name: 'foo-cli', hint: '未找到，请确认已安装并在 PATH 中' },
-      { category: 'file', name: 'scripts/commands.md', hint: '文件不存在' },
-      { category: 'env', name: 'FOO_TOKEN', hint: '未设置' },
-    ]);
-    assert.ok(output.includes('工具缺失'));
-    assert.ok(output.includes('foo-cli'));
-    assert.ok(output.includes('文件缺失'));
-    assert.ok(output.includes('scripts/commands.md'));
-    assert.ok(output.includes('环境变量缺失'));
-    assert.ok(output.includes('FOO_TOKEN'));
-    assert.ok(output.includes('安装缺失的工具') || output.includes('doctor'));
   });
 });
 

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -153,8 +153,7 @@ describe('runDoctor', () => {
     });
     assert.equal(report.kind, 'doctor');
     assert.ok(report.skills.length >= 2);
-    assert.equal(report.failed, false);
-    assert.equal(report.warned, false);
+    assert.equal(report.outcome, 'passed');
     assert.equal(report.totals.pass, report.skills.length);
     for (const skill of report.skills) {
       assert.equal(skill.status, 'pass');
@@ -163,7 +162,7 @@ describe('runDoctor', () => {
     }
   });
 
-  it('marks report.failed=true when any rule fails fatally', async () => {
+  it('marks outcome=failed when any rule fails fatally', async () => {
     const report = await runDoctor({
       target: EXAMPLE_SKILLS_DIR,
       cwd: '/tmp',
@@ -173,12 +172,11 @@ describe('runDoctor', () => {
       lang: 'zh',
       rules: [failingRule],
     });
-    assert.equal(report.failed, true);
-    assert.equal(report.warned, false);
+    assert.equal(report.outcome, 'failed');
     assert.ok(report.totals.fail >= 1);
   });
 
-  it('marks report.warned=true (not failed) when only warn rules trigger', async () => {
+  it('marks outcome=warnings_only when only warn rules trigger (no fatal-fail)', async () => {
     const report = await runDoctor({
       target: EXAMPLE_SKILLS_DIR,
       cwd: '/tmp',
@@ -188,8 +186,7 @@ describe('runDoctor', () => {
       lang: 'zh',
       rules: [warningRule],
     });
-    assert.equal(report.failed, false);
-    assert.equal(report.warned, true);
+    assert.equal(report.outcome, 'warnings_only');
   });
 
   it('catches rule exceptions and marks as fail rather than crashing the engine', async () => {
@@ -202,7 +199,7 @@ describe('runDoctor', () => {
       lang: 'zh',
       rules: [crashingRule],
     });
-    assert.equal(report.failed, true);
+    assert.equal(report.outcome, 'failed');
     for (const skill of report.skills) {
       assert.equal(skill.results[0].status, 'fail');
       assert.ok(skill.results[0].message.includes('rule crashed'));
@@ -240,8 +237,7 @@ describe('runDoctor', () => {
         rules: [passingRule],
       });
       assert.equal(report.skills.length, 0);
-      assert.equal(report.failed, false);
-      assert.equal(report.warned, false);
+      assert.equal(report.outcome, 'passed');
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -292,7 +288,7 @@ describe('runDoctor', () => {
     });
     assert.equal(report.skills.length, 1);
     assert.equal(report.skills[0].skillName, 'inline-fixture');
-    assert.equal(report.failed, false);
+    assert.equal(report.outcome, 'passed');
   });
 
   it('default rules include both BUILTIN_RULES and registerRule()-injected custom rules', async () => {
@@ -362,8 +358,7 @@ describe('runDoctor', () => {
       lang: 'zh',
     });
     assert.equal(report.skills.length, 0);
-    assert.equal(report.failed, false);
-    assert.equal(report.warned, false);
+    assert.equal(report.outcome, 'passed');
   });
 
   it('opts.artifacts undefined falls back to target resolution (preserves omk doctor [path] UX)', async () => {
@@ -535,8 +530,6 @@ describe('DoctorReport — CI-friendly schema fields', () => {
       rules: [passingRule],
     });
     assert.equal(report.outcome, 'passed');
-    assert.equal(report.failed, false);
-    assert.equal(report.warned, false);
   });
 
   it('outcome="warnings_only" when only warn rules trigger (no fatal-fail)', async () => {
@@ -550,8 +543,6 @@ describe('DoctorReport — CI-friendly schema fields', () => {
       rules: [warningRule],
     });
     assert.equal(report.outcome, 'warnings_only');
-    assert.equal(report.failed, false);
-    assert.equal(report.warned, true);
   });
 
   it('outcome="failed" when any rule fails fatally (dominates warns)', async () => {
@@ -565,7 +556,6 @@ describe('DoctorReport — CI-friendly schema fields', () => {
       rules: [failingRule, warningRule],
     });
     assert.equal(report.outcome, 'failed');
-    assert.equal(report.failed, true);
   });
 
   it('ruleStats counts each rule outcome across all skills, including skipped', async () => {

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -48,6 +48,15 @@ const crashingRule: DoctorRule = {
   },
 };
 
+const skippedRule: DoctorRule = {
+  id: 'test_skipped',
+  severity: 'warn',
+  labelKey: 'cli.doctor.rule.skill_readable',
+  async check() {
+    return { status: 'skipped', message: 'preconditions not met' };
+  },
+};
+
 describe('resolveDoctorTargets', () => {
   it('resolves all variants in a directory', () => {
     const artifacts = resolveDoctorTargets(EXAMPLE_SKILLS_DIR, '/tmp');
@@ -497,5 +506,117 @@ describe('runDoctor', () => {
       rmSync(tmpArtifactCwd, { recursive: true, force: true });
       rmSync(tmpOptsDepCwd, { recursive: true, force: true });
     }
+  });
+});
+
+describe('DoctorReport — CI-friendly schema fields', () => {
+  it('stamps schemaVersion on every report (CI can pin/check)', async () => {
+    const report = await runDoctor({
+      target: EXAMPLE_SKILLS_DIR,
+      cwd: '/tmp',
+      executorName: 'claude',
+      model: 'sonnet',
+      timeoutMs: 8000,
+      lang: 'zh',
+      rules: [passingRule],
+    });
+    assert.equal(typeof report.schemaVersion, 'string');
+    assert.match(report.schemaVersion, /^\d+\.\d+\.\d+$/);
+  });
+
+  it('outcome="passed" when all skills pass cleanly', async () => {
+    const report = await runDoctor({
+      target: EXAMPLE_SKILLS_DIR,
+      cwd: '/tmp',
+      executorName: 'claude',
+      model: 'sonnet',
+      timeoutMs: 8000,
+      lang: 'zh',
+      rules: [passingRule],
+    });
+    assert.equal(report.outcome, 'passed');
+    assert.equal(report.failed, false);
+    assert.equal(report.warned, false);
+  });
+
+  it('outcome="warnings_only" when only warn rules trigger (no fatal-fail)', async () => {
+    const report = await runDoctor({
+      target: EXAMPLE_SKILLS_DIR,
+      cwd: '/tmp',
+      executorName: 'claude',
+      model: 'sonnet',
+      timeoutMs: 8000,
+      lang: 'zh',
+      rules: [warningRule],
+    });
+    assert.equal(report.outcome, 'warnings_only');
+    assert.equal(report.failed, false);
+    assert.equal(report.warned, true);
+  });
+
+  it('outcome="failed" when any rule fails fatally (dominates warns)', async () => {
+    const report = await runDoctor({
+      target: EXAMPLE_SKILLS_DIR,
+      cwd: '/tmp',
+      executorName: 'claude',
+      model: 'sonnet',
+      timeoutMs: 8000,
+      lang: 'zh',
+      rules: [failingRule, warningRule],
+    });
+    assert.equal(report.outcome, 'failed');
+    assert.equal(report.failed, true);
+  });
+
+  it('ruleStats counts each rule outcome across all skills, including skipped', async () => {
+    const report = await runDoctor({
+      target: EXAMPLE_SKILLS_DIR,
+      cwd: '/tmp',
+      executorName: 'claude',
+      model: 'sonnet',
+      timeoutMs: 8000,
+      lang: 'zh',
+      rules: [passingRule, warningRule, skippedRule],
+    });
+    const skillCount = report.skills.length;
+    assert.equal(report.ruleStats.pass, skillCount);
+    assert.equal(report.ruleStats.warn, skillCount);
+    assert.equal(report.ruleStats.skipped, skillCount);
+    assert.equal(report.ruleStats.fail, 0);
+    assert.equal(report.ruleStats.total, skillCount * 3);
+    assert.equal(
+      report.ruleStats.total,
+      report.ruleStats.pass + report.ruleStats.warn + report.ruleStats.fail + report.ruleStats.skipped,
+      'total must equal sum of statuses',
+    );
+  });
+
+  it('totals (per-skill) and ruleStats (per-rule) report different granularities', async () => {
+    // 1 skill with 1 pass + 1 warn rule:
+    //   - per-skill outcome = warn (the worst non-fail outcome on the skill)
+    //   - per-rule stats: pass=1, warn=1
+    // This test pins the contract that totals != ruleStats by design.
+    const inlineArtifact: Artifact = {
+      name: 'inline-mixed',
+      kind: 'skill',
+      source: 'inline',
+      content: '你是一个测试 skill,内容长度足够通过 readable rule。',
+    };
+    const report = await runDoctor({
+      artifacts: [inlineArtifact],
+      cwd: '/tmp',
+      executorName: 'claude',
+      model: 'sonnet',
+      timeoutMs: 8000,
+      lang: 'zh',
+      rules: [passingRule, warningRule],
+    });
+    assert.equal(report.skills.length, 1);
+    assert.equal(report.totals.pass, 0, 'skill outcome rolls up to warn, not pass');
+    assert.equal(report.totals.warn, 1);
+    assert.equal(report.ruleStats.pass, 1, 'per-rule pass count is unaffected by roll-up');
+    assert.equal(report.ruleStats.warn, 1);
+    assert.equal(report.ruleStats.total, 2);
+    assert.equal(report.outcome, 'warnings_only');
   });
 });

--- a/test/doctor/rules.test.ts
+++ b/test/doctor/rules.test.ts
@@ -202,6 +202,25 @@ describe('dependenciesPresentRule', () => {
     assert.match(r.hint ?? '', /shell profile|CI secrets|环境变量缺失|missing env/);
     assert.doesNotMatch(r.hint ?? '', /requires\.tools|工具缺失|missing tool/);
   });
+
+  it('preflight failure echoes specific command/stderr from DependencyIssue.hint', async () => {
+    // dependency-checker tags preflight failures as category='tool' but stuffs
+    // the failing command + stderr into DependencyIssue.hint. Doctor must
+    // surface that — generic "install on PATH" would mislead away from the
+    // real cause (the command itself failed, not a missing binary).
+    const skill = sampleSkill({
+      content: `---\npreflight:\n  - "false"\n---\n\n你是一个测试 skill,内容长度足够通过 readable rule。`,
+      // 让 metadata.preflight 被 skill-loader 解析出来:模拟 file-skill 的 metadata 注入
+      metadata: { preflight: ['false'] },
+    });
+    const r = await dependenciesPresentRule.check(ctxWith(skill));
+    assert.equal(r.status, 'fail');
+    assert.match(r.hint ?? '', /preflight 命令执行失败|preflight command failed/);
+    // detail.missing 应保留原 issue 结构供 CI 直接读
+    const missing = (r.detail as { missing?: Array<{ hint?: string }> }).missing;
+    assert.ok(Array.isArray(missing) && missing.length > 0);
+    assert.ok(missing!.some((m) => m.hint?.includes('preflight')));
+  });
 });
 
 describe('samplesContractAlignedRule', () => {

--- a/test/doctor/rules.test.ts
+++ b/test/doctor/rules.test.ts
@@ -203,23 +203,54 @@ describe('dependenciesPresentRule', () => {
     assert.doesNotMatch(r.hint ?? '', /requires\.tools|工具缺失|missing tool/);
   });
 
-  it('preflight failure echoes specific command/stderr from DependencyIssue.hint', async () => {
-    // dependency-checker tags preflight failures as category='tool' but stuffs
-    // the failing command + stderr into DependencyIssue.hint. Doctor must
-    // surface that — generic "install on PATH" would mislead away from the
-    // real cause (the command itself failed, not a missing binary).
+  it('preflight failure surfaces command + reasonCode in localized hint', async () => {
+    // dep-checker emits structured DependencyIssue { category: 'preflight',
+    // reasonCode: 'preflight_failed', reasonDetail: <stderr> }. Doctor localizes
+    // it via ctx.lang. Generic "install on PATH" advice would mislead away from
+    // the real cause (the command itself failed, not a missing binary).
     const skill = sampleSkill({
       content: `---\npreflight:\n  - "false"\n---\n\n你是一个测试 skill,内容长度足够通过 readable rule。`,
-      // 让 metadata.preflight 被 skill-loader 解析出来:模拟 file-skill 的 metadata 注入
       metadata: { preflight: ['false'] },
     });
     const r = await dependenciesPresentRule.check(ctxWith(skill));
     assert.equal(r.status, 'fail');
-    assert.match(r.hint ?? '', /preflight 命令执行失败|preflight command failed/);
-    // detail.missing 应保留原 issue 结构供 CI 直接读
-    const missing = (r.detail as { missing?: Array<{ hint?: string }> }).missing;
+    assert.match(r.hint ?? '', /preflight 命令 "false" 执行失败/);
+    const missing = (r.detail as { missing?: Array<{ category?: string; reasonCode?: string }> }).missing;
     assert.ok(Array.isArray(missing) && missing.length > 0);
-    assert.ok(missing!.some((m) => m.hint?.includes('preflight')));
+    const pf = missing!.find((m) => m.reasonCode === 'preflight_failed');
+    assert.ok(pf, 'should carry preflight_failed reasonCode');
+    assert.equal(pf!.category, 'preflight');
+  });
+
+  it('preflight stderr is preserved in reasonDetail (not just truncated to "Command failed:")', async () => {
+    // execSync's err.message is "Command failed: <cmd>\n<stderr>" — splitting and
+    // keeping line 0 used to drop the actual stderr. Now we read err.stderr
+    // directly so the real cause reaches the user.
+    const stderrMarker = `OMK_PREFLIGHT_STDERR_TOKEN_${Date.now()}`;
+    const skill = sampleSkill({
+      content: '你是一个测试 skill,内容长度足够通过 readable rule。',
+      metadata: { preflight: [`sh -c 'echo ${stderrMarker} >&2; exit 2'`] },
+    });
+    const r = await dependenciesPresentRule.check(ctxWith(skill));
+    assert.equal(r.status, 'fail');
+    assert.ok(r.hint?.includes(stderrMarker),
+      `hint should carry the stderr line "${stderrMarker}"; got: ${r.hint}`);
+    const missing = (r.detail as { missing?: Array<{ reasonDetail?: string }> }).missing;
+    assert.ok(missing?.some((m) => m.reasonDetail?.includes(stderrMarker)));
+  });
+
+  it('--lang en hint contains no Chinese characters (i18n is structural, not pass-through)', async () => {
+    // Catches the bug where dep-checker leaked Chinese hint strings into doctor's
+    // localized hint. With reasonCode-driven translation, en stays pure-en.
+    const skill = sampleSkill({
+      content: '请运行 nonexistent-fake-cli-en 命令来分析数据。',
+    });
+    const r = await dependenciesPresentRule.check(ctxWith(skill, { lang: 'en' }));
+    assert.equal(r.status, 'fail');
+    assert.doesNotMatch(r.hint ?? '', /[一-鿿]/,
+      `en hint should contain no CJK chars; got: ${r.hint}`);
+    assert.doesNotMatch(r.message ?? '', /[一-鿿]/,
+      `en message should contain no CJK chars; got: ${r.message}`);
   });
 });
 

--- a/test/doctor/rules.test.ts
+++ b/test/doctor/rules.test.ts
@@ -67,6 +67,28 @@ describe('skillReadableRule', () => {
     })));
     assert.equal(r.status, 'pass');
   });
+
+  it('echoes the file path in the hint and detail when content is missing', async () => {
+    const r = await skillReadableRule.check(ctxWith(sampleSkill({
+      content: null,
+      locator: '/tmp/missing/skills/v1.md',
+    })));
+    assert.equal(r.status, 'fail');
+    assert.ok(r.hint?.includes('/tmp/missing/skills/v1.md'),
+      `hint should echo the tried path; got: ${r.hint}`);
+    assert.equal((r.detail as { triedPath?: string })?.triedPath, '/tmp/missing/skills/v1.md');
+  });
+
+  it('falls back to inline marker in the hint when artifact has no locator', async () => {
+    const r = await skillReadableRule.check(ctxWith(sampleSkill({
+      name: 'inline-anon',
+      source: 'inline',
+      content: null,
+      locator: undefined,
+    })));
+    assert.equal(r.status, 'fail');
+    assert.match(r.hint ?? '', /<inline:inline-anon>/);
+  });
 });
 
 describe('skillMetadataRule', () => {
@@ -156,6 +178,29 @@ describe('dependenciesPresentRule', () => {
     })));
     assert.equal(r.status, 'fail');
     assert.ok(Array.isArray((r.detail as { missing?: unknown[] }).missing));
+  });
+
+  it('hint mentions tool-fix advice when only a tool is missing (no file/env noise)', async () => {
+    const r = await dependenciesPresentRule.check(ctxWith(sampleSkill({
+      content: '请运行 nonexistent-fake-cli 命令来分析数据。',
+    })));
+    assert.equal(r.status, 'fail');
+    assert.match(r.hint ?? '', /requires\.tools|工具缺失|missing tool/);
+    // Should not surface unrelated category fixes when those categories have 0 items.
+    assert.doesNotMatch(r.hint ?? '', /requires\.files|文件缺失|missing file/);
+    assert.doesNotMatch(r.hint ?? '', /requires\.env|环境变量缺失|missing env/);
+  });
+
+  it('hint mentions env-fix advice when only an env var is required and missing', async () => {
+    // Surface env-only path: declare a required env var that isn't set.
+    const envName = `OMK_DOCTOR_TEST_NOT_SET_${Date.now()}`;
+    delete process.env[envName];
+    const r = await dependenciesPresentRule.check(ctxWith(sampleSkill(), {
+      requires: { env: [envName] },
+    }));
+    assert.equal(r.status, 'fail');
+    assert.match(r.hint ?? '', /shell profile|CI secrets|环境变量缺失|missing env/);
+    assert.doesNotMatch(r.hint ?? '', /requires\.tools|工具缺失|missing tool/);
   });
 });
 


### PR DESCRIPTION
## Summary

`omk doctor --json` 已存在并 work,本 PR 做 v0.26 onboarding 路线上的 polish:让 CI / agent 能更稳定 parse,让 fix hints 更具体可操作,让 i18n 真正干净。

跟 v0.26 分阶段计划里 "doctor 输出更可操作的 fix hints,并补强 doctor --json 给 agent / CI 使用" 这条对齐(详见 `docs/zh/roadmap.md` 的 v0.26 段)。

## 用户影响

**JSON 输出更稳**:每份报告带 `schemaVersion: '1.0.0'`,后续 schema 变化 bump 这个号,CI consumer 可以 pin。`outcome: 'passed' | 'warnings_only' | 'failed'` 作为单一 verdict enum,CI / agent 直接 switch 即可。新增 `ruleStats` 字段记录 per-rule 维度统计(pass / warn / fail / skipped / total)— 原 `totals` 只看 per-skill,看不到"多少 rule 实际跑了 / skipped",对评估 doctor 检查覆盖度不够用。

**Hints 更具体**:`skill_readable` 失败时 hint echo 文件 path 而不是 generic "请确认路径"。`dependencies` 失败时按 missing categories(tool / file / env / preflight)选对应 fix advice,不混不相关类别噪声;preflight 命令失败的具体 stderr 直接拼进 hint(原来被 `err.message.split('\n')[0]` 截掉了)。

**i18n 真干净**:`omk doctor --lang en` 之前会出英文 generic + 中文具体原因混语,因为 dep-checker 把 `hint` 文案硬编码成中文。现在 `DependencyIssue` 只带结构化 `reasonCode` + 未翻译的 `reasonDetail`(stderr / cwd),doctor 按 ctx.lang 自己渲染,en 路径不再漏中文。

## BREAKING

**`DoctorReport`** 删除冗余 `failed` / `warned` boolean,统一 `outcome` 三态 enum 表达 verdict。CI / agent 切换:`failed === true` → `outcome === 'failed'`;`warned === true` → `outcome === 'warnings_only'`。

**`DependencyIssue`** 删除 `hint: string`,改为 `reasonCode: 'tool_not_found' | 'file_not_found' | 'env_not_set' | 'preflight_failed'` + `reasonDetail?: string`(未翻译 raw 信息)。`category` 多一个 `'preflight'` 值。原 `formatDependencyErrors` 一并删除(无生产消费者)。

omk 还未稳定,优先选最干净的 schema 而非保留所有历史字段。`omk doctor --help` 的 `jq` 示例从 `.failed` 改成 `.outcome` 引导用户走推荐路径。

## 测量学不变量

不破坏:judge prompt hash / Report JSON schema / 5 层评分管道 / Bootstrap CI / Krippendorff α / Length-debias toggle 都没动。`DoctorReport` / `DependencyIssue` 是独立 schema,改动跟评测报告无关。

`schemaVersion: '1.0.0'` 标记当前 DoctorReport 形态为 v1 基线,后续任何 user-visible 字段变化都 bump 此版本号供 CI 检测。

## Defer 到 follow-up

`fixCommand` 字段(可执行 shell 命令)defer。涉及安全设计(避免 CI agent 自动执行破坏性命令),需要单独 spec PR 决定 rule 白名单 + 安全边界。

🤖 Generated with [Claude Code](https://claude.com/claude-code)