### PR TITLE
refactor(eval-workflows): evaluation-pipeline 610 行拆为 orchestrator + 4 helper(阶段 7 clarity pass)

### DIFF
--- a/src/eval-workflows/evaluation-pipeline.ts
+++ b/src/eval-workflows/evaluation-pipeline.ts
@@ -1,357 +1,53 @@
-import { createHash } from 'node:crypto';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-import { analyzeResults } from '../analysis/report-diagnostics.js';
-import { computeReportCoverage } from '../analysis/coverage-analyzer.js';
-import { computeReportGapRates } from '../analysis/gap-analyzer.js';
-import { aggregateReport, applyBlindMode, DEFAULT_OUTPUT_DIR, generateRunId, persistReport } from '../eval-core/evaluation-reporting.js';
+/**
+ * evaluation pipeline orchestrator —— 单次 evaluation run 的「执行+收尾」编排。
+ *
+ * 主入口 `executeEvaluationPipeline` 把以下几段串成线性时序:
+ *   1. `initializeEvaluationRunState` 建 run / job 元数据并写 jobStore
+ *   2. resolve judge models + executor map(必须先于 preflight,见函数内注释)
+ *   3. `preflight` + `preflightAllJudges` LLM 连通性
+ *   4. `emitPowerWarnings` + `emitIsolationWarnings` 结构性 / 隔离性预警
+ *   5. `executeTasks` 真正跑用例
+ *   6. `finalizeSuccessfulRun` + `finalizeEvaluationReport` 收尾 + 后置分析
+ *   7. `persistReport` + `persistSuccessfulJob` 落盘
+ *   失败路径走 `persistFailedJob`, finally 关 MCP server。
+ *
+ * 4 块被拆出去的 helper 都在 `./evaluation-pipeline/` 目录下,与本文件 1:1 协作:
+ *   - run-state.ts: EvaluationRunState 生命周期(init / finalizeSuccess / persistSuccess / persistFailed)
+ *   - test-set-hash.ts: 测试集水印 hash(spec §7.1)
+ *   - preflight-warnings.ts: power + isolation 预警
+ *   - report-finalize.ts: report 后置分析装配
+ *
+ * 兼容 re-export: `buildPowerWarnings` / `buildIsolationWarnings` /
+ * `_computeTestSetHashForTest` 保留在本模块的 export surface,避免 test 与
+ * `run-evaluation.ts:275` 动态 import 路径改动。
+ */
+
+import { aggregateReport, DEFAULT_OUTPUT_DIR, generateRunId, persistReport } from '../eval-core/evaluation-reporting.js';
 import { executeTasks, preflight, preflightAllJudges } from '../eval-core/evaluation-execution.js';
 import type { DependencyRequirements } from '../eval-core/dependency-checker.js';
-import {
-  createFileJobStore,
-  DEFAULT_JOBS_DIR,
-} from '../server/job-store.js';
 import { stopAllServers } from '../inputs/mcp-resolver.js';
-import {
-  buildEvaluationRequest,
-  createFailedJob,
-  createEvaluationRun,
-  createQueuedJob,
-  createSucceededJob,
-  finalizeEvaluationRun,
-  markJobRunning,
-  failEvaluationRun,
-} from '../eval-core/evaluation-job.js';
 import type {
   Artifact,
-  EvaluationJob,
-  EvaluationRequest,
-  EvaluationRun,
   ExecutorFn,
   JobStore,
   ProgressCallback,
   Report,
   Sample,
   Task,
-  VariantResult,
 } from '../types/index.js';
 import type { Lang } from '../types/shared.js';
-import { tEvalWorkflowMessage } from './messages.js';
+import {
+  finalizeSuccessfulRun,
+  initializeEvaluationRunState,
+  persistFailedJob,
+  persistSuccessfulJob,
+} from './evaluation-pipeline/run-state.js';
+import { finalizeEvaluationReport } from './evaluation-pipeline/report-finalize.js';
+import { emitIsolationWarnings, emitPowerWarnings } from './evaluation-pipeline/preflight-warnings.js';
 
