### PR TITLE
chore(agents-md): AGENTS.md 改 canonical, CLAUDE.md @import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ package-lock.json
 .claude/settings.local.json
 .claude/outputs/
 .omk/
+# Codex / 其它 agent CLI 的本地 hook / config 是个人偏好,不进仓库
+# —— 项目共享的 agent 入场清单走 AGENTS.md,skill 单一来源放 .claude/skills/,
+#    其它 agent 用户按 AGENTS.md「omk 自带 skill 安装」段引导自取
+.codex/
+.agents/
 
 # 凭据 / 私钥 / 证书文件兜底,跟 docs/dev/sensitive-scan.md 列的 "token / key" 一档对齐 ——
 # 给本地 .env、PEM / SSH 私钥、云厂商 service-account JSON、.netrc 这几类加一道 git-level 防误提网,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md - Agent 入场清单
+
+omk 是面向 LLM 知识输入（prompt / RAG / skill / agent）的评测与迭代框架，固定模型只变知识载体，三阶段 doctor / eval / observe 输出统计可比的诊断，配套 sample / evolve 做用例生成与自动迭代。所有改动都要优先保护测量可比性。
+
+本文件是 [agents.md](https://agents.md) 开放标准约定的多 agent 入场清单，跨 Claude Code / Codex / Cursor / Aider / Gemini CLI 等工具通用。Claude Code 用户：本仓库的 `CLAUDE.md` 通过 `@AGENTS.md` import 同一份内容，无需重复维护。
+
+## 开工先做
+
+- 涉及 commit、PR、分支或发版时，先看 `CONTRIBUTING.md`。
+- 交付前默认跑 `yarn lint && yarn build && yarn test`，除非用户明确要求只做更窄验证。
+
+## 硬规则
+
+- 遵守 `CONTRIBUTING.md` 的 GitHub Flow：`main` 是唯一长期分支；feature / fix / docs / chore 从 `main` 切短分支，通过 PR 回 `main`；release / hotfix 也通过短分支 PR 回 `main`，再由 tag 触发发版。
+- 不要直接在 `main` 上提交；不要再把新工作提交到 `develop`。
+- commit 格式：`type(scope): 中文 subject`。scope 用稳定模块名，如 `cli` / `i18n` / `judge` / `renderer` / `eval-core` / `eval-workflows` / `inputs` / `executors` / `server` / `analysis` / `authoring` / `grading` / `doctor` / `release` / `agents-md`（早期 git history 用过 `claude-md`，rename 后统一用 `agents-md`）。
+- 不要在给用户看的 URL 里硬编码 report server 端口；使用 `server.start()` 返回的实际 URL。
+
+## 测量学不变量
+
+这些是跨版本报告可比性的锚点，不要静默修改：
+
+- `src/types/report.ts` 里的 Report JSON schema 字段语义。
+- `test/grading/judge-hash-frozen.test.ts` 冻结的 judge prompt hash。
+- 五层评分管道语义：assertion / llm / judge / dimension / composite。
+- Bootstrap CI 和 Krippendorff alpha 公式。
+- Length-debias toggle 语义：`--no-debias-length` 与 prompt v2/v3 的对应关系。
+
+确实需要改不变量时，必须在 PR 标题 / description 明确标 `BREAKING-COMPARABILITY`（GitHub Release notes 会从 PR title 自动汇总），并按 `CONTRIBUTING.md` 的版本规则处理。
+
+## 写作规则
+
+- CLI / 报告 UI / 错误信息等 user-facing 文案中文优先。
+- 中文文案统一用全角标点 `，。：；！？（）「」`，符合 GB/T 15834《标点符号用法》。半角 `,.():` 只在以下技术混排里出现：代码块（``` ```）、inline code（`...`）、文件路径、命令行、URL、YAML/JSON frontmatter、数学区间（`[lo, hi]`）、citation 年份（`(2023)`）、`executor:model` 风格的标识符、英文术语 / 技术枚举的括注（如 `用例隔离(construct validity)`、`verdict(PROGRESS / ...)`、`omk 版本(reportMeta.cliVersion)`：括号内容是英文术语、API 字段、枚举值，半角更易复制粘贴）。范围：README.zh.md / docs/zh / SKILL.md / src 内 zh 字符串 / PR description / commit message 的中文 subject 部分。例外：commit 的 `type(scope):` 前缀是 Conventional Commits 语法保留半角，只有冒号后的中文 subject 走全角（写成 `docs(readme): 中文 subject`，不是 `docs（readme）：中文 subject`）。
+- LLM judge 译为 `评委`，不要译为 `判官`。
+- PR description 写用户影响、迁移说明、construct-validity 或测量学 caveat，链接相关 issue / 前置 PR。不要写行号、测试用例清单或嵌套实现细节 — 那些 git diff 里都有。
+
+## UI / Judge 改动
+
+- 改 judge prompt 文本前，先确认 `test/grading/judge-hash-frozen.test.ts` 的影响，不要随手更新 hash。
+- 改报告 UI 后，先 review `test/__snapshots__/html-renderer.test.ts.snap` diff，再决定是否更新 snapshot。
+
+## omk 自带 skill 安装（跨 agent）
+
+仓库根 `.claude/skills/omk/` 是 omk 智能代理 skill 的**单一来源**。Claude Code 用户 clone 仓库即可自动加载，无需额外操作。其它 agent 用户按下面拷贝到工具约定的 skill 目录：
+
+```bash
+# Codex
+cp -r .claude/skills/omk ~/.codex/agents/skills/omk
+
+# Cursor / Aider / Gemini CLI 等
+# 按各工具文档,把 .claude/skills/omk 放到对应 skill 目录即可
+```
+
+skill 内容跟 agent 解耦（不依赖 Claude Code 专属能力），可在任意支持 markdown skill 的 agent 里工作。
+
+## 参考
+
+- 用户文档：`README.md` / `README.zh.md`
+- omk skill 入场：`.claude/skills/omk/SKILL.md`（单一来源，见上节）
+- 设计 spec：`docs/`
+- 分支 / 发版 / 贡献细节：`CONTRIBUTING.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,46 +1,5 @@
-# CLAUDE.md - Agent 入场清单
+# CLAUDE.md
 
-omk 是 LLM 评测框架。所有改动都要优先保护测量可比性。
+本仓库的 agent 入场清单按 [agents.md](https://agents.md) 开放标准放在 [AGENTS.md](./AGENTS.md)，跨工具单一来源。Claude Code 通过下面的 `@import` 自动加载同一份内容，无须重复维护。
 
-## 开工先做
-
-- 涉及 commit、PR、分支或发版时，先看 `CONTRIBUTING.md`。
-- 交付前默认跑 `yarn lint && yarn build && yarn test`，除非用户明确要求只做更窄验证。
-
-## 硬规则
-
-- 遵守 `CONTRIBUTING.md` 的 GitHub Flow：`main` 是唯一长期分支；feature / fix / docs / chore 从 `main` 切短分支，通过 PR 回 `main`；release / hotfix 也通过短分支 PR 回 `main`，再由 tag 触发发版。
-- 不要直接在 `main` 上提交；不要再把新工作提交到 `develop`。
-- commit 格式：`type(scope): 中文 subject`。scope 用稳定模块名，如 `cli` / `i18n` / `judge` / `renderer` / `eval-core` / `eval-workflows` / `inputs` / `executors` / `server` / `analysis` / `authoring` / `grading` / `doctor` / `release` / `claude-md`。
-- 不要在给用户看的 URL 里硬编码 report server 端口；使用 `server.start()` 返回的实际 URL。
-
-## 测量学不变量
-
-这些是跨版本报告可比性的锚点，不要静默修改：
-
-- `src/types/report.ts` 里的 Report JSON schema 字段语义。
-- `test/grading/judge-hash-frozen.test.ts` 冻结的 judge prompt hash。
-- 五层评分管道语义：assertion / llm / judge / dimension / composite。
-- Bootstrap CI 和 Krippendorff alpha 公式。
-- Length-debias toggle 语义：`--no-debias-length` 与 prompt v2/v3 的对应关系。
-
-确实需要改不变量时，必须在 PR 标题 / description 明确标 `BREAKING-COMPARABILITY`（GitHub Release notes 会从 PR title 自动汇总），并按 `CONTRIBUTING.md` 的版本规则处理。
-
-## 写作规则
-
-- CLI / 报告 UI / 错误信息等 user-facing 文案中文优先。
-- 中文文案统一用全角标点 `，。：；！？（）「」`，符合 GB/T 15834《标点符号用法》。半角 `,.():` 只在以下技术混排里出现：代码块（``` ```）、inline code（`...`）、文件路径、命令行、URL、YAML/JSON frontmatter、数学区间（`[lo, hi]`）、citation 年份（`(2023)`）、`executor:model` 风格的标识符、英文术语 / 技术枚举的括注（如 `用例隔离(construct validity)`、`verdict(PROGRESS / ...)`、`omk 版本(reportMeta.cliVersion)`：括号内容是英文术语、API 字段、枚举值，半角更易复制粘贴）。范围：README.zh.md / docs/zh / SKILL.md / src 内 zh 字符串 / PR description / commit message 的中文 subject 部分。例外：commit 的 `type(scope):` 前缀是 Conventional Commits 语法保留半角，只有冒号后的中文 subject 走全角（写成 `docs(readme): 中文 subject`，不是 `docs（readme）：中文 subject`）。
-- LLM judge 译为 `评委`，不要译为 `判官`。
-- PR description 写用户影响、迁移说明、construct-validity 或测量学 caveat，链接相关 issue / 前置 PR。不要写行号、测试用例清单或嵌套实现细节 — 那些 git diff 里都有。
-
-## UI / Judge 改动
-
-- 改 judge prompt 文本前，先确认 `test/grading/judge-hash-frozen.test.ts` 的影响，不要随手更新 hash。
-- 改报告 UI 后，先 review `test/__snapshots__/html-renderer.test.ts.snap` diff，再决定是否更新 snapshot。
-
-## 参考
-
-- 用户文档：`README.md` / `README.zh.md`
-- Claude Code skill：`SKILL.md`
-- 设计 spec：`docs/`
-- 分支 / 发版 / 贡献细节：`CONTRIBUTING.md`
+@AGENTS.md


### PR DESCRIPTION
## Purpose

按 [agents.md](https://agents.md) 开放标准（Linux Foundation 维护，2025 年 OpenAI / Google / Sourcegraph / Cursor / Factory 联合制定），把 omk 的 agent 入场清单改成 multi-agent 友好的 canonical 形式。**根因：避免双份文档手动 sync 必然 drift**（PR #107 几轮 CR 反复戳到的 docs sync 成本问题）。

## 用户影响

- **跨 agent 用户**：Cursor / Codex / Aider / Gemini CLI 等直接读 `AGENTS.md`，omk 现在自带入场清单。`.claude/skills/omk/` 是单一来源，非 Claude Code 用户按 AGENTS.md「跨 agent 安装」段 `cp -r` 到自己工具的 skills 目录即可。
- **Claude Code 用户**：`CLAUDE.md` 仍存在但通过 `@AGENTS.md` import 同一份内容，行为完全不变。

## Changes

- `AGENTS.md`（新）：把当前 `CLAUDE.md` 内容迁过来当 canonical。顺手修 commit scope 名 `claude-md` → `agents-md`（早期 git history 用过 `claude-md`，rename 后统一）。
- `CLAUDE.md`：缩成 thin pointer + `@AGENTS.md` import 一行，Claude Code 加载时自动 follow（[官方支持 `@import` 语法](https://claudelog.com/faqs/claude-md-agents-md-symlink/)）。Windows 友好：不依赖 symlink。
- AGENTS.md 加「omk 自带 skill 安装」段：告诉非 Claude Code 用户怎么从 `.claude/skills/omk/` 安装到自己工具的 skills 目录。
- `.gitignore` 加 `.codex/` + `.agents/`：vendor-specific 本地配置不进仓库。

## 关于「为什么不放 .agents/skills/omk 镜像」

review 过几个方案：

- ❌ **symlink `.agents/skills/omk → .claude/skills/omk`**：方向跟 root 选 `@import` 不一致；Windows 兼容性差；`.agents/skills/` 子目录约定不在 [agents.md spec](https://agents.md) 里。
- ❌ **双份真目录 + PR template sync check**：必然 drift（本 PR 解决的就是这个问题）。
- ✅ **单一来源 `.claude/skills/omk/` + AGENTS.md 写安装指引**：单一来源零 drift；不赌任何 `.agents/skills/` 子目录约定（Codex `~/.codex/agents/skills/` / Cursor `.cursor/rules/` / Aider 各异）；非 Claude Code 用户多一步 `cp -r` 的代价可接受。

## 为什么 AGENTS.md 当 canonical 而不是反过来

行业 2026 共识（多个 source 一致）：

1. **AGENTS.md 是开放标准** — Linux Foundation 维护，跨工具兼容。
2. **Claude Code 透明支持 `@import`** — 截至 2026/04 仍不原生读 AGENTS.md，但 `@AGENTS.md` import 让 thin CLAUDE.md 直接代理过去。
3. **绝不双份手动 sync** — agents.md spec、ClaudeLog FAQ、SSW.Rules 等 source 都强调「会 drift，每个团队都踩过坑」。

参考：
- [agents.md official spec](https://agents.md)
- [AGENTS.md vs CLAUDE.md: The AI Developer's Guide (Hivetrail)](https://hivetrail.com/blog/agents-md-vs-claude-md-cross-tool-standard)
- [Symlink / import FAQ (ClaudeLog)](https://claudelog.com/faqs/claude-md-agents-md-symlink/)

## 不影响测量学不变量

- 不动 `src/types/report.ts` schema
- 不动 `test/grading/judge-hash-frozen.test.ts` 冻结 hash
- 不动评分管道 / Bootstrap CI / Krippendorff α / length-debias

## Test plan

- [x] `yarn lint` 过
- [x] `yarn build` 过
- [x] `yarn test` 过（1422 tests）
- [x] 单一来源验证：`.claude/skills/omk/` 是仓库里唯一的 omk skill 目录

🤖 Generated with [Claude Code](https://claude.com/claude-code)