### PR TITLE
feat(cli): 支持安装内置 Agent Skill

### DIFF
--- a/.agents/skills/omk/SKILL.md
+++ b/.agents/skills/omk/SKILL.md
@@ -4,7 +4,7 @@ description: |
   oh-my-knowledge 知识载体评测工具的智能代理。评测 skill（系统提示词）质量，对比不同版本效果，自动迭代改进。
   Use when: 用户提到"评测"、"测评"、"eval"、"benchmark"、"对比 skill"、"改进 skill"、"evolve"、"生成测试用例"、"gen-samples"、"omk"。
 user-invocable: true
-argument-hint: "<doctor|eval|evolve|init|observe|sample|studio> [options]"
+argument-hint: "<doctor|eval|evolve|init|install|observe|sample|studio> [options]"
 ---
 
 # OMK — 知识载体评测
@@ -19,7 +19,7 @@ argument-hint: "<doctor|eval|evolve|init|observe|sample|studio> [options]"
 npm i oh-my-knowledge -g
 ```
 
-omk CLI 顶层命令固定为 7 个：`init` / `doctor` / `eval` / `observe` / `evolve` / `sample` / `studio`。没有 `bench` / `improve` / `gen-samples` 这些旧子命令名 —— 如果你在历史 SKILL / 文档里看到了，那是 v0.30 命令树重构之前的写法。
+omk CLI 顶层命令包括：`init` / `install` / `doctor` / `eval` / `observe` / `evolve` / `sample` / `studio`。没有 `bench` / `improve` / `gen-samples` 这些旧子命令名 —— 如果你在历史 SKILL / 文档里看到了，那是 v0.30 命令树重构之前的写法。
 
 ## 第二步：理解用户意图
 

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -284,6 +284,48 @@ omk init
 omk init my-project
 ```
 
+## omk install
+
+安装或接管 knowledge input（MVP 支持内置 omk Agent Skill）。
+
+**用法:**
+
+```bash
+omk install <input> [flags]
+```
+
+**参数:**
+
+- `input`(必填):要安装的 knowledge input。当前支持内置 id：omk-agent-skill。
+
+**Flags:**
+
+- `--dest` `option`:自定义 skill 根目录；omk 会安装到 <dir>/omk。
+- `--dry-run` `boolean`:只打印安装目标，不写文件。
+- `--force` `boolean`:覆盖已存在的 omk Agent Skill。
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
+- `--to` `option` (默认 `auto`):安装目标：auto / codex / claude / all，默认 auto。
+
+**示例:**
+
+> 安装 omk 官方 Agent Skill 到默认 agent 目录
+
+```bash
+omk install omk-agent-skill
+```
+
+> 同时安装到 Codex 与 Claude Code
+
+```bash
+omk install omk-agent-skill --to all
+```
+
+> 安装到自定义 skill 根目录
+
+```bash
+omk install omk-agent-skill --dest ~/.my-agent/skills
+```
+
 ## omk observe
 
 分析 sessions 目录的 skill 调用健康度（默认行为）。子命令:ingest / inbox / show。

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -286,7 +286,7 @@ omk init my-project
 
 ## omk install
 
-安装或接管 knowledge input（当前支持内置 omk Agent Skill，默认写入本机已检测 agent 目标）。
+安装 omk 官方 Agent Skill（当前仅支持内置 id：omk-agent-skill，默认写入本机已检测 agent 目标）。
 
 **用法:**
 
@@ -296,7 +296,7 @@ omk install <input> [flags]
 
 **参数:**
 
-- `input`(必填):要安装的 knowledge input。当前支持内置 id：omk-agent-skill。
+- `input`(必填):要安装的知识输入。当前支持内置 id：omk-agent-skill。
 
 **Flags:**
 

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -286,7 +286,7 @@ omk init my-project
 
 ## omk install
 
-安装或接管 knowledge input（MVP 支持内置 omk Agent Skill）。
+安装或接管 knowledge input（MVP 支持内置 omk Agent Skill，默认写入本机已检测 agent 目标）。
 
 **用法:**
 
@@ -304,17 +304,17 @@ omk install <input> [flags]
 - `--dry-run` `boolean`:只打印安装目标，不写文件。
 - `--force` `boolean`:覆盖已存在的 omk Agent Skill。
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
-- `--to` `option` (默认 `auto`):安装目标：auto / codex / claude / all，默认 auto。
+- `--to` `option` (默认 `auto`):安装目标：auto（默认，本机已检测目标） / codex / claude / all。
 
 **示例:**
 
-> 安装 omk 官方 Agent Skill 到默认 agent 目录
+> 安装 omk 官方 Agent Skill 到默认本机目标
 
 ```bash
 omk install omk-agent-skill
 ```
 
-> 同时安装到 Codex 与 Claude Code
+> 强制安装到当前 omk 已知的所有目标
 
 ```bash
 omk install omk-agent-skill --to all

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -286,7 +286,7 @@ omk init my-project
 
 ## omk install
 
-安装或接管 knowledge input（MVP 支持内置 omk Agent Skill，默认写入本机已检测 agent 目标）。
+安装或接管 knowledge input（当前支持内置 omk Agent Skill，默认写入本机已检测 agent 目标）。
 
 **用法:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ omk 是面向 LLM 知识输入（prompt / RAG / skill / agent）的评测与迭�
 omk install omk-agent-skill
 ```
 
+默认只写入本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。需要强制写入当前 omk 已知的全部目标时，用 `--to all`；需要自定义 skill 根目录时，用 `--dest`。
+
 仓库开发或手动复用时，也可以把 `.agents/skills/omk/` 整目录拷到对应工具的 skill 目录：
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,13 @@ omk 是面向 LLM 知识输入（prompt / RAG / skill / agent）的评测与迭�
 - **Codex**：原生加载 `.agents/skills/omk/`（Codex 从 cwd 向上扫到仓库根的 `.agents/skills/`）。
 - **Claude Code**：通过软链 `.claude/skills/omk` → `.agents/skills/omk` 加载。
 
