### PR TITLE
docs(readme): 压缩 README 首屏,主线收敛到 5 分钟出报告

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,30 +21,13 @@ omk answers with objective data, not gut feeling.
 ## Quick start
 
 ```bash
-# install
 npm i oh-my-knowledge -g
-
-# scaffold an eval project
-omk bench init my-eval
-cd my-eval
-
-# drop the artifacts you want to compare into skills/
-# option 1: plain .md files (skills/v1.md, skills/v2.md)
-# option 2: full artifact dirs (skills/my-skill-v1/SKILL.md, ...)
-# a single artifact also works — baseline is auto-added as control
-
-# preview the plan
-omk bench run --dry-run
-
-# run the evaluation (auto-discovers everything under skills/)
-omk bench run    # → HTML report with verdict in 5 minutes
-                 # (omk doctor + LLM connectivity check both run as mandatory gates;
-                 #  --skip-connectivity available for connectivity, doctor is unconditional)
-
-# CLI output language: zh (default) / en — flag wins over env
-omk bench run --lang en
-OMK_LANG=en omk bench report
+omk bench init my-eval && cd my-eval
+# edit skills/code-review-v1/SKILL.md and skills/code-review-v2/SKILL.md with your two versions
+omk bench run --control code-review-v1 --treatment code-review-v2    # → HTML report with verdict in 5 minutes
 ```
+
+Deeper: [use inside Claude Code / Codex](#use-inside-ai-coding-agents) · [`omk bench run` flags](#omk-bench-run) · [artifact directory layout](#artifact-directory-layout) · [`--lang` / `OMK_LANG`](#environment-variables)
 
 ## Use inside AI Coding Agents
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -21,30 +21,13 @@ omk 帮你用客观数据回答,而不是凭感觉。
 ## 快速开始
 
 ```bash
-# 安装
 npm i oh-my-knowledge -g
-
-# 生成评测项目脚手架
-omk bench init my-eval
-cd my-eval
-
-# 把要对比的 artifact 放到 skills/ 目录
-# 方式一：直接放 .md 文件（skills/v1.md, skills/v2.md）
-# 方式二：放完整 artifact 目录（skills/my-skill-v1/SKILL.md, ...）
-# 只放一个 artifact 也行，会自动加 baseline 对照
-
-# 预览评测计划
-omk bench run --dry-run
-
-# 运行评测（自动发现 skills/ 目录下的所有 artifact）
-omk bench run    # → 5 分钟出 HTML 报告 + verdict
-                 # （omk doctor 和 LLM 连通性检测都是强制前置门禁；
-                 #  --skip-connectivity 可跳连通性，doctor 无 skip flag）
-
-# CLI 输出语言: zh (默认) / en — flag 优先级高于环境变量
-omk bench run --lang en
-OMK_LANG=en omk bench report
+omk bench init my-eval && cd my-eval
+# 编辑 skills/code-review-v1/SKILL.md 和 skills/code-review-v2/SKILL.md,填入你的两版内容
+omk bench run --control code-review-v1 --treatment code-review-v2    # → 5 分钟出 HTML 报告 + verdict
 ```
+
+深入:[在 Claude Code / Codex 中调用](#在-ai-coding-agent-中使用) · [`omk bench run` 全 flag](#omk-bench-run) · [artifact 目录结构](#artifact-目录结构) · [`--lang` / `OMK_LANG`](#环境变量)
 
 ## 在 AI Coding Agent 中使用
 


### PR DESCRIPTION
## Summary

v0.26 onboarding 路线最后一条。旧 README 首屏(到 quick start 结束)49 行,塞 5 badge + 两段 tagline + statistical-rigor 引用 + 截图 + 30 行带注释 quick start。新用户要扫完才能开始,跟"5 分钟得到可信报告变成唯一主线"目标冲突。

## 用户影响

**首屏 49 行 → 32 行**(-35%)。

- tagline 两段保留(问句 hook + 框架定义),只去掉冗余装饰行
- quick start 从 27 行 bash + 6 段注释压到 4 行可直接执行的核心路径:install → init → 编辑两个 SKILL.md → `omk bench run --control code-review-v1 --treatment code-review-v2`,和 `omk bench init` 自带的 next-steps 完全一致
- dry-run / 方式二目录 / `--lang` / `OMK_LANG` / connectivity skip 等次要内容下移成一行 deeper 链接,指向已存在的 CLI 参考章节,不丢信息

**保留**:5 个 badge、statistical-rigor 引用块、报告截图、问句 hook tagline — 全在首屏不动。

中英两版同步改。

## 测量学不变量

无影响。纯 docs 改动,不动代码、不动 schema、不动 judge prompt、不动 CI 链条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)