### PR TITLE
feat(eval-core): 产物发现索引扩到 doctor + observe-health 域（#243 阶段 2+3）

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -8,6 +8,7 @@ import { CliExit } from '../lib/cli-exit.js';
 import { tCli } from '../lib/i18n.js';
 import { makeDoctorProgress } from '../lib/progress.js';
 import { DEFAULT_DOCTORS_DIR } from '../../eval-core/default-dirs.js';
+import { indexDoctorWrite, removeDoctorCard } from '../../eval-core/artifact-index.js';
 import { projectDoctorsDir, globalDoctorsDir } from '../../eval-core/measurement-dirs.js';
 import type { Sample, DoctorRule, DoctorRuleLike } from '../../types/index.js';
 import type { DependencyRequirements } from '../../eval-core/dependency-checker.js';
@@ -328,7 +329,14 @@ function persistDoctorReport(report: import('../../types/doctor.js').DoctorRepor
       outcome: skill.status === 'fail' ? 'failed' : skill.status === 'warn' ? 'warnings_only' : 'passed',
     };
     const safeName = skill.skillName.replace(/[/\\:*?"<>|]/g, '_');
-    writeFileSync(join(dir, `${safeName}-${safeId}.json`), JSON.stringify(perSkill, null, 2), 'utf8');
+    const cardId = `${safeName}-${safeId}`;
+    const filePath = join(dir, `${cardId}.json`);
+    writeFileSync(filePath, JSON.stringify(perSkill, null, 2), 'utf8');
+    // 产物发现索引:per-skill 报告落项目本地后,best-effort 追加全局轻卡片,让 studio 跨项目聚合。
+    indexDoctorWrite({
+      id: cardId, path: filePath, skillName: skill.skillName, reportId: report.id, timestamp: report.timestamp,
+      status: skill.status, passCount: counts.pass, warnCount: counts.warn, failCount: counts.fail,
+    }, dir);
     pruneDoctorHistory(dir, skill.skillName, DOCTOR_HISTORY_MAX_PER_SKILL);
   }
 }
@@ -352,5 +360,8 @@ export function pruneDoctorHistory(dir: string, skillName: string, maxKeep: numb
   candidates.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
   for (const { file } of candidates.slice(maxKeep)) {
     try { unlinkSync(join(dir, file)); } catch { /* ignore */ }
+    // 连带删卡片:否则被 prune 掉的报告会经 listDoctorCards 合并在本项目 studio「复活」(正文已删、卡片还在)。
+    // 卡片 id = 文件 stem(`{name}-{id}`),与 indexDoctorWrite 写入口径一致。
+    removeDoctorCard(file.replace(/\.json$/, ''));
   }
 }

--- a/src/cli/commands/observe/index.ts
+++ b/src/cli/commands/observe/index.ts
@@ -1,3 +1,4 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { Args, Flags } from '@oclif/core';
 import { LANG_FLAG, bilingual } from '../../oclif/i18n.js';
@@ -6,6 +7,24 @@ import { CliExit } from '../../lib/cli-exit.js';
 import { tCli } from '../../lib/i18n.js';
 import { parseLastWindow } from '../../lib/shared.js';
 import { projectObserveHealthDir, globalObserveHealthDir } from '../../../eval-core/measurement-dirs.js';
