### PR TITLE
feat(authoring): omk sample --from-traces 把 observe 失败信号回流成回归用例草稿

### DIFF
--- a/.claude/skills/omk/references/commands.md
+++ b/.claude/skills/omk/references/commands.md
@@ -371,7 +371,7 @@ omk observe show <inboxId> [flags]
 
 ## omk sample
 
-为指定 skill 生成评测用例（eval-samples），支持 batch / single / fix 三种模式。
+为指定 skill 生成评测用例（eval-samples），支持 batch / single / fix / from-traces 四种模式。
 
 **用法:**
 
@@ -416,6 +416,12 @@ omk sample --batch --skill-dir skills
 
 ```bash
 omk sample skills/my-skill/SKILL.md --fix
+```
+
+> 从 observe inbox 的失败信号回流生成回归用例草稿
+
+```bash
+omk sample --from-traces
 ```
 
 ## omk studio

--- a/.claude/skills/omk/references/commands.md
+++ b/.claude/skills/omk/references/commands.md
@@ -389,9 +389,11 @@ omk sample [skillPath] [flags]
 - `--count` `option`:生成样本条数。不传由 LLM 按 skill 类型自动决定。
 - `--fix` `boolean`:fix 模式：基于最近评测报告自动修复 sample_design 类型失败。
 - `--focus` `option`:生成焦点（自然语言提示）。控制 LLM 偏向哪类用例。
+- `--from-traces` `boolean`:from-traces 模式：从 observe inbox 的失败信号回流生成回归用例草稿（provenance: production-trace），落草稿待人工 review。
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--model` `option` (默认 `sonnet`):生成 LLM model 名，默认 sonnet。
 - `--no-mock` `boolean`:不生成 mocks，eval 时所有工具调用真实执行。
+- `--observations-dir` `option`:observe inbox 目录（from-traces 模式用），默认项目 .omk/observations。
 - `--reports-dir` `option`:报告目录（fix 模式用），默认 ~/.oh-my-knowledge/reports。
 - `--skill-dir` `option` (默认 `skills`):skill 根目录，默认 skills。batch 模式扫此目录。
 - `--treatment` `option`:指定 treatment 名（fix 模式用），默认推断自 skill 路径。

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -248,16 +248,18 @@ omk sample --batch                  # generate for skills missing eval-samples
 **Flags:**
 
 ```text
-  --batch                Batch mode: scan --skill-dir, generate samples for any skill missing them.
-  --count <value>        Number of samples to generate. Defaults to LLM auto-selection by skill type.
-  --fix                  Fix mode: auto-fix sample_design failures using the latest eval report.
-  --focus <value>        Generation focus (NL hint). Steers LLM toward certain sample types.
-  --lang <value>         Output language zh|en. Priority: CLI > OMK_LANG env > zh.
-  --model <value>        Generation LLM model name, default sonnet.
-  --no-mock              Skip mock generation; all tool calls execute for real during eval.
-  --reports-dir <value>  Reports dir (fix mode), default ~/.oh-my-knowledge/reports.
-  --skill-dir <value>    Skill root dir, default skills. Used by batch mode.
-  --treatment <value>    Treatment name (fix mode), defaults to skill-path inference.
+  --batch                     Batch mode: scan --skill-dir, generate samples for any skill missing them.
+  --count <value>             Number of samples to generate. Defaults to LLM auto-selection by skill type.
+  --fix                       Fix mode: auto-fix sample_design failures using the latest eval report.
+  --focus <value>             Generation focus (NL hint). Steers LLM toward certain sample types.
+  --from-traces               from-traces mode: recycle observe-inbox failure signals into draft regression samples (provenance: production-trace) for review.
+  --lang <value>              Output language zh|en. Priority: CLI > OMK_LANG env > zh.
+  --model <value>             Generation LLM model name, default sonnet.
+  --no-mock                   Skip mock generation; all tool calls execute for real during eval.
+  --observations-dir <value>  Observe inbox dir (from-traces mode), default project .omk/observations.
+  --reports-dir <value>       Reports dir (fix mode), default ~/.oh-my-knowledge/reports.
+  --skill-dir <value>         Skill root dir, default skills. Used by batch mode.
+  --treatment <value>         Treatment name (fix mode), defaults to skill-path inference.
 ```
 
 For full descriptions: `omk sample --help`.

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -248,16 +248,18 @@ omk sample --batch                  # 为目录下缺评测集的 skill 批量�
 **Flags:**
 
 ```text
