### PR TITLE
refactor(eval-workflows): 切除对 cli/lib/i18n 的反向依赖

### DIFF
--- a/src/cli/lib/i18n-dict.ts
+++ b/src/cli/lib/i18n-dict.ts
@@ -76,9 +76,6 @@ export type CliMessageKey =
   | 'cli.run.no_debias_length_active'
   | 'cli.run.invalid_bootstrap_samples'
   | 'cli.run.bootstrap_samples_too_large'
-  | 'cli.run.power_warning_tiny_n'
-  | 'cli.run.power_warning_small_n'
-  | 'cli.run.power_warning_repeat_one'
   | 'cli.run.dry_run_no_scores'
   // eval 完成 / 报告 server / gold compare / 错误
   | 'cli.run.skill_section'
@@ -213,7 +210,6 @@ export type CliMessageKey =
   // omk doctor — CLI level
   | 'cli.doctor.no_skill_found'
   | 'cli.doctor.samples_detected'
-  | 'cli.doctor.gate_blocked'
   | 'cli.run.skip_connectivity_warning';
 
 export interface CliMessage {
@@ -253,18 +249,6 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
   'cli.update.new_version_available': {
     zh: '\n💡 新版本可用: {old} → {new}, 运行 npm update {pkg} -g 升级\n\n',
     en: '\n💡 New version available: {old} → {new}, run npm update {pkg} -g to upgrade\n\n',
-  },
-  'cli.run.power_warning_tiny_n': {
-    zh: '⚠ N={n} < 5：仅适合探索，任何结论都不可靠，CI 会很宽。需要决策时建议 ≥20 条评测用例。',
-    en: '⚠ N={n} < 5 (exploration-only): any conclusion is unreliable, CI will be uselessly wide. Decisions need ≥20 cases.',
-  },
-  'cli.run.power_warning_small_n': {
-    zh: '⚠ N={n} < 20：只能识别很大的效果（Cohen\'s d > 0.8），中等效果（d ≈ 0.5）很难检出。要做可靠决策建议 ≥20 条评测用例。',
-    en: '⚠ N={n} < 20 (large-effect-only, Cohen\'s d > 0.8): medium effects (d ≈ 0.5) hard to detect. For confident decisions consider ≥20 cases.',
-  },
-  'cli.run.power_warning_repeat_one': {
-    zh: '⚠ --repeat=1：单轮评测无法测稳定性（CV 会标记为未测量）。用 --repeat 3+ 检测同一 variant 内部方差。',
-    en: '⚠ --repeat=1: single-run cannot measure stability (CV will be marked "not measured"). Use --repeat 3+ to detect within-variant variance.',
   },
   'cli.run.dry_run_no_scores': {
     zh: 'eval dry-run：仅预览任务，不检查分数',
@@ -1041,10 +1025,6 @@ Examples:
   'cli.doctor.samples_detected': {
     zh: '✓ 使用评测用例文件：{path}',
     en: '✓ Using eval samples file: {path}',
-  },
-  'cli.doctor.gate_blocked': {
-    zh: 'skill 健康检查未通过，评测已中止。doctor 是评测必经环节，无 skip 选项——请修复上述问题后重跑。',
-    en: 'skill health check failed; evaluation aborted. doctor is mandatory and not skippable — fix the issues above and re-run.',
   },
   'cli.run.skip_connectivity_warning': {
     zh: '⚠️  --skip-connectivity 已启用: 跳过 LLM 模型连通性检测。请确保 executor / judge 已通过其他方式验证可达。',

--- a/src/eval-workflows/evaluation-pipeline.ts
+++ b/src/eval-workflows/evaluation-pipeline.ts
@@ -36,7 +36,8 @@ import type {
   Task,
   VariantResult,
 } from '../types/index.js';
-import { tCli, type CliLang } from '../cli/lib/i18n.js';
+import type { Lang } from '../types/shared.js';
+import { tEvalWorkflowMessage } from './messages.js';
 
 type EvaluationResults = Record<string, Record<string, VariantResult>>;
 
@@ -232,20 +233,20 @@ function computeTestSetHash(samplesPath: string, sourceFiles?: string[]): string
  * saturation curves. This is the upfront "you might be wasting the run"
  * heads-up, not a gate.
  */
-export function buildPowerWarnings(sampleCount: number, repeat: number, lang: CliLang = 'zh'): string[] {
+export function buildPowerWarnings(sampleCount: number, repeat: number, lang: Lang = 'zh'): string[] {
   const warnings: string[] = [];
   if (sampleCount < 5) {
-    warnings.push(tCli('cli.run.power_warning_tiny_n', lang, { n: sampleCount }));
+    warnings.push(tEvalWorkflowMessage('power_warning_tiny_n', lang, { n: sampleCount }));
   } else if (sampleCount < 20) {
-    warnings.push(tCli('cli.run.power_warning_small_n', lang, { n: sampleCount }));
+    warnings.push(tEvalWorkflowMessage('power_warning_small_n', lang, { n: sampleCount }));
   }
   if (repeat < 2) {
-    warnings.push(tCli('cli.run.power_warning_repeat_one', lang));
+    warnings.push(tEvalWorkflowMessage('power_warning_repeat_one', lang));
   }
   return warnings;
 }
 
-function emitPowerWarnings(sampleCount: number, repeat: number, lang: CliLang): void {
+function emitPowerWarnings(sampleCount: number, repeat: number, lang: Lang): void {
   for (const w of buildPowerWarnings(sampleCount, repeat, lang)) {
     process.stderr.write(`${w}\n`);
   }
@@ -409,7 +410,7 @@ export interface EvaluationPipelineOptions {
   /** Explicit persisted run id. Used by batch workflows that need stable child ids. */
   runId?: string;
   /** CLI output language for warnings emitted by the pipeline. */
-  lang?: CliLang;
+  lang?: Lang;
   /** Reasoning effort 透传到 executor。默认 'low'(由 RunConfig 兜底)。 */
   effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   /** 关闭 diagnostic。Default false。 */

--- a/src/eval-workflows/messages.ts
+++ b/src/eval-workflows/messages.ts
@@ -1,0 +1,48 @@
+import type { Lang } from '../types/shared.js';
+
+export type EvalWorkflowMessageCode =
+  | 'power_warning_tiny_n'
+  | 'power_warning_small_n'
+  | 'power_warning_repeat_one'
+  | 'doctor_gate_blocked';
+
+interface MessageEntry {
+  zh: string;
+  en: string;
+}
+
+const MESSAGES: Record<EvalWorkflowMessageCode, MessageEntry> = {
+  power_warning_tiny_n: {
+    zh: '⚠ N={n} < 5：仅适合探索，任何结论都不可靠，CI 会很宽。需要决策时建议 ≥20 条评测用例。',
+    en: '⚠ N={n} < 5 (exploration-only): any conclusion is unreliable, CI will be uselessly wide. Decisions need ≥20 cases.',
+  },
+  power_warning_small_n: {
+    zh: '⚠ N={n} < 20：只能识别很大的效果（Cohen\'s d > 0.8），中等效果（d ≈ 0.5）很难检出。要做可靠决策建议 ≥20 条评测用例。',
+    en: '⚠ N={n} < 20 (large-effect-only, Cohen\'s d > 0.8): medium effects (d ≈ 0.5) hard to detect. For confident decisions consider ≥20 cases.',
+  },
+  power_warning_repeat_one: {
+    zh: '⚠ --repeat=1：单轮评测无法测稳定性（CV 会标记为未测量）。用 --repeat 3+ 检测同一 variant 内部方差。',
+    en: '⚠ --repeat=1: single-run cannot measure stability (CV will be marked "not measured"). Use --repeat 3+ to detect within-variant variance.',
+  },
+  doctor_gate_blocked: {
+    zh: 'skill 健康检查未通过，评测已中止。doctor 是评测必经环节，无 skip 选项——请修复上述问题后重跑。',
+    en: 'skill health check failed; evaluation aborted. doctor is mandatory and not skippable — fix the issues above and re-run.',
+  },
+};
+
+const DEFAULT_LANG: Lang = 'zh';
+
+export function tEvalWorkflowMessage(
+  code: EvalWorkflowMessageCode,
+  lang: Lang = DEFAULT_LANG,
+  params?: Record<string, string | number>,
+): string {
+  const entry = MESSAGES[code];
+  let text = entry[lang] ?? entry[DEFAULT_LANG];
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      text = text.replaceAll(`{${k}}`, String(v));
+    }
+  }
+  return text;
+}

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -247,7 +247,7 @@ export async function runEvaluation({
     if (doctorCtx) {
       const { runDoctor } = await import('../doctor/index.js');
       const { renderDoctorReportText } = await import('../doctor/renderer.js');
-      const { tCli } = await import('../cli/lib/i18n.js');
+      const { tEvalWorkflowMessage } = await import('./messages.js');
       const doctorReport = await runDoctor({
         artifacts: doctorCtx.doctorArtifacts,
         cwd: doctorCtx.dependencyCwd,
@@ -261,7 +261,7 @@ export async function runEvaluation({
       });
       if (doctorReport.outcome === 'failed') {
         renderDoctorReportText(doctorReport, lang);
-        throw new Error(`doctor failed: ${tCli('cli.doctor.gate_blocked', lang)}`);
+        throw new Error(`doctor failed: ${tEvalWorkflowMessage('doctor_gate_blocked', lang)}`);
       }
     }
   }


### PR DESCRIPTION
## Summary

阶段性架构债务的前半:`src/eval-workflows/` 之前 import `cli/lib/i18n.js` 拿 `tCli` 翻译自己产生的 4 条 warning / error 文案(3 条 `power_warning_*` + 1 条 `doctor_gate_blocked`),基础层反向依赖 CLI 国际化,层级倒置。

改成:
- 新增 `src/eval-workflows/messages.ts`,自带这 4 条消息的 zh / en 翻译表跟轻量 `tEvalWorkflowMessage(code, lang, params?)`(跟 `tCli` 同形参,模式一致)
- `evaluation-pipeline.ts` / `run-evaluation.ts` 改用本地 `tEvalWorkflowMessage`,`lang` 类型从 `CliLang` 换成 `types/shared.ts` 的 `Lang`(同值同结构,不破调用方)
- 同时清掉 `cli/lib/i18n-dict.ts` 里这 4 条 key(union 成员 + dict 条目),原内容已搬到 eval-workflows/messages,不再两处维护

## 用户影响

无用户可见行为变化:
- CLI / 报告输出文案字节级一致(直接照搬 zh / en 文本)
- Report schema 未动,无 BREAKING-COMPARABILITY
- 错误 message 前缀 `doctor failed:` 仍保留(`run-evaluation.ts:695` 的 prefix 匹配跟 `test/cli/doctor-eval-embed.test.ts` 的 stderr 断言都依赖这个 contract)

## 测量学守门

- ✅ judge-hash-frozen 不动
- ✅ llm-enhanced-review-prompt 不动
- ✅ html-renderer snapshot 不动
- ✅ 任何 prompt / Report schema 文件无 diff

## Test plan

- [x] \`yarn lint && yarn build\` 通过
- [x] \`yarn test\` 1615/1615 通过(含 \`test/eval-workflows/power-warnings.test.ts\` 翻译断言不变即通过)
- [x] grep 确认 \`src/eval-workflows/\` 不再 import \`cli/lib/i18n\`
- [x] grep 确认 CLI dict 删除的 4 个 key 无其它引用

## 后续

doctor 子系统也有反向 i18n 依赖(`src/doctor/{rules,renderer,health/composer}.ts` 4 个点),设计上类似,下一 PR 处理。两 PR 合并后阶段 7(共享 evaluation assembly)前置就齐。