### PR TITLE
refactor(types): Diagnosis 类型集上移解开 observability 反向依赖

### DIFF
--- a/src/diagnosis/types.ts
+++ b/src/diagnosis/types.ts
@@ -1,97 +1,19 @@
-export type DiagnosisSource = 'observe' | 'doctor' | 'eval';
-export type DiagnosisAudience = 'skill-author' | 'sample-author' | 'omk-maintainer' | 'reviewer';
-export type DiagnosisSeverity = 'high' | 'medium' | 'low' | 'info';
-export type DiagnosisLifecycle = 'detected' | 'candidate' | 'confirmed' | 'rejected' | 'resolved' | 'stale';
-export type DiagnosisType =
-  | 'definition_gap'
-  | 'runtime_issue'
-  | 'user_feedback_pattern'
-  | 'eval_failure'
-  | 'sample_design_issue'
-  | 'doctor_gap'
-  | 'standard_candidate'
-  | 'maintenance_issue';
+export type {
+  Diagnosis,
+  DiagnosisAudience,
+  DiagnosisBundle,
+  DiagnosisEvidenceRef,
+  DiagnosisLifecycle,
+  DiagnosisOccurrence,
+  DiagnosisPatch,
+  DiagnosisScope,
+  DiagnosisSeverity,
+  DiagnosisSource,
+  DiagnosisSourceCoverage,
+  DiagnosisType,
+} from '../types/diagnosis.js';
 
