### PR TITLE
refactor(report)!: BREAKING-SCHEMA 删除 reportKind 并统一落盘顶层 kind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ omk 是面向 LLM 知识输入（prompt / RAG / skill / agent）的评测与迭�
 - 不要直接在 `main` 上提交；不要再把新工作提交到 `develop`。
 - commit 格式：`type(scope): 中文 subject`。scope 用稳定模块名，如 `cli` / `i18n` / `judge` / `renderer` / `eval-core` / `eval-workflows` / `inputs` / `executors` / `server` / `analysis` / `authoring` / `grading` / `doctor` / `release` / `agents-md`（早期 git history 用过 `claude-md`，rename 后统一用 `agents-md`）。
 - 不要在给用户看的 URL 里硬编码 report server 端口；使用 `server.start()` 返回的实际 URL。
-- 裸 `kind` 留给 `ArtifactKind`（skill / prompt / agent / workflow）。其它判别字段用限定名（`reportKind` / `eventKind` / `runtimeKind` / `standardKind`）；已序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 是落盘字段名，改名会破坏读取已有文件、要走数据 / schema 迁移（序列化向后兼容，非统计可比性），本轮冻结。细节见 `docs/specs/terminology-spec.md` §5.4，CI 有 `test/scripts/kind-semantics-guard.test.ts` 拦新裸 `kind`。
+- 判别字段命名：新建或可安全改名的字段中，裸 `kind` 默认只表示 `Artifact.kind: ArtifactKind`（baseline / skill / prompt / agent / workflow）。例外是已经发布并落盘/对外暴露的 public schema（如 `report.kind`），这些既有 `kind` 字段不要顺手改成 `reportKind` 一类限定名；确需改名时单独做 schema / data migration，并保持读取旧文件。其它新判别字段用限定名（`eventKind` / `runtimeKind` / `standardKind` 等）。细节见 `docs/specs/terminology-spec.md` §5.4，CI 有 `test/scripts/kind-semantics-guard.test.ts` 拦新裸 `kind`。
 
 ## 测量学不变量
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ omk 是面向 LLM 知识输入（prompt / RAG / skill / agent）的评测与迭�
 - 不要直接在 `main` 上提交；不要再把新工作提交到 `develop`。
 - commit 格式：`type(scope): 中文 subject`。scope 用稳定模块名，如 `cli` / `i18n` / `judge` / `renderer` / `eval-core` / `eval-workflows` / `inputs` / `executors` / `server` / `analysis` / `authoring` / `grading` / `doctor` / `release` / `agents-md`（早期 git history 用过 `claude-md`，rename 后统一用 `agents-md`）。
 - 不要在给用户看的 URL 里硬编码 report server 端口；使用 `server.start()` 返回的实际 URL。
-- 判别字段命名：新建或可安全改名的字段中，裸 `kind` 默认只表示 `Artifact.kind: ArtifactKind`（baseline / skill / prompt / agent / workflow）。例外是已经发布并落盘/对外暴露的 public schema（如 `report.kind`），这些既有 `kind` 字段不要顺手改成 `reportKind` 一类限定名；确需改名时单独做 schema / data migration，并保持读取旧文件。其它新判别字段用限定名（`eventKind` / `runtimeKind` / `standardKind` 等）。细节见 `docs/specs/terminology-spec.md` §5.4，CI 有 `test/scripts/kind-semantics-guard.test.ts` 拦新裸 `kind`。
+- 判别字段命名：新建或可安全改名的字段中，裸 `kind` 默认只表示 `Artifact.kind: ArtifactKind`（baseline / skill / prompt / agent / workflow）。例外是已经发布并落盘/对外暴露的 public schema（如 report / doctor / observe / diagnosis 的顶层 `kind`），这些既有 `kind` 字段不要顺手改成限定名；确需改名时单独做 schema / data migration，并保持读取旧文件。其它新判别字段用限定名（`eventKind` / `runtimeKind` / `standardKind` 等）。细节见 `docs/specs/terminology-spec.md` §5.4，CI 有 `test/scripts/kind-semantics-guard.test.ts` 拦新裸 `kind`。
 
 ## 测量学不变量
 

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -317,6 +317,8 @@ In omk's product vocabulary, bare `kind` defaults to `Artifact.kind` (`ArtifactK
 For other discriminants, use a qualified name when the field is new or safe to rename. Existing published `kind` fields that are already persisted or externally consumed stay as-is unless a dedicated migration changes them:
 
 - `report.kind` stays the canonical public report-schema field
+- `doctor.kind` stays the canonical doctor-report field
+- `observe-*.kind` stays the canonical observe-report field
 - `event.kind` → `eventKind`
 - `executorRuntime.kind` → `runtimeKind`
 - `standard.kind` → `standardKind`

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -314,9 +314,9 @@ Rules:
 
 In omk's product vocabulary, bare `kind` is reserved for `Artifact.kind` (`ArtifactKind`: `baseline` / `skill` / `prompt` / `agent` / `workflow`). `baseline` means the empty eval artifact; experiment role still comes from `control` / `treatment`. CLI design follows the same rule: the `--kind` flag on `omk install` means artifact kind (aligned with `Artifact.kind`), not install target, report type, or observe event type.
 
-For other discriminants, use a qualified name when the field is new or safe to rename. Existing persisted `kind` fields stay as-is unless a dedicated migration changes them:
+For other discriminants, use a qualified name when the field is new or safe to rename. Existing persisted `kind` fields stay as legacy wire aliases unless a dedicated migration changes them:
 
-- `report.kind` → `reportKind` / `documentKind`
+- `report.kind` → internal `reportKind` / `documentKind`; report JSON keeps `kind` as a legacy alias for external consumers
 - `event.kind` → `eventKind`
 - `executorRuntime.kind` → `runtimeKind`
 - `standard.kind` → `standardKind`

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -325,7 +325,7 @@ For other discriminants, use a qualified name when the field is new or safe to r
 
 Two caveats:
 
-- **The persisted report / observe / doctor / diagnosis top-level discriminant is `kind`, cut over from the old `reportKind` in a deliberate BREAKING-SCHEMA change.** The cutover is hard — no dual-read, no migration shim: files written by older versions (top-level `reportKind`, no `kind`) are simply not read and are skipped. This is serialization back-compat, not statistical comparability — the field name changes no measurement number. (`report.kind` additionally sits in the Report-schema invariant list, so treat further changes there with the usual schema care.)
+- **The persisted report / observe / doctor / diagnosis top-level discriminant is `kind`, cut over from its earlier qualified field name in a deliberate BREAKING-SCHEMA change.** The cutover is hard — no dual-read, no migration shim: files written by older versions (an old qualified top-level discriminant, no `kind`) are simply not read and are skipped. This is serialization back-compat, not statistical comparability — the field name changes no measurement number. (`report.kind` additionally sits in the Report-schema invariant list, so treat further changes there with the usual schema care.)
 - Renaming internal non-persisted fields is progressive — done opportunistically when touching that code, not as a big-bang sweep. A CI guard freezes the current set of bare-`kind` declaration sites so new unqualified ones cannot slip in.
 
 ## 6. Term mapping

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -325,7 +325,7 @@ For other discriminants, use a qualified name when the field is new or safe to r
 
 Two caveats:
 
-- **Persisted discriminants are frozen.** Any `kind` already serialized into a report / observe / doctor / diagnosis JSON file is a stored field name: renaming it would break deserializing existing on-disk files, so it needs a dedicated data / schema migration (not done here). This is serialization back-compat, not statistical comparability — renaming the field changes no measurement number. (`report.kind` additionally sits in the Report-schema invariant list, so treat any change there with the usual schema care.)
+- **The persisted report / observe / doctor / diagnosis top-level discriminant is `kind`, cut over from the old `reportKind` in a deliberate BREAKING-SCHEMA change.** The cutover is hard — no dual-read, no migration shim: files written by older versions (top-level `reportKind`, no `kind`) are simply not read and are skipped. This is serialization back-compat, not statistical comparability — the field name changes no measurement number. (`report.kind` additionally sits in the Report-schema invariant list, so treat further changes there with the usual schema care.)
 - Renaming internal non-persisted fields is progressive — done opportunistically when touching that code, not as a big-bang sweep. A CI guard freezes the current set of bare-`kind` declaration sites so new unqualified ones cannot slip in.
 
 ## 6. Term mapping

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -312,11 +312,11 @@ Rules:
 
 ### 4. Reserve bare `kind` for `ArtifactKind`
 
-In omk's product vocabulary, bare `kind` is reserved for `Artifact.kind` (`ArtifactKind`: `baseline` / `skill` / `prompt` / `agent` / `workflow`). `baseline` means the empty eval artifact; experiment role still comes from `control` / `treatment`. CLI design follows the same rule: the `--kind` flag on `omk install` means artifact kind (aligned with `Artifact.kind`), not install target, report type, or observe event type.
+In omk's product vocabulary, bare `kind` defaults to `Artifact.kind` (`ArtifactKind`: `baseline` / `skill` / `prompt` / `agent` / `workflow`). `baseline` means the empty eval artifact; experiment role still comes from `control` / `treatment`. CLI design follows the same rule: the `--kind` flag on `omk install` means artifact kind (aligned with `Artifact.kind`), not install target, report type, or observe event type.
 
-For other discriminants, use a qualified name when the field is new or safe to rename. Existing persisted `kind` fields stay as legacy wire aliases unless a dedicated migration changes them:
+For other discriminants, use a qualified name when the field is new or safe to rename. Existing published `kind` fields that are already persisted or externally consumed stay as-is unless a dedicated migration changes them:
 
-- `report.kind` → internal `reportKind` / `documentKind`; report JSON keeps `kind` as a legacy alias for external consumers
+- `report.kind` stays the canonical public report-schema field
 - `event.kind` → `eventKind`
 - `executorRuntime.kind` → `runtimeKind`
 - `standard.kind` → `standardKind`

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -325,7 +325,7 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 
 两条注意：
 
-- **持久化判别字段冻结。** 任何已经序列化进 report / observe / doctor / diagnosis JSON 的 `kind` 都是落盘格式里的字段名：改名会破坏反序列化磁盘上已有的文件，所以要单独走数据 / schema 迁移（本轮不做）。这是序列化向后兼容，不是统计可比性 —— 改字段名不改任何测量数字。（`report.kind` 另外还在 Report schema 不变量清单里，改它按常规 schema 谨慎处理。）
+- **持久化判别字段 —— report / observe / doctor / diagnosis 的顶层判别字段是 `kind`，由旧的 `reportKind` 经一次有意的 BREAKING-SCHEMA 硬切换而来。** 硬切换不做双读、不留迁移垫片：旧版本写的文件（顶层是 `reportKind`、无 `kind`）直接不读、跳过。这是序列化向后兼容，不是统计可比性 —— 改字段名不改任何测量数字。（`report.kind` 另外还在 Report schema 不变量清单里，后续改动按常规 schema 谨慎处理。）
 - 内部非持久字段的改名是渐进式的 —— 改到那块代码时顺手做，不搞一次性大扫除。一个 CI 护栏冻结当前裸 `kind` 声明点的集合，防止新的不加限定的 `kind` 混进来。
 
 ## 六、术语映射

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -312,11 +312,11 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 
 ### 4. 裸 `kind` 留给 `ArtifactKind`
 
-在 omk 的产品语义里，裸 `kind` 留给 `Artifact.kind`（`ArtifactKind`：`baseline` / `skill` / `prompt` / `agent` / `workflow`）。`baseline` 表示 eval 里的空 artifact；实验角色仍然看 `control` / `treatment`。命令行设计同理：`omk install` 上的 `--kind` flag 表示 artifact kind（对齐 `Artifact.kind`），而不是安装目标、report 类型或 observe event 类型。
+在 omk 的产品语义里，裸 `kind` 默认指 `Artifact.kind`（`ArtifactKind`：`baseline` / `skill` / `prompt` / `agent` / `workflow`）。`baseline` 表示 eval 里的空 artifact；实验角色仍然看 `control` / `treatment`。命令行设计同理：`omk install` 上的 `--kind` flag 表示 artifact kind（对齐 `Artifact.kind`），而不是安装目标、report 类型或 observe event 类型。
 
-其它判别字段如果是新字段，或能安全改名，就用限定名。已经落盘的既有 `kind` 字段作为 legacy wire alias 保持，除非单独做 migration：
+其它判别字段如果是新字段，或能安全改名，就用限定名。已经发布、已落盘或已有外部消费方依赖的 `kind` 字段保持原样，除非单独做 migration：
 
-- `report.kind` → 内部主字段 `reportKind` / `documentKind`；report JSON 保留 `kind` 作为外部消费方的 legacy alias
+- `report.kind` 保持为 report public schema 的 canonical 字段
 - `event.kind` → `eventKind`
 - `executorRuntime.kind` → `runtimeKind`
 - `standard.kind` → `standardKind`

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -325,7 +325,7 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 
 两条注意：
 
-- **持久化判别字段 —— report / observe / doctor / diagnosis 的顶层判别字段是 `kind`，由旧的 `reportKind` 经一次有意的 BREAKING-SCHEMA 硬切换而来。** 硬切换不做双读、不留迁移垫片：旧版本写的文件（顶层是 `reportKind`、无 `kind`）直接不读、跳过。这是序列化向后兼容，不是统计可比性 —— 改字段名不改任何测量数字。（`report.kind` 另外还在 Report schema 不变量清单里，后续改动按常规 schema 谨慎处理。）
+- **持久化判别字段 —— report / observe / doctor / diagnosis 的顶层判别字段是 `kind`，由它早先的限定名字段经一次有意的 BREAKING-SCHEMA 硬切换而来。** 硬切换不做双读、不留迁移垫片：旧版本写的文件（顶层是旧的限定名判别字段、无 `kind`）直接不读、跳过。这是序列化向后兼容，不是统计可比性 —— 改字段名不改任何测量数字。（`report.kind` 另外还在 Report schema 不变量清单里，后续改动按常规 schema 谨慎处理。）
 - 内部非持久字段的改名是渐进式的 —— 改到那块代码时顺手做，不搞一次性大扫除。一个 CI 护栏冻结当前裸 `kind` 声明点的集合，防止新的不加限定的 `kind` 混进来。
 
 ## 六、术语映射

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -314,9 +314,9 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 
 在 omk 的产品语义里，裸 `kind` 留给 `Artifact.kind`（`ArtifactKind`：`baseline` / `skill` / `prompt` / `agent` / `workflow`）。`baseline` 表示 eval 里的空 artifact；实验角色仍然看 `control` / `treatment`。命令行设计同理：`omk install` 上的 `--kind` flag 表示 artifact kind（对齐 `Artifact.kind`），而不是安装目标、report 类型或 observe event 类型。
 
-其它判别字段如果是新字段，或能安全改名，就用限定名。已经落盘的既有 `kind` 字段保持原样，除非单独做 migration：
+其它判别字段如果是新字段，或能安全改名，就用限定名。已经落盘的既有 `kind` 字段作为 legacy wire alias 保持，除非单独做 migration：
 
-- `report.kind` → `reportKind` / `documentKind`
+- `report.kind` → 内部主字段 `reportKind` / `documentKind`；report JSON 保留 `kind` 作为外部消费方的 legacy alias
 - `event.kind` → `eventKind`
 - `executorRuntime.kind` → `runtimeKind`
 - `standard.kind` → `standardKind`

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -317,6 +317,8 @@ omk 当前仍处于 0-1 阶段，用户规模很小，因此不主动保留历�
 其它判别字段如果是新字段，或能安全改名，就用限定名。已经发布、已落盘或已有外部消费方依赖的 `kind` 字段保持原样，除非单独做 migration：
 
 - `report.kind` 保持为 report public schema 的 canonical 字段
+- `doctor.kind` 保持为 doctor report 的 canonical 字段
+- `observe-*.kind` 保持为 observe report 的 canonical 字段
 - `event.kind` → `eventKind`
 - `executorRuntime.kind` → `runtimeKind`
 - `standard.kind` → `standardKind`

