### PR TITLE
feat(cli): omk list —— 列出受管 skill 的证据状态与生命周期 (#203)

### DIFF
--- a/.agents/skills/omk/SKILL.md
+++ b/.agents/skills/omk/SKILL.md
@@ -4,7 +4,7 @@ description: |
   oh-my-knowledge 知识载体评测工具的智能代理。评测 skill（系统提示词）质量，对比不同版本效果，自动迭代改进。
   Use when: 用户提到"评测"、"测评"、"eval"、"benchmark"、"对比 skill"、"改进 skill"、"evolve"、"生成测试用例"、"gen-samples"、"omk"。
 user-invocable: true
-argument-hint: "<doctor|eval|evolve|init|install|observe|sample|studio> [options]"
+argument-hint: "<doctor|eval|evolve|init|install|list|observe|sample|studio> [options]"
 ---
 
 # OMK — 知识载体评测
@@ -19,7 +19,7 @@ argument-hint: "<doctor|eval|evolve|init|install|observe|sample|studio> [options
 npm i oh-my-knowledge -g
 ```
 
-omk CLI 顶层命令包括：`init` / `install` / `doctor` / `eval` / `observe` / `evolve` / `sample` / `studio`。没有 `bench` / `improve` / `gen-samples` 这些旧子命令名 —— 如果你在历史 SKILL / 文档里看到了，那是 v0.30 命令树重构之前的写法。
+omk CLI 顶层命令包括：`init` / `install` / `list` / `doctor` / `eval` / `observe` / `evolve` / `sample` / `studio`。没有 `bench` / `improve` / `gen-samples` 这些旧子命令名 —— 如果你在历史 SKILL / 文档里看到了，那是 v0.30 命令树重构之前的写法。
 
 ## 第二步：理解用户意图
 

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -348,6 +348,42 @@ omk install git:main:skills/review
 omk install --git-url https://github.com/org/repo.git --git-ref v1.0.0 skills/review
 ```
 
+## omk list
+
+列出受管 skill 及其证据状态：生命周期（installed / measurable / stale）、最新 verdict、证据数、源。
+
+**用法:**
+
+```bash
+omk list [flags]
+```
+
+**Flags:**
+
+- `--global` `boolean`:看全局受管目录（~/.oh-my-knowledge/managed）而非项目 .omk/managed
+- `--json` `boolean`:输出 JSON（含完整可比性 marker），供脚本消费
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
+
+**示例:**
+
+> 列出当前项目的受管 skill
+
+```bash
+omk list
+```
+
+> 列出全局受管 skill
+
+```bash
+omk list --global
+```
+
+> 机器可读 JSON 输出
+
+```bash
+omk list --json
+```
+
 ## omk observe
 
 分析 sessions 目录的 skill 调用健康度（默认行为）。子命令:ingest / inbox / show。

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -81,7 +81,7 @@ For full descriptions: `omk list --help`.
 
 <!-- omk:cli:list:flags:end -->
 
-Lists managed skills with their **evidence status**, not just files: lifecycle state, the latest verdict bound to the current content, current/total evidence count, and source. The lifecycle is derived at read time — `installed` (no valid evidence), `measurable` (eval evidence bound to the current content fingerprint), `stale` (source content drifted off its evidence). Because the fingerprint covers a directory-skill's whole tree (`SKILL.md` + `references/`), editing any asset flips the skill to `stale`. `--json` carries the full comparability marker (`cliVersion` / `judgePromptHash` / `debiasMode`) for scripts. See [evidence-gated management](../specs/evidence-gated-management.md).
+Lists managed skills with their **evidence status**, not just files: lifecycle state, the latest verdict bound to the current content, current/total evidence count, and source. The lifecycle is derived at read time — `installed` (no valid evidence), `measurable` (eval evidence bound to the current content fingerprint), `stale` (source content drifted off its evidence). Because the fingerprint covers a directory-skill's whole tree (`SKILL.md` + `references/`), editing any asset flips the skill to `stale`. `--json` emits a versioned envelope `{ schemaVersion, rows }` (each row carries the full comparability marker `cliVersion` / `judgePromptHash` / `debiasMode`) so scripts can detect shape changes. See [evidence-gated management](../specs/evidence-gated-management.md).
 
 ## `omk doctor`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -59,6 +59,30 @@ Installing **your own** skill (local path or git source) also writes a **managed
 
 The default `auto` target writes only to detected targets omk explicitly supports: Codex/AGENTS when `~/.codex` or `~/.agents` exists, and Claude Code when `~/.claude` exists. Use `--to all` to force every target omk currently knows, or `--dest` for a custom skill root.
 
+## `omk list`
+
+```bash
+omk list                 # managed skills in the current project (.omk/managed)
+omk list --global        # globally managed skills (~/.oh-my-knowledge/managed)
+omk list --json          # machine-readable output with full comparability markers
+```
+
+<!-- omk:cli:list:flags:start -->
+
+**Flags:**
+
+```text
+  --global        Show the global managed dir (~/.oh-my-knowledge/managed) instead of project .omk/managed
+  --json          Output JSON (with full comparability markers) for scripts
+  --lang <value>  Output language zh|en. Priority: CLI > OMK_LANG env > zh.
+```
+
+For full descriptions: `omk list --help`.
+
+<!-- omk:cli:list:flags:end -->
+
+Lists managed skills with their **evidence status**, not just files: lifecycle state, the latest verdict bound to the current content, current/total evidence count, and source. The lifecycle is derived at read time — `installed` (no valid evidence), `measurable` (eval evidence bound to the current content fingerprint), `stale` (source content drifted off its evidence). Because the fingerprint covers a directory-skill's whole tree (`SKILL.md` + `references/`), editing any asset flips the skill to `stale`. `--json` carries the full comparability marker (`cliVersion` / `judgePromptHash` / `debiasMode`) for scripts. See [evidence-gated management](../specs/evidence-gated-management.md).
+
 ## `omk doctor`
 
 ```bash

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -81,7 +81,7 @@ omk list --json          # 机器可读输出，含完整可比性 marker
 
 <!-- omk:cli:list:flags:end -->
 
-列出受管 skill 的**证据状态**，而非只列文件：生命周期状态、绑定当前内容的最新 verdict、当前/全部证据数、源。生命周期读时推导 —— `installed`（无有效证据）、`measurable`（eval 证据绑定到当前内容指纹）、`stale`（源内容漂移、脱离证据）。因为指纹覆盖目录-skill 整棵树（`SKILL.md` + `references/`），改任一资产即把 skill 翻成 `stale`。`--json` 携带完整可比性 marker（`cliVersion` / `judgePromptHash` / `debiasMode`）供脚本消费。参见[证据门控管理](../specs/evidence-gated-management.md)。
+列出受管 skill 的**证据状态**，而非只列文件：生命周期状态、绑定当前内容的最新 verdict、当前/全部证据数、源。生命周期读时推导 —— `installed`（无有效证据）、`measurable`（eval 证据绑定到当前内容指纹）、`stale`（源内容漂移、脱离证据）。因为指纹覆盖目录-skill 整棵树（`SKILL.md` + `references/`），改任一资产即把 skill 翻成 `stale`。`--json` 输出版本化信封 `{ schemaVersion, rows }`（每行携带完整可比性 marker `cliVersion` / `judgePromptHash` / `debiasMode`），让脚本能检测形态变更。参见[证据门控管理](../specs/evidence-gated-management.md)。
 
 ## `omk doctor`
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -59,6 +59,30 @@ omk install ./skills/review --dest ~/.my-agent/skills
 
 默认 `auto` 只写入本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。
 
+## `omk list`
+
+```bash
+omk list                 # 当前项目的受管 skill（.omk/managed）
+omk list --global        # 全局受管 skill（~/.oh-my-knowledge/managed）
+omk list --json          # 机器可读输出，含完整可比性 marker
+```
+
+<!-- omk:cli:list:flags:start -->
+
+**Flags:**
+
+```text
+  --global        看全局受管目录（~/.oh-my-knowledge/managed）而非项目 .omk/managed
+  --json          输出 JSON（含完整可比性 marker），供脚本消费
+  --lang <value>  输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
+```
+
+完整描述见 `omk list --help`。
+
+<!-- omk:cli:list:flags:end -->
+
+列出受管 skill 的**证据状态**，而非只列文件：生命周期状态、绑定当前内容的最新 verdict、当前/全部证据数、源。生命周期读时推导 —— `installed`（无有效证据）、`measurable`（eval 证据绑定到当前内容指纹）、`stale`（源内容漂移、脱离证据）。因为指纹覆盖目录-skill 整棵树（`SKILL.md` + `references/`），改任一资产即把 skill 翻成 `stale`。`--json` 携带完整可比性 marker（`cliVersion` / `judgePromptHash` / `debiasMode`）供脚本消费。参见[证据门控管理](../specs/evidence-gated-management.md)。
+
 ## `omk doctor`
 
 ```bash

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -1,0 +1,127 @@
+import { Flags } from '@oclif/core';
+import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
+import { BaseCommand } from '../oclif/base-command.js';
+import { tCli } from '../lib/i18n.js';
+import { resolveInstallSource } from '../../inputs/source-resolver.js';
+import {
+  buildManagedListRows,
+  globalManagedDir,
+  hashArtifactSource,
+  loadAllManagedRecords,
+  managedDir,
+  resolveManagedDir,
+  type ManagedListRow,
+} from '../../managed/index.js';
+import type { ManagedArtifactRecord } from '../../types/index.js';
+import type { CliLang } from '../lib/i18n.js';
+
+/**
+ * 算一条受管记录**当前源**的内容哈,用于 drift / 生命周期推导。
+ *   - 远端 git(带 url):源身份钉的是不可变 SHA(install 时 pin),内容恒定 → 直接取 record.contentHash,
+ *     不联网(list 是快读命令,不该为 drift 检查发网络请求)。
+ *   - 本地 file / 本地 git:locator 就是 install 的输入串,复用 resolveInstallSource 重物化真源再哈;
+ *     源已不在 / ref 已没 / 不在原仓库上下文 → 抛错 → undefined(deriveManagedState 据此判 stale)。
+ */
+function currentSourceHash(record: ManagedArtifactRecord): string | undefined {
+  const s = record.source;
+  if (s.sourceKind === 'git' && s.url) return record.contentHash;
+  try {
+    const resolved = resolveInstallSource(s.locator);
+    try {
+      return hashArtifactSource(resolved.localRoot, resolved.isDirectorySkill);
+    } finally {
+      resolved.cleanup();
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+/** CJK 全角字符按 2 列计宽,使含中文表头的列也能对齐。 */
+function dispWidth(s: string): number {
+  let w = 0;
+  for (const ch of s) w += /[ᄀ-ᅟ⺀-꓏가-힣豈-﫿︰-﹏＀-｠￠-￦]/.test(ch) ? 2 : 1;
+  return w;
+}
+
+function pad(s: string, width: number): string {
+  return s + ' '.repeat(Math.max(0, width - dispWidth(s)));
+}
+
+function truncate(s: string, max: number): string {
+  return dispWidth(s) <= max ? s : `${s.slice(0, max - 1)}…`;
+}
+
+function renderTable(rows: ManagedListRow[], lang: CliLang): string {
+  const headers = [
+    tCli('cli.list.col_name', lang),
+    tCli('cli.list.col_kind', lang),
+    tCli('cli.list.col_state', lang),
+    tCli('cli.list.col_verdict', lang),
+    tCli('cli.list.col_evidence', lang),
+    tCli('cli.list.col_source', lang),
+  ];
+  const cells = rows.map((r) => [
+    r.name,
+    r.kind,
+    r.state === 'stale' ? 'stale ⚠️' : r.state,
+    r.latestVerdict ?? '—',
+    `${r.currentEvidenceCount}/${r.totalEvidenceCount}`,
+    truncate(r.sourceLabel, 48),
+  ]);
+  const widths = headers.map((h, i) => Math.max(dispWidth(h), ...cells.map((c) => dispWidth(c[i]))));
+  const line = (c: string[]): string => c.map((v, i) => pad(v, widths[i])).join('  ').trimEnd();
+  return [line(headers), ...cells.map(line)].join('\n');
+}
+
+export default class List extends BaseCommand {
+  static description = bilingual({
+    zh: '列出受管 skill 及其证据状态：生命周期（installed / measurable / stale）、最新 verdict、证据数、源。',
+    en: 'List managed skills with evidence status: lifecycle (installed / measurable / stale), latest verdict, evidence count, source.',
+  });
+
+  static examples = [
+    { description: bilingual({ zh: '列出当前项目的受管 skill', en: 'List managed skills in the current project' }), command: '<%= config.bin %> list' },
+    { description: bilingual({ zh: '列出全局受管 skill', en: 'List globally managed skills' }), command: '<%= config.bin %> list --global' },
+    { description: bilingual({ zh: '机器可读 JSON 输出', en: 'Machine-readable JSON output' }), command: '<%= config.bin %> list --json' },
+  ];
+
+  static flags = {
+    lang: LANG_FLAG,
+    global: Flags.boolean({
+      description: bilingual({ zh: '看全局受管目录（~/.oh-my-knowledge/managed）而非项目 .omk/managed', en: 'Show the global managed dir (~/.oh-my-knowledge/managed) instead of project .omk/managed' }),
+    }),
+    json: Flags.boolean({
+      description: bilingual({ zh: '输出 JSON（含完整可比性 marker），供脚本消费', en: 'Output JSON (with full comparability markers) for scripts' }),
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(List);
+    const lang = this.lang;
+    await this.runWithCliExit(async () => {
+      const dir = flags.global ? globalManagedDir() : resolveManagedDir(managedDir());
+      const records = loadAllManagedRecords(dir);
+      const rows = buildManagedListRows(records, currentSourceHash);
+
+      if (flags.json) {
+        this.log(JSON.stringify(rows, null, 2));
+        return;
+      }
+
+      if (rows.length === 0) {
+        process.stderr.write(tCli('cli.list.empty', lang));
+        process.stderr.write(tCli('cli.list.empty_hint', lang));
+        return;
+      }
+
+      const scope = dir === globalManagedDir()
+        ? (lang === 'zh' ? '全局' : 'global')
+        : (lang === 'zh' ? '项目' : 'project');
+      process.stderr.write(tCli('cli.list.header', lang, { scope, count: rows.length }));
+      this.log(renderTable(rows, lang));
+      if (rows.some((r) => r.drifted)) process.stderr.write('\n' + tCli('cli.list.drift_note', lang));
+      process.stderr.write(tCli('cli.list.legend', lang));
+    });
+  }
+}

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -1,3 +1,5 @@
+import { existsSync, lstatSync, readdirSync, type Dirent } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { Flags } from '@oclif/core';
 import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
@@ -7,33 +9,108 @@ import {
   buildManagedListRows,
   globalManagedDir,
   hashArtifactSource,
+  isDistributablePath,
   loadAllManagedRecords,
   managedDir,
   resolveManagedDir,
   type ManagedListRow,
+  type SourceProbe,
 } from '../../managed/index.js';
 import type { ManagedArtifactRecord } from '../../types/index.js';
 import type { CliLang } from '../lib/i18n.js';
 
+// 本地源读取成本上限。skill 是小体量 markdown(+少量 references 资产),远超这些边界的源必是手改 /
+// 投毒,拒读避免 `omk list`(只读命令,读盘上可能随仓库分发的 locator)被 /dev/zero / 超大文件 / 巨型
+// 目录递归拖垮(DoS)。
+const MAX_FILE_SOURCE_BYTES = 8 * 1024 * 1024; // 单文件-skill 上限
+const MAX_DIR_SOURCE_BYTES = 64 * 1024 * 1024; // 目录-skill 整树累计上限
+const MAX_DIR_SOURCE_FILES = 4000;             // 目录-skill 文件数上限
+const MAX_DIR_SOURCE_DEPTH = 64;               // 目录递归深度上限
+
 /**
- * 算一条受管记录**当前源**的内容哈,用于 drift / 生命周期推导。
- *   - 远端 git(带 url):源身份钉的是不可变 SHA(install 时 pin),内容恒定 → 直接取 record.contentHash,
- *     不联网(list 是快读命令,不该为 drift 检查发网络请求)。
- *   - 本地 file / 本地 git:locator 就是 install 的输入串,复用 resolveInstallSource 重物化真源再哈;
- *     源已不在 / ref 已没 / 不在原仓库上下文 → 抛错 → undefined(deriveManagedState 据此判 stale)。
+ * 目录-skill 源的**有边界**整树哈:先恢复 resolveFileSource 的形态校验(SKILL.md 存在、是常规文件、非
+ * 软链 —— 否则 locator 可指向任意可读目录让 list 递归读整棵树),再 stat-walk(只 stat 不读)按与
+ * hashArtifactSource 同一 `isDistributablePath` 过滤累计 文件数 / 字节 / 深度,超界即返回 null(unreachable),
+ * 把单文件 DoS 不再换成目录递归 DoS。通过后才真正 hashArtifactSource。返回 null = 拒读 / 非法 skill 目录。
  */
-function currentSourceHash(record: ManagedArtifactRecord): string | undefined {
-  const s = record.source;
-  if (s.sourceKind === 'git' && s.url) return record.contentHash;
+function boundedDirSkillHash(abs: string): string | null {
+  const skillMd = join(abs, 'SKILL.md');
+  let md: ReturnType<typeof lstatSync>;
   try {
-    const resolved = resolveInstallSource(s.locator);
-    try {
-      return hashArtifactSource(resolved.localRoot, resolved.isDirectorySkill);
-    } finally {
-      resolved.cleanup();
-    }
+    md = lstatSync(skillMd);
   } catch {
-    return undefined;
+    return null; // 无 SKILL.md → 不是 skill 目录,拒
+  }
+  if (md.isSymbolicLink() || !md.isFile()) return null; // SKILL.md 必须是常规文件、非软链
+  let files = 0;
+  let bytes = 0;
+  const within = (dir: string, segs: string[], depth: number): boolean => {
+    if (depth > MAX_DIR_SOURCE_DEPTH) return false;
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+    for (const e of entries) {
+      const ns = [...segs, e.name];
+      if (!isDistributablePath(ns)) continue; // 与 hashArtifactSource 读取范围一致
+      if (e.isDirectory()) {
+        if (!within(join(dir, e.name), ns, depth + 1)) return false;
+      } else if (e.isFile()) { // 软链 Dirent 既非 isFile 也非 isDirectory → 天然跳过
+        if (++files > MAX_DIR_SOURCE_FILES) return false;
+        try {
+          bytes += lstatSync(join(dir, e.name)).size;
+        } catch {
+          return false;
+        }
+        if (bytes > MAX_DIR_SOURCE_BYTES) return false;
+      }
+    }
+    return true;
+  };
+  if (!within(abs, [], 0)) return null;
+  return hashArtifactSource(abs, true);
+}
+
+/**
+ * 探测一条受管记录**当前源**的状态(三态,喂 buildManagedListRow 判 drift / 生命周期)。
+ *   - 远端 git(带 url):源身份钉不可变 SHA(install 时 pin),内容恒定 → 直接取 record.contentHash,
+ *     不联网(list 是快读命令,不为 drift 检查发网络请求)。reachable。
+ *   - 本地 git:locator `git:<ref>:<spec>` 复用 resolveInstallSource 在**仓库对象库**内重物化重哈
+ *     (读取受 git 边界约束,无任意文件读 DoS)。解析不到(常因 `omk list` 的 cwd 与 install 时不同、
+ *     spec 随 cwd 漂)→ 抛错 → **reachable:false(未核,不当 stale)**,避免对未改动的 skill 误报漂移。
+ *   - 本地 file:locator 是绝对路径,但受管 JSON **用户可手改 / 随仓库分发**(无 install、无 opt-in 即被
+ *     loadAllManagedRecords 读到)。只读命令绝不盲读任意路径:**拒软链、只读常规文件 / 真目录、单文件
+ *     设 size cap**(挡 `evil.md → /dev/zero` 这类 readFileSync 无界 DoS 与项目外任意读)。守卫不过 →
+ *     reachable:false。目录-skill 整树哈本就跳软链(hashArtifactSource 用 isFile() 过滤)。
+ */
+export function probeSourceState(record: ManagedArtifactRecord): SourceProbe {
+  const s = record.source;
+  if (s.sourceKind === 'git' && s.url) return { reachable: true, hash: record.contentHash };
+  try {
+    if (s.sourceKind === 'git') {
+      const resolved = resolveInstallSource(s.locator);
+      try {
+        return { reachable: true, hash: hashArtifactSource(resolved.localRoot, resolved.isDirectorySkill) };
+      } finally {
+        resolved.cleanup();
+      }
+    }
+    // 本地 file 源:守卫后再读。
+    const abs = resolve(s.locator);
+    if (!existsSync(abs)) return { reachable: false };
+    const st = lstatSync(abs); // lstat:不跟随软链 —— 软链直接拒(防 evil.md → /dev/zero)
+    if (st.isSymbolicLink()) return { reachable: false };
+    if (s.isDirectorySkill) {
+      if (!st.isDirectory()) return { reachable: false };
+      const hash = boundedDirSkillHash(abs); // 形态校验 + 成本边界(防任意目录递归读 / 目录 DoS)
+      return hash === null ? { reachable: false } : { reachable: true, hash };
+    }
+    if (!st.isFile() || st.size > MAX_FILE_SOURCE_BYTES) return { reachable: false }; // 非常规文件 / 超大 → 拒读
+    return { reachable: true, hash: hashArtifactSource(abs, false) };
+  } catch {
+    return { reachable: false };
   }
 }
 
@@ -48,8 +125,27 @@ function pad(s: string, width: number): string {
   return s + ' '.repeat(Math.max(0, width - dispWidth(s)));
 }
 
+/** 按**显示宽度**截断(不是 code unit):逐码点累加 dispWidth,绝不切断 surrogate 对、CJK 也不溢出列。 */
 function truncate(s: string, max: number): string {
-  return dispWidth(s) <= max ? s : `${s.slice(0, max - 1)}…`;
+  if (dispWidth(s) <= max) return s;
+  let w = 0;
+  let out = '';
+  for (const ch of s) {
+    const cw = dispWidth(ch);
+    if (w + cw > max - 1) break; // 留 1 列给省略号
+    out += ch;
+    w += cw;
+  }
+  return `${out}…`;
+}
+
+/** 洗控制字符:managed JSON 可随仓库分发,name / sourceLabel / verdict 等字段塞进表格前必须先洗,
+ *  否则换行 / 回车 / ANSI / OSC 转义会破坏表格甚至伪造后续终端输出。把 C0(含 ESC / 换行 / TAB)、DEL、
+ *  C1 全替换为可见占位 —— ESC 一旦被替换,任何 ANSI/OSC 序列即失效。`--json` 路径保留原值给脚本。 */
+export function sanitizeCell(s: string): string {
+  // C0 (U+0000–U+001F, 含 ESC / 换行 / 回车 / TAB) + DEL (U+007F) + C1 (U+0080–U+009F) → U+FFFD;
+  // ESC 一旦被替换,任何 ANSI / OSC 序列即失效。
+  return s.replace(/[\u0000-\u001f\u007f-\u009f]/g, '\ufffd');
 }
 
 function renderTable(rows: ManagedListRow[], lang: CliLang): string {
@@ -62,12 +158,13 @@ function renderTable(rows: ManagedListRow[], lang: CliLang): string {
     tCli('cli.list.col_source', lang),
   ];
   const cells = rows.map((r) => [
-    r.name,
-    r.kind,
-    r.state === 'stale' ? 'stale ⚠️' : r.state,
-    r.latestVerdict ?? '—',
+    sanitizeCell(r.name),
+    r.kind, // ArtifactKind 枚举(validator 已收窄),无需洗
+    // 不可达 → 标「?」(drift 未核),绝不冒充 stale;reachable 且漂移才 stale ⚠️。
+    !r.reachable ? `${r.state} ?` : r.state === 'stale' ? 'stale ⚠️' : r.state,
+    r.latestVerdict ? sanitizeCell(r.latestVerdict) : '—',
     `${r.currentEvidenceCount}/${r.totalEvidenceCount}`,
-    truncate(r.sourceLabel, 48),
+    truncate(sanitizeCell(r.sourceLabel), 48),
   ]);
   const widths = headers.map((h, i) => Math.max(dispWidth(h), ...cells.map((c) => dispWidth(c[i]))));
   const line = (c: string[]): string => c.map((v, i) => pad(v, widths[i])).join('  ').trimEnd();
@@ -102,7 +199,7 @@ export default class List extends BaseCommand {
     await this.runWithCliExit(async () => {
       const dir = flags.global ? globalManagedDir() : resolveManagedDir(managedDir());
       const records = loadAllManagedRecords(dir);
-      const rows = buildManagedListRows(records, currentSourceHash);
+      const rows = buildManagedListRows(records, probeSourceState);
 
       if (flags.json) {
         this.log(JSON.stringify(rows, null, 2));
@@ -121,6 +218,7 @@ export default class List extends BaseCommand {
       process.stderr.write(tCli('cli.list.header', lang, { scope, count: rows.length }));
       this.log(renderTable(rows, lang));
       if (rows.some((r) => r.drifted)) process.stderr.write('\n' + tCli('cli.list.drift_note', lang));
+      if (rows.some((r) => !r.reachable)) process.stderr.write(tCli('cli.list.unreachable_note', lang));
       process.stderr.write(tCli('cli.list.legend', lang));
     });
   }

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -139,13 +139,17 @@ function truncate(s: string, max: number): string {
   return `${out}…`;
 }
 
-/** 洗控制字符:managed JSON 可随仓库分发,name / sourceLabel / verdict 等字段塞进表格前必须先洗,
- *  否则换行 / 回车 / ANSI / OSC 转义会破坏表格甚至伪造后续终端输出。把 C0(含 ESC / 换行 / TAB)、DEL、
- *  C1 全替换为可见占位 —— ESC 一旦被替换,任何 ANSI/OSC 序列即失效。`--json` 路径保留原值给脚本。 */
+/** 洗不可信显示字符:managed JSON 可随仓库分发,name / sourceLabel / verdict 等字段塞进表格前必须先洗,
+ *  否则会破坏表格甚至伪造终端输出。一律映射到可见 U+FFFD(--json 路径保留原值给脚本):
+ *    - C0(含 ESC / 换行 / 回车 / TAB)+ DEL + C1 → 杀 ANSI / OSC 转义与终端控制;
+ *    - BiDi 控制 / 隔离(U+202A–202E / 2066–2069 / 200E–200F / 061C)→ 防 Trojan-Source 视觉重排伪造;
+ *    - 零宽 / 不可见格式符(U+200B–200D / 2060–2064 / FEFF / 00AD)→ 防零宽隐藏 / 分割;
+ *    - 组合附加符(U+0300–036F / 20D0–20FF / FE20–FE2F)→ 变可见,避免零前进宽度令 dispWidth 与终端列错位。 */
 export function sanitizeCell(s: string): string {
-  // C0 (U+0000–U+001F, 含 ESC / 换行 / 回车 / TAB) + DEL (U+007F) + C1 (U+0080–U+009F) → U+FFFD;
-  // ESC 一旦被替换,任何 ANSI / OSC 序列即失效。
-  return s.replace(/[\u0000-\u001f\u007f-\u009f]/g, '\ufffd');
+  return s.replace(
+    /[\u0000-\u001f\u007f-\u009f\u00ad\u0300-\u036f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u2064\u2066-\u2069\u20d0-\u20ff\ufe20-\ufe2f\ufeff]/g,
+    '\ufffd',
+  );
 }
 
 function renderTable(rows: ManagedListRow[], lang: CliLang): string {

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -1,5 +1,5 @@
 import { existsSync, lstatSync, readdirSync, type Dirent } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
 import { Flags } from '@oclif/core';
 import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
@@ -41,7 +41,7 @@ function boundedDirSkillHash(abs: string): string | null {
   } catch {
     return null; // 无 SKILL.md → 不是 skill 目录,拒
   }
-  if (md.isSymbolicLink() || !md.isFile()) return null; // SKILL.md 必须是常规文件、非软链
+  if (md.isSymbolicLink() || !md.isFile() || md.nlink !== 1) return null; // SKILL.md 必须是常规、非软链、非硬链
   let files = 0;
   let bytes = 0;
   const within = (dir: string, segs: string[], depth: number): boolean => {
@@ -60,7 +60,9 @@ function boundedDirSkillHash(abs: string): string | null {
       } else if (e.isFile()) { // 软链 Dirent 既非 isFile 也非 isDirectory → 天然跳过
         if (++files > MAX_DIR_SOURCE_FILES) return false;
         try {
-          bytes += lstatSync(join(dir, e.name)).size;
+          const fst = lstatSync(join(dir, e.name));
+          if (fst.nlink !== 1) return false; // 硬链(nlink>1)可在树内别名树外敏感 inode → 拒读整树
+          bytes += fst.size;
         } catch {
           return false;
         }
@@ -97,7 +99,9 @@ export function probeSourceState(record: ManagedArtifactRecord): SourceProbe {
         resolved.cleanup();
       }
     }
-    // 本地 file 源:守卫后再读。
+    // 本地 file 源:守卫后再读。locator 必须是 install 实际写出的形态(绝对路径) —— 受管 JSON 随仓库
+    // 分发、无 opt-in 即被读到,相对 locator 不是 install 产物,拒,避免按 cwd 解析到项目外。
+    if (!isAbsolute(s.locator)) return { reachable: false };
     const abs = resolve(s.locator);
     if (!existsSync(abs)) return { reachable: false };
     const st = lstatSync(abs); // lstat:不跟随软链 —— 软链直接拒(防 evil.md → /dev/zero)
@@ -107,7 +111,11 @@ export function probeSourceState(record: ManagedArtifactRecord): SourceProbe {
       const hash = boundedDirSkillHash(abs); // 形态校验 + 成本边界(防任意目录递归读 / 目录 DoS)
       return hash === null ? { reachable: false } : { reachable: true, hash };
     }
-    if (!st.isFile() || st.size > MAX_FILE_SOURCE_BYTES) return { reachable: false }; // 非常规文件 / 超大 → 拒读
+    // 单文件-skill:恢复 install(resolveFileSource)的形态约束 —— 必须是 `.md` 常规文件、非硬链、≤ size cap。
+    // 否则攻击者可写 locator:`/etc/passwd` / `~/.ssh/id_rsa`(非 .md 直接拒),或用 `.md` 命名的**硬链**别名
+    // 树外敏感文件绕过扩展名 / 软链守卫(lstat 分不出硬链)→ 诱 list 把任意本地文件读进进程参与 hash。install
+    // 写出的是 nlink=1 的全新副本,拒 nlink>1 不误伤合法源。非 install 形态一律 reachable:false。
+    if (!/\.md$/i.test(abs) || !st.isFile() || st.nlink !== 1 || st.size > MAX_FILE_SOURCE_BYTES) return { reachable: false };
     return { reachable: true, hash: hashArtifactSource(abs, false) };
   } catch {
     return { reachable: false };

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -123,7 +123,7 @@ export function probeSourceState(record: ManagedArtifactRecord): SourceProbe {
 }
 
 /** CJK 全角字符按 2 列计宽,使含中文表头的列也能对齐。 */
-function dispWidth(s: string): number {
+export function dispWidth(s: string): number {
   let w = 0;
   for (const ch of s) w += /[ᄀ-ᅟ⺀-꓏가-힣豈-﫿︰-﹏＀-｠￠-￦]/.test(ch) ? 2 : 1;
   return w;
@@ -134,7 +134,7 @@ function pad(s: string, width: number): string {
 }
 
 /** 按**显示宽度**截断(不是 code unit):逐码点累加 dispWidth,绝不切断 surrogate 对、CJK 也不溢出列。 */
-function truncate(s: string, max: number): string {
+export function truncate(s: string, max: number): string {
   if (dispWidth(s) <= max) return s;
   let w = 0;
   let out = '';
@@ -148,19 +148,20 @@ function truncate(s: string, max: number): string {
 }
 
 /** 洗不可信显示字符:managed JSON 可随仓库分发,name / sourceLabel / verdict 等字段塞进表格前必须先洗,
- *  否则会破坏表格甚至伪造终端输出。一律映射到可见 U+FFFD(--json 路径保留原值给脚本):
- *    - C0(含 ESC / 换行 / 回车 / TAB)+ DEL + C1 → 杀 ANSI / OSC 转义与终端控制;
- *    - BiDi 控制 / 隔离(U+202A–202E / 2066–2069 / 200E–200F / 061C)→ 防 Trojan-Source 视觉重排伪造;
- *    - 零宽 / 不可见格式符(U+200B–200D / 2060–2064 / FEFF / 00AD)→ 防零宽隐藏 / 分割;
- *    - 组合附加符(U+0300–036F / 20D0–20FF / FE20–FE2F)→ 变可见,避免零前进宽度令 dispWidth 与终端列错位。 */
+ *  否则会破坏表格甚至伪造终端输出。一律映射到可见 U+FFFD(--json 路径保留原值给脚本)。
+ *  用 Unicode **属性类**而非手列码点 —— 手列清单天然有缺口(BiDi、U+2028 / 2029、Tags 块都曾漏一轮补一轮),
+ *  属性类一次覆盖整类、新码点自动纳入:
+ *    - `\p{Cc}` 控制符(C0 / C1 / DEL,含 ESC / 换行 / 回车 / TAB)→ 杀 ANSI / OSC 转义与终端控制;
+ *    - `\p{Cf}` 格式符(BiDi 重排 / 隔离、零宽、joiners、BOM、Tags、interlinear)→ 防 Trojan-Source 视觉伪造与零宽隐藏 / 分割;
+ *    - `\p{Zl}` / `\p{Zp}` 行 / 段分隔(U+2028 / 2029)→ LF 的 Unicode 孪生,防换行伪造表格行;
+ *    - `\p{Mn}` / `\p{Me}` 非间距 / 封闭组合附加符 → 变可见,避免零前进宽度令 dispWidth 与终端列错位
+ *      (间距组合符 `\p{Mc}` 合法占 1 列,保留);
+ *    - Hangul filler(U+115F / U+1160 / U+3164,属 Lo 不在上述任何类)→ 零宽显示诡计,补列。 */
 export function sanitizeCell(s: string): string {
-  return s.replace(
-    /[\u0000-\u001f\u007f-\u009f\u00ad\u0300-\u036f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u2064\u2066-\u2069\u20d0-\u20ff\ufe20-\ufe2f\ufeff]/g,
-    '\ufffd',
-  );
+  return s.replace(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}\p{Mn}\p{Me}ᅟᅠㅤ]/gu, '�');
 }
 
-function renderTable(rows: ManagedListRow[], lang: CliLang): string {
+export function renderTable(rows: ManagedListRow[], lang: CliLang): string {
   const headers = [
     tCli('cli.list.col_name', lang),
     tCli('cli.list.col_kind', lang),
@@ -170,7 +171,7 @@ function renderTable(rows: ManagedListRow[], lang: CliLang): string {
     tCli('cli.list.col_source', lang),
   ];
   const cells = rows.map((r) => [
-    sanitizeCell(r.name),
+    truncate(sanitizeCell(r.name), 40), // name 与 source 同为用户可控、可超长 → 同样按显示宽度截断,防撑爆表宽
     r.kind, // ArtifactKind 枚举(validator 已收窄),无需洗
     // 不可达 → 标「?」(drift 未核),绝不冒充 stale;reachable 且漂移才 stale ⚠️。
     !r.reachable ? `${r.state} ?` : r.state === 'stale' ? 'stale ⚠️' : r.state,
@@ -214,7 +215,9 @@ export default class List extends BaseCommand {
       const rows = buildManagedListRows(records, probeSourceState);
 
       if (flags.json) {
-        this.log(JSON.stringify(rows, null, 2));
+        // 版本化信封 —— 与 eval / doctor / diagnosis 等机读出口一致(都带 schemaVersion),让未来字段增删 /
+        // 改名是可检测的版本 bump,而非脚本静默 break。rows 的逐行形态见 ManagedListRow。
+        this.log(JSON.stringify({ schemaVersion: 1, rows }, null, 2));
         return;
       }
 
@@ -229,8 +232,12 @@ export default class List extends BaseCommand {
         : (lang === 'zh' ? '项目' : 'project');
       process.stderr.write(tCli('cli.list.header', lang, { scope, count: rows.length }));
       this.log(renderTable(rows, lang));
-      if (rows.some((r) => r.drifted)) process.stderr.write('\n' + tCli('cli.list.drift_note', lang));
-      if (rows.some((r) => !r.reachable)) process.stderr.write(tCli('cli.list.unreachable_note', lang));
+      // 注脚块前留一行空白(无论先触发哪条 note);空行挂在块上而非 drift 分支,避免只 unreachable 时丢分隔。
+      const hasDrift = rows.some((r) => r.drifted);
+      const hasUnreachable = rows.some((r) => !r.reachable);
+      if (hasDrift || hasUnreachable) process.stderr.write('\n');
+      if (hasDrift) process.stderr.write(tCli('cli.list.drift_note', lang));
+      if (hasUnreachable) process.stderr.write(tCli('cli.list.unreachable_note', lang));
       process.stderr.write(tCli('cli.list.legend', lang));
     });
   }

--- a/src/cli/lib/i18n-dict.ts
+++ b/src/cli/lib/i18n-dict.ts
@@ -57,6 +57,7 @@ import { genDict, type GenMessageKey } from './i18n-dict/gen.js';
 import { helpDict, type HelpMessageKey } from './i18n-dict/help.js';
 import { initDict, type InitMessageKey } from './i18n-dict/init.js';
 import { installDict, type InstallMessageKey } from './i18n-dict/install.js';
+import { listDict, type ListMessageKey } from './i18n-dict/list.js';
 import { runDict, type RunMessageKey } from './i18n-dict/run.js';
 import type { CliMessage } from './i18n-dict/types.js';
 
@@ -69,6 +70,7 @@ export type CliMessageKey =
   | HelpMessageKey
   | InitMessageKey
   | InstallMessageKey
+  | ListMessageKey
   | RunMessageKey;
 
 export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
@@ -78,5 +80,6 @@ export const CLI_DICT: Record<CliMessageKey, CliMessage> = {
   ...helpDict,
   ...initDict,
   ...installDict,
+  ...listDict,
   ...runDict,
 };

--- a/src/cli/lib/i18n-dict/list.ts
+++ b/src/cli/lib/i18n-dict/list.ts
@@ -1,0 +1,43 @@
+import type { CliMessage } from './types.js';
+
+export type ListMessageKey =
+  | 'cli.list.header'
+  | 'cli.list.empty'
+  | 'cli.list.empty_hint'
+  | 'cli.list.col_name'
+  | 'cli.list.col_kind'
+  | 'cli.list.col_state'
+  | 'cli.list.col_verdict'
+  | 'cli.list.col_evidence'
+  | 'cli.list.col_source'
+  | 'cli.list.drift_note'
+  | 'cli.list.legend';
+
+export const listDict: Record<ListMessageKey, CliMessage> = {
+  'cli.list.header': {
+    zh: '受管 skill（{scope}，{count} 条）\n',
+    en: 'Managed skills ({scope}, {count})\n',
+  },
+  'cli.list.empty': {
+    zh: '没有受管记录。\n',
+    en: 'No managed records.\n',
+  },
+  'cli.list.empty_hint': {
+    zh: '用 omk install <skill> 登记并分发一个 skill 后，它会出现在这里。\n',
+    en: 'Run omk install <skill> to register and distribute a skill; it will show up here.\n',
+  },
+  'cli.list.col_name': { zh: '名称', en: 'NAME' },
+  'cli.list.col_kind': { zh: '类型', en: 'KIND' },
+  'cli.list.col_state': { zh: '状态', en: 'STATE' },
+  'cli.list.col_verdict': { zh: 'VERDICT', en: 'VERDICT' },
+  'cli.list.col_evidence': { zh: '证据', en: 'EVIDENCE' },
+  'cli.list.col_source': { zh: '源', en: 'SOURCE' },
+  'cli.list.drift_note': {
+    zh: '⚠️ = 源内容已漂移、脱离证据（stale）；重跑 omk eval 重新取证。\n',
+    en: '⚠️ = source content drifted off its evidence (stale); re-run omk eval to re-measure.\n',
+  },
+  'cli.list.legend': {
+    zh: '证据列 = 当前有效 / 全部（历史含旧内容证据，供回滚）。\n',
+    en: 'EVIDENCE column = current / total (history keeps old-content evidence for rollback).\n',
+  },
+};

--- a/src/cli/lib/i18n-dict/list.ts
+++ b/src/cli/lib/i18n-dict/list.ts
@@ -11,6 +11,7 @@ export type ListMessageKey =
   | 'cli.list.col_evidence'
   | 'cli.list.col_source'
   | 'cli.list.drift_note'
+  | 'cli.list.unreachable_note'
   | 'cli.list.legend';
 
 export const listDict: Record<ListMessageKey, CliMessage> = {
@@ -35,6 +36,10 @@ export const listDict: Record<ListMessageKey, CliMessage> = {
   'cli.list.drift_note': {
     zh: '⚠️ = 源内容已漂移、脱离证据（stale）；重跑 omk eval 重新取证。\n',
     en: '⚠️ = source content drifted off its evidence (stale); re-run omk eval to re-measure.\n',
+  },
+  'cli.list.unreachable_note': {
+    zh: '? = 源此处不可达 / 拒读，drift 未核（非 stale）；本地 git 源请在原仓库根目录跑 omk list。\n',
+    en: '? = source unreachable / refused here, drift unchecked (not stale); for a local git source run omk list from the original repo root.\n',
   },
   'cli.list.legend': {
     zh: '证据列 = 当前有效 / 全部（历史含旧内容证据，供回滚）。\n',

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -52,7 +52,10 @@ const GIT_PROBE_STDIO: ['ignore', 'pipe', 'ignore'] = ['ignore', 'pipe', 'ignore
 // 由 resolveGitRepoContext 解出 repoRoot 后逐处显式传入。
 export function gitShowFile(ref: string, filePath: string, cwd: string = process.cwd()): string | null {
   try {
-    return execFileSync('git', ['cat-file', 'blob', `${ref}:${filePath}`], { cwd, encoding: 'utf-8', stdio: GIT_PROBE_STDIO }).trim();
+    // `--` 隔断 tree-ish:ref 可能来自盘上受管记录的 locator(用户可手改 / 随仓库分发,被 omk list 等只读
+    // 命令喂进来),前缀 `-` 的 ref 不得被当成 git 选项解析(与 #219 fetch 路径同口径,见
+    // feedback_git_subprocess_dashdash)。加 `--` 后 dash-ref 退化为「非法 object name」fail-closed,普通 ref 输出不变。
+    return execFileSync('git', ['cat-file', 'blob', '--', `${ref}:${filePath}`], { cwd, encoding: 'utf-8', stdio: GIT_PROBE_STDIO }).trim();
   } catch {
     return null;
   }
@@ -64,7 +67,7 @@ export function gitShowFile(ref: string, filePath: string, cwd: string = process
  */
 export function gitShowBytes(ref: string, filePath: string, cwd: string = process.cwd()): Buffer | null {
   try {
-    return execFileSync('git', ['cat-file', 'blob', `${ref}:${filePath}`], { cwd, stdio: GIT_PROBE_STDIO }); // 无 encoding → Buffer
+    return execFileSync('git', ['cat-file', 'blob', '--', `${ref}:${filePath}`], { cwd, stdio: GIT_PROBE_STDIO }); // 无 encoding → Buffer;`--` 隔断同 gitShowFile
   } catch {
     return null;
   }
@@ -87,7 +90,7 @@ export interface GitTreeEntry {
 export function gitLsTreeBlobs(ref: string, treePath: string, cwd: string = process.cwd()): GitTreeEntry[] {
   let out: string;
   try {
-    out = execFileSync('git', ['ls-tree', '-r', '-z', '--full-tree', `${ref}:${treePath}`], { cwd, encoding: 'utf-8', stdio: GIT_PROBE_STDIO });
+    out = execFileSync('git', ['ls-tree', '-r', '-z', '--full-tree', '--', `${ref}:${treePath}`], { cwd, encoding: 'utf-8', stdio: GIT_PROBE_STDIO });
   } catch {
     return [];
   }

--- a/src/managed/index.ts
+++ b/src/managed/index.ts
@@ -4,3 +4,4 @@
  */
 export * from './store.js';
 export * from './evidence.js';
+export * from './list-view.js';

--- a/src/managed/list-view.ts
+++ b/src/managed/list-view.ts
@@ -1,0 +1,75 @@
+/**
+ * `omk list` 的纯视图构造(#203 管理支柱)—— 把受管记录摊成可渲染的行,不做任何 IO。
+ *
+ * 「当前源内容哈」由调用方注入(`currentHashOf`):CLI 侧重物化真源算哈,单测侧给 mock —— 保持本模块
+ * 纯函数、可测。生命周期 state 走 `deriveManagedState`(源缺失 / 漂移 → stale;有当前证据 → measurable;
+ * 否则 installed)。verdict / 可比性取**当前有效证据**(contentHash == record.contentHash)里 recordedAt
+ * 最新那条 —— 旧内容的证据不冒充当前(与 deriveManagedState 同口径)。
+ */
+import type { ArtifactKind, ManagedArtifactRecord, ManagedLifecycleLabel } from '../types/index.js';
+import { deriveManagedState } from './store.js';
+
+export interface ManagedListRow {
+  id: string;
+  name: string;
+  /** artifact 类型,直取自记录(裸 kind 留给 ArtifactKind,见 terminology-spec §5.4)。 */
+  kind: ArtifactKind;
+  sourceKind: 'file' | 'git';
+  /** 展示用源标识:远端 git 优先 url、否则 locator。 */
+  sourceLabel: string;
+  state: ManagedLifecycleLabel;
+  drifted: boolean;
+  /** 当前有效证据(若有)里 recordedAt 最新那条的 verdict。 */
+  latestVerdict?: string;
+  /** 该证据的可比性 marker —— 跨报告比 verdict 前需一致。 */
+  comparability?: { cliVersion: string; judgePromptHash?: string; debiasMode?: Array<'length' | 'position'> };
+  /** 最新当前证据的记录时间。 */
+  recordedAt?: string;
+  /** 当前有效证据数 / 全部证据数(含旧内容的历史证据)。 */
+  currentEvidenceCount: number;
+  totalEvidenceCount: number;
+  distributionCount: number;
+}
+
+function latestCurrentEvidence(record: ManagedArtifactRecord) {
+  const current = record.evidence.filter((e) => e.contentHash === record.contentHash);
+  if (current.length === 0) return undefined;
+  // recordedAt 是 ISO 串,字典序即时间序;并列取后出现的。
+  return current.reduce((a, b) => (b.recordedAt >= a.recordedAt ? b : a));
+}
+
+export function buildManagedListRow(
+  record: ManagedArtifactRecord,
+  currentContentHash: string | undefined,
+): ManagedListRow {
+  const state = deriveManagedState({ record, currentContentHash });
+  const latest = latestCurrentEvidence(record);
+  return {
+    id: record.id,
+    name: record.name,
+    kind: record.kind,
+    sourceKind: record.source.sourceKind,
+    sourceLabel: record.source.url ?? record.source.locator,
+    state: state.label,
+    drifted: state.drifted,
+    ...(latest?.verdict ? { latestVerdict: latest.verdict } : {}),
+    ...(latest?.comparability ? { comparability: latest.comparability } : {}),
+    ...(latest?.recordedAt ? { recordedAt: latest.recordedAt } : {}),
+    currentEvidenceCount: record.evidence.filter((e) => e.contentHash === record.contentHash).length,
+    totalEvidenceCount: record.evidence.length,
+    distributionCount: record.distribution.length,
+  };
+}
+
+/**
+ * 组装全部行。`currentHashOf` 给每条记录算当前源内容哈(undefined = 源已不在 → stale)。
+ * 按 name 排序(稳定、可读);同名再按 kind。
+ */
+export function buildManagedListRows(
+  records: ManagedArtifactRecord[],
+  currentHashOf: (record: ManagedArtifactRecord) => string | undefined,
+): ManagedListRow[] {
+  return records
+    .map((r) => buildManagedListRow(r, currentHashOf(r)))
+    .sort((a, b) => (a.name === b.name ? a.kind.localeCompare(b.kind) : a.name.localeCompare(b.name)));
+}

--- a/src/managed/list-view.ts
+++ b/src/managed/list-view.ts
@@ -1,13 +1,22 @@
 /**
  * `omk list` 的纯视图构造(#203 管理支柱)—— 把受管记录摊成可渲染的行,不做任何 IO。
  *
- * 「当前源内容哈」由调用方注入(`currentHashOf`):CLI 侧重物化真源算哈,单测侧给 mock —— 保持本模块
- * 纯函数、可测。生命周期 state 走 `deriveManagedState`(源缺失 / 漂移 → stale;有当前证据 → measurable;
- * 否则 installed)。verdict / 可比性取**当前有效证据**(contentHash == record.contentHash)里 recordedAt
- * 最新那条 —— 旧内容的证据不冒充当前(与 deriveManagedState 同口径)。
+ * 「当前源探测」由调用方注入(`probeOf`):CLI 侧重物化真源算哈,单测侧给 mock —— 保持本模块纯函数、
+ * 可测。探测是**三态**:`reachable:true + hash`(算出了当前哈,可判 drift)/ `reachable:false`(源不可达 /
+ * 解析失败 / 拒绝读取)。**不可达 ≠ 已 drift** —— 把「这里查不了」当「内容变了」会对从别处看的本地 git 记录
+ * 误报 stale(locator 随 cwd 漂),所以不可达时只按证据给 installed/measurable、不打 drift、单独标「未核」。
+ * reachable 时才走 `deriveManagedState`(哈不等 → stale)。verdict / 可比性取**当前有效证据**
+ * (contentHash == record.contentHash)里 recordedAt 最新那条 —— 旧内容的证据不冒充当前。
  */
 import type { ArtifactKind, ManagedArtifactRecord, ManagedLifecycleLabel } from '../types/index.js';
 import { deriveManagedState } from './store.js';
+
+/** 当前源探测结果(三态)。`reachable:false` = 不可达 / 解析失败 / 拒读,**不等于**已 drift。 */
+export interface SourceProbe {
+  reachable: boolean;
+  /** 当前源整树 / 单文件哈;仅 reachable 时有。 */
+  hash?: string;
+}
 
 export interface ManagedListRow {
   id: string;
@@ -19,6 +28,8 @@ export interface ManagedListRow {
   sourceLabel: string;
   state: ManagedLifecycleLabel;
   drifted: boolean;
+  /** 当前源是否被成功核对过 hash。false = 不可达/拒读 → drift 未核(不据此判 stale)。 */
+  reachable: boolean;
   /** 当前有效证据(若有)里 recordedAt 最新那条的 verdict。 */
   latestVerdict?: string;
   /** 该证据的可比性 marker —— 跨报告比 verdict 前需一致。 */
@@ -38,11 +49,20 @@ function latestCurrentEvidence(record: ManagedArtifactRecord) {
   return current.reduce((a, b) => (b.recordedAt >= a.recordedAt ? b : a));
 }
 
-export function buildManagedListRow(
-  record: ManagedArtifactRecord,
-  currentContentHash: string | undefined,
-): ManagedListRow {
-  const state = deriveManagedState({ record, currentContentHash });
+export function buildManagedListRow(record: ManagedArtifactRecord, probe: SourceProbe): ManagedListRow {
+  const currentEvidenceCount = record.evidence.filter((e) => e.contentHash === record.contentHash).length;
+  let state: ManagedLifecycleLabel;
+  let drifted: boolean;
+  if (probe.reachable) {
+    // 算出了当前哈:正常推导(哈不等 → stale/drift)。
+    const d = deriveManagedState({ record, currentContentHash: probe.hash });
+    state = d.label;
+    drifted = d.drifted;
+  } else {
+    // 不可达:不据此判 stale —— 只按证据给 installed/measurable,drift 标未核。
+    state = currentEvidenceCount > 0 ? 'measurable' : 'installed';
+    drifted = false;
+  }
   const latest = latestCurrentEvidence(record);
   return {
     id: record.id,
@@ -50,26 +70,27 @@ export function buildManagedListRow(
     kind: record.kind,
     sourceKind: record.source.sourceKind,
     sourceLabel: record.source.url ?? record.source.locator,
-    state: state.label,
-    drifted: state.drifted,
+    state,
+    drifted,
+    reachable: probe.reachable,
     ...(latest?.verdict ? { latestVerdict: latest.verdict } : {}),
     ...(latest?.comparability ? { comparability: latest.comparability } : {}),
     ...(latest?.recordedAt ? { recordedAt: latest.recordedAt } : {}),
-    currentEvidenceCount: record.evidence.filter((e) => e.contentHash === record.contentHash).length,
+    currentEvidenceCount,
     totalEvidenceCount: record.evidence.length,
     distributionCount: record.distribution.length,
   };
 }
 
 /**
- * 组装全部行。`currentHashOf` 给每条记录算当前源内容哈(undefined = 源已不在 → stale)。
+ * 组装全部行。`probeOf` 给每条记录探测当前源(三态,见文件头)。
  * 按 name 排序(稳定、可读);同名再按 kind。
  */
 export function buildManagedListRows(
   records: ManagedArtifactRecord[],
-  currentHashOf: (record: ManagedArtifactRecord) => string | undefined,
+  probeOf: (record: ManagedArtifactRecord) => SourceProbe,
 ): ManagedListRow[] {
   return records
-    .map((r) => buildManagedListRow(r, currentHashOf(r)))
+    .map((r) => buildManagedListRow(r, probeOf(r)))
     .sort((a, b) => (a.name === b.name ? a.kind.localeCompare(b.kind) : a.name.localeCompare(b.name)));
 }

--- a/src/managed/list-view.ts
+++ b/src/managed/list-view.ts
@@ -24,7 +24,8 @@ export interface ManagedListRow {
   /** artifact 类型,直取自记录(裸 kind 留给 ArtifactKind,见 terminology-spec §5.4)。 */
   kind: ArtifactKind;
   sourceKind: 'file' | 'git';
-  /** 展示用源标识:远端 git 优先 url、否则 locator。 */
+  /** 展示用源标识:仅远端 git(sourceKind==='git' 且带 url)显 url,其余一律显 locator —— 保证「显示的」
+   *  就是「被 probe / 读取的」路径,file 源即便混入 url(validator 已拒)也不显示它。 */
   sourceLabel: string;
   state: ManagedLifecycleLabel;
   drifted: boolean;
@@ -69,7 +70,7 @@ export function buildManagedListRow(record: ManagedArtifactRecord, probe: Source
     name: record.name,
     kind: record.kind,
     sourceKind: record.source.sourceKind,
-    sourceLabel: record.source.url ?? record.source.locator,
+    sourceLabel: record.source.sourceKind === 'git' && record.source.url ? record.source.url : record.source.locator,
     state,
     drifted,
     reachable: probe.reachable,

--- a/src/managed/list-view.ts
+++ b/src/managed/list-view.ts
@@ -46,8 +46,15 @@ export interface ManagedListRow {
 function latestCurrentEvidence(record: ManagedArtifactRecord) {
   const current = record.evidence.filter((e) => e.contentHash === record.contentHash);
   if (current.length === 0) return undefined;
-  // recordedAt 是 ISO 串,字典序即时间序;并列取后出现的。
-  return current.reduce((a, b) => (b.recordedAt >= a.recordedAt ? b : a));
+  // 取 recordedAt 最新的一条。omk 自写恒 UTC `Z`、字典序即时间序;但记录可手改 / 随仓库分发,异偏移
+  // 或异精度的 ISO 串字典序会乱 → 优先按解析后的真实时刻比,两端都可解析才用;否则退回字典序(不劣化
+  // omk 自写场景)。并列取后出现的。
+  const ms = (s: string): number | null => { const n = Date.parse(s); return Number.isNaN(n) ? null : n; };
+  return current.reduce((a, b) => {
+    const ta = ms(a.recordedAt); const tb = ms(b.recordedAt);
+    if (ta !== null && tb !== null) return tb >= ta ? b : a;
+    return b.recordedAt >= a.recordedAt ? b : a;
+  });
 }
 
 export function buildManagedListRow(record: ManagedArtifactRecord, probe: SourceProbe): ManagedListRow {
@@ -85,7 +92,11 @@ export function buildManagedListRow(record: ManagedArtifactRecord, probe: Source
 
 /**
  * 组装全部行。`probeOf` 给每条记录探测当前源(三态,见文件头)。
- * 按 name 排序(稳定、可读);同名再按 kind。
+ * 按 name 排序(稳定、可读);name collation 相等再按 kind。排序对机读出口(--json)也生效,故:
+ *   - **钉死 locale**(`'en'`):缺省 locale 随宿主 LANG / LC_COLLATE 漂,会让两台机器对同一批记录排出不同
+ *     JSON 顺序,破坏 omk「确定、可比」的底色。
+ *   - 平级判定用**同一 collation 度量**(localeCompare 结果是否为 0)而非 `===`:NFC / NFD 等价的同显示名
+ *     在 `===` 下不等、却 collation 相等,用 `===` 会漏掉 kind 平级 tiebreak、令顺序退回 readdir 序(不定)。
  */
 export function buildManagedListRows(
   records: ManagedArtifactRecord[],
@@ -93,5 +104,8 @@ export function buildManagedListRows(
 ): ManagedListRow[] {
   return records
     .map((r) => buildManagedListRow(r, probeOf(r)))
-    .sort((a, b) => (a.name === b.name ? a.kind.localeCompare(b.kind) : a.name.localeCompare(b.name)));
+    .sort((a, b) => {
+      const byName = a.name.localeCompare(b.name, 'en');
+      return byName !== 0 ? byName : a.kind.localeCompare(b.kind, 'en');
+    });
 }

--- a/src/managed/store.ts
+++ b/src/managed/store.ts
@@ -48,9 +48,18 @@ function isStringField(v: unknown): v is string {
   return typeof v === 'string';
 }
 
-// 校验到元素级:记录文件是用户可手改的(透明性是设计价值),`evidence:[null]` / 缺字段的 distribution
-// 都是现实的坏手改;若只查 Array.isArray,坏元素会在 deriveManagedState / mergeManagedRecord 里
-// 解引用崩溃(且在 load 的 try/catch 之外)。这里直接判脏 → load 丢弃该文件,消费方永远拿不到半成品。
+/** 仅当字段缺省或是 string 才放行(可选 string 字段的脏值守卫,如 source.url / evidence.verdict)。 */
+function isOptionalString(v: unknown): boolean {
+  return v === undefined || typeof v === 'string';
+}
+
+// 受管记录可安装的 kind(managed 记录绝不是 baseline)。
+const MANAGED_KINDS = new Set(['skill', 'prompt', 'agent', 'workflow']);
+
+// 校验到**运行时实际收窄**的边界,不止「字段是 string」:记录文件是用户可手改、且可能随仓库分发(被
+// loadAllManagedRecords 无 opt-in 读到)的不可信输入。若只查 string,畸形记录(如 source.url 是对象、
+// sourceKind 是任意串)会绕过 validator,在下游(omk list 的 sourceLabel ?? → dispWidth(对象) 等)
+// 抛 TypeError 让命令崩溃。这里把 source / evidence 收窄到 list 等消费方实际解引用的类型,判脏即丢弃该文件。
 function isManagedArtifactRecord(value: unknown): value is ManagedArtifactRecord {
   if (!value || typeof value !== 'object') return false;
   const r = value as Partial<ManagedArtifactRecord>;
@@ -58,18 +67,32 @@ function isManagedArtifactRecord(value: unknown): value is ManagedArtifactRecord
     && r.schemaVersion === 2
     && isStringField(r.id)
     && isStringField(r.name)
-    && isStringField(r.kind)
+    && isStringField(r.kind) && MANAGED_KINDS.has(r.kind)
     && isStringField(r.contentHash)
     && r.source && typeof r.source === 'object'
-    && isStringField((r.source as { locator?: unknown }).locator)
-    && isStringField((r.source as { sourceKind?: unknown }).sourceKind)
     && Array.isArray(r.distribution)
     && Array.isArray(r.evidence)
     && Array.isArray(r.decisions))) return false;
+  const src = r.source as unknown as Record<string, unknown>;
+  if (!(isStringField(src.locator)
+    && (src.sourceKind === 'file' || src.sourceKind === 'git')
+    && typeof src.isDirectorySkill === 'boolean'
+    && isOptionalString(src.url)
+    && isOptionalString(src.ref))) return false;
   const okDist = r.distribution.every((d) => d && typeof d === 'object'
     && isStringField((d as { path?: unknown }).path) && isStringField((d as { contentHash?: unknown }).contentHash));
-  const okEv = r.evidence.every((e) => e && typeof e === 'object'
-    && isStringField((e as { reportId?: unknown }).reportId) && isStringField((e as { contentHash?: unknown }).contentHash));
+  const okEv = r.evidence.every((e) => {
+    if (!e || typeof e !== 'object') return false;
+    const ev = e as unknown as Record<string, unknown>;
+    if (!(isStringField(ev.reportId) && isStringField(ev.contentHash) && isStringField(ev.recordedAt))) return false;
+    if (!isOptionalString(ev.verdict)) return false;
+    // comparability 若存在:必须是带 string cliVersion 的对象(list / promote 会读它)。
+    if (ev.comparability !== undefined) {
+      const c = ev.comparability as Record<string, unknown>;
+      if (!c || typeof c !== 'object' || !isStringField(c.cliVersion)) return false;
+    }
+    return true;
+  });
   const okDec = r.decisions.every((d) => d && typeof d === 'object'
     && isStringField((d as { decisionKind?: unknown }).decisionKind));
   return okDist && okEv && okDec;

--- a/src/managed/store.ts
+++ b/src/managed/store.ts
@@ -79,6 +79,9 @@ function isManagedArtifactRecord(value: unknown): value is ManagedArtifactRecord
     && typeof src.isDirectorySkill === 'boolean'
     && isOptionalString(src.url)
     && isOptionalString(src.ref))) return false;
+  // url / ref 是 git-only 字段。file 源带 url 时,list 的 sourceLabel 会显示假 url、掩盖真实被 probe /
+  // 读取的 locator(畸形但可通过上面 string 校验)→ 「读了什么」与「显示什么」不一致。判脏丢弃。
+  if (src.sourceKind === 'file' && (src.url !== undefined || src.ref !== undefined)) return false;
   const okDist = r.distribution.every((d) => d && typeof d === 'object'
     && isStringField((d as { path?: unknown }).path) && isStringField((d as { contentHash?: unknown }).contentHash));
   const okEv = r.evidence.every((e) => {
@@ -86,10 +89,15 @@ function isManagedArtifactRecord(value: unknown): value is ManagedArtifactRecord
     const ev = e as unknown as Record<string, unknown>;
     if (!(isStringField(ev.reportId) && isStringField(ev.contentHash) && isStringField(ev.recordedAt))) return false;
     if (!isOptionalString(ev.verdict)) return false;
-    // comparability 若存在:必须是带 string cliVersion 的对象(list / promote 会读它)。
+    // comparability 若存在:必须是带 string cliVersion 的对象(list / promote 会读它)。可选 marker
+    // judgePromptHash / debiasMode 同样收窄到声明类型 —— 否则任意类型脏值会穿过 validator 原样进 `omk list
+    // --json`(及未来 promote gate)消费方。
     if (ev.comparability !== undefined) {
       const c = ev.comparability as Record<string, unknown>;
       if (!c || typeof c !== 'object' || !isStringField(c.cliVersion)) return false;
+      if (!isOptionalString(c.judgePromptHash)) return false;
+      if (c.debiasMode !== undefined
+        && !(Array.isArray(c.debiasMode) && c.debiasMode.every((m) => m === 'length' || m === 'position'))) return false;
     }
     return true;
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -314,7 +314,7 @@ describe('CLI', () => {
 
   it('Claude Code SKILL manifest uses current product commands', async () => {
     const body = await readFile(join(PROJECT_ROOT, '.agents', 'skills', 'omk', 'SKILL.md'), 'utf8');
-    assert.ok(body.includes('argument-hint: "<doctor|eval|evolve|init|install|observe|sample|studio> [options]"'));
+    assert.ok(body.includes('argument-hint: "<doctor|eval|evolve|init|install|list|observe|sample|studio> [options]"'));
     assert.ok(body.includes('omk eval --batch'));
     assert.ok(body.includes('omk sample --batch'));
     assert.ok(body.includes('omk evolve'));

--- a/test/cli/list-probe.test.ts
+++ b/test/cli/list-probe.test.ts
@@ -1,0 +1,99 @@
+/**
+ * probeSourceState(omk list 的当前源探测)安全/正确性回归。重点锁住 CR 发现的两条:
+ *   - 只读命令绝不盲读攻击者可控 locator:软链 / 非常规文件(/dev/zero)→ reachable:false,不触发
+ *     hashArtifactSource 的无界 readFileSync(DoS 守卫);
+ *   - 远端 git 源 SHA-pin 短路、不联网;
+ *   - 正常本地源算出哈、reachable:true。
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { probeSourceState, sanitizeCell } from '../../src/cli/commands/list.js';
+import { hashArtifactSource } from '../../src/managed/index.js';
+import type { ManagedArtifactRecord, ManagedArtifactSource } from '../../src/types/index.js';
+
+function record(source: ManagedArtifactSource, contentHash = 'pinnedHash00'): ManagedArtifactRecord {
+  return {
+    recordKind: 'managed-artifact', schemaVersion: 2, id: 'id', name: 'x', kind: 'skill',
+    source, contentHash, installedAt: '2026-06-06T00:00:00.000Z', distribution: [], evidence: [], decisions: [],
+  };
+}
+
+describe('probeSourceState', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'omk-probe-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('本地目录-skill:reachable + 哈与 hashArtifactSource 一致', () => {
+    const sk = join(dir, 'review'); mkdirSync(join(sk, 'references'), { recursive: true });
+    writeFileSync(join(sk, 'SKILL.md'), '# review\n'); writeFileSync(join(sk, 'references', 'r.md'), 'v1\n');
+    const p = probeSourceState(record({ sourceKind: 'file', locator: sk, isDirectorySkill: true }));
+    assert.equal(p.reachable, true);
+    assert.equal(p.hash, hashArtifactSource(sk, true));
+  });
+
+  it('本地单文件-skill:reachable + 哈一致', () => {
+    const md = join(dir, 'note.md'); writeFileSync(md, 'body\n');
+    const p = probeSourceState(record({ sourceKind: 'file', locator: md, isDirectorySkill: false }));
+    assert.equal(p.reachable, true);
+    assert.equal(p.hash, hashArtifactSource(md, false));
+  });
+
+  it('安全:locator 是软链 → reachable:false,绝不读(防 evil.md → /dev/zero 无界 readFileSync DoS)', () => {
+    const link = join(dir, 'evil.md');
+    symlinkSync('/dev/zero', link); // 若无守卫,hashArtifactSource 会 readFileSync(/dev/zero) 卡死/OOM
+    const p = probeSourceState(record({ sourceKind: 'file', locator: link, isDirectorySkill: false }));
+    assert.equal(p.reachable, false, '软链被 lstat 拦下、不跟随');
+    assert.equal(p.hash, undefined);
+  });
+
+  it('安全:locator 指向非常规文件(字符设备)→ reachable:false', () => {
+    // 直接把 locator 指到 /dev/zero(非软链路径):lstat 判非常规文件 → 拒读。
+    const p = probeSourceState(record({ sourceKind: 'file', locator: '/dev/zero', isDirectorySkill: false }));
+    assert.equal(p.reachable, false);
+  });
+
+  it('源不存在 → reachable:false(未核,不冒充 stale)', () => {
+    const p = probeSourceState(record({ sourceKind: 'file', locator: join(dir, 'gone.md'), isDirectorySkill: false }));
+    assert.equal(p.reachable, false);
+  });
+
+  it('远端 git(带 url):SHA-pin 短路,reachable + hash = record.contentHash,不联网', () => {
+    const p = probeSourceState(record(
+      { sourceKind: 'git', locator: 'git+https://x/r.git@sha1:review', ref: 'sha1', url: 'https://x/r.git', isDirectorySkill: true },
+      'pinnedHash00',
+    ));
+    assert.equal(p.reachable, true);
+    assert.equal(p.hash, 'pinnedHash00');
+  });
+
+  it('安全:目录源指向无 SKILL.md 的任意目录 → reachable:false(不递归读整棵树)', () => {
+    const any = join(dir, 'arbitrary'); mkdirSync(join(any, 'sub'), { recursive: true });
+    writeFileSync(join(any, 'data.md'), 'x\n'); writeFileSync(join(any, 'sub', 'more.md'), 'y\n');
+    const p = probeSourceState(record({ sourceKind: 'file', locator: any, isDirectorySkill: true }));
+    assert.equal(p.reachable, false, '无 SKILL.md → 非 skill 目录 → 拒(防任意目录递归读)');
+  });
+
+  it('安全:目录源的 SKILL.md 是软链 → reachable:false', () => {
+    const sk = join(dir, 'sneaky'); mkdirSync(sk, { recursive: true });
+    symlinkSync('/dev/zero', join(sk, 'SKILL.md'));
+    const p = probeSourceState(record({ sourceKind: 'file', locator: sk, isDirectorySkill: true }));
+    assert.equal(p.reachable, false, 'SKILL.md 软链被拒');
+  });
+});
+
+describe('sanitizeCell', () => {
+  it('洗掉 ANSI/OSC 转义 + 换行 / 回车 / TAB / DEL / C1(防终端输出伪造)', () => {
+    const evil = '\x1b[31mred\x1b[0m' + 'a\nb\r c\td' + '\x07\x7f' + '\x9b' + 'tail';
+    const out = sanitizeCell(evil);
+    assert.ok(!/[\u0000-\u001f\u007f-\u009f]/.test(out), '输出不含任何 C0 / DEL / C1 控制字符');
+    assert.ok(out.includes('red') && out.includes('tail'), '可见正文保留');
+  });
+
+  it('普通字符串原样', () => {
+    assert.equal(sanitizeCell('./skills/review'), './skills/review');
+    assert.equal(sanitizeCell('git:HEAD:skills/审查'), 'git:HEAD:skills/审查');
+  });
+});

--- a/test/cli/list-probe.test.ts
+++ b/test/cli/list-probe.test.ts
@@ -7,7 +7,8 @@
  */
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, linkSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, linkSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { probeSourceState, sanitizeCell } from '../../src/cli/commands/list.js';
@@ -131,8 +132,52 @@ describe('sanitizeCell', () => {
     assert.ok(out.includes('PASS') && out.includes('hidde') && out.includes('n'), '可见正文保留');
   });
 
+  it('洗掉行 / 段分隔(U+2028 / 2029)+ Tags 块 + Hangul filler + interlinear（属性类一次覆盖整类,堵 LF 的 Unicode 孪生与隐藏诡计）', () => {
+    const evil = 'PASS forged row\u{e0041}tagㅤfill￹anno';
+    const out = sanitizeCell(evil);
+    for (const cp of [' ', ' ', '\u{e0041}', 'ㅤ', '￹']) {
+      assert.ok(!out.includes(cp), 'invisible/separator char stripped: U+' + cp.codePointAt(0)!.toString(16));
+    }
+    assert.ok(out.includes('PASS') && out.includes('forged') && out.includes('row'), '可见正文保留');
+  });
+
+  it('保留合法的间距组合符（\\p{Mc}，如 Devanagari 元音符号占 1 列）', () => {
+    assert.equal(sanitizeCell('काb'), 'काb', '间距组合符占 1 列、不该被洗');
+  });
+
   it('普通字符串原样(含 CJK / 路径)', () => {
     assert.equal(sanitizeCell('./skills/review'), './skills/review');
     assert.equal(sanitizeCell('git:HEAD:skills/审查'), 'git:HEAD:skills/审查');
+  });
+});
+
+describe('probeSourceState 本地 git 分支（resolveInstallSource，之前零覆盖）', () => {
+  let repo: string;
+  let prevCwd: string;
+  beforeEach(() => {
+    repo = realpathSync(mkdtempSync(join(tmpdir(), 'omk-probe-git-')));
+    const g = (args: string[]): void => { execFileSync('git', args, { cwd: repo, stdio: 'pipe' }); };
+    g(['init', '-q']); g(['config', 'user.email', 't@t']); g(['config', 'user.name', 't']);
+    mkdirSync(join(repo, 'skills', 'review', 'references'), { recursive: true });
+    writeFileSync(join(repo, 'skills', 'review', 'SKILL.md'), '# review\n');
+    writeFileSync(join(repo, 'skills', 'review', 'references', 'r.md'), 'asset\n');
+    g(['add', '-A']); g(['commit', '-q', '-m', 'init']);
+    prevCwd = process.cwd();
+    process.chdir(repo); // resolveInstallSource 的 git 上下文取自 cwd
+  });
+  afterEach(() => { process.chdir(prevCwd); rmSync(repo, { recursive: true, force: true }); });
+
+  it('cwd 在原仓库:本地 git locator 重物化重哈 → reachable + 整树哈与 hashArtifactSource 一致', () => {
+    const rec = record({ sourceKind: 'git', locator: 'git:HEAD:skills/review', ref: 'HEAD', isDirectorySkill: true });
+    const p = probeSourceState(rec);
+    assert.equal(p.reachable, true);
+    assert.ok(typeof p.hash === 'string' && p.hash.length > 0, '算出当前整树哈');
+  });
+
+  it('spec 解析不到（如 cwd 漂走 / 名字不存在）→ reachable:false（未核,不抛、不冒充 stale）', () => {
+    const rec = record({ sourceKind: 'git', locator: 'git:HEAD:skills/nope', ref: 'HEAD', isDirectorySkill: true });
+    const p = probeSourceState(rec);
+    assert.equal(p.reachable, false);
+    assert.equal(p.hash, undefined);
   });
 });

--- a/test/cli/list-probe.test.ts
+++ b/test/cli/list-probe.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, linkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { probeSourceState, sanitizeCell } from '../../src/cli/commands/list.js';
@@ -53,6 +53,35 @@ describe('probeSourceState', () => {
     // 直接把 locator 指到 /dev/zero(非软链路径):lstat 判非常规文件 → 拒读。
     const p = probeSourceState(record({ sourceKind: 'file', locator: '/dev/zero', isDirectorySkill: false }));
     assert.equal(p.reachable, false);
+  });
+
+  it('安全:单文件源 locator 非 .md(任意小 regular file,如 /etc/passwd / id_rsa)→ reachable:false', () => {
+    const secret = join(dir, 'id_rsa'); writeFileSync(secret, 'PRIVATE KEY\n'); // 常规文件但非 .md
+    const p = probeSourceState(record({ sourceKind: 'file', locator: secret, isDirectorySkill: false }));
+    assert.equal(p.reachable, false, '非 .md 形态被拒,不把任意本地文件读进进程参与 hash');
+    assert.equal(p.hash, undefined);
+  });
+
+  it('安全:单文件源 locator 是相对路径(非 install 写出形态)→ reachable:false', () => {
+    const p = probeSourceState(record({ sourceKind: 'file', locator: 'relative/note.md', isDirectorySkill: false }));
+    assert.equal(p.reachable, false, '相对 locator 非 install 产物,拒(不按 cwd 解析到项目外)');
+  });
+
+  it('安全:单文件源是 .md 命名、指向非 .md 敏感文件的硬链 → reachable:false(nlink>1 拒,堵硬链别名读)', () => {
+    const secret = join(dir, 'secret.txt'); writeFileSync(secret, 'PRIVATE\n');
+    const alias = join(dir, 'alias.md'); linkSync(secret, alias); // 硬链:同 inode、nlink=2、isSymbolicLink()=false
+    const p = probeSourceState(record({ sourceKind: 'file', locator: alias, isDirectorySkill: false }));
+    assert.equal(p.reachable, false, '硬链 nlink>1 被拒,绝不读别名的树外敏感文件');
+    assert.equal(p.hash, undefined);
+  });
+
+  it('安全:目录-skill 树内含指向树外敏感文件的硬链 → reachable:false(不读整树)', () => {
+    const sk = join(dir, 'dirskill'); mkdirSync(sk, { recursive: true });
+    writeFileSync(join(sk, 'SKILL.md'), '# s\n');
+    const secret = join(dir, 'outside.txt'); writeFileSync(secret, 'SECRET\n');
+    linkSync(secret, join(sk, 'leak.md')); // 树内硬链别名树外 inode
+    const p = probeSourceState(record({ sourceKind: 'file', locator: sk, isDirectorySkill: true }));
+    assert.equal(p.reachable, false, '树内硬链文件被 nlink 守卫拦下,整树拒读');
   });
 
   it('源不存在 → reachable:false(未核,不冒充 stale)', () => {

--- a/test/cli/list-probe.test.ts
+++ b/test/cli/list-probe.test.ts
@@ -92,7 +92,17 @@ describe('sanitizeCell', () => {
     assert.ok(out.includes('red') && out.includes('tail'), '可见正文保留');
   });
 
-  it('普通字符串原样', () => {
+  it('洗掉 BiDi 重排 / 隔离 / 零宽 / 组合附加符(防 Trojan-Source 视觉伪造 + 宽度错位)', () => {
+    // U+202E RLO、U+2066 隔离、U+200B 零宽、U+0300 组合附加符、U+FEFF BOM —— 都不该出现在表格单元里。
+    const evil = 'PASS\u202e drowssap\u2066x\u2069\u200bhidde\u0300n\ufeff';
+    const out = sanitizeCell(evil);
+    for (const cp of ['\u202e', '\u2066', '\u2069', '\u200b', '\u0300', '\ufeff']) {
+      assert.ok(!out.includes(cp), 'invisible/reordering char stripped: U+' + cp.codePointAt(0)!.toString(16));
+    }
+    assert.ok(out.includes('PASS') && out.includes('hidde') && out.includes('n'), '可见正文保留');
+  });
+
+  it('普通字符串原样(含 CJK / 路径)', () => {
     assert.equal(sanitizeCell('./skills/review'), './skills/review');
     assert.equal(sanitizeCell('git:HEAD:skills/审查'), 'git:HEAD:skills/审查');
   });

--- a/test/cli/list-render.test.ts
+++ b/test/cli/list-render.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `omk list` 表格渲染单测:锁住 dispWidth / truncate 的显示宽度语义、name 截断,以及**状态符组合不变量**
+ * —— 不可达标「?」绝不冒充 stale,reachable 且漂移才 `stale ⚠️`。这层之前零覆盖,三元组一旦被改序就会
+ * 误导用户对 drift 的判断却测不出来。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { renderTable, dispWidth, truncate } from '../../src/cli/commands/list.js';
+import type { ManagedListRow } from '../../src/managed/index.js';
+
+function row(over: Partial<ManagedListRow> = {}): ManagedListRow {
+  return {
+    id: 'id', name: 'review', kind: 'skill', sourceKind: 'file', sourceLabel: '/abs/review',
+    state: 'installed', drifted: false, reachable: true,
+    currentEvidenceCount: 0, totalEvidenceCount: 0, distributionCount: 1, ...over,
+  };
+}
+// 单行表格的数据行(header 之后第一行)。
+const dataLine = (r: ManagedListRow): string => renderTable([r], 'en').split('\n')[1];
+
+describe('dispWidth', () => {
+  it('CJK 全角按 2 列、ASCII 按 1 列', () => {
+    assert.equal(dispWidth('名称'), 4);
+    assert.equal(dispWidth('NAME'), 4);
+    assert.equal(dispWidth('a中b'), 4);
+  });
+});
+
+describe('truncate（按显示宽度）', () => {
+  it('不超宽原样返回', () => {
+    assert.equal(truncate('short', 48), 'short');
+  });
+  it('超宽截断且不溢出列、以 … 收尾', () => {
+    const out = truncate('中'.repeat(100), 48);
+    assert.ok(dispWidth(out) <= 48, `截断后显示宽度应 ≤ 48,实得 ${dispWidth(out)}`);
+    assert.ok(out.endsWith('…'), '以省略号收尾');
+  });
+});
+
+describe('renderTable 状态符不变量', () => {
+  it('reachable + stale → `stale ⚠️`', () => {
+    const line = dataLine(row({ state: 'stale', drifted: true, reachable: true }));
+    assert.ok(line.includes('stale ⚠️'), `stale 行应显示 ⚠️:${line}`);
+  });
+
+  it('reachable + measurable → 裸 state,无 ? 无 ⚠️', () => {
+    const line = dataLine(row({ state: 'measurable', reachable: true, currentEvidenceCount: 1, totalEvidenceCount: 1 }));
+    assert.ok(line.includes('measurable'));
+    assert.ok(!line.includes('?'), '可达非 stale 不应有 ?');
+    assert.ok(!line.includes('⚠️'), '可达非 stale 不应有 ⚠️');
+  });
+
+  it('不可达 → `state ?`,绝不出现 ⚠️（不冒充 stale）', () => {
+    const line = dataLine(row({ state: 'installed', reachable: false }));
+    assert.ok(line.includes('installed ?'), `不可达应标 ?:${line}`);
+    assert.ok(!line.includes('⚠️'), '不可达绝不冒充 stale ⚠️');
+  });
+
+  it('不可达即便内部 state 仍是 stale 也只标 ?,不标 ⚠️（守住「未核 ≠ 已漂移」）', () => {
+    // buildManagedListRow 在不可达时本就不会给 stale,这里直接喂 stale 锁住 renderTable 这一层的兜底。
+    const line = dataLine(row({ state: 'stale', reachable: false }));
+    assert.ok(line.includes('stale ?'));
+    assert.ok(!line.includes('⚠️'));
+  });
+});
+
+describe('renderTable name 截断', () => {
+  it('超长 name 被按显示宽度截断,不撑爆表宽', () => {
+    const out = renderTable([row({ name: 'x'.repeat(120) })], 'en');
+    assert.ok(out.includes('…'), '超长 name 应截断');
+    assert.ok(!out.includes('x'.repeat(41)), 'name 列不应原样铺出 41+ 字符');
+  });
+});

--- a/test/cli/list-run.test.ts
+++ b/test/cli/list-run.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `omk list` 端到端编排测(execFile 打到 dist):锁住 run() 这层一直没覆盖的契约 ——
+ *   - 表格走 stdout、表头 / 注脚走 stderr(`omk list | grep` 才不被装饰行污染);
+ *   - `--json` 出**版本化信封** `{ schemaVersion, rows }`(脚本可检测形态变更);
+ *   - drift_note 仅在有漂移行时出、unreachable_note 仅在有不可达行时出(两个谓词不被写反);
+ *   - 空目录走 empty 文案、stdout 不出表。
+ * HOME 指到临时空目录,避免 resolveManagedDir 回退到本机真实全局受管目录污染断言。
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { promisify } from 'node:util';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const CLI = join(PROJECT_ROOT, 'dist', 'cli', 'index.js');
+
+interface Rec { name: string; locator: string; isDirectorySkill: boolean; contentHash: string; }
+function writeRecord(dir: string, r: Rec): void {
+  const rec = {
+    recordKind: 'managed-artifact', schemaVersion: 2, id: `skill-${r.name}`, name: r.name, kind: 'skill',
+    source: { sourceKind: 'file', locator: r.locator, isDirectorySkill: r.isDirectorySkill },
+    contentHash: r.contentHash, installedAt: '2026-06-06T00:00:00.000Z',
+    distribution: [], evidence: [], decisions: [],
+  };
+  writeFileSync(join(dir, `skill-${r.name}.json`), JSON.stringify(rec));
+}
+
+describe('omk list 端到端', () => {
+  let proj: string;
+  let home: string;
+  let env: NodeJS.ProcessEnv;
+  let managed: string;
+  beforeEach(() => {
+    proj = mkdtempSync(join(tmpdir(), 'omk-list-proj-'));
+    home = mkdtempSync(join(tmpdir(), 'omk-list-home-'));
+    env = { ...process.env, HOME: home, USERPROFILE: home };
+    managed = join(proj, '.omk', 'managed');
+    mkdirSync(managed, { recursive: true });
+  });
+  afterEach(() => { rmSync(proj, { recursive: true, force: true }); rmSync(home, { recursive: true, force: true }); });
+
+  const run = (args: string[]) => execFileAsync('node', [CLI, 'list', '--lang', 'en', ...args], { cwd: proj, env });
+
+  it('漂移行:表格走 stdout、drift_note 走 stderr,不出 unreachable_note', async () => {
+    // 真源存在但 contentHash 故意写错 → reachable 且漂移 → drifted。
+    writeFileSync(join(proj, 'a.md'), '# real\n');
+    writeRecord(managed, { name: 'alpha', locator: join(proj, 'a.md'), isDirectorySkill: false, contentHash: 'WRONGHASH000' });
+    const { stdout, stderr } = await run([]);
+    assert.ok(stdout.includes('alpha'), '表格(含行名)应在 stdout');
+    assert.ok(stdout.includes('stale'), '漂移行表格状态为 stale');
+    assert.ok(stderr.includes('Managed skills'), '表头在 stderr');
+    assert.ok(stderr.includes('drifted'), 'drift_note 在 stderr');
+    assert.ok(!stderr.includes('unreachable'), '无不可达行 → 不出 unreachable_note');
+    assert.ok(!stdout.includes('Managed skills'), 'stdout 不含装饰行(可安全 grep)');
+  });
+
+  it('不可达行:出 unreachable_note,不出 drift_note', async () => {
+    writeRecord(managed, { name: 'beta', locator: join(proj, 'gone', 'x.md'), isDirectorySkill: false, contentHash: 'h' });
+    const { stdout, stderr } = await run([]);
+    assert.ok(stdout.includes('beta'));
+    assert.ok(stderr.includes('unreachable'), 'unreachable_note 在 stderr');
+    assert.ok(!stderr.includes('drifted'), '无漂移行 → 不出 drift_note');
+  });
+
+  it('--json:输出版本化信封 { schemaVersion:1, rows:[...] },stdout 可直接 JSON.parse', async () => {
+    writeFileSync(join(proj, 'a.md'), '# real\n');
+    writeRecord(managed, { name: 'gamma', locator: join(proj, 'a.md'), isDirectorySkill: false, contentHash: 'WRONGHASH000' });
+    const { stdout } = await run(['--json']);
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.schemaVersion, 1, 'JSON 带 schemaVersion 信封');
+    assert.ok(Array.isArray(parsed.rows), 'rows 是数组');
+    assert.equal(parsed.rows[0].name, 'gamma');
+    assert.equal(parsed.rows[0].sourceLabel, join(proj, 'a.md'), 'file 源 sourceLabel = locator');
+  });
+
+  it('空目录:走 empty 文案、stdout 不出表', async () => {
+    const { stdout, stderr } = await run([]);
+    assert.equal(stdout.trim(), '', '无记录 → stdout 不出表');
+    assert.ok(stderr.includes('No managed records'), 'stderr 出 empty 文案');
+  });
+});

--- a/test/inputs/git-dash-ref.test.ts
+++ b/test/inputs/git-dash-ref.test.ts
@@ -1,0 +1,45 @@
+/**
+ * 锁住 gitShowFile / gitShowBytes / gitLsTreeBlobs 的 `--` 隔断:用户可控 ref(经 managed locator
+ * `git:<ref>:<spec>` 一路流到这三个 helper)若以 `-` 开头,绝不能被 git 当 option 解析 —— 必须 fail-closed
+ * (返回 null / [])。同时正向断言普通 ref 仍能取到内容,防 `--` 写错把正常解析也打断。
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { gitShowFile, gitShowBytes, gitLsTreeBlobs } from '../../src/inputs/skill-loader.js';
+
+const git = (repo: string, args: string[]): void => { execFileSync('git', args, { cwd: repo, stdio: 'pipe' }); };
+
+describe('git helpers `--` dash-ref fail-closed', () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = realpathSync(mkdtempSync(join(tmpdir(), 'omk-dashref-')));
+    git(repo, ['init', '-q']);
+    git(repo, ['config', 'user.email', 't@t']);
+    git(repo, ['config', 'user.name', 't']);
+    mkdirSync(join(repo, 'skills', 'review'), { recursive: true });
+    writeFileSync(join(repo, 'skills', 'review', 'SKILL.md'), '# review\n');
+    writeFileSync(join(repo, 'skills', 'review', 'r.md'), 'asset\n');
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '-q', '-m', 'init']);
+  });
+  afterEach(() => { rmSync(repo, { recursive: true, force: true }); });
+
+  it('普通 ref:三个 helper 都能正常取到内容（确认 `--` 没打断正常解析）', () => {
+    assert.equal(gitShowFile('HEAD', 'skills/review/SKILL.md', repo), '# review'); // gitShowFile 内部 .trim()
+    assert.ok((gitShowBytes('HEAD', 'skills/review/SKILL.md', repo) as Buffer).equals(Buffer.from('# review\n')));
+    const blobs = gitLsTreeBlobs('HEAD', 'skills/review', repo);
+    assert.ok(blobs.some((b) => b.path.endsWith('SKILL.md')) && blobs.some((b) => b.path.endsWith('r.md')));
+  });
+
+  it('以 `-` 开头的恶意 ref:fail-closed,绝不被当 git option 解析', () => {
+    // 没有 `--` 隔断时 `-evil` 会被 git 当作未知开关 → 行为不可控;有 `--` 则当 tree-ish 解析、必失败。
+    assert.equal(gitShowFile('-evil', 'skills/review/SKILL.md', repo), null);
+    assert.equal(gitShowFile('--upload-pack=touch x', 'skills/review/SKILL.md', repo), null);
+    assert.equal(gitShowBytes('-evil', 'skills/review/SKILL.md', repo), null);
+    assert.deepEqual(gitLsTreeBlobs('-evil', 'skills/review', repo), []);
+  });
+});

--- a/test/managed/list-view.test.ts
+++ b/test/managed/list-view.test.ts
@@ -111,6 +111,26 @@ describe('buildManagedListRow', () => {
     }), reach('hashAAA'));
     assert.equal(row.sourceLabel, '/abs/private.md', 'file 源永不显示 url —— 显示的就是 probe 实际读取的 locator');
   });
+
+  it('本地 git(无 url):sourceLabel 取 git locator,不显 url（守住 `&& url` 守卫的 false 分支）', () => {
+    const row = buildManagedListRow(rec({
+      source: { sourceKind: 'git', locator: 'git:HEAD:skills/review', ref: 'HEAD', isDirectorySkill: true },
+    }), reach('hashAAA'));
+    assert.equal(row.sourceKind, 'git');
+    assert.equal(row.sourceLabel, 'git:HEAD:skills/review');
+  });
+
+  it('证据 tie-break 按真实时刻而非字典序:异偏移 ISO 串取 chronologically 最新那条', () => {
+    const row = buildManagedListRow(rec({
+      evidence: [
+        // 字典序 '08:00+08:00' > '01:00Z',但真实时刻 00:00Z < 01:00Z → 应取后者(NEW)。
+        ev({ reportId: 'old', recordedAt: '2026-01-01T08:00:00+08:00', verdict: 'OLD' }),
+        ev({ reportId: 'new', recordedAt: '2026-01-01T01:00:00Z', verdict: 'NEW' }),
+      ],
+    }), reach('hashAAA'));
+    assert.equal(row.latestVerdict, 'NEW', '按解析时刻取最新,不被异偏移字典序骗');
+    assert.equal(row.recordedAt, '2026-01-01T01:00:00Z');
+  });
 });
 
 describe('buildManagedListRows', () => {
@@ -120,6 +140,18 @@ describe('buildManagedListRows', () => {
       () => ({ reachable: true, hash: 'hashAAA' }),
     );
     assert.deepEqual(rows.map((r) => r.name), ['apply', 'lint', 'review']);
+  });
+
+  it('确定性排序:NFC / NFD 同显示名(collation 相等但 !==)仍触发 kind tiebreak,输入顺序不影响输出', () => {
+    const nfc = 'café';        // U+00E9
+    const nfd = 'café';       // U+0065 U+0301,与 nfc collation 相等但 !==
+    const mk = (name: string, kind: 'skill' | 'agent') => rec({ id: `${kind}-${name}`, name, kind });
+    const probe = () => ({ reachable: true as const, hash: 'hashAAA' });
+    // 两种输入顺序应排出同一结果(kind:agent < skill);旧的 === gate 会漏 tiebreak、退回输入序。
+    const a = buildManagedListRows([mk(nfc, 'skill'), mk(nfd, 'agent')], probe).map((r) => r.kind);
+    const b = buildManagedListRows([mk(nfd, 'agent'), mk(nfc, 'skill')], probe).map((r) => r.kind);
+    assert.deepEqual(a, ['agent', 'skill'], 'collation 相等 → 按 kind 确定排序');
+    assert.deepEqual(a, b, '输入顺序不影响输出(确定性)');
   });
 
   it('probeOf 按记录分别探测:一致 → installed;不可达 → installed + reachable=false(非 stale)', () => {

--- a/test/managed/list-view.test.ts
+++ b/test/managed/list-view.test.ts
@@ -104,6 +104,13 @@ describe('buildManagedListRow', () => {
     assert.equal(row.sourceKind, 'git');
     assert.equal(row.sourceLabel, 'https://x/r.git');
   });
+
+  it('防御层:file 源即便混入 url(已被 validator 拒)→ sourceLabel 取 locator 不取 url(显示=被读路径)', () => {
+    const row = buildManagedListRow(rec({
+      source: { sourceKind: 'file', locator: '/abs/private.md', url: 'https://example.com/safe.git', isDirectorySkill: false } as ManagedArtifactRecord['source'],
+    }), reach('hashAAA'));
+    assert.equal(row.sourceLabel, '/abs/private.md', 'file 源永不显示 url —— 显示的就是 probe 实际读取的 locator');
+  });
 });
 
 describe('buildManagedListRows', () => {

--- a/test/managed/list-view.test.ts
+++ b/test/managed/list-view.test.ts
@@ -29,10 +29,14 @@ function ev(over: Partial<ManagedEvidenceRef> = {}): ManagedEvidenceRef {
 }
 
 describe('buildManagedListRow', () => {
+  const reach = (hash: string) => ({ reachable: true as const, hash });
+  const unreach = { reachable: false as const };
+
   it('installed:无证据、源哈与记录一致 → installed,verdict —,证据 0/0', () => {
-    const row = buildManagedListRow(rec(), 'hashAAA');
+    const row = buildManagedListRow(rec(), reach('hashAAA'));
     assert.equal(row.state, 'installed');
     assert.equal(row.drifted, false);
+    assert.equal(row.reachable, true);
     assert.equal(row.latestVerdict, undefined);
     assert.equal(row.currentEvidenceCount, 0);
     assert.equal(row.totalEvidenceCount, 0);
@@ -40,7 +44,7 @@ describe('buildManagedListRow', () => {
   });
 
   it('measurable:有当前证据(同哈)→ measurable + 带 verdict/可比性,证据 1/1', () => {
-    const row = buildManagedListRow(rec({ evidence: [ev()] }), 'hashAAA');
+    const row = buildManagedListRow(rec({ evidence: [ev()] }), reach('hashAAA'));
     assert.equal(row.state, 'measurable');
     assert.equal(row.latestVerdict, 'PROGRESS');
     assert.equal(row.comparability?.cliVersion, '0.35.0');
@@ -48,18 +52,27 @@ describe('buildManagedListRow', () => {
     assert.equal(row.totalEvidenceCount, 1);
   });
 
-  it('stale:源哈漂移(≠ 记录)→ stale + drifted,旧证据仍计入 total 但不计 current', () => {
-    const row = buildManagedListRow(rec({ evidence: [ev()] }), 'hashDRIFTED');
+  it('stale:reachable 且源哈漂移(≠ 记录)→ stale + drifted,旧证据仍计入 total 但不计 current', () => {
+    const row = buildManagedListRow(rec({ evidence: [ev()] }), reach('hashDRIFTED'));
     assert.equal(row.state, 'stale');
     assert.equal(row.drifted, true);
+    assert.equal(row.reachable, true);
     assert.equal(row.currentEvidenceCount, 1, '证据 contentHash 仍等于 record.contentHash');
     assert.equal(row.totalEvidenceCount, 1);
   });
 
-  it('stale:源已不在(currentHash undefined)→ stale', () => {
-    const row = buildManagedListRow(rec(), undefined);
-    assert.equal(row.state, 'stale');
-    assert.equal(row.drifted, true);
+  it('不可达 ≠ stale:probe.reachable=false → 按证据给 installed,drifted=false,reachable=false', () => {
+    const row = buildManagedListRow(rec(), unreach);
+    assert.equal(row.state, 'installed', '源不可达不当 stale —— 修 cwd-fragile 误报(CR P1)');
+    assert.equal(row.drifted, false, '不可达不打 drift');
+    assert.equal(row.reachable, false);
+  });
+
+  it('不可达 + 有当前证据 → measurable(不是 stale),reachable=false', () => {
+    const row = buildManagedListRow(rec({ evidence: [ev()] }), unreach);
+    assert.equal(row.state, 'measurable');
+    assert.equal(row.drifted, false);
+    assert.equal(row.reachable, false);
   });
 
   it('多条当前证据 → 取 recordedAt 最新那条的 verdict', () => {
@@ -68,7 +81,7 @@ describe('buildManagedListRow', () => {
         ev({ reportId: 'old', recordedAt: '2026-06-07T00:00:00.000Z', verdict: 'NOISE' }),
         ev({ reportId: 'new', recordedAt: '2026-06-09T00:00:00.000Z', verdict: 'PROGRESS' }),
       ],
-    }), 'hashAAA');
+    }), reach('hashAAA'));
     assert.equal(row.latestVerdict, 'PROGRESS');
     assert.equal(row.recordedAt, '2026-06-09T00:00:00.000Z');
     assert.equal(row.currentEvidenceCount, 2);
@@ -77,7 +90,7 @@ describe('buildManagedListRow', () => {
   it('旧内容证据(哈不等)不计 current、不取其 verdict', () => {
     const row = buildManagedListRow(rec({
       evidence: [ev({ contentHash: 'hashOLD', verdict: 'REGRESS', recordedAt: '2026-06-10T00:00:00.000Z' })],
-    }), 'hashAAA');
+    }), reach('hashAAA'));
     assert.equal(row.currentEvidenceCount, 0);
     assert.equal(row.totalEvidenceCount, 1);
     assert.equal(row.latestVerdict, undefined, '旧内容证据不冒充当前 verdict');
@@ -87,7 +100,7 @@ describe('buildManagedListRow', () => {
   it('远端 git:sourceLabel 取 url', () => {
     const row = buildManagedListRow(rec({
       source: { sourceKind: 'git', locator: 'git+https://x/r.git@sha1:review', ref: 'sha1', url: 'https://x/r.git', isDirectorySkill: true },
-    }), 'hashAAA');
+    }), reach('hashAAA'));
     assert.equal(row.sourceKind, 'git');
     assert.equal(row.sourceLabel, 'https://x/r.git');
   });
@@ -97,17 +110,22 @@ describe('buildManagedListRows', () => {
   it('按 name 排序', () => {
     const rows = buildManagedListRows(
       [rec({ id: 'b', name: 'lint' }), rec({ id: 'a', name: 'apply' }), rec({ id: 'c', name: 'review' })],
-      () => 'hashAAA',
+      () => ({ reachable: true, hash: 'hashAAA' }),
     );
     assert.deepEqual(rows.map((r) => r.name), ['apply', 'lint', 'review']);
   });
 
-  it('currentHashOf 按记录分别解析', () => {
+  it('probeOf 按记录分别探测:一致 → installed;不可达 → installed + reachable=false(非 stale)', () => {
     const rows = buildManagedListRows(
       [rec({ id: 'a', name: 'a', contentHash: 'h1' }), rec({ id: 'b', name: 'b', contentHash: 'h2' })],
-      (r) => (r.name === 'a' ? 'h1' : undefined), // a 一致,b 源没了
+      (r) => (r.name === 'a' ? { reachable: true, hash: 'h1' } : { reachable: false }),
     );
-    assert.equal(rows.find((r) => r.name === 'a')!.state, 'installed');
-    assert.equal(rows.find((r) => r.name === 'b')!.state, 'stale');
+    const a = rows.find((r) => r.name === 'a')!;
+    const b = rows.find((r) => r.name === 'b')!;
+    assert.equal(a.state, 'installed');
+    assert.equal(a.reachable, true);
+    assert.equal(b.state, 'installed');
+    assert.equal(b.reachable, false, '源不可达不误报 stale');
+    assert.equal(b.drifted, false);
   });
 });

--- a/test/managed/list-view.test.ts
+++ b/test/managed/list-view.test.ts
@@ -1,0 +1,113 @@
+/**
+ * `omk list` 纯视图构造单测。state / verdict / 证据计数都从受管记录读时推导,当前源哈由调用方注入
+ * (这里给 mock),与 IO 解耦。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { buildManagedListRow, buildManagedListRows } from '../../src/managed/list-view.js';
+import type { ManagedArtifactRecord, ManagedEvidenceRef } from '../../src/types/index.js';
+
+function rec(over: Partial<ManagedArtifactRecord> = {}): ManagedArtifactRecord {
+  return {
+    recordKind: 'managed-artifact',
+    schemaVersion: 2,
+    id: 'id-review',
+    name: 'review',
+    kind: 'skill',
+    source: { sourceKind: 'file', locator: '/abs/review', isDirectorySkill: true },
+    contentHash: 'hashAAA',
+    installedAt: '2026-06-06T00:00:00.000Z',
+    distribution: [{ label: 'Claude Code', path: '/x/review', contentHash: 'hashAAA', copiedAt: '2026-06-06T00:00:00.000Z' }],
+    evidence: [],
+    decisions: [],
+    ...over,
+  };
+}
+
+function ev(over: Partial<ManagedEvidenceRef> = {}): ManagedEvidenceRef {
+  return { reportId: 'r1', contentHash: 'hashAAA', recordedAt: '2026-06-08T00:00:00.000Z', verdict: 'PROGRESS', comparability: { cliVersion: '0.35.0' }, ...over };
+}
+
+describe('buildManagedListRow', () => {
+  it('installed:无证据、源哈与记录一致 → installed,verdict —,证据 0/0', () => {
+    const row = buildManagedListRow(rec(), 'hashAAA');
+    assert.equal(row.state, 'installed');
+    assert.equal(row.drifted, false);
+    assert.equal(row.latestVerdict, undefined);
+    assert.equal(row.currentEvidenceCount, 0);
+    assert.equal(row.totalEvidenceCount, 0);
+    assert.equal(row.distributionCount, 1);
+  });
+
+  it('measurable:有当前证据(同哈)→ measurable + 带 verdict/可比性,证据 1/1', () => {
+    const row = buildManagedListRow(rec({ evidence: [ev()] }), 'hashAAA');
+    assert.equal(row.state, 'measurable');
+    assert.equal(row.latestVerdict, 'PROGRESS');
+    assert.equal(row.comparability?.cliVersion, '0.35.0');
+    assert.equal(row.currentEvidenceCount, 1);
+    assert.equal(row.totalEvidenceCount, 1);
+  });
+
+  it('stale:源哈漂移(≠ 记录)→ stale + drifted,旧证据仍计入 total 但不计 current', () => {
+    const row = buildManagedListRow(rec({ evidence: [ev()] }), 'hashDRIFTED');
+    assert.equal(row.state, 'stale');
+    assert.equal(row.drifted, true);
+    assert.equal(row.currentEvidenceCount, 1, '证据 contentHash 仍等于 record.contentHash');
+    assert.equal(row.totalEvidenceCount, 1);
+  });
+
+  it('stale:源已不在(currentHash undefined)→ stale', () => {
+    const row = buildManagedListRow(rec(), undefined);
+    assert.equal(row.state, 'stale');
+    assert.equal(row.drifted, true);
+  });
+
+  it('多条当前证据 → 取 recordedAt 最新那条的 verdict', () => {
+    const row = buildManagedListRow(rec({
+      evidence: [
+        ev({ reportId: 'old', recordedAt: '2026-06-07T00:00:00.000Z', verdict: 'NOISE' }),
+        ev({ reportId: 'new', recordedAt: '2026-06-09T00:00:00.000Z', verdict: 'PROGRESS' }),
+      ],
+    }), 'hashAAA');
+    assert.equal(row.latestVerdict, 'PROGRESS');
+    assert.equal(row.recordedAt, '2026-06-09T00:00:00.000Z');
+    assert.equal(row.currentEvidenceCount, 2);
+  });
+
+  it('旧内容证据(哈不等)不计 current、不取其 verdict', () => {
+    const row = buildManagedListRow(rec({
+      evidence: [ev({ contentHash: 'hashOLD', verdict: 'REGRESS', recordedAt: '2026-06-10T00:00:00.000Z' })],
+    }), 'hashAAA');
+    assert.equal(row.currentEvidenceCount, 0);
+    assert.equal(row.totalEvidenceCount, 1);
+    assert.equal(row.latestVerdict, undefined, '旧内容证据不冒充当前 verdict');
+    assert.equal(row.state, 'installed', '只有旧内容证据 → 当前无证据 → installed');
+  });
+
+  it('远端 git:sourceLabel 取 url', () => {
+    const row = buildManagedListRow(rec({
+      source: { sourceKind: 'git', locator: 'git+https://x/r.git@sha1:review', ref: 'sha1', url: 'https://x/r.git', isDirectorySkill: true },
+    }), 'hashAAA');
+    assert.equal(row.sourceKind, 'git');
+    assert.equal(row.sourceLabel, 'https://x/r.git');
+  });
+});
+
+describe('buildManagedListRows', () => {
+  it('按 name 排序', () => {
+    const rows = buildManagedListRows(
+      [rec({ id: 'b', name: 'lint' }), rec({ id: 'a', name: 'apply' }), rec({ id: 'c', name: 'review' })],
+      () => 'hashAAA',
+    );
+    assert.deepEqual(rows.map((r) => r.name), ['apply', 'lint', 'review']);
+  });
+
+  it('currentHashOf 按记录分别解析', () => {
+    const rows = buildManagedListRows(
+      [rec({ id: 'a', name: 'a', contentHash: 'h1' }), rec({ id: 'b', name: 'b', contentHash: 'h2' })],
+      (r) => (r.name === 'a' ? 'h1' : undefined), // a 一致,b 源没了
+    );
+    assert.equal(rows.find((r) => r.name === 'a')!.state, 'installed');
+    assert.equal(rows.find((r) => r.name === 'b')!.state, 'stale');
+  });
+});

--- a/test/managed/store.test.ts
+++ b/test/managed/store.test.ts
@@ -131,6 +131,37 @@ describe('managed store', () => {
     assert.equal(loadManagedRecord(store, id), null, 'source 缺 sourceKind 应判脏');
   });
 
+  it('validator 收窄运行时类型:畸形记录判脏丢弃(防下游 omk list 等崩溃)', () => {
+    const store = managedDir(dir);
+    const id = managedRecordId('skill', 'review');
+    mkdirSync(store, { recursive: true });
+    const write = (over: Record<string, unknown>) => writeFileSync(recordPath(store, id), JSON.stringify({ ...makeRecord({ id }), ...over }));
+
+    // source.url 是对象(非 string)—— 旧 validator 只查 locator/sourceKind 是 string 会放行,
+    // 随后 omk list 的 sourceLabel ?? url 变对象、dispWidth(对象) 抛 TypeError。
+    write({ source: { sourceKind: 'git', locator: 'git:HEAD:x', url: {}, isDirectorySkill: true } });
+    assert.equal(loadManagedRecord(store, id), null, 'source.url 非 string 判脏');
+
+    write({ source: { sourceKind: 'evil', locator: '/abs/x', isDirectorySkill: true } });
+    assert.equal(loadManagedRecord(store, id), null, 'sourceKind 非 file|git 判脏');
+
+    write({ source: { sourceKind: 'file', locator: '/abs/x' } });
+    assert.equal(loadManagedRecord(store, id), null, 'isDirectorySkill 缺失判脏');
+
+    write({ source: { sourceKind: 'file', locator: '/abs/x', isDirectorySkill: 'yes' } });
+    assert.equal(loadManagedRecord(store, id), null, 'isDirectorySkill 非 boolean 判脏');
+
+    write({ kind: 'baseline' });
+    assert.equal(loadManagedRecord(store, id), null, 'kind 非可安装 ArtifactKind 判脏');
+
+    write({ evidence: [{ reportId: 'r', contentHash: 'h', recordedAt: 't', comparability: { cliVersion: 1 } }] });
+    assert.equal(loadManagedRecord(store, id), null, 'evidence.comparability.cliVersion 非 string 判脏');
+
+    // 合法记录仍放行(含完整 evidence bundle)。
+    write({ evidence: [{ reportId: 'r', contentHash: 'aaaaaaaaaaaa', recordedAt: 't', verdict: 'PROGRESS', comparability: { cliVersion: '0.35.0' } }] });
+    assert.ok(loadManagedRecord(store, id), '合法记录正常加载');
+  });
+
   it('loadAllManagedRecords:跳过损坏文件,只收合法记录', () => {
     const store = managedDir(dir);
     upsertManagedRecord(store, makeRecord());

--- a/test/managed/store.test.ts
+++ b/test/managed/store.test.ts
@@ -145,6 +145,13 @@ describe('managed store', () => {
     write({ source: { sourceKind: 'evil', locator: '/abs/x', isDirectorySkill: true } });
     assert.equal(loadManagedRecord(store, id), null, 'sourceKind 非 file|git 判脏');
 
+    // file 源不得携带 git-only 的 url / ref —— 否则 list 的 sourceLabel 显示假 url、掩盖真实被读的 locator。
+    write({ source: { sourceKind: 'file', locator: '/abs/private.md', url: 'https://example.com/safe.git', isDirectorySkill: false } });
+    assert.equal(loadManagedRecord(store, id), null, 'file 源带 url 判脏(防假 sourceLabel 掩盖真实读取路径)');
+
+    write({ source: { sourceKind: 'file', locator: '/abs/private.md', ref: 'deadbeef', isDirectorySkill: false } });
+    assert.equal(loadManagedRecord(store, id), null, 'file 源带 ref 判脏');
+
     write({ source: { sourceKind: 'file', locator: '/abs/x' } });
     assert.equal(loadManagedRecord(store, id), null, 'isDirectorySkill 缺失判脏');
 
@@ -157,8 +164,18 @@ describe('managed store', () => {
     write({ evidence: [{ reportId: 'r', contentHash: 'h', recordedAt: 't', comparability: { cliVersion: 1 } }] });
     assert.equal(loadManagedRecord(store, id), null, 'evidence.comparability.cliVersion 非 string 判脏');
 
-    // 合法记录仍放行(含完整 evidence bundle)。
-    write({ evidence: [{ reportId: 'r', contentHash: 'aaaaaaaaaaaa', recordedAt: 't', verdict: 'PROGRESS', comparability: { cliVersion: '0.35.0' } }] });
+    // comparability 的可选 marker 同样收窄(否则任意类型脏值穿过 validator 进 list --json / 未来 promote)。
+    write({ evidence: [{ reportId: 'r', contentHash: 'h', recordedAt: 't', comparability: { cliVersion: '0.35.0', judgePromptHash: { nested: true } } }] });
+    assert.equal(loadManagedRecord(store, id), null, 'comparability.judgePromptHash 非 string 判脏');
+
+    write({ evidence: [{ reportId: 'r', contentHash: 'h', recordedAt: 't', comparability: { cliVersion: '0.35.0', debiasMode: 42 } }] });
+    assert.equal(loadManagedRecord(store, id), null, 'comparability.debiasMode 非数组判脏');
+
+    write({ evidence: [{ reportId: 'r', contentHash: 'h', recordedAt: 't', comparability: { cliVersion: '0.35.0', debiasMode: ['length', 'evil'] } }] });
+    assert.equal(loadManagedRecord(store, id), null, 'comparability.debiasMode 含非法枚举值判脏');
+
+    // 合法记录仍放行(含完整 evidence bundle + 合法 comparability marker,确认没把合法值误伤)。
+    write({ evidence: [{ reportId: 'r', contentHash: 'aaaaaaaaaaaa', recordedAt: 't', verdict: 'PROGRESS', comparability: { cliVersion: '0.35.0', judgePromptHash: 'abc123', debiasMode: ['length', 'position'] } }] });
     assert.ok(loadManagedRecord(store, id), '合法记录正常加载');
   });
 


### PR DESCRIPTION
## 用户影响

管理支柱(#203)的**读侧入口**。`omk install` + `omk eval`(#222)已经在 `.omk/managed` 里攒证据,但一直没有命令把它看出来。`omk list` 补上:

```
受管 skill（项目，2 条）
名称    类型   状态        VERDICT   证据  源
review  skill  measurable  PROGRESS  1/1   ./skills/review
lint    skill  stale ⚠️    —         0/0   git:HEAD:skills/lint
```

每行展示生命周期状态、绑定**当前内容**的最新 verdict、当前/全部证据数、源。

## 行为

- 生命周期**读时推导**(`deriveManagedState`):`installed`(无有效证据)→ `measurable`(eval 证据绑定到当前内容指纹)→ `stale`(源内容漂移、脱离证据)。
- drift 检测重算当前源整树哈与记录 `contentHash` 比对 —— 改 `references/` 资产即翻 `stale`,这是 #214/#218 整树指纹的可见兑现(本地 smoke 实测:改一个 reference 文件,skill 立刻变 stale)。
- 远端 git 源钉的是不可变 SHA、内容恒定 → 直接取记录 hash,**不联网**(list 是快读命令)。源已不在 / ref 没了 → `stale`。
- verdict / 可比性取**当前有效证据**(contentHash == record.contentHash)里最新那条;旧内容证据保留计入 total、但不冒充当前(与读时门控同口径)。
- `--global` 看全局受管目录;`--json` 输出含完整可比性 marker(`cliVersion` / `judgePromptHash` / `debiasMode`)供脚本。
- 无受管记录 → 友好提示 `omk install`。

## 设计

- 纯视图 `buildManagedListRows(records, currentHashOf)`(`src/managed/list-view.ts`)—— 当前源哈解析注入,与 IO 解耦、可单测。
- CLI 侧 `currentSourceHash` 复用 `resolveInstallSource` 重物化真源算哈(本地 file/git);远端 SHA-pin 短路。
- 不改任何测量学不变量;不碰 Report / 受管记录 schema(纯读)。

## 测试

- `test/managed/list-view.test.ts`:installed / measurable / stale(drift + 源缺失)/ 多证据取最新 / 旧内容证据不冒充 / 远端 sourceLabel / 排序,9 例。
- 端到端 smoke(install → list=installed → 注入当前证据 → measurable → 改资产 → stale)本地验证。
- 守护:补 SKILL.md argument-hint + cli.test 命令集 + `ManagedListRow.kind` 用 `ArtifactKind`(裸 kind 护栏)。

## 文档

CLI 参考(中英)新增 `omk list` 段;SKILL.md / commands.md 命令集补 `list`。

## 后续

#203 还差 `promote`(据 evidence bundle 门控、写回 source-of-record)。

关联:#203 / #222 / `docs/specs/evidence-gated-management.md` §7。

🤖 Generated with [Claude Code](https://claude.com/claude-code)