### PR TITLE
refactor(observability): inbox-view-model 收敛 renderer 对 observability 的细粒度 import

### DIFF
--- a/src/observability/inbox-view-model.ts
+++ b/src/observability/inbox-view-model.ts
@@ -182,3 +182,45 @@ function buildReportSessionTimeRange(ranges: ObservationInboxReport['meta']['ses
   const to = ends.reduce((max, value) => value > max ? value : max, ends[0]);
   return { from, to, durationMs: durationMsBetween(from, to) };
 }
+
+// ============================================================================
+// observability → renderer 投影 facade。
+//
+// 把 observation-inbox-renderer.ts 对 observability 内部多个 module 的细粒度
+// import 收敛到 view-model 一处:renderer 只 import 这里 + 已经 facade 化的
+// feedback-projection.js。observability 内部如何重组(rename、拆模块)对
+// renderer 透明。
+//
+// 设计原则:
+//   - 仅 re-export,不做语义合并 / 不引入新类型 / 不写运行时逻辑
+//   - 不改任何字节级输出(html-renderer snapshot 必须字节一致)
+//   - 适合 pre-project 的 function(每个 item / annotation 算一次)后续可上移
+//     到 build view-model 时算好挂字段;text-signal 这类「每次 input 不同」
+//     的保留 facade 形态
+//
+// 范围:仅 observation-inbox-renderer.ts 用到的子集。CLI / server 等其它消费者
+// 继续直接 import observability 内部 —— 它们不是「视图」,不在 facade 收敛范围。
+// ============================================================================
+
+export { severityReasonFor } from './inbox.js';
+export { observationMetricAnnotationTargetId } from './review-state.js';
+export { resolveObservationReviewSession } from './resolved-review.js';
+export { getSkillChainAdvisory, resolveAdvisoryCommand } from './skill-chain-advisories.js';
+export {
+  ASSISTANT_DELIVERABLE_ARTIFACT_RE,
+  hasAssistantDeliverableArtifactText,
+  hasAssistantDeliverySignalText,
+  hasUserHardRuleText,
+  HARD_RULE_TEXT_RE,
+  isAssistantProgressUpdateText,
+  isScheduledTaskPromptText,
+  isSyntheticUserMessageText,
+  isUserInteractionMetricText,
+} from './text-signals.js';
+
+export type { ObservationInboxItem } from './inbox.js';
+export type { ObservationMetricKey } from './review-state.js';
+export type { ResolvedObservationReviewSession, ResolvedOwnerSuggestion } from './resolved-review.js';
+export type { SkillChainAdvisoryCode } from './skill-chain-advisories.js';
+export type { ExperienceProblemBucket, ExperienceProblemPattern, ExperienceProblemSignal } from './problem-patterns.js';
+export type { SkillDerivedStandard, SkillLlmEnhancedReviewSections } from './soft-standards/index.js';

--- a/src/renderer/observation-inbox-renderer.ts
+++ b/src/renderer/observation-inbox-renderer.ts
@@ -1,15 +1,35 @@
 import { DEFAULT_LANG, layout, e } from './layout.js';
 import type { Lang } from '../types/index.js';
-import { severityReasonFor } from '../observability/inbox.js';
-import type { ObservationInboxItem } from '../observability/inbox.js';
-import type { ObservationInboxViewModel } from '../observability/inbox-view-model.js';
+import {
+  severityReasonFor,
+  observationMetricAnnotationTargetId,
+  resolveObservationReviewSession,
+  getSkillChainAdvisory,
+  resolveAdvisoryCommand,
+  ASSISTANT_DELIVERABLE_ARTIFACT_RE,
+  hasAssistantDeliverableArtifactText,
+  hasAssistantDeliverySignalText,
+  hasUserHardRuleText,
+  HARD_RULE_TEXT_RE,
+  isAssistantProgressUpdateText,
+  isScheduledTaskPromptText,
+  isSyntheticUserMessageText,
+  isUserInteractionMetricText,
+} from '../observability/inbox-view-model.js';
+import type {
+  ObservationInboxItem,
+  ObservationInboxViewModel,
+  ObservationMetricKey,
+  ResolvedObservationReviewSession,
+  ResolvedOwnerSuggestion,
+  SkillChainAdvisoryCode,
+  ExperienceProblemBucket,
+  ExperienceProblemPattern,
+  ExperienceProblemSignal,
+  SkillDerivedStandard,
+  SkillLlmEnhancedReviewSections,
+} from '../observability/inbox-view-model.js';
 import { findNegativeFeedbackMatches, findPositiveFeedbackMatches, findUserCorrectionMatches, findUserGoalShiftMatches, hasUserCorrectionSignal, hasUserGoalShiftSignal } from '../observability/feedback-projection.js';
-import type { ExperienceProblemBucket, ExperienceProblemPattern, ExperienceProblemSignal } from '../observability/problem-patterns.js';
-import { observationMetricAnnotationTargetId, type ObservationMetricKey } from '../observability/review-state.js';
-import { resolveObservationReviewSession, type ResolvedObservationReviewSession, type ResolvedOwnerSuggestion } from '../observability/resolved-review.js';
-import { getSkillChainAdvisory, resolveAdvisoryCommand, type SkillChainAdvisoryCode } from '../observability/skill-chain-advisories.js';
-import type { SkillDerivedStandard, SkillLlmEnhancedReviewSections } from '../observability/soft-standards/index.js';
-import { ASSISTANT_DELIVERABLE_ARTIFACT_RE, hasAssistantDeliverableArtifactText, hasAssistantDeliverySignalText, hasUserHardRuleText, HARD_RULE_TEXT_RE, isAssistantProgressUpdateText, isScheduledTaskPromptText, isSyntheticUserMessageText, isUserInteractionMetricText } from '../observability/text-signals.js';
 import { durationMsBetween } from '../shared/time.js';
 import { OBSERVATION_INBOX_STYLES } from './observation-inbox/styles.js';
 import type {


### PR DESCRIPTION
## Summary

- `observation-inbox-renderer.ts` 原本从 observability 内部 8 个 module 细粒度 import 符号(inbox / problem-patterns / resolved-review / review-state / skill-chain-advisories / soft-standards / text-signals 等)。把这些 re-export 收敛到 `observability/inbox-view-model.ts` 一处。
- renderer 现在只 import 两个 facade:`observability/inbox-view-model.js`(本次新增的 facade 段)+ `observability/feedback-projection.js`(已有 facade)。
- observability 内部如何 rename / 拆分对 renderer 透明,后续重组无需再追改 renderer import。

## 不变量

- 仅 re-export,不做语义合并 / 不引入新类型 / 不写运行时逻辑
- HTML snapshot 字节一致(1615 tests pass)
- 红区文件 0 改动(types/report / eval-core/* / grading/* / prompts 全程无 touch)
- 无 BREAKING-COMPARABILITY

## 范围说明

CLI / server 等其它消费者继续直接 import observability 内部 —— 它们不是「视图」,不在 facade 收敛范围。

## Test plan

- [x] `yarn typecheck` 通过
- [x] `yarn lint` 通过
- [x] `yarn test` 1615/1615 通过(HTML snapshot 字节一致)
- [x] `yarn build` 通过
- [x] 红区 diff 为空

🤖 Generated with [Claude Code](https://claude.com/claude-code)