### PR TITLE
docs(workflow): 切换为 GitHub Flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,8 +28,8 @@ commit-message convention, and validation requirements.
 ## Checklist
 
 - [ ] Read `CLAUDE.md`
-- [ ] Branch is `feat/*`, `fix/*`, `docs/*`, `chore/*`, `release/*`, or `hotfix/*` (Gitflow)
-- [ ] Target branch follows the current branch strategy in `CLAUDE.md` / `CONTRIBUTING.md`
+- [ ] Branch is `feat/*`, `fix/*`, `docs/*`, or `chore/*`, cut from `main` (GitHub Flow)
+- [ ] Target branch is `main`
 - [ ] Commit message follows the repo convention (`type(scope): subject`)
 - [ ] PR title / description note user-facing impact + migration if BREAKING (release notes are auto-generated from PR list)
 - [ ] No secrets / internal URLs / personal data in the diff

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   # npm 依赖周更, minor / patch 合一个 PR 减刷屏; major 单独 PR 留出 review 空间。
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -22,7 +22,7 @@ updates:
   # GitHub Actions 工作流也跟着更新, 同样 minor / patch 合一个 PR。
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
-# 同 PR 推 N 次只跑最后一次, 省 GitHub Actions minutes。main / develop push 同样适用。
+# 同 PR 推 N 次只跑最后一次，省 GitHub Actions minutes。main push 同样适用。
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ omk 是 LLM 评测框架。所有改动都要优先保护测量可比性。
 
 ## 硬规则
 
-- 遵守 `CONTRIBUTING.md` 的 Gitflow：普通 feature / fix / docs / chore PR 进 `develop`；release / hotfix 走专门路径。
-- 不要直接在 `main` 或 `develop` 上提交。
+- 遵守 `CONTRIBUTING.md` 的 GitHub Flow：`main` 是唯一长期分支；feature / fix / docs / chore 从 `main` 切短分支，通过 PR 回 `main`；release / hotfix 也通过短分支 PR 回 `main`，再由 tag 触发发版。
+- 不要直接在 `main` 上提交；不要再把新工作提交到 `develop`。
 - commit 格式：`type(scope): 中文 subject`。scope 用稳定模块名，如 `cli` / `i18n` / `judge` / `renderer` / `eval-core` / `eval-workflows` / `inputs` / `executors` / `server` / `analysis` / `authoring` / `grading` / `doctor` / `release` / `claude-md`。
 - 不要在给用户看的 URL 里硬编码 report server 端口；使用 `server.start()` 返回的实际 URL。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,23 +2,20 @@
 
 Thanks for taking the time to contribute to `oh-my-knowledge`.
 
-## Branch model — Gitflow
+## Branch model — GitHub Flow
 
-Two long-lived branches:
+One long-lived branch:
 
-- **`main`** — holds tagged, released versions only. Every commit on `main` corresponds to a published release. Never commit features directly here.
-- **`develop`** — day-to-day integration branch. New features and fixes land here. It represents the "next release in progress".
+- **`main`** — the single integration and release branch. All production-ready work lands here through PRs. Do not commit directly to `main`.
 
-Supporting short-lived branches:
+All work happens on short-lived topic branches cut from `main`:
 
 | Branch prefix | Cut from | Merges back to | Purpose |
 |---|---|---|---|
-| `feat/<desc>` | `develop` | `develop` | new feature |
-| `fix/<desc>` | `develop` | `develop` | bug fix on an in-progress feature or an already-released one that can wait for the next release |
-| `docs/<desc>` | `develop` | `develop` | docs only |
-| `chore/<desc>` | `develop` | `develop` | build, tooling, dependency bumps |
-| `release/<x.y.z>` | `develop` | `main` (then ff `develop` to `main`) | stabilization before a release (version bump, last-mile fixes only) |
-| `hotfix/<x.y.z>` | `main` | `main` (then ff `develop` to `main`) | critical fix against a released version |
+| `feat/<desc>` | `main` | `main` | new feature |
+| `fix/<desc>` | `main` | `main` | bug fix, including urgent production fixes |
+| `docs/<desc>` | `main` | `main` | docs only |
+| `chore/<desc>` | `main` | `main` | build, tooling, dependency bumps, release version bumps |
 
 Delete the topic branch after its PR is merged.
 
