### PR TITLE
feat(observe): observe-inbox 支持 --global 写 / 读（补齐与 observe-health 的对称，#243）

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -435,6 +435,7 @@ omk observe inbox [flags]
 - `--by-skill` `boolean`:按 skill 聚合输出
 - `--executor` `option`:LLM 增强复盘使用的执行器
 - `--explore` `option`:抽样 N 条 medium/low 长尾（replaces limit）
+- `--global` `boolean`:直接读取全局 ~/.oh-my-knowledge/observe-inbox（跳过项目级与兜底）。
 - `--include-noise` `boolean`:explore 时也包含 noise 桶
 - `--input-dir` `option`:inbox 数据目录，默认 .omk/observe-inbox（项目级，相对于 cwd）；目录不存在时兜底读 ~/.oh-my-knowledge/observe-inbox。
 - `--json` `boolean`:JSON 格式输出
@@ -461,8 +462,9 @@ omk observe ingest <traceDir> [flags]
 
 **Flags:**
 
+- `--global` `boolean`:写入全局 ~/.oh-my-knowledge/observe-inbox，而非项目 .omk/observe-inbox。
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
-- `--output-dir` `option`:输出目录，默认 .omk/observe-inbox（项目级，相对于 cwd）。
+- `--output-dir` `option`:输出目录，默认 .omk/observe-inbox（项目级，相对于 cwd；--global 写全局）。
 
 ## omk observe show
 

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -482,6 +482,7 @@ omk observe show <inboxId> [flags]
 
 **Flags:**
 
+- `--global` `boolean`:直接读取全局 ~/.oh-my-knowledge/observe-inbox（跳过项目级与兜底）。
 - `--input-dir` `option`:inbox 数据目录
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 
@@ -638,7 +639,7 @@ omk studio [flags]
 - `--analyses-dir` `option`:观测健康报告目录（可选，默认项目级 .omk/observe-health，空则全局兜底）
 - `--dev` `boolean`:dev 模式：子进程启动 + 热更新
 - `--doctors-dir` `option`:体检报告目录（可选，默认项目级 .omk/doctors，空则全局兜底）
