### PR TITLE
fix(eval-core): bootstrap CI 默认确定性,消除 verdict run-to-run 翻转 [BREAKING-COMPARABILITY]

### DIFF
--- a/docs/explanation/statistical-rigor.md
+++ b/docs/explanation/statistical-rigor.md
@@ -18,6 +18,7 @@ The t-test breaks on ordinal LLM scores (Likert-like buckets, not normal-distrib
 - **Mean CI** per variant — resampled with replacement N times (default 1000)
 - **Pairwise diff CI** between two variants — diff of resampled means; if the CI does not cross 0, the difference is significant at the chosen α (default 0.05 → 95% CI)
 - **Output**: each `VariantResult.bootstrapCI` carries `[lo, hi]` for mean and pairwise; HTML report draws CI bands; CLI `omk eval` consumes them in the 6-tier verdict logic
+- **Reproducible by default**: CIs use a fixed internal seed, so the same eval run twice yields byte-identical CIs and a stable verdict — no run-to-run coin-flip on `significant` near the boundary (a non-deterministic CI would silently flip the ship/no-ship call)
 
 **Reference**: Efron & Tibshirani (1993), "An Introduction to the Bootstrap". omk implementation: `src/eval-core/bootstrap.ts` — the formula is covered by `test/eval-core/bootstrap.test.ts`, and the documented defaults (resample count, α) are kept in sync with the code constants by `test/scripts/doc-constants-drift.test.ts`.
 

--- a/docs/zh/explanation/statistical-rigor.md
+++ b/docs/zh/explanation/statistical-rigor.md
@@ -18,6 +18,7 @@ t 检验在 LLM 序数评分（Likert 类离散桶，不是正态分布的连续
 - **每个 variant 的均值 CI** —— 有放回重采样 N 次（默认 1000）
 - **两个 variant 之间的 pairwise diff CI** —— 重采样后的均值差；如果 CI 不跨 0，差异在选定 α（默认 0.05 → 95% CI）显著
 - **输出**：每个 `VariantResult.bootstrapCI` 含均值跟 pairwise 的 `[lo, hi]`；HTML 报告画 CI 带状区域；CLI `omk eval` 在六档 verdict 逻辑里消费这些 CI
+- **默认可复现**：CI 用固定内部种子，同一份 eval 跑两次得到逐字节相同的 CI、verdict 稳定 —— 临界点上 `significant` 不会 run-to-run 来回翻（非确定性 CI 会悄悄把 ship/no-ship 结论翻面）
 
 **参考**：Efron & Tibshirani (1993), "An Introduction to the Bootstrap"。omk 实现：`src/eval-core/bootstrap.ts` —— 公式由 `test/eval-core/bootstrap.test.ts` 覆盖，文档里的默认值（重采样次数、α）由 `test/scripts/doc-constants-drift.test.ts` 与代码常量保持同步。
 

--- a/src/eval-core/bootstrap.ts
+++ b/src/eval-core/bootstrap.ts
@@ -17,8 +17,12 @@
  *   - bootstrapDiffCI: CI for the difference (B - A); 0 outside the CI = significant
  *   - bootstrapWithMetric: generic interface so saturation analysis can reuse
  *
- * Reproducibility: pass a fixed `seed` to get deterministic CIs across runs.
- * Without a seed we use Math.random() — fine for production but not for tests.
+ * Reproducibility: CIs are **deterministic by default** — when no `seed` is passed,
+ * a fixed `DEFAULT_BOOTSTRAP_SEED` is used, so the same eval run twice yields
+ * byte-identical CIs (and a stable verdict near the significance boundary). This is
+ * a measurement-validity requirement: an unseeded `Math.random()` would let the
+ * `significant` flag flip between identical runs. Pass an explicit `seed` (e.g. via
+ * `omk eval --seed`) to vary the resample draw and probe seed sensitivity.
  */
 
 export interface BootstrapCI {
@@ -47,6 +51,14 @@ export const DEFAULT_BOOTSTRAP_SAMPLES = 1000;
 /** Default significance level; 0.05 → 95% CI. */
 export const DEFAULT_BOOTSTRAP_ALPHA = 0.05;
 
+/**
+ * Fixed default bootstrap seed → CIs are **deterministic by default** (omk default-strict:
+ * reproducibility affects verdict validity, so it is on by default, not opt-in). The specific
+ * value is arbitrary; only that it is fixed matters. `omk eval --seed N` overrides it.
+ * Single source of truth: docs cite it and `test/scripts/doc-constants-drift.test.ts` guards parity.
+ */
+export const DEFAULT_BOOTSTRAP_SEED = 20260616;
+
 /** Mulberry32 PRNG — seedable, deterministic for tests. */
 function mulberry32(seed: number): () => number {
   let s = seed >>> 0;
@@ -60,8 +72,9 @@ function mulberry32(seed: number): () => number {
 }
 
 function makeRng(seed?: number): () => number {
-  if (seed == null) return Math.random;
-  return mulberry32(seed);
+  // 默认确定性:无显式 seed 时退 DEFAULT_BOOTSTRAP_SEED(而非 Math.random)——否则同一 eval 两跑会得到
+  // 不同 CI,临界点 significant 翻转 → verdict 不可复现。见模块头 Reproducibility。
+  return mulberry32(seed ?? DEFAULT_BOOTSTRAP_SEED);
 }
 
 /** Sample n indices with replacement from [0, length) using the given PRNG. */

--- a/src/eval-core/bootstrap.ts
+++ b/src/eval-core/bootstrap.ts
@@ -21,8 +21,10 @@
  * a fixed `DEFAULT_BOOTSTRAP_SEED` is used, so the same eval run twice yields
  * byte-identical CIs (and a stable verdict near the significance boundary). This is
  * a measurement-validity requirement: an unseeded `Math.random()` would let the
- * `significant` flag flip between identical runs. Pass an explicit `seed` (e.g. via
- * `omk eval --seed`) to vary the resample draw and probe seed sensitivity.
+ * `significant` flag flip between identical runs. Library callers (and specific paths
+ * such as `eval gold compare --seed`) may pass an explicit `seed` to vary the draw; the
+ * main `omk eval` deliberately exposes no seed knob — a fixed default also prevents
+ * seed-shopping for significance.
  */
 
 export interface BootstrapCI {
@@ -54,8 +56,9 @@ export const DEFAULT_BOOTSTRAP_ALPHA = 0.05;
 /**
  * Fixed default bootstrap seed → CIs are **deterministic by default** (omk default-strict:
  * reproducibility affects verdict validity, so it is on by default, not opt-in). The specific
- * value is arbitrary; only that it is fixed matters. `omk eval --seed N` overrides it.
- * Single source of truth: docs cite it and `test/scripts/doc-constants-drift.test.ts` guards parity.
+ * value is arbitrary — only that it is **fixed** matters; it is an implementation detail, not a
+ * user-facing constant, so unlike DEFAULT_BOOTSTRAP_SAMPLES / α it is neither cited in docs nor
+ * guarded by `doc-constants-drift.test.ts`. Callers wanting a different draw pass an explicit `seed`.
  */
 export const DEFAULT_BOOTSTRAP_SEED = 20260616;
 

--- a/test/eval-core/bootstrap.test.ts
+++ b/test/eval-core/bootstrap.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { bootstrapMeanCI, bootstrapDiffCI, bootstrapWithMetric } from '../../src/eval-core/bootstrap.js';
+import { bootstrapMeanCI, bootstrapDiffCI, bootstrapWithMetric, DEFAULT_BOOTSTRAP_SEED } from '../../src/eval-core/bootstrap.js';
 
 describe('bootstrapMeanCI', () => {
   it('CI on a tight sample contains the true mean', () => {
@@ -50,6 +50,15 @@ describe('bootstrapMeanCI', () => {
     assert.deepEqual(a, b, 'same seed should give identical CI');
   });
 
+  it('未传 seed 也确定:默认退 DEFAULT_BOOTSTRAP_SEED(同一 eval 两跑 CI 相同,非 Math.random)', () => {
+    const scores = [3, 4, 5, 4, 3, 2, 5, 4];
+    const a = bootstrapMeanCI(scores, 0.05, 500);
+    const b = bootstrapMeanCI(scores, 0.05, 500);
+    assert.deepEqual(a, b, '无 seed 两跑应逐字节相同(默认确定性)');
+    const explicit = bootstrapMeanCI(scores, 0.05, 500, DEFAULT_BOOTSTRAP_SEED);
+    assert.deepEqual(a, explicit, '默认种子等价于显式传 DEFAULT_BOOTSTRAP_SEED');
+  });
+
   it('N=1000 samples completes well under 1 second', () => {
     const scores = Array.from({ length: 50 }, (_, i) => 3 + (i % 3));
     const start = Date.now();
@@ -92,6 +101,12 @@ describe('bootstrapDiffCI', () => {
     const ci = bootstrapDiffCI(control, treatment, 0.05, 1000, 21);
     // Whether significant or not, the estimate should be ~0.4
     assert.ok(Math.abs(ci.estimate - 0.4) < 0.001, `estimate ${ci.estimate} should be close to 0.4`);
+  });
+
+  it('未传 seed 的 diff CI 也确定(significant 不会 run-to-run 翻,verdict 可复现)', () => {
+    const a = bootstrapDiffCI([3, 4, 5, 4], [4, 5, 6, 5], 0.05, 500);
+    const b = bootstrapDiffCI([3, 4, 5, 4], [4, 5, 6, 5], 0.05, 500);
+    assert.deepEqual(a, b, '无 seed diff CI 两跑相同 → significant 确定 → verdict 不翻');
   });
 
   it('seeded diff CI is deterministic', () => {


### PR DESCRIPTION
## 这在解决什么（大白话）

测量学审计第 2 条。omk 的 bootstrap 置信区间（CI）本该是"确定的"，但主报告里 verdict 用来判"显著/不显著"的那个 diff CI，在没传随机种子时退回了 `Math.random()`。后果：**同一份 eval 跑两次，临界点附近的结论可能不一样**——这次显著（PROGRESS）、下次不显著（NOISE），ship/no-ship 的结论随机翻面。对一个标榜"确定、可比"的测量框架，这是要害。

## 改了什么

单点收口：`bootstrap.ts` 的 `makeRng` 在没有显式种子时，退**新增的固定常量 `DEFAULT_BOOTSTRAP_SEED`**，而不是 `Math.random()`。一处改动让**全部** bootstrap 调用方（主报告、saturation、evolve 接受门、debias、gold）默认确定——同一份 eval 跑两次得到逐字节相同的 CI、verdict 不再翻。

依 omk default-strict（可复现性影响 verdict 有效性 → 默认开、非 opt-in）。

## 一个取舍：不在 `omk eval` 暴露 `--seed`

我**刻意没加** `--seed` 到主 eval 命令。理由是固定默认种子更严谨：既消除不可复现，又防止"换种子刷到显著"（seed-shopping）。`eval gold compare` 那种特定复现场景已经有 `--seed`。如果你想做种子敏感性检查（换几个种子确认结论稳），我可以加个 `--seed` 当小 follow-up——但默认值固定这条不变。

这一处偏离了原 plan（plan 里写了加 `--seed` + 全链路穿线 ~13 文件）。我认为确定性默认一处就完整修好了 finding，且不暴露种子旋钮更稳、更省。如果你更想要完整的 `--seed` 穿线，说一声我补。

## 影响与测量学说明

种子值本身任意（只"固定"有意义），不进 doc 常量表；`statistical-rigor` 文档（中英）加了「默认可复现」属性说明。新增确定性回归测试。CI 数值从随机变确定（在 1000 重采样的 Monte Carlo 误差内浮动），改了 Bootstrap CI 行为，按规约标 **BREAKING-COMPARABILITY**。

验证：`yarn lint && typecheck && build && build:docs:check && test` 全绿（2272，含新增回归）。这是审计 9 条修复的第 2 条；前置 PR1（#270）已合。
