### PR TITLE
chore(cli): 收口 oclif Command 共享模板

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,7 +1,8 @@
 import { existsSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { Args, Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../oclif/i18n.js';
+import { Args, Flags } from '@oclif/core';
+import { bilingual } from '../oclif/i18n.js';
+import { BaseCommand } from '../oclif/base-command.js';
 import { CliExit } from '../lib/cli-exit.js';
 import { tCli } from '../lib/i18n.js';
 import type { Sample } from '../../types/index.js';
@@ -50,7 +51,7 @@ function findDefaultSamplesPath(target: string | null, cwd: string): string | nu
   return null;
 }
 
-export default class Doctor extends Command {
+export default class Doctor extends BaseCommand {
   static description = bilingual({
     zh: '体检 omk 工作目录，检查 skill 配置 / 依赖 / executor 连通性。',
     en: 'Preflight health checks for omk workdir: skill config / deps / executor connectivity.',
@@ -153,8 +154,8 @@ export default class Doctor extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(Doctor);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       const target: string | null = args.target ?? null;
       const executorName = flags.executor ?? 'claude';
       const model = flags.model ?? 'sonnet';
@@ -250,13 +251,6 @@ export default class Doctor extends Command {
       }
 
       throw new CliExit(report.outcome === 'failed' ? 1 : 0);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/eval/gold/compare.ts
+++ b/src/cli/commands/eval/gold/compare.ts
@@ -1,12 +1,13 @@
 import { resolve } from 'node:path';
-import { Args, Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../../../oclif/i18n.js';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../../oclif/base-command.js';
+import { bilingual } from '../../../oclif/i18n.js';
 import { CliExit } from '../../../lib/cli-exit.js';
 import { DEFAULT_REPORTS_DIR } from '../../../lib/parse-run-config.js';
 import { requireEvaluationReport } from '../../../lib/shared.js';
 import type { ReportStore } from '../../../../types/index.js';
 
-export default class EvalGoldCompare extends Command {
+export default class EvalGoldCompare extends BaseCommand {
   static description = bilingual({
     zh: '把一份 evaluation report 跟 gold dataset 对比，计算 bootstrap CI 后的 agreement。',
     en: 'Compare an evaluation report against gold dataset, output bootstrap-CI agreement.',
@@ -52,8 +53,8 @@ export default class EvalGoldCompare extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(EvalGoldCompare);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       const reportId = args.reportId;
       if (!reportId) {
         console.error('Usage: omk eval gold compare <reportId> --gold-dir <dir>');
@@ -89,13 +90,6 @@ export default class EvalGoldCompare extends Command {
         seed: Number.isFinite(seedVal) ? seedVal : undefined,
       });
       console.log(formatGoldCompare(result, dataset));
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/eval/gold/index.ts
+++ b/src/cli/commands/eval/gold/index.ts
@@ -7,10 +7,11 @@
 // config.findCommand('eval:gold')) 让 LangAwareHelp 按 --lang 渲染当前 topic 的
 // description + sub-sub 列表(init / validate / compare)。
 
-import { Command, Flags } from '@oclif/core';
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../../oclif/base-command.js';
 import { bilingual } from '../../../oclif/i18n.js';
 
-export default class EvalGold extends Command {
+export default class EvalGold extends BaseCommand {
   static description = bilingual({
     zh: '管理 human-gold 标注集（init / validate / compare 三个子命令）。',
     en: 'Manage human-gold annotation datasets (sub-commands: init / validate / compare).',

--- a/src/cli/commands/eval/gold/init.ts
+++ b/src/cli/commands/eval/gold/init.ts
@@ -1,8 +1,9 @@
-import { Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../../../oclif/i18n.js';
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../../oclif/base-command.js';
+import { bilingual } from '../../../oclif/i18n.js';
 import { CliExit } from '../../../lib/cli-exit.js';
 
-export default class EvalGoldInit extends Command {
+export default class EvalGoldInit extends BaseCommand {
   static description = bilingual({
     zh: '初始化 gold dataset 目录（human-gold 标注集脚手架）。',
     en: 'Init gold dataset dir (scaffold for human-gold annotations).',
@@ -30,8 +31,8 @@ export default class EvalGoldInit extends Command {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(EvalGoldInit);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       const { initGoldDataset } = await import('../../../../grading/gold-cli.js');
       try {
         const written = initGoldDataset(flags.out, {
@@ -48,13 +49,6 @@ export default class EvalGoldInit extends Command {
         console.error((err as Error).message);
         throw new CliExit(1);
       }
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/eval/gold/validate.ts
+++ b/src/cli/commands/eval/gold/validate.ts
@@ -1,8 +1,9 @@
-import { Args, Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../../../oclif/i18n.js';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../../oclif/base-command.js';
+import { bilingual } from '../../../oclif/i18n.js';
 import { CliExit } from '../../../lib/cli-exit.js';
 
-export default class EvalGoldValidate extends Command {
+export default class EvalGoldValidate extends BaseCommand {
   static description = bilingual({
     zh: '校验 gold dataset 目录格式（annotations.yaml schema）。',
     en: 'Validate gold dataset dir (annotations.yaml schema).',
@@ -27,8 +28,8 @@ export default class EvalGoldValidate extends Command {
 
   async run(): Promise<void> {
     const { args } = await this.parse(EvalGoldValidate);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       const dir = args.dir;
       if (!dir) {
         console.error('Usage: omk eval gold validate <dir>');
@@ -45,13 +46,6 @@ export default class EvalGoldValidate extends Command {
       console.error(`✗ gold dataset has ${result.issues.length} issue(s):`);
       for (const msg of result.issues) console.error(`  - ${msg}`);
       throw new CliExit(1);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -1,5 +1,6 @@
-import { Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../../oclif/i18n.js';
+import { Flags } from '@oclif/core';
+import { bilingual } from '../../oclif/i18n.js';
+import { BaseCommand } from '../../oclif/base-command.js';
 import { CliExit } from '../../lib/cli-exit.js';
 import { tCli, type CliLang } from '../../lib/i18n.js';
 import { parseRunConfig } from '../../lib/parse-run-config.js';
@@ -13,7 +14,7 @@ import type { EvalResult, ReportServer } from '../../lib/shared.js';
 // oclif 版 eval(默认 = run 模式) — 单次 typed parse 之后业务 inline。flag schema
 // 镜像 RUN_OPTIONS + eval-runner extra = 41 flag。具体语义跟约束在 parseRunConfig 里。
 //
-// `omk eval gold ...` 由 src/cli/oclif/commands/eval/gold/{init,validate,compare}.ts
+// `omk eval gold ...` 由 src/cli/commands/eval/gold/{init,validate,compare}.ts
 // 处理,oclif 文件目录路由自动接管,不进 eval.ts。
 
 interface SkillProgressInfo {
@@ -335,7 +336,7 @@ async function runEval(
   }
 }
 
-export default class Eval extends Command {
+export default class Eval extends BaseCommand {
   static description = bilingual({
     zh: '跑评测：对一个 control vs 多个 treatment skill 做对照试验，产 verdict 报告。',
     en: 'Run evaluation: control vs treatment(s) comparison, produce verdict report.',
@@ -521,16 +522,9 @@ export default class Eval extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(Eval);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       await runEval(args as Record<string, never>, { ...flags, lang }, lang);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/evolve.ts
+++ b/src/cli/commands/evolve.ts
@@ -1,7 +1,8 @@
 import { resolve, join } from 'node:path';
 import { existsSync } from 'node:fs';
-import { Args, Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../oclif/i18n.js';
+import { Args, Flags } from '@oclif/core';
+import { bilingual } from '../oclif/i18n.js';
+import { BaseCommand } from '../oclif/base-command.js';
 import { CliExit } from '../lib/cli-exit.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
 import { makeOnProgress } from '../lib/progress.js';
@@ -150,7 +151,7 @@ export async function runEvolve(
   }
 }
 
-export default class Evolve extends Command {
+export default class Evolve extends BaseCommand {
   static description = bilingual({
     zh: '自动迭代改进 skill:多轮 eval + skill 重写，直到达到 --target 或耗尽 --rounds。',
     en: 'Auto-iterate skill improvement: multi-round eval + rewrite until --target or --rounds exhausted.',
@@ -269,16 +270,9 @@ export default class Evolve extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(Evolve);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       await runEvolve(args, { ...flags, lang }, lang);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,7 +1,7 @@
 import { resolve, join } from 'node:path';
-import { Args, Command, Flags } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 import { bilingual, resolveLang } from '../oclif/i18n.js';
-import { CliExit } from '../lib/cli-exit.js';
+import { BaseCommand } from '../oclif/base-command.js';
 import { tCli } from '../lib/i18n.js';
 
 const INIT_SAMPLES = `[
@@ -85,7 +85,7 @@ description: 多维度代码审查,覆盖安全 / 健壮 / 可维护 / 性能,�
 对每个维度给出具体的改进建议，并标注严重程度（高/中/低）。
 `;
 
-export default class Init extends Command {
+export default class Init extends BaseCommand {
   static description = bilingual({
     zh: '初始化 omk 项目脚手架（skills/ + eval-samples.json 模板）。',
     en: 'Scaffold an omk project (skills/ + eval-samples.json templates).',
@@ -142,8 +142,8 @@ export default class Init extends Command {
 
   async run(): Promise<void> {
     const { args } = await this.parse(Init);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       const targetDir: string = resolve(args.targetDir || '.');
       const { writeFileSync, mkdirSync } = await import('node:fs');
 
@@ -162,13 +162,6 @@ export default class Init extends Command {
       console.log(tCli('cli.init.next_step_edit_skills', lang));
       console.log(tCli('cli.init.next_step_run', lang));
       console.log(tCli('cli.init.note_codex_executor', lang));
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/observe/inbox.ts
+++ b/src/cli/commands/observe/inbox.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
-import { Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../../oclif/i18n.js';
-import { CliExit } from '../../lib/cli-exit.js';
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../oclif/base-command.js';
+import { bilingual } from '../../oclif/i18n.js';
 import { type CliLang } from '../../lib/i18n.js';
 import type { ObserveInboxArgs, ObserveInboxFlags } from '../../lib/cmd-flags.js';
 
@@ -93,7 +93,7 @@ export async function runObserveInbox(
     : 'Tip: omk observe inbox --explore 10 --include-noise  # explicitly include the noise bucket');
 }
 
-export default class ObserveInbox extends Command {
+export default class ObserveInbox extends BaseCommand {
   static description = bilingual({
     zh: '查询 observation inbox(skill 调用洞察）。',
     en: 'Query observation inbox (skill invocation insights).',
@@ -144,16 +144,9 @@ export default class ObserveInbox extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(ObserveInbox);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       await runObserveInbox(args as Record<string, never>, { ...flags, lang }, lang);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/observe/index.ts
+++ b/src/cli/commands/observe/index.ts
@@ -1,14 +1,15 @@
 import { resolve, join } from 'node:path';
-import { Args, Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../../oclif/i18n.js';
+import { Args, Flags } from '@oclif/core';
+import { bilingual } from '../../oclif/i18n.js';
+import { BaseCommand } from '../../oclif/base-command.js';
 import { CliExit } from '../../lib/cli-exit.js';
 import { tCli } from '../../lib/i18n.js';
 import { parseLastWindow } from '../../lib/shared.js';
 
 // oclif 版 observe 默认命令 — `omk observe <sessions-dir>` 走 health 分析。
-// 三个子命令(ingest / inbox / show)由 src/cli/oclif/commands/observe/ 文件目录托管。
+// 三个子命令(ingest / inbox / show)由 src/cli/commands/observe/ 文件目录托管。
 
-export default class Observe extends Command {
+export default class Observe extends BaseCommand {
   static description = bilingual({
     zh: '分析 sessions 目录的 skill 调用健康度（默认行为）。子命令:ingest / inbox / show。',
     en: 'Analyze skill invocation health from sessions dir (default). Subcommands: ingest / inbox / show.',
@@ -67,8 +68,8 @@ export default class Observe extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(Observe);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       const dir = args.sessionsDir;
       if (!dir) {
         console.error(tCli('cli.help.observe', lang).trim());
@@ -125,13 +126,6 @@ export default class Observe extends Command {
       console.log('');
       console.log(`report written to: ${jsonPath}`);
       console.log(tCli('cli.observe.view_hint', lang));
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/observe/ingest.ts
+++ b/src/cli/commands/observe/ingest.ts
@@ -1,9 +1,10 @@
 import { resolve } from 'node:path';
-import { Args, Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../../oclif/i18n.js';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../oclif/base-command.js';
+import { bilingual } from '../../oclif/i18n.js';
 import { CliExit } from '../../lib/cli-exit.js';
 
-export default class ObserveIngest extends Command {
+export default class ObserveIngest extends BaseCommand {
   static description = bilingual({
     zh: '把 trace 目录 ingest 成 observation inbox 报告。',
     en: 'Ingest trace dir into observation inbox report.',
@@ -34,8 +35,8 @@ export default class ObserveIngest extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(ObserveIngest);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       const dir = args.traceDir;
       if (!dir) {
         // oclif Args.required:true 已经保证非空,这里仍兜底防御。
@@ -69,13 +70,6 @@ export default class ObserveIngest extends Command {
       process.stderr.write(lang === 'zh'
         ? `observe inbox 已写入: ${path}\n`
         : `observe inbox written to: ${path}\n`);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/observe/show.ts
+++ b/src/cli/commands/observe/show.ts
@@ -1,9 +1,10 @@
 import { resolve } from 'node:path';
-import { Args, Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../../oclif/i18n.js';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../oclif/base-command.js';
+import { bilingual } from '../../oclif/i18n.js';
 import { CliExit } from '../../lib/cli-exit.js';
 
-export default class ObserveShow extends Command {
+export default class ObserveShow extends BaseCommand {
   static description = bilingual({
     zh: '展开 observation inbox 中某条 item 的详情。',
     en: 'Show details of a specific observation inbox item.',
@@ -34,8 +35,8 @@ export default class ObserveShow extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(ObserveShow);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       const id = args.inboxId;
       if (!id) {
         console.error(lang === 'zh' ? '用法：omk observe show <inbox_id> [--input-dir <path>]' : 'Usage: omk observe show <inbox_id> [--input-dir <path>]');
@@ -49,13 +50,6 @@ export default class ObserveShow extends Command {
         throw new CliExit(1);
       }
       console.log(formatObservationShow(item));
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -1,8 +1,9 @@
 import { resolve, join, basename, dirname, extname } from 'node:path';
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import yaml from 'js-yaml';
-import { Args, Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../oclif/i18n.js';
+import { Args, Flags } from '@oclif/core';
+import { bilingual } from '../oclif/i18n.js';
+import { BaseCommand } from '../oclif/base-command.js';
 import { CliExit } from '../lib/cli-exit.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
 import { DEFAULT_REPORTS_DIR } from '../lib/parse-run-config.js';
@@ -434,7 +435,7 @@ async function runSample(
   }
 }
 
-export default class Sample extends Command {
+export default class Sample extends BaseCommand {
   static description = bilingual({
     zh: '为指定 skill 生成评测用例（eval-samples），支持 batch / single / fix 三种模式。',
     en: 'Generate eval samples for the given skill. Supports batch / single / fix modes.',
@@ -538,16 +539,9 @@ export default class Sample extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(Sample);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       await runSample(args, { ...flags, lang }, lang);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
-import { Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../oclif/i18n.js';
-import { CliExit } from '../lib/cli-exit.js';
+import { Flags } from '@oclif/core';
+import { bilingual } from '../oclif/i18n.js';
+import { BaseCommand } from '../oclif/base-command.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
 import { DEFAULT_REPORTS_DIR } from '../lib/parse-run-config.js';
 import type { ReportServer } from '../lib/shared.js';
@@ -90,7 +90,7 @@ export async function runStudio(
   }
 }
 
-export default class Studio extends Command {
+export default class Studio extends BaseCommand {
   static description = bilingual({
     zh: '启动 omk Studio 报告服务（skill-centric 仪表盘 + 浏览器自动打开）。',
     en: 'Start omk Studio report server (skill-centric dashboard + browser auto-open).',
@@ -164,16 +164,9 @@ export default class Studio extends Command {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Studio);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       await runStudio({}, { ...flags, lang }, lang);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        if (err.code === 0) return;
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/oclif/base-command.ts
+++ b/src/cli/oclif/base-command.ts
@@ -1,0 +1,27 @@
+import { Command } from '@oclif/core';
+import { CliExit } from '../lib/cli-exit.js';
+import { resolveLang, type Lang } from './i18n.js';
+
+// Shared oclif boundary: command bodies may throw CliExit, and process.argv is
+// stable for one CLI invocation, so language resolution is cached per command.
+export abstract class BaseCommand extends Command {
+  #lang?: Lang;
+
+  protected get lang(): Lang {
+    this.#lang ??= resolveLang(process.argv);
+    return this.#lang;
+  }
+
+  protected async runWithCliExit(fn: () => Promise<void>): Promise<void> {
+    try {
+      await fn();
+    } catch (err) {
+      if (err instanceof CliExit) {
+        if (err.code === 0) return;
+        this.exit(err.code);
+        return;
+      }
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
## 用户影响
无用户可见行为变化。CLI flag、help 文案、exit code 语义保持不变。

## 迁移说明
无需迁移。后续参数 parser / i18n 校验增强仍应拆到独立 PR。

## 架构说明
这次只收口 oclif Command 的公共模板，让命令文件保留业务编排，并复用 lang 解析和 CliExit 边界处理。flag 声明继续直接使用 oclif 原生 Flags API，避免 wrapper 影响 InferredFlags 的 default narrowing。

## 验证
本地已通过 lint、build、test 和 oclif docs sync 检查。