### PR TITLE
refactor(eval)!: 移除 name@cwd，cwd 全程结构化（BREAKING CLI）

### DIFF
--- a/.claude/skills/omk/references/commands.md
+++ b/.claude/skills/omk/references/commands.md
@@ -74,7 +74,8 @@ omk eval [flags]
 - `--budget-usd` `option`:总预算上限 USD（必须 > 0，不传则无上限）
 - `--concurrency` `option`:并发数，默认 1
 - `--config` `option`:eval.yaml 路径
-- `--control` `option`:control variant 表达式
+- `--control` `option`:control variant 表达式（仅 artifact 身份）
+- `--control-cwd` `option`:control 的 runtime context 目录
 - `--dry-run` `boolean`:只 plan 不实跑
 - `--effort` `option`:被测 LLM 扩展思考预算 low/medium/high/xhigh/max（默认 low；跨 effort 报告不严格可比）。
 - `--executor` `option`:执行器:claude / claude-sdk / codex / codex-sdk / openai-api / gemini / 自定义命令（默认 claude）。
@@ -104,7 +105,8 @@ omk eval [flags]
 - `--strict-baseline` `boolean`:强制 baseline 隔离（default true）
 - `--threshold` `option`:verdict 阈值，默认 3.5
 - `--timeout` `option`:单样本超时秒，默认 600
-- `--treatment` `option`:treatment variant 列表，逗号分隔
+- `--treatment` `option`:treatment variant 列表，逗号分隔（仅 artifact 身份）
+- `--treatment-cwd` `option`:treatment 的 runtime context 目录列表，逗号分隔、与 --treatment 按序对齐（空位 = 无 cwd）
 - `--trivial-diff` `option`:可忽略 diff 容差，0 表示不启用容差
 - `--verbose` `boolean`:详细日志
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -6,7 +6,7 @@ Core idea: **fix the model and the samples, vary only the artifact and runtime c
 flowchart TD
     subgraph Input["① Input"]
         S["eval-samples<br/>(JSON / YAML)"]
-        A["artifacts<br/>skills/*.md · SKILL.md<br/>baseline · git:name · @cwd"]
+        A["artifacts<br/>skills/*.md · SKILL.md<br/>baseline · git:name"]
     end
 
     subgraph Prep["② Preprocess (resolve & fetch)"]
@@ -58,7 +58,7 @@ flowchart TD
 **Key design choices:**
 
 - **Interleaved scheduling** removes time drift: different variants of the same sample are dispatched alternately rather than "all of v1 then all of v2", so model load / network jitter can't be mis-attributed to the artifact.
