### PR TITLE
feat(cli): oclif skeleton + doctor / sample 迁移(PR-B of #109)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,22 @@ docs(readme): 补充评测用例说明
 - Add tests for behaviour you change; a regression test for bug fixes is strongly preferred
 - CI runs the same commands on Node 22 and Node 24 for `main` pushes and PRs targeting `main` — all must pass before merge
 
+## CLI 新旧 dispatcher 并存(PR #109 路线)
+
+omk 正在从手写 dispatcher 渐进迁移到 oclif 框架(issue #109)。期间两条路径共存:
+
+- 默认走 **legacy dispatcher**(`src/cli/index.ts` → `src/cli/commands/*.ts`),行为不变
+- `OMK_CLI_NEXT=1` 切到 **oclif dispatcher**(`src/cli/oclif/`),目前只迁了 `doctor` / `sample` 两个命令,其它命令在该模式下会报「command not found」exit 1
+
+dogfood 期间欢迎本地跑 `OMK_CLI_NEXT=1` 反馈差异:
+
+```bash
+OMK_CLI_NEXT=1 omk doctor --help     # 走 oclif,看双语 help / flag 描述
+OMK_CLI_NEXT=1 omk sample --batch    # 走 oclif → 透传到生产 execute()
+```
+
+两条路径在 doctor / sample 的所有 happy path / error path / exit code / 输出文本应该 byte-perfect 一致(测试见 `test/cli/oclif-*.test.ts`)。漂移就是 bug,提 issue 标 `cli-migration`。
+
 ## Style
 
 - TypeScript strict; `yarn lint` must be clean

--- a/package.json
+++ b/package.json
@@ -26,6 +26,22 @@
       "eslint --max-warnings 0"
     ]
   },
+  "oclif": {
+    "bin": "omk",
+    "commands": "./dist/src/cli/oclif/commands",
+    "dirname": "omk",
+    "helpClass": "./dist/src/cli/oclif/help.js",
+    "topicSeparator": " ",
+    "exitCodes": {
+      "default": 1,
+      "failedFlagParsing": 2,
+      "failedFlagValidation": 2,
+      "invalidArgsSpec": 2,
+      "nonExistentFlag": 2,
+      "requiredArgs": 2,
+      "unexpectedArgs": 2
+    }
+  },
   "keywords": [
     "llm-evaluation",
     "evaluation-framework",
@@ -61,6 +77,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.89",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@oclif/core": "^4",
     "@openai/codex-sdk": "0.130.0",
     "ajv": "^8.18.0",
     "chart.js": "^4.5.1",

--- a/src/cli/i18n.ts
+++ b/src/cli/i18n.ts
@@ -58,3 +58,19 @@ export function tCli(
   }
   return text;
 }