-  --batch                批量模式：扫 --skill-dir 下所有缺 samples 的 skill，逐个生成。
-  --count <value>        生成样本条数。不传由 LLM 按 skill 类型自动决定。
-  --fix                  fix 模式：基于最近评测报告自动修复 sample_design 类型失败。
-  --focus <value>        生成焦点（自然语言提示）。控制 LLM 偏向哪类用例。
-  --lang <value>         输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
-  --model <value>        生成 LLM model 名，默认 sonnet。
-  --no-mock              不生成 mocks，eval 时所有工具调用真实执行。
-  --reports-dir <value>  报告目录（fix 模式用），默认 ~/.oh-my-knowledge/reports。
-  --skill-dir <value>    skill 根目录，默认 skills。batch 模式扫此目录。
-  --treatment <value>    指定 treatment 名（fix 模式用），默认推断自 skill 路径。
+  --batch                     批量模式：扫 --skill-dir 下所有缺 samples 的 skill，逐个生成。
+  --count <value>             生成样本条数。不传由 LLM 按 skill 类型自动决定。
+  --fix                       fix 模式：基于最近评测报告自动修复 sample_design 类型失败。
+  --focus <value>             生成焦点（自然语言提示）。控制 LLM 偏向哪类用例。
+  --from-traces               from-traces 模式：从 observe inbox 的失败信号回流生成回归用例草稿（provenance: production-trace），落草稿待人工 review。
+  --lang <value>              输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
+  --model <value>             生成 LLM model 名，默认 sonnet。
+  --no-mock                   不生成 mocks，eval 时所有工具调用真实执行。
+  --observations-dir <value>  observe inbox 目录（from-traces 模式用），默认项目 .omk/observations。
+  --reports-dir <value>       报告目录（fix 模式用），默认 ~/.oh-my-knowledge/reports。
+  --skill-dir <value>         skill 根目录，默认 skills。batch 模式扫此目录。
+  --treatment <value>         指定 treatment 名（fix 模式用），默认推断自 skill 路径。
 ```
 
 完整描述见 `omk sample --help`。

--- a/src/authoring/generator.ts
+++ b/src/authoring/generator.ts
@@ -1,5 +1,6 @@
 import { createExecutor } from '../executors/index.js';
-import type { Sample } from '../types/index.js';
+import type { Sample, SampleProvenance } from '../types/index.js';
+import type { ObservationInboxItem } from '../types/observability.js';
 
 /**
  * Generator 默认模型 'opus' (跟 eval 默认对齐)。
@@ -485,6 +486,131 @@ async function finalizeSamples(
   }
 
   return { samples, costUSD };
+}
+
+const TRACE_GEN_INSTRUCTIONS = `下面给出的不是 skill，而是从生产会话 trace 中观测到的失败 / 异常信号。请为这些信号生成评测用例（eval samples），使评测能复现并守住这些失败模式——把线上真实发生过的问题沉淀成回归用例。
+
+要求：
+- 每个信号生成 1-2 条聚焦回归用例；信号若是噪声 / 证据不足 / 无法复现，跳过它，不要硬凑。
+- prompt 要还原触发该信号的场景（自然语言任务），不要直接复述证据文本。
+- 断言优先用 mock_hit / tools_called / tools_not_called / tool_input_contains 精确锚定失败步骤，再用 contains 兜底；按「原子型」配比处理（无需工作流编号步骤），除非证据明显是多步流程。
+- 不要在输出里说明判断过程，直接输出 JSON 数组。`;
+
+type TraceSignalItem = Pick<
+  ObservationInboxItem,
+  'skillName' | 'signalType' | 'signalSubtype' | 'severity' | 'evidence' | 'messageWindow' | 'occurrences'
+>;
+
+/**
+ * Build the generation prompt for `omk sample --from-traces`. Renders each
+ * observation-inbox signal (evidence + message window) into a section and asks
+ * the generator to synthesize regression samples that reproduce the observed
+ * production failures. The trace text feeds the *generator* only — never the
+ * judge prompt — so judge-prompt isolation is unaffected.
+ */
+export function buildSamplesFromTracesPrompt(items: TraceSignalItem[], count?: number): string {
+  const sections = items.map((it, i) => {
+    const ev = it.evidence ?? {};
+    const evLines = [
+      ev.tool && `工具: ${ev.tool}`,
+      ev.query && `查询/输入: ${ev.query}`,
+      ev.path && `路径: ${ev.path}`,
+      ev.outputSnippet && `输出片段: ${ev.outputSnippet}`,
+      ev.assistantSnippet && `助手片段: ${ev.assistantSnippet}`,
+      ev.markerToken && `标记: ${ev.markerToken}`,
+    ].filter(Boolean).join('\n') || '(无结构化证据)';
+    const win = it.messageWindow
+      ? '\n上下文消息:\n' + [...it.messageWindow.before, ...it.messageWindow.event, ...it.messageWindow.after]
+        .map((m) => `  [${m.role}] ${m.snippet}`).join('\n')
+      : '';
+    return `### 信号 ${i + 1}：${it.signalType} / ${it.signalSubtype}（严重度 ${it.severity}，出现 ${it.occurrences} 次，skill: ${it.skillName}）\n${evLines}${win}`;
+  }).join('\n\n---\n\n');
+
+  const countLine = typeof count === 'number'
+    ? `共生成约 ${count} 条评测用例。`
+    : '按上面的「每个信号 1-2 条」生成。';
+
+  return `${TRACE_GEN_INSTRUCTIONS}
+
+## 观测到的失败信号（共 ${items.length} 个）
+
+${sections}
+
+${countLine}直接输出 JSON 数组。`;
+}
+
+/** Build a sanitize context string from trace evidence so finalizeSamples keeps
+ *  tool-name assertions that reference tools actually seen in the traces (an empty
+ *  context would strip every tool-name fact assertion). */
+function traceSanitizeContext(items: TraceSignalItem[]): string {
+  return items.map((it) => {
+    const ev = it.evidence ?? {};
+    return [ev.tool, ev.query, ev.path, ev.outputSnippet, ev.assistantSnippet, ev.markerToken]
+      .filter(Boolean).join(' ');
+  }).join('\n');
+}
+
+export interface GenerateSamplesFromTracesOptions {
+  items: TraceSignalItem[];
+  count?: number;
+  model?: string;
+  executorName?: string;
+}
+
+/**
+ * Generate draft eval samples from production-trace observation signals. Mirrors
+ * generateSamples' executor / retry / finalize path but feeds the trace prompt and
+ * stamps `provenance: 'production-trace'`. Output is meant to land in a review draft,
+ * not the live dataset (the CLI enforces that).
+ */
+export async function generateSamplesFromTraces({
+  items,
+  count,
+  model = GENERATOR_DEFAULT_MODEL,
+  executorName = 'claude',
+}: GenerateSamplesFromTracesOptions): Promise<{ samples: Sample[]; costUSD: number }> {
+  if (items.length === 0) return { samples: [], costUSD: 0 };
+  const executor = createExecutor(executorName);
+  const prompt = buildSamplesFromTracesPrompt(items, count);
+  const sanitizeContext = traceSanitizeContext(items);
+  const PROVENANCE: SampleProvenance = 'production-trace';
+
+  const MAX_ATTEMPTS = 3;
+  let lastErr = '';
+  let totalCost = 0;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const attemptPrompt = attempt === 1
+      ? prompt
+      : `${prompt}\n\n上一次输出解析失败:${lastErr}\n请严格按 JSON 规范输出(字符串内部用「」全角引号),只输出数组,不要包含其他文字。`;
+    const result = await executor({ model, system: SYSTEM_PROMPT, prompt: attemptPrompt, timeoutMs: 300_000, lean: true });
+    totalCost += result.costUSD || 0;
+    if (!result.ok) {
+      lastErr = result.error || 'unknown error';
+      if (attempt === MAX_ATTEMPTS) throw new Error(`trace generation failed after ${MAX_ATTEMPTS} attempts: ${lastErr}`);
+      continue;
+    }
+    let jsonStr = result.output!.trim();
+    const jsonMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (jsonMatch) jsonStr = jsonMatch[1].trim();
+    let samples: Sample[];
+    try {
+      samples = JSON.parse(jsonStr);
+    } catch (e) {
+      lastErr = `JSON 解析失败: ${(e as Error).message}`;
+      if (attempt === MAX_ATTEMPTS) throw new Error(`trace generation failed after ${MAX_ATTEMPTS} attempts (JSON invalid): ${lastErr}`);
+      process.stderr.write(`[omk sample --from-traces] 第 ${attempt} 次输出 JSON 无效,重试中...\n`);
+      continue;
+    }
+    if (!Array.isArray(samples) || samples.length === 0) {
+      lastErr = '输出为空数组';
+      if (attempt === MAX_ATTEMPTS) throw new Error(`trace generation failed after ${MAX_ATTEMPTS} attempts: ${lastErr}`);
+      continue;
+    }
+    // Stamp provenance before sanitize so it survives (it's a valid enum value).
+    for (const s of samples) s.provenance = PROVENANCE;
+    return await finalizeSamples(samples, totalCost, sanitizeContext);
+  }
+  throw new Error('unreachable');
 }
 
 /**

--- a/src/authoring/generator.ts
+++ b/src/authoring/generator.ts
@@ -1,5 +1,5 @@
 import { createExecutor } from '../executors/index.js';
-import type { Sample, SampleProvenance } from '../types/index.js';
+import type { Sample, SampleProvenance, ExecutorFn } from '../types/index.js';
 import type { ObservationInboxItem } from '../types/observability.js';
 
 /**
@@ -555,6 +555,8 @@ export interface GenerateSamplesFromTracesOptions {
   count?: number;
   model?: string;
   executorName?: string;
+  /** Injectable executor (tests). Defaults to createExecutor(executorName). */
+  executor?: ExecutorFn;
 }
 
 /**
@@ -568,9 +570,10 @@ export async function generateSamplesFromTraces({
   count,
   model = GENERATOR_DEFAULT_MODEL,
   executorName = 'claude',
+  executor: injectedExecutor,
 }: GenerateSamplesFromTracesOptions): Promise<{ samples: Sample[]; costUSD: number }> {
   if (items.length === 0) return { samples: [], costUSD: 0 };
-  const executor = createExecutor(executorName);
+  const executor = injectedExecutor ?? createExecutor(executorName);
   const prompt = buildSamplesFromTracesPrompt(items, count);
   const sanitizeContext = traceSanitizeContext(items);
   const PROVENANCE: SampleProvenance = 'production-trace';
@@ -601,11 +604,15 @@ export async function generateSamplesFromTraces({
       process.stderr.write(`[omk sample --from-traces] 第 ${attempt} 次输出 JSON 无效,重试中...\n`);
       continue;
     }
-    if (!Array.isArray(samples) || samples.length === 0) {
-      lastErr = '输出为空数组';
+    if (!Array.isArray(samples)) {
+      lastErr = '输出不是 JSON 数组';
       if (attempt === MAX_ATTEMPTS) throw new Error(`trace generation failed after ${MAX_ATTEMPTS} attempts: ${lastErr}`);
       continue;
     }
+    // Empty array = the model conservatively skipped every signal (the trace prompt
+    // explicitly permits this when signals are noise / unreproducible). That's a valid
+    // 0-result, not a failure — return it so the CLI can no-op instead of erroring.
+    if (samples.length === 0) return { samples: [], costUSD: totalCost };
     // Stamp provenance before sanitize so it survives (it's a valid enum value).
     for (const s of samples) s.provenance = PROVENANCE;
     return await finalizeSamples(samples, totalCost, sanitizeContext);

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -317,11 +317,13 @@ async function runSampleFromTraces(
     throw new CliExit(1);
   }
 
-  const items = queryObservationInbox(obsDir);
+  // Drop noise-tier signals up front: they're exactly what the generator is told to
+  // skip, so filtering here avoids feeding junk to the LLM and keeps the no-op path clean.
+  const items = queryObservationInbox(obsDir).filter((it) => it.severity !== 'noise');
   if (items.length === 0) {
     process.stderr.write(lang === 'zh'
-      ? `✅ ${obsDir} 没有可回流的失败信号\n`
-      : `✅ No failure signals to recycle in ${obsDir}\n`);
+      ? `✅ ${obsDir} 没有可回流的失败信号（噪声级已跳过）\n`
+      : `✅ No recyclable failure signals in ${obsDir} (noise-level skipped)\n`);
     return;
   }
 
@@ -340,9 +342,17 @@ async function runSampleFromTraces(
 
   try {
     const { samples, costUSD } = await generateSamplesFromTraces({ items, count, model: flags.model });
+    const cost = costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
+    if (samples.length === 0) {
+      // The model conservatively skipped every signal (noise / unreproducible). That's a
+      // valid outcome, not a failure — don't write an empty draft file.
+      process.stderr.write(lang === 'zh'
+        ? `\n✅ 没有可复现的草稿用例（信号多为噪声 / 证据不足，已保守跳过），未写文件${cost}\n`
+        : `\n✅ No reproducible draft samples (signals were noise / insufficient evidence; conservatively skipped); nothing written${cost}\n`);
+      return;
+    }
     mkdirSync(dirname(outPath), { recursive: true });
     writeFileSync(outPath, JSON.stringify(samples, null, 2));
-    const cost = costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
     process.stderr.write(lang === 'zh'
       ? `\n✅ 生成 ${samples.length} 条草稿用例 → ${outPath}（provenance: production-trace）${cost}\n   ⚠️ 这是草稿：trace 只抓失败信号，有抽样偏差。请人工 review 后再合入正式 eval-samples，不要直接当评测集。\n`
       : `\n✅ Generated ${samples.length} draft sample(s) → ${outPath} (provenance: production-trace)${cost}\n   ⚠️ Draft only: traces capture failures, a biased sample. Review before merging into your eval-samples; don't use as-is.\n`);
@@ -489,8 +499,8 @@ async function runSample(
 
 export default class Sample extends BaseCommand {
   static description = bilingual({
-    zh: '为指定 skill 生成评测用例（eval-samples），支持 batch / single / fix 三种模式。',
-    en: 'Generate eval samples for the given skill. Supports batch / single / fix modes.',
+    zh: '为指定 skill 生成评测用例（eval-samples），支持 batch / single / fix / from-traces 四种模式。',
+    en: 'Generate eval samples for the given skill. Supports batch / single / fix / from-traces modes.',
   });
 
   static examples = [
@@ -514,6 +524,13 @@ export default class Sample extends BaseCommand {
         en: 'Auto-fix sample_design failures using the most recent eval report',
       }),
       command: '<%= config.bin %> sample skills/my-skill/SKILL.md --fix',
+    },
+    {
+      description: bilingual({
+        zh: '从 observe inbox 的失败信号回流生成回归用例草稿',
+        en: 'Recycle observe-inbox failure signals into draft regression samples',
+      }),
+      command: '<%= config.bin %> sample --from-traces',
     },
   ];
 

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -302,11 +302,66 @@ async function runSampleFix(
     : `\n🔧 Fix complete: ${result.fixedCount}/${sampleDesignCount} fixed → ${outputTarget}${cost}\n`);
 }
 
+async function runSampleFromTraces(
+  flags: SampleFlags,
+  lang: CliLang,
+): Promise<void> {
+  const { queryObservationInbox, DEFAULT_OBSERVATIONS_DIR } = await import('../../observability/inbox.js');
+  const { generateSamplesFromTraces } = await import('../../authoring/generator.js');
+
+  const obsDir = resolve(flags['observations-dir'] ?? DEFAULT_OBSERVATIONS_DIR);
+  if (!existsSync(obsDir)) {
+    console.error(lang === 'zh'
+      ? `observations 目录不存在: ${obsDir}（先运行 omk observe 生成 inbox）`
+      : `Observations dir not found: ${obsDir} (run omk observe first)`);
+    throw new CliExit(1);
+  }
+
+  const items = queryObservationInbox(obsDir);
+  if (items.length === 0) {
+    process.stderr.write(lang === 'zh'
+      ? `✅ ${obsDir} 没有可回流的失败信号\n`
+      : `✅ No failure signals to recycle in ${obsDir}\n`);
+    return;
+  }
+
+  const outPath = join(obsDir, 'sample-drafts.json');
+  if (existsSync(outPath)) {
+    console.error(lang === 'zh'
+      ? `草稿已存在: ${outPath}，请先 review 并合入正式集（或删除）后再生成`
+      : `Draft already exists: ${outPath}; review/merge (or remove) it before regenerating`);
+    throw new CliExit(1);
+  }
+
+  const count: number | undefined = flags.count !== undefined ? Math.max(1, Number(flags.count) || 5) : undefined;
+  process.stderr.write(lang === 'zh'
+    ? `🔭 发现 ${items.length} 个失败信号，正在生成回归用例草稿...\n`
+    : `🔭 Found ${items.length} failure signal(s); generating regression-sample drafts...\n`);
+
+  try {
+    const { samples, costUSD } = await generateSamplesFromTraces({ items, count, model: flags.model });
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, JSON.stringify(samples, null, 2));
+    const cost = costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
+    process.stderr.write(lang === 'zh'
+      ? `\n✅ 生成 ${samples.length} 条草稿用例 → ${outPath}（provenance: production-trace）${cost}\n   ⚠️ 这是草稿：trace 只抓失败信号，有抽样偏差。请人工 review 后再合入正式 eval-samples，不要直接当评测集。\n`
+      : `\n✅ Generated ${samples.length} draft sample(s) → ${outPath} (provenance: production-trace)${cost}\n   ⚠️ Draft only: traces capture failures, a biased sample. Review before merging into your eval-samples; don't use as-is.\n`);
+  } catch (err: unknown) {
+    if (err instanceof CliExit) throw err;
+    console.error(lang === 'zh' ? `生成失败: ${(err as Error).message}` : `Generation failed: ${(err as Error).message}`);
+    throw new CliExit(1);
+  }
+}
+
 async function runSample(
   args: SampleArgs,
   flags: SampleFlags,
   lang: CliLang,
 ): Promise<void> {
+  if (flags['from-traces']) {
+    await runSampleFromTraces(flags, lang);
+    return;
+  }
   if (flags.fix) {
     await runSampleFix(args, flags, lang);
     return;
@@ -532,6 +587,19 @@ export default class Sample extends BaseCommand {
       description: bilingual({
         zh: '指定 treatment 名（fix 模式用），默认推断自 skill 路径。',
         en: 'Treatment name (fix mode), defaults to skill-path inference.',
+      }),
+    }),
+    'from-traces': Flags.boolean({
+      description: bilingual({
+        zh: 'from-traces 模式：从 observe inbox 的失败信号回流生成回归用例草稿（provenance: production-trace），落草稿待人工 review。',
+        en: 'from-traces mode: recycle observe-inbox failure signals into draft regression samples (provenance: production-trace) for review.',
+      }),
+      default: false,
+    }),
+    'observations-dir': Flags.string({
+      description: bilingual({
+        zh: 'observe inbox 目录（from-traces 模式用），默认项目 .omk/observations。',
+        en: 'Observe inbox dir (from-traces mode), default project .omk/observations.',
       }),
     }),
   };

--- a/src/cli/lib/cmd-flags.ts
+++ b/src/cli/lib/cmd-flags.ts
@@ -166,6 +166,8 @@ export interface SampleFlags {
   fix: boolean;
   'reports-dir'?: string;
   treatment?: string;
+  'from-traces': boolean;
+  'observations-dir'?: string;
 }
 
 // ── eval gold(3 sub-sub) ─────────────────────────────────────────────────────

--- a/test/authoring/generator.test.ts
+++ b/test/authoring/generator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { generateSamples, sanitizeGeneratedSamples, buildSamplesPrompt } from '../../src/authoring/generator.js';
+import { generateSamples, generateSamplesFromTraces, buildSamplesFromTracesPrompt, sanitizeGeneratedSamples, buildSamplesPrompt } from '../../src/authoring/generator.js';
 import type { Sample } from '../../src/types/index.js';
 
 describe('generateSamples', () => {
@@ -13,6 +13,55 @@ describe('generateSamples', () => {
       () => generateSamples({ skillContent: 'test', count: 1, executorName: 'nonexistent' }),
       /ENOENT|failed/,
     );
+  });
+});
+
+describe('buildSamplesFromTracesPrompt', () => {
+  const items = [
+    {
+      skillName: 'prd', signalType: 'failed_search', signalSubtype: 'no_results', severity: 'high', occurrences: 3,
+      evidence: { tool: 'Grep', query: 'auth flow', outputSnippet: 'No matches found' },
+      messageWindow: { before: [], event: [{ role: 'assistant', snippet: 'searching the repo...', messageIndex: 1 }], after: [], resolutionAfter: 'unresolved' },
+    },
+    {
+      skillName: 'prd', signalType: 'hedging', signalSubtype: 'uncertain', severity: 'medium', occurrences: 1,
+      evidence: {},
+    },
+  ] as unknown as Parameters<typeof buildSamplesFromTracesPrompt>[0];
+
+  it('renders each signal with its evidence, skill, and message window', () => {
+    const prompt = buildSamplesFromTracesPrompt(items);
+    assert.match(prompt, /信号 1/);
+    assert.match(prompt, /信号 2/);
+    assert.match(prompt, /failed_search/);
+    assert.match(prompt, /Grep/);
+    assert.match(prompt, /auth flow/);
+    assert.match(prompt, /searching the repo/);
+    assert.match(prompt, /skill: prd/);
+  });
+
+  it('frames the input as production traces, not a skill', () => {
+    const prompt = buildSamplesFromTracesPrompt(items);
+    assert.match(prompt, /trace/);
+    assert.match(prompt, /生产会话/);
+    assert.match(prompt, /不是 skill/);
+  });
+
+  it('falls back gracefully when a signal has no structured evidence', () => {
+    const prompt = buildSamplesFromTracesPrompt(items);
+    assert.match(prompt, /\(无结构化证据\)/);
+  });
+
+  it('honors an explicit count, else instructs 1-2 per signal', () => {
+    assert.match(buildSamplesFromTracesPrompt(items, 8), /共生成约 8 条/);
+    assert.match(buildSamplesFromTracesPrompt(items), /每个信号 1-2 条/);
+  });
+});
+
+describe('generateSamplesFromTraces', () => {
+  it('returns empty without invoking an executor when there are no signals', async () => {
+    const r = await generateSamplesFromTraces({ items: [] });
+    assert.deepEqual(r, { samples: [], costUSD: 0 });
   });
 });
 

--- a/test/authoring/generator.test.ts
+++ b/test/authoring/generator.test.ts
@@ -59,9 +59,33 @@ describe('buildSamplesFromTracesPrompt', () => {
 });
 
 describe('generateSamplesFromTraces', () => {
+  const oneItem = [{
+    skillName: 'prd', signalType: 'failed_search', signalSubtype: 'no_results', severity: 'high', occurrences: 1,
+    evidence: { tool: 'Grep', query: 'x' },
+  }] as unknown as Parameters<typeof generateSamplesFromTraces>[0]['items'];
+
+  const mockExec = (output: string): NonNullable<Parameters<typeof generateSamplesFromTraces>[0]['executor']> =>
+    (async () => ({ ok: true, output, costUSD: 0.01 })) as unknown as NonNullable<Parameters<typeof generateSamplesFromTraces>[0]['executor']>;
+
   it('returns empty without invoking an executor when there are no signals', async () => {
     const r = await generateSamplesFromTraces({ items: [] });
     assert.deepEqual(r, { samples: [], costUSD: 0 });
+  });
+
+  it('treats an empty array from the model as a valid 0-result, not a failure', async () => {
+    // The prompt tells the model to skip noise / unreproducible signals; `[]` is then a
+    // legitimate conservative outcome and must not throw or retry-to-failure.
+    const r = await generateSamplesFromTraces({ items: oneItem, executor: mockExec('[]') });
+    assert.deepEqual(r.samples, []);
+  });
+
+  it('stamps production-trace provenance on generated samples', async () => {
+    const r = await generateSamplesFromTraces({
+      items: oneItem,
+      executor: mockExec(JSON.stringify([{ sample_id: 'trace-1', prompt: 'reproduce the failed search for x', rubric: 'should locate the file' }])),
+    });
+    assert.ok(r.samples.length >= 1);
+    assert.ok(r.samples.every((s) => s.provenance === 'production-trace'));
   });
 });
 


### PR DESCRIPTION
## 背景

omk 三阶段闭环里 observe→eval 一直缺最后一根线：observe inbox 已经产出带 severity / evidence / messageWindow 的结构化失败信号，但没有 producer 把它们变回评测用例。这个 PR 补上闭环——线上真实发生过的失败可以直接沉淀成防回归用例（对标 LangSmith 的 trace→dataset）。

## 改了什么

新增 sample 第四种模式 `omk sample --from-traces`（与 batch / single / fix 并列）：

- 读 observe inbox（`--observations-dir`，默认项目 `.omk/observations`）的失败信号。
- 把每个信号的 evidence + messageWindow 渲染进生成 prompt，复用 generator 的 `SYSTEM_PROMPT` + `finalizeSamples` 校验链，让 LLM 合成能复现这些失败的回归用例。
- 产物强制盖 `provenance: production-trace`，落独立草稿文件 `<dir>/sample-drafts.json`（已存在则拒绝覆盖）。

## 用户影响

跑过 `omk observe` 后，`omk sample --from-traces` 会把 inbox 里的失败信号变成草稿用例，CLI 明确提示「这是草稿，trace 只抓失败信号有抽样偏差，人工 review 后再合入正式集」。默认不直接进 dataset。

## 测量学 / construct validity

- trace 文本只进**生成器** prompt，**绝不进 judge prompt**——judge-prompt isolation 不动；草稿走与 human / llm-generated 完全相同的打分管道。**无 `BREAKING-COMPARABILITY`。**
- sanitize 上下文用 trace 证据（而非空串）拼成，避免把引用了 trace 里真实工具的合法断言误删。
- 默认草稿 + human-in-the-loop 是刻意的：trace 抽样偏差（只抓失败）若直接进 dataset 会让评测集 construct validity 倾斜；大量 trace 样本还会触发 sample-design-spec 的 LLM-generated 占比警示。

`observe inbox --emit-samples` alias 留 follow-up（本 PR 聚焦 producer 本身）。

承上：这是 omk v0.32 改进审计「observe 阶段补完」的 top-priority 项——把 omk 从「并列三块」推向真闭环。

> 注：本地全量测试唯一失败是 `test/executors/sigint-propagation.test.ts` 的一个 macOS 进程信号时序 flake，在 clean main 上同样复现，与本 PR 无关（未触碰任何 executor 代码）。