-要把 skill 复用到其它项目或全局，把 `.agents/skills/omk/` 整目录拷到对应工具的 skill 目录：
+用户安装 npm 包后，推荐用内置安装命令把 omk 官方 Agent Skill 装到本机 agent 工具：
+
+```bash
+omk install omk-agent-skill
+```
+
+仓库开发或手动复用时，也可以把 `.agents/skills/omk/` 整目录拷到对应工具的 skill 目录：
 
 ```bash
 # Claude Code（全局）

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,8 +186,8 @@ oclif Command 的 `description` / `flags` / `args` / `examples` static 字段是
 | 目标 | marker | 输出 | 语言 |
 |---|---|---|---|
 | `.agents/skills/omk/references/commands.md` | 整段 `<!-- omk:cli:start -->` ... `<!-- omk:cli:end -->` | oclif `Config.commands` 全集完整渲染（含 topic / sub / sub-sub） | zh |
-| `README.md` | 每个顶层命令独立 `<!-- omk:cli:<id>:flags:start -->` ... `<!-- omk:cli:<id>:flags:end -->`,7 对 | flag list（```text``` 对齐风格）+ 指向 `--help` 的脚注 | en |
-| `README.zh.md` | 同上 | 同上 | zh |
+| `docs/reference/cli.md` | 每个顶层命令独立 `<!-- omk:cli:<id>:flags:start -->` ... `<!-- omk:cli:<id>:flags:end -->` | flag list（```text``` 对齐风格）+ 指向 `--help` 的脚注 | en |
+| `docs/zh/reference/cli.md` | 同上 | 同上 | zh |
 
 `SKILL.md` 不走 codegen（agent prompt 指令塞结构化命令清单跟 commands.md 重复,还撑大 agent context）。改用 `test/scripts/build-docs.test.ts` 的 vitest case 锁 frontmatter `argument-hint` 跟 oclif 顶层命令 id set（`TOP_LEVEL_IDS`）严格一致——历史上漂过 2 次（`bench run` → `eval`、`improve` → `evolve`),这条 test 把同类 drift 拦在 CI。
 
@@ -195,8 +195,8 @@ oclif Command 的 `description` / `flags` / `args` / `examples` static 字段是
 
 - 改完 oclif Command 的 description / flag,跑 `yarn build && yarn build:docs` 同步全部 3 个目标
 - 不跑就会被 vitest 内嵌 `--check` 拦截（exit 1 + 对每个 drift 的文件打 diff）
-- README 的 prose 段（static-only 解释 / HTML report tab / Studio IA / executor 表格等）在 marker 外,hand-maintained 保留
-- 新增顶层命令时:加 `src/cli/commands/<id>.ts`、在 README.md / README.zh.md 各加一对 `<!-- omk:cli:<id>:flags:start -->` / `:end -->`、SKILL.md frontmatter `argument-hint` 加 `<id>`,跑一遍 `yarn build && yarn build:docs && yarn test`(顶层命令集真值由 `scripts/build-docs.ts` 的 `getTopLevelIds(Config.load)` 从 oclif Command 文件目录派生,不需要再单独维护硬编码数组)
+- CLI reference 的 prose 段（static-only 解释 / HTML report tab / Studio IA / executor 表格等）在 marker 外,hand-maintained 保留
+- 新增顶层命令时:加 `src/cli/commands/<id>.ts`、在 `docs/reference/cli.md` / `docs/zh/reference/cli.md` 各加一对 `<!-- omk:cli:<id>:flags:start -->` / `:end -->`、SKILL.md frontmatter `argument-hint` 加 `<id>`,跑一遍 `yarn build && yarn build:docs && yarn test`(顶层命令集真值由 `scripts/build-docs.ts` 的 `getTopLevelIds(Config.load)` 从 oclif Command 文件目录派生,不需要再单独维护硬编码数组)
 - 新增子命令（如 `omk eval gold init` 这种 sub-sub）时:加 `src/cli/commands/eval/gold/init.ts`,oclif 文件目录自动路由,fullbody 模式自动包含
 
 ### 加新 sub-sub topic 命令

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Deeper: [CLI reference](docs/reference/cli.md) · [how it works](docs/explanatio
 
 ## Use inside AI Coding Agents
 
+Install the official omk Agent Skill to let your coding agent run omk workflows from natural language:
+
+```bash
+omk install omk-agent-skill
+```
+
 ### Use inside Claude Code
 
 When the `omk` skill is available in Claude Code, you can invoke it directly:
@@ -71,7 +77,7 @@ Teams doing knowledge engineering produce lots of knowledge artifacts (skills to
 | Saturation curve | ✓ | ✗ | ✗ | ✗ |
 | Three-layer scoring isolation | ✓ | ✗ | partial | ✗ |
 | Per-variant skill isolation (construct validity) | ✓ default | ✗ | ✗ | ✗ |
-| Native Claude Code skill | ✓ | ✗ | ✗ | ✗ |
+| Native Agent Skill | ✓ | ✗ | ✗ | ✗ |
 | Hosted SaaS dashboard | ✗ | ✗ | ✓ | ✓ |
 
 omk's moat is **default-on safety net** — Bootstrap CI and length-debias aren't advanced flags; they're the default, and judge ↔ human α comes free the moment you add a gold set. Other tools let you opt into confidence intervals; omk makes them unavoidable. Need a hosted SaaS dashboard? Choose LangSmith. Want quick local prompt iteration without statistics? Choose promptfoo. **Shipping to production and someone will ask "why should I trust this number?" Choose omk.**
@@ -107,7 +113,7 @@ The full docs are published at **[oh-my-knowledge.pages.dev](https://oh-my-knowl
 
 - **[How it works](docs/explanation/architecture.md)** — interleaved scheduling, variant resolution, dual-channel scoring, six-dim report
 - **[Eval sample format](docs/reference/eval-sample-format.md)** — sample schema, scoring formulas, 30+ assertion types, custom JS assertions
-- **[CLI reference](docs/reference/cli.md)** — all seven commands with bash examples and flag tables
+- **[CLI reference](docs/reference/cli.md)** — all top-level commands with bash examples and flag tables
 - **[Executors](docs/reference/executors.md)** & **[artifact layout](docs/reference/artifact-layout.md)** — built-in / custom executors; how `variant` resolves to an artifact + runtime context
 - **[How-to guides](docs/guides/agent-eval.md)** — [evaluate an agent](docs/guides/agent-eval.md) (project runtime context) and [use non-Claude models](docs/guides/non-claude-models.md) (GLM / Qwen / DeepSeek / Moonshot / Ollama)
 - **[Quickstart](docs/quickstart-skill-eval.md)** — first-time five-minute walkthrough

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Install the official omk Agent Skill to let your coding agent run omk workflows 
 omk install omk-agent-skill
 ```
 
+By default, omk installs only into detected local targets it explicitly supports: Codex/AGENTS when `~/.codex` or `~/.agents` exists, and Claude Code when `~/.claude` exists. Use `--to all` to force every target omk currently knows, or `--dest` for a custom skill root.
+
 ### Use inside Claude Code
 
 When the `omk` skill is available in Claude Code, you can invoke it directly:

--- a/README.zh.md
+++ b/README.zh.md
@@ -39,6 +39,8 @@ omk eval --control code-review-v1 --treatment code-review-v2
 omk install omk-agent-skill
 ```
 
+默认只会安装到本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。
+
 ### 在 Claude Code 中使用
 
 当 `omk` skill 已在 Claude Code 中可用时，可以直接这样调用：

--- a/README.zh.md
+++ b/README.zh.md
@@ -33,6 +33,12 @@ omk eval --control code-review-v1 --treatment code-review-v2
 
 ## 在 AI Coding Agent 中使用
 
+安装 omk 官方 Agent Skill 后，可以直接用自然语言让 coding agent 跑 omk 工作流：
+
+```bash
+omk install omk-agent-skill
+```
+
 ### 在 Claude Code 中使用
 
 当 `omk` skill 已在 Claude Code 中可用时，可以直接这样调用：
@@ -71,7 +77,7 @@ omk sample skills/my-skill.md
 | 饱和曲线 | ✓ | ✗ | ✗ | ✗ |
 | 三层独立评分 | ✓ | ✗ | 部分 | ✗ |
 | 用例隔离(construct validity) | ✓ 默认 | ✗ | ✗ | ✗ |
-| 原生 Claude Code skill | ✓ | ✗ | ✗ | ✗ |
+| 原生 Agent Skill | ✓ | ✗ | ✗ | ✗ |
 | 托管 SaaS 看板 | ✗ | ✗ | ✓ | ✓ |
 
 omk 的护城河是 **default-on 安全网** —— Bootstrap CI / 长度去偏不是 advanced flag，是默认行为；评委 ↔ 人工 α 只要给一份 gold 集就自动算。其他工具让你**手动**接置信区间；omk 让你**默认无法忽略**它。需要 SaaS 看板？选 LangSmith。要快速 prompt 迭代不要统计层？选 promptfoo。**要发到生产且会被问「为什么应该相信这个数字」？选 omk。**
@@ -107,7 +113,7 @@ RAG 专项评测请看 RAGAS（独立 niche，跟 omk 互补）。完整对比�
 
 - **[工作原理](docs/zh/explanation/architecture.md)** —— 交错调度、variant 解析、双通道评分、六维报告
 - **[评测用例格式](docs/zh/reference/eval-sample-format.md)** —— sample schema、评分公式、30+ 断言类型、自定义 JS 断言
-- **[CLI 参考](docs/zh/reference/cli.md)** —— 7 个命令的 bash 示例和 flag 表
+- **[CLI 参考](docs/zh/reference/cli.md)** —— 顶层命令的 bash 示例和 flag 表
 - **[执行器](docs/zh/reference/executors.md)** & **[artifact 布局](docs/zh/reference/artifact-layout.md)** —— 内置 / 自定义执行器；variant 如何解析为 artifact + runtime context
 - **[操作指南](docs/zh/guides/agent-eval.md)** —— [评测 agent](docs/zh/guides/agent-eval.md)（项目 runtime context）与[使用非 Claude 模型](docs/zh/guides/non-claude-models.md)（GLM / 通义 / DeepSeek / Moonshot / Ollama）
 - **[快速上手](docs/zh/quickstart-skill-eval.md)** —— 第一次跑评测的 5 分钟教程

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Browse by audience or category. For Chinese docs see [简体中文 index](./zh/R
 ## I want to use omk
 
 - [Quickstart](./quickstart-skill-eval.md) — first eval in 5 minutes
+- [Install the omk Agent Skill](./quickstart-skill-eval.md) — agent-driven onboarding with `omk install omk-agent-skill`
 - [CLI reference](./reference/cli.md)
 - [Eval sample format](./reference/eval-sample-format.md)
 - [Executors](./reference/executors.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,4 +23,6 @@ features:
     details: Bootstrap CIs on the difference, judge-ensemble agreement, length-debiasing. A reported delta means a real difference within measurement noise — not a number that moved.
   - title: evolve — keep only proven gains
     details: Propose an edit, gate it on a statistically significant held-out improvement, and report an unbiased score on a locked test set. Refuses gains indistinguishable from judge noise.
+  - title: Agent Skill onboarding
+    details: Install the official omk Agent Skill with npm plus `omk install omk-agent-skill`, then drive doctor, eval, sample, evolve, observe, and studio from natural language inside your coding agent.
 ---

--- a/docs/quickstart-skill-eval.md
+++ b/docs/quickstart-skill-eval.md
@@ -15,7 +15,7 @@ If you want the **agent-driven workflow** (recommended), also install the omk Ag
 omk install omk-agent-skill
 ```
 
-This installs the official omk Agent Skill into your local coding-agent skill directory. Once installed, the agent auto-loads the SKILL context when you mention "omk", "benchmark", "evaluate", "skill eval", etc.
+By default, this installs only into detected local targets omk explicitly supports: Codex/AGENTS when `~/.codex` or `~/.agents` exists, and Claude Code when `~/.claude` exists. Use `--to all` to force every target omk currently knows, or `--dest` for a custom skill root. Once installed, the agent auto-loads the SKILL context when you mention "omk", "benchmark", "evaluate", "skill eval", etc.
 
 ## Prepare your skill (1 minute)
 

--- a/docs/quickstart-skill-eval.md
+++ b/docs/quickstart-skill-eval.md
@@ -9,15 +9,13 @@ npm i oh-my-knowledge -g
 omk --version    # prints a version number once installed
 ```
 
-If you want the **agent-driven workflow** (recommended), also install the omk skill into your coding agent. For Claude Code users:
+If you want the **agent-driven workflow** (recommended), also install the omk Agent Skill into your coding agent:
 
 ```bash
