### PR TITLE
chore(release): 发布 0.34.0

### DIFF
--- a/docs/explanation/statistical-rigor.md
+++ b/docs/explanation/statistical-rigor.md
@@ -92,8 +92,8 @@ See: [docs/specs/sample-design-spec.md](../specs/sample-design-spec.md) for rela
 Every report carries:
 - omk version (`reportMeta.cliVersion`)
 - Node version (`reportMeta.nodeVersion`)
-- Judge model + hash (`reportMeta.judgeModel`, `reportMeta.judgePromptHash`)
-- Executor runtime fingerprint (`reportMeta.executorRuntime`, `reportMeta.judgeRuntime`)
+- Judge models + prompt hash (`reportMeta.judgeModels` — each entry carries its judge model and runtime fingerprint — and `reportMeta.judgePromptHash`)
+- Executor runtime fingerprint (`reportMeta.executorRuntime`)
 - Sample fingerprints (`reportMeta.sampleHashes`)
 - Skill isolation snapshot (`reportMeta.skillIsolation`)
 - Schema version (`reportMeta.schemaVersion`)

--- a/docs/specs/evidence-gated-management.md
+++ b/docs/specs/evidence-gated-management.md
@@ -1,6 +1,6 @@
 # Evidence-gated knowledge input management
 
-> **Status**: design note for #203. This document defines the product boundary before adding broad management commands. It does not change Report schema, judge prompts, scoring, or comparability rules.
+> **Status**: design note for #203. The management entry point — `omk install` registering managed records — has shipped (#211/#212); the rest (`list` / `promote` / `rollback`) remains design. This document defines the product boundary; it does not change Report schema, judge prompts, scoring, or comparability rules.
 
 ## 1. Product thesis
 
@@ -102,24 +102,25 @@ observe → studio
 
 ### `install`
 
-Current release scope:
+`install` is the management entry point. Three sources ship today:
 
 ```bash
-omk install omk-agent-skill
+omk install omk-agent-skill            # reserved built-in id: the official omk Agent Skill (onboarding)
+omk install ./skills/review            # a local skill (directory or .md)
+omk install git:<ref>:skills/review    # a skill at a ref of the current repo
 ```
 
-This installs the official omk Agent Skill for onboarding. It is a reserved built-in id, not a registry package and not the user's evaluated artifact.
+The built-in id is a reserved onboarding skill, not a registry package and not the user's evaluated artifact. Installing a **user** skill (local path or `git:`) both distributes it to the detected agent targets and writes a managed record at `.omk/managed/<id>.json`.
 
-Future managed-input scope:
+Future managed-input scope (not yet supported — `install` hard-rejects non-skill kinds today):
 
 ```bash
-omk install ./skills/review/SKILL.md --kind skill
 omk install ./prompts/rewrite.md --kind prompt
 ```
 
 Rules:
 
-- `--kind` should align with `Artifact.kind`; do not use `kind` for runtime/report/event categories.
+- `--kind` aligns with `Artifact.kind`; do not use `kind` for runtime/report/event categories. It is optional and inferred from `SKILL.md`; only `skill` is supported today.
 - Installing a user artifact creates a managed record but does not imply promotion.
 - Installed artifacts start as `installed` or `measurable`, depending on doctor/sample state.
 
@@ -194,8 +195,9 @@ Done in #208 / PR #207:
 
 ## 9. Open questions
 
-- Where should management records live: `.omk/managed.json`, `.omk/artifacts/`, or another store?
-- How should git refs and omk evidence records interact?
+- **Decided:** management records live in per-record files `.omk/managed/<id>.json` (atomic tmp+rename, mirroring report-store), not a single aggregate file.
+- Unifying the artifact content hash so evidence can bind: `install` records `hashArtifactSource` (whole-tree) while `eval` reports `hashString(SKILL.md text)`, so the `evidence.contentHash === record.contentHash` gate cannot match real report evidence yet. Tracked in #214 — this is the load-bearing blocker for evidence-backed `list` / `promote`.
+- How should git refs and omk evidence records interact (re-materialize a moving branch vs a pinned SHA on drift checks)?
 - What snapshot layout should `evolve` write under its working directory, and what is the deprecation path for users who currently rely on `evolve` writing the winner back to the source file (decision B migration mechanics)?
 - Which verdicts are acceptable for promotion by default: only `PROGRESS`, or `CAUTIOUS` with explicit caveats?
 - What is the stale-evidence policy when only samples change, only runtime context changes, or only artifact content changes?

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -312,7 +312,7 @@ Rules:
 
 ### 4. Reserve bare `kind` for `ArtifactKind`
 
