### PR TITLE
refactor(observability): 引入 feedback-projection facade 收敛 renderer 对 experience 的细粒度耦合

### DIFF
--- a/src/observability/feedback-projection.ts
+++ b/src/observability/feedback-projection.ts
@@ -1,0 +1,51 @@
+/**
+ * observability → renderer 的公开投影层(facade)。
+ *
+ * renderer(视图层)以前直接 import `observability/experience.ts` 的内部符号
+ * (6 个 feedback matcher + 21 个 type),与 experience 内部强耦合。这层 facade
+ * 把 renderer 需要的「feedback / experience 投影面」收敛为一个公开 surface:
+ * renderer 只 import 这里,experience.ts 内部如何重组(后续阶段 3 拆分 feedback
+ * matchers / frontmatter IO)对 renderer 透明。
+ *
+ * 设计原则(阶段 1.5,roadmap):
+ *   - 仅 re-export,不做语义合并 / 不引入新类型 / 不写运行时逻辑
+ *   - 不改任何字节级输出(html-renderer snapshot 必须字节一致)
+ *   - 阶段 8 的 ViewModel 边界会进一步把这些符号封进 ViewModel,renderer 那时
+ *     连这层也不直接看到。本 facade 是中间过渡层,降低阶段 8 的改动面。
+ *
+ * 范围:仅 renderer 用到的子集。其它消费者(diagnosis / CLI observe ingest)
+ * 继续直接 import experience.ts —— 它们不是「视图」,不在 facade 收敛范围内。
+ */
+
+export {
+  findNegativeFeedbackMatches,
+  findPositiveFeedbackMatches,
+  findUserCorrectionMatches,
+  findUserGoalShiftMatches,
+  hasUserCorrectionSignal,
+  hasUserGoalShiftSignal,
+} from './experience.js';
+
+export type {
+  ExperienceAssistiveInference,
+  ExperienceAssistiveInferenceCautionCode,
+  ExperienceAssistiveInferenceCode,
+  ExperienceChecklistItem,
+  ExperienceEvidenceChain,
+  ExperienceEvidenceRef,
+  ExperienceFeedbackAttribution,
+  ExperienceInvocation,
+  ExperienceReviewIndicators,
+  ExperienceReviewBasisCode,
+  ExperienceReviewPriority,
+  ExperienceReviewerReport,
+  ExperienceRuleFinding,
+  ExperienceRuleFindingCode,
+  ExperienceRuleFindingLevel,
+  ExperienceEpisode,
+  ExperienceFeedbackSignal,
+  ExperienceSkillSegment,
+  ExperienceSessionStoryAnswer,
+  ExperienceSessionSummary,
+  ExperienceTimelineEvent,
+} from './experience.js';

--- a/src/renderer/observation-inbox-renderer.ts
+++ b/src/renderer/observation-inbox-renderer.ts
@@ -3,7 +3,7 @@ import type { Lang } from '../types/index.js';
 import { severityReasonFor } from '../observability/inbox.js';
 import type { ObservationInboxItem } from '../observability/inbox.js';
 import type { ObservationInboxViewModel } from '../observability/inbox-view-model.js';
-import { findNegativeFeedbackMatches, findPositiveFeedbackMatches, findUserCorrectionMatches, findUserGoalShiftMatches, hasUserCorrectionSignal, hasUserGoalShiftSignal } from '../observability/experience.js';
+import { findNegativeFeedbackMatches, findPositiveFeedbackMatches, findUserCorrectionMatches, findUserGoalShiftMatches, hasUserCorrectionSignal, hasUserGoalShiftSignal } from '../observability/feedback-projection.js';
 import type { ExperienceProblemBucket, ExperienceProblemPattern, ExperienceProblemSignal } from '../observability/problem-patterns.js';
 import { observationMetricAnnotationTargetId, type ObservationMetricKey } from '../observability/review-state.js';
 import { resolveObservationReviewSession, type ResolvedObservationReviewSession, type ResolvedOwnerSuggestion } from '../observability/resolved-review.js';
@@ -34,7 +34,7 @@ import type {
   ExperienceSessionStoryAnswer,
   ExperienceSessionSummary,
   ExperienceTimelineEvent,
-} from '../observability/experience.js';
+} from '../observability/feedback-projection.js';
 
 function feedbackAttributionRoleLabel(role?: string): string {
   if (role === 'primary_fault') return '主要归因';


### PR DESCRIPTION
## 背景

renderer(视图层)以前直接 import `observability/experience.ts` 的 6 个 feedback matcher + 21 个 type,与 experience 内部强耦合。后续阶段(experience 拆分 / ViewModel 边界)只要动 experience 的内部结构,renderer 就会被牵连;阶段 8 的 ViewModel 边界也无法只在投影层落地。

## 改动

- 新增 `src/observability/feedback-projection.ts`:纯 re-export 的公开投影层(facade),收敛 renderer 需要的 feedback / experience 投影面为一个公开 surface。
- `src/renderer/observation-inbox-renderer.ts` 两处 import 改为 import 该 facade,不再直接 import `observability/experience.js`。
- 该 facade 仅做 re-export,**不引入新类型 / 不做语义合并 / 不写运行时逻辑**;experience.ts 内部如何重组对 renderer 透明。
- 范围限定:仅 renderer 用到的子集走 facade;其它消费者(diagnosis / CLI observe ingest)继续直接 import `experience.ts` —— 它们不是「视图」,不在本 facade 收敛范围内。

## 守门

- `yarn lint` ✅
- `yarn build` ✅
- `yarn test` ✅ 1615/1615 passed
- `test/__snapshots__/html-renderer.test.ts.snap` (318KB) **字节一致**,无 UI/渲染回归。
- `test/grading/judge-hash-frozen.test.ts` / `test/observability/llm-enhanced-review-prompt.test.ts` 全绿。
- 测量学红区(`src/types/report.ts` / `src/eval-core/*` / `src/grading/*` / 任一 prompt 字符串)零 touch。

无 BREAKING-COMPARABILITY。

## 后续

- 阶段 8 ViewModel 边界唯一前置已就绪;后续可在 facade 之上把 renderer 当前用到的 observability 符号收敛为预投影字段。
- 阶段 3 experience 拆分的耦合面同步降低:experience.ts 内部 feedback matcher / frontmatter IO 拆分时,renderer 不会被牵连。