### PR TITLE
feat(cli): 升级提示加落盘缓存与节流，TTY 下高亮框展示

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ omk eval --control code-review-v1 --treatment code-review-v2
 
 That's it — no editing required. `omk init` scaffolds two skill variants and three sample cases; `omk eval` runs the controlled A/B and opens an HTML report with a one-line verdict in about five minutes.
 
+> The CLI notifies you when a newer version is available (at most once per 20h); set `OMK_SKIP_UPDATE_CHECK=1` to silence it permanently.
+
 Walkthrough: [5-minute quickstart guide](docs/quickstart-skill-eval.md) (recommended for first-time users).
 
 Deeper: [CLI reference](docs/reference/cli.md) · [how it works](docs/explanation/architecture.md) · [eval sample format](docs/reference/eval-sample-format.md) · [executors & artifact layout](docs/reference/executors.md)

--- a/README.zh.md
+++ b/README.zh.md
@@ -23,6 +23,8 @@ omk eval --control code-review-v1 --treatment code-review-v2
 
 不用改任何文件 —— `omk init` 帮你脚手架两版 skill 和三条评测用例；`omk eval` 跑控制变量 A/B，5 分钟内出 HTML 报告 + 一行 verdict。
 
+> 命令行有新版本时会自动提示（每 20 小时最多一次）；想永久关闭该提醒，设环境变量 `OMK_SKIP_UPDATE_CHECK=1` 即可。
+
 手把手教程：[5 分钟快速上手](docs/zh/quickstart-skill-eval.md)（推荐第一次跑评测的用户）。
 
 深入：[CLI 参考](docs/zh/reference/cli.md) · [工作原理](docs/zh/explanation/architecture.md) · [评测样本格式](docs/zh/reference/eval-sample-format.md) · [执行器与 artifact 布局](docs/zh/reference/executors.md)

--- a/src/cli/lib/i18n-dict/common.ts
+++ b/src/cli/lib/i18n-dict/common.ts
@@ -11,6 +11,10 @@ export type CommonMessageKey =
   | 'cli.common.judge_models_single_only'
   | 'cli.common.warn_load_samples_failed'
   | 'cli.update.new_version_available'
+  | 'cli.update.box_title'
+  | 'cli.update.box_version_line'
+  | 'cli.update.box_upgrade_line'
+  | 'cli.update.box_silence_line'
   | 'cli.observe.view_hint'
   | 'cli.studio.started'
   | 'cli.studio.stop_hint'
