### PR TITLE
chore(release): .yarnrc.yml 注释固化 enableScripts 安全默认

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,7 @@
+# Yarn 4 defaults enableScripts to false: third-party postinstall scripts are
+# skipped (supply-chain hardening), while the root workspace's own scripts still
+# run. We intentionally rely on this secure default — do NOT add
+# `enableScripts: true` (that reverts to Yarn 1's run-everything behavior). If a
+# trusted dependency genuinely needs its build script, allow-list only that
+# package via `dependenciesMeta.<pkg>.built` in package.json.
 nodeLinker: node-modules


### PR DESCRIPTION
## 目的

把「Yarn 4 依赖脚本安全默认是有意的」固化进 `.yarnrc.yml` 注释，防止以后有人像 #194 迁移时 Yarn 自动写入那样，又手动加回 `enableScripts: true`。

承接 #204 的事后 CR 发现 1（已查官方文档更正）：Yarn 4 的 `enableScripts` 默认 `false`——跳过第三方依赖 `postinstall`（供应链硬化），workspace/根项目脚本照跑。我们当前不写该字段即取此安全默认，符合官方推荐。唯一带 install 脚本的依赖 esbuild 靠预编译平台包工作，不需要 postinstall，CI 双 node 全绿即印证。

## 改动

- `.yarnrc.yml` 加 6 行注释：勿加回 `enableScripts: true`；可信依赖确需 build 时用 `dependenciesMeta.<pkg>.built` 单独放行。

纯注释，无行为改动。`yarn install --immutable` 仍干净、lockfile 零变化。非测量学不变量，无 `BREAKING-COMPARABILITY`。
