### PR TITLE
fix(eval): variant 命名链路完整收口（消歧 + 角色/隔离绑定 + golden + 重构）

### DIFF
--- a/src/cli/lib/parse-run-config/variant-resolution.ts
+++ b/src/cli/lib/parse-run-config/variant-resolution.ts
@@ -9,9 +9,10 @@
  *   - 仅 batch 模式 → 留空,batch workflow 自己生成(baseline vs 每个 skill)
  *   - 都没有 → throw,附带 skill-dir 下候选 variant 提示,引导显式声明
  *
- * 之后做 variant name 唯一性检查 —— 同名 variant 不能同时在 --control 和
- * --treatment,也不能 --treatment 内重复。否则 ensemble agreement / report 字段
- * 都会按 name 去重,跑了但聚不到。
+ * 之后做 variant 唯一性检查 —— 同一个 variant 表达式不能同时在 --control 和
+ * --treatment,也不能 --treatment 内重复。按 expr(而非派生短名)判重:`v1/greeter.md`
+ * 与 `v2/greeter.md` basename 都是 greeter 却是两个不同的 variant,不该被误判成重复;
+ * 它们的最终唯一名由 resolveArtifacts 的 ensureUniqueVariantNames 负责消歧。
  */
 
 import { discoverVariants, variantExprToSkillName } from '../../../inputs/skill-loader.js';
@@ -55,14 +56,15 @@ export function resolveVariantSpecs(
     );
   }
 
-  const seenNames = new Set<string>();
+  const seenExprs = new Set<string>();
   for (const spec of variantSpecs) {
-    if (seenNames.has(spec.name)) {
+    const key = spec.expr.trim();
+    if (seenExprs.has(key)) {
       throw new Error(
-        `variant "${spec.name}" 重复出现——同一 variant 不能同时属于 --control 与 --treatment，也不能在 --treatment 中重复。`,
+        `variant "${spec.expr}" 重复出现——同一 variant 不能同时属于 --control 与 --treatment，也不能在 --treatment 中重复。`,
       );
     }
-    seenNames.add(spec.name);
+    seenExprs.add(key);
   }
 
   return variantSpecs;

--- a/src/cli/lib/parse-run-config/variant-resolution.ts
+++ b/src/cli/lib/parse-run-config/variant-resolution.ts
@@ -9,13 +9,17 @@
  *   - 仅 batch 模式 → 留空,batch workflow 自己生成(baseline vs 每个 skill)
  *   - 都没有 → throw,附带 skill-dir 下候选 variant 提示,引导显式声明
  *
- * 之后做 variant 唯一性检查 —— 同一个 variant 表达式不能同时在 --control 和
- * --treatment,也不能 --treatment 内重复。按 expr(而非派生短名)判重:`v1/greeter.md`
- * 与 `v2/greeter.md` basename 都是 greeter 却是两个不同的 variant,不该被误判成重复;
- * 它们的最终唯一名由 resolveArtifacts 的 ensureUniqueVariantNames 负责消歧。
+ * 之后做 variant 唯一性检查 —— 同一个物理 variant 不能同时在 --control 和
+ * --treatment,也不能 --treatment 内重复。按 `variantIdentity`(规范化后的物理身份,
+ * 路径 resolve、目录与 SKILL.md 折叠、cwd 纳入)判重,而非派生短名,也不是裸 expr 字面量:
+ *   - `v1/greeter.md` 与 `v2/greeter.md` 短名都是 greeter 却是两个 variant —— 不该误判重复,
+ *     最终唯一名由 resolveArtifacts 的 ensureUniqueVariantNames 消歧。
+ *   - `./x.md` 与 `x.md`、`dir` 与 `dir/SKILL.md` 是同一份 skill —— 必须判为重复,
+ *     否则会被解析成两个 artifact 后用 `x` / `x#2` 消歧,变成同一份 skill 自比,
+ *     悄悄废掉「control 不能等于 treatment」的测量保护。
  */
 
-import { discoverVariants, variantExprToSkillName } from '../../../inputs/skill-loader.js';
+import { discoverVariants, variantExprToSkillName, variantIdentity } from '../../../inputs/skill-loader.js';
 import { configVariantsToSpecs } from '../../../inputs/eval-config.js';
 import type { EvalConfig, VariantSpec } from '../../../types/index.js';
 
@@ -56,15 +60,15 @@ export function resolveVariantSpecs(
     );
   }
 
