### PR TITLE
chore(release): 发布 0.30.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ omk studio --no-open
 
 Starts the local knowledge workbench for browsing reports and observation analyses. Verdict, sample diffs, regressions, saturation curves, and per-sample drill-downs all live in the studio UI — there is no CLI export / analysis subcommand. For CI gates, use `omk eval`'s exit code (0 on `PROGRESS`, non-zero otherwise) or `jq` over the report JSON.
 
-Visit `/observations/inbox` for the observe inbox dashboard: per-skill rollup view, reviewer action list, observability funnel, and a per-observation detail panel with the event triplet (surrounding messages).
+Studio is skill-centric — the list page (`/`) shows skill cards with health band / 0-100 reference score / open-issue count / trend; the detail page (`/skills/<name>`) puts a prioritized issue checklist on the left (skill issues / sample issues / tool advisories), and a chart.js health trend plus three compact stage cards (doctor / eval / observe) on the right, with modals for deeper drill-down. The legacy run list moved to `/runs`. Visit `/observations/inbox` for the observe inbox dashboard: per-skill rollup view, reviewer action list, observability funnel, and a per-observation detail panel with the event triplet (surrounding messages).
 
 ## Executors
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -475,7 +475,7 @@ omk observe show <inbox_id>
 + `messageWindow`：前 3 条 / 触发点 / 后 3 条 message 上下文 + `resolutionAfter`（后续是否解决）
 + `evidence.{messageIndex,messageUuid,toolUseId}`：可反向回到原始 jsonl 的锚点
 
-支持 trace 格式：Claude Code session JSONL（`.jsonl`）+ markdown 对话日志（`.log`）。
+支持 trace 格式：Claude Code session JSONL（`.jsonl`）、OpenClaw session JSONL（`.jsonl`）、markdown 对话日志（`.log`）。
 
 ### `omk evolve`
 
@@ -508,7 +508,7 @@ omk studio --no-open
 
 启动本地知识工作台浏览报告。verdict、样本回退、跨样本 diff、饱和曲线、单样本 drill-down 全部在 studio UI 里 —— omk 不提供 CLI 导出 / 分析子命令。CI gate 用 `omk eval` 的 exit code（PROGRESS 退 0、其他非 0），需要文字摘要自己 `jq` report JSON。
 
