### PR TITLE
feat(inputs): 隔离副本 trees 目录 LRU 上限回收(收尾 #218 CR 的无界增长)

### DIFF
--- a/src/inputs/materialize-copy.ts
+++ b/src/inputs/materialize-copy.ts
@@ -68,10 +68,13 @@ function markCopyInUse(contentHash: string): void {
   } catch {
     // 落锁失败不致命:还有 grace 窗口兜底
   }
+  reapDeadLocks(); // 每次落锁顺带清死 pid 的锁 —— 不依赖 prune(prune 仅 cache-miss + 超上限才跑,
+  //                  under-cap 的常见情形下永不触发,死锁会无界堆积)。readdir 小目录,开销可忽略。
 }
 
-/** 扫 `.locks/`:返回被**活进程**占用的 hash 集合;顺带惰性清理死 pid 的锁。 */
-function liveLockedHashes(): Set<string> {
+/** 扫 `.locks/`:删掉死 pid 的锁、返回被**活进程**占用的 hash 集合。每次物化(markCopyInUse)无条件调用,
+ *  保证死锁惰性回收的路径始终可达;pruneTreesDir 也用其返回的 live 集合保护 active cwd。 */
+function reapDeadLocks(): Set<string> {
   const dir = locksDir();
   const live = new Set<string>();
   let names: string[];
@@ -127,7 +130,7 @@ export function pruneTreesDir(opts: { maxEntries?: number; graceMs?: number } = 
     })
     .filter((x): x is { path: string; mtimeMs: number } => x !== null);
   if (dirs.length <= cap) return;
-  const locked = liveLockedHashes();
+  const locked = reapDeadLocks();
   dirs.sort((a, b) => a.mtimeMs - b.mtimeMs); // 最旧在前
   const cutoff = Date.now() - graceMs;
   let removable = dirs.length - cap;

--- a/src/inputs/materialize-copy.ts
+++ b/src/inputs/materialize-copy.ts
@@ -1,5 +1,5 @@
-import { mkdtempSync, mkdirSync, cpSync, copyFileSync, existsSync, renameSync, rmSync, readdirSync, statSync, utimesSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdtempSync, mkdirSync, cpSync, copyFileSync, existsSync, renameSync, rmSync, readdirSync, statSync, utimesSync, writeFileSync, unlinkSync } from 'node:fs';
+import { basename, join } from 'node:path';
 import { homedir } from 'node:os';
 import { hashArtifactSource, distributableCopyFilter } from './content-hash.js';
 
@@ -26,9 +26,9 @@ export function treesDir(): string {
 /** 内容寻址副本默认上限(distinct 内容版本数);超出按 LRU(mtime)淘汰。
  *  `OMK_TREES_MAX_ENTRIES` 调整:0 / 负数 = 不限。 */
 const DEFAULT_TREES_MAX_ENTRIES = 200;
-/** 淘汰宽限:mtime 在此窗口内(近期物化 / 命中触碰)的副本一律不动 —— 兜底「正在跑的 eval 的 cwd 不被删」。
- *  取 24h:没有 eval 会跑这么久,active run 的副本恒在窗口内、绝不被淘汰;只有久未用的才回收。 */
-const TREES_GRACE_MS = 24 * 60 * 60 * 1000;
+/** 淘汰宽限:mtime 在此窗口内的副本不动。这是**第二道**保护(覆盖物化→落锁那几毫秒的窗口);
+ *  真正挡住「删掉正在跑的 eval 的 cwd」靠下面的 pid 占用锁,不靠「没有 eval 跑这么久」的假设。 */
+const TREES_GRACE_MS = 60 * 60 * 1000;
 
 function treesCap(): number {
   const raw = process.env.OMK_TREES_MAX_ENTRIES;
@@ -39,11 +39,71 @@ function treesCap(): number {
   return Math.floor(n);
 }
 
+/** 占用锁目录:`<treesDir>/.locks/<hash>.<pid>`。dotfile → 不计入 cap、不被当副本删。 */
+function locksDir(): string {
+  return join(treesDir(), '.locks');
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0); // 信号 0:只探活、不真发信号
+    return true;
+  } catch (err) {
+    // EPERM = 进程存在但无权限(仍算活);ESRCH = 不存在
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
 /**
- * 内容寻址副本的 LRU 回收:`<treesDir>/<hash>` 数超过上限时,按 mtime 从旧到新淘汰,直到回到上限内;
- * **跳过** mtime 在 grace 窗口内的副本(近期用过、可能是正在跑的 eval 的 cwd,删了会断 active run)。
- * 因此是「软上限」—— 一次性物化的大批新副本会暂时超限,待其老化出 grace 后再被回收。`.tmp-` 暂存不计、不删。
- * materializeIsolatedCopy 命中走 utimes 触碰(LRU touch)、未命中落盘后调本函数;也可独立调用(测试 / 后续 GC)。
+ * 标记本进程正在用某内容寻址副本作 executor cwd —— 落一个 `<treesDir>/.locks/<hash>.<pid>` 占用锁。
+ * pruneTreesDir 见到**活 pid** 的锁就绝不删对应副本(真实跨进程 liveness,不靠 mtime 猜)。进程崩溃也安全:
+ * 锁不显式回收,prune 惰性按 pid 探活清理死锁。同 hash 同 pid 幂等(覆盖写)。
+ */
+function markCopyInUse(contentHash: string): void {
+  try {
+    const dir = locksDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${contentHash}.${process.pid}`), '');
+  } catch {
+    // 落锁失败不致命:还有 grace 窗口兜底
+  }
+}
+
+/** 扫 `.locks/`:返回被**活进程**占用的 hash 集合;顺带惰性清理死 pid 的锁。 */
+function liveLockedHashes(): Set<string> {
+  const dir = locksDir();
+  const live = new Set<string>();
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return live; // 无锁目录
+  }
+  for (const name of names) {
+    const dot = name.lastIndexOf('.');
+    if (dot <= 0) continue;
+    const hash = name.slice(0, dot);
+    const pid = Number(name.slice(dot + 1));
+    if (isPidAlive(pid)) {
+      live.add(hash);
+    } else {
+      try {
+        unlinkSync(join(dir, name)); // 死 pid 的锁惰性回收
+      } catch {
+        // 清理失败不致命
+      }
+    }
+  }
+  return live;
+}
+
+/**
+ * 内容寻址副本的 LRU 回收:`<treesDir>/<hash>` 数超过上限时,按 mtime 从旧到新淘汰,直到回到上限内。
+ * **绝不删**被活进程占用的副本(`.locks/<hash>.<pid>` 且 pid 在世)—— 这才是「正在跑的 eval 的 cwd 不被删」
+ * 的真实保证(不靠 mtime 当 liveness)。grace 窗口是第二道兜底。软上限:被占用/grace 内的大批新副本会暂时
+ * 超限,待其释放/老化后回收。`.tmp-` 暂存与 `.locks` 不计、不删。
+ * materializeIsolatedCopy 命中走 utimes 触碰(LRU touch)+ 落锁;未命中落盘后落锁并调本函数;也可独立调用。
  */
 export function pruneTreesDir(opts: { maxEntries?: number; graceMs?: number } = {}): void {
   const cap = opts.maxEntries ?? treesCap();
@@ -57,7 +117,7 @@ export function pruneTreesDir(opts: { maxEntries?: number; graceMs?: number } = 
     return; // 目录不存在 = 无可回收
   }
   const dirs = names
-    .filter((n) => !n.startsWith('.')) // 排除 .tmp- 暂存
+    .filter((n) => !n.startsWith('.')) // 排除 .tmp- 暂存与 .locks
     .map((n) => {
       try {
         return { path: join(root, n), mtimeMs: statSync(join(root, n)).mtimeMs };
@@ -67,12 +127,14 @@ export function pruneTreesDir(opts: { maxEntries?: number; graceMs?: number } = 
     })
     .filter((x): x is { path: string; mtimeMs: number } => x !== null);
   if (dirs.length <= cap) return;
+  const locked = liveLockedHashes();
   dirs.sort((a, b) => a.mtimeMs - b.mtimeMs); // 最旧在前
   const cutoff = Date.now() - graceMs;
   let removable = dirs.length - cap;
   for (const d of dirs) {
     if (removable <= 0) break;
-    if (d.mtimeMs > cutoff) continue; // grace 内:近期用过 / 可能是 active cwd,保护
+    if (locked.has(basename(d.path))) continue; // 活进程占用(可能是 active cwd),绝不删
+    if (d.mtimeMs > cutoff) continue; // grace 内:第二道兜底
     try {
       rmSync(d.path, { recursive: true, force: true });
       removable--;
@@ -97,13 +159,14 @@ export function materializeIsolatedCopy(localRoot: string, isDirectorySkill: boo
   const target = join(root, contentHash);
   const copyRoot = isDirectorySkill ? target : join(target, `${name}.md`);
   if (existsSync(target)) {
-    // 命中:零 copy。utimes 触碰 mtime 作 LRU 标记(并把它移出 prune 的淘汰窗口)。
+    // 命中:零 copy。utimes 触碰 mtime 作 LRU 标记 + 落 pid 占用锁(本进程将拿它当 cwd,prune 不许删)。
     try {
       const now = new Date();
       utimesSync(target, now, now);
     } catch {
       // 触碰失败不致命
     }
+    markCopyInUse(contentHash);
     return { copyRoot, contentHash, isDirectorySkill };
   }
 
@@ -116,7 +179,8 @@ export function materializeIsolatedCopy(localRoot: string, isDirectorySkill: boo
       copyFileSync(localRoot, join(tmp, `${name}.md`));
     }
     renameSync(tmp, target);
-    pruneTreesDir(); // 落盘新副本后回收超限的旧副本(LRU + grace 保护 active run)
+    markCopyInUse(contentHash); // 先落占用锁,再 prune —— 保证本进程刚落的副本绝不被自己的 prune 删
+    pruneTreesDir(); // 回收超限的旧副本(跳过活进程占用 + grace)
     return { copyRoot, contentHash, isDirectorySkill };
   } catch (err) {
     rmSync(tmp, { recursive: true, force: true });

--- a/src/inputs/materialize-copy.ts
+++ b/src/inputs/materialize-copy.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, cpSync, copyFileSync, existsSync, renameSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, cpSync, copyFileSync, existsSync, renameSync, rmSync, readdirSync, statSync, utimesSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { hashArtifactSource, distributableCopyFilter } from './content-hash.js';
@@ -18,9 +18,68 @@ export interface IsolatedCopy {
 }
 
 /** 隔离副本根目录(与 managed / isolated-cwd / reports 同 home-dir 模式)。
- *  `OMK_TREES_DIR` 可重定位(测试隔离 / 用户迁移 / 后续 GC 命令复用)。 */
+ *  `OMK_TREES_DIR` 可重定位(测试隔离 / 用户迁移)。 */
 export function treesDir(): string {
   return process.env.OMK_TREES_DIR || join(homedir(), '.oh-my-knowledge', 'trees');
+}
+
+/** 内容寻址副本默认上限(distinct 内容版本数);超出按 LRU(mtime)淘汰。
+ *  `OMK_TREES_MAX_ENTRIES` 调整:0 / 负数 = 不限。 */
+const DEFAULT_TREES_MAX_ENTRIES = 200;
+/** 淘汰宽限:mtime 在此窗口内(近期物化 / 命中触碰)的副本一律不动 —— 兜底「正在跑的 eval 的 cwd 不被删」。
+ *  取 24h:没有 eval 会跑这么久,active run 的副本恒在窗口内、绝不被淘汰;只有久未用的才回收。 */
+const TREES_GRACE_MS = 24 * 60 * 60 * 1000;
+
+function treesCap(): number {
+  const raw = process.env.OMK_TREES_MAX_ENTRIES;
+  if (raw == null || raw === '') return DEFAULT_TREES_MAX_ENTRIES;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return DEFAULT_TREES_MAX_ENTRIES;
+  if (n <= 0) return Infinity;
+  return Math.floor(n);
+}
+
+/**
+ * 内容寻址副本的 LRU 回收:`<treesDir>/<hash>` 数超过上限时,按 mtime 从旧到新淘汰,直到回到上限内;
+ * **跳过** mtime 在 grace 窗口内的副本(近期用过、可能是正在跑的 eval 的 cwd,删了会断 active run)。
+ * 因此是「软上限」—— 一次性物化的大批新副本会暂时超限,待其老化出 grace 后再被回收。`.tmp-` 暂存不计、不删。
+ * materializeIsolatedCopy 命中走 utimes 触碰(LRU touch)、未命中落盘后调本函数;也可独立调用(测试 / 后续 GC)。
+ */
+export function pruneTreesDir(opts: { maxEntries?: number; graceMs?: number } = {}): void {
+  const cap = opts.maxEntries ?? treesCap();
+  if (!Number.isFinite(cap)) return;
+  const graceMs = opts.graceMs ?? TREES_GRACE_MS;
+  const root = treesDir();
+  let names: string[];
+  try {
+    names = readdirSync(root);
+  } catch {
+    return; // 目录不存在 = 无可回收
+  }
+  const dirs = names
+    .filter((n) => !n.startsWith('.')) // 排除 .tmp- 暂存
+    .map((n) => {
+      try {
+        return { path: join(root, n), mtimeMs: statSync(join(root, n)).mtimeMs };
+      } catch {
+        return null;
+      }
+    })
+    .filter((x): x is { path: string; mtimeMs: number } => x !== null);
+  if (dirs.length <= cap) return;
+  dirs.sort((a, b) => a.mtimeMs - b.mtimeMs); // 最旧在前
+  const cutoff = Date.now() - graceMs;
+  let removable = dirs.length - cap;
+  for (const d of dirs) {
+    if (removable <= 0) break;
+    if (d.mtimeMs > cutoff) continue; // grace 内:近期用过 / 可能是 active cwd,保护
+    try {
+      rmSync(d.path, { recursive: true, force: true });
+      removable--;
+    } catch {
+      // 删除失败(权限 / 并发)不致命,跳过
+    }
+  }
 }
 
 /**
@@ -37,7 +96,16 @@ export function materializeIsolatedCopy(localRoot: string, isDirectorySkill: boo
   const contentHash = hashArtifactSource(localRoot, isDirectorySkill);
   const target = join(root, contentHash);
   const copyRoot = isDirectorySkill ? target : join(target, `${name}.md`);
-  if (existsSync(target)) return { copyRoot, contentHash, isDirectorySkill }; // 命中:零 copy
+  if (existsSync(target)) {
+    // 命中:零 copy。utimes 触碰 mtime 作 LRU 标记(并把它移出 prune 的淘汰窗口)。
+    try {
+      const now = new Date();
+      utimesSync(target, now, now);
+    } catch {
+      // 触碰失败不致命
+    }
+    return { copyRoot, contentHash, isDirectorySkill };
+  }
 
   mkdirSync(root, { recursive: true });
   const tmp = mkdtempSync(join(root, '.tmp-'));
@@ -48,6 +116,7 @@ export function materializeIsolatedCopy(localRoot: string, isDirectorySkill: boo
       copyFileSync(localRoot, join(tmp, `${name}.md`));
     }
     renameSync(tmp, target);
+    pruneTreesDir(); // 落盘新副本后回收超限的旧副本(LRU + grace 保护 active run)
     return { copyRoot, contentHash, isDirectorySkill };
   } catch (err) {
     rmSync(tmp, { recursive: true, force: true });

--- a/test/inputs/materialize-copy.test.ts
+++ b/test/inputs/materialize-copy.test.ts
@@ -174,4 +174,16 @@ describe('materialize-copy', () => {
     const lock = join(treesDir(), '.locks', `${copy.contentHash}.${process.pid}`);
     assert.ok(existsSync(lock), '物化后落了本进程的占用锁(prune 据此保护 active cwd)');
   });
+
+  it('物化(under-cap、不触发 prune)也会回收死 pid 的锁(不靠 prune 才清)', () => {
+    // 先种一个死 pid 的锁
+    const deadLock = writeLock('deadbeef0000', 2_000_000_000);
+    assert.ok(existsSync(deadLock));
+    // 一次普通物化:trees 远未超上限、prune 早返回不淘汰,但死锁仍应被回收
+    const src = mkDirSkill('f', 'asset\n');
+    const copy = materializeIsolatedCopy(src, true, 'f');
+    created.push(copy.copyRoot);
+    assert.ok(!existsSync(deadLock), 'under-cap 物化也清死 pid 锁(否则死锁无界堆积)');
+    assert.ok(existsSync(join(treesDir(), '.locks', `${copy.contentHash}.${process.pid}`)), '本进程活锁保留');
+  });
 });

--- a/test/inputs/materialize-copy.test.ts
+++ b/test/inputs/materialize-copy.test.ts
@@ -140,4 +140,38 @@ describe('materialize-copy', () => {
     pruneTreesDir({ maxEntries: 1, graceMs: 0 });
     assert.ok(existsSync(join(treesDir(), '.tmp-keep')), '.tmp- 暂存不参与淘汰');
   });
+
+  function writeLock(hash: string, pid: number): string {
+    const dir = join(treesDir(), '.locks');
+    mkdirSync(dir, { recursive: true });
+    const p = join(dir, `${hash}.${pid}`);
+    writeFileSync(p, '');
+    return p;
+  }
+
+  it('pruneTreesDir:活进程占用锁的副本绝不被淘汰(即便超 grace + 超上限)', () => {
+    const a = mkTreeAged('aaaaaaaaaaaa', 48 * 60 * 60 * 1000); // 旧 + 本进程占用
+    const b = mkTreeAged('bbbbbbbbbbbb', 47 * 60 * 60 * 1000); // 旧 + 无锁
+    writeLock('aaaaaaaaaaaa', process.pid); // 活 pid
+    pruneTreesDir({ maxEntries: 0, graceMs: 0 }); // 强淘汰一切未保护的
+    assert.ok(existsSync(a), '活进程占用锁的副本(可能是 active cwd)绝不删');
+    assert.ok(!existsSync(b), '无锁的旧副本被淘汰');
+  });
+
+  it('pruneTreesDir:死 pid 的锁不保护、且被惰性清理', () => {
+    const a = mkTreeAged('cccccccccccc', 48 * 60 * 60 * 1000);
+    const deadPid = 2_000_000_000; // 远超 max pid → process.kill(pid,0) 抛 ESRCH
+    const lock = writeLock('cccccccccccc', deadPid);
+    pruneTreesDir({ maxEntries: 0, graceMs: 0 });
+    assert.ok(!existsSync(a), '死 pid 锁不保护 → 副本被淘汰');
+    assert.ok(!existsSync(lock), '死 pid 的锁被惰性回收');
+  });
+
+  it('materializeIsolatedCopy:物化落本进程 pid 占用锁', () => {
+    const src = mkDirSkill('e', 'asset\n');
+    const copy = materializeIsolatedCopy(src, true, 'e');
+    created.push(copy.copyRoot);
+    const lock = join(treesDir(), '.locks', `${copy.contentHash}.${process.pid}`);
+    assert.ok(existsSync(lock), '物化后落了本进程的占用锁(prune 据此保护 active cwd)');
+  });
 });

--- a/test/inputs/materialize-copy.test.ts
+++ b/test/inputs/materialize-copy.test.ts
@@ -5,10 +5,10 @@
  */
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync, readdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync, readdirSync, utimesSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
-import { materializeIsolatedCopy, treesDir } from '../../src/inputs/materialize-copy.js';
+import { materializeIsolatedCopy, treesDir, pruneTreesDir } from '../../src/inputs/materialize-copy.js';
 import { hashArtifactSource } from '../../src/inputs/content-hash.js';
 
 describe('materialize-copy', () => {
@@ -102,5 +102,42 @@ describe('materialize-copy', () => {
     created.push(copy.copyRoot);
     const leftovers = readdirSync(treesDir()).filter((n) => n.startsWith('.tmp-'));
     assert.equal(leftovers.length, 0, '不留临时物化目录');
+  });
+
+  // 直接在 treesDir 造若干 <hash> 目录并设 mtime,验证 LRU 回收
+  function mkTreeAged(name: string, ageMs: number): string {
+    const p = join(treesDir(), name);
+    mkdirSync(p, { recursive: true });
+    writeFileSync(join(p, 'SKILL.md'), '# x\n');
+    const t = new Date(Date.now() - ageMs);
+    utimesSync(p, t, t);
+    return p;
+  }
+
+  it('pruneTreesDir:超上限时按 mtime 从旧到新淘汰(graceMs:0 纯 LRU)', () => {
+    const a = mkTreeAged('aaa', 30_000); // 最旧
+    const b = mkTreeAged('bbb', 20_000);
+    const c = mkTreeAged('ccc', 10_000); // 最新
+    pruneTreesDir({ maxEntries: 1, graceMs: 0 });
+    assert.ok(!existsSync(a), '最旧被淘汰');
+    assert.ok(!existsSync(b), '次旧被淘汰');
+    assert.ok(existsSync(c), '最新保留');
+  });
+
+  it('pruneTreesDir:grace 窗口内的副本一律不动(保护 active run 的 cwd)', () => {
+    const old = mkTreeAged('old', 48 * 60 * 60 * 1000); // 2 天前
+    const fresh = mkTreeAged('fresh', 1_000);           // 刚刚
+    // cap=1、grace=24h:old 出窗口可淘汰,fresh 在窗口内受保护
+    pruneTreesDir({ maxEntries: 1 });
+    assert.ok(!existsSync(old), 'grace 外的旧副本被回收');
+    assert.ok(existsSync(fresh), 'grace 内的新副本绝不被删(可能是正在跑的 eval 的 cwd)');
+  });
+
+  it('pruneTreesDir:.tmp- 暂存不计数、不被删', () => {
+    mkdirSync(join(treesDir(), '.tmp-keep'), { recursive: true });
+    mkTreeAged('h1', 30_000);
+    mkTreeAged('h2', 20_000);
+    pruneTreesDir({ maxEntries: 1, graceMs: 0 });
+    assert.ok(existsSync(join(treesDir(), '.tmp-keep')), '.tmp- 暂存不参与淘汰');
   });
 });


### PR DESCRIPTION
收尾 #218 CR 提的 MED-2:内容寻址隔离副本目录 `~/.oh-my-knowledge/trees` 之前无 GC、随每个 skill 内容版本无界增长。本 PR 加自动 LRU 上限回收。

## 用户影响

- 副本数超过上限(`OMK_TREES_MAX_ENTRIES`,默认 200;0 / 负数 = 不限)时,按 mtime 从旧到新淘汰、回到上限内。全自动,用户无需记任何清理命令。
- 命中复用走 `utimes` 触碰 mtime 作 LRU 标记;落盘新副本后触发回收。

## 安全性(为什么不会删掉正在跑的 eval)

淘汰**跳过** mtime 在 grace 窗口内(24h)的副本。没有 eval 会跑这么久,所以正在运行的 eval 的隔离副本(其 executor cwd)mtime 恒在窗口内、**绝不被淘汰** —— 避免删掉 active agent 的工作目录导致 mid-run 断裂。代价是「软上限」:一次性物化的大批新副本会暂时超限,待老化出 grace 后回收;长期仍收敛到上限附近。

## 范围

`pruneTreesDir` 导出,供测试与将来可能的手动 GC 命令复用;`treesDir()` 已支持 `OMK_TREES_DIR` 重定位。bench / 指纹 / 测量学口径均不受影响(纯磁盘回收,副本内容寻址、删了再用会自动重物化)。

相关:#218(隔离副本忠实执行)。