### PR TITLE
chore(release): 发布 0.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Purpose

准备发布 `oh-my-knowledge@0.28.0`。

本次 minor release 主要承接已合入 `main` 的 doctor LLM 健康度审计能力：`omk doctor` 默认进入 LLM 健康度审计，支持 7 个内置维度、可扩展维度、HTML 报告，以及 `--static-only` 离线静态检查模式。

## Changes

- 将 `package.json` 版本号从 `0.27.0` bump 到 `0.28.0`。

## Testing

- `yarn lint` passes
- `yarn build` passes
- `yarn test` passes（89 files / 1131 tests）

补充：本地第一次全量测试遇到一次 `test/executors/runtime-fingerprint.test.ts` 偶发失败，单测单独重跑通过，随后全量 `yarn test` 重跑通过；以 PR CI 的 Node 22 / 24 required checks 作为最终发布门禁。

## Release

PR 合并后，在最新 `main` merge commit 上打 annotated tag：

```bash
git tag -a v0.28.0 -m "Release v0.28.0"
git push origin v0.28.0
```

`publish.yml` 会校验 tag actor、annotated tag、tag/version 一致性和 main 可达性，然后发布 npm 并生成 GitHub Release。