+
+/**
+ * 一次拿到 i18n key 的 zh / en 两个串。oclif Command 的 static
+ * description / examples 是模块加载期 evaluate 的字面量,跑不到 tCli 的 runtime
+ * lang dispatch。tBoth 返回 {zh, en} 结构,配合 oclif/i18n.ts 的 bilingual()
+ * 拼成带 sentinel 的串,LangAwareHelp 渲染时按 lang 切。
+ */
+export function tBoth(
+  key: CliMessageKey,
+  params?: Record<string, string | number>,
+): { zh: string; en: string } {
+  return {
+    zh: tCli(key, 'zh', params),
+    en: tCli(key, 'en', params),
+  };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,6 +38,16 @@ function dispatchOrPrintHelp(cmd: CommandModule, argv: string[], lang: CliLang):
 async function main(): Promise<void> {
   const lang = getCliLang(parseLangFromArgv(process.argv));
   checkUpdate(lang);
+
+  // OMK_CLI_NEXT=1 切到 oclif dispatcher(PR-B dogfood 模式)。
+  // legacy 路径完全不动,默认行为零变化。oclif 路径只迁了 doctor / sample 两个命令,
+  // 其它命令在该模式下会报「command not found」exit 1(跟 legacy unknown_domain 行为对得齐)。
+  if (process.env.OMK_CLI_NEXT === '1') {
+    const { runOclifPath } = await import('./oclif/run.js');
+    await runOclifPath();
+    return;
+  }
+
   const [command, ...rest]: string[] = process.argv.slice(2);
 
   if (!command || command === '--help' || command === '-h') {

--- a/src/cli/oclif/commands/doctor.ts
+++ b/src/cli/oclif/commands/doctor.ts
@@ -1,0 +1,274 @@
+import { Args, Command, Flags } from '@oclif/core';
+import { existsSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { tCli } from '../../i18n.js';
+import { bilingual, resolveLang } from '../i18n.js';
+import type { DependencyRequirements } from '../../../eval-core/dependency-checker.js';
+import type { Sample } from '../../../types/index.js';
+
+// oclif 版 doctor — 跟 src/cli/commands/doctor.ts 行为对得齐:
+// - flag 集合一致(lang/json/gate/executor/model/samples/timeout/html/static-only)
+// - positional target 可选
+// - 业务逻辑直接调 runDoctor() / renderDoctorReport*,不重写
+// - 退出码:report.outcome === 'failed' → exit 1,unknown flag → exit 2(oclif 默认),其它 → 0
+//
+// 双语 description / examples 走 bilingual({zh, en}) → [[ZH]]..[[EN]].. sentinel,
+// LangAwareHelp(./help.ts)按 --lang / OMK_LANG 切。每个 flag 描述粒度太碎,
+// 不进 i18n-dict.ts,inline 写双语;命令级一句话描述也 inline。
+
+const DEFAULT_SAMPLE_FILENAMES = ['eval-samples.json', 'eval-samples.yaml', 'eval-samples.yml'] as const;
+
+function findSamplesInDir(dir: string): string | null {
+  for (const name of DEFAULT_SAMPLE_FILENAMES) {
+    const candidate = join(dir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function sampleSearchDirs(target: string | null, cwd: string): string[] {
+  const dirs: string[] = [];
+  const add = (dir: string): void => {
+    const abs = resolve(dir);
+    if (!dirs.includes(abs)) dirs.push(abs);
+  };
+  if (target) {
+    const absTarget = resolve(target);
+    if (existsSync(absTarget)) {
+      const stat = statSync(absTarget);
+      if (stat.isDirectory()) {
+        add(absTarget);
+        add(dirname(absTarget));
+        add(dirname(dirname(absTarget)));
+      } else {
+        const parent = dirname(absTarget);
+        add(parent);
+        add(dirname(parent));
+      }
+    }
+  }
+  add(cwd);
+  return dirs;
+}
+
+function findDefaultSamplesPath(target: string | null, cwd: string): string | null {
+  for (const dir of sampleSearchDirs(target, cwd)) {
+    const samplesPath = findSamplesInDir(dir);
+    if (samplesPath) return samplesPath;
+  }
+  return null;
+}
+
+export default class Doctor extends Command {
+  static description = bilingual({
+    zh: '体检 omk 工作目录,检查 skill 配置 / 依赖 / executor 连通性。',
+    en: 'Preflight health checks for omk workdir: skill config / deps / executor connectivity.',
+  });
+
+  static examples = [
+    {
+      description: bilingual({
+        zh: '默认模式跑 LLM 健康度审计(7 内置维度)。',
+        en: 'Default mode runs LLM-driven health audit (7 built-in dimensions).',
+      }),
+      command: '<%= config.bin %> doctor',
+    },
+    {
+      description: bilingual({
+        zh: '离线静态模式,只跑 4 条静态 rule,不调 LLM,CI 无 LLM 凭证时用。',
+        en: 'Offline static mode, only 4 static rules, no LLM call. Use when CI lacks LLM credentials.',
+      }),
+      command: '<%= config.bin %> doctor --static-only',
+    },
+    {
+      description: bilingual({
+        zh: 'JSON 输出 + 写 HTML 报告,给 CI 抓 exit code 同时人看。',
+        en: 'JSON output + HTML report, for CI exit code + human review.',
+      }),
+      command: '<%= config.bin %> doctor --json --html doctor.html',
+    },
+  ];
+
+  static args = {
+    target: Args.string({
+      description: bilingual({
+        zh: '要体检的 skill 路径或目录。可选,默认扫当前 cwd 下的 skills/。',
+        en: 'Skill path or directory to inspect. Optional, defaults to scanning ./skills/.',
+      }),
+      required: false,
+    }),
+  };
+
+  static flags = {
+    lang: Flags.string({
+      description: bilingual({
+        zh: '输出语言 zh|en,优先级 CLI > OMK_LANG env > zh。',
+        en: 'Output language zh|en. Priority: CLI > OMK_LANG env > zh.',
+      }),
+      options: ['zh', 'en'],
+      default: 'zh',
+      env: 'OMK_LANG',
+    }),
+    json: Flags.boolean({
+      description: bilingual({
+        zh: 'JSON 输出到 stdout,适合 CI / 外部脚本消费。',
+        en: 'JSON output to stdout, for CI / external script consumption.',
+      }),
+      default: false,
+    }),
+    gate: Flags.boolean({
+      description: bilingual({
+        zh: '静默模式,只在 fail 时输出 stderr 摘要,exit code 标识结果。',
+        en: 'Silent mode: only emit stderr summary on fail. Exit code carries the signal.',
+      }),
+      default: false,
+    }),
+    executor: Flags.string({
+      description: bilingual({
+        zh: '执行器名,默认 claude。指定为测试 fixture 路径可在测试里跑(同 omk doctor)。',
+        en: 'Executor name, default claude. Pass a test fixture path to use in tests.',
+      }),
+    }),
+    model: Flags.string({
+      description: bilingual({
+        zh: 'LLM model 名,默认 sonnet。',
+        en: 'LLM model name, default sonnet.',
+      }),
+    }),
+    samples: Flags.string({
+      description: bilingual({
+        zh: '样本文件路径(.json/.yaml)。不传则按 target / cwd 顺序自动发现。',
+        en: 'Samples file path (.json/.yaml). Auto-discovered from target / cwd if omitted.',
+      }),
+    }),
+    timeout: Flags.string({
+      description: bilingual({
+        zh: '单次 LLM 会话超时秒数,默认 600(10 分钟)。',
+        en: 'LLM session timeout in seconds, default 600 (10 min).',
+      }),
+    }),
+    html: Flags.string({
+      description: bilingual({
+        zh: 'HTML 报告输出路径。可跟 --json / --gate 共存。',
+        en: 'HTML report output path. Coexists with --json / --gate.',
+      }),
+    }),
+    'static-only': Flags.boolean({
+      description: bilingual({
+        zh: '离线静态模式,只跑 4 条静态 rule(skill_readable / skill_metadata / dependencies_present / samples_contract_aligned),不调 LLM。',
+        en: 'Offline static mode: only 4 static rules, no LLM call.',
+      }),
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(Doctor);
+    const lang = resolveLang(process.argv);
+
+    const target: string | null = args.target ?? null;
+    const executorName = flags.executor ?? 'claude';
+    const model = flags.model ?? 'sonnet';
+    const staticOnly = flags['static-only'];
+    const runHealthCheck = !staticOnly;
+
+    const defaultTimeoutSec = 600;
+    const timeoutSec = flags.timeout != null ? Number(flags.timeout) : defaultTimeoutSec;
+    const timeoutMs = Math.max(
+      1000,
+      Math.floor((Number.isFinite(timeoutSec) ? timeoutSec : defaultTimeoutSec) * 1000),
+    );
+
+    const cwd = process.cwd();
+    const samplesPath = flags.samples ? resolve(flags.samples) : findDefaultSamplesPath(target, cwd);
+    let samples: Sample[] | undefined;
+    let requires: DependencyRequirements | undefined;
+    if (samplesPath) {
+      try {
+        const { loadSamples } = await import('../../../inputs/load-samples.js');
+        const loaded = loadSamples(samplesPath);
+        samples = loaded.samples;
+        requires = loaded.requires;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          tCli('cli.common.warn_load_samples_failed', lang, { path: samplesPath, message: msg }),
+        );
+      }
+    }
+
+    // 副作用 import: 注册 7 内置维度 spec + skill_health composer rule。
+    await import('../../../doctor/health/register.js');
+
+    const { runDoctor } = await import('../../../doctor/index.js');
+    const { renderDoctorReportText, renderDoctorReportJson } = await import(
+      '../../../doctor/renderer.js'
+    );
+    const { getRegisteredRules } = await import('../../../doctor/rules.js');
+    const { isComposerRule } = await import('../../../types/doctor.js');
+    const rulesOverride = staticOnly
+      ? getRegisteredRules().filter((r) => !isComposerRule(r))
+      : getRegisteredRules().filter(isComposerRule);
+
+    let report;
+    try {
+      report = await runDoctor({
+        target,
+        cwd,
+        executorName,
+        model,
+        timeoutMs,
+        lang,
+        runHealthCheck,
+        rules: rulesOverride,
+        samples,
+        requires,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.error(`${tCli('cli.doctor.no_skill_found', lang, { path: target ?? cwd })}\n(${msg})`, {
+        exit: 1,
+      });
+    }
+
+    if (report.skills.length === 0) {
+      this.error(tCli('cli.doctor.no_skill_found', lang, { path: target ?? cwd }), { exit: 1 });
+    }
+
+    const htmlPath = flags.html;
+    if (htmlPath) {
+      const { renderDoctorReportHtml } = await import('../../../doctor/html-renderer.js');
+      const { writeFileSync, mkdirSync } = await import('node:fs');
+      const { dirname: dn, resolve: rv } = await import('node:path');
+      const abs = rv(htmlPath);
+      mkdirSync(dn(abs), { recursive: true });
+      writeFileSync(abs, renderDoctorReportHtml(report, lang), 'utf8');
+      process.stderr.write(
+        (lang === 'zh' ? `HTML 报告已写入: ${abs}` : `HTML report written to: ${abs}`) + '\n',
+      );
+    }
+
+    if (flags.json) {
+      this.log(renderDoctorReportJson(report));
+    } else if (flags.gate) {
+      if (report.outcome === 'failed') {
+        const summary =
+          lang === 'zh'
+            ? `doctor failed: ${report.totals.fail} 个 skill 未通过 (${report.totals.warn} warn / ${report.totals.pass} pass)`
+            : `doctor failed: ${report.totals.fail} skills did not pass (${report.totals.warn} warn / ${report.totals.pass} pass)`;
+        process.stderr.write(summary + '\n');
+      }
+    } else {
+      if (samplesPath && samples) {
+        process.stderr.write(
+          tCli('cli.doctor.samples_detected', lang, { path: samplesPath }) + '\n',
+        );
+      }
+      renderDoctorReportText(report, lang);
+    }
+
+    if (report.outcome === 'failed') {
+      this.exit(1);
+    }
+  }
+}

--- a/src/cli/oclif/commands/sample.ts
+++ b/src/cli/oclif/commands/sample.ts
@@ -1,0 +1,141 @@
+import { Args, Command, Flags } from '@oclif/core';
+import { bilingual } from '../i18n.js';
+
+// oclif 版 sample — 跟 src/cli/commands/sample.ts 行为对得齐。
+// 实现策略:flag schema 在这里声明一份(给 oclif --help / strict 校验用),
+// run() 实际把 argv 透传给生产 execute(),不重写 batch / fix / single 三路
+// 业务分支(避免 470 行重写,降低 PR-B 风险)。
+//
+// 行为对照表:
+// - 缺 positional + 非 batch / fix → exit 1 (生产逻辑)
+// - 未知 flag → exit 2 (oclif strict 默认)
+// - 已存在 samples / skill 路径不存在 → exit 1 (生产逻辑)
+// - batch / fix 路径 → 生产 execute() 全权处理
+
+export default class Sample extends Command {
+  static description = bilingual({
+    zh: '为指定 skill 生成评测用例(eval-samples),支持 batch / single / fix 三种模式。',
+    en: 'Generate eval samples for the given skill. Supports batch / single / fix modes.',
+  });
+
+  static examples = [
+    {
+      description: bilingual({
+        zh: '为单个 skill 生成默认数量的样本',
+        en: 'Generate default-count samples for a single skill',
+      }),
+      command: '<%= config.bin %> sample skills/my-skill/SKILL.md',
+    },
+    {
+      description: bilingual({
+        zh: '批量为 skill 目录下所有缺 samples 的 skill 生成',
+        en: 'Batch-generate samples for all skills missing them',
+      }),
+      command: '<%= config.bin %> sample --batch --skill-dir skills',
+    },
+    {
+      description: bilingual({
+        zh: '根据最近评测报告自动修复 sample_design 类型失败',
+        en: 'Auto-fix sample_design failures using the most recent eval report',
+      }),
+      command: '<%= config.bin %> sample skills/my-skill/SKILL.md --fix',
+    },
+  ];
+
+  static args = {
+    skillPath: Args.string({
+      description: bilingual({
+        zh: 'skill 文件路径或 SKILL.md 路径。batch 模式不需要;single / fix 模式必填。',
+        en: 'Skill file or SKILL.md path. Not required in batch mode; required for single / fix.',
+      }),
+      required: false,
+    }),
+  };
+
+  static flags = {
+    lang: Flags.string({
+      description: bilingual({
+        zh: '输出语言 zh|en,优先级 CLI > OMK_LANG env > zh。',
+        en: 'Output language zh|en. Priority: CLI > OMK_LANG env > zh.',
+      }),
+      options: ['zh', 'en'],
+      default: 'zh',
+      env: 'OMK_LANG',
+    }),
+    batch: Flags.boolean({
+      description: bilingual({
+        zh: '批量模式:扫 --skill-dir 下所有缺 samples 的 skill,逐个生成。',
+        en: 'Batch mode: scan --skill-dir, generate samples for any skill missing them.',
+      }),
+      default: false,
+    }),
+    count: Flags.string({
+      description: bilingual({
+        zh: '生成样本条数。不传由 LLM 按 skill 类型自动决定。',
+        en: 'Number of samples to generate. Defaults to LLM auto-selection by skill type.',
+      }),
+    }),
+    model: Flags.string({
+      description: bilingual({
+        zh: '生成 LLM model 名,默认 opus。',
+        en: 'Generation LLM model name, default opus.',
+      }),
+      default: 'opus',
+    }),
+    'skill-dir': Flags.string({
+      description: bilingual({
+        zh: 'skill 根目录,默认 skills。batch 模式扫此目录。',
+        en: 'Skill root dir, default skills. Used by batch mode.',
+      }),
+      default: 'skills',
+    }),
+    focus: Flags.string({
+      description: bilingual({
+        zh: '生成焦点(自然语言提示)。控制 LLM 偏向哪类用例。',
+        en: 'Generation focus (NL hint). Steers LLM toward certain sample types.',
+      }),
+    }),
+    fix: Flags.boolean({
+      description: bilingual({
+        zh: 'fix 模式:基于最近评测报告自动修复 sample_design 类型失败。',
+        en: 'Fix mode: auto-fix sample_design failures using the latest eval report.',
+      }),
+      default: false,
+    }),
+    'reports-dir': Flags.string({
+      description: bilingual({
+        zh: '报告目录(fix 模式用),默认 ~/.oh-my-knowledge/reports。',
+        en: 'Reports dir (fix mode), default ~/.oh-my-knowledge/reports.',
+      }),
+    }),
+    treatment: Flags.string({
+      description: bilingual({
+        zh: '指定 treatment 名(fix 模式用),默认推断自 skill 路径。',
+        en: 'Treatment name (fix mode), defaults to skill-path inference.',
+      }),
+    }),
+  };
+
+  async run(): Promise<void> {
+    // 解析触发 oclif 的 --help / strict 校验。flag 值不直接用,交给生产 execute() 重新 parse argv。
+    await this.parse(Sample);
+
+    // 把 argv 透传给生产 execute()。process.argv = [node, script, 'sample', ...args]
+    // 生产 execute(argv) 期望 args(切掉前 3 项)。
+    const argv = process.argv.slice(3);
+
+    const { execute } = await import('../../commands/sample.js');
+    const { CliExit } = await import('../../cli-exit.js');
+
+    try {
+      await execute(argv);
+    } catch (err) {
+      // 生产 execute 走 throw CliExit(code) 表示 exit。oclif 路径下转成 this.exit。
+      if (err instanceof CliExit) {
+        if (err.code === 0) return;
+        this.exit(err.code);
+      }
+      throw err;
+    }
+  }
+}

--- a/src/cli/oclif/help.ts
+++ b/src/cli/oclif/help.ts
@@ -1,0 +1,77 @@
+import { Command, Help } from '@oclif/core';
+import { pickLang, resolveLang, type Lang } from './i18n.js';
+
+// LangAwareHelp:oclif Help 子类,按 --lang / OMK_LANG 把 description / flags
+// 里的双语 sentinel 串切成单语再交给 super 渲染。覆盖三个钩子:
+// - showCommandHelp:打 top 行用 command.description.split('\\n')[0],不
+//   filter 命令就漏切;在这里把 command 整体过滤一遍。
+// - formatCommand:body 区(USAGE / FLAGS / EXAMPLES / DESCRIPTION),正常 filter。
+// - formatCommands:topic 列表(`omk studio --help` 这种),同 filter。
+
+function filterCommand(cmd: Command.Loadable, lang: Lang): Command.Loadable {
+  const clone: Command.Loadable = { ...cmd };
+  clone.description = pickLang(cmd.description, lang);
+  clone.summary = pickLang(cmd.summary, lang);
+
+  if (Array.isArray(cmd.examples)) {
+    clone.examples = cmd.examples.map((ex) => {
+      if (typeof ex === 'string') return pickLang(ex, lang) ?? ex;
+      return {
+        ...ex,
+        description: pickLang(ex.description, lang) ?? ex.description,
+      };
+    });
+  }
+
+  if (cmd.flags) {
+    const flags: Record<string, unknown> = {};
+    for (const [name, flag] of Object.entries(cmd.flags)) {
+      const f = flag as { description?: string; summary?: string };
+      flags[name] = {
+        ...flag,
+        description: pickLang(f.description, lang) ?? f.description,
+        summary: pickLang(f.summary, lang) ?? f.summary,
+      };
+    }
+    clone.flags = flags as typeof cmd.flags;
+  }
+
+  if (cmd.args) {
+    const args: Record<string, unknown> = {};
+    for (const [name, arg] of Object.entries(cmd.args)) {
+      const a = arg as { description?: string };
+      args[name] = {
+        ...arg,
+        description: pickLang(a.description, lang) ?? a.description,
+      };
+    }
+    clone.args = args as typeof cmd.args;
+  }
+  return clone;
+}
+
+export default class LangAwareHelp extends Help {
+  private get lang(): Lang {
+    return resolveLang(process.argv);
+  }
+
+  formatCommand(command: Command.Loadable): string {
+    return super.formatCommand(filterCommand(command, this.lang));
+  }
+
+  formatCommands(commands: Command.Loadable[]): string {
+    return super.formatCommands(commands.map((c) => filterCommand(c, this.lang)));
+  }
+
+  async showCommandHelp(command: Command.Loadable): Promise<void> {
+    return super.showCommandHelp(filterCommand(command, this.lang));
+  }
+
+  async showTopicHelp(topic: { name: string; description?: string }): Promise<void> {
+    const filtered = {
+      ...topic,
+      description: pickLang(topic.description, this.lang) ?? topic.description,
+    };
+    return super.showTopicHelp(filtered);
+  }
+}

--- a/src/cli/oclif/i18n.ts
+++ b/src/cli/oclif/i18n.ts
@@ -1,0 +1,47 @@
+// oclif 路径专用 i18n helper。生产 i18n 还是走 ../i18n.ts (tCli / tBoth) ——
+// 这里只提供 oclif Command static 字段需要的双语形式:
+// bilingual({zh, en}) → 字符串里 `${zh}\n${en}`,LangAwareHelp.formatCommand
+// 按 lang 切第一/第二行。
+//
+// 为什么用 \n 而不是显式 sentinel(如 [[ZH]]/[[EN]]):oclif 错误路径
+// (parse fail 时)硬编码 `new Help(config)`(node_modules/@oclif/core/lib/errors/handle.js
+// L44),绕过 package.json helpClass,所以 LangAwareHelp 不会被调到。
+// 显式 sentinel 在错误路径会原样泄漏给用户,可读性极差;\n 退化成「两种语言
+// 都各占一行」, 错误路径下用户至少能读懂。
+//
+// 代价:flag description 里不能用真换行 — 单行写到底,需要多段时换 prose
+// 文档(legacy 路径的 cli.help.* prose 仍然继续承担长 prose 角色)。
+//
+// PR-E 跟进:或者改 oclif 上游让 errors/handle.js 尊重 helpClass,或者
+// 自写 init hook 把 description 在 parse 前 in-place mutate。
+
+import { getCliLang, parseLangFromArgv } from '../i18n.js';
+import type { CliLang } from '../i18n.js';
+
+export type Lang = CliLang;
+
+export { getCliLang, parseLangFromArgv };
+
+export interface BiText {
+  zh: string;
+  en: string;
+}
+
+/** 把双语对象拼成 `${zh}\n${en}` 串,塞给 oclif Command 的 static description / flags.description 等字段。 */
+export function bilingual(text: BiText): string {
+  return `${text.zh}\n${text.en}`;
+}
+
+/** 按 lang 把双语串切回单语;只有 1 行的串原样返回。 */
+export function pickLang(text: string | undefined, lang: Lang): string | undefined {
+  if (text === undefined) return undefined;
+  const parts = text.split(/\r?\n/);
+  if (parts.length < 2) return text;
+  if (lang === 'zh') return parts[0];
+  return parts.slice(1).join('\n');
+}
+
+/** 从 process.argv 解析 lang,优先级跟 ../i18n.ts 的 getCliLang 一致:CLI flag > OMK_LANG > zh。 */
+export function resolveLang(argv: readonly string[] = process.argv): Lang {
+  return getCliLang(parseLangFromArgv(argv));
+}

--- a/src/cli/oclif/run.ts
+++ b/src/cli/oclif/run.ts
@@ -1,0 +1,12 @@
+import { execute } from '@oclif/core';
+
+// PR-B 期间通过 OMK_CLI_NEXT=1 触发的 oclif dispatcher 入口。从 dist/src/cli/oclif/
+// 这个文件位置出发,oclif 用 package.json oclif.commands ("./dist/src/cli/oclif/commands")
+// 找到所有 Command 类。helpClass 也走 package.json 字段。
+//
+// 注意 dir: import.meta.url 必须传 — oclif 用它确定 package.json 跟 commands
+// dir 的相对位置。
+
+export async function runOclifPath(): Promise<void> {
+  await execute({ dir: import.meta.url });
+}

--- a/test/cli/oclif-dispatch.test.ts
+++ b/test/cli/oclif-dispatch.test.ts
@@ -1,0 +1,73 @@
+/**
+ * oclif dispatcher 分流验收。
+ * 验证 OMK_CLI_NEXT 这个 env switch 行为正确:
+ * - 未设/为空 → 走 legacy dispatcher,行为跟现状一致
+ * - =1 + 已迁命令(doctor / sample)→ 走 oclif
+ * - =1 + 未迁命令 → 报「command not found」exit 1,跟 legacy unknown_domain 对得齐
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const CLI = join(PROJECT_ROOT, 'dist', 'src', 'cli', 'index.js');
+
+interface ExecError extends Error {
+  code?: number;
+  stdout: string;
+  stderr: string;
+}
+
+// 不在 OCLIF_ENV 里 set OMK_CLI_NEXT,vs OMK_CLI_NEXT=1 set,vs OMK_CLI_NEXT=''(空)
+const LEGACY_ENV = { ...process.env };
+delete LEGACY_ENV.OMK_CLI_NEXT;
+const OCLIF_ENV = { ...process.env, OMK_CLI_NEXT: '1' };
+const EMPTY_ENV = { ...process.env, OMK_CLI_NEXT: '' };
+
+describe('OMK_CLI_NEXT dispatcher 分流', () => {
+  it('未设 env 走 legacy(doctor --help 含 cli.help.doctor_usage 的 prose)', async () => {
+    // legacy doctor --help 走 i18n-dict.cli.help.doctor_usage,一段手写完整 prose
+    const { stdout } = await execFileAsync('node', [CLI, 'doctor', '--help'], { env: LEGACY_ENV });
+    // legacy prose 是手写完整段(多行,含 omk doctor 这种用法举例 + flag 说明)
+    // oclif --help 输出风格是 USAGE / FLAGS / DESCRIPTION 这种结构化 block
+    // 通过判断有没有 oclif 的 USAGE 关键字区分(legacy 没有 USAGE 顶头大写)
+    assert.ok(!stdout.includes('\nUSAGE\n'), 'legacy --help should not have oclif USAGE block');
+  });
+
+  it('env=\'\'(空)也走 legacy(只有 ===\'1\' 才切 oclif)', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'doctor', '--help'], { env: EMPTY_ENV });
+    assert.ok(!stdout.includes('\nUSAGE\n'), 'empty env should fall through to legacy');
+  });
+
+  it('env=1 doctor --help 走 oclif(有 USAGE block)', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'doctor', '--help'], { env: OCLIF_ENV });
+    assert.ok(stdout.includes('\nUSAGE\n'), `oclif --help should have USAGE block:\n${stdout.slice(0, 200)}`);
+  });
+
+  it('env=1 + 未迁命令 → exit 1(跟 legacy unknown_domain 对得齐)', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'nope-command'], { env: OCLIF_ENV });
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 1, `expected exit 1 for unknown command, got ${e.code}`);
+    }
+  });
+
+  it('env=1 + eval (legacy 才支持,oclif 路径未迁) → command not found exit 1', async () => {
+    // PR-B 只迁 doctor + sample,eval 还在 legacy 里。
+    // OMK_CLI_NEXT=1 + eval → oclif 找不到 eval command,exit 1。
+    try {
+      await execFileAsync('node', [CLI, 'eval'], { env: OCLIF_ENV });
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 1, `expected exit 1, got ${e.code}`);
+    }
+  });
+});

--- a/test/cli/oclif-doctor.test.ts
+++ b/test/cli/oclif-doctor.test.ts
@@ -1,0 +1,81 @@
+/**
+ * oclif 路径 doctor 命令验收(OMK_CLI_NEXT=1)。
+ * 跟 test/cli.test.ts L341-357 的 legacy doctor 测试对照,验证迁移后行为对得齐:
+ * - --help 双语切换
+ * - unknown flag → exit 2
+ * - happy path 同 legacy stderr 关键字
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const CLI = join(PROJECT_ROOT, 'dist', 'src', 'cli', 'index.js');
+const DOCTOR_FIXTURE = `node ${join(PROJECT_ROOT, 'test', 'fixtures', 'doctor-fixture-executor.mjs')}`;
+
+interface ExecError extends Error {
+  code?: number;
+  stdout: string;
+  stderr: string;
+}
+
+const OCLIF_ENV = { ...process.env, OMK_CLI_NEXT: '1' };
+
+describe('oclif doctor (OMK_CLI_NEXT=1)', () => {
+  it('--help 默认 zh 含中文 description', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'doctor', '--help'], { env: OCLIF_ENV });
+    assert.ok(stdout.includes('体检 omk 工作目录'), `stdout missing zh description:\n${stdout}`);
+    assert.ok(stdout.includes('USAGE'), 'stdout missing USAGE block');
+    assert.ok(stdout.includes('--static-only'), 'stdout missing --static-only flag');
+  });
+
+  it('--help --lang en 切到英文 description', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'doctor', '--help', '--lang', 'en'], { env: OCLIF_ENV });
+    assert.ok(stdout.includes('Preflight health checks'), `stdout missing en description:\n${stdout}`);
+    assert.ok(!stdout.includes('体检 omk 工作目录'), 'stdout should not contain zh in --lang en mode');
+  });
+
+  it('OMK_LANG=en env 同效切到英文', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'doctor', '--help'], { env: { ...OCLIF_ENV, OMK_LANG: 'en' } });
+    assert.ok(stdout.includes('Preflight health checks'), 'OMK_LANG=en should switch help to en');
+  });
+
+  it('unknown flag → exit code 2 (omk parse-strict invariant)', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'doctor', '--no-such-flag'], { env: OCLIF_ENV });
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+      assert.ok(e.stderr.includes('Nonexistent flag'), 'stderr should mention nonexistent flag');
+    }
+  });
+
+  it('happy path: auto-detects cwd eval-samples.json (复刻 legacy 测试)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-oclif-doctor-'));
+    try {
+      const skillDir = join(dir, 'skills', 'review');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), '你是一个测试用的代码审查 skill，内容足够长。');
+      await writeFile(join(dir, 'eval-samples.json'), JSON.stringify([
+        { sample_id: 's1', prompt: 'review this code' },
+      ]));
+
+      const { stderr } = await execFileAsync('node', [CLI, 'doctor', '--executor', DOCTOR_FIXTURE], {
+        cwd: dir,
+        env: OCLIF_ENV,
+      });
+      assert.ok(stderr.includes('使用评测用例文件'), `stderr missing samples_detected:\n${stderr}`);
+      assert.ok(!stderr.includes('未提供 samples'), `stderr should not warn missing samples:\n${stderr}`);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/cli/oclif-sample.test.ts
+++ b/test/cli/oclif-sample.test.ts
@@ -1,0 +1,75 @@
+/**
+ * oclif 路径 sample 命令验收(OMK_CLI_NEXT=1)。
+ * 验证 sample 三模式入口都能正确分流到生产 execute():
+ * - 缺 positional + 非 batch / fix → exit 1 + 中文 hint
+ * - unknown flag → exit 2
+ * - --batch 走不存在的 skill-dir → exit 1
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const CLI = join(PROJECT_ROOT, 'dist', 'src', 'cli', 'index.js');
+
+interface ExecError extends Error {
+  code?: number;
+  stdout: string;
+  stderr: string;
+}
+
+const OCLIF_ENV = { ...process.env, OMK_CLI_NEXT: '1' };
+
+describe('oclif sample (OMK_CLI_NEXT=1)', () => {
+  it('--help 默认 zh', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'sample', '--help'], { env: OCLIF_ENV });
+    assert.ok(stdout.includes('为指定 skill 生成评测用例'), `stdout missing zh description:\n${stdout}`);
+    assert.ok(stdout.includes('--batch'), 'stdout missing --batch flag');
+    assert.ok(stdout.includes('--fix'), 'stdout missing --fix flag');
+  });
+
+  it('--help --lang en 切英文', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'sample', '--help', '--lang', 'en'], { env: OCLIF_ENV });
+    assert.ok(stdout.includes('Generate eval samples'), 'stdout should contain en description');
+  });
+
+  it('缺 positional + 非 batch + 非 fix → exit 1 (生产 execute 透传)', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'sample'], { env: OCLIF_ENV });
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 1, `expected exit 1, got ${e.code}:\n${e.stderr}`);
+      assert.ok(
+        e.stderr.includes('请指定 skill 文件路径'),
+        `stderr missing zh hint:\n${e.stderr}`,
+      );
+    }
+  });
+
+  it('unknown flag → exit 2', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'sample', '--bogus'], { env: OCLIF_ENV });
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}`);
+      assert.ok(e.stderr.includes('Nonexistent flag'));
+    }
+  });
+
+  it('--batch + 不存在的 skill-dir → exit 1', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'sample', '--batch', '--skill-dir', '/tmp/omk-nonexistent-skill-dir-xyz'], { env: OCLIF_ENV });
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 1, `expected exit 1, got ${e.code}:\n${e.stderr}`);
+    }
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -217,6 +217,30 @@
   dependencies:
     "@tybys/wasm-util" "^0.10.1"
 
+"@oclif/core@^4":
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-4.11.3.tgz#87ebe0d3a47d162359482ecf5f5a7220ac709a36"
+  integrity sha512-gQCSYAtUhJilGKaSaZhqejH9X1dDu+jWQjLmtGOgN/XcKaAEPPSeT2mu1UvlvtPox1/NNRdlBcUa8KRKo2HnJQ==
+  dependencies:
+    ansi-escapes "^4.3.2"
+    ansis "^3.17.0"
+    clean-stack "^3.0.1"
+    cli-spinners "^2.9.2"
+    debug "^4.4.3"
+    ejs "^3.1.10"
+    get-package-type "^0.1.0"
+    indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    lilconfig "^3.1.3"
+    minimatch "^10.2.5"
+    semver "^7.8.0"
+    string-width "^4.2.3"
+    supports-color "^8"
+    tinyglobby "^0.2.16"
+    widest-line "^3.1.0"
+    wordwrap "^1.0.0"
+    wrap-ansi "^7.0.0"
+
 "@openai/codex-darwin-arm64@npm:@openai/codex@0.130.0-darwin-arm64":
   version "0.130.0-darwin-arm64"
   resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.130.0-darwin-arm64.tgz#666ace868b7c3250a866a98e7e4de2be0bb10e9e"
@@ -608,6 +632,13 @@ ajv@^8.0.0, ajv@^8.17.1, ajv@^8.18.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
 
+ansi-escapes@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+  dependencies:
+    type-fest "^0.21.3"
+
 ansi-escapes@^7.0.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
@@ -615,15 +646,32 @@ ansi-escapes@^7.0.0:
   dependencies:
     environment "^1.0.0"
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-regex@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
   integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
 
+ansi-styles@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
 ansi-styles@^6.2.1, ansi-styles@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
+
+ansis@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/ansis/-/ansis-3.17.0.tgz#fa8d9c2a93fe7d1177e0c17f9eeb562a58a832d7"
+  integrity sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -634,6 +682,16 @@ assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
+async@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
+  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
+
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 balanced-match@^4.0.2:
   version "4.0.4"
@@ -654,6 +712,13 @@ body-parser@^2.2.1:
     qs "^6.14.1"
     raw-body "^3.0.1"
     type-is "^2.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.0.tgz#4f41a41190216ee36067ec381526fe9539c4f0ae"
+  integrity sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==
+  dependencies:
+    balanced-match "^1.0.0"
 
 brace-expansion@^5.0.5:
   version "5.0.5"
@@ -695,12 +760,24 @@ chart.js@^4.5.1:
   dependencies:
     "@kurkle/color" "^0.3.0"
 
+clean-stack@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.1.tgz#155bf0b2221bf5f4fba89528d24c5953f17fe3a8"
+  integrity sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==
+  dependencies:
+    escape-string-regexp "4.0.0"
+
 cli-cursor@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
   integrity sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==
   dependencies:
     restore-cursor "^5.0.0"
+
+cli-spinners@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.2.tgz#1773a8f4b9c4d6ac31563df53b3fc1d79462fe41"
+  integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
 
 cli-truncate@^5.2.0:
   version "5.2.0"
@@ -709,6 +786,18 @@ cli-truncate@^5.2.0:
   dependencies:
     slice-ansi "^8.0.0"
     string-width "^8.2.0"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 content-disposition@^1.0.0:
   version "1.1.0"
@@ -788,10 +877,22 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
+ejs@^3.1.10:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
+  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
+  dependencies:
+    jake "^10.8.5"
+
 emoji-regex@^10.3.0:
   version "10.6.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
   integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 encodeurl@^2.0.0:
   version "2.0.0"
@@ -830,7 +931,7 @@ escape-html@^1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
-escape-string-regexp@^4.0.0:
+escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
@@ -1031,6 +1132,13 @@ file-entry-cache@^8.0.0:
   dependencies:
     flat-cache "^4.0.0"
 
+filelist@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.6.tgz#1e8870942a7c636c862f7c49b9394937b6a995a3"
+  integrity sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==
+  dependencies:
+    minimatch "^5.0.1"
+
 finalhandler@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-2.1.1.tgz#a2c517a6559852bcdb06d1f8bd7f51b68fad8099"
@@ -1105,6 +1213,11 @@ get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
     hasown "^2.0.2"
     math-intrinsics "^1.1.0"
 
+get-package-type@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
+  integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
+
 get-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
@@ -1124,6 +1237,11 @@ gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbols@^1.1.0:
   version "1.1.0"
@@ -1180,6 +1298,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
@@ -1195,10 +1318,20 @@ ipaddr.js@1.9.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-fullwidth-code-point@^5.0.0, is-fullwidth-code-point@^5.1.0:
   version "5.1.0"
@@ -1219,6 +1352,13 @@ is-promise@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1228,6 +1368,15 @@ isexe@^3.1.1:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.5.tgz#42e368f68d5e10dadfee4fda7b550bc2d8892dc9"
   integrity sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==
+
+jake@^10.8.5:
+  version "10.9.4"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.9.4.tgz#d626da108c63d5cfb00ab5c25fadc7e0084af8e6"
+  integrity sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==
+  dependencies:
+    async "^3.2.6"
+    filelist "^1.0.4"
+    picocolors "^1.1.1"
 
 jose@^6.1.3:
   version "6.2.2"
@@ -1368,6 +1517,11 @@ lightningcss@^1.32.0:
     lightningcss-win32-arm64-msvc "1.32.0"
     lightningcss-win32-x64-msvc "1.32.0"
 
+lilconfig@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
+  integrity sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==
+
 lint-staged@^17.0.4:
   version "17.0.4"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-17.0.4.tgz#7fecff62ab416b9ec88f3b49a53fbbc86a95f462"
@@ -1453,12 +1607,19 @@ mimic-function@^5.0.0:
   resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
   integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
-minimatch@^10.2.2, minimatch@^10.2.4:
+minimatch@^10.2.2, minimatch@^10.2.4, minimatch@^10.2.5:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
   integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
   dependencies:
     brace-expansion "^5.0.5"
+
+minimatch@^5.0.1:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.9.tgz#1293ef15db0098b394540e8f9f744f9fda8dee4b"
+  integrity sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 ms@^2.1.3:
   version "2.1.3"
@@ -1726,6 +1887,11 @@ semver@^7.7.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
+semver@^7.8.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.0.tgz#ed0661039fcbcda2ce71f01fa6adbefaa77040df"
+  integrity sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==
+
 send@^1.1.0, send@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/send/-/send-1.2.1.tgz#9eab743b874f3550f40a26867bf286ad60d3f3ed"
@@ -1871,6 +2037,15 @@ string-argv@^0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
@@ -1888,12 +2063,26 @@ string-width@^8.2.0:
     get-east-asian-width "^1.5.0"
     strip-ansi "^7.1.2"
 
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^7.1.0, strip-ansi@^7.1.2:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
   integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
   dependencies:
     ansi-regex "^6.2.2"
+
+supports-color@^8:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
 
 tinybench@^2.9.0:
   version "2.9.0"
@@ -1944,6 +2133,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-is@^2.0.1:
   version "2.0.1"
@@ -2052,10 +2246,22 @@ why-is-node-running@^2.3.0:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
+widest-line@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-3.1.0.tgz#8292333bbf66cb45ff0de1603b136b7ae1496eca"
+  integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
+  dependencies:
+    string-width "^4.0.0"
+
 word-wrap@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 wrap-ansi@^10.0.0:
   version "10.0.0"
@@ -2065,6 +2271,15 @@ wrap-ansi@^10.0.0:
     ansi-styles "^6.2.3"
     string-width "^8.2.0"
     strip-ansi "^7.1.2"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^9.0.0:
   version "9.0.2"


### PR DESCRIPTION
## Summary

PR-B of multi-PR plan for #109。把 PR-A(#113)oclif spike 的成果搬进生产 src/cli/,验证在真实命令上能跑。

- **OMK_CLI_NEXT=1** env var 切换新旧 dispatcher,默认 zero impact
- 迁移:**doctor + sample 两个代表命令**(eval / evolve / studio / observe / init 留给 PR-C)
- 业务逻辑零改:oclif Doctor / Sample 是薄壳,直接调现有 `runDoctor()` / `generateSamples()` 等

## 范围 + 验证

```
新建:
  src/cli/oclif/{i18n,help,run}.ts            基础设施(LangAwareHelp 子类 + execute 入口)
  src/cli/oclif/commands/doctor.ts             oclif Doctor,9 flag + positional target
  src/cli/oclif/commands/sample.ts             oclif Sample,8 flag + positional skillPath
  test/cli/oclif-{doctor,sample,dispatch}.test.ts  15 个验收 case
修改:
  src/cli/index.ts                             L41 后插 6 行 OMK_CLI_NEXT 分流,legacy 不动
  src/cli/i18n.ts                              加 tBoth(key) helper
  package.json                                 +@oclif/core ^4 / +oclif config / exitCodes.default=1
  CONTRIBUTING.md                              CLI 并存段
```

双路径手工对比验证(diff 输出):

| 场景 | legacy exit | oclif exit | 输出 diff |
|---|---|---|---|
| doctor --static-only (skill 全失败) | 1 | 1 | **0 行** ✅ |
| doctor --static-only --json | 1 | 1 | 2 行(只 timestamp + duration ms 飘) ✅ |
| doctor --static-only --gate | 1 | 1 | **0 行** ✅ |
| sample (缺 positional) | 1 | 1 | **0 行** ✅ |
| sample --batch /tmp/nonexistent | 1 | 1 | **0 行** ✅ |

## 9 项验收 deal-breaker(承接 PR-A)

| # | 项 | PR-B 结果 |
|---|---|---|
| 1 | 双语 help / OMK_LANG | ✅ LangAwareHelp 切换 |
| 2 | unknown flag exit 2 | ✅ oclif strict 默认 |
| 2b | unknown command exit 1 | ✅ 通过 exitCodes.default=1 对齐 legacy(注:PR-A 没装 plugin-not-found 时是 1,装了变 127;PR-B 也没装) |
| 2c | enum 校验 exit | ⚠️ 当前未实测(PR-B doctor / sample 没用 oclif enum option,生产 enum 校验仍走业务函数 throw exit 1) |
| 3 | positional / default / boolean / integer | ✅ doctor target / sample skillPath / count / batch 都通 |
| 4 | subcommand 元数据 | (PR-B 范围 doctor / sample 都不含 subcommand,延 PR-C 验) |
| 5 | docs 自动生成 | (PR-D 接 markers + oclif readme) |
| 6 | npm 打包形态 | ✅ +1 dep,package.json `files: ["dist/src/"]` 自动含 oclif/ 子树 |
| 7 | plugin 系统 | (PR-E 装 + 抹平 exit 127 偏差) |

## 关键技术点

**sentinel 选 `\n` 不选 `[[ZH]]/[[EN]]`**:oclif 错误路径在 `errors/handle.js` L44 硬编码 `new Help(config)`,绕过 package.json `helpClass`。显式 sentinel 在错误路径会原样泄漏给用户,极差;`\n` 退化成「两种语言各占一行」可读。代价:flag description 不能写真换行 — 单行写到底。PR-E 跟进抹平。

**业务逻辑薄壳化**:sample 直接 `await execute(process.argv.slice(3))` 透传到生产 `src/cli/commands/sample.ts`,避免重写 470 行 batch / fix / single 三路。doctor 同样直接调 `runDoctor()` + render*。**生产 src/{doctor,authoring}/ 完全不动**,eval 内嵌 `runDoctor()` 调用路径(src/eval-workflows/run-evaluation.ts L233)零影响。

## Followup

- **PR-C**:迁剩余 5 命令(eval / evolve / studio / observe / init),删 legacy dispatcher,删 OMK_CLI_NEXT 切换(oclif 成默认)
- **PR-D**:`<!-- omk:cli -->` markers 接进 README / SKILL.md / commands.md,`oclif readme` + 双语拼接脚本接 CI 做 drift check
- **PR-E**:plugin-not-found + completion,error 路径 helpClass 修补(让 sentinel 不泄漏)

Refs: #109
After: #113 (PR-A spike,可 merge / 不 merge 不影响本 PR)

## Test plan

- [ ] reviewer 跑 `yarn lint && yarn build && yarn test` 全绿
- [ ] reviewer 手工验 `OMK_CLI_NEXT=1 omk doctor --help` 跟 `omk doctor --help` 风格 / 信息覆盖差异在预期内
- [ ] reviewer 试 `OMK_CLI_NEXT=1 omk doctor --static-only` 跟 `omk doctor --static-only` exit code + stderr 一致
- [ ] reviewer 决策:接受 sentinel `\n` 方案(错误路径双语并行)→ 进 PR-C;否则讨论是否换实现路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)