-In omk's product vocabulary, bare `kind` is reserved for `Artifact.kind` (`ArtifactKind`: `baseline` / `skill` / `prompt` / `agent` / `workflow`). `baseline` means the empty eval artifact; experiment role still comes from `control` / `treatment`. CLI design follows the same rule: a future `--kind` flag should mean artifact kind, not install target, report type, or observe event type.
+In omk's product vocabulary, bare `kind` is reserved for `Artifact.kind` (`ArtifactKind`: `baseline` / `skill` / `prompt` / `agent` / `workflow`). `baseline` means the empty eval artifact; experiment role still comes from `control` / `treatment`. CLI design follows the same rule: the `--kind` flag on `omk install` means artifact kind (aligned with `Artifact.kind`), not install target, report type, or observe event type.
 
 For other discriminants, use a qualified name when the field is new or safe to rename. Existing persisted `kind` fields stay as-is unless a dedicated migration changes them:
 

--- a/docs/zh/explanation/statistical-rigor.md
+++ b/docs/zh/explanation/statistical-rigor.md
@@ -92,8 +92,8 @@ baseline 拿到的 prompt **不应**包含被测 skill。omk 切断三条污染�
 每份报告携带：
 - omk 版本(`reportMeta.cliVersion`)
 - Node 版本(`reportMeta.nodeVersion`)
-- 评委模型 + hash(`reportMeta.judgeModel` / `reportMeta.judgePromptHash`)
-- Executor runtime 指纹(`reportMeta.executorRuntime` / `reportMeta.judgeRuntime`)
+- 评委模型 + hash(`reportMeta.judgeModels`，每条携带该评委的模型与 runtime 指纹；以及 `reportMeta.judgePromptHash`)
+- Executor runtime 指纹(`reportMeta.executorRuntime`)
 - 用例指纹(`reportMeta.sampleHashes`)
 - skill 隔离快照(`reportMeta.skillIsolation`)
 - Schema 版本(`reportMeta.schemaVersion`)

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -53,7 +53,7 @@ omk install ./skills/review --dest ~/.my-agent/skills
 
 安装一个知识输入（skill），把它分发到本机支持的 coding-agent 目标。三种源：内置 id `omk-agent-skill`（omk 官方 Agent Skill 的 onboarding）、本地 skill 路径（目录或 `.md`）、`git:<ref>:<spec>`（当前仓库某个 ref 上的 skill）。`registry` / `marketplace`（按包名去注册表解析）不是目标。
 
-安装**用户自己的** skill（本地路径或 git 源）时，除分发外还会写一条**受管记录**到 `.omk/managed/<id>.json` —— 这是「管理」支柱的入口,让证据随 artifact 一起走过 doctor / eval / promote。`git:` 源的可复现性最强：SHA 不可变、内容寻址可核验,分支则给真实漂移语义。
+安装**用户自己的** skill（本地路径或 git 源）时，除分发外还会写一条**受管记录**到 `.omk/managed/<id>.json` —— 这是「管理」支柱的入口，让证据随 artifact 一起走过 doctor / eval / promote。`git:` 源的可复现性最强：SHA 不可变、内容寻址可核验，分支则给真实漂移语义。
 
 默认 `auto` 只写入本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。
 

--- a/docs/zh/reference/glossary.md
+++ b/docs/zh/reference/glossary.md
@@ -1,6 +1,6 @@
 <!--
 title: 术语对照表 — 业内通用 ML / 统计 / omk 名词的中英对照