-- **variant = artifact + runtime context**: `name@cwd` lets control groups explicitly declare the "project directory" input, separating "project-level accumulated knowledge" from "explicit artifact injection".
+- **variant = artifact + runtime context**: the `cwd` (declared via `--control-cwd`/`--treatment-cwd` or eval.yaml's `cwd:` field, separate from the artifact expression) lets control groups explicitly declare the "project directory" input, separating "project-level accumulated knowledge" from "explicit artifact injection".
 - **Dual-channel scoring is complementary**: assertions catch deterministic defects (must call tool X, must contain field Y); the LLM judge catches subjective quality (readability, completeness). Mean is taken when both are present.
 - **Knowledge-gap signals** are not part of the score — they are an independent tracking channel that tells you "how much risk exposure this evaluation covered", for convergence tracking, not as a completeness proof.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -89,7 +89,8 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
   --budget-usd <value>            Total budget cap USD (must be > 0; omit for no cap)
   --concurrency <value>           Concurrency, default 1
   --config <value>                eval.yaml path
-  --control <value>               Control variant expr
+  --control <value>               Control variant expr (artifact identity only)
+  --control-cwd <value>           Runtime context dir for control
   --dry-run                       Plan only, no real exec
   --effort <value>                Executor LLM reasoning effort low/medium/high/xhigh/max (default low; reports across efforts not strictly comparable).
   --executor <value>              Executor: claude / claude-sdk / codex / codex-sdk / openai-api / gemini / custom (default claude).
@@ -119,7 +120,8 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
   --strict-baseline               Force baseline isolation (default true)
   --threshold <value>             Verdict threshold, default 3.5
   --timeout <value>               Per-sample timeout sec, default 600
-  --treatment <value>             Treatment variants, comma-separated
+  --treatment <value>             Treatment variants, comma-separated (artifact identity only)
+  --treatment-cwd <value>         Runtime context dirs for treatments, comma-separated, index-aligned with --treatment (blank = none)
   --trivial-diff <value>          Trivial diff tolerance; 0 disables tolerance
   --verbose                       Verbose logging
 ```

--- a/docs/reference/executors.md
+++ b/docs/reference/executors.md
@@ -53,11 +53,17 @@ skills/
 |---|---|
 | `name` | looks up `name.md` or `name/SKILL.md` in the artifact dir, resolves to one artifact |
 | `baseline` | empty artifact, no system prompt — think "nothing at all" |
-| `project-env@/path/to/project` | empty artifact, but run in the specified project dir — observe project-level runtime context alone |
+| `project-env` (any non-skill label) | empty artifact; pair with a cwd (below) to run in a project dir — observe project-level runtime context alone |
 | `git:name` | reads the last-committed version of an artifact from git HEAD |
 | `git:ref:name` | reads an artifact from a specific commit |
 | `./path/to/file.md` | path with `/`: read the file directly as an artifact |
-| `variant@/path/to/project` | attach a run dir to any variant; supports `name@cwd`, `git:name@cwd`, `/file.md@cwd` |
+
+The `variant` expression carries **artifact identity only**. Runtime context (`cwd`) is declared separately:
+
+- on the CLI via `--control-cwd <dir>` and `--treatment-cwd <dir,...>` (the latter is comma-separated and index-aligned with `--treatment`; leave a slot blank for "no cwd");
+- per-variant in `eval.yaml` via the structured `cwd:` field.
+
+The old `name@cwd` string syntax has been removed.
 
 When both `--control` and `--treatment` are omitted, use `--config eval.yaml` or `--batch`. With `--batch`, `baseline` is auto-added as control and every discovered artifact becomes a treatment.
 
@@ -70,12 +76,12 @@ omk eval --control baseline --treatment v1,v2,v3
 omk eval --control baseline --treatment my-skill
 
 # observe project-level runtime context in isolation (use a self-describing label)
-omk eval --control baseline --treatment project-env@/path/to/target-project
+omk eval --control baseline --treatment project-env --treatment-cwd /path/to/target-project
 
 # compare "project-level runtime context" vs "explicit artifact injection"
 omk eval \
-  --control project-env@/path/to/target-project \
-  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md@/path/to/target-project
+  --control project-env --control-cwd /path/to/target-project \
+  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md --treatment-cwd /path/to/target-project
 
 # before vs after (old version read from git history)
 omk eval --control git:my-skill --treatment my-skill
@@ -150,7 +156,7 @@ No system prompt, but runs inside a project dir. This is **not** a strict "bare 
 omk eval \
   --executor claude-sdk \
   --control baseline \
-  --treatment project-env@/path/to/target-project
+  --treatment project-env --treatment-cwd /path/to/target-project
 ```
 
 **3. Explicit artifact injection**
@@ -160,8 +166,8 @@ Inject an external `SKILL.md` as the artifact while also keeping the project dir
 ```bash
 omk eval \
   --executor claude-sdk \
-  --control project-env@/path/to/target-project \
-  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md@/path/to/target-project
+  --control project-env --control-cwd /path/to/target-project \
+  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md --treatment-cwd /path/to/target-project
 ```
 
 ### Recommended first-round design
@@ -173,7 +179,7 @@ omk eval \
   --executor claude-sdk \
   --samples skills/evaluate-review/eval-samples.yaml \
   --control baseline \
-  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md@/path/to/target-project
+  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md --treatment-cwd /path/to/target-project
 ```
 
 If you want to prove whether "the knowledge sitting inside the project directory" is effective on its own, add a second treatment:
@@ -183,7 +189,8 @@ omk eval \
   --executor claude-sdk \
   --samples skills/evaluate-review/eval-samples.yaml \
   --control baseline \
-  --treatment project-env@/path/to/target-project,/path/to/target-project/.claude/skills/prd/SKILL.md@/path/to/target-project
+  --treatment project-env,/path/to/target-project/.claude/skills/prd/SKILL.md \
+  --treatment-cwd /path/to/target-project,/path/to/target-project
 ```
 
 ### Design tips

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -58,7 +58,7 @@
 
 - `baseline`
 - `prd`
-- `/path/to/SKILL.md@/path/to/project`
+- `/path/to/SKILL.md`（runtime context 的 cwd 单独声明，不编码进表达式）
 
 规则：
 
@@ -98,8 +98,8 @@
 
 规则：
 
-- `cwd` 归属于 runtime context
-- 如果要表达"空 artifact + 指定 runtime context"，推荐使用自描述标签，例如 `project-env@/path/to/project`
+- `cwd` 归属于 runtime context，单独声明（CLI 的 `--control-cwd` / `--treatment-cwd`，或 eval.yaml 的结构化 `cwd:` 字段），不编码进 variant 表达式
+- 如果要表达"空 artifact + 指定 runtime context"，用自描述标签作 artifact、cwd 单独给，例如 `--treatment project-env --treatment-cwd /path/to/project`
 - 不要把项目目录、项目级 runtime context、显式 artifact 注入混成一个概念
 
 ### 6. Sample / 用例
@@ -164,7 +164,7 @@ Sample schema 含 4 个可选元数据字段,纯文档 / 诊断用,**不参与 g
 
 如果要单独观察项目级 runtime context，推荐显式写成：
 
-- `project-env@/path/to/project`
+- artifact 用自描述标签 `project-env`，cwd 用 `--treatment-cwd /path/to/project`（或 eval.yaml 的 `cwd:` 字段）
 
 这里的 `project-env` 只是实验分组标签，真正的语义是"空 artifact + 指定 runtime context"。
 
@@ -266,7 +266,7 @@ omk 的具体实现：`--repeat N` 让同一 (variant × sample) 跑 N 次，`re
 
 - 使用 `--control <expr>` + `--treatment <v1,v2,...>` 按 experiment role 声明 variant
 - variant 表达式解析为 artifact 与 runtime context
-- 示例对象尽量写具体路径或具体名称，不用 `skill@...` 代替所有场景
+- 示例对象尽量写具体路径或具体名称，不用泛化占位代替所有场景
 - 复杂实验配置推荐用 `--config eval.yaml`，CLI 参数只承担简单场景
 
 ### 3. 报告与验收

--- a/docs/zh/explanation/architecture.md
+++ b/docs/zh/explanation/architecture.md
@@ -6,7 +6,7 @@
 flowchart TD
     subgraph Input["① 输入"]
         S["eval-samples<br/>(JSON / YAML)"]
-        A["artifacts<br/>skills/*.md · SKILL.md<br/>baseline · git:name · @cwd"]
+        A["artifacts<br/>skills/*.md · SKILL.md<br/>baseline · git:name"]
     end
 
     subgraph Prep["② 预处理(解析与抓取)"]
@@ -58,7 +58,7 @@ flowchart TD
 **关键设计：**
 
 - **交错调度**消除时间漂移：同一样本的不同 variant 交替发出，而非 v1 全跑完再跑 v2，避免模型负载/网络波动被错误归因给 artifact。
-- **variant = artifact + runtime context**：`name@cwd` 让对照组可以显式声明「项目目录」这个隐性输入，把「项目级沉淀」和「显式 artifact 注入」拆开测。
+- **variant = artifact + runtime context**：`cwd`（用 `--control-cwd`/`--treatment-cwd` 或 eval.yaml 的 `cwd:` 字段声明，与 artifact 表达式分开）让对照组可以显式声明「项目目录」这个隐性输入，把「项目级沉淀」和「显式 artifact 注入」拆开测。
 - **双通道评分互补**：断言抓确定性缺陷（必须调用某工具/必须包含某字段），LLM 评委抓主观质量（可读性/完整性），两者都存在时取均值。
 - **知识缺口信号**不是评分的一部分，而是一个独立追踪项：它告诉你「这次评测覆盖了多少风险敞口」，用于追踪收敛，而非断言知识「完备」。
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -89,7 +89,8 @@ omk eval gold compare <report-id> --gold-dir gold-dataset
   --budget-usd <value>            总预算上限 USD（必须 > 0，不传则无上限）
   --concurrency <value>           并发数，默认 1
   --config <value>                eval.yaml 路径
-  --control <value>               control variant 表达式
+  --control <value>               control variant 表达式（仅 artifact 身份）
+  --control-cwd <value>           control 的 runtime context 目录
   --dry-run                       只 plan 不实跑
   --effort <value>                被测 LLM 扩展思考预算 low/medium/high/xhigh/max（默认 low；跨 effort 报告不严格可比）。
   --executor <value>              执行器:claude / claude-sdk / codex / codex-sdk / openai-api / gemini / 自定义命令（默认 claude）。
@@ -119,7 +120,8 @@ omk eval gold compare <report-id> --gold-dir gold-dataset
   --strict-baseline               强制 baseline 隔离（default true）
   --threshold <value>             verdict 阈值，默认 3.5
   --timeout <value>               单样本超时秒，默认 600
-  --treatment <value>             treatment variant 列表，逗号分隔
+  --treatment <value>             treatment variant 列表，逗号分隔（仅 artifact 身份）
+  --treatment-cwd <value>         treatment 的 runtime context 目录列表，逗号分隔、与 --treatment 按序对齐（空位 = 无 cwd）
   --trivial-diff <value>          可忽略 diff 容差，0 表示不启用容差
   --verbose                       详细日志
 ```

--- a/docs/zh/reference/executors.md
+++ b/docs/zh/reference/executors.md
@@ -53,11 +53,17 @@ skills/
 |------|------|
 | `name` | 从 artifact 目录查找 `name.md` 或 `name/SKILL.md`，解析为一个 artifact |
 | `baseline` | 空 artifact，不使用 system prompt；可直接理解为「什么都没有」 |
-| `project-env@/path/to/project` | 空 artifact，但在指定项目目录运行，用于单独观察项目级 runtime context |
+| `project-env`（任意非 skill 标签） | 空 artifact，配合下方的 cwd 在指定项目目录运行，用于单独观察项目级 runtime context |
 | `git:name` | 从 git HEAD 读取一个 artifact 的上次提交版本 |
 | `git:ref:name` | 从 git 指定 commit 读取一个 artifact |
 | `./path/to/file.md` | 含 `/` 的路径，直接读取文件作为 artifact |
-| `variant@/path/to/project` | 给任意变体附加运行目录，支持 `name@cwd`、`git:name@cwd`、`/file.md@cwd` |
+
+`variant` 表达式只表达 **artifact 身份**。runtime context（`cwd`）单独声明：
+
+- CLI 上用 `--control-cwd <dir>` 与 `--treatment-cwd <dir,...>`（后者逗号分隔，与 `--treatment` 按序对齐，留空位 = 该 treatment 无 cwd）；
+- eval.yaml 里用每个 variant 的结构化 `cwd:` 字段。
+
+旧的 `name@cwd` 字符串语法已移除。
 
 `--control` 和 `--treatment` 都不传时，用 `--config eval.yaml` 或 `--batch`。`--batch` 模式下会自动用 `baseline` 作对照组，每个被发现的 artifact 作实验组。
 
@@ -70,12 +76,12 @@ omk eval --control baseline --treatment v1,v2,v3
 omk eval --control baseline --treatment my-skill
 
 # 单独观察项目级 runtime context 的影响(用自描述标签)
-omk eval --control baseline --treatment project-env@/path/to/target-project
+omk eval --control baseline --treatment project-env --treatment-cwd /path/to/target-project
 
 # 对比「项目级 runtime context」与「显式 artifact 注入」
 omk eval \
-  --control project-env@/path/to/target-project \
-  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md@/path/to/target-project
+  --control project-env --control-cwd /path/to/target-project \
+  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md --treatment-cwd /path/to/target-project
 
 # 对比修改前后(旧版本从 git 历史读取)
 omk eval --control git:my-skill --treatment my-skill
@@ -150,7 +156,7 @@ omk eval \
 omk eval \
   --executor claude-sdk \
   --control baseline \
-  --treatment project-env@/path/to/target-project
+  --treatment project-env --treatment-cwd /path/to/target-project
 ```
 
 **3. 显式 artifact 注入**
@@ -160,8 +166,8 @@ omk eval \
 ```bash
 omk eval \
   --executor claude-sdk \
-  --control project-env@/path/to/target-project \
-  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md@/path/to/target-project
+  --control project-env --control-cwd /path/to/target-project \
+  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md --treatment-cwd /path/to/target-project
 ```
 
 ### 推荐的第一轮对照设计
@@ -173,7 +179,7 @@ omk eval \
   --executor claude-sdk \
   --samples skills/evaluate-review/eval-samples.yaml \
   --control baseline \
-  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md@/path/to/target-project
+  --treatment /path/to/target-project/.claude/skills/prd/SKILL.md --treatment-cwd /path/to/target-project
 ```
 
 如果你想证明「项目目录中的知识沉淀本身」是否有效，加第二个 treatment：
@@ -183,7 +189,8 @@ omk eval \
   --executor claude-sdk \
   --samples skills/evaluate-review/eval-samples.yaml \
   --control baseline \
-  --treatment project-env@/path/to/target-project,/path/to/target-project/.claude/skills/prd/SKILL.md@/path/to/target-project
+  --treatment project-env,/path/to/target-project/.claude/skills/prd/SKILL.md \
+  --treatment-cwd /path/to/target-project,/path/to/target-project
 ```
 
 ### 设计建议

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -365,12 +365,24 @@ export default class Eval extends BaseCommand {
     lang: LANG_FLAG,
     // ── 实验角色 ──
     control: Flags.string({
-      description: bilingual({ zh: 'control variant 表达式', en: 'Control variant expr' }),
+      description: bilingual({ zh: 'control variant 表达式（仅 artifact 身份）', en: 'Control variant expr (artifact identity only)' }),
     }),
     treatment: Flags.string({
       description: bilingual({
-        zh: 'treatment variant 列表，逗号分隔',
-        en: 'Treatment variants, comma-separated',
+        zh: 'treatment variant 列表，逗号分隔（仅 artifact 身份）',
+        en: 'Treatment variants, comma-separated (artifact identity only)',
+      }),
+    }),
+    'control-cwd': Flags.string({
+      description: bilingual({
+        zh: 'control 的 runtime context 目录',
+        en: 'Runtime context dir for control',
+      }),
+    }),
+    'treatment-cwd': Flags.string({
+      description: bilingual({
+        zh: 'treatment 的 runtime context 目录列表，逗号分隔、与 --treatment 按序对齐（空位 = 无 cwd）',
+        en: 'Runtime context dirs for treatments, comma-separated, index-aligned with --treatment (blank = none)',
       }),
     }),
     config: Flags.string({

--- a/src/cli/lib/parse-run-config/samples-discovery.ts
+++ b/src/cli/lib/parse-run-config/samples-discovery.ts
@@ -18,7 +18,6 @@
 
 import { resolve, join, dirname } from 'node:path';
 import { existsSync, statSync } from 'node:fs';
-import { parseVariantCwd } from '../../../inputs/skill-loader.js';
 
 export function discoverSamplesPath(values: Record<string, unknown>, skillDir: string): string {
   const treatmentRaw = values.treatment as string | undefined;
@@ -36,8 +35,7 @@ export function discoverSamplesPath(values: Record<string, unknown>, skillDir: s
         if (existsSync(join(treatmentDir, name))) return join(treatmentDir, name);
       }
     }
-    const tname = parseVariantCwd(expr).name;
-    const omkDir = join(skillDir, tname, '.omk');
+    const omkDir = join(skillDir, expr, '.omk');
     if (existsSync(omkDir)) return omkDir;
   }
   let cwdFile = 'eval-samples.json';

--- a/src/cli/lib/parse-run-config/variant-resolution.ts
+++ b/src/cli/lib/parse-run-config/variant-resolution.ts
@@ -27,6 +27,8 @@ import type { EvalConfig, ExperimentRole, VariantSpec } from '../../../types/ind
  *  引导用户改用 --control-cwd / --treatment-cwd 或 eval.yaml 的 variant.cwd。git 修订语法 `@{...}`
  *  由 parseVariantCwd 保护、不误判。cwd 由调用方在边界注入(见 eval-runner)。 */
 function cliVariantSpec(rawExpr: string, role: ExperimentRole, cwd?: string): VariantSpec {
+  // 探测旧 name@cwd 形态报错。注:含合法 `@`(非 `@{`)的路径(如 /x/@dir/skill.md)会被一并
+  // 误判 —— 属 pre-existing 限制(这类路径本就不被 @cwd 支持),报错文案仍指向迁移指引。
   if (parseVariantCwd(rawExpr).cwd !== undefined) {
     throw new Error(
       `「name@cwd」语法已移除: "${rawExpr}"。请改用 --${role}-cwd <dir> 声明 runtime context，`

--- a/src/cli/lib/parse-run-config/variant-resolution.ts
+++ b/src/cli/lib/parse-run-config/variant-resolution.ts
@@ -26,14 +26,14 @@ import type { EvalConfig, ExperimentRole, VariantSpec } from '../../../types/ind
 /** CLI 的 --control / --treatment 只收 artifact 身份。`name@cwd` 语法已移除:撞到就抛迁移错误,
  *  引导用户改用 --control-cwd / --treatment-cwd 或 eval.yaml 的 variant.cwd。git 修订语法 `@{...}`
  *  由 parseVariantCwd 保护、不误判。cwd 由调用方在边界注入(见 eval-runner)。 */
-function cliVariantSpec(rawExpr: string, role: ExperimentRole): VariantSpec {
+function cliVariantSpec(rawExpr: string, role: ExperimentRole, cwd?: string): VariantSpec {
   if (parseVariantCwd(rawExpr).cwd !== undefined) {
     throw new Error(
       `「name@cwd」语法已移除: "${rawExpr}"。请改用 --${role}-cwd <dir> 声明 runtime context，`
       + `或在 eval.yaml 的 variant 上用结构化 cwd: 字段。`,
     );
   }
-  return { name: variantExprToSkillName(rawExpr), role, expr: rawExpr };
+  return { name: variantExprToSkillName(rawExpr), role, expr: rawExpr, ...(cwd ? { cwd } : {}) };
 }
 
 export function resolveVariantSpecs(
@@ -45,17 +45,33 @@ export function resolveVariantSpecs(
   const treatmentExprs: string[] = values.treatment
     ? (values.treatment as string).split(',').map((v: string) => v.trim()).filter(Boolean)
     : [];
+  const controlCwd = values['control-cwd'] as string | undefined;
+  // 逗号列表,与 treatment 按序对齐;空位(空串)= 该 treatment 无 cwd。不 filter,保留位次。
+  const treatmentCwds: string[] = values['treatment-cwd']
+    ? (values['treatment-cwd'] as string).split(',').map((v: string) => v.trim())
+    : [];
 
   let variantSpecs: VariantSpec[];
   if (controlExpr || treatmentExprs.length > 0) {
     // CLI roles present → CLI entirely replaces config.variants (no merging).
+    if (controlCwd !== undefined && !controlExpr) {
+      throw new Error('--control-cwd 需要配 --control 一起用。');
+    }
+    if (treatmentCwds.length > 0 && treatmentCwds.length !== treatmentExprs.length) {
+      throw new Error(
+        `--treatment-cwd 的数量(${treatmentCwds.length})必须与 --treatment(${treatmentExprs.length})按序对齐;`
+        + `某个 treatment 不需要 cwd 就在该位留空(如 /a,,/c)。`,
+      );
+    }
     variantSpecs = [];
     if (controlExpr) {
-      variantSpecs.push(cliVariantSpec(controlExpr, 'control'));
+      variantSpecs.push(cliVariantSpec(controlExpr, 'control', controlCwd));
     }
-    for (const expr of treatmentExprs) {
-      variantSpecs.push(cliVariantSpec(expr, 'treatment'));
-    }
+    treatmentExprs.forEach((expr, i) => {
+      variantSpecs.push(cliVariantSpec(expr, 'treatment', treatmentCwds[i]));
+    });
+  } else if (controlCwd !== undefined || treatmentCwds.length > 0) {
+    throw new Error('--control-cwd / --treatment-cwd 需要配 --control / --treatment 一起用(eval.yaml 用 variant 的 cwd: 字段)。');
   } else if (evalConfig) {
     variantSpecs = configVariantsToSpecs(evalConfig.variants);
   } else if (values.batch) {

--- a/src/cli/lib/parse-run-config/variant-resolution.ts
+++ b/src/cli/lib/parse-run-config/variant-resolution.ts
@@ -19,9 +19,22 @@
  *     悄悄废掉「control 不能等于 treatment」的测量保护。
  */
 
-import { discoverVariants, variantExprToSkillName, variantIdentity } from '../../../inputs/skill-loader.js';
+import { discoverVariants, variantExprToSkillName, variantIdentity, parseVariantCwd } from '../../../inputs/skill-loader.js';
 import { configVariantsToSpecs } from '../../../inputs/eval-config.js';
-import type { EvalConfig, VariantSpec } from '../../../types/index.js';
+import type { EvalConfig, ExperimentRole, VariantSpec } from '../../../types/index.js';
+
+/** CLI 的 --control / --treatment 只收 artifact 身份。`name@cwd` 语法已移除:撞到就抛迁移错误,
+ *  引导用户改用 --control-cwd / --treatment-cwd 或 eval.yaml 的 variant.cwd。git 修订语法 `@{...}`
+ *  由 parseVariantCwd 保护、不误判。cwd 由调用方在边界注入(见 eval-runner)。 */
+function cliVariantSpec(rawExpr: string, role: ExperimentRole): VariantSpec {
+  if (parseVariantCwd(rawExpr).cwd !== undefined) {
+    throw new Error(
+      `「name@cwd」语法已移除: "${rawExpr}"。请改用 --${role}-cwd <dir> 声明 runtime context，`
+      + `或在 eval.yaml 的 variant 上用结构化 cwd: 字段。`,
+    );
+  }
+  return { name: variantExprToSkillName(rawExpr), role, expr: rawExpr };
+}
 
 export function resolveVariantSpecs(
   values: Record<string, unknown>,
@@ -38,10 +51,10 @@ export function resolveVariantSpecs(
     // CLI roles present → CLI entirely replaces config.variants (no merging).
     variantSpecs = [];
     if (controlExpr) {
-      variantSpecs.push({ name: variantExprToSkillName(controlExpr), role: 'control', expr: controlExpr });
+      variantSpecs.push(cliVariantSpec(controlExpr, 'control'));
     }
     for (const expr of treatmentExprs) {
-      variantSpecs.push({ name: variantExprToSkillName(expr), role: 'treatment', expr });
+      variantSpecs.push(cliVariantSpec(expr, 'treatment'));
     }
   } else if (evalConfig) {
     variantSpecs = configVariantsToSpecs(evalConfig.variants);
@@ -62,7 +75,7 @@ export function resolveVariantSpecs(
 
   const seenIdentities = new Set<string>();
   for (const spec of variantSpecs) {
-    const key = variantIdentity(spec.expr, skillDir);
+    const key = variantIdentity(spec.expr, skillDir, spec.cwd);
     if (seenIdentities.has(key)) {
       throw new Error(
         `variant "${spec.expr}" 重复出现——同一 variant 不能同时属于 --control 与 --treatment，也不能在 --treatment 中重复。`,

--- a/src/eval-workflows/evaluation-preparation.ts
+++ b/src/eval-workflows/evaluation-preparation.ts
@@ -44,14 +44,14 @@ export async function prepareEvaluationRun({
 }): Promise<PreparedEvaluationRun> {
   const { samples, requires, baseDir: samplesBaseDir, sourceFiles: samplesSourceFiles } = loadSamples(samplesPath);
 
-  // Build expressions from specs (preserving order) and resolve to artifacts.
-  const variantExpressions = variantSpecs.map((spec) => spec.expr);
+  // 结构化传入 {expr, cwd}(顺序一一对应),cwd 不再编码进 expr 字符串。
+  const variantInputs = variantSpecs.map((spec) => ({ expr: spec.expr, cwd: spec.cwd }));
   // 不把 variantAllowedSkills 透进 resolveArtifacts:那里按解析出的 artifact 名查,
   // 与 eval.yaml 的自定义 variant 名不一致时会漏绑。allowedSkills 统一在下面按 spec 绑定。
   // resolveArtifacts 只保留 strictBaseline 默认(baseline → [])。
   const resolvedArtifacts = artifacts || resolveArtifacts(
     resolve(skillDir),
-    variantExpressions,
+    variantInputs,
     { strictBaseline },
   );
 

--- a/src/inputs/eval-config.ts
+++ b/src/inputs/eval-config.ts
@@ -35,7 +35,8 @@ export function configVariantsToSpecs(variants: EvalConfigVariant[]): VariantSpe
   return variants.map((v) => ({
     name: v.name,
     role: v.role,
-    expr: v.cwd ? `${v.artifact}@${v.cwd}` : v.artifact,
+    expr: v.artifact, // 纯 artifact 身份;cwd 结构化携带,不再编码进 expr
+    ...(v.cwd !== undefined && { cwd: v.cwd }),
     ...(v.allowedSkills !== undefined && { allowedSkills: v.allowedSkills }),
   }));
 }

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -187,8 +187,9 @@ function pathPhysicalId(p: string): string {
  *      `skillDir/name/SKILL.md`)取物理身份,这样裸名 `greeter` 与指向同一文件的 `./greeter.md`
  *      能判为重复;没传 skillDir(如纯单测)则退回字面名。
  *    - `git:` / `baseline`：本身就是稳定标识,原样返回。
- *  `@cwd` 也按物理身份纳入 key —— 同一份 skill 绑不同 cwd 是不同 runtime context,不算重复。
- *  不要用派生短名判重:`v1/greeter.md` 与 `v2/greeter.md` 短名都是 greeter 却是两个 variant。 */
+ *  结构化的 `cwd`(第三参数)按物理身份纳入 key —— 同一份 skill 绑不同 cwd 是不同 runtime
+ *  context,不算重复。不要用派生短名判重:`v1/greeter.md` 与 `v2/greeter.md` 短名都是 greeter
+ *  却是两个 variant。 */
 export function variantIdentity(expr: string, skillDir?: string, cwd?: string): string {
   // expr 已是纯 artifact 身份(@cwd 在 CLI/config 边界已剥离);cwd 结构化显式传入。
   const name = expr;

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -189,8 +189,10 @@ function pathPhysicalId(p: string): string {
  *    - `git:` / `baseline`：本身就是稳定标识,原样返回。
  *  `@cwd` 也按物理身份纳入 key —— 同一份 skill 绑不同 cwd 是不同 runtime context,不算重复。
  *  不要用派生短名判重:`v1/greeter.md` 与 `v2/greeter.md` 短名都是 greeter 却是两个 variant。 */
-export function variantIdentity(expr: string, skillDir?: string): string {
-  const { name, cwd } = parseVariantCwd(expr);
+export function variantIdentity(expr: string, skillDir?: string, cwd?: string): string {
+  // cwd 显式传入(结构化)时,expr 视为纯 artifact identity,不再从串里 split @;
+  // 未传则退回从 expr 解析,与既有字符串调用 byte-identical(向后兼容)。
+  const { name, cwd: identCwd } = cwd === undefined ? parseVariantCwd(expr) : { name: expr, cwd };
   let id: string;
   if (name.startsWith('git:')) {
     id = name;
@@ -207,7 +209,7 @@ export function variantIdentity(expr: string, skillDir?: string): string {
   } else {
     id = name; // 无 skillDir 上下文:不同短名即不同 variant
   }
-  return cwd ? `${id}@${pathPhysicalId(resolve(cwd))}` : id;
+  return identCwd ? `${id}@${pathPhysicalId(resolve(identCwd))}` : id;
 }
 
 /** 从已解析的 skill 路径取短名:`SKILL.md` 取其父目录名,否则取去掉 `.md` 后缀的 basename。

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -190,9 +190,8 @@ function pathPhysicalId(p: string): string {
  *  `@cwd` 也按物理身份纳入 key —— 同一份 skill 绑不同 cwd 是不同 runtime context,不算重复。
  *  不要用派生短名判重:`v1/greeter.md` 与 `v2/greeter.md` 短名都是 greeter 却是两个 variant。 */
 export function variantIdentity(expr: string, skillDir?: string, cwd?: string): string {
-  // cwd 显式传入(结构化)时,expr 视为纯 artifact identity,不再从串里 split @;
-  // 未传则退回从 expr 解析,与既有字符串调用 byte-identical(向后兼容)。
-  const { name, cwd: identCwd } = cwd === undefined ? parseVariantCwd(expr) : { name: expr, cwd };
+  // expr 已是纯 artifact 身份(@cwd 在 CLI/config 边界已剥离);cwd 结构化显式传入。
+  const name = expr;
   let id: string;
   if (name.startsWith('git:')) {
     id = name;
@@ -209,7 +208,7 @@ export function variantIdentity(expr: string, skillDir?: string, cwd?: string): 
   } else {
     id = name; // 无 skillDir 上下文:不同短名即不同 variant
   }
-  return identCwd ? `${id}@${pathPhysicalId(resolve(identCwd))}` : id;
+  return cwd ? `${id}@${pathPhysicalId(resolve(cwd))}` : id;
 }
 
 /** 从已解析的 skill 路径取短名:`SKILL.md` 取其父目录名,否则取去掉 `.md` 后缀的 basename。
@@ -220,19 +219,21 @@ export function skillNameFromPath(filePath: string): string {
   return base === 'SKILL.md' ? basename(dirname(filePath)) : base.replace(/\.md$/i, '');
 }
 
-/** Extract short skill name from a variant expression (which may be a path). */
+/** 从 variant 表达式(纯 artifact 身份,可能是路径)取短名。 */
 export function variantExprToSkillName(expr: string): string {
-  const { name } = parseVariantCwd(expr);
-  if (name.startsWith('git:')) return name;
-  if (!name.includes('/')) return name || expr;
+  if (expr.startsWith('git:')) return expr;
+  if (!expr.includes('/')) return expr;
   // 先折叠 dir↔SKILL.md 再取短名,与 resolveArtifacts 的命名一致(否则 `weird.md/` 这类
   // 以 .md 结尾的目录,两处会派生出不同短名)。
-  return skillNameFromPath(canonicalSkillAnchor(resolve(name))) || name;
+  return skillNameFromPath(canonicalSkillAnchor(resolve(expr))) || expr;
 }
+
+/** variant 输入:纯 artifact 表达式字符串,或结构化的 `{expr, cwd?}`。cwd 不再编码进 expr。 */
+export type VariantInput = string | { expr: string; cwd?: string };
 
 export function resolveArtifacts(
   skillDir: string,
-  variants: string[],
+  variants: VariantInput[],
   opts: ResolveArtifactsOptions = {},
 ): Artifact[] {
   const strictBaseline = opts.strictBaseline ?? true;
@@ -241,14 +242,16 @@ export function resolveArtifacts(
   let gitRelDir: string | null = null;
 
   for (const rawVariant of variants) {
-    const { name: variantName, cwd: variantCwd } = parseVariantCwd(rawVariant);
+    // 字符串即纯 expr(无 cwd);结构化对象直接取 expr/cwd。不再 split @cwd。
+    const variantName = typeof rawVariant === 'string' ? rawVariant : rawVariant.expr;
+    const variantCwd = typeof rawVariant === 'string' ? undefined : rawVariant.cwd;
 
     if (!variantName) {
-      throw new Error(`variant 名不能为空: "${rawVariant}"。如需绑定 runtime context,用 label@/path 形式声明。`);
+      throw new Error(`variant 名不能为空。如需绑定 runtime context,用 --control-cwd / --treatment-cwd 或 eval.yaml 的 variant.cwd。`);
     }
 
     if (variantName === 'baseline' && variantCwd) {
-      throw new Error('baseline cannot be bound to a cwd. To express a project-level runtime context, use a custom label such as project-env@/path/to/project');
+      throw new Error('baseline cannot be bound to a cwd. To express a project-level runtime context, use a custom label + cwd (e.g. --treatment project-env --treatment-cwd /path).');
     }
 
     if (variantName === 'baseline') {

--- a/src/types/eval.ts
+++ b/src/types/eval.ts
@@ -190,9 +190,11 @@ export interface VariantConfig {
 }
 
 export interface VariantSpec {
-  name: string;           // variant 显示名,从 expr 提取(parseVariantCwd 后的 name 部分)
+  name: string;           // variant 显示名,从 expr 提取
   role: ExperimentRole;
-  expr: string;           // 原始 CLI / config 表达式(含 @cwd、git: 等前缀)
+  expr: string;           // artifact 身份表达式(git: 前缀等),不再编码 @cwd
+  // runtime context cwd,在 CLI/config 边界解析一次后随 spec 结构化携带,内部不再传播 name@cwd 串。
+  cwd?: string;
   // 显式 skill 隔离声明(来自 eval.yaml variant.allowedSkills)。随 spec 一起走,
   // 避免再按 variant 名建一张并行 map 与 artifact 名互查(那是 allowedSkills 漏绑的源头)。
   allowedSkills?: string[];

--- a/test/eval-config.test.ts
+++ b/test/eval-config.test.ts
@@ -176,14 +176,14 @@ variants:
 });
 
 describe('configVariantsToSpecs', () => {
-  it('merges cwd into expr as name@cwd', () => {
+  it('carries cwd structurally (expr stays pure, no @cwd encoding)', () => {
     const specs = configVariantsToSpecs([
       { name: 'v1', role: 'control', artifact: 'baseline' },
       { name: 'v2', role: 'treatment', artifact: './skill.md', cwd: '/tmp/project' },
     ]);
     assert.deepEqual(specs, [
       { name: 'v1', role: 'control', expr: 'baseline' },
-      { name: 'v2', role: 'treatment', expr: './skill.md@/tmp/project' },
+      { name: 'v2', role: 'treatment', expr: './skill.md', cwd: '/tmp/project' },
     ]);
   });
 

--- a/test/inputs/skill-loader.test.ts
+++ b/test/inputs/skill-loader.test.ts
@@ -37,13 +37,13 @@ describe('resolveArtifacts', () => {
 
   it('baseline@cwd 不再受支持', () => {
     assert.throws(
-      () => resolveArtifacts(SKILL_DIR, ['baseline@/tmp/project-a']),
+      () => resolveArtifacts(SKILL_DIR, [{ expr: 'baseline', cwd: '/tmp/project-a' }]),
       /baseline cannot be bound to a cwd/,
     );
   });
 
-  it('unknown@cwd 作为 cwd-only baseline artifact', () => {
-    const artifacts = resolveArtifacts(SKILL_DIR, ['project-env@/tmp/project-b']);
+  it('unknown expr + cwd 作为 cwd-only baseline artifact', () => {
+    const artifacts = resolveArtifacts(SKILL_DIR, [{ expr: 'project-env', cwd: '/tmp/project-b' }]);
     assert.equal(artifacts.length, 1);
     assert.equal(artifacts[0].name, 'project-env');
     assert.equal(artifacts[0].kind, 'baseline');
@@ -65,8 +65,8 @@ describe('resolveArtifacts', () => {
     assert.equal(artifacts[0].skillRoot, join(MULTI_SKILL_DIR, 'classifier'));
   });
 
-  it('显式 @cwd 覆盖,但 skillRoot 仍记录在 artifact 上(优先级在 task-planner 处理)', () => {
-    const artifacts = resolveArtifacts(MULTI_SKILL_DIR, ['classifier@/tmp/override']);
+  it('显式 cwd 覆盖,但 skillRoot 仍记录在 artifact 上(优先级在 task-planner 处理)', () => {
+    const artifacts = resolveArtifacts(MULTI_SKILL_DIR, [{ expr: 'classifier', cwd: '/tmp/override' }]);
     assert.equal(artifacts.length, 1);
     assert.equal(artifacts[0].cwd, '/tmp/override');
     assert.equal(artifacts[0].skillRoot, join(MULTI_SKILL_DIR, 'classifier'));
@@ -115,8 +115,8 @@ describe('resolveArtifacts skill isolation', () => {
     assert.deepEqual(v1.allowedSkills, [], '显式给 treatment 设 [] 也合法');
   });
 
-  it('cwd-only project-env@/path 也被认作 baseline-kind,strict-baseline 自动隔离', () => {
-    const artifacts = resolveArtifacts(SKILL_DIR, ['project-env@/tmp/proj']);
+  it('cwd-only expr 也被认作 baseline-kind,strict-baseline 自动隔离', () => {
+    const artifacts = resolveArtifacts(SKILL_DIR, [{ expr: 'project-env', cwd: '/tmp/proj' }]);
     assert.deepEqual(artifacts[0].allowedSkills, [],
       'kind:baseline 包括 cwd-only custom variant,strict-baseline 一并隔离');
   });

--- a/test/inputs/variant-name-collision.test.ts
+++ b/test/inputs/variant-name-collision.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ensureUniqueVariantNames, resolveArtifacts, variantIdentity, parseVariantCwd } from '../../src/inputs/skill-loader.js';
 import { resolveVariantSpecs } from '../../src/cli/lib/parse-run-config/variant-resolution.js';
+import { configVariantsToSpecs } from '../../src/inputs/eval-config.js';
 import { prepareEvaluationRun } from '../../src/eval-workflows/evaluation-preparation.js';
 import type { Artifact } from '../../src/types/eval.js';
 
@@ -211,10 +212,15 @@ describe('variantIdentity', () => {
     assert.notEqual(variantIdentity('/repo/v1/greeter.md'), variantIdentity('/repo/v2/greeter.md'));
   });
 
-  it('treats the same skill with different cwd as different identities', () => {
+  it('treats the same skill with different (structured) cwd as different identities', () => {
     const f = join(root, 'x.md');
     writeFileSync(f, '# x\n');
-    assert.notEqual(variantIdentity(`${f}@${root}/a`), variantIdentity(`${f}@${root}/b`));
+    // cwd 结构化作为第三参数,expr 是纯身份
+    assert.notEqual(variantIdentity(f, undefined, `${root}/a`), variantIdentity(f, undefined, `${root}/b`));
+    // 同一份 skill + 同一 cwd → 同 identity(判重触发)
+    assert.equal(variantIdentity(f, undefined, `${root}/a`), variantIdentity(f, undefined, `${root}/a`));
+    // 无 cwd 与有 cwd 不同
+    assert.notEqual(variantIdentity(f), variantIdentity(f, undefined, `${root}/a`));
   });
 
   it('leaves baseline and git refs as stable opaque identities', () => {
@@ -317,5 +323,28 @@ describe('resolveVariantSpecs — --control-cwd / --treatment-cwd 结构化注�
 
   it('errors when --control-cwd is given without --control', () => {
     assert.throws(() => resolveVariantSpecs({ treatment: 'a', 'control-cwd': '/p' }, null, root), /--control-cwd 需要配 --control/);
+  });
+
+  it('flows --treatment-cwd end-to-end into artifact.cwd', async () => {
+    writeFileSync(join(root, 'greeter.md'), '# greeter\n');
+    const samplesPath = join(root, 'samples.json');
+    writeFileSync(samplesPath, JSON.stringify([{ sample_id: 's1', prompt: 'hi' }]));
+    const specs = resolveVariantSpecs(
+      { control: 'baseline', treatment: join(root, 'greeter.md'), 'treatment-cwd': '/proj' }, null, root,
+    );
+    const prepared = await prepareEvaluationRun({ samplesPath, skillDir: root, variantSpecs: specs, dryRun: true });
+    assert.equal(prepared.artifacts.find((a) => a.name === 'greeter')!.cwd, '/proj');
+  });
+
+  it('flows eval.yaml structured cwd end-to-end into artifact.cwd', async () => {
+    writeFileSync(join(root, 'greeter.md'), '# greeter\n');
+    const samplesPath = join(root, 'samples.json');
+    writeFileSync(samplesPath, JSON.stringify([{ sample_id: 's1', prompt: 'hi' }]));
+    const specs = configVariantsToSpecs([
+      { name: 'baseline', role: 'control', artifact: 'baseline' },
+      { name: 't', role: 'treatment', artifact: join(root, 'greeter.md'), cwd: '/yamlproj' },
+    ]);
+    const prepared = await prepareEvaluationRun({ samplesPath, skillDir: root, variantSpecs: specs, dryRun: true });
+    assert.ok(prepared.artifacts.some((a) => a.cwd === '/yamlproj'), 'yaml cwd reached artifact');
   });
 });

--- a/test/inputs/variant-name-collision.test.ts
+++ b/test/inputs/variant-name-collision.test.ts
@@ -325,6 +325,11 @@ describe('resolveVariantSpecs — --control-cwd / --treatment-cwd 结构化注�
     assert.throws(() => resolveVariantSpecs({ treatment: 'a', 'control-cwd': '/p' }, null, root), /--control-cwd 需要配 --control/);
   });
 
+  it('accepts a git reflog/upstream ref as a CLI role without a migration error (@{...} ≠ @cwd)', () => {
+    const specs = resolveVariantSpecs({ control: 'git:HEAD@{2}:greeter', treatment: 'skill-a' }, null, root);
+    assert.equal(specs.find((s) => s.role === 'control')!.expr, 'git:HEAD@{2}:greeter');
+  });
+
   it('flows --treatment-cwd end-to-end into artifact.cwd', async () => {
     writeFileSync(join(root, 'greeter.md'), '# greeter\n');
     const samplesPath = join(root, 'samples.json');

--- a/test/inputs/variant-name-collision.test.ts
+++ b/test/inputs/variant-name-collision.test.ts
@@ -285,3 +285,37 @@ describe('resolveArtifacts — git artifact bound to a cwd (regression: @{...} g
     }
   });
 });
+
+describe('resolveVariantSpecs — --control-cwd / --treatment-cwd 结构化注入', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'omk-cwdflag-')); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('injects control cwd structurally onto the spec', () => {
+    const specs = resolveVariantSpecs({ control: 'baseline', treatment: 'skill-a', 'control-cwd': '/proj' }, null, root);
+    assert.equal(specs.find((s) => s.role === 'control')!.cwd, '/proj');
+    assert.equal(specs.find((s) => s.role === 'treatment')!.cwd, undefined);
+  });
+
+  it('index-aligns --treatment-cwd to --treatment', () => {
+    const specs = resolveVariantSpecs({ treatment: 'a,b', 'treatment-cwd': '/pa,/pb' }, null, root);
+    assert.deepEqual(specs.map((s) => s.cwd), ['/pa', '/pb']);
+  });
+
+  it('blank slot means that treatment has no cwd', () => {
+    const specs = resolveVariantSpecs({ treatment: 'a,b,c', 'treatment-cwd': '/pa,,/pc' }, null, root);
+    assert.deepEqual(specs.map((s) => s.cwd), ['/pa', undefined, '/pc']);
+  });
+
+  it('errors when --treatment-cwd length mismatches --treatment', () => {
+    assert.throws(() => resolveVariantSpecs({ treatment: 'a,b', 'treatment-cwd': '/pa' }, null, root), /按序对齐|数量/);
+  });
+
+  it('errors when --treatment-cwd is given without --treatment', () => {
+    assert.throws(() => resolveVariantSpecs({ 'treatment-cwd': '/pa' }, null, root), /需要配/);
+  });
+
+  it('errors when --control-cwd is given without --control', () => {
+    assert.throws(() => resolveVariantSpecs({ treatment: 'a', 'control-cwd': '/p' }, null, root), /--control-cwd 需要配 --control/);
+  });
+});

--- a/test/inputs/variant-name-collision.test.ts
+++ b/test/inputs/variant-name-collision.test.ts
@@ -84,9 +84,9 @@ describe('resolveArtifacts — same-basename variants in different dirs', () => 
     assert.notEqual(arts[0].content, arts[1].content);
   });
 
-  it('rejects an empty variant name (e.g. "@/cwd") instead of silently loading skillDir/SKILL.md', () => {
+  it('rejects an empty variant expr instead of silently loading skillDir/SKILL.md', () => {
     writeFileSync(join(root, 'SKILL.md'), '# top-level skill\n');
-    assert.throws(() => resolveArtifacts(root, ['@/some/cwd']), /不能为空/);
+    assert.throws(() => resolveArtifacts(root, [{ expr: '', cwd: '/some/cwd' }]), /不能为空/);
   });
 });
 
@@ -136,10 +136,12 @@ describe('CLI dry-run — --control / --treatment same-basename in different dir
     );
   });
 
-  it('allows the same skill bound to two different cwds (distinct runtime contexts)', () => {
+  it('rejects the removed name@cwd CLI syntax with a migration error', () => {
     const skill = join(root, 'v1', 'greeter.md');
-    const specs = resolveVariantSpecs({ control: `${skill}@${root}/v1`, treatment: `${skill}@${root}/v2` }, null, root);
-    assert.equal(specs.length, 2);
+    assert.throws(
+      () => resolveVariantSpecs({ control: `${skill}@${root}/v1` }, null, root),
+      /语法已移除|--control-cwd/,
+    );
   });
 
   it('rejects a bare skill name vs its path form pointing at the same file (skillDir base)', () => {
@@ -271,11 +273,12 @@ describe('resolveArtifacts — git artifact bound to a cwd (regression: @{...} g
       sh(['add', '.']);
       sh(['commit', '-m', 'seed']);
       process.chdir(gitRoot);
-      const arts = resolveArtifacts(gitRoot, [`git:greeter@${gitRoot}/proj`]);
+      // 结构化输入:expr 是纯 git 身份,cwd 单独携带(不再 git:...@cwd 编码进串)。
+      const arts = resolveArtifacts(gitRoot, [{ expr: 'git:greeter', cwd: `${gitRoot}/proj` }]);
       assert.equal(arts.length, 1);
       assert.equal(arts[0].source, 'git');
       assert.equal(arts[0].content, '# git greeter');
-      assert.equal(arts[0].cwd, `${gitRoot}/proj`, 'cwd must survive the git @{...} guard');
+      assert.equal(arts[0].cwd, `${gitRoot}/proj`, 'cwd carried structurally');
     } finally {
       process.chdir(prevCwd);
       rmSync(gitRoot, { recursive: true, force: true });

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -17,10 +17,15 @@ import type { Report, VariantSpec } from '../src/types/index.js';
 // historical `variants: [...]` convention used across legacy fixtures.
 function asSpecs(names: string[]): VariantSpec[] {
   return names.map((name, i) => {
+    // 测试便捷:把 `expr@cwd` 拆成结构化 cwd(生产已移除 @cwd 编码,cwd 随 spec 结构化携带)。
+    const at = name.startsWith('git:') ? -1 : name.indexOf('@');
+    const expr = at === -1 ? name : name.slice(0, at);
+    const cwd = at === -1 ? undefined : name.slice(at + 1);
     return {
-      name: variantExprToSkillName(name),
+      name: variantExprToSkillName(expr),
       role: i === 0 ? 'control' : 'treatment',
-      expr: name,
+      expr,
+      ...(cwd !== undefined && { cwd }),
     };
   });
 }


### PR DESCRIPTION
关闭 #184。

## 为什么

variant 表达式此前把 artifact 身份与 runtime cwd 编码进同一字符串（`name@cwd`、`git:HEAD@{2}:skill@/project`），靠分隔符反复拆解 —— 是 git ref 含 `@`、路径含 `@`、未来 URL / Windows 路径这类边界 bug 的温床（#181 那轮 git@ 回归即此）。本 PR 把 cwd 从「字符串编码」改为「结构化携带」：CLI/config 边界解析一次，内部全程结构化，artifact 身份与 runtime context 彻底解耦。

## ⚠️ 用户面 BREAKING（CLI）

移除 `name@cwd` 字符串语法。runtime context（cwd）改为结构化声明：

- CLI：`--control-cwd <dir>`、`--treatment-cwd <dir,...>`（后者逗号分隔，与 `--treatment` 按序对齐，留空位 = 该 treatment 无 cwd）。
- eval.yaml：每个 variant 的结构化 `cwd:` 字段（本就存在，不变）。

迁移：

```
# 旧
omk eval --control project-env@/proj --treatment ./skill.md@/proj
# 新
omk eval --control project-env --control-cwd /proj --treatment ./skill.md --treatment-cwd /proj
```

CLI 撞到旧 `name@cwd` 会抛迁移错误指引。`--control-cwd`/`--treatment-cwd` 与 eval.yaml `cwd:` 严格配套、不跨面覆盖（CLI roles 整体替换 yaml variants 的现状不变）。

## 测量学

**不**涉及 BREAKING-COMPARABILITY：report 键语义未变，report-variant-keys golden 全程 byte-identical（5 个 commit 每步验证），cwd 只是来源从字符串编码改为结构化。`resolveArtifacts` 公开签名拓宽为 `Array<string | {expr, cwd?}>`，doctor/batch/loadSkills 仍传 `string[]`、行为不变。

## 已知后续

batch 的 per-variant allowedSkills 绑定（#183）、`variantAllowedSkills` legacy fallback 退役仍留作单独跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)