### PR TITLE
feat(doctor): omk doctor 转 LLM 健康度审计 + 维度可扩展 + HTML 报告

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -15,6 +15,7 @@ export async function execute(argv: string[]): Promise<void> {
       executor: { type: 'string' },
       model: { type: 'string' },
       timeout: { type: 'string' },
+      html: { type: 'string' },
     },
   });
 
@@ -22,12 +23,30 @@ export async function execute(argv: string[]): Promise<void> {
   const executorName = (values.executor as string | undefined) ?? 'claude';
   const model = (values.model as string | undefined) ?? 'sonnet';
   const timeoutRaw = values.timeout as string | undefined;
-  const timeoutSec = timeoutRaw != null ? Number(timeoutRaw) : 8;
-  const timeoutMs = Math.max(1000, Math.floor((Number.isFinite(timeoutSec) ? timeoutSec : 8) * 1000));
+  // omk doctor CLI 默认就是 LLM 健康度审计:跑 7 内置维度 + 用户注册的自定义维度。
+  // 4 条静态 rule(skill_readable / skill_metadata / dependencies_present /
+  // samples_contract_aligned)在 bench run/gate 内部仍当强制 gate(代码层保留),
+  // omk doctor 这个用户入口直接跳过它们,聚焦 LLM 深度审计。
+  const runHealthCheck = true;
+  // 单次 LLM 会话(7+N 维度,内部多 turn)默认 timeout 600s(10 min)。
+  const defaultTimeoutSec = 600;
+  const timeoutSec = timeoutRaw != null ? Number(timeoutRaw) : defaultTimeoutSec;
+  const timeoutMs = Math.max(1000, Math.floor((Number.isFinite(timeoutSec) ? timeoutSec : defaultTimeoutSec) * 1000));
   const cwd = process.cwd();
+
+  // 副作用 import: 注册 7 内置维度 spec + skill_health composer rule。
+  // 用户在自己代码 / plugin 里 import dimension-registry 注册自定义维度,
+  // 同样会被 composer 拼到 prompt(顺序 = 注册顺序)。
+  await import('../../doctor/health/register.js');
 
   const { runDoctor } = await import('../../doctor/index.js');
   const { renderDoctorReportText, renderDoctorReportJson } = await import('../../doctor/renderer.js');
+
+  // 过滤掉所有静态 rule,只留 composer(健康度专属角色)。
+  // 静态 rule 是 bench run/gate 的强制 gate,用户用 omk doctor 时不接触它们。
+  const { getRegisteredRules } = await import('../../doctor/rules.js');
+  const { isComposerRule } = await import('../../types/doctor.js');
+  const rulesOverride = getRegisteredRules().filter(isComposerRule);
 
   let report;
   try {
@@ -38,6 +57,8 @@ export async function execute(argv: string[]): Promise<void> {
       model,
       timeoutMs,
       lang,
+      runHealthCheck,
+      rules: rulesOverride,
     });
   } catch (err) {
     // CliExit 透传(防御性,目前 runDoctor 不抛 CliExit,但保持四个 catch 一致)。
@@ -55,6 +76,20 @@ export async function execute(argv: string[]): Promise<void> {
 
   const isJson = values.json as boolean;
   const isGate = values.gate as boolean;
+  const htmlPath = values.html as string | undefined;
+
+  // --html 与 --json/--gate 可以共存:--html 写文件;同时 stdout/stderr 仍按
+  // 主输出格式跑(--json → JSON 到 stdout / --gate → 静默 / 默认 → text 到 stderr)。
+  if (htmlPath) {
+    const { renderDoctorReportHtml } = await import('../../doctor/html-renderer.js');
+    const { writeFileSync, mkdirSync } = await import('node:fs');
+    const { dirname, resolve } = await import('node:path');
+    const abs = resolve(htmlPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, renderDoctorReportHtml(report, lang), 'utf8');
+    // 通知用户(stderr,不污染 --json 的 stdout)
+    console.error(lang === 'zh' ? `HTML 报告已写入: ${abs}` : `HTML report written to: ${abs}`);
+  }
 
   if (isJson) {
     console.log(renderDoctorReportJson(report));

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -168,6 +168,28 @@ export type CliMessageKey =
   | 'cli.doctor.rule.skill_metadata'
   | 'cli.doctor.rule.dependencies'
   | 'cli.doctor.rule.samples_contract'
+  | 'cli.doctor.rule.skill_health_check'
+  // doctor — skill_health composer (opt-in --health)
+  | 'cli.doctor.health.skipped'
+  | 'cli.doctor.health.no_dimensions'
+  | 'cli.doctor.health.fail.executor'
+  | 'cli.doctor.health.fail.parse'
+  | 'cli.doctor.health.fail.empty_output'
+  | 'cli.doctor.health.hint.executor'
+  | 'cli.doctor.health.hint.parse'
+  | 'cli.doctor.health.dim.message'
+  | 'cli.doctor.health.dim.missing'
+  | 'cli.doctor.health.summary.label'
+  | 'cli.doctor.health.summary.message'
+  | 'cli.doctor.health.summary.no_top'
+  // 7 内置维度的 labelKey (id-based,稳定,翻译可独立改)
+  | 'cli.doctor.health.dim.trigger-boundary'
+  | 'cli.doctor.health.dim.doc-clarity'
+  | 'cli.doctor.health.dim.instr-precision'
+  | 'cli.doctor.health.dim.dependency'
+  | 'cli.doctor.health.dim.tool-conventions'
+  | 'cli.doctor.health.dim.security'
+  | 'cli.doctor.health.dim.examples'
   // doctor — pass messages
   | 'cli.doctor.skill_readable.pass'
   | 'cli.doctor.skill_metadata.pass'
@@ -1133,6 +1155,67 @@ Examples:
     zh: '用例 ↔ skill 输入约定',
     en: 'samples ↔ skill contract',
   },
+  'cli.doctor.rule.skill_health_check': {
+    zh: '健康度体检',
+    en: 'Health check',
+  },
+  // ============ skill_health composer (opt-in --health) ============
+  'cli.doctor.health.skipped': {
+    zh: '健康度体检未启用(加 --health 开启)',
+    en: 'health check not enabled (pass --health to enable)',
+  },
+  'cli.doctor.health.no_dimensions': {
+    zh: '没有注册任何健康度维度,跳过',
+    en: 'no health dimensions registered, skipped',
+  },
+  'cli.doctor.health.fail.executor': {
+    zh: 'LLM 调用失败: {error}',
+    en: 'LLM call failed: {error}',
+  },
+  'cli.doctor.health.fail.parse': {
+    zh: 'LLM 输出解析失败: {error}',
+    en: 'failed to parse LLM output: {error}',
+  },
+  'cli.doctor.health.fail.empty_output': {
+    zh: 'LLM 返回了空输出',
+    en: 'LLM returned empty output',
+  },
+  'cli.doctor.health.hint.executor': {
+    zh: '检查 executor 配置(--executor / --model)与网络连通,或调大 --timeout',
+    en: 'Verify executor config (--executor / --model) and connectivity, or raise --timeout',
+  },
+  'cli.doctor.health.hint.parse': {
+    zh: 'LLM 没返回合法 JSON;原文存在 detail.rawOutput 截断片段,可重跑或换 model',
+    en: 'LLM did not return valid JSON; raw snippet stored in detail.rawOutput. Re-run or switch model',
+  },
+  'cli.doctor.health.dim.message': {
+    zh: '{level}: 错误 {err}/警告 {warn}/建议 {sug}',
+    en: '{level}: error {err}/warn {warn}/suggest {sug}',
+  },
+  'cli.doctor.health.dim.missing': {
+    zh: 'LLM 未输出此维度({dim}),已置不适用',
+    en: 'LLM omitted dimension ({dim}); treated as N/A',
+  },
+  'cli.doctor.health.summary.label': {
+    zh: '健康度总览',
+    en: 'Health summary',
+  },
+  'cli.doctor.health.summary.message': {
+    zh: '{overall} | 维度: 健康 {h}/亚健康 {sh}/不健康 {bad}/不适用 {na} | finding: 错误 {err}/警告 {warn}/建议 {sug}',
+    en: '{overall} | dims: healthy {h}/sub {sh}/unhealthy {bad}/n-a {na} | findings: err {err}/warn {warn}/sug {sug}',
+  },
+  'cli.doctor.health.summary.no_top': {
+    zh: '完整详情见 --json 输出或 --html 报告',
+    en: 'Full detail in --json output or --html report',
+  },
+  // 7 内置维度 labelKey (id-based)
+  'cli.doctor.health.dim.trigger-boundary': { zh: '触发与边界', en: 'Trigger & boundary' },
+  'cli.doctor.health.dim.doc-clarity':      { zh: '文档清晰',   en: 'Documentation clarity' },
+  'cli.doctor.health.dim.instr-precision':  { zh: '指令精确性', en: 'Instruction precision' },
+  'cli.doctor.health.dim.dependency':       { zh: '依赖检查',   en: 'Dependency check' },
+  'cli.doctor.health.dim.tool-conventions': { zh: '工具规范',   en: 'Tool conventions' },
+  'cli.doctor.health.dim.security':         { zh: '安全与合规', en: 'Security & compliance' },
+  'cli.doctor.health.dim.examples':         { zh: '示例完备',   en: 'Example completeness' },
   // pass
   'cli.doctor.skill_readable.pass': {
     zh: 'skill 内容长度 {length} 字符',
@@ -1247,10 +1330,10 @@ Examples:
   // ============ omk doctor CLI level ============
   'cli.help.doctor_usage': {
     zh: `
-oh-my-knowledge — omk doctor 健康检查
+oh-my-knowledge — omk doctor 健康度体检 (LLM-judge)
 
 用法:
-  omk doctor [path]                    在 path 上跑评测前置健康检查
+  omk doctor [path]                    在 path 上跑深度健康度体检
   omk doctor                           在当前目录(或 ./skills)批量跑
 
 参数:
@@ -1259,59 +1342,63 @@ oh-my-knowledge — omk doctor 健康检查
 选项:
   --json                 把 DoctorReport 打到 stdout(CI 消费用)
   --gate                 静默模式: 通过 exit 0 / 不通过 exit 1, 仅 stderr 出问题摘要
-  --executor <name>      executor 名(仅向后兼容, doctor 不直接打 LLM)
-  --model <name>         model 名(同上)
-  --timeout <seconds>    rule 执行超时(默认 8)
+  --executor <name>      LLM executor (默认 claude, 可换 anthropic-api/codex 等)
+  --model <name>         模型 (默认 sonnet)
+  --timeout <seconds>    单次 LLM 会话超时 (默认 600)
+  --html <path>          产出可视化 HTML 报告到 <path> (可与 --json 同时用)
   --lang <zh|en>         切换输出语言
 
 示例:
-  omk doctor examples/code-review/skills/v1.md
-  omk doctor examples/code-review/skills --json | jq .outcome  # passed | warnings_only | failed
-  omk doctor --gate; echo $?
+  omk doctor my-skill --html /tmp/report.html             # 深度体检 + HTML 报告 (默认)
+  omk doctor examples/code-review/skills --json > r.json   # JSON 给 CI / 外部工具消费
+  omk doctor --gate; echo $?                               # CI 模式: exit 1 if 任一 skill 不健康
 
-doctor 检查项(纯静态 / 零 LLM 调用):
-  - skill 文件可读 + 内容有最小长度
-  - skill 元数据合法 (front-matter 若有)
-  - 前置依赖完整 (引用的 CLI 工具 / 文件 / 环境变量 / preflight 命令)
-  - 用例 ↔ skill 输入约定 (warn 级, 仅传 samples 时跑)
+doctor = LLM 健康度体检 (单次 LLM 会话):
+  - 7 个内置维度: 触发与边界 / 文档清晰 / 指令精确性 / 依赖检查 / 工具规范 / 安全与合规 / 示例完备
+  - 用户可扩展: 在自己代码里 registerHealthDimension(spec) 加自定义维度,
+    会自动加入同一次 LLM 调用的 prompt + 报告 (顺序 = 注册顺序)
+  - 每维度独立给 健康/亚健康/不健康/不适用 + findings + 改进建议
+  - HTML 报告: 维度按 fail→warn→pass→skipped 排, 错误 finding 排前面
 
-executor / judge 连通性由 evaluation preflight 负责, 不在 doctor 范围内。
-omk bench run / omk bench gate 内置 doctor 强制门禁, 不可 skip — 静态检查
-零成本无理由跳过。LLM 连通性可用 --skip-connectivity 跳过 (--resume 时自动)。
+注: omk bench run / bench gate 内部仍跑静态 skill-readability/metadata/dependency
+gate 保护评测质量, 不走 omk doctor 这条 LLM 路径 (角色分离: doctor=审计, bench=评测)。
+LLM 连通性可用 bench --skip-connectivity 跳过 (--resume 时自动)。
 `.trim() + '\n',
     en: `
-oh-my-knowledge — omk doctor health check
+oh-my-knowledge — omk doctor health audit (LLM-judge)
 
 Usage:
-  omk doctor [path]                    Run pre-evaluation health check on path
-  omk doctor                           Batch check current dir (or ./skills)
+  omk doctor [path]                    Run deep LLM-based health audit on path
+  omk doctor                           Batch audit current dir (or ./skills)
 
 Arguments:
-  path                   A .md file, directory, or omit (= cwd). Directory mode batches all skills.
+  path                   A .md file, directory, or omit (= cwd). Directory batches all skills.
 
 Options:
   --json                 Print DoctorReport JSON to stdout (CI-friendly)
-  --gate                 Silent mode: exit 0 if pass, exit 1 if fail; brief stderr summary only
-  --executor <name>      executor name (kept for compat; doctor does not call LLM)
-  --model <name>         model name (same)
-  --timeout <seconds>    per-rule timeout (default 8)
+  --gate                 Silent mode: exit 0 if pass, exit 1 if fail; brief stderr summary
+  --executor <name>      LLM executor (default 'claude'; switchable to anthropic-api/codex etc)
+  --model <name>         model name (default 'sonnet')
+  --timeout <seconds>    LLM session timeout (default 600)
+  --html <path>          Also write a visual HTML report to <path> (combines with --json)
   --lang <zh|en>         Output language
 
 Examples:
-  omk doctor examples/code-review/skills/v1.md
-  omk doctor examples/code-review/skills --json | jq .outcome  # passed | warnings_only | failed
-  omk doctor --gate; echo $?
+  omk doctor my-skill --html /tmp/report.html             # deep audit + HTML report (default)
+  omk doctor examples/code-review/skills --json > r.json   # JSON for CI / external tools
+  omk doctor --gate; echo $?                               # CI mode: exit 1 if any unhealthy
 
-Checks (pure static / zero LLM calls):
-  - skill file readable + minimum content length
-  - skill metadata valid (front-matter if present)
-  - dependencies present (referenced CLI tools / files / env vars / preflight commands)
-  - samples ↔ skill contract (warn-level, only when samples provided)
+doctor = LLM health audit (single LLM session):
+  - 7 builtin dimensions: trigger & boundary / doc clarity / instruction precision /
+    dependency / tool conventions / security & compliance / example completeness
+  - User-extensible: call registerHealthDimension(spec) in your code to add custom
+    dimensions; they join the same LLM call's prompt + report (order = registration order)
+  - Each dim graded healthy / sub-healthy / unhealthy / N-A + findings + suggestions
+  - HTML report: dims sorted fail→warn→pass→skipped; errors first within each dim
 
-executor / judge connectivity is handled by evaluation preflight, not doctor.
-omk bench run / omk bench gate run doctor as mandatory; no skip flag — static
-checks cost nothing to run. LLM connectivity can be skipped with --skip-connectivity
-(auto-skipped on --resume).
+Note: omk bench run / bench gate still run static skill-readability/metadata/dependency
+gates internally (separate from this doctor command). Roles: doctor=audit, bench=eval.
+LLM connectivity for bench can be skipped with --skip-connectivity (auto on --resume).
 `.trim() + '\n',
   },
   'cli.doctor.no_skill_found': {

--- a/src/doctor/health/builtin-dimensions.ts
+++ b/src/doctor/health/builtin-dimensions.ts
@@ -1,0 +1,96 @@
+/**
+ * 7 个内置健康度维度的 spec。
+ *
+ * 内置维度的 promptSection 完整保留原 Python 版的检查项内容(不写 ## N. 标题,
+ * 框架按注册顺序自动编号)。severity 区分:
+ *   - fatal: trigger-boundary / dependency / security  → `不健康` 时让 doctor outcome=failed
+ *   - warn:  doc-clarity / instr-precision / tool-conventions / examples
+ */
+
+import type { HealthDimensionSpec } from './dimension-spec.js';
+
+export const BUILTIN_HEALTH_DIMENSIONS: HealthDimensionSpec[] = [
+  {
+    id: 'trigger-boundary',
+    displayName: '触发与边界',
+    labelKey: 'cli.doctor.health.dim.trigger-boundary',
+    severity: 'fatal',
+    promptSection: `**该触发时准 + 不该触发时不误用**
+- frontmatter 的 \`description\` / \`when_to_use\` 是否与正文功能一致?
+- 关键词与相邻 skill 的区分度是否足够?(关键词 < 3 个或全是泛词 = 区分度差)
+- 是否**显式声明了不适用范围**?(eg. "本 skill 不处理 X、X 请走 Y skill"、"仅适用 dev 环境")
+- 关键词与其他系统 skill 严重重叠时,是否说明了分工?`,
+  },
+  {
+    id: 'doc-clarity',
+    displayName: '文档清晰',
+    labelKey: 'cli.doctor.health.dim.doc-clarity',
+    severity: 'warn',
+    promptSection: `**写得好不好读**
+- 步骤顺序清楚、结构合理
+- 没有大段冗余(明显可压 50%+ 的章节、无价值废话)
+- 关键决策点显式标出
+- 参数说明完整`,
+  },
+  {
+    id: 'instr-precision',
+    displayName: '指令精确性',
+    labelKey: 'cli.doctor.health.dim.instr-precision',
+    severity: 'warn',
+    promptSection: `**给 LLM 的指令语义是否单一,多次执行不漂移**
+- 模糊量词("一些" / "必要时" / "如有需要" / "适当地")
+- 未限定主语("调用工具" 没说哪个工具)
+- 条件分支没穷举("如果 X 就 A,否则..." 缺 else)
+- 同一动作多种说法导致歧义
+- 数量/阈值没说清("查几条"、"等一会儿")`,
+  },
+  {
+    id: 'dependency',
+    displayName: '依赖检查',
+    labelKey: 'cli.doctor.health.dim.dependency',
+    severity: 'fatal',
+    promptSection: `**依赖在 + 不重复造轮子 + 路径可移植**
+- 引用的脚本 / CLI / MCP 工具 / 其他 skill 实际存在
+- 不内联底层(应该引用某 skill 时却内联了它的实现)
+- **路径可移植**:不能硬编码具体版本号路径(eg. \`~/.nvm/versions/node/v22.22.0/...\`)、用户专属路径(eg. \`/Users/<具体人>/...\`)、机器专属位置——这些在换用户 / 换 Node 版本 / 换安装方式时**直接跑不通**,属于 \`错误\` 级。
+
+  **改进建议必须用运行时中立的方案**:
+  - **skill 内部资源**(\`scripts/\`、\`references/\`、\`mcp.json\` 等):**统一用 \`$SKILL_DIR\` 指代本 skill 加载后的实际根目录(即 SKILL.md 所在目录)**,执行命令时由调用方替换为绝对路径。SKILL.md 里只需在前置说明里加一句:"\`$SKILL_DIR\` 指代本 skill 加载后的实际根目录,执行命令时直接替换为该绝对路径"。
+  - **外部全局 npm 包路径**(eg. \`~/.nvm/versions/node/v22.22.0/lib/node_modules/...\`):改进建议**唯一推荐 \`npm root -g\`**,不要给其它替代方案。
+  - **其它外部 CLI**(非 npm 包):用 \`which xxx\` 等动态解析,**不要**写死具体安装前缀或版本路径。
+  - **禁止**推荐任何**单一运行时**绑定的机制(skill 可能在多种宿主下运行)。具体不要建议:
+    - Claude 专属:\`$CLAUDE_PLUGIN_ROOT\` / \`~/.claude/\` / \`.claude/\` / 把 \`claude\` CLI 当强依赖
+    - OpenClaw 专属:\`$OPENCLAW_*\` / 假设 cwd 在某固定位置
+    - 任何把"宿主"写死到 skill 文档里的方案`,
+  },
+  {
+    id: 'tool-conventions',
+    displayName: '工具规范',
+    labelKey: 'cli.doctor.health.dim.tool-conventions',
+    severity: 'warn',
+    promptSection: `**调用方式标准 + 工具失败降级路径明确**
+- 工具调用方式遵循统一约定(参数命名、返回格式)
+- **工具失败 / 返回异常 / 数据为空时,skill 是否给了明确指令**(重试 / 跳过 / 中断并报告用户),而不是默认让 LLM 自由发挥`,
+  },
+  {
+    id: 'security',
+    displayName: '安全与合规',
+    labelKey: 'cli.doctor.health.dim.security',
+    severity: 'fatal',
+    promptSection: `**3 个 subtype,每条 finding 必须标 subtype**
+- \`不可逆操作\`:\`rm -rf\` / \`git push -f\` / \`git reset --hard\` / \`git clean -fd\` / \`git branch -D\` / \`DROP TABLE\` / \`TRUNCATE\` / 不带 \`WHERE\` 的 \`DELETE\` / \`UPDATE\` / \`--no-verify\` 跳过 hook 等,**没有要求人工确认 / 先 dry-run / 限定 scope**
+- \`凭据硬编码\`:写死的 token / AK / SK / cookie / password(非占位符)
+- \`个人化耦合\`:真实工号 / 真实花名 / 真实邮箱(无"示例:"前缀) / 个人专属路径(\`/Users/<具体人名>/...\`)`,
+  },
+  {
+    id: 'examples',
+    displayName: '示例完备',
+    labelKey: 'cli.doctor.health.dim.examples',
+    severity: 'warn',
+    promptSection: `**用户能否照着用、能否验证**
+- 是否给了**典型调用示例**(用户输入 → 期望输出)?
+- 是否说明了**如何验证调用成功**(看哪个文件 / log / 返回字段)?
+- 关键参数是否有**示例值**,而不是只有类型说明?
+- **失败 / 异常路径**是否有示意?`,
+  },
+];

--- a/src/doctor/health/composer.ts
+++ b/src/doctor/health/composer.ts
@@ -1,0 +1,306 @@
+/**
+ * skill_health composer rule — 健康度体检的"复合 rule"。
+ *
+ * 单次 LLM 调用产出全部已注册维度的 checklist;composer.checkAll() 返回 N+1 条
+ * outcome:N = 注册维度数(每维一条),1 = summary(top_suggestions / overall_health
+ * / feature_points 落在这条)。
+ *
+ * doctor engine 检测 kind='composer' 时把 outcome[] 展开成 N+1 条独立 DoctorRuleResult,
+ * 共享 groupId = composer.id,renderer 按 groupId 分组渲染。
+ *
+ * 工厂模式 makeSkillHealthComposer(execFactory) 给测试注入 mock executor。
+ * 默认 import 时不注册;register.ts 才做 registerRule 副作用。
+ */
+
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tCli } from '../../cli/i18n.js';
+import { createExecutor } from '../../executors/index.js';
+import type { ExecutorFn } from '../../types/executor.js';
+import type {
+  ComposerOutcome,
+  ComposerRule,
+  DoctorContext,
+  DoctorRuleStatus,
+} from '../../types/doctor.js';
+import type {
+  HealthDimensionLevel,
+  HealthDimensionResult,
+  HealthDimensionSpec,
+} from './dimension-spec.js';
+import { getRegisteredHealthDimensions } from './dimension-registry.js';
+import { buildHealthPrompt } from './prompt-builder.js';
+import { deriveOverallHealth, extractJson, parseHealthOutput } from './parser.js';
+
+export const SKILL_HEALTH_COMPOSER_ID = 'skill_health';
+
+export type ExecutorFactory = (name: string) => ExecutorFn;
+const defaultExecutorFactory: ExecutorFactory = createExecutor;
+
+// ---------------------------------------------------------------------------
+// Status mapping
+// ---------------------------------------------------------------------------
+
+function mapDimLevelToStatus(level: HealthDimensionLevel, missing?: boolean): DoctorRuleStatus {
+  if (missing) return 'skipped';
+  switch (level) {
+    case '不健康': return 'fail';
+    case '亚健康': return 'warn';
+    case '健康':   return 'pass';
+    case '不适用': return 'skipped';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-dim outcome rendering
+// ---------------------------------------------------------------------------
+
+function dimMessage(dim: HealthDimensionSpec, r: HealthDimensionResult, lang: 'zh' | 'en'): string {
+  if (r._missing) {
+    return tCli('cli.doctor.health.dim.missing', lang, { dim: dim.displayName });
+  }
+  const errs = r.findings.filter((f) => f.level === '错误').length;
+  const warns = r.findings.filter((f) => f.level === '警告').length;
+  const sugs = r.findings.filter((f) => f.level === '建议').length;
+  return tCli('cli.doctor.health.dim.message', lang, {
+    level: r.level, err: errs, warn: warns, sug: sugs,
+  });
+}
+
+function dimHint(r: HealthDimensionResult): string | undefined {
+  if (r.suggestions.length === 0) return undefined;
+  return r.suggestions[0];
+}
+
+// ---------------------------------------------------------------------------
+// Sub-files / siblings discovery (与上一版本相同)
+// ---------------------------------------------------------------------------
+
+function listSubFiles(skillRoot: string | null): string[] {
+  if (!skillRoot || !existsSync(skillRoot)) return [];
+  const out: string[] = [];
+  const walk = (dir: string, rel: string, depth: number): void => {
+    if (depth > 2) return;
+    let entries: string[] = [];
+    try { entries = readdirSync(dir); } catch { return; }
+    for (const entry of entries) {
+      if (entry.startsWith('.')) continue;
+      if (entry === 'SKILL.md' && rel === '') continue;
+      if (entry === 'node_modules') continue;
+      const full = join(dir, entry);
+      const relPath = rel ? `${rel}/${entry}` : entry;
+      let st;
+      try { st = statSync(full); } catch { continue; }
+      if (st.isDirectory()) walk(full, relPath, depth + 1);
+      else if (st.isFile()) out.push(relPath);
+    }
+  };
+  walk(skillRoot, '', 0);
+  return out.sort();
+}
+
+function listSiblingSkills(skillRoot: string | null): string[] {
+  if (!skillRoot || !existsSync(skillRoot)) return [];
+  const parent = dirname(skillRoot);
+  if (!existsSync(parent)) return [];
+  const self = skillRoot.split('/').pop() ?? '';
+  let entries: string[] = [];
+  try { entries = readdirSync(parent); } catch { return []; }
+  return entries
+    .filter((e) => !e.startsWith('.') && e !== self)
+    .filter((e) => {
+      try { return statSync(join(parent, e)).isDirectory(); } catch { return false; }
+    })
+    .sort();
+}
+
+// ---------------------------------------------------------------------------
+// Composer factory
+// ---------------------------------------------------------------------------
+
+export function makeSkillHealthComposer(
+  execFactory: ExecutorFactory = defaultExecutorFactory,
+): ComposerRule {
+  return {
+    id: SKILL_HEALTH_COMPOSER_ID,
+    kind: 'composer',
+    severity: 'fatal',
+    labelKey: 'cli.doctor.rule.skill_health_check',
+    checkAll: (ctx) => composerCheckAll(ctx, execFactory),
+  };
+}
+
+async function composerCheckAll(
+  ctx: DoctorContext,
+  execFactory: ExecutorFactory,
+): Promise<ComposerOutcome[]> {
+  const dims = getRegisteredHealthDimensions();
+
+  // opt-out: 没开 --health → 给 summary 一条 skipped,各维度不展开避免污染报告
+  if (!ctx.runHealthCheck) {
+    return [{
+      subId: '_summary',
+      severity: 'info',
+      labelKey: 'cli.doctor.rule.skill_health_check',
+      status: 'skipped',
+      message: tCli('cli.doctor.health.skipped', ctx.lang),
+    }];
+  }
+
+  // 没注册任何维度 → 短路
+  if (dims.length === 0) {
+    return [{
+      subId: '_summary',
+      severity: 'info',
+      labelKey: 'cli.doctor.rule.skill_health_check',
+      status: 'skipped',
+      message: tCli('cli.doctor.health.no_dimensions', ctx.lang),
+    }];
+  }
+
+  const content = ctx.artifact.content;
+  if (!content || content.trim().length === 0) {
+    // skill_readable rule 也会 fail;这里只是 short-circuit 防止白白调 LLM
+    return [{
+      subId: '_summary',
+      severity: 'info',
+      labelKey: 'cli.doctor.rule.skill_health_check',
+      status: 'skipped',
+      message: tCli('cli.doctor.health.skipped', ctx.lang),
+    }];
+  }
+
+  const skillName = ctx.artifact.name.replace(/\.md$/, '').split('/').pop() ?? ctx.artifact.name;
+  const skillRoot = ctx.artifact.skillRoot ?? null;
+  const subFiles = listSubFiles(skillRoot);
+  const siblingSkills = listSiblingSkills(skillRoot);
+
+  const prompt = buildHealthPrompt(
+    { skillName, skillContent: content, skillRoot, subFiles, siblingSkills },
+    dims,
+  );
+
+  const executor = execFactory(ctx.executorName);
+  let res;
+  try {
+    res = await executor({
+      model: ctx.model,
+      prompt,
+      cwd: skillRoot ?? ctx.cwd,
+      skillDir: skillRoot ?? null,
+      timeoutMs: ctx.timeoutMs,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return [errorSummaryOutcome(ctx, 'executor', msg)];
+  }
+
+  if (!res.ok) {
+    return [errorSummaryOutcome(ctx, 'executor', res.error ?? 'unknown')];
+  }
+  if (!res.output || res.output.trim().length === 0) {
+    return [errorSummaryOutcome(ctx, 'empty_output', '')];
+  }
+  const cleaned = extractJson(res.output);
+  if (cleaned === null) {
+    return [errorSummaryOutcome(ctx, 'extract', '', { rawOutput: res.output.slice(0, 4000) })];
+  }
+
+  const parseResult = parseHealthOutput(cleaned, dims);
+  const overall = parseResult.overall ?? deriveOverallHealth(parseResult.byDimId);
+  // 诊断:如果所有维度都被标 _missing,说明 LLM 输出 JSON 里 dim_id 字段缺失或写错。
+  // 把 cleaned JSON 的前 3KB 塞进 summary 的 detail.rawSample,方便用户排查。
+  const allMissing = [...parseResult.byDimId.values()].every((r) => r._missing);
+  const rawSample = allMissing ? cleaned.slice(0, 3000) : undefined;
+
+  // 汇总 finding 计数(框架算,不信 LLM 算术)
+  const finding = { '错误': 0, '警告': 0, '建议': 0 };
+  const dimCount = { '健康': 0, '亚健康': 0, '不健康': 0, '不适用': 0 };
+  for (const r of parseResult.byDimId.values()) {
+    if (r._missing) continue;
+    dimCount[r.level] += 1;
+    for (const f of r.findings) finding[f.level] += 1;
+  }
+
+  // N 条维度 outcome
+  const dimOutcomes: ComposerOutcome[] = dims.map((dim) => {
+    const r = parseResult.byDimId.get(dim.id)!;
+    return {
+      subId: dim.id,
+      labelKey: dim.labelKey,
+      severity: dim.severity,
+      status: mapDimLevelToStatus(r.level, r._missing),
+      message: dimMessage(dim, r, ctx.lang),
+      hint: dimHint(r),
+      detail: {
+        dimensionId: dim.id,
+        displayName: dim.displayName,
+        level: r.level,
+        findings: r.findings,
+        suggestions: r.suggestions,
+        missing: r._missing ?? false,
+      },
+    };
+  });
+
+  // 1 条 summary outcome
+  const summaryOutcome: ComposerOutcome = {
+    subId: '_summary',
+    severity: 'info',
+    labelKey: 'cli.doctor.health.summary.label',
+    status: 'pass', // summary 永远 pass(信息性,不影响 outcome)
+    message: tCli('cli.doctor.health.summary.message', ctx.lang, {
+      overall,
+      h: dimCount['健康'], sh: dimCount['亚健康'], bad: dimCount['不健康'], na: dimCount['不适用'],
+      err: finding['错误'], warn: finding['警告'], sug: finding['建议'],
+    }),
+    hint: parseResult.topSuggestions.slice(0, 3).join(' | ')
+      || tCli('cli.doctor.health.summary.no_top', ctx.lang),
+    detail: {
+      overall,
+      dimensionLevelCount: dimCount,
+      findingCountByLevel: finding,
+      topSuggestions: parseResult.topSuggestions,
+      featurePoints: parseResult.featurePoints,
+      durationMs: res.durationMs,
+      durationApiMs: res.durationApiMs,
+      // turns:claude-cli 在内部跑的 LLM 轮次(每轮 = 1 次 messages.create)
+      // numTurns:assistant turn 数 / fullNumTurns:含 tool turn 的总数
+      llmTurns: { numTurns: res.numTurns, fullNumTurns: res.fullNumTurns },
+      tokens: {
+        input: res.inputTokens, output: res.outputTokens,
+        cacheRead: res.cacheReadTokens, cacheCreation: res.cacheCreationTokens,
+      },
+      costUSD: res.costUSD,
+      executor: { name: ctx.executorName, model: ctx.model },
+      ...(rawSample !== undefined ? { rawSample, _diagnostic: 'all dims missing — likely dim_id field absent in LLM output' } : {}),
+    },
+  };
+
+  return [...dimOutcomes, summaryOutcome];
+}
+
+function errorSummaryOutcome(
+  ctx: DoctorContext,
+  phase: 'executor' | 'empty_output' | 'extract',
+  errMsg: string,
+  extra: Record<string, unknown> = {},
+): ComposerOutcome {
+  const messageKey = phase === 'executor'
+    ? 'cli.doctor.health.fail.executor'
+    : phase === 'empty_output'
+      ? 'cli.doctor.health.fail.empty_output'
+      : 'cli.doctor.health.fail.parse';
+  const hintKey = phase === 'executor'
+    ? 'cli.doctor.health.hint.executor'
+    : 'cli.doctor.health.hint.parse';
+  return {
+    subId: '_summary',
+    severity: 'fatal',
+    labelKey: 'cli.doctor.health.summary.label',
+    status: 'fail',
+    message: tCli(messageKey, ctx.lang, { error: errMsg.slice(0, 200) }),
+    hint: tCli(hintKey, ctx.lang),
+    detail: { phase, error: errMsg, ...extra },
+  };
+}

--- a/src/doctor/health/dimension-registry.ts
+++ b/src/doctor/health/dimension-registry.ts
@@ -1,0 +1,33 @@
+/**
+ * HealthDimensionSpec 全局注册表(module-level singleton)。
+ *
+ * 内置 7 个维度由 health/register.ts 注册;用户通过 registerHealthDimension()
+ * 注册自定义维度。注册顺序就是 prompt 中的章节编号顺序。
+ *
+ * id 冲突会抛 — 防止意外覆盖。__resetForTest 给单测用。
+ */
+
+import type { HealthDimensionSpec } from './dimension-spec.js';
+
+const dimensions: HealthDimensionSpec[] = [];
+const seenIds = new Set<string>();
+
+export function registerHealthDimension(spec: HealthDimensionSpec): void {
+  if (!spec.id || spec.id.includes(':')) {
+    throw new Error(`invalid health dimension id: "${spec.id}" (non-empty, no ":")`);
+  }
+  if (seenIds.has(spec.id)) {
+    throw new Error(`health dimension id collision: ${spec.id}`);
+  }
+  seenIds.add(spec.id);
+  dimensions.push(spec);
+}
+
+export function getRegisteredHealthDimensions(): HealthDimensionSpec[] {
+  return [...dimensions]; // 防止外部 mutate
+}
+
+export function __resetHealthDimensionsForTest(): void {
+  dimensions.length = 0;
+  seenIds.clear();
+}

--- a/src/doctor/health/dimension-spec.ts
+++ b/src/doctor/health/dimension-spec.ts
@@ -1,0 +1,50 @@
+/**
+ * HealthDimensionSpec — 健康度维度的可扩展接口。
+ *
+ * 用户写一个 spec 描述自己想加的维度,通过 registerHealthDimension(spec) 注册;
+ * composer 在拼 prompt 时把所有注册的 spec 的 promptSection 拼进"检查维度"区块,
+ * 同时把 spec.id 加入 dim_id 枚举,LLM 必须在 checklist 中按每个 id 出一项。
+ *
+ * 维度结果(level + findings)的解析按统一规则跑;若维度需要特殊解析(eg. 把
+ * subtype 作为 finding 一级字段),后续可以加可选 hooks(parseFindings 等)。
+ */
+
+import type { DoctorSeverity } from '../../types/doctor.js';
+
+export type HealthDimensionLevel = '健康' | '亚健康' | '不健康' | '不适用';
+export type HealthFindingLevel = '错误' | '警告' | '建议';
+
+export interface HealthFinding {
+  level: HealthFindingLevel;
+  /** 仅 security 维度填(`不可逆操作 | 凭据硬编码 | 个人化耦合`),其它维度空字符串。
+   *  保留为通用字段,未来其它维度也可借此做子分类。 */
+  subtype?: string;
+  evidence: string;
+  description: string;
+}
+
+export interface HealthDimensionResult {
+  level: HealthDimensionLevel;
+  findings: HealthFinding[];
+  suggestions: string[];
+  /** 内部标记:LLM 没产出该维度时,parser 会塞一个 placeholder + _missing=true,
+   *  composer 据此把 status 置为 skipped + message 提示 LLM 漏报。 */
+  _missing?: boolean;
+}
+
+export interface HealthDimensionSpec {
+  /** 稳定的英文 id。会成为 prompt 里 dim_id 的取值,以及 ruleId 后缀。
+   *  不允许重复;不允许包含 `:`(避免和 composer ruleId 分隔符冲突)。 */
+  id: string;
+  /** 给人看的简短显示名(LLM prompt 里的章节标题用 + renderer 用)。
+   *  可以是中文或多语言混用,稳定性不重要(因为 LLM 通过 id 派发,不看 displayName)。 */
+  displayName: string;
+  /** i18n key,doctor result 的 labelKey 用。renderer 走 tCli 出最终标题。 */
+  labelKey: string;
+  /** 该维度的严重度。`不健康` → fail 时,severity=fatal 才会让 doctor outcome 进 `failed`。
+   *  内置 7 维度按重要性区分(eg. dependency/security 是 fatal, doc-clarity 是 warn)。 */
+  severity: DoctorSeverity;
+  /** 拼到 prompt 的检查内容片段(纯 markdown,**不写 ## N. 标题** —— 框架自动加章节号)。
+   *  描述这一维度查什么、判定标准、example。 */
+  promptSection: string;
+}

--- a/src/doctor/health/parser.ts
+++ b/src/doctor/health/parser.ts
@@ -1,0 +1,199 @@
+/**
+ * LLM 输出解析:JSON 提取 + dim_id 派发 + 容错。
+ *
+ * 流程:
+ *   1. extractJson 从 LLM 文本(可能带寒暄/code fence)抽出顶层 JSON。
+ *   2. 按 dim_id 把 checklist 项派发到 Map<dimId, HealthDimensionResult>。
+ *   3. 缺失维度(LLM 漏报)塞 _missing=true 的 placeholder,composer 据此 status=skipped。
+ *   4. 不合法 dim_id(LLM 编了 registry 之外的)直接丢弃。
+ *
+ * dimension_level_count / finding_count_by_level 由调用方 / renderer 自己算
+ * (LLM 算术不可靠,prompt 已声明不输出这两字段)。
+ */
+
+import type {
+  HealthDimensionResult,
+  HealthDimensionSpec,
+  HealthFinding,
+  HealthFindingLevel,
+  HealthDimensionLevel,
+} from './dimension-spec.js';
+
+const REQUIRED_TOP_KEYS = new Set(['skill_name', 'checklist', 'summary']);
+
+interface ExtractedCandidate {
+  text: string;
+  obj: Record<string, unknown>;
+}
+
+/** 深度跟踪 brace,在 LLM 文本里找出顶层 JSON。多个候选时优先选含 ≥2 required key 的。 */
+export function extractJson(text: string): string | null {
+  if (!text) return null;
+  const candidates: ExtractedCandidate[] = [];
+  let pos = 0;
+  while (true) {
+    const start = text.indexOf('{', pos);
+    if (start === -1) break;
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    let end = -1;
+    for (let i = start; i < text.length; i += 1) {
+      const c = text[i];
+      if (escape) { escape = false; continue; }
+      if (inString) {
+        if (c === '\\') escape = true;
+        else if (c === '"') inString = false;
+        continue;
+      }
+      if (c === '"') inString = true;
+      else if (c === '{') depth += 1;
+      else if (c === '}') {
+        depth -= 1;
+        if (depth === 0) { end = i; break; }
+      }
+    }
+    if (end === -1) break;
+    const cand = text.slice(start, end + 1);
+    try {
+      const obj: unknown = JSON.parse(cand);
+      if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+        candidates.push({ text: cand, obj: obj as Record<string, unknown> });
+      }
+    } catch {
+      // skip non-parseable; brace inside string is the common reason
+    }
+    pos = start + 1;
+  }
+  if (candidates.length === 0) return null;
+  const strong = candidates.filter((c) => {
+    let hits = 0;
+    for (const k of REQUIRED_TOP_KEYS) if (k in c.obj) hits += 1;
+    return hits >= 2;
+  });
+  if (strong.length > 0) {
+    strong.sort((a, b) => b.text.length - a.text.length);
+    return strong[0].text;
+  }
+  const keyed = candidates.filter((c) => 'skill_name' in c.obj);
+  const pool = keyed.length > 0 ? keyed : candidates;
+  pool.sort((a, b) => b.text.length - a.text.length);
+  return pool[0].text;
+}
+
+// ---------------------------------------------------------------------------
+// Type guards & dispatch
+// ---------------------------------------------------------------------------
+
+function isDimLevel(s: unknown): s is HealthDimensionLevel {
+  return s === '健康' || s === '亚健康' || s === '不健康' || s === '不适用';
+}
+
+function isFindingLevel(s: unknown): s is HealthFindingLevel {
+  return s === '错误' || s === '警告' || s === '建议';
+}
+
+function asFinding(raw: unknown): HealthFinding | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (!isFindingLevel(r.level)) return null;
+  return {
+    level: r.level,
+    subtype: typeof r.subtype === 'string' ? r.subtype : '',
+    evidence: typeof r.evidence === 'string' ? r.evidence : '',
+    description: typeof r.description === 'string' ? r.description : '',
+  };
+}
+
+export interface HealthParseResult {
+  byDimId: Map<string, HealthDimensionResult>;
+  /** LLM 给的 overall(框架视情况覆盖)。 */
+  overall: '良好' | '部分缺陷' | '严重缺陷' | null;
+  topSuggestions: string[];
+  /** 原样保留 feature_points,塞进 composer 主结果 detail。 */
+  featurePoints: unknown[];
+}
+
+/** 从 cleaned JSON 字串(extractJson 的输出)派发到各维度。 */
+export function parseHealthOutput(
+  jsonText: string,
+  dims: HealthDimensionSpec[],
+): HealthParseResult {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(jsonText) as Record<string, unknown>;
+  } catch {
+    parsed = {};
+  }
+
+  const validIds = new Set(dims.map((d) => d.id));
+  const byDimId = new Map<string, HealthDimensionResult>();
+
+  const checklist = Array.isArray(parsed.checklist) ? parsed.checklist : [];
+  for (const itemRaw of checklist) {
+    if (!itemRaw || typeof itemRaw !== 'object') continue;
+    const item = itemRaw as Record<string, unknown>;
+    const dimId = item.dim_id;
+    if (typeof dimId !== 'string' || !validIds.has(dimId)) continue; // 容错:丢弃未注册 id
+    if (byDimId.has(dimId)) continue;                                  // 容错:重复 id 取首条
+    const findingsRaw = Array.isArray(item.findings) ? item.findings : [];
+    const findings: HealthFinding[] = [];
+    for (const fRaw of findingsRaw) {
+      const f = asFinding(fRaw);
+      if (f) findings.push(f);
+    }
+    const suggestions = Array.isArray(item.suggestions)
+      ? (item.suggestions as unknown[]).filter((s): s is string => typeof s === 'string')
+      : [];
+    const level: HealthDimensionLevel = isDimLevel(item.level)
+      ? item.level
+      : deriveDimLevel(findings);
+    byDimId.set(dimId, { level, findings, suggestions });
+  }
+
+  // 漏报维度填 placeholder
+  for (const dim of dims) {
+    if (!byDimId.has(dim.id)) {
+      byDimId.set(dim.id, { level: '不适用', findings: [], suggestions: [], _missing: true });
+    }
+  }
+
+  const summaryRaw = (parsed.summary && typeof parsed.summary === 'object'
+    ? parsed.summary
+    : {}) as Record<string, unknown>;
+  const validOveralls = new Set(['良好', '部分缺陷', '严重缺陷'] as const);
+  const overallRaw = summaryRaw.overall_health;
+  const overall = typeof overallRaw === 'string' && validOveralls.has(overallRaw as never)
+    ? (overallRaw as '良好' | '部分缺陷' | '严重缺陷')
+    : null;
+  const topSuggestions = Array.isArray(summaryRaw.top_suggestions)
+    ? (summaryRaw.top_suggestions as unknown[]).filter((s): s is string => typeof s === 'string')
+    : [];
+
+  const featurePoints = Array.isArray(parsed.feature_points) ? parsed.feature_points : [];
+
+  return { byDimId, overall, topSuggestions, featurePoints };
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation helpers
+// ---------------------------------------------------------------------------
+
+function deriveDimLevel(findings: HealthFinding[]): HealthDimensionLevel {
+  if (findings.some((f) => f.level === '错误')) return '不健康';
+  if (findings.length > 0) return '亚健康';
+  return '健康';
+}
+
+export function deriveOverallHealth(byDimId: Map<string, HealthDimensionResult>): '良好' | '部分缺陷' | '严重缺陷' {
+  let hasUnhealthy = false;
+  let hasSubhealthy = false;
+  for (const r of byDimId.values()) {
+    if (r._missing) continue; // 漏报不算
+    if (r.level === '不健康') hasUnhealthy = true;
+    else if (r.level === '亚健康') hasSubhealthy = true;
+  }
+  if (hasUnhealthy) return '严重缺陷';
+  if (hasSubhealthy) return '部分缺陷';
+  return '良好';
+}

--- a/src/doctor/health/prompt-builder.ts
+++ b/src/doctor/health/prompt-builder.ts
@@ -1,0 +1,182 @@
+/**
+ * 健康度体检 prompt 拼装器。
+ *
+ * 4 个区块:
+ *   Block 1: 任务说明 + skill 输入(固定)
+ *   Block 2: 检查维度章节(动态:遍历 dims,自动加 ## N. 标题 + (id: ...))
+ *   Block 3: 通用规则(同根因合并 / Finding level / 维度 level / overall_health)
+ *   Block 4: JSON schema(半动态:dim_id 枚举 + checklist 项数 = dims.length)
+ *
+ * 关键约束:LLM 用 dim_id(英文)在输出中标识维度,而不是中文 displayName —
+ * displayName 翻译/重命名时不会让 parser 崩。
+ */
+
+import type { HealthDimensionSpec } from './dimension-spec.js';
+
+export interface PromptInput {
+  skillName: string;
+  skillContent: string;
+  skillRoot: string | null;
+  subFiles: string[];
+  siblingSkills: string[];
+}
+
+export function buildHealthPrompt(input: PromptInput, dims: HealthDimensionSpec[]): string {
+  return [
+    renderBlock1Header(input),
+    renderBlock2Dimensions(dims),
+    renderBlock3CommonRules(),
+    renderBlock4JsonSchema(input.skillName, dims),
+  ].join('\n\n');
+}
+
+// ---------------------------------------------------------------------------
+// Block 1: 任务 + skill 输入
+// ---------------------------------------------------------------------------
+
+function renderBlock1Header(input: PromptInput): string {
+  const { skillName, skillContent, skillRoot, subFiles, siblingSkills } = input;
+  const siblingList = siblingSkills.length > 0
+    ? siblingSkills.map((s) => `\`${s}\``).join(', ')
+    : '(none)';
+  const subFilesList = subFiles.length > 0
+    ? subFiles.map((f) => `- ${f}`).join('\n')
+    : '(no sub-files; pure SKILL.md skill)';
+  const skillRootHint = skillRoot
+    ? `skill 根目录: \`${skillRoot}\`(子文件需要时用 Read 工具自取)`
+    : 'skill 是单文件 .md;没有子目录可 Read。';
+
+  return `你正在对 \`${skillName}\` 这个 skill 做**健康度体检**——按下面注册的所有维度逐一检查,给出 level、findings、改进建议。
+
+# 输入
+
+- skill 名: \`${skillName}\`
+- ${skillRootHint}
+- 子文件清单(仅参考,需要时用 Read 工具按路径自取):
+${subFilesList}
+
+# 系统 skill 列表(跨 skill 引用判断用)
+
+${siblingList}
+
+## SKILL.md 内容(已 inline,无需再 Read)
+
+\`\`\`markdown
+${skillContent}
+\`\`\``;
+}
+
+// ---------------------------------------------------------------------------
+// Block 2: 维度章节
+// ---------------------------------------------------------------------------
+
+function renderBlock2Dimensions(dims: HealthDimensionSpec[]): string {
+  const sections = dims.map((dim, idx) => {
+    const num = idx + 1;
+    return `## ${num}. ${dim.displayName} (id: \`${dim.id}\`)
+${dim.promptSection.trim()}`;
+  });
+  return `# 检查维度
+
+${sections.join('\n\n')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Block 3: 通用规则
+// ---------------------------------------------------------------------------
+
+function renderBlock3CommonRules(): string {
+  return `# 同根因合并(去重规则)
+
+多个 finding 如果**根因相同 + 修复方式相同**,必须合并成**一条** finding(可以跨维度合并)。在 \`evidence\` 字段里把所有出现位置列全(用 \` ; \` 分隔),\`description\` 里点明"在 N 处出现"。
+
+合并后,该 finding 的 \`level\` 取所有出现位置中**最严重的一个**。\`suggestions\` 给统一修法。
+
+# Finding level 判定
+
+- \`错误\`:**必须修**。包括:
+  - 在**常见用户环境 / 默认安装方式 / 不同版本号下直接跑不通**(不只是"在文档作者机子上跑不通")
+  - 硬编码绝对路径含具体版本号 / 用户名 → 换环境必失败
+  - 引用了不存在的脚本 / CLI / MCP 工具 / skill
+  - 不可逆操作没有人工确认
+  - 指令严重歧义会让 LLM 在多次执行中跑出截然不同结果
+- \`警告\`:**应该修**。规范不符 / 可读性明显差 / 误触发风险但不会直接挂掉
+- \`建议\`:锦上添花
+
+# 维度 level 派生规则
+
+- \`健康\`:0 个 finding
+- \`亚健康\`:有警告 / 建议但无错误
+- \`不健康\`:至少 1 个错误
+- \`不适用\`:该维度对本 skill 无意义(谨慎使用,不要拿来回避检查)
+
+# overall_health
+
+- \`良好\`:所有维度都是 \`健康\` 或 \`不适用\`
+- \`部分缺陷\`:有 \`亚健康\` 但无 \`不健康\`
+- \`严重缺陷\`:任一维度 \`不健康\``;
+}
+
+// ---------------------------------------------------------------------------
+// Block 4: JSON schema
+// ---------------------------------------------------------------------------
+
+function renderBlock4JsonSchema(skillName: string, dims: HealthDimensionSpec[]): string {
+  const dimIdEnum = dims.map((d) => `"${d.id}"`).join(' | ');
+  const dimIdList = dims.map((d) => `\`${d.id}\``).join(', ');
+
+  return `# 输出 JSON schema
+
+输出**必须是单一合法 JSON 对象**。第一字符 \`{\`,最后 \`}\`,**不要**用 \`\`\`json\`\`\` 围栏,**不要**寒暄。
+
+{
+  "skill_name": "${skillName}",
+  "feature_points": [
+    {
+      "name": "<功能点名>",
+      "description": "<1-2 行>",
+      "simulation": [
+        {
+          "step": 1,
+          "action": "<这一步做什么>",
+          "input": "<参数>",
+          "simulated_output": "<假设返回值,**不真跑**>",
+          "derivable_from_doc": true,
+          "note": "<指令模糊处>"
+        }
+      ]
+    }
+  ],
+  "checklist": [
+    {
+      "dim_id": ${dimIdEnum},
+      "level": "健康 | 亚健康 | 不健康 | 不适用",
+      "findings": [
+        {
+          "level": "错误 | 警告 | 建议",
+          "subtype": "<仅 \`security\` 维度需填:不可逆操作 | 凭据硬编码 | 个人化耦合;其它维度留空字符串>",
+          "evidence": "<具体引用:SKILL.md L<行号> / 章节标题 / 文件名 / 功能点 X 第 Y 步>",
+          "description": "<一句话讲清问题>"
+        }
+      ],
+      "suggestions": ["<可执行的改进动作>"]
+    }
+  ],
+  "summary": {
+    "overall_health": "良好 | 部分缺陷 | 严重缺陷",
+    "top_suggestions": ["<整 skill 视角下最该先改的 3 条,按优先级从高到低>"]
+  }
+}
+
+# 字段约束
+
+- \`checklist\` 必须**恰好包含 ${dims.length} 项**,\`dim_id\` 必须是以下之一,**每个 id 出现且仅出现一次**:
+  ${dimIdList}
+- \`level\` / \`subtype\` 字段值用精确中文字符串,不允许英文或别名
+- \`evidence\` 必须有具体引用,不能笼统说"全文"
+- 字符串里的 skill / 文件 / 命令名用反引号 \`xxx\` 包裹
+- **不要**冒虚假 finding,宁可少报也不要把"看起来可能有问题"硬塞进来
+- 不要输出 \`dimension_level_count\` / \`finding_count_by_level\` 字段(框架自己重算)
+
+读 SKILL.md(已 inline)→ 模拟执行 → 出 JSON。`;
+}

--- a/src/doctor/health/register.ts
+++ b/src/doctor/health/register.ts
@@ -1,0 +1,20 @@
+/**
+ * 副作用入口:把 7 个内置维度注册到 dimensionRegistry,把 composer rule
+ * 注册到 doctor customRules。
+ *
+ * CLI doctor.ts 在 `--health` 时动态 import 本文件 → 副作用一次性完成。
+ * 测试 import 各 module 的具名 export 不会触发本文件,保持 registry 干净。
+ *
+ * 用户自定义维度:在自己的代码里 `registerHealthDimension(spec)`,只要在
+ * composer 跑之前注册即可(eg. 在 omk 配置 / plugin 入口里)。
+ */
+
+import { registerRule } from '../rules.js';
+import { BUILTIN_HEALTH_DIMENSIONS } from './builtin-dimensions.js';
+import { registerHealthDimension } from './dimension-registry.js';
+import { makeSkillHealthComposer } from './composer.js';
+
+for (const spec of BUILTIN_HEALTH_DIMENSIONS) {
+  registerHealthDimension(spec);
+}
+registerRule(makeSkillHealthComposer());

--- a/src/doctor/html-renderer.ts
+++ b/src/doctor/html-renderer.ts
@@ -1,0 +1,392 @@
+/**
+ * doctor HTML 报告渲染器。
+ *
+ * 输出 single-file HTML(JSON inline,CSS/JS 内嵌,无外部依赖),双击可看,
+ * 不需 http server。专为 --health 报告设计 — 重点展示 composer group 内的
+ * 维度结果,但也兼容显示静态 rule 段。
+ *
+ * 排序约定:
+ *   - 维度卡片按 fail → warn → pass → skipped(STATUS_RANK)排
+ *   - 每个维度卡片内的 finding 按 错误 → 警告 → 建议 排
+ *   - skill 级别按 outcome (failed / warnings_only / passed) 排
+ *
+ * 前端交互:
+ *   - 顶部 filter pills:全部 / 仅失败 / 仅警告 / 仅通过 — 切换时 dim card 显隐
+ *   - 维度卡片头部点击折叠/展开 findings 区
+ */
+
+import type {
+  DoctorReport,
+  DoctorRuleResult,
+  DoctorRuleStatus,
+} from '../types/index.js';
+import { CLI_DICT, type CliMessageKey } from '../cli/i18n-dict.js';
+import { tCli, type CliLang } from '../cli/i18n.js';
+
+const STATUS_RANK: Record<DoctorRuleStatus, number> = {
+  fail: 0, warn: 1, pass: 2, skipped: 3,
+};
+const FINDING_RANK: Record<string, number> = { '错误': 0, '警告': 1, '建议': 2 };
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderLabel(result: DoctorRuleResult, lang: CliLang): string {
+  if (result.labelKey in CLI_DICT) return tCli(result.labelKey as CliMessageKey, lang);
+  return result.ruleId;
+}
+
+interface Finding {
+  level: '错误' | '警告' | '建议';
+  subtype?: string;
+  evidence?: string;
+  description?: string;
+}
+
+function getDimDetail(r: DoctorRuleResult): { findings: Finding[]; suggestions: string[]; level?: string; missing?: boolean } {
+  const d = (r.detail ?? {}) as Record<string, unknown>;
+  const findings = Array.isArray(d.findings) ? (d.findings as Finding[]) : [];
+  const suggestions = Array.isArray(d.suggestions)
+    ? (d.suggestions as unknown[]).filter((s): s is string => typeof s === 'string')
+    : [];
+  return {
+    findings: [...findings].sort((a, b) => (FINDING_RANK[a.level] ?? 9) - (FINDING_RANK[b.level] ?? 9)),
+    suggestions,
+    level: typeof d.level === 'string' ? d.level : undefined,
+    missing: d.missing === true,
+  };
+}
+
+function getSummaryDetail(r: DoctorRuleResult | undefined): {
+  overall?: string; topSuggestions: string[]; dimensionLevelCount?: Record<string, number>; findingCountByLevel?: Record<string, number>;
+} {
+  if (!r) return { topSuggestions: [] };
+  const d = (r.detail ?? {}) as Record<string, unknown>;
+  return {
+    overall: typeof d.overall === 'string' ? d.overall : undefined,
+    topSuggestions: Array.isArray(d.topSuggestions)
+      ? (d.topSuggestions as unknown[]).filter((s): s is string => typeof s === 'string')
+      : [],
+    dimensionLevelCount: typeof d.dimensionLevelCount === 'object' && d.dimensionLevelCount !== null
+      ? d.dimensionLevelCount as Record<string, number>
+      : undefined,
+    findingCountByLevel: typeof d.findingCountByLevel === 'object' && d.findingCountByLevel !== null
+      ? d.findingCountByLevel as Record<string, number>
+      : undefined,
+  };
+}
+
+function renderDimCard(r: DoctorRuleResult, lang: CliLang): string {
+  const label = renderLabel(r, lang);
+  const status = r.status;
+  const detail = getDimDetail(r);
+  const findingsHtml = detail.findings.length === 0
+    ? `<div class="empty">${lang === 'zh' ? '无 finding' : 'no findings'}</div>`
+    : detail.findings.map((f) => `
+      <div class="finding finding-${f.level === '错误' ? 'err' : f.level === '警告' ? 'warn' : 'sug'}">
+        <div class="finding-head">
+          <span class="finding-level">${escapeHtml(f.level)}</span>
+          ${f.subtype ? `<span class="finding-subtype">${escapeHtml(f.subtype)}</span>` : ''}
+          <span class="finding-desc">${escapeHtml(f.description ?? '')}</span>
+        </div>
+        ${f.evidence ? `<div class="finding-evidence">${escapeHtml(f.evidence)}</div>` : ''}
+      </div>`).join('');
+  const sugsHtml = detail.suggestions.length === 0 ? '' : `
+    <div class="dim-sugs">
+      <div class="sugs-title">${lang === 'zh' ? '建议' : 'suggestions'}</div>
+      <ul>${detail.suggestions.map((s) => `<li>${escapeHtml(s)}</li>`).join('')}</ul>
+    </div>`;
+  const dimIdHint = (r.detail as { dimensionId?: string } | undefined)?.dimensionId ?? r.ruleId.split(':')[1] ?? '';
+  return `
+    <div class="dim-card status-${status}" data-status="${status}" data-dimid="${escapeHtml(dimIdHint)}">
+      <div class="dim-head" onclick="this.parentElement.classList.toggle('open')">
+        <span class="dim-status">${escapeHtml(detail.level ?? status)}</span>
+        <span class="dim-name">${escapeHtml(label)}</span>
+        <span class="dim-counts">
+          <span class="badge badge-err">${detail.findings.filter((f) => f.level === '错误').length}</span>
+          <span class="badge badge-warn">${detail.findings.filter((f) => f.level === '警告').length}</span>
+          <span class="badge badge-sug">${detail.findings.filter((f) => f.level === '建议').length}</span>
+        </span>
+        <span class="dim-toggle">▸</span>
+      </div>
+      <div class="dim-body">
+        ${detail.missing ? `<div class="dim-missing">⚠ ${escapeHtml(r.message)}</div>` : ''}
+        <div class="dim-findings">${findingsHtml}</div>
+        ${sugsHtml}
+      </div>
+    </div>`;
+}
+
+function renderStaticRule(r: DoctorRuleResult, lang: CliLang): string {
+  return `
+    <div class="rule-row status-${r.status}">
+      <span class="rule-status">${r.status.toUpperCase()}</span>
+      <span class="rule-label">${escapeHtml(renderLabel(r, lang))}</span>
+      <span class="rule-msg">${escapeHtml(r.message)}</span>
+      ${r.hint ? `<div class="rule-hint">💡 ${escapeHtml(r.hint)}</div>` : ''}
+    </div>`;
+}
+
+interface SegmentedSkill {
+  staticRules: DoctorRuleResult[];
+  /** key = groupId */
+  groups: Map<string, DoctorRuleResult[]>;
+}
+
+function segmentSkillResults(skill: { results: DoctorRuleResult[] }): SegmentedSkill {
+  const staticRules: DoctorRuleResult[] = [];
+  const groups = new Map<string, DoctorRuleResult[]>();
+  for (const r of skill.results) {
+    if (!r.groupId) { staticRules.push(r); continue; }
+    let arr = groups.get(r.groupId);
+    if (!arr) { arr = []; groups.set(r.groupId, arr); }
+    arr.push(r);
+  }
+  return { staticRules, groups };
+}
+
+function renderGroup(groupId: string, results: DoctorRuleResult[], lang: CliLang): string {
+  const summaryRow = results.find((r) => r.ruleId.endsWith(':_summary'));
+  const dimRows = results.filter((r) => !r.ruleId.endsWith(':_summary'));
+  dimRows.sort((a, b) => STATUS_RANK[a.status] - STATUS_RANK[b.status]);
+  const groupLabel = summaryRow ? renderLabel(summaryRow, lang) : groupId;
+  const summary = getSummaryDetail(summaryRow);
+  const totalsLine = summary.dimensionLevelCount && summary.findingCountByLevel
+    ? `<div class="group-totals">
+        <span>${lang === 'zh' ? '维度' : 'dims'}: ✗${summary.dimensionLevelCount['不健康'] ?? 0} ⚠${summary.dimensionLevelCount['亚健康'] ?? 0} ✓${summary.dimensionLevelCount['健康'] ?? 0} ⊙${summary.dimensionLevelCount['不适用'] ?? 0}</span>
+        <span>findings: ✗${summary.findingCountByLevel['错误'] ?? 0} ⚠${summary.findingCountByLevel['警告'] ?? 0} ·${summary.findingCountByLevel['建议'] ?? 0}</span>
+       </div>`
+    : '';
+  const topSugsHtml = summary.topSuggestions.length === 0 ? '' : `
+    <div class="group-top">
+      <div class="top-title">★ ${lang === 'zh' ? 'Top 改进建议' : 'Top suggestions'}</div>
+      <ol>${summary.topSuggestions.map((s) => `<li>${escapeHtml(s)}</li>`).join('')}</ol>
+    </div>`;
+  const cardsHtml = dimRows.map((r) => renderDimCard(r, lang)).join('');
+  return `
+    <section class="group" data-group="${escapeHtml(groupId)}">
+      <header class="group-head">
+        <h2>${escapeHtml(groupLabel)}${summary.overall ? ` <span class="group-overall">${escapeHtml(summary.overall)}</span>` : ''}</h2>
+        ${totalsLine}
+      </header>
+      ${topSugsHtml}
+      <div class="filter-pills">
+        <button class="pill active" data-filter="all">${lang === 'zh' ? '全部' : 'All'}</button>
+        <button class="pill" data-filter="fail">${lang === 'zh' ? '仅失败' : 'Fail only'}</button>
+        <button class="pill" data-filter="warn">${lang === 'zh' ? '仅警告' : 'Warn only'}</button>
+        <button class="pill" data-filter="pass">${lang === 'zh' ? '仅通过' : 'Pass only'}</button>
+        <button class="pill" data-filter="skipped">${lang === 'zh' ? '跳过' : 'Skipped'}</button>
+      </div>
+      <div class="dim-grid">${cardsHtml}</div>
+    </section>`;
+}
+
+function renderSkill(skill: { skillName: string; skillPath: string; status: string; results: DoctorRuleResult[] }, lang: CliLang): string {
+  const seg = segmentSkillResults(skill);
+  const staticHtml = seg.staticRules.map((r) => renderStaticRule(r, lang)).join('');
+  const groupsHtml = [...seg.groups.entries()].map(([gid, results]) => renderGroup(gid, results, lang)).join('');
+  return `
+    <article class="skill skill-${skill.status}">
+      <header class="skill-head">
+        <h1>${escapeHtml(skill.skillName)}</h1>
+        <span class="skill-status">${skill.status.toUpperCase()}</span>
+        <span class="skill-path">${escapeHtml(skill.skillPath)}</span>
+      </header>
+      ${seg.staticRules.length > 0 ? `<div class="static-rules">${staticHtml}</div>` : ''}
+      ${groupsHtml}
+    </article>`;
+}
+
+function renderHeader(report: DoctorReport, lang: CliLang): string {
+  const totals = report.totals;
+  const isZh = lang === 'zh';
+  return `
+    <header class="report-head">
+      <h1>${isZh ? 'omk doctor 健康检查报告' : 'omk doctor Health Check Report'}</h1>
+      <div class="meta">
+        <span class="outcome outcome-${report.outcome}">${report.outcome.toUpperCase()}</span>
+        <span>${isZh ? 'Skill 总览' : 'Skills'}: ✗${totals.fail} ⚠${totals.warn} ✓${totals.pass}</span>
+        <span>${isZh ? '生成于' : 'Generated'}: ${escapeHtml(report.timestamp)}</span>
+        <span>${isZh ? '工作目录' : 'CWD'}: <code>${escapeHtml(report.cwd)}</code></span>
+        <span>executor: ${escapeHtml(report.executorName)} / ${escapeHtml(report.model)}</span>
+      </div>
+    </header>`;
+}
+
+const CSS = `
+  :root {
+    --c-fail: #dc2626; --c-warn: #d97706; --c-pass: #16a34a; --c-skip: #6b7280;
+    --c-fail-bg: #fee2e2; --c-warn-bg: #fef3c7; --c-pass-bg: #dcfce7; --c-skip-bg: #f3f4f6;
+    --c-bg: #fafafa; --c-card: #fff; --c-border: #e5e7eb; --c-text: #111;
+    --c-muted: #6b7280;
+  }
+  * { box-sizing: border-box; }
+  body { font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         color: var(--c-text); background: var(--c-bg); margin: 0; padding: 0; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .92em;
+         background: #f5f5f5; padding: 1px 4px; border-radius: 3px; }
+  .container { max-width: 1100px; margin: 0 auto; padding: 24px; }
+
+  .report-head { background: var(--c-card); padding: 20px 24px; border-radius: 8px;
+                 box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 20px; }
+  .report-head h1 { margin: 0 0 8px; font-size: 22px; }
+  .report-head .meta { display: flex; gap: 16px; flex-wrap: wrap; color: var(--c-muted); font-size: 13px; }
+  .outcome { font-weight: 600; padding: 2px 10px; border-radius: 4px; }
+  .outcome-failed { color: var(--c-fail); background: var(--c-fail-bg); }
+  .outcome-warnings_only { color: var(--c-warn); background: var(--c-warn-bg); }
+  .outcome-passed { color: var(--c-pass); background: var(--c-pass-bg); }
+
+  .skill { background: var(--c-card); border-radius: 8px; padding: 20px 24px;
+           margin-bottom: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.06); }
+  .skill-head { display: flex; align-items: center; gap: 12px; margin-bottom: 16px;
+                border-bottom: 1px solid var(--c-border); padding-bottom: 12px; }
+  .skill-head h1 { margin: 0; font-size: 18px; }
+  .skill-status { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 4px; }
+  .skill-fail .skill-status { background: var(--c-fail-bg); color: var(--c-fail); }
+  .skill-warn .skill-status { background: var(--c-warn-bg); color: var(--c-warn); }
+  .skill-pass .skill-status { background: var(--c-pass-bg); color: var(--c-pass); }
+  .skill-path { font-family: ui-monospace, monospace; color: var(--c-muted); font-size: 12px; }
+
+  .static-rules { margin-bottom: 16px; }
+  .rule-row { padding: 8px 12px; border-left: 3px solid; margin-bottom: 4px;
+              background: #fafafa; border-radius: 0 4px 4px 0; }
+  .rule-row.status-fail { border-color: var(--c-fail); }
+  .rule-row.status-warn { border-color: var(--c-warn); }
+  .rule-row.status-pass { border-color: var(--c-pass); }
+  .rule-row.status-skipped { border-color: var(--c-skip); }
+  .rule-status { font-weight: 700; font-size: 11px; margin-right: 8px; }
+  .rule-row.status-fail .rule-status { color: var(--c-fail); }
+  .rule-row.status-warn .rule-status { color: var(--c-warn); }
+  .rule-row.status-pass .rule-status { color: var(--c-pass); }
+  .rule-row.status-skipped .rule-status { color: var(--c-skip); }
+  .rule-label { font-weight: 600; margin-right: 8px; }
+  .rule-msg { color: var(--c-muted); }
+  .rule-hint { margin-top: 4px; font-size: 12px; color: var(--c-muted); }
+
+  .group { margin-top: 20px; padding: 16px; background: #f9fafb; border-radius: 6px; }
+  .group-head h2 { margin: 0 0 6px; font-size: 16px; }
+  .group-overall { font-size: 12px; padding: 2px 8px; border-radius: 4px;
+                   background: var(--c-fail-bg); color: var(--c-fail); margin-left: 8px; }
+  .group-totals { display: flex; gap: 16px; color: var(--c-muted); font-size: 12px; margin-bottom: 12px; }
+  .group-top { background: #fff7ed; border-left: 4px solid var(--c-warn); padding: 12px 16px;
+               border-radius: 0 4px 4px 0; margin-bottom: 12px; }
+  .group-top .top-title { font-weight: 600; margin-bottom: 4px; }
+  .group-top ol { margin: 0; padding-left: 20px; }
+
+  .filter-pills { display: flex; gap: 6px; margin: 12px 0; }
+  .pill { border: 1px solid var(--c-border); background: #fff; padding: 4px 12px;
+          border-radius: 999px; cursor: pointer; font-size: 12px; }
+  .pill.active { background: var(--c-text); color: #fff; border-color: var(--c-text); }
+
+  .dim-grid { display: grid; gap: 8px; }
+  .dim-card { background: #fff; border: 1px solid var(--c-border); border-left-width: 4px;
+              border-radius: 6px; transition: box-shadow .15s; }
+  .dim-card:hover { box-shadow: 0 2px 6px rgba(0,0,0,.06); }
+  .dim-card.status-fail { border-left-color: var(--c-fail); }
+  .dim-card.status-warn { border-left-color: var(--c-warn); }
+  .dim-card.status-pass { border-left-color: var(--c-pass); }
+  .dim-card.status-skipped { border-left-color: var(--c-skip); }
+  .dim-head { display: flex; align-items: center; gap: 12px; padding: 12px 16px;
+              cursor: pointer; user-select: none; }
+  .dim-status { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 4px;
+                background: #f3f4f6; }
+  .status-fail .dim-status { background: var(--c-fail-bg); color: var(--c-fail); }
+  .status-warn .dim-status { background: var(--c-warn-bg); color: var(--c-warn); }
+  .status-pass .dim-status { background: var(--c-pass-bg); color: var(--c-pass); }
+  .status-skipped .dim-status { background: var(--c-skip-bg); color: var(--c-skip); }
+  .dim-name { font-weight: 600; flex: 1; }
+  .dim-counts { display: flex; gap: 4px; }
+  .badge { font-size: 11px; padding: 1px 6px; border-radius: 3px; min-width: 18px;
+           text-align: center; font-weight: 600; }
+  .badge-err { background: var(--c-fail-bg); color: var(--c-fail); }
+  .badge-warn { background: var(--c-warn-bg); color: var(--c-warn); }
+  .badge-sug { background: #f3f4f6; color: var(--c-muted); }
+  .dim-toggle { color: var(--c-muted); transition: transform .15s; }
+  .dim-card.open .dim-toggle { transform: rotate(90deg); }
+
+  .dim-body { display: none; padding: 0 16px 16px; border-top: 1px solid var(--c-border); }
+  .dim-card.open .dim-body { display: block; }
+  .dim-missing { background: var(--c-warn-bg); color: var(--c-warn); padding: 8px 12px;
+                 border-radius: 4px; margin: 12px 0; font-size: 13px; }
+
+  .dim-findings { margin-top: 12px; }
+  .finding { margin-bottom: 8px; padding: 10px 12px; border-radius: 4px; background: #fafafa;
+             border-left: 3px solid; }
+  .finding-err { border-color: var(--c-fail); }
+  .finding-warn { border-color: var(--c-warn); }
+  .finding-sug { border-color: var(--c-skip); }
+  .finding-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .finding-level { font-size: 11px; font-weight: 700; padding: 1px 8px; border-radius: 3px; }
+  .finding-err .finding-level { background: var(--c-fail-bg); color: var(--c-fail); }
+  .finding-warn .finding-level { background: var(--c-warn-bg); color: var(--c-warn); }
+  .finding-sug .finding-level { background: #f3f4f6; color: var(--c-muted); }
+  .finding-subtype { font-size: 11px; padding: 1px 8px; background: #fff; border: 1px solid var(--c-border);
+                     border-radius: 3px; color: var(--c-muted); }
+  .finding-desc { flex: 1; }
+  .finding-evidence { margin-top: 4px; font-family: ui-monospace, monospace; font-size: 12px;
+                      color: var(--c-muted); padding-left: 8px; border-left: 2px solid var(--c-border); }
+
+  .dim-sugs { margin-top: 12px; padding: 8px 12px; background: #f0f9ff; border-radius: 4px; }
+  .dim-sugs .sugs-title { font-weight: 600; font-size: 12px; color: var(--c-muted); margin-bottom: 4px; }
+  .dim-sugs ul { margin: 0; padding-left: 20px; }
+  .dim-sugs li { font-size: 13px; }
+
+  .empty { color: var(--c-muted); font-style: italic; padding: 8px 0; }
+`;
+
+const JS = `
+(function() {
+  // Filter pills: hide dim cards not matching filter (within same group)
+  document.querySelectorAll('.group').forEach(function(group) {
+    var pills = group.querySelectorAll('.pill');
+    pills.forEach(function(pill) {
+      pill.addEventListener('click', function() {
+        pills.forEach(function(p) { p.classList.remove('active'); });
+        pill.classList.add('active');
+        var filter = pill.getAttribute('data-filter');
+        group.querySelectorAll('.dim-card').forEach(function(card) {
+          var status = card.getAttribute('data-status');
+          card.style.display = (filter === 'all' || filter === status) ? '' : 'none';
+        });
+      });
+    });
+  });
+
+  // Auto-open dim cards with status fail/warn (collapsed by default for pass/skipped)
+  document.querySelectorAll('.dim-card.status-fail').forEach(function(c) { c.classList.add('open'); });
+})();
+`;
+
+export function renderDoctorReportHtml(report: DoctorReport, lang: CliLang = 'zh'): string {
+  // 按 outcome 排序 skill: failed > warnings > passed
+  const skillsSorted = [...report.skills].sort((a, b) => {
+    const rank: Record<string, number> = { fail: 0, warn: 1, pass: 2 };
+    return (rank[a.status] ?? 9) - (rank[b.status] ?? 9);
+  });
+  const skillsHtml = skillsSorted.map((s) => renderSkill(s, lang)).join('');
+  const dataInline = JSON.stringify(report);
+  const title = lang === 'zh' ? 'omk doctor 健康检查报告' : 'omk doctor Health Check Report';
+  return `<!DOCTYPE html>
+<html lang="${lang}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>${CSS}</style>
+</head>
+<body>
+<div class="container">
+${renderHeader(report, lang)}
+${skillsHtml}
+</div>
+<script type="application/json" id="doctor-report-data">${escapeHtml(dataInline)}</script>
+<script>${JS}</script>
+</body>
+</html>`;
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -16,13 +16,13 @@ import type {
   DoctorContext,
   DoctorOutcome,
   DoctorReport,
-  DoctorRule,
+  DoctorRuleLike,
   DoctorRuleResult,
   DoctorRunOptions,
   DoctorSkillReport,
   DoctorSkillStatus,
 } from '../types/index.js';
-import { DOCTOR_REPORT_SCHEMA_VERSION } from '../types/doctor.js';
+import { DOCTOR_REPORT_SCHEMA_VERSION, isComposerRule } from '../types/doctor.js';
 import { getRegisteredRules } from './rules.js';
 
 // ---------------------------------------------------------------------------
@@ -89,14 +89,54 @@ function classifySkillStatus(results: DoctorRuleResult[]): DoctorSkillStatus {
 
 async function runRulesOnArtifact(
   artifact: Artifact,
-  rules: DoctorRule[],
+  rules: DoctorRuleLike[],
   ctxBase: Omit<DoctorContext, 'artifact'>,
 ): Promise<DoctorRuleResult[]> {
   const results: DoctorRuleResult[] = [];
+  const ctx = { ...ctxBase, artifact };
   for (const rule of rules) {
     const start = Date.now();
+    if (isComposerRule(rule)) {
+      // ComposerRule: 一次 checkAll() 产出多条 outcome,展开成 N+1 条 result,
+      // 共享同一个 groupId(= composer.id),renderer 用它把多条 result 视为
+      // 一个组(eg. 健康度体检的 7+1 个 sub-result)。
+      try {
+        const outcomes = await rule.checkAll(ctx);
+        const took = Date.now() - start;
+        for (const oc of outcomes) {
+          results.push({
+            ruleId: `${rule.id}:${oc.subId}`,
+            groupId: rule.id,
+            severity: oc.severity ?? rule.severity,
+            labelKey: oc.labelKey ?? rule.labelKey,
+            status: oc.status,
+            message: oc.message,
+            hint: oc.hint,
+            detail: oc.detail,
+            // composer 只给整体耗时一次;均摊到每条 result 没意义,直接复用。
+            durationMs: took,
+          });
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        results.push({
+          ruleId: `${rule.id}:_summary`,
+          groupId: rule.id,
+          severity: rule.severity,
+          labelKey: rule.labelKey,
+          status: 'fail',
+          message: `composer crashed: ${message.slice(0, 160)}`,
+          hint: undefined,
+          detail: { ruleCrash: true, error: message },
+          durationMs: Date.now() - start,
+        });
+      }
+      continue;
+    }
+
+    // 普通 DoctorRule(原路径)
     try {
-      const outcome = await rule.check({ ...ctxBase, artifact });
+      const outcome = await rule.check(ctx);
       results.push({
         ruleId: rule.id,
         severity: rule.severity,
@@ -106,7 +146,6 @@ async function runRulesOnArtifact(
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      // rule 自身崩溃也算 fail,不让 doctor 整体挂掉
       results.push({
         ruleId: rule.id,
         severity: rule.severity,
@@ -175,6 +214,7 @@ export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
     dependencyCwd,
     lang: opts.lang,
     timeoutMs: opts.timeoutMs,
+    runHealthCheck: opts.runHealthCheck ?? false,
   };
 
   const skillReports: DoctorSkillReport[] = [];

--- a/src/doctor/renderer.ts
+++ b/src/doctor/renderer.ts
@@ -5,6 +5,10 @@
  *   - renderDoctorReportText: 终端友好,符号 + 标签 + 消息 + hint。stream 写到给定
  *     write 函数(默认 stderr,因为 doctor 用 --json 模式时 stdout 应该是结构化 JSON)。
  *   - renderDoctorReportJson: 直接 JSON.stringify。CI 消费。
+ *
+ * groupId 分组:由 ComposerRule 产出的多条 result 共享同一 groupId(= composer.id)。
+ * renderer 按 groupId 把它们渲染成一个段落:先打 group header,再缩进打子项。
+ * 普通 rule 不带 groupId,逐行渲染。
  */
 
 import { tCli, type CliLang } from '../cli/i18n.js';
@@ -22,6 +26,12 @@ const STATUS_SYMBOL: Record<DoctorRuleStatus, string> = {
   skipped: '⊙',
 };
 
+/** 维度子项排序权重:fail 最先,warn 次,pass,skipped 最后。
+ *  groupId 内部用,体现"问题严重的排前面"。 */
+const STATUS_RANK: Record<DoctorRuleStatus, number> = {
+  fail: 0, warn: 1, pass: 2, skipped: 3,
+};
+
 function statusLabel(status: DoctorRuleStatus, lang: CliLang): string {
   if (lang === 'zh') {
     return { pass: '通过', warn: '警告', fail: '失败', skipped: '跳过' }[status];
@@ -29,15 +39,71 @@ function statusLabel(status: DoctorRuleStatus, lang: CliLang): string {
   return { pass: 'PASS', warn: 'WARN', fail: 'FAIL', skipped: 'SKIP' }[status];
 }
 
-function renderRuleLine(result: DoctorRuleResult, ruleLabel: string, lang: CliLang): string {
+function renderRuleLabel(result: DoctorRuleResult, lang: CliLang): string {
+  const key = result.labelKey;
+  if (key in CLI_DICT) return tCli(key as CliMessageKey, lang);
+  return result.ruleId;
+}
+
+function renderRuleLine(result: DoctorRuleResult, ruleLabel: string, lang: CliLang, indent: string = '  '): string {
   const sym = STATUS_SYMBOL[result.status];
   const sLabel = statusLabel(result.status, lang);
-  // 主行: ✓ [PASS] skill 文件可读 — skill 内容长度 28 字符
-  let line = `  ${sym} [${sLabel}] ${ruleLabel} — ${result.message}`;
+  let line = `${indent}${sym} [${sLabel}] ${ruleLabel} — ${result.message}`;
   if (result.hint) {
-    line += `\n    💡 ${result.hint}`;
+    line += `\n${indent}  💡 ${result.hint}`;
   }
   return line;
+}
+
+/** 把 result 列表按 groupId 拆成段(普通 rule 段长度 1, composer 段长度 N+1)。
+ *  保留原顺序:每个 group 在它第一条 result 出现的位置占位。 */
+interface ResultSegment {
+  groupId: string | null;
+  results: DoctorRuleResult[];
+}
+
+function segmentResults(results: DoctorRuleResult[]): ResultSegment[] {
+  const segs: ResultSegment[] = [];
+  const groupSegMap = new Map<string, ResultSegment>();
+  for (const r of results) {
+    const gid = r.groupId ?? null;
+    if (gid === null) {
+      segs.push({ groupId: null, results: [r] });
+      continue;
+    }
+    let seg = groupSegMap.get(gid);
+    if (!seg) {
+      seg = { groupId: gid, results: [] };
+      groupSegMap.set(gid, seg);
+      segs.push(seg);
+    }
+    seg.results.push(r);
+  }
+  return segs;
+}
+
+function renderGroupHeader(groupId: string, results: DoctorRuleResult[], lang: CliLang): string {
+  // group label 取首条 result 的 labelKey 翻译;但若有 _summary 子项,优先用它
+  // 的 labelKey(eg. composer 主标题"健康度体检",而不是某维度名)。
+  // 注意:第一条 result 通常是 7 个维度之一,labelKey 是维度名;summary 在末尾。
+  const summaryRow = results.find((r) => r.ruleId.endsWith(':_summary'));
+  const headerLabelResult = summaryRow ?? results[0];
+  const label = renderRuleLabel(headerLabelResult, lang);
+  // Group 整体 status 取最坏(fail > warn > pass > skipped)
+  const worstStatus = results.reduce<DoctorRuleStatus>((acc, r) => {
+    return STATUS_RANK[r.status] < STATUS_RANK[acc] ? r.status : acc;
+  }, 'pass' as DoctorRuleStatus);
+  const sym = STATUS_SYMBOL[worstStatus];
+  const sLabel = statusLabel(worstStatus, lang);
+  return `  ${sym} [${sLabel}] ━━ ${label} ━━ (${groupId})`;
+}
+
+function sortGroupResults(results: DoctorRuleResult[]): DoctorRuleResult[] {
+  // _summary 永远放最后(信息性);其它按 status 严重度排序,fail 最先
+  const summaryRows = results.filter((r) => r.ruleId.endsWith(':_summary'));
+  const dimRows = results.filter((r) => !r.ruleId.endsWith(':_summary'));
+  dimRows.sort((a, b) => STATUS_RANK[a.status] - STATUS_RANK[b.status]);
+  return [...dimRows, ...summaryRows];
 }
 
 export function renderDoctorReportText(
@@ -58,28 +124,26 @@ export function renderDoctorReportText(
 
   for (const skill of report.skills) {
     write(`\n[${skill.skillName}] ${skill.skillPath}\n`);
-    for (const result of skill.results) {
-      const ruleLabel = renderRuleLabel(result, lang);
-      write(renderRuleLine(result, ruleLabel, lang) + '\n');
+    const segments = segmentResults(skill.results);
+    for (const seg of segments) {
+      if (seg.groupId === null) {
+        const r = seg.results[0];
+        write(renderRuleLine(r, renderRuleLabel(r, lang), lang) + '\n');
+        continue;
+      }
+      // ComposerRule group: header + 子项缩进展示
+      write(renderGroupHeader(seg.groupId, seg.results, lang) + '\n');
+      const sorted = sortGroupResults(seg.results);
+      for (const r of sorted) {
+        write(renderRuleLine(r, renderRuleLabel(r, lang), lang, '      ') + '\n');
+      }
     }
   }
 
-  // 总览
   const summary = lang === 'zh'
     ? `\n总览: ${report.totals.pass} 通过 / ${report.totals.warn} 警告 / ${report.totals.fail} 失败\n`
     : `\nSummary: ${report.totals.pass} pass / ${report.totals.warn} warn / ${report.totals.fail} fail\n`;
   write(summary);
-}
-
-/** 用 result.labelKey 翻译 rule 标题。已知 i18n key 走 tCli; 自定义 rule 用未注册的
- *  key 时直接显示 ruleId 作为 fallback (而不是错挂到 skill_readable 的标题)。 */
-function renderRuleLabel(result: DoctorRuleResult, lang: CliLang): string {
-  const key = result.labelKey;
-  // labelKey 是已注册的 CliMessageKey 时走 i18n; 否则 fallback 用 ruleId
-  if (key in CLI_DICT) {
-    return tCli(key as CliMessageKey, lang);
-  }
-  return result.ruleId;
 }
 
 export function renderDoctorReportJson(report: DoctorReport): string {

--- a/src/doctor/rules.ts
+++ b/src/doctor/rules.ts
@@ -25,6 +25,7 @@ import { preflightDependencies } from '../eval-core/dependency-checker.js';
 import type { DependencyIssue } from '../eval-core/dependency-checker.js';
 import type {
   DoctorRule,
+  DoctorRuleLike,
   DoctorContext,
   DoctorRuleCheckOutcome,
 } from '../types/doctor.js';
@@ -258,17 +259,17 @@ export const BUILTIN_RULES: DoctorRule[] = [
   samplesContractAlignedRule,
 ];
 
-/** 扩展 hook(v0.22 不通过 CLI flag 暴露,仅 library API 占位)。 */
-const customRules: DoctorRule[] = [];
+/** 扩展 hook。可注册普通 DoctorRule 或 ComposerRule(健康度体检走 composer)。 */
+const customRules: DoctorRuleLike[] = [];
 
-export function registerRule(rule: DoctorRule): void {
+export function registerRule(rule: DoctorRuleLike): void {
   if (BUILTIN_RULES.some((r) => r.id === rule.id) || customRules.some((r) => r.id === rule.id)) {
     throw new Error(`doctor rule id collision: ${rule.id}`);
   }
   customRules.push(rule);
 }
 
-export function getRegisteredRules(): DoctorRule[] {
+export function getRegisteredRules(): DoctorRuleLike[] {
   return [...BUILTIN_RULES, ...customRules];
 }
 

--- a/src/types/doctor.ts
+++ b/src/types/doctor.ts
@@ -29,9 +29,43 @@ export interface DoctorRuleResult {
   /** 结构化数据,留给 renderer 或上游系统消费(不渲染到终端)。 */
   detail?: Record<string, unknown>;
   durationMs: number;
+  /** 由 ComposerRule 产出的子结果共享同一个 groupId(= composer.id)。renderer
+   *  按 groupId 把多条 result 渲染为同一组(header + 缩进的子项)。普通 rule 不设。 */
+  groupId?: string;
 }
 
-export type DoctorRuleCheckOutcome = Omit<DoctorRuleResult, 'ruleId' | 'severity' | 'labelKey' | 'durationMs'>;
+export type DoctorRuleCheckOutcome = Omit<DoctorRuleResult, 'ruleId' | 'severity' | 'labelKey' | 'durationMs' | 'groupId'>;
+
+/** ComposerRule 的子结果。一次 checkAll() 返回多条,每条会被 engine 映射成
+ *  独立的 DoctorRuleResult。subId 是子 rule 的稳定 id(eg. dimension id),
+ *  最终 ruleId = `${composer.id}:${subId}`。 */
+export interface ComposerOutcome extends DoctorRuleCheckOutcome {
+  subId: string;
+  /** 覆盖 composer 的默认 labelKey(每个子项有自己的标签)。 */
+  labelKey?: string;
+  /** 覆盖 composer 的默认 severity(子项可独立声明 fatal/warn/info)。 */
+  severity?: DoctorSeverity;
+}
+
+/** 复合 rule:一次 checkAll() 产出多条 result,适合"单次 LLM 调用 → N 个维度结果"
+ *  这类场景。doctor engine 检测 kind === 'composer' 时把数组结果展开,每条共享
+ *  同一个 groupId(= composer.id)以便 renderer 分组。 */
+export interface ComposerRule {
+  id: string;
+  kind: 'composer';
+  /** 默认 severity(子 outcome 未指定时用)。 */
+  severity: DoctorSeverity;
+  /** 默认 labelKey(子 outcome 未指定时用,通常是 composer 整体的标签)。 */
+  labelKey: string;
+  checkAll(ctx: DoctorContext): Promise<ComposerOutcome[]>;
+}
+
+/** doctor engine 接受的 rule 类型: 普通 DoctorRule 或 ComposerRule。 */
+export type DoctorRuleLike = DoctorRule | ComposerRule;
+
+export function isComposerRule(r: DoctorRuleLike): r is ComposerRule {
+  return (r as ComposerRule).kind === 'composer';
+}
 
 export interface DoctorContext {
   artifact: Artifact;
@@ -51,6 +85,10 @@ export interface DoctorContext {
   dependencyCwd?: string;
   lang: 'zh' | 'en';
   timeoutMs: number;
+  /** opt-in 深度健康检查(LLM-judge,多维度)。默认 false,只跑静态 rule;true 时
+   *  skill_health composer 才真正调 LLM。composer 不在 BUILTIN_RULES,必须先
+   *  import './doctor/health/register.js' 让 registerRule 副作用生效。 */
+  runHealthCheck?: boolean;
 }
 
 export interface DoctorRule {
@@ -111,6 +149,10 @@ export interface DoctorRunOptions {
    *  artifact.cwd, 高于 cwd)。CLI 嵌入 bench run 时传 skillDir, 与 evaluation
    *  preflight 的 cwd 选择规则保持一致(参见 evaluation-pipeline.ts dependency check)。 */
   dependencyCwd?: string;
-  /** 覆盖默认 rules(test 注入用)。生产路径走 getRegisteredRules() = BUILTIN + custom。 */
-  rules?: DoctorRule[];
+  /** 覆盖默认 rules(test 注入用)。生产路径走 getRegisteredRules() = BUILTIN + custom。
+   *  既可以是普通 DoctorRule,也可以是 ComposerRule(健康度体检走这条)。 */
+  rules?: DoctorRuleLike[];
+  /** opt-in 深度健康检查(7 维 LLM-judge)。透传给 DoctorContext.runHealthCheck。
+   *  CLI 层由 --health flag 控制。默认 false。 */
+  runHealthCheck?: boolean;
 }

--- a/test/doctor/health/composer.test.ts
+++ b/test/doctor/health/composer.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, beforeEach } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  makeSkillHealthComposer,
+  SKILL_HEALTH_COMPOSER_ID,
+  type ExecutorFactory,
+} from '../../../src/doctor/health/composer.js';
+import {
+  registerHealthDimension,
+  __resetHealthDimensionsForTest,
+} from '../../../src/doctor/health/dimension-registry.js';
+import type { Artifact } from '../../../src/types/index.js';
+import type { DoctorContext } from '../../../src/types/doctor.js';
+import type { ExecResult, ExecutorFn } from '../../../src/types/executor.js';
+import type { HealthDimensionSpec } from '../../../src/doctor/health/dimension-spec.js';
+
+const stubDim = (id: string, severity: 'fatal' | 'warn' | 'info' = 'warn'): HealthDimensionSpec => ({
+  id,
+  displayName: id,
+  labelKey: `cli.doctor.health.dim.${id}`,
+  severity,
+  promptSection: `${id} prompt`,
+});
+
+function ctxWith(artifact: Artifact, overrides: Partial<DoctorContext> = {}): DoctorContext {
+  return {
+    artifact,
+    executorName: 'mock',
+    model: 'sonnet',
+    cwd: '/tmp',
+    lang: 'zh',
+    timeoutMs: 60000,
+    runHealthCheck: true,
+    ...overrides,
+  };
+}
+
+const sampleSkill = (overrides: Partial<Artifact> = {}): Artifact => ({
+  name: 'sample',
+  kind: 'skill',
+  source: 'file-path',
+  content: '你是一个测试 skill 助手,负责简短回答用户问题,不超过 200 字。',
+  ...overrides,
+});
+
+function mockExecutor(output: string, opts: Partial<ExecResult> = {}): ExecutorFn {
+  return async () => ({
+    ok: true,
+    output,
+    durationMs: 10,
+    durationApiMs: 10,
+    inputTokens: 0, outputTokens: 0,
+    cacheReadTokens: 0, cacheCreationTokens: 0,
+    costUSD: 0, stopReason: 'end_turn', numTurns: 1,
+    ...opts,
+  });
+}
+
+const factory = (exec: ExecutorFn): ExecutorFactory => () => exec;
+
+function buildLlmReport(opts: {
+  dims: Array<{ id: string; level: '健康' | '亚健康' | '不健康' | '不适用'; findings?: Array<{ level: '错误' | '警告' | '建议' }> }>;
+  overall?: '良好' | '部分缺陷' | '严重缺陷';
+  topSuggestions?: string[];
+}): string {
+  return JSON.stringify({
+    skill_name: 'sample',
+    feature_points: [],
+    checklist: opts.dims.map((d) => ({
+      dim_id: d.id,
+      level: d.level,
+      findings: (d.findings ?? []).map((f) => ({
+        level: f.level, subtype: '', evidence: 'L1', description: 'desc',
+      })),
+      suggestions: [],
+    })),
+    summary: {
+      overall_health: opts.overall ?? '良好',
+      top_suggestions: opts.topSuggestions ?? [],
+    },
+  });
+}
+
+describe('skill_health composer', () => {
+  beforeEach(() => __resetHealthDimensionsForTest());
+
+  it('returns single skipped outcome when runHealthCheck=false', async () => {
+    registerHealthDimension(stubDim('a'));
+    const composer = makeSkillHealthComposer(factory(mockExecutor('{}')));
+    const out = await composer.checkAll(ctxWith(sampleSkill(), { runHealthCheck: false }));
+    assert.equal(out.length, 1);
+    assert.equal(out[0].subId, '_summary');
+    assert.equal(out[0].status, 'skipped');
+  });
+
+  it('returns single skipped outcome when no dimensions registered', async () => {
+    const composer = makeSkillHealthComposer(factory(mockExecutor('{}')));
+    const out = await composer.checkAll(ctxWith(sampleSkill()));
+    assert.equal(out.length, 1);
+    assert.equal(out[0].subId, '_summary');
+    assert.equal(out[0].status, 'skipped');
+  });
+
+  it('returns single skipped outcome when artifact.content empty', async () => {
+    registerHealthDimension(stubDim('a'));
+    const composer = makeSkillHealthComposer(factory(mockExecutor('{}')));
+    const out = await composer.checkAll(ctxWith(sampleSkill({ content: null })));
+    assert.equal(out.length, 1);
+    assert.equal(out[0].subId, '_summary');
+    assert.equal(out[0].status, 'skipped');
+  });
+
+  it('produces N+1 outcomes (N dims + 1 summary) for full run', async () => {
+    registerHealthDimension(stubDim('a'));
+    registerHealthDimension(stubDim('b'));
+    registerHealthDimension(stubDim('c'));
+    const llm = buildLlmReport({
+      dims: [
+        { id: 'a', level: '健康' },
+        { id: 'b', level: '亚健康', findings: [{ level: '警告' }] },
+        { id: 'c', level: '不健康', findings: [{ level: '错误' }] },
+      ],
+      overall: '严重缺陷',
+      topSuggestions: ['fix1', 'fix2'],
+    });
+    const composer = makeSkillHealthComposer(factory(mockExecutor(llm)));
+    const out = await composer.checkAll(ctxWith(sampleSkill()));
+    assert.equal(out.length, 4);
+    const dimOutcomes = out.filter((o) => o.subId !== '_summary');
+    const summary = out.find((o) => o.subId === '_summary');
+    assert.equal(dimOutcomes.length, 3);
+    assert.ok(summary);
+  });
+
+  it('maps dim levels to status: 不健康→fail, 亚健康→warn, 健康→pass, 不适用→skipped', async () => {
+    registerHealthDimension(stubDim('a'));
+    registerHealthDimension(stubDim('b'));
+    registerHealthDimension(stubDim('c'));
+    registerHealthDimension(stubDim('d'));
+    const llm = buildLlmReport({
+      dims: [
+        { id: 'a', level: '不健康', findings: [{ level: '错误' }] },
+        { id: 'b', level: '亚健康', findings: [{ level: '警告' }] },
+        { id: 'c', level: '健康' },
+        { id: 'd', level: '不适用' },
+      ],
+    });
+    const composer = makeSkillHealthComposer(factory(mockExecutor(llm)));
+    const out = await composer.checkAll(ctxWith(sampleSkill()));
+    const map = new Map(out.map((o) => [o.subId, o.status]));
+    assert.equal(map.get('a'), 'fail');
+    assert.equal(map.get('b'), 'warn');
+    assert.equal(map.get('c'), 'pass');
+    assert.equal(map.get('d'), 'skipped');
+  });
+
+  it('marks outcome as skipped + missing message when LLM omits a dim', async () => {
+    registerHealthDimension(stubDim('a'));
+    registerHealthDimension(stubDim('b'));
+    // LLM 只输出 a,漏报 b
+    const llm = buildLlmReport({ dims: [{ id: 'a', level: '健康' }] });
+    const composer = makeSkillHealthComposer(factory(mockExecutor(llm)));
+    const out = await composer.checkAll(ctxWith(sampleSkill()));
+    const bOutcome = out.find((o) => o.subId === 'b');
+    assert.ok(bOutcome);
+    assert.equal(bOutcome!.status, 'skipped');
+    assert.equal((bOutcome!.detail as { missing?: boolean }).missing, true);
+  });
+
+  it('uses dim.severity for outcome (lets fatal dims fail doctor outcome)', async () => {
+    registerHealthDimension(stubDim('crit', 'fatal'));
+    registerHealthDimension(stubDim('soft', 'warn'));
+    const llm = buildLlmReport({
+      dims: [
+        { id: 'crit', level: '健康' },
+        { id: 'soft', level: '健康' },
+      ],
+    });
+    const composer = makeSkillHealthComposer(factory(mockExecutor(llm)));
+    const out = await composer.checkAll(ctxWith(sampleSkill()));
+    const crit = out.find((o) => o.subId === 'crit');
+    const soft = out.find((o) => o.subId === 'soft');
+    assert.equal(crit!.severity, 'fatal');
+    assert.equal(soft!.severity, 'warn');
+  });
+
+  it('embeds top_suggestions and overall in summary outcome', async () => {
+    registerHealthDimension(stubDim('a'));
+    const llm = buildLlmReport({
+      dims: [{ id: 'a', level: '健康' }],
+      overall: '良好',
+      topSuggestions: ['sugg-1', 'sugg-2'],
+    });
+    const composer = makeSkillHealthComposer(factory(mockExecutor(llm)));
+    const out = await composer.checkAll(ctxWith(sampleSkill()));
+    const summary = out.find((o) => o.subId === '_summary');
+    assert.ok(summary!.hint?.includes('sugg-1'));
+    const detail = summary!.detail as { overall?: string; topSuggestions?: string[] };
+    assert.equal(detail.overall, '良好');
+    assert.deepEqual(detail.topSuggestions, ['sugg-1', 'sugg-2']);
+  });
+
+  it('returns single fail summary when executor throws', async () => {
+    registerHealthDimension(stubDim('a'));
+    const failExec: ExecutorFn = async () => { throw new Error('rate limited'); };
+    const composer = makeSkillHealthComposer(factory(failExec));
+    const out = await composer.checkAll(ctxWith(sampleSkill()));
+    assert.equal(out.length, 1);
+    assert.equal(out[0].subId, '_summary');
+    assert.equal(out[0].status, 'fail');
+    assert.equal((out[0].detail as { phase?: string }).phase, 'executor');
+  });
+
+  it('returns single fail summary when LLM output has no JSON', async () => {
+    registerHealthDimension(stubDim('a'));
+    const composer = makeSkillHealthComposer(factory(mockExecutor('I cannot help')));
+    const out = await composer.checkAll(ctxWith(sampleSkill()));
+    assert.equal(out.length, 1);
+    assert.equal((out[0].detail as { phase?: string }).phase, 'extract');
+  });
+
+  it('composer id is exposed for engine to use as ruleId prefix / groupId', () => {
+    assert.equal(SKILL_HEALTH_COMPOSER_ID, 'skill_health');
+    const composer = makeSkillHealthComposer();
+    assert.equal(composer.id, 'skill_health');
+    assert.equal(composer.kind, 'composer');
+  });
+});

--- a/test/doctor/health/parser.test.ts
+++ b/test/doctor/health/parser.test.ts
@@ -1,0 +1,173 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  extractJson,
+  parseHealthOutput,
+  deriveOverallHealth,
+} from '../../../src/doctor/health/parser.js';
+import type { HealthDimensionSpec } from '../../../src/doctor/health/dimension-spec.js';
+
+const stubDim = (id: string): HealthDimensionSpec => ({
+  id,
+  displayName: id,
+  labelKey: `cli.doctor.health.dim.${id}`,
+  severity: 'warn',
+  promptSection: `${id} prompt`,
+});
+
+const dims = [stubDim('a'), stubDim('b'), stubDim('c')];
+
+// ---------------------------------------------------------------------------
+// extractJson
+// ---------------------------------------------------------------------------
+
+describe('extractJson', () => {
+  it('returns null on empty', () => {
+    assert.equal(extractJson(''), null);
+  });
+
+  it('extracts a single object with prose preamble', () => {
+    const text = 'Here:\n{"skill_name":"x","checklist":[],"summary":{}}\nThanks!';
+    const out = extractJson(text);
+    assert.ok(out);
+    assert.equal(JSON.parse(out!).skill_name, 'x');
+  });
+
+  it('prefers candidate with ≥2 required keys', () => {
+    const text = '{"sub":{"k":1}} {"skill_name":"x","checklist":[],"summary":{"overall_health":"良好"}}';
+    const out = extractJson(text);
+    assert.equal(JSON.parse(out!).skill_name, 'x');
+  });
+
+  it('handles braces inside strings', () => {
+    const text = '{"skill_name":"x","note":"contains } brace","checklist":[],"summary":{}}';
+    assert.equal(JSON.parse(extractJson(text)!).note, 'contains } brace');
+  });
+
+  it('handles escaped quotes', () => {
+    const text = '{"skill_name":"x","note":"with \\"quote\\"","checklist":[],"summary":{}}';
+    assert.equal(JSON.parse(extractJson(text)!).note, 'with "quote"');
+  });
+
+  it('returns null if no parseable object', () => {
+    assert.equal(extractJson('not JSON'), null);
+    assert.equal(extractJson('{ unclosed '), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseHealthOutput
+// ---------------------------------------------------------------------------
+
+describe('parseHealthOutput', () => {
+  it('dispatches checklist items to byDimId by dim_id', () => {
+    const json = JSON.stringify({
+      skill_name: 'x',
+      checklist: [
+        { dim_id: 'a', level: '健康', findings: [], suggestions: [] },
+        { dim_id: 'b', level: '亚健康', findings: [{ level: '警告', evidence: 'L1', description: 'd' }], suggestions: ['fix'] },
+        { dim_id: 'c', level: '不健康', findings: [{ level: '错误', evidence: 'L2', description: 'd2' }], suggestions: [] },
+      ],
+      summary: { overall_health: '严重缺陷', top_suggestions: ['top1'] },
+    });
+    const r = parseHealthOutput(json, dims);
+    assert.equal(r.byDimId.size, 3);
+    assert.equal(r.byDimId.get('a')!.level, '健康');
+    assert.equal(r.byDimId.get('b')!.findings.length, 1);
+    assert.equal(r.byDimId.get('c')!.level, '不健康');
+    assert.equal(r.overall, '严重缺陷');
+    assert.deepEqual(r.topSuggestions, ['top1']);
+  });
+
+  it('drops checklist items with unknown dim_id', () => {
+    const json = JSON.stringify({
+      skill_name: 'x',
+      checklist: [
+        { dim_id: 'a', level: '健康', findings: [], suggestions: [] },
+        { dim_id: 'unknown-id', level: '健康', findings: [], suggestions: [] },
+      ],
+      summary: {},
+    });
+    const r = parseHealthOutput(json, dims);
+    assert.equal(r.byDimId.size, 3); // a + b/c missing placeholders, but unknown-id dropped
+    assert.ok(!r.byDimId.has('unknown-id'));
+  });
+
+  it('fills missing dimensions with placeholder marked _missing', () => {
+    const json = JSON.stringify({
+      skill_name: 'x',
+      checklist: [{ dim_id: 'a', level: '健康', findings: [], suggestions: [] }],
+      summary: {},
+    });
+    const r = parseHealthOutput(json, dims);
+    assert.equal(r.byDimId.get('a')!._missing, undefined);
+    assert.equal(r.byDimId.get('b')!._missing, true);
+    assert.equal(r.byDimId.get('c')!._missing, true);
+  });
+
+  it('derives level from findings when item.level is missing/invalid', () => {
+    const json = JSON.stringify({
+      skill_name: 'x',
+      checklist: [
+        { dim_id: 'a', findings: [], suggestions: [] }, // missing level → 健康 (0 findings)
+        { dim_id: 'b', level: 'wat', findings: [{ level: '警告', evidence: 'e', description: 'd' }], suggestions: [] },
+        { dim_id: 'c', findings: [{ level: '错误', evidence: 'e', description: 'd' }], suggestions: [] },
+      ],
+      summary: {},
+    });
+    const r = parseHealthOutput(json, dims);
+    assert.equal(r.byDimId.get('a')!.level, '健康');
+    assert.equal(r.byDimId.get('b')!.level, '亚健康');
+    assert.equal(r.byDimId.get('c')!.level, '不健康');
+  });
+
+  it('returns overall=null when LLM gave invalid value (caller derives)', () => {
+    const json = JSON.stringify({
+      skill_name: 'x',
+      checklist: [{ dim_id: 'a', level: '健康', findings: [], suggestions: [] }],
+      summary: { overall_health: 'wat' },
+    });
+    const r = parseHealthOutput(json, dims);
+    assert.equal(r.overall, null);
+  });
+
+  it('preserves feature_points', () => {
+    const fp = [{ name: 'fp1', simulation: [] }];
+    const json = JSON.stringify({ skill_name: 'x', feature_points: fp, checklist: [], summary: {} });
+    const r = parseHealthOutput(json, dims);
+    assert.deepEqual(r.featurePoints, fp);
+  });
+
+  it('handles malformed JSON gracefully (returns empty results)', () => {
+    const r = parseHealthOutput('not-json', dims);
+    assert.equal(r.byDimId.size, 3); // all 3 placeholders
+    assert.equal(r.byDimId.get('a')!._missing, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveOverallHealth
+// ---------------------------------------------------------------------------
+
+describe('deriveOverallHealth', () => {
+  const buildMap = (entries: Array<[string, '健康' | '亚健康' | '不健康' | '不适用', boolean?]>) => {
+    const m = new Map();
+    for (const [id, level, missing] of entries) {
+      m.set(id, { level, findings: [], suggestions: [], _missing: missing });
+    }
+    return m;
+  };
+
+  it('any 不健康 → 严重缺陷', () => {
+    assert.equal(deriveOverallHealth(buildMap([['a', '不健康'], ['b', '健康']])), '严重缺陷');
+  });
+  it('only 亚健康 → 部分缺陷', () => {
+    assert.equal(deriveOverallHealth(buildMap([['a', '亚健康'], ['b', '健康']])), '部分缺陷');
+  });
+  it('all 健康/不适用 → 良好', () => {
+    assert.equal(deriveOverallHealth(buildMap([['a', '健康'], ['b', '不适用']])), '良好');
+  });
+  it('ignores _missing dims when deriving', () => {
+    assert.equal(deriveOverallHealth(buildMap([['a', '不健康', true], ['b', '健康']])), '良好');
+  });
+});

--- a/test/doctor/health/prompt-builder.test.ts
+++ b/test/doctor/health/prompt-builder.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { buildHealthPrompt } from '../../../src/doctor/health/prompt-builder.js';
+import type { HealthDimensionSpec } from '../../../src/doctor/health/dimension-spec.js';
+
+const dim = (id: string, displayName: string): HealthDimensionSpec => ({
+  id,
+  displayName,
+  labelKey: `cli.doctor.health.dim.${id}`,
+  severity: 'warn',
+  promptSection: `内容: ${id}`,
+});
+
+const baseInput = {
+  skillName: 'test-skill',
+  skillContent: '你是一个助手。',
+  skillRoot: '/tmp/skills/test-skill',
+  subFiles: ['scripts/foo.sh', 'references/api.md'],
+  siblingSkills: ['other-skill-a', 'other-skill-b'],
+};
+
+describe('buildHealthPrompt', () => {
+  it('numbers dimensions automatically by registration order', () => {
+    const dims = [dim('a', 'A 维度'), dim('b', 'B 维度'), dim('c', 'C 维度')];
+    const prompt = buildHealthPrompt(baseInput, dims);
+    assert.ok(prompt.includes('## 1. A 维度 (id: `a`)'));
+    assert.ok(prompt.includes('## 2. B 维度 (id: `b`)'));
+    assert.ok(prompt.includes('## 3. C 维度 (id: `c`)'));
+  });
+
+  it('inlines skill content (no Read needed for SKILL.md)', () => {
+    const dims = [dim('a', 'A')];
+    const prompt = buildHealthPrompt(baseInput, dims);
+    assert.ok(prompt.includes('```markdown\n你是一个助手。\n```'));
+  });
+
+  it('builds dim_id enum from registered ids', () => {
+    const dims = [dim('foo', 'Foo'), dim('bar-baz', 'Bar')];
+    const prompt = buildHealthPrompt(baseInput, dims);
+    assert.ok(prompt.includes('"foo" | "bar-baz"'));
+  });
+
+  it('includes "checklist must contain exactly N items" for N dims', () => {
+    const dims = [dim('a', 'A'), dim('b', 'B'), dim('c', 'C')];
+    const prompt = buildHealthPrompt(baseInput, dims);
+    assert.ok(prompt.includes('恰好包含 3 项'));
+  });
+
+  it('lists sibling skills + sub-files in the input block', () => {
+    const dims = [dim('a', 'A')];
+    const prompt = buildHealthPrompt(baseInput, dims);
+    assert.ok(prompt.includes('`other-skill-a`'));
+    assert.ok(prompt.includes('`other-skill-b`'));
+    assert.ok(prompt.includes('scripts/foo.sh'));
+    assert.ok(prompt.includes('references/api.md'));
+  });
+
+  it('hints "no sub-files" when subFiles empty', () => {
+    const prompt = buildHealthPrompt({ ...baseInput, subFiles: [] }, [dim('a', 'A')]);
+    assert.ok(prompt.includes('no sub-files'));
+  });
+
+  it('hints "single .md skill" when skillRoot is null', () => {
+    const prompt = buildHealthPrompt({ ...baseInput, skillRoot: null }, [dim('a', 'A')]);
+    assert.ok(prompt.includes('skill 是单文件 .md'));
+  });
+
+  it('includes common rules (同根因合并 / Finding level / overall_health)', () => {
+    const prompt = buildHealthPrompt(baseInput, [dim('a', 'A')]);
+    assert.ok(prompt.includes('同根因合并'));
+    assert.ok(prompt.includes('Finding level 判定'));
+    assert.ok(prompt.includes('overall_health'));
+  });
+});

--- a/test/doctor/health/registry.test.ts
+++ b/test/doctor/health/registry.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, beforeEach } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  registerHealthDimension,
+  getRegisteredHealthDimensions,
+  __resetHealthDimensionsForTest,
+} from '../../../src/doctor/health/dimension-registry.js';
+import type { HealthDimensionSpec } from '../../../src/doctor/health/dimension-spec.js';
+
+const stubSpec = (id: string, overrides: Partial<HealthDimensionSpec> = {}): HealthDimensionSpec => ({
+  id,
+  displayName: id,
+  labelKey: `cli.doctor.health.dim.${id}`,
+  severity: 'warn',
+  promptSection: `check ${id}`,
+  ...overrides,
+});
+
+describe('dimension-registry', () => {
+  beforeEach(() => __resetHealthDimensionsForTest());
+
+  it('preserves registration order', () => {
+    registerHealthDimension(stubSpec('a'));
+    registerHealthDimension(stubSpec('b'));
+    registerHealthDimension(stubSpec('c'));
+    assert.deepEqual(getRegisteredHealthDimensions().map((d) => d.id), ['a', 'b', 'c']);
+  });
+
+  it('throws on duplicate id', () => {
+    registerHealthDimension(stubSpec('a'));
+    assert.throws(() => registerHealthDimension(stubSpec('a')), /collision/);
+  });
+
+  it('throws on empty id or id containing colon', () => {
+    assert.throws(() => registerHealthDimension(stubSpec('')), /invalid/);
+    assert.throws(() => registerHealthDimension(stubSpec('a:b')), /invalid/);
+  });
+
+  it('returns a defensive copy (mutation does not affect registry)', () => {
+    registerHealthDimension(stubSpec('a'));
+    const list = getRegisteredHealthDimensions();
+    list.push(stubSpec('rogue'));
+    assert.deepEqual(getRegisteredHealthDimensions().map((d) => d.id), ['a']);
+  });
+});

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { runDoctor, resolveDoctorTargets } from '../../src/doctor/index.js';
 import { registerRule, __resetCustomRulesForTest } from '../../src/doctor/rules.js';
 import type { Artifact } from '../../src/types/index.js';
-import type { DoctorRule } from '../../src/types/doctor.js';
+import type { ComposerRule, DoctorRule } from '../../src/types/doctor.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const EXAMPLE_SKILLS_DIR = join(__dirname, '..', '..', 'examples', 'code-review', 'skills');
@@ -608,5 +608,86 @@ describe('DoctorReport — CI-friendly schema fields', () => {
     assert.equal(report.ruleStats.warn, 1);
     assert.equal(report.ruleStats.total, 2);
     assert.equal(report.outcome, 'warnings_only');
+  });
+
+  it('expands ComposerRule outcomes into multiple results sharing groupId', async () => {
+    const inlineArtifact: Artifact = {
+      name: 'inline-composer',
+      kind: 'skill',
+      source: 'inline',
+      content: '你是一个测试 skill,内容足够长以通过 readable 检测。',
+    };
+    const composer: ComposerRule = {
+      id: 'test_composer',
+      kind: 'composer',
+      severity: 'fatal',
+      labelKey: 'cli.doctor.rule.skill_readable',
+      async checkAll() {
+        return [
+          { subId: 'd1', status: 'fail',  message: 'd1 failed',  severity: 'fatal' },
+          { subId: 'd2', status: 'warn',  message: 'd2 warning', severity: 'warn' },
+          { subId: 'd3', status: 'pass',  message: 'd3 ok' },
+          { subId: '_summary', status: 'pass', message: 'overall summary', severity: 'info' },
+        ];
+      },
+    };
+    const report = await runDoctor({
+      artifacts: [inlineArtifact],
+      cwd: '/tmp',
+      executorName: 'claude',
+      model: 'sonnet',
+      timeoutMs: 8000,
+      lang: 'zh',
+      rules: [composer],
+    });
+    const results = report.skills[0].results;
+    assert.equal(results.length, 4, 'composer 4 outcomes should expand to 4 results');
+    const ids = results.map((r) => r.ruleId);
+    assert.deepEqual(ids, [
+      'test_composer:d1',
+      'test_composer:d2',
+      'test_composer:d3',
+      'test_composer:_summary',
+    ]);
+    for (const r of results) assert.equal(r.groupId, 'test_composer');
+    // skill 状态应该 roll up 到 fail (因为 d1 是 fatal+fail)
+    assert.equal(report.skills[0].status, 'fail');
+    assert.equal(report.outcome, 'failed');
+    // ruleStats 应该统计每条 sub-result(4 条)
+    assert.equal(report.ruleStats.total, 4);
+    assert.equal(report.ruleStats.fail, 1);
+    assert.equal(report.ruleStats.warn, 1);
+    assert.equal(report.ruleStats.pass, 2);
+  });
+
+  it('catches composer crashes and emits a single fail summary', async () => {
+    const inlineArtifact: Artifact = {
+      name: 'inline-crash',
+      kind: 'skill',
+      source: 'inline',
+      content: '你是一个测试 skill,长度足够。',
+    };
+    const crashing: ComposerRule = {
+      id: 'crash_composer',
+      kind: 'composer',
+      severity: 'fatal',
+      labelKey: 'cli.doctor.rule.skill_readable',
+      async checkAll() { throw new Error('composer exploded'); },
+    };
+    const report = await runDoctor({
+      artifacts: [inlineArtifact],
+      cwd: '/tmp',
+      executorName: 'claude',
+      model: 'sonnet',
+      timeoutMs: 8000,
+      lang: 'zh',
+      rules: [crashing],
+    });
+    const results = report.skills[0].results;
+    assert.equal(results.length, 1);
+    assert.equal(results[0].ruleId, 'crash_composer:_summary');
+    assert.equal(results[0].status, 'fail');
+    assert.ok(results[0].message.includes('composer crashed'));
+    assert.equal((results[0].detail as { ruleCrash?: boolean }).ruleCrash, true);
   });
 });


### PR DESCRIPTION
 ## 背景

  omk doctor 之前是「纯静态 / 零 LLM」的 CI gate(4 条
  rule)。需求是把它升级成支持深度健康度审计的工具:LLM
  一次评审产出多维度结果,**用户能自己加维度**,产出**可视化 HTML 报告**。

  ## 改动

  ### 1. 引入 ComposerRule(`src/types/doctor.ts`)
  新增 `ComposerRule` 接口:`checkAll(ctx)` 一次产出 N+1 条 outcome。doctor
  engine(`src/doctor/index.ts`)检测到 `kind === 'composer'` 时把数组结果展开成多条
  `DoctorRuleResult`,共享 `groupId = composer.id`,renderer 按 groupId 分组。

  ### 2. 健康度子系统 `src/doctor/health/`
  - `dimension-spec.ts` — 维度 spec 类型(id / displayName / labelKey / severity /
  promptSection)
  - `dimension-registry.ts` — singleton + `registerHealthDimension(spec)` 公开 API
  - `builtin-dimensions.ts` — 7 内置:trigger-boundary / doc-clarity / instr-precision
   / dependency / tool-conventions / security / examples
  - `prompt-builder.ts` — 4 区块拼装(任务头 / 维度章节自动编号 / 通用规则 / JSON
  schema 含 dim_id 枚举),用户加维度自动加入 prompt
  - `parser.ts` — extractJson + 按 dim_id 派发 + 漏报 placeholder + overall_health
  派生
  - `composer.ts` — `makeSkillHealthComposer(execFactory)` 工厂(测试可注入 mock)
  - `register.ts` — 副作用注册入口

  ### 3. HTML 报告(`src/doctor/html-renderer.ts`)
  - single-file HTML(JSON inline + CSS/JS 内嵌),双击直开
  - skill 按 outcome 排序(failed 在前)
  - 维度卡片按 fail→warn→pass→skipped 排,失败维度默认展开
  - 维度内 finding 按 错误→警告→建议 排
  - 顶部 filter pills 实时过滤

  ### 4. omk doctor CLI 行为变化
  - 默认就跑 LLM 健康度审计(取消 `--health` opt-in)
  - 跳过 4 条静态 rule(`BUILTIN_RULES` 物理保留给 `bench run/gate` 当强
  gate,**角色分离**:doctor=审计,bench=评测)
  - 新增 `--html <path>` 可与 `--json` 共存
  - 默认 timeout 600s

  ### 5. i18n 调整
  - 7 内置维度 labelKey 改用稳定英文 id(`cli.doctor.health.dim.trigger-boundary` 等)
  - composer summary key + dim message key
  - help 文本说明新角色定位

  ## 用户接口

  ```ts
  import { registerHealthDimension } from
  'oh-my-knowledge/dist/src/doctor/health/dimension-registry.js';

  registerHealthDimension({
    id: 'mcp-fence',
    displayName: 'MCP 围栏',
    labelKey: '...',
    severity: 'warn',
    promptSection: '...',
  });
  ```
  注册后立即参与同一次 LLM 调用,产出独立的 `skill_health:mcp-fence` result + HTML
  卡片。

  ## 测试
  - 新增 4 组 36 条 case:`registry.test.ts` / `prompt-builder.test.ts` /
  `parser.test.ts` / `composer.test.ts`
  - `index.test.ts` 加 2 条 composer 集成测试
  - 现有 4 条静态 rule 测试保留(代码层未删)
  - **130/130** 全过

  ## 验证

  ```bash
  omk doctor /path/to/skill --html /tmp/r.html
  # 7 维度 + 1 summary,HTML 报告写出,outcome 取决于 fatal 维度是否 fail
  ```

  实跑 `linke-compile-fix` skill:
  - 7 维度全部解析(security: 不健康 / 其余 6 维: 亚健康)
  - top_suggestions 给出 3 条优先级排序的修复建议
  - HTML 53KB,filter pills + 折叠展开正常

  ## 不影响

  - `omk bench run` / `bench gate` 内部仍跑 4 条静态 rule 当强
  gate(`run-evaluation.ts:227`),评测质量保护不变
  - 现有 BUILTIN_RULES 静态 rule 测试全保留

  ## Test plan

  - [ ] `yarn typecheck && yarn lint && yarn test` 全过(本地已验)
  - [ ] `omk doctor my-skill` 默认输出健康度报告(7+1 result,无静态 rule)
  - [ ] `omk doctor my-skill --html /tmp/r.html` 产出 HTML,双击可看
  - [ ] `omk doctor my-skill --json | jq .outcome` 正确反映 LLM 评估的 outcome
  - [ ] `omk bench run` 路径未受影响,doctor 静态 gate 仍生效
  - [ ] 自定义维度 demo:写一个 `registerHealthDimension(spec)` 调用,验证 prompt 拼装
  + HTML 显示