-- `--global` `boolean`:只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非机器级聚合 / 项目优先；managed / observe-inbox 不受影响
+- `--global` `boolean`:只看全局 reports / observe-health / doctors / observe-inbox 目录（~/.oh-my-knowledge/*），而非机器级聚合 / 项目优先；managed 不受影响
 - `--host` `option`:监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--no-open` `boolean`:不自动打开浏览器

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -447,7 +447,7 @@ omk studio --no-open
   --analyses-dir <value>      Observe-health reports dir (optional, default project .omk/observe-health, falls back to global)
   --dev                       Dev mode: child process with hot reload
   --doctors-dir <value>       Doctor reports dir (optional, default project .omk/doctors, falls back to global)
-  --global                    View only global reports / observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of machine-wide / project-first; does not affect managed / observe-inbox
+  --global                    View only global reports / observe-health / doctors / observe-inbox dirs (~/.oh-my-knowledge/*) instead of machine-wide / project-first; does not affect managed
   --host <value>              Listen host, default localhost. Use 0.0.0.0 to expose to LAN
   --lang <value>              Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --no-open                   Do not auto-open browser

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -447,7 +447,7 @@ omk studio --no-open
   --analyses-dir <value>      观测健康报告目录（可选，默认项目级 .omk/observe-health，空则全局兜底）
   --dev                       dev 模式：子进程启动 + 热更新
   --doctors-dir <value>       体检报告目录（可选，默认项目级 .omk/doctors，空则全局兜底）
-  --global                    只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非机器级聚合 / 项目优先；managed / observe-inbox 不受影响
+  --global                    只看全局 reports / observe-health / doctors / observe-inbox 目录（~/.oh-my-knowledge/*），而非机器级聚合 / 项目优先；managed 不受影响
   --host <value>              监听 host，默认 localhost。改为 0.0.0.0 暴露给局域网
   --lang <value>              输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --no-open                   不自动打开浏览器

--- a/src/cli/commands/observe/inbox.ts
+++ b/src/cli/commands/observe/inbox.ts
@@ -30,8 +30,11 @@ export async function runObserveInbox(
   flags: ObserveInboxFlags,
   lang: CliLang,
 ): Promise<void> {
-  const { queryObservationInbox, selectExploreInboxItems, loadLatestObservationInboxReports, summarizeObservationInboxBySkill, DEFAULT_OBSERVATIONS_DIR } = await import('../../../observability/inbox.js');
-  const dir = resolve(flags['input-dir'] || DEFAULT_OBSERVATIONS_DIR);
+  const { queryObservationInbox, selectExploreInboxItems, loadLatestObservationInboxReports, summarizeObservationInboxBySkill, DEFAULT_OBSERVATIONS_DIR, DEFAULT_GLOBAL_OBSERVATIONS_DIR } = await import('../../../observability/inbox.js');
+  // 显式 --input-dir 最高;否则 --global 直读全局、默认读项目(空则 loadObservationInboxReports 兜底全局)。
+  const dir = flags['input-dir']
+    ? resolve(flags['input-dir'])
+    : (flags.global ? DEFAULT_GLOBAL_OBSERVATIONS_DIR : DEFAULT_OBSERVATIONS_DIR);
   if (flags['llm-enhanced-review']) {
     const { buildObservationInboxViewModel } = await import('../../../observability/inbox-view-model.js');
     const { extractSkillSoftStandards, DEFAULT_LLM_ENHANCED_REVIEW_MODEL } = await import('../../../observability/soft-standards/index.js');
@@ -206,6 +209,13 @@ export default class ObserveInbox extends BaseCommand {
         zh: 'inbox 数据目录，默认 .omk/observe-inbox（项目级，相对于 cwd）；目录不存在时兜底读 ~/.oh-my-knowledge/observe-inbox。',
         en: 'Inbox data dir, default .omk/observe-inbox (project-local); falls back to ~/.oh-my-knowledge/observe-inbox when missing.',
       }),
+    }),
+    global: Flags.boolean({
+      description: bilingual({
+        zh: '直接读取全局 ~/.oh-my-knowledge/observe-inbox（跳过项目级与兜底）。',
+        en: 'Read directly from global ~/.oh-my-knowledge/observe-inbox (skip project-local and fallback).',
+      }),
+      default: false,
     }),
     skill: Flags.string({
       description: bilingual({ zh: '只看指定 skill', en: 'Filter to specific skill' }),

--- a/src/cli/commands/observe/ingest.ts
+++ b/src/cli/commands/observe/ingest.ts
@@ -24,9 +24,16 @@ export default class ObserveIngest extends BaseCommand {
     lang: LANG_FLAG,
     'output-dir': Flags.string({
       description: bilingual({
-        zh: '输出目录，默认 .omk/observe-inbox（项目级，相对于 cwd）。',
-        en: 'Output dir, default .omk/observe-inbox (project-local, relative to cwd).',
+        zh: '输出目录，默认 .omk/observe-inbox（项目级，相对于 cwd；--global 写全局）。',
+        en: 'Output dir, default .omk/observe-inbox (project-local, relative to cwd; --global writes global).',
       }),
+    }),
+    global: Flags.boolean({
+      description: bilingual({
+        zh: '写入全局 ~/.oh-my-knowledge/observe-inbox，而非项目 .omk/observe-inbox。',
+        en: 'Write to global ~/.oh-my-knowledge/observe-inbox instead of project .omk/observe-inbox.',
+      }),
+      default: false,
     }),
   };
 
@@ -58,8 +65,10 @@ export default class ObserveIngest extends BaseCommand {
           : 'Error: --output-dir must not be an empty string.');
         throw new CliExit(2);
       }
-      const { buildObservationInboxReport, saveObservationInboxReport, DEFAULT_OBSERVATIONS_DIR } = await import('../../../observability/inbox.js');
-      const outDir = resolve(outDirRaw ?? DEFAULT_OBSERVATIONS_DIR);
+      const { buildObservationInboxReport, saveObservationInboxReport, DEFAULT_PROJECT_OBSERVATIONS_DIR, DEFAULT_GLOBAL_OBSERVATIONS_DIR } = await import('../../../observability/inbox.js');
+      // 显式 --output-dir 最高;否则 --global 写全局、默认写项目(读侧 loadObservationInboxReports 会从项目兜底到全局)。
+      const defaultDir = flags.global ? DEFAULT_GLOBAL_OBSERVATIONS_DIR : DEFAULT_PROJECT_OBSERVATIONS_DIR;
+      const outDir = resolve(outDirRaw ?? defaultDir);
       const { loadObservationReviewState } = await import('../../../observability/review-state.js');
       const { buildObserveDiagnosticsFromReport } = await import('../../../diagnosis/observe-producer.js');
       const report = buildObservationInboxReport(tracePath, { reviewState: loadObservationReviewState(outDir) });

--- a/src/cli/commands/observe/show.ts
+++ b/src/cli/commands/observe/show.ts
@@ -28,6 +28,13 @@ export default class ObserveShow extends BaseCommand {
         en: 'Inbox data dir',
       }),
     }),
+    global: Flags.boolean({
+      description: bilingual({
+        zh: '直接读取全局 ~/.oh-my-knowledge/observe-inbox（跳过项目级与兜底）。',
+        en: 'Read directly from global ~/.oh-my-knowledge/observe-inbox (skip project-local and fallback).',
+      }),
+      default: false,
+    }),
   };
 
   async run(): Promise<void> {
@@ -39,8 +46,11 @@ export default class ObserveShow extends BaseCommand {
         console.error(lang === 'zh' ? '用法：omk observe show <inbox_id> [--input-dir <path>]' : 'Usage: omk observe show <inbox_id> [--input-dir <path>]');
         throw new CliExit(1);
       }
-      const { findObservationInboxItem, formatObservationShow, DEFAULT_OBSERVATIONS_DIR } = await import('../../../observability/inbox.js');
-      const dir = resolve(flags['input-dir'] || DEFAULT_OBSERVATIONS_DIR);
+      const { findObservationInboxItem, formatObservationShow, DEFAULT_OBSERVATIONS_DIR, DEFAULT_GLOBAL_OBSERVATIONS_DIR } = await import('../../../observability/inbox.js');
+      // 显式 --input-dir 最高;否则 --global 直读全局、默认读项目(空则 findObservationInboxItem 兜底全局)。与 observe inbox 同口径。
+      const dir = flags['input-dir']
+        ? resolve(flags['input-dir'])
+        : (flags.global ? DEFAULT_GLOBAL_OBSERVATIONS_DIR : DEFAULT_OBSERVATIONS_DIR);
       const item = findObservationInboxItem(id, dir);
       if (!item) {
         console.error(lang === 'zh' ? `未找到 observation：${id}` : `Observation not found: ${id}`);

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -195,8 +195,8 @@ export default class Studio extends BaseCommand {
     }),
     global: Flags.boolean({
       description: bilingual({
-        zh: '只看全局 reports / observe-health / doctors 目录（~/.oh-my-knowledge/*），而非机器级聚合 / 项目优先；managed / observe-inbox 不受影响',
-        en: 'View only global reports / observe-health / doctors dirs (~/.oh-my-knowledge/*) instead of machine-wide / project-first; does not affect managed / observe-inbox',
+        zh: '只看全局 reports / observe-health / doctors / observe-inbox 目录（~/.oh-my-knowledge/*），而非机器级聚合 / 项目优先；managed 不受影响',
+        en: 'View only global reports / observe-health / doctors / observe-inbox dirs (~/.oh-my-knowledge/*) instead of machine-wide / project-first; does not affect managed',
       }),
     }),
     'no-open': Flags.boolean({

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -10,6 +10,7 @@ import {
   resolveDoctorsDir, projectDoctorsDir, globalDoctorsDir,
   globalReportsDir,
 } from '../../eval-core/measurement-dirs.js';
+import { DEFAULT_GLOBAL_OBSERVATIONS_DIR } from '../../observability/inbox.js';
 import type { ReportServer } from '../lib/shared.js';
 import type { StudioArgs, StudioFlags } from '../lib/cmd-flags.js';
 
@@ -112,7 +113,13 @@ export async function runStudio(
     // 只看固定目录(与 reports 的 --reports-dir 关闭 indexed store 对称)。observe / doctor 各自独立判定。
     includeObserveCards: !flags.global && !flags['analyses-dir'],
     includeDoctorCards: !flags.global && !flags['doctors-dir'],
-    ...(flags['observations-dir'] ? { observationsDir: resolve(flags['observations-dir']) } : {}),
+    // observe-inbox 缺省按请求项目优先→全局兜底(report-server 默认即此);显式 --observations-dir 固定该目录;
+    // --global 钉全局(与 observe-health / doctors 的 --global 一致)。
+    ...(flags['observations-dir']
+      ? { observationsDir: resolve(flags['observations-dir']) }
+      : flags.global
+        ? { observationsDir: DEFAULT_GLOBAL_OBSERVATIONS_DIR }
+        : {}),
     // 传解析器而非解析结果:Studio 是长会话,受管根目录要按请求解析(项目首次 install 后从 global 切回
     // project),与 omk list 同口径;若在此处一次性解析、冻结进 server,长会话里会与 CLI 分叉。
     managedDir: (): string => resolveManagedDir(managedDir()),

--- a/src/cli/lib/cmd-flags.ts
+++ b/src/cli/lib/cmd-flags.ts
@@ -241,6 +241,7 @@ export type ObserveInboxArgs = Record<string, never>;
 export interface ObserveInboxFlags {
   lang: Lang;
   'input-dir'?: string;
+  global: boolean;
   skill?: string;
   limit?: string;
   explore?: string;

--- a/src/cli/lib/cmd-flags.ts
+++ b/src/cli/lib/cmd-flags.ts
@@ -234,6 +234,7 @@ export interface ObserveIngestArgs {
 export interface ObserveIngestFlags {
   lang: Lang;
   'output-dir'?: string;
+  global: boolean;
 }
 
 // observe inbox(无 positional)
@@ -261,6 +262,7 @@ export interface ObserveShowArgs {
 export interface ObserveShowFlags {
   lang: Lang;
   'input-dir'?: string;
+  global: boolean;
 }
 
 // ── studio ────────────────────────────────────────────────────────────────────

--- a/test/cli/observe-inbox-global.test.ts
+++ b/test/cli/observe-inbox-global.test.ts
@@ -1,7 +1,9 @@
 /**
- * observe-inbox 的 --global 写 / 读对称验收(子进程实跑真 CLI):
- * - `observe ingest --global` 写全局 ~/.oh-my-knowledge/observe-inbox,项目 .omk/observe-inbox 不落;
- * - `observe inbox --global` 直读全局;默认 `observe inbox` 在项目空时兜底读全局。
+ * observe-inbox 的 --global 写 / 读对称验收(子进程实跑真 CLI),覆盖 ingest / inbox / show:
+ * - ingest --global 写全局、默认写项目,两者互斥;
+ * - inbox --global 钉死全局(用可区分内容证明:不串项目),默认项目优先、项目缺失才兜底全局;
+ * - 显式 --output-dir / --input-dir 胜过 --global;
+ * - show --global 顺着 inbox --global 的 id 读到全局那条(项目非空时默认 show 读不到,证明闭环已补)。
  * 每条用例独占一个临时 OMK_HOME,不碰真实 home。
  */
 import { describe, it } from 'vitest';