-访问 `/observations/inbox` 查看 observe inbox 看板：按 skill 资产视图（rollup）+ reviewer 待办建议 + 当前可观测漏斗 + 单 observation 详情面板（含事件三元组）。
+Studio 是 skill-centric 信息架构 — 列表页（`/`）按 skill 卡片展示健康等级 / 0-100 参考分 / 待优化数 / 趋势，详情页（`/skills/<name>`）左栏列关键问题清单（skill 优化 / 用例优化 / 工具反馈三档），右栏画 chart.js 健康趋势 + 三个紧凑阶段卡（doctor / eval / observe），细节走 modal。旧的 run 列表挪到 `/runs`。访问 `/observations/inbox` 查看 observe inbox 看板：按 skill 资产视图（rollup）+ reviewer 待办建议 + 当前可观测漏斗 + 单 observation 详情面板（含事件三元组）。
 
 ## 执行器
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",
   "bin": {

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -16,7 +16,7 @@ export interface VariantResult {
   /** Diagnostic 自身花费(USD)。仅在 failed-assertion 触发 diagnostic 且 executor 报告了 cost 时有值。
    *  Diagnostic 一般跑在 judge executor 上(claude:haiku 标配),所以 cost-reported 语义随
    *  `judgeCostReportedByExecutor`,不再单独引一个 flag。
-   *  v0.32 新增,旧报告无此字段 — 老 costUSD 仍等于 execCostUSD + judgeCostUSD,新 costUSD
+   *  v0.30 新增,旧报告无此字段 — 老 costUSD 仍等于 execCostUSD + judgeCostUSD,新 costUSD
    *  含 diagnostic,跨版本汇总时按字段是否存在判断。 */
   diagnosticCostUSD?: number;
   /** sample 一行的真实总花费 = execCostUSD + judgeCostUSD + (diagnosticCostUSD ?? 0)。
@@ -95,7 +95,7 @@ export interface VariantSummary {
   avgTotalTokens: number;
   /** sum(ok-sample 的 costUSD)。等于 totalExecCostUSD + totalJudgeCostUSD + totalDiagnosticCostUSD。
    *  注意:仅含执行成功且未被 per-sample budget 标 overrun 的 sample,跟 meta.totalCostUSD(全量
-   *  累计,含失败 sample)语义不同 — 那是历史 ok-filter 行为,跟 v0.32 的 diagnostic 引入无关。 */
+   *  累计,含失败 sample)语义不同 — 那是历史 ok-filter 行为,跟 v0.30 的 diagnostic 引入无关。 */
   totalCostUSD: number;
   totalExecCostUSD: number;
   totalJudgeCostUSD: number;


### PR DESCRIPTION
## Summary

发布 0.30.0，bundle 3 个主线 feat + 2 个 deps bump。

- **#95** `feat: skill 健康度框架 + Studio v2(skill-centric) + sandbox mock 评测 (BREAKING-COMPARABILITY)`
- **#100** `feat(observability): problem-patterns 问题模式检测模块`（含 experience / skill-chain / OpenClaw trace 来源）
- **#101** `feat(doctor,renderer): doctor prompt 调优 + Studio v7 详情页重构 + 列表页卡片化`
- **#97 / #98** 依赖 bump

## 本 PR 附带修正

- 修 `src/types/report.ts` 注释两处 `v0.32` → `v0.30`（diagnosticCostUSD / totalDiagnosticCostUSD 实际是 v0.30 引入）
- README.md / README.zh.md 的 `omk studio` 段补 skill-centric 信息架构说明（列表卡片 / 详情页左右两栏 / 旧 run 列表挪到 `/runs`）
- README.zh.md 的 supported trace formats 加 OpenClaw，跟 README.md 对齐

## 发布后必做：Release notes 顶部 hoist 不可比性说明

### Judge prompt 升级（BREAKING-COMPARABILITY）

判官 prompt 版本 \`v2-cot / v3-cot-length → v3-cot-toolargs / v4-cot-len-args\`，hash bump：

- \`OFF: fdc81b19c721 → 9c441e9b6a73\`
- \`ON:  629bf3b8c41d → bd1d97c86a5f\`

跨 v0.29 / v0.30 的 v1 vs v2 分数不直接可比。wrapper-style skill（mcporter / git CLI / code-host CLI 等）的判分从「看不见 Bash 命令里的子调用 → 错误结论『只调了 Bash，没用指定工具』」修复为「能识别 Bash 命令里的真实语义调用」。必要时基线重跑。

### Cost schema 升级

\`VariantResult.costUSD\` 现在 = \`execCostUSD + judgeCostUSD + (diagnosticCostUSD ?? 0)\`。

- 单 sample 成本数字会上涨（多了 diagnostic 一项）。
- 如需保留 v0.29 语义，跑 \`--no-diagnostic\` 关掉诊断 LLM 调用。
- 跨版本汇总按字段是否存在判断（旧报告无 \`diagnosticCostUSD\` 字段）。

## Test plan

- [x] \`yarn lint && yarn typecheck && yarn build && yarn test\` 全绿（1396 pass / 105 test files）
- [x] judge prompt hash 跟冻结值匹配（live + frozen 双向验证）
- [x] schema 改动全部 optional，旧报告向后兼容
- [x] 内部品牌泄漏扫描通过

## 发布步骤（merge 之后）

\`\`\`bash
git checkout main && git pull --ff-only
git tag -a v0.30.0 -m "Release v0.30.0"
git push origin v0.30.0   # 单独 push 触发 publish.yml
\`\`\`

publish.yml 跑完后编辑 GitHub Release，把上面两条不可比性说明 hoist 到顶部。

🤖 Generated with [Claude Code](https://claude.com/claude-code)