### PR TITLE
feat(cli): observe-health / doctors 测量产物默认落项目 .omk/，全局显式 --global（方案 A phase-1）

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -635,7 +635,7 @@ omk studio [flags]
 - `--analyses-dir` `option`:观测健康报告目录（可选，默认项目级 .omk/observe-health，空则全局兜底）
 - `--dev` `boolean`:dev 模式：子进程启动 + 热更新
 - `--doctors-dir` `option`:体检报告目录（可选，默认项目级 .omk/doctors，空则全局兜底）
-- `--global` `boolean`:只看全局目录（~/.oh-my-knowledge/*）而非项目优先
+- `--global` `boolean`:只看全局 observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
 - `--host` `option`:监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--no-open` `boolean`:不自动打开浏览器

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -25,10 +25,11 @@ omk doctor [target] [flags]
 - `--executor` `option`:执行器名，默认 claude。指定为测试 fixture 路径可在测试里跑（同 omk doctor）。
 - `--fix` `boolean`:交互式修复：根据 doctor 报告问题，用 LLM agent 修复 skill。
 - `--gate` `boolean`:静默模式，只在 fail 时输出 stderr 摘要，exit code 标识结果。
+- `--global` `boolean`:写全局 ~/.oh-my-knowledge/doctors，而非项目 .omk/doctors
 - `--json` `boolean`:JSON 输出到 stdout，适合 CI / 外部脚本消费。
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--model` `option`:LLM model 名，默认 sonnet。
-- `--output-dir` `option`:报告输出目录，默认 ~/.oh-my-knowledge/doctors。
+- `--output-dir` `option`:报告输出目录，默认项目级 .omk/doctors（--global 写全局）。
 - `--samples` `option`:用例文件路径（.json/.yaml）。不传则按 target / cwd 顺序自动发现。
 - `--static-only` `boolean`:离线静态模式，只跑 4 条静态 rule(skill_readable / skill_metadata / dependencies_present / samples_contract_aligned），不调 LLM。
 - `--timeout` `option`:单次 LLM 会话超时秒数，默认 600(10 分钟）。
@@ -402,10 +403,11 @@ omk observe [sessionsDir] [flags]
 **Flags:**
 
 - `--from` `option`:起始时间 ISO，优先级高于 --last
+- `--global` `boolean`:写全局 ~/.oh-my-knowledge/observe-health，而非项目 .omk/observe-health
 - `--kb` `option`:知识库 root，启用 KB-aware 分析
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--last` `option`:时间窗(7d / 24h / 30m）
-- `--output-dir` `option`:健康报告输出目录，默认 ~/.oh-my-knowledge/observe-health
+- `--output-dir` `option`:健康报告输出目录，默认项目级 .omk/observe-health（--global 写全局）
 - `--skills` `option`:只看指定 skill，逗号分隔
 - `--to` `option`:结束时间 ISO
 
@@ -630,8 +632,10 @@ omk studio [flags]
 
 **Flags:**
 
-- `--analyses-dir` `option`:观测健康报告目录（可选，默认 ~/.oh-my-knowledge/observe-health）
+- `--analyses-dir` `option`:观测健康报告目录（可选，默认项目级 .omk/observe-health，空则全局兜底）
 - `--dev` `boolean`:dev 模式：子进程启动 + 热更新
+- `--doctors-dir` `option`:体检报告目录（可选，默认项目级 .omk/doctors，空则全局兜底）
+- `--global` `boolean`:只看全局目录（~/.oh-my-knowledge/*）而非项目优先
 - `--host` `option`:监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--no-open` `boolean`:不自动打开浏览器

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -158,10 +158,11 @@ omk doctor --static-only                # offline mode: static checks only, no L
   --executor <value>    Executor name, default claude. Pass a test fixture path to use in tests.
   --fix                 Interactive fix: use LLM agent to fix skill issues reported by doctor.
   --gate                Silent mode: only emit stderr summary on fail. Exit code carries the signal.
+  --global              Write to global ~/.oh-my-knowledge/doctors instead of project .omk/doctors
   --json                JSON output to stdout, for CI / external script consumption.
   --lang <value>        Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --model <value>       LLM model name, default sonnet.
-  --output-dir <value>  Report output dir, default ~/.oh-my-knowledge/doctors.
+  --output-dir <value>  Report output dir, default project-level .omk/doctors (--global for global).
   --samples <value>     Samples file path (.json/.yaml). Auto-detects from target / cwd if omitted.
   --static-only         Offline static mode: only 4 static rules, no LLM call.
   --timeout <value>     Single-session LLM timeout sec, default 600 (10 min).
@@ -295,10 +296,11 @@ omk observe ~/.claude/projects/my-project --kb /path/to/project
 
 ```text
   --from <value>        Start time ISO, overrides --last
+  --global              Write to global ~/.oh-my-knowledge/observe-health instead of project .omk/observe-health
   --kb <value>          KB root, enables KB-aware analysis
   --lang <value>        Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --last <value>        Time window (7d / 24h / 30m)
-  --output-dir <value>  Health report output dir, default ~/.oh-my-knowledge/observe-health
+  --output-dir <value>  Health report output dir, default project-level .omk/observe-health (--global for global)
   --skills <value>      Filter to specific skills, comma-separated
   --to <value>          End time ISO
 ```
@@ -441,8 +443,10 @@ omk studio --no-open
 **Flags:**
 
 ```text
-  --analyses-dir <value>      Observe-health reports dir (optional, default ~/.oh-my-knowledge/observe-health)
+  --analyses-dir <value>      Observe-health reports dir (optional, default project .omk/observe-health, falls back to global)
   --dev                       Dev mode: child process with hot reload
+  --doctors-dir <value>       Doctor reports dir (optional, default project .omk/doctors, falls back to global)
+  --global                    View global dirs (~/.oh-my-knowledge/*) instead of project-first
   --host <value>              Listen host, default localhost. Use 0.0.0.0 to expose to LAN
   --lang <value>              Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --no-open                   Do not auto-open browser

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -446,7 +446,7 @@ omk studio --no-open
   --analyses-dir <value>      Observe-health reports dir (optional, default project .omk/observe-health, falls back to global)
   --dev                       Dev mode: child process with hot reload
   --doctors-dir <value>       Doctor reports dir (optional, default project .omk/doctors, falls back to global)
-  --global                    View global dirs (~/.oh-my-knowledge/*) instead of project-first
+  --global                    View global observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox
   --host <value>              Listen host, default localhost. Use 0.0.0.0 to expose to LAN
   --lang <value>              Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --no-open                   Do not auto-open browser

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -446,7 +446,7 @@ omk studio --no-open
   --analyses-dir <value>      观测健康报告目录（可选，默认项目级 .omk/observe-health，空则全局兜底）
   --dev                       dev 模式：子进程启动 + 热更新
   --doctors-dir <value>       体检报告目录（可选，默认项目级 .omk/doctors，空则全局兜底）
-  --global                    只看全局目录（~/.oh-my-knowledge/*）而非项目优先
+  --global                    只看全局 observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
   --host <value>              监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
   --lang <value>              输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --no-open                   不自动打开浏览器

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -158,10 +158,11 @@ omk doctor --static-only                # 离线模式：只跑静态检查，�
   --executor <value>    执行器名，默认 claude。指定为测试 fixture 路径可在测试里跑（同 omk doctor）。
   --fix                 交互式修复：根据 doctor 报告问题，用 LLM agent 修复 skill。
   --gate                静默模式，只在 fail 时输出 stderr 摘要，exit code 标识结果。
+  --global              写全局 ~/.oh-my-knowledge/doctors，而非项目 .omk/doctors
   --json                JSON 输出到 stdout，适合 CI / 外部脚本消费。
   --lang <value>        输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --model <value>       LLM model 名，默认 sonnet。
-  --output-dir <value>  报告输出目录，默认 ~/.oh-my-knowledge/doctors。
+  --output-dir <value>  报告输出目录，默认项目级 .omk/doctors（--global 写全局）。
   --samples <value>     用例文件路径（.json/.yaml）。不传则按 target / cwd 顺序自动发现。
   --static-only         离线静态模式，只跑 4 条静态 rule(skill_readable / skill_metadata / dependencies_present / samples_contract_aligned），不调 LLM。
   --timeout <value>     单次 LLM 会话超时秒数，默认 600(10 分钟）。
@@ -295,10 +296,11 @@ omk observe ~/.claude/projects/my-project --kb /path/to/project
 
 ```text
   --from <value>        起始时间 ISO，优先级高于 --last
+  --global              写全局 ~/.oh-my-knowledge/observe-health，而非项目 .omk/observe-health
   --kb <value>          知识库 root，启用 KB-aware 分析
   --lang <value>        输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --last <value>        时间窗(7d / 24h / 30m）
-  --output-dir <value>  健康报告输出目录，默认 ~/.oh-my-knowledge/observe-health
+  --output-dir <value>  健康报告输出目录，默认项目级 .omk/observe-health（--global 写全局）
   --skills <value>      只看指定 skill，逗号分隔
   --to <value>          结束时间 ISO
 ```
@@ -441,8 +443,10 @@ omk studio --no-open
 **Flags:**
 
 ```text
-  --analyses-dir <value>      观测健康报告目录（可选，默认 ~/.oh-my-knowledge/observe-health）
+  --analyses-dir <value>      观测健康报告目录（可选，默认项目级 .omk/observe-health，空则全局兜底）
   --dev                       dev 模式：子进程启动 + 热更新
+  --doctors-dir <value>       体检报告目录（可选，默认项目级 .omk/doctors，空则全局兜底）
+  --global                    只看全局目录（~/.oh-my-knowledge/*）而非项目优先
   --host <value>              监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
   --lang <value>              输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --no-open                   不自动打开浏览器

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -8,6 +8,7 @@ import { CliExit } from '../lib/cli-exit.js';
 import { tCli } from '../lib/i18n.js';
 import { makeDoctorProgress } from '../lib/progress.js';
 import { DEFAULT_DOCTORS_DIR } from '../../eval-core/default-dirs.js';
+import { projectDoctorsDir, globalDoctorsDir } from '../../eval-core/measurement-dirs.js';
 import type { Sample, DoctorRule, DoctorRuleLike } from '../../types/index.js';
 import type { DependencyRequirements } from '../../eval-core/dependency-checker.js';
 
@@ -137,8 +138,14 @@ export default class Doctor extends BaseCommand {
     }),
     'output-dir': Flags.string({
       description: bilingual({
-        zh: '报告输出目录，默认 ~/.oh-my-knowledge/doctors。',
-        en: 'Report output dir, default ~/.oh-my-knowledge/doctors.',
+        zh: '报告输出目录，默认项目级 .omk/doctors（--global 写全局）。',
+        en: 'Report output dir, default project-level .omk/doctors (--global for global).',
+      }),
+    }),
+    global: Flags.boolean({
+      description: bilingual({
+        zh: '写全局 ~/.oh-my-knowledge/doctors，而非项目 .omk/doctors',
+        en: 'Write to global ~/.oh-my-knowledge/doctors instead of project .omk/doctors',
       }),
     }),
     dimensions: Flags.string({
@@ -275,7 +282,9 @@ export default class Doctor extends BaseCommand {
         renderDoctorReportText(report, lang);
       }
 
-      persistDoctorReport(report, flags['output-dir'] ? resolve(flags['output-dir']) : undefined);
+      persistDoctorReport(report, flags['output-dir']
+        ? resolve(flags['output-dir'])
+        : (flags.global ? globalDoctorsDir() : projectDoctorsDir()));
 
       if (flags.fix) {
         const existing = report;

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -5,11 +5,11 @@ import { BaseCommand } from '../oclif/base-command.js';
 import { tCli } from '../lib/i18n.js';
 
 // 预置 .omk/.gitignore:测量 bulk(项目本地、可重生)默认不入库;managed/ 治理档案 + 配置不在此列,默认 track。
-const INIT_OMK_GITIGNORE = `# omk 测量 bulk(项目本地、可重生)——不入库
-observe-health/
-doctors/
-observe-inbox/
-reports/
+const INIT_OMK_GITIGNORE = `# omk 测量 bulk(项目本地、可重生)——不入库;前导 / 锚定 .omk/ 顶层,不误伤嵌套同名目录。
+/observe-health/
+/doctors/
+/observe-inbox/
+/reports/
 `;
 
 const INIT_SAMPLES = `[

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -4,6 +4,14 @@ import { LANG_FLAG, bilingual, resolveLang } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { tCli } from '../lib/i18n.js';
 
+// 预置 .omk/.gitignore:测量 bulk(项目本地、可重生)默认不入库;managed/ 治理档案 + 配置不在此列,默认 track。
+const INIT_OMK_GITIGNORE = `# omk 测量 bulk(项目本地、可重生)——不入库
+observe-health/
+doctors/
+observe-inbox/
+reports/
+`;
+
 const INIT_SAMPLES = `[
   {
     "sample_id": "s001",
@@ -148,6 +156,9 @@ export default class Init extends BaseCommand {
       writeFileSync(join(targetDir, 'eval-samples.json'), INIT_SAMPLES);
       writeFileSync(join(targetDir, 'skills', 'code-review-v1', 'SKILL.md'), INIT_SKILL_V1);
       writeFileSync(join(targetDir, 'skills', 'code-review-v2', 'SKILL.md'), INIT_SKILL_V2);
+      // 像 dvc init 那样预置忽略规则,开发者不会误把测量 bulk 提交进库。
+      mkdirSync(join(targetDir, '.omk'), { recursive: true });
+      writeFileSync(join(targetDir, '.omk', '.gitignore'), INIT_OMK_GITIGNORE);
 
       console.log(tCli('cli.init.scaffolded', lang, { dir: targetDir }));
       console.log('');

--- a/src/cli/commands/observe/index.ts
+++ b/src/cli/commands/observe/index.ts
@@ -5,7 +5,7 @@ import { BaseCommand } from '../../oclif/base-command.js';
 import { CliExit } from '../../lib/cli-exit.js';
 import { tCli } from '../../lib/i18n.js';
 import { parseLastWindow } from '../../lib/shared.js';
-import { DEFAULT_OBSERVE_HEALTH_DIR } from '../../../eval-core/default-dirs.js';
+import { projectObserveHealthDir, globalObserveHealthDir } from '../../../eval-core/measurement-dirs.js';
 
 // `omk observe <sessions-dir>` 是默认命令 —— 分析 sessions 目录的 skill 调用健康度，产出 observe-health 报告(JSON)，
 // 由 Studio 健康报告页按需渲染。observe 这条线的另一条产物是观测收件箱(observe-inbox)，走子命令 ingest / inbox / show。
@@ -58,8 +58,14 @@ export default class Observe extends BaseCommand {
     }),
     'output-dir': Flags.string({
       description: bilingual({
-        zh: '健康报告输出目录，默认 ~/.oh-my-knowledge/observe-health',
-        en: 'Health report output dir, default ~/.oh-my-knowledge/observe-health',
+        zh: '健康报告输出目录，默认项目级 .omk/observe-health（--global 写全局）',
+        en: 'Health report output dir, default project-level .omk/observe-health (--global for global)',
+      }),
+    }),
+    global: Flags.boolean({
+      description: bilingual({
+        zh: '写全局 ~/.oh-my-knowledge/observe-health，而非项目 .omk/observe-health',
+        en: 'Write to global ~/.oh-my-knowledge/observe-health instead of project .omk/observe-health',
       }),
     }),
   };
@@ -104,7 +110,9 @@ export default class Observe extends BaseCommand {
       });
 
       // JSON 是主产物；HTML 由 report server 的健康报告详情页按需渲染。
-      const outDir = resolve(flags['output-dir'] || DEFAULT_OBSERVE_HEALTH_DIR);
+      const outDir = flags['output-dir']
+        ? resolve(flags['output-dir'])
+        : (flags.global ? globalObserveHealthDir() : projectObserveHealthDir());
       mkdirSync(outDir, { recursive: true });
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
       const jsonPath = join(outDir, `${timestamp}-observe-health.json`);

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -174,8 +174,8 @@ export default class Studio extends BaseCommand {
     }),
     global: Flags.boolean({
       description: bilingual({
-        zh: '只看全局目录（~/.oh-my-knowledge/*）而非项目优先',
-        en: 'View global dirs (~/.oh-my-knowledge/*) instead of project-first',
+        zh: '只看全局 observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响',
+        en: 'View global observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox',
       }),
     }),
     'no-open': Flags.boolean({

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -6,6 +6,10 @@ import { integerStringParser } from '../oclif/parsers.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
 import { DEFAULT_REPORTS_DIR } from '../lib/parse-run-config.js';
 import { resolveManagedDir, managedDir } from '../../managed/index.js';
+import {
+  resolveObserveHealthDir, projectObserveHealthDir, globalObserveHealthDir,
+  resolveDoctorsDir, projectDoctorsDir, globalDoctorsDir,
+} from '../../eval-core/measurement-dirs.js';
 import type { ReportServer } from '../lib/shared.js';
 import type { StudioArgs, StudioFlags } from '../lib/cmd-flags.js';
 
@@ -58,8 +62,14 @@ export async function runStudio(
     if (flags['analyses-dir']) {
       childArgs.push('--analyses-dir', flags['analyses-dir']);
     }
+    if (flags['doctors-dir']) {
+      childArgs.push('--doctors-dir', flags['doctors-dir']);
+    }
     if (flags['observations-dir']) {
       childArgs.push('--observations-dir', flags['observations-dir']);
+    }
+    if (flags.global) {
+      childArgs.push('--global');
     }
     if (flags['no-open']) {
       childArgs.push('--no-open');
@@ -80,7 +90,14 @@ export async function runStudio(
     port: Number(flags.port),
     ...(flags.host ? { host: flags.host } : {}),
     reportsDir: resolve(reportsDir),
-    ...(flags['analyses-dir'] ? { analysesDir: resolve(flags['analyses-dir']) } : {}),
+    // 测量产物(observe-health / doctors)默认按请求项目优先→全局兜底(同 managed);
+    // 显式 --analyses-dir/--doctors-dir 固定该目录;--global 钉全局目录。
+    analysesDir: flags['analyses-dir']
+      ? resolve(flags['analyses-dir'])
+      : (flags.global ? globalObserveHealthDir : (): string => resolveObserveHealthDir(projectObserveHealthDir())),
+    doctorsDir: flags['doctors-dir']
+      ? resolve(flags['doctors-dir'])
+      : (flags.global ? globalDoctorsDir : (): string => resolveDoctorsDir(projectDoctorsDir())),
     ...(flags['observations-dir'] ? { observationsDir: resolve(flags['observations-dir']) } : {}),
     // 传解析器而非解析结果:Studio 是长会话,受管根目录要按请求解析(项目首次 install 后从 global 切回
     // project),与 omk list 同口径;若在此处一次性解析、冻结进 server,长会话里会与 CLI 分叉。
@@ -139,14 +156,26 @@ export default class Studio extends BaseCommand {
     }),
     'analyses-dir': Flags.string({
       description: bilingual({
-        zh: '观测健康报告目录（可选，默认 ~/.oh-my-knowledge/observe-health）',
-        en: 'Observe-health reports dir (optional, default ~/.oh-my-knowledge/observe-health)',
+        zh: '观测健康报告目录（可选，默认项目级 .omk/observe-health，空则全局兜底）',
+        en: 'Observe-health reports dir (optional, default project .omk/observe-health, falls back to global)',
+      }),
+    }),
+    'doctors-dir': Flags.string({
+      description: bilingual({
+        zh: '体检报告目录（可选，默认项目级 .omk/doctors，空则全局兜底）',
+        en: 'Doctor reports dir (optional, default project .omk/doctors, falls back to global)',
       }),
     }),
     'observations-dir': Flags.string({
       description: bilingual({
         zh: '观测收件箱数据目录（可选，默认 .omk/observe-inbox）',
         en: 'Observe-inbox data dir (optional, default .omk/observe-inbox)',
+      }),
+    }),
+    global: Flags.boolean({
+      description: bilingual({
+        zh: '只看全局目录（~/.oh-my-knowledge/*）而非项目优先',
+        en: 'View global dirs (~/.oh-my-knowledge/*) instead of project-first',
       }),
     }),
     'no-open': Flags.boolean({

--- a/src/cli/lib/cmd-flags.ts
+++ b/src/cli/lib/cmd-flags.ts
@@ -271,7 +271,9 @@ export interface StudioFlags {
   host?: string;
   'reports-dir'?: string;
   'analyses-dir'?: string;
+  'doctors-dir'?: string;
   'observations-dir'?: string;
+  global?: boolean;
   'no-open': boolean;
   dev: boolean;
 }

--- a/src/cli/lib/i18n-dict/help.ts
+++ b/src/cli/lib/i18n-dict/help.ts
@@ -23,7 +23,8 @@ omk observe——分析真实 session trace，生成 skill 健康度报告
   --from <iso>                        窗口起点，优先级高于 --last
   --to <iso>                          窗口终点，优先级高于 --last
   --skills <n1,n2,...>                只分析指定 skill
-  --output-dir <path>                 输出目录（默认：~/.oh-my-knowledge/observe-health）
+  --output-dir <path>                 输出目录（默认：项目级 .omk/observe-health）
+  --global                            写全局 ~/.oh-my-knowledge/observe-health，而非项目 .omk/
 
 观测收件箱（observe inbox）是另一条线，见 omk observe inbox --help。
 `,
@@ -39,7 +40,8 @@ Options:
   --from <iso>                        Window start, overrides --last
   --to <iso>                          Window end, overrides --last
   --skills <n1,n2,...>                Only analyze selected skills
-  --output-dir <path>                 Output directory (default: ~/.oh-my-knowledge/observe-health)
+  --output-dir <path>                 Output directory (default: project-level .omk/observe-health)
+  --global                            Write to global ~/.oh-my-knowledge/observe-health instead of project .omk/
 
 The observe inbox is a separate line; see omk observe inbox --help.
 `,
@@ -231,8 +233,10 @@ omk studio——打开本地知识工作台
   --port <n>                          本地服务端口（默认：7799）
   --host <host>                       监听地址（默认：127.0.0.1；局域网访问可用 0.0.0.0）
   --reports-dir <path>                报告目录（默认：~/.oh-my-knowledge/reports）
-  --analyses-dir <path>               观测健康报告目录（默认：~/.oh-my-knowledge/observe-health）
+  --analyses-dir <path>               观测健康报告目录（默认：项目级 .omk/observe-health，空则全局兜底）
+  --doctors-dir <path>                体检报告目录（默认：项目级 .omk/doctors，空则全局兜底）
   --observations-dir <path>           observe inbox 数据目录（默认：.omk/observe-inbox）
+  --global                            只看全局目录（~/.oh-my-knowledge/*）而非项目优先
   --no-open                           只启动服务，不自动打开浏览器
   --dev                               开发模式：文件变化时自动重启
 
@@ -252,8 +256,10 @@ Options:
   --port <n>                          Local server port (default: 7799)
   --host <host>                       Listen address (default: 127.0.0.1; use 0.0.0.0 for LAN access)
   --reports-dir <path>                Reports directory (default: ~/.oh-my-knowledge/reports)
-  --analyses-dir <path>               Observe-health reports dir (default: ~/.oh-my-knowledge/observe-health)
+  --analyses-dir <path>               Observe-health reports dir (default: project .omk/observe-health, falls back to global)
+  --doctors-dir <path>                Doctor reports dir (default: project .omk/doctors, falls back to global)
   --observations-dir <path>           Observe inbox data directory (default: .omk/observe-inbox)
+  --global                            View global dirs (~/.oh-my-knowledge/*) instead of project-first
   --no-open                           Start the server without opening a browser
   --dev                               Dev mode: restart on file changes
 

--- a/src/cli/lib/i18n-dict/help.ts
+++ b/src/cli/lib/i18n-dict/help.ts
@@ -236,7 +236,7 @@ omk studio——打开本地知识工作台
   --analyses-dir <path>               观测健康报告目录（默认：项目级 .omk/observe-health，空则全局兜底）
   --doctors-dir <path>                体检报告目录（默认：项目级 .omk/doctors，空则全局兜底）
   --observations-dir <path>           observe inbox 数据目录（默认：.omk/observe-inbox）
-  --global                            只看全局目录（~/.oh-my-knowledge/*）而非项目优先
+  --global                            只看全局 observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
   --no-open                           只启动服务，不自动打开浏览器
   --dev                               开发模式：文件变化时自动重启
 
@@ -259,7 +259,7 @@ Options:
   --analyses-dir <path>               Observe-health reports dir (default: project .omk/observe-health, falls back to global)
   --doctors-dir <path>                Doctor reports dir (default: project .omk/doctors, falls back to global)
   --observations-dir <path>           Observe inbox data directory (default: .omk/observe-inbox)
-  --global                            View global dirs (~/.oh-my-knowledge/*) instead of project-first
+  --global                            View global observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox
   --no-open                           Start the server without opening a browser
   --dev                               Dev mode: restart on file changes
 

--- a/src/eval-core/measurement-dirs.ts
+++ b/src/eval-core/measurement-dirs.ts
@@ -1,0 +1,73 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { DEFAULT_OBSERVE_HEALTH_DIR, DEFAULT_DOCTORS_DIR } from './default-dirs.js';
+
+/**
+ * 测量产物的「项目优先 → 全局兜底」目录解析,镜像 managed 的 `resolveManagedDir`
+ * (src/managed/store.ts)。测量产物绑用例集上下文(construct validity,不可全局化),
+ * 默认落项目 `.omk/`,全局作显式 opt-in。
+ *
+ * 「记录优先」—— 目录里有匹配 `.json` 才算数(不是「目录存在」),与 managed 同口径,
+ * 避免空项目目录遮蔽全局数据。项目目录按**调用时** `cwd()` 求值(函数,不是 import 时
+ * 冻结的常量),studio 长会话 per-request 解析才正确。
+ */
+
+/** dir 里是否有至少一个满足 match 的文件(短路,不读文件内容)。 */
+function hasMatchingFile(dir: string, match: (name: string) => boolean): boolean {
+  if (!existsSync(dir)) return false;
+  try {
+    return readdirSync(dir).some(match);
+  } catch {
+    return false;
+  }
+}
+
+// —— observe-health(skill 健康度报告)——
+// 文件名 `{timestamp}-observe-health.json`,匹配后缀避免别的 .json 误翻转 resolver。
+
+/** 项目级 observe-health 目录(相对调用时 cwd)。 */
+export function projectObserveHealthDir(cwd: string = process.cwd()): string {
+  return join(cwd, '.omk', 'observe-health');
+}
+
+/** 全局 observe-health 目录。 */
+export function globalObserveHealthDir(): string {
+  return DEFAULT_OBSERVE_HEALTH_DIR;
+}
+
+/** 权威 observe-health 目录:项目有报告取项目,否则全局有取全局,都空回项目(同 resolveManagedDir)。
+ *  `global` 可注入(默认真实全局目录),仅供测试用受控 temp 目录复现 project↔global 兜底。 */
+export function resolveObserveHealthDir(
+  dir: string = projectObserveHealthDir(),
+  global: string = globalObserveHealthDir(),
+): string {
+  const has = (d: string): boolean => hasMatchingFile(d, (f) => f.endsWith('-observe-health.json'));
+  if (has(dir)) return dir;
+  if (dir !== global && has(global)) return global;
+  return dir;
+}
+
+// —— doctors(体检报告)——
+// 文件名 `{skill}-{id}.json`,谓词用「存在任意 .json」即可(真解析在下游 scanDoctorReports)。
+
+/** 项目级 doctors 目录(相对调用时 cwd)。 */
+export function projectDoctorsDir(cwd: string = process.cwd()): string {
+  return join(cwd, '.omk', 'doctors');
+}
+
+/** 全局 doctors 目录。 */
+export function globalDoctorsDir(): string {
+  return DEFAULT_DOCTORS_DIR;
+}
+
+/** 权威 doctors 目录:项目有报告取项目,否则全局有取全局,都空回项目(同 resolveManagedDir)。
+ *  `global` 可注入(默认真实全局目录),仅供测试用受控 temp 目录复现 project↔global 兜底。 */
+export function resolveDoctorsDir(
+  dir: string = projectDoctorsDir(),
+  global: string = globalDoctorsDir(),
+): string {
+  const has = (d: string): boolean => hasMatchingFile(d, (f) => f.endsWith('.json'));
+  if (has(dir)) return dir;
+  if (dir !== global && has(global)) return global;
+  return dir;
+}

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -13,7 +13,8 @@ import { renderObservationInboxPage } from '../renderer/observation-inbox-render
 import { DEFAULT_LANG, t, layout } from '../renderer/layout.js';
 import { loadAllManagedRecords, resolveManagedDir, managedDir as projectManagedDir, listManagedRows } from '../managed/index.js';
 import { renderManagedList, renderManagedHistory } from '../renderer/managed-history-renderer.js';