-description: 给 omk 文档读者用的术语速查。覆盖 bootstrap CI / Δ / Pearson / Krippendorff α / 综合分 / executor / 测评可信度 等业内通用术语,以及 omk 内部命名(artifact / verdict / 外验集 等)。每条给一句话定义 + 在哪用到。
+description: 给 omk 文档读者用的术语速查。覆盖 bootstrap CI / Δ / Pearson / Krippendorff α / 综合分 / executor / 测评可信度 等业内通用术语，以及 omk 内部命名(artifact / verdict / 外验集 等)。每条给一句话定义 + 在哪用到。
 -->
 
 # 术语对照表

--- a/docs/zh/specs/evidence-gated-management.md
+++ b/docs/zh/specs/evidence-gated-management.md
@@ -1,6 +1,6 @@
 # 证据门控的知识输入管理
 
-> **状态**：#203 的设计说明。本文先定义产品边界，再考虑新增通用管理命令。本文不修改 Report schema、评委提示词、评分管道或可比性规则。
+> **状态**：#203 的设计说明。管理支柱的入口 —— `omk install` 登记受管记录 —— 已落地（#211/#212）；其余（`list` / `promote` / `rollback`）仍是设计。本文定义产品边界；不修改 Report schema、评委提示词、评分管道或可比性规则。
 
 ## 1. 产品判断
 
@@ -102,24 +102,25 @@ observe → studio
 
 ### `install`
 
-当前发布范围：
+`install` 是管理支柱的入口。三种源已经落地：
 
 ```bash
-omk install omk-agent-skill
+omk install omk-agent-skill            # 保留内置 id：omk 官方 Agent Skill（onboarding）
+omk install ./skills/review            # 本地 skill（目录或 .md）
+omk install git:<ref>:skills/review    # 当前仓库某个 ref 上的 skill
 ```
 
-这只是安装 omk 官方 Agent Skill 的 onboarding 入口。`omk-agent-skill` 是保留内置 id，不是 registry 包，也不是用户自己的被测 artifact。
+内置 id 是保留的 onboarding skill，不是 registry 包，也不是用户自己的被测 artifact。安装**用户自己的** skill（本地路径或 `git:`）时，除分发到已检测的 agent 目标外，还会写一条管理记录到 `.omk/managed/<id>.json`。
 
-未来受管输入范围：
+未来受管输入范围（尚不支持 —— 当前 `install` 对非 skill kind 直接报错）：
 
 ```bash
-omk install ./skills/review/SKILL.md --kind skill
 omk install ./prompts/rewrite.md --kind prompt
 ```
 
 规则：
 
-- `--kind` 应对齐 `Artifact.kind`，不要拿 `kind` 表示 runtime / report / event 分类。
+- `--kind` 对齐 `Artifact.kind`，不要拿 `kind` 表示 runtime / report / event 分类。可省、命中 `SKILL.md` 自动推导，当前仅支持 `skill`。
 - 安装用户 artifact 只创建管理记录，不等于转正。
 - 安装后的 artifact 根据 doctor / sample 状态进入 `installed` 或 `measurable`。
 
@@ -194,8 +195,9 @@ Studio 应让决策轨迹可检查：为什么当前是这个版本、证据是�
 
 ## 9. 开放问题
 
-- 管理记录放在哪里：`.omk/managed.json`、`.omk/artifacts/`，还是其它 store？
-- git ref 与 omk 证据记录如何协作？
+- **已定**：管理记录用 per-record 文件 `.omk/managed/<id>.json`（原子 tmp+rename，镜像 report-store），不用单一聚合文件。
+- 统一 artifact 内容指纹以让证据可绑定：`install` 记的是 `hashArtifactSource`（整树），`eval` 报告记的是 `hashString(SKILL.md 正文)`，因此 `evidence.contentHash === record.contentHash` 门控目前无法匹配真实报告证据。见 #214 —— 这是证据驱动的 `list` / `promote` 的承重前置。
+- git ref 与 omk 证据记录如何协作（漂移检查时,分支 ref 重物化 vs 固定 SHA）？
 - `evolve` 的工作目录快照该用什么布局？对当前依赖「evolve 把胜出版本写回源文件」的用户，deprecation 路径是什么？（决策 B 的迁移机制）
 - 默认允许哪些 verdict 转正：只允许 `PROGRESS`，还是允许带 caveat 的 `CAUTIOUS`？
 - 当只有 sample、runtime context 或 artifact 内容变化时，证据过期策略分别是什么？

