### PR TITLE
feat(managed): omk list 与 Studio surface 生产盲区 marker + 决策史观测事件（#235 Slice B）

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -12,10 +12,13 @@ import {
 } from '../../managed/index.js';
 import type { CliLang } from '../lib/i18n.js';
 
-/** CJK 全角字符按 2 列计宽,使含中文表头的列也能对齐。 */
+/** CJK 全角字符 + 星平面 emoji 按 2 列计宽,使含中文表头 / emoji 标记(如 🔬)的列也能对齐。
+ *  逐**码点**迭代(for...of),星平面 emoji 是单码点,加 `\u{1F300}-\u{1FAFF}`(含 🔬 U+1F52C)判 2 列。
+ *  注:`⚠️` 是「U+26A0 + U+FE0F」两码点、各 1 列合计 2,本就与 2 列渲染对齐,不另判(避免重复计数);
+ *  `✓`(U+2713)终端按 1 列渲染、保持 1。 */
 export function dispWidth(s: string): number {
   let w = 0;
-  for (const ch of s) w += /[ᄀ-ᅟ⺀-꓏가-힣豈-﫿︰-﹏＀-｠￠-￦]/.test(ch) ? 2 : 1;
+  for (const ch of s) w += /[ᄀ-ᅟ⺀-꓏가-힣豈-﫿︰-﹏＀-｠￠-￦\u{1F300}-\u{1FAFF}]/u.test(ch) ? 2 : 1;
   return w;
 }
 

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -54,7 +54,9 @@ export function renderTable(rows: ManagedListRow[], lang: CliLang): string {
     truncate(sanitizeCell(r.name), 40), // name 与 source 同为用户可控、可超长 → 同样按显示宽度截断,防撑爆表宽
     r.kind, // ArtifactKind 枚举(validator 已收窄),无需洗
     // 不可达 → 标「?」(drift 未核),绝不冒充 stale;reachable 且漂移才 stale ⚠️;已人工接受标 promoted ✓。
-    !r.reachable ? `${r.state} ?` : r.state === 'stale' ? 'stale ⚠️' : r.state === 'promoted' ? 'promoted ✓' : r.state,
+    // 生产盲区 🔬 与生命周期**正交**(observe 量线上部署版),叠加在 state token 之后,不替换 state。
+    (!r.reachable ? `${r.state} ?` : r.state === 'stale' ? 'stale ⚠️' : r.state === 'promoted' ? 'promoted ✓' : r.state)
+      + (r.productionGap ? ' 🔬' : ''),
     r.latestVerdict ? sanitizeCell(r.latestVerdict) : '—',
     `${r.currentEvidenceCount}/${r.totalEvidenceCount}`,
     truncate(sanitizeCell(r.sourceLabel), 48),
@@ -115,10 +117,12 @@ export default class List extends BaseCommand {
       const hasDrift = rows.some((r) => r.drifted);
       const hasUnreachable = rows.some((r) => !r.reachable);
       const hasPromoted = rows.some((r) => r.state === 'promoted');
-      if (hasDrift || hasUnreachable || hasPromoted) process.stderr.write('\n');
+      const hasProductionGap = rows.some((r) => r.productionGap);
+      if (hasDrift || hasUnreachable || hasPromoted || hasProductionGap) process.stderr.write('\n');
       if (hasPromoted) process.stderr.write(tCli('cli.list.promoted_note', lang));
       if (hasDrift) process.stderr.write(tCli('cli.list.drift_note', lang));
       if (hasUnreachable) process.stderr.write(tCli('cli.list.unreachable_note', lang));
+      if (hasProductionGap) process.stderr.write(tCli('cli.list.production_gap_note', lang));
       process.stderr.write(tCli('cli.list.legend', lang));
     });
   }

--- a/src/cli/commands/observe/index.ts
+++ b/src/cli/commands/observe/index.ts
@@ -34,14 +34,16 @@ const GAP_AREA_LABELS: Record<string, { zh: string; en: string }> = {
   repeated_failure: { zh: '反复失败', en: 'repeated failure' },
 };
 
-/** 取盲区计数最高的前几类,组成「建议补哪类用例」的人话区域串(只展示信号所在,不生成具体用例)。 */
+/** 取盲区计数最高的前几类,组成「建议补哪类用例」的人话区域串(只展示信号所在,不生成具体用例)。
+ *  只迭代**四个已知盲区类型**(GAP_AREA_LABELS 的键),记录 / 报告里若混入额外键一律忽略,不进展示。 */
 function topGapAreas(gapByType: Record<string, number>, lang: CliLang): string {
   const sep = lang === 'zh' ? '、' : ', ';
-  const areas = Object.entries(gapByType)
+  const areas = Object.keys(GAP_AREA_LABELS)
+    .map((k) => [k, gapByType[k] ?? 0] as const)
     .filter(([, n]) => n > 0)
     .sort((a, b) => b[1] - a[1])
     .slice(0, 3)
-    .map(([k]) => GAP_AREA_LABELS[k]?.[lang] ?? k)
+    .map(([k]) => GAP_AREA_LABELS[k][lang])
     .join(sep);
   return areas || (lang === 'zh' ? '未归类盲区' : 'uncategorized gaps');
 }

--- a/src/cli/lib/i18n-dict/list.ts
+++ b/src/cli/lib/i18n-dict/list.ts
@@ -13,6 +13,7 @@ export type ListMessageKey =
   | 'cli.list.drift_note'
   | 'cli.list.unreachable_note'
   | 'cli.list.promoted_note'
