### PR TITLE
docs(cli): install 参考补 git/本地源 + 受管记录;修两处半角标点

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -303,7 +303,7 @@ omk install <input> [flags]
 - `--dest` `option`:自定义 skill 根目录；skill 安装到 <dir>/<name>（内置 omk-agent-skill 为 <dir>/omk）。
 - `--dry-run` `boolean`:只打印安装目标，不写文件。
 - `--force` `boolean`:覆盖目标位置已存在的 skill。
-- `--kind` `skill|prompt|agent|workflow`:用户 artifact 的 kind(对齐 Artifact.kind)。可省:命中 SKILL.md 自动推导,当前仅支持 skill。
+- `--kind` `skill|prompt|agent|workflow`:用户 artifact 的 kind（对齐 Artifact.kind）。可省：命中 SKILL.md 自动推导，当前仅支持 skill。
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--to` `option` (默认 `auto`):安装目标：auto（默认，本机已检测目标） / codex / claude / all。
 
@@ -327,7 +327,7 @@ omk install omk-agent-skill --to all
 omk install omk-agent-skill --dest ~/.my-agent/skills
 ```
 
-> 登记并分发用户自己的 skill(--kind 可省,命中 SKILL.md 自动推导)
+> 登记并分发用户自己的 skill（--kind 可省，命中 SKILL.md 自动推导）
 
 ```bash
 omk install ./skills/review

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,9 +27,11 @@ Scaffolds an evaluation project with two starter skill variants and an `eval-sam
 ## `omk install`
 
 ```bash
-omk install omk-agent-skill
+omk install omk-agent-skill            # built-in official omk Agent Skill (onboarding)
 omk install omk-agent-skill --to all
-omk install omk-agent-skill --dest ~/.my-agent/skills
+omk install ./skills/review            # register + distribute a local skill (writes a managed record)
+omk install git:main:skills/review     # install from a ref of the current repo (SHA is immutable, a branch drifts)
+omk install ./skills/review --dest ~/.my-agent/skills
 ```
 
 <!-- omk:cli:install:flags:start -->
@@ -49,7 +51,11 @@ For full descriptions: `omk install --help`.
 
 <!-- omk:cli:install:flags:end -->
 
-Installs the official omk Agent Skill into local supported coding-agent targets. The default `auto` target writes only to detected targets omk explicitly supports: Codex/AGENTS when `~/.codex` or `~/.agents` exists, and Claude Code when `~/.claude` exists. Use `--to all` to force every target omk currently knows, or `--dest` for a custom skill root.
+Installs a knowledge input (skill) and distributes it to local supported coding-agent targets. Three sources: the built-in id `omk-agent-skill` (onboarding for the official omk Agent Skill), a local skill path (a directory or a `.md`), and `git:<ref>:<spec>` (a skill at a ref of the current repo). A `registry` / `marketplace` (resolving package names against a registry) is a non-goal.
+
+Installing **your own** skill (local path or git source) also writes a **managed record** to `.omk/managed/<id>.json` — the entry point of the "management" pillar, so evidence travels with the artifact through doctor / eval / promote. The `git:` source is the most reproducible: a SHA is immutable and content-addressed (anyone can re-fetch and verify), while a branch gives real drift semantics.
+
+The default `auto` target writes only to detected targets omk explicitly supports: Codex/AGENTS when `~/.codex` or `~/.agents` exists, and Claude Code when `~/.claude` exists. Use `--to all` to force every target omk currently knows, or `--dest` for a custom skill root.
 
 ## `omk doctor`
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -27,9 +27,11 @@ omk init [目录]
 ## `omk install`
 
 ```bash
-omk install omk-agent-skill
+omk install omk-agent-skill            # 内置 omk 官方 Agent Skill（onboarding）
 omk install omk-agent-skill --to all
-omk install omk-agent-skill --dest ~/.my-agent/skills
+omk install ./skills/review            # 登记并分发本地 skill（写一条受管记录）
+omk install git:main:skills/review     # 从当前仓库某个 ref 安装（SHA 不可变、分支随 ref 漂移）
+omk install ./skills/review --dest ~/.my-agent/skills
 ```
 
 <!-- omk:cli:install:flags:start -->
@@ -40,7 +42,7 @@ omk install omk-agent-skill --dest ~/.my-agent/skills
   --dest <value>                  自定义 skill 根目录；skill 安装到 <dir>/<name>（内置 omk-agent-skill 为 <dir>/omk）。
   --dry-run                       只打印安装目标，不写文件。
   --force                         覆盖目标位置已存在的 skill。
