### PR TITLE
revert(observability): 撤回 #155 cleanup

### DIFF
--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -27,6 +27,18 @@ import {
   hasUserGoalShiftSignal,
 } from './feedback-matchers.js';
 
+export {
+  findNegativeFeedbackMatches,
+  findPositiveFeedbackMatches,
+  findUserCorrectionMatches,
+  findUserGoalShiftMatches,
+  hasNegativeFeedbackSignal,
+  hasPositiveFeedbackSignal,
+  hasUserCorrectionSignal,
+  hasUserGoalShiftSignal,
+} from './feedback-matchers.js';
+export type { TextMatchRange } from './feedback-matchers.js';
+
 export type ExperienceReviewPriority = 'review_first' | 'sample_review' | 'routine_sample';
 export type ExperienceGoalSliceReasonCode = 'skill_segment_boundary' | 'explicit_user_goal_shift' | 'default_session_slice';
 export type ExperienceEvidenceKind = 'user_message' | 'synthetic_user_event' | 'assistant_message' | 'tool_use' | 'tool_result' | 'skill_context' | 'runtime_context' | 'observation';

--- a/src/observability/feedback-projection.ts
+++ b/src/observability/feedback-projection.ts
@@ -1,14 +1,17 @@
 /**
  * observability → renderer 的公开投影层(facade)。
  *
+ * renderer(视图层)以前直接 import `observability/experience.ts` 的内部符号
+ * (6 个 feedback matcher + 21 个 type),与 experience 内部强耦合。这层 facade
  * 把 renderer 需要的「feedback / experience 投影面」收敛为一个公开 surface:
- * renderer 只 import 这里,experience / feedback-matchers / frontmatter 等内部
- * module 如何重组对 renderer 透明。配合 `inbox-view-model.ts` 共同构成 observability
- * 对 renderer 的两个 facade 入口。
+ * renderer 只 import 这里,experience.ts 内部如何重组(后续阶段 3 拆分 feedback
+ * matchers / frontmatter IO)对 renderer 透明。
  *
- * 设计原则:
+ * 设计原则(阶段 1.5,roadmap):
  *   - 仅 re-export,不做语义合并 / 不引入新类型 / 不写运行时逻辑
  *   - 不改任何字节级输出(html-renderer snapshot 必须字节一致)
+ *   - 阶段 8 的 ViewModel 边界会进一步把这些符号封进 ViewModel,renderer 那时
+ *     连这层也不直接看到。本 facade 是中间过渡层,降低阶段 8 的改动面。
  *
  * 范围:仅 renderer 用到的子集。其它消费者(diagnosis / CLI observe ingest)
  * 继续直接 import experience.ts —— 它们不是「视图」,不在 facade 收敛范围内。

--- a/test/observability/inbox.test.ts
+++ b/test/observability/inbox.test.ts
@@ -17,21 +17,19 @@ import {
 } from '../../src/observability/inbox.js';
 import {
   aggregateExperienceChecklistItemStatus,
-  foldExperienceChecklistItems,
-  hasRecognizableUserGoalText,
-  isExperienceTraceInProgress,
-  type ExperienceChecklistItem,
-  type ExperienceSessionSummary,
-} from '../../src/observability/experience.js';
-import {
   findNegativeFeedbackMatches,
   findPositiveFeedbackMatches,
   findUserCorrectionMatches,
   findUserGoalShiftMatches,
+  foldExperienceChecklistItems,
+  hasRecognizableUserGoalText,
   hasNegativeFeedbackSignal,
   hasPositiveFeedbackSignal,
   hasUserCorrectionSignal,
-} from '../../src/observability/feedback-matchers.js';
+  isExperienceTraceInProgress,
+  type ExperienceChecklistItem,
+  type ExperienceSessionSummary,
+} from '../../src/observability/experience.js';
 import {
   hasAssistantDeliverySignalText,
   hasUserHardRuleText,


### PR DESCRIPTION
## Summary

- 回滚已经合入 main 的 #155 squash commit（cf02783）。
- 恢复 experience.ts 的旧 matcher re-export、feedback-projection 的原注释，以及 inbox.test.ts 的旧 import 路径。

## Why

#157-#164 已经形成组合关系，应该由发起者先收敛成一个组合 PR 后再整体 CR。为避免 main 先落入其中一个局部 cleanup，先把 #155 撤回，让后续组合 PR 覆盖完整上下文。

## Test plan

- [x] yarn lint
- [x] yarn build
- [x] yarn test（1615 passed）

## Notes

第一次把 build 和 test 并行跑时，packaging mock-hook 检查抢在 build:assets 复制前启动，出现一次假失败；build 完成后单独重跑 yarn test 已通过。