### PR TITLE
refactor(observability): 抽 experience.ts 反馈匹配器簇到 feedback-matchers.ts

### DIFF
--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -14,6 +14,28 @@ import { hasAssistantDeliverableArtifactText, hasAssistantDeliverySignalText, ha
 import { durationMsBetween } from '../shared/time.js';
 import { parseSkillFrontmatter, validateSkillHardRules, validateSkillWorkflows } from '../shared/hard-rules.js';
 import { findSkillMdPath } from './skill-chain.js';
+import {
+  findNegativeFeedbackMatches,
+  findPositiveFeedbackMatches,
+  findUserCorrectionMatches,
+  findUserGoalShiftMatches,
+  hasNegativeFeedbackSignal,
+  hasPositiveFeedbackSignal,
+  hasUserCorrectionSignal,
+  hasUserGoalShiftSignal,
+} from './feedback-matchers.js';
+
+export {
+  findNegativeFeedbackMatches,
+  findPositiveFeedbackMatches,
+  findUserCorrectionMatches,
+  findUserGoalShiftMatches,
+  hasNegativeFeedbackSignal,
+  hasPositiveFeedbackSignal,
+  hasUserCorrectionSignal,
+  hasUserGoalShiftSignal,
+} from './feedback-matchers.js';
+export type { TextMatchRange } from './feedback-matchers.js';
 
 export type ExperienceReviewPriority = 'review_first' | 'sample_review' | 'routine_sample';
 export type ExperienceGoalSliceReasonCode = 'skill_segment_boundary' | 'explicit_user_goal_shift' | 'default_session_slice';
@@ -637,139 +659,6 @@ export interface ObservationExperienceReport {
   skills: ExperienceSkillSummary[];
 }
 
-export interface TextMatchRange {
-  start: number;
-  end: number;
-}
-
-const TEXT_BOUNDARY_CHARS = new Set([
-  ' ', '\n', '\r', '\t',
-  ',', '，', ';', '；', '、', '.', '。', '!', '！', '?', '？', ':', '：',
-  '"', "'", '“', '”', '‘', '’', '(', ')', '[', ']', '{', '}', '<', '>', '《', '》',
-]);
-const BOUNDED_USER_CORRECTION_TERMS = ['不对', '不是', '错了'];
-const PHRASE_USER_CORRECTION_TERMS = [
-  '不是这个',
-  '不要这样',
-  '理解错',
-  '看错',
-  '你应该',
-  '应该是',
-  '直接用',
-  '直接按',
-  '改成',
-  '重来',
-];
-const USER_GOAL_SHIFT_TERMS = [
-  '换个方向',
-  '重新来',
-  '重来',
-  '先不',
-  '不用这个',
-  '先不用',
-  '暂时不用',
-  '不看这个',
-  '换一个',
-  '换下一个',
-  '另一个问题',
-  '另外一个问题',
-  '先看别的',
-  '先处理别的',
-  '新开一个',
-  '新启动一个',
-  '另开一个',
-  '再开一个',
-  '参考apply-cc的能力新开',
-  '拉下最新',
-  '拉取最新',
-  '切到最新',
-];
-const NEGATIVE_FEEDBACK_TERMS = [
-  '没有用',
-  '没用',
-  '太慢',
-  '别再',
-  '怎么又',
-  '赶紧',
-  '做错了',
-  '做错',
-  '完全错',
-  '错得离谱',
-  '很垃圾',
-  '太垃圾',
-  '乱来',
-  '瞎搞',
-  '白干',
-  '浪费时间',
-  '没有价值',
-  '没价值',
-  '没意义',
-  '不好用',
-  '用不了',
-  '没有帮助',
-  '没帮助',
-  '毫无帮助',
-  '太菜',
-  '很菜',
-  '真菜',
-  '菜了',
-  '菜啊',
-];
-const BOUNDED_NEGATIVE_FEEDBACK_TERMS = ['失败', '垃圾', '菜'];
-// 高歧义负向词:前面紧跟描述对象的名词(代码 / 这段 / 这里 等)时是在描述对象有问题, 不算用户对 skill 的负向反馈。
-// 命中后用 BENIGN_NEGATIVE_FEEDBACK_PREFIXES 做"先做不算"的紧邻前缀过滤, 命中即跳过。
-// 详见 memory: feedback_keyword_context_rule.md。
-const AMBIGUOUS_NEGATIVE_FEEDBACK_TERMS = ['有问题', '不需要', '看不懂', '不符合', '不行'];
-// 紧邻命中即"在描述对象有问题, 不算用户对 skill 的负向反馈":
-// 1. 前缀: <object> + 高歧义词        (代码有问题 / 逻辑不符合)
-// 2. 前缀: <object>(里|中|上) + 高歧义词 (代码里不需要)
-// 3. 后缀: 高歧义词 + 的<object>      (有问题的代码)
-// 不放"方案/方法/做法/思路/样式/规范/标准"等评价类词, 这些前接"不行/不符合"通常是负向反馈。
-const BENIGN_NEGATIVE_OBJECT_RE = /(?:代码|这段|这部分|这里|那里|文件|字段|逻辑|函数|接口|参数|配置|路径|目录|架构|写法|算法|文档|输出|结果|结构|文本|展示|渲染|输入|响应|脚本|代码块|代码段|代码片段|网络|信号|环境|机器|电脑)$/;
-const BENIGN_NEGATIVE_OBJECT_LOC_RE = /(?:代码|文件|脚本|目录|文档|项目|仓库)(?:里|中|上)$/;
-const BENIGN_NEGATIVE_OBJECT_SUFFIX_RE = /^的(?:代码|这段|这部分|逻辑|函数|接口|文件|字段|写法|算法|文档|脚本|实现|方法|方案|内容|结构|部分|地方|步骤|代码块|代码段|代码片段)/;
-const ADDITIONAL_NEGATIVE_FEEDBACK_TERMS = [
-  '不对',
-  '错了',
-  '有误',
-  '不可以',
-  '不是这个',
-  '不是我要的',
-  '跑偏',
-  '绕路',
-  '你没懂',
-  '没懂',
-  '重做',
-  '重新做',
-  '重来',
-  '不符合预期',
-];
-const POSITIVE_FEEDBACK_TERMS = [
-  '非常好',
-  '很好',
-  '做得好',
-  '做的好',
-  '做得不错',
-  '做的不错',
-  '不错',
-  '很棒',
-  '优秀',
-  '厉害',
-  '很厉害',
-  '值得鼓励',
-  '很有用',
-  '非常有用',
-  '很有价值',
-  '非常有价值',
-  '很有帮助',
-  '非常有帮助',
-  'good job',
-  'great job',
-  'well done',
-  'nice work',
-  'excellent',
-  'awesome',
-];
 const USER_INTERRUPTION_RE = /\[Request interrupted by user(?: for tool use)?\]|interrupted by user|用户中断|停止任务|停一下|先别|别动|等一下|等下|等等|取消(?:任务|执行)?|先暂停|暂停一下/i;
 const TIMELINE_PREVIEW_EVENT_LIMIT = 240;
 
@@ -4624,99 +4513,6 @@ function uniqueEvidenceRefs(refs: ExperienceEvidenceRef[]): ExperienceEvidenceRe
 function inferUserGoal(userRefs: ExperienceTimelineEvent[]): string | undefined {
   const first = userRefs.find((ref) => ref.snippet && !ref.snippet.includes('tool_result'));
   return snippet(first?.snippet, 180);
-}
-
-export function findUserCorrectionMatches(value: string): TextMatchRange[] {
-  const ranges: TextMatchRange[] = [];
-  for (const term of PHRASE_USER_CORRECTION_TERMS) {
-    pushTermMatches(value, term, ranges, false);
-  }
-  for (const term of BOUNDED_USER_CORRECTION_TERMS) {
-    pushTermMatches(value, term, ranges, true);
-  }
-  return ranges.sort((a, b) => a.start - b.start);
-}
-
-export function hasUserCorrectionSignal(value: string): boolean {
-  return findUserCorrectionMatches(value).length > 0;
-}
-
-export function findUserGoalShiftMatches(value: string): TextMatchRange[] {
-  const ranges: TextMatchRange[] = [];
-  for (const term of USER_GOAL_SHIFT_TERMS) {
-    pushTermMatches(value, term, ranges, false);
-  }
-  return ranges.sort((a, b) => a.start - b.start);
-}
-
-export function hasUserGoalShiftSignal(value: string): boolean {
-  return findUserGoalShiftMatches(value).length > 0;
-}
-
-export function findNegativeFeedbackMatches(value: string): TextMatchRange[] {
-  const ranges: TextMatchRange[] = [];
-  for (const term of [...NEGATIVE_FEEDBACK_TERMS, ...ADDITIONAL_NEGATIVE_FEEDBACK_TERMS].sort((a, b) => b.length - a.length)) {
-    pushTermMatches(value, term, ranges, false);
-  }
-  for (const term of [...BOUNDED_NEGATIVE_FEEDBACK_TERMS].sort((a, b) => b.length - a.length)) {
-    pushTermMatches(value, term, ranges, true);
-  }
-  for (const term of [...AMBIGUOUS_NEGATIVE_FEEDBACK_TERMS].sort((a, b) => b.length - a.length)) {
-    pushTermMatches(value, term, ranges, false, false, (haystack, index) => !isBenignNegativeFeedbackContext(haystack, index, term));
-  }
-  return ranges.sort((a, b) => a.start - b.start);
-}
-
-function isBenignNegativeFeedbackContext(value: string, hitIndex: number, term: string): boolean {
-  const before = value.slice(Math.max(0, hitIndex - 6), hitIndex);
-  if (BENIGN_NEGATIVE_OBJECT_RE.test(before)) return true;
-  if (BENIGN_NEGATIVE_OBJECT_LOC_RE.test(before)) return true;
-  const after = value.slice(hitIndex + term.length, hitIndex + term.length + 10);
-  if (BENIGN_NEGATIVE_OBJECT_SUFFIX_RE.test(after)) return true;
-  return false;
-}
-
-export function hasNegativeFeedbackSignal(value: string): boolean {
-  return findNegativeFeedbackMatches(value).length > 0;
-}
-
-export function findPositiveFeedbackMatches(value: string): TextMatchRange[] {
-  const ranges: TextMatchRange[] = [];
-  for (const term of POSITIVE_FEEDBACK_TERMS) {
-    pushTermMatches(value, term, ranges, false, true);
-  }
-  return ranges.sort((a, b) => a.start - b.start);
-}
-
-export function hasPositiveFeedbackSignal(value: string): boolean {
-  return findPositiveFeedbackMatches(value).length > 0;
-}
-
-function pushTermMatches(
-  value: string,
-  term: string,
-  ranges: TextMatchRange[],
-  requireBoundary: boolean,
-  caseInsensitive = false,
-  contextAllow?: (value: string, index: number) => boolean,
-): void {
-  const haystack = caseInsensitive ? value.toLowerCase() : value;
-  const needle = caseInsensitive ? term.toLowerCase() : term;
-  let index = haystack.indexOf(needle);
-  while (index >= 0) {
-    const end = index + needle.length;
-    if ((!requireBoundary || (isTextBoundary(value[index - 1]) && isTextBoundary(value[end])))
-      && !ranges.some((range) => index < range.end && end > range.start)
-      && (!contextAllow || contextAllow(value, index))) {
-      ranges.push({ start: index, end });
-    }
-    index = haystack.indexOf(needle, index + needle.length);
-  }
-}
-
-function isTextBoundary(value: string | undefined): boolean {
-  if (value === undefined) return true;
-  return TEXT_BOUNDARY_CHARS.has(value);
 }
 
 function isSkillContextRecord(record: CcUserRecord, text: string): boolean {

--- a/src/observability/feedback-matchers.ts
+++ b/src/observability/feedback-matchers.ts
@@ -1,0 +1,251 @@
+/**
+ * 用户文本反馈信号匹配器簇。
+ *
+ * 从用户消息文本里识别四类信号:
+ *   - 用户纠正(user correction):「不对 / 不是 / 错了 / 你应该 / 重来」等
+ *   - 目标切换(user goal shift):「换个方向 / 先不 / 另一个问题」等
+ *   - 负向反馈(negative feedback):「没用 / 垃圾 / 做错了」等;高歧义词
+ *     (「有问题 / 不行 / 不需要 / 看不懂 / 不符合」)需配合 BENIGN_NEGATIVE_*
+ *     上下文规则排除「描述对象本身有问题」的中性表达
+ *   - 正向反馈(positive feedback):「很好 / 做得好 / good job / awesome」等
+ *
+ * 每类信号提供两个 API:
+ *   - findXxxMatches(text): 返回所有命中范围(TextMatchRange[]),供 renderer 高亮
+ *   - hasXxxSignal(text): 命中即 true,供计数 / 判定逻辑
+ *
+ * 词表与上下文规则是观测语义的一部分,改动会影响 `negativeFeedbackCount`、
+ * `positiveFeedbackCount`、`userCorrectionCount`、`userGoalShiftCount` 四个
+ * indicators 字段的值,继而影响 Report 比较学。词表变更前先确认 inbox 测试
+ * (`test/observability/inbox.test.ts`)的影响。
+ *
+ * 阶段 3 拆分历史:这些常量、helper、公开函数原本住在 `experience.ts` 末尾。
+ * 拆出独立文件后,experience.ts 通过 re-export 维持对外签名兼容,renderer
+ * 通过 feedback-projection facade 间接消费。
+ */
+
+export interface TextMatchRange {
+  start: number;
+  end: number;
+}
+
+const TEXT_BOUNDARY_CHARS = new Set([
+  ' ', '\n', '\r', '\t',
+  ',', '，', ';', '；', '、', '.', '。', '!', '！', '?', '？', ':', '：',
+  '"', "'", '“', '”', '‘', '’', '(', ')', '[', ']', '{', '}', '<', '>', '《', '》',
+]);
+const BOUNDED_USER_CORRECTION_TERMS = ['不对', '不是', '错了'];
+const PHRASE_USER_CORRECTION_TERMS = [
+  '不是这个',
+  '不要这样',
+  '理解错',
+  '看错',
+  '你应该',
+  '应该是',
+  '直接用',
+  '直接按',
+  '改成',
+  '重来',
+];
+const USER_GOAL_SHIFT_TERMS = [
+  '换个方向',
+  '重新来',
+  '重来',
+  '先不',
+  '不用这个',
+  '先不用',
+  '暂时不用',
+  '不看这个',
+  '换一个',
+  '换下一个',
+  '另一个问题',
+  '另外一个问题',
+  '先看别的',
+  '先处理别的',
+  '新开一个',
+  '新启动一个',
+  '另开一个',
+  '再开一个',
+  '参考apply-cc的能力新开',
+  '拉下最新',
+  '拉取最新',
+  '切到最新',
+];
+const NEGATIVE_FEEDBACK_TERMS = [
+  '没有用',
+  '没用',
+  '太慢',
+  '别再',
+  '怎么又',
+  '赶紧',
+  '做错了',
+  '做错',
+  '完全错',
+  '错得离谱',
+  '很垃圾',
+  '太垃圾',
+  '乱来',
+  '瞎搞',
+  '白干',
+  '浪费时间',
+  '没有价值',
+  '没价值',
+  '没意义',
+  '不好用',
+  '用不了',
+  '没有帮助',
+  '没帮助',
+  '毫无帮助',
+  '太菜',
+  '很菜',
+  '真菜',
+  '菜了',
+  '菜啊',
+];
+const BOUNDED_NEGATIVE_FEEDBACK_TERMS = ['失败', '垃圾', '菜'];
+// 高歧义负向词:前面紧跟描述对象的名词(代码 / 这段 / 这里 等)时是在描述对象有问题, 不算用户对 skill 的负向反馈。
+// 命中后用 BENIGN_NEGATIVE_FEEDBACK_PREFIXES 做"先做不算"的紧邻前缀过滤, 命中即跳过。
+// 详见 memory: feedback_keyword_context_rule.md。
+const AMBIGUOUS_NEGATIVE_FEEDBACK_TERMS = ['有问题', '不需要', '看不懂', '不符合', '不行'];
+// 紧邻命中即"在描述对象有问题, 不算用户对 skill 的负向反馈":
+// 1. 前缀: <object> + 高歧义词        (代码有问题 / 逻辑不符合)
+// 2. 前缀: <object>(里|中|上) + 高歧义词 (代码里不需要)
+// 3. 后缀: 高歧义词 + 的<object>      (有问题的代码)
+// 不放"方案/方法/做法/思路/样式/规范/标准"等评价类词, 这些前接"不行/不符合"通常是负向反馈。
+const BENIGN_NEGATIVE_OBJECT_RE = /(?:代码|这段|这部分|这里|那里|文件|字段|逻辑|函数|接口|参数|配置|路径|目录|架构|写法|算法|文档|输出|结果|结构|文本|展示|渲染|输入|响应|脚本|代码块|代码段|代码片段|网络|信号|环境|机器|电脑)$/;
+const BENIGN_NEGATIVE_OBJECT_LOC_RE = /(?:代码|文件|脚本|目录|文档|项目|仓库)(?:里|中|上)$/;
+const BENIGN_NEGATIVE_OBJECT_SUFFIX_RE = /^的(?:代码|这段|这部分|逻辑|函数|接口|文件|字段|写法|算法|文档|脚本|实现|方法|方案|内容|结构|部分|地方|步骤|代码块|代码段|代码片段)/;
+const ADDITIONAL_NEGATIVE_FEEDBACK_TERMS = [
+  '不对',
+  '错了',
+  '有误',
+  '不可以',
+  '不是这个',
+  '不是我要的',
+  '跑偏',
+  '绕路',
+  '你没懂',
+  '没懂',
+  '重做',
+  '重新做',
+  '重来',
+  '不符合预期',
+];
+const POSITIVE_FEEDBACK_TERMS = [
+  '非常好',
+  '很好',
+  '做得好',
+  '做的好',
+  '做得不错',
+  '做的不错',
+  '不错',
+  '很棒',
+  '优秀',
+  '厉害',
+  '很厉害',
+  '值得鼓励',
+  '很有用',
+  '非常有用',
+  '很有价值',
+  '非常有价值',
+  '很有帮助',
+  '非常有帮助',
+  'good job',
+  'great job',
+  'well done',
+  'nice work',
+  'excellent',
+  'awesome',
+];
+
+export function findUserCorrectionMatches(value: string): TextMatchRange[] {
+  const ranges: TextMatchRange[] = [];
+  for (const term of PHRASE_USER_CORRECTION_TERMS) {
+    pushTermMatches(value, term, ranges, false);
+  }
+  for (const term of BOUNDED_USER_CORRECTION_TERMS) {
+    pushTermMatches(value, term, ranges, true);
+  }
+  return ranges.sort((a, b) => a.start - b.start);
+}
+
+export function hasUserCorrectionSignal(value: string): boolean {
+  return findUserCorrectionMatches(value).length > 0;
+}
+
+export function findUserGoalShiftMatches(value: string): TextMatchRange[] {
+  const ranges: TextMatchRange[] = [];
+  for (const term of USER_GOAL_SHIFT_TERMS) {
+    pushTermMatches(value, term, ranges, false);
+  }
+  return ranges.sort((a, b) => a.start - b.start);
+}
+
+export function hasUserGoalShiftSignal(value: string): boolean {
+  return findUserGoalShiftMatches(value).length > 0;
+}
+
+export function findNegativeFeedbackMatches(value: string): TextMatchRange[] {
+  const ranges: TextMatchRange[] = [];
+  for (const term of [...NEGATIVE_FEEDBACK_TERMS, ...ADDITIONAL_NEGATIVE_FEEDBACK_TERMS].sort((a, b) => b.length - a.length)) {
+    pushTermMatches(value, term, ranges, false);
+  }
+  for (const term of [...BOUNDED_NEGATIVE_FEEDBACK_TERMS].sort((a, b) => b.length - a.length)) {
+    pushTermMatches(value, term, ranges, true);
+  }
+  for (const term of [...AMBIGUOUS_NEGATIVE_FEEDBACK_TERMS].sort((a, b) => b.length - a.length)) {
+    pushTermMatches(value, term, ranges, false, false, (haystack, index) => !isBenignNegativeFeedbackContext(haystack, index, term));
+  }
+  return ranges.sort((a, b) => a.start - b.start);
+}
+
+function isBenignNegativeFeedbackContext(value: string, hitIndex: number, term: string): boolean {
+  const before = value.slice(Math.max(0, hitIndex - 6), hitIndex);
+  if (BENIGN_NEGATIVE_OBJECT_RE.test(before)) return true;
+  if (BENIGN_NEGATIVE_OBJECT_LOC_RE.test(before)) return true;
+  const after = value.slice(hitIndex + term.length, hitIndex + term.length + 10);
+  if (BENIGN_NEGATIVE_OBJECT_SUFFIX_RE.test(after)) return true;
+  return false;
+}
+
+export function hasNegativeFeedbackSignal(value: string): boolean {
+  return findNegativeFeedbackMatches(value).length > 0;
+}
+
+export function findPositiveFeedbackMatches(value: string): TextMatchRange[] {
+  const ranges: TextMatchRange[] = [];
+  for (const term of POSITIVE_FEEDBACK_TERMS) {
+    pushTermMatches(value, term, ranges, false, true);
+  }
+  return ranges.sort((a, b) => a.start - b.start);
+}
+
+export function hasPositiveFeedbackSignal(value: string): boolean {
+  return findPositiveFeedbackMatches(value).length > 0;
+}
+
+function pushTermMatches(
+  value: string,
+  term: string,
+  ranges: TextMatchRange[],
+  requireBoundary: boolean,
+  caseInsensitive = false,
+  contextAllow?: (value: string, index: number) => boolean,
+): void {
+  const haystack = caseInsensitive ? value.toLowerCase() : value;
+  const needle = caseInsensitive ? term.toLowerCase() : term;
+  let index = haystack.indexOf(needle);
+  while (index >= 0) {
+    const end = index + needle.length;
+    if ((!requireBoundary || (isTextBoundary(value[index - 1]) && isTextBoundary(value[end])))
+      && !ranges.some((range) => index < range.end && end > range.start)
+      && (!contextAllow || contextAllow(value, index))) {
+      ranges.push({ start: index, end });
+    }
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+}
+
+function isTextBoundary(value: string | undefined): boolean {
+  if (value === undefined) return true;
+  return TEXT_BOUNDARY_CHARS.has(value);
+}

--- a/src/observability/feedback-projection.ts
+++ b/src/observability/feedback-projection.ts
@@ -24,7 +24,7 @@ export {
   findUserGoalShiftMatches,
   hasUserCorrectionSignal,
   hasUserGoalShiftSignal,
-} from './experience.js';
+} from './feedback-matchers.js';
 
 export type {
   ExperienceAssistiveInference,


### PR DESCRIPTION
## 背景

`src/observability/experience.ts` 4782 行,末尾的「用户反馈文本匹配器簇」是一个独立单元(8 个 `find*Matches` / `has*Signal` 函数 + 12 个词表常量 + 3 个 helper + `TextMatchRange` 类型),逻辑自包含,与 experience 的「事件链路投影」主职责正交。该簇是阶段 1.5 facade 公开 surface 的 6 个 runtime 函数所在,也是后续阶段 3 PR2(frontmatter IO 拆分)与阶段 8(ViewModel 边界)的耦合面源头。

## 改动

- 新增 `src/observability/feedback-matchers.ts`(251 行):承载反馈匹配器簇的实现。
- `src/observability/experience.ts`:删掉对应实现块(-204 行),改为从 feedback-matchers 直接 import 8 个公开函数内部使用;通过 `export { ... } from './feedback-matchers.js'` 与 `export type { TextMatchRange }` 维持对外签名兼容。
- `src/observability/feedback-projection.ts`(阶段 1.5 facade):将 6 个 runtime 函数 re-export 的源切换为 `feedback-matchers.js`,facade 直接指向真实的源,不再透过 experience.ts。

## 守门

- `yarn lint` ✅
- `yarn build` ✅
- `yarn test` ✅ 1615/1615 passed
- `test/__snapshots__/html-renderer.test.ts.snap`(318KB)**字节一致**。
- `test/observability/inbox.test.ts` 全绿(测试仍 import 自 `experience.js`,re-export 保持兼容)。
- `test/grading/judge-hash-frozen.test.ts` / `test/observability/llm-enhanced-review-prompt.test.ts` 全绿。
- 测量学红区(`src/types/report.ts` / `src/eval-core/*` / `src/grading/*` / 任一 prompt 字符串)零 touch。
- 词表与上下文规则(`NEGATIVE_FEEDBACK_TERMS` / `BENIGN_NEGATIVE_OBJECT_RE` 等)零字节改动,Report 字段(`negativeFeedbackCount` / `positiveFeedbackCount` / `userCorrectionCount` / `userGoalShiftCount`)语义完全不变。

无 BREAKING-COMPARABILITY。

## 后续

- 阶段 3 PR2:抽 frontmatter IO(`src/observability/experience-frontmatter.ts`),让 experience.ts 进一步回归「事件链路投影」单职责。
- 阶段 8:在 facade 之上建 ViewModel 边界,renderer 不再直接消费 matcher 函数。