### PR TITLE
chore(release): 发布 0.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## 用户影响

v0.31.0 → v0.32.0。16 个 commit 的 minor release,主线是「内部结构整顿 + 测量学语义微调」:observability / doctor / eval-workflows 子系统的反向依赖与层级倒置切除、observation-inbox 视图层切片,搭配 observe LLM 复盘 prompt v2 与 CLI 路径统一两次 BREAKING-COMPARABILITY。docs/ 按受众分层重组,README 收敛到第一屏。

## 核心改动

### observe LLM 增强复盘 prompt v2(#134, BREAKING-COMPARABILITY)

prompt 重写 + `ownerSuggestion` 结构化输出;`runtimeAssessment` 字段跨版本不可比,迁移说明见 PR description。

### CLI / server / doctor 路径统一 + doctor 追加模式(#135, BREAKING-COMPARABILITY)

`--report` / `--reports-dir` / `--out` 等路径 flag 默认值与解析口径统一,doctor 输出改追加模式。涉及外部脚本调用约定,迁移说明见 PR description。

### soft-standards.ts LLM 抽取与规则节点匹配拆分(#136, BREAKING-COMPARABILITY)

`runtimeAssessment.softStandardEvaluation` 字段语义重组,LLM 抽取产物与规则节点匹配解耦。详见 PR description。

### docs/ 按受众分层重组(#139 / #140 / #141)

README 800 行参考内容下沉到 `docs/reference|explanation|specs`,顶层 README 收敛到第一屏 launch-ready。CONTRIBUTING 修过期 Docs layout 段。

### 内部架构整顿(#142 / #143 / #144 / #145 / #146 / #147 / #148)

按 roadmap 阶段 1-3 / 4 / 5 推进,**对外行为零变化**:

- 视图层切片:observation-inbox-renderer 抽 styles.ts、引入 feedback-projection facade、抽 feedback-matchers.ts
- 数据层拆分:soft-standards.ts 拆为四层模块
- 层级整顿:observability inbox 不再反向驱动 diagnosis;eval-workflows / doctor 切除对 cli/lib/i18n 的反向依赖

### omk 命名海报与设计上下文(#137 / #138)

新增「为什么这把尺子叫 omk」资源 + 设计 skill 读取的 `.impeccable.md` 上下文。

## 迁移说明

3 个 BREAKING-COMPARABILITY:

- **observe LLM 复盘 prompt v2**(#134):`runtimeAssessment` 字段跨版本不可比,新 prompt hash 锁住测量学不变量。需要重新生成历史 observe 报告才能纳入对比。
- **CLI 路径口径统一**(#135):依赖 `omk eval --report` / `omk observe inbox --reports-dir` 等 flag 的外部脚本要重新核对默认值;详见 #135 description。
- **soft-standards 拆分**(#136):`runtimeAssessment.softStandardEvaluation` 嵌套结构调整,直接消费该字段的外部分析脚本需要适配新 schema;详见 #136 description。

## 测量学说明

- judge prompt hash `9c441e9b6a73` (v3-cot-toolargs) 自 v0.30.0 起锁住未变。
- 五层评分管道 / Bootstrap CI / Krippendorff α / length-debias 全保留。
- `test/grading/judge-hash-frozen.test.ts` 通过。
- 上述 3 个 BREAKING-COMPARABILITY 影响 observe `runtimeAssessment` 投影面,不影响 eval 报告 grading / Bootstrap / α 数字;v0.31 与 v0.32 跨版本 eval 报告仍可比。
- `test/observability/llm-enhanced-review-prompt.test.ts` 锁住 observe LLM 复盘 prompt 新 hash。
- `test/__snapshots__/html-renderer.test.ts.snap` 字节一致(#142 / #147 / #148 视图层切片均未触发 snapshot 更新)。

## 验证

- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` passes(1615/1615)