### PR TITLE
feat(agents-md): commands.md 走 oclif codegen,CI 锁 drift(PR-D of #109)

### DIFF
--- a/.claude/skills/omk/references/commands.md
+++ b/.claude/skills/omk/references/commands.md
@@ -1,147 +1,430 @@
 # omk 命令参考
 
-omk v0.30+ 顶层命令固定为 7 个：`init` / `doctor` / `eval` / `observe` / `evolve` / `sample` / `studio`。本文档同步当前 CLI 表面，跟 `omk <command> --help` 输出一致。
-
-## omk init
-
-生成评测项目脚手架（两版 starter skill + `eval-samples.json`）。
-
-```
-omk init [目录]
-```
+<!-- omk:cli:start -->
+<!-- 此段由 scripts/build-docs.ts 从 src/cli/oclif/commands/ 自动生成。
+     改 CLI 后跑 `yarn build:docs` 同步,CI `yarn build:docs:check` 会拦截 drift。-->
 
 ## omk doctor
 
-LLM 健康度审计：7 个内置维度（结构 / 规范 / 工作流 / 依赖 / 内容 / 一致性 / 可观测性）+ 可扩展规则。
+体检 omk 工作目录,检查 skill 配置 / 依赖 / executor 连通性。
 
-```
-omk doctor                       # 项目内所有 skill 体检
-omk doctor skills/my-skill.md    # 单 skill 体检
-omk doctor --static-only         # 只跑静态规则，不调 LLM judge
-omk doctor --html <path>         # 输出 HTML 报告
+**用法:**
+
+```bash
+omk doctor [target] [flags]
 ```
 
-`omk eval` 默认会先跑一次 doctor 当 preflight 门禁，所以 doctor 一般不用单独跑；想在 eval 之前先扫一遍结构问题再决定要不要跑评测，就单独跑 doctor。
+**参数:**
+
+- `target`(可选):要体检的 skill 路径或目录。可选,默认扫当前 cwd 下的 skills/。
+
+**Flags:**
+
+- `--executor` `option`:执行器名,默认 claude。指定为测试 fixture 路径可在测试里跑(同 omk doctor)。
+- `--gate` `boolean`:静默模式,只在 fail 时输出 stderr 摘要,exit code 标识结果。
+- `--html` `option`:HTML 报告输出路径。可跟 --json / --gate 共存。
+- `--json` `boolean`:JSON 输出到 stdout,适合 CI / 外部脚本消费。
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en,优先级 CLI > OMK_LANG env > zh。
+- `--model` `option`:LLM model 名,默认 sonnet。
+- `--samples` `option`:样本文件路径(.json/.yaml)。不传则按 target / cwd 顺序自动发现。
+- `--static-only` `boolean`:离线静态模式,只跑 4 条静态 rule(skill_readable / skill_metadata / dependencies_present / samples_contract_aligned),不调 LLM。
+- `--timeout` `option`:单次 LLM 会话超时秒数,默认 600(10 分钟)。
+
+**示例:**
+
+> 默认模式跑 LLM 健康度审计(7 内置维度)。
+
+```bash
+omk doctor
+```
+
+> 离线静态模式,只跑 4 条静态 rule,不调 LLM,CI 无 LLM 凭证时用。
+
+```bash
+omk doctor --static-only
+```
+
+> JSON 输出 + 写 HTML 报告,给 CI 抓 exit code 同时人看。
+
+```bash
+omk doctor --json --html doctor.html
+```
 
 ## omk eval
 
-离线评测：比较版本，输出 verdict + report。
+跑评测:对一个 control vs 多个 treatment skill 做对照试验,产 verdict 报告。
 
-```
-omk eval --control <variant> --treatment <variant> [选项]
-```
+**用法:**
 
-常用选项：
-
-```
---samples <path>          用例文件（默认 eval-samples.json，也接受 .yaml / .yml；自动发现 <skill>/.omk/samples.json）
---skill-dir <path>        skill 目录（默认 skills）
---control <expr>          对照组 variant 表达式
---treatment <v1,v2>       实验组 variant 名，逗号分隔
---config <path>           eval.yaml / JSON 配置
---executor <name>         执行器：claude / claude-sdk / codex / codex-sdk / openai-api / gemini / custom
---model <name>            任务执行模型（默认 opus；省钱用 sonnet / haiku）
---effort <level>          扩展思考预算 low / medium / high / xhigh / max（默认 low；跨 effort 报告不严格可比）
---judge-models <list>     评委配置，例如 claude:haiku 或 claude:opus,openai:gpt-4o（≥ 2 = ensemble）
---concurrency <n>         并行任务数
---dry-run                 预览任务计划，不调用模型
---batch                   批量模式：每个 skill 独立 vs baseline
---blind                   盲测模式
---bootstrap               显式开启 bootstrap CI（默认自动开启）
---bootstrap-samples <n>   bootstrap 重采样次数（默认 1000）
---threshold <number>      verdict gate 阈值（默认 3.5）
---trivial-diff <number>   实际可忽略 diff（默认 0.1）
---report-only / --no-gate 生成报告并打印 verdict，但始终 exit 0
---no-serve                评测后不自动启动报告 server
---no-judge                关闭 judge 主观评分（仍跑断言层）
---no-diagnostic           关闭 diagnostic 诊断 LLM 调用
---skip-doctor             escape hatch：跳过 doctor preflight 门禁
+```bash
+omk eval [flags]
 ```
 
-Variant 特殊值：
+**Flags:**
 
-- `baseline` — 不注入 skill 的裸基线（保留 variant 名）
-- `git:<name>` — 从 git HEAD 读取旧版本
-- `git:<ref>:<name>` — 从指定 commit 读取
-- 含 `/` 的路径 — 直接读取文件
+- `--batch` `boolean`:batch 模式:baseline vs 每个 skill
+- `--blind` `boolean`:judge blind 模式
+- `--bootstrap` `boolean`:加 bootstrap CI
+- `--bootstrap-samples` `option`:bootstrap 重采样次数,默认 1000
+- `--budget-per-sample-ms` `option`:单 sample 时长上限 ms
+- `--budget-per-sample-usd` `option`:单 sample 预算上限 USD
+- `--budget-usd` `option`:总预算上限 USD
+- `--concurrency` `option`:并发数,默认 1
+- `--config` `option`:eval.yaml 路径
+- `--control` `option`:control variant 表达式
+- `--dry-run` `boolean`:只 plan 不实跑
+- `--effort` `option`:被测 LLM reasoning effort: low/medium/high/xhigh/max
+- `--executor` `option`:执行器名,默认 claude
+- `--gold-dir` `option`:gold dataset 目录
+- `--judge-models` `option`:评委,格式 executor:model[,...],默认 <executor>:haiku
+- `--judge-repeat` `option`:每个 dim 评 N 次
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en
+- `--layered-stats` `boolean`:输出分层统计
+- `--mcp-config` `option`:MCP 配置文件路径
+- `--model` `option`:被测模型
+- `--no-cache` `boolean`:跳过 executor cache
+- `--no-debias-length` `boolean`:关 length-debias(默认开)
+- `--no-diagnostic` `boolean`:关 diagnostic LLM 调用
+- `--no-gate` `boolean`:关 verdict gate
+- `--no-judge` `boolean`:跳过 LLM judge
+- `--no-serve` `boolean`:不启 report server
+- `--no-strict-baseline` `boolean`:关闭 baseline 隔离
+- `--output-dir` `option`:报告输出目录
+- `--repeat` `option`:每个 sample 重复跑 N 次
+- `--report-only` `boolean`:只出报告不算 verdict
+- `--resume` `option`:从某次失败 run 续跑
+- `--retry` `option`:失败 sample 重试次数
+- `--samples` `option`:样本文件路径
+- `--skill-dir` `option`:skill 目录,默认 skills
+- `--skip-connectivity` `boolean`:跳 LLM 连通性预检
+- `--skip-doctor` `boolean`:跳 doctor 门禁
+- `--strict-baseline` `boolean`:强制 baseline 隔离(default true)
+- `--threshold` `option`:verdict 阈值,默认 3.5
+- `--timeout` `option`:单样本超时秒,默认 120
+- `--treatment` `option`:treatment variant 列表,逗号分隔
+- `--trivial-diff` `option`:可忽略 diff 容差
+- `--verbose` `boolean`:详细日志
 
-退出码：verdict 为 `PROGRESS` 退 0，其他非 0（受 `--threshold` / `--report-only` 影响）。CI gate 直接用 exit code 就行。
+**示例:**
+
+> 最简对照:baseline vs my-skill
+
+```bash
+omk eval --control baseline --treatment my-skill
+```
+
+> eval.yaml 驱动 + bootstrap CI
+
+```bash
+omk eval --config eval.yaml --bootstrap
+```
+
+## omk eval gold compare
+
+把一份 evaluation report 跟 gold dataset 对比,计算 bootstrap CI 后的 agreement。
+
+**用法:**
+
+```bash
+omk eval gold compare [reportId] [flags]
+```
+
+**参数:**
+
+- `reportId`(可选):report ID,必填
+
+**Flags:**
+
+- `--bootstrap-samples` `option`:bootstrap 重采样次数,默认 1000
+- `--gold-dir` `option`:gold dataset 目录,必填
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en
+- `--reports-dir` `option`:报告目录,默认 ~/.oh-my-knowledge/reports
+- `--seed` `option`:bootstrap seed,可复现
+- `--variant` `option`:只比对指定 variant,默认全比
+
+## omk eval gold init
+
+初始化 gold dataset 目录(human-gold 标注集脚手架)。
+
+**用法:**
+
+```bash
+omk eval gold init [flags]
+```
+
+**Flags:**
+
+- `--annotator` `option`:标注者名,写入 metadata.yaml
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en
+- `--out` `option` (默认 `./gold-dataset`):输出目录,默认 ./gold-dataset
+
+## omk eval gold validate
+
+校验 gold dataset 目录格式(annotations.yaml schema)。
+
+**用法:**
+
+```bash
+omk eval gold validate [dir] [flags]
+```
+
+**参数:**
+
+- `dir`(可选):gold dataset 目录,必填
+
+**Flags:**
+
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en
 
 ## omk evolve
 
-LLM 自动多轮迭代改进 skill。
+自动迭代改进 skill:多轮 eval + skill 重写,直到达到 --target 或耗尽 --rounds。
 
-```
-omk evolve <skill 路径> [选项]
-```
+**用法:**
 
-选项：
-
-```
---rounds <n>           最大迭代轮数（默认 5）
---target <分数>        目标分数，达到即停
---samples <path>       用例文件
---model <name>         改进用模型
---effort <level>       扩展思考预算
---no-diagnostic        关闭 diagnostic
---skip-doctor          跳过 doctor preflight
+```bash
+omk evolve [skillPath] [flags]
 ```
 
-每轮版本保存在 `skills/evolve/<skill>.rN.md`。连续 2 轮无改进自动早停。**必须前台运行**：evolve 自带实时进度输出，前台才能看到每个 sample 的 `[N/M] sample_id ⏳ 执行中...` 跟每轮 `Round N: score=... ✓ ACCEPT / ✗ REJECT`。
+**参数:**
 
-## omk sample
+- `skillPath`(可选):skill 文件或 SKILL.md 路径,必填
 
-生成或补齐 eval-samples 评测用例。
+**Flags:**
 
+- `--concurrency` `option` (默认 `1`):评测并发数,默认 1
+- `--effort` `option`:reasoning effort: low/medium/high/xhigh/max
+- `--executor` `option` (默认 `claude`):执行器名,默认 claude
+- `--improve-model` `option` (默认 `sonnet`):负责重写 skill 的 LLM,默认 sonnet
+- `--judge-models` `option` (默认 `claude:haiku`):评委 model(单评委约束),格式 executor:model。默认 claude:haiku
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en
+- `--model` `option` (默认 `sonnet`):被评测的 LLM,默认 sonnet
+- `--no-diagnostic` `boolean`:关 LLM diagnostic 调用
+- `--rounds` `option` (默认 `5`):最大迭代轮数,默认 5
+- `--samples` `option` (默认 `eval-samples.json`):样本文件路径,默认 eval-samples.json
+- `--skip-connectivity` `boolean`:跳过 LLM 连通性预检
+- `--skip-doctor` `boolean`:跳过 doctor 门禁(escape hatch,自负 garbage-in 风险)
+- `--target` `option`:目标 composite 分数,达到即停。不传则跑满 rounds
+- `--timeout` `option` (默认 `120`):单样本超时秒,默认 120
+
+**示例:**
+
+> 默认 5 轮迭代
+
+```bash
+omk evolve skills/my-skill/SKILL.md
 ```
-omk sample <skill 路径>           # 单 skill
-omk sample --batch [选项]         # skill 目录下缺测试集的 skill 批量生成
+
+> 指定目标分 + 自定义模型
+
+```bash
+omk evolve skills/my-skill/SKILL.md --target 4.5 --model opus --improve-model opus
 ```
 
-选项：
+## omk init
 
+初始化 omk 项目脚手架(skills/ + eval-samples.json 模板)。
+
+**用法:**
+
+```bash
+omk init [targetDir] [flags]
 ```
---count <n>            强制生成 N 条（不指定时 LLM 按 skill 类型自动判断：
-                       工作流型 6-8 条 / 原子型 4-6 条 / 混合型 5-7 条）
---model <name>         生成模型（默认 opus；省钱用 sonnet / haiku）
---focus <text>         自然语言指定希望覆盖的场景（追加到 prompt）
---skill-dir <path>     skill 目录（batch 使用，默认 skills）
+
+**参数:**
+
+- `targetDir`(可选):初始化目标目录,默认当前目录(.)
+
+**Flags:**
+
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en,优先级 CLI > OMK_LANG env > zh。
+
+**示例:**
+
+> 在当前目录初始化
+
+```bash
+omk init
 ```
 
-输出位置（默认）：
+> 在指定目录初始化
 
-- `<skill>/SKILL.md` 风格 → `<skill>/.omk/samples.json`（omk 标准约定）
-- 其他 `.md` 路径 → 当前目录 `eval-samples.json`（兜底）
+```bash
+omk init my-project
+```
 
 ## omk observe
 
-线上观测：解析真实 session trace，输出 skill 健康度 / gap 信号 / 失败率 / observe inbox。
+分析 sessions 目录的 skill 调用健康度(默认行为)。子命令:ingest / inbox / show。
 
-```
-omk observe <sessions-dir>                          # skill 健康度报告（默认）
-omk observe ingest <sessions-dir>                   # 摄入 trace 落盘到 .omk/observations/
-omk observe inbox                                   # 看 inbox 列表
-omk observe inbox --skill <name>                    # 只看某 skill
-omk observe inbox --by-skill                        # 按 skill 资产视图
-omk observe show <inbox_id>                         # 单条 observation 事件三元组
+**用法:**
+
+```bash
+omk observe [sessionsDir] [flags]
 ```
 
-支持 trace 格式：Claude Code session JSONL、OpenClaw session JSONL、markdown 对话日志（`.log`）。
+**参数:**
+
+- `sessionsDir`(可选):sessions 目录路径(如 ~/.claude/sessions)
+
+**Flags:**
+
+- `--from` `option`:起始时间 ISO,优先级高于 --last
+- `--kb` `option`:知识库 root,启用 KB-aware 分析
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en
+- `--last` `option`:时间窗(7d / 24h / 30m)
+- `--output-dir` `option`:分析结果输出目录
+- `--skills` `option`:只看指定 skill,逗号分隔
+- `--to` `option`:结束时间 ISO
+
+**示例:**
+
+> 分析最近 7 天
+
+```bash
+omk observe ~/.claude/sessions --last 7d
+```
+
+## omk observe inbox
+
+查询 observation inbox(skill 调用洞察)。
+
+**用法:**
+
+```bash
+omk observe inbox [flags]
+```
+
+**Flags:**
+
+- `--by-skill` `boolean`:按 skill 聚合输出
+- `--explore` `option`:抽样 N 条 medium/low 长尾(replaces limit)
+- `--include-noise` `boolean`:explore 时也包含 noise 桶
+- `--input-dir` `option`:inbox 数据目录,默认 ~/.oh-my-knowledge/observations
+- `--json` `boolean`:JSON 格式输出
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en
+- `--limit` `option`:限制条数,默认 20
+- `--skill` `option`:只看指定 skill
+
+## omk observe ingest
+
+把 trace 目录 ingest 成 observation inbox 报告。
+
+**用法:**
+
+```bash
+omk observe ingest [traceDir] [flags]
+```
+
+**参数:**
+
+- `traceDir`(可选):trace 目录路径,必填
+
+**Flags:**
+
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en
+- `--output-dir` `option`:输出目录,默认 ~/.oh-my-knowledge/observations
+
+## omk observe show
+
+展开 observation inbox 中某条 item 的详情。
+
+**用法:**
+
+```bash
+omk observe show [inboxId] [flags]
+```
+
+**参数:**
+
+- `inboxId`(可选):inbox item ID,必填
+
+**Flags:**
+
+- `--input-dir` `option`:inbox 数据目录
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en
+
+## omk sample
+
+为指定 skill 生成评测用例(eval-samples),支持 batch / single / fix 三种模式。
+
+**用法:**
+
+```bash
+omk sample [skillPath] [flags]
+```
+
+**参数:**
+
+- `skillPath`(可选):skill 文件路径或 SKILL.md 路径。batch 模式不需要;single / fix 模式必填。
+
+**Flags:**
+
+- `--batch` `boolean`:批量模式:扫 --skill-dir 下所有缺 samples 的 skill,逐个生成。
+- `--count` `option`:生成样本条数。不传由 LLM 按 skill 类型自动决定。
+- `--fix` `boolean`:fix 模式:基于最近评测报告自动修复 sample_design 类型失败。
+- `--focus` `option`:生成焦点(自然语言提示)。控制 LLM 偏向哪类用例。
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en,优先级 CLI > OMK_LANG env > zh。
+- `--model` `option` (默认 `opus`):生成 LLM model 名,默认 opus。
+- `--reports-dir` `option`:报告目录(fix 模式用),默认 ~/.oh-my-knowledge/reports。
+- `--skill-dir` `option` (默认 `skills`):skill 根目录,默认 skills。batch 模式扫此目录。
+- `--treatment` `option`:指定 treatment 名(fix 模式用),默认推断自 skill 路径。
+
+**示例:**
+
+> 为单个 skill 生成默认数量的样本
+
+```bash
+omk sample skills/my-skill/SKILL.md
+```
+
+> 批量为 skill 目录下所有缺 samples 的 skill 生成
+
+```bash
+omk sample --batch --skill-dir skills
+```
+
+> 根据最近评测报告自动修复 sample_design 类型失败
+
+```bash
+omk sample skills/my-skill/SKILL.md --fix
+```
 
 ## omk studio
 
-本地报告浏览器。
+启动 omk Studio 报告服务(skill-centric 仪表盘 + 浏览器自动打开)。
 
-```
-omk studio                                # 启动 web 服务
-omk studio --port 8080                    # 改端口（默认 7799）
-omk studio --host 0.0.0.0                 # 局域网访问（默认 127.0.0.1）
-omk studio --reports-dir <path>           # 报告目录
-omk studio --observations-dir <path>      # observe inbox 数据目录
-omk studio --no-open                      # 不自动开浏览器
+**用法:**
+
+```bash
+omk studio [flags]
 ```
 
-Studio 是 skill-centric：列表页（`/`）按 skill 卡片展示健康等级 / 0-100 参考分 / 待优化数 / 趋势；详情页（`/skills/<name>`）左栏列关键问题清单（skill 优化项 / 用例优化项 / 工具反馈三档），右栏画 chart.js 健康趋势 + 三个紧凑阶段卡。旧的 run 列表在 `/runs`，observe inbox 看板在 `/observations/inbox`。
+**Flags:**
+
+- `--analyses-dir` `option`:分析数据目录(可选)
+- `--dev` `boolean`:dev 模式:子进程启动 + 热更新
+- `--host` `option`:监听 host,默认 localhost。改为 0.0.0.0 暴露给局域网
+- `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en
+- `--no-open` `boolean`:不自动打开浏览器
+- `--observations-dir` `option`:观测数据目录(可选)
+- `--port` `option` (默认 `7799`):监听端口,默认 7799。传 0 让 OS 分配
+- `--reports-dir` `option`:报告目录,默认 ~/.oh-my-knowledge/reports
+
+**示例:**
+
+> 默认端口 7799
+
+```bash
+omk studio
+```
+
+> 指定端口,不打开浏览器
+
+```bash
+omk studio --port 8080 --no-open
+```
+<!-- omk:cli:end -->
 
 ## eval-samples 字段参考
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,5 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn build
+      - run: yarn build:docs:check
       - run: yarn test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,17 @@ omk CLI 已迁到 [@oclif/core](https://oclif.io/docs/) 框架(PR-A spike #113 /
 2. flag 用 `bilingual({zh, en})` 包装,跟生产 `execute()` 的 `parseArgsStrictOrExit` 配置对齐
 3. `run()` 透传 `await execute(process.argv.slice(3))` 给生产业务函数
 4. 在 `test/cli/oclif-<name>.test.ts` 加 --help 双语 + unknown flag exit 2 + 关键 happy/error case
+5. 跑 `yarn build && yarn build:docs` 把 oclif Command 的 description / flags / examples 同步到 `.claude/skills/omk/references/commands.md`(见下一节)
+
+### CLI 文档 codegen(PR-D #109)
+
+oclif Command 的 `description` / `flags` / `args` / `examples` static 字段是 CLI 文档的**单一来源**。`scripts/build-docs.ts` 把它生成到 `.claude/skills/omk/references/commands.md` 的 `<!-- omk:cli:start -->` ... `<!-- omk:cli:end -->` marker 之间。
+
+工作流:
+
+- 改完 oclif Command,跑 `yarn build && yarn build:docs` 同步 commands.md
+- 不跑就会被 CI `yarn build:docs:check` 拦截(exit 1 + 打 diff)
+- README / SKILL.md 仍 hand-maintained,后续 PR 视需要扩 codegen 覆盖
 
 ## Style
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   ],
   "scripts": {
     "build": "tsc && node -e \"const fs=require('node:fs'),p=require('node:path');const d='dist/src/eval-core/mock-hook.cjs';fs.mkdirSync(p.dirname(d),{recursive:true});fs.copyFileSync('src/eval-core/mock-hook.cjs',d)\"",
+    "build:docs": "node --import tsx scripts/build-docs.ts --write",
+    "build:docs:check": "node --import tsx scripts/build-docs.ts --check",
     "typecheck": "tsc --noEmit",
     "lint": "eslint 'src/**/*.ts' 'test/**/*.ts' --cache --cache-location node_modules/.cache/eslint/ --max-warnings 0",
     "test": "vitest run",
@@ -94,6 +96,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.4",
     "npm-run-all2": "^8.0.4",
+    "tsx": "^4.22.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.0",
     "vitest": "^4.1.3"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   ],
   "scripts": {
     "build": "tsc && node -e \"const fs=require('node:fs'),p=require('node:path');const d='dist/src/eval-core/mock-hook.cjs';fs.mkdirSync(p.dirname(d),{recursive:true});fs.copyFileSync('src/eval-core/mock-hook.cjs',d)\"",
-    "build:docs": "node --import tsx scripts/build-docs.ts --write",
-    "build:docs:check": "node --import tsx scripts/build-docs.ts --check",
+    "build:docs": "node dist/scripts/build-docs.js --write",
+    "build:docs:check": "node dist/scripts/build-docs.js --check",
     "typecheck": "tsc --noEmit",
     "lint": "eslint 'src/**/*.ts' 'test/**/*.ts' --cache --cache-location node_modules/.cache/eslint/ --max-warnings 0",
     "test": "vitest run",
@@ -96,7 +96,6 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.4",
     "npm-run-all2": "^8.0.4",
-    "tsx": "^4.22.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.0",
     "vitest": "^4.1.3"

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1,0 +1,244 @@
+// scripts/build-docs.ts — 从 oclif Config 渲染 commands.md 的 marker 区段。
+//
+// 来源:src/cli/oclif/commands/*.ts(双语 description / examples / flags / args)。
+// 目标:.claude/skills/omk/references/commands.md 的 <!-- omk:cli:start --> ... <!-- omk:cli:end --> 之间。
+//
+// 模式:
+// - `yarn build:docs`(--write)→ 直接覆盖 marker 区段
+// - `yarn build:docs:check`(--check)→ 比对磁盘内容,不一致 exit 1 + print diff(CI 用)
+//
+// 依赖 dist/ 存在(oclif config.commands 指向 ./dist/src/cli/oclif/commands),
+// 跑之前必须先 `yarn build`。
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Config, type Command } from '@oclif/core';
+
+const REPO_ROOT = resolve(process.cwd());
+const COMMANDS_MD = resolve(REPO_ROOT, '.claude/skills/omk/references/commands.md');
+const MARKER_START = '<!-- omk:cli:start -->';
+const MARKER_END = '<!-- omk:cli:end -->';
+
+// inline pickLang — 跟 src/cli/oclif/i18n.ts:36 行为一致,zh = `${zh}\n${en}` 首行。
+// 本 script 是 build-time 工具,不进 npm 包;inline 避免引入 dist/ 路径 import 依赖。
+function pickZh(text: string | undefined): string {
+  if (!text) return '';
+  const parts = text.split(/\r?\n/);
+  if (parts.length < 2) return text;
+  return parts[0] ?? '';
+}
+
+interface FlagShape {
+  type?: string;
+  default?: unknown;
+  options?: readonly string[];
+  description?: string;
+  env?: string;
+  required?: boolean;
+}
+
+interface ArgShape {
+  required?: boolean;
+  description?: string;
+}
+
+interface ExampleObj {
+  description?: string;
+  command: string;
+}
+
+function renderUsageLine(cmd: Command.Loadable, bin: string, idDisplay: string): string {
+  const pieces = [bin, idDisplay];
+  const args = cmd.args ? Object.entries(cmd.args) : [];
+  for (const [name, raw] of args) {
+    const a = raw as ArgShape;
+    pieces.push(a.required ? `<${name}>` : `[${name}]`);
+  }
+  const flagCount = cmd.flags ? Object.keys(cmd.flags).length : 0;
+  if (flagCount > 0) pieces.push('[flags]');
+  return pieces.join(' ');
+}
+
+function renderArgs(cmd: Command.Loadable): string[] {
+  const args = cmd.args ? Object.entries(cmd.args) : [];
+  if (args.length === 0) return [];
+  const out: string[] = ['**参数:**', ''];
+  for (const [name, raw] of args) {
+    const a = raw as ArgShape;
+    const required = a.required ? '必填' : '可选';
+    const desc = pickZh(a.description);
+    out.push(`- \`${name}\`(${required})${desc ? `:${desc}` : ''}`);
+  }
+  out.push('');
+  return out;
+}
+
+function renderFlagType(f: FlagShape): string {
+  if (f.type === 'boolean') return '`boolean`';
+  if (f.options && f.options.length > 0) return `\`${f.options.join('|')}\``;
+  return '`option`';
+}
+
+function renderFlags(cmd: Command.Loadable): string[] {
+  const flags = cmd.flags ? Object.entries(cmd.flags) : [];
+  if (flags.length === 0) return [];
+  const out: string[] = ['**Flags:**', ''];
+  const sorted = [...flags].sort(([a], [b]) => a.localeCompare(b));
+  for (const [name, raw] of sorted) {
+    const f = raw as FlagShape;
+    const parts: string[] = [`\`--${name}\``, renderFlagType(f)];
+    if (f.default !== undefined && f.default !== null && f.default !== false) {
+      parts.push(`(默认 \`${String(f.default)}\`)`);
+    }
+    if (f.env) parts.push(`(env \`${f.env}\`)`);
+    const desc = pickZh(f.description);
+    out.push(`- ${parts.join(' ')}${desc ? `:${desc}` : ''}`);
+  }
+  out.push('');
+  return out;
+}
+
+function renderExamples(cmd: Command.Loadable, bin: string): string[] {
+  const examples = cmd.examples;
+  if (!Array.isArray(examples) || examples.length === 0) return [];
+  const out: string[] = ['**示例:**', ''];
+  for (const ex of examples) {
+    if (typeof ex === 'string') {
+      const expanded = ex.replace(/<%= config\.bin %>/g, bin);
+      out.push('```bash');
+      out.push(expanded);
+      out.push('```');
+      out.push('');
+    } else {
+      const exo = ex as ExampleObj;
+      const desc = pickZh(exo.description);
+      const text = exo.command.replace(/<%= config\.bin %>/g, bin);
+      if (desc) {
+        out.push(`> ${desc}`);
+        out.push('');
+      }
+      out.push('```bash');
+      out.push(text);
+      out.push('```');
+      out.push('');
+    }
+  }
+  return out;
+}
+
+function renderCommand(cmd: Command.Loadable, bin: string): string[] {
+  const idDisplay = cmd.id.split(':').join(' ');
+  const lines: string[] = [];
+  lines.push(`## ${bin} ${idDisplay}`);
+  lines.push('');
+  const desc = pickZh(cmd.description);
+  if (desc) {
+    lines.push(desc);
+    lines.push('');
+  }
+  lines.push('**用法:**');
+  lines.push('');
+  lines.push('```bash');
+  lines.push(renderUsageLine(cmd, bin, idDisplay));
+  lines.push('```');
+  lines.push('');
+  lines.push(...renderArgs(cmd));
+  lines.push(...renderFlags(cmd));
+  lines.push(...renderExamples(cmd, bin));
+  return lines;
+}
+
+async function generate(): Promise<string> {
+  const config = await Config.load({ root: REPO_ROOT });
+  const cmds = [...config.commands].sort((a, b) => a.id.localeCompare(b.id));
+  const lines: string[] = [];
+  lines.push('<!-- 此段由 scripts/build-docs.ts 从 src/cli/oclif/commands/ 自动生成。');
+  lines.push('     改 CLI 后跑 `yarn build:docs` 同步,CI `yarn build:docs:check` 会拦截 drift。-->');
+  lines.push('');
+  for (const cmd of cmds) {
+    lines.push(...renderCommand(cmd, config.bin));
+  }
+  // 去掉尾部多余空行,后面 compose 会自己加换行。
+  while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  return lines.join('\n');
+}
+
+interface Split {
+  pre: string;
+  post: string;
+}
+
+function splitFile(content: string): Split | null {
+  const startIdx = content.indexOf(MARKER_START);
+  const endIdx = content.indexOf(MARKER_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) return null;
+  const pre = content.slice(0, startIdx + MARKER_START.length);
+  const post = content.slice(endIdx);
+  return { pre, post };
+}
+
+function compose(pre: string, body: string, post: string): string {
+  return `${pre}\n${body}\n${post}`;
+}
+
+function diffPreview(expected: string, actual: string): string {
+  const eLines = expected.split('\n');
+  const aLines = actual.split('\n');
+  const max = Math.max(eLines.length, aLines.length);
+  const out: string[] = [];
+  let shown = 0;
+  for (let i = 0; i < max; i++) {
+    if (eLines[i] !== aLines[i]) {
+      out.push(`L${i + 1}:`);
+      out.push(`  - actual:   ${JSON.stringify(aLines[i])}`);
+      out.push(`  + expected: ${JSON.stringify(eLines[i])}`);
+      shown++;
+      if (shown >= 20) {
+        out.push('...(diff truncated, run `yarn build:docs` to see full update)');
+        break;
+      }
+    }
+  }
+  return out.join('\n');
+}
+
+async function main(): Promise<void> {
+  const mode = process.argv.includes('--check') ? 'check' : 'write';
+  const current = readFileSync(COMMANDS_MD, 'utf8');
+  const split = splitFile(current);
+  if (!split) {
+    process.stderr.write(
+      `[build-docs] commands.md missing markers (${MARKER_START} / ${MARKER_END}).\n`,
+    );
+    process.stderr.write(`Add markers to ${COMMANDS_MD} before running.\n`);
+    process.exit(2);
+  }
+  const body = await generate();
+  const next = compose(split.pre, body, split.post);
+
+  if (mode === 'check') {
+    if (next === current) {
+      process.stdout.write('[build-docs] commands.md is in sync with oclif source.\n');
+      return;
+    }
+    process.stderr.write(
+      '[build-docs] commands.md drifted from oclif source. Run `yarn build:docs` to regenerate.\n',
+    );
+    process.stderr.write('---\n');
+    process.stderr.write(diffPreview(next, current));
+    process.stderr.write('\n');
+    process.exit(1);
+  }
+
+  if (next === current) {
+    process.stdout.write('[build-docs] commands.md already up to date.\n');
+    return;
+  }
+  writeFileSync(COMMANDS_MD, next, 'utf8');
+  process.stdout.write(`[build-docs] wrote ${COMMANDS_MD}\n`);
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/test/scripts/build-docs.test.ts
+++ b/test/scripts/build-docs.test.ts
@@ -1,0 +1,139 @@
+/**
+ * scripts/build-docs.ts 集成测试 — codegen 输出的 commands.md 内容稳定性。
+ * 测试策略:
+ * - 直接断言已提交的 .claude/skills/omk/references/commands.md(代表 codegen 结果)
+ *   的 schema 性质:13 命令 H2 / 关键 flag 存在 / 子命令空格分隔 / `<%= config.bin %>` 已替换
+ * - spawn `node --import tsx scripts/build-docs.ts --check` 验证 --check 模式
+ *   在不漂移时 exit 0,在漂移时 exit 1
+ * - eval-samples 字段参考段不在 marker 内,codegen 后必须原样保留
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const COMMANDS_MD = join(PROJECT_ROOT, '.claude/skills/omk/references/commands.md');
+const BUILD_DOCS = join(PROJECT_ROOT, 'scripts/build-docs.ts');
+
+const MARKER_START = '<!-- omk:cli:start -->';
+const MARKER_END = '<!-- omk:cli:end -->';
+
+interface ExecError extends Error {
+  code?: number;
+  stdout: string;
+  stderr: string;
+}
+
+function readMarkerBody(content: string): string {
+  const s = content.indexOf(MARKER_START);
+  const e = content.indexOf(MARKER_END);
+  assert.ok(s !== -1 && e !== -1 && e > s, 'commands.md must contain markers');
+  return content.slice(s + MARKER_START.length, e);
+}
+
+describe('scripts/build-docs codegen', () => {
+  it('commands.md marker body covers all 13 oclif commands', () => {
+    const content = readFileSync(COMMANDS_MD, 'utf8');
+    const body = readMarkerBody(content);
+    const expectedHeaders = [
+      '## omk doctor',
+      '## omk eval',
+      '## omk eval gold compare',
+      '## omk eval gold init',
+      '## omk eval gold validate',
+      '## omk evolve',
+      '## omk init',
+      '## omk observe',
+      '## omk observe inbox',
+      '## omk observe ingest',
+      '## omk observe show',
+      '## omk sample',
+      '## omk studio',
+    ];
+    for (const h of expectedHeaders) {
+      assert.ok(body.includes(`\n${h}\n`), `marker body missing H2 header "${h}"`);
+    }
+  });
+
+  it('subcommand id (colon-separated internally) renders with spaces', () => {
+    const content = readFileSync(COMMANDS_MD, 'utf8');
+    // 不应出现 colon-id 风格(`eval:gold:init`)
+    assert.ok(!content.includes('omk eval:gold:'), 'should not leak colon-id form');
+    assert.ok(content.includes('omk eval gold init'), 'should render eval gold init with spaces');
+  });
+
+  it('`<%= config.bin %>` template is fully expanded', () => {
+    const content = readFileSync(COMMANDS_MD, 'utf8');
+    assert.ok(!content.includes('<%= config.bin %>'), 'template placeholder should be replaced');
+  });
+
+  it('flag descriptions are zh-only (no English line leaked through)', () => {
+    const content = readFileSync(COMMANDS_MD, 'utf8');
+    const body = readMarkerBody(content);
+    // 选几个稳定的英文 keyword,出现就说明 pickLang 没切掉:
+    // - "Preflight" (doctor.ts en description 头)
+    // - "Init in" (init.ts en example description)
+    // - "Output language zh|en" (lang flag en description)
+    assert.ok(!body.includes('Preflight health checks'), 'doctor en description leaked');
+    assert.ok(!body.includes('Init in current directory'), 'init en example leaked');
+    assert.ok(!body.includes('Output language zh|en'), 'lang flag en description leaked');
+  });
+
+  it('doctor flags include --json --gate --static-only', () => {
+    const content = readFileSync(COMMANDS_MD, 'utf8');
+    const doctorIdx = content.indexOf('\n## omk doctor\n');
+    const nextH2Idx = content.indexOf('\n## omk eval\n', doctorIdx + 1);
+    assert.ok(doctorIdx !== -1 && nextH2Idx !== -1);
+    const doctorBlock = content.slice(doctorIdx, nextH2Idx);
+    assert.ok(doctorBlock.includes('`--json`'), 'doctor must list --json');
+    assert.ok(doctorBlock.includes('`--gate`'), 'doctor must list --gate');
+    assert.ok(doctorBlock.includes('`--static-only`'), 'doctor must list --static-only');
+  });
+
+  it('eval-samples appendix section is preserved outside markers', () => {
+    const content = readFileSync(COMMANDS_MD, 'utf8');
+    const endIdx = content.indexOf(MARKER_END);
+    const tail = content.slice(endIdx + MARKER_END.length);
+    assert.ok(tail.includes('## eval-samples 字段参考'), 'appendix must survive codegen');
+    assert.ok(tail.includes('`sample_id`'), 'appendix table must survive');
+    assert.ok(tail.includes('docs/sample-design-spec.md'), 'appendix link must survive');
+  });
+
+  it('--check mode passes on current committed state', async () => {
+    const { stdout } = await execFileAsync(
+      'node',
+      ['--import', 'tsx', BUILD_DOCS, '--check'],
+      { cwd: PROJECT_ROOT },
+    );
+    assert.ok(stdout.includes('in sync'), `expected in-sync message: ${stdout}`);
+  }, 30000);
+
+  it('--check mode fails on drift and prints diff', async () => {
+    const original = readFileSync(COMMANDS_MD, 'utf8');
+    // 注入一处明显 drift:在 marker body 里加一行
+    const drifted = original.replace(
+      MARKER_START,
+      `${MARKER_START}\n<!-- DRIFT INJECTED FOR TEST -->`,
+    );
+    writeFileSync(COMMANDS_MD, drifted, 'utf8');
+    try {
+      await assert.rejects(
+        () => execFileAsync('node', ['--import', 'tsx', BUILD_DOCS, '--check'], { cwd: PROJECT_ROOT }),
+        (err: unknown) => {
+          const e = err as ExecError;
+          assert.equal(e.code, 1, `expected exit 1 on drift, got ${e.code}`);
+          assert.ok(e.stderr.includes('drifted'), `stderr should mention drift: ${e.stderr.slice(0, 200)}`);
+          return true;
+        },
+      );
+    } finally {
+      writeFileSync(COMMANDS_MD, original, 'utf8');
+    }
+  }, 30000);
+});

--- a/test/scripts/build-docs.test.ts
+++ b/test/scripts/build-docs.test.ts
@@ -3,8 +3,10 @@
  * 测试策略:
  * - 直接断言已提交的 .claude/skills/omk/references/commands.md(代表 codegen 结果)
  *   的 schema 性质:13 命令 H2 / 关键 flag 存在 / 子命令空格分隔 / `<%= config.bin %>` 已替换
- * - spawn `node --import tsx scripts/build-docs.ts --check` 验证 --check 模式
- *   在不漂移时 exit 0,在漂移时 exit 1
+ * - spawn `node dist/scripts/build-docs.js --check` 验证 --check 模式在不漂移时
+ *   exit 0,在漂移时 exit 1。走 dist 而非 tsx,因为 tsx 装在 node_modules 时
+ *   oclif Config.load 会自动 register tsx loader,把 ajv 等库的 .json 文件
+ *   按 JS 解析,破坏 production 行为(详见 PR-D fix commit)。
  * - eval-samples 字段参考段不在 marker 内,codegen 后必须原样保留
  */
 import { describe, it } from 'vitest';
@@ -19,7 +21,7 @@ const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, '..', '..');
 const COMMANDS_MD = join(PROJECT_ROOT, '.claude/skills/omk/references/commands.md');
-const BUILD_DOCS = join(PROJECT_ROOT, 'scripts/build-docs.ts');
+const BUILD_DOCS = join(PROJECT_ROOT, 'dist/scripts/build-docs.js');
 
 const MARKER_START = '<!-- omk:cli:start -->';
 const MARKER_END = '<!-- omk:cli:end -->';
@@ -108,7 +110,7 @@ describe('scripts/build-docs codegen', () => {
   it('--check mode passes on current committed state', async () => {
     const { stdout } = await execFileAsync(
       'node',
-      ['--import', 'tsx', BUILD_DOCS, '--check'],
+      [BUILD_DOCS, '--check'],
       { cwd: PROJECT_ROOT },
     );
     assert.ok(stdout.includes('in sync'), `expected in-sync message: ${stdout}`);
@@ -124,7 +126,7 @@ describe('scripts/build-docs codegen', () => {
     writeFileSync(COMMANDS_MD, drifted, 'utf8');
     try {
       await assert.rejects(
-        () => execFileAsync('node', ['--import', 'tsx', BUILD_DOCS, '--check'], { cwd: PROJECT_ROOT }),
+        () => execFileAsync('node', [BUILD_DOCS, '--check'], { cwd: PROJECT_ROOT }),
         (err: unknown) => {
           const e = err as ExecError;
           assert.equal(e.code, 1, `expected exit 1 on drift, got ${e.code}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
   },
   "include": [
     "src/**/*.ts",
-    "test/**/*.ts"
+    "test/**/*.ts",
+    "scripts/**/*.ts"
   ],
   "exclude": [
     "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,136 +93,6 @@
   dependencies:
     tslib "^2.4.0"
 
-"@esbuild/aix-ppc64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz#7a289c158e29cbf59ea0afc83cc80f06d1c89402"
-  integrity sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==
-
-"@esbuild/android-arm64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz#b8828d9edfa3a92660644eb8de6e4f3c203d7b17"
-  integrity sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==
-
-"@esbuild/android-arm@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.0.tgz#5ec1847605e05b5dbe5df90db9ff7e3e4c58dca7"
-  integrity sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==
-
-"@esbuild/android-x64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.0.tgz#390642175b88ef82bad4cce03f8ab13fe9b1912e"
-  integrity sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==
-
-"@esbuild/darwin-arm64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz#ae45325960d5950cd6951e4f97396f4e1ff7d8d3"
-  integrity sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==
-
-"@esbuild/darwin-x64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz#c079247d589b6b99449659d94f06951b84bff2e4"
-  integrity sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==
-
-"@esbuild/freebsd-arm64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz#45c456215a486593c94900297202dc11c880a37a"
-  integrity sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==
-
-"@esbuild/freebsd-x64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz#0399494c1c85e4388e9b7040bd60d48f2a5b0d2c"
-  integrity sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==
-
-"@esbuild/linux-arm64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz#d6d9f09ef0de54116bf459a4d53cac7e0952fe39"
-  integrity sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==
-
-"@esbuild/linux-arm@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz#7b42ffa84c288ae94fdc431c1b28a89e3c3b9278"
-  integrity sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==
-
-"@esbuild/linux-ia32@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz#deb15d112ed8dd605346b6b953d23a21ff81253f"
-  integrity sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==
-
-"@esbuild/linux-loong64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz#81fb89d07eecc79b157dea61033757726fce0ca4"
-  integrity sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==
-
-"@esbuild/linux-mips64el@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz#d0e42691b3ff7af9fb2217b70fc01f343bdb62bb"
-  integrity sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==
-
-"@esbuild/linux-ppc64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz#389f3e5e98f17d477c467cc87136e1a076eead87"
-  integrity sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==
-
-"@esbuild/linux-riscv64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz#763bd60d59b242be12da1e67d5729f3024c605fa"
-  integrity sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==
-
-"@esbuild/linux-s390x@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz#aac6061634872e4677de693bce8030d73b1fd055"
-  integrity sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==
-
-"@esbuild/linux-x64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz#4f2917747188fe77632bcec65b2d84b422419779"
-  integrity sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==
-
-"@esbuild/netbsd-arm64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz#814df0ae57a0c386814491b8397eeba82094a947"
-  integrity sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==
-
-"@esbuild/netbsd-x64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz#e01bdf7e60fa1a08e46d46d960b0d9bb8ac210af"
-  integrity sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==
-
-"@esbuild/openbsd-arm64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz#4a15c36aacca68d2d5a4c90b710c06759f4c1ffa"
-  integrity sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==
-
-"@esbuild/openbsd-x64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz#475e6101498a8ecce3008d7c388111d7a27c17bd"
-  integrity sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==
-
-"@esbuild/openharmony-arm64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz#cfdc3957f0b7a69f1bde129aad17fcc2f6fa033e"
-  integrity sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==
-
-"@esbuild/sunos-x64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz#a013c856fecacd1c3aec985c8afe1d1cb017497d"
-  integrity sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==
-
-"@esbuild/win32-arm64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz#eae05e0f35271cad3898b43168d3e9a3bbaf47e5"
-  integrity sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==
-
-"@esbuild/win32-ia32@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz#06161ebc5bf75c08d69feb3c6b22560515913998"
-  integrity sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==
-
-"@esbuild/win32-x64@0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz#04d90d5752b4ce65d2b6ac25eba08ff7624fe07c"
-  integrity sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==
-
 "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
@@ -1055,38 +925,6 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
-
-esbuild@~0.28.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.0.tgz#5dee347ffb3e3874212a35a69836b077b1ce6d96"
-  integrity sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==
-  optionalDependencies:
-    "@esbuild/aix-ppc64" "0.28.0"
-    "@esbuild/android-arm" "0.28.0"
-    "@esbuild/android-arm64" "0.28.0"
-    "@esbuild/android-x64" "0.28.0"
-    "@esbuild/darwin-arm64" "0.28.0"
-    "@esbuild/darwin-x64" "0.28.0"
-    "@esbuild/freebsd-arm64" "0.28.0"
-    "@esbuild/freebsd-x64" "0.28.0"
-    "@esbuild/linux-arm" "0.28.0"
-    "@esbuild/linux-arm64" "0.28.0"
-    "@esbuild/linux-ia32" "0.28.0"
-    "@esbuild/linux-loong64" "0.28.0"
-    "@esbuild/linux-mips64el" "0.28.0"
-    "@esbuild/linux-ppc64" "0.28.0"
-    "@esbuild/linux-riscv64" "0.28.0"
-    "@esbuild/linux-s390x" "0.28.0"
-    "@esbuild/linux-x64" "0.28.0"
-    "@esbuild/netbsd-arm64" "0.28.0"
-    "@esbuild/netbsd-x64" "0.28.0"
-    "@esbuild/openbsd-arm64" "0.28.0"
-    "@esbuild/openbsd-x64" "0.28.0"
-    "@esbuild/openharmony-arm64" "0.28.0"
-    "@esbuild/sunos-x64" "0.28.0"
-    "@esbuild/win32-arm64" "0.28.0"
-    "@esbuild/win32-ia32" "0.28.0"
-    "@esbuild/win32-x64" "0.28.0"
 
 escape-html@^1.0.3:
   version "1.0.3"
@@ -2288,15 +2126,6 @@ tslib@^2.4.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
-tsx@^4.22.0:
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.22.0.tgz#9588cadbf41915d4256ae3df69cb65210537f7ab"
-  integrity sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==
-  dependencies:
-    esbuild "~0.28.0"
-  optionalDependencies:
-    fsevents "~2.3.3"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,6 +93,136 @@
   dependencies:
     tslib "^2.4.0"
 
+"@esbuild/aix-ppc64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz#7a289c158e29cbf59ea0afc83cc80f06d1c89402"
+  integrity sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==
+
+"@esbuild/android-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz#b8828d9edfa3a92660644eb8de6e4f3c203d7b17"
+  integrity sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==
+
+"@esbuild/android-arm@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.0.tgz#5ec1847605e05b5dbe5df90db9ff7e3e4c58dca7"
+  integrity sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==
+
+"@esbuild/android-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.0.tgz#390642175b88ef82bad4cce03f8ab13fe9b1912e"
+  integrity sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==
+
+"@esbuild/darwin-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz#ae45325960d5950cd6951e4f97396f4e1ff7d8d3"
+  integrity sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==
+
+"@esbuild/darwin-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz#c079247d589b6b99449659d94f06951b84bff2e4"
+  integrity sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==
+
+"@esbuild/freebsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz#45c456215a486593c94900297202dc11c880a37a"
+  integrity sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==
+
+"@esbuild/freebsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz#0399494c1c85e4388e9b7040bd60d48f2a5b0d2c"
+  integrity sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==
+
+"@esbuild/linux-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz#d6d9f09ef0de54116bf459a4d53cac7e0952fe39"
+  integrity sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==
+
+"@esbuild/linux-arm@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz#7b42ffa84c288ae94fdc431c1b28a89e3c3b9278"
+  integrity sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==
+
+"@esbuild/linux-ia32@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz#deb15d112ed8dd605346b6b953d23a21ff81253f"
+  integrity sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==
+
+"@esbuild/linux-loong64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz#81fb89d07eecc79b157dea61033757726fce0ca4"
+  integrity sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==
+
+"@esbuild/linux-mips64el@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz#d0e42691b3ff7af9fb2217b70fc01f343bdb62bb"
+  integrity sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==
+
+"@esbuild/linux-ppc64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz#389f3e5e98f17d477c467cc87136e1a076eead87"
+  integrity sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==
+
+"@esbuild/linux-riscv64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz#763bd60d59b242be12da1e67d5729f3024c605fa"
+  integrity sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==
+
+"@esbuild/linux-s390x@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz#aac6061634872e4677de693bce8030d73b1fd055"
+  integrity sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==
+
+"@esbuild/linux-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz#4f2917747188fe77632bcec65b2d84b422419779"
+  integrity sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==
+
+"@esbuild/netbsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz#814df0ae57a0c386814491b8397eeba82094a947"
+  integrity sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==
+
+"@esbuild/netbsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz#e01bdf7e60fa1a08e46d46d960b0d9bb8ac210af"
+  integrity sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==
+
+"@esbuild/openbsd-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz#4a15c36aacca68d2d5a4c90b710c06759f4c1ffa"
+  integrity sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==
+
+"@esbuild/openbsd-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz#475e6101498a8ecce3008d7c388111d7a27c17bd"
+  integrity sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==
+
+"@esbuild/openharmony-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz#cfdc3957f0b7a69f1bde129aad17fcc2f6fa033e"
+  integrity sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==
+
+"@esbuild/sunos-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz#a013c856fecacd1c3aec985c8afe1d1cb017497d"
+  integrity sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==
+
+"@esbuild/win32-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz#eae05e0f35271cad3898b43168d3e9a3bbaf47e5"
+  integrity sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==
+
+"@esbuild/win32-ia32@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz#06161ebc5bf75c08d69feb3c6b22560515913998"
+  integrity sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==
+
+"@esbuild/win32-x64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz#04d90d5752b4ce65d2b6ac25eba08ff7624fe07c"
+  integrity sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==
+
 "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
@@ -925,6 +1055,38 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
+
+esbuild@~0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.0.tgz#5dee347ffb3e3874212a35a69836b077b1ce6d96"
+  integrity sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.28.0"
+    "@esbuild/android-arm" "0.28.0"
+    "@esbuild/android-arm64" "0.28.0"
+    "@esbuild/android-x64" "0.28.0"
+    "@esbuild/darwin-arm64" "0.28.0"
+    "@esbuild/darwin-x64" "0.28.0"
+    "@esbuild/freebsd-arm64" "0.28.0"
+    "@esbuild/freebsd-x64" "0.28.0"
+    "@esbuild/linux-arm" "0.28.0"
+    "@esbuild/linux-arm64" "0.28.0"
+    "@esbuild/linux-ia32" "0.28.0"
+    "@esbuild/linux-loong64" "0.28.0"
+    "@esbuild/linux-mips64el" "0.28.0"
+    "@esbuild/linux-ppc64" "0.28.0"
+    "@esbuild/linux-riscv64" "0.28.0"
+    "@esbuild/linux-s390x" "0.28.0"
+    "@esbuild/linux-x64" "0.28.0"
+    "@esbuild/netbsd-arm64" "0.28.0"
+    "@esbuild/netbsd-x64" "0.28.0"
+    "@esbuild/openbsd-arm64" "0.28.0"
+    "@esbuild/openbsd-x64" "0.28.0"
+    "@esbuild/openharmony-arm64" "0.28.0"
+    "@esbuild/sunos-x64" "0.28.0"
+    "@esbuild/win32-arm64" "0.28.0"
+    "@esbuild/win32-ia32" "0.28.0"
+    "@esbuild/win32-x64" "0.28.0"
 
 escape-html@^1.0.3:
   version "1.0.3"
@@ -2126,6 +2288,15 @@ tslib@^2.4.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tsx@^4.22.0:
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.22.0.tgz#9588cadbf41915d4256ae3df69cb65210537f7ab"
+  integrity sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==
+  dependencies:
+    esbuild "~0.28.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Summary

- issue #109 主目标的 MVP:用 oclif Command 类的 `description` / `flags` / `args` / `examples` 作为 CLI 文档单一来源,生成到 `.claude/skills/omk/references/commands.md` 的 marker 区段
- CI `yarn build:docs:check` 在 PR 阶段拦截 drift(exit 1 + 打 diff)
- 改完 oclif Command 直接 `yarn build && yarn build:docs` 一条同步

## Scope

MVP **只覆盖 commands.md**。理由:

- commands.md 是 omk 自带 skill 的 CLI 参考,服务 agent 消费,**纯结构化命令列表**,适合 codegen 全文重写
- README / SKILL.md 含 hand-curated 长 prose(static-only 说明 / executor 表格 / HTML report tab 描述等),硬塞 codegen 会丢内容,留 PR-D2 评估
- CONTRIBUTING 已经把「改完 oclif Command 跑 yarn build:docs」写进新增命令的清单

## Commits

1. `0faf4fc` feat(agents-md): commands.md 走 oclif codegen,CI 锁 drift
2. `7e4a5d3` fix(scripts): build-docs 改走 tsc 编译,避免 tsx 触发 oclif loader 副作用

## 第二个 commit 的来龙去脉

第一个 commit 用 `node --import tsx scripts/build-docs.ts` 跑 codegen,本意是省去为单个 build script 多搞一层 tsc 编译。但本地完整 `yarn test` 跑出 20 个 fail(`test/cli.test.ts` 等 4 个 spawn `dist/src/cli/index.js` 的 spec),错误是 `SyntaxError: ajv/dist/refs/data.json: Unexpected token 'v', "var $id="h"..."`。

交叉验证(checkout PR-C 父分支 + 干净 `rm -rf node_modules && yarn install --frozen-lockfile`)显示同样的测试在 PR-C 上是绿的;然后 cherry pick 我刚 commit 的 PR-D,fail 立即复现 — 锁定根因。

根因在 `node_modules/@oclif/core/lib/config/ts-path.js:208` 的 `determinePath`:只要 repo root 存在 tsconfig.json + `require.resolve('tsx/esm/api')` 能找到 tsx,oclif 在 Config.load 时**无条件 register tsx loader**。tsx 把 require/import 的 .json 路径按 JS 模块编译,ajv 内部用 `require('./refs/data.json')` 读 meta-schema 直接炸。tsx 是开发期 TS runner,oclif 把它当成 dev-mode 提示,但它的副作用波及到生产入口的所有 .json import。

修法:**不把 tsx 当 devDep**,改成 `scripts/build-docs.ts` 进 tsconfig include,tsc 编译到 `dist/scripts/build-docs.js`,scripts 改 `node dist/scripts/build-docs.js`。`package.json` 的 `files: ["dist/src/"]` 不变,`dist/scripts/` 不会进 npm 发布产物。

## What changed

| 文件 | 改动 |
|---|---|
| `scripts/build-docs.ts`(新) | Codegen 主脚本:`Config.load({ root })` → 遍历 commands → pickLang 取 zh 行 → 渲染 markdown |
| `test/scripts/build-docs.test.ts`(新) | 8 case:13 H2 覆盖 / sub-sub 空格分隔 / `<%= config.bin %>` 替换 / pickLang zh 切准 / appendix 不动 / `--check` 双路径(in-sync / drift) |
| `package.json` | scripts 加 `build:docs` + `build:docs:check`(走 `node dist/scripts/build-docs.js`);**不引入 tsx** |
| `tsconfig.json` | `include` 追加 `scripts/**/*.ts`,让 tsc 编出 `dist/scripts/build-docs.js` |
| `.github/workflows/ci.yml` | build 之后 test 之前加 `yarn build:docs:check` |
| `CONTRIBUTING.md` | 「CLI 走 oclif 框架」段尾追加 docs codegen 工作流 |
| `.claude/skills/omk/references/commands.md` | 插入 marker;codegen 填充;`## eval-samples 字段参考` 段保留不动 |

## Test plan

- [x] `yarn build && yarn build:docs --write` 渲染正确 — commands.md 含 13 H2(doctor / eval / eval gold {compare,init,validate} / evolve / init / observe / observe {inbox,ingest,show} / sample / studio),flag 描述纯中文无 \n 残留,`<%= config.bin %>` 全替换
- [x] `yarn build:docs:check` 在已同步状态 exit 0,在手动注入 drift 后 exit 1 + stderr 打 diff
- [x] `## eval-samples 字段参考` 段在 codegen 前后字符级一致
- [x] `yarn lint` 通过
- [x] `yarn test` **1466/1466 通过**(包含 8 个新 build-docs case)

## Followup(留给 PR-D2 / PR-E)

- **PR-D2**:README.md / README.zh.md 的 `## CLI reference` 段。两种思路待评估:
  - 思路 A:整段 codegen 重写(丢 hand-curated prose)
  - 思路 B:只在每个命令子段加 narrow marker 包裹 bash example block + flag list,prose 仍 hand-maintained
  - 用户使用本 PR 一段时间后,看 drift 实际发生位置再决定
- **PR-D3**:SKILL.md。可能新增 `## 命令速查` codegen appendix,也可能完全跳过
- **PR-E**:plugin-not-found / `--json` jsonResponse helper / bash enum completion / oclif 错误路径 helpClass 修补 / product_main prose 重生

🤖 Generated with [Claude Code](https://claude.com/claude-code)