### PR TITLE
fix(cli,observability): 收口 PR #128 引入的 3 个发版阻断

### DIFF
--- a/.claude/skills/omk/references/commands.md
+++ b/.claude/skills/omk/references/commands.md
@@ -423,21 +423,21 @@ omk sample skills/my-skill/SKILL.md --fix
 **用法:**
 
 ```bash
-omk skill-extract [skillName] [flags]
+omk skill-extract <skillName> [flags]
 ```
 
 **参数:**
 
-- `skillName`(可选):skill 名称
+- `skillName`(必填):skill 名称
 
 **Flags:**
 
 - `--input-dir` `option`:observation 数据目录
 - `--json` `boolean`:JSON 格式输出
-- `--lang` `option` (默认 `zh`):输出语言 zh|en
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--reason` `option`:人工判断原因
 - `--review` `option`:要确认或否决的软标准 ID
-- `--status` `option`:确认状态：author_confirmed / rejected / pending_review
+- `--status` `option`:确认状态：author_confirmed / rejected / pending_review（也接受 confirm / confirmed / reject / pending 别名）
 
 ## omk studio
 

--- a/README.md
+++ b/README.md
@@ -569,10 +569,10 @@ omk skill-extract demo-create --review soft-xxx --status rejected --reason "not 
 ```text
   --input-dir <value>  Observation data directory
   --json               JSON output
-  --lang <value>       Output language zh|en
+  --lang <value>       Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --reason <value>     Manual review reason
   --review <value>     Soft standard id to review
-  --status <value>     Review status: author_confirmed / rejected / pending_review
+  --status <value>     Review status: author_confirmed / rejected / pending_review (also accepts aliases: confirm / confirmed / reject / pending)
 ```
 
 For full descriptions: `omk skill-extract --help`.

--- a/README.zh.md
+++ b/README.zh.md
@@ -569,10 +569,10 @@ omk skill-extract demo-create --review soft-xxx --status rejected --reason "不�
 ```text
   --input-dir <value>  observation 数据目录
   --json               JSON 格式输出
-  --lang <value>       输出语言 zh|en
+  --lang <value>       输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --reason <value>     人工判断原因
   --review <value>     要确认或否决的软标准 ID