@@ -56,8 +60,24 @@ export const commonDict: Record<CommonMessageKey, CliMessage> = {
     en: '⚠ Failed to load samples file ({path}): {message}\n',
   },
   'cli.update.new_version_available': {
-    zh: '\n💡 新版本可用: {old} → {new}, 运行 npm update {pkg} -g 升级\n\n',
-    en: '\n💡 New version available: {old} → {new}, run npm update {pkg} -g to upgrade\n\n',
+    zh: '\n💡 新版本可用：{old} → {new}，运行 npm i -g oh-my-knowledge@latest 升级\n\n',
+    en: '\n💡 New version available: {old} → {new}, run npm i -g oh-my-knowledge@latest to upgrade\n\n',
+  },
+  'cli.update.box_title': {
+    zh: '↑ omk 有新版本',
+    en: '↑ omk update available',
+  },
+  'cli.update.box_version_line': {
+    zh: '当前 {old} → 最新 {new}',
+    en: 'current {old} → latest {new}',
+  },
+  'cli.update.box_upgrade_line': {
+    zh: '升级：{cmd}',
+    en: 'Upgrade: {cmd}',
+  },
+  'cli.update.box_silence_line': {
+    zh: '静默：设 {env} 关闭提醒',
+    en: 'Silence: set {env} to disable',
   },
   'cli.observe.view_hint': {
     zh: '分析 JSON 已写入 output-dir；后续可用 omk observe 持续生成日报。',

--- a/src/cli/lib/update-check.ts
+++ b/src/cli/lib/update-check.ts
@@ -68,9 +68,10 @@ const UPDATE_WINDOW_MS = 20 * 3600_000;
 
 /** 落盘缓存。展示只读它(热路径零网络);registry 抓取在后台写它,供下次运行用。 */
 export interface UpdateCache {
-  /** 上次抓到的 registry latest 版本。 */
-  latestVersion: string;
-  /** 上次抓取时间(ISO),用于 20h 重抓节流。 */
+  /** 上次抓到的 registry latest 版本。后台抓取成功才有;只发起过、还没成功时缺位。 */
+  latestVersion?: string;
+  /** 上次「发起检查」的时间(ISO)—— 成功失败都更新,是 20h 重抓节流的锚点。
+   *  父进程在 spawn 刷新前就写它,这样 registry 不通时也不会每条命令都重新拉起后台检查。 */
   lastCheckedAt: string;
   /** 上次提示过的版本,用于「同版本 20h 内不重复提示」。 */
   lastNotifiedVersion?: string;
@@ -97,18 +98,20 @@ export function defaultCachePath(home: string = homedir()): string {
   return join(home, '.oh-my-knowledge', 'update-check.json');
 }
 
-/** 读缓存。缺失 / 损坏 / 非对象一律返回 null,调用方按「无缓存」处理。 */
+/** 读缓存。缺失 / 损坏 / 非对象 / 缺时间锚点一律返回 null,调用方按「无缓存」处理。
+ *  lastCheckedAt(节流锚点)必须有;latestVersion 可缺(只发起过、还没抓成功的记录)。 */
 export function readCache(path: string): UpdateCache | null {
   try {
     const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
     const obj = parsed as Record<string, unknown>;
-    if (typeof obj.latestVersion !== 'string' || typeof obj.lastCheckedAt !== 'string') return null;
+    if (typeof obj.lastCheckedAt !== 'string') return null;
+    const str = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
     return {
-      latestVersion: obj.latestVersion,
+      latestVersion: str(obj.latestVersion),
       lastCheckedAt: obj.lastCheckedAt,
-      lastNotifiedVersion: typeof obj.lastNotifiedVersion === 'string' ? obj.lastNotifiedVersion : undefined,
-      lastNotifiedAt: typeof obj.lastNotifiedAt === 'string' ? obj.lastNotifiedAt : undefined,
+      lastNotifiedVersion: str(obj.lastNotifiedVersion),
+      lastNotifiedAt: str(obj.lastNotifiedAt),
     };
   } catch {
     return null;
@@ -136,7 +139,7 @@ export function shouldNotify(
   now: Date,
   throttleMs: number = UPDATE_WINDOW_MS,
 ): boolean {
-  if (!cache || !isSemverGt(cache.latestVersion, currentVersion)) return false;
+  if (!cache?.latestVersion || !isSemverGt(cache.latestVersion, currentVersion)) return false;
   if (cache.lastNotifiedVersion !== cache.latestVersion) return true;
   if (!cache.lastNotifiedAt) return true;
   const last = Date.parse(cache.lastNotifiedAt);
@@ -150,6 +153,32 @@ export function isStale(cache: UpdateCache | null, now: Date, ttlMs: number = UP
   const last = Date.parse(cache.lastCheckedAt);
   if (Number.isNaN(last)) return true;
   return now.getTime() - last > ttlMs;
+}
+
+/** 一次运行该做什么(纯函数,now 注入,便于确定性测试):
+ *  - notify:是否展示提示(仅凭缓存,无网络)。
+ *  - refresh:是否发起后台刷新。
+ *  - nextCache:需要落盘的新缓存,null 表示无需写。
+ *
+ *  关键:refresh 为真时,nextCache 一定带上 `lastCheckedAt = now` —— 即「发起检查」这件事本身
+ *  会立即落盘,所以 registry 持续不通时,下一次运行看到新鲜的 lastCheckedAt 就不再重复 spawn,
+ *  20h 节流对离线/失败同样生效(不退化成每条命令拉起后台检查)。 */
+export function planUpdateActions(cache: UpdateCache | null, currentVersion: string, now: Date): {
+  notify: boolean;
+  refresh: boolean;
+  nextCache: UpdateCache | null;
+} {
+  const nowIso = now.toISOString();
+  const notify = shouldNotify(cache, currentVersion, now);
+  const refresh = isStale(cache, now);
+  let nextCache: UpdateCache | null = null;
+  if (notify && cache) {
+    nextCache = { ...cache, lastNotifiedVersion: cache.latestVersion, lastNotifiedAt: nowIso };
+  }
+  if (refresh) {
+    nextCache = { ...(nextCache ?? cache ?? {}), lastCheckedAt: nowIso };
+  }
+  return { notify, refresh, nextCache };
 }
 
 /** 终端可视宽度:全角 / CJK codepoint 计 2,其余计 1。用 [...str] 逐 codepoint
@@ -271,10 +300,10 @@ export async function checkUpdate(lang: CliLang): Promise<void> {
     if (!pkg) return;
     const path = defaultCachePath();
     const cache = readCache(path);
-    const now = new Date();
+    const plan = planUpdateActions(cache, pkg.version, new Date());
 
     // 展示:仅凭缓存,无网络
-    if (shouldNotify(cache, pkg.version, now) && cache) {
+    if (plan.notify && cache?.latestVersion) {
       const parts: BoxParts = {
         current: pkg.version,
         latest: cache.latestVersion,
@@ -282,13 +311,11 @@ export async function checkUpdate(lang: CliLang): Promise<void> {
         silenceHint: 'OMK_SKIP_UPDATE_CHECK=1',
       };
       process.stderr.write(renderNotice(parts, pkg.name, lang, process.stderr.isTTY === true));
-      writeCache(path, { ...cache, lastNotifiedVersion: cache.latestVersion, lastNotifiedAt: now.toISOString() });
     }
 
-    // 抓取:后台,供下次运行
-    if (isStale(cache, now)) {
-      fetchAndStore(path, pkg);
-    }
+    // 先把「发起检查」落盘(节流锚点),再 spawn 后台刷新 —— 失败/离线也不会每条命令重来
+    if (plan.nextCache) writeCache(path, plan.nextCache);
+    if (plan.refresh) fetchAndStore(path, pkg);
   } catch {
     /* 静默失败,不影响正常使用 */
   }

--- a/src/cli/lib/update-check.ts
+++ b/src/cli/lib/update-check.ts
@@ -1,3 +1,7 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { tCli, type CliLang } from './i18n.js';
 
 /** 严格按 SemVer 2.0 precedence 判断 `a > b`(只覆盖本仓库实际使用的形态:
@@ -57,38 +61,231 @@ function shouldSkipUpdateCheck(): boolean {
   return false;
 }
 
+/** 统一的 20h 时间窗,两处共用:同一新版本最多提示一次的节流窗口、registry 重抓的过期窗口。
+ *  够长,高频命令下既不反复打网络也不反复 nag;又短于一天,用户隔天能再被提醒一次。 */
+const UPDATE_WINDOW_MS = 20 * 3600_000;
+
+/** 落盘缓存。展示只读它(热路径零网络);registry 抓取在后台写它,供下次运行用。 */
+export interface UpdateCache {
+  /** 上次抓到的 registry latest 版本。 */
+  latestVersion: string;
+  /** 上次抓取时间(ISO),用于 20h 重抓节流。 */
+  lastCheckedAt: string;
+  /** 上次提示过的版本,用于「同版本 20h 内不重复提示」。 */
+  lastNotifiedVersion?: string;
+  /** 上次提示时间(ISO)。 */
+  lastNotifiedAt?: string;
+}
+
+interface LocalPkg {
+  name: string;
+  version: string;
+  registry: string;
+}
+
+interface BoxParts {
+  current: string;
+  latest: string;
+  upgradeCmd: string;
+  silenceHint: string;
+}
+
+/** 缓存落盘走仓库既有约定 `~/.oh-my-knowledge/<...>`(见 src/eval-core/cache.ts、
+ *  src/server/job-store.ts)。home 可注入,方便测试传 tmp 目录。 */
+export function defaultCachePath(home: string = homedir()): string {
+  return join(home, '.oh-my-knowledge', 'update-check.json');
+}
+
+/** 读缓存。缺失 / 损坏 / 非对象一律返回 null,调用方按「无缓存」处理。 */
+export function readCache(path: string): UpdateCache | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj.latestVersion !== 'string' || typeof obj.lastCheckedAt !== 'string') return null;
+    return {
+      latestVersion: obj.latestVersion,
+      lastCheckedAt: obj.lastCheckedAt,
+      lastNotifiedVersion: typeof obj.lastNotifiedVersion === 'string' ? obj.lastNotifiedVersion : undefined,
+      lastNotifiedAt: typeof obj.lastNotifiedAt === 'string' ? obj.lastNotifiedAt : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** 原子写(temp + rename),避免两个 omk 进程并发写出半截 JSON。homedir 不可写时
+ *  整体静默失败 — 退化为「每次后台重抓」,不崩。 */
+export function writeCache(path: string, data: UpdateCache): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(data, null, 2));
+    renameSync(tmp, path);
+  } catch {
+    /* 静默:缓存是装饰性状态,写不进去不影响功能 */
+  }
+}
+
+/** 是否该提示:有缓存的 latest 严格高于当前版本,且(没提示过这个版本 / 距上次提示超 20h)。
+ *  纯函数,now 外部注入,便于确定性测试。 */
+export function shouldNotify(
+  cache: UpdateCache | null,
+  currentVersion: string,
+  now: Date,
+  throttleMs: number = UPDATE_WINDOW_MS,
+): boolean {
+  if (!cache || !isSemverGt(cache.latestVersion, currentVersion)) return false;
+  if (cache.lastNotifiedVersion !== cache.latestVersion) return true;
+  if (!cache.lastNotifiedAt) return true;
+  const last = Date.parse(cache.lastNotifiedAt);
+  if (Number.isNaN(last)) return true;
+  return now.getTime() - last > throttleMs;
+}
+
+/** 缓存是否过期(需后台重抓):无缓存 / 时间戳缺失或不可解析 / 超 ttl。 */
+export function isStale(cache: UpdateCache | null, now: Date, ttlMs: number = UPDATE_WINDOW_MS): boolean {
+  if (!cache?.lastCheckedAt) return true;
+  const last = Date.parse(cache.lastCheckedAt);
+  if (Number.isNaN(last)) return true;
+  return now.getTime() - last > ttlMs;
+}
+
+/** 终端可视宽度:全角 / CJK codepoint 计 2,其余计 1。用 [...str] 逐 codepoint
+ *  迭代以正确处理代理对。框内只用 width-1 的 ↑(U+2191)/→(U+2192),不放 emoji,
+ *  避免 emoji 宽度歧义破坏右边框对齐。 */
+export function visualWidth(str: string): number {
+  let width = 0;
+  for (const ch of str) {
+    const cp = ch.codePointAt(0) ?? 0;
+    width += isWideCodePoint(cp) ? 2 : 1;
+  }
+  return width;
+}
+
+function isWideCodePoint(cp: number): boolean {
+  return (
+    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+    (cp >= 0x2e80 && cp <= 0xa4cf) || // CJK 部首 … 彝文;含 CJK 标点(3000-303F「。、」)与统一表意(4E00-9FFF)
+    (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul 音节
+    (cp >= 0xf900 && cp <= 0xfaff) || // CJK 兼容表意
+    (cp >= 0xfe30 && cp <= 0xfe4f) || // CJK 兼容形式
+    (cp >= 0xff00 && cp <= 0xff60) || // 全角 ASCII / 标点
+    (cp >= 0xffe0 && cp <= 0xffe6) // 全角符号
+  );
+}
+
+/** 右补空格到目标可视宽度(已超宽则原样返回)。 */
+export function padToWidth(str: string, target: number): string {
+  const pad = target - visualWidth(str);
+  return pad > 0 ? str + ' '.repeat(pad) : str;
+}
+
+/** 渲染多行高亮边框(纯函数,可快照测试)。内宽取各行最大可视宽度,逐行用
+ *  padToWidth 对齐后画 ┌┐└┘─│ 框,返回前后留白、以 \n 结尾的整串。 */
+export function renderUpdateBox(parts: BoxParts, lang: CliLang): string {
+  const lines = [
+    tCli('cli.update.box_title', lang),
+    tCli('cli.update.box_version_line', lang, { old: parts.current, new: parts.latest }),
+    tCli('cli.update.box_upgrade_line', lang, { cmd: parts.upgradeCmd }),
+    tCli('cli.update.box_silence_line', lang, { env: parts.silenceHint }),
+  ];
+  const inner = Math.max(...lines.map(visualWidth));
+  const top = `┌${'─'.repeat(inner + 2)}┐`;
+  const bottom = `└${'─'.repeat(inner + 2)}┘`;
+  const body = lines.map((l) => `│ ${padToWidth(l, inner)} │`);
+  return `\n${[top, ...body, bottom].join('\n')}\n\n`;
+}
+
+/** 选染提示文案:TTY 下多行高亮框,管道 / 非 TTY 退回单行(不污染输出)。纯函数,
+ *  isTty 注入便于测试两条分支。 */
+export function renderNotice(parts: BoxParts, pkgName: string, lang: CliLang, isTty: boolean): string {
+  if (isTty) return renderUpdateBox(parts, lang);
+  return tCli('cli.update.new_version_available', lang, {
+    old: parts.current,
+    new: parts.latest,
+    pkg: pkgName,
+  });
+}
+
+/** 从当前文件位置向上找 package.json:dev 跑 src/cli/lib/ 时 3 层到根,
+ *  装到 npm 跑 dist/cli/lib/ 时 3 层到 oh-my-knowledge/。5 次给点 buffer。 */
+function readLocalPkg(): LocalPkg | null {
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let i = 0; i < 5; i++) {
+      const candidate = join(dir, 'package.json');
+      if (existsSync(candidate)) {
+        const pkg: { name?: string; version?: string; publishConfig?: { registry?: string } } = JSON.parse(
+          readFileSync(candidate, 'utf-8'),
+        );
+        if (!pkg.name || !pkg.version) return null;
+        return {
+          name: pkg.name,
+          version: pkg.version,
+          registry: pkg.publishConfig?.registry || 'https://registry.npmjs.org',
+        };
+      }
+      dir = dirname(dir);
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+/** 后台抓 registry latest 写回缓存,供下次运行展示用。fire-and-forget,绝不 await、
+ *  绝不写 stderr/stdout。内层 try/catch 覆盖 fetch/timeout/parse/disk,detached
+ *  promise 必 resolve,不会冒 unhandledRejection。 */
+function fetchAndStore(path: string, pkg: LocalPkg): void {
+  void (async () => {
+    try {
+      const res = await fetch(`${pkg.registry}/${pkg.name}/latest`, { signal: AbortSignal.timeout(3000) });
+      if (!res.ok) return;
+      const data = (await res.json()) as { version?: string };
+      if (!data.version) return;
+      const prev = readCache(path); // 重读以保留 notify 字段,别覆盖展示侧刚写的节流状态
+      writeCache(path, {
+        latestVersion: data.version,
+        lastCheckedAt: new Date().toISOString(),
+        lastNotifiedVersion: prev?.lastNotifiedVersion,
+        lastNotifiedAt: prev?.lastNotifiedAt,
+      });
+    } catch {
+      /* 静默:网络 / 超时 / 解析 / 磁盘任一失败都不影响正常使用 */
+    }
+  })();
+}
+
+/** 升级提示:展示与抓取解耦。本次运行只读缓存即时决定是否提示(热路径零网络);
+ *  缓存过期时后台抓一次写回,供下次用。首次运行(无缓存)不提示。全程 fail-silent,
+ *  由 index.ts 在非短路径下 fire-and-forget 调用。 */
 export async function checkUpdate(lang: CliLang): Promise<void> {
   if (shouldSkipUpdateCheck()) return;
   try {
-    const { readFileSync, existsSync } = await import('node:fs');
-    const { fileURLToPath } = await import('node:url');
-    const { dirname, join } = await import('node:path');
-    const __dirname: string = dirname(fileURLToPath(import.meta.url));
-    // 从当前文件位置向上找 package.json:dev 跑 src/cli/lib/ 时 3 层到根,
-    // 装到 npm 跑 dist/cli/lib/ 时 3 层到 oh-my-knowledge/。5 次给点 buffer。
-    const findPackageJson = (startDir: string): string | null => {
-      let dir = startDir;
-      for (let i = 0; i < 5; i++) {
-        const candidate = join(dir, 'package.json');
-        if (existsSync(candidate)) return candidate;
-        dir = dirname(dir);
-      }
-      return null;
-    };
-    const pkgPath = findPackageJson(__dirname);
-    if (!pkgPath) return;
-    const pkg: { name: string; version: string; publishConfig?: { registry?: string } } =
-      JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    const registry: string = pkg.publishConfig?.registry || 'https://registry.npmjs.org';
-    const res: Response = await fetch(`${registry}/${pkg.name}/latest`, { signal: AbortSignal.timeout(3000) });
-    if (!res.ok) return;
-    const data = await res.json() as { version?: string };
-    // 只在 registry 版本 SemVer 严格大于本地版本时提示。早先版本用 `!==`
-    // 比较,本地 dev 跑出 0.32.0-rc 时会被 registry 的 0.31.0「提示降级」。
-    if (data.version && isSemverGt(data.version, pkg.version)) {
-      process.stderr.write(tCli('cli.update.new_version_available', lang, {
-        old: pkg.version, new: data.version, pkg: pkg.name,
-      }));
+    const pkg = readLocalPkg();
+    if (!pkg) return;
+    const path = defaultCachePath();
+    const cache = readCache(path);
+    const now = new Date();
+
+    // 展示:仅凭缓存,无网络
+    if (shouldNotify(cache, pkg.version, now) && cache) {
+      const parts: BoxParts = {
+        current: pkg.version,
+        latest: cache.latestVersion,
+        upgradeCmd: 'npm i -g oh-my-knowledge@latest',
+        silenceHint: 'OMK_SKIP_UPDATE_CHECK=1',
+      };
+      process.stderr.write(renderNotice(parts, pkg.name, lang, process.stderr.isTTY === true));
+      writeCache(path, { ...cache, lastNotifiedVersion: cache.latestVersion, lastNotifiedAt: now.toISOString() });
     }
-  } catch { /* 静默失败,不影响正常使用 */ }
+
+    // 抓取:后台,供下次运行
+    if (isStale(cache, now)) {
+      fetchAndStore(path, pkg);
+    }
+  } catch {
+    /* 静默失败,不影响正常使用 */
+  }
 }

--- a/src/cli/lib/update-check.ts
+++ b/src/cli/lib/update-check.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -223,7 +224,8 @@ function readLocalPkg(): LocalPkg | null {
         return {
           name: pkg.name,
           version: pkg.version,
-          registry: pkg.publishConfig?.registry || 'https://registry.npmjs.org',
+          // 优先用用户实际安装源(npm 从 .npmrc 注入 npm_config_registry),再退 publish 目标,最后兜底官方源
+          registry: process.env.npm_config_registry || pkg.publishConfig?.registry || 'https://registry.npmjs.org',
         };
       }
       dir = dirname(dir);
@@ -234,27 +236,22 @@ function readLocalPkg(): LocalPkg | null {
   return null;
 }
 
-/** 后台抓 registry latest 写回缓存,供下次运行展示用。fire-and-forget,绝不 await、
- *  绝不写 stderr/stdout。内层 try/catch 覆盖 fetch/timeout/parse/disk,detached
- *  promise 必 resolve,不会冒 unhandledRejection。 */
+/** 后台刷新:spawn 一个 detached + unref 的子进程去抓 registry latest 写回缓存,跟父进程
+ *  生命周期解耦 —— native fetch 的网络 handle 会让进程存活到请求完成 / 3s abort,留在父进程里
+ *  会拖住快命令的退出;丢给独立子进程后,父进程发完 spawn 立即返回、可正常退出,热路径零网络。
+ *  worker 只在编译产物(dist/cli/lib/)里有 `.js`;dev 直接跑源码时不存在,existsSync 兜底跳过。 */
 function fetchAndStore(path: string, pkg: LocalPkg): void {
-  void (async () => {
-    try {
-      const res = await fetch(`${pkg.registry}/${pkg.name}/latest`, { signal: AbortSignal.timeout(3000) });
-      if (!res.ok) return;
-      const data = (await res.json()) as { version?: string };
-      if (!data.version) return;
-      const prev = readCache(path); // 重读以保留 notify 字段,别覆盖展示侧刚写的节流状态
-      writeCache(path, {
-        latestVersion: data.version,
-        lastCheckedAt: new Date().toISOString(),
-        lastNotifiedVersion: prev?.lastNotifiedVersion,
-        lastNotifiedAt: prev?.lastNotifiedAt,
-      });
-    } catch {
-      /* 静默:网络 / 超时 / 解析 / 磁盘任一失败都不影响正常使用 */
-    }
-  })();
+  try {
+    const worker = join(dirname(fileURLToPath(import.meta.url)), 'update-fetch-worker.js');
+    if (!existsSync(worker)) return;
+    const child = spawn(process.execPath, [worker, path, pkg.registry, pkg.name], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+  } catch {
+    /* 静默:spawn 失败不影响正常使用 */
+  }
 }
 
 /** 升级提示:展示与抓取解耦。本次运行只读缓存即时决定是否提示(热路径零网络);

--- a/src/cli/lib/update-check.ts
+++ b/src/cli/lib/update-check.ts
@@ -244,14 +244,21 @@ function fetchAndStore(path: string, pkg: LocalPkg): void {
   try {
     const worker = join(dirname(fileURLToPath(import.meta.url)), 'update-fetch-worker.js');
     if (!existsSync(worker)) return;
-    const child = spawn(process.execPath, [worker, path, pkg.registry, pkg.name], {
-      detached: true,
-      stdio: 'ignore',
-    });
-    child.unref();
+    spawnDetached(worker, [path, pkg.registry, pkg.name]);
   } catch {
-    /* 静默:spawn 失败不影响正常使用 */
+    /* 静默:spawn 同步抛错(罕见)不影响正常使用 */
   }
+}
+
+/** spawn 一个 detached + unref 的子进程跑 worker。子进程启动失败(ENOENT / EACCES /
+ *  EAGAIN)是异步 `error` 事件 —— 不挂 listener 的话 Node 会当 uncaught exception 抛出、
+ *  反过来拖垮主命令,所以必须挂个空 handler 吞掉,维持升级检查全程 fail-silent。 */
+export function spawnDetached(scriptPath: string, args: string[]): void {
+  const child = spawn(process.execPath, [scriptPath, ...args], { detached: true, stdio: 'ignore' });
+  child.on('error', () => {
+    /* 静默:子进程起不来不影响主命令 */
+  });
+  child.unref();
 }
 
 /** 升级提示:展示与抓取解耦。本次运行只读缓存即时决定是否提示(热路径零网络);

--- a/src/cli/lib/update-fetch-worker.ts
+++ b/src/cli/lib/update-fetch-worker.ts
@@ -1,0 +1,32 @@
+/**
+ * 升级检查的后台刷新 worker。由 update-check.ts 的 fetchAndStore 以 detached + unref
+ * spawn,独立于父 CLI 进程运行:抓 registry latest 写回 ~/.oh-my-knowledge/update-check.json,
+ * 供下次运行展示用。父进程不等它,所以这里阻塞式 await fetch 没关系。全程 fail-silent。
+ *
+ * argv: [node, update-fetch-worker.js, cachePath, registry, pkgName]
+ */
+import { readCache, writeCache } from './update-check.js';
+
+async function main(): Promise<void> {
+  const [cachePath, registry, name] = process.argv.slice(2);
+  if (!cachePath || !registry || !name) return;
+  try {
+    const res = await fetch(`${registry.replace(/\/$/, '')}/${name}/latest`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) return;
+    const data = (await res.json()) as { version?: string };
+    if (!data.version) return;
+    const prev = readCache(cachePath); // 重读以保留展示侧写的 notify 节流字段,别覆盖
+    writeCache(cachePath, {
+      latestVersion: data.version,
+      lastCheckedAt: new Date().toISOString(),
+      lastNotifiedVersion: prev?.lastNotifiedVersion,
+      lastNotifiedAt: prev?.lastNotifiedAt,
+    });
+  } catch {
+    /* 静默:网络 / 超时 / 解析 / 磁盘任一失败都不影响 */
+  }
+}
+
+void main();

--- a/test/cli/__snapshots__/update-notify.test.ts.snap
+++ b/test/cli/__snapshots__/update-notify.test.ts.snap
@@ -1,0 +1,25 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderUpdateBox > matches snapshot (en) 1`] = `
+"
+┌─────────────────────────────────────────────────┐
+│ ↑ omk update available                          │
+│ current 0.32.0 → latest 0.33.0                  │
+│ Upgrade: npm i -g oh-my-knowledge@latest        │
+│ Silence: set OMK_SKIP_UPDATE_CHECK=1 to disable │
+└─────────────────────────────────────────────────┘
+
+"
+`;
+
+exports[`renderUpdateBox > matches snapshot (zh) 1`] = `
+"
+┌───────────────────────────────────────────┐
+│ ↑ omk 有新版本                            │
+│ 当前 0.32.0 → 最新 0.33.0                 │
+│ 升级：npm i -g oh-my-knowledge@latest     │
+│ 静默：设 OMK_SKIP_UPDATE_CHECK=1 关闭提醒 │
+└───────────────────────────────────────────┘
+
+"
+`;

--- a/test/cli/update-exit-latency.test.ts
+++ b/test/cli/update-exit-latency.test.ts
@@ -1,0 +1,76 @@
+/**
+ * 回归:stale cache 下升级检查的后台刷新不能拖住 CLI 退出。
+ *
+ * 起一个只 accept、永不应答的本地 TCP server 当 registry —— 若刷新走父进程内的 fetch,
+ * 进程会被网络 handle 拖到 3s abort 才退；现在刷新丢给 detached + unref 子进程,父进程发完
+ * spawn 立即返回。用一个非短路径命令(doctor 指向不存在的 skill,快速失败)触发 checkUpdate,
+ * 断言整体退出远早于 3s abort。子进程在后台自行 3s 超时退出,execFileAsync 只等父进程。
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createServer, type Server, type Socket } from 'node:net';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { AddressInfo } from 'node:net';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = join(__dirname, '..', '..', 'dist', 'cli', 'index.js');
+
+const EXIT_BUDGET_MS = 2500; // 远低于 worker 的 3000ms abort;命令本身快速失败,余量挡掉退出被拖的回归
+
+let server: Server;
+let port: number;
+const sockets = new Set<Socket>();
+
+beforeAll(async () => {
+  // 只 accept、不回应:HTTP 请求会一直挂着,直到客户端 abort
+  server = createServer((sock) => {
+    sockets.add(sock);
+    sock.on('close', () => sockets.delete(sock));
+    sock.on('error', () => sockets.delete(sock));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  for (const s of sockets) s.destroy();
+  server.close();
+});
+
+describe('update check background refresh must not delay CLI exit', () => {
+  it(`stale cache + 黑洞 registry 下,非短路径命令仍在 ${EXIT_BUDGET_MS}ms 内退出`, async () => {
+    const home = mkdtempSync(join(tmpdir(), 'omk-exit-'));
+    mkdirSync(join(home, '.oh-my-knowledge'), { recursive: true });
+    // stale(lastCheckedAt 很旧)→ 触发刷新;latestVersion 很低 → 不触发提示,只测退出时延
+    writeFileSync(
+      join(home, '.oh-my-knowledge', 'update-check.json'),
+      JSON.stringify({ latestVersion: '0.0.1', lastCheckedAt: '2020-01-01T00:00:00.000Z' }),
+    );
+
+    const env = { ...process.env, HOME: home, USERPROFILE: home, npm_config_registry: `http://127.0.0.1:${port}/` };
+    delete env.NODE_ENV; // 否则 shouldSkipUpdateCheck 直接跳过,测不到刷新路径
+    delete env.CI;
+    delete env.OMK_SKIP_UPDATE_CHECK;
+
+    const t0 = Date.now();
+    try {
+      // doctor 指向不存在的 skill,快速失败(exit 1);execFileAsync 因非零退出 reject,计时照常
+      await execFileAsync('node', [CLI, 'doctor', join(home, 'no-such-skill'), '--static-only'], { env });
+    } catch {
+      /* 预期非零退出,忽略 */
+    }
+    const ms = Date.now() - t0;
+    rmSync(home, { recursive: true, force: true });
+
+    assert.ok(
+      ms < EXIT_BUDGET_MS,
+      `CLI took ${ms}ms to exit with a stalling registry; expected < ${EXIT_BUDGET_MS}ms (regression: background refresh must be detached, not an in-process fetch holding the event loop)`,
+    );
+  }, 20000);
+});