+  | 'cli.list.production_gap_note'
   | 'cli.list.legend';
 
 export const listDict: Record<ListMessageKey, CliMessage> = {
@@ -45,6 +46,10 @@ export const listDict: Record<ListMessageKey, CliMessage> = {
   'cli.list.promoted_note': {
     zh: '✓ = 当前版本已按证据人工接受为 promoted（omk promote）。\n',
     en: '✓ = current version accepted as promoted on evidence (omk promote).\n',
+  },
+  'cli.list.production_gap_note': {
+    zh: '🔬 = observe 在线上检测到生产盲区（与生命周期无关的版本无关信号）；建议补对应用例后重跑 omk eval。\n',
+    en: '🔬 = observe detected a production gap in real traffic (a version-agnostic signal, orthogonal to lifecycle); add matching samples and re-run omk eval.\n',
   },
   'cli.list.legend': {
     zh: '证据列 = 当前有效 / 全部（历史含旧内容证据，供回滚）。\n',

--- a/src/managed/list-view.ts
+++ b/src/managed/list-view.ts
@@ -8,8 +8,8 @@
  * reachable 时才走 `deriveManagedState`(哈不等 → stale)。verdict / 可比性取**当前有效证据**
  * (contentHash == record.contentHash)里 recordedAt 最新那条 —— 旧内容的证据不冒充当前。
  */
-import type { ArtifactKind, ManagedArtifactRecord, ManagedLifecycleLabel } from '../types/index.js';
-import { deriveManagedState, isCurrentlyPromoted, currentPromoteOverride } from './store.js';
+import type { ArtifactKind, ManagedArtifactRecord, ManagedLifecycleLabel, ManagedObservation } from '../types/index.js';
+import { deriveManagedState, isCurrentlyPromoted, currentPromoteOverride, deriveProductionGap } from './store.js';
 
 /** 当前源探测结果(三态)。`reachable:false` = 不可达 / 解析失败 / 拒读,**不等于**已 drift。 */
 export interface SourceProbe {
@@ -38,6 +38,14 @@ export interface ManagedListRow {
   /** 当前 promoted 版本是否经 `--force` override 采用(只读审计标);非越门 / 已 rollback / 未采用 → undefined。
    *  override 的写仍只在 CLI(`promote --force`),Studio 只读展示 —— 见 spec §9(#238)。 */
   override?: { verdict: string; overriddenBlocks?: string[] };
+  /** observe 生产盲区 marker(#235):仅当 `deriveProductionGap` 取最新观测为**确诊盲区**(红 + 统计够力)时填。
+   *  与 `state` / `drifted` **正交** —— 它是版本无关的生产信号(observe 量线上部署版),绝不参与生命周期、不翻
+   *  stale(见 store.deriveProductionGap)。underpowered / 非红观测不在此 surface(留 unknown / 信息态,避免噪声)。 */
+  productionGap?: {
+    healthBand: ManagedObservation['healthBand'];
+    confidence: ManagedObservation['confidence'];
+    gapByType: ManagedObservation['gapByType'];
+  };
   /** 最新当前证据的记录时间。 */
   recordedAt?: string;
   /** 当前有效证据数 / 全部证据数(含旧内容的历史证据)。 */
@@ -80,6 +88,9 @@ export function buildManagedListRow(record: ManagedArtifactRecord, probe: Source
   }
   const latest = latestCurrentEvidence(record);
   const override = currentPromoteOverride(record);
+  // 生产盲区是读时 marker、与生命周期正交:在 reachable / unreachable / 任意 state 下都照常计算并 surface
+  // (observe 量的是线上部署版,与本机能否 probe 源、源是否漂移无关)。只 surface 确诊盲区(marker==='gap')。
+  const gap = deriveProductionGap(record);
   return {
     id: record.id,
     name: record.name,
@@ -93,6 +104,9 @@ export function buildManagedListRow(record: ManagedArtifactRecord, probe: Source
     ...(latest?.comparability ? { comparability: latest.comparability } : {}),
     ...(latest?.recordedAt ? { recordedAt: latest.recordedAt } : {}),
     ...(override ? { override } : {}),
+    ...(gap.marker === 'gap' && gap.latest
+      ? { productionGap: { healthBand: gap.latest.healthBand, confidence: gap.latest.confidence, gapByType: gap.latest.gapByType } }
+      : {}),
     currentEvidenceCount,
     totalEvidenceCount: record.evidence.length,
     distributionCount: record.distribution.length,

--- a/src/renderer/managed-history-renderer.ts
+++ b/src/renderer/managed-history-renderer.ts
@@ -151,7 +151,7 @@ function eventRow(ev: TimelineEvent, lang: Lang, restorePath?: string): string {
   // 其余(green/yellow 够力)→ 中性带标。与 deriveProductionGap 的 marker 分类同口径(store.ts)。
   if (ev.type === 'observe') {
     if (ev.healthBand === 'red' && ev.confidence !== 'underpowered') {
-      head.push(`<span class="mh-gap">${t('生产盲区', 'production gap')}</span>`);
+      head.push(`<span class="mh-gap">🔬 ${t('生产盲区', 'production gap')}</span>`);
     } else if (ev.confidence === 'underpowered') {
       head.push(`<span class="mh-badge-raw">${t('数据不足', 'underpowered')}</span>`);
     } else {
@@ -189,9 +189,15 @@ function eventRow(ev: TimelineEvent, lang: Lang, restorePath?: string): string {
     detail.push(`<span class="mh-detail-item mh-restore">${t('还原', 'restore')} <code>${e(cmd)}</code></span>`);
   }
 
+  // 圆点配色:多数事件按 type 取色;observe 事件按**健康 band** 取色(盲区红 / 数据不足灰 / 健康绿)——
+  // observe 是 type 内有强弱的事件,健康观测画红点会撒谎,故复用 state-band 配色按实际健康度上色。
+  const dotClass = ev.type === 'observe'
+    ? (ev.healthBand === 'red' && ev.confidence !== 'underpowered' ? 'mh-dot--red'
+      : ev.confidence === 'underpowered' ? 'mh-dot--muted' : 'mh-dot--green')
+    : `mh-dot--${ev.type}`;
   return `<li class="mh-event mh-event--${ev.type}">
     <span class="mh-time">${e(fmtLocalTime(ev.at))}</span>
-    <span class="mh-marker"><span class="mh-dot mh-dot--${ev.type}"></span></span>
+    <span class="mh-marker"><span class="mh-dot ${dotClass}"></span></span>
     <div class="mh-body">
       <div class="mh-head">${head.join(' ')}</div>
       ${detail.length ? `<div class="mh-detail">${detail.join('')}</div>` : ''}
@@ -337,7 +343,8 @@ function productionGapBadge(row: ManagedListRow, lang: Lang): string {
   const t = L(lang);
   const areas = topGapAreas(row.productionGap.gapByType, lang);
   const tip = areas ? t(`线上生产盲区，集中在：${areas}`, `production gap in real traffic, in: ${areas}`) : t('线上检测到生产盲区', 'production gap detected in real traffic');
-  return ` <span class="mh-gap" title="${e(tip)}">🔬 ${t('生产盲区', 'prod gap')}</span>`;
+  // 只放图标(state 列窄、固定 130px,带文字徽标会溢出压到 name 列);全称走 tooltip + legend + 时间线。
+  return ` <span class="mh-gap" title="${e(tip)}">🔬</span>`;
 }
 
 function listRow(row: ManagedListRow, lang: Lang): string {
@@ -375,7 +382,7 @@ export function renderManagedList(rows: ManagedListRow[], lang: Lang): string {
     <span class="mh-legend-item">${t('? 源未核（不可达 / 拒读，漂移待定）', '? = source unverified (unreachable / refused)')}</span>
     <span class="mh-legend-item">${t('证据列：当前有效 / 全部历史（旧证据留作回滚）', 'Evidence = current / total (old evidence kept for rollback)')}</span>
     <span class="mh-legend-item"><span class="mh-override">${t('越门', 'override')}</span>${t(' 当前采用是 --force 越门来的（决定人由命令行记录）', ' = current version force-promoted via --force (actor recorded by CLI)')}</span>
-    <span class="mh-legend-item"><span class="mh-gap">🔬 ${t('生产盲区', 'prod gap')}</span>${t(' observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）', ' = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)')}</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬</span>${t(' 生产盲区：observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）', ' = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)')}</span>
   </div>`;
 
   const body = `<main class="mh-main">
@@ -423,7 +430,6 @@ const MANAGED_CSS = `
 .mh-dot--promote{background:var(--green)}
 .mh-dot--rollback{background:var(--yellow)}
 .mh-dot--reject{background:var(--red)}
-.mh-dot--observe{background:var(--red);box-shadow:0 0 0 2px var(--red-bg)}
 .mh-dot--green{background:var(--green)}.mh-dot--accent{background:var(--accent)}.mh-dot--muted{background:var(--text-muted)}.mh-dot--red{background:var(--red)}
 .mh-body{flex:1;min-width:0}
 .mh-head{display:flex;flex-wrap:wrap;align-items:center;gap:8px;font-size:14px}

--- a/src/renderer/managed-history-renderer.ts
+++ b/src/renderer/managed-history-renderer.ts
@@ -24,6 +24,24 @@ const isVerdictLevel = (v: string): v is VerdictLevel => Object.prototype.hasOwn
 
 const shortHash = (h: string): string => h.slice(0, 12);
 const L = (lang: Lang) => (zh: string, en: string): string => (lang === 'zh' ? zh : en);
+
+// 盲区信号类型 → 人话标签。与 CLI observe 的 GAP_AREA_LABELS 同义但本地另存一份 —— renderer 绝不 import
+// cli/commands(支柱分层),且两边走各自的 i18n 机制。键集随 ManagedObservation.gapByType 固定四类同步。
+const GAP_AREA_LABELS: Record<string, { zh: string; en: string }> = {
+  failed_search: { zh: '检索失败', en: 'failed search' },
+  explicit_marker: { zh: '显式缺口', en: 'explicit gap' },
+  hedging: { zh: '含糊回避', en: 'hedging' },
+  repeated_failure: { zh: '反复失败', en: 'repeated failure' },
+};
+/** 盲区计数最高的前几类组成人话区域串(只展示信号所在,不生成用例)。全 0 → 空串(调用方据此略过)。 */
+function topGapAreas(gapByType: Record<string, number>, lang: Lang): string {
+  return Object.entries(gapByType)
+    .filter(([, n]) => n > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([k]) => GAP_AREA_LABELS[k]?.[lang] ?? k)
+    .join(lang === 'zh' ? '、' : ', ');
+}
 /** 页内跳转统一带上 lang，否则点一下就掉回默认中文。zh 是默认 → 空串(不脏 URL)。 */
 const langQuery = (lang: Lang): string => (lang === 'en' ? '?lang=en' : '');
 
@@ -47,7 +65,7 @@ function verdictBadge(verdict: string | undefined, lang: Lang): string {
 
 interface TimelineEvent {
   at: string;
-  type: 'install' | 'eval' | 'promote' | 'reject' | 'rollback';
+  type: 'install' | 'eval' | 'promote' | 'reject' | 'rollback' | 'observe';
   contentHash?: string;
   verdict?: string;
   reportId?: string;
@@ -57,6 +75,10 @@ interface TimelineEvent {
   sampleCount?: number;
   cliVersion?: string;
   gitCommit?: string;
+  // observe 观测(#235):版本无关的生产信号,无 contentHash → 不参与版本分段。
+  healthBand?: 'green' | 'yellow' | 'red';
+  confidence?: 'high' | 'low' | 'underpowered';
+  gapByType?: { failed_search: number; explicit_marker: number; hedging: number; repeated_failure: number };
 }
 
 function buildTimeline(record: ManagedArtifactRecord): TimelineEvent[] {
@@ -75,6 +97,14 @@ function buildTimeline(record: ManagedArtifactRecord): TimelineEvent[] {
     events.push({
       at: d.decidedAt, type: d.decisionKind, contentHash: d.contentHash,
       reportId: d.reportId, actor: d.actor, reason: d.reason, override: d.override,
+    });
+  }
+  // observe 生产健康观测(#235):每条一个事件。**不带 contentHash** —— observe 是版本无关的生产信号
+  // (量线上部署版),像 install 事件那样只作时间点,绝不重置版本分段(见 renderManagedHistory 分段循环)。
+  for (const obs of record.observations ?? []) {
+    events.push({
+      at: obs.observedAt, type: 'observe',
+      healthBand: obs.healthBand, confidence: obs.confidence, gapByType: obs.gapByType,
     });
   }
   return events.sort((a, b) => cmpDesc(a.at, b.at));
@@ -113,9 +143,21 @@ function eventRow(ev: TimelineEvent, lang: Lang, restorePath?: string): string {
     promote: t('采用', 'Promote'),
     reject: t('否决', 'Reject'),
     rollback: t('回滚', 'Rollback'),
+    observe: t('观测', 'Observe'),
   };
   const head: string[] = [`<span class="mh-type">${e(typeLabel[ev.type])}</span>`];
   if (ev.type === 'eval') head.push(verdictBadge(ev.verdict, lang));
+  // observe 观测徽标:红 + 够力 → 「生产盲区」(确诊);underpowered → 「数据不足」(unknown,不当盲区);
+  // 其余(green/yellow 够力)→ 中性带标。与 deriveProductionGap 的 marker 分类同口径(store.ts)。
+  if (ev.type === 'observe') {
+    if (ev.healthBand === 'red' && ev.confidence !== 'underpowered') {
+      head.push(`<span class="mh-gap">${t('生产盲区', 'production gap')}</span>`);
+    } else if (ev.confidence === 'underpowered') {
+      head.push(`<span class="mh-badge-raw">${t('数据不足', 'underpowered')}</span>`);
+    } else {
+      head.push(`<span class="mh-badge-raw">${e(t('健康', 'healthy'))} · ${e(ev.healthBand ?? '')}</span>`);
+    }
+  }
   if (ev.override) {
     const blocks = ev.override.overriddenBlocks?.length ? `：${e(ev.override.overriddenBlocks.join(' / '))}` : '';
     head.push(`<span class="mh-override">${t('越门 override', 'override')}${blocks}</span>`);
@@ -125,6 +167,14 @@ function eventRow(ev: TimelineEvent, lang: Lang, restorePath?: string): string {
   if (ev.actor) detail.push(`<span class="mh-detail-item">${t('决定人', 'by')} ${e(ev.actor)}</span>`);
   if (ev.type === 'eval' && typeof ev.sampleCount === 'number') {
     detail.push(`<span class="mh-detail-item">${ev.sampleCount} ${t('用例', 'samples')}</span>`);
+  }
+  // observe 事件:列盲区集中的信号区域 + 建议补样本(只提示、不生成用例,不改样本集)。全 0 不显区域行。
+  if (ev.type === 'observe' && ev.gapByType) {
+    const areas = topGapAreas(ev.gapByType, lang);
+    if (areas) detail.push(`<span class="mh-detail-item">${t('盲区集中在：', 'gaps in: ')}${e(areas)}</span>`);
+    if (ev.healthBand === 'red' && ev.confidence !== 'underpowered') {
+      detail.push(`<span class="mh-detail-item mh-gap-hint">${t('建议补对应用例后重跑 omk eval', 'add matching samples, then re-run omk eval')}</span>`);
+    }
   }
   if (ev.cliVersion) detail.push(`<span class="mh-detail-item">omk ${e(ev.cliVersion)}</span>`);
   if (ev.reportId) detail.push(reportLink(ev.reportId, lang));
@@ -280,13 +330,23 @@ function overrideBadge(row: ManagedListRow, lang: Lang): string {
   return ` <span class="mh-override" title="${e(tip)}">${t('越门', 'override')}</span>`;
 }
 
+/** 生产盲区只读标(#235):该 skill 最新观测是确诊生产盲区(红 + 够力)就标出来,tooltip 列盲区区域。
+ *  与 state 正交(observe 量线上部署版、版本无关),只 surface、不参与生命周期 —— 见 deriveProductionGap。 */
+function productionGapBadge(row: ManagedListRow, lang: Lang): string {
+  if (!row.productionGap) return '';
+  const t = L(lang);
+  const areas = topGapAreas(row.productionGap.gapByType, lang);
+  const tip = areas ? t(`线上生产盲区，集中在：${areas}`, `production gap in real traffic, in: ${areas}`) : t('线上检测到生产盲区', 'production gap detected in real traffic');
+  return ` <span class="mh-gap" title="${e(tip)}">🔬 ${t('生产盲区', 'prod gap')}</span>`;
+}
+
 function listRow(row: ManagedListRow, lang: Lang): string {
   const t = L(lang);
   const st = stateMeta(row.state, lang);
   const mark = !row.reachable ? ' <span class="mh-mark mh-mark--q" title="' + e(t('源不可达 / 拒读，漂移未核', 'source unreachable / refused, drift unchecked')) + '">?</span>'
     : row.state === 'stale' ? ' <span class="mh-mark mh-mark--warn" title="' + e(t('已漂移，需重测', 'drifted, re-measure')) + '">⚠️</span>' : '';
   return `<a class="mh-row" href="/managed/${encodeURIComponent(row.id)}${langQuery(lang)}">
-    <span class="mh-row-state" title="${e(st.tip)}"><span class="mh-dot mh-dot--${stateBand(row.state)}"></span>${e(st.label)}${mark}</span>
+    <span class="mh-row-state" title="${e(st.tip)}"><span class="mh-dot mh-dot--${stateBand(row.state)}"></span>${e(st.label)}${mark}${productionGapBadge(row, lang)}</span>
     <span class="mh-row-name">${e(row.name)}</span>
     <span class="mh-row-kind">${e(row.kind)}</span>
     <span class="mh-row-verdict">${row.latestVerdict ? verdictBadge(row.latestVerdict, lang) : '—'}${overrideBadge(row, lang)}</span>
@@ -315,6 +375,7 @@ export function renderManagedList(rows: ManagedListRow[], lang: Lang): string {
     <span class="mh-legend-item">${t('? 源未核（不可达 / 拒读，漂移待定）', '? = source unverified (unreachable / refused)')}</span>
     <span class="mh-legend-item">${t('证据列：当前有效 / 全部历史（旧证据留作回滚）', 'Evidence = current / total (old evidence kept for rollback)')}</span>
     <span class="mh-legend-item"><span class="mh-override">${t('越门', 'override')}</span>${t(' 当前采用是 --force 越门来的（决定人由命令行记录）', ' = current version force-promoted via --force (actor recorded by CLI)')}</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬 ${t('生产盲区', 'prod gap')}</span>${t(' observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）', ' = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)')}</span>
   </div>`;
 
   const body = `<main class="mh-main">
@@ -362,11 +423,14 @@ const MANAGED_CSS = `
 .mh-dot--promote{background:var(--green)}
 .mh-dot--rollback{background:var(--yellow)}
 .mh-dot--reject{background:var(--red)}
+.mh-dot--observe{background:var(--red);box-shadow:0 0 0 2px var(--red-bg)}
 .mh-dot--green{background:var(--green)}.mh-dot--accent{background:var(--accent)}.mh-dot--muted{background:var(--text-muted)}.mh-dot--red{background:var(--red)}
 .mh-body{flex:1;min-width:0}
 .mh-head{display:flex;flex-wrap:wrap;align-items:center;gap:8px;font-size:14px}
 .mh-type{font-weight:600;color:var(--text-primary)}
 .mh-override{font-size:11px;font-weight:600;color:var(--yellow);background:var(--yellow-bg);padding:1px 8px;border-radius:9px}
+.mh-gap{font-size:11px;font-weight:600;color:var(--red);background:var(--red-bg);padding:1px 8px;border-radius:9px;white-space:nowrap}
+.mh-gap-hint{color:var(--red)}
 .mh-badge-raw{font-size:11.5px;color:var(--text-secondary);background:var(--bg-soft);padding:1px 8px;border-radius:9px}
 .mh-detail{display:flex;flex-wrap:wrap;gap:4px 14px;margin-top:4px;font-size:12px;color:var(--text-muted)}
 .mh-restore code{font-family:"SF Mono",Menlo,monospace;font-size:11.5px;color:var(--text-secondary);background:var(--bg-soft);padding:1px 6px;border-radius:5px;user-select:all}

--- a/src/renderer/managed-history-renderer.ts
+++ b/src/renderer/managed-history-renderer.ts
@@ -147,15 +147,18 @@ function eventRow(ev: TimelineEvent, lang: Lang, restorePath?: string): string {
   };
   const head: string[] = [`<span class="mh-type">${e(typeLabel[ev.type])}</span>`];
   if (ev.type === 'eval') head.push(verdictBadge(ev.verdict, lang));
-  // observe 观测徽标:红 + 够力 → 「生产盲区」(确诊);underpowered → 「数据不足」(unknown,不当盲区);
-  // 其余(green/yellow 够力)→ 中性带标。与 deriveProductionGap 的 marker 分类同口径(store.ts)。
+  // observe 观测徽标,四分支(green / yellow 必须分开 —— yellow 不是健康):红 + 够力 → 「生产盲区」(确诊);
+  // underpowered → 「数据不足」(unknown,任意 band 都先归此,与 deriveProductionGap 同口径);yellow + 够力 →
+  // 「需关注」(盲区已进注意区间、未达 red 告警,不能说成健康);green + 够力 → 「健康」。
   if (ev.type === 'observe') {
     if (ev.healthBand === 'red' && ev.confidence !== 'underpowered') {
       head.push(`<span class="mh-gap">🔬 ${t('生产盲区', 'production gap')}</span>`);
     } else if (ev.confidence === 'underpowered') {
       head.push(`<span class="mh-badge-raw">${t('数据不足', 'underpowered')}</span>`);
+    } else if (ev.healthBand === 'yellow') {
+      head.push(`<span class="mh-watch">${t('需关注', 'elevated')}</span>`);
     } else {
-      head.push(`<span class="mh-badge-raw">${e(t('健康', 'healthy'))} · ${e(ev.healthBand ?? '')}</span>`);
+      head.push(`<span class="mh-badge-raw">${t('健康', 'healthy')}</span>`);
     }
   }
   if (ev.override) {
@@ -189,11 +192,12 @@ function eventRow(ev: TimelineEvent, lang: Lang, restorePath?: string): string {
     detail.push(`<span class="mh-detail-item mh-restore">${t('还原', 'restore')} <code>${e(cmd)}</code></span>`);
   }
 
-  // 圆点配色:多数事件按 type 取色;observe 事件按**健康 band** 取色(盲区红 / 数据不足灰 / 健康绿)——
-  // observe 是 type 内有强弱的事件,健康观测画红点会撒谎,故复用 state-band 配色按实际健康度上色。
+  // 圆点配色:多数事件按 type 取色;observe 事件按**健康 band** 取色(盲区红 / 数据不足灰 / 注意黄 / 健康绿)
+  // —— observe 是 type 内有强弱的事件,健康或注意观测画错色会撒谎,故按实际健康度上色,与上面徽标四分支同口径。
   const dotClass = ev.type === 'observe'
     ? (ev.healthBand === 'red' && ev.confidence !== 'underpowered' ? 'mh-dot--red'
-      : ev.confidence === 'underpowered' ? 'mh-dot--muted' : 'mh-dot--green')
+      : ev.confidence === 'underpowered' ? 'mh-dot--muted'
+      : ev.healthBand === 'yellow' ? 'mh-dot--yellow' : 'mh-dot--green')
     : `mh-dot--${ev.type}`;
   return `<li class="mh-event mh-event--${ev.type}">
     <span class="mh-time">${e(fmtLocalTime(ev.at))}</span>
@@ -430,12 +434,13 @@ const MANAGED_CSS = `
 .mh-dot--promote{background:var(--green)}
 .mh-dot--rollback{background:var(--yellow)}
 .mh-dot--reject{background:var(--red)}
-.mh-dot--green{background:var(--green)}.mh-dot--accent{background:var(--accent)}.mh-dot--muted{background:var(--text-muted)}.mh-dot--red{background:var(--red)}
+.mh-dot--green{background:var(--green)}.mh-dot--accent{background:var(--accent)}.mh-dot--muted{background:var(--text-muted)}.mh-dot--red{background:var(--red)}.mh-dot--yellow{background:var(--yellow)}
 .mh-body{flex:1;min-width:0}
 .mh-head{display:flex;flex-wrap:wrap;align-items:center;gap:8px;font-size:14px}
 .mh-type{font-weight:600;color:var(--text-primary)}
 .mh-override{font-size:11px;font-weight:600;color:var(--yellow);background:var(--yellow-bg);padding:1px 8px;border-radius:9px}
 .mh-gap{font-size:11px;font-weight:600;color:var(--red);background:var(--red-bg);padding:1px 8px;border-radius:9px;white-space:nowrap}
+.mh-watch{font-size:11px;font-weight:600;color:var(--yellow);background:var(--yellow-bg);padding:1px 8px;border-radius:9px;white-space:nowrap}
 .mh-gap-hint{color:var(--red)}
 .mh-badge-raw{font-size:11.5px;color:var(--text-secondary);background:var(--bg-soft);padding:1px 8px;border-radius:9px}
 .mh-detail{display:flex;flex-wrap:wrap;gap:4px 14px;margin-top:4px;font-size:12px;color:var(--text-muted)}

--- a/src/renderer/managed-history-renderer.ts
+++ b/src/renderer/managed-history-renderer.ts
@@ -33,13 +33,16 @@ const GAP_AREA_LABELS: Record<string, { zh: string; en: string }> = {
   hedging: { zh: '含糊回避', en: 'hedging' },
   repeated_failure: { zh: '反复失败', en: 'repeated failure' },
 };
-/** 盲区计数最高的前几类组成人话区域串(只展示信号所在,不生成用例)。全 0 → 空串(调用方据此略过)。 */
+/** 盲区计数最高的前几类组成人话区域串(只展示信号所在,不生成用例)。全 0 → 空串(调用方据此略过)。
+ *  只迭代**四个已知盲区类型**(GAP_AREA_LABELS 的键),记录里若被手改塞进额外键则一律忽略 —— 消费侧收口,
+ *  比让 validator 因一个额外键丢整条记录更稳;额外键即便混入也进不了展示(再叠 e() 转义,无注入面)。 */
 function topGapAreas(gapByType: Record<string, number>, lang: Lang): string {
-  return Object.entries(gapByType)
+  return Object.keys(GAP_AREA_LABELS)
+    .map((k) => [k, gapByType[k] ?? 0] as const)
     .filter(([, n]) => n > 0)
     .sort((a, b) => b[1] - a[1])
     .slice(0, 3)
-    .map(([k]) => GAP_AREA_LABELS[k]?.[lang] ?? k)
+    .map(([k]) => GAP_AREA_LABELS[k][lang])
     .join(lang === 'zh' ? '、' : ', ');
 }
 /** 页内跳转统一带上 lang，否则点一下就掉回默认中文。zh 是默认 → 空串(不脏 URL)。 */

--- a/test/cli/list-render.test.ts
+++ b/test/cli/list-render.test.ts
@@ -24,6 +24,13 @@ describe('dispWidth', () => {
     assert.equal(dispWidth('NAME'), 4);
     assert.equal(dispWidth('a中b'), 4);
   });
+
+  it('星平面 emoji(🔬)按 2 列、✓ 保持 1 列、⚠️ 为 2 列', () => {
+    assert.equal(dispWidth('🔬'), 2, '🔬 终端按 2 列渲染,列宽须计 2(防 STATE 列少补 1)');
+    assert.equal(dispWidth('a🔬b'), 4, '混排逐码点累加');
+    assert.equal(dispWidth('✓'), 1, '✓ 终端 1 列、保持 1');
+    assert.equal(dispWidth('⚠️'), 2, '⚠️ 是两码点各 1、合计 2,本就对齐');
+  });
 });
 
 describe('truncate（按显示宽度）', () => {

--- a/test/cli/list-render.test.ts
+++ b/test/cli/list-render.test.ts
@@ -76,6 +76,33 @@ describe('renderTable 状态符不变量', () => {
   });
 });
 
+describe('renderTable 生产盲区 🔬 标(#235,与 state 正交)', () => {
+  const gap = { healthBand: 'red' as const, confidence: 'high' as const, gapByType: { failed_search: 2, explicit_marker: 0, hedging: 0, repeated_failure: 0 } };
+
+  it('measurable + productionGap → state 列叠加 🔬,不替换 state', () => {
+    const line = dataLine(row({ state: 'measurable', reachable: true, currentEvidenceCount: 1, totalEvidenceCount: 1, productionGap: gap }));
+    assert.ok(line.includes('measurable'), 'state token 仍在');
+    assert.ok(line.includes('🔬'), '叠加生产盲区标');
+  });
+
+  it('无 productionGap → 无 🔬', () => {
+    const line = dataLine(row({ state: 'measurable', reachable: true, currentEvidenceCount: 1, totalEvidenceCount: 1 }));
+    assert.ok(!line.includes('🔬'), '无观测盲区不出 🔬');
+  });
+
+  it('正交性:stale ⚠️ 与生产盲区 🔬 可共存(两轴独立)', () => {
+    const line = dataLine(row({ state: 'stale', drifted: true, reachable: true, productionGap: gap }));
+    assert.ok(line.includes('stale ⚠️'), '漂移轴仍标 ⚠️');
+    assert.ok(line.includes('🔬'), '生产盲区轴独立标 🔬');
+  });
+
+  it('正交性:不可达 `?` 与生产盲区 🔬 可共存(observe 量线上部署版,与源可达无关)', () => {
+    const line = dataLine(row({ state: 'installed', reachable: false, productionGap: gap }));
+    assert.ok(line.includes('installed ?'), '不可达轴仍标 ?');
+    assert.ok(line.includes('🔬'), '生产盲区轴独立标 🔬');
+  });
+});
+
 describe('renderTable name 截断', () => {
   it('超长 name 被按显示宽度截断,不撑爆表宽', () => {
     const out = renderTable([row({ name: 'x'.repeat(120) })], 'en');

--- a/test/cli/list-run.test.ts
+++ b/test/cli/list-run.test.ts
@@ -20,16 +20,23 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, '..', '..');
 const CLI = join(PROJECT_ROOT, 'dist', 'cli', 'index.js');
 
-interface Rec { name: string; locator: string; isDirectorySkill: boolean; contentHash: string; }
+interface Rec { name: string; locator: string; isDirectorySkill: boolean; contentHash: string; observations?: unknown[]; }
 function writeRecord(dir: string, r: Rec): void {
   const rec = {
     recordKind: 'managed-artifact', schemaVersion: 2, id: `skill-${r.name}`, name: r.name, kind: 'skill',
     source: { sourceKind: 'file', locator: r.locator, isDirectorySkill: r.isDirectorySkill },
     contentHash: r.contentHash, installedAt: '2026-06-06T00:00:00.000Z',
     distribution: [], evidence: [], decisions: [],
+    ...(r.observations ? { observations: r.observations } : {}),
   };
   writeFileSync(join(dir, `skill-${r.name}.json`), JSON.stringify(rec));
 }
+
+const redGapObs = {
+  observationKind: 'production-health', reportId: 'obs-1', observedAt: '2026-06-12T00:00:00.000Z',
+  gapRate: 0.4, weightedGapRate: 0.4, confidence: 'high', healthBand: 'red', segmentCount: 50,
+  gapByType: { failed_search: 3, explicit_marker: 1, hedging: 0, repeated_failure: 0 },
+};
 
 describe('omk list 端到端', () => {
   let proj: string;
@@ -77,6 +84,26 @@ describe('omk list 端到端', () => {
     assert.ok(Array.isArray(parsed.rows), 'rows 是数组');
     assert.equal(parsed.rows[0].name, 'gamma');
     assert.equal(parsed.rows[0].sourceLabel, join(proj, 'a.md'), 'file 源 sourceLabel = locator');
+  });
+
+  it('生产盲区:红+够力观测 → stdout 表格出 🔬、stderr 出 production_gap_note、--json 行带 productionGap', async () => {
+    // 源不可达(locator 不存在)→ state=installed ?,但生产盲区与可达性正交,🔬 仍应 surface。
+    writeRecord(managed, { name: 'delta', locator: join(proj, 'gone', 'x.md'), isDirectorySkill: false, contentHash: 'h', observations: [redGapObs] });
+    const { stdout, stderr } = await run([]);
+    assert.ok(stdout.includes('🔬'), '生产盲区标 🔬 在表格(stdout)');
+    assert.ok(stdout.includes('installed ?'), '不可达轴仍标 ?(证明与生产盲区正交)');
+    assert.ok(stderr.includes('production gap'), 'production_gap_note 在 stderr');
+    const { stdout: jsonOut } = await run(['--json']);
+    const parsed = JSON.parse(jsonOut);
+    assert.equal(parsed.rows[0].productionGap.healthBand, 'red', '--json 行带 productionGap');
+  });
+
+  it('green 观测:不出 🔬、不出 production_gap_note(只 surface 确诊盲区)', async () => {
+    const greenObs = { ...redGapObs, reportId: 'obs-g', healthBand: 'green', weightedGapRate: 0.02, gapByType: { failed_search: 0, explicit_marker: 0, hedging: 0, repeated_failure: 0 } };
+    writeRecord(managed, { name: 'epsilon', locator: join(proj, 'gone', 'y.md'), isDirectorySkill: false, contentHash: 'h', observations: [greenObs] });
+    const { stdout, stderr } = await run([]);
+    assert.ok(!stdout.includes('🔬'), 'green 观测不出 🔬');
+    assert.ok(!stderr.includes('production gap'), 'green 不出 production_gap_note');
   });
 
   it('空目录:走 empty 文案、stdout 不出表', async () => {

--- a/test/managed/list-view.test.ts
+++ b/test/managed/list-view.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { buildManagedListRow, buildManagedListRows } from '../../src/managed/list-view.js';
-import type { ManagedArtifactRecord, ManagedEvidenceRef } from '../../src/types/index.js';
+import type { ManagedArtifactRecord, ManagedEvidenceRef, ManagedObservation } from '../../src/types/index.js';
 
 function rec(over: Partial<ManagedArtifactRecord> = {}): ManagedArtifactRecord {
   return {
@@ -26,6 +26,14 @@ function rec(over: Partial<ManagedArtifactRecord> = {}): ManagedArtifactRecord {
 
 function ev(over: Partial<ManagedEvidenceRef> = {}): ManagedEvidenceRef {
   return { reportId: 'r1', contentHash: 'hashAAA', recordedAt: '2026-06-08T00:00:00.000Z', verdict: 'PROGRESS', comparability: { cliVersion: '0.35.0' }, ...over };
+}
+
+function obs(over: Partial<ManagedObservation> = {}): ManagedObservation {
+  return {
+    observationKind: 'production-health', reportId: 'o1', observedAt: '2026-06-12T00:00:00.000Z',
+    gapRate: 0.4, weightedGapRate: 0.4, confidence: 'high', healthBand: 'red', segmentCount: 50,
+    gapByType: { failed_search: 3, explicit_marker: 1, hedging: 0, repeated_failure: 0 }, ...over,
+  };
 }
 
 describe('buildManagedListRow', () => {
@@ -182,6 +190,48 @@ describe('buildManagedListRow', () => {
     }), reach('hashAAA'));
     assert.equal(row.latestVerdict, 'NEW', '按解析时刻取最新,不被异偏移字典序骗');
     assert.equal(row.recordedAt, '2026-01-01T01:00:00Z');
+  });
+
+  // ── 生产盲区 marker(#235):与 state / drifted / reachable 正交 ──
+
+  it('承重不变量:red+够力观测 + 当前内容(哈匹配)→ 仍 measurable,绝不 stale,且 productionGap 独立填', () => {
+    const row = buildManagedListRow(rec({ evidence: [ev()], observations: [obs()] }), reach('hashAAA'));
+    assert.equal(row.state, 'measurable', '生产盲区是 marker、不进生命周期 —— 当前哈匹配仍 measurable');
+    assert.equal(row.drifted, false);
+    assert.deepEqual(row.productionGap, {
+      healthBand: 'red', confidence: 'high',
+      gapByType: { failed_search: 3, explicit_marker: 1, hedging: 0, repeated_failure: 0 },
+    });
+  });
+
+  it('green 观测 → productionGap undefined(只 surface 确诊盲区)', () => {
+    const row = buildManagedListRow(rec({ observations: [obs({ healthBand: 'green', weightedGapRate: 0 })] }), reach('hashAAA'));
+    assert.equal(row.productionGap, undefined);
+  });
+
+  it('underpowered 观测(数据不足)→ productionGap undefined(unknown,不当盲区)', () => {
+    const row = buildManagedListRow(rec({ observations: [obs({ confidence: 'underpowered', segmentCount: 3 })] }), reach('hashAAA'));
+    assert.equal(row.productionGap, undefined);
+  });
+
+  it('latest-wins:旧 red + 新 green → productionGap undefined(线上已恢复)', () => {
+    const row = buildManagedListRow(rec({ observations: [
+      obs({ reportId: 'old', observedAt: '2026-06-08T00:00:00.000Z', healthBand: 'red' }),
+      obs({ reportId: 'new', observedAt: '2026-06-12T00:00:00.000Z', healthBand: 'green', weightedGapRate: 0 }),
+    ] }), reach('hashAAA'));
+    assert.equal(row.productionGap, undefined);
+  });
+
+  it('与 reachability 正交:源不可达也照常 surface 生产盲区(observe 量线上部署版)', () => {
+    const row = buildManagedListRow(rec({ observations: [obs()] }), unreach);
+    assert.equal(row.reachable, false);
+    assert.equal(row.productionGap?.healthBand, 'red', '不可达不影响版本无关的生产信号');
+  });
+
+  it('源漂移(stale)仍可叠加生产盲区:state=stale 且 productionGap 同时存在(两轴正交)', () => {
+    const row = buildManagedListRow(rec({ evidence: [ev()], observations: [obs()] }), reach('hashDRIFTED'));
+    assert.equal(row.state, 'stale');
+    assert.equal(row.productionGap?.healthBand, 'red');
   });
 });
 

--- a/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
+++ b/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
@@ -235,6 +235,13 @@ exports[`managed-history-renderer snapshots > renderManagedHistory 带 observe �
       <div class="mh-head"><span class="mh-type">Reject</span></div>
       <div class="mh-detail"><span class="mh-detail-item">by carol</span></div>
     </div>
+  </li><li class="mh-event mh-event--observe">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--yellow"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Observe</span> <span class="mh-watch">elevated</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">gaps in: failed search, hedging</span></div>
+    </div>
   </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">current</span></li><li class="mh-event mh-event--promote">
     <span class="mh-time">[TIMESTAMP]</span>
     <span class="mh-marker"><span class="mh-dot mh-dot--promote"></span></span>
@@ -260,7 +267,7 @@ exports[`managed-history-renderer snapshots > renderManagedHistory 带 observe �
     <span class="mh-time">[TIMESTAMP]</span>
     <span class="mh-marker"><span class="mh-dot mh-dot--green"></span></span>
     <div class="mh-body">
-      <div class="mh-head"><span class="mh-type">Observe</span> <span class="mh-badge-raw">healthy · green</span></div>
+      <div class="mh-head"><span class="mh-type">Observe</span> <span class="mh-badge-raw">healthy</span></div>
 
     </div>
   </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV1conten</code></li><li class="mh-event mh-event--eval">
@@ -318,6 +325,13 @@ exports[`managed-history-renderer snapshots > renderManagedHistory 带 observe �
       <div class="mh-head"><span class="mh-type">否决</span></div>
       <div class="mh-detail"><span class="mh-detail-item">决定人 carol</span></div>
     </div>
+  </li><li class="mh-event mh-event--observe">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--yellow"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">观测</span> <span class="mh-watch">需关注</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">盲区集中在：检索失败、含糊回避</span></div>
+    </div>
   </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">当前</span></li><li class="mh-event mh-event--promote">
     <span class="mh-time">[TIMESTAMP]</span>
     <span class="mh-marker"><span class="mh-dot mh-dot--promote"></span></span>
@@ -343,7 +357,7 @@ exports[`managed-history-renderer snapshots > renderManagedHistory 带 observe �
     <span class="mh-time">[TIMESTAMP]</span>
     <span class="mh-marker"><span class="mh-dot mh-dot--green"></span></span>
     <div class="mh-body">
-      <div class="mh-head"><span class="mh-type">观测</span> <span class="mh-badge-raw">健康 · green</span></div>
+      <div class="mh-head"><span class="mh-type">观测</span> <span class="mh-badge-raw">健康</span></div>
 
     </div>
   </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV1conten</code></li><li class="mh-event mh-event--eval">

--- a/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
+++ b/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
@@ -216,9 +216,9 @@ exports[`managed-history-renderer snapshots > renderManagedHistory 带 observe �
 
     <ol class="mh-timeline"><li class="mh-event mh-event--observe">
     <span class="mh-time">[TIMESTAMP]</span>
-    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--red"></span></span>
     <div class="mh-body">
-      <div class="mh-head"><span class="mh-type">Observe</span> <span class="mh-gap">production gap</span></div>
+      <div class="mh-head"><span class="mh-type">Observe</span> <span class="mh-gap">🔬 production gap</span></div>
       <div class="mh-detail"><span class="mh-detail-item">gaps in: failed search, explicit gap, hedging</span><span class="mh-detail-item mh-gap-hint">add matching samples, then re-run omk eval</span></div>
     </div>
   </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">current</span></li><li class="mh-event mh-event--rollback">
@@ -251,14 +251,14 @@ exports[`managed-history-renderer snapshots > renderManagedHistory 带 observe �
     </div>
   </li><li class="mh-event mh-event--observe">
     <span class="mh-time">[TIMESTAMP]</span>
-    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--muted"></span></span>
     <div class="mh-body">
       <div class="mh-head"><span class="mh-type">Observe</span> <span class="mh-badge-raw">underpowered</span></div>
       <div class="mh-detail"><span class="mh-detail-item">gaps in: failed search</span></div>
     </div>
   </li><li class="mh-event mh-event--observe">
     <span class="mh-time">[TIMESTAMP]</span>
-    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--green"></span></span>
     <div class="mh-body">
       <div class="mh-head"><span class="mh-type">Observe</span> <span class="mh-badge-raw">healthy · green</span></div>
 
@@ -299,9 +299,9 @@ exports[`managed-history-renderer snapshots > renderManagedHistory 带 observe �
 
     <ol class="mh-timeline"><li class="mh-event mh-event--observe">
     <span class="mh-time">[TIMESTAMP]</span>
-    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--red"></span></span>
     <div class="mh-body">
-      <div class="mh-head"><span class="mh-type">观测</span> <span class="mh-gap">生产盲区</span></div>
+      <div class="mh-head"><span class="mh-type">观测</span> <span class="mh-gap">🔬 生产盲区</span></div>
       <div class="mh-detail"><span class="mh-detail-item">盲区集中在：检索失败、显式缺口、含糊回避</span><span class="mh-detail-item mh-gap-hint">建议补对应用例后重跑 omk eval</span></div>
     </div>
   </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">当前</span></li><li class="mh-event mh-event--rollback">
@@ -334,14 +334,14 @@ exports[`managed-history-renderer snapshots > renderManagedHistory 带 observe �
     </div>
   </li><li class="mh-event mh-event--observe">
     <span class="mh-time">[TIMESTAMP]</span>
-    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--muted"></span></span>
     <div class="mh-body">
       <div class="mh-head"><span class="mh-type">观测</span> <span class="mh-badge-raw">数据不足</span></div>
       <div class="mh-detail"><span class="mh-detail-item">盲区集中在：检索失败</span></div>
     </div>
   </li><li class="mh-event mh-event--observe">
     <span class="mh-time">[TIMESTAMP]</span>
-    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--green"></span></span>
     <div class="mh-body">
       <div class="mh-head"><span class="mh-type">观测</span> <span class="mh-badge-raw">健康 · green</span></div>
 
@@ -633,7 +633,7 @@ exports[`managed-history-renderer snapshots > renderManagedList en 1`] = `
     <span class="mh-legend-item">? = source unverified (unreachable / refused)</span>
     <span class="mh-legend-item">Evidence = current / total (old evidence kept for rollback)</span>
     <span class="mh-legend-item"><span class="mh-override">override</span> = current version force-promoted via --force (actor recorded by CLI)</span>
-    <span class="mh-legend-item"><span class="mh-gap">🔬 prod gap</span> = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬</span> = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)</span>
   </div>
   </main>"
 `;
@@ -664,7 +664,7 @@ exports[`managed-history-renderer snapshots > renderManagedList zh 1`] = `
     <span class="mh-legend-item">? 源未核（不可达 / 拒读，漂移待定）</span>
     <span class="mh-legend-item">证据列：当前有效 / 全部历史（旧证据留作回滚）</span>
     <span class="mh-legend-item"><span class="mh-override">越门</span> 当前采用是 --force 越门来的（决定人由命令行记录）</span>
-    <span class="mh-legend-item"><span class="mh-gap">🔬 生产盲区</span> observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬</span> 生产盲区：observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）</span>
   </div>
   </main>"
 `;
@@ -730,7 +730,7 @@ exports[`managed-history-renderer snapshots > renderManagedList 各状态 + 标�
     <span class="mh-legend-item">? = source unverified (unreachable / refused)</span>
     <span class="mh-legend-item">Evidence = current / total (old evidence kept for rollback)</span>
     <span class="mh-legend-item"><span class="mh-override">override</span> = current version force-promoted via --force (actor recorded by CLI)</span>
-    <span class="mh-legend-item"><span class="mh-gap">🔬 prod gap</span> = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬</span> = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)</span>
   </div>
   </main>"
 `;
@@ -796,7 +796,7 @@ exports[`managed-history-renderer snapshots > renderManagedList 各状态 + 标�
     <span class="mh-legend-item">? 源未核（不可达 / 拒读，漂移待定）</span>
     <span class="mh-legend-item">证据列：当前有效 / 全部历史（旧证据留作回滚）</span>
     <span class="mh-legend-item"><span class="mh-override">越门</span> 当前采用是 --force 越门来的（决定人由命令行记录）</span>
-    <span class="mh-legend-item"><span class="mh-gap">🔬 生产盲区</span> observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬</span> 生产盲区：observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）</span>
   </div>
   </main>"
 `;
@@ -812,7 +812,7 @@ exports[`managed-history-renderer snapshots > renderManagedList 生产盲区徽�
     <span>状态</span><span>名称</span><span>类型</span>
     <span>verdict</span><span>证据</span><span>源</span>
   </div><a class="mh-row" href="/managed/i-gap">
-    <span class="mh-row-state" title="当前内容已有有效证据，可进入采用门禁"><span class="mh-dot mh-dot--accent"></span>证据就绪 <span class="mh-gap" title="线上生产盲区，集中在：检索失败、显式缺口">🔬 生产盲区</span></span>
+    <span class="mh-row-state" title="当前内容已有有效证据，可进入采用门禁"><span class="mh-dot mh-dot--accent"></span>证据就绪 <span class="mh-gap" title="线上生产盲区，集中在：检索失败、显式缺口">🔬</span></span>
     <span class="mh-row-name">gap-skill</span>
     <span class="mh-row-kind">skill</span>
     <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>明显进步</span></span></span>
@@ -827,7 +827,7 @@ exports[`managed-history-renderer snapshots > renderManagedList 生产盲区徽�
     <span class="mh-legend-item">? 源未核（不可达 / 拒读，漂移待定）</span>
     <span class="mh-legend-item">证据列：当前有效 / 全部历史（旧证据留作回滚）</span>
     <span class="mh-legend-item"><span class="mh-override">越门</span> 当前采用是 --force 越门来的（决定人由命令行记录）</span>
-    <span class="mh-legend-item"><span class="mh-gap">🔬 生产盲区</span> observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬</span> 生产盲区：observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）</span>
   </div>
   </main>"
 `;
@@ -843,7 +843,7 @@ exports[`managed-history-renderer snapshots > renderManagedList 生产盲区徽�
     <span>state</span><span>name</span><span>kind</span>
     <span>verdict</span><span>evidence</span><span>source</span>
   </div><a class="mh-row" href="/managed/i-gap?lang=en">
-    <span class="mh-row-state" title="Current content has valid evidence; ready for the promote gate"><span class="mh-dot mh-dot--accent"></span>Measurable <span class="mh-gap" title="production gap in real traffic, in: failed search, explicit gap">🔬 prod gap</span></span>
+    <span class="mh-row-state" title="Current content has valid evidence; ready for the promote gate"><span class="mh-dot mh-dot--accent"></span>Measurable <span class="mh-gap" title="production gap in real traffic, in: failed search, explicit gap">🔬</span></span>
     <span class="mh-row-name">gap-skill</span>
     <span class="mh-row-kind">skill</span>
     <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>PROGRESS</span></span></span>
@@ -858,7 +858,7 @@ exports[`managed-history-renderer snapshots > renderManagedList 生产盲区徽�
     <span class="mh-legend-item">? = source unverified (unreachable / refused)</span>
     <span class="mh-legend-item">Evidence = current / total (old evidence kept for rollback)</span>
     <span class="mh-legend-item"><span class="mh-override">override</span> = current version force-promoted via --force (actor recorded by CLI)</span>
-    <span class="mh-legend-item"><span class="mh-gap">🔬 prod gap</span> = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬</span> = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)</span>
   </div>
   </main>"
 `;

--- a/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
+++ b/test/renderer/__snapshots__/managed-history-renderer.test.ts.snap
@@ -205,6 +205,172 @@ exports[`managed-history-renderer snapshots > renderManagedHistory 带 git 还�
   </main>"
 `;
 
+exports[`managed-history-renderer snapshots > renderManagedHistory 带 observe 观测 en 1`] = `
+"<main class="mh-main">
+    <nav class="mh-back"><a href="/managed?lang=en">← Managed</a></nav>
+    <header class="mh-hero">
+      <div class="mh-kind">Managed history</div>
+      <h1 class="mh-name">review</h1>
+      <div class="mh-meta"><span>skill</span><span>git</span><span>hashV2conten</span><span>since [TIMESTAMP]</span></div>
+    </header>
+
+    <ol class="mh-timeline"><li class="mh-event mh-event--observe">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Observe</span> <span class="mh-gap">production gap</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">gaps in: failed search, explicit gap, hedging</span><span class="mh-detail-item mh-gap-hint">add matching samples, then re-run omk eval</span></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">current</span></li><li class="mh-event mh-event--rollback">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--rollback"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Rollback</span> <span class="mh-override">override：drifted</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">by bob</span></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV1conten</code></li><li class="mh-event mh-event--reject">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--reject"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Reject</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">by carol</span></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">current</span></li><li class="mh-event mh-event--promote">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--promote"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Promote</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">by alice</span><a class="mh-link" href="/reports/evolve-review-002?lang=en">report →</a><span class="mh-reason">「已人工复核」</span></div>
+    </div>
+  </li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Eval</span> <span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>PROGRESS</span></span></div>
+      <div class="mh-detail"><span class="mh-detail-item">6 samples</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-002?lang=en">report →</a></div>
+    </div>
+  </li><li class="mh-event mh-event--observe">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Observe</span> <span class="mh-badge-raw">underpowered</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">gaps in: failed search</span></div>
+    </div>
+  </li><li class="mh-event mh-event--observe">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Observe</span> <span class="mh-badge-raw">healthy · green</span></div>
+
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV1conten</code></li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Eval</span> <span class="verdict-NOISE"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>NOISE</span></span></div>
+      <div class="mh-detail"><span class="mh-detail-item">6 samples</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-001?lang=en">report →</a></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">version</span><code class="mh-hash">hashV0conten</code></li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Eval</span> <span class="mh-badge-raw">INCONCLUSIVE</span></div>
+      <div class="mh-detail"><a class="mh-link" href="/reports/evolve-review-000?lang=en">report →</a></div>
+    </div>
+  </li><li class="mh-event mh-event--install">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--install"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">Installed</span></div>
+
+    </div>
+  </li></ol>
+  </main>"
+`;
+
+exports[`managed-history-renderer snapshots > renderManagedHistory 带 observe 观测(生产盲区 / 数据不足 / 健康)zh 1`] = `
+"<main class="mh-main">
+    <nav class="mh-back"><a href="/managed">← 受管列表</a></nav>
+    <header class="mh-hero">
+      <div class="mh-kind">受管决策史</div>
+      <h1 class="mh-name">review</h1>
+      <div class="mh-meta"><span>skill</span><span>git</span><span>hashV2conten</span><span>纳管于 [TIMESTAMP]</span></div>
+    </header>
+
+    <ol class="mh-timeline"><li class="mh-event mh-event--observe">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">观测</span> <span class="mh-gap">生产盲区</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">盲区集中在：检索失败、显式缺口、含糊回避</span><span class="mh-detail-item mh-gap-hint">建议补对应用例后重跑 omk eval</span></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">当前</span></li><li class="mh-event mh-event--rollback">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--rollback"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">回滚</span> <span class="mh-override">越门 override：drifted</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">决定人 bob</span></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV1conten</code></li><li class="mh-event mh-event--reject">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--reject"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">否决</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">决定人 carol</span></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV2conten</code><span class="mh-vcur">当前</span></li><li class="mh-event mh-event--promote">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--promote"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">采用</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">决定人 alice</span><a class="mh-link" href="/reports/evolve-review-002">查看报告 →</a><span class="mh-reason">「已人工复核」</span></div>
+    </div>
+  </li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">评测</span> <span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>明显进步</span></span></div>
+      <div class="mh-detail"><span class="mh-detail-item">6 用例</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-002">查看报告 →</a></div>
+    </div>
+  </li><li class="mh-event mh-event--observe">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">观测</span> <span class="mh-badge-raw">数据不足</span></div>
+      <div class="mh-detail"><span class="mh-detail-item">盲区集中在：检索失败</span></div>
+    </div>
+  </li><li class="mh-event mh-event--observe">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--observe"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">观测</span> <span class="mh-badge-raw">健康 · green</span></div>
+
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV1conten</code></li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">评测</span> <span class="verdict-NOISE"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>基本持平</span></span></div>
+      <div class="mh-detail"><span class="mh-detail-item">6 用例</span><span class="mh-detail-item">omk 0.37.0</span><a class="mh-link" href="/reports/evolve-review-001">查看报告 →</a></div>
+    </div>
+  </li><li class="mh-vhead"><span class="mh-vhead-label">版本</span><code class="mh-hash">hashV0conten</code></li><li class="mh-event mh-event--eval">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--eval"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">评测</span> <span class="mh-badge-raw">INCONCLUSIVE</span></div>
+      <div class="mh-detail"><a class="mh-link" href="/reports/evolve-review-000">查看报告 →</a></div>
+    </div>
+  </li><li class="mh-event mh-event--install">
+    <span class="mh-time">[TIMESTAMP]</span>
+    <span class="mh-marker"><span class="mh-dot mh-dot--install"></span></span>
+    <div class="mh-body">
+      <div class="mh-head"><span class="mh-type">安装纳管</span></div>
+
+    </div>
+  </li></ol>
+  </main>"
+`;
+
 exports[`managed-history-renderer snapshots > renderManagedHistory 带版本回归曲线 en 1`] = `
 "<main class="mh-main">
     <nav class="mh-back"><a href="/managed?lang=en">← Managed</a></nav>
@@ -467,6 +633,7 @@ exports[`managed-history-renderer snapshots > renderManagedList en 1`] = `
     <span class="mh-legend-item">? = source unverified (unreachable / refused)</span>
     <span class="mh-legend-item">Evidence = current / total (old evidence kept for rollback)</span>
     <span class="mh-legend-item"><span class="mh-override">override</span> = current version force-promoted via --force (actor recorded by CLI)</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬 prod gap</span> = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)</span>
   </div>
   </main>"
 `;
@@ -497,6 +664,7 @@ exports[`managed-history-renderer snapshots > renderManagedList zh 1`] = `
     <span class="mh-legend-item">? 源未核（不可达 / 拒读，漂移待定）</span>
     <span class="mh-legend-item">证据列：当前有效 / 全部历史（旧证据留作回滚）</span>
     <span class="mh-legend-item"><span class="mh-override">越门</span> 当前采用是 --force 越门来的（决定人由命令行记录）</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬 生产盲区</span> observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）</span>
   </div>
   </main>"
 `;
@@ -562,6 +730,7 @@ exports[`managed-history-renderer snapshots > renderManagedList 各状态 + 标�
     <span class="mh-legend-item">? = source unverified (unreachable / refused)</span>
     <span class="mh-legend-item">Evidence = current / total (old evidence kept for rollback)</span>
     <span class="mh-legend-item"><span class="mh-override">override</span> = current version force-promoted via --force (actor recorded by CLI)</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬 prod gap</span> = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)</span>
   </div>
   </main>"
 `;
@@ -627,6 +796,69 @@ exports[`managed-history-renderer snapshots > renderManagedList 各状态 + 标�
     <span class="mh-legend-item">? 源未核（不可达 / 拒读，漂移待定）</span>
     <span class="mh-legend-item">证据列：当前有效 / 全部历史（旧证据留作回滚）</span>
     <span class="mh-legend-item"><span class="mh-override">越门</span> 当前采用是 --force 越门来的（决定人由命令行记录）</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬 生产盲区</span> observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）</span>
+  </div>
+  </main>"
+`;
+
+exports[`managed-history-renderer snapshots > renderManagedList 生产盲区徽标 + legend zh 1`] = `
+"<main class="mh-main">
+    <header class="mh-hero">
+      <div class="mh-kind">受管 skill</div>
+      <h1 class="mh-name">决策史</h1>
+      <div class="mh-meta"><span>每个 skill 的 install → 评测 → 采用 / 回滚 全过程</span></div>
+    </header>
+    <div class="mh-table"><div class="mh-row mh-row--head">
+    <span>状态</span><span>名称</span><span>类型</span>
+    <span>verdict</span><span>证据</span><span>源</span>
+  </div><a class="mh-row" href="/managed/i-gap">
+    <span class="mh-row-state" title="当前内容已有有效证据，可进入采用门禁"><span class="mh-dot mh-dot--accent"></span>证据就绪 <span class="mh-gap" title="线上生产盲区，集中在：检索失败、显式缺口">🔬 生产盲区</span></span>
+    <span class="mh-row-name">gap-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>明显进步</span></span></span>
+    <span class="mh-row-ev">1/1</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a></div>
+    <div class="mh-legend">
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--green"></span>已采用：已按证据人工接受</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--accent"></span>证据就绪：当前内容有有效证据、可采用</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--muted"></span>已纳管：尚无当前证据</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--red"></span>已漂移 ⚠️：源变了、需重跑 omk eval</span>
+    <span class="mh-legend-item">? 源未核（不可达 / 拒读，漂移待定）</span>
+    <span class="mh-legend-item">证据列：当前有效 / 全部历史（旧证据留作回滚）</span>
+    <span class="mh-legend-item"><span class="mh-override">越门</span> 当前采用是 --force 越门来的（决定人由命令行记录）</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬 生产盲区</span> observe 在线上检测到的盲区（版本无关信号、与生命周期正交，不翻 stale）</span>
+  </div>
+  </main>"
+`;
+
+exports[`managed-history-renderer snapshots > renderManagedList 生产盲区徽标 en 1`] = `
+"<main class="mh-main">
+    <header class="mh-hero">
+      <div class="mh-kind">Managed skills</div>
+      <h1 class="mh-name">Decision history</h1>
+      <div class="mh-meta"><span>install → eval → promote / rollback per skill</span></div>
+    </header>
+    <div class="mh-table"><div class="mh-row mh-row--head">
+    <span>state</span><span>name</span><span>kind</span>
+    <span>verdict</span><span>evidence</span><span>source</span>
+  </div><a class="mh-row" href="/managed/i-gap?lang=en">
+    <span class="mh-row-state" title="Current content has valid evidence; ready for the promote gate"><span class="mh-dot mh-dot--accent"></span>Measurable <span class="mh-gap" title="production gap in real traffic, in: failed search, explicit gap">🔬 prod gap</span></span>
+    <span class="mh-row-name">gap-skill</span>
+    <span class="mh-row-kind">skill</span>
+    <span class="mh-row-verdict"><span class="verdict-PROGRESS"><span class="page-verdict-badge"><span class="page-verdict-badge-dot">●</span>PROGRESS</span></span></span>
+    <span class="mh-row-ev">1/1</span>
+    <span class="mh-row-src" title="https://example.com/r">https://example.com/r</span>
+  </a></div>
+    <div class="mh-legend">
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--green"></span>Promoted = accepted on evidence</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--accent"></span>Measurable = current content has evidence, gate-ready</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--muted"></span>Installed = no current evidence yet</span>
+    <span class="mh-legend-item"><span class="mh-dot mh-dot--red"></span>Drifted ⚠️ = source changed, re-run omk eval</span>
+    <span class="mh-legend-item">? = source unverified (unreachable / refused)</span>
+    <span class="mh-legend-item">Evidence = current / total (old evidence kept for rollback)</span>
+    <span class="mh-legend-item"><span class="mh-override">override</span> = current version force-promoted via --force (actor recorded by CLI)</span>
+    <span class="mh-legend-item"><span class="mh-gap">🔬 prod gap</span> = production gap from observe (version-agnostic, orthogonal to lifecycle, never flips stale)</span>
   </div>
   </main>"
 `;

--- a/test/renderer/managed-history-renderer.test.ts
+++ b/test/renderer/managed-history-renderer.test.ts
@@ -103,6 +103,24 @@ const GIT_RESTORE_FILE_SKILL: ManagedArtifactRecord = {
   source: { sourceKind: 'git', locator: 'git:HEAD:review', ref: 'HEAD', isDirectorySkill: false },
 };
 
+// observe 观测(#235)三条覆盖渲染分支:red+高(生产盲区徽标 + 盲区区域 + 补样本提示)、underpowered(数据
+// 不足带标)、green(健康带标)。三条 observedAt 各异且**无 contentHash** —— 用来锁「观测事件不重置版本分段」。
+const OBSERVE_RECORD: ManagedArtifactRecord = {
+  ...RECORD,
+  id: 'skill-observe-fixture',
+  observations: [
+    { observationKind: 'production-health', reportId: 'obs-red', observedAt: '2026-03-09T00:00:00.000Z', gapRate: 0.42, weightedGapRate: 0.42, confidence: 'high', healthBand: 'red', segmentCount: 80, gapByType: { failed_search: 5, explicit_marker: 2, hedging: 1, repeated_failure: 0 } },
+    { observationKind: 'production-health', reportId: 'obs-weak', observedAt: '2026-03-04T00:00:00.000Z', gapRate: 0.5, weightedGapRate: 0.5, confidence: 'underpowered', healthBand: 'red', segmentCount: 2, gapByType: { failed_search: 1, explicit_marker: 0, hedging: 0, repeated_failure: 0 } },
+    { observationKind: 'production-health', reportId: 'obs-green', observedAt: '2026-03-03T00:00:00.000Z', gapRate: 0.02, weightedGapRate: 0.02, confidence: 'high', healthBand: 'green', segmentCount: 90, gapByType: { failed_search: 0, explicit_marker: 0, hedging: 0, repeated_failure: 0 } },
+  ],
+};
+
+// 列表生产盲区徽标 + legend:一行带 productionGap(确诊盲区,latest-wins 由 list-view 派生,这里直接构造)。
+const GAP_ROWS: ManagedListRow[] = [
+  mkRow({ id: 'i-gap', name: 'gap-skill', state: 'measurable', latestVerdict: 'PROGRESS',
+    productionGap: { healthBand: 'red', confidence: 'high', gapByType: { failed_search: 4, explicit_marker: 1, hedging: 0, repeated_failure: 0 } } }),
+];
+
 describe('managed-history-renderer snapshots', () => {
   it('renderManagedList zh', () => {
     expect(normalizeForSnapshot(renderManagedList(ROWS, 'zh' as Lang))).toMatchSnapshot();
@@ -145,5 +163,29 @@ describe('managed-history-renderer snapshots', () => {
   });
   it('renderManagedHistory 裸名 file-skill 还原路径补 .md zh', () => {
     expect(normalizeForSnapshot(renderManagedHistory(GIT_RESTORE_FILE_SKILL, 'zh' as Lang))).toMatchSnapshot();
+  });
+
+  // ── observe 生产健康观测时间线 + 列表徽标(#235)──
+  it('renderManagedHistory 带 observe 观测(生产盲区 / 数据不足 / 健康)zh', () => {
+    expect(normalizeForSnapshot(renderManagedHistory(OBSERVE_RECORD, 'zh' as Lang))).toMatchSnapshot();
+  });
+  it('renderManagedHistory 带 observe 观测 en', () => {
+    expect(normalizeForSnapshot(renderManagedHistory(OBSERVE_RECORD, 'en' as Lang))).toMatchSnapshot();
+  });
+  it('renderManagedList 生产盲区徽标 + legend zh', () => {
+    expect(normalizeForSnapshot(renderManagedList(GAP_ROWS, 'zh' as Lang))).toMatchSnapshot();
+  });
+  it('renderManagedList 生产盲区徽标 en', () => {
+    expect(normalizeForSnapshot(renderManagedList(GAP_ROWS, 'en' as Lang))).toMatchSnapshot();
+  });
+
+  // 承重不变量:observe 事件无 contentHash → 绝不新增版本段头。加了 3 条观测后 `mh-vhead` 数量应与无观测时相同。
+  it('observe 观测不重置版本分段(版本段头数量不变)', () => {
+    const headers = (html: string): number => (html.match(/mh-vhead/g) ?? []).length;
+    const withObs = renderManagedHistory(OBSERVE_RECORD, 'zh' as Lang);
+    const withoutObs = renderManagedHistory(RECORD, 'zh' as Lang);
+    expect(headers(withObs)).toBe(headers(withoutObs));
+    // 且观测确实进了时间线(渲染出 observe 事件)。
+    expect(withObs).toContain('mh-event--observe');
   });
 });

--- a/test/renderer/managed-history-renderer.test.ts
+++ b/test/renderer/managed-history-renderer.test.ts
@@ -110,6 +110,7 @@ const OBSERVE_RECORD: ManagedArtifactRecord = {
   id: 'skill-observe-fixture',
   observations: [
     { observationKind: 'production-health', reportId: 'obs-red', observedAt: '2026-03-09T00:00:00.000Z', gapRate: 0.42, weightedGapRate: 0.42, confidence: 'high', healthBand: 'red', segmentCount: 80, gapByType: { failed_search: 5, explicit_marker: 2, hedging: 1, repeated_failure: 0 } },
+    { observationKind: 'production-health', reportId: 'obs-yellow', observedAt: '2026-03-06T12:00:00.000Z', gapRate: 0.18, weightedGapRate: 0.18, confidence: 'high', healthBand: 'yellow', segmentCount: 70, gapByType: { failed_search: 2, explicit_marker: 0, hedging: 1, repeated_failure: 0 } },
     { observationKind: 'production-health', reportId: 'obs-weak', observedAt: '2026-03-04T00:00:00.000Z', gapRate: 0.5, weightedGapRate: 0.5, confidence: 'underpowered', healthBand: 'red', segmentCount: 2, gapByType: { failed_search: 1, explicit_marker: 0, hedging: 0, repeated_failure: 0 } },
     { observationKind: 'production-health', reportId: 'obs-green', observedAt: '2026-03-03T00:00:00.000Z', gapRate: 0.02, weightedGapRate: 0.02, confidence: 'high', healthBand: 'green', segmentCount: 90, gapByType: { failed_search: 0, explicit_marker: 0, hedging: 0, repeated_failure: 0 } },
   ],
@@ -179,7 +180,18 @@ describe('managed-history-renderer snapshots', () => {
     expect(normalizeForSnapshot(renderManagedList(GAP_ROWS, 'en' as Lang))).toMatchSnapshot();
   });
 
-  // 承重不变量:observe 事件无 contentHash → 绝不新增版本段头。加了 3 条观测后 `mh-vhead` 数量应与无观测时相同。
+  // 回归:yellow 观测绝不渲染成「健康」/ 绿点(yellow 是注意区间、非健康)。red 仍是盲区红点。
+  it('yellow 观测渲染为「需关注」+ 黄点,不冒充健康/绿点', () => {
+    const zh = renderManagedHistory(OBSERVE_RECORD, 'zh' as Lang);
+    expect(zh).toContain('<span class="mh-watch">需关注</span>');
+    expect(zh).toContain('mh-dot--yellow');
+    // green 观测才是「健康」+ 绿点;yellow 不该混进去。
+    expect(zh).toContain('<span class="mh-badge-raw">健康</span>');
+    const en = renderManagedHistory(OBSERVE_RECORD, 'en' as Lang);
+    expect(en).toContain('<span class="mh-watch">elevated</span>');
+  });
+
+  // 承重不变量:observe 事件无 contentHash → 绝不新增版本段头。加了观测后 `mh-vhead` 数量应与无观测时相同。
   it('observe 观测不重置版本分段(版本段头数量不变)', () => {
     const headers = (html: string): number => (html.match(/mh-vhead/g) ?? []).length;
     const withObs = renderManagedHistory(OBSERVE_RECORD, 'zh' as Lang);


### PR DESCRIPTION
## 这在解决什么（大白话）

Slice A 把 observe 的生产健康信号写进了受管记录，也算好了「这个 skill 线上有没有盲区」，但**没人看得见**——`omk list` 和 Studio 都还没把它显出来。Slice B 就是把这个已经算好的信号接到两个只读出口，让你一眼看到「哪个 skill 线上正在出盲区，该补哪类用例」。

纯展示层，叠在 Slice A 上的薄 PR：不新增写入、不碰测量学不变量、不动 Slice A 的核心逻辑。

## 改了什么

`omk list`：STATE 列在 `✓`/`⚠️`/`?` 之外多一个 `🔬` 标——表示确诊生产盲区（红 + 统计够力）。它和生命周期**正交**：叠加在 state token 之后，不替换 state（一个 skill 可以既 `measurable` 又有 🔬）。有 gap 行时加一条脚注解释。`--json` 的 `ManagedListRow` 加可选 `productionGap` 字段，信封仍 `schemaVersion 1`（additive，跟 override 一样不 bump）。

Studio：列表加 `🔬 生产盲区` 只读徽标（tooltip 列出盲区集中的区域）+ legend 条目；决策史时间线把每条 observation 推成一条「观测」事件，按红+够力 / underpowered / 健康分三类渲染，红的带「盲区集中在 …」+「建议补对应用例后重跑 omk eval」。

## 守住的不变量

生产盲区与 `state` / `drifted` / `reachable` 三轴全部正交——它是**版本无关的生产信号**（observe 量的是线上部署版），只 surface、绝不参与生命周期、永不翻 `stale`。观测**无 contentHash**，所以时间线不重置版本分段（用非快照断言锁死：加 3 条观测后版本段头数量不变）。渲染器**不 import cli**：gap-area 人话标签在 renderer 本地另存一份（两个出口各走各的 i18n 机制）。

只 surface 确诊盲区（marker==='gap'）：underpowered 是 unknown、green/yellow 是信息态，都不在 list / 徽标里报警，避免低样本噪声。

## 验证

`yarn lint && typecheck && build && build:docs:check` 全绿；`yarn test` 2260 过（唯一失败是 `sigint-propagation` 时序 flaky，隔离 11/11 过）。渲染器既有快照只新增 legend 一行、无任何删除（已逐行核 diff），其余为新增 observe / gap 快照。

CR 前不自动合。前置：#268（Slice A）已合入 main。
