### PR TITLE
chore(release): 发布 0.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
发布 0.33.0,汇总 v0.32.0 以来合并的五项改进(均为「信号已算好、补接进决策出口」)。

## 用户影响

- **评测可信度护栏(observe)** — observe 健康度按样本量分三档置信度(high / low / underpowered)。段数过少时色带、稳定率、盲区不再下硬红 / 硬绿结论,Studio 列表 / 详情、CLI 日报、`/analyses` 列表、insights 严重度统一弱化为「样本不足,仅供参考」。
- **评委 ensemble 分歧降级 verdict** — 多评委强烈分歧(最差 Pearson 偏低)时,PROGRESS 降级为 CAUTIOUS,避免「评委自己都不一致」时给出乐观判定。
- **evolve 防 train-on-test** — `omk evolve` 加 `--holdout-ratio` 切分,accept 决策看验收集分数,避免在用来迭代的同一批用例上「自我验证」。
- **production-trace → eval 回流** — 新增 `omk sample --from-traces`,把 observe 抓到的真实失败信号转成回归用例草稿,补上 observe→eval 的闭环。
- **statistical-rigor 文档对齐 + 漂移门禁** — bootstrap 默认值文档与代码对齐(实为 1000),新增 doc-vs-code 常量一致性测试,纳入「文档跟不上代码」防线。

## 迁移说明(BREAKING-COMPARABILITY ×2)

两项动了跨版本可比性锚点,跨 0.33.0 前后的报告需谨慎对比:

- **#172 评委 ensemble 分歧降级**:同一批数据在分歧场景下的 verdict 可能从 PROGRESS 变为 CAUTIOUS。要复现旧判定,需对照单评委 / 高一致性场景。
- **#175 observe 置信度护栏**:低样本量 skill 的 observe 健康带从硬色带改为「样本不足」中性态,`runtimeAssessment` / 健康分口径变化。旧 JSON 报告按 `segmentCount` 兜底推断置信度,不会渲染 `undefined`。

非可比性变更(features / docs / 依赖)走常规 minor。

合并的 PR:#171 #172 #173 #174 #175(+ #170 文档对齐、依赖 bump)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
