### PR TITLE
fix(site): 锁 yarn 1 classic + 跳过 engine 校验，修 Cloudflare Pages 构建

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,4 @@
+# 构建机（Cloudflare Pages 等）的 Node 可能落在某些 devDep 的 engine 范围之下
+# （如 npm-run-all2 要求 ^22.22.2 || ^24.15.0 || >=26），engine 不匹配只是工具链
+# 版本差、不影响 VitePress / 本包构建，这里统一跳过 engine 校验避免 install 失败。
+ignore-engines true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "oh-my-knowledge",
   "version": "0.33.0",
+  "packageManager": "yarn@1.22.22",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## 背景

文档站 PR 合并后，Cloudflare Pages 首次构建失败 —— 卡在 CF 自动的依赖安装步，根本没跑到 `yarn docs:build`。

两个原因：

1. **yarn 版本**：CF 默认拿 `yarn@4.9.1`，试图把仓库的 yarn 1 经典 `yarn.lock` 迁移成 berry 格式；但 CI 是 immutable，禁止改 lockfile（`YN0028: lockfile would have been modified… explicitly forbidden`）→ 安装直接失败。
2. **Node engine**：构建机 Node `24.13.1`，低于部分 devDep（如 `npm-run-all2` 要求 `^22.22.2 || ^24.15.0 || >=26`）的下限，会触发 engine 报错。

## 修复

- `package.json` 加 `"packageManager": "yarn@1.22.22"`：让 corepack / CF 用 yarn 1 经典，直接读经典 lockfile，不再迁移。
- 加 `.yarnrc`（`ignore-engines true`）：跳过 engine 校验。engine 不匹配只是工具链版本差，不影响 VitePress / 本包构建。

## 验证

本地以 Node 24.14（同样 < 24.15、复现失败条件）做 clean `yarn install --frozen-lockfile`：通过、无 engine 报错；`yarn docs:build` 正常。**合并前可直接看本 PR 的 Cloudflare preview 构建是否变绿**作为线上验证。

## 影响

`packageManager` 与本地一致（yarn 1.22.22），`ignore-engines` 让全仓 install 对工具链 Node 版本更宽容；不动任何源码 / 文档正文。