### PR TITLE
chore(release): 发布 0.35.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ RAG-specific evals: see RAGAS (separate niche, complementary to omk). Full compa
 | **Production observability** | parse Claude Code session JSONL traces; measure per-skill failure rate / latency / cost / knowledge-gap signals |
 | **Knowledge-gap detection** | severity-weighted signals quantify risk exposure instead of claiming completeness |
 | **Construct-validity isolation** | `--strict-baseline` (default ON) cuts three contamination channels so baseline doesn't silently see the skill it's being compared against |
+| **Git & remote sources** | install / eval from a local git ref or a remote git URL (`--git-url`); directory-skills run in a content-addressed **isolated copy** so `references/` assets are real measured input, not just `SKILL.md` |
+| **Evidence-gated management** | `omk install` registers a managed record; `omk eval` auto-writes evidence bound by content fingerprint, moving a skill `installed → measurable`. [spec →](docs/specs/evidence-gated-management.md) |
 | **Sample design science** | sample schema with `capability` / `difficulty` / `construct` / `provenance` metadata (HF Dataset Cards style); studio surfaces coverage breakdown plus `rubric_clarity_low` / `capability_thin` flags. [docs/specs/sample-design-spec.md](docs/specs/sample-design-spec.md) |
 | **Multi-judge ensemble** | `--judge-models claude:opus,openai:gpt-4o` cross-vendor scoring + agreement metrics |
 | **Blind A/B** | `--blind` hides variant names; HTML report has a reveal button |
