### PR TITLE
feat(diagnosis): 引入 Diagnosis 统一诊断模型，observe 一支接通

### DIFF
--- a/docs/diagnosis-occurrence-mapping.md
+++ b/docs/diagnosis-occurrence-mapping.md
@@ -1,0 +1,906 @@
+# Diagnosis / Occurrence Mapping
+
+This document aligns the architecture direction for GitHub issue #103.
+
+It is intentionally a design mapping first. It does not change the current
+runtime code. The target structures below refer to the post-observe-inbox
+architecture where `skill-insights`, `skill-chain`, `problem-patterns`,
+reviewer reports, and soft-standard extraction all exist.
+
+## Problem
+
+Studio and observation currently express skill diagnostics through different
+models.
+
+```text
+studio / skill detail
+└─ Insight[]
+   ├─ audience
+   ├─ severity
+   ├─ evidence
+   ├─ recommendations
+   └─ patch
+
+observe inbox
+├─ ObservationSkillChain
+├─ SkillChainAdvisory
+├─ ExperienceProblemPattern
+├─ ExperienceReviewerReportFinding
+└─ SkillDerivedStandard
+```
+
+Both sides answer "what is wrong with this skill", but they do not share a
+diagnostic abstraction. The goal is not to make the two pages look the same.
+The goal is to define a shared diagnostic layer underneath them.
+
+## Non Goals
+
+```text
+not doing
+├─ moving observe inbox UI into studio
+├─ making studio show every session trace
+├─ making observation adopt the Insight display format
+├─ replacing raw reports with Diagnosis
+└─ doing a broad refactor before the mapping is validated
+```
+
+## Current Models
+
+### Insight
+
+`Insight` is a productized repair diagnosis for studio / skill detail.
+
+```text
+Insight
+├─ id
+├─ category
+├─ audience: skill-author | sample-author | omk-maintainer
+├─ severity: high | medium | low
+├─ title / description
+├─ affectedCount
+├─ evidence[]
+├─ recommendations[]
+├─ patch?
+└─ stageRefs?
+```
+
+Its inputs are doctor, eval, and observe snapshots. Its output is already close
+to a user-facing diagnosis, but it mixes the aggregate diagnosis with the source
+occurrence that produced it.
+
+### ObservationSkillChain / SkillChainAdvisory
+
+`ObservationSkillChain` is an evidence-oriented definition chain.
+
+```text
+ObservationSkillChain
+├─ definition
+│  ├─ found
+│  ├─ path
+│  └─ content
+├─ healthCheck
+│  ├─ hardRules declared / valid / errors / advisoryCode
+│  └─ workflows declared / valid / errors / advisoryCode
+└─ runtime
+   ├─ hardRules: ObservationRuntimeCheck[]
+   └─ workflowNodes: ObservationRuntimeCheck[]
+```
+
+`SkillChainAdvisory` is currently a small UI advisory dictionary:
+
+```text
+hardrules_not_declared
+workflows_not_declared
+skill_md_not_found
+```
+
+### ExperienceProblemPattern
+
+`ExperienceProblemPattern` clusters repeated observe signals.
+
+```text
+ExperienceProblemPattern
+├─ id
+├─ bucket
+├─ patternKey
+├─ count
+├─ sessionCount
+├─ recentSessionIds
+├─ signalTypes
+├─ evidenceRefs
+└─ lastSeen
+```
+
+It is already aggregated within observation, but it has no explicit audience,
+severity, or action model.
+
+### ExperienceReviewerReportFinding
+
+Reviewer findings are session-level deterministic findings.
+
+```text
+ExperienceReviewerReportFinding
+├─ id
+├─ judgmentId
+├─ source: deterministic_rule | llm_soft | manual
+├─ level: attention | possible_false_positive | note
+├─ title / body
+├─ ruleSource
+├─ ruleVersion
+└─ evidenceRefs
+```
+
+They should not become one studio-level diagnosis per finding. They are
+source occurrences that may aggregate into a diagnosis.
+
+### SkillDerivedStandard
+
+Soft standards are candidate standards extracted from SKILL.md and runtime
+summary.
+
+```text
+SkillDerivedStandard
+├─ id
+├─ kind: hard_rule_candidate | workflow_candidate
+├─ status: pending_review | author_confirmed | rejected | stale
+├─ title / body
+├─ source: llm_soft_standard
+├─ confidence
+└─ evidence[]
+```
+
+They are closer to a diagnosis candidate than a runtime problem: "this skill is
+missing a standard declaration candidate".
+
+## Target Abstraction
+
+The shared layer has two levels.
+
+```text
+Diagnosis
+└─ aggregate problem or candidate for a skill
+
+DiagnosisOccurrence
+└─ one source detecting or supporting that diagnosis
+```
+
+This split is required because the same issue can appear in doctor, eval, and
+observe. Studio needs one aggregate row. Observation needs exact source
+evidence.
+
+### Diagnosis
+
+First-version fields should be trimmed and explicit.
+
+```text
+Diagnosis
+├─ id
+├─ stableKey
+├─ skillName
+├─ type
+├─ signal
+├─ title
+├─ summary?
+├─ severity
+├─ audience
+├─ lifecycle
+├─ scope
+├─ occurrences[]
+├─ occurrenceCount
+├─ evidenceSummary?
+├─ recommendation?
+├─ patch?
+└─ command?
+```
+
+Required fields:
+
+```text
+required
+├─ stableKey
+├─ skillName
+├─ type
+├─ signal
+├─ title
+├─ severity
+├─ audience
+├─ lifecycle
+├─ scope
+└─ occurrences
+```
+
+Optional fields are intentionally optional. They should not block producers
+that only know facts but not repair actions.
+
+### DiagnosisOccurrence
+
+```text
+DiagnosisOccurrence
+├─ id
+├─ diagnosisStableKey
+├─ source
+├─ sourceId
+├─ sourceKind
+├─ timestamp?
+├─ severity?
+├─ evidenceRefs[]
+├─ rawRef?
+├─ producer
+└─ payload?
+```
+
+Occurrences are append-only source evidence. They should not own lifecycle.
+Lifecycle belongs to the aggregate diagnosis.
+
+## Field Definitions
+
+### type
+
+`type` is the broad diagnostic family. It replaces the ambiguous
+`category / kind / signal` triple.
+
+```text
+type
+├─ definition_gap
+├─ runtime_issue
+├─ user_feedback_pattern
+├─ eval_failure
+├─ sample_design_issue
+├─ doctor_gap
+├─ standard_candidate
+└─ maintenance_issue
+```
+
+### signal
+
+`signal` is the concrete trigger.
+
+```text
+examples
+├─ hardrules_not_declared
+├─ workflows_not_declared
+├─ skill_md_not_found
+├─ runtime_hardrule_attention
+├─ runtime_workflow_attention
+├─ user_correction
+├─ negative_feedback
+├─ user_interruption
+├─ tool_failure
+├─ final_delivery_absent
+├─ environment_blocked_mocks
+├─ failure_mode_skill
+└─ soft_workflow_candidate
+```
+
+### scope
+
+Scope should not be a flat six-way enum. Rule and workflow are not peers of
+skill; they belong under a definition scope.
+
+```text
+scope
+├─ primary: skill | definition | session | sample
+└─ refs
+   ├─ skillName
+   ├─ sessionId?
+   ├─ invocationId?
+   ├─ sampleId?
+   ├─ ruleId?
+   ├─ workflowId?
+   └─ sourceTrace?
+```
+
+### severity
+
+Diagnosis severity should be normalized across sources.
+
+```text
+severity
+├─ high
+├─ medium
+├─ low
+└─ info
+```
+
+Mapping guidance:
+
+```text
+Insight.high                    -> high
+Insight.medium                  -> medium
+Insight.low                     -> low
+runtime attention               -> medium by default
+runtime manual_review           -> low by default
+reviewer finding attention      -> medium by default
+reviewer possible_false_positive -> low
+reviewer note                   -> info
+problem pattern sessionCount>=3 -> high
+problem pattern sessionCount>=2 -> medium
+problem pattern sessionCount=1  -> low
+soft standard pending_review    -> low
+soft standard author_confirmed  -> info or medium if missing frontmatter remains
+```
+
+### audience
+
+```text
+audience
+├─ skill-author
+├─ sample-author
+├─ omk-maintainer
+└─ reviewer
+```
+
+Default mappings:
+
+```text
+definition_gap                  -> skill-author
+runtime_issue                   -> skill-author
+user_feedback_pattern           -> skill-author
+eval environment blocked mocks  -> sample-author
+eval coverage gap               -> sample-author
+doctor blindspot                -> omk-maintainer
+manual review only              -> reviewer
+```
+
+### lifecycle
+
+```text
+lifecycle
+├─ detected
+├─ candidate
+├─ confirmed
+├─ rejected
+├─ resolved
+└─ stale
+```
+
+Lifecycle is attached to `stableKey`, not to source occurrence.
+
+```text
+rules
+├─ new source occurrence on same stableKey inherits the current lifecycle
+├─ rejected + new later occurrence should be shown as "re-detected"
+├─ resolved + new later occurrence should reopen to detected unless manually pinned
+└─ source occurrences remain immutable
+```
+
+## Stable Key
+
+`stableKey` is the hardest part of the model. It decides whether multiple
+sources refer to the same diagnosis.
+
+Principle:
+
+```text
+DiagnosisOccurrence is source-local.
+Diagnosis is cross-source aggregate.
+```
+
+Stable key format:
+
+```text
+skill:<skillName>
+|type:<type>
+|signal:<signal>
+|target:<targetKey>
+```
+
+Target key examples:
+
+```text
+hardrules_not_declared
+└─ target: definition:hardRules
+
+workflows_not_declared
+└─ target: definition:workflows
+
+runtime_hardrule_attention
+└─ target: rule:<ruleId>
+
+runtime_workflow_attention
+└─ target: workflow:<workflowId>
+
+user_correction output_format
+└─ target: pattern:output_format
+
+final_delivery_absent
+└─ target: session-pattern:final_delivery
+
+environment_blocked_mocks
+└─ target: eval:mock-coverage
+```
+
+Do not over-merge in version 1. Only merge sources into the same diagnosis
+when the target key is explicit and stable.
+
+## Mapping Table
+
+### Insight -> Diagnosis / Occurrence
+
+| Source field | Diagnosis field | Occurrence field | Notes |
+| --- | --- | --- | --- |
+| `Insight.id` | `signal` fallback, `stableKey` target | `sourceId` | Existing insights are already aggregate. |
+| `category` | `type` + `signal` | `sourceKind` | Needs explicit mapping table. |
+| `audience` | `audience` | - | Direct mapping. |
+| `severity` | `severity` | `severity` | Direct mapping. |
+| `title` | `title` | - | Direct mapping. |
+| `description` | `summary` | - | Direct mapping. |
+| `affectedCount` | `occurrenceCount` or `evidenceSummary` | - | Keep exact meaning source-specific. |
+| `evidence[]` | `evidenceSummary` | `payload` | Insight evidence is not always trace-ref addressable. |
+| `recommendations[]` | `recommendation` | - | Keep first/highest-priority as primary action. |
+| `patch` | `patch` | - | Direct mapping if present. |
+| `stageRefs` | `scope.refs` | `rawRef` | sample/rule refs become source refs. |
+
+Granularity:
+
+```text
+one Insight
+└─ one Diagnosis + one Insight occurrence
+```
+
+### SkillChainAdvisory -> Diagnosis / Occurrence
+
+| Source | Diagnosis | Occurrence | Notes |
+| --- | --- | --- | --- |
+| `hardrules_not_declared` | `definition_gap / hardrules_not_declared` | source `skill_chain` | target `definition:hardRules` |
+| `workflows_not_declared` | `definition_gap / workflows_not_declared` | source `skill_chain` | target `definition:workflows` |
+| `skill_md_not_found` | `definition_gap / skill_md_not_found` | source `skill_chain` | target `definition:skill_md` |
+| `message` | `summary` | `payload.message` | |
+| `exampleYaml` | `patch` or `recommendation` | `payload.exampleYaml` | Patch target is SKILL.md frontmatter. |
+| `commandTemplate` | `command` | - | |
+
+Granularity:
+
+```text
+one advisory code per skill
+└─ one Diagnosis
+```
+
+### ObservationRuntimeCheck -> Diagnosis / Occurrence
+
+| Source field | Diagnosis field | Occurrence field | Notes |
+| --- | --- | --- | --- |
+| `kind=hardRule` | `type=runtime_issue` | `sourceKind=runtime_check` | Only `attention` and `manual_review` produce diagnostics. |
+| `kind=workflowNode` | `type=runtime_issue` | `sourceKind=runtime_check` | Only `attention` and `manual_review` produce diagnostics. |
+| `id` | `scope.refs.ruleId/workflowId` + targetKey | `sourceId` | |
+| `title` | `title` | `payload.title` | |
+| `expectation` | `summary` | `payload.expectation` | |
+| `status` | `severity` | `severity` | passed does not create diagnosis. |
+| `reason` | `summary` | `payload.reason` | |
+| `evidenceSnippets` | `evidenceSummary` | `payload.evidenceSnippets` | Snippets are not enough; prefer evidenceRefs when available. |
+
+Granularity:
+
+```text
+runtime check attention/manual_review
+└─ one occurrence grouped by skill + check kind + check id
+```
+
+### ExperienceProblemPattern -> Diagnosis / Occurrence
+
+| Source field | Diagnosis field | Occurrence field | Notes |
+| --- | --- | --- | --- |
+| `bucket` | `type` target family | `payload.bucket` | `output_format`, `workflow_mismatch`, etc. |
+| `signalTypes[]` | `signal` primary or compound | `payload.signalTypes` | Use first/highest priority signal as primary. |
+| `patternKey` | `stableKey.target` | `sourceId` | Already designed for grouping. |
+| `count` | `occurrenceCount` | `payload.count` | |
+| `sessionCount` | severity input | `payload.sessionCount` | |
+| `recentSessionIds` | `scope.refs.sessionId[]` | `payload.recentSessionIds` | |
+| `evidenceRefs` | evidence refs | `evidenceRefs` | Direct mapping. |
+| `lastSeen` | - | `timestamp` | |
+
+Granularity:
+
+```text
+one problem pattern per skill + bucket + patternKey
+└─ one Diagnosis
+   └─ occurrence contains recent evidence refs
+```
+
+### ExperienceReviewerReportFinding -> Diagnosis / Occurrence
+
+Reviewer findings must not map one-to-one to studio diagnoses.
+
+| Source field | Diagnosis field | Occurrence field | Notes |
+| --- | --- | --- | --- |
+| `id` | - | `sourceId` | Source-local occurrence id. |
+| `judgmentId` | lifecycle review target | `payload.judgmentId` | Manual review may update aggregate lifecycle. |
+| `source` | provenance | `producer` | deterministic_rule / llm_soft / manual |
+| `level` | severity input | `severity` | |
+| `title` | `title` fallback | `payload.title` | Aggregate title should be ruleSource-based. |
+| `body` | `summary` fallback | `payload.body` | |
+| `ruleSource` | `signal` | `sourceKind` | Primary grouping key. |
+| `ruleVersion` | provenance | `payload.ruleVersion` | |
+| `evidenceRefs` | evidence refs | `evidenceRefs` | Direct mapping. |
+
+Granularity:
+
+```text
+one reviewer finding
+└─ one DiagnosisOccurrence
+
+aggregate Diagnosis
+└─ grouped by skillName + ruleSource + targetKey
+```
+
+Grouping examples:
+
+```text
+final_delivery_absent
+└─ Diagnosis: "multiple runs lack explicit final delivery"
+   └─ occurrences: session-level findings
+
+tool_error_recovery
+└─ Diagnosis: "tool failure recovery needs review"
+   └─ occurrences: session-level findings
+
+no_priority_signal
+└─ no Diagnosis by default
+```
+
+### SkillDerivedStandard -> Diagnosis / Occurrence
+
+| Source field | Diagnosis field | Occurrence field | Notes |
+| --- | --- | --- | --- |
+| `id` | targetKey candidate id | `sourceId` | |
+| `kind` | `type=standard_candidate`, `signal` | `sourceKind` | hard rule vs workflow candidate. |
+| `status` | lifecycle | `payload.status` | pending_review -> candidate |
+| `title` | `title` | `payload.title` | |
+| `body` | `summary` | `payload.body` | |
+| `source` | producer | `producer` | llm_soft_standard |
+| `confidence` | confidence/evidenceSummary | `payload.confidence` | Not severity. |
+| `evidence[]` | evidenceSummary | `payload.evidence` | Text evidence, not trace refs. |
+| record `model/prompt` | provenance | `payload.model/promptVersion` | |
+
+Granularity:
+
+```text
+one soft standard candidate
+└─ one Diagnosis with lifecycle candidate/confirmed/rejected/stale
+```
+
+Default lifecycle decision:
+
+```text
+pending_review
+└─ Diagnosis lifecycle: candidate
+   └─ visible in review queues and definition-chain candidate UI
+
+author_confirmed
+└─ Diagnosis lifecycle: resolved
+   ├─ not shown as an active studio problem by default
+   ├─ still visible in definition-chain / standards view
+   └─ feeds ResolvedSkillStandard as confirmed_soft
+
+rejected
+└─ Diagnosis lifecycle: rejected
+   └─ hidden by default, preserved for audit and re-detection logic
+
+stale
+└─ Diagnosis lifecycle: stale
+   └─ visible only where source freshness matters
+```
+
+Rationale:
+
+```text
+confirmed soft standard is no longer an active problem.
+It is an accepted standard source.
+```
+
+If confirmed standards stay in the active Diagnosis list, studio will look like
+it is still asking the author to fix something already accepted. If confirmed
+standards disappear completely, users lose the explanation for why a soft
+standard is now active. The split is therefore:
+
+```text
+Diagnosis list
+└─ hides resolved confirmed standards by default
+
+definition-chain / standards view
+└─ shows confirmed standards as active standard sources
+```
+
+Boundary:
+
+```text
+Diagnosis
+└─ owns lifecycle, provenance, and source linkage
+
+standards view
+└─ owns the product nudge to move confirmed_soft into SKILL.md frontmatter
+```
+
+The standards view should decide whether to show metrics such as unmaterialized
+ratio or days since confirmation. That reminder mechanism is intentionally not
+specified in the Diagnosis model.
+
+## Conflict Table
+
+| Existing concept | Conflict | Diagnosis decision |
+| --- | --- | --- |
+| Insight `category` vs problem `bucket` | Similar but not identical | Both map into `type`, original value kept in occurrence payload. |
+| Insight `evidence` vs observe `evidenceRefs` | Insight evidence can be narrative only | Diagnosis supports evidence summary; occurrences keep raw payload. |
+| Runtime `passed` | Not a problem | Do not emit Diagnosis. It can remain in skill-chain view. |
+| Reviewer `note` | Often not actionable | Emit only if explicitly configured; default no studio diagnosis. |
+| Soft standard `confidence` | Confidence is not severity | Keep confidence separate from severity. |
+| Manual review state | Existing target ids differ | Lifecycle should key by diagnosis stableKey, with legacy target ids bridged during migration. |
+
+## Migration Direction
+
+Issue #103 completion scope:
+
+```text
+in scope for #103
+├─ Phase 1: mapping and schema alignment
+├─ Phase 2: observe diagnostics produce Diagnosis / Occurrence
+└─ Phase 3: studio consumes Diagnosis with source coverage
+
+follow-up after #103
+└─ Phase 4: doctor / eval become native Diagnosis producers
+```
+
+Phase 1-3 are enough to resolve the issue's core mismatch: studio no longer
+needs a separate diagnosis model for observation results, and observation does
+not need to adopt studio's display format.
+
+### Phase 1: Mapping Only
+
+```text
+do
+├─ define this mapping
+├─ validate each existing producer against Diagnosis / Occurrence
+├─ identify missing fields and conflicts
+└─ keep current implementation untouched
+
+do not
+├─ change report JSON
+├─ change studio renderer
+├─ change observe inbox renderer
+└─ change CLI output
+```
+
+Phase 1 guardrails:
+
+```text
+guardrails
+├─ do not add a runtime `types.ts` for Diagnosis yet
+├─ do not export a TypeScript schema yet
+├─ do not write producer adapters yet
+├─ do not change review-state target types yet
+├─ do not add hidden dual-run output yet
+└─ do not make studio or observe read Diagnosis yet
+```
+
+PR checklist for Phase 1:
+
+```text
+checklist
+├─ [ ] This PR changes documentation / mapping only.
+├─ [ ] This PR does not add Diagnosis runtime types.
+├─ [ ] This PR does not change report JSON.
+├─ [ ] This PR does not change CLI behavior.
+├─ [ ] This PR does not change studio or observe UI.
+└─ [ ] This PR lists unresolved mapping conflicts explicitly.
+```
+
+Reason:
+
+```text
+The mapping exercise is meant to expose schema conflicts before implementation.
+Adding code in Phase 1 turns the mapping into an unvalidated commitment.
+```
+
+This guardrail applies to a Phase 1-only mapping PR. An implementation PR that
+starts after the mapping is accepted should not claim to be mapping-only; it can
+add runtime types and adapters, but producer selection must stay aligned with
+the observe sources in this document.
+
+### Phase 2: Observe Producer First
+
+Observe is the best first migration candidate because it has the most
+conflicting shapes.
+
+```text
+observe first
+├─ skill-chain advisory -> Diagnosis
+├─ runtime attention/manual_review -> DiagnosisOccurrence
+├─ problem pattern -> Diagnosis
+├─ reviewer finding -> DiagnosisOccurrence
+└─ soft standard candidate -> Diagnosis
+```
+
+Phase 2 deliverable:
+
+```text
+observe diagnostic output
+├─ emits Diagnosis[] for aggregate observe-level issues
+├─ emits DiagnosisOccurrence[] for source-local evidence
+├─ preserves existing observe report fields during migration
+├─ does not remove skill-chain / problem-pattern / reviewer report fields
+└─ records source coverage as observe=true, doctor=false, eval=false
+```
+
+Phase 2 producer boundary:
+
+```text
+allowed observe inputs
+├─ skill-chain advisory
+├─ runtime attention/manual_review checks
+├─ problem patterns
+├─ reviewer findings
+└─ soft standard candidates
+
+not allowed in this phase
+├─ skill-health analysis reports
+├─ eval report diagnostics
+└─ doctor health diagnostics
+```
+
+Required observe mappings:
+
+```text
+required
+├─ definition gaps
+│  ├─ hardrules_not_declared
+│  ├─ workflows_not_declared
+│  └─ skill_md_not_found
+│
+├─ runtime checks
+│  ├─ hardRule attention/manual_review
+│  └─ workflowNode attention/manual_review
+│
+├─ repeated patterns
+│  ├─ user_correction
+│  ├─ negative_feedback
+│  ├─ user_interruption
+│  ├─ hard_rule
+│  ├─ user_goal_shift
+│  └─ tool_failure
+│
+├─ reviewer findings
+│  ├─ final_delivery_absent
+│  ├─ tool_error_recovery
+│  ├─ user_correction
+│  ├─ user_interruption
+│  ├─ negative_feedback
+│  └─ user_hard_rule
+│
+└─ soft standards
+   ├─ hard_rule_candidate
+   └─ workflow_candidate
+```
+
+Success criteria:
+
+```text
+success
+├─ stableKey grouping works for repeated session findings
+├─ reviewer findings do not explode studio rows
+├─ definition gaps show as skill-level diagnostics
+├─ soft standard lifecycle maps cleanly
+└─ observe inbox can still show source-specific evidence
+```
+
+### Phase 3: Studio Data Projection
+
+```text
+studio
+├─ shared projection groups Diagnosis by audience/source/severity
+├─ projection exposes active count and source coverage
+├─ Insight can later become a studio projection over Diagnosis
+└─ old Insight remains as compatibility input during dual-run
+```
+
+Phase 3 deliverable:
+
+```text
+studio data consumption
+├─ data layer returns observe-backed Diagnosis count
+├─ data layer returns rows grouped by audience / source / severity
+├─ rows keep evidence refs where available
+├─ legacy Insight remains visible during dual-run
+└─ source coverage is available wherever counts are later shown
+```
+
+Phase 3 UI boundary:
+
+```text
+current #103 data-layer implementation
+├─ may add projection helpers and API-ready fields
+├─ must not switch studio renderer yet
+├─ must not change observe inbox renderer yet
+└─ must label source coverage as partial while doctor/eval are not migrated
+```
+
+Studio projection rule:
+
+```text
+Diagnosis
+├─ active lifecycle: detected / candidate / stale
+│  └─ can appear in studio problem lists
+│
+├─ inactive lifecycle: resolved / rejected
+│  └─ hidden by default from active problem lists
+│
+└─ occurrence evidence
+   └─ shown as drill-down, not duplicated as separate studio rows
+```
+
+Issue #103 can be considered functionally resolved when Phase 3 is complete:
+
+```text
+done for #103
+├─ observe diagnostics have a shared Diagnosis shape
+├─ studio can consume those observe diagnostics
+├─ studio clearly marks source coverage as partial
+├─ old Insight and new Diagnosis can coexist during migration
+└─ no observation UI model is directly imported into studio
+```
+
+Dual-run UI completeness risk:
+
+```text
+risk
+├─ Phase 2 may migrate observe first
+├─ Phase 3 may let studio consume Diagnosis
+├─ Phase 4 doctor / eval may still be unmigrated
+└─ studio could show Diagnosis as if it were complete
+```
+
+During dual-run, studio must show data coverage explicitly.
+
+```text
+studio completeness banner
+├─ covered sources: observe
+├─ not yet covered: doctor / eval
+├─ diagnosis count is partial
+└─ use legacy insight count until all configured sources are covered
+```
+
+Recommended display rule:
+
+```text
+if sourceCoverage is partial
+├─ label counts as "partial diagnostics"
+├─ show source coverage next to the count
+├─ keep legacy Insight-derived counts visible or merged with provenance
+└─ prevent users from reading the number as "all known problems"
+```
+
+### Phase 4: Doctor / Eval Producers Follow-up
+
+Phase 4 is not required to close issue #103. It is the full-convergence step
+after studio can already consume observe-backed Diagnosis.
+
+```text
+doctor / eval
+├─ doctor rule failures produce DiagnosisOccurrences
+├─ eval failure clusters produce Diagnosis
+├─ mock/sample issues keep audience=sample-author
+└─ omk blindspots keep audience=omk-maintainer
+```
+
+## Open Questions
+
+```text
+open
+├─ exact stableKey normalization for cross-source merge
+├─ when rejected diagnostics should re-open
+├─ whether reviewer note findings should ever surface in studio
+└─ how much narrative evidence should be duplicated into Diagnosis vs raw payload
+```
+
+Resolved decisions from this draft:
+
+```text
+decisions
+├─ confirmed soft standard
+│  └─ lifecycle=resolved; active in standards view, hidden from active problem list by default
+│
+├─ Phase 1
+│  └─ mapping-only; no runtime schema or implementation code
+│
+└─ dual-run UI
+   └─ studio must show source coverage while Diagnosis coverage is partial
+```

