### PR TITLE
fix(eval-workflows): batch 修 treatment 角色误标 control(#183)

### DIFF
--- a/src/eval-workflows/batch-evaluation-workflow.ts
+++ b/src/eval-workflows/batch-evaluation-workflow.ts
@@ -60,6 +60,25 @@ interface CompletedBatchSkillRun {
   filePath: string | null;
 }
 
+/** Batch 每个 entry 的实验结构固定:baseline control vs 当前 skill treatment。
+ *  resolveArtifacts 产出的 `artifact.name` 是派生短名(skillNameFromPath(skillPath)),
+ *  不等于全路径 `entry.skillPath`,所以按 `kind` 而非 name 串区分角色:baseline-kind 绑
+ *  control,skill-kind 绑 treatment 并对齐到 entry 逻辑名。variantAllowedSkills 已按短名
+ *  (== entry.name)在 resolveArtifacts 内命中,无需补全路径 key。
+ *  real-run(executeBatchEvaluationRuns)与 dry-run(runBatchEvaluation)共用此处,
+ *  避免两份手抄实现漂移(#183 即同一误绑在两处各存一份)。 */
+export function buildBatchSkillArtifacts(
+  skillDirAbs: string,
+  entry: { name: string; skillPath: string },
+  opts: { strictBaseline?: boolean; variantAllowedSkills?: Record<string, string[]> },
+): Artifact[] {
+  return resolveArtifacts(skillDirAbs, ['baseline', entry.skillPath], opts).map((artifact) =>
+    artifact.kind === 'baseline'
+      ? { ...artifact, experimentRole: 'control' as const }
+      : { ...artifact, name: entry.name, experimentRole: 'treatment' as const },
+  );
+}
+
 function commonRuntime(runtimes: Record<string, ExecutorRuntimeFingerprint>): ExecutorRuntimeFingerprint | undefined {
   const values = Object.values(runtimes);
   if (values.length === 0) return undefined;
@@ -341,20 +360,7 @@ export async function executeBatchEvaluationRuns({
     const entry = skillEntries[i];
     onSkillProgress?.({ phase: 'start', skill: entry.name, current: i + 1, total: skillEntries.length });
 
-    // Batch mode 的实验结构固定为 baseline control vs 当前 skill treatment。
-    // resolveArtifacts 产出的 artifact.name 是派生短名(skillNameFromPath(skillPath)),
-    // 不等于全路径 entry.skillPath,所以按 kind 而非 name 串区分:baseline-kind 即 control,
-    // skill-kind 即 treatment(对齐到 entry 的逻辑名)。variantAllowedSkills 已按短名(== entry.name)
-    // 在 resolveArtifacts 内命中,无需再补一个全路径 key。
-    const skillArtifacts = resolveArtifacts(
-      resolve(skillDir),
-      ['baseline', entry.skillPath],
-      { strictBaseline, variantAllowedSkills },
-    ).map((artifact) =>
-      artifact.kind === 'baseline'
-        ? { ...artifact, experimentRole: 'control' as const }
-        : { ...artifact, name: entry.name, experimentRole: 'treatment' as const },
-    );
+    const skillArtifacts = buildBatchSkillArtifacts(resolve(skillDir), entry, { strictBaseline, variantAllowedSkills });
     const childRunId = `${batchRunId}-${String(i + 1).padStart(2, '0')}-${safeRunIdPart(entry.name)}`;
     const { report, filePath } = await runSingleEvaluation({
       samplesPath: entry.samplesPath,

--- a/src/eval-workflows/batch-evaluation-workflow.ts
+++ b/src/eval-workflows/batch-evaluation-workflow.ts
@@ -342,19 +342,19 @@ export async function executeBatchEvaluationRuns({
     onSkillProgress?.({ phase: 'start', skill: entry.name, current: i + 1, total: skillEntries.length });
 
     // Batch mode 的实验结构固定为 baseline control vs 当前 skill treatment。
-    const perSkillAllowedSkills = variantAllowedSkills?.[entry.name] !== undefined
-      ? { ...variantAllowedSkills, [entry.skillPath]: variantAllowedSkills[entry.name] }
-      : variantAllowedSkills;
+    // resolveArtifacts 产出的 artifact.name 是派生短名(skillNameFromPath(skillPath)),
+    // 不等于全路径 entry.skillPath,所以按 kind 而非 name 串区分:baseline-kind 即 control,
+    // skill-kind 即 treatment(对齐到 entry 的逻辑名)。variantAllowedSkills 已按短名(== entry.name)
+    // 在 resolveArtifacts 内命中,无需再补一个全路径 key。
     const skillArtifacts = resolveArtifacts(
       resolve(skillDir),
       ['baseline', entry.skillPath],
-      { strictBaseline, variantAllowedSkills: perSkillAllowedSkills },
-    ).map((artifact) => {
-      if (artifact.name === entry.skillPath) {
-        return { ...artifact, name: entry.name, experimentRole: 'treatment' as const };
-      }
-      return { ...artifact, experimentRole: 'control' as const };
-    });
+      { strictBaseline, variantAllowedSkills },
+    ).map((artifact) =>
+      artifact.kind === 'baseline'
+        ? { ...artifact, experimentRole: 'control' as const }
+        : { ...artifact, name: entry.name, experimentRole: 'treatment' as const },
+    );
     const childRunId = `${batchRunId}-${String(i + 1).padStart(2, '0')}-${safeRunIdPart(entry.name)}`;
     const { report, filePath } = await runSingleEvaluation({
       samplesPath: entry.samplesPath,

--- a/src/eval-workflows/batch-evaluation-workflow.ts
+++ b/src/eval-workflows/batch-evaluation-workflow.ts
@@ -1,24 +1,27 @@
-import { dirname, resolve } from 'node:path';
+import { dirname } from 'node:path';
 import { DEFAULT_OUTPUT_DIR, generateRunId, getCliVersion, getGitInfo, persistReport } from '../eval-core/evaluation-reporting.js';
 import { buildEvaluationRequest, createEvaluationRun, createSucceededJob, finalizeEvaluationRun } from '../eval-core/evaluation-job.js';
 import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
 import { createFileJobStore, DEFAULT_JOBS_DIR } from '../server/job-store.js';
-import { resolveArtifacts } from '../inputs/skill-loader.js';
 import type {
-  Artifact,
   BatchEvaluationReport,
   BatchEvaluationItem,
   EvaluationReport,
   ExecutorRuntimeFingerprint,
   JobStore,
   ProgressCallback,
+  VariantSpec,
   VariantSummary,
 } from '../types/index.js';
 
 interface RunSingleEvaluationOptions {
   samplesPath: string;
   skillDir: string;
-  artifacts: Artifact[];
+  /** 每个 batch entry 的实验结构(baseline control vs 当前 skill treatment),由
+   *  runEvaluation 的 spec-based 解析统一绑定 role / 隔离。 */
+  variantSpecs: VariantSpec[];
+  /** strict-baseline default,透传给 per-skill runEvaluation(baseline → allowedSkills=[])。 */
+  strictBaseline?: boolean;
   model: string;
   judgeModel: string;
   outputDir: string | null;
@@ -61,22 +64,23 @@ interface CompletedBatchSkillRun {
 }
 
 /** Batch 每个 entry 的实验结构固定:baseline control vs 当前 skill treatment。
- *  resolveArtifacts 产出的 `artifact.name` 是派生短名(skillNameFromPath(skillPath)),
- *  不等于全路径 `entry.skillPath`,所以按 `kind` 而非 name 串区分角色:baseline-kind 绑
- *  control,skill-kind 绑 treatment 并对齐到 entry 逻辑名。variantAllowedSkills 已按短名
- *  (== entry.name)在 resolveArtifacts 内命中,无需补全路径 key。
- *  real-run(executeBatchEvaluationRuns)与 dry-run(runBatchEvaluation)共用此处,
- *  避免两份手抄实现漂移(#183 即同一误绑在两处各存一份)。 */
-export function buildBatchSkillArtifacts(
-  skillDirAbs: string,
+ *  构造 VariantSpec 交给 runEvaluation 的 spec-based 解析按身份绑定 role / 隔离——与单跑
+ *  路径同一处绑定逻辑,batch 不再自管 artifact 拼装(此前两处手抄 resolveArtifacts().map()
+ *  导致 #183 角色误绑各存一份)。treatment 的 allowedSkills 来自 eval.yaml variants[].allowedSkills
+ *  (按 skill 名 entry.name 查),挂到 spec 上由 prepareEvaluationRun 统一绑定。 */
+export function buildBatchVariantSpecs(
   entry: { name: string; skillPath: string },
-  opts: { strictBaseline?: boolean; variantAllowedSkills?: Record<string, string[]> },
-): Artifact[] {
-  return resolveArtifacts(skillDirAbs, ['baseline', entry.skillPath], opts).map((artifact) =>
-    artifact.kind === 'baseline'
-      ? { ...artifact, experimentRole: 'control' as const }
-      : { ...artifact, name: entry.name, experimentRole: 'treatment' as const },
-  );
+  treatmentAllowedSkills?: string[],
+): VariantSpec[] {
+  return [
+    { name: 'baseline', role: 'control', expr: 'baseline' },
+    {
+      name: entry.name,
+      role: 'treatment',
+      expr: entry.skillPath,
+      ...(treatmentAllowedSkills !== undefined && { allowedSkills: treatmentAllowedSkills }),
+    },
+  ];
 }
 
 function commonRuntime(runtimes: Record<string, ExecutorRuntimeFingerprint>): ExecutorRuntimeFingerprint | undefined {
@@ -360,12 +364,13 @@ export async function executeBatchEvaluationRuns({
     const entry = skillEntries[i];
     onSkillProgress?.({ phase: 'start', skill: entry.name, current: i + 1, total: skillEntries.length });
 
-    const skillArtifacts = buildBatchSkillArtifacts(resolve(skillDir), entry, { strictBaseline, variantAllowedSkills });
+    const variantSpecs = buildBatchVariantSpecs(entry, variantAllowedSkills?.[entry.name]);
     const childRunId = `${batchRunId}-${String(i + 1).padStart(2, '0')}-${safeRunIdPart(entry.name)}`;
     const { report, filePath } = await runSingleEvaluation({
       samplesPath: entry.samplesPath,
       skillDir,
-      artifacts: skillArtifacts,
+      variantSpecs,
+      strictBaseline,
       model,
       judgeModel,
       outputDir,

--- a/src/eval-workflows/batch-evaluation-workflow.ts
+++ b/src/eval-workflows/batch-evaluation-workflow.ts
@@ -66,19 +66,29 @@ interface CompletedBatchSkillRun {
 /** Batch 每个 entry 的实验结构固定:baseline control vs 当前 skill treatment。
  *  构造 VariantSpec 交给 runEvaluation 的 spec-based 解析按身份绑定 role / 隔离——与单跑
  *  路径同一处绑定逻辑,batch 不再自管 artifact 拼装(此前两处手抄 resolveArtifacts().map()
- *  导致 #183 角色误绑各存一份)。treatment 的 allowedSkills 来自 eval.yaml variants[].allowedSkills
- *  (按 skill 名 entry.name 查),挂到 spec 上由 prepareEvaluationRun 统一绑定。 */
+ *  导致 #183 角色误绑各存一份)。
+ *  两个 variant 的 allowedSkills 都从 eval.yaml variants[].allowedSkills 取:treatment 按 skill
+ *  名 entry.name 查、baseline 按保留名 `baseline` 查,挂到对应 spec 上由 prepareEvaluationRun
+ *  统一绑定。baseline 的显式声明(白名单或 `[]`)必须保留——eval.yaml variant.allowedSkills
+ *  优先于 strictBaseline 默认,漏挂会让 `--batch --config` 的 baseline 隔离配置静默失效。 */
 export function buildBatchVariantSpecs(
   entry: { name: string; skillPath: string },
-  treatmentAllowedSkills?: string[],
+  variantAllowedSkills?: Record<string, string[]>,
 ): VariantSpec[] {
+  const baselineAllowed = variantAllowedSkills?.baseline;
+  const treatmentAllowed = variantAllowedSkills?.[entry.name];
   return [
-    { name: 'baseline', role: 'control', expr: 'baseline' },
+    {
+      name: 'baseline',
+      role: 'control',
+      expr: 'baseline',
+      ...(baselineAllowed !== undefined && { allowedSkills: baselineAllowed }),
+    },
     {
       name: entry.name,
       role: 'treatment',
       expr: entry.skillPath,
-      ...(treatmentAllowedSkills !== undefined && { allowedSkills: treatmentAllowedSkills }),
+      ...(treatmentAllowed !== undefined && { allowedSkills: treatmentAllowed }),
     },
   ];
 }
@@ -364,7 +374,7 @@ export async function executeBatchEvaluationRuns({
     const entry = skillEntries[i];
     onSkillProgress?.({ phase: 'start', skill: entry.name, current: i + 1, total: skillEntries.length });
 
-    const variantSpecs = buildBatchVariantSpecs(entry, variantAllowedSkills?.[entry.name]);
+    const variantSpecs = buildBatchVariantSpecs(entry, variantAllowedSkills);
     const childRunId = `${batchRunId}-${String(i + 1).padStart(2, '0')}-${safeRunIdPart(entry.name)}`;
     const { report, filePath } = await runSingleEvaluation({
       samplesPath: entry.samplesPath,

--- a/src/eval-workflows/evaluation-preparation.ts
+++ b/src/eval-workflows/evaluation-preparation.ts
@@ -53,12 +53,13 @@ export async function prepareEvaluationRun({
   );
 
   // Attach experimentRole to each artifact.
-  //   - 当 artifacts 由本函数从 variantSpecs.map(spec => spec.expr) 解析时,两者顺序一一对应,
-  //     按 index 绑定 role,并把 spec.name 同步成消歧后的最终唯一名。不能按 spec.name 匹配
-  //     artifact.name:同 basename 的 variant 被 ensureUniqueVariantNames 消歧后(v1/greeter /
-  //     v2/greeter)就和 spec 的派生短名(greeter)对不上,会丢 role。
-  //   - 当 artifacts 由外部传入(如 batch workflow,role 已预置)时,index 无法对齐,
-  //     退回按 name 匹配,且 if-already-set 守卫会保留预置 role。
+  //   - 当 artifacts 由本函数从 variantSpecs.map(spec => spec.expr) 解析时(eval 单跑与 batch
+  //     都走这支),两者顺序一一对应,按 index 绑定 role,并把 spec.name 同步成消歧后的最终唯一名。
+  //     不能按 spec.name 匹配 artifact.name:同 basename 的 variant 被 ensureUniqueVariantNames
+  //     消歧后(v1/greeter / v2/greeter)就和 spec 的派生短名(greeter)对不上,会丢 role。
+  //   - 当 artifacts 由外部直接传入(role 可能已预置)时,index 无法对齐,退回按 name 匹配,
+  //     且 if-already-set 守卫会保留预置 role。这是 runEvaluation({artifacts}) 直调 API 的兜底,
+  //     当前生产路径都走上面的 spec 解析,不进这支。
   if (!artifacts && variantSpecs.length === resolvedArtifacts.length) {
     variantSpecs.forEach((spec, i) => {
       const artifact = resolvedArtifacts[i];
@@ -73,7 +74,7 @@ export async function prepareEvaluationRun({
     const roleByName: Record<string, VariantSpec['role']> = {};
     for (const spec of variantSpecs) roleByName[spec.name] = spec.role;
     for (const artifact of resolvedArtifacts) {
-      if (artifact.experimentRole) continue;  // preserve if already set (e.g. batch workflow)
+      if (artifact.experimentRole) continue;  // preserve if caller pre-set it on the passed-in artifact
       const role = roleByName[artifact.name];
       if (role) artifact.experimentRole = role;
     }

--- a/src/eval-workflows/evaluation-preparation.ts
+++ b/src/eval-workflows/evaluation-preparation.ts
@@ -29,7 +29,6 @@ export async function prepareEvaluationRun({
   dryRun,
   mcpConfig,
   strictBaseline,
-  variantAllowedSkills,
 }: {
   samplesPath: string;
   skillDir: string;
@@ -39,8 +38,6 @@ export async function prepareEvaluationRun({
   mcpConfig?: string;
   /**  — default true, baseline-kind 自动 allowedSkills=[]。 */
   strictBaseline?: boolean;
-  /**  — eval.yaml 显式 allowedSkills per variant (overrides strictBaseline default). */
-  variantAllowedSkills?: Record<string, string[]>;
 }): Promise<PreparedEvaluationRun> {
   const { samples, requires, baseDir: samplesBaseDir, sourceFiles: samplesSourceFiles } = loadSamples(samplesPath);
 
@@ -66,14 +63,10 @@ export async function prepareEvaluationRun({
     variantSpecs.forEach((spec, i) => {
       const artifact = resolvedArtifacts[i];
       if (!artifact.experimentRole) artifact.experimentRole = spec.role;
-      // allowedSkills 按 spec 身份绑定(eval 主路径的唯一隔离绑定点,显式声明优先于
-      // strictBaseline 默认)。首选 spec.allowedSkills(eval.yaml 经 configVariantsToSpecs 带上);
-      // 旧的按变量名 map 仅作 legacy fallback,兜住「CLI roles 覆盖 config 时 spec 不带
-      // allowedSkills」等边角,行为与重构前一致。
-      // TODO: 待所有路径都按 spec 携带 allowedSkills 后,移除 variantAllowedSkills 这条 fallback,
-      //       与 resolveArtifacts 里的按名绑定一并收成单一来源。
-      const explicit = spec.allowedSkills ?? variantAllowedSkills?.[spec.name];
-      if (explicit !== undefined) artifact.allowedSkills = explicit;
+      // allowedSkills 按 spec 身份绑定:spec.allowedSkills 是隔离声明的单一来源
+      //（eval.yaml 经 configVariantsToSpecs、batch 经 buildBatchVariantSpecs 都挂到 spec 上),
+      // 显式声明优先于 strictBaseline 默认。
+      if (spec.allowedSkills !== undefined) artifact.allowedSkills = spec.allowedSkills;
       spec.name = artifact.name; // 同步唯一名,让 spec 与 report / variantNames 一致(放最后,前面还要用旧名查)
     });
   } else {

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -657,12 +657,13 @@ export async function runBatchEvaluation({
         skillDirAbs,
         ['baseline', entry.skillPath],
         { strictBaseline, variantAllowedSkills },
-      ).map((artifact) => {
-        if (artifact.name === entry.skillPath) {
-          return { ...artifact, name: entry.name, experimentRole: 'treatment' as const };
-        }
-        return { ...artifact, experimentRole: 'control' as const };
-      });
+      ).map((artifact) =>
+        // artifact.name 是派生短名,不等于全路径 entry.skillPath,按 kind 区分角色
+        // (与 executeBatchEvaluationRuns real-run 严格一致)。
+        artifact.kind === 'baseline'
+          ? { ...artifact, experimentRole: 'control' as const }
+          : { ...artifact, name: entry.name, experimentRole: 'treatment' as const },
+      );
       let entryReport: DryRunReport;
       try {
         const result = await runEvaluation({

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -1,9 +1,9 @@
 import { resolve } from 'node:path';
 import { DEFAULT_OUTPUT_DIR, persistReport } from '../eval-core/evaluation-reporting.js';
 import { createExecutor, DEFAULT_MODEL, JUDGE_MODEL } from '../executors/index.js';
-import { discoverBatchSkills, resolveArtifacts } from '../inputs/skill-loader.js';
+import { discoverBatchSkills } from '../inputs/skill-loader.js';
 import { confidenceInterval, tTest, effectSize } from '../eval-core/statistics.js';
-import { executeBatchEvaluationRuns } from './batch-evaluation-workflow.js';
+import { executeBatchEvaluationRuns, buildBatchSkillArtifacts } from './batch-evaluation-workflow.js';
 import {
   buildDryRunTaskReport,
   prepareEvaluationRun,
@@ -653,17 +653,7 @@ export async function runBatchEvaluation({
     const skillDirAbs = resolve(skillDir);
     const dryArtifacts: DryRunBatchSkill[] = [];
     for (const entry of skillEntries) {
-      const skillArtifacts = resolveArtifacts(
-        skillDirAbs,
-        ['baseline', entry.skillPath],
-        { strictBaseline, variantAllowedSkills },
-      ).map((artifact) =>
-        // artifact.name 是派生短名,不等于全路径 entry.skillPath,按 kind 区分角色
-        // (与 executeBatchEvaluationRuns real-run 严格一致)。
-        artifact.kind === 'baseline'
-          ? { ...artifact, experimentRole: 'control' as const }
-          : { ...artifact, name: entry.name, experimentRole: 'treatment' as const },
-      );
+      const skillArtifacts = buildBatchSkillArtifacts(skillDirAbs, entry, { strictBaseline, variantAllowedSkills });
       let entryReport: DryRunReport;
       try {
         const result = await runEvaluation({

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -643,8 +643,8 @@ export async function runBatchEvaluation({
   if (dryRun) {
     // batch dry-run 走 per-entry runEvaluation(dryRun: true) — doctor 嵌入
     // 自动复用 runEvaluation 内部的 builder + 单一逻辑,不再在 batch 这边
-    // 旁路一套 doctor / 路径推断。entry artifact 拼装方式与 batch real-run
-    // (executeBatchEvaluationRuns) 严格一致, 避免 dry-run / real-run 漂移。
+    // 旁路一套 doctor / 路径推断。entry 的 spec 构造(buildBatchVariantSpecs)与 batch
+    // real-run(executeBatchEvaluationRuns)同一处,避免 dry-run / real-run 漂移。
     const dryArtifacts: DryRunBatchSkill[] = [];
     for (const entry of skillEntries) {
       const variantSpecs = buildBatchVariantSpecs(entry, variantAllowedSkills?.[entry.name]);

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -3,7 +3,7 @@ import { DEFAULT_OUTPUT_DIR, persistReport } from '../eval-core/evaluation-repor
 import { createExecutor, DEFAULT_MODEL, JUDGE_MODEL } from '../executors/index.js';
 import { discoverBatchSkills } from '../inputs/skill-loader.js';
 import { confidenceInterval, tTest, effectSize } from '../eval-core/statistics.js';
-import { executeBatchEvaluationRuns, buildBatchSkillArtifacts } from './batch-evaluation-workflow.js';
+import { executeBatchEvaluationRuns, buildBatchVariantSpecs } from './batch-evaluation-workflow.js';
 import {
   buildDryRunTaskReport,
   prepareEvaluationRun,
@@ -108,12 +108,9 @@ export interface RunEvaluationOptions extends CommonEvaluationOptions {
   /** Explicit persisted run id. Used by batch workflows that need stable child ids. */
   runId?: string;
   /** strict-baseline default (CLI `--strict-baseline` default true).
-   *  When undefined, treated as true. baseline-kind variants get allowedSkills=[]
-   *  unless eval.yaml explicitly overrides per-variant. */
+   *  When undefined, treated as true. baseline-kind variants get allowedSkills=[].
+   *  per-variant 显式隔离声明走 variantSpecs[].allowedSkills(eval.yaml 经 configVariantsToSpecs)。 */
   strictBaseline?: boolean;
-  /** per-variant explicit allowedSkills override map (from eval.yaml).
-   *  Keyed by variant name. Always wins over strictBaseline default. */
-  variantAllowedSkills?: Record<string, string[]>;
 }
 
 export interface RunBatchEvaluationOptions extends CommonEvaluationOptions {
@@ -200,7 +197,6 @@ export async function runEvaluation({
   lengthDebias,
   budget,
   strictBaseline,
-  variantAllowedSkills,
   effort,
   noDiagnostic,
 }: RunEvaluationOptions): Promise<{ report: Report | DryRunReport; filePath: string | null }> {
@@ -219,7 +215,6 @@ export async function runEvaluation({
     dryRun,
     mcpConfig,
     strictBaseline,
-    variantAllowedSkills,
   });
 
   // doctor 强制门禁: skill 静态结构 + 元数据 + 依赖 + 用例契约。
@@ -650,16 +645,15 @@ export async function runBatchEvaluation({
     // 自动复用 runEvaluation 内部的 builder + 单一逻辑,不再在 batch 这边
     // 旁路一套 doctor / 路径推断。entry artifact 拼装方式与 batch real-run
     // (executeBatchEvaluationRuns) 严格一致, 避免 dry-run / real-run 漂移。
-    const skillDirAbs = resolve(skillDir);
     const dryArtifacts: DryRunBatchSkill[] = [];
     for (const entry of skillEntries) {
-      const skillArtifacts = buildBatchSkillArtifacts(skillDirAbs, entry, { strictBaseline, variantAllowedSkills });
+      const variantSpecs = buildBatchVariantSpecs(entry, variantAllowedSkills?.[entry.name]);
       let entryReport: DryRunReport;
       try {
         const result = await runEvaluation({
           samplesPath: entry.samplesPath,
           skillDir,
-          artifacts: skillArtifacts,
+          variantSpecs,
           model,
           executorName,
           dryRun: true,
@@ -668,7 +662,6 @@ export async function runBatchEvaluation({
           lang,
           mcpConfig,
           strictBaseline,
-          variantAllowedSkills,
           // 透传 user 显式输入的参数,让 dry-run power / isolation warning 与
           // 真实 run 一致(否则 batch dry-run 永远按 repeat=1 报警,误导用户)。
           repeat,

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -647,7 +647,7 @@ export async function runBatchEvaluation({
     // real-run(executeBatchEvaluationRuns)同一处,避免 dry-run / real-run 漂移。
     const dryArtifacts: DryRunBatchSkill[] = [];
     for (const entry of skillEntries) {
-      const variantSpecs = buildBatchVariantSpecs(entry, variantAllowedSkills?.[entry.name]);
+      const variantSpecs = buildBatchVariantSpecs(entry, variantAllowedSkills);
       let entryReport: DryRunReport;
       try {
         const result = await runEvaluation({

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -136,12 +136,10 @@ export function loadSkills(skillDir: string, variants: string[]): Record<string,
 
 /** opts for resolveArtifacts skill-isolation wiring. */
 export interface ResolveArtifactsOptions {
-  /** Default true. When true, baseline-kind artifacts get allowedSkills=[] auto-injected
-   *  unless overridden by variantAllowedSkills. */
+  /** Default true. When true, baseline-kind artifacts get allowedSkills=[] auto-injected.
+   *  显式 per-variant 隔离声明走 spec.allowedSkills(prepareEvaluationRun 按 spec 身份绑定),
+   *  不经此处——resolveArtifacts 只认 strictBaseline 默认,隔离绑定收成单一来源。 */
   strictBaseline?: boolean;
-  /** Per-variant explicit allowedSkills (from eval.yaml). Keyed by variant name (post
-   *  parseVariantCwd, matches Artifact.name). Always overrides strictBaseline default. */
-  variantAllowedSkills?: Record<string, string[]>;
 }
 
 /**
@@ -238,7 +236,6 @@ export function resolveArtifacts(
   opts: ResolveArtifactsOptions = {},
 ): Artifact[] {
   const strictBaseline = opts.strictBaseline ?? true;
-  const variantAllowedSkills = opts.variantAllowedSkills ?? {};
   const artifacts: Artifact[] = [];
   let gitRelDir: string | null = null;
 
@@ -363,25 +360,15 @@ export function resolveArtifacts(
     }
   }
 
-  // Skill-isolation wiring（按 artifact 名查 variantAllowedSkills）。
-  //   Priority: variantAllowedSkills (explicit eval.yaml) > strictBaseline default > none。
-  //   strictBaseline=true 时,所有 kind:'baseline' artifact 默认 allowedSkills=[]。
-  //   显式 [] 也是合法(用户主动想"完全发现")的反义靠 strictBaseline=false 表达整批关闭。
-  //
-  //   职责边界:这条按名查的绑定服务 doctor / batch / loadSkills 等直接调 resolveArtifacts 的
-  //   调用方。eval 主路径(prepareEvaluationRun)已改为按 spec 身份绑定、不再传 variantAllowedSkills,
-  //   不走这里。两条路径暂并存。
-  //   TODO: 待 batch 也迁到 spec-based 绑定后,退役 opts.variantAllowedSkills,让隔离绑定收成一处。
+  // Skill-isolation:resolveArtifacts 只负责 strictBaseline 默认——strictBaseline=true 时
+  //   所有 kind:'baseline' artifact 默认 allowedSkills=[];否则保持 undefined → SDK 全量发现。
+  //   per-variant 显式隔离声明(eval.yaml variants[].allowedSkills)统一走 spec.allowedSkills,
+  //   由 prepareEvaluationRun 按 spec 身份绑定;batch 的 eval.yaml allowedSkills 也已在
+  //   buildBatchVariantSpecs 处挂到 spec 上。隔离绑定收成单一来源,这里不再按名查。
   for (const artifact of artifacts) {
-    const explicit = variantAllowedSkills[artifact.name];
-    if (explicit !== undefined) {
-      artifact.allowedSkills = explicit;
-      continue;
-    }
     if (strictBaseline && artifact.kind === 'baseline') {
       artifact.allowedSkills = [];
     }
-    // else leave undefined → SDK default (full discovery)
   }
 
   ensureUniqueVariantNames(artifacts);

--- a/test/eval-core/report-variant-keys.golden.test.ts
+++ b/test/eval-core/report-variant-keys.golden.test.ts
@@ -95,7 +95,6 @@ function assertAllVariantSurfacesEqual(report: Report, variantNames: string[]): 
 
 interface RunCaseOpts {
   variantSpecs: VariantSpec[];
-  variantAllowedSkills?: Record<string, string[]>;
   request?: EvaluationRequest;
   scored?: boolean;
 }
@@ -110,7 +109,6 @@ async function runCase(opts: RunCaseOpts): Promise<{ report: Report; variantName
     skillDir: root,
     variantSpecs: opts.variantSpecs,
     dryRun: true,
-    variantAllowedSkills: opts.variantAllowedSkills,
   });
   const sampleIds = prepared.samples.map((s) => s.sample_id);
   const results = buildResults(sampleIds, prepared.variantNames, opts.scored ?? false);
@@ -177,10 +175,9 @@ describe('GOLDEN report variant keys', () => {
   it('case 3 — eval.yaml custom name + allowedSkills:[] lands on disambiguated artifact', async () => {
     const { report, variantNames } = await runCase({
       variantSpecs: [
-        { name: 'control-v1', role: 'control', expr: join(root, 'v1', 'greeter.md') },
+        { name: 'control-v1', role: 'control', expr: join(root, 'v1', 'greeter.md'), allowedSkills: [] },
         { name: 'treat-v2', role: 'treatment', expr: join(root, 'v2', 'greeter.md') },
       ],
-      variantAllowedSkills: { 'control-v1': [] },
     });
     assert.deepEqual(variantNames, ['v1/greeter', 'v2/greeter']);
     assertAllVariantSurfacesEqual(report, variantNames);

--- a/test/inputs/skill-loader.test.ts
+++ b/test/inputs/skill-loader.test.ts
@@ -104,28 +104,9 @@ describe('resolveArtifacts skill isolation', () => {
     assert.equal(baseline.allowedSkills, undefined);
   });
 
-  it('显式 variantAllowedSkills 优先于 strictBaseline 默认', () => {
-    const artifacts = resolveArtifacts(SKILL_DIR, ['baseline', 'v1'], {
-      strictBaseline: true,
-      variantAllowedSkills: { baseline: ['react-skill'], v1: [] },
-    });
-    const baseline = artifacts.find((a) => a.name === 'baseline')!;
-    const v1 = artifacts.find((a) => a.name === 'v1')!;
-    assert.deepEqual(baseline.allowedSkills, ['react-skill'], 'eval.yaml 显式覆盖 strict-baseline 默认 []');
-    assert.deepEqual(v1.allowedSkills, [], '显式给 treatment 设 [] 也合法');
-  });
-
   it('cwd-only expr 也被认作 baseline-kind,strict-baseline 自动隔离', () => {
     const artifacts = resolveArtifacts(SKILL_DIR, [{ expr: 'project-env', cwd: '/tmp/proj' }]);
     assert.deepEqual(artifacts[0].allowedSkills, [],
       'kind:baseline 包括 cwd-only custom variant,strict-baseline 一并隔离');
-  });
-
-  it('strictBaseline=true 但 variantAllowedSkills 显式给 baseline 一个非空白名单 → 用白名单', () => {
-    const artifacts = resolveArtifacts(SKILL_DIR, ['baseline'], {
-      strictBaseline: true,
-      variantAllowedSkills: { baseline: ['allowed-one'] },
-    });
-    assert.deepEqual(artifacts[0].allowedSkills, ['allowed-one']);
   });
 });

--- a/test/inputs/variant-name-collision.test.ts
+++ b/test/inputs/variant-name-collision.test.ts
@@ -172,14 +172,16 @@ describe('CLI dry-run — --control / --treatment same-basename in different dir
 
   it('keeps an eval.yaml-style explicit name + allowedSkills wired to the right artifact', async () => {
     // 模拟 eval.yaml:variant 名(control-v1)与 artifact 路径短名(greeter)不同,且声明 allowedSkills:[]。
-    // variantAllowedSkills 按 config 名建索引,resolveArtifacts 按 artifact 短名查会漏绑 —— 这里验证 index 分支把它补回来。
-    const variantSpecs = [{ name: 'control-v1', role: 'control' as const, expr: join(root, 'v1', 'greeter.md') }];
+    // allowedSkills 走 spec.allowedSkills(configVariantsToSpecs 挂上的单一来源),即便消歧把
+    // artifact 名改成 v1/greeter,也按 spec 身份(index 对齐)绑到正确 artifact 上。
+    const variantSpecs = [
+      { name: 'control-v1', role: 'control' as const, expr: join(root, 'v1', 'greeter.md'), allowedSkills: [] },
+    ];
     const prepared = await prepareEvaluationRun({
       samplesPath,
       skillDir: root,
       variantSpecs,
       dryRun: true,
-      variantAllowedSkills: { 'control-v1': [] },
     });
     assert.equal(prepared.artifacts.length, 1);
     // allowedSkills 必须落到 artifact 上(=[] 表示隔离),不能是 undefined(=SDK 默认 discovery)

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -757,13 +757,72 @@ describe('runBatchEvaluation', () => {
         },
       });
 
-      // allowedSkills 从 variantAllowedSkills[entry.name] 取出、挂到 treatment spec 上;
-      // baseline 不带(由 strict-baseline 在 resolveArtifacts 隔离),后续 spec→artifact 绑定
-      // 由 prepareEvaluationRun 完成(golden case 1 + collision 测试覆盖)。
+      // 这里 eval.yaml 只声明 greeter,baseline 未声明 → treatment spec 挂 only-this、
+      // baseline spec 不带(隔离交给 strict-baseline 默认)。后续 spec→artifact 绑定由
+      // prepareEvaluationRun 完成(golden case 1 + collision 测试覆盖)。
       const treatmentSpec = capturedSpecs.find((s) => s.expr !== 'baseline');
       const baselineSpec = capturedSpecs.find((s) => s.expr === 'baseline');
       assert.deepEqual(treatmentSpec?.allowedSkills, ['only-this'], 'eval.yaml per-variant allowedSkills 挂到 treatment spec');
-      assert.equal(baselineSpec?.allowedSkills, undefined, 'baseline spec 不带 allowedSkills,隔离交给 strict-baseline');
+      assert.equal(baselineSpec?.allowedSkills, undefined, '未声明 baseline → 不带 allowedSkills,隔离交给 strict-baseline');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('batch 下 eval.yaml 显式给 baseline 配 allowedSkills 必须优先于 strict-baseline 默认', async () => {
+    // 回归:batch 迁 spec 后,baseline 的 eval.yaml 隔离声明(白名单或 [])不能被漏挂——
+    // variant.allowedSkills 优先于 strictBaseline,否则 `--batch --config` 的 baseline 隔离静默失效。
+    const tmpDir = mkdtempSync(join(tmpdir(), 'omk-batch-baseline-allowed-'));
+    try {
+      const skillPath = join(tmpDir, 'greeter.md');
+      const samplesPath = join(tmpDir, 'greeter.eval-samples.json');
+      writeFileSync(skillPath, 'skill content');
+      writeFileSync(samplesPath, JSON.stringify([{ sample_id: 's1', prompt: 'p' }]));
+
+      let capturedSpecs: import('../src/types/index.js').VariantSpec[] = [];
+      await executeBatchEvaluationRuns({
+        skillDir: tmpDir,
+        skillEntries: [{ name: 'greeter', skillPath, samplesPath }],
+        model: 'm',
+        judgeModel: 'j',
+        outputDir: join(tmpDir, 'reports'),
+        noJudge: true,
+        concurrency: 1,
+        noCache: true,
+        executorName: 'claude',
+        persistJob: false,
+        strictBaseline: true,
+        variantAllowedSkills: { baseline: ['allow-x'], greeter: [] },
+        runSingleEvaluation: async (options) => {
+          capturedSpecs = options.variantSpecs;
+          const report: Report = {
+            kind: 'evaluation',
+            id: options.runId!,
+            meta: {
+              variants: ['baseline', 'greeter'],
+              model: options.model,
+              judgeModels: [{ executor: options.executorName, model: 'haiku' }],
+              noJudge: true,
+              executor: options.executorName,
+              sampleCount: 1,
+              taskCount: 2,
+              totalCostUSD: 0,
+              timestamp: '2026-05-01T00:00:00.000Z',
+              cliVersion: 'test',
+              nodeVersion: 'test',
+              artifactHashes: { baseline: 'no-skill', greeter: 'h' },
+            },
+            summary: {},
+            results: [],
+          };
+          return { report, filePath: null };
+        },
+      });
+
+      const baselineSpec = capturedSpecs.find((s) => s.expr === 'baseline');
+      const treatmentSpec = capturedSpecs.find((s) => s.expr !== 'baseline');
+      assert.deepEqual(baselineSpec?.allowedSkills, ['allow-x'], 'eval.yaml baseline 白名单优先于 strict-baseline 默认 []');
+      assert.deepEqual(treatmentSpec?.allowedSkills, [], '显式给 treatment 配 [] 也透传');
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -617,6 +617,7 @@ describe('runBatchEvaluation', () => {
         avgCompositeScore: score,
       });
 
+      let capturedArtifacts: import('../src/types/index.js').Artifact[] = [];
       const result = await executeBatchEvaluationRuns({
         skillDir: tmpDir,
         skillEntries: [{ name: 'alpha', skillPath, samplesPath }],
@@ -630,7 +631,10 @@ describe('runBatchEvaluation', () => {
         persistJob: false,
         runSingleEvaluation: async (options) => {
           assert.equal(options.noCache, true);
-          const treatment = options.artifacts.find((artifact) => artifact.experimentRole === 'treatment')?.name ?? 'alpha';
+          capturedArtifacts = options.artifacts;
+          // #183 回归:不再用 `?? 'alpha'` 兜底——必须真有一个 treatment-role artifact,
+          // 否则 find 返回 undefined、treatment 取 undefined.name 抛错,把角色误绑暴露成测试失败。
+          const treatment = options.artifacts.find((artifact) => artifact.experimentRole === 'treatment')!.name;
           const report: Report = {
             kind: 'evaluation',
             id: options.runId!,
@@ -691,6 +695,72 @@ describe('runBatchEvaluation', () => {
       assert.equal(childReport.meta.artifactHashes.alpha, 'hash-alpha');
       assert.ok(childReport.summary.alpha);
       assert.equal(childReport.summary.skill, undefined);
+
+      // #183 回归:batch 必须把 baseline 绑 control、当前 skill 绑 treatment。
+      // 旧实现按 `artifact.name === entry.skillPath`(短名 vs 全路径,永 false)判定,
+      // 导致 treatment skill 落入 else 分支被误标 control,两个 artifact 都成 control。
+      const baselineArt = capturedArtifacts.find((a) => a.kind === 'baseline');
+      const treatmentArt = capturedArtifacts.find((a) => a.kind === 'skill');
+      assert.equal(baselineArt?.experimentRole, 'control');
+      assert.equal(treatmentArt?.experimentRole, 'treatment');
+      assert.equal(treatmentArt?.name, 'alpha', 'treatment 对齐到 entry 的逻辑名');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('#183: per-variant allowedSkills 在 batch 下按短名(== entry.name)绑到 treatment', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'omk-batch-allowed-'));
+    try {
+      const skillPath = join(tmpDir, 'greeter.md');
+      const samplesPath = join(tmpDir, 'greeter.eval-samples.json');
+      writeFileSync(skillPath, 'skill content');
+      writeFileSync(samplesPath, JSON.stringify([{ sample_id: 's1', prompt: 'p' }]));
+
+      let capturedArtifacts: import('../src/types/index.js').Artifact[] = [];
+      await executeBatchEvaluationRuns({
+        skillDir: tmpDir,
+        skillEntries: [{ name: 'greeter', skillPath, samplesPath }],
+        model: 'm',
+        judgeModel: 'j',
+        outputDir: join(tmpDir, 'reports'),
+        noJudge: true,
+        concurrency: 1,
+        noCache: true,
+        executorName: 'claude',
+        persistJob: false,
+        strictBaseline: true,
+        variantAllowedSkills: { greeter: ['only-this'] },
+        runSingleEvaluation: async (options) => {
+          capturedArtifacts = options.artifacts;
+          const report: Report = {
+            kind: 'evaluation',
+            id: options.runId!,
+            meta: {
+              variants: ['baseline', 'greeter'],
+              model: options.model,
+              judgeModels: [{ executor: options.executorName, model: 'haiku' }],
+              noJudge: true,
+              executor: options.executorName,
+              sampleCount: 1,
+              taskCount: 2,
+              totalCostUSD: 0,
+              timestamp: '2026-05-01T00:00:00.000Z',
+              cliVersion: 'test',
+              nodeVersion: 'test',
+              artifactHashes: { baseline: 'no-skill', greeter: 'h' },
+            },
+            summary: {},
+            results: [],
+          };
+          return { report, filePath: null };
+        },
+      });
+
+      const baselineArt = capturedArtifacts.find((a) => a.kind === 'baseline');
+      const treatmentArt = capturedArtifacts.find((a) => a.kind === 'skill');
+      assert.deepEqual(baselineArt?.allowedSkills, [], 'strict-baseline 默认隔离 baseline');
+      assert.deepEqual(treatmentArt?.allowedSkills, ['only-this'], 'eval.yaml per-variant allowedSkills 按短名绑到 treatment');
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -617,7 +617,7 @@ describe('runBatchEvaluation', () => {
         avgCompositeScore: score,
       });
 
-      let capturedArtifacts: import('../src/types/index.js').Artifact[] = [];
+      let capturedSpecs: import('../src/types/index.js').VariantSpec[] = [];
       const result = await executeBatchEvaluationRuns({
         skillDir: tmpDir,
         skillEntries: [{ name: 'alpha', skillPath, samplesPath }],
@@ -631,10 +631,10 @@ describe('runBatchEvaluation', () => {
         persistJob: false,
         runSingleEvaluation: async (options) => {
           assert.equal(options.noCache, true);
-          capturedArtifacts = options.artifacts;
-          // #183 回归:不再用 `?? 'alpha'` 兜底——必须真有一个 treatment-role artifact,
-          // 否则 find 返回 undefined、treatment 取 undefined.name 抛错,把角色误绑暴露成测试失败。
-          const treatment = options.artifacts.find((artifact) => artifact.experimentRole === 'treatment')!.name;
+          capturedSpecs = options.variantSpecs;
+          // #183 回归:batch 必须真有一个 treatment-role spec(此前误绑成 control,两个都 control)。
+          // 不兜底——find 落空就 undefined.name 抛错,把误绑暴露成测试失败。
+          const treatment = options.variantSpecs.find((spec) => spec.role === 'treatment')!.name;
           const report: Report = {
             kind: 'evaluation',
             id: options.runId!,
@@ -654,7 +654,7 @@ describe('runBatchEvaluation', () => {
               request: {
                 samplesPath: options.samplesPath,
                 skillDir: options.skillDir,
-                artifacts: options.artifacts,
+                artifacts: [],
                 model: options.model,
                 judgeModels: [{ executor: options.judgeExecutorName || options.executorName, model: 'haiku' }],
                 executor: options.executorName,
@@ -696,20 +696,20 @@ describe('runBatchEvaluation', () => {
       assert.ok(childReport.summary.alpha);
       assert.equal(childReport.summary.skill, undefined);
 
-      // #183 回归:batch 必须把 baseline 绑 control、当前 skill 绑 treatment。
-      // 旧实现按 `artifact.name === entry.skillPath`(短名 vs 全路径,永 false)判定,
-      // 导致 treatment skill 落入 else 分支被误标 control,两个 artifact 都成 control。
-      const baselineArt = capturedArtifacts.find((a) => a.kind === 'baseline');
-      const treatmentArt = capturedArtifacts.find((a) => a.kind === 'skill');
-      assert.equal(baselineArt?.experimentRole, 'control');
-      assert.equal(treatmentArt?.experimentRole, 'treatment');
-      assert.equal(treatmentArt?.name, 'alpha', 'treatment 对齐到 entry 的逻辑名');
+      // #183 回归:batch 构造的 spec 必须 baseline=control、当前 skill=treatment(对齐 entry 名)。
+      // 旧实现自管 artifact 拼装、按 `artifact.name === entry.skillPath`(短名 vs 全路径,永 false)
+      // 误标,两个都成 control;现在交给 spec-based 解析,role 由 spec 唯一声明。
+      const baselineSpec = capturedSpecs.find((s) => s.expr === 'baseline');
+      const treatmentSpec = capturedSpecs.find((s) => s.expr !== 'baseline');
+      assert.equal(baselineSpec?.role, 'control');
+      assert.equal(treatmentSpec?.role, 'treatment');
+      assert.equal(treatmentSpec?.name, 'alpha', 'treatment spec 对齐到 entry 的逻辑名');
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 
-  it('#183: per-variant allowedSkills 在 batch 下按短名(== entry.name)绑到 treatment', async () => {
+  it('#183: per-variant allowedSkills 从 eval.yaml(按 entry.name 查)挂到 treatment spec 上', async () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'omk-batch-allowed-'));
     try {
       const skillPath = join(tmpDir, 'greeter.md');
@@ -717,7 +717,7 @@ describe('runBatchEvaluation', () => {
       writeFileSync(skillPath, 'skill content');
       writeFileSync(samplesPath, JSON.stringify([{ sample_id: 's1', prompt: 'p' }]));
 
-      let capturedArtifacts: import('../src/types/index.js').Artifact[] = [];
+      let capturedSpecs: import('../src/types/index.js').VariantSpec[] = [];
       await executeBatchEvaluationRuns({
         skillDir: tmpDir,
         skillEntries: [{ name: 'greeter', skillPath, samplesPath }],
@@ -732,7 +732,7 @@ describe('runBatchEvaluation', () => {
         strictBaseline: true,
         variantAllowedSkills: { greeter: ['only-this'] },
         runSingleEvaluation: async (options) => {
-          capturedArtifacts = options.artifacts;
+          capturedSpecs = options.variantSpecs;
           const report: Report = {
             kind: 'evaluation',
             id: options.runId!,
@@ -757,10 +757,13 @@ describe('runBatchEvaluation', () => {
         },
       });
 
-      const baselineArt = capturedArtifacts.find((a) => a.kind === 'baseline');
-      const treatmentArt = capturedArtifacts.find((a) => a.kind === 'skill');
-      assert.deepEqual(baselineArt?.allowedSkills, [], 'strict-baseline 默认隔离 baseline');
-      assert.deepEqual(treatmentArt?.allowedSkills, ['only-this'], 'eval.yaml per-variant allowedSkills 按短名绑到 treatment');
+      // allowedSkills 从 variantAllowedSkills[entry.name] 取出、挂到 treatment spec 上;
+      // baseline 不带(由 strict-baseline 在 resolveArtifacts 隔离),后续 spec→artifact 绑定
+      // 由 prepareEvaluationRun 完成(golden case 1 + collision 测试覆盖)。
+      const treatmentSpec = capturedSpecs.find((s) => s.expr !== 'baseline');
+      const baselineSpec = capturedSpecs.find((s) => s.expr === 'baseline');
+      assert.deepEqual(treatmentSpec?.allowedSkills, ['only-this'], 'eval.yaml per-variant allowedSkills 挂到 treatment spec');
+      assert.equal(baselineSpec?.allowedSkills, undefined, 'baseline spec 不带 allowedSkills,隔离交给 strict-baseline');
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## 用户影响

batch 评测模式（`omk eval` 扫目录批量跑 baseline vs 每个 skill）下,当前 skill 的实验角色被误标为 `control`,导致报告 `variantConfigs[skill].experimentRole` 写成 `control` 而非 `treatment`。下游分析靠 baseline 排在首位的巧合仍能算出对比,但 report 里的角色字段语义错误,任何严格按 `experimentRole` 取对照/实验组的消费者会拿到污染数据,违反 terminology-spec「experimentRole 是唯一来源」。

修复后 batch 的角色绑定与单跑路径(`prepareEvaluationRun` 已按 spec 身份绑定)一致。报告键命名链路不变,无 BREAKING-COMPARABILITY。

## 根因

batch 用 `artifact.name === entry.skillPath` 区分 treatment,但 `resolveArtifacts` 产出的 `artifact.name` 是派生短名(`skillNameFromPath(skillPath)`),`entry.skillPath` 是全路径,等值恒为 false。treatment skill 因此落入 else 分支被标 `control`,baseline 与 skill 双双成 `control`。real-run(`batch-evaluation-workflow.ts`)与 dry-run(`run-evaluation.ts`)两处同一缺陷。

改为按 `artifact.kind` 区分:batch 结构固定为 1 个 baseline-kind + 1 个 skill-kind,baseline-kind 绑 control、skill-kind 绑 treatment 并对齐到 entry 逻辑名。

## 顺带澄清(原 issue 的 claim #2 是误报)

原 issue 怀疑 per-variant `allowedSkills` 在 batch 下被静默忽略。实测不成立:`entry.name` 恒等于短名,`variantAllowedSkills[entry.name]` 在 `resolveArtifacts` 内按短名命中,隔离声明本就正确绑定。`perSkillAllowedSkills` 那段补全路径 key 的代码是死代码,一并删除。回归测试覆盖此结论。

## 测试

补 batch 角色绑定 + per-variant allowedSkills 两条回归(此前 batch 角色/隔离零覆盖;旧测试用 `?? 'alpha'` 兜底掩盖了误绑)。已验证:revert 源码修复后,角色断言失败;allowedSkills 断言两侧均过(印证 claim #2 非 bug)。

Closes #183

---

## 追加:抽 `buildBatchSkillArtifacts` 收口角色绑定(refactor commit)

本次误绑能在 real-run / dry-run 两处各存一份,根因是同一段 `resolveArtifacts(['baseline', skillPath]).map(kind → role)` 被手抄两遍。修复同时抽成单一 `buildBatchSkillArtifacts`,两条 batch 路径共用,杜绝再次漂移;`run-evaluation` 不再直接依赖 `resolveArtifacts`。纯结构调整,无行为变化,1758 测试全绿。

更彻底的统一(batch 迁到 spec-based 角色/隔离绑定 → 退役 `resolveArtifacts` 的 `variantAllowedSkills` 参数与 legacy fallback,对应 skill-loader / evaluation-preparation 两处 TODO)留作后续单独立项,不在本 PR。

---

## 追加:tier 2/3 —— batch 迁 spec-based 绑定 + 隔离声明收成单一来源

在抽 helper 的基础上,进一步把 batch 整体迁到与单跑一致的 spec-based 绑定,并退役按变量名查的旧隔离机制(对应 skill-loader / evaluation-preparation 两处 TODO):

batch 改为构造 `VariantSpec[]`(`buildBatchVariantSpecs`),treatment 的 eval.yaml `allowedSkills` 挂到 spec 上,由 `runEvaluation` → `prepareEvaluationRun` 按 spec 身份统一绑 role / 隔离;batch 不再自管 artifact 拼装与 kind 反推。

`resolveArtifacts` 删 `variantAllowedSkills` 参数与名键 loop(只保留 `strictBaseline` 默认);`prepareEvaluationRun` 删该参数与 `spec.allowedSkills ?? map` fallback;`runEvaluation` 删该参数。隔离声明从此只有 `spec.allowedSkills` 一个来源。

report 键命名与 `skillIsolation` 输出不变,golden 快照 0 diff(byte-identical),无 BREAKING-COMPARABILITY。1756 测试全绿(移除 2 条已失效的 resolveArtifacts 隔离单测)。
