### PR TITLE
chore(release): 发布 0.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- 版本 0.31.0 → 0.32.0
- 涵盖 P1-P3 架构 roadmap 合入(#166):types 层反向依赖收敛、import-boundary 守门、i18n-dict / inbox-test / observation-inbox helper 拆分、SemVer update-check 修复

## ⚠️ Release notes 必带项

publish.yml 跑完后,需要手工 hoist 到 GitHub Release notes 顶部:

> **TypeScript barrel 类型重命名**:`src/types/report.ts` 里报告分析用的 `Insight` 改名为 `AnalysisInsight`(为消除与新 SkillIndex `Insight` 的命名冲突)。JSON 输出字段 `{type, severity, details}` 完全不变,Report 序列化可比性保留;但 `src/types/index.ts` barrel 上的 `Insight` 已让位给新 SkillIndex `Insight`,programmatic TypeScript consumer 若直接 import 需改用 `AnalysisInsight`。

无 BREAKING-COMPARABILITY(JSON schema 字段语义零变更)。

## 验证

- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test`(132 files / 1624 tests)

## Test plan

- [ ] CI 通过(Node 22 / 24)
- [ ] merge 后在 main 上打 tag `v0.32.0` 并独立 push(`git push origin v0.32.0`,不能跟 `--tags` 合并 push,见 CONTRIBUTING.md 释义)
- [ ] publish.yml 跑完后到 https://github.com/lizhiyao/oh-my-knowledge/releases/tag/v0.32.0 hoist 上面的 release notes 必带项到顶部

🤖 Generated with [Claude Code](https://claude.com/claude-code)