### PR TITLE
chore(cli): 厘清 omk init 语义为「初始化一个 omk 项目」

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -196,6 +196,38 @@ omk eval gold validate <dir> [flags]
 
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 
+## omk eval init
+
+初始化 omk 项目脚手架（skills/ + eval-samples.json 模板）。
+
+**用法:**
+
+```bash
+omk eval init [targetDir] [flags]
+```
+
+**参数:**
+
+- `targetDir`(可选):初始化目标目录，默认当前目录（.）
+
+**Flags:**
+
+- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
+
+**示例:**
+
+> 在当前目录初始化
+
+```bash
+omk eval init
+```
+
+> 在指定目录初始化
+
+```bash
+omk eval init my-project
+```
+
 ## omk evolve
 
 自动迭代改进 skill:多轮 eval + skill 重写，直到达到 --target 或耗尽 --rounds。
@@ -256,7 +288,7 @@ omk evolve skills/my-skill/SKILL.md --target 4.5 --model opus --improve-model op
 
 ## omk init
 
-初始化 omk 项目脚手架（skills/ + eval-samples.json 模板）。
+初始化一个 omk 项目：在目标目录铺好待测知识载体（skills/）与评测用例（eval-samples.json），供 omk eval / doctor / evolve / observe / list 操作。默认是两版 code-review skill 的 A/B 起步模板。
 
 **用法:**
 
@@ -274,13 +306,13 @@ omk init [targetDir] [flags]
 
 **示例:**
 
-> 在当前目录初始化
+> 在当前目录初始化一个 omk 项目
 
 ```bash
 omk init
 ```
 
-> 在指定目录初始化
+> 在指定目录初始化一个 omk 项目
 
 ```bash
 omk init my-project

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -196,38 +196,6 @@ omk eval gold validate <dir> [flags]
 
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 
-## omk eval init
-
-初始化 omk 项目脚手架（skills/ + eval-samples.json 模板）。
-
-**用法:**
-
-```bash
-omk eval init [targetDir] [flags]
-```
-
-**参数:**
-
-- `targetDir`(可选):初始化目标目录，默认当前目录（.）
-
-**Flags:**
-
-- `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
-
-**示例:**
-
-> 在当前目录初始化
-
-```bash
-omk eval init
-```
-
-> 在指定目录初始化
-
-```bash
-omk eval init my-project
-```
-
 ## omk evolve
 
 自动迭代改进 skill:多轮 eval + skill 重写，直到达到 --target 或耗尽 --rounds。

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # omk CLI reference
 
-omk exposes a workflow CLI for knowledge artifacts. Top-level commands cover the full loop: `init` (scaffold) · `install` (install the official omk Agent Skill) · `list` (managed skills & evidence status) · `promote` (accept a version on evidence) · `rollback` (revoke a promotion) · `doctor` (static check) · `eval` (offline A/B) · `observe` (online trace) · `evolve` (auto-iterate a skill) · `sample` (generate or fill test cases) · `studio` (local web UI for reports & analysis).
+omk exposes a workflow CLI for knowledge artifacts. Top-level commands cover the full loop: `init` (initialize an omk project) · `install` (install the official omk Agent Skill) · `list` (managed skills & evidence status) · `promote` (accept a version on evidence) · `rollback` (revoke a promotion) · `doctor` (static check) · `eval` (offline A/B) · `observe` (online trace) · `evolve` (auto-iterate a skill) · `sample` (generate or fill test cases) · `studio` (local web UI for reports & analysis).
 
 <!-- Maintainers: the Flags blocks in this file are auto-generated from the oclif command source by scripts/build-docs.ts. Run `yarn build:docs` after editing CLI flags; `yarn build:docs:check` runs in CI to catch drift. -->
 
@@ -22,7 +22,7 @@ For full descriptions: `omk init --help`.
 
 <!-- omk:cli:init:flags:end -->
 
