### PR TITLE
chore(release): 发布 0.39.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 这一版做了什么（大白话）

0.39.0 把**管理支柱**的「看见每个版本」这条线补齐了——你装的 skill 改了好几版，现在能在 Studio 里一眼看清每版分数怎么走、哪些版本能直接比、想回退到旧版该跑哪条 git 命令。

自 0.38.0 起合入：

- **版本回归曲线**（#236 / #265）：Studio 决策史画出每版 composite 均值 + 95% 置信区间，换过评委 / 改过样本集 / 缺指纹的版本标空心点 + 虚线，不把不可比的差值糊成「在变好」。
- **每版 git 还原坐标 + `git checkout` 提示**（#236 Slice B / #234 / #266）：每条证据记下被测版本的 git commit（取该 variant 的 ref 解析出的真实 commit，不是 cwd HEAD），Studio 给出现成的 `git checkout <sha> -- <path>` 把源带回那一版。字节级还原交给 git，omk 不自建版本仓库。
- **override 仅限 CLI 写、Studio 只读审计**（#238 / #264）：人工越门采用只能从 CLI（可审计 actor），Studio 列表标「越门采用」徽标。
- **`omk sample --append`**：在已有用例集上追加，不必重建。
- 受管证据 staleness / drift 策略定案（#237 / #261）、历史版本还原交给 git 的边界写进 spec（#234 / #263）。

## 测量学

无 `BREAKING-COMPARABILITY`：本版新增的 git 还原坐标、版本曲线都是附加展示，不进可比性签名、不改 verdict / Δ / 评分管道 / 评委 prompt / Report schema 既有字段语义。跨版本报告可比性不变。

## 发版

minor 版本：0.38.0 → 0.39.0。合并后在 main 的合并提交上打 `v0.39.0` tag、单独推 tag 触发 publish.yml（npm publish + 自动 GitHub Release notes）。