### PR TITLE
feat(cli): omk eval init 收敛命名，omk init 保留为长期别名

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -196,6 +196,38 @@ omk eval gold validate <dir> [flags]
 
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 
+## omk eval init
+
+初始化 omk 项目脚手架（skills/ + eval-samples.json 模板）。
+
+**用法:**
+
+```bash
+omk eval init [targetDir] [flags]
+```
+
+**参数:**
+
+- `targetDir`(可选):初始化目标目录，默认当前目录（.）
+
+**Flags:**
+
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
+
+**示例:**
+
+> 在当前目录初始化
+
+```bash
+omk eval init
+```
+
+> 在指定目录初始化
+
+```bash
+omk eval init my-project
+```
+
 ## omk evolve
 
 自动迭代改进 skill:多轮 eval + skill 重写，直到达到 --target 或耗尽 --rounds。
@@ -256,7 +288,7 @@ omk evolve skills/my-skill/SKILL.md --target 4.5 --model opus --improve-model op
 
 ## omk init
 
-初始化 omk 项目脚手架（skills/ + eval-samples.json 模板）。
+初始化 omk 项目脚手架（skills/ + eval-samples.json 模板）。收敛后的命名是 omk eval init，本命令长期保留为别名。
 
 **用法:**
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ A/B test your prompts and skills with statistical rigor — bootstrap CI and len
 
 ```bash
 npm i -g oh-my-knowledge
-omk init demo && cd demo
+omk eval init demo && cd demo
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-That's it — no editing required. `omk init` scaffolds two skill variants and three sample cases; `omk eval` runs the controlled A/B and opens an HTML report with a one-line verdict in about five minutes.
+That's it — no editing required. `omk eval init` (alias: `omk init`) scaffolds two skill variants and three sample cases; `omk eval` runs the controlled A/B and opens an HTML report with a one-line verdict in about five minutes.
 
 > The CLI notifies you when a newer version is available (at most once per 20h); set `OMK_SKIP_UPDATE_CHECK=1` to silence it permanently.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -19,11 +19,11 @@
 
 ```bash
 npm i -g oh-my-knowledge
-omk init demo && cd demo
+omk eval init demo && cd demo
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-不用改任何文件 —— `omk init` 帮你脚手架两版 skill 和三条评测用例；`omk eval` 跑控制变量 A/B，5 分钟内出 HTML 报告 + 一行 verdict。
+不用改任何文件 —— `omk eval init`（别名：`omk init`）帮你脚手架两版 skill 和三条评测用例；`omk eval` 跑控制变量 A/B，5 分钟内出 HTML 报告 + 一行 verdict。
 
 > 命令行有新版本时会自动提示（每 20 小时最多一次）；想永久关闭该提醒，设环境变量 `OMK_SKIP_UPDATE_CHECK=1` 即可。
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,6 +24,8 @@ For full descriptions: `omk init --help`.
 
 Scaffolds an evaluation project with two starter skill variants and an `eval-samples.json` file.
 
+The converged name is `omk eval init`; `omk init` stays as a long-lived alias and behaves identically (it just prints a one-line hint pointing to the new name). Use either.
+
 ## `omk install`
 
 ```bash

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -24,6 +24,8 @@ omk init [目录]
 
 生成一个评测项目脚手架，包含两版 starter skill 和 `eval-samples.json`。
 
+收敛后的命名是 `omk eval init`；`omk init` 作为长期别名保留，行为完全一致（只是会多打一行指向新名的提示）。两者皆可。
+
 ## `omk install`
 
 ```bash

