### PR TITLE
chore(release): 发布 0.40.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
0.40.0 版本号 bump。本次 minor 收口**测量学有效性审计「第一条轴」**——评分 / 判定核心的九条问题,分五个 PR 全部 `BREAKING-COMPARABILITY`,已先后合入 main:

- `#270` 统一 `score=0` 语义:评委失败=缺测,不再当 0 分污染 composite。
- `#271` bootstrap CI 默认确定性种子:消除 verdict 在临界点的 run-to-run 翻转。
- `#272` 配对设计改用配对 bootstrap:收回被独立重采样浪费的功效。
- `#273` verdict 稳健性:多重比较 Bonferroni α/K 校正 + 稳定性 CV 门控。
- `#274` 修复七类 + `assert-set` 组合器漏分层导致的静默丢分 + 穷尽性 gate。

## 迁移说明

跨版本可比性边界:0.40.0 之前与之后的报告,其 `compositeScore` / `significant` / verdict 口径已变,**不可直接对比**。受影响最明显的是:用 `mock_hit` / RAG 指标 / 文本相似度 / `assert-set` 断言的用例(此前被漏算,现计入分层 composite);多 treatment(K≥3)报告的显著性(现按 Bonferroni 收紧);多轮且不稳(median CV>15%)的 PROGRESS(现降为 CAUTIOUS)。

未触碰任何 prompt 文本,judge / observe 的冻结 hash 不变。明细见各 PR description。