### PR TITLE
chore(github): PR template checklist 强化 docs sync 防御

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,8 @@ commit-message convention, and validation requirements.
 - [ ] Commit message follows the repo convention (`type(scope): subject`)
 - [ ] PR title / description note user-facing impact + migration if BREAKING (release notes are auto-generated from PR list)
 - [ ] No secrets / internal URLs / personal data in the diff
-- [ ] README / docs updated if behavior or CLI surface changed
+- [ ] If CLI surface or user-facing behavior changed: README.md / README.zh.md / `.claude/skills/omk/SKILL.md` (+ `references/commands.md`) / quickstart docs all updated as needed
+- [ ] Bilingual parity: en (`README.md`, `docs/*.md`) and zh (`README.zh.md`, `docs/zh/*.md`) versions stay in sync — never update one language without the other
 
 ## Additional context
 


### PR DESCRIPTION
## Purpose

把 PR template 现有的 \"README / docs updated if behavior or CLI surface changed\" 这条改成两条更具体的勾选项，给最近几次踩坑做直接 process 防御。

## Changes

\`.github/PULL_REQUEST_TEMPLATE.md\` 第 36 行原来一句模糊 checklist：

\`\`\`
- [ ] README / docs updated if behavior or CLI surface changed
\`\`\`

改成两条：

\`\`\`
- [ ] If CLI surface or user-facing behavior changed: README.md / README.zh.md / .claude/skills/omk/SKILL.md (+ references/commands.md) / quickstart docs all updated as needed
- [ ] Bilingual parity: en (README.md, docs/*.md) and zh (README.zh.md, docs/zh/*.md) versions stay in sync — never update one language without the other
\`\`\`

## 用户影响

新提 PR 时 checklist 会更明确：

- 直接列出要同步的具体文件路径，而不是模糊的「README / docs」
- 显式要求双语 parity（en + zh）

## 这是对最近几次踩坑的直接防御

1. \`3d86680 feat(cli)!: 收口产品命令树\` 删了 \`omk bench *\` 整个命名空间，但 \`.claude/skills/omk/SKILL.md\` 跟 \`references/commands.md\` 一直没跟，导致 agent 加载 omk skill 后跑 \`omk bench run\` 全部 \`command not found\`，半个版本周期才在 #108 发现并修
2. README.zh.md 漏 OpenClaw trace source 提及（README.md 有），跨 PR review 才发现
3. \`src/types/report.ts\` 注释里 \`v0.32 新增\` 漂成 typo（实际是 v0.30），靠 v0.30.0 release CR 才修

## 长期方案

短期 process 兜底。长期靠 #109（CLI → docs 单向 codegen）根治 —— 那个落地后 README + SKILL.md 的 CLI 段都从源码生成，物理上不可能漂移。

## Test plan

- [x] PR template 改动只影响 \`.github/PULL_REQUEST_TEMPLATE.md\`，无代码改动
- [x] 新 checklist 项可以勾选（GitHub PR UI 自动识别 \`- [ ]\` 语法）

🤖 Generated with [Claude Code](https://claude.com/claude-code)