### PR TITLE
fix(eval-core)!: git variant runtime fingerprint 消除 node_modules 污染 [BREAKING-COMPARABILITY]

### DIFF
--- a/src/eval-core/dependency-checker.ts
+++ b/src/eval-core/dependency-checker.ts
@@ -185,7 +185,8 @@ function buildPreflightEnv(artifacts?: Artifact[]): NodeJS.ProcessEnv {
   if (!artifacts) return process.env;
   const extraPaths: string[] = [];
   for (const a of artifacts) {
-    if (!a.locator) continue;
+    // git artifact 的 locator 是 git spec、非在盘目录,对它取 dirname 会得到伪路径;跳过(与 extractSkillDir 一致)。
+    if (!a.locator || a.source === 'git') continue;
     const dir = dirname(a.locator);
     const nodeBin = join(dir, 'node_modules', '.bin');
     if (existsSync(nodeBin)) extraPaths.push(nodeBin);

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -130,9 +130,11 @@ function buildExecutorRuntimesByVariant({
   for (const variant of variants) {
     if (runtimes[variant]) continue;
     const artifact = artifacts.find((a) => a.name === variant);
-    const fallbackSkillDir = artifact?.kind === 'baseline'
+    // git artifact 无在盘 skillDir(content 经 SDK 注入),与 baseline 一样取 null —— 与主路径
+    // extractSkillDir 的判定一致,避免 git variant 的 runtime fingerprint 被 cwd 的 node_modules 污染。
+    const fallbackSkillDir = artifact?.kind === 'baseline' || artifact?.source === 'git'
       ? null
-      : artifact?.locator && artifact.source !== 'git'
+      : artifact?.locator
         ? dirname(artifact.locator)
         : request?.skillDir;
     runtimes[variant] = getExecutorRuntimeFingerprint(executorName, model, {

--- a/src/eval-core/execution-strategy.ts
+++ b/src/eval-core/execution-strategy.ts
@@ -84,7 +84,11 @@ export function buildVariantConfig(artifact: Artifact): VariantConfig {
 }
 
 function extractSkillDir(artifact: Artifact): string | null {
-  if (!artifact.locator) return null;
+  // git artifact 的 content 经 SDK 注入、根本不落盘,其 locator 是 git spec(`review` / `skills/review`)
+  // 而非磁盘目录。若对它取 dirname,会得到相对进程 cwd 的伪 skillDir(`.` / `skills`),进而让 buildExecEnv
+  // 把 `<cwd>/node_modules/.bin` 误并进 PATH、污染 runtime fingerprint —— 与 baseline(skillDir=null)
+  // 不对称,造成 Δ 污染。git 与 baseline 一样无在盘 skillDir,返回 null。
+  if (!artifact.locator || artifact.source === 'git') return null;
   return dirname(artifact.locator);
 }
 

--- a/test/eval-core/git-variant-runtime.test.ts
+++ b/test/eval-core/git-variant-runtime.test.ts
@@ -1,0 +1,70 @@
+/**
+ * git variant 的 runtime 环境与 baseline 对称 —— git artifact 的 content 经 SDK 注入、不落盘,
+ * 其 locator 是 git spec 而非磁盘目录。回归:不得对它取 dirname 当 skillDir,否则 buildExecEnv
+ * 会把 `<cwd>/node_modules/.bin` 误并进 PATH,污染 runtime fingerprint、与 baseline 不对称(Δ 污染)。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveExecutionStrategy } from '../../src/eval-core/execution-strategy.js';
+import { buildTasksFromArtifacts } from '../../src/eval-core/task-planner.js';
+import { buildExecEnv } from '../../src/executors/shared.js';
+import type { Artifact } from '../../src/types/index.js';
+
+function planSkillDir(artifact: Artifact): string | null | undefined {
+  const tasks = buildTasksFromArtifacts([{ sample_id: 's1', prompt: 'hi' }], [artifact]);
+  return resolveExecutionStrategy(tasks[0], 'claude-opus-4-8').input.skillDir;
+}
+
+describe('git variant runtime skillDir(防 node_modules 污染指纹)', () => {
+  it('git artifact → skillDir=null,与 baseline 一致(不取 git spec 的 dirname)', () => {
+    const git: Artifact = {
+      name: 'git:HEAD:review', kind: 'skill', source: 'git', content: '# s',
+      locator: 'review', ref: 'HEAD', experimentRole: 'treatment',
+    };
+    const baseline: Artifact = {
+      name: 'baseline', kind: 'baseline', source: 'baseline', content: null,
+      experimentRole: 'control',
+    };
+    assert.equal(planSkillDir(git), null, 'git 的 skillDir 必须为 null');
+    assert.equal(planSkillDir(baseline), null, 'baseline 的 skillDir 为 null');
+  });
+
+  it('带路径的 git spec(skills/review)同样 → null,不退化成 skills', () => {
+    const git: Artifact = {
+      name: 'git:HEAD:skills/review', kind: 'skill', source: 'git', content: '# s',
+      locator: 'skills/review', ref: 'HEAD', experimentRole: 'treatment',
+    };
+    assert.equal(planSkillDir(git), null);
+  });
+
+  it('file-path artifact 仍取其在盘目录(skill 自带 deps 是合法 runtime)', () => {
+    const file: Artifact = {
+      name: 'v1', kind: 'skill', source: 'file-path', content: '# s',
+      locator: '/some/dir/v1/SKILL.md', experimentRole: 'treatment',
+    };
+    assert.equal(planSkillDir(file), '/some/dir/v1');
+  });
+
+  it('从带 ./node_modules/.bin 的 cwd 跑:git 与 baseline 的 PATH 不分叉', () => {
+    // 重现污染条件:cwd 下存在 node_modules/.bin。修复前 git 的 skillDir=`.` 会让 buildExecEnv 命中并
+    // 注入,baseline 不会 → 两者 PATH 分叉。修复后 git skillDir=null,两者 PATH 一致。
+    const dir = mkdtempSync(join(tmpdir(), 'omk-git-rt-'));
+    const prev = process.cwd();
+    try {
+      mkdirSync(join(dir, 'node_modules', '.bin'), { recursive: true });
+      process.chdir(dir);
+      const gitPath = buildExecEnv(planSkillDir({
+        name: 'git:HEAD:review', kind: 'skill', source: 'git', content: '# s',
+        locator: 'review', ref: 'HEAD', experimentRole: 'treatment',
+      })).PATH;
+      const basePath = buildExecEnv(null).PATH;
+      assert.equal(gitPath, basePath, 'git 与 baseline 的 PATH 必须一致,不被 cwd 的 node_modules 污染');
+    } finally {
+      process.chdir(prev);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 这是什么

修一个**预存**的测量可比性 bug:`git:` variant 的 runtime 环境会被运行 cwd 的 `node_modules/.bin` 污染,与 baseline 不对称,造成 Δ 污染。#212 把 git 源提为一等公民后,这条更容易被踩到,故单列修复。

## 根因

git artifact 的 content 经 SDK 注入、**根本不落盘**,其 `locator` 是 git spec(`review` / `skills/review`)而非磁盘目录。但 `extractSkillDir`(`eval-core/execution-strategy.ts`)对它取 `dirname(locator)`,得到相对进程 cwd 的伪 skillDir(`.` / `skills`),流进 `buildExecEnv` 后 `<cwd>/node_modules/.bin` 被并进 `PATH`。

baseline 的 skillDir 是 `null`、不并。于是从**任一含 `./node_modules/.bin` 的目录**(JS 项目根、omk 仓库自身)跑 baseline 对照 `git:HEAD:review` 时,两者 `PATH` 不同。`evaluation-reporting` 的 fallback 支早有 `source !== 'git'` 守卫,但那支只覆盖**零任务** variant;真实评测走的主路径(`extractSkillDir`)没守,守卫等于死代码。

## 修法

git 与 baseline 一样无在盘 skillDir,**三处统一取 `null`**:`extractSkillDir`(主路径)、`evaluation-reporting` 的零任务 fallback、`dependency-checker` 的 preflight env。file-path variant 仍取其在盘目录(skill 自带 deps 是合法 runtime,不变)。

## 影响面(为何标 BREAKING-COMPARABILITY)

`executionPlan.input.skillDir` 不只喂 report fingerprint —— 它同时喂 git variant 的**实际执行环境**(`evaluation-execution.ts:168`,并进 cache key)。所以本修复改的是**真实运行环境**,不是单纯改一个记录值:

- **实际执行**:git variant 运行时不再把 `<cwd>/node_modules/.bin` 注入其 PATH。若某 git skill 的执行恰好调用了 cwd/node_modules 里的工具,其测量行为可能变(罕见,但这正是 BREAKING-COMPARABILITY 要承接的)。baseline 从来没有这个注入 —— 修复让 git 与 baseline 在同一次 run 内**对称、可比**。
- **cache**:git variant 的 fingerprint 变 → 旧 cache 失效、重算(良性)。
- **范围**:仅 git variant、且仅当运行 cwd 含 `node_modules/.bin`;clean cwd 下 `buildExecEnv('.')` 与 `buildExecEnv(null)` 同值、**无变化**(golden case 5 即此,snapshot 未动)。被影响的旧值本就是污染值(baseline 与 git 分叉、不可比),本修复**恢复**同一次 run 内的可比性。
- **不触碰任何冻结不变量**(judge/observe prompt hash、五层评分、Bootstrap/alpha、report schema 字段语义)。

## 附带

git variant 的 `mocksBaseDir` fallback:skillDir=null 后从伪 `dirname` 改为 `effectiveCwd`,且仅当未传 `samplesBaseDir`(罕见)时才有差异,对 git+mock 更合理。

## 测试

新增 `test/eval-core/git-variant-runtime.test.ts`:git / 带路径 git spec → skillDir=null(同 baseline);file-path 仍取在盘目录;**从含 `./node_modules/.bin` 的 cwd 跑,git 与 baseline 的 PATH 不分叉**(修复前必失败)。全量 1856 测试绿、lint 干净。

## 出处

由 #212 的深度 CR 顺带查出,确认在 main 上 `locator: name` 与 `extractSkillDir` 字节相同 —— 预存,非 #212 回归。按可比性纪律单列本 PR,不并入特性 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
