### PR TITLE
feat(eval-core): 评委 ensemble 强烈分歧时降级 verdict（BREAKING-COMPARABILITY）

### DIFF
--- a/docs/zh/specs/scoring.md
+++ b/docs/zh/specs/scoring.md
@@ -105,11 +105,13 @@ verdict 算法（精简版）：
   - 全部层 CI 不显著                            → NOISE
   - composite 显著 + 全层 gate PASS              → PROGRESS · SHIP
   - composite 显著但某层 gate FAIL              → CAUTIOUS · INVESTIGATE
+  - 本应 PROGRESS,但评委 ensemble 强烈分歧
+    (inter-judge Pearson < 0.4,对照或实验组任一)  → CAUTIOUS · 评委信号不可靠
 ```
 
 **意义**：composite 单分 +2.78 不能让 omk 给出 SHIP 判定，必须 **三层都 pass**。这削弱（不是消除）composite ad hoc 聚合的误导风险。
 
-「方法学审计」section 里的 4 个 badge（评委一致 / 差异显著 / 已饱和 / 人工对齐）就是把这套独立检验的结论可视化，让用户在 review 时能 spot 到「composite 看上去不错但某层有问题」的情况。
+「方法学审计」section 里的 4 个 badge（评委一致 / 差异显著 / 已饱和 / 人工对齐）就是把这套独立检验的结论可视化，让用户在 review 时能 spot 到「composite 看上去不错但某层有问题」的情况。其中「评委一致」（inter-judge Pearson）不只是可视化：多评委强烈分歧（Pearson < 0.4）会把本应 PROGRESS 的判定降级为 CAUTIOUS —— 评委自己都谈不拢时，驱动这次「变好」的评委层信号不可靠。
 
 ---
 

--- a/src/eval-core/verdict.ts
+++ b/src/eval-core/verdict.ts
@@ -6,9 +6,10 @@
  * v0.21 makes the data trustworthy.  closes the last mile: senior
  * engineers' #1 complaint is "the report has all the right numbers but I
  * still need 30 minutes to read it before I can decide". This module
- * aggregates the four data sources omk already produces — Bootstrap CI on
- * the pairwise diff, three-layer CI gate, saturation curve, and (when
- * available) Krippendorff α against gold — and emits one of four verdicts:
+ * aggregates the data sources omk already produces — Bootstrap CI on the
+ * pairwise diff, three-layer CI gate, saturation curve, inter-judge ensemble
+ * agreement, and (when available) Krippendorff α against gold — and emits one
+ * of six verdicts:
  *
  *  - **PROGRESS**     diff CI shows real positive shift, no layer regressed
  *  - **CAUTIOUS**     positive shift but at least one layer broke its gate,
@@ -37,6 +38,17 @@ import { evaluateLayerGates } from './layer-gates.js';
  * guarded by `test/scripts/doc-constants-drift.test.ts`.
  */
 export const UNDERPOWERED_MIN_SAMPLES = 20;
+
+/**
+ * Inter-judge Pearson bands, shared with the report's ensemble-agreement audit
+ * badge (`src/renderer/summary.ts`) so the verdict gate and the UI read one scale.
+ *  - `>= ENSEMBLE_STRONG_PEARSON` (0.7): judges agree on rank order (badge green).
+ *  - `< ENSEMBLE_DISSENT_PEARSON` (0.4): strong disagreement (badge red). A
+ *    would-be PROGRESS is downgraded to CAUTIOUS — the judge-layer signal driving
+ *    the win is unreliable when the ensemble can't agree.
+ */
+export const ENSEMBLE_STRONG_PEARSON = 0.7;
+export const ENSEMBLE_DISSENT_PEARSON = 0.4;
 
 export type VerdictLevel =
   | 'PROGRESS'
@@ -242,6 +254,20 @@ function verdictForPair(
     };
   }
 
+  // Ensemble dissent gate: a real, gate-passing gain is only PROGRESS if the
+  // judges that produced it actually agree. When inter-judge Pearson sits in the
+  // badge's red band (< ENSEMBLE_DISSENT_PEARSON) for either compared variant,
+  // the judge-layer signal behind the win is unreliable → downgrade to CAUTIOUS.
+  const dissent = ensembleDissent(pair, summary);
+  if (dissent) {
+    return {
+      control,
+      treatment,
+      level: 'CAUTIOUS',
+      headline: `${headlineCore} · gain real, but judges disagree on ${dissent.variant} (Pearson ${dissent.pearson} < ${ENSEMBLE_DISSENT_PEARSON})`,
+    };
+  }
+
   // Did control break a gate? Then treatment winning isn't surprising — flag.
   if (!cGate.allPass) {
     return {
@@ -253,6 +279,28 @@ function verdictForPair(
   }
 
   return { control, treatment, level: 'PROGRESS', headline: `${headlineCore} · clean win` };
+}
+
+/**
+ * Strong inter-judge disagreement on the compared pair, if any. Reuses the
+ * persisted per-variant ensemble Pearson (`summary[v].judgeAgreement.pearson`).
+ * Returns the worst offender below the dissent threshold, or null when every
+ * variant agrees / has no ensemble signal (single- or constant-score judge ⇒
+ * pearson undefined, nothing to act on — its disagreement, if any, still shows
+ * in the report's MAD column).
+ */
+function ensembleDissent(
+  pair: { control: string; treatment: string },
+  summary: Record<string, VariantSummary>,
+): { variant: string; pearson: number } | null {
+  let worst: { variant: string; pearson: number } | null = null;
+  for (const variant of [pair.treatment, pair.control]) {
+    const pearson = summary[variant]?.judgeAgreement?.pearson;
+    if (pearson != null && pearson < ENSEMBLE_DISSENT_PEARSON) {
+      if (!worst || pearson < worst.pearson) worst = { variant, pearson };
+    }
+  }
+  return worst;
 }
 
 function avgComposite(s: VariantSummary | undefined): number {

--- a/src/renderer/summary.ts
+++ b/src/renderer/summary.ts
@@ -805,11 +805,19 @@ function badgeIcon(status: AuditBadgeStatus): string {
 }
 
 function computeJudgeAgreementBadge(variants: string[], summary: Record<string, VariantSummary>, lang: Lang): AuditBadge | null {
-  const treatment = variants[1] ?? variants[0];
-  const ag = summary[treatment]?.judgeAgreement;
-  if (!ag || ag.pearson == null) return null;
-  const p = ag.pearson;
-  const status: AuditBadgeStatus = p >= 0.7 ? 'pass' : p >= 0.4 ? 'warn' : 'fail';
+  // Match the verdict's ensemble-dissent perspective: consider every compared
+  // variant (control + treatments), not just the treatment, and surface the worst
+  // agreement. Otherwise the hero verdict can downgrade to CAUTIOUS on a low control
+  // Pearson while this badge stays green on a high treatment Pearson — contradictory
+  // methodology signals in the same report. Thresholds come from the shared bands.
+  let p: number | null = null;
+  for (const v of variants) {
+    const pearson = summary[v]?.judgeAgreement?.pearson;
+    if (pearson == null) continue;
+    if (p == null || pearson < p) p = pearson;
+  }
+  if (p == null) return null;
+  const status: AuditBadgeStatus = p >= ENSEMBLE_STRONG_PEARSON ? 'pass' : p >= ENSEMBLE_DISSENT_PEARSON ? 'warn' : 'fail';
   const verdict = status === 'pass'
     ? (lang === 'zh' ? '评委一致' : 'judges agree')
     : status === 'warn'
@@ -819,7 +827,9 @@ function computeJudgeAgreementBadge(variants: string[], summary: Record<string, 
     key: 'judge',
     label: verdict,
     status,
-    detail: lang === 'zh' ? `Pearson ${p}（≥0.7 一致 / 0.4-0.7 偏弱 / <0.4 分歧）` : `Pearson ${p} (≥0.7 agree / 0.4-0.7 weak / <0.4 diverge)`,
+    detail: lang === 'zh'
+      ? `Pearson ${p}（≥${ENSEMBLE_STRONG_PEARSON} 一致 / ${ENSEMBLE_DISSENT_PEARSON}-${ENSEMBLE_STRONG_PEARSON} 偏弱 / <${ENSEMBLE_DISSENT_PEARSON} 分歧）`
+      : `Pearson ${p} (≥${ENSEMBLE_STRONG_PEARSON} agree / ${ENSEMBLE_DISSENT_PEARSON}-${ENSEMBLE_STRONG_PEARSON} weak / <${ENSEMBLE_DISSENT_PEARSON} diverge)`,
   };
 }
 

--- a/src/renderer/summary.ts
+++ b/src/renderer/summary.ts
@@ -1,7 +1,7 @@
 import { e, fmtNum, fmtCost, fmtDuration, COLORS, t } from './layout.js';
 import { generateAnalysisSummary } from '../analysis/report-diagnostics.js';
 import { pValueCategory } from '../eval-core/statistics.js';
-import { computeVerdict, type VerdictLevel, type VerdictResult } from '../eval-core/verdict.js';
+import { computeVerdict, ENSEMBLE_STRONG_PEARSON, ENSEMBLE_DISSENT_PEARSON, type VerdictLevel, type VerdictResult } from '../eval-core/verdict.js';
 import type { GapReport, GapSignalRef, AnalysisInsight, KnowledgeCoverage, Lang, Report, ReportHumanAgreement, SaturationData, VarianceComparison, VarianceComparisonMetric, VarianceData, VarianceLayerKey, VariantPairComparison, VariantSummary } from '../types/index.js';
 
 /**
@@ -747,7 +747,7 @@ export function renderJudgeAgreementBlock(variants: string[], summary: Record<st
     const ag = s.judgeAgreement!;
     const judgeList = (s.judgeModels || []).map((j) => `<code>${e(`${j.executor}:${j.model}`)}</code>`).join(', ');
     const pearsonCell = ag.pearson != null
-      ? `<span title="${t('pearsonDesc', lang)}" style="color:${ag.pearson >= 0.7 ? 'var(--green)' : ag.pearson >= 0.4 ? 'var(--yellow)' : 'var(--red)'}"><strong>${ag.pearson}</strong></span>`
+      ? `<span title="${t('pearsonDesc', lang)}" style="color:${ag.pearson >= ENSEMBLE_STRONG_PEARSON ? 'var(--green)' : ag.pearson >= ENSEMBLE_DISSENT_PEARSON ? 'var(--yellow)' : 'var(--red)'}"><strong>${ag.pearson}</strong></span>`
       : `<span style="color:var(--text-muted)">—</span>`;
     const madCell = `<span title="${t('madDesc', lang)}" style="color:${ag.meanAbsDiff < 0.5 ? 'var(--green)' : ag.meanAbsDiff < 1.5 ? 'var(--yellow)' : 'var(--red)'}"><strong>${ag.meanAbsDiff}</strong></span>`;
     return `<tr>

