### PR TITLE
refactor(types)!: BREAKING-SERIALIZATION 收敛 kind 判别字段

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ omk 是面向 LLM 知识输入（prompt / RAG / skill / agent）的评测与迭�
 - 不要直接在 `main` 上提交；不要再把新工作提交到 `develop`。
 - commit 格式：`type(scope): 中文 subject`。scope 用稳定模块名，如 `cli` / `i18n` / `judge` / `renderer` / `eval-core` / `eval-workflows` / `inputs` / `executors` / `server` / `analysis` / `authoring` / `grading` / `doctor` / `release` / `agents-md`（早期 git history 用过 `claude-md`，rename 后统一用 `agents-md`）。
 - 不要在给用户看的 URL 里硬编码 report server 端口；使用 `server.start()` 返回的实际 URL。
+- 裸 `kind` 留给 `ArtifactKind`（skill / prompt / agent / workflow）。其它判别字段用限定名（`reportKind` / `eventKind` / `runtimeKind` / `standardKind`）；已序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 是可比性不变量，冻结不改，要改走 schema migration。细节见 `docs/specs/terminology-spec.md` §5.4，CI 有 `test/scripts/kind-semantics-guard.test.ts` 拦新裸 `kind`。
 
 ## 测量学不变量
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ omk 是面向 LLM 知识输入（prompt / RAG / skill / agent）的评测与迭�
 - 不要直接在 `main` 上提交；不要再把新工作提交到 `develop`。
 - commit 格式：`type(scope): 中文 subject`。scope 用稳定模块名，如 `cli` / `i18n` / `judge` / `renderer` / `eval-core` / `eval-workflows` / `inputs` / `executors` / `server` / `analysis` / `authoring` / `grading` / `doctor` / `release` / `agents-md`（早期 git history 用过 `claude-md`，rename 后统一用 `agents-md`）。
 - 不要在给用户看的 URL 里硬编码 report server 端口；使用 `server.start()` 返回的实际 URL。
-- 裸 `kind` 留给 `ArtifactKind`（skill / prompt / agent / workflow）。其它判别字段用限定名（`reportKind` / `eventKind` / `runtimeKind` / `standardKind`）；已序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 是可比性不变量，冻结不改，要改走 schema migration。细节见 `docs/specs/terminology-spec.md` §5.4，CI 有 `test/scripts/kind-semantics-guard.test.ts` 拦新裸 `kind`。
+- 裸 `kind` 留给 `ArtifactKind`（skill / prompt / agent / workflow）。其它判别字段用限定名（`reportKind` / `eventKind` / `runtimeKind` / `standardKind`）；已序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 是落盘字段名，改名会破坏读取已有文件、要走数据 / schema 迁移（序列化向后兼容，非统计可比性），本轮冻结。细节见 `docs/specs/terminology-spec.md` §5.4，CI 有 `test/scripts/kind-semantics-guard.test.ts` 拦新裸 `kind`。
 
 ## 测量学不变量
 

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -314,7 +314,7 @@ Rules:
 
 In omk's product vocabulary, an unqualified `kind` means a knowledge-artifact kind (`Artifact.kind: ArtifactKind` — `skill` / `prompt` / `agent` / `workflow`; `baseline` is the eval-only control role). Command flags follow suit: a `--kind` flag means an `ArtifactKind`, never a platform target, report type, or observe event type.
 
-For new structures and non-persisted internal discriminants, every other discriminant carries a qualified name, never a bare `kind` (persisted fields are frozen; see caveats below):
+Except for existing discriminants already persisted into report / observe / doctor / diagnosis JSON, new or safely renamable discriminants should not use bare `kind`; use a qualified name instead:
 
 - `report.kind` → `reportKind` / `documentKind`
 - `event.kind` → `eventKind`

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -314,7 +314,7 @@ Rules:
 
 In omk's product vocabulary, an unqualified `kind` means a knowledge-artifact kind (`Artifact.kind: ArtifactKind` — `skill` / `prompt` / `agent` / `workflow`; `baseline` is the eval-only control role). Command flags follow suit: a `--kind` flag means an `ArtifactKind`, never a platform target, report type, or observe event type.
 
-Every other discriminant carries a qualified name, never a bare `kind`:
+For new structures and non-persisted internal discriminants, every other discriminant carries a qualified name, never a bare `kind` (persisted fields are frozen; see caveats below):
 
 - `report.kind` → `reportKind` / `documentKind`
 - `event.kind` → `eventKind`

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -310,6 +310,22 @@ Rules:
 - Experiment role: `control` / `treatment` (not `baseline` / `experiment`)
 - Runtime environment: `runtime context` / `cwd`
 
+### 4. Bare `kind` defaults to `ArtifactKind`
+
+In omk's product vocabulary, an unqualified `kind` means a knowledge-artifact kind (`Artifact.kind: ArtifactKind` — `skill` / `prompt` / `agent` / `workflow`; `baseline` is the eval-only control role). Command flags follow suit: a `--kind` flag means an `ArtifactKind`, never a platform target, report type, or observe event type.
+
+Every other discriminant carries a qualified name, never a bare `kind`:
+
+- `report.kind` → `reportKind` / `documentKind`
+- `event.kind` → `eventKind`
+- `executorRuntime.kind` → `runtimeKind`
+- `standard.kind` → `standardKind`
+
+Two caveats:
+
+- **Persisted discriminants are frozen.** Any `kind` already serialized into a report / observe / doctor / diagnosis JSON file is a comparability invariant and is not renamed in place; changing one requires a dedicated schema migration with the comparability impact called out (`BREAKING-COMPARABILITY` when it affects report comparability). New code reserves bare `kind` for `ArtifactKind` from the start.
+- Renaming internal non-persisted fields is progressive — done opportunistically when touching that code, not as a big-bang sweep. A CI guard freezes the current set of bare-`kind` declaration sites so new unqualified ones cannot slip in.
+
 ## 6. Term mapping
 
 | Old term | New standard term | Note |

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -323,7 +323,7 @@ Except for existing discriminants already persisted into report / observe / doct
 
 Two caveats:
 
-- **Persisted discriminants are frozen.** Any `kind` already serialized into a report / observe / doctor / diagnosis JSON file is a comparability invariant and is not renamed in place; changing one requires a dedicated schema migration with the comparability impact called out (`BREAKING-COMPARABILITY` when it affects report comparability). New code reserves bare `kind` for `ArtifactKind` from the start.
+- **Persisted discriminants are frozen.** Any `kind` already serialized into a report / observe / doctor / diagnosis JSON file is a stored field name: renaming it would break deserializing existing on-disk files, so it needs a dedicated data / schema migration (not done here). This is serialization back-compat, not statistical comparability — renaming the field changes no measurement number. (`report.kind` additionally sits in the Report-schema invariant list, so treat any change there with the usual schema care.) New code reserves bare `kind` for `ArtifactKind` from the start.
 - Renaming internal non-persisted fields is progressive — done opportunistically when touching that code, not as a big-bang sweep. A CI guard freezes the current set of bare-`kind` declaration sites so new unqualified ones cannot slip in.
 
 ## 6. Term mapping

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -310,11 +310,11 @@ Rules:
 - Experiment role: `control` / `treatment` (not `baseline` / `experiment`)
 - Runtime environment: `runtime context` / `cwd`
 
-### 4. Bare `kind` defaults to `ArtifactKind`
+### 4. Reserve bare `kind` for `ArtifactKind`
 
-In omk's product vocabulary, an unqualified `kind` means a knowledge-artifact kind (`Artifact.kind: ArtifactKind` — `skill` / `prompt` / `agent` / `workflow`; `baseline` is the eval-only control role). Command flags follow suit: a `--kind` flag means an `ArtifactKind`, never a platform target, report type, or observe event type.
+In omk's product vocabulary, bare `kind` is reserved for `Artifact.kind` (`ArtifactKind`: `baseline` / `skill` / `prompt` / `agent` / `workflow`). `baseline` means the empty eval artifact; experiment role still comes from `control` / `treatment`. CLI design follows the same rule: a future `--kind` flag should mean artifact kind, not install target, report type, or observe event type.
 
-Except for existing discriminants already persisted into report / observe / doctor / diagnosis JSON, new or safely renamable discriminants should not use bare `kind`; use a qualified name instead:
+For other discriminants, use a qualified name when the field is new or safe to rename. Existing persisted `kind` fields stay as-is unless a dedicated migration changes them:
 
 - `report.kind` → `reportKind` / `documentKind`
 - `event.kind` → `eventKind`
@@ -323,7 +323,7 @@ Except for existing discriminants already persisted into report / observe / doct
 
 Two caveats:
 
-- **Persisted discriminants are frozen.** Any `kind` already serialized into a report / observe / doctor / diagnosis JSON file is a stored field name: renaming it would break deserializing existing on-disk files, so it needs a dedicated data / schema migration (not done here). This is serialization back-compat, not statistical comparability — renaming the field changes no measurement number. (`report.kind` additionally sits in the Report-schema invariant list, so treat any change there with the usual schema care.) New code reserves bare `kind` for `ArtifactKind` from the start.
+- **Persisted discriminants are frozen.** Any `kind` already serialized into a report / observe / doctor / diagnosis JSON file is a stored field name: renaming it would break deserializing existing on-disk files, so it needs a dedicated data / schema migration (not done here). This is serialization back-compat, not statistical comparability — renaming the field changes no measurement number. (`report.kind` additionally sits in the Report-schema invariant list, so treat any change there with the usual schema care.)
 - Renaming internal non-persisted fields is progressive — done opportunistically when touching that code, not as a big-bang sweep. A CI guard freezes the current set of bare-`kind` declaration sites so new unqualified ones cannot slip in.
 
 ## 6. Term mapping

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -314,7 +314,7 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 
 在 omk 的产品语义里，不带限定词的 `kind` 一律指知识 artifact 的类型（`Artifact.kind: ArtifactKind` —— `skill` / `prompt` / `agent` / `workflow`；`baseline` 是只用于 eval 的 control 角色）。命令行 flag 同理：`--kind` 表示 `ArtifactKind`，不指平台目标、report 类型或 observe event 类型。
 
-对新结构和内部非持久判别字段，其它判别字段一律用限定名，不用裸 `kind`（持久化字段冻结，见下方注意）：
+除已经落盘到 report / observe / doctor / diagnosis JSON 的既有字段外，新增或可安全改名的判别字段都不要再叫裸 `kind`，而要带限定名：
 
 - `report.kind` → `reportKind` / `documentKind`
 - `event.kind` → `eventKind`

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -314,7 +314,7 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 
 在 omk 的产品语义里，不带限定词的 `kind` 一律指知识 artifact 的类型（`Artifact.kind: ArtifactKind` —— `skill` / `prompt` / `agent` / `workflow`；`baseline` 是只用于 eval 的 control 角色）。命令行 flag 同理：`--kind` 表示 `ArtifactKind`，不指平台目标、report 类型或 observe event 类型。
 
-其它判别字段一律用限定名，不用裸 `kind`：
+对新结构和内部非持久判别字段，其它判别字段一律用限定名，不用裸 `kind`（持久化字段冻结，见下方注意）：
 
 - `report.kind` → `reportKind` / `documentKind`
 - `event.kind` → `eventKind`

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -310,11 +310,11 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 - 实验角色用 `control` / `treatment`（不用 `baseline` / `experiment`）
 - 运行环境用 `runtime context` / `cwd`
 
-### 4. 裸 `kind` 默认指 `ArtifactKind`
+### 4. 裸 `kind` 留给 `ArtifactKind`
 
-在 omk 的产品语义里，不带限定词的 `kind` 一律指知识 artifact 的类型（`Artifact.kind: ArtifactKind` —— `skill` / `prompt` / `agent` / `workflow`；`baseline` 是只用于 eval 的 control 角色）。命令行 flag 同理：`--kind` 表示 `ArtifactKind`，不指平台目标、report 类型或 observe event 类型。
+在 omk 的产品语义里，裸 `kind` 留给 `Artifact.kind`（`ArtifactKind`：`baseline` / `skill` / `prompt` / `agent` / `workflow`）。`baseline` 表示 eval 里的空 artifact；实验角色仍然看 `control` / `treatment`。命令行设计同理：未来如果出现 `--kind`，它也应该表示 artifact kind，而不是安装目标、report 类型或 observe event 类型。
 
-除已经落盘到 report / observe / doctor / diagnosis JSON 的既有字段外，新增或可安全改名的判别字段都不要再叫裸 `kind`，而要带限定名：
+其它判别字段如果是新字段，或能安全改名，就用限定名。已经落盘的既有 `kind` 字段保持原样，除非单独做 migration：
 
 - `report.kind` → `reportKind` / `documentKind`
 - `event.kind` → `eventKind`
@@ -323,7 +323,7 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 
 两条注意：
 
-- **持久化判别字段冻结。** 任何已经序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 都是落盘格式里的字段名：改名会破坏反序列化磁盘上已有的文件，所以要单独走数据 / schema 迁移（本轮不做）。这是序列化向后兼容，不是统计可比性 —— 改字段名不改任何测量数字。（`report.kind` 另外还在 Report schema 不变量清单里，改它按常规 schema 谨慎处理。）新代码从一开始就把裸 `kind` 留给 `ArtifactKind`。
+- **持久化判别字段冻结。** 任何已经序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 都是落盘格式里的字段名：改名会破坏反序列化磁盘上已有的文件，所以要单独走数据 / schema 迁移（本轮不做）。这是序列化向后兼容，不是统计可比性 —— 改字段名不改任何测量数字。（`report.kind` 另外还在 Report schema 不变量清单里，改它按常规 schema 谨慎处理。）
 - 内部非持久字段的改名是渐进式的 —— 改到那块代码时顺手做，不搞一次性大扫除。一个 CI 护栏冻结当前裸 `kind` 声明点的集合，防止新的不加限定的 `kind` 混进来。
 
 ## 六、术语映射

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -323,7 +323,7 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 
 两条注意：
 
-- **持久化判别字段冻结。** 任何已经序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 都是可比性不变量，不原地改名；要改必须单独走 schema migration、写明可比性影响（影响报告可比性时标 `BREAKING-COMPARABILITY`）。新代码从一开始就把裸 `kind` 留给 `ArtifactKind`。
+- **持久化判别字段冻结。** 任何已经序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 都是落盘格式里的字段名：改名会破坏反序列化磁盘上已有的文件，所以要单独走数据 / schema 迁移（本轮不做）。这是序列化向后兼容，不是统计可比性 —— 改字段名不改任何测量数字。（`report.kind` 另外还在 Report schema 不变量清单里，改它按常规 schema 谨慎处理。）新代码从一开始就把裸 `kind` 留给 `ArtifactKind`。
 - 内部非持久字段的改名是渐进式的 —— 改到那块代码时顺手做，不搞一次性大扫除。一个 CI 护栏冻结当前裸 `kind` 声明点的集合，防止新的不加限定的 `kind` 混进来。
 
 ## 六、术语映射

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -310,6 +310,22 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 - 实验角色用 `control` / `treatment`（不用 `baseline` / `experiment`）
 - 运行环境用 `runtime context` / `cwd`
 
+### 4. 裸 `kind` 默认指 `ArtifactKind`
+
+在 omk 的产品语义里，不带限定词的 `kind` 一律指知识 artifact 的类型（`Artifact.kind: ArtifactKind` —— `skill` / `prompt` / `agent` / `workflow`；`baseline` 是只用于 eval 的 control 角色）。命令行 flag 同理：`--kind` 表示 `ArtifactKind`，不指平台目标、report 类型或 observe event 类型。
+
+其它判别字段一律用限定名，不用裸 `kind`：
+
+- `report.kind` → `reportKind` / `documentKind`
+- `event.kind` → `eventKind`
+- `executorRuntime.kind` → `runtimeKind`
+- `standard.kind` → `standardKind`
+
+两条注意：
+
+- **持久化判别字段冻结。** 任何已经序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 都是可比性不变量，不原地改名；要改必须单独走 schema migration、写明可比性影响（影响报告可比性时标 `BREAKING-COMPARABILITY`）。新代码从一开始就把裸 `kind` 留给 `ArtifactKind`。
+- 内部非持久字段的改名是渐进式的 —— 改到那块代码时顺手做，不搞一次性大扫除。一个 CI 护栏冻结当前裸 `kind` 声明点的集合，防止新的不加限定的 `kind` 混进来。
+
 ## 六、术语映射
 
 | 旧术语 | 新标准术语 | 说明 |

--- a/src/analysis/sample-diagnostics.ts
+++ b/src/analysis/sample-diagnostics.ts
@@ -43,7 +43,7 @@ export type SampleIssueKind =
 export interface SampleIssue {
   sample_id: string;
   severity: 'error' | 'warning' | 'info';
-  kind: SampleIssueKind;
+  issueKind: SampleIssueKind;
   /** Minimal evidence to make the issue actionable. */
   evidence: Record<string, unknown>;
 }
@@ -134,17 +134,17 @@ export function diagnoseSamples(report: Report, options: DiagnoseOptions = {}): 
       const min = Math.min(...scores);
       if (max === 5 && min === 5) {
         issues.push({
-          sample_id: entry.sample_id, severity: 'info', kind: 'all_pass',
+          sample_id: entry.sample_id, severity: 'info', issueKind: 'all_pass',
           evidence: { scores: scoresMap(entry, variants) },
         });
       } else if (max === 1 && min === 1) {
         issues.push({
-          sample_id: entry.sample_id, severity: 'error', kind: 'all_fail',
+          sample_id: entry.sample_id, severity: 'error', issueKind: 'all_fail',
           evidence: { scores: scoresMap(entry, variants) },
         });
       } else if (max - min < opt.flatThreshold) {
         issues.push({
-          sample_id: entry.sample_id, severity: 'warning', kind: 'flat_scores',
+          sample_id: entry.sample_id, severity: 'warning', issueKind: 'flat_scores',
           evidence: { scores: scoresMap(entry, variants), spread: Number((max - min).toFixed(2)), threshold: opt.flatThreshold },
         });
       }
@@ -153,7 +153,7 @@ export function diagnoseSamples(report: Report, options: DiagnoseOptions = {}): 
     // Errored on at least one variant — sample may be broken (env / executor / fixture).
     if (errors > 0) {
       issues.push({
-        sample_id: entry.sample_id, severity: errors === variants.length ? 'error' : 'warning', kind: 'error_prone',
+        sample_id: entry.sample_id, severity: errors === variants.length ? 'error' : 'warning', issueKind: 'error_prone',
         evidence: { errorCount: errors, variantCount: variants.length },
       });
     }