-git clone https://github.com/lizhiyao/oh-my-knowledge.git /tmp/omk-src
-mkdir -p ~/.claude/skills
-cp -r /tmp/omk-src/.agents/skills/omk ~/.claude/skills/
+omk install omk-agent-skill
 ```
 
-Codex users: copy into `~/.agents/skills/` instead. Once installed, the agent auto-loads the SKILL context when you mention "omk", "benchmark", "evaluate", "skill eval", etc.
+This installs the official omk Agent Skill into your local coding-agent skill directory. Once installed, the agent auto-loads the SKILL context when you mention "omk", "benchmark", "evaluate", "skill eval", etc.
 
 ## Prepare your skill (1 minute)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,14 +41,14 @@ omk install omk-agent-skill --dest ~/.my-agent/skills
   --dry-run       Print install targets without writing files.
   --force         Overwrite an existing omk Agent Skill.
   --lang <value>  Output language zh|en. Priority: CLI > OMK_LANG env > zh.
-  --to <value>    Install target: auto / codex / claude / all. Default auto.
+  --to <value>    Install target: auto (default, detected local targets) / codex / claude / all.
 ```
 
 For full descriptions: `omk install --help`.
 
 <!-- omk:cli:install:flags:end -->
 
-Installs the official omk Agent Skill into a local coding-agent skill directory. This is the onboarding path for agent-driven workflows; user knowledge inputs will use the same lifecycle entry point in future releases.
+Installs the official omk Agent Skill into local supported coding-agent targets. The default `auto` target writes only to detected targets omk explicitly supports: Codex/AGENTS when `~/.codex` or `~/.agents` exists, and Claude Code when `~/.claude` exists. Use `--to all` to force every target omk currently knows, or `--dest` for a custom skill root. This is the onboarding path for agent-driven workflows; user knowledge inputs will use the same lifecycle entry point in future releases.
 
 ## `omk doctor`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # omk CLI reference
 
-omk exposes a workflow CLI for knowledge artifacts. Seven top-level commands cover the full loop: `init` (scaffold) · `doctor` (static check) · `eval` (offline A/B) · `observe` (online trace) · `evolve` (auto-iterate a skill) · `sample` (generate or fill test cases) · `studio` (local web UI for reports & analysis).
+omk exposes a workflow CLI for knowledge artifacts. Top-level commands cover the full loop: `init` (scaffold) · `install` (install/adopt a knowledge input) · `doctor` (static check) · `eval` (offline A/B) · `observe` (online trace) · `evolve` (auto-iterate a skill) · `sample` (generate or fill test cases) · `studio` (local web UI for reports & analysis).
 
 <!-- Maintainers: the Flags blocks in this file are auto-generated from the oclif command source by scripts/build-docs.ts. Run `yarn build:docs` after editing CLI flags; `yarn build:docs:check` runs in CI to catch drift. -->
 
@@ -23,6 +23,32 @@ For full descriptions: `omk init --help`.
 <!-- omk:cli:init:flags:end -->
 
 Scaffolds an evaluation project with two starter skill variants and an `eval-samples.json` file.
+
+## `omk install`
+
+```bash
+omk install omk-agent-skill
+omk install omk-agent-skill --to all
+omk install omk-agent-skill --dest ~/.my-agent/skills
+```
+
+<!-- omk:cli:install:flags:start -->
+
+**Flags:**
+
+```text
+  --dest <value>  Custom skill root; installs into <dir>/omk.
+  --dry-run       Print install targets without writing files.
+  --force         Overwrite an existing omk Agent Skill.
+  --lang <value>  Output language zh|en. Priority: CLI > OMK_LANG env > zh.
+  --to <value>    Install target: auto / codex / claude / all. Default auto.
+```
+
+For full descriptions: `omk install --help`.
+
+<!-- omk:cli:install:flags:end -->
+
+Installs the official omk Agent Skill into a local coding-agent skill directory. This is the onboarding path for agent-driven workflows; user knowledge inputs will use the same lifecycle entry point in future releases.
 
 ## `omk doctor`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # omk CLI reference
 
-omk exposes a workflow CLI for knowledge artifacts. Top-level commands cover the full loop: `init` (scaffold) · `install` (install/adopt a knowledge input) · `doctor` (static check) · `eval` (offline A/B) · `observe` (online trace) · `evolve` (auto-iterate a skill) · `sample` (generate or fill test cases) · `studio` (local web UI for reports & analysis).
+omk exposes a workflow CLI for knowledge artifacts. Top-level commands cover the full loop: `init` (scaffold) · `install` (install the official omk Agent Skill) · `doctor` (static check) · `eval` (offline A/B) · `observe` (online trace) · `evolve` (auto-iterate a skill) · `sample` (generate or fill test cases) · `studio` (local web UI for reports & analysis).
 
 <!-- Maintainers: the Flags blocks in this file are auto-generated from the oclif command source by scripts/build-docs.ts. Run `yarn build:docs` after editing CLI flags; `yarn build:docs:check` runs in CI to catch drift. -->
 
@@ -48,7 +48,7 @@ For full descriptions: `omk install --help`.
 
 <!-- omk:cli:install:flags:end -->
 
-Installs the official omk Agent Skill into local supported coding-agent targets. The default `auto` target writes only to detected targets omk explicitly supports: Codex/AGENTS when `~/.codex` or `~/.agents` exists, and Claude Code when `~/.claude` exists. Use `--to all` to force every target omk currently knows, or `--dest` for a custom skill root. This is the onboarding path for agent-driven workflows; user knowledge inputs will use the same lifecycle entry point in future releases.
+Installs the official omk Agent Skill into local supported coding-agent targets. The default `auto` target writes only to detected targets omk explicitly supports: Codex/AGENTS when `~/.codex` or `~/.agents` exists, and Claude Code when `~/.claude` exists. Use `--to all` to force every target omk currently knows, or `--dest` for a custom skill root.
 
 ## `omk doctor`
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -5,6 +5,7 @@
 ## 我想用 omk
 
 - [快速上手](./quickstart-skill-eval.md) —— 5 分钟跑完第一次评测
+- [安装 omk Agent Skill](./quickstart-skill-eval.md) —— 用 `omk install omk-agent-skill` 开启 agent 驱动工作流
 - [CLI 参考](./reference/cli.md)
 - [评测用例格式](./reference/eval-sample-format.md)
 - [执行器](./reference/executors.md)

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -23,4 +23,6 @@ features:
     details: 对差值做 bootstrap 置信区间、评委一致性、长度去偏。报告里的 Δ 代表测量噪声之内的真实差异，而不是「数字动了一下」。
   - title: evolve——只收被证明的提升
     details: 提出一处改动，在留出集上要求统计显著才接受，并在锁定的 test 集上给一个无偏泛化分。拒绝与评委噪声不可分的「提升」。
+  - title: Agent Skill 入场
+    details: 通过 npm 安装 omk 后运行 `omk install omk-agent-skill`，即可把 omk 官方 Agent Skill 装到本机 coding agent，用自然语言驱动 doctor、eval、sample、evolve、observe 和 studio。
 ---

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -9,15 +9,13 @@ npm i oh-my-knowledge -g
 omk --version    # 能输出版本号即装好
 ```
 
-如果你想用「自然语言让 agent 帮你跑」的方式（推荐），还需要把 omk skill 装到你的 agent 工具里。Claude Code 用户：
+如果你想用「自然语言让 agent 帮你跑」的方式（推荐），还需要把 omk Agent Skill 装到你的 agent 工具里：
 
 ```bash
-git clone https://github.com/lizhiyao/oh-my-knowledge.git /tmp/omk-src
-mkdir -p ~/.claude/skills
-cp -r /tmp/omk-src/.agents/skills/omk ~/.claude/skills/
+omk install omk-agent-skill
 ```
 
-Codex 用户改 `~/.agents/skills/`。装好之后，agent 收到含「omk」「评测」「benchmark」之类的关键词就会自动加载 SKILL 上下文。
+这会把 omk 官方 Agent Skill 安装到本机 coding agent 的 skill 目录。装好之后，agent 收到含「omk」「评测」「benchmark」之类的关键词就会自动加载 SKILL 上下文。
 
 ## 准备 skill（1 分钟）
 

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -15,7 +15,7 @@ omk --version    # 能输出版本号即装好
 omk install omk-agent-skill
 ```
 
-这会把 omk 官方 Agent Skill 安装到本机 coding agent 的 skill 目录。装好之后，agent 收到含「omk」「评测」「benchmark」之类的关键词就会自动加载 SKILL 上下文。
+默认只会安装到本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。装好之后，agent 收到含「omk」「评测」「benchmark」之类的关键词就会自动加载 SKILL 上下文。
 
 ## 准备 skill（1 分钟）
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -1,6 +1,6 @@
 # omk CLI 参考
 
