### PR TITLE
fix(release): 补齐发版前体验修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ Exports evidence for PRs, CI summaries, and audit trails. HTML writes a standalo
 omk studio
 omk studio --port 7799
 omk studio --reports-dir ~/.oh-my-knowledge/reports
+omk studio --no-open
 ```
 
 Starts the local knowledge workbench for browsing reports and observation analyses.

--- a/README.zh.md
+++ b/README.zh.md
@@ -462,6 +462,7 @@ omk export saturation <report-id>
 omk studio
 omk studio --port 7799
 omk studio --reports-dir ~/.oh-my-knowledge/reports
+omk studio --no-open
 ```
 
 启动本地知识工作台，用来浏览报告和观测分析。

--- a/SKILL.md
+++ b/SKILL.md
@@ -148,6 +148,7 @@ omk improve samples --batch
 ```bash
 # 打开本地工作台
 omk studio
+omk studio --no-open
 
 # 导出为独立 HTML
 omk export <reportId> --format html

--- a/SKILL.md
+++ b/SKILL.md
@@ -25,7 +25,10 @@ npm i oh-my-knowledge -g
 
 | 用户意图 | 操作 |
 |---------|------|
+| 创建/初始化评测项目 | → 初始化项目 |
+| 健康检查/检测 skill | → 运行 doctor |
 | 评测/对比 skill | → 运行评测 |
+| 线上观测/真实 session 分析 | → 运行 observe |
 | 改进/优化 skill | → 自动迭代改进 |
 | 生成评测用例 | → 生成评测用例 |
 | 查看报告 | → 打开本地工作台 |
@@ -40,14 +43,42 @@ npm i oh-my-knowledge -g
 1. `skills/` 目录下有哪些 skill 文件（`.md` 或 `*/SKILL.md`）
 2. 是否存在 `eval-samples.json`、`eval-samples.yaml`、`eval-samples.yml`
 3. 是否有 `skills/*.eval-samples.json`（--batch 模式的配对文件）
+4. 是否存在 Claude Code session trace（常见在 `~/.claude/projects/...`，用于 `omk observe`）
 
 根据检测结果决定：
+- 没有 omk 项目结构 → 建议 `omk init <dir>` 初始化
 - 有多个 skill + 各自的 eval-samples → 建议 `--batch` 批量模式
 - 有多个 skill + 共享 eval-samples → 建议版本对比模式
 - 只有一个 skill → 建议 `baseline` 对照或 `improve skill` 改进
 - 没有 eval-samples → 建议先 `improve samples` 生成
+- 用户关心真实使用效果、失败率、耗时、token 或知识缺口 → 建议 `observe`
 
 ## 第四步：执行操作
+
+### 初始化项目
+
+```bash
+# 创建一个包含两版 starter skill 和 eval-samples.json 的评测项目
+omk init my-eval
+cd my-eval
+```
+
+初始化后先让用户编辑 `skills/*/SKILL.md` 和 `eval-samples.json`，再进入 `doctor` / `eval`。
+
+### 健康检查
+
+```bash
+# 检查当前目录或 ./skills
+omk doctor
+
+# 检查单个 skill 文件
+omk doctor skills/my-skill.md
+
+# CI 门禁模式
+omk doctor --gate
+```
+
+`doctor` 是纯静态检查，零 LLM 调用。它检查 skill 可读性、frontmatter、前置依赖和评测用例契约；`omk eval` 前也会强制运行。
 
 ### 评测 Skill
 
@@ -79,6 +110,21 @@ omk eval --dry-run
 - `--gold-dir <path>`: 引入人工锚点算 Krippendorff α,验证评委是否可信
 - `--judge-models claude:opus,openai:gpt-4o`: 多评委 ensemble,消除单评委偏差
 - `--repeat 5`: 启用饱和曲线分析,告诉用户"再多跑样本是否有收益"
+
+### 线上观测
+
+```bash
+# 解析真实 Claude Code session trace
+omk observe ~/.claude/projects/-Users-you-Documents-my-project
+
+# 只看最近 7 天
+omk observe ~/.claude/projects/-Users-you-Documents-my-project --last 7d
+
+# 只观测指定 skill
+omk observe ~/.claude/projects/-Users-you-Documents-my-project --skills audit,polish
+```
+
+`observe` 用真实 session 生成 skill 健康度报告：知识使用、失败率、gap 信号、耗时和 token。它是生产观测，不是离线评分；用户问"线上到底有没有用"时优先推荐。
 
 ### 自动迭代改进
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,5 +1,5 @@
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { CliExit } from '../cli-exit.js';
 import { tCli, langFromArgv } from '../i18n.js';
 import { COMMON_OPTIONS } from '../parse-run-config.js';
@@ -7,10 +7,45 @@ import { parseArgsStrictOrExit } from '../parse-strict.js';
 import type { DependencyRequirements } from '../../eval-core/dependency-checker.js';
 import type { Sample } from '../../types/index.js';
 
-function findDefaultSamplesPath(cwd: string): string | null {
-  for (const name of ['eval-samples.json', 'eval-samples.yaml', 'eval-samples.yml']) {
-    const candidate = join(cwd, name);
+const DEFAULT_SAMPLE_FILENAMES = ['eval-samples.json', 'eval-samples.yaml', 'eval-samples.yml'] as const;
+
+function findSamplesInDir(dir: string): string | null {
+  for (const name of DEFAULT_SAMPLE_FILENAMES) {
+    const candidate = join(dir, name);
     if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function sampleSearchDirs(target: string | null, cwd: string): string[] {
+  const dirs: string[] = [];
+  const add = (dir: string): void => {
+    const abs = resolve(dir);
+    if (!dirs.includes(abs)) dirs.push(abs);
+  };
+  if (target) {
+    const absTarget = resolve(target);
+    if (existsSync(absTarget)) {
+      const stat = statSync(absTarget);
+      if (stat.isDirectory()) {
+        add(absTarget);
+        add(dirname(absTarget));
+        add(dirname(dirname(absTarget)));
+      } else {
+        const parent = dirname(absTarget);
+        add(parent);
+        add(dirname(parent));
+      }
+    }
+  }
+  add(cwd);
+  return dirs;
+}
+
+function findDefaultSamplesPath(target: string | null, cwd: string): string | null {
+  for (const dir of sampleSearchDirs(target, cwd)) {
+    const samplesPath = findSamplesInDir(dir);
+    if (samplesPath) return samplesPath;
   }
   return null;
 }
@@ -26,6 +61,7 @@ export async function execute(argv: string[]): Promise<void> {
       gate: { type: 'boolean', default: false },
       executor: { type: 'string' },
       model: { type: 'string' },
+      samples: { type: 'string' },
       timeout: { type: 'string' },
     },
   });
@@ -37,7 +73,7 @@ export async function execute(argv: string[]): Promise<void> {
   const timeoutSec = timeoutRaw != null ? Number(timeoutRaw) : 8;
   const timeoutMs = Math.max(1000, Math.floor((Number.isFinite(timeoutSec) ? timeoutSec : 8) * 1000));
   const cwd = process.cwd();
-  const samplesPath = findDefaultSamplesPath(cwd);
+  const samplesPath = values.samples ? resolve(values.samples as string) : findDefaultSamplesPath(target, cwd);
   let samples: Sample[] | undefined;
   let requires: DependencyRequirements | undefined;
   if (samplesPath) {
@@ -95,6 +131,9 @@ export async function execute(argv: string[]): Promise<void> {
       console.error(summary);
     }
   } else {
+    if (samplesPath && samples) {
+      process.stderr.write(tCli('cli.doctor.samples_detected', lang, { path: samplesPath }) + '\n');
+    }
     renderDoctorReportText(report, lang);
   }
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,7 +1,19 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { CliExit } from '../cli-exit.js';
 import { tCli, langFromArgv } from '../i18n.js';
 import { COMMON_OPTIONS } from '../parse-run-config.js';
 import { parseArgsStrictOrExit } from '../parse-strict.js';
+import type { DependencyRequirements } from '../../eval-core/dependency-checker.js';
+import type { Sample } from '../../types/index.js';
+
+function findDefaultSamplesPath(cwd: string): string | null {
+  for (const name of ['eval-samples.json', 'eval-samples.yaml', 'eval-samples.yml']) {
+    const candidate = join(cwd, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
 
 export async function execute(argv: string[]): Promise<void> {
   const lang = langFromArgv(argv);
@@ -25,6 +37,20 @@ export async function execute(argv: string[]): Promise<void> {
   const timeoutSec = timeoutRaw != null ? Number(timeoutRaw) : 8;
   const timeoutMs = Math.max(1000, Math.floor((Number.isFinite(timeoutSec) ? timeoutSec : 8) * 1000));
   const cwd = process.cwd();
+  const samplesPath = findDefaultSamplesPath(cwd);
+  let samples: Sample[] | undefined;
+  let requires: DependencyRequirements | undefined;
+  if (samplesPath) {
+    try {
+      const { loadSamples } = await import('../../inputs/load-samples.js');
+      const loaded = loadSamples(samplesPath);
+      samples = loaded.samples;
+      requires = loaded.requires;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(tCli('cli.common.warn_load_samples_failed', lang, { path: samplesPath, message: msg }));
+    }
+  }
 
   const { runDoctor } = await import('../../doctor/index.js');
   const { renderDoctorReportText, renderDoctorReportJson } = await import('../../doctor/renderer.js');
@@ -38,6 +64,8 @@ export async function execute(argv: string[]): Promise<void> {
       model,
       timeoutMs,
       lang,
+      samples,
+      requires,
     });
   } catch (err) {
     // CliExit 透传(防御性,目前 runDoctor 不抛 CliExit,但保持四个 catch 一致)。

--- a/src/cli/commands/eval-runner.ts
+++ b/src/cli/commands/eval-runner.ts
@@ -282,7 +282,7 @@ export async function execute(argv: string[]): Promise<void> {
       }) as { report: BatchEvaluationReport | DryRunBatchReport; filePath: string | null };
       console.log(JSON.stringify(report, null, 2));
       if (isDryRunBatchReport(report)) {
-        console.log('Eval dry-run: no scores to check');
+        console.log(tCli('cli.run.dry_run_no_scores', lang));
         throw new CliExit(0);
       }
       if (filePath) {
@@ -312,7 +312,7 @@ export async function execute(argv: string[]): Promise<void> {
       })) as EvalResult;
       if (isDryRunReport(result.report)) {
         console.log(JSON.stringify(result.report, null, 2));
-        console.log('Eval dry-run: no scores to check');
+        console.log(tCli('cli.run.dry_run_no_scores', lang));
         throw new CliExit(0);
       }
       report = result.report as Report;

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -4,6 +4,20 @@ import { COMMON_OPTIONS, DEFAULT_REPORTS_DIR } from '../parse-run-config.js';
 import { parseArgsStrictOrExit } from '../parse-strict.js';
 import type { ReportServer } from './_shared.js';
 
+async function openWorkbench(url: string): Promise<void> {
+  const { execFile } = await import('node:child_process');
+  const { platform } = await import('node:os');
+  const browser = process.env.BROWSER?.trim();
+  const openCmd = browser && browser.toLowerCase() !== 'none'
+    ? browser
+    : platform() === 'darwin'
+      ? 'open'
+      : platform() === 'win32'
+        ? 'start'
+        : 'xdg-open';
+  execFile(openCmd, [url], () => undefined);
+}
+
 export async function execute(argv: string[]): Promise<void> {
   const lang = langFromArgv(argv);
   const { values } = parseArgsStrictOrExit({
@@ -13,6 +27,7 @@ export async function execute(argv: string[]): Promise<void> {
       port: { type: 'string', default: '7799' },
       'reports-dir': { type: 'string', default: DEFAULT_REPORTS_DIR },
       'analyses-dir': { type: 'string' },
+      'no-open': { type: 'boolean', default: false },
       dev: { type: 'boolean', default: false },
     },
   });
@@ -32,6 +47,9 @@ export async function execute(argv: string[]): Promise<void> {
     if (values['analyses-dir']) {
       args.push('--analyses-dir', values['analyses-dir'] as string);
     }
+    if (values['no-open']) {
+      args.push('--no-open');
+    }
     const child = spawn(process.execPath, args, {
       stdio: 'inherit',
       env: { ...process.env, __OMK_DEV_CHILD: '1' },
@@ -50,4 +68,7 @@ export async function execute(argv: string[]): Promise<void> {
   const url = await server.start();
   console.log(tCli('cli.studio.started', lang, { url }));
   console.log(tCli('cli.studio.stop_hint', lang));
+  if (!values['no-open'] && process.stdout.isTTY) {
+    await openWorkbench(url);
+  }
 }

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -1,21 +1,27 @@
 import { resolve } from 'node:path';
-import { langFromArgv, tCli } from '../i18n.js';
+import { langFromArgv, tCli, type CliLang } from '../i18n.js';
 import { COMMON_OPTIONS, DEFAULT_REPORTS_DIR } from '../parse-run-config.js';
 import { parseArgsStrictOrExit } from '../parse-strict.js';
 import type { ReportServer } from './_shared.js';
 
-async function openWorkbench(url: string): Promise<void> {
+async function openWorkbench(url: string, lang: CliLang): Promise<void> {
   const { execFile } = await import('node:child_process');
   const { platform } = await import('node:os');
   const browser = process.env.BROWSER?.trim();
-  const openCmd = browser && browser.toLowerCase() !== 'none'
-    ? browser
-    : platform() === 'darwin'
-      ? 'open'
-      : platform() === 'win32'
-        ? 'start'
-        : 'xdg-open';
-  execFile(openCmd, [url], () => undefined);
+  if (browser?.toLowerCase() === 'none') return;
+
+  const os = platform();
+  const command = browser || (os === 'win32' ? 'cmd' : os === 'darwin' ? 'open' : 'xdg-open');
+  const args = os === 'win32' && !browser
+    ? ['/c', 'start', '', url]
+    : [url];
+  execFile(command, args, (err) => {
+    if (!err) return;
+    process.stderr.write(tCli('cli.studio.open_failed', lang, {
+      command,
+      message: err.message,
+    }));
+  });
 }
 
 export async function execute(argv: string[]): Promise<void> {
@@ -69,6 +75,6 @@ export async function execute(argv: string[]): Promise<void> {
   console.log(tCli('cli.studio.started', lang, { url }));
   console.log(tCli('cli.studio.stop_hint', lang));
   if (!values['no-open'] && process.stdout.isTTY) {
-    await openWorkbench(url);
+    await openWorkbench(url, lang);
   }
 }

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -116,6 +116,7 @@ export type CliMessageKey =
   | 'cli.export.done'
   | 'cli.studio.started'
   | 'cli.studio.stop_hint'
+  | 'cli.studio.open_failed'
   // improve samples
   | 'cli.gen.skill_skipped_existing'
   | 'cli.gen.skill_generating'
@@ -201,6 +202,7 @@ export type CliMessageKey =
   // omk doctor — CLI level
   | 'cli.help.doctor_usage'
   | 'cli.doctor.no_skill_found'
+  | 'cli.doctor.samples_detected'
   | 'cli.doctor.gate_blocked'
   | 'cli.run.skip_connectivity_warning';
 
@@ -441,6 +443,10 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
   'cli.studio.stop_hint': {
     zh: '按 Ctrl+C 停止服务',
     en: 'Press Ctrl+C to stop',
+  },
+  'cli.studio.open_failed': {
+    zh: '⚠ 无法自动打开浏览器（{command}）：{message}\n',
+    en: '⚠ Failed to open browser automatically ({command}): {message}\n',
   },
   'cli.gen.skill_skipped_existing': {
     zh: '⏭️  {name}: eval-samples 已存在, 跳过\n',
@@ -1244,6 +1250,7 @@ oh-my-knowledge — omk doctor 健康检查
   --gate                 静默模式: 通过 exit 0 / 不通过 exit 1, 仅 stderr 出问题摘要
   --executor <name>      executor 名(仅向后兼容, doctor 不直接打 LLM)
   --model <name>         model 名(同上)
+  --samples <path>       显式指定评测用例文件
   --timeout <seconds>    rule 执行超时(默认 8)
   --lang <zh|en>         切换输出语言
 
@@ -1277,6 +1284,7 @@ Options:
   --gate                 Silent mode: exit 0 if pass, exit 1 if fail; brief stderr summary only
   --executor <name>      executor name (kept for compat; doctor does not call LLM)
   --model <name>         model name (same)
+  --samples <path>       Explicit eval samples file
   --timeout <seconds>    per-rule timeout (default 8)
   --lang <zh|en>         Output language
 
@@ -1300,6 +1308,10 @@ checks cost nothing to run. LLM connectivity can be skipped with --skip-connecti
   'cli.doctor.no_skill_found': {
     zh: '未在 {path} 下发现 skill 文件。\n  doctor 期望 .md 文件、目录(包含 .md 或 SKILL.md)或 cwd 下的 skills/ 子目录。',
     en: 'No skills found at {path}.\n  doctor expects a .md file, a directory (containing .md or SKILL.md), or skills/ under cwd.',
+  },
+  'cli.doctor.samples_detected': {
+    zh: '✓ 使用评测用例文件：{path}',
+    en: '✓ Using eval samples file: {path}',
   },
   'cli.doctor.gate_blocked': {
     zh: 'skill 健康检查未通过, 评测已中止。doctor 是评测必经环节, 无 skip 选项 — 请修复上述问题后重跑。',

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -1051,11 +1051,13 @@ omk studio — 打开本地知识工作台
   --port <n>                          本地服务端口（默认：7799）
   --reports-dir <path>                报告目录（默认：~/.oh-my-knowledge/reports）
   --analyses-dir <path>               观测分析目录
+  --no-open                           只启动服务，不自动打开浏览器
   --dev                               开发模式：文件变化时自动重启
 
 示例：
   omk studio
   omk studio --port 7798
+  omk studio --no-open
 `,
     en: `
 omk studio — open the local knowledge workbench
@@ -1067,11 +1069,13 @@ Options:
   --port <n>                          Local server port (default: 7799)
   --reports-dir <path>                Reports directory (default: ~/.oh-my-knowledge/reports)
   --analyses-dir <path>               Observation analyses directory
+  --no-open                           Start the server without opening a browser
   --dev                               Dev mode: restart on file changes
 
 Examples:
   omk studio
   omk studio --port 7798
+  omk studio --no-open
 `,
   },
   // sample design coverage block strings

