### PR TITLE
feat(agents-md): README/zh flag codegen + SKILL.md frontmatter gate(PR-D2 of #109)

### DIFF
--- a/.claude/skills/omk/references/commands.md
+++ b/.claude/skills/omk/references/commands.md
@@ -73,10 +73,10 @@ omk eval [flags]
 - `--config` `option`:eval.yaml 路径
 - `--control` `option`:control variant 表达式
 - `--dry-run` `boolean`:只 plan 不实跑
-- `--effort` `option`:被测 LLM reasoning effort: low/medium/high/xhigh/max
-- `--executor` `option`:执行器名,默认 claude
+- `--effort` `option`:被测 LLM 扩展思考预算 low/medium/high/xhigh/max(默认 low;跨 effort 报告不严格可比)。
+- `--executor` `option`:执行器:claude / claude-sdk / codex / codex-sdk / openai-api / gemini / 自定义命令(默认 claude)。
 - `--gold-dir` `option`:gold dataset 目录
-- `--judge-models` `option`:评委,格式 executor:model[,...],默认 <executor>:haiku
+- `--judge-models` `option`:评委配置,格式 executor:model[,...],例 claude:haiku 或 claude:opus,openai:gpt-4o(≥ 2 个 = ensemble)。默认 <executor>:haiku。
 - `--judge-repeat` `option`:每个 dim 评 N 次
 - `--lang` `zh|en` (默认 `zh`) (env `OMK_LANG`):输出语言 zh|en
 - `--layered-stats` `boolean`:输出分层统计
@@ -84,20 +84,20 @@ omk eval [flags]
 - `--model` `option`:被测模型
 - `--no-cache` `boolean`:跳过 executor cache
 - `--no-debias-length` `boolean`:关 length-debias(默认开)
-- `--no-diagnostic` `boolean`:关 diagnostic LLM 调用
+- `--no-diagnostic` `boolean`:关闭 diagnostic 诊断 LLM 调用(默认开,给 failed sample 出「哪错了 + 怎么改」建议)。
 - `--no-gate` `boolean`:关 verdict gate
 - `--no-judge` `boolean`:跳过 LLM judge
 - `--no-serve` `boolean`:不启 report server
 - `--no-strict-baseline` `boolean`:关闭 baseline 隔离
 - `--output-dir` `option`:报告输出目录
 - `--repeat` `option`:每个 sample 重复跑 N 次
-- `--report-only` `boolean`:只出报告不算 verdict
+- `--report-only` `boolean`:生成报告并打印 verdict,但始终 exit 0(不参与 CI gate)。
 - `--resume` `option`:从某次失败 run 续跑
 - `--retry` `option`:失败 sample 重试次数
-- `--samples` `option`:样本文件路径
+- `--samples` `option`:样本文件路径。默认 eval-samples.json,也接受 .yaml/.yml;自动发现 --skill-dir 下的 <skill>/.omk/samples.json。
 - `--skill-dir` `option`:skill 目录,默认 skills
 - `--skip-connectivity` `boolean`:跳 LLM 连通性预检
-- `--skip-doctor` `boolean`:跳 doctor 门禁
+- `--skip-doctor` `boolean`:escape hatch:跳 doctor 健康检查门禁(默认强制启用)。沙箱 mock 提供依赖时绕开 doctor 物理路径误报;garbage-in 风险自负。
 - `--strict-baseline` `boolean`:强制 baseline 隔离(default true)
 - `--threshold` `option`:verdict 阈值,默认 3.5
 - `--timeout` `option`:单样本超时秒,默认 120

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,15 +153,23 @@ omk CLI 已迁到 [@oclif/core](https://oclif.io/docs/) 框架(PR-A spike #113 /
 4. 在 `test/cli/oclif-<name>.test.ts` 加 --help 双语 + unknown flag exit 2 + 关键 happy/error case
 5. 跑 `yarn build && yarn build:docs` 把 oclif Command 的 description / flags / examples 同步到 `.claude/skills/omk/references/commands.md`(见下一节)
 
-### CLI 文档 codegen(PR-D #109)
+### CLI 文档 codegen(#109)
 
-oclif Command 的 `description` / `flags` / `args` / `examples` static 字段是 CLI 文档的**单一来源**。`scripts/build-docs.ts` 把它生成到 `.claude/skills/omk/references/commands.md` 的 `<!-- omk:cli:start -->` ... `<!-- omk:cli:end -->` marker 之间。
+oclif Command 的 `description` / `flags` / `args` / `examples` static 字段是 CLI 文档的**单一来源**。`scripts/build-docs.ts` 把它渲染到三个目标文件的 marker 区段:
+
+| 目标 | marker | 输出 | 语言 |
+|---|---|---|---|
+| `.claude/skills/omk/references/commands.md` | 整段 `<!-- omk:cli:start -->` ... `<!-- omk:cli:end -->` | 13 个 oclif command(含 sub-sub)完整渲染 | zh |
+| `README.md` | 每个顶层命令独立 `<!-- omk:cli:<id>:flags:start -->` ... `<!-- omk:cli:<id>:flags:end -->`,7 对 | flag list(```text``` 对齐风格)+ 指向 `--help` 的脚注 | en |
+| `README.zh.md` | 同上 | 同上 | zh |
 
 工作流:
 
-- 改完 oclif Command,跑 `yarn build && yarn build:docs` 同步 commands.md
-- 不跑就会被 CI `yarn build:docs:check` 拦截(exit 1 + 打 diff)
-- README / SKILL.md 仍 hand-maintained,后续 PR 视需要扩 codegen 覆盖
+- 改完 oclif Command 的 description / flag,跑 `yarn build && yarn build:docs` 同步全部 3 个目标
+- 不跑就会被 CI `yarn build:docs:check` 拦截(exit 1 + 对每个 drift 的文件打 diff)
+- README 的 prose 段(static-only 解释 / HTML report tab / Studio IA / executor 表格等)在 marker 外,hand-maintained 保留
+- 新增顶层命令时:在 README.md / README.zh.md 各加一对 `<!-- omk:cli:<new-id>:flags:start -->` / `:end -->`,并把 id 加进 `scripts/build-docs.ts` 的 `TARGETS[*].topLevelIds`
+- SKILL.md 暂不覆盖,留 PR-D3 评估
 
 ## Style
 

--- a/README.md
+++ b/README.md
@@ -446,10 +446,10 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
   --config <value>                eval.yaml path
   --control <value>               Control variant expr
   --dry-run                       Plan only, no real exec
-  --effort <value>                Reasoning effort: low/medium/high/xhigh/max
-  --executor <value>              Executor, default claude
+  --effort <value>                Executor LLM reasoning effort low/medium/high/xhigh/max (default low; reports across efforts not strictly comparable).
+  --executor <value>              Executor: claude / claude-sdk / codex / codex-sdk / openai-api / gemini / custom (default claude).
   --gold-dir <value>              Gold dataset dir
-  --judge-models <value>          Judge model(s), executor:model[,...] format
+  --judge-models <value>          Judge config: executor:model[,...]. e.g. claude:haiku or claude:opus,openai:gpt-4o (≥ 2 = ensemble). Default <executor>:haiku.
   --judge-repeat <value>          Judge each dim N times
   --lang <zh|en>                  Output language zh|en
   --layered-stats                 Emit layered stats
@@ -457,20 +457,20 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
   --model <value>                 Evaluated model
   --no-cache                      Skip executor cache
   --no-debias-length              Disable length-debias (default on)
-  --no-diagnostic                 Disable diagnostic LLM call
+  --no-diagnostic                 Disable diagnostic LLM call (on by default; emits "what went wrong + how to fix" advice for failed samples).
   --no-gate                       Disable verdict gate
   --no-judge                      Skip LLM judge
   --no-serve                      Do not start report server
   --no-strict-baseline            Disable baseline isolation
   --output-dir <value>            Report output dir
   --repeat <value>                Repeat each sample N times
-  --report-only                   Report only, no verdict
+  --report-only                   Produce the report and print verdict, but always exit 0 (no CI gate).
   --resume <value>                Resume a previous failed run
   --retry <value>                 Per-sample retry count
-  --samples <value>               Samples file path
+  --samples <value>               Samples file path. Defaults to eval-samples.json (also .yaml/.yml); auto-discovers <skill>/.omk/samples.json under --skill-dir.
   --skill-dir <value>             Skill dir, default skills
   --skip-connectivity             Skip LLM connectivity preflight
-  --skip-doctor                   Skip doctor gate
+  --skip-doctor                   Escape hatch: skip the doctor health-check gate (on by default). Use when sandbox mocks supply deps; caller owns garbage-in risk.
   --strict-baseline               Force baseline isolation (default true)
   --threshold <value>             Verdict threshold, default 3.5
   --timeout <value>               Per-sample timeout sec, default 120

--- a/README.md
+++ b/README.md
@@ -367,6 +367,18 @@ omk exposes a workflow CLI for knowledge artifacts. Seven top-level commands cov
 omk init [dir]
 ```
 
+<!-- omk:cli:init:flags:start -->
+
+**Flags:**
+
+```text
+  --lang <zh|en>  Output language zh|en. Priority: CLI > OMK_LANG env > zh.
+```
+
+For full descriptions: `omk init --help`.
+
+<!-- omk:cli:init:flags:end -->
+
 Scaffolds an evaluation project with two starter skill variants and an `eval-samples.json` file.
 
 ### `omk doctor`
@@ -379,6 +391,26 @@ omk doctor skills/ --json > r.json      # JSON for CI / external tools
 omk doctor --gate; echo $?              # silent gate; exit 1 on fatal failures, warnings do not block
 omk doctor --static-only                # offline mode: static checks only, no LLM call
 ```
+
+<!-- omk:cli:doctor:flags:start -->
+
+**Flags:**
+
+```text
+  --executor <value>  Executor name, default claude. Pass a test fixture path to use in tests.
+  --gate              Silent mode: only emit stderr summary on fail. Exit code carries the signal.
+  --html <value>      HTML report output path. Coexists with --json / --gate.
+  --json              JSON output to stdout, for CI / external script consumption.
+  --lang <zh|en>      Output language zh|en. Priority: CLI > OMK_LANG env > zh.
+  --model <value>     LLM model name, default sonnet.
+  --samples <value>   Samples file path (.json/.yaml). Auto-discovered from target / cwd if omitted.
+  --static-only       Offline static mode: only 4 static rules, no LLM call.
+  --timeout <value>   LLM session timeout in seconds, default 600 (10 min).
+```
+
+For full descriptions: `omk doctor --help`.
+
+<!-- omk:cli:doctor:flags:end -->
 
 LLM health audit: a single LLM session emits per-dimension grades, findings, and suggestions for the 7 builtin dimensions; the HTML report sorts dimensions fail→warn→pass→skipped with errors first within each dim. Dimensions are extensible — call `registerHealthDimension` in your own code and the new section is folded into the same LLM call's prompt and report (order = registration order).
 
@@ -398,35 +430,58 @@ omk eval gold compare <report-id> --gold-dir gold-dataset
 
 Runs the offline evaluation, applies the verdict gate, persists the report, and returns a ship/no-ship exit code. Bootstrap CI is enabled by default on this workflow.
 
-Common options:
+<!-- omk:cli:eval:flags:start -->
+
+**Flags:**
 
 ```text
-  --samples <path>       sample file (default: eval-samples.json, also detects .yaml/.yml; auto-discovers <skill>/.omk/samples.json under --skill-dir)
-  --skill-dir <path>     artifact dir (default: skills)
-  --control <expr>       control variant expression
-  --treatment <v1,v2>    treatment variants, comma-separated
-  --config <path>        YAML/JSON evaluation config
-  --model <name>         task execution model (default: opus alias)
-  --effort <level>       reasoning effort for executor LLM: low/medium/high/xhigh/max (default: low; reports across efforts not strictly comparable)
-  --judge-models <list>  judge config, e.g. claude:haiku or claude:opus,openai:gpt-4o
-  --executor <name>      claude / claude-sdk / codex / codex-sdk / openai-api / gemini / custom
-  --no-judge             skip LLM judge subjective scoring
-  --no-diagnostic        skip the diagnostic LLM call (default: on; emits "what went wrong + how to fix" advice for failed samples)
-  --skip-doctor          escape hatch: bypass the doctor health-check gate (default: on). Use when sandbox mocks supply deps and doctor's path/env checks misfire; caller owns garbage-in risk
-  --dry-run              preview only
-  --blind                blind A/B mode
-  --concurrency <n>      parallel tasks
-  --timeout <sec>        per-task timeout
-  --repeat <n>           repeat N times for variance analysis
-  --batch                evaluate each artifact independently vs baseline
-  --bootstrap-samples N  bootstrap resample count (default 1000)
-  --threshold <number>   verdict layer-gate threshold (default 3.5)
-  --trivial-diff <num>   practically tiny diff cutoff (default 0.1)
-  --report-only          produce the report and print verdict, but always exit 0
-  --no-gate              alias for --report-only
-  --skip-connectivity    skip model connectivity check (internal static gates still run)
-  --no-serve             do not auto-start the report server after evaluation
+  --batch                         Batch mode: baseline vs each skill
+  --blind                         Blind judge mode
+  --bootstrap                     Add bootstrap CI
+  --bootstrap-samples <value>     Bootstrap resamples, default 1000
+  --budget-per-sample-ms <value>  Per-sample time cap ms
+  --budget-per-sample-usd <value> Per-sample budget cap USD
+  --budget-usd <value>            Total budget cap USD
+  --concurrency <value>           Concurrency, default 1
+  --config <value>                eval.yaml path
+  --control <value>               Control variant expr
+  --dry-run                       Plan only, no real exec
+  --effort <value>                Reasoning effort: low/medium/high/xhigh/max
+  --executor <value>              Executor, default claude
+  --gold-dir <value>              Gold dataset dir
+  --judge-models <value>          Judge model(s), executor:model[,...] format
+  --judge-repeat <value>          Judge each dim N times
+  --lang <zh|en>                  Output language zh|en
+  --layered-stats                 Emit layered stats
+  --mcp-config <value>            MCP config path
+  --model <value>                 Evaluated model
+  --no-cache                      Skip executor cache
+  --no-debias-length              Disable length-debias (default on)
+  --no-diagnostic                 Disable diagnostic LLM call
+  --no-gate                       Disable verdict gate
+  --no-judge                      Skip LLM judge
+  --no-serve                      Do not start report server
+  --no-strict-baseline            Disable baseline isolation
+  --output-dir <value>            Report output dir
+  --repeat <value>                Repeat each sample N times
+  --report-only                   Report only, no verdict
+  --resume <value>                Resume a previous failed run
+  --retry <value>                 Per-sample retry count
+  --samples <value>               Samples file path
+  --skill-dir <value>             Skill dir, default skills
+  --skip-connectivity             Skip LLM connectivity preflight
+  --skip-doctor                   Skip doctor gate
+  --strict-baseline               Force baseline isolation (default true)
+  --threshold <value>             Verdict threshold, default 3.5
+  --timeout <value>               Per-sample timeout sec, default 120
+  --treatment <value>             Treatment variants, comma-separated
+  --trivial-diff <value>          Trivial diff tolerance
+  --verbose                       Verbose logging
 ```
+
+For full descriptions: `omk eval --help`.
+
+<!-- omk:cli:eval:flags:end -->
 
 The HTML report has two tabs:
 - **📊 Score view** — the verdict-driven A/B comparison (fact / behavior / judge layers, bootstrap CI, length-debias).
@@ -445,6 +500,24 @@ omk observe ~/.claude/projects/my-project --from 2026-04-01T00:00:00Z --to 2026-
 omk observe ~/.claude/projects/my-project --skills audit,polish
 omk observe ~/.claude/projects/my-project --kb /path/to/project
 ```
+
+<!-- omk:cli:observe:flags:start -->
+
+**Flags:**
+
+```text
+  --from <value>        Start time ISO, overrides --last
+  --kb <value>          KB root, enables KB-aware analysis
+  --lang <zh|en>        Output language zh|en
+  --last <value>        Time window (7d / 24h / 30m)
+  --output-dir <value>  Analysis output directory
+  --skills <value>      Filter to specific skills, comma-separated
+  --to <value>          End time ISO
+```
+
+For full descriptions: `omk observe --help`.
+
+<!-- omk:cli:observe:flags:end -->
 
 Turns real Claude Code session traces into skill-health reports: knowledge usage, gap signals, execution stability, tokens, and latency. This is production observation, not production scoring.
 
@@ -486,6 +559,31 @@ omk evolve <skill>                  # multi-round auto-iteration on a skill
 omk evolve skills/foo.md --rounds 10 --target 4.5
 ```
 
+<!-- omk:cli:evolve:flags:start -->
+
+**Flags:**
+
+```text
+  --concurrency <value>    Eval concurrency, default 1
+  --effort <value>         Reasoning effort: low/medium/high/xhigh/max
+  --executor <value>       Executor name, default claude
+  --improve-model <value>  LLM that rewrites the skill, default sonnet
+  --judge-models <value>   Judge model (single judge required), executor:model format. Default claude:haiku
+  --lang <zh|en>           Output language zh|en
+  --model <value>          Evaluated LLM, default sonnet
+  --no-diagnostic          Disable diagnostic LLM call
+  --rounds <value>         Max iteration rounds, default 5
+  --samples <value>        Samples file, default eval-samples.json
+  --skip-connectivity      Skip LLM connectivity preflight
+  --skip-doctor            Skip doctor gate (escape hatch; user takes garbage-in risk)
+  --target <value>         Target composite score; stop when reached. If omitted, runs all rounds.
+  --timeout <value>        Per-sample timeout sec, default 120
+```
+
+For full descriptions: `omk evolve --help`.
+
+<!-- omk:cli:evolve:flags:end -->
+
 Auto-iterates a skill through repeated eval → judge → rewrite loops until it hits `--target` or exhausts `--rounds`. Cost scales with `rounds × samples × variants`; a typical run takes minutes to tens of minutes. Original skill files are versioned under `skills/evolve/*.r0.md`.
 
 ### `omk sample`
@@ -494,6 +592,26 @@ Auto-iterates a skill through repeated eval → judge → rewrite loops until it
 omk sample <skill>                  # generate or fill eval-samples test cases for one skill
 omk sample --batch                  # generate for skills missing eval-samples
 ```
+
+<!-- omk:cli:sample:flags:start -->
+
+**Flags:**
+
+```text
+  --batch                Batch mode: scan --skill-dir, generate samples for any skill missing them.
+  --count <value>        Number of samples to generate. Defaults to LLM auto-selection by skill type.
+  --fix                  Fix mode: auto-fix sample_design failures using the latest eval report.
+  --focus <value>        Generation focus (NL hint). Steers LLM toward certain sample types.
+  --lang <zh|en>         Output language zh|en. Priority: CLI > OMK_LANG env > zh.
+  --model <value>        Generation LLM model name, default opus.
+  --reports-dir <value>  Reports dir (fix mode), default ~/.oh-my-knowledge/reports.
+  --skill-dir <value>    Skill root dir, default skills. Used by batch mode.
+  --treatment <value>    Treatment name (fix mode), defaults to skill-path inference.
+```
+
+For full descriptions: `omk sample --help`.
+
+<!-- omk:cli:sample:flags:end -->
 
 One-shot generation. Auto-stamps `provenance` on generated cases. Generated assertions use English, numbers, or code tokens so they compare cleanly across bilingual outputs.
 
@@ -507,6 +625,25 @@ omk studio --reports-dir ~/.oh-my-knowledge/reports
 omk studio --observations-dir .omk/observations    # observe inbox data directory
 omk studio --no-open
 ```
+
+<!-- omk:cli:studio:flags:start -->
+
+**Flags:**
+
+```text
+  --analyses-dir <value>      Analyses dir (optional)
+  --dev                       Dev mode: child process with hot reload
+  --host <value>              Listen host, default localhost. Use 0.0.0.0 to expose to LAN
+  --lang <zh|en>              Output language zh|en
+  --no-open                   Do not auto-open browser
+  --observations-dir <value>  Observations dir (optional)
+  --port <value>              Listen port, default 7799. Pass 0 for OS-assigned
+  --reports-dir <value>       Reports dir, default ~/.oh-my-knowledge/reports
+```
+
+For full descriptions: `omk studio --help`.
+
+<!-- omk:cli:studio:flags:end -->
 
 Starts the local knowledge workbench for browsing reports and observation analyses. Verdict, sample diffs, regressions, saturation curves, and per-sample drill-downs all live in the studio UI — there is no CLI export / analysis subcommand. For CI gates, use `omk eval`'s exit code (0 on `PROGRESS`, non-zero otherwise) or `jq` over the report JSON.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -446,10 +446,10 @@ omk eval gold compare <report-id> --gold-dir gold-dataset
   --config <value>                eval.yaml 路径
   --control <value>               control variant 表达式
   --dry-run                       只 plan 不实跑
-  --effort <value>                被测 LLM reasoning effort: low/medium/high/xhigh/max
-  --executor <value>              执行器名,默认 claude
+  --effort <value>                被测 LLM 扩展思考预算 low/medium/high/xhigh/max(默认 low;跨 effort 报告不严格可比)。
+  --executor <value>              执行器:claude / claude-sdk / codex / codex-sdk / openai-api / gemini / 自定义命令(默认 claude)。
   --gold-dir <value>              gold dataset 目录
-  --judge-models <value>          评委,格式 executor:model[,...],默认 <executor>:haiku
+  --judge-models <value>          评委配置,格式 executor:model[,...],例 claude:haiku 或 claude:opus,openai:gpt-4o(≥ 2 个 = ensemble)。默认 <executor>:haiku。
   --judge-repeat <value>          每个 dim 评 N 次
   --lang <zh|en>                  输出语言 zh|en
   --layered-stats                 输出分层统计
@@ -457,20 +457,20 @@ omk eval gold compare <report-id> --gold-dir gold-dataset
   --model <value>                 被测模型
   --no-cache                      跳过 executor cache
   --no-debias-length              关 length-debias(默认开)
-  --no-diagnostic                 关 diagnostic LLM 调用
+  --no-diagnostic                 关闭 diagnostic 诊断 LLM 调用(默认开,给 failed sample 出「哪错了 + 怎么改」建议)。
   --no-gate                       关 verdict gate
   --no-judge                      跳过 LLM judge
   --no-serve                      不启 report server
   --no-strict-baseline            关闭 baseline 隔离
   --output-dir <value>            报告输出目录
   --repeat <value>                每个 sample 重复跑 N 次
-  --report-only                   只出报告不算 verdict
+  --report-only                   生成报告并打印 verdict,但始终 exit 0(不参与 CI gate)。
   --resume <value>                从某次失败 run 续跑
   --retry <value>                 失败 sample 重试次数
-  --samples <value>               样本文件路径
+  --samples <value>               样本文件路径。默认 eval-samples.json,也接受 .yaml/.yml;自动发现 --skill-dir 下的 <skill>/.omk/samples.json。
   --skill-dir <value>             skill 目录,默认 skills
   --skip-connectivity             跳 LLM 连通性预检
-  --skip-doctor                   跳 doctor 门禁
+  --skip-doctor                   escape hatch:跳 doctor 健康检查门禁(默认强制启用)。沙箱 mock 提供依赖时绕开 doctor 物理路径误报;garbage-in 风险自负。
   --strict-baseline               强制 baseline 隔离(default true)
   --threshold <value>             verdict 阈值,默认 3.5
   --timeout <value>               单样本超时秒,默认 120

--- a/README.zh.md
+++ b/README.zh.md
@@ -367,6 +367,18 @@ omk 的公开 CLI 由 7 个顶层命令构成完整闭环：`init`（脚手架�
 omk init [目录]
 ```
 
+<!-- omk:cli:init:flags:start -->
+
+**Flags:**
+
+```text
+  --lang <zh|en>  输出语言 zh|en,优先级 CLI > OMK_LANG env > zh。
+```
+
+完整描述见 `omk init --help`。
+
+<!-- omk:cli:init:flags:end -->
+
 生成一个评测项目脚手架，包含两版 starter skill 和 `eval-samples.json`。
 
 ### `omk doctor`
@@ -379,6 +391,26 @@ omk doctor skills/ --json > r.json      # JSON 给 CI / 外部工具消费
 omk doctor --gate; echo $?              # 静默门禁，fatal 问题 exit 1，警告不阻断
 omk doctor --static-only                # 离线模式：只跑静态检查，不调 LLM
 ```
+
+<!-- omk:cli:doctor:flags:start -->
+
+**Flags:**
+
+```text
+  --executor <value>  执行器名,默认 claude。指定为测试 fixture 路径可在测试里跑(同 omk doctor)。
+  --gate              静默模式,只在 fail 时输出 stderr 摘要,exit code 标识结果。
+  --html <value>      HTML 报告输出路径。可跟 --json / --gate 共存。
+  --json              JSON 输出到 stdout,适合 CI / 外部脚本消费。
+  --lang <zh|en>      输出语言 zh|en,优先级 CLI > OMK_LANG env > zh。
+  --model <value>     LLM model 名,默认 sonnet。
+  --samples <value>   样本文件路径(.json/.yaml)。不传则按 target / cwd 顺序自动发现。
+  --static-only       离线静态模式,只跑 4 条静态 rule(skill_readable / skill_metadata / dependencies_present / samples_contract_aligned),不调 LLM。
+  --timeout <value>   单次 LLM 会话超时秒数,默认 600(10 分钟)。
+```
+
+完整描述见 `omk doctor --help`。
+
+<!-- omk:cli:doctor:flags:end -->
 
 LLM 健康度审计：单次 LLM 会话产出 7 个内置维度的健康度评分 + findings + 改进建议；HTML 报告按 fail→warn→pass→skipped 排序，错误 finding 优先。维度可扩展（在自己代码里调 `registerHealthDimension`，自动并入同一次 LLM 调用的 prompt 与报告，顺序 = 注册顺序）。
 
@@ -398,35 +430,58 @@ omk eval gold compare <report-id> --gold-dir gold-dataset
 
 运行离线评测，应用 verdict gate，持久化报告，并用 exit code 表示 ship/no-ship。这个工作流默认开启 bootstrap CI。
 
-常用选项：
+<!-- omk:cli:eval:flags:start -->
+
+**Flags:**
 
 ```text
-  --samples <路径>       样本文件（默认：eval-samples.json，也自动检测 .yaml/.yml；--skill-dir 下的 <skill>/.omk/samples.json 会被自动发现）
-  --skill-dir <路径>     artifact 目录（默认：skills）
-  --control <expr>       对照组 variant 表达式
-  --treatment <v1,v2>    实验组 variants，逗号分隔
-  --config <路径>        YAML/JSON 评测配置
-  --model <名称>         任务执行模型（默认：opus alias）
-  --effort <level>       执行模型扩展思考预算 low/medium/high/xhigh/max（默认：low；高 effort 跨报告不可严格比较）
-  --judge-models <list>  评委配置，例如 claude:haiku 或 claude:opus,openai:gpt-4o
-  --executor <名称>      claude / claude-sdk / codex / codex-sdk / openai-api / gemini / custom
-  --no-judge             跳过 LLM 评委主观评分
-  --no-diagnostic        关闭 diagnostic 诊断 LLM 调用（默认开启，给 failed sample 出"哪错了 + 怎么改"建议）
-  --skip-doctor          escape hatch：跳过 doctor 健康检查门禁（默认强制启用）。沙箱 mock 提供依赖时绕开 doctor 物理路径误报；garbage-in 风险由调用方承担
-  --dry-run              仅预览
-  --blind                盲测模式
-  --concurrency <n>      并行任务数
-  --timeout <秒>         单任务超时
-  --repeat <n>           重复 N 次做方差分析
-  --batch                每个 artifact 独立和 baseline 对比
-  --bootstrap-samples N  bootstrap 重采样次数（默认 1000）
-  --threshold <number>   verdict 分层门禁阈值（默认 3.5）
-  --trivial-diff <num>   实际可忽略 diff 阈值（默认 0.1）
-  --report-only          生成报告并打印 verdict，但始终 exit 0
-  --no-gate              --report-only 的别名
-  --skip-connectivity    跳过模型连通性检查（内部静态 gate 仍强制执行）
-  --no-serve             评测后不自动启动报告服务
+  --batch                         batch 模式:baseline vs 每个 skill
+  --blind                         judge blind 模式
+  --bootstrap                     加 bootstrap CI
+  --bootstrap-samples <value>     bootstrap 重采样次数,默认 1000
+  --budget-per-sample-ms <value>  单 sample 时长上限 ms
+  --budget-per-sample-usd <value> 单 sample 预算上限 USD
+  --budget-usd <value>            总预算上限 USD
+  --concurrency <value>           并发数,默认 1
+  --config <value>                eval.yaml 路径
+  --control <value>               control variant 表达式
+  --dry-run                       只 plan 不实跑
+  --effort <value>                被测 LLM reasoning effort: low/medium/high/xhigh/max
+  --executor <value>              执行器名,默认 claude
+  --gold-dir <value>              gold dataset 目录
+  --judge-models <value>          评委,格式 executor:model[,...],默认 <executor>:haiku
+  --judge-repeat <value>          每个 dim 评 N 次
+  --lang <zh|en>                  输出语言 zh|en
+  --layered-stats                 输出分层统计
+  --mcp-config <value>            MCP 配置文件路径
+  --model <value>                 被测模型
+  --no-cache                      跳过 executor cache
+  --no-debias-length              关 length-debias(默认开)
+  --no-diagnostic                 关 diagnostic LLM 调用
+  --no-gate                       关 verdict gate
+  --no-judge                      跳过 LLM judge
+  --no-serve                      不启 report server
+  --no-strict-baseline            关闭 baseline 隔离
+  --output-dir <value>            报告输出目录
+  --repeat <value>                每个 sample 重复跑 N 次
+  --report-only                   只出报告不算 verdict
+  --resume <value>                从某次失败 run 续跑
+  --retry <value>                 失败 sample 重试次数
+  --samples <value>               样本文件路径
+  --skill-dir <value>             skill 目录,默认 skills
+  --skip-connectivity             跳 LLM 连通性预检
+  --skip-doctor                   跳 doctor 门禁
+  --strict-baseline               强制 baseline 隔离(default true)
+  --threshold <value>             verdict 阈值,默认 3.5
+  --timeout <value>               单样本超时秒,默认 120
+  --treatment <value>             treatment variant 列表,逗号分隔
+  --trivial-diff <value>          可忽略 diff 容差
+  --verbose                       详细日志
 ```
+
+完整描述见 `omk eval --help`。
+
+<!-- omk:cli:eval:flags:end -->
 
 HTML 报告有两个 tab：
 - **📊 评分视角** — verdict 驱动的 A/B 对比（事实/行为/judge 三层、bootstrap CI、length-debias）。
@@ -445,6 +500,24 @@ omk observe ~/.claude/projects/my-project --from 2026-04-01T00:00:00Z --to 2026-
 omk observe ~/.claude/projects/my-project --skills audit,polish
 omk observe ~/.claude/projects/my-project --kb /path/to/project
 ```
+
+<!-- omk:cli:observe:flags:start -->
+
+**Flags:**
+
+```text
+  --from <value>        起始时间 ISO,优先级高于 --last
+  --kb <value>          知识库 root,启用 KB-aware 分析
+  --lang <zh|en>        输出语言 zh|en
+  --last <value>        时间窗(7d / 24h / 30m)
+  --output-dir <value>  分析结果输出目录
+  --skills <value>      只看指定 skill,逗号分隔
+  --to <value>          结束时间 ISO
+```
+
+完整描述见 `omk observe --help`。
+
+<!-- omk:cli:observe:flags:end -->
 
 把真实 Claude Code session trace 转成 skill 健康度报告：知识使用、gap 信号、执行稳定性、token 和耗时。这是生产观测，不是生产评分。
 
@@ -486,6 +559,31 @@ omk evolve <skill>                  # 多轮自动迭代 skill
 omk evolve skills/foo.md --rounds 10 --target 4.5
 ```
 
+<!-- omk:cli:evolve:flags:start -->
+
+**Flags:**
+
+```text
+  --concurrency <value>    评测并发数,默认 1
+  --effort <value>         reasoning effort: low/medium/high/xhigh/max
+  --executor <value>       执行器名,默认 claude
+  --improve-model <value>  负责重写 skill 的 LLM,默认 sonnet
+  --judge-models <value>   评委 model(单评委约束),格式 executor:model。默认 claude:haiku
+  --lang <zh|en>           输出语言 zh|en
+  --model <value>          被评测的 LLM,默认 sonnet
+  --no-diagnostic          关 LLM diagnostic 调用
+  --rounds <value>         最大迭代轮数,默认 5
+  --samples <value>        样本文件路径,默认 eval-samples.json
+  --skip-connectivity      跳过 LLM 连通性预检
+  --skip-doctor            跳过 doctor 门禁(escape hatch,自负 garbage-in 风险)
+  --target <value>         目标 composite 分数,达到即停。不传则跑满 rounds
+  --timeout <value>        单样本超时秒,默认 120
+```
+
+完整描述见 `omk evolve --help`。
+
+<!-- omk:cli:evolve:flags:end -->
+
 让 skill 跑 eval → judge → 改写 SKILL.md 的多轮闭环，直到达到 `--target` 或 `--rounds` 上限。耗时按 `轮数 × 样本 × 变体` 累加，几分钟到几十分钟级别。原始 skill 文件版本保存在 `skills/evolve/*.r0.md`。
 
 ### `omk sample`
@@ -494,6 +592,26 @@ omk evolve skills/foo.md --rounds 10 --target 4.5
 omk sample <skill>                  # 为单个 skill 生成或补齐评测用例
 omk sample --batch                  # 为目录下缺评测集的 skill 批量生成
 ```
+
+<!-- omk:cli:sample:flags:start -->
+
+**Flags:**
+
+```text
+  --batch                批量模式:扫 --skill-dir 下所有缺 samples 的 skill,逐个生成。
+  --count <value>        生成样本条数。不传由 LLM 按 skill 类型自动决定。
+  --fix                  fix 模式:基于最近评测报告自动修复 sample_design 类型失败。
+  --focus <value>        生成焦点(自然语言提示)。控制 LLM 偏向哪类用例。
+  --lang <zh|en>         输出语言 zh|en,优先级 CLI > OMK_LANG env > zh。
+  --model <value>        生成 LLM model 名,默认 opus。
+  --reports-dir <value>  报告目录(fix 模式用),默认 ~/.oh-my-knowledge/reports。
+  --skill-dir <value>    skill 根目录,默认 skills。batch 模式扫此目录。
+  --treatment <value>    指定 treatment 名(fix 模式用),默认推断自 skill 路径。
+```
+
+完整描述见 `omk sample --help`。
+
+<!-- omk:cli:sample:flags:end -->
 
 一次性生成。自动给生成的用例打 `provenance`。生成的 assertions 使用英文 / 数字 / 代码 token，便于跨中英文输出对比。
 
@@ -507,6 +625,25 @@ omk studio --reports-dir ~/.oh-my-knowledge/reports
 omk studio --observations-dir .omk/observations    # observe inbox 数据目录
 omk studio --no-open
 ```
+
+<!-- omk:cli:studio:flags:start -->
+
+**Flags:**
+
+```text
+  --analyses-dir <value>      分析数据目录(可选)
+  --dev                       dev 模式:子进程启动 + 热更新
+  --host <value>              监听 host,默认 localhost。改为 0.0.0.0 暴露给局域网
+  --lang <zh|en>              输出语言 zh|en
+  --no-open                   不自动打开浏览器
+  --observations-dir <value>  观测数据目录(可选)
+  --port <value>              监听端口,默认 7799。传 0 让 OS 分配
+  --reports-dir <value>       报告目录,默认 ~/.oh-my-knowledge/reports
+```
+
+完整描述见 `omk studio --help`。
+
+<!-- omk:cli:studio:flags:end -->
 
 启动本地知识工作台浏览报告。verdict、样本回退、跨样本 diff、饱和曲线、单样本 drill-down 全部在 studio UI 里 —— omk 不提供 CLI 导出 / 分析子命令。CI gate 用 `omk eval` 的 exit code（PROGRESS 退 0、其他非 0），需要文字摘要自己 `jq` report JSON。
 

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1,11 +1,17 @@
-// scripts/build-docs.ts — 从 oclif Config 渲染 commands.md 的 marker 区段。
+// scripts/build-docs.ts — 从 oclif Config 渲染若干 markdown 文件的 marker 区段。
 //
 // 来源:src/cli/oclif/commands/*.ts(双语 description / examples / flags / args)。
-// 目标:.claude/skills/omk/references/commands.md 的 <!-- omk:cli:start --> ... <!-- omk:cli:end --> 之间。
+//
+// 目标(每条一个 Target):
+// - commands.md(.claude/skills/omk/references/commands.md):整段 marker 包裹,
+//   全命令 fullbody(13 个 oclif command 全输出)。
+// - README.md / README.zh.md:per-command flags 模式,每个 H3 顶层命令独立 marker
+//   对,内容只输出 flag list(README 已经手写 bash 示例和 prose,不重复)。
 //
 // 模式:
-// - `yarn build:docs`(--write)→ 直接覆盖 marker 区段
-// - `yarn build:docs:check`(--check)→ 比对磁盘内容,不一致 exit 1 + print diff(CI 用)
+// - `yarn build:docs`(--write)→ 覆盖所有 target 的 marker 区段
+// - `yarn build:docs:check`(--check)→ 比对磁盘内容,任一 target 不一致就 exit 1
+//   + print diff(CI 用)
 //
 // 依赖 dist/ 存在(oclif config.commands 指向 ./dist/src/cli/oclif/commands),
 // 跑之前必须先 `yarn build`。
@@ -15,17 +21,17 @@ import { resolve } from 'node:path';
 import { Config, type Command } from '@oclif/core';
 
 const REPO_ROOT = resolve(process.cwd());
-const COMMANDS_MD = resolve(REPO_ROOT, '.claude/skills/omk/references/commands.md');
-const MARKER_START = '<!-- omk:cli:start -->';
-const MARKER_END = '<!-- omk:cli:end -->';
 
-// inline pickLang — 跟 src/cli/oclif/i18n.ts:36 行为一致,zh = `${zh}\n${en}` 首行。
-// 本 script 是 build-time 工具,不进 npm 包;inline 避免引入 dist/ 路径 import 依赖。
-function pickZh(text: string | undefined): string {
+type Lang = 'zh' | 'en';
+
+// inline pickLang — 跟 src/cli/oclif/i18n.ts:36 行为一致。description 是
+// `${zh}\n${en}` 形式;zh = 第一行,en = 后续行 join。
+function pickLang(text: string | undefined, lang: Lang): string {
   if (!text) return '';
   const parts = text.split(/\r?\n/);
   if (parts.length < 2) return text;
-  return parts[0] ?? '';
+  if (lang === 'zh') return parts[0] ?? '';
+  return parts.slice(1).join('\n');
 }
 
 interface FlagShape {
@@ -47,6 +53,8 @@ interface ExampleObj {
   command: string;
 }
 
+// ── commands.md(fullbody)渲染 ────────────────────────────────────────────────
+
 function renderUsageLine(cmd: Command.Loadable, bin: string, idDisplay: string): string {
   const pieces = [bin, idDisplay];
   const args = cmd.args ? Object.entries(cmd.args) : [];
@@ -59,46 +67,46 @@ function renderUsageLine(cmd: Command.Loadable, bin: string, idDisplay: string):
   return pieces.join(' ');
 }
 
-function renderArgs(cmd: Command.Loadable): string[] {
+function renderArgsZh(cmd: Command.Loadable): string[] {
   const args = cmd.args ? Object.entries(cmd.args) : [];
   if (args.length === 0) return [];
   const out: string[] = ['**参数:**', ''];
   for (const [name, raw] of args) {
     const a = raw as ArgShape;
     const required = a.required ? '必填' : '可选';
-    const desc = pickZh(a.description);
+    const desc = pickLang(a.description, 'zh');
     out.push(`- \`${name}\`(${required})${desc ? `:${desc}` : ''}`);
   }
   out.push('');
   return out;
 }
 
-function renderFlagType(f: FlagShape): string {
+function renderFlagTypeBracket(f: FlagShape): string {
   if (f.type === 'boolean') return '`boolean`';
   if (f.options && f.options.length > 0) return `\`${f.options.join('|')}\``;
   return '`option`';
 }
 
-function renderFlags(cmd: Command.Loadable): string[] {
+function renderFlagsZhBullets(cmd: Command.Loadable): string[] {
   const flags = cmd.flags ? Object.entries(cmd.flags) : [];
   if (flags.length === 0) return [];
   const out: string[] = ['**Flags:**', ''];
   const sorted = [...flags].sort(([a], [b]) => a.localeCompare(b));
   for (const [name, raw] of sorted) {
     const f = raw as FlagShape;
-    const parts: string[] = [`\`--${name}\``, renderFlagType(f)];
+    const parts: string[] = [`\`--${name}\``, renderFlagTypeBracket(f)];
     if (f.default !== undefined && f.default !== null && f.default !== false) {
       parts.push(`(默认 \`${String(f.default)}\`)`);
     }
     if (f.env) parts.push(`(env \`${f.env}\`)`);
-    const desc = pickZh(f.description);
+    const desc = pickLang(f.description, 'zh');
     out.push(`- ${parts.join(' ')}${desc ? `:${desc}` : ''}`);
   }
   out.push('');
   return out;
 }
 
-function renderExamples(cmd: Command.Loadable, bin: string): string[] {
+function renderExamplesZh(cmd: Command.Loadable, bin: string): string[] {
   const examples = cmd.examples;
   if (!Array.isArray(examples) || examples.length === 0) return [];
   const out: string[] = ['**示例:**', ''];
@@ -111,7 +119,7 @@ function renderExamples(cmd: Command.Loadable, bin: string): string[] {
       out.push('');
     } else {
       const exo = ex as ExampleObj;
-      const desc = pickZh(exo.description);
+      const desc = pickLang(exo.description, 'zh');
       const text = exo.command.replace(/<%= config\.bin %>/g, bin);
       if (desc) {
         out.push(`> ${desc}`);
@@ -126,12 +134,12 @@ function renderExamples(cmd: Command.Loadable, bin: string): string[] {
   return out;
 }
 
-function renderCommand(cmd: Command.Loadable, bin: string): string[] {
+function renderCommandFullbody(cmd: Command.Loadable, bin: string): string[] {
   const idDisplay = cmd.id.split(':').join(' ');
   const lines: string[] = [];
   lines.push(`## ${bin} ${idDisplay}`);
   lines.push('');
-  const desc = pickZh(cmd.description);
+  const desc = pickLang(cmd.description, 'zh');
   if (desc) {
     lines.push(desc);
     lines.push('');
@@ -142,44 +150,179 @@ function renderCommand(cmd: Command.Loadable, bin: string): string[] {
   lines.push(renderUsageLine(cmd, bin, idDisplay));
   lines.push('```');
   lines.push('');
-  lines.push(...renderArgs(cmd));
-  lines.push(...renderFlags(cmd));
-  lines.push(...renderExamples(cmd, bin));
+  lines.push(...renderArgsZh(cmd));
+  lines.push(...renderFlagsZhBullets(cmd));
+  lines.push(...renderExamplesZh(cmd, bin));
   return lines;
 }
 
-async function generate(): Promise<string> {
-  const config = await Config.load({ root: REPO_ROOT });
+function generateFullbody(config: Config): string {
   const cmds = [...config.commands].sort((a, b) => a.id.localeCompare(b.id));
   const lines: string[] = [];
   lines.push('<!-- 此段由 scripts/build-docs.ts 从 src/cli/oclif/commands/ 自动生成。');
   lines.push('     改 CLI 后跑 `yarn build:docs` 同步,CI `yarn build:docs:check` 会拦截 drift。-->');
   lines.push('');
   for (const cmd of cmds) {
-    lines.push(...renderCommand(cmd, config.bin));
+    lines.push(...renderCommandFullbody(cmd, config.bin));
   }
-  // 去掉尾部多余空行,后面 compose 会自己加换行。
   while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
   return lines.join('\n');
 }
+
+// ── README.md / README.zh.md(per-cmd-flags)渲染 ─────────────────────────────
+
+function renderFlagTypeAngle(f: FlagShape): string {
+  if (f.type === 'boolean') return '';
+  if (f.options && f.options.length > 0) return `<${f.options.join('|')}>`;
+  return '<value>';
+}
+
+// README ```text``` 风格:每行一个 flag,padding 对齐,描述用 pickLang 切 lang。
+// 输出格式:
+//   --flag-name <type>     description
+function renderFlagsBlock(cmd: Command.Loadable, bin: string, lang: Lang): string {
+  const flags = cmd.flags ? Object.entries(cmd.flags) : [];
+  if (flags.length === 0) {
+    const noFlagLine = lang === 'zh'
+      ? `(\`${bin} ${cmd.id.split(':').join(' ')}\` 无 flag)`
+      : `(\`${bin} ${cmd.id.split(':').join(' ')}\` has no flags)`;
+    const helpHint = lang === 'zh'
+      ? `完整描述见 \`${bin} ${cmd.id.split(':').join(' ')} --help\`。`
+      : `For full descriptions: \`${bin} ${cmd.id.split(':').join(' ')} --help\`.`;
+    return [noFlagLine, '', helpHint].join('\n');
+  }
+  const sorted = [...flags].sort(([a], [b]) => a.localeCompare(b));
+  const labels = sorted.map(([name, raw]) => {
+    const f = raw as FlagShape;
+    const typePart = renderFlagTypeAngle(f);
+    return typePart ? `--${name} ${typePart}` : `--${name}`;
+  });
+  const labelWidth = Math.max(...labels.map((l) => l.length));
+  const padTo = Math.min(labelWidth, 30) + 2;
+  const flagsLabel = lang === 'zh' ? '**Flags:**' : '**Flags:**';
+  const helpHint = lang === 'zh'
+    ? `完整描述见 \`${bin} ${cmd.id.split(':').join(' ')} --help\`。`
+    : `For full descriptions: \`${bin} ${cmd.id.split(':').join(' ')} --help\`.`;
+
+  const lines: string[] = [];
+  lines.push(flagsLabel);
+  lines.push('');
+  lines.push('```text');
+  for (let i = 0; i < sorted.length; i++) {
+    const [, raw] = sorted[i]!;
+    const f = raw as FlagShape;
+    const label = labels[i]!;
+    const desc = pickLang(f.description, lang);
+    const padded = label.padEnd(padTo, ' ');
+    lines.push(`  ${padded}${desc}`);
+  }
+  lines.push('```');
+  lines.push('');
+  lines.push(helpHint);
+  return lines.join('\n');
+}
+
+// ── 目标 / marker 定义 ─────────────────────────────────────────────────────────
+
+interface FullbodyTarget {
+  mode: 'fullbody';
+  file: string;
+  markerStart: string;
+  markerEnd: string;
+}
+
+interface PerCmdFlagsTarget {
+  mode: 'per-cmd-flags';
+  file: string;
+  lang: Lang;
+  // 哪些 oclif top-level id 在 README 里出现(7 个顶层命令)。
+  // 注:eval 是 top-level,eval gold * 是 sub-sub,不在 README 展开。
+  // observe 是 top-level,observe inbox/ingest/show 是 sub,也不在 README 展开。
+  topLevelIds: readonly string[];
+}
+
+type Target = FullbodyTarget | PerCmdFlagsTarget;
+
+const TARGETS: Target[] = [
+  {
+    mode: 'fullbody',
+    file: '.claude/skills/omk/references/commands.md',
+    markerStart: '<!-- omk:cli:start -->',
+    markerEnd: '<!-- omk:cli:end -->',
+  },
+  {
+    mode: 'per-cmd-flags',
+    file: 'README.md',
+    lang: 'en',
+    topLevelIds: ['init', 'doctor', 'eval', 'observe', 'evolve', 'sample', 'studio'],
+  },
+  {
+    mode: 'per-cmd-flags',
+    file: 'README.zh.md',
+    lang: 'zh',
+    topLevelIds: ['init', 'doctor', 'eval', 'observe', 'evolve', 'sample', 'studio'],
+  },
+];
+
+// ── marker 区段定位 + 替换 ─────────────────────────────────────────────────────
 
 interface Split {
   pre: string;
   post: string;
 }
 
-function splitFile(content: string): Split | null {
-  const startIdx = content.indexOf(MARKER_START);
-  const endIdx = content.indexOf(MARKER_END);
+function splitOnMarker(content: string, markerStart: string, markerEnd: string): Split | null {
+  const startIdx = content.indexOf(markerStart);
+  const endIdx = content.indexOf(markerEnd);
   if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) return null;
-  const pre = content.slice(0, startIdx + MARKER_START.length);
+  const pre = content.slice(0, startIdx + markerStart.length);
   const post = content.slice(endIdx);
   return { pre, post };
 }
 
-function compose(pre: string, body: string, post: string): string {
-  return `${pre}\n${body}\n${post}`;
+function composeFullbody(content: string, body: string, target: FullbodyTarget): { next: string; error?: string } {
+  const split = splitOnMarker(content, target.markerStart, target.markerEnd);
+  if (!split) {
+    return { next: content, error: `missing markers ${target.markerStart} / ${target.markerEnd}` };
+  }
+  const next = `${split.pre}\n${body}\n${split.post}`;
+  return { next };
 }
+
+function flagsMarkerStart(id: string): string {
+  return `<!-- omk:cli:${id}:flags:start -->`;
+}
+function flagsMarkerEnd(id: string): string {
+  return `<!-- omk:cli:${id}:flags:end -->`;
+}
+
+function composePerCmdFlags(
+  content: string,
+  config: Config,
+  target: PerCmdFlagsTarget,
+): { next: string; missing: string[] } {
+  let next = content;
+  const missing: string[] = [];
+  for (const id of target.topLevelIds) {
+    const cmd = config.commands.find((c) => c.id === id);
+    if (!cmd) {
+      missing.push(`oclif command not found: ${id}`);
+      continue;
+    }
+    const start = flagsMarkerStart(id);
+    const end = flagsMarkerEnd(id);
+    const split = splitOnMarker(next, start, end);
+    if (!split) {
+      missing.push(`missing marker pair for ${id} (${start} / ${end})`);
+      continue;
+    }
+    const body = renderFlagsBlock(cmd, config.bin, target.lang);
+    next = `${split.pre}\n\n${body}\n\n${split.post}`;
+  }
+  return { next, missing };
+}
+
+// ── diff print ────────────────────────────────────────────────────────────────
 
 function diffPreview(expected: string, actual: string): string {
   const eLines = expected.split('\n');
@@ -202,40 +345,87 @@ function diffPreview(expected: string, actual: string): string {
   return out.join('\n');
 }
 
+// ── 主循环 ────────────────────────────────────────────────────────────────────
+
+interface TargetResult {
+  file: string;
+  current: string;
+  next: string;
+  missingMarkers: string[];
+}
+
+async function generateAll(): Promise<TargetResult[]> {
+  const config = await Config.load({ root: REPO_ROOT });
+  const results: TargetResult[] = [];
+  for (const target of TARGETS) {
+    const absPath = resolve(REPO_ROOT, target.file);
+    const current = readFileSync(absPath, 'utf8');
+    if (target.mode === 'fullbody') {
+      const body = generateFullbody(config);
+      const { next, error } = composeFullbody(current, body, target);
+      results.push({
+        file: target.file,
+        current,
+        next,
+        missingMarkers: error ? [error] : [],
+      });
+    } else {
+      const { next, missing } = composePerCmdFlags(current, config, target);
+      results.push({
+        file: target.file,
+        current,
+        next,
+        missingMarkers: missing,
+      });
+    }
+  }
+  return results;
+}
+
 async function main(): Promise<void> {
   const mode = process.argv.includes('--check') ? 'check' : 'write';
-  const current = readFileSync(COMMANDS_MD, 'utf8');
-  const split = splitFile(current);
-  if (!split) {
-    process.stderr.write(
-      `[build-docs] commands.md missing markers (${MARKER_START} / ${MARKER_END}).\n`,
-    );
-    process.stderr.write(`Add markers to ${COMMANDS_MD} before running.\n`);
+  const results = await generateAll();
+
+  // 任一 target 缺 marker 就 hard exit 2,提示用户手补
+  const missingByFile = results.filter((r) => r.missingMarkers.length > 0);
+  if (missingByFile.length > 0) {
+    process.stderr.write('[build-docs] missing markers:\n');
+    for (const r of missingByFile) {
+      for (const m of r.missingMarkers) {
+        process.stderr.write(`  ${r.file}: ${m}\n`);
+      }
+    }
+    process.stderr.write('Add the marker pair(s) and re-run.\n');
     process.exit(2);
   }
-  const body = await generate();
-  const next = compose(split.pre, body, split.post);
 
   if (mode === 'check') {
-    if (next === current) {
-      process.stdout.write('[build-docs] commands.md is in sync with oclif source.\n');
+    const drifted = results.filter((r) => r.next !== r.current);
+    if (drifted.length === 0) {
+      process.stdout.write('[build-docs] all targets in sync with oclif source.\n');
       return;
     }
     process.stderr.write(
-      '[build-docs] commands.md drifted from oclif source. Run `yarn build:docs` to regenerate.\n',
+      '[build-docs] drifted from oclif source. Run `yarn build:docs` to regenerate.\n',
     );
-    process.stderr.write('---\n');
-    process.stderr.write(diffPreview(next, current));
-    process.stderr.write('\n');
+    for (const r of drifted) {
+      process.stderr.write(`\n--- ${r.file} ---\n`);
+      process.stderr.write(diffPreview(r.next, r.current));
+      process.stderr.write('\n');
+    }
     process.exit(1);
   }
 
-  if (next === current) {
-    process.stdout.write('[build-docs] commands.md already up to date.\n');
-    return;
+  let wrote = 0;
+  for (const r of results) {
+    if (r.next === r.current) continue;
+    writeFileSync(resolve(REPO_ROOT, r.file), r.next, 'utf8');
+    process.stdout.write(`[build-docs] wrote ${r.file}\n`);
+    wrote++;
   }
-  writeFileSync(COMMANDS_MD, next, 'utf8');
-  process.stdout.write(`[build-docs] wrote ${COMMANDS_MD}\n`);
+  if (wrote === 0) {
+    process.stdout.write('[build-docs] all targets already up to date.\n');
+  }
 }
 
 main().catch((err: unknown) => {

--- a/src/cli/oclif/commands/eval.ts
+++ b/src/cli/oclif/commands/eval.ts
@@ -52,7 +52,10 @@ export default class Eval extends Command {
       description: bilingual({ zh: 'eval.yaml 路径', en: 'eval.yaml path' }),
     }),
     samples: Flags.string({
-      description: bilingual({ zh: '样本文件路径', en: 'Samples file path' }),
+      description: bilingual({
+        zh: '样本文件路径。默认 eval-samples.json,也接受 .yaml/.yml;自动发现 --skill-dir 下的 <skill>/.omk/samples.json。',
+        en: 'Samples file path. Defaults to eval-samples.json (also .yaml/.yml); auto-discovers <skill>/.omk/samples.json under --skill-dir.',
+      }),
     }),
     'skill-dir': Flags.string({
       description: bilingual({ zh: 'skill 目录,默认 skills', en: 'Skill dir, default skills' }),
@@ -62,12 +65,15 @@ export default class Eval extends Command {
       description: bilingual({ zh: '被测模型', en: 'Evaluated model' }),
     }),
     executor: Flags.string({
-      description: bilingual({ zh: '执行器名,默认 claude', en: 'Executor, default claude' }),
+      description: bilingual({
+        zh: '执行器:claude / claude-sdk / codex / codex-sdk / openai-api / gemini / 自定义命令(默认 claude)。',
+        en: 'Executor: claude / claude-sdk / codex / codex-sdk / openai-api / gemini / custom (default claude).',
+      }),
     }),
     'judge-models': Flags.string({
       description: bilingual({
-        zh: '评委,格式 executor:model[,...],默认 <executor>:haiku',
-        en: 'Judge model(s), executor:model[,...] format',
+        zh: '评委配置,格式 executor:model[,...],例 claude:haiku 或 claude:opus,openai:gpt-4o(≥ 2 个 = ensemble)。默认 <executor>:haiku。',
+        en: 'Judge config: executor:model[,...]. e.g. claude:haiku or claude:opus,openai:gpt-4o (≥ 2 = ensemble). Default <executor>:haiku.',
       }),
     }),
     'output-dir': Flags.string({
@@ -99,7 +105,10 @@ export default class Eval extends Command {
       description: bilingual({ zh: '跳 LLM 连通性预检', en: 'Skip LLM connectivity preflight' }),
     }),
     'skip-doctor': Flags.boolean({
-      description: bilingual({ zh: '跳 doctor 门禁', en: 'Skip doctor gate' }),
+      description: bilingual({
+        zh: 'escape hatch:跳 doctor 健康检查门禁(默认强制启用)。沙箱 mock 提供依赖时绕开 doctor 物理路径误报;garbage-in 风险自负。',
+        en: 'Escape hatch: skip the doctor health-check gate (on by default). Use when sandbox mocks supply deps; caller owns garbage-in risk.',
+      }),
     }),
     'mcp-config': Flags.string({
       description: bilingual({ zh: 'MCP 配置文件路径', en: 'MCP config path' }),
@@ -127,12 +136,15 @@ export default class Eval extends Command {
     }),
     effort: Flags.string({
       description: bilingual({
-        zh: '被测 LLM reasoning effort: low/medium/high/xhigh/max',
-        en: 'Reasoning effort: low/medium/high/xhigh/max',
+        zh: '被测 LLM 扩展思考预算 low/medium/high/xhigh/max(默认 low;跨 effort 报告不严格可比)。',
+        en: 'Executor LLM reasoning effort low/medium/high/xhigh/max (default low; reports across efforts not strictly comparable).',
       }),
     }),
     'no-diagnostic': Flags.boolean({
-      description: bilingual({ zh: '关 diagnostic LLM 调用', en: 'Disable diagnostic LLM call' }),
+      description: bilingual({
+        zh: '关闭 diagnostic 诊断 LLM 调用(默认开,给 failed sample 出「哪错了 + 怎么改」建议)。',
+        en: 'Disable diagnostic LLM call (on by default; emits "what went wrong + how to fix" advice for failed samples).',
+      }),
     }),
     // ── eval-runner extra ──
     blind: Flags.boolean({
@@ -172,7 +184,10 @@ export default class Eval extends Command {
       description: bilingual({ zh: '可忽略 diff 容差', en: 'Trivial diff tolerance' }),
     }),
     'report-only': Flags.boolean({
-      description: bilingual({ zh: '只出报告不算 verdict', en: 'Report only, no verdict' }),
+      description: bilingual({
+        zh: '生成报告并打印 verdict,但始终 exit 0(不参与 CI gate)。',
+        en: 'Produce the report and print verdict, but always exit 0 (no CI gate).',
+      }),
     }),
     'no-gate': Flags.boolean({
       description: bilingual({ zh: '关 verdict gate', en: 'Disable verdict gate' }),

--- a/test/scripts/build-docs.test.ts
+++ b/test/scripts/build-docs.test.ts
@@ -23,6 +23,7 @@ const PROJECT_ROOT = join(__dirname, '..', '..');
 const COMMANDS_MD = join(PROJECT_ROOT, '.claude/skills/omk/references/commands.md');
 const README_EN = join(PROJECT_ROOT, 'README.md');
 const README_ZH = join(PROJECT_ROOT, 'README.zh.md');
+const SKILL_MD = join(PROJECT_ROOT, 'SKILL.md');
 const BUILD_DOCS = join(PROJECT_ROOT, 'dist/scripts/build-docs.js');
 
 const MARKER_START = '<!-- omk:cli:start -->';
@@ -229,5 +230,28 @@ describe('scripts/build-docs codegen', () => {
     assert.ok(idxBatch !== -1 && idxConcurrency !== -1 && idxThreshold !== -1);
     assert.ok(idxBatch < idxConcurrency, '--batch should precede --concurrency');
     assert.ok(idxConcurrency < idxThreshold, '--concurrency should precede --threshold');
+  });
+
+  it('SKILL.md argument-hint frontmatter matches oclif top-level command set', () => {
+    // SKILL.md frontmatter L7 形如:
+    //   argument-hint: "<init|doctor|eval|observe|evolve|sample|studio> [options]"
+    // 历史上 omk 顶层命令树重构过两次(bench run → eval、improve → evolve、
+    // export → sample),每次都靠人工同步这一行。本测试把它锁住:argument-hint
+    // 列出的 7 个 id 必须跟 TOP_LEVEL_IDS 严格一致(set 比较,顺序无关)。
+    // 未来重命名 / 增删顶层命令时,reviewer 改 oclif Command 文件 → 改
+    // TOP_LEVEL_IDS → 本测试逼着同步 SKILL.md。
+    const content = readFileSync(SKILL_MD, 'utf8');
+    const match = content.match(/^argument-hint:\s*"<([^>]+)>/m);
+    assert.ok(match, 'SKILL.md frontmatter must contain argument-hint: "<...>" pattern');
+    const listed = match[1]!.split('|').map((s) => s.trim()).filter(Boolean);
+    const expected = [...TOP_LEVEL_IDS].sort();
+    const actual = [...listed].sort();
+    assert.deepEqual(
+      actual,
+      expected,
+      `SKILL.md argument-hint command list drifted from oclif top-level set.\n` +
+      `  expected: ${expected.join('|')}\n` +
+      `  actual:   ${actual.join('|')}`,
+    );
   });
 });

--- a/test/scripts/build-docs.test.ts
+++ b/test/scripts/build-docs.test.ts
@@ -21,10 +21,23 @@ const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, '..', '..');
 const COMMANDS_MD = join(PROJECT_ROOT, '.claude/skills/omk/references/commands.md');
+const README_EN = join(PROJECT_ROOT, 'README.md');
+const README_ZH = join(PROJECT_ROOT, 'README.zh.md');
 const BUILD_DOCS = join(PROJECT_ROOT, 'dist/scripts/build-docs.js');
 
 const MARKER_START = '<!-- omk:cli:start -->';
 const MARKER_END = '<!-- omk:cli:end -->';
+
+const TOP_LEVEL_IDS = ['init', 'doctor', 'eval', 'observe', 'evolve', 'sample', 'studio'] as const;
+
+function readFlagsBlock(content: string, id: string): string {
+  const start = `<!-- omk:cli:${id}:flags:start -->`;
+  const end = `<!-- omk:cli:${id}:flags:end -->`;
+  const s = content.indexOf(start);
+  const e = content.indexOf(end);
+  assert.ok(s !== -1 && e !== -1 && e > s, `marker pair for ${id} not found`);
+  return content.slice(s + start.length, e);
+}
 
 interface ExecError extends Error {
   code?: number;
@@ -138,4 +151,83 @@ describe('scripts/build-docs codegen', () => {
       writeFileSync(COMMANDS_MD, original, 'utf8');
     }
   }, 30000);
+
+  it('README.md has 7 marker pairs for top-level oclif commands', () => {
+    const content = readFileSync(README_EN, 'utf8');
+    for (const id of TOP_LEVEL_IDS) {
+      assert.ok(
+        content.includes(`<!-- omk:cli:${id}:flags:start -->`),
+        `README.md missing marker start for ${id}`,
+      );
+      assert.ok(
+        content.includes(`<!-- omk:cli:${id}:flags:end -->`),
+        `README.md missing marker end for ${id}`,
+      );
+    }
+  });
+
+  it('README.zh.md has 7 marker pairs for top-level oclif commands', () => {
+    const content = readFileSync(README_ZH, 'utf8');
+    for (const id of TOP_LEVEL_IDS) {
+      assert.ok(
+        content.includes(`<!-- omk:cli:${id}:flags:start -->`),
+        `README.zh.md missing marker start for ${id}`,
+      );
+      assert.ok(
+        content.includes(`<!-- omk:cli:${id}:flags:end -->`),
+        `README.zh.md missing marker end for ${id}`,
+      );
+    }
+  });
+
+  it('README.md eval flags block contains English descriptions (en pickLang)', () => {
+    const content = readFileSync(README_EN, 'utf8');
+    const block = readFlagsBlock(content, 'eval');
+    assert.ok(block.includes('--bootstrap-samples'), 'must list --bootstrap-samples');
+    assert.ok(block.includes('--judge-models'), 'must list --judge-models');
+    // 英文 keyword 出现 → pickLang('en') 工作正确
+    assert.ok(/Bootstrap resamples|Judge model/i.test(block), `expected EN descriptions: ${block.slice(0, 400)}`);
+    // 中文 description 头部不应出现 — 防止 pickLang 选错语言
+    assert.ok(!/被测模型|样本文件路径/.test(block), `zh description leaked into README.md: ${block.slice(0, 400)}`);
+    assert.ok(block.includes('For full descriptions:'), 'must include EN help hint footer');
+  });
+
+  it('README.zh.md eval flags block contains Chinese descriptions (zh pickLang)', () => {
+    const content = readFileSync(README_ZH, 'utf8');
+    const block = readFlagsBlock(content, 'eval');
+    assert.ok(block.includes('--bootstrap-samples'), 'must list --bootstrap-samples');
+    // 中文 keyword 出现
+    assert.ok(/被测模型|样本文件路径|评委/.test(block), `expected zh descriptions: ${block.slice(0, 400)}`);
+    // 英文 description 不应出现
+    assert.ok(!/Bootstrap resamples/.test(block), `en description leaked into README.zh.md: ${block.slice(0, 400)}`);
+    assert.ok(block.includes('完整描述见'), 'must include zh help hint footer');
+  });
+
+  it('README.md hand-curated prose around eval flags is preserved', () => {
+    const content = readFileSync(README_EN, 'utf8');
+    // 这些 prose 在 marker 之外,本 codegen 不应触碰
+    assert.ok(content.includes('Runs the offline evaluation, applies the verdict gate'), 'eval intro prose missing');
+    assert.ok(content.includes('The HTML report has two tabs'), 'HTML report two-tabs prose missing');
+    assert.ok(content.includes('Static-only mode'), 'doctor static-only prose missing');
+    assert.ok(content.includes('Studio is skill-centric'), 'Studio IA prose missing');
+  });
+
+  it('README.zh.md hand-curated prose preserved', () => {
+    const content = readFileSync(README_ZH, 'utf8');
+    assert.ok(content.includes('运行离线评测'), 'eval intro zh prose missing');
+    assert.ok(content.includes('HTML 报告有两个 tab'), 'HTML 报告 tabs zh prose missing');
+    assert.ok(content.includes('离线静态模式'), 'doctor static-only zh prose missing');
+  });
+
+  it('README.md eval block has flags in alphabetic order', () => {
+    const content = readFileSync(README_EN, 'utf8');
+    const block = readFlagsBlock(content, 'eval');
+    // 抽两个稳定的 flag 名,看出现顺序符合 alphabetic
+    const idxBatch = block.indexOf('--batch');
+    const idxConcurrency = block.indexOf('--concurrency');
+    const idxThreshold = block.indexOf('--threshold');
+    assert.ok(idxBatch !== -1 && idxConcurrency !== -1 && idxThreshold !== -1);
+    assert.ok(idxBatch < idxConcurrency, '--batch should precede --concurrency');
+    assert.ok(idxConcurrency < idxThreshold, '--concurrency should precede --threshold');
+  });
 });


### PR DESCRIPTION
## Summary

issue #109(消除 omk CLI 跟 4 份 markdown 文档的 drift)收口最后一公里。本 PR 覆盖剩下 3 份:

- **README.md / README.zh.md**:每个顶层命令独立 marker 对,flag list 由 oclif Command 自动生成(en/zh 各一份)
- **SKILL.md**:argument-hint frontmatter 行通过 vitest 断言锁住跟 oclif 顶层命令同步,不走 codegen

`yarn build && yarn build:docs` 一行同步三个 codegen 目标(commands.md / README.md / README.zh.md);SKILL.md 的 argument-hint drift 由测试 fail 拦截。

## Commits

1. `54eaf54` feat(agents-md): README/zh flag list 走 oclif codegen
2. `edc007d` test(agents-md): 锁 SKILL.md argument-hint frontmatter 跟 oclif 顶层命令同步

## Scope decisions

### B2 — 给所有 7 个顶层命令加 Flags 块(README/zh)

理由:eval 当前 flag 最多,但未来其他命令加 flag 时 README 仍会漂。一次性给 7 个命令(init / doctor / eval / observe / evolve / sample / studio)全加保护,reviewer 添新 flag 时 CI 自动拦截 sync。

**marker 外保留**:每个 H3 下的 bash 示例块、static-only 解释、HTML report tab 描述、Studio IA、executor 表格 / artifact directory layout 等 hand-curated prose。

子命令(eval gold * / observe ingest/inbox/show)在 README 不展开,本身已被 commands.md(PR-D)锁住 drift。

### SKILL.md 不走 codegen,加测试

SKILL.md 是 agent prompt 指令,目的是教 LLM 怎么用 omk + 怎么解读用户意图。bash 例子是教 agent「这是常见用法」,不是穷举 flag。塞一个 `## 命令速查` codegen appendix 会:
- 跟 commands.md 重复(agent 已经能读 `references/commands.md`)
- 把 SKILL.md context window 撑大(每次都 load 进 agent context)

但 git history 显示 SKILL.md L7 的 argument-hint frontmatter 历史上漂过两次(`<eval|evolve|gen-samples|report|export>` → `<...|improve|export|...>` → `<init|doctor|eval|observe|evolve|sample|studio>`),每次重构都靠人工同步。

折中:加一个轻量 vitest case,断言 argument-hint 列出的 7 个 id 严格等于 TOP_LEVEL_IDS(顺序无关,set 比较)。未来 oclif 顶层命令树有增删/重命名 → reviewer 改 TOP_LEVEL_IDS → 本测试逼着同步 SKILL.md。零 codegen、零 marker、零文件结构改动。

## What changed

### scripts/build-docs.ts

- pickZh → pickLang(text, lang),参数化语言
- TARGETS 抽象 = 三条:commands.md(fullbody/zh)、README.md(per-cmd-flags/en)、README.zh.md(per-cmd-flags/zh)
- multi-marker splitFile:单文件内多 marker 对各自定位 + 替换
- renderFlagsBlock(cmd, lang):```text``` 对齐风格 + 指向 `omk <cmd> --help` 脚注

### README.md / README.zh.md

- 7 个 H3 顶层命令各插一对 marker(共 14 marker)
- eval 段原 27 行 hand-curated Common options 块整段删,marker 接管
- codegen 后 eval flag 数量从 27 涨到 41(补齐 --budget-* / --resume / --retry / --layered-stats / --strict-baseline / --verbose 等 14 个之前漏列的)

### test/scripts/build-docs.test.ts

PR-D 既有 8 case → 16 case,新增 8 个:

- README.md / README.zh.md 各 7 marker 对完整
- README.md eval block 含英文描述、不漏中文
- README.zh.md eval block 含中文描述、不漏英文
- hand-curated prose marker 外保留(双语各 1 case)
- flag alphabetic 排序稳定
- **SKILL.md argument-hint 跟 TOP_LEVEL_IDS set 严格相等**

### CONTRIBUTING.md

更新「CLI 文档 codegen」段:新增三目标表格、扩展工作流(改 oclif Command 后 build:docs 一行同步)、加新顶层命令时怎么注册新 marker。

## 取舍代价

oclif Command 的 flag description 比 README 原 hand-curated 短:

- 原 README:`--samples <path>       sample file (default: eval-samples.json, also detects .yaml/.yml; auto-discovers <skill>/.omk/samples.json under --skill-dir)`
- codegen:`--samples <value>      Samples file path`

mitigation:每个 codegen 块尾加 `For full descriptions: \`omk <cmd> --help\`.`(zh 版「完整描述见 ...」),指向 --help。长期 reviewer 在 oclif Command 写更丰富 description,渐进迁移。本 PR 不做。

## Test plan

- [x] \`yarn build && yarn build:docs --write\` 后 README.md / README.zh.md 7 marker 对完整,内容是预期语言的 flag list
- [x] 手动改 doctor.ts \`--json\` description + \`yarn build && yarn build:docs:check\` → exit 1 + 对 commands.md / README.md / README.zh.md 三处都打 diff
- [x] hand-curated prose 字符级保留
- [x] SKILL.md argument-hint 故意改坏后 \`yarn test\` 报相应 assertion 失败
- [x] \`yarn lint\` 通过
- [x] \`yarn test\` **1474/1474 通过**

## Followup

- **PR-D4(可选)**:oclif Command 描述富化 — 把 README terse 化丢掉的描述细节加回 oclif source,让 codegen 输出更丰富。等用户用一段时间感觉信息密度不够再做
- **PR-E**:plugin-not-found / \`--json\` jsonResponse helper / bash enum completion / oclif 错误路径 helpClass 修补 / product_main prose 重生

#109 主目标至此闭环。

🤖 Generated with [Claude Code](https://claude.com/claude-code)