--- a/test/cli/update-notify.test.ts
+++ b/test/cli/update-notify.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  isStale,
+  padToWidth,
+  readCache,
+  renderNotice,
+  renderUpdateBox,
+  shouldNotify,
+  visualWidth,
+  writeCache,
+  type UpdateCache,
+} from '../../src/cli/lib/update-check.js';
+
+const NOW = new Date('2026-06-01T00:00:00.000Z');
+const hoursAgo = (h: number): string => new Date(NOW.getTime() - h * 3600_000).toISOString();
+
+describe('readCache / writeCache', () => {
+  let dir: string;
+  let path: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'omk-update-'));
+    path = join(dir, 'update-check.json');
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('round-trips a cache object', () => {
+    const data: UpdateCache = {
+      latestVersion: '0.33.0',
+      lastCheckedAt: hoursAgo(1),
+      lastNotifiedVersion: '0.33.0',
+      lastNotifiedAt: hoursAgo(1),
+    };
+    writeCache(path, data);
+    expect(readCache(path)).toEqual(data);
+  });
+
+  it('returns null on missing file', () => {
+    expect(readCache(join(dir, 'nope.json'))).toBeNull();
+  });
+
+  it('returns null on corrupt JSON', () => {
+    writeFileSync(path, '{garbage');
+    expect(readCache(path)).toBeNull();
+  });
+
+  it('returns null on non-object JSON (null / array)', () => {
+    writeFileSync(path, 'null');
+    expect(readCache(path)).toBeNull();
+    writeFileSync(path, '[]');
+    expect(readCache(path)).toBeNull();
+  });
+
+  it('returns null when required fields are missing', () => {
+    writeFileSync(path, JSON.stringify({ latestVersion: '0.33.0' }));
+    expect(readCache(path)).toBeNull();
+  });
+
+  it('leaves no .tmp residue after an atomic write', () => {
+    writeCache(path, { latestVersion: '0.33.0', lastCheckedAt: hoursAgo(1) });
+    const leftover = readdirSync(dir).filter((f) => f.includes('.tmp.'));
+    expect(leftover).toEqual([]);
+  });
+});
+
+describe('shouldNotify', () => {
+  const base = (over: Partial<UpdateCache>): UpdateCache => ({
+    latestVersion: '0.33.0',
+    lastCheckedAt: hoursAgo(1),
+    ...over,
+  });
+
+  it('false when cache is null', () => {
+    expect(shouldNotify(null, '0.32.0', NOW)).toBe(false);
+  });
+
+  it('false when latest equals current', () => {
+    expect(shouldNotify(base({}), '0.33.0', NOW)).toBe(false);
+  });
+
+  it('false when latest is older than current (local dev rc)', () => {
+    expect(shouldNotify(base({ latestVersion: '0.31.0' }), '0.32.0-rc.1', NOW)).toBe(false);
+  });
+
+  it('true when newer and never notified', () => {
+    expect(shouldNotify(base({}), '0.32.0', NOW)).toBe(true);
+  });
+
+  it('false when same version notified within throttle window', () => {
+    const cache = base({ lastNotifiedVersion: '0.33.0', lastNotifiedAt: hoursAgo(1) });
+    expect(shouldNotify(cache, '0.32.0', NOW)).toBe(false);
+  });
+
+  it('true when same version was notified past the throttle window', () => {
+    const cache = base({ lastNotifiedVersion: '0.33.0', lastNotifiedAt: hoursAgo(21) });
+    expect(shouldNotify(cache, '0.32.0', NOW)).toBe(true);
+  });
+
+  it('true when a newer version supersedes the last notified one', () => {
+    const cache = base({ lastNotifiedVersion: '0.32.5', lastNotifiedAt: hoursAgo(1) });
+    expect(shouldNotify(cache, '0.32.0', NOW)).toBe(true);
+  });
+});
+
+describe('isStale', () => {
+  it('true when cache is null', () => {
+    expect(isStale(null, NOW)).toBe(true);
+  });
+  it('false when checked 19h ago', () => {
+    expect(isStale({ latestVersion: '0.33.0', lastCheckedAt: hoursAgo(19) }, NOW)).toBe(false);
+  });
+  it('true when checked 21h ago', () => {
+    expect(isStale({ latestVersion: '0.33.0', lastCheckedAt: hoursAgo(21) }, NOW)).toBe(true);
+  });
+  it('true when timestamp is unparseable', () => {
+    expect(isStale({ latestVersion: '0.33.0', lastCheckedAt: 'not-a-date' }, NOW)).toBe(true);
+  });
+});
+
+describe('visualWidth / padToWidth', () => {
+  it('counts ASCII as width 1', () => {
+    expect(visualWidth('abc')).toBe(3);
+  });
+  it('counts CJK as width 2', () => {
+    expect(visualWidth('中文')).toBe(4);
+  });
+  it('counts arrows ↑ → as width 1', () => {
+    expect(visualWidth('↑→')).toBe(2);
+  });
+  it('handles mixed CJK + ASCII', () => {
+    expect(visualWidth('omk 升级')).toBe(4 /* omk_ */ + 4 /* 升级 */);
+  });
+  it('is surrogate-pair safe', () => {
+    expect(visualWidth('a😀b')).toBe(3); // emoji outside wide ranges → 1
+  });
+  it('pads to the target visual width', () => {
+    expect(visualWidth(padToWidth('中', 6))).toBe(6);
+    expect(visualWidth(padToWidth('abc', 6))).toBe(6);
+  });
+  it('leaves over-wide strings untouched', () => {
+    expect(padToWidth('中文', 2)).toBe('中文');
+  });
+});
+
+describe('renderUpdateBox', () => {
+  const parts = {
+    current: '0.32.0',
+    latest: '0.33.0',
+    upgradeCmd: 'npm i -g oh-my-knowledge@latest',
+    silenceHint: 'OMK_SKIP_UPDATE_CHECK=1',
+  };
+
+  it('aligns every body line to equal visual width (right border lines up)', () => {
+    const box = renderUpdateBox(parts, 'zh');
+    const bodyLines = box.split('\n').filter((l) => l.startsWith('│'));
+    expect(bodyLines.length).toBe(4);
+    const widths = new Set(bodyLines.map(visualWidth));
+    expect(widths.size).toBe(1);
+  });
+
+  it('draws box-drawing borders', () => {
+    const box = renderUpdateBox(parts, 'zh');
+    expect(box).toContain('┌');
+    expect(box).toContain('└');
+    expect(box).toContain('│');
+  });
+
+  it('matches snapshot (zh)', () => {
+    expect(renderUpdateBox(parts, 'zh')).toMatchSnapshot();
+  });
+
+  it('matches snapshot (en)', () => {
+    expect(renderUpdateBox(parts, 'en')).toMatchSnapshot();
+  });
+});
+
+describe('renderNotice (TTY vs pipe branch)', () => {
+  const parts = {
+    current: '0.32.0',
+    latest: '0.33.0',
+    upgradeCmd: 'npm i -g oh-my-knowledge@latest',
+    silenceHint: 'OMK_SKIP_UPDATE_CHECK=1',
+  };
+
+  it('renders the multi-line box on a TTY', () => {
+    const out = renderNotice(parts, 'oh-my-knowledge', 'zh', true);
+    expect(out).toContain('┌');
+    expect(out.split('\n').filter((l) => l.startsWith('│')).length).toBe(4);
+  });
+
+  it('falls back to a single line off a TTY (no box chars)', () => {
+    const out = renderNotice(parts, 'oh-my-knowledge', 'zh', false);
+    expect(out).not.toContain('┌');
+    expect(out).not.toContain('│');
+    expect(out.trim().split('\n').length).toBe(1);
+  });
+
+  it('the fallback line carries the new upgrade command (guards the rename)', () => {
+    expect(renderNotice(parts, 'oh-my-knowledge', 'zh', false)).toContain('npm i -g oh-my-knowledge@latest');
+    expect(renderNotice(parts, 'oh-my-knowledge', 'en', false)).toContain('npm i -g oh-my-knowledge@latest');
+  });
+});

