### PR TITLE
fix(cli): promote 回显的 CLI 入参 name/kind 洗白防终端注入

### DIFF
--- a/src/cli/commands/promote.ts
+++ b/src/cli/commands/promote.ts
@@ -80,14 +80,14 @@ export default class Promote extends BaseCommand {
       const name = args.name;
       const kind = flags.kind as ArtifactKind;
       if (!SUPPORTED_KINDS.includes(kind)) {
-        process.stderr.write(tCli('cli.promote.kind_unsupported', lang, { kind }) + '\n');
+        process.stderr.write(tCli('cli.promote.kind_unsupported', lang, { kind: sanitizeCell(String(kind)) }) + '\n');
         throw new CliExit(1);
       }
 
       const dir = flags.global ? globalManagedDir() : resolveManagedDir(managedDir());
       const record = loadManagedRecord(dir, managedRecordId(kind, name));
       if (!record) {
-        process.stderr.write(tCli('cli.promote.not_managed', lang, { name, kind }) + '\n');
+        process.stderr.write(tCli('cli.promote.not_managed', lang, { name: sanitizeCell(name), kind }) + '\n');
         throw new CliExit(1);
       }
 
@@ -101,7 +101,7 @@ export default class Promote extends BaseCommand {
         && record.decisions.some((d) => d.decisionKind === 'promote' && d.contentHash === record.contentHash);
       if (alreadyPromoted) {
         if (flags.json) this.log(JSON.stringify({ schemaVersion: 1, alreadyPromoted: { name, contentHash: record.contentHash } }, null, 2));
-        else process.stderr.write(tCli('cli.promote.already_promoted', lang, { name }) + '\n');
+        else process.stderr.write(tCli('cli.promote.already_promoted', lang, { name: sanitizeCell(name) }) + '\n');
         return;
       }
 
@@ -148,7 +148,7 @@ export default class Promote extends BaseCommand {
       this.log(JSON.stringify({ schemaVersion: 1, blocked: { name, reasons: gate.blocked.map((b) => ({ blockKind: b.blockKind, ...(b.detail ? { detail: b.detail } : {}) })) } }, null, 2));
       return;
     }
-    process.stderr.write(tCli('cli.promote.blocked_header', lang, { name }) + '\n');
+    process.stderr.write(tCli('cli.promote.blocked_header', lang, { name: sanitizeCell(name) }) + '\n');
     // detail 里的 verdict / judgePromptHash 来自不可信受管 JSON,文本路径先洗(与 list 同口径,防 ANSI/OSC 注入)。
     for (const b of gate.blocked) process.stderr.write(tCli(BLOCK_KEY[b.blockKind], lang, safeDetail(b.detail)) + '\n');
     if (gate.warnings.length > 0) process.stderr.write(tCli('cli.promote.incomparable_unverified', lang) + '\n');
@@ -168,7 +168,8 @@ export default class Promote extends BaseCommand {
     // hash / verdict / reportId 来自不可信受管 JSON,文本路径先洗(--json 路径上面已 return、保留原值)。
     const short = sanitizeCell(hash.slice(0, 12));
     const safeVerdict = sanitizeCell(verdict ?? 'UNKNOWN');
-    if (overridden) this.log(tCli('cli.promote.forced_override', lang, { name, hash: short, verdict: safeVerdict }));
-    else this.log(tCli('cli.promote.promoted', lang, { name, hash: short, verdict: safeVerdict, reportId: sanitizeCell(reportId ?? '—') }));
+    const safeName = sanitizeCell(name);
+    if (overridden) this.log(tCli('cli.promote.forced_override', lang, { name: safeName, hash: short, verdict: safeVerdict }));
+    else this.log(tCli('cli.promote.promoted', lang, { name: safeName, hash: short, verdict: safeVerdict, reportId: sanitizeCell(reportId ?? '—') }));
   }
 }

--- a/test/cli/promote-run.test.ts
+++ b/test/cli/promote-run.test.ts
@@ -192,6 +192,22 @@ describe('omk promote 端到端', () => {
     assert.ok(r.stderr.includes('No managed record'), r.stderr);
   });
 
+  it('--kind 非 skill → 退 1 kind_unsupported,点名收到的 kind', async () => {
+    const r = await run(['promote', 'review', '--kind', 'prompt']);
+    assert.equal(r.code, 1);
+    assert.ok(r.stderr.includes('only kind=skill'), `kind_unsupported 拦截:${r.stderr}`);
+    assert.ok(r.stderr.includes('prompt'), '点名收到的 kind');
+  });
+
+  it('CLI-arg name 含 ANSI/控制符 → 文本输出洗成 U+FFFD,不喷转义', async () => {
+    // name 是用户 CLI 入参,not_managed 回显路径必须洗白,防 ANSI/OSC 终端注入。
+    const r = await run(['promote', 'gh\x1b]0;PWNED\x07\x1b[2Jost']);
+    assert.equal(r.code, 1);
+    assert.ok(!r.stderr.includes('\x1b'), 'ESC 不得原样喷到终端');
+    assert.ok(!r.stderr.includes('\x07'), 'BEL 不得原样喷出');
+    assert.ok(r.stderr.includes('�'), '控制符应映射为 U+FFFD');
+  });
+
   it('--json:成功出版本化信封', async () => {
     writeRecord({ verdict: 'PROGRESS' });
     const r = await run(['promote', 'review', '--json']);


### PR DESCRIPTION
## 用户影响

`omk promote` 文本输出里回显的 `name`（CLI 位置参数）和 `kind`（`--kind` 入参）此前未经洗白，构造含 ANSI/OSC 转义序列的 skill 名调用 `omk promote`，转义会原样打到终端——攻击者可借此清屏、改窗口标题或注入伪造提示。本次把这些 user-facing 文本路径的 `name`/`kind` 统一过 `sanitizeCell`（控制符 / 零宽 / 双向覆写映射为 U+FFFD），与 `omk list` 同口径。`--json` 信封保持原值，脚本消费不受影响。

涉及分支：`not_managed` / `kind_unsupported` / `blocked_header` / `promoted` / `forced_override` / `already_promoted`。`promote` 此前已洗白记录派生字段（hash / verdict / reportId），本次补齐 CLI 入参侧的遗漏。

## 测量学 / 兼容性

纯防御性洗白，不动 report schema / judge prompt / 评分管道 / 受管记录 schema。无迁移，非 BREAKING。

## 验证

`yarn lint && yarn build && yarn test`（2002 测试）+ `yarn build:docs:check` 全绿。补两条端到端测：`--kind` 非 skill 的拦截覆盖、CLI-arg `name` 注入洗白回归。

收尾 #203 evidence-gated management 的 `omk promote`（#f539c7a）发现的两处 CR 残留。