-  --status <value>     确认状态：author_confirmed / rejected / pending_review
+  --status <value>     确认状态：author_confirmed / rejected / pending_review（也接受 confirm / confirmed / reject / pending 别名）
 ```
 
 完整描述见 `omk skill-extract --help`。

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "node": ">=22"
   },
   "files": [
-    "dist/src/"
+    "dist/src/",
+    "docs/prompts/"
   ],
   "scripts": {
     "build": "tsc && node -e \"const fs=require('node:fs'),p=require('node:path');const d='dist/src/eval-core/mock-hook.cjs';fs.mkdirSync(p.dirname(d),{recursive:true});fs.copyFileSync('src/eval-core/mock-hook.cjs',d)\"",

--- a/src/cli/commands/skill-extract.ts
+++ b/src/cli/commands/skill-extract.ts
@@ -1,25 +1,31 @@
 import { resolve } from 'node:path';
-import { Args, Command, Flags } from '@oclif/core';
-import { bilingual, resolveLang } from '../oclif/i18n.js';
-import { CliExit } from '../lib/cli-exit.js';
+import { Args, Flags } from '@oclif/core';
+import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
+import { BaseCommand } from '../oclif/base-command.js';
+import { enumStringParser } from '../oclif/parsers.js';
 import { type CliLang } from '../lib/i18n.js';
 import type { SkillExtractArgs, SkillExtractFlags } from '../lib/cmd-flags.js';
 import { DEFAULT_OBSERVATIONS_DIR } from '../../observability/inbox.js';
 import { updateObservationReviewState } from '../../observability/review-state.js';
 import { updateSkillDerivedStandardStatus, type SkillDerivedStandardStatus } from '../../observability/soft-standards.js';
 
+const STATUS_VALUES = ['author_confirmed', 'rejected', 'pending_review', 'confirm', 'confirmed', 'reject', 'pending'] as const;
+
+function canonicalStatus(value?: string): SkillDerivedStandardStatus {
+  if (!value || value === 'confirm' || value === 'confirmed') return 'author_confirmed';
+  if (value === 'reject') return 'rejected';
+  if (value === 'pending') return 'pending_review';
+  return value as SkillDerivedStandardStatus;
+}
+
 export async function runSkillExtract(
   args: SkillExtractArgs,
   flags: SkillExtractFlags,
-  _lang: CliLang,
+  lang: CliLang,
 ): Promise<void> {
   const skillName = args.skillName;
-  const standardId = flags.review || '';
-  if (!skillName || !standardId) {
-    console.error('Usage: omk skill-extract <skill> --review <standard-id> [--status author_confirmed|rejected|pending_review] [--input-dir <path>]');
-    throw new CliExit(2);
-  }
-  const status = normalizeStatus(flags.status);
+  const standardId = flags.review;
+  const status = canonicalStatus(flags.status);
   const observationsDir = resolve(flags['input-dir'] || DEFAULT_OBSERVATIONS_DIR);
   const now = new Date().toISOString();
   const record = updateSkillDerivedStandardStatus(observationsDir, skillName, standardId, status, now);
@@ -34,19 +40,12 @@ export async function runSkillExtract(
     console.log(JSON.stringify({ kind: 'skill-extract-review', skillName, standardId, status, record, reviewState }, null, 2));
     return;
   }
-  console.log(`soft standard reviewed: ${skillName} ${standardId} status=${status}`);
+  console.log(lang === 'zh'
+    ? `软标准已复核：${skillName} ${standardId} status=${status}`
+    : `Soft standard reviewed: ${skillName} ${standardId} status=${status}`);
 }
 
-function normalizeStatus(value?: string): SkillDerivedStandardStatus {
-  if (!value || value === 'confirm' || value === 'confirmed') return 'author_confirmed';
-  if (value === 'author_confirmed' || value === 'rejected' || value === 'pending_review') return value;
-  if (value === 'reject') return 'rejected';
-  if (value === 'pending') return 'pending_review';
-  console.error(`invalid status: ${value}`);
-  throw new CliExit(2);
-}
-
-export default class SkillExtract extends Command {
+export default class SkillExtract extends BaseCommand {
   static description = bilingual({
     zh: '确认或否决 skill 软标准候选。',
     en: 'Confirm or reject skill soft standard candidates.',
@@ -55,26 +54,25 @@ export default class SkillExtract extends Command {
   static args = {
     skillName: Args.string({
       description: bilingual({ zh: 'skill 名称', en: 'Skill name' }),
-      required: false,
+      required: true,
     }),
   };
 
   static flags = {
-    lang: Flags.string({
-      description: bilingual({ zh: '输出语言 zh|en', en: 'Output language zh|en' }),
-      default: 'zh',
-    }),
+    lang: LANG_FLAG,
     'input-dir': Flags.string({
       description: bilingual({ zh: 'observation 数据目录', en: 'Observation data directory' }),
     }),
     review: Flags.string({
       description: bilingual({ zh: '要确认或否决的软标准 ID', en: 'Soft standard id to review' }),
+      required: true,
     }),
     status: Flags.string({
       description: bilingual({
-        zh: '确认状态：author_confirmed / rejected / pending_review',
-        en: 'Review status: author_confirmed / rejected / pending_review',
+        zh: '确认状态：author_confirmed / rejected / pending_review（也接受 confirm / confirmed / reject / pending 别名）',
+        en: 'Review status: author_confirmed / rejected / pending_review (also accepts aliases: confirm / confirmed / reject / pending)',
       }),
+      parse: enumStringParser('--status', STATUS_VALUES),
     }),
     reason: Flags.string({
       description: bilingual({ zh: '人工判断原因', en: 'Manual review reason' }),
@@ -87,15 +85,9 @@ export default class SkillExtract extends Command {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SkillExtract);
-    const lang = resolveLang(process.argv);
-    try {
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
       await runSkillExtract(args, { ...flags, lang }, lang);
-    } catch (err) {
-      if (err instanceof CliExit) {
-        this.exit(err.code);
-        return;
-      }
-      throw err;
-    }
+    });
   }
 }

--- a/src/cli/lib/cmd-flags.ts
+++ b/src/cli/lib/cmd-flags.ts
@@ -249,12 +249,12 @@ export interface ObserveShowFlags {
 
 // skill-extract(standalone review command)
 export interface SkillExtractArgs {
-  skillName?: string;
+  skillName: string;
 }
 export interface SkillExtractFlags {
   lang: Lang;
   'input-dir'?: string;
-  review?: string;
+  review: string;
   status?: string;
   reason?: string;
   json: boolean;

--- a/src/observability/text-signals.ts
+++ b/src/observability/text-signals.ts
@@ -5,8 +5,12 @@ const RUNTIME_PROTOCOL_PROMPT_RE =
 
 const SCHEDULED_TASK_PROMPT_RE = /^\s*\[cron:[^\]]+\]/i;
 
+// 要求整条消息就是协议词(允许少量空白/尾标点),不要只匹前缀。
+// 旧形态 `(?:\s|\n|$)` 让 "OK 我来帮你查一下" / "ACK 已收到任务" 这类
+// 中文对话开头被错分类为协议消息,把真实的 assistantDeliverySignal 屏蔽掉,
+// 系统性低估 final_delivery_absent 等测量信号。
 const ASSISTANT_PROTOCOL_REPLY_RE =
-  /^\s*(?:HEARTBEAT_OK|HEARTBEAT|PING_OK|PONG|ACK|OK|::FORWARD-OK::)(?:\s|\n|$)/i;
+  /^\s*(?:HEARTBEAT_OK|HEARTBEAT|PING_OK|PONG|ACK|OK|::FORWARD-OK::)\s*[.!]?\s*$/i;
 
 const AIMA_CMD_BLOCK_RE = /<aima-cmd\b[^>]*>[\s\S]*?<\/aima-cmd>|<aima-cmd\b[^>]*\/>/gi;
 

--- a/src/shared/llm-prompts/index.ts
+++ b/src/shared/llm-prompts/index.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export interface LlmPromptDocument {
   id: string;
@@ -9,17 +10,33 @@ export interface LlmPromptDocument {
   hash: string;
 }
 
+// 锁定 omk 包根目录,不走 process.cwd()。
+// 走 cwd 会让 npm 全局安装的 omk 在用户项目目录里找不到 prompt 文件。
+// 编译后位置 dist/src/shared/llm-prompts/index.js 跟源码位置 src/shared/llm-prompts/index.ts
+// 跟包根的层级不同(4 vs 3),所以用 walk-up 找最近一层有 package.json 的目录,
+// 两种位置都能正确解析。
+function findPackageRoot(startDir: string): string {
+  let current = startDir;
+  while (current !== dirname(current)) {
+    if (existsSync(join(current, 'package.json'))) return current;
+    current = dirname(current);
+  }
+  throw new Error(`package.json not found walking up from ${startDir}`);
+}
+
+const PACKAGE_ROOT = findPackageRoot(dirname(fileURLToPath(import.meta.url)));
+
 export function hashPromptText(text: string): string {
   return createHash('sha256').update(text).digest('hex');
 }
 
 export function readPromptDocument(options: {
-  cwd?: string;
+  rootDir?: string;
   fileName: string;
   id: string;
   version: string;
 }): LlmPromptDocument {
-  const path = join(options.cwd ?? process.cwd(), 'docs', 'prompts', options.fileName);
+  const path = join(options.rootDir ?? PACKAGE_ROOT, 'docs', 'prompts', options.fileName);
   if (!existsSync(path)) throw new Error(`missing prompt document: ${path}`);
   const body = readFileSync(path, 'utf-8');
   return {

--- a/test/cli/oclif-skill-extract.test.ts
+++ b/test/cli/oclif-skill-extract.test.ts
@@ -1,0 +1,79 @@
+/**
+ * oclif 路径 skill-extract 命令验收。
+ * 锁住 BaseCommand 约定 + enumStringParser 行为:--status 走 oclif 边界校验
+ * 而不是业务层 console.error。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const CLI = join(PROJECT_ROOT, 'dist', 'src', 'cli', 'index.js');
+
+interface ExecError extends Error {
+  code?: number;
+  stdout: string;
+  stderr: string;
+}
+
+describe('oclif skill-extract', () => {
+  it('--help 默认 zh', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'skill-extract', '--help']);
+    assert.ok(stdout.includes('确认或否决 skill 软标准候选'), `stdout missing zh description:\n${stdout}`);
+    assert.ok(stdout.includes('--review'), 'stdout missing --review flag');
+    assert.ok(stdout.includes('--status'), 'stdout missing --status flag');
+  });
+
+  it('--help --lang en', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'skill-extract', '--help', '--lang', 'en']);
+    assert.ok(stdout.includes('Confirm or reject skill soft standard candidates'), 'stdout should contain en description');
+  });
+
+  it('缺 skillName positional → exit 2(oclif required-args)', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'skill-extract', '--review', 'foo']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2 on missing skillName, got ${e.code}:\n${e.stderr}`);
+    }
+  });
+
+  it('缺 --review → exit 2(oclif required-flag)', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'skill-extract', 'demo-skill']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2 on missing --review, got ${e.code}:\n${e.stderr}`);
+      assert.match(e.stderr, /Missing required flag review/i, `stderr should report missing --review: ${e.stderr}`);
+    }
+  });
+
+  it('非法 --status → exit 2 + 中文 parser 错误(走 enumStringParser)', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'skill-extract', 'demo-skill', '--review', 'sid', '--status', 'maybe']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+      assert.match(e.stderr, /--status(?=[\s\S]*author_confirmed)(?=[\s\S]*之一)/, `stderr missing zh enum parser error:\n${e.stderr}`);
+    }
+  });
+
+  it('非法 --status --lang en → English parser error', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'skill-extract', 'demo-skill', '--review', 'sid', '--status', 'maybe', '--lang', 'en']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2);
+      assert.match(e.stderr, /--status[\s\S]*must be one of[\s\S]*author_confirmed/, `stderr missing en parser error:\n${e.stderr}`);
+    }
+  });
+});

--- a/test/observability/llm-enhanced-review-prompt.test.ts
+++ b/test/observability/llm-enhanced-review-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
 import { readPromptDocument } from '../../src/shared/llm-prompts/index.js';
 
 // 历史 hash 锚点。llm-enhanced-review 的 runtimeAssessment 会影响 observe
@@ -23,5 +24,27 @@ describe('LLM enhanced review prompt hash byte-level freeze', () => {
         '若确需 bump,先改 SOFT_STANDARD_PROMPT_VERSION 字符串(并新增冻结值),' +
         'PR 标题 / description 明确标 BREAKING-COMPARABILITY,再来更新此测试',
     );
+  });
+
+  it('loads prompt regardless of process.cwd() (npm-installed portability)', () => {
+    // npm install -g omk 后,用户 cwd 是自己项目目录,不是 omk 包目录。
+    // readPromptDocument 必须从 import.meta.url 锁定的包安装位置解析 docs/prompts/,
+    // 不能 fallback 到 process.cwd()。这条测试模拟用户场景,锁住 portability。
+    const original = process.cwd();
+    try {
+      process.chdir(tmpdir());
+      const prompt = readPromptDocument({
+        fileName: 'llm-enhanced-review.prompt.md',
+        id: 'llm-enhanced-review',
+        version: '2026-05-18.v1',
+      });
+      assert.equal(
+        prompt.hash,
+        FROZEN_LLM_ENHANCED_REVIEW_PROMPT_HASH,
+        'prompt 必须能从任意 cwd 加载(否则 npm 用户跑 --soft-standard-extract 必挂)',
+      );
+    } finally {
+      process.chdir(original);
+    }
   });
 });

--- a/test/observability/text-signals.test.ts
+++ b/test/observability/text-signals.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { isAssistantProtocolReplyText } from '../../src/observability/text-signals.js';
+
+describe('isAssistantProtocolReplyText', () => {
+  it('classifies bare protocol tokens as protocol reply', () => {
+    for (const text of ['OK', 'OK\n', '  OK  ', 'PONG', 'ACK', 'HEARTBEAT_OK', 'HEARTBEAT', 'PING_OK', '::FORWARD-OK::']) {
+      assert.equal(isAssistantProtocolReplyText(text), true, `should classify as protocol: ${JSON.stringify(text)}`);
+    }
+  });
+
+  it('accepts protocol token with trailing punctuation', () => {
+    for (const text of ['OK.', 'OK!', 'PONG.', 'ACK!\n']) {
+      assert.equal(isAssistantProtocolReplyText(text), true, `should classify as protocol: ${JSON.stringify(text)}`);
+    }
+  });
+
+  it('rejects conversational messages that start with a protocol token', () => {
+    // 这一组是 v0.30 之前的回归 trap。旧 `(?:\s|\n|$)` 形态把这种正常对话开头
+    // 误分类为协议消息,assistantDeliverySignal 会被错误抑制,污染测量信号。
+    for (const text of [
+      'OK 我来帮你查一下',
+      'OK 我看一下',
+      'ACK 已收到任务',
+      'OK done!',
+      'OK, here is the result',
+      'OK 没问题',
+      'PONG 我准备好了',
+    ]) {
+      assert.equal(isAssistantProtocolReplyText(text), false, `should NOT classify as protocol: ${JSON.stringify(text)}`);
+    }
+  });
+
+  it('rejects empty / whitespace-only input', () => {
+    for (const text of ['', '   ', '\n', '\t']) {
+      assert.equal(isAssistantProtocolReplyText(text), false, `should reject blank: ${JSON.stringify(text)}`);
+    }
+  });
+});


### PR DESCRIPTION
## 用户影响

修复 PR #128 引入、PR #130 部分重构后仍残留在 main 上的 3 个发版阻断（1 P0 + 2 P1）。
没修之前的影响：

- npm 全局安装 omk 后跑 `omk observe inbox --soft-standard-extract` 直接 throw missing prompt document
- 助手回复以「OK 我...」/「ACK 已收到...」开头时被错分类为协议消息，系统性低估 `assistantDeliverySignal`，污染 `final_delivery_absent` / `goal_satisfaction` 测量
- `omk skill-extract` 错误文案 en-only，`--status` 非法值给非标准 `console.error` 而不是 oclif parse 边界双语错误

## 改动概要

**P0 — `src/shared/llm-prompts/index.ts`**

- `readPromptDocument` 走 walk-up 找最近一层 `package.json` 作为 `PACKAGE_ROOT`，TS 源（vitest）跟 dist（npm install 后）两种位置都自适应
- `options.cwd` → `options.rootDir`（旧名误导）
- `package.json:files` 加 `docs/prompts/` 让 prompt 跟着 npm pack 走
- 回归测试：`tmpdir()` chdir 后调 `readPromptDocument` 仍能加载，锁住 npm-installed scenario

**P1 — `src/observability/text-signals.ts`**

`ASSISTANT_PROTOCOL_REPLY_RE` 加 `\s*[.!]?\s*\$` 尾锚，要求整条消息就是协议词。`OK 我来帮你查一下` / `ACK 已收到任务` 不再误命中；`OK` / `OK.` / `OK!` / `PONG` 仍正常识别。

**P1 — `src/cli/commands/skill-extract.ts`**

收口到 PR #126/#127 立起来的 oclif Command 约定：

- `Command` → `BaseCommand`（`this.lang` 缓存 + `runWithCliExit` 模板）
- `lang` 走 `LANG_FLAG` 常量
- `--status` 走 `enumStringParser`，oclif parse 边界自带双语错误，`normalizeStatus` 收口成纯别名 `canonicalStatus`
- `skillName` / `--review` 标 `required: true`，删手写空值检查
- 业务侧 `console.log` 双语；`_lang` 参数实际起作用
- `cmd-flags.ts` `SkillExtractArgs/Flags` 跟 `required: true` 对齐
- 新 `test/cli/oclif-skill-extract.test.ts` 6 case：zh/en help、缺 positional、缺 --review、非法 --status 双语错误
- 跟随 codegen 重新生成 `commands.md` / `README.md` / `README.zh.md`

## 测量学说明

不动任何测量学不变量：`Report` schema、judge prompt hash、五层评分管道、Bootstrap CI / Krippendorff α 公式、length-debias toggle 都保持。`FROZEN_LLM_ENHANCED_REVIEW_PROMPT_HASH` 锚点也仍然通过。

`ASSISTANT_PROTOCOL_REPLY_RE` 修法窄化了「协议消息」识别面，让真实的 assistantDeliverySignal 重新被计入，是把测量信号从「系统性偏低」修回正确状态，不是改变 metric 语义。

## 验证

- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` passes (1570 / 1570)
- [x] `npm pack --dry-run` 确认 `docs/prompts/llm-enhanced-review.prompt.md` 入包
- [x] /tmp 实测：`readPromptDocument` 从非 repo cwd 加载成功