### PR TITLE
fix(release): 修复 annotated tag 校验

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,12 @@ jobs:
           exit 1
         fi
 
-        tag_type="$(git cat-file -t "${GITHUB_REF_NAME}")"
+        # actions/checkout checks out the tag target commit for tag-triggered runs.
+        # Fetch the tag ref explicitly so annotated-tag validation checks the tag
+        # object instead of the dereferenced commit.
+        git fetch --force --no-tags origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
+        tag_ref="refs/tags/${GITHUB_REF_NAME}"
+        tag_type="$(git cat-file -t "${tag_ref}")"
         if [[ "${tag_type}" != "tag" ]]; then
           echo "::error::Release tag ${GITHUB_REF_NAME} must be an annotated tag."
           exit 1
@@ -53,7 +58,7 @@ jobs:
         fi
 
         git fetch --no-tags origin main
-        tag_commit="$(git rev-list -n 1 "${GITHUB_REF_NAME}")"
+        tag_commit="$(git rev-list -n 1 "${tag_ref}")"
         if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
           echo "::error::Release tag ${GITHUB_REF_NAME} must point to a commit reachable from origin/main."
           exit 1


### PR DESCRIPTION
## Purpose

修复 `v0.28.0` 发布 workflow 在 annotated tag 校验处误判失败的问题。

本地和 GitHub API 都确认 `v0.28.0` 是 annotated tag，但 tag-triggered workflow 里 `actions/checkout` 默认检出的是 tag 指向的 commit。原校验直接执行 `git cat-file -t "$GITHUB_REF_NAME"`，在 runner 本地看到的是 dereferenced commit，因此误报 “must be an annotated tag”。

## Changes

- 在 `Validate release tag` 步骤中显式 fetch `refs/tags/$GITHUB_REF_NAME`。
- 后续 annotated tag 类型检查和 main 可达性检查都使用 `refs/tags/$GITHUB_REF_NAME`。

## Testing

- `git diff --check` passes
- 该改动只影响 GitHub Actions tag workflow；PR CI 会继续跑 Node 22 / 24 required checks。

## Release follow-up

本 PR 合并后，需要删除失败的远端 `v0.28.0` tag，重新在最新 `main` 上创建 annotated tag 并单独推送，以重新触发 `publish.yml`。
