### PR TITLE
refactor(types): SkillIndex / Insight DTO 上移解开 renderer → server 反向依赖

### DIFF
--- a/src/analysis/report-diagnostics.ts
+++ b/src/analysis/report-diagnostics.ts
@@ -2,7 +2,7 @@
  * Auto-analysis: detect patterns and generate insights from evaluation results.
  */
 
-import type { Report, ResultEntry, Insight, AnalysisResult, Sample, SampleQualityAggregate, Lang } from '../types/index.js';
+import type { Report, ResultEntry, AnalysisInsight, AnalysisResult, Sample, SampleQualityAggregate, Lang } from '../types/index.js';
 import { normalizeCapability } from './sample-diagnostics.js';
 
 /** opts for `analyzeResults`. Optional because most older callers don't have
@@ -17,7 +17,7 @@ export interface AnalyzeResultsOptions {
  * Analyze an evaluation report and produce structured insights.
  */
 export function analyzeResults(report: Report, opts: AnalyzeResultsOptions = {}): AnalysisResult {
-  const insights: Insight[] = [];
+  const insights: AnalysisInsight[] = [];
   const variants = report.meta?.variants || [];
   const results = report.results || [];
 
@@ -433,7 +433,7 @@ function collectAgentAssertionTypes(results: ResultEntry[], variants: string[]):
   return types;
 }
 