-  const seenExprs = new Set<string>();
+  const seenIdentities = new Set<string>();
   for (const spec of variantSpecs) {
-    const key = spec.expr.trim();
-    if (seenExprs.has(key)) {
+    const key = variantIdentity(spec.expr);
+    if (seenIdentities.has(key)) {
       throw new Error(
         `variant "${spec.expr}" 重复出现——同一 variant 不能同时属于 --control 与 --treatment，也不能在 --treatment 中重复。`,
       );
     }
-    seenExprs.add(key);
+    seenIdentities.add(key);
   }
 
   return variantSpecs;

--- a/src/cli/lib/parse-run-config/variant-resolution.ts
+++ b/src/cli/lib/parse-run-config/variant-resolution.ts
@@ -62,7 +62,7 @@ export function resolveVariantSpecs(
 
   const seenIdentities = new Set<string>();
   for (const spec of variantSpecs) {
-    const key = variantIdentity(spec.expr);
+    const key = variantIdentity(spec.expr, skillDir);
     if (seenIdentities.has(key)) {
       throw new Error(
         `variant "${spec.expr}" 重复出现——同一 variant 不能同时属于 --control 与 --treatment，也不能在 --treatment 中重复。`,

--- a/src/eval-workflows/evaluation-preparation.ts
+++ b/src/eval-workflows/evaluation-preparation.ts
@@ -66,9 +66,12 @@ export async function prepareEvaluationRun({
     variantSpecs.forEach((spec, i) => {
       const artifact = resolvedArtifacts[i];
       if (!artifact.experimentRole) artifact.experimentRole = spec.role;
-      // allowedSkills 按 spec 身份绑定,显式声明优先于 strictBaseline 默认。spec.allowedSkills
-      // 是首选来源(eval.yaml 经 configVariantsToSpecs 带上);旧的按变量名 map 仅作 fallback,
-      // 兜住「CLI roles 覆盖 config 时 spec 不带 allowedSkills」等边角,行为与重构前一致。
+      // allowedSkills 按 spec 身份绑定(eval 主路径的唯一隔离绑定点,显式声明优先于
+      // strictBaseline 默认)。首选 spec.allowedSkills(eval.yaml 经 configVariantsToSpecs 带上);
+      // 旧的按变量名 map 仅作 legacy fallback,兜住「CLI roles 覆盖 config 时 spec 不带
+      // allowedSkills」等边角,行为与重构前一致。
+      // TODO: 待所有路径都按 spec 携带 allowedSkills 后,移除 variantAllowedSkills 这条 fallback,
+      //       与 resolveArtifacts 里的按名绑定一并收成单一来源。
       const explicit = spec.allowedSkills ?? variantAllowedSkills?.[spec.name];
       if (explicit !== undefined) artifact.allowedSkills = explicit;
       spec.name = artifact.name; // 同步唯一名,让 spec 与 report / variantNames 一致(放最后,前面还要用旧名查)

--- a/src/eval-workflows/evaluation-preparation.ts
+++ b/src/eval-workflows/evaluation-preparation.ts
@@ -52,13 +52,27 @@ export async function prepareEvaluationRun({
     { strictBaseline, variantAllowedSkills },
   );
 
-  // Attach experimentRole to each artifact by matching spec.name to artifact.name.
-  const roleByName: Record<string, VariantSpec['role']> = {};
-  for (const spec of variantSpecs) roleByName[spec.name] = spec.role;
-  for (const artifact of resolvedArtifacts) {
-    if (artifact.experimentRole) continue;  // preserve if already set (e.g. batch workflow)
-    const role = roleByName[artifact.name];
-    if (role) artifact.experimentRole = role;
+  // Attach experimentRole to each artifact.
+  //   - 当 artifacts 由本函数从 variantSpecs.map(spec => spec.expr) 解析时,两者顺序一一对应,
+  //     按 index 绑定 role,并把 spec.name 同步成消歧后的最终唯一名。不能按 spec.name 匹配
+  //     artifact.name:同 basename 的 variant 被 ensureUniqueVariantNames 消歧后(v1/greeter /
+  //     v2/greeter)就和 spec 的派生短名(greeter)对不上,会丢 role。
+  //   - 当 artifacts 由外部传入(如 batch workflow,role 已预置)时,index 无法对齐,
+  //     退回按 name 匹配,且 if-already-set 守卫会保留预置 role。
+  if (!artifacts && variantSpecs.length === resolvedArtifacts.length) {
+    variantSpecs.forEach((spec, i) => {
+      const artifact = resolvedArtifacts[i];
+      if (!artifact.experimentRole) artifact.experimentRole = spec.role;
+      spec.name = artifact.name; // 同步唯一名,让 spec 与 report / variantNames 一致
+    });
+  } else {
+    const roleByName: Record<string, VariantSpec['role']> = {};
+    for (const spec of variantSpecs) roleByName[spec.name] = spec.role;
+    for (const artifact of resolvedArtifacts) {
+      if (artifact.experimentRole) continue;  // preserve if already set (e.g. batch workflow)
+      const role = roleByName[artifact.name];
+      if (role) artifact.experimentRole = role;
+    }
   }
 
   if (!dryRun) {

--- a/src/eval-workflows/evaluation-preparation.ts
+++ b/src/eval-workflows/evaluation-preparation.ts
@@ -46,10 +46,13 @@ export async function prepareEvaluationRun({
 
   // Build expressions from specs (preserving order) and resolve to artifacts.
   const variantExpressions = variantSpecs.map((spec) => spec.expr);
+  // 不把 variantAllowedSkills 透进 resolveArtifacts:那里按解析出的 artifact 名查,
+  // 与 eval.yaml 的自定义 variant 名不一致时会漏绑。allowedSkills 统一在下面按 spec 绑定。
+  // resolveArtifacts 只保留 strictBaseline 默认(baseline → [])。
   const resolvedArtifacts = artifacts || resolveArtifacts(
     resolve(skillDir),
     variantExpressions,
-    { strictBaseline, variantAllowedSkills },
+    { strictBaseline },
   );
 
   // Attach experimentRole to each artifact.
@@ -63,12 +66,10 @@ export async function prepareEvaluationRun({
     variantSpecs.forEach((spec, i) => {
       const artifact = resolvedArtifacts[i];
       if (!artifact.experimentRole) artifact.experimentRole = spec.role;
-      // allowedSkills 也要按 spec 身份重绑:resolveArtifacts 里是按解析出的 artifact.name 查
-      // variantAllowedSkills,而 eval.yaml 的 key 是用户自定义的 variant 名(可与 artifact
-      // 短名不同,如 name:control-v1 / artifact:.../v1.md)。漏绑会把本该隔离的 variant 悄悄
-      // 退回 SDK 默认 discovery,破坏 construct validity。用同步前的 spec.name 覆盖回来,
-      // 显式声明优先于 strictBaseline 默认。
-      const explicit = variantAllowedSkills?.[spec.name];
+      // allowedSkills 按 spec 身份绑定,显式声明优先于 strictBaseline 默认。spec.allowedSkills
+      // 是首选来源(eval.yaml 经 configVariantsToSpecs 带上);旧的按变量名 map 仅作 fallback,
+      // 兜住「CLI roles 覆盖 config 时 spec 不带 allowedSkills」等边角,行为与重构前一致。
+      const explicit = spec.allowedSkills ?? variantAllowedSkills?.[spec.name];
       if (explicit !== undefined) artifact.allowedSkills = explicit;
       spec.name = artifact.name; // 同步唯一名,让 spec 与 report / variantNames 一致(放最后,前面还要用旧名查)
     });

--- a/src/eval-workflows/evaluation-preparation.ts
+++ b/src/eval-workflows/evaluation-preparation.ts
@@ -63,7 +63,14 @@ export async function prepareEvaluationRun({
     variantSpecs.forEach((spec, i) => {
       const artifact = resolvedArtifacts[i];
       if (!artifact.experimentRole) artifact.experimentRole = spec.role;
-      spec.name = artifact.name; // 同步唯一名,让 spec 与 report / variantNames 一致
+      // allowedSkills 也要按 spec 身份重绑:resolveArtifacts 里是按解析出的 artifact.name 查
+      // variantAllowedSkills,而 eval.yaml 的 key 是用户自定义的 variant 名(可与 artifact
+      // 短名不同,如 name:control-v1 / artifact:.../v1.md)。漏绑会把本该隔离的 variant 悄悄
+      // 退回 SDK 默认 discovery,破坏 construct validity。用同步前的 spec.name 覆盖回来,
+      // 显式声明优先于 strictBaseline 默认。
+      const explicit = variantAllowedSkills?.[spec.name];
+      if (explicit !== undefined) artifact.allowedSkills = explicit;
+      spec.name = artifact.name; // 同步唯一名,让 spec 与 report / variantNames 一致(放最后,前面还要用旧名查)
     });
   } else {
     const roleByName: Record<string, VariantSpec['role']> = {};

--- a/src/inputs/eval-config.ts
+++ b/src/inputs/eval-config.ts
@@ -36,6 +36,7 @@ export function configVariantsToSpecs(variants: EvalConfigVariant[]): VariantSpe
     name: v.name,
     role: v.role,
     expr: v.cwd ? `${v.artifact}@${v.cwd}` : v.artifact,
+    ...(v.allowedSkills !== undefined && { allowedSkills: v.allowedSkills }),
   }));
 }
 

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -306,5 +306,58 @@ export function resolveArtifacts(
     // else leave undefined → SDK default (full discovery)
   }
 
+  ensureUniqueVariantNames(artifacts);
   return artifacts;
+}
+
+/** variant 短名的消歧路径:取「短名所源自的那一段」所在的完整路径,用来逐段往前限定。
+ *  - dir/SKILL.md 或 dir-variant:skillRoot(= 那个 skill 目录,basename 即短名)
+ *  - 单文件 .md:locator 去掉 .md(basename 即短名)
+ *  - baseline / git variant:无可用路径(git 名本就唯一,baseline 不参与对比键),返回 null。 */
+function identityPathOf(a: Artifact): string | null {
+  if (a.kind !== 'skill' || a.source === 'git' || !a.locator) return null;
+  return a.skillRoot ?? a.locator.replace(/\.md$/i, '');
+}
+
+/** 消歧:多个 variant resolve 出同名时(如 `v1/greeter.md` vs `v2/greeter.md` 都叫 `greeter`),
+ *  用父目录逐段限定恢复唯一性。否则 `results[sample][variant]` / `summary[variant]` 按 name 键时
+ *  后写覆盖前写,把对照 / 实验组的结果搅在一起、verdict 拿同名跟自己比 —— 静默破坏对比可信度。
+ *  没有可用路径(baseline / git)时退化加 `#n` 序号兜底,保证返回的 name 一定两两不同。 */
+export function ensureUniqueVariantNames(artifacts: Artifact[]): void {
+  const groups = new Map<string, Artifact[]>();
+  for (const a of artifacts) {
+    const g = groups.get(a.name);
+    if (g) g.push(a);
+    else groups.set(a.name, [a]);
+  }
+  if (![...groups.values()].some((g) => g.length > 1)) return; // 无冲突,常见路径直接返回
+
+  const used = new Set<string>();
+  for (const [name, g] of groups) if (g.length === 1) used.add(name);
+
+  for (const [name, g] of groups) {
+    if (g.length === 1) continue;
+    // 找能让组内全部区分、又不撞已用名的最小段深,组内统一用同一深度 → 对称标签(v1/greeter 对 v2/greeter)
+    const segLists = g.map((a) => {
+      const p = identityPathOf(a);
+      return p ? p.split(/[\\/]+/).filter(Boolean) : null;
+    });
+    const maxDepth = Math.max(0, ...segLists.map((s) => s?.length ?? 0));
+    let chosen: string[] | null = null;
+    for (let take = 2; take <= maxDepth; take++) {
+      const cands = segLists.map((s) => (s && s.length >= take ? s.slice(-take).join('/') : null));
+      if (cands.includes(null)) continue;
+      if (new Set(cands).size === cands.length && cands.every((c) => !used.has(c as string))) {
+        chosen = cands as string[];
+        break;
+      }
+    }
+    g.forEach((a, i) => {
+      const candidate = chosen ? chosen[i] : name; // 无可用路径(baseline 等)退化到原名 + #n 序号
+      let unique = candidate;
+      for (let n = 2; used.has(unique); n++) unique = `${candidate}#${n}`;
+      a.name = unique;
+      used.add(unique);
+    });
+  }
 }

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -149,24 +149,39 @@ export interface ResolveArtifactsOptions {
  * Format: "name@/path/to/cwd" or just "name"
  */
 export function parseVariantCwd(variant: string): { name: string; cwd?: string } {
+  // git ref 可含 `@`(reflog `git:HEAD@{2}:x`、upstream `git:main@{u}:x`),不切 @cwd,
+  // 否则会被误拆成 name=`git:HEAD`、cwd=`{2}:x`,下游静默评测错版本。
+  if (variant.startsWith('git:')) return { name: variant };
   const atIdx = variant.indexOf('@');
   if (atIdx === -1) return { name: variant };
   return { name: variant.slice(0, atIdx), cwd: variant.slice(atIdx + 1) };
 }
 
-/** 把一个 variant 表达式规范化成稳定的物理身份,用于「同一 variant 不能既是 control 又是
- *  treatment」的判重。同一份 skill 的不同写法必须折叠成同一个 key:
- *    - `./x.md` 与 `x.md`：路径型一律 `resolve(...)` 成绝对路径。
- *    - 目录 `dir` 与 `dir/SKILL.md`：都折叠到该目录下的 SKILL.md(skill 根的稳定锚点)。
- *    - `git:` / `baseline`：本身就是稳定标识,原样返回。
- *  `@cwd` 也规范化后纳入 key —— 同一份 skill 绑不同 cwd 是不同 runtime context,不算重复。
- *  不要用派生短名判重:`v1/greeter.md` 与 `v2/greeter.md` 短名都是 greeter 却是两个 variant。 */
-/** 把一个绝对路径折叠到稳定的 skill 锚点:目录型 skill 与其 `SKILL.md` 归一到同一个
- *  `dir/SKILL.md`,单文件 .md 用其绝对路径本身。供 variant 身份判重折叠等价写法。 */
+/** 把一个路径折叠到稳定的 skill 锚点:目录型 skill 与其 `SKILL.md` 归一到同一个
+ *  `dir/SKILL.md`,单文件 .md 用其路径本身。返回路径(不解物理身份),供取短名与身份判重共用。 */
 function canonicalSkillAnchor(absPath: string): string {
   return existsSync(absPath) && statSync(absPath).isDirectory() ? join(absPath, 'SKILL.md') : absPath;
 }
 
+/** 路径的稳定物理身份:存在则取 `dev:ino`(解符号链接、折叠大小写不敏感卷的等价写法、认硬链),
+ *  不存在则退回原路径串。判重必须用物理身份——纯字符串 resolve 会把同一文件的软链/大小写/
+ *  绝对 vs CWD 相对写法判成两个 variant,放过真重复 → 同一份 skill 自比、悄悄废掉对比保护。 */
+function pathPhysicalId(p: string): string {
+  try {
+    const st = statSync(p);
+    return `ino:${st.dev}:${st.ino}`;
+  } catch {
+    return p;
+  }
+}
+
+/** 把一个 variant 表达式规范化成稳定的物理身份,用于「同一 variant 不能既是 control 又是
+ *  treatment」的判重。同一份 skill 的不同写法必须折叠成同一个 key:
+ *    - `./x.md` 与 `x.md`、符号链接、大小写不敏感卷上的等价写法:resolve 后取 `dev:ino` 物理身份。
+ *    - 目录 `dir` 与 `dir/SKILL.md`：先折叠到同一锚点再取物理身份。
+ *    - `git:` / `baseline`：本身就是稳定标识,原样返回。
+ *  `@cwd` 也按物理身份纳入 key —— 同一份 skill 绑不同 cwd 是不同 runtime context,不算重复。
+ *  不要用派生短名判重:`v1/greeter.md` 与 `v2/greeter.md` 短名都是 greeter 却是两个 variant。 */
 export function variantIdentity(expr: string): string {
   const { name, cwd } = parseVariantCwd(expr);
   let id: string;
@@ -175,11 +190,11 @@ export function variantIdentity(expr: string): string {
   } else if (name === 'baseline') {
     id = 'baseline';
   } else if (name.includes('/') || /\.md$/i.test(name)) {
-    id = canonicalSkillAnchor(resolve(name));
+    id = pathPhysicalId(canonicalSkillAnchor(resolve(name)));
   } else {
     id = name; // 裸短名(相对 skill-dir 解析),不同短名即不同 variant
   }
-  return cwd ? `${id}@${resolve(cwd)}` : id;
+  return cwd ? `${id}@${pathPhysicalId(resolve(cwd))}` : id;
 }
 
 /** 从已解析的 skill 路径取短名:`SKILL.md` 取其父目录名,否则取去掉 `.md` 后缀的 basename。
@@ -195,7 +210,9 @@ export function variantExprToSkillName(expr: string): string {
   const { name } = parseVariantCwd(expr);
   if (name.startsWith('git:')) return name;
   if (!name.includes('/')) return name || expr;
-  return skillNameFromPath(resolve(name)) || name;
+  // 先折叠 dir↔SKILL.md 再取短名,与 resolveArtifacts 的命名一致(否则 `weird.md/` 这类
+  // 以 .md 结尾的目录,两处会派生出不同短名)。
+  return skillNameFromPath(canonicalSkillAnchor(resolve(name))) || name;
 }
 
 export function resolveArtifacts(
@@ -210,6 +227,10 @@ export function resolveArtifacts(
 
   for (const rawVariant of variants) {
     const { name: variantName, cwd: variantCwd } = parseVariantCwd(rawVariant);
+
+    if (!variantName) {
+      throw new Error(`variant 名不能为空: "${rawVariant}"。如需绑定 runtime context,用 label@/path 形式声明。`);
+    }
 
     if (variantName === 'baseline' && variantCwd) {
       throw new Error('baseline cannot be bound to a cwd. To express a project-level runtime context, use a custom label such as project-env@/path/to/project');
@@ -323,10 +344,15 @@ export function resolveArtifacts(
     }
   }
 
-  // Skill-isolation wiring.
-  //   Priority: variantAllowedSkills (explicit eval.yaml) > strictBaseline default > none.
+  // Skill-isolation wiring（按 artifact 名查 variantAllowedSkills）。
+  //   Priority: variantAllowedSkills (explicit eval.yaml) > strictBaseline default > none。
   //   strictBaseline=true 时,所有 kind:'baseline' artifact 默认 allowedSkills=[]。
   //   显式 [] 也是合法(用户主动想"完全发现")的反义靠 strictBaseline=false 表达整批关闭。
+  //
+  //   职责边界:这条按名查的绑定服务 doctor / batch / loadSkills 等直接调 resolveArtifacts 的
+  //   调用方。eval 主路径(prepareEvaluationRun)已改为按 spec 身份绑定、不再传 variantAllowedSkills,
+  //   不走这里。两条路径暂并存。
+  //   TODO: 待 batch 也迁到 spec-based 绑定后,退役 opts.variantAllowedSkills,让隔离绑定收成一处。
   for (const artifact of artifacts) {
     const explicit = variantAllowedSkills[artifact.name];
     if (explicit !== undefined) {

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -149,10 +149,14 @@ export interface ResolveArtifactsOptions {
  * Format: "name@/path/to/cwd" or just "name"
  */
 export function parseVariantCwd(variant: string): { name: string; cwd?: string } {
-  // git ref 可含 `@`(reflog `git:HEAD@{2}:x`、upstream `git:main@{u}:x`),不切 @cwd,
-  // 否则会被误拆成 name=`git:HEAD`、cwd=`{2}:x`,下游静默评测错版本。
-  if (variant.startsWith('git:')) return { name: variant };
-  const atIdx = variant.indexOf('@');
+  // 找 name@cwd 的切分点:跳过 git 修订语法里的 `@{...}`(reflog `HEAD@{2}`、upstream
+  // `main@{u}`),取第一个不是紧跟 `{` 的 `@`。这样 `git:v1@/proj`(git artifact + cwd,
+  // eval.yaml 经 configVariantsToSpecs 生成的形态)仍能切出 cwd,而 `git:HEAD@{2}:x`
+  // (无 cwd)不会被误拆成 name=`git:HEAD`、cwd=`{2}:x` → 下游静默评测错版本。
+  let atIdx = -1;
+  for (let i = variant.indexOf('@'); i !== -1; i = variant.indexOf('@', i + 1)) {
+    if (variant[i + 1] !== '{') { atIdx = i; break; }
+  }
   if (atIdx === -1) return { name: variant };
   return { name: variant.slice(0, atIdx), cwd: variant.slice(atIdx + 1) };
 }

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -178,15 +178,20 @@ export function variantIdentity(expr: string): string {
   return cwd ? `${id}@${resolve(cwd)}` : id;
 }
 
+/** 从已解析的 skill 路径取短名:`SKILL.md` 取其父目录名,否则取去掉 `.md` 后缀的 basename。
+ *  `variantExprToSkillName`(expr → 短名)与 `resolveArtifacts` 的 file-path 命名共用这一处,
+ *  避免两份各写一遍后悄悄发散——report 键就来自 resolveArtifacts 这一支。 */
+export function skillNameFromPath(filePath: string): string {
+  const base = basename(filePath);
+  return base === 'SKILL.md' ? basename(dirname(filePath)) : base.replace(/\.md$/i, '');
+}
+
 /** Extract short skill name from a variant expression (which may be a path). */
 export function variantExprToSkillName(expr: string): string {
   const { name } = parseVariantCwd(expr);
   if (name.startsWith('git:')) return name;
   if (!name.includes('/')) return name || expr;
-  const resolved = resolve(name);
-  const base = basename(resolved);
-  const result = /^SKILL\.md$/i.test(base) ? basename(dirname(resolved)) : base.replace(/\.md$/i, '');
-  return result || name;
+  return skillNameFromPath(resolve(name)) || name;
 }
 
 export function resolveArtifacts(
@@ -260,7 +265,7 @@ export function resolveArtifacts(
       }
       const content = readFileSync(filePath, 'utf-8').trim();
       const isSkillMd = basename(filePath) === 'SKILL.md';
-      const name = isSkillMd ? basename(dirname(filePath)) : basename(filePath).replace(/\.md$/i, '');
+      const name = skillNameFromPath(filePath);
       artifacts.push({
         name,
         kind: 'skill',

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -179,10 +179,13 @@ function pathPhysicalId(p: string): string {
  *  treatment」的判重。同一份 skill 的不同写法必须折叠成同一个 key:
  *    - `./x.md` 与 `x.md`、符号链接、大小写不敏感卷上的等价写法:resolve 后取 `dev:ino` 物理身份。
  *    - 目录 `dir` 与 `dir/SKILL.md`：先折叠到同一锚点再取物理身份。
+ *    - 裸短名(传了 `skillDir` 时):按 resolveArtifacts 的解析基准(`skillDir/name.md` 或
+ *      `skillDir/name/SKILL.md`)取物理身份,这样裸名 `greeter` 与指向同一文件的 `./greeter.md`
+ *      能判为重复;没传 skillDir(如纯单测)则退回字面名。
  *    - `git:` / `baseline`：本身就是稳定标识,原样返回。
  *  `@cwd` 也按物理身份纳入 key —— 同一份 skill 绑不同 cwd 是不同 runtime context,不算重复。
  *  不要用派生短名判重:`v1/greeter.md` 与 `v2/greeter.md` 短名都是 greeter 却是两个 variant。 */
-export function variantIdentity(expr: string): string {
+export function variantIdentity(expr: string, skillDir?: string): string {
   const { name, cwd } = parseVariantCwd(expr);
   let id: string;
   if (name.startsWith('git:')) {
@@ -191,8 +194,14 @@ export function variantIdentity(expr: string): string {
     id = 'baseline';
   } else if (name.includes('/') || /\.md$/i.test(name)) {
     id = pathPhysicalId(canonicalSkillAnchor(resolve(name)));
+  } else if (skillDir) {
+    // 裸短名按 resolveArtifacts 的同一基准(skillDir/name.md 或 skillDir/name/SKILL.md)解析,
+    // 命不中就退回字面名(resolveArtifacts 随后会报 not found)。
+    const md = join(skillDir, `${name}.md`);
+    const dirMd = join(skillDir, name, 'SKILL.md');
+    id = existsSync(md) ? pathPhysicalId(md) : existsSync(dirMd) ? pathPhysicalId(dirMd) : name;
   } else {
-    id = name; // 裸短名(相对 skill-dir 解析),不同短名即不同 variant
+    id = name; // 无 skillDir 上下文:不同短名即不同 variant
   }
   return cwd ? `${id}@${pathPhysicalId(resolve(cwd))}` : id;
 }

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -161,6 +161,12 @@ export function parseVariantCwd(variant: string): { name: string; cwd?: string }
  *    - `git:` / `baseline`：本身就是稳定标识,原样返回。
  *  `@cwd` 也规范化后纳入 key —— 同一份 skill 绑不同 cwd 是不同 runtime context,不算重复。
  *  不要用派生短名判重:`v1/greeter.md` 与 `v2/greeter.md` 短名都是 greeter 却是两个 variant。 */
+/** 把一个绝对路径折叠到稳定的 skill 锚点:目录型 skill 与其 `SKILL.md` 归一到同一个
+ *  `dir/SKILL.md`,单文件 .md 用其绝对路径本身。供 variant 身份判重折叠等价写法。 */
+function canonicalSkillAnchor(absPath: string): string {
+  return existsSync(absPath) && statSync(absPath).isDirectory() ? join(absPath, 'SKILL.md') : absPath;
+}
+
 export function variantIdentity(expr: string): string {
   const { name, cwd } = parseVariantCwd(expr);
   let id: string;
@@ -169,9 +175,7 @@ export function variantIdentity(expr: string): string {
   } else if (name === 'baseline') {
     id = 'baseline';
   } else if (name.includes('/') || /\.md$/i.test(name)) {
-    const abs = resolve(name);
-    // 目录型 skill 与其 SKILL.md 折叠到同一锚点;单文件 .md 用其绝对路径。
-    id = existsSync(abs) && statSync(abs).isDirectory() ? join(abs, 'SKILL.md') : abs;
+    id = canonicalSkillAnchor(resolve(name));
   } else {
     id = name; // 裸短名(相对 skill-dir 解析),不同短名即不同 variant
   }

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -154,6 +154,30 @@ export function parseVariantCwd(variant: string): { name: string; cwd?: string }
   return { name: variant.slice(0, atIdx), cwd: variant.slice(atIdx + 1) };
 }
 
+/** 把一个 variant 表达式规范化成稳定的物理身份,用于「同一 variant 不能既是 control 又是
+ *  treatment」的判重。同一份 skill 的不同写法必须折叠成同一个 key:
+ *    - `./x.md` 与 `x.md`：路径型一律 `resolve(...)` 成绝对路径。
+ *    - 目录 `dir` 与 `dir/SKILL.md`：都折叠到该目录下的 SKILL.md(skill 根的稳定锚点)。
+ *    - `git:` / `baseline`：本身就是稳定标识,原样返回。
+ *  `@cwd` 也规范化后纳入 key —— 同一份 skill 绑不同 cwd 是不同 runtime context,不算重复。
+ *  不要用派生短名判重:`v1/greeter.md` 与 `v2/greeter.md` 短名都是 greeter 却是两个 variant。 */
+export function variantIdentity(expr: string): string {
+  const { name, cwd } = parseVariantCwd(expr);
+  let id: string;
+  if (name.startsWith('git:')) {
+    id = name;
+  } else if (name === 'baseline') {
+    id = 'baseline';
+  } else if (name.includes('/') || /\.md$/i.test(name)) {
+    const abs = resolve(name);
+    // 目录型 skill 与其 SKILL.md 折叠到同一锚点;单文件 .md 用其绝对路径。
+    id = existsSync(abs) && statSync(abs).isDirectory() ? join(abs, 'SKILL.md') : abs;
+  } else {
+    id = name; // 裸短名(相对 skill-dir 解析),不同短名即不同 variant
+  }
+  return cwd ? `${id}@${resolve(cwd)}` : id;
+}
+
 /** Extract short skill name from a variant expression (which may be a path). */
 export function variantExprToSkillName(expr: string): string {
   const { name } = parseVariantCwd(expr);

--- a/src/types/eval.ts
+++ b/src/types/eval.ts
@@ -193,6 +193,9 @@ export interface VariantSpec {
   name: string;           // variant 显示名,从 expr 提取(parseVariantCwd 后的 name 部分)
   role: ExperimentRole;
   expr: string;           // 原始 CLI / config 表达式(含 @cwd、git: 等前缀)
+  // 显式 skill 隔离声明(来自 eval.yaml variant.allowedSkills)。随 spec 一起走,
+  // 避免再按 variant 名建一张并行 map 与 artifact 名互查(那是 allowedSkills 漏绑的源头)。
+  allowedSkills?: string[];
 }
 
 export interface EvalConfigVariant {

--- a/test/eval-core/__snapshots__/report-variant-keys.golden.test.ts.snap
+++ b/test/eval-core/__snapshots__/report-variant-keys.golden.test.ts.snap
@@ -1,0 +1,294 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GOLDEN report variant keys > case 1 — baseline vs single skill: isolation [] vs null, roles 1`] = `
+{
+  "artifactHashKeys": [
+    "baseline",
+    "greeter",
+  ],
+  "executorRuntimeKeys": [
+    "baseline",
+    "greeter",
+  ],
+  "metaVariants": [
+    "baseline",
+    "greeter",
+  ],
+  "pairComparisons": [],
+  "resultVariantKeys": [
+    {
+      "sample_id": "s1",
+      "variants": [
+        "baseline",
+        "greeter",
+      ],
+    },
+    {
+      "sample_id": "s2",
+      "variants": [
+        "baseline",
+        "greeter",
+      ],
+    },
+  ],
+  "roleByVariant": {
+    "baseline": "control",
+    "greeter": "treatment",
+  },
+  "skillIsolation": {
+    "baseline": [],
+    "greeter": null,
+  },
+  "summaryKeys": [
+    "baseline",
+    "greeter",
+  ],
+}
+`;
+
+exports[`GOLDEN report variant keys > case 2 — same-basename diff dirs flow disambiguated names to every surface 1`] = `
+{
+  "artifactHashKeys": [
+    "v1/greeter",
+    "v2/greeter",
+  ],
+  "executorRuntimeKeys": [
+    "v1/greeter",
+    "v2/greeter",
+  ],
+  "metaVariants": [
+    "v1/greeter",
+    "v2/greeter",
+  ],
+  "pairComparisons": [],
+  "resultVariantKeys": [
+    {
+      "sample_id": "s1",
+      "variants": [
+        "v1/greeter",
+        "v2/greeter",
+      ],
+    },
+    {
+      "sample_id": "s2",
+      "variants": [
+        "v1/greeter",
+        "v2/greeter",
+      ],
+    },
+  ],
+  "roleByVariant": {
+    "v1/greeter": "control",
+    "v2/greeter": "treatment",
+  },
+  "skillIsolation": {
+    "v1/greeter": null,
+    "v2/greeter": null,
+  },
+  "summaryKeys": [
+    "v1/greeter",
+    "v2/greeter",
+  ],
+}
+`;
+
+exports[`GOLDEN report variant keys > case 3 — eval.yaml custom name + allowedSkills:[] lands on disambiguated artifact 1`] = `
+{
+  "artifactHashKeys": [
+    "v1/greeter",
+    "v2/greeter",
+  ],
+  "executorRuntimeKeys": [
+    "v1/greeter",
+    "v2/greeter",
+  ],
+  "metaVariants": [
+    "v1/greeter",
+    "v2/greeter",
+  ],
+  "pairComparisons": [],
+  "resultVariantKeys": [
+    {
+      "sample_id": "s1",
+      "variants": [
+        "v1/greeter",
+        "v2/greeter",
+      ],
+    },
+    {
+      "sample_id": "s2",
+      "variants": [
+        "v1/greeter",
+        "v2/greeter",
+      ],
+    },
+  ],
+  "roleByVariant": {
+    "v1/greeter": "control",
+    "v2/greeter": "treatment",
+  },
+  "skillIsolation": {
+    "v1/greeter": [],
+    "v2/greeter": null,
+  },
+  "summaryKeys": [
+    "v1/greeter",
+    "v2/greeter",
+  ],
+}
+`;
+
+exports[`GOLDEN report variant keys > case 4 — multi-treatment + bootstrap: pairComparisons by name, 3 distinct keys 1`] = `
+{
+  "artifactHashKeys": [
+    "a",
+    "b",
+    "baseline",
+  ],
+  "executorRuntimeKeys": [
+    "a",
+    "b",
+    "baseline",
+  ],
+  "metaVariants": [
+    "baseline",
+    "a",
+    "b",
+  ],
+  "pairComparisons": [
+    {
+      "control": "baseline",
+      "treatment": "a",
+    },
+    {
+      "control": "baseline",
+      "treatment": "b",
+    },
+  ],
+  "resultVariantKeys": [
+    {
+      "sample_id": "s1",
+      "variants": [
+        "a",
+        "b",
+        "baseline",
+      ],
+    },
+    {
+      "sample_id": "s2",
+      "variants": [
+        "a",
+        "b",
+        "baseline",
+      ],
+    },
+  ],
+  "roleByVariant": {
+    "a": "treatment",
+    "b": "treatment",
+    "baseline": "control",
+  },
+  "skillIsolation": {
+    "a": null,
+    "b": null,
+    "baseline": [],
+  },
+  "summaryKeys": [
+    "a",
+    "b",
+    "baseline",
+  ],
+}
+`;
+
+exports[`GOLDEN report variant keys > case 5 — git variant passes through opaquely to all keys 1`] = `
+{
+  "artifactHashKeys": [
+    "baseline",
+    "git:HEAD:greeter",
+  ],
+  "executorRuntimeKeys": [
+    "baseline",
+    "git:HEAD:greeter",
+  ],
+  "metaVariants": [
+    "baseline",
+    "git:HEAD:greeter",
+  ],
+  "pairComparisons": [],
+  "resultVariantKeys": [
+    {
+      "sample_id": "s1",
+      "variants": [
+        "baseline",
+        "git:HEAD:greeter",
+      ],
+    },
+    {
+      "sample_id": "s2",
+      "variants": [
+        "baseline",
+        "git:HEAD:greeter",
+      ],
+    },
+  ],
+  "roleByVariant": {
+    "baseline": "control",
+    "git:HEAD:greeter": "treatment",
+  },
+  "skillIsolation": {
+    "baseline": [],
+    "git:HEAD:greeter": null,
+  },
+  "summaryKeys": [
+    "baseline",
+    "git:HEAD:greeter",
+  ],
+}
+`;
+
+exports[`GOLDEN report variant keys > case 6 — custom names with no collision are replaced by derived short names 1`] = `
+{
+  "artifactHashKeys": [
+    "greeter",
+    "helper",
+  ],
+  "executorRuntimeKeys": [
+    "greeter",
+    "helper",
+  ],
+  "metaVariants": [
+    "greeter",
+    "helper",
+  ],
+  "pairComparisons": [],
+  "resultVariantKeys": [
+    {
+      "sample_id": "s1",
+      "variants": [
+        "greeter",
+        "helper",
+      ],
+    },
+    {
+      "sample_id": "s2",
+      "variants": [
+        "greeter",
+        "helper",
+      ],
+    },
+  ],
+  "roleByVariant": {
+    "greeter": "control",
+    "helper": "treatment",
+  },
+  "skillIsolation": {
+    "greeter": null,
+    "helper": null,
+  },
+  "summaryKeys": [
+    "greeter",
+    "helper",
+  ],
+}
+`;

--- a/test/eval-core/__snapshots__/report-variant-keys.golden.test.ts.snap
+++ b/test/eval-core/__snapshots__/report-variant-keys.golden.test.ts.snap
@@ -292,3 +292,11 @@ exports[`GOLDEN report variant keys > case 6 — custom names with no collision 
   ],
 }
 `;
+
+exports[`GOLDEN report variant keys > case 7 — blind mode remaps every variant surface to A/B/C and round-trips 1`] = `
+{
+  "A": "baseline",
+  "B": "a",
+  "C": "b",
+}
+`;

--- a/test/eval-core/report-variant-keys.golden.test.ts
+++ b/test/eval-core/report-variant-keys.golden.test.ts
@@ -3,10 +3,17 @@
  *
  * variant 命名链路(expr → artifact.name → 报告键)是测量学不变量:artifact.name 同时
  * 是 meta.variants / summary / results[].variants / artifactHashes / skillIsolation /
- * executorRuntimes / pairComparisons.control|treatment / runId 的键。这条链路在
+ * executorRuntimes / pairComparisons.control|treatment 的键。这条链路在
  * skill-loader 里有多处独立派生,历史上反复发散。本测试走真实解析路径
  * (prepareEvaluationRun dryRun → aggregateReport),把这组键钉死,作为后续「行为保持」
  * 重构的护栏:快照只要 byte-identical,就证明重构没动跨版本可比性。
+ *
+ * runId 不在快照投影里(它由 new Date() 派生、含时间戳);其变量名编码部分另由文末的
+ * generateRunId 单测用 regex 单独覆盖,而非靠本快照。
+ *
+ * 覆盖范围:只覆盖 eval 主路径(prepareEvaluationRun 的 !artifacts 分支,按 index 绑定)。
+ * batch 路径(外部预置 artifacts 走 else 分支按 name 匹配)不在本 golden 内,见
+ * batch-evaluation-workflow 的独立测试 / 跟进 issue。
  *
  * 投影(projectVariantSurfaces)只保留 variant 相关的键面,丢掉 timestamp / cliVersion /
  * executorRuntimes 的值(含本机 PATH/工具版本,非确定)等噪声,避免无关变动误伤命名 golden。
@@ -201,6 +208,8 @@ describe('GOLDEN report variant keys', () => {
     // 临时 git 仓库,提交 greeter.md。resolveArtifacts 的 git 解析(getGitRelativePath /
     // gitShowFile)走进程 cwd,且 git toplevel 在 macOS 下是 realpath(/private/...),所以
     // chdir 进 realpath 化的仓库根、skillDir 也传 realpath,relative 才为空、能命中 HEAD:greeter.md。
+    // 注:这里用 process.chdir(进程级全局态)。依赖 vitest 文件级进程隔离(默认 fileParallelism
+    // 下每文件独立 worker、同文件内 test 串行)+ 下方 finally 还原 cwd;若改并发/线程池需重新评估。
     const gitRoot = realpathSync(mkdtempSync(join(tmpdir(), 'omk-golden-git-')));
     const sh = (args: string[]): void => { execFileSync('git', args, { cwd: gitRoot, stdio: 'ignore' }); };
     const prevCwd = process.cwd();
@@ -272,9 +281,17 @@ describe('GOLDEN report variant keys', () => {
     }
     assert.deepEqual(Object.keys(report.meta.artifactHashes ?? {}).sort(), ['a', 'b', 'baseline'], 'artifactHashes NOT remapped');
     assert.deepEqual(Object.keys(report.meta.skillIsolation ?? {}).sort(), ['a', 'b', 'baseline'], 'skillIsolation NOT remapped');
-    // blindMap 反向映射能把标签还原回原始 variant 名(键往返不丢)
-    const back = new Set(Object.values(report.meta.blindMap ?? {}));
-    assert.deepEqual([...back].sort(), ['a', 'b', 'baseline']);
+    // blindMap 是 bijection(标签集 ↔ 原始 variant 集,无丢无重)
+    const blindMap = report.meta.blindMap ?? {};
+    assert.deepEqual(Object.keys(blindMap).sort(), ['A', 'B', 'C'], 'blindMap labels');
+    assert.deepEqual(Object.values(blindMap).slice().sort(), ['a', 'b', 'baseline'], 'blindMap originals');
+    // 固定 seed → 映射确定,快照钉住具体的 label→原名(升级「往返不丢」为「映射正确」:
+    // 哪怕集合不变、A/B/C 各映到错的 variant,本快照也会抓到)。
+    expect(blindMap).toMatchSnapshot();
+    // 反向映射:summary 在 blind 后的某个 label,其对应原名确实来自 blindMap(往返自洽)
+    for (const label of Object.keys(report.summary)) {
+      assert.ok(label in blindMap, `summary label ${label} has a blindMap entry`);
+    }
   });
 
   it('generateRunId encodes variant names in order, sanitized', () => {

--- a/test/eval-core/report-variant-keys.golden.test.ts
+++ b/test/eval-core/report-variant-keys.golden.test.ts
@@ -1,0 +1,285 @@
+/**
+ * GOLDEN — 端到端钉住 variant 报告键。
+ *
+ * variant 命名链路(expr → artifact.name → 报告键)是测量学不变量:artifact.name 同时
+ * 是 meta.variants / summary / results[].variants / artifactHashes / skillIsolation /
+ * executorRuntimes / pairComparisons.control|treatment / runId 的键。这条链路在
+ * skill-loader 里有多处独立派生,历史上反复发散。本测试走真实解析路径
+ * (prepareEvaluationRun dryRun → aggregateReport),把这组键钉死,作为后续「行为保持」
+ * 重构的护栏:快照只要 byte-identical,就证明重构没动跨版本可比性。
+ *
+ * 投影(projectVariantSurfaces)只保留 variant 相关的键面,丢掉 timestamp / cliVersion /
+ * executorRuntimes 的值(含本机 PATH/工具版本,非确定)等噪声,避免无关变动误伤命名 golden。
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { prepareEvaluationRun } from '../../src/eval-workflows/evaluation-preparation.js';
+import { aggregateReport, applyBlindMode, generateRunId } from '../../src/eval-core/evaluation-reporting.js';
+import type { Report, VariantResult, VariantSpec, EvaluationRequest } from '../../src/types/index.js';
+
+function makeVariantResult(compositeScore?: number): VariantResult {
+  return {
+    ok: true,
+    durationMs: 100, durationApiMs: 100,
+    inputTokens: 100, outputTokens: 50, totalTokens: 150,
+    cacheReadTokens: 0, cacheCreationTokens: 0,
+    execCostUSD: 0.001, judgeCostUSD: 0, costUSD: 0.001,
+    numTurns: 1, outputPreview: 'ok',
+    ...(compositeScore !== undefined ? { compositeScore } : {}),
+  };
+}
+
+/** 照 evaluation-execution.ts 的 results[sample][task.variant] 形状拼造确定性结果。
+ *  每个 sample × variant 一个 entry;compositeScore 让 bootstrap / pairComparisons 能产出。 */
+function buildResults(
+  sampleIds: string[],
+  variantNames: string[],
+  scored: boolean,
+): Record<string, Record<string, VariantResult>> {
+  const results: Record<string, Record<string, VariantResult>> = {};
+  for (const sid of sampleIds) {
+    results[sid] = {};
+    variantNames.forEach((v, vi) => {
+      // 给不同 variant 不同分,且每 variant 跨 sample ≥2 个正分,满足 bootstrap 阈值
+      results[sid][v] = makeVariantResult(scored ? 0.5 + vi * 0.1 : undefined);
+    });
+  }
+  return results;
+}
+
+/** variant 相关键面的确定性投影。命名链路一旦发散,这些就对不上。 */
+function projectVariantSurfaces(report: Report) {
+  const meta = report.meta;
+  const variantConfigs = meta.variantConfigs ?? [];
+  return {
+    metaVariants: meta.variants,
+    summaryKeys: Object.keys(report.summary).sort(),
+    artifactHashKeys: Object.keys(meta.artifactHashes ?? {}).sort(),
+    skillIsolation: meta.skillIsolation, // name → allowedSkills | null(确定,命名+构念相关)
+    executorRuntimeKeys: Object.keys(meta.executorRuntimes ?? {}).sort(),
+    resultVariantKeys: report.results.map((r) => ({
+      sample_id: r.sample_id,
+      variants: Object.keys(r.variants).sort(),
+    })),
+    roleByVariant: Object.fromEntries(
+      meta.variants.map((v, i) => [v, variantConfigs[i]?.experimentRole ?? null]),
+    ),
+    pairComparisons: (meta.pairComparisons ?? []).map((p) => ({ control: p.control, treatment: p.treatment })),
+  };
+}
+
+/** 头号不变量:所有 variant 键面共享同一组键。碎片化恰恰让它们发散,这一条价值最高。 */
+function assertAllVariantSurfacesEqual(report: Report, variantNames: string[]): void {
+  const expected = [...variantNames].sort();
+  const meta = report.meta;
+  assert.deepEqual([...meta.variants].sort(), expected, 'meta.variants');
+  assert.deepEqual(Object.keys(report.summary).sort(), expected, 'summary keys');
+  assert.deepEqual(Object.keys(meta.artifactHashes ?? {}).sort(), expected, 'artifactHashes keys');
+  assert.deepEqual(Object.keys(meta.skillIsolation ?? {}).sort(), expected, 'skillIsolation keys');
+  assert.deepEqual(Object.keys(meta.executorRuntimes ?? {}).sort(), expected, 'executorRuntimes keys');
+  for (const r of report.results) {
+    assert.deepEqual(Object.keys(r.variants).sort(), expected, `results[${r.sample_id}].variants keys`);
+  }
+}
+
+interface RunCaseOpts {
+  variantSpecs: VariantSpec[];
+  variantAllowedSkills?: Record<string, string[]>;
+  request?: EvaluationRequest;
+  scored?: boolean;
+}
+
+let root: string;
+let samplesPath: string;
+
+/** 真实解析 + 聚合:prepareEvaluationRun(dryRun) → 确定性 results → aggregateReport。 */
+async function runCase(opts: RunCaseOpts): Promise<{ report: Report; variantNames: string[] }> {
+  const prepared = await prepareEvaluationRun({
+    samplesPath,
+    skillDir: root,
+    variantSpecs: opts.variantSpecs,
+    dryRun: true,
+    variantAllowedSkills: opts.variantAllowedSkills,
+  });
+  const sampleIds = prepared.samples.map((s) => s.sample_id);
+  const results = buildResults(sampleIds, prepared.variantNames, opts.scored ?? false);
+  const report = aggregateReport({
+    runId: 'golden-run',
+    variants: prepared.variantNames,
+    model: 'mock-model',
+    judgeModel: 'mock-judge',
+    noJudge: true,
+    executorName: 'mock-exec',
+    samples: prepared.samples,
+    tasks: prepared.tasks,
+    results,
+    totalCostUSD: 0,
+    artifacts: prepared.artifacts,
+    request: opts.request,
+  });
+  return { report, variantNames: prepared.variantNames };
+}
+
+const ctrl = (expr: string, name = 'x'): VariantSpec => ({ name, role: 'control', expr });
+const treat = (expr: string, name = 'x'): VariantSpec => ({ name, role: 'treatment', expr });
+
+describe('GOLDEN report variant keys', () => {
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'omk-golden-'));
+    // v1/v2 同 basename 分目录,顶层 greeter.md / helper.md / a.md / b.md
+    for (const v of ['v1', 'v2']) {
+      mkdirSync(join(root, v), { recursive: true });
+      writeFileSync(join(root, v, 'greeter.md'), `# greeter ${v}\n`);
+    }
+    writeFileSync(join(root, 'greeter.md'), '# greeter top\n');
+    writeFileSync(join(root, 'helper.md'), '# helper top\n');
+    writeFileSync(join(root, 'a.md'), '# skill a\n');
+    writeFileSync(join(root, 'b.md'), '# skill b\n');
+    samplesPath = join(root, 'samples.json');
+    writeFileSync(samplesPath, JSON.stringify([
+      { sample_id: 's1', prompt: '你好' },
+      { sample_id: 's2', prompt: '世界' },
+    ]));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('case 1 — baseline vs single skill: isolation [] vs null, roles', async () => {
+    const { report, variantNames } = await runCase({
+      variantSpecs: [ctrl('baseline', 'baseline'), treat(join(root, 'greeter.md'), 'greeter')],
+    });
+    assert.deepEqual(variantNames, ['baseline', 'greeter']);
+    assertAllVariantSurfacesEqual(report, variantNames);
+    assert.deepEqual(report.meta.skillIsolation, { baseline: [], greeter: null });
+    assert.deepEqual(projectVariantSurfaces(report).roleByVariant, { baseline: 'control', greeter: 'treatment' });
+    expect(projectVariantSurfaces(report)).toMatchSnapshot();
+  });
+
+  it('case 2 — same-basename diff dirs flow disambiguated names to every surface', async () => {
+    const { report, variantNames } = await runCase({
+      variantSpecs: [ctrl(join(root, 'v1', 'greeter.md')), treat(join(root, 'v2', 'greeter.md'))],
+    });
+    assert.deepEqual(variantNames, ['v1/greeter', 'v2/greeter']);
+    assertAllVariantSurfacesEqual(report, variantNames);
+    expect(projectVariantSurfaces(report)).toMatchSnapshot();
+  });
+
+  it('case 3 — eval.yaml custom name + allowedSkills:[] lands on disambiguated artifact', async () => {
+    const { report, variantNames } = await runCase({
+      variantSpecs: [
+        { name: 'control-v1', role: 'control', expr: join(root, 'v1', 'greeter.md') },
+        { name: 'treat-v2', role: 'treatment', expr: join(root, 'v2', 'greeter.md') },
+      ],
+      variantAllowedSkills: { 'control-v1': [] },
+    });
+    assert.deepEqual(variantNames, ['v1/greeter', 'v2/greeter']);
+    assertAllVariantSurfacesEqual(report, variantNames);
+    // 自定义名声明的 allowedSkills:[] 必须落到消歧后的 artifact 名上(隔离生效,不是 undefined→null)
+    assert.deepEqual(report.meta.skillIsolation, { 'v1/greeter': [], 'v2/greeter': null });
+    expect(projectVariantSurfaces(report)).toMatchSnapshot();
+  });
+
+  it('case 4 — multi-treatment + bootstrap: pairComparisons by name, 3 distinct keys', async () => {
+    const { report, variantNames } = await runCase({
+      variantSpecs: [ctrl('baseline', 'baseline'), treat(join(root, 'a.md'), 'a'), treat(join(root, 'b.md'), 'b')],
+      request: { bootstrap: true, bootstrapSamples: 50 } as EvaluationRequest,
+      scored: true,
+    });
+    assert.deepEqual(variantNames, ['baseline', 'a', 'b']);
+    assertAllVariantSurfacesEqual(report, variantNames);
+    assert.deepEqual(
+      report.meta.pairComparisons?.map((p) => ({ control: p.control, treatment: p.treatment })),
+      [{ control: 'baseline', treatment: 'a' }, { control: 'baseline', treatment: 'b' }],
+    );
+    expect(projectVariantSurfaces(report)).toMatchSnapshot();
+  });
+
+  it('case 5 — git variant passes through opaquely to all keys', async () => {
+    // 临时 git 仓库,提交 greeter.md。resolveArtifacts 的 git 解析(getGitRelativePath /
+    // gitShowFile)走进程 cwd,且 git toplevel 在 macOS 下是 realpath(/private/...),所以
+    // chdir 进 realpath 化的仓库根、skillDir 也传 realpath,relative 才为空、能命中 HEAD:greeter.md。
+    const gitRoot = realpathSync(mkdtempSync(join(tmpdir(), 'omk-golden-git-')));
+    const sh = (args: string[]): void => { execFileSync('git', args, { cwd: gitRoot, stdio: 'ignore' }); };
+    const prevCwd = process.cwd();
+    try {
+      sh(['init']);
+      sh(['config', 'user.email', 'golden@example.com']);
+      sh(['config', 'user.name', 'golden']);
+      writeFileSync(join(gitRoot, 'greeter.md'), '# git greeter\n');
+      writeFileSync(join(gitRoot, 'samples.json'), JSON.stringify([{ sample_id: 's1', prompt: 'p' }, { sample_id: 's2', prompt: 'q' }]));
+      sh(['add', '.']);
+      sh(['commit', '-m', 'seed']);
+      process.chdir(gitRoot);
+      const prepared = await prepareEvaluationRun({
+        samplesPath: join(gitRoot, 'samples.json'),
+        skillDir: gitRoot,
+        variantSpecs: [ctrl('baseline', 'baseline'), treat('git:HEAD:greeter', 'greeter')],
+        dryRun: true,
+      });
+      assert.deepEqual(prepared.variantNames, ['baseline', 'git:HEAD:greeter']);
+      const results = buildResults(prepared.samples.map((s) => s.sample_id), prepared.variantNames, false);
+      const report = aggregateReport({
+        runId: 'golden-run', variants: prepared.variantNames, model: 'mock-model', judgeModel: 'mock-judge',
+        noJudge: true, executorName: 'mock-exec', samples: prepared.samples, tasks: prepared.tasks,
+        results, totalCostUSD: 0, artifacts: prepared.artifacts,
+      });
+      assertAllVariantSurfacesEqual(report, prepared.variantNames);
+      assert.ok('git:HEAD:greeter' in report.meta.skillIsolation!, 'git variant name is a report key verbatim');
+      expect(projectVariantSurfaces(report)).toMatchSnapshot();
+    } finally {
+      process.chdir(prevCwd);
+      rmSync(gitRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('case 6 — custom names with no collision are replaced by derived short names', async () => {
+    const { report, variantNames } = await runCase({
+      variantSpecs: [
+        { name: 'my-control', role: 'control', expr: join(root, 'greeter.md') },
+        { name: 'my-treat', role: 'treatment', expr: join(root, 'helper.md') },
+      ],
+    });
+    // spec.name 被派生短名替换,而非保留自定义名 —— 钉住这一行为,重构不能悄悄改
+    assert.deepEqual(variantNames, ['greeter', 'helper']);
+    assertAllVariantSurfacesEqual(report, variantNames);
+    expect(projectVariantSurfaces(report)).toMatchSnapshot();
+  });
+
+  it('case 7 — blind mode remaps every variant surface to A/B/C and round-trips', async () => {
+    const prepared = await prepareEvaluationRun({
+      samplesPath, skillDir: root, dryRun: true,
+      variantSpecs: [ctrl('baseline', 'baseline'), treat(join(root, 'a.md'), 'a'), treat(join(root, 'b.md'), 'b')],
+    });
+    const sampleIds = prepared.samples.map((s) => s.sample_id);
+    const results = buildResults(sampleIds, prepared.variantNames, false);
+    const report = aggregateReport({
+      runId: 'golden-run', variants: prepared.variantNames, model: 'mock-model', judgeModel: 'mock-judge',
+      noJudge: true, executorName: 'mock-exec', samples: prepared.samples, tasks: prepared.tasks,
+      results, totalCostUSD: 0, artifacts: prepared.artifacts,
+    });
+    applyBlindMode(report, prepared.variantNames, 'fixed-seed');
+    // 当前行为(被钉住):blind 只 remap variants / summary / results / executorRuntimes 到 A/B/C,
+    // 不动 artifactHashes / skillIsolation(仍是原始名)。这层不对称是既有事实,重构不能悄悄改;
+    // 若日后要让 blind 也覆盖这两个键面(防泄露),属于行为变更,得显式改这条断言。
+    assert.deepEqual(report.meta.variants, ['A', 'B', 'C']);
+    assert.deepEqual(Object.keys(report.summary).sort(), ['A', 'B', 'C']);
+    assert.deepEqual(Object.keys(report.meta.executorRuntimes ?? {}).sort(), ['A', 'B', 'C']);
+    for (const r of report.results) {
+      assert.deepEqual(Object.keys(r.variants).sort(), ['A', 'B', 'C'], `results[${r.sample_id}]`);
+    }
+    assert.deepEqual(Object.keys(report.meta.artifactHashes ?? {}).sort(), ['a', 'b', 'baseline'], 'artifactHashes NOT remapped');
+    assert.deepEqual(Object.keys(report.meta.skillIsolation ?? {}).sort(), ['a', 'b', 'baseline'], 'skillIsolation NOT remapped');
+    // blindMap 反向映射能把标签还原回原始 variant 名(键往返不丢)
+    const back = new Set(Object.values(report.meta.blindMap ?? {}));
+    assert.deepEqual([...back].sort(), ['a', 'b', 'baseline']);
+  });
+
+  it('generateRunId encodes variant names in order, sanitized', () => {
+    assert.match(generateRunId(['baseline', 'greeter']), /^baseline-vs-greeter-\d{8}-\d{4}$/);
+    assert.match(generateRunId(['v1/greeter', 'v2/greeter']), /^v1-greeter-vs-v2-greeter-\d{8}-\d{4}$/);
+    assert.match(generateRunId(['git:HEAD:greeter']), /^git-HEAD-greeter-\d{8}-\d{4}$/);
+  });
+});

--- a/test/inputs/variant-name-collision.test.ts
+++ b/test/inputs/variant-name-collision.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { ensureUniqueVariantNames, resolveArtifacts, variantIdentity } from '../../src/inputs/skill-loader.js';
+import { ensureUniqueVariantNames, resolveArtifacts, variantIdentity, parseVariantCwd } from '../../src/inputs/skill-loader.js';
 import { resolveVariantSpecs } from '../../src/cli/lib/parse-run-config/variant-resolution.js';
 import { prepareEvaluationRun } from '../../src/eval-workflows/evaluation-preparation.js';
 import type { Artifact } from '../../src/types/eval.js';
@@ -81,6 +81,11 @@ describe('resolveArtifacts — same-basename variants in different dirs', () => 
     assert.deepEqual(names, ['v1/greeter', 'v2/greeter']);
     // 内容确实是两份不同的 skill,没有被覆盖
     assert.notEqual(arts[0].content, arts[1].content);
+  });
+
+  it('rejects an empty variant name (e.g. "@/cwd") instead of silently loading skillDir/SKILL.md', () => {
+    writeFileSync(join(root, 'SKILL.md'), '# top-level skill\n');
+    assert.throws(() => resolveArtifacts(root, ['@/some/cwd']), /不能为空/);
   });
 });
 
@@ -202,5 +207,35 @@ describe('variantIdentity', () => {
   it('leaves baseline and git refs as stable opaque identities', () => {
     assert.equal(variantIdentity('baseline'), 'baseline');
     assert.equal(variantIdentity('git:HEAD:greeter'), 'git:HEAD:greeter');
+  });
+
+  it('folds a symlinked path to the same physical identity (resolve alone would miss it)', () => {
+    const real = join(root, 'realdir');
+    mkdirSync(real, { recursive: true });
+    writeFileSync(join(real, 'SKILL.md'), '# s\n');
+    const link = join(root, 'linkdir');
+    symlinkSync(real, link, 'dir');
+    // 软链目录、真实目录、真实目录的 SKILL.md —— 同一物理文件,必须同 identity
+    assert.equal(variantIdentity(link), variantIdentity(real));
+    assert.equal(variantIdentity(link), variantIdentity(join(real, 'SKILL.md')));
+  });
+
+  it('folds absolute vs realpath-equivalent file to the same identity', () => {
+    const f = join(root, 'g.md');
+    writeFileSync(f, '# g\n');
+    // realpathSync 解掉 /tmp→/private/tmp 这类软链前缀,二者指向同一 inode → 同 identity
+    assert.equal(variantIdentity(f), variantIdentity(realpathSync(f)));
+  });
+});
+
+describe('parseVariantCwd — git ref with @ is not split into cwd', () => {
+  it('keeps a reflog/upstream git ref whole', () => {
+    assert.deepEqual(parseVariantCwd('git:HEAD@{2}:greeter'), { name: 'git:HEAD@{2}:greeter' });
+    assert.deepEqual(parseVariantCwd('git:main@{u}:greeter'), { name: 'git:main@{u}:greeter' });
+    assert.equal(variantIdentity('git:HEAD@{2}:greeter'), 'git:HEAD@{2}:greeter');
+  });
+
+  it('still splits @cwd for non-git variants', () => {
+    assert.deepEqual(parseVariantCwd('my-skill@/proj'), { name: 'my-skill', cwd: '/proj' });
   });
 });

--- a/test/inputs/variant-name-collision.test.ts
+++ b/test/inputs/variant-name-collision.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { ensureUniqueVariantNames, resolveArtifacts } from '../../src/inputs/skill-loader.js';
+import { ensureUniqueVariantNames, resolveArtifacts, variantIdentity } from '../../src/inputs/skill-loader.js';
 import { resolveVariantSpecs } from '../../src/cli/lib/parse-run-config/variant-resolution.js';
 import { prepareEvaluationRun } from '../../src/eval-workflows/evaluation-preparation.js';
 import type { Artifact } from '../../src/types/eval.js';
@@ -113,6 +113,29 @@ describe('CLI dry-run — --control / --treatment same-basename in different dir
     assert.throws(() => resolveVariantSpecs({ control: same, treatment: same }, null, root), /重复出现/);
   });
 
+  it('rejects the same physical skill written two different ways (./x.md vs x.md)', () => {
+    const abs = join(root, 'v1', 'greeter.md');
+    // 用相对写法构造同一份 skill 的另一种写法:control 绝对、treatment 相对(从 root 出发)
+    const rel = `${root}/./v1/greeter.md`;
+    assert.throws(() => resolveVariantSpecs({ control: abs, treatment: rel }, null, root), /重复出现/);
+  });
+
+  it('rejects a dir-skill vs its SKILL.md (same skill root)', () => {
+    const skillDir = join(root, 'dirskill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '# dir skill\n');
+    assert.throws(
+      () => resolveVariantSpecs({ control: skillDir, treatment: join(skillDir, 'SKILL.md') }, null, root),
+      /重复出现/,
+    );
+  });
+
+  it('allows the same skill bound to two different cwds (distinct runtime contexts)', () => {
+    const skill = join(root, 'v1', 'greeter.md');
+    const specs = resolveVariantSpecs({ control: `${skill}@${root}/v1`, treatment: `${skill}@${root}/v2` }, null, root);
+    assert.equal(specs.length, 2);
+  });
+
   it('prepareEvaluationRun assigns distinct names AND a role to each variant (regression)', async () => {
     const variantSpecs = resolveVariantSpecs(
       { control: join(root, 'v1', 'greeter.md'), treatment: join(root, 'v2', 'greeter.md') },
@@ -126,5 +149,58 @@ describe('CLI dry-run — --control / --treatment same-basename in different dir
     assert.deepEqual(prepared.artifacts.map((a) => a.experimentRole), ['control', 'treatment']);
     // spec.name 已同步成消歧后的唯一名,与 report / variantNames 一致
     assert.deepEqual(variantSpecs.map((s) => s.name), ['v1/greeter', 'v2/greeter']);
+  });
+
+  it('keeps an eval.yaml-style explicit name + allowedSkills wired to the right artifact', async () => {
+    // 模拟 eval.yaml:variant 名(control-v1)与 artifact 路径短名(greeter)不同,且声明 allowedSkills:[]。
+    // variantAllowedSkills 按 config 名建索引,resolveArtifacts 按 artifact 短名查会漏绑 —— 这里验证 index 分支把它补回来。
+    const variantSpecs = [{ name: 'control-v1', role: 'control' as const, expr: join(root, 'v1', 'greeter.md') }];
+    const prepared = await prepareEvaluationRun({
+      samplesPath,
+      skillDir: root,
+      variantSpecs,
+      dryRun: true,
+      variantAllowedSkills: { 'control-v1': [] },
+    });
+    assert.equal(prepared.artifacts.length, 1);
+    // allowedSkills 必须落到 artifact 上(=[] 表示隔离),不能是 undefined(=SDK 默认 discovery)
+    assert.deepEqual(prepared.artifacts[0].allowedSkills, []);
+    assert.equal(prepared.artifacts[0].experimentRole, 'control');
+  });
+});
+
+describe('variantIdentity', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'omk-vid-'));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('folds ./x.md and x.md (relative spellings) to the same identity', () => {
+    const f = join(root, 'x.md');
+    writeFileSync(f, '# x\n');
+    assert.equal(variantIdentity(f), variantIdentity(`${root}/./x.md`));
+  });
+
+  it('folds a dir-skill and its SKILL.md to the same identity', () => {
+    const d = join(root, 'skill');
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, 'SKILL.md'), '# s\n');
+    assert.equal(variantIdentity(d), variantIdentity(join(d, 'SKILL.md')));
+  });
+
+  it('keeps different basenames in different dirs distinct', () => {
+    assert.notEqual(variantIdentity('/repo/v1/greeter.md'), variantIdentity('/repo/v2/greeter.md'));
+  });
+
+  it('treats the same skill with different cwd as different identities', () => {
+    const f = join(root, 'x.md');
+    writeFileSync(f, '# x\n');
+    assert.notEqual(variantIdentity(`${f}@${root}/a`), variantIdentity(`${f}@${root}/b`));
+  });
+
+  it('leaves baseline and git refs as stable opaque identities', () => {
+    assert.equal(variantIdentity('baseline'), 'baseline');
+    assert.equal(variantIdentity('git:HEAD:greeter'), 'git:HEAD:greeter');
   });
 });

--- a/test/inputs/variant-name-collision.test.ts
+++ b/test/inputs/variant-name-collision.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, realpathSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ensureUniqueVariantNames, resolveArtifacts, variantIdentity, parseVariantCwd } from '../../src/inputs/skill-loader.js';
@@ -238,14 +239,46 @@ describe('variantIdentity', () => {
   });
 });
 
-describe('parseVariantCwd — git ref with @ is not split into cwd', () => {
-  it('keeps a reflog/upstream git ref whole', () => {
+describe('parseVariantCwd — protects git @{...} but still splits a trailing @cwd', () => {
+  it('keeps a reflog/upstream git ref whole (no cwd)', () => {
     assert.deepEqual(parseVariantCwd('git:HEAD@{2}:greeter'), { name: 'git:HEAD@{2}:greeter' });
     assert.deepEqual(parseVariantCwd('git:main@{u}:greeter'), { name: 'git:main@{u}:greeter' });
     assert.equal(variantIdentity('git:HEAD@{2}:greeter'), 'git:HEAD@{2}:greeter');
   });
 
+  it('still splits a trailing @cwd off a git artifact (eval.yaml git + cwd form)', () => {
+    // configVariantsToSpecs 把 `artifact: git:my-skill` + `cwd: /proj` 合成 `git:my-skill@/proj`
+    assert.deepEqual(parseVariantCwd('git:my-skill@/tmp/project'), { name: 'git:my-skill', cwd: '/tmp/project' });
+    // reflog ref 内部的 @{...} 不切,末尾的 @cwd 仍切
+    assert.deepEqual(parseVariantCwd('git:HEAD@{2}:greeter@/proj'), { name: 'git:HEAD@{2}:greeter', cwd: '/proj' });
+  });
+
   it('still splits @cwd for non-git variants', () => {
     assert.deepEqual(parseVariantCwd('my-skill@/proj'), { name: 'my-skill', cwd: '/proj' });
+  });
+});
+
+describe('resolveArtifacts — git artifact bound to a cwd (regression: @{...} guard must not eat @cwd)', () => {
+  it('loads the git skill AND sets artifact.cwd from the trailing @cwd', () => {
+    const gitRoot = realpathSync(mkdtempSync(join(tmpdir(), 'omk-gitcwd-')));
+    const sh = (args: string[]): void => { execFileSync('git', args, { cwd: gitRoot, stdio: 'ignore' }); };
+    const prevCwd = process.cwd();
+    try {
+      sh(['init']);
+      sh(['config', 'user.email', 't@t.co']);
+      sh(['config', 'user.name', 't']);
+      writeFileSync(join(gitRoot, 'greeter.md'), '# git greeter\n');
+      sh(['add', '.']);
+      sh(['commit', '-m', 'seed']);
+      process.chdir(gitRoot);
+      const arts = resolveArtifacts(gitRoot, [`git:greeter@${gitRoot}/proj`]);
+      assert.equal(arts.length, 1);
+      assert.equal(arts[0].source, 'git');
+      assert.equal(arts[0].content, '# git greeter');
+      assert.equal(arts[0].cwd, `${gitRoot}/proj`, 'cwd must survive the git @{...} guard');
+    } finally {
+      process.chdir(prevCwd);
+      rmSync(gitRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/test/inputs/variant-name-collision.test.ts
+++ b/test/inputs/variant-name-collision.test.ts
@@ -141,6 +141,16 @@ describe('CLI dry-run — --control / --treatment same-basename in different dir
     assert.equal(specs.length, 2);
   });
 
+  it('rejects a bare skill name vs its path form pointing at the same file (skillDir base)', () => {
+    // skillDir 下放一个 greeter.md;`greeter`(裸名,按 skillDir 解析)与 `<skillDir>/greeter.md`
+    // (路径)指向同一物理文件 → 必须判为重复,否则会变成同一份 skill 自比。
+    writeFileSync(join(root, 'greeter.md'), '# top greeter\n');
+    assert.throws(
+      () => resolveVariantSpecs({ control: 'greeter', treatment: join(root, 'greeter.md') }, null, root),
+      /重复出现/,
+    );
+  });
+
   it('prepareEvaluationRun assigns distinct names AND a role to each variant (regression)', async () => {
     const variantSpecs = resolveVariantSpecs(
       { control: join(root, 'v1', 'greeter.md'), treatment: join(root, 'v2', 'greeter.md') },

--- a/test/inputs/variant-name-collision.test.ts
+++ b/test/inputs/variant-name-collision.test.ts
@@ -4,6 +4,8 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ensureUniqueVariantNames, resolveArtifacts } from '../../src/inputs/skill-loader.js';
+import { resolveVariantSpecs } from '../../src/cli/lib/parse-run-config/variant-resolution.js';
+import { prepareEvaluationRun } from '../../src/eval-workflows/evaluation-preparation.js';
 import type { Artifact } from '../../src/types/eval.js';
 
 const skill = (name: string, over: Partial<Artifact> = {}): Artifact => ({
@@ -79,5 +81,50 @@ describe('resolveArtifacts — same-basename variants in different dirs', () => 
     assert.deepEqual(names, ['v1/greeter', 'v2/greeter']);
     // 内容确实是两份不同的 skill,没有被覆盖
     assert.notEqual(arts[0].content, arts[1].content);
+  });
+});
+
+describe('CLI dry-run — --control / --treatment same-basename in different dirs', () => {
+  let root: string;
+  let samplesPath: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'omk-variant-cli-'));
+    for (const v of ['v1', 'v2']) {
+      mkdirSync(join(root, v), { recursive: true });
+      writeFileSync(join(root, v, 'greeter.md'), `# greeter ${v}\n`);
+    }
+    samplesPath = join(root, 'samples.json');
+    writeFileSync(samplesPath, JSON.stringify([{ sample_id: 's1', prompt: '你好' }]));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('resolveVariantSpecs does not flag two different paths as a duplicate variant', () => {
+    const specs = resolveVariantSpecs(
+      { control: join(root, 'v1', 'greeter.md'), treatment: join(root, 'v2', 'greeter.md') },
+      null,
+      root,
+    );
+    assert.equal(specs.length, 2);
+    assert.deepEqual(specs.map((s) => s.role), ['control', 'treatment']);
+  });
+
+  it('resolveVariantSpecs still rejects the same expr in control and treatment', () => {
+    const same = join(root, 'v1', 'greeter.md');
+    assert.throws(() => resolveVariantSpecs({ control: same, treatment: same }, null, root), /重复出现/);
+  });
+
+  it('prepareEvaluationRun assigns distinct names AND a role to each variant (regression)', async () => {
+    const variantSpecs = resolveVariantSpecs(
+      { control: join(root, 'v1', 'greeter.md'), treatment: join(root, 'v2', 'greeter.md') },
+      null,
+      root,
+    );
+    const prepared = await prepareEvaluationRun({ samplesPath, skillDir: root, variantSpecs, dryRun: true });
+    assert.equal(prepared.artifacts.length, 2);
+    assert.deepEqual(prepared.variantNames, ['v1/greeter', 'v2/greeter']);
+    // 两个 artifact 都拿到了 experimentRole(否则 buildVariantConfig 会抛 “缺少 experimentRole”)
+    assert.deepEqual(prepared.artifacts.map((a) => a.experimentRole), ['control', 'treatment']);
+    // spec.name 已同步成消歧后的唯一名,与 report / variantNames 一致
+    assert.deepEqual(variantSpecs.map((s) => s.name), ['v1/greeter', 'v2/greeter']);
   });
 });

--- a/test/inputs/variant-name-collision.test.ts
+++ b/test/inputs/variant-name-collision.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ensureUniqueVariantNames, resolveArtifacts } from '../../src/inputs/skill-loader.js';
+import type { Artifact } from '../../src/types/eval.js';
+
+const skill = (name: string, over: Partial<Artifact> = {}): Artifact => ({
+  name,
+  kind: 'skill',
+  source: 'file-path',
+  content: 'x',
+  ...over,
+});
+
+describe('ensureUniqueVariantNames', () => {
+  it('leaves already-unique names untouched', () => {
+    const arts = [skill('greeter', { locator: '/a/greeter.md' }), skill('helper', { locator: '/a/helper.md' })];
+    ensureUniqueVariantNames(arts);
+    assert.deepEqual(arts.map((a) => a.name), ['greeter', 'helper']);
+  });
+
+  it('disambiguates same-basename file variants by parent dir', () => {
+    const arts = [
+      skill('greeter', { locator: '/repo/v1/greeter.md' }),
+      skill('greeter', { locator: '/repo/v2/greeter.md' }),
+    ];
+    ensureUniqueVariantNames(arts);
+    assert.deepEqual(arts.map((a) => a.name), ['v1/greeter', 'v2/greeter']);
+  });
+
+  it('disambiguates SKILL.md dir skills by the dir above the skill root', () => {
+    const arts = [
+      skill('greeter', { locator: '/repo/v1/greeter/SKILL.md', skillRoot: '/repo/v1/greeter' }),
+      skill('greeter', { locator: '/repo/v2/greeter/SKILL.md', skillRoot: '/repo/v2/greeter' }),
+    ];
+    ensureUniqueVariantNames(arts);
+    assert.deepEqual(arts.map((a) => a.name), ['v1/greeter', 'v2/greeter']);
+  });
+
+  it('walks further up the path when the immediate parent also collides', () => {
+    const arts = [
+      skill('greeter', { locator: '/repo/a/v1/greeter.md' }),
+      skill('greeter', { locator: '/repo/b/v1/greeter.md' }),
+    ];
+    ensureUniqueVariantNames(arts);
+    assert.deepEqual(arts.map((a) => a.name), ['a/v1/greeter', 'b/v1/greeter']);
+  });
+
+  it('falls back to a numeric suffix when no path is available (e.g. baseline)', () => {
+    const arts = [
+      skill('x', { kind: 'baseline', source: 'baseline', content: null }),
+      skill('x', { kind: 'baseline', source: 'baseline', content: null }),
+    ];
+    ensureUniqueVariantNames(arts);
+    const names = arts.map((a) => a.name);
+    assert.equal(new Set(names).size, 2, `expected unique names, got ${names.join(',')}`);
+    assert.ok(names.includes('x') && names.includes('x#2'), names.join(','));
+  });
+});
+
+describe('resolveArtifacts — same-basename variants in different dirs', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'omk-variant-'));
+    for (const v of ['v1', 'v2']) {
+      mkdirSync(join(root, v), { recursive: true });
+      writeFileSync(join(root, v, 'greeter.md'), `# greeter ${v}\n`);
+    }
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('does not collapse two same-named skills into one (regression)', () => {
+    const arts = resolveArtifacts(root, [join(root, 'v1', 'greeter.md'), join(root, 'v2', 'greeter.md')]);
+    assert.equal(arts.length, 2);
+    const names = arts.map((a) => a.name);
+    assert.equal(new Set(names).size, 2, `variant names must stay distinct, got ${names.join(',')}`);
+    assert.deepEqual(names, ['v1/greeter', 'v2/greeter']);
+    // 内容确实是两份不同的 skill,没有被覆盖
+    assert.notEqual(arts[0].content, arts[1].content);
+  });
+});


### PR DESCRIPTION
## 为什么

变更前同一个 variant 表达式在代码里被独立派生成名字/身份多处（`variantExprToSkillName`、`resolveArtifacts` 内联、`identityPathOf`、`variantIdentity`），再叠加按字符串名互查的角色/隔离绑定。这套碎片化导致一类数据正确性 bug：`v1/greeter.md` 与 `v2/greeter.md` 短名都叫 `greeter`，而 `artifact.name` 是 `results[sample][variant]` / `summary[variant]` / report 各处的键，后写覆盖前写，把对照/实验组结果搅在一起、verdict 拿同名自比——静默破坏对比可信度，正是 omk 自己最该防的失败。

本 PR 把这条链路完整收口：先修正确性，再用端到端 golden 钉住报告键，最后做行为保持的重构消除碎片化根因。

## 用户影响

- `omk eval --control v1/greeter.md --treatment v2/greeter.md`（同 basename 分目录）不再静默合并，两个 variant 拿到各自唯一名 `v1/greeter` / `v2/greeter`，落到 report 每个键面。
- variant 判重改按规范化物理身份（路径 resolve、目录与 SKILL.md 折叠、cwd 纳入）：`./x.md` 与 `x.md`、`dir` 与 `dir/SKILL.md` 判为同一 variant；不同路径同 basename 不再误判重复。
- eval.yaml 自定义 variant 名 + `allowedSkills`：隔离声明不再因「自定义名 vs 路径短名」不一致而漏绑（此前会静默退回 SDK 默认 discovery，破坏 construct validity）。

## 改了什么（分层，可独立回溯到各 commit）

1. 修复（3 commit）：同名按路径消歧防互相覆盖；role 按 expr 判重、按 index 绑定；判重按规范化身份、allowedSkills 按 spec 重绑。
2. golden（1 commit）：端到端 `prepareEvaluationRun(dryRun)` → `aggregateReport()` 钉住全部 variant 键面（`meta.variants` / `summary` / `results[].variants` / `artifactHashes` / `skillIsolation` / `executorRuntimes` / `pairComparisons` / `runId`），7 类配置 + 头号不变量「所有键面共享同一组键」。已做验伪：临时改坏派生名 golden 立刻飘红。
3. 重构（3 commit，行为保持）：短名派生收成单一 `skillNameFromPath`；dir↔SKILL.md 折叠抽成 `canonicalSkillAnchor`；`allowedSkills` 随 `VariantSpec` 走、收掉并行名表。golden 全程 byte-identical 即证。

## 测量学

不改任何测量学不变量——本 PR 反而把「variant 报告键」这组不变量钉成可执行护栏。`resolveArtifacts` 公开签名保持稳定（doctor/batch/loadSkills 不动）。

## 已知后续

batch 路径仍保留按 variant 名 → skill 路径的 remap workaround（`batch-evaluation-workflow.ts`）。golden 不覆盖 batch，故本 PR 不动它；统一到同一 spec binder 留作单独跟进，避免无护栏盲改。

并入说明：原 golden 拆分 PR #182 的内容已收进本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)