### PR TITLE
fix(cli): update-check 改用 SemVer 严格大于比较;CI / 测试环境关闭

### DIFF
--- a/src/cli/lib/update-check.ts
+++ b/src/cli/lib/update-check.ts
@@ -1,6 +1,64 @@
 import { tCli, type CliLang } from './i18n.js';
 
+/** 严格按 SemVer 2.0 precedence 判断 `a > b`(只覆盖本仓库实际使用的形态:
+ *  MAJOR.MINOR.PATCH 可选 `-prerelease`)。非法字符串直接返回 false,update-check
+ *  fail-safe 不提示。
+ *  - release > prerelease(同 MAJOR.MINOR.PATCH)
+ *  - prerelease 之间按 dot-separated identifier 比较(数字段当数字,字母段当字符串) */
+export function isSemverGt(a: string, b: string): boolean {
+  const parse = (v: string): { major: number; minor: number; patch: number; pre: string } | null => {
+    const match = v.trim().replace(/^v/, '').match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/);
+    if (!match) return null;
+    return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]), pre: match[4] ?? '' };
+  };
+  const av = parse(a);
+  const bv = parse(b);
+  if (!av || !bv) return false;
+  if (av.major !== bv.major) return av.major > bv.major;
+  if (av.minor !== bv.minor) return av.minor > bv.minor;
+  if (av.patch !== bv.patch) return av.patch > bv.patch;
+  if (av.pre === '' && bv.pre === '') return false;
+  if (av.pre === '' && bv.pre !== '') return true;
+  if (av.pre !== '' && bv.pre === '') return false;
+  const aParts = av.pre.split('.');
+  const bParts = bv.pre.split('.');
+  const len = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < len; i++) {
+    const ap = aParts[i];
+    const bp = bParts[i];
+    if (ap === undefined) return false;
+    if (bp === undefined) return true;
+    const aNum = /^\d+$/.test(ap);
+    const bNum = /^\d+$/.test(bp);
+    if (aNum && bNum) {
+      const an = Number(ap);
+      const bn = Number(bp);
+      if (an !== bn) return an > bn;
+    } else if (aNum && !bNum) {
+      return false;
+    } else if (!aNum && bNum) {
+      return true;
+    } else if (ap !== bp) {
+      return ap > bp;
+    }
+  }
+  return false;
+}
+
+/** CI / 测试环境 / 用户显式 opt-out 时跳过 update check:
+ *  - 避免 CI 日志噪声(GitHub Actions / GitLab CI / CircleCI 等都设 CI=true)
+ *  - vitest 启动期不打 stderr,免 snapshot / startup-budget 测试受影响
+ *  - OMK_SKIP_UPDATE_CHECK=1 给用户显式 escape hatch */
+function shouldSkipUpdateCheck(): boolean {
+  const env = process.env;
+  if (env.OMK_SKIP_UPDATE_CHECK === '1') return true;
+  if (env.CI && env.CI !== '0' && env.CI !== 'false') return true;
+  if (env.NODE_ENV === 'test') return true;
+  return false;
+}
+
 export async function checkUpdate(lang: CliLang): Promise<void> {
+  if (shouldSkipUpdateCheck()) return;
   try {
     const { readFileSync, existsSync } = await import('node:fs');
     const { fileURLToPath } = await import('node:url');
@@ -25,7 +83,9 @@ export async function checkUpdate(lang: CliLang): Promise<void> {
     const res: Response = await fetch(`${registry}/${pkg.name}/latest`, { signal: AbortSignal.timeout(3000) });
     if (!res.ok) return;
     const data = await res.json() as { version?: string };
-    if (data.version && data.version !== pkg.version) {
+    // 只在 registry 版本 SemVer 严格大于本地版本时提示。早先版本用 `!==`
+    // 比较,本地 dev 跑出 0.32.0-rc 时会被 registry 的 0.31.0「提示降级」。
+    if (data.version && isSemverGt(data.version, pkg.version)) {
       process.stderr.write(tCli('cli.update.new_version_available', lang, {
         old: pkg.version, new: data.version, pkg: pkg.name,
       }));

--- a/test/cli/update-check.test.ts
+++ b/test/cli/update-check.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { isSemverGt } from '../../src/cli/lib/update-check.js';
+
+describe('isSemverGt', () => {
+  it('正确比较 major / minor / patch', () => {
+    expect(isSemverGt('1.0.0', '0.99.99')).toBe(true);
+    expect(isSemverGt('0.32.0', '0.31.9')).toBe(true);
+    expect(isSemverGt('0.31.1', '0.31.0')).toBe(true);
+    expect(isSemverGt('0.31.0', '0.31.0')).toBe(false);
+    expect(isSemverGt('0.31.0', '0.32.0')).toBe(false);
+    expect(isSemverGt('0.31.0', '1.0.0')).toBe(false);
+  });
+
+  it('release > prerelease(同 MAJOR.MINOR.PATCH)', () => {
+    expect(isSemverGt('0.32.0', '0.32.0-rc.1')).toBe(true);
+    expect(isSemverGt('0.32.0-rc.1', '0.32.0')).toBe(false);
+  });
+
+  it('prerelease 之间数字段按数字比较', () => {
+    expect(isSemverGt('0.32.0-rc.2', '0.32.0-rc.1')).toBe(true);
+    expect(isSemverGt('0.32.0-rc.10', '0.32.0-rc.2')).toBe(true);
+    expect(isSemverGt('0.32.0-rc.2', '0.32.0-rc.10')).toBe(false);
+  });
+
+  it('regression: 本地 dev rc 高于 registry 时不应判 registry > 本地', () => {
+    // 这是 #149 暴露的「本地 0.32.0-rc 跑出来看到 registry 0.31.0 提示降级」场景
+    expect(isSemverGt('0.31.0', '0.32.0-rc.1')).toBe(false);
+    expect(isSemverGt('0.31.0', '0.32.0')).toBe(false);
+  });
+
+  it('容忍 v 前缀', () => {
+    expect(isSemverGt('v1.0.0', '0.99.0')).toBe(true);
+    expect(isSemverGt('1.0.0', 'v0.99.0')).toBe(true);
+  });
+
+  it('忽略 build metadata(+xxx)', () => {
+    expect(isSemverGt('1.0.0+build.1', '1.0.0')).toBe(false);
+    expect(isSemverGt('1.0.0', '1.0.0+build.1')).toBe(false);
+  });
+
+  it('非法字符串 fail-safe 返回 false', () => {
+    expect(isSemverGt('', '1.0.0')).toBe(false);
+    expect(isSemverGt('1.0.0', '')).toBe(false);
+    expect(isSemverGt('not-a-version', '1.0.0')).toBe(false);
+    expect(isSemverGt('1.0.0', 'not-a-version')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- 抽 \`isSemverGt(a, b)\`,按 SemVer 2.0 precedence 解析 \`MAJOR.MINOR.PATCH\` 与可选 \`-prerelease\`。
- \`checkUpdate\` 改用 \`isSemverGt(data.version, pkg.version)\` 判断,只在 registry 版本严格大于本地时提示升级。
- 新增 \`shouldSkipUpdateCheck()\`:\`CI\` truthy / \`NODE_ENV=test\` / \`OMK_SKIP_UPDATE_CHECK=1\` 任一命中时整段跳过。
- 配套 \`test/cli/update-check.test.ts\` 7 个 case 覆盖正常比较 / release vs prerelease / #149 regression / 容错 / 非法输入 fail-safe。

## Why

之前 \`src/cli/lib/update-check.ts:28\` 用 \`data.version !== pkg.version\`。当本地跑 dev / rc 版本(eg. \`0.32.0-rc.1\`)而 registry \`latest\` 还停在 \`0.31.0\` 时,会反向提示「升级到 0.31.0」—— #149 release 期间已暴露过。CI / 测试环境跑 CLI 也会被这条 fetch 拖且没意义。

## Test plan

- [x] \`yarn lint\`
- [x] \`yarn build\`
- [x] \`yarn test\`(1622 passed,新增 7 个 case)
- [x] 手工核 #149 regression:\`isSemverGt('0.31.0', '0.32.0-rc.1')\` 返回 \`false\`

## 不变量守护

- 红区文件 diff 为空。
- 无 Report schema / judge / observe prompt 改动。
- 无新增 runtime 依赖(inline 实现而非 \`semver\` 包,~30 行)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)