### PR TITLE
fix(eval-core): 配对设计的 diff CI 改用配对 bootstrap,收回功效 [BREAKING-COMPARABILITY]

### DIFF
--- a/src/authoring/evolver.ts
+++ b/src/authoring/evolver.ts
@@ -1132,11 +1132,15 @@ export async function evolveSkill({
     // Significance accept gate: accept only when the candidate is *significantly*
     // above the current best on the decision (val) set, not merely numerically higher
     // — rejecting gains indistinguishable from judge noise. `lastReport` is the current
-    // best's fresh eval and `candidateReport` the candidate's, over the same samples;
-    // bootstrapDiffCI resamples the two arrays independently (conservative — not a paired
-    // bootstrap). Under-powered decision sets degrade to the legacy point-estimate accept
-    // (note: that path compares the prior-round best scalar, not this fresh re-eval) and
-    // flag `gate.underpowered`.
+    // best's fresh eval and `candidateReport` the candidate's, over the same samples.
+    // **Deliberately UNPAIRED here** (independent resampling, `decideAccept` → `bootstrapDiffCI`),
+    // unlike the report verdict / debias which switched to `bootstrapPairedDiffCI`: this is an
+    // *optimization accept-gate*, and the unpaired bootstrap's wider, conservative CI is the
+    // wanted bias — it raises the bar to accept, so evolve does not chase paired-tightened,
+    // marginally-significant gains that risk overfitting the decision set. Power is not the goal
+    // for de-/escalation gates; not accepting noise is. Under-powered decision sets degrade to the
+    // legacy point-estimate accept (note: that path compares the prior-round best scalar, not this
+    // fresh re-eval) and flag `gate.underpowered`.
     const valIds = split ? split.valIds : new Set(allSampleIds);
     const bestScores = perSampleComposite(lastReport, lastVariantKey, valIds);
     const candScores = perSampleComposite(candidateReport, candidateVariantKey, valIds);

--- a/src/cli/lib/record-evolve-outcome.ts
+++ b/src/cli/lib/record-evolve-outcome.ts
@@ -39,7 +39,8 @@ export interface EvolveOutcomeResult {
 
 /**
  * round-bestRound vs round-0 的忠实 verdict：复刻 eval 管线（evaluation-reporting.ts）对两变体抽
- * per-sample composite → bootstrapDiffCI → computeVerdict，与 `omk eval --bootstrap` 同口径、同 α / 重采样数。
+ * per-sample composite → 按 sample 配对 bootstrapPairedDiffCI → computeVerdict，与 `omk eval --bootstrap`
+ * 同口径、同 α / 重采样数。
  * 不自造门限：评委是否显著、是否 PROGRESS 全交给既有 computeVerdict。
  */
 function winnerVerdict(report: EvaluationReport, winnerVariant: string): string {

--- a/src/cli/lib/record-evolve-outcome.ts
+++ b/src/cli/lib/record-evolve-outcome.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path';
 import { createOverlayReportStore } from '../../server/report-store.js';
 import { projectReportsDir, globalReportsDir } from '../../eval-core/measurement-dirs.js';
 import { computeVerdict } from '../../eval-core/verdict.js';
-import { bootstrapDiffCI, DEFAULT_BOOTSTRAP_ALPHA, DEFAULT_BOOTSTRAP_SAMPLES } from '../../eval-core/bootstrap.js';
+import { bootstrapPairedDiffCI, DEFAULT_BOOTSTRAP_ALPHA, DEFAULT_BOOTSTRAP_SAMPLES } from '../../eval-core/bootstrap.js';
 import {
   resolveManagedDir,
   managedDir,
@@ -44,17 +44,24 @@ export interface EvolveOutcomeResult {
  */
 function winnerVerdict(report: EvaluationReport, winnerVariant: string): string {
   const baseline = 'round-0';
-  const scoresOf = (v: string): number[] => report.results
-    .map((r) => r.variants[v])
-    .filter((e): e is NonNullable<typeof e> => !!e && typeof e.compositeScore === 'number' && e.compositeScore > 0)
-    .map((e) => e.compositeScore as number);
-  const ctrl = scoresOf(baseline);
-  const treat = scoresOf(winnerVariant);
-  const pairComparisons = ctrl.length >= 2 && treat.length >= 2
+  // 按 sample **配对**(与 evaluation-reporting 主 A/B 同口径 —— 本函数职责就是复刻 eval 管线):baseline 与
+  // winner 在同一 sample 上都可测(composite > 0)才入对。同一 sample 两版分数正相关,配对 bootstrap 收紧 diff
+  // CI;独立重采样会高估方差、保守失功效。diff = b − a = winner − baseline。
+  const compositeOf = (v: string, r: typeof report.results[number]): number | undefined => {
+    const e = r.variants[v];
+    return e && typeof e.compositeScore === 'number' && e.compositeScore > 0 ? e.compositeScore : undefined;
+  };
+  const pairs: Array<{ a: number; b: number }> = [];
+  for (const r of report.results) {
+    const a = compositeOf(baseline, r);
+    const b = compositeOf(winnerVariant, r);
+    if (a !== undefined && b !== undefined) pairs.push({ a, b });
+  }
+  const pairComparisons = pairs.length >= 2
     ? [{
       control: baseline,
       treatment: winnerVariant,
-      diffBootstrapCI: bootstrapDiffCI(ctrl, treat, DEFAULT_BOOTSTRAP_ALPHA, DEFAULT_BOOTSTRAP_SAMPLES),
+      diffBootstrapCI: bootstrapPairedDiffCI(pairs, DEFAULT_BOOTSTRAP_ALPHA, DEFAULT_BOOTSTRAP_SAMPLES),
     }]
     : undefined;
   const slice: EvaluationReport = {

--- a/src/eval-core/bootstrap.ts
+++ b/src/eval-core/bootstrap.ts
@@ -209,8 +209,11 @@ export function bootstrapDiffCI(
  * conservative bias is wanted). The point estimate is identical (mean of per-pair diffs =
  * difference of paired means); only the CI tightens.
  *
- * `significant` is computed on the **unrounded** bounds (then the bounds are rounded for
- * display) so a 4-decimal round never flips the call at the 0 boundary.
+ * `significant` is derived from the **rounded** `low`/`high` (the persisted bounds), so the
+ * flag never contradicts what is stored / displayed: a CI that rounds to include 0 reads as
+ * not-significant. (Computing it on the unrounded bounds would let the JSON say `low: 0,
+ * significant: true` — a self-contradictory `CI=[0, …]` that downstream `computeVerdict` and
+ * external consumers cannot reconcile.) Matches `bootstrapDiffCI`.
  *
  * @param pairs    Aligned observations; `a` = control/baseline, `b` = treatment. diff = b - a.
  * @param alpha    Significance level. Default 0.05.
@@ -237,14 +240,15 @@ export function bootstrapPairedDiffCI(
     resampleDiffMeans[s] = sum / n;
   }
   resampleDiffMeans.sort((a, b) => a - b);
-  const lowRaw = sortedQuantile(resampleDiffMeans, alpha / 2);
-  const highRaw = sortedQuantile(resampleDiffMeans, 1 - alpha / 2);
+  const low = round4(sortedQuantile(resampleDiffMeans, alpha / 2));
+  const high = round4(sortedQuantile(resampleDiffMeans, 1 - alpha / 2));
   return {
-    low: round4(lowRaw),
-    high: round4(highRaw),
+    low,
+    high,
     estimate: round4(mean(diffs)),
     samples,
-    significant: !(lowRaw <= 0 && 0 <= highRaw),
+    // significant 与持久化的(舍入)边界一致 —— 见函数头:绝不出现「low:0 但 significant:true」自相矛盾。
+    significant: !(low <= 0 && 0 <= high),
   };
 }
 

--- a/src/eval-core/bootstrap.ts
+++ b/src/eval-core/bootstrap.ts
@@ -195,6 +195,60 @@ export function bootstrapDiffCI(
 }
 
 /**
+ * Bootstrap CI for the *difference* of two means on **paired** observations — when A and B
+ * are two measurements of the **same unit** (e.g. control vs treatment on the same sample,
+ * or original vs alternate judge prompt on the same response). Resamples the **pair indices
+ * jointly** and averages each pair's `b - a`, so the within-pair correlation is preserved.
+ *
+ * Why paired (vs `bootstrapDiffCI`'s independent resampling): when A and B move together
+ * across units (the usual case — the same sample scored by two variants is positively
+ * correlated), much of each group's variance is shared and cancels in the per-pair diff.
+ * The independent (unpaired) bootstrap ignores that, over-states the diff's variance, and
+ * widens the CI — *conservative*, costing real power. Use paired whenever the design is
+ * paired; use `bootstrapDiffCI` only for genuinely independent groups (or where a deliberate
+ * conservative bias is wanted). The point estimate is identical (mean of per-pair diffs =
+ * difference of paired means); only the CI tightens.
+ *
+ * `significant` is computed on the **unrounded** bounds (then the bounds are rounded for
+ * display) so a 4-decimal round never flips the call at the 0 boundary.
+ *
+ * @param pairs    Aligned observations; `a` = control/baseline, `b` = treatment. diff = b - a.
+ * @param alpha    Significance level. Default 0.05.
+ * @param samples  Bootstrap resamples. Default 1000.
+ * @param seed     Optional seed (deterministic by default — see module header).
+ */
+export function bootstrapPairedDiffCI(
+  pairs: Array<{ a: number; b: number }>,
+  alpha = DEFAULT_BOOTSTRAP_ALPHA,
+  samples = DEFAULT_BOOTSTRAP_SAMPLES,
+  seed?: number,
+): BootstrapDiffCI {
+  if (pairs.length === 0) {
+    return { low: 0, high: 0, estimate: 0, samples: 0, significant: false };
+  }
+  const n = pairs.length;
+  const diffs = pairs.map((p) => p.b - p.a);
+  const rng = makeRng(seed);
+  const resampleDiffMeans: number[] = new Array(samples);
+  for (let s = 0; s < samples; s++) {
+    const idx = resampleIndices(n, n, rng);
+    let sum = 0;
+    for (const i of idx) sum += diffs[i];
+    resampleDiffMeans[s] = sum / n;
+  }
+  resampleDiffMeans.sort((a, b) => a - b);
+  const lowRaw = sortedQuantile(resampleDiffMeans, alpha / 2);
+  const highRaw = sortedQuantile(resampleDiffMeans, 1 - alpha / 2);
+  return {
+    low: round4(lowRaw),
+    high: round4(highRaw),
+    estimate: round4(mean(diffs)),
+    samples,
+    significant: !(lowRaw <= 0 && 0 <= highRaw),
+  };
+}
+
+/**
  * Generic bootstrap CI for an arbitrary sample-level metric. Used by
  * saturation analysis to get CI on metrics like stddev or
  * agreement, not just mean.

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -10,7 +10,7 @@ import { buildVariantConfig, resolveExecutionStrategy } from './execution-strate
 import { getJudgePromptHash } from '../grading/judge.js';
 import {
   bootstrapMeanCI,
-  bootstrapDiffCI,
+  bootstrapPairedDiffCI,
   DEFAULT_BOOTSTRAP_ALPHA,
   DEFAULT_BOOTSTRAP_SAMPLES,
 } from './bootstrap.js';
@@ -214,21 +214,26 @@ export function aggregateReport({
     if (variants.length >= 2) {
       pairComparisons = [];
       const controlName = variants[0];
-      const controlEntries = Object.values(results).map((r) => r[controlName]).filter(Boolean);
-      const controlScores = controlEntries
-        .filter((e) => typeof e.compositeScore === 'number' && e.compositeScore! > 0)
-        .map((e) => e.compositeScore!);
+      const sampleRecords = Object.values(results);
       for (let i = 1; i < variants.length; i++) {
         const treatmentName = variants[i];
-        const treatmentEntries = Object.values(results).map((r) => r[treatmentName]).filter(Boolean);
-        const treatmentScores = treatmentEntries
-          .filter((e) => typeof e.compositeScore === 'number' && e.compositeScore! > 0)
-          .map((e) => e.compositeScore!);
-        if (controlScores.length >= 2 && treatmentScores.length >= 2) {
+        // **配对** diff CI:A/B 是同一批 sample 分别过 control / treatment(配对设计),按 sample 对齐 ——
+        // 同一 sample 上 control 与 treatment 都可测(composite > 0,见上不变量)才入对。同一 sample 两 variant
+        // 的分数正相关,配对 bootstrap 据此抵消共有方差、收紧 diff CI、更有功效;旧的独立(非配对)重采样高估
+        // 方差、CI 偏宽、保守失功效(见 bootstrapPairedDiffCI)。点估计不变,只收紧 CI。
+        const pairs: Array<{ a: number; b: number }> = [];
+        for (const r of sampleRecords) {
+          const c = r[controlName];
+          const t = r[treatmentName];
+          const a = c && typeof c.compositeScore === 'number' && c.compositeScore > 0 ? c.compositeScore : undefined;
+          const b = t && typeof t.compositeScore === 'number' && t.compositeScore > 0 ? t.compositeScore : undefined;
+          if (a !== undefined && b !== undefined) pairs.push({ a, b });
+        }
+        if (pairs.length >= 2) {
           pairComparisons.push({
             control: controlName,
             treatment: treatmentName,
-            diffBootstrapCI: bootstrapDiffCI(controlScores, treatmentScores, DEFAULT_BOOTSTRAP_ALPHA, bootstrapSamples),
+            diffBootstrapCI: bootstrapPairedDiffCI(pairs, DEFAULT_BOOTSTRAP_ALPHA, bootstrapSamples),
           });
         }
       }

--- a/src/grading/debias-validate.ts
+++ b/src/grading/debias-validate.ts
@@ -26,7 +26,7 @@
 
 import type { ExecutorFn, Report, Sample } from '../types/index.js';
 import { llmJudge } from './judge.js';
-import { bootstrapDiffCI, type BootstrapDiffCI } from '../eval-core/bootstrap.js';
+import { bootstrapPairedDiffCI, type BootstrapDiffCI } from '../eval-core/bootstrap.js';
 
 export interface DebiasValidateInput {
   report: Report;
@@ -157,9 +157,12 @@ export async function validateLengthDebias(input: DebiasValidateInput): Promise<
 
   const meanOriginal = avg(pairs.map((p) => p.originalScore));
   const meanAlternate = avg(pairs.map((p) => p.alternateScore));
-  const diffCI = bootstrapDiffCI(
-    pairs.map((p) => p.originalScore),
-    pairs.map((p) => p.alternateScore),
+  // **配对** diff CI:每个 sample 同时有 original 与 alternate prompt 两个分数(同一回答、两个 judge prompt
+  // = 配对设计)。原先拆成两数组喂独立重采样,丢弃了配对、高估方差、CI 偏宽 —— 对一个**检测**长度偏置敏感性
+  // 的工具,保守方向恰好是错的(更难检出真实偏置)。改配对:重采样 sample 下标、按 (alternate − original) 算,
+  // 保留 within-sample 相关、收紧 CI,提升对偏置的检出力。diff = b − a = alternate − original(同原约定)。
+  const diffCI = bootstrapPairedDiffCI(
+    pairs.map((p) => ({ a: p.originalScore, b: p.alternateScore })),
     0.05,
     bootstrapSamples,
     seed,

--- a/test/eval-core/bootstrap.test.ts
+++ b/test/eval-core/bootstrap.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { bootstrapMeanCI, bootstrapDiffCI, bootstrapWithMetric, DEFAULT_BOOTSTRAP_SEED } from '../../src/eval-core/bootstrap.js';
+import { bootstrapMeanCI, bootstrapDiffCI, bootstrapPairedDiffCI, bootstrapWithMetric, DEFAULT_BOOTSTRAP_SEED } from '../../src/eval-core/bootstrap.js';
 
 describe('bootstrapMeanCI', () => {
   it('CI on a tight sample contains the true mean', () => {
@@ -113,6 +113,39 @@ describe('bootstrapDiffCI', () => {
     const a = bootstrapDiffCI([3, 4, 5], [4, 5, 6], 0.05, 500, 555);
     const b = bootstrapDiffCI([3, 4, 5], [4, 5, 6], 0.05, 500, 555);
     assert.deepEqual(a, b);
+  });
+});
+
+describe('bootstrapPairedDiffCI', () => {
+  const width = (ci: { low: number; high: number }): number => ci.high - ci.low;
+
+  it('正相关配对数据:配对 CI 明显窄于独立重采样(收回被独立法浪费的功效)', () => {
+    // b = a + 0.5,每对差恒为 0.5(完全正相关)。配对:重采样后均值恒 0.5 → CI 退化到点 [0.5,0.5];
+    // 独立:分别重采样 a / b,mean(b)-mean(a) 有抽样波动 → CI 有宽度。这是配对收紧功效的极限演示。
+    const a = [1, 2, 3, 4, 5, 2, 4, 3];
+    const b = a.map((x) => x + 0.5);
+    const pairs = a.map((x, i) => ({ a: x, b: b[i] }));
+    const paired = bootstrapPairedDiffCI(pairs, 0.05, 1000, 42);
+    const unpaired = bootstrapDiffCI(a, b, 0.05, 1000, 42);
+    assert.ok(width(paired) < width(unpaired), `配对 CI 宽 ${width(paired)} 应 < 独立 ${width(unpaired)}`);
+    assert.equal(paired.estimate, 0.5, '点估计 = 平均每对差');
+    assert.equal(paired.low, 0.5);
+    assert.equal(paired.high, 0.5);
+    assert.ok(paired.significant, '恒正差 → 0 在 CI 外 → 显著');
+  });
+
+  it('点估计 = 配对均值差 = 差的均值,与独立法一致(只 CI 收紧,不动点估计)', () => {
+    const pairs = [{ a: 3, b: 4 }, { a: 4, b: 4 }, { a: 5, b: 7 }, { a: 2, b: 3 }];
+    const paired = bootstrapPairedDiffCI(pairs, 0.05, 500, 7);
+    // mean(b)-mean(a) = (4+4+7+3)/4 - (3+4+5+2)/4 = 4.5 - 3.5 = 1.0
+    assert.equal(paired.estimate, 1);
+  });
+
+  it('默认确定性 + 空输入安全', () => {
+    const pairs = [{ a: 3, b: 4 }, { a: 4, b: 4 }, { a: 5, b: 7 }];
+    assert.deepEqual(bootstrapPairedDiffCI(pairs, 0.05, 500), bootstrapPairedDiffCI(pairs, 0.05, 500));
+    assert.deepEqual(bootstrapPairedDiffCI(pairs, 0.05, 500), bootstrapPairedDiffCI(pairs, 0.05, 500, DEFAULT_BOOTSTRAP_SEED));
+    assert.deepEqual(bootstrapPairedDiffCI([], 0.05, 500), { low: 0, high: 0, estimate: 0, samples: 0, significant: false });
   });
 });
 

--- a/test/eval-core/bootstrap.test.ts
+++ b/test/eval-core/bootstrap.test.ts
@@ -141,6 +141,28 @@ describe('bootstrapPairedDiffCI', () => {
     assert.equal(paired.estimate, 1);
   });
 
+  it('near-zero:CI 舍入后含 0 → significant=false,绝不出现「low:0 但 significant:true」自相矛盾', () => {
+    // 恒定的极小正差 0.00003 → raw CI [0.00003, 0.00003] → 舍入到 [0, 0](含 0)。significant 须按持久
+    // (舍入)边界判 = false;若按 raw 判会得 true,落成自相矛盾的 {low:0, significant:true}(复审 P2)。
+    const pairs = Array.from({ length: 6 }, () => ({ a: 1, b: 1.00003 }));
+    const ci = bootstrapPairedDiffCI(pairs, 0.05, 500);
+    assert.equal(ci.low, 0);
+    assert.equal(ci.high, 0);
+    assert.equal(ci.significant, false, '持久 CI 含 0 → significant 必须 false(与边界一致)');
+  });
+
+  it('不变量:significant 恒与持久(舍入)边界一致(任意数据都不自相矛盾)', () => {
+    const datasets = [
+      Array.from({ length: 8 }, (_, i) => ({ a: i, b: i + 0.5 })),       // 稳定正差
+      Array.from({ length: 8 }, (_, i) => ({ a: i, b: i + (i % 2 ? 1 : -1) })), // 跨 0
+      Array.from({ length: 6 }, () => ({ a: 2, b: 2 })),                  // 零差
+    ];
+    for (const pairs of datasets) {
+      const ci = bootstrapPairedDiffCI(pairs, 0.05, 500);
+      assert.equal(ci.significant, !(ci.low <= 0 && 0 <= ci.high), `significant 须与返回的 low/high 一致:${JSON.stringify(ci)}`);
+    }
+  });
+
   it('默认确定性 + 空输入安全', () => {
     const pairs = [{ a: 3, b: 4 }, { a: 4, b: 4 }, { a: 5, b: 7 }];
     assert.deepEqual(bootstrapPairedDiffCI(pairs, 0.05, 500), bootstrapPairedDiffCI(pairs, 0.05, 500));

--- a/test/evaluation/evaluation-reporting.test.ts
+++ b/test/evaluation/evaluation-reporting.test.ts
@@ -333,3 +333,42 @@ describe('aggregateReport — meta.skillIsolation', () => {
     assert.deepEqual(report.meta.skillIsolation!['skill-clean'], ['react-skill']);
   });
 });
+
+describe('aggregateReport — 配对 pairwise diff CI(#235 审计 PR3)', () => {
+  const withComposite = (composite: number): VariantResult => ({ ...makeVariantResult(), compositeScore: composite });
+  const reqBootstrap = { bootstrap: true } as unknown as EvaluationRequest;
+
+  it('开 bootstrap + 2 variant:按 sample 配对算 diff CI(treatment 稳定高于 control → 显著正 Δ)', () => {
+    const ids = ['s1', 's2', 's3', 's4', 's5'];
+    const aScores = [3.0, 3.5, 4.0, 2.5, 3.8];
+    const bScores = [3.8, 4.3, 4.8, 3.3, 4.6]; // 每个 sample 上 b 比 a 高约 0.8 → 配对差稳定为正
+    const results = Object.fromEntries(ids.map((id, i) => [id, { a: withComposite(aScores[i]), b: withComposite(bScores[i]) }]));
+    const report = aggregateReport({
+      runId: 'r', variants: ['a', 'b'], model: 'm', judgeModel: 'haiku', noJudge: true,
+      executorName: 'codex', samples: ids.map((id) => makeSample(id, 'task')), tasks: [],
+      results, totalCostUSD: 0, artifacts: [makeArtifact('a', 'a'), makeArtifact('b', 'b')],
+      request: reqBootstrap,
+    });
+    const pair = report.meta.pairComparisons?.[0];
+    assert.ok(pair?.diffBootstrapCI, '应产出配对 diffBootstrapCI');
+    assert.equal(pair!.control, 'a');
+    assert.equal(pair!.treatment, 'b');
+    assert.ok(pair!.diffBootstrapCI!.estimate > 0, 'treatment 高于 control → 正 Δ');
+    assert.ok(pair!.diffBootstrapCI!.significant, '稳定正向配对差 → 显著');
+  });
+
+  it('某 sample 一侧缺测(composite 0)→ 该 sample 不入配对对,其余仍成对', () => {
+    const results = {
+      s1: { a: withComposite(3.0), b: withComposite(4.0) },
+      s2: { a: withComposite(3.0), b: withComposite(0) }, // b 在 s2 缺测 → s2 被排除
+      s3: { a: withComposite(3.5), b: withComposite(4.2) },
+    };
+    const report = aggregateReport({
+      runId: 'r', variants: ['a', 'b'], model: 'm', judgeModel: 'haiku', noJudge: true,
+      executorName: 'codex', samples: ['s1', 's2', 's3'].map((id) => makeSample(id, 'task')), tasks: [],
+      results, totalCostUSD: 0, artifacts: [makeArtifact('a', 'a'), makeArtifact('b', 'b')],
+      request: reqBootstrap,
+    });
+    assert.ok(report.meta.pairComparisons?.[0]?.diffBootstrapCI, 's2 缺测但 s1/s3 仍成对 → 仍出配对 diff CI');
+  });
+});


### PR DESCRIPTION
## 这在解决什么（大白话）

测量学审计第 3 条。omk 比较两个 variant（A/B）时，会算一个"差异置信区间"判断显著性。但它用的是**独立重采样**——把 control 的分数和 treatment 的分数当成两组无关的数据。问题是：omk 的 A/B 是**同一批样本**分别过两个 variant，同一个样本被两个 variant 打的分是**正相关**的（难的样本两边都难、简单的两边都简单）。独立法忽略这层相关，把差异的方差算大了，CI 偏宽——也就是**白白损失了检验功效**，本该显著的结论被算成不显著。

`debias-validate`（检测评委长度偏置的工具）尤其错向：它的数据是"同一个回答、两个 judge prompt"的配对，却也用独立法 → 保守只会让它**更难检出**真实的长度偏置，方向正好反了。

## 改了什么

新增 `bootstrapPairedDiffCI`：重采样**样本下标**、对每个重采样的样本同时取两边的分、按"每对之差"求均值——保留了同一样本内的相关性，CI 据此收紧、功效回来了。点估计完全不变，只是 CI 更准。

切配对**三处**：
- 主 A/B 的 verdict diff CI（按 `sample_id` 对齐，两个 variant 在同一样本上都可测才入对）；
- `debias-validate`（显式配对数据，必修）；
- `record-evolve-outcome`（它的职责就是"复刻 eval 管线"，所以跟主 A/B 同口径）。

**刻意保留非配对一处**：evolve 的接受门。那是优化循环里"要不要接受这个候选"的门，独立法偏宽的保守 CI **正是想要的**——抬高接受门槛、不去追配对收紧后冒出来的边际显著增益、防止过拟合到 decision 集。这是有意设计，注释里写明了，不是漏改。

## 影响与测量学说明

CI 收紧（更窄、更准），临界点附近 `significant` 可能从"不显著"变"显著"（这正是要修的——之前在丢功效）。点估计不变。改了 Bootstrap CI 语义，标 **BREAKING-COMPARABILITY**。

新增测试：配对函数（强相关数据下配对 CI 明显窄于独立、恒定差退化到点、点估计与独立法一致、默认确定+空安全）+ `aggregateReport` 配对胶水集成（按样本配对、某样本一侧缺测则该样本不入对）。

验证：`yarn lint && typecheck && build && build:docs:check && test` 全绿（2277，+5 新测试）。这是审计 9 条的第 3 条；前置 PR1/PR2（#270/#271）已合。
