### PR TITLE
chore(release): 发布 0.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

发布 0.29.0。

## 包含内容

- **#92 feat(renderer)**：报告页测量学诚实重构 — verdict hero 结构、综合分构造效度公开（cards + modal + docs/zh/scoring.md）、方法学审计折叠、能力卡片 i18n
- **#93 docs(zh)**：业内通用 ML / 测量学术语中英文对照表 docs/zh/glossary.md
- **#89 feat(observe)**：本地优先的 observe inbox 最小闭环 — 三阶段框架 observe 阶段第一步落地，按严重度加权打分输出 hard_miss / exploratory_miss / hedging 信号清单

## 测量学影响

无 BREAKING-COMPARABILITY。综合分算法未变，#92 是把既有局限性暴露到 UI / docs；#89 inbox 是诊断信号、不参与评分；#93 纯文档。

## Test plan

- [x] yarn lint && yarn build && yarn test (1174/1174)
- [x] CI Node 22 / Node 24 待跑