### PR TITLE
docs: 加英文 quickstart + README 双向链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ omk init my-eval && cd my-eval
 omk eval --control code-review-v1 --treatment code-review-v2    # → HTML report with verdict in 5 minutes
 ```
 
+Walkthrough: [5-minute quickstart guide](docs/quickstart-skill-eval.md) (recommended for first-time users).
+
 Deeper: [use inside Claude Code / Codex](#use-inside-ai-coding-agents) · [`omk eval` flags](#omk-eval) · [artifact directory layout](#artifact-directory-layout) · [`--lang` / `OMK_LANG`](#environment-variables)
 
 ## Use inside AI Coding Agents

--- a/README.zh.md
+++ b/README.zh.md
@@ -27,6 +27,8 @@ omk init my-eval && cd my-eval
 omk eval --control code-review-v1 --treatment code-review-v2    # → 5 分钟出 HTML 报告 + verdict
 ```
 
+手把手教程：[5 分钟快速上手](docs/zh/quickstart-skill-eval.md)（推荐第一次跑评测的用户）。
+
 深入：[在 Claude Code / Codex 中调用](#在-ai-coding-agent-中使用) · [`omk eval` 全 flag](#omk-eval) · [artifact 目录结构](#artifact-目录结构) · [`--lang` / `OMK_LANG`](#环境变量)
 
 ## 在 AI Coding Agent 中使用

--- a/docs/quickstart-skill-eval.md
+++ b/docs/quickstart-skill-eval.md
@@ -1,0 +1,113 @@
+# omk quickstart: benchmark a skill
+
+Get your first report in 5 minutes. Target audience: you have one (or several) skill files and want data to answer "is this skill any good?" or "which of v1 vs v2 is the safer bet?"
+
+## Setup (1 minute)
+
+```bash
+npm i oh-my-knowledge -g
+omk --version    # prints a version number once installed
+```
+
+If you want the **agent-driven workflow** (recommended), also install the omk skill into your coding agent. For Claude Code users:
+
+```bash
+git clone https://github.com/lizhiyao/oh-my-knowledge.git /tmp/omk-src
+mkdir -p ~/.claude/skills
+cp -r /tmp/omk-src/.claude/skills/omk ~/.claude/skills/
+```
+
+Codex users: copy into `~/.codex/agents/skills/` instead. Once installed, the agent auto-loads the SKILL context when you mention "omk", "benchmark", "evaluate", "skill eval", etc.
+
+## Prepare your skill (1 minute)
+
+Place skills under `skills/`. **Single `.md` files are the simplest layout**:
+
+```
+skills/
+├── my-skill-v1.md
+└── my-skill-v2.md
+```
+
+Switch to a directory layout (one folder per version) only when a skill is large enough to need split-out examples or references:
+
+```
+skills/
+├── my-skill-v1/
+│   └── SKILL.md
+└── my-skill-v2/
+    ├── SKILL.md
+    └── references/     long examples / reference material
+        └── examples.md
+```
+
+Both layouts are recognized; mixing them is fine. For a v1 vs v2 A/B, drop in two versions. To answer "does this skill help at all" with a baseline control, one version is enough.
+
+## Run the eval (3 minutes)
+
+### Path A: natural language (recommended)
+
+Open Claude Code, `cd` into your project, and say:
+
+> Use omk to benchmark skills/my-skill
+
+The omk skill takes care of the rest: it auto-generates samples if `eval-samples.json` is missing, runs the eval, and opens the report in your browser. Other useful phrasings:
+
+- "Use omk to compare skills/my-skill-v1 against skills/my-skill-v2"
+- "Use omk to run a baseline control for skills/audit (with-skill vs without-skill)"
+- "Use omk to batch-evaluate every skill under skills/"
+- "Use omk evolve to auto-improve skills/my-skill over 5 rounds"
+
+### Path B: command line
+
+```bash
+omk sample skills/my-skill.md                       # first time: AI-generate eval samples
+omk eval --control v1 --treatment v2 --dry-run      # preview the task plan
+omk eval --control v1 --treatment v2                # run for real
+omk studio                                          # open the report browser
+```
+
+`--dry-run` prints expected call count and cost estimates — confirm, drop the flag, and run. `omk eval` runs a doctor health check as a preflight gate by default; if a skill has structural problems it gets blocked early. Pass `--skip-doctor` to bypass when you know what you're doing.
+
+## Read the report (1 minute)
+
+The browser auto-opens (default `http://127.0.0.1:7799/`). Look at three things:
+
+**Verdict** (cross-version conclusion): `PROGRESS` (better) / `NOISE` (diff inside the confidence band, undecidable) / `REGRESSION` (worse) / `CAUTIOUS` (trends look good but confidence is thin). This is the one-line answer to bring to a review meeting.
+
+**Composite score**: each variant's average on a 0–5 scale, with a `+Δ` against the control. The 95% confidence interval next to Δ is what decides where the verdict lands.
+
+**Low-scoring samples**: drill into the ones where the LLM tripped. Compare "rubric expectation" against "actual LLM output" — usually the gap points right back at a specific paragraph in the skill that wasn't clear enough.
+
+## Things to keep in mind
+
+**Sample generation takes time.** omk asks the AI to generate 10–20 samples per skill by default, but AI-generated samples are **biased**: they cluster around the happy-path scenarios the skill already documents well, and undersample edge cases, counterexamples, and misuse paths. **Spend 30 minutes** after the first run filtering: drop the implausible ones, add the missing boundary cases, add a few "intentionally wrong user instructions" to see whether the skill resists being misled. This is the single biggest variable in how much you can trust your numbers.
+
+**Evaluation costs LLM tokens.** Rough order of magnitude: one sample × one variant ≈ $0.01–0.05, ten samples × two variants ≈ $0.2–1. Always `--dry-run` first.
+
+**Conclusions only generalize to the sample set you wrote.** "This version of the skill is better" is bounded by "better on the N samples I designed". Swap the sample set and the conclusion could flip. So **sample design itself is the source of conclusion credibility** — don't treat it as a chore before running the eval, it *is* the eval.
+
+## Common task cheat-sheet
+
+| Goal | Natural language | Equivalent command |
+|---|---|---|
+| First-time scoring of a skill | run a baseline control for skills/X | `omk eval --control baseline --treatment X` |
+| Before/after a skill change | compare git history skills/X against current | `omk eval --control git:X --treatment X` |
+| Auto-improve a skill | use omk evolve on skills/X for 5 rounds | `omk evolve skills/X.md --rounds 5` |
+| Batch-eval every skill | run eval on every skill under skills/ | `omk eval --batch` |
+| Generate samples only | generate eval samples for skills/X | `omk sample skills/X.md` |
+| Run health-check alone | run a doctor health check on skills/X | `omk doctor skills/X.md` |
+| View past reports | open omk studio | `omk studio` |
+
+## What to bring to the review meeting after your first run
+
+- Verdict + composite score + Δ + 95% CI band
+- Which samples scored lowest, and where the gap between rubric expectation and LLM output was
+- Which samples you have doubts about by design (it's healthy to "let data speak, then question the data")
+- Doctor health-check result (eval runs it by default; run `omk doctor` alone if you want to audit the skill's structure separately)
+
+## Going deeper
+
+- Full CLI / executor / judge / observe reference: [README.md](../README.md)
+- Five-layer scoring pipeline (assertion / LLM / judge / dimension / composite): [statistical-rigor.md](./statistical-rigor.md)
+- Sample design spec (`mocks` / `environment` / `tripwire` / `mocksStrict`): [sample-design-spec.md](./sample-design-spec.md)


### PR DESCRIPTION
## Summary

补一份英文版 5 分钟 quickstart 跟中文版对齐，并在 README.md / README.zh.md 的 Quick start 段加双向链接。

omk 是开源项目（npm 公开），README.md 是英文入口。之前只有 `docs/zh/quickstart-skill-eval.md`，国际用户从英文 README 找不到 5 分钟上手路径，门槛比中文用户高。这次补齐 `docs/quickstart-skill-eval.md`，结构跟 zh 版镜像。

## 用户影响

- 英文用户：README 加 [5-minute quickstart guide](docs/quickstart-skill-eval.md) 入口
- 中文用户：README.zh 同位置加 [5 分钟快速上手](docs/zh/quickstart-skill-eval.md) 入口
- 仓库内 `docs/` parity 改善：英文 docs 直接放 `docs/` 根、中文放 `docs/zh/`，跟现有 `docs/comparison.md` / `docs/statistical-rigor.md` 等惯例一致

## 翻译本地化

- 自然语言例句翻成英文 prompt 形态（「Use omk to benchmark skills/X」）
- 货币不写「美元」单位词，只保留 `$0.01-0.05`
- 术语跟现有 README.md 英文段对齐（benchmark / judge / sample / verdict）
- 「更深的玩法」段链接指英文 docs（不再走 zh 路径）

## 不影响测量学不变量

- 不动 `src/types/report.ts` schema
- 不动 `test/grading/judge-hash-frozen.test.ts` 冻结 hash
- 不动评分管道 / Bootstrap CI / Krippendorff α / length-debias

## Test plan

- [x] `yarn lint` pass（只改 .md，无 TS）
- [x] 英文版结构跟 zh 版镜像（113 行 vs 114 行）
- [x] 英文版提到的所有命令过 `omk <cmd> --help` 核对

🤖 Generated with [Claude Code](https://claude.com/claude-code)
