### PR TITLE
fix(cli): omk init 的 .omk/.gitignore 补忽略 /backups/，并补进存储布局 spec

### DIFF
--- a/docs/specs/storage-layout-spec.md
+++ b/docs/specs/storage-layout-spec.md
@@ -44,6 +44,7 @@ The four in the first row are placed the same way (project-local default + globa
 
 <project>/.omk/                 # project-local · keep · tied to this project's sample set
   reports/  observe-health/  doctors/  observe-inbox/   # measurement output & inbox — gitignored by default
+  backups/                      # pre-fix skill originals saved by doctor --fix (for undo) — gitignored by default
   managed/                      # governance archive for project-vendored skills — committable (decision history)
   eval-samples.yaml / eval.yaml # measurement definition — committed
 ```
@@ -105,7 +106,7 @@ Split by "can it rebuild itself if deleted":
 
 - **Already auto-cleaning (scratch)**: `doctor` keeps the latest 50 per skill; `cache` caps at 2000; `trees` / `isolated-cwd` cap at 200 (with a lock protecting the in-use process). All three are env-tunable.
 - **Deliberately not cleaned (data)**: `reports` / `observe-health` / `observe-inbox` are never background-deleted. Two reasons: (1) `reports` is referenced by `id` from governance archives and task records, so auto-deleting breaks links; (2) a report's entire value is "compare history against the new version", so auto-deleting quietly destroys the basis for comparison. They're just a few JSON files anyway.
-- **No cap yet**: `jobs` (studio async task records) are a few KB each and carry an `id` pointing at a report, landing in the "don't randomly delete anything that references a report" rule — so they're not auto-cleaned either. Add a lenient cap if they ever bloat.
+- **No cap yet**: `jobs` (studio async task records) are a few KB each and carry an `id` pointing at a report, landing in the "don't randomly delete anything that references a report" rule — so they're not auto-cleaned either. `backups` (pre-fix skill originals saved on every `doctor --fix`) is likewise uncapped — it's the undo safety net, so deleting it early loses the ability to roll back; not auto-cleaned, add a lenient cap if it ever bloats.
 
 ## 8. This isn't made up — the industry does it this way
 

--- a/docs/zh/specs/storage-layout-spec.md
+++ b/docs/zh/specs/storage-layout-spec.md
@@ -44,6 +44,7 @@
 
 <项目>/.omk/                    # 项目本地 · 要留 · 绑这个项目的用例集
   reports/  observe-health/  doctors/  observe-inbox/   # 测量产物与收件箱 —— 默认 gitignore，不进库
+  backups/                      # doctor --fix 改 skill 前存的原件（撤销用）—— 默认 gitignore，不进库
   managed/                      # 项目自带 skill 的治理档案 —— 可以提交（决策史）
   eval-samples.yaml / eval.yaml # 测量定义 —— 提交
 ```
@@ -105,7 +106,7 @@
 
 - **已经在自动清的（草稿）**：`doctor` 每个 skill 留最近 50 份；`cache` 最多 2000 条；`trees` / `isolated-cwd` 最多 200 条（带正在用的进程锁保护）。三个都能用环境变量调。
 - **故意不清的（数据）**：`reports` / `observe-health` / `observe-inbox` 永不后台删。两个理由：(1) `reports` 被治理档案和任务记录按 `id` 引着，自动删会断链；(2) 报告的全部价值就是「拿历史比新版」，自动删等于偷偷毁掉比较的底子。也就几个 json，不占地方。
-- **暂时没上限的**：`jobs`（studio 异步任务记录）每个几 KB、还记着指向报告的 `id`，落在「引用了报告的别乱删」这条里，一并不自动清。真撑爆那天再加个宽松上限。
+- **暂时没上限的**：`jobs`（studio 异步任务记录）每个几 KB、还记着指向报告的 `id`，落在「引用了报告的别乱删」这条里，一并不自动清。`backups`（doctor --fix 每次改 skill 前存的原件）也一样无上限——它是撤销用的安全网，删早了就没法回退，所以不自动清，真撑爆再加宽松上限。
 
 ## 八、这套不是拍脑袋，业界都这么干
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -4,12 +4,14 @@ import { LANG_FLAG, bilingual, resolveLang } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { tCli } from '../lib/i18n.js';
 
-// 预置 .omk/.gitignore:测量 bulk(项目本地、可重生)默认不入库;managed/ 治理档案 + 配置不在此列,默认 track。
-const INIT_OMK_GITIGNORE = `# omk 测量 bulk(项目本地、可重生)——不入库;前导 / 锚定 .omk/ 顶层,不误伤嵌套同名目录。
+// 预置 .omk/.gitignore:测量 bulk + doctor --fix 备份(项目本地、不该入库)默认不入库;
+// managed/ 治理档案 + 配置不在此列,默认 track。
+const INIT_OMK_GITIGNORE = `# omk 测量 bulk + doctor --fix 备份(项目本地)——不入库;前导 / 锚定 .omk/ 顶层,不误伤嵌套同名目录。
 /observe-health/
 /doctors/
 /observe-inbox/
 /reports/
+/backups/
 `;
 
 const INIT_SAMPLES = `[

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -57,7 +57,7 @@ describe('oclif init', () => {
       const gitignorePath = join(target, '.omk', '.gitignore');
       assert.ok(existsSync(gitignorePath), '.omk/.gitignore not created');
       const gi = readFileSync(gitignorePath, 'utf8');
-      for (const d of ['observe-health/', 'doctors/', 'observe-inbox/', 'reports/']) {
+      for (const d of ['observe-health/', 'doctors/', 'observe-inbox/', 'reports/', 'backups/']) {
         assert.ok(gi.includes(d), `.omk/.gitignore should ignore ${d}`);
       }
       assert.ok(!/^managed\/?$/m.test(gi), '.omk/.gitignore must not ignore managed/');


### PR DESCRIPTION
## 这个 PR 做什么

修一个 `.omk/.gitignore` 漏项 + 补一处 spec 漏列，都围绕 `.omk/backups/`。

`doctor --fix` 改 skill 前会把原件备份到 `.omk/backups/doctor-fix-<stamp>/`（`src/doctor/fixer.ts`）。但 `omk init` 预置的 `.omk/.gitignore` 只忽略 `reports / observe-health / doctors / observe-inbox`，**漏了 `backups`**——这些撤销用的原件备份会被 `git add` 误提交进库。补上 `/backups/`。

顺带把 `backups` 补进 `storage-layout-spec`：此前目录树漏列它，留存段也没提。现补进项目目录树 + 留存口径（同 `jobs`：撤销安全网，不自动清、暂无上限），中英双版。

## 用户影响

`omk init` 起的新项目，`.omk/backups/` 不再会被误提交。已有项目若已生成 `.omk/.gitignore`，需手动补一行 `/backups/`（或重跑 init 不覆盖现有文件，需手动加）。

## 背景

这是「现有目录结构是否合理」复盘里查出的两个真问题之一（另一是命名一致性，留作独立 design-note）。

## 验证

`yarn lint && typecheck && build && test`（178 文件 / 2191）全绿，`docs:build` 无死链。init 测试断言已加 `backups/`。

相关：#243（存储布局重整）。