### PR TITLE
docs(claude-md): 中文文案统一全角标点 + 回填 README.zh / docs/zh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ omk 是 LLM 评测框架。所有改动都要优先保护测量可比性。
 ## 写作规则
 
 - CLI / 报告 UI / 错误信息等 user-facing 文案中文优先。
-- 中文文案统一用全角标点 `，。：；！？（）「」`，符合 GB/T 15834《标点符号用法》。半角 `,.():` 只在以下技术混排里出现：代码块（``` ```）、inline code（`...`）、文件路径、命令行、URL、YAML/JSON frontmatter、数学区间（`[lo, hi]`）、citation 年份（`(2023)`）、`executor:model` 风格的标识符。范围：README.zh.md / docs/zh / SKILL.md / src 内 zh 字符串 / PR description / commit message 的中文 subject 部分。例外：commit 的 `type(scope):` 前缀是 Conventional Commits 语法保留半角，只有冒号后的中文 subject 走全角（写成 `docs(readme): 中文 subject`，不是 `docs（readme）：中文 subject`）。
+- 中文文案统一用全角标点 `，。：；！？（）「」`，符合 GB/T 15834《标点符号用法》。半角 `,.():` 只在以下技术混排里出现：代码块（``` ```）、inline code（`...`）、文件路径、命令行、URL、YAML/JSON frontmatter、数学区间（`[lo, hi]`）、citation 年份（`(2023)`）、`executor:model` 风格的标识符、英文术语 / 技术枚举的括注（如 `用例隔离(construct validity)`、`verdict(PROGRESS / ...)`、`omk 版本(reportMeta.cliVersion)`：括号内容是英文术语、API 字段、枚举值，半角更易复制粘贴）。范围：README.zh.md / docs/zh / SKILL.md / src 内 zh 字符串 / PR description / commit message 的中文 subject 部分。例外：commit 的 `type(scope):` 前缀是 Conventional Commits 语法保留半角，只有冒号后的中文 subject 走全角（写成 `docs(readme): 中文 subject`，不是 `docs（readme）：中文 subject`）。
 - LLM judge 译为 `评委`，不要译为 `判官`。
 - PR description 写用户影响、迁移说明、construct-validity 或测量学 caveat，链接相关 issue / 前置 PR。不要写行号、测试用例清单或嵌套实现细节 — 那些 git diff 里都有。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ omk 是 LLM 评测框架。所有改动都要优先保护测量可比性。
 ## 写作规则
 
 - CLI / 报告 UI / 错误信息等 user-facing 文案中文优先。
-- 中文文案统一用全角标点 `，。：；！？（）「」`，符合 GB/T 15834《标点符号用法》。半角 `,.():` 仅在代码块、命令行、文件路径、英文段落里出现。README.zh.md / docs/zh / SKILL.md / commit message subject / PR description 都按这条来。
+- 中文文案统一用全角标点 `，。：；！？（）「」`，符合 GB/T 15834《标点符号用法》。半角 `,.():` 只在以下技术混排里出现：代码块（``` ```）、inline code（`...`）、文件路径、命令行、URL、YAML/JSON frontmatter、数学区间（`[lo, hi]`）、citation 年份（`(2023)`）、`executor:model` 风格的标识符。范围：README.zh.md / docs/zh / SKILL.md / src 内 zh 字符串 / PR description / commit message 的中文 subject 部分。例外：commit 的 `type(scope):` 前缀是 Conventional Commits 语法保留半角，只有冒号后的中文 subject 走全角（写成 `docs(readme): 中文 subject`，不是 `docs（readme）：中文 subject`）。
 - LLM judge 译为 `评委`，不要译为 `判官`。
 - PR description 写用户影响、迁移说明、construct-validity 或测量学 caveat，链接相关 issue / 前置 PR。不要写行号、测试用例清单或嵌套实现细节 — 那些 git diff 里都有。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,13 +24,14 @@ omk 是 LLM 评测框架。所有改动都要优先保护测量可比性。
 - Bootstrap CI 和 Krippendorff alpha 公式。
 - Length-debias toggle 语义：`--no-debias-length` 与 prompt v2/v3 的对应关系。
 
-确实需要改不变量时，必须在 PR 标题 / description 明确标 `BREAKING-COMPARABILITY`(GitHub Release notes 会从 PR title 自动汇总),并按 `CONTRIBUTING.md` 的版本规则处理。
+确实需要改不变量时，必须在 PR 标题 / description 明确标 `BREAKING-COMPARABILITY`（GitHub Release notes 会从 PR title 自动汇总），并按 `CONTRIBUTING.md` 的版本规则处理。
 
 ## 写作规则
 
 - CLI / 报告 UI / 错误信息等 user-facing 文案中文优先。
+- 中文文案统一用全角标点 `，。：；！？（）「」`，符合 GB/T 15834《标点符号用法》。半角 `,.():` 仅在代码块、命令行、文件路径、英文段落里出现。README.zh.md / docs/zh / SKILL.md / commit message subject / PR description 都按这条来。
 - LLM judge 译为 `评委`，不要译为 `判官`。
-- PR description 写用户影响、迁移说明、construct-validity 或测量学 caveat,链接相关 issue / 前置 PR。不要写行号、测试用例清单或嵌套实现细节 — 那些 git diff 里都有。
+- PR description 写用户影响、迁移说明、construct-validity 或测量学 caveat，链接相关 issue / 前置 PR。不要写行号、测试用例清单或嵌套实现细节 — 那些 git diff 里都有。
 
 ## UI / Judge 改动
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -171,7 +171,7 @@ flowchart TD
 **关键设计：**
 
 - **交错调度**消除时间漂移：同一样本的不同 variant 交替发出，而非 v1 全跑完再跑 v2，避免模型负载/网络波动被错误归因给 artifact。
-- **variant = artifact + runtime context**:`name@cwd` 让对照组可以显式声明"项目目录"这个隐性输入，把"项目级沉淀"和"显式 artifact 注入"拆开测。
+- **variant = artifact + runtime context**：`name@cwd` 让对照组可以显式声明"项目目录"这个隐性输入，把"项目级沉淀"和"显式 artifact 注入"拆开测。
 - **双通道评分互补**：断言抓确定性缺陷（必须调用某工具/必须包含某字段），LLM 评委抓主观质量（可读性/完整性），两者都存在时取均值。
 - **知识缺口信号**不是评分的一部分，而是一个独立追踪项：它告诉你"这次评测覆盖了多少风险敞口"，用于追踪收敛，而非断言知识"完备"。
 
@@ -306,7 +306,7 @@ flowchart TD
 | `bleu_min` | BLEU-4 ≥ threshold（unsmoothed，短文本会塌陷到 0） |
 | `faithfulness` | 输出是否被 `sample.context` 支持（反幻觉）；LLM judge 1-5 评分，threshold 默认 3 |
 | `answer_relevancy` | 输出是否切题回答 `sample.prompt`；能抓住跑题、回避、冗余；threshold 默认 3 |
-| `context_recall` | `sample.context` 关键事实在输出中的覆盖率；`reference` 可显式指定 gold facts;threshold 默认 3 |
+| `context_recall` | `sample.context` 关键事实在输出中的覆盖率；`reference` 可显式指定 gold facts；threshold 默认 3 |
 | `semantic_similarity` | LLM 语义相似度（与 reference 的整体相似度，与 RAG 三 metric 互补） |
 | `custom` | 自定义 JS 函数（30s 超时） |
 
@@ -408,9 +408,9 @@ omk bench run [选项]
   --budget-per-sample-ms <num>   单样本耗时上限 (ms);超出该样本失败但评测继续
 ```
 
-**eval.yaml 预算字段**： `budget: { totalUSD?, perSampleUSD?, perSampleMs? }`，所有字段可选且必须 ≥ 0。CLI 同名 flag 覆盖配置值。
+**eval.yaml 预算字段**：`budget: { totalUSD?, perSampleUSD?, perSampleMs? }`，所有字段可选且必须 ≥ 0。CLI 同名 flag 覆盖配置值。
 
-**eval.yaml 实验设计字段**： 上面 CLI flag 同样可以写到 `eval.yaml` 让实验配置可复现 （CLI > eval.yaml > 默认）：
+**eval.yaml 实验设计字段**：上面 CLI flag 同样可以写到 `eval.yaml` 让实验配置可复现（CLI > eval.yaml > 默认）：
 
 ```yaml
 samples: ./eval-samples.yaml
@@ -431,9 +431,9 @@ variants:
   - { name: my-skill, role: treatment, artifact: ./skills/my-skill.md }
 ```
 
-**字段入口**： `bench run` 完整支持上述全部字段； `bench gate` 通过 `parseRunConfig` 共享 variants / executor / model / `judgeModels`（单评委 + ensemble 都生效）/ noJudge / noCache / blind / strictBaseline / budget / mcpConfig / variantAllowedSkills，但 `handleRun` 自己处理的实验设计字段(`repeat` / `judgeRepeat` / `bootstrap` / `bootstrapSamples` / `goldDir` / `lengthDebias`)gate 不读，后续按需扩展到 gate。其他子命令（`evolve` / `verdict` / `diff` / `analyze` 等）完全不读 eval.yaml。
+**字段入口**：`bench run` 完整支持上述全部字段；`bench gate` 通过 `parseRunConfig` 共享 variants / executor / model / `judgeModels`（单评委 + ensemble 都生效）/ noJudge / noCache / blind / strictBaseline / budget / mcpConfig / variantAllowedSkills，但 `handleRun` 自己处理的实验设计字段(`repeat` / `judgeRepeat` / `bootstrap` / `bootstrapSamples` / `goldDir` / `lengthDebias`)gate 不读，后续按需扩展到 gate。其他子命令（`evolve` / `verdict` / `diff` / `analyze` 等）完全不读 eval.yaml。
 
-**和 `cost_max` / `latency_max` 断言的区别**： 断言是**单样本评分维度**（超出直接打 0 分，run 继续）；budget 是**工作流级硬阈值**（`totalUSD` 超出整个 run abort 保留 partial report,per-sample 超出该样本失败但 run 继续）。一个回答"质量是否达标"，一个回答"花钱/时间是否在预算内"。
+**和 `cost_max` / `latency_max` 断言的区别**：断言是**单样本评分维度**（超出直接打 0 分，run 继续）；budget 是**工作流级硬阈值**（`totalUSD` 超出整个 run abort 保留 partial report，per-sample 超出该样本失败但 run 继续）。一个回答"质量是否达标"，一个回答"花钱/时间是否在预算内"。
 
 ### `omk bench run --batch`（批量评测）
 
@@ -512,7 +512,7 @@ omk bench evolve skills/my-skill.md --rounds 10 --target 4.5
 
 在自动化流水线中运行评测。评分达标则退出码为 0（通过），否则为 1（失败），可直接用于卡点判断。
 
-门禁是**三层 all-pass**:`avgFactScore >= threshold AND avgBehaviorScore >= threshold AND avgJudgeScore >= threshold`，任一层低于阈值即 FAIL，输出显示是哪一层破了 gate。这样能把"事实 4.5→2.5 但 judge 3→5"这种合成分均值不变但事实层崩盘的 case 暴露出来 — 任何一层退化都会被卡住。
+门禁是**三层 all-pass**：`avgFactScore >= threshold AND avgBehaviorScore >= threshold AND avgJudgeScore >= threshold`，任一层低于阈值即 FAIL，输出显示是哪一层破了 gate。这样能把"事实 4.5→2.5 但 judge 3→5"这种合成分均值不变但事实层崩盘的 case 暴露出来 — 任何一层退化都会被卡住。
 
 ```bash
 omk bench gate [选项]
@@ -538,7 +538,7 @@ doctor 检查项：
 - **前置依赖完整** — 引用的 CLI 工具、文件、环境变量都可用（复用 `preflightDependencies`）
 - **用例 ↔ skill 输入约定** — 传 samples 时校验非空且含 prompt 字段（warn 级）
 
-executor / judge 连通性由独立的 evaluation preflight 阶段负责，不在 doctor 范围内 — 边界清晰：doctor 静态，eval 动态。`bench run` / `bench gate` 在 doctor 失败时 abort（exit 1,stderr 前缀 `doctor failed:`）。**doctor 是评测必经环节，无 skip flag**（静态检查零成本无理由跳过）；LLM 连通性可用 `--skip-connectivity` 单独控制（`--resume` 时自动跳过）。
+executor / judge 连通性由独立的 evaluation preflight 阶段负责，不在 doctor 范围内 — 边界清晰：doctor 静态，eval 动态。`bench run` / `bench gate` 在 doctor 失败时 abort（exit 1，stderr 前缀 `doctor failed:`）。**doctor 是评测必经环节，无 skip flag**（静态检查零成本无理由跳过）；LLM 连通性可用 `--skip-connectivity` 单独控制（`--resume` 时自动跳过）。
 
 ### `omk bench report`
 
@@ -575,7 +575,7 @@ gold-dir/
 
 α 阈值参考 Krippendorff (2011)：≥ 0.80 高度一致；[0.67, 0.80) 可接受；< 0.40 偏差大需排查 rubric / prompt。
 
-完整 demo: [examples/gold-dataset/](examples/gold-dataset/)
+完整 demo：[examples/gold-dataset/](examples/gold-dataset/)
 
 ### `omk bench debias-validate length`（评委长度偏差检测）
 
@@ -620,7 +620,7 @@ omk bench verdict <reportId> [选项]
 
 ### `omk bench diagnose`（样本质量诊断）
 
-回答"测评结论是否被坏样本污染"。诊断 7 类样本质量问题：`flat_scores`（区分度低）/ `all_pass`（太简单）/ `all_fail`（broken,error 级）/ `near_duplicate`（prompt ROUGE-1 ≥ 阈值）/ `ambiguous_rubric`（judge stddev 大，需要 `--judge-repeat ≥ 2`）/ `cost_outlier`（≥ k× median）/ `latency_outlier`（≥ k× median）/ `error_prone`（执行失败）。
+回答"测评结论是否被坏样本污染"。诊断 7 类样本质量问题：`flat_scores`（区分度低）/ `all_pass`（太简单）/ `all_fail`（broken，error 级）/ `near_duplicate`（prompt ROUGE-1 ≥ 阈值）/ `ambiguous_rubric`（judge stddev 大，需要 `--judge-repeat ≥ 2`）/ `cost_outlier`（≥ k× median）/ `latency_outlier`（≥ k× median）/ `error_prone`（执行失败）。
 
 ```bash
 omk bench diagnose <reportId> [选项]
@@ -650,9 +650,9 @@ omk bench failures <reportId> [选项]
 
 ### `omk bench diff`（报告对比 — 单参 / 双参双模式）
 
-**单参模式**（within-report sample-level 钻取）： `omk bench diff <reportId>` — 在同一份报告内对比两个 variant 的逐样本得分，默认对比 `variants[0]` vs `variants[1]`。
+**单参模式**（within-report sample-level 钻取）：`omk bench diff <reportId>` — 在同一份报告内对比两个 variant 的逐样本得分，默认对比 `variants[0]` vs `variants[1]`。
 
-**双参模式**(cross-report variant-level): `omk bench diff <reportId1> <reportId2>` — 跨报告对比同一 variant 的整体均值漂移（向后兼容旧用法）。
+**双参模式**（cross-report variant-level）：`omk bench diff <reportId1> <reportId2>` — 跨报告对比同一 variant 的整体均值漂移（向后兼容旧用法）。
 
 ```bash
 omk bench diff <reportId> [--variant <name>] [--regressions-only] [--threshold 0] [--top N]