-function detectLowDiscrimination(results: ResultEntry[], variants: string[], insights: Insight[]): void {
+function detectLowDiscrimination(results: ResultEntry[], variants: string[], insights: AnalysisInsight[]): void {
   // For each sample, check if all variants have the same assertion pass/fail pattern
   const allPassedPatterns: Array<{ sample_id: string; type: string; value: string | number; allPassed: boolean }> = [];
   const allFailedPatterns: Array<{ sample_id: string; type: string; value: string | number; allPassed: boolean }> = [];
@@ -488,7 +488,7 @@ function detectLowDiscrimination(results: ResultEntry[], variants: string[], ins
   }
 }
 
-function detectUniformScores(results: ResultEntry[], variants: string[], insights: Insight[]): void {
+function detectUniformScores(results: ResultEntry[], variants: string[], insights: AnalysisInsight[]): void {
   let uniformCount = 0;
   const uniformSamples: string[] = [];
 
@@ -516,7 +516,7 @@ function detectUniformScores(results: ResultEntry[], variants: string[], insight
   }
 }
 
-function detectAllPassFail(results: ResultEntry[], variants: string[], insights: Insight[]): void {
+function detectAllPassFail(results: ResultEntry[], variants: string[], insights: AnalysisInsight[]): void {
   let allPassCount = 0;
   let allFailCount = 0;
 
@@ -547,7 +547,7 @@ function detectAllPassFail(results: ResultEntry[], variants: string[], insights:
   }
 }
 
-function detectNeedRepeat(report: Report, results: ResultEntry[], variants: string[], insights: Insight[]): void {
+function detectNeedRepeat(report: Report, results: ResultEntry[], variants: string[], insights: AnalysisInsight[]): void {
   // Skip if already has variance data (i.e. --repeat was used)
   if (report.variance) return;
 
@@ -567,7 +567,7 @@ function detectNeedRepeat(report: Report, results: ResultEntry[], variants: stri
   }
 }
 
-function detectEfficiencyGap(report: Report, variants: string[], insights: Insight[]): void {
+function detectEfficiencyGap(report: Report, variants: string[], insights: AnalysisInsight[]): void {
   if (variants.length < 2) return;
   const summary = report.summary || {};
 
@@ -617,7 +617,7 @@ function detectEfficiencyGap(report: Report, variants: string[], insights: Insig
   }
 }
 
-function detectToolPatterns(report: Report, variants: string[], insights: Insight[]): void {
+function detectToolPatterns(report: Report, variants: string[], insights: AnalysisInsight[]): void {
   const summary = report.summary || {};
   const hasTools = variants.some((v) => summary[v]?.avgToolCalls != null && summary[v].avgToolCalls! > 0);
   if (!hasTools) return;
@@ -655,7 +655,7 @@ function detectToolPatterns(report: Report, variants: string[], insights: Insigh
   }
 }
 
-function detectToolPermissionIssues(results: ResultEntry[], variants: string[], insights: Insight[]): void {
+function detectToolPermissionIssues(results: ResultEntry[], variants: string[], insights: AnalysisInsight[]): void {
   const permissionErrors: Array<{ variant: string; tool: string; sample_id: string; output: string }> = [];
 
   for (const result of results) {
@@ -685,7 +685,7 @@ function detectToolPermissionIssues(results: ResultEntry[], variants: string[], 
   });
 }
 
-function detectTraceIntegrity(report: Report, variants: string[], insights: Insight[]): void {
+function detectTraceIntegrity(report: Report, variants: string[], insights: AnalysisInsight[]): void {
   const summary = report.summary || {};
   const agentAssertionTypes = collectAgentAssertionTypes(report.results || [], variants);
   const needsTraceHeavyCoverage = [...agentAssertionTypes].some((type) => TRACE_HEAVY_AGENT_ASSERTION_TYPES.has(type));
@@ -714,7 +714,7 @@ function detectTraceIntegrity(report: Report, variants: string[], insights: Insi
   }
 }
 
-function detectAgentAssertionDiscrimination(results: ResultEntry[], variants: string[], insights: Insight[]): void {
+function detectAgentAssertionDiscrimination(results: ResultEntry[], variants: string[], insights: AnalysisInsight[]): void {
   const assertionTypes = collectAgentAssertionTypes(results, variants);
   const hasTraceHeavyAssertions = [...assertionTypes].some((type) => TRACE_HEAVY_AGENT_ASSERTION_TYPES.has(type));
   if (!hasTraceHeavyAssertions) return;
@@ -784,7 +784,7 @@ function detectAgentAssertionDiscrimination(results: ResultEntry[], variants: st
   }
 }
 
-function detectHighCost(results: ResultEntry[], variants: string[], insights: Insight[]): void {
+function detectHighCost(results: ResultEntry[], variants: string[], insights: AnalysisInsight[]): void {
   const costs: Array<{ sample_id: string; costUSD: number }> = [];
   for (const r of results) {
     let sampleCost = 0;

--- a/src/diagnosis/studio-projection.ts
+++ b/src/diagnosis/studio-projection.ts
@@ -1,13 +1,6 @@
-import { isActiveDiagnosisLifecycle, type Diagnosis, type DiagnosisBundle, type DiagnosisSeverity, type DiagnosisSourceCoverage } from './types.js';
+import { isActiveDiagnosisLifecycle, type Diagnosis, type DiagnosisBundle, type DiagnosisSeverity, type StudioDiagnosisSummary } from './types.js';
 
-export interface StudioDiagnosisSummary {
-  sourceCoverage: DiagnosisSourceCoverage;
-  totalCount: number;
-  partial: boolean;
-  bySeverity: Record<DiagnosisSeverity, number>;
-  bySkill: Record<string, number>;
-  byAudience: Record<string, number>;
-}
+export type { StudioDiagnosisSummary };
 
 export function buildStudioDiagnosisSummary(bundle?: DiagnosisBundle): StudioDiagnosisSummary {
   const sourceCoverage = bundle?.sourceCoverage ?? { observe: false, doctor: false, eval: false };

--- a/src/diagnosis/types.ts
+++ b/src/diagnosis/types.ts
@@ -11,6 +11,7 @@ export type {
   DiagnosisSource,
   DiagnosisSourceCoverage,
   DiagnosisType,
+  StudioDiagnosisSummary,
 } from '../types/diagnosis.js';
 
 import type { DiagnosisLifecycle } from '../types/diagnosis.js';

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -12,10 +12,17 @@
  *   隐藏 modal:每条 insight 一个 + 3 个阶段全量明细各一个
  */
 import { layout, e, DEFAULT_LANG } from './layout.js';
-import type { Lang, EvaluationReport } from '../types/index.js';
-import type { SkillIndexEntry, SkillDoctorSnapshot, SkillEvalSnapshot, SkillObserveSnapshot } from '../server/skill-index.js';
-import type { Insight, InsightIllustration } from '../server/skill-insights.js';
-import type { DoctorRuleResult } from '../types/doctor.js';
+import type {
+  Lang,
+  EvaluationReport,
+  DoctorRuleResult,
+  SkillIndexEntry,
+  SkillDoctorSnapshot,
+  SkillEvalSnapshot,
+  SkillObserveSnapshot,
+  Insight,
+  InsightIllustration,
+} from '../types/index.js';
 
 const BAND_DOT: Record<'green' | 'yellow' | 'red' | 'gray', string> = {
   green: '🟢', yellow: '🟡', red: '🔴', gray: '⚪',

--- a/src/renderer/skill-list-renderer.ts
+++ b/src/renderer/skill-list-renderer.ts
@@ -11,9 +11,7 @@
  */
 import { layout, e, DEFAULT_LANG } from './layout.js';
 import { assessHealth } from './skill-detail-renderer.js';
-import type { Lang } from '../types/index.js';
-import type { SkillIndex, SkillIndexEntry } from '../server/skill-index.js';
-import type { Insight } from '../server/skill-insights.js';
+import type { Lang, SkillIndex, SkillIndexEntry, Insight } from '../types/index.js';
 
 function relTime(ts: string | null | undefined, lang: Lang): string {
   if (!ts) return lang === 'zh' ? '未跑' : 'never';

--- a/src/renderer/summary.ts
+++ b/src/renderer/summary.ts
@@ -2,7 +2,7 @@ import { e, fmtNum, fmtCost, fmtDuration, COLORS, t } from './layout.js';
 import { generateAnalysisSummary } from '../analysis/report-diagnostics.js';
 import { pValueCategory } from '../eval-core/statistics.js';
 import { computeVerdict, type VerdictLevel, type VerdictResult } from '../eval-core/verdict.js';
-import type { GapReport, GapSignalRef, Insight, KnowledgeCoverage, Lang, Report, ReportHumanAgreement, SaturationData, VarianceComparison, VarianceComparisonMetric, VarianceData, VarianceLayerKey, VariantPairComparison, VariantSummary } from '../types/index.js';
+import type { GapReport, GapSignalRef, AnalysisInsight, KnowledgeCoverage, Lang, Report, ReportHumanAgreement, SaturationData, VarianceComparison, VarianceComparisonMetric, VarianceData, VarianceLayerKey, VariantPairComparison, VariantSummary } from '../types/index.js';
 
 /**
  * Verdict pill — sticky banner at the top of the HTML report giving the same
@@ -1382,7 +1382,7 @@ const CONCLUSION_TYPES = new Set([
   'efficiency_gap', 'tool_count_gap', 'high_cost_sample',
 ]);
 
-function isConclusion(insight: Insight): boolean {
+function isConclusion(insight: AnalysisInsight): boolean {
   return CONCLUSION_TYPES.has(insight.type);
 }
 
@@ -1446,7 +1446,7 @@ function num(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
-function localizedInsightMessage(insight: Insight, report: Report | undefined, lang: Lang): string {
+function localizedInsightMessage(insight: AnalysisInsight, report: Report | undefined, lang: Lang): string {
   const details = asRecord(insight.details);
   const detailItems = asArray(insight.details);
   const totalSamples = report?.results?.length || detailItems.length || num(details.total) || 0;
@@ -1554,7 +1554,7 @@ function localizedInsightMessage(insight: Insight, report: Report | undefined, l
   }
 }
 
-function localizedSuggestion(insight: Insight, lang: Lang): string {
+function localizedSuggestion(insight: AnalysisInsight, lang: Lang): string {
   switch (insight.type) {
     case 'low_discrimination_all_passed':
       return lang === 'zh'

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -17,14 +17,35 @@
  */
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, isAbsolute, basename, dirname } from 'node:path';
-import type { ReportDocument, EvaluationReport, AssertionDetail } from '../types/index.js';
+import type {
+  ReportDocument,
+  EvaluationReport,
+  AssertionDetail,
+  DoctorReport,
+  Diagnosis,
+  SkillDoctorSnapshot,
+  SkillEvalSnapshot,
+  SkillObserveSnapshot,
+  SkillIndexEntry,
+  SkillIndexSummary,
+  SkillIndex,
+  Insight,
+} from '../types/index.js';
 import type { SkillHealthReport } from '../observability/skill-health-analyzer.js';
-import type { DoctorReport, DoctorRuleResult, DoctorSkillStatus } from '../types/doctor.js';
 import { computeVerdict } from '../eval-core/verdict.js';
-import { detectInsights, type Insight } from './skill-insights.js';
+import { detectInsights } from './skill-insights.js';
 import { DEFAULT_OBSERVATIONS_DIR, loadLatestObservationInboxReports } from '../observability/inbox.js';
-import { buildStudioDiagnosisSummary, mergeDiagnosisBundles, type StudioDiagnosisSummary } from '../diagnosis/studio-projection.js';
-import type { Diagnosis } from '../diagnosis/types.js';
+import { buildStudioDiagnosisSummary, mergeDiagnosisBundles } from '../diagnosis/studio-projection.js';
+
+// Re-export DTO 类型,保持既有 import 路径 backward-compat。新代码请直接从 ../types/index.js 导入。
+export type {
+  SkillDoctorSnapshot,
+  SkillEvalSnapshot,
+  SkillObserveSnapshot,
+  SkillIndexEntry,
+  SkillIndexSummary,
+  SkillIndex,
+};
 
 // ── 模块级缓存:Studio 每次请求都跑 buildSkillIndex,扫盘成本随 skill 数线性,
 // 数据量大后列表 / 详情页响应变慢(PR #95 review P2-4 — cache 引入本身那一条)。
@@ -122,76 +143,6 @@ function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, d
 /** 测试 / 调试用:强制清掉 in-process skill-index 缓存。 */
 export function _resetSkillIndexCache(): void {
   _indexCache = null;
-}
-
-export interface SkillDoctorSnapshot {
-  reportId: string;
-  timestamp: string;
-  status: DoctorSkillStatus;
-  passCount: number;
-  warnCount: number;
-  failCount: number;
-  results: DoctorRuleResult[];
-}
-
-export interface SkillEvalSnapshot {
-  reportId: string;
-  timestamp: string;
-  variantName: string;
-  verdictLevel: string;
-  verdictHeadline: string;
-  compositeScore: number | null;
-  passCount: number;
-  failCount: number;
-  tripwireCount: number;
-  totalSamples: number;
-}
-
-export interface SkillObserveSnapshot {
-  analysisId: string;
-  generatedAt: string;
-  healthBand: 'green' | 'yellow' | 'red';
-  failureRate: number;
-  segmentCount: number;
-  gapRate: number;
-}
-
-export interface SkillIndexEntry {
-  skillName: string;
-  /** 当前(最新)snapshot — 等价于对应 history 的最后一项,空时为 null。renderer
-   *  老路径直接读这个,不必动 history。 */
-  doctor: SkillDoctorSnapshot | null;
-  eval: SkillEvalSnapshot | null;
-  observe: SkillObserveSnapshot | null;
-  /** 历史 snapshot,chronological 升序(最早 → 最近)。renderer 用它画 sparkline 趋势。 */
-  doctorHistory: SkillDoctorSnapshot[];
-  evalHistory: SkillEvalSnapshot[];
-  observeHistory: SkillObserveSnapshot[];
-  /** 综合健康灯。doctor / eval / observe 任一红 → red;任一黄 → yellow;
-   *  全绿 → green;皆未跑 → gray。 */
-  band: 'green' | 'yellow' | 'red' | 'gray';
-}
-
-export interface SkillIndexSummary {
-  totalSkills: number;
-  withEval: number;
-  withObserve: number;
-  withDoctor: number;
-  red: number;
-  yellow: number;
-  green: number;
-  gray: number;
-}
-
-export interface SkillIndex {
-  entries: SkillIndexEntry[];
-  summary: SkillIndexSummary;
-  /** detectInsights 结果按 skillName 索引。在 buildSkillIndex 时同步算好,跟 SkillIndex
-   *  本身共享同一 fingerprint 缓存(reports 数组 + dir mtime 任一变就 invalidate)。
-   *  list 页 N×detectInsights 重算的 CPU 开销由此消除。 */
-  insightsBySkill: Map<string, Insight[]>;
-  diagnosticsBySkill: Map<string, Diagnosis[]>;
-  diagnosisSummary: StudioDiagnosisSummary;
 }
 
 function isEvolveRoundVariant(report: EvaluationReport, variant: string): boolean {

--- a/src/server/skill-insights.ts
+++ b/src/server/skill-insights.ts
@@ -21,96 +21,46 @@
  *   6. skill-too-long              skill-author   skill 文档过长 LLM 找不到段落
  *   7. omk-doctor-blindspot        omk-maintainer doctor 应该卡却没规则的反模式
  */
-import type { EvaluationReport, VariantResult, ToolCallInfo } from '../types/index.js';
-import type { SkillIndexEntry, SkillDoctorSnapshot, SkillObserveSnapshot, SkillEvalSnapshot } from './skill-index.js';
-import { isActiveDiagnosisLifecycle, type Diagnosis, type DiagnosisAudience, type DiagnosisSeverity, type DiagnosisType } from '../diagnosis/types.js';
+import type {
+  EvaluationReport,
+  VariantResult,
+  ToolCallInfo,
+  Diagnosis,
+  DiagnosisAudience,
+  DiagnosisSeverity,
+  DiagnosisType,
+  SkillIndexEntry,
+  SkillDoctorSnapshot,
+  SkillObserveSnapshot,
+  SkillEvalSnapshot,
+  InsightCategory,
+  InsightSeverity,
+  InsightAudience,
+  InsightPerspective,
+  InsightIllustration,
+  InsightEvidence,
+  InsightPatch,
+  InsightRecommendation,
+  InsightStageRefs,
+  Insight,
+  DetectInsightsOptions,
+} from '../types/index.js';
+import { isActiveDiagnosisLifecycle } from '../diagnosis/types.js';
 
-export type InsightCategory =
-  | 'environment-blocked-mocks'
-  | 'skill-doc-gap'
-  | 'failure-mode-skill'
-  | 'coverage-gap'
-  | 'production-instability'
-  | 'skill-too-long'
-  | 'omk-doctor-blindspot'
-  | 'other';
-
-export type InsightSeverity = 'high' | 'medium' | 'low';
-
-export type InsightAudience = 'skill-author' | 'sample-author' | 'omk-maintainer';
-
-export type InsightPerspective = 'doctor' | 'eval-score' | 'eval-functional' | 'observe';
-
-/** 现象证据:把抽象"X 模式 N 条"翻译成用户能看到的具体行为。 */
-export interface InsightIllustration {
-  sampleId: string;
-  /** 用户给 LLM 的 prompt(截断到 ~200 字)。 */
-  samplePrompt?: string;
-  /** LLM 最终输出(截断到 ~200 字)。 */
-  llmOutput?: string;
-  /** LLM 实际调的工具(简化字符串列表,顺序保留)。 */
-  toolCalls?: string[];
-  /** 哪条 assertion 没过 + value。 */
-  failedAssertion?: string;
-}
-
-export interface InsightEvidence {
-  perspective: InsightPerspective;
-  status: 'flagged' | 'blind' | 'silent' | 'na';
-  /** 简短说明(用户语,不堆术语)。 */
-  message: string;
-  ref?: string;
-  /** 如果有现象证据,展开看 1-2 条具体 sample 的实际 prompt/output/toolCalls。 */
-  illustrations?: InsightIllustration[];
-}
-
-/** 可粘贴的 patch 片段。target 指明改哪种文件,location 是文件/章节,snippet 是代码块。 */
-export interface InsightPatch {
-  target: 'skill' | 'sample-environment' | 'sample-mocks' | 'doctor-rule';
-  /** 目标位置描述,如 'sample s003 的 mocks 数组' / 'SKILL.md「项目创建」节'。 */
-  location: string;
-  /** 代码块或 diff 片段。 */
-  snippet: string;
-}
-
-export interface InsightRecommendation {
-  action: string;
-  priority: InsightSeverity;
-  patch?: InsightPatch;
-}
-
-/** 该 insight 关联的具体阶段元素 — UI 渲染 timeline 时用来在阶段卡内挂 #N 徽章。 */
-export interface InsightStageRefs {
-  doctorRuleIds?: string[];
-  evalSampleIds?: string[];
-  /** observe 信号类型标签:'high-failure-rate' / 'gap' / 'uncovered-files'。
-   *  observe 内单条信号没像 doctor rule / eval sample 那么细的 id,用类型标即可。 */
-  observeRefs?: string[];
-}
-
-export interface Insight {
-  id: string;
-  category: InsightCategory;
-  audience: InsightAudience;
-  /** 用户语标题。 */
-  title: string;
-  /** 一句话现象描述(标题之外的细节)。 */
-  description?: string;
-  severity: InsightSeverity;
-  affectedCount: number;
-  evidence: InsightEvidence[];
-  recommendations: InsightRecommendation[];
-  /** 关联到 timeline 哪些阶段元素 — renderer 据此在阶段卡内插入 #N 徽章。 */
-  stageRefs?: InsightStageRefs;
-}
-
-export interface DetectInsightsOptions {
-  /**
-   * Diagnosis 是 observe 侧迁移后的主数据源。传入该字段时,observe 相关 insight
-   * 从 Diagnosis 投影,不再从 entry.observe 重复推断,避免维护者新增规则时双写。
-   */
-  diagnostics?: Diagnosis[];
-}
+// Re-export Insight* 类型,保持既有 import 路径 backward-compat。新代码请直接从 ../types/index.js 导入。
+export type {
+  InsightCategory,
+  InsightSeverity,
+  InsightAudience,
+  InsightPerspective,
+  InsightIllustration,
+  InsightEvidence,
+  InsightPatch,
+  InsightRecommendation,
+  InsightStageRefs,
+  Insight,
+  DetectInsightsOptions,
+};
 
 // ────────── helpers ──────────
 

--- a/src/types/diagnosis.ts
+++ b/src/types/diagnosis.ts
@@ -92,3 +92,12 @@ export interface DiagnosisBundle {
   sourceCoverage: DiagnosisSourceCoverage;
   bySkill: Record<string, Diagnosis[]>;
 }
+
+export interface StudioDiagnosisSummary {
+  sourceCoverage: DiagnosisSourceCoverage;
+  totalCount: number;
+  partial: boolean;
+  bySeverity: Record<DiagnosisSeverity, number>;
+  bySkill: Record<string, number>;
+  byAudience: Record<string, number>;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,3 +6,4 @@ export * from './report.js';
 export * from './storage.js';
 export * from './doctor.js';
 export * from './diagnosis.js';
+export * from './skill-index.js';

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -387,7 +387,10 @@ export interface BatchEvaluationReport {
 
 export type ReportDocument = EvaluationReport | BatchEvaluationReport;
 
-export interface Insight {
+/** 报告级 analysis insight(report-diagnostics 产出,跟 SkillIndex 的 audience-aware
+ *  `Insight` 不同 — 这条只有 type / severity / details 三字段,挂在 AnalysisResult.insights 下,
+ *  用于 evaluation 报告的「分析」面板,跟 Studio skill 健康洞察是两套语义)。 */
+export interface AnalysisInsight {
   type: string;
   severity: 'error' | 'warning' | 'info';
   details: unknown;
@@ -414,7 +417,7 @@ export interface KnowledgeCoverage {
 export interface AnalysisResult {
   /** @deprecated Legacy display text. Renderers generate localized summaries from structured report data. */
   summary?: string;
-  insights: Insight[];
+  insights: AnalysisInsight[];
   /** @deprecated Legacy display text. Renderers generate localized suggestions from structured insights. */
   suggestions?: string[];
   coverage?: Record<string, KnowledgeCoverage>;

--- a/src/types/skill-index.ts
+++ b/src/types/skill-index.ts
@@ -1,0 +1,168 @@
+/**
+ * Skill-centric 聚合 DTO 与 Insight DTO。
+ *
+ * Studio 的 list / detail 视图层(renderer/skill-*-renderer)只依赖这些稳定形状,
+ * 不直接 import server 装配层。runtime 函数(buildSkillIndex / detectInsights 等)
+ * 仍在 src/server/skill-index.ts 与 src/server/skill-insights.ts。
+ */
+import type { Diagnosis, StudioDiagnosisSummary } from './diagnosis.js';
+import type { DoctorRuleResult, DoctorSkillStatus } from './doctor.js';
+
+export interface SkillDoctorSnapshot {
+  reportId: string;
+  timestamp: string;
+  status: DoctorSkillStatus;
+  passCount: number;
+  warnCount: number;
+  failCount: number;
+  results: DoctorRuleResult[];
+}
+
+export interface SkillEvalSnapshot {
+  reportId: string;
+  timestamp: string;
+  variantName: string;
+  verdictLevel: string;
+  verdictHeadline: string;
+  compositeScore: number | null;
+  passCount: number;
+  failCount: number;
+  tripwireCount: number;
+  totalSamples: number;
+}
+
+export interface SkillObserveSnapshot {
+  analysisId: string;
+  generatedAt: string;
+  healthBand: 'green' | 'yellow' | 'red';
+  failureRate: number;
+  segmentCount: number;
+  gapRate: number;
+}
+
+export interface SkillIndexEntry {
+  skillName: string;
+  /** 当前(最新)snapshot — 等价于对应 history 的最后一项,空时为 null。renderer
+   *  老路径直接读这个,不必动 history。 */
+  doctor: SkillDoctorSnapshot | null;
+  eval: SkillEvalSnapshot | null;
+  observe: SkillObserveSnapshot | null;
+  /** 历史 snapshot,chronological 升序(最早 → 最近)。renderer 用它画 sparkline 趋势。 */
+  doctorHistory: SkillDoctorSnapshot[];
+  evalHistory: SkillEvalSnapshot[];
+  observeHistory: SkillObserveSnapshot[];
+  /** 综合健康灯。doctor / eval / observe 任一红 → red;任一黄 → yellow;
+   *  全绿 → green;皆未跑 → gray。 */
+  band: 'green' | 'yellow' | 'red' | 'gray';
+}
+
+export interface SkillIndexSummary {
+  totalSkills: number;
+  withEval: number;
+  withObserve: number;
+  withDoctor: number;
+  red: number;
+  yellow: number;
+  green: number;
+  gray: number;
+}
+
+export interface SkillIndex {
+  entries: SkillIndexEntry[];
+  summary: SkillIndexSummary;
+  /** detectInsights 结果按 skillName 索引。在 buildSkillIndex 时同步算好,跟 SkillIndex
+   *  本身共享同一 fingerprint 缓存(reports 数组 + dir mtime 任一变就 invalidate)。
+   *  list 页 N×detectInsights 重算的 CPU 开销由此消除。 */
+  insightsBySkill: Map<string, Insight[]>;
+  diagnosticsBySkill: Map<string, Diagnosis[]>;
+  diagnosisSummary: StudioDiagnosisSummary;
+}
+
+// ───────── Insight ─────────
+
+export type InsightCategory =
+  | 'environment-blocked-mocks'
+  | 'skill-doc-gap'
+  | 'failure-mode-skill'
+  | 'coverage-gap'
+  | 'production-instability'
+  | 'skill-too-long'
+  | 'omk-doctor-blindspot'
+  | 'other';
+
+export type InsightSeverity = 'high' | 'medium' | 'low';
+
+export type InsightAudience = 'skill-author' | 'sample-author' | 'omk-maintainer';
+
+export type InsightPerspective = 'doctor' | 'eval-score' | 'eval-functional' | 'observe';
+
+/** 现象证据:把抽象"X 模式 N 条"翻译成用户能看到的具体行为。 */
+export interface InsightIllustration {
+  sampleId: string;
+  /** 用户给 LLM 的 prompt(截断到 ~200 字)。 */
+  samplePrompt?: string;
+  /** LLM 最终输出(截断到 ~200 字)。 */
+  llmOutput?: string;
+  /** LLM 实际调的工具(简化字符串列表,顺序保留)。 */
+  toolCalls?: string[];
+  /** 哪条 assertion 没过 + value。 */
+  failedAssertion?: string;
+}
+
+export interface InsightEvidence {
+  perspective: InsightPerspective;
+  status: 'flagged' | 'blind' | 'silent' | 'na';
+  /** 简短说明(用户语,不堆术语)。 */
+  message: string;
+  ref?: string;
+  /** 如果有现象证据,展开看 1-2 条具体 sample 的实际 prompt/output/toolCalls。 */
+  illustrations?: InsightIllustration[];
+}
+
+/** 可粘贴的 patch 片段。target 指明改哪种文件,location 是文件/章节,snippet 是代码块。 */
+export interface InsightPatch {
+  target: 'skill' | 'sample-environment' | 'sample-mocks' | 'doctor-rule';
+  /** 目标位置描述,如 'sample s003 的 mocks 数组' / 'SKILL.md「项目创建」节'。 */
+  location: string;
+  /** 代码块或 diff 片段。 */
+  snippet: string;
+}
+
+export interface InsightRecommendation {
+  action: string;
+  priority: InsightSeverity;
+  patch?: InsightPatch;
+}
+
+/** 该 insight 关联的具体阶段元素 — UI 渲染 timeline 时用来在阶段卡内挂 #N 徽章。 */
+export interface InsightStageRefs {
+  doctorRuleIds?: string[];
+  evalSampleIds?: string[];
+  /** observe 信号类型标签:'high-failure-rate' / 'gap' / 'uncovered-files'。
+   *  observe 内单条信号没像 doctor rule / eval sample 那么细的 id,用类型标即可。 */
+  observeRefs?: string[];
+}
+
+export interface Insight {
+  id: string;
+  category: InsightCategory;
+  audience: InsightAudience;
+  /** 用户语标题。 */
+  title: string;
+  /** 一句话现象描述(标题之外的细节)。 */
+  description?: string;
+  severity: InsightSeverity;
+  affectedCount: number;
+  evidence: InsightEvidence[];
+  recommendations: InsightRecommendation[];
+  /** 关联到 timeline 哪些阶段元素 — renderer 据此在阶段卡内插入 #N 徽章。 */
+  stageRefs?: InsightStageRefs;
+}
+
+export interface DetectInsightsOptions {
+  /**
+   * Diagnosis 是 observe 侧迁移后的主数据源。传入该字段时,observe 相关 insight
+   * 从 Diagnosis 投影,不再从 entry.observe 重复推断,避免维护者新增规则时双写。
+   */
+  diagnostics?: Diagnosis[];
+}


### PR DESCRIPTION
## Summary

renderer 两个 skill 视图(`skill-list-renderer.ts` / `skill-detail-renderer.ts`)此前 `import type` 从 `server/skill-index.ts` 和 `server/skill-insights.ts` 拿稳定 DTO,违反「视图层不依赖装配层」边界(PR #159 boundary test 把这条规则固化了,有 4 条 whitelist 暂登记)。

把 DTO 形状下沉到 `src/types/skill-index.ts`,server 文件保留 runtime 逻辑且 re-export 同名类型保持向后兼容(tests 不受影响)。

## 变更面

- 新增 `src/types/skill-index.ts`,集中放 `SkillDoctorSnapshot / SkillEvalSnapshot / SkillObserveSnapshot / SkillIndexEntry / SkillIndexSummary / SkillIndex` 和 `Insight* / DetectInsightsOptions` 共 17 个类型
- `StudioDiagnosisSummary` 一并上移到 `src/types/diagnosis.ts`(SkillIndex 引用它),`diagnosis/studio-projection.ts` 改 re-export
- `types/report.ts` 的旧 `Insight` 重命名为 `AnalysisInsight`,消除跟 SkillIndex 那侧新 `Insight` 的 barrel 命名冲突。仅 `src/analysis/report-diagnostics.ts` 和 `src/renderer/summary.ts` 两个内部消费者,JSON 字段语义不变(serialization 不带类型名)
- `src/server/skill-index.ts` 和 `src/server/skill-insights.ts` re-export 全部 DTO 供老路径使用,测试不动 import
- renderer 两文件 import 全部走 `../types/index.js`,不再 reach 进 `server/`

## 测量学守门

- Report JSON schema 字段语义不变(只是 TS 接口改名)
- judge prompt hash / observe LLM 复盘 prompt hash 不动
- HTML snapshot 字节一致
- 1615 个测试全过

## 跟 PR #159 的关系

PR #159 boundary test 中 4 条 \`renderer/skill-*-renderer.ts::server/skill-*\` whitelist entry,在两个 PR 都合入后会被 dead-whitelist 检查自动标红提示清理。

## Test plan

- [x] yarn lint
- [x] yarn build
- [x] yarn test(1615 全过)

🤖 Generated with [Claude Code](https://claude.com/claude-code)