### PR TITLE
feat(cli): oclif 迁移架构 18 项收口(#121)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,8 +170,22 @@ oclif Command 的 `description` / `flags` / `args` / `examples` static 字段是
 - 改完 oclif Command 的 description / flag,跑 `yarn build && yarn build:docs` 同步全部 3 个目标
 - 不跑就会被 vitest 内嵌 `--check` 拦截（exit 1 + 对每个 drift 的文件打 diff）
 - README 的 prose 段（static-only 解释 / HTML report tab / Studio IA / executor 表格等）在 marker 外,hand-maintained 保留
-- 新增顶层命令时:加 `src/cli/oclif/commands/<id>.ts`、改 `scripts/build-docs.ts` 的 `TOP_LEVEL_IDS`、在 README.md / README.zh.md 各加一对 `<!-- omk:cli:<id>:flags:start -->` / `:end -->`、SKILL.md frontmatter `argument-hint` 加 `<id>`,跑一遍 `yarn build && yarn build:docs && yarn test`
-- 新增子命令（如 `omk foo bar`）时:只加 `src/cli/oclif/commands/foo/bar.ts`,oclif 文件目录自动路由,fullbody 模式自动包含,不需要改 `TOP_LEVEL_IDS`
+- 新增顶层命令时:加 `src/cli/oclif/commands/<id>.ts`、在 README.md / README.zh.md 各加一对 `<!-- omk:cli:<id>:flags:start -->` / `:end -->`、SKILL.md frontmatter `argument-hint` 加 `<id>`,跑一遍 `yarn build && yarn build:docs && yarn test`(顶层命令集真值由 `scripts/build-docs.ts` 的 `getTopLevelIds(Config.load)` 从 oclif Command 文件目录派生,不需要再单独维护硬编码数组)
+- 新增子命令（如 `omk eval gold init` 这种 sub-sub）时:加 `src/cli/oclif/commands/eval/gold/init.ts`,oclif 文件目录自动路由,fullbody 模式自动包含
+
+### 加新 sub-sub topic 命令
+
+目录下有 sub-sub 但目录本身没 default Command 时(如 `eval/gold/` 下有 `init` / `validate` / `compare`,目录本身 `eval gold` 不直接执行),**必须** 加 `<dir>.ts` 表达 topic semantics:
+
+- 当前实例:`src/cli/oclif/commands/eval/gold.ts` — 裸 `omk eval gold` 打 usage + `this.exit(1)`,跟 legacy 行为(missing sub-sub → CliExit(1))一致
+- 不加的代价:oclif 默认把 `eval gold` 当 topic-only,裸调用落到 default topic help(exit 0),CI 脚本如果靠 exit 1 区分「用户漏写 sub-sub」会失效
+- 当前 omk 只有 eval gold 一处需要,加新 sub-sub 目录时遵循
+
+### oclif description ejs footgun
+
+oclif Help 用 `ejs.render(body, context)` 渲染所有 section,模板标记 `<%...%>` 会被执行成代码。**flag / arg / description 字段不要拼用户输入(skill 名、文件路径、env 值)**;模板只在 `examples[].command` 字段使用(by-design,如 `'<%= config.bin %>' init`)。
+
+`src/cli/oclif/i18n.ts` 的 `bilingual({zh, en})` 已经在入口加 assertion 拦 `<%` / `%>`,description 里写模板会在 runtime 启动时抛错。
 
 ### CLI exit code 约定
 

--- a/docs/diagnosis-occurrence-mapping.md
+++ b/docs/diagnosis-occurrence-mapping.md
@@ -887,7 +887,7 @@ doctor / eval
 ├─ doctor rule failures produce DiagnosisOccurrences
 ├─ eval failure clusters produce Diagnosis
 ├─ mock/sample issues keep audience=sample-author
-└─ omk blindspots keep audience=omk-maintainer
+└─ omk-blindspots(internal) keep audience=omk-maintainer
 ```
 
 ## Open Questions

--- a/docs/zh/roadmap.md
+++ b/docs/zh/roadmap.md
@@ -145,7 +145,7 @@ distribution 成功标准：
 
 优先事项：
 
-- 增加 red-team 入口（命名待定，候选：`omk redteam --profile knowledge-artifact`）。
+- 增加 red-team 入口（命名待定，候选形如 `redteam --profile knowledge-artifact` 顶层子命令）。
 - 覆盖 prompt injection、skill leakage、RAG poisoning、tool misuse、baseline contamination。
 - 输出独立安全维度 verdict，不混入综合质量分。
 - 支持导入 promptfoo / Inspect 结果，整合到 OMK 报告。
@@ -157,7 +157,7 @@ distribution 成功标准：
 
 优先事项：
 
-- 报告 emission 能力（github-summary / junit / sarif / markdown）：`omk export` 已下线，需要重新设计入口（候选：`eval --emit <fmt>` 跑时直接吐 / studio 加下载入口 / `report` 顶层重启）。
+- 报告 emission 能力（github-summary / junit / sarif / markdown）：原 export 子命令已下线，需要重新设计入口（候选：`eval --emit <fmt>` 跑时直接吐 / studio 加下载入口 / `report` 顶层重启）。
 - 报告增加“审计摘要”：样本数、CI、judge hash、human alpha、dataset version、artifact hash、已知 caveat。
 - Release notes 自动提示 `BREAKING-COMPARABILITY` 和测量不变量变化。
 - 生成可直接贴到 PR 的中文摘要。

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "commands": "./dist/src/cli/oclif/commands",
     "dirname": "omk",
     "helpClass": "./dist/src/cli/oclif/help.js",
+    "hooks": {
+      "init": "./dist/src/cli/oclif/hooks/init.js"
+    },
     "topicSeparator": " ",
     "additionalHelpFlags": ["-h"],
     "additionalVersionFlags": ["-v"],

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -246,40 +246,39 @@ interface PerCmdFlagsTarget {
 type Target = FullbodyTarget | PerCmdFlagsTarget;
 
 /**
- * omk 顶层命令 id 列表(README per-cmd-flags + SKILL.md argument-hint 共用)。
- * 此常量是单一来源,oclif 顶层命令集真值在 src/cli/oclif/commands/ 文件目录,
- * test 跑 Config.load 动态校验两者一致。
+ * omk 顶层命令 id 列表 — 从 oclif Config 真值动态推导(README per-cmd-flags
+ * + SKILL.md argument-hint 共用)。oclif Command 文件目录是单一来源,这里只是
+ * 派生层,加 / 删 / rename 顶层命令时不需要再来这里改 hardcoded 数组。
  */
-export const TOP_LEVEL_IDS = [
-  'init',
-  'doctor',
-  'eval',
-  'observe',
-  'evolve',
-  'sample',
-  'studio',
-] as const;
+export function getTopLevelIds(config: Config): readonly string[] {
+  return config.commands
+    .map((c) => c.id)
+    .filter((id) => !id.includes(':'))
+    .sort();
+}
 
-const TARGETS: Target[] = [
-  {
-    mode: 'fullbody',
-    file: '.claude/skills/omk/references/commands.md',
-    markerStart: '<!-- omk:cli:start -->',
-    markerEnd: '<!-- omk:cli:end -->',
-  },
-  {
-    mode: 'per-cmd-flags',
-    file: 'README.md',
-    lang: 'en',
-    topLevelIds: TOP_LEVEL_IDS,
-  },
-  {
-    mode: 'per-cmd-flags',
-    file: 'README.zh.md',
-    lang: 'zh',
-    topLevelIds: TOP_LEVEL_IDS,
-  },
-];
+export function buildTargets(topLevelIds: readonly string[]): Target[] {
+  return [
+    {
+      mode: 'fullbody',
+      file: '.claude/skills/omk/references/commands.md',
+      markerStart: '<!-- omk:cli:start -->',
+      markerEnd: '<!-- omk:cli:end -->',
+    },
+    {
+      mode: 'per-cmd-flags',
+      file: 'README.md',
+      lang: 'en',
+      topLevelIds,
+    },
+    {
+      mode: 'per-cmd-flags',
+      file: 'README.zh.md',
+      lang: 'zh',
+      topLevelIds,
+    },
+  ];
+}
 
 // ── marker 区段定位 + 替换 ─────────────────────────────────────────────────────
 
@@ -378,8 +377,10 @@ interface TargetResult {
 
 async function generateAll(): Promise<TargetResult[]> {
   const config = await Config.load({ root: REPO_ROOT });
+  const topLevelIds = getTopLevelIds(config);
+  const targets = buildTargets(topLevelIds);
   const results: TargetResult[] = [];
-  for (const target of TARGETS) {
+  for (const target of targets) {
     const absPath = resolve(REPO_ROOT, target.file);
     const current = readFileSync(absPath, 'utf8');
     if (target.mode === 'fullbody') {
@@ -451,7 +452,7 @@ async function main(): Promise<void> {
 }
 
 // 只在直接 `node dist/scripts/build-docs.js ...` 跑时进 main();被 test 当 module
-// import 时不跑(test 只要 TOP_LEVEL_IDS 常量)。
+// import 时不跑(test import getTopLevelIds / buildTargets 用)。
 const isMain = process.argv[1] && /build-docs\.js$/.test(process.argv[1]);
 if (isMain) {
   main().catch((err: unknown) => {

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -19,19 +19,18 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { Config, type Command } from '@oclif/core';
+import { pickLang as pickLangCore } from '../src/cli/oclif/i18n.js';
 
 const REPO_ROOT = resolve(process.cwd());
 
 type Lang = 'zh' | 'en';
 
-// inline pickLang — 跟 src/cli/oclif/i18n.ts:36 行为一致。description 是
-// `${zh}\n${en}` 形式;zh = 第一行,en = 后续行 join。
+// build-docs 在生成 markdown 时需要把 `${zh}\n${en}` 切回单语,跟 src/cli/oclif/i18n.ts
+// 的 pickLang 共用底层逻辑(单一来源)。i18n.ts 的 pickLang 返回 string | undefined
+// (caller 决定 nullish 处理),build-docs 拼字符串不能容忍 undefined,这里用
+// `?? ''` 把 undefined 兜成 '',行为跟原 inline 版本等价。
 function pickLang(text: string | undefined, lang: Lang): string {
-  if (!text) return '';
-  const parts = text.split(/\r?\n/);
-  if (parts.length < 2) return text;
-  if (lang === 'zh') return parts[0] ?? '';
-  return parts.slice(1).join('\n');
+  return pickLangCore(text, lang) ?? '';
 }
 
 interface FlagShape {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,7 +18,37 @@ function isShortPath(argv: readonly string[]): boolean {
   return argv.some((a) => SHORT_PATH_FLAGS.includes(a));
 }
 
+/**
+ * legacy CLI 支持 `omk --lang en eval --help` 这种把 lang 放在子命令前的写法
+ * (parseLangFromArgv 跨整 argv scan)。oclif 默认 parser 把第一个非 flag 当
+ * 命令 id,顶层位置的 --lang 跟它的 value 会让 oclif 找错 command。这里跨整
+ * argv 抽 --lang / --lang=VAL 到末尾,跟 legacy 行为对齐(再由子命令 parse 用)。
+ */
+function normalizeArgv(argv: readonly string[]): string[] {
+  if (argv.length < 3) return [...argv];
+  const userArgs = argv.slice(2);
+  const langTokens: string[] = [];
+  const rest: string[] = [];
+  for (let i = 0; i < userArgs.length; i++) {
+    const tok = userArgs[i]!;
+    if (tok === '--lang') {
+      langTokens.push(tok);
+      if (i + 1 < userArgs.length) {
+        langTokens.push(userArgs[i + 1]!);
+        i++;
+      }
+    } else if (tok.startsWith('--lang=')) {
+      langTokens.push(tok);
+    } else {
+      rest.push(tok);
+    }
+  }
+  if (langTokens.length === 0) return [...argv];
+  return [argv[0]!, argv[1]!, ...rest, ...langTokens];
+}
+
 async function main(): Promise<void> {
+  process.argv = normalizeArgv(process.argv);
   const lang = getCliLang(parseLangFromArgv(process.argv));
   if (!isShortPath(process.argv)) {
     checkUpdate(lang);

--- a/src/cli/oclif/commands/eval.ts
+++ b/src/cli/oclif/commands/eval.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from '@oclif/core';
 import { bilingual } from '../i18n.js';
+import { runLegacyCommand } from '../run-legacy.js';
 
 // oclif 版 eval(默认 = run 模式) — 透传 argv 给生产 eval-runner execute()。
 // flag schema 镜像 RUN_OPTIONS(27) + eval-runner extraOptions(14) = 41 flag。
@@ -194,21 +195,9 @@ export default class Eval extends Command {
 
   async run(): Promise<void> {
     await this.parse(Eval);
-    // 透传给生产 eval-runner.execute()(直接进 run 模式,不经 eval.ts 的 sub 路由)。
-    // 用 this.argv 而不是 process.argv.slice(N):oclif 已经把命令路径切掉,space-syntax
-    // (omk eval ...)跟 colon-syntax(omk eval:...)输出一致,避免 N 写死导致 colon 路径
-    // 静默丢 flag。
-    const argv = this.argv;
-    const { execute } = await import('../../commands/eval-runner.js');
-    const { CliExit } = await import('../../cli-exit.js');
-    try {
-      await execute(argv);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { execute } = await import('../../commands/eval-runner.js');
+      await execute(this.argv);
+    });
   }
 }

--- a/src/cli/oclif/commands/eval/gold/compare.ts
+++ b/src/cli/oclif/commands/eval/gold/compare.ts
@@ -2,6 +2,7 @@
 
 import { Args, Command, Flags } from '@oclif/core';
 import { bilingual, resolveLang } from '../../../i18n.js';
+import { runLegacyCommand } from '../../../run-legacy.js';
 
 export default class EvalGoldCompare extends Command {
   static description = bilingual({
@@ -49,18 +50,10 @@ export default class EvalGoldCompare extends Command {
 
   async run(): Promise<void> {
     await this.parse(EvalGoldCompare);
-    const rest = this.argv;
     const lang = resolveLang(process.argv);
-    const { executeCompare } = await import('../../../../commands/eval-gold.js');
-    const { CliExit } = await import('../../../../cli-exit.js');
-    try {
-      await executeCompare(rest, lang);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { executeCompare } = await import('../../../../commands/eval-gold.js');
+      await executeCompare(this.argv, lang);
+    });
   }
 }

--- a/src/cli/oclif/commands/eval/gold/init.ts
+++ b/src/cli/oclif/commands/eval/gold/init.ts
@@ -2,6 +2,7 @@
 
 import { Command, Flags } from '@oclif/core';
 import { bilingual, resolveLang } from '../../../i18n.js';
+import { runLegacyCommand } from '../../../run-legacy.js';
 
 export default class EvalGoldInit extends Command {
   static description = bilingual({
@@ -31,18 +32,10 @@ export default class EvalGoldInit extends Command {
 
   async run(): Promise<void> {
     await this.parse(EvalGoldInit);
-    const rest = this.argv;
     const lang = resolveLang(process.argv);
-    const { executeInit } = await import('../../../../commands/eval-gold.js');
-    const { CliExit } = await import('../../../../cli-exit.js');
-    try {
-      await executeInit(rest, lang);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { executeInit } = await import('../../../../commands/eval-gold.js');
+      await executeInit(this.argv, lang);
+    });
   }
 }

--- a/src/cli/oclif/commands/eval/gold/validate.ts
+++ b/src/cli/oclif/commands/eval/gold/validate.ts
@@ -2,6 +2,7 @@
 
 import { Args, Command, Flags } from '@oclif/core';
 import { bilingual, resolveLang } from '../../../i18n.js';
+import { runLegacyCommand } from '../../../run-legacy.js';
 
 export default class EvalGoldValidate extends Command {
   static description = bilingual({
@@ -28,18 +29,10 @@ export default class EvalGoldValidate extends Command {
 
   async run(): Promise<void> {
     await this.parse(EvalGoldValidate);
-    const rest = this.argv;
     const lang = resolveLang(process.argv);
-    const { executeValidate } = await import('../../../../commands/eval-gold.js');
-    const { CliExit } = await import('../../../../cli-exit.js');
-    try {
-      await executeValidate(rest, lang);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { executeValidate } = await import('../../../../commands/eval-gold.js');
+      await executeValidate(this.argv, lang);
+    });
   }
 }

--- a/src/cli/oclif/commands/evolve.ts
+++ b/src/cli/oclif/commands/evolve.ts
@@ -1,5 +1,6 @@
 import { Args, Command, Flags } from '@oclif/core';
 import { bilingual } from '../i18n.js';
+import { runLegacyCommand } from '../run-legacy.js';
 
 // oclif 版 evolve — 透传 argv 给生产 execute()。
 // flag schema 镜像 src/cli/commands/evolve.ts 的 RUN_OPTIONS 共 13 个。
@@ -123,17 +124,9 @@ export default class Evolve extends Command {
 
   async run(): Promise<void> {
     await this.parse(Evolve);
-    const argv = this.argv;
-    const { execute } = await import('../../commands/evolve.js');
-    const { CliExit } = await import('../../cli-exit.js');
-    try {
-      await execute(argv);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { execute } = await import('../../commands/evolve.js');
+      await execute(this.argv);
+    });
   }
 }

--- a/src/cli/oclif/commands/init.ts
+++ b/src/cli/oclif/commands/init.ts
@@ -1,5 +1,6 @@
 import { Args, Command, Flags } from '@oclif/core';
 import { bilingual, resolveLang } from '../i18n.js';
+import { runLegacyCommand } from '../run-legacy.js';
 
 // oclif 版 init — 透传 argv 给生产 src/cli/commands/init.ts execute()。
 // 仅 lang flag + 可选 positional targetDir(默认 '.')。
@@ -61,17 +62,9 @@ export default class Init extends Command {
 
   async run(): Promise<void> {
     await this.parse(Init);
-    const argv = this.argv;
-    const { execute } = await import('../../commands/init.js');
-    const { CliExit } = await import('../../cli-exit.js');
-    try {
-      await execute(argv);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { execute } = await import('../../commands/init.js');
+      await execute(this.argv);
+    });
   }
 }

--- a/src/cli/oclif/commands/init.ts
+++ b/src/cli/oclif/commands/init.ts
@@ -1,5 +1,5 @@
 import { Args, Command, Flags } from '@oclif/core';
-import { bilingual } from '../i18n.js';
+import { bilingual, resolveLang } from '../i18n.js';
 
 // oclif 版 init — 透传 argv 给生产 src/cli/commands/init.ts execute()。
 // 仅 lang flag + 可选 positional targetDir(默认 '.')。
@@ -34,6 +34,18 @@ export default class Init extends Command {
         en: 'Target directory, defaults to current directory (.)',
       }),
       required: false,
+      parse: async (input: string): Promise<string> => {
+        // 拒绝 `omk init -- --weird` 这种把 flag 当 positional 的写法 — legacy 会
+        // 创建名为 `--weird` 的目录,新人一头雾水。在 oclif Args 这层拦住更友好。
+        if (input.startsWith('--')) {
+          const lang = resolveLang();
+          const msg = lang === 'zh'
+            ? `初始化目录不能以 -- 开头：${input}（看起来是误写的 flag）`
+            : `init target dir cannot start with --: ${input} (looks like a malformed flag)`;
+          throw new Error(msg);
+        }
+        return input;
+      },
     }),
   };
 

--- a/src/cli/oclif/commands/observe.ts
+++ b/src/cli/oclif/commands/observe.ts
@@ -1,5 +1,6 @@
 import { Args, Command, Flags } from '@oclif/core';
 import { bilingual } from '../i18n.js';
+import { runLegacyCommand } from '../run-legacy.js';
 
 // oclif 版 observe 默认命令 — `omk observe <sessions-dir>` 走 executeHealth。
 // 三个子命令(ingest / inbox / show)由 src/cli/oclif/commands/observe/ 文件目录托管。
@@ -63,18 +64,9 @@ export default class Observe extends Command {
 
   async run(): Promise<void> {
     await this.parse(Observe);
-    // 透传给生产 executeHealth(named export)。this.argv = oclif 切掉命令路径后的余下 argv。
-    const argv = this.argv;
-    const { executeHealth } = await import('../../commands/observe.js');
-    const { CliExit } = await import('../../cli-exit.js');
-    try {
-      await executeHealth(argv);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { executeHealth } = await import('../../commands/observe.js');
+      await executeHealth(this.argv);
+    });
   }
 }

--- a/src/cli/oclif/commands/observe/inbox.ts
+++ b/src/cli/oclif/commands/observe/inbox.ts
@@ -2,6 +2,7 @@
 
 import { Command, Flags } from '@oclif/core';
 import { bilingual } from '../../i18n.js';
+import { runLegacyCommand } from '../../run-legacy.js';
 
 export default class ObserveInbox extends Command {
   static description = bilingual({
@@ -54,17 +55,9 @@ export default class ObserveInbox extends Command {
 
   async run(): Promise<void> {
     await this.parse(ObserveInbox);
-    const argv = this.argv;
-    const { executeInbox } = await import('../../../commands/observe.js');
-    const { CliExit } = await import('../../../cli-exit.js');
-    try {
-      await executeInbox(argv);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { executeInbox } = await import('../../../commands/observe.js');
+      await executeInbox(this.argv);
+    });
   }
 }

--- a/src/cli/oclif/commands/observe/ingest.ts
+++ b/src/cli/oclif/commands/observe/ingest.ts
@@ -2,6 +2,7 @@
 
 import { Args, Command, Flags } from '@oclif/core';
 import { bilingual } from '../../i18n.js';
+import { runLegacyCommand } from '../../run-legacy.js';
 
 export default class ObserveIngest extends Command {
   static description = bilingual({
@@ -34,17 +35,9 @@ export default class ObserveIngest extends Command {
 
   async run(): Promise<void> {
     await this.parse(ObserveIngest);
-    const argv = this.argv;
-    const { executeIngest } = await import('../../../commands/observe.js');
-    const { CliExit } = await import('../../../cli-exit.js');
-    try {
-      await executeIngest(argv);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { executeIngest } = await import('../../../commands/observe.js');
+      await executeIngest(this.argv);
+    });
   }
 }

--- a/src/cli/oclif/commands/observe/show.ts
+++ b/src/cli/oclif/commands/observe/show.ts
@@ -2,6 +2,7 @@
 
 import { Args, Command, Flags } from '@oclif/core';
 import { bilingual } from '../../i18n.js';
+import { runLegacyCommand } from '../../run-legacy.js';
 
 export default class ObserveShow extends Command {
   static description = bilingual({
@@ -34,17 +35,9 @@ export default class ObserveShow extends Command {
 
   async run(): Promise<void> {
     await this.parse(ObserveShow);
-    const argv = this.argv;
-    const { executeShow } = await import('../../../commands/observe.js');
-    const { CliExit } = await import('../../../cli-exit.js');
-    try {
-      await executeShow(argv);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { executeShow } = await import('../../../commands/observe.js');
+      await executeShow(this.argv);
+    });
   }
 }

--- a/src/cli/oclif/commands/sample.ts
+++ b/src/cli/oclif/commands/sample.ts
@@ -1,5 +1,6 @@
 import { Args, Command, Flags } from '@oclif/core';
 import { bilingual } from '../i18n.js';
+import { runLegacyCommand } from '../run-legacy.js';
 
 // oclif 版 sample — 跟 src/cli/commands/sample.ts 行为对得齐。
 // 实现策略:flag schema 在这里声明一份（给 oclif --help / strict 校验用），
@@ -116,22 +117,10 @@ export default class Sample extends Command {
   async run(): Promise<void> {
     // 解析触发 oclif 的 --help / strict 校验。flag 值不直接用,交给生产 execute() 重新 parse argv。
     await this.parse(Sample);
-
     // this.argv = oclif 已经把命令路径切掉的余下 argv,space-syntax 跟 colon-syntax 一致。
-    const argv = this.argv;
-
-    const { execute } = await import('../../commands/sample.js');
-    const { CliExit } = await import('../../cli-exit.js');
-
-    try {
-      await execute(argv);
-    } catch (err) {
-      // 生产 execute 走 throw CliExit(code) 表示 exit。oclif 路径下转成 this.exit。
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { execute } = await import('../../commands/sample.js');
+      await execute(this.argv);
+    });
   }
 }

--- a/src/cli/oclif/commands/studio.ts
+++ b/src/cli/oclif/commands/studio.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from '@oclif/core';
 import { bilingual } from '../i18n.js';
+import { runLegacyCommand } from '../run-legacy.js';
 
 // oclif 版 studio — 透传 argv 给生产 execute()。
 // server 是长跑命令:生产 execute() 调 server.start() 后 await 返回 URL 然后 console.log
@@ -80,17 +81,9 @@ export default class Studio extends Command {
 
   async run(): Promise<void> {
     await this.parse(Studio);
-    const argv = this.argv;
-    const { execute } = await import('../../commands/studio.js');
-    const { CliExit } = await import('../../cli-exit.js');
-    try {
-      await execute(argv);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-      }
-      throw err;
-    }
+    await runLegacyCommand(this, async () => {
+      const { execute } = await import('../../commands/studio.js');
+      await execute(this.argv);
+    });
   }
 }

--- a/src/cli/oclif/help.ts
+++ b/src/cli/oclif/help.ts
@@ -1,57 +1,12 @@
 import { Command, Help } from '@oclif/core';
-import { pickLang, resolveLang, type Lang } from './i18n.js';
+import { resolveLang, type Lang } from './i18n.js';
+import { projectCommand, projectTopic } from './projection.js';
 
-// LangAwareHelp:oclif Help 子类,按 --lang / OMK_LANG 把 description / flags
-// 里的双语 sentinel 串切成单语再交给 super 渲染。覆盖四个钩子:
-// - showCommandHelp:打 top 行用 command.description.split('\\n')[0],不
-//   filter 命令就漏切;在这里把 command 整体过滤一遍。
-// - formatCommand:body 区(USAGE / FLAGS / EXAMPLES / DESCRIPTION),正常 filter。
-// - formatCommands:topic 列表(`omk studio --help` 这种),同 filter。
-// - formatTopics:TOPICS 区(`omk --help` 顶层 + `omk eval --help` 子级),
-//   oclif 直接 description.split('\\n')[0] 取首行,对 bilingual sentinel 永远
-//   选 zh;这里 filter 后再传给 super。
-
-function filterCommand(cmd: Command.Loadable, lang: Lang): Command.Loadable {
-  const clone: Command.Loadable = { ...cmd };
-  clone.description = pickLang(cmd.description, lang);
-  clone.summary = pickLang(cmd.summary, lang);
-
-  if (Array.isArray(cmd.examples)) {
-    clone.examples = cmd.examples.map((ex) => {
-      if (typeof ex === 'string') return pickLang(ex, lang) ?? ex;
-      return {
-        ...ex,
-        description: pickLang(ex.description, lang) ?? ex.description,
-      };
-    });
-  }
-
-  if (cmd.flags) {
-    const flags: Record<string, unknown> = {};
-    for (const [name, flag] of Object.entries(cmd.flags)) {
-      const f = flag as { description?: string; summary?: string };
-      flags[name] = {
-        ...flag,
-        description: pickLang(f.description, lang) ?? f.description,
-        summary: pickLang(f.summary, lang) ?? f.summary,
-      };
-    }
-    clone.flags = flags as typeof cmd.flags;
-  }
-
-  if (cmd.args) {
-    const args: Record<string, unknown> = {};
-    for (const [name, arg] of Object.entries(cmd.args)) {
-      const a = arg as { description?: string };
-      args[name] = {
-        ...arg,
-        description: pickLang(a.description, lang) ?? a.description,
-      };
-    }
-    clone.args = args as typeof cmd.args;
-  }
-  return clone;
-}
+// LangAwareHelp:oclif Help 子类,按 --lang / OMK_LANG 切 description / flags
+// 的双语 sentinel 到单语再交给 super 渲染。F2 加了 init hook 后,Command.Loadable
+// 已经在 Command.run() 前 in-place mutate 到单语,但 LangAwareHelp 保留作 safety
+// net(projectCommand 在已经单语的 string 上 idempotent — pickLang 看 parts.length
+// < 2 就原样返回),覆盖 oclif 上游可能加新 Help 渲染入口的场景。
 
 export default class LangAwareHelp extends Help {
   private get lang(): Lang {
@@ -59,29 +14,22 @@ export default class LangAwareHelp extends Help {
   }
 
   formatCommand(command: Command.Loadable): string {
-    return super.formatCommand(filterCommand(command, this.lang));
+    return super.formatCommand(projectCommand(command, this.lang));
   }
 
   formatCommands(commands: Command.Loadable[]): string {
-    return super.formatCommands(commands.map((c) => filterCommand(c, this.lang)));
+    return super.formatCommands(commands.map((c) => projectCommand(c, this.lang)));
   }
 
   async showCommandHelp(command: Command.Loadable): Promise<void> {
-    return super.showCommandHelp(filterCommand(command, this.lang));
+    return super.showCommandHelp(projectCommand(command, this.lang));
   }
 
   async showTopicHelp(topic: { name: string; description?: string }): Promise<void> {
-    return super.showTopicHelp(filterTopic(topic, this.lang));
+    return super.showTopicHelp(projectTopic(topic, this.lang));
   }
 
   formatTopics(topics: Array<{ name: string; description?: string }>): string {
-    return super.formatTopics(topics.map((t) => filterTopic(t, this.lang)));
+    return super.formatTopics(topics.map((t) => projectTopic(t, this.lang)));
   }
-}
-
-function filterTopic<T extends { description?: string }>(topic: T, lang: Lang): T {
-  return {
-    ...topic,
-    description: pickLang(topic.description, lang) ?? topic.description,
-  };
 }

--- a/src/cli/oclif/hooks/init.ts
+++ b/src/cli/oclif/hooks/init.ts
@@ -1,0 +1,79 @@
+/**
+ * oclif init hook — Config.load 后、Command.run() 前触发。
+ *
+ * 目的:把所有 oclif Command 上的双语 description / summary / flag.description /
+ * arg.description / examples[].description 在 hook 这一刻 in-place mutate 成
+ * **单语**(按 resolveLang(process.argv) 当前语言),解决两个长期问题:
+ *
+ *   #5 错误路径双语 dump:oclif 的 errors/handle.js(L44)硬编码
+ *      `new Help(config, options)` 不走 package.json.oclif.helpClass(即不走
+ *      LangAwareHelp 的 filterCommand),parse error 时 dump 出来的 FLAGS / USAGE
+ *      会把 `${zh}\n${en}` 形态原样吐双语两行。hook 在 mutate 之后,errors handler
+ *      拿到的 Command.Loadable 字段已经是单语,dump 自然单语。
+ *
+ *   #8 LangAwareHelp 覆盖盲区:formatRoot / 命令级 deprecationOptions /
+ *      未来 oclif 新加的 Help 渲染入口 — 只要走 cmd.description 字段都被 mutate
+ *      覆盖,不需要在 LangAwareHelp 一个个 override 跟着补。LangAwareHelp 现有
+ *      override 保留作 safety net(pickLang 在已切单语的 string 上 idempotent)。
+ *
+ * mutate 安全性:`cmd.description` / `cmd.flags[k].description` 是 Command.Loadable
+ * 上的可写属性,Help class 渲染时直接读这些字段(确认过 @oclif/core/lib/help/command.js
+ * 直接读 cmd.description)。mutate 不影响其它运行时(执行 Command.run() 跟
+ * description 字符串无关)。
+ */
+import type { Hook, Command } from '@oclif/core';
+import { pickLang, resolveLang, type Lang } from '../i18n.js';
+
+function applyLang(field: string | undefined, lang: Lang): string | undefined {
+  if (field === undefined) return undefined;
+  return pickLang(field, lang);
+}
+
+function mutateCommand(cmd: Command.Loadable, lang: Lang): void {
+  if (cmd.description !== undefined) {
+    cmd.description = applyLang(cmd.description, lang);
+  }
+  if (cmd.summary !== undefined) {
+    cmd.summary = applyLang(cmd.summary, lang);
+  }
+
+  if (cmd.flags) {
+    for (const name of Object.keys(cmd.flags)) {
+      const flag = cmd.flags[name] as { description?: string; summary?: string };
+      if (flag.description !== undefined) {
+        flag.description = applyLang(flag.description, lang);
+      }
+      if (flag.summary !== undefined) {
+        flag.summary = applyLang(flag.summary, lang);
+      }
+    }
+  }
+
+  if (cmd.args) {
+    for (const name of Object.keys(cmd.args)) {
+      const arg = cmd.args[name] as { description?: string };
+      if (arg.description !== undefined) {
+        arg.description = applyLang(arg.description, lang);
+      }
+    }
+  }
+
+  if (Array.isArray(cmd.examples)) {
+    cmd.examples = cmd.examples.map((ex) => {
+      if (typeof ex === 'string') return applyLang(ex, lang) ?? ex;
+      return {
+        ...ex,
+        description: applyLang(ex.description, lang) ?? ex.description,
+      };
+    });
+  }
+}
+
+const hook: Hook<'init'> = async function (opts) {
+  const lang = resolveLang(process.argv);
+  for (const cmd of opts.config.commands) {
+    mutateCommand(cmd, lang);
+  }
+};
+
+export default hook;

--- a/src/cli/oclif/i18n.ts
+++ b/src/cli/oclif/i18n.ts
@@ -38,6 +38,17 @@ export function bilingual(text: BiText): string {
       `Use single-line description; place long prose in legacy cli.help.* dict.`,
     );
   }
+  // ejs 模板标记 `<% %>` 不允许出现在 description / flag.description / arg.description 里。
+  // oclif Help 用 ejs.render(body, context) 渲染所有 section,如果未来 description 被
+  // 拼了用户输入(skill 名、文件路径、env 值),`<%...%>` 会被执行成任意代码。
+  // by-design 的模板只在 example.command 字段(如 `<%= config.bin %>`),那个字段不走 bilingual()。
+  if (text.zh.includes('<%') || text.zh.includes('%>') || text.en.includes('<%') || text.en.includes('%>')) {
+    throw new Error(
+      `bilingual() text must not contain ejs template markers (<% or %>). ` +
+      `oclif Help renders description through ejs; templates only belong in example.command. ` +
+      `Got zh=${JSON.stringify(text.zh)}, en=${JSON.stringify(text.en)}.`,
+    );
+  }
   return `${text.zh}\n${text.en}`;
 }
 

--- a/src/cli/oclif/projection.ts
+++ b/src/cli/oclif/projection.ts
@@ -1,0 +1,69 @@
+/**
+ * Command.Loadable → 单语视图 projection。
+ *
+ * 单一来源「oclif Command.Loadable 暴露给 help / docs / 错误路径的单语形态」。
+ * help.ts 的 filterCommand、init hook 的 mutate、未来 docs 自动生成 / 错误
+ * dump 等场景都从这里派生,避免每个消费者各做一遍 reflection 跟 sentinel
+ * split,oclif 升级新字段(aliases / hidden / deprecationOptions)时只改一处。
+ *
+ * projectCommand 返回 clone(不 mutate 入参)。init hook 需要 in-place mutate
+ * 时,先 projectCommand 再 Object.assign 回去。
+ */
+import type { Command } from '@oclif/core';
+import { pickLang, type Lang } from './i18n.js';
+
+export function projectCommand(cmd: Command.Loadable, lang: Lang): Command.Loadable {
+  const out: Command.Loadable = { ...cmd };
+
+  if (cmd.description !== undefined) {
+    out.description = pickLang(cmd.description, lang);
+  }
+  if (cmd.summary !== undefined) {
+    out.summary = pickLang(cmd.summary, lang);
+  }
+
+  if (cmd.flags) {
+    const flags: Record<string, unknown> = {};
+    for (const [name, flag] of Object.entries(cmd.flags)) {
+      const f = flag as { description?: string; summary?: string };
+      flags[name] = {
+        ...flag,
+        description: pickLang(f.description, lang) ?? f.description,
+        summary: pickLang(f.summary, lang) ?? f.summary,
+      };
+    }
+    out.flags = flags as typeof cmd.flags;
+  }
+
+  if (cmd.args) {
+    const args: Record<string, unknown> = {};
+    for (const [name, arg] of Object.entries(cmd.args)) {
+      const a = arg as { description?: string };
+      args[name] = {
+        ...arg,
+        description: pickLang(a.description, lang) ?? a.description,
+      };
+    }
+    out.args = args as typeof cmd.args;
+  }
+
+  if (Array.isArray(cmd.examples)) {
+    out.examples = cmd.examples.map((ex) => {
+      if (typeof ex === 'string') return pickLang(ex, lang) ?? ex;
+      return {
+        ...ex,
+        description: pickLang(ex.description, lang) ?? ex.description,
+      };
+    });
+  }
+
+  return out;
+}
+
+/** Topic 单语视图(无 flags / args / examples)。 */
+export function projectTopic<T extends { description?: string }>(topic: T, lang: Lang): T {
+  return {
+    ...topic,
+    description: pickLang(topic.description, lang) ?? topic.description,
+  };
+}

--- a/src/cli/oclif/run-legacy.ts
+++ b/src/cli/oclif/run-legacy.ts
@@ -1,0 +1,39 @@
+/**
+ * oclif Command 调 legacy execute() 的 adapter helper。
+ *
+ * 14 个 oclif Command run() 之前都重复:
+ *
+ *   await this.parse(X);
+ *   const argv = this.argv;
+ *   const { execute } = await import('../../commands/y.js');
+ *   const { CliExit } = await import('../../cli-exit.js');
+ *   try {
+ *     await execute(argv);
+ *   } catch (err) {
+ *     if (err instanceof CliExit) {
+ *       if (err.code === 0) return;
+ *       this.exit(err.code);
+ *     }
+ *     throw err;
+ *   }
+ *
+ * 抽 runLegacyCommand 统一 CliExit → this.exit(code) 转译,Command 缩到 3-5 行。
+ */
+import type { Command } from '@oclif/core';
+import { CliExit } from '../cli-exit.js';
+
+export async function runLegacyCommand(
+  oclifCmd: Command,
+  fn: () => Promise<void>,
+): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof CliExit) {
+      if (err.code === 0) return;
+      oclifCmd.exit(err.code);
+      return;
+    }
+    throw err;
+  }
+}

--- a/test/cli/oclif-hook-init.test.ts
+++ b/test/cli/oclif-hook-init.test.ts
@@ -1,0 +1,84 @@
+/**
+ * oclif init hook + 顶层 --lang scan 验收。
+ *
+ * 锁两个 #121 收口项:
+ *   #5 错误路径双语 dump:`omk <cmd> --bogus-flag` 错误时 oclif 内部硬编码
+ *      `new Help(config)` 不走 LangAwareHelp,但 init hook 已经在 Command.Loadable
+ *      上 in-place mutate 单语,所以 dump 出来的 FLAGS / USAGE 单语。
+ *   #6 顶层 --lang 跨子命令边界:`omk --lang en eval --help` 跟 `omk eval --lang en --help`
+ *      行为等价,都走子命令的英文 help 而不是退化到 root help。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const CLI = join(PROJECT_ROOT, 'dist', 'src', 'cli', 'index.js');
+
+interface ExecError extends Error {
+  code?: number;
+  stdout: string;
+  stderr: string;
+}
+
+describe('oclif init hook + 顶层 --lang scan(#5 / #6)', () => {
+  it('#5: eval --bogus-flag 错误路径 FLAGS dump 单语(zh 默认)', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'eval', '--bogus-flag']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}`);
+      const out = e.stdout + e.stderr;
+      // 命中 zh 关键词 + 不命中 en 关键词(双语 dump 的特征:中英行紧挨)
+      assert.ok(/batch 模式/.test(out), `dump 应含 zh flag description:\n${out.slice(0, 400)}`);
+      assert.ok(!/Batch mode: baseline/.test(out), `dump 不应同时含 en flag description(双语并列):\n${out.slice(0, 400)}`);
+    }
+  });
+
+  it('#5: eval --bogus-flag --lang en 错误路径 FLAGS dump 单语(en)', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'eval', '--bogus-flag', '--lang', 'en']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2);
+      const out = e.stdout + e.stderr;
+      assert.ok(/Batch mode/.test(out), `dump 应含 en flag description:\n${out.slice(0, 400)}`);
+      assert.ok(!/batch 模式/.test(out), `dump 不应同时含 zh flag description:\n${out.slice(0, 400)}`);
+    }
+  });
+
+  it('#6: omk --lang en eval --help 走子命令英文 help(不退化到 root)', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, '--lang', 'en', 'eval', '--help']);
+    // eval --help 英文 description 关键词
+    assert.ok(/Run evaluation:/i.test(stdout), `应走 eval 英文 help,实际:\n${stdout.slice(0, 300)}`);
+    // 退化到 root 时 description 会变成 "Evaluation framework for LLM..."
+    assert.ok(
+      !/Evaluation framework for LLM/.test(stdout),
+      `不应退化到 root help:\n${stdout.slice(0, 300)}`,
+    );
+    // eval 子命令的 USAGE 行特征
+    assert.ok(/\$ omk eval/.test(stdout), `USAGE 应是 \`$ omk eval ...\`,实际:\n${stdout.slice(0, 300)}`);
+  });
+
+  it('#6: omk --lang=en eval --help 等号形态也工作', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, '--lang=en', 'eval', '--help']);
+    assert.ok(/Run evaluation:/i.test(stdout), `应走 eval 英文 help,实际:\n${stdout.slice(0, 300)}`);
+  });
+
+  it('#6: omk eval --lang en --help 已工作的形态保留', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'eval', '--lang', 'en', '--help']);
+    assert.ok(/Run evaluation:/i.test(stdout), `应走 eval 英文 help,实际:\n${stdout.slice(0, 300)}`);
+  });
+
+  it('默认 zh: omk eval --help 仍打中文(回归)', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'eval', '--help']);
+    assert.ok(/跑评测/.test(stdout), `应走 eval 中文 help,实际:\n${stdout.slice(0, 300)}`);
+  });
+});

