### PR TITLE
docs(contributing): 修 Docs layout 段过期表述

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,9 +228,9 @@ oclif 迁移后 omk 的 exit code 契约（CI / 脚本若有 `[ $? -eq N ]` 分�
 - `docs/reference/` — flag tables, sample format, executor matrix, comparison ↔ what users look up
 - `docs/explanation/` — architecture, statistical rigor ↔ how / why omk works
 - `docs/specs/` — design specs read by contributors (sample design, gap signal, RAG metrics, terminology, ...)
-- `docs/{quickstart,README}.md` stay at the top level; `docs/zh/` mirrors the same structure
+- `docs/quickstart-skill-eval.md` + `docs/README.md` stay at the top level; `docs/zh/` mirrors the same structure
 - `docs/README.md` + `docs/zh/README.md` are the audience-grouped indexes — add new files to the matching section
-- EN/ZH symmetry is **not** mandatory. Some specs are EN-only; `docs/zh/roadmap.md` is intentionally ZH-only (internal planning). Indexes annotate cross-language links with `(中文版) / (英文版)` instead of TODO promises
+- EN/ZH symmetry is **not** mandatory. Several docs are currently ZH-only (e.g. `docs/specs/*`, `docs/dev/*`, `docs/zh/reference/glossary.md`, `docs/zh/specs/scoring.md`, `docs/zh/roadmap.md` — the last is intentionally ZH-only internal planning). Indexes annotate cross-language links with `(中文版) / (英文版)` instead of TODO promises
 
 ## Scope
 


### PR DESCRIPTION
## Summary

跟进 PR #140 review [4350931587](https://github.com/lizhiyao/oh-my-knowledge/pull/140#pullrequestreview-4350931587) 的遗留 P3：CONTRIBUTING.md 的 Docs layout 段有两处过期表述。

- `docs/{quickstart,README}.md` 引用了不存在的 `docs/quickstart.md`，实际文件是 `docs/quickstart-skill-eval.md`
- 「Some specs are EN-only」与现状不符：`docs/specs/*` 4 篇 + `docs/dev/*` 2 篇虽在 EN 路径但内容是中文。当前真正只缺英文版的是 `docs/specs/*`、`docs/dev/*`、`docs/zh/reference/glossary.md`、`docs/zh/specs/scoring.md`、`docs/zh/roadmap.md`（最后一篇是 internal planning，故意 ZH-only），改回事实描述以免后续维护者按旧描述补错索引标注

## Test plan

- [x] 改动只是 CONTRIBUTING.md 文案，不触发任何代码路径
- [x] 引用的 `docs/quickstart-skill-eval.md` 已确认存在
- [x] 列出的 ZH-only 路径 `ls` 已确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)