-type EvaluationResults = Record<string, Record<string, VariantResult>>;
-
-interface EvaluationRunState {
-  request: EvaluationRequest;
-  runId: string;
-  jobId: string;
-  createdAt: string;
-  startedAt: string;
-  initialRun: EvaluationRun;
-  runningJob: EvaluationJob;
-  resolvedJobStore: JobStore | null;
-}
-
-async function initializeEvaluationRunState({
-  samplesPath,
-  skillDir,
-  artifacts,
-  model,
-  judgeModel,
-  noJudge,
-  executorName,
-  judgeExecutorName,
-  concurrency,
-  timeoutMs,
-  noCache,
-  blind,
-  project,
-  owner,
-  tags,
-  runId,
-  jobStore,
-  persistJob,
-  repeat,
-  batch,
-  judgeRepeat,
-  judgeModels,
-  bootstrap,
-  bootstrapSamples,
-  lengthDebias,
-  budget,
-  effort,
-}: {
-  samplesPath: string;
-  skillDir: string;
-  artifacts: Artifact[];
-  model: string;
-  judgeModel: string;
-  noJudge: boolean;
-  executorName: string;
-  judgeExecutorName: string;
-  concurrency: number;
-  timeoutMs?: number;
-  noCache: boolean;
-  blind: boolean;
-  project?: string;
-  owner?: string;
-  tags?: string[];
-  runId: string;
-  jobStore?: JobStore | null;
-  persistJob?: boolean;
-  repeat?: number;
-  batch?: boolean;
-  judgeRepeat?: number;
-  judgeModels?: import('../types/index.js').JudgeConfig[];
-  bootstrap?: boolean;
-  bootstrapSamples?: number;
-  lengthDebias?: boolean;
-  budget?: import('../types/index.js').EvalBudget;
-  effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
-}): Promise<EvaluationRunState> {
-  const effectiveJudges: import('../types/index.js').JudgeConfig[] = judgeModels && judgeModels.length > 0
-    ? judgeModels
-    : [{ executor: judgeExecutorName, model: judgeModel }];
-  const request = buildEvaluationRequest({
-    samplesPath,
-    skillDir,
-    artifacts,
-    model,
-    executor: executorName,
-    noJudge,
-    concurrency,
-    timeoutMs,
-    noCache,
-    dryRun: false,
-    blind,
-    project,
-    owner,
-    tags,
-    repeat,
-    batch,
-    judgeRepeat,
-    judgeModels: effectiveJudges,
-    bootstrap,
-    bootstrapSamples,
-    lengthDebias,
-    budget,
-    effort,
-  });
-  const createdAt = new Date().toISOString();
-  const { run: initialRun, startedAt } = createEvaluationRun(runId, createdAt);
-  const jobId = `job-${runId}`;
-  const resolvedJobStore = persistJob ? (jobStore ?? createFileJobStore(DEFAULT_JOBS_DIR)) : null;
-  const queuedJob = createQueuedJob({ jobId, request, createdAt });
-  if (resolvedJobStore) await resolvedJobStore.save(jobId, queuedJob);
-  const runningJob = markJobRunning(queuedJob, runId, startedAt);
-  if (resolvedJobStore) await resolvedJobStore.save(jobId, runningJob);
-  return { request, runId, jobId, createdAt, startedAt, initialRun, runningJob, resolvedJobStore };
-}
-
-function finalizeSuccessfulRun(state: EvaluationRunState) {
-  const finishedAt = new Date().toISOString();
-  const run = finalizeEvaluationRun(state.initialRun, finishedAt);
-  const job = createSucceededJob({
-    jobId: state.jobId,
-    runId: state.runId,
-    reportId: state.runId,
-    request: state.request,
-    createdAt: state.createdAt,
-    startedAt: state.startedAt,
-    finishedAt,
-  });
-  return { run, job };
-}
-
-async function persistSuccessfulJob(state: EvaluationRunState, job: EvaluationJob): Promise<void> {
-  if (state.resolvedJobStore) {
-    await state.resolvedJobStore.save(state.jobId, job);
-  }
-}
-
-async function persistFailedJob(state: EvaluationRunState, err: unknown): Promise<void> {
-  const finishedAt = new Date().toISOString();
-  const failedJob = createFailedJob({
-    job: { ...state.runningJob, runId: state.runId, startedAt: state.startedAt, finishedAt: undefined },
-    error: err instanceof Error ? err.message : String(err),
-    finishedAt,
-  });
-  void failEvaluationRun(state.initialRun, finishedAt);
-  if (state.resolvedJobStore) {
-    await state.resolvedJobStore.save(state.jobId, failedJob);
-  }
-}
-
-/**
- * Compute the mandatory test set watermark hash (spec §7.1).
- *
- * - 单文件 / sourceFiles 单元素:hash 该文件内容
- * - 多文件(目录模式):按文件名排序后,把每个文件 basename + sha256 拼成 manifest,
- *   对 manifest 再 sha256,前 12 hex chars。这样:
- *     1) 加 / 删 sample 文件 → hash 变
- *     2) 任一文件内容改 → hash 变
- *     3) 同样文件不同顺序 → hash 不变(排序后稳定)
- *
- * 之前对目录 readFileSync() 抛 EISDIR → 返回 null,gap report 水印丢失。
- */
-export function _computeTestSetHashForTest(samplesPath: string, sourceFiles?: string[]): string | null {
-  return computeTestSetHash(samplesPath, sourceFiles);
-}
-
-function computeTestSetHash(samplesPath: string, sourceFiles?: string[]): string | null {
-  // 优先 sourceFiles(目录模式可靠),fallback samplesPath 兼容老调用
-  const files = sourceFiles && sourceFiles.length > 0
-    ? [...sourceFiles].sort()
-    : (samplesPath && existsSync(samplesPath) ? [samplesPath] : []);
-  if (files.length === 0) return null;
-  try {
-    if (files.length === 1) {
-      return createHash('sha256').update(readFileSync(files[0], 'utf-8')).digest('hex').slice(0, 12);
-    }
-    const manifest = files.map((f) => {
-      const base = f.split(/[/\\]/).pop() ?? f;
-      const inner = createHash('sha256').update(readFileSync(f, 'utf-8')).digest('hex');
-      return `${base}:${inner}`;
-    }).join('\n');
-    return createHash('sha256').update(manifest).digest('hex').slice(0, 12);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Compute structural power warnings (pure function, no I/O — for testing).
- *
- * Not MDE / power-analysis predictions (we don't have σ pre-run; predicting
- * "CI half-width ~ ±0.4" before any data exists is hand-wave). These are
- * **hard-floor + experience-based** thresholds:
- *   - n < 5: any conclusion unreliable, CI uselessly wide
- *   - 5 ≤ n < 20: only large effects (Cohen's d > 0.8) detectable
- *   - repeat=1: stability cannot be measured at all
- *
- * Real power claims happen post-hoc via `omk eval` UNDERPOWERED state +
- * saturation curves. This is the upfront "you might be wasting the run"
- * heads-up, not a gate.
- */
-export function buildPowerWarnings(sampleCount: number, repeat: number, lang: Lang = 'zh'): string[] {
-  const warnings: string[] = [];
-  if (sampleCount < 5) {
-    warnings.push(tEvalWorkflowMessage('power_warning_tiny_n', lang, { n: sampleCount }));
-  } else if (sampleCount < 20) {
-    warnings.push(tEvalWorkflowMessage('power_warning_small_n', lang, { n: sampleCount }));
-  }
-  if (repeat < 2) {
-    warnings.push(tEvalWorkflowMessage('power_warning_repeat_one', lang));
-  }
-  return warnings;
-}
-
-function emitPowerWarnings(sampleCount: number, repeat: number, lang: Lang): void {
-  for (const w of buildPowerWarnings(sampleCount, repeat, lang)) {
-    process.stderr.write(`${w}\n`);
-  }
-}
-
-/**
- * Pre-flight warning emitted when user explicitly opts out of strict-baseline
- * (--no-strict-baseline) AND there are baseline-kind variants AND ~/.claude/skills/
- * has content. baseline 会被 SDK 全发现污染 → verdict / Δ 不可信。
- *
- * 默认 strict 时(strictBaseline === true / undefined)不出 warn。
- *
- * Exported for tests.
- */
-export function buildIsolationWarnings(
-  artifacts: Artifact[],
-  strictBaseline: boolean | undefined,
-): string[] {
-  // Only warn when user explicitly disabled isolation.
-  if (strictBaseline !== false) return [];
-
-  const hasBaselineKind = artifacts.some((a) => a.kind === 'baseline');
-  if (!hasBaselineKind) return [];
-
-  // Check ~/.claude/skills/ for content (avoid hard-coding home — read at runtime).
-  const skillsDir = join(homedir(), '.claude', 'skills');
-  if (!existsSync(skillsDir)) return [];
-
-  let skillCount = 0;
-  try {
-    skillCount = readdirSync(skillsDir).filter((entry) => !entry.startsWith('.')).length;
-  } catch {
-    return [];
-  }
-  if (skillCount === 0) return [];
-
-  return [
-    `⚠ baseline 隔离已关闭(--no-strict-baseline)。检测到 ~/.claude/skills/ 内有 ${skillCount} 个 skill, baseline variant 可能被 auto-discovery 污染。除非你确认要这种比较,建议恢复默认 strict 模式。`,
-  ];
-}
-
-function emitIsolationWarnings(artifacts: Artifact[], strictBaseline: boolean | undefined): void {
-  for (const w of buildIsolationWarnings(artifacts, strictBaseline)) {
-    process.stderr.write(`${w}\n`);
-  }
-}
-
-function finalizeEvaluationReport({
-  report,
-  results,
-  artifacts,
-  variantNames,
-  blind,
-  samplesPath,
-  samplesSourceFiles,
-  samples,
-}: {
-  report: Report;
-  results: EvaluationResults;
-  artifacts: Artifact[];
-  variantNames: string[];
-  blind: boolean;
-  samplesPath: string;
-  /** 目录模式下,bundle 内所有源文件;单文件模式下 [samplesPath]。computeTestSetHash 用。 */
-  samplesSourceFiles?: string[];
-  samples: Sample[];
-}): Report {
-  // pass samples so analyzeResults can populate analysis.sampleQuality
-  // (capability/difficulty/construct/provenance coverage aggregate). Without
-  // samples, analysis.sampleQuality is omitted (老报告读取仍可工作).
-  report.analysis = analyzeResults(report, { samples });
-
-  const hasToolData = Object.values(results).some((sampleResults) => (
-    Object.values(sampleResults).some((variantResult) => variantResult.toolCalls && variantResult.toolCalls.length > 0)
-  ));
-  if (hasToolData) {
-    const artifactContents = Object.fromEntries(artifacts.map((artifact) => [artifact.name, artifact.content]));
-    const artifactCwds = Object.fromEntries(artifacts.map((artifact) => [artifact.name, artifact.cwd || null]));
-    const coverage = computeReportCoverage(report, artifactContents, artifactCwds);
-    if (Object.keys(coverage).length > 0) {
-      report.analysis!.coverage = coverage;
-    }
-  }
-
-  // Gap rate computation runs on every successful report regardless of whether
-  // tool trace data is present — text-based signals (markers, hedging) still
-  // apply. The samples-file SHA is the mandatory watermark required by spec §7.1.
-  const gapReports = computeReportGapRates(report.results, variantNames);
-  if (Object.keys(gapReports).length > 0) {
-    const testSetHash = computeTestSetHash(samplesPath, samplesSourceFiles);
-    for (const variant of variantNames) {
-      const gr = gapReports[variant];
-      if (!gr) continue;
-      gr.testSetPath = samplesPath;
-      gr.testSetHash = testSetHash;
-    }
-    report.analysis!.gapReports = gapReports;
-  }
-
-  if (blind) {
-    applyBlindMode(report, variantNames, `${variantNames.join(',')}:${samplesPath}`);
-  }
-
-  return report;
-}
+// 兼容 re-export:测试与 run-evaluation.ts 动态 import 仍打 evaluation-pipeline.js
+export { buildPowerWarnings, buildIsolationWarnings } from './evaluation-pipeline/preflight-warnings.js';
+export { _computeTestSetHashForTest } from './evaluation-pipeline/test-set-hash.js';
 
 export interface EvaluationPipelineOptions {
   samplesPath: string;
@@ -416,6 +112,8 @@ export interface EvaluationPipelineOptions {
   /** 关闭 diagnostic。Default false。 */
   noDiagnostic?: boolean;
 }
+
+type VariantResult = import('../types/index.js').VariantResult;
 
 export async function executeEvaluationPipeline({
   samplesPath,

--- a/src/eval-workflows/evaluation-pipeline/preflight-warnings.ts
+++ b/src/eval-workflows/evaluation-pipeline/preflight-warnings.ts
@@ -1,0 +1,74 @@
+/**
+ * preflight 阶段的结构性 / 隔离性警告。
+ *
+ * 两组互不相关的 warning,共用「执行前 stderr 提示,不是 verdict gate」的语义:
+ *   - power: 基于 sample 数 / repeat 的硬底线(n<5 不可靠, n<20 仅能测大效应,
+ *     repeat<2 无法测稳定性)。**不是 MDE / power analysis 预测** —— run 之前
+ *     还没有 σ,预测「CI 半宽 ~ ±0.4」是手挥;真正的 power 判定在 post-hoc
+ *     verdict(UNDERPOWERED state + saturation curve)
+ *   - isolation: 用户显式 `--no-strict-baseline` 且存在 baseline-kind variant 且
+ *     `~/.claude/skills/` 里有内容 —— baseline 会被 SDK 全发现污染,verdict / Δ
+ *     不可信。默认 strict 时不出 warn
+ *
+ * `buildXxxWarnings` 是纯函数,export 给单测断言文案语义;`emitXxxWarnings` 是
+ * 写 stderr 的薄包装,只给 orchestrator 用。
+ */
+
+import { existsSync, readdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { Artifact } from '../../types/index.js';
+import type { Lang } from '../../types/shared.js';
+import { tEvalWorkflowMessage } from '../messages.js';
+
+export function buildPowerWarnings(sampleCount: number, repeat: number, lang: Lang = 'zh'): string[] {
+  const warnings: string[] = [];
+  if (sampleCount < 5) {
+    warnings.push(tEvalWorkflowMessage('power_warning_tiny_n', lang, { n: sampleCount }));
+  } else if (sampleCount < 20) {
+    warnings.push(tEvalWorkflowMessage('power_warning_small_n', lang, { n: sampleCount }));
+  }
+  if (repeat < 2) {
+    warnings.push(tEvalWorkflowMessage('power_warning_repeat_one', lang));
+  }
+  return warnings;
+}
+
+export function emitPowerWarnings(sampleCount: number, repeat: number, lang: Lang): void {
+  for (const w of buildPowerWarnings(sampleCount, repeat, lang)) {
+    process.stderr.write(`${w}\n`);
+  }
+}
+
+export function buildIsolationWarnings(
+  artifacts: Artifact[],
+  strictBaseline: boolean | undefined,
+): string[] {
+  // Only warn when user explicitly disabled isolation.
+  if (strictBaseline !== false) return [];
+
+  const hasBaselineKind = artifacts.some((a) => a.kind === 'baseline');
+  if (!hasBaselineKind) return [];
+
+  // Check ~/.claude/skills/ for content (avoid hard-coding home — read at runtime).
+  const skillsDir = join(homedir(), '.claude', 'skills');
+  if (!existsSync(skillsDir)) return [];
+
+  let skillCount = 0;
+  try {
+    skillCount = readdirSync(skillsDir).filter((entry) => !entry.startsWith('.')).length;
+  } catch {
+    return [];
+  }
+  if (skillCount === 0) return [];
+
+  return [
+    `⚠ baseline 隔离已关闭(--no-strict-baseline)。检测到 ~/.claude/skills/ 内有 ${skillCount} 个 skill, baseline variant 可能被 auto-discovery 污染。除非你确认要这种比较,建议恢复默认 strict 模式。`,
+  ];
+}
+
+export function emitIsolationWarnings(artifacts: Artifact[], strictBaseline: boolean | undefined): void {
+  for (const w of buildIsolationWarnings(artifacts, strictBaseline)) {
+    process.stderr.write(`${w}\n`);
+  }
+}

--- a/src/eval-workflows/evaluation-pipeline/report-finalize.ts
+++ b/src/eval-workflows/evaluation-pipeline/report-finalize.ts
@@ -1,0 +1,85 @@
+/**
+ * Report 最终化 —— task execution 结果 → 完整 Report。
+ *
+ * `executeTasks` 出来的是裸结果(results / totalCostUSD),`aggregateReport` 把
+ * 它们包成 Report 骨架。`finalizeEvaluationReport` 在这之上挂三层后置分析:
+ *   - `report.analysis` 主体: diagnostics + sampleQuality(传入 samples 用于
+ *     capability / difficulty / construct / provenance 覆盖率聚合)
+ *   - 可选 coverage: 仅当结果里含 tool trace 数据时计算
+ *   - 可选 gapReports: 文本信号(markers / hedging)始终适用,与 tool trace 无关;
+ *     带上 testSetHash 水印(spec §7.1 强制要求)
+ *
+ * 最后一步 `applyBlindMode` 是 blind 模式下的字段脱敏,放在所有 analysis 之后,
+ * 避免脱敏后字段被分析逻辑读取。
+ *
+ * 仅被 orchestrator 调用;独立拆出主要为让 orchestrator 的 try-finally 主干
+ * 看起来纯粹是「执行→收尾」时序。
+ */
+
+import { analyzeResults } from '../../analysis/report-diagnostics.js';
+import { computeReportCoverage } from '../../analysis/coverage-analyzer.js';
+import { computeReportGapRates } from '../../analysis/gap-analyzer.js';
+import { applyBlindMode } from '../../eval-core/evaluation-reporting.js';
+import type { Artifact, Report, Sample, VariantResult } from '../../types/index.js';
+import { computeTestSetHash } from './test-set-hash.js';
+
+type EvaluationResults = Record<string, Record<string, VariantResult>>;
+
+export function finalizeEvaluationReport({
+  report,
+  results,
+  artifacts,
+  variantNames,
+  blind,
+  samplesPath,
+  samplesSourceFiles,
+  samples,
+}: {
+  report: Report;
+  results: EvaluationResults;
+  artifacts: Artifact[];
+  variantNames: string[];
+  blind: boolean;
+  samplesPath: string;
+  /** 目录模式下,bundle 内所有源文件;单文件模式下 [samplesPath]。computeTestSetHash 用。 */
+  samplesSourceFiles?: string[];
+  samples: Sample[];
+}): Report {
+  // pass samples so analyzeResults can populate analysis.sampleQuality
+  // (capability/difficulty/construct/provenance coverage aggregate). Without
+  // samples, analysis.sampleQuality is omitted (老报告读取仍可工作).
+  report.analysis = analyzeResults(report, { samples });
+
+  const hasToolData = Object.values(results).some((sampleResults) => (
+    Object.values(sampleResults).some((variantResult) => variantResult.toolCalls && variantResult.toolCalls.length > 0)
+  ));
+  if (hasToolData) {
+    const artifactContents = Object.fromEntries(artifacts.map((artifact) => [artifact.name, artifact.content]));
+    const artifactCwds = Object.fromEntries(artifacts.map((artifact) => [artifact.name, artifact.cwd || null]));
+    const coverage = computeReportCoverage(report, artifactContents, artifactCwds);
+    if (Object.keys(coverage).length > 0) {
+      report.analysis!.coverage = coverage;
+    }
+  }
+
+  // Gap rate computation runs on every successful report regardless of whether
+  // tool trace data is present — text-based signals (markers, hedging) still
+  // apply. The samples-file SHA is the mandatory watermark required by spec §7.1.
+  const gapReports = computeReportGapRates(report.results, variantNames);
+  if (Object.keys(gapReports).length > 0) {
+    const testSetHash = computeTestSetHash(samplesPath, samplesSourceFiles);
+    for (const variant of variantNames) {
+      const gr = gapReports[variant];
+      if (!gr) continue;
+      gr.testSetPath = samplesPath;
+      gr.testSetHash = testSetHash;
+    }
+    report.analysis!.gapReports = gapReports;
+  }
+
+  if (blind) {
+    applyBlindMode(report, variantNames, `${variantNames.join(',')}:${samplesPath}`);
+  }
+
+  return report;
+}

--- a/src/eval-workflows/evaluation-pipeline/run-state.ts
+++ b/src/eval-workflows/evaluation-pipeline/run-state.ts
@@ -1,0 +1,176 @@
+/**
+ * evaluation pipeline 的运行状态生命周期。
+ *
+ * 把 `EvaluationRunState` + 4 个 helper(initialize / finalizeSuccessfulRun /
+ * persistSuccessfulJob / persistFailedJob)从 evaluation-pipeline.ts 拆出来,
+ * 让 orchestrator 主体回归「编排」单职责。这些 helper 之间是线性时序耦合
+ * (init → preflight → executeTasks → finalize → persist),向上只被
+ * `executeEvaluationPipeline` 调用,向下只依赖 `eval-core/evaluation-job` 与
+ * `server/job-store` 的纯 job-store 抽象,与 task execution / report assembly
+ * 解耦。
+ *
+ * 不再单独 export 给测试 —— job 生命周期通过 orchestrator 间接验证,无独立单测。
+ */
+
+import {
+  buildEvaluationRequest,
+  createFailedJob,
+  createEvaluationRun,
+  createQueuedJob,
+  createSucceededJob,
+  finalizeEvaluationRun,
+  markJobRunning,
+  failEvaluationRun,
+} from '../../eval-core/evaluation-job.js';
+import {
+  createFileJobStore,
+  DEFAULT_JOBS_DIR,
+} from '../../server/job-store.js';
+import type {
+  Artifact,
+  EvaluationJob,
+  EvaluationRequest,
+  EvaluationRun,
+  JobStore,
+} from '../../types/index.js';
+
+export interface EvaluationRunState {
+  request: EvaluationRequest;
+  runId: string;
+  jobId: string;
+  createdAt: string;
+  startedAt: string;
+  initialRun: EvaluationRun;
+  runningJob: EvaluationJob;
+  resolvedJobStore: JobStore | null;
+}
+
+export async function initializeEvaluationRunState({
+  samplesPath,
+  skillDir,
+  artifacts,
+  model,
+  judgeModel,
+  noJudge,
+  executorName,
+  judgeExecutorName,
+  concurrency,
+  timeoutMs,
+  noCache,
+  blind,
+  project,
+  owner,
+  tags,
+  runId,
+  jobStore,
+  persistJob,
+  repeat,
+  batch,
+  judgeRepeat,
+  judgeModels,
+  bootstrap,
+  bootstrapSamples,
+  lengthDebias,
+  budget,
+  effort,
+}: {
+  samplesPath: string;
+  skillDir: string;
+  artifacts: Artifact[];
+  model: string;
+  judgeModel: string;
+  noJudge: boolean;
+  executorName: string;
+  judgeExecutorName: string;
+  concurrency: number;
+  timeoutMs?: number;
+  noCache: boolean;
+  blind: boolean;
+  project?: string;
+  owner?: string;
+  tags?: string[];
+  runId: string;
+  jobStore?: JobStore | null;
+  persistJob?: boolean;
+  repeat?: number;
+  batch?: boolean;
+  judgeRepeat?: number;
+  judgeModels?: import('../../types/index.js').JudgeConfig[];
+  bootstrap?: boolean;
+  bootstrapSamples?: number;
+  lengthDebias?: boolean;
+  budget?: import('../../types/index.js').EvalBudget;
+  effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+}): Promise<EvaluationRunState> {
+  const effectiveJudges: import('../../types/index.js').JudgeConfig[] = judgeModels && judgeModels.length > 0
+    ? judgeModels
+    : [{ executor: judgeExecutorName, model: judgeModel }];
+  const request = buildEvaluationRequest({
+    samplesPath,
+    skillDir,
+    artifacts,
+    model,
+    executor: executorName,
+    noJudge,
+    concurrency,
+    timeoutMs,
+    noCache,
+    dryRun: false,
+    blind,
+    project,
+    owner,
+    tags,
+    repeat,
+    batch,
+    judgeRepeat,
+    judgeModels: effectiveJudges,
+    bootstrap,
+    bootstrapSamples,
+    lengthDebias,
+    budget,
+    effort,
+  });
+  const createdAt = new Date().toISOString();
+  const { run: initialRun, startedAt } = createEvaluationRun(runId, createdAt);
+  const jobId = `job-${runId}`;
+  const resolvedJobStore = persistJob ? (jobStore ?? createFileJobStore(DEFAULT_JOBS_DIR)) : null;
+  const queuedJob = createQueuedJob({ jobId, request, createdAt });
+  if (resolvedJobStore) await resolvedJobStore.save(jobId, queuedJob);
+  const runningJob = markJobRunning(queuedJob, runId, startedAt);
+  if (resolvedJobStore) await resolvedJobStore.save(jobId, runningJob);
+  return { request, runId, jobId, createdAt, startedAt, initialRun, runningJob, resolvedJobStore };
+}
+
+export function finalizeSuccessfulRun(state: EvaluationRunState) {
+  const finishedAt = new Date().toISOString();
+  const run = finalizeEvaluationRun(state.initialRun, finishedAt);
+  const job = createSucceededJob({
+    jobId: state.jobId,
+    runId: state.runId,
+    reportId: state.runId,
+    request: state.request,
+    createdAt: state.createdAt,
+    startedAt: state.startedAt,
+    finishedAt,
+  });
+  return { run, job };
+}
+
+export async function persistSuccessfulJob(state: EvaluationRunState, job: EvaluationJob): Promise<void> {
+  if (state.resolvedJobStore) {
+    await state.resolvedJobStore.save(state.jobId, job);
+  }
+}
+
+export async function persistFailedJob(state: EvaluationRunState, err: unknown): Promise<void> {
+  const finishedAt = new Date().toISOString();
+  const failedJob = createFailedJob({
+    job: { ...state.runningJob, runId: state.runId, startedAt: state.startedAt, finishedAt: undefined },
+    error: err instanceof Error ? err.message : String(err),
+    finishedAt,
+  });
+  void failEvaluationRun(state.initialRun, finishedAt);
+  if (state.resolvedJobStore) {
+    await state.resolvedJobStore.save(state.jobId, failedJob);
+  }
+}

--- a/src/eval-workflows/evaluation-pipeline/test-set-hash.ts
+++ b/src/eval-workflows/evaluation-pipeline/test-set-hash.ts
@@ -1,0 +1,46 @@
+/**
+ * 测试集水印 hash 计算(spec §7.1)。
+ *
+ * 规则:
+ *   - 单文件 / sourceFiles 单元素:hash 该文件内容
+ *   - 多文件(目录模式):按文件名排序后,把每个文件 basename + sha256 拼成
+ *     manifest,对 manifest 再 sha256,取前 12 hex chars。这样:
+ *       1. 加 / 删 sample 文件 → hash 变
+ *       2. 任一文件内容改 → hash 变
+ *       3. 同样文件不同顺序 → hash 不变(排序后稳定)
+ *
+ * 历史问题: 之前对目录 readFileSync() 抛 EISDIR → 返回 null,gap report 水印丢失。
+ *
+ * 导出:
+ *   - `computeTestSetHash`: pipeline 内部使用
+ *   - `_computeTestSetHashForTest`: 单测专用别名,保留以兼容历史 import surface
+ *     (`test/eval-workflows/test-set-hash.test.ts`)
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+
+export function computeTestSetHash(samplesPath: string, sourceFiles?: string[]): string | null {
+  // 优先 sourceFiles(目录模式可靠),fallback samplesPath 兼容老调用
+  const files = sourceFiles && sourceFiles.length > 0
+    ? [...sourceFiles].sort()
+    : (samplesPath && existsSync(samplesPath) ? [samplesPath] : []);
+  if (files.length === 0) return null;
+  try {
+    if (files.length === 1) {
+      return createHash('sha256').update(readFileSync(files[0], 'utf-8')).digest('hex').slice(0, 12);
+    }
+    const manifest = files.map((f) => {
+      const base = f.split(/[/\\]/).pop() ?? f;
+      const inner = createHash('sha256').update(readFileSync(f, 'utf-8')).digest('hex');
+      return `${base}:${inner}`;
+    }).join('\n');
+    return createHash('sha256').update(manifest).digest('hex').slice(0, 12);
+  } catch {
+    return null;
+  }
+}
+
+export function _computeTestSetHashForTest(samplesPath: string, sourceFiles?: string[]): string | null {
+  return computeTestSetHash(samplesPath, sourceFiles);
+}


### PR DESCRIPTION
## Summary

- 把 `src/eval-workflows/evaluation-pipeline.ts`(610 行)按 5 个职责 cluster 拆成主文件(orchestrator + options)+ 同级 `evaluation-pipeline/` 目录下 4 个 helper
- 主文件收敛到约 280 行,纯粹是「执行+收尾」时序编排;4 块 helper 与 orchestrator 1:1 协作,无环依赖
- 保留兼容 re-export(`buildPowerWarnings` / `buildIsolationWarnings` / `_computeTestSetHashForTest`),test 与 `run-evaluation.ts:275` 动态 import 路径全部零改动

## 拆分布局

```
src/eval-workflows/
├── evaluation-pipeline.ts                       (orchestrator, ~280 行)
└── evaluation-pipeline/
    ├── run-state.ts                             EvaluationRunState 生命周期
    ├── test-set-hash.ts                         测试集水印 hash(spec §7.1)
    ├── preflight-warnings.ts                    power + isolation 结构性预警
    └── report-finalize.ts                       report 后置分析装配
```

## 阶段 7 上下文

roadmap 阶段 7 原本立项是「三入口共享 evaluation assembly」,survey 发现该前提不成立:
- `omk eval` 是唯一有完整 pipeline 的入口
- `omk sample --fix` 只用 `createExecutor('claude')` 修 sample,没有 judge / renderer / cache
- server 不跑 eval execution

装配早已收敛在 `evaluation-pipeline.ts:500-521`。所以 PR1 改为 clarity pass:review `evaluation-pipeline.ts` 看是否有可拆点 —— 结论是有,5 个 cluster 单向耦合干净,值得一刀。

## 测量学不变量

无 BREAKING-COMPARABILITY。所有改动是搬代码不改语义:
- `src/types/report.ts` / `src/eval-core/{bootstrap,statistics,comparability}.ts` / `src/grading/{judge,assertions,layered-scores}.ts` / 所有 prompt 文件 diff 为空
- judge prompt hash / observe LLM 增强复盘 prompt hash 不变(测试通过)
- HTML snapshot 不动(本 PR 不碰 renderer)

## Test plan

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn build` + `yarn build:docs:check`
- [x] `yarn test` 1615/1615 全通过
- [x] `git diff main -- src/types/report.ts src/eval-core/* src/grading/* 'src/**/prompts/**' 'src/**/*.prompt.md' 'src/shared/llm-prompts/**'` 为空