### PR TITLE
chore(observability): 清理重构遗留 phase tag 与 experience matcher re-export

### DIFF
--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -27,18 +27,6 @@ import {
   hasUserGoalShiftSignal,
 } from './feedback-matchers.js';
 
-export {
-  findNegativeFeedbackMatches,
-  findPositiveFeedbackMatches,
-  findUserCorrectionMatches,
-  findUserGoalShiftMatches,
-  hasNegativeFeedbackSignal,
-  hasPositiveFeedbackSignal,
-  hasUserCorrectionSignal,
-  hasUserGoalShiftSignal,
-} from './feedback-matchers.js';
-export type { TextMatchRange } from './feedback-matchers.js';
-
 export type ExperienceReviewPriority = 'review_first' | 'sample_review' | 'routine_sample';
 export type ExperienceGoalSliceReasonCode = 'skill_segment_boundary' | 'explicit_user_goal_shift' | 'default_session_slice';
 export type ExperienceEvidenceKind = 'user_message' | 'synthetic_user_event' | 'assistant_message' | 'tool_use' | 'tool_result' | 'skill_context' | 'runtime_context' | 'observation';

--- a/src/observability/feedback-projection.ts
+++ b/src/observability/feedback-projection.ts
@@ -1,17 +1,14 @@
 /**
  * observability → renderer 的公开投影层(facade)。
  *
- * renderer(视图层)以前直接 import `observability/experience.ts` 的内部符号
- * (6 个 feedback matcher + 21 个 type),与 experience 内部强耦合。这层 facade
  * 把 renderer 需要的「feedback / experience 投影面」收敛为一个公开 surface:
- * renderer 只 import 这里,experience.ts 内部如何重组(后续阶段 3 拆分 feedback
- * matchers / frontmatter IO)对 renderer 透明。
+ * renderer 只 import 这里,experience / feedback-matchers / frontmatter 等内部
+ * module 如何重组对 renderer 透明。配合 `inbox-view-model.ts` 共同构成 observability
+ * 对 renderer 的两个 facade 入口。
  *
- * 设计原则(阶段 1.5,roadmap):
+ * 设计原则:
  *   - 仅 re-export,不做语义合并 / 不引入新类型 / 不写运行时逻辑
  *   - 不改任何字节级输出(html-renderer snapshot 必须字节一致)
- *   - 阶段 8 的 ViewModel 边界会进一步把这些符号封进 ViewModel,renderer 那时
- *     连这层也不直接看到。本 facade 是中间过渡层,降低阶段 8 的改动面。
  *
  * 范围:仅 renderer 用到的子集。其它消费者(diagnosis / CLI observe ingest)
  * 继续直接 import experience.ts —— 它们不是「视图」,不在 facade 收敛范围内。

--- a/test/observability/inbox.test.ts
+++ b/test/observability/inbox.test.ts
@@ -17,19 +17,21 @@ import {
 } from '../../src/observability/inbox.js';
 import {
   aggregateExperienceChecklistItemStatus,
-  findNegativeFeedbackMatches,
-  findPositiveFeedbackMatches,
-  findUserCorrectionMatches,
-  findUserGoalShiftMatches,
   foldExperienceChecklistItems,
   hasRecognizableUserGoalText,
-  hasNegativeFeedbackSignal,
-  hasPositiveFeedbackSignal,
-  hasUserCorrectionSignal,
   isExperienceTraceInProgress,
   type ExperienceChecklistItem,
   type ExperienceSessionSummary,
 } from '../../src/observability/experience.js';
+import {
+  findNegativeFeedbackMatches,
+  findPositiveFeedbackMatches,
+  findUserCorrectionMatches,
+  findUserGoalShiftMatches,
+  hasNegativeFeedbackSignal,
+  hasPositiveFeedbackSignal,
+  hasUserCorrectionSignal,
+} from '../../src/observability/feedback-matchers.js';
 import {
   hasAssistantDeliverySignalText,
   hasUserHardRuleText,


### PR DESCRIPTION
## Summary

post-roadmap cleanup,两个独立但同主题的小修:

1. `feedback-projection.ts` 文件头注释残留「阶段 1.5,roadmap」「阶段 8 的 ViewModel 边界」等 phase tag —— 违反代码注释不带 review / PR / 版本时点 tag 的约定。重写为去 phase 化的设计描述,保留 facade 意图与范围说明。
2. `experience.ts` 行 30-40 的 6 个 matcher function + TextMatchRange 类型 re-export 是「旧 import 路径兼容层」。production 代码全部已走 `feedback-matchers.js`(直接)或 `feedback-projection.js`(facade),唯一残留消费者是 `test/observability/inbox.test.ts`。把测试的 matcher import 重定向到 `feedback-matchers.js`,删掉 experience.ts 的兼容 re-export。experience.ts 自身仍 import 8 个 matcher 供内部 build 链路用,行为不变。

## 不变量

- HTML snapshot 字节一致(1615 tests pass)
- 红区 0 改动
- 无 BREAKING-COMPARABILITY

## Test plan

- [x] yarn typecheck 通过
- [x] yarn lint 通过
- [x] yarn test 1615/1615 通过
- [x] yarn build 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)