--- a/src/cli/i18n-dict.ts
+++ b/src/cli/i18n-dict.ts
@@ -78,6 +78,10 @@ export type CliMessageKey =
   | 'cli.run.no_debias_length_active'
   | 'cli.run.invalid_bootstrap_samples'
   | 'cli.run.bootstrap_samples_too_large'
+  | 'cli.run.power_warning_tiny_n'
+  | 'cli.run.power_warning_small_n'
+  | 'cli.run.power_warning_repeat_one'
+  | 'cli.run.dry_run_no_scores'
   // eval 完成 / 报告 server / gold compare / 错误
   | 'cli.run.skill_section'
   | 'cli.run.run_section'
@@ -237,6 +241,22 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
   'cli.update.new_version_available': {
     zh: '\n💡 新版本可用: {old} → {new}, 运行 npm update {pkg} -g 升级\n\n',
     en: '\n💡 New version available: {old} → {new}, run npm update {pkg} -g to upgrade\n\n',
+  },
+  'cli.run.power_warning_tiny_n': {
+    zh: '⚠ N={n} < 5：仅适合探索，任何结论都不可靠，CI 会很宽。需要决策时建议 ≥20 条评测用例。',
+    en: '⚠ N={n} < 5 (exploration-only): any conclusion is unreliable, CI will be uselessly wide. Decisions need ≥20 cases.',
+  },
+  'cli.run.power_warning_small_n': {
+    zh: '⚠ N={n} < 20：只能识别很大的效果（Cohen\'s d > 0.8），中等效果（d ≈ 0.5）很难检出。要做可靠决策建议 ≥20 条评测用例。',
+    en: '⚠ N={n} < 20 (large-effect-only, Cohen\'s d > 0.8): medium effects (d ≈ 0.5) hard to detect. For confident decisions consider ≥20 cases.',
+  },
+  'cli.run.power_warning_repeat_one': {
+    zh: '⚠ --repeat=1：单轮评测无法测稳定性（CV 会标记为未测量）。用 --repeat 3+ 检测同一 variant 内部方差。',
+    en: '⚠ --repeat=1: single-run cannot measure stability (CV will be marked "not measured"). Use --repeat 3+ to detect within-variant variance.',
+  },
+  'cli.run.dry_run_no_scores': {
+    zh: 'eval dry-run：仅预览任务，不检查分数',
+    en: 'Eval dry-run: no scores to check',
   },
   'cli.progress.preflight_starting': {
     zh: '⏳ 正在预检模型连通性...\n',

--- a/src/eval-core/fact-checker.ts
+++ b/src/eval-core/fact-checker.ts
@@ -27,7 +27,7 @@ const PATH_PATTERNS = [
   // .claude paths
   /\.claude\/[a-zA-Z0-9_/.@-]+/g,
   // Paths with file extensions mentioned in text
-  /[a-zA-Z0-9_/-]+\.(?:ts|js|tsx|jsx|md|json|yaml|yml|sh)\b/g,
+  /[a-zA-Z0-9_/-]+\.(?:ts|js|tsx|jsx|md|json|yaml|yml|sh)\b(?!\s*\()/g,
 ];
 
 // Paths to ignore (too generic or always present)

--- a/src/eval-workflows/evaluation-pipeline.ts
+++ b/src/eval-workflows/evaluation-pipeline.ts
@@ -36,6 +36,7 @@ import type {
   Task,
   VariantResult,
 } from '../types/index.js';
+import { tCli, type CliLang } from '../cli/i18n.js';
 
 type EvaluationResults = Record<string, Record<string, VariantResult>>;
 
@@ -206,27 +207,21 @@ function computeTestSetHash(samplesPath: string): string | null {
  * saturation curves. This is the upfront "you might be wasting the run"
  * heads-up, not a gate.
  */
-export function buildPowerWarnings(sampleCount: number, repeat: number): string[] {
+export function buildPowerWarnings(sampleCount: number, repeat: number, lang: CliLang = 'en'): string[] {
   const warnings: string[] = [];
   if (sampleCount < 5) {
-    warnings.push(
-      `⚠ N=${sampleCount} < 5 (exploration-only): any conclusion is unreliable, CI will be uselessly wide. Decisions need ≥20 cases.`,
-    );
+    warnings.push(tCli('cli.run.power_warning_tiny_n', lang, { n: sampleCount }));
   } else if (sampleCount < 20) {
-    warnings.push(
-      `⚠ N=${sampleCount} < 20 (large-effect-only, Cohen's d > 0.8): medium effects (d ≈ 0.5) hard to detect. For confident decisions consider ≥20 cases.`,
-    );
+    warnings.push(tCli('cli.run.power_warning_small_n', lang, { n: sampleCount }));
   }
   if (repeat < 2) {
-    warnings.push(
-      `⚠ --repeat=1: single-run cannot measure stability (CV will be marked "not measured"). Use --repeat 3+ to detect within-variant variance.`,
-    );
+    warnings.push(tCli('cli.run.power_warning_repeat_one', lang));
   }
   return warnings;
 }
 
-function emitPowerWarnings(sampleCount: number, repeat: number): void {
-  for (const w of buildPowerWarnings(sampleCount, repeat)) {
+function emitPowerWarnings(sampleCount: number, repeat: number, lang: CliLang): void {
+  for (const w of buildPowerWarnings(sampleCount, repeat, lang)) {
     process.stderr.write(`${w}\n`);
   }
 }
@@ -381,6 +376,8 @@ export interface EvaluationPipelineOptions {
   strictBaseline?: boolean;
   /** Explicit persisted run id. Used by batch workflows that need stable child ids. */
   runId?: string;
+  /** CLI output language for warnings emitted by the pipeline. */
+  lang?: CliLang;
 }
 
 export async function executeEvaluationPipeline({
@@ -425,6 +422,7 @@ export async function executeEvaluationPipeline({
   budget,
   strictBaseline,
   runId,
+  lang = 'zh',
 }: EvaluationPipelineOptions): Promise<{ report: Report; filePath: string | null }> {
   const variantNames = artifacts.map((artifact) => artifact.name);
   const runState = await initializeEvaluationRunState({
@@ -494,7 +492,7 @@ export async function executeEvaluationPipeline({
     // tasks start. These are *not* MDE / power-analysis predictions (we don't have
     // σ before the run); they're hard-floor + experience-based thresholds. Verdict
     // gate (computeVerdict) handles real power claims post-hoc.
-    emitPowerWarnings(samples.length, repeat ?? 1);
+    emitPowerWarnings(samples.length, repeat ?? 1, lang);
     // Isolation pre-flight warning (--no-strict-baseline + ~/.claude/skills/ non-empty)
     emitIsolationWarnings(artifacts, strictBaseline);
 

--- a/src/eval-workflows/evaluation-pipeline.ts
+++ b/src/eval-workflows/evaluation-pipeline.ts
@@ -207,7 +207,7 @@ function computeTestSetHash(samplesPath: string): string | null {
  * saturation curves. This is the upfront "you might be wasting the run"
  * heads-up, not a gate.
  */
-export function buildPowerWarnings(sampleCount: number, repeat: number, lang: CliLang = 'en'): string[] {
+export function buildPowerWarnings(sampleCount: number, repeat: number, lang: CliLang = 'zh'): string[] {
   const warnings: string[] = [];
   if (sampleCount < 5) {
     warnings.push(tCli('cli.run.power_warning_tiny_n', lang, { n: sampleCount }));

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -253,7 +253,7 @@ export async function runEvaluation({
     // Emit power warnings during dry-run too — this is exactly when users
     // preview the run, the right moment to flag "you might be wasting it".
     const { buildPowerWarnings, buildIsolationWarnings } = await import('./evaluation-pipeline.js');
-    for (const w of buildPowerWarnings(samples.length, repeat ?? 1)) {
+    for (const w of buildPowerWarnings(samples.length, repeat ?? 1, lang)) {
       process.stderr.write(`${w}\n`);
     }
     for (const w of buildIsolationWarnings(resolvedArtifacts, strictBaseline)) {
@@ -354,6 +354,7 @@ export async function runEvaluation({
     budget,
     strictBaseline,
     runId,
+    lang,
   });
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -269,6 +269,7 @@ describe('CLI', () => {
       '--skill-dir', skillDir,
       '--control', 'v1',
       '--treatment', 'v2',
+      '--lang', 'zh',
     ]);
     assert.ok(stdout.includes('eval dry-run'));
     assert.ok(stderr.includes('只能识别很大的效果'));
@@ -291,6 +292,7 @@ describe('CLI', () => {
       '--threshold', '3.2',
       '--trivial-diff', '0.2',
       '--no-gate',
+      '--lang', 'zh',
     ]);
     assert.ok(stdout.includes('eval dry-run'));
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -261,7 +261,7 @@ describe('CLI', () => {
   it('eval --dry-run exits 0 through eval workflow', async () => {
     const samplesPath = join(PROJECT_ROOT, 'examples', 'code-review', 'eval-samples.json');
     const skillDir = join(PROJECT_ROOT, 'examples', 'code-review', 'skills');
-    const { stdout } = await execFileAsync('node', [
+    const { stdout, stderr } = await execFileAsync('node', [
       CLI, 'eval',
       '--dry-run',
       '--samples', samplesPath,
@@ -269,7 +269,9 @@ describe('CLI', () => {
       '--control', 'v1',
       '--treatment', 'v2',
     ]);
-    assert.ok(stdout.includes('Eval dry-run'));
+    assert.ok(stdout.includes('eval dry-run'));
+    assert.ok(stderr.includes('只能识别很大的效果'));
+    assert.ok(!stderr.includes('exploration-only'));
   });
 
   it('eval dry-run accepts product workflow options on the unified runner', async () => {
@@ -289,7 +291,7 @@ describe('CLI', () => {
       '--trivial-diff', '0.2',
       '--no-gate',
     ]);
-    assert.ok(stdout.includes('Eval dry-run'));
+    assert.ok(stdout.includes('eval dry-run'));
   });
 
   it('Claude Code SKILL manifest uses current product commands', async () => {
@@ -308,6 +310,24 @@ describe('CLI', () => {
     try {
       const { stdout } = await execFileAsync('node', [CLI, 'init', dir]);
       assert.ok(stdout.includes('已初始化测评项目'));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('doctor auto-detects cwd eval-samples.json', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-doctor-samples-'));
+    try {
+      const skillDir = join(dir, 'skills', 'review');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), '你是一个测试用的代码审查 skill，内容足够长。');
+      await writeFile(join(dir, 'eval-samples.json'), JSON.stringify([
+        { sample_id: 's1', prompt: 'review this code' },
+      ]));
+
+      const { stderr } = await execFileAsync('node', [CLI, 'doctor'], { cwd: dir });
+      assert.ok(stderr.includes('用例 1 条'), stderr);
+      assert.ok(!stderr.includes('未提供 samples'), stderr);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -209,6 +209,7 @@ describe('CLI', () => {
     assert.ok(stdout.includes('omk studio'));
     assert.ok(stdout.includes('--reports-dir'));
     assert.ok(stdout.includes('--analyses-dir'));
+    assert.ok(stdout.includes('--no-open'));
   });
 
   // dispatcher 检查 --help 时扫整个 argv,不限第一位。

--- a/test/cli/doctor-eval-embed.test.ts
+++ b/test/cli/doctor-eval-embed.test.ts
@@ -114,7 +114,7 @@ describe('omk eval doctor preflight embedding', () => {
     ]);
     // Should NOT fail with doctor
     assert.ok(!stderr.includes('doctor failed:'), `stderr should not have doctor failure: ${stderr.slice(0, 500)}`);
-    assert.ok(stdout.includes('Eval dry-run'));
+    assert.ok(stdout.includes('eval dry-run'));
   });
 
   it('--skip-connectivity does not bypass doctor', async () => {
@@ -194,7 +194,7 @@ describe('omk eval doctor preflight embedding', () => {
 
       // doctor 应该只检查 v1 + v2 (健康), 完全忽略 draft.md
       assert.ok(!stderr.includes('doctor failed:'), `expected no doctor failure when draft.md is unrelated to this run; stderr: ${stderr.slice(0, 400)}`);
-      assert.ok(stdout.includes('Eval dry-run'));
+      assert.ok(stdout.includes('eval dry-run'));
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/cli/doctor-eval-embed.test.ts
+++ b/test/cli/doctor-eval-embed.test.ts
@@ -111,6 +111,7 @@ describe('omk eval doctor preflight embedding', () => {
       '--control', 'v1',
       '--treatment', 'v2',
       '--dry-run',
+      '--lang', 'zh',
     ]);
     // Should NOT fail with doctor
     assert.ok(!stderr.includes('doctor failed:'), `stderr should not have doctor failure: ${stderr.slice(0, 500)}`);
@@ -190,6 +191,7 @@ describe('omk eval doctor preflight embedding', () => {
         '--control', 'v1',
         '--treatment', 'v2',
         '--dry-run',
+        '--lang', 'zh',
       ], { cwd: tmp });
 
       // doctor 应该只检查 v1 + v2 (健康), 完全忽略 draft.md

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -25,6 +25,7 @@ describe('omk doctor CLI', () => {
     assert.ok(stdout.includes('健康检查'));
     assert.ok(stdout.includes('--json'));
     assert.ok(stdout.includes('--gate'));
+    assert.ok(stdout.includes('--samples'));
   });
 
   it('--help --lang en shows English usage', async () => {
@@ -112,6 +113,67 @@ describe('omk doctor CLI', () => {
     ]);
     assert.ok(stderr.includes('健康检查'));
     assert.ok(stderr.includes('总览:'));
+  });
+
+  it('auto-detects samples from the target project when cwd differs', async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const tmp = mkdtempSync(join(tmpdir(), 'doctor-target-samples-'));
+    const outside = mkdtempSync(join(tmpdir(), 'doctor-outside-cwd-'));
+    try {
+      const project = join(tmp, 'project');
+      const skillRoot = join(project, 'skills', 'review');
+      mkdirSync(skillRoot, { recursive: true });
+      writeFileSync(join(skillRoot, 'SKILL.md'), '你是一个测试用的代码审查 skill，内容足够长。');
+      writeFileSync(join(project, 'eval-samples.json'), JSON.stringify([
+        { sample_id: 's1', prompt: 'review this code' },
+      ]));
+
+      const { stderr } = await execFileAsync('node', [
+        CLI,
+        'doctor',
+        join(project, 'skills'),
+        '--lang', 'zh',
+      ], { cwd: outside });
+      assert.ok(stderr.includes('使用评测用例文件'), stderr);
+      assert.ok(stderr.includes('eval-samples.json'), stderr);
+      assert.ok(stderr.includes('用例 1 条'), stderr);
+      assert.ok(!stderr.includes('未提供 samples'), stderr);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('--samples overrides auto-detected samples', async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const tmp = mkdtempSync(join(tmpdir(), 'doctor-explicit-samples-'));
+    try {
+      const skillRoot = join(tmp, 'skills', 'review');
+      mkdirSync(skillRoot, { recursive: true });
+      writeFileSync(join(skillRoot, 'SKILL.md'), '你是一个测试用的代码审查 skill，内容足够长。');
+      writeFileSync(join(tmp, 'eval-samples.json'), JSON.stringify([
+        { sample_id: 'auto', prompt: 'auto sample' },
+      ]));
+      const explicitSamples = join(tmp, 'explicit-samples.json');
+      writeFileSync(explicitSamples, JSON.stringify([
+        { sample_id: 'e1', prompt: 'explicit sample 1' },
+        { sample_id: 'e2', prompt: 'explicit sample 2' },
+      ]));
+
+      const { stderr } = await execFileAsync('node', [
+        CLI,
+        'doctor',
+        join(tmp, 'skills'),
+        '--samples', explicitSamples,
+        '--lang', 'zh',
+      ], { cwd: tmp });
+      assert.ok(stderr.includes(`使用评测用例文件：${explicitSamples}`), stderr);
+      assert.ok(stderr.includes('用例 2 条'), stderr);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it('product dispatch lists omk doctor as a top-level command', async () => {

--- a/test/cli/strict-unknown-options.test.ts
+++ b/test/cli/strict-unknown-options.test.ts
@@ -157,6 +157,7 @@ describe('strict unknown option rejection', () => {
       '--treatment', 'v2',
       '--dry-run',
       '--skip-connectivity',
+      '--lang', 'zh',
     ]);
     assert.ok(stdout.includes('eval dry-run'));
   });

--- a/test/cli/strict-unknown-options.test.ts
+++ b/test/cli/strict-unknown-options.test.ts
@@ -158,6 +158,6 @@ describe('strict unknown option rejection', () => {
       '--dry-run',
       '--skip-connectivity',
     ]);
-    assert.ok(stdout.includes('Eval dry-run'));
+    assert.ok(stdout.includes('eval dry-run'));
   });
 });

--- a/test/cli/studio-dev-spawn.test.ts
+++ b/test/cli/studio-dev-spawn.test.ts
@@ -1,23 +1,74 @@
-import { describe, it, vi, beforeEach, expect } from 'vitest';
+import { describe, it, vi, beforeEach, afterEach, expect } from 'vitest';
 
 interface CapturedSpawn {
   command: string;
   args: string[];
 }
 
+interface CapturedExecFile {
+  command: string;
+  args: string[];
+}
+
 const spawnCalls: CapturedSpawn[] = [];
+const execFileCalls: CapturedExecFile[] = [];
+let platformName = 'darwin';
+let execFileError: Error | null = null;
+
+const originalStdoutIsTty = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+
+function setStdoutIsTTY(value: boolean): void {
+  Object.defineProperty(process.stdout, 'isTTY', { value, configurable: true });
+}
+
+function restoreStdoutIsTTY(): void {
+  if (originalStdoutIsTty) {
+    Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTty);
+  } else {
+    Reflect.deleteProperty(process.stdout, 'isTTY');
+  }
+}
 
 vi.mock('node:child_process', () => ({
   spawn: vi.fn((command: string, args: string[]) => {
     spawnCalls.push({ command, args });
     return { on: () => undefined };
   }),
+  execFile: vi.fn((command: string, args: string[], callback: (err: Error | null) => void) => {
+    execFileCalls.push({ command, args });
+    callback(execFileError);
+    return { on: () => undefined };
+  }),
+}));
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return {
+    ...actual,
+    platform: vi.fn(() => platformName),
+  };
+});
+
+vi.mock('../../src/server/report-server.js', () => ({
+  createReportServer: vi.fn(() => ({
+    start: vi.fn(async () => 'http://127.0.0.1:7799'),
+  })),
 }));
 
 describe('studio --dev child spawn argv', () => {
   beforeEach(() => {
     spawnCalls.length = 0;
+    execFileCalls.length = 0;
+    execFileError = null;
+    platformName = 'darwin';
     delete process.env.__OMK_DEV_CHILD;
+    delete process.env.BROWSER;
+    setStdoutIsTTY(false);
+  });
+
+  afterEach(() => {
+    restoreStdoutIsTTY();
+    vi.clearAllMocks();
   });
 
   it('uses cli/index.js as child entrypoint and re-enters studio', async () => {
@@ -32,5 +83,46 @@ describe('studio --dev child spawn argv', () => {
     expect(cliPath).not.toMatch(/[\\/]commands[\\/]/);
     expect(command).toBe('studio');
     expect(rest).toEqual(['--port', '8080', '--reports-dir', 'tmp-reports', '--no-open']);
+  });
+
+  it('treats BROWSER=none as no browser open', async () => {
+    const { execute } = await import('../../src/cli/commands/studio.js');
+    setStdoutIsTTY(true);
+    process.env.BROWSER = 'none';
+
+    await execute([]);
+
+    expect(execFileCalls).toHaveLength(0);
+  });
+
+  it('uses cmd start for the default Windows browser opener', async () => {
+    const { execute } = await import('../../src/cli/commands/studio.js');
+    setStdoutIsTTY(true);
+    platformName = 'win32';
+
+    await execute([]);
+
+    expect(execFileCalls).toEqual([
+      { command: 'cmd', args: ['/c', 'start', '', 'http://127.0.0.1:7799'] },
+    ]);
+  });
+
+  it('warns when browser auto-open fails', async () => {
+    const { execute } = await import('../../src/cli/commands/studio.js');
+    setStdoutIsTTY(true);
+    platformName = 'linux';
+    execFileError = new Error('xdg-open missing');
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      await execute([]);
+
+      expect(execFileCalls).toEqual([
+        { command: 'xdg-open', args: ['http://127.0.0.1:7799'] },
+      ]);
+      expect(stderr.mock.calls.some((call) => String(call[0]).includes('无法自动打开浏览器'))).toBe(true);
+    } finally {
+      stderr.mockRestore();
+    }
   });
 });

--- a/test/cli/studio-dev-spawn.test.ts
+++ b/test/cli/studio-dev-spawn.test.ts
@@ -22,7 +22,7 @@ describe('studio --dev child spawn argv', () => {
 
   it('uses cli/index.js as child entrypoint and re-enters studio', async () => {
     const { execute } = await import('../../src/cli/commands/studio.js');
-    await execute(['--dev', '--port', '8080', '--reports-dir', 'tmp-reports']);
+    await execute(['--dev', '--port', '8080', '--reports-dir', 'tmp-reports', '--no-open']);
 
     expect(spawnCalls).toHaveLength(1);
     const [, watchRoot, cliPath, command, ...rest] = spawnCalls[0].args;
@@ -31,6 +31,6 @@ describe('studio --dev child spawn argv', () => {
     expect(cliPath).toMatch(/[\\/]cli[\\/]index\.(js|ts)$/);
     expect(cliPath).not.toMatch(/[\\/]commands[\\/]/);
     expect(command).toBe('studio');
-    expect(rest).toEqual(['--port', '8080', '--reports-dir', 'tmp-reports']);
+    expect(rest).toEqual(['--port', '8080', '--reports-dir', 'tmp-reports', '--no-open']);
   });
 });

--- a/test/eval-core/fact-checker.test.ts
+++ b/test/eval-core/fact-checker.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { extractPathClaims } from '../../src/eval-core/fact-checker.js';
+
+describe('fact-checker path extraction', () => {
+  it('does not treat method calls as file paths', () => {
+    const claims = extractPathClaims('const data = await res.json(); return data;');
+    assert.ok(!claims.includes('res.json'));
+  });
+
+  it('still extracts real file paths with known extensions', () => {
+    const claims = extractPathClaims('Update eval-samples.json and src/cli/index.ts.');
+    assert.ok(claims.includes('eval-samples.json'));
+    assert.ok(claims.includes('src/cli/index.ts'));
+  });
+});

--- a/test/eval-workflows/power-warnings.test.ts
+++ b/test/eval-workflows/power-warnings.test.ts
@@ -41,6 +41,14 @@ describe('buildPowerWarnings', () => {
     assert.match(w[1], /--repeat=1/);
   });
 
+  it('中文输出不泄漏英文 dry-run 体验文案', () => {
+    const w = buildPowerWarnings(3, 1, 'zh');
+    assert.equal(w.length, 2);
+    assert.match(w[0], /仅适合探索/);
+    assert.match(w[1], /单轮评测无法测稳定性/);
+    assert.doesNotMatch(w.join('\n'), /exploration-only|single-run cannot measure stability/);
+  });
+
   it('完美配置(n=30, repeat=3)无警告', () => {
     const w = buildPowerWarnings(30, 3);
     assert.equal(w.length, 0);

--- a/test/eval-workflows/power-warnings.test.ts
+++ b/test/eval-workflows/power-warnings.test.ts
@@ -4,27 +4,27 @@ import { buildPowerWarnings } from '../../src/eval-workflows/evaluation-pipeline
 
 describe('buildPowerWarnings', () => {
   it('n < 5: 探索级警告', () => {
-    const w = buildPowerWarnings(3, 1);
+    const w = buildPowerWarnings(3, 1, 'en');
     assert.equal(w.length, 2);  // n + repeat
     assert.match(w[0], /N=3 < 5/);
     assert.match(w[0], /exploration-only/);
   });
 
   it('5 ≤ n < 20: 大效应警告', () => {
-    const w = buildPowerWarnings(10, 1);
+    const w = buildPowerWarnings(10, 1, 'en');
     assert.equal(w.length, 2);
     assert.match(w[0], /N=10 < 20/);
     assert.match(w[0], /large-effect-only/);
   });
 
   it('n ≥ 20: 不报 n 警告(只剩 repeat=1)', () => {
-    const w = buildPowerWarnings(20, 1);
+    const w = buildPowerWarnings(20, 1, 'en');
     assert.equal(w.length, 1);
     assert.match(w[0], /--repeat=1/);
   });
 
   it('repeat=1: 稳定性测不到警告', () => {
-    const w = buildPowerWarnings(30, 1);
+    const w = buildPowerWarnings(30, 1, 'en');
     assert.equal(w.length, 1);
     assert.match(w[0], /single-run cannot measure stability/);
   });
@@ -35,7 +35,7 @@ describe('buildPowerWarnings', () => {
   });
 
   it('两条警告同时报(小 n + 单轮)', () => {
-    const w = buildPowerWarnings(3, 1);
+    const w = buildPowerWarnings(3, 1, 'en');
     assert.equal(w.length, 2);
     assert.match(w[0], /N=3/);
     assert.match(w[1], /--repeat=1/);
@@ -50,17 +50,17 @@ describe('buildPowerWarnings', () => {
   });
 
   it('完美配置(n=30, repeat=3)无警告', () => {
-    const w = buildPowerWarnings(30, 3);
+    const w = buildPowerWarnings(30, 3, 'en');
     assert.equal(w.length, 0);
   });
 
   it('边界:n=4(<5) 触发探索级,n=5(≥5) 触发大效应级', () => {
-    assert.match(buildPowerWarnings(4, 3)[0], /< 5/);
-    assert.match(buildPowerWarnings(5, 3)[0], /< 20/);
+    assert.match(buildPowerWarnings(4, 3, 'en')[0], /< 5/);
+    assert.match(buildPowerWarnings(5, 3, 'en')[0], /< 20/);
   });
 
   it('边界:n=19(<20) 触发大效应级,n=20(≥20) 不报 n 警告', () => {
-    assert.equal(buildPowerWarnings(19, 3).length, 1);
-    assert.equal(buildPowerWarnings(20, 3).length, 0);
+    assert.equal(buildPowerWarnings(19, 3, 'en').length, 1);
+    assert.equal(buildPowerWarnings(20, 3, 'en').length, 0);
   });
 });


### PR DESCRIPTION
## 用户影响

这次处理 0.27 发版前 review 提到的首体验问题：

- Claude Code 的 `SKILL.md` 补齐 `init` / `doctor` / `observe` 正文教学，让新增的检测和观测工作流能被 agent 正确路由。
- `omk doctor` 支持 `--samples <path>`，并会从 target 项目附近或 cwd 自动发现 `eval-samples.json` / `.yaml` / `.yml`，普通输出会说明实际使用的评测用例文件。
- `omk eval --dry-run` 和正式 eval 的小样本 / 单轮 warning、dry-run 收尾文案接入 CLI i18n，中文默认输出不再混入英文体验文案。
- `factCheck` 不再把 `res.json()` 这类方法调用误识别成缺失文件，避免 starter 评测用例首跑出现误导性事实校验。
- `omk studio --no-open` 已支持，headless / CI smoke 可以只启动服务，不自动打开浏览器；`--dev` 子进程也会透传该参数。
- `studio` 浏览器打开逻辑补齐 Windows `cmd /c start`、`BROWSER=none` 跳过打开、以及打开失败时的 stderr 提示。

## 测量学说明

不修改 report schema、评分管道、judge prompt、bootstrap、verdict 或 length-debias 语义。`doctor` 只是把已有 samples 契约检查接到 CLI 默认发现路径；`factCheck` 只减少方法调用的误报，不放宽真实文件路径校验；`studio --no-open` 只影响本地工作台启动体验。

## 验证

- `yarn build`
- `yarn lint`
- `yarn test test/eval-workflows/power-warnings.test.ts test/eval-core/fact-checker.test.ts test/cli.test.ts test/cli/doctor-eval-embed.test.ts test/cli/strict-unknown-options.test.ts`
- `yarn test test/cli/studio-dev-spawn.test.ts test/cli/doctor.test.ts test/eval-workflows/power-warnings.test.ts test/cli.test.ts test/cli/doctor-eval-embed.test.ts test/cli/strict-unknown-options.test.ts`
- `yarn test`
- smoke：`omk init` → `omk doctor` → `omk eval --dry-run --skip-connectivity --no-serve`
- smoke：`omk doctor --help` / `omk studio --help`