@@ -162,7 +162,7 @@ export function diagnoseSamples(report: Report, options: DiagnoseOptions = {}): 
     const maxStddev = judgeStddevs.length > 0 ? Math.max(...judgeStddevs) : 0;
     if (maxStddev >= opt.ambiguousStddev) {
       issues.push({
-        sample_id: entry.sample_id, severity: 'warning', kind: 'ambiguous_rubric',
+        sample_id: entry.sample_id, severity: 'warning', issueKind: 'ambiguous_rubric',
         evidence: { maxStddev: Number(maxStddev.toFixed(2)), threshold: opt.ambiguousStddev, stddevs: judgeStddevs.map((s) => Number(s.toFixed(2))) },
       });
     }
@@ -177,13 +177,13 @@ export function diagnoseSamples(report: Report, options: DiagnoseOptions = {}): 
   for (const s of sampleStats) {
     if (medianCost > 0 && s.cost >= opt.costOutlierK * medianCost) {
       issues.push({
-        sample_id: s.entry.sample_id, severity: 'info', kind: 'cost_outlier',
+        sample_id: s.entry.sample_id, severity: 'info', issueKind: 'cost_outlier',
         evidence: { cost: Number(s.cost.toFixed(4)), medianCost: Number(medianCost.toFixed(4)), multiplier: opt.costOutlierK },
       });
     }
     if (medianLatency > 0 && s.latencyMs >= opt.latencyOutlierK * medianLatency) {
       issues.push({
-        sample_id: s.entry.sample_id, severity: 'info', kind: 'latency_outlier',
+        sample_id: s.entry.sample_id, severity: 'info', issueKind: 'latency_outlier',
         evidence: { latencyMs: s.latencyMs, medianMs: medianLatency, multiplier: opt.latencyOutlierK },
       });
     }
@@ -210,7 +210,7 @@ export function diagnoseSamples(report: Report, options: DiagnoseOptions = {}): 
           if (seenPair.has(key)) continue;
           seenPair.add(key);
           issues.push({
-            sample_id: prompts[i].id, severity: 'warning', kind: 'near_duplicate',
+            sample_id: prompts[i].id, severity: 'warning', issueKind: 'near_duplicate',
             evidence: { duplicateOf: prompts[j].id, rouge1: Number(score.toFixed(2)), threshold: opt.duplicateRouge },
           });
         }
@@ -233,7 +233,7 @@ export function diagnoseSamples(report: Report, options: DiagnoseOptions = {}): 
       if (rubric.length >= 20) continue;
       if (containsRubricGradeKeyword(rubric)) continue;
       issues.push({
-        sample_id: entry.sample_id, severity: 'info', kind: 'rubric_clarity_low',
+        sample_id: entry.sample_id, severity: 'info', issueKind: 'rubric_clarity_low',
         evidence: { rubricLength: rubric.length, rubricSnippet: rubric.slice(0, 80) },
       });
     }
@@ -264,7 +264,7 @@ export function diagnoseSamples(report: Report, options: DiagnoseOptions = {}): 
         // 报警挂在该 capability 的第一个 sample 上(便于定位),其他在 evidence 里列。
         const primarySampleId = info.sampleIds[0];
         issues.push({
-          sample_id: primarySampleId, severity: 'warning', kind: 'capability_thin',
+          sample_id: primarySampleId, severity: 'warning', issueKind: 'capability_thin',
           evidence: { capability: cap, sampleCount: info.count, threshold, sampleIds: info.sampleIds },
         });
       }
