### PR TITLE
feat(eval-core): 产物发现索引 + studio 机器级总览（reports 域，#243 阶段 1）

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -636,13 +636,13 @@ omk studio [flags]
 - `--analyses-dir` `option`:观测健康报告目录（可选，默认项目级 .omk/observe-health，空则全局兜底）
 - `--dev` `boolean`:dev 模式：子进程启动 + 热更新
 - `--doctors-dir` `option`:体检报告目录（可选，默认项目级 .omk/doctors，空则全局兜底）
-- `--global` `boolean`:只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
+- `--global` `boolean`:只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非机器级聚合 / 项目优先；managed / observe-inbox 不受影响
 - `--host` `option`:监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--no-open` `boolean`:不自动打开浏览器
 - `--observations-dir` `option`:观测收件箱数据目录（可选，默认 .omk/observe-inbox）
 - `--port` `option` (默认 `7799`):监听端口，默认 7799。传 0 让 OS 分配
-- `--reports-dir` `option`:报告目录（可选，默认项目级 .omk/reports 盖全局兜底）
+- `--reports-dir` `option`:只看指定报告目录（可选；默认机器级聚合：当前项目 + 全局 + 别项目索引）
 
 **示例:**
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -447,13 +447,13 @@ omk studio --no-open
   --analyses-dir <value>      Observe-health reports dir (optional, default project .omk/observe-health, falls back to global)
   --dev                       Dev mode: child process with hot reload
   --doctors-dir <value>       Doctor reports dir (optional, default project .omk/doctors, falls back to global)
-  --global                    View global reports / observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox
+  --global                    View only global reports / observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of machine-wide / project-first; does not affect managed / observe-inbox
   --host <value>              Listen host, default localhost. Use 0.0.0.0 to expose to LAN
   --lang <value>              Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --no-open                   Do not auto-open browser
   --observations-dir <value>  Observe-inbox data dir (optional, default .omk/observe-inbox)
   --port <value>              Listen port, default 7799. Pass 0 for OS-assigned
-  --reports-dir <value>       Reports dir (optional, default project .omk/reports overlaid on global)
+  --reports-dir <value>       View only this reports dir (optional; default aggregates machine-wide: current project + global + other projects via index)
 ```
 
 For full descriptions: `omk studio --help`.

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -447,13 +447,13 @@ omk studio --no-open
   --analyses-dir <value>      观测健康报告目录（可选，默认项目级 .omk/observe-health，空则全局兜底）
   --dev                       dev 模式：子进程启动 + 热更新
   --doctors-dir <value>       体检报告目录（可选，默认项目级 .omk/doctors，空则全局兜底）
-  --global                    只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
+  --global                    只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非机器级聚合 / 项目优先；managed / observe-inbox 不受影响
   --host <value>              监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
   --lang <value>              输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --no-open                   不自动打开浏览器
   --observations-dir <value>  观测收件箱数据目录（可选，默认 .omk/observe-inbox）
   --port <value>              监听端口，默认 7799。传 0 让 OS 分配
-  --reports-dir <value>       报告目录（可选，默认项目级 .omk/reports 盖全局兜底）
+  --reports-dir <value>       只看指定报告目录（可选；默认机器级聚合：当前项目 + 全局 + 别项目索引）
 ```
 
 完整描述见 `omk studio --help`。

--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { resolve, join, dirname, basename } from 'node:path';
 import { runEvaluation } from '../eval-workflows/run-evaluation.js';
 import { createExecutor, DEFAULT_MODEL, JUDGE_MODEL } from '../executors/index.js';
-import { persistReport, DEFAULT_OUTPUT_DIR, generateRunId, hashString } from '../eval-core/evaluation-reporting.js';
+import { persistReport, DEFAULT_OUTPUT_DIR, runIdSuffix, hashString } from '../eval-core/evaluation-reporting.js';
 import { createOverlayReportStore } from '../server/report-store.js';
 import { projectReportsDir, globalReportsDir } from '../eval-core/measurement-dirs.js';
 import { analyzeResults } from '../analysis/report-diagnostics.js';
@@ -784,7 +784,7 @@ export function mergeEvolveReports(
     if (originalKey) artifactHashes[variantLabels[i]] = hashes[originalKey];
   }
 
-  const runId = `evolve-${skillName}-${generateRunId([skillName]).split('-').slice(-2).join('-')}`;
+  const runId = `evolve-${skillName}-${runIdSuffix()}`;
 
   const report: Report = {
     kind: 'evaluation',

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -41,8 +41,8 @@ export async function runStudio(
   flags: StudioFlags,
   lang: CliLang,
 ): Promise<void> {
-  // reports 读取目录:显式 --reports-dir 固定该目录;--global 钉全局;默认走 overlay(项目盖全局,
-  // 由 server 在 store 层做记录优先 + 按 id 兜底)。默认 = undefined,交给 createReportServer 建 overlay。
+  // reports 读取目录:显式 --reports-dir 固定该目录;--global 钉全局;默认 = undefined,交给
+  // createReportServer 建 indexed(机器级聚合:当前项目 + 全局 live ∪ 别项目索引卡片)。
   const reportsDirOpt = flags['reports-dir']
     ? resolve(flags['reports-dir'])
     : flags.global

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -97,7 +97,8 @@ export async function runStudio(
   const server: ReportServer = createReportServer({
     port: Number(flags.port),
     ...(flags.host ? { host: flags.host } : {}),
-    // reportsDir 缺省 undefined → server 建 overlay(项目盖全局);显式 --reports-dir / --global 固定单目录。
+    // reportsDir 缺省 undefined → server 建 indexed(机器级:当前项目 + 全局 + 别项目索引卡片);
+    // 显式 --reports-dir / --global 固定单目录(逃生舱,不走聚合)。
     ...(reportsDirOpt !== undefined ? { reportsDir: reportsDirOpt } : {}),
     // 测量产物(observe-health / doctors)默认按请求项目优先→全局兜底(同 managed);
     // 显式 --analyses-dir/--doctors-dir 固定该目录;--global 钉全局目录。
@@ -159,8 +160,8 @@ export default class Studio extends BaseCommand {
     }),
     'reports-dir': Flags.string({
       description: bilingual({
-        zh: '报告目录（可选，默认项目级 .omk/reports 盖全局兜底）',
-        en: 'Reports dir (optional, default project .omk/reports overlaid on global)',
+        zh: '只看指定报告目录（可选；默认机器级聚合：当前项目 + 全局 + 别项目索引）',
+        en: 'View only this reports dir (optional; default aggregates machine-wide: current project + global + other projects via index)',
       }),
     }),
     'analyses-dir': Flags.string({
@@ -183,8 +184,8 @@ export default class Studio extends BaseCommand {
     }),
     global: Flags.boolean({
       description: bilingual({
-        zh: '只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响',
-        en: 'View global reports / observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox',
+        zh: '只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非机器级聚合 / 项目优先；managed / observe-inbox 不受影响',
+        en: 'View only global reports / observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of machine-wide / project-first; does not affect managed / observe-inbox',
       }),
     }),
     'no-open': Flags.boolean({

--- a/src/cli/lib/i18n-dict/help.ts
+++ b/src/cli/lib/i18n-dict/help.ts
@@ -232,11 +232,11 @@ omk studio——打开本地知识工作台
 选项：
   --port <n>                          本地服务端口（默认：7799）
   --host <host>                       监听地址（默认：127.0.0.1；局域网访问可用 0.0.0.0）
-  --reports-dir <path>                报告目录（默认：项目级 .omk/reports 盖全局兜底）
+  --reports-dir <path>                只看指定报告目录（默认机器级聚合：当前项目 + 全局 + 别项目索引）
   --analyses-dir <path>               观测健康报告目录（默认：项目级 .omk/observe-health，空则全局兜底）
   --doctors-dir <path>                体检报告目录（默认：项目级 .omk/doctors，空则全局兜底）
   --observations-dir <path>           observe inbox 数据目录（默认：.omk/observe-inbox）
-  --global                            只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非项目优先；managed / observe-inbox 不受影响
+  --global                            只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非机器级聚合 / 项目优先；managed / observe-inbox 不受影响
   --no-open                           只启动服务，不自动打开浏览器
   --dev                               开发模式：文件变化时自动重启
 
@@ -255,11 +255,11 @@ Usage:
 Options:
   --port <n>                          Local server port (default: 7799)
   --host <host>                       Listen address (default: 127.0.0.1; use 0.0.0.0 for LAN access)
-  --reports-dir <path>                Reports directory (default: project .omk/reports overlaid on global)
+  --reports-dir <path>                View only this reports dir (default aggregates machine-wide: current project + global + other projects via index)
   --analyses-dir <path>               Observe-health reports dir (default: project .omk/observe-health, falls back to global)
   --doctors-dir <path>                Doctor reports dir (default: project .omk/doctors, falls back to global)
   --observations-dir <path>           Observe inbox data directory (default: .omk/observe-inbox)
-  --global                            View global reports / observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of project-first; does not affect managed / observe-inbox
+  --global                            View only global reports / observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of machine-wide / project-first; does not affect managed / observe-inbox
   --no-open                           Start the server without opening a browser
   --dev                               Dev mode: restart on file changes
 

--- a/src/eval-core/artifact-index.ts
+++ b/src/eval-core/artifact-index.ts
@@ -78,7 +78,10 @@ export function listReportCards(): ReportIndexCard[] {
     if (!f.endsWith('.json') || f.includes('.json.tmp.')) continue;
     try {
       const c = JSON.parse(readFileSync(join(dir, f), 'utf-8')) as ReportIndexCard;
-      if (c && c.domain === 'report' && typeof c.id === 'string' && typeof c.path === 'string' && c.meta) cards.push(c);
+      // kind 白名单:cardToReportDocument 对任何非 evaluation 一律按 batch 投影,坏 kind(拼错 / 'doctor')
+      // 会污染机器级 list 成空 batch 报告。索引是可重生 scratch,读侧从严跳过坏卡片。
+      const kindOk = c?.kind === 'evaluation' || c?.kind === 'batch-evaluation';
+      if (c && c.domain === 'report' && kindOk && typeof c.id === 'string' && typeof c.path === 'string' && c.meta) cards.push(c);
     } catch { /* skip corrupt card */ }
   }
   return cards;

--- a/src/eval-core/artifact-index.ts
+++ b/src/eval-core/artifact-index.ts
@@ -1,0 +1,105 @@
+/**
+ * 产物发现索引(report 域)。
+ *
+ * 报告正文(含 results 逐样本重体)永远单份留它的项目本地 `.omk/reports/<id>.json`;报告落盘后,在全局
+ * `state/artifact-index/report/<id>.json` 留一张轻卡片(meta + summary,无 results,`path` 指向真身),
+ * 让 `omk studio` 跨项目聚合成「机器级总览」—— 当前项目 + 全局靠 live-scan 永远新鲜,别的项目靠卡片发现。
+ *
+ * 索引是可重生 scratch:写失败永不阻断报告落盘(正文是 source of truth);丢了由 live-scan / 重跑重建。
+ * doctor / observe-health 域后续复用 `artifactIndexDir(domain)` + tmp-rename 写卡片的同一套机制。
+ */
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { DEFAULT_ARTIFACT_INDEX_DIR } from './default-dirs.js';
+import { globalReportsDir } from './measurement-dirs.js';
+import type { BatchEvaluationReport, EvaluationReport, ReportDocument, ReportIndexCard } from '../types/index.js';
+
+export type ArtifactDomain = 'report' | 'doctor' | 'observe-health';
+
+/** 索引根:`OMK_ARTIFACT_INDEX_DIR` 覆盖(测试隔离,仿 OMK_TREES_DIR),默认 state/artifact-index。 */
+function artifactIndexRoot(): string {
+  return process.env.OMK_ARTIFACT_INDEX_DIR || DEFAULT_ARTIFACT_INDEX_DIR;
+}
+
+/** 某域的索引目录 `<root>/<domain>/`。 */
+export function artifactIndexDir(domain: ArtifactDomain): string {
+  return join(artifactIndexRoot(), domain);
+}
+
+/** 只索引「非全局目录」的写:全局是单一物理目录、任何 studio 都 live-scan 它 → 全局写卡片冗余;
+ *  卡片唯一价值是别项目的项目级 `.omk/reports`。 */
+export function shouldIndexReport(outputDir: string): boolean {
+  return resolve(outputDir) !== resolve(globalReportsDir());
+}
+
+function safeFileName(id: string): string {
+  return id.replaceAll(/[/\\:*?"<>|]/g, '_');
+}
+
+/** 原子写一张卡片(tmp+rename,防半截 JSON 被 reader 读到)。 */
+function writeCard(indexDir: string, id: string, card: ReportIndexCard): void {
+  mkdirSync(indexDir, { recursive: true });
+  const target = join(indexDir, `${safeFileName(id)}.json`);
+  const tmp = `${target}.tmp.${process.pid}.${Math.random().toString(36).slice(2)}`;
+  writeFileSync(tmp, JSON.stringify(card, null, 2));
+  renameSync(tmp, target);
+}
+
+/** 报告投影成卡片(剥掉 results 重体)。 */
+function reportCard(report: ReportDocument, sourcePath: string): ReportIndexCard {
+  return report.kind === 'evaluation'
+    ? { domain: 'report', id: report.id, path: sourcePath, kind: 'evaluation', meta: report.meta, summary: report.summary }
+    : { domain: 'report', id: report.id, path: sourcePath, kind: 'batch-evaluation', meta: report.meta, items: report.items };
+}
+
+/**
+ * persistReport 的索引钩子:报告落盘后 best-effort 追加卡片。永不抛、永不阻断报告落盘。
+ * 入参故意收 `{id}` 宽松(同 persistReport 的 PersistableReport):非完整报告(无 canonical kind)防御式跳过。
+ */
+export function indexReportWrite(report: { id: string }, sourcePath: string, outputDir: string): void {
+  try {
+    if (!shouldIndexReport(outputDir)) return;
+    const doc = report as Partial<ReportDocument>;
+    if (doc.kind !== 'evaluation' && doc.kind !== 'batch-evaluation') return;
+    writeCard(artifactIndexDir('report'), report.id, reportCard(doc as ReportDocument, sourcePath));
+  } catch {
+    // 索引可重建,失败静默(可选 stderr warn);正文已落盘不受影响。
+  }
+}
+
+/** 读 report 域全部卡片(跳过坏文件 / 缺字段)。 */
+export function listReportCards(): ReportIndexCard[] {
+  const dir = artifactIndexDir('report');
+  if (!existsSync(dir)) return [];
+  const cards: ReportIndexCard[] = [];
+  let files: string[];
+  try { files = readdirSync(dir); } catch { return []; }
+  for (const f of files) {
+    if (!f.endsWith('.json') || f.includes('.json.tmp.')) continue;
+    try {
+      const c = JSON.parse(readFileSync(join(dir, f), 'utf-8')) as ReportIndexCard;
+      if (c && c.domain === 'report' && typeof c.id === 'string' && typeof c.path === 'string' && c.meta) cards.push(c);
+    } catch { /* skip corrupt card */ }
+  }
+  return cards;
+}
+
+/** 卡片 → ReportDocument(results:[]):供 studio list / buildSkillIndex / trend 消费(它们不读 results)。 */
+export function cardToReportDocument(card: ReportIndexCard): ReportDocument {
+  return card.kind === 'evaluation'
+    ? { kind: 'evaluation', id: card.id, meta: card.meta as EvaluationReport['meta'], summary: card.summary ?? {}, results: [] }
+    : { kind: 'batch-evaluation', id: card.id, mode: 'skill', meta: card.meta as BatchEvaluationReport['meta'], items: card.items ?? [] };
+}
+
+/** 删 report 域某 id 的卡片(DELETE 报告时连卡片一起删,使其从机器级 list 消失)。幂等、best-effort。
+ *  返回卡片是否曾存在(供 remove 在「真身在别项目删不到、但卡片删了」时仍回报成功)。 */
+export function removeReportCard(id: string): boolean {
+  try {
+    const p = join(artifactIndexDir('report'), `${safeFileName(id)}.json`);
+    if (!existsSync(p)) return false;
+    unlinkSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/eval-core/default-dirs.ts
+++ b/src/eval-core/default-dirs.ts
@@ -26,3 +26,10 @@ export const DEFAULT_CACHE_DIR: string = join(DEFAULT_STATE_DIR, 'cache');
 export const DEFAULT_ISOLATED_CWD_DIR: string = join(DEFAULT_STATE_DIR, 'isolated-cwd');
 export const DEFAULT_TREES_DIR: string = join(DEFAULT_STATE_DIR, 'trees');
 export const DEFAULT_JOBS_DIR: string = join(DEFAULT_STATE_DIR, 'jobs');
+
+/**
+ * 产物发现索引根:每类测量产物(report / doctor / observe-health)项目本地落盘后,在全局这里留一张
+ * 轻量目录卡片(指向项目里的真身),让 `omk studio` 跨项目聚合成「机器级总览」。索引是可重生的 scratch
+ * (丢了重跑即重建,且当前项目+全局靠 live-scan 永远覆盖),故收在 state/ 子树。
+ */
+export const DEFAULT_ARTIFACT_INDEX_DIR: string = join(DEFAULT_STATE_DIR, 'artifact-index');

--- a/src/eval-core/default-dirs.ts
+++ b/src/eval-core/default-dirs.ts
@@ -4,8 +4,13 @@ import { join } from 'node:path';
 /**
  * omk 所有默认产物的用户级根目录 —— 全部 `~/.oh-my-knowledge/*` 默认目录的单一基准,
  * 各目录都从这里派生,不在散落各处重复拼 `join(homedir(), '.oh-my-knowledge', ...)`。
+ *
+ * `OMK_HOME` 环境变量可整体重定向这棵树:一处覆盖即把 reports / doctors / observe-health / state
+ * (cache / trees / jobs / artifact-index)全部移走。测试用它一次性隔离,免得每加一个会从深层调用点写
+ * 全局默认目录的写路径,都得单独补一个 per-dir env 兜底(否则注入不进的写路径会静默污染真实 home)。
+ * 生产不设此变量时回落到 `~/.oh-my-knowledge`,行为不变。用户迁移整个数据目录也可用它。
  */