--- a/docs/diagnosis-occurrence-mapping.md
+++ b/docs/diagnosis-occurrence-mapping.md
@@ -660,7 +660,16 @@ do not
 └─ change CLI output
 ```
 
-Phase 1 guardrails:
+> **Note**: The original Phase 1 plan was to land mapping documentation alone. The actual
+> first PR (this one) instead landed Phase 1 + 2 + 3 together — mapping doc, observe
+> producer, and studio consumer in a single change — because (a) the mapping had already
+> stabilized through earlier draft iterations, and (b) splitting into three PRs would
+> double the rebase / review cost without surfacing additional schema conflicts. The
+> guardrails below remain valid for any **future** mapping-only PR (e.g., if doctor or
+> eval producers spawn a new mapping cycle); they do not describe the actual phasing of
+> the first landing.
+
+Phase 1 guardrails (apply only to a mapping-only PR):
 
 ```text
 guardrails

--- a/src/diagnosis/observe-mapper.ts
+++ b/src/diagnosis/observe-mapper.ts
@@ -348,14 +348,20 @@ function maxSeverity(a: DiagnosisSeverity, b: DiagnosisSeverity): DiagnosisSever
   return severityRank(a) >= severityRank(b) ? a : b;
 }
 
-function maxLifecycle(a: DiagnosisLifecycle, b: DiagnosisLifecycle): DiagnosisLifecycle {
+export function maxLifecycle(a: DiagnosisLifecycle, b: DiagnosisLifecycle): DiagnosisLifecycle {
+  // mapper 内的 upsert 合并语义:同一批 build 里多个 source 产生同 stableKey 时,
+  // 终态(resolved / rejected)是作者人为确认或驳回的结果,优先级高于自动检出态。
+  // 比如 `derivedStandard.author_confirmed` 已经把 standard 标 resolved,旁路再来一个
+  // 自动 detected 信号,应保留 resolved 而不是把 confirmation 擦掉。
+  // 「resolved 后新 occurrence 进来 reopen 到 detected」属于跨时间的 lifecycle 状态机,
+  // 由上层 review-state store 决定,不在此处处理。
   const rank: Record<DiagnosisLifecycle, number> = {
-    detected: 5,
-    candidate: 4,
-    stale: 3,
+    resolved: 6,
+    rejected: 5,
+    detected: 4,
+    candidate: 3,
     confirmed: 2,
-    resolved: 1,
-    rejected: 0,
+    stale: 1,
   };
   return rank[a] >= rank[b] ? a : b;
 }

--- a/src/diagnosis/observe-mapper.ts
+++ b/src/diagnosis/observe-mapper.ts
@@ -1,0 +1,372 @@
+import { createHash } from 'node:crypto';
+import type {
+  Diagnosis,
+  DiagnosisAudience,
+  DiagnosisBundle,
+  DiagnosisEvidenceRef,
+  DiagnosisLifecycle,
+  DiagnosisOccurrence,
+  DiagnosisSeverity,
+  DiagnosisType,
+} from './types.js';
+
+const OBSERVE_ONLY_COVERAGE = { observe: true, doctor: false, eval: false } as const;
+
+export interface ObserveDiagnosisInput {
+  generatedAt: string;
+  skillChainAdvisories?: SkillChainAdvisorySource[];
+  runtimeChecks?: ObservationRuntimeCheckSource[];
+  problemPatterns?: ExperienceProblemPatternSource[];
+  reviewerFindings?: ExperienceReviewerReportFindingSource[];
+  derivedStandards?: SkillDerivedStandardSource[];
+}
+
+export interface SkillChainAdvisorySource {
+  skillName: string;
+  code: 'hardrules_not_declared' | 'workflows_not_declared' | 'skill_md_not_found';
+  message?: string;
+  exampleYaml?: string;
+  commandTemplate?: string;
+  sourceId?: string;
+}
+
+export interface ObservationRuntimeCheckSource {
+  skillName: string;
+  id: string;
+  kind: 'hardRule' | 'workflowNode';
+  status: 'passed' | 'attention' | 'manual_review';
+  title?: string;
+  expectation?: string;
+  reason?: string;
+  evidenceRefs?: DiagnosisEvidenceRef[];
+  evidenceSnippets?: string[];
+}
+
+export interface ExperienceProblemPatternSource {
+  skillName: string;
+  bucket: string;
+  patternKey: string;
+  signalTypes: string[];
+  count: number;
+  sessionCount: number;
+  recentSessionIds?: string[];
+  evidenceRefs?: DiagnosisEvidenceRef[];
+  lastSeen?: string;
+}
+
+export interface ExperienceReviewerReportFindingSource {
+  skillName: string;
+  id: string;
+  judgmentId?: string;
+  source: 'deterministic_rule' | 'llm_soft' | 'manual';
+  level: 'info' | 'low' | 'medium' | 'high' | 'attention' | 'sample' | 'normal' | 'warning' | 'critical';
+  title?: string;
+  body?: string;
+  ruleSource: string;
+  ruleVersion?: string;
+  targetKey?: string;
+  evidenceRefs?: DiagnosisEvidenceRef[];
+}
+
+export interface SkillDerivedStandardSource {
+  skillName: string;
+  id: string;
+  kind: 'hard_rule_candidate' | 'workflow_candidate';
+  status: 'pending_review' | 'author_confirmed' | 'rejected' | 'stale';
+  title: string;
+  body?: string;
+  source?: 'llm_soft_standard' | 'manual';
+  confidence?: number;
+  evidence?: string[];
+  model?: string;
+  promptVersion?: string;
+}
+
+export function buildObserveDiagnostics(input: ObserveDiagnosisInput): DiagnosisBundle {
+  const byStableKey = new Map<string, Diagnosis>();
+  for (const advisory of input.skillChainAdvisories ?? []) {
+    upsertDiagnosis(byStableKey, advisoryToDiagnosis(input.generatedAt, advisory));
+  }
+  for (const check of input.runtimeChecks ?? []) {
+    const diagnosis = runtimeCheckToDiagnosis(input.generatedAt, check);
+    if (diagnosis) upsertDiagnosis(byStableKey, diagnosis);
+  }
+  for (const pattern of input.problemPatterns ?? []) {
+    upsertDiagnosis(byStableKey, problemPatternToDiagnosis(input.generatedAt, pattern));
+  }
+  for (const finding of input.reviewerFindings ?? []) {
+    const diagnosis = reviewerFindingToDiagnosis(input.generatedAt, finding);
+    if (diagnosis) upsertDiagnosis(byStableKey, diagnosis);
+  }
+  for (const standard of input.derivedStandards ?? []) {
+    upsertDiagnosis(byStableKey, derivedStandardToDiagnosis(input.generatedAt, standard));
+  }
+
+  const bySkill: Record<string, Diagnosis[]> = {};
+  for (const diagnosis of byStableKey.values()) {
+    bySkill[diagnosis.skillName] ??= [];
+    bySkill[diagnosis.skillName].push(diagnosis);
+  }
+  for (const diagnoses of Object.values(bySkill)) {
+    diagnoses.sort((a, b) => severityRank(b.severity) - severityRank(a.severity) || a.signal.localeCompare(b.signal));
+  }
+
+  return {
+    schemaVersion: 1,
+    generatedAt: input.generatedAt,
+    sourceCoverage: { ...OBSERVE_ONLY_COVERAGE },
+    bySkill,
+  };
+}
+
+function advisoryToDiagnosis(generatedAt: string, advisory: SkillChainAdvisorySource): Diagnosis {
+  const target = advisory.code === 'hardrules_not_declared'
+    ? 'definition:hardRules'
+    : advisory.code === 'workflows_not_declared'
+      ? 'definition:workflows'
+      : 'definition:skill_md';
+  const title = advisory.code === 'hardrules_not_declared'
+    ? 'Hard rules are not declared in SKILL.md'
+    : advisory.code === 'workflows_not_declared'
+      ? 'Workflow is not declared in SKILL.md'
+      : 'SKILL.md was not found';
+  return makeDiagnosis(generatedAt, {
+    skillName: advisory.skillName,
+    type: 'definition_gap',
+    signal: advisory.code,
+    target,
+    title,
+    summary: advisory.message,
+    severity: advisory.code === 'skill_md_not_found' ? 'high' : 'medium',
+    audience: 'skill-author',
+    lifecycle: 'detected',
+    sourceKind: 'skill_chain',
+    sourceId: advisory.sourceId ?? `skill_chain:${advisory.code}:${advisory.skillName}`,
+    evidenceRefs: [],
+    payload: { ...advisory },
+    recommendation: advisory.exampleYaml ? 'Move confirmed rules or workflow into SKILL.md frontmatter.' : undefined,
+    command: advisory.commandTemplate,
+    patch: advisory.exampleYaml
+      ? { target: 'definition', location: 'SKILL.md frontmatter', snippet: advisory.exampleYaml }
+      : undefined,
+  });
+}
+
+function runtimeCheckToDiagnosis(generatedAt: string, check: ObservationRuntimeCheckSource): Diagnosis | null {
+  if (check.status === 'passed') return null;
+  const target = check.kind === 'hardRule' ? `runtime:hardRule:${check.id}` : `runtime:workflowNode:${check.id}`;
+  return makeDiagnosis(generatedAt, {
+    skillName: check.skillName,
+    type: 'runtime_issue',
+    signal: check.kind === 'hardRule' ? 'runtime_hard_rule_review' : 'runtime_workflow_review',
+    target,
+    title: check.title ?? (check.kind === 'hardRule' ? 'Hard rule runtime check needs review' : 'Workflow runtime check needs review'),
+    summary: check.reason ?? check.expectation,
+    severity: check.status === 'manual_review' ? 'medium' : 'low',
+    audience: 'reviewer',
+    lifecycle: 'detected',
+    sourceKind: 'runtime_check',
+    sourceId: check.id,
+    evidenceRefs: check.evidenceRefs ?? [],
+    payload: { ...check },
+  });
+}
+
+function problemPatternToDiagnosis(generatedAt: string, pattern: ExperienceProblemPatternSource): Diagnosis {
+  const signal = pattern.signalTypes[0] ?? pattern.bucket;
+  return makeDiagnosis(generatedAt, {
+    skillName: pattern.skillName,
+    type: typeForPattern(pattern.bucket, signal),
+    signal,
+    target: `pattern:${pattern.bucket}:${pattern.patternKey}`,
+    title: `Repeated observe pattern: ${signal}`,
+    summary: `Seen in ${pattern.sessionCount} session(s), ${pattern.count} occurrence(s).`,
+    severity: pattern.sessionCount >= 3 ? 'high' : pattern.sessionCount >= 2 ? 'medium' : 'low',
+    audience: 'skill-author',
+    lifecycle: 'detected',
+    sourceKind: 'problem_pattern',
+    sourceId: pattern.patternKey,
+    evidenceRefs: pattern.evidenceRefs ?? [],
+    timestamp: pattern.lastSeen,
+    payload: { ...pattern },
+  });
+}
+
+function reviewerFindingToDiagnosis(generatedAt: string, finding: ExperienceReviewerReportFindingSource): Diagnosis | null {
+  if (finding.ruleSource === 'no_priority_signal') return null;
+  const target = finding.targetKey ?? `reviewer:${finding.ruleSource}`;
+  return makeDiagnosis(generatedAt, {
+    skillName: finding.skillName,
+    type: typeForReviewerRule(finding.ruleSource),
+    signal: finding.ruleSource,
+    target,
+    title: titleForReviewerRule(finding.ruleSource, finding.title),
+    summary: finding.body,
+    severity: severityFromReviewerLevel(finding.level),
+    audience: 'reviewer',
+    lifecycle: 'detected',
+    sourceKind: finding.ruleSource,
+    sourceId: finding.id,
+    evidenceRefs: finding.evidenceRefs ?? [],
+    producer: finding.source,
+    payload: { ...finding },
+  });
+}
+
+function derivedStandardToDiagnosis(generatedAt: string, standard: SkillDerivedStandardSource): Diagnosis {
+  return makeDiagnosis(generatedAt, {
+    skillName: standard.skillName,
+    type: 'standard_candidate',
+    signal: standard.kind,
+    target: `standard:${standard.kind}:${standard.id}`,
+    title: standard.title,
+    summary: standard.body,
+    severity: standard.status === 'author_confirmed' ? 'info' : 'low',
+    audience: 'skill-author',
+    lifecycle: lifecycleFromStandardStatus(standard.status),
+    sourceKind: standard.kind,
+    sourceId: standard.id,
+    evidenceRefs: [],
+    producer: standard.source === 'manual' ? 'manual' : 'llm_soft',
+    payload: { ...standard },
+    evidenceSummary: standard.evidence?.join('\n'),
+  });
+}
+
+function makeDiagnosis(
+  generatedAt: string,
+  input: {
+    skillName: string;
+    type: DiagnosisType;
+    signal: string;
+    target: string;
+    title: string;
+    summary?: string;
+    severity: DiagnosisSeverity;
+    audience: DiagnosisAudience;
+    lifecycle: DiagnosisLifecycle;
+    sourceKind: string;
+    sourceId: string;
+    evidenceRefs: DiagnosisEvidenceRef[];
+    producer?: DiagnosisOccurrence['producer'];
+    payload: Record<string, unknown>;
+    timestamp?: string;
+    evidenceSummary?: string;
+    recommendation?: string;
+    command?: string;
+    patch?: Diagnosis['patch'];
+  },
+): Diagnosis {
+  const stableKey = [
+    `skill:${input.skillName}`,
+    `type:${input.type}`,
+    `signal:${input.signal}`,
+    `target:${input.target}`,
+  ].join('|');
+  const occurrence: DiagnosisOccurrence = {
+    id: hashParts('occurrence', stableKey, input.sourceKind, input.sourceId),
+    diagnosisStableKey: stableKey,
+    source: 'observe',
+    sourceId: input.sourceId,
+    sourceKind: input.sourceKind,
+    timestamp: input.timestamp ?? generatedAt,
+    severity: input.severity,
+    evidenceRefs: input.evidenceRefs,
+    producer: input.producer ?? 'deterministic_rule',
+    payload: input.payload,
+  };
+  return {
+    id: hashParts('diagnosis', stableKey),
+    stableKey,
+    skillName: input.skillName,
+    type: input.type,
+    signal: input.signal,
+    title: input.title,
+    summary: input.summary,
+    severity: input.severity,
+    audience: input.audience,
+    lifecycle: input.lifecycle,
+    scope: {
+      primary: input.target.startsWith('definition:') || input.target.startsWith('standard:') ? 'definition' : 'skill',
+      refs: { skillName: input.skillName },
+    },
+    occurrences: [occurrence],
+    occurrenceCount: 1,
+    evidenceSummary: input.evidenceSummary,
+    recommendation: input.recommendation,
+    command: input.command,
+    patch: input.patch,
+  };
+}
+
+function upsertDiagnosis(byStableKey: Map<string, Diagnosis>, next: Diagnosis): void {
+  const existing = byStableKey.get(next.stableKey);
+  if (!existing) {
+    byStableKey.set(next.stableKey, next);
+    return;
+  }
+  existing.occurrences.push(...next.occurrences);
+  existing.occurrenceCount = existing.occurrences.length;
+  existing.severity = maxSeverity(existing.severity, next.severity);
+  existing.lifecycle = maxLifecycle(existing.lifecycle, next.lifecycle);
+}
+
+function typeForPattern(bucket: string, signal: string): DiagnosisType {
+  if (bucket === 'definition_gap') return 'definition_gap';
+  if (signal.includes('feedback') || signal.includes('correction') || signal.includes('interruption')) return 'user_feedback_pattern';
+  return 'runtime_issue';
+}
+
+function typeForReviewerRule(ruleSource: string): DiagnosisType {
+  if (ruleSource.includes('feedback') || ruleSource.includes('correction') || ruleSource.includes('interruption')) {
+    return 'user_feedback_pattern';
+  }
+  return 'runtime_issue';
+}
+
+function titleForReviewerRule(ruleSource: string, fallback?: string): string {
+  if (ruleSource === 'final_delivery_absent') return 'Final delivery is missing in repeated runs';
+  if (ruleSource === 'tool_error_recovery') return 'Tool failure recovery needs review';
+  return fallback ?? `Reviewer finding: ${ruleSource}`;
+}
+
+function severityFromReviewerLevel(level: ExperienceReviewerReportFindingSource['level']): DiagnosisSeverity {
+  if (level === 'critical' || level === 'high') return 'high';
+  if (level === 'warning' || level === 'attention' || level === 'medium') return 'medium';
+  if (level === 'sample' || level === 'low') return 'low';
+  return 'info';
+}
+
+function lifecycleFromStandardStatus(status: SkillDerivedStandardSource['status']): DiagnosisLifecycle {
+  if (status === 'pending_review') return 'candidate';
+  if (status === 'author_confirmed') return 'resolved';
+  if (status === 'rejected') return 'rejected';
+  return 'stale';
+}
+
+function maxSeverity(a: DiagnosisSeverity, b: DiagnosisSeverity): DiagnosisSeverity {
+  return severityRank(a) >= severityRank(b) ? a : b;
+}
+
+function maxLifecycle(a: DiagnosisLifecycle, b: DiagnosisLifecycle): DiagnosisLifecycle {
+  const rank: Record<DiagnosisLifecycle, number> = {
+    detected: 5,
+    candidate: 4,
+    stale: 3,
+    confirmed: 2,
+    resolved: 1,
+    rejected: 0,
+  };
+  return rank[a] >= rank[b] ? a : b;
+}
+
+function severityRank(severity: DiagnosisSeverity): number {
+  if (severity === 'high') return 4;
+  if (severity === 'medium') return 3;
+  if (severity === 'low') return 2;
+  return 1;
+}
+
+function hashParts(...parts: string[]): string {
+  return createHash('sha256').update(parts.join('\u0000')).digest('hex').slice(0, 16);
+}

--- a/src/diagnosis/observe-mapper.ts
+++ b/src/diagnosis/observe-mapper.ts
@@ -189,6 +189,9 @@ function problemPatternToDiagnosis(generatedAt: string, pattern: ExperienceProbl
     evidenceRefs: pattern.evidenceRefs ?? [],
     timestamp: pattern.lastSeen,
     payload: { ...pattern },
+    // pattern.count = 总发生次数(可能跨多 session),用作 affectedCount 更贴近用户感知的「影响范围」,
+    // 比 sessionCount 更稳(单 session 内重复 10 次也算 10 次发生)。
+    occurrenceCount: pattern.count,
   });
 }
 