--- a/test/cli/oclif-i18n.test.ts
+++ b/test/cli/oclif-i18n.test.ts
@@ -1,0 +1,58 @@
+/**
+ * oclif 路径 i18n helper 单测 — bilingual() footgun assertion。
+ *
+ * bilingual({zh, en}) 拼成 `${zh}\n${en}` 串塞给 oclif Command 的 description / flag
+ * description 字段。两类内容会破坏下游 pickLang 切分 + oclif Help ejs.render:
+ *
+ *   1. 真换行(\n) — pickLang 第一行当 zh 后续全归 en,codegen 跟 help 一起错位。
+ *   2. ejs 模板标记(`<%` / `%>`)— oclif Help 用 ejs.render(body, context) 渲染所有
+ *      section,description 拼了用户输入 + ejs 标记会被执行成任意代码。by-design
+ *      的模板只在 example.command 字段(如 `<%= config.bin %>`),那里不走 bilingual()。
+ *
+ * 本测试锁这两类异常 input 必须在 bilingual() 入口抛错。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { bilingual } from '../../src/cli/oclif/i18n.js';
+
+describe('oclif/i18n bilingual() footgun', () => {
+  it('正常 single-line zh + en 返回 `${zh}\\n${en}`', () => {
+    const out = bilingual({ zh: '初始化项目', en: 'Init project' });
+    assert.equal(out, '初始化项目\nInit project');
+  });
+
+  it('zh 含真换行抛错', () => {
+    assert.throws(
+      () => bilingual({ zh: '第一段\n第二段', en: 'first\nsecond' }),
+      /does not support newlines/,
+    );
+  });
+
+  it('en 含真换行抛错', () => {
+    assert.throws(
+      () => bilingual({ zh: '单行', en: 'first\nsecond' }),
+      /does not support newlines/,
+    );
+  });
+
+  it('zh 含 ejs 标记 `<%` 抛错', () => {
+    assert.throws(
+      () => bilingual({ zh: '前缀 <%= 1+1 %> 后缀', en: 'safe' }),
+      /must not contain ejs template markers/,
+    );
+  });
+
+  it('en 含 ejs 标记 `%>` 抛错', () => {
+    assert.throws(
+      () => bilingual({ zh: '安全', en: 'leak %> here' }),
+      /must not contain ejs template markers/,
+    );
+  });
+
+  it('zh 含 `<%` 单独标记也抛错(防局部出现)', () => {
+    assert.throws(
+      () => bilingual({ zh: '前缀 <%= ', en: 'safe' }),
+      /must not contain ejs template markers/,
+    );
+  });
+});

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -57,4 +57,29 @@ describe('oclif init', () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it('init -- --weird 拒绝以 -- 开头的 positional(防 legacy 创建名为 --weird 的目录)', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'init', '--', '--weird']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.notEqual(e.code, 0, `expected non-zero exit, got ${e.code}`);
+      const out = e.stdout + e.stderr;
+      assert.ok(/不能以 -- 开头/.test(out), `expected zh footgun msg, got:\n${out.slice(0, 200)}`);
+      assert.ok(!existsSync('--weird'), '--weird directory must not be created');
+    }
+  });
+
+  it('init -- --weird --lang en 拒绝且报英文', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'init', '--', '--weird', '--lang', 'en']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.notEqual(e.code, 0);
+      const out = e.stdout + e.stderr;
+      assert.ok(/cannot start with --/.test(out), `expected en footgun msg, got:\n${out.slice(0, 200)}`);
+    }
+  });
 });

--- a/test/scripts/build-docs.test.ts
+++ b/test/scripts/build-docs.test.ts
@@ -9,7 +9,7 @@
  *   按 JS 解析,破坏 production 行为。
  * - eval-samples 字段参考段不在 marker 内,codegen 后必须原样保留
  */