-export interface DiagnosisSourceCoverage {
-  observe: boolean;
-  doctor: boolean;
-  eval: boolean;
-}
-
-export interface DiagnosisScope {
-  primary: 'skill' | 'definition' | 'session' | 'sample';
-  refs: {
-    skillName: string;
-    sessionId?: string;
-    invocationId?: string;
-    sampleId?: string;
-    ruleId?: string;
-    workflowId?: string;
-    sourceTrace?: string;
-  };
-}
-
-export interface DiagnosisEvidenceRef {
-  id: string;
-  kind: string;
-  sourceTrace?: string;
-  sessionId?: string;
-  messageIndex?: number;
-  logicalMessageIndex?: number;
-  sourceLineIndex?: number;
-  messageUuid?: string;
-  toolUseId?: string;
-  timestamp?: string;
-  label?: string;
-  snippet?: string;
-}
-
-export interface DiagnosisOccurrence {
-  id: string;
-  diagnosisStableKey: string;
-  source: DiagnosisSource;
-  sourceId: string;
-  sourceKind: string;
-  timestamp?: string;
-  severity?: DiagnosisSeverity;
-  evidenceRefs: DiagnosisEvidenceRef[];
-  rawRef?: string;
-  producer: 'deterministic_rule' | 'llm_soft' | 'manual';
-  payload?: Record<string, unknown>;
-}
-
-export interface DiagnosisPatch {
-  target: 'skill' | 'sample-environment' | 'sample-mocks' | 'doctor-rule' | 'definition';
-  location: string;
-  snippet: string;
-}
-
-export interface Diagnosis {
-  id: string;
-  stableKey: string;
-  skillName: string;
-  type: DiagnosisType;
-  signal: string;
-  title: string;
-  summary?: string;
-  severity: DiagnosisSeverity;
-  audience: DiagnosisAudience;
-  lifecycle: DiagnosisLifecycle;
-  scope: DiagnosisScope;
-  occurrences: DiagnosisOccurrence[];
-  occurrenceCount: number;
-  evidenceSummary?: string;
-  recommendation?: string;
-  patch?: DiagnosisPatch;
-  command?: string;
-}
-
-export interface DiagnosisBundle {
-  schemaVersion: 1;
-  generatedAt: string;
-  sourceCoverage: DiagnosisSourceCoverage;
-  bySkill: Record<string, Diagnosis[]>;
-}
+import type { DiagnosisLifecycle } from '../types/diagnosis.js';
 
 /** Diagnosis 是否「active problem」的唯一权威定义。
  *

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -9,7 +9,7 @@ import { isSearchToolCall, toolCallQuery } from '../shared/tool-search.js';
 import { durationMsBetween } from '../shared/time.js';
 import { buildObservationExperienceReport, type ObservationExperienceReport } from './experience.js';
 import type { ObservationReviewState } from './review-state.js';
-import type { DiagnosisBundle } from '../diagnosis/types.js';
+import type { DiagnosisBundle } from '../types/diagnosis.js';
 
 export const DEFAULT_PROJECT_OBSERVATIONS_DIR = join(process.cwd(), '.omk', 'observations');
 export const DEFAULT_GLOBAL_OBSERVATIONS_DIR = join(homedir(), '.oh-my-knowledge', 'observations');

--- a/src/types/diagnosis.ts
+++ b/src/types/diagnosis.ts
@@ -1,0 +1,94 @@
+export type DiagnosisSource = 'observe' | 'doctor' | 'eval';
+export type DiagnosisAudience = 'skill-author' | 'sample-author' | 'omk-maintainer' | 'reviewer';
+export type DiagnosisSeverity = 'high' | 'medium' | 'low' | 'info';
+export type DiagnosisLifecycle = 'detected' | 'candidate' | 'confirmed' | 'rejected' | 'resolved' | 'stale';
+export type DiagnosisType =
+  | 'definition_gap'
+  | 'runtime_issue'
+  | 'user_feedback_pattern'
+  | 'eval_failure'
+  | 'sample_design_issue'
+  | 'doctor_gap'
+  | 'standard_candidate'
+  | 'maintenance_issue';
+
+export interface DiagnosisSourceCoverage {
+  observe: boolean;
+  doctor: boolean;
+  eval: boolean;
+}
+
+export interface DiagnosisScope {
+  primary: 'skill' | 'definition' | 'session' | 'sample';
+  refs: {
+    skillName: string;
+    sessionId?: string;
+    invocationId?: string;
+    sampleId?: string;
+    ruleId?: string;
+    workflowId?: string;
+    sourceTrace?: string;
+  };
+}
+
+export interface DiagnosisEvidenceRef {
+  id: string;
+  kind: string;
+  sourceTrace?: string;
+  sessionId?: string;
+  messageIndex?: number;
+  logicalMessageIndex?: number;
+  sourceLineIndex?: number;
+  messageUuid?: string;
+  toolUseId?: string;
+  timestamp?: string;
+  label?: string;
+  snippet?: string;
+}
+
+export interface DiagnosisOccurrence {
+  id: string;
+  diagnosisStableKey: string;
+  source: DiagnosisSource;
+  sourceId: string;
+  sourceKind: string;
+  timestamp?: string;
+  severity?: DiagnosisSeverity;
+  evidenceRefs: DiagnosisEvidenceRef[];
+  rawRef?: string;
+  producer: 'deterministic_rule' | 'llm_soft' | 'manual';
+  payload?: Record<string, unknown>;
+}
+
+export interface DiagnosisPatch {
+  target: 'skill' | 'sample-environment' | 'sample-mocks' | 'doctor-rule' | 'definition';
+  location: string;
+  snippet: string;
+}
+
+export interface Diagnosis {
+  id: string;
+  stableKey: string;
+  skillName: string;
+  type: DiagnosisType;
+  signal: string;
+  title: string;
+  summary?: string;
+  severity: DiagnosisSeverity;
+  audience: DiagnosisAudience;
+  lifecycle: DiagnosisLifecycle;
+  scope: DiagnosisScope;
+  occurrences: DiagnosisOccurrence[];
+  occurrenceCount: number;
+  evidenceSummary?: string;
+  recommendation?: string;
+  patch?: DiagnosisPatch;
+  command?: string;
+}
+
+export interface DiagnosisBundle {
+  schemaVersion: 1;
+  generatedAt: string;
+  sourceCoverage: DiagnosisSourceCoverage;
+  bySkill: Record<string, Diagnosis[]>;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,4 @@ export * from './eval.js';
 export * from './report.js';
 export * from './storage.js';
 export * from './doctor.js';
+export * from './diagnosis.js';


### PR DESCRIPTION
## Summary

- 将 `Diagnosis` / `DiagnosisBundle` 等纯类型定义从 `src/diagnosis/types.ts` 上移到 `src/types/diagnosis.ts`（`src/types/index.ts` barrel 同步 export）。
- `src/diagnosis/types.ts` 缩为类型 re-export + `isActiveDiagnosisLifecycle` 运行时 helper；diagnosis 包内部消费者无需改动。
- `src/observability/inbox.ts:12` 对 `DiagnosisBundle` 的 type-only import 改走 `../types/diagnosis.js`，**observability → diagnosis 反向依赖彻底切除**。

## Why

之前 `src/observability/inbox.ts` 通过 type-only 反向 import 了 `diagnosis/types.ts` 的 `DiagnosisBundle`，是 observability ↔ diagnosis 的最后一条跨层依赖。虽然 type-only 在运行时被擦除、不构成真循环依赖，但 schema 层面的耦合仍在：observability 包的报告类型依赖 diagnosis 包内部定义。

把 cross-layer 的纯类型上移到 `src/types/`（已经是 Report / Doctor / Executor / Judge 等 schema 的中立归集地），让 observability 和 diagnosis 都从 `types/` 拿类型，diagnosis 包专注承载运行时逻辑（mapper、producer、studio-projection、lifecycle helper）。

## 不变量守护

- 无 Report schema 字段语义变化。
- 无 judge / observe LLM 复盘 prompt 改动。
- 无 5 层评分管道 / Bootstrap / α / length-debias 改动。
- 红区文件 diff 为空（`src/types/report.ts` / `src/eval-core/*` / `src/grading/*`）。
- 1615 个测试全绿，HTML snapshot 字节一致。

## Test plan

- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test`（1615 passed）
- [x] grep 确认 `src/observability/` 已无 `../diagnosis/` import
- [x] 红区 diff 为空

🤖 Generated with [Claude Code](https://claude.com/claude-code)