-  --kind <skill|prompt|agent|workflow>用户 artifact 的 kind(对齐 Artifact.kind)。可省:命中 SKILL.md 自动推导,当前仅支持 skill。
+  --kind <skill|prompt|agent|workflow>用户 artifact 的 kind（对齐 Artifact.kind）。可省：命中 SKILL.md 自动推导，当前仅支持 skill。
   --lang <value>                  输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --to <value>                    安装目标：auto（默认，本机已检测目标） / codex / claude / all。
 ```
@@ -49,7 +51,11 @@ omk install omk-agent-skill --dest ~/.my-agent/skills
 
 <!-- omk:cli:install:flags:end -->
 
-把 omk 官方 Agent Skill 安装到本机支持的 coding-agent 目标。默认 `auto` 只会写入本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。
+安装一个知识输入（skill），把它分发到本机支持的 coding-agent 目标。三种源：内置 id `omk-agent-skill`（omk 官方 Agent Skill 的 onboarding）、本地 skill 路径（目录或 `.md`）、`git:<ref>:<spec>`（当前仓库某个 ref 上的 skill）。`registry` / `marketplace`（按包名去注册表解析）不是目标。
+
+安装**用户自己的** skill（本地路径或 git 源）时，除分发外还会写一条**受管记录**到 `.omk/managed/<id>.json` —— 这是「管理」支柱的入口,让证据随 artifact 一起走过 doctor / eval / promote。`git:` 源的可复现性最强：SHA 不可变、内容寻址可核验,分支则给真实漂移语义。
+
+默认 `auto` 只写入本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。
 
 ## `omk doctor`
 

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -282,7 +282,7 @@ export default class Install extends BaseCommand {
     },
     {
       description: bilingual({
-        zh: '登记并分发用户自己的 skill(--kind 可省,命中 SKILL.md 自动推导)',
+        zh: '登记并分发用户自己的 skill（--kind 可省，命中 SKILL.md 自动推导）',
         en: 'Register and distribute your own skill (--kind optional; inferred from SKILL.md)',
       }),
       command: '<%= config.bin %> install ./skills/review',
@@ -310,7 +310,7 @@ export default class Install extends BaseCommand {
     lang: LANG_FLAG,
     kind: Flags.string({
       description: bilingual({
-        zh: '用户 artifact 的 kind(对齐 Artifact.kind)。可省:命中 SKILL.md 自动推导,当前仅支持 skill。',
+        zh: '用户 artifact 的 kind（对齐 Artifact.kind）。可省：命中 SKILL.md 自动推导，当前仅支持 skill。',
         en: 'Kind of the user artifact (aligns with Artifact.kind). Optional: inferred from SKILL.md; only skill is supported today.',
       }),
       options: INSTALLABLE_KINDS,


### PR DESCRIPTION
## 这是什么

`omk install` 参考文档收尾 + 两处半角标点修复。由 #212 git 源特性的整体 review 顺带查出,与 #213(运行时指纹)、#214(指纹统一)是独立的小收尾。

## 改了什么

- **`docs/reference/cli.md`(+zh)的 install 段陈旧**:手维护的示例块与正文此前只讲 `omk-agent-skill`,而自动生成的 flags 块已经露出 `--kind`,读者看到一个「用户 artifact 的 kind」flag 却零示例、像孤儿。补上本地路径与 `git:<ref>:<spec>` 源示例;正文说明三种源、安装用户 skill 会写一条受管记录(`.omk/managed/<id>.json`)、git 源可复现性最强,并点明 `registry`/`marketplace` 非目标。
- **两处半角标点**:`install.ts` 的 `--kind` flag 与用户 skill 示例的内联 zh 描述用了半角 `()`,`:`,`,`,改全角(GB/T 15834)。这两条进 `--help` 与生成的 `commands.md` / `cli.md`,已 `yarn build:docs` 重生成同步。

## 不在本 PR

- 运行时指纹污染修复 → #213。
- skill 内容指纹统一(install 树哈 vs eval 文本哈)→ #214。
- git spec 写法统一(eval 相对 skillDir vs install 相对 cwd → 统一为相对仓库根)→ 并入 #214 的 eval-git 重做。

## 验证

`yarn build:docs:check` 同步、lint 干净、全量 1851 测试绿(1 条 `sigint-propagation` 满载计时 flake,隔离单跑绿、与本改无关)。纯文档 + 文案,无逻辑改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