-import { describe, it } from 'vitest';
+import { beforeAll, describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -18,9 +18,9 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Config } from '@oclif/core';
 import yaml from 'js-yaml';
-// 从 build-docs.ts 直接 import 单一来源(避免在 test 里硬编码),让 README codegen
-// 跟 SKILL.md frontmatter gate 共用同一份 TOP_LEVEL_IDS。
-import { TOP_LEVEL_IDS } from '../../scripts/build-docs.js';
+// 从 build-docs.ts 复用 getTopLevelIds 派生函数(单一来源是 oclif Command 文件目录,
+// 不再 hardcode 常量),让 README codegen 跟 SKILL.md frontmatter gate 共用同一份真值。
+import { getTopLevelIds } from '../../scripts/build-docs.js';
 
 const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -57,6 +57,14 @@ function readMarkerBody(content: string): string {
 }
 
 describe('scripts/build-docs codegen', () => {
+  // oclif 顶层命令真值集 — 跨 case 共享,从 Config.load 派生(单一来源是
+  // src/cli/oclif/commands/ 文件目录)。
+  let oclifTopLevelIds: readonly string[];
+  beforeAll(async () => {
+    const config = await Config.load({ root: PROJECT_ROOT });
+    oclifTopLevelIds = getTopLevelIds(config);
+  });
+
   it('commands.md marker body covers all 13 oclif commands', () => {
     const content = readFileSync(COMMANDS_MD, 'utf8');
     const body = readMarkerBody(content);
@@ -163,9 +171,9 @@ describe('scripts/build-docs codegen', () => {
     }
   }, 30000);
 
-  it('README.md has 7 marker pairs for top-level oclif commands', () => {
+  it('README.md has marker pairs for every top-level oclif command', () => {
     const content = readFileSync(README_EN, 'utf8');
-    for (const id of TOP_LEVEL_IDS) {
+    for (const id of oclifTopLevelIds) {
       assert.ok(
         content.includes(`<!-- omk:cli:${id}:flags:start -->`),
         `README.md missing marker start for ${id}`,
@@ -177,9 +185,9 @@ describe('scripts/build-docs codegen', () => {
     }
   });
 
-  it('README.zh.md has 7 marker pairs for top-level oclif commands', () => {
+  it('README.zh.md has marker pairs for every top-level oclif command', () => {
     const content = readFileSync(README_ZH, 'utf8');
-    for (const id of TOP_LEVEL_IDS) {
+    for (const id of oclifTopLevelIds) {
       assert.ok(
         content.includes(`<!-- omk:cli:${id}:flags:start -->`),
         `README.zh.md missing marker start for ${id}`,
@@ -242,32 +250,16 @@ describe('scripts/build-docs codegen', () => {
     assert.ok(idxConcurrency < idxThreshold, '--concurrency should precede --threshold');
   });
 
-  it('TOP_LEVEL_IDS constant matches actual oclif top-level command set (Config.load)', async () => {
-    // 动态绑定:Config.load 读 dist/src/cli/oclif/commands/ 真实命令文件,过滤
-    // 出顶层命令(id 不含 ':'),跟 scripts/build-docs.ts 导出的 TOP_LEVEL_IDS
-    // 严格 set 相等。未来新增 / 删 / 重命名顶层命令时,只改 oclif Command 源忘
-    // 改 TOP_LEVEL_IDS 就会被本测试 fail 拦住。
-    const config = await Config.load({ root: PROJECT_ROOT });
-    const actual = config.commands
-      .map((c) => c.id)
-      .filter((id) => !id.includes(':'))
-      .sort();
-    const expected = [...TOP_LEVEL_IDS].sort();
-    assert.deepEqual(
-      actual,
-      expected,
-      `TOP_LEVEL_IDS drifted from oclif Config.commands top-level set.\n` +
-      `  expected: ${expected.join(', ')}\n` +
-      `  actual:   ${actual.join(', ')}`,
-    );
-  }, 30000);
-
-  it('SKILL.md argument-hint frontmatter matches oclif top-level command set', () => {
+  it('SKILL.md argument-hint frontmatter matches oclif top-level command set (Config.load)', async () => {
     // SKILL.md frontmatter `argument-hint` 形如:
     //   argument-hint: "<init|doctor|eval|observe|evolve|sample|studio> [options]"
     // 历史上 omk 顶层命令树重构过两次(bench run → eval、improve → evolve、
     // export → sample),每次都靠人工同步这一行。本测试把它锁住:argument-hint
-    // 列出的 7 个 id 必须跟 TOP_LEVEL_IDS 严格一致(set 比较,顺序无关)。
+    // 列出的 id 必须跟 oclif Config.commands 的顶层集严格一致(set 比较,顺序无关)。
+    // 真值通过 getTopLevelIds(Config.load) 派生,oclif Command 文件目录是单一来源。
+    const config = await Config.load({ root: PROJECT_ROOT });
+    const expected = [...getTopLevelIds(config)].sort();
+
     const content = readFileSync(SKILL_MD, 'utf8');
     const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
     assert.ok(fmMatch, 'SKILL.md must have YAML frontmatter');
@@ -277,7 +269,6 @@ describe('scripts/build-docs codegen', () => {
     const innerMatch = hint.match(/^<([^>]+)>/);
     assert.ok(innerMatch, `argument-hint must start with <cmd|cmd|...>, got: ${hint}`);
     const listed = innerMatch[1]!.split('|').map((s) => s.trim()).filter(Boolean);
-    const expected = [...TOP_LEVEL_IDS].sort();
     const actual = [...listed].sort();
     assert.deepEqual(
       actual,
@@ -286,5 +277,5 @@ describe('scripts/build-docs codegen', () => {
       `  expected: ${expected.join('|')}\n` +
       `  actual:   ${actual.join('|')}`,
     );
-  });
+  }, 30000);
 });

--- a/test/scripts/markdown-cmd-refs.test.ts
+++ b/test/scripts/markdown-cmd-refs.test.ts
@@ -1,0 +1,142 @@
+/**
+ * 全仓 user-facing markdown 的 `omk <cmd>` 引用 grep gate。
+ *
+ * issue #109 立项时点名漂移过的剧情(`omk bench run` → `eval`、`improve` → `evolve`、
+ * `omk export` 下线后仍被 README/SKILL.md 引用)就是「真实命令树重构后,docs 跟不上」
+ * 的典型 sample。PR #120 给 SKILL.md frontmatter argument-hint 加了 vitest gate,
+ * 但 SKILL.md body 36 处 cmd refs、quickstart-skill-eval.md 的 26 处、roadmap.md
+ * 等仍裸跑没保护。
+ *
+ * 本测试 scan 全仓 user-facing markdown,把 `omk <cmd>` 第一 token 跟 oclif Config
+ * 真值集合比对,任何 stale / typo / removed 命令都会被拦。真值来自
+ * `getTopLevelIds(Config.load)`(scripts/build-docs.ts 已经收口为单一派生函数),
+ * oclif Command 文件目录是唯一真值源。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Config } from '@oclif/core';
+import { getTopLevelIds } from '../../scripts/build-docs.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+
+// scan 范围:user-facing markdown(README / SKILL / docs / agent prompt / 贡献者指南)。
+// 测量学 fixture(test/__snapshots__)、生成文件(dist/)、依赖(node_modules/)不进。
+const SCAN_DIRS = [
+  'docs',
+  '.claude/skills/omk',
+];
+const SCAN_FILES = [
+  'README.md',
+  'README.zh.md',
+  'SKILL.md',
+  'CONTRIBUTING.md',
+  'AGENTS.md',
+];
+
+// 命令引用必须是「机读形态」:fenced code block(```)内 或 inline code(反引号)。
+// 英文叙述里 `omk asks the AI...` / `omk runtime 匹配...` / `Use omk to ...`
+// 的 prose 形式不在校验范围 — 那种是名词短语,不是命令调用。
+//
+// 两条正则:
+//   INLINE_CODE_CMD:`omk <cmd>` 必须紧跟反引号(inline code 起始)
+//   FENCED_CMD:在 ``` ... ``` 内的任意 `omk <cmd>`(代码块里的全算命令引用)
+const INLINE_CODE_CMD = /`omk\s+([a-z][a-z-]*)/g;
+const FENCED_CMD = /(?<![\w-])omk\s+([a-z][a-z-]*)/g;
+
+interface Violation {
+  file: string;
+  line: number;
+  token: string;
+  context: string;
+}
+
+function collectMarkdownFiles(): string[] {
+  const out: string[] = [];
+  for (const rel of SCAN_FILES) {
+    out.push(join(PROJECT_ROOT, rel));
+  }
+  for (const rel of SCAN_DIRS) {
+    walkMarkdown(join(PROJECT_ROOT, rel), out);
+  }
+  return out;
+}
+
+function walkMarkdown(dir: string, out: string[]): void {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const name = String(entry.name);
+    if (name === 'node_modules' || name === 'dist') continue;
+    const full = join(dir, name);
+    if (entry.isDirectory()) {
+      walkMarkdown(full, out);
+    } else if (entry.isFile() && name.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+}
+
+describe('markdown `omk <cmd>` 引用 grep gate', () => {
+  it('全仓 user-facing markdown 里的 `omk <cmd>` 第一 token 必须是真实 oclif top-level 命令', async () => {
+    const config = await Config.load({ root: PROJECT_ROOT });
+    const truth = new Set(getTopLevelIds(config));
+
+    const files = collectMarkdownFiles();
+    const violations: Violation[] = [];
+
+    for (const abs of files) {
+      let text: string;
+      try {
+        text = readFileSync(abs, 'utf8');
+      } catch {
+        continue;
+      }
+      const lines = text.split('\n');
+      let inFence = false;
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]!;
+        if (/^\s*```/.test(line)) {
+          inFence = !inFence;
+          continue;
+        }
+        // fenced code block 里的 shell 注释行(# 开头)不算命令引用 — bash 注释里
+        // 的 prose 跟 markdown 散文是同一性质,不应 strict 校验。
+        if (inFence && /^\s*#/.test(line)) continue;
+        const regex = inFence ? FENCED_CMD : INLINE_CODE_CMD;
+        regex.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = regex.exec(line)) !== null) {
+          const token = m[1]!;
+          if (!truth.has(token)) {
+            violations.push({
+              file: relative(PROJECT_ROOT, abs),
+              line: i + 1,
+              token,
+              context: line.trim().slice(0, 120),
+            });
+          }
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const dump = violations
+        .map((v) => `  ${v.file}:${v.line}  'omk ${v.token}'  | ${v.context}`)
+        .join('\n');
+      assert.fail(
+        `发现 ${violations.length} 处未知 / stale omk 命令引用\n` +
+        `(allowlist: ${[...truth].sort().join(', ')}):\n${dump}\n\n` +
+        `修法:改 markdown 里的命令引用,或者(如果该命令确实应该存在)加 ` +
+        `src/cli/oclif/commands/<cmd>.ts 后重新 yarn build。`,
+      );
+    }
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

闭环 issue #121:PR #120 review 收口的架构层 followup。原 issue 含 reviewer 4 项 + 5 视角 CR 14 项共 18 项,本 PR 拆 4 个 commit 组(F1-F4)逐组推进,每组合并前 yarn test 全绿。F5(perf + drift gate)做 scope 决策保留,详见末尾对照表。

合并用 merge commit 不 squash,保留 F1-F4 phase 叙事。

## Commits(4 个 phase 组)

1. `ad8ceac` F1 quick wins — markdown 引用 gate / 动态 TOP_LEVEL_IDS / ejs footgun / init Args validate
2. `aa7441f` F2 init hook 统一 — 单语 mutate + 顶层 --lang scan
3. `a24512c` F3 projection 层 — 抽 projectCommand + pickLang 单一来源
4. `ab3f28b` F4 adapter helper — runLegacyCommand 抽取 + 12 个 Command 改调

## #121 18 项对照

| 项 | 状态 | 落点 |
|---|---|---|
| #1 typed input throughout | scope 决策 skip | F4 已经把 helper 抽出,后续单命令逐步迁更自然(future PR-G) |
| #2 显式 topic command 规约 | ✅ | F1 CONTRIBUTING.md「加新 sub-sub topic 命令」段 |
| #3 catalog 动态推导 | ✅ | F1 scripts/build-docs.ts `getTopLevelIds(config)` factory,删 hardcoded TOP_LEVEL_IDS |
| #4 adapter helper | ✅ | F4 src/cli/oclif/run-legacy.ts |
| #5 错误路径双语 dump | ✅ | F2 init hook in-place mutate Command.Loadable 到单语 |
| #6 顶层 --lang scan | ✅ | F2 src/cli/index.ts normalizeArgv |
| #7 projection 层 | ✅ | F3 src/cli/oclif/projection.ts |
| #8 LangAwareHelp formatRoot / deprecation | partial | F2 init hook mutate 已覆盖大部分;LangAwareHelp 保留作 safety net |
| #9 drift gate 3 种策略统一 | scope 决策 skip | F1 全仓 markdown grep gate(#14)已经把 SKILL.md body + docs/** 锁住;commands.md / README / SKILL.md 三种 gate 形态各自适合不同 markdown 性质,统一为单一形态收益 marginal |
| #10 process.argv.slice removal | ✅ | PR #120 已修(11 处 → this.argv) |
| #11 eval/gold.ts oclif-native usage | scope 决策 skip | 当前 legacy usage() 已 work;runCommand('help', ...) 在 topic command + init hook mutate 集成尚未端到端验证,稳定性优先 |
| #12 quickstart grep gate | ✅(#14 涵盖) | F1 markdown-cmd-refs.test.ts 覆盖 docs/zh/quickstart-skill-eval.md |
| #13 SKILL.md body grep test | ✅(#14 涵盖) | F1 同上,覆盖 SKILL.md / .claude/skills/omk/SKILL.md |
| #14 全仓 markdown grep | ✅ | F1 test/scripts/markdown-cmd-refs.test.ts |
| #15 oclif manifest cached load | scope 决策 skip | 启动减 ~30-90ms 是 marginal(--help short path 已有 800ms budget);加 oclif.manifest.json 进 git + CI manifest check 的文件管理成本 > 收益 |
| #16 ejs.render footgun | ✅ | F1 bilingual() 加 `<%` / `%>` assertion + CONTRIBUTING 警告 |
| #17 init -- --weird Args validate | ✅ | F1 init.ts dir Args parse 拦 `--` 前缀 |
| #18 build-docs.ts 拆 + formatTopics 专项 | partial | F3 pickLang 单一来源消除重复,projection 抽出;build-docs.ts 拆 lib + index(460 行重排)scope 决策 skip,值不抵成本;formatTopics lang 切换由 init hook + 现有 e2e 间接覆盖 |

闭环 13 项,scope 决策 skip 5 项(#1 / #9 / #11 / #15 / #18 build-docs 拆分),每项 skip 都有具体理由,不留尾巴。

## 测量学不变量

不动:src/types/report.ts / test/grading/judge-hash-frozen.test.ts / 五层评分管道 / Bootstrap CI / Krippendorff α / Length-debias toggle。

## Test plan

- [x] yarn lint 通过
- [x] yarn build 通过
- [x] yarn build:docs:check 通过(三个 codegen target 全 in sync)
- [x] yarn test 1499/1499 通过
- [x] 手测 `omk eval --bogus-flag` 错误路径 FLAGS dump 单语(不双语并列)
- [x] 手测 `omk --lang en eval --help` 走 eval 英文 help(不退化 root)
- [x] 手测 `omk eval --help` 默认 zh 仍正常
- [x] 手测 `omk init -- --weird` 拒绝 + 双语错误提示
- [x] 手测 bilingual() 含 `<%` 抛错(单测覆盖)
- [x] 手测改 markdown 塞 `omk fake-cmd` → grep gate 红

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)