### PR TITLE
refactor(types): Dependency* DTO 下沉解开 types → eval-core 反向依赖

### DIFF
--- a/src/eval-core/dependency-checker.ts
+++ b/src/eval-core/dependency-checker.ts
@@ -9,41 +9,20 @@
 import { existsSync } from 'node:fs';
 import { delimiter, dirname, join, resolve } from 'node:path';
 import { execFileSync, execSync } from 'node:child_process';
-import type { Artifact, Sample } from '../types/index.js';
+import type {
+  Artifact,
+  DependencyCheckResult,
+  DependencyIssue,
+  DependencyRequirements,
+  Sample,
+} from '../types/index.js';
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface DependencyRequirements {
-  tools?: string[];
-  files?: string[];
-  env?: string[];
-  preflight?: string[];
-}
-
-export type DependencyReasonCode =
-  | 'tool_not_found'
-  | 'file_not_found'
-  | 'env_not_set'
-  | 'preflight_failed';
-
-export interface DependencyIssue {
-  category: 'tool' | 'file' | 'env' | 'preflight';
-  name: string;
-  /** Stable enum so consumers (doctor, eval-pipeline) translate per their own lang.
-   *  The dep-checker itself never produces user-facing strings — it only carries facts. */
-  reasonCode: DependencyReasonCode;
-  /** Optional untranslated raw context: stderr line, cwd, command — surfaces at the
-   *  consumer's UI layer so the actual failure is visible without round-tripping the
-   *  process. Never localized; pass through verbatim. */
-  reasonDetail?: string;
-}
-
-export interface DependencyCheckResult {
-  ok: boolean;
-  missing: DependencyIssue[];
-}
+export type {
+  DependencyCheckResult,
+  DependencyIssue,
+  DependencyReasonCode,
+  DependencyRequirements,
+} from '../types/index.js';
 
 // ---------------------------------------------------------------------------
 // Extraction — scan text for dependencies

--- a/src/types/dependencies.ts
+++ b/src/types/dependencies.ts
@@ -1,0 +1,29 @@
+export interface DependencyRequirements {
+  tools?: string[];
+  files?: string[];
+  env?: string[];
+  preflight?: string[];
+}
+
+export type DependencyReasonCode =
+  | 'tool_not_found'
+  | 'file_not_found'
+  | 'env_not_set'
+  | 'preflight_failed';
+
+export interface DependencyIssue {
+  category: 'tool' | 'file' | 'env' | 'preflight';
+  name: string;
+  /** Stable enum so consumers (doctor, eval-pipeline) translate per their own lang.
+   *  The dep-checker itself never produces user-facing strings — it only carries facts. */
+  reasonCode: DependencyReasonCode;
+  /** Optional untranslated raw context: stderr line, cwd, command — surfaces at the
+   *  consumer's UI layer so the actual failure is visible without round-tripping the
+   *  process. Never localized; pass through verbatim. */
+  reasonDetail?: string;
+}
+
+export interface DependencyCheckResult {
+  ok: boolean;
+  missing: DependencyIssue[];
+}

--- a/src/types/doctor.ts
+++ b/src/types/doctor.ts
@@ -1,5 +1,5 @@
 import type { Artifact, Sample } from './eval.js';
-import type { DependencyRequirements } from '../eval-core/dependency-checker.js';
+import type { DependencyRequirements } from './dependencies.js';
 
 export type DoctorSeverity = 'fatal' | 'warn' | 'info';
 export type DoctorRuleStatus = 'pass' | 'warn' | 'fail' | 'skipped';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,3 +6,4 @@ export * from './report.js';
 export * from './storage.js';
 export * from './doctor.js';
 export * from './diagnosis.js';
+export * from './dependencies.js';


### PR DESCRIPTION
## Summary

- `DependencyRequirements` / `DependencyReasonCode` / `DependencyIssue` / `DependencyCheckResult` 4 个纯 DTO 从 `src/eval-core/dependency-checker.ts` 上移到 `src/types/dependencies.ts`(`src/types/index.ts` barrel 同步 export）。
- `src/eval-core/dependency-checker.ts` 改为从 `src/types/` import 并 re-export 这些类型,对外签名零变化。
- `src/types/doctor.ts:2` 改为从同级 `./dependencies.js` 拿 `DependencyRequirements`,**types → eval-core 反向 type import 切除**。

## Why

`src/types/doctor.ts:2` 反向 `import type { DependencyRequirements } from '../eval-core/dependency-checker.js'`,而 `src/eval-core/dependency-checker.ts:12` 又正向 `import type { Artifact, Sample } from '../types/index.js'`。虽然 type-only 在运行时被擦除、不构成真循环,但 schema 层耦合仍在:`types/` 作为最底层稳定契约,不应反向看实现模块。

把 cross-layer 的纯 DTO 收口到 `src/types/`(已是 Report / Doctor / Diagnosis / Executor / Judge 等 schema 的中立归集地),`types/` 严格单向被消费,后续可以靠守门测试(P1.3)固化这一方向。

## 不变量守护

- 无 Report schema 字段语义变化。
- 无 judge / observe LLM 复盘 prompt 改动。
- 无 5 层评分管道 / Bootstrap / α / length-debias 改动。
- 红区文件 diff 为空(`src/types/report.ts` / `src/eval-core/{bootstrap,statistics,comparability}.ts` / `src/grading/*`）。
- 1615 个测试全绿,HTML snapshot 字节一致。

## Test plan

- [x] \`yarn lint\`
- [x] \`yarn build\`
- [x] \`yarn test\`(1615 passed)
- [x] grep 确认 `src/types/` 已无 `../eval-core/` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)