### PR TITLE
feat(cli): install 支持 git 源 + source-resolver 抽象

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -333,7 +333,7 @@ omk install omk-agent-skill --dest ~/.my-agent/skills
 omk install ./skills/review
 ```
 
-> 从当前仓库某个 ref 安装 skill(可复现;SHA 不可变、分支会随 ref 漂移)
+> 从当前仓库某个 ref 安装 skill（可复现；SHA 不可变、分支会随 ref 漂移）
 
 ```bash
 omk install git:main:skills/review

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -286,7 +286,7 @@ omk init my-project
 
 ## omk install
 
-安装 omk 官方 Agent Skill,或登记并分发用户自己的 skill(内置 id omk-agent-skill,或 skill 路径 + --kind skill)。默认写入本机已检测 agent 目标;安装用户 skill 时同时登记一条受管记录。
+安装 omk 官方 Agent Skill,或登记并分发用户自己的 skill(内置 id omk-agent-skill,本地路径,或 git:<ref>:<name> 取当前仓库某个 ref 的 skill)。默认写入本机已检测 agent 目标;安装用户 skill 时同时登记一条受管记录。
 
 **用法:**
 
@@ -331,6 +331,12 @@ omk install omk-agent-skill --dest ~/.my-agent/skills
 
 ```bash
 omk install ./skills/review
+```
+
+> 从当前仓库某个 ref 安装 skill(可复现;SHA 不可变、分支会随 ref 漂移)
+
+```bash
+omk install git:main:skills/review
 ```
 
 ## omk observe

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -286,7 +286,7 @@ omk init my-project
 
 ## omk install
 
-安装 omk 官方 Agent Skill,或登记并分发用户自己的 skill(内置 id omk-agent-skill,本地路径,或 git:<ref>:<name> 取当前仓库某个 ref 的 skill)。默认写入本机已检测 agent 目标;安装用户 skill 时同时登记一条受管记录。
+安装 omk 官方 Agent Skill，或登记并分发用户自己的 skill（内置 id omk-agent-skill，本地路径，或 git:<ref>:<name> 取当前仓库某个 ref 的 skill）。默认写入本机已检测 agent 目标；安装用户 skill 时同时登记一条受管记录。
 
 **用法:**
 
@@ -296,7 +296,7 @@ omk install <input> [flags]
 
 **参数:**
 
-- `input`(必填):要安装的知识输入:内置 id omk-agent-skill,本地 skill 路径(目录或 .md),或 git:<ref>:<name>(当前仓库某 ref 的 skill)。
+- `input`(必填):要安装的知识输入：内置 id omk-agent-skill，本地 skill 路径（目录或 .md），或 git:<ref>:<name>（当前仓库某 ref 的 skill）。
 
 **Flags:**
 

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -296,13 +296,13 @@ omk install <input> [flags]
 
 **参数:**
 
-- `input`(必填):要安装的知识输入:内置 id omk-agent-skill,或用户 skill 路径(目录或 .md)。
+- `input`(必填):要安装的知识输入:内置 id omk-agent-skill,本地 skill 路径(目录或 .md),或 git:<ref>:<name>(当前仓库某 ref 的 skill)。
 
 **Flags:**
 
-- `--dest` `option`:自定义 skill 根目录；omk 会安装到 <dir>/omk。
+- `--dest` `option`:自定义 skill 根目录；skill 安装到 <dir>/<name>（内置 omk-agent-skill 为 <dir>/omk）。
 - `--dry-run` `boolean`:只打印安装目标，不写文件。
-- `--force` `boolean`:覆盖已存在的 omk Agent Skill。
+- `--force` `boolean`:覆盖目标位置已存在的 skill。
 - `--kind` `skill|prompt|agent|workflow`:用户 artifact 的 kind(对齐 Artifact.kind)。可省:命中 SKILL.md 自动推导,当前仅支持 skill。
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--to` `option` (默认 `auto`):安装目标：auto（默认，本机已检测目标） / codex / claude / all。

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -37,9 +37,9 @@ omk install omk-agent-skill --dest ~/.my-agent/skills
 **Flags:**
 
 ```text
-  --dest <value>                  Custom skill root; installs into <dir>/omk.
+  --dest <value>                  Custom skill root; a skill installs into <dir>/<name> (the built-in omk-agent-skill into <dir>/omk).
   --dry-run                       Print install targets without writing files.