@@ -705,7 +705,7 @@ omk analyze ~/.claude/projects/my-project --kb /path/to/project
 |--------|----------|------|
 | `claude` | 默认 | 通过 `claude -p` 调用 Claude CLI |
 | `claude-sdk` | 结构化输出 | 通过 Claude Agent SDK 调用，无 stdout 解析，避免 buffer 截断 |
-| `codex` | OpenAI agent CLI | 通过 `codex exec --json` 调用，需本地装好登录的 codex(`@openai/codex`);best-effort tool trace,**costUSD 不报**（codex 自身不输出 USD，需外部账单核算） |
+| `codex` | OpenAI agent CLI | 通过 `codex exec --json` 调用，需本地装好登录的 codex（`@openai/codex`）；best-effort tool trace，**costUSD 不报**（codex 自身不输出 USD，需外部账单核算） |
 | `codex-sdk` | OpenAI agent SDK | 通过 `@openai/codex-sdk` 调用其自带的 `@openai/codex` binary 和 SDK 事件流；**costUSD 不报** |
 | `gemini` | 跨厂商对比 | 通过 `gemini` CLI 调用 |
 | `anthropic-api` | 无需 CLI | 直接调用 Anthropic HTTP API（需 `ANTHROPIC_API_KEY`） |
@@ -713,7 +713,7 @@ omk analyze ~/.claude/projects/my-project --kb /path/to/project
 
 API 直调执行器支持通过环境变量自定义 Base URL：`ANTHROPIC_BASE_URL`、`OPENAI_BASE_URL`。
 
-Codex construct-validity 说明：(1) `codex` 使用 `PATH` 上找到的 `codex` binary;`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。报告会持久化 per-variant `meta.executorRuntimes`、`meta.executorRuntime`，以及每个评委的 `meta.judgeModels[].runtime` 指纹（binary 或 SDK 版本 + 能力快照），`bench diff` / `bench verdict` 会在 strict comparability 无法审计时提示。runtime 指纹不一致时，结果应解释为 executor runtime 对比，而不只是 prompt/template 行为对比。(2) 两个 executor 都隔离用户级 config:`codex` 传 `--ephemeral` + `--ignore-user-config`,`codex-sdk` 把 `$CODEX_HOME` 重定向到 per-process tmp 目录（auth.json 通过 symlink 透传）。用户的 `~/.codex/config.toml` 不会渗入任意一个 executor 的 eval。
+Codex construct-validity 说明：（1）`codex` 使用 `PATH` 上找到的 `codex` binary；`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。报告会持久化 per-variant `meta.executorRuntimes`、`meta.executorRuntime`，以及每个评委的 `meta.judgeModels[].runtime` 指纹（binary 或 SDK 版本 + 能力快照），`bench diff` / `bench verdict` 会在 strict comparability 无法审计时提示。runtime 指纹不一致时，结果应解释为 executor runtime 对比，而不只是 prompt/template 行为对比。（2）两个 executor 都隔离用户级 config：`codex` 传 `--ephemeral` + `--ignore-user-config`，`codex-sdk` 把 `$CODEX_HOME` 重定向到 per-process tmp 目录（auth.json 通过 symlink 透传）。用户的 `~/.codex/config.toml` 不会渗入任意一个 executor 的 eval。
 
 ### 自定义执行器
 
@@ -874,7 +874,7 @@ omk bench run \
   --treatment /path/to/target-project/.claude/skills/prd/SKILL.md@/path/to/target-project
 ```
 
-如果你想证明"项目目录中的知识沉淀本身"是否有效，加第二个 treatment:
+如果你想证明"项目目录中的知识沉淀本身"是否有效，加第二个 treatment：
 
 ```bash
 omk bench run \
@@ -929,7 +929,7 @@ omk bench run --executor "python examples/custom-executor/ollama-executor.py" \
 
 **关于评委：**
 
-- `--judge-models <list>` 指定评委，格式 `executor:model[,executor:model]`。默认 `${executor}:haiku`（没设 `--executor` 时为 claude:haiku）
+- `--judge-models <list>` 指定评委，格式 `executor:model[,executor:model]`。默认 `${executor}:haiku`（没设 `--executor` 时为 `claude:haiku`）
 - 1 条 = 单评委；≥ 2 条 = 多评委 ensemble + inter-judge agreement
 - 没有 Claude 时把 `--judge-models` 指向你可用的模型，例如 `--judge-models openai-api:glm-4-plus`
 - 加 `--no-judge` 可跳过 LLM 评委，仅使用断言评分

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,13 +8,13 @@
 
 [English](./README.md) | **简体中文**
 
-**omk** — 你给 LLM 的知识,价值在哪里?
-omk 帮你用客观数据回答,而不是凭感觉。
+**omk** — 你给 LLM 的知识，价值在哪里？
+omk 帮你用客观数据回答，而不是凭感觉。
 
-**面向 LLM 知识输入(prompt / RAG / skill / agent)的评测框架** —— 固定模型,只变知识载体。
+**面向 LLM 知识输入(prompt / RAG / skill / agent)的评测框架** —— 固定模型，只变知识载体。
 
 <a id="statistical-rigor"></a>
-> 默认带:Bootstrap 置信区间 · Krippendorff α(评委 ↔ 人工)· 长度去偏 · 饱和曲线 · 用例隔离(construct validity)。[这些为什么重要 →](docs/zh/statistical-rigor.md)
+> 默认带：Bootstrap 置信区间 · Krippendorff α（评委 ↔ 人工）· 长度去偏 · 饱和曲线 · 用例隔离(construct validity)。[这些为什么重要 →](docs/zh/statistical-rigor.md)
 
 ![omk 报告](./assets/screenshots/report-overview-zh.png)
 
@@ -27,7 +27,7 @@ omk bench init my-eval && cd my-eval
 omk bench run --control code-review-v1 --treatment code-review-v2    # → 5 分钟出 HTML 报告 + verdict
 ```
 
-深入:[在 Claude Code / Codex 中调用](#在-ai-coding-agent-中使用) · [`omk bench run` 全 flag](#omk-bench-run) · [artifact 目录结构](#artifact-目录结构) · [`--lang` / `OMK_LANG`](#环境变量)
+深入：[在 Claude Code / Codex 中调用](#在-ai-coding-agent-中使用) · [`omk bench run` 全 flag](#omk-bench-run) · [artifact 目录结构](#artifact-目录结构) · [`--lang` / `OMK_LANG`](#环境变量)
 
 ## 在 AI Coding Agent 中使用
 
@@ -61,20 +61,20 @@ omk bench gen-samples skills/my-skill.md
 
 ## 核心能力
 
-- **评测前置健康检查** — `omk doctor` 在 `bench run` / `bench gate` 之前**强制**运行,检查 skill 可读性、元数据合法性、依赖完整性、samples 契约——纯静态零 LLM 调用,类比 SE 工具栈的 lint + typecheck。executor / judge 连通性是独立阶段,可用 `--skip-connectivity` 单独跳过
+- **评测前置健康检查** — `omk doctor` 在 `bench run` / `bench gate` 之前**强制**运行，检查 skill 可读性、元数据合法性、依赖完整性、samples 契约——纯静态零 LLM 调用，类比 SE 工具栈的 lint + typecheck。executor / judge 连通性是独立阶段，可用 `--skip-connectivity` 单独跳过
 - **控制变量离线评测** — 固定模型和用例，只变知识载体；兼容 Claude Code skill、CLAUDE.md prompt、RAG 知识库等任何 markdown 形式的指令
 - **六维独立打分** — Fact / Behavior / LLM-judge / Cost / Efficiency / Stability 分别出信号，单一维度的回退不会被其他维度的收益掩盖
 - **线上 session 观测** — 解析 Claude Code session JSONL，在真实用户会话上测量各 skill 的失败率、耗时、token 成本和知识缺口信号
-- **知识缺口识别** — 严重度加权的信号（显式标记 / 搜索失败 / hedging 用语 / 反复失败）量化风险敞口,不宣称完备性
+- **知识缺口识别** — 严重度加权的信号（显式标记 / 搜索失败 / hedging 用语 / 反复失败）量化风险敞口，不宣称完备性
 - **合并前 CI 门** — `omk bench gate` 强制三层 all-pass（fact + behavior + llm-judge），抓复合分掩盖的单层回退
-- **一行 ship/no-ship 结论** — `omk bench verdict <reportId>` 聚合 bootstrap CI / 三层 ci-gate / saturation / human α,给六档 verdict(PROGRESS / CAUTIOUS / REGRESS / NOISE / UNDERPOWERED / SOLO)+ 行动建议;exit code 反映是否可 ship
+- **一行 ship/no-ship 结论** — `omk bench verdict <reportId>` 聚合 bootstrap CI / 三层 ci-gate / saturation / human α，给六档 verdict(PROGRESS / CAUTIOUS / REGRESS / NOISE / UNDERPOWERED / SOLO)+ 行动建议；exit code 反映是否可 ship
 
 ## 为什么选 omk
 
 | | omk | promptfoo | DeepEval | LangSmith |
 |--|--|--|--|--|
 | Bootstrap 置信区间 | ✓ 默认 | ✗ | ✗ | ✗ |
-| Krippendorff α(评委 ↔ 人工) | ✓ 默认 | ✗ | ✗ | ✗ |
+| Krippendorff α（评委 ↔ 人工） | ✓ 默认 | ✗ | ✗ | ✗ |
 | 长度去偏的评委 prompt | ✓ 默认 | ✗ | ✗ | ✗ |
 | 饱和曲线 | ✓ | ✗ | ✗ | ✗ |
 | 三层独立评分 | ✓ | ✗ | 部分 | ✗ |
@@ -82,25 +82,25 @@ omk bench gen-samples skills/my-skill.md
 | 原生 Claude Code skill | ✓ | ✗ | ✗ | ✗ |
 | 托管 SaaS 看板 | ✗ | ✗ | ✓ | ✓ |
 
-omk 的护城河是 **default-on 安全网** —— Bootstrap CI / 评委 ↔ 人工 α / 长度去偏不是 advanced flag,是默认行为。其他工具让你**手动**接置信区间;omk 让你**默认无法忽略**它。需要 SaaS 看板?选 LangSmith。要快速 prompt 迭代不要统计层?选 promptfoo。**要发到生产且会被问"为什么应该相信这个数字"?选 omk。**
+omk 的护城河是 **default-on 安全网** —— Bootstrap CI / 评委 ↔ 人工 α / 长度去偏不是 advanced flag，是默认行为。其他工具让你**手动**接置信区间；omk 让你**默认无法忽略**它。需要 SaaS 看板？选 LangSmith。要快速 prompt 迭代不要统计层？选 promptfoo。**要发到生产且会被问"为什么应该相信这个数字"？选 omk。**
 
-RAG 专项评测请看 RAGAS(独立 niche,跟 omk 互补)。完整对比(7 个工具 × 25+ 维度): [docs/zh/comparison.md](docs/zh/comparison.md)
+RAG 专项评测请看 RAGAS（独立 niche，跟 omk 互补）。完整对比（7 个工具 × 25+ 维度）： [docs/zh/comparison.md](docs/zh/comparison.md)
 
 ## 特性
 
 | 特性 | 说明 |
 |------|------|
-| **Verdict 一行结论** | `omk bench verdict <id>` 六档判定 + ship 建议 + exit code 路由,与 HTML 报告 verdict pill 共享规则 |
+| **Verdict 一行结论** | `omk bench verdict <id>` 六档判定 + ship 建议 + exit code 路由，与 HTML 报告 verdict pill 共享规则 |
 | **六维评估** | 事实 / 行为 / LLM 评价 / 成本 / 效率 / 稳定性独立展示 |
 | **多执行器** | 支持 Claude CLI / Claude SDK / Codex CLI / Codex SDK / OpenAI / Gemini 及自定义命令 |
 | **21+ 种断言** | 包含子串、正则、JSON Schema、ROUGE/BLEU/Levenshtein 相似度、Agent 工具调用、语义相似度、自定义函数等 |
 | **统计严谨性** | Bootstrap CI / Krippendorff α / 长度去偏 / 饱和曲线 —— 全部默认开。[详情 →](docs/zh/statistical-rigor.md) |
-| **用例质量诊断** | `omk bench diagnose <id>` 7 类 issue(区分度低 / 重复 / 歧义 / 成本异常 / 全 fail 等)+ healthScore 0-100 |
+| **用例质量诊断** | `omk bench diagnose <id>` 7 类 issue（区分度低 / 重复 / 歧义 / 成本异常 / 全 fail 等）+ healthScore 0-100 |
 | **失败聚类 + 根因** | `omk bench failures <id>` 单 LLM 调用聚类失败用例 + 每 cluster 给修复建议 |
-| **RAG metrics** | `faithfulness` / `answer_relevancy` / `context_recall` 三 metric — 反幻觉 + 切题度 + context 覆盖,自动继承长度去偏 |
-| **预算硬阈值** | `--budget-usd / --budget-per-sample-usd / --budget-per-sample-ms` 总成本 + 单用例成本/耗时上限,超出中止保留 partial report |
-| **用例隔离 (construct validity)** | `--strict-baseline` (默认开) 三堵 baseline 拿到被测 skill 的污染路径:(1) SDK skill auto-discovery (2) subagent Skill 工具调用 (3) cwd 文件系统(避免 baseline 顺 `skills/<name>/` symlink 直接 Read 到 SKILL.md)。eval.yaml `allowedSkills` 支持 per-variant 白名单 |
-| **用例设计科学性 (sample design science)** | Sample schema 加 `capability` / `difficulty` / `construct` / `provenance` 元数据字段(HF Dataset Cards 风)。`bench diagnose` 输出 coverage 分桶 + 检测 `rubric_clarity_low` / `capability_thin` 两类新 issue。`bench gen-samples` 自动给生成的用例打 provenance。详见 [docs/sample-design-spec.md](docs/sample-design-spec.md),含 8 条行业 gap(HELM / MMLU-Pro / Construct Validity / IRT / Dataset Cards / Adversarial)的 omk v1 映射 |
+| **RAG metrics** | `faithfulness` / `answer_relevancy` / `context_recall` 三 metric — 反幻觉 + 切题度 + context 覆盖，自动继承长度去偏 |
+| **预算硬阈值** | `--budget-usd / --budget-per-sample-usd / --budget-per-sample-ms` 总成本 + 单用例成本/耗时上限，超出中止保留 partial report |
+| **用例隔离 (construct validity)** | `--strict-baseline` （默认开） 三堵 baseline 拿到被测 skill 的污染路径：(1) SDK skill auto-discovery (2) subagent Skill 工具调用 (3) cwd 文件系统（避免 baseline 顺 `skills/<name>/` symlink 直接 Read 到 SKILL.md）。eval.yaml `allowedSkills` 支持 per-variant 白名单 |
+| **用例设计科学性 (sample design science)** | Sample schema 加 `capability` / `difficulty` / `construct` / `provenance` 元数据字段（HF Dataset Cards 风）。`bench diagnose` 输出 coverage 分桶 + 检测 `rubric_clarity_low` / `capability_thin` 两类新 issue。`bench gen-samples` 自动给生成的用例打 provenance。详见 [docs/sample-design-spec.md](docs/sample-design-spec.md)，含 8 条行业 gap(HELM / MMLU-Pro / Construct Validity / IRT / Dataset Cards / Adversarial)的 omk v1 映射 |
 | **多评委 ensemble** | `--judge-models claude:opus,openai:gpt-4o` 跨厂商评分 + agreement 度量 |
 | **MCP URL 获取** | 通过 MCP Server 获取私有文档 URL 内容（SSO 保护的知识库等） |
 | **盲测 A/B** | `--blind` 隐藏变体名称，HTML 报告有揭晓按钮 |
@@ -113,7 +113,7 @@ RAG 专项评测请看 RAGAS(独立 niche,跟 omk 互补)。完整对比(7 个�
 
 ## 工作原理
 
-核心思路:**固定模型 + 固定样本,只变 artifact 和 runtime context**,通过交错调度消除时间漂移,用断言 + LLM 评委双通道评分,再叠加知识缺口信号量化风险敞口。
+核心思路：**固定模型 + 固定样本，只变 artifact 和 runtime context**，通过交错调度消除时间漂移，用断言 + LLM 评委双通道评分，再叠加知识缺口信号量化风险敞口。
 
 ```mermaid
 flowchart TD