@@ -255,6 +258,10 @@ function makeDiagnosis(
     recommendation?: string;
     command?: string;
     patch?: Diagnosis['patch'];
+    /** 对聚合型 source(如 problem pattern)用真实 count 覆盖默认的 1。
+     *  默认 1 是「每个 source 贡献一个 occurrence」语义。但 problemPattern 已经是
+     *  「N 个 session / M 次发生」的聚合,1 会让 Studio 排序和 affectedCount 显示失真。 */
+    occurrenceCount?: number;
   },
 ): Diagnosis {
   const stableKey = [
@@ -291,7 +298,7 @@ function makeDiagnosis(
       refs: { skillName: input.skillName },
     },
     occurrences: [occurrence],
-    occurrenceCount: 1,
+    occurrenceCount: input.occurrenceCount ?? 1,
     evidenceSummary: input.evidenceSummary,
     recommendation: input.recommendation,
     command: input.command,

--- a/src/diagnosis/observe-producer.ts
+++ b/src/diagnosis/observe-producer.ts
@@ -1,0 +1,173 @@
+import { buildObservationSkillChains, type ObservationRuntimeCheck, type ObservationSkillChain } from '../observability/skill-chain.js';
+import { getSkillChainAdvisory, resolveAdvisoryCommand } from '../observability/skill-chain-advisories.js';
+import type { ObservationInboxReport } from '../observability/inbox.js';
+import type {
+  ExperienceEvidenceRef,
+  ExperienceRuleFinding,
+  ExperienceSkillSummary,
+  ObservationExperienceReport,
+} from '../observability/experience.js';
+import type { ExperienceProblemPattern } from '../observability/problem-patterns.js';
+import { buildObserveDiagnostics, type ExperienceReviewerReportFindingSource } from './observe-mapper.js';
+import type { DiagnosisBundle, DiagnosisEvidenceRef } from './types.js';
+
+export interface BuildObserveDiagnosticsFromReportOptions {
+  cwd?: string;
+  skillChains?: Record<string, ObservationSkillChain>;
+}
+
+export function buildObserveDiagnosticsFromReport(
+  report: ObservationInboxReport,
+  options: BuildObserveDiagnosticsFromReportOptions = {},
+): DiagnosisBundle {
+  const experienceReports = report.experience ? [report.experience] : [];
+  const skillNames = skillNamesFromReport(report);
+  const chains = options.skillChains ?? buildObservationSkillChains(skillNames, options.cwd ?? process.cwd(), experienceReports);
+  return buildObserveDiagnostics({
+    generatedAt: report.meta.generatedAt,
+    skillChainAdvisories: Object.values(chains).flatMap(chainAdvisories),
+    runtimeChecks: Object.values(chains).flatMap(chainRuntimeChecks),
+    problemPatterns: experienceReports.flatMap(experienceProblemPatterns),
+    reviewerFindings: experienceReports.flatMap(experienceRuleFindings),
+    derivedStandards: [],
+  });
+}
+
+function skillNamesFromReport(report: ObservationInboxReport): string[] {
+  return Array.from(new Set([
+    ...Object.keys(report.meta.skillInvocationCounts ?? {}),
+    ...Object.keys(report.meta.skillSessionCounts ?? {}),
+    ...report.items.map((item) => item.skillName),
+    ...(report.experience?.skills.map((skill) => skill.skillName) ?? []),
+  ].filter(Boolean))).sort();
+}
+
+function chainAdvisories(chain: ObservationSkillChain) {
+  if (!chain.definition.found) {
+    const advisory = getSkillChainAdvisory('skill_md_not_found');
+    return [{
+      skillName: chain.skillName,
+      code: advisory.code,
+      message: advisory.message,
+      exampleYaml: advisory.exampleYaml,
+      commandTemplate: resolveAdvisoryCommand(advisory, chain.skillName),
+      sourceId: `skill_chain:${chain.skillName}:${advisory.code}`,
+    }];
+  }
+
+  return [
+    chain.healthCheck.hardRules.advisoryCode,
+    chain.healthCheck.workflows.advisoryCode,
+  ].filter((code): code is NonNullable<typeof code> => Boolean(code)).map((code) => {
+    const advisory = getSkillChainAdvisory(code);
+    return {
+      skillName: chain.skillName,
+      code: advisory.code,
+      message: advisory.message,
+      exampleYaml: advisory.exampleYaml,
+      commandTemplate: resolveAdvisoryCommand(advisory, chain.skillName),
+      sourceId: `skill_chain:${chain.skillName}:${advisory.code}`,
+    };
+  });
+}
+
+function chainRuntimeChecks(chain: ObservationSkillChain) {
+  return [...chain.runtime.hardRules, ...chain.runtime.workflowNodes]
+    .filter((check) => check.status !== 'passed')
+    .map((check) => ({
+      skillName: chain.skillName,
+      id: check.id,
+      kind: check.kind,
+      status: check.status,
+      title: check.title,
+      expectation: check.expectation,
+      reason: check.reason,
+      evidenceSnippets: check.evidenceSnippets,
+      evidenceRefs: evidenceRefsFromRuntimeCheck(check, chain.skillName),
+    }));
+}
+
+function evidenceRefsFromRuntimeCheck(check: ObservationRuntimeCheck, skillName: string): DiagnosisEvidenceRef[] {
+  return (check.evidenceSnippets ?? []).map((snippet, index) => ({
+    id: `runtime:${skillName}:${check.kind}:${check.id}:${index}`,
+    kind: check.kind,
+    label: check.title,
+    snippet,
+  }));
+}
+
+function experienceProblemPatterns(report: ObservationExperienceReport) {
+  return report.skills.flatMap((skill) =>
+    skill.problemPatterns.map((pattern) => ({
+      skillName: skill.skillName,
+      bucket: pattern.bucket,
+      patternKey: pattern.patternKey,
+      signalTypes: pattern.signalTypes,
+      count: pattern.count,
+      sessionCount: pattern.sessionCount,
+      recentSessionIds: pattern.recentSessionIds,
+      evidenceRefs: pattern.evidenceRefs.map(evidenceRef),
+      lastSeen: pattern.lastSeen,
+    }))
+  );
+}
+
+function experienceRuleFindings(report: ObservationExperienceReport): ExperienceReviewerReportFindingSource[] {
+  return report.skills.flatMap((skill) =>
+    skill.ruleFindings
+      .filter((finding) => finding.level !== 'normal' || finding.code === 'no_priority_signal')
+      .map((finding) => ruleFindingSource(skill, finding))
+  );
+}
+
+function ruleFindingSource(
+  skill: ExperienceSkillSummary,
+  finding: ExperienceRuleFinding,
+): ExperienceReviewerReportFindingSource {
+  return {
+    skillName: skill.skillName,
+    id: `rule_finding:${skill.skillName}:${finding.code}`,
+    source: 'deterministic_rule',
+    level: finding.level,
+    title: titleForRuleFinding(finding.code),
+    body: `Detected ${finding.count} occurrence(s) for ${finding.code}.`,
+    ruleSource: finding.code,
+    targetKey: `experience_rule:${finding.code}`,
+    evidenceRefs: finding.evidenceRefs.map(evidenceRef),
+  };
+}
+
+function titleForRuleFinding(code: ExperienceRuleFinding['code']): string {
+  const titles: Record<ExperienceRuleFinding['code'], string> = {
+    high_observation_seen: 'High-priority observation seen',
+    medium_observation_seen: 'Medium-priority observation seen',
+    user_correction_seen: 'User correction seen',
+    user_interruption_seen: 'User interruption seen',
+    negative_feedback_seen: 'Negative feedback seen',
+    positive_feedback_seen: 'Positive feedback seen',
+    user_goal_shift_seen: 'User goal shift seen',
+    hard_rule_seen: 'User hard rule seen',
+    tool_failure_seen: 'Tool failure seen',
+    hedging_seen: 'Hedging signal seen',
+    explicit_marker_seen: 'Explicit gap marker seen',
+    runtime_context_excluded: 'Runtime context excluded',
+    skill_context_excluded: 'Skill context excluded',
+    no_priority_signal: 'No priority signal',
+  };
+  return titles[code];
+}
+
+function evidenceRef(ref: ExperienceEvidenceRef | ExperienceProblemPattern['evidenceRefs'][number]): DiagnosisEvidenceRef {
+  return {
+    id: ref.id,
+    kind: ref.kind,
+    sourceTrace: ref.sourceTrace,
+    sessionId: ref.sessionId,
+    messageIndex: ref.messageIndex,
+    messageUuid: ref.messageUuid,
+    toolUseId: ref.toolUseId,
+    timestamp: ref.timestamp,
+    label: ref.label,
+    snippet: ref.snippet,
+  };
+}

--- a/src/diagnosis/observe-producer.ts
+++ b/src/diagnosis/observe-producer.ts
@@ -1,4 +1,4 @@
-import { buildObservationSkillChains, type ObservationRuntimeCheck, type ObservationSkillChain } from '../observability/skill-chain.js';
+import { buildObservationSkillChain, buildObservationSkillChains, type ObservationRuntimeCheck, type ObservationSkillChain } from '../observability/skill-chain.js';
 import { getSkillChainAdvisory, resolveAdvisoryCommand } from '../observability/skill-chain-advisories.js';
 import type { ObservationInboxReport } from '../observability/inbox.js';
 import type {
@@ -22,7 +22,7 @@ export function buildObserveDiagnosticsFromReport(
 ): DiagnosisBundle {
   const experienceReports = report.experience ? [report.experience] : [];
   const skillNames = skillNamesFromReport(report);
-  const chains = options.skillChains ?? buildObservationSkillChains(skillNames, options.cwd ?? process.cwd(), experienceReports);
+  const chains = resolveSkillChains(report, skillNames, experienceReports, options);
   return buildObserveDiagnostics({
     generatedAt: report.meta.generatedAt,
     skillChainAdvisories: Object.values(chains).flatMap(chainAdvisories),
@@ -31,6 +31,49 @@ export function buildObserveDiagnosticsFromReport(
     reviewerFindings: experienceReports.flatMap(experienceRuleFindings),
     derivedStandards: [],
   });
+}
+
+function resolveSkillChains(
+  report: ObservationInboxReport,
+  skillNames: string[],
+  experienceReports: ObservationExperienceReport[],
+  options: BuildObserveDiagnosticsFromReportOptions,
+): Record<string, ObservationSkillChain> {
+  // 调用方显式传 skillChains(测试 mock)或 cwd(已知项目根)时直接用。
+  // 否则按 skill 推断 cwd:
+  //   - 该 skill 的所有 inbox items 只出现 1 个 cwd → 用它构建 chain
+  //   - 多个 cwd 或完全没有 cwd 信息 → 跳过该 skill 的 chain 构建
+  //
+  // 跳过比 fallback 到 process.cwd() 安全:跨项目 `omk observe ingest /path/to/B-traces`
+  // 时 process.cwd() 找不到 SKILL.md 会产生 `skill_md_not_found` 假阳性,而且这条 advisory
+  // 会被 build 路径持久化进 inbox JSON,后续 Studio 读取时已无从分辨是 cwd 漂移导致的误报。
+  // 跳过的语义是「没把握判断,不发 advisory」,problemPatterns / reviewerFindings 仍正常工作。
+  if (options.skillChains) return options.skillChains;
+  if (options.cwd) return buildObservationSkillChains(skillNames, options.cwd, experienceReports);
+  const cwdBySkill = inferCwdBySkill(report);
+  const chains: Record<string, ObservationSkillChain> = {};
+  for (const skillName of skillNames) {
+    const cwd = cwdBySkill.get(skillName);
+    if (cwd) {
+      chains[skillName] = buildObservationSkillChain(skillName, cwd, experienceReports);
+    }
+  }
+  return chains;
+}
+
+/** 按 skill 从 inbox items 聚合 cwd。返回:单一 cwd 字符串 / null(多 cwd 或缺失,跳过 chain)。 */
+function inferCwdBySkill(report: ObservationInboxReport): Map<string, string | null> {
+  const cwdsBySkill = new Map<string, Set<string>>();
+  for (const item of report.items) {
+    if (!item.skillName || !item.cwd) continue;
+    if (!cwdsBySkill.has(item.skillName)) cwdsBySkill.set(item.skillName, new Set());
+    cwdsBySkill.get(item.skillName)!.add(item.cwd);
+  }
+  const out = new Map<string, string | null>();
+  for (const [skill, set] of cwdsBySkill) {
+    out.set(skill, set.size === 1 ? Array.from(set)[0] : null);
+  }
+  return out;
 }
 
 function skillNamesFromReport(report: ObservationInboxReport): string[] {

--- a/src/diagnosis/observe-producer.ts
+++ b/src/diagnosis/observe-producer.ts
@@ -61,13 +61,30 @@ function resolveSkillChains(
   return chains;
 }
 
-/** 按 skill 从 inbox items 聚合 cwd。返回:单一 cwd 字符串 / null(多 cwd 或缺失,跳过 chain)。 */
+/** 按 skill 从 inbox items + experience 聚合 cwd。返回:单一 cwd 字符串 / null(多 cwd,跳过 chain)。
+ *
+ *  数据源优先级一致(同等聚合 set,不分先后):
+ *    - report.items[].cwd:有 observation signal 的 skill 调用
+ *    - report.experience.invocations[].cwd:所有 skill 调用(干净运行也有,items 可能为空)
+ *    - report.experience.goalSlices[].cwd:goal slice 级 cwd
+ *
+ *  「items 为空但 experience 有 cwd」是真实 build 路径的常见态(skill 跑得很干净没产生 signal,
+ *  但仍要看 SKILL.md 结构),只看 items 会漏整个 chain advisory + runtime check。 */
 function inferCwdBySkill(report: ObservationInboxReport): Map<string, string | null> {
   const cwdsBySkill = new Map<string, Set<string>>();
+  const addCwd = (skillName: string | undefined | null, cwd: string | undefined): void => {
+    if (!skillName || !cwd) return;
+    if (!cwdsBySkill.has(skillName)) cwdsBySkill.set(skillName, new Set());
+    cwdsBySkill.get(skillName)!.add(cwd);
+  };
   for (const item of report.items) {
-    if (!item.skillName || !item.cwd) continue;
-    if (!cwdsBySkill.has(item.skillName)) cwdsBySkill.set(item.skillName, new Set());
-    cwdsBySkill.get(item.skillName)!.add(item.cwd);
+    addCwd(item.skillName, item.cwd);
+  }
+  for (const invocation of report.experience?.invocations ?? []) {
+    addCwd(invocation.skillName, invocation.cwd);
+  }
+  for (const slice of report.experience?.goalSlices ?? []) {
+    addCwd(slice.skillName, slice.cwd);
   }
   const out = new Map<string, string | null>();
   for (const [skill, set] of cwdsBySkill) {

--- a/src/diagnosis/studio-projection.ts
+++ b/src/diagnosis/studio-projection.ts
@@ -52,7 +52,11 @@ export function mergeDiagnosisBundles(bundles: DiagnosisBundle[], generatedAt = 
         continue;
       }
       existing.occurrences.push(...diagnosis.occurrences);
-      existing.occurrenceCount = existing.occurrences.length;
+      // 累加而不是用 occurrences.length 覆盖:聚合型 Diagnosis(如 problemPattern)的
+      // occurrenceCount 是「N 次真实发生」的语义,不是「N 条 source occurrence 条数」。
+      // 用 length 会把 `3 次 + 4 次` 真实发生压成 `2`(两条 source 条目),Studio 排序和
+      // affectedCount 显示偏小。
+      existing.occurrenceCount = existing.occurrenceCount + diagnosis.occurrenceCount;
       existing.severity = severityRank(existing.severity) >= severityRank(diagnosis.severity)
         ? existing.severity
         : diagnosis.severity;

--- a/src/diagnosis/studio-projection.ts
+++ b/src/diagnosis/studio-projection.ts
@@ -1,0 +1,89 @@
+import type { Diagnosis, DiagnosisBundle, DiagnosisSeverity, DiagnosisSourceCoverage } from './types.js';
+
+export interface StudioDiagnosisSummary {
+  sourceCoverage: DiagnosisSourceCoverage;
+  totalCount: number;
+  partial: boolean;
+  bySeverity: Record<DiagnosisSeverity, number>;
+  bySkill: Record<string, number>;
+  byAudience: Record<string, number>;
+}
+
+export function buildStudioDiagnosisSummary(bundle?: DiagnosisBundle): StudioDiagnosisSummary {
+  const sourceCoverage = bundle?.sourceCoverage ?? { observe: false, doctor: false, eval: false };
+  const diagnostics = Object.values(bundle?.bySkill ?? {}).flat();
+  const bySeverity: Record<DiagnosisSeverity, number> = { high: 0, medium: 0, low: 0, info: 0 };
+  const bySkill: Record<string, number> = {};
+  const byAudience: Record<string, number> = {};
+  for (const diagnosis of diagnostics) {
+    bySeverity[diagnosis.severity] += 1;
+    bySkill[diagnosis.skillName] = (bySkill[diagnosis.skillName] ?? 0) + 1;
+    byAudience[diagnosis.audience] = (byAudience[diagnosis.audience] ?? 0) + 1;
+  }
+  return {
+    sourceCoverage,
+    totalCount: countDiagnostics(bundle),
+    partial: !sourceCoverage.doctor || !sourceCoverage.eval || !sourceCoverage.observe,
+    bySeverity,
+    bySkill,
+    byAudience,
+  };
+}
+
+export function countDiagnostics(bundle?: DiagnosisBundle): number {
+  if (!bundle) return 0;
+  return Object.values(bundle.bySkill).reduce((sum, values) => sum + values.length, 0);
+}
+
+export function mergeDiagnosisBundles(bundles: DiagnosisBundle[], generatedAt = new Date().toISOString()): DiagnosisBundle {
+  const byStableKey = new Map<string, Diagnosis>();
+  const sourceCoverage = { observe: false, doctor: false, eval: false };
+  for (const bundle of bundles) {
+    sourceCoverage.observe = sourceCoverage.observe || bundle.sourceCoverage.observe;
+    sourceCoverage.doctor = sourceCoverage.doctor || bundle.sourceCoverage.doctor;
+    sourceCoverage.eval = sourceCoverage.eval || bundle.sourceCoverage.eval;
+    for (const diagnosis of Object.values(bundle.bySkill).flat()) {
+      const existing = byStableKey.get(diagnosis.stableKey);
+      if (!existing) {
+        byStableKey.set(diagnosis.stableKey, {
+          ...diagnosis,
+          occurrences: [...diagnosis.occurrences],
+        });
+        continue;
+      }
+      existing.occurrences.push(...diagnosis.occurrences);
+      existing.occurrenceCount = existing.occurrences.length;
+      existing.severity = severityRank(existing.severity) >= severityRank(diagnosis.severity)
+        ? existing.severity
+        : diagnosis.severity;
+    }
+  }
+  const bySkill: DiagnosisBundle['bySkill'] = {};
+  for (const diagnosis of byStableKey.values()) {
+    bySkill[diagnosis.skillName] ??= [];
+    bySkill[diagnosis.skillName].push(diagnosis);
+  }
+  for (const values of Object.values(bySkill)) {
+    values.sort((a, b) => severityRank(b.severity) - severityRank(a.severity) || a.signal.localeCompare(b.signal));
+  }
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    sourceCoverage,
+    bySkill,
+  };
+}
+
+export function activeStudioDiagnostics(bundle?: DiagnosisBundle): Diagnosis[] {
+  return Object.values(bundle?.bySkill ?? {})
+    .flat()
+    .filter((diagnosis) => diagnosis.lifecycle === 'detected' || diagnosis.lifecycle === 'candidate' || diagnosis.lifecycle === 'stale')
+    .sort((a, b) => severityRank(b.severity) - severityRank(a.severity) || a.skillName.localeCompare(b.skillName));
+}
+
+function severityRank(severity: DiagnosisSeverity): number {
+  if (severity === 'high') return 4;
+  if (severity === 'medium') return 3;
+  if (severity === 'low') return 2;
+  return 1;
+}

--- a/src/diagnosis/studio-projection.ts
+++ b/src/diagnosis/studio-projection.ts
@@ -1,4 +1,4 @@
-import type { Diagnosis, DiagnosisBundle, DiagnosisSeverity, DiagnosisSourceCoverage } from './types.js';
+import { isActiveDiagnosisLifecycle, type Diagnosis, type DiagnosisBundle, type DiagnosisSeverity, type DiagnosisSourceCoverage } from './types.js';
 
 export interface StudioDiagnosisSummary {
   sourceCoverage: DiagnosisSourceCoverage;
@@ -81,7 +81,7 @@ export function mergeDiagnosisBundles(bundles: DiagnosisBundle[], generatedAt = 
 export function activeStudioDiagnostics(bundle?: DiagnosisBundle): Diagnosis[] {
   return Object.values(bundle?.bySkill ?? {})
     .flat()
-    .filter((diagnosis) => diagnosis.lifecycle === 'detected' || diagnosis.lifecycle === 'candidate' || diagnosis.lifecycle === 'stale')
+    .filter((diagnosis) => isActiveDiagnosisLifecycle(diagnosis.lifecycle))
     .sort((a, b) => severityRank(b.severity) - severityRank(a.severity) || a.skillName.localeCompare(b.skillName));
 }
 

--- a/src/diagnosis/types.ts
+++ b/src/diagnosis/types.ts
@@ -1,0 +1,92 @@
+export type DiagnosisSource = 'observe' | 'doctor' | 'eval';
+export type DiagnosisAudience = 'skill-author' | 'sample-author' | 'omk-maintainer' | 'reviewer';
+export type DiagnosisSeverity = 'high' | 'medium' | 'low' | 'info';
+export type DiagnosisLifecycle = 'detected' | 'candidate' | 'confirmed' | 'rejected' | 'resolved' | 'stale';
+export type DiagnosisType =
+  | 'definition_gap'
+  | 'runtime_issue'
+  | 'user_feedback_pattern'
+  | 'eval_failure'
+  | 'sample_design_issue'
+  | 'doctor_gap'
+  | 'standard_candidate'
+  | 'maintenance_issue';
+
+export interface DiagnosisSourceCoverage {
+  observe: boolean;
+  doctor: boolean;
+  eval: boolean;
+}
+
+export interface DiagnosisScope {
+  primary: 'skill' | 'definition' | 'session' | 'sample';
+  refs: {
+    skillName: string;
+    sessionId?: string;
+    invocationId?: string;
+    sampleId?: string;
+    ruleId?: string;
+    workflowId?: string;
+    sourceTrace?: string;
+  };
+}
+
+export interface DiagnosisEvidenceRef {
+  id: string;
+  kind: string;
+  sourceTrace?: string;
+  sessionId?: string;
+  messageIndex?: number;
+  messageUuid?: string;
+  toolUseId?: string;
+  timestamp?: string;
+  label?: string;
+  snippet?: string;
+}
+
+export interface DiagnosisOccurrence {
+  id: string;
+  diagnosisStableKey: string;
+  source: DiagnosisSource;
+  sourceId: string;
+  sourceKind: string;
+  timestamp?: string;
+  severity?: DiagnosisSeverity;
+  evidenceRefs: DiagnosisEvidenceRef[];
+  rawRef?: string;
+  producer: 'deterministic_rule' | 'llm_soft' | 'manual';
+  payload?: Record<string, unknown>;
+}
+
+export interface DiagnosisPatch {
+  target: 'skill' | 'sample-environment' | 'sample-mocks' | 'doctor-rule' | 'definition';
+  location: string;
+  snippet: string;
+}
+
+export interface Diagnosis {
+  id: string;
+  stableKey: string;
+  skillName: string;
+  type: DiagnosisType;
+  signal: string;
+  title: string;
+  summary?: string;
+  severity: DiagnosisSeverity;
+  audience: DiagnosisAudience;
+  lifecycle: DiagnosisLifecycle;
+  scope: DiagnosisScope;
+  occurrences: DiagnosisOccurrence[];
+  occurrenceCount: number;
+  evidenceSummary?: string;
+  recommendation?: string;
+  patch?: DiagnosisPatch;
+  command?: string;
+}
+
+export interface DiagnosisBundle {
+  schemaVersion: 1;
+  generatedAt: string;
+  sourceCoverage: DiagnosisSourceCoverage;
+  bySkill: Record<string, Diagnosis[]>;
+}

--- a/src/diagnosis/types.ts
+++ b/src/diagnosis/types.ts
@@ -90,3 +90,24 @@ export interface DiagnosisBundle {
   sourceCoverage: DiagnosisSourceCoverage;
   bySkill: Record<string, Diagnosis[]>;
 }
+
+/** Diagnosis 是否「active problem」的唯一权威定义。
+ *
+ *  跟 docs/diagnosis-occurrence-mapping.md 的 studio projection rule 对齐:
+ *    active = detected / candidate / stale
+ *    inactive = resolved / rejected(默认从 active 列表隐藏)
+ *    confirmed:目前 mapper 不产出,如果将来 producer / review-state 写出,会被一并算 inactive
+ *               —— 跟 confirmed soft standard 的「已被认知、进入处理流程」语义一致。
+ *
+ *  抽这个 helper 是为了:Insight 投影(影响 skill 健康 / 待优化数)和 /api/observations/diagnostics
+ *  的 active 列表共用同一份口径,避免「Insight 把 confirmed 算 active 但 API 不算」的口径分叉。
+ */
+const ACTIVE_DIAGNOSIS_LIFECYCLES: ReadonlySet<DiagnosisLifecycle> = new Set<DiagnosisLifecycle>([
+  'detected',
+  'candidate',
+  'stale',
+]);
+
+export function isActiveDiagnosisLifecycle(lifecycle: DiagnosisLifecycle): boolean {
+  return ACTIVE_DIAGNOSIS_LIFECYCLES.has(lifecycle);
+}

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -664,7 +664,11 @@ export function loadObservationInboxReports(dir: string = DEFAULT_OBSERVATIONS_D
             severityReason: undefined,
           };
         });
-        report.diagnostics = report.diagnostics ?? buildObserveDiagnosticsFromReport(report);
+        // 不在 load 路径重建 diagnostics:`buildObserveDiagnosticsFromReport` 默认 cwd 是
+        // `process.cwd()`,但加载历史 inbox 时 cwd 通常跟 trace 原始项目根不一致,
+        // `buildObservationSkillChains` 会读错 `skills/*/SKILL.md` 导致误报 `skill_md_not_found`。
+        // 新版 build 路径(buildObservationInboxReport)总会写入 diagnostics 字段;老 inbox JSON
+        // 没有字段时让 Studio 显示「该 trace 暂无 Diagnosis,请重新 observe 一次」,比给错数据安全。
         return report;
       } catch {
         return null;

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -9,6 +9,8 @@ import { isSearchToolCall, toolCallQuery } from '../shared/tool-search.js';
 import { durationMsBetween } from '../shared/time.js';
 import { buildObservationExperienceReport, type ObservationExperienceReport } from './experience.js';
 import type { ObservationReviewState } from './review-state.js';
+import { buildObserveDiagnosticsFromReport } from '../diagnosis/observe-producer.js';
+import type { DiagnosisBundle } from '../diagnosis/types.js';
 
 export const DEFAULT_PROJECT_OBSERVATIONS_DIR = join(process.cwd(), '.omk', 'observations');
 export const DEFAULT_GLOBAL_OBSERVATIONS_DIR = join(homedir(), '.oh-my-knowledge', 'observations');
@@ -129,6 +131,7 @@ export interface ObservationInboxReport {
   };
   items: ObservationInboxItem[];
   experience?: ObservationExperienceReport;
+  diagnostics?: DiagnosisBundle;
 }
 
 export interface ObservationSkillRollup {
@@ -529,7 +532,7 @@ export function buildObservationInboxReport(tracePath: string, options: BuildObs
   }
   const items = finishInboxAggregation(aggregationState);
   const experience = buildObservationExperienceReport({ sessions, segments, items, generatedAt, reviewState: options.reviewState });
-  return {
+  const report: ObservationInboxReport = {
     kind: 'observe-inbox',
     schemaVersion: 1,
     meta: {
@@ -548,6 +551,8 @@ export function buildObservationInboxReport(tracePath: string, options: BuildObs
     items,
     experience,
   };
+  report.diagnostics = buildObserveDiagnosticsFromReport(report);
+  return report;
 }
 
 interface InboxAggregationState {
@@ -659,6 +664,7 @@ export function loadObservationInboxReports(dir: string = DEFAULT_OBSERVATIONS_D
             severityReason: undefined,
           };
         });
+        report.diagnostics = report.diagnostics ?? buildObserveDiagnosticsFromReport(report);
         return report;
       } catch {
         return null;

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -664,11 +664,12 @@ export function loadObservationInboxReports(dir: string = DEFAULT_OBSERVATIONS_D
             severityReason: undefined,
           };
         });
-        // 不在 load 路径重建 diagnostics:`buildObserveDiagnosticsFromReport` 默认 cwd 是
-        // `process.cwd()`,但加载历史 inbox 时 cwd 通常跟 trace 原始项目根不一致,
-        // `buildObservationSkillChains` 会读错 `skills/*/SKILL.md` 导致误报 `skill_md_not_found`。
-        // 新版 build 路径(buildObservationInboxReport)总会写入 diagnostics 字段;老 inbox JSON
-        // 没有字段时让 Studio 显示「该 trace 暂无 Diagnosis,请重新 observe 一次」,比给错数据安全。
+        // 不在 load 路径重建 diagnostics:`buildObserveDiagnosticsFromReport` 现在虽然会从
+        // report.items[].cwd / experience 推断每个 skill 的 cwd(没把握就跳过该 skill 的
+        // chain advisory,不再 fallback process.cwd()),但 load 时全跳过的话整个 trace
+        // 都没有 Diagnosis。新版 build 路径(buildObservationInboxReport)总会写入
+        // diagnostics 字段;老 inbox JSON 缺字段时让 Studio 显示「该 trace 暂无 Diagnosis,
+        // 请重新 observe 一次」,比惰性重建安全。
         return report;
       } catch {
         return null;

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -62,7 +62,19 @@ export interface HealthAssessment {
 
 export function assessHealth(entry: SkillIndexEntry, insights: Insight[], lang: Lang): HealthAssessment {
   const ran = [entry.doctor, entry.eval, entry.observe].filter(Boolean).length;
+  // 三大维度都没跑过时,如果 Diagnosis 已经给出 high/medium 信号(例如只跑了 `omk observe ingest`
+  // 拿到 `skill_md_not_found`),仍然要把卡片标红/黄,而不是落到灰色「未评估」。
+  // 否则 Diagnosis 作为 Studio 数据源的价值会被 UI 口径吞掉:红色筛选筛不到,
+  // 用户看不到「这个 skill 有待优化项,但卡片仍灰」的矛盾态。
+  const highCount = insights.filter((i) => i.severity === 'high').length;
+  const medCount = insights.filter((i) => i.severity === 'medium').length;
   if (ran === 0) {
+    if (highCount > 0) {
+      return { grade: 'unhealthy', score: null, label: lang === 'zh' ? '不健康' : 'Unhealthy', emoji: '🔴', color: 'red' };
+    }
+    if (medCount > 0) {
+      return { grade: 'fair', score: null, label: lang === 'zh' ? '待改进' : 'Fair', emoji: '🟡', color: 'yellow' };
+    }
     return { grade: 'unscored', score: null, label: lang === 'zh' ? '未评估' : 'Unscored', emoji: '⚪', color: 'gray' };
   }
 
@@ -97,13 +109,10 @@ export function assessHealth(entry: SkillIndexEntry, insights: Insight[], lang: 
   const hasWarn = (entry.doctor != null && entry.doctor.warnCount > 0)
     || (entry.eval != null && entry.eval.compositeScore != null && entry.eval.compositeScore < 3.5)
     || (entry.observe != null && entry.observe.healthBand === 'yellow');
-  const high = insights.filter((i) => i.severity === 'high').length;
-  const med = insights.filter((i) => i.severity === 'medium').length;
-
-  if (high > 0 || hasFail) {
+  if (highCount > 0 || hasFail) {
     return { grade: 'unhealthy', score, label: lang === 'zh' ? '不健康' : 'Unhealthy', emoji: '🔴', color: 'red' };
   }
-  if (med > 0 || hasWarn) {
+  if (medCount > 0 || hasWarn) {
     return { grade: 'fair', score, label: lang === 'zh' ? '待改进' : 'Fair', emoji: '🟡', color: 'yellow' };
   }
   if (insights.length === 0 && !hasWarn) {

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -23,9 +23,8 @@ const BAND_DOT: Record<'green' | 'yellow' | 'red' | 'gray', string> = {
 
 // v6 之前的 insight × audience × 三视角 抽象在 v7 详情页砍掉了,只保留 sample 维度
 // (renderEvalSection 直接读 evalReport.results,不再走 detectInsights / audience 分组)。
-// 相关常量(SEVERITY_ICON / AUDIENCE_INFO_* / PATCH_TARGET_*)等以后做诊断 / 调试 UI
+// 相关常量(SEVERITY_ICON / AUDIENCE_INFO_* / PATCH_TARGET_*)等以后做调试 UI
 // 需要时再恢复。
-
 
 function relTime(ts: string | null | undefined, lang: Lang): string {
   if (!ts) return lang === 'zh' ? '未跑' : 'never';

--- a/src/renderer/skill-list-renderer.ts
+++ b/src/renderer/skill-list-renderer.ts
@@ -63,7 +63,7 @@ function summarizeCard(entry: SkillIndexEntry, insights: Insight[]): CardSummary
   return { warnCount, highWarn, trendDir, trendDelta };
 }
 
-function renderHealthSummary(entry: SkillIndexEntry, lang: Lang): string {
+function renderHealthSummary(entry: SkillIndexEntry, insights: Insight[], lang: Lang): string {
   const parts: string[] = [];
   if (entry.doctor) {
     if (entry.doctor.failCount > 0) parts.push(lang === 'zh' ? `doctor ${entry.doctor.failCount} 项不通过` : `doctor ${entry.doctor.failCount} fail`);
@@ -83,7 +83,15 @@ function renderHealthSummary(entry: SkillIndexEntry, lang: Lang): string {
       : { green: 'stable', yellow: 'flaky', red: 'unstable' };
     parts.push(lang === 'zh' ? `observe ${labels[entry.observe.healthBand]}` : `observe ${labels[entry.observe.healthBand]}`);
   }
-  if (parts.length === 0) return lang === 'zh' ? '尚未运行任何检查' : 'No checks run yet';
+  if (parts.length === 0) {
+    // Diagnosis-only skill(例如只跑了 observe ingest 拿到 skill_md_not_found):没有三大
+    // snapshot 但有待优化项。显示「检出 N 个待优化」比「尚未运行任何检查」准确,
+    // 否则会跟 warn badge 的「N 待优化」对不上、用户看到矛盾态。
+    if (insights.length > 0) {
+      return lang === 'zh' ? `检出 ${insights.length} 个待优化项` : `${insights.length} insight(s) detected`;
+    }
+    return lang === 'zh' ? '尚未运行任何检查' : 'No checks run yet';
+  }
   return parts.join(lang === 'zh' ? '，' : ', ');
 }
 
@@ -141,7 +149,7 @@ function renderCard(entry: SkillIndexEntry, insights: Insight[], langQ: string, 
       ${warnBadge}
       ${renderTrendBadge(summary, lang)}
     </div>
-    <div class="sl-card-summary">${renderHealthSummary(entry, lang)}</div>
+    <div class="sl-card-summary">${renderHealthSummary(entry, insights, lang)}</div>
     <div class="sl-card-metrics">${renderMetrics(entry, lang)}</div>
   </a>`;
 }

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -17,6 +17,7 @@ import type { JobStore, ReportStore } from '../types/index.js';
 import type { SkillHealthReport } from '../observability/skill-health-analyzer.js';
 import { DEFAULT_OBSERVATIONS_DIR, findObservationInboxItem, formatObservationShow, queryObservationInbox } from '../observability/inbox.js';
 import { buildObservationInboxViewModel } from '../observability/inbox-view-model.js';
+import { activeStudioDiagnostics } from '../diagnosis/studio-projection.js';
 import { deleteObservationReviewState, loadObservationReviewState, updateObservationReviewState, type ObservationReviewStateUpdate } from '../observability/review-state.js';
 import type { AddressInfo } from 'node:net';
 
@@ -575,6 +576,24 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
         return;
       }
 
+      if (path === '/api/observations/diagnostics') {
+        const runs = await reportStore.list();
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir);
+        res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({
+          sourceCoverage: idx.diagnosisSummary.sourceCoverage,
+          summary: idx.diagnosisSummary,
+          bySkill: Object.fromEntries(idx.diagnosticsBySkill),
+          active: activeStudioDiagnostics({
+            schemaVersion: 1,
+            generatedAt: new Date().toISOString(),
+            sourceCoverage: idx.diagnosisSummary.sourceCoverage,
+            bySkill: Object.fromEntries(idx.diagnosticsBySkill),
+          }),
+        }));
+        return;
+      }
+
       if (path === '/api/observations/show') {
         const id = parsed.searchParams.get('id') || '';
         const item = id ? findObservationInboxItem(id, observationsDir) : null;
@@ -800,9 +819,25 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
       // list renderer 直接消费,不再每请求 N×detectInsights 重算。
       if (path === '/') {
         const runs = await reportStore.list();
-        const idx = buildSkillIndex(runs, analysesDir, doctorsDir);
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir);
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(renderSkillList(idx, lang));
+        return;
+      }
+
+      if (path === '/api/skills') {
+        const runs = await reportStore.list();
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir);
+        res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({
+          entries: idx.entries.map((entry) => ({
+            ...entry,
+            insightCount: idx.insightsBySkill.get(entry.skillName)?.length ?? 0,
+            diagnosisCount: idx.diagnosticsBySkill.get(entry.skillName)?.length ?? 0,
+          })),
+          summary: idx.summary,
+          diagnosisSummary: idx.diagnosisSummary,
+        }));
         return;
       }
 
@@ -812,7 +847,7 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
       if (skillDetailMatch) {
         const skillName = decodeURIComponent(skillDetailMatch[1]);
         const runs = await reportStore.list();
-        const idx = buildSkillIndex(runs, analysesDir, doctorsDir);
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir);
         const entry = idx.entries.find((e) => e.skillName === skillName);
         if (!entry) {
           res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
@@ -831,6 +866,26 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
         return;
       }
 
+      const skillDiagnosticsApiMatch = path.match(/^\/api\/skills\/(.+)\/diagnostics$/);
+      if (skillDiagnosticsApiMatch) {
+        const skillName = decodeURIComponent(skillDiagnosticsApiMatch[1]);
+        const runs = await reportStore.list();
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir);
+        const diagnostics = idx.diagnosticsBySkill.get(skillName);
+        if (!diagnostics) {
+          res.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
+          res.end(JSON.stringify({ error: 'skill diagnostics not found' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({
+          skillName,
+          sourceCoverage: idx.diagnosisSummary.sourceCoverage,
+          diagnostics,
+        }));
+        return;
+      }
+
       res.writeHead(404, { 'Content-Type': 'text/plain' });
       res.end('Not Found');
     } catch (err: unknown) {
@@ -843,6 +898,7 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
     if (server) return serverUrl!;
     if (!existsSync(reportsDir)) mkdirSync(reportsDir, { recursive: true });
     if (!existsSync(analysesDir)) mkdirSync(analysesDir, { recursive: true });
+    if (!existsSync(observationsDir)) mkdirSync(observationsDir, { recursive: true });
     if (!existsSync(jobsDir)) mkdirSync(jobsDir, { recursive: true });
 
     const p = port ?? Number(process.env.OMK_REPORT_PORT || DEFAULT_PORT);

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -439,6 +439,24 @@ export function buildSkillIndex(
       diagnostics: diagnosisBundle.bySkill[ent.skillName] ?? [],
     }));
   }
+
+  // 跨层口径统一:三大 snapshot(doctor / eval / observe)都空但 Diagnosis / Insight 投影出
+  // high / medium 信号的 skill,把 entry.band 从 gray 升级。否则 HTML renderer(assessHealth)
+  // 会把卡片标红、API(/api/skills)却返回 band='gray' summary.gray+=1,renderNextSteps 又会
+  // 追加「完全没报告」建议 —— 用户视角看到的是「红卡 + 待优化 N + 完全没报告」矛盾态。
+  for (const ent of entries) {
+    if (ent.band !== 'gray') continue;
+    const ins = insightsBySkill.get(ent.skillName) ?? [];
+    const hasHigh = ins.some((i) => i.severity === 'high');
+    const hasMed = ins.some((i) => i.severity === 'medium');
+    if (hasHigh) ent.band = 'red';
+    else if (hasMed) ent.band = 'yellow';
+  }
+  summary.red = entries.filter((e) => e.band === 'red').length;
+  summary.yellow = entries.filter((e) => e.band === 'yellow').length;
+  summary.green = entries.filter((e) => e.band === 'green').length;
+  summary.gray = entries.filter((e) => e.band === 'gray').length;
+
   const diagnosticsBySkill = new Map<string, Diagnosis[]>(
     Object.entries(diagnosisBundle.bySkill),
   );

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -22,6 +22,9 @@ import type { SkillHealthReport } from '../observability/skill-health-analyzer.j
 import type { DoctorReport, DoctorRuleResult, DoctorSkillStatus } from '../types/doctor.js';
 import { computeVerdict } from '../eval-core/verdict.js';
 import { detectInsights, type Insight } from './skill-insights.js';
+import { DEFAULT_OBSERVATIONS_DIR, loadLatestObservationInboxReports } from '../observability/inbox.js';
+import { buildStudioDiagnosisSummary, mergeDiagnosisBundles, type StudioDiagnosisSummary } from '../diagnosis/studio-projection.js';
+import type { Diagnosis } from '../diagnosis/types.js';
 
 // ── 模块级缓存:Studio 每次请求都跑 buildSkillIndex,扫盘成本随 skill 数线性,
 // 数据量大后列表 / 详情页响应变慢(PR #95 review P2-4 — cache 引入本身那一条)。
@@ -103,7 +106,7 @@ function safeDirJsonContentFingerprint(dir: string): string {
   return `${dir}|${dirMtimeMs}|${fileParts.join(',')}`;
 }
 
-function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, doctorsDir: string): string {
+function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, doctorsDir: string, observationsDir: string): string {
   // `d:` 跟 `o:` 前缀("d for doctors / o for observability analyses")沿用 pre-fix
   // 字面格式,避免外部 logging / debug 时 grep fingerprint 字符串的格式漂移。
   // 每一段的 right-hand-side 从旧的 "{dir-mtime}-{file-count}" 双标量升级成
@@ -112,7 +115,8 @@ function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, d
   const reportIds = reports.map((r) => `${r.id}:${r.meta?.timestamp ?? ''}`).join(',');
   const doctorsFp = safeDirJsonContentFingerprint(doctorsDir);
   const analysesFp = safeDirJsonContentFingerprint(analysesDir);
-  return `${reportIds}|d:${doctorsFp}|o:${analysesFp}`;
+  const observationsFp = safeDirJsonContentFingerprint(observationsDir);
+  return `${reportIds}|d:${doctorsFp}|o:${analysesFp}|obs:${observationsFp}`;
 }
 
 /** 测试 / 调试用:强制清掉 in-process skill-index 缓存。 */
@@ -186,6 +190,8 @@ export interface SkillIndex {
    *  本身共享同一 fingerprint 缓存(reports 数组 + dir mtime 任一变就 invalidate)。
    *  list 页 N×detectInsights 重算的 CPU 开销由此消除。 */
   insightsBySkill: Map<string, Insight[]>;
+  diagnosticsBySkill: Map<string, Diagnosis[]>;
+  diagnosisSummary: StudioDiagnosisSummary;
 }
 
 function sampleAllPassed(details: AssertionDetail[] | undefined): boolean {
@@ -335,9 +341,10 @@ export function buildSkillIndex(
   reports: ReportDocument[],
   analysesDir: string,
   doctorsDir: string,
+  observationsDir: string = DEFAULT_OBSERVATIONS_DIR,
 ): SkillIndex {
   // 命中缓存就直接返回(fingerprint 覆盖 reports + 两个 dir 的变化信号)
-  const fp = buildIndexFingerprint(reports, analysesDir, doctorsDir);
+  const fp = buildIndexFingerprint(reports, analysesDir, doctorsDir, observationsDir);
   if (_indexCache && _indexCache.fingerprint === fp) {
     return _indexCache.result;
   }
@@ -385,10 +392,14 @@ export function buildSkillIndex(
 
   // ── doctor 聚合(历史 list)──────────────────────────────
   const doctorBy = scanDoctorReports(doctorsDir);
+  const diagnosisBundle = mergeDiagnosisBundles(
+    loadLatestObservationInboxReports(observationsDir).flatMap((report) => report.diagnostics ? [report.diagnostics] : []),
+    new Date().toISOString(),
+  );
 
   // ── 合并 ──────────────────────────────────────────────────
   const allSkills = new Set<string>([
-    ...Object.keys(evalBy), ...Object.keys(observeBy), ...Object.keys(doctorBy),
+    ...Object.keys(evalBy), ...Object.keys(observeBy), ...Object.keys(doctorBy), ...Object.keys(diagnosisBundle.bySkill),
   ]);
   const entries: SkillIndexEntry[] = [];
   for (const name of allSkills) {
@@ -424,10 +435,16 @@ export function buildSkillIndex(
   const insightsBySkill = new Map<string, Insight[]>();
   for (const ent of entries) {
     const evalReport = ent.eval ? reports.find((r) => r.id === ent.eval!.reportId && r.kind === 'evaluation') as EvaluationReport | undefined : undefined;
-    insightsBySkill.set(ent.skillName, detectInsights(ent, evalReport ?? null));
+    insightsBySkill.set(ent.skillName, detectInsights(ent, evalReport ?? null, {
+      diagnostics: diagnosisBundle.bySkill[ent.skillName] ?? [],
+    }));
   }
+  const diagnosticsBySkill = new Map<string, Diagnosis[]>(
+    Object.entries(diagnosisBundle.bySkill),
+  );
+  const diagnosisSummary = buildStudioDiagnosisSummary(diagnosisBundle);
 
-  const result: SkillIndex = { entries, summary, insightsBySkill };
+  const result: SkillIndex = { entries, summary, insightsBySkill, diagnosticsBySkill, diagnosisSummary };
   _indexCache = { fingerprint: fp, result };
   return result;
 }

--- a/src/server/skill-insights.ts
+++ b/src/server/skill-insights.ts
@@ -871,23 +871,29 @@ export function detectInsights(
   // 只看自己 variant 那部分数据,否则 /skills/<treatment-2> 会看到 treatment-1 的
   // failureModes / coverage / illustrations / verdict。
   const variantName = entry.eval?.variantName ?? null;
-  // 只有真正拿到 observe 侧 Diagnosis（非空）时才屏蔽 legacy observe 检测路径。
-  // 空数组（调用方默认传 `diagnosisBundle.bySkill[name] ?? []`）说明该 skill 没有 Diagnosis
-  // 投影,此时仍要走 legacy detectProductionInstability / detectSkillTooLong 等以 entry.observe
-  // 为输入的 detector,否则 dual-run 期间 observe 有数据但 mapper 没产出对应 Diagnosis 的 skill
-  // 会丢失诊断。
-  const hasDiagnostics = (options.diagnostics?.length ?? 0) > 0;
-  const diagnosisInsights = hasDiagnostics ? projectDiagnosticsToInsights(options.diagnostics!) : [];
-  const observeForLegacy = hasDiagnostics ? null : entry.observe;
+  // Diagnosis 投影 → legacy detector 去重:只跳过「Diagnosis 已经覆盖了等价 category」的 detector,
+  // 而不是「该 skill 有任何 Diagnosis 就一刀切关掉所有 legacy observe-side 检测」。
+  //
+  // 当前 buildObserveDiagnosticsFromReport 只消费 inbox 的 skill-chain / runtime checks /
+  // problemPatterns / reviewerFindings,**不**消费 SkillHealthReport 的 failureRate / gapRate /
+  // coverage 等聚合指标。所以一个 skill 即便因 `hardrules_not_declared` 之类有 Diagnosis,
+  // 也仍可能完全没有 `production-instability` / `coverage-gap` 等价 Diagnosis,这种情况下
+  // legacy detectProductionInstability / detectCoverageGap 必须继续跑,否则信号会被默默丢掉。
+  const diagnosisInsights = options.diagnostics?.length
+    ? projectDiagnosticsToInsights(options.diagnostics)
+    : [];
+  const coveredCategories = new Set<InsightCategory>(diagnosisInsights.map((i) => i.category));
+  const skipIfCovered = (category: InsightCategory, run: () => Insight | null): Insight | null =>
+    coveredCategories.has(category) ? null : run();
   const out: Insight[] = [];
   const detectors: Array<() => Insight | null> = [
     () => detectEnvironmentBlocked(evalReport, variantName),
-    () => detectSkillDocGap(entry.doctor, evalReport, observeForLegacy, variantName),
+    () => skipIfCovered('skill-doc-gap', () => detectSkillDocGap(entry.doctor, evalReport, entry.observe, variantName)),
     () => detectFailureModeSkillIssue(evalReport, variantName),
-    () => detectCoverageGap(evalReport, observeForLegacy, variantName),
-    () => detectProductionInstability(entry.doctor, observeForLegacy),
-    () => detectSkillTooLong(entry.doctor, observeForLegacy),
-    () => detectOmkDoctorBlindspot(entry.doctor, evalReport, variantName),
+    () => skipIfCovered('coverage-gap', () => detectCoverageGap(evalReport, entry.observe, variantName)),
+    () => skipIfCovered('production-instability', () => detectProductionInstability(entry.doctor, entry.observe)),
+    () => skipIfCovered('skill-too-long', () => detectSkillTooLong(entry.doctor, entry.observe)),
+    () => skipIfCovered('omk-doctor-blindspot', () => detectOmkDoctorBlindspot(entry.doctor, evalReport, variantName)),
   ];
   for (const detect of detectors) {
     const ins = detect();

--- a/src/server/skill-insights.ts
+++ b/src/server/skill-insights.ts
@@ -23,6 +23,7 @@
  */
 import type { EvaluationReport, VariantResult, ToolCallInfo } from '../types/index.js';
 import type { SkillIndexEntry, SkillDoctorSnapshot, SkillObserveSnapshot, SkillEvalSnapshot } from './skill-index.js';
+import type { Diagnosis, DiagnosisAudience, DiagnosisLifecycle, DiagnosisSeverity, DiagnosisType } from '../diagnosis/types.js';
 
 export type InsightCategory =
   | 'environment-blocked-mocks'
@@ -101,6 +102,14 @@ export interface Insight {
   recommendations: InsightRecommendation[];
   /** 关联到 timeline 哪些阶段元素 — renderer 据此在阶段卡内插入 #N 徽章。 */
   stageRefs?: InsightStageRefs;
+}
+
+export interface DetectInsightsOptions {
+  /**
+   * Diagnosis 是 observe 侧迁移后的主数据源。传入该字段时,observe 相关 insight
+   * 从 Diagnosis 投影,不再从 entry.observe 重复推断,避免维护者新增规则时双写。
+   */
+  diagnostics?: Diagnosis[];
 }
 
 // ────────── helpers ──────────
@@ -764,30 +773,114 @@ export const skillAntiPatternComposer: ComposerRule = {
 // ────────── 入口 ──────────
 
 const SEVERITY_RANK: Record<InsightSeverity, number> = { high: 3, medium: 2, low: 1 };
+const ACTIVE_DIAGNOSIS_LIFECYCLES = new Set<DiagnosisLifecycle>(['detected', 'candidate', 'confirmed', 'stale']);
+
+function insightSeverityFromDiagnosis(severity: DiagnosisSeverity): InsightSeverity {
+  if (severity === 'high') return 'high';
+  if (severity === 'medium') return 'medium';
+  return 'low';
+}
+
+function insightAudienceFromDiagnosis(audience: DiagnosisAudience): InsightAudience {
+  if (audience === 'sample-author') return 'sample-author';
+  if (audience === 'omk-maintainer') return 'omk-maintainer';
+  return 'skill-author';
+}
+
+function insightCategoryFromDiagnosis(type: DiagnosisType, signal: string): InsightCategory {
+  if (type === 'definition_gap' || type === 'standard_candidate') return 'skill-doc-gap';
+  if (type === 'eval_failure') return 'failure-mode-skill';
+  if (type === 'sample_design_issue') return 'environment-blocked-mocks';
+  if (type === 'doctor_gap') return 'omk-doctor-blindspot';
+  if (type === 'user_feedback_pattern') return 'production-instability';
+  if (signal.includes('gap') || signal.includes('coverage')) return 'coverage-gap';
+  if (signal.includes('tool_failure') || signal.includes('tool')) return 'production-instability';
+  return 'other';
+}
+
+function patchTargetFromDiagnosis(target: NonNullable<Diagnosis['patch']>['target']): InsightPatch['target'] {
+  if (target === 'definition') return 'skill';
+  return target;
+}
+
+function projectDiagnosisToInsight(diagnosis: Diagnosis): Insight {
+  const severity = insightSeverityFromDiagnosis(diagnosis.severity);
+  const recommendations: InsightRecommendation[] = [];
+  if (diagnosis.recommendation || diagnosis.patch) {
+    recommendations.push({
+      action: diagnosis.recommendation ?? diagnosis.command ?? '查看诊断证据并修正对应定义',
+      priority: severity,
+      ...(diagnosis.patch ? {
+        patch: {
+          target: patchTargetFromDiagnosis(diagnosis.patch.target),
+          location: diagnosis.patch.location,
+          snippet: diagnosis.patch.snippet,
+        },
+      } : {}),
+    });
+  }
+  if (diagnosis.command && !recommendations.some((r) => r.action === diagnosis.command)) {
+    recommendations.push({ action: diagnosis.command, priority: severity });
+  }
+
+  return {
+    id: `diagnosis:${diagnosis.id}`,
+    category: insightCategoryFromDiagnosis(diagnosis.type, diagnosis.signal),
+    audience: insightAudienceFromDiagnosis(diagnosis.audience),
+    title: diagnosis.title,
+    description: diagnosis.summary ?? diagnosis.evidenceSummary,
+    severity,
+    affectedCount: diagnosis.occurrenceCount,
+    stageRefs: { observeRefs: [diagnosis.signal] },
+    evidence: [{
+      perspective: 'observe',
+      status: 'flagged',
+      message: diagnosis.evidenceSummary ?? diagnosis.summary ?? diagnosis.title,
+      ref: diagnosis.occurrences[0]?.sourceId ?? diagnosis.stableKey,
+    }],
+    recommendations,
+  };
+}
+
+export function projectDiagnosticsToInsights(diagnostics: Diagnosis[]): Insight[] {
+  return diagnostics
+    .filter((diagnosis) => ACTIVE_DIAGNOSIS_LIFECYCLES.has(diagnosis.lifecycle))
+    .map(projectDiagnosisToInsight)
+    .sort((a, b) => {
+      const sa = SEVERITY_RANK[a.severity];
+      const sb = SEVERITY_RANK[b.severity];
+      if (sa !== sb) return sb - sa;
+      return b.affectedCount - a.affectedCount;
+    });
+}
 
 export function detectInsights(
   entry: SkillIndexEntry,
   evalReport: EvaluationReport | null,
+  options: DetectInsightsOptions = {},
 ): Insight[] {
   // entry.eval.variantName 是当前 skill entry 对应的 treatment variant 名;
   // multi-treatment 报告里同一份 evalReport 会被 N 个 entry 共用,每个 entry 都该
   // 只看自己 variant 那部分数据,否则 /skills/<treatment-2> 会看到 treatment-1 的
   // failureModes / coverage / illustrations / verdict。
   const variantName = entry.eval?.variantName ?? null;
+  const diagnosisInsights = options.diagnostics ? projectDiagnosticsToInsights(options.diagnostics) : [];
+  const observeForLegacy = options.diagnostics ? null : entry.observe;
   const out: Insight[] = [];
   const detectors: Array<() => Insight | null> = [
     () => detectEnvironmentBlocked(evalReport, variantName),
-    () => detectSkillDocGap(entry.doctor, evalReport, entry.observe, variantName),
+    () => detectSkillDocGap(entry.doctor, evalReport, observeForLegacy, variantName),
     () => detectFailureModeSkillIssue(evalReport, variantName),
-    () => detectCoverageGap(evalReport, entry.observe, variantName),
-    () => detectProductionInstability(entry.doctor, entry.observe),
-    () => detectSkillTooLong(entry.doctor, entry.observe),
+    () => detectCoverageGap(evalReport, observeForLegacy, variantName),
+    () => detectProductionInstability(entry.doctor, observeForLegacy),
+    () => detectSkillTooLong(entry.doctor, observeForLegacy),
     () => detectOmkDoctorBlindspot(entry.doctor, evalReport, variantName),
   ];
   for (const detect of detectors) {
     const ins = detect();
     if (ins) out.push(ins);
   }
+  out.push(...diagnosisInsights);
   out.sort((a, b) => {
     const sa = SEVERITY_RANK[a.severity];
     const sb = SEVERITY_RANK[b.severity];

--- a/src/server/skill-insights.ts
+++ b/src/server/skill-insights.ts
@@ -793,8 +793,15 @@ function insightCategoryFromDiagnosis(type: DiagnosisType, signal: string): Insi
   if (type === 'sample_design_issue') return 'environment-blocked-mocks';
   if (type === 'doctor_gap') return 'omk-doctor-blindspot';
   if (type === 'user_feedback_pattern') return 'production-instability';
-  if (signal.includes('gap') || signal.includes('coverage')) return 'coverage-gap';
-  if (signal.includes('tool_failure') || signal.includes('tool')) return 'production-instability';
+  // runtime_issue:运行时执行偏差,signal 子串里能拆出 coverage/gap → coverage-gap,
+  // 工具失败 → production-instability,其它兜底为 production-instability(runtime 偏差对用户来说
+  // 最终都体现为生产稳定性)。
+  if (type === 'runtime_issue') {
+    if (signal.includes('gap') || signal.includes('coverage')) return 'coverage-gap';
+    return 'production-instability';
+  }
+  // maintenance_issue:omk 维护者侧问题(judge / executor / 工具链等),归到 doctor 盲点。
+  if (type === 'maintenance_issue') return 'omk-doctor-blindspot';
   return 'other';
 }
 
@@ -864,8 +871,14 @@ export function detectInsights(
   // 只看自己 variant 那部分数据,否则 /skills/<treatment-2> 会看到 treatment-1 的
   // failureModes / coverage / illustrations / verdict。
   const variantName = entry.eval?.variantName ?? null;
-  const diagnosisInsights = options.diagnostics ? projectDiagnosticsToInsights(options.diagnostics) : [];
-  const observeForLegacy = options.diagnostics ? null : entry.observe;
+  // 只有真正拿到 observe 侧 Diagnosis（非空）时才屏蔽 legacy observe 检测路径。
+  // 空数组（调用方默认传 `diagnosisBundle.bySkill[name] ?? []`）说明该 skill 没有 Diagnosis
+  // 投影,此时仍要走 legacy detectProductionInstability / detectSkillTooLong 等以 entry.observe
+  // 为输入的 detector,否则 dual-run 期间 observe 有数据但 mapper 没产出对应 Diagnosis 的 skill
+  // 会丢失诊断。
+  const hasDiagnostics = (options.diagnostics?.length ?? 0) > 0;
+  const diagnosisInsights = hasDiagnostics ? projectDiagnosticsToInsights(options.diagnostics!) : [];
+  const observeForLegacy = hasDiagnostics ? null : entry.observe;
   const out: Insight[] = [];
   const detectors: Array<() => Insight | null> = [
     () => detectEnvironmentBlocked(evalReport, variantName),

--- a/src/server/skill-insights.ts
+++ b/src/server/skill-insights.ts
@@ -23,7 +23,7 @@
  */
 import type { EvaluationReport, VariantResult, ToolCallInfo } from '../types/index.js';
 import type { SkillIndexEntry, SkillDoctorSnapshot, SkillObserveSnapshot, SkillEvalSnapshot } from './skill-index.js';
-import type { Diagnosis, DiagnosisAudience, DiagnosisLifecycle, DiagnosisSeverity, DiagnosisType } from '../diagnosis/types.js';
+import { isActiveDiagnosisLifecycle, type Diagnosis, type DiagnosisAudience, type DiagnosisSeverity, type DiagnosisType } from '../diagnosis/types.js';
 
 export type InsightCategory =
   | 'environment-blocked-mocks'
@@ -773,7 +773,6 @@ export const skillAntiPatternComposer: ComposerRule = {
 // ────────── 入口 ──────────
 
 const SEVERITY_RANK: Record<InsightSeverity, number> = { high: 3, medium: 2, low: 1 };
-const ACTIVE_DIAGNOSIS_LIFECYCLES = new Set<DiagnosisLifecycle>(['detected', 'candidate', 'confirmed', 'stale']);
 
 function insightSeverityFromDiagnosis(severity: DiagnosisSeverity): InsightSeverity {
   if (severity === 'high') return 'high';
@@ -851,7 +850,7 @@ function projectDiagnosisToInsight(diagnosis: Diagnosis): Insight {
 
 export function projectDiagnosticsToInsights(diagnostics: Diagnosis[]): Insight[] {
   return diagnostics
-    .filter((diagnosis) => ACTIVE_DIAGNOSIS_LIFECYCLES.has(diagnosis.lifecycle))
+    .filter((diagnosis) => isActiveDiagnosisLifecycle(diagnosis.lifecycle))
     .map(projectDiagnosisToInsight)
     .sort((a, b) => {
       const sa = SEVERITY_RANK[a.severity];

--- a/src/server/skill-insights.ts
+++ b/src/server/skill-insights.ts
@@ -871,29 +871,33 @@ export function detectInsights(
   // 只看自己 variant 那部分数据,否则 /skills/<treatment-2> 会看到 treatment-1 的
   // failureModes / coverage / illustrations / verdict。
   const variantName = entry.eval?.variantName ?? null;
-  // Diagnosis 投影 → legacy detector 去重:只跳过「Diagnosis 已经覆盖了等价 category」的 detector,
-  // 而不是「该 skill 有任何 Diagnosis 就一刀切关掉所有 legacy observe-side 检测」。
+  // Dual-run 期间不做去重 — legacy detector + Diagnosis 投影都跑。原因:
   //
-  // 当前 buildObserveDiagnosticsFromReport 只消费 inbox 的 skill-chain / runtime checks /
-  // problemPatterns / reviewerFindings,**不**消费 SkillHealthReport 的 failureRate / gapRate /
-  // coverage 等聚合指标。所以一个 skill 即便因 `hardrules_not_declared` 之类有 Diagnosis,
-  // 也仍可能完全没有 `production-instability` / `coverage-gap` 等价 Diagnosis,这种情况下
-  // legacy detectProductionInstability / detectCoverageGap 必须继续跑,否则信号会被默默丢掉。
+  // 1. InsightCategory 是呈现层分类,不是数据源等价语义。`runtime_workflow_review`
+  //    Diagnosis 投影后 category 是 `production-instability`,但它跟 legacy
+  //    `detectProductionInstability` 读的 `entry.observe.failureRate >= 0.4` 不等价 —
+  //    按 category 去重会误关 SkillHealthReport 信号。`definition_gap` → `skill-doc-gap`
+  //    同理:legacy detectSkillDocGap 还会吃 doctor dependency / eval sample 失败证据,
+  //    Diagnosis 没替代这部分。
+  //
+  // 2. legacy id 是固定字符串(`production-instability` 等),Diagnosis 投影 id 是
+  //    `diagnosis:<hash>`,二者不冲突,UI 同时显示「来自 observe inbox 的具体 runtime
+  //    警告」+「来自 SkillHealthReport 的高失败率聚合」对用户也合理 —— 两条不同数据源。
+  //
+  // 等 doctor / eval producer 也迁成 Diagnosis、`DiagnosisBundle.sourceCoverage` 完整后,
+  // 单独 PR 引入基于 stable target / source 的精确去重(不再用 category 这种粗粒度)。
   const diagnosisInsights = options.diagnostics?.length
     ? projectDiagnosticsToInsights(options.diagnostics)
     : [];
-  const coveredCategories = new Set<InsightCategory>(diagnosisInsights.map((i) => i.category));
-  const skipIfCovered = (category: InsightCategory, run: () => Insight | null): Insight | null =>
-    coveredCategories.has(category) ? null : run();
   const out: Insight[] = [];
   const detectors: Array<() => Insight | null> = [
     () => detectEnvironmentBlocked(evalReport, variantName),
-    () => skipIfCovered('skill-doc-gap', () => detectSkillDocGap(entry.doctor, evalReport, entry.observe, variantName)),
+    () => detectSkillDocGap(entry.doctor, evalReport, entry.observe, variantName),
     () => detectFailureModeSkillIssue(evalReport, variantName),
-    () => skipIfCovered('coverage-gap', () => detectCoverageGap(evalReport, entry.observe, variantName)),
-    () => skipIfCovered('production-instability', () => detectProductionInstability(entry.doctor, entry.observe)),
-    () => skipIfCovered('skill-too-long', () => detectSkillTooLong(entry.doctor, entry.observe)),
-    () => skipIfCovered('omk-doctor-blindspot', () => detectOmkDoctorBlindspot(entry.doctor, evalReport, variantName)),
+    () => detectCoverageGap(evalReport, entry.observe, variantName),
+    () => detectProductionInstability(entry.doctor, entry.observe),
+    () => detectSkillTooLong(entry.doctor, entry.observe),
+    () => detectOmkDoctorBlindspot(entry.doctor, evalReport, variantName),
   ];
   for (const detect of detectors) {
     const ins = detect();

--- a/test/diagnosis/observe-mapper.test.ts
+++ b/test/diagnosis/observe-mapper.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { buildObserveDiagnostics } from '../../src/diagnosis/observe-mapper.js';
+import { buildObserveDiagnostics, maxLifecycle } from '../../src/diagnosis/observe-mapper.js';
 import { activeStudioDiagnostics, buildStudioDiagnosisSummary } from '../../src/diagnosis/studio-projection.js';
 
 describe('buildObserveDiagnostics', () => {
@@ -128,5 +128,26 @@ describe('buildObserveDiagnostics', () => {
     const active = activeStudioDiagnostics(bundle);
     assert.equal(active.length, 1);
     assert.equal(active[0].signal, 'skill_md_not_found');
+  });
+});
+
+describe('maxLifecycle', () => {
+  it('终态(resolved / rejected)优先于自动检出态', () => {
+    // 作者确认过的 standard(resolved)不能被新来的自动 detected 信号覆盖掉。
+    assert.equal(maxLifecycle('resolved', 'detected'), 'resolved');
+    assert.equal(maxLifecycle('detected', 'resolved'), 'resolved');
+    assert.equal(maxLifecycle('rejected', 'detected'), 'rejected');
+    assert.equal(maxLifecycle('rejected', 'candidate'), 'rejected');
+  });
+
+  it('两个终态同时存在时 resolved 胜出', () => {
+    assert.equal(maxLifecycle('resolved', 'rejected'), 'resolved');
+    assert.equal(maxLifecycle('rejected', 'resolved'), 'resolved');
+  });
+
+  it('active 态之间按主动性排序:detected > candidate > confirmed > stale', () => {
+    assert.equal(maxLifecycle('detected', 'candidate'), 'detected');
+    assert.equal(maxLifecycle('candidate', 'confirmed'), 'candidate');
+    assert.equal(maxLifecycle('confirmed', 'stale'), 'confirmed');
   });
 });

--- a/test/diagnosis/observe-mapper.test.ts
+++ b/test/diagnosis/observe-mapper.test.ts
@@ -201,3 +201,23 @@ describe('mergeDiagnosisBundles', () => {
     assert.equal(merged.sourceCoverage.eval, false);
   });
 });
+
+describe('activeStudioDiagnostics — lifecycle 口径', () => {
+  it('confirmed / resolved / rejected 都不算 active,跟 Insight 投影口径一致', () => {
+    // shared isActiveDiagnosisLifecycle 只放 detected / candidate / stale。
+    // 这条 case 防止两个投影口径再分叉。
+    const bundle = buildObserveDiagnostics({
+      generatedAt: 't',
+      derivedStandards: [
+        { skillName: 'a', id: 's1', kind: 'hard_rule_candidate', status: 'pending_review', title: 'pending(candidate)' },
+        { skillName: 'a', id: 's2', kind: 'hard_rule_candidate', status: 'author_confirmed', title: 'confirmed(→resolved)' },
+        { skillName: 'a', id: 's3', kind: 'hard_rule_candidate', status: 'rejected', title: 'rejected' },
+      ],
+    });
+    const active = activeStudioDiagnostics(bundle);
+    const titles = active.map((d) => d.title);
+    assert.ok(titles.includes('pending(candidate)'), 'candidate 算 active');
+    assert.equal(titles.includes('confirmed(→resolved)'), false, 'resolved 不算 active');
+    assert.equal(titles.includes('rejected'), false, 'rejected 不算 active');
+  });
+});

--- a/test/diagnosis/observe-mapper.test.ts
+++ b/test/diagnosis/observe-mapper.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { buildObserveDiagnostics, maxLifecycle } from '../../src/diagnosis/observe-mapper.js';
-import { activeStudioDiagnostics, buildStudioDiagnosisSummary } from '../../src/diagnosis/studio-projection.js';
+import { activeStudioDiagnostics, buildStudioDiagnosisSummary, mergeDiagnosisBundles } from '../../src/diagnosis/studio-projection.js';
 
 describe('buildObserveDiagnostics', () => {
   it('maps observe source types into a shared diagnosis bundle', () => {
@@ -156,5 +156,48 @@ describe('maxLifecycle', () => {
     assert.equal(maxLifecycle('detected', 'candidate'), 'detected');
     assert.equal(maxLifecycle('candidate', 'confirmed'), 'candidate');
     assert.equal(maxLifecycle('confirmed', 'stale'), 'confirmed');
+  });
+});
+
+describe('mergeDiagnosisBundles', () => {
+  it('合并相同 stableKey 时累加 occurrenceCount,保留聚合型语义', () => {
+    // 两个 bundle 都含同 problemPattern(同 stableKey),分别 occurrenceCount = 3 和 4。
+    // 期望合并后 occurrenceCount = 7,不是 occurrences.length = 2。
+    const bundleA = buildObserveDiagnostics({
+      generatedAt: '2026-05-15T00:00:00.000Z',
+      problemPatterns: [{
+        skillName: 'audit',
+        bucket: 'workflow_mismatch',
+        patternKey: 'wf-key',
+        signalTypes: ['user_correction'],
+        count: 3,
+        sessionCount: 2,
+      }],
+    });
+    const bundleB = buildObserveDiagnostics({
+      generatedAt: '2026-05-15T00:01:00.000Z',
+      problemPatterns: [{
+        skillName: 'audit',
+        bucket: 'workflow_mismatch',
+        patternKey: 'wf-key',
+        signalTypes: ['user_correction'],
+        count: 4,
+        sessionCount: 3,
+      }],
+    });
+    const merged = mergeDiagnosisBundles([bundleA, bundleB]);
+    const diag = merged.bySkill.audit.find((d) => d.signal === 'user_correction');
+    assert.ok(diag);
+    assert.equal(diag.occurrenceCount, 7, '应累加 3 + 4,不是 occurrences.length=2');
+    assert.equal(diag.occurrences.length, 2, '源 occurrence 条数确实是 2');
+  });
+
+  it('sourceCoverage 用 OR 合并', () => {
+    const bundleA = buildObserveDiagnostics({ generatedAt: 't1' });
+    const bundleB = buildObserveDiagnostics({ generatedAt: 't2' });
+    const merged = mergeDiagnosisBundles([bundleA, bundleB]);
+    assert.equal(merged.sourceCoverage.observe, true);
+    assert.equal(merged.sourceCoverage.doctor, false);
+    assert.equal(merged.sourceCoverage.eval, false);
   });
 });

--- a/test/diagnosis/observe-mapper.test.ts
+++ b/test/diagnosis/observe-mapper.test.ts
@@ -107,6 +107,13 @@ describe('buildObserveDiagnostics', () => {
     const confirmed = diagnoses.find((item) => item.signal === 'hard_rule_candidate');
     assert.ok(confirmed);
     assert.equal(confirmed.lifecycle, 'resolved');
+
+    // problemPattern 投影后 occurrenceCount 应该用 pattern.count(3),不是默认 1。
+    // 这是给 Studio 排序和 affectedCount 的关键:3 个 session 反复出现的 pattern 不能跟
+    // 单点 advisory 一样按 1 算。
+    const pattern = diagnoses.find((item) => item.signal === 'user_correction');
+    assert.ok(pattern);
+    assert.equal(pattern.occurrenceCount, 3, 'problem pattern occurrenceCount 应该等于 pattern.count');
   });
 
   it('builds studio projection without changing UI renderers', () => {

--- a/test/diagnosis/observe-mapper.test.ts
+++ b/test/diagnosis/observe-mapper.test.ts
@@ -1,0 +1,132 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { buildObserveDiagnostics } from '../../src/diagnosis/observe-mapper.js';
+import { activeStudioDiagnostics, buildStudioDiagnosisSummary } from '../../src/diagnosis/studio-projection.js';
+
+describe('buildObserveDiagnostics', () => {
+  it('maps observe source types into a shared diagnosis bundle', () => {
+    const bundle = buildObserveDiagnostics({
+      generatedAt: '2026-05-15T00:00:00.000Z',
+      skillChainAdvisories: [
+        {
+          skillName: 'prd-create',
+          code: 'workflows_not_declared',
+          message: 'workflow structure was detected but not declared',
+          exampleYaml: 'workflow:\n  - step: write demo',
+        },
+      ],
+      runtimeChecks: [
+        {
+          skillName: 'prd-create',
+          id: 'workflow-step-1',
+          kind: 'workflowNode',
+          status: 'manual_review',
+          title: 'Workflow node needs review',
+          reason: 'runtime did not show the expected step',
+          evidenceRefs: [{ id: 'e1', kind: 'message', sessionId: 's1', messageIndex: 3 }],
+        },
+        {
+          skillName: 'prd-create',
+          id: 'hardrule-ok',
+          kind: 'hardRule',
+          status: 'passed',
+        },
+      ],
+      problemPatterns: [
+        {
+          skillName: 'prd-create',
+          bucket: 'workflow_mismatch',
+          patternKey: 'workflow-mismatch:demo',
+          signalTypes: ['user_correction'],
+          count: 3,
+          sessionCount: 2,
+          recentSessionIds: ['s1', 's2'],
+        },
+      ],
+      reviewerFindings: [
+        {
+          skillName: 'prd-create',
+          id: 'finding-1',
+          source: 'deterministic_rule',
+          level: 'attention',
+          ruleSource: 'final_delivery_absent',
+          ruleVersion: 'v1',
+          evidenceRefs: [{ id: 'e2', kind: 'message', sessionId: 's2', messageIndex: 9 }],
+        },
+        {
+          skillName: 'prd-create',
+          id: 'finding-2',
+          source: 'deterministic_rule',
+          level: 'low',
+          ruleSource: 'final_delivery_absent',
+          ruleVersion: 'v1',
+          evidenceRefs: [{ id: 'e3', kind: 'message', sessionId: 's3', messageIndex: 10 }],
+        },
+        {
+          skillName: 'prd-create',
+          id: 'finding-ignored',
+          source: 'deterministic_rule',
+          level: 'info',
+          ruleSource: 'no_priority_signal',
+        },
+      ],
+      derivedStandards: [
+        {
+          skillName: 'prd-create',
+          id: 'standard-1',
+          kind: 'workflow_candidate',
+          status: 'pending_review',
+          title: 'Demo generation workflow should be declared',
+          source: 'llm_soft_standard',
+          confidence: 0.7,
+        },
+        {
+          skillName: 'prd-create',
+          id: 'standard-2',
+          kind: 'hard_rule_candidate',
+          status: 'author_confirmed',
+          title: 'Use source document before generating demo',
+          source: 'manual',
+        },
+      ],
+    });
+
+    assert.deepEqual(bundle.sourceCoverage, { observe: true, doctor: false, eval: false });
+    const diagnoses = bundle.bySkill['prd-create'];
+    assert.ok(diagnoses);
+    assert.ok(diagnoses.some((item) => item.signal === 'workflows_not_declared'));
+    assert.ok(diagnoses.some((item) => item.signal === 'runtime_workflow_review'));
+    assert.ok(diagnoses.some((item) => item.signal === 'user_correction'));
+    assert.ok(diagnoses.some((item) => item.signal === 'workflow_candidate'));
+
+    const reviewer = diagnoses.find((item) => item.signal === 'final_delivery_absent');
+    assert.ok(reviewer);
+    assert.equal(reviewer.occurrenceCount, 2);
+    assert.equal(reviewer.occurrences[0].sourceKind, 'final_delivery_absent');
+
+    const confirmed = diagnoses.find((item) => item.signal === 'hard_rule_candidate');
+    assert.ok(confirmed);
+    assert.equal(confirmed.lifecycle, 'resolved');
+  });
+
+  it('builds studio projection without changing UI renderers', () => {
+    const bundle = buildObserveDiagnostics({
+      generatedAt: '2026-05-15T00:00:00.000Z',
+      skillChainAdvisories: [
+        { skillName: 'audit', code: 'skill_md_not_found' },
+      ],
+      derivedStandards: [
+        { skillName: 'audit', id: 'confirmed-1', kind: 'hard_rule_candidate', status: 'author_confirmed', title: 'Confirmed rule' },
+      ],
+    });
+
+    const summary = buildStudioDiagnosisSummary(bundle);
+    assert.equal(summary.totalCount, 2);
+    assert.equal(summary.partial, true);
+    assert.equal(summary.bySkill.audit, 2);
+
+    const active = activeStudioDiagnostics(bundle);
+    assert.equal(active.length, 1);
+    assert.equal(active[0].signal, 'skill_md_not_found');
+  });
+});

--- a/test/diagnosis/observe-producer.test.ts
+++ b/test/diagnosis/observe-producer.test.ts
@@ -1,0 +1,147 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildObserveDiagnosticsFromReport } from '../../src/diagnosis/observe-producer.js';
+import type { ObservationInboxReport } from '../../src/observability/inbox.js';
+
+describe('buildObserveDiagnosticsFromReport', () => {
+  it('uses real observe skill-chain, runtime checks, patterns, and rule findings', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-observe-diagnosis-'));
+    try {
+      const skillDir = join(dir, 'skills', 'audit');
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(join(skillDir, 'SKILL.md'), `---
+hardRules:
+  - id: read-domain
+    rule: 必须读取领域知识文件
+    expectedBehavior: 使用 Read 读取 domain 文件
+workflows:
+  - id: main
+    nodes:
+      - id: upload
+        action: 上传产物
+---
+
+# audit
+`);
+      const report = {
+        kind: 'observe-inbox',
+        schemaVersion: 1,
+        meta: {
+          tracePath: '/tmp/synthetic-trace',
+          generatedAt: '2026-05-15T00:00:00.000Z',
+          segmentCount: 1,
+          itemCount: 0,
+          skillInvocationCounts: { audit: 1 },
+          skillSessionCounts: { audit: 1 },
+        },
+        items: [],
+        experience: {
+          kind: 'observe-experience',
+          schemaVersion: 1,
+          scope: 'evidence-only',
+          generatedAt: '2026-05-15T00:00:00.000Z',
+          meta: {
+            sessionCount: 1,
+            skillCount: 1,
+            invocationCount: 1,
+            goalSliceCount: 1,
+            noteCodes: ['no_llm_judge', 'deterministic_assistive_inference'],
+          },
+          goalSlices: [],
+          invocations: [{
+            skillName: 'audit',
+            toolCounts: { Read: 1 },
+            indicators: { toolCallCount: 1, toolFailureCount: 0 },
+            timeline: [
+              { id: 'e1', kind: 'tool_use', sourceTrace: '/tmp/synthetic.jsonl', sessionId: 's1', order: 1, toolName: 'Read', label: 'tool_use Read', snippet: '{"file_path":"domain.md"}' },
+            ],
+          }],
+          sessions: [],
+          skills: [{
+            skillName: 'audit',
+            invocationCount: 1,
+            sessionCount: 1,
+            sourceKinds: ['claude'],
+            entrypoints: [],
+            entrypointCounts: {},
+            sourceMetadataCounts: { channels: {}, senders: {}, aimaCommands: {}, providers: {}, models: {} },
+            attributionCounts: {},
+            pluginNames: [],
+            rawSkillRefs: [],
+            commandNames: [],
+            toolCounts: { Read: 1 },
+            firstSeen: '2026-05-15T00:00:00.000Z',
+            lastSeen: '2026-05-15T00:01:00.000Z',
+            reviewFirstSessionCount: 1,
+            sampleReviewSessionCount: 0,
+            indicators: {
+              userMessageCount: 1,
+              userFollowUpCount: 0,
+              userCorrectionCount: 1,
+              userInterruptionCount: 0,
+              negativeFeedbackCount: 0,
+              positiveFeedbackCount: 0,
+              userGoalShiftCount: 0,
+              hardRuleTextHitCount: 0,
+              assistantDeliverySignalCount: 0,
+              toolCallCount: 1,
+              toolFailureCount: 0,
+              highObservationCount: 0,
+              mediumObservationCount: 0,
+              hedgingCount: 0,
+              explicitMarkerCount: 0,
+            },
+            evidenceChain: {
+              userMessageCount: 1,
+              runtimeContextCount: 0,
+              skillContextCount: 0,
+              assistantMessageCount: 0,
+              toolUseCount: 1,
+              toolResultCount: 0,
+              toolFailureResultCount: 0,
+              observationCount: 0,
+            },
+            ruleFindings: [{
+              code: 'user_correction_seen',
+              level: 'attention',
+              count: 1,
+              evidenceRefs: [{ id: 'u1', kind: 'user_message', sourceTrace: '/tmp/synthetic.jsonl', sessionId: 's1', messageIndex: 1, snippet: '不对，重新生成' }],
+            }],
+            assistiveInference: {
+              mode: 'deterministic_rules_only',
+              code: 'review_recommended',
+              confidence: 'high',
+              basisRuleCodes: ['user_correction_seen'],
+              cautionCodes: ['no_llm_judge', 'rule_only'],
+              evidenceRefs: [],
+            },
+            problemPatterns: [{
+              id: 'p1',
+              bucket: 'workflow_mismatch',
+              patternKey: 'workflow_mismatch:user_correction',
+              count: 2,
+              sessionCount: 1,
+              recentSessionIds: ['s1'],
+              signalTypes: ['user_correction'],
+              evidenceRefs: [{ id: 'u1', kind: 'user_message', sourceTrace: '/tmp/synthetic.jsonl', sessionId: 's1', messageIndex: 1, snippet: '不对，重新生成' }],
+              lastSeen: '2026-05-15T00:01:00.000Z',
+            }],
+            relatedObservationIds: [],
+          }],
+        },
+      } as unknown as ObservationInboxReport;
+
+      const bundle = buildObserveDiagnosticsFromReport(report, { cwd: dir });
+      const signals = bundle.bySkill.audit.map((item) => item.signal);
+      assert.ok(signals.includes('runtime_workflow_review'));
+      assert.ok(signals.includes('user_correction'));
+      assert.ok(signals.includes('user_correction_seen'));
+      assert.equal(bundle.sourceCoverage.observe, true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/diagnosis/observe-producer.test.ts
+++ b/test/diagnosis/observe-producer.test.ts
@@ -10,7 +10,7 @@ describe('buildObserveDiagnosticsFromReport', () => {
   it('uses real observe skill-chain, runtime checks, patterns, and rule findings', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-observe-diagnosis-'));
     try {
-      const skillDir = join(dir, 'skills', 'audit');
+      const skillDir = join(dir, 'skills', 'omk_fake_skill_x9z');
       mkdirSync(skillDir, { recursive: true });
       writeFileSync(join(skillDir, 'SKILL.md'), `---
 hardRules:
@@ -24,7 +24,7 @@ workflows:
         action: 上传产物
 ---
 
-# audit
+# omk_fake_skill_x9z
 `);
       const report = {
         kind: 'observe-inbox',
@@ -34,8 +34,8 @@ workflows:
           generatedAt: '2026-05-15T00:00:00.000Z',
           segmentCount: 1,
           itemCount: 0,
-          skillInvocationCounts: { audit: 1 },
-          skillSessionCounts: { audit: 1 },
+          skillInvocationCounts: { omk_fake_skill_x9z: 1 },
+          skillSessionCounts: { omk_fake_skill_x9z: 1 },
         },
         items: [],
         experience: {
@@ -52,7 +52,7 @@ workflows:
           },
           goalSlices: [],
           invocations: [{
-            skillName: 'audit',
+            skillName: 'omk_fake_skill_x9z',
             toolCounts: { Read: 1 },
             indicators: { toolCallCount: 1, toolFailureCount: 0 },
             timeline: [
@@ -61,7 +61,7 @@ workflows:
           }],
           sessions: [],
           skills: [{
-            skillName: 'audit',
+            skillName: 'omk_fake_skill_x9z',
             invocationCount: 1,
             sessionCount: 1,
             sourceKinds: ['claude'],
@@ -135,7 +135,7 @@ workflows:
       } as unknown as ObservationInboxReport;
 
       const bundle = buildObserveDiagnosticsFromReport(report, { cwd: dir });
-      const signals = bundle.bySkill.audit.map((item) => item.signal);
+      const signals = bundle.bySkill.omk_fake_skill_x9z.map((item) => item.signal);
       assert.ok(signals.includes('runtime_workflow_review'));
       assert.ok(signals.includes('user_correction'));
       assert.ok(signals.includes('user_correction_seen'));
@@ -147,21 +147,21 @@ workflows:
 
   it('未传 cwd 时按 inbox items[].cwd 推断每个 skill 的 cwd,跨项目场景下不误报 skill_md_not_found', () => {
     // 模拟 `omk observe ingest /path/to/B-traces`:用户在 A 目录跑命令,trace 来自 B 项目。
-    // build 路径以前用 process.cwd() = A,A 下没有 skills/audit/SKILL.md,会产出 `skill_md_not_found`
+    // build 路径以前用 process.cwd() = A,A 下没有 skills/omk_fake_skill_x9z/SKILL.md,会产出 `skill_md_not_found`
     // 假阳性并持久化进 inbox JSON。改成从 inbox items[].cwd 按 skill 推断后,应该用 B 目录的
     // SKILL.md 正确解析。
     const projectB = mkdtempSync(join(tmpdir(), 'omk-project-b-'));
     const projectA = mkdtempSync(join(tmpdir(), 'omk-project-a-'));
     try {
-      mkdirSync(join(projectB, 'skills', 'audit'), { recursive: true });
-      writeFileSync(join(projectB, 'skills', 'audit', 'SKILL.md'), `---
+      mkdirSync(join(projectB, 'skills', 'omk_fake_skill_x9z'), { recursive: true });
+      writeFileSync(join(projectB, 'skills', 'omk_fake_skill_x9z', 'SKILL.md'), `---
 hardRules:
   - id: r1
     rule: must read domain
     expectedBehavior: use Read
 ---
 
-# audit
+# omk_fake_skill_x9z
 `);
       const origCwd = process.cwd();
       process.chdir(projectA);  // 模拟在 projectA 跑 ingest
@@ -174,11 +174,11 @@ hardRules:
             generatedAt: '2026-05-15T00:00:00.000Z',
             segmentCount: 1,
             itemCount: 1,
-            skillInvocationCounts: { audit: 1 },
-            skillSessionCounts: { audit: 1 },
+            skillInvocationCounts: { omk_fake_skill_x9z: 1 },
+            skillSessionCounts: { omk_fake_skill_x9z: 1 },
           },
           items: [{
-            id: 'obs-1', skillName: 'audit', artifactVersion: 'unknown',
+            id: 'obs-1', skillName: 'omk_fake_skill_x9z', artifactVersion: 'unknown',
             cwd: projectB,  // 关键:item 记录了 trace 的原始 cwd
             sessionId: 's1', sourceTrace: '/tmp/trace-b/s1.jsonl', sourceKind: 'claude',
             signalType: 'failed_search', signalSubtype: 'hard_miss',
@@ -188,10 +188,93 @@ hardRules:
           }],
         } as unknown as ObservationInboxReport;
         const bundle = buildObserveDiagnosticsFromReport(report);
-        const signals = (bundle.bySkill.audit ?? []).map((item) => item.signal);
+        const signals = (bundle.bySkill.omk_fake_skill_x9z ?? []).map((item) => item.signal);
         assert.equal(
           signals.includes('skill_md_not_found'), false,
           `不应产生 skill_md_not_found 假阳性(应该用 ${projectB} 找到 SKILL.md)`,
+        );
+      } finally {
+        process.chdir(origCwd);
+      }
+    } finally {
+      rmSync(projectB, { recursive: true, force: true });
+      rmSync(projectA, { recursive: true, force: true });
+    }
+  });
+
+  it('items 为空但 experience.invocations 有 cwd 时,仍能正确推断并产出 chain advisory', () => {
+    // 真实 build 路径的常见态:skill 跑得很干净,inbox items 为空,但 experience
+    // 仍然记录了 invocation + cwd。只看 items 会漏掉整个 chain advisory + runtime check。
+    // 这条 case 防止「干净运行场景诊断完全缺失」的回归。
+    const projectB = mkdtempSync(join(tmpdir(), 'omk-project-b-clean-'));
+    const projectA = mkdtempSync(join(tmpdir(), 'omk-project-a-clean-'));
+    try {
+      // projectB 下没建 skills/omk_fake_skill_x9z 目录,故意让 chain 出 skill_md_not_found,以验证「chain
+      // advisory 确实被构建出来」—— 如果 cwd 推断没拿到 projectB,advisory 不会产生(实现里
+      // 该 skill 直接跳过 chain),拿到了才会跑出 skill_md_not_found。
+      const origCwd = process.cwd();
+      process.chdir(projectA);
+      try {
+        const report = {
+          kind: 'observe-inbox',
+          schemaVersion: 1,
+          meta: {
+            tracePath: '/tmp/trace-clean',
+            generatedAt: '2026-05-15T00:00:00.000Z',
+            segmentCount: 1,
+            itemCount: 0,
+            skillInvocationCounts: { omk_fake_skill_x9z: 1 },
+            skillSessionCounts: { omk_fake_skill_x9z: 1 },
+          },
+          items: [],
+          experience: {
+            kind: 'observe-experience',
+            schemaVersion: 1,
+            scope: 'evidence-only',
+            generatedAt: '2026-05-15T00:00:00.000Z',
+            meta: { sessionCount: 1, skillCount: 1, invocationCount: 1, goalSliceCount: 1, noteCodes: [] },
+            goalSlices: [{
+              id: 'g1', skillName: 'omk_fake_skill_x9z', sessionId: 's1', sourceTrace: '/t',
+              cwd: projectB,
+              startTimestamp: 't', endTimestamp: 't',
+              sliceReasonCode: 'skill_boundary', sliceConfidence: 'high', userMessageRefs: [],
+            }],
+            invocations: [{
+              skillName: 'omk_fake_skill_x9z', cwd: projectB, sessionId: 's1', sourceTrace: '/t', sourceKind: 'claude',
+              toolCounts: {}, indicators: { toolCallCount: 0, toolFailureCount: 0 }, timeline: [],
+            }],
+            sessions: [],
+            skills: [{
+              skillName: 'omk_fake_skill_x9z', invocationCount: 1, sessionCount: 1, sourceKinds: ['claude'],
+              entrypoints: [], entrypointCounts: {},
+              sourceMetadataCounts: { channels: {}, senders: {}, aimaCommands: {}, providers: {}, models: {} },
+              attributionCounts: {}, pluginNames: [], rawSkillRefs: [], commandNames: [],
+              toolCounts: {}, firstSeen: 't', lastSeen: 't',
+              reviewFirstSessionCount: 0, sampleReviewSessionCount: 0,
+              indicators: {
+                userMessageCount: 0, userFollowUpCount: 0, userCorrectionCount: 0,
+                userInterruptionCount: 0, negativeFeedbackCount: 0, positiveFeedbackCount: 0,
+                userGoalShiftCount: 0, hardRuleTextHitCount: 0, assistantDeliverySignalCount: 0,
+                toolCallCount: 0, toolFailureCount: 0, highObservationCount: 0,
+                mediumObservationCount: 0, hedgingCount: 0, explicitMarkerCount: 0,
+              },
+              evidenceChain: {
+                userMessageCount: 0, runtimeContextCount: 0, skillContextCount: 0,
+                assistantMessageCount: 0, toolUseCount: 0, toolResultCount: 0,
+                toolFailureResultCount: 0, observationCount: 0,
+              },
+              ruleFindings: [],
+              assistiveInference: { mode: 'deterministic_rules_only', code: 'review_recommended', confidence: 'high', basisRuleCodes: [], cautionCodes: [], evidenceRefs: [] },
+              problemPatterns: [],
+              relatedObservationIds: [],
+            }],
+          },
+        } as unknown as ObservationInboxReport;
+        const bundle = buildObserveDiagnosticsFromReport(report);
+        const signals = (bundle.bySkill.omk_fake_skill_x9z ?? []).map((item) => item.signal);
+        assert.ok(
+          signals.includes('skill_md_not_found'),
+          `应该从 experience.invocations[].cwd 推断到 ${projectB},chain 跑出 skill_md_not_found`,
         );
       } finally {
         process.chdir(origCwd);
@@ -214,22 +297,22 @@ hardRules:
         generatedAt: '2026-05-15T00:00:00.000Z',
         segmentCount: 2,
         itemCount: 2,
-        skillInvocationCounts: { audit: 2 },
-        skillSessionCounts: { audit: 2 },
+        skillInvocationCounts: { omk_fake_skill_x9z: 2 },
+        skillSessionCounts: { omk_fake_skill_x9z: 2 },
       },
       items: [
-        { id: 'o1', skillName: 'audit', cwd: '/repo-x', sessionId: 's1', sourceTrace: '/t', sourceKind: 'claude',
+        { id: 'o1', skillName: 'omk_fake_skill_x9z', cwd: '/repo-x', sessionId: 's1', sourceTrace: '/t', sourceKind: 'claude',
           signalType: 'failed_search', signalSubtype: 'hard_miss', confidence: 0.9,
           attributionConfidence: 0.85, severity: 'high', evidence: {},
           firstSeen: 't', lastSeen: 't', occurrences: 1, recentSessionIds: ['s1'], representativeEvidence: [] },
-        { id: 'o2', skillName: 'audit', cwd: '/repo-y', sessionId: 's2', sourceTrace: '/t', sourceKind: 'claude',
+        { id: 'o2', skillName: 'omk_fake_skill_x9z', cwd: '/repo-y', sessionId: 's2', sourceTrace: '/t', sourceKind: 'claude',
           signalType: 'failed_search', signalSubtype: 'hard_miss', confidence: 0.9,
           attributionConfidence: 0.85, severity: 'high', evidence: {},
           firstSeen: 't', lastSeen: 't', occurrences: 1, recentSessionIds: ['s2'], representativeEvidence: [] },
       ],
     } as unknown as ObservationInboxReport;
     const bundle = buildObserveDiagnosticsFromReport(report);
-    const signals = (bundle.bySkill.audit ?? []).map((item) => item.signal);
+    const signals = (bundle.bySkill.omk_fake_skill_x9z ?? []).map((item) => item.signal);
     assert.equal(
       signals.includes('skill_md_not_found'), false,
       '多 cwd ambiguous 时应跳过 chain advisory',

--- a/test/diagnosis/observe-producer.test.ts
+++ b/test/diagnosis/observe-producer.test.ts
@@ -144,4 +144,99 @@ workflows:
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it('未传 cwd 时按 inbox items[].cwd 推断每个 skill 的 cwd,跨项目场景下不误报 skill_md_not_found', () => {
+    // 模拟 `omk observe ingest /path/to/B-traces`:用户在 A 目录跑命令,trace 来自 B 项目。
+    // build 路径以前用 process.cwd() = A,A 下没有 skills/audit/SKILL.md,会产出 `skill_md_not_found`
+    // 假阳性并持久化进 inbox JSON。改成从 inbox items[].cwd 按 skill 推断后,应该用 B 目录的
+    // SKILL.md 正确解析。
+    const projectB = mkdtempSync(join(tmpdir(), 'omk-project-b-'));
+    const projectA = mkdtempSync(join(tmpdir(), 'omk-project-a-'));
+    try {
+      mkdirSync(join(projectB, 'skills', 'audit'), { recursive: true });
+      writeFileSync(join(projectB, 'skills', 'audit', 'SKILL.md'), `---
+hardRules:
+  - id: r1
+    rule: must read domain
+    expectedBehavior: use Read
+---
+
+# audit
+`);
+      const origCwd = process.cwd();
+      process.chdir(projectA);  // 模拟在 projectA 跑 ingest
+      try {
+        const report = {
+          kind: 'observe-inbox',
+          schemaVersion: 1,
+          meta: {
+            tracePath: '/tmp/trace-b',
+            generatedAt: '2026-05-15T00:00:00.000Z',
+            segmentCount: 1,
+            itemCount: 1,
+            skillInvocationCounts: { audit: 1 },
+            skillSessionCounts: { audit: 1 },
+          },
+          items: [{
+            id: 'obs-1', skillName: 'audit', artifactVersion: 'unknown',
+            cwd: projectB,  // 关键:item 记录了 trace 的原始 cwd
+            sessionId: 's1', sourceTrace: '/tmp/trace-b/s1.jsonl', sourceKind: 'claude',
+            signalType: 'failed_search', signalSubtype: 'hard_miss',
+            confidence: 0.9, attributionConfidence: 0.85, severity: 'high',
+            evidence: {}, firstSeen: '2026-05-15T00:00:00.000Z', lastSeen: '2026-05-15T00:00:00.000Z',
+            occurrences: 1, recentSessionIds: ['s1'], representativeEvidence: [],
+          }],
+        } as unknown as ObservationInboxReport;
+        const bundle = buildObserveDiagnosticsFromReport(report);
+        const signals = (bundle.bySkill.audit ?? []).map((item) => item.signal);
+        assert.equal(
+          signals.includes('skill_md_not_found'), false,
+          `不应产生 skill_md_not_found 假阳性(应该用 ${projectB} 找到 SKILL.md)`,
+        );
+      } finally {
+        process.chdir(origCwd);
+      }
+    } finally {
+      rmSync(projectB, { recursive: true, force: true });
+      rmSync(projectA, { recursive: true, force: true });
+    }
+  });
+
+  it('未传 cwd 且 inbox 同 skill 出现多个 cwd 时跳过 chain advisory,避免任意挑一个误报', () => {
+    // skill 在多个 cwd 都被调用过,无法确定权威路径。保守做法:跳过该 skill 的
+    // skill_md_not_found / hardrules_not_declared 等 chain advisory,只保留 problemPatterns 等
+    // 跟 cwd 无关的诊断。
+    const report = {
+      kind: 'observe-inbox',
+      schemaVersion: 1,
+      meta: {
+        tracePath: '/tmp/trace',
+        generatedAt: '2026-05-15T00:00:00.000Z',
+        segmentCount: 2,
+        itemCount: 2,
+        skillInvocationCounts: { audit: 2 },
+        skillSessionCounts: { audit: 2 },
+      },
+      items: [
+        { id: 'o1', skillName: 'audit', cwd: '/repo-x', sessionId: 's1', sourceTrace: '/t', sourceKind: 'claude',
+          signalType: 'failed_search', signalSubtype: 'hard_miss', confidence: 0.9,
+          attributionConfidence: 0.85, severity: 'high', evidence: {},
+          firstSeen: 't', lastSeen: 't', occurrences: 1, recentSessionIds: ['s1'], representativeEvidence: [] },
+        { id: 'o2', skillName: 'audit', cwd: '/repo-y', sessionId: 's2', sourceTrace: '/t', sourceKind: 'claude',
+          signalType: 'failed_search', signalSubtype: 'hard_miss', confidence: 0.9,
+          attributionConfidence: 0.85, severity: 'high', evidence: {},
+          firstSeen: 't', lastSeen: 't', occurrences: 1, recentSessionIds: ['s2'], representativeEvidence: [] },
+      ],
+    } as unknown as ObservationInboxReport;
+    const bundle = buildObserveDiagnosticsFromReport(report);
+    const signals = (bundle.bySkill.audit ?? []).map((item) => item.signal);
+    assert.equal(
+      signals.includes('skill_md_not_found'), false,
+      '多 cwd ambiguous 时应跳过 chain advisory',
+    );
+    assert.equal(
+      signals.includes('hardrules_not_declared'), false,
+      '多 cwd ambiguous 时也不发 hardrules_not_declared',
+    );
+  });
 });

--- a/test/renderer/assess-health.test.ts
+++ b/test/renderer/assess-health.test.ts
@@ -1,0 +1,74 @@
+/**
+ * assessHealth — Diagnosis-only skill 的健康等级判定。
+ *
+ * 重点覆盖:三大维度(doctor / eval / observe)都没跑过时,如果 insights 含
+ * high/medium 信号(来自 Diagnosis 投影),卡片不应该落到灰色「未评估」,
+ * 否则只跑了 observe ingest 拿到 `skill_md_not_found` 的 skill 会被红色筛选
+ * 漏掉。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { assessHealth } from '../../src/renderer/skill-detail-renderer.js';
+import type { SkillIndexEntry } from '../../src/server/skill-index.js';
+import type { Insight } from '../../src/server/skill-insights.js';
+
+function mkEntry(overrides: Partial<SkillIndexEntry> = {}): SkillIndexEntry {
+  return {
+    skillName: 'test-skill',
+    doctor: null,
+    eval: null,
+    observe: null,
+    doctorHistory: [],
+    evalHistory: [],
+    observeHistory: [],
+    band: 'gray',
+    ...overrides,
+  };
+}
+
+function mkInsight(severity: Insight['severity'], id = 'i1'): Insight {
+  return {
+    id,
+    category: 'skill-doc-gap',
+    audience: 'skill-author',
+    title: 't',
+    severity,
+    affectedCount: 1,
+    evidence: [],
+    recommendations: [],
+  };
+}
+
+describe('assessHealth — Diagnosis-only skill', () => {
+  it('三大维度都没跑 + 有 high insight → red,不再落灰色', () => {
+    const h = assessHealth(mkEntry(), [mkInsight('high')], 'zh');
+    assert.equal(h.grade, 'unhealthy');
+    assert.equal(h.color, 'red');
+    assert.equal(h.score, null);
+  });
+
+  it('三大维度都没跑 + 只有 medium insight → yellow', () => {
+    const h = assessHealth(mkEntry(), [mkInsight('medium')], 'zh');
+    assert.equal(h.grade, 'fair');
+    assert.equal(h.color, 'yellow');
+    assert.equal(h.score, null);
+  });
+
+  it('三大维度都没跑 + 只有 low insight → 仍然 unscored', () => {
+    const h = assessHealth(mkEntry(), [mkInsight('low')], 'zh');
+    assert.equal(h.grade, 'unscored');
+    assert.equal(h.color, 'gray');
+  });
+
+  it('三大维度都没跑 + insights 完全为空 → unscored', () => {
+    const h = assessHealth(mkEntry(), [], 'zh');
+    assert.equal(h.grade, 'unscored');
+    assert.equal(h.color, 'gray');
+  });
+
+  it('EN 文案也走对应分支', () => {
+    const h = assessHealth(mkEntry(), [mkInsight('high')], 'en');
+    assert.equal(h.grade, 'unhealthy');
+    assert.equal(h.label, 'Unhealthy');
+  });
+});

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -191,6 +191,40 @@ describe('report-server', () => {
           representativeEvidence: [{ tool: 'Read', path: '/repo/large.ts' }],
         },
       ],
+      diagnostics: {
+        schemaVersion: 1,
+        generatedAt: '2026-05-07T00:00:00.000Z',
+        sourceCoverage: { observe: true, doctor: false, eval: false },
+        bySkill: {
+          audit: [
+            {
+              id: 'diag-audit-skill-md',
+              stableKey: 'skill:audit|type:definition_gap|signal:skill_md_not_found|target:definition:skill_md',
+              skillName: 'audit',
+              type: 'definition_gap',
+              signal: 'skill_md_not_found',
+              title: 'SKILL.md was not found',
+              severity: 'high',
+              audience: 'skill-author',
+              lifecycle: 'detected',
+              scope: { primary: 'definition', refs: { skillName: 'audit' } },
+              occurrences: [{
+                id: 'occ-audit-skill-md',
+                diagnosisStableKey: 'skill:audit|type:definition_gap|signal:skill_md_not_found|target:definition:skill_md',
+                source: 'observe',
+                sourceId: 'skill_chain:audit:skill_md_not_found',
+                sourceKind: 'skill_chain',
+                timestamp: '2026-05-07T00:00:00.000Z',
+                severity: 'high',
+                evidenceRefs: [],
+                producer: 'deterministic_rule',
+                payload: {},
+              }],
+              occurrenceCount: 1,
+            },
+          ],
+        },
+      },
     }, null, 2));
     server = createReportServer({ port: 0, reportsDir: TEST_DIR, observationsDir: OBSERVATIONS_DIR, jobsDir: JOBS_DIR });
     baseUrl = await server.start();

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -253,6 +253,34 @@ describe('report-server', () => {
     assert.equal(data[0].severity, 'high');
   });
 
+  it('GET /api/observations/diagnostics exposes observe-backed Diagnosis data', async () => {
+    const res = await fetch(`${baseUrl}/api/observations/diagnostics`);
+    assert.equal(res.status, 200);
+    const data = JSON.parse(res.body);
+    assert.equal(data.sourceCoverage.observe, true);
+    assert.equal(data.summary.totalCount, 1);
+    assert.equal(data.bySkill.audit[0].signal, 'skill_md_not_found');
+  });
+
+  it('GET /api/skills includes diagnosis counts without changing renderer output', async () => {
+    const res = await fetch(`${baseUrl}/api/skills`);
+    assert.equal(res.status, 200);
+    const data = JSON.parse(res.body);
+    const audit = data.entries.find((entry: { skillName: string }) => entry.skillName === 'audit');
+    assert.ok(audit);
+    assert.equal(audit.diagnosisCount, 1);
+    assert.equal(data.diagnosisSummary.sourceCoverage.observe, true);
+  });
+
+  it('GET /api/skills/:name/diagnostics returns per-skill diagnostics', async () => {
+    const res = await fetch(`${baseUrl}/api/skills/audit/diagnostics`);
+    assert.equal(res.status, 200);
+    const data = JSON.parse(res.body);
+    assert.equal(data.skillName, 'audit');
+    assert.equal(data.diagnostics.length, 1);
+    assert.equal(data.diagnostics[0].signal, 'skill_md_not_found');
+  });
+
   it('GET /api/jobs supports filtering by project and tag', async () => {
     const res = await fetch(`${baseUrl}/api/jobs?project=alpha&tag=nightly`);
     assert.equal(res.status, 200);

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -9,6 +9,10 @@ import { createReportServer } from '../../src/server/report-server.js';
 const TEST_DIR = join(tmpdir(), `omk-test-reports-${Date.now()}`);
 const JOBS_DIR = join(tmpdir(), `omk-test-jobs-${Date.now()}`);
 const OBSERVATIONS_DIR = join(tmpdir(), `omk-test-observations-${Date.now()}`);
+// 隔离 analyses / doctors dir,避免读取 home dir 的真实 SkillHealthReport / doctor report
+// 导致 fixture skill 意外携带 observe / doctor snapshot(本地 / CI 漂移)。
+const ANALYSES_DIR = join(tmpdir(), `omk-test-analyses-${Date.now()}`);
+const DOCTORS_DIR = join(tmpdir(), `omk-test-doctors-${Date.now()}`);
 
 const SAMPLE_REPORT = {
   kind: 'evaluation',
@@ -135,6 +139,8 @@ describe('report-server', () => {
     mkdirSync(TEST_DIR, { recursive: true });
     mkdirSync(JOBS_DIR, { recursive: true });
     mkdirSync(OBSERVATIONS_DIR, { recursive: true });
+    mkdirSync(ANALYSES_DIR, { recursive: true });
+    mkdirSync(DOCTORS_DIR, { recursive: true });
     writeFileSync(join(TEST_DIR, 'test-run-001.json'), JSON.stringify(SAMPLE_REPORT, null, 2));
     writeFileSync(join(JOBS_DIR, 'job-test-run-001.json'), JSON.stringify(SAMPLE_JOB, null, 2));
     writeFileSync(join(JOBS_DIR, 'job-test-run-002.json'), JSON.stringify(FAILED_JOB, null, 2));
@@ -226,7 +232,7 @@ describe('report-server', () => {
         },
       },
     }, null, 2));
-    server = createReportServer({ port: 0, reportsDir: TEST_DIR, observationsDir: OBSERVATIONS_DIR, jobsDir: JOBS_DIR });
+    server = createReportServer({ port: 0, reportsDir: TEST_DIR, observationsDir: OBSERVATIONS_DIR, jobsDir: JOBS_DIR, analysesDir: ANALYSES_DIR, doctorsDir: DOCTORS_DIR });
     baseUrl = await server.start();
   });
 
@@ -235,6 +241,8 @@ describe('report-server', () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
     rmSync(JOBS_DIR, { recursive: true, force: true });
     rmSync(OBSERVATIONS_DIR, { recursive: true, force: true });
+    rmSync(ANALYSES_DIR, { recursive: true, force: true });
+    rmSync(DOCTORS_DIR, { recursive: true, force: true });
   });
 
   it('GET /health returns ok', async () => {
@@ -304,6 +312,19 @@ describe('report-server', () => {
     assert.ok(audit);
     assert.equal(audit.diagnosisCount, 1);
     assert.equal(data.diagnosisSummary.sourceCoverage.observe, true);
+  });
+
+  it('Diagnosis-only skill 的 band 被升级,API summary 跟 HTML renderer 口径一致', async () => {
+    // audit skill 在 fixture 里只有 observe Diagnosis(high `skill_md_not_found`),没有
+    // doctor / eval / observe snapshot。原先 band 一律 gray,summary.gray += 1,renderer
+    // 通过 assessHealth 把卡片标红 —— 跨层矛盾。修后 entry.band 应升级为 red,summary.red
+    // 包含它,/api/skills 暴露的 band 跟 HTML 视觉一致。
+    const res = await fetch(`${baseUrl}/api/skills`);
+    const data = JSON.parse(res.body);
+    const audit = data.entries.find((entry: { skillName: string }) => entry.skillName === 'audit');
+    assert.ok(audit);
+    assert.equal(audit.band, 'red', 'Diagnosis-only skill 的 band 应升级到 red(high severity)');
+    assert.ok(data.summary.red >= 1, 'summary.red 应包含 Diagnosis-only red skill');
   });
 
   it('GET /api/skills/:name/diagnostics returns per-skill diagnostics', async () => {

--- a/test/server/skill-insights.test.ts
+++ b/test/server/skill-insights.test.ts
@@ -352,7 +352,9 @@ describe('detectInsights — Diagnosis projection', () => {
     );
   });
 
-  it('传入非空 Diagnosis 时屏蔽 legacy observe-side 检测,避免双写', () => {
+  it('传入同 category Diagnosis 时屏蔽对应 legacy detector,避免双写', () => {
+    // 这条 Diagnosis 投影后 category 是 production-instability(`runtime_issue` + signal `tool_failure_seen`
+    // → production-instability),所以 legacy production-instability 应该被去重。
     const entry = mkEntry({
       observe: {
         analysisId: 'a1', generatedAt: '2026-05-09T10:00:00Z',
@@ -363,9 +365,35 @@ describe('detectInsights — Diagnosis projection', () => {
     assert.equal(
       insights.find((i) => i.id === 'production-instability'),
       undefined,
-      'legacy production-instability 应被 Diagnosis 投影替代',
+      'legacy production-instability 应被同 category Diagnosis 投影替代',
     );
     assert.ok(insights.find((i) => i.id === 'diagnosis:diag-1'));
+  });
+
+  it('传入不同 category Diagnosis 时仍跑 legacy observe detector(关键:防止 SkillHealthReport 信号被吞)', () => {
+    // 这条 Diagnosis 投影后 category 是 skill-doc-gap,跟 production-instability 不重叠。
+    // legacy detectProductionInstability 应继续基于 observe.failureRate 0.5 触发,否则
+    // 「只跑了 observe ingest 拿到 skill_md_not_found 但 failureRate 也高」的 skill 会丢
+    // production-instability 信号(buildObserveDiagnosticsFromReport 当前不消费 SkillHealthReport)。
+    const docGapDiagnosis = mkDiagnosis({
+      id: 'diag-doc',
+      type: 'definition_gap',
+      signal: 'skill_md_not_found',
+      title: 'SKILL.md was not found',
+      stableKey: 'skill:test-skill|type:definition_gap|signal:skill_md_not_found|target:definition:skill_md',
+    });
+    const entry = mkEntry({
+      observe: {
+        analysisId: 'a1', generatedAt: '2026-05-09T10:00:00Z',
+        healthBand: 'red', failureRate: 0.5, segmentCount: 20, gapRate: 0,
+      },
+    });
+    const insights = detectInsights(entry, null, { diagnostics: [docGapDiagnosis] });
+    assert.ok(
+      insights.find((i) => i.id === 'production-instability'),
+      'legacy production-instability 应该仍触发,因为该 Diagnosis 是 skill-doc-gap 不是 production-instability',
+    );
+    assert.ok(insights.find((i) => i.id === 'diagnosis:diag-doc'));
   });
 });
 

--- a/test/server/skill-insights.test.ts
+++ b/test/server/skill-insights.test.ts
@@ -352,9 +352,14 @@ describe('detectInsights — Diagnosis projection', () => {
     );
   });
 
-  it('传入同 category Diagnosis 时屏蔽对应 legacy detector,避免双写', () => {
-    // 这条 Diagnosis 投影后 category 是 production-instability(`runtime_issue` + signal `tool_failure_seen`
-    // → production-instability),所以 legacy production-instability 应该被去重。
+  it('dual-run 期间 legacy + Diagnosis 即便概念相近也共存,不基于 category 去重', () => {
+    // 这条 Diagnosis 投影后 category 是 production-instability,看起来跟 legacy detector
+    // 同名,但二者读不同数据源 —— Diagnosis 来自 inbox 的 runtime/tool_failure_seen
+    // 单点告警,legacy 来自 SkillHealthReport 的 failureRate >= 0.4 聚合指标,不等价。
+    //
+    // dual-run 期间不能用 InsightCategory 去重,否则 `runtime_workflow_review` 这类
+    // 投影出 production-instability 的 Diagnosis 会误关掉 SkillHealthReport 高失败率信号。
+    // 等 doctor / eval producer 都迁完 Diagnosis,再单独 PR 基于 stable target 精确去重。
     const entry = mkEntry({
       observe: {
         analysisId: 'a1', generatedAt: '2026-05-09T10:00:00Z',
@@ -362,19 +367,21 @@ describe('detectInsights — Diagnosis projection', () => {
       },
     });
     const insights = detectInsights(entry, null, { diagnostics: [mkDiagnosis()] });
-    assert.equal(
+    assert.ok(
       insights.find((i) => i.id === 'production-instability'),
-      undefined,
-      'legacy production-instability 应被同 category Diagnosis 投影替代',
+      'legacy production-instability(SkillHealthReport 聚合)应仍触发',
     );
-    assert.ok(insights.find((i) => i.id === 'diagnosis:diag-1'));
+    assert.ok(
+      insights.find((i) => i.id === 'diagnosis:diag-1'),
+      'Diagnosis 投影(inbox 单点告警)也应共存',
+    );
   });
 
-  it('传入不同 category Diagnosis 时仍跑 legacy observe detector(关键:防止 SkillHealthReport 信号被吞)', () => {
-    // 这条 Diagnosis 投影后 category 是 skill-doc-gap,跟 production-instability 不重叠。
-    // legacy detectProductionInstability 应继续基于 observe.failureRate 0.5 触发,否则
-    // 「只跑了 observe ingest 拿到 skill_md_not_found 但 failureRate 也高」的 skill 会丢
-    // production-instability 信号(buildObserveDiagnosticsFromReport 当前不消费 SkillHealthReport)。
+  it('definition_gap Diagnosis 不会吞掉 legacy detectSkillDocGap 的 eval / doctor 证据', () => {
+    // legacy detectSkillDocGap 会基于 eval rootCause 跟 doctor dependency rule 出 insight。
+    // 早先按 category 去重的实现会让 `skill_md_not_found` definition_gap Diagnosis 把整个
+    // legacy detector 关掉(它们都映射到 skill-doc-gap),导致 doctor + eval 那部分证据消失。
+    // 现在 dual-run 共存。
     const docGapDiagnosis = mkDiagnosis({
       id: 'diag-doc',
       type: 'definition_gap',
@@ -391,7 +398,7 @@ describe('detectInsights — Diagnosis projection', () => {
     const insights = detectInsights(entry, null, { diagnostics: [docGapDiagnosis] });
     assert.ok(
       insights.find((i) => i.id === 'production-instability'),
-      'legacy production-instability 应该仍触发,因为该 Diagnosis 是 skill-doc-gap 不是 production-instability',
+      'legacy production-instability 应该仍触发(不同 category 也不去重,跟同 category dual-run 一致)',
     );
     assert.ok(insights.find((i) => i.id === 'diagnosis:diag-doc'));
   });

--- a/test/server/skill-insights.test.ts
+++ b/test/server/skill-insights.test.ts
@@ -10,6 +10,7 @@ import assert from 'node:assert/strict';
 import { detectInsights, flattenRecommendations } from '../../src/server/skill-insights.js';
 import type { SkillIndexEntry } from '../../src/server/skill-index.js';
 import type { EvaluationReport, ResultEntry } from '../../src/types/index.js';
+import type { Diagnosis } from '../../src/diagnosis/types.js';
 
 function mkResult(sampleId: string, variant: string, opts: {
   passedAssertions?: boolean;
@@ -284,6 +285,64 @@ describe('detectInsights — production-instability', () => {
       },
     });
     const insights = detectInsights(entry, null);
+    assert.equal(insights.find((i) => i.id === 'production-instability'), undefined);
+  });
+});
+
+describe('detectInsights — Diagnosis projection', () => {
+  function mkDiagnosis(overrides: Partial<Diagnosis> = {}): Diagnosis {
+    return {
+      id: 'diag-1',
+      stableKey: 'skill:test-skill|type:runtime_issue|signal:tool_failure_seen|target:x',
+      skillName: 'test-skill',
+      type: 'runtime_issue',
+      signal: 'tool_failure_seen',
+      title: 'Tool failure seen',
+      summary: '工具失败在真实 session 中重复出现。',
+      severity: 'high',
+      audience: 'skill-author',
+      lifecycle: 'detected',
+      scope: { primary: 'skill', refs: { skillName: 'test-skill' } },
+      occurrences: [{
+        id: 'occ-1',
+        diagnosisStableKey: 'skill:test-skill|type:runtime_issue|signal:tool_failure_seen|target:x',
+        source: 'observe',
+        sourceId: 'rule_finding:test-skill:tool_failure_seen',
+        sourceKind: 'tool_failure_seen',
+        timestamp: '2026-05-09T10:00:00Z',
+        severity: 'high',
+        evidenceRefs: [],
+        producer: 'deterministic_rule',
+      }],
+      occurrenceCount: 1,
+      recommendation: '补充工具失败时的重试和失败告知流程。',
+      ...overrides,
+    };
+  }
+
+  it('传入 Diagnosis 后,observe 类 Insight 从 Diagnosis 投影', () => {
+    const entry = mkEntry({
+      observe: {
+        analysisId: 'a1', generatedAt: '2026-05-09T10:00:00Z',
+        healthBand: 'green', failureRate: 0, segmentCount: 10, gapRate: 0,
+      },
+    });
+    const insights = detectInsights(entry, null, { diagnostics: [mkDiagnosis()] });
+    const projected = insights.find((i) => i.id === 'diagnosis:diag-1');
+    assert.ok(projected);
+    assert.equal(projected!.category, 'production-instability');
+    assert.equal(projected!.evidence[0].perspective, 'observe');
+    assert.equal(projected!.severity, 'high');
+  });
+
+  it('传入 Diagnosis 时不再从 entry.observe 生成旧 production-instability', () => {
+    const entry = mkEntry({
+      observe: {
+        analysisId: 'a1', generatedAt: '2026-05-09T10:00:00Z',
+        healthBand: 'red', failureRate: 0.5, segmentCount: 20, gapRate: 0,
+      },
+    });
+    const insights = detectInsights(entry, null, { diagnostics: [] });
     assert.equal(insights.find((i) => i.id === 'production-instability'), undefined);
   });
 });

--- a/test/server/skill-insights.test.ts
+++ b/test/server/skill-insights.test.ts
@@ -335,7 +335,10 @@ describe('detectInsights — Diagnosis projection', () => {
     assert.equal(projected!.severity, 'high');
   });
 
-  it('传入 Diagnosis 时不再从 entry.observe 生成旧 production-instability', () => {
+  it('diagnostics 为空数组时,legacy observe-side 检测仍然触发（dual-run 兼容）', () => {
+    // observe 有 red + failureRate 0.5 但 mapper 没产出对应 Diagnosis 的场景:
+    // 该 skill 的 diagnosticsBundle.bySkill[name] 默认是 [] 不是 undefined,
+    // 这条 case 防止以前那种「[] 也判 truthy 把 legacy 全关掉」的回归。
     const entry = mkEntry({
       observe: {
         analysisId: 'a1', generatedAt: '2026-05-09T10:00:00Z',
@@ -343,7 +346,26 @@ describe('detectInsights — Diagnosis projection', () => {
       },
     });
     const insights = detectInsights(entry, null, { diagnostics: [] });
-    assert.equal(insights.find((i) => i.id === 'production-instability'), undefined);
+    assert.ok(
+      insights.find((i) => i.id === 'production-instability'),
+      'legacy production-instability 应在空 diagnostics 下仍然触发',
+    );
+  });
+
+  it('传入非空 Diagnosis 时屏蔽 legacy observe-side 检测,避免双写', () => {
+    const entry = mkEntry({
+      observe: {
+        analysisId: 'a1', generatedAt: '2026-05-09T10:00:00Z',
+        healthBand: 'red', failureRate: 0.5, segmentCount: 20, gapRate: 0,
+      },
+    });
+    const insights = detectInsights(entry, null, { diagnostics: [mkDiagnosis()] });
+    assert.equal(
+      insights.find((i) => i.id === 'production-instability'),
+      undefined,
+      'legacy production-instability 应被 Diagnosis 投影替代',
+    );
+    assert.ok(insights.find((i) => i.id === 'diagnosis:diag-1'));
   });
 });
 

--- a/test/server/skill-insights.test.ts
+++ b/test/server/skill-insights.test.ts
@@ -419,6 +419,29 @@ describe('detectInsights — Diagnosis projection', () => {
       'Diagnosis 投影也应共存',
     );
   });
+
+  it('confirmed lifecycle 不算 active,跟 activeStudioDiagnostics 口径一致', () => {
+    // 抽 shared isActiveDiagnosisLifecycle 之后,Insight 投影和 /api/observations/diagnostics 的
+    // active 列表都按同一份 set 过滤(detected / candidate / stale)。confirmed 不算 active,
+    // 不会被投影成 Insight,避免「Insight 影响 skill 健康但 diagnostics API 不显示」的口径分叉。
+    const confirmedDiag = mkDiagnosis({
+      id: 'diag-confirmed',
+      lifecycle: 'confirmed',
+      stableKey: 'skill:test-skill|type:runtime_issue|signal:c|target:x',
+    });
+    const detectedDiag = mkDiagnosis({
+      id: 'diag-detected',
+      lifecycle: 'detected',
+      stableKey: 'skill:test-skill|type:runtime_issue|signal:d|target:y',
+    });
+    const insights = detectInsights(mkEntry(), null, { diagnostics: [confirmedDiag, detectedDiag] });
+    assert.equal(
+      insights.find((i) => i.id === 'diagnosis:diag-confirmed'),
+      undefined,
+      'confirmed 不投影成 Insight',
+    );
+    assert.ok(insights.find((i) => i.id === 'diagnosis:diag-detected'));
+  });
 });
 
 describe('detectInsights — skill-too-long', () => {

--- a/test/server/skill-insights.test.ts
+++ b/test/server/skill-insights.test.ts
@@ -378,10 +378,11 @@ describe('detectInsights — Diagnosis projection', () => {
   });
 
   it('definition_gap Diagnosis 不会吞掉 legacy detectSkillDocGap 的 eval / doctor 证据', () => {
-    // legacy detectSkillDocGap 会基于 eval rootCause 跟 doctor dependency rule 出 insight。
+    // legacy detectSkillDocGap 会基于 eval rootCause + doctor dependency rule 出 insight。
     // 早先按 category 去重的实现会让 `skill_md_not_found` definition_gap Diagnosis 把整个
     // legacy detector 关掉(它们都映射到 skill-doc-gap),导致 doctor + eval 那部分证据消失。
-    // 现在 dual-run 共存。
+    // 这条 case 必须真的让 detectSkillDocGap 有触发条件(doctor warn + eval rootCause),
+    // 否则断言会误过 —— 这是上一版本测试 fixture 不充分的回归点。
     const docGapDiagnosis = mkDiagnosis({
       id: 'diag-doc',
       type: 'definition_gap',
@@ -390,17 +391,29 @@ describe('detectInsights — Diagnosis projection', () => {
       stableKey: 'skill:test-skill|type:definition_gap|signal:skill_md_not_found|target:definition:skill_md',
     });
     const entry = mkEntry({
-      observe: {
-        analysisId: 'a1', generatedAt: '2026-05-09T10:00:00Z',
-        healthBand: 'red', failureRate: 0.5, segmentCount: 20, gapRate: 0,
+      doctor: {
+        reportId: 'd1', timestamp: '2026-05-09T10:00:00Z', status: 'warn',
+        passCount: 3, warnCount: 1, failCount: 0,
+        results: [{
+          ruleId: 'dependencies_present', severity: 'warn', labelKey: 'x', status: 'warn',
+          message: '前置依赖警告', durationMs: 10,
+        }],
       },
+      evalSnap: { reportId: 'e1', variantName: 'test-skill', timestamp: '2026-05-09T10:00:00Z', passCount: 0, failCount: 1, compositeScore: null },
     });
-    const insights = detectInsights(entry, null, { diagnostics: [docGapDiagnosis] });
+    // eval 报告含 skill_doc_missing rootCause,让 detectSkillDocGap 真的有数据触发
+    const report = mkEvalReport('test-skill', [
+      mkResult('s1', 'test-skill', { rootCause: ['skill_doc_missing'] }),
+    ]);
+    const insights = detectInsights(entry, report, { diagnostics: [docGapDiagnosis] });
     assert.ok(
-      insights.find((i) => i.id === 'production-instability'),
-      'legacy production-instability 应该仍触发(不同 category 也不去重,跟同 category dual-run 一致)',
+      insights.find((i) => i.id === 'skill-doc-gap'),
+      'legacy skill-doc-gap 应仍触发(基于 doctor warn + eval skill_doc_missing,跟 Diagnosis 共存)',
     );
-    assert.ok(insights.find((i) => i.id === 'diagnosis:diag-doc'));
+    assert.ok(
+      insights.find((i) => i.id === 'diagnosis:diag-doc'),
+      'Diagnosis 投影也应共存',
+    );
   });
 });
 

--- a/test/server/skill-insights.test.ts
+++ b/test/server/skill-insights.test.ts
@@ -399,7 +399,11 @@ describe('detectInsights — Diagnosis projection', () => {
           message: '前置依赖警告', durationMs: 10,
         }],
       },
-      evalSnap: { reportId: 'e1', variantName: 'test-skill', timestamp: '2026-05-09T10:00:00Z', passCount: 0, failCount: 1, compositeScore: null },
+      evalSnap: {
+        reportId: 'e1', variantName: 'test-skill', timestamp: '2026-05-09T10:00:00Z',
+        verdictLevel: 'NOISE', verdictHeadline: 'noise',
+        compositeScore: null, passCount: 0, failCount: 1, tripwireCount: 0, totalSamples: 1,
+      },
     });
     // eval 报告含 skill_doc_missing rootCause,让 detectSkillDocGap 真的有数据触发
     const report = mkEvalReport('test-skill', [


### PR DESCRIPTION
## Purpose

回应 [issue #103](https://github.com/lizhiyao/oh-my-knowledge/issues/103) 提到的「两套并行的 skill 诊断系统未整合」。引入 \`Diagnosis + DiagnosisOccurrence\` 二层数据模型作为 skill 诊断的统一底层；observe 一支已经接通，doctor / eval 留给后续 PR。

设计原则：
- **UI 心智不动**：renderer 接口签名 0 行改动
- **数据底层走 Diagnosis**：observe inbox 生成 bundle，skill-insights 内部投影成 Insight 形态喂给 renderer，避免双算

Fixes #103（部分；doctor + eval 接入留 follow-up）。

## Changes

- **新增 \`src/diagnosis/\`**
  - \`types.ts\` — Diagnosis / DiagnosisOccurrence / DiagnosisBundle / 枚举
  - \`observe-mapper.ts\` — 5 类 observe source 翻译为 Diagnosis（纯函数）
  - \`observe-producer.ts\` — 从 \`ObservationInboxReport\` 实际接通 mapper
  - \`studio-projection.ts\` — summary + merge + active 投影 helper
- **接通点**
  - \`src/observability/inbox.ts\`：\`ObservationInboxReport\` 挂 \`diagnostics\` 可选字段
  - \`src/server/skill-index.ts\`：加 \`diagnosticsBySkill\` / \`diagnosisSummary\`，fingerprint 含 observations 目录失效信号
  - \`src/server/skill-insights.ts\`：\`projectDiagnosticsToInsights\` + \`detectInsights(entry, evalReport, { diagnostics })\`；传入 diagnostics 时屏蔽 observe 老路径，避免维护者双写
  - \`src/server/report-server.ts\`：暴露 \`/api/observations/diagnostics\`
- **设计文档** \`docs/diagnosis-occurrence-mapping.md\` 完整 mapping spec
- **renderer 0 接口改动**：skill-list / skill-detail renderer 接口签名一行没变

## Testing

- [x] \`yarn lint\` passes
- [x] \`yarn build\` passes
- [x] \`yarn test\` passes（1404 tests，新增 4 个测试文件覆盖 mapper / producer / skill-insights 投影 / 新 API）
- [x] \`scripts/check-git-user.ts\` ✅

## Checklist

- [x] Read \`CLAUDE.md\`
- [x] Branch is \`feat/diagnosis-architecture\`（从 main 切出，GitHub Flow）
- [x] Target branch is \`main\`
- [x] Commit message follows \`type(scope): subject\` 约定
- [x] PR title / description 注明用户可见影响与 follow-up
- [x] 无 secrets / 内部 URL / 个人数据
- [x] 设计文档同步进 \`docs/\`

## Follow-up（不阻塞本 PR 合并）

- soft standard 接入：等 [PR #106](https://github.com/lizhiyao/oh-my-knowledge/pull/106) 合并后补 \`SkillDerivedStandard\` 这一类
- observe-producer 当前用 \`ExperienceRuleFinding.code\` 当 \`ruleSource\`，PR #106 合并后改读真实 \`ExperienceReviewerReportFinding.ruleSource\` 字段
- \`maxLifecycle\` 合并策略中 \`resolved / confirmed / rejected\` 优先级排序需校准（按 docs/diagnosis-occurrence-mapping.md "confirmed soft standard → lifecycle=resolved" 的语义，resolved 应该是终态，当前 confirmed > resolved 反了）
- \`ExperienceReviewerReportFindingSource.level\` 当前枚举 7 选偏宽（含 critical/warning 等），PR #106 真实只有 3 种，可在 follow-up PR 收窄
- doctor / eval producer 迁移（issue #103 不包含此 scope，需要时另开 issue）
- partial coverage banner UI（dual-run 期间 studio 显式提示数据覆盖不全），留给 doctor/eval 全部迁完后再统一加

## Additional context

- 改动跟 [PR #106](https://github.com/lizhiyao/oh-my-knowledge/pull/106) 没有 schema 冲突：PR #106 引入的 \`reviewerReport / sessionStory / softStandard\` 字段不动，本 PR 只新增 Diagnosis 模型作为底层 + skill-insights 投影
- Diagnosis 模型设计文档已经多轮迭代，含 Phase 1-4 迁移路径、Open Questions、Conflict Table
- 本 PR 严格落到 issue #103 字面诉求 + 不动 UI 心智的双重约束内；超出范围的能力（如 standards view 的 nudge UI）留给后续单独 PR