### PR TITLE
feat(authoring): evolve 加显著性接受门 + 锁定 test 集 + 抗过拟

### DIFF
--- a/.claude/skills/omk/SKILL.md
+++ b/.claude/skills/omk/SKILL.md
@@ -88,7 +88,11 @@ omk eval --config eval.yaml
 ```bash
 omk evolve skills/my-skill.md --rounds 5
 omk evolve skills/my-skill.md --rounds 10 --target 4.5
+# 严格留出 + 锁定 test：按 val 显著性接受、收尾给无偏泛化分
+omk evolve skills/my-skill.md --holdout-ratio 0.2 --test-ratio 0.2
 ```
+
+evolve 默认开**显著性接受门**：候选只在相对当前最优**统计显著更好**时才被接受（`bootstrapDiffCI` 的 95% CI 排除 0），而不是「分数高一点点就收」—— 拒绝与评委噪声不可分的提升。决策样本太少时退回点估计并 warn；`--no-significance-gate` 可关。配 `--holdout-ratio` 留出 val 选择集、`--test-ratio` 再锁一份全程不参与选择的 test 集，收尾读一次给无偏泛化分。改动过大的候选评测前直接判拒（`--edit-budget`，默认 0.2）。
 
 **重要：evolve 必须在前台运行（不要用 `run_in_background`）。** 原因：evolve 自带实时进度输出，每个 sample 执行时会打印 `[1/5] s001/... ⏳ 执行中...`，每轮完成会打印 `Round N: score=... ✓ ACCEPT / ✗ REJECT`。前台运行时用户能实时看到这些进度，无需手动询问。设置足够长的 timeout（建议 600000ms）以确保命令不会中途超时。
 

--- a/.claude/skills/omk/references/commands.md
+++ b/.claude/skills/omk/references/commands.md
@@ -213,6 +213,7 @@ omk evolve <skillPath> [flags]
 
 - `--auto-fix-samples` `boolean`:每轮先修 skill，再修 sample，随后一起评估候选结果
 - `--concurrency` `option` (默认 `1`):评测并发数，默认 1
+- `--edit-budget` `option` (默认 `0.2`):单轮最多改动的 skill 行占比（默认 0.2）。超预算的候选评测前直接判拒，省 eval 成本
 - `--effort` `option`:reasoning effort: low/medium/high/xhigh/max
 - `--executor` `option` (默认 `claude`):执行器名，默认 claude
 - `--holdout-ratio` `option` (默认 `0`):留出验收集比例（0..1，默认 0=关）。> 0 时按 holdout 分接受候选、weak-sample 只取训练集，防 train-on-test
@@ -222,14 +223,19 @@ omk evolve <skillPath> [flags]
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--model` `option` (默认 `sonnet`):被评测的 LLM，默认 sonnet
 - `--no-diagnostic` `boolean`:关 LLM diagnostic 调用
+- `--no-edit-budget` `boolean`:关掉 edit budget 约束（允许任意大小的单轮改动）
+- `--no-reject-memory` `boolean`:关掉 rejected-edit 记忆（不把被拒改法回灌下一轮 prompt）
+- `--no-significance-gate` `boolean`:关掉显著性接受门，退回「候选分高一点点就收」的点估计判定（默认门开：只收统计显著的提升）
 - `--reuse-latest-eval` `boolean`:复用可比的最新 eval 报告作为 round-0
 - `--rounds` `option` (默认 `5`):最大迭代轮数，默认 5
 - `--sample-fix-max-attempts` `option` (默认 `2`):每条 sample 自动修复最多尝试次数（默认：2）
 - `--samples` `option` (默认 `eval-samples.json`):样本文件路径，默认 eval-samples.json
+- `--significance-alpha` `option` (默认 `0.05`):显著性门的 diff CI 显著性水平（默认 0.05 = 95% CI）
 - `--skip-connectivity` `boolean`:跳过 LLM 连通性预检
 - `--skip-doctor` `boolean`:跳过 doctor 门禁（escape hatch，自负 garbage-in 风险）
 - `--stop-on-assertions-pass` `boolean`:普通样本断言全过时提前停止
 - `--target` `option`:目标 composite 分数，达到即停。不传则跑满 rounds
+- `--test-ratio` `option` (默认 `0`):锁定 test 集比例（0..1，默认 0=关），需配 --holdout-ratio。全程不参与选择，收尾读一次给无偏泛化分
 - `--timeout` `option` (默认 `600`):单样本超时秒，默认 600
 
 **示例:**

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -214,6 +214,7 @@ omk evolve skills/foo.md --rounds 10 --target 4.5
 ```text
   --auto-fix-samples              Fix the skill, then fix samples, then evaluate the combined candidate
   --concurrency <value>           Eval concurrency, default 1
+  --edit-budget <value>           Max fraction of skill lines a round may change (default 0.2). Over-budget candidates are rejected before evaluation, saving eval cost
   --effort <value>                Reasoning effort: low/medium/high/xhigh/max
   --executor <value>              Executor name, default claude
   --holdout-ratio <value>         Holdout fraction for the accept decision (0..1, default 0=off). When > 0, candidates are accepted on holdout score and weak samples come only from train — guards against train-on-test
@@ -223,14 +224,19 @@ omk evolve skills/foo.md --rounds 10 --target 4.5
   --lang <value>                  Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --model <value>                 Evaluated LLM, default sonnet
   --no-diagnostic                 Disable diagnostic LLM call
+  --no-edit-budget                Disable the edit budget (allow arbitrarily large single-round edits)
+  --no-reject-memory              Disable rejected-edit memory (do not feed rejected edits back into the next prompt)
+  --no-significance-gate          Disable the significance accept gate, reverting to point-estimate accept (default: gate on — accept only statistically significant gains)
   --reuse-latest-eval             Reuse the latest comparable eval report as round-0
   --rounds <value>                Max iteration rounds, default 5
   --sample-fix-max-attempts <value>Max auto-fix attempts per sample (default: 2)
   --samples <value>               Samples file, default eval-samples.json
+  --significance-alpha <value>    Significance level for the accept gate diff CI (default 0.05 = 95% CI)
   --skip-connectivity             Skip LLM connectivity preflight
   --skip-doctor                   Skip doctor gate (escape hatch; user takes garbage-in risk)
   --stop-on-assertions-pass       Stop early when normal samples pass assertions
   --target <value>                Target composite score; stop when reached. If omitted, runs all rounds.
+  --test-ratio <value>            Locked test fraction (0..1, default 0=off); requires --holdout-ratio. Never used for selection; read once at the end for an unbiased generalization score
   --timeout <value>               Per-sample timeout sec, default 600
 ```
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -214,6 +214,7 @@ omk evolve skills/foo.md --rounds 10 --target 4.5
 ```text
   --auto-fix-samples              每轮先修 skill，再修 sample，随后一起评估候选结果
   --concurrency <value>           评测并发数，默认 1
+  --edit-budget <value>           单轮最多改动的 skill 行占比（默认 0.2）。超预算的候选评测前直接判拒，省 eval 成本
   --effort <value>                reasoning effort: low/medium/high/xhigh/max
   --executor <value>              执行器名，默认 claude
   --holdout-ratio <value>         留出验收集比例（0..1，默认 0=关）。> 0 时按 holdout 分接受候选、weak-sample 只取训练集，防 train-on-test
@@ -223,14 +224,19 @@ omk evolve skills/foo.md --rounds 10 --target 4.5
   --lang <value>                  输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --model <value>                 被评测的 LLM，默认 sonnet
   --no-diagnostic                 关 LLM diagnostic 调用
+  --no-edit-budget                关掉 edit budget 约束（允许任意大小的单轮改动）
+  --no-reject-memory              关掉 rejected-edit 记忆（不把被拒改法回灌下一轮 prompt）
+  --no-significance-gate          关掉显著性接受门，退回「候选分高一点点就收」的点估计判定（默认门开：只收统计显著的提升）
   --reuse-latest-eval             复用可比的最新 eval 报告作为 round-0
   --rounds <value>                最大迭代轮数，默认 5
   --sample-fix-max-attempts <value>每条 sample 自动修复最多尝试次数（默认：2）
   --samples <value>               样本文件路径，默认 eval-samples.json
+  --significance-alpha <value>    显著性门的 diff CI 显著性水平（默认 0.05 = 95% CI）
   --skip-connectivity             跳过 LLM 连通性预检
   --skip-doctor                   跳过 doctor 门禁（escape hatch，自负 garbage-in 风险）
   --stop-on-assertions-pass       普通样本断言全过时提前停止
   --target <value>                目标 composite 分数，达到即停。不传则跑满 rounds
