### PR TITLE
feat(eval-core): reports 默认落项目 .omk/reports，studio 读走 overlay 项目盖全局（方案 A phase-2a）

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -80,6 +80,7 @@ omk eval [flags]
 - `--dry-run` `boolean`:只 plan 不实跑
 - `--effort` `option`:被测 LLM 扩展思考预算 low/medium/high/xhigh/max（默认 low；跨 effort 报告不严格可比）。
 - `--executor` `option`:执行器:claude / claude-sdk / codex / codex-sdk / openai-api / gemini / 自定义命令（默认 claude）。
+- `--global` `boolean`:报告写全局 ~/.oh-my-knowledge/reports，而非项目 .omk/
 - `--gold-dir` `option`:gold dataset 目录
 - `--judge-models` `option`:评委配置，格式 executor:model[,...]，例 claude:haiku 或 claude:opus,openai:gpt-4o(≥ 2 个 = ensemble）。默认 <executor>:haiku。
 - `--judge-repeat` `option`:每个 dim 评 N 次
@@ -95,7 +96,7 @@ omk eval [flags]
 - `--no-judge` `boolean`:跳过 LLM judge
 - `--no-serve` `boolean`:不启 report server
 - `--no-strict-baseline` `boolean`:关闭 baseline 隔离
-- `--output-dir` `option`:报告输出目录
+- `--output-dir` `option`:报告输出目录（默认项目级 .omk/reports）
 - `--repeat` `option`:每个 sample 重复跑 N 次
 - `--report-only` `boolean`:生成报告并打印 verdict，但始终 exit 0(不参与 CI gate）。
 - `--resume` `option`:从某次失败 run 续跑
@@ -635,13 +636,13 @@ omk studio [flags]
 - `--analyses-dir` `option`:观测健康报告目录（可选，默认项目级 .omk/observe-health，空则全局兜底）
 - `--dev` `boolean`:dev 模式：子进程启动 + 热更新
 - `--doctors-dir` `option`:体检报告目录（可选，默认项目级 .omk/doctors，空则全局兜底）
-- `--global` `boolean`:只看全局 observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
+- `--global` `boolean`:只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
 - `--host` `option`:监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--no-open` `boolean`:不自动打开浏览器
 - `--observations-dir` `option`:观测收件箱数据目录（可选，默认 .omk/observe-inbox）
 - `--port` `option` (默认 `7799`):监听端口，默认 7799。传 0 让 OS 分配
-- `--reports-dir` `option`:报告目录，默认 ~/.oh-my-knowledge/reports
+- `--reports-dir` `option`:报告目录（可选，默认项目级 .omk/reports 盖全局兜底）
 
 **示例:**
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -235,6 +235,7 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
   --dry-run                       Plan only, no real exec
   --effort <value>                Executor LLM reasoning effort low/medium/high/xhigh/max (default low; reports across efforts not strictly comparable).
   --executor <value>              Executor: claude / claude-sdk / codex / codex-sdk / openai-api / gemini / custom (default claude).
+  --global                        Write report to global ~/.oh-my-knowledge/reports instead of project .omk/
   --gold-dir <value>              Gold dataset dir
   --judge-models <value>          Judge config: executor:model[,...]. e.g. claude:haiku or claude:opus,openai:gpt-4o (≥ 2 = ensemble). Default <executor>:haiku.
   --judge-repeat <value>          Judge each dim N times
@@ -250,7 +251,7 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
   --no-judge                      Skip LLM judge
   --no-serve                      Do not start report server
   --no-strict-baseline            Disable baseline isolation
-  --output-dir <value>            Report output dir
+  --output-dir <value>            Report output dir (default project .omk/reports)
   --repeat <value>                Repeat each sample N times
   --report-only                   Produce the report and print verdict, but always exit 0 (no CI gate).
   --resume <value>                Resume a previous failed run
@@ -446,13 +447,13 @@ omk studio --no-open
   --analyses-dir <value>      Observe-health reports dir (optional, default project .omk/observe-health, falls back to global)
   --dev                       Dev mode: child process with hot reload
   --doctors-dir <value>       Doctor reports dir (optional, default project .omk/doctors, falls back to global)
-  --global                    View global observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox
+  --global                    View global reports / observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox
   --host <value>              Listen host, default localhost. Use 0.0.0.0 to expose to LAN
   --lang <value>              Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --no-open                   Do not auto-open browser
   --observations-dir <value>  Observe-inbox data dir (optional, default .omk/observe-inbox)
   --port <value>              Listen port, default 7799. Pass 0 for OS-assigned
-  --reports-dir <value>       Reports dir, default ~/.oh-my-knowledge/reports
+  --reports-dir <value>       Reports dir (optional, default project .omk/reports overlaid on global)
 ```
 
 For full descriptions: `omk studio --help`.

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -235,6 +235,7 @@ omk eval gold compare <report-id> --gold-dir gold-dataset
   --dry-run                       只 plan 不实跑
   --effort <value>                被测 LLM 扩展思考预算 low/medium/high/xhigh/max（默认 low；跨 effort 报告不严格可比）。
   --executor <value>              执行器:claude / claude-sdk / codex / codex-sdk / openai-api / gemini / 自定义命令（默认 claude）。
+  --global                        报告写全局 ~/.oh-my-knowledge/reports，而非项目 .omk/
   --gold-dir <value>              gold dataset 目录
   --judge-models <value>          评委配置，格式 executor:model[,...]，例 claude:haiku 或 claude:opus,openai:gpt-4o(≥ 2 个 = ensemble）。默认 <executor>:haiku。
   --judge-repeat <value>          每个 dim 评 N 次
@@ -250,7 +251,7 @@ omk eval gold compare <report-id> --gold-dir gold-dataset
   --no-judge                      跳过 LLM judge
   --no-serve                      不启 report server
   --no-strict-baseline            关闭 baseline 隔离
-  --output-dir <value>            报告输出目录
+  --output-dir <value>            报告输出目录（默认项目级 .omk/reports）
   --repeat <value>                每个 sample 重复跑 N 次
   --report-only                   生成报告并打印 verdict，但始终 exit 0(不参与 CI gate）。
   --resume <value>                从某次失败 run 续跑
@@ -446,13 +447,13 @@ omk studio --no-open
   --analyses-dir <value>      观测健康报告目录（可选，默认项目级 .omk/observe-health，空则全局兜底）
   --dev                       dev 模式：子进程启动 + 热更新
   --doctors-dir <value>       体检报告目录（可选，默认项目级 .omk/doctors，空则全局兜底）
-  --global                    只看全局 observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
+  --global                    只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
   --host <value>              监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
   --lang <value>              输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --no-open                   不自动打开浏览器
   --observations-dir <value>  观测收件箱数据目录（可选，默认 .omk/observe-inbox）
   --port <value>              监听端口，默认 7799。传 0 让 OS 分配
-  --reports-dir <value>       报告目录，默认 ~/.oh-my-knowledge/reports
+  --reports-dir <value>       报告目录（可选，默认项目级 .omk/reports 盖全局兜底）
 ```
 
 完整描述见 `omk studio --help`。

--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -3,7 +3,8 @@ import { resolve, join, dirname, basename } from 'node:path';
 import { runEvaluation } from '../eval-workflows/run-evaluation.js';
 import { createExecutor, DEFAULT_MODEL, JUDGE_MODEL } from '../executors/index.js';
 import { persistReport, DEFAULT_OUTPUT_DIR, generateRunId, hashString } from '../eval-core/evaluation-reporting.js';
-import { createFileStore } from '../server/report-store.js';
+import { createOverlayReportStore } from '../server/report-store.js';
+import { projectReportsDir, globalReportsDir } from '../eval-core/measurement-dirs.js';
 import { analyzeResults } from '../analysis/report-diagnostics.js';
 import { loadSamples } from '../inputs/load-samples.js';
 import { hashArtifactSource } from '../inputs/content-hash.js';
@@ -117,7 +118,9 @@ async function findReusableBaselineReport(opts: {
   effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   noDiagnostic?: boolean;
 }): Promise<Report | null> {
-  const store = createFileStore(DEFAULT_OUTPUT_DIR);
+  // baseline 复用读 overlay(项目 .omk/reports ∪ 全局):eval 写默认翻项目后,复用既能命中 eval 新写的项目
+  // baseline,又继续覆盖全局(含 evolve 自身写到全局的合并报告),复用命中率与报告数字不降。
+  const store = createOverlayReportStore(projectReportsDir(), globalReportsDir());
   const { samples } = loadSamples(opts.samplesPath);
   const artifactHash = opts.artifactHash;
   const reports = await store.findByArtifactHash(artifactHash);

--- a/src/cli/commands/eval/gold/compare.ts
+++ b/src/cli/commands/eval/gold/compare.ts
@@ -4,7 +4,7 @@ import { BaseCommand } from '../../../oclif/base-command.js';
 import { LANG_FLAG, bilingual } from '../../../oclif/i18n.js';
 import { integerStringParser } from '../../../oclif/parsers.js';
 import { CliExit } from '../../../lib/cli-exit.js';
-import { DEFAULT_REPORTS_DIR } from '../../../lib/parse-run-config.js';
+import { projectReportsDir, globalReportsDir } from '../../../../eval-core/measurement-dirs.js';
 import { requireEvaluationReport } from '../../../lib/shared.js';
 import type { ReportStore } from '../../../../types/index.js';
 
@@ -67,7 +67,7 @@ export default class EvalGoldCompare extends BaseCommand {
       }
       const { loadGoldDataset } = await import('../../../../grading/gold-dataset.js');
       const { compareGoldToReport, formatGoldCompare } = await import('../../../../grading/gold-cli.js');
-      const { createFileStore } = await import('../../../../server/report-store.js');
+      const { createFileStore, createOverlayReportStore } = await import('../../../../server/report-store.js');
 
       const { dataset, issues } = loadGoldDataset(goldDir);
       if (!dataset) {
@@ -77,8 +77,11 @@ export default class EvalGoldCompare extends BaseCommand {
       }
       for (const i of issues) console.error(`warn: ${i.message}`);
 
-      const reportsDir = flags['reports-dir'] ?? DEFAULT_REPORTS_DIR;
-      const store: ReportStore = createFileStore(resolve(reportsDir));
+      // 显式 --reports-dir 固定该目录;默认 overlay(项目 .omk/reports 盖全局),get(reportId) 项目→全局兜底,
+      // 不因 eval 写默认翻项目而对比落空。
+      const store: ReportStore = flags['reports-dir']
+        ? createFileStore(resolve(flags['reports-dir']))
+        : createOverlayReportStore(projectReportsDir(), globalReportsDir());
       const report = requireEvaluationReport(await store.get(reportId), reportId, lang);
       const samples = Math.max(100, Number(flags['bootstrap-samples'] ?? 1000) || 1000);
       const seedVal = flags.seed != null ? Number(flags.seed) : undefined;

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -129,8 +129,11 @@ async function loadBatchChildReports(
   reportsDir: string,
   lang: CliLang,
 ): Promise<EvaluationReport[]> {
-  const { createFileStore } = await import('../../../server/report-store.js');
-  const store = createFileStore(reportsDir);
+  // 读侧走 overlay(本次 reportsDir 优先 → 全局兜底):写默认翻项目后,batch.json 引用的存量 / 全局子报告
+  // 仍能 get 命中,不致降级到 batchItemFallbackReport(来自 batch metadata 的过时数据)。
+  const { createOverlayReportStore } = await import('../../../server/report-store.js');
+  const { globalReportsDir } = await import('../../../eval-core/measurement-dirs.js');
+  const store = createOverlayReportStore(reportsDir, globalReportsDir());
   const reports: EvaluationReport[] = [];
   for (const item of batch.items) {
     const loaded = await store.get(item.reportId);
@@ -199,6 +202,8 @@ async function announceSavedReport({
 
   if (!values['no-serve'] && process.stdout.isTTY) {
     const { createReportServer } = await import('../../../server/report-server.js');
+    // eval 结束的即时 serve 刻意钉本次 outputDir(--global 时即全局),不走 overlay:它的语义是「看我刚跑的这份」,
+    // 单目录保证刚写的报告(含 --global 写到全局的)一定可见;浏览全机器历史是 omk studio 的事(默认 overlay 项目优先)。
     const server: ReportServer = createReportServer({ reportsDir });
     const serverUrl: string = await server.start();
     const reportUrl: string = `${serverUrl}/reports/${report.id}`;

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -449,7 +449,13 @@ export default class Eval extends BaseCommand {
       }),
     }),
     'output-dir': Flags.string({
-      description: bilingual({ zh: '报告输出目录', en: 'Report output dir' }),
+      description: bilingual({ zh: '报告输出目录（默认项目级 .omk/reports）', en: 'Report output dir (default project .omk/reports)' }),
+    }),
+    global: Flags.boolean({
+      description: bilingual({
+        zh: '报告写全局 ~/.oh-my-knowledge/reports，而非项目 .omk/',
+        en: 'Write report to global ~/.oh-my-knowledge/reports instead of project .omk/',
+      }),
     }),
     // ── 评测 toggle ──
     'no-judge': Flags.boolean({

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -7,7 +7,7 @@ import { BaseCommand } from '../oclif/base-command.js';
 import { integerStringParser } from '../oclif/parsers.js';
 import { CliExit } from '../lib/cli-exit.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
-import { DEFAULT_REPORTS_DIR } from '../lib/parse-run-config.js';
+import { projectReportsDir, globalReportsDir } from '../../eval-core/measurement-dirs.js';
 import { loadSamples, parseYaml, type LoadSamplesResult } from '../../inputs/load-samples.js';
 import { hashSample } from '../../eval-core/evaluation-reporting.js';
 import { hashArtifactSource } from '../../inputs/content-hash.js';
@@ -185,10 +185,9 @@ async function runSampleFix(
   lang: CliLang,
 ): Promise<void> {
   const { fixSamples } = await import('../../authoring/sample-fixer.js');
-  const { createFileStore } = await import('../../server/report-store.js');
+  const { createFileStore, createOverlayReportStore } = await import('../../server/report-store.js');
 
   const model = flags.model;
-  const reportsDir = resolve(flags['reports-dir'] ?? DEFAULT_REPORTS_DIR);
 
   const skillPath = args.skillPath;
   if (!skillPath) {
@@ -218,11 +217,18 @@ async function runSampleFix(
   const treatmentName = flags.treatment ?? defaultTreatmentName;
 
   process.stderr.write(lang === 'zh' ? `🔍 正在查找 ${treatmentName} 的最新评测报告...\n` : `🔍 Scanning latest report for ${treatmentName}...\n`);
-  const store = createFileStore(reportsDir);
+  // 显式 --reports-dir 固定该目录;默认 overlay(项目 .omk/reports 盖全局),findByVariant 记录优先看项目、
+  // 空则全局兜底,不因 eval 写默认翻项目而查不到报告。
+  const store = flags['reports-dir']
+    ? createFileStore(resolve(flags['reports-dir']))
+    : createOverlayReportStore(projectReportsDir(), globalReportsDir());
   const reports = await store.findByVariant(treatmentName);
 
   if (reports.length === 0) {
-    console.error(lang === 'zh' ? `未找到 ${treatmentName} 的评测报告（报告目录: ${reportsDir}）` : `No eval report found for ${treatmentName} in ${reportsDir}`);
+    const where = flags['reports-dir']
+      ? resolve(flags['reports-dir'])
+      : (lang === 'zh' ? '项目 .omk/reports 或全局 ~/.oh-my-knowledge/reports' : 'project .omk/reports or global ~/.oh-my-knowledge/reports');
+    console.error(lang === 'zh' ? `未找到 ${treatmentName} 的评测报告（报告目录: ${where}）` : `No eval report found for ${treatmentName} in ${where}`);
     throw new CliExit(1);
   }
 

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -4,11 +4,11 @@ import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { integerStringParser } from '../oclif/parsers.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
-import { DEFAULT_REPORTS_DIR } from '../lib/parse-run-config.js';
 import { resolveManagedDir, managedDir } from '../../managed/index.js';
 import {
   resolveObserveHealthDir, projectObserveHealthDir, globalObserveHealthDir,
   resolveDoctorsDir, projectDoctorsDir, globalDoctorsDir,
+  globalReportsDir,
 } from '../../eval-core/measurement-dirs.js';
 import type { ReportServer } from '../lib/shared.js';
 import type { StudioArgs, StudioFlags } from '../lib/cmd-flags.js';
@@ -41,7 +41,13 @@ export async function runStudio(
   flags: StudioFlags,
   lang: CliLang,
 ): Promise<void> {
-  const reportsDir = flags['reports-dir'] ?? DEFAULT_REPORTS_DIR;
+  // reports 读取目录:显式 --reports-dir 固定该目录;--global 钉全局;默认走 overlay(项目盖全局,
+  // 由 server 在 store 层做记录优先 + 按 id 兜底)。默认 = undefined,交给 createReportServer 建 overlay。
+  const reportsDirOpt = flags['reports-dir']
+    ? resolve(flags['reports-dir'])
+    : flags.global
+      ? globalReportsDir()
+      : undefined;
 
   if (flags.dev && !process.env.__OMK_DEV_CHILD) {
     const { spawn } = await import('node:child_process');
@@ -57,8 +63,10 @@ export async function runStudio(
       'studio',
       '--port', flags.port,
       ...(flags.host ? ['--host', flags.host] : []),
-      '--reports-dir', reportsDir,
     ];
+    if (flags['reports-dir']) {
+      childArgs.push('--reports-dir', flags['reports-dir']);
+    }
     if (flags['analyses-dir']) {
       childArgs.push('--analyses-dir', flags['analyses-dir']);
     }
@@ -89,7 +97,8 @@ export async function runStudio(
   const server: ReportServer = createReportServer({
     port: Number(flags.port),
     ...(flags.host ? { host: flags.host } : {}),
-    reportsDir: resolve(reportsDir),
+    // reportsDir 缺省 undefined → server 建 overlay(项目盖全局);显式 --reports-dir / --global 固定单目录。
+    ...(reportsDirOpt !== undefined ? { reportsDir: reportsDirOpt } : {}),
     // 测量产物(observe-health / doctors)默认按请求项目优先→全局兜底(同 managed);
     // 显式 --analyses-dir/--doctors-dir 固定该目录;--global 钉全局目录。
     analysesDir: flags['analyses-dir']
@@ -150,8 +159,8 @@ export default class Studio extends BaseCommand {
     }),
     'reports-dir': Flags.string({
       description: bilingual({
-        zh: '报告目录，默认 ~/.oh-my-knowledge/reports',
-        en: 'Reports dir, default ~/.oh-my-knowledge/reports',
+        zh: '报告目录（可选，默认项目级 .omk/reports 盖全局兜底）',
+        en: 'Reports dir (optional, default project .omk/reports overlaid on global)',
       }),
     }),
     'analyses-dir': Flags.string({
@@ -174,8 +183,8 @@ export default class Studio extends BaseCommand {
     }),
     global: Flags.boolean({
       description: bilingual({
-        zh: '只看全局 observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响',
-        en: 'View global observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox',
+        zh: '只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响',
+        en: 'View global reports / observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox',
       }),
     }),
     'no-open': Flags.boolean({

--- a/src/cli/lib/cmd-flags.ts
+++ b/src/cli/lib/cmd-flags.ts
@@ -86,6 +86,8 @@ export interface EvalFlags {
   executor?: string;
   'judge-models'?: string;
   'output-dir'?: string;
+  /** 报告写全局而非项目 .omk/reports(写入侧 escape;读取侧 studio / 复用走 overlay 兜底)。 */
+  global?: boolean;
   // 下面 17 个 boolean 都没在 Eval Command 上设 `default: false`,oclif 运行时
   // absent → undefined,业务在 parseRunConfig() / runEval() 里靠 undefined vs
   // boolean 的三态区分 CLI 没传 vs 显式开关 vs 走 eval.yaml fallback;不能简化

--- a/src/cli/lib/i18n-dict/help.ts
+++ b/src/cli/lib/i18n-dict/help.ts
@@ -232,11 +232,11 @@ omk studio——打开本地知识工作台
 选项：
   --port <n>                          本地服务端口（默认：7799）
   --host <host>                       监听地址（默认：127.0.0.1；局域网访问可用 0.0.0.0）
-  --reports-dir <path>                报告目录（默认：~/.oh-my-knowledge/reports）
+  --reports-dir <path>                报告目录（默认：项目级 .omk/reports 盖全局兜底）
   --analyses-dir <path>               观测健康报告目录（默认：项目级 .omk/observe-health，空则全局兜底）
   --doctors-dir <path>                体检报告目录（默认：项目级 .omk/doctors，空则全局兜底）
   --observations-dir <path>           observe inbox 数据目录（默认：.omk/observe-inbox）
-  --global                            只看全局 observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
+  --global                            只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
   --no-open                           只启动服务，不自动打开浏览器
   --dev                               开发模式：文件变化时自动重启
 
@@ -255,11 +255,11 @@ Usage:
 Options:
   --port <n>                          Local server port (default: 7799)
   --host <host>                       Listen address (default: 127.0.0.1; use 0.0.0.0 for LAN access)
-  --reports-dir <path>                Reports directory (default: ~/.oh-my-knowledge/reports)
+  --reports-dir <path>                Reports directory (default: project .omk/reports overlaid on global)
   --analyses-dir <path>               Observe-health reports dir (default: project .omk/observe-health, falls back to global)
   --doctors-dir <path>                Doctor reports dir (default: project .omk/doctors, falls back to global)
   --observations-dir <path>           Observe inbox data directory (default: .omk/observe-inbox)
-  --global                            View global observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox
+  --global                            View global reports / observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox
   --no-open                           Start the server without opening a browser
   --dev                               Dev mode: restart on file changes
 

--- a/src/cli/lib/parse-run-config.ts
+++ b/src/cli/lib/parse-run-config.ts
@@ -19,7 +19,6 @@
  */
 
 import { resolve } from 'node:path';
-import { DEFAULT_REPORTS_DIR } from '../../eval-core/default-dirs.js';
 import { projectReportsDir, globalReportsDir } from '../../eval-core/measurement-dirs.js';
 import { loadEvalConfig } from '../../inputs/eval-config.js';
 import { DEFAULT_MODEL } from '../../executors/shared.js';
@@ -101,9 +100,6 @@ export interface ParseRunConfigResult {
    *  (e.g. repeat / judgeRepeat / bootstrap — handled in `commands/eval-runner.ts` for input validation). */
   evalConfig: EvalConfig | null;
 }
-
-// 单一来源在 eval-core/default-dirs；此处 re-export 保持既有 import 入口不破(studio / sample / eval gold compare 仍从本文件取)。
-export { DEFAULT_REPORTS_DIR };
 
 /**
  * 接 typed flags(来自 oclif Command.parse() 输出)。oclif strict 模式已经在

--- a/src/cli/lib/parse-run-config.ts
+++ b/src/cli/lib/parse-run-config.ts
@@ -20,6 +20,7 @@
 
 import { resolve } from 'node:path';
 import { DEFAULT_REPORTS_DIR } from '../../eval-core/default-dirs.js';
+import { projectReportsDir, globalReportsDir } from '../../eval-core/measurement-dirs.js';
 import { loadEvalConfig } from '../../inputs/eval-config.js';
 import { DEFAULT_MODEL } from '../../executors/shared.js';
 import type {
@@ -157,7 +158,12 @@ export function parseRunConfig(
   const judgeModels: JudgeConfig[] = parsedJudges
     ?? evalConfig?.judgeModels
     ?? [{ executor: executorName, model: 'haiku' }];
-  const outputDir = resolve((values['output-dir'] as string | undefined) ?? DEFAULT_REPORTS_DIR);
+  // 报告默认落项目 `.omk/reports`(绑用例集,construct validity);--global 写全局;--output-dir 最高优先。
+  // 同 observe / doctor 写入侧口径。读取侧(studio / resume / gold-compare / 复用)走 overlay 项目→全局兜底。
+  const outputDir = resolve(
+    (values['output-dir'] as string | undefined)
+    ?? (values.global ? globalReportsDir() : projectReportsDir()),
+  );
   const concurrencyRaw =
     (values.concurrency as string | undefined) !== undefined
       ? Number(values.concurrency)

--- a/src/cli/lib/record-evolve-outcome.ts
+++ b/src/cli/lib/record-evolve-outcome.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path';
-import { createFileStore } from '../../server/report-store.js';
-import { DEFAULT_OUTPUT_DIR } from '../../eval-core/evaluation-reporting.js';
+import { createOverlayReportStore } from '../../server/report-store.js';
+import { projectReportsDir, globalReportsDir } from '../../eval-core/measurement-dirs.js';
 import { computeVerdict } from '../../eval-core/verdict.js';
 import { bootstrapDiffCI, DEFAULT_BOOTSTRAP_ALPHA, DEFAULT_BOOTSTRAP_SAMPLES } from '../../eval-core/bootstrap.js';
 import {
@@ -25,7 +25,7 @@ export interface EvolveOutcomeInput {
   skillDir: string;
   /** evolve 目标本身的形态（目录-skill / 文件-skill），由原始入参 statSync 判定。用于按形态精确匹配受管记录。 */
   isDirectorySkill: boolean;
-  /** 报告加载器覆盖（测试用）；默认从 DEFAULT_OUTPUT_DIR 的文件存储按 id 读。 */
+  /** 报告加载器覆盖（测试用）；默认走 overlay 报告存储（项目 .omk/reports → 全局兜底）按 id 读。 */
   loadReport?: (id: string) => Promise<EvaluationReport | null>;
   /** 受管目录覆盖（测试用）。 */
   dir?: string;
@@ -103,7 +103,8 @@ function findRecordBySource(
 }
 
 async function loadEvolveReport(id: string): Promise<EvaluationReport | null> {
-  const doc = await createFileStore(DEFAULT_OUTPUT_DIR).get(id);
+  // overlay get：项目 .omk/reports → 全局兜底，evolve 写到全局的合并报告仍命中，eval 新写项目的也能取到。
+  const doc = await createOverlayReportStore(projectReportsDir(), globalReportsDir()).get(id);
   return doc && doc.kind === 'evaluation' ? (doc as EvaluationReport) : null;
 }
 

--- a/src/eval-core/measurement-dirs.ts
+++ b/src/eval-core/measurement-dirs.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { DEFAULT_OBSERVE_HEALTH_DIR, DEFAULT_DOCTORS_DIR } from './default-dirs.js';
+import { DEFAULT_OBSERVE_HEALTH_DIR, DEFAULT_DOCTORS_DIR, DEFAULT_REPORTS_DIR } from './default-dirs.js';
 
 /**
  * 测量产物的「项目优先 → 全局兜底」目录解析,镜像 managed 的 `resolveManagedDir`
@@ -70,4 +70,20 @@ export function resolveDoctorsDir(
   if (has(dir)) return dir;
   if (dir !== global && has(global)) return global;
   return dir;
+}
+
+// —— reports(eval 评测报告)——
+// reports 与 observe-health / doctors 不同:它不是「选一个权威目录」就够的展示列表,而是按 id
+// 寻址的 store(get(id) / findByArtifactHash 被 resume / gold-compare / baseline 复用依赖)。
+// 故记录优先在 store 层做(见 createOverlayReportStore:项目盖全局),此处只给写入侧与 --global
+// 用的项目 / 全局目录 getter,不给 resolveReportsDir(单目录二选一会让目标 id 在另一目录时 get 落空)。
+
+/** 项目级 reports 目录(相对调用时 cwd)。 */
+export function projectReportsDir(cwd: string = process.cwd()): string {
+  return join(cwd, '.omk', 'reports');
+}
+
+/** 全局 reports 目录。 */
+export function globalReportsDir(): string {
+  return DEFAULT_REPORTS_DIR;
 }

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -288,8 +288,11 @@ export async function runEvaluation({
   // --resume: load existing report results to skip completed tasks
   let existingResults: Record<string, Record<string, import('../types/index.js').VariantResult>> | undefined;
   if (resume) {
-    const { createFileStore } = await import('../server/report-store.js');
-    const store = createFileStore(resolve(outputDir || DEFAULT_OUTPUT_DIR));
+    // 读侧走 overlay(本次 outputDir 优先 → 全局兜底):写默认翻项目后,--resume 一个存量 / 全局报告(升级前
+    // 全部落全局)仍能 get 命中,不致整轮重跑。写仍是另起新报告到 outputDir,与读位置解耦,无 read/write 分叉。
+    const { createOverlayReportStore } = await import('../server/report-store.js');
+    const { globalReportsDir } = await import('../eval-core/measurement-dirs.js');
+    const store = createOverlayReportStore(resolve(outputDir || DEFAULT_OUTPUT_DIR), globalReportsDir());
     const existing = await store.get(resume);
     if (existing?.kind === 'evaluation') {
       existingResults = {};

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -13,12 +13,12 @@ import { renderObservationInboxPage } from '../renderer/observation-inbox-render
 import { DEFAULT_LANG, t, layout } from '../renderer/layout.js';
 import { loadAllManagedRecords, resolveManagedDir, managedDir as projectManagedDir, listManagedRows } from '../managed/index.js';
 import { renderManagedList, renderManagedHistory } from '../renderer/managed-history-renderer.js';
-import { DEFAULT_REPORTS_DIR, DEFAULT_JOBS_DIR } from '../eval-core/default-dirs.js';
-import { resolveObserveHealthDir, projectObserveHealthDir, resolveDoctorsDir, projectDoctorsDir } from '../eval-core/measurement-dirs.js';
+import { DEFAULT_JOBS_DIR } from '../eval-core/default-dirs.js';
+import { resolveObserveHealthDir, projectObserveHealthDir, resolveDoctorsDir, projectDoctorsDir, projectReportsDir, globalReportsDir } from '../eval-core/measurement-dirs.js';
 import { buildSkillIndex } from './skill-index.js';
 import type { Lang } from '../types/index.js';
 import { createFileJobStore } from './job-store.js';
-import { createFileStore, queryJob, queryJobList, queryRun, queryRunList, queryTrend } from './report-store.js';
+import { createFileStore, createOverlayReportStore, queryJob, queryJobList, queryRun, queryRunList, queryTrend } from './report-store.js';
 import type { JobStore, ReportStore, DoctorReport } from '../types/index.js';
 import { confidenceOf, type SkillHealthReport } from '../observability/skill-health-analyzer.js';
 import { DEFAULT_OBSERVATIONS_DIR, findObservationInboxItem, formatObservationShow, queryObservationInbox } from '../observability/inbox.js';
@@ -609,12 +609,18 @@ export function formatListenError(p: number, err: unknown): Error | null {
   return null;
 }
 
-export function createReportServer({ port, host: hostOption, reportsDir = DEFAULT_REPORTS_DIR, analysesDir, doctorsDir, observationsDir = DEFAULT_OBSERVATIONS_DIR, jobsDir = DEFAULT_JOBS_DIR, managedDir, store, jobStore }: ReportServerOptions = {}): ReportServer {
+export function createReportServer({ port, host: hostOption, reportsDir, analysesDir, doctorsDir, observationsDir = DEFAULT_OBSERVATIONS_DIR, jobsDir = DEFAULT_JOBS_DIR, managedDir, store, jobStore }: ReportServerOptions = {}): ReportServer {
   let server: Server | null = null;
   let serverUrl: string | null = null;
 
-  // Use provided store or default to file store
-  const reportStore: ReportStore = store || createFileStore(reportsDir);
+  // reports store:显式注入 store > 显式 reportsDir(eval serve 的本次 outputDir / 测试 / 覆盖,固定单目录)
+  // > 缺省 overlay(项目 .omk/reports 盖全局,studio 默认看当前项目、存量全局兜底)。overlay 在 store 层做
+  // 记录优先 + 按 id 兜底,故无需像 analyses/doctors 那样每请求重解析(底层 createFileStore 的 mtime 指纹
+  // 自动反映内容变化),一次构建即可。
+  const reportStore: ReportStore = store
+    ?? (reportsDir !== undefined
+      ? createFileStore(reportsDir)
+      : createOverlayReportStore(projectReportsDir(), globalReportsDir()));
   const resolvedJobStore: JobStore = jobStore || createFileJobStore(jobsDir);
   // 受管根目录按**请求**解析,不在启动时冻结 —— 否则长会话里会跟 omk list 分叉:Studio 启动时项目 .omk/managed
   // 还空、回退到 global,随后用户在项目里首次 omk install,omk list 下次会切到 project,而冻结了 root 的 Studio
@@ -1133,10 +1139,9 @@ export function createReportServer({ port, host: hostOption, reportsDir = DEFAUL
 
   async function start(): Promise<string> {
     if (server) return serverUrl!;
-    if (!existsSync(reportsDir)) mkdirSync(reportsDir, { recursive: true });
-    // analysesDir 现在是 per-request resolver(项目优先→全局兜底),不在启动时 mkdir ——
-    // studio 是只读消费,readers 都 existsSync 守卫、writer(omk observe)自建目录,
-    // 启动时往随机 cwd 建空 .omk/observe-health 反而是噪声。
+    // reports / analyses / doctors 都不在启动时 mkdir —— studio 只读消费,readers 都 existsSync 守卫、
+    // writer(omk eval / observe / doctor)各自建目录;reports 默认走 overlay(项目盖全局),启动时往随机
+    // cwd 建空 .omk/reports 既无意义又是噪声。observationsDir / jobsDir 仍预建(既有行为)。
     if (!existsSync(observationsDir)) mkdirSync(observationsDir, { recursive: true });
     if (!existsSync(jobsDir)) mkdirSync(jobsDir, { recursive: true });
 

--- a/src/server/report-store.ts
+++ b/src/server/report-store.ts
@@ -189,6 +189,63 @@ export function createFileStore(dir: string): ReportStore {
   return { list, get, save, update, remove, exists, findByVariant, findByArtifactHash };
 }
 
+/**
+ * 项目盖全局的 overlay 报告存储。reports 默认落项目 `.omk/reports`(绑用例集,construct validity),
+ * 全局 `~/.oh-my-knowledge/reports` 作存量兜底。两类语义刻意不同:
+ *   - 浏览(list / findByVariant):记录优先 —— 项目有报告只看项目(studio 不混进跨项目全局堆),
+ *     项目空才回退全局(空项目不白屏)。同 resolveManagedDir / phase-1 口径。
+ *   - 寻址(get / exists / findByArtifactHash):项目→全局兜底 —— 拿具体 id / 内容哈找文件时两处都查,
+ *     resume / gold-compare / baseline 复用不因「写默认翻项目」而落空;复用查找继续覆盖全局,报告数字零变化。
+ * 写(save / update / remove):落项目(写默认目标);update / remove 找不到再落/试全局(改删 studio 当前所见那份)。
+ * 两个底层 createFileStore 各自带 list 指纹缓存,overlay 一次构建即可、无需每请求重建(cwd 进程内不变,
+ * 内容变化由 createFileStore 的 mtime 指纹自动失效)。
+ */
+export function createOverlayReportStore(projectDir: string, globalDir: string): ReportStore {
+  const project = createFileStore(projectDir);
+  const global = createFileStore(globalDir);
+
+  async function projectHasReports(): Promise<boolean> {
+    return (await project.list()).length > 0;
+  }
+
+  async function list(): Promise<ReportDocument[]> {
+    return (await projectHasReports()) ? project.list() : global.list();
+  }
+
+  async function get(id: string): Promise<ReportDocument | null> {
+    return (await project.get(id)) ?? global.get(id);
+  }
+
+  async function exists(id: string): Promise<boolean> {
+    return (await project.exists(id)) || global.exists(id);
+  }
+
+  async function save(id: string, report: ReportDocument): Promise<void> {
+    return project.save(id, report);
+  }
+
+  async function update(id: string, mutator: (report: ReportDocument) => void): Promise<ReportDocument | null> {
+    return (await project.exists(id)) ? project.update(id, mutator) : global.update(id, mutator);
+  }
+
+  async function remove(id: string): Promise<boolean> {
+    return (await project.remove(id)) || global.remove(id);
+  }
+
+  async function findByVariant(variantName: string): Promise<EvaluationReport[]> {
+    return (await projectHasReports()) ? project.findByVariant(variantName) : global.findByVariant(variantName);
+  }
+
+  async function findByArtifactHash(hash: string): Promise<EvaluationReport[]> {
+    // 跨两处合并(项目优先 dedup):baseline 复用继续覆盖全局,保证复用命中率与报告数字不变。
+    const [p, g] = await Promise.all([project.findByArtifactHash(hash), global.findByArtifactHash(hash)]);
+    const seen = new Set(p.map((r) => r.id));
+    return [...p, ...g.filter((r) => !seen.has(r.id))];
+  }
+
+  return { list, get, save, update, remove, exists, findByVariant, findByArtifactHash };
+}
+
 export interface JobQuery {
   status?: string;
   reportId?: string;

--- a/test/cli/reports-output-dir.test.ts
+++ b/test/cli/reports-output-dir.test.ts
@@ -1,0 +1,38 @@
+/**
+ * eval 报告写入默认目录(parseRunConfig.outputDir)三态:
+ *   - 默认 → 项目级 .omk/reports(绑用例集,construct validity)
+ *   - --global → 全局 ~/.oh-my-knowledge/reports
+ *   - --output-dir → 显式目录(最高优先)
+ * 纯文件落点,不动任何评分;读取侧 studio / resume / gold-compare / 复用走 overlay 兜底(见 report-store)。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { parseRunConfig } from '../../src/cli/lib/parse-run-config.js';
+import { globalReportsDir, projectReportsDir } from '../../src/eval-core/measurement-dirs.js';
+
+const BASE_FLAGS = {
+  'skill-dir': 'examples/code-review/skills',
+  control: 'baseline',
+  treatment: 'v1',
+  'dry-run': true,
+};
+
+describe('eval 报告写入默认目录', () => {
+  it('默认 → 项目级 .omk/reports', () => {
+    const { config } = parseRunConfig({ ...BASE_FLAGS });
+    assert.equal(config.outputDir, projectReportsDir());
+    assert.ok(config.outputDir.endsWith(join('.omk', 'reports')), '应落项目 .omk/reports');
+  });
+
+  it('--global → 全局 reports', () => {
+    const { config } = parseRunConfig({ ...BASE_FLAGS, global: true });
+    assert.equal(config.outputDir, globalReportsDir());
+    assert.ok(config.outputDir.endsWith(join('.oh-my-knowledge', 'reports')));
+  });
+
+  it('--output-dir 最高优先(压过默认与 --global)', () => {
+    const { config } = parseRunConfig({ ...BASE_FLAGS, global: true, 'output-dir': 'custom-reports' });
+    assert.equal(config.outputDir, join(process.cwd(), 'custom-reports'));
+  });
+});

--- a/test/cli/studio-dev-spawn.test.ts
+++ b/test/cli/studio-dev-spawn.test.ts
@@ -91,6 +91,36 @@ describe('studio --dev child spawn argv', () => {
     expect(rest).toEqual(['--port', '8080', '--reports-dir', 'tmp-reports', '--no-open']);
   });
 
+  it('默认(无 --reports-dir)→ 子进程 argv 不带 --reports-dir(交给 server 建 overlay)', async () => {
+    const { runStudio } = await import('../../src/cli/commands/studio.js');
+    await runStudio({}, {
+      lang: 'zh',
+      port: '7799',
+      'no-open': true,
+      dev: true,
+    }, 'zh');
+
+    expect(spawnCalls).toHaveLength(1);
+    const [, , , , ...rest] = spawnCalls[0].args;
+    expect(rest).toEqual(['--port', '7799', '--no-open']);
+    expect(rest).not.toContain('--reports-dir');
+  });
+
+  it('--global → 子进程 argv 透传 --global(reports / observe-health / doctors 钉全局)', async () => {
+    const { runStudio } = await import('../../src/cli/commands/studio.js');
+    await runStudio({}, {
+      lang: 'zh',
+      port: '7799',
+      'no-open': true,
+      dev: true,
+      global: true,
+    }, 'zh');
+
+    expect(spawnCalls).toHaveLength(1);
+    const [, , , , ...rest] = spawnCalls[0].args;
+    expect(rest).toEqual(['--port', '7799', '--global', '--no-open']);
+  });
+
   it('treats BROWSER=none as no browser open', async () => {
     const { runStudio } = await import('../../src/cli/commands/studio.js');
     setStdoutIsTTY(true);

--- a/test/eval-core/measurement-dirs.test.ts
+++ b/test/eval-core/measurement-dirs.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import {
   projectObserveHealthDir, globalObserveHealthDir, resolveObserveHealthDir,
   projectDoctorsDir, globalDoctorsDir, resolveDoctorsDir,
+  projectReportsDir, globalReportsDir,
 } from '../../src/eval-core/measurement-dirs.js';
 
 function mkTmp(tag: string): string {
@@ -18,8 +19,16 @@ describe('measurement-dirs 项目优先→全局兜底(记录优先)', () => {
   it('project/global getter 路径', () => {
     assert.equal(projectObserveHealthDir('/x'), join('/x', '.omk', 'observe-health'));
     assert.equal(projectDoctorsDir('/x'), join('/x', '.omk', 'doctors'));
+    assert.equal(projectReportsDir('/x'), join('/x', '.omk', 'reports'));
     assert.ok(globalObserveHealthDir().endsWith(join('.oh-my-knowledge', 'observe-health')));
     assert.ok(globalDoctorsDir().endsWith(join('.oh-my-knowledge', 'doctors')));
+    assert.ok(globalReportsDir().endsWith(join('.oh-my-knowledge', 'reports')));
+  });
+
+  it('reports 不给 resolveReportsDir(记录优先在 overlay store 层做,见 report-store)', () => {
+    // 故意只暴露 project/global getter:单目录二选一会让目标 id 在另一目录时 get 落空,
+    // reports 的项目→全局兜底必须在 store 层(createOverlayReportStore),不在 dir 解析层。
+    assert.equal(projectReportsDir(), join(process.cwd(), '.omk', 'reports'));
   });
 
   it('observe-health:项目有报告→项目;项目空+全局有→全局;都空→项目', () => {

--- a/test/server/report-store.test.ts
+++ b/test/server/report-store.test.ts
@@ -1,0 +1,129 @@
+/**
+ * createOverlayReportStore(项目盖全局)语义验收。
+ *
+ * 两类语义刻意不同:
+ *   - 浏览(list / findByVariant):记录优先 —— 项目有报告只看项目,空则全局兜底。
+ *   - 寻址(get / exists / findByArtifactHash):项目→全局兜底 / 跨两处合并 —— 拿具体 id / 内容哈
+ *     找文件时两处都查,resume / gold-compare / baseline 复用不因写默认翻项目而落空,复用数字不降。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createOverlayReportStore } from '../../src/server/report-store.js';
+
+function mkTmp(tag: string): string {
+  const d = join(tmpdir(), `omk-overlay-${tag}-${Date.now()}-${Math.round(performance.now())}`);
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+interface MiniReportOpts {
+  id: string;
+  variant: string;
+  hash: string;
+  timestamp: string;
+}
+
+function writeReport(dir: string, opts: MiniReportOpts): void {
+  const doc = {
+    kind: 'evaluation',
+    id: opts.id,
+    meta: { timestamp: opts.timestamp, variants: [opts.variant], artifactHashes: { [opts.variant]: opts.hash } },
+    summary: { [opts.variant]: {} },
+    results: [],
+  };
+  writeFileSync(join(dir, `${opts.id}.json`), JSON.stringify(doc));
+}
+
+describe('createOverlayReportStore 项目盖全局', () => {
+  it('都空 → list/get 皆空', async () => {
+    const proj = mkTmp('empty-p');
+    const glob = mkTmp('empty-g');
+    try {
+      const store = createOverlayReportStore(proj, glob);
+      assert.deepEqual(await store.list(), []);
+      assert.equal(await store.get('nope'), null);
+      assert.equal(await store.exists('nope'), false);
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+      rmSync(glob, { recursive: true, force: true });
+    }
+  });
+
+  it('仅全局有 → 浏览看全局,寻址命中全局', async () => {
+    const proj = mkTmp('g-only-p');
+    const glob = mkTmp('g-only-g');
+    try {
+      writeReport(glob, { id: 'rg', variant: 'vg', hash: 'hashG', timestamp: '2026-01-01T00:00:00Z' });
+      const store = createOverlayReportStore(proj, glob);
+      assert.equal((await store.list()).length, 1, '项目空 → 全局兜底');
+      assert.equal((await store.get('rg'))?.id, 'rg');
+      assert.equal(await store.exists('rg'), true);
+      assert.equal((await store.findByVariant('vg')).length, 1, '项目空 → findByVariant 全局兜底');
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+      rmSync(glob, { recursive: true, force: true });
+    }
+  });
+
+  it('项目有报告 → 浏览只看项目(隐藏全局堆),但寻址仍兜底全局', async () => {
+    const proj = mkTmp('both-p');
+    const glob = mkTmp('both-g');
+    try {
+      writeReport(glob, { id: 'rg', variant: 'vg', hash: 'hashG', timestamp: '2026-01-01T00:00:00Z' });
+      writeReport(proj, { id: 'rp', variant: 'vp', hash: 'hashP', timestamp: '2026-02-02T00:00:00Z' });
+      const store = createOverlayReportStore(proj, glob);
+
+      // 浏览(list / findByVariant):记录优先,项目非空 → 只看项目,全局被隐藏(避免 studio 混进跨项目堆)。
+      const listed = await store.list();
+      assert.equal(listed.length, 1, '项目非空 → list 只项目');
+      assert.equal(listed[0].id, 'rp');
+      assert.equal((await store.findByVariant('vg')).length, 0, '记录优先:全局 variant 不出现在浏览里');
+      assert.equal((await store.findByVariant('vp')).length, 1);
+
+      // 寻址(get / exists):项目→全局兜底,即便项目非空也能拿到全局那份(resume / gold-compare 不落空)。
+      assert.equal((await store.get('rg'))?.id, 'rg', 'get 项目→全局兜底');
+      assert.equal((await store.get('rp'))?.id, 'rp');
+      assert.equal(await store.exists('rg'), true);
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+      rmSync(glob, { recursive: true, force: true });
+    }
+  });
+
+  it('findByArtifactHash 跨两处合并(项目优先 dedup)→ baseline 复用数字不降', async () => {
+    const proj = mkTmp('hash-p');
+    const glob = mkTmp('hash-g');
+    try {
+      writeReport(glob, { id: 'rg', variant: 'vg', hash: 'hashG', timestamp: '2026-01-01T00:00:00Z' });
+      writeReport(proj, { id: 'rp', variant: 'vp', hash: 'hashP', timestamp: '2026-02-02T00:00:00Z' });
+      const store = createOverlayReportStore(proj, glob);
+      // 关键:项目非空时 findByArtifactHash 仍覆盖全局(与 findByVariant 的记录优先不同),
+      // 否则 eval 写默认翻项目后复用会漏掉全局 baseline → 复用命中率降 → 报告数字漂移。
+      assert.equal((await store.findByArtifactHash('hashG')).length, 1, '项目非空仍命中全局 hash');
+      assert.equal((await store.findByArtifactHash('hashP')).length, 1, '命中项目 hash');
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+      rmSync(glob, { recursive: true, force: true });
+    }
+  });
+
+  it('remove:项目找不到再试全局', async () => {
+    const proj = mkTmp('rm-p');
+    const glob = mkTmp('rm-g');
+    try {
+      writeReport(glob, { id: 'rg', variant: 'vg', hash: 'hashG', timestamp: '2026-01-01T00:00:00Z' });
+      writeReport(proj, { id: 'rp', variant: 'vp', hash: 'hashP', timestamp: '2026-02-02T00:00:00Z' });
+      const store = createOverlayReportStore(proj, glob);
+      assert.equal(await store.remove('rg'), true, '项目无 → 删全局');
+      assert.equal(await store.get('rg'), null, '删后取不到');
+      assert.equal(await store.remove('rp'), true, '删项目那份');
+      assert.equal(await store.remove('missing'), false, '两处都无 → false');
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+      rmSync(glob, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/server/report-store.test.ts
+++ b/test/server/report-store.test.ts
@@ -110,6 +110,22 @@ describe('createOverlayReportStore 项目盖全局', () => {
     }
   });
 
+  it('update:项目找不到改全局那份(与 remove 兜底对称)', async () => {
+    const proj = mkTmp('up-p');
+    const glob = mkTmp('up-g');
+    try {
+      writeReport(glob, { id: 'rg', variant: 'vg', hash: 'hashG', timestamp: '2026-01-01T00:00:00Z' });
+      const store = createOverlayReportStore(proj, glob);
+      const updated = await store.update('rg', (doc) => { (doc.meta as { note?: string }).note = 'touched'; });
+      assert.equal(updated?.id, 'rg', '项目无 → update 改全局那份');
+      assert.equal(((await store.get('rg'))?.meta as { note?: string } | undefined)?.note, 'touched', '改动落盘');
+      assert.equal(await store.update('missing', () => undefined), null, '两处都无 → null');
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+      rmSync(glob, { recursive: true, force: true });
+    }
+  });
+
   it('remove:项目找不到再试全局', async () => {
     const proj = mkTmp('rm-p');
     const glob = mkTmp('rm-g');


### PR DESCRIPTION
## 用户影响

`omk eval` 的报告默认从全局公共桶 `~/.oh-my-knowledge/reports` 改为落当前项目 `.omk/reports`，跟着项目走、天然按用例集隔离。`omk studio` 默认只看当前项目的报告（项目空则全局兜底，不白屏）。这是问题一（测量产物项目化，#243）的最后一件，与 phase-1（observe-health / doctors，#250）对齐。

迁移说明（加法、可回退）：存量全局报告靠 overlay 兜底**全部仍可见、一个文件都不挪**；要写/看全局加 `--global`，显式目录用 `--output-dir` / `--reports-dir`（最高优先）。

## 为什么 reports 比 observe-health / doctors 多一层

后两者是展示用列表，phase-1「记录优先选一个权威目录」就够。reports 是**按 id 寻址的 store**（`get(id)` / `findByArtifactHash` 被 resume / gold-compare / baseline 复用依赖）：若照搬「二选一目录」，当 resolver 选了项目目录而目标 id 在全局时 `get` 会落空 → resume / 对比断掉。故新建 `createOverlayReportStore`（项目盖全局），两类语义刻意不同：

- 浏览（`list` / `findByVariant`）：记录优先 —— 项目有报告只看项目（studio 不混进跨项目全局堆），空则全局兜底。
- 寻址（`get` / `exists` / `findByArtifactHash`）：项目→全局兜底 / 跨两处合并 —— 拿具体 id / 内容哈找文件时两处都查。

## 测量学 caveat

纯文件落点迁移，不碰 report schema / judge / 评分 —— **非 BREAKING-COMPARABILITY**，与 phase-1 同性质。两条保数字不变的关键：

- 治理门禁不回读报告文件（`evaluatePromoteGate` 跑 denormalize 的 evidence 快照，`buildEvidenceRef` 抄完字段即弃），挪报告位置对治理零影响。
- baseline 复用（`findByArtifactHash`）继续覆盖全局（union 而非记录优先），复用前提本就卡 `sampleHashesMatch` + 同 model / executor / judges（内容寻址、跨项目合法），复用命中率与「复用了哪份 baseline」零变化。

## 范围与遗留

四个 by-id 零头（gold-compare / sample / evolve 复用 / evolve outcome）默认改项目优先 overlay，避免写默认翻项目后漏报告。evolve **自身写**仍落全局（有独立 lineage 语义、且无 escape flag），留 phase-2b（连同 baseline 复用索引抽进 `state/` cache）。

设计定稿见 #243（issuecomment-4698956238：断链不存在 / overlay 项目盖全局 / 复用走全局保数字）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)