### PR TITLE
refactor(observability): 把 resolveObservationReviewSession 预投影到 ViewModel

### DIFF
--- a/src/observability/inbox-view-model.ts
+++ b/src/observability/inbox-view-model.ts
@@ -6,6 +6,10 @@ import {
 } from './inbox.js';
 import type { ObservationExperienceReport } from './experience.js';
 import { loadObservationReviewState, type ObservationReviewState } from './review-state.js';
+import {
+  resolveObservationReviewSession,
+  type ResolvedObservationReviewSession,
+} from './resolved-review.js';
 import { buildObservationSkillChains, type ObservationSkillChain } from './skill-chain.js';
 import {
   loadSkillDerivedStandards,
@@ -34,6 +38,10 @@ export interface ObservationInboxViewModel {
   reportCount: number;
   latestSeenLabel: string;
   reviewState: ObservationReviewState;
+  // 预投影:对 experience 里每个 session 提前算好 resolved review,renderer 多处用
+  // 同一份(card / list / aggregate),避免在 render path 上对同一 session 反复
+  // resolve。键 = session.id。
+  resolvedReviewSessions: Record<string, ResolvedObservationReviewSession>;
 }
 
 export interface ObservationInboxViewModelOptions {
@@ -100,6 +108,17 @@ export function buildObservationInboxViewModel(observationsDir: string, options:
   const reportCount = reports.length;
   const latestSeenLabel = latestSeen ? latestSeen.slice(0, 19).replace('T', ' ') : '—';
   const reviewState = loadObservationReviewState(observationsDir);
+  const resolvedReviewSessions: Record<string, ResolvedObservationReviewSession> = {};
+  for (const experience of experienceReports) {
+    for (const session of experience.sessions) {
+      const enhancedReview = skillDerivedStandards[session.skillName]?.enhancedReview;
+      resolvedReviewSessions[session.id] = resolveObservationReviewSession({
+        session,
+        enhancedReview,
+        reviewState,
+      });
+    }
+  }
 
   return {
     activeSkill,
@@ -120,6 +139,7 @@ export function buildObservationInboxViewModel(observationsDir: string, options:
     reportCount,
     latestSeenLabel,
     reviewState,
+    resolvedReviewSessions,
   };
 }
 

--- a/src/renderer/observation-inbox-renderer.ts
+++ b/src/renderer/observation-inbox-renderer.ts
@@ -3,7 +3,6 @@ import type { Lang } from '../types/index.js';
 import {
   severityReasonFor,
   observationMetricAnnotationTargetId,
-  resolveObservationReviewSession,
   getSkillChainAdvisory,
   resolveAdvisoryCommand,
   ASSISTANT_DELIVERABLE_ARTIFACT_RE,
@@ -90,6 +89,7 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
     reportCount,
     latestSeenLabel,
 	    reviewState,
+    resolvedReviewSessions,
 	  } = model;
 	  const experience = experienceReports.find((report) => report.skills.length > 0 || report.sessions.length > 0 || report.invocations.length > 0);
 	  const pageTitle = activeSkill ? `Observe Inbox · ${activeSkill}` : 'Observe Inbox';
@@ -3582,17 +3582,12 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
     </tr>`;
   }).join('');
   void experienceSkillRows;
-  const inboxLlmReviewForPriority = (skillName: string): SkillLlmEnhancedReviewSections | undefined =>
-    skillDerivedStandards[skillName]?.enhancedReview;
+  // resolvedReviewSessions 在 ViewModel build 阶段已经按 session.id 预投影。
+  // 这里只做查表,避免 render path 上对同一 session 反复 resolve。
   const inboxResolvedSession = (skill: ExperienceSessionSummary): ResolvedObservationReviewSession =>
-    resolveObservationReviewSession({
-      session: skill,
-      enhancedReview: inboxLlmReviewForPriority(skill.skillName),
-      reviewState,
-    });
-  const inboxResolvedPriority = (skill: ExperienceSessionSummary): ExperienceReviewPriority => {
-    return inboxResolvedSession(skill).priority;
-  };
+    resolvedReviewSessions[skill.id];
+  const inboxResolvedPriority = (skill: ExperienceSessionSummary): ExperienceReviewPriority =>
+    resolvedReviewSessions[skill.id].priority;
   const sessionSkillOrder = new Map((experience?.skills ?? []).map((skill, index) => [skill.skillName, index]));
   const experienceSessionGroups = Array.from((experience?.sessions ?? []).reduce((map, session) => {
     const group = map.get(session.skillName) ?? [];

--- a/test/observability/inbox.test.ts
+++ b/test/observability/inbox.test.ts
@@ -57,7 +57,18 @@ import {
   updateSkillDerivedStandardStatus,
 } from '../../src/observability/soft-standards/index.js';
 import type { ObservationSkillChain } from '../../src/observability/skill-chain.js';
+import { resolveObservationReviewSession, type ResolvedObservationReviewSession } from '../../src/observability/resolved-review.js';
+import type { ObservationExperienceReport } from '../../src/observability/experience.js';
+import type { ObservationReviewState } from '../../src/observability/review-state.js';
 import { renderFeedbackAttributionLabel, renderObservationInboxPage } from '../../src/renderer/observation-inbox-renderer.js';
+
+function resolvedReviewSessionsForFixture(experience: ObservationExperienceReport, reviewState: ObservationReviewState): Record<string, ResolvedObservationReviewSession> {
+  return Object.fromEntries(experience.sessions.map((session) => [session.id, resolveObservationReviewSession({
+    session,
+    enhancedReview: undefined,
+    reviewState,
+  })]));
+}
 
 function businessActionTag(name: string, text: string): string {
   const tag = ['ai', 'ma-cmd'].join('');
@@ -403,6 +414,7 @@ describe('observe inbox', () => {
       reportCount: 1,
       latestSeenLabel: '2026-05-10 00:00:02',
       reviewState,
+      resolvedReviewSessions: resolvedReviewSessionsForFixture(annotatedReport.experience!, reviewState),
     });
     assert.match(rendered, /<span class="inbox-answer-check is-(?:detected|absent)"[^>]*>[\s\S]*(?:没给可点开的产物|给了可点开的产物|会话进行中)/);
   });
@@ -1234,6 +1246,12 @@ describe('observe inbox', () => {
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       },
+      resolvedReviewSessions: resolvedReviewSessionsForFixture(experience, {
+        kind: 'observe-review-state',
+        schemaVersion: 1,
+        updatedAt: '2026-05-01T00:00:00.000Z',
+        entries: {},
+      }),
     });
     assert.equal((rendered.match(/data-inbox-card="audit"/g) ?? []).length, 1);
     assert.equal((rendered.match(/data-session-tab="/g) ?? []).length, 2);
@@ -1993,6 +2011,12 @@ describe('observe inbox', () => {
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       },
+      resolvedReviewSessions: resolvedReviewSessionsForFixture(experience, {
+        kind: 'observe-review-state',
+        schemaVersion: 1,
+        updatedAt: '2026-05-01T00:00:00.000Z',
+        entries: {},
+      }),
     });
     assert.match(rendered, /线上观测报告/);
     assert.match(rendered, /class="inbox-shell"/);


### PR DESCRIPTION
## Summary

- observation-inbox-renderer 原本在 render path 上通过 `inboxResolvedSession` / `inboxResolvedPriority` 两个 helper 对 experience 里每个 session 反复调用 `resolveObservationReviewSession`,15+ 个调用点(card / list / aggregate / filter 多处共用同一份 resolution)。
- 把这一步上移到 ViewModel build 阶段:遍历 `experienceReports.sessions`,以 `session.id` 为键预算好 resolved review,挂到 `ObservationInboxViewModel.resolvedReviewSessions`。
- renderer 两个 helper 退化为查表;不再持有 `resolveObservationReviewSession` 的 import。

## 为什么这次只 pre-project 这一个

PR1 facade 收敛后,我把 renderer 当前用到的 observability function 都过了一遍判断 pre-projection 是否成立:

| 函数 | 是否 pre-project | 理由 |
|---|---|---|
| `severityReasonFor(item, lang)` | 否 | 依赖 render-time lang,ViewModel build 不知 lang |
| `observationMetricAnnotationTargetId(event, metricKey)` | 否 | 依赖 per-call event + metricScopeId,不是「同 input 多次算」 |
| `resolveObservationReviewSession(...)` | **是** | 输入(session、reviewState、skillDerivedStandards)全在 ViewModel,15+ 调用点共用同一份 |
| `getSkillChainAdvisory(code)` | 否 | 纯字典查表,无 compute-once-use-many 收益 |
| `resolveAdvisoryCommand(advisory, skillName)` | 否 | 依赖 per-call skillName |

## 不变量

- `resolveObservationReviewSession` 实现 0 改动,仅调用位置上移
- HTML snapshot 字节一致(1615 tests pass)
- 红区 0 改动(types/report / eval-core/* / grading/* / prompts 全程无 touch)
- 无 BREAKING-COMPARABILITY

## 同步改动

`test/observability/inbox.test.ts` 三个手写 ViewModel fixture 加上 `resolvedReviewSessions` 字段:抽了一个 `resolvedReviewSessionsForFixture(experience, reviewState)` helper,空 `skillDerivedStandards` 下 `enhancedReview` 传 undefined,跟生产 build 路径行为一致。

## Test plan

- [x] `yarn typecheck` 通过
- [x] `yarn lint` 通过
- [x] `yarn test` 1615/1615 通过(HTML snapshot 字节一致)
- [x] `yarn build` 通过
- [x] 红区 diff 为空

🤖 Generated with [Claude Code](https://claude.com/claude-code)