### PR TITLE
refactor(observability): 抽 experience.ts skill frontmatter IO 到独立模块

### DIFF
--- a/src/observability/experience-frontmatter.ts
+++ b/src/observability/experience-frontmatter.ts
@@ -1,0 +1,105 @@
+/**
+ * skill SKILL.md frontmatter 读取 + 投影到 experience 报告字段。
+ *
+ * experience.ts 在构建复盘报告时需要三处 frontmatter 投影:
+ *   - `loadFrontmatterSkillType`:读 `skillType` / `type` / `category` 字段,
+ *     归一化为 `ExperienceRuntimeSkillType`(router / executor / advisory / ...),
+ *     用于声明侧 skill 类型(对照 trace 推断)
+ *   - `loadSkillDeclarationCheck`:解析 SKILL.md 的 hard rules / workflows 声明,
+ *     用于复盘报告里的 declaration 步骤
+ *   - `loadExpectedToolsForSkill`:读 `expected_tools` / `expectedTools` 字段,
+ *     用于「真用上声明的工具」判定
+ *
+ * 设计原则:
+ *   - 只做 IO + 投影:读 skill.md、解析 frontmatter、归一化字段
+ *   - 不做事件链路推断:`traceInferredSkillType` 等不属于 frontmatter 投影,留在 experience.ts
+ *   - 所有读文件异常 swallow:复盘报告不该因为缺一个 skill.md 而 throw,
+ *     缺失时降级为 undefined / [] / `{declared:false,count:0}`
+ *
+ * 阶段 3 PR2 拆分历史:原本住在 experience.ts 内部,与事件链路投影逻辑混杂。
+ * 拆出独立文件后,experience.ts 主体回归「事件 → 复盘字段」单职责,frontmatter
+ * IO 改为通过本模块显式调用。
+ */
+
+import { readFileSync } from 'node:fs';
+import { parseSkillFrontmatter, validateSkillHardRules, validateSkillWorkflows } from '../shared/hard-rules.js';
+import { findSkillMdPath } from './skill-chain.js';
+import type { ExperienceRuntimeSkillType } from './experience.js';
+
+export interface SkillDeclarationCheck {
+  hardRules: {
+    declared: boolean;
+    count: number;
+  };
+  workflows: {
+    declared: boolean;
+    count: number;
+  };
+}
+
+export function loadFrontmatterSkillType(skillName: string, cwd?: string): ExperienceRuntimeSkillType | undefined {
+  const path = findSkillMdPath(skillName, cwd ?? '');
+  if (!path) return undefined;
+  try {
+    const parsed = parseSkillFrontmatter(readFileSync(path, 'utf8'));
+    if (!parsed.ok) return undefined;
+    const raw = parsed.data?.skillType ?? parsed.data?.type ?? parsed.data?.category;
+    return normalizeRuntimeSkillType(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+export function loadSkillDeclarationCheck(skillName: string, cwd?: string): SkillDeclarationCheck {
+  const path = findSkillMdPath(skillName, cwd ?? process.cwd());
+  if (!path) {
+    return {
+      hardRules: { declared: false, count: 0 },
+      workflows: { declared: false, count: 0 },
+    };
+  }
+  try {
+    const content = readFileSync(path, 'utf-8');
+    const hardRules = validateSkillHardRules(content);
+    const workflows = validateSkillWorkflows(content);
+    return {
+      hardRules: { declared: hardRules.declared, count: hardRules.rules.length },
+      workflows: { declared: workflows.declared, count: workflows.workflows.reduce((sum, workflow) => sum + workflow.nodes.length, 0) },
+    };
+  } catch {
+    return {
+      hardRules: { declared: false, count: 0 },
+      workflows: { declared: false, count: 0 },
+    };
+  }
+}
+
+export function loadExpectedToolsForSkill(skillName: string, cwd?: string): string[] {
+  const path = findSkillMdPath(skillName, cwd ?? process.cwd());
+  if (!path) return [];
+  try {
+    const parsed = parseSkillFrontmatter(readFileSync(path, 'utf-8'));
+    const data = parsed.ok ? parsed.data : undefined;
+    const value = data?.expected_tools ?? data?.expectedTools;
+    return Array.isArray(value)
+      ? unique(value.filter((item): item is string => typeof item === 'string' && Boolean(item.trim())).map((item) => item.trim()))
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeRuntimeSkillType(value: unknown): ExperienceRuntimeSkillType | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim().toLowerCase().replace(/[_\s-]+/g, '_');
+  if (normalized === 'router' || normalized === 'route') return 'router';
+  if (normalized === 'delegation' || normalized === 'delegate' || normalized === 'delegator') return 'delegation';
+  if (normalized === 'executor' || normalized === 'execute') return 'executor';
+  if (normalized === 'advisory' || normalized === 'advisor' || normalized === 'consulting') return 'advisory';
+  if (normalized === 'workflow_owner' || normalized === 'workflowowner' || normalized === 'workflow') return 'workflow_owner';
+  return undefined;
+}
+
+function unique<T>(values: T[]): T[] {
+  return Array.from(new Set(values));
+}

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -1,5 +1,4 @@
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
 import type { ObservationInboxItem, ObservationSourceKind } from './inbox.js';
 import {
   buildExperienceProblemPatterns,
@@ -12,8 +11,11 @@ import type { SkillSegment } from './trace-segmenter.js';
 import { extractCommandEnvelopeText, stripCommandEnvelopeText } from './trace-attribution.js';
 import { hasAssistantDeliverableArtifactText, hasAssistantDeliverySignalText, hasUserHardRuleText, isAssistantProgressUpdateText, isAssistantProtocolReplyText, isRuntimeProtocolPromptText, isSyntheticUserMessageText, isToolResultFailureText, isUserInteractionMetricText } from './text-signals.js';
 import { durationMsBetween } from '../shared/time.js';
-import { parseSkillFrontmatter, validateSkillHardRules, validateSkillWorkflows } from '../shared/hard-rules.js';
-import { findSkillMdPath } from './skill-chain.js';
+import {
+  loadExpectedToolsForSkill,
+  loadFrontmatterSkillType,
+  loadSkillDeclarationCheck,
+} from './experience-frontmatter.js';
 import {
   findNegativeFeedbackMatches,
   findPositiveFeedbackMatches,
@@ -2024,7 +2026,7 @@ function sessionStorySkillSegments(
   const invocationById = new Map(invocations.map((invocation) => [invocation.id, invocation]));
   return skillLinks.map((link, index) => {
     const group = link.invocationIds.map((id) => invocationById.get(id)).filter((value): value is ExperienceInvocation => Boolean(value));
-    const declaredSkillType = frontmatterSkillType(link.skillName, session.cwd);
+    const declaredSkillType = loadFrontmatterSkillType(link.skillName, session.cwd);
     const traceInferredSkillType = traceInferredSkillTypeForLink(link);
     const skillType = declaredSkillType ?? traceInferredSkillType ?? 'unknown';
     const evidenceRefs = uniqueEvidenceRefs([
@@ -2079,7 +2081,7 @@ function episodeRoleForLink(
   session: ExperienceSessionSummary,
   resolvedSkillType?: ExperienceRuntimeSkillType,
 ): ExperienceEpisodeRole {
-  const skillType = resolvedSkillType ?? frontmatterSkillType(link.skillName, session.cwd) ?? traceInferredSkillTypeForLink(link) ?? 'unknown';
+  const skillType = resolvedSkillType ?? loadFrontmatterSkillType(link.skillName, session.cwd) ?? traceInferredSkillTypeForLink(link) ?? 'unknown';
   if (skillType === 'router') return 'router';
   if (skillType === 'delegation') return 'delegator';
   if (skillType === 'executor') return 'main_executor';
@@ -2090,29 +2092,6 @@ function episodeRoleForLink(
   return 'supporting';
 }
 
-function frontmatterSkillType(skillName: string, cwd?: string): ExperienceRuntimeSkillType | undefined {
-  const path = findSkillMdPath(skillName, cwd ?? '');
-  if (!path) return undefined;
-  try {
-    const parsed = parseSkillFrontmatter(readFileSync(path, 'utf8'));
-    if (!parsed.ok) return undefined;
-    const raw = parsed.data?.skillType ?? parsed.data?.type ?? parsed.data?.category;
-    return normalizeRuntimeSkillType(raw);
-  } catch {
-    return undefined;
-  }
-}
-
-function normalizeRuntimeSkillType(value: unknown): ExperienceRuntimeSkillType | undefined {
-  if (typeof value !== 'string') return undefined;
-  const normalized = value.trim().toLowerCase().replace(/[_\s-]+/g, '_');
-  if (normalized === 'router' || normalized === 'route') return 'router';
-  if (normalized === 'delegation' || normalized === 'delegate' || normalized === 'delegator') return 'delegation';
-  if (normalized === 'executor' || normalized === 'execute') return 'executor';
-  if (normalized === 'advisory' || normalized === 'advisor' || normalized === 'consulting') return 'advisory';
-  if (normalized === 'workflow_owner' || normalized === 'workflowowner' || normalized === 'workflow') return 'workflow_owner';
-  return undefined;
-}
 
 function sessionStoryOrchestrationEdges(
   episodeId: string,
@@ -3163,7 +3142,7 @@ function goalSatisfactionChecklistItems(session: ExperienceSessionSummary, episo
 
 function declaredBehaviorChecklistItems(session: ExperienceSessionSummary, episodes?: ExperienceEpisode[]): ExperienceChecklistItem[] {
   const expectedToolCheck = expectedToolCheckForSession(session);
-  const declarations = skillDeclarationCheckForSession(session);
+  const declarations = loadSkillDeclarationCheck(session.skillName, session.cwd);
   const hasSkillRead = session.evidenceChain.skillContextCount > 0;
   const attributionLabel = attributionSourcesToLabel(session.attributionSources ?? []);
   const items: ExperienceChecklistItem[] = [
@@ -3654,17 +3633,6 @@ interface ExpectedToolCheck {
   declared: boolean;
 }
 
-interface SkillDeclarationCheck {
-  hardRules: {
-    declared: boolean;
-    count: number;
-  };
-  workflows: {
-    declared: boolean;
-    count: number;
-  };
-}
-
 function executionStepStatus(session: ExperienceSessionSummary, expectedToolCheck: ExpectedToolCheck): ExperienceReviewerReportStepStatus {
   if (session.indicators.toolFailureCount > 0 || expectedToolCheck.declared && expectedToolCheck.matchedTools.length === 0) return 'attention';
   if (session.indicators.toolCallCount > 0) return 'ok';
@@ -3849,45 +3817,6 @@ function expectedToolCheckForSession(session: ExperienceSessionSummary): Expecte
   };
 }
 
-function skillDeclarationCheckForSession(session: ExperienceSessionSummary): SkillDeclarationCheck {
-  const path = findSkillMdPathForExperience(session.skillName, session.cwd ?? process.cwd());
-  if (!path) {
-    return {
-      hardRules: { declared: false, count: 0 },
-      workflows: { declared: false, count: 0 },
-    };
-  }
-  try {
-    const content = readFileSync(path, 'utf-8');
-    const hardRules = validateSkillHardRules(content);
-    const workflows = validateSkillWorkflows(content);
-    return {
-      hardRules: { declared: hardRules.declared, count: hardRules.rules.length },
-      workflows: { declared: workflows.declared, count: workflows.workflows.reduce((sum, workflow) => sum + workflow.nodes.length, 0) },
-    };
-  } catch {
-    return {
-      hardRules: { declared: false, count: 0 },
-      workflows: { declared: false, count: 0 },
-    };
-  }
-}
-
-function loadExpectedToolsForSkill(skillName: string, cwd?: string): string[] {
-  const path = findSkillMdPathForExperience(skillName, cwd ?? process.cwd());
-  if (!path) return [];
-  try {
-    const parsed = parseSkillFrontmatter(readFileSync(path, 'utf-8'));
-    const data = parsed.ok ? parsed.data : undefined;
-    const value = data?.expected_tools ?? data?.expectedTools;
-    return Array.isArray(value)
-      ? unique(value.filter((item): item is string => typeof item === 'string' && Boolean(item.trim())).map((item) => item.trim()))
-      : [];
-  } catch {
-    return [];
-  }
-}
-
 function eventMatchesExpectedTool(event: ExperienceTimelineEvent, expectedTool: string): boolean {
   if (event.kind !== 'tool_use') return false;
   const text = `${event.toolName ?? ''}\n${event.label ?? ''}\n${event.snippet ?? ''}\n${event.fullText ?? ''}`.toLowerCase();
@@ -3901,10 +3830,6 @@ function eventMatchesExpectedTool(event: ExperienceTimelineEvent, expectedTool: 
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function findSkillMdPathForExperience(skillName: string, cwd: string): string | undefined {
-  return findSkillMdPath(skillName, cwd);
 }
 
 function reviewerFindingsForSession(session: ExperienceSessionSummary, reviewState?: ObservationReviewState): ExperienceReviewerReportFinding[] {


### PR DESCRIPTION
## 背景

`src/observability/experience.ts` 在构建复盘报告时,有 3 处会去读 SKILL.md frontmatter:
- `frontmatterSkillType` — 读 `skillType` / `type` / `category` 字段判定声明侧 skill 类型
- `skillDeclarationCheckForSession` — 解析 hard rules / workflows 声明数
- `loadExpectedToolsForSkill` — 读 `expected_tools` 字段

这三处共享 `findSkillMdPath + readFileSync + parseSkillFrontmatter` 的 IO 骨架,与事件链路投影逻辑混杂在一个 4500+ 行的文件里。阶段 3 PR2 把这块剥出来,让 experience.ts 主体回归「事件 → 复盘字段」单职责。

## 改动

- 新增 `src/observability/experience-frontmatter.ts`(105 行):承载 skill frontmatter IO + 投影,3 个公开函数 + `SkillDeclarationCheck` 类型 + `normalizeRuntimeSkillType` helper。
- `src/observability/experience.ts`:
  - 删去 5 个内部函数(`frontmatterSkillType` / `normalizeRuntimeSkillType` / `skillDeclarationCheckForSession` / `loadExpectedToolsForSkill` / `findSkillMdPathForExperience`)与 `SkillDeclarationCheck` 内部接口,-75 行。
  - 不再 import `node:fs` / `../shared/hard-rules.js` / `./skill-chain.js`(这些都随函数搬走)。
  - 3 处 call-site 改名:`frontmatterSkillType` → `loadFrontmatterSkillType`、`skillDeclarationCheckForSession(session)` → `loadSkillDeclarationCheck(session.skillName, session.cwd)`、`loadExpectedToolsForSkill` 同名沿用。

`experience-frontmatter.ts` 用 `import type { ExperienceRuntimeSkillType } from './experience.js'`(类型导入,运行时擦除,不构成运行时循环)。

## 守门

- `yarn lint` ✅
- `yarn build` ✅
- `yarn test` ✅ 1615/1615 passed
- `test/__snapshots__/html-renderer.test.ts.snap`(318KB)**字节一致**。
- `test/observability/inbox.test.ts` 全绿。
- `test/grading/judge-hash-frozen.test.ts` / `test/observability/llm-enhanced-review-prompt.test.ts` 全绿。
- 测量学红区(`src/types/report.ts` / `src/eval-core/*` / `src/grading/*` / 任一 prompt 字符串)零 touch。
- frontmatter 读取 / 解析 / 归一化逻辑零行为改动,Report 字段(declaredSkillType / skillTypeSource / expectedTools / hardRules.declared / workflows.declared 等)语义完全不变。

无 BREAKING-COMPARABILITY。

## 后续

阶段 3 完整收尾。experience.ts 从 4782 行(PR1 前)→ 4503 行(本 PR 后),feedback matcher 簇 + frontmatter IO 已各自独立成模块。接下来按 roadmap 进入阶段 7(三入口共享 evaluation assembly)与阶段 8(ViewModel 边界)。