--- a/test/eval-core/verdict.test.ts
+++ b/test/eval-core/verdict.test.ts
@@ -47,6 +47,70 @@ describe('computeVerdict', () => {
     assert.match(v.headline, /clean win/);
   });
 
+  // --- inter-judge dissent gate -------------------------------------------
+  // A clean, gate-passing positive diff. Tests below vary only the ensemble
+  // agreement on top of this to isolate the dissent gate.
+  const cleanProgress = (): Report => buildReport({
+    variants: ['baseline', 'skill'],
+    perVariantAvg: {
+      baseline: { fact: 4, behavior: 4, judge: 4, composite: 4 },
+      skill:    { fact: 4.3, behavior: 4.2, judge: 4.5, composite: 4.33 },
+    },
+    pairs: [{
+      control: 'baseline', treatment: 'skill',
+      diffBootstrapCI: { low: 0.2, high: 0.5, estimate: 0.33, samples: 1000, significant: true },
+    }],
+  });
+  const withAgreement = (r: Report, variant: string, agreement: VariantSummary['judgeAgreement']): Report => {
+    const s = r.summary[variant];
+    assert.ok(s, `variant ${variant} missing from summary`);
+    s.judgeAgreement = agreement;
+    return r;
+  };
+
+  it('PROGRESS downgrades to CAUTIOUS when treatment judges strongly disagree (Pearson < 0.4)', () => {
+    const r = withAgreement(cleanProgress(), 'skill', { pearson: 0.3, meanAbsDiff: 1.2, pairCount: 1, sampleCount: 30 });
+    const v = computeVerdict(r);
+    assert.equal(v.level, 'CAUTIOUS');
+    assert.match(v.headline, /judges disagree on skill/);
+  });
+
+  it('PROGRESS stays PROGRESS when the ensemble agrees (high Pearson)', () => {
+    const r = withAgreement(cleanProgress(), 'skill', { pearson: 0.85, meanAbsDiff: 0.3, pairCount: 1, sampleCount: 30 });
+    const v = computeVerdict(r);
+    assert.equal(v.level, 'PROGRESS');
+  });
+
+  it('no dissent downgrade when Pearson is undefined (single / constant-score judge)', () => {
+    const r = withAgreement(cleanProgress(), 'skill', { meanAbsDiff: 2.0, pairCount: 1, sampleCount: 30 });
+    const v = computeVerdict(r);
+    assert.equal(v.level, 'PROGRESS');
+  });
+
+  it('dissent on the control variant also downgrades PROGRESS to CAUTIOUS', () => {
+    const r = withAgreement(cleanProgress(), 'baseline', { pearson: 0.2, meanAbsDiff: 1.8, pairCount: 1, sampleCount: 30 });
+    const v = computeVerdict(r);
+    assert.equal(v.level, 'CAUTIOUS');
+    assert.match(v.headline, /judges disagree on baseline/);
+  });
+
+  it('dissent gate only touches PROGRESS — a REGRESS with low Pearson stays REGRESS', () => {
+    const r = buildReport({
+      variants: ['baseline', 'skill'],
+      perVariantAvg: {
+        baseline: { fact: 4, behavior: 4, judge: 4, composite: 4 },
+        skill:    { fact: 3.5, behavior: 3.5, judge: 3.5, composite: 3.5 },
+      },
+      pairs: [{
+        control: 'baseline', treatment: 'skill',
+        diffBootstrapCI: { low: -0.7, high: -0.2, estimate: -0.5, samples: 1000, significant: true },
+      }],
+    });
+    withAgreement(r, 'skill', { pearson: 0.1, meanAbsDiff: 2.5, pairCount: 1, sampleCount: 30 });
+    const v = computeVerdict(r);
+    assert.equal(v.level, 'REGRESS');
+  });
+
   it('REGRESS when diff CI is significantly negative', () => {
     const r = buildReport({
       variants: ['baseline', 'skill'],

--- a/test/renderer/methodology-audit-badge.test.ts
+++ b/test/renderer/methodology-audit-badge.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { renderMethodologyAudit } from '../../src/renderer/summary.js';
+import type { Report, VariantSummary } from '../../src/types/index.js';
+
+// The "评委一致" methodology-audit badge must read the same pair perspective as the
+// verdict's ensemble-dissent gate (worst Pearson across control + treatment). Otherwise
+// the hero verdict can downgrade to CAUTIOUS on a low control Pearson while this badge
+// stays green on a high treatment Pearson — contradictory signals in one report.
+const agreement = (pearson: number): VariantSummary['judgeAgreement'] =>
+  ({ pearson, meanAbsDiff: 1, pairCount: 1, sampleCount: 30 });
+
+const reportWith = (baseline: number, skill: number): { report: Report; summary: Record<string, VariantSummary> } => ({
+  report: { meta: { variants: ['baseline', 'skill'] } } as unknown as Report,
+  summary: {
+    baseline: { judgeAgreement: agreement(baseline) },
+    skill: { judgeAgreement: agreement(skill) },
+  } as unknown as Record<string, VariantSummary>,
+});
+
+describe('methodology audit — judge-agreement badge pair perspective', () => {
+  it('reflects the worst variant: low control Pearson → 评委分歧大 even when treatment agrees', () => {
+    const { report, summary } = reportWith(0.2, 0.85);
+    const html = renderMethodologyAudit(report, ['baseline', 'skill'], summary, 'zh');
+    // Worst (control 0.2) is in the red band → badge must read "评委分歧大", matching the
+    // verdict's "judges disagree on baseline" downgrade. Pre-fix it read "评委一致".
+    assert.match(html, /评委分歧大/);
+  });
+
+  it('stays green only when every compared variant agrees', () => {
+    const { report, summary } = reportWith(0.82, 0.85);
+    const html = renderMethodologyAudit(report, ['baseline', 'skill'], summary, 'zh');
+    assert.doesNotMatch(html, /评委分歧大/);
+  });
+});


### PR DESCRIPTION
> **Stacked on #171**（base = `docs/statistical-rigor-const-drift`）。#171 合并后 GitHub 会自动把本 PR retarget 到 `main`；建议先合 #171 再合本 PR。

## 背景

多评委一致性（inter-judge Pearson / MAD）一路算到报告「方法学审计」的**评委一致 badge**，但 `computeVerdict` 从不读它——只读 gold 的 `humanAgreement`。后果：composite 显著、三层 gate 全过、但两个评委对排序强烈分歧的场景照样判 `PROGRESS · SHIP`，而驱动这次「变好」的评委层信号此时并不可靠。这是 omk 差异化护城河里「信号已算好却没接进决策出口」的一处——single-judge 工具根本拿不出这个信号。

## 改了什么

把已持久化的 per-variant `summary[v].judgeAgreement.pearson` 接进 verdict：本应 `PROGRESS` 的判定，若对照或实验组任一的 inter-judge Pearson 落在 audit badge 的红带（**< 0.4**）就降级为 `CAUTIOUS`，headline 点名分歧变体与其 Pearson。

- 复用 badge 已落地的 0.4 / 0.7 刻度，抽成 `ENSEMBLE_DISSENT_PEARSON` / `ENSEMBLE_STRONG_PEARSON` 单一来源，`summary.ts` 的 badge 一并引用，**不引第三套刻度**。
- `pearson` 为 undefined（单评委 / 常量评分评委，无方差）时**不触发**，避免把 MAD 第二套刻度拖进 verdict；其分歧仍在报告 MAD 列可见。
- **只降级 PROGRESS**；REGRESS / NOISE / UNDERPOWERED 不受影响。

## 用户影响 / 迁移

跑多评委（`--judge-models a,b`）时，过去会得到 `PROGRESS` 的报告，如果评委彼此强烈分歧，现在会得到 `CAUTIOUS` 并提示评委信号不可靠——这是更诚实的 ship/no-ship 结论，提示你先看评委为什么谈不拢。单评委（默认）行为完全不变。

## 测量学

verdict 不持久化进 `report.json`（渲染 / CLI 时由 `computeVerdict` 实时算），故**无 Report schema 字段变更**。但同一份历史报告在新版本下 `PROGRESS` 可能变 `CAUTIOUS`，跨版本 verdict 语义改变——按测量学不变量规则标 **`BREAKING-COMPARABILITY`**。

construct-validity 取舍：降级阈值取 badge 红带（Pearson < 0.4 = 强烈分歧），而非黄带（< 0.7），避免对「中等一致」过度触发；降到 `CAUTIOUS` 而非 `NOISE`，因为 composite 增益是真的、只是评委层这一个输入不可靠。

承上：这是 omk v0.32 改进审计「测量学护城河深化」的 top-priority 项（把已算好但没进决策的信号兑现到 verdict）。