### PR TITLE
fix(eval-core): 对齐 statistical-rigor bootstrap 默认值并加 doc-vs-code 漂移门禁

### DIFF
--- a/docs/explanation/statistical-rigor.md
+++ b/docs/explanation/statistical-rigor.md
@@ -15,11 +15,11 @@ This page is the depth reference. The README hero callout is the entry; come her
 
 The t-test breaks on ordinal LLM scores (Likert-like buckets, not normal-distributed continuous values). Bootstrap directly resamples the raw observations and stays valid at small N (< 30) and on skewed distributions.
 
-- **Mean CI** per variant — resampled with replacement N times (default 5000)
+- **Mean CI** per variant — resampled with replacement N times (default 1000)
 - **Pairwise diff CI** between two variants — diff of resampled means; if the CI does not cross 0, the difference is significant at the chosen α (default 0.05 → 95% CI)
 - **Output**: each `VariantResult.bootstrapCI` carries `[lo, hi]` for mean and pairwise; HTML report draws CI bands; CLI `omk eval` consumes them in the 6-tier verdict logic
 
-**Reference**: Efron & Tibshirani (1993), "An Introduction to the Bootstrap". omk implementation: `src/eval-core/bootstrap.ts`. Frozen by `judge-hash-frozen.test.ts` to prevent silent formula drift.
+**Reference**: Efron & Tibshirani (1993), "An Introduction to the Bootstrap". omk implementation: `src/eval-core/bootstrap.ts` — the formula is covered by `test/eval-core/bootstrap.test.ts`, and the documented defaults (resample count, α) are kept in sync with the code constants by `test/scripts/doc-constants-drift.test.ts`.
 
 ## 2. Human Gold + Krippendorff α(`--gold-dir`)
 

--- a/docs/zh/explanation/statistical-rigor.md
+++ b/docs/zh/explanation/statistical-rigor.md
@@ -15,11 +15,11 @@ omk 要回答的问题是 **"你给 LLM 的知识，价值在哪里？"** ——
 
 t 检验在 LLM 序数评分（Likert 类离散桶，不是正态分布的连续值）上失效。Bootstrap 直接重采样原始观测值，对小 N(< 30)和偏态分布都稳。
 
-- **每个 variant 的均值 CI** —— 有放回重采样 N 次（默认 5000）
+- **每个 variant 的均值 CI** —— 有放回重采样 N 次（默认 1000）
 - **两个 variant 之间的 pairwise diff CI** —— 重采样后的均值差；如果 CI 不跨 0，差异在选定 α（默认 0.05 → 95% CI）显著
 - **输出**：每个 `VariantResult.bootstrapCI` 含均值跟 pairwise 的 `[lo, hi]`；HTML 报告画 CI 带状区域；CLI `omk eval` 在六档 verdict 逻辑里消费这些 CI
 
-**参考**：Efron & Tibshirani (1993), "An Introduction to the Bootstrap"。omk 实现：`src/eval-core/bootstrap.ts`。由 `judge-hash-frozen.test.ts` 冻结防止公式悄悄漂移。
+**参考**：Efron & Tibshirani (1993), "An Introduction to the Bootstrap"。omk 实现：`src/eval-core/bootstrap.ts` —— 公式由 `test/eval-core/bootstrap.test.ts` 覆盖，文档里的默认值（重采样次数、α）由 `test/scripts/doc-constants-drift.test.ts` 与代码常量保持同步。
 
 ## 2. Human Gold + Krippendorff α(`--gold-dir`)
 

--- a/src/analysis/saturation.ts
+++ b/src/analysis/saturation.ts
@@ -28,9 +28,19 @@
  * that look like convergence but aren't.
  */
 
-import { bootstrapMeanCI } from '../eval-core/bootstrap.js';
+import { bootstrapMeanCI, DEFAULT_BOOTSTRAP_ALPHA, DEFAULT_BOOTSTRAP_SAMPLES } from '../eval-core/bootstrap.js';
 
 export type SaturationMethod = 'slope' | 'bootstrap-ci-width' | 'plateau-height';
