### PR TITLE
fix(grading): 七类 assertion 漏分层导致静默丢分,补全分类 + 穷尽性 gate [BREAKING-COMPARABILITY]

### DIFF
--- a/docs/reference/eval-sample-format.md
+++ b/docs/reference/eval-sample-format.md
@@ -193,6 +193,8 @@ Any assertion takes `not: true` to invert (replaces paired `not_contains` / `not
 
 Children can independently use `not: true`; nested `assert-set`s can express any boolean shape.
 
+> **Layered scoring note.** An `assert-set` is attributed to the fact/behavior layered score only when its leaf children are *homogeneous* — all fact-type or all behavior-type. A **mixed-layer** `assert-set` (e.g. one `contains` + one `max_length`) has no single honest layer, so it is left out of the layered composite (it still counts toward the flat assertion pass/fail). If you want a sample's signal to land in the layered composite, prefer leaf assertions, or keep each `assert-set` within one layer.
+
 ## Custom assertion
 
 ```js

--- a/docs/zh/reference/eval-sample-format.md
+++ b/docs/zh/reference/eval-sample-format.md
@@ -193,6 +193,8 @@
 
 子断言可独立带 `not: true`；嵌套 assert-set 可表达任意布尔逻辑。
 
+> **分层评分提示。** `assert-set` 只在叶子子断言**同层**（全是事实层 / 全是行为层）时才计入 fact / behavior 分层 composite。**混层** `assert-set`（如一条 `contains` + 一条 `max_length`）没有单一可诚实归属的层，故不计入分层 composite（仍计入扁平的断言通过 / 失败）。若想让某条用例的信号落进分层 composite，优先用叶子断言，或让每个 `assert-set` 保持在同一层内。
+
 ## 自定义断言
 
 ```js

--- a/src/eval-core/verdict.ts
+++ b/src/eval-core/verdict.ts
@@ -215,7 +215,10 @@ function verdictForPair(
   const cGate = evaluateLayerGates({ [control]: summary[control] }, gateThreshold);
   const tGate = evaluateLayerGates({ [treatment]: summary[treatment] }, gateThreshold);
 
-  // No bootstrap CI available → fall back to point-estimate diff comparison.
+  // No bootstrap CI available → fall back to point-estimate diff comparison. 这是 `--no-bootstrap` 的**降级
+  // 模式**:bootstrap 默认开,正常路径永远有 CI,这里只在用户显式关掉时触达。降级路径刻意不对称——正 Δ 最多给
+  // CAUTIOUS(没 CI 不敢判 PROGRESS),负 Δ 直接 REGRESS(不做显著性检验)。这对"检测变差"是保守安全方向(宁可
+  // 误报回归也别漏掉),代价是把噪声级的负 Δ 也叫 REGRESS;要严谨结论就别关 bootstrap。
   if (!diff) {
     const cMean = avgComposite(summary[control]);
     const tMean = avgComposite(summary[treatment]);
@@ -332,7 +335,10 @@ function ensembleDissent(
 function avgComposite(s: VariantSummary | undefined): number {
   if (!s) return 0;
   if (typeof s.avgCompositeScore === 'number') return s.avgCompositeScore;
-  // Fallback: average of the three layers when composite isn't on the summary.
+  // 兜底:summary 无 avgCompositeScore 时,用三层均值近似。**有偏**:真 composite 是 per-sample
+  // (present-layers 均值)再跨 sample 平均;这里是「跨 sample 的层均值」再跨层平均,各层在不同 sample 上缺失
+  // 不均时两者不等(Jensen / 分母不一致)。仅 no-bootstrap 降级路径 + summary 缺 composite 的老报告才触达
+  // (默认开 bootstrap、新报告必带 avgCompositeScore,故极罕见),不值得回填 per-sample 重算 —— 标注保留近似。
   const layers = [s.avgFactScore, s.avgBehaviorScore, s.avgJudgeScore].filter(
     (x): x is number => typeof x === 'number',
   );

--- a/src/grading/assertions.ts
+++ b/src/grading/assertions.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import _Ajv from 'ajv';
 import type { Assertion, AssertionDetail, AssertionResults, ExecutorFn, Sample, ToolCallInfo } from '../types/index.js';
+import { ASSERTION_LAYER } from './layered-scores.js';
 
 const Ajv = _Ajv.default ?? _Ajv;
 const ajv = new Ajv();
@@ -290,6 +291,29 @@ function evalAssertion(
   }
 }
 
+/**
+ * assert-set 是布尔组合器,不是叶子断言,没有静态的「层」。它在 runAssertions 里只产出一条聚合明细
+ * (`type: 'assert-set'`、aggregate pass/fail),computeLayeredScores 无法据此判 fact / behavior。
+ * 这里在 grading 期(能看到 children 树时)按**叶子子断言**的层解析:递归收集所有叶子(穿透嵌套 assert-set),
+ *   - 同层(全 fact 或全 behavior)→ 返回该层:聚合 pass/fail 归这一层,与 any/all 模式无关(同层信号无歧义)。
+ *   - 混层 / 空 / 含未分类叶子 → 返回 undefined:不归层(混层组合器塞进单层会引入口径偏差,诚实做法是不计入分层)。
+ * 解析结果落到 detail.layer,computeLayeredScores 优先读它。
+ */
+function resolveAssertSetLayer(assertion: Assertion): 'fact' | 'behavior' | undefined {
+  const layers = new Set<'fact' | 'behavior' | 'unknown'>();
+  const collect = (a: Assertion): void => {
+    if (a.type === 'assert-set') {
+      for (const c of a.children ?? []) collect(c);
+      return;
+    }
+    layers.add(ASSERTION_LAYER[a.type] ?? 'unknown');
+  };
+  collect(assertion);
+  if (layers.size !== 1) return undefined; // 0 / 混层 → 不归层
+  const [only] = [...layers];
+  return only === 'unknown' ? undefined : only;
+}
+
 export function runAssertions(
   output: string,
   assertions: Assertion[],
@@ -305,11 +329,14 @@ export function runAssertions(
     const weight = assertion.weight ?? 1;
     const raw = evalAssertion(output, assertion, ctx);
     const passed = assertion.not ? !raw : raw;
+    // assert-set 组合器:在此(能看到 children)解析其层,供 computeLayeredScores 用;叶子断言按静态映射归层、不带 layer。
+    const layer = assertion.type === 'assert-set' ? resolveAssertSetLayer(assertion) : undefined;
     details.push({
       type: assertion.type,
       value: assertion.value ?? assertion.pattern ?? assertion.values?.join(', ') ?? '',
       weight,
       passed,
+      ...(layer ? { layer } : {}),
     });
   }
 

--- a/src/grading/layered-scores.ts
+++ b/src/grading/layered-scores.ts
@@ -8,7 +8,8 @@ import type { AssertionDetail, LayeredScores } from '../types/index.js';
  *
  * 不变量:**runner 支持的每个 assertion 类型(`assertions.ts` 的 evalAssertion switch + ASYNC_ASSERTION_TYPES)
  * 都必须在此分类**,否则该类型的 pass/fail 会被 computeLayeredScores 从 fact 与 behavior 同时漏掉 —— 既不报错
- * 也不进 composite,静默丢分(曾漏掉 mock_hit / rouge_n_min / bleu_min / levenshtein_max 四类)。
+ * 也不进 composite,静默丢分(曾漏掉七类:mock_hit / rouge_n_min / bleu_min / levenshtein_max + RAG 三件套
+ * faithfulness / answer_relevancy / context_recall)。
  * `test/grading/layered-scores-exhaustiveness.test.ts` 扫 runner 源 + ASYNC 集守住这条:新增类型未分类即 CI 失败。
  */
 export const ASSERTION_LAYER: Record<string, 'fact' | 'behavior'> = {

--- a/src/grading/layered-scores.ts
+++ b/src/grading/layered-scores.ts
@@ -1,38 +1,56 @@
 import type { AssertionDetail, LayeredScores } from '../types/index.js';
 
-const FACTUAL_ASSERTION_TYPES = new Set([
-  'contains',
-  'not_contains',
-  'regex',
-  'json_valid',
-  'json_schema',
-  'equals',
-  'not_equals',
-  'contains_all',
-  'contains_any',
-  'semantic_similarity',
-  'tool_output_contains',
-  'tool_input_contains',
-  'tool_input_not_contains',
-]);
-
-const BEHAVIORAL_ASSERTION_TYPES = new Set([
-  'starts_with',
-  'ends_with',
-  'min_length',
-  'max_length',
-  'word_count_min',
-  'word_count_max',
-  'cost_max',
-  'latency_max',
-  'turns_min',
-  'turns_max',
-  'tools_called',
-  'tools_not_called',
-  'tools_count_min',
-  'tools_count_max',
-  'custom',
-]);
+/**
+ * 每个 assertion 类型归到事实层 / 行为层。**单一来源**:`computeLayeredScores` 据此把 assertion 明细拆进
+ * fact / behavior 两层算分。
+ *   - **事实层(fact)**:测输出内容对不对 —— 命中 / 匹配 / 结构合法 / 与参考的文本相似度。
+ *   - **行为层(behavior)**:测做事的方式 —— 长度 / 成本 / 轮次 / 工具调用 / 必经里程碑,不看内容本身。
+ *
+ * 不变量:**runner 支持的每个 assertion 类型(`assertions.ts` 的 evalAssertion switch + ASYNC_ASSERTION_TYPES)
+ * 都必须在此分类**,否则该类型的 pass/fail 会被 computeLayeredScores 从 fact 与 behavior 同时漏掉 —— 既不报错
+ * 也不进 composite,静默丢分(曾漏掉 mock_hit / rouge_n_min / bleu_min / levenshtein_max 四类)。
+ * `test/grading/layered-scores-exhaustiveness.test.ts` 扫 runner 源 + ASYNC 集守住这条:新增类型未分类即 CI 失败。
+ */
+export const ASSERTION_LAYER: Record<string, 'fact' | 'behavior'> = {
+  contains: 'fact',
+  not_contains: 'fact',
+  regex: 'fact',
+  json_valid: 'fact',
+  json_schema: 'fact',
+  equals: 'fact',
+  not_equals: 'fact',
+  contains_all: 'fact',
+  contains_any: 'fact',
+  semantic_similarity: 'fact',
+  tool_output_contains: 'fact',
+  tool_input_contains: 'fact',
+  tool_input_not_contains: 'fact',
+  // 文本相似度指标:衡量输出与参考答案的内容贴合度 = 内容保真 → 事实层。
+  rouge_n_min: 'fact',
+  bleu_min: 'fact',
+  levenshtein_max: 'fact',
+  // RAG 评委指标:都评输出内容质量(忠实度 / 答非所问 / 关键事实召回),= 内容正确性 → 事实层。
+  faithfulness: 'fact',
+  answer_relevancy: 'fact',
+  context_recall: 'fact',
+  starts_with: 'behavior',
+  ends_with: 'behavior',
+  min_length: 'behavior',
+  max_length: 'behavior',
+  word_count_min: 'behavior',
+  word_count_max: 'behavior',
+  cost_max: 'behavior',
+  latency_max: 'behavior',
+  turns_min: 'behavior',
+  turns_max: 'behavior',
+  tools_called: 'behavior',
+  tools_not_called: 'behavior',
+  tools_count_min: 'behavior',
+  tools_count_max: 'behavior',
+  custom: 'behavior',
+  // 必经工具 / 步骤里程碑(value 形如 "Tool:N"):测"有没有走到那一步" = 做事方式 → 行为层(类同 tools_called)。
+  mock_hit: 'behavior',
+};
 
 function ratioToScore(ratio: number): number {
   return Number((1 + ratio * 4).toFixed(2));
@@ -55,8 +73,8 @@ export function computeLayeredScores(results: CompositeInput): { compositeScore:
   const layered: LayeredScores = {};
 
   if (results.assertions?.details) {
-    const factDetails = results.assertions.details.filter((d) => FACTUAL_ASSERTION_TYPES.has(d.type));
-    const behaviorDetails = results.assertions.details.filter((d) => BEHAVIORAL_ASSERTION_TYPES.has(d.type));
+    const factDetails = results.assertions.details.filter((d) => ASSERTION_LAYER[d.type] === 'fact');
+    const behaviorDetails = results.assertions.details.filter((d) => ASSERTION_LAYER[d.type] === 'behavior');
     layered.factScore = scoreFromDetails(factDetails) ?? undefined;
     layered.behaviorScore = scoreFromDetails(behaviorDetails) ?? undefined;
   }

--- a/src/grading/layered-scores.ts
+++ b/src/grading/layered-scores.ts
@@ -6,11 +6,13 @@ import type { AssertionDetail, LayeredScores } from '../types/index.js';
  *   - **事实层(fact)**:测输出内容对不对 —— 命中 / 匹配 / 结构合法 / 与参考的文本相似度。
  *   - **行为层(behavior)**:测做事的方式 —— 长度 / 成本 / 轮次 / 工具调用 / 必经里程碑,不看内容本身。
  *
- * 不变量:**runner 支持的每个 assertion 类型(`assertions.ts` 的 evalAssertion switch + ASYNC_ASSERTION_TYPES)
- * 都必须在此分类**,否则该类型的 pass/fail 会被 computeLayeredScores 从 fact 与 behavior 同时漏掉 —— 既不报错
- * 也不进 composite,静默丢分(曾漏掉七类:mock_hit / rouge_n_min / bleu_min / levenshtein_max + RAG 三件套
- * faithfulness / answer_relevancy / context_recall)。
- * `test/grading/layered-scores-exhaustiveness.test.ts` 扫 runner 源 + ASYNC 集守住这条:新增类型未分类即 CI 失败。
+ * 不变量:**runner 支持的每个 assertion 类型都必须能被归层**,否则该类型的 pass/fail 会被 computeLayeredScores
+ * 从 fact 与 behavior 同时漏掉 —— 既不报错也不进 composite,静默丢分(曾漏掉七类:mock_hit / rouge_n_min /
+ * bleu_min / levenshtein_max + RAG 三件套 faithfulness / answer_relevancy / context_recall)。叶子断言在此静态
+ * 分类;组合器 `assert-set` 没有静态层,由 `assertions.ts` 的 resolveAssertSetLayer 在 grading 期按其叶子 children
+ * 解析(同层→归层、混层→不计),结果落 detail.layer。`test/grading/layered-scores-exhaustiveness.test.ts` 扫
+ * runner 源(evalAssertion 的 case ∪ `assertion.type ===` 组合器 ∪ ASYNC_ASSERTION_TYPES)守住:新增类型既不在本
+ * 映射、又不是已知组合器,即 CI 失败。
  */
 export const ASSERTION_LAYER: Record<string, 'fact' | 'behavior'> = {
   contains: 'fact',
@@ -74,8 +76,11 @@ export function computeLayeredScores(results: CompositeInput): { compositeScore:
   const layered: LayeredScores = {};
 
   if (results.assertions?.details) {
-    const factDetails = results.assertions.details.filter((d) => ASSERTION_LAYER[d.type] === 'fact');
-    const behaviorDetails = results.assertions.details.filter((d) => ASSERTION_LAYER[d.type] === 'behavior');
+    // 优先用 detail.layer(组合器如 assert-set 在 grading 期按 children 解析出的层;混层组合器无 layer → 两层都不计,
+    // 见 assertions.ts resolveAssertSetLayer);叶子断言无 layer,退回静态 ASSERTION_LAYER[type]。
+    const layerOf = (d: AssertionDetail): 'fact' | 'behavior' | undefined => d.layer ?? ASSERTION_LAYER[d.type];
+    const factDetails = results.assertions.details.filter((d) => layerOf(d) === 'fact');
+    const behaviorDetails = results.assertions.details.filter((d) => layerOf(d) === 'behavior');
     layered.factScore = scoreFromDetails(factDetails) ?? undefined;
     layered.behaviorScore = scoreFromDetails(behaviorDetails) ?? undefined;
   }

--- a/src/types/judge.ts
+++ b/src/types/judge.ts
@@ -148,6 +148,14 @@ export interface AssertionDetail {
   weight: number;
   passed: boolean;
   message?: string;
+  /**
+   * Layer override for `computeLayeredScores`. Only set for combinator types whose layer is not a
+   * static property of `type` — currently `assert-set`, whose layer is resolved at grading time from
+   * its leaf children: homogeneous (all fact / all behavior) → that layer; mixed (or empty) → field
+   * left unset so the combinator is excluded from layered attribution (no single layer is honest).
+   * Leaf assertions never set this; they classify by `ASSERTION_LAYER[type]`.
+   */
+  layer?: 'fact' | 'behavior';
 }
 
 export interface AssertionResults {

--- a/test/evaluation/evaluation-reporting.test.ts
+++ b/test/evaluation/evaluation-reporting.test.ts
@@ -415,4 +415,28 @@ describe('aggregateReport — 多重比较 Bonferroni 校正(#235 审计 PR4)', 
     assert.equal(k3.length, 3);
     for (const p of k3) assert.ok(Math.abs(p.alpha! - 0.05 / 3) < 1e-12, `每对 α 应 ≈ α/3,实得 ${p.alpha}`);
   });
+
+  it('实锤:边界对在 K=1 显著,纳入 K=2(α/2)后翻为不显著 —— family-wise 假阳被压下', () => {
+    // 这组配对差在默认种子下,α=0.05 的 CI 下界 +0.025(显著)、α/2=0.025 的下界 −0.017(含 0,不显著)——
+    // 正是多重比较该挡的边界假阳性。a 取常量 3.0、b = 3.0 + diff(全 > 0 成对);第三个 treatment c 只为把 K 撑到 2。
+    const diffs = [0.35, 0.25, 0.45, -0.45, 0.35, 0.55, -0.35, 0.35, 0.65, -0.15, 0.45, 0.35];
+    const fids = diffs.map((_, i) => `f${i + 1}`);
+    const mk = (variants: string[]) => aggregateReport({
+      runId: 'r', variants, model: 'm', judgeModel: 'haiku', noJudge: true, executorName: 'codex',
+      samples: fids.map((id) => makeSample(id, 'task')), tasks: [],
+      results: Object.fromEntries(fids.map((id, i) => {
+        const row: Record<string, VariantResult> = { a: withComposite(3.0), b: withComposite(3.0 + diffs[i]) };
+        if (variants.includes('c')) row.c = withComposite(3.1);
+        return [id, row];
+      })),
+      totalCostUSD: 0, artifacts: variants.map((v) => makeArtifact(v, v)), request: reqBootstrap,
+    });
+    const ab1 = mk(['a', 'b']).meta.pairComparisons!.find((p) => p.treatment === 'b')!;
+    const ab2 = mk(['a', 'b', 'c']).meta.pairComparisons!.find((p) => p.treatment === 'b')!;
+    assert.equal(ab1.alpha, undefined, 'K=1 名义 α');
+    assert.equal(ab1.diffBootstrapCI!.significant, true, 'K=1(α=0.05)边界对显著');
+    assert.equal(ab2.alpha, 0.05 / 2, 'K=2 → α/2');
+    assert.equal(ab2.diffBootstrapCI!.significant, false, 'K=2(α/2=0.025)同一份 (a,b) 翻为不显著 → 假阳被压下');
+    assert.equal(ab1.diffBootstrapCI!.estimate, ab2.diffBootstrapCI!.estimate, '点估计与 K 无关,不变');
+  });
 });

--- a/test/grading/layered-scores-exhaustiveness.test.ts
+++ b/test/grading/layered-scores-exhaustiveness.test.ts
@@ -1,0 +1,50 @@
+/**
+ * assertion 类型分层穷尽性 gate。
+ *
+ * `computeLayeredScores` 按 `ASSERTION_LAYER` 把每条 assertion 明细拆进 fact / behavior 两层。runner
+ * (`assertions.ts`)支持的某个类型若不在 `ASSERTION_LAYER` 里,它的 pass/fail 会被两层同时漏掉 —— 既不
+ * 报错、也不进 composite,静默丢分。曾因此漏掉 mock_hit / rouge_n_min / bleu_min / levenshtein_max 四类。
+ *
+ * 机制:扫 runner 真源拿到"实际支持的全部类型" = evalAssertion 的 `case '<type>':` ∪ ASYNC_ASSERTION_TYPES,
+ * 断言每一个都在 `ASSERTION_LAYER` 有分类。新增 case 而忘了分类 → 本测试失败,挡在合并前。
+ * 与 `doc-constants-drift.test.ts` 同属"扫源防漂移"一类 gate。
+ */
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ASSERTION_LAYER, computeLayeredScores } from '../../src/grading/layered-scores.js';
+import { ASYNC_ASSERTION_TYPES } from '../../src/grading/assertions.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ASSERTIONS_SRC = join(__dirname, '..', '..', 'src', 'grading', 'assertions.ts');
+
+/** runner 实际支持的全部 assertion 类型:evalAssertion 的 case 字面量 ∪ 异步类型集。 */
+function supportedAssertionTypes(): string[] {
+  const src = readFileSync(ASSERTIONS_SRC, 'utf8');
+  const syncCases = [...src.matchAll(/case '([a-z_]+)':/g)].map((m) => m[1]);
+  assert.ok(syncCases.length >= 25, `evalAssertion 的 case 没扫到(实得 ${syncCases.length}),正则或源结构可能变了`);
+  return [...new Set([...syncCases, ...ASYNC_ASSERTION_TYPES])];
+}
+
+describe('assertion 类型分层穷尽性', () => {
+  it('runner 支持的每个 assertion 类型都在 ASSERTION_LAYER 分类(fact|behavior),无静默漏层', () => {
+    const unclassified = supportedAssertionTypes().filter((t) => ASSERTION_LAYER[t] !== 'fact' && ASSERTION_LAYER[t] !== 'behavior');
+    assert.deepEqual(unclassified, [], `这些 runner 支持的类型未分层,会被 computeLayeredScores 静默丢分:${unclassified.join(', ')}`);
+  });
+
+  it('曾被漏掉的四类如今进 composite(回归):文本相似度→fact,mock_hit→behavior', () => {
+    const detail = (type: string) => ({ type, value: '', weight: 1, passed: true });
+    for (const t of ['rouge_n_min', 'bleu_min', 'levenshtein_max']) {
+      const { layeredScores, compositeScore } = computeLayeredScores({ assertions: { details: [detail(t)] } });
+      assert.equal(layeredScores.factScore, 5, `${t} 应进事实层(全通过 → 5)`);
+      assert.equal(layeredScores.behaviorScore, undefined, `${t} 不应进行为层`);
+      assert.equal(compositeScore, 5, `${t} 应计入 composite,而非被丢成 0`);
+    }
+    const mock = computeLayeredScores({ assertions: { details: [detail('mock_hit')] } });
+    assert.equal(mock.layeredScores.behaviorScore, 5, 'mock_hit 应进行为层');
+    assert.equal(mock.layeredScores.factScore, undefined, 'mock_hit 不应进事实层');
+    assert.equal(mock.compositeScore, 5, 'mock_hit 应计入 composite');
+  });
+});

--- a/test/grading/layered-scores-exhaustiveness.test.ts
+++ b/test/grading/layered-scores-exhaustiveness.test.ts
@@ -3,7 +3,8 @@
  *
  * `computeLayeredScores` 按 `ASSERTION_LAYER` 把每条 assertion 明细拆进 fact / behavior 两层。runner
  * (`assertions.ts`)支持的某个类型若不在 `ASSERTION_LAYER` 里,它的 pass/fail 会被两层同时漏掉 —— 既不
- * 报错、也不进 composite,静默丢分。曾因此漏掉 mock_hit / rouge_n_min / bleu_min / levenshtein_max 四类。
+ * 报错、也不进 composite,静默丢分。曾因此漏掉七类:mock_hit / rouge_n_min / bleu_min / levenshtein_max +
+ * RAG 三件套 faithfulness / answer_relevancy / context_recall。
  *
  * 机制:扫 runner 真源拿到"实际支持的全部类型" = evalAssertion 的 `case '<type>':` ∪ ASYNC_ASSERTION_TYPES,
  * 断言每一个都在 `ASSERTION_LAYER` 有分类。新增 case 而忘了分类 → 本测试失败,挡在合并前。
@@ -34,9 +35,10 @@ describe('assertion 类型分层穷尽性', () => {
     assert.deepEqual(unclassified, [], `这些 runner 支持的类型未分层,会被 computeLayeredScores 静默丢分:${unclassified.join(', ')}`);
   });
 
-  it('曾被漏掉的四类如今进 composite(回归):文本相似度→fact,mock_hit→behavior', () => {
+  it('曾被漏掉的七类如今进 composite(回归):文本相似度 + RAG 三件套→fact,mock_hit→behavior', () => {
     const detail = (type: string) => ({ type, value: '', weight: 1, passed: true });
-    for (const t of ['rouge_n_min', 'bleu_min', 'levenshtein_max']) {
+    // 文本相似度 + RAG 内容质量都判事实层。
+    for (const t of ['rouge_n_min', 'bleu_min', 'levenshtein_max', 'faithfulness', 'answer_relevancy', 'context_recall']) {
       const { layeredScores, compositeScore } = computeLayeredScores({ assertions: { details: [detail(t)] } });
       assert.equal(layeredScores.factScore, 5, `${t} 应进事实层(全通过 → 5)`);
       assert.equal(layeredScores.behaviorScore, undefined, `${t} 不应进行为层`);

--- a/test/grading/layered-scores-exhaustiveness.test.ts
+++ b/test/grading/layered-scores-exhaustiveness.test.ts
@@ -30,7 +30,12 @@ const ASSERTIONS_SRC = join(__dirname, '..', '..', 'src', 'grading', 'assertions
  */
 const LAYER_COMBINATORS = new Set(['assert-set']);
 
-/** runner 实际支持的全部 assertion 类型:case 字面量 ∪ pre-switch 组合器比较 ∪ 异步类型集(含连字符)。 */
+/**
+ * runner 实际支持的全部 assertion 类型:case 字面量 ∪ pre-switch 组合器比较 ∪ 异步类型集(含连字符)。
+ * 两条 idiom 锚得很死:`case '<type>':` 是 switch 分派,`assertion.type === '<type>'` 按定义就是「这条断言
+ * 是不是 <type>」的类型分派 —— 字面量恒为真实类型,不会误捕(正则限定 `assertion.type` 标识符,不匹配别的
+ * `xxx.type`)。两种 idiom 之外若再冒出第三种分派方式,caseTypes 数量守卫会先炸,逼这里同步。
+ */
 function supportedAssertionTypes(): string[] {
   const src = readFileSync(ASSERTIONS_SRC, 'utf8');
   const caseTypes = [...src.matchAll(/case '([a-z_-]+)':/g)].map((m) => m[1]);
@@ -67,6 +72,16 @@ describe('assertion 类型分层穷尽性', () => {
     assert.equal(mixed.layeredScores.factScore, undefined, '混层 assert-set 不进事实层');
     assert.equal(mixed.layeredScores.behaviorScore, undefined, '混层 assert-set 不进行为层');
     assert.equal(mixed.compositeScore, 0, '混层组合器无单层可归 → 不计入分层(诚实,不塞单层引偏差)');
+  });
+
+  it('detail.layer 契约:仅同层组合器明细带 layer(随报告持久化为归属溯源);叶子 / 混层 / 非组合器一律不带', () => {
+    // layer 是 assert-set 唯一的「层」载体(聚合明细是 grading→持久化的同一对象,叶子 children 不单独成明细),
+    // 故有意落到 detail 上。本用例钉死它「只在同层组合器明细出现」的契约,把它从偶发字段变成受测的对外 schema 面。
+    const layerOfFirst = (a: Assertion): unknown => runAssertions('hello world', [a]).details[0].layer;
+    assert.equal(layerOfFirst({ type: 'assert-set', mode: 'all', children: [{ type: 'contains', value: 'hello' }, { type: 'contains', value: 'world' }] }), 'fact', '同层(fact)组合器 → layer=fact');
+    assert.equal(layerOfFirst({ type: 'assert-set', mode: 'all', children: [{ type: 'min_length', value: 1 }, { type: 'max_length', value: 99 }] }), 'behavior', '同层(behavior)组合器 → layer=behavior');
+    assert.equal(layerOfFirst({ type: 'assert-set', mode: 'all', children: [{ type: 'contains', value: 'hello' }, { type: 'max_length', value: 99 }] }), undefined, '混层组合器 → 不带 layer(交由静态映射,而它无 assert-set 条目 → 不计)');
+    assert.equal(layerOfFirst({ type: 'contains', value: 'hello' }), undefined, '叶子断言绝不带 layer(按静态 ASSERTION_LAYER 归层)');
   });
 
   it('曾被漏掉的七类如今进 composite(回归):文本相似度 + RAG 三件套→fact,mock_hit→behavior', () => {

--- a/test/grading/layered-scores-exhaustiveness.test.ts
+++ b/test/grading/layered-scores-exhaustiveness.test.ts
@@ -6,9 +6,11 @@
  * 报错、也不进 composite,静默丢分。曾因此漏掉七类:mock_hit / rouge_n_min / bleu_min / levenshtein_max +
  * RAG 三件套 faithfulness / answer_relevancy / context_recall。
  *
- * 机制:扫 runner 真源拿到"实际支持的全部类型" = evalAssertion 的 `case '<type>':` ∪ ASYNC_ASSERTION_TYPES,
- * 断言每一个都在 `ASSERTION_LAYER` 有分类。新增 case 而忘了分类 → 本测试失败,挡在合并前。
- * 与 `doc-constants-drift.test.ts` 同属"扫源防漂移"一类 gate。
+ * 机制:扫 runner 真源拿到"实际支持的全部类型" = evalAssertion 的 `case '<type>':` ∪ pre-switch 组合器
+ * (`assertion.type === '<type>'`,如 assert-set)∪ ASYNC_ASSERTION_TYPES,断言每一个**要么在 ASSERTION_LAYER
+ * 静态分类、要么是已知组合器**(运行时按 children 解析层,见 resolveAssertSetLayer)。新增类型两者都不沾 → 失败,
+ * 挡在合并前。曾因只扫 `case` 漏掉 pre-switch 的 assert-set(复审 P2)。与 `doc-constants-drift.test.ts` 同属
+ * "扫源防漂移"一类 gate。
  */
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
@@ -16,23 +18,55 @@ import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ASSERTION_LAYER, computeLayeredScores } from '../../src/grading/layered-scores.js';
-import { ASYNC_ASSERTION_TYPES } from '../../src/grading/assertions.js';
+import { ASYNC_ASSERTION_TYPES, runAssertions } from '../../src/grading/assertions.js';
+import type { Assertion } from '../../src/types/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ASSERTIONS_SRC = join(__dirname, '..', '..', 'src', 'grading', 'assertions.ts');
 
-/** runner 实际支持的全部 assertion 类型:evalAssertion 的 case 字面量 ∪ 异步类型集。 */
+/**
+ * 组合器类型:无静态层,由 grading 期按 children 解析(resolveAssertSetLayer)。穷尽性 gate 认它们「已处理」,
+ * 但仍要求被扫描覆盖(否则又成盲区)。
+ */
+const LAYER_COMBINATORS = new Set(['assert-set']);
+
+/** runner 实际支持的全部 assertion 类型:case 字面量 ∪ pre-switch 组合器比较 ∪ 异步类型集(含连字符)。 */
 function supportedAssertionTypes(): string[] {
   const src = readFileSync(ASSERTIONS_SRC, 'utf8');
-  const syncCases = [...src.matchAll(/case '([a-z_]+)':/g)].map((m) => m[1]);
-  assert.ok(syncCases.length >= 25, `evalAssertion 的 case 没扫到(实得 ${syncCases.length}),正则或源结构可能变了`);
-  return [...new Set([...syncCases, ...ASYNC_ASSERTION_TYPES])];
+  const caseTypes = [...src.matchAll(/case '([a-z_-]+)':/g)].map((m) => m[1]);
+  const eqTypes = [...src.matchAll(/assertion\.type === '([a-z_-]+)'/g)].map((m) => m[1]);
+  assert.ok(caseTypes.length >= 25, `evalAssertion 的 case 没扫到(实得 ${caseTypes.length}),正则或源结构可能变了`);
+  return [...new Set([...caseTypes, ...eqTypes, ...ASYNC_ASSERTION_TYPES])];
 }
 
 describe('assertion 类型分层穷尽性', () => {
-  it('runner 支持的每个 assertion 类型都在 ASSERTION_LAYER 分类(fact|behavior),无静默漏层', () => {
-    const unclassified = supportedAssertionTypes().filter((t) => ASSERTION_LAYER[t] !== 'fact' && ASSERTION_LAYER[t] !== 'behavior');
-    assert.deepEqual(unclassified, [], `这些 runner 支持的类型未分层,会被 computeLayeredScores 静默丢分:${unclassified.join(', ')}`);
+  it('runner 支持的每个 assertion 类型都能归层(静态分类或已知组合器),无静默漏层', () => {
+    const unhandled = supportedAssertionTypes().filter(
+      (t) => ASSERTION_LAYER[t] !== 'fact' && ASSERTION_LAYER[t] !== 'behavior' && !LAYER_COMBINATORS.has(t),
+    );
+    assert.deepEqual(unhandled, [], `这些 runner 支持的类型既未静态分层、又非已知组合器,会被静默丢分:${unhandled.join(', ')}`);
+  });
+
+  it('扫描确实抓到了 pre-switch 组合器 assert-set(防回归:复审 P2 的盲区)', () => {
+    assert.ok(supportedAssertionTypes().includes('assert-set'), 'assert-set 必须进入待校验集,否则 gate 又有盲区');
+  });
+
+  it('assert-set 同层 children → 聚合归该层进 composite;混层 → 不计入分层(无口径偏差)', () => {
+    const layered = (a: Assertion) => computeLayeredScores({ assertions: { details: runAssertions('hello world foo', [a]).details } });
+    // 同为事实层(contains / equals):归事实层。
+    const allFact = layered({ type: 'assert-set', mode: 'all', children: [{ type: 'contains', value: 'hello' }, { type: 'contains', value: 'world' }] });
+    assert.equal(allFact.layeredScores.factScore, 5, '同层(fact)assert-set 全通过 → 事实层 5');
+    assert.equal(allFact.layeredScores.behaviorScore, undefined, '不应进行为层');
+    assert.equal(allFact.compositeScore, 5, '同层 assert-set 必须计入 composite,而非被丢成 0');
+    // 同为行为层(min_length / max_length):归行为层。
+    const allBehavior = layered({ type: 'assert-set', mode: 'all', children: [{ type: 'min_length', value: 1 }, { type: 'max_length', value: 999 }] });
+    assert.equal(allBehavior.layeredScores.behaviorScore, 5, '同层(behavior)assert-set → 行为层 5');
+    assert.equal(allBehavior.layeredScores.factScore, undefined, '不应进事实层');
+    // 混层(contains=fact + max_length=behavior):不归任何层 → 不计入 composite(无单层可诚实归属)。
+    const mixed = layered({ type: 'assert-set', mode: 'all', children: [{ type: 'contains', value: 'hello' }, { type: 'max_length', value: 999 }] });
+    assert.equal(mixed.layeredScores.factScore, undefined, '混层 assert-set 不进事实层');
+    assert.equal(mixed.layeredScores.behaviorScore, undefined, '混层 assert-set 不进行为层');
+    assert.equal(mixed.compositeScore, 0, '混层组合器无单层可归 → 不计入分层(诚实,不塞单层引偏差)');
   });
 
   it('曾被漏掉的七类如今进 composite(回归):文本相似度 + RAG 三件套→fact,mock_hit→behavior', () => {


### PR DESCRIPTION
## 这在解决什么

omk 的五层评分把每条 assertion 按类型拆进「事实层」(测内容对不对)或「行为层」(测做事方式)。问题是:分层用的两个类型集是手写的,漏了 runner 实际支持的**七类** assertion。这些类型照常判 pass/fail、照常进明细,却在分层时**两层都没接住** —— 不报错、也不计入 composite,就这么静默丢掉了。

漏掉的七类里有两类很要命:`mock_hit`(omk 自己的用例生成器把它当 agent 用例断言的骨干 —— 「必经工具/步骤里程碑」基本都靠它)和整套 RAG 评委指标(`faithfulness` / `answer_relevancy` / `context_recall`)。也就是说,凡是用 mock_hit 锚定步骤的 agent 评测、以及所有 RAG 评测,它们的事实/行为/composite 分之前都被系统性低估,甚至当成「这条用例没有可测层」直接丢掉。

本来这是「审计收尾」PR 里一条「加个防漏的护栏」的小任务 —— 结果护栏一上,当场抓出这七类已经在漏。

## 改动

把手写的两个类型集合并成单一 `ASSERTION_LAYER` 映射,补全七类:文本相似度(`rouge_n_min` / `bleu_min` / `levenshtein_max`)与 RAG 内容质量(`faithfulness` / `answer_relevancy` / `context_recall`)归事实层;`mock_hit`(工具/步骤里程碑,测「有没有走到那一步」)归行为层。

新增 `test/grading/layered-scores-exhaustiveness.test.ts`:扫 runner 真源(`evalAssertion` 的 case ∪ `ASYNC_ASSERTION_TYPES`),断言每个被支持的类型都已分层。以后谁加新断言类型却忘了分层,CI 直接红 —— 这类静默漏分不会再发生。

附带两条非破坏收尾:`verdict` 的 `avgComposite` 兜底近似有偏、no-bootstrap 降级路径正负不对称,各补一段注释讲清取舍(不改行为);再补一条 Bonferroni 的「显著性翻转」端到端用例(同一对比较 K=1 显著、纳入 K=2 后按 α/2 翻为不显著)。

## 用户影响 / 迁移

凡用到这七类 assertion 的报告,其 fact / behavior / composite 与 verdict 可能变化(普遍是**变高或从「无数据」变为有分**,因为之前被漏掉的通过项现在计入了)。mock_hit 密集的 agent 评测、RAG 评测受影响最明显。这是修正,不是回归:之前的分数是错的(漏算)。

## 测量学 caveat

标 `BREAKING-COMPARABILITY`:composite / verdict 口径变了,新旧报告对这些断言类型不可直接对比。未碰任何 prompt 文本,judge / observe 冻结 hash 不动。

属 #235 测量学有效性审计的收尾(第 5 步),衔接已合并的 #270 / #271 / #272 / #273。原计划里「`significant` 在 round4 之前判」一条已**作废**:#272 复审已证明那样会造出自相矛盾的 CI(`low:0` 却 `significant:true`),现有「先舍入再判」才对。至此审计九条问题全部落地,可统一发一次 minor(0.40.0)。