### PR TITLE
fix(cli): 拒绝非法数值参数并输出双语错误

### DIFF
--- a/.claude/skills/omk/references/commands.md
+++ b/.claude/skills/omk/references/commands.md
@@ -66,9 +66,9 @@ omk eval [flags]
 - `--blind` `boolean`:judge blind 模式
 - `--bootstrap` `boolean`:加 bootstrap CI
 - `--bootstrap-samples` `option`:bootstrap 重采样次数，默认 1000
-- `--budget-per-sample-ms` `option`:单 sample 时长上限 ms
-- `--budget-per-sample-usd` `option`:单 sample 预算上限 USD
-- `--budget-usd` `option`:总预算上限 USD
+- `--budget-per-sample-ms` `option`:单 sample 时长上限 ms（必须 > 0，不传则无上限）
+- `--budget-per-sample-usd` `option`:单 sample 预算上限 USD（必须 > 0，不传则无上限）
+- `--budget-usd` `option`:总预算上限 USD（必须 > 0，不传则无上限）
 - `--concurrency` `option`:并发数，默认 1
 - `--config` `option`:eval.yaml 路径
 - `--control` `option`:control variant 表达式
@@ -102,7 +102,7 @@ omk eval [flags]
 - `--threshold` `option`:verdict 阈值，默认 3.5
 - `--timeout` `option`:单样本超时秒，默认 120
 - `--treatment` `option`:treatment variant 列表，逗号分隔
-- `--trivial-diff` `option`:可忽略 diff 容差
+- `--trivial-diff` `option`:可忽略 diff 容差，0 表示不启用容差
 - `--verbose` `boolean`:详细日志
 
 **示例:**

--- a/README.md
+++ b/README.md
@@ -439,9 +439,9 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
   --blind                         Blind judge mode
   --bootstrap                     Add bootstrap CI
   --bootstrap-samples <value>     Bootstrap resamples, default 1000
-  --budget-per-sample-ms <value>  Per-sample time cap ms
-  --budget-per-sample-usd <value> Per-sample budget cap USD
-  --budget-usd <value>            Total budget cap USD
+  --budget-per-sample-ms <value>  Per-sample time cap ms (must be > 0; omit for no cap)
+  --budget-per-sample-usd <value> Per-sample budget cap USD (must be > 0; omit for no cap)
+  --budget-usd <value>            Total budget cap USD (must be > 0; omit for no cap)
   --concurrency <value>           Concurrency, default 1
   --config <value>                eval.yaml path
   --control <value>               Control variant expr
@@ -475,7 +475,7 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
   --threshold <value>             Verdict threshold, default 3.5
   --timeout <value>               Per-sample timeout sec, default 120
   --treatment <value>             Treatment variants, comma-separated
-  --trivial-diff <value>          Trivial diff tolerance
+  --trivial-diff <value>          Trivial diff tolerance; 0 disables tolerance
   --verbose                       Verbose logging
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -439,9 +439,9 @@ omk eval gold compare <report-id> --gold-dir gold-dataset
   --blind                         judge blind 模式
   --bootstrap                     加 bootstrap CI
   --bootstrap-samples <value>     bootstrap 重采样次数，默认 1000
-  --budget-per-sample-ms <value>  单 sample 时长上限 ms
-  --budget-per-sample-usd <value> 单 sample 预算上限 USD
-  --budget-usd <value>            总预算上限 USD
+  --budget-per-sample-ms <value>  单 sample 时长上限 ms（必须 > 0，不传则无上限）
+  --budget-per-sample-usd <value> 单 sample 预算上限 USD（必须 > 0，不传则无上限）
+  --budget-usd <value>            总预算上限 USD（必须 > 0，不传则无上限）
   --concurrency <value>           并发数，默认 1
   --config <value>                eval.yaml 路径
   --control <value>               control variant 表达式
