### PR TITLE
feat(server): Studio 受管 skill 决策史页（/managed 列表 + 时间线）

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -2,21 +2,15 @@ import { Flags } from '@oclif/core';
 import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { tCli } from '../lib/i18n.js';
-import { probeSourceState } from '../lib/source-probe.js';
 import { sanitizeCell } from '../lib/cell-format.js';
 import {
-  buildManagedListRows,
   globalManagedDir,
-  loadAllManagedRecords,
+  listManagedRows,
   managedDir,
   resolveManagedDir,
   type ManagedListRow,
 } from '../../managed/index.js';
 import type { CliLang } from '../lib/i18n.js';
-
-// 源探测(含 DoS / 软硬链 / 投毒守卫)已抽到 ../lib/source-probe.js,promote 复用同一套守卫与 drift 判定。
-// 此处 re-export 保持既有 import 入口不破(test/cli/list-probe.test.ts 仍从本文件取 probeSourceState)。
-export { probeSourceState };
 
 /** CJK 全角字符按 2 列计宽,使含中文表头的列也能对齐。 */
 export function dispWidth(s: string): number {
@@ -97,8 +91,7 @@ export default class List extends BaseCommand {
     const lang = this.lang;
     await this.runWithCliExit(async () => {
       const dir = flags.global ? globalManagedDir() : resolveManagedDir(managedDir());
-      const records = loadAllManagedRecords(dir);
-      const rows = buildManagedListRows(records, probeSourceState);
+      const rows = listManagedRows(dir);
 
       if (flags.json) {
         // 版本化信封 —— 与 eval / doctor / diagnosis 等机读出口一致(都带 schemaVersion),让未来字段增删 /

--- a/src/cli/commands/promote.ts
+++ b/src/cli/commands/promote.ts
@@ -4,7 +4,6 @@ import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
 import { CliExit } from '../lib/cli-exit.js';
-import { probeSourceState } from '../lib/source-probe.js';
 import { sanitizeCell } from '../lib/cell-format.js';
 import { getJudgePromptHash } from '../../grading/judge.js';
 import {
@@ -13,6 +12,7 @@ import {
   globalManagedDir,
   isCurrentlyPromoted,
   loadManagedRecord,
+  probeSourceState,
   managedDir,
   managedRecordId,
   resolveManagedDir,

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -82,7 +82,9 @@ export async function runStudio(
     reportsDir: resolve(reportsDir),
     ...(flags['analyses-dir'] ? { analysesDir: resolve(flags['analyses-dir']) } : {}),
     ...(flags['observations-dir'] ? { observationsDir: resolve(flags['observations-dir']) } : {}),
-    managedDir: resolveManagedDir(managedDir()),
+    // 传解析器而非解析结果:Studio 是长会话,受管根目录要按请求解析(项目首次 install 后从 global 切回
+    // project),与 omk list 同口径;若在此处一次性解析、冻结进 server,长会话里会与 CLI 分叉。
+    managedDir: (): string => resolveManagedDir(managedDir()),
   });
 
   const url = await server.start();

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -5,6 +5,7 @@ import { BaseCommand } from '../oclif/base-command.js';
 import { integerStringParser } from '../oclif/parsers.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
 import { DEFAULT_REPORTS_DIR } from '../lib/parse-run-config.js';
+import { resolveManagedDir, managedDir } from '../../managed/index.js';
 import type { ReportServer } from '../lib/shared.js';
 import type { StudioArgs, StudioFlags } from '../lib/cmd-flags.js';
 
@@ -81,6 +82,7 @@ export async function runStudio(
     reportsDir: resolve(reportsDir),
     ...(flags['analyses-dir'] ? { analysesDir: resolve(flags['analyses-dir']) } : {}),
     ...(flags['observations-dir'] ? { observationsDir: resolve(flags['observations-dir']) } : {}),
+    managedDir: resolveManagedDir(managedDir()),
   });
 
   const url = await server.start();

--- a/src/cli/lib/record-evolve-outcome.ts
+++ b/src/cli/lib/record-evolve-outcome.ts
@@ -10,8 +10,8 @@ import {
   appendManagedEvidence,
   rebaselineManagedContentHash,
   buildEvidenceRef,
+  probeSourceState,
 } from '../../managed/index.js';
-import { probeSourceState } from './source-probe.js';
 import type { EvaluationReport, ManagedArtifactRecord, ManagedEvidenceRef } from '../../types/index.js';
 
 export interface EvolveOutcomeInput {

--- a/src/cli/lib/source-probe.ts
+++ b/src/cli/lib/source-probe.ts
@@ -1,0 +1,113 @@
+import { existsSync, lstatSync, readdirSync, type Dirent } from 'node:fs';
+import { isAbsolute, resolve, join } from 'node:path';
+import { resolveInstallSource } from '../../inputs/source-resolver.js';
+import { hashArtifactSource, isDistributablePath, type SourceProbe } from '../../managed/index.js';
+import type { ManagedArtifactRecord } from '../../types/index.js';
+
+/**
+ * 受管记录**当前源**的状态探测——`omk list`(drift / 生命周期)与 `omk promote`(门禁前先确认源未漂)共用
+ * 的单一来源。两命令必须用同一套守卫与 drift 判定:否则 list 显示「未漂」而 promote 判「漂」(或反之)会
+ * 互相矛盾,且安全守卫一旦各写一份必然漂掉一份。
+ *
+ * 本地源读取成本上限:skill 是小体量 markdown(+少量 references 资产),远超这些边界的源必是手改 / 投毒,
+ * 拒读避免只读命令(读盘上可能随仓库分发的 locator)被 /dev/zero / 超大文件 / 巨型目录递归拖垮(DoS)。
+ */
+const MAX_FILE_SOURCE_BYTES = 8 * 1024 * 1024; // 单文件-skill 上限
+const MAX_DIR_SOURCE_BYTES = 64 * 1024 * 1024; // 目录-skill 整树累计上限
+const MAX_DIR_SOURCE_FILES = 4000;             // 目录-skill 文件数上限
+const MAX_DIR_SOURCE_DEPTH = 64;               // 目录递归深度上限
+
+/**
+ * 目录-skill 源的**有边界**整树哈:先恢复 resolveFileSource 的形态校验(SKILL.md 存在、是常规文件、非
+ * 软链 —— 否则 locator 可指向任意可读目录让递归读整棵树),再 stat-walk(只 stat 不读)按与
+ * hashArtifactSource 同一 `isDistributablePath` 过滤累计 文件数 / 字节 / 深度,超界即返回 null(unreachable),
+ * 把单文件 DoS 不再换成目录递归 DoS。通过后才真正 hashArtifactSource。返回 null = 拒读 / 非法 skill 目录。
+ */
+function boundedDirSkillHash(abs: string): string | null {
+  const skillMd = join(abs, 'SKILL.md');
+  let md: ReturnType<typeof lstatSync>;
+  try {
+    md = lstatSync(skillMd);
+  } catch {
+    return null; // 无 SKILL.md → 不是 skill 目录,拒
+  }
+  if (md.isSymbolicLink() || !md.isFile() || md.nlink !== 1) return null; // SKILL.md 必须是常规、非软链、非硬链
+  let files = 0;
+  let bytes = 0;
+  const within = (dir: string, segs: string[], depth: number): boolean => {
+    if (depth > MAX_DIR_SOURCE_DEPTH) return false;
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+    for (const e of entries) {
+      const ns = [...segs, e.name];
+      if (!isDistributablePath(ns)) continue; // 与 hashArtifactSource 读取范围一致
+      if (e.isDirectory()) {
+        if (!within(join(dir, e.name), ns, depth + 1)) return false;
+      } else if (e.isFile()) { // 软链 Dirent 既非 isFile 也非 isDirectory → 天然跳过
+        if (++files > MAX_DIR_SOURCE_FILES) return false;
+        try {
+          const fst = lstatSync(join(dir, e.name));
+          if (fst.nlink !== 1) return false; // 硬链(nlink>1)可在树内别名树外敏感 inode → 拒读整树
+          bytes += fst.size;
+        } catch {
+          return false;
+        }
+        if (bytes > MAX_DIR_SOURCE_BYTES) return false;
+      }
+    }
+    return true;
+  };
+  if (!within(abs, [], 0)) return null;
+  return hashArtifactSource(abs, true);
+}
+
+/**
+ * 探测一条受管记录**当前源**的状态(三态,喂 buildManagedListRow 判 drift / 生命周期)。
+ *   - 远端 git(带 url):源身份钉不可变 SHA(install 时 pin),内容恒定 → 直接取 record.contentHash,
+ *     不联网(快读命令不为 drift 检查发网络请求)。reachable。
+ *   - 本地 git:locator `git:<ref>:<spec>` 复用 resolveInstallSource 在**仓库对象库**内重物化重哈
+ *     (读取受 git 边界约束,无任意文件读 DoS)。解析不到(常因 cwd 与 install 时不同、spec 随 cwd 漂)
+ *     → 抛错 → **reachable:false(未核,不当 stale)**,避免对未改动的 skill 误报漂移。
+ *   - 本地 file:locator 是绝对路径,但受管 JSON **用户可手改 / 随仓库分发**(无 install、无 opt-in 即被
+ *     loadAllManagedRecords 读到)。只读命令绝不盲读任意路径:**拒软链、只读常规文件 / 真目录、单文件
+ *     设 size cap**(挡 `evil.md → /dev/zero` 这类 readFileSync 无界 DoS 与项目外任意读)。守卫不过 →
+ *     reachable:false。目录-skill 整树哈本就跳软链(hashArtifactSource 用 isFile() 过滤)。
+ */
+export function probeSourceState(record: ManagedArtifactRecord): SourceProbe {
+  const s = record.source;
+  if (s.sourceKind === 'git' && s.url) return { reachable: true, hash: record.contentHash };
+  try {
+    if (s.sourceKind === 'git') {
+      const resolved = resolveInstallSource(s.locator);
+      try {
+        return { reachable: true, hash: hashArtifactSource(resolved.localRoot, resolved.isDirectorySkill) };
+      } finally {
+        resolved.cleanup();
+      }
+    }
+    // 本地 file 源:守卫后再读。locator 必须是 install 实际写出的形态(绝对路径) —— 受管 JSON 随仓库
+    // 分发、无 opt-in 即被读到,相对 locator 不是 install 产物,拒,避免按 cwd 解析到项目外。
+    if (!isAbsolute(s.locator)) return { reachable: false };
+    const abs = resolve(s.locator);
+    if (!existsSync(abs)) return { reachable: false };
+    const st = lstatSync(abs); // lstat:不跟随软链 —— 软链直接拒(防 evil.md → /dev/zero)
+    if (st.isSymbolicLink()) return { reachable: false };
+    if (s.isDirectorySkill) {
+      if (!st.isDirectory()) return { reachable: false };
+      const hash = boundedDirSkillHash(abs); // 形态校验 + 成本边界(防任意目录递归读 / 目录 DoS)
+      return hash === null ? { reachable: false } : { reachable: true, hash };
+    }
+    // 单文件-skill:恢复 install(resolveFileSource)的形态约束 —— 必须是 `.md` 常规文件、非硬链、≤ size cap。
+    // 否则攻击者可写 locator:`/etc/passwd` / `~/.ssh/id_rsa`(非 .md 直接拒),或用 `.md` 命名的**硬链**别名
+    // 树外敏感文件绕过扩展名 / 软链守卫(lstat 分不出硬链)→ 诱 list 把任意本地文件读进进程参与 hash。install
+    // 写出的是 nlink=1 的全新副本,拒 nlink>1 不误伤合法源。非 install 形态一律 reachable:false。
+    if (!/\.md$/i.test(abs) || !st.isFile() || st.nlink !== 1 || st.size > MAX_FILE_SOURCE_BYTES) return { reachable: false };
+    return { reachable: true, hash: hashArtifactSource(abs, false) };
+  } catch {
+    return { reachable: false };
+  }
+}

--- a/src/managed/index.ts
+++ b/src/managed/index.ts
@@ -5,4 +5,6 @@
 export * from './store.js';
 export * from './evidence.js';
 export * from './list-view.js';
+export * from './list-query.js';
+export * from './source-probe.js';
 export * from './promote-gate.js';

--- a/src/managed/list-query.ts
+++ b/src/managed/list-query.ts
@@ -1,0 +1,12 @@
+import { buildManagedListRows, type ManagedListRow } from './list-view.js';
+import { loadAllManagedRecords } from './store.js';
+import { probeSourceState } from './source-probe.js';
+
+/**
+ * 「读受管记录做展示」的单一编排:load 全部记录 → 逐条源探测(drift / 生命周期)→ 展示行。
+ * omk list(CLI) 与 Studio(report-server) 共用同一口径,避免两个交付层各串一份。
+ * dir 省略时走 loadAllManagedRecords 的 project→global 回退。
+ */
+export function listManagedRows(dir?: string): ManagedListRow[] {
+  return buildManagedListRows(loadAllManagedRecords(dir), probeSourceState);
+}

--- a/src/managed/source-probe.ts
+++ b/src/managed/source-probe.ts
@@ -1,8 +1,9 @@
 import { existsSync, lstatSync, readdirSync, type Dirent } from 'node:fs';
 import { isAbsolute, resolve, join } from 'node:path';
-import { resolveInstallSource } from '../../inputs/source-resolver.js';
-import { hashArtifactSource, isDistributablePath, type SourceProbe } from '../../managed/index.js';
-import type { ManagedArtifactRecord } from '../../types/index.js';
+import { resolveInstallSource } from '../inputs/source-resolver.js';
+import { hashArtifactSource, isDistributablePath } from '../inputs/content-hash.js';
+import type { SourceProbe } from './list-view.js';
+import type { ManagedArtifactRecord } from '../types/index.js';
 
 /**
  * 受管记录**当前源**的状态探测——`omk list`(drift / 生命周期)与 `omk promote`(门禁前先确认源未漂)共用

--- a/src/renderer/managed-history-renderer.ts
+++ b/src/renderer/managed-history-renderer.ts
@@ -163,12 +163,26 @@ function stateBand(state: string): string {
   return state === 'promoted' ? 'green' : state === 'stale' ? 'red' : state === 'measurable' ? 'accent' : 'muted';
 }
 
+/** 生命周期状态的面向用户文案 + 一句话释义(挂 title)。原始 token 仍在 /api/managed 的 row.state（机读口径不变）,
+ *  此处只本地化人看的 HTML —— measurable / installed 这类内部枚举对首次接触管理支柱的人并不自解释。 */
+function stateMeta(state: string, lang: Lang): { label: string; tip: string } {
+  const t = L(lang);
+  switch (state) {
+    case 'promoted': return { label: t('已采用', 'Promoted'), tip: t('已按证据人工复核并接受当前内容', 'Manually reviewed and accepted on evidence') };
+    case 'measurable': return { label: t('证据就绪', 'Measurable'), tip: t('当前内容已有有效证据，可进入采用门禁', 'Current content has valid evidence; ready for the promote gate') };
+    case 'stale': return { label: t('已漂移', 'Drifted'), tip: t('源内容已变更、脱离证据，需重跑 omk eval 取证', 'Source changed off its evidence — re-run omk eval') };
+    case 'installed': return { label: t('已纳管', 'Installed'), tip: t('已纳入管理，当前内容尚无有效证据', 'Under management; no valid evidence for current content yet') };
+    default: return { label: state, tip: state };
+  }
+}
+
 function listRow(row: ManagedListRow, lang: Lang): string {
   const t = L(lang);
-  const mark = !row.reachable ? ' <span class="mh-mark mh-mark--q" title="' + t('源未核', 'unverified') + '">?</span>'
-    : row.state === 'stale' ? ' <span class="mh-mark mh-mark--warn">⚠️</span>' : '';
+  const st = stateMeta(row.state, lang);
+  const mark = !row.reachable ? ' <span class="mh-mark mh-mark--q" title="' + e(t('源不可达 / 拒读，漂移未核', 'source unreachable / refused, drift unchecked')) + '">?</span>'
+    : row.state === 'stale' ? ' <span class="mh-mark mh-mark--warn" title="' + e(t('已漂移，需重测', 'drifted, re-measure')) + '">⚠️</span>' : '';
   return `<a class="mh-row" href="/managed/${encodeURIComponent(row.id)}${langQuery(lang)}">
-    <span class="mh-row-state"><span class="mh-dot mh-dot--${stateBand(row.state)}"></span>${e(row.state)}${mark}</span>
+    <span class="mh-row-state" title="${e(st.tip)}"><span class="mh-dot mh-dot--${stateBand(row.state)}"></span>${e(st.label)}${mark}</span>
     <span class="mh-row-name">${e(row.name)}</span>
     <span class="mh-row-kind">${e(row.kind)}</span>
     <span class="mh-row-verdict">${row.latestVerdict ? verdictBadge(row.latestVerdict, lang) : '—'}</span>
@@ -187,13 +201,24 @@ export function renderManagedList(rows: ManagedListRow[], lang: Lang): string {
     ? `<div class="mh-empty">${t('暂无受管 skill，运行 ', 'No managed skills yet — run ')}<code>omk install &lt;skill&gt;</code>${t(' 开始纳管。', ' to start.')}</div>`
     : head + rows.map((r) => listRow(r, lang)).join('');
 
+  // 页内图例,镜像 omk list 的注脚（状态语义 + ⚠️ / ? 标记 + 证据列含义）—— 首次接触管理支柱的人不必先懂内部枚举。
+  const legend = rows.length === 0 ? '' : `
+    <div class="mh-legend">
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--green"></span>${t('已采用：已按证据人工接受', 'Promoted = accepted on evidence')}</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--accent"></span>${t('证据就绪：当前内容有有效证据、可采用', 'Measurable = current content has evidence, gate-ready')}</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--muted"></span>${t('已纳管：尚无当前证据', 'Installed = no current evidence yet')}</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--red"></span>${t('已漂移 ⚠️：源变了、需重跑 omk eval', 'Drifted ⚠️ = source changed, re-run omk eval')}</span>
+    <span class="mh-legend-item">${t('? 源未核（不可达 / 拒读，漂移待定）', '? = source unverified (unreachable / refused)')}</span>
+    <span class="mh-legend-item">${t('证据列：当前有效 / 全部历史（旧证据留作回滚）', 'Evidence = current / total (old evidence kept for rollback)')}</span>
+  </div>`;
+
   const body = `<main class="mh-main">
     <header class="mh-hero">
       <div class="mh-kind">${t('受管 skill', 'Managed skills')}</div>
       <h1 class="mh-name">${t('决策史', 'Decision history')}</h1>
       <div class="mh-meta"><span>${t('每个 skill 的 install → 评测 → 采用 / 回滚 全过程', 'install → eval → promote / rollback per skill')}</span></div>
     </header>
-    <div class="mh-table">${list}</div>
+    <div class="mh-table">${list}</div>${legend}
   </main>
   <style>${MANAGED_CSS}</style>`;
 
@@ -251,4 +276,6 @@ const MANAGED_CSS = `
 .mh-mark--q{color:var(--text-muted);font-weight:700}
 .mh-empty{padding:40px 20px;text-align:center;color:var(--text-muted);font-size:13px}
 .mh-empty code{background:var(--bg-soft);padding:1px 6px;border-radius:5px}
+.mh-legend{display:flex;flex-wrap:wrap;gap:7px 16px;margin-top:14px;padding:12px 16px;background:var(--bg-surface);border:1px solid var(--border);border-radius:var(--radius-lg);font-size:12px;color:var(--text-muted)}
+.mh-legend-item{display:inline-flex;align-items:center;gap:6px}
 `;

--- a/src/renderer/managed-history-renderer.ts
+++ b/src/renderer/managed-history-renderer.ts
@@ -15,8 +15,12 @@ import type { ManagedArtifactRecord } from '../types/index.js';
 import type { ManagedListRow } from '../managed/index.js';
 import type { VerdictLevel } from '../eval-core/verdict.js';
 
-const VERDICT_LEVELS: readonly string[] = ['PROGRESS', 'CAUTIOUS', 'REGRESS', 'NOISE', 'UNDERPOWERED', 'SOLO'];
-const isVerdictLevel = (v: string): v is VerdictLevel => VERDICT_LEVELS.includes(v);
+// Record<VerdictLevel, true> 让 TS 编译期强制列全所有 level —— eval-core 新增 level 时这里报错、逼同步,
+// 避免新 verdict 被静默当未知字符串降级渲染（无运行时 level 清单可 import,故用穷举 Record 做编译期闸门）。
+const VERDICT_LEVELS: Record<VerdictLevel, true> = {
+  PROGRESS: true, CAUTIOUS: true, REGRESS: true, NOISE: true, UNDERPOWERED: true, SOLO: true,
+};
+const isVerdictLevel = (v: string): v is VerdictLevel => Object.prototype.hasOwnProperty.call(VERDICT_LEVELS, v);
 
 const shortHash = (h: string): string => h.slice(0, 12);
 const L = (lang: Lang) => (zh: string, en: string): string => (lang === 'zh' ? zh : en);

--- a/src/renderer/managed-history-renderer.ts
+++ b/src/renderer/managed-history-renderer.ts
@@ -1,0 +1,248 @@
+/**
+ * 受管 skill 的「决策史」渲染（Studio /managed 列表 + /managed/<name> 详情时间线）。
+ *
+ * 纯函数、无 IO：吃已构造好的数据（list 吃 ManagedListRow[]、history 吃 ManagedArtifactRecord），
+ * 便于 snapshot 测试。把 install / 每次 eval 证据 / 每次 promote·reject·rollback 决定合并成一条按时间
+ * 倒序的事件流，按内容版本（contentHash）分段，让「这个 skill 的一生」一眼可读——#203 管理支柱的可视化出口。
+ *
+ * 本切片只用受管记录自带数据（不读 report 文件）：evidence 上有 denormalize 的 verdict / 样本数 / 可比性，
+ * 够画事件时间线。带数字 Δ/95%CI 的版本回归曲线（要读 report 文件）是 Slice 2。
+ */
+import { layout, e, fmtLocalTime } from './layout.js';
+import { levelLabel } from './summary.js';
+import type { Lang } from '../types/index.js';
+import type { ManagedArtifactRecord } from '../types/index.js';
+import type { ManagedListRow } from '../managed/index.js';
+import type { VerdictLevel } from '../eval-core/verdict.js';
+
+const VERDICT_LEVELS: readonly string[] = ['PROGRESS', 'CAUTIOUS', 'REGRESS', 'NOISE', 'UNDERPOWERED', 'SOLO'];
+const isVerdictLevel = (v: string): v is VerdictLevel => VERDICT_LEVELS.includes(v);
+
+const shortHash = (h: string): string => h.slice(0, 12);
+const L = (lang: Lang) => (zh: string, en: string): string => (lang === 'zh' ? zh : en);
+
+/** ISO 时刻解析（两端可解析按真实时刻、否则退字典序），与 latestCurrentEvidence 同口径。 */
+function cmpDesc(a: string, b: string): number {
+  const pa = Date.parse(a);
+  const pb = Date.parse(b);
+  if (!Number.isNaN(pa) && !Number.isNaN(pb)) return pb - pa;
+  return a < b ? 1 : a > b ? -1 : 0;
+}
+
+/** verdict 徽标：已知 VerdictLevel 走本地化标签 + 配色（复用 layout.ts 的 .verdict-<LEVEL> 全局样式）；
+ *  未知字符串降级为纯文本徽标，绝不假装是某个 level。 */
+function verdictBadge(verdict: string | undefined, lang: Lang): string {
+  if (!verdict) return '';
+  if (isVerdictLevel(verdict)) {
+    return `<span class="verdict-${verdict}"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>${e(levelLabel(verdict, lang))}</span></span>`;
+  }
+  return `<span class="mh-badge-raw">${e(verdict)}</span>`;
+}
+
+interface TimelineEvent {
+  at: string;
+  type: 'install' | 'eval' | 'promote' | 'reject' | 'rollback';
+  contentHash?: string;
+  verdict?: string;
+  reportId?: string;
+  actor?: string;
+  reason?: string;
+  override?: { verdict: string; overriddenBlocks?: string[] };
+  sampleCount?: number;
+  cliVersion?: string;
+}
+
+function buildTimeline(record: ManagedArtifactRecord): TimelineEvent[] {
+  const events: TimelineEvent[] = [];
+  // install 不带 contentHash：record.contentHash 是「当前基线」（evolve 会 re-baseline），不是安装时那份；
+  // 拿它标安装事件会误导，故安装只作时间起点，版本分段只用 evidence / decision 自带的 contentHash。
+  events.push({ at: record.installedAt, type: 'install' });
+  for (const ev of record.evidence) {
+    events.push({
+      at: ev.recordedAt, type: 'eval', contentHash: ev.contentHash, verdict: ev.verdict,
+      reportId: ev.reportId, sampleCount: ev.sampleCoverage?.count, cliVersion: ev.comparability?.cliVersion,
+    });
+  }
+  for (const d of record.decisions) {
+    events.push({
+      at: d.decidedAt, type: d.decisionKind, contentHash: d.contentHash,
+      reportId: d.reportId, actor: d.actor, reason: d.reason, override: d.override,
+    });
+  }
+  return events.sort((a, b) => cmpDesc(a.at, b.at));
+}
+
+function reportLink(reportId: string | undefined, lang: Lang): string {
+  if (!reportId) return '';
+  return `<a class="mh-link" href="/reports/${encodeURIComponent(reportId)}">${L(lang)('查看报告', 'report')} →</a>`;
+}
+
+function eventRow(ev: TimelineEvent, lang: Lang): string {
+  const t = L(lang);
+  const typeLabel: Record<TimelineEvent['type'], string> = {
+    install: t('安装纳管', 'Installed'),
+    eval: t('评测', 'Eval'),
+    promote: t('采用', 'Promote'),
+    reject: t('否决', 'Reject'),
+    rollback: t('回滚', 'Rollback'),
+  };
+  const head: string[] = [`<span class="mh-type">${e(typeLabel[ev.type])}</span>`];
+  if (ev.type === 'eval') head.push(verdictBadge(ev.verdict, lang));
+  if (ev.override) {
+    const blocks = ev.override.overriddenBlocks?.length ? `：${e(ev.override.overriddenBlocks.join(' / '))}` : '';
+    head.push(`<span class="mh-override">${t('越门 override', 'override')}${blocks}</span>`);
+  }
+
+  const detail: string[] = [];
+  if (ev.actor) detail.push(`<span class="mh-detail-item">${t('决定人', 'by')} ${e(ev.actor)}</span>`);
+  if (ev.type === 'eval' && typeof ev.sampleCount === 'number') {
+    detail.push(`<span class="mh-detail-item">${ev.sampleCount} ${t('用例', 'samples')}</span>`);
+  }
+  if (ev.cliVersion) detail.push(`<span class="mh-detail-item">omk ${e(ev.cliVersion)}</span>`);
+  if (ev.reportId) detail.push(reportLink(ev.reportId, lang));
+  if (ev.reason) detail.push(`<span class="mh-reason">「${e(ev.reason)}」</span>`);
+
+  return `<li class="mh-event mh-event--${ev.type}">
+    <span class="mh-time">${e(fmtLocalTime(ev.at))}</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--${ev.type}"></span></span>
+    <div class="mh-body">
+      <div class="mh-head">${head.join(' ')}</div>
+      ${detail.length ? `<div class="mh-detail">${detail.join('')}</div>` : ''}
+    </div>
+  </li>`;
+}
+
+function versionHeader(hash: string, isCurrent: boolean, lang: Lang): string {
+  const cur = isCurrent ? `<span class="mh-vcur">${L(lang)('当前', 'current')}</span>` : '';
+  return `<li class="mh-vhead"><span class="mh-vhead-label">${L(lang)('版本', 'version')}</span><code class="mh-hash">${e(shortHash(hash))}</code>${cur}</li>`;
+}
+
+export function renderManagedHistory(record: ManagedArtifactRecord, lang: Lang): string {
+  const t = L(lang);
+  const events = buildTimeline(record);
+
+  // 倒序遍历：内容版本（contentHash）变化处插版本段头；install 等无 hash 事件不重置分段。
+  const rows: string[] = [];
+  let prevHash: string | undefined;
+  for (const ev of events) {
+    if (ev.contentHash && ev.contentHash !== prevHash) {
+      rows.push(versionHeader(ev.contentHash, ev.contentHash === record.contentHash, lang));
+      prevHash = ev.contentHash;
+    }
+    rows.push(eventRow(ev, lang));
+  }
+
+  const meta = [
+    record.kind,
+    record.source.sourceKind,
+    shortHash(record.contentHash),
+    `${t('纳管于', 'since')} ${fmtLocalTime(record.installedAt)}`,
+  ].map((m) => `<span>${e(m)}</span>`).join('');
+
+  const body = `<main class="mh-main">
+    <nav class="mh-back"><a href="/managed">← ${t('受管列表', 'Managed')}</a></nav>
+    <header class="mh-hero">
+      <div class="mh-kind">${t('受管决策史', 'Managed history')}</div>
+      <h1 class="mh-name">${e(record.name)}</h1>
+      <div class="mh-meta">${meta}</div>
+    </header>
+    <ol class="mh-timeline">${rows.join('')}</ol>
+  </main>
+  <style>${MANAGED_CSS}</style>`;
+
+  return layout(`${t('受管决策史', 'Managed history')} · ${record.name}`, body, lang);
+}
+
+function stateBand(state: string): string {
+  return state === 'promoted' ? 'green' : state === 'stale' ? 'red' : state === 'measurable' ? 'accent' : 'muted';
+}
+
+function listRow(row: ManagedListRow, lang: Lang): string {
+  const t = L(lang);
+  const mark = !row.reachable ? ' <span class="mh-mark mh-mark--q" title="' + t('源未核', 'unverified') + '">?</span>'
+    : row.state === 'stale' ? ' <span class="mh-mark mh-mark--warn">⚠️</span>' : '';
+  return `<a class="mh-row" href="/managed/${encodeURIComponent(row.name)}">
+    <span class="mh-row-state"><span class="mh-dot mh-dot--${stateBand(row.state)}"></span>${e(row.state)}${mark}</span>
+    <span class="mh-row-name">${e(row.name)}</span>
+    <span class="mh-row-kind">${e(row.kind)}</span>
+    <span class="mh-row-verdict">${row.latestVerdict ? verdictBadge(row.latestVerdict, lang) : '—'}</span>
+    <span class="mh-row-ev">${row.currentEvidenceCount}/${row.totalEvidenceCount}</span>
+    <span class="mh-row-src" title="${e(row.sourceLabel)}">${e(row.sourceLabel)}</span>
+  </a>`;
+}
+
+export function renderManagedList(rows: ManagedListRow[], lang: Lang): string {
+  const t = L(lang);
+  const head = `<div class="mh-row mh-row--head">
+    <span>${t('状态', 'state')}</span><span>${t('名称', 'name')}</span><span>${t('类型', 'kind')}</span>
+    <span>verdict</span><span>${t('证据', 'evidence')}</span><span>${t('源', 'source')}</span>
+  </div>`;
+  const list = rows.length === 0
+    ? `<div class="mh-empty">${t('暂无受管 skill，运行 ', 'No managed skills yet — run ')}<code>omk install &lt;skill&gt;</code>${t(' 开始纳管。', ' to start.')}</div>`
+    : head + rows.map((r) => listRow(r, lang)).join('');
+
+  const body = `<main class="mh-main">
+    <header class="mh-hero">
+      <div class="mh-kind">${t('受管 skill', 'Managed skills')}</div>
+      <h1 class="mh-name">${t('决策史', 'Decision history')}</h1>
+      <div class="mh-meta"><span>${t('每个 skill 的 install → 评测 → 采用 / 回滚 全过程', 'install → eval → promote / rollback per skill')}</span></div>
+    </header>
+    <div class="mh-table">${list}</div>
+  </main>
+  <style>${MANAGED_CSS}</style>`;
+
+  return layout(t('受管 skill', 'Managed skills'), body, lang);
+}
+
+const MANAGED_CSS = `
+.mh-main{max-width:920px;margin:0 auto;padding:24px 20px 48px}
+.mh-back{margin-bottom:14px;font-size:13px}
+.mh-back a{color:var(--text-secondary);text-decoration:none}
+.mh-back a:hover{color:var(--accent)}
+.mh-hero{background:var(--bg-surface);border:1px solid var(--border);border-radius:var(--radius-lg);box-shadow:var(--shadow-sm);padding:20px 24px;margin-bottom:18px}
+.mh-kind{font-size:13px;font-weight:600;color:var(--text-secondary)}
+.mh-name{margin:4px 0 0;font-size:20px;font-weight:700;color:var(--text-primary);letter-spacing:-.2px}
+.mh-meta{display:flex;flex-wrap:wrap;gap:6px 14px;margin-top:6px;color:var(--text-muted);font-size:12px}
+.mh-meta span{display:inline-flex;align-items:center;gap:4px;font-variant-numeric:tabular-nums}
+
+/* ── 时间线 ── */
+.mh-timeline{list-style:none;padding:0;margin:0;background:var(--bg-surface);border:1px solid var(--border);border-radius:var(--radius-lg);box-shadow:var(--shadow-sm);overflow:hidden}
+.mh-vhead{display:flex;align-items:center;gap:8px;padding:10px 20px;background:var(--bg-elevated);border-top:1px solid var(--border);font-size:12px;color:var(--text-secondary)}
+.mh-vhead:first-child{border-top:none}
+.mh-vhead-label{font-weight:600}
+.mh-vcur{font-size:11px;font-weight:600;color:var(--green);background:var(--green-bg);padding:1px 7px;border-radius:9px}
+.mh-event{display:flex;align-items:flex-start;gap:12px;padding:13px 20px;border-top:1px solid var(--border)}
+.mh-time{flex-shrink:0;width:128px;color:var(--text-muted);font-size:12px;font-variant-numeric:tabular-nums;padding-top:1px}
+.mh-marker{flex-shrink:0;padding-top:4px}
+.mh-dot{display:inline-block;width:8px;height:8px;border-radius:50%}
+.mh-dot--install{background:var(--text-muted)}
+.mh-dot--eval{background:var(--accent)}
+.mh-dot--promote{background:var(--green)}
+.mh-dot--rollback{background:var(--yellow)}
+.mh-dot--reject{background:var(--red)}
+.mh-dot--green{background:var(--green)}.mh-dot--accent{background:var(--accent)}.mh-dot--muted{background:var(--text-muted)}.mh-dot--red{background:var(--red)}
+.mh-body{flex:1;min-width:0}
+.mh-head{display:flex;flex-wrap:wrap;align-items:center;gap:8px;font-size:14px}
+.mh-type{font-weight:600;color:var(--text-primary)}
+.mh-override{font-size:11px;font-weight:600;color:var(--yellow);background:var(--yellow-bg);padding:1px 8px;border-radius:9px}
+.mh-badge-raw{font-size:11.5px;color:var(--text-secondary);background:var(--bg-soft);padding:1px 8px;border-radius:9px}
+.mh-detail{display:flex;flex-wrap:wrap;gap:4px 14px;margin-top:4px;font-size:12px;color:var(--text-muted)}
+.mh-reason{color:var(--text-secondary);font-style:italic}
+.mh-link{color:var(--accent);text-decoration:none}
+.mh-link:hover{text-decoration:underline}
+
+/* ── 列表 ── */
+.mh-table{background:var(--bg-surface);border:1px solid var(--border);border-radius:var(--radius-lg);box-shadow:var(--shadow-sm);overflow:hidden}
+.mh-row{display:grid;grid-template-columns:130px 1.4fr .8fr 1.1fr .7fr 1.6fr;align-items:center;gap:12px;padding:12px 20px;border-top:1px solid var(--border);text-decoration:none;color:var(--text-primary);font-size:13px}
+.mh-row:hover{background:var(--bg-soft)}
+.mh-row--head{border-top:none;color:var(--text-secondary);font-size:11.5px;font-weight:600;text-transform:uppercase;letter-spacing:.04em;cursor:default}
+.mh-row--head:hover{background:transparent}
+.mh-row-state{display:inline-flex;align-items:center;gap:6px}
+.mh-row-name{font-family:"SF Mono",Menlo,monospace;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.mh-row-kind,.mh-row-src{color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.mh-row-ev{font-variant-numeric:tabular-nums;color:var(--text-secondary)}
+.mh-mark--warn{font-size:11px}
+.mh-mark--q{color:var(--text-muted);font-weight:700}
+.mh-empty{padding:40px 20px;text-align:center;color:var(--text-muted);font-size:13px}
+.mh-empty code{background:var(--bg-soft);padding:1px 6px;border-radius:5px}
+`;

--- a/src/renderer/managed-history-renderer.ts
+++ b/src/renderer/managed-history-renderer.ts
@@ -11,7 +11,7 @@
 import { layout, e, fmtLocalTime } from './layout.js';
 import { levelLabel } from './summary.js';
 import type { Lang } from '../types/index.js';
-import type { ManagedArtifactRecord } from '../types/index.js';
+import type { ManagedArtifactRecord, ManagedLifecycleLabel } from '../types/index.js';
 import type { ManagedListRow } from '../managed/index.js';
 import type { VerdictLevel } from '../eval-core/verdict.js';
 
@@ -164,16 +164,23 @@ function stateBand(state: string): string {
 }
 
 /** 生命周期状态的面向用户文案 + 一句话释义(挂 title)。原始 token 仍在 /api/managed 的 row.state（机读口径不变）,
- *  此处只本地化人看的 HTML —— measurable / installed 这类内部枚举对首次接触管理支柱的人并不自解释。 */
+ *  此处只本地化人看的 HTML —— measurable / installed 这类内部枚举对首次接触管理支柱的人并不自解释。
+ *  用 Record<ManagedLifecycleLabel> 让 TS 编译期强制列全所有状态 —— types/managed 新增 label（如已声明
+ *  却尚未在列表出现的 discovered）时这里报错、逼同步,避免新状态被静默当原始 token 渲染。 */
+const STATE_LABELS: Record<ManagedLifecycleLabel, { zh: [string, string]; en: [string, string] }> = {
+  discovered: { zh: ['已发现', '已发现，尚未纳管取证'], en: ['Discovered', 'Discovered, not yet under management'] },
+  installed: { zh: ['已纳管', '已纳入管理，当前内容尚无有效证据'], en: ['Installed', 'Under management; no valid evidence for current content yet'] },
+  measurable: { zh: ['证据就绪', '当前内容已有有效证据，可进入采用门禁'], en: ['Measurable', 'Current content has valid evidence; ready for the promote gate'] },
+  stale: { zh: ['已漂移', '源内容已变更、脱离证据，需重跑 omk eval 取证'], en: ['Drifted', 'Source changed off its evidence — re-run omk eval'] },
+  promoted: { zh: ['已采用', '已按证据人工复核并接受当前内容'], en: ['Promoted', 'Manually reviewed and accepted on evidence'] },
+};
+
 function stateMeta(state: string, lang: Lang): { label: string; tip: string } {
-  const t = L(lang);
-  switch (state) {
-    case 'promoted': return { label: t('已采用', 'Promoted'), tip: t('已按证据人工复核并接受当前内容', 'Manually reviewed and accepted on evidence') };
-    case 'measurable': return { label: t('证据就绪', 'Measurable'), tip: t('当前内容已有有效证据，可进入采用门禁', 'Current content has valid evidence; ready for the promote gate') };
-    case 'stale': return { label: t('已漂移', 'Drifted'), tip: t('源内容已变更、脱离证据，需重跑 omk eval 取证', 'Source changed off its evidence — re-run omk eval') };
-    case 'installed': return { label: t('已纳管', 'Installed'), tip: t('已纳入管理，当前内容尚无有效证据', 'Under management; no valid evidence for current content yet') };
-    default: return { label: state, tip: state };
-  }
+  // Record 保证联合内全覆盖;?? 兜被污染的非法 token(已被 isManagedArtifactRecord 校验过,理论不达),原样降级不崩。
+  const m = (STATE_LABELS as Record<string, { zh: [string, string]; en: [string, string] }>)[state]
+    ?? { zh: [state, state] as [string, string], en: [state, state] as [string, string] };
+  const [label, tip] = lang === 'zh' ? m.zh : m.en;
+  return { label, tip };
 }
 
 function listRow(row: ManagedListRow, lang: Lang): string {

--- a/src/renderer/managed-history-renderer.ts
+++ b/src/renderer/managed-history-renderer.ts
@@ -24,6 +24,8 @@ const isVerdictLevel = (v: string): v is VerdictLevel => Object.prototype.hasOwn
 
 const shortHash = (h: string): string => h.slice(0, 12);
 const L = (lang: Lang) => (zh: string, en: string): string => (lang === 'zh' ? zh : en);
+/** 页内跳转统一带上 lang，否则点一下就掉回默认中文。zh 是默认 → 空串(不脏 URL)。 */
+const langQuery = (lang: Lang): string => (lang === 'en' ? '?lang=en' : '');
 
 /** ISO 时刻解析（两端可解析按真实时刻、否则退字典序），与 latestCurrentEvidence 同口径。 */
 function cmpDesc(a: string, b: string): number {
@@ -78,7 +80,7 @@ function buildTimeline(record: ManagedArtifactRecord): TimelineEvent[] {
 
 function reportLink(reportId: string | undefined, lang: Lang): string {
   if (!reportId) return '';
-  return `<a class="mh-link" href="/reports/${encodeURIComponent(reportId)}">${L(lang)('查看报告', 'report')} →</a>`;
+  return `<a class="mh-link" href="/reports/${encodeURIComponent(reportId)}${langQuery(lang)}">${L(lang)('查看报告', 'report')} →</a>`;
 }
 
 function eventRow(ev: TimelineEvent, lang: Lang): string {
@@ -144,7 +146,7 @@ export function renderManagedHistory(record: ManagedArtifactRecord, lang: Lang):
   ].map((m) => `<span>${e(m)}</span>`).join('');
 
   const body = `<main class="mh-main">
-    <nav class="mh-back"><a href="/managed">← ${t('受管列表', 'Managed')}</a></nav>
+    <nav class="mh-back"><a href="/managed${langQuery(lang)}">← ${t('受管列表', 'Managed')}</a></nav>
     <header class="mh-hero">
       <div class="mh-kind">${t('受管决策史', 'Managed history')}</div>
       <h1 class="mh-name">${e(record.name)}</h1>
@@ -165,7 +167,7 @@ function listRow(row: ManagedListRow, lang: Lang): string {
   const t = L(lang);
   const mark = !row.reachable ? ' <span class="mh-mark mh-mark--q" title="' + t('源未核', 'unverified') + '">?</span>'
     : row.state === 'stale' ? ' <span class="mh-mark mh-mark--warn">⚠️</span>' : '';
-  return `<a class="mh-row" href="/managed/${encodeURIComponent(row.name)}">
+  return `<a class="mh-row" href="/managed/${encodeURIComponent(row.id)}${langQuery(lang)}">
     <span class="mh-row-state"><span class="mh-dot mh-dot--${stateBand(row.state)}"></span>${e(row.state)}${mark}</span>
     <span class="mh-row-name">${e(row.name)}</span>
     <span class="mh-row-kind">${e(row.kind)}</span>

--- a/src/renderer/skill-list-renderer.ts
+++ b/src/renderer/skill-list-renderer.ts
@@ -59,6 +59,7 @@ function renderPanel(a: Agg, lang: Lang): string {
     <h1>${zh ? 'Skill 健康评测工作台' : 'Skill Health Dashboard'}</h1>
     <span class="phead-sub">${a.totalSkills} ${zh ? '个 skill' : 'skills'}</span>
     <span class="phead-when">${icon('clock', { size: 13 })} ${zh ? '更新于' : 'updated'} ${fmtDate(a.lastTs)}</span>
+    <a href="/managed" style="margin-left:auto;font-size:13px;color:var(--accent);text-decoration:none;white-space:nowrap">${zh ? '受管决策史' : 'Managed history'} →</a>
   </div>`;
 
   // 综合健康(细线总览首格):ring + 标签 + 说明入口。

--- a/src/renderer/skill-list-renderer.ts
+++ b/src/renderer/skill-list-renderer.ts
@@ -59,7 +59,7 @@ function renderPanel(a: Agg, lang: Lang): string {
     <h1>${zh ? 'Skill 健康评测工作台' : 'Skill Health Dashboard'}</h1>
     <span class="phead-sub">${a.totalSkills} ${zh ? '个 skill' : 'skills'}</span>
     <span class="phead-when">${icon('clock', { size: 13 })} ${zh ? '更新于' : 'updated'} ${fmtDate(a.lastTs)}</span>
-    <a href="/managed" style="margin-left:auto;font-size:13px;color:var(--accent);text-decoration:none;white-space:nowrap">${zh ? '受管决策史' : 'Managed history'} →</a>
+    <a href="/managed${zh ? '' : '?lang=en'}" style="margin-left:auto;font-size:13px;color:var(--accent);text-decoration:none;white-space:nowrap">${zh ? '受管决策史' : 'Managed history'} →</a>
   </div>`;
 
   // 综合健康(细线总览首格):ring + 标签 + 说明入口。

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -43,8 +43,10 @@ interface ReportServerOptions {
   doctorsDir?: string;
   observationsDir?: string;
   jobsDir?: string;
-  /** 受管目录(.omk/managed 或全局)。只读消费,供 /managed 决策史页。默认 project→global 权威目录。 */
-  managedDir?: string;
+  /** 受管目录(.omk/managed 或全局),或一个按请求动态解析它的函数。只读消费,供 /managed 决策史页。
+   *  传函数 → 每次请求重解析(长会话里跟 omk list 同口径:项目首次 install 后从 global 实时切回 project);
+   *  传字符串 → 固定到该目录(测试 / 显式覆盖);默认动态解析 project→global 权威目录。 */
+  managedDir?: string | (() => string);
   store?: ReportStore;
   jobStore?: JobStore;
 }
@@ -612,8 +614,18 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
   // Use provided store or default to file store
   const reportStore: ReportStore = store || createFileStore(reportsDir);
   const resolvedJobStore: JobStore = jobStore || createFileJobStore(jobsDir);
-  // 受管目录在创建时解析(cwd 此刻正确),不在模块加载期 —— 避免按错误 cwd 定位 .omk/managed。
-  const managedRoot: string = managedDir ?? resolveManagedDir(projectManagedDir());
+  // 受管根目录按**请求**解析,不在启动时冻结 —— 否则长会话里会跟 omk list 分叉:Studio 启动时项目 .omk/managed
+  // 还空、回退到 global,随后用户在项目里首次 omk install,omk list 下次会切到 project,而冻结了 root 的 Studio
+  // 仍盯着旧 global,页面与 CLI 不一致。cwd 在进程内不变,变的是目录里有没有记录,故每次请求重判。
+  //   - 传函数 → 直接当解析器,每次请求调用(测试可注入受控解析器复现 project↔global 切换);
+  //   - 传字符串 → 固定该目录(显式覆盖 / 测试);
+  //   - 缺省 → 动态解析 project→global 权威目录,与 omk list 同口径。
+  const resolveManagedRoot: () => string =
+    typeof managedDir === 'function'
+      ? managedDir
+      : managedDir !== undefined
+        ? (): string => managedDir
+        : (): string => resolveManagedDir(projectManagedDir());
 
   async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
     try {
@@ -672,13 +684,13 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
       // 受管 skill 决策史（#203 管理支柱可视化出口）。只读受管记录,口径同 omk list。
       if (path === '/api/managed') {
         res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
-        res.end(JSON.stringify({ schemaVersion: 1, rows: listManagedRows(managedRoot) }));
+        res.end(JSON.stringify({ schemaVersion: 1, rows: listManagedRows(resolveManagedRoot()) }));
         return;
       }
 
       if (path === '/managed') {
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(renderManagedList(listManagedRows(managedRoot), lang));
+        res.end(renderManagedList(listManagedRows(resolveManagedRoot()), lang));
         return;
       }
 
@@ -688,7 +700,7 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
         try { id = decodeURIComponent(managedDetailMatch[1]); } catch { id = ''; }
         // 按稳定 id(= hash(kind, name)) 精确查 —— 同名不同 kind(skill/review vs prompt/review)各有独立 id,
         // 不会串到同一页;且只在已加载、已校验的记录里查,不拼文件路径、无路径穿越。
-        const record = id ? loadAllManagedRecords(managedRoot).find((r) => r.id === id) : undefined;
+        const record = id ? loadAllManagedRecords(resolveManagedRoot()).find((r) => r.id === id) : undefined;
         if (!record) {
           res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
           res.end(lang === 'en' ? 'managed record not found' : '受管记录不存在');

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -12,6 +12,8 @@ import { assessHealth } from '../renderer/skill-detail-renderer.js';
 import type { SkillIndexEntry, Insight } from '../types/skill-index.js';
 import { renderObservationInboxPage } from '../renderer/observation-inbox-renderer.js';
 import { DEFAULT_LANG, t, layout } from '../renderer/layout.js';
+import { loadAllManagedRecords, resolveManagedDir, managedDir as projectManagedDir, listManagedRows } from '../managed/index.js';
+import { renderManagedList, renderManagedHistory } from '../renderer/managed-history-renderer.js';
 import { buildSkillIndex } from './skill-index.js';
 import type { Lang } from '../types/index.js';
 import { createFileJobStore, DEFAULT_JOBS_DIR } from './job-store.js';
@@ -41,6 +43,8 @@ interface ReportServerOptions {
   doctorsDir?: string;
   observationsDir?: string;
   jobsDir?: string;
+  /** 受管目录(.omk/managed 或全局)。只读消费,供 /managed 决策史页。默认 project→global 权威目录。 */
+  managedDir?: string;
   store?: ReportStore;
   jobStore?: JobStore;
 }
@@ -601,13 +605,15 @@ export function formatListenError(p: number, err: unknown): Error | null {
   return null;
 }
 
-export function createReportServer({ port, host: hostOption, reportsDir = DEFAULT_REPORTS_DIR, analysesDir = DEFAULT_ANALYSES_DIR, doctorsDir = DEFAULT_DOCTORS_DIR, observationsDir = DEFAULT_OBSERVATIONS_DIR, jobsDir = DEFAULT_JOBS_DIR, store, jobStore }: ReportServerOptions = {}): ReportServer {
+export function createReportServer({ port, host: hostOption, reportsDir = DEFAULT_REPORTS_DIR, analysesDir = DEFAULT_ANALYSES_DIR, doctorsDir = DEFAULT_DOCTORS_DIR, observationsDir = DEFAULT_OBSERVATIONS_DIR, jobsDir = DEFAULT_JOBS_DIR, managedDir, store, jobStore }: ReportServerOptions = {}): ReportServer {
   let server: Server | null = null;
   let serverUrl: string | null = null;
 
   // Use provided store or default to file store
   const reportStore: ReportStore = store || createFileStore(reportsDir);
   const resolvedJobStore: JobStore = jobStore || createFileJobStore(jobsDir);
+  // 受管目录在创建时解析(cwd 此刻正确),不在模块加载期 —— 避免按错误 cwd 定位 .omk/managed。
+  const managedRoot: string = managedDir ?? resolveManagedDir(projectManagedDir());
 
   async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
     try {
@@ -660,6 +666,35 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
       if (path === '/analyses') {
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(renderAnalysisList(listAnalyses(analysesDir), lang));
+        return;
+      }
+
+      // 受管 skill 决策史（#203 管理支柱可视化出口）。只读受管记录,口径同 omk list。
+      if (path === '/api/managed') {
+        res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ schemaVersion: 1, rows: listManagedRows(managedRoot) }));
+        return;
+      }
+
+      if (path === '/managed') {
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(renderManagedList(listManagedRows(managedRoot), lang));
+        return;
+      }
+
+      const managedDetailMatch = path.match(/^\/managed\/(.+)$/);
+      if (managedDetailMatch) {
+        let name: string;
+        try { name = decodeURIComponent(managedDetailMatch[1]); } catch { name = ''; }
+        // 只在已加载、已校验的记录里按 name 精确查 —— 不拼文件路径、无路径穿越、跨 kind 命中。
+        const record = name ? loadAllManagedRecords(managedRoot).find((r) => r.name === name) : undefined;
+        if (!record) {
+          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+          res.end(lang === 'en' ? 'managed record not found' : '受管记录不存在');
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(renderManagedHistory(record, lang));
         return;
       }
 

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -684,10 +684,11 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
 
       const managedDetailMatch = path.match(/^\/managed\/(.+)$/);
       if (managedDetailMatch) {
-        let name: string;
-        try { name = decodeURIComponent(managedDetailMatch[1]); } catch { name = ''; }
-        // 只在已加载、已校验的记录里按 name 精确查 —— 不拼文件路径、无路径穿越、跨 kind 命中。
-        const record = name ? loadAllManagedRecords(managedRoot).find((r) => r.name === name) : undefined;
+        let id: string;
+        try { id = decodeURIComponent(managedDetailMatch[1]); } catch { id = ''; }
+        // 按稳定 id(= hash(kind, name)) 精确查 —— 同名不同 kind(skill/review vs prompt/review)各有独立 id,
+        // 不会串到同一页;且只在已加载、已校验的记录里查,不拼文件路径、无路径穿越。
+        const record = id ? loadAllManagedRecords(managedRoot).find((r) => r.id === id) : undefined;
         if (!record) {
           res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
           res.end(lang === 'en' ? 'managed record not found' : '受管记录不存在');

--- a/test-import.ts
+++ b/test-import.ts
@@ -1,0 +1,2 @@
+import type { SourceProbe } from './dist/managed/index';
+const x: SourceProbe = { reachable: true, hash: 'abc' };

--- a/test-source-probe-import.ts
+++ b/test-source-probe-import.ts
@@ -1,0 +1,3 @@
+import type { SourceProbe } from './src/managed/index.js';
+
+const x: SourceProbe = { reachable: true, hash: 'abc' };

--- a/test/cli/list-probe.test.ts
+++ b/test/cli/list-probe.test.ts
@@ -11,8 +11,8 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, linkSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { probeSourceState, sanitizeCell } from '../../src/cli/commands/list.js';
-import { hashArtifactSource } from '../../src/managed/index.js';
+import { sanitizeCell } from '../../src/cli/commands/list.js';
+import { probeSourceState, hashArtifactSource } from '../../src/managed/index.js';
 import type { ManagedArtifactRecord, ManagedArtifactSource } from '../../src/types/index.js';
 
 function record(source: ManagedArtifactSource, contentHash = 'pinnedHash00'): ManagedArtifactRecord {

--- a/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
+++ b/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`managed-history-renderer snapshots > renderManagedHistory en 1`] = `
 "<main class="mh-main">
-    <nav class="mh-back"><a href="/managed">← Managed</a></nav>
+    <nav class="mh-back"><a href="/managed?lang=en">← Managed</a></nav>
     <header class="mh-hero">
       <div class="mh-kind">Managed history</div>
       <h1 class="mh-name">review</h1>
@@ -20,21 +20,21 @@ exports[`managed-history-renderer snapshots > renderManagedHistory en 1`] = `
     <span class="mh-marker"><span class="mh-dot mh-dot--promote"></span></span>
     <div class="mh-body">
       <div class="mh-head"><span class="mh-type">Promote</span></div>
-      <div class="mh-detail"><span class="mh-detail-item">by alice</span><a class="mh-link" href="/reports/evolve-review-002">report →</a><span class="mh-reason">「已人工复核」</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">by alice</span><a class="mh-link" href="/reports/evolve-review-002?lang=en">report →</a><span class="mh-reason">「已人工复核」</span></div>
     </div>
   </li><li class="mh-event mh-event--eval">
     <span class="mh-time">[TIMESTAMP]</span>
     <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
     <div class="mh-body">
       <div class="mh-head"><span class="mh-type">Eval</span> <span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>PROGRESS</span></span></div>
-      <div class="mh-detail"><span class="mh-detail-item">6 samples</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-002">report →</a></div>
+      <div class="mh-detail"><span class="mh-detail-item">6 samples</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-002?lang=en">report →</a></div>
     </div>
   </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV1conten</code></li><li class="mh-event mh-event--eval">
     <span class="mh-time">[TIMESTAMP]</span>
     <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
     <div class="mh-body">
       <div class="mh-head"><span class="mh-type">Eval</span> <span class="verdict-NOISE"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>NOISE</span></span></div>
-      <div class="mh-detail"><span class="mh-detail-item">6 samples</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-001">report →</a></div>
+      <div class="mh-detail"><span class="mh-detail-item">6 samples</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-001?lang=en">report →</a></div>
     </div>
   </li><li class="mh-event mh-event--install">
     <span class="mh-time">[TIMESTAMP]</span>
@@ -115,7 +115,7 @@ exports[`managed-history-renderer snapshots > renderManagedList en 1`] = `
     <div class="mh-table"><div class="mh-row mh-row--head">
     <span>state</span><span>name</span><span>kind</span>
     <span>verdict</span><span>evidence</span><span>source</span>
-  </div><a class="mh-row" href="/managed/review">
+  </div><a class="mh-row" href="/managed/skill-review-fixture?lang=en">
     <span class="mh-row-state"><span class="mh-dot mh-dot--accent"></span>measurable</span>
     <span class="mh-row-name">review</span>
     <span class="mh-row-kind">skill</span>
@@ -136,7 +136,7 @@ exports[`managed-history-renderer snapshots > renderManagedList zh 1`] = `
     <div class="mh-table"><div class="mh-row mh-row--head">
     <span>状态</span><span>名称</span><span>类型</span>
     <span>verdict</span><span>证据</span><span>源</span>
-  </div><a class="mh-row" href="/managed/review">
+  </div><a class="mh-row" href="/managed/skill-review-fixture">
     <span class="mh-row-state"><span class="mh-dot mh-dot--accent"></span>measurable</span>
     <span class="mh-row-name">review</span>
     <span class="mh-row-kind">skill</span>

--- a/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
+++ b/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
@@ -1,0 +1,148 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`managed-history-renderer snapshots > renderManagedHistory en 1`] = `
+"<main class="mh-main">
+    <nav class="mh-back"><a href="/managed">← Managed</a></nav>
+    <header class="mh-hero">
+      <div class="mh-kind">Managed history</div>
+      <h1 class="mh-name">review</h1>
+      <div class="mh-meta"><span>skill</span><span>git</span><span>hashV2conten</span><span>since [TIMESTAMP]</span></div>
+    </header>
+    <ol class="mh-timeline"><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">current</span></li><li class="mh-event mh-event--rollback">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--rollback"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Rollback</span> <span class="mh-override">override：drifted</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">by bob</span></div>
+    </div>
+  </li><li class="mh-event mh-event--promote">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--promote"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Promote</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">by alice</span><a class="mh-link" href="/reports/evolve-review-002">report →</a><span class="mh-reason">「已人工复核」</span></div>
+    </div>
+  </li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Eval</span> <span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>PROGRESS</span></span></div>
+      <div class="mh-detail"><span class="mh-detail-item">6 samples</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-002">report →</a></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV1conten</code></li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Eval</span> <span class="verdict-NOISE"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>NOISE</span></span></div>
+      <div class="mh-detail"><span class="mh-detail-item">6 samples</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-001">report →</a></div>
+    </div>
+  </li><li class="mh-event mh-event--install">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--install"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Installed</span></div>
+
+    </div>
+  </li></ol>
+  </main>"
+`;
+
+exports[`managed-history-renderer snapshots > renderManagedHistory zh 1`] = `
+"<main class="mh-main">
+    <nav class="mh-back"><a href="/managed">← 受管列表</a></nav>
+    <header class="mh-hero">
+      <div class="mh-kind">受管决策史</div>
+      <h1 class="mh-name">review</h1>
+      <div class="mh-meta"><span>skill</span><span>git</span><span>hashV2conten</span><span>纳管于 [TIMESTAMP]</span></div>
+    </header>
+    <ol class="mh-timeline"><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">当前</span></li><li class="mh-event mh-event--rollback">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--rollback"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">回滚</span> <span class="mh-override">越门 override：drifted</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">决定人 bob</span></div>
+    </div>
+  </li><li class="mh-event mh-event--promote">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--promote"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">采用</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">决定人 alice</span><a class="mh-link" href="/reports/evolve-review-002">查看报告 →</a><span class="mh-reason">「已人工复核」</span></div>
+    </div>
+  </li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">评测</span> <span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>明显进步</span></span></div>
+      <div class="mh-detail"><span class="mh-detail-item">6 用例</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-002">查看报告 →</a></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV1conten</code></li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">评测</span> <span class="verdict-NOISE"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>基本持平</span></span></div>
+      <div class="mh-detail"><span class="mh-detail-item">6 用例</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-001">查看报告 →</a></div>
+    </div>
+  </li><li class="mh-event mh-event--install">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--install"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">安装纳管</span></div>
+
+    </div>
+  </li></ol>
+  </main>"
+`;
+
+exports[`managed-history-renderer snapshots > renderManagedList empty zh 1`] = `
+"<main class="mh-main">
+    <header class="mh-hero">
+      <div class="mh-kind">受管 skill</div>
+      <h1 class="mh-name">决策史</h1>
+      <div class="mh-meta"><span>每个 skill 的 install → 评测 → 采用 / 回滚 全过程</span></div>
+    </header>
+    <div class="mh-table"><div class="mh-empty">暂无受管 skill，运行 <code>omk install &lt;skill&gt;</code> 开始纳管。</div></div>
+  </main>"
+`;
+
+exports[`managed-history-renderer snapshots > renderManagedList en 1`] = `
+"<main class="mh-main">
+    <header class="mh-hero">
+      <div class="mh-kind">Managed skills</div>
+      <h1 class="mh-name">Decision history</h1>
+      <div class="mh-meta"><span>install → eval → promote / rollback per skill</span></div>
+    </header>
+    <div class="mh-table"><div class="mh-row mh-row--head">
+    <span>state</span><span>name</span><span>kind</span>
+    <span>verdict</span><span>evidence</span><span>source</span>
+  </div><a class="mh-row" href="/managed/review">
+    <span class="mh-row-state"><span class="mh-dot mh-dot--accent"></span>measurable</span>
+    <span class="mh-row-name">review</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>PROGRESS</span></span></span>
+    <span class="mh-row-ev">1/2</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a></div>
+  </main>"
+`;
+
+exports[`managed-history-renderer snapshots > renderManagedList zh 1`] = `
+"<main class="mh-main">
+    <header class="mh-hero">
+      <div class="mh-kind">受管 skill</div>
+      <h1 class="mh-name">决策史</h1>
+      <div class="mh-meta"><span>每个 skill 的 install → 评测 → 采用 / 回滚 全过程</span></div>
+    </header>
+    <div class="mh-table"><div class="mh-row mh-row--head">
+    <span>状态</span><span>名称</span><span>类型</span>
+    <span>verdict</span><span>证据</span><span>源</span>
+  </div><a class="mh-row" href="/managed/review">
+    <span class="mh-row-state"><span class="mh-dot mh-dot--accent"></span>measurable</span>
+    <span class="mh-row-name">review</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>明显进步</span></span></span>
+    <span class="mh-row-ev">1/2</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a></div>
+  </main>"
+`;

--- a/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
+++ b/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
@@ -116,13 +116,21 @@ exports[`managed-history-renderer snapshots > renderManagedList en 1`] = `
     <span>state</span><span>name</span><span>kind</span>
     <span>verdict</span><span>evidence</span><span>source</span>
   </div><a class="mh-row" href="/managed/skill-review-fixture?lang=en">
-    <span class="mh-row-state"><span class="mh-dot mh-dot--accent"></span>measurable</span>
+    <span class="mh-row-state" title="Current content has valid evidence; ready for the promote gate"><span class="mh-dot mh-dot--accent"></span>Measurable</span>
     <span class="mh-row-name">review</span>
     <span class="mh-row-kind">skill</span>
     <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>PROGRESS</span></span></span>
     <span class="mh-row-ev">1/2</span>
     <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
   </a></div>
+    <div class="mh-legend">
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--green"></span>Promoted = accepted on evidence</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--accent"></span>Measurable = current content has evidence, gate-ready</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--muted"></span>Installed = no current evidence yet</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--red"></span>Drifted ⚠️ = source changed, re-run omk eval</span>
+    <span class="mh-legend-item">? = source unverified (unreachable / refused)</span>
+    <span class="mh-legend-item">Evidence = current / total (old evidence kept for rollback)</span>
+  </div>
   </main>"
 `;
 
@@ -137,12 +145,20 @@ exports[`managed-history-renderer snapshots > renderManagedList zh 1`] = `
     <span>状态</span><span>名称</span><span>类型</span>
     <span>verdict</span><span>证据</span><span>源</span>
   </div><a class="mh-row" href="/managed/skill-review-fixture">
-    <span class="mh-row-state"><span class="mh-dot mh-dot--accent"></span>measurable</span>
+    <span class="mh-row-state" title="当前内容已有有效证据，可进入采用门禁"><span class="mh-dot mh-dot--accent"></span>证据就绪</span>
     <span class="mh-row-name">review</span>
     <span class="mh-row-kind">skill</span>
     <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>明显进步</span></span></span>
     <span class="mh-row-ev">1/2</span>
     <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
   </a></div>
+    <div class="mh-legend">
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--green"></span>已采用：已按证据人工接受</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--accent"></span>证据就绪：当前内容有有效证据、可采用</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--muted"></span>已纳管：尚无当前证据</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--red"></span>已漂移 ⚠️：源变了、需重跑 omk eval</span>
+    <span class="mh-legend-item">? 源未核（不可达 / 拒读，漂移待定）</span>
+    <span class="mh-legend-item">证据列：当前有效 / 全部历史（旧证据留作回滚）</span>
+  </div>
   </main>"
 `;

--- a/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
+++ b/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
@@ -15,7 +15,14 @@ exports[`managed-history-renderer snapshots > renderManagedHistory en 1`] = `
       <div class="mh-head"><span class="mh-type">Rollback</span> <span class="mh-override">override：drifted</span></div>
       <div class="mh-detail"><span class="mh-detail-item">by bob</span></div>
     </div>
-  </li><li class="mh-event mh-event--promote">
+  </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV1conten</code></li><li class="mh-event mh-event--reject">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--reject"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Reject</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">by carol</span></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">current</span></li><li class="mh-event mh-event--promote">
     <span class="mh-time">[TIMESTAMP]</span>
     <span class="mh-marker"><span class="mh-dot mh-dot--promote"></span></span>
     <div class="mh-body">
@@ -35,6 +42,13 @@ exports[`managed-history-renderer snapshots > renderManagedHistory en 1`] = `
     <div class="mh-body">
       <div class="mh-head"><span class="mh-type">Eval</span> <span class="verdict-NOISE"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>NOISE</span></span></div>
       <div class="mh-detail"><span class="mh-detail-item">6 samples</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-001?lang=en">report →</a></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV0conten</code></li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Eval</span> <span class="mh-badge-raw">INCONCLUSIVE</span></div>
+      <div class="mh-detail"><a class="mh-link" href="/reports/evolve-review-000?lang=en">report →</a></div>
     </div>
   </li><li class="mh-event mh-event--install">
     <span class="mh-time">[TIMESTAMP]</span>
@@ -62,7 +76,14 @@ exports[`managed-history-renderer snapshots > renderManagedHistory zh 1`] = `
       <div class="mh-head"><span class="mh-type">回滚</span> <span class="mh-override">越门 override：drifted</span></div>
       <div class="mh-detail"><span class="mh-detail-item">决定人 bob</span></div>
     </div>
-  </li><li class="mh-event mh-event--promote">
+  </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV1conten</code></li><li class="mh-event mh-event--reject">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--reject"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">否决</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">决定人 carol</span></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">当前</span></li><li class="mh-event mh-event--promote">
     <span class="mh-time">[TIMESTAMP]</span>
     <span class="mh-marker"><span class="mh-dot mh-dot--promote"></span></span>
     <div class="mh-body">
@@ -82,6 +103,13 @@ exports[`managed-history-renderer snapshots > renderManagedHistory zh 1`] = `
     <div class="mh-body">
       <div class="mh-head"><span class="mh-type">评测</span> <span class="verdict-NOISE"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>基本持平</span></span></div>
       <div class="mh-detail"><span class="mh-detail-item">6 用例</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-001">查看报告 →</a></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV0conten</code></li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">评测</span> <span class="mh-badge-raw">INCONCLUSIVE</span></div>
+      <div class="mh-detail"><a class="mh-link" href="/reports/evolve-review-000">查看报告 →</a></div>
     </div>
   </li><li class="mh-event mh-event--install">
     <span class="mh-time">[TIMESTAMP]</span>
@@ -120,7 +148,7 @@ exports[`managed-history-renderer snapshots > renderManagedList en 1`] = `
     <span class="mh-row-name">review</span>
     <span class="mh-row-kind">skill</span>
     <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>PROGRESS</span></span></span>
-    <span class="mh-row-ev">1/2</span>
+    <span class="mh-row-ev">1/3</span>
     <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
   </a></div>
     <div class="mh-legend">
@@ -149,7 +177,121 @@ exports[`managed-history-renderer snapshots > renderManagedList zh 1`] = `
     <span class="mh-row-name">review</span>
     <span class="mh-row-kind">skill</span>
     <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>明显进步</span></span></span>
-    <span class="mh-row-ev">1/2</span>
+    <span class="mh-row-ev">1/3</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a></div>
+    <div class="mh-legend">
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--green"></span>已采用：已按证据人工接受</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--accent"></span>证据就绪：当前内容有有效证据、可采用</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--muted"></span>已纳管：尚无当前证据</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--red"></span>已漂移 ⚠️：源变了、需重跑 omk eval</span>
+    <span class="mh-legend-item">? 源未核（不可达 / 拒读，漂移待定）</span>
+    <span class="mh-legend-item">证据列：当前有效 / 全部历史（旧证据留作回滚）</span>
+  </div>
+  </main>"
+`;
+
+exports[`managed-history-renderer snapshots > renderManagedList 各状态 + 标记 en 1`] = `
+"<main class="mh-main">
+    <header class="mh-hero">
+      <div class="mh-kind">Managed skills</div>
+      <h1 class="mh-name">Decision history</h1>
+      <div class="mh-meta"><span>install → eval → promote / rollback per skill</span></div>
+    </header>
+    <div class="mh-table"><div class="mh-row mh-row--head">
+    <span>state</span><span>name</span><span>kind</span>
+    <span>verdict</span><span>evidence</span><span>source</span>
+  </div><a class="mh-row" href="/managed/i-prom?lang=en">
+    <span class="mh-row-state" title="Manually reviewed and accepted on evidence"><span class="mh-dot mh-dot--green"></span>Promoted</span>
+    <span class="mh-row-name">promoted-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>PROGRESS</span></span></span>
+    <span class="mh-row-ev">1/1</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a><a class="mh-row" href="/managed/i-meas?lang=en">
+    <span class="mh-row-state" title="Current content has valid evidence; ready for the promote gate"><span class="mh-dot mh-dot--accent"></span>Measurable</span>
+    <span class="mh-row-name">measurable-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict"><span class="verdict-CAUTIOUS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>CAUTIOUS</span></span></span>
+    <span class="mh-row-ev">1/1</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a><a class="mh-row" href="/managed/i-inst?lang=en">
+    <span class="mh-row-state" title="Under management; no valid evidence for current content yet"><span class="mh-dot mh-dot--muted"></span>Installed</span>
+    <span class="mh-row-name">installed-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict">—</span>
+    <span class="mh-row-ev">0/0</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a><a class="mh-row" href="/managed/i-stale?lang=en">
+    <span class="mh-row-state" title="Source changed off its evidence — re-run omk eval"><span class="mh-dot mh-dot--red"></span>Drifted <span class="mh-mark mh-mark--warn" title="drifted, re-measure">⚠️</span></span>
+    <span class="mh-row-name">stale-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict">—</span>
+    <span class="mh-row-ev">1/1</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a><a class="mh-row" href="/managed/i-unre?lang=en">
+    <span class="mh-row-state" title="Current content has valid evidence; ready for the promote gate"><span class="mh-dot mh-dot--accent"></span>Measurable <span class="mh-mark mh-mark--q" title="source unreachable / refused, drift unchecked">?</span></span>
+    <span class="mh-row-name">unreachable-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict">—</span>
+    <span class="mh-row-ev">1/1</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a></div>
+    <div class="mh-legend">
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--green"></span>Promoted = accepted on evidence</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--accent"></span>Measurable = current content has evidence, gate-ready</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--muted"></span>Installed = no current evidence yet</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--red"></span>Drifted ⚠️ = source changed, re-run omk eval</span>
+    <span class="mh-legend-item">? = source unverified (unreachable / refused)</span>
+    <span class="mh-legend-item">Evidence = current / total (old evidence kept for rollback)</span>
+  </div>
+  </main>"
+`;
+
+exports[`managed-history-renderer snapshots > renderManagedList 各状态 + 标记 zh 1`] = `
+"<main class="mh-main">
+    <header class="mh-hero">
+      <div class="mh-kind">受管 skill</div>
+      <h1 class="mh-name">决策史</h1>
+      <div class="mh-meta"><span>每个 skill 的 install → 评测 → 采用 / 回滚 全过程</span></div>
+    </header>
+    <div class="mh-table"><div class="mh-row mh-row--head">
+    <span>状态</span><span>名称</span><span>类型</span>
+    <span>verdict</span><span>证据</span><span>源</span>
+  </div><a class="mh-row" href="/managed/i-prom">
+    <span class="mh-row-state" title="已按证据人工复核并接受当前内容"><span class="mh-dot mh-dot--green"></span>已采用</span>
+    <span class="mh-row-name">promoted-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>明显进步</span></span></span>
+    <span class="mh-row-ev">1/1</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a><a class="mh-row" href="/managed/i-meas">
+    <span class="mh-row-state" title="当前内容已有有效证据，可进入采用门禁"><span class="mh-dot mh-dot--accent"></span>证据就绪</span>
+    <span class="mh-row-name">measurable-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict"><span class="verdict-CAUTIOUS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>略微进步</span></span></span>
+    <span class="mh-row-ev">1/1</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a><a class="mh-row" href="/managed/i-inst">
+    <span class="mh-row-state" title="已纳入管理，当前内容尚无有效证据"><span class="mh-dot mh-dot--muted"></span>已纳管</span>
+    <span class="mh-row-name">installed-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict">—</span>
+    <span class="mh-row-ev">0/0</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a><a class="mh-row" href="/managed/i-stale">
+    <span class="mh-row-state" title="源内容已变更、脱离证据，需重跑 omk eval 取证"><span class="mh-dot mh-dot--red"></span>已漂移 <span class="mh-mark mh-mark--warn" title="已漂移，需重测">⚠️</span></span>
+    <span class="mh-row-name">stale-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict">—</span>
+    <span class="mh-row-ev">1/1</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a><a class="mh-row" href="/managed/i-unre">
+    <span class="mh-row-state" title="当前内容已有有效证据，可进入采用门禁"><span class="mh-dot mh-dot--accent"></span>证据就绪 <span class="mh-mark mh-mark--q" title="源不可达 / 拒读，漂移未核">?</span></span>
+    <span class="mh-row-name">unreachable-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict">—</span>
+    <span class="mh-row-ev">1/1</span>
     <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
   </a></div>
     <div class="mh-legend">

--- a/test/renderer/managed-history-renderer.test.ts
+++ b/test/renderer/managed-history-renderer.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { renderManagedList, renderManagedHistory } from '../../src/renderer/managed-history-renderer.js';
-import { buildManagedListRows } from '../../src/managed/index.js';
+import { buildManagedListRows, type ManagedListRow } from '../../src/managed/index.js';
 import type { Lang, ManagedArtifactRecord } from '../../src/types/index.js';
 
 // 只快照 <main> 结构块:剥掉 layout 全局壳与 CSS（在别处测）—— 快照聚焦受管渲染的结构/文案,
@@ -16,7 +16,11 @@ function normalizeForSnapshot(html: string): string {
     .replace(/[ \t]+$/gm, '');
 }
 
-// install + 两个内容版本(hashV1 NOISE → hashV2 PROGRESS)的证据 + promote(hashV2) + 一条带 override 的 rollback。
+// 三个内容版本的证据 + 全部决定类型,刻意覆盖每条渲染分支:
+//   - evidence[0] hashV0:未知 verdict(INCONCLUSIVE,非 VerdictLevel → mh-badge-raw 降级)+ 缺 sampleCoverage /
+//     comparability(测 eventRow 的可选字段 if 守卫,无 sample 数 / omk 版本时不应渲染那两段);
+//   - hashV1 NOISE → hashV2 PROGRESS:已知 verdict 走配色徽标;
+//   - decisions:promote(带 reason)+ reject(缺 reason,测守卫 + dot--reject 配色)+ 带 override 的 rollback。
 const RECORD: ManagedArtifactRecord = {
   recordKind: 'managed-artifact',
   schemaVersion: 2,
@@ -28,16 +32,32 @@ const RECORD: ManagedArtifactRecord = {
   installedAt: '2026-03-01T00:00:00.000Z',
   distribution: [],
   evidence: [
+    { reportId: 'evolve-review-000', contentHash: 'hashV0contenthashlong', recordedAt: '2026-03-01T12:00:00.000Z', verdict: 'INCONCLUSIVE' },
     { reportId: 'evolve-review-001', contentHash: 'hashV1contenthashlong', recordedAt: '2026-03-02T00:00:00.000Z', verdict: 'NOISE', sampleCoverage: { count: 6, hash: 'sh1' }, comparability: { cliVersion: '0.37.0' } },
     { reportId: 'evolve-review-002', contentHash: 'hashV2contenthashlong', recordedAt: '2026-03-05T00:00:00.000Z', verdict: 'PROGRESS', sampleCoverage: { count: 6, hash: 'sh2' }, comparability: { cliVersion: '0.37.0' } },
   ],
   decisions: [
     { decisionKind: 'promote', actor: 'alice', decidedAt: '2026-03-06T00:00:00.000Z', contentHash: 'hashV2contenthashlong', reportId: 'evolve-review-002', reason: '已人工复核' },
+    { decisionKind: 'reject', actor: 'carol', decidedAt: '2026-03-07T00:00:00.000Z', contentHash: 'hashV1contenthashlong' },
     { decisionKind: 'rollback', actor: 'bob', decidedAt: '2026-03-08T00:00:00.000Z', contentHash: 'hashV2contenthashlong', override: { verdict: 'PROGRESS', overriddenBlocks: ['drifted'] } },
   ],
 };
 
 const ROWS = buildManagedListRows([RECORD], () => ({ reachable: true, hash: 'hashV2contenthashlong' }));
+
+// 直接构造每个生命周期状态各一行,锁住 listRow 的本地化文案 + ? / ⚠️ 标记(派生逻辑在 list-view 测,这里只测渲染)。
+const mkRow = (over: Partial<ManagedListRow>): ManagedListRow => ({
+  id: 'id', name: 'x', kind: 'skill', sourceKind: 'git', sourceLabel: 'https://example.com/r',
+  state: 'measurable', drifted: false, reachable: true,
+  currentEvidenceCount: 1, totalEvidenceCount: 1, distributionCount: 0, ...over,
+});
+const STATE_ROWS: ManagedListRow[] = [
+  mkRow({ id: 'i-prom', name: 'promoted-skill', state: 'promoted', latestVerdict: 'PROGRESS' }),
+  mkRow({ id: 'i-meas', name: 'measurable-skill', state: 'measurable', latestVerdict: 'CAUTIOUS' }),
+  mkRow({ id: 'i-inst', name: 'installed-skill', state: 'installed', currentEvidenceCount: 0, totalEvidenceCount: 0 }),
+  mkRow({ id: 'i-stale', name: 'stale-skill', state: 'stale', drifted: true }),
+  mkRow({ id: 'i-unre', name: 'unreachable-skill', state: 'measurable', reachable: false }),
+];
 
 describe('managed-history-renderer snapshots', () => {
   it('renderManagedList zh', () => {
@@ -48,6 +68,12 @@ describe('managed-history-renderer snapshots', () => {
   });
   it('renderManagedList empty zh', () => {
     expect(normalizeForSnapshot(renderManagedList([], 'zh' as Lang))).toMatchSnapshot();
+  });
+  it('renderManagedList 各状态 + 标记 zh', () => {
+    expect(normalizeForSnapshot(renderManagedList(STATE_ROWS, 'zh' as Lang))).toMatchSnapshot();
+  });
+  it('renderManagedList 各状态 + 标记 en', () => {
+    expect(normalizeForSnapshot(renderManagedList(STATE_ROWS, 'en' as Lang))).toMatchSnapshot();
   });
   it('renderManagedHistory zh', () => {
     expect(normalizeForSnapshot(renderManagedHistory(RECORD, 'zh' as Lang))).toMatchSnapshot();

--- a/test/renderer/managed-history-renderer.test.ts
+++ b/test/renderer/managed-history-renderer.test.ts
@@ -1,0 +1,58 @@
+/**
+ * 受管决策史渲染 snapshot（zh / en × 列表 / 时间线）。固定 fixture + 时间戳 normalize 让跨机器稳定。
+ * 改这两个渲染函数若动到非预期处,snapshot 会红 —— 先 review diff 再 vitest -u（AGENTS.md）。
+ */
+import { describe, it, expect } from 'vitest';
+import { renderManagedList, renderManagedHistory } from '../../src/renderer/managed-history-renderer.js';
+import { buildManagedListRows } from '../../src/managed/index.js';
+import type { Lang, ManagedArtifactRecord } from '../../src/types/index.js';
+
+// 只快照 <main> 结构块:剥掉 layout 全局壳与 CSS（在别处测）—— 快照聚焦受管渲染的结构/文案,
+// 且不被 layout.ts 的样式改动无端弄红。时间戳归一化跨机器稳定。
+function normalizeForSnapshot(html: string): string {
+  const m = html.match(/<main[\s\S]*?<\/main>/);
+  return (m ? m[0] : html)
+    .replace(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}(:\d{2})?/g, '[TIMESTAMP]')
+    .replace(/[ \t]+$/gm, '');
+}
+
+// install + 两个内容版本(hashV1 NOISE → hashV2 PROGRESS)的证据 + promote(hashV2) + 一条带 override 的 rollback。
+const RECORD: ManagedArtifactRecord = {
+  recordKind: 'managed-artifact',
+  schemaVersion: 2,
+  id: 'skill-review-fixture',
+  name: 'review',
+  kind: 'skill',
+  source: { sourceKind: 'git', locator: 'git+https://example.com/r@abc123:review', url: 'https://example.com/r', ref: 'abc123', isDirectorySkill: true },
+  contentHash: 'hashV2contenthashlong',
+  installedAt: '2026-03-01T00:00:00.000Z',
+  distribution: [],
+  evidence: [
+    { reportId: 'evolve-review-001', contentHash: 'hashV1contenthashlong', recordedAt: '2026-03-02T00:00:00.000Z', verdict: 'NOISE', sampleCoverage: { count: 6, hash: 'sh1' }, comparability: { cliVersion: '0.37.0' } },
+    { reportId: 'evolve-review-002', contentHash: 'hashV2contenthashlong', recordedAt: '2026-03-05T00:00:00.000Z', verdict: 'PROGRESS', sampleCoverage: { count: 6, hash: 'sh2' }, comparability: { cliVersion: '0.37.0' } },
+  ],
+  decisions: [
+    { decisionKind: 'promote', actor: 'alice', decidedAt: '2026-03-06T00:00:00.000Z', contentHash: 'hashV2contenthashlong', reportId: 'evolve-review-002', reason: '已人工复核' },
+    { decisionKind: 'rollback', actor: 'bob', decidedAt: '2026-03-08T00:00:00.000Z', contentHash: 'hashV2contenthashlong', override: { verdict: 'PROGRESS', overriddenBlocks: ['drifted'] } },
+  ],
+};
+
+const ROWS = buildManagedListRows([RECORD], () => ({ reachable: true, hash: 'hashV2contenthashlong' }));
+
+describe('managed-history-renderer snapshots', () => {
+  it('renderManagedList zh', () => {
+    expect(normalizeForSnapshot(renderManagedList(ROWS, 'zh' as Lang))).toMatchSnapshot();
+  });
+  it('renderManagedList en', () => {
+    expect(normalizeForSnapshot(renderManagedList(ROWS, 'en' as Lang))).toMatchSnapshot();
+  });
+  it('renderManagedList empty zh', () => {
+    expect(normalizeForSnapshot(renderManagedList([], 'zh' as Lang))).toMatchSnapshot();
+  });
+  it('renderManagedHistory zh', () => {
+    expect(normalizeForSnapshot(renderManagedHistory(RECORD, 'zh' as Lang))).toMatchSnapshot();
+  });
+  it('renderManagedHistory en', () => {
+    expect(normalizeForSnapshot(renderManagedHistory(RECORD, 'en' as Lang))).toMatchSnapshot();
+  });
+});

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -13,6 +13,28 @@ const OBSERVATIONS_DIR = join(tmpdir(), `omk-test-observations-${Date.now()}`);
 // 导致 fixture skill 意外携带 observe / doctor snapshot(本地 / CI 漂移)。
 const ANALYSES_DIR = join(tmpdir(), `omk-test-analyses-${Date.now()}`);
 const DOCTORS_DIR = join(tmpdir(), `omk-test-doctors-${Date.now()}`);
+const MANAGED_DIR = join(tmpdir(), `omk-test-managed-${Date.now()}`);
+
+// 受管记录 fixture:git+url 源 → probeSourceState 直接 reachable + record.contentHash,零文件 IO、跨机稳定。
+// install + 两版本证据(NOISE→PROGRESS) + promote(当前内容)→ 行状态应为 promoted。
+const MANAGED_RECORD = {
+  recordKind: 'managed-artifact',
+  schemaVersion: 2,
+  id: 'skill-review-smoke',
+  name: 'review',
+  kind: 'skill',
+  source: { sourceKind: 'git', locator: 'git+https://example.com/r@abc123:review', url: 'https://example.com/r', ref: 'abc123', isDirectorySkill: true },
+  contentHash: 'hashV2smoke',
+  installedAt: '2026-03-01T00:00:00.000Z',
+  distribution: [],
+  evidence: [
+    { reportId: 'r1', contentHash: 'hashV1smoke', recordedAt: '2026-03-02T00:00:00.000Z', verdict: 'NOISE', sampleCoverage: { count: 6, hash: 'sh1' }, comparability: { cliVersion: '0.37.0' } },
+    { reportId: 'test-run-001', contentHash: 'hashV2smoke', recordedAt: '2026-03-05T00:00:00.000Z', verdict: 'PROGRESS', sampleCoverage: { count: 6, hash: 'sh2' }, comparability: { cliVersion: '0.37.0' } },
+  ],
+  decisions: [
+    { decisionKind: 'promote', actor: 'alice', decidedAt: '2026-03-06T00:00:00.000Z', contentHash: 'hashV2smoke', reportId: 'test-run-001' },
+  ],
+};
 
 const SAMPLE_REPORT = {
   kind: 'evaluation',
@@ -141,6 +163,8 @@ describe('report-server', () => {
     mkdirSync(OBSERVATIONS_DIR, { recursive: true });
     mkdirSync(ANALYSES_DIR, { recursive: true });
     mkdirSync(DOCTORS_DIR, { recursive: true });
+    mkdirSync(MANAGED_DIR, { recursive: true });
+    writeFileSync(join(MANAGED_DIR, 'skill-review-smoke.json'), JSON.stringify(MANAGED_RECORD, null, 2));
     writeFileSync(join(TEST_DIR, 'test-run-001.json'), JSON.stringify(SAMPLE_REPORT, null, 2));
     writeFileSync(join(JOBS_DIR, 'job-test-run-001.json'), JSON.stringify(SAMPLE_JOB, null, 2));
     writeFileSync(join(JOBS_DIR, 'job-test-run-002.json'), JSON.stringify(FAILED_JOB, null, 2));
@@ -232,7 +256,7 @@ describe('report-server', () => {
         },
       },
     }, null, 2));
-    server = createReportServer({ port: 0, reportsDir: TEST_DIR, observationsDir: OBSERVATIONS_DIR, jobsDir: JOBS_DIR, analysesDir: ANALYSES_DIR, doctorsDir: DOCTORS_DIR });
+    server = createReportServer({ port: 0, reportsDir: TEST_DIR, observationsDir: OBSERVATIONS_DIR, jobsDir: JOBS_DIR, analysesDir: ANALYSES_DIR, doctorsDir: DOCTORS_DIR, managedDir: MANAGED_DIR });
     baseUrl = await server.start();
   });
 
@@ -243,6 +267,54 @@ describe('report-server', () => {
     rmSync(OBSERVATIONS_DIR, { recursive: true, force: true });
     rmSync(ANALYSES_DIR, { recursive: true, force: true });
     rmSync(DOCTORS_DIR, { recursive: true, force: true });
+    rmSync(MANAGED_DIR, { recursive: true, force: true });
+  });
+
+  it('GET /managed lists managed skills with link + verdict', async () => {
+    const res = await fetch(`${baseUrl}/managed`);
+    assert.equal(res.status, 200);
+    assert.match(res.headers['content-type'] as string, /text\/html/);
+    assert.ok(res.body.includes('review'), 'should show skill name');
+    assert.ok(res.body.includes('/managed/review'), 'should link to detail page');
+    assert.ok(res.body.includes('verdict-PROGRESS'), 'current verdict badge');
+    assert.ok(res.body.includes('promoted'), 'lifecycle state from promote decision');
+  });
+
+  it('GET /api/managed returns versioned envelope', async () => {
+    const res = await fetch(`${baseUrl}/api/managed`);
+    assert.equal(res.status, 200);
+    const json = JSON.parse(res.body);
+    assert.equal(json.schemaVersion, 1);
+    assert.ok(Array.isArray(json.rows));
+    const row = json.rows.find((r: { name: string }) => r.name === 'review');
+    assert.ok(row, 'review row present');
+    assert.equal(row.state, 'promoted');
+    assert.equal(row.latestVerdict, 'PROGRESS');
+  });
+
+  it('GET /managed/<name> renders the decision timeline', async () => {
+    const res = await fetch(`${baseUrl}/managed/review`);
+    assert.equal(res.status, 200);
+    assert.match(res.headers['content-type'] as string, /text\/html/);
+    assert.ok(res.body.includes('mh-timeline'), 'timeline present');
+    assert.ok(res.body.includes('安装纳管'), 'install event');
+    assert.ok(res.body.includes('verdict-PROGRESS') && res.body.includes('verdict-NOISE'), 'both version verdicts');
+    assert.ok(res.body.includes('alice'), 'promote actor');
+    assert.ok(res.body.includes('/reports/test-run-001'), 'links to evidence report');
+  });
+
+  it('GET /managed/<missing> → 404 (zh default, en via ?lang=en)', async () => {
+    const zh = await fetch(`${baseUrl}/managed/nope`);
+    assert.equal(zh.status, 404);
+    assert.ok(zh.body.includes('受管记录不存在'));
+    const en = await fetch(`${baseUrl}/managed/nope?lang=en`);
+    assert.equal(en.status, 404);
+    assert.ok(en.body.includes('managed record not found'));
+  });
+
+  it('GET /managed/<malformed %> → 404, not 500', async () => {
+    const res = await fetch(`${baseUrl}/managed/%E0%A4%A`);
+    assert.equal(res.status, 404, 'bad percent-encoding decodes to no match, not a crash');
   });
 
   it('GET /health returns ok', async () => {

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -275,7 +275,7 @@ describe('report-server', () => {
     assert.equal(res.status, 200);
     assert.match(res.headers['content-type'] as string, /text\/html/);
     assert.ok(res.body.includes('review'), 'should show skill name');
-    assert.ok(res.body.includes('/managed/review'), 'should link to detail page');
+    assert.ok(res.body.includes('/managed/skill-review-smoke'), 'should link to detail page by stable id');
     assert.ok(res.body.includes('verdict-PROGRESS'), 'current verdict badge');
     assert.ok(res.body.includes('promoted'), 'lifecycle state from promote decision');
   });
@@ -292,8 +292,8 @@ describe('report-server', () => {
     assert.equal(row.latestVerdict, 'PROGRESS');
   });
 
-  it('GET /managed/<name> renders the decision timeline', async () => {
-    const res = await fetch(`${baseUrl}/managed/review`);
+  it('GET /managed/<id> renders the decision timeline', async () => {
+    const res = await fetch(`${baseUrl}/managed/skill-review-smoke`);
     assert.equal(res.status, 200);
     assert.match(res.headers['content-type'] as string, /text\/html/);
     assert.ok(res.body.includes('mh-timeline'), 'timeline present');
@@ -315,6 +315,37 @@ describe('report-server', () => {
   it('GET /managed/<malformed %> → 404, not 500', async () => {
     const res = await fetch(`${baseUrl}/managed/%E0%A4%A`);
     assert.equal(res.status, 404, 'bad percent-encoding decodes to no match, not a crash');
+  });
+
+  it('EN 页内跳转透传 lang=en —— 列表行 / 返回 / 报告链接都带 lang(P2)', async () => {
+    const list = await fetch(`${baseUrl}/managed?lang=en`);
+    assert.ok(list.body.includes('/managed/skill-review-smoke?lang=en'), 'list row link carries lang');
+    const detail = await fetch(`${baseUrl}/managed/skill-review-smoke?lang=en`);
+    assert.ok(detail.body.includes('/managed?lang=en'), 'back-to-list link carries lang');
+    assert.ok(detail.body.includes('/reports/test-run-001?lang=en'), 'evidence report link carries lang');
+  });
+
+  it('同名跨 kind —— skill/review 与 prompt/review 各有独立 id,都可达(P1)', async () => {
+    const dir = join(tmpdir(), `omk-test-managed-xkind-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const mk = (kind: string, id: string) => ({
+      recordKind: 'managed-artifact', schemaVersion: 2, id, name: 'review', kind,
+      source: { sourceKind: 'git', locator: 'git+https://x@s:review', url: 'https://x', ref: 's', isDirectorySkill: kind === 'skill' },
+      contentHash: 'h', installedAt: '2026-03-01T00:00:00.000Z', distribution: [], evidence: [], decisions: [],
+    });
+    writeFileSync(join(dir, 'a.json'), JSON.stringify(mk('skill', 'id-skill-review')));
+    writeFileSync(join(dir, 'b.json'), JSON.stringify(mk('prompt', 'id-prompt-review')));
+    const s = createReportServer({ port: 0, reportsDir: TEST_DIR, jobsDir: JOBS_DIR, observationsDir: OBSERVATIONS_DIR, analysesDir: ANALYSES_DIR, doctorsDir: DOCTORS_DIR, managedDir: dir });
+    const u = await s.start();
+    try {
+      assert.equal((await fetch(`${u}/managed/id-skill-review`)).status, 200, 'skill/review reachable');
+      assert.equal((await fetch(`${u}/managed/id-prompt-review`)).status, 200, 'prompt/review reachable');
+      const listBody = (await fetch(`${u}/managed`)).body;
+      assert.ok(listBody.includes('/managed/id-skill-review') && listBody.includes('/managed/id-prompt-review'), 'both rows link to distinct ids');
+    } finally {
+      await s.stop();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('GET /health returns ok', async () => {

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, writeFileSync, rmSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import http from 'node:http';
@@ -277,7 +277,8 @@ describe('report-server', () => {
     assert.ok(res.body.includes('review'), 'should show skill name');
     assert.ok(res.body.includes('/managed/skill-review-smoke'), 'should link to detail page by stable id');
     assert.ok(res.body.includes('verdict-PROGRESS'), 'current verdict badge');
-    assert.ok(res.body.includes('promoted'), 'lifecycle state from promote decision');
+    assert.ok(res.body.includes('已采用'), 'localized lifecycle label from promote decision (raw token stays in /api/managed)');
+    assert.ok(res.body.includes('mh-legend'), 'state/marker legend present for first-time viewers');
   });
 
   it('GET /api/managed returns versioned envelope', async () => {
@@ -345,6 +346,38 @@ describe('report-server', () => {
     } finally {
       await s.stop();
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('受管根目录按请求解析 —— 会话中途项目获首条记录后从 global 切回 project,不冻结于启动(P1)', async () => {
+    // 复现 reviewer 场景的可控版:local 空 → 解析到 global;local 有记录 → 解析到 local(模拟 resolveManagedDir
+    // 的 project→global 回退,但用受控 temp 目录、不碰 homedir,跨机稳定)。注入解析器 = server 持有的是「如何解析」
+    // 策略而非冻结 root —— 若 server 在启动时定死,中途新增的 project 记录就永远看不到。
+    const projDir = join(tmpdir(), `omk-test-managed-proj-${Date.now()}`);
+    const globalDir = join(tmpdir(), `omk-test-managed-glob-${Date.now()}`);
+    mkdirSync(projDir, { recursive: true });
+    mkdirSync(globalDir, { recursive: true });
+    const mk = (id: string, name: string) => ({
+      recordKind: 'managed-artifact', schemaVersion: 2, id, name, kind: 'skill',
+      source: { sourceKind: 'git', locator: 'git+https://x@s:review', url: 'https://x', ref: 's', isDirectorySkill: true },
+      contentHash: 'h', installedAt: '2026-03-01T00:00:00.000Z', distribution: [], evidence: [], decisions: [],
+    });
+    writeFileSync(join(globalDir, 'g.json'), JSON.stringify(mk('id-global-skill', 'global-skill')));
+    // local 非空才用 local,否则回退 global —— 即 resolveManagedDir 的口径。
+    const resolver = (): string => (readdirSync(projDir).length > 0 ? projDir : globalDir);
+    const s = createReportServer({ port: 0, reportsDir: TEST_DIR, jobsDir: JOBS_DIR, observationsDir: OBSERVATIONS_DIR, analysesDir: ANALYSES_DIR, doctorsDir: DOCTORS_DIR, managedDir: resolver });
+    const u = await s.start();
+    try {
+      const before = JSON.parse((await fetch(`${u}/api/managed`)).body);
+      assert.deepEqual(before.rows.map((r: { name: string }) => r.name), ['global-skill'], '启动时 local 空 → 解析到 global');
+      // 会话中途:项目里首次 install,local 目录获得记录。
+      writeFileSync(join(projDir, 'p.json'), JSON.stringify(mk('id-project-skill', 'project-skill')));
+      const after = JSON.parse((await fetch(`${u}/api/managed`)).body);
+      assert.deepEqual(after.rows.map((r: { name: string }) => r.name), ['project-skill'], '中途 local 获记录 → 同一会话实时切回 project');
+    } finally {
+      await s.stop();
+      rmSync(projDir, { recursive: true, force: true });
+      rmSync(globalDir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
#236 的第一刀（Slice 1）。Relates to #203。

## 用户影响

把 #203 证据门禁管理支柱从「埋在 `.omk/managed` JSON + CLI 文本里」搬到 Studio 可视化——兑现 #203 设想的「版本史不是 git log，而是带证据的决策史」：

- `/managed` 列表：每个受管 skill 的生命周期（installed / measurable / promoted / stale）、最新 verdict、当前/全部证据数、源；首页加了入口链接。
- `/managed/<name>` 决策史时间线：`install` → 每次评测证据（挂 verdict badge + 链到对应报告） → `promote` / `reject` / `rollback` 决定（带 actor / reason / 越门标记），**按时间倒序、按内容版本（contentHash）分段**，当前版本标「当前」。
- `/api/managed` 机读信封 `{schemaVersion:1, rows}`，对称 `/api/analyses`。

纯用受管记录自带数据（evidence 上 denormalize 的 verdict / 样本数 / 可比性），**不读 report 文件**。口径与 `omk list` 完全一致（同一条读取链路）。

## 架构归位（顺带）

`source-probe`（受管记录当前源状态 / drift 判定）从 `cli/lib` 提到 `managed/`——它是管理支柱的领域逻辑，原先躺在 cli/lib 只因 `omk list` 第一个用到。新增共享 `listManagedRows(dir)` 收编「读受管记录做展示」的编排，`omk list` 与 server 同调。结果：cli 与 server 都只依赖 `managed/ + renderer/ + types/`，**消除 server→cli 倒挂、去掉重复编排**。纯机械、行为不变（全量测试行数不变佐证）。

## 安全 / 边界

`/managed/<name>` 只在已加载、已校验的记录里按 `name` 精确查（不拼文件路径 → 无路径穿越、跨 kind）；`decodeURIComponent` 失败 → 404 而非 500；server 对受管目录只读、不 mkdir；渲染所有动态值过 `e()` 转义；未知 verdict 安全降级为纯文本。

## 测量学

不碰 report schema / judge hash / 评分管道 / verdict / bootstrap —— 纯展示层。非 BREAKING。

## 验证

166 文件 2112 测试全绿，lint / build / `build:docs:check` 干净。新增 renderer snapshot（zh/en × 列表/时间线/空态，只截 `<main>` 与 layout CSS 解耦）+ server 路由 smoke（200 / 404 双语 / malformed→404 不 500）。跑了 1 轮多维对抗式 CR（架构 / 安全 / 正确性 / 规约 × 双验伪）：真问题 1 条已修（verdict level 守卫改编译期穷举防与 eval-core 漂移），其余为正面确认或被驳回的伪问题。

## Slice 2（#236 留开，不在本 PR）

带 `avgCompositeScore` + 95%CI 的版本回归曲线（要读 report 文件 + variant 匹配）；`omk studio --managed-dir` flag + dev 透传；全站 app-bar 导航。

🤖 Generated with [Claude Code](https://claude.com/claude-code)