--- a/docs/zh/specs/knowledge-gap-signal-spec.md
+++ b/docs/zh/specs/knowledge-gap-signal-spec.md
@@ -202,9 +202,9 @@ v0.1 不区分信号严重度，所有四类一律"有信号"；v0.2 引入加�
 
 | 信号类型 | 权重 | 分档理由 |
 |---------|------|----------|
-| `failed_search` | **1.0**（强） | agent 工具层真的调了 Grep/Read 没命中,确定性 miss |
-| `repeated_failure` | **1.0**（强） | 同一类查询连续 ≥3 次失败,已不是偶然 |
-| `explicit_marker` | 0.5（弱） | 依赖 agent 按约定打【推断】等标记,可能漏标或假装 |
+| `failed_search` | **1.0**（强） | agent 工具层真的调了 Grep/Read 没命中，确定性 miss |
+| `repeated_failure` | **1.0**（强） | 同一类查询连续 ≥3 次失败，已不是偶然 |
+| `explicit_marker` | 0.5（弱） | 依赖 agent 按约定打【推断】等标记，可能漏标或假装 |
 | `hedging` | 0.5（弱） | regex 召回 + LLM 二次判定（v0.2,详见 §四.3）;classifier 失败降级时全部保留 |
 
 聚合产出 **`weightedGapRate`**（与 `gapRate` 并列，不替代）：

--- a/docs/zh/specs/rag-metrics-spec.md
+++ b/docs/zh/specs/rag-metrics-spec.md
@@ -33,15 +33,15 @@ omk 的取舍:**单次 1-5 分判断**,与 omk 其他 LLM-judge assertion 一致
 - 粒度比 RAGAS 粗 — 看不到具体哪条陈述错了
 - judge 自身的 1-5 评分稳定性影响明显 — 建议配合 `--judge-repeat 3` 或 `--judge-models claude:opus,openai:gpt-4o` ensemble 校准
 
-需要 RAGAS 级粒度的场景:用 `custom` assertion 自己实现 statement-decomposition,或者跨层 wrapping omk 的 LLM judge 输出。
+需要 RAGAS 级粒度的场景：用 `custom` assertion 自己实现 statement-decomposition,或者跨层 wrapping omk 的 LLM judge 输出。
 
 ## Prompt 形态 (1-5 评分锚)
 
 三个 metric 的判分锚点(从 `src/grading/assertions.ts` 的 `runRagJudge` 抽取):
 
 ### faithfulness
-- 5 = 全部陈述都有 context 支持,无编造
-- 4 = 多数有支持,有 1-2 处不重要的编造
+- 5 = 全部陈述都有 context 支持，无编造
+- 4 = 多数有支持，有 1-2 处不重要的编造
 - 3 = 一半有支持
 - 2 = 多数无支持
 - 1 = 完全编造或与 context 矛盾
@@ -49,9 +49,9 @@ omk 的取舍:**单次 1-5 分判断**,与 omk 其他 LLM-judge assertion 一致
 默认 threshold = 3 (>= 才 pass)。建议生产场景用 4。
 
 ### answer_relevancy
-- 5 = 完整切题回答,无冗余无遗漏
+- 5 = 完整切题回答，无冗余无遗漏
 - 4 = 切题但有少量冗余或小遗漏
-- 3 = 部分切题,部分跑题或避而不答
+- 3 = 部分切题，部分跑题或避而不答
 - 2 = 大部分跑题
 - 1 = 完全跑题或拒答
 
@@ -59,7 +59,7 @@ omk 的取舍:**单次 1-5 分判断**,与 omk 其他 LLM-judge assertion 一致
 
 ### context_recall
 - 5 = 全部关键事实被覆盖
-- 4 = 大部分覆盖,缺 1-2 条次要事实
+- 4 = 大部分覆盖，缺 1-2 条次要事实
 - 3 = 一半覆盖
 - 2 = 仅覆盖少量
 - 1 = 完全未覆盖
@@ -71,8 +71,8 @@ omk 的取舍:**单次 1-5 分判断**,与 omk 其他 LLM-judge assertion 一致
 三个 metric 的 judge prompt **自动包含与主 judge 同款的"长度不是质量信号"段落**:
 
 ```
-## 重要:长度不是质量信号
-评分时聚焦内容实质,不要因输出更长就给更高分。
+## 重要：长度不是质量信号
+评分时聚焦内容实质，不要因输出更长就给更高分。
 简洁正确的回答与冗长正确的回答应得相同分数。
 ```
 
