### PR TITLE
chore(release): 发布 0.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## 0.33.0

自 v0.32.0 累积的发版。版本号 `0.32.0 → 0.33.0`(pre-1.0 minor)。完整 release notes 由 GitHub 从 tag 间 PR 列表自动生成,本说明只汇总用户影响与迁移要点。

## 主要内容

- variant 命名链路完整收口(#181):修同 basename 分目录(`v1/greeter.md` vs `v2/greeter.md`)对照/实验组结果互相覆盖;判重改用物理身份(`dev:ino`,认软链/大小写/裸名 vs 路径混写);role 与 allowedSkills 按 spec 绑定;新增端到端 golden 钉住报告键。
- observe 健康度加统计可信度护栏(#175)。
- 评委 ensemble 强烈分歧时降级 verdict(#172)。
- `omk sample --from-traces` 把 observe 失败信号回流成回归用例草稿(#174)。
- evolve 加 holdout 切分、accept 看验收集分防 train-on-test(#173)。
- statistical-rigor bootstrap 默认值对齐 + doc-vs-code 漂移门禁(#171)。
- CLI 升级提示加落盘缓存 + 节流,TTY 下高亮框展示(#179)。

## BREAKING-COMPARABILITY 迁移

本版含三处影响跨版本报告可比性的变更,跨大版本对比 verdict / Δ 前请重新基线:

- 评委 ensemble 强烈分歧降级 verdict(#172):composite verdict 在评委严重分歧时会降级,旧报告与本版的 verdict 不可直接互比。
- observe 健康度统计可信度护栏(#175):runtimeAssessment 口径变化,observe 历史日报需在本版重新生成后再纵向对比。
- variant name 统一为短名 + 历史列表(#178):report 中 variant 键语义调整,跨该版本的 variant 级对比需重算。

各项详细迁移步骤见对应 PR description。

## 测量学

#181 经 golden 验证报告键 byte-identical,不引入新的可比性破坏;上述三项已在各自 PR 标 BREAKING-COMPARABILITY。

🤖 Generated with [Claude Code](https://claude.com/claude-code)