@@ -168,12 +168,12 @@ flowchart TD
     G --> R
 ```
 
-**关键设计:**
+**关键设计：**
 
-- **交错调度**消除时间漂移:同一样本的不同 variant 交替发出,而非 v1 全跑完再跑 v2,避免模型负载/网络波动被错误归因给 artifact。
-- **variant = artifact + runtime context**:`name@cwd` 让对照组可以显式声明"项目目录"这个隐性输入,把"项目级沉淀"和"显式 artifact 注入"拆开测。
-- **双通道评分互补**:断言抓确定性缺陷(必须调用某工具/必须包含某字段),LLM 评委抓主观质量(可读性/完整性),两者都存在时取均值。
-- **知识缺口信号**不是评分的一部分,而是一个独立追踪项:它告诉你"这次评测覆盖了多少风险敞口",用于追踪收敛,而非断言知识"完备"。
+- **交错调度**消除时间漂移：同一样本的不同 variant 交替发出，而非 v1 全跑完再跑 v2，避免模型负载/网络波动被错误归因给 artifact。
+- **variant = artifact + runtime context**:`name@cwd` 让对照组可以显式声明"项目目录"这个隐性输入，把"项目级沉淀"和"显式 artifact 注入"拆开测。
+- **双通道评分互补**：断言抓确定性缺陷（必须调用某工具/必须包含某字段），LLM 评委抓主观质量（可读性/完整性），两者都存在时取均值。
+- **知识缺口信号**不是评分的一部分，而是一个独立追踪项：它告诉你"这次评测覆盖了多少风险敞口"，用于追踪收敛，而非断言知识"完备"。
 
 ## 评测样本格式
 
@@ -304,10 +304,10 @@ flowchart TD
 | `rouge_n_min` | ROUGE-N recall ≥ threshold（`reference` 字段填参考答案，`n` 默认 1，`threshold` 默认 0.5） |
 | `levenshtein_max` | 编辑距离 ≤ value（用于"输出跟参考几乎一致"场景） |
 | `bleu_min` | BLEU-4 ≥ threshold（unsmoothed，短文本会塌陷到 0） |
-| `faithfulness` | 输出是否被 `sample.context` 支持(反幻觉);LLM judge 1-5 评分,threshold 默认 3 |
-| `answer_relevancy` | 输出是否切题回答 `sample.prompt`;能抓住跑题、回避、冗余;threshold 默认 3 |
-| `context_recall` | `sample.context` 关键事实在输出中的覆盖率;`reference` 可显式指定 gold facts;threshold 默认 3 |
-| `semantic_similarity` | LLM 语义相似度（与 reference 的整体相似度,与 RAG 三 metric 互补） |
+| `faithfulness` | 输出是否被 `sample.context` 支持（反幻觉）；LLM judge 1-5 评分，threshold 默认 3 |
+| `answer_relevancy` | 输出是否切题回答 `sample.prompt`；能抓住跑题、回避、冗余；threshold 默认 3 |
+| `context_recall` | `sample.context` 关键事实在输出中的覆盖率；`reference` 可显式指定 gold facts;threshold 默认 3 |
+| `semantic_similarity` | LLM 语义相似度（与 reference 的整体相似度，与 RAG 三 metric 互补） |
 | `custom` | 自定义 JS 函数（30s 超时） |
 
 **通用修饰：**
@@ -346,7 +346,7 @@ export default function(output, { sample, assertion }) {
 
 ## 六维评估指标
 
-评测报告从六个维度独立展示结果。其中评分三层(事实 / 行为 / LLM 评价)分开展示,让你看到**是哪一层拉胯**,而不是只看到一个合成分:
+评测报告从六个维度独立展示结果。其中评分三层（事实 / 行为 / LLM 评价）分开展示，让你看到**是哪一层拉胯**，而不是只看到一个合成分：
 
 | 维度 | 指标 | 说明 |
 |------|------|------|
@@ -408,9 +408,9 @@ omk bench run [选项]
   --budget-per-sample-ms <num>   单样本耗时上限 (ms);超出该样本失败但评测继续
 ```
 
-**eval.yaml 预算字段**: `budget: { totalUSD?, perSampleUSD?, perSampleMs? }`,所有字段可选且必须 ≥ 0。CLI 同名 flag 覆盖配置值。
+**eval.yaml 预算字段**： `budget: { totalUSD?, perSampleUSD?, perSampleMs? }`，所有字段可选且必须 ≥ 0。CLI 同名 flag 覆盖配置值。
 
-**eval.yaml 实验设计字段**: 上面 CLI flag 同样可以写到 `eval.yaml` 让实验配置可复现 (CLI > eval.yaml > 默认):
+**eval.yaml 实验设计字段**： 上面 CLI flag 同样可以写到 `eval.yaml` 让实验配置可复现 （CLI > eval.yaml > 默认）：
 
 ```yaml
 samples: ./eval-samples.yaml
@@ -431,9 +431,9 @@ variants:
   - { name: my-skill, role: treatment, artifact: ./skills/my-skill.md }
 ```
 
-**字段入口**: `bench run` 完整支持上述全部字段; `bench gate` 通过 `parseRunConfig` 共享 variants / executor / model / `judgeModels`(单评委 + ensemble 都生效)/ noJudge / noCache / blind / strictBaseline / budget / mcpConfig / variantAllowedSkills,但 `handleRun` 自己处理的实验设计字段(`repeat` / `judgeRepeat` / `bootstrap` / `bootstrapSamples` / `goldDir` / `lengthDebias`)gate 不读,后续按需扩展到 gate。其他子命令(`evolve` / `verdict` / `diff` / `analyze` 等)完全不读 eval.yaml。
+**字段入口**： `bench run` 完整支持上述全部字段； `bench gate` 通过 `parseRunConfig` 共享 variants / executor / model / `judgeModels`（单评委 + ensemble 都生效）/ noJudge / noCache / blind / strictBaseline / budget / mcpConfig / variantAllowedSkills，但 `handleRun` 自己处理的实验设计字段(`repeat` / `judgeRepeat` / `bootstrap` / `bootstrapSamples` / `goldDir` / `lengthDebias`)gate 不读，后续按需扩展到 gate。其他子命令（`evolve` / `verdict` / `diff` / `analyze` 等）完全不读 eval.yaml。
 
-**和 `cost_max` / `latency_max` 断言的区别**: 断言是**单样本评分维度**(超出直接打 0 分,run 继续);budget 是**工作流级硬阈值**(`totalUSD` 超出整个 run abort 保留 partial report,per-sample 超出该样本失败但 run 继续)。一个回答"质量是否达标",一个回答"花钱/时间是否在预算内"。
+**和 `cost_max` / `latency_max` 断言的区别**： 断言是**单样本评分维度**（超出直接打 0 分，run 继续）；budget 是**工作流级硬阈值**（`totalUSD` 超出整个 run abort 保留 partial report,per-sample 超出该样本失败但 run 继续）。一个回答"质量是否达标"，一个回答"花钱/时间是否在预算内"。
 
 ### `omk bench run --batch`（批量评测）
 
@@ -510,9 +510,9 @@ omk bench evolve skills/my-skill.md --rounds 10 --target 4.5
 
 ### `omk bench gate`
 
-在自动化流水线中运行评测。评分达标则退出码为 0(通过),否则为 1(失败),可直接用于卡点判断。
+在自动化流水线中运行评测。评分达标则退出码为 0（通过），否则为 1（失败），可直接用于卡点判断。
 
-门禁是**三层 all-pass**:`avgFactScore >= threshold AND avgBehaviorScore >= threshold AND avgJudgeScore >= threshold`,任一层低于阈值即 FAIL,输出显示是哪一层破了 gate。这样能把"事实 4.5→2.5 但 judge 3→5"这种合成分均值不变但事实层崩盘的 case 暴露出来 — 任何一层退化都会被卡住。
+门禁是**三层 all-pass**:`avgFactScore >= threshold AND avgBehaviorScore >= threshold AND avgJudgeScore >= threshold`，任一层低于阈值即 FAIL，输出显示是哪一层破了 gate。这样能把"事实 4.5→2.5 但 judge 3→5"这种合成分均值不变但事实层崩盘的 case 暴露出来 — 任何一层退化都会被卡住。
 
 ```bash
 omk bench gate [选项]
@@ -520,9 +520,9 @@ omk bench gate [选项]
                          fact / behavior / judge 三层
 ```
 
-### `omk doctor`(评测前置健康检查)
+### `omk doctor`（评测前置健康检查）
 
-纯静态 / 零 LLM 调用,类比 SE 工具栈的 lint + typecheck。`bench run` / `bench gate` 之前强制运行,YAML 写错、依赖缺失这类问题会 abort 评测并给可操作错误,而不是让你拿到 garbage-in 的 verdict 数字。也可独立调用,适合本地迭代或 CI 单跑。
+纯静态 / 零 LLM 调用，类比 SE 工具栈的 lint + typecheck。`bench run` / `bench gate` 之前强制运行，YAML 写错、依赖缺失这类问题会 abort 评测并给可操作错误，而不是让你拿到 garbage-in 的 verdict 数字。也可独立调用，适合本地迭代或 CI 单跑。
 
 ```bash
 omk doctor                    # 批量检查当前目录或 ./skills 下所有 skill
@@ -531,14 +531,14 @@ omk doctor skills/ --json     # JSON 输出供 CI 消费
 omk doctor --gate; echo $?    # 静默模式 — 任意 fatal 失败 exit 1
 ```
 
-doctor 检查项:
+doctor 检查项：
 
 - **skill 文件可读** — 文件存在、内容非空、有最低长度
-- **skill 元数据合法** — front-matter(若有)YAML 合法;directory-skill 有 `SKILL.md`
-- **前置依赖完整** — 引用的 CLI 工具、文件、环境变量都可用(复用 `preflightDependencies`)
-- **用例 ↔ skill 输入约定** — 传 samples 时校验非空且含 prompt 字段(warn 级)
+- **skill 元数据合法** — front-matter（若有）YAML 合法；directory-skill 有 `SKILL.md`
+- **前置依赖完整** — 引用的 CLI 工具、文件、环境变量都可用（复用 `preflightDependencies`）
+- **用例 ↔ skill 输入约定** — 传 samples 时校验非空且含 prompt 字段（warn 级）
 
-executor / judge 连通性由独立的 evaluation preflight 阶段负责,不在 doctor 范围内 — 边界清晰:doctor 静态,eval 动态。`bench run` / `bench gate` 在 doctor 失败时 abort(exit 1,stderr 前缀 `doctor failed:`)。**doctor 是评测必经环节,无 skip flag**(静态检查零成本无理由跳过);LLM 连通性可用 `--skip-connectivity` 单独控制(`--resume` 时自动跳过)。
+executor / judge 连通性由独立的 evaluation preflight 阶段负责，不在 doctor 范围内 — 边界清晰：doctor 静态，eval 动态。`bench run` / `bench gate` 在 doctor 失败时 abort（exit 1,stderr 前缀 `doctor failed:`）。**doctor 是评测必经环节，无 skip flag**（静态检查零成本无理由跳过）；LLM 连通性可用 `--skip-connectivity` 单独控制（`--resume` 时自动跳过）。
 
 ### `omk bench report`
 
@@ -607,7 +607,7 @@ HTML 报告会内联 SVG 饱和曲线（横 N，纵 mean ± 95% CI 阴影带，p
 
 ### `omk bench verdict`（一行 ship/no-ship 结论）
 
-聚合 bootstrap CI / 三层 ci-gate / saturation / human α 给一行结论。Verdict 六档:**PROGRESS**（显著改进 + 三层全过 → exit 0）/ **CAUTIOUS**（改进真实但有警告:gate 破/幅度太小/控制组本身崩 → exit 1）/ **REGRESS**（显著回退 → exit 1）/ **NOISE**（CI 跨 0,无法判定 → exit 1）/ **UNDERPOWERED**（样本不足 → exit 1）/ **SOLO**（单变体,仅自身三层 gate 过才 exit 0）。
+聚合 bootstrap CI / 三层 ci-gate / saturation / human α 给一行结论。Verdict 六档：**PROGRESS**（显著改进 + 三层全过 → exit 0）/ **CAUTIOUS**（改进真实但有警告：gate 破/幅度太小/控制组本身崩 → exit 1）/ **REGRESS**（显著回退 → exit 1）/ **NOISE**（CI 跨 0，无法判定 → exit 1）/ **UNDERPOWERED**（样本不足 → exit 1）/ **SOLO**（单变体，仅自身三层 gate 过才 exit 0）。
 
 ```bash
 omk bench verdict <reportId> [选项]
@@ -616,11 +616,11 @@ omk bench verdict <reportId> [选项]
   --verbose              展开 per-pair 详情
 ```
 
-与 HTML 报告顶部的 verdict pill 共享规则模块,CLI 与 UI 不会矛盾。
+与 HTML 报告顶部的 verdict pill 共享规则模块，CLI 与 UI 不会矛盾。
 
 ### `omk bench diagnose`（样本质量诊断）
 
-回答"测评结论是否被坏样本污染"。诊断 7 类样本质量问题:`flat_scores`（区分度低）/ `all_pass`（太简单）/ `all_fail`（broken,error 级）/ `near_duplicate`（prompt ROUGE-1 ≥ 阈值）/ `ambiguous_rubric`（judge stddev 大,需要 `--judge-repeat ≥ 2`）/ `cost_outlier`（≥ k× median）/ `latency_outlier`（≥ k× median）/ `error_prone`（执行失败）。
+回答"测评结论是否被坏样本污染"。诊断 7 类样本质量问题：`flat_scores`（区分度低）/ `all_pass`（太简单）/ `all_fail`（broken,error 级）/ `near_duplicate`（prompt ROUGE-1 ≥ 阈值）/ `ambiguous_rubric`（judge stddev 大，需要 `--judge-repeat ≥ 2`）/ `cost_outlier`（≥ k× median）/ `latency_outlier`（≥ k× median）/ `error_prone`（执行失败）。
 
 ```bash
 omk bench diagnose <reportId> [选项]
@@ -632,11 +632,11 @@ omk bench diagnose <reportId> [选项]
   --flat <num>                flat_scores 分差阈值 (默认 0.5)
 ```
 
-输出含 healthScore（0-100,公式 `100 - normalized × 20`,其中 `normalized = (errors×8 + warnings×3 + infos×1) / N`）。exit code 0 仅当 `healthScore ≥ 70` 且无 error 级 issue,适合 CI 链。
+输出含 healthScore（0-100，公式 `100 - normalized × 20`，其中 `normalized = (errors×8 + warnings×3 + infos×1) / N`）。exit code 0 仅当 `healthScore ≥ 70` 且无 error 级 issue，适合 CI 链。
 
 ### `omk bench failures`（失败 case LLM 聚类）
 