@@ -89,7 +89,7 @@ omk 的取舍:**单次 1-5 分判断**,与 omk 其他 LLM-judge assertion 一致
 | Bootstrap CI | ✓ (composite 层) | ✗ | ✗ |
 | Krippendorff α | ✓ (--gold-dir) | ✗ | ✗ |
 
-omk 的差异化在"严谨性叠加":粒度比 RAGAS 粗,但每个 1-5 分都自动落入 omk 的统计框架,有 bootstrap CI、有 α 锚点、有 length-debias。RAGAS 给你更细的诊断,omk 给你更可靠的统计结论。
+omk 的差异化在"严谨性叠加":粒度比 RAGAS 粗，但每个 1-5 分都自动落入 omk 的统计框架，有 bootstrap CI、有 α 锚点、有 length-debias。RAGAS 给你更细的诊断,omk 给你更可靠的统计结论。
 
 ## 用法示例
 

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -1,6 +1,6 @@
 # omk 术语规范
 
-> **范围**: 这是 omk 维护者的内部设计决策归档(为什么 artifact 不叫 evaluand、为什么 v0.16 起废 `--variants`、qualityScore → judgeScore 迁移路径等)。不是新用户入门文档——日常用法看 [README](../README.md) 即可。中英双版并存(`docs/specs/` 英文 / `docs/zh/specs/` 中文),术语本身全是英文,源码为命名的事实来源。
+> **范围**: 这是 omk 维护者的内部设计决策归档(为什么 artifact 不叫 evaluand、为什么 v0.16 起废 `--variants`、qualityScore → judgeScore 迁移路径等)。不是新用户入门文档——日常用法看 [README](../README.md) 即可。中英双版并存(`docs/specs/` 英文 / `docs/zh/specs/` 中文),术语本身全是英文，源码为命名的事实来源。
 
 ## 一、目标
 
@@ -108,14 +108,14 @@
 
 规则:
 
-- **代码 / API / 文件名 / CLI flag 继续用 `sample`**:`Sample` 类型、`sample_id` 字段、`eval-samples.json` 文件名、`--samples` flag——这些是开源 API + 英文圈 LLM eval 通用术语,不动
-- **user-facing 中文文案默认用「用例」,不用「样本」**:CLI 输出、报告 UI、错误信息、文档正文、commit message 中文部分。包括"用例数"/"用例难度"/"用例不足"/"跨用例散度"等组合
-- **理由**:omk 的 `eval-samples` 是开发者**手挑**的测试用例,不是从某分布**随机抽样**的统计样本。「样本」会暗示"再多跑就能扩大样本量",误导用户——实际是要补设计、补用例。「用例」是工程语境(test case),与用户写测评时的心智一致("我设计了 5 个用例")
-- **例外:统计学术语场景保留「样本」**——Cohen's d / Hedges' g 的"**小样本修正**"、"**样本均值**"、"**样本方差**"、"**样本量**"、bootstrap "**重采样**" 等,这些是 stats 领域的固定提法(对应英文 small-sample correction / sample mean / sample variance / sample size / resampling),硬翻成「用例」反而让懂统计的读者多一拍。判定准则:**这个词指的是"对总体的一次随机抽样"统计概念**(那就是样本),还是**"开发者手挑的一条测试用例"**(那就是用例)。两者不混用、上下文清晰
+- **代码 / API / 文件名 / CLI flag 继续用 `sample`**:`Sample` 类型、`sample_id` 字段、`eval-samples.json` 文件名、`--samples` flag——这些是开源 API + 英文圈 LLM eval 通用术语，不动
+- **user-facing 中文文案默认用「用例」，不用「样本」**:CLI 输出、报告 UI、错误信息、文档正文、commit message 中文部分。包括"用例数"/"用例难度"/"用例不足"/"跨用例散度"等组合
+- **理由**:omk 的 `eval-samples` 是开发者**手挑**的测试用例，不是从某分布**随机抽样**的统计样本。「样本」会暗示"再多跑就能扩大样本量",误导用户——实际是要补设计、补用例。「用例」是工程语境(test case),与用户写测评时的心智一致("我设计了 5 个用例")
+- **例外：统计学术语场景保留「样本」**——Cohen's d / Hedges' g 的"**小样本修正**"、"**样本均值**"、"**样本方差**"、"**样本量**"、bootstrap "**重采样**" 等，这些是 stats 领域的固定提法(对应英文 small-sample correction / sample mean / sample variance / sample size / resampling),硬翻成「用例」反而让懂统计的读者多一拍。判定准则:**这个词指的是"对总体的一次随机抽样"统计概念**(那就是样本),还是**"开发者手挑的一条测试用例"**(那就是用例)。两者不混用、上下文清晰
 
 #### 6.1 Sample 元数据字段
 