@@ -122,6 +124,7 @@ The full docs are published at **[oh-my-knowledge.pages.dev](https://oh-my-knowl
 - **[Sample design spec](docs/specs/sample-design-spec.md)** — capability / construct / provenance metadata; industry-gap mapping
 - **[Statistical rigor](docs/explanation/statistical-rigor.md)** — why bootstrap CI / α / length-debias / saturation matter
 - **[Comparison with 7 tools](docs/reference/comparison.md)** — 25+ dimensions across promptfoo / DeepEval / RAGAS / OpenAI Evals / LangSmith / lm-eval-harness / inspect-ai
+- **[Evidence-gated management](docs/specs/evidence-gated-management.md)** — managed records, lifecycle states (installed / measurable / stale), install → eval → measurable
 
 ## Environment variables
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -100,6 +100,8 @@ RAG 专项评测请看 RAGAS（独立 niche，跟 omk 互补）。完整对比�
 | **线上 session 观测** | 解析 Claude Code session JSONL，测量各 skill 的失败率、耗时、token 成本、知识缺口信号 |
 | **知识缺口识别** | 严重度加权的信号量化风险敞口，不宣称完备性 |
 | **用例隔离 (construct validity)** | `--strict-baseline`（默认开）三堵 baseline 拿到被测 skill 的污染路径 |
+| **Git / 远端源** | install / eval 支持本地 git ref 或远端 git URL（`--git-url`）；目录-skill 在内容寻址**隔离副本**里执行，`references/` 资产是真实测量输入，不只是 `SKILL.md` |
+| **证据门控管理** | `omk install` 登记受管记录；`omk eval` 按内容指纹自动写入证据，把 skill 从 `installed` 推到 `measurable`。[规范 →](docs/zh/specs/evidence-gated-management.md) |
 | **用例设计科学性** | Sample schema 加 `capability` / `difficulty` / `construct` / `provenance` 元数据字段（HF Dataset Cards 风），studio 输出 coverage 分桶 + `rubric_clarity_low` / `capability_thin` issue。[docs/zh/specs/sample-design-spec.md](docs/zh/specs/sample-design-spec.md) |
 | **多评委 ensemble** | `--judge-models claude:opus,openai:gpt-4o` 跨厂商评分 + agreement 度量 |
 | **盲测 A/B** | `--blind` 隐藏变体名称，HTML 报告有揭晓按钮 |
@@ -122,6 +124,7 @@ RAG 专项评测请看 RAGAS（独立 niche，跟 omk 互补）。完整对比�
 - **[用例设计规范](docs/zh/specs/sample-design-spec.md)** —— capability / construct / provenance 元数据；行业 gap 映射
 - **[统计严谨性](docs/zh/explanation/statistical-rigor.md)** —— 为什么 Bootstrap CI / α / 长度去偏 / 饱和曲线重要
 - **[7 工具对比](docs/zh/reference/comparison.md)** —— promptfoo / DeepEval / RAGAS / OpenAI Evals / LangSmith / lm-eval-harness / inspect-ai 等 25+ 维度横评
+- **[证据门控管理](docs/zh/specs/evidence-gated-management.md)** —— 受管记录、生命周期状态（installed / measurable / stale）、install → eval → measurable
 
 ## 环境变量
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -60,6 +60,9 @@ omk docs (blog posts, SKILL.md, CLI output, report pages) freely mix industry-st
 | judge (layer) | The 1-5 score the judge gives directly against the rubric | "💬 LLM judge" in the six-dimension comparison table |
 | dimension | Capability-aligned scoring dimension (not part of composite) | five-layer scoring pipeline architecture |
 | reliability check | Four evidence blocks — judge agreement / significant difference / saturation / human alignment — collapsible on the report page | details block on the report page |
+| [managed record](../specs/evidence-gated-management.md) | A `.omk/managed/<id>.json` fact record from `omk install` (source / contentHash / distribution / evidence / decisions) | `omk install`; evidence-gated management |
+| lifecycle (installed / measurable / stale) | Read-time state of a managed skill: `installed` (no valid evidence) → `measurable` (eval evidence bound) → `stale` (content drifted off its evidence) | `deriveManagedState`; `omk eval` "→ measurable" |
+| evidence (managed) | A `ManagedEvidenceRef` an eval run appends to a managed record, bound to the content fingerprint it measured (report id / sample coverage / verdict / comparability) | `omk eval` auto-write |
 
 ---
 

--- a/docs/zh/reference/glossary.md
+++ b/docs/zh/reference/glossary.md
@@ -60,6 +60,9 @@ omk 文档（包括博客、SKILL.md、CLI 输出、报告页）会混用一些 
 | judge (layer) | LLM 评价层 | 评委按 rubric 直接给的 1-5 分 | 六维对比表「💬 LLM 评价」 |
 | dimension | 维度 | capability-aligned 评分维度（v0.x 后期落地，未进 composite） | 五层评分管道架构 |
 | reliability check | 测评可信度 | 评委一致 / 差异显著 / 已饱和 / 人工对齐四块证据，可折叠展开 | 报告页 details 块 |
+| [managed record](../specs/evidence-gated-management.md) | 受管记录 | `omk install` 建的 `.omk/managed/<id>.json` 事实记录（源 / contentHash / 分发 / 证据 / 决定） | `omk install`；证据门控管理 |
+| lifecycle | 生命周期（installed / measurable / stale） | 受管 skill 的读时状态：`installed`（无有效证据）→ `measurable`（eval 证据已绑）→ `stale`（内容漂移脱离证据） | `deriveManagedState`；`omk eval`「→ measurable」 |
+| evidence (managed) | 证据 | eval 跑完追加进受管记录的 `ManagedEvidenceRef`，绑定它测的内容指纹（report id / 样本覆盖 / verdict / 可比性） | `omk eval` 自动写入 |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 发布 0.35.0

bump `0.34.0 → 0.35.0`,汇总自上次发版(#216)以来合入 `main` 的 5 个 PR。tag `v0.35.0` 触发 npm 发布。

### 包含

- **#218 `BREAKING-COMPARABILITY`** —— 统一 artifact 内容指纹到整树哈 + dir-skill 隔离副本忠实执行(report `schemaVersion 3`);git dir-skill evidence 可绑。
- **#219** —— 远端 git 源:`install --git-url` + eval.yaml 结构化 `git:`,@cwd/`:` 零冲突。
- **#220** —— 隔离副本 trees 目录 LRU 上限回收 + pid 占用锁。
- **#222** —— eval → managed evidence 写入:skill `installed → measurable`。
- **#217** —— 依赖 minor/patch 组 bump。

### ⚠️ Breaking changes(可比性)

#218 把 artifact 内容指纹从「SKILL.md 字节(git dir-skill)/ 旧口径」统一到**整树哈**,report `schemaVersion` 升到 **3**。**0.34.0 及更早产出的 git dir-skill 报告与 0.35.0 不可严格比较**,drift / lineage 消费方对 git dir-skill gate `>= 3`,旧报告标不可比、请重跑 `omk eval`。本地 dir-skill 在 schemaVersion 2/3 都整树、不受影响。迁移:重跑受影响的 git dir-skill 评测即可。

### 文档(本次随发版全局更新)

- README(中英)特性表补两行:「Git / 远端源 + 隔离副本忠实执行」「证据门控管理(`install → eval → measurable`)」;文档区加证据门控管理链接。
- glossary(中英)补三个 user-facing 术语:受管记录、生命周期(`installed` / `measurable` / `stale`)、受管证据。

### 验证

`yarn ci`(lint / typecheck / build / build:docs:check / test)全绿,1906 用例。

> 合并后打 `v0.35.0` tag 单独 push 触发 publish.yml;发布完把本说明的 Breaking changes 段 hoist 进 GitHub Release notes。

🤖 Generated with [Claude Code](https://claude.com/claude-code)