-跑完 14 条失败,逐个看太慢。本命令把失败样本喂给单次 LLM 调用,自动聚到 ≤ N 个 cluster,每个 cluster 给根因 + 修复建议。失败定义:`compositeScore < threshold` 或 `ok = false`。
+跑完 14 条失败，逐个看太慢。本命令把失败样本喂给单次 LLM 调用，自动聚到 ≤ N 个 cluster，每个 cluster 给根因 + 修复建议。失败定义：`compositeScore < threshold` 或 `ok = false`。
 
 ```bash
 omk bench failures <reportId> [选项]
@@ -646,24 +646,24 @@ omk bench failures <reportId> [选项]
   --max-feed <n>              最多喂给 LLM 多少条 (默认 50,超出取最差)
 ```
 
-容错:tolerate ```json``` markdown fence、`"sample_id@variant"` 字符串成员形式、hallucinated 成员自动剔除、单条失败跳过 LLM 直接列出、executor 错误降级到 unclassified。
+容错：tolerate ```json``` markdown fence、`"sample_id@variant"` 字符串成员形式、hallucinated 成员自动剔除、单条失败跳过 LLM 直接列出、executor 错误降级到 unclassified。
 
 ### `omk bench diff`（报告对比 — 单参 / 双参双模式）
 
-**单参模式**(within-report sample-level 钻取): `omk bench diff <reportId>` — 在同一份报告内对比两个 variant 的逐样本得分,默认对比 `variants[0]` vs `variants[1]`。
+**单参模式**（within-report sample-level 钻取）： `omk bench diff <reportId>` — 在同一份报告内对比两个 variant 的逐样本得分，默认对比 `variants[0]` vs `variants[1]`。
 
-**双参模式**(cross-report variant-level): `omk bench diff <reportId1> <reportId2>` — 跨报告对比同一 variant 的整体均值漂移(向后兼容旧用法)。
+**双参模式**(cross-report variant-level): `omk bench diff <reportId1> <reportId2>` — 跨报告对比同一 variant 的整体均值漂移（向后兼容旧用法）。
 
 ```bash
 omk bench diff <reportId> [--variant <name>] [--regressions-only] [--threshold 0] [--top N]
 omk bench diff <reportId1> <reportId2> [--regressions-only] [--threshold 0]
 ```
 
-单参模式表格按 |Δ| 排序,Δ < threshold 高亮 regression。`--top N` 限制行数,`--regressions-only` 过滤到只看回退。
+单参模式表格按 |Δ| 排序，Δ < threshold 高亮 regression。`--top N` 限制行数，`--regressions-only` 过滤到只看回退。
 
 ## `omk analyze` — 生产观测
 
-`omk bench run` 是**离线评测**(固定对照、可复现、可评分)。生产环境不一样 — 没对照组、没标准答案、没重复,所以评分在那里不成立。`omk analyze` 把已有的 Claude Code session trace 转成**skill 健康度报告**(按 skill 维度的覆盖率、缺口信号、执行稳定性、tokens/延迟)。它给的是"哪个 skill 值得拉回离线再测一遍"的线索,不是生产评分。
+`omk bench run` 是**离线评测**（固定对照、可复现、可评分）。生产环境不一样 — 没对照组、没标准答案、没重复，所以评分在那里不成立。`omk analyze` 把已有的 Claude Code session trace 转成**skill 健康度报告**（按 skill 维度的覆盖率、缺口信号、执行稳定性、tokens/延迟）。它给的是"哪个 skill 值得拉回离线再测一遍"的线索，不是生产评分。
 
 ```bash
 # 分析当前项目的所有 cc session(kb 路径从 trace 里自动推断)
@@ -682,20 +682,20 @@ omk analyze ~/.claude/projects/my-project --skills audit,polish
 omk analyze ~/.claude/projects/my-project --kb /path/to/project
 ```
 
-命令产出 `~/.oh-my-knowledge/analyses/<timestamp>-skill-health.json`。启 `omk bench report` 后,首页右上有"📊 Skill 健康度日报"入口;每张 skill card 上有"查看趋势 →"链接;`/analyses` 列表页顶部有 Compare 选择器,可以选两份报告生成 diff。
+命令产出 `~/.oh-my-knowledge/analyses/<timestamp>-skill-health.json`。启 `omk bench report` 后，首页右上有"📊 Skill 健康度日报"入口；每张 skill card 上有"查看趋势 →"链接；`/analyses` 列表页顶部有 Compare 选择器，可以选两份报告生成 diff。
 
-**每个 skill 你能看到:**
+**每个 skill 你能看到：**
 
 - **知识使用** — 这个 skill 实际读了哪些 KB 文件(coverage %)
-- **知识盲区** — 四类加权信号(搜索未命中 / 模型标记缺口 / 表达不确定 / 反复未命中);hedging 经 LLM 二次判定过滤"业务可能性"和"知识不确定"
-- **执行稳定性** — 工具失败率;失败率 > 20% 的 skill 会标警告,提示"gap 信号可能是环境问题而非真实知识缺口"
-- **使用成本** — billable tokens(input+output)和 cached tokens 分列,总耗时
+- **知识盲区** — 四类加权信号（搜索未命中 / 模型标记缺口 / 表达不确定 / 反复未命中）；hedging 经 LLM 二次判定过滤"业务可能性"和"知识不确定"
+- **执行稳定性** — 工具失败率；失败率 > 20% 的 skill 会标警告，提示"gap 信号可能是环境问题而非真实知识缺口"
+- **使用成本** — billable tokens(input+output)和 cached tokens 分列，总耗时
 
-**这不是什么:**
+**这不是什么：**
 
-- 不是通用 APM(请求级 latency/cost tracing 是 Langfuse / Datadog 的领域)
-- 不是 streaming / alert(只做 batch — 想要周期快照用 cron)
-- 不是生产评分(没对照组没标答 — 评分回到 `omk bench run`)
+- 不是通用 APM（请求级 latency/cost tracing 是 Langfuse / Datadog 的领域）
+- 不是 streaming / alert（只做 batch — 想要周期快照用 cron）
+- 不是生产评分（没对照组没标答 — 评分回到 `omk bench run`）
 
 ## 执行器
 
@@ -705,15 +705,15 @@ omk analyze ~/.claude/projects/my-project --kb /path/to/project
 |--------|----------|------|
 | `claude` | 默认 | 通过 `claude -p` 调用 Claude CLI |
 | `claude-sdk` | 结构化输出 | 通过 Claude Agent SDK 调用，无 stdout 解析，避免 buffer 截断 |
-| `codex` | OpenAI agent CLI | 通过 `codex exec --json` 调用,需本地装好登录的 codex(`@openai/codex`);best-effort tool trace,**costUSD 不报**(codex 自身不输出 USD,需外部账单核算) |
-| `codex-sdk` | OpenAI agent SDK | 通过 `@openai/codex-sdk` 调用其自带的 `@openai/codex` binary 和 SDK 事件流;**costUSD 不报** |
+| `codex` | OpenAI agent CLI | 通过 `codex exec --json` 调用，需本地装好登录的 codex(`@openai/codex`);best-effort tool trace,**costUSD 不报**（codex 自身不输出 USD，需外部账单核算） |
+| `codex-sdk` | OpenAI agent SDK | 通过 `@openai/codex-sdk` 调用其自带的 `@openai/codex` binary 和 SDK 事件流；**costUSD 不报** |
 | `gemini` | 跨厂商对比 | 通过 `gemini` CLI 调用 |
 | `anthropic-api` | 无需 CLI | 直接调用 Anthropic HTTP API（需 `ANTHROPIC_API_KEY`） |
 | `openai-api` | 无需 CLI | 直接调用 OpenAI HTTP API（需 `OPENAI_API_KEY`） |
 
 API 直调执行器支持通过环境变量自定义 Base URL：`ANTHROPIC_BASE_URL`、`OPENAI_BASE_URL`。
 
-Codex construct-validity 说明:(1) `codex` 使用 `PATH` 上找到的 `codex` binary;`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。报告会持久化 per-variant `meta.executorRuntimes`、`meta.executorRuntime`,以及每个评委的 `meta.judgeModels[].runtime` 指纹(binary 或 SDK 版本 + 能力快照),`bench diff` / `bench verdict` 会在 strict comparability 无法审计时提示。runtime 指纹不一致时,结果应解释为 executor runtime 对比,而不只是 prompt/template 行为对比。(2) 两个 executor 都隔离用户级 config:`codex` 传 `--ephemeral` + `--ignore-user-config`,`codex-sdk` 把 `$CODEX_HOME` 重定向到 per-process tmp 目录(auth.json 通过 symlink 透传)。用户的 `~/.codex/config.toml` 不会渗入任意一个 executor 的 eval。
+Codex construct-validity 说明：(1) `codex` 使用 `PATH` 上找到的 `codex` binary;`codex-sdk` 使用 `@openai/codex-sdk` 解析到的自带 `@openai/codex` binary。报告会持久化 per-variant `meta.executorRuntimes`、`meta.executorRuntime`，以及每个评委的 `meta.judgeModels[].runtime` 指纹（binary 或 SDK 版本 + 能力快照），`bench diff` / `bench verdict` 会在 strict comparability 无法审计时提示。runtime 指纹不一致时，结果应解释为 executor runtime 对比，而不只是 prompt/template 行为对比。(2) 两个 executor 都隔离用户级 config:`codex` 传 `--ephemeral` + `--ignore-user-config`,`codex-sdk` 把 `$CODEX_HOME` 重定向到 per-process tmp 目录（auth.json 通过 symlink 透传）。用户的 `~/.codex/config.toml` 不会渗入任意一个 executor 的 eval。
 
 ### 自定义执行器
 
@@ -758,7 +758,7 @@ skills/
 | `./path/to/file.md` | 含 `/` 的路径，直接读取文件作为 artifact |
 | `variant@/path/to/project` | 给任意变体附加运行目录，支持 `name@cwd`、`git:name@cwd`、`/file.md@cwd` |
 
-`--control` 和 `--treatment` 都不传时,用 `--config eval.yaml` 或 `--batch`。`--batch` 模式下会自动用 `baseline` 作对照组,每个被发现的 artifact 作实验组。
+`--control` 和 `--treatment` 都不传时，用 `--config eval.yaml` 或 `--batch`。`--batch` 模式下会自动用 `baseline` 作对照组，每个被发现的 artifact 作实验组。
 
 ```bash
 # 显式:一个 control,一个或多个 treatment
@@ -831,7 +831,7 @@ omk bench run --executor claude-sdk
 
 **1. 裸模型 baseline**
 
-不注入 system prompt,也不进入带知识的项目目录。至少需要一个 treatment 做对比:
+不注入 system prompt，也不进入带知识的项目目录。至少需要一个 treatment 做对比：
 
 ```bash
 omk bench run \
@@ -842,7 +842,7 @@ omk bench run \
 
 **2. 空 artifact + 项目级 runtime context**
 
-不注入 system prompt,但在项目目录运行。它不是严格意义上的"裸 baseline",而是"空 artifact + 项目级 runtime context"。
+不注入 system prompt，但在项目目录运行。它不是严格意义上的"裸 baseline"，而是"空 artifact + 项目级 runtime context"。
 
 ```bash
 omk bench run \
@@ -853,7 +853,7 @@ omk bench run \
 
 **3. 显式 artifact 注入**
 
-直接把某个外部 `SKILL.md` 作为 artifact 注入,同时保留项目目录上下文。适合对比"项目级 runtime context"与"显式单 artifact 注入"之间的差异。
+直接把某个外部 `SKILL.md` 作为 artifact 注入，同时保留项目目录上下文。适合对比"项目级 runtime context"与"显式单 artifact 注入"之间的差异。
 
 ```bash
 omk bench run \
@@ -864,7 +864,7 @@ omk bench run \
 
 #### 推荐的第一轮对照设计
 
-对于 PRD / 复杂业务知识场景,建议从下面开始:
+对于 PRD / 复杂业务知识场景，建议从下面开始：
 
 ```bash
 omk bench run \
@@ -874,7 +874,7 @@ omk bench run \
   --treatment /path/to/target-project/.claude/skills/prd/SKILL.md@/path/to/target-project
 ```
 
-如果你想证明"项目目录中的知识沉淀本身"是否有效,加第二个 treatment:
+如果你想证明"项目目录中的知识沉淀本身"是否有效，加第二个 treatment:
 
 ```bash
 omk bench run \