-Sample schema 含 4 个可选元数据字段,纯文档 / 诊断用,**不参与 grading / judge / verdict**。详见 [docs/zh/specs/sample-design-spec.md](sample-design-spec.md)。
+Sample schema 含 4 个可选元数据字段，纯文档 / 诊断用,**不参与 grading / judge / verdict**。详见 [docs/zh/specs/sample-design-spec.md](sample-design-spec.md)。
 
 - **`capability?: string[]`** — 该 sample 测试的能力维度(可多个)。归一时大小写 / 短横线 / 驼峰 / 下划线不敏感。
 - **`difficulty?: 'easy' | 'medium' | 'hard'`** — 难度分层(强枚举)。
@@ -123,7 +123,7 @@ Sample schema 含 4 个可选元数据字段,纯文档 / 诊断用,**不参与 g
 - **`provenance?: 'human' | 'llm-generated' | 'production-trace'`** — 数据来源。
 
 **construct 跟 capability 区别**(用户最常混淆的两个字段):
-- **construct** = 这个 sample 测**哪类事**(necessity / quality / capability)。是实验设计的层面 — 你跑 baseline-vs-skill 是测必要性,跑 skill-v1-vs-skill-v2 是测质量。
+- **construct** = 这个 sample 测**哪类事**(necessity / quality / capability)。是实验设计的层面 — 你跑 baseline-vs-skill 是测必要性，跑 skill-v1-vs-skill-v2 是测质量。
 - **capability** = 这个 sample 测**哪些具体能力**(api-selection / error-diagnosis / fallback)。是被测对象的能力维度。
 
 ### 7. Task
@@ -207,7 +207,7 @@ Sample schema 含 4 个可选元数据字段,纯文档 / 诊断用,**不参与 g
 
 - **持续集成场景的内部 helper 一律用 "gate"**：`omk eval` 的 gate 路径 / `evaluateLayerGates` / `gateThreshold` / `LayerGateResult`
 - **置信区间场景一律用 "CI"**:`bootstrap CI` / `diff CI` / `bootstrapCI` 字段 / "95% CI"
-- 文档 / 注释 / commit message 提到 "CI" 时不必加澄清 — 单一含义,读者不需上下文判断
+- 文档 / 注释 / commit message 提到 "CI" 时不必加澄清 — 单一含义，读者不需上下文判断
 
 ### 6. 稳定性 = 跨重复运行（test-retest），不是跨用例散度
 
@@ -312,7 +312,7 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 
 ### 4. 裸 `kind` 留给 `ArtifactKind`
 
-在 omk 的产品语义里，裸 `kind` 留给 `Artifact.kind`（`ArtifactKind`：`baseline` / `skill` / `prompt` / `agent` / `workflow`）。`baseline` 表示 eval 里的空 artifact；实验角色仍然看 `control` / `treatment`。命令行设计同理：未来如果出现 `--kind`，它也应该表示 artifact kind，而不是安装目标、report 类型或 observe event 类型。
+在 omk 的产品语义里，裸 `kind` 留给 `Artifact.kind`（`ArtifactKind`：`baseline` / `skill` / `prompt` / `agent` / `workflow`）。`baseline` 表示 eval 里的空 artifact；实验角色仍然看 `control` / `treatment`。命令行设计同理：`omk install` 上的 `--kind` flag 表示 artifact kind（对齐 `Artifact.kind`），而不是安装目标、report 类型或 observe event 类型。
 
 其它判别字段如果是新字段，或能安全改名，就用限定名。已经落盘的既有 `kind` 字段保持原样，除非单独做 migration：
 