+
+/** Default consecutive-window run length required before declaring saturation. */
+export const DEFAULT_SATURATION_WINDOW_SIZE = 3;
+
+/**
+ * Default `bootstrap-ci-width` cutoff: declare saturation when the relative
+ * CI-width shrink per checkpoint stays under 5%. Single source of truth for
+ * the documented threshold; guarded by `doc-constants-drift.test.ts`.
+ */
+export const DEFAULT_CI_WIDTH_SHRINK_THRESHOLD = 0.05;
 
 /**
  * One observation in a saturation curve. `n` is the cumulative sample
@@ -80,8 +90,8 @@ export function findSaturationPoint(
   cumulativeScores: number[][],
   method: SaturationMethod = 'bootstrap-ci-width',
   threshold?: number,
-  windowSize = 3,
-  bootstrapSamples = 1000,
+  windowSize = DEFAULT_SATURATION_WINDOW_SIZE,
+  bootstrapSamples = DEFAULT_BOOTSTRAP_SAMPLES,
   seed?: number,
 ): SaturationResult {
   const trace: SaturationResult['trace'] = [];
@@ -89,7 +99,7 @@ export function findSaturationPoint(
 
   for (const scores of cumulativeScores) {
     if (scores.length === 0) continue;
-    const ci = bootstrapMeanCI(scores, 0.05, bootstrapSamples, seed);
+    const ci = bootstrapMeanCI(scores, DEFAULT_BOOTSTRAP_ALPHA, bootstrapSamples, seed);
     checkpoints.push({
       n: scores.length,
       mean: ci.estimate,
@@ -196,7 +206,7 @@ export function findSaturationPoint(
 function defaultThreshold(method: SaturationMethod): number {
   switch (method) {
     case 'slope': return 0.005;
-    case 'bootstrap-ci-width': return 0.05;
+    case 'bootstrap-ci-width': return DEFAULT_CI_WIDTH_SHRINK_THRESHOLD;
     case 'plateau-height': return 0.1;
   }
 }

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -11,6 +11,7 @@ import type { EvalArgs, EvalFlags } from '../../lib/cmd-flags.js';
 import type { BatchEvaluationReport, EvaluationReport, Report, ProgressCallback } from '../../../types/index.js';
 import type { DryRunBatchReport, DryRunReport } from '../../../eval-workflows/run-evaluation.js';
 import type { EvalResult, ReportServer } from '../../lib/shared.js';
+import { DEFAULT_BOOTSTRAP_SAMPLES } from '../../../eval-core/bootstrap.js';
 
 // oclif 版 eval(默认 = run 模式) — 单次 typed parse 之后业务 inline。flag schema
 // 镜像 RUN_OPTIONS + eval-runner extra = 41 flag。具体语义跟约束在 parseRunConfig 里。
@@ -232,11 +233,11 @@ async function runEval(
   if (bootstrapEnabled) {
     config.bootstrap = true;
     const bsRaw = values['bootstrap-samples'] as string | undefined;
-    const parsedBs = bsRaw !== undefined ? Number(bsRaw) : (evalConfig?.bootstrapSamples ?? 1000);
+    const parsedBs = bsRaw !== undefined ? Number(bsRaw) : (evalConfig?.bootstrapSamples ?? DEFAULT_BOOTSTRAP_SAMPLES);
     if (bsRaw !== undefined && (!Number.isFinite(parsedBs) || parsedBs < 100)) {
       process.stderr.write(tCli('cli.run.invalid_bootstrap_samples', lang, { value: bsRaw }));
     }
-    const bsCount = Math.max(100, Math.floor(parsedBs) || 1000);
+    const bsCount = Math.max(100, Math.floor(parsedBs) || DEFAULT_BOOTSTRAP_SAMPLES);
     if (bsCount > 10000) {
       process.stderr.write(tCli('cli.run.bootstrap_samples_too_large', lang, { n: bsCount }));
     }

--- a/src/eval-core/bootstrap.ts
+++ b/src/eval-core/bootstrap.ts
@@ -37,6 +37,16 @@ export interface BootstrapDiffCI extends BootstrapCI {
   significant: boolean;
 }
 
+/**
+ * Default number of bootstrap resamples. Every eval path uses this unless
+ * `--bootstrap-samples` overrides it. Single source of truth: the docs cite
+ * it and `test/scripts/doc-constants-drift.test.ts` guards doc ↔ code parity.
+ */
+export const DEFAULT_BOOTSTRAP_SAMPLES = 1000;
+
+/** Default significance level; 0.05 → 95% CI. */
+export const DEFAULT_BOOTSTRAP_ALPHA = 0.05;
+
 /** Mulberry32 PRNG — seedable, deterministic for tests. */
 function mulberry32(seed: number): () => number {
   let s = seed >>> 0;
@@ -93,8 +103,8 @@ function sortedQuantile(sorted: number[], q: number): number {
  */
 export function bootstrapMeanCI(
   scores: number[],
-  alpha = 0.05,
-  samples = 1000,
+  alpha = DEFAULT_BOOTSTRAP_ALPHA,
+  samples = DEFAULT_BOOTSTRAP_SAMPLES,
   seed?: number,
 ): BootstrapCI {
   if (scores.length === 0) {
@@ -138,8 +148,8 @@ export function bootstrapMeanCI(
 export function bootstrapDiffCI(
   scoresA: number[],
   scoresB: number[],
-  alpha = 0.05,
-  samples = 1000,
+  alpha = DEFAULT_BOOTSTRAP_ALPHA,
+  samples = DEFAULT_BOOTSTRAP_SAMPLES,
   seed?: number,
 ): BootstrapDiffCI {
   if (scoresA.length === 0 || scoresB.length === 0) {
@@ -179,8 +189,8 @@ export function bootstrapDiffCI(
 export function bootstrapWithMetric(
   scores: number[],
   metricFn: (resampled: number[]) => number,
-  alpha = 0.05,
-  samples = 1000,
+  alpha = DEFAULT_BOOTSTRAP_ALPHA,
+  samples = DEFAULT_BOOTSTRAP_SAMPLES,
   seed?: number,
 ): BootstrapCI {
   if (scores.length === 0) return { low: 0, high: 0, estimate: 0, samples: 0 };

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -7,7 +7,12 @@ import { fileURLToPath } from 'node:url';
 import { buildVariantSummary } from './schema.js';
 import { buildVariantConfig, resolveExecutionStrategy } from './execution-strategy.js';
 import { getJudgePromptHash } from '../grading/judge.js';
-import { bootstrapMeanCI, bootstrapDiffCI } from './bootstrap.js';
+import {
+  bootstrapMeanCI,
+  bootstrapDiffCI,
+  DEFAULT_BOOTSTRAP_ALPHA,
+  DEFAULT_BOOTSTRAP_SAMPLES,
+} from './bootstrap.js';
 import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
 import type {
   Artifact,
@@ -182,7 +187,7 @@ export function aggregateReport({
   // Bootstrap CI (per-variant mean) when --bootstrap requested. Adds bootstrapCI to
   // each VariantSummary; legacy t-interval (in summary's other fields) is preserved.
   const bootstrapEnabled = request?.bootstrap === true;
-  const bootstrapSamples = request?.bootstrapSamples ?? 1000;
+  const bootstrapSamples = request?.bootstrapSamples ?? DEFAULT_BOOTSTRAP_SAMPLES;
   let pairComparisons: VariantPairComparison[] | undefined;
   if (bootstrapEnabled) {
     for (const variant of variants) {
@@ -191,7 +196,7 @@ export function aggregateReport({
         .filter((e) => typeof e.compositeScore === 'number' && e.compositeScore! > 0)
         .map((e) => e.compositeScore!);
       if (compositeScores.length >= 2) {
-        summary[variant].bootstrapCI = bootstrapMeanCI(compositeScores, 0.05, bootstrapSamples);
+        summary[variant].bootstrapCI = bootstrapMeanCI(compositeScores, DEFAULT_BOOTSTRAP_ALPHA, bootstrapSamples);
       }
     }
 
@@ -214,7 +219,7 @@ export function aggregateReport({
           pairComparisons.push({
             control: controlName,
             treatment: treatmentName,
-            diffBootstrapCI: bootstrapDiffCI(controlScores, treatmentScores, 0.05, bootstrapSamples),
+            diffBootstrapCI: bootstrapDiffCI(controlScores, treatmentScores, DEFAULT_BOOTSTRAP_ALPHA, bootstrapSamples),
           });
         }
       }

--- a/src/eval-core/verdict.ts
+++ b/src/eval-core/verdict.ts
@@ -30,6 +30,14 @@
 import type { Report, VariantPairComparison, VariantSummary } from '../types/index.js';
 import { evaluateLayerGates } from './layer-gates.js';
 
+/**
+ * Below this sample count a non-significant diff is read as UNDERPOWERED
+ * (only large effects are detectable) rather than NOISE. Matches the
+ * pre-flight power band documented in `docs/specs/sample-design-spec.md`;
+ * guarded by `test/scripts/doc-constants-drift.test.ts`.
+ */
+export const UNDERPOWERED_MIN_SAMPLES = 20;
+
 export type VerdictLevel =
   | 'PROGRESS'
   | 'CAUTIOUS'
@@ -196,7 +204,7 @@ function verdictForPair(
     // from "noise (saturation says: we're saturated, the effect just isn't there)".
     const satVerdict = report.variance?.saturation?.verdicts?.[treatment];
     const underpowered =
-      sampleCount < 20 ||
+      sampleCount < UNDERPOWERED_MIN_SAMPLES ||
       (satVerdict && !satVerdict.saturated && satVerdict.confidence !== 'high');
     if (underpowered) {
       return {

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -448,7 +448,11 @@ function buildComparisonMetric(scoresA: number[], scoresB: number[], meanA: numb
  * verdict is computed — the user still sees the curve, just without the auto
  * "saturated at N=X" claim.
  */
-function buildSaturationData(runs: Report[]): SaturationData | undefined {
+function buildSaturationData(
+  runs: Report[],
+  bootstrapSamples = DEFAULT_BOOTSTRAP_SAMPLES,
+  seed?: number,
+): SaturationData | undefined {
   if (runs.length < 2) return undefined;
   const variants = runs[0].meta.variants ?? [];
   if (variants.length === 0) return undefined;
@@ -479,7 +483,7 @@ function buildSaturationData(runs: Report[]): SaturationData | undefined {
       cumulativeByVariant[variant].push([...acc[variant]]);
 
       // Per-checkpoint trace: bootstrap CI on cumulative scores.
-      const ci = bootstrapMeanCI(acc[variant], DEFAULT_BOOTSTRAP_ALPHA, DEFAULT_BOOTSTRAP_SAMPLES);
+      const ci = bootstrapMeanCI(acc[variant], DEFAULT_BOOTSTRAP_ALPHA, bootstrapSamples, seed);
       if (!tracesByVariant[variant]) tracesByVariant[variant] = [];
       tracesByVariant[variant].push({
         n: acc[variant].length,
@@ -495,7 +499,7 @@ function buildSaturationData(runs: Report[]): SaturationData | undefined {
     for (const variant of variants) {
       const cumulative = cumulativeByVariant[variant];
       if (!cumulative) continue;
-      const r = findSaturationPoint(cumulative, 'bootstrap-ci-width');
+      const r = findSaturationPoint(cumulative, 'bootstrap-ci-width', undefined, undefined, bootstrapSamples, seed);
       verdicts[variant] = {
         saturated: r.saturated,
         atN: r.atN,
@@ -514,7 +518,11 @@ function buildSaturationData(runs: Report[]): SaturationData | undefined {
   };
 }
 
-export function buildVarianceData(runs: Report[]): VarianceData | null {
+export function buildVarianceData(
+  runs: Report[],
+  bootstrapSamples = DEFAULT_BOOTSTRAP_SAMPLES,
+  seed?: number,
+): VarianceData | null {
   if (runs.length <= 1) {
     return null;
   }
@@ -584,7 +592,7 @@ export function buildVarianceData(runs: Report[]): VarianceData | null {
     }
   }
 
-  const saturation = buildSaturationData(runs);
+  const saturation = buildSaturationData(runs, bootstrapSamples, seed);
   return {
     runs: runs.length,
     perVariant,
@@ -782,7 +790,7 @@ export async function runMultiple({ repeat = 1, onRepeatProgress, ...config }: R
   }
 
   const report = runs[runs.length - 1];
-  const aggregated = buildVarianceData(runs);
+  const aggregated = buildVarianceData(runs, config.bootstrapSamples ?? DEFAULT_BOOTSTRAP_SAMPLES);
   let filePath: string | null = null;
   if (aggregated) {
     report.variance = aggregated;

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -29,7 +29,7 @@ import type {
   VariantVariance,
 } from '../types/index.js';
 import { findSaturationPoint } from '../analysis/saturation.js';
-import { bootstrapMeanCI } from '../eval-core/bootstrap.js';
+import { bootstrapMeanCI, DEFAULT_BOOTSTRAP_ALPHA, DEFAULT_BOOTSTRAP_SAMPLES } from '../eval-core/bootstrap.js';
 
 export interface SkillProgressInfo {
   phase: string;
@@ -479,7 +479,7 @@ function buildSaturationData(runs: Report[]): SaturationData | undefined {
       cumulativeByVariant[variant].push([...acc[variant]]);
 
       // Per-checkpoint trace: bootstrap CI on cumulative scores.
-      const ci = bootstrapMeanCI(acc[variant], 0.05, 1000);
+      const ci = bootstrapMeanCI(acc[variant], DEFAULT_BOOTSTRAP_ALPHA, DEFAULT_BOOTSTRAP_SAMPLES);
       if (!tracesByVariant[variant]) tracesByVariant[variant] = [];
       tracesByVariant[variant].push({
         n: acc[variant].length,

--- a/test/saturation-integration.test.ts
+++ b/test/saturation-integration.test.ts
@@ -84,4 +84,19 @@ describe('buildSaturationData via buildVarianceData', () => {
     const data = buildVarianceData([buildRun('r1', { v1: [3, 4, 5] })]);
     assert.equal(data, null);
   });
+
+  it('threads a custom bootstrapSamples into the saturation bootstrap path', () => {
+    // Spread scores so the bootstrap CI is non-degenerate (ciLow != ciHigh),
+    // making the resample count observable in the trace bounds.
+    const runs = [buildRun('r1', { v1: [2, 3, 4, 5] }), buildRun('r2', { v1: [2, 3, 4, 5] })];
+    // Same seed, different resample counts → different Monte Carlo CI bounds.
+    // If bootstrapSamples didn't reach bootstrapMeanCI inside buildSaturationData,
+    // these would be identical — this is the regression guard for that wiring.
+    const few = buildVarianceData(runs, 31, 7);
+    const many = buildVarianceData(runs, 4001, 7);
+    assert.notDeepEqual(few?.saturation?.perVariant, many?.saturation?.perVariant);
+    // Same args → identical (determinism sanity, and proves seed is honored).
+    const again = buildVarianceData(runs, 31, 7);
+    assert.deepEqual(again?.saturation?.perVariant, few?.saturation?.perVariant);
+  });
 });

--- a/test/scripts/doc-constants-drift.test.ts
+++ b/test/scripts/doc-constants-drift.test.ts
@@ -1,0 +1,124 @@
+/**
+ * doc ↔ code 常量漂移 gate。
+ *
+ * statistical-rigor.md 曾经写 bootstrap「默认 5000」,而代码默认是 1000
+ * (`DEFAULT_BOOTSTRAP_SAMPLES`)。这页正是 omk 卖「auditable, not just claimed」
+ * 的招牌,把审计者预期从 1000 误导成 5000(实际拿到更宽的 CI)恰好砸自己招牌。
+ * 跟 `markdown-cmd-refs.test.ts`(命令/flag 漂移)同一类「文档跟不上代码」的债,
+ * 这里守住文档里明确陈述的统计默认值。
+ *
+ * 机制:每条 check 把一个代码常量绑到陈述它的那句文档措辞(正则带一个 capture)。
+ *   - capture 出来的数字跟代码常量不等 → 漂移,fail。
+ *   - 正则压根没命中 → 文档措辞被改了,也 fail(强制更新本 anchor 或修文档)。
+ * 不做宽泛全文数字扫描:`bootstrap 在小 N(< 30)仍有效` 的 30 是适用区间、
+ * 不是默认值,naive grep 会误判 — 所以每条都按语义点对点锚定。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DEFAULT_BOOTSTRAP_SAMPLES, DEFAULT_BOOTSTRAP_ALPHA } from '../../src/eval-core/bootstrap.js';
+import { DEFAULT_SATURATION_WINDOW_SIZE, DEFAULT_CI_WIDTH_SHRINK_THRESHOLD } from '../../src/analysis/saturation.js';
+import { UNDERPOWERED_MIN_SAMPLES } from '../../src/eval-core/verdict.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+
+interface Check {
+  /** 测试名 + 失败信息里用的标签。 */
+  label: string;
+  /** 相对仓库根的文档路径。 */
+  file: string;
+  /** 恰好一个 capture group = 文档里陈述的那个数字。 */
+  pattern: RegExp;
+  /** 代码侧真值常量。 */
+  expected: number;
+  /** capture 字符串 → 可比数值;默认 Number。百分号类需 /100。 */
+  toNumber?: (s: string) => number;
+}
+
+const CHECKS: Check[] = [
+  // bootstrap 默认重采样次数(en + zh)
+  {
+    label: 'bootstrap resamples (en)',
+    file: 'docs/explanation/statistical-rigor.md',
+    pattern: /resampled with replacement N times \(default (\d+)\)/,
+    expected: DEFAULT_BOOTSTRAP_SAMPLES,
+  },
+  {
+    label: 'bootstrap resamples (zh)',
+    file: 'docs/zh/explanation/statistical-rigor.md',
+    pattern: /有放回重采样 N 次（默认 (\d+)）/,
+    expected: DEFAULT_BOOTSTRAP_SAMPLES,
+  },
+  // bootstrap 默认显著性水平 α(en + zh)
+  {
+    label: 'bootstrap alpha (en)',
+    file: 'docs/explanation/statistical-rigor.md',
+    pattern: /\(default (0\.\d+) → 95% CI\)/,
+    expected: DEFAULT_BOOTSTRAP_ALPHA,
+  },
+  {
+    label: 'bootstrap alpha (zh)',
+    file: 'docs/zh/explanation/statistical-rigor.md',
+    pattern: /（默认 (0\.\d+) → 95% CI）/,
+    expected: DEFAULT_BOOTSTRAP_ALPHA,
+  },
+  // saturation 窗口大小(en + zh)
+  {
+    label: 'saturation window size (en)',
+    file: 'docs/explanation/statistical-rigor.md',
+    pattern: /Default window size: (\d+) consecutive measurements/,
+    expected: DEFAULT_SATURATION_WINDOW_SIZE,
+  },
+  {
+    label: 'saturation window size (zh)',
+    file: 'docs/zh/explanation/statistical-rigor.md',
+    pattern: /默认窗口大小：(\d+) 个连续测量/,
+    expected: DEFAULT_SATURATION_WINDOW_SIZE,
+  },
+  // saturation bootstrap-ci-width 收敛阈值:文档以百分号陈述,代码是小数(en + zh)
+  {
+    label: 'saturation ci-width threshold (en)',
+    file: 'docs/explanation/statistical-rigor.md',
+    pattern: /threshold: (\d+)% relative shrink/,
+    expected: DEFAULT_CI_WIDTH_SHRINK_THRESHOLD,
+    toNumber: (s) => Number(s) / 100,
+  },
+  {
+    label: 'saturation ci-width threshold (zh)',
+    file: 'docs/zh/explanation/statistical-rigor.md',
+    pattern: /相对衰减 (\d+)%/,
+    expected: DEFAULT_CI_WIDTH_SHRINK_THRESHOLD,
+    toNumber: (s) => Number(s) / 100,
+  },
+  // UNDERPOWERED 的 N 阈值:sample-design-spec 的 pre-flight power band 写死的 20
+  {
+    label: 'underpowered min N (sample-design-spec)',
+    file: 'docs/specs/sample-design-spec.md',
+    pattern: /`N < (\d+)`\(只大效应可测\)/,
+    expected: UNDERPOWERED_MIN_SAMPLES,
+  },
+];
+
+describe('doc ↔ code 常量漂移 gate', () => {
+  for (const c of CHECKS) {
+    it(`${c.label}:文档陈述的数值必须等于代码常量`, () => {
+      const text = readFileSync(join(PROJECT_ROOT, c.file), 'utf8');
+      const m = c.pattern.exec(text);
+      assert.ok(
+        m,
+        `锚点未命中:${c.file} 里 ${c.pattern} 没匹配到。文档措辞可能改了 —— ` +
+          `要么更新本测试的 pattern,要么修文档。`,
+      );
+      const got = (c.toNumber ?? Number)(m![1]!);
+      assert.equal(
+        got,
+        c.expected,
+        `doc-vs-code 漂移(${c.label}):${c.file} 写的是 "${m![1]}"(→ ${got}),` +
+          `代码常量是 ${c.expected}。改文档或改代码使二者一致。`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## 背景

`docs/explanation/statistical-rigor.md`（en/zh）把 bootstrap 重采样次数写成「默认 5000」，但 omk 全代码路径的实际默认是 **1000**（`--bootstrap-samples` 默认、saturation、综合分 reporting、run-evaluation 全一致）。这页正是 omk 卖「auditable, not just claimed」的招牌，把审计读者的预期从 1000 误导成 5000——读者会以为拿到的 CI 比实际更紧，恰好砸自己招牌。

同段还有一处错误归属：「bootstrap 公式由 `judge-hash-frozen.test.ts` 冻结」——judge-hash 冻结的是评委 prompt，bootstrap 公式实际由 `bootstrap.test.ts` 守。一并改对。

## 改了什么

- 文档对齐：bootstrap 默认值 `5000 → 1000`（en + zh），并修正公式守卫的错误指向。
- 把文档陈述的统计默认值收口为代码具名常量单一来源（bootstrap samples/α、saturation 窗口大小与 ci-width 收敛阈值、verdict 的 UNDERPOWERED 最小 N），消掉 eval 综合分 bootstrap 主链上散落的魔数。
- 新增 doc-vs-code 漂移 gate：把每个常量点对点绑到陈述它的那句文档措辞，值不一致、或文档措辞被改动导致锚点失配，都会 fail。跟 `markdown-cmd-refs` 的命令/flag gate 同属「文档跟不上代码」防线，从源头堵这一类回归。

## 用户影响

读文档的人拿到与代码一致的 bootstrap 默认值；以后任何人改了默认值或改了文档措辞而没同步另一边，CI 会拦下。

## 测量学

行为字节不变——1000 本就是真实默认，本 PR 只把字面量抽成同值具名常量并修文档，不改任何默认值、公式、report schema、judge/observe prompt hash。**不触测量学不变量，无 `BREAKING-COMPARABILITY`。**

承上：这是 omk v0.32 改进审计「测量学护城河深化」主题下的 do-now 项（文档与代码自洽）。