-omk 的公开 CLI 由 7 个顶层命令构成完整闭环：`init`（脚手架）·`doctor`（静态检查）·`eval`（离线 A/B 评测）·`observe`（线上 trace 观测）·`evolve`（多轮自动迭代 skill）·`sample`（生成或补齐评测用例）·`studio`（本地 Web 工作台，看报告 / 分析）。
+omk 的公开 CLI 由顶层命令构成完整闭环：`init`（脚手架）·`install`（安装 / 接管 knowledge input）·`doctor`（静态检查）·`eval`（离线 A/B 评测）·`observe`（线上 trace 观测）·`evolve`（多轮自动迭代 skill）·`sample`（生成或补齐评测用例）·`studio`（本地 Web 工作台，看报告 / 分析）。
 
 <!-- 维护者须知：本文件里的 Flags 区块由 scripts/build-docs.ts 从 oclif 命令源码自动生成。改 CLI flag 后跑 `yarn build:docs` 同步；CI 跑 `yarn build:docs:check` 拦截 drift。 -->
 
@@ -23,6 +23,32 @@ omk init [目录]
 <!-- omk:cli:init:flags:end -->
 
 生成一个评测项目脚手架，包含两版 starter skill 和 `eval-samples.json`。
+
+## `omk install`
+
+```bash
+omk install omk-agent-skill
+omk install omk-agent-skill --to all
+omk install omk-agent-skill --dest ~/.my-agent/skills
+```
+
+<!-- omk:cli:install:flags:start -->
+
+**Flags:**
+
+```text
+  --dest <value>  自定义 skill 根目录；omk 会安装到 <dir>/omk。
+  --dry-run       只打印安装目标，不写文件。
+  --force         覆盖已存在的 omk Agent Skill。
+  --lang <value>  输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
+  --to <value>    安装目标：auto / codex / claude / all，默认 auto。
+```
+
+完整描述见 `omk install --help`。
+
+<!-- omk:cli:install:flags:end -->
+
+把 omk 官方 Agent Skill 安装到本机 coding agent 的 skill 目录。这是 agent-driven workflow 的 onboarding 入口；用户自己的 knowledge input 后续也会沿用同一个生命周期入口。
 
 ## `omk doctor`
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -1,6 +1,6 @@
 # omk CLI 参考
 
-omk 的公开 CLI 由顶层命令构成完整闭环：`init`（脚手架）·`install`（安装 / 接管 knowledge input）·`doctor`（静态检查）·`eval`（离线 A/B 评测）·`observe`（线上 trace 观测）·`evolve`（多轮自动迭代 skill）·`sample`（生成或补齐评测用例）·`studio`（本地 Web 工作台，看报告 / 分析）。
+omk 的公开 CLI 由顶层命令构成完整闭环：`init`（脚手架）·`install`（安装 omk 官方 Agent Skill）·`doctor`（静态检查）·`eval`（离线 A/B 评测）·`observe`（线上 trace 观测）·`evolve`（多轮自动迭代 skill）·`sample`（生成或补齐评测用例）·`studio`（本地 Web 工作台，看报告 / 分析）。
 
 <!-- 维护者须知：本文件里的 Flags 区块由 scripts/build-docs.ts 从 oclif 命令源码自动生成。改 CLI flag 后跑 `yarn build:docs` 同步；CI 跑 `yarn build:docs:check` 拦截 drift。 -->
 
@@ -48,7 +48,7 @@ omk install omk-agent-skill --dest ~/.my-agent/skills
 
 <!-- omk:cli:install:flags:end -->
 
-把 omk 官方 Agent Skill 安装到本机支持的 coding-agent 目标。默认 `auto` 只会写入本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。这是 agent-driven workflow 的 onboarding 入口；用户自己的 knowledge input 后续也会沿用同一个生命周期入口。
+把 omk 官方 Agent Skill 安装到本机支持的 coding-agent 目标。默认 `auto` 只会写入本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。
 
 ## `omk doctor`
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -41,14 +41,14 @@ omk install omk-agent-skill --dest ~/.my-agent/skills
   --dry-run       只打印安装目标，不写文件。
   --force         覆盖已存在的 omk Agent Skill。
   --lang <value>  输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