@@ -353,18 +353,18 @@ omk 跑 baseline-vs-skill 评测时,baseline variant 默认通过**三条 channe
 
 1. **SDK skill auto-discovery**:Claude Agent SDK 默认扫 `~/.claude/skills/` 把 skill 列表注入 main session system prompt
 2. **subagent Skill 工具**:即便 main session 没 skill,SDK 内置 task subagent 调 `Skill(...)` 仍会按需加载 skill 内容
-3. **cwd 文件系统访问**:baseline 默认 cwd 是用户评测工作目录,该目录通常有 `skills/<name>/` symlink 给 treatment 用,baseline 用 plain `Glob` / `Read` 工具就能顺 symlink 直接读 `SKILL.md`
+3. **cwd 文件系统访问**:baseline 默认 cwd 是用户评测工作目录，该目录通常有 `skills/<name>/` symlink 给 treatment 用,baseline 用 plain `Glob` / `Read` 工具就能顺 symlink 直接读 `SKILL.md`
 
 三条 channel 都堵掉之后,baseline 才真的"裸"。任何一条没堵,baseline 都会绕过其他堵点拿到 skill 内容,verdict / Δ 反映的是污染基线 vs treatment,而不是真实"无知识 vs 有知识"。
 
 ### 2. 术语
 
-- **`allowedSkills`**(per-variant 字段,新加在 `Artifact` / `VariantConfig` / `EvalConfigVariant` 上):
+- **`allowedSkills`**(per-variant 字段，新加在 `Artifact` / `VariantConfig` / `EvalConfigVariant` 上):
   - `undefined` → SDK 默认行为(全发现 `~/.claude/skills/`)
   - `[]` → **完全隔离**:`options.skills = []` + `options.disallowedTools = ['Skill']`,main session 不发现任何 skill,subagent 也无法调 Skill 工具
   - `[name1, name2]` → **白名单**:`options.skills = [name1, name2]`,只载入指定 skill。subagent 走独立 channel,白名单场景 v1 不强制 subagent 跟随(follow-up)
 - **`--strict-baseline` flag**(default true):对所有 `kind === 'baseline'` 的 artifact 自动设 `allowedSkills = []`;`--no-strict-baseline` 关掉(显式 opt-out)
-- **`meta.skillIsolation`**(report meta 新字段):variantName → allowedSkills 快照,跨报告对比 verdict / Δ 时校验
+- **`meta.skillIsolation`**(report meta 新字段):variantName → allowedSkills 快照，跨报告对比 verdict / Δ 时校验
 
 ### 3. 默认值与优先级
 
@@ -387,9 +387,9 @@ baseline-kind 默认 `[]`(strict),其他 kind 默认 `undefined`(SDK 全发现)�
 | `AgentDefinition.skills` 白名单精确控制 | ❌(known hole, v1 不做) | follow-up:omk 加 `agents` option |
 | script executor | ❌ | stderr warn,用户自定义不参与 isolation |
 
-**为什么 cwd 这条 channel 单独列出**:仅堵 SDK 两条 channel(`skills:[]` + `disallowedTools:['Skill']`)后,baseline 的 `Skill` 工具调用确实降到 0,但 baseline 仍能用 plain `Glob` / `Read` 顺 cwd 下的 `skills/<name>/` symlink 读到 `SKILL.md`,完全绕过 SDK 隔离。根因:omk 默认 `baseline.cwd === null` → SDK fallback 到 `process.cwd()` = 用户评测工作目录,那里通常有 `skills/<name>/` symlink 给 treatment 用。修法是 baseline 默认 cwd 切到 `~/.oh-my-knowledge/isolated-cwd/`(空目录)。**用户显式给 baseline 设 cwd 时不动**(显式 cwd = 用户负责该目录干净)。
+**为什么 cwd 这条 channel 单独列出**:仅堵 SDK 两条 channel(`skills:[]` + `disallowedTools:['Skill']`)后,baseline 的 `Skill` 工具调用确实降到 0,但 baseline 仍能用 plain `Glob` / `Read` 顺 cwd 下的 `skills/<name>/` symlink 读到 `SKILL.md`,完全绕过 SDK 隔离。根因:omk 默认 `baseline.cwd === null` → SDK fallback 到 `process.cwd()` = 用户评测工作目录，那里通常有 `skills/<name>/` symlink 给 treatment 用。修法是 baseline 默认 cwd 切到 `~/.oh-my-knowledge/isolated-cwd/`(空目录)。**用户显式给 baseline 设 cwd 时不动**(显式 cwd = 用户负责该目录干净)。
 