@@ -27,10 +24,11 @@ Delete the topic branch after its PR is merged.
 ### Everyday feature / fix
 
 ```bash
-# sync develop first
-git checkout develop && git pull
+# sync main first
+git checkout main
+git pull --ff-only
 
-# cut a topic branch from develop
+# cut a topic branch from main
 git checkout -b feat/my-feature
 
 # build / test / lint
@@ -39,73 +37,63 @@ yarn build
 yarn test      # must pass
 yarn lint      # must pass
 
-git commit -m "feat: short imperative summary"
+git commit -m "feat(cli): 中文 subject"
 git push -u origin feat/my-feature
 
-# open a PR against **develop** (not main)
+# open a PR against **main**
 ```
 
 ### Releasing a new version
 
 ```bash
-# from develop
-git checkout -b release/0.19.0 develop
-
-# bump version in package.json, final polish commits
-
-# merge into main and tag
+# cut a release version-bump branch from main
 git checkout main
-git merge --no-ff release/0.19.0
-git tag -a v0.19.0 -m "Release v0.19.0"
+git pull --ff-only
+git checkout -b chore/release-0.28.0
 
-# Push commits and the tag SEPARATELY.
+# bump version in package.json, final polish commits, then verify
+yarn lint
+yarn build
+yarn test
+
+# commit and open a PR against main
+git commit -m "chore(release): 发布 0.28.0"
+git push -u origin chore/release-0.28.0
+
+# after the PR is merged, tag the merge commit on main
+git checkout main
+git pull --ff-only
+git tag -a v0.28.0 -m "Release v0.28.0"
+
+# Push the tag as its own command.
 # `git push origin main --tags` is an atomic push — GitHub treats it as one
 # event and only triggers workflows watching `branches: [main]`, so the
 # `tags: ['v*']` trigger in publish.yml never fires and npm publish is
 # skipped. Pushing the tag in its own command produces a distinct push
 # event that fires the tag workflow.
-git push origin main
-git push origin v0.19.0
-
-# Sync develop to main with a fast-forward — NOT another merge of the release
-# branch. Doing `git merge --no-ff release/0.19.0` here creates a sibling
-# merge commit that lives only on develop, so main's release commit never
-# enters develop's ancestry and the two branches drift apart with every
-# release. ff-only keeps develop a strict superset of main.
-git checkout develop
-git merge --ff-only origin/main
-git push origin develop
-
-# delete the release branch
-git branch -d release/0.19.0
-git push origin --delete release/0.19.0
+git push origin v0.28.0
 ```
 
 ### Hotfix against a released version
 
 ```bash
-# cut from main (the last released state)
-git checkout -b hotfix/0.18.1 main
+# cut from main
+git checkout main
+git pull --ff-only
+git checkout -b fix/critical-bug
 
-# make the fix, bump version
+# make the fix, bump patch version, verify, then open a PR against main
+yarn lint
+yarn build
+yarn test
+git commit -m "fix(cli): 中文 subject"
+git push -u origin fix/critical-bug
 
-# merge into main + tag
-git checkout main && git merge --no-ff hotfix/0.18.1
-git tag -a v0.18.1 -m "Hotfix v0.18.1"
-
-# Push commits and tag separately — see the "Releasing a new version"
-# section above for why `git push origin main --tags` skips publish.yml.
-git push origin main
-git push origin v0.18.1
-
-# Sync develop to main with a fast-forward (same reasoning as the
-# release flow — avoid creating a sibling merge that strands the hotfix
-# commit only on main).
-git checkout develop && git merge --ff-only origin/main
-git push origin develop
-
-git branch -d hotfix/0.18.1
-git push origin --delete hotfix/0.18.1
+# after the PR is merged, tag the merge commit on main and push the tag
+git checkout main
+git pull --ff-only
+git tag -a v0.28.1 -m "Release v0.28.1"
+git push origin v0.28.1
 ```
 
 ## Release notes
@@ -131,19 +119,19 @@ This keeps users who only read release notes (not individual PR descriptions) fr
 
 ## Commit messages
 
-Short imperative lines. Chinese or English both fine — match the tone of surrounding history. Prefix with a scope when it helps:
+Use Conventional Commits with a stable scope and a Chinese subject:
 
 ```
-feat(bench): add --repeat to --each mode
-fix(each): unswallow --repeat in --each branch
-docs: clarify --control / --treatment usage
+feat(cli): 新增工作流命令
+fix(eval-core): 修复事实检查误报
+docs(readme): 补充评测用例说明
 ```
 
 ## Tests
 
 - `yarn test` runs the full vitest suite
 - Add tests for behaviour you change; a regression test for bug fixes is strongly preferred
-- CI runs the same commands on Node 20 and Node 22 across both `main` and `develop` — all must pass before merge
+- CI runs the same commands on Node 22 and Node 24 for `main` pushes and PRs targeting `main` — all must pass before merge
 
 ## Style
 


### PR DESCRIPTION
## 为什么切换到 GitHub Flow

- 降低维护成本：OMK 当前是小型开源项目，没有独立 staging / production 环境，也没有多版本长期维护需求。`develop` 在这里主要增加同步、合并和发版步骤，并没有提供对应收益。
- 缩短反馈链路：所有改动都通过短分支 PR 直接回 `main`，CI 对最终目标分支负责，减少「先合 develop，发版时再搬到 main」带来的二次验证和分支漂移风险。
- 更符合外部贡献者心智：开源项目贡献者通常默认向 `main` 提 PR。GitHub Flow 能减少选错 base branch、Dependabot 打到旧集成分支、release 分支滞留等流程摩擦。
- 让发版更可审计：版本号 bump 仍然走 PR；PR 合入 `main` 后只对 merge commit 打 tag，由 tag 触发 npm publish 和 GitHub Release。安全边界从「release 分支」转为「PR review + CI + tag」。
- 保留必要约束：仍然禁止直接提交 `main`；所有 feature / fix / docs / chore 都必须短分支、PR、CI 通过后合并。

## 用户影响

- 将项目分支模型从 Gitflow 切换为 GitHub Flow：`main` 成为唯一长期分支。
- feature / fix / docs / chore 都从 `main` 切短分支，通过 PR 回 `main`。
- release / hotfix 不再走 `develop` / `release/*` 专门流程，改为短分支 PR 合入 `main` 后打 tag 发版。

## 迁移说明

- Dependabot 改为向 `main` 提 PR。
- CI 只监听 `main` push 和目标为 `main` 的 PR。
- `develop` 分支不再作为新工作的目标分支；远端分支清理可作为后续仓库维护动作单独处理。

## 验证

- `yarn lint`
- `yarn build`
- `yarn test`
- `git diff --check`