-export const OMK_HOME: string = join(homedir(), '.oh-my-knowledge');
+export const OMK_HOME: string = process.env.OMK_HOME || join(homedir(), '.oh-my-knowledge');
 
 /**
  * 耐久测量数据(要留、被 reportId 等引用,绝不自动删)的默认根目录。这几个是 cli 写、server(Studio)读

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { DEFAULT_REPORTS_DIR } from './default-dirs.js';
+import { indexReportWrite } from './artifact-index.js';
 import { buildVariantSummary } from './schema.js';
 import { buildVariantConfig, resolveExecutionStrategy } from './execution-strategy.js';
 import { getJudgePromptHash } from '../grading/judge.js';
@@ -383,6 +384,9 @@ export function persistReport(report: PersistableReport, outputDir: string | nul
   if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
   const filePath = join(outputDir, `${report.id}.json`);
   writeFileSync(filePath, JSON.stringify(report, null, 2));
+  // 产物发现索引:报告落项目本地后,best-effort 追加全局轻卡片,让 omk studio 跨项目聚合成机器级总览。
+  // 永不抛、永不阻断报告落盘(正文是 source of truth)。
+  indexReportWrite(report, filePath, outputDir);
   return filePath;
 }
 
@@ -390,9 +394,13 @@ export function generateRunId(variants: string[]): string {
   const d = new Date();
   const pad = (n: number): string => String(n).padStart(2, '0');
   const date = `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}`;
-  const time = `${pad(d.getHours())}${pad(d.getMinutes())}`;
+  // 含秒 + 4 位随机后缀:id 是 run 标签(非测量数),但被 studio 机器级 dedup 与 managed 证据 (reportId,
+  // contentHash) 去重当唯一键用。分钟级会让跨项目 / 同分钟重跑撞同 id → 索引静默顶掉一份、managed 错并一条。
+  // 秒+随机根治撞名,保证每次 run 全局唯一。
+  const time = `${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`;
+  const rand = Math.random().toString(36).slice(2, 6);
   const variantPart = variants
     .map((variant) => variant.replaceAll(/[\\/:]/g, '-').replaceAll(/[^a-zA-Z0-9._@-]/g, '_'))
     .join('-vs-');
-  return `${variantPart}-${date}-${time}`;
+  return `${variantPart}-${date}-${time}-${rand}`;
 }

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -390,17 +390,24 @@ export function persistReport(report: PersistableReport, outputDir: string | nul
   return filePath;
 }
 
-export function generateRunId(variants: string[]): string {
+/**
+ * run id 的时间戳后缀 `YYYYMMDD-HHmmss-rand4`。
+ * 含秒 + 4 位随机:id 是 run 标签(非测量数),但被 studio 机器级 dedup 与 managed 证据 (reportId,
+ * contentHash) 去重当唯一键用。分钟级会让跨项目 / 同分钟重跑撞同 id → 索引静默顶掉一份、managed 错并一条。
+ * 秒+随机根治撞名,保证每次 run 全局唯一。供 generateRunId 与 evolve 合并 id 共用,避免靠 split 反解格式。
+ */
+export function runIdSuffix(): string {
   const d = new Date();
   const pad = (n: number): string => String(n).padStart(2, '0');
   const date = `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}`;
-  // 含秒 + 4 位随机后缀:id 是 run 标签(非测量数),但被 studio 机器级 dedup 与 managed 证据 (reportId,
-  // contentHash) 去重当唯一键用。分钟级会让跨项目 / 同分钟重跑撞同 id → 索引静默顶掉一份、managed 错并一条。
-  // 秒+随机根治撞名,保证每次 run 全局唯一。
   const time = `${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`;
   const rand = Math.random().toString(36).slice(2, 6);
+  return `${date}-${time}-${rand}`;
+}
+
+export function generateRunId(variants: string[]): string {
   const variantPart = variants
     .map((variant) => variant.replaceAll(/[\\/:]/g, '-').replaceAll(/[^a-zA-Z0-9._@-]/g, '_'))
     .join('-vs-');
-  return `${variantPart}-${date}-${time}-${rand}`;
+  return `${variantPart}-${runIdSuffix()}`;
 }

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -171,7 +171,9 @@ export function renderRunList(runs: ReportDocument[], lang: Lang = DEFAULT_LANG)
   // 顶部 verdict pill 主导视觉,id+date 是身份,scores 是成绩,底部 meta 是元数据,
   // delete 默认隐藏在 hover 出现避免误点。批量报告共用同一组件,batch pill 替代 verdict。
   const formatDateFromId = (id: string, fallbackTs?: string): string => {
-    const idMatch = id.match(/(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})$/);
+    // 兼容两代 run id 后缀:旧 `…YYYYMMDD-HHmm`、新 `…YYYYMMDD-HHmmss-rand4`(含秒+随机)。
+    // 都从 id 直接派生本地展示时间(确定性,不走时区敏感的 toLocaleString);新增的秒段 + 随机后缀可选匹配。
+    const idMatch = id.match(/(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(?:\d{2}-[a-z0-9]+)?$/);
     if (idMatch) return `${idMatch[2]}/${idMatch[3]} ${idMatch[4]}:${idMatch[5]}`;
     return fallbackTs ? new Date(fallbackTs).toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' }) : '';
   };

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -911,9 +911,11 @@ function renderEvalHistory(history: SkillEvalSnapshot[], langQ: string, lang: La
   const rows = [...history].reverse().map((h) => {
     const date = h.timestamp ? new Date(h.timestamp).toLocaleString(lang === 'zh' ? 'zh-CN' : 'en-US', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' }) : '-';
     const score = h.compositeScore != null ? h.compositeScore.toFixed(2) : '-';
-    const status = h.failCount === 0 ? '✅' : `❌ ${h.failCount} fail`;
+    // 卡片来源无逐样本通过数:状态 / 通过列都给「—」,不显误导的 ✅ 与 0/N。
+    const status = h.resultsStripped ? '—' : h.failCount === 0 ? '✅' : `❌ ${h.failCount} fail`;
+    const passCell = h.resultsStripped ? '—' : `${h.passCount}/${h.totalSamples}`;
     const link = `<a href="/reports/${e(h.reportId)}${langQ}">${e(h.reportId)}</a>`;
-    return `<tr><td>${date}</td><td>${score}</td><td>${h.passCount}/${h.totalSamples}</td><td>${status}</td><td>${link}</td></tr>`;
+    return `<tr><td>${date}</td><td>${score}</td><td>${passCell}</td><td>${status}</td><td>${link}</td></tr>`;
   }).join('\n');
   return `<details class="si-sect-fold">
     <summary>${lang === 'zh' ? `▸ 历史评测记录 (${history.length} 次)` : `▸ Eval history (${history.length} runs)`}</summary>
@@ -1003,7 +1005,11 @@ function renderEvalSection(
 
   const total = snap.passCount + snap.failCount;
   const pct = total > 0 ? Math.round((snap.passCount / total) * 100) : 0;
-  const sectBand = snap.failCount === 0 ? 'green' : snap.passCount === 0 ? 'red' : 'yellow';
+  // 别项目索引卡片(resultsStripped)pass/fail 被剥成 0:不能让 failCount===0 误判绿带「全通过」。
+  // 卡片可信信号只有 compositeScore,据它定带(>=4 绿 / >=3 黄 / 否则红,与 renderScoreBar 阈值一致);无分时中性灰。
+  const sectBand = snap.resultsStripped
+    ? (snap.compositeScore == null ? 'gray' : snap.compositeScore >= 4 ? 'green' : snap.compositeScore >= 3 ? 'yellow' : 'red')
+    : snap.failCount === 0 ? 'green' : snap.passCount === 0 ? 'red' : 'yellow';
 
   const failedBlock = failedSamples.length > 0
     ? failedSamples.map((s) => {
@@ -1072,9 +1078,12 @@ function renderEvalSection(
       </details>`
     : '';
 
-  const failedHeading = failedSamples.length > 0
-    ? `<div class="si-sect-line">${lang === 'zh' ? `${failedSamples.length} 条用例失败:` : `${failedSamples.length} samples failed:`}</div>`
-    : `<div class="si-sect-allpass">✓ ${lang === 'zh' ? '所有用例通过' : 'all samples pass'}</div>`;
+  const failedHeading = snap.resultsStripped
+    // 卡片来源无逐样本数据:既不能显「失败」也不能显「全通过」,给出「明细在源项目」占位。
+    ? `<div class="si-sect-line">${lang === 'zh' ? '逐样本明细需在源项目查看' : 'per-sample details available in source project'}</div>`
+    : failedSamples.length > 0
+      ? `<div class="si-sect-line">${lang === 'zh' ? `${failedSamples.length} 条用例失败:` : `${failedSamples.length} samples failed:`}</div>`
+      : `<div class="si-sect-allpass">✓ ${lang === 'zh' ? '所有用例通过' : 'all samples pass'}</div>`;
 
   // 综合得分 + 六维雷达
   const variantSummary = evalReport?.summary?.[snap.variantName];
@@ -1107,7 +1116,7 @@ function renderEvalSection(
   return `<section id="section-eval" class="si-sect si-sect--${sectBand}">
     <div class="si-sect-h">
       <span class="si-sect-title">🧪 ${lang === 'zh' ? '评测结果 (eval)' : 'Test score (eval)'}</span>
-      <span class="si-sect-meta">${snap.totalSamples} ${lang === 'zh' ? '用例' : 'samples'} · ${pct}% ${lang === 'zh' ? '通过' : 'pass'}${snap.compositeScore != null ? ` · ${snap.compositeScore.toFixed(2)}/5` : ''} · ${relTime(snap.timestamp, lang)}</span>
+      <span class="si-sect-meta">${snap.totalSamples} ${lang === 'zh' ? '用例' : 'samples'} · ${snap.resultsStripped ? (lang === 'zh' ? '明细在源项目' : 'details in source project') : `${pct}% ${lang === 'zh' ? '通过' : 'pass'}`}${snap.compositeScore != null ? ` · ${snap.compositeScore.toFixed(2)}/5` : ''} · ${relTime(snap.timestamp, lang)}</span>
     </div>
     <div class="si-sect-body">
       ${scoreSummary}

--- a/src/server/indexed-report-store.ts
+++ b/src/server/indexed-report-store.ts
@@ -1,0 +1,104 @@
+/**
+ * 机器级总览报告存储:让 `omk studio` 跨项目聚合所有报告。
+ *
+ * 三数据源合并、按 id dedup(live 盖卡片,优先级 项目 > 全局 > 卡片):
+ *   - live(当前项目 `.omk/reports`) + live(全局 `~/.oh-my-knowledge/reports`):完整真身,永远新鲜(无需 backfill);
+ *   - 索引卡片(state/artifact-index/report/):覆盖**别的项目**的报告(当前 studio 的 cwd live 扫不到),
+ *     卡片只含 meta+summary(无 results),详情按 `card.path` 读真身。
+ *
+ * 与 createOverlayReportStore(项目盖全局、记录优先)的区别:这里是**机器级 merge**(看全本机),不是项目优先;
+ * 可比性红线在比较层(verdict / findByVariant 锁同口径)而非视图层,故跨项目 merge 列表合法。
+ * by-id 复用 / resume / gold-compare 仍走 overlay(当前项目→全局),不走本 store —— 索引只供 studio 浏览。
+ */
+import { existsSync, statSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { createFileStore } from './report-store.js';
+import { artifactIndexDir, listReportCards, cardToReportDocument, removeReportCard } from '../eval-core/artifact-index.js';
+import type { ReportDocument, ReportStore, EvaluationReport } from '../types/index.js';
+
+function isEvaluation(r: ReportDocument): r is EvaluationReport {
+  return r.kind === 'evaluation';
+}
+
+export interface IndexedReportStoreOptions {
+  /** 当前项目 reports 目录(随 studio 进程 cwd 固定)。 */
+  projectDir: string;
+  /** 全局 reports 目录。 */
+  globalDir: string;
+}
+
+export function createIndexedReportStore({ projectDir, globalDir }: IndexedReportStoreOptions): ReportStore {
+  const project = createFileStore(projectDir);
+  const global = createFileStore(globalDir);
+
+  // 卡片扫描的轻量指纹缓存:索引目录 mtime + 条目数变化即失效(卡片 tmp+rename 写入会动目录 mtime)。
+  // live 两源各自带 report-store 的指纹缓存,这里只缓存卡片层。
+  let cachedFp = '';
+  let cachedCards: ReportDocument[] | null = null;
+  function cardDocs(): ReportDocument[] {
+    const dir = artifactIndexDir('report');
+    let fp = 'none';
+    try {
+      if (existsSync(dir)) fp = `${statSync(dir).mtimeMs}`;
+    } catch { /* fall through */ }
+    if (fp === cachedFp && cachedCards) return cachedCards;
+    const docs = listReportCards().map(cardToReportDocument);
+    cachedFp = fp;
+    cachedCards = docs;
+    return docs;
+  }
+
+  async function list(): Promise<ReportDocument[]> {
+    const [proj, glob] = await Promise.all([project.list(), global.list()]);
+    const seen = new Set<string>();
+    const merged: ReportDocument[] = [];
+    for (const r of proj) { if (!seen.has(r.id)) { seen.add(r.id); merged.push(r); } }
+    for (const r of glob) { if (!seen.has(r.id)) { seen.add(r.id); merged.push(r); } }
+    for (const r of cardDocs()) { if (!seen.has(r.id)) { seen.add(r.id); merged.push(r); } }
+    merged.sort((a, b) => (b.meta?.timestamp || '').localeCompare(a.meta?.timestamp || ''));
+    return merged;
+  }
+
+  async function get(id: string): Promise<ReportDocument | null> {
+    // 先 live(当前项目→全局),命中即完整真身。
+    const live = (await project.get(id)) ?? (await global.get(id));
+    if (live) return live;
+    // 别项目:按卡片 path 读真身;悬空(项目被移动/删除)→ 返回卡片壳(results:[])不抛、不 500。
+    const card = listReportCards().find((c) => c.id === id);
+    if (!card) return null;
+    const fromFile = await createFileStore(dirname(card.path)).get(id);
+    return fromFile ?? cardToReportDocument(card);
+  }
+
+  async function exists(id: string): Promise<boolean> {
+    if (await project.exists(id)) return true;
+    if (await global.exists(id)) return true;
+    return listReportCards().some((c) => c.id === id);
+  }
+
+  async function save(id: string, report: ReportDocument): Promise<void> {
+    return project.save(id, report);
+  }
+
+  async function update(id: string, mutator: (report: ReportDocument) => void): Promise<ReportDocument | null> {
+    // 只改 live 真身(卡片是只读指针);别项目真身不在本机可写范围。
+    return (await project.exists(id)) ? project.update(id, mutator) : global.update(id, mutator);
+  }
+
+  async function remove(id: string): Promise<boolean> {
+    const liveRemoved = (await project.remove(id)) || (await global.remove(id));
+    // 真身可能在别项目删不到,但删卡片即让它从机器级 list 消失(达成「从总览移除」意图)。
+    const cardRemoved = removeReportCard(id);
+    return liveRemoved || cardRemoved;
+  }
+
+  async function findByVariant(variantName: string): Promise<EvaluationReport[]> {
+    return (await list()).filter(isEvaluation).filter((r) => r.meta?.variants?.includes(variantName));
+  }
+
+  async function findByArtifactHash(hash: string): Promise<EvaluationReport[]> {
+    return (await list()).filter(isEvaluation).filter((r) => Object.values(r.meta?.artifactHashes || {}).includes(hash));
+  }
+
+  return { list, get, save, update, remove, exists, findByVariant, findByArtifactHash };
+}

--- a/src/server/indexed-report-store.ts
+++ b/src/server/indexed-report-store.ts
@@ -96,12 +96,15 @@ export function createIndexedReportStore({ projectDir, globalDir }: IndexedRepor
   }
 
   async function remove(id: string): Promise<boolean> {
-    const liveRemoved = (await project.remove(id)) || (await global.remove(id));
+    // 三处各自删、不能短路:同一 id 可能在项目与全局都有副本(旧数据迁移期最常见),
+    // 用 `||` 会在删掉项目那份后短路、漏删全局那份,下次 list 全局同 id 又浮出来(DELETE 返 200 但 id 复活)。
+    const projectRemoved = await project.remove(id);
+    const globalRemoved = await global.remove(id);
+    const cardRemoved = removeReportCard(id);
     // 真身在别项目删不到,但删卡片即让它从机器级 list 消失。返回契约刻意是「是否从本机器级视图移除成功」
     // (= 删了真身或删了卡片),而非「删了正文真身」—— studio DELETE 的语义是「从我的总览拿掉这条」,
     // 别项目正文留在它自己项目里不受影响。
-    const cardRemoved = removeReportCard(id);
-    return liveRemoved || cardRemoved;
+    return projectRemoved || globalRemoved || cardRemoved;
   }
 
   async function findByVariant(variantName: string): Promise<EvaluationReport[]> {

--- a/src/server/indexed-report-store.ts
+++ b/src/server/indexed-report-store.ts
@@ -10,8 +10,8 @@
  * 可比性红线在比较层(verdict / findByVariant 锁同口径)而非视图层,故跨项目 merge 列表合法。
  * by-id 复用 / resume / gold-compare 仍走 overlay(当前项目→全局),不走本 store —— 索引只供 studio 浏览。
  */
-import { existsSync, statSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { existsSync, statSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { createFileStore } from './report-store.js';
 import { artifactIndexDir, listReportCards, cardToReportDocument, removeReportCard } from '../eval-core/artifact-index.js';
 import type { ReportDocument, ReportStore, EvaluationReport } from '../types/index.js';
@@ -31,16 +31,26 @@ export function createIndexedReportStore({ projectDir, globalDir }: IndexedRepor
   const project = createFileStore(projectDir);
   const global = createFileStore(globalDir);
 
-  // 卡片扫描的轻量指纹缓存:索引目录 mtime + 条目数变化即失效(卡片 tmp+rename 写入会动目录 mtime)。
+  // 卡片扫描的指纹缓存:目录 mtime + 每张卡片(名:mtime:size)三元组 —— 与 createFileStore 同口径(report-store.ts:79)。
+  // 仅用目录 mtime 不够:同毫秒内改卡片内容 / mtime 精度问题会漏失效、发陈旧;三元组到单文件粒度,内容一变即失效。
   // live 两源各自带 report-store 的指纹缓存,这里只缓存卡片层。
   let cachedFp = '';
   let cachedCards: ReportDocument[] | null = null;
-  function cardDocs(): ReportDocument[] {
+  function cardFingerprint(): string {
     const dir = artifactIndexDir('report');
-    let fp = 'none';
     try {
-      if (existsSync(dir)) fp = `${statSync(dir).mtimeMs}`;
-    } catch { /* fall through */ }
+      if (!existsSync(dir)) return 'none';
+      const files = readdirSync(dir).filter((f) => f.endsWith('.json') && !f.includes('.json.tmp.')).sort();
+      const parts = files.map((f) => {
+        try { const s = statSync(join(dir, f)); return `${f}:${s.mtimeMs}:${s.size}`; } catch { return `${f}:?`; }
+      });
+      return `${statSync(dir).mtimeMs}|${parts.join(',')}`;
+    } catch {
+      return 'none';
+    }
+  }
+  function cardDocs(): ReportDocument[] {
+    const fp = cardFingerprint();
     if (fp === cachedFp && cachedCards) return cachedCards;
     const docs = listReportCards().map(cardToReportDocument);
     cachedFp = fp;
@@ -87,7 +97,9 @@ export function createIndexedReportStore({ projectDir, globalDir }: IndexedRepor
 
   async function remove(id: string): Promise<boolean> {
     const liveRemoved = (await project.remove(id)) || (await global.remove(id));
-    // 真身可能在别项目删不到,但删卡片即让它从机器级 list 消失(达成「从总览移除」意图)。
+    // 真身在别项目删不到,但删卡片即让它从机器级 list 消失。返回契约刻意是「是否从本机器级视图移除成功」
+    // (= 删了真身或删了卡片),而非「删了正文真身」—— studio DELETE 的语义是「从我的总览拿掉这条」,
+    // 别项目正文留在它自己项目里不受影响。
     const cardRemoved = removeReportCard(id);
     return liveRemoved || cardRemoved;
   }

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -18,7 +18,8 @@ import { resolveObserveHealthDir, projectObserveHealthDir, resolveDoctorsDir, pr
 import { buildSkillIndex } from './skill-index.js';
 import type { Lang } from '../types/index.js';
 import { createFileJobStore } from './job-store.js';
-import { createFileStore, createOverlayReportStore, queryJob, queryJobList, queryRun, queryRunList, queryTrend } from './report-store.js';
+import { createFileStore, queryJob, queryJobList, queryRun, queryRunList, queryTrend } from './report-store.js';
+import { createIndexedReportStore } from './indexed-report-store.js';
 import type { JobStore, ReportStore, DoctorReport } from '../types/index.js';
 import { confidenceOf, type SkillHealthReport } from '../observability/skill-health-analyzer.js';
 import { DEFAULT_OBSERVATIONS_DIR, findObservationInboxItem, formatObservationShow, queryObservationInbox } from '../observability/inbox.js';
@@ -614,13 +615,12 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
   let serverUrl: string | null = null;
 
   // reports store:显式注入 store > 显式 reportsDir(eval serve 的本次 outputDir / 测试 / 覆盖,固定单目录)
-  // > 缺省 overlay(项目 .omk/reports 盖全局,studio 默认看当前项目、存量全局兜底)。overlay 在 store 层做
-  // 记录优先 + 按 id 兜底,故无需像 analyses/doctors 那样每请求重解析(底层 createFileStore 的 mtime 指纹
-  // 自动反映内容变化),一次构建即可。
+  // > 缺省 indexed(机器级总览:当前项目 + 全局 live ∪ 别项目的索引卡片,按 id dedup)。indexed 在 store 层做
+  // merge,底层 createFileStore 的 mtime 指纹自动反映内容变化,一次构建即可。
   const reportStore: ReportStore = store
     ?? (reportsDir !== undefined
       ? createFileStore(reportsDir)
-      : createOverlayReportStore(projectReportsDir(), globalReportsDir()));
+      : createIndexedReportStore({ projectDir: projectReportsDir(), globalDir: globalReportsDir() }));
   const resolvedJobStore: JobStore = jobStore || createFileJobStore(jobsDir);
   // 受管根目录按**请求**解析,不在启动时冻结 —— 否则长会话里会跟 omk list 分叉:Studio 启动时项目 .omk/managed
   // 还空、回退到 global,随后用户在项目里首次 omk install,omk list 下次会切到 project,而冻结了 root 的 Studio

--- a/src/server/report-store.ts
+++ b/src/server/report-store.ts
@@ -6,7 +6,7 @@
 
 import { readdir, readFile, writeFile, unlink, access, mkdir, rename, stat } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { BatchEvaluationReport, EvaluationJob, EvaluationReport, JobStore, ReportDocument, ReportMeta, ReportStore, VariantSummary } from '../types/index.js';
+import type { EvaluationJob, EvaluationReport, JobStore, ReportDocument, ReportIndexCard, ReportMeta, ReportStore, VariantSummary } from '../types/index.js';
 
 // Per-id in-memory mutex for safe read-modify-write.
 // Uses a queue to avoid the race window between checking and acquiring the lock.
@@ -284,13 +284,9 @@ export async function queryJob(jobStore: JobStore, id: string): Promise<Evaluati
   return jobStore.get(id);
 }
 
-export interface RunListItem {
-  id: string;
-  kind: ReportDocument['kind'];
-  meta: ReportDocument['meta'];
-  summary?: EvaluationReport['summary'];
-  items?: BatchEvaluationReport['items'];
-}
+// 与 ReportIndexCard(types/report.ts)同形,去掉 domain 判别与 path 寻址字段:索引卡片即「带寻址信息的
+// RunListItem」,两边共用一处形状定义,避免字段漂移。
+export type RunListItem = Omit<ReportIndexCard, 'domain' | 'path'>;
 
 export interface TrendPoint {
   reportId: string;

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -181,13 +181,6 @@ function buildEvalSnapshot(report: EvaluationReport, variant: string): SkillEval
     else if (isTripwire) tripwire += 1;
     else fail += 1;
   }
-  // 别项目的报告以「索引卡片」形态进 studio(results 被剥掉只留 summary,见 indexed-report-store)。
-  // 此时上面逐样本累加全 0 → 列表会显「0/0 样本」。从 summary 的执行计数回填,使跨项目卡片也有真实样本数。
-  if (report.results.length === 0 && (summary.successCount || summary.errorCount || summary.totalSamples)) {
-    pass = summary.successCount ?? 0;
-    fail = summary.errorCount ?? 0;
-    tripwire = 0;
-  }
 
   // verdict 是运行期计算的,不进 report,这里现算。
   // multi-treatment 报告:computeVerdict 顶层 level 是 worst-of perPair,headline 也是
@@ -217,7 +210,10 @@ function buildEvalSnapshot(report: EvaluationReport, variant: string): SkillEval
     passCount: pass,
     failCount: fail,
     tripwireCount: tripwire,
-    totalSamples: pass + fail + tripwire,
+    // 别项目以「索引卡片」进 studio 时 results 被剥掉(pass/fail 逐样本断言分布不可得,留 0);但 totalSamples
+    // 用 summary 的真实样本数,避免显「0 样本」。卡片的可信信号是 compositeScore + verdict(均来自 summary/meta)。
+    // 不把 summary.successCount(执行成功)当 pass(断言通过)回填 —— 两者语义不同,会让列表误读。
+    totalSamples: report.results.length === 0 ? (summary.totalSamples ?? 0) : pass + fail + tripwire,
   };
 }
 

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -181,6 +181,13 @@ function buildEvalSnapshot(report: EvaluationReport, variant: string): SkillEval
     else if (isTripwire) tripwire += 1;
     else fail += 1;
   }
+  // 别项目的报告以「索引卡片」形态进 studio(results 被剥掉只留 summary,见 indexed-report-store)。
+  // 此时上面逐样本累加全 0 → 列表会显「0/0 样本」。从 summary 的执行计数回填,使跨项目卡片也有真实样本数。
+  if (report.results.length === 0 && (summary.successCount || summary.errorCount || summary.totalSamples)) {
+    pass = summary.successCount ?? 0;
+    fail = summary.errorCount ?? 0;
+    tripwire = 0;
+  }
 
   // verdict 是运行期计算的,不进 report,这里现算。
   // multi-treatment 报告:computeVerdict 顶层 level 是 worst-of perPair,headline 也是

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -214,6 +214,8 @@ function buildEvalSnapshot(report: EvaluationReport, variant: string): SkillEval
     // 用 summary 的真实样本数,避免显「0 样本」。卡片的可信信号是 compositeScore + verdict(均来自 summary/meta)。
     // 不把 summary.successCount(执行成功)当 pass(断言通过)回填 —— 两者语义不同,会让列表误读。
     totalSamples: report.results.length === 0 ? (summary.totalSamples ?? 0) : pass + fail + tripwire,
+    // 标记卡片来源:渲染端据此不把 pass/fail=0 当真实通过率(否则 failCount===0 会误判绿带「全通过」+「0% pass」同屏自相矛盾)。
+    ...(report.results.length === 0 ? { resultsStripped: true } : {}),
   };
 }
 

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -406,6 +406,22 @@ export interface BatchEvaluationReport {
 
 export type ReportDocument = EvaluationReport | BatchEvaluationReport;
 
+/**
+ * 产物发现索引卡片(report 域)。报告正文(含 results 逐样本重体)永远单份留项目本地;全局
+ * `state/artifact-index/report/` 下存这张轻卡片(meta + summary,无 results),`path` 指向真身绝对路径。
+ * `omk studio` 读「卡片(覆盖别项目)∪ live-scan(当前项目+全局)」聚合成机器级总览,详情按 `path` 读真身。
+ * 字段与 server 的 `RunListItem` 同形(后者复用本类型投影),多 `domain` 判别 + `path` 寻址。
+ */
+export interface ReportIndexCard {
+  domain: 'report';
+  id: string;
+  path: string;
+  kind: ReportDocument['kind'];
+  meta: ReportDocument['meta'];
+  summary?: EvaluationReport['summary'];
+  items?: BatchEvaluationReport['items'];
+}
+
 /** 报告级 analysis insight(report-diagnostics 产出,跟 SkillIndex 的 audience-aware
  *  `Insight` 不同 — 这条只有 type / severity / details 三字段,挂在 AnalysisResult.insights 下,
  *  用于 evaluation 报告的「分析」面板,跟 Studio skill 健康洞察是两套语义)。 */

--- a/src/types/skill-index.ts
+++ b/src/types/skill-index.ts
@@ -29,6 +29,9 @@ export interface SkillEvalSnapshot {
   failCount: number;
   tripwireCount: number;
   totalSamples: number;
+  /** 该快照来自别项目的「索引卡片」(results 被剥掉,逐样本断言分布不可得),passCount/failCount 留 0
+   *  仅占位、不代表真实通过率。渲染端据此用占位替代 0% pass / 全通过 / 0-of-N 等会误读的派生量。 */
+  resultsStripped?: boolean;
 }
 
 export interface SkillObserveSnapshot {

--- a/test/__snapshots__/html-renderer.test.ts.snap
+++ b/test/__snapshots__/html-renderer.test.ts.snap
@@ -464,7 +464,7 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
     <div class="rs-hero-left">
       <div class="rs-hero-kind"><span class="rs-hero-icon" style="color:#7c3aed"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 11l2 2 4-4"/></svg></span> Eval Report</div>
       <h1 class="rs-hero-name">v2</h1>
-      <div class="rs-hero-meta"><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> [TIMESTAMP]</span><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="3"/><path d="M8 12h8"/></svg> sonnet</span><span>test-run-20260325-1000</span></div>
+      <div class="rs-hero-meta"><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> [TIMESTAMP]</span><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="3"/><path d="M8 12h8"/></svg> sonnet</span><span>test-run-20260325-100000-abcd</span></div>
     </div>
     <div class="rs-hero-score">
       <div class="rs-hero-num" style="color:#1f9d63">4.80</div>
@@ -1610,7 +1610,7 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
     <div class="rs-hero-left">
       <div class="rs-hero-kind"><span class="rs-hero-icon" style="color:#7c3aed"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 11l2 2 4-4"/></svg></span> 用例评测报告</div>
       <h1 class="rs-hero-name">v2</h1>
-      <div class="rs-hero-meta"><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> [TIMESTAMP]</span><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="3"/><path d="M8 12h8"/></svg> sonnet</span><span>test-run-20260325-1000</span></div>
+      <div class="rs-hero-meta"><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> [TIMESTAMP]</span><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="3"/><path d="M8 12h8"/></svg> sonnet</span><span>test-run-20260325-100000-abcd</span></div>
     </div>
     <div class="rs-hero-score">
       <div class="rs-hero-num" style="color:#1f9d63">4.80</div>
@@ -2771,17 +2771,17 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
       <p style="font-size:11px;color:var(--text-muted);margin:14px 0 0;line-height:1.6">Full derivation / five-layer scoring pipeline / multi-layer gate & composite relationship: <a href="https://github.com/lizhiyao/oh-my-knowledge/blob/main/docs/specs/scoring.md" target="_blank" rel="noopener">docs/specs/scoring.md</a></p>
     </div>
   </div>
-    <div id="run-list" class="run-list"><a class="run-card verdict-CAUTIOUS" href="/reports/test-run-20260325-1000?lang=en">
+    <div id="run-list" class="run-list"><a class="run-card verdict-CAUTIOUS" href="/reports/test-run-20260325-100000-abcd?lang=en">
       <div class="run-card-h">
         <span class="run-status verdict-CAUTIOUS" title="Treatment slightly above control — small gap or layer below gate" aria-label="CAUTIOUS — Treatment slightly above control — small gap or layer below gate"><span class="run-status-dot" aria-hidden="true">▲</span>CAUTIOUS</span>
-        <span class="run-card-id">test-run-20260325-1000</span>
+        <span class="run-card-id">test-run-20260325-100000-abcd</span>
         <span class="run-card-date">03/25 10:00</span>
       </div>
       <div class="run-card-meta">sonnet · 2 samples · v1 · v2</div>
       <div class="run-card-scores"><div class="rc-score-row"><span class="rc-score-label" title="v1">v1</span><div class="rc-score-bar"><div class="rc-score-bar-fill rc-score-bar-fill--pass" style="width:80%"></div></div><span class="rc-score-num rc-score-num--pass">4.00</span></div><div class="rc-score-row"><span class="rc-score-label" title="v2">v2</span><div class="rc-score-bar"><div class="rc-score-bar-fill rc-score-bar-fill--pass" style="width:96%"></div></div><span class="rc-score-num rc-score-num--pass">4.80</span></div></div>
       <div class="run-card-foot">
         <span class="run-card-stat">10.0s</span>
-        <button class="run-card-delete" onclick="event.preventDefault();event.stopPropagation();deleteRun('test-run-20260325-1000',this)" data-i18n="deleteBtnText" aria-label="Delete">×</button>
+        <button class="run-card-delete" onclick="event.preventDefault();event.stopPropagation();deleteRun('test-run-20260325-100000-abcd',this)" data-i18n="deleteBtnText" aria-label="Delete">×</button>
       </div>
     </a></div>
     <style>
@@ -3368,17 +3368,17 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
       <p style="font-size:11px;color:var(--text-muted);margin:14px 0 0;line-height:1.6">完整推导 / 五层评分管道架构 / 多层 gate 与综合分的关系：<a href="https://github.com/lizhiyao/oh-my-knowledge/blob/main/docs/zh/specs/scoring.md" target="_blank" rel="noopener">docs/zh/specs/scoring.md</a></p>
     </div>
   </div>
-    <div id="run-list" class="run-list"><a class="run-card verdict-CAUTIOUS" href="/reports/test-run-20260325-1000">
+    <div id="run-list" class="run-list"><a class="run-card verdict-CAUTIOUS" href="/reports/test-run-20260325-100000-abcd">
       <div class="run-card-h">
         <span class="run-status verdict-CAUTIOUS" title="实验组略优于对照组,但差距小或某层未达 gate" aria-label="略微进步 — 实验组略优于对照组,但差距小或某层未达 gate"><span class="run-status-dot" aria-hidden="true">▲</span>略微进步</span>
-        <span class="run-card-id">test-run-20260325-1000</span>
+        <span class="run-card-id">test-run-20260325-100000-abcd</span>
         <span class="run-card-date">03/25 10:00</span>
       </div>
       <div class="run-card-meta">sonnet · 2 用例 · v1 · v2</div>
       <div class="run-card-scores"><div class="rc-score-row"><span class="rc-score-label" title="v1">v1</span><div class="rc-score-bar"><div class="rc-score-bar-fill rc-score-bar-fill--pass" style="width:80%"></div></div><span class="rc-score-num rc-score-num--pass">4.00</span></div><div class="rc-score-row"><span class="rc-score-label" title="v2">v2</span><div class="rc-score-bar"><div class="rc-score-bar-fill rc-score-bar-fill--pass" style="width:96%"></div></div><span class="rc-score-num rc-score-num--pass">4.80</span></div></div>
       <div class="run-card-foot">
         <span class="run-card-stat">10.0s</span>
-        <button class="run-card-delete" onclick="event.preventDefault();event.stopPropagation();deleteRun('test-run-20260325-1000',this)" data-i18n="deleteBtnText" aria-label="删除">×</button>
+        <button class="run-card-delete" onclick="event.preventDefault();event.stopPropagation();deleteRun('test-run-20260325-100000-abcd',this)" data-i18n="deleteBtnText" aria-label="删除">×</button>
       </div>
     </a></div>
     <style>

--- a/test/cli/reports-output-dir.test.ts
+++ b/test/cli/reports-output-dir.test.ts
@@ -10,6 +10,7 @@ import assert from 'node:assert/strict';
 import { join } from 'node:path';
 import { parseRunConfig } from '../../src/cli/lib/parse-run-config.js';
 import { globalReportsDir, projectReportsDir } from '../../src/eval-core/measurement-dirs.js';
+import { OMK_HOME } from '../../src/eval-core/default-dirs.js';
 
 const BASE_FLAGS = {
   'skill-dir': 'examples/code-review/skills',
@@ -28,7 +29,8 @@ describe('eval 报告写入默认目录', () => {
   it('--global → 全局 reports', () => {
     const { config } = parseRunConfig({ ...BASE_FLAGS, global: true });
     assert.equal(config.outputDir, globalReportsDir());
-    assert.ok(config.outputDir.endsWith(join('.oh-my-knowledge', 'reports')));
+    // 全局目录从 OMK_HOME 派生(可被 env 整体重定向),不硬编码 .oh-my-knowledge。
+    assert.equal(config.outputDir, join(OMK_HOME, 'reports'));
   });
 
   it('--output-dir 最高优先(压过默认与 --global)', () => {

--- a/test/eval-core/artifact-index.test.ts
+++ b/test/eval-core/artifact-index.test.ts
@@ -4,11 +4,11 @@
  */
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
-  indexReportWrite, listReportCards, cardToReportDocument, removeReportCard, shouldIndexReport,
+  indexReportWrite, listReportCards, cardToReportDocument, removeReportCard, shouldIndexReport, artifactIndexDir,
 } from '../../src/eval-core/artifact-index.js';
 import { globalReportsDir } from '../../src/eval-core/measurement-dirs.js';
 
@@ -77,5 +77,16 @@ describe('artifact-index 写侧(report 域)', () => {
   it('非完整报告(无 canonical kind)防御式跳过,不落卡片', () => {
     indexReportWrite({ id: 'bare' }, join(projDir, 'bare.json'), projDir);
     assert.equal(listReportCards().length, 0);
+  });
+
+  it('坏 kind 卡片(拼错 / doctor)读侧跳过,不污染机器级 list', () => {
+    indexReportWrite(makeEvalReport('good') as never, join(projDir, 'good.json'), projDir);
+    // 直接写一张 kind 不在白名单的卡片(绕过写侧 guard,模拟脏文件 / 别域误落本目录)
+    const dir = artifactIndexDir('report');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'bad.json'), JSON.stringify({
+      domain: 'report', id: 'bad', path: join(projDir, 'bad.json'), kind: 'doctor', meta: { timestamp: '2026-06-14T00:00:00Z' },
+    }));
+    assert.deepEqual(listReportCards().map((c) => c.id), ['good'], '只收白名单 kind,坏卡片跳过');
   });
 });

--- a/test/eval-core/artifact-index.test.ts
+++ b/test/eval-core/artifact-index.test.ts
@@ -1,0 +1,81 @@
+/**
+ * 产物发现索引(report 域)写侧验收:项目写落卡片、全局写跳过、卡片投影、删除幂等、防御式跳过。
+ * 全程把 OMK_ARTIFACT_INDEX_DIR 指到 per-test temp 目录,不碰真实 ~/.oh-my-knowledge/state。
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  indexReportWrite, listReportCards, cardToReportDocument, removeReportCard, shouldIndexReport,
+} from '../../src/eval-core/artifact-index.js';
+import { globalReportsDir } from '../../src/eval-core/measurement-dirs.js';
+
+function makeEvalReport(id: string, variant = 'v1', hash = 'h1'): Record<string, unknown> {
+  return {
+    kind: 'evaluation',
+    id,
+    meta: { timestamp: '2026-06-14T00:00:00Z', variants: [variant], artifactHashes: { [variant]: hash } },
+    summary: { [variant]: { totalSamples: 3, successCount: 2, errorCount: 1 } },
+    results: [{ sample_id: 's1', variants: {} }],
+  };
+}
+
+describe('artifact-index 写侧(report 域)', () => {
+  let indexRoot: string;
+  let projDir: string;
+  let origEnv: string | undefined;
+
+  beforeEach(() => {
+    origEnv = process.env.OMK_ARTIFACT_INDEX_DIR;
+    indexRoot = mkdtempSync(join(tmpdir(), 'omk-ai-idx-'));
+    projDir = mkdtempSync(join(tmpdir(), 'omk-ai-proj-'));
+    process.env.OMK_ARTIFACT_INDEX_DIR = indexRoot;
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.OMK_ARTIFACT_INDEX_DIR;
+    else process.env.OMK_ARTIFACT_INDEX_DIR = origEnv;
+    rmSync(indexRoot, { recursive: true, force: true });
+    rmSync(projDir, { recursive: true, force: true });
+  });
+
+  it('项目写 → 落卡片(无 results),含 id/path/kind/meta/summary', () => {
+    const filePath = join(projDir, 'r1.json');
+    indexReportWrite(makeEvalReport('r1') as never, filePath, projDir);
+    const cards = listReportCards();
+    assert.equal(cards.length, 1);
+    assert.equal(cards[0].id, 'r1');
+    assert.equal(cards[0].path, filePath);
+    assert.equal(cards[0].domain, 'report');
+    assert.equal(cards[0].kind, 'evaluation');
+    assert.ok(cards[0].summary?.v1, '卡片含 summary');
+    assert.ok(!('results' in cards[0]), '卡片不含 results 重体');
+  });
+
+  it('全局写 → 不落卡片(shouldIndexReport false,全局靠 live-scan 覆盖)', () => {
+    assert.equal(shouldIndexReport(globalReportsDir()), false);
+    indexReportWrite(makeEvalReport('rg') as never, join(globalReportsDir(), 'rg.json'), globalReportsDir());
+    assert.equal(listReportCards().length, 0);
+  });
+
+  it('cardToReportDocument:卡片 → results:[] 文档(供 list/trend 消费)', () => {
+    indexReportWrite(makeEvalReport('r2') as never, join(projDir, 'r2.json'), projDir);
+    const doc = cardToReportDocument(listReportCards()[0]);
+    assert.equal(doc.kind, 'evaluation');
+    assert.deepEqual(doc.kind === 'evaluation' ? doc.results : null, []);
+  });
+
+  it('removeReportCard:删卡片幂等', () => {
+    indexReportWrite(makeEvalReport('r3') as never, join(projDir, 'r3.json'), projDir);
+    assert.equal(removeReportCard('r3'), true);
+    assert.equal(listReportCards().length, 0);
+    assert.equal(removeReportCard('r3'), false, '再删返回 false(幂等)');
+  });
+
+  it('非完整报告(无 canonical kind)防御式跳过,不落卡片', () => {
+    indexReportWrite({ id: 'bare' }, join(projDir, 'bare.json'), projDir);
+    assert.equal(listReportCards().length, 0);
+  });
+});

--- a/test/eval-core/home-isolation.test.ts
+++ b/test/eval-core/home-isolation.test.ts
@@ -1,0 +1,28 @@
+/**
+ * 测试隔离守卫:vitest.config 用 OMK_HOME 把整棵默认产物树重定向到临时目录后,
+ * 全局测量目录(reports / doctors / observe-health / state)必须都落在 temp,绝不指向真实 ~/.oh-my-knowledge。
+ * 这道断言把「一处 OMK_HOME 隔离整棵树」的接线钉死:谁日后改回写死 home / 漏了 env 接线,这里立刻红。
+ * 防的是「从注入不进的深层调用点写全局默认目录、静默污染开发者真实 home」那类回归。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { OMK_HOME } from '../../src/eval-core/default-dirs.js';
+import { globalReportsDir } from '../../src/eval-core/measurement-dirs.js';
+import { globalObserveHealthDir, globalDoctorsDir } from '../../src/eval-core/measurement-dirs.js';
+
+describe('OMK_HOME 测试隔离守卫', () => {
+  const realHome = join(homedir(), '.oh-my-knowledge');
+
+  it('OMK_HOME 被 vitest env 重定向,不等于真实 ~/.oh-my-knowledge', () => {
+    assert.notEqual(OMK_HOME, realHome, 'OMK_HOME 应指向 temp,而非真实 home');
+  });
+
+  it('全局测量目录(reports / doctors / observe-health)都不落真实 home', () => {
+    for (const d of [globalReportsDir(), globalDoctorsDir(), globalObserveHealthDir()]) {
+      assert.ok(!d.startsWith(realHome), `${d} 不得指向真实 ~/.oh-my-knowledge`);
+      assert.ok(d.startsWith(OMK_HOME), `${d} 应从重定向后的 OMK_HOME 派生`);
+    }
+  });
+});

--- a/test/eval-core/measurement-dirs.test.ts
+++ b/test/eval-core/measurement-dirs.test.ts
@@ -8,6 +8,7 @@ import {
   projectDoctorsDir, globalDoctorsDir, resolveDoctorsDir,
   projectReportsDir, globalReportsDir,
 } from '../../src/eval-core/measurement-dirs.js';
+import { OMK_HOME } from '../../src/eval-core/default-dirs.js';
 
 function mkTmp(tag: string): string {
   const d = join(tmpdir(), `omk-mdir-${tag}-${Date.now()}-${Math.round(performance.now())}`);
@@ -20,9 +21,10 @@ describe('measurement-dirs 项目优先→全局兜底(记录优先)', () => {
     assert.equal(projectObserveHealthDir('/x'), join('/x', '.omk', 'observe-health'));
     assert.equal(projectDoctorsDir('/x'), join('/x', '.omk', 'doctors'));
     assert.equal(projectReportsDir('/x'), join('/x', '.omk', 'reports'));
-    assert.ok(globalObserveHealthDir().endsWith(join('.oh-my-knowledge', 'observe-health')));
-    assert.ok(globalDoctorsDir().endsWith(join('.oh-my-knowledge', 'doctors')));
-    assert.ok(globalReportsDir().endsWith(join('.oh-my-knowledge', 'reports')));
+    // 全局目录从 OMK_HOME 派生(OMK_HOME 可被 env 整体重定向,故不硬编码 .oh-my-knowledge)。
+    assert.equal(globalObserveHealthDir(), join(OMK_HOME, 'observe-health'));
+    assert.equal(globalDoctorsDir(), join(OMK_HOME, 'doctors'));
+    assert.equal(globalReportsDir(), join(OMK_HOME, 'reports'));
   });
 
   it('reports 不给 resolveReportsDir(记录优先在 overlay store 层做,见 report-store)', () => {

--- a/test/eval-core/report-variant-keys.golden.test.ts
+++ b/test/eval-core/report-variant-keys.golden.test.ts
@@ -292,8 +292,15 @@ describe('GOLDEN report variant keys', () => {
   });
 
   it('generateRunId encodes variant names in order, sanitized', () => {
-    assert.match(generateRunId(['baseline', 'greeter']), /^baseline-vs-greeter-\d{8}-\d{4}$/);
-    assert.match(generateRunId(['v1/greeter', 'v2/greeter']), /^v1-greeter-vs-v2-greeter-\d{8}-\d{4}$/);
-    assert.match(generateRunId(['git:HEAD:greeter']), /^git-HEAD-greeter-\d{8}-\d{4}$/);
+    // 格式:<variants>-<YYYYMMDD>-<HHmmss>-<rand4>。秒 + 4 位随机后缀保证跨项目 / 同分钟重跑全局唯一。
+    assert.match(generateRunId(['baseline', 'greeter']), /^baseline-vs-greeter-\d{8}-\d{6}-[a-z0-9]{4}$/);
+    assert.match(generateRunId(['v1/greeter', 'v2/greeter']), /^v1-greeter-vs-v2-greeter-\d{8}-\d{6}-[a-z0-9]{4}$/);
+    assert.match(generateRunId(['git:HEAD:greeter']), /^git-HEAD-greeter-\d{8}-\d{6}-[a-z0-9]{4}$/);
+  });
+
+  it('generateRunId 同时刻两次产出不同 id(撞名根治)', () => {
+    const a = generateRunId(['baseline', 'greeter']);
+    const b = generateRunId(['baseline', 'greeter']);
+    assert.notEqual(a, b, '随机后缀应让同一时刻两次 run 的 id 不同');
   });
 });

--- a/test/evaluation/execution-strategy.test.ts
+++ b/test/evaluation/execution-strategy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { buildVariantConfig, resolveExecutionStrategy } from '../../src/eval-core/execution-strategy.js';
+import { DEFAULT_ISOLATED_CWD_DIR } from '../../src/eval-core/default-dirs.js';
 import type { Artifact, Task } from '../../src/types/index.js';
 
 function mockTask(kind: string, content: string | null = 'skill content'): Task {
@@ -87,8 +88,9 @@ describe('resolveExecutionStrategy', () => {
     t.artifact.allowedSkills = [];
     t.cwd = null;
     const plan = resolveExecutionStrategy(t, 'sonnet');
-    assert.ok(plan.input.cwd?.includes('.oh-my-knowledge/state/isolated-cwd'),
-      `cwd should be isolated, got: ${plan.input.cwd}`);
+    // isolated cwd 落在 state/isolated-cwd 下(从 OMK_HOME 派生,可被 env 整体重定向,不硬编码真实 home)。
+    assert.ok(plan.input.cwd?.startsWith(DEFAULT_ISOLATED_CWD_DIR),
+      `cwd should be isolated under ${DEFAULT_ISOLATED_CWD_DIR}, got: ${plan.input.cwd}`);
   });
 
   it('strict baseline 但用户显式给 cwd → 不动用户 cwd(用户自己负责)', () => {

--- a/test/evolver.test.ts
+++ b/test/evolver.test.ts
@@ -67,8 +67,8 @@ describe('mergeEvolveReports', () => {
     // totalCostUSD
     assert.equal(merged.meta.totalCostUSD, 1.5);
 
-    // id starts with evolve-
-    assert.ok(merged.id.startsWith('evolve-test-skill-'));
+    // id = evolve-<skill>-YYYYMMDD-HHmmss-rand4(含日期,可追溯 / 可扫读)
+    assert.match(merged.id, /^evolve-test-skill-\d{8}-\d{6}-[a-z0-9]{4}$/);
   });
 
   it('单轮（仅 baseline）也能正常生成报告', () => {

--- a/test/html-renderer.test.ts
+++ b/test/html-renderer.test.ts
@@ -14,10 +14,10 @@ function normalizeForSnapshot(html: string): string {
 
 const SAMPLE_REPORT: Report = {
   kind: 'evaluation',
-  // 让 id 匹配 renderRunList 里的 YYYYMMDD-HHmm regex (html-renderer.ts:62),
-  // 这样列表页 row 的时间从 id 直接提取 (deterministic), 不走 toLocaleString
-  // — 后者本地时区敏感, 会让 snapshot 在 CI UTC 和本地 CST 之间不一致.
-  id: 'test-run-20260325-1000',
+  // 用生产 id 格式 YYYYMMDD-HHmmss-rand4(含秒+随机),让列表页 row 时间走 formatDateFromId
+  // 的 id 直接提取路径 (deterministic, 不走时区敏感的 toLocaleString — 后者会让 snapshot 在 CI UTC
+  // 和本地 CST 之间不一致)。秒段在展示时被丢弃,派生出的 MM/DD HH:MM 与旧格式一致,快照稳定。
+  id: 'test-run-20260325-100000-abcd',
   meta: {
     variants: ['v1', 'v2'],
     model: 'sonnet',

--- a/test/renderer/card-shell-eval-render.test.ts
+++ b/test/renderer/card-shell-eval-render.test.ts
@@ -1,0 +1,49 @@
+/**
+ * 别项目「索引卡片」(resultsStripped)进 studio 详情时的渲染口径守卫。
+ * 卡片 results 被剥掉 → passCount/failCount 留 0,但 totalSamples / compositeScore / verdict 真实。
+ * 渲染端不能让 failCount===0 误判绿带「所有用例通过」、也不能显「0% 通过」—— 与同屏综合分自相矛盾。
+ * 改成:eval section 用占位「明细在源项目」替代通过率,色带按 compositeScore 定(非按 pass/fail)。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { renderSkillDetail } from '../../src/renderer/skill-detail-renderer.js';
+import type { SkillIndexEntry } from '../../src/types/skill-index.js';
+
+function cardShellEntry(): SkillIndexEntry {
+  return {
+    skillName: 'cross-project-skill',
+    doctor: null,
+    eval: {
+      reportId: 'baseline-vs-x-20260614-141600-ab12',
+      timestamp: '2026-06-14T14:16:00Z',
+      variantName: 'x',
+      verdictLevel: 'PROGRESS',
+      verdictHeadline: '处理更稳',
+      compositeScore: 4.3, // 可信:来自 summary
+      passCount: 0, // 卡片剥空,占位
+      failCount: 0,
+      tripwireCount: 0,
+      totalSamples: 3, // 来自 summary.totalSamples
+      resultsStripped: true,
+    },
+    observe: null,
+    doctorHistory: [],
+    evalHistory: [],
+    observeHistory: [],
+    band: 'green',
+  } as unknown as SkillIndexEntry;
+}
+
+describe('索引卡片 eval section 渲染口径', () => {
+  it('不显「0% 通过」、不显「所有用例通过」,改显「明细在源项目」占位', () => {
+    const html = renderSkillDetail(cardShellEntry(), null, 'zh');
+    assert.doesNotMatch(html, /0% 通过/, 'pass/fail 剥空时不得显 0% 通过');
+    assert.doesNotMatch(html, /所有用例通过/, 'failCount===0 不得误判全通过');
+    assert.match(html, /明细在源项目|逐样本明细需在源项目查看/, '给出明细需回源项目的占位');
+  });
+
+  it('totalSamples 真实显示(不退化成 0 用例)', () => {
+    const html = renderSkillDetail(cardShellEntry(), null, 'zh');
+    assert.match(html, /3 用例/, 'totalSamples 用 summary 真实样本数');
+  });
+});

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -37,7 +37,9 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   // —— 持久化 report schema（Report JSON 字段语义，CLAUDE.md 列明的不变量）——
   "src/types/report.ts::EvaluationReport::'evaluation'",
   "src/types/report.ts::BatchEvaluationReport::'batch-evaluation'",
-  "src/server/report-store.ts::RunListItem::ReportDocument['kind']",
+  // ReportIndexCard 是产物发现索引卡片,kind 镜像 ReportDocument['kind'](evaluation/batch-evaluation)同
+  // 持久化 report 顶层 kind;RunListItem 现复用其投影(Omit),kind 声明点从 RunListItem 移到此处。
+  "src/types/report.ts::ReportIndexCard::ReportDocument['kind']",
   "src/types/doctor.ts::DoctorReport::'doctor'",
   "src/types/observability.ts::ObservationReviewState::'observe-review-state'",
   "src/types/observability.ts::ObservationInboxReport::'observe-inbox'",

--- a/test/server/indexed-report-store.test.ts
+++ b/test/server/indexed-report-store.test.ts
@@ -116,4 +116,14 @@ describe('createIndexedReportStore 机器级总览', () => {
     assert.equal(await store.remove('ro'), true, '别项目删卡片即成功');
     assert.deepEqual((await store.list()).map((r) => r.id), []);
   });
+
+  it('remove:同一 id 在项目与全局都有副本(迁移期) → 两份都删、不短路,删后 list/get 都不再命中', async () => {
+    writeReportFile(proj, evalDoc('dup'));
+    writeReportFile(glob, evalDoc('dup'));
+    const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
+    assert.equal((await store.list()).filter((r) => r.id === 'dup').length, 1, 'dedup 后只一条');
+    assert.equal(await store.remove('dup'), true);
+    assert.equal(await store.get('dup'), null, 'remove 后 get 不再命中(全局副本未被 || 短路漏删)');
+    assert.deepEqual((await store.list()).map((r) => r.id), [], 'list 不再浮出全局同 id');
+  });
 });

--- a/test/server/indexed-report-store.test.ts
+++ b/test/server/indexed-report-store.test.ts
@@ -99,6 +99,15 @@ describe('createIndexedReportStore 机器级总览', () => {
     assert.equal((await store.findByArtifactHash('ho')).length, 1);
   });
 
+  it('卡片缓存按 per-file 指纹失效:构造 store 后再写/删卡片,list 立即反映', async () => {
+    const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
+    assert.deepEqual((await store.list()).map((r) => r.id), [], '初始空');
+    writeCard('ro', join(other, 'ro.json'), evalDoc('ro')); // 构造后新增卡片
+    assert.deepEqual((await store.list()).map((r) => r.id), ['ro'], '新卡片立即可见(指纹失效)');
+    await store.remove('ro'); // 删卡片
+    assert.deepEqual((await store.list()).map((r) => r.id), [], '删后立即消失');
+  });
+
   it('remove:删 live 真身 + 删卡片;别项目删不到真身但删卡片仍报成功、从 list 消失', async () => {
     writeReportFile(proj, evalDoc('rp'));
     writeCard('ro', join(other, 'ro.json'), evalDoc('ro'));

--- a/test/server/indexed-report-store.test.ts
+++ b/test/server/indexed-report-store.test.ts
@@ -1,0 +1,110 @@
+/**
+ * createIndexedReportStore 机器级总览验收:当前项目 + 全局 live ∪ 别项目索引卡片,按 id dedup;
+ * get live 命中真身 / 别项目按卡片 path 读真身 / 悬空降级壳;findByVariant/Hash 跨项目;remove 删真身+卡片。
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createIndexedReportStore } from '../../src/server/indexed-report-store.js';
+import { artifactIndexDir } from '../../src/eval-core/artifact-index.js';
+
+interface MiniDoc { kind: 'evaluation'; id: string; meta: Record<string, unknown>; summary: Record<string, unknown>; results: unknown[]; }
+
+function evalDoc(id: string, variant = 'v1', hash = 'h1', ts = '2026-06-14T00:00:00Z'): MiniDoc {
+  return {
+    kind: 'evaluation',
+    id,
+    meta: { timestamp: ts, variants: [variant], artifactHashes: { [variant]: hash } },
+    summary: { [variant]: {} },
+    results: [{ sample_id: 's1', variants: {} }],
+  };
+}
+
+function writeReportFile(dir: string, doc: MiniDoc): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${doc.id}.json`), JSON.stringify(doc));
+}
+
+function writeCard(id: string, path: string, doc: MiniDoc): void {
+  const dir = artifactIndexDir('report');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${id}.json`), JSON.stringify({ domain: 'report', id, path, kind: doc.kind, meta: doc.meta, summary: doc.summary }));
+}
+
+describe('createIndexedReportStore 机器级总览', () => {
+  let proj: string;
+  let glob: string;
+  let other: string;
+  let idxRoot: string;
+  let origEnv: string | undefined;
+
+  beforeEach(() => {
+    origEnv = process.env.OMK_ARTIFACT_INDEX_DIR;
+    idxRoot = mkdtempSync(join(tmpdir(), 'omk-irs-idx-'));
+    process.env.OMK_ARTIFACT_INDEX_DIR = idxRoot;
+    proj = mkdtempSync(join(tmpdir(), 'omk-irs-proj-'));
+    glob = mkdtempSync(join(tmpdir(), 'omk-irs-glob-'));
+    other = mkdtempSync(join(tmpdir(), 'omk-irs-other-'));
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.OMK_ARTIFACT_INDEX_DIR;
+    else process.env.OMK_ARTIFACT_INDEX_DIR = origEnv;
+    for (const d of [idxRoot, proj, glob, other]) rmSync(d, { recursive: true, force: true });
+  });
+
+  it('list:当前项目 + 全局 live ∪ 别项目卡片,按 id dedup + 时序 desc', async () => {
+    writeReportFile(proj, evalDoc('rp', 'vp', 'hp', '2026-03-01T00:00:00Z'));
+    writeReportFile(glob, evalDoc('rg', 'vg', 'hg', '2026-02-01T00:00:00Z'));
+    const otherDoc = evalDoc('ro', 'vo', 'ho', '2026-01-01T00:00:00Z');
+    writeCard('ro', join(other, 'ro.json'), otherDoc); // 别项目:仅卡片(本 store 不 live 扫 other)
+    const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
+    assert.deepEqual((await store.list()).map((r) => r.id), ['rp', 'rg', 'ro']);
+  });
+
+  it('list:同 id 在 live 与卡片都有 → live 盖卡片,只一条', async () => {
+    writeReportFile(proj, evalDoc('rp'));
+    writeCard('rp', join(other, 'rp.json'), evalDoc('rp')); // 重复卡片
+    const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
+    assert.equal((await store.list()).filter((r) => r.id === 'rp').length, 1);
+  });
+
+  it('get:live 命中完整真身;别项目按卡片 path 读真身(含 results)', async () => {
+    writeReportFile(proj, evalDoc('rp'));
+    const otherDoc = evalDoc('ro');
+    writeReportFile(other, otherDoc);
+    writeCard('ro', join(other, 'ro.json'), otherDoc);
+    const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
+    const live = await store.get('rp');
+    assert.equal(live?.kind === 'evaluation' ? live.results.length : -1, 1, 'live 完整 results');
+    const viaCard = await store.get('ro');
+    assert.equal(viaCard?.id, 'ro');
+    assert.equal(viaCard?.kind === 'evaluation' ? viaCard.results.length : -1, 1, '别项目按 path 读到完整真身');
+  });
+
+  it('get 悬空:卡片在但真身没了 → 卡片壳(results:[]) 不抛、非 null', async () => {
+    writeCard('ro', join(other, 'gone.json'), evalDoc('ro')); // 真身文件不存在
+    const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
+    const got = await store.get('ro');
+    assert.equal(got?.id, 'ro');
+    assert.deepEqual(got?.kind === 'evaluation' ? got.results : null, [], '悬空降级为壳');
+  });
+
+  it('findByVariant / findByArtifactHash 跨项目(含别项目卡片)', async () => {
+    writeCard('ro', join(other, 'ro.json'), evalDoc('ro', 'vo', 'ho'));
+    const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
+    assert.equal((await store.findByVariant('vo')).length, 1);
+    assert.equal((await store.findByArtifactHash('ho')).length, 1);
+  });
+
+  it('remove:删 live 真身 + 删卡片;别项目删不到真身但删卡片仍报成功、从 list 消失', async () => {
+    writeReportFile(proj, evalDoc('rp'));
+    writeCard('ro', join(other, 'ro.json'), evalDoc('ro'));
+    const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
+    assert.equal(await store.remove('rp'), true, '删项目真身');
+    assert.equal(await store.remove('ro'), true, '别项目删卡片即成功');
+    assert.deepEqual((await store.list()).map((r) => r.id), []);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,14 +17,14 @@ export default defineConfig({
     // loadSamples] ⚠ lenient mode" stderr lines that appear during test runs
     // are diagnostic noise — they confirm which fixtures contain legacy-style
     // text-class assertions and are not failures.
-    // 把隔离副本根重定向到临时目录:测试解析 dir-skill 时(materialize 默认 true)不写用户真实
-    // ~/.oh-my-knowledge/trees。需要断言「无 .tmp- 残留」等全局扫描的用例再各自 per-test 覆盖。
-    // OMK_ARTIFACT_INDEX_DIR 同理:persistReport 被海量测试间接调用会写产物索引卡片,重定向到 temp
-    // 避免污染真实 ~/.oh-my-knowledge/state/artifact-index。索引语义的用例各自 per-test 覆盖具体目录。
+    // OMK_HOME 一处重定向,把整棵默认产物树(reports / doctors / observe-health / state 下的
+    // cache / trees / jobs / artifact-index)全部移到临时目录,从根上隔离 —— 任何从深层调用点写全局默认
+    // 目录的写路径(如 persistReport 间接写产物索引卡片、materialize 写隔离副本)都自动落 temp,不再需要
+    // 每个子目录单独补 env 兜底,也消除「新写路径忘了补兜底就静默污染真实 ~/.oh-my-knowledge」的隐患。
+    // 需要更细粒度的用例仍可 per-test 覆盖 OMK_TREES_DIR / OMK_ARTIFACT_INDEX_DIR 等子目录变量。
     env: {
       OMK_LENIENT_ASSERTIONS: '1',
-      OMK_TREES_DIR: join(tmpdir(), 'omk-test-trees'),
-      OMK_ARTIFACT_INDEX_DIR: join(tmpdir(), 'omk-test-artifact-index'),
+      OMK_HOME: join(tmpdir(), 'omk-test-home'),
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,12 @@ export default defineConfig({
     // text-class assertions and are not failures.
     // 把隔离副本根重定向到临时目录:测试解析 dir-skill 时(materialize 默认 true)不写用户真实
     // ~/.oh-my-knowledge/trees。需要断言「无 .tmp- 残留」等全局扫描的用例再各自 per-test 覆盖。
-    env: { OMK_LENIENT_ASSERTIONS: '1', OMK_TREES_DIR: join(tmpdir(), 'omk-test-trees') },
+    // OMK_ARTIFACT_INDEX_DIR 同理:persistReport 被海量测试间接调用会写产物索引卡片,重定向到 temp
+    // 避免污染真实 ~/.oh-my-knowledge/state/artifact-index。索引语义的用例各自 per-test 覆盖具体目录。
+    env: {
+      OMK_LENIENT_ASSERTIONS: '1',
+      OMK_TREES_DIR: join(tmpdir(), 'omk-test-trees'),
+      OMK_ARTIFACT_INDEX_DIR: join(tmpdir(), 'omk-test-artifact-index'),
+    },
   },
 });


### PR DESCRIPTION
## 用户影响

`omk studio` 默认从「项目优先」升级为**机器级总览面板**：看到本机所有项目的报告（之前 #251 让 studio 只看当前项目）。报告正文仍单份留它的项目本地 `.omk/reports`，不挪不复制；新增一层轻量「发现索引」让 studio 跨项目聚合。

`--global`（只看全局）/ `--reports-dir <dir>`（只看指定目录）仍是逃生舱，不走聚合。

## 这是什么

报告落项目本地后，在全局 `state/artifact-index/report/<id>.json` 留一张目录卡片（`meta + summary`，**无 results 重体**，`path` 指向真身）。studio 默认读「卡片（覆盖别项目）∪ live-scan（当前项目 + 全局）」按 id dedup 聚合；点详情按 `card.path` 读真身。零 backfill：当前项目 + 全局靠 live-scan 永远新鲜，别项目靠卡片发现。

- **通用、domain 参数化**：`artifact-index.ts` 的机制 doctor / observe-health 后续阶段复用（本 PR 只落 reports 域）。
- **只索引「非全局目录」的写**：全局是单一物理目录、任何 studio 都 live-scan 它 → 全局写卡片冗余；卡片唯一价值是别项目的项目级目录。
- **best-effort**：索引写永不抛、永不阻断报告落盘（正文是 source of truth）；索引可重建。
- **悬空降级**：别项目被移动 / 删除 → 详情返回卡片壳不 500。

## 测量学 caveat

纯发现层 + 文件落点，不碰 report schema / judge / 评分 —— **非 BREAKING-COMPARABILITY**。可比性红线在比较层（`findByVariant` / `verdict` 锁同口径、跨项目同名 variant 靠 `artifactHash` 区分），不在视图层，故机器级 merge 列表合法。

**id 加固（连带修潜伏 bug）**：`generateRunId` 加秒 + 4 位随机后缀。原分钟级会让跨项目 / 同分钟重跑撞同 id → 机器级 dedup 静默顶掉一份、且 managed 证据 `(reportId, contentHash)` 去重把同分钟两次重跑错并成一条；随机后缀根治撞名，顺带修掉该 managed 潜伏 bug。id 是 run 标签非测量数，格式变更非 comparability anchor。

## 范围

by-id 读取链路（resume / gold-compare / sample / evolve 复用）**不动**，仍走 overlay（项目→全局）—— 索引只供 studio 浏览，不进复用 / 写回链路。doctor（阶段 2）、observe-health（阶段 3，含修其同秒覆盖 bug）后续薄 PR 复用本 PR 的通用核心。设计定稿与分期见 #243。

测试隔离：`OMK_ARTIFACT_INDEX_DIR` 重定向到 temp（仿 `OMK_TREES_DIR`），`yarn lint && build && test` 全绿（171 文件 / 2153 用例）+ `build:docs:check` 同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)