### PR TITLE
refactor(types): observability DTO 上移到 src/types/ 解开内部循环

### DIFF
--- a/src/observability/experience-frontmatter.ts
+++ b/src/observability/experience-frontmatter.ts
@@ -24,7 +24,7 @@
 import { readFileSync } from 'node:fs';
 import { parseSkillFrontmatter, validateSkillHardRules, validateSkillWorkflows } from '../shared/hard-rules.js';
 import { findSkillMdPath } from './skill-chain.js';
-import type { ExperienceRuntimeSkillType } from './experience.js';
+import type { ExperienceRuntimeSkillType } from '../types/index.js';
 
 export interface SkillDeclarationCheck {
   hardRules: {

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -1,12 +1,81 @@
 import { createHash } from 'node:crypto';
-import type { ObservationInboxItem, ObservationSourceKind } from './inbox.js';
+import type {
+  ExperienceAssistiveInference,
+  ExperienceAssistiveInferenceCautionCode,
+  ExperienceAssistiveInferenceCode,
+  ExperienceAssistiveInferenceConfidence,
+  ExperienceChecklistContribution,
+  ExperienceChecklistItem,
+  ExperienceChecklistItemStatus,
+  ExperienceEpisode,
+  ExperienceEpisodeArtifact,
+  ExperienceEpisodeArtifactKind,
+  ExperienceEpisodeBoundaryReason,
+  ExperienceEpisodeOutcome,
+  ExperienceEpisodeRole,
+  ExperienceEvidenceChain,
+  ExperienceEvidenceKind,
+  ExperienceEvidenceRef,
+  ExperienceFeedbackAttribution,
+  ExperienceFeedbackAttributionReason,
+  ExperienceFeedbackAttributionRole,
+  ExperienceFeedbackSignal,
+  ExperienceFeedbackSignalType,
+  ExperienceGoalEvidenceRef,
+  ExperienceGoalSlice,
+  ExperienceGoalSliceReasonCode,
+  ExperienceInvocation,
+  ExperienceMessageRange,
+  ExperienceOrchestrationEdge,
+  ExperienceOrchestrationEdgeKind,
+  ExperienceOrchestrationEdgeStatus,
+  ExperienceOutcomeClosure,
+  ExperienceParentReason,
+  ExperienceReviewBasisCode,
+  ExperienceReviewIndicators,
+  ExperienceReviewPriority,
+  ExperienceReviewerReport,
+  ExperienceReviewerReportFinding,
+  ExperienceReviewerReportFindingLevel,
+  ExperienceReviewerReportFindingSource,
+  ExperienceReviewerReportScope,
+  ExperienceReviewerReportStep,
+  ExperienceReviewerReportStepStatus,
+  ExperienceRuleFinding,
+  ExperienceRuleFindingCode,
+  ExperienceRuleFindingLevel,
+  ExperienceRuntimeSkillType,
+  ExperienceRuntimeSkillTypeSource,
+  ExperienceSessionStory,
+  ExperienceSessionStoryAnswer,
+  ExperienceSessionStoryAnswerKey,
+  ExperienceSessionStoryGoalSlice,
+  ExperienceSessionStoryGraphEdge,
+  ExperienceSessionStoryGraphNode,
+  ExperienceSessionStoryNode,
+  ExperienceSessionStoryNodeKind,
+  ExperienceSessionStorySkillLink,
+  ExperienceSessionStorySkillRole,
+  ExperienceSessionStorySubagentDispatch,
+  ExperienceSessionSummary,
+  ExperienceSkillSegment,
+  ExperienceSkillSummary,
+  ExperienceTimelineBranch,
+  ExperienceTimelineEvent,
+  ExperienceTimelineTree,
+  ObservationExperienceReport,
+  ObservationInboxItem,
+  ObservationMetricKey,
+  ObservationReviewState,
+  ObservationSourceKind,
+  TraceSourceMetadata,
+} from '../types/index.js';
 import {
   buildExperienceProblemPatterns,
   mergeExperienceProblemPatterns,
-  type ExperienceProblemPattern,
 } from './problem-patterns.js';
-import { observationMetricAnnotationVerdict, observationReviewStateKey, type ObservationMetricKey, type ObservationReviewState } from './review-state.js';
-import type { CcAssistantRecord, CcRecord, CcSession, CcUserRecord, TraceSourceMetadata } from './trace-source.js';
+import { observationMetricAnnotationVerdict, observationReviewStateKey } from './review-state.js';
+import type { CcAssistantRecord, CcRecord, CcSession, CcUserRecord } from './trace-source.js';
 import type { SkillSegment } from './trace-segmenter.js';
 import { extractCommandEnvelopeText, stripCommandEnvelopeText } from './trace-attribution.js';
 import { hasAssistantDeliverableArtifactText, hasAssistantDeliverySignalText, hasUserHardRuleText, isAssistantProgressUpdateText, isAssistantProtocolReplyText, isRuntimeProtocolPromptText, isSyntheticUserMessageText, isToolResultFailureText, isUserInteractionMetricText } from './text-signals.js';
@@ -39,224 +108,72 @@ export {
 } from './feedback-matchers.js';
 export type { TextMatchRange } from './feedback-matchers.js';
 
-export type ExperienceReviewPriority = 'review_first' | 'sample_review' | 'routine_sample';
-export type ExperienceGoalSliceReasonCode = 'skill_segment_boundary' | 'explicit_user_goal_shift' | 'default_session_slice';
-export type ExperienceEvidenceKind = 'user_message' | 'synthetic_user_event' | 'assistant_message' | 'tool_use' | 'tool_result' | 'skill_context' | 'runtime_context' | 'observation';
-export type ExperienceAssistiveInferenceCode =
-  | 'review_recommended'
-  | 'sample_recommended'
-  | 'positive_signal_observed'
-  | 'user_switched_topic_neutral'
-  | 'no_obvious_issue_from_rules'
-  | 'insufficient_human_context';
-export type ExperienceAssistiveInferenceConfidence = 'low' | 'medium' | 'high';
-export type ExperienceAssistiveInferenceCautionCode =
-  | 'no_llm_judge'
-  | 'rule_only'
-  | 'runtime_context_excluded'
-  | 'skill_context_excluded'
-  | 'no_human_user_message'
-  | 'limited_timeline_window';
-export type ExperienceReviewBasisCode =
-  | 'has_high_observation'
-  | 'has_medium_observation'
-  | 'user_correction'
-  | 'user_interruption'
-  | 'session_interrupted'
-  | 'negative_feedback'
-  | 'hard_rule_text_hit'
-  | 'tool_failure'
-  | 'hedging_signal'
-  | 'explicit_marker';
-export type ExperienceRuleFindingLevel = 'attention' | 'sample' | 'normal';
-export type ExperienceReviewerReportScope = 'single_skill_single_goal' | 'degraded_complex';
-export type ExperienceReviewerReportStepStatus = 'ok' | 'attention' | 'unknown' | 'degraded' | 'not_applicable';
-export type ExperienceReviewerReportFindingLevel = 'attention' | 'possible_false_positive' | 'note';
-export type ExperienceReviewerReportFindingSource = 'deterministic_rule' | 'llm_soft' | 'manual';
-export type ExperienceChecklistItemStatus = 'passed' | 'failed' | 'unknown' | 'not_declared' | 'not_applicable' | 'degraded';
-export type ExperienceChecklistContribution = 'blocking' | 'attention' | 'informational' | 'positive' | 'neutral';
-export type ExperienceParentReason =
-  | 'data_degraded'
-  | 'blocking_failed'
-  | 'attention_accumulated'
-  | 'unknown_dominant'
-  | 'all_passed'
-  | 'not_applicable';
-export type ExperienceSessionStoryNodeKind =
-  | 'user_goal'
-  | 'skill_invocation'
-  | 'subagent_branch'
-  | 'tool_execution'
-  | 'delivery'
-  | 'user_feedback'
-  | 'goal_shift';
-export type ExperienceSessionStoryAnswerKey = 'goal_satisfaction' | 'declared_behavior_fit' | 'user_feeling';
-export type ExperienceSessionStorySkillRole = 'router' | 'executor' | 'mixed' | 'unknown';
-export type ExperienceEpisodeBoundaryReason = 'goal_shift' | 'checkpoint_or_subagent' | 'downstream_closed' | 'session_end';
-export type ExperienceEpisodeRole = 'main_executor' | 'router' | 'delegator' | 'supporting' | 'observer';
-export type ExperienceFeedbackSignalType = 'correction' | 'follow_up' | 'frustration' | 'interruption' | 'positive' | 'unknown';
-export type ExperienceFeedbackAttributionRole = 'primary_fault' | 'downstream_related' | 'context_only';
-export type ExperienceFeedbackAttributionReason = 'object_match' | 'promise_match' | 'action_match' | 'orchestration_edge' | 'episode_context';
-export type ExperienceOutcomeClosure = 'closed' | 'unresolved' | 'abandoned' | 'unknown';
-export type ExperienceRuntimeSkillType = 'router' | 'delegation' | 'executor' | 'advisory' | 'workflow_owner' | 'unknown';
-export type ExperienceRuntimeSkillTypeSource = 'frontmatter' | 'trace' | 'unknown';
-export type ExperienceEpisodeArtifactKind = 'path' | 'url' | 'document' | 'code' | 'execution_window' | 'unknown';
-export type ExperienceOrchestrationEdgeStatus = 'started' | 'completed' | 'failed' | 'unknown';
-export type ExperienceOrchestrationEdgeKind = 'internal_skill' | 'external_child_session';
-export type ExperienceRuleFindingCode =
-  | 'high_observation_seen'
-  | 'medium_observation_seen'
-  | 'user_correction_seen'
-  | 'user_interruption_seen'
-  | 'session_interrupted_seen'
-  | 'negative_feedback_seen'
-  | 'positive_feedback_seen'
-  | 'user_goal_shift_seen'
-  | 'hard_rule_seen'
-  | 'tool_failure_seen'
-  | 'hedging_seen'
-  | 'explicit_marker_seen'
-  | 'runtime_context_excluded'
-  | 'skill_context_excluded'
-  | 'no_priority_signal';
-
-export interface ExperienceEvidenceRef {
-  id: string;
-  kind: ExperienceEvidenceKind;
-  sourceTrace: string;
-  sessionId: string;
-  traceRole?: 'standalone' | 'main' | 'subagent';
-  traceLabel?: string;
-  messageIndex?: number;
-  logicalMessageIndex?: number;
-  sourceLineIndex?: number;
-  messageUuid?: string;
-  toolUseId?: string;
-  timestamp?: string;
-  role?: 'user' | 'assistant' | 'tool' | 'other';
-  label?: string;
-  snippet?: string;
-}
-
-export interface ExperienceTimelineEvent extends ExperienceEvidenceRef {
-  order: number;
-  toolName?: string;
-  isError?: boolean;
-  fullText?: string;
-}
-
-export interface ExperienceTimelineBranch {
-  id: string;
-  label: string;
-  sourceTrace: string;
-  traceRole: 'main' | 'subagent' | 'standalone';
-  attachTo?: {
-    sourceTrace: string;
-    messageIndex?: number;
-    toolUseId?: string;
-    label?: string;
-  };
-  events: ExperienceTimelineEvent[];
-}
-
-export interface ExperienceTimelineTree {
-  sessionId: string;
-  main: ExperienceTimelineEvent[];
-  branches: ExperienceTimelineBranch[];
-}
-
-export interface ExperienceEvidenceChain {
-  userMessageCount: number;
-  runtimeContextCount: number;
-  skillContextCount: number;
-  assistantMessageCount: number;
-  toolUseCount: number;
-  toolResultCount: number;
-  toolFailureResultCount: number;
-  observationCount: number;
-  firstUserMessage?: ExperienceEvidenceRef;
-  firstRuntimeContext?: ExperienceEvidenceRef;
-  firstSkillContext?: ExperienceEvidenceRef;
-  firstToolUse?: ExperienceEvidenceRef;
-  firstToolFailure?: ExperienceEvidenceRef;
-  lastAssistantMessage?: ExperienceEvidenceRef;
-}
-
-export interface ExperienceRuleFinding {
-  code: ExperienceRuleFindingCode;
-  level: ExperienceRuleFindingLevel;
-  count: number;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
-
-export interface ExperienceAssistiveInference {
-  mode: 'deterministic_rules_only';
-  code: ExperienceAssistiveInferenceCode;
-  confidence: ExperienceAssistiveInferenceConfidence;
-  basisRuleCodes: ExperienceRuleFindingCode[];
-  cautionCodes: ExperienceAssistiveInferenceCautionCode[];
-  evidenceRefs: ExperienceEvidenceRef[];
-}
-
-export interface ExperienceReviewerReportStep {
-  order: number;
-  label: string;
-  status: ExperienceReviewerReportStepStatus;
-  text: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
-
-export interface ExperienceReviewerReportFinding {
-  id: string;
-  judgmentId: string;
-  source: ExperienceReviewerReportFindingSource;
-  level: ExperienceReviewerReportFindingLevel;
-  title: string;
-  body: string;
-  ruleSource: string;
-  ruleVersion: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-  reviewStateRef: {
-    targetType: 'reviewer_judgment';
-    targetId: string;
-    verdict?: string;
-    reason?: string;
-    note?: string;
-    reviewedAt?: string;
-  };
-}
-
-export interface ExperienceSessionStoryNode {
-  id: string;
-  order: number;
-  kind: ExperienceSessionStoryNodeKind;
-  label: string;
-  status: ExperienceReviewerReportStepStatus;
-  text: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
-
-export interface ExperienceSessionStoryAnswer {
-  key: ExperienceSessionStoryAnswerKey;
-  label: string;
-  status: ExperienceReviewerReportStepStatus;
-  reason: ExperienceParentReason;
-  sourceItemKeys: string[];
-  text: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-  checklistItems: ExperienceChecklistItem[];
-}
-
-export interface ExperienceChecklistItem {
-  key: string;
-  label: string;
-  status: ExperienceChecklistItemStatus;
-  contribution: ExperienceChecklistContribution;
-  reason: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-  source: ExperienceReviewerReportFindingSource;
-  suggestionKey?: string;
-}
+export type {
+  ExperienceAssistiveInference,
+  ExperienceAssistiveInferenceCautionCode,
+  ExperienceAssistiveInferenceCode,
+  ExperienceAssistiveInferenceConfidence,
+  ExperienceChecklistContribution,
+  ExperienceChecklistItem,
+  ExperienceChecklistItemStatus,
+  ExperienceEpisode,
+  ExperienceEpisodeArtifact,
+  ExperienceEpisodeArtifactKind,
+  ExperienceEpisodeBoundaryReason,
+  ExperienceEpisodeOutcome,
+  ExperienceEpisodeRole,
+  ExperienceEvidenceChain,
+  ExperienceEvidenceKind,
+  ExperienceEvidenceRef,
+  ExperienceFeedbackAttribution,
+  ExperienceFeedbackAttributionReason,
+  ExperienceFeedbackAttributionRole,
+  ExperienceFeedbackSignal,
+  ExperienceFeedbackSignalType,
+  ExperienceGoalEvidenceRef,
+  ExperienceGoalSlice,
+  ExperienceGoalSliceReasonCode,
+  ExperienceInvocation,
+  ExperienceMessageRange,
+  ExperienceOrchestrationEdge,
+  ExperienceOrchestrationEdgeKind,
+  ExperienceOrchestrationEdgeStatus,
+  ExperienceOutcomeClosure,
+  ExperienceParentReason,
+  ExperienceReviewBasisCode,
+  ExperienceReviewIndicators,
+  ExperienceReviewPriority,
+  ExperienceReviewerReport,
+  ExperienceReviewerReportFinding,
+  ExperienceReviewerReportFindingLevel,
+  ExperienceReviewerReportFindingSource,
+  ExperienceReviewerReportScope,
+  ExperienceReviewerReportStep,
+  ExperienceReviewerReportStepStatus,
+  ExperienceRuleFinding,
+  ExperienceRuleFindingCode,
+  ExperienceRuleFindingLevel,
+  ExperienceRuntimeSkillType,
+  ExperienceRuntimeSkillTypeSource,
+  ExperienceSessionStory,
+  ExperienceSessionStoryAnswer,
+  ExperienceSessionStoryAnswerKey,
+  ExperienceSessionStoryGoalSlice,
+  ExperienceSessionStoryGraphEdge,
+  ExperienceSessionStoryGraphNode,
+  ExperienceSessionStoryNode,
+  ExperienceSessionStoryNodeKind,
+  ExperienceSessionStorySkillLink,
+  ExperienceSessionStorySkillRole,
+  ExperienceSessionStorySubagentDispatch,
+  ExperienceSessionSummary,
+  ExperienceSkillSegment,
+  ExperienceSkillSummary,
+  ExperienceTimelineBranch,
+  ExperienceTimelineEvent,
+  ExperienceTimelineTree,
+  ObservationExperienceReport,
+};
 
 export function aggregateExperienceChecklistItemStatus(statuses: ExperienceChecklistItemStatus[]): ExperienceChecklistItemStatus {
   if (statuses.includes('degraded')) return 'degraded';
@@ -267,398 +184,12 @@ export function aggregateExperienceChecklistItemStatus(statuses: ExperienceCheck
   return 'not_applicable';
 }
 
-export interface ExperienceSessionStoryGoalSlice {
-  id: string;
-  order: number;
-  skillNames: string[];
-  startTimestamp: string;
-  endTimestamp: string;
-  reasonCode: ExperienceGoalSliceReasonCode;
-  inferredUserGoal?: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
-
-export interface ExperienceSessionStorySubagentDispatch {
-  id: string;
-  order: number;
-  branchId: string;
-  label: string;
-  sourceTrace: string;
-  attachTo?: {
-    messageIndex?: number;
-    toolUseId?: string;
-    label?: string;
-  };
-  eventCount: number;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
-
-export interface ExperienceSessionStorySkillLink {
-  id: string;
-  order: number;
-  skillName: string;
-  role: ExperienceSessionStorySkillRole;
-  invocationIds: string[];
-  goalSliceIds: string[];
-  evidenceRefs: ExperienceEvidenceRef[];
-}
-
-export interface ExperienceGoalEvidenceRef {
-  kind: 'user_message' | 'goal_slice' | 'llm_goal';
-  goalSliceId?: string;
-  evidenceRef?: ExperienceEvidenceRef;
-  label?: string;
-}
-
-type ExperienceMessageRange = {
-  startMessageIndex: number;
-  endMessageIndex: number;
-  sourceTrace?: string;
-  sessionId?: string;
-};
-
-export interface ExperienceSkillSegment {
-  id: string;
-  order: number;
-  skillName: string;
-  skillType: ExperienceRuntimeSkillType;
-  skillTypeSource?: ExperienceRuntimeSkillTypeSource;
-  declaredSkillType?: ExperienceRuntimeSkillType;
-  traceInferredSkillType?: ExperienceRuntimeSkillType;
-  episodeRole: ExperienceEpisodeRole;
-  skillInvocationIds: string[];
-  startMessageIndex?: number;
-  endMessageIndex?: number;
-  messageRanges?: ExperienceMessageRange[];
-  startTimestamp: string;
-  endTimestamp: string;
-  typeSpecificChecklist: ExperienceChecklistItem[];
-  runtimeAssessment?: {
-    goalSatisfaction?: string;
-    declaredBehaviorFit?: string;
-    artifactGoalMatch?: string;
-    userFeeling?: string;
-  };
-  evidenceRefs: ExperienceEvidenceRef[];
-}
-
 interface ExperienceEpisodeRange {
   startMessageIndex: number;
   endMessageIndex: number;
   sourceTrace?: string;
   sessionId?: string;
   boundaryReason?: ExperienceEpisodeBoundaryReason;
-}
-
-export interface ExperienceOrchestrationEdge {
-  id: string;
-  episodeId: string;
-  edgeKind: ExperienceOrchestrationEdgeKind;
-  parentSkillSegmentId?: string;
-  executorSkillSegmentId?: string;
-  childSessionId?: string;
-  runnerStartedRef?: ExperienceEvidenceRef;
-  runnerCompletedRef?: ExperienceEvidenceRef;
-  notificationRef?: ExperienceEvidenceRef;
-  status: ExperienceOrchestrationEdgeStatus;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
-
-export interface ExperienceFeedbackAttribution {
-  skillName?: string;
-  skillSegmentId?: string;
-  attributionRole: ExperienceFeedbackAttributionRole;
-  reasonCode: ExperienceFeedbackAttributionReason;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
-
-export interface ExperienceFeedbackSignal {
-  id: string;
-  order: number;
-  type: ExperienceFeedbackSignalType;
-  text: string;
-  targetObject?: string;
-  sourceWindow: 'session' | 'episode' | 'skill_invocation' | 'downstream_child';
-  evidenceRef: ExperienceEvidenceRef;
-  canonicalAttributions?: ExperienceFeedbackAttribution[];
-  attributions: ExperienceFeedbackAttribution[];
-}
-
-export interface ExperienceEpisodeArtifact {
-  kind: ExperienceEpisodeArtifactKind;
-  label: string;
-  pathOrUrl?: string;
-  artifactGoalMatch: 'passed' | 'failed' | 'unknown';
-  evidenceRef: ExperienceEvidenceRef;
-}
-
-export interface ExperienceEpisodeOutcome {
-  closure: ExperienceOutcomeClosure;
-  artifacts: ExperienceEpisodeArtifact[];
-  verdict: ExperienceReviewPriority;
-  acceptanceCriteria?: string;
-}
-
-export interface ExperienceEpisode {
-  id: string;
-  order: number;
-  sessionId: string;
-  primaryGoal?: string;
-  goalEvidenceRefs: ExperienceGoalEvidenceRef[];
-  startTimestamp: string;
-  endTimestamp: string;
-  startRef?: ExperienceEvidenceRef;
-  endRef?: ExperienceEvidenceRef;
-  boundaryReason: ExperienceEpisodeBoundaryReason;
-  skillSegments: ExperienceSkillSegment[];
-  orchestrationEdges: ExperienceOrchestrationEdge[];
-  feedbackSignals: ExperienceFeedbackSignal[];
-  outcome: ExperienceEpisodeOutcome;
-}
-
-export interface ExperienceSessionStoryGraphNode {
-  id: string;
-  label: string;
-  kind: ExperienceSessionStoryNodeKind;
-  status: ExperienceReviewerReportStepStatus;
-  role?: ExperienceSessionStorySkillRole;
-  detailNodeId?: string;
-}
-
-export interface ExperienceSessionStoryGraphEdge {
-  fromId: string;
-  toId: string;
-  label: string;
-}
-
-export interface ExperienceSessionStory {
-  schemaVersion: 1;
-  summary: string;
-  invocationCount: number;
-  goalSliceCount: number;
-  branchCount: number;
-  progressUpdateCount: number;
-  finalDeliverySignalCount: number;
-  mainlineNodeIds: string[];
-  goalSlices: ExperienceSessionStoryGoalSlice[];
-  subagentDispatches: ExperienceSessionStorySubagentDispatch[];
-  skillLinks: ExperienceSessionStorySkillLink[];
-  episodes?: ExperienceEpisode[];
-  graph: {
-    nodes: ExperienceSessionStoryGraphNode[];
-    edges: ExperienceSessionStoryGraphEdge[];
-  };
-  nodes: ExperienceSessionStoryNode[];
-  answers: ExperienceSessionStoryAnswer[];
-}
-
-export interface ExperienceReviewerReport {
-  schemaVersion: 1;
-  mode: 'deterministic_milestone_1' | 'deterministic_session_story';
-  generatedAt: string;
-  title: string;
-  summary: string;
-  scope: {
-    kind: ExperienceReviewerReportScope;
-    reasonCodes: string[];
-  };
-  chainSteps: ExperienceReviewerReportStep[];
-  findings: ExperienceReviewerReportFinding[];
-  oneLookMetrics: {
-    toolCallCount: number;
-    toolFailureCount: number;
-    userMessageCount: number;
-    userFollowUpCount: number;
-    assistantDeliverySignalCount: number;
-    deliverableArtifactSignalCount: number;
-    routerDownstreamCompleted: number;
-    routerDownstreamFailed: number;
-    assistantProgressUpdateCount: number;
-    selfCorrectionCount: number;
-    repeatedExecutionCount: number;
-    finalDeliverySignalCount: number;
-    traceEventCount: number;
-    tokenUsage: {
-      inputTokens: number;
-      outputTokens: number;
-      cacheReadTokens: number;
-      cacheCreationTokens: number;
-      attribution: 'skill_segment';
-    };
-  };
-  sessionStory: ExperienceSessionStory;
-  authorSuggestions: string[];
-  traceLinks: ExperienceEvidenceRef[];
-}
-
-export interface ExperienceGoalSlice {
-  id: string;
-  skillName: string;
-  sessionId: string;
-  sourceTrace: string;
-  cwd?: string;
-  startTimestamp: string;
-  endTimestamp: string;
-  sliceReasonCode: ExperienceGoalSliceReasonCode;
-  sliceConfidence: 'low' | 'medium' | 'high';
-  inferredUserGoal?: string;
-  userMessageRefs: ExperienceEvidenceRef[];
-}
-
-export interface ExperienceReviewIndicators {
-  userMessageCount: number;
-  userFollowUpCount: number;
-  userCorrectionCount: number;
-  userInterruptionCount: number;
-  sessionInterruptedCount: number;
-  negativeFeedbackCount: number;
-  positiveFeedbackCount: number;
-  userGoalShiftCount: number;
-  hardRuleTextHitCount: number;
-  assistantDeliverySignalCount: number;
-  deliverableArtifactSignalCount: number;
-  routerDownstreamCompleted: number;
-  routerDownstreamFailed: number;
-  selfCorrectionCount: number;
-  repeatedExecutionCount: number;
-  toolCallCount: number;
-  toolFailureCount: number;
-  highObservationCount: number;
-  mediumObservationCount: number;
-  hedgingCount: number;
-  explicitMarkerCount: number;
-}
-
-export interface ExperienceInvocation {
-  id: string;
-  skillName: string;
-  sessionId: string;
-  sessionGroupKey: string;
-  sourceTrace: string;
-  sourceKind: ObservationSourceKind;
-  entrypoint?: string;
-  sourceMetadata?: TraceSourceMetadata;
-  cwd?: string;
-  segmentIndex: number;
-  goalSliceId: string;
-  startTimestamp: string;
-  endTimestamp: string;
-  attribution: {
-    source: string;
-    confidence: number;
-    rawSkillRef?: string;
-    pluginName?: string;
-    commandName?: string;
-  };
-  metrics: SkillSegment['metrics'];
-  toolCounts: Record<string, number>;
-  indicators: ExperienceReviewIndicators;
-  evidenceChain: ExperienceEvidenceChain;
-  ruleFindings: ExperienceRuleFinding[];
-  assistiveInference: ExperienceAssistiveInference;
-  problemPatterns: ExperienceProblemPattern[];
-  relatedObservationIds: string[];
-  evidenceRefs: ExperienceEvidenceRef[];
-  timeline: ExperienceTimelineEvent[];
-}
-
-export interface ExperienceSessionSummary {
-  id: string;
-  skillName: string;
-  sessionId: string;
-  sourceTrace: string;
-  sourceKind: ObservationSourceKind;
-  entrypoint?: string;
-  sourceMetadata?: TraceSourceMetadata;
-  cwd?: string;
-  sourceSessionStartTimestamp?: string;
-  sourceSessionEndTimestamp?: string;
-  sourceSessionDurationMs?: number;
-  startTimestamp: string;
-  endTimestamp: string;
-  invocationIds: string[];
-  goalSliceIds: string[];
-  reviewPriority: ExperienceReviewPriority;
-  reviewPriorityScore: number;
-  reviewBasisCodes: ExperienceReviewBasisCode[];
-  indicators: ExperienceReviewIndicators;
-  evidenceChain: ExperienceEvidenceChain;
-  ruleFindings: ExperienceRuleFinding[];
-  assistiveInference: ExperienceAssistiveInference;
-  problemPatterns: ExperienceProblemPattern[];
-  relatedObservationIds: string[];
-  timelinePreview: ExperienceTimelineEvent[];
-  fullSessionTimeline: ExperienceTimelineEvent[];
-  timelineTree?: ExperienceTimelineTree;
-  timelineScope: {
-    mode: 'skill_segment_window';
-    segmentStartRecordIndex?: number;
-    segmentEndRecordIndex?: number;
-    previewStartRecordIndex?: number;
-    previewEndRecordIndex?: number;
-    sessionStartRecordIndex: number;
-    sessionEndRecordIndex: number;
-    previewEventCount: number;
-    fullSessionEventCount: number;
-    truncated: boolean;
-    omittedBeforeCount: number;
-    omittedAfterCount: number;
-  };
-  attributionSources: string[];
-  pluginNames: string[];
-  rawSkillRefs: string[];
-  commandNames: string[];
-  sessionStory?: ExperienceSessionStory;
-  reviewerReport?: ExperienceReviewerReport;
-}
-
-export interface ExperienceSkillSummary {
-  skillName: string;
-  invocationCount: number;
-  sessionCount: number;
-  sourceKinds: ObservationSourceKind[];
-  entrypoints: string[];
-  entrypointCounts: Record<string, number>;
-  sourceMetadataCounts: {
-    channels: Record<string, number>;
-    senders: Record<string, number>;
-    businessActions: Record<string, number>;
-    providers: Record<string, number>;
-    models: Record<string, number>;
-  };
-  attributionCounts: Record<string, number>;
-  pluginNames: string[];
-  rawSkillRefs: string[];
-  commandNames: string[];
-  toolCounts: Record<string, number>;
-  firstSeen: string;
-  lastSeen: string;
-  reviewFirstSessionCount: number;
-  sampleReviewSessionCount: number;
-  indicators: ExperienceReviewIndicators;
-  evidenceChain: ExperienceEvidenceChain;
-  ruleFindings: ExperienceRuleFinding[];
-  assistiveInference: ExperienceAssistiveInference;
-  problemPatterns: ExperienceProblemPattern[];
-  relatedObservationIds: string[];
-}
-
-export interface ObservationExperienceReport {
-  kind: 'observe-experience';
-  schemaVersion: 1;
-  scope: 'evidence-only';
-  generatedAt: string;
-  meta: {
-    sessionCount: number;
-    skillCount: number;
-    invocationCount: number;
-    goalSliceCount: number;
-    noteCodes: Array<'no_llm_judge' | 'no_auto_verdict' | 'default_goal_slice_is_allowed' | 'deterministic_assistive_inference'>;
-  };
-  goalSlices: ExperienceGoalSlice[];
-  invocations: ExperienceInvocation[];
-  sessions: ExperienceSessionSummary[];
-  skills: ExperienceSkillSummary[];
 }
 
 const USER_INTERRUPTION_RE = /\[Request interrupted by user(?: for tool use)?\]|interrupted by user|用户中断|停止任务|停一下|先别|别动|等一下|等下|等等|取消(?:任务|执行)?|先暂停|暂停一下/i;

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -2,152 +2,46 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import type { GapSignalRef, ToolCallInfo } from '../types/index.js';
+import type {
+  BuildObservationInboxReportOptions,
+  GapSignalRef,
+  ObservationEvidence,
+  ObservationInboxItem,
+  ObservationInboxReport,
+  ObservationMessageRef,
+  ObservationMessageWindow,
+  ObservationSessionTimeRange,
+  ObservationSeverityReasonCode,
+  ObservationSignalSubtype,
+  ObservationSignalType,
+  ObservationSkillRollup,
+  ObservationSourceKind,
+  ToolCallInfo,
+} from '../types/index.js';
 import { extractGapSignalsFromTrace } from '../analysis/gap-analyzer.js';
 import { ccTracesToResultEntries, type CcSession, type SkillSegment } from './trace-adapter.js';
 import { isSearchToolCall, toolCallQuery } from '../shared/tool-search.js';
 import { durationMsBetween } from '../shared/time.js';
-import { buildObservationExperienceReport, type ObservationExperienceReport } from './experience.js';
-import type { ObservationReviewState } from './review-state.js';
-import type { DiagnosisBundle } from '../types/diagnosis.js';
+import { buildObservationExperienceReport } from './experience.js';
+
+export type {
+  BuildObservationInboxReportOptions,
+  ObservationEvidence,
+  ObservationInboxItem,
+  ObservationInboxReport,
+  ObservationMessageRef,
+  ObservationMessageWindow,
+  ObservationSessionTimeRange,
+  ObservationSeverityReasonCode,
+  ObservationSignalSubtype,
+  ObservationSignalType,
+  ObservationSkillRollup,
+  ObservationSourceKind,
+};
 
 export const DEFAULT_PROJECT_OBSERVATIONS_DIR = join(process.cwd(), '.omk', 'observations');
 export const DEFAULT_GLOBAL_OBSERVATIONS_DIR = join(homedir(), '.oh-my-knowledge', 'observations');
 export const DEFAULT_OBSERVATIONS_DIR = DEFAULT_PROJECT_OBSERVATIONS_DIR;
-
-export type ObservationSignalType = 'failed_search' | 'repeated_failure' | 'hedging' | 'explicit_marker';
-export type ObservationSourceKind = 'claude' | 'openclaw' | 'markdown_log' | 'unknown';
-export type ObservationSeverityReasonCode =
-  | 'knowledge_gap_suspected'
-  | 'repeated_failure_suspected'
-  | 'explicit_gap_marker'
-  | 'exploratory_probe'
-  | 'skill_asset_unavailable'
-  | 'soft_hedging_signal'
-  | 'tool_or_runtime_noise';
-export type ObservationSignalSubtype =
-  | 'hard_miss'
-  | 'repeated_failure'
-  | 'exploratory_miss'
-  | 'tool_error'
-  | 'permission_error'
-  | 'bash_probe'
-  | 'not_found'
-  | 'transient_file_missing'
-  | 'skill_asset_read_failed'
-  | 'permission_denied'
-  | 'tool_limit'
-  | 'tool_failure'
-  | 'regex_only'
-  | 'llm_classified'
-  | 'marker';
-
-export interface ObservationEvidence {
-  tool?: string;
-  query?: string;
-  path?: string;
-  outputSnippet?: string;
-  assistantSnippet?: string;
-  markerToken?: string;
-  messageIndex?: number;
-  messageUuid?: string;
-  toolUseId?: string;
-  segmentTimestamp?: string;
-}
-
-export interface ObservationMessageRef {
-  role: 'user' | 'assistant' | 'other';
-  snippet: string;
-  messageIndex: number;
-  uuid?: string;
-  timestamp?: string;
-}
-
-export interface ObservationMessageWindow {
-  before: ObservationMessageRef[];
-  event: ObservationMessageRef[];
-  after: ObservationMessageRef[];
-  resolutionAfter: 'resolved' | 'unresolved' | 'unknown';
-}
-
-export interface ObservationInboxItem {
-  id: string;
-  skillName: string;
-  artifactVersion: string | 'unknown';
-  artifactHash?: string;
-  cwd?: string;
-  sessionId: string;
-  sourceTrace: string;
-  sourceKind: ObservationSourceKind;
-  signalType: ObservationSignalType;
-  signalSubtype: ObservationSignalSubtype;
-  confidence: number;
-  attributionConfidence: number;
-  severity: 'high' | 'medium' | 'low' | 'noise';
-  severityReasonCode?: ObservationSeverityReasonCode;
-  severityReason?: string;
-  evidence: ObservationEvidence;
-  messageWindow?: ObservationMessageWindow;
-  firstSeen: string;
-  lastSeen: string;
-  occurrences: number;
-  recentSessionIds: string[];
-  representativeEvidence: ObservationEvidence[];
-}
-
-export interface ObservationSessionTimeRange {
-  sessionId: string;
-  sessionGroupId?: string;
-  sourceTrace: string;
-  sourceKind: ObservationSourceKind;
-  traceRole?: 'standalone' | 'main' | 'subagent';
-  traceLabel?: string;
-  cwd?: string;
-  startTimestamp?: string;
-  endTimestamp?: string;
-  durationMs?: number;
-}
-
-export interface ObservationInboxReport {
-  kind: 'observe-inbox';
-  schemaVersion: 1;
-  meta: {
-    tracePath: string;
-    generatedAt: string;
-    sessionCount?: number;
-    sessionTimeRange?: {
-      from: string;
-      to: string;
-      durationMs?: number;
-    };
-    sessionTimeRanges?: ObservationSessionTimeRange[];
-    segmentCount: number;
-    itemCount: number;
-    skillInvocationCounts?: Record<string, number>;
-    skillSessionCounts?: Record<string, number>;
-    skillInvocationLastSeen?: Record<string, string>;
-    skillToolCallCounts?: Record<string, Record<string, number>>;
-  };
-  items: ObservationInboxItem[];
-  experience?: ObservationExperienceReport;
-  diagnostics?: DiagnosisBundle;
-}
-
-export interface ObservationSkillRollup {
-  skillName: string;
-  invocationCount: number;
-  sessionCount: number;
-  observationCount: number;
-  highCount: number;
-  mediumCount: number;
-  lowCount: number;
-  noiseCount: number;
-  latestSeen: string;
-}
-
-export interface BuildObservationInboxReportOptions {
-  reviewState?: ObservationReviewState;
-}
 
 function hashString(input: string): string {
   return createHash('sha256').update(input).digest('hex').slice(0, 16);

--- a/src/observability/problem-patterns.ts
+++ b/src/observability/problem-patterns.ts
@@ -1,75 +1,22 @@
 import { createHash } from 'node:crypto';
-import { observationMetricAnnotationVerdict, type ObservationMetricKey, type ObservationReviewState } from './review-state.js';
+import { observationMetricAnnotationVerdict } from './review-state.js';
+import type { ObservationMetricKey, ObservationReviewState } from '../types/index.js';
 import { hasUserHardRuleText, isUserInteractionMetricText } from './text-signals.js';
+import type {
+  ExperienceProblemBucket,
+  ExperienceProblemEvidenceRef,
+  ExperienceProblemPattern,
+  ExperienceProblemSignal,
+  ProblemTimelineEvent,
+} from '../types/index.js';
 
-export type ExperienceProblemBucket =
-  | 'output_format'
-  | 'content_accuracy'
-  | 'missing_context'
-  | 'rule_violation'
-  | 'workflow_mismatch'
-  | 'tool_runtime'
-  | 'goal_shift'
-  | 'unclear';
-
-export type ExperienceProblemSignal =
-  | 'user_correction'
-  | 'negative_feedback'
-  | 'user_interruption'
-  | 'hard_rule'
-  | 'user_goal_shift'
-  | 'tool_failure'
-  | 'workflow_mismatch'
-  | 'artifact_missing'
-  | 'observer_lifecycle_failed'
-  | 'orchestration_boundary_violation';
-
-export interface ExperienceProblemEvidenceRef {
-  id: string;
-  kind: string;
-  sourceTrace: string;
-  sessionId: string;
-  messageIndex?: number;
-  logicalMessageIndex?: number;
-  sourceLineIndex?: number;
-  messageUuid?: string;
-  toolUseId?: string;
-  timestamp?: string;
-  role?: 'user' | 'assistant' | 'tool' | 'other';
-  label?: string;
-  snippet?: string;
-}
-
-export interface ExperienceProblemPattern {
-  id: string;
-  bucket: ExperienceProblemBucket;
-  patternKey: string;
-  count: number;
-  sessionCount: number;
-  recentSessionIds: string[];
-  signalTypes: ExperienceProblemSignal[];
-  evidenceRefs: ExperienceProblemEvidenceRef[];
-  lastSeen?: string;
-}
-
-export interface ProblemTimelineEvent {
-  id: string;
-  kind: string;
-  sourceTrace: string;
-  sessionId: string;
-  messageIndex?: number;
-  logicalMessageIndex?: number;
-  sourceLineIndex?: number;
-  messageUuid?: string;
-  toolUseId?: string;
-  timestamp?: string;
-  role?: 'user' | 'assistant' | 'tool' | 'other';
-  label?: string;
-  snippet?: string;
-  fullText?: string;
-  toolName?: string;
-  isError?: boolean;
-}
+export type {
+  ExperienceProblemBucket,
+  ExperienceProblemEvidenceRef,
+  ExperienceProblemPattern,
+  ExperienceProblemSignal,
+  ProblemTimelineEvent,
+};
 
 interface PatternDraft {
   bucket: ExperienceProblemBucket;

--- a/src/observability/review-state.ts
+++ b/src/observability/review-state.ts
@@ -1,81 +1,25 @@
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import type {
+  ObservationMetricKey,
+  ObservationMetricScope,
+  ObservationReviewState,
+  ObservationReviewStateEntry,
+  ObservationReviewStateUpdate,
+  ObservationReviewTargetType,
+  ObservationReviewVerdict,
+} from '../types/index.js';
 
-export type ObservationReviewTargetType =
-  | 'experience_session'
-  | 'inbox_item'
-  | 'skill'
-  | 'goal_slice_correction'
-  | 'evidence_metric'
-  | 'reviewer_judgment'
-  | 'soft_standard'
-  | 'goal_keyword_correction'
-  | 'result_artifact_correction'
-  | 'completion_result_correction'
-  | 'deliverable_artifact_correction'
-  | 'skill_relevance_correction'
-  | 'workflow_completion_correction'
-  | 'hardrule_execution_correction'
-  | 'main_tool_execution_correction';
-export type ObservationReviewVerdict = 'reviewed' | 'real_issue' | 'not_issue' | 'needs_more_context' | 'confirmed' | 'rejected';
-export type ObservationMetricKey =
-  | 'user_correction'
-  | 'user_interruption'
-  | 'user_follow_up'
-  | 'negative_feedback'
-  | 'positive_feedback'
-  | 'hard_rule'
-  | 'user_goal_shift'
-  | 'result_artifact'
-  | 'completion_result'
-  | 'deliverable_artifact'
-  | 'progress_update'
-  | 'self_correction'
-  | 'repeated_execution';
-export type ObservationMetricScope = 'message' | 'skill_segment';
-
-export interface ObservationReviewStateEntry {
-  targetType: ObservationReviewTargetType;
-  targetId: string;
-  verdict: ObservationReviewVerdict;
-  reviewedAt: string;
-  note?: string;
-  reason?: string;
-  metricKey?: ObservationMetricKey;
-  metricScope?: ObservationMetricScope;
-  metricScopeId?: string;
-  sourceTrace?: string;
-  sessionId?: string;
-  messageIndex?: number;
-  messageUuid?: string;
-  toolUseId?: string;
-  snippet?: string;
-}
-
-export interface ObservationReviewState {
-  kind: 'observe-review-state';
-  schemaVersion: 1;
-  updatedAt: string;
-  entries: Record<string, ObservationReviewStateEntry>;
-}
-
-export interface ObservationReviewStateUpdate {
-  targetType: ObservationReviewTargetType;
-  targetId: string;
-  verdict: ObservationReviewVerdict;
-  note?: string;
-  reason?: string;
-  metricKey?: ObservationMetricKey;
-  metricScope?: ObservationMetricScope;
-  metricScopeId?: string;
-  sourceTrace?: string;
-  sessionId?: string;
-  messageIndex?: number;
-  messageUuid?: string;
-  toolUseId?: string;
-  snippet?: string;
-}
+export type {
+  ObservationMetricKey,
+  ObservationMetricScope,
+  ObservationReviewState,
+  ObservationReviewStateEntry,
+  ObservationReviewStateUpdate,
+  ObservationReviewTargetType,
+  ObservationReviewVerdict,
+};
 
 export function observationReviewStateKey(targetType: ObservationReviewTargetType, targetId: string): string {
   return `${targetType}:${targetId}`;

--- a/src/observability/skill-chain-advisories.ts
+++ b/src/observability/skill-chain-advisories.ts
@@ -6,21 +6,9 @@
  * 这样将来 doctor 若也要展示同样的提示，code 可复用。
  */
 
-export type SkillChainAdvisoryCode =
-  | 'hardrules_not_declared'
-  | 'workflows_not_declared'
-  | 'skill_md_not_found';
+import type { SkillChainAdvisory, SkillChainAdvisoryCode } from '../types/index.js';
 
-export interface SkillChainAdvisory {
-  code: SkillChainAdvisoryCode;
-  message: string;
-  /** 可选：例子 yaml（hardrules / workflows 用） */
-  exampleYaml?: string;
-  /** 可选：建议命令模板，`${skillName}` 会被替换 */
-  commandTemplate?: string;
-  /** advisory 在 L1 辅助推断里展示的简短 caution 标签（不超过 18 字） */
-  shortLabel: string;
-}
+export type { SkillChainAdvisory, SkillChainAdvisoryCode };
 
 const ADVISORIES: Record<SkillChainAdvisoryCode, SkillChainAdvisory> = {
   hardrules_not_declared: {

--- a/src/observability/skill-chain.ts
+++ b/src/observability/skill-chain.ts
@@ -8,125 +8,28 @@ import {
   type SkillHardRule,
   type SkillWorkflow,
 } from '../shared/hard-rules.js';
-import type { SkillChainAdvisoryCode } from './skill-chain-advisories.js';
-import type { ObservationExperienceReport, ExperienceEvidenceRef, ExperienceInvocation, ExperienceTimelineEvent } from './experience.js';
+import type {
+  ExperienceInvocation,
+  ExperienceTimelineEvent,
+  ObservationExperienceReport,
+  ObservationRuntimeCheck,
+  ObservationRuntimeCheckStatus,
+  ObservationSkillChain,
+  SkillRuntimeEvidencePack,
+  SkillRuntimeEvidencePackNode,
+  SkillRuntimeEvidencePackRef,
+  SkillRuntimeEvidencePackSourceType,
+} from '../types/index.js';
 
-export type ObservationRuntimeCheckStatus = 'passed' | 'attention' | 'manual_review';
-
-export interface ObservationRuntimeCheck {
-  kind: 'hardRule' | 'workflowNode';
-  id: string;
-  title: string;
-  expectation: string;
-  status: ObservationRuntimeCheckStatus;
-  reason: string;
-  evidenceCount: number;
-  evidenceSnippets: string[];
-}
-
-export type SkillRuntimeEvidencePackSourceType =
-  | 'tool_call'
-  | 'tool_result'
-  | 'assistant_message'
-  | 'user_feedback'
-  | 'artifact'
-  | 'runtime_context'
-  | 'skill_context'
-  | 'unknown';
-
-export interface SkillRuntimeEvidencePackRef extends Pick<ExperienceEvidenceRef,
-  'id' | 'kind' | 'sourceTrace' | 'sessionId' | 'messageUuid' | 'messageIndex' | 'logicalMessageIndex' | 'sourceLineIndex' | 'toolUseId' | 'timestamp' | 'role' | 'label' | 'snippet'
-> {
-  sourceType: SkillRuntimeEvidencePackSourceType;
-  toolName?: string;
-  isError?: boolean;
-}
-
-export interface SkillRuntimeEvidencePackNode {
-  nodeId: string;
-  kind: 'workflowNode' | 'hardRule';
-  title: string;
-  expectation: string;
-  deterministicStatus: ObservationRuntimeCheckStatus;
-  deterministicReason: string;
-  candidateEvidenceRefs: SkillRuntimeEvidencePackRef[];
-  candidateEvidenceSnippets: string[];
-}
-
-export interface SkillRuntimeEvidencePack {
-  schemaVersion: 1;
-  skillName: string;
-  generatedBy: 'deterministic_rule_pack';
-  definition: {
-    found: boolean;
-    path?: string;
-    truncated?: boolean;
-  };
-  declaredStandards: {
-    hardRules: Array<{ id: string; title: string; expectation: string; source: 'frontmatter' }>;
-    workflowNodes: Array<{ id: string; title: string; expectation: string; workflowId: string; source: 'frontmatter' | 'markdown_headings' }>;
-  };
-  runtimeEvidence: {
-    toolCalls: SkillRuntimeEvidencePackRef[];
-    assistantMessages: SkillRuntimeEvidencePackRef[];
-    userFeedback: SkillRuntimeEvidencePackRef[];
-    artifacts: SkillRuntimeEvidencePackRef[];
-  };
-  nodeEvidence: SkillRuntimeEvidencePackNode[];
-  evidenceQuality: {
-    pollutedSourceCount: number;
-    windowTooNarrow: boolean;
-    missingRuntimeEvidence: boolean;
-    notes: string[];
-  };
-}
-
-export interface ObservationSkillChain {
-  skillName: string;
-  definition: {
-    found: boolean;
-    path?: string;
-    content?: string;
-    truncated?: boolean;
-  };
-  healthCheck: {
-    source: 'doctor-static-rules';
-    hardRules: {
-      declared: boolean;
-      valid: boolean;
-      count: number;
-      rules: SkillHardRule[];
-      errors: string[];
-      advisoryCode?: SkillChainAdvisoryCode;
-    };
-    workflows: {
-      declared: boolean;
-      valid: boolean;
-      branchCount: number;
-      nodeCount: number;
-      workflows: SkillWorkflow[];
-      errors: string[];
-      source: 'frontmatter' | 'markdown_headings' | 'none';
-      advisoryCode?: SkillChainAdvisoryCode;
-    };
-  };
-  runtime: {
-    supported: true;
-    mode: 'deterministic-no-llm';
-    message: string;
-    summary: {
-      invocationCount: number;
-      toolCallCount: number;
-      toolFailureCount: number;
-      passedCount: number;
-      attentionCount: number;
-      manualReviewCount: number;
-    };
-    hardRules: ObservationRuntimeCheck[];
-    workflowNodes: ObservationRuntimeCheck[];
-    evidencePack?: SkillRuntimeEvidencePack;
-  };
-}
+export type {
+  ObservationRuntimeCheck,
+  ObservationRuntimeCheckStatus,
+  ObservationSkillChain,
+  SkillRuntimeEvidencePack,
+  SkillRuntimeEvidencePackNode,
+  SkillRuntimeEvidencePackRef,
+  SkillRuntimeEvidencePackSourceType,
+};
 
 const MAX_SKILL_DEFINITION_CHARS = 12000;
 

--- a/src/observability/trace-source.ts
+++ b/src/observability/trace-source.ts
@@ -4,6 +4,7 @@ import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { basename, dirname, join, relative } from 'node:path';
 import { extractMarkdownLogSkill } from './trace-attribution.js';
 import { isToolResultFailureText } from './text-signals.js';
+import type { TraceSourceMetadata } from '../types/index.js';
 
 // ---------- cc session JSONL raw schema (v0.18 subset) ----------
 
@@ -67,15 +68,7 @@ export interface CcUserRecord {
 
 export type CcRecord = CcAssistantRecord | CcUserRecord | { type: string; [k: string]: unknown };
 
-export interface TraceSourceMetadata {
-  channel?: string;
-  sender?: string;
-  senderId?: string;
-  provider?: string;
-  model?: string;
-  modelApi?: string;
-  businessActions?: string[];
-}
+export type { TraceSourceMetadata } from '../types/index.js';
 
 // ---------- Session-level structure ----------
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,3 +6,4 @@ export * from './report.js';
 export * from './storage.js';
 export * from './doctor.js';
 export * from './diagnosis.js';
+export * from './observability.js';

--- a/src/types/observability.ts
+++ b/src/types/observability.ts
@@ -1,0 +1,1065 @@
+/**
+ * Observability DTO 集中定义。
+ *
+ * 解开 `src/observability/` 内部 4 个文件(experience / inbox / skill-chain /
+ * experience-frontmatter)之间的 type-only 循环依赖：types/ 是叶子层，不依赖
+ * 任何业务模块；observability/ 的运行时文件向这里 import 类型即可。
+ *
+ * 设计原则：
+ *   - 只放纯 DTO(string union / interface / 类型别名)，不放任何运行时函数 / 常量
+ *   - 不依赖 src 内的业务模块(observability / cli / server / renderer / diagnosis)
+ *   - 跨层共享类型集中在 types/，单一来源
+ */
+
+import type { DiagnosisBundle } from './diagnosis.js';
+import type { SkillHardRule, SkillWorkflow } from '../shared/hard-rules.js';
+
+// ---------- trace-source ----------
+
+export interface TraceSourceMetadata {
+  channel?: string;
+  sender?: string;
+  senderId?: string;
+  provider?: string;
+  model?: string;
+  modelApi?: string;
+  businessActions?: string[];
+}
+
+// ---------- review-state ----------
+
+export type ObservationReviewTargetType =
+  | 'experience_session'
+  | 'inbox_item'
+  | 'skill'
+  | 'goal_slice_correction'
+  | 'evidence_metric'
+  | 'reviewer_judgment'
+  | 'soft_standard'
+  | 'goal_keyword_correction'
+  | 'result_artifact_correction'
+  | 'completion_result_correction'
+  | 'deliverable_artifact_correction'
+  | 'skill_relevance_correction'
+  | 'workflow_completion_correction'
+  | 'hardrule_execution_correction'
+  | 'main_tool_execution_correction';
+export type ObservationReviewVerdict = 'reviewed' | 'real_issue' | 'not_issue' | 'needs_more_context' | 'confirmed' | 'rejected';
+export type ObservationMetricKey =
+  | 'user_correction'
+  | 'user_interruption'
+  | 'user_follow_up'
+  | 'negative_feedback'
+  | 'positive_feedback'
+  | 'hard_rule'
+  | 'user_goal_shift'
+  | 'result_artifact'
+  | 'completion_result'
+  | 'deliverable_artifact'
+  | 'progress_update'
+  | 'self_correction'
+  | 'repeated_execution';
+export type ObservationMetricScope = 'message' | 'skill_segment';
+
+export interface ObservationReviewStateEntry {
+  targetType: ObservationReviewTargetType;
+  targetId: string;
+  verdict: ObservationReviewVerdict;
+  reviewedAt: string;
+  note?: string;
+  reason?: string;
+  metricKey?: ObservationMetricKey;
+  metricScope?: ObservationMetricScope;
+  metricScopeId?: string;
+  sourceTrace?: string;
+  sessionId?: string;
+  messageIndex?: number;
+  messageUuid?: string;
+  toolUseId?: string;
+  snippet?: string;
+}
+
+export interface ObservationReviewState {
+  kind: 'observe-review-state';
+  schemaVersion: 1;
+  updatedAt: string;
+  entries: Record<string, ObservationReviewStateEntry>;
+}
+
+export interface ObservationReviewStateUpdate {
+  targetType: ObservationReviewTargetType;
+  targetId: string;
+  verdict: ObservationReviewVerdict;
+  note?: string;
+  reason?: string;
+  metricKey?: ObservationMetricKey;
+  metricScope?: ObservationMetricScope;
+  metricScopeId?: string;
+  sourceTrace?: string;
+  sessionId?: string;
+  messageIndex?: number;
+  messageUuid?: string;
+  toolUseId?: string;
+  snippet?: string;
+}
+
+// ---------- problem-patterns ----------
+
+export type ExperienceProblemBucket =
+  | 'output_format'
+  | 'content_accuracy'
+  | 'missing_context'
+  | 'rule_violation'
+  | 'workflow_mismatch'
+  | 'tool_runtime'
+  | 'goal_shift'
+  | 'unclear';
+
+export type ExperienceProblemSignal =
+  | 'user_correction'
+  | 'negative_feedback'
+  | 'user_interruption'
+  | 'hard_rule'
+  | 'user_goal_shift'
+  | 'tool_failure'
+  | 'workflow_mismatch'
+  | 'artifact_missing'
+  | 'observer_lifecycle_failed'
+  | 'orchestration_boundary_violation';
+
+export interface ExperienceProblemEvidenceRef {
+  id: string;
+  kind: string;
+  sourceTrace: string;
+  sessionId: string;
+  messageIndex?: number;
+  logicalMessageIndex?: number;
+  sourceLineIndex?: number;
+  messageUuid?: string;
+  toolUseId?: string;
+  timestamp?: string;
+  role?: 'user' | 'assistant' | 'tool' | 'other';
+  label?: string;
+  snippet?: string;
+}
+
+export interface ExperienceProblemPattern {
+  id: string;
+  bucket: ExperienceProblemBucket;
+  patternKey: string;
+  count: number;
+  sessionCount: number;
+  recentSessionIds: string[];
+  signalTypes: ExperienceProblemSignal[];
+  evidenceRefs: ExperienceProblemEvidenceRef[];
+  lastSeen?: string;
+}
+
+export interface ProblemTimelineEvent {
+  id: string;
+  kind: string;
+  sourceTrace: string;
+  sessionId: string;
+  messageIndex?: number;
+  logicalMessageIndex?: number;
+  sourceLineIndex?: number;
+  messageUuid?: string;
+  toolUseId?: string;
+  timestamp?: string;
+  role?: 'user' | 'assistant' | 'tool' | 'other';
+  label?: string;
+  snippet?: string;
+  fullText?: string;
+  toolName?: string;
+  isError?: boolean;
+}
+
+// ---------- skill-chain-advisories ----------
+
+export type SkillChainAdvisoryCode =
+  | 'hardrules_not_declared'
+  | 'workflows_not_declared'
+  | 'skill_md_not_found';
+
+export interface SkillChainAdvisory {
+  code: SkillChainAdvisoryCode;
+  message: string;
+  exampleYaml?: string;
+  commandTemplate?: string;
+  shortLabel: string;
+}
+
+// ---------- inbox ----------
+
+export type ObservationSignalType = 'failed_search' | 'repeated_failure' | 'hedging' | 'explicit_marker';
+export type ObservationSourceKind = 'claude' | 'openclaw' | 'markdown_log' | 'unknown';
+export type ObservationSeverityReasonCode =
+  | 'knowledge_gap_suspected'
+  | 'repeated_failure_suspected'
+  | 'explicit_gap_marker'
+  | 'exploratory_probe'
+  | 'skill_asset_unavailable'
+  | 'soft_hedging_signal'
+  | 'tool_or_runtime_noise';
+export type ObservationSignalSubtype =
+  | 'hard_miss'
+  | 'repeated_failure'
+  | 'exploratory_miss'
+  | 'tool_error'
+  | 'permission_error'
+  | 'bash_probe'
+  | 'not_found'
+  | 'transient_file_missing'
+  | 'skill_asset_read_failed'
+  | 'permission_denied'
+  | 'tool_limit'
+  | 'tool_failure'
+  | 'regex_only'
+  | 'llm_classified'
+  | 'marker';
+
+export interface ObservationEvidence {
+  tool?: string;
+  query?: string;
+  path?: string;
+  outputSnippet?: string;
+  assistantSnippet?: string;
+  markerToken?: string;
+  messageIndex?: number;
+  messageUuid?: string;
+  toolUseId?: string;
+  segmentTimestamp?: string;
+}
+
+export interface ObservationMessageRef {
+  role: 'user' | 'assistant' | 'other';
+  snippet: string;
+  messageIndex: number;
+  uuid?: string;
+  timestamp?: string;
+}
+
+export interface ObservationMessageWindow {
+  before: ObservationMessageRef[];
+  event: ObservationMessageRef[];
+  after: ObservationMessageRef[];
+  resolutionAfter: 'resolved' | 'unresolved' | 'unknown';
+}
+
+export interface ObservationInboxItem {
+  id: string;
+  skillName: string;
+  artifactVersion: string | 'unknown';
+  artifactHash?: string;
+  cwd?: string;
+  sessionId: string;
+  sourceTrace: string;
+  sourceKind: ObservationSourceKind;
+  signalType: ObservationSignalType;
+  signalSubtype: ObservationSignalSubtype;
+  confidence: number;
+  attributionConfidence: number;
+  severity: 'high' | 'medium' | 'low' | 'noise';
+  severityReasonCode?: ObservationSeverityReasonCode;
+  severityReason?: string;
+  evidence: ObservationEvidence;
+  messageWindow?: ObservationMessageWindow;
+  firstSeen: string;
+  lastSeen: string;
+  occurrences: number;
+  recentSessionIds: string[];
+  representativeEvidence: ObservationEvidence[];
+}
+
+export interface ObservationSessionTimeRange {
+  sessionId: string;
+  sessionGroupId?: string;
+  sourceTrace: string;
+  sourceKind: ObservationSourceKind;
+  traceRole?: 'standalone' | 'main' | 'subagent';
+  traceLabel?: string;
+  cwd?: string;
+  startTimestamp?: string;
+  endTimestamp?: string;
+  durationMs?: number;
+}
+
+export interface ObservationInboxReport {
+  kind: 'observe-inbox';
+  schemaVersion: 1;
+  meta: {
+    tracePath: string;
+    generatedAt: string;
+    sessionCount?: number;
+    sessionTimeRange?: {
+      from: string;
+      to: string;
+      durationMs?: number;
+    };
+    sessionTimeRanges?: ObservationSessionTimeRange[];
+    segmentCount: number;
+    itemCount: number;
+    skillInvocationCounts?: Record<string, number>;
+    skillSessionCounts?: Record<string, number>;
+    skillInvocationLastSeen?: Record<string, string>;
+    skillToolCallCounts?: Record<string, Record<string, number>>;
+  };
+  items: ObservationInboxItem[];
+  experience?: ObservationExperienceReport;
+  diagnostics?: DiagnosisBundle;
+}
+
+export interface ObservationSkillRollup {
+  skillName: string;
+  invocationCount: number;
+  sessionCount: number;
+  observationCount: number;
+  highCount: number;
+  mediumCount: number;
+  lowCount: number;
+  noiseCount: number;
+  latestSeen: string;
+}
+
+export interface BuildObservationInboxReportOptions {
+  reviewState?: ObservationReviewState;
+}
+
+// ---------- experience: string unions ----------
+
+export type ExperienceReviewPriority = 'review_first' | 'sample_review' | 'routine_sample';
+export type ExperienceGoalSliceReasonCode = 'skill_segment_boundary' | 'explicit_user_goal_shift' | 'default_session_slice';
+export type ExperienceEvidenceKind = 'user_message' | 'synthetic_user_event' | 'assistant_message' | 'tool_use' | 'tool_result' | 'skill_context' | 'runtime_context' | 'observation';
+export type ExperienceAssistiveInferenceCode =
+  | 'review_recommended'
+  | 'sample_recommended'
+  | 'positive_signal_observed'
+  | 'user_switched_topic_neutral'
+  | 'no_obvious_issue_from_rules'
+  | 'insufficient_human_context';
+export type ExperienceAssistiveInferenceConfidence = 'low' | 'medium' | 'high';
+export type ExperienceAssistiveInferenceCautionCode =
+  | 'no_llm_judge'
+  | 'rule_only'
+  | 'runtime_context_excluded'
+  | 'skill_context_excluded'
+  | 'no_human_user_message'
+  | 'limited_timeline_window';
+export type ExperienceReviewBasisCode =
+  | 'has_high_observation'
+  | 'has_medium_observation'
+  | 'user_correction'
+  | 'user_interruption'
+  | 'session_interrupted'
+  | 'negative_feedback'
+  | 'hard_rule_text_hit'
+  | 'tool_failure'
+  | 'hedging_signal'
+  | 'explicit_marker';
+export type ExperienceRuleFindingLevel = 'attention' | 'sample' | 'normal';
+export type ExperienceReviewerReportScope = 'single_skill_single_goal' | 'degraded_complex';
+export type ExperienceReviewerReportStepStatus = 'ok' | 'attention' | 'unknown' | 'degraded' | 'not_applicable';
+export type ExperienceReviewerReportFindingLevel = 'attention' | 'possible_false_positive' | 'note';
+export type ExperienceReviewerReportFindingSource = 'deterministic_rule' | 'llm_soft' | 'manual';
+export type ExperienceChecklistItemStatus = 'passed' | 'failed' | 'unknown' | 'not_declared' | 'not_applicable' | 'degraded';
+export type ExperienceChecklistContribution = 'blocking' | 'attention' | 'informational' | 'positive' | 'neutral';
+export type ExperienceParentReason =
+  | 'data_degraded'
+  | 'blocking_failed'
+  | 'attention_accumulated'
+  | 'unknown_dominant'
+  | 'all_passed'
+  | 'not_applicable';
+export type ExperienceSessionStoryNodeKind =
+  | 'user_goal'
+  | 'skill_invocation'
+  | 'subagent_branch'
+  | 'tool_execution'
+  | 'delivery'
+  | 'user_feedback'
+  | 'goal_shift';
+export type ExperienceSessionStoryAnswerKey = 'goal_satisfaction' | 'declared_behavior_fit' | 'user_feeling';
+export type ExperienceSessionStorySkillRole = 'router' | 'executor' | 'mixed' | 'unknown';
+export type ExperienceEpisodeBoundaryReason = 'goal_shift' | 'checkpoint_or_subagent' | 'downstream_closed' | 'session_end';
+export type ExperienceEpisodeRole = 'main_executor' | 'router' | 'delegator' | 'supporting' | 'observer';
+export type ExperienceFeedbackSignalType = 'correction' | 'follow_up' | 'frustration' | 'interruption' | 'positive' | 'unknown';
+export type ExperienceFeedbackAttributionRole = 'primary_fault' | 'downstream_related' | 'context_only';
+export type ExperienceFeedbackAttributionReason = 'object_match' | 'promise_match' | 'action_match' | 'orchestration_edge' | 'episode_context';
+export type ExperienceOutcomeClosure = 'closed' | 'unresolved' | 'abandoned' | 'unknown';
+export type ExperienceRuntimeSkillType = 'router' | 'delegation' | 'executor' | 'advisory' | 'workflow_owner' | 'unknown';
+export type ExperienceRuntimeSkillTypeSource = 'frontmatter' | 'trace' | 'unknown';
+export type ExperienceEpisodeArtifactKind = 'path' | 'url' | 'document' | 'code' | 'execution_window' | 'unknown';
+export type ExperienceOrchestrationEdgeStatus = 'started' | 'completed' | 'failed' | 'unknown';
+export type ExperienceOrchestrationEdgeKind = 'internal_skill' | 'external_child_session';
+export type ExperienceRuleFindingCode =
+  | 'high_observation_seen'
+  | 'medium_observation_seen'
+  | 'user_correction_seen'
+  | 'user_interruption_seen'
+  | 'session_interrupted_seen'
+  | 'negative_feedback_seen'
+  | 'positive_feedback_seen'
+  | 'user_goal_shift_seen'
+  | 'hard_rule_seen'
+  | 'tool_failure_seen'
+  | 'hedging_seen'
+  | 'explicit_marker_seen'
+  | 'runtime_context_excluded'
+  | 'skill_context_excluded'
+  | 'no_priority_signal';
+
+// ---------- experience: interfaces ----------
+
+export interface ExperienceEvidenceRef {
+  id: string;
+  kind: ExperienceEvidenceKind;
+  sourceTrace: string;
+  sessionId: string;
+  traceRole?: 'standalone' | 'main' | 'subagent';
+  traceLabel?: string;
+  messageIndex?: number;
+  logicalMessageIndex?: number;
+  sourceLineIndex?: number;
+  messageUuid?: string;
+  toolUseId?: string;
+  timestamp?: string;
+  role?: 'user' | 'assistant' | 'tool' | 'other';
+  label?: string;
+  snippet?: string;
+}
+
+export interface ExperienceTimelineEvent extends ExperienceEvidenceRef {
+  order: number;
+  toolName?: string;
+  isError?: boolean;
+  fullText?: string;
+}
+
+export interface ExperienceTimelineBranch {
+  id: string;
+  label: string;
+  sourceTrace: string;
+  traceRole: 'main' | 'subagent' | 'standalone';
+  attachTo?: {
+    sourceTrace: string;
+    messageIndex?: number;
+    toolUseId?: string;
+    label?: string;
+  };
+  events: ExperienceTimelineEvent[];
+}
+
+export interface ExperienceTimelineTree {
+  sessionId: string;
+  main: ExperienceTimelineEvent[];
+  branches: ExperienceTimelineBranch[];
+}
+
+export interface ExperienceEvidenceChain {
+  userMessageCount: number;
+  runtimeContextCount: number;
+  skillContextCount: number;
+  assistantMessageCount: number;
+  toolUseCount: number;
+  toolResultCount: number;
+  toolFailureResultCount: number;
+  observationCount: number;
+  firstUserMessage?: ExperienceEvidenceRef;
+  firstRuntimeContext?: ExperienceEvidenceRef;
+  firstSkillContext?: ExperienceEvidenceRef;
+  firstToolUse?: ExperienceEvidenceRef;
+  firstToolFailure?: ExperienceEvidenceRef;
+  lastAssistantMessage?: ExperienceEvidenceRef;
+}
+
+export interface ExperienceRuleFinding {
+  code: ExperienceRuleFindingCode;
+  level: ExperienceRuleFindingLevel;
+  count: number;
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceAssistiveInference {
+  mode: 'deterministic_rules_only';
+  code: ExperienceAssistiveInferenceCode;
+  confidence: ExperienceAssistiveInferenceConfidence;
+  basisRuleCodes: ExperienceRuleFindingCode[];
+  cautionCodes: ExperienceAssistiveInferenceCautionCode[];
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceReviewerReportStep {
+  order: number;
+  label: string;
+  status: ExperienceReviewerReportStepStatus;
+  text: string;
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceReviewerReportFinding {
+  id: string;
+  judgmentId: string;
+  source: ExperienceReviewerReportFindingSource;
+  level: ExperienceReviewerReportFindingLevel;
+  title: string;
+  body: string;
+  ruleSource: string;
+  ruleVersion: string;
+  evidenceRefs: ExperienceEvidenceRef[];
+  reviewStateRef: {
+    targetType: 'reviewer_judgment';
+    targetId: string;
+    verdict?: string;
+    reason?: string;
+    note?: string;
+    reviewedAt?: string;
+  };
+}
+
+export interface ExperienceSessionStoryNode {
+  id: string;
+  order: number;
+  kind: ExperienceSessionStoryNodeKind;
+  label: string;
+  status: ExperienceReviewerReportStepStatus;
+  text: string;
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceSessionStoryAnswer {
+  key: ExperienceSessionStoryAnswerKey;
+  label: string;
+  status: ExperienceReviewerReportStepStatus;
+  reason: ExperienceParentReason;
+  sourceItemKeys: string[];
+  text: string;
+  evidenceRefs: ExperienceEvidenceRef[];
+  checklistItems: ExperienceChecklistItem[];
+}
+
+export interface ExperienceChecklistItem {
+  key: string;
+  label: string;
+  status: ExperienceChecklistItemStatus;
+  contribution: ExperienceChecklistContribution;
+  reason: string;
+  evidenceRefs: ExperienceEvidenceRef[];
+  source: ExperienceReviewerReportFindingSource;
+  suggestionKey?: string;
+}
+
+export interface ExperienceSessionStoryGoalSlice {
+  id: string;
+  order: number;
+  skillNames: string[];
+  startTimestamp: string;
+  endTimestamp: string;
+  reasonCode: ExperienceGoalSliceReasonCode;
+  inferredUserGoal?: string;
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceSessionStorySubagentDispatch {
+  id: string;
+  order: number;
+  branchId: string;
+  label: string;
+  sourceTrace: string;
+  attachTo?: {
+    messageIndex?: number;
+    toolUseId?: string;
+    label?: string;
+  };
+  eventCount: number;
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceSessionStorySkillLink {
+  id: string;
+  order: number;
+  skillName: string;
+  role: ExperienceSessionStorySkillRole;
+  invocationIds: string[];
+  goalSliceIds: string[];
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceGoalEvidenceRef {
+  kind: 'user_message' | 'goal_slice' | 'llm_goal';
+  goalSliceId?: string;
+  evidenceRef?: ExperienceEvidenceRef;
+  label?: string;
+}
+
+export interface ExperienceMessageRange {
+  startMessageIndex: number;
+  endMessageIndex: number;
+  sourceTrace?: string;
+  sessionId?: string;
+}
+
+export interface ExperienceSkillSegment {
+  id: string;
+  order: number;
+  skillName: string;
+  skillType: ExperienceRuntimeSkillType;
+  skillTypeSource?: ExperienceRuntimeSkillTypeSource;
+  declaredSkillType?: ExperienceRuntimeSkillType;
+  traceInferredSkillType?: ExperienceRuntimeSkillType;
+  episodeRole: ExperienceEpisodeRole;
+  skillInvocationIds: string[];
+  startMessageIndex?: number;
+  endMessageIndex?: number;
+  messageRanges?: ExperienceMessageRange[];
+  startTimestamp: string;
+  endTimestamp: string;
+  typeSpecificChecklist: ExperienceChecklistItem[];
+  runtimeAssessment?: {
+    goalSatisfaction?: string;
+    declaredBehaviorFit?: string;
+    artifactGoalMatch?: string;
+    userFeeling?: string;
+  };
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceOrchestrationEdge {
+  id: string;
+  episodeId: string;
+  edgeKind: ExperienceOrchestrationEdgeKind;
+  parentSkillSegmentId?: string;
+  executorSkillSegmentId?: string;
+  childSessionId?: string;
+  runnerStartedRef?: ExperienceEvidenceRef;
+  runnerCompletedRef?: ExperienceEvidenceRef;
+  notificationRef?: ExperienceEvidenceRef;
+  status: ExperienceOrchestrationEdgeStatus;
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceFeedbackAttribution {
+  skillName?: string;
+  skillSegmentId?: string;
+  attributionRole: ExperienceFeedbackAttributionRole;
+  reasonCode: ExperienceFeedbackAttributionReason;
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceFeedbackSignal {
+  id: string;
+  order: number;
+  type: ExperienceFeedbackSignalType;
+  text: string;
+  targetObject?: string;
+  sourceWindow: 'session' | 'episode' | 'skill_invocation' | 'downstream_child';
+  evidenceRef: ExperienceEvidenceRef;
+  canonicalAttributions?: ExperienceFeedbackAttribution[];
+  attributions: ExperienceFeedbackAttribution[];
+}
+
+export interface ExperienceEpisodeArtifact {
+  kind: ExperienceEpisodeArtifactKind;
+  label: string;
+  pathOrUrl?: string;
+  artifactGoalMatch: 'passed' | 'failed' | 'unknown';
+  evidenceRef: ExperienceEvidenceRef;
+}
+
+export interface ExperienceEpisodeOutcome {
+  closure: ExperienceOutcomeClosure;
+  artifacts: ExperienceEpisodeArtifact[];
+  verdict: ExperienceReviewPriority;
+  acceptanceCriteria?: string;
+}
+
+export interface ExperienceEpisode {
+  id: string;
+  order: number;
+  sessionId: string;
+  primaryGoal?: string;
+  goalEvidenceRefs: ExperienceGoalEvidenceRef[];
+  startTimestamp: string;
+  endTimestamp: string;
+  startRef?: ExperienceEvidenceRef;
+  endRef?: ExperienceEvidenceRef;
+  boundaryReason: ExperienceEpisodeBoundaryReason;
+  skillSegments: ExperienceSkillSegment[];
+  orchestrationEdges: ExperienceOrchestrationEdge[];
+  feedbackSignals: ExperienceFeedbackSignal[];
+  outcome: ExperienceEpisodeOutcome;
+}
+
+export interface ExperienceSessionStoryGraphNode {
+  id: string;
+  label: string;
+  kind: ExperienceSessionStoryNodeKind;
+  status: ExperienceReviewerReportStepStatus;
+  role?: ExperienceSessionStorySkillRole;
+  detailNodeId?: string;
+}
+
+export interface ExperienceSessionStoryGraphEdge {
+  fromId: string;
+  toId: string;
+  label: string;
+}
+
+export interface ExperienceSessionStory {
+  schemaVersion: 1;
+  summary: string;
+  invocationCount: number;
+  goalSliceCount: number;
+  branchCount: number;
+  progressUpdateCount: number;
+  finalDeliverySignalCount: number;
+  mainlineNodeIds: string[];
+  goalSlices: ExperienceSessionStoryGoalSlice[];
+  subagentDispatches: ExperienceSessionStorySubagentDispatch[];
+  skillLinks: ExperienceSessionStorySkillLink[];
+  episodes?: ExperienceEpisode[];
+  graph: {
+    nodes: ExperienceSessionStoryGraphNode[];
+    edges: ExperienceSessionStoryGraphEdge[];
+  };
+  nodes: ExperienceSessionStoryNode[];
+  answers: ExperienceSessionStoryAnswer[];
+}
+
+export interface ExperienceReviewerReport {
+  schemaVersion: 1;
+  mode: 'deterministic_milestone_1' | 'deterministic_session_story';
+  generatedAt: string;
+  title: string;
+  summary: string;
+  scope: {
+    kind: ExperienceReviewerReportScope;
+    reasonCodes: string[];
+  };
+  chainSteps: ExperienceReviewerReportStep[];
+  findings: ExperienceReviewerReportFinding[];
+  oneLookMetrics: {
+    toolCallCount: number;
+    toolFailureCount: number;
+    userMessageCount: number;
+    userFollowUpCount: number;
+    assistantDeliverySignalCount: number;
+    deliverableArtifactSignalCount: number;
+    routerDownstreamCompleted: number;
+    routerDownstreamFailed: number;
+    assistantProgressUpdateCount: number;
+    selfCorrectionCount: number;
+    repeatedExecutionCount: number;
+    finalDeliverySignalCount: number;
+    traceEventCount: number;
+    tokenUsage: {
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens: number;
+      cacheCreationTokens: number;
+      attribution: 'skill_segment';
+    };
+  };
+  sessionStory: ExperienceSessionStory;
+  authorSuggestions: string[];
+  traceLinks: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceGoalSlice {
+  id: string;
+  skillName: string;
+  sessionId: string;
+  sourceTrace: string;
+  cwd?: string;
+  startTimestamp: string;
+  endTimestamp: string;
+  sliceReasonCode: ExperienceGoalSliceReasonCode;
+  sliceConfidence: 'low' | 'medium' | 'high';
+  inferredUserGoal?: string;
+  userMessageRefs: ExperienceEvidenceRef[];
+}
+
+export interface ExperienceReviewIndicators {
+  userMessageCount: number;
+  userFollowUpCount: number;
+  userCorrectionCount: number;
+  userInterruptionCount: number;
+  sessionInterruptedCount: number;
+  negativeFeedbackCount: number;
+  positiveFeedbackCount: number;
+  userGoalShiftCount: number;
+  hardRuleTextHitCount: number;
+  assistantDeliverySignalCount: number;
+  deliverableArtifactSignalCount: number;
+  routerDownstreamCompleted: number;
+  routerDownstreamFailed: number;
+  selfCorrectionCount: number;
+  repeatedExecutionCount: number;
+  toolCallCount: number;
+  toolFailureCount: number;
+  highObservationCount: number;
+  mediumObservationCount: number;
+  hedgingCount: number;
+  explicitMarkerCount: number;
+}
+
+export interface ExperienceInvocationMetrics {
+  durationMs: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  numTurns: number;
+  numToolCalls: number;
+  numToolFailures: number;
+}
+
+export interface ExperienceInvocation {
+  id: string;
+  skillName: string;
+  sessionId: string;
+  sessionGroupKey: string;
+  sourceTrace: string;
+  sourceKind: ObservationSourceKind;
+  entrypoint?: string;
+  sourceMetadata?: TraceSourceMetadata;
+  cwd?: string;
+  segmentIndex: number;
+  goalSliceId: string;
+  startTimestamp: string;
+  endTimestamp: string;
+  attribution: {
+    source: string;
+    confidence: number;
+    rawSkillRef?: string;
+    pluginName?: string;
+    commandName?: string;
+  };
+  metrics: ExperienceInvocationMetrics;
+  toolCounts: Record<string, number>;
+  indicators: ExperienceReviewIndicators;
+  evidenceChain: ExperienceEvidenceChain;
+  ruleFindings: ExperienceRuleFinding[];
+  assistiveInference: ExperienceAssistiveInference;
+  problemPatterns: ExperienceProblemPattern[];
+  relatedObservationIds: string[];
+  evidenceRefs: ExperienceEvidenceRef[];
+  timeline: ExperienceTimelineEvent[];
+}
+
+export interface ExperienceSessionSummary {
+  id: string;
+  skillName: string;
+  sessionId: string;
+  sourceTrace: string;
+  sourceKind: ObservationSourceKind;
+  entrypoint?: string;
+  sourceMetadata?: TraceSourceMetadata;
+  cwd?: string;
+  sourceSessionStartTimestamp?: string;
+  sourceSessionEndTimestamp?: string;
+  sourceSessionDurationMs?: number;
+  startTimestamp: string;
+  endTimestamp: string;
+  invocationIds: string[];
+  goalSliceIds: string[];
+  reviewPriority: ExperienceReviewPriority;
+  reviewPriorityScore: number;
+  reviewBasisCodes: ExperienceReviewBasisCode[];
+  indicators: ExperienceReviewIndicators;
+  evidenceChain: ExperienceEvidenceChain;
+  ruleFindings: ExperienceRuleFinding[];
+  assistiveInference: ExperienceAssistiveInference;
+  problemPatterns: ExperienceProblemPattern[];
+  relatedObservationIds: string[];
+  timelinePreview: ExperienceTimelineEvent[];
+  fullSessionTimeline: ExperienceTimelineEvent[];
+  timelineTree?: ExperienceTimelineTree;
+  timelineScope: {
+    mode: 'skill_segment_window';
+    segmentStartRecordIndex?: number;
+    segmentEndRecordIndex?: number;
+    previewStartRecordIndex?: number;
+    previewEndRecordIndex?: number;
+    sessionStartRecordIndex: number;
+    sessionEndRecordIndex: number;
+    previewEventCount: number;
+    fullSessionEventCount: number;
+    truncated: boolean;
+    omittedBeforeCount: number;
+    omittedAfterCount: number;
+  };
+  attributionSources: string[];
+  pluginNames: string[];
+  rawSkillRefs: string[];
+  commandNames: string[];
+  sessionStory?: ExperienceSessionStory;
+  reviewerReport?: ExperienceReviewerReport;
+}
+
+export interface ExperienceSkillSummary {
+  skillName: string;
+  invocationCount: number;
+  sessionCount: number;
+  sourceKinds: ObservationSourceKind[];
+  entrypoints: string[];
+  entrypointCounts: Record<string, number>;
+  sourceMetadataCounts: {
+    channels: Record<string, number>;
+    senders: Record<string, number>;
+    businessActions: Record<string, number>;
+    providers: Record<string, number>;
+    models: Record<string, number>;
+  };
+  attributionCounts: Record<string, number>;
+  pluginNames: string[];
+  rawSkillRefs: string[];
+  commandNames: string[];
+  toolCounts: Record<string, number>;
+  firstSeen: string;
+  lastSeen: string;
+  reviewFirstSessionCount: number;
+  sampleReviewSessionCount: number;
+  indicators: ExperienceReviewIndicators;
+  evidenceChain: ExperienceEvidenceChain;
+  ruleFindings: ExperienceRuleFinding[];
+  assistiveInference: ExperienceAssistiveInference;
+  problemPatterns: ExperienceProblemPattern[];
+  relatedObservationIds: string[];
+}
+
+export interface ObservationExperienceReport {
+  kind: 'observe-experience';
+  schemaVersion: 1;
+  scope: 'evidence-only';
+  generatedAt: string;
+  meta: {
+    sessionCount: number;
+    skillCount: number;
+    invocationCount: number;
+    goalSliceCount: number;
+    noteCodes: Array<'no_llm_judge' | 'no_auto_verdict' | 'default_goal_slice_is_allowed' | 'deterministic_assistive_inference'>;
+  };
+  goalSlices: ExperienceGoalSlice[];
+  invocations: ExperienceInvocation[];
+  sessions: ExperienceSessionSummary[];
+  skills: ExperienceSkillSummary[];
+}
+
+// ---------- skill-chain ----------
+
+export type ObservationRuntimeCheckStatus = 'passed' | 'attention' | 'manual_review';
+
+export interface ObservationRuntimeCheck {
+  kind: 'hardRule' | 'workflowNode';
+  id: string;
+  title: string;
+  expectation: string;
+  status: ObservationRuntimeCheckStatus;
+  reason: string;
+  evidenceCount: number;
+  evidenceSnippets: string[];
+}
+
+export type SkillRuntimeEvidencePackSourceType =
+  | 'tool_call'
+  | 'tool_result'
+  | 'assistant_message'
+  | 'user_feedback'
+  | 'artifact'
+  | 'runtime_context'
+  | 'skill_context'
+  | 'unknown';
+
+export interface SkillRuntimeEvidencePackRef extends Pick<ExperienceEvidenceRef,
+  'id' | 'kind' | 'sourceTrace' | 'sessionId' | 'messageUuid' | 'messageIndex' | 'logicalMessageIndex' | 'sourceLineIndex' | 'toolUseId' | 'timestamp' | 'role' | 'label' | 'snippet'
+> {
+  sourceType: SkillRuntimeEvidencePackSourceType;
+  toolName?: string;
+  isError?: boolean;
+}
+
+export interface SkillRuntimeEvidencePackNode {
+  nodeId: string;
+  kind: 'workflowNode' | 'hardRule';
+  title: string;
+  expectation: string;
+  deterministicStatus: ObservationRuntimeCheckStatus;
+  deterministicReason: string;
+  candidateEvidenceRefs: SkillRuntimeEvidencePackRef[];
+  candidateEvidenceSnippets: string[];
+}
+
+export interface SkillRuntimeEvidencePack {
+  schemaVersion: 1;
+  skillName: string;
+  generatedBy: 'deterministic_rule_pack';
+  definition: {
+    found: boolean;
+    path?: string;
+    truncated?: boolean;
+  };
+  declaredStandards: {
+    hardRules: Array<{ id: string; title: string; expectation: string; source: 'frontmatter' }>;
+    workflowNodes: Array<{ id: string; title: string; expectation: string; workflowId: string; source: 'frontmatter' | 'markdown_headings' }>;
+  };
+  runtimeEvidence: {
+    toolCalls: SkillRuntimeEvidencePackRef[];
+    assistantMessages: SkillRuntimeEvidencePackRef[];
+    userFeedback: SkillRuntimeEvidencePackRef[];
+    artifacts: SkillRuntimeEvidencePackRef[];
+  };
+  nodeEvidence: SkillRuntimeEvidencePackNode[];
+  evidenceQuality: {
+    pollutedSourceCount: number;
+    windowTooNarrow: boolean;
+    missingRuntimeEvidence: boolean;
+    notes: string[];
+  };
+}
+
+export interface ObservationSkillChain {
+  skillName: string;
+  definition: {
+    found: boolean;
+    path?: string;
+    content?: string;
+    truncated?: boolean;
+  };
+  healthCheck: {
+    source: 'doctor-static-rules';
+    hardRules: {
+      declared: boolean;
+      valid: boolean;
+      count: number;
+      rules: SkillHardRule[];
+      errors: string[];
+      advisoryCode?: SkillChainAdvisoryCode;
+    };
+    workflows: {
+      declared: boolean;
+      valid: boolean;
+      branchCount: number;
+      nodeCount: number;
+      workflows: SkillWorkflow[];
+      errors: string[];
+      source: 'frontmatter' | 'markdown_headings' | 'none';
+      advisoryCode?: SkillChainAdvisoryCode;
+    };
+  };
+  runtime: {
+    supported: true;
+    mode: 'deterministic-no-llm';
+    message: string;
+    summary: {
+      invocationCount: number;
+      toolCallCount: number;
+      toolFailureCount: number;
+      passedCount: number;
+      attentionCount: number;
+      manualReviewCount: number;
+    };
+    hardRules: ObservationRuntimeCheck[];
+    workflowNodes: ObservationRuntimeCheck[];
+    evidencePack?: SkillRuntimeEvidencePack;
+  };
+}


### PR DESCRIPTION
## 用户影响

无对外 API / Report schema 变化。observability/ 下多个文件的纯类型声明集中到 `src/types/observability.ts`，源文件改为 facade 模式（`import type` + `export type` re-export）。所有原 import 路径继续可用，外部消费者零感知。

## 动机

`observability/` 内部存在三处 type-only 互引：

- `experience.ts` ↔ `inbox.ts`（experience.ts 引 ObservationInboxItem，inbox.ts 引 ObservationExperienceReport）
- `experience.ts` ↔ `experience-frontmatter.ts`（共享 ExperienceRuntimeSkillType）
- `skill-chain.ts` → `experience.ts`（拉 Experience\* 一堆类型）

虽然 type-only 在 isolatedModules 下可擦除，但 IDE / 编译器图谱上仍是双向耦合，且未来若误将 type-only 改成 value 引用会瞬间变运行时循环。这次按 P2.6 (skill-index DTO 上移) 的同一模式把它们整体抽到 leaf 层 `types/`。

## 改动

新文件 `src/types/observability.ts`（约 1030 行）汇总：

- trace-source: `TraceSourceMetadata`
- review-state: 7 个类型（`ObservationReviewTargetType` 等）
- problem-patterns: 5 个类型
- skill-chain-advisories: 2 个类型
- inbox: 12 个类型（含 `ObservationInboxReport`，`diagnostics?: DiagnosisBundle` 字段保持不变）
- experience: ~60 个类型（含所有 `Experience*` 与 `ObservationExperienceReport`）
- skill-chain: 7 个类型（`ObservationSkillChain` 复用 `shared/hard-rules.ts` 的 `SkillHardRule` / `SkillWorkflow`，不重复定义）

源文件全部改为 facade：
`skill-chain.ts` / `skill-chain-advisories.ts` / `review-state.ts` / `problem-patterns.ts` / `inbox.ts` / `experience.ts` / `experience-frontmatter.ts` / `trace-source.ts`

保留在原位的：运行时函数、常量、内部 helper 类型（如 `ExperienceEpisodeRange`、`BuildExperienceInput`）、`aggregateExperienceChecklistItemStatus` 等纯逻辑工具。

## 测量学

- 红区文件零改动：`src/types/report.ts` / `src/eval-core/{bootstrap,statistics,comparability}.ts` / `src/grading/{judge,assertions,layered-scores}.ts`
- `judge-hash-frozen` / `llm-enhanced-review-prompt` 守门测试全绿
- `html-renderer.test.ts.snap` 字节一致
- 全量 1615 测试通过

**无 BREAKING-COMPARABILITY。**

## Roadmap 上下文

属于架构债 roadmap 的 P2.4，前序 P1.1-P1.3 / P2.6 已合入（#155 #157 #158 #159 #160）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)