-  --force                         Overwrite an existing omk Agent Skill.
+  --force                         Overwrite an existing skill at the target location.
   --kind <skill|prompt|agent|workflow>Kind of the user artifact (aligns with Artifact.kind). Optional: inferred from SKILL.md; only skill is supported today.
   --lang <value>                  Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --to <value>                    Install target: auto (default, detected local targets) / codex / claude / all.

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -37,9 +37,9 @@ omk install omk-agent-skill --dest ~/.my-agent/skills
 **Flags:**
 
 ```text
-  --dest <value>                  自定义 skill 根目录；omk 会安装到 <dir>/omk。
+  --dest <value>                  自定义 skill 根目录；skill 安装到 <dir>/<name>（内置 omk-agent-skill 为 <dir>/omk）。
   --dry-run                       只打印安装目标，不写文件。
-  --force                         覆盖已存在的 omk Agent Skill。
+  --force                         覆盖目标位置已存在的 skill。
   --kind <skill|prompt|agent|workflow>用户 artifact 的 kind(对齐 Artifact.kind)。可省:命中 SKILL.md 自动推导,当前仅支持 skill。
   --lang <value>                  输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --to <value>                    安装目标：auto（默认，本机已检测目标） / codex / claude / all。

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -299,8 +299,8 @@ export default class Install extends BaseCommand {
   static args = {
     input: Args.string({
       description: bilingual({
-        zh: '要安装的知识输入:内置 id omk-agent-skill,或用户 skill 路径(目录或 .md)。',
-        en: 'Knowledge input to install: built-in id omk-agent-skill, or a user skill path (directory or .md).',
+        zh: '要安装的知识输入:内置 id omk-agent-skill,本地 skill 路径(目录或 .md),或 git:<ref>:<name>(当前仓库某 ref 的 skill)。',
+        en: 'Knowledge input to install: built-in id omk-agent-skill, a local skill path (directory or .md), or git:<ref>:<name> (a skill at a ref of the current repo).',
       }),
       required: true,
     }),
@@ -324,14 +324,14 @@ export default class Install extends BaseCommand {
     }),
     dest: Flags.string({
       description: bilingual({
-        zh: '自定义 skill 根目录；omk 会安装到 <dir>/omk。',
-        en: 'Custom skill root; installs into <dir>/omk.',
+        zh: '自定义 skill 根目录；skill 安装到 <dir>/<name>（内置 omk-agent-skill 为 <dir>/omk）。',
+        en: 'Custom skill root; a skill installs into <dir>/<name> (the built-in omk-agent-skill into <dir>/omk).',
       }),
     }),
     force: Flags.boolean({
       description: bilingual({
-        zh: '覆盖已存在的 omk Agent Skill。',
-        en: 'Overwrite an existing omk Agent Skill.',
+        zh: '覆盖目标位置已存在的 skill。',
+        en: 'Overwrite an existing skill at the target location.',
       }),
       default: false,
     }),

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -6,9 +6,10 @@ import { Args, Flags } from '@oclif/core';
 import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { tCli } from '../lib/i18n.js';
-import { resolveArtifacts } from '../../inputs/skill-loader.js';
+import { resolveInstallSource, SourceResolveError } from '../../inputs/source-resolver.js';
 import { buildManagedArtifactRecord, hashArtifactSource, isDistributablePath, managedDir, recordManagedArtifact } from '../../managed/index.js';
 import type { ArtifactKind, ManagedDistributionTarget } from '../../types/index.js';
+import type { InstallMessageKey } from '../lib/i18n-dict/install.js';
 
 const BUILTIN_OMK_AGENT_SKILL_ID = 'omk-agent-skill';
 const INSTALLABLE_KINDS: ArtifactKind[] = ['skill', 'prompt', 'agent', 'workflow'];
@@ -253,8 +254,8 @@ function looksLikeArtifactPath(input: string): boolean {
 
 export default class Install extends BaseCommand {
   static description = bilingual({
-    zh: '安装 omk 官方 Agent Skill,或登记并分发用户自己的 skill(内置 id omk-agent-skill,或 skill 路径 + --kind skill)。默认写入本机已检测 agent 目标;安装用户 skill 时同时登记一条受管记录。',
-    en: 'Install the official omk Agent Skill, or register and distribute your own skill (built-in id omk-agent-skill, or a skill path + --kind skill). Defaults to detected local agent targets; installing a user skill also records a managed entry.',
+    zh: '安装 omk 官方 Agent Skill,或登记并分发用户自己的 skill(内置 id omk-agent-skill,本地路径,或 git:<ref>:<name> 取当前仓库某个 ref 的 skill)。默认写入本机已检测 agent 目标;安装用户 skill 时同时登记一条受管记录。',
+    en: 'Install the official omk Agent Skill, or register and distribute your own skill (built-in id omk-agent-skill, a local path, or git:<ref>:<name> for a skill at a ref of the current repo). Defaults to detected local agent targets; installing a user skill also records a managed entry.',
   });
 
   static examples = [
@@ -285,6 +286,13 @@ export default class Install extends BaseCommand {
         en: 'Register and distribute your own skill (--kind optional; inferred from SKILL.md)',
       }),
       command: '<%= config.bin %> install ./skills/review',
+    },
+    {
+      description: bilingual({
+        zh: '从当前仓库某个 ref 安装 skill(可复现;SHA 不可变、分支会随 ref 漂移)',
+        en: 'Install a skill from a ref of the current repo (reproducible; a SHA is immutable, a branch drifts with the ref)',
+      }),
+      command: '<%= config.bin %> install git:main:skills/review',
     },
   ];
 
@@ -345,8 +353,8 @@ export default class Install extends BaseCommand {
         this.installBuiltinAgentSkill(flags, lang);
         return;
       }
-      if (looksLikeArtifactPath(args.input)) {
-        this.installUserSkill(args.input, flags.kind, flags, lang);
+      if (args.input.startsWith('git:') || looksLikeArtifactPath(args.input)) {
+        this.installManagedSkill(args.input, flags.kind, flags, lang);
         return;
       }
       throw new Error(tCli('cli.install.unknown_input', lang, { input: args.input }));
@@ -368,89 +376,82 @@ export default class Install extends BaseCommand {
     if (!flags['dry-run']) console.log(tCli('cli.install.next_hint', lang));
   }
 
-  private installUserSkill(input: string, kindFlag: string | undefined, flags: InstallFlags, lang: 'zh' | 'en'): void {
-    // kind 推导:--kind 显式优先;否则命中 SKILL.md / Phase 1 缺省 skill。
+  private installManagedSkill(input: string, kindFlag: string | undefined, flags: InstallFlags, lang: 'zh' | 'en'): void {
+    // kind 推导:--kind 显式优先;否则缺省 skill(Phase 1 仅 skill)。
     const kind: ArtifactKind = (kindFlag as ArtifactKind | undefined) ?? 'skill';
     if (kind !== 'skill') {
       throw new Error(tCli('cli.install.kind_unsupported', lang, { kind }));
     }
 
-    // 先做精确的、可 i18n 的路径校验,避免 resolveArtifacts 抛出未翻译的中英混杂裸串。
-    const abs = resolve(input);
-    if (!existsSync(abs)) {
-      throw new Error(tCli('cli.install.path_not_found', lang, { path: abs }));
+    // 源解析委托给 source-resolver(file / git ...),install 主干源无关。
+    // resolver 不依赖 CLI,错误以 SourceResolveError(messageKey) 抛出,这里映射成本地化文案。
+    let src;
+    try {
+      src = resolveInstallSource(input);
+    } catch (err) {
+      if (err instanceof SourceResolveError) {
+        throw new Error(tCli(err.messageKey as InstallMessageKey, lang, err.params));
+      }
+      throw err;
     }
-    const inputIsDir = statSync(abs).isDirectory();
-    if (inputIsDir && !existsSync(join(abs, 'SKILL.md'))) {
-      throw new Error(tCli('cli.install.skillmd_missing', lang, { path: abs }));
-    }
-    if (!inputIsDir && !/\.md$/i.test(abs)) {
-      throw new Error(tCli('cli.install.not_a_skill', lang, { path: abs }));
-    }
-
-    // 绝对路径必含 `/`,走 resolveArtifacts 的 file-path 分支(目录→SKILL.md 设 skillRoot,裸 .md 不设)。
-    const artifact = resolveArtifacts(dirname(abs), [abs])[0];
-    const isDirectorySkill = Boolean(artifact.skillRoot);
-    // source = 重读重哈的根:目录-skill 为 skillRoot(目录),文件-skill 为 .md。locator 也存这个,
-    // 使未来 hashArtifactSource(record.source.locator, isDirectorySkill) 能直接 round-trip。
-    const source = isDirectorySkill ? artifact.skillRoot! : artifact.locator!;
-    // 目录-skill 哈整棵分发树(含 references/ 等资产,排除 .omk/.git/evolve),drift 不漏资产改动。
-    const contentHash = hashArtifactSource(source, isDirectorySkill);
-
-    const targets = resolveInstallTargets({ to: flags.to, dest: flags.dest, lang });
-    validateInstallTargets({
-      targetPaths: targets.map((t) => targetArtifactPath(t, artifact.name, isDirectorySkill)),
-      force: flags.force,
-      dryRun: flags['dry-run'],
-      lang,
-      source,
-    });
-
-    const now = new Date().toISOString();
-    const distribution: ManagedDistributionTarget[] = [];
-    const dir = managedDir();
-    // 即便多目标中途失败,也把已成功分发的落点登记进记录,保持"磁盘 == 记录"一致;
-    // 重跑 --force 时 upsert 会按 path 去重并补齐其余目标。
-    const writeRecordIfAny = (): void => {
-      if (flags['dry-run'] || distribution.length === 0) return;
-      const record = buildManagedArtifactRecord({
-        name: artifact.name,
-        kind,
-        source: {
-          locator: source,
-          ...(artifact.ref ? { ref: artifact.ref } : {}),
-          isDirectorySkill,
-        },
-        contentHash,
-        installedAt: now,
-        distribution,
-      });
-      recordManagedArtifact(record, { dir });
-      console.log(tCli('cli.install.registered', lang, { id: record.id, store: dir }));
-    };
 
     try {
-      for (const target of targets) {
-        const targetPath = targetArtifactPath(target, artifact.name, isDirectorySkill);
-        const { planned, inPlace } = copyArtifactToTarget({
-          source,
-          isDirectorySkill,
-          targetPath,
-          skillsDir: target.skillsDir,
-          force: flags.force,
-          dryRun: flags['dry-run'],
-          lang,
+      const { localRoot, name, isDirectorySkill, sourceKind, locator, ref } = src;
+      // 目录-skill 哈整棵可分发树(排除 .omk/.git/evolve);git 源哈的是物化后的临时树。
+      const contentHash = hashArtifactSource(localRoot, isDirectorySkill);
+
+      const targets = resolveInstallTargets({ to: flags.to, dest: flags.dest, lang });
+      validateInstallTargets({
+        targetPaths: targets.map((t) => targetArtifactPath(t, name, isDirectorySkill)),
+        force: flags.force,
+        dryRun: flags['dry-run'],
+        lang,
+        source: localRoot,
+      });
+
+      const now = new Date().toISOString();
+      const distribution: ManagedDistributionTarget[] = [];
+      const dir = managedDir();
+      // 即便多目标中途失败,也把已成功分发的落点登记进记录,保持"磁盘 == 记录"一致;
+      // 重跑 --force 时 upsert 会按 path 去重并补齐其余目标。
+      const writeRecordIfAny = (): void => {
+        if (flags['dry-run'] || distribution.length === 0) return;
+        const record = buildManagedArtifactRecord({
+          name,
+          kind,
+          source: { sourceKind, locator, ...(ref ? { ref } : {}), isDirectorySkill },
+          contentHash,
+          installedAt: now,
+          distribution,
         });
-        if (planned) {
-          console.log(tCli('cli.install.plan', lang, { path: targetPath }));
-        } else {
-          // inPlace:源就在目标位置,未动文件,但仍登记为一条分发落点。
-          console.log(tCli(inPlace ? 'cli.install.adopted' : 'cli.install.copied', lang, { name: artifact.name, path: targetPath }));
-          distribution.push({ label: target.label, path: targetPath, contentHash, copiedAt: now });
+        recordManagedArtifact(record, { dir });
+        console.log(tCli('cli.install.registered', lang, { id: record.id, store: dir }));
+      };
+
+      try {
+        for (const target of targets) {
+          const targetPath = targetArtifactPath(target, name, isDirectorySkill);
+          const { planned, inPlace } = copyArtifactToTarget({
+            source: localRoot,
+            isDirectorySkill,
+            targetPath,
+            skillsDir: target.skillsDir,
+            force: flags.force,
+            dryRun: flags['dry-run'],
+            lang,
+          });
+          if (planned) {
+            console.log(tCli('cli.install.plan', lang, { path: targetPath }));
+          } else {
+            console.log(tCli(inPlace ? 'cli.install.adopted' : 'cli.install.copied', lang, { name, path: targetPath }));
+            distribution.push({ label: target.label, path: targetPath, contentHash, copiedAt: now });
+          }
         }
+      } finally {
+        writeRecordIfAny();
       }
     } finally {
-      writeRecordIfAny();
+      src.cleanup(); // git 删临时物化目录;file noop
     }
   }
 }

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -238,7 +238,7 @@ function installOmkAgentSkill(params: {
 
 /**
  * 是否当作用户 artifact 路径(否则按 typo 的内置 id 处理,报 unknown_input)。
- *   - 显式路径意图(含 `/`)或 `.md` 结尾 → 是(后续 installUserSkill 会给出精确的存在性 / SKILL.md 报错);
+ *   - 显式路径意图(含 `/`)或 `.md` 结尾 → 是(后续 installManagedSkill 经 resolver 给出精确的存在性 / SKILL.md 报错);
  *   - 裸短名 → 仅当它确实解析到一个含 SKILL.md 的目录才算;裸的同名普通文件(如 cwd 里恰好有个
  *     `omk-agnt-skill` 文件)不该被当成 skill 安装,落回 unknown_input。
  */
@@ -254,7 +254,7 @@ function looksLikeArtifactPath(input: string): boolean {
 
 export default class Install extends BaseCommand {
   static description = bilingual({
-    zh: '安装 omk 官方 Agent Skill,或登记并分发用户自己的 skill(内置 id omk-agent-skill,本地路径,或 git:<ref>:<name> 取当前仓库某个 ref 的 skill)。默认写入本机已检测 agent 目标;安装用户 skill 时同时登记一条受管记录。',
+    zh: '安装 omk 官方 Agent Skill，或登记并分发用户自己的 skill（内置 id omk-agent-skill，本地路径，或 git:<ref>:<name> 取当前仓库某个 ref 的 skill）。默认写入本机已检测 agent 目标；安装用户 skill 时同时登记一条受管记录。',
     en: 'Install the official omk Agent Skill, or register and distribute your own skill (built-in id omk-agent-skill, a local path, or git:<ref>:<name> for a skill at a ref of the current repo). Defaults to detected local agent targets; installing a user skill also records a managed entry.',
   });
 
@@ -299,7 +299,7 @@ export default class Install extends BaseCommand {
   static args = {
     input: Args.string({
       description: bilingual({
-        zh: '要安装的知识输入:内置 id omk-agent-skill,本地 skill 路径(目录或 .md),或 git:<ref>:<name>(当前仓库某 ref 的 skill)。',
+        zh: '要安装的知识输入：内置 id omk-agent-skill，本地 skill 路径（目录或 .md），或 git:<ref>:<name>（当前仓库某 ref 的 skill）。',
         en: 'Knowledge input to install: built-in id omk-agent-skill, a local skill path (directory or .md), or git:<ref>:<name> (a skill at a ref of the current repo).',
       }),
       required: true,
@@ -456,7 +456,7 @@ export default class Install extends BaseCommand {
   }
 }
 
-// --kind 单独传入 installUserSkill,故此处不含 kind 字段(裸 kind 留给 ArtifactKind)。
+// --kind 单独传入 installManagedSkill,故此处不含 kind 字段(裸 kind 留给 ArtifactKind)。
 type InstallFlags = {
   to: string;
   dest?: string;

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -289,7 +289,7 @@ export default class Install extends BaseCommand {
     },
     {
       description: bilingual({
-        zh: '从当前仓库某个 ref 安装 skill(可复现;SHA 不可变、分支会随 ref 漂移)',
+        zh: '从当前仓库某个 ref 安装 skill（可复现；SHA 不可变、分支会随 ref 漂移）',
         en: 'Install a skill from a ref of the current repo (reproducible; a SHA is immutable, a branch drifts with the ref)',
       }),
       command: '<%= config.bin %> install git:main:skills/review',

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -441,7 +441,7 @@ export default class Install extends BaseCommand {
             lang,
           });
           if (planned) {
-            console.log(tCli('cli.install.plan', lang, { path: targetPath }));
+            console.log(tCli('cli.install.plan_skill', lang, { name, path: targetPath }));
           } else {
             console.log(tCli(inPlace ? 'cli.install.adopted' : 'cli.install.copied', lang, { name, path: targetPath }));
             distribution.push({ label: target.label, path: targetPath, contentHash, copiedAt: now });

--- a/src/cli/lib/i18n-dict/install.ts
+++ b/src/cli/lib/i18n-dict/install.ts
@@ -30,8 +30,8 @@ export const installDict: Record<InstallMessageKey, CliMessage> = {
     en: 'Packaged built-in asset not found: {path}. Run yarn build first, or verify the npm package includes dist/assets/agent-skills/omk.',
   },
   'cli.install.unknown_input': {
-    zh: 'install 接受内置 id omk-agent-skill,或一个 skill 路径（如 ./skills/review、./review.md）。无法识别的输入：{input}',
-    en: 'install accepts the built-in id omk-agent-skill, or a skill path (e.g. ./skills/review or ./review.md). Unrecognized input: {input}',
+    zh: 'install 接受内置 id omk-agent-skill、本地 skill 路径（如 ./skills/review、./review.md），或 git:<ref>:<name>（当前仓库某 ref 的 skill）。无法识别的输入：{input}',
+    en: 'install accepts the built-in id omk-agent-skill, a local skill path (e.g. ./skills/review or ./review.md), or git:<ref>:<name> (a skill at a ref of the current repo). Unrecognized input: {input}',
   },
   'cli.install.unknown_target': {
     zh: '未知安装目标：{target}。可用值：auto, codex, claude, all；或用 --dest <dir> 指定 skill 根目录。',
@@ -106,7 +106,7 @@ export const installDict: Record<InstallMessageKey, CliMessage> = {
     en: 'Skill {name} not found at git ref {ref} (neither {name}/SKILL.md nor {name}.md).',
   },
   'cli.install.git_unsafe_path': {
-    zh: 'git tree 含越界路径 {path}（.. / 绝对路径 / 空段),拒绝物化以防写出临时目录。该 skill 的 git tree 可能被手工构造,请核查来源。',
+    zh: 'git tree 含越界路径 {path}（.. / 绝对路径 / 空段），拒绝物化以防写出临时目录。该 skill 的 git tree 可能被手工构造，请核查来源。',
     en: 'git tree contains an out-of-bounds path {path} (.. / absolute / empty segment); refusing to materialize to avoid escaping the temp dir. The skill git tree may be hand-crafted; verify the source.',
   },
   'cli.install.next_hint': {

--- a/src/cli/lib/i18n-dict/install.ts
+++ b/src/cli/lib/i18n-dict/install.ts
@@ -8,6 +8,7 @@ export type InstallMessageKey =
   | 'cli.install.no_detected_targets'
   | 'cli.install.target_exists'
   | 'cli.install.plan'
+  | 'cli.install.plan_skill'
   | 'cli.install.installed'
   | 'cli.install.kind_unsupported'
   | 'cli.install.copied'
@@ -44,12 +45,16 @@ export const installDict: Record<InstallMessageKey, CliMessage> = {
     en: 'No supported local agent skill directory was detected. Pass --to codex / --to claude / --to all, or pass --dest <dir> for a custom skill root.',
   },
   'cli.install.target_exists': {
-    zh: '目标已存在：{path}。如要更新 omk Agent Skill，请加 --force。',
-    en: 'Target already exists: {path}. Pass --force to update the omk Agent Skill.',
+    zh: '目标已存在：{path}。如要覆盖，请加 --force。',
+    en: 'Target already exists: {path}. Pass --force to overwrite.',
   },
   'cli.install.plan': {
     zh: '将安装 omk Agent Skill 到：{path}',
     en: 'Will install the omk Agent Skill to: {path}',
+  },
+  'cli.install.plan_skill': {
+    zh: '将安装 skill {name} 到：{path}',
+    en: 'Will install skill {name} to: {path}',
   },
   'cli.install.installed': {
     zh: '已安装 omk Agent Skill：{path}',

--- a/src/cli/lib/i18n-dict/install.ts
+++ b/src/cli/lib/i18n-dict/install.ts
@@ -87,7 +87,7 @@ export const installDict: Record<InstallMessageKey, CliMessage> = {
     en: 'Not a skill file (expected a .md file or a directory containing SKILL.md): {path}',
   },
   'cli.install.not_a_git_repo': {
-    zh: '当前目录不在 git 仓库内,无法解析 git: 源。请在仓库内执行,或改用本地路径。',
+    zh: '当前目录不在 git 仓库内，无法解析 git: 源。请在仓库内执行，或改用本地路径。',
     en: 'Current directory is not inside a git repo; cannot resolve a git: source. Run inside the repo, or use a local path.',
   },
   'cli.install.git_skill_not_found': {

--- a/src/cli/lib/i18n-dict/install.ts
+++ b/src/cli/lib/i18n-dict/install.ts
@@ -17,6 +17,8 @@ export type InstallMessageKey =
   | 'cli.install.path_not_found'
   | 'cli.install.skillmd_missing'
   | 'cli.install.not_a_skill'
+  | 'cli.install.not_a_git_repo'
+  | 'cli.install.git_skill_not_found'
   | 'cli.install.next_hint';
 
 export const installDict: Record<InstallMessageKey, CliMessage> = {
@@ -83,6 +85,14 @@ export const installDict: Record<InstallMessageKey, CliMessage> = {
   'cli.install.not_a_skill': {
     zh: '不是 skill 文件（需要 .md 或含 SKILL.md 的目录）：{path}',
     en: 'Not a skill file (expected a .md file or a directory containing SKILL.md): {path}',
+  },
+  'cli.install.not_a_git_repo': {
+    zh: '当前目录不在 git 仓库内,无法解析 git: 源。请在仓库内执行,或改用本地路径。',
+    en: 'Current directory is not inside a git repo; cannot resolve a git: source. Run inside the repo, or use a local path.',
+  },
+  'cli.install.git_skill_not_found': {
+    zh: '在 git ref {ref} 下找不到 skill {name}（既无 {name}/SKILL.md 也无 {name}.md）。',
+    en: 'Skill {name} not found at git ref {ref} (neither {name}/SKILL.md nor {name}.md).',
   },
   'cli.install.next_hint': {
     zh: '现在可以在 coding agent 中说「用 omk 评测这个 skill」。',

--- a/src/cli/lib/i18n-dict/install.ts
+++ b/src/cli/lib/i18n-dict/install.ts
@@ -21,6 +21,7 @@ export type InstallMessageKey =
   | 'cli.install.not_a_skill'
   | 'cli.install.not_a_git_repo'
   | 'cli.install.git_skill_not_found'
+  | 'cli.install.git_unsafe_path'
   | 'cli.install.next_hint';
 
 export const installDict: Record<InstallMessageKey, CliMessage> = {
@@ -103,6 +104,10 @@ export const installDict: Record<InstallMessageKey, CliMessage> = {
   'cli.install.git_skill_not_found': {
     zh: '在 git ref {ref} 下找不到 skill {name}（既无 {name}/SKILL.md 也无 {name}.md）。',
     en: 'Skill {name} not found at git ref {ref} (neither {name}/SKILL.md nor {name}.md).',
+  },
+  'cli.install.git_unsafe_path': {
+    zh: 'git tree 含越界路径 {path}（.. / 绝对路径 / 空段),拒绝物化以防写出临时目录。该 skill 的 git tree 可能被手工构造,请核查来源。',
+    en: 'git tree contains an out-of-bounds path {path} (.. / absolute / empty segment); refusing to materialize to avoid escaping the temp dir. The skill git tree may be hand-crafted; verify the source.',
   },
   'cli.install.next_hint': {
     zh: '现在可以在 coding agent 中说「用 omk 评测这个 skill」。',

--- a/src/cli/lib/i18n-dict/install.ts
+++ b/src/cli/lib/i18n-dict/install.ts
@@ -16,6 +16,7 @@ export type InstallMessageKey =
   | 'cli.install.target_overlaps_source'
   | 'cli.install.path_not_found'
   | 'cli.install.skillmd_missing'
+  | 'cli.install.skillmd_is_symlink'
   | 'cli.install.not_a_skill'
   | 'cli.install.not_a_git_repo'
   | 'cli.install.git_skill_not_found'
@@ -85,6 +86,10 @@ export const installDict: Record<InstallMessageKey, CliMessage> = {
   'cli.install.not_a_skill': {
     zh: '不是 skill 文件（需要 .md 或含 SKILL.md 的目录）：{path}',
     en: 'Not a skill file (expected a .md file or a directory containing SKILL.md): {path}',
+  },
+  'cli.install.skillmd_is_symlink': {
+    zh: 'SKILL.md 是指向 {target} 的软链，分发会跳过软链、装出来的 skill 会缺 SKILL.md。请直接 install 真源位置：{target}',
+    en: 'SKILL.md is a symlink to {target}; symlinks are skipped during distribution, so the installed skill would be missing its SKILL.md. Install the real source instead: {target}',
   },
   'cli.install.not_a_git_repo': {
     zh: '当前目录不在 git 仓库内，无法解析 git: 源。请在仓库内执行，或改用本地路径。',

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -67,12 +67,14 @@ export interface GitTreeEntry {
 /**
  * 递归列出 `<ref>:<treePath>` 子树下的叶子条目(blob / 软链 / submodule)。tree 不存在返回 []。
  * 用 `-z`(NUL 分隔):git 不会对含换行 / 非 ASCII 的路径做 C-quote,路径原样可回喂 git show。
+ * 用 `--full-tree`:treePath 是仓库根相对路径,不受当前 cwd 前缀限制 —— 否则在仓库子目录执行时
+ * `ls-tree HEAD:skills/review` 会返回空(而 gitShowFile 探测不受限,导致"探测命中→物化为空"的发散)。
  * `treePath` 为空时列整棵根 tree(`<ref>:`)。
  */
 export function gitLsTreeBlobs(ref: string, treePath: string): GitTreeEntry[] {
   let out: string;
   try {
-    out = execFileSync('git', ['ls-tree', '-r', '-z', `${ref}:${treePath}`], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO });
+    out = execFileSync('git', ['ls-tree', '-r', '-z', '--full-tree', `${ref}:${treePath}`], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO });
   } catch {
     return [];
   }

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -101,6 +101,55 @@ export function getGitRelativePath(absolutePath: string): string {
   return relative(gitRoot, absolutePath);
 }
 
+/** 拼 git 仓库相对路径:始终用 `/`,空 base 直接返回 b(避免 join 产生 `.` 这类退化 tree-ish)。 */
+export function gitJoin(base: string, sub: string): string {
+  return base ? `${base}/${sub}` : sub;
+}
+
+export interface GitSkillRef {
+  isDir: boolean;
+  /** dir-skill 的子树根(仓库相对);file-skill 为空。 */
+  treePath: string;
+  /** file-skill 的 .md 路径(仓库相对);dir-skill 为空。 */
+  fileSkillPath: string;
+  name: string;
+}
+
+/**
+ * 把 git spec 解析成 dir / file skill —— **install 与 eval 共用此一处**,保证两条路径对同一
+ * `git:<ref>:<spec>` 的 file-vs-dir 归类绝不发散(发散会让 eval 量文件、install 注册目录,
+ * 两边对不上)。接受三种写法,与本地路径安装对称:
+ *   - 显式 SKILL.md:`skills/dir/SKILL.md` → 目录-skill,name 取父目录名;
+ *   - 显式 .md:`skills/foo.md` → 文件-skill;
+ *   - 裸 spec:`skills/review` → **文件优先**(先试 `<spec>.md`,再试 `<spec>/SKILL.md`)。
+ * 裸 spec 的文件优先必须与 eval 历史顺序一致 —— 否则同名同时存在 .md 与 dir/SKILL.md 时,
+ * eval 量文件、install 注册目录,evidence 读时按 hash 门控被静默剥离、记录永久 stale。
+ * `gitRelDir` 是各调用方的解析基准(install=cwd 相对仓库根、eval=skillDir 相对仓库根),作为显式
+ * 参数传入,基准差异留给调用方、归类逻辑单一来源。任一探测命中即返回;都不中返回 null。
+ */
+export function classifyGitSkillRef(ref: string, gitRelDir: string, spec: string): GitSkillRef | null {
+  if (basename(spec) === 'SKILL.md') {
+    if (gitShowFile(ref, gitJoin(gitRelDir, spec)) === null) return null;
+    const dirSpec = dirname(spec);
+    const treePath = dirSpec === '.' ? gitRelDir : gitJoin(gitRelDir, dirSpec);
+    let name = basename(dirSpec);
+    if (name === '.' || name === '') name = basename(treePath) || basename(gitRelDir) || 'skill';
+    return { isDir: true, treePath, fileSkillPath: '', name };
+  }
+  if (/\.md$/i.test(spec)) {
+    const fileSkillPath = gitJoin(gitRelDir, spec);
+    if (gitShowFile(ref, fileSkillPath) === null) return null;
+    return { isDir: false, treePath: '', fileSkillPath, name: basename(spec).replace(/\.md$/i, '') };
+  }
+  if (gitShowFile(ref, gitJoin(gitRelDir, `${spec}.md`)) !== null) {
+    return { isDir: false, treePath: '', fileSkillPath: gitJoin(gitRelDir, `${spec}.md`), name: basename(spec) };
+  }
+  if (gitShowFile(ref, gitJoin(gitJoin(gitRelDir, spec), 'SKILL.md')) !== null) {
+    return { isDir: true, treePath: gitJoin(gitRelDir, spec), fileSkillPath: '', name: basename(spec) };
+  }
+  return null;
+}
+
 export function discoverVariants(skillDir: string): string[] {
   if (!existsSync(skillDir)) return [];
 
@@ -327,8 +376,11 @@ export function resolveArtifacts(
         name = parts.slice(1).join(':');
       }
       if (!gitRelDir) gitRelDir = getGitRelativePath(skillDir);
-      const content = gitShowFile(ref, join(gitRelDir, `${name}.md`))
-        || gitShowFile(ref, join(gitRelDir, name, 'SKILL.md'));
+      // file-vs-dir 归类与 install 共用 classifyGitSkillRef(裸 spec 文件优先),两条路径绝不发散。
+      const resolved = classifyGitSkillRef(ref, gitRelDir, name);
+      const content = resolved
+        ? (resolved.isDir ? gitShowFile(ref, gitJoin(resolved.treePath, 'SKILL.md')) : gitShowFile(ref, resolved.fileSkillPath))
+        : null;
       if (!content) {
         throw new Error(`skill not found in git ${ref}: ${name}.md or ${name}/SKILL.md`);
       }

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -36,7 +36,7 @@ function buildMetadata(content: string): Record<string, unknown> | undefined {
   return Object.keys(metadata).length > 0 ? metadata : undefined;
 }
 
-function gitShowFile(ref: string, filePath: string): string | null {
+export function gitShowFile(ref: string, filePath: string): string | null {
   try {
     return execFileSync('git', ['show', `${ref}:${filePath}`], { encoding: 'utf-8' }).trim();
   } catch {
@@ -44,7 +44,40 @@ function gitShowFile(ref: string, filePath: string): string | null {
   }
 }
 
-function getGitRelativePath(absolutePath: string): string {
+/** 取 `<ref>:<filePath>` 的原始字节(二进制资产用,不做 utf-8 解码);不存在/出错返回 null。 */
+export function gitShowBytes(ref: string, filePath: string): Buffer | null {
+  try {
+    return execFileSync('git', ['show', `${ref}:${filePath}`]); // 无 encoding → Buffer
+  } catch {
+    return null;
+  }
+}
+
+export interface GitTreeEntry {
+  /** git 文件模式:100644/100755=普通文件,120000=软链,160000=submodule。 */
+  mode: string;
+  /** 相对所列 tree 的路径。 */
+  path: string;
+}
+
+/** 递归列出 `<ref>:<treePath>` 子树下的叶子条目(blob / 软链 / submodule)。tree 不存在返回 []。 */
+export function gitLsTreeBlobs(ref: string, treePath: string): GitTreeEntry[] {
+  let out: string;
+  try {
+    out = execFileSync('git', ['-c', 'core.quotePath=false', 'ls-tree', '-r', `${ref}:${treePath}`], { encoding: 'utf-8' });
+  } catch {
+    return [];
+  }
+  const entries: GitTreeEntry[] = [];
+  for (const line of out.split(/\r?\n/)) {
+    // 行格式:`<mode> <type> <object>\t<path>`
+    const m = line.match(/^(\d+) \S+ \S+\t(.+)$/);
+    if (m) entries.push({ mode: m[1], path: m[2] });
+  }
+  return entries;
+}
+
+export function getGitRelativePath(absolutePath: string): string {
   const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf-8' }).trim();
   return relative(gitRoot, absolutePath);
 }

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -36,9 +36,13 @@ function buildMetadata(content: string): Record<string, unknown> | undefined {
   return Object.keys(metadata).length > 0 ? metadata : undefined;
 }
 
+// 这些是**探测**(尝试某路径是否存在),miss 是正常流程,不是错误 → 吞掉 git 的 `fatal:` stderr,
+// 否则一次成功的 install/eval 也会在用户终端打印吓人的 `fatal: path ... does not exist`。
+const GIT_PROBE_STDIO: ['ignore', 'pipe', 'ignore'] = ['ignore', 'pipe', 'ignore'];
+
 export function gitShowFile(ref: string, filePath: string): string | null {
   try {
-    return execFileSync('git', ['show', `${ref}:${filePath}`], { encoding: 'utf-8' }).trim();
+    return execFileSync('git', ['show', `${ref}:${filePath}`], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO }).trim();
   } catch {
     return null;
   }
@@ -47,7 +51,7 @@ export function gitShowFile(ref: string, filePath: string): string | null {
 /** 取 `<ref>:<filePath>` 的原始字节(二进制资产用,不做 utf-8 解码);不存在/出错返回 null。 */
 export function gitShowBytes(ref: string, filePath: string): Buffer | null {
   try {
-    return execFileSync('git', ['show', `${ref}:${filePath}`]); // 无 encoding → Buffer
+    return execFileSync('git', ['show', `${ref}:${filePath}`], { stdio: GIT_PROBE_STDIO }); // 无 encoding → Buffer
   } catch {
     return null;
   }
@@ -68,7 +72,7 @@ export interface GitTreeEntry {
 export function gitLsTreeBlobs(ref: string, treePath: string): GitTreeEntry[] {
   let out: string;
   try {
-    out = execFileSync('git', ['ls-tree', '-r', '-z', `${ref}:${treePath}`], { encoding: 'utf-8' });
+    out = execFileSync('git', ['ls-tree', '-r', '-z', `${ref}:${treePath}`], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO });
   } catch {
     return [];
   }
@@ -83,7 +87,8 @@ export function gitLsTreeBlobs(ref: string, treePath: string): GitTreeEntry[] {
 }
 
 export function getGitRelativePath(absolutePath: string): string {
-  const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf-8' }).trim();
+  // stderr 吞掉:不在 git 仓库时的 `fatal:` 由上层(resolver)转成友好的 not_a_git_repo,不双重打印。
+  const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO }).trim();
   return relative(gitRoot, absolutePath);
 }
 

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -40,18 +40,25 @@ function buildMetadata(content: string): Record<string, unknown> | undefined {
 // 否则一次成功的 install/eval 也会在用户终端打印吓人的 `fatal: path ... does not exist`。
 const GIT_PROBE_STDIO: ['ignore', 'pipe', 'ignore'] = ['ignore', 'pipe', 'ignore'];
 
+// 用 `cat-file blob` 而非 `git show`:`git show <ref>:<目录>` 对**目录**会退出码 0 并打印树清单
+// (`tree <ref>:path\n\nSKILL.md`),被这里当成"文件存在 + 内容"误收 —— 名字以 .md 结尾的目录会被
+// classify 误判为 file-skill、物化出树清单当 skill 正文,也会让 eval 把清单文本量成 skill 内容。
+// `cat-file blob` 对非 blob(tree/submodule)直接非零退出,从根上只认 blob。对真 blob 字节与 show 一致。
 export function gitShowFile(ref: string, filePath: string): string | null {
   try {
-    return execFileSync('git', ['show', `${ref}:${filePath}`], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO }).trim();
+    return execFileSync('git', ['cat-file', 'blob', `${ref}:${filePath}`], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO }).trim();
   } catch {
     return null;
   }
 }
 
-/** 取 `<ref>:<filePath>` 的原始字节(二进制资产用,不做 utf-8 解码);不存在/出错返回 null。 */
+/**
+ * 取 `<ref>:<filePath>` 的原始字节(二进制资产用,不做 utf-8 解码);不存在/非 blob/出错返回 null。
+ * 同 gitShowFile 用 `cat-file blob`:对目录会非零退出,不会把树清单字节当文件内容物化。
+ */
 export function gitShowBytes(ref: string, filePath: string): Buffer | null {
   try {
-    return execFileSync('git', ['show', `${ref}:${filePath}`], { stdio: GIT_PROBE_STDIO }); // 无 encoding → Buffer
+    return execFileSync('git', ['cat-file', 'blob', `${ref}:${filePath}`], { stdio: GIT_PROBE_STDIO }); // 无 encoding → Buffer
   } catch {
     return null;
   }

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -124,11 +124,18 @@ function nearestExistingDir(p: string): string {
  * not_a_git_repo。stderr 吞掉,不双重打印 `fatal:`。
  */
 export function resolveGitRepoContext(fromPath: string): GitRepoContext {
-  const anchor = realpathSync(nearestExistingDir(fromPath));
+  const absInput = resolve(fromPath);
+  const existing = nearestExistingDir(absInput);
+  const anchor = realpathSync(existing);
   const repoRoot = realpathSync(
     execFileSync('git', ['-C', anchor, 'rev-parse', '--show-toplevel'], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO }).trim(),
   );
-  const absFrom = existsSync(resolve(fromPath)) ? realpathSync(resolve(fromPath)) : resolve(fromPath);
+  // 对称归一:repoRoot 经 realpath,fromPath 也必须经同源 realpath,否则 fromPath 尚不在磁盘时
+  // (纯 git eval:skill 只在 HEAD、工作树已删)absFrom 保留未归一字面,在 macOS /var ↔ /private/var
+  // 这类等价路径上 relative 会算出越界的 `../../..` relDir → classify 探到仓库外 → 误报 not_found。
+  // 做法:realpath 最近存在祖先,再拼回尚不存在的尾段(尾段为空即 fromPath 本身存在)。
+  const tail = relative(existing, absInput);
+  const absFrom = tail ? join(anchor, tail) : anchor;
   return { repoRoot, relDir: relative(repoRoot, absFrom) };
 }
 

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -144,6 +144,21 @@ export function gitJoin(base: string, sub: string): string {
   return base ? `${base}/${sub}` : sub;
 }
 
+/**
+ * 解析 `git:<ref>:<spec>` —— **install 与 eval 共用此一处**,保证两侧对 ref/spec 的切分与合法性
+ * 判定一致。`git:<spec>` 缺省 ref=HEAD;spec 可含 `/`(如 skills/review)。空 ref / 空 spec 都非法
+ * 并返回 null:空 ref(`git::x`)会被 git 当 index/stage-0 解析,量到不可复取、依赖本地暂存区的内容,
+ * 破坏 git variant 的可复现语义;空 spec(`git:HEAD:`)会退化去探 `.md`/`SKILL.md` 误命中。
+ */
+export function parseGitInput(input: string): { ref: string; spec: string } | null {
+  const parts = input.slice('git:'.length).split(':');
+  const { ref, spec } = parts.length === 1
+    ? { ref: 'HEAD', spec: parts[0] }
+    : { ref: parts[0], spec: parts.slice(1).join(':') };
+  if (!ref || !spec) return null;
+  return { ref, spec };
+}
+
 export interface GitSkillRef {
   isDir: boolean;
   /** dir-skill 的子树根(仓库相对);file-skill 为空。 */
@@ -403,16 +418,13 @@ export function resolveArtifacts(
     }
 
     if (variantName.startsWith('git:')) {
-      const parts = variantName.slice(4).split(':');
-      let ref: string;
-      let name: string;
-      if (parts.length === 1) {
-        ref = 'HEAD';
-        name = parts[0];
-      } else {
-        ref = parts[0];
-        name = parts.slice(1).join(':');
+      // 与 install 共用 parseGitInput:空 ref(`git::x`,会被 git 当 index 量本地暂存区、不可复取)/
+      // 空 spec(`git:HEAD:`)一律拒,守住 git variant 的可复现语义。
+      const parsed = parseGitInput(variantName);
+      if (!parsed) {
+        throw new Error(`无效的 git variant "${variantName}"：ref 与 skill 名都不能为空，应为 git:<ref>:<name>（如 git:HEAD:review）。`);
       }
+      const { ref, spec: name } = parsed;
       // git 上下文锚定 skillDir 所属仓库(不是进程 cwd):从别处调用、skillDir 在另一个 repo 时也对。
       if (!gitCtx) gitCtx = resolveGitRepoContext(skillDir);
       // file-vs-dir 归类与 install 共用 classifyGitSkillRef(裸 spec 文件优先),两条路径绝不发散。

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -60,18 +60,23 @@ export interface GitTreeEntry {
   path: string;
 }
 
-/** 递归列出 `<ref>:<treePath>` 子树下的叶子条目(blob / 软链 / submodule)。tree 不存在返回 []。 */
+/**
+ * 递归列出 `<ref>:<treePath>` 子树下的叶子条目(blob / 软链 / submodule)。tree 不存在返回 []。
+ * 用 `-z`(NUL 分隔):git 不会对含换行 / 非 ASCII 的路径做 C-quote,路径原样可回喂 git show。
+ * `treePath` 为空时列整棵根 tree(`<ref>:`)。
+ */
 export function gitLsTreeBlobs(ref: string, treePath: string): GitTreeEntry[] {
   let out: string;
   try {
-    out = execFileSync('git', ['-c', 'core.quotePath=false', 'ls-tree', '-r', `${ref}:${treePath}`], { encoding: 'utf-8' });
+    out = execFileSync('git', ['ls-tree', '-r', '-z', `${ref}:${treePath}`], { encoding: 'utf-8' });
   } catch {
     return [];
   }
+  const NUL = String.fromCharCode(0);
   const entries: GitTreeEntry[] = [];
-  for (const line of out.split(/\r?\n/)) {
-    // 行格式:`<mode> <type> <object>\t<path>`
-    const m = line.match(/^(\d+) \S+ \S+\t(.+)$/);
+  for (const rec of out.split(NUL)) {
+    // 记录格式:`<mode> <type> <object>\t<path>`(path 可含换行,故用 [\s\S])。
+    const m = rec.match(/^(\d+) \S+ \S+\t([\s\S]*)$/);
     if (m) entries.push({ mode: m[1], path: m[2] });
   }
   return entries;

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync, statSync, realpathSync } from 'node:fs';
 import { resolve, join, relative, dirname, basename } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { extractSkillHardRules, extractSkillWorkflows } from '../shared/hard-rules.js';
@@ -44,9 +44,12 @@ const GIT_PROBE_STDIO: ['ignore', 'pipe', 'ignore'] = ['ignore', 'pipe', 'ignore
 // (`tree <ref>:path\n\nSKILL.md`),被这里当成"文件存在 + 内容"误收 —— 名字以 .md 结尾的目录会被
 // classify 误判为 file-skill、物化出树清单当 skill 正文,也会让 eval 把清单文本量成 skill 内容。
 // `cat-file blob` 对非 blob(tree/submodule)直接非零退出,从根上只认 blob。对真 blob 字节与 show 一致。
-export function gitShowFile(ref: string, filePath: string): string | null {
+// 所有 git helper 收 `cwd`(默认进程 cwd):git 解析必须在**目标仓库**里跑,否则 eval 从别处调用、
+// skillDir 指向另一个 repo 时,会拿进程 cwd 的 repo 与 HEAD 去解析,轻则 not_found、重则评测错内容。
+// 由 resolveGitRepoContext 解出 repoRoot 后逐处显式传入。
+export function gitShowFile(ref: string, filePath: string, cwd: string = process.cwd()): string | null {
   try {
-    return execFileSync('git', ['cat-file', 'blob', `${ref}:${filePath}`], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO }).trim();
+    return execFileSync('git', ['cat-file', 'blob', `${ref}:${filePath}`], { cwd, encoding: 'utf-8', stdio: GIT_PROBE_STDIO }).trim();
   } catch {
     return null;
   }
@@ -56,9 +59,9 @@ export function gitShowFile(ref: string, filePath: string): string | null {
  * 取 `<ref>:<filePath>` 的原始字节(二进制资产用,不做 utf-8 解码);不存在/非 blob/出错返回 null。
  * 同 gitShowFile 用 `cat-file blob`:对目录会非零退出,不会把树清单字节当文件内容物化。
  */
-export function gitShowBytes(ref: string, filePath: string): Buffer | null {
+export function gitShowBytes(ref: string, filePath: string, cwd: string = process.cwd()): Buffer | null {
   try {
-    return execFileSync('git', ['cat-file', 'blob', `${ref}:${filePath}`], { stdio: GIT_PROBE_STDIO }); // 无 encoding → Buffer
+    return execFileSync('git', ['cat-file', 'blob', `${ref}:${filePath}`], { cwd, stdio: GIT_PROBE_STDIO }); // 无 encoding → Buffer
   } catch {
     return null;
   }
@@ -78,10 +81,10 @@ export interface GitTreeEntry {
  * `ls-tree HEAD:skills/review` 会返回空(而 gitShowFile 探测不受限,导致"探测命中→物化为空"的发散)。
  * `treePath` 为空时列整棵根 tree(`<ref>:`)。
  */
-export function gitLsTreeBlobs(ref: string, treePath: string): GitTreeEntry[] {
+export function gitLsTreeBlobs(ref: string, treePath: string, cwd: string = process.cwd()): GitTreeEntry[] {
   let out: string;
   try {
-    out = execFileSync('git', ['ls-tree', '-r', '-z', '--full-tree', `${ref}:${treePath}`], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO });
+    out = execFileSync('git', ['ls-tree', '-r', '-z', '--full-tree', `${ref}:${treePath}`], { cwd, encoding: 'utf-8', stdio: GIT_PROBE_STDIO });
   } catch {
     return [];
   }
@@ -95,10 +98,38 @@ export function gitLsTreeBlobs(ref: string, treePath: string): GitTreeEntry[] {
   return entries;
 }
 
-export function getGitRelativePath(absolutePath: string): string {
-  // stderr 吞掉:不在 git 仓库时的 `fatal:` 由上层(resolver)转成友好的 not_a_git_repo,不双重打印。
-  const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO }).trim();
-  return relative(gitRoot, absolutePath);
+export interface GitRepoContext {
+  /** 仓库根(realpath 归一,避免 macOS /var ↔ /private/var 等价路径算错)。所有 git helper 以此为 cwd。 */
+  repoRoot: string;
+  /** fromPath 相对仓库根的路径(realpath 归一后计算)。 */
+  relDir: string;
+}
+
+/** 从 p 起向上找最近的存在目录(skillDir 可能尚不在磁盘,但仍要定位它所属的 repo)。 */
+function nearestExistingDir(p: string): string {
+  let cur = resolve(p);
+  while (!existsSync(cur)) {
+    const parent = dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return cur;
+}
+
+/**
+ * 解出 `fromPath` 所属 git 仓库的上下文。**关键**:`git rev-parse` 在 `fromPath` 处执行(-C),
+ * 而非进程 cwd —— 否则 eval 从别处调用、skillDir 指向另一个 repo 时,会拿进程 cwd 的 repo root 和
+ * HEAD 去解析,轻则 not_found、重则评测错 repo 的同名内容。repoRoot / relDir 都 realpath 归一,
+ * 消除 /var ↔ /private/var 这类等价路径导致 relative 算错。不在 git 仓库时 rev-parse 抛错,由上层转
+ * not_a_git_repo。stderr 吞掉,不双重打印 `fatal:`。
+ */
+export function resolveGitRepoContext(fromPath: string): GitRepoContext {
+  const anchor = realpathSync(nearestExistingDir(fromPath));
+  const repoRoot = realpathSync(
+    execFileSync('git', ['-C', anchor, 'rev-parse', '--show-toplevel'], { encoding: 'utf-8', stdio: GIT_PROBE_STDIO }).trim(),
+  );
+  const absFrom = existsSync(resolve(fromPath)) ? realpathSync(resolve(fromPath)) : resolve(fromPath);
+  return { repoRoot, relDir: relative(repoRoot, absFrom) };
 }
 
 /** 拼 git 仓库相对路径:始终用 `/`,空 base 直接返回 b(避免 join 产生 `.` 这类退化 tree-ish)。 */
@@ -127,9 +158,9 @@ export interface GitSkillRef {
  * `gitRelDir` 是各调用方的解析基准(install=cwd 相对仓库根、eval=skillDir 相对仓库根),作为显式
  * 参数传入,基准差异留给调用方、归类逻辑单一来源。任一探测命中即返回;都不中返回 null。
  */
-export function classifyGitSkillRef(ref: string, gitRelDir: string, spec: string): GitSkillRef | null {
+export function classifyGitSkillRef(ref: string, gitRelDir: string, spec: string, cwd: string = process.cwd()): GitSkillRef | null {
   if (basename(spec) === 'SKILL.md') {
-    if (gitShowFile(ref, gitJoin(gitRelDir, spec)) === null) return null;
+    if (gitShowFile(ref, gitJoin(gitRelDir, spec), cwd) === null) return null;
     const dirSpec = dirname(spec);
     const treePath = dirSpec === '.' ? gitRelDir : gitJoin(gitRelDir, dirSpec);
     let name = basename(dirSpec);
@@ -138,13 +169,13 @@ export function classifyGitSkillRef(ref: string, gitRelDir: string, spec: string
   }
   if (/\.md$/i.test(spec)) {
     const fileSkillPath = gitJoin(gitRelDir, spec);
-    if (gitShowFile(ref, fileSkillPath) === null) return null;
+    if (gitShowFile(ref, fileSkillPath, cwd) === null) return null;
     return { isDir: false, treePath: '', fileSkillPath, name: basename(spec).replace(/\.md$/i, '') };
   }
-  if (gitShowFile(ref, gitJoin(gitRelDir, `${spec}.md`)) !== null) {
+  if (gitShowFile(ref, gitJoin(gitRelDir, `${spec}.md`), cwd) !== null) {
     return { isDir: false, treePath: '', fileSkillPath: gitJoin(gitRelDir, `${spec}.md`), name: basename(spec) };
   }
-  if (gitShowFile(ref, gitJoin(gitJoin(gitRelDir, spec), 'SKILL.md')) !== null) {
+  if (gitShowFile(ref, gitJoin(gitJoin(gitRelDir, spec), 'SKILL.md'), cwd) !== null) {
     return { isDir: true, treePath: gitJoin(gitRelDir, spec), fileSkillPath: '', name: basename(spec) };
   }
   return null;
@@ -338,7 +369,7 @@ export function resolveArtifacts(
 ): Artifact[] {
   const strictBaseline = opts.strictBaseline ?? true;
   const artifacts: Artifact[] = [];
-  let gitRelDir: string | null = null;
+  let gitCtx: GitRepoContext | null = null;
 
   for (const rawVariant of variants) {
     // 字符串即纯 expr(无 cwd);结构化对象直接取 expr/cwd。不再 split @cwd。
@@ -375,11 +406,12 @@ export function resolveArtifacts(
         ref = parts[0];
         name = parts.slice(1).join(':');
       }
-      if (!gitRelDir) gitRelDir = getGitRelativePath(skillDir);
+      // git 上下文锚定 skillDir 所属仓库(不是进程 cwd):从别处调用、skillDir 在另一个 repo 时也对。
+      if (!gitCtx) gitCtx = resolveGitRepoContext(skillDir);
       // file-vs-dir 归类与 install 共用 classifyGitSkillRef(裸 spec 文件优先),两条路径绝不发散。
-      const resolved = classifyGitSkillRef(ref, gitRelDir, name);
+      const resolved = classifyGitSkillRef(ref, gitCtx.relDir, name, gitCtx.repoRoot);
       const content = resolved
-        ? (resolved.isDir ? gitShowFile(ref, gitJoin(resolved.treePath, 'SKILL.md')) : gitShowFile(ref, resolved.fileSkillPath))
+        ? (resolved.isDir ? gitShowFile(ref, gitJoin(resolved.treePath, 'SKILL.md'), gitCtx.repoRoot) : gitShowFile(ref, resolved.fileSkillPath, gitCtx.repoRoot))
         : null;
       if (!content) {
         throw new Error(`skill not found in git ${ref}: ${name}.md or ${name}/SKILL.md`);

--- a/src/inputs/source-resolver.ts
+++ b/src/inputs/source-resolver.ts
@@ -160,11 +160,14 @@ function classifyGitSkillRef(ref: string, gitRelDir: string, spec: string): GitS
     if (gitShowFile(ref, fileSkillPath) === null) return null;
     return { isDir: false, treePath: '', fileSkillPath, name: basename(spec).replace(/\.md$/i, '') };
   }
-  if (gitShowFile(ref, gitJoin(gitJoin(gitRelDir, spec), 'SKILL.md')) !== null) {
-    return { isDir: true, treePath: gitJoin(gitRelDir, spec), fileSkillPath: '', name: basename(spec) };
-  }
+  // 裸 spec 的歧义(同时存在 <spec>.md 与 <spec>/SKILL.md)必须**文件优先**,与 eval 的 git/本地
+  // 解析顺序(skill-loader.ts:resolveArtifacts 先 <name>.md 再 <name>/SKILL.md)一致 —— 否则 eval 量的
+  // 是文件、install 注册的是目录,contentHash 不同,evidence 会被读时 hash 门控静默剥离。
   if (gitShowFile(ref, gitJoin(gitRelDir, `${spec}.md`)) !== null) {
     return { isDir: false, treePath: '', fileSkillPath: gitJoin(gitRelDir, `${spec}.md`), name: basename(spec) };
+  }
+  if (gitShowFile(ref, gitJoin(gitJoin(gitRelDir, spec), 'SKILL.md')) !== null) {
+    return { isDir: true, treePath: gitJoin(gitRelDir, spec), fileSkillPath: '', name: basename(spec) };
   }
   return null;
 }

--- a/src/inputs/source-resolver.ts
+++ b/src/inputs/source-resolver.ts
@@ -1,6 +1,6 @@
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, resolve, sep } from 'node:path';
 import { isDistributablePath } from '../managed/index.js';
 import { classifyGitSkillRef, getGitRelativePath, gitJoin, gitLsTreeBlobs, gitShowBytes, skillNameFromPath } from './skill-loader.js';
 
@@ -41,6 +41,23 @@ export class SourceResolveError extends Error {
 }
 
 const noop = (): void => {};
+
+/**
+ * 校验 git tree 条目路径在物化目标内,越界即 fail closed(抛 SourceResolveError)。
+ * 双保险:既显式拒 `..` / 空段(git tree 可被手工构造出名为 `..` 的子树),也用 resolve 兜底
+ * 确认落点仍在 temp 之下(绝对路径 / 符号化逃逸)。绝不静默跳过——跳过会让物化树与真实树发散。
+ */
+function assertContainedRelPath(temp: string, relPath: string): void {
+  const segments = relPath.split('/');
+  if (segments.some((s) => s === '' || s === '.' || s === '..')) {
+    throw new SourceResolveError('cli.install.git_unsafe_path', { path: relPath });
+  }
+  const root = resolve(temp);
+  const dest = resolve(temp, relPath);
+  if (dest !== root && !dest.startsWith(root + sep)) {
+    throw new SourceResolveError('cli.install.git_unsafe_path', { path: relPath });
+  }
+}
 
 export function resolveInstallSource(input: string): ResolvedSource {
   if (input.startsWith('git:')) return resolveGitSource(input);
@@ -105,6 +122,11 @@ function resolveGitSource(input: string): ResolvedSource {
     const locator = `git:${ref}:${spec}`;
     if (resolved.isDir) {
       for (const entry of gitLsTreeBlobs(ref, resolved.treePath)) {
+        // 安全边界 fail closed:git tree 可被 git mktree 手工构造出名为 `..` 的子树,`ls-tree -r` 会
+        // 吐 `../evil.txt`,`join(temp, ...)` 会逃出临时目录写盘、cleanup 也删不掉。任一越界路径(.. /
+        // 绝对路径 / 空段 / 解析后不在 temp 内)直接抛错,而非静默跳过——静默跳过会让物化树与真实
+        // git tree / hash / 分发树发散。正常 checkout 永不触发。
+        assertContainedRelPath(temp, entry.path);
         if (entry.mode === '120000' || entry.mode === '160000') continue; // 跳过软链 / submodule(与本地分发一致)
         if (!isDistributablePath(entry.path.split('/'))) continue; // 排除 .omk/.git/evolve 等
         const bytes = gitShowBytes(ref, gitJoin(resolved.treePath, entry.path));

--- a/src/inputs/source-resolver.ts
+++ b/src/inputs/source-resolver.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { isDistributablePath } from '../managed/index.js';
@@ -51,8 +51,15 @@ function resolveFileSource(input: string): ResolvedSource {
   const abs = resolve(input);
   if (!existsSync(abs)) throw new SourceResolveError('cli.install.path_not_found', { path: abs });
   const isDir = statSync(abs).isDirectory();
-  if (isDir && !existsSync(join(abs, 'SKILL.md'))) {
-    throw new SourceResolveError('cli.install.skillmd_missing', { path: abs });
+  if (isDir) {
+    const skillMd = join(abs, 'SKILL.md');
+    if (!existsSync(skillMd)) {
+      throw new SourceResolveError('cli.install.skillmd_missing', { path: abs });
+    }
+    // 软链 SKILL.md 会被分发跳过(与 git 物化、cpSync 的软链策略一致)→ 装出空壳。指向真源,让记录落在真源上。
+    if (lstatSync(skillMd).isSymbolicLink()) {
+      throw new SourceResolveError('cli.install.skillmd_is_symlink', { target: realpathSync(skillMd) });
+    }
   }
   if (!isDir && !/\.md$/i.test(abs)) {
     throw new SourceResolveError('cli.install.not_a_skill', { path: abs });

--- a/src/inputs/source-resolver.ts
+++ b/src/inputs/source-resolver.ts
@@ -1,8 +1,8 @@
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, dirname, join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { isDistributablePath } from '../managed/index.js';
-import { getGitRelativePath, gitLsTreeBlobs, gitShowBytes, gitShowFile, skillNameFromPath } from './skill-loader.js';
+import { classifyGitSkillRef, getGitRelativePath, gitJoin, gitLsTreeBlobs, gitShowBytes, skillNameFromPath } from './skill-loader.js';
 
 /**
  * 安装源解析器 —— 把"各种源"物化成统一的本地形态,让 install / managed 主干**源无关**。
@@ -132,49 +132,3 @@ function resolveGitSource(input: string): ResolvedSource {
   }
 }
 
-interface GitSkillRef {
-  isDir: boolean;
-  /** dir-skill 的子树根(仓库相对);file-skill 为空。 */
-  treePath: string;
-  /** file-skill 的 .md 路径(仓库相对);dir-skill 为空。 */
-  fileSkillPath: string;
-  name: string;
-}
-
-/**
- * 把 git spec 解析成 dir / file skill —— 与本地路径安装对称,接受三种写法:
- *   - 显式 SKILL.md:`skills/dir/SKILL.md` → 目录-skill,name 取父目录名;
- *   - 显式 .md:`skills/foo.md` → 文件-skill;
- *   - 裸 spec:`skills/review` → 先试 `<spec>/SKILL.md`(目录),再试 `<spec>.md`(文件)。
- * 任一探测命中即返回;都不中返回 null。
- */
-/** 拼 git 仓库相对路径:始终用 `/`,空 base 直接返回 b(避免 join 产生 `.` 这类退化 tree-ish)。 */
-function gitJoin(base: string, sub: string): string {
-  return base ? `${base}/${sub}` : sub;
-}
-
-function classifyGitSkillRef(ref: string, gitRelDir: string, spec: string): GitSkillRef | null {
-  if (basename(spec) === 'SKILL.md') {
-    if (gitShowFile(ref, gitJoin(gitRelDir, spec)) === null) return null;
-    const dirSpec = dirname(spec);
-    const treePath = dirSpec === '.' ? gitRelDir : gitJoin(gitRelDir, dirSpec);
-    let name = basename(dirSpec);
-    if (name === '.' || name === '') name = basename(treePath) || basename(gitRelDir) || 'skill';
-    return { isDir: true, treePath, fileSkillPath: '', name };
-  }
-  if (/\.md$/i.test(spec)) {
-    const fileSkillPath = gitJoin(gitRelDir, spec);
-    if (gitShowFile(ref, fileSkillPath) === null) return null;
-    return { isDir: false, treePath: '', fileSkillPath, name: basename(spec).replace(/\.md$/i, '') };
-  }
-  // 裸 spec 的歧义(同时存在 <spec>.md 与 <spec>/SKILL.md)必须**文件优先**,与 eval 的 git/本地
-  // 解析顺序(skill-loader.ts:resolveArtifacts 先 <name>.md 再 <name>/SKILL.md)一致 —— 否则 eval 量的
-  // 是文件、install 注册的是目录,contentHash 不同,evidence 会被读时 hash 门控静默剥离。
-  if (gitShowFile(ref, gitJoin(gitRelDir, `${spec}.md`)) !== null) {
-    return { isDir: false, treePath: '', fileSkillPath: gitJoin(gitRelDir, `${spec}.md`), name: basename(spec) };
-  }
-  if (gitShowFile(ref, gitJoin(gitJoin(gitRelDir, spec), 'SKILL.md')) !== null) {
-    return { isDir: true, treePath: gitJoin(gitRelDir, spec), fileSkillPath: '', name: basename(spec) };
-  }
-  return null;
-}

--- a/src/inputs/source-resolver.ts
+++ b/src/inputs/source-resolver.ts
@@ -2,7 +2,7 @@ import { existsSync, lstatSync, mkdirSync, mkdtempSync, realpathSync, rmSync, st
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve, sep } from 'node:path';
 import { isDistributablePath } from '../managed/index.js';
-import { classifyGitSkillRef, resolveGitRepoContext, gitJoin, gitLsTreeBlobs, gitShowBytes, skillNameFromPath } from './skill-loader.js';
+import { classifyGitSkillRef, parseGitInput, resolveGitRepoContext, gitJoin, gitLsTreeBlobs, gitShowBytes, skillNameFromPath } from './skill-loader.js';
 
 /**
  * 安装源解析器 —— 把"各种源"物化成统一的本地形态,让 install / managed 主干**源无关**。
@@ -85,17 +85,12 @@ function resolveFileSource(input: string): ResolvedSource {
   return { sourceKind: 'file', localRoot: abs, name, isDirectorySkill: isDir, locator: abs, cleanup: noop };
 }
 
-/** 解析 `git:<ref>:<spec>`;`git:<spec>` 缺省 ref=HEAD。spec 可含路径(如 skills/review)。 */
-function parseGitInput(input: string): { ref: string; spec: string } {
-  const parts = input.slice('git:'.length).split(':');
-  if (parts.length === 1) return { ref: 'HEAD', spec: parts[0] };
-  return { ref: parts[0], spec: parts.slice(1).join(':') };
-}
-
 function resolveGitSource(input: string): ResolvedSource {
-  const { ref, spec } = parseGitInput(input);
-  // 空 spec / 空 ref 都拒:空 ref(`git::x`)会被 git 当 index/stage-0 解析,破坏"可复现、可重取"的前提。
-  if (!spec || !ref) throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
+  // 空 spec / 空 ref 由共享 parseGitInput 拒(返回 null):空 ref(`git::x`)会被 git 当 index/stage-0
+  // 解析,破坏"可复现、可重取"的前提;eval 与 install 经同一 helper 判定一致。
+  const parsed = parseGitInput(input);
+  if (!parsed) throw new SourceResolveError('cli.install.git_skill_not_found', { ref: '', name: input });
+  const { ref, spec } = parsed;
 
   let ctx;
   try {

--- a/src/inputs/source-resolver.ts
+++ b/src/inputs/source-resolver.ts
@@ -1,0 +1,124 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { isDistributablePath } from '../managed/index.js';
+import { getGitRelativePath, gitLsTreeBlobs, gitShowBytes, gitShowFile, skillNameFromPath } from './skill-loader.js';
+
+/**
+ * 安装源解析器 —— 把"各种源"物化成统一的本地形态,让 install / managed 主干**源无关**。
+ * 新增一种源 = 加一个分支,install.ts 不动。本模块不依赖 CLI(不打印、不 tCli):错误以
+ * `SourceResolveError(messageKey)` 抛出,由调用方(install)映射成本地化文案。
+ *
+ * 当前支持:`file`(本地路径)、`git`(当前仓库的某个 ref)。远端 git / URL clone 留作后续,
+ * 沿同一 `ResolvedSource` 契约扩展即可。
+ */
+
+export type SourceKind = 'file' | 'git';
+
+export interface ResolvedSource {
+  sourceKind: SourceKind;
+  /** 物化后的本地根:目录-skill 为目录、文件-skill 为 .md;喂 hashArtifactSource + 分发。 */
+  localRoot: string;
+  /** skill 短名(分发落点 / 记录 name)。 */
+  name: string;
+  isDirectorySkill: boolean;
+  /** 记录身份:file=绝对路径;git=`git:<ref>:<spec>`(非临时物化路径)。 */
+  locator: string;
+  ref?: string;
+  /** 释放临时资源(git 删临时目录);file 源为 noop。 */
+  cleanup: () => void;
+}
+
+export class SourceResolveError extends Error {
+  readonly messageKey: string;
+  readonly params: Record<string, string | number>;
+  constructor(messageKey: string, params: Record<string, string | number> = {}) {
+    super(messageKey);
+    this.name = 'SourceResolveError';
+    this.messageKey = messageKey;
+    this.params = params;
+  }
+}
+
+const noop = (): void => {};
+
+export function resolveInstallSource(input: string): ResolvedSource {
+  if (input.startsWith('git:')) return resolveGitSource(input);
+  return resolveFileSource(input);
+}
+
+function resolveFileSource(input: string): ResolvedSource {
+  const abs = resolve(input);
+  if (!existsSync(abs)) throw new SourceResolveError('cli.install.path_not_found', { path: abs });
+  const isDir = statSync(abs).isDirectory();
+  if (isDir && !existsSync(join(abs, 'SKILL.md'))) {
+    throw new SourceResolveError('cli.install.skillmd_missing', { path: abs });
+  }
+  if (!isDir && !/\.md$/i.test(abs)) {
+    throw new SourceResolveError('cli.install.not_a_skill', { path: abs });
+  }
+  const name = isDir ? skillNameFromPath(join(abs, 'SKILL.md')) : skillNameFromPath(abs);
+  return { sourceKind: 'file', localRoot: abs, name, isDirectorySkill: isDir, locator: abs, cleanup: noop };
+}
+
+/** 解析 `git:<ref>:<spec>`;`git:<spec>` 缺省 ref=HEAD。spec 可含路径(如 skills/review)。 */
+function parseGitInput(input: string): { ref: string; spec: string } {
+  const parts = input.slice('git:'.length).split(':');
+  if (parts.length === 1) return { ref: 'HEAD', spec: parts[0] };
+  return { ref: parts[0], spec: parts.slice(1).join(':') };
+}
+
+function resolveGitSource(input: string): ResolvedSource {
+  const { ref, spec } = parseGitInput(input);
+  if (!spec) throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
+
+  let gitRelDir: string;
+  try {
+    gitRelDir = getGitRelativePath(resolve('.'));
+  } catch {
+    throw new SourceResolveError('cli.install.not_a_git_repo', {});
+  }
+
+  const skillName = basename(spec);
+  const dirSkillPath = join(gitRelDir, spec, 'SKILL.md');
+  const fileSkillPath = join(gitRelDir, `${spec}.md`);
+  const isDir = gitShowFile(ref, dirSkillPath) !== null;
+  const isFile = !isDir && gitShowFile(ref, fileSkillPath) !== null;
+  if (!isDir && !isFile) {
+    throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
+  }
+
+  const temp = mkdtempSync(join(tmpdir(), 'omk-install-git-'));
+  const cleanup = (): void => {
+    try {
+      rmSync(temp, { recursive: true, force: true });
+    } catch {
+      // 临时目录清理失败不致命
+    }
+  };
+
+  try {
+    const locator = `git:${ref}:${spec}`;
+    if (isDir) {
+      const treePath = join(gitRelDir, spec);
+      for (const entry of gitLsTreeBlobs(ref, treePath)) {
+        if (entry.mode === '120000' || entry.mode === '160000') continue; // 跳过软链 / submodule(与本地分发一致)
+        if (!isDistributablePath(entry.path.split('/'))) continue; // 排除 .omk/.git/evolve 等
+        const bytes = gitShowBytes(ref, join(treePath, entry.path));
+        if (!bytes) continue;
+        const dest = join(temp, entry.path);
+        mkdirSync(dirname(dest), { recursive: true });
+        writeFileSync(dest, bytes);
+      }
+      return { sourceKind: 'git', localRoot: temp, name: skillName, isDirectorySkill: true, locator, ref, cleanup };
+    }
+    const bytes = gitShowBytes(ref, fileSkillPath);
+    if (!bytes) throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
+    const dest = join(temp, `${skillName}.md`);
+    writeFileSync(dest, bytes);
+    return { sourceKind: 'git', localRoot: dest, name: skillName, isDirectorySkill: false, locator, ref, cleanup };
+  } catch (err) {
+    cleanup();
+    throw err;
+  }
+}

--- a/src/inputs/source-resolver.ts
+++ b/src/inputs/source-resolver.ts
@@ -79,12 +79,8 @@ function resolveGitSource(input: string): ResolvedSource {
     throw new SourceResolveError('cli.install.not_a_git_repo', {});
   }
 
-  const skillName = basename(spec);
-  const dirSkillPath = join(gitRelDir, spec, 'SKILL.md');
-  const fileSkillPath = join(gitRelDir, `${spec}.md`);
-  const isDir = gitShowFile(ref, dirSkillPath) !== null;
-  const isFile = !isDir && gitShowFile(ref, fileSkillPath) !== null;
-  if (!isDir && !isFile) {
+  const resolved = classifyGitSkillRef(ref, gitRelDir, spec);
+  if (!resolved) {
     throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
   }
 
@@ -99,26 +95,63 @@ function resolveGitSource(input: string): ResolvedSource {
 
   try {
     const locator = `git:${ref}:${spec}`;
-    if (isDir) {
-      const treePath = join(gitRelDir, spec);
-      for (const entry of gitLsTreeBlobs(ref, treePath)) {
+    if (resolved.isDir) {
+      for (const entry of gitLsTreeBlobs(ref, resolved.treePath)) {
         if (entry.mode === '120000' || entry.mode === '160000') continue; // 跳过软链 / submodule(与本地分发一致)
         if (!isDistributablePath(entry.path.split('/'))) continue; // 排除 .omk/.git/evolve 等
-        const bytes = gitShowBytes(ref, join(treePath, entry.path));
+        const bytes = gitShowBytes(ref, join(resolved.treePath, entry.path));
         if (!bytes) continue;
         const dest = join(temp, entry.path);
         mkdirSync(dirname(dest), { recursive: true });
         writeFileSync(dest, bytes);
       }
-      return { sourceKind: 'git', localRoot: temp, name: skillName, isDirectorySkill: true, locator, ref, cleanup };
+      return { sourceKind: 'git', localRoot: temp, name: resolved.name, isDirectorySkill: true, locator, ref, cleanup };
     }
-    const bytes = gitShowBytes(ref, fileSkillPath);
+    const bytes = gitShowBytes(ref, resolved.fileSkillPath);
     if (!bytes) throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
-    const dest = join(temp, `${skillName}.md`);
+    const dest = join(temp, `${resolved.name}.md`);
     writeFileSync(dest, bytes);
-    return { sourceKind: 'git', localRoot: dest, name: skillName, isDirectorySkill: false, locator, ref, cleanup };
+    return { sourceKind: 'git', localRoot: dest, name: resolved.name, isDirectorySkill: false, locator, ref, cleanup };
   } catch (err) {
     cleanup();
     throw err;
   }
+}
+
+interface GitSkillRef {
+  isDir: boolean;
+  /** dir-skill 的子树根(仓库相对);file-skill 为空。 */
+  treePath: string;
+  /** file-skill 的 .md 路径(仓库相对);dir-skill 为空。 */
+  fileSkillPath: string;
+  name: string;
+}
+
+/**
+ * 把 git spec 解析成 dir / file skill —— 与本地路径安装对称,接受三种写法:
+ *   - 显式 SKILL.md:`skills/dir/SKILL.md` → 目录-skill,name 取父目录名;
+ *   - 显式 .md:`skills/foo.md` → 文件-skill;
+ *   - 裸 spec:`skills/review` → 先试 `<spec>/SKILL.md`(目录),再试 `<spec>.md`(文件)。
+ * 任一探测命中即返回;都不中返回 null。
+ */
+function classifyGitSkillRef(ref: string, gitRelDir: string, spec: string): GitSkillRef | null {
+  if (basename(spec) === 'SKILL.md') {
+    if (gitShowFile(ref, join(gitRelDir, spec)) === null) return null;
+    const dirSpec = dirname(spec);
+    let name = basename(dirSpec);
+    if (name === '.' || name === '') name = basename(gitRelDir) || 'skill';
+    return { isDir: true, treePath: join(gitRelDir, dirSpec), fileSkillPath: '', name };
+  }
+  if (/\.md$/i.test(spec)) {
+    const fileSkillPath = join(gitRelDir, spec);
+    if (gitShowFile(ref, fileSkillPath) === null) return null;
+    return { isDir: false, treePath: '', fileSkillPath, name: basename(spec).replace(/\.md$/i, '') };
+  }
+  if (gitShowFile(ref, join(gitRelDir, spec, 'SKILL.md')) !== null) {
+    return { isDir: true, treePath: join(gitRelDir, spec), fileSkillPath: '', name: basename(spec) };
+  }
+  if (gitShowFile(ref, join(gitRelDir, `${spec}.md`)) !== null) {
+    return { isDir: false, treePath: '', fileSkillPath: join(gitRelDir, `${spec}.md`), name: basename(spec) };
+  }
+  return null;
 }

--- a/src/inputs/source-resolver.ts
+++ b/src/inputs/source-resolver.ts
@@ -70,7 +70,8 @@ function parseGitInput(input: string): { ref: string; spec: string } {
 
 function resolveGitSource(input: string): ResolvedSource {
   const { ref, spec } = parseGitInput(input);
-  if (!spec) throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
+  // 空 spec / 空 ref 都拒:空 ref(`git::x`)会被 git 当 index/stage-0 解析,破坏"可复现、可重取"的前提。
+  if (!spec || !ref) throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
 
   let gitRelDir: string;
   try {
@@ -99,11 +100,17 @@ function resolveGitSource(input: string): ResolvedSource {
       for (const entry of gitLsTreeBlobs(ref, resolved.treePath)) {
         if (entry.mode === '120000' || entry.mode === '160000') continue; // 跳过软链 / submodule(与本地分发一致)
         if (!isDistributablePath(entry.path.split('/'))) continue; // 排除 .omk/.git/evolve 等
-        const bytes = gitShowBytes(ref, join(resolved.treePath, entry.path));
+        const bytes = gitShowBytes(ref, gitJoin(resolved.treePath, entry.path));
         if (!bytes) continue;
         const dest = join(temp, entry.path);
         mkdirSync(dirname(dest), { recursive: true });
-        writeFileSync(dest, bytes);
+        // 保留可执行位(与本地 cpSync 一致);其余 0644。
+        writeFileSync(dest, bytes, { mode: entry.mode === '100755' ? 0o755 : 0o644 });
+      }
+      // 纵深防御:classify 与物化用的是两条 git 路径(gitShowFile vs ls-tree),万一发散(如 treePath 退化)
+      // 导致空树,这里失败而非静默分发一个空 skill。
+      if (!existsSync(join(temp, 'SKILL.md'))) {
+        throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
       }
       return { sourceKind: 'git', localRoot: temp, name: resolved.name, isDirectorySkill: true, locator, ref, cleanup };
     }
@@ -134,24 +141,30 @@ interface GitSkillRef {
  *   - 裸 spec:`skills/review` → 先试 `<spec>/SKILL.md`(目录),再试 `<spec>.md`(文件)。
  * 任一探测命中即返回;都不中返回 null。
  */
+/** 拼 git 仓库相对路径:始终用 `/`,空 base 直接返回 b(避免 join 产生 `.` 这类退化 tree-ish)。 */
+function gitJoin(base: string, sub: string): string {
+  return base ? `${base}/${sub}` : sub;
+}
+
 function classifyGitSkillRef(ref: string, gitRelDir: string, spec: string): GitSkillRef | null {
   if (basename(spec) === 'SKILL.md') {
-    if (gitShowFile(ref, join(gitRelDir, spec)) === null) return null;
+    if (gitShowFile(ref, gitJoin(gitRelDir, spec)) === null) return null;
     const dirSpec = dirname(spec);
+    const treePath = dirSpec === '.' ? gitRelDir : gitJoin(gitRelDir, dirSpec);
     let name = basename(dirSpec);
-    if (name === '.' || name === '') name = basename(gitRelDir) || 'skill';
-    return { isDir: true, treePath: join(gitRelDir, dirSpec), fileSkillPath: '', name };
+    if (name === '.' || name === '') name = basename(treePath) || basename(gitRelDir) || 'skill';
+    return { isDir: true, treePath, fileSkillPath: '', name };
   }
   if (/\.md$/i.test(spec)) {
-    const fileSkillPath = join(gitRelDir, spec);
+    const fileSkillPath = gitJoin(gitRelDir, spec);
     if (gitShowFile(ref, fileSkillPath) === null) return null;
     return { isDir: false, treePath: '', fileSkillPath, name: basename(spec).replace(/\.md$/i, '') };
   }
-  if (gitShowFile(ref, join(gitRelDir, spec, 'SKILL.md')) !== null) {
-    return { isDir: true, treePath: join(gitRelDir, spec), fileSkillPath: '', name: basename(spec) };
+  if (gitShowFile(ref, gitJoin(gitJoin(gitRelDir, spec), 'SKILL.md')) !== null) {
+    return { isDir: true, treePath: gitJoin(gitRelDir, spec), fileSkillPath: '', name: basename(spec) };
   }
-  if (gitShowFile(ref, join(gitRelDir, `${spec}.md`)) !== null) {
-    return { isDir: false, treePath: '', fileSkillPath: join(gitRelDir, `${spec}.md`), name: basename(spec) };
+  if (gitShowFile(ref, gitJoin(gitRelDir, `${spec}.md`)) !== null) {
+    return { isDir: false, treePath: '', fileSkillPath: gitJoin(gitRelDir, `${spec}.md`), name: basename(spec) };
   }
   return null;
 }

--- a/src/inputs/source-resolver.ts
+++ b/src/inputs/source-resolver.ts
@@ -2,7 +2,7 @@ import { existsSync, lstatSync, mkdirSync, mkdtempSync, realpathSync, rmSync, st
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve, sep } from 'node:path';
 import { isDistributablePath } from '../managed/index.js';
-import { classifyGitSkillRef, getGitRelativePath, gitJoin, gitLsTreeBlobs, gitShowBytes, skillNameFromPath } from './skill-loader.js';
+import { classifyGitSkillRef, resolveGitRepoContext, gitJoin, gitLsTreeBlobs, gitShowBytes, skillNameFromPath } from './skill-loader.js';
 
 /**
  * 安装源解析器 —— 把"各种源"物化成统一的本地形态,让 install / managed 主干**源无关**。
@@ -97,14 +97,14 @@ function resolveGitSource(input: string): ResolvedSource {
   // 空 spec / 空 ref 都拒:空 ref(`git::x`)会被 git 当 index/stage-0 解析,破坏"可复现、可重取"的前提。
   if (!spec || !ref) throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
 
-  let gitRelDir: string;
+  let ctx;
   try {
-    gitRelDir = getGitRelativePath(resolve('.'));
+    ctx = resolveGitRepoContext(resolve('.'));
   } catch {
     throw new SourceResolveError('cli.install.not_a_git_repo', {});
   }
 
-  const resolved = classifyGitSkillRef(ref, gitRelDir, spec);
+  const resolved = classifyGitSkillRef(ref, ctx.relDir, spec, ctx.repoRoot);
   if (!resolved) {
     throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
   }
@@ -121,7 +121,7 @@ function resolveGitSource(input: string): ResolvedSource {
   try {
     const locator = `git:${ref}:${spec}`;
     if (resolved.isDir) {
-      for (const entry of gitLsTreeBlobs(ref, resolved.treePath)) {
+      for (const entry of gitLsTreeBlobs(ref, resolved.treePath, ctx.repoRoot)) {
         // 安全边界 fail closed:git tree 可被 git mktree 手工构造出名为 `..` 的子树,`ls-tree -r` 会
         // 吐 `../evil.txt`,`join(temp, ...)` 会逃出临时目录写盘、cleanup 也删不掉。任一越界路径(.. /
         // 绝对路径 / 空段 / 解析后不在 temp 内)直接抛错,而非静默跳过——静默跳过会让物化树与真实
@@ -129,7 +129,7 @@ function resolveGitSource(input: string): ResolvedSource {
         assertContainedRelPath(temp, entry.path);
         if (entry.mode === '120000' || entry.mode === '160000') continue; // 跳过软链 / submodule(与本地分发一致)
         if (!isDistributablePath(entry.path.split('/'))) continue; // 排除 .omk/.git/evolve 等
-        const bytes = gitShowBytes(ref, gitJoin(resolved.treePath, entry.path));
+        const bytes = gitShowBytes(ref, gitJoin(resolved.treePath, entry.path), ctx.repoRoot);
         if (!bytes) continue;
         const dest = join(temp, entry.path);
         mkdirSync(dirname(dest), { recursive: true });
@@ -143,7 +143,7 @@ function resolveGitSource(input: string): ResolvedSource {
       }
       return { sourceKind: 'git', localRoot: temp, name: resolved.name, isDirectorySkill: true, locator, ref, cleanup };
     }
-    const bytes = gitShowBytes(ref, resolved.fileSkillPath);
+    const bytes = gitShowBytes(ref, resolved.fileSkillPath, ctx.repoRoot);
     if (!bytes) throw new SourceResolveError('cli.install.git_skill_not_found', { ref, name: spec });
     const dest = join(temp, `${resolved.name}.md`);
     writeFileSync(dest, bytes);

--- a/src/managed/store.ts
+++ b/src/managed/store.ts
@@ -53,14 +53,19 @@ const GLOBAL_EXCLUDED_NAMES = new Set<string>(['.omk', '.git', 'node_modules', '
 const ROOT_ONLY_EXCLUDED_NAMES = new Set<string>(['evolve']);
 
 /**
- * 给定相对源根的路径分段(空数组 = 源根本身),判断是否进可分发树。hash 的 walk 与 copy 的
- * filter 共用此一处,保证"算进 hash 的"与"分发出去的"完全一致。
+ * 给定相对源根的路径分段(空数组 = 源根本身),判断是否进可分发树。hash 的 walk、copy 的 filter、
+ * git 物化共用此一处,保证三者完全一致。
+ *
+ * 关键:检查**每一段**而非只看叶子。本地 walk / cpSync 是逐层下降、命中目录即剪枝,只看叶子也够;
+ * 但 git ls-tree 给的是**扁平路径**(如 `.omk/samples.json`),只看叶子 `samples.json` 会让 `.omk`
+ * 内容漏过。故:任一段命中全局排除即排除;首段命中 root-only(evolve)即排除(嵌套同名是合法资产)。
  */
 export function isDistributablePath(segments: string[]): boolean {
   if (segments.length === 0) return true; // 源根永远算
-  const base = segments[segments.length - 1];
-  if (GLOBAL_EXCLUDED_NAMES.has(base)) return false;
-  if (segments.length === 1 && ROOT_ONLY_EXCLUDED_NAMES.has(base)) return false;
+  for (const seg of segments) {
+    if (GLOBAL_EXCLUDED_NAMES.has(seg)) return false;
+  }
+  if (ROOT_ONLY_EXCLUDED_NAMES.has(segments[0])) return false;
   return true;
 }
 
@@ -118,12 +123,14 @@ function isManagedArtifactRecord(value: unknown): value is ManagedArtifactRecord
   if (!value || typeof value !== 'object') return false;
   const r = value as Partial<ManagedArtifactRecord>;
   if (!(r.recordKind === 'managed-artifact'
-    && r.schemaVersion === 1
+    && r.schemaVersion === 2
     && isStringField(r.id)
     && isStringField(r.name)
     && isStringField(r.kind)
     && isStringField(r.contentHash)
-    && r.source && typeof r.source === 'object' && isStringField((r.source as { locator?: unknown }).locator)
+    && r.source && typeof r.source === 'object'
+    && isStringField((r.source as { locator?: unknown }).locator)
+    && isStringField((r.source as { sourceKind?: unknown }).sourceKind)
     && Array.isArray(r.distribution)
     && Array.isArray(r.evidence)
     && Array.isArray(r.decisions))) return false;
@@ -230,7 +237,7 @@ export function buildManagedArtifactRecord(input: {
 }): ManagedArtifactRecord {
   return {
     recordKind: 'managed-artifact',
-    schemaVersion: 1,
+    schemaVersion: 2,
     id: input.id ?? managedRecordId(input.kind, input.name),
     name: input.name,
     kind: input.kind,

--- a/src/managed/store.ts
+++ b/src/managed/store.ts
@@ -202,6 +202,9 @@ export function mergeManagedRecord(
   for (const t of next.distribution) byPath.set(normKey(t.path), t);
   // 维护点:`...next` 取本次安装的事实,下面四个字段从 prev 保留(历史 / 首次时间)。
   // 将来若新增任何"必须从安装基线保留"的字段,务必加进这份覆盖清单,否则会被 next 静默覆盖成 undefined。
+  // 注意语义边界:distribution 是**多源容忍**的(按归一化 path 累积去重),而 source / contentHash 是
+  // **末次写入(单源)**。同一 (kind,name) 先 file 后 git 重装会得到一条 source=git 的记录,但 distribution
+  // 仍含 file 时代的落点 —— 那些落点会按 git 的 contentHash 被判 drift。这是"换源即重基线"的有意取舍。
   return {
     ...next,
     installedAt: prev.installedAt,

--- a/src/types/managed.ts
+++ b/src/types/managed.ts
@@ -44,10 +44,13 @@ export interface ManagedDecision {
 }
 
 export interface ManagedArtifactSource {
-  /** 重哈根:目录-skill 为其根目录、文件-skill 为 .md;`hashArtifactSource(locator, isDirectorySkill)`
-   *  据此 round-trip 做 drift 检测(故目录-skill 存目录而非 SKILL.md)。 */
+  /** 源类型(限定判别字,非裸 kind)。`file`=本地路径;`git`=当前仓库的某个 ref。 */
+  sourceKind: 'file' | 'git';
+  /** 源身份,按 sourceKind 分义:
+   *   - file:本地重哈根(目录-skill 为根目录、文件-skill 为 .md),`hashArtifactSource(locator, isDirectorySkill)` 直接 round-trip;
+   *   - git:`git:<ref>:<name>`(非临时物化路径),drift 由 resolver 重物化重哈 —— mutable ref 给真实漂移、SHA 给不可变。 */
   locator: string;
-  /** git 来源的 ref(预留)。 */
+  /** git 来源的 ref(file 源无)。 */
   ref?: string;
   /** 目录-skill(SKILL.md + assets)还是裸 .md 文件-skill。 */
   isDirectorySkill: boolean;
@@ -56,7 +59,8 @@ export interface ManagedArtifactSource {
 /** 一条记录一个文件 `.omk/managed/<id>.json`,自带 recordKind + schemaVersion 便于单独迁移。 */
 export interface ManagedArtifactRecord {
   recordKind: 'managed-artifact';
-  schemaVersion: 1;
+  /** v2 起 source 带 sourceKind(多源化)。v1(仅 #211)无,按去兼容直接判脏丢弃、不迁移。 */
+  schemaVersion: 2;
   /** 稳定身份 = hash(kind, name);源路径是可变属性、不进 id——挪动源文件不孤儿化记录。 */
   id: string;
   name: string;

--- a/test/cli/oclif-install.test.ts
+++ b/test/cli/oclif-install.test.ts
@@ -594,6 +594,32 @@ describe('oclif install', () => {
     }
   });
 
+  it('git 源裸 spec 歧义:文件优先(e2e 端到端记录 isDirectorySkill:false,防 evidence 静默剥离)', async () => {
+    // 同名同时存在 skills/dual.md 与 skills/dual/SKILL.md。eval(skill-loader resolveArtifacts)先试
+    // <name>.md 再 <name>/SKILL.md → 量的是文件;install 必须同样文件优先,否则注册成目录、contentHash
+    // 与 eval 不同,evidence 读时按 hash 门控被静默剥离、记录永久 stale。这里端到端锁住 install 的归类。
+    const repo = await mkdtemp(join(tmpdir(), 'omk-install-gitdual-'));
+    try {
+      git(repo, ['init', '-q']);
+      git(repo, ['config', 'user.email', 't@t']);
+      git(repo, ['config', 'user.name', 't']);
+      await mkdir(join(repo, 'skills', 'dual'), { recursive: true });
+      await writeFile(join(repo, 'skills', 'dual.md'), '# dual file\n');
+      await writeFile(join(repo, 'skills', 'dual', 'SKILL.md'), '# dual dir\n');
+      git(repo, ['add', '-A']);
+      git(repo, ['commit', '-q', '-m', 'dual']);
+      const dest = join(repo, 'dist-skills');
+      await execFileAsync('node', [CLI, 'install', 'git:HEAD:skills/dual', '--dest', dest], { cwd: repo, env: cliEnv() });
+      const record = await readSoleManagedRecord(repo);
+      const source = record.source as Record<string, unknown>;
+      assert.equal(source.isDirectorySkill, false, '裸 spec 歧义必须文件优先,与 eval 对齐');
+      assert.ok(existsSync(join(dest, 'dual.md')), '应分发文件-skill,落点为 dual.md');
+      assert.ok(!existsSync(join(dest, 'dual')), '不应分发目录-skill');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it('git 源在非 git 仓库内友好报错', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'omk-install-nogit-'));
     try {

--- a/test/cli/oclif-install.test.ts
+++ b/test/cli/oclif-install.test.ts
@@ -580,13 +580,15 @@ describe('oclif install', () => {
     }
   });
 
-  it('git 源 --dry-run 不分发不登记', async () => {
+  it('git 源 --dry-run 不分发不登记,文案源中性', async () => {
     const repo = await makeGitRepoWithSkill();
     try {
       const dest = join(repo, 'dist-skills');
-      await execFileAsync('node', [CLI, 'install', 'git:HEAD:skills/review', '--dest', dest, '--dry-run'], { cwd: repo, env: cliEnv() });
+      const { stdout } = await execFileAsync('node', [CLI, 'install', 'git:HEAD:skills/review', '--dest', dest, '--dry-run'], { cwd: repo, env: cliEnv() });
       assert.ok(!existsSync(join(dest, 'review')), 'dry-run must not distribute');
       assert.ok(!existsSync(join(repo, '.omk', 'managed')), 'dry-run must not register');
+      assert.ok(stdout.includes('将安装 skill review'), `plan 文案应源中性:\n${stdout}`);
+      assert.ok(!stdout.includes('omk Agent Skill'), 'user skill 的 dry-run 不应提 omk Agent Skill');
     } finally {
       await rm(repo, { recursive: true, force: true });
     }

--- a/test/cli/oclif-install.test.ts
+++ b/test/cli/oclif-install.test.ts
@@ -566,6 +566,20 @@ describe('oclif install', () => {
     }
   });
 
+  it('git 源 --force 重装幂等:仍一条记录、分发不重复', async () => {
+    const repo = await makeGitRepoWithSkill();
+    try {
+      const dest = join(repo, 'dist-skills');
+      await execFileAsync('node', [CLI, 'install', 'git:HEAD:skills/review', '--dest', dest], { cwd: repo, env: cliEnv() });
+      await execFileAsync('node', [CLI, 'install', 'git:HEAD:skills/review', '--dest', dest, '--force'], { cwd: repo, env: cliEnv() });
+      const record = await readSoleManagedRecord(repo);
+      assert.equal((record.distribution as Array<unknown>).length, 1, 'distribution 应按 path 去重');
+      assert.ok(existsSync(join(dest, 'review', 'SKILL.md')), 'force 重装后目标仍在');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it('git 源 --dry-run 不分发不登记', async () => {
     const repo = await makeGitRepoWithSkill();
     try {

--- a/test/cli/oclif-install.test.ts
+++ b/test/cli/oclif-install.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { execFile } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
 import { mkdir, mkdtemp, rm, readFile, readdir, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { promisify } from 'node:util';
@@ -331,9 +331,10 @@ describe('oclif install', () => {
 
       const record = await readSoleManagedRecord(dir);
       assert.equal(record.recordKind, 'managed-artifact');
-      assert.equal(record.schemaVersion, 1);
+      assert.equal(record.schemaVersion, 2);
       assert.equal(record.name, 'review');
       assert.equal(record.kind, 'skill');
+      assert.equal((record.source as Record<string, unknown>).sourceKind, 'file');
       assert.equal(typeof record.contentHash, 'string');
       assert.ok((record.contentHash as string).length > 0, 'contentHash empty');
       assert.deepEqual(record.evidence, []);
@@ -523,6 +524,72 @@ describe('oclif install', () => {
         assert.ok((e.stdout + e.stderr).includes('skill'), 'error should mention skill-only support');
       }
       assert.ok(!existsSync(join(dir, '.omk', 'managed')), 'unsupported kind must not register');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  // —— git 源 ——
+
+  function git(repo: string, args: string[]): void {
+    execFileSync('git', args, { cwd: repo, stdio: 'pipe' });
+  }
+
+  async function makeGitRepoWithSkill(): Promise<string> {
+    const repo = await mkdtemp(join(tmpdir(), 'omk-install-gitrepo-'));
+    git(repo, ['init', '-q']);
+    git(repo, ['config', 'user.email', 't@t']);
+    git(repo, ['config', 'user.name', 't']);
+    await makeDirSkill(repo, 'review'); // <repo>/skills/review
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '-q', '-m', 'init']);
+    return repo;
+  }
+
+  it('git 源:从当前仓库 ref 安装,分发整树 + 登记 sourceKind:git', async () => {
+    const repo = await makeGitRepoWithSkill();
+    try {
+      const dest = join(repo, 'dist-skills');
+      const { stdout } = await execFileAsync('node', [CLI, 'install', 'git:HEAD:skills/review', '--dest', dest], { cwd: repo, env: cliEnv() });
+      assert.ok(stdout.includes('已安装 skill review'), `stdout missing copy msg:\n${stdout}`);
+      assert.ok(existsSync(join(dest, 'review', 'SKILL.md')), 'git skill SKILL.md not distributed');
+      assert.ok(existsSync(join(dest, 'review', 'references', 'cmd.md')), 'git skill asset not distributed');
+      const record = await readSoleManagedRecord(repo);
+      const source = record.source as Record<string, unknown>;
+      assert.equal(source.sourceKind, 'git');
+      assert.equal(source.ref, 'HEAD');
+      assert.equal(source.locator, 'git:HEAD:skills/review');
+      assert.equal(source.isDirectorySkill, true);
+      assert.equal(record.name, 'review');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('git 源 --dry-run 不分发不登记', async () => {
+    const repo = await makeGitRepoWithSkill();
+    try {
+      const dest = join(repo, 'dist-skills');
+      await execFileAsync('node', [CLI, 'install', 'git:HEAD:skills/review', '--dest', dest, '--dry-run'], { cwd: repo, env: cliEnv() });
+      assert.ok(!existsSync(join(dest, 'review')), 'dry-run must not distribute');
+      assert.ok(!existsSync(join(repo, '.omk', 'managed')), 'dry-run must not register');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('git 源在非 git 仓库内友好报错', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-install-nogit-'));
+    try {
+      try {
+        await execFileAsync('node', [CLI, 'install', 'git:HEAD:review'], { cwd: dir, env: cliEnv() });
+        assert.fail('expected non-zero exit');
+      } catch (err) {
+        const e = err as ExecError;
+        assert.notEqual(e.code, 0);
+        assert.ok((e.stdout + e.stderr).includes('git'), 'error should mention git repo');
+      }
+      assert.ok(!existsSync(join(dir, '.omk', 'managed')), 'must not register on error');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/inputs/skill-loader.test.ts
+++ b/test/inputs/skill-loader.test.ts
@@ -1,7 +1,10 @@
-import { describe, it } from 'vitest';
+import { describe, it, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { resolveArtifacts } from '../../src/inputs/skill-loader.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -108,5 +111,53 @@ describe('resolveArtifacts skill isolation', () => {
     const artifacts = resolveArtifacts(SKILL_DIR, [{ expr: 'project-env', cwd: '/tmp/proj' }]);
     assert.deepEqual(artifacts[0].allowedSkills, [],
       'kind:baseline 包括 cwd-only custom variant,strict-baseline 一并隔离');
+  });
+});
+
+// eval 的 git 解析与 install 共用 classifyGitSkillRef —— 这里锁住 eval 层的归类不再被重新内联走偏。
+describe('resolveArtifacts git(与 install 共用归类)', () => {
+  let repo: string;
+  let prevCwd: string;
+
+  afterEach(() => {
+    if (prevCwd) process.chdir(prevCwd);
+    if (repo) rmSync(repo, { recursive: true, force: true });
+  });
+
+  function mkRepo(): void {
+    repo = realpathSync(mkdtempSync(join(tmpdir(), 'omk-eval-git-')));
+    const sh = (args: string[]): void => { execFileSync('git', args, { cwd: repo, stdio: 'ignore' }); };
+    sh(['init', '-q']);
+    sh(['config', 'user.email', 't@t']);
+    sh(['config', 'user.name', 't']);
+    prevCwd = process.cwd();
+  }
+
+  it('裸 spec 歧义:eval 也文件优先(与 install 对齐,量的是 .md 文件而非 dir/SKILL.md)', () => {
+    mkRepo();
+    mkdirSync(join(repo, 'dual'), { recursive: true });
+    writeFileSync(join(repo, 'dual.md'), '# dual file\n');
+    writeFileSync(join(repo, 'dual', 'SKILL.md'), '# dual dir\n');
+    execFileSync('git', ['add', '-A'], { cwd: repo, stdio: 'ignore' });
+    execFileSync('git', ['commit', '-q', '-m', 'dual'], { cwd: repo, stdio: 'ignore' });
+    process.chdir(repo);
+    const artifacts = resolveArtifacts(repo, ['git:HEAD:dual']);
+    assert.equal(artifacts[0].source, 'git');
+    assert.ok(artifacts[0].content?.includes('dual file'), 'eval 必须文件优先,量的是 dual.md');
+    assert.ok(!artifacts[0].content?.includes('dual dir'), '绝不能量成 dual/SKILL.md');
+  });
+
+  it('名字以 .md 结尾的目录不被当文件 blob:回退到真 dir-skill,不把树清单量成内容', () => {
+    mkRepo();
+    mkdirSync(join(repo, 'foo.md'), { recursive: true }); // 目录,影子遮挡
+    writeFileSync(join(repo, 'foo.md', 'note.txt'), 'shadow\n');
+    mkdirSync(join(repo, 'foo'), { recursive: true });
+    writeFileSync(join(repo, 'foo', 'SKILL.md'), '# real foo\n');
+    execFileSync('git', ['add', '-A'], { cwd: repo, stdio: 'ignore' });
+    execFileSync('git', ['commit', '-q', '-m', 'shadow'], { cwd: repo, stdio: 'ignore' });
+    process.chdir(repo);
+    const artifacts = resolveArtifacts(repo, ['git:HEAD:foo']);
+    assert.ok(artifacts[0].content?.includes('real foo'), '应回退到 foo/SKILL.md');
+    assert.ok(!artifacts[0].content?.startsWith('tree '), '绝不能把 git 树清单当 skill 内容');
   });
 });

--- a/test/inputs/skill-loader.test.ts
+++ b/test/inputs/skill-loader.test.ts
@@ -160,4 +160,26 @@ describe('resolveArtifacts git(与 install 共用归类)', () => {
     assert.ok(artifacts[0].content?.includes('real foo'), '应回退到 foo/SKILL.md');
     assert.ok(!artifacts[0].content?.startsWith('tree '), '绝不能把 git 树清单当 skill 内容');
   });
+
+  it('从仓库外调用:git 上下文锚定 skillDir 所属 repo,而非进程 cwd', () => {
+    // 进程 cwd 停在 omk 仓库(测试运行目录),skillDir 指向另一个临时 repo,且**不 chdir 进去**。
+    // 修复前 rev-parse 在进程 cwd 跑 → 拿 omk repo 的 root/HEAD → not_found 或评测错 repo 的同名内容。
+    const ext = realpathSync(mkdtempSync(join(tmpdir(), 'omk-eval-extrepo-')));
+    try {
+      const sh = (args: string[]): void => { execFileSync('git', args, { cwd: ext, stdio: 'ignore' }); };
+      sh(['init', '-q']);
+      sh(['config', 'user.email', 't@t']);
+      sh(['config', 'user.name', 't']);
+      mkdirSync(join(ext, 'skills'), { recursive: true });
+      writeFileSync(join(ext, 'skills', 'review.md'), '# external review skill\n');
+      sh(['add', '-A']);
+      sh(['commit', '-q', '-m', 'seed']);
+      const artifacts = resolveArtifacts(join(ext, 'skills'), ['git:review']); // 注意:不 chdir
+      assert.equal(artifacts[0].source, 'git');
+      assert.ok(artifacts[0].content?.includes('external review skill'),
+        'git 上下文必须锚定 skillDir 的 repo,读外部 repo 的 skills/review.md');
+    } finally {
+      rmSync(ext, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/inputs/skill-loader.test.ts
+++ b/test/inputs/skill-loader.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolveArtifacts } from '../../src/inputs/skill-loader.js';
 
@@ -180,6 +180,33 @@ describe('resolveArtifacts git(与 install 共用归类)', () => {
         'git 上下文必须锚定 skillDir 的 repo,读外部 repo 的 skills/review.md');
     } finally {
       rmSync(ext, { recursive: true, force: true });
+    }
+  });
+
+  it('skillDir 工作树已删(skill 只在 HEAD)+ 经软链路径:relDir 对称归一,不越界误报 not_found', () => {
+    // 纯 git eval:skill 在 HEAD 但工作树已删除;skillDir 经软链传入。修复前 repoRoot 经 realpath、
+    // fromPath 未归一,relative 在软链 ↔ 真实路径间算出 `../../..` 越界 relDir → classify 探到仓库外
+    // → 误报 not_found。对称归一(realpath 最近存在祖先 + 拼回尾段)后应正常从 HEAD 读到内容。
+    const real = realpathSync(mkdtempSync(join(tmpdir(), 'omk-eval-ctxreal-')));
+    const link = join(tmpdir(), `omk-eval-ctxlink-${process.pid}-${process.hrtime.bigint()}`);
+    symlinkSync(real, link);
+    try {
+      const sh = (args: string[]): void => { execFileSync('git', args, { cwd: real, stdio: 'ignore' }); };
+      sh(['init', '-q']);
+      sh(['config', 'user.email', 't@t']);
+      sh(['config', 'user.name', 't']);
+      mkdirSync(join(real, 'skills', 'old'), { recursive: true });
+      writeFileSync(join(real, 'skills', 'old', 'SKILL.md'), '# old skill in HEAD\n');
+      sh(['add', '-A']);
+      sh(['commit', '-q', '-m', 'seed']);
+      rmSync(join(real, 'skills'), { recursive: true, force: true }); // 工作树删掉,只剩 HEAD
+      // skillDir 经软链且不在磁盘 → 触发未归一分支
+      const artifacts = resolveArtifacts(join(link, 'skills'), ['git:old']);
+      assert.ok(artifacts[0].content?.includes('old skill in HEAD'),
+        'relDir 对称归一后应从 HEAD 读到 skills/old/SKILL.md,不因软链算越界');
+    } finally {
+      rmSync(link, { force: true });
+      rmSync(real, { recursive: true, force: true });
     }
   });
 });

--- a/test/inputs/skill-loader.test.ts
+++ b/test/inputs/skill-loader.test.ts
@@ -115,6 +115,16 @@ describe('resolveArtifacts skill isolation', () => {
 });
 
 // eval 的 git 解析与 install 共用 classifyGitSkillRef —— 这里锁住 eval 层的归类不再被重新内联走偏。
+describe('resolveArtifacts git 输入校验(与 install 共用 parseGitInput)', () => {
+  // parseGitInput 在任何 git 调用前先拒,故无需真 repo。
+  it('空 ref(git::review)被拒:绝不当 git index 量本地暂存区(不可复取)', () => {
+    assert.throws(() => resolveArtifacts(SKILL_DIR, ['git::review']), /无效的 git variant/);
+  });
+  it('空 spec(git:HEAD:)被拒:不退化去探 .md / SKILL.md', () => {
+    assert.throws(() => resolveArtifacts(SKILL_DIR, ['git:HEAD:']), /无效的 git variant/);
+  });
+});
+
 describe('resolveArtifacts git(与 install 共用归类)', () => {
   let repo: string;
   let prevCwd: string;

--- a/test/inputs/source-resolver.test.ts
+++ b/test/inputs/source-resolver.test.ts
@@ -215,6 +215,25 @@ describe('source-resolver git repo-root SKILL.md', () => {
   });
 });
 
+describe('source-resolver file', () => {
+  it('目录-skill 的 SKILL.md 是软链 → 报错指向真源,不静默分发空壳', () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), 'omk-src-symlink-')));
+    try {
+      const real = join(dir, 'real-skill.md');
+      writeFileSync(real, '# real\n');
+      const skillDir = join(dir, 'review');
+      mkdirSync(skillDir, { recursive: true });
+      symlinkSync(real, join(skillDir, 'SKILL.md'));
+      assert.throws(
+        () => resolveInstallSource(skillDir),
+        (e: unknown) => e instanceof SourceResolveError && e.messageKey === 'cli.install.skillmd_is_symlink',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('source-resolver git outside repo', () => {
   it('非 git 仓库 → not_a_git_repo', () => {
     const dir = realpathSync(mkdtempSync(join(tmpdir(), 'omk-src-nogit-')));

--- a/test/inputs/source-resolver.test.ts
+++ b/test/inputs/source-resolver.test.ts
@@ -216,20 +216,26 @@ describe('source-resolver git', () => {
       execFileSync('git', ['mktree'], { cwd: repo, encoding: 'utf-8', input: spec }).trim();
     const tab = String.fromCharCode(9);
     const nl = String.fromCharCode(10);
+    // 唯一 marker 名:逃逸落点是 tmpdir()/<markerName>(temp 父级),固定名会被他机残留/并发误炸。
+    const markerName = `omk-escape-${process.pid}-${process.hrtime.bigint()}.txt`;
     const evil = ho('pwned' + nl);
     const skillmd = ho('# mal skill' + nl);
-    const dotdot = mktree(`100644 blob ${evil}${tab}evil.txt${nl}`);
+    const dotdot = mktree(`100644 blob ${evil}${tab}${markerName}${nl}`);
     const skillTree = mktree(`040000 tree ${dotdot}${tab}..${nl}100644 blob ${skillmd}${tab}SKILL.md${nl}`);
     const rootTree = mktree(`040000 tree ${skillTree}${tab}skill${nl}`);
     const commit = execFileSync('git', ['commit-tree', rootTree, '-m', 'mal'], { cwd: repo, encoding: 'utf-8', input: '' }).trim();
     git(repo, ['update-ref', 'refs/heads/mal', commit]);
-    const escaped = join(tmpdir(), 'evil.txt'); // temp = mkdtemp(tmpdir()/omk-install-git-*),父级即 tmpdir
-    assert.ok(!existsSync(escaped), '前置:逃逸落点应不存在');
-    assert.throws(
-      () => resolveInstallSource('git:mal:skill'),
-      (e: unknown) => e instanceof SourceResolveError && e.messageKey === 'cli.install.git_unsafe_path',
-    );
-    assert.ok(!existsSync(escaped), '越界路径绝不能写出临时目录');
+    const escaped = join(tmpdir(), markerName); // temp = mkdtemp(tmpdir()/omk-install-git-*),父级即 tmpdir
+    try {
+      assert.ok(!existsSync(escaped), '前置:逃逸落点应不存在');
+      assert.throws(
+        () => resolveInstallSource('git:mal:skill'),
+        (e: unknown) => e instanceof SourceResolveError && e.messageKey === 'cli.install.git_unsafe_path',
+      );
+      assert.ok(!existsSync(escaped), '越界路径绝不能写出临时目录');
+    } finally {
+      rmSync(escaped, { force: true }); // 万一回归(写出了),也不留脏
+    }
   });
 
   it('从仓库子目录执行也能物化(ls-tree --full-tree,不受 cwd 前缀限制)', () => {

--- a/test/inputs/source-resolver.test.ts
+++ b/test/inputs/source-resolver.test.ts
@@ -120,6 +120,42 @@ describe('source-resolver git', () => {
       (e: unknown) => e instanceof SourceResolveError,
     );
   });
+
+  it('空 ref(git::x)被拒,绝不当 git index 解析', () => {
+    assert.throws(
+      () => resolveInstallSource('git::skills/review'),
+      (e: unknown) => e instanceof SourceResolveError && e.messageKey === 'cli.install.git_skill_not_found',
+    );
+  });
+});
+
+describe('source-resolver git repo-root SKILL.md', () => {
+  it('git:HEAD:SKILL.md(根 SKILL.md)物化整根树、非空,不静默产空 skill', () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), 'omk-src-root-')));
+    const prev = process.cwd();
+    try {
+      git(root, ['init', '-q']);
+      git(root, ['config', 'user.email', 't@t']);
+      git(root, ['config', 'user.name', 't']);
+      writeFileSync(join(root, 'SKILL.md'), '# root\n');
+      mkdirSync(join(root, 'references'), { recursive: true });
+      writeFileSync(join(root, 'references', 'a.md'), 'x\n');
+      git(root, ['add', '-A']);
+      git(root, ['commit', '-q', '-m', 'init']);
+      process.chdir(root);
+      const src = resolveInstallSource('git:HEAD:SKILL.md');
+      try {
+        assert.equal(src.isDirectorySkill, true);
+        assert.ok(existsSync(join(src.localRoot, 'SKILL.md')), '根 SKILL.md 应被物化(非空)');
+        assert.ok(existsSync(join(src.localRoot, 'references', 'a.md')), '根树资产应被物化');
+      } finally {
+        src.cleanup();
+      }
+    } finally {
+      process.chdir(prev);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('source-resolver git outside repo', () => {

--- a/test/inputs/source-resolver.test.ts
+++ b/test/inputs/source-resolver.test.ts
@@ -207,6 +207,31 @@ describe('source-resolver git', () => {
     }
   });
 
+  it('恶意 git tree 含 `..` 子树 → fail closed,不逃逸临时目录写盘', () => {
+    // git mktree 手工造一棵 skill 子树:含真 SKILL.md + 名为 `..` 的子树 → ls-tree -r 吐 `../evil.txt`,
+    // join(temp, '../evil.txt') 会写到 temp 父级(tmpdir)。必须抛错且不留逃逸残留。
+    const ho = (content: string): string =>
+      execFileSync('git', ['hash-object', '-w', '--stdin'], { cwd: repo, encoding: 'utf-8', input: content }).trim();
+    const mktree = (spec: string): string =>
+      execFileSync('git', ['mktree'], { cwd: repo, encoding: 'utf-8', input: spec }).trim();
+    const tab = String.fromCharCode(9);
+    const nl = String.fromCharCode(10);
+    const evil = ho('pwned' + nl);
+    const skillmd = ho('# mal skill' + nl);
+    const dotdot = mktree(`100644 blob ${evil}${tab}evil.txt${nl}`);
+    const skillTree = mktree(`040000 tree ${dotdot}${tab}..${nl}100644 blob ${skillmd}${tab}SKILL.md${nl}`);
+    const rootTree = mktree(`040000 tree ${skillTree}${tab}skill${nl}`);
+    const commit = execFileSync('git', ['commit-tree', rootTree, '-m', 'mal'], { cwd: repo, encoding: 'utf-8', input: '' }).trim();
+    git(repo, ['update-ref', 'refs/heads/mal', commit]);
+    const escaped = join(tmpdir(), 'evil.txt'); // temp = mkdtemp(tmpdir()/omk-install-git-*),父级即 tmpdir
+    assert.ok(!existsSync(escaped), '前置:逃逸落点应不存在');
+    assert.throws(
+      () => resolveInstallSource('git:mal:skill'),
+      (e: unknown) => e instanceof SourceResolveError && e.messageKey === 'cli.install.git_unsafe_path',
+    );
+    assert.ok(!existsSync(escaped), '越界路径绝不能写出临时目录');
+  });
+
   it('从仓库子目录执行也能物化(ls-tree --full-tree,不受 cwd 前缀限制)', () => {
     const prev = process.cwd();
     process.chdir(join(repo, 'skills', 'review'));

--- a/test/inputs/source-resolver.test.ts
+++ b/test/inputs/source-resolver.test.ts
@@ -128,6 +128,13 @@ describe('source-resolver git', () => {
     );
   });
 
+  it('空 spec(git:HEAD:)被拒,不退化去探 .md / SKILL.md', () => {
+    assert.throws(
+      () => resolveInstallSource('git:HEAD:'),
+      (e: unknown) => e instanceof SourceResolveError && e.messageKey === 'cli.install.git_skill_not_found',
+    );
+  });
+
   it('裸 spec 歧义:文件优先(与 eval 解析顺序一致,防 evidence 静默剥离)', () => {
     writeFileSync(join(repo, 'skills', 'dual.md'), '# dual file\n');
     mkdirSync(join(repo, 'skills', 'dual'), { recursive: true });

--- a/test/inputs/source-resolver.test.ts
+++ b/test/inputs/source-resolver.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, realpathSync, chmodSync, statSync, symlinkSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, realpathSync, chmodSync, statSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { resolveInstallSource, SourceResolveError } from '../../src/inputs/source-resolver.js';
@@ -180,6 +180,28 @@ describe('source-resolver git', () => {
     try {
       assert.ok(!existsSync(join(src.localRoot, 'link.md')), '软链不该被物化');
       assert.ok(existsSync(join(src.localRoot, 'SKILL.md')), '正常文件仍物化');
+    } finally {
+      src.cleanup();
+    }
+  });
+
+  it('名字以 .md 结尾的目录不被误当文件 blob(cat-file blob 拒 tree,不物化树清单)', () => {
+    // git show <ref>:<目录> 退出码 0 且打印树清单文本(`tree HEAD:...\n\nSKILL.md`)。若探测用 show,
+    // 裸 spec `skills/foo` 先探 `skills/foo.md`,而 foo.md 恰是目录时 → 被误判为 file-skill、物化树清单
+    // 当 skill 正文,真正的 foo/SKILL.md 被跳过。cat-file blob 对 tree 非零退出,探测落空、回退到 dir。
+    mkdirSync(join(repo, 'skills', 'foo.md'), { recursive: true }); // 一个名字以 .md 结尾的目录,影子遮挡
+    writeFileSync(join(repo, 'skills', 'foo.md', 'note.txt'), 'shadow\n');
+    mkdirSync(join(repo, 'skills', 'foo'), { recursive: true }); // 真正的 dir-skill
+    writeFileSync(join(repo, 'skills', 'foo', 'SKILL.md'), '# real foo skill\n');
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '-q', '-m', 'shadow']);
+    const src = resolveInstallSource('git:HEAD:skills/foo');
+    try {
+      assert.equal(src.isDirectorySkill, true, 'foo.md 是目录、非 blob,应回退到真正的 foo/SKILL.md(dir-skill)');
+      assert.equal(src.name, 'foo');
+      const body = readFileSync(join(src.localRoot, 'SKILL.md'), 'utf-8');
+      assert.ok(body.includes('real foo skill'), '应物化真正的 SKILL.md,而非 git 树清单文本');
+      assert.ok(!body.startsWith('tree '), '绝不能把 `tree HEAD:...` 清单当 skill 正文');
     } finally {
       src.cleanup();
     }

--- a/test/inputs/source-resolver.test.ts
+++ b/test/inputs/source-resolver.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, realpathSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, realpathSync, chmodSync, statSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { resolveInstallSource, SourceResolveError } from '../../src/inputs/source-resolver.js';
@@ -126,6 +126,63 @@ describe('source-resolver git', () => {
       () => resolveInstallSource('git::skills/review'),
       (e: unknown) => e instanceof SourceResolveError && e.messageKey === 'cli.install.git_skill_not_found',
     );
+  });
+
+  it('裸 spec 歧义:文件优先(与 eval 解析顺序一致,防 evidence 静默剥离)', () => {
+    writeFileSync(join(repo, 'skills', 'dual.md'), '# dual file\n');
+    mkdirSync(join(repo, 'skills', 'dual'), { recursive: true });
+    writeFileSync(join(repo, 'skills', 'dual', 'SKILL.md'), '# dual dir\n');
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '-q', '-m', 'dual']);
+    const src = resolveInstallSource('git:HEAD:skills/dual');
+    try {
+      assert.equal(src.isDirectorySkill, false, '同时存在 .md 与 dir/SKILL.md 时应选文件,与 eval 一致');
+      assert.equal(src.name, 'dual');
+    } finally {
+      src.cleanup();
+    }
+  });
+
+  it('物化保留可执行位', () => {
+    const exe = join(repo, 'skills', 'review', 'references', 'run.sh');
+    writeFileSync(exe, '#!/bin/sh\necho hi\n');
+    chmodSync(exe, 0o755);
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '-q', '-m', 'exe']);
+    const src = resolveInstallSource('git:HEAD:skills/review');
+    try {
+      const mode = statSync(join(src.localRoot, 'references', 'run.sh')).mode;
+      assert.equal(mode & 0o100, 0o100, '可执行位应随物化保留');
+    } finally {
+      src.cleanup();
+    }
+  });
+
+  it('文件名含换行也能物化(ls-tree -z 不 quote)', () => {
+    const nl = String.fromCharCode(10);
+    const fname = `line${nl}break.md`;
+    writeFileSync(join(repo, 'skills', 'review', 'references', fname), 'nl\n');
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '-q', '-m', 'nl']);
+    const src = resolveInstallSource('git:HEAD:skills/review');
+    try {
+      assert.ok(existsSync(join(src.localRoot, 'references', fname)), '含换行文件名应被物化、不被丢');
+    } finally {
+      src.cleanup();
+    }
+  });
+
+  it('git 树里的软链被跳过,不物化(与本地分发一致)', () => {
+    symlinkSync('SKILL.md', join(repo, 'skills', 'review', 'link.md'));
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '-q', '-m', 'link']);
+    const src = resolveInstallSource('git:HEAD:skills/review');
+    try {
+      assert.ok(!existsSync(join(src.localRoot, 'link.md')), '软链不该被物化');
+      assert.ok(existsSync(join(src.localRoot, 'SKILL.md')), '正常文件仍物化');
+    } finally {
+      src.cleanup();
+    }
   });
 });
 

--- a/test/inputs/source-resolver.test.ts
+++ b/test/inputs/source-resolver.test.ts
@@ -184,6 +184,24 @@ describe('source-resolver git', () => {
       src.cleanup();
     }
   });
+
+  it('从仓库子目录执行也能物化(ls-tree --full-tree,不受 cwd 前缀限制)', () => {
+    const prev = process.cwd();
+    process.chdir(join(repo, 'skills', 'review'));
+    try {
+      const src = resolveInstallSource('git:HEAD:SKILL.md');
+      try {
+        assert.equal(src.isDirectorySkill, true);
+        assert.equal(src.name, 'review');
+        assert.ok(existsSync(join(src.localRoot, 'SKILL.md')), '子目录执行也应物化到 SKILL.md');
+        assert.ok(existsSync(join(src.localRoot, 'references', 'cmd.md')), '资产也应物化');
+      } finally {
+        src.cleanup();
+      }
+    } finally {
+      process.chdir(prev);
+    }
+  });
 });
 
 describe('source-resolver git repo-root SKILL.md', () => {

--- a/test/inputs/source-resolver.test.ts
+++ b/test/inputs/source-resolver.test.ts
@@ -1,0 +1,119 @@
+/**
+ * source-resolver 的 git 物化单测:真实临时 git 仓库。
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveInstallSource, SourceResolveError } from '../../src/inputs/source-resolver.js';
+
+function git(repo: string, args: string[]): void {
+  execFileSync('git', args, { cwd: repo, stdio: 'pipe' });
+}
+
+describe('source-resolver git', () => {
+  let repo: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    repo = realpathSync(mkdtempSync(join(tmpdir(), 'omk-src-git-')));
+    git(repo, ['init', '-q']);
+    git(repo, ['config', 'user.email', 't@t']);
+    git(repo, ['config', 'user.name', 't']);
+    mkdirSync(join(repo, 'skills', 'review', 'references'), { recursive: true });
+    writeFileSync(join(repo, 'skills', 'review', 'SKILL.md'), '# review\n');
+    writeFileSync(join(repo, 'skills', 'review', 'references', 'cmd.md'), 'asset\n');
+    mkdirSync(join(repo, 'skills', 'review', '.omk'), { recursive: true });
+    writeFileSync(join(repo, 'skills', 'review', '.omk', 'samples.json'), '[]\n');
+    writeFileSync(join(repo, 'notes.md'), '# notes\n');
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '-q', '-m', 'init']);
+    prevCwd = process.cwd();
+    process.chdir(repo);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('物化目录-skill 到临时目录,含资产、排除 .omk', () => {
+    const src = resolveInstallSource('git:HEAD:skills/review');
+    try {
+      assert.equal(src.sourceKind, 'git');
+      assert.equal(src.name, 'review');
+      assert.equal(src.isDirectorySkill, true);
+      assert.equal(src.ref, 'HEAD');
+      assert.equal(src.locator, 'git:HEAD:skills/review');
+      assert.ok(existsSync(join(src.localRoot, 'SKILL.md')), 'SKILL.md 应被物化');
+      assert.ok(existsSync(join(src.localRoot, 'references', 'cmd.md')), '资产应被物化');
+      assert.ok(!existsSync(join(src.localRoot, '.omk')), '.omk 评测数据不该被物化');
+    } finally {
+      src.cleanup();
+    }
+  });
+
+  it('物化文件-skill 为单个 .md', () => {
+    const src = resolveInstallSource('git:HEAD:notes');
+    try {
+      assert.equal(src.isDirectorySkill, false);
+      assert.equal(src.name, 'notes');
+      assert.ok(existsSync(src.localRoot));
+      assert.ok(src.localRoot.endsWith('notes.md'));
+    } finally {
+      src.cleanup();
+    }
+  });
+
+  it('具体 commit SHA 也能解析', () => {
+    const sha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
+    const src = resolveInstallSource(`git:${sha}:skills/review`);
+    try {
+      assert.equal(src.ref, sha);
+      assert.ok(existsSync(join(src.localRoot, 'SKILL.md')));
+    } finally {
+      src.cleanup();
+    }
+  });
+
+  it('cleanup 删除临时目录', () => {
+    const src = resolveInstallSource('git:HEAD:skills/review');
+    const root = src.localRoot;
+    assert.ok(existsSync(root));
+    src.cleanup();
+    assert.ok(!existsSync(root), 'cleanup 后临时目录应被删');
+  });
+
+  it('skill 在该 ref 不存在 → SourceResolveError(git_skill_not_found)', () => {
+    assert.throws(
+      () => resolveInstallSource('git:HEAD:nope'),
+      (e: unknown) => e instanceof SourceResolveError && e.messageKey === 'cli.install.git_skill_not_found',
+    );
+  });
+
+  it('ref 不存在 → SourceResolveError', () => {
+    assert.throws(
+      () => resolveInstallSource('git:doesnotexist:skills/review'),
+      (e: unknown) => e instanceof SourceResolveError,
+    );
+  });
+});
+
+describe('source-resolver git outside repo', () => {
+  it('非 git 仓库 → not_a_git_repo', () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), 'omk-src-nogit-')));
+    const prev = process.cwd();
+    process.chdir(dir);
+    try {
+      assert.throws(
+        () => resolveInstallSource('git:HEAD:review'),
+        (e: unknown) => e instanceof SourceResolveError && e.messageKey === 'cli.install.not_a_git_repo',
+      );
+    } finally {
+      process.chdir(prev);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/inputs/source-resolver.test.ts
+++ b/test/inputs/source-resolver.test.ts
@@ -67,6 +67,27 @@ describe('source-resolver git', () => {
     }
   });
 
+  it('显式 .md / SKILL.md spec 与本地路径安装对称', () => {
+    // 显式文件名
+    const f = resolveInstallSource('git:HEAD:notes.md');
+    try {
+      assert.equal(f.isDirectorySkill, false);
+      assert.equal(f.name, 'notes');
+    } finally {
+      f.cleanup();
+    }
+    // 显式 SKILL.md → 目录-skill,name 取父目录
+    const d = resolveInstallSource('git:HEAD:skills/review/SKILL.md');
+    try {
+      assert.equal(d.isDirectorySkill, true);
+      assert.equal(d.name, 'review');
+      assert.equal(d.locator, 'git:HEAD:skills/review/SKILL.md');
+      assert.ok(existsSync(join(d.localRoot, 'references', 'cmd.md')), '应物化整树');
+    } finally {
+      d.cleanup();
+    }
+  });
+
   it('具体 commit SHA 也能解析', () => {
     const sha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf-8' }).trim();
     const src = resolveInstallSource(`git:${sha}:skills/review`);

--- a/test/managed/store.test.ts
+++ b/test/managed/store.test.ts
@@ -118,6 +118,20 @@ describe('managed store', () => {
     assert.ok(loadManagedRecord(store, id));
   });
 
+  it('迁移边界:v1 记录(无 sourceKind)/ v2 缺 sourceKind 都判脏丢弃', () => {
+    const store = managedDir(dir);
+    const id = managedRecordId('skill', 'review');
+    mkdirSync(store, { recursive: true });
+    // #211 的 v1 记录:schemaVersion 1,source 无 sourceKind —— 去兼容直接丢弃。
+    const v1: Record<string, unknown> = { ...makeRecord({ id }), schemaVersion: 1, source: { locator: '/abs/review', isDirectorySkill: true } };
+    writeFileSync(recordPath(store, id), JSON.stringify(v1));
+    assert.equal(loadManagedRecord(store, id), null, 'schemaVersion 1 应被迁移边界拒绝');
+    // v2 但 source 缺新必填的 sourceKind:同样判脏。
+    const noSk: Record<string, unknown> = { ...makeRecord({ id }), source: { locator: '/abs/review', isDirectorySkill: true } };
+    writeFileSync(recordPath(store, id), JSON.stringify(noSk));
+    assert.equal(loadManagedRecord(store, id), null, 'source 缺 sourceKind 应判脏');
+  });
+
   it('loadAllManagedRecords:跳过损坏文件,只收合法记录', () => {
     const store = managedDir(dir);
     upsertManagedRecord(store, makeRecord());

--- a/test/managed/store.test.ts
+++ b/test/managed/store.test.ts
@@ -23,11 +23,11 @@ import type { ManagedArtifactRecord } from '../../src/types/index.js';
 function makeRecord(over: Partial<ManagedArtifactRecord> = {}): ManagedArtifactRecord {
   return {
     recordKind: 'managed-artifact',
-    schemaVersion: 1,
+    schemaVersion: 2,
     id: managedRecordId('skill', 'review'),
     name: 'review',
     kind: 'skill',
-    source: { locator: '/abs/review/SKILL.md', isDirectorySkill: true },
+    source: { sourceKind: 'file', locator: '/abs/review', isDirectorySkill: true },
     contentHash: 'aaaaaaaaaaaa',
     installedAt: '2026-06-06T00:00:00.000Z',
     distribution: [{ label: 'Claude Code', path: '/home/.claude/skills/review', contentHash: 'aaaaaaaaaaaa', copiedAt: '2026-06-06T00:00:00.000Z' }],
@@ -56,13 +56,13 @@ describe('managed store', () => {
     const rec = buildManagedArtifactRecord({
       name: 'review',
       kind: 'skill',
-      source: { locator: '/abs/review/SKILL.md', isDirectorySkill: true },
+      source: { sourceKind: 'file', locator: '/abs/review', isDirectorySkill: true },
       contentHash: 'aaaaaaaaaaaa',
       installedAt: '2026-06-06T00:00:00.000Z',
       distribution: [],
     });
     assert.equal(rec.recordKind, 'managed-artifact');
-    assert.equal(rec.schemaVersion, 1);
+    assert.equal(rec.schemaVersion, 2);
     assert.equal(rec.id, managedRecordId('skill', 'review'));
     assert.deepEqual(rec.evidence, []);
     assert.deepEqual(rec.decisions, []);


### PR DESCRIPTION
## 这是什么

`omk install` 多源化的第一步:支持 **git 源**,并把"把源物化成本地形态"抽成 **source-resolver**,让 install / managed 主干**源无关**。

```bash
omk install git:main:skills/review     # 从当前仓库 main 上的 skill 安装
omk install git:<sha>:review           # 从某个 commit(不可变,最强可复现)
omk install ./skills/review            # 本地路径(不变)
omk install omk-agent-skill            # 内置 onboarding(不变)
```

## 划定的线:locator,不是 registry

支持的是**源定位符**(git ref / 本地路径)—— "我这个具体 skill 在哪儿,纳进 omk 管"。**registry / marketplace**(浏览目录、按包名去注册表解析)仍是设计明确的非目标(那是 Claude plugins / npm 的地盘;omk 的差异化是证据,不是更好的包管理器)。

**`git:` = 当前仓库的某个 ref**(跨 commit,与 eval 的 `git:` 同义),不是 clone 远端 URL。远端 git / URL clone(网络、鉴权、注入面)留作后续 —— resolver 抽象已给它们沿同一 `ResolvedSource` 契约扩展的位。

## 为什么 git 源契合证据门控

不同源的**可复现性**不同,这正是 omk 的命根:git ref 内容寻址、`contentHash` 可被任何人重取核验。SHA 给不可变(证据永远对得上),分支给**真实漂移** —— `git:main:review` 重取若 main 动了,drift 自然被检出。这比可变 URL 干净得多。

## source-resolver 抽象

`resolveInstallSource(input) → ResolvedSource { sourceKind, localRoot, name, isDirectorySkill, locator, ref?, cleanup }`。install 主干只认 `localRoot`(物化后的本地根)做 hash + 分发,认 `locator/ref/sourceKind` 写记录,`cleanup` 在 finally 释放临时物化。新增一种源 = 加一个 resolver 分支,install.ts 不动 —— 不再像上个 feature 那样逐源在 install 里特判。resolver 不依赖 CLI(consumer-agnostic),错误以 `SourceResolveError` 抛出、由 install 本地化。

git 物化:`ls-tree` 列子树叶子 → 跳软链/submodule(与本地分发一致)→ 套 `isDistributablePath` 过滤 → 逐 blob `git show` 原始字节写临时目录。

## 用户影响 / 迁移

- 本地路径、内置 id 安装行为完全不变。
- managed record `source` 新增 `sourceKind`('file'|'git',限定判别字),`schemaVersion` 1→2。#211 才落地、0-1 去兼容:旧 v1 记录按 malformed 丢弃、不迁移。非测量学不变量改动,**无 BREAKING-COMPARABILITY**。

## 顺带修掉的一个真 bug

`isDistributablePath` 原来只看路径**叶子段**。本地 walk 逐层剪枝没事,但 git `ls-tree` 给的是**扁平路径**(`.omk/samples.json`),只看叶子 `samples.json` 会让 `.omk` 评测数据漏进 hash 与分发。改为检查每一段(任一段命中全局排除即排除,首段命中 evolve 即排除)—— 对本地 walk 行为不变,对扁平路径才正确。

## 测试

- `test/inputs/source-resolver.test.ts`:真实临时 git 仓库物化 dir-skill(含资产、排除 .omk)/ file-skill;HEAD 与具体 SHA;cleanup 删临时;ref/skill 不存在、非 git 仓库报错。
- `test/cli/oclif-install.test.ts`:`install git:HEAD:skills/review` e2e(分发整树 + 记录 sourceKind:git/ref/locator);git `--dry-run` 不分发不登记;非 git 仓库友好报错;文件源全部既有用例回归绿。
- 全量 1831 测试绿、lint 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