--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -781,7 +781,7 @@ export function mergeEvolveReports(
   const runId = `evolve-${skillName}-${generateRunId([skillName]).split('-').slice(-2).join('-')}`;
 
   const report: Report = {
-    reportKind: 'evaluation',
+    kind: 'evaluation',
     id: runId,
     meta: {
       ...firstReport.meta,

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -317,7 +317,7 @@ export function pruneDoctorHistory(dir: string, skillName: string, maxKeep: numb
     if (!file.endsWith('.json')) continue;
     try {
       const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as import('../../types/doctor.js').DoctorReport;
-      if (data?.reportKind !== 'doctor' || !Array.isArray(data.skills) || data.skills.length !== 1) continue;
+      if (data?.kind !== 'doctor' || !Array.isArray(data.skills) || data.skills.length !== 1) continue;
       if (data.skills[0].skillName !== skillName) continue;
       candidates.push({ file, timestamp: data.timestamp });
     } catch { /* skip corrupt / unrelated json */ }

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -316,8 +316,8 @@ export function pruneDoctorHistory(dir: string, skillName: string, maxKeep: numb
   for (const file of readdirSync(dir)) {
     if (!file.endsWith('.json')) continue;
     try {
-      const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as import('../../types/doctor.js').DoctorReport & { reportKind?: unknown };
-      const kind = data?.kind === 'doctor' ? data.kind : data?.reportKind === 'doctor' ? data.reportKind : null;
+      const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as import('../../types/doctor.js').DoctorReport;
+      const kind = data?.kind === 'doctor' ? data.kind : null;
       if (!kind || !Array.isArray(data.skills) || data.skills.length !== 1) continue;
       if (data.skills[0].skillName !== skillName) continue;
       candidates.push({ file, timestamp: data.timestamp });

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -316,8 +316,9 @@ export function pruneDoctorHistory(dir: string, skillName: string, maxKeep: numb
   for (const file of readdirSync(dir)) {
     if (!file.endsWith('.json')) continue;
     try {
-      const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as import('../../types/doctor.js').DoctorReport;
-      if (data?.kind !== 'doctor' || !Array.isArray(data.skills) || data.skills.length !== 1) continue;
+      const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as import('../../types/doctor.js').DoctorReport & { reportKind?: unknown };
+      const kind = data?.kind === 'doctor' ? data.kind : data?.reportKind === 'doctor' ? data.reportKind : null;
+      if (!kind || !Array.isArray(data.skills) || data.skills.length !== 1) continue;
       if (data.skills[0].skillName !== skillName) continue;
       candidates.push({ file, timestamp: data.timestamp });
     } catch { /* skip corrupt / unrelated json */ }

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -105,7 +105,6 @@ function batchItemFallbackReport(
   item: BatchEvaluationReport['items'][number],
 ): EvaluationReport {
   return {
-    reportKind: 'evaluation',
     kind: 'evaluation',
     id: item.reportId,
     meta: {
@@ -134,7 +133,7 @@ async function loadBatchChildReports(
   const reports: EvaluationReport[] = [];
   for (const item of batch.items) {
     const loaded = await store.get(item.reportId);
-    if (loaded?.reportKind === 'evaluation') {
+    if (loaded?.kind === 'evaluation') {
       reports.push(loaded);
     } else {
       process.stderr.write(tCli('cli.run.batch_child_report_missing', lang, { id: item.reportId }));
@@ -193,7 +192,7 @@ async function announceSavedReport({
   lang: CliLang;
 }): Promise<void> {
   const tally = computeRunTally(report);
-  process.stderr.write(tCli(report.reportKind === 'batch-evaluation' ? 'cli.run.batch_complete' : 'cli.run.eval_complete', lang));
+  process.stderr.write(tCli(report.kind === 'batch-evaluation' ? 'cli.run.batch_complete' : 'cli.run.eval_complete', lang));
   process.stderr.write(tCli('cli.run.tally', lang, tally));
   process.stderr.write(tCli('cli.run.report_saved', lang, { path: filePath }));
 

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -106,6 +106,7 @@ function batchItemFallbackReport(
 ): EvaluationReport {
   return {
     reportKind: 'evaluation',
+    kind: 'evaluation',
     id: item.reportId,
     meta: {
       ...batch.meta,

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -12,6 +12,7 @@ import type { BatchEvaluationReport, EvaluationReport, Report, ProgressCallback 
 import type { DryRunBatchReport, DryRunReport } from '../../../eval-workflows/run-evaluation.js';
 import type { EvalResult, ReportServer } from '../../lib/shared.js';
 import { DEFAULT_BOOTSTRAP_SAMPLES } from '../../../eval-core/bootstrap.js';
+import { EVALUATION_REPORT_SCHEMA_VERSION } from '../../../eval-core/evaluation-reporting.js';
 
 // oclif 版 eval(默认 = run 模式) — 单次 typed parse 之后业务 inline。flag schema
 // 镜像 RUN_OPTIONS + eval-runner extra = 41 flag。具体语义跟约束在 parseRunConfig 里。
@@ -112,9 +113,9 @@ function batchItemFallbackReport(
       variants: ['baseline', item.name],
       sampleCount: item.sampleCount,
       totalCostUSD: item.totalCostUSD,
-      // item.artifactHash 来自子报告(走 aggregateReport 的整树哈),故 fallback 与之一致标 schemaVersion 3,
-      // 避免「树哈 artifactHashes + 错位 schemaVersion」的错配。
-      schemaVersion: 3,
+      // item.artifactHash 来自子报告(走 aggregateReport 的整树哈),故 fallback 与之一致标当前 eval
+      // report schemaVersion,避免「树哈 artifactHashes + 错位 schemaVersion」的错配。
+      schemaVersion: EVALUATION_REPORT_SCHEMA_VERSION,
       artifactHashes: item.artifactHash ? { [item.name]: item.artifactHash } : {},
     },
     summary: item.summary,

--- a/src/cli/lib/run-tally.ts
+++ b/src/cli/lib/run-tally.ts
@@ -21,7 +21,7 @@ export function computeRunTally(report: ReportDocument): { passed: number; faile
       failed += s.errorCount;
     }
   };
-  if (report.reportKind === 'batch-evaluation') {
+  if (report.kind === 'batch-evaluation') {
     for (const item of report.items) accumulate(item.summary);
   } else {
     accumulate(report.summary);

--- a/src/cli/lib/shared.ts
+++ b/src/cli/lib/shared.ts
@@ -16,7 +16,7 @@ export function requireEvaluationReport(report: ReportDocument | null, id: strin
     console.error(tCli('cli.common.report_not_found', lang, { id }));
     throw new CliExit(1);
   }
-  if (report.reportKind === 'batch-evaluation') {
+  if (report.kind === 'batch-evaluation') {
     console.error(lang === 'zh'
       ? `报告 ${id} 是 BatchEvaluationReport。该命令需要单次 EvaluationReport；请使用其中的 child reportId。`
       : `Report ${id} is a BatchEvaluationReport. This command requires an EvaluationReport; use a child reportId from the batch.`);

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -255,7 +255,7 @@ export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
       : 'passed';
 
   return {
-    reportKind: 'doctor',
+    kind: 'doctor',
     schemaVersion: DOCTOR_REPORT_SCHEMA_VERSION,
     id: nextReportId(),
     timestamp: new Date().toISOString(),

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -263,7 +263,6 @@ export function aggregateReport({
     variant.execCostReported !== false && variant.judgeCostReported !== false);
 
   return {
-    reportKind: 'evaluation',
     kind: 'evaluation',
     id: runId,
     meta: {

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -279,9 +279,9 @@ export function aggregateReport({
       cliVersion: getCliVersion(),
       nodeVersion: process.version,
       // schemaVersion 3 起,所有 dir-skill(本地 + git)都经隔离副本物化、整棵可分发树哈,与 install
-      // 受管记录 contentHash 同空间(evidence 全绑)。4 延续 v3 的哈/绑定义,但把顶层判别字段
-      // 从 reportKind 统一为 kind,方便外部消费方按版本识别 JSON 形状。2 是过渡纪元(本地
-      // dir-skill 树哈、git dir-skill 仅 SKILL.md 字节、不绑);git dir-skill 的 v2 与 v3+ 不可比。
+      // 受管记录 contentHash 同空间(evidence 全绑)。4 延续 v3 的哈/绑定义,并作为当前 canonical
+      // 顶层判别字段纪元,方便外部消费方按版本识别 JSON 形状。2 是过渡纪元(本地 dir-skill 树哈、
+      // git dir-skill 仅 SKILL.md 字节、不绑);git dir-skill 的 v2 与 v3+ 不可比。
       schemaVersion: EVALUATION_REPORT_SCHEMA_VERSION,
       artifactHashes,
       sampleHashes,

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -264,6 +264,7 @@ export function aggregateReport({
 
   return {
     reportKind: 'evaluation',
+    kind: 'evaluation',
     id: runId,
     meta: {
       variants,

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -43,6 +43,7 @@ function findPackageJson(startDir: string): string {
 const PKG: { version: string } = JSON.parse(readFileSync(findPackageJson(__dirname), 'utf-8')) as { version: string };
 
 export const DEFAULT_OUTPUT_DIR: string = join(homedir(), '.oh-my-knowledge', 'reports');
+export const EVALUATION_REPORT_SCHEMA_VERSION = 4;
 
 export function hashString(str: string): string {
   return createHash('sha256').update(str).digest('hex').slice(0, 12);
@@ -278,9 +279,10 @@ export function aggregateReport({
       cliVersion: getCliVersion(),
       nodeVersion: process.version,
       // schemaVersion 3 起,所有 dir-skill(本地 + git)都经隔离副本物化、整棵可分发树哈,与 install
-      // 受管记录 contentHash 同空间(evidence 全绑)。2 是过渡纪元(本地 dir-skill 树哈、git dir-skill
-      // 仅 SKILL.md 字节、不绑);git dir-skill 的 v2 与 v3 不可比。作判别位:消费方对缺位/旧报告不错配比对。
-      schemaVersion: 3,
+      // 受管记录 contentHash 同空间(evidence 全绑)。4 延续 v3 的哈/绑定义,但把顶层判别字段
+      // 从 reportKind 统一为 kind,方便外部消费方按版本识别 JSON 形状。2 是过渡纪元(本地
+      // dir-skill 树哈、git dir-skill 仅 SKILL.md 字节、不绑);git dir-skill 的 v2 与 v3+ 不可比。
+      schemaVersion: EVALUATION_REPORT_SCHEMA_VERSION,
       artifactHashes,
       sampleHashes,
       ...(noJudge ? {} : { judgePromptHash: getJudgePromptHash(lengthDebiasOn) }),

--- a/src/eval-workflows/batch-evaluation-workflow.ts
+++ b/src/eval-workflows/batch-evaluation-workflow.ts
@@ -264,6 +264,7 @@ export function buildBatchEvaluationReport({
 
   const report: BatchEvaluationReport = {
     reportKind: 'batch-evaluation',
+    kind: 'batch-evaluation',
     id: batchRunId,
     mode: 'skill',
     meta: {

--- a/src/eval-workflows/batch-evaluation-workflow.ts
+++ b/src/eval-workflows/batch-evaluation-workflow.ts
@@ -1,5 +1,12 @@
 import { dirname } from 'node:path';
-import { DEFAULT_OUTPUT_DIR, generateRunId, getCliVersion, getGitInfo, persistReport } from '../eval-core/evaluation-reporting.js';
+import {
+  DEFAULT_OUTPUT_DIR,
+  EVALUATION_REPORT_SCHEMA_VERSION,
+  generateRunId,
+  getCliVersion,
+  getGitInfo,
+  persistReport,
+} from '../eval-core/evaluation-reporting.js';
 import { buildEvaluationRequest, createEvaluationRun, createSucceededJob, finalizeEvaluationRun } from '../eval-core/evaluation-job.js';
 import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
 import { createFileJobStore, DEFAULT_JOBS_DIR } from '../server/job-store.js';
@@ -268,6 +275,7 @@ export function buildBatchEvaluationReport({
     mode: 'skill',
     meta: {
       mode: 'skill',
+      schemaVersion: EVALUATION_REPORT_SCHEMA_VERSION,
       model,
       executor: executorName,
       skillDir,

--- a/src/eval-workflows/batch-evaluation-workflow.ts
+++ b/src/eval-workflows/batch-evaluation-workflow.ts
@@ -263,7 +263,6 @@ export function buildBatchEvaluationReport({
   }));
 
   const report: BatchEvaluationReport = {
-    reportKind: 'batch-evaluation',
     kind: 'batch-evaluation',
     id: batchRunId,
     mode: 'skill',

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -291,7 +291,7 @@ export async function runEvaluation({
     const { createFileStore } = await import('../server/report-store.js');
     const store = createFileStore(resolve(outputDir || DEFAULT_OUTPUT_DIR));
     const existing = await store.get(resume);
-    if (existing?.reportKind === 'evaluation') {
+    if (existing?.kind === 'evaluation') {
       existingResults = {};
       for (const entry of existing.results || []) {
         existingResults[entry.sample_id] = entry.variants;
@@ -317,7 +317,7 @@ export async function runEvaluation({
           + `   新 entries 不隔离 → 与现有 entries 不可比。建议恢复默认 strict-baseline。\n`,
         );
       }
-    } else if (existing?.reportKind === 'batch-evaluation') {
+    } else if (existing?.kind === 'batch-evaluation') {
       process.stderr.write(`\n⚠️  report ${resume} is a BatchEvaluationReport; resume needs a child EvaluationReport, starting from scratch\n`);
     } else {
       process.stderr.write(`\n⚠️  report ${resume} not found, starting from scratch\n`);

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -341,11 +341,7 @@ export function buildObservationExperienceReport(input: BuildExperienceInput): O
 export function normalizeObservationExperienceReport(value: unknown): ObservationExperienceReport | null {
   if (!value || typeof value !== 'object') return null;
   const report = value as Record<string, unknown>;
-  const kind = report.kind === 'observe-experience'
-    ? report.kind
-    : report.reportKind === 'observe-experience'
-      ? report.reportKind
-      : null;
+  const kind = report.kind === 'observe-experience' ? report.kind : null;
   if (!kind) return null;
   if (report.schemaVersion !== 1 && report.schemaVersion !== 2) return null;
   if (report.scope !== 'evidence-only') return null;

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -318,7 +318,7 @@ export function buildObservationExperienceReport(input: BuildExperienceInput): O
   const skills = summarizeExperienceSkills(sessions, invocations);
 
   return {
-    reportKind: 'observe-experience',
+    kind: 'observe-experience',
     schemaVersion: 1,
     scope: 'evidence-only',
     generatedAt: input.generatedAt,

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -176,6 +176,8 @@ export type {
   ObservationReviewState,
 };
 
+export const OBSERVATION_EXPERIENCE_SCHEMA_VERSION = 2;
+
 export function aggregateExperienceChecklistItemStatus(statuses: ExperienceChecklistItemStatus[]): ExperienceChecklistItemStatus {
   if (statuses.includes('degraded')) return 'degraded';
   if (statuses.includes('failed')) return 'failed';
@@ -319,7 +321,7 @@ export function buildObservationExperienceReport(input: BuildExperienceInput): O
 
   return {
     kind: 'observe-experience',
-    schemaVersion: 1,
+    schemaVersion: OBSERVATION_EXPERIENCE_SCHEMA_VERSION,
     scope: 'evidence-only',
     generatedAt: input.generatedAt,
     meta: {
@@ -333,6 +335,34 @@ export function buildObservationExperienceReport(input: BuildExperienceInput): O
     invocations,
     sessions,
     skills,
+  };
+}
+
+export function normalizeObservationExperienceReport(value: unknown): ObservationExperienceReport | null {
+  if (!value || typeof value !== 'object') return null;
+  const report = value as Record<string, unknown>;
+  const kind = report.kind === 'observe-experience'
+    ? report.kind
+    : report.reportKind === 'observe-experience'
+      ? report.reportKind
+      : null;
+  if (!kind) return null;
+  if (report.schemaVersion !== 1 && report.schemaVersion !== 2) return null;
+  if (report.scope !== 'evidence-only') return null;
+  if (typeof report.generatedAt !== 'string' || !report.meta || typeof report.meta !== 'object') return null;
+  if (!Array.isArray(report.goalSlices) || !Array.isArray(report.invocations) || !Array.isArray(report.sessions) || !Array.isArray(report.skills)) {
+    return null;
+  }
+  return {
+    kind: 'observe-experience',
+    schemaVersion: OBSERVATION_EXPERIENCE_SCHEMA_VERSION,
+    scope: 'evidence-only',
+    generatedAt: report.generatedAt,
+    meta: report.meta as ObservationExperienceReport['meta'],
+    goalSlices: report.goalSlices as ObservationExperienceReport['goalSlices'],
+    invocations: report.invocations as ObservationExperienceReport['invocations'],
+    sessions: report.sessions as ObservationExperienceReport['sessions'],
+    skills: report.skills as ObservationExperienceReport['skills'],
   };
 }
 

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -343,7 +343,7 @@ export function normalizeObservationExperienceReport(value: unknown): Observatio
   const report = value as Record<string, unknown>;
   const kind = report.kind === 'observe-experience' ? report.kind : null;
   if (!kind) return null;
-  if (report.schemaVersion !== 1 && report.schemaVersion !== 2) return null;
+  if (report.schemaVersion !== OBSERVATION_EXPERIENCE_SCHEMA_VERSION) return null;
   if (report.scope !== 'evidence-only') return null;
   if (typeof report.generatedAt !== 'string' || !report.meta || typeof report.meta !== 'object') return null;
   if (!Array.isArray(report.goalSlices) || !Array.isArray(report.invocations) || !Array.isArray(report.sessions) || !Array.isArray(report.skills)) {

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -595,11 +595,7 @@ export function loadObservationInboxReports(dir: string = DEFAULT_OBSERVATIONS_D
 function normalizeObservationInboxReport(value: unknown): ObservationInboxReport | null {
   if (!value || typeof value !== 'object') return null;
   const report = value as Record<string, unknown>;
-  const kind = report.kind === 'observe-inbox'
-    ? report.kind
-    : report.reportKind === 'observe-inbox'
-      ? report.reportKind
-      : null;
+  const kind = report.kind === 'observe-inbox' ? report.kind : null;
   if (!kind) return null;
   if (report.schemaVersion !== 1 && report.schemaVersion !== 2) return null;
   if (!report.meta || typeof report.meta !== 'object' || !Array.isArray(report.items)) return null;

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -443,7 +443,7 @@ export function buildObservationInboxReport(tracePath: string, options: BuildObs
   const items = finishInboxAggregation(aggregationState);
   const experience = buildObservationExperienceReport({ sessions, segments, items, generatedAt, reviewState: options.reviewState });
   const report: ObservationInboxReport = {
-    reportKind: 'observe-inbox',
+    kind: 'observe-inbox',
     schemaVersion: 1,
     meta: {
       tracePath,
@@ -584,7 +584,7 @@ export function loadObservationInboxReports(dir: string = DEFAULT_OBSERVATIONS_D
         return null;
       }
     })
-    .filter((r): r is ObservationInboxReport => r?.reportKind === 'observe-inbox');
+    .filter((r): r is ObservationInboxReport => r?.kind === 'observe-inbox');
 }
 
 export function loadLatestObservationInboxReport(dir: string = DEFAULT_OBSERVATIONS_DIR): ObservationInboxReport | null {

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -22,7 +22,10 @@ import { extractGapSignalsFromTrace } from '../analysis/gap-analyzer.js';
 import { ccTracesToResultEntries, type CcSession, type SkillSegment } from './trace-adapter.js';
 import { isSearchToolCall, toolCallQuery } from '../shared/tool-search.js';
 import { durationMsBetween } from '../shared/time.js';
-import { buildObservationExperienceReport } from './experience.js';
+import {
+  buildObservationExperienceReport,
+  normalizeObservationExperienceReport,
+} from './experience.js';
 
 export type {
   BuildObservationInboxReportOptions,
@@ -42,6 +45,7 @@ export type {
 export const DEFAULT_PROJECT_OBSERVATIONS_DIR = join(process.cwd(), '.omk', 'observations');
 export const DEFAULT_GLOBAL_OBSERVATIONS_DIR = join(homedir(), '.oh-my-knowledge', 'observations');
 export const DEFAULT_OBSERVATIONS_DIR = DEFAULT_PROJECT_OBSERVATIONS_DIR;
+const OBSERVATION_INBOX_SCHEMA_VERSION = 2;
 
 function hashString(input: string): string {
   return createHash('sha256').update(input).digest('hex').slice(0, 16);
@@ -444,7 +448,7 @@ export function buildObservationInboxReport(tracePath: string, options: BuildObs
   const experience = buildObservationExperienceReport({ sessions, segments, items, generatedAt, reviewState: options.reviewState });
   const report: ObservationInboxReport = {
     kind: 'observe-inbox',
-    schemaVersion: 1,
+    schemaVersion: OBSERVATION_INBOX_SCHEMA_VERSION,
     meta: {
       tracePath,
       generatedAt,
@@ -561,7 +565,8 @@ export function loadObservationInboxReports(dir: string = DEFAULT_OBSERVATIONS_D
     .filter((file) => file.endsWith('-observe-inbox.json'))
     .map((file) => {
       try {
-        const report = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as ObservationInboxReport;
+        const report = normalizeObservationInboxReport(JSON.parse(readFileSync(join(dir, file), 'utf-8')));
+        if (!report) return null;
         report.items = report.items.map((item) => {
           const sourceKind = (item as { sourceKind?: string }).sourceKind;
           return {
@@ -585,6 +590,30 @@ export function loadObservationInboxReports(dir: string = DEFAULT_OBSERVATIONS_D
       }
     })
     .filter((r): r is ObservationInboxReport => r?.kind === 'observe-inbox');
+}
+
+function normalizeObservationInboxReport(value: unknown): ObservationInboxReport | null {
+  if (!value || typeof value !== 'object') return null;
+  const report = value as Record<string, unknown>;
+  const kind = report.kind === 'observe-inbox'
+    ? report.kind
+    : report.reportKind === 'observe-inbox'
+      ? report.reportKind
+      : null;
+  if (!kind) return null;
+  if (report.schemaVersion !== 1 && report.schemaVersion !== 2) return null;
+  if (!report.meta || typeof report.meta !== 'object' || !Array.isArray(report.items)) return null;
+  const experience = report.experience === undefined
+    ? undefined
+    : normalizeObservationExperienceReport(report.experience) ?? undefined;
+  return {
+    kind: 'observe-inbox',
+    schemaVersion: OBSERVATION_INBOX_SCHEMA_VERSION,
+    meta: report.meta as ObservationInboxReport['meta'],
+    items: report.items as ObservationInboxReport['items'],
+    ...(experience ? { experience } : {}),
+    ...(report.diagnostics !== undefined ? { diagnostics: report.diagnostics as ObservationInboxReport['diagnostics'] } : {}),
+  };
 }
 
 export function loadLatestObservationInboxReport(dir: string = DEFAULT_OBSERVATIONS_DIR): ObservationInboxReport | null {

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -597,7 +597,7 @@ function normalizeObservationInboxReport(value: unknown): ObservationInboxReport
   const report = value as Record<string, unknown>;
   const kind = report.kind === 'observe-inbox' ? report.kind : null;
   if (!kind) return null;
-  if (report.schemaVersion !== 1 && report.schemaVersion !== 2) return null;
+  if (report.schemaVersion !== OBSERVATION_INBOX_SCHEMA_VERSION) return null;
   if (!report.meta || typeof report.meta !== 'object' || !Array.isArray(report.items)) return null;
   const experience = report.experience === undefined
     ? undefined

--- a/src/observability/review-state.ts
+++ b/src/observability/review-state.ts
@@ -133,11 +133,7 @@ export function updateObservationReviewState(
 function normalizeObservationReviewState(value: unknown): ObservationReviewState | null {
   if (!value || typeof value !== 'object') return null;
   const parsed = value as Record<string, unknown>;
-  const kind = parsed.kind === 'observe-review-state'
-    ? parsed.kind
-    : parsed.reportKind === 'observe-review-state'
-      ? parsed.reportKind
-      : null;
+  const kind = parsed.kind === 'observe-review-state' ? parsed.kind : null;
   if (!kind) return null;
   if (parsed.schemaVersion !== 1 && parsed.schemaVersion !== 2) return null;
   if (!parsed.entries || typeof parsed.entries !== 'object') return null;

--- a/src/observability/review-state.ts
+++ b/src/observability/review-state.ts
@@ -77,10 +77,12 @@ export function observationReviewStatePath(observationsDir: string): string {
   return join(observationsDir, 'review-state.json');
 }
 
+const OBSERVATION_REVIEW_STATE_SCHEMA_VERSION = 2;
+
 export function emptyObservationReviewState(now = new Date().toISOString()): ObservationReviewState {
   return {
     kind: 'observe-review-state',
-    schemaVersion: 1,
+    schemaVersion: OBSERVATION_REVIEW_STATE_SCHEMA_VERSION,
     updatedAt: now,
     entries: {},
   };
@@ -90,18 +92,8 @@ export function loadObservationReviewState(observationsDir: string): Observation
   const path = observationReviewStatePath(observationsDir);
   if (!existsSync(path)) return emptyObservationReviewState();
   try {
-    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<ObservationReviewState>;
-    if (parsed.kind !== 'observe-review-state' || parsed.schemaVersion !== 1 || !parsed.entries || typeof parsed.entries !== 'object') {
-      return emptyObservationReviewState();
-    }
-    return {
-      kind: 'observe-review-state',
-      schemaVersion: 1,
-      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
-      entries: Object.fromEntries(
-        Object.entries(parsed.entries).filter(([, entry]) => isReviewStateEntry(entry)),
-      ),
-    };
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
+    return normalizeObservationReviewState(parsed) ?? emptyObservationReviewState();
   } catch {
     return emptyObservationReviewState();
   }
@@ -136,6 +128,27 @@ export function updateObservationReviewState(
   mkdirSync(observationsDir, { recursive: true });
   writeFileSync(observationReviewStatePath(observationsDir), JSON.stringify(state, null, 2));
   return state;
+}
+
+function normalizeObservationReviewState(value: unknown): ObservationReviewState | null {
+  if (!value || typeof value !== 'object') return null;
+  const parsed = value as Record<string, unknown>;
+  const kind = parsed.kind === 'observe-review-state'
+    ? parsed.kind
+    : parsed.reportKind === 'observe-review-state'
+      ? parsed.reportKind
+      : null;
+  if (!kind) return null;
+  if (parsed.schemaVersion !== 1 && parsed.schemaVersion !== 2) return null;
+  if (!parsed.entries || typeof parsed.entries !== 'object') return null;
+  return {
+    kind: 'observe-review-state',
+    schemaVersion: OBSERVATION_REVIEW_STATE_SCHEMA_VERSION,
+    updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
+    entries: Object.fromEntries(
+      Object.entries(parsed.entries).filter(([, entry]) => isReviewStateEntry(entry)),
+    ),
+  };
 }
 
 export function deleteObservationReviewState(

--- a/src/observability/review-state.ts
+++ b/src/observability/review-state.ts
@@ -135,7 +135,7 @@ function normalizeObservationReviewState(value: unknown): ObservationReviewState
   const parsed = value as Record<string, unknown>;
   const kind = parsed.kind === 'observe-review-state' ? parsed.kind : null;
   if (!kind) return null;
-  if (parsed.schemaVersion !== 1 && parsed.schemaVersion !== 2) return null;
+  if (parsed.schemaVersion !== OBSERVATION_REVIEW_STATE_SCHEMA_VERSION) return null;
   if (!parsed.entries || typeof parsed.entries !== 'object') return null;
   return {
     kind: 'observe-review-state',

--- a/src/observability/review-state.ts
+++ b/src/observability/review-state.ts
@@ -79,7 +79,7 @@ export function observationReviewStatePath(observationsDir: string): string {
 
 export function emptyObservationReviewState(now = new Date().toISOString()): ObservationReviewState {
   return {
-    reportKind: 'observe-review-state',
+    kind: 'observe-review-state',
     schemaVersion: 1,
     updatedAt: now,
     entries: {},
@@ -91,11 +91,11 @@ export function loadObservationReviewState(observationsDir: string): Observation
   if (!existsSync(path)) return emptyObservationReviewState();
   try {
     const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<ObservationReviewState>;
-    if (parsed.reportKind !== 'observe-review-state' || parsed.schemaVersion !== 1 || !parsed.entries || typeof parsed.entries !== 'object') {
+    if (parsed.kind !== 'observe-review-state' || parsed.schemaVersion !== 1 || !parsed.entries || typeof parsed.entries !== 'object') {
       return emptyObservationReviewState();
     }
     return {
-      reportKind: 'observe-review-state',
+      kind: 'observe-review-state',
       schemaVersion: 1,
       updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
       entries: Object.fromEntries(

--- a/src/observability/soft-standards/llm-extractor.ts
+++ b/src/observability/soft-standards/llm-extractor.ts
@@ -91,7 +91,7 @@ export async function extractSkillSoftStandards(options: ExtractSkillSoftStandar
     source: 'llm_soft_standard' as const,
   }));
   const record: SkillDerivedStandards = {
-    reportKind: 'observe-skill-derived-standards',
+    kind: 'observe-skill-derived-standards',
     schemaVersion: 1,
     skillName: skillChain.skillName,
     sourceSkillPath: skillChain.definition.path,

--- a/src/observability/soft-standards/llm-extractor.ts
+++ b/src/observability/soft-standards/llm-extractor.ts
@@ -16,6 +16,7 @@ import {
   hashText,
   loadExisting,
   markStale,
+  SKILL_DERIVED_STANDARDS_SCHEMA_VERSION,
   skillDerivedStandardsDir,
   skillDerivedStandardsPath,
 } from './skill-standards-store.js';
@@ -92,7 +93,7 @@ export async function extractSkillSoftStandards(options: ExtractSkillSoftStandar
   }));
   const record: SkillDerivedStandards = {
     kind: 'observe-skill-derived-standards',
-    schemaVersion: 1,
+    schemaVersion: SKILL_DERIVED_STANDARDS_SCHEMA_VERSION,
     skillName: skillChain.skillName,
     sourceSkillPath: skillChain.definition.path,
     sourceHash,

--- a/src/observability/soft-standards/skill-standards-store.ts
+++ b/src/observability/soft-standards/skill-standards-store.ts
@@ -156,7 +156,7 @@ function normalizeSkillDerivedStandards(value: unknown): SkillDerivedStandards |
   const item = value as Record<string, unknown>;
   const kind = item.kind === 'observe-skill-derived-standards' ? item.kind : null;
   if (!kind) return undefined;
-  if (item.schemaVersion !== 1 && item.schemaVersion !== 2) return undefined;
+  if (item.schemaVersion !== SKILL_DERIVED_STANDARDS_SCHEMA_VERSION) return undefined;
   if (typeof item.skillName !== 'string' || typeof item.generatedAt !== 'string' || typeof item.model !== 'string' || typeof item.executor !== 'string') {
     return undefined;
   }

--- a/src/observability/soft-standards/skill-standards-store.ts
+++ b/src/observability/soft-standards/skill-standards-store.ts
@@ -154,11 +154,7 @@ export function isSkillDerivedStandards(value: unknown): value is SkillDerivedSt
 function normalizeSkillDerivedStandards(value: unknown): SkillDerivedStandards | undefined {
   if (!value || typeof value !== 'object') return undefined;
   const item = value as Record<string, unknown>;
-  const kind = item.kind === 'observe-skill-derived-standards'
-    ? item.kind
-    : item.reportKind === 'observe-skill-derived-standards'
-      ? item.reportKind
-      : null;
+  const kind = item.kind === 'observe-skill-derived-standards' ? item.kind : null;
   if (!kind) return undefined;
   if (item.schemaVersion !== 1 && item.schemaVersion !== 2) return undefined;
   if (typeof item.skillName !== 'string' || typeof item.generatedAt !== 'string' || typeof item.model !== 'string' || typeof item.executor !== 'string') {

--- a/src/observability/soft-standards/skill-standards-store.ts
+++ b/src/observability/soft-standards/skill-standards-store.ts
@@ -7,9 +7,12 @@ import type {
   ResolvedSkillStandard,
   ResolvedSkillStandardKind,
   ResolvedSkillStandards,
+  SkillDerivedStandard,
   SkillDerivedStandardStatus,
   SkillDerivedStandards,
 } from './types.js';
+
+export const SKILL_DERIVED_STANDARDS_SCHEMA_VERSION = 2;
 
 export function skillDerivedStandardsDir(observationsDir: string): string {
   return join(observationsDir, 'skill-derived');
@@ -26,8 +29,8 @@ export function loadSkillDerivedStandards(observationsDir: string): Record<strin
   for (const file of readdirSync(dir)) {
     if (!file.endsWith('.json')) continue;
     try {
-      const parsed = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as SkillDerivedStandards;
-      if (isSkillDerivedStandards(parsed)) out[parsed.skillName] = parsed;
+      const parsed = normalizeSkillDerivedStandards(JSON.parse(readFileSync(join(dir, file), 'utf-8')));
+      if (parsed) out[parsed.skillName] = parsed;
     } catch {
       // Ignore broken cache files; the extraction command can refresh them.
     }
@@ -63,11 +66,13 @@ export function updateSkillDerivedStandardStatus(
 
 export function resolveSkillStandards(skillName: string, options: ResolveSkillStandardsOptions): ResolvedSkillStandards {
   const skillChain = options.skillChain ?? buildObservationSkillChain(skillName, options.cwd ?? process.cwd());
-  const derived = options.derivedStandards
-    ? isSkillDerivedStandards(options.derivedStandards)
-      ? options.derivedStandards
-      : options.derivedStandards[skillName]
-    : loadSkillDerivedStandards(options.observationsDir)[skillName];
+  const directDerived = normalizeSkillDerivedStandards(options.derivedStandards);
+  const mappedDerived = options.derivedStandards && !isSkillDerivedStandards(options.derivedStandards)
+    ? normalizeSkillDerivedStandards(options.derivedStandards[skillName])
+    : undefined;
+  const derived = directDerived
+    ?? mappedDerived
+    ?? loadSkillDerivedStandards(options.observationsDir)[skillName];
   const active: ResolvedSkillStandard[] = [];
   const candidates: ResolvedSkillStandard[] = [];
   const hasFrontmatterHardRules = skillChain.healthCheck.hardRules.declared && skillChain.healthCheck.hardRules.rules.length > 0;
@@ -126,8 +131,7 @@ export function resolveSkillStandards(skillName: string, options: ResolveSkillSt
 export function loadExisting(path: string): SkillDerivedStandards | undefined {
   if (!existsSync(path)) return undefined;
   try {
-    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as SkillDerivedStandards;
-    return isSkillDerivedStandards(parsed) ? parsed : undefined;
+    return normalizeSkillDerivedStandards(JSON.parse(readFileSync(path, 'utf-8')));
   } catch {
     return undefined;
   }
@@ -144,12 +148,70 @@ export function markStale(record: SkillDerivedStandards, generatedAt: string): S
 }
 
 export function isSkillDerivedStandards(value: unknown): value is SkillDerivedStandards {
-  if (!value || typeof value !== 'object') return false;
-  const item = value as Partial<SkillDerivedStandards>;
-  return item.kind === 'observe-skill-derived-standards'
-    && item.schemaVersion === 1
-    && typeof item.skillName === 'string'
-    && Array.isArray(item.standards);
+  return normalizeSkillDerivedStandards(value) !== undefined;
+}
+
+function normalizeSkillDerivedStandards(value: unknown): SkillDerivedStandards | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const item = value as Record<string, unknown>;
+  const kind = item.kind === 'observe-skill-derived-standards'
+    ? item.kind
+    : item.reportKind === 'observe-skill-derived-standards'
+      ? item.reportKind
+      : null;
+  if (!kind) return undefined;
+  if (item.schemaVersion !== 1 && item.schemaVersion !== 2) return undefined;
+  if (typeof item.skillName !== 'string' || typeof item.generatedAt !== 'string' || typeof item.model !== 'string' || typeof item.executor !== 'string') {
+    return undefined;
+  }
+  if (typeof item.promptId !== 'string' || typeof item.promptVersion !== 'string' || !Array.isArray(item.standards)) return undefined;
+  const standards = item.standards
+    .map(normalizeSkillDerivedStandard)
+    .filter((record): record is SkillDerivedStandard => record !== null);
+  return {
+    kind: 'observe-skill-derived-standards',
+    schemaVersion: SKILL_DERIVED_STANDARDS_SCHEMA_VERSION,
+    skillName: item.skillName,
+    ...(typeof item.sourceSkillPath === 'string' ? { sourceSkillPath: item.sourceSkillPath } : {}),
+    ...(typeof item.sourceHash === 'string' ? { sourceHash: item.sourceHash } : {}),
+    generatedAt: item.generatedAt,
+    model: item.model,
+    executor: item.executor,
+    promptId: item.promptId as SkillDerivedStandards['promptId'],
+    promptVersion: item.promptVersion as SkillDerivedStandards['promptVersion'],
+    ...(typeof item.promptHash === 'string' ? { promptHash: item.promptHash } : {}),
+    ...(typeof item.runtimeEvidenceHash === 'string' ? { runtimeEvidenceHash: item.runtimeEvidenceHash } : {}),
+    ...(item.enhancedReview && typeof item.enhancedReview === 'object' ? { enhancedReview: item.enhancedReview as SkillDerivedStandards['enhancedReview'] } : {}),
+    standards,
+  };
+}
+
+function normalizeSkillDerivedStandard(value: unknown): SkillDerivedStandard | null {
+  if (!value || typeof value !== 'object') return null;
+  const item = value as Record<string, unknown>;
+  const standardKind = item.standardKind === 'hard_rule_candidate' || item.standardKind === 'workflow_candidate'
+    ? item.standardKind
+    : item.kind === 'hard_rule_candidate' || item.kind === 'workflow_candidate'
+      ? item.kind
+      : null;
+  if (!standardKind) return null;
+  if (typeof item.id !== 'string' || typeof item.title !== 'string' || typeof item.body !== 'string') return null;
+  if (item.status !== 'pending_review' && item.status !== 'author_confirmed' && item.status !== 'rejected' && item.status !== 'stale') {
+    return null;
+  }
+  if (item.source !== 'llm_soft_standard') return null;
+  if (item.confidence !== 'low' && item.confidence !== 'medium' && item.confidence !== 'high') return null;
+  if (!Array.isArray(item.evidence) || item.evidence.some((entry) => typeof entry !== 'string')) return null;
+  return {
+    id: item.id,
+    standardKind,
+    status: item.status,
+    title: item.title,
+    body: item.body,
+    source: item.source,
+    confidence: item.confidence,
+    evidence: item.evidence,
+  };
 }
 
 function candidateRank(status?: SkillDerivedStandardStatus): number {

--- a/src/observability/soft-standards/skill-standards-store.ts
+++ b/src/observability/soft-standards/skill-standards-store.ts
@@ -146,7 +146,7 @@ export function markStale(record: SkillDerivedStandards, generatedAt: string): S
 export function isSkillDerivedStandards(value: unknown): value is SkillDerivedStandards {
   if (!value || typeof value !== 'object') return false;
   const item = value as Partial<SkillDerivedStandards>;
-  return item.reportKind === 'observe-skill-derived-standards'
+  return item.kind === 'observe-skill-derived-standards'
     && item.schemaVersion === 1
     && typeof item.skillName === 'string'
     && Array.isArray(item.standards);

--- a/src/observability/soft-standards/types.ts
+++ b/src/observability/soft-standards/types.ts
@@ -22,7 +22,7 @@ export interface SkillDerivedStandard {
 
 export interface SkillDerivedStandards {
   kind: 'observe-skill-derived-standards';
-  schemaVersion: 1;
+  schemaVersion: 2;
   skillName: string;
   sourceSkillPath?: string;
   sourceHash?: string;

--- a/src/observability/soft-standards/types.ts
+++ b/src/observability/soft-standards/types.ts
@@ -21,7 +21,7 @@ export interface SkillDerivedStandard {
 }
 
 export interface SkillDerivedStandards {
-  reportKind: 'observe-skill-derived-standards';
+  kind: 'observe-skill-derived-standards';
   schemaVersion: 1;
   skillName: string;
   sourceSkillPath?: string;

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -38,7 +38,7 @@ function levelDot(level: VerdictLevel): string {
 type RuntimeMeta = Pick<EvaluationReport['meta'], 'executorRuntime' | 'executorRuntimes' | 'judgeModels' | 'noJudge'>;
 
 function isEvaluationReport(document: ReportDocument): document is EvaluationReport {
-  return document.reportKind === 'evaluation';
+  return document.kind === 'evaluation';
 }
 
 function scoreOf(summary: VariantSummary | undefined): number | null {
@@ -184,7 +184,7 @@ export function renderRunList(runs: ReportDocument[], lang: Lang = DEFAULT_LANG)
   };
 
   const cards = runs.map((run) => {
-    if (run.reportKind === 'batch-evaluation') {
+    if (run.kind === 'batch-evaluation') {
       const m = run.meta;
       const scores = run.items.length > 0
         ? run.items.map((item) => {
@@ -686,7 +686,7 @@ export function renderBatchEvaluationDetail(report: BatchEvaluationReport | null
 
 export function renderReportDocumentDetail(report: ReportDocument | null, lang: Lang = DEFAULT_LANG): string {
   if (!report) return renderRunDetail(null, lang);
-  return report.reportKind === 'batch-evaluation'
+  return report.kind === 'batch-evaluation'
     ? renderBatchEvaluationDetail(report, lang)
     : renderRunDetail(report, lang);
 }

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -880,7 +880,7 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
         let evalReport = null;
         if (entry.eval) {
           const r = await reportStore.get(entry.eval.reportId);
-          if (r && r.reportKind === 'evaluation') evalReport = r;
+          if (r && r.kind === 'evaluation') evalReport = r;
         }
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         const insights = idx.insightsBySkill.get(skillName) ?? [];

--- a/src/server/report-store.ts
+++ b/src/server/report-store.ts
@@ -39,53 +39,52 @@ export function createFileStore(dir: string): ReportStore {
     }
   }
 
-  function withLegacyReportKind<T extends ReportDocument>(report: T): T {
-    return { ...report, kind: report.reportKind } as T;
-  }
-
   function normalizeReportDocument(data: unknown, fallbackId: string): ReportDocument | null {
     if (!data || typeof data !== 'object') return null;
     const record = data as Record<string, unknown>;
-    const reportKind = record.reportKind === 'evaluation' || record.reportKind === 'batch-evaluation'
-      ? record.reportKind
-      : record.kind === 'evaluation' || record.kind === 'batch-evaluation'
-        ? record.kind
+    const rest = { ...record };
+    delete rest.reportKind;
+    const kind = record.kind === 'evaluation' || record.kind === 'batch-evaluation'
+      ? record.kind
+      : record.reportKind === 'evaluation' || record.reportKind === 'batch-evaluation'
+        ? record.reportKind
         : undefined;
-    if (reportKind === 'evaluation') {
+    if (kind === 'evaluation') {
       if (!record.meta || !record.summary || !Array.isArray(record.results)) return null;
-      return withLegacyReportKind({
-        ...record,
-        reportKind,
+      return {
+        ...rest,
+        kind,
         id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
-      } as unknown as ReportDocument);
+      } as unknown as ReportDocument;
     }
-    if (reportKind === 'batch-evaluation') {
+    if (kind === 'batch-evaluation') {
       if (!record.meta || !Array.isArray(record.items)) return null;
-      return withLegacyReportKind({
-        ...record,
-        reportKind,
+      return {
+        ...rest,
+        kind,
         id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
-      } as unknown as ReportDocument);
+      } as unknown as ReportDocument;
     }
     if (
       record.kind === undefined
+      && record.reportKind === undefined
       && record.overview === undefined
       && record.artifacts === undefined
       && record.meta
       && record.summary
       && Array.isArray(record.results)
     ) {
-      return withLegacyReportKind({
-        ...record,
-        reportKind: 'evaluation',
+      return {
+        ...rest,
+        kind: 'evaluation',
         id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
-      } as unknown as ReportDocument);
+      } as unknown as ReportDocument;
     }
     return null;
   }
 
   function isEvaluationReport(report: ReportDocument): report is EvaluationReport {
-    return report.reportKind === 'evaluation';
+    return report.kind === 'evaluation';
   }
 
   // Studio 每个 / 和 /skills/<name> 请求都调 list(),里面对每个 .json 同步 readFile +
@@ -153,7 +152,7 @@ export function createFileStore(dir: string): ReportStore {
   async function save(id: string, report: ReportDocument): Promise<void> {
     await ensureDir();
     const tmpPath = join(dir, `${id}.json.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`);
-    await writeFile(tmpPath, JSON.stringify(withLegacyReportKind(report), null, 2));
+    await writeFile(tmpPath, JSON.stringify(report, null, 2));
     await rename(tmpPath, join(dir, `${id}.json`));
   }
 
@@ -247,9 +246,7 @@ export async function queryJob(jobStore: JobStore, id: string): Promise<Evaluati
 
 export interface RunListItem {
   id: string;
-  reportKind: ReportDocument['reportKind'];
-  /** Legacy wire alias kept for external consumers that still read run.kind. */
-  kind: ReportDocument['reportKind'];
+  kind: ReportDocument['kind'];
   meta: ReportDocument['meta'];
   summary?: EvaluationReport['summary'];
   items?: BatchEvaluationReport['items'];
@@ -275,10 +272,9 @@ export interface TrendQueryResult {
 export async function queryRunList(reportStore: ReportStore): Promise<RunListItem[]> {
   return (await reportStore.list()).map((report) => ({
     id: report.id,
-    reportKind: report.reportKind,
-    kind: report.reportKind,
+    kind: report.kind,
     meta: report.meta,
-    ...(report.reportKind === 'evaluation' ? { summary: report.summary } : { items: report.items }),
+    ...(report.kind === 'evaluation' ? { summary: report.summary } : { items: report.items }),
   }));
 }
 

--- a/src/server/report-store.ts
+++ b/src/server/report-store.ts
@@ -61,8 +61,8 @@ export function createFileStore(dir: string): ReportStore {
         id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
       } as unknown as ReportDocument;
     }
-    // 只认 canonical 顶层 `kind`(evaluation / batch-evaluation)。不再为旧格式(无判别字段 / 旧
-    // reportKind)做读兼容 —— 顶层 kind cutover 是硬切换,旧文件直接判脏丢弃。
+    // 只认 canonical 顶层 `kind`(evaluation / batch-evaluation)。不再为旧格式(顶层无该判别字段的
+    // 历史文件)做读兼容 —— 顶层 kind cutover 是硬切换,旧文件直接判脏丢弃。
     return null;
   }
 

--- a/src/server/report-store.ts
+++ b/src/server/report-store.ts
@@ -31,16 +31,6 @@ async function withLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
  * Create a file-system-based report store.
  */
 export function createFileStore(dir: string): ReportStore {
-  const LEGACY_EVALUATION_TOP_LEVEL_KEYS = new Set([
-    'id',
-    'meta',
-    'summary',
-    'results',
-    'sampleSnapshots',
-    'analysis',
-    'variance',
-  ]);
-
   async function ensureDir(): Promise<void> {
     try {
       await access(dir);
@@ -71,21 +61,8 @@ export function createFileStore(dir: string): ReportStore {
         id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
       } as unknown as ReportDocument;
     }
-    if (
-      record.kind === undefined
-      && record.overview === undefined
-      && record.artifacts === undefined
-      && record.meta
-      && record.summary
-      && Array.isArray(record.results)
-      && Object.keys(record).every((key) => LEGACY_EVALUATION_TOP_LEVEL_KEYS.has(key))
-    ) {
-      return {
-        ...record,
-        kind: 'evaluation',
-        id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
-      } as unknown as ReportDocument;
-    }
+    // 只认 canonical 顶层 `kind`(evaluation / batch-evaluation)。不再为旧格式(无判别字段 / 旧
+    // reportKind)做读兼容 —— 顶层 kind cutover 是硬切换,旧文件直接判脏丢弃。
     return null;
   }
 

--- a/src/server/report-store.ts
+++ b/src/server/report-store.ts
@@ -31,6 +31,16 @@ async function withLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
  * Create a file-system-based report store.
  */
 export function createFileStore(dir: string): ReportStore {
+  const LEGACY_EVALUATION_TOP_LEVEL_KEYS = new Set([
+    'id',
+    'meta',
+    'summary',
+    'results',
+    'sampleSnapshots',
+    'analysis',
+    'variance',
+  ]);
+
   async function ensureDir(): Promise<void> {
     try {
       await access(dir);
@@ -63,12 +73,12 @@ export function createFileStore(dir: string): ReportStore {
     }
     if (
       record.kind === undefined
-      && record.reportKind === undefined
       && record.overview === undefined
       && record.artifacts === undefined
       && record.meta
       && record.summary
       && Array.isArray(record.results)
+      && Object.keys(record).every((key) => LEGACY_EVALUATION_TOP_LEVEL_KEYS.has(key))
     ) {
       return {
         ...record,

--- a/src/server/report-store.ts
+++ b/src/server/report-store.ts
@@ -39,16 +39,33 @@ export function createFileStore(dir: string): ReportStore {
     }
   }
 
+  function withLegacyReportKind<T extends ReportDocument>(report: T): T {
+    return { ...report, kind: report.reportKind } as T;
+  }
+
   function normalizeReportDocument(data: unknown, fallbackId: string): ReportDocument | null {
     if (!data || typeof data !== 'object') return null;
     const record = data as Record<string, unknown>;
-    if (record.reportKind === 'evaluation') {
+    const reportKind = record.reportKind === 'evaluation' || record.reportKind === 'batch-evaluation'
+      ? record.reportKind
+      : record.kind === 'evaluation' || record.kind === 'batch-evaluation'
+        ? record.kind
+        : undefined;
+    if (reportKind === 'evaluation') {
       if (!record.meta || !record.summary || !Array.isArray(record.results)) return null;
-      return { ...record, id: typeof record.id === 'string' && record.id ? record.id : fallbackId } as unknown as ReportDocument;
+      return withLegacyReportKind({
+        ...record,
+        reportKind,
+        id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
+      } as unknown as ReportDocument);
     }
-    if (record.reportKind === 'batch-evaluation') {
+    if (reportKind === 'batch-evaluation') {
       if (!record.meta || !Array.isArray(record.items)) return null;
-      return { ...record, id: typeof record.id === 'string' && record.id ? record.id : fallbackId } as unknown as ReportDocument;
+      return withLegacyReportKind({
+        ...record,
+        reportKind,
+        id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
+      } as unknown as ReportDocument);
     }
     if (
       record.kind === undefined
@@ -58,11 +75,11 @@ export function createFileStore(dir: string): ReportStore {
       && record.summary
       && Array.isArray(record.results)
     ) {
-      return {
+      return withLegacyReportKind({
         ...record,
         reportKind: 'evaluation',
         id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
-      } as unknown as ReportDocument;
+      } as unknown as ReportDocument);
     }
     return null;
   }
@@ -136,7 +153,7 @@ export function createFileStore(dir: string): ReportStore {
   async function save(id: string, report: ReportDocument): Promise<void> {
     await ensureDir();
     const tmpPath = join(dir, `${id}.json.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`);
-    await writeFile(tmpPath, JSON.stringify(report, null, 2));
+    await writeFile(tmpPath, JSON.stringify(withLegacyReportKind(report), null, 2));
     await rename(tmpPath, join(dir, `${id}.json`));
   }
 
@@ -231,6 +248,8 @@ export async function queryJob(jobStore: JobStore, id: string): Promise<Evaluati
 export interface RunListItem {
   id: string;
   reportKind: ReportDocument['reportKind'];
+  /** Legacy wire alias kept for external consumers that still read run.kind. */
+  kind: ReportDocument['reportKind'];
   meta: ReportDocument['meta'];
   summary?: EvaluationReport['summary'];
   items?: BatchEvaluationReport['items'];
@@ -257,6 +276,7 @@ export async function queryRunList(reportStore: ReportStore): Promise<RunListIte
   return (await reportStore.list()).map((report) => ({
     id: report.id,
     reportKind: report.reportKind,
+    kind: report.reportKind,
     meta: report.meta,
     ...(report.reportKind === 'evaluation' ? { summary: report.summary } : { items: report.items }),
   }));

--- a/src/server/report-store.ts
+++ b/src/server/report-store.ts
@@ -42,17 +42,13 @@ export function createFileStore(dir: string): ReportStore {
   function normalizeReportDocument(data: unknown, fallbackId: string): ReportDocument | null {
     if (!data || typeof data !== 'object') return null;
     const record = data as Record<string, unknown>;
-    const rest = { ...record };
-    delete rest.reportKind;
     const kind = record.kind === 'evaluation' || record.kind === 'batch-evaluation'
       ? record.kind
-      : record.reportKind === 'evaluation' || record.reportKind === 'batch-evaluation'
-        ? record.reportKind
-        : undefined;
+      : undefined;
     if (kind === 'evaluation') {
       if (!record.meta || !record.summary || !Array.isArray(record.results)) return null;
       return {
-        ...rest,
+        ...record,
         kind,
         id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
       } as unknown as ReportDocument;
@@ -60,7 +56,7 @@ export function createFileStore(dir: string): ReportStore {
     if (kind === 'batch-evaluation') {
       if (!record.meta || !Array.isArray(record.items)) return null;
       return {
-        ...rest,
+        ...record,
         kind,
         id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
       } as unknown as ReportDocument;
@@ -75,7 +71,7 @@ export function createFileStore(dir: string): ReportStore {
       && Array.isArray(record.results)
     ) {
       return {
-        ...rest,
+        ...record,
         kind: 'evaluation',
         id: typeof record.id === 'string' && record.id ? record.id : fallbackId,
       } as unknown as ReportDocument;

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -134,7 +134,7 @@ function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, d
   // 每一段的 right-hand-side 从旧的 "{dir-mtime}-{file-count}" 双标量升级成
   // safeDirJsonContentFingerprint 返回的 "{dir-mtime}|{file1}:{m}:{s},..."
   // content-aware 字符串。
-  const reportIds = reports.map((r) => `${r.id}:${r.meta?.timestamp ?? ''}:${r.reportKind === 'evaluation' ? r.meta.evolve?.skillName ?? '' : ''}`).join(',');
+  const reportIds = reports.map((r) => `${r.id}:${r.meta?.timestamp ?? ''}:${r.kind === 'evaluation' ? r.meta.evolve?.skillName ?? '' : ''}`).join(',');
   const doctorsFp = safeDirJsonContentFingerprint(doctorsDir);
   const analysesFp = safeDirJsonContentFingerprint(analysesDir);
   const observationsFp = safeDirJsonContentFingerprint(observationsDir);
@@ -327,7 +327,7 @@ export function buildSkillIndex(
   // ── eval 聚合(历史 list)─────────────────────────────────
   const evalBy: Record<string, SkillEvalSnapshot[]> = {};
   for (const r of reports) {
-    if (r.reportKind !== 'evaluation') continue;
+    if (r.kind !== 'evaluation') continue;
     const variants = r.meta.variants || [];
     for (const v of variants) {
       const skillName = skillNameForEvalVariant(r, v);
@@ -412,7 +412,7 @@ export function buildSkillIndex(
   // list 页对每个 entry 跑 detectInsights 的 CPU 开销迁移到这里,只 miss 时算一次。
   const insightsBySkill = new Map<string, Insight[]>();
   for (const ent of entries) {
-    const evalReport = ent.eval ? reports.find((r) => r.id === ent.eval!.reportId && r.reportKind === 'evaluation') as EvaluationReport | undefined : undefined;
+    const evalReport = ent.eval ? reports.find((r) => r.id === ent.eval!.reportId && r.kind === 'evaluation') as EvaluationReport | undefined : undefined;
     insightsBySkill.set(ent.skillName, detectInsights(ent, evalReport ?? null, {
       diagnostics: diagnosisBundle.bySkill[ent.skillName] ?? [],
     }));

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -287,7 +287,7 @@ function scanDoctorReports(dir: string): Record<string, SkillDoctorSnapshot[]> {
     if (!file.endsWith('.json')) continue;
     try {
       const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as DoctorReport;
-      if (data?.reportKind !== 'doctor' || !Array.isArray(data.skills)) continue;
+      if (data?.kind !== 'doctor' || !Array.isArray(data.skills)) continue;
       const ts = data.timestamp;
       for (const sr of data.skills) {
         const passN = sr.results.filter((r) => r.status === 'pass').length;

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -286,8 +286,9 @@ function scanDoctorReports(dir: string): Record<string, SkillDoctorSnapshot[]> {
   for (const file of readdirSync(dir)) {
     if (!file.endsWith('.json')) continue;
     try {
-      const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as DoctorReport;
-      if (data?.kind !== 'doctor' || !Array.isArray(data.skills)) continue;
+      const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as DoctorReport & { reportKind?: unknown };
+      const kind = data?.kind === 'doctor' ? data.kind : data?.reportKind === 'doctor' ? data.reportKind : null;
+      if (!kind || !Array.isArray(data.skills)) continue;
       const ts = data.timestamp;
       for (const sr of data.skills) {
         const passN = sr.results.filter((r) => r.status === 'pass').length;

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -286,8 +286,8 @@ function scanDoctorReports(dir: string): Record<string, SkillDoctorSnapshot[]> {
   for (const file of readdirSync(dir)) {
     if (!file.endsWith('.json')) continue;
     try {
-      const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as DoctorReport & { reportKind?: unknown };
-      const kind = data?.kind === 'doctor' ? data.kind : data?.reportKind === 'doctor' ? data.reportKind : null;
+      const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as DoctorReport;
+      const kind = data?.kind === 'doctor' ? data.kind : null;
       if (!kind || !Array.isArray(data.skills)) continue;
       const ts = data.timestamp;
       for (const sr of data.skills) {

--- a/src/types/doctor.ts
+++ b/src/types/doctor.ts
@@ -13,7 +13,7 @@ export type DoctorOutcome = 'passed' | 'warnings_only' | 'failed';
 
 /** Bumped whenever DoctorReport schema changes in a way CI consumers should
  *  be able to detect. CI can pin/check this when parsing the JSON. */
-export const DOCTOR_REPORT_SCHEMA_VERSION = '2.0.0';
+export const DOCTOR_REPORT_SCHEMA_VERSION = '3.0.0';
 
 export interface DoctorRuleResult {
   ruleId: string;

--- a/src/types/doctor.ts
+++ b/src/types/doctor.ts
@@ -109,7 +109,7 @@ export interface DoctorSkillReport {
 }
 
 export interface DoctorReport {
-  reportKind: 'doctor';
+  kind: 'doctor';
   /** Schema version the JSON consumer can pin/check. Bumped on any
    *  user-visible change to this report's shape. See DOCTOR_REPORT_SCHEMA_VERSION. */
   schemaVersion: string;

--- a/src/types/observability.ts
+++ b/src/types/observability.ts
@@ -81,7 +81,7 @@ export interface ObservationReviewStateEntry {
 
 export interface ObservationReviewState {
   kind: 'observe-review-state';
-  schemaVersion: 1;
+  schemaVersion: 2;
   updatedAt: string;
   entries: Record<string, ObservationReviewStateEntry>;
 }
@@ -286,7 +286,7 @@ export interface ObservationSessionTimeRange {
 
 export interface ObservationInboxReport {
   kind: 'observe-inbox';
-  schemaVersion: 1;
+  schemaVersion: 2;
   meta: {
     tracePath: string;
     generatedAt: string;
@@ -929,7 +929,7 @@ export interface ExperienceSkillSummary {
 
 export interface ObservationExperienceReport {
   kind: 'observe-experience';
-  schemaVersion: 1;
+  schemaVersion: 2;
   scope: 'evidence-only';
   generatedAt: string;
   meta: {

--- a/src/types/observability.ts
+++ b/src/types/observability.ts
@@ -80,7 +80,7 @@ export interface ObservationReviewStateEntry {
 }
 
 export interface ObservationReviewState {
-  reportKind: 'observe-review-state';
+  kind: 'observe-review-state';
   schemaVersion: 1;
   updatedAt: string;
   entries: Record<string, ObservationReviewStateEntry>;
@@ -285,7 +285,7 @@ export interface ObservationSessionTimeRange {
 }
 
 export interface ObservationInboxReport {
-  reportKind: 'observe-inbox';
+  kind: 'observe-inbox';
   schemaVersion: 1;
   meta: {
     tracePath: string;
@@ -928,7 +928,7 @@ export interface ExperienceSkillSummary {
 }
 
 export interface ObservationExperienceReport {
-  reportKind: 'observe-experience';
+  kind: 'observe-experience';
   schemaVersion: 1;
   scope: 'evidence-only';
   generatedAt: string;

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -335,9 +335,7 @@ export interface SampleSnapshot {
 }
 
 export interface EvaluationReport {
-  reportKind: 'evaluation';
-  /** Legacy wire alias kept for external JSON consumers that still read report.kind. */
-  kind?: 'evaluation';
+  kind: 'evaluation';
   id: string;
   meta: ReportMeta;
   summary: Record<string, VariantSummary>;
@@ -394,9 +392,7 @@ export interface BatchEvaluationItem {
 }
 
 export interface BatchEvaluationReport {
-  reportKind: 'batch-evaluation';
-  /** Legacy wire alias kept for external JSON consumers that still read report.kind. */
-  kind?: 'batch-evaluation';
+  kind: 'batch-evaluation';
   id: string;
   mode: 'skill';
   meta: BatchEvaluationMeta;

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -336,6 +336,8 @@ export interface SampleSnapshot {
 
 export interface EvaluationReport {
   reportKind: 'evaluation';
+  /** Legacy wire alias kept for external JSON consumers that still read report.kind. */
+  kind?: 'evaluation';
   id: string;
   meta: ReportMeta;
   summary: Record<string, VariantSummary>;
@@ -393,6 +395,8 @@ export interface BatchEvaluationItem {
 
 export interface BatchEvaluationReport {
   reportKind: 'batch-evaluation';
+  /** Legacy wire alias kept for external JSON consumers that still read report.kind. */
+  kind?: 'batch-evaluation';
   id: string;
   mode: 'skill';
   meta: BatchEvaluationMeta;

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -227,10 +227,10 @@ export interface ReportMeta {
    *  for eval-side reports). Value 1 was specified for v0.21+ but never emitted in practice.
    *  Value 2 marked the artifactHashes tree-hash era for local dir-skills (git dir-skills still
    *  SKILL.md-only). Value 3 extends whole-tree hashing to git dir-skills via isolated copies
-   *  (all dir-skills bind). Value 4 keeps the v3 hash/binding semantics but renames the top-level
-   *  report discriminant from `reportKind` to `kind`, so external consumers can version-gate the
-   *  JSON shape. Drift / lineage consumers gate on `>= 2` (tree-hash era); git-dir-skill binding
-   *  additionally requires `>= 3`. */
+   *  (all dir-skills bind). Value 4 keeps the v3 hash/binding semantics but marks the canonical
+   *  top-level discriminant era, so external consumers can version-gate the JSON shape. Drift /
+   *  lineage consumers gate on `>= 2` (tree-hash era); git-dir-skill binding additionally
+   *  requires `>= 3`. */
   schemaVersion?: number;
   /** SHA256-12 of every sample's content (sample_id → hash). Same hash = same sample. */
   sampleHashes?: Record<string, string>;
@@ -354,7 +354,7 @@ export type Report = EvaluationReport;
 export interface BatchEvaluationMeta {
   mode: 'skill';
   /** Batch report JSON schema version. Kept in lockstep with child EvaluationReport top-level
-   *  shape so external consumers can distinguish `reportKind` vs `kind` payloads. */
+   *  shape so external consumers can identify the canonical discriminant era. */
   schemaVersion: number;
   model: string;
   executor: string;

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -227,8 +227,10 @@ export interface ReportMeta {
    *  for eval-side reports). Value 1 was specified for v0.21+ but never emitted in practice.
    *  Value 2 marked the artifactHashes tree-hash era for local dir-skills (git dir-skills still
    *  SKILL.md-only). Value 3 extends whole-tree hashing to git dir-skills via isolated copies
-   *  (all dir-skills bind). Drift / lineage consumers gate on `>= 2` (tree-hash era); git-dir-skill
-   *  binding additionally requires `>= 3`. */
+   *  (all dir-skills bind). Value 4 keeps the v3 hash/binding semantics but renames the top-level
+   *  report discriminant from `reportKind` to `kind`, so external consumers can version-gate the
+   *  JSON shape. Drift / lineage consumers gate on `>= 2` (tree-hash era); git-dir-skill binding
+   *  additionally requires `>= 3`. */
   schemaVersion?: number;
   /** SHA256-12 of every sample's content (sample_id → hash). Same hash = same sample. */
   sampleHashes?: Record<string, string>;
@@ -351,6 +353,9 @@ export type Report = EvaluationReport;
 
 export interface BatchEvaluationMeta {
   mode: 'skill';
+  /** Batch report JSON schema version. Kept in lockstep with child EvaluationReport top-level
+   *  shape so external consumers can distinguish `reportKind` vs `kind` payloads. */
+  schemaVersion: number;
   model: string;
   executor: string;
   skillDir: string;

--- a/test/analysis/failure-clusterer.test.ts
+++ b/test/analysis/failure-clusterer.test.ts
@@ -13,7 +13,7 @@ const variantResult = (overrides: Partial<VariantResult> = {}): VariantResult =>
 });
 
 const buildReport = (entries: Array<{ id: string; perVariant: Record<string, Partial<VariantResult>> }>, variants: string[]): Report => ({
-  reportKind: 'evaluation',
+  kind: 'evaluation',
   id: 'r',
   meta: {
     variants, model: 'm', judgeModels: [{ executor: 'claude', model: 'j' }], executor: 'claude',

--- a/test/analysis/sample-diagnostics.test.ts
+++ b/test/analysis/sample-diagnostics.test.ts
@@ -13,7 +13,7 @@ const variantResult = (overrides: Partial<VariantResult> = {}): VariantResult =>
 });
 
 const buildReport = (entries: Array<{ id: string; perVariant: Record<string, Partial<VariantResult>> }>, variants: string[]): Report => ({
-  reportKind: 'evaluation',
+  kind: 'evaluation',
   id: 'r',
   meta: {
     variants, model: 'm', judgeModels: [{ executor: 'claude', model: 'j' }], executor: 'claude',

--- a/test/analysis/sample-quality-aggregate.test.ts
+++ b/test/analysis/sample-quality-aggregate.test.ts
@@ -91,7 +91,7 @@ describe('buildSampleQualityAggregate', () => {
 describe('analyzeResults — sampleQuality wiring', () => {
   function emptyReport(): Report {
     return {
-      reportKind: 'evaluation',
+      kind: 'evaluation',
       id: 'r',
       meta: {
         variants: ['v1', 'v2'], model: 'm', judgeModels: [{ executor: 'claude', model: 'j' }], executor: 'claude',

--- a/test/authoring/sample-fixer.test.ts
+++ b/test/authoring/sample-fixer.test.ts
@@ -5,7 +5,7 @@ import type { EvaluationReport } from '../../src/types/report.js';
 
 function reportWithFailedAssertion(): EvaluationReport {
   return {
-    reportKind: 'evaluation',
+    kind: 'evaluation',
     id: 'r1',
     meta: {
       variants: ['skill'],

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -61,7 +61,7 @@ const variantSummary = (score: number): VariantSummary => ({
 });
 
 const buildProductTreeReport = (): Report => ({
-  reportKind: 'evaluation',
+  kind: 'evaluation',
   id: 'cli-tree-report',
   meta: {
     variants: ['baseline', 'v1'],

--- a/test/cli/doctor-retention.test.ts
+++ b/test/cli/doctor-retention.test.ts
@@ -12,7 +12,7 @@ function seedDoctorHistory(dir: string, skillName: string, count: number): strin
     const timestamp = `2026-05-${String(10 + i).padStart(2, '0')}T00:00:00.000Z`;
     const file = `${skillName}-r${String(i).padStart(3, '0')}.json`;
     writeFileSync(join(dir, file), JSON.stringify({
-      reportKind: 'doctor',
+      kind: 'doctor',
       id: `r${i}`,
       timestamp,
       skills: [{ skillName, status: 'pass', results: [] }],
@@ -66,7 +66,7 @@ describe('pruneDoctorHistory', () => {
   it('清理遗留 `{name}.json` 命名:同 skill 旧文件也参与轮换', () => {
     // 旧 schema:文件名是 {skill}.json,timestamp 是早期
     writeFileSync(join(dir, 'code-review.json'), JSON.stringify({
-      reportKind: 'doctor',
+      kind: 'doctor',
       id: 'legacy',
       timestamp: '2025-01-01T00:00:00.000Z',
       skills: [{ skillName: 'code-review', status: 'pass', results: [] }],
@@ -83,9 +83,9 @@ describe('pruneDoctorHistory', () => {
   });
 
   it('忽略 non-doctor / 多 skill / 损坏 JSON', () => {
-    writeFileSync(join(dir, 'eval-report.json'), JSON.stringify({ reportKind: 'evaluation' }));
+    writeFileSync(join(dir, 'eval-report.json'), JSON.stringify({ kind: 'evaluation' }));
     writeFileSync(join(dir, 'multi-skill.json'), JSON.stringify({
-      reportKind: 'doctor',
+      kind: 'doctor',
       skills: [{ skillName: 'a' }, { skillName: 'b' }],
     }));
     writeFileSync(join(dir, 'corrupt.json'), '{ not json');

--- a/test/cli/doctor-retention.test.ts
+++ b/test/cli/doctor-retention.test.ts
@@ -66,7 +66,7 @@ describe('pruneDoctorHistory', () => {
   it('清理遗留 `{name}.json` 命名:同 skill 旧文件也参与轮换', () => {
     // 旧 schema:文件名是 {skill}.json,timestamp 是早期
     writeFileSync(join(dir, 'code-review.json'), JSON.stringify({
-      kind: 'doctor',
+      reportKind: 'doctor',
       id: 'legacy',
       timestamp: '2025-01-01T00:00:00.000Z',
       skills: [{ skillName: 'code-review', status: 'pass', results: [] }],

--- a/test/cli/doctor-retention.test.ts
+++ b/test/cli/doctor-retention.test.ts
@@ -66,7 +66,7 @@ describe('pruneDoctorHistory', () => {
   it('清理遗留 `{name}.json` 命名:同 skill 旧文件也参与轮换', () => {
     // 旧 schema:文件名是 {skill}.json,timestamp 是早期
     writeFileSync(join(dir, 'code-review.json'), JSON.stringify({
-      reportKind: 'doctor',
+      kind: 'doctor',
       id: 'legacy',
       timestamp: '2025-01-01T00:00:00.000Z',
       skills: [{ skillName: 'code-review', status: 'pass', results: [] }],

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -38,7 +38,7 @@ describe('omk doctor CLI', () => {
     assert.ok(!stdout.includes('健康度'));
   });
 
-  it('--json on example skill outputs valid DoctorReport with reportKind=doctor', async () => {
+  it('--json on example skill outputs valid DoctorReport with kind=doctor', async () => {
     const { stdout } = await execFileAsync('node', [
       CLI,
       'doctor',
@@ -47,7 +47,7 @@ describe('omk doctor CLI', () => {
       '--executor', DOCTOR_FIXTURE,
     ]);
     const parsed = JSON.parse(stdout);
-    assert.equal(parsed.reportKind, 'doctor');
+    assert.equal(parsed.kind, 'doctor');
     assert.ok(Array.isArray(parsed.skills));
     assert.ok(parsed.skills.length >= 1);
     assert.equal(parsed.outcome, 'passed');
@@ -62,7 +62,7 @@ describe('omk doctor CLI', () => {
       '--executor', DOCTOR_FIXTURE,
     ]);
     const parsed = JSON.parse(stdout);
-    assert.equal(parsed.reportKind, 'doctor');
+    assert.equal(parsed.kind, 'doctor');
     assert.ok(parsed.skills.length >= 2, 'should batch multiple skills from the dir');
   });
 
@@ -196,7 +196,7 @@ describe('omk doctor CLI', () => {
       '--static-only',
     ]);
     const parsed = JSON.parse(stdout);
-    assert.equal(parsed.reportKind, 'doctor');
+    assert.equal(parsed.kind, 'doctor');
     assert.ok(parsed.skills.length >= 1);
     // Static rules present, composer (skill_health) absent under --static-only.
     const staticRuleIds = parsed.skills[0].results.map((r: { ruleId: string }) => r.ruleId);

--- a/test/cli/observe.test.ts
+++ b/test/cli/observe.test.ts
@@ -9,7 +9,7 @@ describe('observe CLI', () => {
   it('filters by skill before rendering the by-skill rollup', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-observe-cli-'));
     writeFileSync(join(dir, '2026-05-07T00-00-00-observe-inbox.json'), JSON.stringify({
-      reportKind: 'observe-inbox',
+      kind: 'observe-inbox',
       schemaVersion: 1,
       meta: {
         tracePath: '/tmp/trace',

--- a/test/cli/observe.test.ts
+++ b/test/cli/observe.test.ts
@@ -9,8 +9,8 @@ describe('observe CLI', () => {
   it('filters by skill before rendering the by-skill rollup', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-observe-cli-'));
     writeFileSync(join(dir, '2026-05-07T00-00-00-observe-inbox.json'), JSON.stringify({
-      reportKind: 'observe-inbox',
-      schemaVersion: 1,
+      kind: 'observe-inbox',
+      schemaVersion: 2,
       meta: {
         tracePath: '/tmp/trace',
         generatedAt: '2026-05-07T00:00:00.000Z',

--- a/test/cli/observe.test.ts
+++ b/test/cli/observe.test.ts
@@ -9,7 +9,7 @@ describe('observe CLI', () => {
   it('filters by skill before rendering the by-skill rollup', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-observe-cli-'));
     writeFileSync(join(dir, '2026-05-07T00-00-00-observe-inbox.json'), JSON.stringify({
-      kind: 'observe-inbox',
+      reportKind: 'observe-inbox',
       schemaVersion: 1,
       meta: {
         tracePath: '/tmp/trace',

--- a/test/cli/run-tally.test.ts
+++ b/test/cli/run-tally.test.ts
@@ -29,7 +29,7 @@ function summary(successCount: number, errorCount: number): VariantSummary {
 describe('computeRunTally', () => {
   it('aggregates successCount / errorCount across variants in a single-skill report', () => {
     const report = {
-      reportKind: 'evaluation',
+      kind: 'evaluation',
       id: 'r1',
       meta: {} as EvaluationReport['meta'],
       summary: {
@@ -44,7 +44,7 @@ describe('computeRunTally', () => {
 
   it('aggregates across all batch items', () => {
     const report = {
-      reportKind: 'batch-evaluation',
+      kind: 'batch-evaluation',
       id: 'b1',
       mode: 'skill',
       meta: {} as BatchEvaluationReport['meta'],
@@ -97,7 +97,7 @@ describe('computeRunTally', () => {
 
   it('returns zeros for an empty single report', () => {
     const report = {
-      reportKind: 'evaluation',
+      kind: 'evaluation',
       id: 'empty',
       meta: {} as EvaluationReport['meta'],
       summary: {},

--- a/test/diagnosis/observe-producer.test.ts
+++ b/test/diagnosis/observe-producer.test.ts
@@ -27,7 +27,7 @@ workflows:
 # omk_fake_skill_x9z
 `);
       const report = {
-        reportKind: 'observe-inbox',
+        kind: 'observe-inbox',
         schemaVersion: 1,
         meta: {
           tracePath: '/tmp/synthetic-trace',
@@ -39,7 +39,7 @@ workflows:
         },
         items: [],
         experience: {
-          reportKind: 'observe-experience',
+          kind: 'observe-experience',
           schemaVersion: 1,
           scope: 'evidence-only',
           generatedAt: '2026-05-15T00:00:00.000Z',
@@ -167,7 +167,7 @@ hardRules:
       process.chdir(projectA);  // 模拟在 projectA 跑 ingest
       try {
         const report = {
-          reportKind: 'observe-inbox',
+          kind: 'observe-inbox',
           schemaVersion: 1,
           meta: {
             tracePath: '/tmp/trace-b',
@@ -216,7 +216,7 @@ hardRules:
       process.chdir(projectA);
       try {
         const report = {
-          reportKind: 'observe-inbox',
+          kind: 'observe-inbox',
           schemaVersion: 1,
           meta: {
             tracePath: '/tmp/trace-clean',
@@ -228,7 +228,7 @@ hardRules:
           },
           items: [],
           experience: {
-            reportKind: 'observe-experience',
+            kind: 'observe-experience',
             schemaVersion: 1,
             scope: 'evidence-only',
             generatedAt: '2026-05-15T00:00:00.000Z',
@@ -290,7 +290,7 @@ hardRules:
     // skill_md_not_found / hardrules_not_declared 等 chain advisory,只保留 problemPatterns 等
     // 跟 cwd 无关的诊断。
     const report = {
-      reportKind: 'observe-inbox',
+      kind: 'observe-inbox',
       schemaVersion: 1,
       meta: {
         tracePath: '/tmp/trace',

--- a/test/diagnosis/observe-producer.test.ts
+++ b/test/diagnosis/observe-producer.test.ts
@@ -28,7 +28,7 @@ workflows:
 `);
       const report = {
         kind: 'observe-inbox',
-        schemaVersion: 1,
+        schemaVersion: 2,
         meta: {
           tracePath: '/tmp/synthetic-trace',
           generatedAt: '2026-05-15T00:00:00.000Z',
@@ -40,7 +40,7 @@ workflows:
         items: [],
         experience: {
           kind: 'observe-experience',
-          schemaVersion: 1,
+          schemaVersion: 2,
           scope: 'evidence-only',
           generatedAt: '2026-05-15T00:00:00.000Z',
           meta: {
@@ -168,7 +168,7 @@ hardRules:
       try {
         const report = {
           kind: 'observe-inbox',
-          schemaVersion: 1,
+          schemaVersion: 2,
           meta: {
             tracePath: '/tmp/trace-b',
             generatedAt: '2026-05-15T00:00:00.000Z',
@@ -217,7 +217,7 @@ hardRules:
       try {
         const report = {
           kind: 'observe-inbox',
-          schemaVersion: 1,
+          schemaVersion: 2,
           meta: {
             tracePath: '/tmp/trace-clean',
             generatedAt: '2026-05-15T00:00:00.000Z',
@@ -229,7 +229,7 @@ hardRules:
           items: [],
           experience: {
             kind: 'observe-experience',
-            schemaVersion: 1,
+            schemaVersion: 2,
             scope: 'evidence-only',
             generatedAt: '2026-05-15T00:00:00.000Z',
             meta: { sessionCount: 1, skillCount: 1, invocationCount: 1, goalSliceCount: 1, noteCodes: [] },
@@ -291,7 +291,7 @@ hardRules:
     // 跟 cwd 无关的诊断。
     const report = {
       kind: 'observe-inbox',
-      schemaVersion: 1,
+      schemaVersion: 2,
       meta: {
         tracePath: '/tmp/trace',
         generatedAt: '2026-05-15T00:00:00.000Z',

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -163,7 +163,7 @@ describe('runDoctor', () => {
       lang: 'zh',
       rules: [passingRule],
     });
-    assert.equal(report.reportKind, 'doctor');
+    assert.equal(report.kind, 'doctor');
     assert.ok(report.skills.length >= 2);
     assert.equal(report.outcome, 'passed');
     assert.equal(report.totals.pass, report.skills.length);

--- a/test/eval-core/comparability.test.ts
+++ b/test/eval-core/comparability.test.ts
@@ -26,7 +26,7 @@ function runtime(executor: string, model: string, fingerprint: string): Executor
 
 function report(overrides: Partial<Report['meta']> = {}): Report {
   return {
-    reportKind: 'evaluation',
+    kind: 'evaluation',
     id: 'r',
     meta: {
       variants: ['control', 'treatment'],

--- a/test/eval-core/verdict.test.ts
+++ b/test/eval-core/verdict.test.ts
@@ -13,7 +13,7 @@ const summary = (avg: { fact?: number; behavior?: number; judge?: number; compos
 });
 
 const buildReport = (overrides: Partial<Report> & { variants: string[]; perVariantAvg: Record<string, Parameters<typeof summary>[0]>; pairs?: Report['meta']['pairComparisons'] }): Report => ({
-  reportKind: 'evaluation',
+  kind: 'evaluation',
   id: 'r1',
   meta: {
     variants: overrides.variants,

--- a/test/evolver.test.ts
+++ b/test/evolver.test.ts
@@ -13,7 +13,7 @@ function makeSummary(avgScore: number): VariantSummary {
 
 function makeReport(variantName: string, sampleScores: Record<string, number>, avgScore: number): Report {
   return {
-    reportKind: 'evaluation',
+    kind: 'evaluation',
     id: `${variantName}-id`,
     meta: {
       variants: [variantName],

--- a/test/grading/debias-validate.test.ts
+++ b/test/grading/debias-validate.test.ts
@@ -38,7 +38,7 @@ const buildReport = (
   rows: Array<{ sample_id: string; output: string; llmScore: number }>,
   debiasMode: Array<'length' | 'position'> = ['length'],
 ): Report => ({
-  reportKind: 'evaluation',
+  kind: 'evaluation',
   id: 'r1',
   meta: {
     variants: [variant],

--- a/test/grading/gold-cli.test.ts
+++ b/test/grading/gold-cli.test.ts
@@ -34,7 +34,7 @@ const buildReport = (
   scoresById: Record<string, number>,
   judgeModel = 'claude-sonnet-4-6',
 ): Report => ({
-  reportKind: 'evaluation',
+  kind: 'evaluation',
   id: 'r1',
   meta: {
     variants: [variant],

--- a/test/html-renderer.test.ts
+++ b/test/html-renderer.test.ts
@@ -12,7 +12,7 @@ function normalizeForSnapshot(html: string): string {
 }
 
 const SAMPLE_REPORT: Report = {
-  reportKind: 'evaluation',
+  kind: 'evaluation',
   // 让 id 匹配 renderRunList 里的 YYYYMMDD-HHmm regex (html-renderer.ts:62),
   // 这样列表页 row 的时间从 id 直接提取 (deterministic), 不走 toLocaleString
   // — 后者本地时区敏感, 会让 snapshot 在 CI UTC 和本地 CST 之间不一致.

--- a/test/managed/evidence.test.ts
+++ b/test/managed/evidence.test.ts
@@ -34,7 +34,7 @@ function makeReport(over: {
   debiasMode?: Array<'length' | 'position'>;
 } = {}): EvaluationReport {
   return {
-    reportKind: 'evaluation',
+    kind: 'evaluation',
     id: over.id ?? 'report-abc',
     meta: {
       variants: over.variants ?? ['baseline', 'review'],

--- a/test/observability/inbox/aggregation.test.ts
+++ b/test/observability/inbox/aggregation.test.ts
@@ -122,7 +122,7 @@ describe('observe inbox - aggregation', () => {
   it('queries only the latest saved report by default', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-'));
     const oldReport = {
-      reportKind: 'observe-inbox' as const,
+      kind: 'observe-inbox' as const,
       schemaVersion: 1 as const,
       meta: {
         generatedAt: '2026-05-01T00:00:00.000Z',
@@ -145,7 +145,7 @@ describe('observe inbox - aggregation', () => {
       items: [baseItem({ id: 'old', skillName: 'old_skill', lastSeen: '2026-05-01T00:00:00.000Z' })],
     };
     const latestReport = {
-      reportKind: 'observe-inbox' as const,
+      kind: 'observe-inbox' as const,
       schemaVersion: 1 as const,
       meta: {
         generatedAt: '2026-05-02T00:00:00.000Z',

--- a/test/observability/inbox/aggregation.test.ts
+++ b/test/observability/inbox/aggregation.test.ts
@@ -123,7 +123,7 @@ describe('observe inbox - aggregation', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-'));
     const oldReport = {
       kind: 'observe-inbox' as const,
-      schemaVersion: 1 as const,
+      schemaVersion: 2 as const,
       meta: {
         generatedAt: '2026-05-01T00:00:00.000Z',
         tracePath: '/tmp/old',
@@ -146,7 +146,7 @@ describe('observe inbox - aggregation', () => {
     };
     const latestReport = {
       kind: 'observe-inbox' as const,
-      schemaVersion: 1 as const,
+      schemaVersion: 2 as const,
       meta: {
         generatedAt: '2026-05-02T00:00:00.000Z',
         tracePath: '/tmp/latest',

--- a/test/observability/inbox/experience-report.test.ts
+++ b/test/observability/inbox/experience-report.test.ts
@@ -201,13 +201,13 @@ describe('observe inbox - experience report', () => {
       latestSeenLabel: '2026-05-01 00:00:04',
       reviewState: {
         kind: 'observe-review-state',
-        schemaVersion: 1,
+        schemaVersion: 2,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       },
       resolvedReviewSessions: resolvedReviewSessionsForFixture(experience, {
         kind: 'observe-review-state',
-        schemaVersion: 1,
+        schemaVersion: 2,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       }),
@@ -279,7 +279,7 @@ describe('observe inbox - experience report', () => {
     const annotatedReport = buildObservationInboxReport(file, {
       reviewState: {
         kind: 'observe-review-state',
-        schemaVersion: 1,
+        schemaVersion: 2,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {
           [observationReviewStateKey('evidence_metric', correctionTargetId)]: {

--- a/test/observability/inbox/experience-report.test.ts
+++ b/test/observability/inbox/experience-report.test.ts
@@ -107,7 +107,7 @@ describe('observe inbox - experience report', () => {
     const report = buildObservationInboxReport(file);
     const experience = report.experience;
     assert.ok(experience);
-    assert.equal(experience.reportKind, 'observe-experience');
+    assert.equal(experience.kind, 'observe-experience');
     assert.equal(experience.scope, 'evidence-only');
     assert.equal(experience.meta.skillCount, 1);
     assert.equal(experience.goalSlices.length, 1);
@@ -200,13 +200,13 @@ describe('observe inbox - experience report', () => {
       reportCount: 1,
       latestSeenLabel: '2026-05-01 00:00:04',
       reviewState: {
-        reportKind: 'observe-review-state',
+        kind: 'observe-review-state',
         schemaVersion: 1,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       },
       resolvedReviewSessions: resolvedReviewSessionsForFixture(experience, {
-        reportKind: 'observe-review-state',
+        kind: 'observe-review-state',
         schemaVersion: 1,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
@@ -278,7 +278,7 @@ describe('observe inbox - experience report', () => {
     }, 'user_goal_shift');
     const annotatedReport = buildObservationInboxReport(file, {
       reviewState: {
-        reportKind: 'observe-review-state',
+        kind: 'observe-review-state',
         schemaVersion: 1,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {

--- a/test/observability/inbox/review-state.test.ts
+++ b/test/observability/inbox/review-state.test.ts
@@ -130,7 +130,7 @@ describe('observe inbox - review state', () => {
     assert.ok(correction);
     const targetId = observationMetricAnnotationTargetId({ ...correction.evidenceRef, metricScopeId: session.id }, 'user_correction');
     const reviewState = {
-      reportKind: 'observe-review-state' as const,
+      kind: 'observe-review-state' as const,
       schemaVersion: 1 as const,
       updatedAt: '2026-05-11T02:00:03.000Z',
       entries: {
@@ -420,7 +420,7 @@ describe('observe inbox - review state', () => {
     };
     mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
     writeFileSync(skillDerivedStandardsPath(dir, chain.skillName), JSON.stringify({
-      reportKind: 'observe-skill-derived-standards',
+      kind: 'observe-skill-derived-standards',
       schemaVersion: 1,
       skillName: chain.skillName,
       generatedAt: '2026-05-18T00:00:00.000Z',
@@ -500,7 +500,7 @@ describe('observe inbox - review state', () => {
     };
     mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
     writeFileSync(skillDerivedStandardsPath(dir, chain.skillName), JSON.stringify({
-      reportKind: 'observe-skill-derived-standards',
+      kind: 'observe-skill-derived-standards',
       schemaVersion: 1,
       skillName: chain.skillName,
       generatedAt: '2026-05-18T00:00:00.000Z',

--- a/test/observability/inbox/review-state.test.ts
+++ b/test/observability/inbox/review-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { buildObservationInboxReport } from '../../../src/observability/inbox.js';
@@ -68,42 +68,6 @@ describe('observe inbox - review state', () => {
 
     const afterDelete = deleteObservationReviewState(dir, 'goal_slice_correction', 'session-1:42', '2026-05-01T00:02:00.000Z');
     assert.equal(afterDelete.entries[correctionKey], undefined);
-  });
-
-  it('loads legacy reportKind review-state and rewrites it as schemaVersion 2 on update', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'omk-review-state-legacy-'));
-    const legacyKey = observationReviewStateKey('skill', 'legacy-audit');
-    writeFileSync(join(dir, 'review-state.json'), JSON.stringify({
-      reportKind: 'observe-review-state',
-      schemaVersion: 1,
-      updatedAt: '2026-05-10T00:00:00.000Z',
-      entries: {
-        [legacyKey]: {
-          targetType: 'skill',
-          targetId: 'legacy-audit',
-          verdict: 'reviewed',
-          reviewedAt: '2026-05-10T00:00:00.000Z',
-        },
-      },
-    }, null, 2));
-
-    const loaded = loadObservationReviewState(dir);
-    assert.equal(loaded.kind, 'observe-review-state');
-    assert.equal(loaded.schemaVersion, 2);
-    assert.equal(loaded.entries[legacyKey].verdict, 'reviewed');
-
-    const updated = updateObservationReviewState(dir, {
-      targetType: 'skill',
-      targetId: 'fresh-audit',
-      verdict: 'not_issue',
-    }, '2026-05-10T00:01:00.000Z');
-    assert.equal(updated.entries[legacyKey].verdict, 'reviewed');
-    assert.equal(updated.entries[observationReviewStateKey('skill', 'fresh-audit')].verdict, 'not_issue');
-
-    const persisted = JSON.parse(readFileSync(join(dir, 'review-state.json'), 'utf-8')) as Record<string, unknown>;
-    assert.equal(persisted.kind, 'observe-review-state');
-    assert.equal('reportKind' in persisted, false);
-    assert.equal(persisted.schemaVersion, 2);
   });
 
   it('scopes relative metric annotations by skill segment while keeping message metrics shared', () => {
@@ -456,7 +420,7 @@ describe('observe inbox - review state', () => {
     };
     mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
     writeFileSync(skillDerivedStandardsPath(dir, chain.skillName), JSON.stringify({
-      reportKind: 'observe-skill-derived-standards',
+      kind: 'observe-skill-derived-standards',
       schemaVersion: 1,
       skillName: chain.skillName,
       generatedAt: '2026-05-18T00:00:00.000Z',
@@ -536,7 +500,7 @@ describe('observe inbox - review state', () => {
     };
     mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
     writeFileSync(skillDerivedStandardsPath(dir, chain.skillName), JSON.stringify({
-      reportKind: 'observe-skill-derived-standards',
+      kind: 'observe-skill-derived-standards',
       schemaVersion: 1,
       skillName: chain.skillName,
       generatedAt: '2026-05-18T00:00:00.000Z',
@@ -584,48 +548,6 @@ describe('observe inbox - review state', () => {
     assert.equal(second.standards.length, 1);
     assert.equal(second.standards[0].id, 'soft-only-confirmed');
     assert.equal(second.standards[0].status, 'stale');
-  });
-
-  it('updates legacy reportKind soft standards without treating them as missing', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'omk-soft-standards-legacy-update-'));
-    mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
-    const file = skillDerivedStandardsPath(dir, 'legacy-skill');
-    writeFileSync(file, JSON.stringify({
-      reportKind: 'observe-skill-derived-standards',
-      schemaVersion: 1,
-      skillName: 'legacy-skill',
-      generatedAt: '2026-05-18T00:00:00.000Z',
-      model: 'sonnet',
-      executor: 'test-executor',
-      promptId: 'llm-enhanced-review',
-      promptVersion: '2026-05-18.v1',
-      standards: [{
-        id: 'legacy-rule',
-        kind: 'workflow_candidate',
-        status: 'pending_review',
-        title: '旧流程建议',
-        body: '这是一条 legacy soft standard。',
-        source: 'llm_soft_standard',
-        confidence: 'medium',
-        evidence: ['旧记录'],
-      }],
-    }, null, 2));
-
-    const updated = updateSkillDerivedStandardStatus(
-      dir,
-      'legacy-skill',
-      'legacy-rule',
-      'author_confirmed',
-      '2026-05-18T00:01:00.000Z',
-    );
-    assert.equal(updated.schemaVersion, 2);
-    assert.equal(updated.standards[0].standardKind, 'workflow_candidate');
-    assert.equal(updated.standards[0].status, 'author_confirmed');
-
-    const persisted = JSON.parse(readFileSync(file, 'utf-8')) as Record<string, unknown>;
-    assert.equal(persisted.kind, 'observe-skill-derived-standards');
-    assert.equal('reportKind' in persisted, false);
-    assert.equal(persisted.schemaVersion, 2);
   });
 
   it('prepends required ownerSuggestions so they survive the 10-item cap', async () => {

--- a/test/observability/inbox/review-state.test.ts
+++ b/test/observability/inbox/review-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { buildObservationInboxReport } from '../../../src/observability/inbox.js';
@@ -70,6 +70,42 @@ describe('observe inbox - review state', () => {
     assert.equal(afterDelete.entries[correctionKey], undefined);
   });
 
+  it('loads legacy reportKind review-state and rewrites it as schemaVersion 2 on update', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-review-state-legacy-'));
+    const legacyKey = observationReviewStateKey('skill', 'legacy-audit');
+    writeFileSync(join(dir, 'review-state.json'), JSON.stringify({
+      reportKind: 'observe-review-state',
+      schemaVersion: 1,
+      updatedAt: '2026-05-10T00:00:00.000Z',
+      entries: {
+        [legacyKey]: {
+          targetType: 'skill',
+          targetId: 'legacy-audit',
+          verdict: 'reviewed',
+          reviewedAt: '2026-05-10T00:00:00.000Z',
+        },
+      },
+    }, null, 2));
+
+    const loaded = loadObservationReviewState(dir);
+    assert.equal(loaded.kind, 'observe-review-state');
+    assert.equal(loaded.schemaVersion, 2);
+    assert.equal(loaded.entries[legacyKey].verdict, 'reviewed');
+
+    const updated = updateObservationReviewState(dir, {
+      targetType: 'skill',
+      targetId: 'fresh-audit',
+      verdict: 'not_issue',
+    }, '2026-05-10T00:01:00.000Z');
+    assert.equal(updated.entries[legacyKey].verdict, 'reviewed');
+    assert.equal(updated.entries[observationReviewStateKey('skill', 'fresh-audit')].verdict, 'not_issue');
+
+    const persisted = JSON.parse(readFileSync(join(dir, 'review-state.json'), 'utf-8')) as Record<string, unknown>;
+    assert.equal(persisted.kind, 'observe-review-state');
+    assert.equal('reportKind' in persisted, false);
+    assert.equal(persisted.schemaVersion, 2);
+  });
+
   it('scopes relative metric annotations by skill segment while keeping message metrics shared', () => {
     const ref = {
       sourceTrace: '/tmp/session.jsonl',
@@ -131,7 +167,7 @@ describe('observe inbox - review state', () => {
     const targetId = observationMetricAnnotationTargetId({ ...correction.evidenceRef, metricScopeId: session.id }, 'user_correction');
     const reviewState = {
       kind: 'observe-review-state' as const,
-      schemaVersion: 1 as const,
+      schemaVersion: 2 as const,
       updatedAt: '2026-05-11T02:00:03.000Z',
       entries: {
         [observationReviewStateKey('evidence_metric', targetId)]: {
@@ -420,7 +456,7 @@ describe('observe inbox - review state', () => {
     };
     mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
     writeFileSync(skillDerivedStandardsPath(dir, chain.skillName), JSON.stringify({
-      kind: 'observe-skill-derived-standards',
+      reportKind: 'observe-skill-derived-standards',
       schemaVersion: 1,
       skillName: chain.skillName,
       generatedAt: '2026-05-18T00:00:00.000Z',
@@ -500,7 +536,7 @@ describe('observe inbox - review state', () => {
     };
     mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
     writeFileSync(skillDerivedStandardsPath(dir, chain.skillName), JSON.stringify({
-      kind: 'observe-skill-derived-standards',
+      reportKind: 'observe-skill-derived-standards',
       schemaVersion: 1,
       skillName: chain.skillName,
       generatedAt: '2026-05-18T00:00:00.000Z',
@@ -548,6 +584,48 @@ describe('observe inbox - review state', () => {
     assert.equal(second.standards.length, 1);
     assert.equal(second.standards[0].id, 'soft-only-confirmed');
     assert.equal(second.standards[0].status, 'stale');
+  });
+
+  it('updates legacy reportKind soft standards without treating them as missing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-soft-standards-legacy-update-'));
+    mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
+    const file = skillDerivedStandardsPath(dir, 'legacy-skill');
+    writeFileSync(file, JSON.stringify({
+      reportKind: 'observe-skill-derived-standards',
+      schemaVersion: 1,
+      skillName: 'legacy-skill',
+      generatedAt: '2026-05-18T00:00:00.000Z',
+      model: 'sonnet',
+      executor: 'test-executor',
+      promptId: 'llm-enhanced-review',
+      promptVersion: '2026-05-18.v1',
+      standards: [{
+        id: 'legacy-rule',
+        kind: 'workflow_candidate',
+        status: 'pending_review',
+        title: '旧流程建议',
+        body: '这是一条 legacy soft standard。',
+        source: 'llm_soft_standard',
+        confidence: 'medium',
+        evidence: ['旧记录'],
+      }],
+    }, null, 2));
+
+    const updated = updateSkillDerivedStandardStatus(
+      dir,
+      'legacy-skill',
+      'legacy-rule',
+      'author_confirmed',
+      '2026-05-18T00:01:00.000Z',
+    );
+    assert.equal(updated.schemaVersion, 2);
+    assert.equal(updated.standards[0].standardKind, 'workflow_candidate');
+    assert.equal(updated.standards[0].status, 'author_confirmed');
+
+    const persisted = JSON.parse(readFileSync(file, 'utf-8')) as Record<string, unknown>;
+    assert.equal(persisted.kind, 'observe-skill-derived-standards');
+    assert.equal('reportKind' in persisted, false);
+    assert.equal(persisted.schemaVersion, 2);
   });
 
   it('prepends required ownerSuggestions so they survive the 10-item cap', async () => {

--- a/test/observability/inbox/review-state.test.ts
+++ b/test/observability/inbox/review-state.test.ts
@@ -421,7 +421,7 @@ describe('observe inbox - review state', () => {
     mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
     writeFileSync(skillDerivedStandardsPath(dir, chain.skillName), JSON.stringify({
       kind: 'observe-skill-derived-standards',
-      schemaVersion: 1,
+      schemaVersion: 2,
       skillName: chain.skillName,
       generatedAt: '2026-05-18T00:00:00.000Z',
       model: 'sonnet',
@@ -501,7 +501,7 @@ describe('observe inbox - review state', () => {
     mkdirSync(skillDerivedStandardsDir(dir), { recursive: true });
     writeFileSync(skillDerivedStandardsPath(dir, chain.skillName), JSON.stringify({
       kind: 'observe-skill-derived-standards',
-      schemaVersion: 1,
+      schemaVersion: 2,
       skillName: chain.skillName,
       generatedAt: '2026-05-18T00:00:00.000Z',
       model: 'sonnet',

--- a/test/observability/inbox/signal-detection.test.ts
+++ b/test/observability/inbox/signal-detection.test.ts
@@ -298,7 +298,7 @@ describe('observe inbox - signal detection', () => {
     const artifactTargetId = observationMetricAnnotationTargetId(artifactEvent, 'deliverable_artifact');
     const reviewState = {
       kind: 'observe-review-state' as const,
-      schemaVersion: 1 as const,
+      schemaVersion: 2 as const,
       updatedAt: '2026-05-10T00:00:00.000Z',
       entries: {
         [observationReviewStateKey('evidence_metric', artifactTargetId)]: {

--- a/test/observability/inbox/signal-detection.test.ts
+++ b/test/observability/inbox/signal-detection.test.ts
@@ -297,7 +297,7 @@ describe('observe inbox - signal detection', () => {
     assert.ok(artifactEvent);
     const artifactTargetId = observationMetricAnnotationTargetId(artifactEvent, 'deliverable_artifact');
     const reviewState = {
-      reportKind: 'observe-review-state' as const,
+      kind: 'observe-review-state' as const,
       schemaVersion: 1 as const,
       updatedAt: '2026-05-10T00:00:00.000Z',
       entries: {

--- a/test/observability/inbox/trace-ingestion.test.ts
+++ b/test/observability/inbox/trace-ingestion.test.ts
@@ -649,47 +649,6 @@ describe('observe inbox - trace ingestion', () => {
     assert.ok(tracePaths.has('/tmp/B'));
   });
 
-  it('loads legacy reportKind observe-inbox files and canonicalizes nested experience reports', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-legacy-'));
-    writeFileSync(join(dir, '2026-05-07T12-00-00-observe-inbox.json'), JSON.stringify({
-      reportKind: 'observe-inbox',
-      schemaVersion: 1,
-      meta: {
-        generatedAt: '2026-05-07T12:00:00.111Z',
-        tracePath: '/tmp/legacy-trace',
-        sessionCount: 1,
-        segmentCount: 1,
-        itemCount: 1,
-      },
-      items: [baseItem({ id: 'legacy', skillName: 'legacy_skill', lastSeen: '2026-05-07T12:00:00.111Z' })],
-      experience: {
-        reportKind: 'observe-experience',
-        schemaVersion: 1,
-        scope: 'evidence-only',
-        generatedAt: '2026-05-07T12:00:00.111Z',
-        meta: {
-          sessionCount: 1,
-          skillCount: 1,
-          invocationCount: 1,
-          goalSliceCount: 0,
-          noteCodes: ['no_llm_judge', 'no_auto_verdict', 'default_goal_slice_is_allowed', 'deterministic_assistive_inference'],
-        },
-        goalSlices: [],
-        invocations: [],
-        sessions: [],
-        skills: [],
-      },
-    }, null, 2));
-
-    const [report] = loadObservationInboxReports(dir);
-    assert.ok(report);
-    assert.equal(report.kind, 'observe-inbox');
-    assert.equal(report.schemaVersion, 2);
-    assert.equal('reportKind' in report, false);
-    assert.equal(report.experience?.kind, 'observe-experience');
-    assert.equal(report.experience?.schemaVersion, 2);
-  });
-
   it('uses a dedicated reason code for skill asset read failures', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-'));
     const file = join(dir, 'session.jsonl');

--- a/test/observability/inbox/trace-ingestion.test.ts
+++ b/test/observability/inbox/trace-ingestion.test.ts
@@ -57,7 +57,7 @@ describe('observe inbox - trace ingestion', () => {
     writeFileSync(file, records.map((r) => JSON.stringify(r)).join('\n'));
 
     const report = buildObservationInboxReport(file);
-    assert.equal(report.reportKind, 'observe-inbox');
+    assert.equal(report.kind, 'observe-inbox');
     assert.equal(report.schemaVersion, 1);
     assert.equal(report.items.length, 1);
     assert.equal(report.items[0].severityReason, undefined);
@@ -214,13 +214,13 @@ describe('observe inbox - trace ingestion', () => {
       reportCount: 1,
       latestSeenLabel: '2026-05-01 00:10:02',
       reviewState: {
-        reportKind: 'observe-review-state',
+        kind: 'observe-review-state',
         schemaVersion: 1,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       },
       resolvedReviewSessions: resolvedReviewSessionsForFixture(experience, {
-        reportKind: 'observe-review-state',
+        kind: 'observe-review-state',
         schemaVersion: 1,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
@@ -606,7 +606,7 @@ describe('observe inbox - trace ingestion', () => {
     // 不同毫秒的 report 共用同一文件名, 第二份静默覆盖第一份。修复后保留毫秒。
     const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-'));
     const reportA = {
-      reportKind: 'observe-inbox' as const,
+      kind: 'observe-inbox' as const,
       schemaVersion: 1 as const,
       meta: {
         generatedAt: '2026-05-07T12:00:00.111Z',

--- a/test/observability/inbox/trace-ingestion.test.ts
+++ b/test/observability/inbox/trace-ingestion.test.ts
@@ -58,7 +58,7 @@ describe('observe inbox - trace ingestion', () => {
 
     const report = buildObservationInboxReport(file);
     assert.equal(report.kind, 'observe-inbox');
-    assert.equal(report.schemaVersion, 1);
+    assert.equal(report.schemaVersion, 2);
     assert.equal(report.items.length, 1);
     assert.equal(report.items[0].severityReason, undefined);
     assert.equal(report.items[0].severityReasonCode, 'knowledge_gap_suspected');
@@ -215,13 +215,13 @@ describe('observe inbox - trace ingestion', () => {
       latestSeenLabel: '2026-05-01 00:10:02',
       reviewState: {
         kind: 'observe-review-state',
-        schemaVersion: 1,
+        schemaVersion: 2,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       },
       resolvedReviewSessions: resolvedReviewSessionsForFixture(experience, {
         kind: 'observe-review-state',
-        schemaVersion: 1,
+        schemaVersion: 2,
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       }),
@@ -607,7 +607,7 @@ describe('observe inbox - trace ingestion', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-'));
     const reportA = {
       kind: 'observe-inbox' as const,
-      schemaVersion: 1 as const,
+      schemaVersion: 2 as const,
       meta: {
         generatedAt: '2026-05-07T12:00:00.111Z',
         tracePath: '/tmp/A',
@@ -647,6 +647,47 @@ describe('observe inbox - trace ingestion', () => {
     const tracePaths = new Set(reports.map((r) => r.meta.tracePath));
     assert.ok(tracePaths.has('/tmp/A'));
     assert.ok(tracePaths.has('/tmp/B'));
+  });
+
+  it('loads legacy reportKind observe-inbox files and canonicalizes nested experience reports', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-legacy-'));
+    writeFileSync(join(dir, '2026-05-07T12-00-00-observe-inbox.json'), JSON.stringify({
+      reportKind: 'observe-inbox',
+      schemaVersion: 1,
+      meta: {
+        generatedAt: '2026-05-07T12:00:00.111Z',
+        tracePath: '/tmp/legacy-trace',
+        sessionCount: 1,
+        segmentCount: 1,
+        itemCount: 1,
+      },
+      items: [baseItem({ id: 'legacy', skillName: 'legacy_skill', lastSeen: '2026-05-07T12:00:00.111Z' })],
+      experience: {
+        reportKind: 'observe-experience',
+        schemaVersion: 1,
+        scope: 'evidence-only',
+        generatedAt: '2026-05-07T12:00:00.111Z',
+        meta: {
+          sessionCount: 1,
+          skillCount: 1,
+          invocationCount: 1,
+          goalSliceCount: 0,
+          noteCodes: ['no_llm_judge', 'no_auto_verdict', 'default_goal_slice_is_allowed', 'deterministic_assistive_inference'],
+        },
+        goalSlices: [],
+        invocations: [],
+        sessions: [],
+        skills: [],
+      },
+    }, null, 2));
+
+    const [report] = loadObservationInboxReports(dir);
+    assert.ok(report);
+    assert.equal(report.kind, 'observe-inbox');
+    assert.equal(report.schemaVersion, 2);
+    assert.equal('reportKind' in report, false);
+    assert.equal(report.experience?.kind, 'observe-experience');
+    assert.equal(report.experience?.schemaVersion, 2);
   });
 
   it('uses a dedicated reason code for skill asset read failures', () => {

--- a/test/observability/resolved-review.test.ts
+++ b/test/observability/resolved-review.test.ts
@@ -5,7 +5,7 @@ import type { ObservationReviewState } from '../../src/observability/review-stat
 import type { ExperienceSessionStoryAnswer } from '../../src/observability/experience.js';
 
 const emptyReviewState: ObservationReviewState = {
-  reportKind: 'observe-review-state',
+  kind: 'observe-review-state',
   schemaVersion: 1,
   updatedAt: '2026-05-18T00:00:00.000Z',
   entries: {},

--- a/test/observability/resolved-review.test.ts
+++ b/test/observability/resolved-review.test.ts
@@ -6,7 +6,7 @@ import type { ExperienceSessionStoryAnswer } from '../../src/observability/exper
 
 const emptyReviewState: ObservationReviewState = {
   kind: 'observe-review-state',
-  schemaVersion: 1,
+  schemaVersion: 2,
   updatedAt: '2026-05-18T00:00:00.000Z',
   entries: {},
 };

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -636,7 +636,7 @@ describe('runBatchEvaluation', () => {
           // 不兜底——find 落空就 undefined.name 抛错,把误绑暴露成测试失败。
           const treatment = options.variantSpecs.find((spec) => spec.role === 'treatment')!.name;
           const report: Report = {
-            reportKind: 'evaluation',
+            kind: 'evaluation',
             id: options.runId!,
             meta: {
               variants: ['baseline', treatment],
@@ -674,7 +674,7 @@ describe('runBatchEvaluation', () => {
         },
       });
 
-      assert.equal(result.report.reportKind, 'batch-evaluation');
+      assert.equal(result.report.kind, 'batch-evaluation');
       assert.equal(result.report.mode, 'skill');
       assert.equal(result.report.meta.request?.batch, true);
       assert.equal(result.report.meta.request?.noCache, true);
@@ -734,7 +734,7 @@ describe('runBatchEvaluation', () => {
         runSingleEvaluation: async (options) => {
           capturedSpecs = options.variantSpecs;
           const report: Report = {
-            reportKind: 'evaluation',
+            kind: 'evaluation',
             id: options.runId!,
             meta: {
               variants: ['baseline', 'greeter'],
@@ -796,7 +796,7 @@ describe('runBatchEvaluation', () => {
         runSingleEvaluation: async (options) => {
           capturedSpecs = options.variantSpecs;
           const report: Report = {
-            reportKind: 'evaluation',
+            kind: 'evaluation',
             id: options.runId!,
             meta: {
               variants: ['baseline', 'greeter'],

--- a/test/saturation-integration.test.ts
+++ b/test/saturation-integration.test.ts
@@ -19,7 +19,7 @@ const buildRun = (
   const variants = Object.keys(variantScores);
   const sampleCount = variantScores[variants[0]].length;
   return {
-    reportKind: 'evaluation',
+    kind: 'evaluation',
     id: runId,
     meta: {
       variants,

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -2,8 +2,8 @@
  * issue #206 护栏:裸 `kind` 字段只允许 `ArtifactKind`。
  *
  * 产品语义里不带限定词的 `kind` 默认指 knowledge artifact 类型(`Artifact.kind: ArtifactKind`)。
- * 例外是已经发布并落盘/对外暴露的 public schema（如 report.kind）；其它判别字段必须用限定名
- * (`reportKind` / `eventKind` / `runtimeKind` / `standardKind` ...)。
+ * 例外是已经发布并落盘/对外暴露的 public schema（如 report / doctor / observe 的顶层
+ * kind）；其它判别字段必须用限定名（`eventKind` / `runtimeKind` / `standardKind` ...）。
  *
  * 本测试用 TypeScript AST 扫 `src/**\/*.ts` 里**每个名为 `kind` 的字段声明**
  * (interface / type-literal 的 PropertySignature、class 的 PropertyDeclaration —— 不含
@@ -38,6 +38,11 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   "src/types/report.ts::EvaluationReport::'evaluation'",
   "src/types/report.ts::BatchEvaluationReport::'batch-evaluation'",
   "src/server/report-store.ts::RunListItem::ReportDocument['kind']",
+  "src/types/doctor.ts::DoctorReport::'doctor'",
+  "src/types/observability.ts::ObservationReviewState::'observe-review-state'",
+  "src/types/observability.ts::ObservationInboxReport::'observe-inbox'",
+  "src/types/observability.ts::ObservationExperienceReport::'observe-experience'",
+  "src/observability/soft-standards/types.ts::SkillDerivedStandards::'observe-skill-derived-standards'",
   // —— 持久化 observe / experience JSON ——
   'src/types/observability.ts::ExperienceEvidenceRef::ExperienceEvidenceKind',
   'src/types/observability.ts::ExperienceSessionStoryNode::ExperienceSessionStoryNodeKind',
@@ -129,7 +134,7 @@ describe('issue #206: 裸 kind 护栏', () => {
       [],
       `发现未登记的裸 \`kind\` 字段声明(issue #206)。裸 kind 留给 ArtifactKind:\n` +
         `${offenders.join('\n')}\n\n` +
-        `修法:改成限定名(reportKind / eventKind / runtimeKind / standardKind 等);` +
+        `修法:改成限定名(eventKind / runtimeKind / standardKind / recordKind 等);` +
         `或——若确为新的持久化判别字段——把上面的 key 加进 FROZEN_KIND_EXCEPTIONS 并在 PR 说明理由。`,
     );
     assert.deepEqual(

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -1,8 +1,9 @@
 /**
  * issue #206 护栏:裸 `kind` 字段只允许 `ArtifactKind`。
  *
- * 产品语义里不带限定词的 `kind` 一律指 knowledge artifact 类型(`Artifact.kind: ArtifactKind`)。
- * 其它判别字段必须用限定名(`reportKind` / `eventKind` / `runtimeKind` / `standardKind` ...)。
+ * 产品语义里不带限定词的 `kind` 默认指 knowledge artifact 类型(`Artifact.kind: ArtifactKind`)。
+ * 例外是已经发布并落盘/对外暴露的 public schema（如 report.kind）；其它判别字段必须用限定名
+ * (`reportKind` / `eventKind` / `runtimeKind` / `standardKind` ...)。
  *
  * 本测试用 TypeScript AST 扫 `src/**\/*.ts` 里**每个名为 `kind` 的字段声明**
  * (interface / type-literal 的 PropertySignature、class 的 PropertyDeclaration —— 不含
@@ -36,7 +37,7 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   // —— 持久化 report schema（Report JSON 字段语义，CLAUDE.md 列明的不变量）——
   "src/types/report.ts::EvaluationReport::'evaluation'",
   "src/types/report.ts::BatchEvaluationReport::'batch-evaluation'",
-  "src/server/report-store.ts::RunListItem::ReportDocument['reportKind']",
+  "src/server/report-store.ts::RunListItem::ReportDocument['kind']",
   // —— 持久化 observe / experience JSON ——
   'src/types/observability.ts::ExperienceEvidenceRef::ExperienceEvidenceKind',
   'src/types/observability.ts::ExperienceSessionStoryNode::ExperienceSessionStoryNodeKind',

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -34,6 +34,9 @@ const SRC_DIR = join(PROJECT_ROOT, 'src');
 // 这是债务登记,不是「允许裸 kind」的背书。
 const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   // —— 持久化 report schema（Report JSON 字段语义，CLAUDE.md 列明的不变量）——
+  "src/types/report.ts::EvaluationReport::'evaluation'",
+  "src/types/report.ts::BatchEvaluationReport::'batch-evaluation'",
+  "src/server/report-store.ts::RunListItem::ReportDocument['reportKind']",
   // —— 持久化 observe / experience JSON ——
   'src/types/observability.ts::ExperienceEvidenceRef::ExperienceEvidenceKind',
   'src/types/observability.ts::ExperienceSessionStoryNode::ExperienceSessionStoryNodeKind',

--- a/test/server/query-reports.test.ts
+++ b/test/server/query-reports.test.ts
@@ -26,7 +26,7 @@ function makeReport(id: string, variant: string, timestamp: string, avgScore: nu
     },
   };
   return {
-    reportKind: 'evaluation',
+    kind: 'evaluation',
     id,
     meta: {
       variants: [variant],
@@ -67,8 +67,8 @@ describe('queryRunList', () => {
     const list = await queryRunList(store);
     assert.equal(list.length, 1);
     assert.equal(list[0].id, 'r1');
-    assert.equal(list[0].reportKind, 'evaluation');
     assert.equal(list[0].kind, 'evaluation');
+    assert.equal('reportKind' in list[0], false);
     assert.ok(list[0].meta);
     assert.ok(list[0].summary);
     assert.equal(list[0].meta.model, 'sonnet');
@@ -80,65 +80,64 @@ describe('createFileStore legacy report loading', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-report-'));
     try {
       const legacy = makeReport('legacy-run', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
-      delete legacy.reportKind;
+      delete legacy.kind;
       delete legacy.id;
       writeFileSync(join(dir, 'legacy-run.json'), JSON.stringify(legacy, null, 2));
 
       const store = createFileStore(dir);
       const report = await store.get('legacy-run');
-      assert.equal(report?.reportKind, 'evaluation');
+      assert.equal(report?.kind, 'evaluation');
       assert.equal(report?.id, 'legacy-run');
       const list = await store.list();
       assert.equal(list.length, 1);
-      assert.equal(list[0].reportKind, 'evaluation');
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('兼容带 kind 的历史普通报告', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-kind-report-'));
-    try {
-      const legacy = makeReport('legacy-kind-run', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
-      legacy.kind = 'evaluation';
-      delete legacy.reportKind;
-      delete legacy.id;
-      writeFileSync(join(dir, 'legacy-kind-run.json'), JSON.stringify(legacy, null, 2));
-
-      const store = createFileStore(dir);
-      const report = await store.get('legacy-kind-run');
-      assert.equal(report?.reportKind, 'evaluation');
-      assert.equal(report?.kind, 'evaluation');
-      assert.equal(report?.id, 'legacy-kind-run');
-      const list = await store.list();
-      assert.equal(list.length, 1);
-      assert.equal(list[0].reportKind, 'evaluation');
       assert.equal(list[0].kind, 'evaluation');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it('保存 report 时双写 reportKind 和 legacy kind', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'omk-dual-kind-report-'));
+  it('兼容带 reportKind 的历史普通报告', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-reportKind-report-'));
     try {
-      const store = createFileStore(dir);
-      await store.save('new-run', makeReport('new-run', 'v1', '2024-01-01T00:00:00Z', 0.8));
+      const legacy = makeReport('legacy-reportKind-run', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
+      legacy.reportKind = 'evaluation';
+      delete legacy.kind;
+      delete legacy.id;
+      writeFileSync(join(dir, 'legacy-reportKind-run.json'), JSON.stringify(legacy, null, 2));
 
-      const raw = JSON.parse(readFileSync(join(dir, 'new-run.json'), 'utf-8')) as Record<string, unknown>;
-      assert.equal(raw.reportKind, 'evaluation');
-      assert.equal(raw.kind, 'evaluation');
+      const store = createFileStore(dir);
+      const report = await store.get('legacy-reportKind-run');
+      assert.equal(report?.kind, 'evaluation');
+      assert.equal('reportKind' in (report ?? {}), false);
+      assert.equal(report?.id, 'legacy-reportKind-run');
+      const list = await store.list();
+      assert.equal(list.length, 1);
+      assert.equal(list[0].kind, 'evaluation');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it('兼容带 kind 的历史批量报告', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-kind-batch-report-'));
+  it('保存 report 时只写 canonical kind', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-kind-report-'));
+    try {
+      const store = createFileStore(dir);
+      await store.save('new-run', makeReport('new-run', 'v1', '2024-01-01T00:00:00Z', 0.8));
+
+      const raw = JSON.parse(readFileSync(join(dir, 'new-run.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(raw.kind, 'evaluation');
+      assert.equal('reportKind' in raw, false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('兼容带 reportKind 的历史批量报告', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-reportKind-batch-report-'));
     try {
       const legacyBatch = {
-        kind: 'batch-evaluation',
-        id: 'legacy-kind-batch',
+        reportKind: 'batch-evaluation',
+        id: 'legacy-reportKind-batch',
         mode: 'skill',
         meta: {
           mode: 'skill',
@@ -156,12 +155,12 @@ describe('createFileStore legacy report loading', () => {
         },
         items: [],
       };
-      writeFileSync(join(dir, 'legacy-kind-batch.json'), JSON.stringify(legacyBatch, null, 2));
+      writeFileSync(join(dir, 'legacy-reportKind-batch.json'), JSON.stringify(legacyBatch, null, 2));
 
       const store = createFileStore(dir);
-      const report = await store.get('legacy-kind-batch');
-      assert.equal(report?.reportKind, 'batch-evaluation');
+      const report = await store.get('legacy-reportKind-batch');
       assert.equal(report?.kind, 'batch-evaluation');
+      assert.equal('reportKind' in (report ?? {}), false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -171,7 +170,7 @@ describe('createFileStore legacy report loading', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-batch-'));
     try {
       const legacyBatch = makeReport('legacy-batch', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
-      delete legacyBatch.reportKind;
+      delete legacyBatch.kind;
       legacyBatch.overview = { totalArtifacts: 1, totalSamples: 1, totalCostUSD: 0, artifacts: [] };
       legacyBatch.artifacts = [];
       writeFileSync(join(dir, 'legacy-batch.json'), JSON.stringify(legacyBatch, null, 2));

--- a/test/server/query-reports.test.ts
+++ b/test/server/query-reports.test.ts
@@ -96,7 +96,7 @@ describe('createFileStore legacy report loading', () => {
     }
   });
 
-  it('兼容带 reportKind 的历史普通报告', async () => {
+  it('不再兼容仅带 reportKind 的历史普通报告', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-reportKind-report-'));
     try {
       const legacy = makeReport('legacy-reportKind-run', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
@@ -106,13 +106,8 @@ describe('createFileStore legacy report loading', () => {
       writeFileSync(join(dir, 'legacy-reportKind-run.json'), JSON.stringify(legacy, null, 2));
 
       const store = createFileStore(dir);
-      const report = await store.get('legacy-reportKind-run');
-      assert.equal(report?.kind, 'evaluation');
-      assert.equal('reportKind' in (report ?? {}), false);
-      assert.equal(report?.id, 'legacy-reportKind-run');
-      const list = await store.list();
-      assert.equal(list.length, 1);
-      assert.equal(list[0].kind, 'evaluation');
+      assert.equal(await store.get('legacy-reportKind-run'), null);
+      assert.deepEqual(await store.list(), []);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -132,7 +127,7 @@ describe('createFileStore legacy report loading', () => {
     }
   });
 
-  it('兼容带 reportKind 的历史批量报告', async () => {
+  it('不再兼容仅带 reportKind 的历史批量报告', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-reportKind-batch-report-'));
     try {
       const legacyBatch = {
@@ -158,9 +153,8 @@ describe('createFileStore legacy report loading', () => {
       writeFileSync(join(dir, 'legacy-reportKind-batch.json'), JSON.stringify(legacyBatch, null, 2));
 
       const store = createFileStore(dir);
-      const report = await store.get('legacy-reportKind-batch');
-      assert.equal(report?.kind, 'batch-evaluation');
-      assert.equal('reportKind' in (report ?? {}), false);
+      assert.equal(await store.get('legacy-reportKind-batch'), null);
+      assert.deepEqual(await store.list(), []);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/server/query-reports.test.ts
+++ b/test/server/query-reports.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createFileStore, queryRunList, queryRun, queryTrend } from '../../src/server/report-store.js';
@@ -67,6 +67,8 @@ describe('queryRunList', () => {
     const list = await queryRunList(store);
     assert.equal(list.length, 1);
     assert.equal(list[0].id, 'r1');
+    assert.equal(list[0].reportKind, 'evaluation');
+    assert.equal(list[0].kind, 'evaluation');
     assert.ok(list[0].meta);
     assert.ok(list[0].summary);
     assert.equal(list[0].meta.model, 'sonnet');
@@ -89,6 +91,77 @@ describe('createFileStore legacy report loading', () => {
       const list = await store.list();
       assert.equal(list.length, 1);
       assert.equal(list[0].reportKind, 'evaluation');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('兼容带 kind 的历史普通报告', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-kind-report-'));
+    try {
+      const legacy = makeReport('legacy-kind-run', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
+      legacy.kind = 'evaluation';
+      delete legacy.reportKind;
+      delete legacy.id;
+      writeFileSync(join(dir, 'legacy-kind-run.json'), JSON.stringify(legacy, null, 2));
+
+      const store = createFileStore(dir);
+      const report = await store.get('legacy-kind-run');
+      assert.equal(report?.reportKind, 'evaluation');
+      assert.equal(report?.kind, 'evaluation');
+      assert.equal(report?.id, 'legacy-kind-run');
+      const list = await store.list();
+      assert.equal(list.length, 1);
+      assert.equal(list[0].reportKind, 'evaluation');
+      assert.equal(list[0].kind, 'evaluation');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('保存 report 时双写 reportKind 和 legacy kind', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-dual-kind-report-'));
+    try {
+      const store = createFileStore(dir);
+      await store.save('new-run', makeReport('new-run', 'v1', '2024-01-01T00:00:00Z', 0.8));
+
+      const raw = JSON.parse(readFileSync(join(dir, 'new-run.json'), 'utf-8')) as Record<string, unknown>;
+      assert.equal(raw.reportKind, 'evaluation');
+      assert.equal(raw.kind, 'evaluation');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('兼容带 kind 的历史批量报告', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-kind-batch-report-'));
+    try {
+      const legacyBatch = {
+        kind: 'batch-evaluation',
+        id: 'legacy-kind-batch',
+        mode: 'skill',
+        meta: {
+          mode: 'skill',
+          model: 'sonnet',
+          executor: 'claude',
+          skillDir: 'skills',
+          sampleCount: 1,
+          taskCount: 2,
+          totalArtifacts: 1,
+          totalCostUSD: 0,
+          timestamp: '2024-01-01T00:00:00Z',
+          cliVersion: '0.8.1',
+          nodeVersion: '20.0.0',
+          judgeModels: [{ executor: 'claude', model: 'haiku' }],
+        },
+        items: [],
+      };
+      writeFileSync(join(dir, 'legacy-kind-batch.json'), JSON.stringify(legacyBatch, null, 2));
+
+      const store = createFileStore(dir);
+      const report = await store.get('legacy-kind-batch');
+      assert.equal(report?.reportKind, 'batch-evaluation');
+      assert.equal(report?.kind, 'batch-evaluation');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/server/query-reports.test.ts
+++ b/test/server/query-reports.test.ts
@@ -74,8 +74,8 @@ describe('queryRunList', () => {
   });
 });
 
-describe('createFileStore legacy report loading', () => {
-  it('把无 kind 的历史普通报告归一化为 evaluation', async () => {
+describe('createFileStore kind-only report loading（无旧格式读兼容）', () => {
+  it('无顶层 kind 的历史普通报告不再读取（硬切换、无旧格式兼容）', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-report-'));
     try {
       const legacy = makeReport('legacy-run', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
@@ -84,18 +84,14 @@ describe('createFileStore legacy report loading', () => {
       writeFileSync(join(dir, 'legacy-run.json'), JSON.stringify(legacy, null, 2));
 
       const store = createFileStore(dir);
-      const report = await store.get('legacy-run');
-      assert.equal(report?.kind, 'evaluation');
-      assert.equal(report?.id, 'legacy-run');
-      const list = await store.list();
-      assert.equal(list.length, 1);
-      assert.equal(list[0].kind, 'evaluation');
+      assert.equal(await store.get('legacy-run'), null);
+      assert.deepEqual(await store.list(), []);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it('不兼容带额外未知顶层判别字段的历史普通报告', async () => {
+  it('带额外未知顶层判别字段的历史普通报告不读取', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-extra-discriminant-report-'));
     try {
       const legacy = makeReport('legacy-extra-discriminant-run', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;

--- a/test/server/query-reports.test.ts
+++ b/test/server/query-reports.test.ts
@@ -68,7 +68,6 @@ describe('queryRunList', () => {
     assert.equal(list.length, 1);
     assert.equal(list[0].id, 'r1');
     assert.equal(list[0].kind, 'evaluation');
-    assert.equal('reportKind' in list[0], false);
     assert.ok(list[0].meta);
     assert.ok(list[0].summary);
     assert.equal(list[0].meta.model, 'sonnet');
@@ -96,17 +95,17 @@ describe('createFileStore legacy report loading', () => {
     }
   });
 
-  it('不再兼容仅带 reportKind 的历史普通报告', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-reportKind-report-'));
+  it('不兼容带额外未知顶层判别字段的历史普通报告', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-extra-discriminant-report-'));
     try {
-      const legacy = makeReport('legacy-reportKind-run', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
-      legacy.reportKind = 'evaluation';
+      const legacy = makeReport('legacy-extra-discriminant-run', 'v1', '2024-01-01T00:00:00Z', 0.8) as unknown as Record<string, unknown>;
+      legacy.legacyDiscriminant = 'evaluation';
       delete legacy.kind;
       delete legacy.id;
-      writeFileSync(join(dir, 'legacy-reportKind-run.json'), JSON.stringify(legacy, null, 2));
+      writeFileSync(join(dir, 'legacy-extra-discriminant-run.json'), JSON.stringify(legacy, null, 2));
 
       const store = createFileStore(dir);
-      assert.equal(await store.get('legacy-reportKind-run'), null);
+      assert.equal(await store.get('legacy-extra-discriminant-run'), null);
       assert.deepEqual(await store.list(), []);
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -121,18 +120,17 @@ describe('createFileStore legacy report loading', () => {
 
       const raw = JSON.parse(readFileSync(join(dir, 'new-run.json'), 'utf-8')) as Record<string, unknown>;
       assert.equal(raw.kind, 'evaluation');
-      assert.equal('reportKind' in raw, false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it('不再兼容仅带 reportKind 的历史批量报告', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-reportKind-batch-report-'));
+  it('不兼容带额外未知顶层判别字段的历史批量报告', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-legacy-extra-discriminant-batch-report-'));
     try {
       const legacyBatch = {
-        reportKind: 'batch-evaluation',
-        id: 'legacy-reportKind-batch',
+        legacyDiscriminant: 'batch-evaluation',
+        id: 'legacy-extra-discriminant-batch',
         mode: 'skill',
         meta: {
           mode: 'skill',
@@ -150,10 +148,10 @@ describe('createFileStore legacy report loading', () => {
         },
         items: [],
       };
-      writeFileSync(join(dir, 'legacy-reportKind-batch.json'), JSON.stringify(legacyBatch, null, 2));
+      writeFileSync(join(dir, 'legacy-extra-discriminant-batch.json'), JSON.stringify(legacyBatch, null, 2));
 
       const store = createFileStore(dir);
-      assert.equal(await store.get('legacy-reportKind-batch'), null);
+      assert.equal(await store.get('legacy-extra-discriminant-batch'), null);
       assert.deepEqual(await store.list(), []);
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -146,7 +146,7 @@ describe('report-server', () => {
     writeFileSync(join(JOBS_DIR, 'job-test-run-002.json'), JSON.stringify(FAILED_JOB, null, 2));
     writeFileSync(join(OBSERVATIONS_DIR, '2026-05-07T00-00-00-observe-inbox.json'), JSON.stringify({
       kind: 'observe-inbox',
-      schemaVersion: 1,
+      schemaVersion: 2,
       meta: {
         tracePath: '/tmp/trace',
         generatedAt: '2026-05-07T00:00:00.000Z',

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -15,7 +15,7 @@ const ANALYSES_DIR = join(tmpdir(), `omk-test-analyses-${Date.now()}`);
 const DOCTORS_DIR = join(tmpdir(), `omk-test-doctors-${Date.now()}`);
 
 const SAMPLE_REPORT = {
-  reportKind: 'evaluation',
+  kind: 'evaluation',
   id: 'test-run-001',
   meta: {
     variants: ['v1', 'v2'],
@@ -145,7 +145,7 @@ describe('report-server', () => {
     writeFileSync(join(JOBS_DIR, 'job-test-run-001.json'), JSON.stringify(SAMPLE_JOB, null, 2));
     writeFileSync(join(JOBS_DIR, 'job-test-run-002.json'), JSON.stringify(FAILED_JOB, null, 2));
     writeFileSync(join(OBSERVATIONS_DIR, '2026-05-07T00-00-00-observe-inbox.json'), JSON.stringify({
-      reportKind: 'observe-inbox',
+      kind: 'observe-inbox',
       schemaVersion: 1,
       meta: {
         tracePath: '/tmp/trace',

--- a/test/server/skill-index-cache.test.ts
+++ b/test/server/skill-index-cache.test.ts
@@ -186,30 +186,6 @@ describe('buildSkillIndex 模块级缓存', () => {
     assert.notEqual(idx2, idx1, 'explicit reset bypasses fingerprint-eq check');
   });
 
-  it('legacy reportKind doctor JSON 仍会进入 skill index 的 doctor snapshot', () => {
-    const observationsDir = mkdtempSync(join(tmpdir(), 'omk-observations-'));
-    cleanupDirs.push(observationsDir);
-    writeFileSync(join(doctorsDir, 'legacy-doctor.json'), JSON.stringify({
-      reportKind: 'doctor',
-      schemaVersion: '2.0.0',
-      id: 'legacy-doctor',
-      timestamp: '2026-05-11T00:00:00.000Z',
-      skills: [{
-        skillName: 'audit',
-        status: 'warn',
-        results: [{ status: 'warn' }],
-      }],
-      totals: { pass: 0, warn: 1, fail: 0 },
-      outcome: 'warnings_only',
-      ruleStats: { pass: 0, warn: 1, fail: 0, skipped: 0, total: 1 },
-    }, null, 2));
-
-    const idx = buildSkillIndex([], analysesDir, doctorsDir, observationsDir);
-    assert.equal(idx.summary.withDoctor, 1);
-    assert.equal(idx.entries[0]?.doctor?.reportId, 'legacy-doctor');
-    assert.equal(idx.entries[0]?.doctor?.status, 'warn');
-  });
-
   it('case 4 (P2-a 核心 — analysesDir 里 same-name JSON 内容原地 in-place 覆写之后 fingerprint 必须 invalidate cache):reviewer 5/11 描述的"同份 analysis JSON 把 toolFailureRate 从 0 改成 0.9, server 进程内二次 buildSkillIndex 返回 same object reference 仍是旧值"那条 ship-blocker 锁定', () => {
     const reports = [mkReport('r1', '2026-05-11T00:00:00Z', 'foo')];
     const analysisJsonPath = join(analysesDir, 'health-2026-05-11.json');

--- a/test/server/skill-index-cache.test.ts
+++ b/test/server/skill-index-cache.test.ts
@@ -72,7 +72,7 @@ import type { EvaluationReport } from '../../src/types/index.js';
 
 function mkReport(id: string, ts: string, variant: string): EvaluationReport {
   return {
-    reportKind: 'evaluation',
+    kind: 'evaluation',
     id,
     meta: {
       variants: ['baseline', variant],

--- a/test/server/skill-index-cache.test.ts
+++ b/test/server/skill-index-cache.test.ts
@@ -186,6 +186,30 @@ describe('buildSkillIndex 模块级缓存', () => {
     assert.notEqual(idx2, idx1, 'explicit reset bypasses fingerprint-eq check');
   });
 
+  it('legacy reportKind doctor JSON 仍会进入 skill index 的 doctor snapshot', () => {
+    const observationsDir = mkdtempSync(join(tmpdir(), 'omk-observations-'));
+    cleanupDirs.push(observationsDir);
+    writeFileSync(join(doctorsDir, 'legacy-doctor.json'), JSON.stringify({
+      reportKind: 'doctor',
+      schemaVersion: '2.0.0',
+      id: 'legacy-doctor',
+      timestamp: '2026-05-11T00:00:00.000Z',
+      skills: [{
+        skillName: 'audit',
+        status: 'warn',
+        results: [{ status: 'warn' }],
+      }],
+      totals: { pass: 0, warn: 1, fail: 0 },
+      outcome: 'warnings_only',
+      ruleStats: { pass: 0, warn: 1, fail: 0, skipped: 0, total: 1 },
+    }, null, 2));
+
+    const idx = buildSkillIndex([], analysesDir, doctorsDir, observationsDir);
+    assert.equal(idx.summary.withDoctor, 1);
+    assert.equal(idx.entries[0]?.doctor?.reportId, 'legacy-doctor');
+    assert.equal(idx.entries[0]?.doctor?.status, 'warn');
+  });
+
   it('case 4 (P2-a 核心 — analysesDir 里 same-name JSON 内容原地 in-place 覆写之后 fingerprint 必须 invalidate cache):reviewer 5/11 描述的"同份 analysis JSON 把 toolFailureRate 从 0 改成 0.9, server 进程内二次 buildSkillIndex 返回 same object reference 仍是旧值"那条 ship-blocker 锁定', () => {
     const reports = [mkReport('r1', '2026-05-11T00:00:00Z', 'foo')];
     const analysisJsonPath = join(analysesDir, 'health-2026-05-11.json');

--- a/test/server/skill-insights.test.ts
+++ b/test/server/skill-insights.test.ts
@@ -54,7 +54,7 @@ function mkResult(sampleId: string, variant: string, opts: {
 
 function mkEvalReport(variant: string, results: ResultEntry[]): EvaluationReport {
   return {
-    reportKind: 'evaluation',
+    kind: 'evaluation',
     id: `${variant}-test-id`,
     meta: {
       variants: ['baseline', variant],

--- a/test/variance-layers.test.ts
+++ b/test/variance-layers.test.ts
@@ -41,7 +41,7 @@ function makeRun(runId: string, perVariant: Record<string, LayerSeed>): Report {
     };
   }
   return {
-    reportKind: 'evaluation',
+    kind: 'evaluation',
     id: runId,
     meta: {
       variants: Object.keys(perVariant),

--- a/test/variance-workflow.test.ts
+++ b/test/variance-workflow.test.ts
@@ -5,7 +5,7 @@ import type { Report, VariantSummary } from '../src/types/index.js';
 
 function makeReport(id: string, variantScores: Record<string, number>): Report {
   return {
-    reportKind: 'evaluation',
+    kind: 'evaluation',
     id,
     meta: {
       variants: Object.keys(variantScores),


### PR DESCRIPTION
## 用户影响
代码层面与落盘 JSON 统一只保留顶层 `kind`。对外消费 eval／batch／doctor／observe JSON 的脚本与内部系统，都需要把 `reportKind` 读取切到 `kind`。

## 迁移说明
这是一次有意的 schema cutover。本 PR 已删除全部 `reportKind` 兼容代码，不保留 `reportKind` 的双写或双读兼容。

升级前若本地或线上仍保留旧 JSON，必须先做一次性迁移：
- 把顶层 `reportKind` 重写为顶层 `kind`
- eval / batch report、doctor report、observe report 都按同一规则处理
- 外部消费方从 `obj.reportKind` 改为 `obj.kind`

如果不迁移旧文件，升级后这些历史 JSON 会被视为旧格式并跳过读取。

## 测量学 caveat
这次改动只统一落盘字段名与读取边界，不改评分管道、judge prompt、bootstrap 统计或 verdict 语义；受影响的是序列化 schema 与消费方解析逻辑，不是测量数值本身。

## 验证
已跑 `yarn lint`、`yarn build`、类型检查，以及 report／doctor／observe 相关针对性测试。当前仓库内已无 `reportKind` 代码引用。