@@ -18,88 +20,133 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, '..', '..');
 const CLI = join(PROJECT_ROOT, 'dist', 'cli', 'index.js');
 
-/** 造一个最小 trace 目录(单条 user 记录,够 buildObservationInboxReport 产出有效报告)。 */
-function makeTrace(base: string): string {
-  const traceDir = join(base, 'trace');
-  mkdirSync(traceDir, { recursive: true });
-  const rec = {
-    type: 'user', uuid: 'u1', parentUuid: null, sessionId: 's1',
-    timestamp: '2026-05-01T00:00:00.000Z', cwd: '/repo-a',
-    message: { role: 'user', content: '<command-name>/audit</command-name>\nhi' },
-  };
-  writeFileSync(join(traceDir, 'session.jsonl'), JSON.stringify(rec));
-  return traceDir;
+interface ExecError extends Error { code?: number; stdout: string; stderr: string; }
+
+/** 造一个 trace 目录,产出一条 hard_miss item(skillName = `skill`),让 global / project 内容可区分。 */
+function makeTrace(dir: string, skill: string): string {
+  mkdirSync(dir, { recursive: true });
+  const records = [
+    { type: 'user', uuid: 'u1', parentUuid: null, sessionId: 's1', timestamp: '2026-05-01T00:00:00.000Z', cwd: '/repo-a',
+      message: { role: 'user', content: `<command-name>/${skill}</command-name>\nFind revenue schema` } },
+    { type: 'assistant', uuid: 'a1', parentUuid: 'u1', sessionId: 's1', timestamp: '2026-05-01T00:00:01.000Z', cwd: '/repo-a',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'Grep', input: { pattern: 'revenue_schema', path: '/repo-a' } }] } },
+    { type: 'user', uuid: 'u2', parentUuid: 'a1', sessionId: 's1', timestamp: '2026-05-01T00:00:02.000Z', cwd: '/repo-a',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'No matches found', is_error: false }] } },
+  ];
+  writeFileSync(join(dir, 'session.jsonl'), records.map((r) => JSON.stringify(r)).join('\n'));
+  return dir;
 }
 
