### PR TITLE
refactor(observability): 切除 inbox 反向驱动 diagnosis 的层级倒置

### DIFF
--- a/src/cli/commands/observe/ingest.ts
+++ b/src/cli/commands/observe/ingest.ts
@@ -61,7 +61,9 @@ export default class ObserveIngest extends BaseCommand {
       const { buildObservationInboxReport, saveObservationInboxReport, DEFAULT_OBSERVATIONS_DIR } = await import('../../../observability/inbox.js');
       const outDir = resolve(outDirRaw ?? DEFAULT_OBSERVATIONS_DIR);
       const { loadObservationReviewState } = await import('../../../observability/review-state.js');
+      const { buildObserveDiagnosticsFromReport } = await import('../../../diagnosis/observe-producer.js');
       const report = buildObservationInboxReport(tracePath, { reviewState: loadObservationReviewState(outDir) });
+      report.diagnostics = buildObserveDiagnosticsFromReport(report);
       const path = saveObservationInboxReport(report, outDir);
       console.log(JSON.stringify(report, null, 2));
       process.stderr.write(lang === 'zh'

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -9,7 +9,6 @@ import { isSearchToolCall, toolCallQuery } from '../shared/tool-search.js';
 import { durationMsBetween } from '../shared/time.js';
 import { buildObservationExperienceReport, type ObservationExperienceReport } from './experience.js';
 import type { ObservationReviewState } from './review-state.js';
-import { buildObserveDiagnosticsFromReport } from '../diagnosis/observe-producer.js';
 import type { DiagnosisBundle } from '../diagnosis/types.js';
 
 export const DEFAULT_PROJECT_OBSERVATIONS_DIR = join(process.cwd(), '.omk', 'observations');
@@ -499,6 +498,11 @@ function skillSessionCountKey(segment: SkillSegment): string {
   return segment.sourceTrace ? `${segment.sessionId}\u0000${segment.sourceTrace}` : segment.sessionId;
 }
 
+/**
+ * 不再附带 diagnostics 字段 —— observability 不再反向驱动 diagnosis。
+ * 需要 diagnostics 的调用方(如 CLI observe ingest)拿到 report 后,自行调
+ * `buildObserveDiagnosticsFromReport(report)` 写入 `report.diagnostics`。
+ */
 export function buildObservationInboxReport(tracePath: string, options: BuildObservationInboxReportOptions = {}): ObservationInboxReport {
   const { sessions, segments } = ccTracesToResultEntries(tracePath);
   const generatedAt = new Date().toISOString();
@@ -563,7 +567,6 @@ export function buildObservationInboxReport(tracePath: string, options: BuildObs
     items,
     experience,
   };
-  report.diagnostics = buildObserveDiagnosticsFromReport(report);
   return report;
 }
 
@@ -679,9 +682,9 @@ export function loadObservationInboxReports(dir: string = DEFAULT_OBSERVATIONS_D
         // 不在 load 路径重建 diagnostics:`buildObserveDiagnosticsFromReport` 现在虽然会从
         // report.items[].cwd / experience 推断每个 skill 的 cwd(没把握就跳过该 skill 的
         // chain advisory,不再 fallback process.cwd()),但 load 时全跳过的话整个 trace
-        // 都没有 Diagnosis。新版 build 路径(buildObservationInboxReport)总会写入
-        // diagnostics 字段;老 inbox JSON 缺字段时让 Studio 显示「该 trace 暂无 Diagnosis,
-        // 请重新 observe 一次」,比惰性重建安全。
+        // 都没有 Diagnosis。新版 build 路径由调用方(CLI observe ingest)在 build 之后
+        // 显式驱动 diagnostics 装配后写入 JSON;老 inbox JSON 缺字段时让 Studio 显示
+        // 「该 trace 暂无 Diagnosis,请重新 observe 一次」,比惰性重建安全。
         return report;
       } catch {
         return null;


### PR DESCRIPTION
## Summary

修阶段性架构债务:`src/observability/inbox.ts` 之前在 `buildObservationInboxReport` 内部直接 import 并调用 `buildObserveDiagnosticsFromReport`,下游 diagnosis 反向被上游 observability 驱动,层级倒置。

改成:
- `inbox.ts` 不再 import diagnosis 的运行时符号,只保留 `DiagnosisBundle` 的 type-only import(编译后无运行时依赖)
- `buildObservationInboxReport` 不再附带 `diagnostics` 字段,doc-comment 明示此约定
- CLI observe ingest 装配层(`src/cli/commands/observe/ingest.ts`)在拿到 report 后显式调 `buildObserveDiagnosticsFromReport(report)` 并赋值

## 用户影响

无用户可见行为变化:
- CLI `omk observe ingest` 输出的 inbox JSON `diagnostics` 字段及内部结构与重构前**字段级一致**(操作只是把同一行赋值从 builder 内部移到 builder 调用点)
- Report schema 未动,无 BREAKING-COMPARABILITY
- HTML snapshot 字节一致

## 内部 API 行为变化

`buildObservationInboxReport()` 不再默认附带 `diagnostics`。当前唯一生产调用方是 CLI observe ingest,已同步更新;未来新增 build 路径的装配方需自行驱动 diagnostics 装配。doc-comment 已写明此约定。

测试侧:
- `test/observability/inbox.test.ts` 各用例不读 `report.diagnostics`,无需调整
- `test/server/report-server.test.ts` 手写 fixture,跟此 PR 无关
- `test/diagnosis/observe-producer.test.ts` 直接测 `buildObserveDiagnosticsFromReport`,跟此 PR 无关

## Test plan

- [x] `yarn lint && yarn build` 通过
- [x] `yarn test` 1615/1615 通过(含 html-renderer snapshot / judge-hash-frozen / llm-enhanced-review-prompt 守门)
- [x] `src/observability/inbox.ts` 仅余 type-only 的 `DiagnosisBundle` import,无运行时反向依赖