-  --to <value>    安装目标：auto / codex / claude / all，默认 auto。
+  --to <value>    安装目标：auto（默认，本机已检测目标） / codex / claude / all。
 ```
 
 完整描述见 `omk install --help`。
 
 <!-- omk:cli:install:flags:end -->
 
-把 omk 官方 Agent Skill 安装到本机 coding agent 的 skill 目录。这是 agent-driven workflow 的 onboarding 入口；用户自己的 knowledge input 后续也会沿用同一个生命周期入口。
+把 omk 官方 Agent Skill 安装到本机支持的 coding-agent 目标。默认 `auto` 只会写入本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。这是 agent-driven workflow 的 onboarding 入口；用户自己的 knowledge input 后续也会沿用同一个生命周期入口。
 
 ## `omk doctor`
 

--- a/scripts/copy-assets.cjs
+++ b/scripts/copy-assets.cjs
@@ -1,6 +1,7 @@
 'use strict';
 
 // build-time asset copy: src/ 下的非 .ts 资产(mock-hook.cjs / runtime prompt md)
+// 以及仓库内置 agent skill。
 // tsc 不会自动复制非 .ts 文件。把每个 asset 复制到 dist/ 下对应路径,
 // 让运行时 sibling-relative 解析(dirname(import.meta.url) + sibling 文件)
 // 在 dev(src/)和 npm 安装(dist/)两种位置都能拿到 asset。
@@ -16,4 +17,14 @@ const ASSETS = [
 for (const [src, dst] of ASSETS) {
   fs.mkdirSync(path.dirname(dst), { recursive: true });
   fs.copyFileSync(src, dst);
+}
+
+const DIR_ASSETS = [
+  ['.agents/skills/omk', 'dist/assets/agent-skills/omk'],
+];
+
+for (const [src, dst] of DIR_ASSETS) {
+  fs.rmSync(dst, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.cpSync(src, dst, { recursive: true });
 }

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -100,8 +100,8 @@ function installOmkAgentSkill(params: {
 
 export default class Install extends BaseCommand {
   static description = bilingual({
-    zh: '安装或接管 knowledge input（MVP 支持内置 omk Agent Skill，默认写入本机已检测 agent 目标）。',
-    en: 'Install or adopt a knowledge input (MVP supports the built-in omk Agent Skill, defaulting to detected local agent targets).',
+    zh: '安装或接管 knowledge input（当前支持内置 omk Agent Skill，默认写入本机已检测 agent 目标）。',
+    en: 'Install or adopt a knowledge input (currently supports the built-in omk Agent Skill, defaulting to detected local agent targets).',
   });
 
   static examples = [

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -87,7 +87,7 @@ function resolveInstallTargets(params: { to: string; dest?: string; lang: 'zh' |
     return [{ label: 'custom', skillsDir: resolve(params.dest) }];
   }
 
-  const targets = params.to === 'auto' ? autoTargets() : parseTargets(params.to, params.lang);
+  const targets = parseTargets(params.to, params.lang);
   if (targets.length === 0) {
     throw new Error(tCli('cli.install.no_detected_targets', params.lang));
   }
@@ -102,6 +102,26 @@ function resolveInstallTargets(params: { to: string; dest?: string; lang: 'zh' |
     });
 }
 
+function targetSkillDir(target: InstallTarget): string {
+  return join(target.skillsDir, 'omk');
+}
+
+function validateInstallTargets(params: {
+  targets: InstallTarget[];
+  force: boolean;
+  dryRun: boolean;
+  lang: 'zh' | 'en';
+}): void {
+  if (params.dryRun || params.force) return;
+
+  for (const target of params.targets) {
+    const targetDir = targetSkillDir(target);
+    if (existsSync(targetDir)) {
+      throw new Error(tCli('cli.install.target_exists', params.lang, { path: targetDir }));
+    }
+  }
+}
+
 function installOmkAgentSkill(params: {
   sourceDir: string;
   target: InstallTarget;
@@ -113,7 +133,7 @@ function installOmkAgentSkill(params: {
     throw new Error(tCli('cli.install.asset_missing', params.lang, { path: params.sourceDir }));
   }
 
-  const targetDir = join(params.target.skillsDir, 'omk');
+  const targetDir = targetSkillDir(params.target);
   if (params.dryRun) {
     console.log(tCli('cli.install.plan', params.lang, { path: targetDir }));
     return targetDir;
@@ -132,8 +152,8 @@ function installOmkAgentSkill(params: {
 
 export default class Install extends BaseCommand {
   static description = bilingual({
-    zh: '安装或接管 knowledge input（当前支持内置 omk Agent Skill，默认写入本机已检测 agent 目标）。',
-    en: 'Install or adopt a knowledge input (currently supports the built-in omk Agent Skill, defaulting to detected local agent targets).',
+    zh: '安装 omk 官方 Agent Skill（当前仅支持内置 id：omk-agent-skill，默认写入本机已检测 agent 目标）。',
+    en: 'Install the official omk Agent Skill (currently supports only built-in id: omk-agent-skill, defaulting to detected local agent targets).',
   });
 
   static examples = [
@@ -163,7 +183,7 @@ export default class Install extends BaseCommand {
   static args = {
     input: Args.string({
       description: bilingual({
-        zh: '要安装的 knowledge input。当前支持内置 id：omk-agent-skill。',
+        zh: '要安装的知识输入。当前支持内置 id：omk-agent-skill。',
         en: 'Knowledge input to install. Currently supports built-in id: omk-agent-skill.',
       }),
       required: true,
@@ -212,6 +232,12 @@ export default class Install extends BaseCommand {
 
       const sourceDir = packagedOmkAgentSkillDir();
       const targets = resolveInstallTargets({ to: flags.to, dest: flags.dest, lang });
+      validateInstallTargets({
+        targets,
+        force: flags.force,
+        dryRun: flags['dry-run'],
+        lang,
+      });
       for (const target of targets) {
         installOmkAgentSkill({
           sourceDir,

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,0 +1,190 @@
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Args, Flags } from '@oclif/core';
+import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
+import { BaseCommand } from '../oclif/base-command.js';
+import { tCli } from '../lib/i18n.js';
+
+const BUILTIN_OMK_AGENT_SKILL_ID = 'omk-agent-skill';
+
+type AgentTarget = 'codex' | 'claude';
+
+interface InstallTarget {
+  label: string;
+  skillsDir: string;
+}
+
+function packagedOmkAgentSkillDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', 'assets', 'agent-skills', 'omk');
+}
+
+function knownTarget(target: AgentTarget): InstallTarget {
+  if (target === 'claude') {
+    return { label: 'Claude Code', skillsDir: join(homedir(), '.claude', 'skills') };
+  }
+  return { label: 'Codex', skillsDir: join(homedir(), '.agents', 'skills') };
+}
+
+function parseTargets(raw: string, lang: 'zh' | 'en'): AgentTarget[] {
+  const parts = raw.split(',').map((part) => part.trim()).filter(Boolean);
+  if (parts.length === 0 || parts.includes('auto')) return ['codex'];
+  if (parts.includes('all')) return ['codex', 'claude'];
+  const out: AgentTarget[] = [];
+  for (const part of parts) {
+    if (part !== 'codex' && part !== 'claude') {
+      throw new Error(tCli('cli.install.unknown_target', lang, { target: part }));
+    }
+    out.push(part);
+  }
+  return [...new Set(out)];
+}
+
+function autoTargets(): AgentTarget[] {
+  const targets: AgentTarget[] = ['codex'];
+  if (existsSync(join(homedir(), '.claude'))) targets.push('claude');
+  return targets;
+}
+
+function resolveInstallTargets(params: { to: string; dest?: string; lang: 'zh' | 'en' }): InstallTarget[] {
+  if (params.dest) {
+    return [{ label: 'custom', skillsDir: resolve(params.dest) }];
+  }
+
+  const targets = params.to === 'auto' ? autoTargets() : parseTargets(params.to, params.lang);
+  const seen = new Set<string>();
+  return targets
+    .map(knownTarget)
+    .filter((target) => {
+      const key = resolve(target.skillsDir);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
+function installOmkAgentSkill(params: {
+  sourceDir: string;
+  target: InstallTarget;
+  force: boolean;
+  dryRun: boolean;
+  lang: 'zh' | 'en';
+}): string {
+  if (!existsSync(params.sourceDir)) {
+    throw new Error(tCli('cli.install.asset_missing', params.lang, { path: params.sourceDir }));
+  }
+
+  const targetDir = join(params.target.skillsDir, 'omk');
+  if (params.dryRun) {
+    console.log(tCli('cli.install.plan', params.lang, { path: targetDir }));
+    return targetDir;
+  }
+
+  if (existsSync(targetDir) && !params.force) {
+    throw new Error(tCli('cli.install.target_exists', params.lang, { path: targetDir }));
+  }
+
+  mkdirSync(params.target.skillsDir, { recursive: true });
+  rmSync(targetDir, { recursive: true, force: true });
+  cpSync(params.sourceDir, targetDir, { recursive: true });
+  console.log(tCli('cli.install.installed', params.lang, { path: targetDir }));
+  return targetDir;
+}
+
+export default class Install extends BaseCommand {
+  static description = bilingual({
+    zh: '安装或接管 knowledge input（MVP 支持内置 omk Agent Skill）。',
+    en: 'Install or adopt a knowledge input (MVP supports the built-in omk Agent Skill).',
+  });
+
+  static examples = [
+    {
+      description: bilingual({
+        zh: '安装 omk 官方 Agent Skill 到默认 agent 目录',
+        en: 'Install the official omk Agent Skill into the default agent directory',
+      }),
+      command: '<%= config.bin %> install omk-agent-skill',
+    },
+    {
+      description: bilingual({
+        zh: '同时安装到 Codex 与 Claude Code',
+        en: 'Install into both Codex and Claude Code',
+      }),
+      command: '<%= config.bin %> install omk-agent-skill --to all',
+    },
+    {
+      description: bilingual({
+        zh: '安装到自定义 skill 根目录',
+        en: 'Install into a custom skill root',
+      }),
+      command: '<%= config.bin %> install omk-agent-skill --dest ~/.my-agent/skills',
+    },
+  ];
+
+  static args = {
+    input: Args.string({
+      description: bilingual({
+        zh: '要安装的 knowledge input。当前支持内置 id：omk-agent-skill。',
+        en: 'Knowledge input to install. Currently supports built-in id: omk-agent-skill.',
+      }),
+      required: true,
+    }),
+  };
+
+  static flags = {
+    lang: LANG_FLAG,
+    to: Flags.string({
+      description: bilingual({
+        zh: '安装目标：auto / codex / claude / all，默认 auto。',
+        en: 'Install target: auto / codex / claude / all. Default auto.',
+      }),
+      default: 'auto',
+    }),
+    dest: Flags.string({
+      description: bilingual({
+        zh: '自定义 skill 根目录；omk 会安装到 <dir>/omk。',
+        en: 'Custom skill root; installs into <dir>/omk.',
+      }),
+    }),
+    force: Flags.boolean({
+      description: bilingual({
+        zh: '覆盖已存在的 omk Agent Skill。',
+        en: 'Overwrite an existing omk Agent Skill.',
+      }),
+      default: false,
+    }),
+    'dry-run': Flags.boolean({
+      description: bilingual({
+        zh: '只打印安装目标，不写文件。',
+        en: 'Print install targets without writing files.',
+      }),
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(Install);
+    const lang = this.lang;
+
+    await this.runWithCliExit(async () => {
+      if (args.input !== BUILTIN_OMK_AGENT_SKILL_ID) {
+        throw new Error(tCli('cli.install.unknown_input', lang, { input: args.input }));
+      }
+
+      const sourceDir = packagedOmkAgentSkillDir();
+      const targets = resolveInstallTargets({ to: flags.to, dest: flags.dest, lang });
+      for (const target of targets) {
+        installOmkAgentSkill({
+          sourceDir,
+          target,
+          force: flags.force,
+          dryRun: flags['dry-run'],
+          lang,
+        });
+      }
+      if (!flags['dry-run']) console.log(tCli('cli.install.next_hint', lang));
+    });
+  }
+}

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -30,7 +30,7 @@ function knownTarget(target: AgentTarget): InstallTarget {
 
 function parseTargets(raw: string, lang: 'zh' | 'en'): AgentTarget[] {
   const parts = raw.split(',').map((part) => part.trim()).filter(Boolean);
-  if (parts.length === 0 || parts.includes('auto')) return ['codex'];
+  if (parts.length === 0 || parts.includes('auto')) return autoTargets();
   if (parts.includes('all')) return ['codex', 'claude'];
   const out: AgentTarget[] = [];
   for (const part of parts) {
@@ -43,8 +43,10 @@ function parseTargets(raw: string, lang: 'zh' | 'en'): AgentTarget[] {
 }
 
 function autoTargets(): AgentTarget[] {
-  const targets: AgentTarget[] = ['codex'];
-  if (existsSync(join(homedir(), '.claude'))) targets.push('claude');
+  const home = homedir();
+  const targets: AgentTarget[] = [];
+  if (existsSync(join(home, '.agents')) || existsSync(join(home, '.codex'))) targets.push('codex');
+  if (existsSync(join(home, '.claude'))) targets.push('claude');
   return targets;
 }
 
@@ -54,6 +56,9 @@ function resolveInstallTargets(params: { to: string; dest?: string; lang: 'zh' |
   }
 
   const targets = params.to === 'auto' ? autoTargets() : parseTargets(params.to, params.lang);
+  if (targets.length === 0) {
+    throw new Error(tCli('cli.install.no_detected_targets', params.lang));
+  }
   const seen = new Set<string>();
   return targets
     .map(knownTarget)
@@ -95,22 +100,22 @@ function installOmkAgentSkill(params: {
 
 export default class Install extends BaseCommand {
   static description = bilingual({
-    zh: '安装或接管 knowledge input（MVP 支持内置 omk Agent Skill）。',
-    en: 'Install or adopt a knowledge input (MVP supports the built-in omk Agent Skill).',
+    zh: '安装或接管 knowledge input（MVP 支持内置 omk Agent Skill，默认写入本机已检测 agent 目标）。',
+    en: 'Install or adopt a knowledge input (MVP supports the built-in omk Agent Skill, defaulting to detected local agent targets).',
   });
 
   static examples = [
     {
       description: bilingual({
-        zh: '安装 omk 官方 Agent Skill 到默认 agent 目录',
-        en: 'Install the official omk Agent Skill into the default agent directory',
+        zh: '安装 omk 官方 Agent Skill 到默认本机目标',
+        en: 'Install the official omk Agent Skill into default local targets',
       }),
       command: '<%= config.bin %> install omk-agent-skill',
     },
     {
       description: bilingual({
-        zh: '同时安装到 Codex 与 Claude Code',
-        en: 'Install into both Codex and Claude Code',
+        zh: '强制安装到当前 omk 已知的所有目标',
+        en: 'Install into every target currently known to omk',
       }),
       command: '<%= config.bin %> install omk-agent-skill --to all',
     },
@@ -137,8 +142,8 @@ export default class Install extends BaseCommand {
     lang: LANG_FLAG,
     to: Flags.string({
       description: bilingual({
-        zh: '安装目标：auto / codex / claude / all，默认 auto。',
-        en: 'Install target: auto / codex / claude / all. Default auto.',
+        zh: '安装目标：auto（默认，本机已检测目标） / codex / claude / all。',
+        en: 'Install target: auto (default, detected local targets) / codex / claude / all.',
       }),
       default: 'auto',
     }),

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, rmSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -16,22 +16,57 @@ interface InstallTarget {
   skillsDir: string;
 }
 
+interface AgentTargetSpec {
+  label: string;
+  skillsDir: (home: string) => string;
+  detectDirs: (home: string) => string[];
+}
+
+const TARGET_ORDER: AgentTarget[] = ['codex', 'claude'];
+
+const TARGET_SPECS: Record<AgentTarget, AgentTargetSpec> = {
+  codex: {
+    label: 'Codex/AGENTS',
+    skillsDir: (home) => join(home, '.agents', 'skills'),
+    detectDirs: (home) => [join(home, '.agents'), join(home, '.codex')],
+  },
+  claude: {
+    label: 'Claude Code',
+    skillsDir: (home) => join(home, '.claude', 'skills'),
+    detectDirs: (home) => [join(home, '.claude')],
+  },
+};
+
 function packagedOmkAgentSkillDir(): string {
   const here = dirname(fileURLToPath(import.meta.url));
   return resolve(here, '..', '..', 'assets', 'agent-skills', 'omk');
 }
 
 function knownTarget(target: AgentTarget): InstallTarget {
-  if (target === 'claude') {
-    return { label: 'Claude Code', skillsDir: join(homedir(), '.claude', 'skills') };
+  const home = homedir();
+  const spec = TARGET_SPECS[target];
+  return { label: spec.label, skillsDir: spec.skillsDir(home) };
+}
+
+function directoryExists(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
   }
-  return { label: 'Codex', skillsDir: join(homedir(), '.agents', 'skills') };
 }
 
 function parseTargets(raw: string, lang: 'zh' | 'en'): AgentTarget[] {
-  const parts = raw.split(',').map((part) => part.trim()).filter(Boolean);
-  if (parts.length === 0 || parts.includes('auto')) return autoTargets();
-  if (parts.includes('all')) return ['codex', 'claude'];
+  const parts = [...new Set(raw.split(',').map((part) => part.trim()).filter(Boolean))];
+  if (parts.length === 0) return autoTargets();
+  if (parts.includes('auto')) {
+    if (parts.length > 1) throw new Error(tCli('cli.install.invalid_target_combo', lang, { target: raw }));
+    return autoTargets();
+  }
+  if (parts.includes('all')) {
+    if (parts.length > 1) throw new Error(tCli('cli.install.invalid_target_combo', lang, { target: raw }));
+    return TARGET_ORDER;
+  }
   const out: AgentTarget[] = [];
   for (const part of parts) {
     if (part !== 'codex' && part !== 'claude') {
@@ -39,15 +74,12 @@ function parseTargets(raw: string, lang: 'zh' | 'en'): AgentTarget[] {
     }
     out.push(part);
   }
-  return [...new Set(out)];
+  return out;
 }
 
 function autoTargets(): AgentTarget[] {
   const home = homedir();
-  const targets: AgentTarget[] = [];
-  if (existsSync(join(home, '.agents')) || existsSync(join(home, '.codex'))) targets.push('codex');
-  if (existsSync(join(home, '.claude'))) targets.push('claude');
-  return targets;
+  return TARGET_ORDER.filter((target) => TARGET_SPECS[target].detectDirs(home).some(directoryExists));
 }
 
 function resolveInstallTargets(params: { to: string; dest?: string; lang: 'zh' | 'en' }): InstallTarget[] {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { getCliLang, parseLangFromArgv } from './lib/i18n.js';
-import { checkUpdate } from './lib/update-check.js';
 import { CliExit } from './lib/cli-exit.js';
 
 // CLI 入口:lang / 版本提醒等共享前置逻辑跑完,把控制权交给 oclif dispatcher。
@@ -18,6 +17,7 @@ function isShortPath(argv: readonly string[]): boolean {
 async function main(): Promise<void> {
   const lang = getCliLang(parseLangFromArgv(process.argv));
   if (!isShortPath(process.argv)) {
+    const { checkUpdate } = await import('./lib/update-check.js');
     checkUpdate(lang);
   }
 

--- a/src/cli/lib/i18n-dict.ts
+++ b/src/cli/lib/i18n-dict.ts
@@ -56,6 +56,7 @@ import { evolveDict, type EvolveMessageKey } from './i18n-dict/evolve.js';
 import { genDict, type GenMessageKey } from './i18n-dict/gen.js';
 import { helpDict, type HelpMessageKey } from './i18n-dict/help.js';
 import { initDict, type InitMessageKey } from './i18n-dict/init.js';
+import { installDict, type InstallMessageKey } from './i18n-dict/install.js';
 import { runDict, type RunMessageKey } from './i18n-dict/run.js';
 import type { CliMessage } from './i18n-dict/types.js';
 
@@ -67,6 +68,7 @@ export type CliMessageKey =
   | GenMessageKey
   | HelpMessageKey
   | InitMessageKey
+  | InstallMessageKey
   | RunMessageKey;
 
 export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
@@ -75,5 +77,6 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
   ...genDict,
   ...helpDict,
   ...initDict,
+  ...installDict,
   ...runDict,
 };

--- a/src/cli/lib/i18n-dict/install.ts
+++ b/src/cli/lib/i18n-dict/install.ts
@@ -16,8 +16,8 @@ export const installDict: Record<InstallMessageKey, CliMessage> = {
     en: 'Packaged built-in asset not found: {path}. Run yarn build first, or verify the npm package includes dist/assets/agent-skills/omk.',
   },
   'cli.install.unknown_input': {
-    zh: '当前 install MVP 只支持内置 id：omk-agent-skill。收到：{input}',
-    en: 'The install MVP currently supports only the built-in id: omk-agent-skill. Got: {input}',
+    zh: '当前 install 命令只支持内置 id：omk-agent-skill。收到：{input}',
+    en: 'The install command currently supports only the built-in id: omk-agent-skill. Got: {input}',
   },
   'cli.install.unknown_target': {
     zh: '未知安装目标：{target}。可用值：auto, codex, claude, all；或用 --dest <dir> 指定 skill 根目录。',

--- a/src/cli/lib/i18n-dict/install.ts
+++ b/src/cli/lib/i18n-dict/install.ts
@@ -1,0 +1,41 @@
+import type { CliMessage } from './types.js';
+
+export type InstallMessageKey =
+  | 'cli.install.asset_missing'
+  | 'cli.install.unknown_input'
+  | 'cli.install.unknown_target'
+  | 'cli.install.target_exists'
+  | 'cli.install.plan'
+  | 'cli.install.installed'
+  | 'cli.install.next_hint';
+
+export const installDict: Record<InstallMessageKey, CliMessage> = {
+  'cli.install.asset_missing': {
+    zh: '未找到打包内置资源：{path}。请先运行 yarn build，或确认 npm 包包含 dist/assets/agent-skills/omk。',
+    en: 'Packaged built-in asset not found: {path}. Run yarn build first, or verify the npm package includes dist/assets/agent-skills/omk.',
+  },
+  'cli.install.unknown_input': {
+    zh: '当前 install MVP 只支持内置 id：omk-agent-skill。收到：{input}',
+    en: 'The install MVP currently supports only the built-in id: omk-agent-skill. Got: {input}',
+  },
+  'cli.install.unknown_target': {
+    zh: '未知安装目标：{target}。可用值：auto, codex, claude, all；或用 --dest <dir> 指定 skill 根目录。',
+    en: 'Unknown install target: {target}. Use auto, codex, claude, all; or pass --dest <dir> for a custom skill root.',
+  },
+  'cli.install.target_exists': {
+    zh: '目标已存在：{path}。如要更新 omk Agent Skill，请加 --force。',
+    en: 'Target already exists: {path}. Pass --force to update the omk Agent Skill.',
+  },
+  'cli.install.plan': {
+    zh: '将安装 omk Agent Skill 到：{path}',
+    en: 'Will install the omk Agent Skill to: {path}',
+  },
+  'cli.install.installed': {
+    zh: '已安装 omk Agent Skill：{path}',
+    en: 'Installed omk Agent Skill: {path}',
+  },
+  'cli.install.next_hint': {
+    zh: '现在可以在 coding agent 中说「用 omk 评测这个 skill」。',
+    en: 'You can now ask your coding agent: "use omk to evaluate this skill".',
+  },
+};

--- a/src/cli/lib/i18n-dict/install.ts
+++ b/src/cli/lib/i18n-dict/install.ts
@@ -4,6 +4,7 @@ export type InstallMessageKey =
   | 'cli.install.asset_missing'
   | 'cli.install.unknown_input'
   | 'cli.install.unknown_target'
+  | 'cli.install.invalid_target_combo'
   | 'cli.install.no_detected_targets'
   | 'cli.install.target_exists'
   | 'cli.install.plan'
@@ -22,6 +23,10 @@ export const installDict: Record<InstallMessageKey, CliMessage> = {
   'cli.install.unknown_target': {
     zh: '未知安装目标：{target}。可用值：auto, codex, claude, all；或用 --dest <dir> 指定 skill 根目录。',
     en: 'Unknown install target: {target}. Use auto, codex, claude, all; or pass --dest <dir> for a custom skill root.',
+  },
+  'cli.install.invalid_target_combo': {
+    zh: '安装目标组合不合法：{target}。auto 和 all 必须单独使用；如需多个明确目标，请写 codex,claude。',
+    en: 'Invalid install target combination: {target}. auto and all must be used alone; use codex,claude for multiple explicit targets.',
   },
   'cli.install.no_detected_targets': {
     zh: '未检测到本机支持的 agent skill 目录。请用 --to codex / --to claude / --to all 明确目标，或用 --dest <dir> 指定 skill 根目录。',

--- a/src/cli/lib/i18n-dict/install.ts
+++ b/src/cli/lib/i18n-dict/install.ts
@@ -4,6 +4,7 @@ export type InstallMessageKey =
   | 'cli.install.asset_missing'
   | 'cli.install.unknown_input'
   | 'cli.install.unknown_target'
+  | 'cli.install.no_detected_targets'
   | 'cli.install.target_exists'
   | 'cli.install.plan'
   | 'cli.install.installed'
@@ -21,6 +22,10 @@ export const installDict: Record<InstallMessageKey, CliMessage> = {
   'cli.install.unknown_target': {
     zh: '未知安装目标：{target}。可用值：auto, codex, claude, all；或用 --dest <dir> 指定 skill 根目录。',
     en: 'Unknown install target: {target}. Use auto, codex, claude, all; or pass --dest <dir> for a custom skill root.',
+  },
+  'cli.install.no_detected_targets': {
+    zh: '未检测到本机支持的 agent skill 目录。请用 --to codex / --to claude / --to all 明确目标，或用 --dest <dir> 指定 skill 根目录。',
+    en: 'No supported local agent skill directory was detected. Pass --to codex / --to claude / --to all, or pass --dest <dir> for a custom skill root.',
   },
   'cli.install.target_exists': {
     zh: '目标已存在：{path}。如要更新 omk Agent Skill，请加 --force。',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -314,7 +314,7 @@ describe('CLI', () => {
 
   it('Claude Code SKILL manifest uses current product commands', async () => {
     const body = await readFile(join(PROJECT_ROOT, '.agents', 'skills', 'omk', 'SKILL.md'), 'utf8');
-    assert.ok(body.includes('argument-hint: "<doctor|eval|evolve|init|observe|sample|studio> [options]"'));
+    assert.ok(body.includes('argument-hint: "<doctor|eval|evolve|init|install|observe|sample|studio> [options]"'));
     assert.ok(body.includes('omk eval --batch'));
     assert.ok(body.includes('omk sample --batch'));
     assert.ok(body.includes('omk evolve'));

--- a/test/cli/oclif-install.test.ts
+++ b/test/cli/oclif-install.test.ts
@@ -78,6 +78,58 @@ describe('oclif install', () => {
     }
   });
 
+  it('auto detects AGENTS root directories, not same-named files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-auto-file-'));
+    try {
+      const home = join(dir, 'home');
+      await mkdir(home, { recursive: true });
+      await writeFile(join(home, '.codex'), 'not a directory');
+      try {
+        await execFileAsync('node', [CLI, 'install', 'omk-agent-skill'], {
+          env: cliEnv({ HOME: home }),
+        });
+        assert.fail('expected non-zero exit');
+      } catch (err) {
+        const e = err as ExecError;
+        assert.notEqual(e.code, 0);
+        assert.ok((e.stdout + e.stderr).includes('未检测到本机支持的 agent skill 目录'));
+      }
+      assert.ok(!existsSync(join(home, '.agents')), 'same-named file detection must not create AGENTS root');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('supports explicit multiple targets', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-explicit-multi-'));
+    try {
+      const home = join(dir, 'home');
+      await mkdir(home, { recursive: true });
+      const { stdout } = await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--to', 'codex,claude'], {
+        env: cliEnv({ HOME: home }),
+      });
+      assert.equal((stdout.match(/已安装 omk Agent Skill/g) ?? []).length, 2, `stdout should list two installs:\n${stdout}`);
+      assert.ok(existsSync(join(home, '.agents', 'skills', 'omk', 'SKILL.md')), 'Codex/AGENTS target not installed');
+      assert.ok(existsSync(join(home, '.claude', 'skills', 'omk', 'SKILL.md')), 'Claude Code target not installed');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects mixed auto/all target combinations', async () => {
+    for (const to of ['auto,codex', 'all,claude']) {
+      try {
+        await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--to', to]);
+        assert.fail(`expected non-zero exit for --to ${to}`);
+      } catch (err) {
+        const e = err as ExecError;
+        assert.notEqual(e.code, 0);
+        const out = e.stdout + e.stderr;
+        assert.ok(out.includes('安装目标组合不合法'), `missing invalid combo message for ${to}:\n${out}`);
+      }
+    }
+  });
+
   it('auto fails when no supported local target is detected', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'omk-install-auto-missing-'));
     try {

--- a/test/cli/oclif-install.test.ts
+++ b/test/cli/oclif-install.test.ts
@@ -1,0 +1,116 @@
+/**
+ * oclif 路径 install 命令验收。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { promisify } from 'node:util';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const CLI = join(PROJECT_ROOT, 'dist', 'cli', 'index.js');
+
+interface ExecError extends Error {
+  code?: number;
+  stdout: string;
+  stderr: string;
+}
+
+describe('oclif install', () => {
+  it('--help 默认 zh', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'install', '--help']);
+    assert.ok(stdout.includes('安装或接管 knowledge input'), `stdout missing zh description:\n${stdout}`);
+    assert.ok(stdout.includes('omk-agent-skill'), 'stdout missing builtin id');
+  });
+
+  it('--help --lang en', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'install', '--help', '--lang', 'en']);
+    assert.ok(stdout.includes('Install or adopt a knowledge input'), 'stdout should contain en description');
+  });
+
+  it('unknown flag → exit 2', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--bogus']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2);
+    }
+  });
+
+  it('installs omk-agent-skill into a custom skill root', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-'));
+    try {
+      const dest = join(dir, 'skills-root');
+      const { stdout } = await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--dest', dest]);
+      assert.ok(stdout.includes('已安装 omk Agent Skill'), `stdout missing install msg:\n${stdout}`);
+      assert.ok(existsSync(join(dest, 'omk', 'SKILL.md')), 'SKILL.md not installed');
+      assert.ok(existsSync(join(dest, 'omk', 'references', 'commands.md')), 'commands reference not installed');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to overwrite existing install without --force', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-exists-'));
+    try {
+      const dest = join(dir, 'skills-root');
+      await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--dest', dest]);
+      try {
+        await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--dest', dest]);
+        assert.fail('expected non-zero exit');
+      } catch (err) {
+        const e = err as ExecError;
+        assert.notEqual(e.code, 0);
+        assert.ok((e.stdout + e.stderr).includes('--force'), 'error should mention --force');
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('--force overwrites existing install', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-force-'));
+    try {
+      const dest = join(dir, 'skills-root');
+      const skillMd = join(dest, 'omk', 'SKILL.md');
+      await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--dest', dest]);
+      await writeFile(skillMd, 'local edit');
+      await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--dest', dest, '--force']);
+      const body = await readFile(skillMd, 'utf8');
+      assert.ok(body.includes('name: omk'), 'force install should restore packaged skill');
+      assert.ok(!body.includes('local edit'), 'force install should overwrite local edit');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('--dry-run prints target and does not write files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-dry-'));
+    try {
+      const dest = join(dir, 'skills-root');
+      const { stdout } = await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--dest', dest, '--dry-run']);
+      assert.ok(stdout.includes('将安装 omk Agent Skill 到'), `stdout missing plan msg:\n${stdout}`);
+      assert.ok(!existsSync(join(dest, 'omk')), 'dry-run must not create target');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('unknown input exits non-zero', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'install', 'other-skill']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.notEqual(e.code, 0);
+      assert.ok((e.stdout + e.stderr).includes('omk-agent-skill'), 'error should mention supported builtin id');
+    }
+  });
+});

--- a/test/cli/oclif-install.test.ts
+++ b/test/cli/oclif-install.test.ts
@@ -4,7 +4,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { promisify } from 'node:util';
 import { join, dirname } from 'node:path';
@@ -20,6 +20,10 @@ interface ExecError extends Error {
   code?: number;
   stdout: string;
   stderr: string;
+}
+
+function cliEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { ...process.env, OMK_SKIP_UPDATE_CHECK: '1', ...extra };
 }
 
 describe('oclif install', () => {
@@ -52,6 +56,47 @@ describe('oclif install', () => {
       assert.ok(stdout.includes('已安装 omk Agent Skill'), `stdout missing install msg:\n${stdout}`);
       assert.ok(existsSync(join(dest, 'omk', 'SKILL.md')), 'SKILL.md not installed');
       assert.ok(existsSync(join(dest, 'omk', 'references', 'commands.md')), 'commands reference not installed');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('auto installs into detected local supported targets', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-auto-'));
+    try {
+      const home = join(dir, 'home');
+      await mkdir(join(home, '.codex'), { recursive: true });
+      await mkdir(join(home, '.claude'), { recursive: true });
+      const { stdout } = await execFileAsync('node', [CLI, 'install', 'omk-agent-skill'], {
+        env: cliEnv({ HOME: home }),
+      });
+      assert.equal((stdout.match(/已安装 omk Agent Skill/g) ?? []).length, 2, `stdout should list two installs:\n${stdout}`);
+      assert.ok(existsSync(join(home, '.agents', 'skills', 'omk', 'SKILL.md')), 'Codex/AGENTS target not installed');
+      assert.ok(existsSync(join(home, '.claude', 'skills', 'omk', 'SKILL.md')), 'Claude Code target not installed');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('auto fails when no supported local target is detected', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-auto-missing-'));
+    try {
+      const home = join(dir, 'home');
+      await mkdir(home, { recursive: true });
+      try {
+        await execFileAsync('node', [CLI, 'install', 'omk-agent-skill'], {
+          env: cliEnv({ HOME: home }),
+        });
+        assert.fail('expected non-zero exit');
+      } catch (err) {
+        const e = err as ExecError;
+        assert.notEqual(e.code, 0);
+        const out = e.stdout + e.stderr;
+        assert.ok(out.includes('未检测到本机支持的 agent skill 目录'), `missing detected-target hint:\n${out}`);
+        assert.ok(out.includes('--to codex') && out.includes('--dest'), `missing explicit target guidance:\n${out}`);
+      }
+      assert.ok(!existsSync(join(home, '.agents')), 'auto must not create AGENTS root without detection');
+      assert.ok(!existsSync(join(home, '.claude')), 'auto must not create Claude root without detection');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/cli/oclif-install.test.ts
+++ b/test/cli/oclif-install.test.ts
@@ -29,13 +29,13 @@ function cliEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 describe('oclif install', () => {
   it('--help 默认 zh', async () => {
     const { stdout } = await execFileAsync('node', [CLI, 'install', '--help']);
-    assert.ok(stdout.includes('安装或接管 knowledge input'), `stdout missing zh description:\n${stdout}`);
+    assert.ok(stdout.includes('安装 omk 官方 Agent Skill'), `stdout missing zh description:\n${stdout}`);
     assert.ok(stdout.includes('omk-agent-skill'), 'stdout missing builtin id');
   });
 
   it('--help --lang en', async () => {
     const { stdout } = await execFileAsync('node', [CLI, 'install', '--help', '--lang', 'en']);
-    assert.ok(stdout.includes('Install or adopt a knowledge input'), 'stdout should contain en description');
+    assert.ok(stdout.includes('Install the official omk Agent Skill'), 'stdout should contain en description');
   });
 
   it('unknown flag → exit 2', async () => {
@@ -54,8 +54,22 @@ describe('oclif install', () => {
       const dest = join(dir, 'skills-root');
       const { stdout } = await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--dest', dest]);
       assert.ok(stdout.includes('已安装 omk Agent Skill'), `stdout missing install msg:\n${stdout}`);
+      assert.ok(stdout.includes('现在可以在 coding agent 中说'), `stdout missing next hint:\n${stdout}`);
       assert.ok(existsSync(join(dest, 'omk', 'SKILL.md')), 'SKILL.md not installed');
       assert.ok(existsSync(join(dest, 'omk', 'references', 'commands.md')), 'commands reference not installed');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prints runtime messages in English', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-en-'));
+    try {
+      const dest = join(dir, 'skills-root');
+      const { stdout } = await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--dest', dest, '--lang', 'en']);
+      assert.ok(stdout.includes('Installed omk Agent Skill'), `stdout missing en install msg:\n${stdout}`);
+      assert.ok(stdout.includes('You can now ask your coding agent'), `stdout missing en next hint:\n${stdout}`);
+      assert.ok(existsSync(join(dest, 'omk', 'SKILL.md')), 'SKILL.md not installed');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -116,6 +130,53 @@ describe('oclif install', () => {
     }
   });
 
+  it('supports --to all without detected targets', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-all-'));
+    try {
+      const home = join(dir, 'home');
+      await mkdir(home, { recursive: true });
+      const { stdout } = await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--to', 'all'], {
+        env: cliEnv({ HOME: home }),
+      });
+      assert.equal((stdout.match(/已安装 omk Agent Skill/g) ?? []).length, 2, `stdout should list two installs:\n${stdout}`);
+      assert.ok(existsSync(join(home, '.agents', 'skills', 'omk', 'SKILL.md')), 'Codex/AGENTS target not installed');
+      assert.ok(existsSync(join(home, '.claude', 'skills', 'omk', 'SKILL.md')), 'Claude Code target not installed');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('supports explicit single targets', async () => {
+    for (const target of ['codex', 'claude'] as const) {
+      const dir = await mkdtemp(join(tmpdir(), `omk-install-${target}-`));
+      try {
+        const home = join(dir, 'home');
+        await mkdir(home, { recursive: true });
+        const { stdout } = await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--to', target], {
+          env: cliEnv({ HOME: home }),
+        });
+        assert.equal((stdout.match(/已安装 omk Agent Skill/g) ?? []).length, 1, `stdout should list one install:\n${stdout}`);
+        const installed = target === 'codex'
+          ? join(home, '.agents', 'skills', 'omk', 'SKILL.md')
+          : join(home, '.claude', 'skills', 'omk', 'SKILL.md');
+        assert.ok(existsSync(installed), `${target} target not installed`);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('rejects unknown install targets', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--to', 'gemini']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.notEqual(e.code, 0);
+      assert.ok((e.stdout + e.stderr).includes('未知安装目标'), 'error should mention unknown install target');
+    }
+  });
+
   it('rejects mixed auto/all target combinations', async () => {
     for (const to of ['auto,codex', 'all,claude']) {
       try {
@@ -167,6 +228,32 @@ describe('oclif install', () => {
         assert.notEqual(e.code, 0);
         assert.ok((e.stdout + e.stderr).includes('--force'), 'error should mention --force');
       }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('preflights existing targets before multi-target install', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-preflight-'));
+    try {
+      const home = join(dir, 'home');
+      const claudeSkill = join(home, '.claude', 'skills', 'omk');
+      await mkdir(claudeSkill, { recursive: true });
+      await writeFile(join(claudeSkill, 'SKILL.md'), 'existing claude install');
+
+      try {
+        await execFileAsync('node', [CLI, 'install', 'omk-agent-skill', '--to', 'codex,claude'], {
+          env: cliEnv({ HOME: home }),
+        });
+        assert.fail('expected non-zero exit');
+      } catch (err) {
+        const e = err as ExecError;
+        assert.notEqual(e.code, 0);
+        assert.ok((e.stdout + e.stderr).includes('--force'), 'error should mention --force');
+      }
+
+      assert.ok(!existsSync(join(home, '.agents')), 'preflight failure must not partially install Codex target');
+      assert.equal(await readFile(join(claudeSkill, 'SKILL.md'), 'utf8'), 'existing claude install');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/cli/oclif-startup.test.ts
+++ b/test/cli/oclif-startup.test.ts
@@ -26,8 +26,12 @@ interface ExecError extends Error {
  * --help 会在网络 I/O 之前 resolve;反之会被拖到 ~3s timeout。
  * 阈值给得宽松(800ms),既能挡住 1100ms 回归又不被偶发 GC / IO 抖动误判。
  */
-const HOSTILE_ENV = {
-  ...process.env,
+const HOSTILE_ENV: NodeJS.ProcessEnv = {
+  PATH: process.env.PATH,
+  HOME: process.env.HOME,
+  USER: process.env.USER,
+  TMPDIR: process.env.TMPDIR,
+  LANG: process.env.LANG,
   npm_config_registry: 'http://127.0.0.1:1/',
 };
 const STARTUP_BUDGET_MS = 800;


### PR DESCRIPTION
## 用户影响

`npm i -g oh-my-knowledge` 后，用户可以直接运行 `omk install omk-agent-skill` 安装 omk 官方 Agent Skill，无需手工复制仓库里的 `.agents/skills/omk` 目录。

默认只安装到本机已检测到、且 omk 当前明确支持的 skill 目录：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。需要强制写入当前 omk 已知的全部目标时可以用 `--to all`，需要明确单一目标时可以用 `--to codex|claude`，需要自定义 skill root 时可以用 `--dest`。

官网 quickstart、CLI reference、首页和文档索引都补充了 Agent Skill 安装入口，用户从 npm 包安装路径进入时也能看到下一步。

## 迁移说明

现有从仓库直接加载 `.agents/skills/omk` 的用法不变。已经手工安装过 omk Agent Skill 的用户，如需用 npm 包内置版本更新本地 skill，需要显式加 `--force`，避免误覆盖本地修改。

## 测量学说明

本 PR 不修改 Report schema、judge prompt、评分管道、统计公式或历史报告字段语义，不影响既有评测报告的可比性。

## 议题关系

Closes #208。

Refs #203：本 PR 只处理从 #203 解耦出来的 onboarding 安装简化，不关闭 #203 的长期路线讨论。