--- a/src/cli/commands/eval/init.ts
+++ b/src/cli/commands/eval/init.ts
@@ -1,0 +1,27 @@
+import { bilingual } from '../../oclif/i18n.js';
+import Init from '../init.js';
+
+/**
+ * `omk eval init` —— 项目脚手架的收敛后命名(归入 eval 命名空间)。实现完全复用 Init:继承同一套
+ * args / flags / run,仅覆写命令文案并关掉「改用 eval init」的收敛提示(自己就是收敛后的名字)。
+ * `omk init` 作为别名长期保留,见 commands/init.ts。
+ */
+export default class EvalInit extends Init {
+  static description = bilingual({
+    zh: '初始化 omk 项目脚手架（skills/ + eval-samples.json 模板）。',
+    en: 'Scaffold an omk project (skills/ + eval-samples.json templates).',
+  });
+
+  static examples = [
+    {
+      description: bilingual({ zh: '在当前目录初始化', en: 'Init in current directory' }),
+      command: '<%= config.bin %> eval init',
+    },
+    {
+      description: bilingual({ zh: '在指定目录初始化', en: 'Init in specified directory' }),
+      command: '<%= config.bin %> eval init my-project',
+    },
+  ];
+
+  protected emitRenameHint = false;
+}

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,94 +1,14 @@
-import { resolve, join } from 'node:path';
+import { resolve } from 'node:path';
 import { Args } from '@oclif/core';
 import { LANG_FLAG, bilingual, resolveLang } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { tCli } from '../lib/i18n.js';
