### PR TITLE
chore(release): 发布 0.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 本次发布 0.36.0

自 0.35.0 起合入 main：
- #224 `omk list` —— 受管 skill 的证据状态与生命周期读出口（管理支柱 install → eval → list 闭环成型）。
- #225 `reportKind` → 顶层 `kind` 落盘统一（BREAKING-SCHEMA）。
- #226 发版前文档同步。

## ⚠️ Breaking changes（迁移说明）
#225 是落盘报告 schema 的硬切换：eval / batch / doctor / observe 报告的顶层判别字段从 `reportKind` 改为 `kind`，schema 版本同步抬升（report 3→4 / doctor 2.0.0→3.0.0 / observe 1→2），不保留双读兼容。

升级后，旧版本写的报告（顶层 `reportKind`、无 `kind`）会被视为旧格式**跳过读取** —— studio / observe inbox / doctor 历史不再显示这些旧报告。两种处理方式二选一：重新跑一次 eval / doctor / observe 生成新格式报告；或一次性把旧 JSON 顶层 `reportKind` 字段重写为 `kind`。

属序列化口径变更，不动评分管道 / judge prompt / bootstrap / verdict —— 测量数值跨 0.35.0 → 0.36.0 可比。

🤖 Generated with [Claude Code](https://claude.com/claude-code)