### PR TITLE
feat(authoring): evolve 加 holdout 切分，accept 看验收集分防 train-on-test

### DIFF
--- a/.claude/skills/omk/references/commands.md
+++ b/.claude/skills/omk/references/commands.md
@@ -211,6 +211,7 @@ omk evolve <skillPath> [flags]
 - `--concurrency` `option` (默认 `1`):评测并发数，默认 1
 - `--effort` `option`:reasoning effort: low/medium/high/xhigh/max
 - `--executor` `option` (默认 `claude`):执行器名，默认 claude
+- `--holdout-ratio` `option` (默认 `0`):留出验收集比例（0..1，默认 0=关）。> 0 时按 holdout 分接受候选、weak-sample 只取训练集，防 train-on-test
 - `--improve-mode` `agent|rewrite` (默认 `agent`):改写策略（默认：agent）
 - `--improve-model` `option` (默认 `sonnet`):负责重写 skill 的 LLM，默认 sonnet
 - `--judge-models` `option` (默认 `claude:haiku`):评委 model（单评委约束），格式 executor:model。默认 claude:haiku

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -212,6 +212,7 @@ omk evolve skills/foo.md --rounds 10 --target 4.5
   --concurrency <value>           Eval concurrency, default 1
   --effort <value>                Reasoning effort: low/medium/high/xhigh/max
   --executor <value>              Executor name, default claude
+  --holdout-ratio <value>         Holdout fraction for the accept decision (0..1, default 0=off). When > 0, candidates are accepted on holdout score and weak samples come only from train — guards against train-on-test
   --improve-mode <agent|rewrite>  Improvement strategy (default: agent)
   --improve-model <value>         LLM that rewrites the skill, default sonnet
   --judge-models <value>          Judge model (single judge required), executor:model format. Default claude:haiku

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -212,6 +212,7 @@ omk evolve skills/foo.md --rounds 10 --target 4.5
   --concurrency <value>           评测并发数，默认 1
   --effort <value>                reasoning effort: low/medium/high/xhigh/max
   --executor <value>              执行器名，默认 claude
+  --holdout-ratio <value>         留出验收集比例（0..1，默认 0=关）。> 0 时按 holdout 分接受候选、weak-sample 只取训练集，防 train-on-test
   --improve-mode <agent|rewrite>  改写策略（默认：agent）
   --improve-model <value>         负责重写 skill 的 LLM，默认 sonnet
   --judge-models <value>          评委 model（单评委约束），格式 executor:model。默认 claude:haiku

--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -232,6 +232,17 @@ function subsetCompositeScore(report: Report, variantKey: string, ids: Set<strin
   return buildVariantSummary(entries).avgCompositeScore ?? 0;
 }
 