-
-const INIT_SAMPLES = `[
-  {
-    "sample_id": "s001",
-    "prompt": "审查以下代码",
-    "context": "function authenticate(username, password) {\\n  const query = \`SELECT * FROM users WHERE name='\${username}' AND pass='\${password}'\`;\\n  return db.execute(query);\\n}",
-    "rubric": "应识别 SQL 注入风险，建议使用参数化查询",
-    "assertions": [
-      { "type": "contains", "value": "SQL", "weight": 1 },
-      { "type": "contains", "value": "injection", "weight": 1 },
-      { "type": "regex", "pattern": "parameterized|prepared|placeholder|bind", "flags": "i", "weight": 0.5 },
-      { "type": "not_contains", "value": "looks good", "weight": 0.5 }
-    ],
-    "dimensions": {
-      "security": "是否准确识别出 SQL 注入漏洞并说明其危害",
-      "actionability": "是否给出可直接使用的参数化查询修复代码"
-    }
-  },
-  {
-    "sample_id": "s002",
-    "prompt": "审查以下代码",
-    "context": "async function fetchData(url) {\\n  const res = await fetch(url);\\n  const data = await res.json();\\n  return data;\\n}",
-    "rubric": "应指出缺少错误处理（网络异常、非 JSON 响应、HTTP 错误状态码）",
-    "assertions": [
-      { "type": "contains", "value": "error handling", "weight": 1 },
-      { "type": "regex", "pattern": "try[\\\\s\\\\S]*catch|exception|error", "flags": "i", "weight": 1 },
-      { "type": "contains", "value": "status", "weight": 0.5 }
-    ],
-    "dimensions": {
-      "robustness": "是否指出了所有缺失的错误处理场景",
-      "actionability": "是否给出了完整的 try-catch 修复代码"
-    }
-  },
-  {
-    "sample_id": "s003",
-    "prompt": "审查以下代码",
-    "context": "function renderComment(comment) {\\n  document.getElementById('output').innerHTML = '<p>' + comment + '</p>';\\n}",
-    "rubric": "应识别 XSS 风险，建议使用 textContent 或转义 HTML",
-    "assertions": [
-      { "type": "contains", "value": "XSS", "weight": 1 },
-      { "type": "regex", "pattern": "textContent|escape|sanitize|sanitizer", "flags": "i", "weight": 1 },
-      { "type": "contains", "value": "innerHTML", "weight": 0.5 }
-    ],
-    "dimensions": {
-      "security": "是否准确识别出 XSS 漏洞并说明攻击方式",
-      "actionability": "是否给出使用 textContent 或转义的修复代码"
-    }
-  }
-]
-`;
-
-// 模板带 Claude Code SKILL.md 兼容 frontmatter(name + description),让用户
-// 可以把 init 出来的 SKILL.md 直接 deploy 到 ~/.claude/skills/ 给 Claude Code 用,
-// 一份文件双向 dogfood(omk 评测 + Claude 部署)。omk 当前不 strip frontmatter,
-// 它会跟着 leak 进 system prompt — 在 model 行为层面是无害噪声,跨 executor 一致。
-const INIT_SKILL_V1 = `---
-name: code-review-v1
-description: 简单代码审查 skill,识别明显问题
----
-
-# Code review v1
-
-你是一个代码审查助手。请审查用户提供的代码，指出潜在问题。
-`;
-
-const INIT_SKILL_V2 = `---
-name: code-review-v2
-description: 多维度代码审查,覆盖安全 / 健壮 / 可维护 / 性能,带严重程度标注
----
-
-# Code review v2
-
-你是一个高级代码审查专家。请从以下维度审查用户提供的代码：
-
-1. 安全性：是否存在注入、XSS、敏感信息泄露等风险
-2. 健壮性：是否有适当的错误处理和边界检查
-3. 可维护性：命名是否清晰、结构是否合理
-4. 性能：是否存在明显的性能瓶颈
-
-对每个维度给出具体的改进建议，并标注严重程度（高/中/低）。
-`;
+import { scaffoldInitProject } from '../lib/scaffold-init.js';
 
 export default class Init extends BaseCommand {
   static description = bilingual({
-    zh: '初始化 omk 项目脚手架（skills/ + eval-samples.json 模板）。',
-    en: 'Scaffold an omk project (skills/ + eval-samples.json templates).',
+    zh: '初始化 omk 项目脚手架（skills/ + eval-samples.json 模板）。收敛后的命名是 omk eval init，本命令长期保留为别名。',
+    en: 'Scaffold an omk project (skills/ + eval-samples.json templates). The converged name is `omk eval init`; this command stays as a long-lived alias.',
   });
 
   static examples = [
@@ -134,28 +54,16 @@ export default class Init extends BaseCommand {
     lang: LANG_FLAG,
   };
 
+  /** `omk init`(别名)打印收敛提示;`omk eval init`(收敛后命名)覆写为 false 不打。 */
+  protected emitRenameHint = true;
+
   async run(): Promise<void> {
     const { args } = await this.parse(Init);
     const lang = this.lang;
     await this.runWithCliExit(async () => {
-      const targetDir: string = resolve(args.targetDir || '.');
-      const { writeFileSync, mkdirSync } = await import('node:fs');
-
-      // omk skill loader 把 `skills/<name>/SKILL.md` 子目录识别为 directory-skill,
-      // cwd 默认锚到 skill 根目录,后续可在同目录下放 assets / 子文档。
-      mkdirSync(join(targetDir, 'skills', 'code-review-v1'), { recursive: true });
-      mkdirSync(join(targetDir, 'skills', 'code-review-v2'), { recursive: true });
-      writeFileSync(join(targetDir, 'eval-samples.json'), INIT_SAMPLES);
-      writeFileSync(join(targetDir, 'skills', 'code-review-v1', 'SKILL.md'), INIT_SKILL_V1);
-      writeFileSync(join(targetDir, 'skills', 'code-review-v2', 'SKILL.md'), INIT_SKILL_V2);
-
-      console.log(tCli('cli.init.scaffolded', lang, { dir: targetDir }));
-      console.log('');
-      console.log(tCli('cli.init.next_steps_title', lang));
-      console.log(tCli('cli.init.next_step_edit_samples', lang));
-      console.log(tCli('cli.init.next_step_edit_skills', lang));
-      console.log(tCli('cli.init.next_step_run', lang));
-      console.log(tCli('cli.init.note_codex_executor', lang));
+      scaffoldInitProject(resolve(args.targetDir || '.'), lang);
+      // 软提示走 stderr,不污染 stdout(脚本 / 管道只取 stdout)。omk init 仍长期可用,只是建议改用新名。
+      if (this.emitRenameHint) console.error(tCli('cli.init.prefer_eval_init', lang));
     });
   }
 }

--- a/src/cli/lib/i18n-dict/init.ts
+++ b/src/cli/lib/i18n-dict/init.ts
@@ -6,7 +6,8 @@ export type InitMessageKey =
   | 'cli.init.next_step_edit_samples'
   | 'cli.init.next_step_edit_skills'
   | 'cli.init.next_step_run'
-  | 'cli.init.note_codex_executor';
+  | 'cli.init.note_codex_executor'
+  | 'cli.init.prefer_eval_init';
 
 export const initDict: Record<InitMessageKey, CliMessage> = {
   'cli.init.scaffolded': {
@@ -32,5 +33,9 @@ export const initDict: Record<InitMessageKey, CliMessage> = {
   'cli.init.note_codex_executor': {
     zh: '\n注: omk 评测时把 SKILL.md 整文(含 frontmatter)作为 system prompt 注入——跨 executor 一致(claude / codex / openai-api / gemini 都走同一条路径,不依赖任何 executor 的 native skill auto-discovery 或 Skill 工具机制)。frontmatter 在 prompt 头部对 model 行为无显著影响。\n模板带 Claude Code 兼容的 frontmatter(name + description)是为了让同一份 directory-skill 也能 deploy 到 Claude Code:把整个目录复制到 ~/.claude/skills/code-review-v1/(整目录,不是单个 SKILL.md),Claude SDK 才能识别。这是 omk 评测之外的 bonus,一份文件双向 dogfood。',
     en: '\nNote: during omk evaluation the full SKILL.md (frontmatter included) is injected as the system prompt — uniformly across executors (claude / codex / openai-api / gemini all take the same path; omk does not rely on any executor\'s native skill auto-discovery or Skill tool). Frontmatter has no measurable impact on model behavior in this position.\nThe template ships with Claude Code-compatible frontmatter (name + description) so the same directory-skill can also be deployed to Claude Code: copy the whole directory to ~/.claude/skills/code-review-v1/ (the directory, not just SKILL.md) so Claude SDK can recognize it. That is a bonus beyond omk evaluation — one source, two-way dogfood.',
+  },
+  'cli.init.prefer_eval_init': {
+    zh: '\n提示：该命令已收敛到 omk eval init。omk init 仍长期可用，建议改用 omk eval init。',
+    en: '\nTip: this command has converged to `omk eval init`. `omk init` still works long-term, but prefer `omk eval init`.',
   },
 };

--- a/src/cli/lib/scaffold-init.ts
+++ b/src/cli/lib/scaffold-init.ts
@@ -1,0 +1,106 @@
+import { join } from 'node:path';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { tCli, type CliLang } from './i18n.js';
+
+// 项目脚手架的共享落盘逻辑 —— `omk eval init`(收敛后命名)与 `omk init`(长期保留的别名)共用同一份实现,
+// 命令类只负责 parse 入参与各自的提示文案,避免两处复制模板 / 落盘逻辑漂移。
+
+const INIT_SAMPLES = `[
+  {
+    "sample_id": "s001",
+    "prompt": "审查以下代码",
+    "context": "function authenticate(username, password) {\\n  const query = \`SELECT * FROM users WHERE name='\${username}' AND pass='\${password}'\`;\\n  return db.execute(query);\\n}",
+    "rubric": "应识别 SQL 注入风险，建议使用参数化查询",
+    "assertions": [
+      { "type": "contains", "value": "SQL", "weight": 1 },
+      { "type": "contains", "value": "injection", "weight": 1 },
+      { "type": "regex", "pattern": "parameterized|prepared|placeholder|bind", "flags": "i", "weight": 0.5 },
+      { "type": "not_contains", "value": "looks good", "weight": 0.5 }
+    ],
+    "dimensions": {
+      "security": "是否准确识别出 SQL 注入漏洞并说明其危害",
+      "actionability": "是否给出可直接使用的参数化查询修复代码"
+    }
+  },
+  {
+    "sample_id": "s002",
+    "prompt": "审查以下代码",
+    "context": "async function fetchData(url) {\\n  const res = await fetch(url);\\n  const data = await res.json();\\n  return data;\\n}",
+    "rubric": "应指出缺少错误处理（网络异常、非 JSON 响应、HTTP 错误状态码）",
+    "assertions": [
+      { "type": "contains", "value": "error handling", "weight": 1 },
+      { "type": "regex", "pattern": "try[\\\\s\\\\S]*catch|exception|error", "flags": "i", "weight": 1 },
+      { "type": "contains", "value": "status", "weight": 0.5 }
+    ],
+    "dimensions": {
+      "robustness": "是否指出了所有缺失的错误处理场景",
+      "actionability": "是否给出了完整的 try-catch 修复代码"
+    }
+  },
+  {
+    "sample_id": "s003",
+    "prompt": "审查以下代码",
+    "context": "function renderComment(comment) {\\n  document.getElementById('output').innerHTML = '<p>' + comment + '</p>';\\n}",
+    "rubric": "应识别 XSS 风险，建议使用 textContent 或转义 HTML",
+    "assertions": [
+      { "type": "contains", "value": "XSS", "weight": 1 },
+      { "type": "regex", "pattern": "textContent|escape|sanitize|sanitizer", "flags": "i", "weight": 1 },
+      { "type": "contains", "value": "innerHTML", "weight": 0.5 }
+    ],
+    "dimensions": {
+      "security": "是否准确识别出 XSS 漏洞并说明攻击方式",
+      "actionability": "是否给出使用 textContent 或转义的修复代码"
+    }
+  }
+]
+`;
+
+// 模板带 Claude Code SKILL.md 兼容 frontmatter(name + description),让用户
+// 可以把 init 出来的 SKILL.md 直接 deploy 到 ~/.claude/skills/ 给 Claude Code 用,
+// 一份文件双向 dogfood(omk 评测 + Claude 部署)。omk 当前不 strip frontmatter,
+// 它会跟着 leak 进 system prompt — 在 model 行为层面是无害噪声,跨 executor 一致。
+const INIT_SKILL_V1 = `---
+name: code-review-v1
+description: 简单代码审查 skill,识别明显问题
+---
+
+# Code review v1
+
+你是一个代码审查助手。请审查用户提供的代码，指出潜在问题。
+`;
+
+const INIT_SKILL_V2 = `---
+name: code-review-v2
+description: 多维度代码审查,覆盖安全 / 健壮 / 可维护 / 性能,带严重程度标注
+---
+
+# Code review v2
+
+你是一个高级代码审查专家。请从以下维度审查用户提供的代码：
+
+1. 安全性：是否存在注入、XSS、敏感信息泄露等风险
+2. 健壮性：是否有适当的错误处理和边界检查
+3. 可维护性：命名是否清晰、结构是否合理
+4. 性能：是否存在明显的性能瓶颈
+
+对每个维度给出具体的改进建议，并标注严重程度（高/中/低）。
+`;
+
+/** 在 targetDir 落 skills/ + eval-samples.json 模板,并打印下一步指引。命令类只调它。 */
+export function scaffoldInitProject(targetDir: string, lang: CliLang): void {
+  // omk skill loader 把 `skills/<name>/SKILL.md` 子目录识别为 directory-skill,
+  // cwd 默认锚到 skill 根目录,后续可在同目录下放 assets / 子文档。
+  mkdirSync(join(targetDir, 'skills', 'code-review-v1'), { recursive: true });
+  mkdirSync(join(targetDir, 'skills', 'code-review-v2'), { recursive: true });
+  writeFileSync(join(targetDir, 'eval-samples.json'), INIT_SAMPLES);
+  writeFileSync(join(targetDir, 'skills', 'code-review-v1', 'SKILL.md'), INIT_SKILL_V1);
+  writeFileSync(join(targetDir, 'skills', 'code-review-v2', 'SKILL.md'), INIT_SKILL_V2);
+
+  console.log(tCli('cli.init.scaffolded', lang, { dir: targetDir }));
+  console.log('');
+  console.log(tCli('cli.init.next_steps_title', lang));
+  console.log(tCli('cli.init.next_step_edit_samples', lang));
+  console.log(tCli('cli.init.next_step_edit_skills', lang));
+  console.log(tCli('cli.init.next_step_run', lang));
+  console.log(tCli('cli.init.note_codex_executor', lang));
+}

--- a/test/cli/oclif-eval-init.test.ts
+++ b/test/cli/oclif-eval-init.test.ts
@@ -1,0 +1,52 @@
+/**
+ * `omk eval init`(项目脚手架收敛后命名)验收 + `omk init` 别名行为:两者落盘一致,仅 `omk init` 在 stderr
+ * 打「建议改用 omk eval init」收敛提示,`omk eval init` 不打。提示走 stderr,不污染 stdout。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { promisify } from 'node:util';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = join(__dirname, '..', '..', 'dist', 'cli', 'index.js');
+
+describe('oclif eval init', () => {
+  it('--help:命令被发现且用法显示 omk eval init', async () => {
+    const { stdout } = await execFileAsync('node', [CLI, 'eval', 'init', '--help']);
+    assert.ok(stdout.includes('初始化 omk 项目脚手架'), `missing zh description:\n${stdout}`);
+    assert.ok(/omk eval init/.test(stdout), `usage should show "omk eval init":\n${stdout}`);
+  });
+
+  it('happy path:落 skills/ + eval-samples.json,且 stderr 无收敛提示', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-eval-init-'));
+    try {
+      const target = join(dir, 'project');
+      const { stdout, stderr } = await execFileAsync('node', [CLI, 'eval', 'init', target]);
+      assert.ok(stdout.includes('已初始化测评项目'), `missing scaffolded msg:\n${stdout}`);
+      assert.ok(existsSync(join(target, 'skills', 'code-review-v1', 'SKILL.md')), 'SKILL.md not created');
+      assert.ok(existsSync(join(target, 'eval-samples.json')), 'eval-samples.json not created');
+      assert.ok(!/omk eval init/.test(stderr), `eval init 不应打收敛提示, got stderr:\n${stderr}`);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('omk init 别名:落盘一致,但 stderr 打「建议改用 omk eval init」收敛提示', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-init-alias-'));
+    try {
+      const target = join(dir, 'project');
+      const { stdout, stderr } = await execFileAsync('node', [CLI, 'init', target]);
+      assert.ok(existsSync(join(target, 'eval-samples.json')), 'alias should scaffold identically');
+      assert.ok(!stdout.includes('建议改用'), '收敛提示应在 stderr 而非 stdout（不污染管道）');
+      assert.ok(/omk eval init/.test(stderr) && /建议改用/.test(stderr), `omk init 应在 stderr 提示收敛, got:\n${stderr}`);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
关闭 #239。

## 用户影响

项目脚手架命名收敛到 eval 命名空间：新增 `omk eval init` 作为 canonical 名（消解 omk 词汇里 `skill = 被测物` 与 onboarding 的歧义，并把脚手架归到 eval 主轴下）。`omk init` 作为长期别名保留，落盘行为完全一致，只是会在 stderr 多打一行「建议改用 omk eval init」的软提示——不污染 stdout（脚本 / 管道只取 stdout），老用户与既有文档的 `omk init` 继续可用。

## 设计

- 抽 scaffold 落盘逻辑到 `src/cli/lib/scaffold-init.ts` 共享 lib，模板与下一步指引单一来源。
- `omk eval init`（`commands/eval/init.ts`）继承 `Init`，复用同一套 args / flags / run，仅覆写命令文案并关掉收敛提示；oclif 文件目录路由自动接管（与既有 `omk eval gold init` 同模式）。
- `omk init`（`commands/init.ts`）打软提示，`omk eval init` 不打。

## 兼容策略（#239 待决项的落地）

无硬弃用、无移除时间表：`omk init` 永久保留为别名。这是 #239「保留期 alias 与弃用提示策略」的最小破坏选择。

## 验证

`omk eval init --help` 被发现、用法显示 `omk eval init`；`omk eval init <dir>` 落盘且 stderr 无提示；`omk init <dir>` 落盘一致且 stderr 有收敛提示——3 条 e2e 锁定。lint / build / `build:docs:check` 绿，166 文件 2105 测试全绿。不碰任何测量学不变量。

README（EN/zh）quickstart 与 `docs/reference/cli.md`（EN/zh）改用 `omk eval init` 并标注别名；`.agents/.../commands.md` 随 `yarn build:docs` regen。

Relates to #203（正交项，CLI 面收敛轨）。