### PR TITLE
fix(release): 修复发布前 smoke 问题

### DIFF
--- a/src/executors/script.ts
+++ b/src/executors/script.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
 import type { ExecResult, ExecutorFn, ExecutorInput } from '../types/index.js';
 import {
   DEFAULT_TIMEOUT_MS,
@@ -12,7 +14,21 @@ import {
 // 让用户知道 strict-baseline / 显式 allowedSkills 在 script executor 下静默无效。
 let scriptIsolationWarned = false;
 
+function resolveExecutorPath(part: string, baseCwd: string): string {
+  if (isAbsolute(part)) return part;
+  if (!part.includes('/') && !part.startsWith('.')) return part;
+  const candidate = resolve(baseCwd, part);
+  return existsSync(candidate) ? candidate : part;
+}
+
 export function createScriptExecutor(command: string): ExecutorFn {
+  const baseCwd = process.cwd();
+  const parts = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [command];
+  const cmd = resolveExecutorPath(parts[0].replace(/^["']|["']$/g, ''), baseCwd);
+  const args = parts.slice(1)
+    .map((a) => a.replace(/^["']|["']$/g, ''))
+    .map((a) => resolveExecutorPath(a, baseCwd));
+
   return async function scriptExecutor({ model, system, prompt, cwd, timeoutMs = DEFAULT_TIMEOUT_MS, allowedSkills }: ExecutorInput): Promise<ExecResult> {
     if (allowedSkills !== undefined && !scriptIsolationWarned) {
       scriptIsolationWarned = true;
@@ -23,10 +39,6 @@ export function createScriptExecutor(command: string): ExecutorFn {
     }
     const input = JSON.stringify({ model, system: system || '', prompt });
     const start = Date.now();
-
-    const parts = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [command];
-    const cmd = parts[0].replace(/^["']|["']$/g, '');
-    const args = parts.slice(1).map((a) => a.replace(/^["']|["']$/g, ''));
 
     const { child, done } = spawnWithSigintPropagation(cmd, args, {
       env: { ...process.env },

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -13,6 +13,7 @@ import type { SkillHealthReport } from '../observability/skill-health-analyzer.j
 import type { AddressInfo } from 'node:net';
 
 const DEFAULT_PORT = 7799;
+const PORT_HINT = `OMK_REPORT_PORT=${DEFAULT_PORT} omk eval ...`;
 const DEFAULT_REPORTS_DIR = join(homedir(), '.oh-my-knowledge', 'reports');
 const DEFAULT_ANALYSES_DIR = join(homedir(), '.oh-my-knowledge', 'analyses');
 
@@ -404,7 +405,7 @@ export function formatListenError(p: number, err: unknown): Error | null {
       `cannot bind ephemeral port (--port 0): ${errno ?? 'unknown error'}.\n` +
       `  likely cause: sandboxed / restricted network environment ` +
       `(Docker without --net=host, container without bind permission).\n` +
-      `  try a fixed port: OMK_REPORT_PORT=8080 omk eval ...`
+      `  try a fixed port: ${PORT_HINT}`
     );
   }
 
@@ -414,7 +415,7 @@ export function formatListenError(p: number, err: unknown): Error | null {
     return new Error(
       `cannot bind port ${p}: permission denied (${errno}).\n` +
       `  ports < 1024 require root on Unix; sandboxed environments may block all binds.\n` +
-      `  pick a higher port: OMK_REPORT_PORT=8080 omk eval ...`
+      `  pick another unblocked port: ${PORT_HINT}`
     );
   }
 
@@ -423,7 +424,7 @@ export function formatListenError(p: number, err: unknown): Error | null {
   if (errno && errno !== 'EADDRINUSE') {
     return new Error(
       `cannot bind port ${p}: ${errno} (${getErrorMessage(err)}).\n` +
-      `  pick another port: OMK_REPORT_PORT=8080 omk eval ...`
+      `  pick another port: ${PORT_HINT}`
     );
   }
 
@@ -703,7 +704,7 @@ export function createReportServer({ port, reportsDir = DEFAULT_REPORTS_DIR, ana
           `port ${p} is already in use by another process.\n` +
           `  inspect: lsof -i:${p}\n` +
           `  release: lsof -ti:${p} | xargs kill\n` +
-          `  or pick another port: OMK_REPORT_PORT=8080 omk eval ...`
+          `  or pick another port: ${PORT_HINT}`
         );
       }
     }

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -1,5 +1,8 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createExecutor } from '../src/executors/index.js';
 
 describe('createExecutor', () => {
@@ -31,5 +34,22 @@ describe('createExecutor', () => {
   it('falls back to script executor for unknown name', () => {
     const executor = createExecutor('echo hello');
     assert.equal(typeof executor, 'function');
+  });
+
+  it('resolves relative script executor paths before per-task cwd changes', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omk-script-executor-cwd-'));
+    try {
+      const executor = createExecutor('node test/fixtures/script-executor.mjs');
+      const result = await executor({
+        model: 'test',
+        system: '',
+        prompt: 'hello',
+        cwd,
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.output, 'fixture: hello');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/test/fixtures/script-executor.mjs
+++ b/test/fixtures/script-executor.mjs
@@ -1,0 +1,4 @@
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const input = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+process.stdout.write(JSON.stringify({ output: `fixture: ${input.prompt}` }));

--- a/test/server/format-listen-error.test.ts
+++ b/test/server/format-listen-error.test.ts
@@ -31,12 +31,12 @@ describe('formatListenError', () => {
     assert.match(out.message, /unknown error/);
   });
 
-  it('p=80 + EACCES → permission-denied message, suggests higher port', () => {
+  it('p=80 + EACCES → permission-denied message, suggests configured report port', () => {
     const out = formatListenError(80, nodeErr('EACCES'));
     assert.ok(out);
     assert.match(out.message, /permission denied/);
     assert.match(out.message, /port 80/);
-    assert.match(out.message, /pick a higher port/);
+    assert.match(out.message, /OMK_REPORT_PORT=7799/);
     assert.doesNotMatch(out.message, /already in use/);
   });
 
@@ -73,7 +73,7 @@ describe('formatListenError', () => {
     ];
     for (const out of cases) {
       assert.ok(out);
-      assert.match(out.message, /--port \d+|pick another port|pick a higher port/);
+      assert.match(out.message, /OMK_REPORT_PORT=7799|--port \d+|pick another port|pick another unblocked port/);
     }
   });
 });


### PR DESCRIPTION
## 用户影响

发布前真实 smoke 暴露了两个发布前需要修正的问题：

- `omk studio --port 7798` 在端口不可绑定时，错误提示仍建议 `OMK_REPORT_PORT=8080`，和当前默认端口 7799、studio 示例 7798 的口径不一致。
- 自定义 script executor 使用相对路径时，评测任务切换到 per-task `cwd` 后会找不到脚本，导致 baseline 分支报 `spawn ... ENOENT`。

这次把 report server 的端口修复建议统一到默认端口 7799，并让 script executor 在创建时解析相对脚本路径，后续任务 `cwd` 只影响子进程工作目录，不影响 executor 定位。

## 测量学说明

不影响 report schema、评测统计、judge prompt、bootstrap、verdict 或 length-debias 语义。script executor 修复只改变失败路径下的脚本定位行为，让相对 executor 路径按用户启动 omk 时的工作目录解释。

## 验证

- `yarn build`
- `yarn lint`
- `yarn test test/server/format-listen-error.test.ts test/server/report-server.test.ts test/cli/studio-dev-spawn.test.ts`
- `yarn test test/executor.test.ts`
- `yarn test`
- smoke：`omk studio --port 7798 --reports-dir ...` 在 Codex 沙箱中仍因环境限制 EPERM，但提示已改为 `OMK_REPORT_PORT=7799`
- smoke：相对 `--executor examples/custom-executor/echo-executor.sh` 的真实 eval 已通过，baseline 和 treatment 均无 `ENOENT`