+  --test-ratio <value>            锁定 test 集比例（0..1，默认 0=关），需配 --holdout-ratio。全程不参与选择，收尾读一次给无偏泛化分
   --timeout <value>               单样本超时秒，默认 600
 ```
 

--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -301,11 +301,15 @@ export interface AcceptDecision {
 
 /**
  * The accept decision for one round. With the significance gate on and enough
- * decision samples, a candidate is accepted only when its per-sample composite is
- * **significantly** above the current best (`bootstrapDiffCI(...).significant &&
- * estimate > 0`) — gains indistinguishable from judge noise are rejected. Off, or
- * under-powered, it degrades to the legacy point-estimate comparison. Pure (modulo
- * the seeded bootstrap) so the core behavior is unit-testable.
+ * decision samples, a candidate is accepted only when it is **significantly** above
+ * the current best's fresh re-eval (`bootstrapDiffCI(...).significant && estimate > 0`)
+ * AND its decision score actually beats the recorded best (`pointCand > pointBest`).
+ * The second clause preserves evolve's monotonic invariant: `bestScore` never
+ * decreases. Without it, an unlucky (noise-low) re-eval of the current best could let
+ * a candidate that is significantly above that re-eval — yet still below the recorded
+ * best — win and overwrite the best downward. Off, or under-powered, the gate degrades
+ * to the legacy point-estimate comparison alone. Pure (modulo the seeded bootstrap) so
+ * the core behavior is unit-testable.
  */
 export function decideAccept(
   bestScores: number[],
@@ -318,7 +322,7 @@ export function decideAccept(
   if (opts.significanceGate && powered) {
     const diff = bootstrapDiffCI(bestScores, candScores, opts.alpha, DEFAULT_BOOTSTRAP_SAMPLES, opts.seed);
     return {
-      accepted: diff.significant && diff.estimate > 0,
+      accepted: diff.significant && diff.estimate > 0 && pointCand > pointBest,
       diffCI: { low: diff.low, high: diff.high, estimate: diff.estimate, significant: diff.significant },
       underpowered: false,
     };
@@ -696,8 +700,10 @@ export interface EvolveResult {
    *  split was too small and evolve fell back to full-set scoring (CLI formats the
    *  user-facing message bilingually). */
   holdout?: { ratio: number; trainCount: number; holdoutCount: number; disabled?: boolean };
-  /** Locked-test split summary when `--test-ratio` > 0 produced a valid 3-way split. */
-  test?: { ratio: number; count: number };
+  /** Locked-test split summary. `disabled` is true when `--test-ratio` was requested
+   *  but the 3-way split was too small, so evolve fell back to a 2-way holdout and
+   *  produced no generalization score. */
+  test?: { ratio: number; count: number; disabled?: boolean };
   /** Unbiased composite of the best skill on the locked test set — the headline honest
    *  number. Present only when a 3-way split was active. The test set never influenced
    *  selection or weak-sample extraction, so this is an out-of-sample estimate. */
@@ -871,7 +877,12 @@ export async function evolveSkill({
       ...(split ? {} : { disabled: true }),
     }
     : undefined;
-  const testInfo: EvolveResult['test'] = threeWay ? { ratio: testRatio, count: threeWay.testIds.size } : undefined;
+  // test 被请求(配了 --holdout-ratio)但 3-way 太小回退 → 标 disabled，别让用户
+  // 以为拿到了 locked-test 泛化分。
+  const testRequested = testRatio > 0 && holdoutRatio > 0;
+  const testInfo: EvolveResult['test'] = threeWay
+    ? { ratio: testRatio, count: threeWay.testIds.size }
+    : testRequested ? { ratio: testRatio, count: 0, disabled: true } : undefined;
   // Deterministic seed so the gate's CIs are reproducible across reruns (and
   // assertable in tests). Derived from skill identity + sample count, parsed to a uint32.
   const gateSeed = parseInt(hashString(`${skillName}:${allSampleIds.length}`).slice(0, 8), 16) >>> 0;
@@ -893,7 +904,8 @@ export async function evolveSkill({
   // read once at the very end. Present only under a valid 3-way split; the test
   // set never influenced selection or weak-sample extraction.
   const buildGeneralization = (): { test?: EvolveResult['test']; generalizationScore?: number } => {
-    if (!threeWay || !split?.testIds) return {};
+    if (!testInfo) return {};
+    if (!threeWay || !split?.testIds) return { test: testInfo }; // requested but degraded → disabled, no score
     const best = roundReports.find((r) => r.round === bestRound)?.report;
     if (!best) return { test: testInfo };
     const key = Object.keys(best.summary)[0];

--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -506,7 +506,7 @@ interface EditDelta {
  * improver doesn't re-propose changes that already failed. Order-insensitive and
  * O(n) over small skill files.
  */
-function computeEditDelta(before: string, after: string, maxSummaryLines = 12): EditDelta {
+export function computeEditDelta(before: string, after: string, maxSummaryLines = 12): EditDelta {
   const beforeArr = before.split('\n').map((l) => l.trim()).filter(Boolean);
   const afterArr = after.split('\n').map((l) => l.trim()).filter(Boolean);
   const beforeSet = new Set(beforeArr);
@@ -594,6 +594,10 @@ export interface EvolveRoundProgressInfo {
   costReported?: boolean;
   error?: string;
   reused?: boolean;
+  /** When the significance gate ran: whether the candidate's gain was significant.
+   *  False on a rejected round means "score rose but within noise" — lets the CLI
+   *  explain an otherwise-confusing `(+0.0x) ✗ REJECT`. Undefined = gate didn't run. */
+  significant?: boolean;
 }
 
 interface EvolveOptions {
@@ -868,8 +872,8 @@ export async function evolveSkill({
     }
     : undefined;
   const testInfo: EvolveResult['test'] = threeWay ? { ratio: testRatio, count: threeWay.testIds.size } : undefined;
-  // Deterministic seed so the gate's CIs are reproducible across reruns (and asserers
-  // in tests). Derived from skill identity + sample count, parsed to a uint32.
+  // Deterministic seed so the gate's CIs are reproducible across reruns (and
+  // assertable in tests). Derived from skill identity + sample count, parsed to a uint32.
   const gateSeed = parseInt(hashString(`${skillName}:${allSampleIds.length}`).slice(0, 8), 16) >>> 0;
   let gateUnderpowered = false;
 
@@ -1101,9 +1105,11 @@ export async function evolveSkill({
     // Significance accept gate: accept only when the candidate is *significantly*
     // above the current best on the decision (val) set, not merely numerically higher
     // — rejecting gains indistinguishable from judge noise. `lastReport` is the current
-    // best's fresh eval and `candidateReport` the candidate's, on the same samples, so
-    // the two per-sample arrays are paired. Under-powered decision sets degrade to the
-    // legacy point-estimate accept and flag `gate.underpowered`.
+    // best's fresh eval and `candidateReport` the candidate's, over the same samples;
+    // bootstrapDiffCI resamples the two arrays independently (conservative — not a paired
+    // bootstrap). Under-powered decision sets degrade to the legacy point-estimate accept
+    // (note: that path compares the prior-round best scalar, not this fresh re-eval) and
+    // flag `gate.underpowered`.
     const valIds = split ? split.valIds : new Set(allSampleIds);
     const bestScores = perSampleComposite(lastReport, lastVariantKey, valIds);
     const candScores = perSampleComposite(candidateReport, candidateVariantKey, valIds);
@@ -1126,7 +1132,7 @@ export async function evolveSkill({
     if (accepted) roundReports.push({ round, accepted, report: candidateReport });
     const roundDelta = candidateScore - trajectory[trajectory.length - 1].score;
     trajectory.push({ round, score: candidateScore, delta: roundDelta, accepted, costUSD: roundCost, ...splitScores(candidateReport, candidateVariantKey, candidateScore), ...(diffCI ? { diffCI } : {}), editRatio: Number(editDelta.ratio.toFixed(4)) });
-    if (onRoundProgress) onRoundProgress({ round, totalRounds: rounds, phase: 'done', score: candidateScore, delta: roundDelta, accepted, costUSD: roundCost, costReported: roundCostReported });
+    if (onRoundProgress) onRoundProgress({ round, totalRounds: rounds, phase: 'done', score: candidateScore, delta: roundDelta, accepted, costUSD: roundCost, costReported: roundCostReported, ...(diffCI ? { significant: diffCI.significant } : {}) });
 
     // Early stop
     if (stopOnAssertionsPass && accepted && allNonTripwireAssertionsPass(candidateReport, candidateVariantKey)) {

--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -7,6 +7,7 @@ import { createFileStore } from '../server/report-store.js';
 import { analyzeResults } from '../analysis/report-diagnostics.js';
 import { loadSamples } from '../inputs/load-samples.js';
 import { buildVariantSummary } from '../eval-core/schema.js';
+import { bootstrapDiffCI, DEFAULT_BOOTSTRAP_ALPHA, DEFAULT_BOOTSTRAP_SAMPLES } from '../eval-core/bootstrap.js';
 import { fixSamples } from './sample-fixer.js';
 import type { JudgeConfig, ProgressCallback, Report, ResultEntry, Sample, VariantResult } from '../types/index.js';
 
@@ -190,9 +191,34 @@ interface HoldoutSplit {
   holdoutIds: Set<string>;
 }
 
-/** Below this many samples on either side, a holdout split is too small to be
- *  meaningful — evolve falls back to full-set scoring and warns. */
+/** A train / val / test partition. `val` drives the accept decision; `test` is
+ *  locked — never seen during the loop, read once at the end for an unbiased
+ *  generalization score. */
+interface TrainValTestSplit {
+  trainIds: Set<string>;
+  valIds: Set<string>;
+  testIds: Set<string>;
+}
+
+/** Below this many samples on any side, a split is too small to be meaningful —
+ *  evolve falls back to full-set scoring and warns. */
 const MIN_HOLDOUT_SUBSET = 3;
+
+/** Below this many decision (val) samples the bootstrap diff CI almost never
+ *  excludes 0 for realistic effect sizes, so the significance gate would reject
+ *  every candidate. Under that floor evolve degrades to the point-estimate accept
+ *  and flags `gate.underpowered`. */
+export const MIN_GATE_SAMPLES = 8;
+
+/** Pick `count` ids at an even stride across `ids` (deterministic, no RNG) so the
+ *  picked subset is representative of the ordering and stable across rounds/runs. */
+function pickByStride(ids: string[], count: number): Set<string> {
+  const picked = new Set<string>();
+  if (count <= 0) return picked;
+  const stride = ids.length / count;
+  for (let k = 0; k < count; k++) picked.add(ids[Math.floor(k * stride)]);
+  return picked;
+}
 
 /**
  * Deterministically split sample ids into train / holdout by `ratio` (fraction
@@ -206,13 +232,29 @@ export function splitHoldout(sampleIds: string[], ratio: number): HoldoutSplit |
   const holdoutCount = Math.round(sampleIds.length * ratio);
   const trainCount = sampleIds.length - holdoutCount;
   if (holdoutCount < MIN_HOLDOUT_SUBSET || trainCount < MIN_HOLDOUT_SUBSET) return null;
-  const stride = sampleIds.length / holdoutCount;
-  const holdoutIds = new Set<string>();
-  for (let k = 0; k < holdoutCount; k++) {
-    holdoutIds.add(sampleIds[Math.floor(k * stride)]);
-  }
+  const holdoutIds = pickByStride(sampleIds, holdoutCount);
   const trainIds = new Set(sampleIds.filter((id) => !holdoutIds.has(id)));
   return { trainIds, holdoutIds };
+}
+
+/**
+ * Deterministically split sample ids into train / val / test. `val` is carved
+ * first at an even stride; `test` is carved at an even stride over what remains,
+ * so the three sets are disjoint and stable across rounds/runs (no RNG). Returns
+ * null when either ratio ≤ 0 or any of the three sides would drop below
+ * MIN_HOLDOUT_SUBSET — the caller then degrades to a 2-way (or full-set) split.
+ */
+export function splitTrainValTest(sampleIds: string[], valRatio: number, testRatio: number): TrainValTestSplit | null {
+  if (!(valRatio > 0) || !(testRatio > 0) || sampleIds.length === 0) return null;
+  const valCount = Math.round(sampleIds.length * valRatio);
+  const testCount = Math.round(sampleIds.length * testRatio);
+  const trainCount = sampleIds.length - valCount - testCount;
+  if (valCount < MIN_HOLDOUT_SUBSET || testCount < MIN_HOLDOUT_SUBSET || trainCount < MIN_HOLDOUT_SUBSET) return null;
+  const valIds = pickByStride(sampleIds, valCount);
+  const remaining = sampleIds.filter((id) => !valIds.has(id));
+  const testIds = pickByStride(remaining, testCount);
+  const trainIds = new Set(sampleIds.filter((id) => !valIds.has(id) && !testIds.has(id)));
+  return { trainIds, valIds, testIds };
 }
 
 /**
@@ -230,6 +272,58 @@ function subsetCompositeScore(report: Report, variantKey: string, ids: Set<strin
   }
   if (entries.length === 0) return 0;
   return buildVariantSummary(entries).avgCompositeScore ?? 0;
+}
+
+/**
+ * Per-sample composite scores over the subset of a report's results whose
+ * sample_id is in `ids`, in result order. Feeds `bootstrapDiffCI` for the
+ * significance accept gate — the array (not the mean) is what the bootstrap
+ * resamples. Entries without a numeric compositeScore are skipped.
+ */
+function perSampleComposite(report: Report, variantKey: string, ids: Set<string>): number[] {
+  const scores: number[] = [];
+  for (const r of report.results) {
+    if (!ids.has(r.sample_id)) continue;
+    const v = r.variants[variantKey];
+    if (v && typeof v.compositeScore === 'number') scores.push(v.compositeScore);
+  }
+  return scores;
+}
+
+export interface AcceptDecision {
+  accepted: boolean;
+  /** Diff CI (candidate − best) when the gate ran; absent when it degraded. */
+  diffCI?: { low: number; high: number; estimate: number; significant: boolean };
+  /** True when the gate was requested but the decision set was below MIN_GATE_SAMPLES,
+   *  so the decision degraded to the point-estimate comparison. */
+  underpowered: boolean;
+}
+
+/**
+ * The accept decision for one round. With the significance gate on and enough
+ * decision samples, a candidate is accepted only when its per-sample composite is
+ * **significantly** above the current best (`bootstrapDiffCI(...).significant &&
+ * estimate > 0`) — gains indistinguishable from judge noise are rejected. Off, or
+ * under-powered, it degrades to the legacy point-estimate comparison. Pure (modulo
+ * the seeded bootstrap) so the core behavior is unit-testable.
+ */
+export function decideAccept(
+  bestScores: number[],
+  candScores: number[],
+  pointBest: number,
+  pointCand: number,
+  opts: { significanceGate: boolean; alpha: number; seed: number },
+): AcceptDecision {
+  const powered = bestScores.length >= MIN_GATE_SAMPLES && candScores.length >= MIN_GATE_SAMPLES;
+  if (opts.significanceGate && powered) {
+    const diff = bootstrapDiffCI(bestScores, candScores, opts.alpha, DEFAULT_BOOTSTRAP_SAMPLES, opts.seed);
+    return {
+      accepted: diff.significant && diff.estimate > 0,
+      diffCI: { low: diff.low, high: diff.high, estimate: diff.estimate, significant: diff.significant },
+      underpowered: false,
+    };
+  }
+  return { accepted: pointCand > pointBest, underpowered: opts.significanceGate && !powered };
 }
 
 /**
@@ -393,7 +487,43 @@ async function autoFixSamplesAfterSkillRound(opts: {
   return { fixedCount: result.fixedCount, costUSD: result.costUSD };
 }
 
-export function buildImprovementPrompt(skillContent: string, score: number, weakSamples: WeakSample[]): string {
+/** Number of skill lines below which the edit budget never trips — so a tiny skill
+ *  isn't frozen by a percentage threshold that a few lines already blow past. */
+const EDIT_BUDGET_FLOOR_LINES = 10;
+
+interface EditDelta {
+  /** Symmetric line difference (added + removed unique lines) over original line count. */
+  ratio: number;
+  /** Absolute count of added + removed unique lines. */
+  changedLines: number;
+  /** Compact `+`/`-` summary of the changed lines, truncated. */
+  summary: string;
+}
+
+/**
+ * How a candidate differs from the current best, by trimmed non-empty line sets.
+ * `ratio` drives the edit budget; `summary` feeds the rejected-edit memory so the
+ * improver doesn't re-propose changes that already failed. Order-insensitive and
+ * O(n) over small skill files.
+ */
+function computeEditDelta(before: string, after: string, maxSummaryLines = 12): EditDelta {
+  const beforeArr = before.split('\n').map((l) => l.trim()).filter(Boolean);
+  const afterArr = after.split('\n').map((l) => l.trim()).filter(Boolean);
+  const beforeSet = new Set(beforeArr);
+  const afterSet = new Set(afterArr);
+  const added = [...afterSet].filter((l) => !beforeSet.has(l));
+  const removed = [...beforeSet].filter((l) => !afterSet.has(l));
+  const changedLines = added.length + removed.length;
+  const ratio = changedLines / Math.max(beforeArr.length, 1);
+  const parts: string[] = [];
+  for (const l of added.slice(0, maxSummaryLines)) parts.push(`+ ${l}`);
+  if (added.length > maxSummaryLines) parts.push(`+ …(其余 +${added.length - maxSummaryLines} 行)`);
+  for (const l of removed.slice(0, maxSummaryLines)) parts.push(`- ${l}`);
+  if (removed.length > maxSummaryLines) parts.push(`- …(其余 -${removed.length - maxSummaryLines} 行)`);
+  return { ratio, changedLines, summary: parts.join('\n') || '(无文本差异)' };
+}
+
+export function buildImprovementPrompt(skillContent: string, score: number, weakSamples: WeakSample[], rejectedEdits?: string[]): string {
   const weakDetails = weakSamples.map((s) => {
     const parts = [`### ${s.sample_id}（${s.compositeScore}/5.0）`];
     if (s.llmReason) parts.push(`评委反馈: ${s.llmReason}`);
