### PR TITLE
fix(grading): 评委失败(score=0)当缺测而非 0 分,不再污染 composite [BREAKING-COMPARABILITY]

### DIFF
--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -196,6 +196,9 @@ export function aggregateReport({
   const bootstrapSamples = request?.bootstrapSamples ?? DEFAULT_BOOTSTRAP_SAMPLES;
   let pairComparisons: VariantPairComparison[] | undefined;
   if (bootstrapEnabled) {
+    // 不变量(见 grading/layered-scores.ts):composite 在至少一层可测时恒 ≥ 1,`compositeScore === 0`
+    // 当且仅当该样本**无任何可测层**(真·缺测,如纯评委样本且评委失败)。故 `> 0` 过滤精确剔除非测量、
+    // 绝不丢"低分内容"(评委失败已在上游当缺测,不会以 0 进 composite)。下同(control / treatment)。
     for (const variant of variants) {
       const entries = Object.values(results).map((r) => r[variant]).filter(Boolean);
       const compositeScores = entries

--- a/src/eval-core/schema.ts
+++ b/src/eval-core/schema.ts
@@ -106,7 +106,8 @@ export function buildVariantResult(execResult: ExecResult, gradeResult: GradeRes
         layeredScores.factScore = assertionFact != null
           ? Number(((assertionFact + hardScore) / 2).toFixed(2))
           : hardScore;
-        // Recompute composite from updated layers (保留 0 分,仅过滤真正缺失)
+        // Recompute composite from updated layers. 仅过滤 null/undefined(缺测层);评委失败时 judgeScore
+        // 本就是 undefined(见 grading 的 score=0 修复:评委失败=缺测、不以 0 进层),不存在「0 分」要保留。
         const scores = [layeredScores.factScore, layeredScores.behaviorScore, layeredScores.judgeScore].filter((s): s is number => s != null);
         compositeScore = scores.length > 0 ? Number((scores.reduce((a, b) => a + b, 0) / scores.length).toFixed(2)) : compositeScore;
       }
@@ -222,8 +223,9 @@ export function buildVariantSummary(entries: VariantResult[]): VariantSummary {
       };
     })(),
     ...(() => {
-      // 保留 0 分用例(评委打"完全不合格"是合法低分,不是缺失)。
-      // 仅 filter null / undefined(真正缺数据,如该 sample 无对应断言或未配 judge)。
+      // 各层分量为 null/undefined = 该层缺测(无对应断言 / 未配 judge / 评委失败)。评委失败已在 grading 层
+      // 当缺测、judgeScore 留 undefined(见 score=0 修复),不存在「0 分内容」要保留;评委有效分恒 1-5。
+      // filter != null 即精确剔除缺测层。
       const factScores = ok.map((e) => e.layeredScores?.factScore).filter((s): s is number => s != null);
       const behaviorScores = ok.map((e) => e.layeredScores?.behaviorScore).filter((s): s is number => s != null);
       const judgeScores = ok.map((e) => e.layeredScores?.judgeScore).filter((s): s is number => s != null);

--- a/src/grading/index.ts
+++ b/src/grading/index.ts
@@ -153,7 +153,11 @@ export async function grade({ output, sample, judgeModels, judgeExecutors, allow
     const judge = useEnsemble
       ? await llmJudgeEnsemble(rubricOptions, judgeModels, executorByName, judgeRepeat)
       : await llmJudgeRepeat(rubricOptions, judgeRepeat);
-    results.llmScore = judge.score;
+    // judge.score <= 0 表示该样本所有判定尝试都失败(非 JSON / parse / executor 错——见 judge.ts 失败哨兵
+    // 268/275/298,prompt 只发 1-5),是**缺测**而非「0 分内容」。不写 llmScore(留 undefined)→ 让
+    // computeLayeredScores 当缺层排除,而不是把基础设施失败当内容分污染 composite(与多维度路径 filter(s>0)
+    // 及多轮路径 validSamples 已排除失败同口径)。llmReason / scoreSamples 仍记录,供诊断"为何失败"。
+    if (judge.score > 0) results.llmScore = judge.score;
     results.llmReason = judge.reason;
     if (judge.reasoning) results.llmReasoning = judge.reasoning;
     if (judge.scoreSamples && judge.scoreSamples.length > 1) {

--- a/src/grading/layered-scores.ts
+++ b/src/grading/layered-scores.ts
@@ -61,10 +61,11 @@ export function computeLayeredScores(results: CompositeInput): { compositeScore:
     layered.behaviorScore = scoreFromDetails(behaviorDetails) ?? undefined;
   }
 
-  // 评委打 0 分是"完全不合格"的合法低分,不是缺失——保留进 composite 计算,不做 > 0 gate。
-  // 只排除 undefined(真正缺数据:没配 judge 或打分失败)。fact/behavior 通过 ratioToScore
-  // 产出的分数理论上 ≥ 1,null 判断即可。
-  if (typeof results.llmScore === 'number') {
+  // 评委分量表是 1-5(见 judge.ts prompt),`score <= 0` 是失败哨兵(非 JSON / parse / executor 错),
+  // 是**缺测**不是「0 分内容」—— 当缺层排除,绝不让基础设施失败当内容分污染 composite。上游(grading/index.ts
+  // 单评委路径 + 多维度 filter(s>0) + 多轮 validSamples)已保证失败不进 llmScore;这里再 `> 0` 防御一层,
+  // 与全管线"0=失败=排除"口径一致(fact/behavior 经 ratioToScore 恒 ≥ 1,有效评委分亦 ≥ 1)。
+  if (typeof results.llmScore === 'number' && results.llmScore > 0) {
     layered.judgeScore = results.llmScore;
   }
 

--- a/test/grader.test.ts
+++ b/test/grader.test.ts
@@ -445,6 +445,45 @@ describe('grade', () => {
     assert.equal(result.compositeScore, 4.5);
   });
 
+  it('judge 失败(非 JSON)+ 通过断言:composite 排除失败评委,不被 0 污染(score=0 语义修复)', async () => {
+    // 评委返回不可解析内容 → judge.score=0(失败哨兵,非「0 分内容」)。修复前 llmScore=0 会把
+    // composite 从 5 拖到 mean(5,0)=2.5;修复后评委当缺测、composite 仍取 fact 单层=5。
+    const failingJudge = async (): Promise<ExecResult> => ({
+      ok: true, output: 'sorry, I cannot grade this', costUSD: 0.001, durationMs: 0, durationApiMs: 0,
+      inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0, stopReason: 'end_turn', numTurns: 1,
+    });
+    const result = await grade({
+      output: 'SQL injection found, use parameterized queries',
+      sample: {
+        sample_id: 'test', prompt: 'Review code', rubric: 'Should find SQL injection',
+        assertions: [
+          { type: 'contains', value: 'SQL', weight: 1 },
+          { type: 'contains', value: 'parameterized', weight: 1 },
+        ],
+      },
+      judgeModels: [{ executor: 'claude', model: 'haiku' }],
+      judgeExecutors: { claude: failingJudge },
+    });
+    assert.equal(result.assertions!.passed, 2);
+    assert.equal(result.llmScore, undefined, '评委失败 → llmScore 缺测,不是 0');
+    assert.equal(result.compositeScore, 5, 'composite 排除失败评委,不被基础设施失败污染');
+  });
+
+  it('纯评委样本 + 评委失败:composite=0(真·缺测,下游 >0 过滤当非测量)', async () => {
+    const failingJudge = async (): Promise<ExecResult> => ({
+      ok: true, output: 'no parseable score', costUSD: 0.001, durationMs: 0, durationApiMs: 0,
+      inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0, stopReason: 'end_turn', numTurns: 1,
+    });
+    const result = await grade({
+      output: 'whatever',
+      sample: { sample_id: 'test', prompt: 'Review code', rubric: 'Should find SQL injection' },
+      judgeModels: [{ executor: 'claude', model: 'haiku' }],
+      judgeExecutors: { claude: failingJudge },
+    });
+    assert.equal(result.llmScore, undefined, '评委失败 → 无 llmScore');
+    assert.equal(result.compositeScore, 0, '无可测层 → composite 0(非测量,非 0 分内容)');
+  });
+
   it('dimensions: multi-dimensional scoring', async () => {
     let callCount = 0;
     const mockExecutor = async (): Promise<ExecResult> => {

--- a/test/variance-layers.test.ts
+++ b/test/variance-layers.test.ts
@@ -195,9 +195,9 @@ describe('buildVarianceData — three-layer breakdown (PR-2)', () => {
   });
 
   it('边界: mean = 0 (全 0 分数)不崩,byLayer 输出 stddev=0', () => {
-    // 所有用例 judge=0(评委判全部不合格)。mean=0 是合法数据,不是 NaN。
-    // 这是 "judgeScore > 0 过滤 bias" fix 之后的关键 case:0 分用例应该进聚合,
-    // 最终 byLayer.judge.mean === 0,stddev === 0,不抛异常。
+    // 数值健壮性:byLayer 聚合喂入全相等(此处全 0,如旧数据 / 合成输入)时,mean / stddev 必须算成 0、
+    // 不 NaN、不抛异常。注:经 score=0 修复后,真实 grading 评委失败产出 undefined(非 0)、不会以 0 进层,
+    // 故本例是退化输入的健壮性边界,不代表「评委 0 分是有效内容」。
     const runs: Report[] = [
       makeRun('r1', { v1: { composite: 2.0, fact: 4.0, behavior: 2.0, quality: 0 } }),
       makeRun('r2', { v1: { composite: 2.0, fact: 4.0, behavior: 2.0, quality: 0 } }),
@@ -205,7 +205,7 @@ describe('buildVarianceData — three-layer breakdown (PR-2)', () => {
     const data = buildVarianceData(runs);
     assert.ok(data);
     const judgeStats = data!.perVariant.v1.byLayer?.judge;
-    assert.ok(judgeStats, 'judge layer should be populated (0 is valid score, not missing)');
+    assert.ok(judgeStats, 'byLayer 对退化全相等输入仍输出该层(不丢、不 NaN)');
     assert.equal(judgeStats!.mean, 0);
     assert.equal(judgeStats!.stddev, 0);
     assert.deepEqual(judgeStats!.scores, [0, 0]);


### PR DESCRIPTION
## 这在解决什么（大白话）

测量学审计第一条轴挖出的**最严重**一条。LLM 评委本该打 1-5 分；当评委调用出错（返回非 JSON、解析失败、executor 报错）时，代码用 `score=0` 当"失败信号"。问题是这个 0 在不同模块各说各话：

- `judge.ts`：0 = 评委失败（哨兵）。多维度路径、多轮路径都已经把 0 当失败排除掉。
- `layered-scores.ts`：注释却说"评委打 0 是合法低分，保留进 composite"。
- 单评委路径 `grading/index.ts:156`：把失败的 0 原样写进分数。

后果是真实的：一个样本断言全过（该 5 分），只要评委这一次**基础设施失败**，composite 就被从 5 拖到 mean(5,0)=2.5——一次网络错误能把好结果算成 REGRESS。纯评委样本失败时 composite=0，又被下游 `>0` 过滤当"没数据"丢掉。等于评委的**基础设施故障**被当成了**内容质量分**。

## 改了什么

把这个异类对齐全管线本就主流的"0=失败=排除"口径：评委整体失败（`score<=0`，即没有任何一次成功判定）时**不写** `llmScore`（留 undefined），让 composite 把它当缺测的那一层排除，而不是当 0 分计入。改正 `layered-scores` 的误导注释并加一层 `>0` 防御。`llmReason`/`scoreSamples` 仍记录失败原因供诊断。

结果：composite 在至少一层可测时恒 ≥ 1，`=0` 当且仅当真的无任何可测层。下游约 8 处 `compositeScore > 0` 过滤随之变得语义精确（只剔非测量、绝不丢低分内容），补了注释说明这条不变量。

## 影响与测量学说明

实际数值变化**仅限"跑出过评委失败"的报告**——干净运行（无评委失败）composite 完全不变。但因为这改了五层评分管道对失败的处理语义（CLAUDE.md 列的不变量），按规约标 **BREAKING-COMPARABILITY**。这是测量学审计 9 条修复的第 1 条（地基），后续 4 个 PR（确定性种子 / 配对 bootstrap / 多重比较 + 稳定性门控 / 收尾）会陆续来，最后统一一次 minor 版本。

新增两条回归测试：评委失败 + 通过断言 → composite 不被污染（仍 5）；纯评委失败 → composite=0 当非测量。

验证：`yarn lint && typecheck && build && build:docs:check && test` 全绿（2270，含新增回归）。
