### PR TITLE
chore(release): 发布 0.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 发布 0.38.0

bump 版本 0.37.0 → 0.38.0。自 0.37.0 起全部 additive、非 BREAKING-COMPARABILITY。

主要内容：
- **#243 存储布局重整**：测量产物（reports / observe-health / doctors / observe-inbox）默认落项目 `.omk/`、`--global` 显式写全局、studio 读走「项目优先 → 全局兜底」；studio 升级为机器级总览，产物发现索引覆盖 report / doctor / observe-health 三域（轻量卡片指向项目正文，跨项目聚合浏览，比较层仍锁同口径）；可重生 scratch（cache / isolated-cwd / trees / jobs / artifact-index）收进 `~/.oh-my-knowledge/state/` 子树。
- **observe 命名统一**到 `observe-*` 词根（命令 / 目录 / 文件 / kind / 路由对齐，旧路由 302/307 兜底）。
- **observe-inbox 支持 `--global`** 写 / 读（ingest / inbox / show / studio 一致），补全全局 skill 观测闭环。
- **存储布局规范北极星文档** `docs/specs/storage-layout-spec.md`（中英双版）。
- **managed 决策史页**（Studio `/managed` 列表 + 时间线）。
- **script executor mock**（物化 settings + env 暴露）。
- `omk init` 的 `.omk/.gitignore` 补忽略 `/backups/`（doctor --fix 原件备份不再误入库）。

## 验证

`yarn lint && typecheck && build && build:docs:check && test`（178 文件 / 2191）本地全绿。

注：本地全量跑偶发 1 个 flaky 失败（重跑即过，与版本 bump 无关，pre-existing），CI 会再跑一遍门禁。