### PR TITLE
chore(release): 发布 0.37.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 0.37.0

证据门禁管理支柱写侧闭环 —— 新增 `omk promote`（按证据门禁接受当前版本）与 `omk rollback`（撤销 promoted 接受），与已有 install / list / eval 自动写证据合成完整管理闭环。

同时纳入 #228：Studio 报告 UI 改版、doctor 新增 endpoint 维度（自指审查端点健康检查，含 SSRF 防护）、evolve 一键化（无用例时自动生成再自迭代）、双语落地页。

自 0.36.0 起全部 additive，未触碰报告 schema 语义、judge prompt、评分管道等测量学不变量，非破坏性。release notes 由 publish.yml 在打 tag 后从 PR 标题自动汇总。