-注:isolated-cwd 不是 sandbox,baseline 仍可 Read 任意 absolute path。但模型不会主动猜用户私有路径(没 system prompt 暗示)。如果评测场景里 baseline 会被 prompt 引导去读绝对路径,需要再加层 sandbox 保护(out-of-scope)。
+注:isolated-cwd 不是 sandbox,baseline 仍可 Read 任意 absolute path。但模型不会主动猜用户私有路径(没 system prompt 暗示)。如果评测场景里 baseline 会被 prompt 引导去读绝对路径，需要再加层 sandbox 保护(out-of-scope)。
 
 ### 5. cache key 版本
 
@@ -403,7 +403,7 @@ cache key 当前为 `v4:` prefix,含 allowedSkills、executor 名和 executor ru
 | `claude-cli` | 默认 | `--disable-slash-commands --disallowedTools Skill` | **throw**(用户改 sdk) |
 | `script` | 默认 | stderr warn,不阻塞(无效) | stderr warn,不阻塞(无效) |
 
-claude-cli executor 用 `--disable-slash-commands`(文档:"Disable all skills")+ `--disallowedTools Skill` 双堵,跟 SDK 等价,**只缺 partial whitelist 能力**——白名单 `[name]` 需求必须走 claude-sdk(SDK `skills` option 直接支持白名单语义)。`script` executor 用户自定义,无法保证遵循 isolation,只 warn。
+claude-cli executor 用 `--disable-slash-commands`(文档:"Disable all skills")+ `--disallowedTools Skill` 双堵，跟 SDK 等价,**只缺 partial whitelist 能力**——白名单 `[name]` 需求必须走 claude-sdk(SDK `skills` option 直接支持白名单语义)。`script` executor 用户自定义，无法保证遵循 isolation,只 warn。
 
 ## 八、落地判断标准
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 发布 0.34.0

自 v0.33.0 以来的累积发布。本 PR 含版本号 bump（0.33.0 → 0.34.0）+ 发版前的文档校准。

### 主要变化（v0.33.0..main）

- **feat:`omk install` 补完整为「管理」支柱入口**（#207 / #211 / #212）：内置 Agent Skill onboarding、本地路径源、`git:<ref>:<spec>` 源；安装用户 skill 同时登记一条受管记录(`.omk/managed/<id>.json`)。引入 source-resolver 抽象,主干源无关。
- **fix(eval-core):git variant runtime fingerprint 消除 node_modules 污染**(#213)。
- **refactor(types):收敛 kind 判别字段**(#210)。
- 工程：迁移到 Yarn 4 Berry、发布包瘦身（去 source/declaration map）、CI 跑 typecheck、文档站多轮精修。
- **docs:发版前全站校准**（本 PR）：修过期 ReportMeta 字段名、evidence-gated 设计 note 的 install 现状/开放问题、terminology 的 `--kind` 现状;统一 zh 半角标点(GB/T 15834)。

### ⚠️ 破坏性变化（发版后需手动并入 release notes）

- **`#210` BREAKING-SERIALIZATION**：kind 判别字段收敛。已序列化进 report / observe / doctor / diagnosis JSON 的判别字段改名，读旧文件需走数据 / schema 迁移。详见该 PR description。
- **`#213` BREAKING-COMPARABILITY**：git variant 的 runtime fingerprint 在「从含 `node_modules/.bin` 的 cwd 运行」时变化(此前被污染、现归正);clean cwd 无变化。不碰冻结不变量。详见该 PR description。

### 验证

`yarn ci` 全绿(lint + typecheck + build + build:docs:check + 1856 tests),docs:build 无死链。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
