### PR TITLE
chore(release): 收紧发版入口校验

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,36 @@ jobs:
     - name: Install dependencies
       run: yarn install --frozen-lockfile
 
+    - name: Validate release tag
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [[ "${GITHUB_ACTOR}" != "lizhiyao" ]]; then
+          echo "::error::Only lizhiyao is allowed to trigger an npm release."
+          exit 1
+        fi
+
+        tag_type="$(git cat-file -t "${GITHUB_REF_NAME}")"
+        if [[ "${tag_type}" != "tag" ]]; then
+          echo "::error::Release tag ${GITHUB_REF_NAME} must be an annotated tag."
+          exit 1
+        fi
+
+        package_version="$(node -p "require('./package.json').version")"
+        expected_tag="v${package_version}"
+        if [[ "${GITHUB_REF_NAME}" != "${expected_tag}" ]]; then
+          echo "::error::Release tag ${GITHUB_REF_NAME} does not match package.json version ${package_version}."
+          exit 1
+        fi
+
+        git fetch --no-tags origin main
+        tag_commit="$(git rev-list -n 1 "${GITHUB_REF_NAME}")"
+        if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
+          echo "::error::Release tag ${GITHUB_REF_NAME} must point to a commit reachable from origin/main."
+          exit 1
+        fi
+
     - name: Run Lint
       run: yarn run lint
 


### PR DESCRIPTION
## 用户影响

- `v*` tag 触发 npm publish 前先做发版入口校验，避免误 tag 或非授权触发直接发布。
- 发版 tag 必须由 `lizhiyao` 触发、必须是 annotated tag、必须匹配 `package.json` version、且 tag commit 必须可从 `origin/main` 追溯。

## 迁移说明

- 后续发版继续使用 `git tag -a vX.Y.Z -m "Release vX.Y.Z"`。
- 不再接受 lightweight release tag。

## 验证

- `node -e "const fs=require('fs'); const yaml=require('js-yaml'); yaml.load(fs.readFileSync('.github/workflows/publish.yml','utf8')); console.log('publish.yml ok')"`
- `git diff --check`
- `yarn lint`
- `yarn build`
- `yarn test`