### PR TITLE
docs(specs): 存储布局目录树把 observe-inbox 并进测量产物同行

### DIFF
--- a/docs/specs/storage-layout-spec.md
+++ b/docs/specs/storage-layout-spec.md
@@ -35,17 +35,15 @@ The four in the first row are placed the same way (project-local default + globa
 
 ```
 ~/.oh-my-knowledge/             # machine-global dir (honors OMK_HOME, relocatable as a whole)
-  reports/ observe-health/ doctors/   # written here only when you run omk ... --global
+  reports/ observe-health/ doctors/ observe-inbox/   # written here only when you run omk ... --global
   managed/                      # governance archive for globally-installed skills
-  observe-inbox/                # global inbox (--global write / read)
   update-check.json
   state/                        # scratch · wipe anytime
     cache/  isolated-cwd/  trees/  jobs/
     artifact-index/<domain>/<id>.json   # index cards for the cross-project overview (section 6)
 
 <project>/.omk/                 # project-local · keep · tied to this project's sample set
-  reports/  observe-health/  doctors/   # measurement output — gitignored by default
-  observe-inbox/                # inbox — gitignored by default
+  reports/  observe-health/  doctors/  observe-inbox/   # measurement output & inbox — gitignored by default
   managed/                      # governance archive for project-vendored skills — committable (decision history)
   eval-samples.yaml / eval.yaml # measurement definition — committed
 ```

--- a/docs/zh/specs/storage-layout-spec.md
+++ b/docs/zh/specs/storage-layout-spec.md
@@ -35,17 +35,15 @@
 
 ```
 ~/.oh-my-knowledge/             # 电脑全局目录（认 OMK_HOME，可整体搬走）
-  reports/ observe-health/ doctors/   # 只有 omk ... --global 主动跑时才写这里
+  reports/ observe-health/ doctors/ observe-inbox/   # 只有 omk ... --global 主动跑时才写这里
   managed/                      # 全局装的 skill 的治理档案
-  observe-inbox/                # 全局收件箱（--global 写 / 读）
   update-check.json
   state/                        # 草稿区 · 随时可整删
     cache/  isolated-cwd/  trees/  jobs/
     artifact-index/<domain>/<id>.json   # 跨项目总览用的索引卡片（见第六节）
 
 <项目>/.omk/                    # 项目本地 · 要留 · 绑这个项目的用例集
-  reports/  observe-health/  doctors/   # 测量产物 —— 默认 gitignore，不进库
-  observe-inbox/                # 收件箱 —— 默认 gitignore，不进库
+  reports/  observe-health/  doctors/  observe-inbox/   # 测量产物与收件箱 —— 默认 gitignore，不进库
   managed/                      # 项目自带 skill 的治理档案 —— 可以提交（决策史）
   eval-samples.yaml / eval.yaml # 测量定义 —— 提交
 ```


### PR DESCRIPTION
## 这个 PR 做什么

存储布局规范第三节的目录树里，把 `observe-inbox/` 从单独一行并进 `reports / observe-health / doctors` 同一行（全局树 + 项目树各一处，中英双版）。

`observe-inbox` 补了 `--global` 后，归属规则已与那三者完全一致——全局只在 `--global` 主动跑时写、项目本地默认 gitignore。单独占一行是补 `--global` 之前的残留，并进同一行更紧凑、也更准确地反映「四者同口径」。

纯文档排版，无语义变化。

## 验证

`yarn docs:build`（VitePress）无死链。