--- a/test/cli/update-notify.test.ts
+++ b/test/cli/update-notify.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
 import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawn: spawnMock }));
+
 import {
   isStale,
   padToWidth,
@@ -9,6 +14,7 @@ import {
   renderNotice,
   renderUpdateBox,
   shouldNotify,
+  spawnDetached,
   visualWidth,
   writeCache,
   type UpdateCache,
@@ -200,5 +206,29 @@ describe('renderNotice (TTY vs pipe branch)', () => {
   it('the fallback line carries the new upgrade command (guards the rename)', () => {
     expect(renderNotice(parts, 'oh-my-knowledge', 'zh', false)).toContain('npm i -g oh-my-knowledge@latest');
     expect(renderNotice(parts, 'oh-my-knowledge', 'en', false)).toContain('npm i -g oh-my-knowledge@latest');
+  });
+});
+
+describe('spawnDetached (fail-silent on child startup error)', () => {
+  beforeEach(() => spawnMock.mockReset());
+
+  it('detaches + unrefs the child', () => {
+    const child = Object.assign(new EventEmitter(), { unref: vi.fn() });
+    spawnMock.mockReturnValue(child);
+    spawnDetached('/x/worker.js', ['a', 'b']);
+    expect(spawnMock).toHaveBeenCalledWith(
+      process.execPath,
+      ['/x/worker.js', 'a', 'b'],
+      expect.objectContaining({ detached: true, stdio: 'ignore' }),
+    );
+    expect(child.unref).toHaveBeenCalledOnce();
+  });
+
+  it('swallows the async error event (no listener would throw)', () => {
+    const child = Object.assign(new EventEmitter(), { unref: vi.fn() });
+    spawnMock.mockReturnValue(child);
+    spawnDetached('/x/worker.js', []);
+    // EventEmitter 没有 error listener 时 emit('error') 会同步抛;挂了 handler 才静默
+    expect(() => child.emit('error', Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }))).not.toThrow();
   });
 });