-/** 独立沙盒:临时 OMK_HOME(全局根)+ 临时项目 cwd。 */
-function sandbox(): { home: string; project: string; trace: string; env: NodeJS.ProcessEnv; cleanup: () => void } {
+function box(): { home: string; project: string; base: string; env: NodeJS.ProcessEnv; cleanup: () => void } {
   const base = mkdtempSync(join(tmpdir(), 'omk-inbox-global-'));
   const home = join(base, 'home');
   const project = join(base, 'project');
   mkdirSync(home, { recursive: true });
   mkdirSync(project, { recursive: true });
-  const trace = makeTrace(base);
-  return {
-    home, project, trace,
-    env: { ...process.env, OMK_HOME: home },
-    cleanup: () => rmSync(base, { recursive: true, force: true }),
-  };
+  return { home, project, base, env: { ...process.env, OMK_HOME: home }, cleanup: () => rmSync(base, { recursive: true, force: true }) };
 }
 
 function inboxJsons(dir: string): string[] {
   return existsSync(dir) ? readdirSync(dir).filter((f) => f.endsWith('-observe-inbox.json')) : [];
 }
 
+const globalInbox = (home: string): string => join(home, 'observe-inbox');
+const projectInbox = (project: string): string => join(project, '.omk', 'observe-inbox');
+
+async function cli(args: string[], cwd: string, env: NodeJS.ProcessEnv): Promise<string> {
+  const { stdout } = await execFileAsync('node', [CLI, ...args], { cwd, env });
+  return stdout;
+}
+function skillNames(jsonStdout: string): string[] {
+  const parsed = JSON.parse(jsonStdout);
+  return (parsed.items as Array<{ skillName: string }>).map((i) => i.skillName);
+}
+
 describe('observe-inbox --global', () => {
-  it('ingest --global → 写全局 observe-inbox,项目 .omk/observe-inbox 不落', async () => {
-    const s = sandbox();
+  it('ingest --global → 写全局,项目不落;ingest 默认 → 写项目,全局不落', async () => {
+    const s = box();
     try {
-      await execFileAsync('node', [CLI, 'observe', 'ingest', s.trace, '--global'], { cwd: s.project, env: s.env });
-      const globalDir = join(s.home, 'observe-inbox');
-      const projectDir = join(s.project, '.omk', 'observe-inbox');
-      assert.equal(inboxJsons(globalDir).length, 1, '全局目录有一份 observe-inbox 报告');
-      assert.deepEqual(inboxJsons(projectDir), [], '项目目录不落(--global 走全局)');
-    } finally {
-      s.cleanup();
-    }
+      await cli(['observe', 'ingest', makeTrace(join(s.base, 'tg'), 'gskill'), '--global'], s.project, s.env);
+      assert.equal(inboxJsons(globalInbox(s.home)).length, 1, '--global 写全局');
+      assert.deepEqual(inboxJsons(projectInbox(s.project)), [], '--global 不落项目');
+
+      const s2 = box();
+      try {
+        await cli(['observe', 'ingest', makeTrace(join(s2.base, 'tp'), 'pskill')], s2.project, s2.env);
+        assert.equal(inboxJsons(projectInbox(s2.project)).length, 1, '默认写项目');
+        assert.deepEqual(inboxJsons(globalInbox(s2.home)), [], '默认不落全局');
+      } finally { s2.cleanup(); }
+    } finally { s.cleanup(); }
   });
 
-  it('ingest(默认）→ 写项目 .omk/observe-inbox,全局不落', async () => {
-    const s = sandbox();
+  it('inbox --global 钉死全局、默认读项目:用可区分内容证明读路由不串', async () => {
+    const s = box();
     try {
-      await execFileAsync('node', [CLI, 'observe', 'ingest', s.trace], { cwd: s.project, env: s.env });
-      const globalDir = join(s.home, 'observe-inbox');
-      const projectDir = join(s.project, '.omk', 'observe-inbox');
-      assert.equal(inboxJsons(projectDir).length, 1, '项目目录有一份(默认项目级)');
-      assert.deepEqual(inboxJsons(globalDir), [], '全局不落');
-    } finally {
-      s.cleanup();
-    }
+      await cli(['observe', 'ingest', makeTrace(join(s.base, 'tg'), 'gskill'), '--global'], s.project, s.env);
+      await cli(['observe', 'ingest', makeTrace(join(s.base, 'tp'), 'pskill')], s.project, s.env); // 默认写项目
+
+      const g = skillNames(await cli(['observe', 'inbox', '--global', '--json'], s.project, s.env));
+      assert.ok(g.length > 0, '--global 读到非空');
+      assert.ok(g.includes('gskill'), '--global 含全局那条');
+      assert.ok(!g.includes('pskill'), '--global 不串项目数据');
+
+      const d = skillNames(await cli(['observe', 'inbox', '--json'], s.project, s.env));
+      assert.ok(d.length > 0, '默认读到非空');
+      assert.ok(d.includes('pskill'), '默认含项目那条');
+      assert.ok(!d.includes('gskill'), '项目非空时默认不串全局');
+    } finally { s.cleanup(); }
   });
 
-  it('inbox --global → 直读全局;默认 inbox 在项目空时兜底读全局', async () => {
-    const s = sandbox();
+  it('inbox 默认在项目目录缺失时兜底读全局', async () => {
+    const s = box();
     try {
-      // 只写全局,项目侧保持空。
-      await execFileAsync('node', [CLI, 'observe', 'ingest', s.trace, '--global'], { cwd: s.project, env: s.env });
-      // --global 直读全局。
-      const g = await execFileAsync('node', [CLI, 'observe', 'inbox', '--global', '--json'], { cwd: s.project, env: s.env });
-      const gp = JSON.parse(g.stdout);
-      assert.equal(gp.kind, 'observe-inbox-query');
-      // 默认(无 --global):项目空 → loadObservationInboxReports 兜底读全局,同样看到。
-      const d = await execFileAsync('node', [CLI, 'observe', 'inbox', '--json'], { cwd: s.project, env: s.env });
-      const dp = JSON.parse(d.stdout);
-      assert.equal(dp.kind, 'observe-inbox-query');
-      assert.ok(Array.isArray(dp.items));
-    } finally {
-      s.cleanup();
-    }
+      await cli(['observe', 'ingest', makeTrace(join(s.base, 'tg'), 'gskill'), '--global'], s.project, s.env);
+      // 项目从未写过 → .omk/observe-inbox 不存在 → loadObservationInboxReports 兜底全局。
+      assert.ok(!existsSync(projectInbox(s.project)), '前提:项目 inbox 目录不存在');
+      const d = skillNames(await cli(['observe', 'inbox', '--json'], s.project, s.env));
+      assert.ok(d.includes('gskill'), '默认兜底读到全局');
+    } finally { s.cleanup(); }
   });
 
-  it('ingest --help / inbox --help 列出 --global', async () => {
-    const ing = await execFileAsync('node', [CLI, 'observe', 'ingest', '--help']);
-    assert.ok(ing.stdout.includes('--global'), 'ingest --help 应列 --global');
-    const inb = await execFileAsync('node', [CLI, 'observe', 'inbox', '--help']);
-    assert.ok(inb.stdout.includes('--global'), 'inbox --help 应列 --global');
+  it('显式 --output-dir / --input-dir 胜过 --global', async () => {
+    const s = box();
+    try {
+      const explicit = join(s.base, 'explicit');
+      await cli(['observe', 'ingest', makeTrace(join(s.base, 'tx'), 'xskill'), '--output-dir', explicit, '--global'], s.project, s.env);
+      assert.equal(inboxJsons(explicit).length, 1, '--output-dir 胜过 --global,落显式目录');
+      assert.deepEqual(inboxJsons(globalInbox(s.home)), [], '--global 被 --output-dir 压住,全局不落');
+
+      const r = skillNames(await cli(['observe', 'inbox', '--input-dir', explicit, '--global', '--json'], s.project, s.env));
+      assert.ok(r.includes('xskill'), '--input-dir 胜过 --global,读显式目录');
+    } finally { s.cleanup(); }
+  });
+
+  it('show --global 读到全局那条;项目非空时默认 show 读不到(闭环已补)', async () => {
+    const s = box();
+    try {
+      await cli(['observe', 'ingest', makeTrace(join(s.base, 'tg'), 'gskill'), '--global'], s.project, s.env);
+      await cli(['observe', 'ingest', makeTrace(join(s.base, 'tp'), 'pskill')], s.project, s.env); // 项目非空 → 默认不兜底
+      const items = JSON.parse(await cli(['observe', 'inbox', '--global', '--json'], s.project, s.env)).items as Array<{ id: string; skillName: string }>;
+      const gid = items.find((i) => i.skillName === 'gskill')?.id;
+      assert.ok(gid, '从 inbox --global 拿到全局那条的 id');
+
+      const shown = await cli(['observe', 'show', gid as string, '--global'], s.project, s.env);
+      assert.ok(shown.length > 0, 'show --global 读到全局那条详情');
+
+      // 不带 --global:项目目录非空 → 不兜底全局 → 找不到这条全局 id(证明缺口已被 --global 补上)。
+      try {
+        await cli(['observe', 'show', gid as string], s.project, s.env);
+        assert.fail('预期默认 show 找不到全局 id 而非零退出');
+      } catch (err) {
+        assert.equal((err as ExecError).code, 1, '默认 show 找不到 → exit 1');
+      }
+    } finally { s.cleanup(); }
+  });
+
+  it('ingest / inbox / show --help 都列出 --global', async () => {
+    for (const sub of ['ingest', 'inbox', 'show']) {
+      const { stdout } = await execFileAsync('node', [CLI, 'observe', sub, '--help']);
+      assert.ok(stdout.includes('--global'), `observe ${sub} --help 应列 --global`);
+    }
   });
 });

--- a/test/cli/observe-inbox-global.test.ts
+++ b/test/cli/observe-inbox-global.test.ts
@@ -1,0 +1,105 @@
+/**
+ * observe-inbox 的 --global 写 / 读对称验收(子进程实跑真 CLI):
+ * - `observe ingest --global` 写全局 ~/.oh-my-knowledge/observe-inbox,项目 .omk/observe-inbox 不落;
+ * - `observe inbox --global` 直读全局;默认 `observe inbox` 在项目空时兜底读全局。
+ * 每条用例独占一个临时 OMK_HOME,不碰真实 home。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const CLI = join(PROJECT_ROOT, 'dist', 'cli', 'index.js');
+
+/** 造一个最小 trace 目录(单条 user 记录,够 buildObservationInboxReport 产出有效报告)。 */
+function makeTrace(base: string): string {
+  const traceDir = join(base, 'trace');
+  mkdirSync(traceDir, { recursive: true });
+  const rec = {
+    type: 'user', uuid: 'u1', parentUuid: null, sessionId: 's1',
+    timestamp: '2026-05-01T00:00:00.000Z', cwd: '/repo-a',
+    message: { role: 'user', content: '<command-name>/audit</command-name>\nhi' },
+  };
+  writeFileSync(join(traceDir, 'session.jsonl'), JSON.stringify(rec));
+  return traceDir;
+}
+
+/** 独立沙盒:临时 OMK_HOME(全局根)+ 临时项目 cwd。 */
+function sandbox(): { home: string; project: string; trace: string; env: NodeJS.ProcessEnv; cleanup: () => void } {
+  const base = mkdtempSync(join(tmpdir(), 'omk-inbox-global-'));
+  const home = join(base, 'home');
+  const project = join(base, 'project');
+  mkdirSync(home, { recursive: true });
+  mkdirSync(project, { recursive: true });
+  const trace = makeTrace(base);
+  return {
+    home, project, trace,
+    env: { ...process.env, OMK_HOME: home },
+    cleanup: () => rmSync(base, { recursive: true, force: true }),
+  };
+}
+
+function inboxJsons(dir: string): string[] {
+  return existsSync(dir) ? readdirSync(dir).filter((f) => f.endsWith('-observe-inbox.json')) : [];
+}
+
+describe('observe-inbox --global', () => {
+  it('ingest --global → 写全局 observe-inbox,项目 .omk/observe-inbox 不落', async () => {
+    const s = sandbox();
+    try {
+      await execFileAsync('node', [CLI, 'observe', 'ingest', s.trace, '--global'], { cwd: s.project, env: s.env });
+      const globalDir = join(s.home, 'observe-inbox');
+      const projectDir = join(s.project, '.omk', 'observe-inbox');
+      assert.equal(inboxJsons(globalDir).length, 1, '全局目录有一份 observe-inbox 报告');
+      assert.deepEqual(inboxJsons(projectDir), [], '项目目录不落(--global 走全局)');
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it('ingest(默认）→ 写项目 .omk/observe-inbox,全局不落', async () => {
+    const s = sandbox();
+    try {
+      await execFileAsync('node', [CLI, 'observe', 'ingest', s.trace], { cwd: s.project, env: s.env });
+      const globalDir = join(s.home, 'observe-inbox');
+      const projectDir = join(s.project, '.omk', 'observe-inbox');
+      assert.equal(inboxJsons(projectDir).length, 1, '项目目录有一份(默认项目级)');
+      assert.deepEqual(inboxJsons(globalDir), [], '全局不落');
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it('inbox --global → 直读全局;默认 inbox 在项目空时兜底读全局', async () => {
+    const s = sandbox();
+    try {
+      // 只写全局,项目侧保持空。
+      await execFileAsync('node', [CLI, 'observe', 'ingest', s.trace, '--global'], { cwd: s.project, env: s.env });
+      // --global 直读全局。
+      const g = await execFileAsync('node', [CLI, 'observe', 'inbox', '--global', '--json'], { cwd: s.project, env: s.env });
+      const gp = JSON.parse(g.stdout);
+      assert.equal(gp.kind, 'observe-inbox-query');
+      // 默认(无 --global):项目空 → loadObservationInboxReports 兜底读全局,同样看到。
+      const d = await execFileAsync('node', [CLI, 'observe', 'inbox', '--json'], { cwd: s.project, env: s.env });
+      const dp = JSON.parse(d.stdout);
+      assert.equal(dp.kind, 'observe-inbox-query');
+      assert.ok(Array.isArray(dp.items));
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it('ingest --help / inbox --help 列出 --global', async () => {
+    const ing = await execFileAsync('node', [CLI, 'observe', 'ingest', '--help']);
+    assert.ok(ing.stdout.includes('--global'), 'ingest --help 应列 --global');
+    const inb = await execFileAsync('node', [CLI, 'observe', 'inbox', '--help']);
+    assert.ok(inb.stdout.includes('--global'), 'inbox --help 应列 --global');
+  });
+});

--- a/test/cli/observe.test.ts
+++ b/test/cli/observe.test.ts
@@ -52,6 +52,7 @@ describe('observe CLI', () => {
         {
           lang: 'zh',
           'input-dir': dir,
+          global: false,
           skill: 'audit',
           'include-noise': false,
           'by-skill': true,

--- a/test/cli/studio-dev-spawn.test.ts
+++ b/test/cli/studio-dev-spawn.test.ts
@@ -121,6 +121,23 @@ describe('studio --dev child spawn argv', () => {
     expect(rest).toEqual(['--port', '7799', '--global', '--no-open']);
   });
 
+  it('server 模式 --global → observationsDir 钉全局(与 observe-health / doctors 一致)', async () => {
+    const { runStudio } = await import('../../src/cli/commands/studio.js');
+    const { createReportServer } = await import('../../src/server/report-server.js');
+    const { DEFAULT_GLOBAL_OBSERVATIONS_DIR } = await import('../../src/observability/inbox.js');
+    await runStudio({}, { lang: 'zh', port: '7799', 'no-open': true, dev: false, global: true }, 'zh');
+    const opts = vi.mocked(createReportServer).mock.calls.at(-1)?.[0];
+    expect(opts?.observationsDir).toBe(DEFAULT_GLOBAL_OBSERVATIONS_DIR);
+  });
+
+  it('server 模式默认(无 --global / --observations-dir）→ observationsDir 不设(交给 server 项目优先+全局兜底)', async () => {
+    const { runStudio } = await import('../../src/cli/commands/studio.js');
+    const { createReportServer } = await import('../../src/server/report-server.js');
+    await runStudio({}, { lang: 'zh', port: '7799', 'no-open': true, dev: false }, 'zh');
+    const opts = vi.mocked(createReportServer).mock.calls.at(-1)?.[0];
+    expect(opts?.observationsDir).toBeUndefined();
+  });
+
   it('treats BROWSER=none as no browser open', async () => {
     const { runStudio } = await import('../../src/cli/commands/studio.js');
     setStdoutIsTTY(true);


### PR DESCRIPTION
## 这个 PR 做什么

给 `observe-inbox` 补齐 `--global` 支持，消除它与同阶段 `observe-health` 之间的不对称。

`observe-health`（健康汇总）早已支持 `--global` 写全局，而 `observe-inbox`（逐条观察的 triage 收件箱）此前只有项目本地写 + 全局读兜底、没有 `--global`。这是 rollout 顺序的历史遗留，不是有意设计。

## 用户影响

- `omk observe ingest <trace> --global`：把收件箱写到全局 `~/.oh-my-knowledge/observe-inbox`，而非项目 `.omk/observe-inbox`。
- `omk observe inbox --global`：直读全局收件箱（跳过项目级与兜底）。
- `omk studio --global`：连带把收件箱视图钉到全局，与 `observe-health` / `doctors` 在 `--global` 下的行为一致。
- 默认行为不变：项目本地写、读时项目优先→全局兜底。

补全了全局 skill 的观测闭环：全局 skill → 全局健康报告（`observe --global`）→ 全局收件箱里 triage → 建议补进它的 canonical / golden 用例集 → `omk eval --global` 跑分。

## 一处刻意的设计决定

`observe-inbox` **不进**产物发现索引（`omk studio` 的机器级跨项目总览）。发现索引服务的是「可比的测量产物」（report / doctor / observe-health 这类复盘结论），而收件箱是当前项目的 triage 工作台——在 A 项目的 studio 里浏览 B 项目的待办队列价值低且易误操作。所以 observe-health（汇总）进索引、observe-inbox（原始待办）不进，是有原则的边界，不是缺口。

## 测量学 caveat

非 BREAKING-COMPARABILITY：只新增写 / 读目标路由，不碰报告格式、judge / observe prompt 或任何算出来的数字。

## 验证

`yarn lint && typecheck && build && build:docs:check && test` 全绿（178 文件 / 2189 测试）。新增子进程集成测试覆盖 ingest --global 写全局 / 项目不落、inbox --global 直读 + 默认兜底读、help 列出 --global；studio server 模式 --global 钉 inbox 全局的单测。全程 OMK_HOME 隔离，不碰真实 home。

相关：#243（存储布局重整）。配套文档 spec（#254）同步描述这层对称。

🤖 Generated with [Claude Code](https://claude.com/claude-code)