@@ -475,7 +475,7 @@ omk eval gold compare <report-id> --gold-dir gold-dataset
   --threshold <value>             verdict 阈值，默认 3.5
   --timeout <value>               单样本超时秒，默认 120
   --treatment <value>             treatment variant 列表，逗号分隔
-  --trivial-diff <value>          可忽略 diff 容差
+  --trivial-diff <value>          可忽略 diff 容差，0 表示不启用容差
   --verbose                       详细日志
 ```
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from 'node:path';
 import { Args, Flags } from '@oclif/core';
 import { bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
+import { numberStringParser } from '../oclif/parsers.js';
 import { CliExit } from '../lib/cli-exit.js';
 import { tCli } from '../lib/i18n.js';
 import type { Sample } from '../../types/index.js';
@@ -136,6 +137,7 @@ export default class Doctor extends BaseCommand {
         zh: '单次 LLM 会话超时秒数，默认 600(10 分钟）。',
         en: 'Single-session LLM timeout sec, default 600 (10 min).',
       }),
+      parse: numberStringParser('--timeout', { min: 1 }),
     }),
     html: Flags.string({
       description: bilingual({

--- a/src/cli/commands/eval/gold/compare.ts
+++ b/src/cli/commands/eval/gold/compare.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../../oclif/base-command.js';
 import { bilingual } from '../../../oclif/i18n.js';
+import { integerStringParser } from '../../../oclif/parsers.js';
 import { CliExit } from '../../../lib/cli-exit.js';
 import { DEFAULT_REPORTS_DIR } from '../../../lib/parse-run-config.js';
 import { requireEvaluationReport } from '../../../lib/shared.js';
@@ -45,9 +46,11 @@ export default class EvalGoldCompare extends BaseCommand {
         zh: 'bootstrap 重采样次数，默认 1000',
         en: 'Bootstrap resamples, default 1000',
       }),
+      parse: integerStringParser('--bootstrap-samples', { min: 100 }),
     }),
     seed: Flags.string({
       description: bilingual({ zh: 'bootstrap seed，可复现', en: 'Bootstrap seed for reproducibility' }),
+      parse: integerStringParser('--seed', { min: 0 }),
     }),
   };
 

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -1,6 +1,7 @@
 import { Flags } from '@oclif/core';
 import { bilingual } from '../../oclif/i18n.js';
 import { BaseCommand } from '../../oclif/base-command.js';
+import { enumStringParser, integerStringParser, numberStringParser } from '../../oclif/parsers.js';
 import { CliExit } from '../../lib/cli-exit.js';
 import { tCli, type CliLang } from '../../lib/i18n.js';
 import { parseRunConfig } from '../../lib/parse-run-config.js';
@@ -417,9 +418,11 @@ export default class Eval extends BaseCommand {
     }),
     concurrency: Flags.string({
       description: bilingual({ zh: '并发数，默认 1', en: 'Concurrency, default 1' }),
+      parse: integerStringParser('--concurrency', { min: 1 }),
     }),
     timeout: Flags.string({
       description: bilingual({ zh: '单样本超时秒，默认 120', en: 'Per-sample timeout sec, default 120' }),
+      parse: numberStringParser('--timeout', { min: 1 }),
     }),
     batch: Flags.boolean({
       description: bilingual({
@@ -447,6 +450,7 @@ export default class Eval extends BaseCommand {
     }),
     retry: Flags.string({
       description: bilingual({ zh: '失败 sample 重试次数', en: 'Per-sample retry count' }),
+      parse: integerStringParser('--retry', { min: 0 }),
     }),
     resume: Flags.string({
       description: bilingual({ zh: '从某次失败 run 续跑', en: 'Resume a previous failed run' }),
@@ -465,6 +469,7 @@ export default class Eval extends BaseCommand {
         zh: '被测 LLM 扩展思考预算 low/medium/high/xhigh/max（默认 low；跨 effort 报告不严格可比）。',
         en: 'Executor LLM reasoning effort low/medium/high/xhigh/max (default low; reports across efforts not strictly comparable).',
       }),
+      parse: enumStringParser('--effort', ['low', 'medium', 'high', 'xhigh', 'max']),
     }),
     'no-diagnostic': Flags.boolean({
       description: bilingual({
@@ -478,15 +483,18 @@ export default class Eval extends BaseCommand {
     }),
     repeat: Flags.string({
       description: bilingual({ zh: '每个 sample 重复跑 N 次', en: 'Repeat each sample N times' }),
+      parse: integerStringParser('--repeat', { min: 1 }),
     }),
     'judge-repeat': Flags.string({
       description: bilingual({ zh: '每个 dim 评 N 次', en: 'Judge each dim N times' }),
+      parse: integerStringParser('--judge-repeat', { min: 1 }),
     }),
     bootstrap: Flags.boolean({
       description: bilingual({ zh: '加 bootstrap CI', en: 'Add bootstrap CI' }),
     }),
     'bootstrap-samples': Flags.string({
       description: bilingual({ zh: 'bootstrap 重采样次数，默认 1000', en: 'Bootstrap resamples, default 1000' }),
+      parse: integerStringParser('--bootstrap-samples', { min: 100 }),
     }),
     'gold-dir': Flags.string({
       description: bilingual({ zh: 'gold dataset 目录', en: 'Gold dataset dir' }),
@@ -495,19 +503,24 @@ export default class Eval extends BaseCommand {
       description: bilingual({ zh: '关 length-debias（默认开）', en: 'Disable length-debias (default on)' }),
     }),
     'budget-usd': Flags.string({
-      description: bilingual({ zh: '总预算上限 USD', en: 'Total budget cap USD' }),
+      description: bilingual({ zh: '总预算上限 USD（必须 > 0，不传则无上限）', en: 'Total budget cap USD (must be > 0; omit for no cap)' }),
+      parse: numberStringParser('--budget-usd', { minExclusive: 0 }),
     }),
     'budget-per-sample-usd': Flags.string({
-      description: bilingual({ zh: '单 sample 预算上限 USD', en: 'Per-sample budget cap USD' }),
+      description: bilingual({ zh: '单 sample 预算上限 USD（必须 > 0，不传则无上限）', en: 'Per-sample budget cap USD (must be > 0; omit for no cap)' }),
+      parse: numberStringParser('--budget-per-sample-usd', { minExclusive: 0 }),
     }),
     'budget-per-sample-ms': Flags.string({
-      description: bilingual({ zh: '单 sample 时长上限 ms', en: 'Per-sample time cap ms' }),
+      description: bilingual({ zh: '单 sample 时长上限 ms（必须 > 0，不传则无上限）', en: 'Per-sample time cap ms (must be > 0; omit for no cap)' }),
+      parse: numberStringParser('--budget-per-sample-ms', { minExclusive: 0 }),
     }),
     threshold: Flags.string({
       description: bilingual({ zh: 'verdict 阈值，默认 3.5', en: 'Verdict threshold, default 3.5' }),
+      parse: numberStringParser('--threshold'),
     }),
     'trivial-diff': Flags.string({
-      description: bilingual({ zh: '可忽略 diff 容差', en: 'Trivial diff tolerance' }),
+      description: bilingual({ zh: '可忽略 diff 容差，0 表示不启用容差', en: 'Trivial diff tolerance; 0 disables tolerance' }),
+      parse: numberStringParser('--trivial-diff', { min: 0 }),
     }),
     'report-only': Flags.boolean({
       description: bilingual({

--- a/src/cli/commands/evolve.ts
+++ b/src/cli/commands/evolve.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { Args, Flags } from '@oclif/core';
 import { bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
+import { enumStringParser, integerStringParser, numberStringParser } from '../oclif/parsers.js';
 import { CliExit } from '../lib/cli-exit.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
 import { makeOnProgress } from '../lib/progress.js';
@@ -192,12 +193,14 @@ export default class Evolve extends BaseCommand {
     rounds: Flags.string({
       description: bilingual({ zh: '最大迭代轮数，默认 5', en: 'Max iteration rounds, default 5' }),
       default: '5',
+      parse: integerStringParser('--rounds', { min: 1 }),
     }),
     target: Flags.string({
       description: bilingual({
         zh: '目标 composite 分数，达到即停。不传则跑满 rounds',
         en: 'Target composite score; stop when reached. If omitted, runs all rounds.',
       }),
+      parse: numberStringParser('--target', { min: 0, max: 5 }),
     }),
     samples: Flags.string({
       description: bilingual({
@@ -230,10 +233,12 @@ export default class Evolve extends BaseCommand {
     concurrency: Flags.string({
       description: bilingual({ zh: '评测并发数，默认 1', en: 'Eval concurrency, default 1' }),
       default: '1',
+      parse: integerStringParser('--concurrency', { min: 1 }),
     }),
     timeout: Flags.string({
       description: bilingual({ zh: '单样本超时秒，默认 120', en: 'Per-sample timeout sec, default 120' }),
       default: '120',
+      parse: numberStringParser('--timeout', { min: 1 }),
     }),
     executor: Flags.string({
       description: bilingual({ zh: '执行器名，默认 claude', en: 'Executor name, default claude' }),
@@ -251,6 +256,7 @@ export default class Evolve extends BaseCommand {
         zh: 'reasoning effort: low/medium/high/xhigh/max',
         en: 'Reasoning effort: low/medium/high/xhigh/max',
       }),
+      parse: enumStringParser('--effort', ['low', 'medium', 'high', 'xhigh', 'max']),
     }),
     'no-diagnostic': Flags.boolean({
       description: bilingual({

--- a/src/cli/commands/observe/inbox.ts
+++ b/src/cli/commands/observe/inbox.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../oclif/base-command.js';
 import { bilingual } from '../../oclif/i18n.js';
+import { integerStringParser } from '../../oclif/parsers.js';
 import { type CliLang } from '../../lib/i18n.js';
 import type { ObserveInboxArgs, ObserveInboxFlags } from '../../lib/cmd-flags.js';
 
@@ -115,12 +116,14 @@ export default class ObserveInbox extends BaseCommand {
     }),
     limit: Flags.string({
       description: bilingual({ zh: '限制条数，默认 20', en: 'Result limit, default 20' }),
+      parse: integerStringParser('--limit', { min: 1 }),
     }),
     explore: Flags.string({
       description: bilingual({
         zh: '抽样 N 条 medium/low 长尾（replaces limit）',
         en: 'Sample N medium/low long-tail items (replaces limit)',
       }),
+      parse: integerStringParser('--explore', { min: 1 }),
     }),
     'include-noise': Flags.boolean({
       description: bilingual({

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -4,6 +4,7 @@ import yaml from 'js-yaml';
 import { Args, Flags } from '@oclif/core';
 import { bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
+import { integerStringParser } from '../oclif/parsers.js';
 import { CliExit } from '../lib/cli-exit.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
 import { DEFAULT_REPORTS_DIR } from '../lib/parse-run-config.js';
@@ -495,6 +496,7 @@ export default class Sample extends BaseCommand {
         zh: '生成样本条数。不传由 LLM 按 skill 类型自动决定。',
         en: 'Number of samples to generate. Defaults to LLM auto-selection by skill type.',
       }),
+      parse: integerStringParser('--count', { min: 1 }),
     }),
     model: Flags.string({
       description: bilingual({

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import { Flags } from '@oclif/core';
 import { bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
+import { integerStringParser } from '../oclif/parsers.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
 import { DEFAULT_REPORTS_DIR } from '../lib/parse-run-config.js';
 import type { ReportServer } from '../lib/shared.js';
@@ -121,6 +122,7 @@ export default class Studio extends BaseCommand {
         en: 'Listen port, default 7799. Pass 0 for OS-assigned',
       }),
       default: '7799',
+      parse: integerStringParser('--port', { min: 0, max: 65_535 }),
     }),
     host: Flags.string({
       description: bilingual({

--- a/src/cli/oclif/parsers.ts
+++ b/src/cli/oclif/parsers.ts
@@ -1,0 +1,119 @@
+import { resolveLang, type BiText } from './i18n.js';
+
+interface NumericStringParserOptions {
+  min?: number;
+  minExclusive?: number;
+  max?: number;
+}
+
+const DECIMAL_RE = /^-?(?:\d+(?:\.\d+)?|\.\d+)$/;
+
+function localize(text: BiText, lang = resolveLang(process.argv)): string {
+  return lang === 'zh' ? text.zh : text.en;
+}
+
+function requirement(flag: string, kind: 'integer' | 'number', options: NumericStringParserOptions): BiText {
+  const noun = kind === 'integer'
+    ? { zh: '整数', en: 'integer' }
+    : { zh: '数字', en: 'number' };
+  const article = kind === 'integer' ? 'an' : 'a';
+  if (options.min !== undefined && options.max !== undefined) {
+    return {
+      zh: `${flag} 必须是 ${options.min} 到 ${options.max} 之间的${noun.zh}`,
+      en: `${flag} must be ${article} ${noun.en} between ${options.min} and ${options.max}`,
+    };
+  }
+  if (options.min !== undefined) {
+    return {
+      zh: `${flag} 必须是大于等于 ${options.min} 的${noun.zh}`,
+      en: `${flag} must be ${article} ${noun.en} greater than or equal to ${options.min}`,
+    };
+  }
+  if (options.minExclusive !== undefined) {
+    return {
+      zh: `${flag} 必须是大于 ${options.minExclusive} 的${noun.zh}`,
+      en: `${flag} must be ${article} ${noun.en} greater than ${options.minExclusive}`,
+    };
+  }
+  if (options.max !== undefined) {
+    return {
+      zh: `${flag} 必须是小于等于 ${options.max} 的${noun.zh}`,
+      en: `${flag} must be ${article} ${noun.en} less than or equal to ${options.max}`,
+    };
+  }
+  return {
+    zh: `${flag} 必须是${noun.zh}`,
+    en: `${flag} must be ${article} ${noun.en}`,
+  };
+}
+
+function numericError(
+  flag: string,
+  input: string,
+  kind: 'integer' | 'number',
+  options: NumericStringParserOptions,
+  lang = resolveLang(process.argv),
+): Error {
+  const req = requirement(flag, kind, options);
+  return new Error(localize({
+    zh: `${req.zh}，实际为 ${JSON.stringify(input)}。`,
+    en: `${req.en} (got ${JSON.stringify(input)}).`,
+  }, lang));
+}
+
+export function integerStringParser(flag: string, options: NumericStringParserOptions = {}) {
+  const lang = resolveLang(process.argv);
+  return async (input: string): Promise<string> => {
+    const raw = input.trim();
+    if (!/^-?\d+$/.test(raw)) {
+      throw numericError(flag, input, 'integer', options, lang);
+    }
+    const value = Number(raw);
+    if (!Number.isSafeInteger(value)) {
+      throw numericError(flag, input, 'integer', options, lang);
+    }
+    if (options.min !== undefined && value < options.min) {
+      throw numericError(flag, input, 'integer', options, lang);
+    }
+    if (options.minExclusive !== undefined && value <= options.minExclusive) {
+      throw numericError(flag, input, 'integer', options, lang);
+    }
+    if (options.max !== undefined && value > options.max) {
+      throw numericError(flag, input, 'integer', options, lang);
+    }
+    return input;
+  };
+}
+
+export function numberStringParser(flag: string, options: NumericStringParserOptions = {}) {
+  const lang = resolveLang(process.argv);
+  return async (input: string): Promise<string> => {
+    const raw = input.trim();
+    const value = Number(raw);
+    if (!DECIMAL_RE.test(raw) || !Number.isFinite(value)) {
+      throw numericError(flag, input, 'number', options, lang);
+    }
+    if (options.min !== undefined && value < options.min) {
+      throw numericError(flag, input, 'number', options, lang);
+    }
+    if (options.minExclusive !== undefined && value <= options.minExclusive) {
+      throw numericError(flag, input, 'number', options, lang);
+    }
+    if (options.max !== undefined && value > options.max) {
+      throw numericError(flag, input, 'number', options, lang);
+    }
+    return input;
+  };
+}
+
+export function enumStringParser(flag: string, values: readonly string[]) {
+  const lang = resolveLang(process.argv);
+  return async (input: string): Promise<string> => {
+    if (values.includes(input)) return input;
+    const joined = values.join(' / ');
+    throw new Error(localize({
+      zh: `${flag} 必须是 ${joined} 之一，实际为 ${JSON.stringify(input)}。`,
+      en: `${flag} must be one of ${joined} (got ${JSON.stringify(input)}).`,
+    }, lang));
+  };
+}

--- a/test/cli/oclif-eval.test.ts
+++ b/test/cli/oclif-eval.test.ts
@@ -96,6 +96,28 @@ describe('oclif eval', () => {
     }
   });
 
+  it('eval 非法 --repeat --lang en → exit 2 + English parser error', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'eval', '--repeat', 'abc', '--lang', 'en']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+      assert.match(e.stderr, /--repeat[\s\S]*integer[\s\S]*1/, `stderr missing en parser error:\n${e.stderr}`);
+    }
+  });
+
+  it('eval gold compare 非法 --bootstrap-samples → exit 2 + 中文 parser 错误', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'eval', 'gold', 'compare', 'report-1', '--bootstrap-samples', '10']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+      assert.match(e.stderr, /--bootstrap-samples(?=[\s\S]*整数)(?=[\s\S]*100)/, `stderr missing zh parser error:\n${e.stderr}`);
+    }
+  });
+
   it('bare `eval gold`(无 sub-sub)→ exit 1 + 打 usage', async () => {
     // EvalGold 薄壳保证 oclif 不把 eval gold 当 topic-only(默认 exit 0),
     // 跟 legacy execute([]) 的 CliExit(1) 行为对齐。

--- a/test/cli/oclif-evolve.test.ts
+++ b/test/cli/oclif-evolve.test.ts
@@ -44,6 +44,28 @@ describe('oclif evolve', () => {
     }
   });
 
+  it('非法 --rounds → exit 2 + 中文 parser 错误', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'evolve', 'skills/demo/SKILL.md', '--rounds', 'nope']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+      assert.match(e.stderr, /--rounds(?=[\s\S]*整数)(?=[\s\S]*1)/, `stderr missing zh parser error:\n${e.stderr}`);
+    }
+  });
+
+  it('非法 --effort --lang en → exit 2 + English parser error', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'evolve', 'skills/demo/SKILL.md', '--effort', 'turbo', '--lang', 'en']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+      assert.match(e.stderr, /--effort[\s\S]*low[\s\S]*medium[\s\S]*high[\s\S]*xhigh[\s\S]*max/, `stderr missing en parser error:\n${e.stderr}`);
+    }
+  });
+
   it('缺 skillPath positional → exit 2(oclif required-args)', async () => {
     try {
       await execFileAsync('node', [CLI, 'evolve']);

--- a/test/cli/oclif-observe.test.ts
+++ b/test/cli/oclif-observe.test.ts
@@ -78,6 +78,17 @@ describe('oclif observe', () => {
     }
   });
 
+  it('observe inbox 非法 --limit → exit 2 + 中文 parser 错误', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'observe', 'inbox', '--limit', '0']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+      assert.match(e.stderr, /--limit(?=[\s\S]*整数)(?=[\s\S]*1)/, `stderr missing zh parser error:\n${e.stderr}`);
+    }
+  });
+
   it('observe ingest --output-dir "" → exit 2(空串不被 silent fallback 到 cwd)', async () => {
     // resolve('') === process.cwd();没拦住空串就会让 shell 里 `--output-dir "$DIR"`
     // 而 $DIR 未设的情况把 observation 报告写到任意 cwd。锁住业务侧 trim() 判 +

--- a/test/cli/oclif-parsers.test.ts
+++ b/test/cli/oclif-parsers.test.ts
@@ -1,0 +1,114 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import Eval from '../../src/cli/commands/eval/index.js';
+import EvalGoldCompare from '../../src/cli/commands/eval/gold/compare.js';
+import Evolve from '../../src/cli/commands/evolve.js';
+import Sample from '../../src/cli/commands/sample.js';
+import Studio from '../../src/cli/commands/studio.js';
+import ObserveInbox from '../../src/cli/commands/observe/inbox.js';
+
+interface FlagLike {
+  parse?: unknown;
+}
+
+type FlagMap = Record<string, FlagLike>;
+type ParseFn = (input: string) => Promise<string>;
+
+function flagsOf(commandFlags: unknown): FlagMap {
+  return commandFlags as FlagMap;
+}
+
+function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function parserFor(flags: FlagMap, name: string): ParseFn {
+  const parse = flags[name]?.parse;
+  assert.equal(typeof parse, 'function', `${name} should define a parser`);
+  return parse as ParseFn;
+}
+
+async function assertParserWired(flags: FlagMap, name: string, invalidValue: string): Promise<void> {
+  await assert.rejects(
+    () => parserFor(flags, name)(invalidValue),
+    new RegExp(`--${escapeRegex(name)}`),
+    `${name} parser should report its flag name`,
+  );
+}
+
+describe('oclif custom parsers', () => {
+  it('wires every intended parser onto command flags', async () => {
+    for (const name of [
+      'concurrency',
+      'retry',
+      'repeat',
+      'judge-repeat',
+      'bootstrap-samples',
+    ]) {
+      await assertParserWired(flagsOf(Eval.flags), name, '1.5');
+    }
+    for (const name of [
+      'timeout',
+      'budget-usd',
+      'budget-per-sample-usd',
+      'budget-per-sample-ms',
+      'threshold',
+      'trivial-diff',
+    ]) {
+      await assertParserWired(flagsOf(Eval.flags), name, 'not-a-number');
+    }
+    await assertParserWired(flagsOf(Eval.flags), 'effort', 'turbo');
+
+    for (const name of ['rounds', 'concurrency']) {
+      await assertParserWired(flagsOf(Evolve.flags), name, '1.5');
+    }
+    for (const name of ['target', 'timeout']) {
+      await assertParserWired(flagsOf(Evolve.flags), name, 'not-a-number');
+    }
+    await assertParserWired(flagsOf(Evolve.flags), 'effort', 'turbo');
+
+    await assertParserWired(flagsOf(Sample.flags), 'count', '1.5');
+    await assertParserWired(flagsOf(Studio.flags), 'port', '1.5');
+    await assertParserWired(flagsOf(ObserveInbox.flags), 'limit', '1.5');
+    await assertParserWired(flagsOf(ObserveInbox.flags), 'explore', '1.5');
+    await assertParserWired(flagsOf(EvalGoldCompare.flags), 'bootstrap-samples', '1.5');
+    await assertParserWired(flagsOf(EvalGoldCompare.flags), 'seed', '1.5');
+  });
+
+  it('checks inclusive integer boundaries', async () => {
+    const parsePort = parserFor(flagsOf(Studio.flags), 'port');
+    assert.equal(await parsePort('0'), '0');
+    assert.equal(await parsePort('65535'), '65535');
+    await assert.rejects(() => parsePort('-1'), /--port.*0.*65535/);
+    await assert.rejects(() => parsePort('65536'), /--port.*0.*65535/);
+  });
+
+  it('rejects non-decimal number literals', async () => {
+    const parseThreshold = parserFor(flagsOf(Eval.flags), 'threshold');
+    assert.equal(await parseThreshold('0.5'), '0.5');
+    await assert.rejects(() => parseThreshold('0x10'), /--threshold/);
+    await assert.rejects(() => parseThreshold('1e3'), /--threshold/);
+  });
+
+  it('distinguishes positive caps from zero-tolerance values', async () => {
+    const parseBudget = parserFor(flagsOf(Eval.flags), 'budget-usd');
+    const parseTrivialDiff = parserFor(flagsOf(Eval.flags), 'trivial-diff');
+    assert.equal(await parseBudget('0.0001'), '0.0001');
+    await assert.rejects(() => parseBudget('0'), /--budget-usd[\s\S]*大于 0/);
+    assert.equal(await parseTrivialDiff('0'), '0');
+  });
+
+  it('checks target score bounds', async () => {
+    const parseTarget = parserFor(flagsOf(Evolve.flags), 'target');
+    assert.equal(await parseTarget('0'), '0');
+    assert.equal(await parseTarget('5'), '5');
+    await assert.rejects(() => parseTarget('-1'), /--target.*0.*5/);
+    await assert.rejects(() => parseTarget('1000'), /--target.*0.*5/);
+  });
+
+  it('keeps bootstrap seed non-negative', async () => {
+    const parseSeed = parserFor(flagsOf(EvalGoldCompare.flags), 'seed');
+    assert.equal(await parseSeed('0'), '0');
+    await assert.rejects(() => parseSeed('-1'), /--seed[\s\S]*0/);
+  });
+});

--- a/test/cli/oclif-sample.test.ts
+++ b/test/cli/oclif-sample.test.ts
@@ -62,6 +62,17 @@ describe('oclif sample', () => {
     }
   });
 
+  it('非法 --count --lang en → exit 2 + English parser error', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'sample', 'skills/demo/SKILL.md', '--count', 'abc', '--lang', 'en']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+      assert.match(e.stderr, /--count[\s\S]*integer[\s\S]*1/, `stderr missing en parser error:\n${e.stderr}`);
+    }
+  });
+
   it('--batch + 不存在的 skill-dir → exit 1', async () => {
     try {
       await execFileAsync('node', [CLI, 'sample', '--batch', '--skill-dir', '/tmp/omk-nonexistent-skill-dir-xyz']);

--- a/test/cli/oclif-studio.test.ts
+++ b/test/cli/oclif-studio.test.ts
@@ -44,4 +44,15 @@ describe('oclif studio', () => {
       assert.equal(e.code, 2);
     }
   });
+
+  it('非法 --port → exit 2 + 中文 parser 错误', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'studio', '--port', '70000']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+      assert.match(e.stderr, /--port(?=[\s\S]*整数)(?=[\s\S]*0)(?=[\s\S]*65535)/, `stderr missing zh parser error:\n${e.stderr}`);
+    }
+  });
 });


### PR DESCRIPTION
## 用户影响
非法 CLI 参数会在 oclif parse 边界直接以 exit 2 失败，并按 `--lang` / `OMK_LANG` 输出中文或英文错误。此前部分非法数值会静默回退到默认值，容易让用户误以为本次评测使用了自己传入的配置。

## 迁移说明
脚本里如果传了非法数值或非法 `--effort`，需要改成合法值。受影响的主要参数包括 `eval` / `evolve` / `sample` / `doctor` / `studio` / `observe inbox` / `eval gold compare` 中的数值参数，以及 `eval` / `evolve` 的 `--effort` 枚举。

预算类上限现在要求显式正数；不传表示不设置上限。`--trivial-diff 0` 保留合法，并在帮助文档里明确表示不启用容差。`--target` 约束在 composite 分数区间 `[0, 5]`，`--seed` 要求非负，数字参数只接受十进制写法，`0x10` 和 `1e3` 这类写法会被拒绝。

## 测量学说明
这次改动不改变合法参数下的评测语义；它只阻止非法 CLI 输入被静默替换成默认值，减少报告参数与用户意图不一致的问题。

## 范围外
未处理 `cmd-flags.ts` 与 deep business function 的 `string` vs `string | undefined` 收口，也未抽 `LANG_FLAG` 常量。