+import { indexObserveWrite } from '../../../eval-core/artifact-index.js';
+import type { SkillHealthReport } from '../../../observability/skill-health-analyzer.js';
+
+/**
+ * observe-health 报告落盘:id / 文件名加 4 位随机段,根治「同秒两次 omk observe 直接覆盖、数据丢失」的 bug。
+ * 保留 `-observe-health.json` 后缀 —— resolveObserveHealthDir 靠它判项目优先、listAnalyses 靠它取 id stem、
+ * loadAnalysis 靠 `${id}.json` 读真身。落盘后 best-effort 追加全局轻卡片,让 studio 跨项目聚合。
+ */
+export function persistObserveHealthReport(report: SkillHealthReport, outDir: string): { id: string; jsonPath: string } {
+  mkdirSync(outDir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const rand = Math.random().toString(36).slice(2, 6);
+  const id = `${timestamp}-${rand}-observe-health`;
+  const jsonPath = join(outDir, `${id}.json`);
+  writeFileSync(jsonPath, JSON.stringify(report, null, 2));
+  indexObserveWrite(report, jsonPath, outDir, id);
+  return { id, jsonPath };
+}
 
 // `omk observe <sessions-dir>` 是默认命令 —— 分析 sessions 目录的 skill 调用健康度，产出 observe-health 报告(JSON)，
 // 由 Studio 健康报告页按需渲染。observe 这条线的另一条产物是观测收件箱(observe-inbox)，走子命令 ingest / inbox / show。
@@ -81,7 +100,7 @@ export default class Observe extends BaseCommand {
       }
       const tracePath = resolve(dir);
 
-      const { existsSync, mkdirSync, writeFileSync } = await import('node:fs');
+      const { existsSync } = await import('node:fs');
       if (!existsSync(tracePath)) {
         console.error(`Trace path does not exist: ${tracePath}`);
         throw new CliExit(1);
@@ -113,10 +132,7 @@ export default class Observe extends BaseCommand {
       const outDir = flags['output-dir']
         ? resolve(flags['output-dir'])
         : (flags.global ? globalObserveHealthDir() : projectObserveHealthDir());
-      mkdirSync(outDir, { recursive: true });
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-      const jsonPath = join(outDir, `${timestamp}-observe-health.json`);
-      writeFileSync(jsonPath, JSON.stringify(report, null, 2));
+      const { jsonPath } = persistObserveHealthReport(report, outDir);
 
       const { sessionCount, segmentCount, toolCallCount, toolFailureRate } = report.meta;
       console.log('');

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -108,6 +108,10 @@ export async function runStudio(
     doctorsDir: flags['doctors-dir']
       ? resolve(flags['doctors-dir'])
       : (flags.global ? globalDoctorsDir : (): string => resolveDoctorsDir(projectDoctorsDir())),
+    // 只有默认机器级模式才合别项目的索引卡片;--global / 显式 --analyses-dir / --doctors-dir 是逃生舱,
+    // 只看固定目录(与 reports 的 --reports-dir 关闭 indexed store 对称)。observe / doctor 各自独立判定。
+    includeObserveCards: !flags.global && !flags['analyses-dir'],
+    includeDoctorCards: !flags.global && !flags['doctors-dir'],
     ...(flags['observations-dir'] ? { observationsDir: resolve(flags['observations-dir']) } : {}),
     // 传解析器而非解析结果:Studio 是长会话,受管根目录要按请求解析(项目首次 install 后从 global 切回
     // project),与 omk list 同口径;若在此处一次性解析、冻结进 server,长会话里会与 CLI 分叉。

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -184,7 +184,10 @@ let reportIdCounter = 0;
 function nextReportId(): string {
   reportIdCounter += 1;
   const ts = new Date().toISOString().replace(/[-:.]/g, '').slice(0, 15);
-  return `doctor-${ts}-${reportIdCounter}`;
+  // 进程内计数器只防同进程同秒撞;跨进程同秒(两个 omk doctor 并发 / 不同项目)仍会撞同 id,
+  // 经机器级卡片 dedup 当唯一键用时会静默并掉一份。加 4 位随机根治跨进程撞名(id 是标签非测量数)。
+  const rand = Math.random().toString(36).slice(2, 6);
+  return `doctor-${ts}-${reportIdCounter}-${rand}`;
 }
 
 function readCliVersion(): string {

--- a/src/eval-core/artifact-index.ts
+++ b/src/eval-core/artifact-index.ts
@@ -9,7 +9,7 @@
  * 三域共用 `artifactIndexDir(domain)` + tmp-rename 原子写 + 指纹缓存读 的同一套机制,各域只差「投影成卡片」
  * 与「卡片还原成 snapshot」两段域特定逻辑。
  */
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, renameSync, unlinkSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { DEFAULT_ARTIFACT_INDEX_DIR } from './default-dirs.js';
 import { globalReportsDir, globalDoctorsDir, globalObserveHealthDir } from './measurement-dirs.js';
@@ -100,6 +100,30 @@ function removeArtifactCard(domain: ArtifactDomain, id: string): boolean {
  */
 function liveCards<T extends { path: string }>(cards: T[]): T[] {
   return cards.filter((c) => existsSync(c.path));
+}
+
+/**
+ * 某域所有卡片「真身(card.path)」的存在性 + mtime/size 指纹。
+ * 消费方(indexed-report-store / buildSkillIndex)的缓存指纹必须纳入它:卡片 JSON 本身没变、只靠卡片目录
+ * mtime 的指纹检测不到「真身被带外删」,长会话会继续命中旧缓存展示悬空卡片。真身删/改 → 此 sentinel 变 →
+ * 缓存失效 → live 过滤生效。读卡片只为拿 path,字段宽松。
+ */
+export function cardTargetSentinel(domain: ArtifactDomain): string {
+  const dir = artifactIndexDir(domain);
+  if (!existsSync(dir)) return '';
+  let files: string[];
+  try { files = readdirSync(dir); } catch { return ''; }
+  const parts: string[] = [];
+  for (const f of files) {
+    if (!f.endsWith('.json') || f.includes('.json.tmp.')) continue;
+    try {
+      const c = JSON.parse(readFileSync(join(dir, f), 'utf-8')) as { path?: unknown };
+      if (typeof c.path !== 'string') continue;
+      try { const s = statSync(c.path); parts.push(`${f}=${s.mtimeMs}:${s.size}`); }
+      catch { parts.push(`${f}=gone`); }
+    } catch { /* skip corrupt */ }
+  }
+  return parts.sort().join(',');
 }
 
 // ── report 域 ───────────────────────────────────────────────────────────────

--- a/src/eval-core/artifact-index.ts
+++ b/src/eval-core/artifact-index.ts
@@ -1,20 +1,25 @@
 /**
- * 产物发现索引(report 域)。
+ * 产物发现索引(report / doctor / observe-health 三域)。
  *
- * 报告正文(含 results 逐样本重体)永远单份留它的项目本地 `.omk/reports/<id>.json`;报告落盘后,在全局
- * `state/artifact-index/report/<id>.json` 留一张轻卡片(meta + summary,无 results,`path` 指向真身),
+ * 每类测量产物的正文(含逐样本 / 逐规则 / 逐信号重体)永远单份留它的项目本地 `.omk/<域>/`;产物落盘后,
+ * 在全局 `state/artifact-index/<域>/<id>.json` 留一张轻卡片(元数据 + 必要标量,剥掉重体,`path` 指向真身),
  * 让 `omk studio` 跨项目聚合成「机器级总览」—— 当前项目 + 全局靠 live-scan 永远新鲜,别的项目靠卡片发现。
  *
- * 索引是可重生 scratch:写失败永不阻断报告落盘(正文是 source of truth);丢了由 live-scan / 重跑重建。
- * doctor / observe-health 域后续复用 `artifactIndexDir(domain)` + tmp-rename 写卡片的同一套机制。
+ * 索引是可重生 scratch:写失败永不阻断正文落盘(正文是 source of truth);丢了由 live-scan / 重跑重建。
+ * 三域共用 `artifactIndexDir(domain)` + tmp-rename 原子写 + 指纹缓存读 的同一套机制,各域只差「投影成卡片」
+ * 与「卡片还原成 snapshot」两段域特定逻辑。
  */
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { DEFAULT_ARTIFACT_INDEX_DIR } from './default-dirs.js';
-import { globalReportsDir } from './measurement-dirs.js';
+import { globalReportsDir, globalDoctorsDir, globalObserveHealthDir } from './measurement-dirs.js';
 import type { BatchEvaluationReport, EvaluationReport, ReportDocument, ReportIndexCard } from '../types/index.js';
+import type { SkillDoctorSnapshot } from '../types/skill-index.js';
+import type { DoctorSkillStatus } from '../types/doctor.js';
 
 export type ArtifactDomain = 'report' | 'doctor' | 'observe-health';
+
+// ── 通用机制(域无关)──────────────────────────────────────────────────────────
 
 /** 索引根:`OMK_ARTIFACT_INDEX_DIR` 覆盖(测试隔离,仿 OMK_TREES_DIR),默认 state/artifact-index。 */
 function artifactIndexRoot(): string {
@@ -27,9 +32,14 @@ export function artifactIndexDir(domain: ArtifactDomain): string {
 }
 
 /** 只索引「非全局目录」的写:全局是单一物理目录、任何 studio 都 live-scan 它 → 全局写卡片冗余;
- *  卡片唯一价值是别项目的项目级 `.omk/reports`。 */
+ *  卡片唯一价值是别项目的项目级 `.omk/<域>`。 */
+function shouldIndexDir(outputDir: string, globalDir: string): boolean {
+  return resolve(outputDir) !== resolve(globalDir);
+}
+
+/** report 域口径(保持向后兼容的既有导出)。 */
 export function shouldIndexReport(outputDir: string): boolean {
-  return resolve(outputDir) !== resolve(globalReportsDir());
+  return shouldIndexDir(outputDir, globalReportsDir());
 }
 
 function safeFileName(id: string): string {
@@ -37,13 +47,45 @@ function safeFileName(id: string): string {
 }
 
 /** 原子写一张卡片(tmp+rename,防半截 JSON 被 reader 读到)。 */
-function writeCard(indexDir: string, id: string, card: ReportIndexCard): void {
+function writeCard(domain: ArtifactDomain, id: string, card: object): void {
+  const indexDir = artifactIndexDir(domain);
   mkdirSync(indexDir, { recursive: true });
   const target = join(indexDir, `${safeFileName(id)}.json`);
   const tmp = `${target}.tmp.${process.pid}.${Math.random().toString(36).slice(2)}`;
   writeFileSync(tmp, JSON.stringify(card, null, 2));
   renameSync(tmp, target);
 }
+
+/** 读某域全部卡片,逐条用 `valid` 谓词过滤坏文件 / 缺字段(索引是 scratch,读侧从严)。 */
+function readArtifactCards<T>(domain: ArtifactDomain, valid: (c: unknown) => c is T): T[] {
+  const dir = artifactIndexDir(domain);
+  if (!existsSync(dir)) return [];
+  let files: string[];
+  try { files = readdirSync(dir); } catch { return []; }
+  const out: T[] = [];
+  for (const f of files) {
+    if (!f.endsWith('.json') || f.includes('.json.tmp.')) continue;
+    try {
+      const c: unknown = JSON.parse(readFileSync(join(dir, f), 'utf-8'));
+      if (valid(c)) out.push(c);
+    } catch { /* skip corrupt card */ }
+  }
+  return out;
+}
+
+/** 删某域某 id 的卡片。幂等、best-effort。返回卡片是否曾存在。 */
+function removeArtifactCard(domain: ArtifactDomain, id: string): boolean {
+  try {
+    const p = join(artifactIndexDir(domain), `${safeFileName(id)}.json`);
+    if (!existsSync(p)) return false;
+    unlinkSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── report 域 ───────────────────────────────────────────────────────────────
 
 /** 报告投影成卡片(剥掉 results 重体)。 */
 function reportCard(report: ReportDocument, sourcePath: string): ReportIndexCard {
@@ -61,30 +103,21 @@ export function indexReportWrite(report: { id: string }, sourcePath: string, out
     if (!shouldIndexReport(outputDir)) return;
     const doc = report as Partial<ReportDocument>;
     if (doc.kind !== 'evaluation' && doc.kind !== 'batch-evaluation') return;
-    writeCard(artifactIndexDir('report'), report.id, reportCard(doc as ReportDocument, sourcePath));
+    writeCard('report', report.id, reportCard(doc as ReportDocument, sourcePath));
   } catch {
     // 索引可重建,失败静默(可选 stderr warn);正文已落盘不受影响。
   }
 }
 
-/** 读 report 域全部卡片(跳过坏文件 / 缺字段)。 */
+/** 读 report 域全部卡片(跳过坏文件 / 缺字段 / 坏 kind)。 */
 export function listReportCards(): ReportIndexCard[] {
-  const dir = artifactIndexDir('report');
-  if (!existsSync(dir)) return [];
-  const cards: ReportIndexCard[] = [];
-  let files: string[];
-  try { files = readdirSync(dir); } catch { return []; }
-  for (const f of files) {
-    if (!f.endsWith('.json') || f.includes('.json.tmp.')) continue;
-    try {
-      const c = JSON.parse(readFileSync(join(dir, f), 'utf-8')) as ReportIndexCard;
-      // kind 白名单:cardToReportDocument 对任何非 evaluation 一律按 batch 投影,坏 kind(拼错 / 'doctor')
-      // 会污染机器级 list 成空 batch 报告。索引是可重生 scratch,读侧从严跳过坏卡片。
-      const kindOk = c?.kind === 'evaluation' || c?.kind === 'batch-evaluation';
-      if (c && c.domain === 'report' && kindOk && typeof c.id === 'string' && typeof c.path === 'string' && c.meta) cards.push(c);
-    } catch { /* skip corrupt card */ }
-  }
-  return cards;
+  return readArtifactCards('report', (c): c is ReportIndexCard => {
+    const card = c as Partial<ReportIndexCard>;
+    // kind 白名单:cardToReportDocument 对任何非 evaluation 一律按 batch 投影,坏 kind(拼错 / 'doctor')
+    // 会污染机器级 list 成空 batch 报告。索引是可重生 scratch,读侧从严跳过坏卡片。
+    const kindOk = card?.kind === 'evaluation' || card?.kind === 'batch-evaluation';
+    return !!card && card.domain === 'report' && kindOk && typeof card.id === 'string' && typeof card.path === 'string' && !!card.meta;
+  });
 }
 
 /** 卡片 → ReportDocument(results:[]):供 studio list / buildSkillIndex / trend 消费(它们不读 results)。 */
@@ -94,15 +127,120 @@ export function cardToReportDocument(card: ReportIndexCard): ReportDocument {
     : { kind: 'batch-evaluation', id: card.id, mode: 'skill', meta: card.meta as BatchEvaluationReport['meta'], items: card.items ?? [] };
 }
 
-/** 删 report 域某 id 的卡片(DELETE 报告时连卡片一起删,使其从机器级 list 消失)。幂等、best-effort。
- *  返回卡片是否曾存在(供 remove 在「真身在别项目删不到、但卡片删了」时仍回报成功)。 */
+/** 删 report 域某 id 的卡片(DELETE 报告时连卡片一起删,使其从机器级 list 消失)。幂等、best-effort。 */
 export function removeReportCard(id: string): boolean {
+  return removeArtifactCard('report', id);
+}
+
+// ── doctor 域 ───────────────────────────────────────────────────────────────
+
+/** doctor 卡片:per-skill 文件(`{skillName}-{reportId}.json`)一张。id = 文件名 stem(唯一),
+ *  reportId = 该次 doctor run 的 id(同 run 多 skill 共享)。剥掉逐规则 results 重体,只留 per-skill 计数。
+ *  无 `kind` 字段 —— domain 已足够判别(doctor 只有一种报告 kind)。 */
+export interface DoctorIndexCard {
+  domain: 'doctor';
+  id: string;
+  path: string;
+  skillName: string;
+  reportId: string;
+  timestamp: string;
+  status: DoctorSkillStatus;
+  passCount: number;
+  warnCount: number;
+  failCount: number;
+}
+
+/** persistDoctorReport per-skill 循环里的索引钩子。best-effort,永不抛、永不阻断正文落盘。 */
+export function indexDoctorWrite(card: Omit<DoctorIndexCard, 'domain'>, outputDir: string): void {
   try {
-    const p = join(artifactIndexDir('report'), `${safeFileName(id)}.json`);
-    if (!existsSync(p)) return false;
-    unlinkSync(p);
-    return true;
-  } catch {
-    return false;
-  }
+    if (!shouldIndexDir(outputDir, globalDoctorsDir())) return;
+    writeCard('doctor', card.id, { domain: 'doctor', ...card } satisfies DoctorIndexCard);
+  } catch { /* 索引可重建,失败静默 */ }
+}
+
+/** 读 doctor 域全部卡片。 */
+export function listDoctorCards(): DoctorIndexCard[] {
+  return readArtifactCards('doctor', (c): c is DoctorIndexCard => {
+    const card = c as Partial<DoctorIndexCard>;
+    return !!card && card.domain === 'doctor' && typeof card.id === 'string' && typeof card.path === 'string'
+      && typeof card.skillName === 'string' && typeof card.reportId === 'string' && typeof card.timestamp === 'string';
+  });
+}
+
+/** doctor 卡片 → (skillName, SkillDoctorSnapshot)。results:[](逐规则详情需回源项目看)。 */
+export function cardToDoctorSnapshot(card: DoctorIndexCard): { skillName: string; snap: SkillDoctorSnapshot } {
+  return {
+    skillName: card.skillName,
+    snap: {
+      reportId: card.reportId, timestamp: card.timestamp, status: card.status,
+      passCount: card.passCount, warnCount: card.warnCount, failCount: card.failCount, results: [],
+    },
+  };
+}
+
+/** 删 doctor 域某 id(文件 stem)的卡片。doctor 历史按 50/skill prune,删正文时必须连卡片一起删,
+ *  否则被 prune 掉的报告会经卡片合并在本项目 studio「复活」。 */
+export function removeDoctorCard(id: string): boolean {
+  return removeArtifactCard('doctor', id);
+}
+
+// ── observe-health 域 ─────────────────────────────────────────────────────────
+
+/** observe 报告投影到卡片所需的结构子集(不 import observability/SkillHealthReport,保持 eval-core 解耦)。 */
+interface ObserveCardSkill {
+  toolFailureRate: number;
+  segmentCount: number;
+  gap?: { weightedGapRate?: number };
+  confidence?: 'high' | 'low' | 'underpowered';
+}
+interface ObserveSource {
+  meta: { generatedAt: string; sessionCount: number; segmentCount: number };
+  overall: { healthBand: 'green' | 'yellow' | 'red'; confidence?: 'high' | 'low' | 'underpowered' };
+  bySkill: Record<string, ObserveCardSkill>;
+}
+
+/** observe 卡片:每份报告一张。id = 文件名 stem。剥掉每个 skill 的 gap.signals 等重体,只留 list / skill-index
+ *  口径需要的标量(meta 摘要 + overall + per-skill 标量)。详情(含 signals)走 card.path 读真身。无 `kind` 字段。 */
+export interface ObserveIndexCard {
+  domain: 'observe-health';
+  id: string;
+  path: string;
+  meta: { generatedAt: string; sessionCount: number; segmentCount: number };
+  overall: { healthBand: 'green' | 'yellow' | 'red'; confidence?: 'high' | 'low' | 'underpowered' };
+  bySkill: Record<string, ObserveCardSkill>;
+}
+
+/** persistObserveHealthReport 的索引钩子。best-effort,永不抛、永不阻断正文落盘。 */
+export function indexObserveWrite(report: ObserveSource, sourcePath: string, outputDir: string, id: string): void {
+  try {
+    if (!shouldIndexDir(outputDir, globalObserveHealthDir())) return;
+    const bySkill: Record<string, ObserveCardSkill> = {};
+    for (const [name, h] of Object.entries(report.bySkill || {})) {
+      bySkill[name] = {
+        toolFailureRate: h.toolFailureRate, segmentCount: h.segmentCount,
+        gap: { weightedGapRate: h.gap?.weightedGapRate ?? 0 }, confidence: h.confidence,
+      };
+    }
+    const card: ObserveIndexCard = {
+      domain: 'observe-health', id, path: sourcePath,
+      meta: { generatedAt: report.meta.generatedAt, sessionCount: report.meta.sessionCount, segmentCount: report.meta.segmentCount },
+      overall: { healthBand: report.overall.healthBand, confidence: report.overall.confidence },
+      bySkill,
+    };
+    writeCard('observe-health', id, card);
+  } catch { /* 索引可重建,失败静默 */ }
+}
+
+/** 读 observe-health 域全部卡片。 */
+export function listObserveCards(): ObserveIndexCard[] {
+  return readArtifactCards('observe-health', (c): c is ObserveIndexCard => {
+    const card = c as Partial<ObserveIndexCard>;
+    return !!card && card.domain === 'observe-health' && typeof card.id === 'string' && typeof card.path === 'string'
+      && !!card.meta && !!card.overall && !!card.bySkill;
+  });
+}
+
+/** 删 observe 域某 id 的卡片。 */
+export function removeObserveCard(id: string): boolean {
+  return removeArtifactCard('observe-health', id);
 }

--- a/src/eval-core/artifact-index.ts
+++ b/src/eval-core/artifact-index.ts
@@ -46,6 +46,13 @@ function safeFileName(id: string): string {
   return id.replaceAll(/[/\\:*?"<>|]/g, '_');
 }
 
+// 卡片读侧小 guard:索引是可重生 scratch,坏卡片(脏文件 / 别域误落 / 字段缺失)读侧从严跳过,
+// 不让 undefined / 非法枚举 / NaN 当可信输入污染 studio。
+const isFiniteNumber = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
+const isDoctorStatus = (v: unknown): v is DoctorSkillStatus => v === 'pass' || v === 'warn' || v === 'fail';
+const isHealthBand = (v: unknown): v is 'green' | 'yellow' | 'red' => v === 'green' || v === 'yellow' || v === 'red';
+const isConfidence = (v: unknown): boolean => v === undefined || v === 'high' || v === 'low' || v === 'underpowered';
+
 /** 原子写一张卡片(tmp+rename,防半截 JSON 被 reader 读到)。 */
 function writeCard(domain: ArtifactDomain, id: string, card: object): void {
   const indexDir = artifactIndexDir(domain);
@@ -163,7 +170,9 @@ export function listDoctorCards(): DoctorIndexCard[] {
   return readArtifactCards('doctor', (c): c is DoctorIndexCard => {
     const card = c as Partial<DoctorIndexCard>;
     return !!card && card.domain === 'doctor' && typeof card.id === 'string' && typeof card.path === 'string'
-      && typeof card.skillName === 'string' && typeof card.reportId === 'string' && typeof card.timestamp === 'string';
+      && typeof card.skillName === 'string' && typeof card.reportId === 'string' && typeof card.timestamp === 'string'
+      && isDoctorStatus(card.status)
+      && isFiniteNumber(card.passCount) && isFiniteNumber(card.warnCount) && isFiniteNumber(card.failCount);
   });
 }
 
@@ -235,8 +244,16 @@ export function indexObserveWrite(report: ObserveSource, sourcePath: string, out
 export function listObserveCards(): ObserveIndexCard[] {
   return readArtifactCards('observe-health', (c): c is ObserveIndexCard => {
     const card = c as Partial<ObserveIndexCard>;
-    return !!card && card.domain === 'observe-health' && typeof card.id === 'string' && typeof card.path === 'string'
-      && !!card.meta && !!card.overall && !!card.bySkill;
+    if (!card || card.domain !== 'observe-health' || typeof card.id !== 'string' || typeof card.path !== 'string') return false;
+    const meta = card.meta; const overall = card.overall; const bySkill = card.bySkill;
+    if (!meta || !isFiniteNumber(meta.sessionCount) || !isFiniteNumber(meta.segmentCount) || typeof meta.generatedAt !== 'string') return false;
+    if (!overall || !isHealthBand(overall.healthBand) || !isConfidence(overall.confidence)) return false;
+    if (!bySkill || typeof bySkill !== 'object') return false;
+    // 每个 skill 的标量也校验:坏 toolFailureRate / segmentCount 会让 bandFromObserveHealth / 趋势出 NaN。
+    for (const h of Object.values(bySkill)) {
+      if (!h || !isFiniteNumber(h.toolFailureRate) || !isFiniteNumber(h.segmentCount) || !isConfidence(h.confidence)) return false;
+    }
+    return true;
   });
 }
 

--- a/src/eval-core/artifact-index.ts
+++ b/src/eval-core/artifact-index.ts
@@ -92,6 +92,16 @@ function removeArtifactCard(domain: ArtifactDomain, id: string): boolean {
   }
 }
 
+/**
+ * 过滤悬空卡片:真身文件(`card.path`)已不在(项目被整目录删 / 移走等带外途径)→ 卡片视为「指向不存在的产物」。
+ * 机器级 list / merge 展示路径用 listLive*Cards,不展示这类卡片(把卡片当活指针,而非持久记录)。
+ * 注:by-id 的 get / loadXReport 兜底仍走 raw list*Cards —— 直链书签按 card.path 读到则给真身、读不到各自降级,
+ * 是 best-effort,不在这层过滤。doctor 历史 prune 已连带删卡片,故悬空主要发生在「带外删整个项目目录」。
+ */
+function liveCards<T extends { path: string }>(cards: T[]): T[] {
+  return cards.filter((c) => existsSync(c.path));
+}
+
 // ── report 域 ───────────────────────────────────────────────────────────────
 
 /** 报告投影成卡片(剥掉 results 重体)。 */
@@ -125,6 +135,11 @@ export function listReportCards(): ReportIndexCard[] {
     const kindOk = card?.kind === 'evaluation' || card?.kind === 'batch-evaluation';
     return !!card && card.domain === 'report' && kindOk && typeof card.id === 'string' && typeof card.path === 'string' && !!card.meta;
   });
+}
+
+/** report 卡片(过滤悬空真身):供 studio 机器级 list / findBy 展示。 */
+export function listLiveReportCards(): ReportIndexCard[] {
+  return liveCards(listReportCards());
 }
 
 /** 卡片 → ReportDocument(results:[]):供 studio list / buildSkillIndex / trend 消费(它们不读 results)。 */
@@ -174,6 +189,11 @@ export function listDoctorCards(): DoctorIndexCard[] {
       && isDoctorStatus(card.status)
       && isFiniteNumber(card.passCount) && isFiniteNumber(card.warnCount) && isFiniteNumber(card.failCount);
   });
+}
+
+/** doctor 卡片(过滤悬空真身):供 buildSkillIndex 机器级合并。 */
+export function listLiveDoctorCards(): DoctorIndexCard[] {
+  return liveCards(listDoctorCards());
 }
 
 /** doctor 卡片 → (skillName, SkillDoctorSnapshot)。results:[](逐规则详情需回源项目看)。 */
@@ -257,6 +277,11 @@ export function listObserveCards(): ObserveIndexCard[] {
     }
     return true;
   });
+}
+
+/** observe 卡片(过滤悬空真身):供 listAnalyses / buildSkillIndex 机器级合并。 */
+export function listLiveObserveCards(): ObserveIndexCard[] {
+  return liveCards(listObserveCards());
 }
 
 /** 删 observe 域某 id 的卡片。 */

--- a/src/eval-core/artifact-index.ts
+++ b/src/eval-core/artifact-index.ts
@@ -249,9 +249,11 @@ export function listObserveCards(): ObserveIndexCard[] {
     if (!meta || !isFiniteNumber(meta.sessionCount) || !isFiniteNumber(meta.segmentCount) || typeof meta.generatedAt !== 'string') return false;
     if (!overall || !isHealthBand(overall.healthBand) || !isConfidence(overall.confidence)) return false;
     if (!bySkill || typeof bySkill !== 'object') return false;
-    // 每个 skill 的标量也校验:坏 toolFailureRate / segmentCount 会让 bandFromObserveHealth / 趋势出 NaN。
+    // 每个 skill 的标量也校验:坏 toolFailureRate / segmentCount / gap.weightedGapRate 会让 bandFromObserveHealth /
+    // 趋势 / 健康快照出 NaN(buildSkillIndex 直接取 h.gap?.weightedGapRate ?? 0 进 gapRate、参与阈值判断)。
     for (const h of Object.values(bySkill)) {
       if (!h || !isFiniteNumber(h.toolFailureRate) || !isFiniteNumber(h.segmentCount) || !isConfidence(h.confidence)) return false;
+      if (h.gap !== undefined && h.gap.weightedGapRate !== undefined && !isFiniteNumber(h.gap.weightedGapRate)) return false;
     }
     return true;
   });

--- a/src/server/indexed-report-store.ts
+++ b/src/server/indexed-report-store.ts
@@ -13,7 +13,7 @@
 import { existsSync, statSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { createFileStore } from './report-store.js';
-import { artifactIndexDir, listReportCards, cardToReportDocument, removeReportCard } from '../eval-core/artifact-index.js';
+import { artifactIndexDir, listReportCards, listLiveReportCards, cardToReportDocument, removeReportCard } from '../eval-core/artifact-index.js';
 import type { ReportDocument, ReportStore, EvaluationReport } from '../types/index.js';
 
 function isEvaluation(r: ReportDocument): r is EvaluationReport {
@@ -52,7 +52,9 @@ export function createIndexedReportStore({ projectDir, globalDir }: IndexedRepor
   function cardDocs(): ReportDocument[] {
     const fp = cardFingerprint();
     if (fp === cachedFp && cachedCards) return cachedCards;
-    const docs = listReportCards().map(cardToReportDocument);
+    // 机器级 list 展示用 live 卡片:真身被带外删/移走的悬空卡片不进列表(把卡片当活指针)。
+    // get() 仍走 raw listReportCards 做 by-id best-effort(直链命中真身则给真身、悬空降级壳)。
+    const docs = listLiveReportCards().map(cardToReportDocument);
     cachedFp = fp;
     cachedCards = docs;
     return docs;

--- a/src/server/indexed-report-store.ts
+++ b/src/server/indexed-report-store.ts
@@ -13,7 +13,7 @@
 import { existsSync, statSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { createFileStore } from './report-store.js';
-import { artifactIndexDir, listReportCards, listLiveReportCards, cardToReportDocument, removeReportCard } from '../eval-core/artifact-index.js';
+import { artifactIndexDir, listReportCards, listLiveReportCards, cardToReportDocument, removeReportCard, cardTargetSentinel } from '../eval-core/artifact-index.js';
 import type { ReportDocument, ReportStore, EvaluationReport } from '../types/index.js';
 
 function isEvaluation(r: ReportDocument): r is EvaluationReport {
@@ -44,7 +44,8 @@ export function createIndexedReportStore({ projectDir, globalDir }: IndexedRepor
       const parts = files.map((f) => {
         try { const s = statSync(join(dir, f)); return `${f}:${s.mtimeMs}:${s.size}`; } catch { return `${f}:?`; }
       });
-      return `${statSync(dir).mtimeMs}|${parts.join(',')}`;
+      // 真身存在性也进指纹:否则真身被带外删、卡片 JSON 没变,缓存命中会继续展示已悬空卡片。
+      return `${statSync(dir).mtimeMs}|${parts.join(',')}|t:${cardTargetSentinel('report')}`;
     } catch {
       return 'none';
     }

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -15,7 +15,7 @@ import { loadAllManagedRecords, resolveManagedDir, managedDir as projectManagedD
 import { renderManagedList, renderManagedHistory } from '../renderer/managed-history-renderer.js';
 import { DEFAULT_JOBS_DIR } from '../eval-core/default-dirs.js';
 import { resolveObserveHealthDir, projectObserveHealthDir, resolveDoctorsDir, projectDoctorsDir, projectReportsDir, globalReportsDir } from '../eval-core/measurement-dirs.js';
-import { listObserveCards, listDoctorCards } from '../eval-core/artifact-index.js';
+import { listObserveCards, listDoctorCards, listLiveObserveCards } from '../eval-core/artifact-index.js';
 import { buildSkillIndex } from './skill-index.js';
 import type { Lang } from '../types/index.js';
 import { createFileJobStore } from './job-store.js';
@@ -115,7 +115,7 @@ function listAnalyses(dir: string, includeCards = false): AnalysisListItem[] {
   // 仅机器级模式合并;固定 --analyses-dir / --global 时 includeCards=false,只看该目录(逃生舱语义)。
   if (includeCards) {
     const seen = new Set(items.map((i) => i.id));
-    for (const card of listObserveCards()) {
+    for (const card of listLiveObserveCards()) {
       if (seen.has(card.id)) continue;
       items.push({
         id: card.id, generatedAt: card.meta.generatedAt, sessionCount: card.meta.sessionCount,

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -89,24 +89,27 @@ function loadChartJsBundle(): string | null {
 }
 
 function listAnalyses(dir: string, includeCards = false): AnalysisListItem[] {
-  if (!existsSync(dir)) return [];
   const items: AnalysisListItem[] = [];
-  for (const file of readdirSync(dir)) {
-    if (!file.endsWith('.json')) continue;
-    try {
-      const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as SkillHealthReport;
-      if (!data.meta || !data.overall) continue;
-      items.push({
-        id: file.replace(/\.json$/, ''),
-        generatedAt: data.meta.generatedAt,
-        sessionCount: data.meta.sessionCount,
-        segmentCount: data.meta.segmentCount,
-        skillCount: Object.keys(data.bySkill || {}).length,
-        healthBand: data.overall.healthBand,
-        // 旧 JSON 缺 confidence 时按 segmentCount 兜底,跟 Studio / CLI 口径一致。
-        confidence: data.overall.confidence ?? confidenceOf(data.meta.segmentCount),
-      });
-    } catch { /* skip corrupt */ }
+  // live 扫描 dir 存在才做;dir 不存在(默认机器级模式下当前项目还没 .omk/observe-health、全局也空)时 live 为空,
+  // 但**不能早退** —— 后面仍要按 includeCards 合并别项目卡片,否则 observe 列表会与合卡片的 /api/skills 口径分裂。
+  if (existsSync(dir)) {
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith('.json')) continue;
+      try {
+        const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as SkillHealthReport;
+        if (!data.meta || !data.overall) continue;
+        items.push({
+          id: file.replace(/\.json$/, ''),
+          generatedAt: data.meta.generatedAt,
+          sessionCount: data.meta.sessionCount,
+          segmentCount: data.meta.segmentCount,
+          skillCount: Object.keys(data.bySkill || {}).length,
+          healthBand: data.overall.healthBand,
+          // 旧 JSON 缺 confidence 时按 segmentCount 兜底,跟 Studio / CLI 口径一致。
+          confidence: data.overall.confidence ?? confidenceOf(data.meta.segmentCount),
+        });
+      } catch { /* skip corrupt */ }
+    }
   }
   // 别项目的 observe 卡片(当前 dir live 扫不到的项目)→ list item,dedup by id(live 盖卡片)。
   // 仅机器级模式合并;固定 --analyses-dir / --global 时 includeCards=false,只看该目录(逃生舱语义)。

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -15,6 +15,7 @@ import { loadAllManagedRecords, resolveManagedDir, managedDir as projectManagedD
 import { renderManagedList, renderManagedHistory } from '../renderer/managed-history-renderer.js';
 import { DEFAULT_JOBS_DIR } from '../eval-core/default-dirs.js';
 import { resolveObserveHealthDir, projectObserveHealthDir, resolveDoctorsDir, projectDoctorsDir, projectReportsDir, globalReportsDir } from '../eval-core/measurement-dirs.js';
+import { listObserveCards, listDoctorCards } from '../eval-core/artifact-index.js';
 import { buildSkillIndex } from './skill-index.js';
 import type { Lang } from '../types/index.js';
 import { createFileJobStore } from './job-store.js';
@@ -101,6 +102,16 @@ function listAnalyses(dir: string): AnalysisListItem[] {
       });
     } catch { /* skip corrupt */ }
   }
+  // 别项目的 observe 卡片(当前 dir live 扫不到的项目)→ list item,dedup by id(live 盖卡片)。
+  const seen = new Set(items.map((i) => i.id));
+  for (const card of listObserveCards()) {
+    if (seen.has(card.id)) continue;
+    items.push({
+      id: card.id, generatedAt: card.meta.generatedAt, sessionCount: card.meta.sessionCount,
+      segmentCount: card.meta.segmentCount, skillCount: Object.keys(card.bySkill).length,
+      healthBand: card.overall.healthBand, confidence: card.overall.confidence ?? confidenceOf(card.meta.segmentCount),
+    });
+  }
   // 最新在前
   items.sort((a, b) => b.generatedAt.localeCompare(a.generatedAt));
   return items;
@@ -108,28 +119,46 @@ function listAnalyses(dir: string): AnalysisListItem[] {
 
 function loadAnalysis(dir: string, id: string): SkillHealthReport | null {
   const path = join(dir, `${id}.json`);
-  if (!existsSync(path)) return null;
-  try {
-    return JSON.parse(readFileSync(path, 'utf-8')) as SkillHealthReport;
-  } catch {
-    return null;
+  if (existsSync(path)) {
+    try { return JSON.parse(readFileSync(path, 'utf-8')) as SkillHealthReport; } catch { /* fall through to card */ }
   }
+  // 别项目:按 observe 卡片 path 读真身(含 signals 等完整详情)。悬空(项目被移走)→ null,详情页 404。
+  const card = listObserveCards().find((c) => c.id === id);
+  if (card && existsSync(card.path)) {
+    try { return JSON.parse(readFileSync(card.path, 'utf-8')) as SkillHealthReport; } catch { /* corrupt 真身 */ }
+  }
+  return null;
 }
 
 /** 扫 doctorsDir 找 id 匹配的 doctor 报告（文件名不一定等于 report id）。
  *  批量 doctor 会按 skill 拆成多份共享同一 id 的 per-skill 文件，传 skillName 时
  *  优先返回含该 skill 的那份；都不含时回退首个 id 命中（单 skill / 无参行为不变）。 */
 function loadDoctorReport(dir: string, id: string, skillName?: string): DoctorReport | null {
-  if (!existsSync(dir)) return null;
   let fallback: DoctorReport | null = null;
-  for (const file of readdirSync(dir)) {
-    if (!file.endsWith('.json')) continue;
+  if (existsSync(dir)) {
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith('.json')) continue;
+      try {
+        const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as DoctorReport;
+        if (data?.kind !== 'doctor' || data.id !== id) continue;
+        if (!skillName || data.skills?.some((s) => s.skillName === skillName)) return data;
+        fallback ??= data;
+      } catch { /* skip */ }
+    }
+  }
+  if (fallback) return fallback;
+  // 别项目:按 doctor 卡片(reportId 匹配 + 可选 skillName)的 path 读真身。detail 路由传的 id 是 reportId(非卡片 stem)。
+  for (const card of listDoctorCards()) {
+    if (card.reportId !== id) continue;
+    if (skillName && card.skillName !== skillName) continue;
+    if (!existsSync(card.path)) continue;
     try {
-      const data = JSON.parse(readFileSync(join(dir, file), 'utf-8')) as DoctorReport;
-      if (data?.kind !== 'doctor' || data.id !== id) continue;
-      if (!skillName || data.skills?.some((s) => s.skillName === skillName)) return data;
-      fallback ??= data;
-    } catch { /* skip */ }
+      const data = JSON.parse(readFileSync(card.path, 'utf-8')) as DoctorReport;
+      if (data?.kind === 'doctor' && data.id === id) {
+        if (!skillName || data.skills?.some((s) => s.skillName === skillName)) return data;
+        fallback ??= data;
+      }
+    } catch { /* corrupt 真身 */ }
   }
   return fallback;
 }

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -53,6 +53,12 @@ interface ReportServerOptions {
   managedDir?: string | (() => string);
   store?: ReportStore;
   jobStore?: JobStore;
+  /** 是否把别项目的 observe-health 索引卡片合进列表 / 详情 / skill 首页(机器级总览)。
+   *  默认 false(固定目录 / 测试 hermetic);studio 仅在「无 --analyses-dir 且无 --global」的默认机器级模式传 true。 */
+  includeObserveCards?: boolean;
+  /** 是否把别项目的 doctor 索引卡片合进 skill 首页 / 详情兜底(机器级总览)。
+   *  默认 false;studio 仅在「无 --doctors-dir 且无 --global」的默认机器级模式传 true。 */
+  includeDoctorCards?: boolean;
 }
 
 interface AnalysisListItem {
@@ -82,7 +88,7 @@ function loadChartJsBundle(): string | null {
   return cachedChartJsBytes;
 }
 
-function listAnalyses(dir: string): AnalysisListItem[] {
+function listAnalyses(dir: string, includeCards = false): AnalysisListItem[] {
   if (!existsSync(dir)) return [];
   const items: AnalysisListItem[] = [];
   for (const file of readdirSync(dir)) {
@@ -103,26 +109,31 @@ function listAnalyses(dir: string): AnalysisListItem[] {
     } catch { /* skip corrupt */ }
   }
   // 别项目的 observe 卡片(当前 dir live 扫不到的项目)→ list item,dedup by id(live 盖卡片)。
-  const seen = new Set(items.map((i) => i.id));
-  for (const card of listObserveCards()) {
-    if (seen.has(card.id)) continue;
-    items.push({
-      id: card.id, generatedAt: card.meta.generatedAt, sessionCount: card.meta.sessionCount,
-      segmentCount: card.meta.segmentCount, skillCount: Object.keys(card.bySkill).length,
-      healthBand: card.overall.healthBand, confidence: card.overall.confidence ?? confidenceOf(card.meta.segmentCount),
-    });
+  // 仅机器级模式合并;固定 --analyses-dir / --global 时 includeCards=false,只看该目录(逃生舱语义)。
+  if (includeCards) {
+    const seen = new Set(items.map((i) => i.id));
+    for (const card of listObserveCards()) {
+      if (seen.has(card.id)) continue;
+      items.push({
+        id: card.id, generatedAt: card.meta.generatedAt, sessionCount: card.meta.sessionCount,
+        segmentCount: card.meta.segmentCount, skillCount: Object.keys(card.bySkill).length,
+        healthBand: card.overall.healthBand, confidence: card.overall.confidence ?? confidenceOf(card.meta.segmentCount),
+      });
+    }
   }
   // 最新在前
   items.sort((a, b) => b.generatedAt.localeCompare(a.generatedAt));
   return items;
 }
 
-function loadAnalysis(dir: string, id: string): SkillHealthReport | null {
+function loadAnalysis(dir: string, id: string, includeCards = false): SkillHealthReport | null {
   const path = join(dir, `${id}.json`);
   if (existsSync(path)) {
     try { return JSON.parse(readFileSync(path, 'utf-8')) as SkillHealthReport; } catch { /* fall through to card */ }
   }
   // 别项目:按 observe 卡片 path 读真身(含 signals 等完整详情)。悬空(项目被移走)→ null,详情页 404。
+  // 仅机器级模式兜底;固定目录 / --global 不回源别项目卡片(逃生舱语义)。
+  if (!includeCards) return null;
   const card = listObserveCards().find((c) => c.id === id);
   if (card && existsSync(card.path)) {
     try { return JSON.parse(readFileSync(card.path, 'utf-8')) as SkillHealthReport; } catch { /* corrupt 真身 */ }
@@ -133,7 +144,7 @@ function loadAnalysis(dir: string, id: string): SkillHealthReport | null {
 /** 扫 doctorsDir 找 id 匹配的 doctor 报告（文件名不一定等于 report id）。
  *  批量 doctor 会按 skill 拆成多份共享同一 id 的 per-skill 文件，传 skillName 时
  *  优先返回含该 skill 的那份；都不含时回退首个 id 命中（单 skill / 无参行为不变）。 */
-function loadDoctorReport(dir: string, id: string, skillName?: string): DoctorReport | null {
+function loadDoctorReport(dir: string, id: string, skillName?: string, includeCards = false): DoctorReport | null {
   let fallback: DoctorReport | null = null;
   if (existsSync(dir)) {
     for (const file of readdirSync(dir)) {
@@ -147,6 +158,8 @@ function loadDoctorReport(dir: string, id: string, skillName?: string): DoctorRe
     }
   }
   if (fallback) return fallback;
+  // 仅机器级模式兜底;固定 --doctors-dir / --global 不回源别项目卡片(逃生舱语义)。
+  if (!includeCards) return null;
   // 别项目:按 doctor 卡片(reportId 匹配 + 可选 skillName)的 path 读真身。detail 路由传的 id 是 reportId(非卡片 stem)。
   for (const card of listDoctorCards()) {
     if (card.reportId !== id) continue;
@@ -189,11 +202,11 @@ interface SkillTrendResult {
 /**
  * 扫 analyses/ 所有 JSON,按 skillName 过滤,按时间排序成 trend points。
  */
-function querySkillTrend(dir: string, skillName: string): SkillTrendResult {
-  const items = listAnalyses(dir);
+function querySkillTrend(dir: string, skillName: string, includeCards = false): SkillTrendResult {
+  const items = listAnalyses(dir, includeCards);
   const points: SkillTrendPoint[] = [];
   for (const it of items) {
-    const report = loadAnalysis(dir, it.id);
+    const report = loadAnalysis(dir, it.id, includeCards);
     if (!report) continue;
     const h = report.bySkill[skillName];
     if (!h) continue;
@@ -251,9 +264,9 @@ interface SkillDiffResult {
  * 比较两份 skill health report. `from` 通常是较早的,`to` 是较晚的;
  * 对于每个 skill, 显示前后值和 delta. 缺失一侧时 presence 标记。
  */
-function querySkillDiff(dir: string, fromId: string, toId: string): SkillDiffResult | null {
-  const from = loadAnalysis(dir, fromId);
-  const to = loadAnalysis(dir, toId);
+function querySkillDiff(dir: string, fromId: string, toId: string, includeCards = false): SkillDiffResult | null {
+  const from = loadAnalysis(dir, fromId, includeCards);
+  const to = loadAnalysis(dir, toId, includeCards);
   if (!from || !to) return null;
   const allSkills = new Set<string>([...Object.keys(from.bySkill), ...Object.keys(to.bySkill)]);
   const rows: SkillDiffRow[] = [];
@@ -639,7 +652,7 @@ export function formatListenError(p: number, err: unknown): Error | null {
   return null;
 }
 
-export function createReportServer({ port, host: hostOption, reportsDir, analysesDir, doctorsDir, observationsDir = DEFAULT_OBSERVATIONS_DIR, jobsDir = DEFAULT_JOBS_DIR, managedDir, store, jobStore }: ReportServerOptions = {}): ReportServer {
+export function createReportServer({ port, host: hostOption, reportsDir, analysesDir, doctorsDir, observationsDir = DEFAULT_OBSERVATIONS_DIR, jobsDir = DEFAULT_JOBS_DIR, managedDir, store, jobStore, includeObserveCards = false, includeDoctorCards = false }: ReportServerOptions = {}): ReportServer {
   let server: Server | null = null;
   let serverUrl: string | null = null;
 
@@ -753,13 +766,13 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
 
       if (path === '/api/observe-health') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(listAnalyses(analysesDir)));
+        res.end(JSON.stringify(listAnalyses(analysesDir, includeObserveCards)));
         return;
       }
 
       if (path === '/observe-health') {
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(renderAnalysisList(listAnalyses(analysesDir), lang));
+        res.end(renderAnalysisList(listAnalyses(analysesDir, includeObserveCards), lang));
         return;
       }
 
@@ -821,7 +834,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
 
       if (path === '/api/observe-inbox/diagnostics') {
         const runs = await reportStore.list();
-        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir);
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
         res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
         res.end(JSON.stringify({
           sourceCoverage: idx.diagnosisSummary.sourceCoverage,
@@ -901,7 +914,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
       if (doctorDetailMatch) {
         const id = decodeURIComponent(doctorDetailMatch[1]);
         const skillName = parsed.searchParams.get('skill') ?? '';
-        const report = loadDoctorReport(doctorsDir, id, skillName || undefined);
+        const report = loadDoctorReport(doctorsDir, id, skillName || undefined, includeDoctorCards);
         if (!report) {
           res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
           res.end(lang === 'en' ? 'doctor report not found' : '体检报告不存在');
@@ -910,7 +923,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
         let ctx: SkillReportContext | undefined;
         if (skillName) {
           const runs = await reportStore.list();
-          const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir);
+          const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
           const entry = idx.entries.find((en) => en.skillName === skillName);
           if (entry) ctx = buildSkillContext(entry, 'doctor', id, idx.insightsBySkill.get(entry.skillName) ?? [], lang);
         }
@@ -923,7 +936,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
       const analysisDetailMatch = path.match(/^\/observe-health\/(.+)$/);
       if (analysisDetailMatch) {
         const id = decodeURIComponent(analysisDetailMatch[1]);
-        const report = loadAnalysis(analysesDir, id);
+        const report = loadAnalysis(analysesDir, id, includeObserveCards);
         if (!report) {
           res.writeHead(404, { 'Content-Type': 'text/plain' });
           res.end('analysis not found');
@@ -937,7 +950,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
       const analysisApiMatch = path.match(/^\/api\/observe-health\/(.+)$/);
       if (analysisApiMatch) {
         const id = decodeURIComponent(analysisApiMatch[1]);
-        const report = loadAnalysis(analysesDir, id);
+        const report = loadAnalysis(analysesDir, id, includeObserveCards);
         if (!report) {
           res.writeHead(404, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'analysis not found' }));
@@ -952,7 +965,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
       if (skillTrendApiMatch) {
         const skillName = decodeURIComponent(skillTrendApiMatch[1]);
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(querySkillTrend(analysesDir, skillName)));
+        res.end(JSON.stringify(querySkillTrend(analysesDir, skillName, includeObserveCards)));
         return;
       }
 
@@ -960,7 +973,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
       if (skillTrendPageMatch) {
         const skillName = decodeURIComponent(skillTrendPageMatch[1]);
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(renderSkillTrendPage(querySkillTrend(analysesDir, skillName), lang));
+        res.end(renderSkillTrendPage(querySkillTrend(analysesDir, skillName, includeObserveCards), lang));
         return;
       }
 
@@ -972,7 +985,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
           res.end('missing from/to query params');
           return;
         }
-        const diff = querySkillDiff(analysesDir, fromId, toId);
+        const diff = querySkillDiff(analysesDir, fromId, toId, includeObserveCards);
         if (!diff) {
           res.writeHead(404, { 'Content-Type': 'text/plain' });
           res.end('analysis not found');
@@ -991,7 +1004,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
           res.end(JSON.stringify({ error: 'missing from/to query params' }));
           return;
         }
-        const diff = querySkillDiff(analysesDir, fromId, toId);
+        const diff = querySkillDiff(analysesDir, fromId, toId, includeObserveCards);
         if (!diff) {
           res.writeHead(404, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'analysis not found' }));
@@ -1084,7 +1097,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
         let ctx: SkillReportContext | undefined;
         if (report && report.kind === 'evaluation') {
           const runs = await reportStore.list();
-          const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir);
+          const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
           // 按 evalHistory 匹配(非仅最新),历史 eval 报告也能定位到所属 skill。
           const entry = idx.entries.find((en) => en.evalHistory.some((h) => h.reportId === reportId));
           if (entry) ctx = buildSkillContext(entry, 'eval', reportId, idx.insightsBySkill.get(entry.skillName) ?? [], lang);
@@ -1107,7 +1120,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
       // list renderer 直接消费,不再每请求 N×detectInsights 重算。
       if (path === '/') {
         const runs = await reportStore.list();
-        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir);
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(renderSkillList(idx, lang));
         return;
@@ -1115,7 +1128,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
 
       if (path === '/api/skills') {
         const runs = await reportStore.list();
-        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir);
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
         res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
         res.end(JSON.stringify({
           entries: idx.entries.map((entry) => ({
@@ -1138,7 +1151,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
       if (skillDiagnosticsApiMatch) {
         const skillName = decodeURIComponent(skillDiagnosticsApiMatch[1]);
         const runs = await reportStore.list();
-        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir);
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
         const diagnostics = idx.diagnosticsBySkill.get(skillName);
         if (!diagnostics) {
           res.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -34,7 +34,7 @@ import type {
 import type { SkillHealthReport } from '../observability/skill-health-analyzer.js';
 import { confidenceOf } from '../observability/skill-health-analyzer.js';
 import { computeVerdict } from '../eval-core/verdict.js';
-import { artifactIndexDir, listDoctorCards, cardToDoctorSnapshot, listObserveCards } from '../eval-core/artifact-index.js';
+import { artifactIndexDir, listLiveDoctorCards, cardToDoctorSnapshot, listLiveObserveCards } from '../eval-core/artifact-index.js';
 import { detectInsights } from './skill-insights.js';
 import { DEFAULT_OBSERVATIONS_DIR, loadLatestObservationInboxReports } from '../observability/inbox.js';
 import { buildStudioDiagnosisSummary, mergeDiagnosisBundles } from '../diagnosis/studio-projection.js';
@@ -391,7 +391,7 @@ export function buildSkillIndex(
   // 别项目的 observe 卡片(当前 analysesDir live 扫不到的项目)→ per-skill snapshot,dedup by analysisId(live 盖卡片)。
   // 仅机器级模式合并;固定 --analyses-dir / --global 时 includeObserveCards=false,只看该目录(逃生舱语义)。
   if (includeObserveCards) {
-    for (const card of listObserveCards()) {
+    for (const card of listLiveObserveCards()) {
       for (const [skill, h] of Object.entries(card.bySkill)) {
         const list = (observeBy[skill] ??= []);
         if (list.some((s) => s.analysisId === card.id)) continue;
@@ -410,7 +410,7 @@ export function buildSkillIndex(
   // 别项目的 doctor 卡片 → per-skill snapshot,dedup by reportId(live 盖卡片);prune 删正文时已连带删卡片,故无「复活」。
   // 仅机器级模式合并;固定 --doctors-dir / --global 时 includeDoctorCards=false,只看该目录(逃生舱语义)。
   if (includeDoctorCards) {
-    for (const card of listDoctorCards()) {
+    for (const card of listLiveDoctorCards()) {
       const { skillName, snap } = cardToDoctorSnapshot(card);
       const list = (doctorBy[skillName] ??= []);
       if (!list.some((s) => s.reportId === snap.reportId)) list.push(snap);

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -34,7 +34,7 @@ import type {
 import type { SkillHealthReport } from '../observability/skill-health-analyzer.js';
 import { confidenceOf } from '../observability/skill-health-analyzer.js';
 import { computeVerdict } from '../eval-core/verdict.js';
-import { artifactIndexDir, listLiveDoctorCards, cardToDoctorSnapshot, listLiveObserveCards } from '../eval-core/artifact-index.js';
+import { artifactIndexDir, listLiveDoctorCards, cardToDoctorSnapshot, listLiveObserveCards, cardTargetSentinel } from '../eval-core/artifact-index.js';
 import { detectInsights } from './skill-insights.js';
 import { DEFAULT_OBSERVATIONS_DIR, loadLatestObservationInboxReports } from '../observability/inbox.js';
 import { buildStudioDiagnosisSummary, mergeDiagnosisBundles } from '../diagnosis/studio-projection.js';
@@ -142,8 +142,9 @@ function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, d
   // 别项目的 doctor / observe 卡片也进 fingerprint:否则别项目新跑一份后,本项目 studio 因缓存命中看不到更新。
   // 仅在对应域开启卡片合并(机器级模式)时才纳入 —— 固定目录 / --global 模式不合卡片,卡片变化不应触发重算;
   // 且 include 标志本身进 fingerprint,避免同目录在 include on/off 两种模式间命中错误缓存。
-  const doctorCardsFp = includeDoctorCards ? safeDirJsonContentFingerprint(artifactIndexDir('doctor')) : '';
-  const observeCardsFp = includeObserveCards ? safeDirJsonContentFingerprint(artifactIndexDir('observe-health')) : '';
+  // 卡片目录指纹 + 真身存在性 sentinel 都纳入:后者使「卡片真身被带外删」也能让缓存失效(否则悬空卡片继续展示)。
+  const doctorCardsFp = includeDoctorCards ? `${safeDirJsonContentFingerprint(artifactIndexDir('doctor'))}|t:${cardTargetSentinel('doctor')}` : '';
+  const observeCardsFp = includeObserveCards ? `${safeDirJsonContentFingerprint(artifactIndexDir('observe-health'))}|t:${cardTargetSentinel('observe-health')}` : '';
   return `${reportIds}|d:${doctorsFp}|o:${analysesFp}|obs:${observationsFp}|dc:${doctorCardsFp}|oc:${observeCardsFp}|inc:${includeObserveCards ? 'o' : ''}${includeDoctorCards ? 'd' : ''}`;
 }
 

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -34,6 +34,7 @@ import type {
 import type { SkillHealthReport } from '../observability/skill-health-analyzer.js';
 import { confidenceOf } from '../observability/skill-health-analyzer.js';
 import { computeVerdict } from '../eval-core/verdict.js';
+import { artifactIndexDir, listDoctorCards, cardToDoctorSnapshot, listObserveCards } from '../eval-core/artifact-index.js';
 import { detectInsights } from './skill-insights.js';
 import { DEFAULT_OBSERVATIONS_DIR, loadLatestObservationInboxReports } from '../observability/inbox.js';
 import { buildStudioDiagnosisSummary, mergeDiagnosisBundles } from '../diagnosis/studio-projection.js';
@@ -138,7 +139,10 @@ function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, d
   const doctorsFp = safeDirJsonContentFingerprint(doctorsDir);
   const analysesFp = safeDirJsonContentFingerprint(analysesDir);
   const observationsFp = safeDirJsonContentFingerprint(observationsDir);
-  return `${reportIds}|d:${doctorsFp}|o:${analysesFp}|obs:${observationsFp}`;
+  // 别项目的 doctor / observe 卡片也进 fingerprint:否则别项目新跑一份后,本项目 studio 因缓存命中看不到更新。
+  const doctorCardsFp = safeDirJsonContentFingerprint(artifactIndexDir('doctor'));
+  const observeCardsFp = safeDirJsonContentFingerprint(artifactIndexDir('observe-health'));
+  return `${reportIds}|d:${doctorsFp}|o:${analysesFp}|obs:${observationsFp}|dc:${doctorCardsFp}|oc:${observeCardsFp}`;
 }
 
 /** 测试 / 调试用:强制清掉 in-process skill-index 缓存。 */
@@ -372,10 +376,29 @@ export function buildSkillIndex(
       } catch { /* skip corrupt */ }
     }
   }
+  // 别项目的 observe 卡片(当前 analysesDir live 扫不到的项目)→ per-skill snapshot,dedup by analysisId(live 盖卡片)。
+  for (const card of listObserveCards()) {
+    for (const [skill, h] of Object.entries(card.bySkill)) {
+      const list = (observeBy[skill] ??= []);
+      if (list.some((s) => s.analysisId === card.id)) continue;
+      list.push({
+        analysisId: card.id, generatedAt: card.meta.generatedAt,
+        healthBand: bandFromObserveHealth(h), failureRate: h.toolFailureRate, segmentCount: h.segmentCount,
+        gapRate: h.gap?.weightedGapRate ?? 0, confidence: h.confidence ?? confidenceOf(h.segmentCount),
+      });
+    }
+  }
   for (const list of Object.values(observeBy)) list.sort((a, b) => a.generatedAt.localeCompare(b.generatedAt));
 
   // ── doctor 聚合(历史 list)──────────────────────────────
   const doctorBy = scanDoctorReports(doctorsDir);
+  // 别项目的 doctor 卡片 → per-skill snapshot,dedup by reportId(live 盖卡片);prune 删正文时已连带删卡片,故无「复活」。
+  for (const card of listDoctorCards()) {
+    const { skillName, snap } = cardToDoctorSnapshot(card);
+    const list = (doctorBy[skillName] ??= []);
+    if (!list.some((s) => s.reportId === snap.reportId)) list.push(snap);
+  }
+  for (const list of Object.values(doctorBy)) list.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
   const diagnosisBundle = mergeDiagnosisBundles(
     loadLatestObservationInboxReports(observationsDir).flatMap((report) => report.diagnostics ? [report.diagnostics] : []),
     new Date().toISOString(),

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -129,7 +129,7 @@ function safeDirJsonContentFingerprint(dir: string): string {
   return `${dir}|${dirMtimeMs}|${fileParts.join(',')}`;
 }
 
-function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, doctorsDir: string, observationsDir: string): string {
+function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, doctorsDir: string, observationsDir: string, includeObserveCards: boolean, includeDoctorCards: boolean): string {
   // `d:` 跟 `o:` 前缀("d for doctors / o for observability analyses")沿用 pre-fix
   // 字面格式,避免外部 logging / debug 时 grep fingerprint 字符串的格式漂移。
   // 每一段的 right-hand-side 从旧的 "{dir-mtime}-{file-count}" 双标量升级成
@@ -140,9 +140,11 @@ function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, d
   const analysesFp = safeDirJsonContentFingerprint(analysesDir);
   const observationsFp = safeDirJsonContentFingerprint(observationsDir);
   // 别项目的 doctor / observe 卡片也进 fingerprint:否则别项目新跑一份后,本项目 studio 因缓存命中看不到更新。
-  const doctorCardsFp = safeDirJsonContentFingerprint(artifactIndexDir('doctor'));
-  const observeCardsFp = safeDirJsonContentFingerprint(artifactIndexDir('observe-health'));
-  return `${reportIds}|d:${doctorsFp}|o:${analysesFp}|obs:${observationsFp}|dc:${doctorCardsFp}|oc:${observeCardsFp}`;
+  // 仅在对应域开启卡片合并(机器级模式)时才纳入 —— 固定目录 / --global 模式不合卡片,卡片变化不应触发重算;
+  // 且 include 标志本身进 fingerprint,避免同目录在 include on/off 两种模式间命中错误缓存。
+  const doctorCardsFp = includeDoctorCards ? safeDirJsonContentFingerprint(artifactIndexDir('doctor')) : '';
+  const observeCardsFp = includeObserveCards ? safeDirJsonContentFingerprint(artifactIndexDir('observe-health')) : '';
+  return `${reportIds}|d:${doctorsFp}|o:${analysesFp}|obs:${observationsFp}|dc:${doctorCardsFp}|oc:${observeCardsFp}|inc:${includeObserveCards ? 'o' : ''}${includeDoctorCards ? 'd' : ''}`;
 }
 
 /** 测试 / 调试用:强制清掉 in-process skill-index 缓存。 */
@@ -322,14 +324,24 @@ function scanDoctorReports(dir: string): Record<string, SkillDoctorSnapshot[]> {
  *
  * 同 skill 多份报告时取 timestamp 最新的一份。
  */
+export interface BuildSkillIndexOptions {
+  /** 合并别项目 observe 卡片(机器级模式)。固定 --analyses-dir / --global 时为 false,只看该目录。 */
+  includeObserveCards?: boolean;
+  /** 合并别项目 doctor 卡片(机器级模式)。固定 --doctors-dir / --global 时为 false,只看该目录。 */
+  includeDoctorCards?: boolean;
+}
+
 export function buildSkillIndex(
   reports: ReportDocument[],
   analysesDir: string,
   doctorsDir: string,
   observationsDir: string = DEFAULT_OBSERVATIONS_DIR,
+  opts: BuildSkillIndexOptions = {},
 ): SkillIndex {
-  // 命中缓存就直接返回(fingerprint 覆盖 reports + 两个 dir 的变化信号)
-  const fp = buildIndexFingerprint(reports, analysesDir, doctorsDir, observationsDir);
+  const includeObserveCards = opts.includeObserveCards ?? false;
+  const includeDoctorCards = opts.includeDoctorCards ?? false;
+  // 命中缓存就直接返回(fingerprint 覆盖 reports + 两个 dir + 卡片 include 模式的变化信号)
+  const fp = buildIndexFingerprint(reports, analysesDir, doctorsDir, observationsDir, includeObserveCards, includeDoctorCards);
   if (_indexCache && _indexCache.fingerprint === fp) {
     return _indexCache.result;
   }
@@ -377,15 +389,18 @@ export function buildSkillIndex(
     }
   }
   // 别项目的 observe 卡片(当前 analysesDir live 扫不到的项目)→ per-skill snapshot,dedup by analysisId(live 盖卡片)。
-  for (const card of listObserveCards()) {
-    for (const [skill, h] of Object.entries(card.bySkill)) {
-      const list = (observeBy[skill] ??= []);
-      if (list.some((s) => s.analysisId === card.id)) continue;
-      list.push({
-        analysisId: card.id, generatedAt: card.meta.generatedAt,
-        healthBand: bandFromObserveHealth(h), failureRate: h.toolFailureRate, segmentCount: h.segmentCount,
-        gapRate: h.gap?.weightedGapRate ?? 0, confidence: h.confidence ?? confidenceOf(h.segmentCount),
-      });
+  // 仅机器级模式合并;固定 --analyses-dir / --global 时 includeObserveCards=false,只看该目录(逃生舱语义)。
+  if (includeObserveCards) {
+    for (const card of listObserveCards()) {
+      for (const [skill, h] of Object.entries(card.bySkill)) {
+        const list = (observeBy[skill] ??= []);
+        if (list.some((s) => s.analysisId === card.id)) continue;
+        list.push({
+          analysisId: card.id, generatedAt: card.meta.generatedAt,
+          healthBand: bandFromObserveHealth(h), failureRate: h.toolFailureRate, segmentCount: h.segmentCount,
+          gapRate: h.gap?.weightedGapRate ?? 0, confidence: h.confidence ?? confidenceOf(h.segmentCount),
+        });
+      }
     }
   }
   for (const list of Object.values(observeBy)) list.sort((a, b) => a.generatedAt.localeCompare(b.generatedAt));
@@ -393,10 +408,13 @@ export function buildSkillIndex(
   // ── doctor 聚合(历史 list)──────────────────────────────
   const doctorBy = scanDoctorReports(doctorsDir);
   // 别项目的 doctor 卡片 → per-skill snapshot,dedup by reportId(live 盖卡片);prune 删正文时已连带删卡片,故无「复活」。
-  for (const card of listDoctorCards()) {
-    const { skillName, snap } = cardToDoctorSnapshot(card);
-    const list = (doctorBy[skillName] ??= []);
-    if (!list.some((s) => s.reportId === snap.reportId)) list.push(snap);
+  // 仅机器级模式合并;固定 --doctors-dir / --global 时 includeDoctorCards=false,只看该目录(逃生舱语义)。
+  if (includeDoctorCards) {
+    for (const card of listDoctorCards()) {
+      const { skillName, snap } = cardToDoctorSnapshot(card);
+      const list = (doctorBy[skillName] ??= []);
+      if (!list.some((s) => s.reportId === snap.reportId)) list.push(snap);
+    }
   }
   for (const list of Object.values(doctorBy)) list.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
   const diagnosisBundle = mergeDiagnosisBundles(

--- a/test/cli/observe-persist.test.ts
+++ b/test/cli/observe-persist.test.ts
@@ -1,0 +1,57 @@
+/**
+ * persistObserveHealthReport 验收:id / 文件名加随机段,根治「同秒两次 observe 直接覆盖、数据丢失」的 bug;
+ * 落盘后写 observe 索引卡片。隔离 OMK_ARTIFACT_INDEX_DIR,不碰真实 home。
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { persistObserveHealthReport } from '../../src/cli/commands/observe/index.js';
+import { listObserveCards } from '../../src/eval-core/artifact-index.js';
+import type { SkillHealthReport } from '../../src/observability/skill-health-analyzer.js';
+
+function mkReport(): SkillHealthReport {
+  return {
+    kind: 'observe-health',
+    meta: { tracePath: '/t', kbPath: null, sessionCount: 1, segmentCount: 10, messageCount: 5,
+      toolCallCount: 3, toolFailureRate: 0.0, timeRange: { from: 'a', to: 'b' }, generatedAt: '2026-06-14T00:00:00Z' },
+    bySkill: {},
+    overall: { gapRate: 0, weightedGapRate: 0, healthBand: 'green', confidence: 'high' },
+  };
+}
+
+describe('persistObserveHealthReport', () => {
+  let outDir: string; let indexRoot: string; let origEnv: string | undefined;
+
+  beforeEach(() => {
+    origEnv = process.env.OMK_ARTIFACT_INDEX_DIR;
+    outDir = mkdtempSync(join(tmpdir(), 'omk-obp-out-'));
+    indexRoot = mkdtempSync(join(tmpdir(), 'omk-obp-idx-'));
+    process.env.OMK_ARTIFACT_INDEX_DIR = indexRoot;
+  });
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.OMK_ARTIFACT_INDEX_DIR;
+    else process.env.OMK_ARTIFACT_INDEX_DIR = origEnv;
+    for (const d of [outDir, indexRoot]) rmSync(d, { recursive: true, force: true });
+  });
+
+  it('同秒两次落盘 → 两个不同文件 / id,不覆盖(修数据丢失 bug)', () => {
+    const a = persistObserveHealthReport(mkReport(), outDir);
+    const b = persistObserveHealthReport(mkReport(), outDir);
+    assert.notEqual(a.id, b.id, '两次 id 不同(随机段)');
+    assert.notEqual(a.jsonPath, b.jsonPath);
+    assert.equal(readdirSync(outDir).filter((f) => f.endsWith('.json')).length, 2, '两份都在,无覆盖');
+  });
+
+  it('文件名保留 -observe-health.json 后缀(resolver / listAnalyses / loadAnalysis 依赖)', () => {
+    const { id, jsonPath } = persistObserveHealthReport(mkReport(), outDir);
+    assert.ok(id.endsWith('-observe-health'), 'id stem 以 -observe-health 结尾');
+    assert.ok(jsonPath.endsWith('-observe-health.json'));
+  });
+
+  it('落盘后写 observe 索引卡片(非全局目录)', () => {
+    const { id } = persistObserveHealthReport(mkReport(), outDir);
+    assert.deepEqual(listObserveCards().map((c) => c.id), [id]);
+  });
+});

--- a/test/eval-core/artifact-index-doctor-observe.test.ts
+++ b/test/eval-core/artifact-index-doctor-observe.test.ts
@@ -1,0 +1,130 @@
+/**
+ * 产物发现索引 doctor / observe-health 两域写侧验收:项目写落卡片(剥重体)、全局写跳过、卡片投影、删除幂等。
+ * 全程把 OMK_ARTIFACT_INDEX_DIR 指到 per-test temp,不碰真实 ~/.oh-my-knowledge/state。
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  indexDoctorWrite, listDoctorCards, cardToDoctorSnapshot, removeDoctorCard,
+  indexObserveWrite, listObserveCards, removeObserveCard, artifactIndexDir,
+} from '../../src/eval-core/artifact-index.js';
+import { globalDoctorsDir, globalObserveHealthDir } from '../../src/eval-core/measurement-dirs.js';
+
+describe('artifact-index 写侧(doctor 域)', () => {
+  let indexRoot: string;
+  let projDir: string;
+  let origEnv: string | undefined;
+
+  beforeEach(() => {
+    origEnv = process.env.OMK_ARTIFACT_INDEX_DIR;
+    indexRoot = mkdtempSync(join(tmpdir(), 'omk-ai-didx-'));
+    projDir = mkdtempSync(join(tmpdir(), 'omk-ai-dproj-'));
+    process.env.OMK_ARTIFACT_INDEX_DIR = indexRoot;
+  });
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.OMK_ARTIFACT_INDEX_DIR;
+    else process.env.OMK_ARTIFACT_INDEX_DIR = origEnv;
+    rmSync(indexRoot, { recursive: true, force: true });
+    rmSync(projDir, { recursive: true, force: true });
+  });
+
+  function doctorCard(id = 'sk-doctor-20260614-1-ab12', skillName = 'sk') {
+    return { id, path: join(projDir, `${id}.json`), skillName, reportId: 'doctor-20260614-1-ab12',
+      timestamp: '2026-06-14T00:00:00Z', status: 'pass' as const, passCount: 3, warnCount: 0, failCount: 0 };
+  }
+
+  it('项目写 → 落卡片(带 skillName/reportId/计数,无 results)', () => {
+    indexDoctorWrite(doctorCard(), projDir);
+    const cards = listDoctorCards();
+    assert.equal(cards.length, 1);
+    assert.equal(cards[0].skillName, 'sk');
+    assert.equal(cards[0].reportId, 'doctor-20260614-1-ab12');
+    assert.equal(cards[0].passCount, 3);
+    assert.ok(!('results' in cards[0]), '卡片不含逐规则 results 重体');
+  });
+
+  it('全局写 → 不落卡片(shouldIndexDir false)', () => {
+    indexDoctorWrite(doctorCard(), globalDoctorsDir());
+    assert.equal(listDoctorCards().length, 0);
+  });
+
+  it('cardToDoctorSnapshot:卡片 → SkillDoctorSnapshot(results:[])', () => {
+    indexDoctorWrite(doctorCard(), projDir);
+    const { skillName, snap } = cardToDoctorSnapshot(listDoctorCards()[0]);
+    assert.equal(skillName, 'sk');
+    assert.equal(snap.reportId, 'doctor-20260614-1-ab12');
+    assert.equal(snap.passCount, 3);
+    assert.deepEqual(snap.results, []);
+  });
+
+  it('removeDoctorCard 幂等', () => {
+    indexDoctorWrite(doctorCard('sk-r3'), projDir);
+    assert.equal(removeDoctorCard('sk-r3'), true);
+    assert.equal(listDoctorCards().length, 0);
+    assert.equal(removeDoctorCard('sk-r3'), false, '再删返回 false');
+  });
+
+  it('坏 domain 卡片读侧跳过', () => {
+    const dir = artifactIndexDir('doctor');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'bad.json'), JSON.stringify({ domain: 'report', id: 'bad' }));
+    indexDoctorWrite(doctorCard('sk-good'), projDir);
+    assert.deepEqual(listDoctorCards().map((c) => c.id), ['sk-good']);
+  });
+});
+
+describe('artifact-index 写侧(observe-health 域)', () => {
+  let indexRoot: string;
+  let projDir: string;
+  let origEnv: string | undefined;
+
+  beforeEach(() => {
+    origEnv = process.env.OMK_ARTIFACT_INDEX_DIR;
+    indexRoot = mkdtempSync(join(tmpdir(), 'omk-ai-oidx-'));
+    projDir = mkdtempSync(join(tmpdir(), 'omk-ai-oproj-'));
+    process.env.OMK_ARTIFACT_INDEX_DIR = indexRoot;
+  });
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.OMK_ARTIFACT_INDEX_DIR;
+    else process.env.OMK_ARTIFACT_INDEX_DIR = origEnv;
+    rmSync(indexRoot, { recursive: true, force: true });
+    rmSync(projDir, { recursive: true, force: true });
+  });
+
+  // 结构子集 + 故意塞一个重体 signals 数组,验证卡片把它剥掉。
+  function observeReport() {
+    return {
+      meta: { generatedAt: '2026-06-14T00:00:00Z', sessionCount: 5, segmentCount: 40 },
+      overall: { healthBand: 'green' as const, confidence: 'high' as const },
+      bySkill: {
+        sk: { toolFailureRate: 0.1, segmentCount: 40, confidence: 'high' as const,
+          gap: { weightedGapRate: 0.2, signals: new Array(100).fill({ heavy: true }) } },
+      },
+    };
+  }
+
+  it('项目写 → 落卡片(meta+overall+per-skill 标量,剥掉 gap.signals 重体)', () => {
+    indexObserveWrite(observeReport(), join(projDir, 'a-observe-health.json'), projDir, 'a-observe-health');
+    const cards = listObserveCards();
+    assert.equal(cards.length, 1);
+    assert.equal(cards[0].overall.healthBand, 'green');
+    assert.equal(cards[0].bySkill.sk.toolFailureRate, 0.1);
+    assert.equal(cards[0].bySkill.sk.gap?.weightedGapRate, 0.2);
+    assert.ok(!('signals' in (cards[0].bySkill.sk.gap ?? {})), '卡片剥掉 gap.signals 重体');
+  });
+
+  it('全局写 → 不落卡片', () => {
+    indexObserveWrite(observeReport(), join(globalObserveHealthDir(), 'g.json'), globalObserveHealthDir(), 'g');
+    assert.equal(listObserveCards().length, 0);
+  });
+
+  it('removeObserveCard 幂等', () => {
+    indexObserveWrite(observeReport(), join(projDir, 'x-observe-health.json'), projDir, 'x-observe-health');
+    assert.equal(removeObserveCard('x-observe-health'), true);
+    assert.equal(listObserveCards().length, 0);
+    assert.equal(removeObserveCard('x-observe-health'), false);
+  });
+});

--- a/test/eval-core/artifact-index-doctor-observe.test.ts
+++ b/test/eval-core/artifact-index-doctor-observe.test.ts
@@ -151,7 +151,11 @@ describe('artifact-index 写侧(observe-health 域)', () => {
     writeFileSync(join(dir, 'b2.json'), JSON.stringify({ domain: 'observe-health', id: 'b2', path: '/x',
       meta: { generatedAt: 't', sessionCount: 1, segmentCount: 1 }, overall: { healthBand: 'green' },
       bySkill: { s: { toolFailureRate: 'nope', segmentCount: 1 } } }));
+    // 坏 gap.weightedGapRate(非数 → 会流进 gapRate / 阈值判定)
+    writeFileSync(join(dir, 'b3.json'), JSON.stringify({ domain: 'observe-health', id: 'b3', path: '/x',
+      meta: { generatedAt: 't', sessionCount: 1, segmentCount: 1 }, overall: { healthBand: 'green' },
+      bySkill: { s: { toolFailureRate: 0, segmentCount: 1, gap: { weightedGapRate: 'nan' } } } }));
     indexObserveWrite(observeReport(), join(projDir, 'ok-observe-health.json'), projDir, 'ok-observe-health');
-    assert.deepEqual(listObserveCards().map((c) => c.id), ['ok-observe-health'], '只收 healthBand 合法 + 标量为有限数的卡片');
+    assert.deepEqual(listObserveCards().map((c) => c.id), ['ok-observe-health'], '只收 healthBand 合法 + 全标量(含 gap.weightedGapRate)为有限数的卡片');
   });
 });

--- a/test/eval-core/artifact-index-doctor-observe.test.ts
+++ b/test/eval-core/artifact-index-doctor-observe.test.ts
@@ -74,6 +74,19 @@ describe('artifact-index 写侧(doctor 域)', () => {
     indexDoctorWrite(doctorCard('sk-good'), projDir);
     assert.deepEqual(listDoctorCards().map((c) => c.id), ['sk-good']);
   });
+
+  it('坏 status / 缺计数字段的卡片读侧从严跳过(不让 undefined/NaN 当可信输入)', () => {
+    const dir = artifactIndexDir('doctor');
+    mkdirSync(dir, { recursive: true });
+    // 坏 status
+    writeFileSync(join(dir, 'b1.json'), JSON.stringify({ domain: 'doctor', id: 'b1', path: '/x', skillName: 's',
+      reportId: 'r', timestamp: 't', status: 'bogus', passCount: 0, warnCount: 0, failCount: 0 }));
+    // 缺计数字段
+    writeFileSync(join(dir, 'b2.json'), JSON.stringify({ domain: 'doctor', id: 'b2', path: '/x', skillName: 's',
+      reportId: 'r', timestamp: 't', status: 'pass' }));
+    indexDoctorWrite(doctorCard('sk-ok'), projDir);
+    assert.deepEqual(listDoctorCards().map((c) => c.id), ['sk-ok'], '只收字段齐全且枚举合法的卡片');
+  });
 });
 
 describe('artifact-index 写侧(observe-health 域)', () => {
@@ -126,5 +139,19 @@ describe('artifact-index 写侧(observe-health 域)', () => {
     assert.equal(removeObserveCard('x-observe-health'), true);
     assert.equal(listObserveCards().length, 0);
     assert.equal(removeObserveCard('x-observe-health'), false);
+  });
+
+  it('坏 healthBand / 非数标量的卡片读侧从严跳过', () => {
+    const dir = artifactIndexDir('observe-health');
+    mkdirSync(dir, { recursive: true });
+    // 坏 overall.healthBand
+    writeFileSync(join(dir, 'b1.json'), JSON.stringify({ domain: 'observe-health', id: 'b1', path: '/x',
+      meta: { generatedAt: 't', sessionCount: 1, segmentCount: 1 }, overall: { healthBand: 'purple' }, bySkill: {} }));
+    // 坏 per-skill 标量(toolFailureRate 非数)
+    writeFileSync(join(dir, 'b2.json'), JSON.stringify({ domain: 'observe-health', id: 'b2', path: '/x',
+      meta: { generatedAt: 't', sessionCount: 1, segmentCount: 1 }, overall: { healthBand: 'green' },
+      bySkill: { s: { toolFailureRate: 'nope', segmentCount: 1 } } }));
+    indexObserveWrite(observeReport(), join(projDir, 'ok-observe-health.json'), projDir, 'ok-observe-health');
+    assert.deepEqual(listObserveCards().map((c) => c.id), ['ok-observe-health'], '只收 healthBand 合法 + 标量为有限数的卡片');
   });
 });

--- a/test/server/card-gate-server.test.ts
+++ b/test/server/card-gate-server.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createReportServer } from '../../src/server/report-server.js';
@@ -30,10 +30,15 @@ describe('卡片合并 include 开关(server 级)', () => {
     // 别项目卡片各一张(live 目录扫不到,只能靠卡片发现)。
     indexDoctorWrite({ id: 'cg-doctor-1-aa', path: join(proj, 'cg.json'), skillName: 'cg-skill', reportId: 'doctor-cg-1-aa',
       timestamp: '2026-06-14T00:00:00Z', status: 'pass', passCount: 1, warnCount: 0, failCount: 0 }, proj);
-    indexObserveWrite({ meta: { generatedAt: '2026-06-14T01:00:00Z', sessionCount: 1, segmentCount: 10 },
-      overall: { healthBand: 'green', confidence: 'high' },
-      bySkill: { 'cg-skill': { toolFailureRate: 0, segmentCount: 10, confidence: 'high', gap: { weightedGapRate: 0 } } },
-    } as never, join(proj, 'cg-observe-health.json'), proj, 'cg-observe-health');
+    const obsReport = { kind: 'observe-health',
+      meta: { tracePath: '/t', kbPath: null, sessionCount: 1, segmentCount: 10, messageCount: 5, toolCallCount: 3,
+        toolFailureRate: 0, timeRange: { from: 'a', to: 'b' }, generatedAt: '2026-06-14T01:00:00Z' },
+      bySkill: { 'cg-skill': { skillName: 'cg-skill', segmentCount: 10, toolCallCount: 3, toolFailureCount: 0,
+        toolFailureRate: 0, stability: 1, confidence: 'high', gap: { gapRate: 0, weightedGapRate: 0, signals: [] } } },
+      overall: { gapRate: 0, weightedGapRate: 0, healthBand: 'green', confidence: 'high' } };
+    // 同时写「真身文件」(供 loadAnalysis 按 card.path 回源,如 skill-trend 详情)+ 卡片。
+    writeFileSync(join(proj, 'cg-observe-health.json'), JSON.stringify(obsReport));
+    indexObserveWrite(obsReport as never, join(proj, 'cg-observe-health.json'), proj, 'cg-observe-health');
   });
   afterEach(() => {
     if (origEnv === undefined) delete process.env.OMK_ARTIFACT_INDEX_DIR;
@@ -67,6 +72,23 @@ describe('卡片合并 include 开关(server 级)', () => {
       assert.deepEqual(oh.map((x: { id: string }) => x.id), ['cg-observe-health'], '机器级模式合 observe 卡片');
       const sk = await (await fetch(`${url}/api/skills`)).json();
       assert.ok(sk.entries.some((e: { skillName: string }) => e.skillName === 'cg-skill'), '机器级模式卡片 skill 进索引');
+    } finally { await srv.stop(); }
+  });
+
+  it('include=true 且 live analyses 目录不存在:/api/observe-health 与 /api/skill-trend 仍合并卡片(不早退)', async () => {
+    // 默认机器级模式下当前项目还没 .omk/observe-health、全局也空 → 传给 server 的是不存在的目录。
+    const missing = join(emptyAnalyses, 'does-not-exist');
+    const srv = createReportServer({
+      port: 0, reportsDir: emptyReports, analysesDir: missing, doctorsDir: emptyDoctors,
+      observationsDir: emptyObs, jobsDir: emptyJobs, managedDir: emptyManaged,
+      includeObserveCards: true, includeDoctorCards: true,
+    });
+    const url = await srv.start();
+    try {
+      const oh = await (await fetch(`${url}/api/observe-health`)).json();
+      assert.deepEqual(oh.map((x: { id: string }) => x.id), ['cg-observe-health'], 'live 目录不存在也不早退,仍合 observe 卡片');
+      const trend = await (await fetch(`${url}/api/skill-trend/cg-skill`)).json();
+      assert.ok(trend.points.length >= 1, 'skill-trend 也依赖 listAnalyses,同样合并卡片(按 card.path 回源真身)');
     } finally { await srv.stop(); }
   });
 });

--- a/test/server/card-gate-server.test.ts
+++ b/test/server/card-gate-server.test.ts
@@ -27,7 +27,8 @@ describe('卡片合并 include 开关(server 级)', () => {
     [emptyReports, emptyAnalyses, emptyDoctors, emptyObs, emptyJobs, emptyManaged, proj] =
       ['rp', 'an', 'dr', 'ob', 'jb', 'mg', 'pj'].map((t) => mkdtempSync(join(tmpdir(), `omk-cg-${t}-`)));
     dirs.push(idxRoot, emptyReports, emptyAnalyses, emptyDoctors, emptyObs, emptyJobs, emptyManaged, proj);
-    // 别项目卡片各一张(live 目录扫不到,只能靠卡片发现)。
+    // 别项目卡片各一张(live 目录扫不到,只能靠卡片发现);真身写出来,免得被悬空过滤掉。
+    writeFileSync(join(proj, 'cg.json'), '{}');
     indexDoctorWrite({ id: 'cg-doctor-1-aa', path: join(proj, 'cg.json'), skillName: 'cg-skill', reportId: 'doctor-cg-1-aa',
       timestamp: '2026-06-14T00:00:00Z', status: 'pass', passCount: 1, warnCount: 0, failCount: 0 }, proj);
     const obsReport = { kind: 'observe-health',

--- a/test/server/card-gate-server.test.ts
+++ b/test/server/card-gate-server.test.ts
@@ -1,0 +1,72 @@
+/**
+ * 卡片合并 include 开关的 server 级回归(CR #253 P2):
+ * 固定 analyses/doctors 目录(逃生舱,include 默认 false)时,即便索引里有别项目卡片,
+ * /api/observe-health 与 /api/skills 都必须为空 —— --global / --analyses-dir / --doctors-dir 只看该目录;
+ * 开 include(机器级默认模式)时才合并卡片。
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createReportServer } from '../../src/server/report-server.js';
+import { indexDoctorWrite, indexObserveWrite } from '../../src/eval-core/artifact-index.js';
+
+interface Srv { stop(): Promise<void> }
+
+describe('卡片合并 include 开关(server 级)', () => {
+  let idxRoot: string; let emptyReports: string; let emptyAnalyses: string; let emptyDoctors: string;
+  let emptyObs: string; let emptyJobs: string; let emptyManaged: string; let proj: string;
+  let origEnv: string | undefined;
+  const dirs: string[] = [];
+
+  beforeEach(() => {
+    origEnv = process.env.OMK_ARTIFACT_INDEX_DIR;
+    idxRoot = mkdtempSync(join(tmpdir(), 'omk-cg-idx-'));
+    process.env.OMK_ARTIFACT_INDEX_DIR = idxRoot;
+    [emptyReports, emptyAnalyses, emptyDoctors, emptyObs, emptyJobs, emptyManaged, proj] =
+      ['rp', 'an', 'dr', 'ob', 'jb', 'mg', 'pj'].map((t) => mkdtempSync(join(tmpdir(), `omk-cg-${t}-`)));
+    dirs.push(idxRoot, emptyReports, emptyAnalyses, emptyDoctors, emptyObs, emptyJobs, emptyManaged, proj);
+    // 别项目卡片各一张(live 目录扫不到,只能靠卡片发现)。
+    indexDoctorWrite({ id: 'cg-doctor-1-aa', path: join(proj, 'cg.json'), skillName: 'cg-skill', reportId: 'doctor-cg-1-aa',
+      timestamp: '2026-06-14T00:00:00Z', status: 'pass', passCount: 1, warnCount: 0, failCount: 0 }, proj);
+    indexObserveWrite({ meta: { generatedAt: '2026-06-14T01:00:00Z', sessionCount: 1, segmentCount: 10 },
+      overall: { healthBand: 'green', confidence: 'high' },
+      bySkill: { 'cg-skill': { toolFailureRate: 0, segmentCount: 10, confidence: 'high', gap: { weightedGapRate: 0 } } },
+    } as never, join(proj, 'cg-observe-health.json'), proj, 'cg-observe-health');
+  });
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.OMK_ARTIFACT_INDEX_DIR;
+    else process.env.OMK_ARTIFACT_INDEX_DIR = origEnv;
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  function mkServer(include: boolean): Promise<{ url: string; srv: Srv }> {
+    const srv = createReportServer({
+      port: 0, reportsDir: emptyReports, analysesDir: emptyAnalyses, doctorsDir: emptyDoctors,
+      observationsDir: emptyObs, jobsDir: emptyJobs, managedDir: emptyManaged,
+      includeObserveCards: include, includeDoctorCards: include,
+    });
+    return srv.start().then((url) => ({ url, srv }));
+  }
+
+  it('include=false(固定目录/逃生舱):有别项目卡片但 /api/observe-health 与 /api/skills 为空', async () => {
+    const { url, srv } = await mkServer(false);
+    try {
+      const oh = await (await fetch(`${url}/api/observe-health`)).json();
+      assert.deepEqual(oh, [], '固定目录不合 observe 卡片');
+      const sk = await (await fetch(`${url}/api/skills`)).json();
+      assert.deepEqual(sk.entries.map((e: { skillName: string }) => e.skillName), [], '固定目录不合 doctor/observe 卡片进 skill 索引');
+    } finally { await srv.stop(); }
+  });
+
+  it('include=true(机器级默认):同样的卡片下 /api/observe-health 与 /api/skills 看到别项目产物', async () => {
+    const { url, srv } = await mkServer(true);
+    try {
+      const oh = await (await fetch(`${url}/api/observe-health`)).json();
+      assert.deepEqual(oh.map((x: { id: string }) => x.id), ['cg-observe-health'], '机器级模式合 observe 卡片');
+      const sk = await (await fetch(`${url}/api/skills`)).json();
+      assert.ok(sk.entries.some((e: { skillName: string }) => e.skillName === 'cg-skill'), '机器级模式卡片 skill 进索引');
+    } finally { await srv.stop(); }
+  });
+});

--- a/test/server/cross-project-doctor-observe.test.ts
+++ b/test/server/cross-project-doctor-observe.test.ts
@@ -34,6 +34,9 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
   });
 
   it('别项目 doctor 卡片 + observe 卡片 → buildSkillIndex 看到对应 skill', () => {
+    // 卡片真身(悬空过滤要求 card.path 存在;buildSkillIndex 合并只读卡片本身,真身内容随意)。
+    writeFileSync(join(proj, 'foo-doctor-20260614-1-aa11.json'), '{}');
+    writeFileSync(join(proj, 'o-observe-health.json'), '{}');
     indexDoctorWrite({
       id: 'foo-doctor-20260614-1-aa11', path: join(proj, 'foo-doctor-20260614-1-aa11.json'), skillName: 'foo',
       reportId: 'doctor-20260614-1-aa11', timestamp: '2026-06-14T00:00:00Z', status: 'pass', passCount: 2, warnCount: 0, failCount: 0,
@@ -52,6 +55,18 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
     assert.equal(foo.doctor?.reportId, 'doctor-20260614-1-aa11');
     const bar = idx.entries.find((e) => e.skillName === 'bar')!;
     assert.equal(bar.observe?.analysisId, 'o-observe-health');
+  });
+
+  it('悬空卡片(真身被带外删)不进 buildSkillIndex:include=true 也不展示', () => {
+    // 卡片在、真身不在(项目被移走/手动 rm)→ 机器级合并不应展示。
+    indexDoctorWrite({ id: 'gone-doctor-1-zz', path: join(proj, 'gone.json'), skillName: 'gone-skill', reportId: 'doctor-1-zz',
+      timestamp: '2026-06-14T00:00:00Z', status: 'pass', passCount: 1, warnCount: 0, failCount: 0 }, proj);
+    indexObserveWrite({ meta: { generatedAt: '2026-06-14T01:00:00Z', sessionCount: 1, segmentCount: 10 },
+      overall: { healthBand: 'green', confidence: 'high' },
+      bySkill: { 'gone-obs': { toolFailureRate: 0, segmentCount: 10, confidence: 'high', gap: { weightedGapRate: 0 } } },
+    }, join(proj, 'gone-observe-health.json'), proj, 'gone-observe-health'); // 真身均不写
+    const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs, { includeObserveCards: true, includeDoctorCards: true });
+    assert.deepEqual(idx.entries.map((e) => e.skillName), [], '悬空卡片(真身不在)不进 skill 索引');
   });
 
   it('固定目录模式(include 默认 false):索引里有别项目卡片但 buildSkillIndex 不合并 → skill 索引为空', () => {

--- a/test/server/cross-project-doctor-observe.test.ts
+++ b/test/server/cross-project-doctor-observe.test.ts
@@ -61,7 +61,7 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
       kind: 'doctor', schemaVersion: '3.0.0', id: 'rd', timestamp: '2026-06-14T00:00:00Z', cliVersion: 't', cwd: '/x',
       executorName: 'claude', model: 'm', outcome: 'passed',
       skills: [{ skillName: 'd', skillPath: '/x/d', status: 'pass',
-        results: [{ ruleId: 'r1', severity: 'error', labelKey: 'k', status: 'pass', message: 'ok', durationMs: 1 }] }],
+        results: [{ ruleId: 'r1', severity: 'warn', labelKey: 'k', status: 'pass', message: 'ok', durationMs: 1 }] }],
       totals: { pass: 1, warn: 0, fail: 0 }, ruleStats: { pass: 1, warn: 0, fail: 0, skipped: 0, total: 1 },
     };
     writeFileSync(join(emptyDoctors, `${dStem}.json`), JSON.stringify(liveDoctor));
@@ -75,8 +75,8 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
       meta: { tracePath: '/t', kbPath: null, sessionCount: 1, segmentCount: 10, messageCount: 5, toolCallCount: 3,
         toolFailureRate: 0, timeRange: { from: 'a', to: 'b' }, generatedAt: '2026-06-14T00:00:00Z' },
       bySkill: { o: { skillName: 'o', segmentCount: 10, toolCallCount: 3, toolFailureCount: 0, toolFailureRate: 0,
-        stability: 1, confidence: 'high', gap: { gapRate: 0, weightedGapRate: 0, signals: [{ h: 1 }] } } },
-      overall: { gapRate: 0, weightedGapRate: 0, healthBand: 'green', confidence: 'high' },
+        stability: 1, confidence: 'high' as const, gap: { gapRate: 0, weightedGapRate: 0, signals: [{ h: 1 }] } } },
+      overall: { gapRate: 0, weightedGapRate: 0, healthBand: 'green' as const, confidence: 'high' as const },
     };
     writeFileSync(join(emptyAnalyses, `${oid}.json`), JSON.stringify(liveObs));
     indexObserveWrite(liveObs, join(emptyAnalyses, `${oid}.json`), emptyAnalyses, oid);

--- a/test/server/cross-project-doctor-observe.test.ts
+++ b/test/server/cross-project-doctor-observe.test.ts
@@ -1,0 +1,82 @@
+/**
+ * 机器级总览验收(doctor / observe-health 域):buildSkillIndex 把别项目的 doctor/observe 卡片合并进 skill 索引;
+ * doctor 历史 prune 删正文时连带删卡片,杜绝「被 prune 的报告经卡片复活」。全程隔离 OMK_ARTIFACT_INDEX_DIR。
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildSkillIndex, _resetSkillIndexCache } from '../../src/server/skill-index.js';
+import { indexDoctorWrite, indexObserveWrite, listDoctorCards } from '../../src/eval-core/artifact-index.js';
+import { pruneDoctorHistory } from '../../src/cli/commands/doctor.js';
+import type { DoctorReport } from '../../src/types/index.js';
+
+describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
+  let indexRoot: string; let proj: string; let emptyAnalyses: string; let emptyDoctors: string; let emptyObs: string;
+  let origEnv: string | undefined;
+
+  beforeEach(() => {
+    origEnv = process.env.OMK_ARTIFACT_INDEX_DIR;
+    indexRoot = mkdtempSync(join(tmpdir(), 'omk-xp-idx-'));
+    process.env.OMK_ARTIFACT_INDEX_DIR = indexRoot;
+    proj = mkdtempSync(join(tmpdir(), 'omk-xp-proj-'));
+    emptyAnalyses = mkdtempSync(join(tmpdir(), 'omk-xp-an-'));
+    emptyDoctors = mkdtempSync(join(tmpdir(), 'omk-xp-dr-'));
+    emptyObs = mkdtempSync(join(tmpdir(), 'omk-xp-obs-'));
+    _resetSkillIndexCache();
+  });
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.OMK_ARTIFACT_INDEX_DIR;
+    else process.env.OMK_ARTIFACT_INDEX_DIR = origEnv;
+    for (const d of [indexRoot, proj, emptyAnalyses, emptyDoctors, emptyObs]) rmSync(d, { recursive: true, force: true });
+    _resetSkillIndexCache();
+  });
+
+  it('别项目 doctor 卡片 + observe 卡片 → buildSkillIndex 看到对应 skill', () => {
+    indexDoctorWrite({
+      id: 'foo-doctor-20260614-1-aa11', path: join(proj, 'foo-doctor-20260614-1-aa11.json'), skillName: 'foo',
+      reportId: 'doctor-20260614-1-aa11', timestamp: '2026-06-14T00:00:00Z', status: 'pass', passCount: 2, warnCount: 0, failCount: 0,
+    }, proj);
+    indexObserveWrite({
+      meta: { generatedAt: '2026-06-14T01:00:00Z', sessionCount: 3, segmentCount: 30 },
+      overall: { healthBand: 'green', confidence: 'high' },
+      bySkill: { bar: { toolFailureRate: 0.0, segmentCount: 30, confidence: 'high', gap: { weightedGapRate: 0.1 } } },
+    }, join(proj, 'o-observe-health.json'), proj, 'o-observe-health');
+
+    const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs);
+    const names = idx.entries.map((e) => e.skillName).sort();
+    assert.ok(names.includes('foo'), 'doctor 卡片的 skill 进索引');
+    assert.ok(names.includes('bar'), 'observe 卡片的 skill 进索引');
+    const foo = idx.entries.find((e) => e.skillName === 'foo')!;
+    assert.equal(foo.doctor?.reportId, 'doctor-20260614-1-aa11');
+    const bar = idx.entries.find((e) => e.skillName === 'bar')!;
+    assert.equal(bar.observe?.analysisId, 'o-observe-health');
+  });
+
+  it('doctor prune 删正文连带删卡片 → 被 prune 的报告不经卡片复活', () => {
+    function singleSkillReport(id: string, ts: string): DoctorReport {
+      return {
+        kind: 'doctor', schemaVersion: '3.0.0', id, timestamp: ts, cliVersion: 't', cwd: '/x',
+        executorName: 'claude', model: 'm', outcome: 'passed',
+        skills: [{ skillName: 'p', skillPath: '/x/p', status: 'pass', results: [] }],
+        totals: { pass: 1, warn: 0, fail: 0 }, ruleStats: { pass: 0, warn: 0, fail: 0, skipped: 0, total: 0 },
+      } as DoctorReport;
+    }
+    // 两份同 skill 的 per-skill 报告(老 t1 / 新 t2)+ 各自卡片(id=文件 stem)。
+    for (const [stem, rid, ts] of [['p-r1', 'r1', '2026-06-01T00:00:00Z'], ['p-r2', 'r2', '2026-06-14T00:00:00Z']] as const) {
+      writeFileSync(join(emptyDoctors, `${stem}.json`), JSON.stringify(singleSkillReport(rid, ts)));
+      indexDoctorWrite({ id: stem, path: join(emptyDoctors, `${stem}.json`), skillName: 'p', reportId: rid, timestamp: ts,
+        status: 'pass', passCount: 0, warnCount: 0, failCount: 0 }, emptyDoctors);
+    }
+    assert.equal(listDoctorCards().length, 2, '两张卡片');
+
+    pruneDoctorHistory(emptyDoctors, 'p', 1); // 只留最新 1 份 → 删 p-r1 正文 + 卡片
+
+    assert.deepEqual(listDoctorCards().map((c) => c.id), ['p-r2'], '老卡片随正文一起删');
+    const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs);
+    const p = idx.entries.find((e) => e.skillName === 'p')!;
+    assert.equal(p.doctorHistory.length, 1, '历史只剩 1 份,被 prune 的没经卡片复活');
+    assert.equal(p.doctor?.reportId, 'r2');
+  });
+});

--- a/test/server/cross-project-doctor-observe.test.ts
+++ b/test/server/cross-project-doctor-observe.test.ts
@@ -57,7 +57,7 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
     assert.equal(bar.observe?.analysisId, 'o-observe-health');
   });
 
-  it('悬空卡片(真身被带外删)不进 buildSkillIndex:include=true 也不展示', () => {
+  it('悬空卡片(真身从未存在)不进 buildSkillIndex:include=true 也不展示', () => {
     // 卡片在、真身不在(项目被移走/手动 rm)→ 机器级合并不应展示。
     indexDoctorWrite({ id: 'gone-doctor-1-zz', path: join(proj, 'gone.json'), skillName: 'gone-skill', reportId: 'doctor-1-zz',
       timestamp: '2026-06-14T00:00:00Z', status: 'pass', passCount: 1, warnCount: 0, failCount: 0 }, proj);
@@ -67,6 +67,24 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
     }, join(proj, 'gone-observe-health.json'), proj, 'gone-observe-health'); // 真身均不写
     const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs, { includeObserveCards: true, includeDoctorCards: true });
     assert.deepEqual(idx.entries.map((e) => e.skillName), [], '悬空卡片(真身不在)不进 skill 索引');
+  });
+
+  it('悬空检测穿透 buildSkillIndex 缓存:先 build 可见、仅删真身(卡片目录不变、不 reset 缓存)→ 再 build 应消失', () => {
+    writeFileSync(join(proj, 'fd.json'), '{}');
+    writeFileSync(join(proj, 'fo-observe-health.json'), '{}');
+    indexDoctorWrite({ id: 'fd', path: join(proj, 'fd.json'), skillName: 'cf', reportId: 'doctor-cf-1',
+      timestamp: '2026-06-14T00:00:00Z', status: 'pass', passCount: 1, warnCount: 0, failCount: 0 }, proj);
+    indexObserveWrite({ meta: { generatedAt: '2026-06-14T01:00:00Z', sessionCount: 1, segmentCount: 10 },
+      overall: { healthBand: 'green', confidence: 'high' },
+      bySkill: { co: { toolFailureRate: 0, segmentCount: 10, confidence: 'high', gap: { weightedGapRate: 0 } } },
+    }, join(proj, 'fo-observe-health.json'), proj, 'fo-observe-health');
+    const opts = { includeObserveCards: true, includeDoctorCards: true };
+    let idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs, opts);
+    assert.deepEqual(idx.entries.map((e) => e.skillName).sort(), ['cf', 'co'], 'build1 可见(进模块缓存)');
+    rmSync(join(proj, 'fd.json'), { force: true }); // 仅删真身,不动卡片目录、不 _resetSkillIndexCache
+    rmSync(join(proj, 'fo-observe-health.json'), { force: true });
+    idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs, opts);
+    assert.deepEqual(idx.entries.map((e) => e.skillName), [], '真身没了 → 真身 sentinel 进 fingerprint、缓存失效,悬空不展示');
   });
 
   it('固定目录模式(include 默认 false):索引里有别项目卡片但 buildSkillIndex 不合并 → skill 索引为空', () => {

--- a/test/server/cross-project-doctor-observe.test.ts
+++ b/test/server/cross-project-doctor-observe.test.ts
@@ -44,7 +44,7 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
       bySkill: { bar: { toolFailureRate: 0.0, segmentCount: 30, confidence: 'high', gap: { weightedGapRate: 0.1 } } },
     }, join(proj, 'o-observe-health.json'), proj, 'o-observe-health');
 
-    const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs);
+    const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs, { includeObserveCards: true, includeDoctorCards: true });
     const names = idx.entries.map((e) => e.skillName).sort();
     assert.ok(names.includes('foo'), 'doctor 卡片的 skill 进索引');
     assert.ok(names.includes('bar'), 'observe 卡片的 skill 进索引');
@@ -52,6 +52,19 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
     assert.equal(foo.doctor?.reportId, 'doctor-20260614-1-aa11');
     const bar = idx.entries.find((e) => e.skillName === 'bar')!;
     assert.equal(bar.observe?.analysisId, 'o-observe-health');
+  });
+
+  it('固定目录模式(include 默认 false):索引里有别项目卡片但 buildSkillIndex 不合并 → skill 索引为空', () => {
+    // 模拟 --analyses-dir/--doctors-dir/--global 逃生舱:有卡片(别项目),但 live 目录空且不开 include。
+    indexDoctorWrite({ id: 'x-doctor-1-aa', path: join(proj, 'x.json'), skillName: 'x', reportId: 'doctor-1-aa',
+      timestamp: '2026-06-14T00:00:00Z', status: 'pass', passCount: 1, warnCount: 0, failCount: 0 }, proj);
+    indexObserveWrite({ meta: { generatedAt: '2026-06-14T01:00:00Z', sessionCount: 1, segmentCount: 10 },
+      overall: { healthBand: 'green', confidence: 'high' },
+      bySkill: { y: { toolFailureRate: 0, segmentCount: 10, confidence: 'high', gap: { weightedGapRate: 0 } } },
+    }, join(proj, 'y-observe-health.json'), proj, 'y-observe-health');
+    // 不传 include 标志(默认 false)→ 固定目录语义,卡片一律不合并。
+    const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs);
+    assert.deepEqual(idx.entries.map((e) => e.skillName), [], '固定目录模式下别项目卡片不进 skill 索引');
   });
 
   it('同项目 live 正文 + 同 id 卡片 → dedup,live 盖卡片(不双计;机器级总览的 no-double-count 核心不变量)', () => {
@@ -81,7 +94,7 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
     writeFileSync(join(emptyAnalyses, `${oid}.json`), JSON.stringify(liveObs));
     indexObserveWrite(liveObs, join(emptyAnalyses, `${oid}.json`), emptyAnalyses, oid);
 
-    const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs);
+    const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs, { includeObserveCards: true, includeDoctorCards: true });
     const d = idx.entries.find((e) => e.skillName === 'd')!;
     assert.equal(d.doctorHistory.length, 1, 'doctor 同 reportId 的 live+卡片 dedup 为 1 条,不双计');
     assert.ok((d.doctor?.results.length ?? 0) > 0, 'live 盖卡片:取含 results 的 live 那份,非卡片空壳');
@@ -109,7 +122,7 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
     pruneDoctorHistory(emptyDoctors, 'p', 1); // 只留最新 1 份 → 删 p-r1 正文 + 卡片
 
     assert.deepEqual(listDoctorCards().map((c) => c.id), ['p-r2'], '老卡片随正文一起删');
-    const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs);
+    const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs, { includeObserveCards: true, includeDoctorCards: true });
     const p = idx.entries.find((e) => e.skillName === 'p')!;
     assert.equal(p.doctorHistory.length, 1, '历史只剩 1 份,被 prune 的没经卡片复活');
     assert.equal(p.doctor?.reportId, 'r2');

--- a/test/server/cross-project-doctor-observe.test.ts
+++ b/test/server/cross-project-doctor-observe.test.ts
@@ -54,6 +54,41 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
     assert.equal(bar.observe?.analysisId, 'o-observe-health');
   });
 
+  it('同项目 live 正文 + 同 id 卡片 → dedup,live 盖卡片(不双计;机器级总览的 no-double-count 核心不变量)', () => {
+    // doctor:live 正文(results 非空)写进 doctorsDir + 同 stem 卡片(本项目 persist 时既写正文又写卡片的稳态)。
+    const dStem = 'd-rd';
+    const liveDoctor: DoctorReport = {
+      kind: 'doctor', schemaVersion: '3.0.0', id: 'rd', timestamp: '2026-06-14T00:00:00Z', cliVersion: 't', cwd: '/x',
+      executorName: 'claude', model: 'm', outcome: 'passed',
+      skills: [{ skillName: 'd', skillPath: '/x/d', status: 'pass',
+        results: [{ ruleId: 'r1', severity: 'error', labelKey: 'k', status: 'pass', message: 'ok', durationMs: 1 }] }],
+      totals: { pass: 1, warn: 0, fail: 0 }, ruleStats: { pass: 1, warn: 0, fail: 0, skipped: 0, total: 1 },
+    };
+    writeFileSync(join(emptyDoctors, `${dStem}.json`), JSON.stringify(liveDoctor));
+    indexDoctorWrite({ id: dStem, path: join(emptyDoctors, `${dStem}.json`), skillName: 'd', reportId: 'rd',
+      timestamp: '2026-06-14T00:00:00Z', status: 'pass', passCount: 1, warnCount: 0, failCount: 0 }, emptyDoctors);
+
+    // observe:live 正文(bySkill.o 带 signals)写进 analysesDir + 同 id 卡片。
+    const oid = 'oid-observe-health';
+    const liveObs = {
+      kind: 'observe-health',
+      meta: { tracePath: '/t', kbPath: null, sessionCount: 1, segmentCount: 10, messageCount: 5, toolCallCount: 3,
+        toolFailureRate: 0, timeRange: { from: 'a', to: 'b' }, generatedAt: '2026-06-14T00:00:00Z' },
+      bySkill: { o: { skillName: 'o', segmentCount: 10, toolCallCount: 3, toolFailureCount: 0, toolFailureRate: 0,
+        stability: 1, confidence: 'high', gap: { gapRate: 0, weightedGapRate: 0, signals: [{ h: 1 }] } } },
+      overall: { gapRate: 0, weightedGapRate: 0, healthBand: 'green', confidence: 'high' },
+    };
+    writeFileSync(join(emptyAnalyses, `${oid}.json`), JSON.stringify(liveObs));
+    indexObserveWrite(liveObs, join(emptyAnalyses, `${oid}.json`), emptyAnalyses, oid);
+
+    const idx = buildSkillIndex([], emptyAnalyses, emptyDoctors, emptyObs);
+    const d = idx.entries.find((e) => e.skillName === 'd')!;
+    assert.equal(d.doctorHistory.length, 1, 'doctor 同 reportId 的 live+卡片 dedup 为 1 条,不双计');
+    assert.ok((d.doctor?.results.length ?? 0) > 0, 'live 盖卡片:取含 results 的 live 那份,非卡片空壳');
+    const o = idx.entries.find((e) => e.skillName === 'o')!;
+    assert.equal(o.observeHistory.length, 1, 'observe 同 analysisId 的 live+卡片 dedup 为 1 条,不双计');
+  });
+
   it('doctor prune 删正文连带删卡片 → 被 prune 的报告不经卡片复活', () => {
     function singleSkillReport(id: string, ts: string): DoctorReport {
       return {

--- a/test/server/indexed-report-store.test.ts
+++ b/test/server/indexed-report-store.test.ts
@@ -59,6 +59,7 @@ describe('createIndexedReportStore 机器级总览', () => {
     writeReportFile(proj, evalDoc('rp', 'vp', 'hp', '2026-03-01T00:00:00Z'));
     writeReportFile(glob, evalDoc('rg', 'vg', 'hg', '2026-02-01T00:00:00Z'));
     const otherDoc = evalDoc('ro', 'vo', 'ho', '2026-01-01T00:00:00Z');
+    writeReportFile(other, otherDoc); // 别项目真身(卡片 path 指向它;悬空过滤要求真身在)
     writeCard('ro', join(other, 'ro.json'), otherDoc); // 别项目:仅卡片(本 store 不 live 扫 other)
     const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
     assert.deepEqual((await store.list()).map((r) => r.id), ['rp', 'rg', 'ro']);
@@ -93,7 +94,9 @@ describe('createIndexedReportStore 机器级总览', () => {
   });
 
   it('findByVariant / findByArtifactHash 跨项目(含别项目卡片)', async () => {
-    writeCard('ro', join(other, 'ro.json'), evalDoc('ro', 'vo', 'ho'));
+    const ro = evalDoc('ro', 'vo', 'ho');
+    writeReportFile(other, ro);
+    writeCard('ro', join(other, 'ro.json'), ro);
     const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
     assert.equal((await store.findByVariant('vo')).length, 1);
     assert.equal((await store.findByArtifactHash('ho')).length, 1);
@@ -102,10 +105,23 @@ describe('createIndexedReportStore 机器级总览', () => {
   it('卡片缓存按 per-file 指纹失效:构造 store 后再写/删卡片,list 立即反映', async () => {
     const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
     assert.deepEqual((await store.list()).map((r) => r.id), [], '初始空');
+    writeReportFile(other, evalDoc('ro')); // 真身
     writeCard('ro', join(other, 'ro.json'), evalDoc('ro')); // 构造后新增卡片
     assert.deepEqual((await store.list()).map((r) => r.id), ['ro'], '新卡片立即可见(指纹失效)');
     await store.remove('ro'); // 删卡片
     assert.deepEqual((await store.list()).map((r) => r.id), [], '删后立即消失');
+  });
+
+  it('list 不展示悬空卡片:真身被带外删除后,机器级 list 不再出现该条', async () => {
+    const ro = evalDoc('ro', 'vo', 'ho');
+    writeReportFile(other, ro);
+    writeCard('ro', join(other, 'ro.json'), ro);
+    const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
+    assert.deepEqual((await store.list()).map((r) => r.id), ['ro'], '真身在 → 卡片可见');
+    rmSync(join(other, 'ro.json'), { force: true }); // 带外删真身(项目被移走/手动 rm)
+    writeCard('keep', join(other, 'keep.json'), evalDoc('keep')); // 触发卡片目录指纹变化使缓存失效
+    writeReportFile(other, evalDoc('keep'));
+    assert.deepEqual((await store.list()).map((r) => r.id).sort(), ['keep'], '悬空 ro 不展示,只剩仍有真身的 keep');
   });
 
   it('remove:删 live 真身 + 删卡片;别项目删不到真身但删卡片仍报成功、从 list 消失', async () => {

--- a/test/server/indexed-report-store.test.ts
+++ b/test/server/indexed-report-store.test.ts
@@ -112,16 +112,14 @@ describe('createIndexedReportStore 机器级总览', () => {
     assert.deepEqual((await store.list()).map((r) => r.id), [], '删后立即消失');
   });
 
-  it('list 不展示悬空卡片:真身被带外删除后,机器级 list 不再出现该条', async () => {
+  it('list 不展示悬空卡片(穿透缓存):首次可见进缓存后,仅删真身(卡片 JSON / 目录不变)→ 再 list 应消失', async () => {
     const ro = evalDoc('ro', 'vo', 'ho');
     writeReportFile(other, ro);
     writeCard('ro', join(other, 'ro.json'), ro);
     const store = createIndexedReportStore({ projectDir: proj, globalDir: glob });
-    assert.deepEqual((await store.list()).map((r) => r.id), ['ro'], '真身在 → 卡片可见');
-    rmSync(join(other, 'ro.json'), { force: true }); // 带外删真身(项目被移走/手动 rm)
-    writeCard('keep', join(other, 'keep.json'), evalDoc('keep')); // 触发卡片目录指纹变化使缓存失效
-    writeReportFile(other, evalDoc('keep'));
-    assert.deepEqual((await store.list()).map((r) => r.id).sort(), ['keep'], '悬空 ro 不展示,只剩仍有真身的 keep');
+    assert.deepEqual((await store.list()).map((r) => r.id), ['ro'], '真身在 → 卡片可见(进 cardDocs 缓存)');
+    rmSync(join(other, 'ro.json'), { force: true }); // 仅删真身,不动卡片 JSON / 卡片目录(不靠卡片目录指纹变化)
+    assert.deepEqual((await store.list()).map((r) => r.id), [], '真身没了 → 真身 sentinel 使缓存失效,悬空卡片不再展示');
   });
 
   it('remove:删 live 真身 + 删卡片;别项目删不到真身但删卡片仍报成功、从 list 消失', async () => {

--- a/test/server/skill-index-cache.test.ts
+++ b/test/server/skill-index-cache.test.ts
@@ -149,14 +149,23 @@ describe('buildSkillIndex 模块级缓存', () => {
   let analysesDir: string;
   let doctorsDir: string;
 
+  let origIndexEnv: string | undefined;
+
   beforeEach(() => {
     _resetSkillIndexCache();
     analysesDir = mkdtempSync(join(tmpdir(), 'omk-analyses-'));
     doctorsDir = mkdtempSync(join(tmpdir(), 'omk-doctors-'));
-    cleanupDirs.push(analysesDir, doctorsDir);
+    // buildSkillIndex 现在会合并机器级 doctor/observe 卡片(listDoctorCards/listObserveCards);把卡片索引
+    // 指到本测独占的空临时目录,隔离别的测试(persistDoctor/Observe)写进套件级索引的卡片,保证 entries 计数纯净。
+    origIndexEnv = process.env.OMK_ARTIFACT_INDEX_DIR;
+    const idxDir = mkdtempSync(join(tmpdir(), 'omk-skidx-cards-'));
+    process.env.OMK_ARTIFACT_INDEX_DIR = idxDir;
+    cleanupDirs.push(analysesDir, doctorsDir, idxDir);
   });
 
   afterEach(() => {
+    if (origIndexEnv === undefined) delete process.env.OMK_ARTIFACT_INDEX_DIR;
+    else process.env.OMK_ARTIFACT_INDEX_DIR = origIndexEnv;
     for (const d of cleanupDirs.splice(0)) {
       try { rmSync(d, { recursive: true, force: true }); } catch { /* noop */ }
     }


### PR DESCRIPTION
## 这个 PR 做什么

复用 #252 阶段 1 的产物发现索引通用核心,把 `omk studio` 的机器级总览从 reports 扩到 **doctor** 与 **observe-health** 两域 —— studio 现在能跨项目看到本机所有项目的体检与健康报告。

每类产物的正文仍单份留项目本地 `.omk/<域>`;落盘后在全局 `state/artifact-index/<域>/` 留一张轻卡片(剥掉逐规则 / 逐信号重体,`path` 指真身)。当前项目 + 全局靠 live-scan 永远新鲜,别项目靠卡片发现。可比性红线在比较层、不在视图层,机器级 merge 合法。

## 用户影响

- 在任意项目目录起 `omk studio`,skill 仪表盘 / observe-health 列表都能看到**别项目**的 doctor、observe 产物;点详情按 `card.path` 读到完整真身。
- 修掉一个**现存数据丢失 bug**:同一秒内两次 `omk observe` 原来会因文件名相同直接覆盖、丢前一份;现在 id / 文件名加随机段,两份都留。
- doctor id 加随机后缀,根治跨进程 / 跨项目同秒撞 id(此前进程内计数器只防同进程)。

## 关键设计

- **通用化**:`artifact-index.ts` 抽出域无关的原子写 / 指纹缓存读 / best-effort 钩子 / 删除,三域共用,各域只差「投影成卡片」「卡片还原成 snapshot」两段。doctor / observe 卡片不带 `kind` 字段(domain 已足够判别)。
- **doctor prune 连带删卡片**:doctor 历史按 50/skill prune,删正文时必须连带删卡片 —— 否则被 prune 的报告会经卡片在本项目 studio「复活」。已加回归测试锁定。
- **解耦**:`eval-core` 不 import `observability`,observe 卡片走结构子集类型;`by-id` 复用链路全程不动;只索引非全局写(全局靠 live-scan)。
- skill-index fingerprint 纳入两域卡片目录,别项目新跑后本项目 studio 不被缓存挡住。

## 验证

`yarn lint && build && test`(176 文件 / 2173 用例)+ `build:docs:check` 全绿。新增 doctor/observe 写侧 + 卡片投影 + buildSkillIndex 跨项目合并 + doctor prune 防复活 + observe 同秒不覆盖等单测。**端到端冒烟过**:A 起 studio 经真实 HTTP 看到 B 的 doctor/observe(列表卡片合并 / 详情 `card.path` 读真身 / 跨项目 skill 聚合 / doctor 详情兜底),真实 home 零污染。

非 BREAKING-COMPARABILITY(id 是标签非测量数,未碰任何可比性锚点)。前置 #252(阶段 1)已合。关联 #243。

悬空卡片无 GC(list 不校验 card.path 存在)仍是跨三域的共同 follow-up:卡片当持久记录还是活指针,待单议。

🤖 Generated with [Claude Code](https://claude.com/claude-code)