@@ -414,13 +544,17 @@ export function buildImprovementPrompt(skillContent: string, score: number, weak
     return parts.join('\n');
   }).join('\n\n');
 
+  const rejectedSection = rejectedEdits && rejectedEdits.length > 0
+    ? `\n\n## 已试过且未带来显著提升的改法（不要重复）\n\n${rejectedEdits.join('\n\n')}`
+    : '';
+
   return `## 当前 Skill（平均分: ${score.toFixed(2)}/5.0）
 
 ${skillContent}
 
 ## 低分用例分析
 
-${weakDetails || '（无低分用例）'}`;
+${weakDetails || '（无低分用例）'}${rejectedSection}`;
 }
 
 function buildImprovementSuffix(mode: 'agent' | 'rewrite', candidatePath?: string): string {
@@ -495,21 +629,52 @@ interface EvolveOptions {
    *  so the skill is never tuned to the samples that judge it. Too small a split
    *  (either side < MIN_HOLDOUT_SUBSET) falls back to full-set scoring + a warning. */
   holdoutRatio?: number;
+  /** Statistically gate acceptance: a candidate is accepted only when its
+   *  per-sample composite is **significantly** above the current best on the
+   *  decision (val) set — `bootstrapDiffCI(...).significant && estimate > 0` —
+   *  not merely numerically higher. Default true (rejecting improvements
+   *  indistinguishable from judge noise is the point). Below MIN_GATE_SAMPLES
+   *  decision samples the gate is underpowered and degrades to the point-estimate
+   *  comparison + a warning. Set false to force the legacy point-estimate accept. */
+  significanceGate?: boolean;
+  /** Significance level for the accept gate's diff CI. Default 0.05 (95% CI). */
+  significanceAlpha?: number;
+  /** Fraction of samples locked away as a **test** set (0..1). Default 0 = off.
+   *  Only honored alongside `holdoutRatio` > 0 (test needs a separate val set to
+   *  decide on). The test split is never seen during the loop — not by weak-sample
+   *  extraction, not by the accept gate — and is read exactly once at the end for an
+   *  unbiased `generalizationScore`. Too small a 3-way split degrades to 2-way. */
+  testRatio?: number;
+  /** Max fraction of skill lines a single round may change before the candidate is
+   *  rejected **without paying for evaluation**. Default 0.2 (matches the "≤20%"
+   *  the improvement prompt already asks for — this enforces it). A small floor
+   *  always permits a handful of lines so tiny skills aren't frozen. Set 0 to disable. */
+  editBudget?: number;
+  /** Feed rejected candidate edits back into the next round's improvement prompt
+   *  ("these were tried and did not help — don't repeat them"). Default true. */
+  rejectMemory?: boolean;
   onProgress?: ProgressCallback | null;
   onRoundProgress?: ((progress: EvolveRoundProgressInfo) => void) | null;
 }
 
 interface TrajectoryEntry {
   round: number;
-  /** Accept-decision score: holdout composite when holdout is active, else full-set. */
+  /** Accept-decision score: val composite when a holdout split is active, else full-set. */
   score: number;
   delta: number;
   accepted: boolean;
   costUSD: number;
-  /** Present when holdout is active: the training-split composite (improvement signal). */
+  /** Present when a holdout split is active: the training-split composite (improvement signal). */
   trainScore?: number;
-  /** Present when holdout is active: the holdout-split composite (== score). */
+  /** Present when a holdout split is active: the val-split composite (== score). */
   holdoutScore?: number;
+  /** Significance-gate diff CI (candidate − current best) on the decision set, when
+   *  the gate was powered enough to run. `significant` 决定接受。 */
+  diffCI?: { low: number; high: number; estimate: number; significant: boolean };
+  /** Fraction of skill lines this candidate changed vs the current best. */
+  editRatio?: number;
+  /** True when the candidate was rejected by the edit budget before evaluation. */
+  rejectedPreEval?: boolean;
 }
 
 export interface EvolveResult {
@@ -527,6 +692,15 @@ export interface EvolveResult {
    *  split was too small and evolve fell back to full-set scoring (CLI formats the
    *  user-facing message bilingually). */
   holdout?: { ratio: number; trainCount: number; holdoutCount: number; disabled?: boolean };
+  /** Locked-test split summary when `--test-ratio` > 0 produced a valid 3-way split. */
+  test?: { ratio: number; count: number };
+  /** Unbiased composite of the best skill on the locked test set — the headline honest
+   *  number. Present only when a 3-way split was active. The test set never influenced
+   *  selection or weak-sample extraction, so this is an out-of-sample estimate. */
+  generalizationScore?: number;
+  /** Accept-gate summary. `underpowered` = the decision set was below MIN_GATE_SAMPLES
+   *  at least once, so the gate degraded to the point-estimate comparison + warned. */
+  gate?: { enabled: boolean; alpha: number; underpowered?: boolean };
   trajectory: TrajectoryEntry[];
   bestSkillPath: string;
   allVersions: string[];
@@ -641,6 +815,11 @@ export async function evolveSkill({
   noDiagnostic,
   skipDoctor,
   holdoutRatio = 0,
+  significanceGate = true,
+  significanceAlpha = DEFAULT_BOOTSTRAP_ALPHA,
+  testRatio = 0,
+  editBudget = 0.2,
+  rejectMemory = true,
   onProgress = null,
   onRoundProgress = null,
 }: EvolveOptions): Promise<EvolveResult> {
@@ -665,32 +844,69 @@ export async function evolveSkill({
   if (!existsSync(absSamplesPath)) throw new Error(`samples file not found: ${absSamplesPath}`);
   mkdirSync(evolveDir, { recursive: true });
 
-  // Holdout split (opt-in). Computed once over the canonical sample order so it's
-  // stable across rounds. When active, accept decisions use the holdout composite
-  // and weak-sample extraction only sees the training split — the skill is never
-  // tuned to the samples that decide whether it's accepted.
+  // Split (opt-in). Computed once over the canonical sample order so it's stable
+  // across rounds. `val` drives the accept decision; weak-sample extraction and the
+  // sample-fixer only ever see `train`; `test` is locked away — never seen during the
+  // loop — and read once at the end for an unbiased generalization score. With no
+  // holdout the decision runs on the full set (legacy). A too-small 3-way split
+  // degrades to 2-way, then to full-set.
   const allSampleIds = loadSamples(absSamplesPath).samples.map((s) => s.sample_id);
-  const holdoutSplit = splitHoldout(allSampleIds, holdoutRatio);
+  const threeWay = (testRatio > 0 && holdoutRatio > 0) ? splitTrainValTest(allSampleIds, holdoutRatio, testRatio) : null;
+  const twoWay = (!threeWay && holdoutRatio > 0) ? splitHoldout(allSampleIds, holdoutRatio) : null;
+  const split: { trainIds: Set<string>; valIds: Set<string>; testIds: Set<string> | null } | null =
+    threeWay
+      ? { trainIds: threeWay.trainIds, valIds: threeWay.valIds, testIds: threeWay.testIds }
+      : twoWay
+        ? { trainIds: twoWay.trainIds, valIds: twoWay.holdoutIds, testIds: null }
+        : null;
   const holdoutInfo: EvolveResult['holdout'] = holdoutRatio > 0
     ? {
       ratio: holdoutRatio,
-      trainCount: holdoutSplit?.trainIds.size ?? allSampleIds.length,
-      holdoutCount: holdoutSplit?.holdoutIds.size ?? 0,
-      ...(holdoutSplit ? {} : { disabled: true }),
+      trainCount: split?.trainIds.size ?? allSampleIds.length,
+      holdoutCount: split?.valIds.size ?? 0,
+      ...(split ? {} : { disabled: true }),
     }
     : undefined;
+  const testInfo: EvolveResult['test'] = threeWay ? { ratio: testRatio, count: threeWay.testIds.size } : undefined;
+  // Deterministic seed so the gate's CIs are reproducible across reruns (and asserers
+  // in tests). Derived from skill identity + sample count, parsed to a uint32.
+  const gateSeed = parseInt(hashString(`${skillName}:${allSampleIds.length}`).slice(0, 8), 16) >>> 0;
+  let gateUnderpowered = false;
 
-  // Accept-decision score for a report's variant: holdout composite when the split
-  // is active, otherwise the full-set composite (legacy behavior).
+  // Accept-decision score for a report's variant: val composite when a split is
+  // active, otherwise the full-set composite (legacy behavior).
   const decisionScore = (report: Report, key: string): number =>
-    holdoutSplit
-      ? subsetCompositeScore(report, key, holdoutSplit.holdoutIds)
+    split
+      ? subsetCompositeScore(report, key, split.valIds)
       : (report.summary[key]?.avgCompositeScore ?? 0);
   const trainScoreOf = (report: Report, key: string): number | undefined =>
-    holdoutSplit ? subsetCompositeScore(report, key, holdoutSplit.trainIds) : undefined;
+    split ? subsetCompositeScore(report, key, split.trainIds) : undefined;
   // Per-round trajectory tail: train / holdout breakdown, only when split active.
   const splitScores = (report: Report, key: string, decision: number): Partial<TrajectoryEntry> =>
-    holdoutSplit ? { trainScore: trainScoreOf(report, key), holdoutScore: decision } : {};
+    split ? { trainScore: trainScoreOf(report, key), holdoutScore: decision } : {};
+
+  // Unbiased generalization: the best skill's composite on the locked test set,
+  // read once at the very end. Present only under a valid 3-way split; the test
+  // set never influenced selection or weak-sample extraction.
+  const buildGeneralization = (): { test?: EvolveResult['test']; generalizationScore?: number } => {
+    if (!threeWay || !split?.testIds) return {};
+    const best = roundReports.find((r) => r.round === bestRound)?.report;
+    if (!best) return { test: testInfo };
+    const key = Object.keys(best.summary)[0];
+    return { test: testInfo, generalizationScore: Number(subsetCompositeScore(best, key, split.testIds).toFixed(4)) };
+  };
+  const gateInfo = (): EvolveResult['gate'] =>
+    ({ enabled: significanceGate, alpha: significanceAlpha, ...(gateUnderpowered ? { underpowered: true } : {}) });
+
+  // Rejected-edit memory (most recent K). Fed back into the next round's improvement
+  // prompt so the improver doesn't re-propose changes that already failed to help.
+  const rejectedEdits: string[] = [];
+  const REJECT_MEMORY_K = 3;
+  const rememberRejected = (round: number, summary: string, reason: string): void => {
+    if (!rejectMemory) return;
+    rejectedEdits.push(`【第 ${round} 轮被拒（${reason}）】\n${summary}`);
+    if (rejectedEdits.length > REJECT_MEMORY_K) rejectedEdits.shift();
+  };
 
   // Save original as r0
   let currentBest = readFileSync(absSkillPath, 'utf-8').trim();
@@ -762,6 +978,8 @@ export async function evolveSkill({
       ...(reusedBaselineReportId && { reusedBaselineReportId }),
       ...(totalCostReported ? {} : { costReported: false }),
       ...(holdoutInfo ? { holdout: holdoutInfo } : {}),
+      ...buildGeneralization(),
+      gate: gateInfo(),
       trajectory,
       bestSkillPath: allVersions[bestRound],
       allVersions,
@@ -787,11 +1005,11 @@ export async function evolveSkill({
       if (reportHasUnreportedCost(lastReport)) totalCostReported = false;
     }
     const lastVariantKey = Object.keys(lastReport.summary)[0];
-    const weakSamples = extractWeakSamples(lastReport, lastVariantKey, 5, holdoutSplit?.trainIds);
+    const weakSamples = extractWeakSamples(lastReport, lastVariantKey, 5, split?.trainIds);
 
     // Generate improvement
     const candidatePath = join(evolveDir, `${skillName}.r${round}.md`);
-    const basePrompt = buildImprovementPrompt(currentBest, bestScore, weakSamples);
+    const basePrompt = buildImprovementPrompt(currentBest, bestScore, weakSamples, rejectMemory ? rejectedEdits : undefined);
     const executor = createExecutor(executorName);
     let candidateContent: string;
     let improveCostUSD: number;
@@ -833,6 +1051,21 @@ export async function evolveSkill({
     if (!improveCostReported) totalCostReported = false;
     allVersions.push(candidatePath);
 
+    // Edit budget: reject oversized rewrites BEFORE paying for evaluation. The
+    // improvement prompt already asks for ≤ editBudget of lines changed — this
+    // enforces it. A small floor still lets tiny skills change a handful of lines.
+    const editDelta = computeEditDelta(currentBest, candidateContent);
+    if (editBudget > 0 && editDelta.ratio > editBudget && editDelta.changedLines > EDIT_BUDGET_FLOOR_LINES) {
+      totalCostUSD += improveCostUSD;
+      consecutiveRejects++;
+      const reason = `改动过大 ${(editDelta.ratio * 100).toFixed(0)}%（预算 ${(editBudget * 100).toFixed(0)}%），评测前判拒`;
+      rememberRejected(round, editDelta.summary, reason);
+      trajectory.push({ round, score: bestScore, delta: 0, accepted: false, costUSD: improveCostUSD, editRatio: Number(editDelta.ratio.toFixed(4)), rejectedPreEval: true });
+      if (onRoundProgress) onRoundProgress({ round, totalRounds: rounds, phase: 'done', score: bestScore, delta: 0, accepted: false, costUSD: improveCostUSD, costReported: improveCostReported });
+      if (consecutiveRejects >= 2) { stopReason = 'consecutive-rejects'; break; }
+      continue;
+    }
+
     let preEvalSampleFixCost = 0;
     if (autoFixSamples) {
       const sampleFix = await autoFixSamplesAfterSkillRound({
@@ -840,7 +1073,7 @@ export async function evolveSkill({
         skillContent: candidateContent,
         // Under an active holdout, the sample-fixer may only see training-split samples —
         // never the holdout samples that drive the accept decision (leak guard).
-        report: holdoutSplit ? restrictReportToSamples(lastReport, holdoutSplit.trainIds) : lastReport,
+        report: split ? restrictReportToSamples(lastReport, split.trainIds) : lastReport,
         treatmentKey: lastVariantKey,
         executorName,
         model: improveModel,
@@ -865,7 +1098,19 @@ export async function evolveSkill({
     if (!roundCostReported) totalCostReported = false;
     totalCostUSD += improveCostUSD + candidateReport.meta.totalCostUSD;
 
-    const accepted = candidateScore > bestScore;
+    // Significance accept gate: accept only when the candidate is *significantly*
+    // above the current best on the decision (val) set, not merely numerically higher
+    // — rejecting gains indistinguishable from judge noise. `lastReport` is the current
+    // best's fresh eval and `candidateReport` the candidate's, on the same samples, so
+    // the two per-sample arrays are paired. Under-powered decision sets degrade to the
+    // legacy point-estimate accept and flag `gate.underpowered`.
+    const valIds = split ? split.valIds : new Set(allSampleIds);
+    const bestScores = perSampleComposite(lastReport, lastVariantKey, valIds);
+    const candScores = perSampleComposite(candidateReport, candidateVariantKey, valIds);
+    const decision = decideAccept(bestScores, candScores, bestScore, candidateScore, { significanceGate, alpha: significanceAlpha, seed: gateSeed });
+    const accepted = decision.accepted;
+    const diffCI = decision.diffCI;
+    if (decision.underpowered) gateUnderpowered = true;
 
     if (accepted) {
       currentBest = candidateContent;
@@ -874,11 +1119,13 @@ export async function evolveSkill({
       consecutiveRejects = 0;
     } else {
       consecutiveRejects++;
+      const reason = diffCI ? (diffCI.estimate > 0 ? '提升不显著' : '方向为负') : '未超过当前最优';
+      rememberRejected(round, editDelta.summary, reason);
     }
 
     if (accepted) roundReports.push({ round, accepted, report: candidateReport });
     const roundDelta = candidateScore - trajectory[trajectory.length - 1].score;
-    trajectory.push({ round, score: candidateScore, delta: roundDelta, accepted, costUSD: roundCost, ...splitScores(candidateReport, candidateVariantKey, candidateScore) });
+    trajectory.push({ round, score: candidateScore, delta: roundDelta, accepted, costUSD: roundCost, ...splitScores(candidateReport, candidateVariantKey, candidateScore), ...(diffCI ? { diffCI } : {}), editRatio: Number(editDelta.ratio.toFixed(4)) });
     if (onRoundProgress) onRoundProgress({ round, totalRounds: rounds, phase: 'done', score: candidateScore, delta: roundDelta, accepted, costUSD: roundCost, costReported: roundCostReported });
 
     // Early stop
@@ -922,6 +1169,8 @@ export async function evolveSkill({
     ...(reusedBaselineReportId && { reusedBaselineReportId }),
     ...(totalCostReported ? {} : { costReported: false }),
     ...(holdoutInfo ? { holdout: holdoutInfo } : {}),
+    ...buildGeneralization(),
+    gate: gateInfo(),
     trajectory,
     bestSkillPath: allVersions[bestRound],
     allVersions,

--- a/src/cli/commands/evolve.ts
+++ b/src/cli/commands/evolve.ts
@@ -57,7 +57,7 @@ interface EvolveResult {
   totalCostUSD: number;
   costReported?: boolean;
   holdout?: { ratio: number; trainCount: number; holdoutCount: number; disabled?: boolean };
-  test?: { ratio: number; count: number };
+  test?: { ratio: number; count: number; disabled?: boolean };
   generalizationScore?: number;
   gate?: { enabled: boolean; alpha: number; underpowered?: boolean };
   trajectory: TrajectoryEntry[];
@@ -184,7 +184,9 @@ export async function runEvolve(
     if (result.gate?.underpowered) {
       process.stderr.write(tCli('cli.evolve.gate_underpowered', lang));
     }
-    if (result.test && typeof result.generalizationScore === 'number') {
+    if (result.test?.disabled) {
+      process.stderr.write(tCli('cli.evolve.test_disabled', lang, { ratio: result.test.ratio }));
+    } else if (result.test && typeof result.generalizationScore === 'number') {
       process.stderr.write(tCli('cli.evolve.generalization', lang, {
         count: result.test.count, score: result.generalizationScore.toFixed(2),
       }));

--- a/src/cli/commands/evolve.ts
+++ b/src/cli/commands/evolve.ts
@@ -30,6 +30,9 @@ interface TrajectoryEntry {
   costUSD: number;
   trainScore?: number;
   holdoutScore?: number;
+  diffCI?: { low: number; high: number; estimate: number; significant: boolean };
+  editRatio?: number;
+  rejectedPreEval?: boolean;
 }
 
 const VALID_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
@@ -53,6 +56,9 @@ interface EvolveResult {
   totalCostUSD: number;
   costReported?: boolean;
   holdout?: { ratio: number; trainCount: number; holdoutCount: number; disabled?: boolean };
+  test?: { ratio: number; count: number };
+  generalizationScore?: number;
+  gate?: { enabled: boolean; alpha: number; underpowered?: boolean };
   trajectory: TrajectoryEntry[];
   bestSkillPath: string;
   allVersions: string[];
@@ -70,6 +76,14 @@ export async function runEvolve(
   if (!skillPathArg) {
     console.error(tCli('cli.evolve.specify_skill_path', lang));
     throw new CliExit(1);
+  }
+
+  // A locked test set needs a separate val set to decide on; --test-ratio alone is a no-op.
+  if ((Number(flags['test-ratio']) || 0) > 0 && (Number(flags['holdout-ratio']) || 0) === 0) {
+    console.error(lang === 'zh'
+      ? '--test-ratio 需要配合 --holdout-ratio 使用（test 集只在留出 val 集时才有意义）。'
+      : '--test-ratio requires --holdout-ratio (a locked test set only makes sense alongside a held-out val set).');
+    throw new CliExit(2);
   }
 
   const { resolveSkillInput } = await import('../lib/resolve-skill-input.js');
@@ -117,6 +131,11 @@ export async function runEvolve(
       sampleFixMaxAttempts: Math.max(1, Number(flags['sample-fix-max-attempts']) || 2),
       reuseLatestEval: flags['reuse-latest-eval'],
       holdoutRatio: Number(flags['holdout-ratio']) || 0,
+      significanceGate: !flags['no-significance-gate'],
+      significanceAlpha: Number(flags['significance-alpha']) || 0.05,
+      testRatio: Number(flags['test-ratio']) || 0,
+      editBudget: flags['no-edit-budget'] ? 0 : (Number(flags['edit-budget']) || 0.2),
+      rejectMemory: !flags['no-reject-memory'],
       improveMode: flags['improve-mode'] === 'rewrite' ? 'rewrite' : 'agent',
       onProgress: makeOnProgress(lang) as unknown as ProgressCallback,
       onRoundProgress({ round, totalRounds: _totalRounds, phase, score, delta, accepted, costUSD, costReported, error }: RoundProgressInfo): void {
@@ -156,6 +175,14 @@ export async function runEvolve(
         : tCli('cli.evolve.holdout_active', lang, {
           train: result.holdout.trainCount, holdout: result.holdout.holdoutCount,
         }));
+    }
+    if (result.gate?.underpowered) {
+      process.stderr.write(tCli('cli.evolve.gate_underpowered', lang));
+    }
+    if (result.test && typeof result.generalizationScore === 'number') {
+      process.stderr.write(tCli('cli.evolve.generalization', lang, {
+        count: result.test.count, score: result.generalizationScore.toFixed(2),
+      }));
     }
     process.stderr.write(tCli('cli.evolve.best_path', lang, {
       best: result.bestSkillPath, target: resolve(skillPath),
@@ -336,6 +363,51 @@ export default class Evolve extends BaseCommand {
       }),
       default: '0',
       parse: numberStringParser('--holdout-ratio', { min: 0, max: 1 }),
+    }),
+    'no-significance-gate': Flags.boolean({
+      description: bilingual({
+        zh: '关掉显著性接受门，退回「候选分高一点点就收」的点估计判定（默认门开：只收统计显著的提升）',
+        en: 'Disable the significance accept gate, reverting to point-estimate accept (default: gate on — accept only statistically significant gains)',
+      }),
+      default: false,
+    }),
+    'significance-alpha': Flags.string({
+      description: bilingual({
+        zh: '显著性门的 diff CI 显著性水平（默认 0.05 = 95% CI）',
+        en: 'Significance level for the accept gate diff CI (default 0.05 = 95% CI)',
+      }),
+      default: '0.05',
+      parse: numberStringParser('--significance-alpha', { min: 0, max: 1 }),
+    }),
+    'test-ratio': Flags.string({
+      description: bilingual({
+        zh: '锁定 test 集比例（0..1，默认 0=关），需配 --holdout-ratio。全程不参与选择，收尾读一次给无偏泛化分',
+        en: 'Locked test fraction (0..1, default 0=off); requires --holdout-ratio. Never used for selection; read once at the end for an unbiased generalization score',
+      }),
+      default: '0',
+      parse: numberStringParser('--test-ratio', { min: 0, max: 1 }),
+    }),
+    'edit-budget': Flags.string({
+      description: bilingual({
+        zh: '单轮最多改动的 skill 行占比（默认 0.2）。超预算的候选评测前直接判拒，省 eval 成本',
+        en: 'Max fraction of skill lines a round may change (default 0.2). Over-budget candidates are rejected before evaluation, saving eval cost',
+      }),
+      default: '0.2',
+      parse: numberStringParser('--edit-budget', { min: 0, max: 1 }),
+    }),
+    'no-edit-budget': Flags.boolean({
+      description: bilingual({
+        zh: '关掉 edit budget 约束（允许任意大小的单轮改动）',
+        en: 'Disable the edit budget (allow arbitrarily large single-round edits)',
+      }),
+      default: false,
+    }),
+    'no-reject-memory': Flags.boolean({
+      description: bilingual({
+        zh: '关掉 rejected-edit 记忆（不把被拒改法回灌下一轮 prompt）',
+        en: 'Disable rejected-edit memory (do not feed rejected edits back into the next prompt)',
+      }),
+      default: false,
     }),
   };
 

--- a/src/cli/commands/evolve.ts
+++ b/src/cli/commands/evolve.ts
@@ -20,6 +20,7 @@ interface RoundProgressInfo {
   costUSD?: number;
   costReported?: boolean;
   error?: string;
+  significant?: boolean;
 }
 
 interface TrajectoryEntry {
@@ -132,13 +133,15 @@ export async function runEvolve(
       reuseLatestEval: flags['reuse-latest-eval'],
       holdoutRatio: Number(flags['holdout-ratio']) || 0,
       significanceGate: !flags['no-significance-gate'],
-      significanceAlpha: Number(flags['significance-alpha']) || 0.05,
-      testRatio: Number(flags['test-ratio']) || 0,
-      editBudget: flags['no-edit-budget'] ? 0 : (Number(flags['edit-budget']) || 0.2),
+      // parser 已保证是合法数字串；用 Number() 直取，不用 `|| default`——否则
+      // `--edit-budget 0`（关预算）/ `--significance-alpha 0` 会被 falsy 吞成默认值。
+      significanceAlpha: Number(flags['significance-alpha']),
+      testRatio: Number(flags['test-ratio']),
+      editBudget: flags['no-edit-budget'] ? 0 : Number(flags['edit-budget']),
       rejectMemory: !flags['no-reject-memory'],
       improveMode: flags['improve-mode'] === 'rewrite' ? 'rewrite' : 'agent',
       onProgress: makeOnProgress(lang) as unknown as ProgressCallback,
-      onRoundProgress({ round, totalRounds: _totalRounds, phase, score, delta, accepted, costUSD, costReported, error }: RoundProgressInfo): void {
+      onRoundProgress({ round, totalRounds: _totalRounds, phase, score, delta, accepted, costUSD, costReported, error, significant }: RoundProgressInfo): void {
         // costReported=false 时显示「—」而不是 $0.0000(executor 不报 cost,如 codex)。
         const fmtRoundCost = (c: number, r: boolean): string => r ? `$${c.toFixed(4)}` : '—';
         if (phase === 'baseline') {
@@ -151,7 +154,9 @@ export async function runEvolve(
           }));
         } else if (phase === 'done') {
           const delta_: string = delta! >= 0 ? `+${delta!.toFixed(2)}` : delta!.toFixed(2);
-          const status: string = accepted ? '✓ ACCEPT' : '✗ REJECT';
+          // 门拒掉「均分上升但不显著」的候选时，补一句原因，否则 (+0.0x) ✗ REJECT 看着矛盾。
+          const rejectNote = !accepted && significant === false ? tCli('cli.evolve.reject_not_significant', lang) : '';
+          const status: string = accepted ? '✓ ACCEPT' : `✗ REJECT${rejectNote}`;
           process.stderr.write(tCli('cli.evolve.round_done', lang, {
             round, score: score!.toFixed(2), delta: delta_, status, cost: fmtRoundCost(costUSD!, costReported !== false),
           }));

--- a/src/cli/lib/cmd-flags.ts
+++ b/src/cli/lib/cmd-flags.ts
@@ -150,6 +150,12 @@ export interface EvolveFlags {
   'reuse-latest-eval': boolean;
   'improve-mode': string;
   'holdout-ratio': string;
+  'no-significance-gate': boolean;
+  'significance-alpha': string;
+  'test-ratio': string;
+  'edit-budget': string;
+  'no-edit-budget': boolean;
+  'no-reject-memory': boolean;
 }
 
 // ── sample ────────────────────────────────────────────────────────────────────

--- a/src/cli/lib/i18n-dict/evolve.ts
+++ b/src/cli/lib/i18n-dict/evolve.ts
@@ -12,7 +12,9 @@ export type EvolveMessageKey =
   | 'cli.evolve.versions_saved'
   | 'cli.evolve.report_link'
   | 'cli.evolve.holdout_active'
-  | 'cli.evolve.holdout_disabled';
+  | 'cli.evolve.holdout_disabled'
+  | 'cli.evolve.gate_underpowered'
+  | 'cli.evolve.generalization';
 
 export const evolveDict: Record<EvolveMessageKey, CliMessage> = {
   'cli.evolve.specify_skill_path': {
@@ -62,5 +64,13 @@ export const evolveDict: Record<EvolveMessageKey, CliMessage> = {
   'cli.evolve.holdout_disabled': {
     zh: '⚠️ holdout-ratio={ratio} 样本太少无法切分，已回退全集打分\n',
     en: '⚠️ holdout-ratio={ratio} too few samples to split; using full-set scoring\n',
+  },
+  'cli.evolve.gate_underpowered': {
+    zh: '⚠️ 决策样本量不足以做显著性门禁，本轮退回点估计接受；增大用例集或降 --holdout-ratio 可启用严格门\n',
+    en: '⚠️ Too few decision samples for the significance gate; fell back to point-estimate accept. Add samples or lower --holdout-ratio to enable the strict gate\n',
+  },
+  'cli.evolve.generalization': {
+    zh: '🔒 锁定 test 集（{count} 条，全程不参与选择）：泛化分 {score}\n',
+    en: '🔒 Locked test set ({count} samples, never used for selection): generalization {score}\n',
   },
 };

--- a/src/cli/lib/i18n-dict/evolve.ts
+++ b/src/cli/lib/i18n-dict/evolve.ts
@@ -15,6 +15,7 @@ export type EvolveMessageKey =
   | 'cli.evolve.holdout_disabled'
   | 'cli.evolve.gate_underpowered'
   | 'cli.evolve.generalization'
+  | 'cli.evolve.test_disabled'
   | 'cli.evolve.reject_not_significant';
 
 export const evolveDict: Record<EvolveMessageKey, CliMessage> = {
@@ -77,5 +78,9 @@ export const evolveDict: Record<EvolveMessageKey, CliMessage> = {
   'cli.evolve.reject_not_significant': {
     zh: '（差异不显著）',
     en: ' (not significant)',
+  },
+  'cli.evolve.test_disabled': {
+    zh: '⚠️ test-ratio={ratio} 样本太少无法做三路切分，已回退两路 holdout，本次无泛化分\n',
+    en: '⚠️ test-ratio={ratio} too few samples for a 3-way split; fell back to 2-way holdout, no generalization score this run\n',
   },
 };

--- a/src/cli/lib/i18n-dict/evolve.ts
+++ b/src/cli/lib/i18n-dict/evolve.ts
@@ -14,7 +14,8 @@ export type EvolveMessageKey =
   | 'cli.evolve.holdout_active'
   | 'cli.evolve.holdout_disabled'
   | 'cli.evolve.gate_underpowered'
-  | 'cli.evolve.generalization';
+  | 'cli.evolve.generalization'
+  | 'cli.evolve.reject_not_significant';
 
 export const evolveDict: Record<EvolveMessageKey, CliMessage> = {
   'cli.evolve.specify_skill_path': {
@@ -72,5 +73,9 @@ export const evolveDict: Record<EvolveMessageKey, CliMessage> = {
   'cli.evolve.generalization': {
     zh: '🔒 锁定 test 集（{count} 条，全程不参与选择）：泛化分 {score}\n',
     en: '🔒 Locked test set ({count} samples, never used for selection): generalization {score}\n',
+  },
+  'cli.evolve.reject_not_significant': {
+    zh: '（差异不显著）',
+    en: ' (not significant)',
   },
 };

--- a/test/authoring/evolver.test.ts
+++ b/test/authoring/evolver.test.ts
@@ -311,6 +311,19 @@ describe('decideAccept (significance gate)', () => {
     assert.equal(d.accepted, false); // significant but estimate < 0
   });
 
+  it('does NOT overwrite a higher recorded best when the fresh re-eval is noise-low (monotonic guard)', () => {
+    // P1: the current best re-evaluated noise-low (2.0); the candidate (3.0) is
+    // significantly above THAT re-eval, but the recorded best was 4.0 — accepting would
+    // downgrade best. The diff is genuinely significant and positive, yet pointCand <
+    // pointBest must block acceptance so bestScore never decreases.
+    const best = fill(2.0, 20);
+    const cand = fill(3.0, 20);
+    const d = decideAccept(best, cand, 4.0, 3.0, GATE);
+    assert.equal(d.accepted, false);
+    assert.equal(d.diffCI!.significant, true);
+    assert.ok(d.diffCI!.estimate > 0);
+  });
+
   it('degrades to the point estimate (and flags underpowered) below the sample floor', () => {
     const best = fill(3.0, 5);
     const cand = fill(4.0, 5);

--- a/test/authoring/evolver.test.ts
+++ b/test/authoring/evolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { extractWeakSamples, buildImprovementPrompt, evolveSkill, allNonTripwireAssertionsPass, splitHoldout, restrictReportToSamples } from '../../src/authoring/evolver.js';
+import { extractWeakSamples, buildImprovementPrompt, evolveSkill, allNonTripwireAssertionsPass, splitHoldout, splitTrainValTest, restrictReportToSamples, decideAccept } from '../../src/authoring/evolver.js';
 import { fixSamples } from '../../src/authoring/sample-fixer.js';
 import type { Report, EvaluationReport } from '../../src/types/index.js';
 
@@ -82,6 +82,45 @@ describe('splitHoldout', () => {
     const a = splitHoldout(ids(17), 0.25);
     const b = splitHoldout(ids(17), 0.25);
     assert.deepEqual([...a!.holdoutIds], [...b!.holdoutIds]);
+  });
+});
+
+describe('splitTrainValTest', () => {
+  const ids = (n: number): string[] => Array.from({ length: n }, (_, i) => `s${i}`);
+
+  it('returns null when either ratio is 0 (off / no test)', () => {
+    assert.equal(splitTrainValTest(ids(30), 0, 0.2), null);
+    assert.equal(splitTrainValTest(ids(30), 0.2, 0), null);
+  });
+
+  it('returns null when any of the three sides falls below the minimum subset', () => {
+    // N=10, val 0.2 → 2 < 3 → disabled.
+    assert.equal(splitTrainValTest(ids(10), 0.2, 0.2), null);
+    // N=12, val 0.4 (5), test 0.4 (5) → train 2 < 3 → disabled.
+    assert.equal(splitTrainValTest(ids(12), 0.4, 0.4), null);
+  });
+
+  it('carves three disjoint, exhaustive sets at an even stride', () => {
+    const split = splitTrainValTest(ids(20), 0.2, 0.2);
+    assert.ok(split);
+    assert.equal(split!.valIds.size, 4);
+    assert.equal(split!.testIds.size, 4);
+    assert.equal(split!.trainIds.size, 12);
+    // Pairwise disjoint.
+    for (const id of split!.valIds) {
+      assert.ok(!split!.testIds.has(id));
+      assert.ok(!split!.trainIds.has(id));
+    }
+    for (const id of split!.testIds) assert.ok(!split!.trainIds.has(id));
+    // Exhaustive.
+    assert.equal(split!.valIds.size + split!.testIds.size + split!.trainIds.size, 20);
+  });
+
+  it('is deterministic across calls (stable split, no RNG)', () => {
+    const a = splitTrainValTest(ids(23), 0.25, 0.25);
+    const b = splitTrainValTest(ids(23), 0.25, 0.25);
+    assert.deepEqual([...a!.valIds], [...b!.valIds]);
+    assert.deepEqual([...a!.testIds], [...b!.testIds]);
   });
 });
 
@@ -192,6 +231,62 @@ describe('allNonTripwireAssertionsPass', () => {
       ],
     });
     assert.equal(allNonTripwireAssertionsPass(report, 'skill'), true);
+  });
+});
+
+describe('decideAccept (significance gate)', () => {
+  const fill = (v: number, n: number): number[] => Array.from({ length: n }, () => v);
+  const GATE = { significanceGate: true, alpha: 0.05, seed: 42 };
+  const OFF = { significanceGate: false, alpha: 0.05, seed: 42 };
+
+  it('THE core difference: a noise-only gain is accepted by the old point estimate but REJECTED by the gate', () => {
+    // Best is flat 3.0; candidate is mostly 3.0 with a couple of higher samples — its
+    // mean edges above best, but the improvement is indistinguishable from noise.
+    const best = fill(3.0, 20);
+    const cand = [...fill(3.0, 18), 3.5, 3.5];
+    const pointBest = 3.0;
+    const pointCand = cand.reduce((a, b) => a + b, 0) / cand.length; // 3.05 > 3.0
+
+    // Old behavior (gate off): point estimate accepts.
+    assert.equal(decideAccept(best, cand, pointBest, pointCand, OFF).accepted, true);
+    // New behavior (gate on): not significant → rejected. This is the PR's whole point.
+    const gated = decideAccept(best, cand, pointBest, pointCand, GATE);
+    assert.equal(gated.accepted, false);
+    assert.equal(gated.diffCI!.significant, false);
+    assert.equal(gated.underpowered, false);
+  });
+
+  it('accepts a clearly significant improvement', () => {
+    const best = fill(2.0, 20);
+    const cand = fill(4.0, 20);
+    const d = decideAccept(best, cand, 2.0, 4.0, GATE);
+    assert.equal(d.accepted, true);
+    assert.equal(d.diffCI!.significant, true);
+    assert.ok(d.diffCI!.estimate > 0);
+  });
+
+  it('rejects a significant REGRESSION even though the gate fired', () => {
+    const best = fill(4.0, 20);
+    const cand = fill(2.0, 20);
+    const d = decideAccept(best, cand, 4.0, 2.0, GATE);
+    assert.equal(d.accepted, false); // significant but estimate < 0
+  });
+
+  it('degrades to the point estimate (and flags underpowered) below the sample floor', () => {
+    const best = fill(3.0, 5);
+    const cand = fill(4.0, 5);
+    const d = decideAccept(best, cand, 3.0, 4.0, GATE);
+    assert.equal(d.accepted, true); // point estimate: 4 > 3
+    assert.equal(d.underpowered, true);
+    assert.equal(d.diffCI, undefined);
+  });
+
+  it('is deterministic for a fixed seed', () => {
+    const best = fill(3.0, 20);
+    const cand = [...fill(3.0, 16), 3.5, 3.5, 3.5, 3.5];
+    const a = decideAccept(best, cand, 3.0, 3.1, GATE);
+    const b = decideAccept(best, cand, 3.0, 3.1, GATE);
+    assert.deepEqual(a.diffCI, b.diffCI);
   });
 });
 

--- a/test/authoring/evolver.test.ts
+++ b/test/authoring/evolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { extractWeakSamples, buildImprovementPrompt, evolveSkill, allNonTripwireAssertionsPass, splitHoldout, splitTrainValTest, restrictReportToSamples, decideAccept } from '../../src/authoring/evolver.js';
+import { extractWeakSamples, buildImprovementPrompt, evolveSkill, allNonTripwireAssertionsPass, splitHoldout, splitTrainValTest, restrictReportToSamples, decideAccept, computeEditDelta } from '../../src/authoring/evolver.js';
 import { fixSamples } from '../../src/authoring/sample-fixer.js';
 import type { Report, EvaluationReport } from '../../src/types/index.js';
 
@@ -190,6 +190,45 @@ describe('buildImprovementPrompt', () => {
     assert.ok(prompt.includes('2/5.0'));
     assert.ok(prompt.includes('Missing analysis'));
     assert.ok(prompt.includes('contains: SQL'));
+  });
+
+  it('appends the rejected-edit memory section when given, omits it when empty', () => {
+    const withMemory = buildImprovementPrompt('skill', 3.0, [], ['【第 2 轮被拒（提升不显著）】\n+ 加了一句废话']);
+    assert.match(withMemory, /已试过且未带来显著提升的改法/);
+    assert.match(withMemory, /加了一句废话/);
+    const without = buildImprovementPrompt('skill', 3.0, [], []);
+    assert.doesNotMatch(without, /已试过且未带来显著提升/);
+    const undef = buildImprovementPrompt('skill', 3.0, []);
+    assert.doesNotMatch(undef, /已试过且未带来显著提升/);
+  });
+});
+
+describe('computeEditDelta (edit budget)', () => {
+  it('reports zero change for identical content', () => {
+    const d = computeEditDelta('a\nb\nc', 'a\nb\nc');
+    assert.equal(d.changedLines, 0);
+    assert.equal(d.ratio, 0);
+  });
+
+  it('counts added + removed unique non-empty lines, ratio over original line count', () => {
+    // before 4 lines; remove "b", add "x" and "y" → 1 removed + 2 added = 3 changed / 4.
+    const d = computeEditDelta('a\nb\nc\nd', 'a\nc\nd\nx\ny');
+    assert.equal(d.changedLines, 3);
+    assert.equal(d.ratio, 3 / 4);
+    assert.match(d.summary, /\+ x/);
+    assert.match(d.summary, /- b/);
+  });
+
+  it('ignores whitespace-only differences (trimmed, empty-filtered)', () => {
+    const d = computeEditDelta('a\nb', '  a  \n\n b ');
+    assert.equal(d.changedLines, 0);
+  });
+
+  it('truncates the summary past maxSummaryLines', () => {
+    const before = 'k';
+    const after = ['k', ...Array.from({ length: 20 }, (_, i) => `add${i}`)].join('\n');
+    const d = computeEditDelta(before, after, 5);
+    assert.match(d.summary, /其余 \+15 行/);
   });
 });
 

--- a/test/cli/oclif-evolve.test.ts
+++ b/test/cli/oclif-evolve.test.ts
@@ -27,6 +27,30 @@ describe('oclif evolve', () => {
     assert.ok(stdout.includes('--rounds'), 'stdout missing --rounds flag');
     assert.ok(stdout.includes('--target'), 'stdout missing --target flag');
     assert.ok(stdout.includes('--improve-model'), 'stdout missing --improve-model flag');
+    assert.ok(stdout.includes('--no-significance-gate'), 'stdout missing --no-significance-gate flag');
+    assert.ok(stdout.includes('--test-ratio'), 'stdout missing --test-ratio flag');
+    assert.ok(stdout.includes('--edit-budget'), 'stdout missing --edit-budget flag');
+  });
+
+  it('非法 --significance-alpha → exit 2', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'evolve', 'skills/demo/SKILL.md', '--significance-alpha', '2']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+    }
+  });
+
+  it('--test-ratio 不配 --holdout-ratio → exit 2', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'evolve', 'skills/demo/SKILL.md', '--test-ratio', '0.2']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+      assert.match(e.stderr, /--test-ratio[\s\S]*--holdout-ratio/, `stderr missing guard message:\n${e.stderr}`);
+    }
   });
 
   it('--help --lang en', async () => {


### PR DESCRIPTION
## 背景

evolve 此前的接受判定是裸点估计比较：候选在决策集上哪怕被评委噪声抬高一点点也会被接受 —— 这正是「追噪声 / train-on-test」的隐患。而 omk 在 eval 侧早已造好统计严谨的 bootstrap diff CI，evolve 却没用上。本 PR 把这套测量严谨接进 evolve 的接受出口，让 evolve 的迭代决策从「看着更好」升级为「被证明更好」。

## 用户影响

evolve 现在默认开**显著性接受门**：候选只在相对当前最优**统计显著更好**时才被接受（逐样本 composite 的 bootstrap diff CI 排除 0 且方向为正），而不是分数高一点点就收。这意味着 evolve 会接受更少候选 —— 这是有意为之的保守：拒绝与评委噪声不可分的提升。

新增能力：

- `--holdout-ratio` 留出 val 选择集、`--test-ratio` 再锁一份全程不参与选择与弱样本抽取的 **test 集**，收尾读一次给无偏泛化分（避免「拿选择集当汇报数」的 winner's curse）。CLI summary 会额外打印泛化分。
- 廉价抗过拟：被拒候选的改法回灌下一轮 prompt（别重复无效改动）；单轮改动超 `--edit-budget`（默认 0.2）的候选评测前直接判拒，省 eval 成本。

## 迁移

- 想要旧的点估计判定：`--no-significance-gate`。
- 决策样本不足以做显著性检验时，本轮自动退回点估计并打印 warn —— 行为与旧版一致，只是多一行提示。
- `--test-ratio` 需配合 `--holdout-ratio`（单独给会报错提示）。

## 测量学 caveat

- 接受门复用 eval 已有的 bootstrap diff CI（独立重采样），对配对数据偏保守，不引入第二套统计原语。
- 小样本下显著性门退化为点估计，会显式 warn，不会静默「假装严格」。
- 锁定 test 集的 honest 性来自「全程不参与选择 / 弱样本抽取」，收尾只读一次已算好的分数，不构成泄漏。

## 可比性

报告 JSON schema、judge / observe prompt hash、五层评分管道、bootstrap/Krippendorff 公式均未改动 —— 改的是 evolve 的接受决策与返回结构，不动报告可比性锚点。**不涉及 BREAKING-COMPARABILITY。**