@@ -276,8 +276,8 @@ export function diagnoseSamples(report: Report, options: DiagnoseOptions = {}): 
 
   const byKind: SampleDiagnosticReport['byKind'] = {};
   for (const i of issues) {
-    if (!byKind[i.kind]) byKind[i.kind] = [];
-    if (!byKind[i.kind]!.includes(i.sample_id)) byKind[i.kind]!.push(i.sample_id);
+    if (!byKind[i.issueKind]) byKind[i.issueKind] = [];
+    if (!byKind[i.issueKind]!.includes(i.sample_id)) byKind[i.issueKind]!.push(i.sample_id);
   }
 
   const totals = {
@@ -371,7 +371,7 @@ function evidenceString(evidence: Record<string, unknown>, key: string, fallback
 
 export function formatSampleIssue(issue: SampleIssue, lang: DiagnosticLang = 'zh'): string {
   const evidence = issue.evidence;
-  switch (issue.kind) {
+  switch (issue.issueKind) {
     case 'all_pass':
       return lang === 'zh'
         ? '所有 variant 得分均为 5——用例可能太简单或断言过宽'
@@ -441,8 +441,8 @@ export function formatSampleIssue(issue: SampleIssue, lang: DiagnosticLang = 'zh
     }
     default:
       return lang === 'zh'
-        ? `结构化诊断：${issue.kind}`
-        : `Structured diagnostic: ${issue.kind}`;
+        ? `结构化诊断：${issue.issueKind}`
+        : `Structured diagnostic: ${issue.issueKind}`;
   }
 }
 
@@ -473,7 +473,7 @@ export function formatSampleDiagnostics(diag: SampleDiagnosticReport, options: {
     const ids = diag.byKind[kind] ?? [];
     if (ids.length === 0) continue;
     lines.push(`  [${kind}] ${ids.length} sample(s)`);
-    const matching = diag.issues.filter((i) => i.kind === kind);
+    const matching = diag.issues.filter((i) => i.issueKind === kind);
     const display = topN ? matching.slice(0, topN) : matching;
     for (const issue of display) {
       const sev = issue.severity === 'error' ? '✗' : issue.severity === 'warning' ? '⚠' : 'ℹ';

--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -777,7 +777,7 @@ export function mergeEvolveReports(
   const runId = `evolve-${skillName}-${generateRunId([skillName]).split('-').slice(-2).join('-')}`;
 
   const report: Report = {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id: runId,
     meta: {
       ...firstReport.meta,

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -317,7 +317,7 @@ export function pruneDoctorHistory(dir: string, skillName: string, maxKeep: numb
     if (!file.endsWith('.json')) continue;
     try {
       const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as import('../../types/doctor.js').DoctorReport;
-      if (data?.kind !== 'doctor' || !Array.isArray(data.skills) || data.skills.length !== 1) continue;
+      if (data?.reportKind !== 'doctor' || !Array.isArray(data.skills) || data.skills.length !== 1) continue;
       if (data.skills[0].skillName !== skillName) continue;
       candidates.push({ file, timestamp: data.timestamp });
     } catch { /* skip corrupt / unrelated json */ }

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -79,7 +79,7 @@ function batchItemFallbackReport(
   item: BatchEvaluationReport['items'][number],
 ): EvaluationReport {
   return {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id: item.reportId,
     meta: {
       ...batch.meta,
@@ -104,7 +104,7 @@ async function loadBatchChildReports(
   const reports: EvaluationReport[] = [];
   for (const item of batch.items) {
     const loaded = await store.get(item.reportId);
-    if (loaded?.kind === 'evaluation') {
+    if (loaded?.reportKind === 'evaluation') {
       reports.push(loaded);
     } else {
       process.stderr.write(tCli('cli.run.batch_child_report_missing', lang, { id: item.reportId }));
@@ -158,7 +158,7 @@ async function announceSavedReport({
   lang: CliLang;
 }): Promise<void> {
   const tally = computeRunTally(report);
-  process.stderr.write(tCli(report.kind === 'batch-evaluation' ? 'cli.run.batch_complete' : 'cli.run.eval_complete', lang));
+  process.stderr.write(tCli(report.reportKind === 'batch-evaluation' ? 'cli.run.batch_complete' : 'cli.run.eval_complete', lang));
   process.stderr.write(tCli('cli.run.tally', lang, tally));
   process.stderr.write(tCli('cli.run.report_saved', lang, { path: filePath }));
 

--- a/src/cli/lib/run-tally.ts
+++ b/src/cli/lib/run-tally.ts
@@ -21,7 +21,7 @@ export function computeRunTally(report: ReportDocument): { passed: number; faile
       failed += s.errorCount;
     }
   };
-  if (report.kind === 'batch-evaluation') {
+  if (report.reportKind === 'batch-evaluation') {
     for (const item of report.items) accumulate(item.summary);
   } else {
     accumulate(report.summary);

--- a/src/cli/lib/shared.ts
+++ b/src/cli/lib/shared.ts
@@ -16,7 +16,7 @@ export function requireEvaluationReport(report: ReportDocument | null, id: strin
     console.error(tCli('cli.common.report_not_found', lang, { id }));
     throw new CliExit(1);
   }
-  if (report.kind === 'batch-evaluation') {
+  if (report.reportKind === 'batch-evaluation') {
     console.error(lang === 'zh'
       ? `报告 ${id} 是 BatchEvaluationReport。该命令需要单次 EvaluationReport；请使用其中的 child reportId。`
       : `Report ${id} is a BatchEvaluationReport. This command requires an EvaluationReport; use a child reportId from the batch.`);

--- a/src/diagnosis/observe-mapper.ts
+++ b/src/diagnosis/observe-mapper.ts
@@ -33,7 +33,7 @@ export interface SkillChainAdvisorySource {
 export interface ObservationRuntimeCheckSource {
   skillName: string;
   id: string;
-  kind: 'hardRule' | 'workflowNode';
+  nodeKind: 'hardRule' | 'workflowNode';
   status: 'passed' | 'attention' | 'manual_review';
   title?: string;
   expectation?: string;
@@ -71,7 +71,7 @@ export interface ExperienceReviewerReportFindingSource {
 export interface SkillDerivedStandardSource {
   skillName: string;
   id: string;
-  kind: 'hard_rule_candidate' | 'workflow_candidate';
+  standardKind: 'hard_rule_candidate' | 'workflow_candidate';
   status: 'pending_review' | 'author_confirmed' | 'rejected' | 'stale';
   title: string;
   body?: string;
@@ -154,13 +154,13 @@ function advisoryToDiagnosis(generatedAt: string, advisory: SkillChainAdvisorySo
 
 function runtimeCheckToDiagnosis(generatedAt: string, check: ObservationRuntimeCheckSource): Diagnosis | null {
   if (check.status === 'passed') return null;
-  const target = check.kind === 'hardRule' ? `runtime:hardRule:${check.id}` : `runtime:workflowNode:${check.id}`;
+  const target = check.nodeKind === 'hardRule' ? `runtime:hardRule:${check.id}` : `runtime:workflowNode:${check.id}`;
   return makeDiagnosis(generatedAt, {
     skillName: check.skillName,
     type: 'runtime_issue',
-    signal: check.kind === 'hardRule' ? 'runtime_hard_rule_review' : 'runtime_workflow_review',
+    signal: check.nodeKind === 'hardRule' ? 'runtime_hard_rule_review' : 'runtime_workflow_review',
     target,
-    title: check.title ?? (check.kind === 'hardRule' ? 'Hard rule runtime check needs review' : 'Workflow runtime check needs review'),
+    title: check.title ?? (check.nodeKind === 'hardRule' ? 'Hard rule runtime check needs review' : 'Workflow runtime check needs review'),
     summary: check.reason ?? check.expectation,
     severity: check.status === 'manual_review' ? 'medium' : 'low',
     audience: 'reviewer',
@@ -220,14 +220,14 @@ function derivedStandardToDiagnosis(generatedAt: string, standard: SkillDerivedS
   return makeDiagnosis(generatedAt, {
     skillName: standard.skillName,
     type: 'standard_candidate',
-    signal: standard.kind,
-    target: `standard:${standard.kind}:${standard.id}`,
+    signal: standard.standardKind,
+    target: `standard:${standard.standardKind}:${standard.id}`,
     title: standard.title,
     summary: standard.body,
     severity: standard.status === 'author_confirmed' ? 'info' : 'low',
     audience: 'skill-author',
     lifecycle: lifecycleFromStandardStatus(standard.status),
-    sourceKind: standard.kind,
+    sourceKind: standard.standardKind,
     sourceId: standard.id,
     evidenceRefs: [],
     producer: standard.source === 'manual' ? 'manual' : 'llm_soft',

--- a/src/diagnosis/observe-producer.ts
+++ b/src/diagnosis/observe-producer.ts
@@ -137,7 +137,7 @@ function chainRuntimeChecks(chain: ObservationSkillChain) {
     .map((check) => ({
       skillName: chain.skillName,
       id: check.id,
-      kind: check.kind,
+      nodeKind: check.nodeKind,
       status: check.status,
       title: check.title,
       expectation: check.expectation,
@@ -149,8 +149,8 @@ function chainRuntimeChecks(chain: ObservationSkillChain) {
 
 function evidenceRefsFromRuntimeCheck(check: ObservationRuntimeCheck, skillName: string): DiagnosisEvidenceRef[] {
   return (check.evidenceSnippets ?? []).map((snippet, index) => ({
-    id: `runtime:${skillName}:${check.kind}:${check.id}:${index}`,
-    kind: check.kind,
+    id: `runtime:${skillName}:${check.nodeKind}:${check.id}:${index}`,
+    kind: check.nodeKind,
     label: check.title,
     snippet,
   }));

--- a/src/doctor/health/composer.ts
+++ b/src/doctor/health/composer.ts
@@ -127,7 +127,7 @@ export function makeSkillHealthComposer(
 ): ComposerRule {
   return {
     id: SKILL_HEALTH_COMPOSER_ID,
-    kind: 'composer',
+    ruleKind: 'composer',
     severity: 'fatal',
     labelKey: 'cli.doctor.rule.skill_health_check',
     checkAll: (ctx) => composerCheckAll(ctx, execFactory),

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -255,7 +255,7 @@ export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
       : 'passed';
 
   return {
-    kind: 'doctor',
+    reportKind: 'doctor',
     schemaVersion: DOCTOR_REPORT_SCHEMA_VERSION,
     id: nextReportId(),
     timestamp: new Date().toISOString(),

--- a/src/eval-core/comparability.ts
+++ b/src/eval-core/comparability.ts
@@ -52,9 +52,9 @@ function packageReasons(pkg: ExecutorRuntimePackage | undefined, label: string):
 
 function runtimeUnverifiableReasons(runtime: ExecutorRuntimeFingerprint): string[] {
   const reasons: string[] = [];
-  if (runtime.kind === 'api') return reasons;
+  if (runtime.runtimeKind === 'api') return reasons;
 
-  if (runtime.kind === 'agent-sdk') {
+  if (runtime.runtimeKind === 'agent-sdk') {
     reasons.push(...packageReasons(runtime.sdk, 'sdk'));
   }
 
@@ -75,7 +75,7 @@ function runtimeUnverifiableReasons(runtime: ExecutorRuntimeFingerprint): string
     reasons.push('binary source unknown');
   }
 
-  if (runtime.kind === 'unknown') reasons.push('runtime kind unknown');
+  if (runtime.runtimeKind === 'unknown') reasons.push('runtime kind unknown');
   return [...new Set(reasons)];
 }
 

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -256,7 +256,7 @@ export function aggregateReport({
     variant.execCostReported !== false && variant.judgeCostReported !== false);
 
   return {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id: runId,
     meta: {
       variants,

--- a/src/eval-workflows/batch-evaluation-workflow.ts
+++ b/src/eval-workflows/batch-evaluation-workflow.ts
@@ -263,7 +263,7 @@ export function buildBatchEvaluationReport({
   }));
 
   const report: BatchEvaluationReport = {
-    kind: 'batch-evaluation',
+    reportKind: 'batch-evaluation',
     id: batchRunId,
     mode: 'skill',
     meta: {

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -291,7 +291,7 @@ export async function runEvaluation({
     const { createFileStore } = await import('../server/report-store.js');
     const store = createFileStore(resolve(outputDir || DEFAULT_OUTPUT_DIR));
     const existing = await store.get(resume);
-    if (existing?.kind === 'evaluation') {
+    if (existing?.reportKind === 'evaluation') {
       existingResults = {};
       for (const entry of existing.results || []) {
         existingResults[entry.sample_id] = entry.variants;
@@ -317,7 +317,7 @@ export async function runEvaluation({
           + `   新 entries 不隔离 → 与现有 entries 不可比。建议恢复默认 strict-baseline。\n`,
         );
       }
-    } else if (existing?.kind === 'batch-evaluation') {
+    } else if (existing?.reportKind === 'batch-evaluation') {
       process.stderr.write(`\n⚠️  report ${resume} is a BatchEvaluationReport; resume needs a child EvaluationReport, starting from scratch\n`);
     } else {
       process.stderr.write(`\n⚠️  report ${resume} not found, starting from scratch\n`);

--- a/src/executors/runtime-fingerprint.ts
+++ b/src/executors/runtime-fingerprint.ts
@@ -148,7 +148,7 @@ function withFingerprint(input: Omit<ExecutorRuntimeFingerprint, 'fingerprint'>)
   const stablePayload = {
     executor: input.executor,
     model: input.model,
-    kind: input.kind,
+    kind: input.runtimeKind,
     binary: input.binary
       ? {
         name: input.binary.name,
@@ -186,7 +186,7 @@ function runtime(
   return withFingerprint({
     executor,
     model,
-    kind,
+    runtimeKind: kind,
     capabilities,
     ...extra,
   });

--- a/src/executors/shared.ts
+++ b/src/executors/shared.ts
@@ -137,7 +137,7 @@ export interface CodexEvent {
     content?: string;
     query?: string;
     results?: unknown[];
-    changes?: Array<{ path?: string; kind?: string }>;
+    changes?: Array<{ path?: string }>;
     server?: string;
     tool?: string;
     arguments?: unknown;

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -318,7 +318,7 @@ export function buildObservationExperienceReport(input: BuildExperienceInput): O
   const skills = summarizeExperienceSkills(sessions, invocations);
 
   return {
-    kind: 'observe-experience',
+    reportKind: 'observe-experience',
     schemaVersion: 1,
     scope: 'evidence-only',
     generatedAt: input.generatedAt,

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -443,7 +443,7 @@ export function buildObservationInboxReport(tracePath: string, options: BuildObs
   const items = finishInboxAggregation(aggregationState);
   const experience = buildObservationExperienceReport({ sessions, segments, items, generatedAt, reviewState: options.reviewState });
   const report: ObservationInboxReport = {
-    kind: 'observe-inbox',
+    reportKind: 'observe-inbox',
     schemaVersion: 1,
     meta: {
       tracePath,
@@ -584,7 +584,7 @@ export function loadObservationInboxReports(dir: string = DEFAULT_OBSERVATIONS_D
         return null;
       }
     })
-    .filter((r): r is ObservationInboxReport => r?.kind === 'observe-inbox');
+    .filter((r): r is ObservationInboxReport => r?.reportKind === 'observe-inbox');
 }
 
 export function loadLatestObservationInboxReport(dir: string = DEFAULT_OBSERVATIONS_DIR): ObservationInboxReport | null {

--- a/src/observability/resolved-review.ts
+++ b/src/observability/resolved-review.ts
@@ -313,16 +313,16 @@ function runtimeNodeChecklistItems(enhancedReview: SkillLlmEnhancedReviewSection
   const runtimeResults = enhancedReview.runtimeNodeResults?.nodes ?? [];
   if (runtimeResults.length > 0) {
     return runtimeResults.slice(0, 12).map((node) => checklistItem(
-      `runtime_node_${node.kind}_${node.nodeId}`,
-      `${runtimeNodeKindLabel(node.kind)}：${node.title || node.nodeId}`,
+      `runtime_node_${node.nodeKind}_${node.nodeId}`,
+      `${runtimeNodeKindLabel(node.nodeKind)}：${node.title || node.nodeId}`,
       runtimeNodeChecklistStatus(node.status),
       node.reason || '规则层基于 LLM 拆解的 typed signal 匹配运行证据。',
       node.status === 'violated' || node.status === 'degraded' ? 'attention' : 'informational',
     ));
   }
   return (enhancedReview.runtimeNodeAssessment?.nodes ?? []).slice(0, 12).map((node) => checklistItem(
-    `legacy_llm_node_${node.kind}_${node.nodeId}`,
-    `${node.kind === 'workflowNode' ? '流程节点' : '硬性规则'}：${node.nodeId}`,
+    `legacy_llm_node_${node.nodeKind}_${node.nodeId}`,
+    `${node.nodeKind === 'workflowNode' ? '流程节点' : '硬性规则'}：${node.nodeId}`,
     checklistStatus(node.status),
     node.reason ?? '旧版模型节点复核结果。',
     node.status === 'failed' || node.status === 'degraded' ? 'attention' : 'informational',
@@ -625,10 +625,10 @@ function ownerSuggestionTexts(enhancedReview?: SkillLlmEnhancedReviewSections, s
   const checklistLabelByKey = new Map((enhancedReview?.typeSpecificAssessment?.checklist ?? [])
     .map((item) => [item.key, `${skillTypeLabel(skillType ?? enhancedReview?.skillType)}：${readableTypeSpecificLabel(item, skillType ?? enhancedReview?.skillType)}`] as const));
   for (const node of enhancedReview?.runtimeNodeResults?.nodes ?? []) {
-    checklistLabelByKey.set(node.nodeId, `${runtimeNodeKindLabel(node.kind)}：${node.title || node.nodeId}`);
+    checklistLabelByKey.set(node.nodeId, `${runtimeNodeKindLabel(node.nodeKind)}：${node.title || node.nodeId}`);
   }
   for (const node of enhancedReview?.runtimeNodeAssessment?.nodes ?? []) {
-    checklistLabelByKey.set(node.suggestionKey ?? node.nodeId, `${node.kind === 'workflowNode' ? '流程节点' : '硬性规则'}：${node.nodeId}`);
+    checklistLabelByKey.set(node.suggestionKey ?? node.nodeId, `${node.nodeKind === 'workflowNode' ? '流程节点' : '硬性规则'}：${node.nodeId}`);
   }
   return (enhancedReview?.ownerSuggestions ?? [])
     .flatMap((suggestion): ResolvedOwnerSuggestion[] => {

--- a/src/observability/review-state.ts
+++ b/src/observability/review-state.ts
@@ -79,7 +79,7 @@ export function observationReviewStatePath(observationsDir: string): string {
 
 export function emptyObservationReviewState(now = new Date().toISOString()): ObservationReviewState {
   return {
-    kind: 'observe-review-state',
+    reportKind: 'observe-review-state',
     schemaVersion: 1,
     updatedAt: now,
     entries: {},
@@ -91,11 +91,11 @@ export function loadObservationReviewState(observationsDir: string): Observation
   if (!existsSync(path)) return emptyObservationReviewState();
   try {
     const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<ObservationReviewState>;
-    if (parsed.kind !== 'observe-review-state' || parsed.schemaVersion !== 1 || !parsed.entries || typeof parsed.entries !== 'object') {
+    if (parsed.reportKind !== 'observe-review-state' || parsed.schemaVersion !== 1 || !parsed.entries || typeof parsed.entries !== 'object') {
       return emptyObservationReviewState();
     }
     return {
-      kind: 'observe-review-state',
+      reportKind: 'observe-review-state',
       schemaVersion: 1,
       updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
       entries: Object.fromEntries(

--- a/src/observability/skill-chain.ts
+++ b/src/observability/skill-chain.ts
@@ -107,14 +107,14 @@ function buildRuntimeChecks(
   const invocations = experienceReports.flatMap((report) => report.invocations.filter((invocation) => invocation.skillName === skillName));
   const evidence = runtimeEvidence(invocations);
   const hardRuleChecks = hardRules.map((rule) => evaluateRuntimeText({
-    kind: 'hardRule',
+    nodeKind: 'hardRule',
     id: rule.id,
     title: rule.rule,
     expectation: rule.expectedBehavior,
   }, evidence));
   const workflowChecks = workflows.flatMap((workflow) =>
     workflow.nodes.map((node) => evaluateRuntimeText({
-      kind: 'workflowNode',
+      nodeKind: 'workflowNode',
       id: `${workflow.id}.${node.id}`,
       title: node.action || `${workflow.id} / ${node.id}`,
       expectation: node.action,
@@ -180,7 +180,7 @@ function buildSkillRuntimeEvidencePack(input: {
     ...input.hardRules.map((rule) => nodeEvidenceForCheck({
       check: standardById.get(rule.id),
       nodeId: rule.id,
-      kind: 'hardRule' as const,
+      nodeKind: 'hardRule' as const,
       title: rule.rule,
       expectation: rule.expectedBehavior,
       refs: allRuntimeRefs,
@@ -188,7 +188,7 @@ function buildSkillRuntimeEvidencePack(input: {
     ...workflowNodes.map((node) => nodeEvidenceForCheck({
       check: standardById.get(node.id),
       nodeId: node.id,
-      kind: 'workflowNode' as const,
+      nodeKind: 'workflowNode' as const,
       title: node.title,
       expectation: node.expectation,
       refs: allRuntimeRefs,
@@ -230,7 +230,7 @@ function buildSkillRuntimeEvidencePack(input: {
 function nodeEvidenceForCheck(input: {
   check?: ObservationRuntimeCheck;
   nodeId: string;
-  kind: 'workflowNode' | 'hardRule';
+  nodeKind: 'workflowNode' | 'hardRule';
   title: string;
   expectation: string;
   refs: SkillRuntimeEvidencePackRef[];
@@ -241,7 +241,7 @@ function nodeEvidenceForCheck(input: {
     : [];
   return {
     nodeId: input.nodeId,
-    kind: input.kind,
+    nodeKind: input.nodeKind,
     title: input.title,
     expectation: input.expectation,
     deterministicStatus: input.check?.status ?? 'manual_review',
@@ -279,7 +279,7 @@ function runtimeEvidence(invocations: ExperienceInvocation[]): RuntimeEvidence {
 }
 
 function evaluateRuntimeText(
-  base: Pick<ObservationRuntimeCheck, 'kind' | 'id' | 'title' | 'expectation'>,
+  base: Pick<ObservationRuntimeCheck, 'nodeKind' | 'id' | 'title' | 'expectation'>,
   evidence: RuntimeEvidence,
 ): ObservationRuntimeCheck {
   const text = `${base.title}\n${base.expectation}`;

--- a/src/observability/soft-standards/llm-extractor.ts
+++ b/src/observability/soft-standards/llm-extractor.ts
@@ -91,7 +91,7 @@ export async function extractSkillSoftStandards(options: ExtractSkillSoftStandar
     source: 'llm_soft_standard' as const,
   }));
   const record: SkillDerivedStandards = {
-    kind: 'observe-skill-derived-standards',
+    reportKind: 'observe-skill-derived-standards',
     schemaVersion: 1,
     skillName: skillChain.skillName,
     sourceSkillPath: skillChain.definition.path,

--- a/src/observability/soft-standards/llm-extractor.ts
+++ b/src/observability/soft-standards/llm-extractor.ts
@@ -142,14 +142,14 @@ function buildSoftStandardPrompt(
 
 function availableNodeEvidenceSummaries(evidencePack?: SkillRuntimeEvidencePack): Array<{
   nodeId: string;
-  kind: SkillRuntimeEvidencePackNode['kind'];
+  nodeKind: SkillRuntimeEvidencePackNode['nodeKind'];
   title: string;
   expectation: string;
   candidateEvidenceSnippets: string[];
 }> {
   return (evidencePack?.nodeEvidence ?? []).slice(0, 40).map((node) => ({
     nodeId: node.nodeId,
-    kind: node.kind,
+    nodeKind: node.nodeKind,
     title: node.title.slice(0, 120),
     expectation: node.expectation.slice(0, 240),
     candidateEvidenceSnippets: node.candidateEvidenceSnippets.slice(0, 3).map((snippet) => snippet.slice(0, 180)),
@@ -276,7 +276,7 @@ function normalizeExtractedStandards(
   if (!value || typeof value !== 'object') {
     if (!Array.isArray(legacyStandards)) return undefined;
     return {
-      hardrules: legacyStandards.map((item, index) => normalizeStandardSectionItem(item, index)).filter((item): item is Omit<SkillDerivedStandard, 'id' | 'kind' | 'status' | 'source'> => Boolean(item)),
+      hardrules: legacyStandards.map((item, index) => normalizeStandardSectionItem(item, index)).filter((item): item is Omit<SkillDerivedStandard, 'id' | 'standardKind' | 'status' | 'source'> => Boolean(item)),
       workflows: [],
       completionCriteria: [],
       artifactCriteria: [],
@@ -332,7 +332,7 @@ function normalizeStandardNode(value: unknown): RuntimeStandardNode | null {
   return {
     nodeId,
     nodeEvidenceRef: typeof item.nodeEvidenceRef === 'string' ? normalizeIdentifier(item.nodeEvidenceRef, 120) || undefined : undefined,
-    kind,
+    nodeKind: kind,
     title,
     description: typeof item.description === 'string' ? item.description.slice(0, 600) : undefined,
     childNodeIds: Array.isArray(item.childNodeIds)
@@ -508,12 +508,12 @@ function normalizeSourceHints(value: unknown): RuntimeStandardNodeSourceHint[] {
   return hints.filter((entry): entry is RuntimeStandardNodeSourceHint => Boolean(entry)).slice(0, 8);
 }
 
-function normalizeStandardSection(value: unknown): Array<Omit<SkillDerivedStandard, 'id' | 'kind' | 'status' | 'source'>> {
+function normalizeStandardSection(value: unknown): Array<Omit<SkillDerivedStandard, 'id' | 'standardKind' | 'status' | 'source'>> {
   if (!Array.isArray(value)) return [];
-  return value.map((item, index) => normalizeStandardSectionItem(item, index)).filter((item): item is Omit<SkillDerivedStandard, 'id' | 'kind' | 'status' | 'source'> => Boolean(item));
+  return value.map((item, index) => normalizeStandardSectionItem(item, index)).filter((item): item is Omit<SkillDerivedStandard, 'id' | 'standardKind' | 'status' | 'source'> => Boolean(item));
 }
 
-function normalizeStandardSectionItem(value: unknown, index: number): Omit<SkillDerivedStandard, 'id' | 'kind' | 'status' | 'source'> | null {
+function normalizeStandardSectionItem(value: unknown, index: number): Omit<SkillDerivedStandard, 'id' | 'standardKind' | 'status' | 'source'> | null {
   if (typeof value === 'string') {
     const text = value.trim();
     if (!text) return null;
@@ -618,7 +618,7 @@ function attachRuntimeNodeResults(
     },
     runtimeNodeResults: {
       summary: nodeResults.length > 0
-        ? `规则层已复核 ${nodeResults.filter((node) => node.kind !== 'stage').length} 个流程/规则节点。`
+        ? `规则层已复核 ${nodeResults.filter((node) => node.nodeKind !== 'stage').length} 个流程/规则节点。`
         : '没有可复核的流程/规则节点。',
       nodes: nodeResults,
     },
@@ -658,7 +658,7 @@ const WORKFLOW_OWNER_FALLBACK_STANDARD_NODES: RuntimeStandardNode[] = [
 function workflowOwnerStage(nodeId: string, title: string, childNodeIds: string[]): RuntimeStandardNode {
   return {
     nodeId,
-    kind: 'stage',
+    nodeKind: 'stage',
     title,
     description: 'workflow_owner 通用兜底阶段；当 SKILL.md 没有可抽取阶段时使用。',
     childNodeIds,
@@ -679,7 +679,7 @@ function workflowOwnerNode(
 ): RuntimeStandardNode {
   return {
     nodeId,
-    kind,
+    nodeKind: kind,
     title,
     expectedSignals,
     failureSignals: [],
@@ -743,13 +743,13 @@ function normalizeOwnerSuggestions(value: unknown): SkillLlmEnhancedReviewSectio
 
 function normalizeStandard(value: unknown, index: number): Omit<SkillDerivedStandard, 'status' | 'source'> | null {
   if (!value || typeof value !== 'object') return null;
-  const item = value as Partial<SkillDerivedStandard>;
+  const item = value as Record<string, unknown>;
   const kind = item.kind === 'workflow_candidate' ? 'workflow_candidate' : item.kind === 'hard_rule_candidate' ? 'hard_rule_candidate' : undefined;
   if (!kind || typeof item.title !== 'string' || typeof item.body !== 'string') return null;
   const stable = [kind, item.title, item.body].join('\u0000');
   return {
     id: typeof item.id === 'string' && item.id.trim() ? item.id.trim() : `soft-${hashText(stable).slice(0, 12)}-${index}`,
-    kind,
+    standardKind: kind,
     title: item.title.slice(0, 160),
     body: item.body.slice(0, 600),
     confidence: item.confidence === 'high' || item.confidence === 'medium' || item.confidence === 'low' ? item.confidence : 'low',

--- a/src/observability/soft-standards/runtime-evaluator.ts
+++ b/src/observability/soft-standards/runtime-evaluator.ts
@@ -34,7 +34,7 @@ export function evaluateRuntimeStandardNodes(nodes: RuntimeStandardNode[], evide
   const resultByNodeId = new Map(rawResults.map((result) => [result.nodeId, result]));
   return rawResults.map((result) => {
     const node = nodes.find((item) => item.nodeId === result.nodeId);
-    if (!node || node.kind !== 'stage' || !node.childNodeIds || node.childNodeIds.length === 0) return result;
+    if (!node || node.nodeKind !== 'stage' || !node.childNodeIds || node.childNodeIds.length === 0) return result;
     const childResults = node.childNodeIds
       .map((id) => resultByNodeId.get(id))
       .filter((item): item is RuntimeNodeResult => Boolean(item));
@@ -62,7 +62,7 @@ function evaluateRuntimeStandardNode(node: RuntimeStandardNode, evidencePack: Sk
   const evidenceRefs = dedupeEvidenceRefs(matchedSignals.flatMap((match) => match.refs));
   return {
     nodeId: node.nodeId,
-    kind: node.kind,
+    nodeKind: node.nodeKind,
     title: node.title,
     status,
     matchedSignals: matchedSignals.map((match) => ({

--- a/src/observability/soft-standards/skill-standards-store.ts
+++ b/src/observability/soft-standards/skill-standards-store.ts
@@ -146,7 +146,7 @@ export function markStale(record: SkillDerivedStandards, generatedAt: string): S
 export function isSkillDerivedStandards(value: unknown): value is SkillDerivedStandards {
   if (!value || typeof value !== 'object') return false;
   const item = value as Partial<SkillDerivedStandards>;
-  return item.kind === 'observe-skill-derived-standards'
+  return item.reportKind === 'observe-skill-derived-standards'
     && item.schemaVersion === 1
     && typeof item.skillName === 'string'
     && Array.isArray(item.standards);

--- a/src/observability/soft-standards/skill-standards-store.ts
+++ b/src/observability/soft-standards/skill-standards-store.ts
@@ -76,7 +76,7 @@ export function resolveSkillStandards(skillName: string, options: ResolveSkillSt
   for (const rule of skillChain.healthCheck.hardRules.rules) {
     active.push({
       id: rule.id,
-      kind: 'hard_rule',
+      standardKind: 'hard_rule',
       title: rule.rule,
       body: rule.expectedBehavior,
       source: 'frontmatter',
@@ -86,7 +86,7 @@ export function resolveSkillStandards(skillName: string, options: ResolveSkillSt
     for (const node of workflow.nodes) {
       active.push({
         id: `${workflow.id}.${node.id}`,
-        kind: 'workflow',
+        standardKind: 'workflow',
         title: `${workflow.id} / ${node.id}`,
         body: node.action,
         source: 'frontmatter',
@@ -95,11 +95,11 @@ export function resolveSkillStandards(skillName: string, options: ResolveSkillSt
   }
 
   for (const standard of derived?.standards ?? []) {
-    const kind: ResolvedSkillStandardKind = standard.kind === 'workflow_candidate' ? 'workflow' : 'hard_rule';
+    const kind: ResolvedSkillStandardKind = standard.standardKind === 'workflow_candidate' ? 'workflow' : 'hard_rule';
     const blockedByFrontmatter = kind === 'hard_rule' ? hasFrontmatterHardRules : hasFrontmatterWorkflows;
     const resolved: ResolvedSkillStandard = {
       id: standard.id,
-      kind,
+      standardKind: kind,
       title: standard.title,
       body: standard.body,
       source: standard.status === 'author_confirmed' ? 'confirmed_soft' : 'pending_soft',

--- a/src/observability/soft-standards/types.ts
+++ b/src/observability/soft-standards/types.ts
@@ -21,7 +21,7 @@ export interface SkillDerivedStandard {
 }
 
 export interface SkillDerivedStandards {
-  kind: 'observe-skill-derived-standards';
+  reportKind: 'observe-skill-derived-standards';
   schemaVersion: 1;
   skillName: string;
   sourceSkillPath?: string;

--- a/src/observability/soft-standards/types.ts
+++ b/src/observability/soft-standards/types.ts
@@ -11,7 +11,7 @@ export type SkillDerivedStandardKind = 'hard_rule_candidate' | 'workflow_candida
 
 export interface SkillDerivedStandard {
   id: string;
-  kind: SkillDerivedStandardKind;
+  standardKind: SkillDerivedStandardKind;
   status: SkillDerivedStandardStatus;
   title: string;
   body: string;
@@ -104,7 +104,7 @@ export interface RuntimeStandardNodeSourceHint {
 export interface RuntimeStandardNode {
   nodeId: string;
   nodeEvidenceRef?: string;
-  kind: RuntimeStandardNodeKind;
+  nodeKind: RuntimeStandardNodeKind;
   title: string;
   description?: string;
   childNodeIds?: string[];
@@ -125,7 +125,7 @@ export interface RuntimeMatchedSignal {
 
 export interface RuntimeNodeResult {
   nodeId: string;
-  kind: RuntimeStandardNodeKind;
+  nodeKind: RuntimeStandardNodeKind;
   title: string;
   status: RuntimeNodeVerdict;
   matchedSignals: RuntimeMatchedSignal[];
@@ -144,7 +144,7 @@ export interface SkillLlmTypeSpecificChecklistItem {
 
 export interface SkillLlmRuntimeNodeAssessment {
   nodeId: string;
-  kind: 'workflowNode' | 'hardRule';
+  nodeKind: 'workflowNode' | 'hardRule';
   status: LlmEnhancedChecklistStatus;
   reason?: string;
   evidence?: string[];
@@ -154,10 +154,10 @@ export interface SkillLlmRuntimeNodeAssessment {
 export interface SkillLlmEnhancedReviewSections {
   skillType?: LlmEnhancedSkillType;
   extractedStandards?: {
-    hardrules: Array<Omit<SkillDerivedStandard, 'id' | 'kind' | 'status' | 'source'>>;
-    workflows: Array<Omit<SkillDerivedStandard, 'id' | 'kind' | 'status' | 'source'>>;
-    completionCriteria: Array<Omit<SkillDerivedStandard, 'id' | 'kind' | 'status' | 'source'>>;
-    artifactCriteria: Array<Omit<SkillDerivedStandard, 'id' | 'kind' | 'status' | 'source'>>;
+    hardrules: Array<Omit<SkillDerivedStandard, 'id' | 'standardKind' | 'status' | 'source'>>;
+    workflows: Array<Omit<SkillDerivedStandard, 'id' | 'standardKind' | 'status' | 'source'>>;
+    completionCriteria: Array<Omit<SkillDerivedStandard, 'id' | 'standardKind' | 'status' | 'source'>>;
+    artifactCriteria: Array<Omit<SkillDerivedStandard, 'id' | 'standardKind' | 'status' | 'source'>>;
     standardNodes?: RuntimeStandardNode[];
   };
   userGoal?: {
@@ -212,7 +212,7 @@ export type ResolvedSkillStandardKind = 'hard_rule' | 'workflow';
 
 export interface ResolvedSkillStandard {
   id: string;
-  kind: ResolvedSkillStandardKind;
+  standardKind: ResolvedSkillStandardKind;
   title: string;
   body: string;
   source: ResolvedSkillStandardSource;

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -113,7 +113,7 @@ function runtimeTooltip(runtime: ExecutorRuntimeFingerprint): string {
   return [
     `executor=${runtime.executor}`,
     `model=${runtime.model}`,
-    `kind=${runtime.kind}`,
+    `kind=${runtime.runtimeKind}`,
     `system=${runtime.capabilities.systemPrompt}`,
     `cost=${runtime.capabilities.costUSD}`,
     `trace=${runtime.capabilities.trace}`,

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -38,7 +38,7 @@ function levelDot(level: VerdictLevel): string {
 type RuntimeMeta = Pick<EvaluationReport['meta'], 'executorRuntime' | 'executorRuntimes' | 'judgeModels' | 'noJudge'>;
 
 function isEvaluationReport(document: ReportDocument): document is EvaluationReport {
-  return document.kind === 'evaluation';
+  return document.reportKind === 'evaluation';
 }
 
 function scoreOf(summary: VariantSummary | undefined): number | null {
@@ -184,7 +184,7 @@ export function renderRunList(runs: ReportDocument[], lang: Lang = DEFAULT_LANG)
   };
 
   const cards = runs.map((run) => {
-    if (run.kind === 'batch-evaluation') {
+    if (run.reportKind === 'batch-evaluation') {
       const m = run.meta;
       const scores = run.items.length > 0
         ? run.items.map((item) => {
@@ -686,7 +686,7 @@ export function renderBatchEvaluationDetail(report: BatchEvaluationReport | null
 
 export function renderReportDocumentDetail(report: ReportDocument | null, lang: Lang = DEFAULT_LANG): string {
   if (!report) return renderRunDetail(null, lang);
-  return report.kind === 'batch-evaluation'
+  return report.reportKind === 'batch-evaluation'
     ? renderBatchEvaluationDetail(report, lang)
     : renderRunDetail(report, lang);
 }

--- a/src/renderer/observation-inbox-renderer.ts
+++ b/src/renderer/observation-inbox-renderer.ts
@@ -941,7 +941,7 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
     const runtime = chain.runtime.summary;
     const record = skillDerivedStandards[skillName];
     const detectedHardCount = (record?.standards ?? []).filter((standard) =>
-      standard.kind === 'hard_rule_candidate' && (standard.status === 'author_confirmed' || standard.status === 'pending_review')
+      standard.standardKind === 'hard_rule_candidate' && (standard.status === 'author_confirmed' || standard.status === 'pending_review')
     ).length;
     const hardText = hard.declared
       ? `标准化规则 ${hard.count} 条`
@@ -956,8 +956,8 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
           : `流程检测 ${workflows.branchCount} 条 / 节点 ${workflows.nodeCount}`
       : '标准化流程未声明';
     const pending = (record?.standards ?? []).filter((standard) => standard.status === 'pending_review' || standard.status === 'stale');
-    const hardPending = pending.filter((standard) => standard.kind === 'hard_rule_candidate');
-    const workflowPending = pending.filter((standard) => standard.kind === 'workflow_candidate');
+    const hardPending = pending.filter((standard) => standard.standardKind === 'hard_rule_candidate');
+    const workflowPending = pending.filter((standard) => standard.standardKind === 'workflow_candidate');
     const pendingLine = pending.length > 0
       ? `<div class="skill-chain-compact-candidates">
           <span>待确认 ${pending.length} 条</span>
@@ -1052,8 +1052,8 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
     ];
     const llmHardRuleStandards = extractedStandards?.hardrules ?? [];
     const llmStandardNodes = extractedStandards?.standardNodes ?? [];
-    const llmWorkflowNodes = llmStandardNodes.filter((node) => node.kind !== 'hardRule');
-    const llmHardRuleNodes = llmStandardNodes.filter((node) => node.kind === 'hardRule');
+    const llmWorkflowNodes = llmStandardNodes.filter((node) => node.nodeKind !== 'hardRule');
+    const llmHardRuleNodes = llmStandardNodes.filter((node) => node.nodeKind === 'hardRule');
     const standardNodeById = new Map(llmStandardNodes.map((node) => [node.nodeId, node] as const));
     const standardNodeParentById = new Map<string, string>();
     for (const node of llmStandardNodes) {
@@ -1175,7 +1175,7 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
           const depth = standardNodeDepth(node);
           return `<li class="runtime-rule-node is-depth-${depth}">
             <div class="runtime-rule-node-head">
-              <span>${node.kind === 'stage' ? `阶段 ${index + 1}` : `节点 ${index + 1}`}</span>
+              <span>${node.nodeKind === 'stage' ? `阶段 ${index + 1}` : `节点 ${index + 1}`}</span>
               <strong>${e(node.title)}</strong>
               <em>标准拆解</em>
             </div>
@@ -1192,7 +1192,7 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
           const depth = standardNodeDepth(node);
           return `<li class="runtime-step runtime-rule-execution-item ${modelNodeStatusClass(review?.status)} is-depth-${depth}">
             <div class="runtime-step-head">
-              <span class="runtime-step-index">${node.kind === 'stage' ? `阶段 ${index + 1}` : `节点 ${index + 1}`}</span>
+              <span class="runtime-step-index">${node.nodeKind === 'stage' ? `阶段 ${index + 1}` : `节点 ${index + 1}`}</span>
               <span class="runtime-step-name">${e(node.title)}</span>
               <span class="runtime-step-state" title="${e(modelNodeStatusText(review?.status))}">${modelNodeStatusIcon(review?.status)}</span>
             </div>
@@ -1339,9 +1339,9 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
       stale: 3,
     };
     const sortedSoftStandards = [...softStandards].sort((a, b) =>
-      statusPriority[a.status] - statusPriority[b.status] || a.kind.localeCompare(b.kind) || a.title.localeCompare(b.title)
+      statusPriority[a.status] - statusPriority[b.status] || a.standardKind.localeCompare(b.standardKind) || a.title.localeCompare(b.title)
     );
-    const kindLabel = (kind: SkillDerivedStandard['kind']): string =>
+    const kindLabel = (kind: SkillDerivedStandard['standardKind']): string =>
       kind === 'workflow_candidate' ? '流程候选' : '规则候选';
     const annotationStateClass = (status: SkillDerivedStandard['status']): string =>
       status === 'author_confirmed' ? 'is-confirmed' : status === 'rejected' ? 'is-rejected' : '';
@@ -1391,7 +1391,7 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
       const parts: string[] = [];
       for (const { standard, range } of annotations) {
         parts.push(e(content.slice(cursor, range.start)));
-        parts.push(`<span class="skill-md-highlight skill-md-highlight-${standard.kind === 'workflow_candidate' ? 'workflow' : 'rule'}" data-soft-standard-id="${e(standard.id)}">${e(content.slice(range.start, range.end))}</span><span class="skill-md-annotation ${annotationStateClass(standard.status)}" data-soft-standard-id="${e(standard.id)}" data-soft-standard-skill="${e(skillName)}"><span class="skill-md-annotation-icon" data-soft-standard-icon="${e(standard.status)}">${e(annotationStateIcon(standard.status))}</span><span class="skill-md-annotation-content"><strong>${e(kindLabel(standard.kind))}：</strong>${e(standard.title)}${renderCandidateActions(standard)}</span></span>`);
+        parts.push(`<span class="skill-md-highlight skill-md-highlight-${standard.standardKind === 'workflow_candidate' ? 'workflow' : 'rule'}" data-soft-standard-id="${e(standard.id)}">${e(content.slice(range.start, range.end))}</span><span class="skill-md-annotation ${annotationStateClass(standard.status)}" data-soft-standard-id="${e(standard.id)}" data-soft-standard-skill="${e(skillName)}"><span class="skill-md-annotation-icon" data-soft-standard-icon="${e(standard.status)}">${e(annotationStateIcon(standard.status))}</span><span class="skill-md-annotation-content"><strong>${e(kindLabel(standard.standardKind))}：</strong>${e(standard.title)}${renderCandidateActions(standard)}</span></span>`);
         cursor = range.end;
       }
       parts.push(e(content.slice(cursor)));
@@ -1407,7 +1407,7 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
           <div class="soft-standard-modal-list">${unlocatedStandards.map((standard) => `<div class="soft-standard-modal-item ${annotationStateClass(standard.status)}" data-soft-standard-id="${e(standard.id)}" data-soft-standard-skill="${e(skillName)}">
             <div class="soft-standard-modal-head">
               <span class="skill-md-annotation-icon" data-soft-standard-icon="${e(standard.status)}">${e(annotationStateIcon(standard.status))}</span>
-              <strong>${e(kindLabel(standard.kind))}：${e(standard.title)}</strong>
+              <strong>${e(kindLabel(standard.standardKind))}：${e(standard.title)}</strong>
               <span data-soft-standard-status="${e(standard.status)}">${e(softStandardStatusLabel(standard.status))}</span>
             </div>
             <div class="soft-standard-modal-body">${e(standard.body)}</div>
@@ -1424,10 +1424,10 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
       !workflows.declared ? renderAdvisoryBlock(workflows.advisoryCode, skillName) : '',
     ].filter(Boolean).join('');
     const detectedHardRuleStandards = sortedSoftStandards.filter((standard) =>
-      standard.kind === 'hard_rule_candidate' && (standard.status === 'author_confirmed' || standard.status === 'pending_review')
+      standard.standardKind === 'hard_rule_candidate' && (standard.status === 'author_confirmed' || standard.status === 'pending_review')
     );
     const detectedWorkflowStandards = sortedSoftStandards.filter((standard) =>
-      standard.kind === 'workflow_candidate' && (standard.status === 'author_confirmed' || standard.status === 'pending_review')
+      standard.standardKind === 'workflow_candidate' && (standard.status === 'author_confirmed' || standard.status === 'pending_review')
     );
     const detectedMarker = (status: SkillDerivedStandard['status']): string =>
       status === 'author_confirmed' ? '✅' : '待';
@@ -1547,7 +1547,7 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
       const grouped = groups.map(([label, standards]) => `<section class="review-log-group">
         <h4>${e(label)} ${standards.length}</h4>
         ${standards.length > 0
-          ? `<ul>${standards.map((standard) => `<li><span>${e(kindLabel(standard.kind))}</span><strong>${e(standard.title)}</strong></li>`).join('')}</ul>`
+          ? `<ul>${standards.map((standard) => `<li><span>${e(kindLabel(standard.standardKind))}</span><strong>${e(standard.title)}</strong></li>`).join('')}</ul>`
           : '<p class="context-muted">暂无</p>'}
       </section>`).join('');
       return `${meta}${grouped}`;

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -880,7 +880,7 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
         let evalReport = null;
         if (entry.eval) {
           const r = await reportStore.get(entry.eval.reportId);
-          if (r && r.kind === 'evaluation') evalReport = r;
+          if (r && r.reportKind === 'evaluation') evalReport = r;
         }
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         const insights = idx.insightsBySkill.get(skillName) ?? [];

--- a/src/server/report-store.ts
+++ b/src/server/report-store.ts
@@ -42,11 +42,11 @@ export function createFileStore(dir: string): ReportStore {
   function normalizeReportDocument(data: unknown, fallbackId: string): ReportDocument | null {
     if (!data || typeof data !== 'object') return null;
     const record = data as Record<string, unknown>;
-    if (record.kind === 'evaluation') {
+    if (record.reportKind === 'evaluation') {
       if (!record.meta || !record.summary || !Array.isArray(record.results)) return null;
       return { ...record, id: typeof record.id === 'string' && record.id ? record.id : fallbackId } as unknown as ReportDocument;
     }
-    if (record.kind === 'batch-evaluation') {
+    if (record.reportKind === 'batch-evaluation') {
       if (!record.meta || !Array.isArray(record.items)) return null;
       return { ...record, id: typeof record.id === 'string' && record.id ? record.id : fallbackId } as unknown as ReportDocument;
     }
@@ -60,7 +60,7 @@ export function createFileStore(dir: string): ReportStore {
     ) {
       return {
         ...record,
-        kind: 'evaluation',
+        reportKind: 'evaluation',
         id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
       } as unknown as ReportDocument;
     }
@@ -68,7 +68,7 @@ export function createFileStore(dir: string): ReportStore {
   }
 
   function isEvaluationReport(report: ReportDocument): report is EvaluationReport {
-    return report.kind === 'evaluation';
+    return report.reportKind === 'evaluation';
   }
 
   // Studio 每个 / 和 /skills/<name> 请求都调 list(),里面对每个 .json 同步 readFile +
@@ -230,7 +230,7 @@ export async function queryJob(jobStore: JobStore, id: string): Promise<Evaluati
 
 export interface RunListItem {
   id: string;
-  kind: ReportDocument['kind'];
+  reportKind: ReportDocument['reportKind'];
   meta: ReportDocument['meta'];
   summary?: EvaluationReport['summary'];
   items?: BatchEvaluationReport['items'];
@@ -256,9 +256,9 @@ export interface TrendQueryResult {
 export async function queryRunList(reportStore: ReportStore): Promise<RunListItem[]> {
   return (await reportStore.list()).map((report) => ({
     id: report.id,
-    kind: report.kind,
+    reportKind: report.reportKind,
     meta: report.meta,
-    ...(report.kind === 'evaluation' ? { summary: report.summary } : { items: report.items }),
+    ...(report.reportKind === 'evaluation' ? { summary: report.summary } : { items: report.items }),
   }));
 }
 

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -134,7 +134,7 @@ function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, d
   // 每一段的 right-hand-side 从旧的 "{dir-mtime}-{file-count}" 双标量升级成
   // safeDirJsonContentFingerprint 返回的 "{dir-mtime}|{file1}:{m}:{s},..."
   // content-aware 字符串。
-  const reportIds = reports.map((r) => `${r.id}:${r.meta?.timestamp ?? ''}:${r.kind === 'evaluation' ? r.meta.evolve?.skillName ?? '' : ''}`).join(',');
+  const reportIds = reports.map((r) => `${r.id}:${r.meta?.timestamp ?? ''}:${r.reportKind === 'evaluation' ? r.meta.evolve?.skillName ?? '' : ''}`).join(',');
   const doctorsFp = safeDirJsonContentFingerprint(doctorsDir);
   const analysesFp = safeDirJsonContentFingerprint(analysesDir);
   const observationsFp = safeDirJsonContentFingerprint(observationsDir);
@@ -327,7 +327,7 @@ export function buildSkillIndex(
   // ── eval 聚合(历史 list)─────────────────────────────────
   const evalBy: Record<string, SkillEvalSnapshot[]> = {};
   for (const r of reports) {
-    if (r.kind !== 'evaluation') continue;
+    if (r.reportKind !== 'evaluation') continue;
     const variants = r.meta.variants || [];
     for (const v of variants) {
       const skillName = skillNameForEvalVariant(r, v);
@@ -412,7 +412,7 @@ export function buildSkillIndex(
   // list 页对每个 entry 跑 detectInsights 的 CPU 开销迁移到这里,只 miss 时算一次。
   const insightsBySkill = new Map<string, Insight[]>();
   for (const ent of entries) {
-    const evalReport = ent.eval ? reports.find((r) => r.id === ent.eval!.reportId && r.kind === 'evaluation') as EvaluationReport | undefined : undefined;
+    const evalReport = ent.eval ? reports.find((r) => r.id === ent.eval!.reportId && r.reportKind === 'evaluation') as EvaluationReport | undefined : undefined;
     insightsBySkill.set(ent.skillName, detectInsights(ent, evalReport ?? null, {
       diagnostics: diagnosisBundle.bySkill[ent.skillName] ?? [],
     }));

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -287,7 +287,7 @@ function scanDoctorReports(dir: string): Record<string, SkillDoctorSnapshot[]> {
     if (!file.endsWith('.json')) continue;
     try {
       const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as DoctorReport;
-      if (data?.kind !== 'doctor' || !Array.isArray(data.skills)) continue;
+      if (data?.reportKind !== 'doctor' || !Array.isArray(data.skills)) continue;
       const ts = data.timestamp;
       for (const sr of data.skills) {
         const passN = sr.results.filter((r) => r.status === 'pass').length;

--- a/src/server/skill-insights.ts
+++ b/src/server/skill-insights.ts
@@ -735,7 +735,7 @@ function detectOmkDoctorBlindspot(
           snippet: `// omk 仓库新增 composer rule(omk 维护者负责,非 skill 开发者职责)
 export const skillAntiPatternComposer: ComposerRule = {
   id: 'skill_anti_patterns',
-  kind: 'composer',
+  ruleKind: 'composer',
   severity: 'warn',
   labelKey: 'doctor.skill_anti_patterns.label',
   async checkAll(ctx): Promise<ComposerOutcome[]> {

--- a/src/types/doctor.ts
+++ b/src/types/doctor.ts
@@ -13,7 +13,7 @@ export type DoctorOutcome = 'passed' | 'warnings_only' | 'failed';
 
 /** Bumped whenever DoctorReport schema changes in a way CI consumers should
  *  be able to detect. CI can pin/check this when parsing the JSON. */
-export const DOCTOR_REPORT_SCHEMA_VERSION = '1.0.0';
+export const DOCTOR_REPORT_SCHEMA_VERSION = '2.0.0';
 
 export interface DoctorRuleResult {
   ruleId: string;
@@ -109,7 +109,7 @@ export interface DoctorSkillReport {
 }
 
 export interface DoctorReport {
-  kind: 'doctor';
+  reportKind: 'doctor';
   /** Schema version the JSON consumer can pin/check. Bumped on any
    *  user-visible change to this report's shape. See DOCTOR_REPORT_SCHEMA_VERSION. */
   schemaVersion: string;

--- a/src/types/doctor.ts
+++ b/src/types/doctor.ts
@@ -48,11 +48,11 @@ export interface ComposerOutcome extends DoctorRuleCheckOutcome {
 }
 
 /** 复合 rule:一次 checkAll() 产出多条 result,适合"单次 LLM 调用 → N 个维度结果"
- *  这类场景。doctor engine 检测 kind === 'composer' 时把数组结果展开,每条共享
+ *  这类场景。doctor engine 检测 ruleKind === 'composer' 时把数组结果展开,每条共享
  *  同一个 groupId(= composer.id)以便 renderer 分组。 */
 export interface ComposerRule {
   id: string;
-  kind: 'composer';
+  ruleKind: 'composer';
   /** 默认 severity(子 outcome 未指定时用)。 */
   severity: DoctorSeverity;
   /** 默认 labelKey(子 outcome 未指定时用,通常是 composer 整体的标签)。 */
@@ -64,7 +64,7 @@ export interface ComposerRule {
 export type DoctorRuleLike = DoctorRule | ComposerRule;
 
 export function isComposerRule(r: DoctorRuleLike): r is ComposerRule {
-  return (r as ComposerRule).kind === 'composer';
+  return (r as ComposerRule).ruleKind === 'composer';
 }
 
 export interface DoctorContext {

--- a/src/types/executor.ts
+++ b/src/types/executor.ts
@@ -169,7 +169,7 @@ export interface ExecutorRuntimeBinary {
 export interface ExecutorRuntimeFingerprint {
   executor: string;
   model: string;
-  kind: ExecutorRuntimeKind;
+  runtimeKind: ExecutorRuntimeKind;
   fingerprint: string;
   binary?: ExecutorRuntimeBinary;
   sdk?: ExecutorRuntimePackage;

--- a/src/types/observability.ts
+++ b/src/types/observability.ts
@@ -80,7 +80,7 @@ export interface ObservationReviewStateEntry {
 }
 
 export interface ObservationReviewState {
-  kind: 'observe-review-state';
+  reportKind: 'observe-review-state';
   schemaVersion: 1;
   updatedAt: string;
   entries: Record<string, ObservationReviewStateEntry>;
@@ -285,7 +285,7 @@ export interface ObservationSessionTimeRange {
 }
 
 export interface ObservationInboxReport {
-  kind: 'observe-inbox';
+  reportKind: 'observe-inbox';
   schemaVersion: 1;
   meta: {
     tracePath: string;
@@ -928,7 +928,7 @@ export interface ExperienceSkillSummary {
 }
 
 export interface ObservationExperienceReport {
-  kind: 'observe-experience';
+  reportKind: 'observe-experience';
   schemaVersion: 1;
   scope: 'evidence-only';
   generatedAt: string;

--- a/src/types/observability.ts
+++ b/src/types/observability.ts
@@ -950,7 +950,7 @@ export interface ObservationExperienceReport {
 export type ObservationRuntimeCheckStatus = 'passed' | 'attention' | 'manual_review';
 
 export interface ObservationRuntimeCheck {
-  kind: 'hardRule' | 'workflowNode';
+  nodeKind: 'hardRule' | 'workflowNode';
   id: string;
   title: string;
   expectation: string;
@@ -980,7 +980,7 @@ export interface SkillRuntimeEvidencePackRef extends Pick<ExperienceEvidenceRef,
 
 export interface SkillRuntimeEvidencePackNode {
   nodeId: string;
-  kind: 'workflowNode' | 'hardRule';
+  nodeKind: 'workflowNode' | 'hardRule';
   title: string;
   expectation: string;
   deterministicStatus: ObservationRuntimeCheckStatus;

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -321,7 +321,7 @@ export interface SampleSnapshot {
 }
 
 export interface EvaluationReport {
-  kind: 'evaluation';
+  reportKind: 'evaluation';
   id: string;
   meta: ReportMeta;
   summary: Record<string, VariantSummary>;
@@ -378,7 +378,7 @@ export interface BatchEvaluationItem {
 }
 
 export interface BatchEvaluationReport {
-  kind: 'batch-evaluation';
+  reportKind: 'batch-evaluation';
   id: string;
   mode: 'skill';
   meta: BatchEvaluationMeta;

--- a/test/analysis/failure-clusterer.test.ts
+++ b/test/analysis/failure-clusterer.test.ts
@@ -13,7 +13,7 @@ const variantResult = (overrides: Partial<VariantResult> = {}): VariantResult =>
 });
 
 const buildReport = (entries: Array<{ id: string; perVariant: Record<string, Partial<VariantResult>> }>, variants: string[]): Report => ({
-  kind: 'evaluation',
+  reportKind: 'evaluation',
   id: 'r',
   meta: {
     variants, model: 'm', judgeModels: [{ executor: 'claude', model: 'j' }], executor: 'claude',

--- a/test/analysis/sample-diagnostics.test.ts
+++ b/test/analysis/sample-diagnostics.test.ts
@@ -43,7 +43,7 @@ describe('diagnoseSamples — flat / all-pass / all-fail', () => {
     ], ['v1', 'v2']);
     const d = diagnoseSamples(r);
     assert.ok(d.byKind.all_fail?.includes('s1'));
-    assert.ok(d.issues.some((i) => i.kind === 'all_fail' && i.severity === 'error'));
+    assert.ok(d.issues.some((i) => i.issueKind === 'all_fail' && i.severity === 'error'));
   });
 
   it('flags flat_scores when spread < threshold', () => {
@@ -77,7 +77,7 @@ describe('diagnoseSamples — error_prone', () => {
       { id: 'all-broken', perVariant: { v1: { ok: false }, v2: { ok: false } } },
     ], ['v1', 'v2']);
     const d = diagnoseSamples(r);
-    const issue = d.issues.find((i) => i.kind === 'error_prone');
+    const issue = d.issues.find((i) => i.issueKind === 'error_prone');
     assert.equal(issue?.severity, 'error');
   });
 });
@@ -139,7 +139,7 @@ describe('diagnoseSamples — near_duplicate', () => {
     const d = diagnoseSamples(r, { samples, duplicateRouge: 0.6 });
     assert.ok(d.byKind.near_duplicate, 'expected near_duplicate kind');
     assert.equal(d.byKind.near_duplicate![0], 'a');
-    const issue = d.issues.find((i) => i.kind === 'near_duplicate');
+    const issue = d.issues.find((i) => i.issueKind === 'near_duplicate');
     assert.equal(issue?.evidence.duplicateOf, 'b');
   });
 
@@ -311,7 +311,7 @@ describe('diagnoseSamples — capability_thin', () => {
     const { report, samples } = buildN(10, (i) => i < 8 ? ['common'] : ['rare']);
     const d = diagnoseSamples(report, { samples });
     assert.ok(d.byKind.capability_thin, 'rare capability should be flagged');
-    const rareIssue = d.issues.find((i) => i.kind === 'capability_thin');
+    const rareIssue = d.issues.find((i) => i.issueKind === 'capability_thin');
     assert.ok(rareIssue);
     assert.equal((rareIssue!.evidence as { capability: string }).capability, 'rare');
     assert.equal((rareIssue!.evidence as { sampleCount: number }).sampleCount, 2);
@@ -344,7 +344,7 @@ describe('diagnoseSamples — capability_thin', () => {
       return ['core'];
     });
     const d = diagnoseSamples(report, { samples });
-    const rareIssue = d.issues.find((i) => i.kind === 'capability_thin'
+    const rareIssue = d.issues.find((i) => i.issueKind === 'capability_thin'
       && (i.evidence as { capability?: string })?.capability === 'rare');
     assert.ok(rareIssue, 'rare capability with deduped count=1 should still flag thin');
     assert.equal((rareIssue!.evidence as { sampleCount: number }).sampleCount, 1, 'count should be 1 (deduped), not 3');

--- a/test/analysis/sample-diagnostics.test.ts
+++ b/test/analysis/sample-diagnostics.test.ts
@@ -13,7 +13,7 @@ const variantResult = (overrides: Partial<VariantResult> = {}): VariantResult =>
 });
 
 const buildReport = (entries: Array<{ id: string; perVariant: Record<string, Partial<VariantResult>> }>, variants: string[]): Report => ({
-  kind: 'evaluation',
+  reportKind: 'evaluation',
   id: 'r',
   meta: {
     variants, model: 'm', judgeModels: [{ executor: 'claude', model: 'j' }], executor: 'claude',

--- a/test/analysis/sample-quality-aggregate.test.ts
+++ b/test/analysis/sample-quality-aggregate.test.ts
@@ -91,7 +91,7 @@ describe('buildSampleQualityAggregate', () => {
 describe('analyzeResults — sampleQuality wiring', () => {
   function emptyReport(): Report {
     return {
-      kind: 'evaluation',
+      reportKind: 'evaluation',
       id: 'r',
       meta: {
         variants: ['v1', 'v2'], model: 'm', judgeModels: [{ executor: 'claude', model: 'j' }], executor: 'claude',

--- a/test/authoring/sample-fixer.test.ts
+++ b/test/authoring/sample-fixer.test.ts
@@ -5,7 +5,7 @@ import type { EvaluationReport } from '../../src/types/report.js';
 
 function reportWithFailedAssertion(): EvaluationReport {
   return {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id: 'r1',
     meta: {
       variants: ['skill'],

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -61,7 +61,7 @@ const variantSummary = (score: number): VariantSummary => ({
 });
 
 const buildProductTreeReport = (): Report => ({
-  kind: 'evaluation',
+  reportKind: 'evaluation',
   id: 'cli-tree-report',
   meta: {
     variants: ['baseline', 'v1'],

--- a/test/cli/doctor-retention.test.ts
+++ b/test/cli/doctor-retention.test.ts
@@ -12,7 +12,7 @@ function seedDoctorHistory(dir: string, skillName: string, count: number): strin
     const timestamp = `2026-05-${String(10 + i).padStart(2, '0')}T00:00:00.000Z`;
     const file = `${skillName}-r${String(i).padStart(3, '0')}.json`;
     writeFileSync(join(dir, file), JSON.stringify({
-      kind: 'doctor',
+      reportKind: 'doctor',
       id: `r${i}`,
       timestamp,
       skills: [{ skillName, status: 'pass', results: [] }],
@@ -66,7 +66,7 @@ describe('pruneDoctorHistory', () => {
   it('清理遗留 `{name}.json` 命名:同 skill 旧文件也参与轮换', () => {
     // 旧 schema:文件名是 {skill}.json,timestamp 是早期
     writeFileSync(join(dir, 'code-review.json'), JSON.stringify({
-      kind: 'doctor',
+      reportKind: 'doctor',
       id: 'legacy',
       timestamp: '2025-01-01T00:00:00.000Z',
       skills: [{ skillName: 'code-review', status: 'pass', results: [] }],
@@ -85,7 +85,7 @@ describe('pruneDoctorHistory', () => {
   it('忽略 non-doctor / 多 skill / 损坏 JSON', () => {
     writeFileSync(join(dir, 'eval-report.json'), JSON.stringify({ kind: 'evaluation' }));
     writeFileSync(join(dir, 'multi-skill.json'), JSON.stringify({
-      kind: 'doctor',
+      reportKind: 'doctor',
       skills: [{ skillName: 'a' }, { skillName: 'b' }],
     }));
     writeFileSync(join(dir, 'corrupt.json'), '{ not json');

--- a/test/cli/doctor-retention.test.ts
+++ b/test/cli/doctor-retention.test.ts
@@ -83,7 +83,7 @@ describe('pruneDoctorHistory', () => {
   });
 
   it('忽略 non-doctor / 多 skill / 损坏 JSON', () => {
-    writeFileSync(join(dir, 'eval-report.json'), JSON.stringify({ kind: 'evaluation' }));
+    writeFileSync(join(dir, 'eval-report.json'), JSON.stringify({ reportKind: 'evaluation' }));
     writeFileSync(join(dir, 'multi-skill.json'), JSON.stringify({
       reportKind: 'doctor',
       skills: [{ skillName: 'a' }, { skillName: 'b' }],

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -38,7 +38,7 @@ describe('omk doctor CLI', () => {
     assert.ok(!stdout.includes('健康度'));
   });
 
-  it('--json on example skill outputs valid DoctorReport with kind=doctor', async () => {
+  it('--json on example skill outputs valid DoctorReport with reportKind=doctor', async () => {
     const { stdout } = await execFileAsync('node', [
       CLI,
       'doctor',
@@ -47,7 +47,7 @@ describe('omk doctor CLI', () => {
       '--executor', DOCTOR_FIXTURE,
     ]);
     const parsed = JSON.parse(stdout);
-    assert.equal(parsed.kind, 'doctor');
+    assert.equal(parsed.reportKind, 'doctor');
     assert.ok(Array.isArray(parsed.skills));
     assert.ok(parsed.skills.length >= 1);
     assert.equal(parsed.outcome, 'passed');
@@ -62,7 +62,7 @@ describe('omk doctor CLI', () => {
       '--executor', DOCTOR_FIXTURE,
     ]);
     const parsed = JSON.parse(stdout);
-    assert.equal(parsed.kind, 'doctor');
+    assert.equal(parsed.reportKind, 'doctor');
     assert.ok(parsed.skills.length >= 2, 'should batch multiple skills from the dir');
   });
 
@@ -196,7 +196,7 @@ describe('omk doctor CLI', () => {
       '--static-only',
     ]);
     const parsed = JSON.parse(stdout);
-    assert.equal(parsed.kind, 'doctor');
+    assert.equal(parsed.reportKind, 'doctor');
     assert.ok(parsed.skills.length >= 1);
     // Static rules present, composer (skill_health) absent under --static-only.
     const staticRuleIds = parsed.skills[0].results.map((r: { ruleId: string }) => r.ruleId);

--- a/test/cli/observe.test.ts
+++ b/test/cli/observe.test.ts
@@ -9,7 +9,7 @@ describe('observe CLI', () => {
   it('filters by skill before rendering the by-skill rollup', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-observe-cli-'));
     writeFileSync(join(dir, '2026-05-07T00-00-00-observe-inbox.json'), JSON.stringify({
-      kind: 'observe-inbox',
+      reportKind: 'observe-inbox',
       schemaVersion: 1,
       meta: {
         tracePath: '/tmp/trace',

--- a/test/cli/run-tally.test.ts
+++ b/test/cli/run-tally.test.ts
@@ -29,7 +29,7 @@ function summary(successCount: number, errorCount: number): VariantSummary {
 describe('computeRunTally', () => {
   it('aggregates successCount / errorCount across variants in a single-skill report', () => {
     const report = {
-      kind: 'evaluation',
+      reportKind: 'evaluation',
       id: 'r1',
       meta: {} as EvaluationReport['meta'],
       summary: {
@@ -44,7 +44,7 @@ describe('computeRunTally', () => {
 
   it('aggregates across all batch items', () => {
     const report = {
-      kind: 'batch-evaluation',
+      reportKind: 'batch-evaluation',
       id: 'b1',
       mode: 'skill',
       meta: {} as BatchEvaluationReport['meta'],
@@ -97,7 +97,7 @@ describe('computeRunTally', () => {
 
   it('returns zeros for an empty single report', () => {
     const report = {
-      kind: 'evaluation',
+      reportKind: 'evaluation',
       id: 'empty',
       meta: {} as EvaluationReport['meta'],
       summary: {},

--- a/test/diagnosis/observe-mapper.test.ts
+++ b/test/diagnosis/observe-mapper.test.ts
@@ -19,7 +19,7 @@ describe('buildObserveDiagnostics', () => {
         {
           skillName: 'prd-create',
           id: 'workflow-step-1',
-          kind: 'workflowNode',
+          nodeKind: 'workflowNode',
           status: 'manual_review',
           title: 'Workflow node needs review',
           reason: 'runtime did not show the expected step',
@@ -28,7 +28,7 @@ describe('buildObserveDiagnostics', () => {
         {
           skillName: 'prd-create',
           id: 'hardrule-ok',
-          kind: 'hardRule',
+          nodeKind: 'hardRule',
           status: 'passed',
         },
       ],
@@ -74,7 +74,7 @@ describe('buildObserveDiagnostics', () => {
         {
           skillName: 'prd-create',
           id: 'standard-1',
-          kind: 'workflow_candidate',
+          standardKind: 'workflow_candidate',
           status: 'pending_review',
           title: 'Demo generation workflow should be declared',
           source: 'llm_soft_standard',
@@ -83,7 +83,7 @@ describe('buildObserveDiagnostics', () => {
         {
           skillName: 'prd-create',
           id: 'standard-2',
-          kind: 'hard_rule_candidate',
+          standardKind: 'hard_rule_candidate',
           status: 'author_confirmed',
           title: 'Use source document before generating demo',
           source: 'manual',
@@ -123,7 +123,7 @@ describe('buildObserveDiagnostics', () => {
         { skillName: 'audit', code: 'skill_md_not_found' },
       ],
       derivedStandards: [
-        { skillName: 'audit', id: 'confirmed-1', kind: 'hard_rule_candidate', status: 'author_confirmed', title: 'Confirmed rule' },
+        { skillName: 'audit', id: 'confirmed-1', standardKind: 'hard_rule_candidate', status: 'author_confirmed', title: 'Confirmed rule' },
       ],
     });
 
@@ -209,9 +209,9 @@ describe('activeStudioDiagnostics — lifecycle 口径', () => {
     const bundle = buildObserveDiagnostics({
       generatedAt: 't',
       derivedStandards: [
-        { skillName: 'a', id: 's1', kind: 'hard_rule_candidate', status: 'pending_review', title: 'pending(candidate)' },
-        { skillName: 'a', id: 's2', kind: 'hard_rule_candidate', status: 'author_confirmed', title: 'confirmed(→resolved)' },
-        { skillName: 'a', id: 's3', kind: 'hard_rule_candidate', status: 'rejected', title: 'rejected' },
+        { skillName: 'a', id: 's1', standardKind: 'hard_rule_candidate', status: 'pending_review', title: 'pending(candidate)' },
+        { skillName: 'a', id: 's2', standardKind: 'hard_rule_candidate', status: 'author_confirmed', title: 'confirmed(→resolved)' },
+        { skillName: 'a', id: 's3', standardKind: 'hard_rule_candidate', status: 'rejected', title: 'rejected' },
       ],
     });
     const active = activeStudioDiagnostics(bundle);

--- a/test/diagnosis/observe-producer.test.ts
+++ b/test/diagnosis/observe-producer.test.ts
@@ -27,7 +27,7 @@ workflows:
 # omk_fake_skill_x9z
 `);
       const report = {
-        kind: 'observe-inbox',
+        reportKind: 'observe-inbox',
         schemaVersion: 1,
         meta: {
           tracePath: '/tmp/synthetic-trace',
@@ -39,7 +39,7 @@ workflows:
         },
         items: [],
         experience: {
-          kind: 'observe-experience',
+          reportKind: 'observe-experience',
           schemaVersion: 1,
           scope: 'evidence-only',
           generatedAt: '2026-05-15T00:00:00.000Z',
@@ -167,7 +167,7 @@ hardRules:
       process.chdir(projectA);  // 模拟在 projectA 跑 ingest
       try {
         const report = {
-          kind: 'observe-inbox',
+          reportKind: 'observe-inbox',
           schemaVersion: 1,
           meta: {
             tracePath: '/tmp/trace-b',
@@ -216,7 +216,7 @@ hardRules:
       process.chdir(projectA);
       try {
         const report = {
-          kind: 'observe-inbox',
+          reportKind: 'observe-inbox',
           schemaVersion: 1,
           meta: {
             tracePath: '/tmp/trace-clean',
@@ -228,7 +228,7 @@ hardRules:
           },
           items: [],
           experience: {
-            kind: 'observe-experience',
+            reportKind: 'observe-experience',
             schemaVersion: 1,
             scope: 'evidence-only',
             generatedAt: '2026-05-15T00:00:00.000Z',
@@ -290,7 +290,7 @@ hardRules:
     // skill_md_not_found / hardrules_not_declared 等 chain advisory,只保留 problemPatterns 等
     // 跟 cwd 无关的诊断。
     const report = {
-      kind: 'observe-inbox',
+      reportKind: 'observe-inbox',
       schemaVersion: 1,
       meta: {
         tracePath: '/tmp/trace',

--- a/test/doctor/health/composer.test.ts
+++ b/test/doctor/health/composer.test.ts
@@ -223,6 +223,6 @@ describe('skill_health composer', () => {
     assert.equal(SKILL_HEALTH_COMPOSER_ID, 'skill_health');
     const composer = makeSkillHealthComposer();
     assert.equal(composer.id, 'skill_health');
-    assert.equal(composer.kind, 'composer');
+    assert.equal(composer.ruleKind, 'composer');
   });
 });

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -163,7 +163,7 @@ describe('runDoctor', () => {
       lang: 'zh',
       rules: [passingRule],
     });
-    assert.equal(report.kind, 'doctor');
+    assert.equal(report.reportKind, 'doctor');
     assert.ok(report.skills.length >= 2);
     assert.equal(report.outcome, 'passed');
     assert.equal(report.totals.pass, report.skills.length);

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -652,7 +652,7 @@ describe('DoctorReport — CI-friendly schema fields', () => {
     };
     const composer: ComposerRule = {
       id: 'test_composer',
-      kind: 'composer',
+      ruleKind: 'composer',
       severity: 'fatal',
       labelKey: 'cli.doctor.rule.skill_readable',
       async checkAll() {
@@ -702,7 +702,7 @@ describe('DoctorReport — CI-friendly schema fields', () => {
     };
     const crashing: ComposerRule = {
       id: 'crash_composer',
-      kind: 'composer',
+      ruleKind: 'composer',
       severity: 'fatal',
       labelKey: 'cli.doctor.rule.skill_readable',
       async checkAll() { throw new Error('composer exploded'); },

--- a/test/eval-core/comparability.test.ts
+++ b/test/eval-core/comparability.test.ts
@@ -11,7 +11,7 @@ function runtime(executor: string, model: string, fingerprint: string): Executor
   return {
     executor,
     model,
-    kind: 'agent-sdk',
+    runtimeKind: 'agent-sdk',
     fingerprint,
     binary: { name: executor, source: 'bundled', version: '1.0.0' },
     sdk: { name: `${executor}-sdk`, version: '1.0.0' },
@@ -68,7 +68,7 @@ describe('comparability warnings', () => {
     const warnings = reportComparabilityWarnings(report({
       executorRuntime: {
         ...runtime('codex', 'm', 'exec11111111'),
-        kind: 'agent-cli',
+        runtimeKind: 'agent-cli',
         binary: { name: 'codex', source: 'path', error: 'not found' },
         sdk: undefined,
       },

--- a/test/eval-core/comparability.test.ts
+++ b/test/eval-core/comparability.test.ts
@@ -26,7 +26,7 @@ function runtime(executor: string, model: string, fingerprint: string): Executor
 
 function report(overrides: Partial<Report['meta']> = {}): Report {
   return {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id: 'r',
     meta: {
       variants: ['control', 'treatment'],

--- a/test/eval-core/verdict.test.ts
+++ b/test/eval-core/verdict.test.ts
@@ -13,7 +13,7 @@ const summary = (avg: { fact?: number; behavior?: number; judge?: number; compos
 });
 
 const buildReport = (overrides: Partial<Report> & { variants: string[]; perVariantAvg: Record<string, Parameters<typeof summary>[0]>; pairs?: Report['meta']['pairComparisons'] }): Report => ({
-  kind: 'evaluation',
+  reportKind: 'evaluation',
   id: 'r1',
   meta: {
     variants: overrides.variants,

--- a/test/evaluation/evaluation-reporting.test.ts
+++ b/test/evaluation/evaluation-reporting.test.ts
@@ -96,7 +96,7 @@ describe('aggregateReport — reproducibility metadata', () => {
     const report = aggregateReport({ ...baseOpts, executorName: 'codex-sdk', model: 'gpt-5', noJudge: true });
     assert.equal(report.meta.executorRuntime?.executor, 'codex-sdk');
     assert.equal(report.meta.executorRuntime?.model, 'gpt-5');
-    assert.equal(report.meta.executorRuntime?.kind, 'agent-sdk');
+    assert.equal(report.meta.executorRuntime?.runtimeKind, 'agent-sdk');
     assert.match(report.meta.executorRuntime!.fingerprint, /^[0-9a-f]{12}$/);
     assert.equal(report.meta.executorRuntime?.sdk?.name, '@openai/codex-sdk');
     assert.equal(report.meta.executorRuntime?.binary?.source, 'bundled');

--- a/test/evolver.test.ts
+++ b/test/evolver.test.ts
@@ -13,7 +13,7 @@ function makeSummary(avgScore: number): VariantSummary {
 
 function makeReport(variantName: string, sampleScores: Record<string, number>, avgScore: number): Report {
   return {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id: `${variantName}-id`,
     meta: {
       variants: [variantName],

--- a/test/grading/debias-validate.test.ts
+++ b/test/grading/debias-validate.test.ts
@@ -38,7 +38,7 @@ const buildReport = (
   rows: Array<{ sample_id: string; output: string; llmScore: number }>,
   debiasMode: Array<'length' | 'position'> = ['length'],
 ): Report => ({
-  kind: 'evaluation',
+  reportKind: 'evaluation',
   id: 'r1',
   meta: {
     variants: [variant],

--- a/test/grading/gold-cli.test.ts
+++ b/test/grading/gold-cli.test.ts
@@ -34,7 +34,7 @@ const buildReport = (
   scoresById: Record<string, number>,
   judgeModel = 'claude-sonnet-4-6',
 ): Report => ({
-  kind: 'evaluation',
+  reportKind: 'evaluation',
   id: 'r1',
   meta: {
     variants: [variant],

--- a/test/html-renderer.test.ts
+++ b/test/html-renderer.test.ts
@@ -12,7 +12,7 @@ function normalizeForSnapshot(html: string): string {
 }
 
 const SAMPLE_REPORT: Report = {
-  kind: 'evaluation',
+  reportKind: 'evaluation',
   // 让 id 匹配 renderRunList 里的 YYYYMMDD-HHmm regex (html-renderer.ts:62),
   // 这样列表页 row 的时间从 id 直接提取 (deterministic), 不走 toLocaleString
   // — 后者本地时区敏感, 会让 snapshot 在 CI UTC 和本地 CST 之间不一致.

--- a/test/html-renderer.test.ts
+++ b/test/html-renderer.test.ts
@@ -387,7 +387,7 @@ describe('renderRunDetail', () => {
     runtimeReport.meta.executorRuntime = {
       executor: 'codex-sdk',
       model: 'gpt-5',
-      kind: 'agent-sdk',
+      runtimeKind: 'agent-sdk',
       fingerprint: 'abc123def456',
       binary: { name: 'codex', source: 'bundled', version: '0.128.0' },
       sdk: { name: '@openai/codex-sdk', version: '0.128.0' },
@@ -403,7 +403,7 @@ describe('renderRunDetail', () => {
       runtime: {
         executor: 'claude-sdk',
         model: 'haiku',
-        kind: 'agent-sdk',
+        runtimeKind: 'agent-sdk',
         fingerprint: 'def456abc123',
         binary: { name: 'claude-code', source: 'bundled', version: '2.1.118' },
         sdk: { name: '@anthropic-ai/claude-agent-sdk', version: '0.2.118' },
@@ -431,7 +431,7 @@ describe('renderRunDetail', () => {
         runtime: {
           executor: 'claude',
           model: 'opus',
-          kind: 'agent-cli',
+          runtimeKind: 'agent-cli',
           fingerprint: 'judge1111111',
           binary: { name: 'claude', source: 'path', version: '2.0.0' },
           capabilities: { systemPrompt: 'native', costUSD: 'reported', trace: 'native', skillIsolation: 'full-no-partial' },
@@ -443,7 +443,7 @@ describe('renderRunDetail', () => {
         runtime: {
           executor: 'openai-api',
           model: 'gpt-4o',
-          kind: 'api',
+          runtimeKind: 'api',
           fingerprint: 'judge2222222',
           binary: { name: 'openai-api', source: 'none' },
           capabilities: { systemPrompt: 'native', costUSD: 'not-reported', trace: 'none', skillIsolation: 'none' },

--- a/test/observability/inbox/aggregation.test.ts
+++ b/test/observability/inbox/aggregation.test.ts
@@ -122,7 +122,7 @@ describe('observe inbox - aggregation', () => {
   it('queries only the latest saved report by default', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-'));
     const oldReport = {
-      kind: 'observe-inbox' as const,
+      reportKind: 'observe-inbox' as const,
       schemaVersion: 1 as const,
       meta: {
         generatedAt: '2026-05-01T00:00:00.000Z',
@@ -145,7 +145,7 @@ describe('observe inbox - aggregation', () => {
       items: [baseItem({ id: 'old', skillName: 'old_skill', lastSeen: '2026-05-01T00:00:00.000Z' })],
     };
     const latestReport = {
-      kind: 'observe-inbox' as const,
+      reportKind: 'observe-inbox' as const,
       schemaVersion: 1 as const,
       meta: {
         generatedAt: '2026-05-02T00:00:00.000Z',

--- a/test/observability/inbox/experience-report.test.ts
+++ b/test/observability/inbox/experience-report.test.ts
@@ -107,7 +107,7 @@ describe('observe inbox - experience report', () => {
     const report = buildObservationInboxReport(file);
     const experience = report.experience;
     assert.ok(experience);
-    assert.equal(experience.kind, 'observe-experience');
+    assert.equal(experience.reportKind, 'observe-experience');
     assert.equal(experience.scope, 'evidence-only');
     assert.equal(experience.meta.skillCount, 1);
     assert.equal(experience.goalSlices.length, 1);
@@ -200,13 +200,13 @@ describe('observe inbox - experience report', () => {
       reportCount: 1,
       latestSeenLabel: '2026-05-01 00:00:04',
       reviewState: {
-        kind: 'observe-review-state',
+        reportKind: 'observe-review-state',
         schemaVersion: 1,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       },
       resolvedReviewSessions: resolvedReviewSessionsForFixture(experience, {
-        kind: 'observe-review-state',
+        reportKind: 'observe-review-state',
         schemaVersion: 1,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
@@ -278,7 +278,7 @@ describe('observe inbox - experience report', () => {
     }, 'user_goal_shift');
     const annotatedReport = buildObservationInboxReport(file, {
       reviewState: {
-        kind: 'observe-review-state',
+        reportKind: 'observe-review-state',
         schemaVersion: 1,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {

--- a/test/observability/inbox/review-state.test.ts
+++ b/test/observability/inbox/review-state.test.ts
@@ -130,7 +130,7 @@ describe('observe inbox - review state', () => {
     assert.ok(correction);
     const targetId = observationMetricAnnotationTargetId({ ...correction.evidenceRef, metricScopeId: session.id }, 'user_correction');
     const reviewState = {
-      kind: 'observe-review-state' as const,
+      reportKind: 'observe-review-state' as const,
       schemaVersion: 1 as const,
       updatedAt: '2026-05-11T02:00:03.000Z',
       entries: {
@@ -420,7 +420,7 @@ describe('observe inbox - review state', () => {
     };
     mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
     writeFileSync(skillDerivedStandardsPath(dir, chain.skillName), JSON.stringify({
-      kind: 'observe-skill-derived-standards',
+      reportKind: 'observe-skill-derived-standards',
       schemaVersion: 1,
       skillName: chain.skillName,
       generatedAt: '2026-05-18T00:00:00.000Z',
@@ -500,7 +500,7 @@ describe('observe inbox - review state', () => {
     };
     mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
     writeFileSync(skillDerivedStandardsPath(dir, chain.skillName), JSON.stringify({
-      kind: 'observe-skill-derived-standards',
+      reportKind: 'observe-skill-derived-standards',
       schemaVersion: 1,
       skillName: chain.skillName,
       generatedAt: '2026-05-18T00:00:00.000Z',

--- a/test/observability/inbox/signal-detection.test.ts
+++ b/test/observability/inbox/signal-detection.test.ts
@@ -297,7 +297,7 @@ describe('observe inbox - signal detection', () => {
     assert.ok(artifactEvent);
     const artifactTargetId = observationMetricAnnotationTargetId(artifactEvent, 'deliverable_artifact');
     const reviewState = {
-      kind: 'observe-review-state' as const,
+      reportKind: 'observe-review-state' as const,
       schemaVersion: 1 as const,
       updatedAt: '2026-05-10T00:00:00.000Z',
       entries: {

--- a/test/observability/inbox/trace-ingestion.test.ts
+++ b/test/observability/inbox/trace-ingestion.test.ts
@@ -57,7 +57,7 @@ describe('observe inbox - trace ingestion', () => {
     writeFileSync(file, records.map((r) => JSON.stringify(r)).join('\n'));
 
     const report = buildObservationInboxReport(file);
-    assert.equal(report.kind, 'observe-inbox');
+    assert.equal(report.reportKind, 'observe-inbox');
     assert.equal(report.schemaVersion, 1);
     assert.equal(report.items.length, 1);
     assert.equal(report.items[0].severityReason, undefined);
@@ -214,13 +214,13 @@ describe('observe inbox - trace ingestion', () => {
       reportCount: 1,
       latestSeenLabel: '2026-05-01 00:10:02',
       reviewState: {
-        kind: 'observe-review-state',
+        reportKind: 'observe-review-state',
         schemaVersion: 1,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       },
       resolvedReviewSessions: resolvedReviewSessionsForFixture(experience, {
-        kind: 'observe-review-state',
+        reportKind: 'observe-review-state',
         schemaVersion: 1,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
@@ -606,7 +606,7 @@ describe('observe inbox - trace ingestion', () => {
     // 不同毫秒的 report 共用同一文件名, 第二份静默覆盖第一份。修复后保留毫秒。
     const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-'));
     const reportA = {
-      kind: 'observe-inbox' as const,
+      reportKind: 'observe-inbox' as const,
       schemaVersion: 1 as const,
       meta: {
         generatedAt: '2026-05-07T12:00:00.111Z',

--- a/test/observability/resolved-review.test.ts
+++ b/test/observability/resolved-review.test.ts
@@ -5,7 +5,7 @@ import type { ObservationReviewState } from '../../src/observability/review-stat
 import type { ExperienceSessionStoryAnswer } from '../../src/observability/experience.js';
 
 const emptyReviewState: ObservationReviewState = {
-  kind: 'observe-review-state',
+  reportKind: 'observe-review-state',
   schemaVersion: 1,
   updatedAt: '2026-05-18T00:00:00.000Z',
   entries: {},

--- a/test/observability/soft-standards.test.ts
+++ b/test/observability/soft-standards.test.ts
@@ -64,7 +64,7 @@ function node(input: Partial<RuntimeStandardNode> & { expectedSignals?: RuntimeS
   return {
     nodeId: input.nodeId ?? 'node',
     nodeEvidenceRef: input.nodeEvidenceRef,
-    kind: input.kind ?? 'workflow',
+    nodeKind: input.nodeKind ?? 'workflow',
     title: input.title ?? 'node',
     expectedSignals: input.expectedSignals ?? [],
     failureSignals: input.failureSignals ?? [],
@@ -272,7 +272,7 @@ describe('runtime standard trigger evaluator', () => {
       sameNodeRef,
     ], [{
       nodeId: 'same-node',
-      kind: 'workflowNode',
+      nodeKind: 'workflowNode',
       title: 'same-node',
       expectation: '结论',
       deterministicStatus: 'passed',
@@ -298,7 +298,7 @@ describe('runtime standard trigger evaluator', () => {
       ref({ id: 'global-result', sourceType: 'assistant_message', snippet: '结论如下', messageIndex: 12 }),
     ], [{
       nodeId: 'same-node',
-      kind: 'workflowNode',
+      nodeKind: 'workflowNode',
       title: 'same-node',
       expectation: '结论',
       deterministicStatus: 'manual_review',
@@ -323,7 +323,7 @@ describe('runtime standard trigger evaluator', () => {
     const readRef = ref({ id: 'read-ref', sourceType: 'tool_call', toolName: 'Read', snippet: 'Read source.md', messageIndex: 3 });
     const result = evaluateRuntimeStandardNodes([standard], pack([readRef], [{
       nodeId: 'workflow.read_source',
-      kind: 'workflowNode',
+      nodeKind: 'workflowNode',
       title: '读取源文档',
       expectation: '读取用户提供的文档',
       deterministicStatus: 'passed',
@@ -348,7 +348,7 @@ describe('runtime standard trigger evaluator', () => {
     const bashRef = ref({ id: 'bash-ref', sourceType: 'tool_call', toolName: 'Bash', snippet: 'node runner.js', messageIndex: 4 });
     const result = evaluateRuntimeStandardNodes([standard], pack([bashRef], [{
       nodeId: 'workflow.launch_child',
-      kind: 'workflowNode',
+      nodeKind: 'workflowNode',
       title: '启动子任务',
       expectation: '使用 runner.js 后台启动 child',
       deterministicStatus: 'passed',
@@ -373,7 +373,7 @@ describe('runtime standard trigger evaluator', () => {
     const resultRef = ref({ id: 'result-ref', sourceType: 'assistant_message', snippet: '结果如下', messageIndex: 5 });
     const positive = evaluateRuntimeStandardNodes([standard], pack([resultRef], [{
       nodeId: 'workflow.report_result',
-      kind: 'workflowNode',
+      nodeKind: 'workflowNode',
       title: '回传结果',
       expectation: '向用户回传结果',
       deterministicStatus: 'passed',
@@ -384,7 +384,7 @@ describe('runtime standard trigger evaluator', () => {
     const tied = evaluateRuntimeStandardNodes([standard], pack([resultRef], [
       {
         nodeId: 'workflow.report_result_a',
-        kind: 'workflowNode',
+        nodeKind: 'workflowNode',
         title: '回传结果',
         expectation: '向用户回传结果',
         deterministicStatus: 'passed',
@@ -394,7 +394,7 @@ describe('runtime standard trigger evaluator', () => {
       },
       {
         nodeId: 'workflow.report_result_b',
-        kind: 'workflowNode',
+        nodeKind: 'workflowNode',
         title: '回传结果',
         expectation: '向用户回传结果',
         deterministicStatus: 'passed',
@@ -480,7 +480,7 @@ describe('runtime standard trigger evaluator', () => {
     });
     const stage = node({
       nodeId: 'stage',
-      kind: 'stage',
+      nodeKind: 'stage',
       childNodeIds: ['child_ok', 'child_bad'],
     });
     const results = evaluateRuntimeStandardNodes([childOk, childBad, stage], pack([

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -636,7 +636,7 @@ describe('runBatchEvaluation', () => {
           // 不兜底——find 落空就 undefined.name 抛错,把误绑暴露成测试失败。
           const treatment = options.variantSpecs.find((spec) => spec.role === 'treatment')!.name;
           const report: Report = {
-            kind: 'evaluation',
+            reportKind: 'evaluation',
             id: options.runId!,
             meta: {
               variants: ['baseline', treatment],
@@ -674,7 +674,7 @@ describe('runBatchEvaluation', () => {
         },
       });
 
-      assert.equal(result.report.kind, 'batch-evaluation');
+      assert.equal(result.report.reportKind, 'batch-evaluation');
       assert.equal(result.report.mode, 'skill');
       assert.equal(result.report.meta.request?.batch, true);
       assert.equal(result.report.meta.request?.noCache, true);
@@ -734,7 +734,7 @@ describe('runBatchEvaluation', () => {
         runSingleEvaluation: async (options) => {
           capturedSpecs = options.variantSpecs;
           const report: Report = {
-            kind: 'evaluation',
+            reportKind: 'evaluation',
             id: options.runId!,
             meta: {
               variants: ['baseline', 'greeter'],
@@ -796,7 +796,7 @@ describe('runBatchEvaluation', () => {
         runSingleEvaluation: async (options) => {
           capturedSpecs = options.variantSpecs;
           const report: Report = {
-            kind: 'evaluation',
+            reportKind: 'evaluation',
             id: options.runId!,
             meta: {
               variants: ['baseline', 'greeter'],

--- a/test/saturation-integration.test.ts
+++ b/test/saturation-integration.test.ts
@@ -19,7 +19,7 @@ const buildRun = (
   const variants = Object.keys(variantScores);
   const sampleCount = variantScores[variants[0]].length;
   return {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id: runId,
     meta: {
       variants,

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -36,8 +36,6 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   // —— 持久化 report schema（Report JSON 字段语义，CLAUDE.md 列明的不变量）——
   "src/types/report.ts::EvaluationReport::'evaluation'",
   "src/types/report.ts::BatchEvaluationReport::'batch-evaluation'",
-  'src/types/executor.ts::ExecutorRuntimeFingerprint::ExecutorRuntimeKind',
-  "src/types/doctor.ts::DoctorReport::'doctor'",
   "src/server/report-store.ts::RunListItem::ReportDocument['kind']",
   // —— 持久化 observe / experience JSON ——
   "src/types/observability.ts::ObservationReviewState::'observe-review-state'",
@@ -70,7 +68,6 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   // 持久化进 experience evidence-pack 的 runtime check 节点
   "src/observability/skill-chain.ts::(anonymous)::'workflowNode' | 'hardRule'",
   // 外部 codex JSONL 事件的镜像 shape（omk 解析 codex stdout，非 omk 自有判别字段；codex 实际用 type）
-  'src/executors/shared.ts::CodexEvent::string',
 ]);
 
 function collectTsFiles(dir: string): string[] {

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -38,9 +38,6 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   "src/types/report.ts::BatchEvaluationReport::'batch-evaluation'",
   "src/server/report-store.ts::RunListItem::ReportDocument['kind']",
   // —— 持久化 observe / experience JSON ——
-  "src/types/observability.ts::ObservationReviewState::'observe-review-state'",
-  "src/types/observability.ts::ObservationInboxReport::'observe-inbox'",
-  "src/types/observability.ts::ObservationExperienceReport::'observe-experience'",
   'src/types/observability.ts::ExperienceEvidenceRef::ExperienceEvidenceKind',
   'src/types/observability.ts::ExperienceSessionStoryNode::ExperienceSessionStoryNodeKind',
   "src/types/observability.ts::ExperienceGoalEvidenceRef::'user_message' | 'goal_slice' | 'llm_goal'",
@@ -50,7 +47,6 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   'src/types/observability.ts::ExperienceProblemEvidenceRef::string',
   'src/types/observability.ts::ProblemTimelineEvent::string',
   // —— 持久化 soft-standards JSON（含 enhancedReview 内嵌结构）——
-  "src/observability/soft-standards/types.ts::SkillDerivedStandards::'observe-skill-derived-standards'",
   // ResolvedSkillStandard 非持久（view-model），但与持久 standard 同源、且被 renderer 多处 .kind 消费，
   // 跨模块改名风险高，渐进式留待后续单独处理。
   // —— 持久化 diagnosis JSON（payload spread 进 Diagnosis）——

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -1,0 +1,106 @@
+/**
+ * issue #206 护栏:裸 `kind` 留给 `ArtifactKind`。
+ *
+ * 产品语义里不带限定词的 `kind` 一律指 knowledge artifact 类型(`Artifact.kind`)。
+ * 其它判别字段必须用限定名(`reportKind` / `eventKind` / `runtimeKind` / `standardKind` ...)。
+ * 本测试 scan `src/**\/*.ts`,把「含裸 `kind` 作为对象 key / 字段声明」的文件集合冻结在
+ * ALLOWED_KIND_FILES 里。新文件引入裸 `kind` → 失败:
+ *   - 一般情况:改成限定名;
+ *   - 若确实是新的持久化判别字段:把文件加进 ALLOWED_KIND_FILES 并在 PR 里说明理由。
+ *
+ * 已序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 是可比性不变量,不在
+ * 渐进重命名范围内(改它要走 schema migration)。详见 docs/specs/terminology-spec.md §5.4。
+ *
+ * 检测口径与生成白名单的 grep 一致(逐行原文,不剥注释):
+ *   `kind` 前面不是标识符字符或点(排除 `artifactKind` / `byKind` / `.kind`),后跟 `?:` 或 `:`。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const SRC_DIR = join(PROJECT_ROOT, 'src');
+
+const BARE_KIND = /(^|[^A-Za-z0-9_.])kind\s*\??\s*:/;
+
+// 当前(post-#206-rename)合法持有裸 `kind` 的文件:
+//   - category A:`Artifact.kind: ArtifactKind` 及其构造点(eval.ts / skill-loader / task-planner ...);
+//   - category B:已持久化进 report / observe / doctor / diagnosis JSON 的判别字段(冻结);
+//   - 少数局部 param(parsers.ts 的数字解析 `kind`)。
+// 渐进重命名只动「内部非持久」字段,不动 B;新增裸 `kind` 一律先看能不能改限定名。
+const ALLOWED_KIND_FILES = new Set<string>([
+  'src/authoring/evolver.ts',
+  'src/cli/commands/eval/index.ts',
+  'src/cli/commands/observe/inbox.ts',
+  'src/cli/oclif/parsers.ts',
+  'src/diagnosis/observe-mapper.ts',
+  'src/diagnosis/observe-producer.ts',
+  'src/doctor/index.ts',
+  'src/doctor/preflight.ts',
+  'src/eval-core/evaluation-reporting.ts',
+  'src/eval-core/task-planner.ts',
+  'src/eval-workflows/batch-evaluation-workflow.ts',
+  'src/executors/runtime-fingerprint.ts',
+  'src/executors/shared.ts',
+  'src/inputs/skill-loader.ts',
+  'src/observability/experience.ts',
+  'src/observability/inbox.ts',
+  'src/observability/problem-patterns.ts',
+  'src/observability/resolved-review.ts',
+  'src/observability/review-state.ts',
+  'src/observability/skill-chain.ts',
+  'src/observability/soft-standards/llm-extractor.ts',
+  'src/observability/soft-standards/runtime-evaluator.ts',
+  'src/observability/soft-standards/skill-standards-store.ts',
+  'src/observability/soft-standards/types.ts',
+  'src/renderer/observation-inbox-renderer.ts',
+  'src/server/report-store.ts',
+  'src/types/diagnosis.ts',
+  'src/types/doctor.ts',
+  'src/types/eval.ts',
+  'src/types/executor.ts',
+  'src/types/observability.ts',
+  'src/types/report.ts',
+]);
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectTsFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+function hasBareKind(file: string): boolean {
+  return readFileSync(file, 'utf8').split('\n').some((line) => BARE_KIND.test(line));
+}
+
+describe('issue #206: 裸 kind 护栏', () => {
+  it('src 里没有未登记的裸 kind 声明文件', () => {
+    const actual = new Set(
+      collectTsFiles(SRC_DIR)
+        .filter(hasBareKind)
+        .map((f) => relative(PROJECT_ROOT, f).split('\\').join('/')),
+    );
+    const extra = [...actual].filter((f) => !ALLOWED_KIND_FILES.has(f)).sort();
+    const missing = [...ALLOWED_KIND_FILES].filter((f) => !actual.has(f)).sort();
+
+    assert.deepEqual(
+      extra,
+      [],
+      `这些文件新引入了裸 \`kind\`(issue #206)。裸 kind 留给 ArtifactKind;` +
+        `请改成限定名(reportKind/eventKind/runtimeKind/standardKind 等),` +
+        `或——若确为新的持久化判别字段——把文件加进 ALLOWED_KIND_FILES 并注明理由:\n  ${extra.join('\n  ')}`,
+    );
+    assert.deepEqual(
+      missing,
+      [],
+      `这些文件已不再含裸 \`kind\`,请从 ALLOWED_KIND_FILES 删除以保持白名单收紧:\n  ${missing.join('\n  ')}`,
+    );
+  });
+});

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -1,69 +1,74 @@
 /**
- * issue #206 护栏:裸 `kind` 留给 `ArtifactKind`。
+ * issue #206 护栏:裸 `kind` 字段只允许 `ArtifactKind`。
  *
- * 产品语义里不带限定词的 `kind` 一律指 knowledge artifact 类型(`Artifact.kind`)。
+ * 产品语义里不带限定词的 `kind` 一律指 knowledge artifact 类型(`Artifact.kind: ArtifactKind`)。
  * 其它判别字段必须用限定名(`reportKind` / `eventKind` / `runtimeKind` / `standardKind` ...)。
- * 本测试 scan `src/**\/*.ts`,把「含裸 `kind` 作为对象 key / 字段声明」的文件集合冻结在
- * ALLOWED_KIND_FILES 里。新文件引入裸 `kind` → 失败:
- *   - 一般情况:改成限定名;
- *   - 若确实是新的持久化判别字段:把文件加进 ALLOWED_KIND_FILES 并在 PR 里说明理由。
  *
- * 已序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 是可比性不变量,不在
- * 渐进重命名范围内(改它要走 schema migration)。详见 docs/specs/terminology-spec.md §5.4。
+ * 本测试用 TypeScript AST 扫 `src/**\/*.ts` 里**每个名为 `kind` 的字段声明**
+ * (interface / type-literal 的 PropertySignature、class 的 PropertyDeclaration —— 不含
+ * 函数 param、`.kind` 读取、对象字面量构造点、注释 / 字符串):
+ *   - 字段类型是 `ArtifactKind`(或以它为基的类型)→ 放行;
+ *   - 否则必须登记在 FROZEN_KIND_EXCEPTIONS —— 这些都是已经序列化进
+ *     report / observe / doctor / diagnosis JSON 的判别字段,是可比性不变量,改名要走
+ *     schema migration(详见 docs/specs/terminology-spec.md §5.4);
+ *   - 两者都不是 → 新代码引入了裸 `kind`,失败。改成限定名,或(确为新的持久化判别字段时)
+ *     显式登记并在 PR 里说明理由。
  *
- * 检测口径与生成白名单的 grep 一致(逐行原文,不剥注释):
- *   `kind` 前面不是标识符字符或点(排除 `artifactKind` / `byKind` / `.kind`),后跟 `?:` 或 `:`。
+ * key 形如 `相对路径::EnclosingType::字段类型文本`,只在真正增删 `kind` 字段时变化,
+ * 对缩进 / 换行 / 重排不敏感。
  */
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, '..', '..');
 const SRC_DIR = join(PROJECT_ROOT, 'src');
 
-const BARE_KIND = /(^|[^A-Za-z0-9_.])kind\s*\??\s*:/;
-
-// 当前(post-#206-rename)合法持有裸 `kind` 的文件:
-//   - category A:`Artifact.kind: ArtifactKind` 及其构造点(eval.ts / skill-loader / task-planner ...);
-//   - category B:已持久化进 report / observe / doctor / diagnosis JSON 的判别字段(冻结);
-//   - 少数局部 param(parsers.ts 的数字解析 `kind`)。
-// 渐进重命名只动「内部非持久」字段,不动 B;新增裸 `kind` 一律先看能不能改限定名。
-const ALLOWED_KIND_FILES = new Set<string>([
-  'src/authoring/evolver.ts',
-  'src/cli/commands/eval/index.ts',
-  'src/cli/commands/observe/inbox.ts',
-  'src/cli/oclif/parsers.ts',
-  'src/diagnosis/observe-mapper.ts',
-  'src/diagnosis/observe-producer.ts',
-  'src/doctor/index.ts',
-  'src/doctor/preflight.ts',
-  'src/eval-core/evaluation-reporting.ts',
-  'src/eval-core/task-planner.ts',
-  'src/eval-workflows/batch-evaluation-workflow.ts',
-  'src/executors/runtime-fingerprint.ts',
-  'src/executors/shared.ts',
-  'src/inputs/skill-loader.ts',
-  'src/observability/experience.ts',
-  'src/observability/inbox.ts',
-  'src/observability/problem-patterns.ts',
-  'src/observability/resolved-review.ts',
-  'src/observability/review-state.ts',
-  'src/observability/skill-chain.ts',
-  'src/observability/soft-standards/llm-extractor.ts',
-  'src/observability/soft-standards/runtime-evaluator.ts',
-  'src/observability/soft-standards/skill-standards-store.ts',
-  'src/observability/soft-standards/types.ts',
-  'src/renderer/observation-inbox-renderer.ts',
-  'src/server/report-store.ts',
-  'src/types/diagnosis.ts',
-  'src/types/doctor.ts',
-  'src/types/eval.ts',
-  'src/types/executor.ts',
-  'src/types/observability.ts',
-  'src/types/report.ts',
+// 已持久化进 JSON 的判别字段(可比性不变量,本轮冻结不改名)。
+// 这不是「允许裸 kind」的背书,而是「改名要走 schema migration」的债务登记。
+const FROZEN_KIND_EXCEPTIONS = new Set<string>([
+  // —— 持久化 report schema（Report JSON 字段语义，CLAUDE.md 列明的不变量）——
+  "src/types/report.ts::EvaluationReport::'evaluation'",
+  "src/types/report.ts::BatchEvaluationReport::'batch-evaluation'",
+  'src/types/executor.ts::ExecutorRuntimeFingerprint::ExecutorRuntimeKind',
+  "src/types/doctor.ts::DoctorReport::'doctor'",
+  "src/server/report-store.ts::RunListItem::ReportDocument['kind']",
+  // —— 持久化 observe / experience JSON ——
+  "src/types/observability.ts::ObservationReviewState::'observe-review-state'",
+  "src/types/observability.ts::ObservationInboxReport::'observe-inbox'",
+  "src/types/observability.ts::ObservationExperienceReport::'observe-experience'",
+  'src/types/observability.ts::ExperienceEvidenceRef::ExperienceEvidenceKind',
+  'src/types/observability.ts::ExperienceSessionStoryNode::ExperienceSessionStoryNodeKind',
+  "src/types/observability.ts::ExperienceGoalEvidenceRef::'user_message' | 'goal_slice' | 'llm_goal'",
+  'src/types/observability.ts::ExperienceEpisodeArtifact::ExperienceEpisodeArtifactKind',
+  'src/types/observability.ts::ExperienceSessionStoryGraphNode::ExperienceSessionStoryNodeKind',
+  'src/types/observability.ts::ExperienceReviewerReport::ExperienceReviewerReportScope',
+  'src/types/observability.ts::ExperienceProblemEvidenceRef::string',
+  'src/types/observability.ts::ProblemTimelineEvent::string',
+  "src/types/observability.ts::ObservationRuntimeCheck::'hardRule' | 'workflowNode'",
+  "src/types/observability.ts::SkillRuntimeEvidencePackNode::'workflowNode' | 'hardRule'",
+  // —— 持久化 soft-standards JSON（含 enhancedReview 内嵌结构）——
+  'src/observability/soft-standards/types.ts::SkillDerivedStandard::SkillDerivedStandardKind',
+  "src/observability/soft-standards/types.ts::SkillDerivedStandards::'observe-skill-derived-standards'",
+  'src/observability/soft-standards/types.ts::RuntimeStandardNode::RuntimeStandardNodeKind',
+  'src/observability/soft-standards/types.ts::RuntimeNodeResult::RuntimeStandardNodeKind',
+  "src/observability/soft-standards/types.ts::SkillLlmRuntimeNodeAssessment::'workflowNode' | 'hardRule'",
+  "src/observability/soft-standards/llm-extractor.ts::(anonymous)::SkillRuntimeEvidencePackNode['kind']",
+  // ResolvedSkillStandard 非持久（view-model），但与持久 standard 同源、且被 renderer 多处 .kind 消费，
+  // 跨模块改名风险高，渐进式留待后续单独处理。
+  'src/observability/soft-standards/types.ts::ResolvedSkillStandard::ResolvedSkillStandardKind',
+  // —— 持久化 diagnosis JSON（payload spread 进 Diagnosis）——
+  'src/types/diagnosis.ts::DiagnosisEvidenceRef::string',
+  "src/diagnosis/observe-mapper.ts::ObservationRuntimeCheckSource::'hardRule' | 'workflowNode'",
+  "src/diagnosis/observe-mapper.ts::SkillDerivedStandardSource::'hard_rule_candidate' | 'workflow_candidate'",
+  // 持久化进 experience evidence-pack 的 runtime check 节点
+  "src/observability/skill-chain.ts::(anonymous)::'workflowNode' | 'hardRule'",
+  // 外部 codex JSONL 事件的镜像 shape（omk 解析 codex stdout，非 omk 自有判别字段；codex 实际用 type）
+  'src/executors/shared.ts::CodexEvent::string',
 ]);
 
 function collectTsFiles(dir: string): string[] {
@@ -76,31 +81,76 @@ function collectTsFiles(dir: string): string[] {
   return out;
 }
 
-function hasBareKind(file: string): boolean {
-  return readFileSync(file, 'utf8').split('\n').some((line) => BARE_KIND.test(line));
+interface KindSite {
+  key: string;
+  file: string;
+  line: number;
+  enclosing: string;
+  typeText: string;
+}
+
+function enclosingTypeName(node: ts.Node): string {
+  let p: ts.Node | undefined = node.parent;
+  while (p) {
+    if (ts.isInterfaceDeclaration(p) || ts.isTypeAliasDeclaration(p)) return p.name.text;
+    if (ts.isClassDeclaration(p) && p.name) return p.name.text;
+    p = p.parent;
+  }
+  return '(anonymous)';
+}
+
+function findKindFields(absFile: string): KindSite[] {
+  const text = readFileSync(absFile, 'utf8');
+  const sf = ts.createSourceFile(absFile, text, ts.ScriptTarget.Latest, true);
+  const rel = relative(PROJECT_ROOT, absFile).split('\\').join('/');
+  const out: KindSite[] = [];
+  function visit(node: ts.Node): void {
+    if (
+      (ts.isPropertySignature(node) || ts.isPropertyDeclaration(node)) &&
+      node.name &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === 'kind'
+    ) {
+      const typeText = node.type ? node.type.getText(sf).replace(/\s+/g, ' ').trim() : '(none)';
+      const enclosing = enclosingTypeName(node);
+      const line = sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
+      out.push({ key: `${rel}::${enclosing}::${typeText}`, file: rel, line, enclosing, typeText });
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sf);
+  return out;
+}
+
+// `ArtifactKind` 本身,或以它为基的类型(如 `Exclude<ArtifactKind, 'baseline'>` / `ArtifactKind | null`)。
+function isArtifactKindType(typeText: string): boolean {
+  return /\bArtifactKind\b/.test(typeText);
 }
 
 describe('issue #206: 裸 kind 护栏', () => {
-  it('src 里没有未登记的裸 kind 声明文件', () => {
-    const actual = new Set(
-      collectTsFiles(SRC_DIR)
-        .filter(hasBareKind)
-        .map((f) => relative(PROJECT_ROOT, f).split('\\').join('/')),
-    );
-    const extra = [...actual].filter((f) => !ALLOWED_KIND_FILES.has(f)).sort();
-    const missing = [...ALLOWED_KIND_FILES].filter((f) => !actual.has(f)).sort();
+  it('每个 kind 字段声明要么是 ArtifactKind,要么是已登记的持久化例外', () => {
+    const sites = collectTsFiles(SRC_DIR).flatMap(findKindFields);
+
+    const offenders = sites
+      .filter((s) => !isArtifactKindType(s.typeText) && !FROZEN_KIND_EXCEPTIONS.has(s.key))
+      .map((s) => `  ${s.file}:${s.line}  ${s.enclosing}.kind: ${s.typeText}\n    key: ${s.key}`)
+      .sort();
+
+    const presentKeys = new Set(sites.map((s) => s.key));
+    const staleFrozen = [...FROZEN_KIND_EXCEPTIONS].filter((k) => !presentKeys.has(k)).sort();
 
     assert.deepEqual(
-      extra,
+      offenders,
       [],
-      `这些文件新引入了裸 \`kind\`(issue #206)。裸 kind 留给 ArtifactKind;` +
-        `请改成限定名(reportKind/eventKind/runtimeKind/standardKind 等),` +
-        `或——若确为新的持久化判别字段——把文件加进 ALLOWED_KIND_FILES 并注明理由:\n  ${extra.join('\n  ')}`,
+      `发现未登记的裸 \`kind\` 字段声明(issue #206)。裸 kind 留给 ArtifactKind:\n` +
+        `${offenders.join('\n')}\n\n` +
+        `修法:改成限定名(reportKind / eventKind / runtimeKind / standardKind 等);` +
+        `或——若确为新的持久化判别字段——把上面的 key 加进 FROZEN_KIND_EXCEPTIONS 并在 PR 说明理由。`,
     );
     assert.deepEqual(
-      missing,
+      staleFrozen,
       [],
-      `这些文件已不再含裸 \`kind\`,请从 ALLOWED_KIND_FILES 删除以保持白名单收紧:\n  ${missing.join('\n  ')}`,
+      `这些 FROZEN_KIND_EXCEPTIONS 已不存在(字段被删 / 改名 / 改类型),请删除以保持清单收紧:\n  ${staleFrozen.join('\n  ')}`,
     );
   });
 });

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -9,8 +9,9 @@
  * 函数 param、`.kind` 读取、对象字面量构造点、注释 / 字符串):
  *   - 字段类型是 `ArtifactKind`(或以它为基的类型)→ 放行;
  *   - 否则必须登记在 FROZEN_KIND_EXCEPTIONS —— 这些都是已经序列化进
- *     report / observe / doctor / diagnosis JSON 的判别字段,是可比性不变量,改名要走
- *     schema migration(详见 docs/specs/terminology-spec.md §5.4);
+ *     report / observe / doctor / diagnosis JSON 的判别字段,改名会破坏读取已有落盘文件,
+ *     要走单独的数据 / schema 迁移(序列化向后兼容,非统计可比性;
+ *     详见 docs/specs/terminology-spec.md §5.4);
  *   - 两者都不是 → 新代码引入了裸 `kind`,失败。改成限定名,或(确为新的持久化判别字段时)
  *     显式登记并在 PR 里说明理由。
  *
@@ -28,8 +29,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, '..', '..');
 const SRC_DIR = join(PROJECT_ROOT, 'src');
 
-// 已持久化进 JSON 的判别字段(可比性不变量,本轮冻结不改名)。
-// 这不是「允许裸 kind」的背书,而是「改名要走 schema migration」的债务登记。
+// 已序列化进 JSON 的判别字段:改名会破坏反序列化磁盘上已有的 report/observe/doctor/diagnosis
+// 文件,要走单独的数据/schema 迁移(序列化向后兼容,非统计可比性),本轮冻结。
+// 这是债务登记,不是「允许裸 kind」的背书。
 const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   // —— 持久化 report schema（Report JSON 字段语义，CLAUDE.md 列明的不变量）——
   "src/types/report.ts::EvaluationReport::'evaluation'",

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -34,9 +34,6 @@ const SRC_DIR = join(PROJECT_ROOT, 'src');
 // 这是债务登记,不是「允许裸 kind」的背书。
 const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   // —— 持久化 report schema（Report JSON 字段语义，CLAUDE.md 列明的不变量）——
-  "src/types/report.ts::EvaluationReport::'evaluation'",
-  "src/types/report.ts::BatchEvaluationReport::'batch-evaluation'",
-  "src/server/report-store.ts::RunListItem::ReportDocument['kind']",
   // —— 持久化 observe / experience JSON ——
   'src/types/observability.ts::ExperienceEvidenceRef::ExperienceEvidenceKind',
   'src/types/observability.ts::ExperienceSessionStoryNode::ExperienceSessionStoryNodeKind',

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -49,24 +49,13 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   'src/types/observability.ts::ExperienceReviewerReport::ExperienceReviewerReportScope',
   'src/types/observability.ts::ExperienceProblemEvidenceRef::string',
   'src/types/observability.ts::ProblemTimelineEvent::string',
-  "src/types/observability.ts::ObservationRuntimeCheck::'hardRule' | 'workflowNode'",
-  "src/types/observability.ts::SkillRuntimeEvidencePackNode::'workflowNode' | 'hardRule'",
   // —— 持久化 soft-standards JSON（含 enhancedReview 内嵌结构）——
-  'src/observability/soft-standards/types.ts::SkillDerivedStandard::SkillDerivedStandardKind',
   "src/observability/soft-standards/types.ts::SkillDerivedStandards::'observe-skill-derived-standards'",
-  'src/observability/soft-standards/types.ts::RuntimeStandardNode::RuntimeStandardNodeKind',
-  'src/observability/soft-standards/types.ts::RuntimeNodeResult::RuntimeStandardNodeKind',
-  "src/observability/soft-standards/types.ts::SkillLlmRuntimeNodeAssessment::'workflowNode' | 'hardRule'",
-  "src/observability/soft-standards/llm-extractor.ts::(anonymous)::SkillRuntimeEvidencePackNode['kind']",
   // ResolvedSkillStandard 非持久（view-model），但与持久 standard 同源、且被 renderer 多处 .kind 消费，
   // 跨模块改名风险高，渐进式留待后续单独处理。
-  'src/observability/soft-standards/types.ts::ResolvedSkillStandard::ResolvedSkillStandardKind',
   // —— 持久化 diagnosis JSON（payload spread 进 Diagnosis）——
   'src/types/diagnosis.ts::DiagnosisEvidenceRef::string',
-  "src/diagnosis/observe-mapper.ts::ObservationRuntimeCheckSource::'hardRule' | 'workflowNode'",
-  "src/diagnosis/observe-mapper.ts::SkillDerivedStandardSource::'hard_rule_candidate' | 'workflow_candidate'",
   // 持久化进 experience evidence-pack 的 runtime check 节点
-  "src/observability/skill-chain.ts::(anonymous)::'workflowNode' | 'hardRule'",
   // 外部 codex JSONL 事件的镜像 shape（omk 解析 codex stdout，非 omk 自有判别字段；codex 实际用 type）
 ]);
 

--- a/test/server/query-reports.test.ts
+++ b/test/server/query-reports.test.ts
@@ -26,7 +26,7 @@ function makeReport(id: string, variant: string, timestamp: string, avgScore: nu
     },
   };
   return {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id,
     meta: {
       variants: [variant],
@@ -78,17 +78,17 @@ describe('createFileStore legacy report loading', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-report-'));
     try {
       const legacy = makeReport('legacy-run', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
-      delete legacy.kind;
+      delete legacy.reportKind;
       delete legacy.id;
       writeFileSync(join(dir, 'legacy-run.json'), JSON.stringify(legacy, null, 2));
 
       const store = createFileStore(dir);
       const report = await store.get('legacy-run');
-      assert.equal(report?.kind, 'evaluation');
+      assert.equal(report?.reportKind, 'evaluation');
       assert.equal(report?.id, 'legacy-run');
       const list = await store.list();
       assert.equal(list.length, 1);
-      assert.equal(list[0].kind, 'evaluation');
+      assert.equal(list[0].reportKind, 'evaluation');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -98,7 +98,7 @@ describe('createFileStore legacy report loading', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-batch-'));
     try {
       const legacyBatch = makeReport('legacy-batch', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
-      delete legacyBatch.kind;
+      delete legacyBatch.reportKind;
       legacyBatch.overview = { totalArtifacts: 1, totalSamples: 1, totalCostUSD: 0, artifacts: [] };
       legacyBatch.artifacts = [];
       writeFileSync(join(dir, 'legacy-batch.json'), JSON.stringify(legacyBatch, null, 2));

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -145,7 +145,7 @@ describe('report-server', () => {
     writeFileSync(join(JOBS_DIR, 'job-test-run-001.json'), JSON.stringify(SAMPLE_JOB, null, 2));
     writeFileSync(join(JOBS_DIR, 'job-test-run-002.json'), JSON.stringify(FAILED_JOB, null, 2));
     writeFileSync(join(OBSERVATIONS_DIR, '2026-05-07T00-00-00-observe-inbox.json'), JSON.stringify({
-      kind: 'observe-inbox',
+      reportKind: 'observe-inbox',
       schemaVersion: 1,
       meta: {
         tracePath: '/tmp/trace',

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -15,7 +15,7 @@ const ANALYSES_DIR = join(tmpdir(), `omk-test-analyses-${Date.now()}`);
 const DOCTORS_DIR = join(tmpdir(), `omk-test-doctors-${Date.now()}`);
 
 const SAMPLE_REPORT = {
-  kind: 'evaluation',
+  reportKind: 'evaluation',
   id: 'test-run-001',
   meta: {
     variants: ['v1', 'v2'],

--- a/test/server/skill-index-cache.test.ts
+++ b/test/server/skill-index-cache.test.ts
@@ -72,7 +72,7 @@ import type { EvaluationReport } from '../../src/types/index.js';
 
 function mkReport(id: string, ts: string, variant: string): EvaluationReport {
   return {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id,
     meta: {
       variants: ['baseline', variant],

--- a/test/server/skill-insights.test.ts
+++ b/test/server/skill-insights.test.ts
@@ -54,7 +54,7 @@ function mkResult(sampleId: string, variant: string, opts: {
 
 function mkEvalReport(variant: string, results: ResultEntry[]): EvaluationReport {
   return {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id: `${variant}-test-id`,
     meta: {
       variants: ['baseline', variant],

--- a/test/variance-layers.test.ts
+++ b/test/variance-layers.test.ts
@@ -41,7 +41,7 @@ function makeRun(runId: string, perVariant: Record<string, LayerSeed>): Report {
     };
   }
   return {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id: runId,
     meta: {
       variants: Object.keys(perVariant),

--- a/test/variance-workflow.test.ts
+++ b/test/variance-workflow.test.ts
@@ -5,7 +5,7 @@ import type { Report, VariantSummary } from '../src/types/index.js';
 
 function makeReport(id: string, variantScores: Record<string, number>): Report {
   return {
-    kind: 'evaluation',
+    reportKind: 'evaluation',
     id,
     meta: {
       variants: Object.keys(variantScores),


### PR DESCRIPTION
## 用户影响

这是一条内部判别字段命名收敛 PR，落实 #206「让 `Artifact.kind` 成为 omk 里裸 `kind` 的主语义」。

对普通 CLI 用户，运行评测、查看报告、doctor / observe 的产品行为不变。对读取 omk JSON 的脚本、历史报告文件、Studio 旧落盘数据有迁移影响：本 PR 把多处已经落盘的判别字段从 `kind` 收敛为限定名（如 `reportKind` / `runtimeKind` / `standardKind` / `nodeKind`），旧 JSON 不保证被新版直接反序列化。

## 改了什么

- 约定：terminology spec §5.4（中英）+ AGENTS.md 确立「裸 `kind` 留给 `Artifact.kind` / `ArtifactKind`」；其它判别字段新写或能安全改名时用限定名。
- 非持久内部字段改名：`SampleIssue.kind` → `issueKind`、`ComposerRule.kind` → `ruleKind`。
- 护栏：`test/scripts/kind-semantics-guard.test.ts` 从文件级白名单升级为 TypeScript AST 声明点级扫描，只允许 `ArtifactKind` 字段继续叫裸 `kind`，其它例外必须显式登记。
- 落盘 / wire shape 收敛：
  - `EvaluationReport.kind` / `BatchEvaluationReport.kind` → `reportKind`。
  - `DoctorReport.kind` → `reportKind`，并把 `DOCTOR_REPORT_SCHEMA_VERSION` bump 到 `2.0.0`。
  - 多个 observe / experience / inbox 落盘文档判别字段 → `reportKind`。
  - runtime / soft-standard / runtime-node 判别字段收敛为 `runtimeKind` / `standardKind` / `nodeKind`。
  - `ExecutorRuntimeFingerprint` 的 TypeScript 字段改为 `runtimeKind`，但 fingerprint stable payload 仍写旧 key `kind`，避免 executor 指纹漂移。

## 迁移说明

这是 `BREAKING-SERIALIZATION`，不是 `BREAKING-COMPARABILITY`。

- 旧版生成的 report / observe / doctor / diagnosis JSON 如果依赖裸 `kind` 判别字段，新版可能无法直接识别或需要脚本侧更新字段名。
- 依赖 omk JSON 的外部脚本需要把读取字段改到新限定名：例如 `report.kind` → `report.reportKind`。
- 已落盘的旧报告 / observe inbox / doctor JSON 推荐重新生成；当前 PR 不提供旧 JSON 的通用 schema migration。
- Doctor JSON 消费方如果 pin 了 `DOCTOR_REPORT_SCHEMA_VERSION`，需要更新到 `2.0.0`。

## 测量学 caveat

本 PR 改的是序列化字段名和 TypeScript 判别字段，不改评分口径：不修改 judge prompt、observe LLM 增强复盘 prompt、五层评分管道、Bootstrap CI、Krippendorff alpha、length-debias 语义或 verdict 计算。

因此新旧 JSON **wire format 不兼容**，但同一评测在重新生成报告后，其测量数字和统计解释口径不因这次字段改名而变化。

## #206 待决处置

- RAG 是否表达成新 `ArtifactKind`：方向认可，但等 RAG 的 artifact 模型定义清楚再加 `rag` / `corpus`，现在不落空类型（届时单开 issue）。
- terminology spec / glossary 补原则：本 PR 已做（§5.4）。
- 内部非持久 kind 渐进 rename：本 PR 先做两处安全改名，并用 AST 护栏防止新裸 `kind` 混入。
- 已落盘 kind 字段：本 PR 选择在 0-1 阶段集中收敛，代价是序列化兼容破坏；迁移影响见上。
- install / list 前先补 lifecycle design note：已由 #209 覆盖。

Closes #206