-Scaffolds an evaluation project with two starter skill variants and an `eval-samples.json` file.
+Initializes an **omk project** in the target directory: knowledge artifacts to measure (today `skills/<name>/SKILL.md`) plus their eval samples (`eval-samples.json`) — the per-directory workspace that `omk eval` / `doctor` / `evolve` / `observe` / `list` all operate on. Like a git repo, you have one per measurement target (the sample set is the measurement context, so it travels with the artifact, not globally). The managed registry (`install` / `list` / `promote`, optionally global) is a separate layer `init` does not touch. The two starter skill variants + three sample cases are just the default A/B template.
 
 ## `omk install`
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -1,6 +1,6 @@
 # omk CLI 参考
 
-omk 的公开 CLI 由顶层命令构成完整闭环：`init`（脚手架）·`install`（安装 omk 官方 Agent Skill）·`list`（受管 skill 与证据状态）·`promote`（按证据接受版本）·`rollback`（撤销一次 promote）·`doctor`（静态检查）·`eval`（离线 A/B 评测）·`observe`（线上 trace 观测）·`evolve`（多轮自动迭代 skill）·`sample`（生成或补齐评测用例）·`studio`（本地 Web 工作台，看报告 / 分析）。
+omk 的公开 CLI 由顶层命令构成完整闭环：`init`（初始化一个 omk 项目）·`install`（安装 omk 官方 Agent Skill）·`list`（受管 skill 与证据状态）·`promote`（按证据接受版本）·`rollback`（撤销一次 promote）·`doctor`（静态检查）·`eval`（离线 A/B 评测）·`observe`（线上 trace 观测）·`evolve`（多轮自动迭代 skill）·`sample`（生成或补齐评测用例）·`studio`（本地 Web 工作台，看报告 / 分析）。
 
 <!-- 维护者须知：本文件里的 Flags 区块由 scripts/build-docs.ts 从 oclif 命令源码自动生成。改 CLI flag 后跑 `yarn build:docs` 同步；CI 跑 `yarn build:docs:check` 拦截 drift。 -->
 
@@ -22,7 +22,7 @@ omk init [目录]
 
 <!-- omk:cli:init:flags:end -->
 
