### PR TITLE
feat(cli): bare omk 入口接回 product_main 双语 prose(PR-E1 of #109)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,19 +1,40 @@
 #!/usr/bin/env node
 
-import { getCliLang, parseLangFromArgv } from './i18n.js';
+import { getCliLang, parseLangFromArgv, tCli } from './i18n.js';
 import { checkUpdate } from './update-check.js';
 import { CliExit } from './cli-exit.js';
 
 // CLI 入口:lang / 版本提醒等共享前置逻辑跑完,把控制权交给 oclif dispatcher。
-// legacy PRODUCT_COMMANDS 查表 + cli.help.product_main prose 已于 PR-C(issue #109)
-// 移除;所有命令现在统一走 src/cli/oclif/commands/* 下的 oclif Command。
+// 例外:`omk`(无子命令,只带可选 --lang)时打 cli.help.product_main 双语
+// prose 后 exit — oclif 默认的 VERSION/USAGE/TOPICS 列表对中文用户和新用户
+// 都太 terse,product_main 段教学性更强(用法 / 主路径 / 通用选项)。
 //
 // 业务 execute() 函数仍住在 src/cli/commands/*.ts,oclif Command 是薄壳:
 // 解析 flag 给 oclif --help 用,然后透传 argv 调对应 legacy execute()。
 
+/** 判断 argv 是否只剩 `--lang [zh|en]`(及其 `--lang=...` 形式)— 即 bare invocation。 */
+function isBareInvocation(argv: readonly string[]): boolean {
+  // argv = process.argv.slice(2),即去掉 node + script path 后的用户输入。
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i] ?? '';
+    if (token === '--lang') {
+      i++; // 跳过 --lang 的 value
+      continue;
+    }
+    if (token.startsWith('--lang=')) continue;
+    return false;
+  }
+  return true;
+}
+
 async function main(): Promise<void> {
   const lang = getCliLang(parseLangFromArgv(process.argv));
   checkUpdate(lang);
+
+  if (isBareInvocation(process.argv.slice(2))) {
+    process.stdout.write(tCli('cli.help.product_main', lang).trim() + '\n');
+    return;
+  }
 
   const { runOclifPath } = await import('./oclif/run.js');
   await runOclifPath();

--- a/test/cli/oclif-product-help.test.ts
+++ b/test/cli/oclif-product-help.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `omk`(无子命令)入口 — 打 cli.help.product_main 双语 prose。
+ *
+ * PR-C 删 legacy dispatcher 后,bare `omk` 退化成 oclif 默认 VERSION/USAGE/
+ * TOPICS/COMMANDS 表格,中文用户和新用户都受影响。本 PR 在 src/cli/index.ts
+ * 增加 isBareInvocation 检测,把 product_main prose(legacy 留下的双语
+ * i18n key)接回这条入口。oclif --help / sub-command --help / unknown sub 等
+ * 其它路径行为不变,仍由 oclif 自己处理。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const CLI = join(PROJECT_ROOT, 'dist', 'src', 'cli', 'index.js');
+
+interface ExecError extends Error {
+  code?: number;
+  stdout: string;
+  stderr: string;
+}
+
+describe('omk bare invocation prints product_main prose', () => {
+  it('bare `omk` prints zh prose (default lang)', async () => {
+    const { stdout } = await execFileAsync('node', [CLI]);
+    assert.ok(stdout.includes('知识载体工作台'), `expected zh title: ${stdout.slice(0, 200)}`);
+    assert.ok(stdout.includes('用法'), 'must include 用法 section');
+    assert.ok(stdout.includes('主路径'), 'must include 主路径 section');
+    assert.ok(stdout.includes('omk init'), 'must list omk init');
+    assert.ok(stdout.includes('omk eval'), 'must list omk eval');
+    assert.ok(stdout.includes('omk evolve'), 'must list omk evolve');
+    assert.ok(!stdout.includes('VERSION'), 'should not show oclif VERSION block (legacy prose only)');
+  });
+
+  it('`omk --lang en` prints English prose', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, '--lang', 'en']);
+    assert.ok(
+      stdout.includes('Knowledge Artifact Workbench'),
+      `expected en title: ${stdout.slice(0, 200)}`,
+    );
+    assert.ok(stdout.includes('Usage:'), 'must include Usage section');
+    assert.ok(stdout.includes('Main workflow:'), 'must include Main workflow section');
+    assert.ok(!stdout.includes('知识载体工作台'), 'zh title should not appear');
+  });
+
+  it('`omk --lang=en` (= form) also picks en', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, '--lang=en']);
+    assert.ok(stdout.includes('Knowledge Artifact Workbench'), `expected en: ${stdout.slice(0, 200)}`);
+  });
+
+  it('OMK_LANG=en env var picks en', async () => {
+    const { stdout } = await execFileAsync('node', [CLI], {
+      env: { ...process.env, OMK_LANG: 'en' },
+    });
+    assert.ok(stdout.includes('Knowledge Artifact Workbench'), `expected en from env: ${stdout.slice(0, 200)}`);
+  });
+
+  it('bare omk exits 0', async () => {
+    const { stdout } = await execFileAsync('node', [CLI]);
+    assert.ok(stdout.length > 0);
+    // execFileAsync 不 reject = exit 0
+  });
+
+  it('`omk --help` still goes through oclif (USAGE/COMMANDS block,非 product_main prose)', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, '--help']);
+    assert.ok(stdout.includes('USAGE'), 'must include oclif USAGE block');
+    assert.ok(stdout.includes('COMMANDS'), 'must include oclif COMMANDS block');
+    // 不应包含 product_main 的「主路径」关键字 — --help 是 oclif 路径
+    assert.ok(!stdout.includes('主路径'), '--help should NOT print product_main prose');
+  });
+
+  it('`omk doctor` still routes to oclif Doctor Command (regression)', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'doctor', '--help']);
+    assert.ok(stdout.includes('USAGE'), 'doctor --help should still work');
+    assert.ok(stdout.includes('--gate') || stdout.includes('gate'), 'doctor --help should list --gate flag');
+  });
+
+  it('unknown command still exits non-zero via oclif (regression)', async () => {
+    await assert.rejects(
+      () => execFileAsync('node', [CLI, 'nope-command-xyz']),
+      (err: unknown) => {
+        const e = err as ExecError;
+        assert.equal(e.code, 1, `expected exit 1 for unknown command, got ${e.code}`);
+        return true;
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

PR-C 删 legacy dispatcher 时,bare \`omk\`(无子命令)退化成 oclif 默认 VERSION/USAGE/TOPICS/COMMANDS terse 表格,**第一行是英文 description**,丢了 hand-curated 的「用法 / 主路径 / 通用选项」三段教学性内容。这条入口是新用户第一屏,UX 退步明显。

本 PR 接回去:src/cli/index.ts 加 isBareInvocation 检测,argv 只含 \`--lang [zh|en]\`(及 \`--lang=...\` 形式)时打 \`tCli('cli.help.product_main', lang)\` 后 return,不进 oclif 路径。

\`cli.help.product_main\` 这个 i18n key 在 i18n-dict.ts 里 zh/en 完整保留(PR-C 删 dispatcher 时没动 dict 内容,只是没人调了),复用即可,零新增 prose 文案。

## Before / After

**Before(PR-C 之后,当前 main 链表现)**:

\`\`\`
Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows...

VERSION
  oh-my-knowledge/0.30.0 darwin-arm64 node-v24.14.0

USAGE
  \$ omk [COMMAND]

TOPICS
  eval     ...
  observe  ...

COMMANDS
  doctor   ...
  eval     ...
  ...
\`\`\`

**After(本 PR)**:

\`\`\`
oh-my-knowledge——知识载体工作台

用法：
  omk init [dir]                      初始化一个 skill 评测项目
  omk doctor [path]                   LLM 健康度审计（7 内置维度 + 可扩展）；--static-only 切离线静态模式
  omk eval [options]                  离线评测：比较版本，输出 verdict + report
  omk observe <sessions-dir>          线上观测：真实 session、gap、失败率、inbox
  omk evolve <skill>                  多轮自动迭代改进 skill
  omk sample <skill>                  生成或补齐 eval-samples 评测用例（或 --batch 批量模式）
  omk studio                          打开本地工作台浏览报告

主路径：
  omk doctor
  omk eval --control code-review-v1 --treatment code-review-v2
  omk observe ~/.claude/projects/<project>
  omk evolve skills/code-review-v2/SKILL.md
  omk studio

通用选项：
  --lang <zh|en>                      CLI 输出语言（默认：zh，也可设 OMK_LANG）

运行 'omk <command> --help' 查看单个命令的参数。
\`\`\`

\`omk --lang en\` 切到英文版（原 dict 里 en 段已齐）。

## Scope

只动 \`src/cli/index.ts\` 一处入口判断 + 一个 i18n key 复用 + 一个 test 文件。\*\*不依赖 PR-D / PR-D2 docs codegen 链\*\*,base 直接 \`feat/oclif-migrate-rest\`(PR-C 顶端),可独立 review / merge。

## i18n 优先级

\`--lang\`(CLI flag)> \`OMK_LANG\`(env)> \`zh\`(default)。三个 case 都有测试覆盖。

## What changed

| 文件 | 改动 |
|---|---|
| \`src/cli/index.ts\` | main() 之前加 isBareInvocation 检测;命中 → tCli('cli.help.product_main', lang) + return;否则按原流程进 oclif |
| \`test/cli/oclif-product-help.test.ts\`(新) | 8 case:zh / en / --lang= 形式 / OMK_LANG env / exit 0 / --help 仍走 oclif / 子命令仍 work / 未知命令仍 exit 1 |

不动:
- \`src/cli/i18n-dict.ts\` 的 \`cli.help.product_main\` 内容(zh/en 已齐,直接复用)
- \`src/cli/oclif/\` 任何 Command(本 PR 不动 oclif 路径)
- \`omk --help\` / \`omk <sub>\` / \`omk <unknown>\` 等其它入口的现有行为

## Test plan

- [x] \`yarn lint\` 通过
- [x] \`yarn build && yarn test\` 1466/1466 通过(PR-C 基线 + 8 个新 product-help case)
- [x] 手工 \`omk\` / \`omk --lang en\` / \`OMK_LANG=en omk\` / \`omk --lang=en\` 输出符合 i18n 优先级
- [x] \`omk --help\` 仍走 oclif(显示 USAGE/COMMANDS 表)
- [x] \`omk doctor --help\` 仍正常
- [x] \`omk nope-cmd\` 仍 exit 1(oclif command-not-found)

## Followup(可选,独立 PR)

- PR-E 其它项:plugin-not-found 抹平 exit 偏差、\`--json\` jsonResponse helper、bash enum completion、oclif 错误路径 helpClass 修补(parse fail 时漏 sentinel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)