### PR TITLE
chore(comment,test): 微调注释跟测试 fixture 文本

### DIFF
--- a/src/util/safe-slice.ts
+++ b/src/util/safe-slice.ts
@@ -9,8 +9,8 @@
  *   `\uDCxx`,严格 JSON parser(jq / serde / Java Jackson 等)解析会报
  *   "Invalid surrogate pair"。Python json / V8 JSON.parse 宽松接受。
  *
- *   这是 omk 报告 JSON 写盘后被 jq 解析失败的真因(2026-05 dima-workitem-tracker
- *   报告 line 807 col 313 即此)。
+ *   这是 omk 报告 JSON 写盘后被 jq 解析失败的真因(线上某下游 jq 消费者
+ *   实际撞过这条:报告 line 807 col 313 即此)。
  *
  * 修法:
  *   切完之后检查最后一个 code unit。如果是高位 surrogate,回退一位。这样最多损失

--- a/test/observability/inbox.test.ts
+++ b/test/observability/inbox.test.ts
@@ -2223,7 +2223,7 @@ describe('observe inbox', () => {
 name: yuque
 expected_tools:
   - yuque-cli
-  - yuque-ant-cli
+  - yuque-dl
 ---
 
 # yuque

--- a/test/observability/trace-adapter.test.ts
+++ b/test/observability/trace-adapter.test.ts
@@ -213,7 +213,7 @@ describe('loadCcSessions', () => {
         timestamp: '2026-05-12T00:00:01.000Z',
         message: {
           role: 'user',
-          content: [{ type: 'text', text: '帮我写底仓货架需求\n<aima-cmd name="生成PRD">请根据以上需求生成 PRD 文档。</aima-cmd>\n<aima-cmd name="生成Demo">请根据以上需求生成可交互的 Demo。</aima-cmd>' }],
+          content: [{ type: 'text', text: '帮我写新功能的需求\n<aima-cmd name="生成PRD">请根据以上需求生成 PRD 文档。</aima-cmd>\n<aima-cmd name="生成Demo">请根据以上需求生成可交互的 Demo。</aima-cmd>' }],
         },
       },
       {


### PR DESCRIPTION
## 用户影响

无。仅改 1 处源码注释 + 2 处测试 fixture 文本，不动业务逻辑、不动断言。

## 改动

- `src/util/safe-slice.ts:12` surrogate pair bug 的注释里去掉特定项目名引用，换成更通用的「线上某下游 jq 消费者」描述。注释解释保持一致，只是不绑定到具体 caller — 将来 caller 切换时注释不用同步改。
- `test/observability/inbox.test.ts:2226` `expected_tools` fixture 把第二个工具从一个非公开包名换成 `yuque-dl`（npm 上长期维护的 Yuque 下载 CLI），fixture 复用性更好。
- `test/observability/trace-adapter.test.ts:216` `<aima-cmd>` 父消息文本换成更通用的「帮我写新功能的需求」。测试目标是验证业务动作 split 跟 SKILL.md 读取归因，跟父消息具体业务领域无耦合，换通用文本不影响断言。

## 测量学说明

不动测量学不变量：Report schema、judge prompt hash、五层评分管道、Bootstrap CI / Krippendorff α / length-debias 一行没改。

## 验证

- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` passes（1570/1570）