-生成一个评测项目脚手架，包含两版 starter skill 和 `eval-samples.json`。
+在目标目录初始化一个 **omk 项目**：待测知识载体（今天是 `skills/<name>/SKILL.md`）+ 它们的评测用例（`eval-samples.json`）—— 这是 `omk eval` / `doctor` / `evolve` / `observe` / `list` 共同操作的「每目录工作区」。跟 git 仓库一样，一个测量目标一个项目（用例集就是测量上下文，随载体走、不全局共享）。受管登记表（`install` / `list` / `promote`，可全局）是另一层，不归 `init` 管。现有两版 skill + 三条用例只是默认的 A/B 起步模板。
 
 ## `omk install`
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -87,22 +87,22 @@ description: 多维度代码审查,覆盖安全 / 健壮 / 可维护 / 性能,�
 
 export default class Init extends BaseCommand {
   static description = bilingual({
-    zh: '初始化 omk 项目脚手架（skills/ + eval-samples.json 模板）。',
-    en: 'Scaffold an omk project (skills/ + eval-samples.json templates).',
+    zh: '初始化一个 omk 项目：在目标目录铺好待测知识载体（skills/）与评测用例（eval-samples.json），供 omk eval / doctor / evolve / observe / list 操作。默认是两版 code-review skill 的 A/B 起步模板。',
+    en: 'Initialize an omk project: scaffold knowledge artifacts (skills/) and eval samples (eval-samples.json) in the target dir for omk eval / doctor / evolve / observe / list to work on. Ships a two-variant code-review A/B starter template by default.',
   });
 
   static examples = [
     {
       description: bilingual({
-        zh: '在当前目录初始化',
-        en: 'Init in current directory',
+        zh: '在当前目录初始化一个 omk 项目',
+        en: 'Initialize an omk project in the current directory',
       }),
       command: '<%= config.bin %> init',
     },
     {
       description: bilingual({
-        zh: '在指定目录初始化',
-        en: 'Init in specified directory',
+        zh: '在指定目录初始化一个 omk 项目',
+        en: 'Initialize an omk project in a specified directory',
       }),
       command: '<%= config.bin %> init my-project',
     },

--- a/src/cli/lib/i18n-dict/init.ts
+++ b/src/cli/lib/i18n-dict/init.ts
@@ -10,8 +10,8 @@ export type InitMessageKey =
 
 export const initDict: Record<InitMessageKey, CliMessage> = {
   'cli.init.scaffolded': {
-    zh: '已初始化测评项目: {dir}',
-    en: 'Eval project scaffolded at: {dir}',
+    zh: '已初始化 omk 项目: {dir}',
+    en: 'omk project initialized at: {dir}',
   },
   'cli.init.next_steps_title': {
     zh: '下一步:',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -324,11 +324,11 @@ describe('CLI', () => {
     assert.ok(!body.includes('--each'));
   });
 
-  it('init scaffolds eval project from top-level command', async () => {
+  it('init initializes an omk project from top-level command', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'omk-init-'));
     try {
       const { stdout } = await execFileAsync('node', [CLI, 'init', dir]);
-      assert.ok(stdout.includes('已初始化测评项目'));
+      assert.ok(stdout.includes('已初始化 omk 项目'));
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -26,13 +26,13 @@ interface ExecError extends Error {
 describe('oclif init', () => {
   it('--help 默认 zh', async () => {
     const { stdout } = await execFileAsync('node', [CLI, 'init', '--help']);
-    assert.ok(stdout.includes('初始化 omk 项目脚手架'), `stdout missing zh description:\n${stdout}`);
+    assert.ok(stdout.includes('初始化一个 omk 项目'), `stdout missing zh description:\n${stdout}`);
     assert.ok(stdout.includes('TARGETDIR'), 'stdout missing positional');
   });
 
   it('--help --lang en', async () => {
     const { stdout } = await execFileAsync('node', [CLI, 'init', '--help', '--lang', 'en']);
-    assert.ok(stdout.includes('Scaffold an omk project'), 'stdout should contain en description');
+    assert.ok(stdout.includes('Initialize an omk project'), 'stdout should contain en description');
   });
 
   it('unknown flag → exit 2', async () => {
@@ -50,7 +50,7 @@ describe('oclif init', () => {
     try {
       const target = join(dir, 'project');
       const { stdout } = await execFileAsync('node', [CLI, 'init', target]);
-      assert.ok(stdout.includes('已初始化测评项目'), `stdout missing scaffolded msg:\n${stdout}`);
+      assert.ok(stdout.includes('已初始化 omk 项目'), `stdout missing scaffolded msg:\n${stdout}`);
       assert.ok(existsSync(join(target, 'skills', 'code-review-v1', 'SKILL.md')), 'skills/code-review-v1/SKILL.md not created');
       assert.ok(existsSync(join(target, 'eval-samples.json')), 'eval-samples.json not created');
     } finally {


### PR DESCRIPTION
关闭 #239。

## 背景

`omk init` 的歧义不在命令层级，在**宾语缺失**——命令名通用、干的事具体（铺两版 skill + 用例做 A/B）。`omk eval init` 改名方向（PR #240）经讨论否决：omk 是多支柱工具（评测 / 管理 / 观测），onboarding 不该钉死在 eval 一柱，且顶层 `init` 是行业通识（git / npm / cargo），把它埋进 eval 子命令反而成平命令面里的异类。

## 改动

把 `init` 的宾语钉成「**一个 omk 项目**（每目录工作区：待测知识载体 + 评测用例，供 `omk eval` / `doctor` / `evolve` / `observe` / `list` 操作）」：

- 输出文案 `已初始化测评项目` → `已初始化 omk 项目`（en 同步）。
- help / 描述 / examples 重写成「初始化一个 omk 项目」，现有两版 A/B 内容明确降为默认起步模板。
- `cli.md`（EN/zh）补定义：项目 = 每目录工作区、一个测量目标一份（同 git，用例集就是测量上下文不能全局共享）；受管登记表（`install` / `list` / `promote`，可全局）是另一层、不归 `init`。
- `commands.md` 随 `yarn build:docs` regen。

## 不做

不改名为 `omk eval init`、不加别名、**不动任何行为**（落盘文件不变，仅语义文案）。不碰测量学不变量。

## 验证

lint / build / `build:docs:check` 绿，165 文件 2102 测试全绿。

Relates to #203（正交项，CLI 面）。