+/**
+ * A view of `report` whose results are restricted to `sampleIds`. Used to keep the
+ * holdout split out of the sample-fixer: under an active holdout, only training-split
+ * samples may enter the --auto-fix-samples prompt or be rewritten — otherwise the
+ * skill's samples get tuned to the very samples that decide acceptance, reintroducing
+ * the leak holdout exists to prevent.
+ */
+export function restrictReportToSamples(report: Report, sampleIds: Set<string>): Report {
+  return { ...report, results: report.results.filter((r) => sampleIds.has(r.sample_id)) };
+}
+
 export function allNonTripwireAssertionsPass(report: Report, variantKey: string): boolean {
   for (const entry of report.results) {
     const variant = entry.variants[variantKey];
@@ -827,7 +838,9 @@ export async function evolveSkill({
       const sampleFix = await autoFixSamplesAfterSkillRound({
         samplesPath: absSamplesPath,
         skillContent: candidateContent,
-        report: lastReport,
+        // Under an active holdout, the sample-fixer may only see training-split samples —
+        // never the holdout samples that drive the accept decision (leak guard).
+        report: holdoutSplit ? restrictReportToSamples(lastReport, holdoutSplit.trainIds) : lastReport,
         treatmentKey: lastVariantKey,
         executorName,
         model: improveModel,

--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -6,6 +6,7 @@ import { persistReport, DEFAULT_OUTPUT_DIR, generateRunId, hashString } from '..
 import { createFileStore } from '../server/report-store.js';
 import { analyzeResults } from '../analysis/report-diagnostics.js';
 import { loadSamples } from '../inputs/load-samples.js';
+import { buildVariantSummary } from '../eval-core/schema.js';
 import { fixSamples } from './sample-fixer.js';
 import type { JudgeConfig, ProgressCallback, Report, ResultEntry, Sample, VariantResult } from '../types/index.js';
 
@@ -145,9 +146,15 @@ function readSkillName(skillPath: string): string | null {
   }
 }
 
-export function extractWeakSamples(report: Report, variantKey: string, count: number = 5): WeakSample[] {
+export function extractWeakSamples(
+  report: Report,
+  variantKey: string,
+  count: number = 5,
+  sampleIdFilter?: Set<string>,
+): WeakSample[] {
   const weakSamples: WeakSample[] = [];
   for (const r of report.results) {
+    if (sampleIdFilter && !sampleIdFilter.has(r.sample_id)) continue;
     const v = r.variants[variantKey];
     if (!v || typeof v.compositeScore !== 'number') continue;
     const suggestion = v.diagnostic?.suggestion;
@@ -175,6 +182,54 @@ export function extractWeakSamples(report: Report, variantKey: string, count: nu
   return weakSamples
     .sort((a, b) => a.compositeScore - b.compositeScore)
     .slice(0, count);
+}
+
+/** A train / holdout partition of a sample set. */
+interface HoldoutSplit {
+  trainIds: Set<string>;
+  holdoutIds: Set<string>;
+}
+
+/** Below this many samples on either side, a holdout split is too small to be
+ *  meaningful — evolve falls back to full-set scoring and warns. */
+const MIN_HOLDOUT_SUBSET = 3;
+
+/**
+ * Deterministically split sample ids into train / holdout by `ratio` (fraction
+ * held out). Holdout members are picked at an even stride so the partition is
+ * representative of the ordering, and the split is stable across rounds and runs
+ * (no RNG). Returns null when ratio ≤ 0 or either side would drop below
+ * MIN_HOLDOUT_SUBSET — the caller then scores on the full set.
+ */
+export function splitHoldout(sampleIds: string[], ratio: number): HoldoutSplit | null {
+  if (!(ratio > 0) || sampleIds.length === 0) return null;
+  const holdoutCount = Math.round(sampleIds.length * ratio);
+  const trainCount = sampleIds.length - holdoutCount;
+  if (holdoutCount < MIN_HOLDOUT_SUBSET || trainCount < MIN_HOLDOUT_SUBSET) return null;
+  const stride = sampleIds.length / holdoutCount;
+  const holdoutIds = new Set<string>();
+  for (let k = 0; k < holdoutCount; k++) {
+    holdoutIds.add(sampleIds[Math.floor(k * stride)]);
+  }
+  const trainIds = new Set(sampleIds.filter((id) => !holdoutIds.has(id)));
+  return { trainIds, holdoutIds };
+}
+
+/**
+ * Mean composite over the subset of a report's results whose sample_id is in
+ * `ids`, using the same aggregation as the full-run summary
+ * (`buildVariantSummary`) so train / holdout scores stay comparable to the
+ * headline composite. Returns 0 when the subset has no scorable entries.
+ */
+function subsetCompositeScore(report: Report, variantKey: string, ids: Set<string>): number {
+  const entries: VariantResult[] = [];
+  for (const r of report.results) {
+    if (!ids.has(r.sample_id)) continue;
+    const v = r.variants[variantKey];
+    if (v) entries.push(v);
+  }
+  if (entries.length === 0) return 0;
+  return buildVariantSummary(entries).avgCompositeScore ?? 0;
 }
 
 export function allNonTripwireAssertionsPass(report: Report, variantKey: string): boolean {
@@ -423,16 +478,27 @@ interface EvolveOptions {
   noDiagnostic?: boolean;
   /** 跳过 doctor 健康检查门禁。默认 false。 */
   skipDoctor?: boolean;
+  /** Fraction of samples held out for the accept decision (0..1). Default 0 = off.
+   *  When > 0, a candidate is accepted on its **holdout** composite rather than the
+   *  training composite, and weak-sample extraction only sees the training split —
+   *  so the skill is never tuned to the samples that judge it. Too small a split
+   *  (either side < MIN_HOLDOUT_SUBSET) falls back to full-set scoring + a warning. */
+  holdoutRatio?: number;
   onProgress?: ProgressCallback | null;
   onRoundProgress?: ((progress: EvolveRoundProgressInfo) => void) | null;
 }
 
 interface TrajectoryEntry {
   round: number;
+  /** Accept-decision score: holdout composite when holdout is active, else full-set. */
   score: number;
   delta: number;
   accepted: boolean;
   costUSD: number;
+  /** Present when holdout is active: the training-split composite (improvement signal). */
+  trainScore?: number;
+  /** Present when holdout is active: the holdout-split composite (== score). */
+  holdoutScore?: number;
 }
 
 export interface EvolveResult {
@@ -446,6 +512,10 @@ export interface EvolveResult {
   reusedBaselineReportId?: string;
   /** False = 任一轮的 exec / judge 不报 cost → totalCostUSD 是 lower-bound 而非真值。 */
   costReported?: boolean;
+  /** Holdout split summary when `--holdout-ratio` > 0. `disabled` is true when the
+   *  split was too small and evolve fell back to full-set scoring (CLI formats the
+   *  user-facing message bilingually). */
+  holdout?: { ratio: number; trainCount: number; holdoutCount: number; disabled?: boolean };
   trajectory: TrajectoryEntry[];
   bestSkillPath: string;
   allVersions: string[];
@@ -559,6 +629,7 @@ export async function evolveSkill({
   effort,
   noDiagnostic,
   skipDoctor,
+  holdoutRatio = 0,
   onProgress = null,
   onRoundProgress = null,
 }: EvolveOptions): Promise<EvolveResult> {
@@ -582,6 +653,33 @@ export async function evolveSkill({
   if (!existsSync(absSkillPath)) throw new Error(`skill file not found: ${absSkillPath}`);
   if (!existsSync(absSamplesPath)) throw new Error(`samples file not found: ${absSamplesPath}`);
   mkdirSync(evolveDir, { recursive: true });
+
+  // Holdout split (opt-in). Computed once over the canonical sample order so it's
+  // stable across rounds. When active, accept decisions use the holdout composite
+  // and weak-sample extraction only sees the training split — the skill is never
+  // tuned to the samples that decide whether it's accepted.
+  const allSampleIds = loadSamples(absSamplesPath).samples.map((s) => s.sample_id);
+  const holdoutSplit = splitHoldout(allSampleIds, holdoutRatio);
+  const holdoutInfo: EvolveResult['holdout'] = holdoutRatio > 0
+    ? {
+      ratio: holdoutRatio,
+      trainCount: holdoutSplit?.trainIds.size ?? allSampleIds.length,
+      holdoutCount: holdoutSplit?.holdoutIds.size ?? 0,
+      ...(holdoutSplit ? {} : { disabled: true }),
+    }
+    : undefined;
+
+  // Accept-decision score for a report's variant: holdout composite when the split
+  // is active, otherwise the full-set composite (legacy behavior).
+  const decisionScore = (report: Report, key: string): number =>
+    holdoutSplit
+      ? subsetCompositeScore(report, key, holdoutSplit.holdoutIds)
+      : (report.summary[key]?.avgCompositeScore ?? 0);
+  const trainScoreOf = (report: Report, key: string): number | undefined =>
+    holdoutSplit ? subsetCompositeScore(report, key, holdoutSplit.trainIds) : undefined;
+  // Per-round trajectory tail: train / holdout breakdown, only when split active.
+  const splitScores = (report: Report, key: string, decision: number): Partial<TrajectoryEntry> =>
+    holdoutSplit ? { trainScore: trainScoreOf(report, key), holdoutScore: decision } : {};
 
   // Save original as r0
   let currentBest = readFileSync(absSkillPath, 'utf-8').trim();
@@ -626,13 +724,13 @@ export async function evolveSkill({
     });
   }
   const baselineVariantKey = Object.keys(baselineReport.summary)[0];
-  bestScore = baselineReport.summary[baselineVariantKey]?.avgCompositeScore ?? 0;
+  bestScore = decisionScore(baselineReport, baselineVariantKey);
   const baselineCost = baselineReused ? 0 : baselineReport.meta.totalCostUSD;
   totalCostUSD += baselineCost;
   const baselineCostReported = baselineReused || !reportHasUnreportedCost(baselineReport);
   if (!baselineCostReported) totalCostReported = false;
 
-  trajectory.push({ round: 0, score: bestScore, delta: 0, accepted: true, costUSD: baselineCost });
+  trajectory.push({ round: 0, score: bestScore, delta: 0, accepted: true, costUSD: baselineCost, ...splitScores(baselineReport, baselineVariantKey, bestScore) });
   roundReports.push({ round: 0, accepted: true, report: baselineReport });
   if (onRoundProgress) onRoundProgress({ round: 0, totalRounds: rounds, phase: 'baseline', score: bestScore, costUSD: baselineCost, costReported: baselineCostReported, reused: baselineReused });
 
@@ -652,6 +750,7 @@ export async function evolveSkill({
       ...(sampleFixes.length > 0 && { sampleFixes }),
       ...(reusedBaselineReportId && { reusedBaselineReportId }),
       ...(totalCostReported ? {} : { costReported: false }),
+      ...(holdoutInfo ? { holdout: holdoutInfo } : {}),
       trajectory,
       bestSkillPath: allVersions[bestRound],
       allVersions,
@@ -677,7 +776,7 @@ export async function evolveSkill({
       if (reportHasUnreportedCost(lastReport)) totalCostReported = false;
     }
     const lastVariantKey = Object.keys(lastReport.summary)[0];
-    const weakSamples = extractWeakSamples(lastReport, lastVariantKey);
+    const weakSamples = extractWeakSamples(lastReport, lastVariantKey, 5, holdoutSplit?.trainIds);
 
     // Generate improvement
     const candidatePath = join(evolveDir, `${skillName}.r${round}.md`);
@@ -747,7 +846,7 @@ export async function evolveSkill({
       samplesPath: absSamplesPath, skillDir, model, judgeModels: effectiveJudgeModels, executorName, concurrency, timeoutMs, skipConnectivity, effort, noDiagnostic, skipDoctor, onProgress,
     });
     const candidateVariantKey = Object.keys(candidateReport.summary)[0];
-    const candidateScore = candidateReport.summary[candidateVariantKey]?.avgCompositeScore ?? 0;
+    const candidateScore = decisionScore(candidateReport, candidateVariantKey);
     const roundCost = improveCostUSD + preEvalSampleFixCost + candidateReport.meta.totalCostUSD;
     const roundCostReported = improveCostReported && !reportHasUnreportedCost(candidateReport);
     if (!roundCostReported) totalCostReported = false;
@@ -766,7 +865,7 @@ export async function evolveSkill({
 
     if (accepted) roundReports.push({ round, accepted, report: candidateReport });
     const roundDelta = candidateScore - trajectory[trajectory.length - 1].score;
-    trajectory.push({ round, score: candidateScore, delta: roundDelta, accepted, costUSD: roundCost });
+    trajectory.push({ round, score: candidateScore, delta: roundDelta, accepted, costUSD: roundCost, ...splitScores(candidateReport, candidateVariantKey, candidateScore) });
     if (onRoundProgress) onRoundProgress({ round, totalRounds: rounds, phase: 'done', score: candidateScore, delta: roundDelta, accepted, costUSD: roundCost, costReported: roundCostReported });
 
     // Early stop
@@ -809,6 +908,7 @@ export async function evolveSkill({
     ...(sampleFixes.length > 0 && { sampleFixes }),
     ...(reusedBaselineReportId && { reusedBaselineReportId }),
     ...(totalCostReported ? {} : { costReported: false }),
+    ...(holdoutInfo ? { holdout: holdoutInfo } : {}),
     trajectory,
     bestSkillPath: allVersions[bestRound],
     allVersions,

--- a/src/cli/commands/evolve.ts
+++ b/src/cli/commands/evolve.ts
@@ -28,6 +28,8 @@ interface TrajectoryEntry {
   delta: number;
   accepted: boolean;
   costUSD: number;
+  trainScore?: number;
+  holdoutScore?: number;
 }
 
 const VALID_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
@@ -50,6 +52,7 @@ interface EvolveResult {
   totalRounds: number;
   totalCostUSD: number;
   costReported?: boolean;
+  holdout?: { ratio: number; trainCount: number; holdoutCount: number; disabled?: boolean };
   trajectory: TrajectoryEntry[];
   bestSkillPath: string;
   allVersions: string[];
@@ -113,6 +116,7 @@ export async function runEvolve(
       autoFixSamples: flags['auto-fix-samples'],
       sampleFixMaxAttempts: Math.max(1, Number(flags['sample-fix-max-attempts']) || 2),
       reuseLatestEval: flags['reuse-latest-eval'],
+      holdoutRatio: Number(flags['holdout-ratio']) || 0,
       improveMode: flags['improve-mode'] === 'rewrite' ? 'rewrite' : 'agent',
       onProgress: makeOnProgress(lang) as unknown as ProgressCallback,
       onRoundProgress({ round, totalRounds: _totalRounds, phase, score, delta, accepted, costUSD, costReported, error }: RoundProgressInfo): void {
@@ -146,6 +150,13 @@ export async function runEvolve(
       start: result.startScore.toFixed(2), final: result.finalScore.toFixed(2),
       percent: improvement, rounds: result.totalRounds, cost: totalCostStr,
     }));
+    if (result.holdout) {
+      process.stderr.write(result.holdout.disabled
+        ? tCli('cli.evolve.holdout_disabled', lang, { ratio: result.holdout.ratio })
+        : tCli('cli.evolve.holdout_active', lang, {
+          train: result.holdout.trainCount, holdout: result.holdout.holdoutCount,
+        }));
+    }
     process.stderr.write(tCli('cli.evolve.best_path', lang, {
       best: result.bestSkillPath, target: resolve(skillPath),
     }));
@@ -317,6 +328,14 @@ export default class Evolve extends BaseCommand {
       }),
       default: 'agent',
       options: ['agent', 'rewrite'],
+    }),
+    'holdout-ratio': Flags.string({
+      description: bilingual({
+        zh: '留出验收集比例（0..1，默认 0=关）。> 0 时按 holdout 分接受候选、weak-sample 只取训练集，防 train-on-test',
+        en: 'Holdout fraction for the accept decision (0..1, default 0=off). When > 0, candidates are accepted on holdout score and weak samples come only from train — guards against train-on-test',
+      }),
+      default: '0',
+      parse: numberStringParser('--holdout-ratio', { min: 0, max: 1 }),
     }),
   };
 

--- a/src/cli/lib/cmd-flags.ts
+++ b/src/cli/lib/cmd-flags.ts
@@ -147,6 +147,7 @@ export interface EvolveFlags {
   'sample-fix-max-attempts': string;
   'reuse-latest-eval': boolean;
   'improve-mode': string;
+  'holdout-ratio': string;
 }
 
 // ── sample ────────────────────────────────────────────────────────────────────

--- a/src/cli/lib/i18n-dict/evolve.ts
+++ b/src/cli/lib/i18n-dict/evolve.ts
@@ -10,7 +10,9 @@ export type EvolveMessageKey =
   | 'cli.evolve.summary'
   | 'cli.evolve.best_path'
   | 'cli.evolve.versions_saved'
-  | 'cli.evolve.report_link';
+  | 'cli.evolve.report_link'
+  | 'cli.evolve.holdout_active'
+  | 'cli.evolve.holdout_disabled';
 
 export const evolveDict: Record<EvolveMessageKey, CliMessage> = {
   'cli.evolve.specify_skill_path': {
@@ -52,5 +54,13 @@ export const evolveDict: Record<EvolveMessageKey, CliMessage> = {
   'cli.evolve.report_link': {
     zh: '📊 查看报告：omk studio（报告 ID：{id}）\n',
     en: '📊 View report: omk studio (report id: {id})\n',
+  },
+  'cli.evolve.holdout_active': {
+    zh: '🔀 holdout 切分：训练 {train} / 验收 {holdout}，accept 看 holdout 分（防 train-on-test）\n',
+    en: '🔀 Holdout split: {train} train / {holdout} holdout; accepted on holdout score (guards train-on-test)\n',
+  },
+  'cli.evolve.holdout_disabled': {
+    zh: '⚠️ holdout-ratio={ratio} 样本太少无法切分，已回退全集打分\n',
+    en: '⚠️ holdout-ratio={ratio} too few samples to split; using full-set scoring\n',
   },
 };

--- a/test/authoring/evolver.test.ts
+++ b/test/authoring/evolver.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { extractWeakSamples, buildImprovementPrompt, evolveSkill, allNonTripwireAssertionsPass, splitHoldout } from '../../src/authoring/evolver.js';
-import type { Report } from '../../src/types/index.js';
+import { extractWeakSamples, buildImprovementPrompt, evolveSkill, allNonTripwireAssertionsPass, splitHoldout, restrictReportToSamples } from '../../src/authoring/evolver.js';
+import { fixSamples } from '../../src/authoring/sample-fixer.js';
+import type { Report, EvaluationReport } from '../../src/types/index.js';
 
 function toReport(value: unknown): Report {
   return value as Report;
@@ -81,6 +82,56 @@ describe('splitHoldout', () => {
     const a = splitHoldout(ids(17), 0.25);
     const b = splitHoldout(ids(17), 0.25);
     assert.deepEqual([...a!.holdoutIds], [...b!.holdoutIds]);
+  });
+});
+
+describe('restrictReportToSamples (holdout leak guard)', () => {
+  it('keeps only results whose sample_id is in the set', () => {
+    const report = toReport({
+      results: [
+        { sample_id: 's1', variants: {} },
+        { sample_id: 's2', variants: {} },
+        { sample_id: 's3', variants: {} },
+      ],
+    });
+    const out = restrictReportToSamples(report, new Set(['s1', 's3']));
+    assert.deepEqual(out.results.map((r) => r.sample_id), ['s1', 's3']);
+  });
+});
+
+describe('auto-fix-samples respects the holdout split', () => {
+  // Both modes (agent / rewrite) iterate the same `report.results`; evolveSkill now
+  // hands the fixer a train-restricted report, so a holdout sample can never enter the
+  // fix prompt nor be rewritten. This exercises the rewrite path end-to-end (injectable
+  // executor) — the strongest place to prove the leak guard.
+  it('a holdout sample never enters the sample-fix prompt (rewrite mode)', async () => {
+    const failVariant = { ok: true, compositeScore: 2, assertions: { details: [{ type: 'contains', value: 'x', passed: false }] } };
+    const fullReport = toReport({
+      results: [
+        { sample_id: 's_train', variants: { skill: failVariant } },
+        { sample_id: 's_hold', variants: { skill: failVariant } },
+      ],
+    });
+    const samples: Record<string, unknown>[] = [
+      { sample_id: 's_train', prompt: 'p', assertions: [] },
+      { sample_id: 's_hold', prompt: 'p', assertions: [] },
+    ];
+    let capturedPrompt = '';
+    const mockExecutor: Parameters<typeof fixSamples>[0]['executor'] = async (o) => {
+      capturedPrompt += o.prompt;
+      return { ok: true, text: '[]', costUSD: 0 };
+    };
+    await fixSamples({
+      skillContent: 'skill',
+      samples,
+      // What evolveSkill passes under an active holdout: only training-split results.
+      report: restrictReportToSamples(fullReport, new Set(['s_train'])) as unknown as EvaluationReport,
+      treatmentKey: 'skill',
+      executor: mockExecutor,
+      model: 'm',
+    });
+    assert.match(capturedPrompt, /s_train/);
+    assert.doesNotMatch(capturedPrompt, /s_hold/);
   });
 });
 

--- a/test/authoring/evolver.test.ts
+++ b/test/authoring/evolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { extractWeakSamples, buildImprovementPrompt, evolveSkill, allNonTripwireAssertionsPass } from '../../src/authoring/evolver.js';
+import { extractWeakSamples, buildImprovementPrompt, evolveSkill, allNonTripwireAssertionsPass, splitHoldout } from '../../src/authoring/evolver.js';
 import type { Report } from '../../src/types/index.js';
 
 function toReport(value: unknown): Report {
@@ -39,6 +39,48 @@ describe('extractWeakSamples', () => {
     const s003 = weak.find((s: { sample_id: string }) => s.sample_id === 's003');
     assert.equal(s003!.dimensions!.security, 3);
     assert.equal(s003!.dimensions!.actionability, 4);
+  });
+
+  it('restricts to the train split when a sampleIdFilter is given (holdout leak guard)', () => {
+    // s002 is the weakest but lives in the holdout split — it must NOT surface as a
+    // weak sample, otherwise the improvement prompt would tune the skill to holdout.
+    const trainIds = new Set(['s001', 's003']);
+    const weak = extractWeakSamples(toReport(mockReport), 'skill', 5, trainIds);
+    assert.deepEqual(weak.map((s) => s.sample_id), ['s003', 's001']);
+    assert.ok(!weak.some((s) => s.sample_id === 's002'));
+  });
+});
+
+describe('splitHoldout', () => {
+  const ids = (n: number): string[] => Array.from({ length: n }, (_, i) => `s${i}`);
+
+  it('returns null when ratio is 0 (off)', () => {
+    assert.equal(splitHoldout(ids(20), 0), null);
+  });
+
+  it('returns null when either side would fall below the minimum subset', () => {
+    // N=4, ratio 0.5 → holdout 2 < 3 → disabled.
+    assert.equal(splitHoldout(ids(4), 0.5), null);
+    // ratio > 1 → holdout > N → train negative → disabled.
+    assert.equal(splitHoldout(ids(10), 1.5), null);
+  });
+
+  it('splits at an even stride into disjoint train / holdout covering all ids', () => {
+    const split = splitHoldout(ids(10), 0.3);
+    assert.ok(split);
+    assert.equal(split!.holdoutIds.size, 3);
+    assert.equal(split!.trainIds.size, 7);
+    // Even stride over 10 with 3 held out → indices 0, 3, 6.
+    assert.deepEqual([...split!.holdoutIds].sort(), ['s0', 's3', 's6']);
+    // Disjoint and exhaustive.
+    for (const id of split!.holdoutIds) assert.ok(!split!.trainIds.has(id));
+    assert.equal(split!.holdoutIds.size + split!.trainIds.size, 10);
+  });
+
+  it('is deterministic across calls (stable split, no RNG)', () => {
+    const a = splitHoldout(ids(17), 0.25);
+    const b = splitHoldout(ids(17), 0.25);
+    assert.deepEqual([...a!.holdoutIds], [...b!.holdoutIds]);
   });
 });
 


### PR DESCRIPTION
## 背景

evolve 的接受决策是 `candidateScore > bestScore`，而 `candidateScore` 与驱动改进的 weak-sample 提取用的是**同一批 samples**——教科书级 train-on-test，开 `--auto-fix-samples` 时更严重。多轮迭代下 skill 被直接调到「评判它的那批样本」上，刷分但不代表泛化。这是 omk 改进审计里测量学护城河的一处缺口。

## 改了什么

加 opt-in `--holdout-ratio`（0..1，默认 0=关）。> 0 时：

- 确定性偶步长把样本切成训练 / 验收两份（stable across rounds，无 RNG）。
- 接受决策改看候选在**验收集**上的 composite（子集复用 `buildVariantSummary` 聚合，与全集 composite 口径一致），而非训练集分。
- weak-sample 提取**只从训练集**取——skill 永远看不到验收集的失败，不会被调到验收集上。
- 任一侧样本太少时回退全集打分并告警（CLI 双语），不静默。
- `report.evolve` trajectory 增加 train / holdout 分项。

## 用户影响 / 迁移

默认 `--holdout-ratio 0` 完全保持现有行为。想要可信的自动迭代时加 `--holdout-ratio 0.3`，evolve 会按验收集分接受候选，CLI 打印 `🔀 holdout 切分：训练 N / 验收 M`。

## 测量学 / construct validity

opt-in 且默认 0，不改既有 Report 字段语义、不触测量学不变量，**无 `BREAKING-COMPARABILITY`**。

诚实 caveat：多轮在同一 holdout 上反复选最优仍有 optimism bias（model-selection over a validation set 的多重比较）。严格消除需要第三份 test set；但相比当前的 train-on-test 是明确改进。小样本（切分后两侧 < 最小子集）会触发回退 + 告警，避免在 N 太小时给出假的 holdout 信号。

承上：这是 omk v0.32 改进审计「测量学护城河深化」的 top-priority 项。