### PR TITLE
refactor(eval-core): reports 目录常量收敛到单一来源，去重三处定义

### DIFF
--- a/src/cli/lib/parse-run-config.ts
+++ b/src/cli/lib/parse-run-config.ts
@@ -18,8 +18,8 @@
  * 反而失去「精度链一目了然」的可读性。
  */
 
-import { resolve, join } from 'node:path';
-import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import { DEFAULT_REPORTS_DIR } from '../../eval-core/default-dirs.js';
 import { loadEvalConfig } from '../../inputs/eval-config.js';
 import { DEFAULT_MODEL } from '../../executors/shared.js';
 import type {
@@ -101,7 +101,8 @@ export interface ParseRunConfigResult {
   evalConfig: EvalConfig | null;
 }
 
-export const DEFAULT_REPORTS_DIR: string = join(homedir(), '.oh-my-knowledge', 'reports');
+// 单一来源在 eval-core/default-dirs；此处 re-export 保持既有 import 入口不破(studio / sample / eval gold compare 仍从本文件取)。
+export { DEFAULT_REPORTS_DIR };
 
 /**
  * 接 typed flags(来自 oclif Command.parse() 输出)。oclif strict 模式已经在

--- a/src/eval-core/default-dirs.ts
+++ b/src/eval-core/default-dirs.ts
@@ -1,0 +1,9 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * reports 默认根目录的**单一来源**:cli 侧 eval-runner 写、server 侧 report store 读,二者必须一致 ——
+ * 否则 cli 把报告写到一处、studio 从另一处读,页面就空。放在中立的 eval-core 层,让 cli/ 与 server/
+ * 两个交付层都能合法 import 同一个常量,而不必让 server 反向 import cli(那是 #242 刚清掉的分层倒挂)。
+ */
+export const DEFAULT_REPORTS_DIR: string = join(homedir(), '.oh-my-knowledge', 'reports');

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -1,9 +1,9 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { DEFAULT_REPORTS_DIR } from './default-dirs.js';
 import { buildVariantSummary } from './schema.js';
 import { buildVariantConfig, resolveExecutionStrategy } from './execution-strategy.js';
 import { getJudgePromptHash } from '../grading/judge.js';
@@ -42,7 +42,8 @@ function findPackageJson(startDir: string): string {
 
 const PKG: { version: string } = JSON.parse(readFileSync(findPackageJson(__dirname), 'utf-8')) as { version: string };
 
-export const DEFAULT_OUTPUT_DIR: string = join(homedir(), '.oh-my-knowledge', 'reports');
+// 写报告的默认目录 = reports 单一来源(default-dirs)。保留 DEFAULT_OUTPUT_DIR 名给既有 16 处 import,值统一,杜绝写/读两端漂移。
+export const DEFAULT_OUTPUT_DIR: string = DEFAULT_REPORTS_DIR;
 export const EVALUATION_REPORT_SCHEMA_VERSION = 4;
 
 export function hashString(str: string): string {

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -14,6 +14,7 @@ import { renderObservationInboxPage } from '../renderer/observation-inbox-render
 import { DEFAULT_LANG, t, layout } from '../renderer/layout.js';
 import { loadAllManagedRecords, resolveManagedDir, managedDir as projectManagedDir, listManagedRows } from '../managed/index.js';
 import { renderManagedList, renderManagedHistory } from '../renderer/managed-history-renderer.js';
+import { DEFAULT_REPORTS_DIR } from '../eval-core/default-dirs.js';
 import { buildSkillIndex } from './skill-index.js';
 import type { Lang } from '../types/index.js';
 import { createFileJobStore, DEFAULT_JOBS_DIR } from './job-store.js';
@@ -29,7 +30,7 @@ import type { AddressInfo } from 'node:net';
 
 const DEFAULT_PORT = 7799;
 const PORT_HINT = `OMK_REPORT_PORT=${DEFAULT_PORT} omk eval ...`;
-const DEFAULT_REPORTS_DIR = join(homedir(), '.oh-my-knowledge', 'reports');
+// reports 默认目录的单一来源在 eval-core/default-dirs(cli 写 / server 读须一致);analyses/doctors 仅此处一用,保留本地定义。
 const DEFAULT_ANALYSES_DIR = join(homedir(), '.oh-my-knowledge', 'analyses');
 const DEFAULT_DOCTORS_DIR = join(homedir(), '.oh-my-knowledge', 'doctors');
 


### PR DESCRIPTION
## 做什么

把 `~/.oh-my-knowledge/reports` 这个默认目录常量收敛到单一来源。它此前在三处各自硬编码、且必须始终一致（cli 把报告写到这里、studio 从这里读，漂了页面就空）：

- cli：`parse-run-config.ts` 的 `DEFAULT_REPORTS_DIR`
- server：`report-server.ts` 的本地同名 `const`
- eval-core：`evaluation-reporting.ts` 的 `DEFAULT_OUTPUT_DIR`（写报告侧用，被 eval pipeline / evolver / batch 等 ~16 处 import）

## 怎么做

新增中立叶子模块 `src/eval-core/default-dirs.ts` 作为唯一定义，三处都改为引用它。

特意放在 eval-core 而**不是**让 server 去 import cli 的 parse-run-config——后者会引入 server → cli 的分层倒挂，正是 #242 刚清理掉的方向（规则：cli/ 与 server/ 是平级交付层，都只依赖 managed/ + eval-core/ + renderer/ + types/）。`DEFAULT_OUTPUT_DIR` 保留原名作别名，既有 import 站点零改动。

## 用户影响

无。纯常量搬迁，值不变、行为不变（reports 仍落在同一目录）。

## 范围

这是 #243「工程卫生·无悔项」里唯一零风险零回归的一条。`omk clean` 命令、scratch 搬 `state/` 子树、reports/analyses/observations 的保留实现、以及问题一的项目/全局归属决策——均不在本 PR，留给后续。#243 里「零保留策略」的不准确表述已在该 issue 中一并修正（trees/cache/doctors 早有保留上限）。

链接 #243。
