### PR TITLE
chore(release): 发布 0.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## 用户影响

v0.30.0 → v0.31.0。跨度大的一次 minor release，190+ commits 跨 5 月 14 日到 5 月 18 日，集中落地：CLI 全面 oclif 化、observe 报告语义重构、doctor 自修复 agent。

## 核心改动

### CLI 全面迁 oclif-native（#120 / #122 / #124 / #126 / #127 / #129）

从手写参数解析迁到 oclif 4：文件目录路由、双语 LangAwareHelp、typed flags、参数 parse 边界双语校验、共享 BaseCommand 模板。BREAKING-CLI 在各 PR title。

### observe 3.0 reviewer 报告重构（#128）

四层硬编码逻辑（3 问答 / checklist / finding / authorSuggestion）收敛到统一的 ChecklistItem 状态对象 + fold 投影。文案口语化：「数据不可判」→「数据有问题」，「需复核」→「要看一眼」。多 session 卡片改 N/M 聚合。

### LLM 增强复盘投影层（#130）

observe inbox 三层投影：事实层（规则） / 增强层（LLM 6 子段） / 修正层（人工标注）。`observe inbox --soft-standard-extract` 改名 `--llm-enhanced-review`（BREAKING-CLI）。prompt 字节级哈希冻结，跨版本可比性锁住。

### doctor --fix 交互 LLM 修复 agent（#130）

`omk doctor --fix` 用 LLM agent 分析 doctor 报告问题、最小化 Edit skill 文件。evolver 同步增强 `--auto-fix-samples` / `--reuse-latest-eval` / `--improve-mode agent|rewrite`。

### 收口 #128 引入的 3 个发版阻断（#131）

- prompt 加载器从 `process.cwd()` 改 `import.meta.url` walk-up + `docs/prompts/` 加入 `package.json:files`，修复 npm install 后 `--llm-enhanced-review` 找不到 prompt 文件
- `ASSISTANT_PROTOCOL_REPLY_RE` 加尾锚，「OK 我...」/「ACK 已收到...」不再被错分类为协议消息
- `skill-extract.ts` 收口到 BaseCommand 约定，`--status` 走 enumStringParser 双语错误

## 迁移说明

BREAKING-CLI 列表（详细迁移指南在各 PR description）：

- `omk --lang en eval --help` → `omk eval --lang en --help`（顶层 --lang 不再 dispatch）
- `omk observe inbox --skill-extract` → `omk observe inbox --soft-standard-extract` → `omk observe inbox --llm-enhanced-review`（两段重命名）
- `omk eval --bogus-flag` 错误路径 FLAGS dump 改双语并列（oclif `errors/handle.js` 上游限制，known limitation）

## 测量学说明

不动测量学不变量：

- Report JSON schema 只加 `ReportMeta.evolve?: {skillName, skillPath?}` 可选字段，老报告仍 parse
- judge prompt hash `9c441e9b6a73` (v3-cot-toolargs) 自 v0.30.0 起锁住未变
- 五层评分管道 / Bootstrap CI / Krippendorff α / length-debias 全保留
- 无 BREAKING-COMPARABILITY，v0.30 与 v0.31 跨版本 eval 报告仍可比

`llm-enhanced-review.prompt.md` 是新加的 LLM 增强复盘 prompt（不是 judge prompt），打了字节级 hash 冻结测试 `FROZEN_LLM_ENHANCED_REVIEW_PROMPT_HASH`，跟随 observe 报告而非 eval 测量管道。

## 验证

- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` passes（1570/1570）
- [x] `yarn build:docs:check` passes
- [x] `npm pack --dry-run` 确认 `docs/prompts/llm-enhanced-review.prompt.md` 入包
- [x] 端到端 npm install 烟测：/tmp 起空目录 pack→install→run，`omk observe inbox --llm-enhanced-review` 不再报 missing prompt