-import { DEFAULT_REPORTS_DIR, DEFAULT_OBSERVE_HEALTH_DIR, DEFAULT_DOCTORS_DIR, DEFAULT_JOBS_DIR } from '../eval-core/default-dirs.js';
+import { DEFAULT_REPORTS_DIR, DEFAULT_JOBS_DIR } from '../eval-core/default-dirs.js';
+import { resolveObserveHealthDir, projectObserveHealthDir, resolveDoctorsDir, projectDoctorsDir } from '../eval-core/measurement-dirs.js';
 import { buildSkillIndex } from './skill-index.js';
 import type { Lang } from '../types/index.js';
 import { createFileJobStore } from './job-store.js';
@@ -36,8 +37,12 @@ interface ReportServerOptions {
    *  暴露到容器外 / 局域网用 '0.0.0.0'。也可走 OMK_REPORT_HOST 环境变量。 */
   host?: string;
   reportsDir?: string;
-  analysesDir?: string;
-  doctorsDir?: string;
+  /** observe-health 报告目录(项目 .omk/observe-health 或全局),或一个按请求动态解析它的函数。
+   *  传函数 → 每次请求重解析(长会话里项目首次 omk observe 后从 global 实时切回 project);
+   *  传字符串 → 固定到该目录(测试 / 显式覆盖);默认动态解析 project→global 权威目录。 */
+  analysesDir?: string | (() => string);
+  /** 体检报告目录(项目 .omk/doctors 或全局),或一个按请求动态解析它的函数。三模式同 analysesDir。 */
+  doctorsDir?: string | (() => string);
   observationsDir?: string;
   jobsDir?: string;
   /** 受管目录(.omk/managed 或全局),或一个按请求动态解析它的函数。只读消费,供 /managed 决策史页。
@@ -604,7 +609,7 @@ export function formatListenError(p: number, err: unknown): Error | null {
   return null;
 }
 
-export function createReportServer({ port, host: hostOption, reportsDir = DEFAULT_REPORTS_DIR, analysesDir = DEFAULT_OBSERVE_HEALTH_DIR, doctorsDir = DEFAULT_DOCTORS_DIR, observationsDir = DEFAULT_OBSERVATIONS_DIR, jobsDir = DEFAULT_JOBS_DIR, managedDir, store, jobStore }: ReportServerOptions = {}): ReportServer {
+export function createReportServer({ port, host: hostOption, reportsDir = DEFAULT_REPORTS_DIR, analysesDir, doctorsDir, observationsDir = DEFAULT_OBSERVATIONS_DIR, jobsDir = DEFAULT_JOBS_DIR, managedDir, store, jobStore }: ReportServerOptions = {}): ReportServer {
   let server: Server | null = null;
   let serverUrl: string | null = null;
 
@@ -624,12 +629,34 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
         ? (): string => managedDir
         : (): string => resolveManagedDir(projectManagedDir());
 
+  // observe-health 目录同 managed 按**请求**解析(项目 .omk/observe-health 优先、空则全局兜底) ——
+  // 长会话里项目首次 omk observe 后,studio 下次请求即从 global 切回 project,不在启动时冻结。
+  // 三模式同 managedDir:函数透传 / 字符串固定 / 缺省动态解析。
+  const resolveAnalysesDir: () => string =
+    typeof analysesDir === 'function'
+      ? analysesDir
+      : analysesDir !== undefined
+        ? (): string => analysesDir
+        : (): string => resolveObserveHealthDir(projectObserveHealthDir());
+
+  // doctors 目录同 analyses 按请求解析(项目优先→全局兜底),三模式同 managedDir / analysesDir。
+  const resolveDoctorsRoot: () => string =
+    typeof doctorsDir === 'function'
+      ? doctorsDir
+      : doctorsDir !== undefined
+        ? (): string => doctorsDir
+        : (): string => resolveDoctorsDir(projectDoctorsDir());
+
   async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
     try {
       const parsed = new URL(req.url || '/', 'http://127.0.0.1');
       const path = parsed.pathname;
       const langParam = parsed.searchParams.get('lang');
       const lang: Lang = langParam === 'en' ? 'en' : langParam === 'zh' ? 'zh' : DEFAULT_LANG;
+
+      // observe-health / doctors 目录每请求解析一次(项目优先→全局兜底),下面各 handler 用这两个 local 字符串。
+      const analysesDir = resolveAnalysesDir();
+      const doctorsDir = resolveDoctorsRoot();
 
       if (path === '/health') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -1107,7 +1134,9 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
   async function start(): Promise<string> {
     if (server) return serverUrl!;
     if (!existsSync(reportsDir)) mkdirSync(reportsDir, { recursive: true });
-    if (!existsSync(analysesDir)) mkdirSync(analysesDir, { recursive: true });
+    // analysesDir 现在是 per-request resolver(项目优先→全局兜底),不在启动时 mkdir ——
+    // studio 是只读消费,readers 都 existsSync 守卫、writer(omk observe)自建目录,
+    // 启动时往随机 cwd 建空 .omk/observe-health 反而是噪声。
     if (!existsSync(observationsDir)) mkdirSync(observationsDir, { recursive: true });
     if (!existsSync(jobsDir)) mkdirSync(jobsDir, { recursive: true });
 

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -5,7 +5,7 @@ import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { promisify } from 'node:util';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -53,6 +53,14 @@ describe('oclif init', () => {
       assert.ok(stdout.includes('已初始化 omk 项目'), `stdout missing scaffolded msg:\n${stdout}`);
       assert.ok(existsSync(join(target, 'skills', 'code-review-v1', 'SKILL.md')), 'skills/code-review-v1/SKILL.md not created');
       assert.ok(existsSync(join(target, 'eval-samples.json')), 'eval-samples.json not created');
+      // 预置 .omk/.gitignore:测量 bulk 不入库,managed/ 不被忽略(默认 track)。
+      const gitignorePath = join(target, '.omk', '.gitignore');
+      assert.ok(existsSync(gitignorePath), '.omk/.gitignore not created');
+      const gi = readFileSync(gitignorePath, 'utf8');
+      for (const d of ['observe-health/', 'doctors/', 'observe-inbox/', 'reports/']) {
+        assert.ok(gi.includes(d), `.omk/.gitignore should ignore ${d}`);
+      }
+      assert.ok(!/^managed\/?$/m.test(gi), '.omk/.gitignore must not ignore managed/');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/eval-core/measurement-dirs.test.ts
+++ b/test/eval-core/measurement-dirs.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  projectObserveHealthDir, globalObserveHealthDir, resolveObserveHealthDir,
+  projectDoctorsDir, globalDoctorsDir, resolveDoctorsDir,
+} from '../../src/eval-core/measurement-dirs.js';
+
+function mkTmp(tag: string): string {
+  const d = join(tmpdir(), `omk-mdir-${tag}-${Date.now()}-${Math.round(performance.now())}`);
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+describe('measurement-dirs 项目优先→全局兜底(记录优先)', () => {
+  it('project/global getter 路径', () => {
+    assert.equal(projectObserveHealthDir('/x'), join('/x', '.omk', 'observe-health'));
+    assert.equal(projectDoctorsDir('/x'), join('/x', '.omk', 'doctors'));
+    assert.ok(globalObserveHealthDir().endsWith(join('.oh-my-knowledge', 'observe-health')));
+    assert.ok(globalDoctorsDir().endsWith(join('.oh-my-knowledge', 'doctors')));
+  });
+
+  it('observe-health:项目有报告→项目;项目空+全局有→全局;都空→项目', () => {
+    const proj = mkTmp('h-proj');
+    const glob = mkTmp('h-glob');
+    try {
+      // 都空 → 回项目
+      assert.equal(resolveObserveHealthDir(proj, glob), proj, '都空回项目');
+      // 仅全局有 → 全局
+      writeFileSync(join(glob, '2026-01-01T00-00-00-observe-health.json'), '{}');
+      assert.equal(resolveObserveHealthDir(proj, glob), glob, '项目空+全局有→全局');
+      // 项目也有 → 项目优先
+      writeFileSync(join(proj, '2026-02-02T00-00-00-observe-health.json'), '{}');
+      assert.equal(resolveObserveHealthDir(proj, glob), proj, '项目有→项目优先');
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+      rmSync(glob, { recursive: true, force: true });
+    }
+  });
+
+  it('observe-health 记录优先按后缀:无关 .json 不算报告', () => {
+    const proj = mkTmp('h-suffix');
+    const glob = mkTmp('h-suffix-g');
+    try {
+      writeFileSync(join(proj, 'random.json'), '{}'); // 非 -observe-health.json
+      writeFileSync(join(glob, '2026-01-01T00-00-00-observe-health.json'), '{}');
+      // 项目只有无关 .json → 不算有报告 → 回退全局
+      assert.equal(resolveObserveHealthDir(proj, glob), glob, '后缀不匹配不算报告');
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+      rmSync(glob, { recursive: true, force: true });
+    }
+  });
+
+  it('doctors:项目有任意 .json→项目;项目空+全局有→全局;都空→项目', () => {
+    const proj = mkTmp('d-proj');
+    const glob = mkTmp('d-glob');
+    try {
+      assert.equal(resolveDoctorsDir(proj, glob), proj, '都空回项目');
+      writeFileSync(join(glob, 'some-skill-id.json'), '{}');
+      assert.equal(resolveDoctorsDir(proj, glob), glob, '项目空+全局有→全局');
+      writeFileSync(join(proj, 'another-skill-id.json'), '{}');
+      assert.equal(resolveDoctorsDir(proj, glob), proj, '项目有→项目优先');
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+      rmSync(glob, { recursive: true, force: true });
+    }
+  });
+
+  it('目录不存在不抛,返回非空字符串', () => {
+    const proj = join(tmpdir(), `omk-mdir-nonexist-${Date.now()}`);
+    const out = resolveObserveHealthDir(proj, join(tmpdir(), 'also-nonexist'));
+    assert.equal(out, proj, '都不存在 → 回项目');
+  });
+});

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -381,6 +381,35 @@ describe('report-server', () => {
     }
   });
 
+  it('analyses 目录按请求解析 —— 项目获报告后同会话切回 project,不冻结(P1)', async () => {
+    // 同 managed:注入受控 resolver(项目空→global),验 server 持有「如何解析」而非启动时冻结 root。
+    // doctorsDir 也传函数,顺带验三模式接受函数不报错。
+    const projA = join(tmpdir(), `omk-test-an-proj-${Date.now()}`);
+    const globA = join(tmpdir(), `omk-test-an-glob-${Date.now()}`);
+    mkdirSync(projA, { recursive: true });
+    mkdirSync(globA, { recursive: true });
+    const healthReport = (gen: string): string => JSON.stringify({
+      meta: { generatedAt: gen, sessionCount: 1, segmentCount: 40, toolCallCount: 1, toolFailureRate: 0, messageCount: 0, tracePath: '/t', kbPath: null, timeRange: { from: gen, to: gen } },
+      overall: { gapRate: 0.1, weightedGapRate: 0.1, healthBand: 'green', confidence: 'high' },
+      bySkill: {},
+    });
+    writeFileSync(join(globA, 'global-h-observe-health.json'), healthReport('2026-01-01T00:00:00Z'));
+    const analysesResolver = (): string => (readdirSync(projA).length > 0 ? projA : globA);
+    const s = createReportServer({ port: 0, reportsDir: TEST_DIR, jobsDir: JOBS_DIR, observationsDir: OBSERVATIONS_DIR, analysesDir: analysesResolver, doctorsDir: (): string => DOCTORS_DIR, managedDir: MANAGED_DIR });
+    const u = await s.start();
+    try {
+      const before = JSON.parse((await fetch(`${u}/api/observe-health`)).body) as Array<{ id: string }>;
+      assert.deepEqual(before.map((x) => x.id), ['global-h-observe-health'], '启动时项目空 → 解析到 global');
+      writeFileSync(join(projA, 'proj-h-observe-health.json'), healthReport('2026-02-02T00:00:00Z'));
+      const after = JSON.parse((await fetch(`${u}/api/observe-health`)).body) as Array<{ id: string }>;
+      assert.deepEqual(after.map((x) => x.id), ['proj-h-observe-health'], '中途项目获报告 → 同会话实时切回 project');
+    } finally {
+      await s.stop();
+      rmSync(projA, { recursive: true, force: true });
+      rmSync(globA, { recursive: true, force: true });
+    }
+  });
+
   it('GET /health returns ok', async () => {
     const res = await fetch(`${baseUrl}/health`);
     assert.equal(res.status, 200);


### PR DESCRIPTION
## 这是什么

#243 问题一 phase-1：把测量产物从「全局共享桶」改成「项目优先 `.omk/` → 全局兜底」。测量产物绑用例集上下文（construct validity，不可全局化，#239），堆进全局桶会让 `omk studio` 从任意 cwd 打开看到跨项目混合、无归属 —— 等于把不可比性焊进存储布局。方案 A 让正确归属成为默认，对齐行业主流（MLflow `./mlruns`、Inspect `./logs`、HELM `benchmark_output` 都是项目本地默认 + 全局显式）。

本次只做 **observe-health + doctors**。**reports 不动** —— 它被 `ManagedEvidenceRef.reportId` / `EvaluationJob.resultReportId` 引用，迁移有断链风险，留 phase-2 单独议。

## 用户影响

- `omk observe <sessions>` / `omk doctor <skills>` 默认写**项目** `.omk/observe-health` / `.omk/doctors`（原全局）。加 `--global` 写全局（给「全局/canonical 评测」用）；`--output-dir` 显式仍最高优先。
- `omk studio` 默认看**当前项目**（项目空则自动回退全局，不空窗）；`--global` 看全局聚合；新增 `--doctors-dir` 补齐与 `--analyses-dir` 的对称。
- `omk init` 预置 `.omk/.gitignore`：忽略 `observe-health/ doctors/ observe-inbox/ reports/` 测量 bulk，`managed/` 治理档案默认 track（像 `dvc init`）。
- **additive、可回退**：保留全局兜底（记录优先：项目有报告用项目，否则用全局），旧全局数据照常可见；`--global` 是写 / 读逃生口。

## 实现

- 新增 `eval-core/measurement-dirs.ts`：project/global getter + `resolveObserveHealthDir` / `resolveDoctorsDir`（**记录优先**，镜像 `resolveManagedDir`；`global` 参数可注入仅供测试用受控 temp 目录复现兜底）。
- `report-server` 的 `analysesDir` / `doctorsDir` 扩成 `string | (() => string)` 三模式（同 `managedDir`），`handleRequest` 顶部每请求解析一次成 local，16 个 handler 站点零逐处改动。删掉 `start()` 对 `analysesDir` 的启动 mkdir（改 resolver 后是函数；readers 都 `existsSync` 守卫，studio 只读不该往随机 cwd 建空目录）。
- studio 默认传项目优先 resolver、`--global` 钉全局 getter；dev 子进程 passthrough 守卫新 flag。

## 语义自洽

`omk observe --global` 写全局、项目空 → `omk studio`（默认）记录优先返回全局 → 看得到。项目和全局都有数据时记录优先返回项目（`--global` 是逃生口）—— 跟现有 managed 同口径。

## 测量学

纯归属 / 默认值改动，**不动任何算出来的数字**。**非** BREAKING-COMPARABILITY。

## 验证

`yarn lint && build && test` 全绿（167 文件 / 2129 用例），`build:docs:check` 同步。新测试：measurement-dirs resolver 全矩阵（项目有→项目 / 项目空+全局有→全局 / 都空→项目，含后缀匹配）、report-server 注入翻转 resolver 验 per-request、init 写 `.omk/.gitignore`。现有测试 0 处强制改挂（都传显式字符串目录，三模式保留字符串模式）。

关联 #243（问题一 phase-1）。doctors 已随本 PR 一并做（`--global` 天然跨两者）；reports 归属 = phase-2。