### PR TITLE
docs: omk skill 同步 v0.30 命令树 + 加中文 skill 评测 quickstart

### DIFF
--- a/.claude/skills/omk/SKILL.md
+++ b/.claude/skills/omk/SKILL.md
@@ -2,7 +2,7 @@
 name: omk
 description: oh-my-knowledge 知识载体评测工具的智能代理。评测 skill（系统提示词）质量，对比不同版本效果，自动迭代改进。 Use when: 用户提到"评测"、"测评"、"eval"、"benchmark"、"对比 skill"、"改进 skill"、"evolve"、"生成测试用例"、"gen-samples"、"omk"。
 user-invocable: true
-argument-hint: "<eval|evolve|gen-samples|report|export> [options]"
+argument-hint: "<eval|evolve|sample|doctor|studio> [options]"
 ---
 
 # OMK — 知识载体评测
@@ -17,17 +17,20 @@ argument-hint: "<eval|evolve|gen-samples|report|export> [options]"
 npm i oh-my-knowledge -g
 ```
 
+omk CLI 顶层命令固定为 7 个：`init` / `doctor` / `eval` / `observe` / `evolve` / `sample` / `studio`。没有 `bench` / `improve` / `gen-samples` 这些旧子命令名 —— 如果你在历史 SKILL / 文档里看到了，那是 v0.30 命令树重构之前的写法。
+
 ## 第二步：理解用户意图
 
 根据用户的描述，匹配对应的操作：
 
 | 用户意图 | 操作 |
 |---------|------|
-| 评测/对比 skill | → 运行评测 |
-| 改进/优化 skill | → 自动迭代改进 |
-| 生成测试用例 | → 生成 eval-samples |
-| 查看报告 | → 启动报告服务 |
-| 导出报告 | → 导出 HTML |
+| 评测 / 对比 skill | → `omk eval` |
+| 改进 / 优化 skill | → `omk evolve`（自动多轮迭代） |
+| 生成测试用例 | → `omk sample` |
+| 体检 skill 写法 | → `omk doctor` |
+| 查看 / 浏览报告 | → `omk studio`（启动本地报告浏览器） |
+| 看真实使用 trace | → `omk observe` |
 
 如果用户意图不明确，先扫描当前项目结构（skills/ 目录和 eval-samples 文件），然后推荐最合适的操作。
 
@@ -36,47 +39,55 @@ npm i oh-my-knowledge -g
 使用 Glob 和 Read 工具检查：
 
 1. `skills/` 目录下有哪些 skill 文件（`.md` 或 `*/SKILL.md`）
-2. 是否存在 `eval-samples.json`、`eval-samples.yaml`、`eval-samples.yml`
-3. 是否有 `skills/*.eval-samples.json`（--each 模式的配对文件）
+2. 是否存在 `eval-samples.json` / `eval-samples.yaml` / `eval-samples.yml` / `<skill>/.omk/samples.json`（推荐的标准位置）
+3. 是否有 `skills/*.eval-samples.json`（每 skill 配对文件 → `--batch` 模式）
 
 根据检测结果决定：
 
-- 有多个 skill + 各自的 eval-samples → 建议 `--each` 批量模式
-- 有多个 skill + 共享 eval-samples → 建议版本对比模式
-- 只有一个 skill → 建议 `baseline` 对照或 `evolve` 改进
-- 没有 eval-samples → 建议先 `gen-samples` 生成
+- 多个 skill + 各自的 eval-samples → 建议 `--batch` 批量模式
+- 多个 skill + 共享 eval-samples → 建议版本对比模式
+- 只有一个 skill → 建议 `baseline` 对照（`omk eval --control baseline --treatment <skill>`）或 `omk evolve` 改进
+- 没有 eval-samples → 先 `omk sample <skill>` 生成
 
 ## 第四步：执行操作
 
-### 评测 Skill
+### 评测 skill
 
 ```bash
-# 自动发现 skills/ 下的所有 skill
-omk bench run
+# 单 skill 必要性测试（有 skill vs 没 skill）
+omk eval --control baseline --treatment my-skill
 
-# 对比指定变体
-omk bench run --variants v1,v2
+# 版本 A/B 对比
+omk eval --control my-skill-v1 --treatment my-skill-v2
 
-# 对比有无 skill 的效果
-omk bench run --variants baseline,my-skill
+# 对比 git 历史里的版本跟当前
+omk eval --control git:my-skill --treatment my-skill
 
-# 对比修改前后（从 git 历史读取旧版本）
-omk bench run --variants git:my-skill,my-skill
+# 批量评测：每个 skill 独立 vs baseline
+omk eval --batch
 
-# 批量评测多个独立 skill
-omk bench run --each
+# 先预览任务计划再执行
+omk eval --control v1 --treatment v2 --dry-run
 
-# 先预览再执行
-omk bench run --dry-run
+# 复杂配置走 eval.yaml
+omk eval --config eval.yaml
 ```
 
-常用选项：`--model`（被测模型）、`--judge-models executor:model`（评委,1 条 = 单评委,≥ 2 条 = ensemble）、`--concurrency`（并发数）
+常用选项：
+
+- `--model <name>` 任务执行模型（默认 opus；省钱用 sonnet / haiku）
+- `--effort <low|medium|high|xhigh|max>` 执行模型扩展思考预算（默认 low；跨 effort 报告不严格可比）
+- `--judge-models <executor:model[,...]>` 评委配置（默认 claude:haiku，≥ 2 条 = ensemble）
+- `--concurrency <n>` 并发数
+- `--skip-doctor` 跳过 doctor preflight 门禁（默认 doctor 会先跑一次卡掉 skill 写法大问题）
+- `--no-diagnostic` 关掉 diagnostic 诊断 LLM 调用（默认开启，给 failed sample 出「哪错了 + 怎么改」建议）
+- `--no-judge` 关掉评委主观评分（保留断言层）
 
 ### 自动迭代改进
 
 ```bash
-omk bench evolve skills/my-skill.md --rounds 5
-omk bench evolve skills/my-skill.md --rounds 10 --target 4.5
+omk evolve skills/my-skill.md --rounds 5
+omk evolve skills/my-skill.md --rounds 10 --target 4.5
 ```
 
 **重要：evolve 必须在前台运行（不要用 `run_in_background`）。** 原因：evolve 自带实时进度输出，每个 sample 执行时会打印 `[1/5] s001/... ⏳ 执行中...`，每轮完成会打印 `Round N: score=... ✓ ACCEPT / ✗ REJECT`。前台运行时用户能实时看到这些进度，无需手动询问。设置足够长的 timeout（建议 600000ms）以确保命令不会中途超时。
@@ -85,40 +96,64 @@ omk bench evolve skills/my-skill.md --rounds 10 --target 4.5
 
 ```bash
 # 为单个 skill 生成
-omk bench gen-samples skills/my-skill.md
+omk sample skills/my-skill.md
 
-# 为所有缺少测试集的 skill 批量生成
-omk bench gen-samples --each
+# 显式指定数量（不指定时 LLM 根据 skill 类型自动决定 4-8 条）
+omk sample skills/my-skill.md --count 8
+
+# 自然语言指定重点覆盖场景
+omk sample skills/my-skill.md --focus "重点覆盖搜索失败 / 权限拒绝 / 跨工具 fallback 路径"
+
+# 为 skill 目录下所有缺测试集的 skill 批量生成
+omk sample --batch
 ```
 
-### 查看/导出报告
+输出位置：`<skill>/SKILL.md` 风格 → `<skill>/.omk/samples.json`（标准），其他 `.md` 路径 → 当前目录 `eval-samples.json`（兜底）。
+
+### 体检 skill 写法
 
 ```bash
-# 启动报告服务
-omk bench report
+# 全量体检（含 LLM-judge 维度）
+omk doctor
 
-# 导出为独立 HTML
-omk bench report --export <报告名称>
+# 只跑静态检查不调 LLM
+omk doctor --static-only
+
+# 针对单 skill
+omk doctor skills/my-skill.md
 ```
+
+`omk eval` 默认会先跑一次 doctor 当 preflight 门禁，所以一般不用单独跑；想在 eval 之前先把结构问题先扫一遍再跑评测，就单独跑 `omk doctor`。
+
+### 查看 / 浏览报告
+
+```bash
+omk studio                                # 启动本地 web 报告浏览器
+omk studio --port 8080                    # 改端口
+omk studio --host 0.0.0.0                 # 局域网访问（默认 127.0.0.1）
+omk studio --no-open                      # 不自动开浏览器
+```
+
+Studio 是 skill-centric：列表页（`/`）按 skill 卡片展示健康等级 / 0-100 参考分 / 待优化数 / 趋势；详情页（`/skills/<name>`）左栏列关键问题清单，右栏画健康趋势 + 三档阶段卡（doctor / eval / observe）。访问 `/observations/inbox` 查看 observe inbox 看板。
 
 ## 第五步：解读结果
 
-评测命令会输出 JSON 结果。你需要用自然语言总结关键发现：
+`omk eval` 跑完会自动启动 studio 并输出 JSON 结果。你需要用自然语言总结关键发现：
 
 ### 版本对比模式
 
 总结要包含：
 
-1. **结论**：哪个 variant 更好（或差不多）
-2. **质量分数**：各 variant 的平均综合分数（满分 5 分）
-3. **成本对比**：token 消耗和费用差异
-4. **低分样本**：哪些样本两个版本差异最大，为什么
+1. **结论**：verdict 是 PROGRESS / NOISE / REGRESSION / CAUTIOUS，哪个 variant 更好
+2. **质量分数**：各 variant 的平均综合分（0-5 分）+ Δ + 95% CI
+3. **成本对比**：token 消耗、execCostUSD、判官花费、diagnostic 花费
+4. **低分样本**：哪些样本两个版本差异最大，rubric 期望 vs 实际差在哪
 5. **建议**：基于数据给出的下一步行动建议
 
 示例输出：
 
 ```
-v2 比 v1 更好：
+v2 比 v1 更好（verdict: PROGRESS，Δ=+0.7，95% CI [+0.3, +1.1]）：
 - 质量：v2 平均 4.5 分 vs v1 平均 3.8 分（+18%）
 - 成本：v2 略高（$0.15 vs $0.12），因为输出更详细
 - 亮点：v2 在 s002（错误处理）上显著提升（2.5 → 4.5），因为新增了"列出所有缺失的错误处理场景"指令
@@ -127,9 +162,9 @@ v2 比 v1 更好：
 
 ### evolve 模式
 
-总结进化过程：起始分数 → 最终分数，接受/拒绝了哪些改进，总花费。如果用户想看具体改了什么，引导查看 `skills/evolve/` 目录下的版本文件。
+总结进化过程：起始分数 → 最终分数，接受 / 拒绝了哪些改进，总花费。如果用户想看具体改了什么，引导查看 `skills/evolve/` 目录下的版本文件。
 
-### 批量评测模式
+### 批量评测模式（`--batch`）
 
 列出每个 skill 的 baseline 分 vs skill 分和提升幅度，高亮表现最好和最差的 skill。
 
@@ -146,11 +181,11 @@ v2 比 v1 更好：
       values: ["auth.ts", "login.tsx"]
 ```
 
-`cwd` 会作为 executor 的工作目录，`claude -p` 将在该目录下运行，能自动读取仓库代码。适用于"给一个任务 query，断言应该修改哪些文件"的 A/B 评测场景。
+`cwd` 会作为 executor 的工作目录，`claude -p` 将在该目录下运行，能自动读取仓库代码。适用于「给一个任务 query，断言应该修改哪些文件」的 A/B 评测场景。
 
 ## 注意事项
 
-- 评测需要调用 LLM，会产生费用。运行前告知用户预估成本（样本数 × 变体数 × 约 $0.01-0.05/次）
+- 评测需要调用 LLM，会产生费用。运行前告知用户预估成本（样本数 × 变体数 × 约 $0.01-0.05 美元 / 次）
 - 首次使用建议先 `--dry-run` 预览任务计划
 - `evolve` 命令会修改原始 skill 文件，原始版本保存在 `skills/evolve/*.r0.md`
 - 详细命令参考见 [commands.md](references/commands.md)

--- a/.claude/skills/omk/references/commands.md
+++ b/.claude/skills/omk/references/commands.md
@@ -1,87 +1,147 @@
-# OMK 命令参考
+# omk 命令参考
 
-## omk bench run
+omk v0.30+ 顶层命令固定为 7 个：`init` / `doctor` / `eval` / `observe` / `evolve` / `sample` / `studio`。本文档同步当前 CLI 表面，跟 `omk <command> --help` 输出一致。
 
-运行评测，对比不同 skill 版本的效果。
+## omk init
+
+生成评测项目脚手架（两版 starter skill + `eval-samples.json`）。
 
 ```
-omk bench run [选项]
+omk init [目录]
+```
 
-选项：
-  --samples <路径>       样本文件（默认：eval-samples.json）
-  --skill-dir <路径>     skill 目录（默认：skills）
-  --variants <a,b>       变体名称，不指定时自动从 skill 目录发现
-  --model <名称>         被测模型（默认：sonnet）
-  --judge-models <executor:model[,executor:model]>  评委（默认：claude:haiku；≥ 2 = ensemble）
-  --concurrency <n>      并行任务数（默认：1）
-  --timeout <秒>         单个任务的执行器超时时间（默认：120）
-  --no-judge             跳过 LLM 评分
-  --no-cache             禁用结果缓存
-  --dry-run              仅预览任务计划
-  --blind                盲测模式
-  --repeat <n>           重复 N 次做方差分析
-  --each                 批量模式：每个 skill 独立和 baseline 对比
-  --executor <名称>      执行器：claude, openai, gemini, anthropic-api, openai-api,
-                         或任意 shell 命令（如 "python my_provider.py"）
+## omk doctor
+
+LLM 健康度审计：7 个内置维度（结构 / 规范 / 工作流 / 依赖 / 内容 / 一致性 / 可观测性）+ 可扩展规则。
+
+```
+omk doctor                       # 项目内所有 skill 体检
+omk doctor skills/my-skill.md    # 单 skill 体检
+omk doctor --static-only         # 只跑静态规则，不调 LLM judge
+omk doctor --html <path>         # 输出 HTML 报告
+```
+
+`omk eval` 默认会先跑一次 doctor 当 preflight 门禁，所以 doctor 一般不用单独跑；想在 eval 之前先扫一遍结构问题再决定要不要跑评测，就单独跑 doctor。
+
+## omk eval
+
+离线评测：比较版本，输出 verdict + report。
+
+```
+omk eval --control <variant> --treatment <variant> [选项]
+```
+
+常用选项：
+
+```
+--samples <path>          用例文件（默认 eval-samples.json，也接受 .yaml / .yml；自动发现 <skill>/.omk/samples.json）
+--skill-dir <path>        skill 目录（默认 skills）
+--control <expr>          对照组 variant 表达式
+--treatment <v1,v2>       实验组 variant 名，逗号分隔
+--config <path>           eval.yaml / JSON 配置
+--executor <name>         执行器：claude / claude-sdk / codex / codex-sdk / openai-api / gemini / custom
+--model <name>            任务执行模型（默认 opus；省钱用 sonnet / haiku）
+--effort <level>          扩展思考预算 low / medium / high / xhigh / max（默认 low；跨 effort 报告不严格可比）
+--judge-models <list>     评委配置，例如 claude:haiku 或 claude:opus,openai:gpt-4o（≥ 2 = ensemble）
+--concurrency <n>         并行任务数
+--dry-run                 预览任务计划，不调用模型
+--batch                   批量模式：每个 skill 独立 vs baseline
+--blind                   盲测模式
+--bootstrap               显式开启 bootstrap CI（默认自动开启）
+--bootstrap-samples <n>   bootstrap 重采样次数（默认 1000）
+--threshold <number>      verdict gate 阈值（默认 3.5）
+--trivial-diff <number>   实际可忽略 diff（默认 0.1）
+--report-only / --no-gate 生成报告并打印 verdict，但始终 exit 0
+--no-serve                评测后不自动启动报告 server
+--no-judge                关闭 judge 主观评分（仍跑断言层）
+--no-diagnostic           关闭 diagnostic 诊断 LLM 调用
+--skip-doctor             escape hatch：跳过 doctor preflight 门禁
 ```
 
 Variant 特殊值：
-- `baseline` — 无 skill 对照
-- `git:name` — 从 git HEAD 读取旧版本
-- `git:ref:name` — 从指定 commit 读取
+
+- `baseline` — 不注入 skill 的裸基线（保留 variant 名）
+- `git:<name>` — 从 git HEAD 读取旧版本
+- `git:<ref>:<name>` — 从指定 commit 读取
 - 含 `/` 的路径 — 直接读取文件
 
-## omk bench evolve
+退出码：verdict 为 `PROGRESS` 退 0，其他非 0（受 `--threshold` / `--report-only` 影响）。CI gate 直接用 exit code 就行。
 
-AI 自动迭代改进 skill。
+## omk evolve
+
+LLM 自动多轮迭代改进 skill。
 
 ```
-omk bench evolve <skill路径> [选项]
+omk evolve <skill 路径> [选项]
+```
 
 选项：
-  --rounds <n>           最大迭代轮数（默认：5）
-  --target <分数>        目标分数，达到即停
-  --samples <路径>       样本文件（默认：eval-samples.json）
-  --improve-model <名称> 改进用模型（默认：sonnet）
-```
-
-每轮版本保存在 `skills/evolve/` 目录。连续 2 轮无改进自动早停。
-
-## omk bench gen-samples
-
-LLM 辅助生成测评用例。
 
 ```
-omk bench gen-samples <skill路径>        # 单个 skill
-omk bench gen-samples --each             # 批量生成
+--rounds <n>           最大迭代轮数（默认 5）
+--target <分数>        目标分数，达到即停
+--samples <path>       用例文件
+--model <name>         改进用模型
+--effort <level>       扩展思考预算
+--no-diagnostic        关闭 diagnostic
+--skip-doctor          跳过 doctor preflight
+```
+
+每轮版本保存在 `skills/evolve/<skill>.rN.md`。连续 2 轮无改进自动早停。**必须前台运行**：evolve 自带实时进度输出，前台才能看到每个 sample 的 `[N/M] sample_id ⏳ 执行中...` 跟每轮 `Round N: score=... ✓ ACCEPT / ✗ REJECT`。
+
+## omk sample
+
+生成或补齐 eval-samples 评测用例。
+
+```
+omk sample <skill 路径>           # 单 skill
+omk sample --batch [选项]         # skill 目录下缺测试集的 skill 批量生成
+```
 
 选项：
-  --count <n>            样本数（默认：5）
-  --model <名称>         生成用模型（默认：sonnet）
-  --skill-dir <路径>     skill 目录（配合 --each）
-```
-
-## omk bench report
-
-启动报告服务或导出报告。
 
 ```
-omk bench report                         # 启动 web 服务
-omk bench report --export <报告名称>     # 导出独立 HTML
-
-选项：
-  --port <端口号>        服务端口（默认：7799）
-  --reports-dir <路径>   报告目录
+--count <n>            强制生成 N 条（不指定时 LLM 按 skill 类型自动判断：
+                       工作流型 6-8 条 / 原子型 4-6 条 / 混合型 5-7 条）
+--model <name>         生成模型（默认 opus；省钱用 sonnet / haiku）
+--focus <text>         自然语言指定希望覆盖的场景（追加到 prompt）
+--skill-dir <path>     skill 目录（batch 使用，默认 skills）
 ```
 
-## omk bench ci
+输出位置（默认）：
 
-CI 流水线中运行评测，分数达标退出 0，否则退出 1。
+- `<skill>/SKILL.md` 风格 → `<skill>/.omk/samples.json`（omk 标准约定）
+- 其他 `.md` 路径 → 当前目录 `eval-samples.json`（兜底）
+
+## omk observe
+
+线上观测：解析真实 session trace，输出 skill 健康度 / gap 信号 / 失败率 / observe inbox。
 
 ```
-omk bench ci [选项]
-  --threshold <数值>     达标分数（默认：3.5）
+omk observe <sessions-dir>                          # skill 健康度报告（默认）
+omk observe ingest <sessions-dir>                   # 摄入 trace 落盘到 .omk/observations/
+omk observe inbox                                   # 看 inbox 列表
+omk observe inbox --skill <name>                    # 只看某 skill
+omk observe inbox --by-skill                        # 按 skill 资产视图
+omk observe show <inbox_id>                         # 单条 observation 事件三元组
 ```
+
+支持 trace 格式：Claude Code session JSONL、OpenClaw session JSONL、markdown 对话日志（`.log`）。
+
+## omk studio
+
+本地报告浏览器。
+
+```
+omk studio                                # 启动 web 服务
+omk studio --port 8080                    # 改端口（默认 7799）
+omk studio --host 0.0.0.0                 # 局域网访问（默认 127.0.0.1）
+omk studio --reports-dir <path>           # 报告目录
+omk studio --observations-dir <path>      # observe inbox 数据目录
+omk studio --no-open                      # 不自动开浏览器
+```
+
+Studio 是 skill-centric：列表页（`/`）按 skill 卡片展示健康等级 / 0-100 参考分 / 待优化数 / 趋势；详情页（`/skills/<name>`）左栏列关键问题清单（skill 优化项 / 用例优化项 / 工具反馈三档），右栏画 chart.js 健康趋势 + 三个紧凑阶段卡。旧的 run 列表在 `/runs`，observe inbox 看板在 `/observations/inbox`。
 
 ## eval-samples 字段参考
 
@@ -92,13 +152,14 @@ omk bench ci [选项]
 | `context` | 否 | 附加上下文（代码片段等） |
 | `cwd` | 否 | executor 工作目录，用于指定目标仓库路径 |
 | `rubric` | 否 | LLM 评分标准 |
-| `assertions` | 否 | 断言数组 |
-| `dimensions` | 否 | 多维度评分 { 维度名: 评分标准 } |
+| `assertions` | 否 | 断言数组（含 `mock_hit` 等新 v0.30 类型） |
+| `dimensions` | 否 | 多维度评分 `{ 维度名: 评分标准 }` |
+| `capability` | 否 | 能力标签（HF Dataset Cards 风） |
+| `difficulty` | 否 | 难度等级 |
+| `construct` | 否 | 测的是什么构念 |
+| `provenance` | 否 | 用例来源（`omk sample` 自动打） |
+| `mocks` | 否 | 工具调用 mock 返回（sandbox 评测） |
+| `environment` | 否 | 评测环境前置「已就绪」声明 |
+| `tripwire` | 否 | 标记为「故意诱错」样本，failed 时 diagnostic 不建议改 skill |
 
-## omk bench init
-
-生成评测项目脚手架。
-
-```
-omk bench init [目录]
-```
+完整 schema 见 [docs/sample-design-spec.md](../../../docs/sample-design-spec.md)。

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -1,0 +1,106 @@
+# omk 快速上手：给 skill 跑评测
+
+5 分钟跑出第一份报告。目标读者：手里有一版（或几版）skill，想用数据看看「这版 skill 到底好不好」「v1 跟 v2 哪版更稳」。
+
+## 前置（1 分钟）
+
+```bash
+npm i oh-my-knowledge -g
+omk --version
+```
+
+跑 `omk --version` 看到版本号就装好了。
+
+如果你想用「自然语言让 agent 帮你跑」的方式（推荐），还需要把 omk skill 装到你的 agent 工具里。Claude Code 用户：
+
+```bash
+git clone https://github.com/lizhiyao/oh-my-knowledge.git /tmp/omk-src
+mkdir -p ~/.claude/skills
+cp -r /tmp/omk-src/.claude/skills/omk ~/.claude/skills/
+```
+
+Codex 用户改 `~/.codex/agents/skills/`。装好之后，agent 收到含「omk」「评测」「benchmark」之类的关键词就会自动加载 SKILL 上下文。
+
+## 准备 skill（1 分钟）
+
+按 omk 默认布局放 skill：
+
+```
+skills/
+├── my-skill.md           单文件 skill
+└── my-skill-v2/
+    ├── SKILL.md          目录式 skill
+    └── references/       可选,长示例 / 参考资料
+```
+
+要跑 v1 vs v2 对比，就放两份；只想看「有 skill vs 没 skill」的差距，放一份就行（baseline 对照模式）。
+
+## 跑评测（3 分钟）
+
+### 路径 A：自然语言（推荐）
+
+打开 Claude Code，进入项目目录，直接说一句话：
+
+> 帮我用 omk 给 skills/my-skill 跑一次评测
+
+omk skill 会自动判断：没有 `eval-samples.json` 就先帮你生成用例，然后跑评测，最后把报告浏览器弹出来。常见说法：
+
+- 「用 omk 对比 skills/my-skill-v1 跟 skills/my-skill-v2」
+- 「用 omk 给 skills/audit 跑 baseline 对照（有 skill vs 没 skill）」
+- 「用 omk 跑 skills/ 下面所有 skill 的批量评测」
+- 「用 omk evolve 自动改进 skills/my-skill，跑 5 轮」
+
+### 路径 B：直接命令行
+
+```bash
+omk sample skills/my-skill.md                       # 第一次:让 AI 给你的 skill 生成评测用例
+omk eval --control v1 --treatment v2 --dry-run      # 预览要跑什么
+omk eval --control v1 --treatment v2                # 真跑
+omk studio                                          # 启动报告浏览器
+```
+
+`--dry-run` 预览时会告诉你预估调用次数和成本，确认 OK 再去掉 flag 真跑。`omk eval` 默认会先跑一次 doctor 健康度检查当门禁，发现 skill 写法有大问题就直接拦下来；如果你确认知道自己在干嘛，加 `--skip-doctor` 绕过。
+
+## 看结果（1 分钟）
+
+报告浏览器自动弹出（默认 `http://127.0.0.1:7799/`），重点看三个地方：
+
+**verdict**（跨版本结论）：`PROGRESS`（变好）/ `NOISE`（差距在置信区间内不可区分）/ `REGRESSION`（变差）/ `CAUTIOUS`（趋势好但置信不足）。这是你能直接拿出去对焦的一句话结论。
+
+**综合分**：每版 0-5 分平均，跟基线比 `+Δ` 多少。Δ 旁边的 95% 置信区间决定 verdict 落点。
+
+**低分用例**：点开看 LLM 在哪条用例上崩了。对照「rubric 期望」跟「LLM 实际输出」找差距 —— 通常能直接看出 skill 文档哪段写得不够清楚。
+
+## 关键提示
+
+**用例生成会花时间**。omk 默认让 AI 给你的 skill 生成 10-20 条用例，但 AI 生成的用例**有偏**：容易扎堆在 skill 文档已经写清楚的「happy path」上，对边界 / 反例 / 误用场景覆盖不足。**强烈建议**第一次跑完之后花 30 分钟人工筛一遍：删掉不合理的、补缺关键边界、补几条「故意写错的用户指令」看 skill 会不会被带偏。这是评测结果可信度的最大变量。
+
+**评测会产生 LLM 费用**。粗算单条用例 × 单 variant 约 $0.01-0.05 美元，10 条用例 × 2 variants 约 $0.2-1 美元。跑前 `--dry-run` 预览。
+
+**结论只对你给定的用例集负责**。「我这版 skill 更好」这句话的天花板是「在你设计的 N 条用例上更好」。换用例集结论可能翻盘。所以**用例设计本身就是结论可信度的源头** —— 不要把它当成「跑评测前的麻烦事」，它就是评测本身。
+
+## 常见场景速查
+
+| 想做什么 | 自然语言说法 | 等价命令 |
+|---|---|---|
+| 第一次给 skill 跑分 | 给 skills/X 跑 baseline 对照 | `omk eval --control baseline --treatment X` |
+| 改完前后对比 | 对比 git 历史里的 skills/X 跟当前版本 | `omk eval --control git:X --treatment X` |
+| 让 omk 帮我自动改 skill | 用 omk evolve skills/X 跑 5 轮 | `omk evolve skills/X.md --rounds 5` |
+| 批量评测一批 skill | 给 skills/ 下所有 skill 跑评测 | `omk eval --batch` |
+| 只生成用例不跑评测 | 给 skills/X 生成测试用例 | `omk sample skills/X.md` |
+| 单独跑健康度检查 | 给 skills/X 做 doctor 体检 | `omk doctor skills/X.md` |
+| 看历史报告 | 打开 omk studio | `omk studio` |
+
+## 跑完第一份报告，对焦时拿这些信息走
+
+- verdict + 综合分 + Δ + 95% CI 区间
+- 哪几条用例分数最低，rubric 期望 vs LLM 实际差在哪
+- 你对哪些用例的设计有疑问（避免「数据说话也要怀疑数据」的盲信）
+- doctor 健康度结论（eval 默认会跑，报告里有；如果想单独审一次跑 `omk doctor`）
+
+## 更深的玩法
+
+- 详细 CLI / executor / judge / observe 参考：[README.zh.md](../../README.zh.md)
+- 评分管道（assertion / llm / judge / dimension / composite 五层）：[scoring.md](./scoring.md)
+- 测量学严谨性（Bootstrap CI / Krippendorff α / length-debias 等）：[statistical-rigor.md](./statistical-rigor.md)
+- 用例设计规范（mocks / environment / tripwire / mocksStrict）：[sample-design-spec.md](../sample-design-spec.md)

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -29,16 +29,19 @@ skills/
 └── my-skill-v2.md
 ```
 
-只有当 skill 内容超长、想把示例 / 参考资料拆到独立文件时，再用目录式：
+只有当 skill 内容超长、想把示例 / 参考资料拆到独立文件时，再用目录式（每版一个目录）：
 
 ```
-skills/my-skill/
-├── SKILL.md         主体
-└── references/      长示例 / 参考资料
-    └── examples.md
+skills/
+├── my-skill-v1/
+│   └── SKILL.md
+└── my-skill-v2/
+    ├── SKILL.md
+    └── references/      长示例 / 参考资料
+        └── examples.md
 ```
 
-两种形式 omk 都能识别，混用也行。要跑 v1 vs v2 对比就放两份；只想看「有 skill vs 没 skill」的差距，放一份就够，用 baseline 对照。
+两种形式 omk 都能识别，混用也行。要跑 v1 vs v2 对比就按上面放两版；只想看「有 skill vs 没 skill」的差距，放一份就够，用 baseline 对照。
 
 ## 跑评测（3 分钟）
 

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -6,10 +6,8 @@
 
 ```bash
 npm i oh-my-knowledge -g
-omk --version
+omk --version    # 能输出版本号即装好
 ```
-
-跑 `omk --version` 看到版本号就装好了。
 
 如果你想用「自然语言让 agent 帮你跑」的方式（推荐），还需要把 omk skill 装到你的 agent 工具里。Claude Code 用户：
 
@@ -23,17 +21,24 @@ Codex 用户改 `~/.codex/agents/skills/`。装好之后，agent 收到含「omk
 
 ## 准备 skill（1 分钟）
 
-按 omk 默认布局放 skill：
+按 omk 默认布局把 skill 放到 `skills/` 目录下。**推荐用单 `.md` 文件**，最简单：
 
 ```
 skills/
-├── my-skill.md           单文件 skill
-└── my-skill-v2/
-    ├── SKILL.md          目录式 skill
-    └── references/       可选,长示例 / 参考资料
+├── my-skill-v1.md
+└── my-skill-v2.md
 ```
 
-要跑 v1 vs v2 对比，就放两份；只想看「有 skill vs 没 skill」的差距，放一份就行（baseline 对照模式）。
+只有当 skill 内容超长、想把示例 / 参考资料拆到独立文件时，再用目录式：
+
+```
+skills/my-skill/
+├── SKILL.md         主体
+└── references/      长示例 / 参考资料
+    └── examples.md
+```
+
+两种形式 omk 都能识别，混用也行。要跑 v1 vs v2 对比就放两份；只想看「有 skill vs 没 skill」的差距，放一份就够，用 baseline 对照。
 
 ## 跑评测（3 分钟）
 


### PR DESCRIPTION
## Summary

两个文档改动一起合：

1. **修 omk skill 跟当前 CLI 表面对不上的 bug**  
   `.claude/skills/omk/SKILL.md` + `.claude/skills/omk/references/commands.md` 在 ec85bc7（2026-05-02）之后没动过，但 \`3d86680 feat(cli)!: 收口产品命令树\` 把 \`omk bench *\` 整套命名空间删了。结果就是 agent 加载 omk skill 之后真去跑评测会拿到 \`command not found: omk bench\`。本次把 SKILL 与参考表的所有 \`omk bench *\` 替换成 v0.30 真实 CLI（\`omk eval\` / \`omk evolve\` / \`omk sample\` / \`omk studio\`），顺带补 v0.30 新增字段（diagnostic / mocks / tripwire 等）和 Studio v2 skill-centric 信息架构的描述。

2. **加中文 skill 评测 quickstart**  
   \`docs/zh/quickstart-skill-eval.md\`（106 行）。仓库目前没 quickstart 文档，README 是长 reference。这一份是 5 分钟从零跑出第一份报告的实操指南，目标读者是「有一版 skill，想用数据看看 v1 vs v2 哪版更稳」的内部同事 / 外部用户。

## 用户影响

- omk skill 用户：从「跑评测拿 command not found」修为「跑评测能跑通」
- 外部新用户：仓库新增 quickstart 入口，README 不再是唯一上手路径

## 不影响测量学不变量

- 不动 \`src/types/report.ts\` schema 字段语义
- 不动 \`test/grading/judge-hash-frozen.test.ts\` 冻结 hash
- 不动评分管道 / Bootstrap CI / Krippendorff α / length-debias

## Test plan

- [x] \`yarn lint\` pass（只改 .md，无 TS）
- [x] \`grep -n "omk bench" .claude/skills/omk/\` 零命中
- [x] quickstart 提到的命令都过 \`omk <cmd> --help\` 核对

🤖 Generated with [Claude Code](https://claude.com/claude-code)