@@ -927,12 +927,12 @@ omk bench run --executor "python examples/custom-executor/ollama-executor.py" \
   --model llama3 --no-judge
 ```
 
-**关于评委:**
+**关于评委：**
 
-- `--judge-models <list>` 指定评委,格式 `executor:model[,executor:model]`。默认 `${executor}:haiku`(没设 `--executor` 时为 claude:haiku)
-- 1 条 = 单评委;≥ 2 条 = 多评委 ensemble + inter-judge agreement
-- 没有 Claude 时把 `--judge-models` 指向你可用的模型,例如 `--judge-models openai-api:glm-4-plus`
-- 加 `--no-judge` 可跳过 LLM 评委,仅使用断言评分
+- `--judge-models <list>` 指定评委，格式 `executor:model[,executor:model]`。默认 `${executor}:haiku`（没设 `--executor` 时为 claude:haiku）
+- 1 条 = 单评委；≥ 2 条 = 多评委 ensemble + inter-judge agreement
+- 没有 Claude 时把 `--judge-models` 指向你可用的模型，例如 `--judge-models openai-api:glm-4-plus`
+- 加 `--no-judge` 可跳过 LLM 评委，仅使用断言评分
 
 ## 环境变量
 

--- a/docs/zh/comparison.md
+++ b/docs/zh/comparison.md
@@ -1,18 +1,18 @@
 # omk 与同类工具对比
 
-与 7 个 LLM 评测工具的事实性对比,数据截至 2026-04。欢迎 PR 修正——如果竞品新增了我们标 `✗` 的能力,请提 PR,我们会及时更新。
+与 7 个 LLM 评测工具的事实性对比，数据截至 2026-04。欢迎 PR 修正——如果竞品新增了我们标 `✗` 的能力，请提 PR，我们会及时更新。
 
 [English](../comparison.md)
 
 ## 一句话总结
 
-omk 的护城河是**统计严谨性**:每条结论都能被研究者审计。Bootstrap CI、Krippendorff α 对人工锚点、length-debias 评委 prompt、饱和曲线——同类工具中**没有一个把这四件全做了**。
+omk 的护城河是**统计严谨性**：每条结论都能被研究者审计。Bootstrap CI、Krippendorff α 对人工锚点、length-debias 评委 prompt、饱和曲线——同类工具中**没有一个把这四件全做了**。
 
-需要**托管式 SaaS 看板**?选 LangSmith / Confident AI。
-要**本地快速 prompt 迭代不要统计层**?选 promptfoo。
-要**学术级 benchmark 覆盖**?选 lm-evaluation-harness。
-要**安全评测的 agent 沙箱**?选 inspect-ai。
-**要把 skill / prompt / RAG ship 到生产,且会被问"为什么应该相信这个数字"?选 omk。**
+需要**托管式 SaaS 看板**？选 LangSmith / Confident AI。
+要**本地快速 prompt 迭代不要统计层**？选 promptfoo。
+要**学术级 benchmark 覆盖**？选 lm-evaluation-harness。
+要**安全评测的 agent 沙箱**？选 inspect-ai。
+**要把 skill / prompt / RAG ship 到生产，且会被问"为什么应该相信这个数字"？选 omk。**
 
 ## 参与对比的工具
 
@@ -20,47 +20,47 @@ omk 的护城河是**统计严谨性**:每条结论都能被研究者审计。Bo
 |---|---|---|---|
 | [**omk**](https://github.com/lizhiyao/oh-my-knowledge) | TS / Node | 统计严谨性 + Claude Code 原生的 LLM 评测 | MIT |
 | [promptfoo](https://github.com/promptfoo/promptfoo) | TS / Node | 本地 CLI、red-team 重点、被 OpenAI 收购 | MIT |
-| [DeepEval](https://github.com/confident-ai/deepeval) | Python | pytest 风格 metric 库,Confident AI 商业化引流 | Apache 2.0 |
+| [DeepEval](https://github.com/confident-ai/deepeval) | Python | pytest 风格 metric 库，Confident AI 商业化引流 | Apache 2.0 |
 | [RAGAS](https://github.com/explodinggradients/ragas) | Python | RAG 专用 metric,statement-decomposition 实现 | Apache 2.0 |
-| [OpenAI Evals](https://github.com/openai/evals) | Python | benchmark 注册表,OpenAI 官方 | MIT |
+| [OpenAI Evals](https://github.com/openai/evals) | Python | benchmark 注册表，OpenAI 官方 | MIT |
 | [LangSmith](https://docs.smith.langchain.com/) | Python (LangChain) | 托管 SaaS,tracing + eval | 商业 |
-| [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) | Python | 学术黄金标准,HuggingFace Open LLM Leaderboard 后端 | MIT |
+| [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) | Python | 学术黄金标准，HuggingFace Open LLM Leaderboard 后端 | MIT |
 | [inspect-ai](https://github.com/UKGovernmentBEIS/inspect_ai) | Python | UK AISI 安全评测 | MIT |
 
 ## 统计严谨性
 
 | | omk | promptfoo | DeepEval | RAGAS | OpenAI Evals | LangSmith | lm-eval-harness | inspect-ai |
 |---|---|---|---|---|---|---|---|---|
-| Bootstrap CI(变量均值 + diff) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Krippendorff α(评委 ↔ 人工锚点) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Length-debias 评委 prompt(默认开) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Bootstrap CI（变量均值 + diff） | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Krippendorff α（评委 ↔ 人工锚点） | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Length-debias 评委 prompt（默认开） | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 饱和曲线 / 用例数诊断 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 配对用例显著性检验 | ✓(bootstrap) | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 
-omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的 lm-evaluation-harness 重学术复现,统计层只到点估计。
+omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的 lm-evaluation-harness 重学术复现，统计层只到点估计。
 
 ## 评分架构
 
 | | omk | promptfoo | DeepEval | RAGAS | OpenAI Evals | LangSmith | lm-eval-harness | inspect-ai |
 |---|---|---|---|---|---|---|---|---|
-| 三层独立评分(事实/行为/评委) | ✓ | ✗ | 部分 | ✗ | ✗ | ✗ | ✗ | ✗ |
+| 三层独立评分（事实/行为/评委） | ✓ | ✗ | 部分 | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 三层 all-pass CI gate | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| 用例隔离(per-variant skill 隔离 / construct validity) | ✓ 默认开 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | 部分 |
+| 用例隔离（per-variant skill 隔离 / construct validity） | ✓ 默认开 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | 部分 |
 | 用例设计元数据(capability / difficulty / construct / provenance) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 一行 verdict(PROGRESS / REGRESS / NOISE / ...) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| 知识缺口信号(严重度加权) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| 用例质量诊断(7 类 issue) | ✓ | 仅低区分度 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| 知识缺口信号（严重度加权） | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| 用例质量诊断（7 类 issue） | ✓ | 仅低区分度 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 失败 case LLM 聚类 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 
-三层独立评分能挡住"复合分掩盖单层崩盘":`fact 4.5→2.5 + judge 3→5` 在复合均值看着无伤,但三层 all-pass gate 能立刻抓出来。
+三层独立评分能挡住"复合分掩盖单层崩盘":`fact 4.5→2.5 + judge 3→5` 在复合均值看着无伤，但三层 all-pass gate 能立刻抓出来。
 
-**用例隔离**是一个 construct validity 维度:跑 `baseline` vs skill variant 时,三条 channel 都可能让 `baseline` 静默拿到用户 `~/.claude/skills/` 里被测的那个 skill。omk 默认 `--strict-baseline` 把三条都堵掉:(1) SDK skill auto-discovery,通过 `options.skills:[]`;(2) subagent Skill 工具,通过 `options.disallowedTools:['Skill']`;(3) cwd 文件系统访问 — baseline 默认 cwd 是用户评测工作目录,那里通常有 `skills/<name>/` symlink 给 treatment 用,baseline 用 `Glob` + `Read` 顺 symlink 直读 `SKILL.md` 就完全绕过 SDK 隔离。omk 在用户没显式指定 cwd 时把 baseline cwd 切到 `~/.oh-my-knowledge/isolated-cwd/`(空目录)。`--no-strict-baseline` 是逃生口,eval.yaml 支持 per-variant `allowedSkills` 白名单。inspect-ai 的 per-sample solver 模式能达到类似效果但需要显式逐题 wiring;promptfoo / DeepEval / OpenAI Evals 都不处理这维度。
+**用例隔离**是一个 construct validity 维度：跑 `baseline` vs skill variant 时，三条 channel 都可能让 `baseline` 静默拿到用户 `~/.claude/skills/` 里被测的那个 skill。omk 默认 `--strict-baseline` 把三条都堵掉：(1) SDK skill auto-discovery，通过 `options.skills:[]`;(2) subagent Skill 工具，通过 `options.disallowedTools:['Skill']`;(3) cwd 文件系统访问 — baseline 默认 cwd 是用户评测工作目录，那里通常有 `skills/<name>/` symlink 给 treatment 用，baseline 用 `Glob` + `Read` 顺 symlink 直读 `SKILL.md` 就完全绕过 SDK 隔离。omk 在用户没显式指定 cwd 时把 baseline cwd 切到 `~/.oh-my-knowledge/isolated-cwd/`（空目录）。`--no-strict-baseline` 是逃生口，eval.yaml 支持 per-variant `allowedSkills` 白名单。inspect-ai 的 per-sample solver 模式能达到类似效果但需要显式逐题 wiring;promptfoo / DeepEval / OpenAI Evals 都不处理这维度。
 
 ## 评委
 
 | | omk | promptfoo | DeepEval | RAGAS | OpenAI Evals | LangSmith | lm-eval-harness | inspect-ai |
 |---|---|---|---|---|---|---|---|---|
-| 多评委 ensemble(跨厂商) | ✓ Pearson + MAD | ✗ | ✗ | ✗ | ✗ | 部分 | ✗ | ✗ |
+| 多评委 ensemble（跨厂商） | ✓ Pearson + MAD | ✗ | ✗ | ✗ | ✗ | 部分 | ✗ | ✗ |
 | Judge-repeat 自一致性 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 评委 prompt hash 追溯 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Length-bias 实测验证 | ✓ `debias-validate` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -70,9 +70,9 @@ omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的
 
 | | omk | promptfoo | DeepEval | RAGAS | OpenAI Evals | LangSmith | lm-eval-harness | inspect-ai |
 |---|---|---|---|---|---|---|---|---|
-| RAG: faithfulness / answer_relevancy / context_recall | ✓ 自动继承 length-debias | 部分 | ✓ | ✓(多步分解) | ✗ | 部分 | ✗ | ✗ |
+| RAG: faithfulness / answer_relevancy / context_recall | ✓ 自动继承 length-debias | 部分 | ✓ | ✓（多步分解） | ✗ | 部分 | ✗ | ✗ |
 | ROUGE-N / Levenshtein / BLEU | ✓ 自实现零依赖 | ✓ | 部分 | ✗ | ✓ | ✗ | ✓ | ✗ |
-| 语义相似度(LLM 评分) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ |
+| 语义相似度（LLM 评分） | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ |
 | 工具调用 / agent 断言 | ✓ 9 种 | ✗ | 部分 | ✗ | ✗ | 部分 | ✗ | ✓ 强 |
 | 自定义 JS / Python 断言 | ✓ JS | ✓ JS | ✓ Python | 部分 | ✓ Python | ✓ Python | ✓ Python | ✓ Python |
 
@@ -85,7 +85,7 @@ omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的
 | 自迭代(`omk bench evolve`) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | eval.yaml(evaluation-as-code) | ✓ | ✓ | ✗ | ✗ | 部分 | ✗ | 部分 | ✓ |
 | CI/CD `omk bench gate` 退出码路由 | ✓ 三层 | ✓ 基础 | ✓ | ✗ | ✗ | 部分 | ✗ | ✓ |
-| 预算硬阈值(工作流级中止) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| 预算硬阈值（工作流级中止） | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 中断恢复 | ✓ `--resume` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 盲测 A/B + 揭晓 | ✓ | ✗ | ✗ | ✗ | ✗ | ✓ pairwise | ✗ | ✗ |
 | 多轮方差 + t 检验 | ✓ + bootstrap | ✗ | ✗ | ✗ | ✗ | 部分 | ✗ | ✗ |
@@ -94,28 +94,28 @@ omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的
 
 | | omk | promptfoo | DeepEval | RAGAS | OpenAI Evals | LangSmith | lm-eval-harness | inspect-ai |
 |---|---|---|---|---|---|---|---|---|
-| 完整中文文档 | ✓ | 部分(社区) | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| 完整中文文档 | ✓ | 部分（社区） | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | HTML 报告 i18n 切换 | ✓ EN/ZH | 部分 | ✗ | ✗ | ✗ | 部分 | ✗ | ✗ |
-| GitHub stars(2026-04) | 新生 | 9k+ | 12k+ | 9k+ | 16k+ | (商业) | 7.5k+ | 2k+ |
+| GitHub stars(2026-04) | 新生 | 9k+ | 12k+ | 9k+ | 16k+ | （商业） | 7.5k+ | 2k+ |
 | Cloud SaaS dashboard | ✗ | ✗ | ✓ Confident AI | ✗ | ✗ | ✓ | ✗ | ✗ |
 
 ## 什么场景选 omk
 
-**研究 / 学术 / NIST AI 800-3 合规对齐**。统计严谨性四件套就是为了回答"这个结论在小 N / 非正态数据 / 评委偏差下是否还稳健"。要发表或审计,bootstrap CI + α + length-debias 三件套是当前唯一现成可用的组合。
+**研究 / 学术 / NIST AI 800-3 合规对齐**。统计严谨性四件套就是为了回答"这个结论在小 N / 非正态数据 / 评委偏差下是否还稳健"。要发表或审计，bootstrap CI + α + length-debias 三件套是当前唯一现成可用的组合。
 
-**大厂 ML 平台团队**。当 skill / prompt 上线生产,组内会有人问"为什么我应该相信这个数字",omk 的审计链(judge prompt hash + 三层得分 + bootstrap CI + gold α)给你一个能扛住事故复盘的答案。
+**大厂 ML 平台团队**。当 skill / prompt 上线生产，组内会有人问"为什么我应该相信这个数字",omk 的审计链（judge prompt hash + 三层得分 + bootstrap CI + gold α）给你一个能扛住事故复盘的答案。
 
-**中文 AI 工程团队**。omk 是参与对比工具中**唯一**有完整中文文档的——README、CLI help、HTML 报告、术语规范、缺口信号规范、RAG metric 规范全部原生中文(非机翻)。
+**中文 AI 工程团队**。omk 是参与对比工具中**唯一**有完整中文文档的——README、CLI help、HTML 报告、术语规范、缺口信号规范、RAG metric 规范全部原生中文（非机翻）。
 
-**Claude Code 用户**。omk 在 Claude Code 里的工作流最原生:既可以作为 Claude Code skill 使用,底层 `omk` CLI 也能被 Codex 等 coding agent 直接驱动。promptfoo / DeepEval 等通常需要 shim 一层自定义 executor,才能接近这种面向 artifact 的工作流。
+**Claude Code 用户**。omk 在 Claude Code 里的工作流最原生：既可以作为 Claude Code skill 使用，底层 `omk` CLI 也能被 Codex 等 coding agent 直接驱动。promptfoo / DeepEval 等通常需要 shim 一层自定义 executor，才能接近这种面向 artifact 的工作流。
 
 ## 什么场景**不**选 omk
 
-**需要托管 SaaS 看板 + 团队账号 + 共享 dataset hub**。选 LangSmith 或 Confident AI。omk 刻意只做 CLI + 本地 HTML,不打算 ship SaaS。
+**需要托管 SaaS 看板 + 团队账号 + 共享 dataset hub**。选 LangSmith 或 Confident AI。omk 刻意只做 CLI + 本地 HTML，不打算 ship SaaS。
 
-**做 red-team,需要攻击 prompt 库**。选 promptfoo,它有 67+ 个 red-team 插件;omk 是通用评测,不专攻攻击库。
+**做 red-team，需要攻击 prompt 库**。选 promptfoo，它有 67+ 个 red-team 插件；omk 是通用评测，不专攻攻击库。
 
-**对基础模型跑学术基准(HumanEval / MMLU 等)**。选 lm-evaluation-harness,它是事实上的 leaderboard 后端;omk 不为 benchmark 注册表场景优化。
+**对基础模型跑学术基准（HumanEval / MMLU 等）**。选 lm-evaluation-harness，它是事实上的 leaderboard 后端；omk 不为 benchmark 注册表场景优化。
 
 **安全场景需要 Docker / Kubernetes / Modal 紧密沙箱**。选 inspect-ai,UK AISI 就是为这场景做的。
 
@@ -123,14 +123,14 @@ omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的
 
 ## 共存模式
 
-omk 与其他工具天然兼容。常见组合:
+omk 与其他工具天然兼容。常见组合：
 
-- **omk + LangSmith** — omk 做离线评测严谨性,LangSmith 做生产 tracing
+- **omk + LangSmith** — omk 做离线评测严谨性，LangSmith 做生产 tracing
 - **omk + RAGAS** — RAGAS 做细粒度 statement-decomposition faithfulness,omk 做跨版本回归 + 统计 CI
-- **omk + lm-eval-harness** — lm-eval 跑基础模型 leaderboard 分,omk 在 prompt / skill / RAG 层做工程评测
+- **omk + lm-eval-harness** — lm-eval 跑基础模型 leaderboard 分，omk 在 prompt / skill / RAG 层做工程评测
 
 ## 更新与修正
 
-本页尽力保持准确,但竞品能力变化快(2025 年内 promptfoo 加了 `assert-set`,DeepEval 加了 agentic eval suite)。如发现过时或错误,请提 PR,我们会合并。
+本页尽力保持准确，但竞品能力变化快（2025 年内 promptfoo 加了 `assert-set`,DeepEval 加了 agentic eval suite）。如发现过时或错误，请提 PR，我们会合并。
 
-最后核对:2026-04-25。
+最后核对：2026-04-25。

--- a/docs/zh/comparison.md
+++ b/docs/zh/comparison.md
@@ -21,9 +21,9 @@ omk 的护城河是**统计严谨性**：每条结论都能被研究者审计。
 | [**omk**](https://github.com/lizhiyao/oh-my-knowledge) | TS / Node | 统计严谨性 + Claude Code 原生的 LLM 评测 | MIT |
 | [promptfoo](https://github.com/promptfoo/promptfoo) | TS / Node | 本地 CLI、red-team 重点、被 OpenAI 收购 | MIT |
 | [DeepEval](https://github.com/confident-ai/deepeval) | Python | pytest 风格 metric 库，Confident AI 商业化引流 | Apache 2.0 |
-| [RAGAS](https://github.com/explodinggradients/ragas) | Python | RAG 专用 metric,statement-decomposition 实现 | Apache 2.0 |
+| [RAGAS](https://github.com/explodinggradients/ragas) | Python | RAG 专用 metric，statement-decomposition 实现 | Apache 2.0 |
 | [OpenAI Evals](https://github.com/openai/evals) | Python | benchmark 注册表，OpenAI 官方 | MIT |
-| [LangSmith](https://docs.smith.langchain.com/) | Python (LangChain) | 托管 SaaS,tracing + eval | 商业 |
+| [LangSmith](https://docs.smith.langchain.com/) | Python (LangChain) | 托管 SaaS，tracing + eval | 商业 |
 | [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) | Python | 学术黄金标准，HuggingFace Open LLM Leaderboard 后端 | MIT |
 | [inspect-ai](https://github.com/UKGovernmentBEIS/inspect_ai) | Python | UK AISI 安全评测 | MIT |
 
@@ -52,9 +52,9 @@ omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的
 | 用例质量诊断（7 类 issue） | ✓ | 仅低区分度 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 失败 case LLM 聚类 | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 
-三层独立评分能挡住"复合分掩盖单层崩盘":`fact 4.5→2.5 + judge 3→5` 在复合均值看着无伤，但三层 all-pass gate 能立刻抓出来。
+三层独立评分能挡住"复合分掩盖单层崩盘"：`fact 4.5→2.5 + judge 3→5` 在复合均值看着无伤，但三层 all-pass gate 能立刻抓出来。
 
-**用例隔离**是一个 construct validity 维度：跑 `baseline` vs skill variant 时，三条 channel 都可能让 `baseline` 静默拿到用户 `~/.claude/skills/` 里被测的那个 skill。omk 默认 `--strict-baseline` 把三条都堵掉：(1) SDK skill auto-discovery，通过 `options.skills:[]`;(2) subagent Skill 工具，通过 `options.disallowedTools:['Skill']`;(3) cwd 文件系统访问 — baseline 默认 cwd 是用户评测工作目录，那里通常有 `skills/<name>/` symlink 给 treatment 用，baseline 用 `Glob` + `Read` 顺 symlink 直读 `SKILL.md` 就完全绕过 SDK 隔离。omk 在用户没显式指定 cwd 时把 baseline cwd 切到 `~/.oh-my-knowledge/isolated-cwd/`（空目录）。`--no-strict-baseline` 是逃生口，eval.yaml 支持 per-variant `allowedSkills` 白名单。inspect-ai 的 per-sample solver 模式能达到类似效果但需要显式逐题 wiring;promptfoo / DeepEval / OpenAI Evals 都不处理这维度。
+**用例隔离**是一个 construct validity 维度：跑 `baseline` vs skill variant 时，三条 channel 都可能让 `baseline` 静默拿到用户 `~/.claude/skills/` 里被测的那个 skill。omk 默认 `--strict-baseline` 把三条都堵掉：（1）SDK skill auto-discovery，通过 `options.skills:[]`；（2）subagent Skill 工具，通过 `options.disallowedTools:['Skill']`；（3）cwd 文件系统访问 — baseline 默认 cwd 是用户评测工作目录，那里通常有 `skills/<name>/` symlink 给 treatment 用，baseline 用 `Glob` + `Read` 顺 symlink 直读 `SKILL.md` 就完全绕过 SDK 隔离。omk 在用户没显式指定 cwd 时把 baseline cwd 切到 `~/.oh-my-knowledge/isolated-cwd/`（空目录）。`--no-strict-baseline` 是逃生口，eval.yaml 支持 per-variant `allowedSkills` 白名单。inspect-ai 的 per-sample solver 模式能达到类似效果但需要显式逐题 wiring；promptfoo / DeepEval / OpenAI Evals 都不处理这维度。
 
 ## 评委
 
@@ -103,7 +103,7 @@ omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的
 
 **研究 / 学术 / NIST AI 800-3 合规对齐**。统计严谨性四件套就是为了回答"这个结论在小 N / 非正态数据 / 评委偏差下是否还稳健"。要发表或审计，bootstrap CI + α + length-debias 三件套是当前唯一现成可用的组合。
 
-**大厂 ML 平台团队**。当 skill / prompt 上线生产，组内会有人问"为什么我应该相信这个数字",omk 的审计链（judge prompt hash + 三层得分 + bootstrap CI + gold α）给你一个能扛住事故复盘的答案。
+**大厂 ML 平台团队**。当 skill / prompt 上线生产，组内会有人问"为什么我应该相信这个数字"，omk 的审计链（judge prompt hash + 三层得分 + bootstrap CI + gold α）给你一个能扛住事故复盘的答案。
 
 **中文 AI 工程团队**。omk 是参与对比工具中**唯一**有完整中文文档的——README、CLI help、HTML 报告、术语规范、缺口信号规范、RAG metric 规范全部原生中文（非机翻）。
 
@@ -117,7 +117,7 @@ omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的
 
 **对基础模型跑学术基准（HumanEval / MMLU 等）**。选 lm-evaluation-harness，它是事实上的 leaderboard 后端；omk 不为 benchmark 注册表场景优化。
 
-**安全场景需要 Docker / Kubernetes / Modal 紧密沙箱**。选 inspect-ai,UK AISI 就是为这场景做的。
+**安全场景需要 Docker / Kubernetes / Modal 紧密沙箱**。选 inspect-ai，UK AISI 就是为这场景做的。
 
 **只是一次性测 5 个 prompt**。写个一次性 Python 脚本就行。omk 的价值在反复跑 + 跨时间统计可比。
 
@@ -126,11 +126,11 @@ omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的
 omk 与其他工具天然兼容。常见组合：
 
 - **omk + LangSmith** — omk 做离线评测严谨性，LangSmith 做生产 tracing
-- **omk + RAGAS** — RAGAS 做细粒度 statement-decomposition faithfulness,omk 做跨版本回归 + 统计 CI
+- **omk + RAGAS** — RAGAS 做细粒度 statement-decomposition faithfulness，omk 做跨版本回归 + 统计 CI
 - **omk + lm-eval-harness** — lm-eval 跑基础模型 leaderboard 分，omk 在 prompt / skill / RAG 层做工程评测
 
 ## 更新与修正
 
-本页尽力保持准确，但竞品能力变化快（2025 年内 promptfoo 加了 `assert-set`,DeepEval 加了 agentic eval suite）。如发现过时或错误，请提 PR，我们会合并。
+本页尽力保持准确，但竞品能力变化快（2025 年内 promptfoo 加了 `assert-set`，DeepEval 加了 agentic eval suite）。如发现过时或错误，请提 PR，我们会合并。
 
 最后核对：2026-04-25。

--- a/docs/zh/roadmap.md
+++ b/docs/zh/roadmap.md
@@ -46,16 +46,16 @@ OMK 下一步不应继续横向堆 metric，而应做“可信评测产品化”
 
 项目级指标：
 
-- GitHub:stars 从 1 增长到 25+；至少 3 个外部 issue / discussion；至少 1 个外部 PR 或明确外部用户案例。
-- npm:weekly downloads 从约 779 增长到 1500+。
+- GitHub：stars 从 1 增长到 25+；至少 3 个外部 issue / discussion；至少 1 个外部 PR 或明确外部用户案例。
+- npm：weekly downloads 从约 779 增长到 1500+。
 - 首次成功路径：新用户从 `omk bench init` 到第一份 HTML report 的中位时间低于 5 分钟。
 - 社区反馈：至少 3 个非作者团队实际跑过 `omk bench run` 并反馈问题。
 
 功能成功指标：
 
-- v0.26：新模板项目在干净环境中 `init -> dry-run -> run -> report` 成功率接近 100%;doctor 输出的问题可直接行动。
+- v0.26：新模板项目在干净环境中 `init -> dry-run -> run -> report` 成功率接近 100%；doctor 输出的问题可直接行动。
 - v0.27：至少 10 条真实 session / trace 能自动转成 eval sample 草稿；trace adapter 遇到未知 vendor schema 时降级而不是崩溃。
-- v0.28:MVP 只覆盖知识 artifact 相关安全面，能跑出安全 verdict 和可复现 case，不追求通用 red-team 覆盖。
+- v0.28：MVP 只覆盖知识 artifact 相关安全面，能跑出安全 verdict 和可复现 case，不追求通用 red-team 覆盖。
 - v0.29：报告可以一键导出 PR / CI / 审计材料，并被至少 1 个真实 PR 流程使用。
 
 ## 行业方向
@@ -76,7 +76,7 @@ OMK 下一步不应继续横向堆 metric，而应做“可信评测产品化”
 低成本高 ROI 动作：
 
 - 写 1 篇长文：主题聚焦“为什么 prompt / RAG / skill / agent 需要可信评测，不是凭感觉上线”。
-- 做 1-2 个 demo video:5 分钟从 `bench init` 到 report；另一个展示 trace 回流 eval dataset。
+- 做 1-2 个 demo video：5 分钟从 `bench init` 到 report；另一个展示 trace 回流 eval dataset。
 - 内部推广 3 个真实团队或项目，收集失败路径和术语误解。
 - 在 dev.to / 掘金 / GitHub Discussions 发布中文和英文短版。
 - 给 awesome-llm-eval / awesome-ai-agents 等列表提 PR，把 OMK 加进去。
@@ -93,10 +93,10 @@ distribution 成功标准：
 
 建议节奏：
 
-- v0.26:2-3 周，偏产品打磨和文案。
-- v0.27:3-5 周，取决于 Claude / Codex session schema 稳定性。
-- v0.28:4-6 周，必须限制为 MVP，否则会滑向完整 red-team 平台。
-- v0.29:2-4 周，偏导出、报告和 CI 集成。
+- v0.26：2-3 周，偏产品打磨和文案。
+- v0.27：3-5 周，取决于 Claude / Codex session schema 稳定性。
+- v0.28：4-6 周，必须限制为 MVP，否则会滑向完整 red-team 平台。
+- v0.29：2-4 周，偏导出、报告和 CI 集成。
 
 主要风险：
 
@@ -106,7 +106,7 @@ distribution 成功标准：
 
 ## 分阶段计划
 
-### v0.26: 首次成功路径
+### v0.26：首次成功路径
 
 目标：用户从安装到第一份可信报告不掉坑。
 
@@ -119,20 +119,20 @@ distribution 成功标准：
 - 压缩 README 首屏信息密度，把“5 分钟得到可信报告”变成唯一主线。
 - 成功标准：`init -> dry-run -> run -> report` 中位时间低于 5 分钟；npm weekly downloads 达到 1500+；新增至少 3 条外部 issue / discussion / 用户反馈。
 
-### v0.27: production trace 到 eval dataset 闭环
+### v0.27：production trace 到 eval dataset 闭环
 
 目标：把 OMK 从离线评测工具推进到“真实使用问题回流评测”的工具。
 
 优先事项：
 
-- 抽出 schema-version-aware trace adapter:Claude / Codex / future vendor trace 都先归一到 OMK 内部 trace schema。
+- 抽出 schema-version-aware trace adapter：Claude / Codex / future vendor trace 都先归一到 OMK 内部 trace schema。
 - `omk analyze sessions` 输出候选失败样本。
 - `omk bench gen-samples --from-traces` 把真实失败 trace 转成 eval sample 草稿。
 - 报告展示“本次 eval 覆盖了哪些真实使用缺口”。
 - 对 Claude Code / Codex trace 做更清晰的 tool trajectory 诊断。
 - 成功标准：至少 10 条真实 trace 能自动生成 sample 草稿；未知 vendor trace 字段不导致崩溃；至少 1 个真实问题通过 trace 回流后被 eval 防回归。
 
-### v0.28: 安全与知识污染专项
+### v0.28：安全与知识污染专项
 
 目标：承接行业 red-team 趋势，但保持 OMK 的知识 artifact 定位。
 
@@ -151,7 +151,7 @@ distribution 成功标准：
 - 支持导入 promptfoo / Inspect 结果，整合到 OMK 报告。
 - 成功标准：每类 MVP 风险至少 3 条可复现用例；安全 verdict 可独立导出；至少 1 个外部工具结果能被导入 OMK 报告。
 
-### v0.29: 可信报告包
+### v0.29：可信报告包
 
 目标：让团队能把报告用于 code review、事故复盘、release notes 和审计。
 
@@ -179,7 +179,7 @@ distribution 成功标准：
 
 ## 修订记录
 
-- 2026-05-03 v1: 初稿，六段（核心判断 / 短板 / 信号 / 行业方向 / 分阶段 / 暂缓）。
-- 2026-05-03 v2: 加成功标准量化 / 并行 distribution stream / 时间节奏与风险 / v0.28 范围约束 / 每个 minor 版本独立成功标准。
+- 2026-05-03 v1：初稿，六段（核心判断 / 短板 / 信号 / 行业方向 / 分阶段 / 暂缓）。
+- 2026-05-03 v2：加成功标准量化 / 并行 distribution stream / 时间节奏与风险 / v0.28 范围约束 / 每个 minor 版本独立成功标准。
 
 如果你打算更新本文档，建议保留 git history 而非整段 rewrite——后人需要从 history 看判断是怎么演化的。

--- a/docs/zh/roadmap.md
+++ b/docs/zh/roadmap.md
@@ -1,88 +1,88 @@
 # OMK 下一阶段路线图笔记
 
 > [!NOTE]
-> 本文是 planning note,记录 2026-05-03 时点对项目方向的判断。
-> **不是 release 承诺,也不替代 issue / PR 的具体设计**。
+> 本文是 planning note，记录 2026-05-03 时点对项目方向的判断。
+> **不是 release 承诺，也不替代 issue / PR 的具体设计**。
 > 任何 minor 版本到来前内容可能已过时——请以最近的 PR 标题、release notes 为准。
-> 本 roadmap 至少每个 minor 版本回顾一次;如果 git 最近修改时间 > 60 天,大概率已过时。
+> 本 roadmap 至少每个 minor 版本回顾一次；如果 git 最近修改时间 > 60 天，大概率已过时。
 
-日期: 2026-05-03
+日期： 2026-05-03
 
 ## 核心判断
 
-OMK 下一步不应继续横向堆 metric,而应做“可信评测产品化”:把现有统计严谨性、知识输入定位、Claude / Codex agent 工作流变成低摩擦、可复现、可审计的一条主路径。
+OMK 下一步不应继续横向堆 metric，而应做“可信评测产品化”：把现有统计严谨性、知识输入定位、Claude / Codex agent 工作流变成低摩擦、可复现、可审计的一条主路径。
 
-当前优势:
+当前优势：
 
-- 统计严谨性默认开启:Bootstrap CI、Krippendorff alpha、长度去偏、饱和曲线。
-- artifact 隔离和 construct validity 是差异化能力,尤其适合 skill / prompt / RAG / agent workflow。
-- 多执行器和多评委已经具备基础:Claude、Codex、OpenAI、Gemini、自定义命令。
+- 统计严谨性默认开启：Bootstrap CI、Krippendorff alpha、长度去偏、饱和曲线。
+- artifact 隔离和 construct validity 是差异化能力，尤其适合 skill / prompt / RAG / agent workflow。
+- 多执行器和多评委已经具备基础：Claude、Codex、OpenAI、Gemini、自定义命令。
 - 中文体验和中文文档是明确差异化点。
 
-当前短板:
+当前短板：
 
-- 真实用户闭环还弱:生产 session / trace 到 eval dataset 的路径不够顺滑。
-- 首次上手路径偏工程化:能力很多,但用户第一份可信报告的路径还不够短。
-- warning / fatal / progress noise 的语义区分还不够清楚,容易影响调试判断。
+- 真实用户闭环还弱：生产 session / trace 到 eval dataset 的路径不够顺滑。
+- 首次上手路径偏工程化：能力很多，但用户第一份可信报告的路径还不够短。
+- warning / fatal / progress noise 的语义区分还不够清楚，容易影响调试判断。
 - 安全 / red-team 与生产 trace 回流还没有形成产品化主线。
-- distribution / community 维度不足:当前真实外部 visitor、star、issue、fork 都很少。单纯继续做产品功能无法自动解决 awareness 问题。
+- distribution / community 维度不足：当前真实外部 visitor、star、issue、fork 都很少。单纯继续做产品功能无法自动解决 awareness 问题。
 
 ## 近期使用信号
 
-- npm 下载在 2026-04-23 后明显抬升,最近一周约 779 downloads。
-- GitHub 近两周 traffic 显示有 clone 和浏览行为,但 star / issue / discussion 还很少。
+- npm 下载在 2026-04-23 后明显抬升，最近一周约 779 downloads。
+- GitHub 近两周 traffic 显示有 clone 和浏览行为，但 star / issue / discussion 还很少。
 - 近期 PR 集中在 `omk doctor`、`eval.yaml v0.2 / judgeModels`、release flow、README 定位、测试维护性。
-- 实际协作暴露出的用户摩擦包括:
+- 实际协作暴露出的用户摩擦包括：
   - agent 容易忘记项目工作流和分支规则。
   - 预期内 warning / fatal 会被误认为测试失败风险。
-  - 测试数量变化需要解释,否则容易被误读为覆盖下降。
+  - 测试数量变化需要解释，否则容易被误读为覆盖下降。
   - Codex / Claude Code 的入口和职责边界需要持续清晰化。
 
-这些信号说明 OMK 当前更像“早期高频验证 + 自动化使用”阶段,还没有形成稳定外部社区反馈循环。
+这些信号说明 OMK 当前更像“早期高频验证 + 自动化使用”阶段，还没有形成稳定外部社区反馈循环。
 
 ## 成功标准
 
-这份 roadmap 不是 release 承诺,但每个阶段都需要复盘锚点。下面数字是 planning anchor,后续可以按真实数据修正。
+这份 roadmap 不是 release 承诺，但每个阶段都需要复盘锚点。下面数字是 planning anchor，后续可以按真实数据修正。
 
-项目级指标:
+项目级指标：
 
-- GitHub:stars 从 1 增长到 25+;至少 3 个外部 issue / discussion;至少 1 个外部 PR 或明确外部用户案例。
+- GitHub:stars 从 1 增长到 25+；至少 3 个外部 issue / discussion；至少 1 个外部 PR 或明确外部用户案例。
 - npm:weekly downloads 从约 779 增长到 1500+。
-- 首次成功路径:新用户从 `omk bench init` 到第一份 HTML report 的中位时间低于 5 分钟。
-- 社区反馈:至少 3 个非作者团队实际跑过 `omk bench run` 并反馈问题。
+- 首次成功路径：新用户从 `omk bench init` 到第一份 HTML report 的中位时间低于 5 分钟。
+- 社区反馈：至少 3 个非作者团队实际跑过 `omk bench run` 并反馈问题。
 
-功能成功指标:
+功能成功指标：
 
-- v0.26:新模板项目在干净环境中 `init -> dry-run -> run -> report` 成功率接近 100%;doctor 输出的问题可直接行动。
-- v0.27:至少 10 条真实 session / trace 能自动转成 eval sample 草稿;trace adapter 遇到未知 vendor schema 时降级而不是崩溃。
-- v0.28:MVP 只覆盖知识 artifact 相关安全面,能跑出安全 verdict 和可复现 case,不追求通用 red-team 覆盖。
-- v0.29:报告可以一键导出 PR / CI / 审计材料,并被至少 1 个真实 PR 流程使用。
+- v0.26：新模板项目在干净环境中 `init -> dry-run -> run -> report` 成功率接近 100%;doctor 输出的问题可直接行动。
+- v0.27：至少 10 条真实 session / trace 能自动转成 eval sample 草稿；trace adapter 遇到未知 vendor schema 时降级而不是崩溃。
+- v0.28:MVP 只覆盖知识 artifact 相关安全面，能跑出安全 verdict 和可复现 case，不追求通用 red-team 覆盖。
+- v0.29：报告可以一键导出 PR / CI / 审计材料，并被至少 1 个真实 PR 流程使用。
 
 ## 行业方向
 
-行业趋势和 OMK 的关系:
+行业趋势和 OMK 的关系：
 
-- LangSmith 的主线是 offline eval + online eval + production trace 反馈闭环。OMK 已有 session observability,下一步应把真实失败 trace 回流到 offline eval 做顺。
-- DeepEval 强调 pytest 风格、本地优先、50+ metrics、component-level tracing。OMK 不应追 metric 数量,但需要把 agent / tool trace 的组件级定位做得更直接。
-- Promptfoo / OpenAI Frontier 方向表明 red-team、安全、合规、traceability 已经是企业 agent eval 的核心诉求。OMK 可以做知识 artifact 语境下的安全评测,但不必复刻完整 red-team 平台。
-- Ragas 已经覆盖 RAG / agent / tool / SQL / 通用 metric。OMK 更适合互操作和报告整合,不应重复造完整专项 metric zoo。
-- Inspect AI 的强项是 agent eval + sandbox + 外部 agent。OMK 可以兼容其产物,但短期不应投入大型 sandbox。
+- LangSmith 的主线是 offline eval + online eval + production trace 反馈闭环。OMK 已有 session observability，下一步应把真实失败 trace 回流到 offline eval 做顺。
+- DeepEval 强调 pytest 风格、本地优先、50+ metrics、component-level tracing。OMK 不应追 metric 数量，但需要把 agent / tool trace 的组件级定位做得更直接。
+- Promptfoo / OpenAI Frontier 方向表明 red-team、安全、合规、traceability 已经是企业 agent eval 的核心诉求。OMK 可以做知识 artifact 语境下的安全评测，但不必复刻完整 red-team 平台。
+- Ragas 已经覆盖 RAG / agent / tool / SQL / 通用 metric。OMK 更适合互操作和报告整合，不应重复造完整专项 metric zoo。
+- Inspect AI 的强项是 agent eval + sandbox + 外部 agent。OMK 可以兼容其产物，但短期不应投入大型 sandbox。
 - NIST / MLCommons AILuminate / HELM 都在强化多维、标准化、透明、可审计评测。这与 OMK 的统计严谨性护城河一致。
 
 ## 并行 distribution / community stream
 
-这个 stream 不绑定具体 minor 版本,应与 v0.26-v0.29 并行推进。原因:当前 OMK 更缺真实用户和外部反馈,不是只缺产品功能。
+这个 stream 不绑定具体 minor 版本，应与 v0.26-v0.29 并行推进。原因：当前 OMK 更缺真实用户和外部反馈，不是只缺产品功能。
 
-低成本高 ROI 动作:
+低成本高 ROI 动作：
 
-- 写 1 篇长文:主题聚焦“为什么 prompt / RAG / skill / agent 需要可信评测,不是凭感觉上线”。
-- 做 1-2 个 demo video:5 分钟从 `bench init` 到 report;另一个展示 trace 回流 eval dataset。
-- 内部推广 3 个真实团队或项目,收集失败路径和术语误解。
+- 写 1 篇长文：主题聚焦“为什么 prompt / RAG / skill / agent 需要可信评测，不是凭感觉上线”。
+- 做 1-2 个 demo video:5 分钟从 `bench init` 到 report；另一个展示 trace 回流 eval dataset。
+- 内部推广 3 个真实团队或项目，收集失败路径和术语误解。
 - 在 dev.to / 掘金 / GitHub Discussions 发布中文和英文短版。
-- 给 awesome-llm-eval / awesome-ai-agents 等列表提 PR,把 OMK 加进去。
-- 把 `assets/screenshots` 和 README 首屏调整成可传播材料,避免只有技术细节没有第一眼价值。
+- 给 awesome-llm-eval / awesome-ai-agents 等列表提 PR，把 OMK 加进去。
+- 把 `assets/screenshots` 和 README 首屏调整成可传播材料，避免只有技术细节没有第一眼价值。
 
-distribution 成功标准:
+distribution 成功标准：
 
 - 每月至少 1 个外部渠道发布。
 - 每月至少 3 个真实用户访谈或异步反馈。
@@ -91,81 +91,81 @@ distribution 成功标准:
 
 ## 时间节奏和风险
 
-建议节奏:
+建议节奏：
 
-- v0.26:2-3 周,偏产品打磨和文案。
-- v0.27:3-5 周,取决于 Claude / Codex session schema 稳定性。
-- v0.28:4-6 周,必须限制为 MVP,否则会滑向完整 red-team 平台。
-- v0.29:2-4 周,偏导出、报告和 CI 集成。
+- v0.26:2-3 周，偏产品打磨和文案。
+- v0.27:3-5 周，取决于 Claude / Codex session schema 稳定性。
+- v0.28:4-6 周，必须限制为 MVP，否则会滑向完整 red-team 平台。
+- v0.29:2-4 周，偏导出、报告和 CI 集成。
 
-主要风险:
+主要风险：
 
-- vendor trace schema 改动会拖累 v0.27。需要 schema-version-aware adapter,未知字段保留、未知版本降级、输出明确 warning。
-- v0.28 容易被低估。prompt injection、RAG poisoning、tool misuse 都是完整领域,OMK 只做知识 artifact 语境下的最小闭环。
-- distribution 如果不并行推进,即使 v0.26-v0.29 全做完,仍可能只有很少外部用户。
+- vendor trace schema 改动会拖累 v0.27。需要 schema-version-aware adapter，未知字段保留、未知版本降级、输出明确 warning。
+- v0.28 容易被低估。prompt injection、RAG poisoning、tool misuse 都是完整领域，OMK 只做知识 artifact 语境下的最小闭环。
+- distribution 如果不并行推进，即使 v0.26-v0.29 全做完，仍可能只有很少外部用户。
 
 ## 分阶段计划
 
 ### v0.26: 首次成功路径
 
-目标:用户从安装到第一份可信报告不掉坑。
+目标：用户从安装到第一份可信报告不掉坑。
 
-优先事项:
+优先事项：
 
-- `omk bench init` 增加更明确模板:`skill` / `prompt` / `rag` / `agent`。
-- `omk doctor` 输出更可操作的 fix hints,并补强 `doctor --json` 给 agent / CI 使用。
-- 把预期内 progress noise、warning、fatal 区分清楚,避免用户把预期噪声误读为真实失败。
+- `omk bench init` 增加更明确模板：`skill` / `prompt` / `rag` / `agent`。
+- `omk doctor` 输出更可操作的 fix hints，并补强 `doctor --json` 给 agent / CI 使用。
+- 把预期内 progress noise、warning、fatal 区分清楚，避免用户把预期噪声误读为真实失败。
 - 修正 report server 在受限环境下 `listen(0)` 被拒时误报 `port 0 is already in use` 的错误文案。
-- 压缩 README 首屏信息密度,把“5 分钟得到可信报告”变成唯一主线。
-- 成功标准:`init -> dry-run -> run -> report` 中位时间低于 5 分钟;npm weekly downloads 达到 1500+;新增至少 3 条外部 issue / discussion / 用户反馈。
+- 压缩 README 首屏信息密度，把“5 分钟得到可信报告”变成唯一主线。
+- 成功标准：`init -> dry-run -> run -> report` 中位时间低于 5 分钟；npm weekly downloads 达到 1500+；新增至少 3 条外部 issue / discussion / 用户反馈。
 
 ### v0.27: production trace 到 eval dataset 闭环
 
-目标:把 OMK 从离线评测工具推进到“真实使用问题回流评测”的工具。
+目标：把 OMK 从离线评测工具推进到“真实使用问题回流评测”的工具。
 
-优先事项:
+优先事项：
 
 - 抽出 schema-version-aware trace adapter:Claude / Codex / future vendor trace 都先归一到 OMK 内部 trace schema。
 - `omk analyze sessions` 输出候选失败样本。
 - `omk bench gen-samples --from-traces` 把真实失败 trace 转成 eval sample 草稿。
 - 报告展示“本次 eval 覆盖了哪些真实使用缺口”。
 - 对 Claude Code / Codex trace 做更清晰的 tool trajectory 诊断。
-- 成功标准:至少 10 条真实 trace 能自动生成 sample 草稿;未知 vendor trace 字段不导致崩溃;至少 1 个真实问题通过 trace 回流后被 eval 防回归。
+- 成功标准：至少 10 条真实 trace 能自动生成 sample 草稿；未知 vendor trace 字段不导致崩溃；至少 1 个真实问题通过 trace 回流后被 eval 防回归。
 
 ### v0.28: 安全与知识污染专项
 
-目标:承接行业 red-team 趋势,但保持 OMK 的知识 artifact 定位。
+目标：承接行业 red-team 趋势，但保持 OMK 的知识 artifact 定位。
 
-范围约束:
+范围约束：
 
-- 只做 knowledge-artifact profile,不做通用 red-team 平台。
-- 只覆盖 5 类 MVP 风险:prompt injection、skill leakage、RAG poisoning、tool misuse、baseline contamination。
-- 每类先做少量高质量固定用例 + 可解释 verdict,不追求攻击库规模。
-- 对外部 red-team 工具优先做 import / report integration,不复刻其攻击生成能力。
+- 只做 knowledge-artifact profile，不做通用 red-team 平台。
+- 只覆盖 5 类 MVP 风险：prompt injection、skill leakage、RAG poisoning、tool misuse、baseline contamination。
+- 每类先做少量高质量固定用例 + 可解释 verdict，不追求攻击库规模。
+- 对外部 red-team 工具优先做 import / report integration，不复刻其攻击生成能力。
 
-优先事项:
+优先事项：
 
 - 增加 `omk bench redteam --profile knowledge-artifact`。
 - 覆盖 prompt injection、skill leakage、RAG poisoning、tool misuse、baseline contamination。
-- 输出独立安全维度 verdict,不混入综合质量分。
-- 支持导入 promptfoo / Inspect 结果,整合到 OMK 报告。
-- 成功标准:每类 MVP 风险至少 3 条可复现用例;安全 verdict 可独立导出;至少 1 个外部工具结果能被导入 OMK 报告。
+- 输出独立安全维度 verdict，不混入综合质量分。
+- 支持导入 promptfoo / Inspect 结果，整合到 OMK 报告。
+- 成功标准：每类 MVP 风险至少 3 条可复现用例；安全 verdict 可独立导出；至少 1 个外部工具结果能被导入 OMK 报告。
 
 ### v0.29: 可信报告包
 
-目标:让团队能把报告用于 code review、事故复盘、release notes 和审计。
+目标：让团队能把报告用于 code review、事故复盘、release notes 和审计。
 
-优先事项:
+优先事项：
 
 - `omk bench export --format github-summary|junit|sarif|markdown`。
-- 报告增加“审计摘要”:样本数、CI、judge hash、human alpha、dataset version、artifact hash、已知 caveat。
+- 报告增加“审计摘要”：样本数、CI、judge hash、human alpha、dataset version、artifact hash、已知 caveat。
 - Release notes 自动提示 `BREAKING-COMPARABILITY` 和测量不变量变化。
 - 生成可直接贴到 PR 的中文摘要。
-- 成功标准:GitHub summary / markdown 至少被 1 个真实 PR 使用;CI/JUnit/SARIF 至少能在 GitHub Actions 中消费;审计摘要包含所有测量学不变量和 caveat。
+- 成功标准：GitHub summary / markdown 至少被 1 个真实 PR 使用；CI/JUnit/SARIF 至少能在 GitHub Actions 中消费；审计摘要包含所有测量学不变量和 caveat。
 
 ## 暂缓事项
 
-短期不建议投入:
+短期不建议投入：
 
 - SaaS dashboard。
 - 大而全 metric zoo。
@@ -179,7 +179,7 @@ distribution 成功标准:
 
 ## 修订记录
 
-- 2026-05-03 v1: 初稿,六段(核心判断 / 短板 / 信号 / 行业方向 / 分阶段 / 暂缓)。
+- 2026-05-03 v1: 初稿，六段（核心判断 / 短板 / 信号 / 行业方向 / 分阶段 / 暂缓）。
 - 2026-05-03 v2: 加成功标准量化 / 并行 distribution stream / 时间节奏与风险 / v0.28 范围约束 / 每个 minor 版本独立成功标准。
 
-如果你打算更新本文档,建议保留 git history 而非整段 rewrite——后人需要从 history 看判断是怎么演化的。
+如果你打算更新本文档，建议保留 git history 而非整段 rewrite——后人需要从 history 看判断是怎么演化的。

--- a/docs/zh/statistical-rigor.md
+++ b/docs/zh/statistical-rigor.md
@@ -5,91 +5,91 @@ description: 为什么 omk 的评测结果可被审计而不是声称严谨。�
 
 # 统计严谨性
 
-omk 要回答的问题是 **"你给 LLM 的知识,价值在哪里?"** —— 用客观数据,不靠凭感觉。LLM 评测最常踩的坑是 **"自信的偏差"** —— CI 很窄但结论错。omk 默认带四件事让结论可被外部审计。
+omk 要回答的问题是 **"你给 LLM 的知识，价值在哪里？"** —— 用客观数据，不靠凭感觉。LLM 评测最常踩的坑是 **"自信的偏差"** —— CI 很窄但结论错。omk 默认带四件事让结论可被外部审计。
 
-本页是深度参考。README 顶部的 callout 是入口,公式 / flag / 设计动机来这里查。
+本页是深度参考。README 顶部的 callout 是入口，公式 / flag / 设计动机来这里查。
 
 ## 1. Bootstrap CI(`--bootstrap`)
 
 **不假设分布的置信区间。**
 
-t 检验在 LLM 序数评分(Likert 类离散桶,不是正态分布的连续值)上失效。Bootstrap 直接重采样原始观测值,对小 N(< 30)和偏态分布都稳。
+t 检验在 LLM 序数评分（Likert 类离散桶，不是正态分布的连续值）上失效。Bootstrap 直接重采样原始观测值，对小 N(< 30)和偏态分布都稳。
 
-- **每个 variant 的均值 CI** —— 有放回重采样 N 次(默认 5000)
-- **两个 variant 之间的 pairwise diff CI** —— 重采样后的均值差;如果 CI 不跨 0,差异在选定 α(默认 0.05 → 95% CI)显著
-- **输出**:每个 `VariantResult.bootstrapCI` 含均值跟 pairwise 的 `[lo, hi]`;HTML 报告画 CI 带状区域;CLI `bench verdict` 在六档 verdict 逻辑里消费这些 CI
+- **每个 variant 的均值 CI** —— 有放回重采样 N 次（默认 5000）
+- **两个 variant 之间的 pairwise diff CI** —— 重采样后的均值差；如果 CI 不跨 0，差异在选定 α（默认 0.05 → 95% CI）显著
+- **输出**：每个 `VariantResult.bootstrapCI` 含均值跟 pairwise 的 `[lo, hi]`;HTML 报告画 CI 带状区域；CLI `bench verdict` 在六档 verdict 逻辑里消费这些 CI
 
-**参考**:Efron & Tibshirani (1993), "An Introduction to the Bootstrap"。omk 实现:`src/eval-core/bootstrap.ts`。由 `judge-hash-frozen.test.ts` 冻结防止公式悄悄漂移。
+**参考**：Efron & Tibshirani (1993), "An Introduction to the Bootstrap"。omk 实现：`src/eval-core/bootstrap.ts`。由 `judge-hash-frozen.test.ts` 冻结防止公式悄悄漂移。
 
 ## 2. Human Gold + Krippendorff α(`--gold-dir`)
 
-**评委 ↔ 人工一致性,外部锚定。**
+**评委 ↔ 人工一致性，外部锚定。**
 
-CI 告诉你"评委在重采样里稳不稳"。α 告诉你"评委跟人工标准对不对"。两个互补维度:
+CI 告诉你"评委在重采样里稳不稳"。α 告诉你"评委跟人工标准对不对"。两个互补维度：
 
-- **稳定 + α 低** = 评委稳定地错(系统性偏差)
+- **稳定 + α 低** = 评委稳定地错（系统性偏差）
 - **不稳定 + α 高** = 评委平均跟人工一致但波动大
 - **稳定 + α 高** = 这个 rubric 下评委可信
 - **不稳定 + α 低** = 评委坏了
 
-omk 自动检测 gold-judge 同源污染:如果 gold annotator 跟评委是同一个模型(比如都是 `claude-3.5-sonnet`),α 会被抬高(两者共享偏差)。omk 警告 + 报告调整后的 α。
+omk 自动检测 gold-judge 同源污染：如果 gold annotator 跟评委是同一个模型（比如都是 `claude-3.5-sonnet`），α 会被抬高（两者共享偏差）。omk 警告 + 报告调整后的 α。
 
-**公式**:标准 Krippendorff α + 序数距离度量。实现:`src/grading/human-gold.ts`。输入:`<gold-dir>/<sample_id>.json` per-用例每维度的人工评分。
+**公式**：标准 Krippendorff α + 序数距离度量。实现：`src/grading/human-gold.ts`。输入：`<gold-dir>/<sample_id>.json` per-用例每维度的人工评分。
 
-## 3. 长度去偏的评委 prompt(默认开启)
+## 3. 长度去偏的评委 prompt（默认开启）
 
-**研究证实 LLM 评委隐性偏向更长的回答。** 越长分越高,跟质量无关。omk 的评委 prompt 显式声明"长度不是质量信号"+ chain-of-thought + 长度归一化启发式。
+**研究证实 LLM 评委隐性偏向更长的回答。** 越长分越高，跟质量无关。omk 的评委 prompt 显式声明"长度不是质量信号"+ chain-of-thought + 长度归一化启发式。
 
-- Template hash `v3-cot-length` —— 旧报告用 `v2-cot`(去偏前),报告 hash 肉眼可辨
-- `omk bench debias-validate length <reportId>` —— 用相反设置重判,报告分数偏移;如果偏移超阈值,原报告有可测量的长度偏差
+- Template hash `v3-cot-length` —— 旧报告用 `v2-cot`（去偏前），报告 hash 肉眼可辨
+- `omk bench debias-validate length <reportId>` —— 用相反设置重判，报告分数偏移；如果偏移超阈值，原报告有可测量的长度偏差
 - `--no-debias-length` 给研究 / 复现场景留 opt-out 口子
-- 参考:Saito et al. (2023), "Verbosity Bias in Preference Labeling by Large Language Models"
+- 参考：Saito et al. (2023), "Verbosity Bias in Preference Labeling by Large Language Models"
 
-**冻结**:`test/grading/judge-hash-frozen.test.ts` 字节级 hash 冻结,防版本间 prompt 悄悄漂移。
+**冻结**：`test/grading/judge-hash-frozen.test.ts` 字节级 hash 冻结，防版本间 prompt 悄悄漂移。
 
 ## 4. 饱和曲线
 
 **回答"我跑够样本了吗"。**
 
-`--repeat ≥ 5` 时,omk 累积 N → bootstrap CI 序列。当 CI 宽度衰减率 < 5% 持续 3 个窗口,评测**饱和** —— 再多样本对结论无实质收益,额外的成本是浪费。
+`--repeat ≥ 5` 时，omk 累积 N → bootstrap CI 序列。当 CI 宽度衰减率 < 5% 持续 3 个窗口，评测**饱和** —— 再多样本对结论无实质收益，额外的成本是浪费。
 
 - HTML 报告内联 SVG 饱和曲线 + verdict 标签
 - `omk bench verdict` 把饱和度作为六档 verdict 逻辑的输入之一
-- 默认窗口大小:3 个连续测量;阈值:CI 宽度相对衰减 5%
-- 参考:omk 自有设计,不是已发表方法。实现:`src/eval-core/saturation.ts`
+- 默认窗口大小：3 个连续测量；阈值：CI 宽度相对衰减 5%
+- 参考：omk 自有设计，不是已发表方法。实现：`src/eval-core/saturation.ts`
 
 ## 四件事一起看
 
-每件事守住一个不同的失败模式:
+每件事守住一个不同的失败模式：
 
 | 失败模式 | 守口 |
 |---|---|
-| "v2 看着更好但其实在误差范围内" | Bootstrap CI(pairwise diff CI 不跨 0) |
-| "评委说 v2 更好但我不信评委" | Krippendorff α(评委 ↔ 人工) |
+| "v2 看着更好但其实在误差范围内" | Bootstrap CI（pairwise diff CI 不跨 0） |
+| "评委说 v2 更好但我不信评委" | Krippendorff α（评委 ↔ 人工） |
 | "评委偏向冗长的回答" | 长度去偏的评委 prompt |
-| "我跑了 10 个用例就停了 —— 够吗?" | 饱和曲线 |
+| "我跑了 10 个用例就停了 —— 够吗？" | 饱和曲线 |
 
-少一件,洞就出来。omk 默认四件全开;长度去偏可为研究复现 opt out,其他三件无条件。
+少一件，洞就出来。omk 默认四件全开；长度去偏可为研究复现 opt out，其他三件无条件。
 
-## 用例隔离(`--strict-baseline`,默认开)
+## 用例隔离（`--strict-baseline`，默认开）
 
-跟上面四件并列、但也是默认开的第五件:
+跟上面四件并列、但也是默认开的第五件：
 
-baseline 拿到的 prompt **不应**包含被测 skill。omk 切断三条污染路径,防止 baseline 偷偷看到对照组的 skill:
+baseline 拿到的 prompt **不应**包含被测 skill。omk 切断三条污染路径，防止 baseline 偷偷看到对照组的 skill:
 
 1. SDK skill auto-discovery
 2. subagent Skill 工具
-3. cwd 文件系统(顺 `skills/<name>/` symlink 直接 Read 到 SKILL.md)
+3. cwd 文件系统（顺 `skills/<name>/` symlink 直接 Read 到 SKILL.md）
 
-`eval.yaml` 的 `allowedSkills` 支持 per-variant 白名单给高级场景。没有隔离时,任何"v2 比 baseline 好"的结论都可疑 —— baseline 可能通过这三条路径之一已经看到 v2 的 SKILL.md。
+`eval.yaml` 的 `allowedSkills` 支持 per-variant 白名单给高级场景。没有隔离时，任何"v2 比 baseline 好"的结论都可疑 —— baseline 可能通过这三条路径之一已经看到 v2 的 SKILL.md。
 
-详见:[docs/sample-design-spec.md](../sample-design-spec.md) 的相关用例设计。
+详见：[docs/sample-design-spec.md](../sample-design-spec.md) 的相关用例设计。
 
 ---
 
 ## 可复现 / 审计追溯
 
-每份报告携带:
+每份报告携带：
 - omk 版本(`reportMeta.cliVersion`)
 - Node 版本(`reportMeta.nodeVersion`)
 - 评委模型 + hash(`reportMeta.judgeModel` / `reportMeta.judgePromptHash`)
@@ -98,4 +98,4 @@ baseline 拿到的 prompt **不应**包含被测 skill。omk 切断三条污染�
 - skill 隔离快照(`reportMeta.skillIsolation`)
 - Schema 版本(`reportMeta.schemaVersion`)
 
-跨版本可比性由 [GitHub Releases](https://github.com/lizhiyao/oh-my-knowledge/releases) 中的 `BREAKING-COMPARABILITY` callout 强制 —— 测量学不变量改了,你能看到。
+跨版本可比性由 [GitHub Releases](https://github.com/lizhiyao/oh-my-knowledge/releases) 中的 `BREAKING-COMPARABILITY` callout 强制 —— 测量学不变量改了，你能看到。

--- a/docs/zh/statistical-rigor.md
+++ b/docs/zh/statistical-rigor.md
@@ -17,7 +17,7 @@ t 检验在 LLM 序数评分（Likert 类离散桶，不是正态分布的连续
 
 - **每个 variant 的均值 CI** —— 有放回重采样 N 次（默认 5000）
 - **两个 variant 之间的 pairwise diff CI** —— 重采样后的均值差；如果 CI 不跨 0，差异在选定 α（默认 0.05 → 95% CI）显著
-- **输出**：每个 `VariantResult.bootstrapCI` 含均值跟 pairwise 的 `[lo, hi]`;HTML 报告画 CI 带状区域；CLI `bench verdict` 在六档 verdict 逻辑里消费这些 CI
+- **输出**：每个 `VariantResult.bootstrapCI` 含均值跟 pairwise 的 `[lo, hi]`；HTML 报告画 CI 带状区域；CLI `bench verdict` 在六档 verdict 逻辑里消费这些 CI
 
 **参考**：Efron & Tibshirani (1993), "An Introduction to the Bootstrap"。omk 实现：`src/eval-core/bootstrap.ts`。由 `judge-hash-frozen.test.ts` 冻结防止公式悄悄漂移。
 
@@ -75,7 +75,7 @@ omk 自动检测 gold-judge 同源污染：如果 gold annotator 跟评委是同
 
 跟上面四件并列、但也是默认开的第五件：
 
-baseline 拿到的 prompt **不应**包含被测 skill。omk 切断三条污染路径，防止 baseline 偷偷看到对照组的 skill:
+baseline 拿到的 prompt **不应**包含被测 skill。omk 切断三条污染路径，防止 baseline 偷偷看到对照组的 skill：
 
 1. SDK skill auto-discovery
 2. subagent Skill 工具


### PR DESCRIPTION
## Summary

CLAUDE.md 写作规则加硬规则：zh 文案统一用全角 `，。：；！？（）「」`，符合 GB/T 15834《标点符号用法》。半角 `,.():` 仅在技术混排里保留——代码块、inline code、文件路径、命令行、URL、YAML/JSON frontmatter、数学区间（`[lo, hi]`）、citation 年份（`(2023)`）、`executor:model` 风格的标识符、英文术语 / 技术枚举的括注（`用例隔离(construct validity)`、`verdict(PROGRESS / ...)`）。同时按规则回填 README.zh.md 与 docs/zh/。

## 用户影响

- **新规则**：CLAUDE.md `## 写作规则` 节加一条，agent 与人类贡献者按这条写新 zh 文案
- **commit 例外**：Conventional Commits 的 `type(scope):` 前缀保留半角，只有冒号后中文 subject 走全角（写成 `docs(readme): 中文 subject`）
- **回填范围**：README.zh.md / docs/zh/comparison.md / roadmap.md / statistical-rigor.md
- **保留半角**：上面规则列出的所有技术混排场景。例如 `(construct validity)` 这类纯英文术语括注、`Krippendorff (1993)` citation、`[lo, hi]` 数学区间、`claude:haiku` 这类 `executor:model` 标识符
- **未触动**：src/ 的 zh 字符串、test/ 的 zh fixture、commit history、SKILL.md。规则适用于未来新写内容；老内容这次只清 README + docs 两处用户最常见入口

## 测量学不变量

无影响。纯 docs / CLAUDE.md 改动，不动代码、schema、judge prompt、CI 链条。1062 tests 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)