### PR TITLE
chore(cli): 收口 required 与 lang flag 声明

### DIFF
--- a/.claude/skills/omk/references/commands.md
+++ b/.claude/skills/omk/references/commands.md
@@ -78,7 +78,7 @@ omk eval [flags]
 - `--gold-dir` `option`:gold dataset 目录
 - `--judge-models` `option`:评委配置，格式 executor:model[,...]，例 claude:haiku 或 claude:opus,openai:gpt-4o(≥ 2 个 = ensemble）。默认 <executor>:haiku。
 - `--judge-repeat` `option`:每个 dim 评 N 次
-- `--lang` `option` (默认 `zh`):输出语言 zh|en
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--layered-stats` `boolean`:输出分层统计
 - `--mcp-config` `option`:MCP 配置文件路径
 - `--model` `option`:被测模型
@@ -151,7 +151,7 @@ omk eval gold compare <reportId> [flags]
 
 - `--bootstrap-samples` `option`:bootstrap 重采样次数，默认 1000
 - `--gold-dir` `option`:gold dataset 目录，必填
-- `--lang` `option` (默认 `zh`):输出语言 zh|en
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--reports-dir` `option`:报告目录，默认 ~/.oh-my-knowledge/reports
 - `--seed` `option`:bootstrap seed，可复现
 - `--variant` `option`:只比对指定 variant，默认全比
@@ -169,7 +169,7 @@ omk eval gold init [flags]
 **Flags:**
 
 - `--annotator` `option`:标注者名，写入 metadata.yaml
-- `--lang` `option` (默认 `zh`):输出语言 zh|en
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--out` `option` (默认 `./gold-dataset`):输出目录，默认 ./gold-dataset
 
 ## omk eval gold validate
@@ -188,7 +188,7 @@ omk eval gold validate <dir> [flags]
 
 **Flags:**
 
-- `--lang` `option` (默认 `zh`):输出语言 zh|en
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 
 ## omk evolve
 
@@ -211,7 +211,7 @@ omk evolve <skillPath> [flags]
 - `--executor` `option` (默认 `claude`):执行器名，默认 claude
 - `--improve-model` `option` (默认 `sonnet`):负责重写 skill 的 LLM，默认 sonnet
 - `--judge-models` `option` (默认 `claude:haiku`):评委 model（单评委约束），格式 executor:model。默认 claude:haiku
-- `--lang` `option` (默认 `zh`):输出语言 zh|en
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--model` `option` (默认 `sonnet`):被评测的 LLM，默认 sonnet
 - `--no-diagnostic` `boolean`:关 LLM diagnostic 调用
 - `--rounds` `option` (默认 `5`):最大迭代轮数，默认 5
@@ -285,7 +285,7 @@ omk observe [sessionsDir] [flags]
 
 - `--from` `option`:起始时间 ISO，优先级高于 --last
 - `--kb` `option`:知识库 root，启用 KB-aware 分析
-- `--lang` `option` (默认 `zh`):输出语言 zh|en
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--last` `option`:时间窗(7d / 24h / 30m）
 - `--output-dir` `option`:分析结果输出目录
 - `--skills` `option`:只看指定 skill，逗号分隔
@@ -316,7 +316,7 @@ omk observe inbox [flags]
 - `--include-noise` `boolean`:explore 时也包含 noise 桶
 - `--input-dir` `option`:inbox 数据目录，默认 .omk/observations（项目级，相对于 cwd）；目录不存在时兜底读 ~/.oh-my-knowledge/observations。
 - `--json` `boolean`:JSON 格式输出
-- `--lang` `option` (默认 `zh`):输出语言 zh|en
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--limit` `option`:限制条数，默认 20
 - `--skill` `option`:只看指定 skill
 
@@ -336,7 +336,7 @@ omk observe ingest <traceDir> [flags]
 
 **Flags:**
 
-- `--lang` `option` (默认 `zh`):输出语言 zh|en
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--output-dir` `option`:输出目录，默认 .omk/observations（项目级，相对于 cwd）。
 
 ## omk observe show
@@ -356,7 +356,7 @@ omk observe show <inboxId> [flags]
 **Flags:**
 
 - `--input-dir` `option`:inbox 数据目录
-- `--lang` `option` (默认 `zh`):输出语言 zh|en
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 
 ## omk sample
 
@@ -419,7 +419,7 @@ omk studio [flags]
 - `--analyses-dir` `option`:分析数据目录（可选）
 - `--dev` `boolean`:dev 模式：子进程启动 + 热更新
 - `--host` `option`:监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
-- `--lang` `option` (默认 `zh`):输出语言 zh|en
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--no-open` `boolean`:不自动打开浏览器
 - `--observations-dir` `option`:观测数据目录（可选）
 - `--port` `option` (默认 `7799`):监听端口，默认 7799。传 0 让 OS 分配

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
   --gold-dir <value>              Gold dataset dir
   --judge-models <value>          Judge config: executor:model[,...]. e.g. claude:haiku or claude:opus,openai:gpt-4o (≥ 2 = ensemble). Default <executor>:haiku.
   --judge-repeat <value>          Judge each dim N times
-  --lang <value>                  Output language zh|en
+  --lang <value>                  Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --layered-stats                 Emit layered stats
   --mcp-config <value>            MCP config path
   --model <value>                 Evaluated model
@@ -508,7 +508,7 @@ omk observe ~/.claude/projects/my-project --kb /path/to/project
 ```text
   --from <value>        Start time ISO, overrides --last
   --kb <value>          KB root, enables KB-aware analysis
-  --lang <value>        Output language zh|en
+  --lang <value>        Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --last <value>        Time window (7d / 24h / 30m)
   --output-dir <value>  Analysis output directory
   --skills <value>      Filter to specific skills, comma-separated
@@ -569,7 +569,7 @@ omk evolve skills/foo.md --rounds 10 --target 4.5
   --executor <value>       Executor name, default claude
   --improve-model <value>  LLM that rewrites the skill, default sonnet
   --judge-models <value>   Judge model (single judge required), executor:model format. Default claude:haiku
-  --lang <value>           Output language zh|en
+  --lang <value>           Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --model <value>          Evaluated LLM, default sonnet
   --no-diagnostic          Disable diagnostic LLM call
   --rounds <value>         Max iteration rounds, default 5
@@ -634,7 +634,7 @@ omk studio --no-open
   --analyses-dir <value>      Analyses dir (optional)
   --dev                       Dev mode: child process with hot reload
   --host <value>              Listen host, default localhost. Use 0.0.0.0 to expose to LAN
-  --lang <value>              Output language zh|en
+  --lang <value>              Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --no-open                   Do not auto-open browser
   --observations-dir <value>  Observations dir (optional)
   --port <value>              Listen port, default 7799. Pass 0 for OS-assigned

--- a/README.zh.md
+++ b/README.zh.md
@@ -451,7 +451,7 @@ omk eval gold compare <report-id> --gold-dir gold-dataset
   --gold-dir <value>              gold dataset 目录
   --judge-models <value>          评委配置，格式 executor:model[,...]，例 claude:haiku 或 claude:opus,openai:gpt-4o(≥ 2 个 = ensemble）。默认 <executor>:haiku。
   --judge-repeat <value>          每个 dim 评 N 次
-  --lang <value>                  输出语言 zh|en
+  --lang <value>                  输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --layered-stats                 输出分层统计
   --mcp-config <value>            MCP 配置文件路径
   --model <value>                 被测模型
@@ -508,7 +508,7 @@ omk observe ~/.claude/projects/my-project --kb /path/to/project
 ```text
   --from <value>        起始时间 ISO，优先级高于 --last
   --kb <value>          知识库 root，启用 KB-aware 分析
-  --lang <value>        输出语言 zh|en
+  --lang <value>        输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --last <value>        时间窗(7d / 24h / 30m）
   --output-dir <value>  分析结果输出目录
   --skills <value>      只看指定 skill，逗号分隔
@@ -569,7 +569,7 @@ omk evolve skills/foo.md --rounds 10 --target 4.5
   --executor <value>       执行器名，默认 claude
   --improve-model <value>  负责重写 skill 的 LLM，默认 sonnet
   --judge-models <value>   评委 model（单评委约束），格式 executor:model。默认 claude:haiku
-  --lang <value>           输出语言 zh|en
+  --lang <value>           输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --model <value>          被评测的 LLM，默认 sonnet
   --no-diagnostic          关 LLM diagnostic 调用
   --rounds <value>         最大迭代轮数，默认 5
@@ -634,7 +634,7 @@ omk studio --no-open
   --analyses-dir <value>      分析数据目录（可选）
   --dev                       dev 模式：子进程启动 + 热更新
   --host <value>              监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
-  --lang <value>              输出语言 zh|en
+  --lang <value>              输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --no-open                   不自动打开浏览器
   --observations-dir <value>  观测数据目录（可选）
   --port <value>              监听端口，默认 7799。传 0 让 OS 分配

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,7 +1,7 @@
 import { existsSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { Args, Flags } from '@oclif/core';
-import { bilingual } from '../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { numberStringParser } from '../oclif/parsers.js';
 import { CliExit } from '../lib/cli-exit.js';
@@ -93,13 +93,7 @@ export default class Doctor extends BaseCommand {
   };
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({
-        zh: '输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。',
-        en: 'Output language zh|en. Priority: CLI > OMK_LANG env > zh.',
-      }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     json: Flags.boolean({
       description: bilingual({
         zh: 'JSON 输出到 stdout，适合 CI / 外部脚本消费。',

--- a/src/cli/commands/eval/gold/compare.ts
+++ b/src/cli/commands/eval/gold/compare.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../../oclif/base-command.js';
-import { bilingual } from '../../../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../../../oclif/i18n.js';
 import { integerStringParser } from '../../../oclif/parsers.js';
 import { CliExit } from '../../../lib/cli-exit.js';
 import { DEFAULT_REPORTS_DIR } from '../../../lib/parse-run-config.js';
@@ -22,10 +22,7 @@ export default class EvalGoldCompare extends BaseCommand {
   };
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({ zh: '输出语言 zh|en', en: 'Output language zh|en' }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     'gold-dir': Flags.string({
       description: bilingual({ zh: 'gold dataset 目录，必填', en: 'Gold dataset dir (required)' }),
     }),

--- a/src/cli/commands/eval/gold/index.ts
+++ b/src/cli/commands/eval/gold/index.ts
@@ -7,9 +7,8 @@
 // config.findCommand('eval:gold')) 让 LangAwareHelp 按 --lang 渲染当前 topic 的
 // description + sub-sub 列表(init / validate / compare)。
 
-import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../../oclif/base-command.js';
-import { bilingual } from '../../../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../../../oclif/i18n.js';
 
 export default class EvalGold extends BaseCommand {
   static description = bilingual({
@@ -18,13 +17,7 @@ export default class EvalGold extends BaseCommand {
   });
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({
-        zh: '输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。',
-        en: 'Output language zh|en. Priority: CLI > OMK_LANG env > zh.',
-      }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
   };
 
   async run(): Promise<void> {

--- a/src/cli/commands/eval/gold/init.ts
+++ b/src/cli/commands/eval/gold/init.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../../oclif/base-command.js';
-import { bilingual } from '../../../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../../../oclif/i18n.js';
 import { CliExit } from '../../../lib/cli-exit.js';
 
 export default class EvalGoldInit extends BaseCommand {
@@ -10,10 +10,7 @@ export default class EvalGoldInit extends BaseCommand {
   });
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({ zh: '输出语言 zh|en', en: 'Output language zh|en' }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     out: Flags.string({
       description: bilingual({
         zh: '输出目录，默认 ./gold-dataset',

--- a/src/cli/commands/eval/gold/validate.ts
+++ b/src/cli/commands/eval/gold/validate.ts
@@ -1,6 +1,6 @@
-import { Args, Flags } from '@oclif/core';
+import { Args } from '@oclif/core';
 import { BaseCommand } from '../../../oclif/base-command.js';
-import { bilingual } from '../../../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../../../oclif/i18n.js';
 import { CliExit } from '../../../lib/cli-exit.js';
 
 export default class EvalGoldValidate extends BaseCommand {
@@ -20,10 +20,7 @@ export default class EvalGoldValidate extends BaseCommand {
   };
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({ zh: '输出语言 zh|en', en: 'Output language zh|en' }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
   };
 
   async run(): Promise<void> {

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core';
-import { bilingual } from '../../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../../oclif/i18n.js';
 import { BaseCommand } from '../../oclif/base-command.js';
 import { enumStringParser, integerStringParser, numberStringParser } from '../../oclif/parsers.js';
 import { CliExit } from '../../lib/cli-exit.js';
@@ -361,10 +361,7 @@ export default class Eval extends BaseCommand {
   ];
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({ zh: '输出语言 zh|en', en: 'Output language zh|en' }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     // ── 实验角色 ──
     control: Flags.string({
       description: bilingual({ zh: 'control variant 表达式', en: 'Control variant expr' }),

--- a/src/cli/commands/evolve.ts
+++ b/src/cli/commands/evolve.ts
@@ -1,7 +1,7 @@
 import { resolve, join } from 'node:path';
 import { existsSync } from 'node:fs';
 import { Args, Flags } from '@oclif/core';
-import { bilingual } from '../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { enumStringParser, integerStringParser, numberStringParser } from '../oclif/parsers.js';
 import { CliExit } from '../lib/cli-exit.js';
@@ -69,7 +69,7 @@ export async function runEvolve(
     throw new CliExit(1);
   }
 
-  let samplesFile: string = flags.samples ?? 'eval-samples.json';
+  let samplesFile: string = flags.samples;
   if (samplesFile === 'eval-samples.json' && !existsSync(resolve(samplesFile))) {
     if (existsSync(resolve('eval-samples.yaml'))) samplesFile = 'eval-samples.yaml';
     else if (existsSync(resolve('eval-samples.yml'))) samplesFile = 'eval-samples.yml';
@@ -186,10 +186,7 @@ export default class Evolve extends BaseCommand {
   };
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({ zh: '输出语言 zh|en', en: 'Output language zh|en' }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     rounds: Flags.string({
       description: bilingual({ zh: '最大迭代轮数，默认 5', en: 'Max iteration rounds, default 5' }),
       default: '5',

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,6 +1,6 @@
 import { resolve, join } from 'node:path';
-import { Args, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../oclif/i18n.js';
+import { Args } from '@oclif/core';
+import { LANG_FLAG, bilingual, resolveLang } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { tCli } from '../lib/i18n.js';
 
@@ -131,13 +131,7 @@ export default class Init extends BaseCommand {
   };
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({
-        zh: '输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。',
-        en: 'Output language zh|en. Priority: CLI > OMK_LANG env > zh.',
-      }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
   };
 
   async run(): Promise<void> {

--- a/src/cli/commands/observe/inbox.ts
+++ b/src/cli/commands/observe/inbox.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../oclif/base-command.js';
-import { bilingual } from '../../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../../oclif/i18n.js';
 import { integerStringParser } from '../../oclif/parsers.js';
 import { type CliLang } from '../../lib/i18n.js';
 import type { ObserveInboxArgs, ObserveInboxFlags } from '../../lib/cmd-flags.js';
@@ -101,10 +101,7 @@ export default class ObserveInbox extends BaseCommand {
   });
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({ zh: '输出语言 zh|en', en: 'Output language zh|en' }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     'input-dir': Flags.string({
       description: bilingual({
         zh: 'inbox 数据目录，默认 .omk/observations（项目级，相对于 cwd）；目录不存在时兜底读 ~/.oh-my-knowledge/observations。',

--- a/src/cli/commands/observe/index.ts
+++ b/src/cli/commands/observe/index.ts
@@ -1,6 +1,6 @@
 import { resolve, join } from 'node:path';
 import { Args, Flags } from '@oclif/core';
-import { bilingual } from '../../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../../oclif/i18n.js';
 import { BaseCommand } from '../../oclif/base-command.js';
 import { CliExit } from '../../lib/cli-exit.js';
 import { tCli } from '../../lib/i18n.js';
@@ -36,10 +36,7 @@ export default class Observe extends BaseCommand {
   };
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({ zh: '输出语言 zh|en', en: 'Output language zh|en' }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     kb: Flags.string({
       description: bilingual({ zh: '知识库 root，启用 KB-aware 分析', en: 'KB root, enables KB-aware analysis' }),
     }),

--- a/src/cli/commands/observe/ingest.ts
+++ b/src/cli/commands/observe/ingest.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../oclif/base-command.js';
-import { bilingual } from '../../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../../oclif/i18n.js';
 import { CliExit } from '../../lib/cli-exit.js';
 
 export default class ObserveIngest extends BaseCommand {
@@ -21,10 +21,7 @@ export default class ObserveIngest extends BaseCommand {
   };
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({ zh: '输出语言 zh|en', en: 'Output language zh|en' }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     'output-dir': Flags.string({
       description: bilingual({
         zh: '输出目录，默认 .omk/observations（项目级，相对于 cwd）。',

--- a/src/cli/commands/observe/show.ts
+++ b/src/cli/commands/observe/show.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../oclif/base-command.js';
-import { bilingual } from '../../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../../oclif/i18n.js';
 import { CliExit } from '../../lib/cli-exit.js';
 
 export default class ObserveShow extends BaseCommand {
@@ -21,10 +21,7 @@ export default class ObserveShow extends BaseCommand {
   };
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({ zh: '输出语言 zh|en', en: 'Output language zh|en' }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     'input-dir': Flags.string({
       description: bilingual({
         zh: 'inbox 数据目录',

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -2,7 +2,7 @@ import { resolve, join, basename, dirname, extname } from 'node:path';
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import yaml from 'js-yaml';
 import { Args, Flags } from '@oclif/core';
-import { bilingual } from '../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { integerStringParser } from '../oclif/parsers.js';
 import { CliExit } from '../lib/cli-exit.js';
@@ -178,7 +178,7 @@ async function runSampleFix(
   const { fixSamples } = await import('../../authoring/sample-fixer.js');
   const { createFileStore } = await import('../../server/report-store.js');
 
-  const model = flags.model ?? 'opus';
+  const model = flags.model;
   const reportsDir = resolve(flags['reports-dir'] ?? DEFAULT_REPORTS_DIR);
 
   const skillPath = args.skillPath;
@@ -477,13 +477,7 @@ export default class Sample extends BaseCommand {
   };
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({
-        zh: '输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。',
-        en: 'Output language zh|en. Priority: CLI > OMK_LANG env > zh.',
-      }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     batch: Flags.boolean({
       description: bilingual({
         zh: '批量模式：扫 --skill-dir 下所有缺 samples 的 skill，逐个生成。',

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path';
 import { Flags } from '@oclif/core';
-import { bilingual } from '../oclif/i18n.js';
+import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { integerStringParser } from '../oclif/parsers.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
@@ -112,10 +112,7 @@ export default class Studio extends BaseCommand {
   ];
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({ zh: '输出语言 zh|en', en: 'Output language zh|en' }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     port: Flags.string({
       description: bilingual({
         zh: '监听端口，默认 7799。传 0 让 OS 分配',

--- a/src/cli/oclif/i18n.ts
+++ b/src/cli/oclif/i18n.ts
@@ -15,6 +15,7 @@
 // 跟进(Phase B):改 oclif 上游让 errors/handle.js 尊重 helpClass / 接受双语 dump
 // 不再 fix(早期 init hook description mutate 方案 PR #124 已删,接受 BREAKING-CLI)。
 
+import { Flags } from '@oclif/core';
 import { getCliLang, parseLangFromArgv } from '../lib/i18n.js';
 import type { CliLang } from '../lib/i18n.js';
 
@@ -51,6 +52,14 @@ export function bilingual(text: BiText): string {
   }
   return `${text.zh}\n${text.en}`;
 }
+
+export const LANG_FLAG = Flags.string({
+  description: bilingual({
+    zh: '输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。',
+    en: 'Output language zh|en. Priority: CLI > OMK_LANG env > zh.',
+  }),
+  default: 'zh',
+});
 
 /** 按 lang 把双语串切回单语;只有 1 行的串原样返回。 */
 export function pickLang(text: string | undefined, lang: Lang): string | undefined {


### PR DESCRIPTION
## 用户影响
无 CLI 行为变化。`omk evolve` 和 `omk sample --fix` 仍使用 oclif flag default 注入的默认值；各命令的 `--lang` help 文案统一补齐 `CLI > OMK_LANG env > zh` 优先级说明。

## 迁移说明
不需要迁移。

## 测量学说明
不改变合法参数下的评测语义，只移除业务函数里永远不会触发的 `??` fallback，让实现和 `cmd-flags.ts` 中 required string 类型保持一致。

## 实现说明
新增共享 `LANG_FLAG` 常量，14 个 oclif Command 统一复用同一份 lang flag 声明；没有重新引入会损失 `InferredFlags` narrowing 的 wrapper factory。

## 范围外
不调整其他真正 optional flag 的 fallback。