--- a/test/cli/update-notify.test.ts
+++ b/test/cli/update-notify.test.ts
@@ -10,6 +10,7 @@ vi.mock('node:child_process', () => ({ spawn: spawnMock }));
 import {
   isStale,
   padToWidth,
+  planUpdateActions,
   readCache,
   renderNotice,
   renderUpdateBox,
@@ -59,9 +60,20 @@ describe('readCache / writeCache', () => {
     expect(readCache(path)).toBeNull();
   });
 
-  it('returns null when required fields are missing', () => {
+  it('returns null when the time anchor (lastCheckedAt) is missing', () => {
     writeFileSync(path, JSON.stringify({ latestVersion: '0.33.0' }));
     expect(readCache(path)).toBeNull();
+  });
+
+  it('accepts an attempt-only record (lastCheckedAt without latestVersion)', () => {
+    const stamp = hoursAgo(1);
+    writeFileSync(path, JSON.stringify({ lastCheckedAt: stamp }));
+    expect(readCache(path)).toEqual({
+      latestVersion: undefined,
+      lastCheckedAt: stamp,
+      lastNotifiedVersion: undefined,
+      lastNotifiedAt: undefined,
+    });
   });
 
   it('leaves no .tmp residue after an atomic write', () => {
@@ -80,6 +92,10 @@ describe('shouldNotify', () => {
 
   it('false when cache is null', () => {
     expect(shouldNotify(null, '0.32.0', NOW)).toBe(false);
+  });
+
+  it('false for an attempt-only record (no latestVersion yet)', () => {
+    expect(shouldNotify({ lastCheckedAt: hoursAgo(1) }, '0.32.0', NOW)).toBe(false);
   });
 
   it('false when latest equals current', () => {
@@ -122,6 +138,52 @@ describe('isStale', () => {
   });
   it('true when timestamp is unparseable', () => {
     expect(isStale({ latestVersion: '0.33.0', lastCheckedAt: 'not-a-date' }, NOW)).toBe(true);
+  });
+});
+
+describe('planUpdateActions', () => {
+  it('no cache → refresh, and stamps lastCheckedAt now (no notice)', () => {
+    const plan = planUpdateActions(null, '0.32.0', NOW);
+    expect(plan.notify).toBe(false);
+    expect(plan.refresh).toBe(true);
+    expect(plan.nextCache).toEqual({ lastCheckedAt: NOW.toISOString() });
+  });
+
+  it('offline throttle: a second run within 20h does NOT refresh again (spawn once)', () => {
+    // run 1:无缓存 → 发起刷新 + 落盘 attempt 戳
+    const first = planUpdateActions(null, '0.32.0', NOW);
+    expect(first.refresh).toBe(true);
+    // run 2:registry 仍不通(worker 没写成功),缓存只有 attempt 戳;5 分钟后再跑
+    const later = new Date(NOW.getTime() + 5 * 60_000);
+    const second = planUpdateActions(first.nextCache, '0.32.0', later);
+    expect(second.refresh).toBe(false);
+    expect(second.nextCache).toBeNull();
+  });
+
+  it('stale cache + newer version unseen → notify AND refresh, merged into one write', () => {
+    const cache: UpdateCache = { latestVersion: '0.33.0', lastCheckedAt: hoursAgo(25) };
+    const plan = planUpdateActions(cache, '0.32.0', NOW);
+    expect(plan.notify).toBe(true);
+    expect(plan.refresh).toBe(true);
+    expect(plan.nextCache).toEqual({
+      latestVersion: '0.33.0',
+      lastCheckedAt: NOW.toISOString(),
+      lastNotifiedVersion: '0.33.0',
+      lastNotifiedAt: NOW.toISOString(),
+    });
+  });
+
+  it('fresh cache + newer version unseen → notify only, no refresh', () => {
+    const cache: UpdateCache = { latestVersion: '0.33.0', lastCheckedAt: hoursAgo(1) };
+    const plan = planUpdateActions(cache, '0.32.0', NOW);
+    expect(plan.notify).toBe(true);
+    expect(plan.refresh).toBe(false);
+    expect(plan.nextCache).toEqual({
+      latestVersion: '0.33.0',
+      lastCheckedAt: hoursAgo(1),
+      lastNotifiedVersion: '0.33.0',
+      lastNotifiedAt: NOW.toISOString(),
+    });
   });
 });
 


### PR DESCRIPTION
## 这是什么

把 omk CLI 的升级提示从「每条命令实时打一次 npm」改成**落盘缓存 + 后台刷新 + 节流**，并把提示形态升级为 TTY 下的多行高亮边框。notify-only，不做自升级、不识别安装方式。源于和 codex CLI 升级逻辑的对比：codex 的重缓存 + 自升级适配常驻 TUI，omk 作为非交互、可进管道的一次性 CLI 取「轻量档」即可。

## 用户影响

- **不再每条命令打网络**：本次运行只读 `~/.oh-my-knowledge/update-check.json` 即时决定是否提示（热路径零网络）；仅当缓存过期（超 20 小时）才后台抓一次写回，供下次运行用。
- **不再每条命令 nag**：同一新版本最多 20 小时提示一次。永久关闭仍用 `OMK_SKIP_UPDATE_CHECK=1`（提示框内会标出）。
- **提示更醒目**：TTY 下展示多行高亮边框（当前 → 最新版本、升级命令、静默提示）；管道 / 非 TTY 退回单行，不污染 stdout / 管道。
- **升级命令统一**为 `npm i -g oh-my-knowledge@latest`（旧文案是 `npm update -g`），并把既有提示文案的半角标点修为全角（GB/T 15834）。
- **行为变化**：首次运行（无缓存）不再提示，下次起按缓存提示（仿 codex，可接受）。

## 测量学 / 兼容性

纯 CLI 文案与提示行为改动，**不触及任何测量学不变量**（report schema / judge·observe prompt hash / 五层评分 / bootstrap·Krippendorff / length-debias），无 `BREAKING-COMPARABILITY`。未新增 oclif flag / 命令，`build:docs` 无需重生成。

## 构造效度 caveat

「同一版本 20 小时一次」+「首次运行不提示」意味着一个全新且过期的安装，首条提示要到第二次合格运行才出现（缓存先在后台落地）。这是用即时性换「热路径零网络」的刻意取舍。

## 验证

`yarn lint && build && test` 全绿（1705 passed，含新增 helper 单测 + 高亮框 zh/en 快照）。确认 `yarn test` 不写真实 `~/.oh-my-knowledge`、不联网。手动验证：TTY 下高亮框对齐、管道退回单行、`OMK_SKIP_UPDATE_CHECK=1` 完全静默、同版本二次运行被节流。

🤖 Generated with [Claude Code](https://claude.com/claude-code)