### PR TITLE
feat(judge): 评委 prompt 加排版 / 语气中性化指令(BREAKING-COMPARABILITY)

### DIFF
--- a/docs/explanation/statistical-rigor.md
+++ b/docs/explanation/statistical-rigor.md
@@ -39,13 +39,13 @@ The same logic applies on the judge-vs-output axis: if the judge is the same mod
 
 **Formula**: standard Krippendorff α with ordinal distance metric. Implementation: `src/grading/human-gold.ts`. Inputs: `<gold-dir>/<sample_id>.json` files with human scores per dimension.
 
-## 3. Length-controlled judge prompt(default ON)
+## 3. Debiased judge prompt: length / presentation / tone (default ON)
 
-**Research shows LLM judges over-weight verbosity.** Longer responses get higher scores, independent of quality. omk's judge prompt explicitly states "length is not a quality signal" + uses chain-of-thought + length normalization heuristics.
+**Research shows LLM judges over-weight verbosity, polished formatting, and confident tone** — longer, prettier, more assertive answers score higher independent of quality (format / markdown bias; sycophancy / authority bias). omk's judge prompt explicitly states both "length is not a quality signal" and "presentation and tone are not quality signals" + uses chain-of-thought against the rubric. The wording is deliberately symmetric — it neither rewards polish/confidence nor penalizes plainness/hedging — so the debias instruction does not over-correct into a reverse bias.
 
-- Template hash `v3-cot-length` — older reports use `v2-cot` (pre-debias), reports are visibly different by hash
-- Report metadata records the judge prompt hash and length-debias setting; compare reports with and without `--no-debias-length` when you need a dedicated length-bias audit
-- `--no-debias-length` opt-out for research / replication scenarios
+- Report metadata records the judge prompt hash (template version); changing any debias instruction changes the hash, and reports with different hashes are never compared blind
+- Presentation/tone neutrality is always on with no toggle; length-debias can be opted out via `--no-debias-length` for research / replication — for a dedicated length-bias audit, compare reports with and without that flag
+- These are "research says judges generally have this bias" prompt instructions; omk does not run a before/after bias measurement on its own judge. The real channel to validate that debiasing works is gold calibration (Krippendorff α vs human)
 - Reference: Saito et al. (2023), "Verbosity Bias in Preference Labeling by Large Language Models"
 
 **Frozen by**: `test/grading/judge-hash-frozen.test.ts` — byte-level hash freeze prevents silent prompt drift across versions.
@@ -69,7 +69,7 @@ Each piece guards a different failure mode:
 |---|---|
 | "v2 looks better but it's within margin of error" | Bootstrap CI(pairwise diff CI not crossing 0) |
 | "Judge says v2 is better but I don't trust the judge" | Krippendorff α (judge ↔ human) |
-| "Judge is biased toward verbose answers" | Length-controlled judge prompt |
+| "Judge favors verbose / polished / confident answers" | Length / presentation / tone debiased judge prompt |
 | "I ran 10 samples and stopped — was that enough?" | Saturation curve |
 
 Skip any one and you have a hole. Bootstrap CI, length-debias and saturation are on by default — you can opt out of length-debias for research replication, but those are otherwise unconditional; Krippendorff α turns on automatically once you supply a gold set (`--gold-dir`).

--- a/docs/zh/explanation/statistical-rigor.md
+++ b/docs/zh/explanation/statistical-rigor.md
@@ -39,13 +39,13 @@ omk 自动检测 gold-judge 同源污染：如果 gold annotator 跟评委是同
 
 **公式**：标准 Krippendorff α + 序数距离度量。实现：`src/grading/human-gold.ts`。输入：`<gold-dir>/<sample_id>.json` per-用例每维度的人工评分。
 
-## 3. 长度去偏的评委 prompt（默认开启）
+## 3. 评委 prompt 去偏：长度 / 排版 / 语气（默认开启）
 
-**研究证实 LLM 评委隐性偏向更长的回答。** 越长分越高，跟质量无关。omk 的评委 prompt 显式声明"长度不是质量信号"+ chain-of-thought + 长度归一化启发式。
+**研究证实 LLM 评委隐性偏向更长、排版更精致、语气更自信的回答**，跟内容质量无关（format / markdown bias；sycophancy / authority bias）。omk 的评委 prompt 显式声明「长度不是质量信号」和「排版与语气不是质量信号」+ chain-of-thought 逐条对照评分标准。措辞严格对称——既不奖励精致 / 自信，也不因朴素 / 含糊而扣分——避免去偏指令本身过度矫正成反向偏置。
 
-- Template hash `v3-cot-length` —— 旧报告用 `v2-cot`（去偏前），报告 hash 肉眼可辨
-- 报告元数据记录评委 prompt hash 和长度去偏设置；需要专门审计长度偏差时，用带 / 不带 `--no-debias-length` 的两份报告做对照
-- `--no-debias-length` 给研究 / 复现场景留 opt-out 口子
+- 报告元数据记录评委 prompt hash（template 版本）；改动任一去偏指令都会让 hash 变，不同 hash 的报告不做盲比
+- 排版 / 语气中性化始终开启、无开关；长度去偏可用 `--no-debias-length` 为研究 / 复现 opt out，需要专门审计长度偏差时用带 / 不带该 flag 的两份报告做对照
+- 这些是「研究表明评委普遍有此偏置」驱动的 prompt 指令，omk 未对自己的评委做前后对照实测；真正验证去偏是否有效的通道是 gold 校准（Krippendorff α vs 人工）
 - 参考：Saito et al. (2023), "Verbosity Bias in Preference Labeling by Large Language Models"
 
 **冻结**：`test/grading/judge-hash-frozen.test.ts` 字节级 hash 冻结，防版本间 prompt 悄悄漂移。
@@ -69,7 +69,7 @@ omk 自动检测 gold-judge 同源污染：如果 gold annotator 跟评委是同
 |---|---|
 | "v2 看着更好但其实在误差范围内" | Bootstrap CI（pairwise diff CI 不跨 0） |
 | "评委说 v2 更好但我不信评委" | Krippendorff α（评委 ↔ 人工） |
-| "评委偏向冗长的回答" | 长度去偏的评委 prompt |
+| 「评委偏向冗长 / 精致排版 / 自信语气的回答」 | 长度 / 排版 / 语气去偏的评委 prompt |
 | "我跑了 10 个用例就停了 —— 够吗？" | 饱和曲线 |
 
 少一件，洞就出来。Bootstrap CI / 长度去偏 / 饱和曲线默认开（长度去偏可为研究复现 opt out，其余无条件）；Krippendorff α 在你提供 gold 集（`--gold-dir`）后自动开启。

--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -93,8 +93,8 @@ export const runDict: Record<RunMessageKey, CliMessage> = {
     en: '⚠ --judge-repeat "{value}" is invalid (expected an integer ≥ 1), falling back to 1 judge call\n',
   },
   'cli.run.no_debias_length_active': {
-    zh: 'ℹ --no-debias-length 已生效: judge prompt 退回 v2-cot, 与 < v0.21 报告 hash 一致。\n',
-    en: 'ℹ --no-debias-length is active: judge prompt reverts to v2-cot, matching < v0.21 report hashes.\n',
+    zh: 'ℹ --no-debias-length 已生效：judge prompt 去掉长度去偏指令（debias-off 变体），hash 与默认开启时不同。\n',
+    en: 'ℹ --no-debias-length is active: the judge prompt drops the length-debias instruction (debias-off variant); its hash differs from the default.\n',
   },
   'cli.run.invalid_bootstrap_samples': {
     zh: '⚠ --bootstrap-samples "{value}" 无效 (期望 ≥ 100 的整数), 已按 1000 执行\n',

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -277,8 +277,8 @@ export function aggregateReport({
     ...(noJudge ? {} : { runtime: getExecutorRuntimeFingerprint(jc.executor, jc.model, runtimeOptions) }),
   }));
   // length-debias is on by default; the request only sets it
-  // false when the user passed --no-debias-length. The hash differs between
-  // v3-cot-length (on) and v2-cot (off) so readers can detect the divergence.
+  // false when the user passed --no-debias-length. The judgePromptHash differs between
+  // the length-debias-on and -off prompt variants so readers can detect the divergence.
   const lengthDebiasOn = request?.lengthDebias !== false;
   const debiasModeList: Array<'length' | 'position'> = [];
   if (lengthDebiasOn) debiasModeList.push('length');

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -82,7 +82,7 @@ interface CommonEvaluationOptions {
   bootstrap?: boolean;
   /** --bootstrap-samples N. Default 1000. */
   bootstrapSamples?: number;
-  /** length-debias toggle. Default true (judge prompt v3-cot-length).
+  /** length-debias toggle. Default true (length-debias instruction on).
    *  CLI passes false when --no-debias-length is set. */
   lengthDebias?: boolean;
   /** hard budget caps. */

--- a/src/grading/assertions.ts
+++ b/src/grading/assertions.ts
@@ -477,23 +477,30 @@ export async function runAsyncAssertions(output: string, assertions: Assertion[]
 //     faster, less rigorous than RAGAS but consistent with omk's other LLM-judge
 //     assertions. Users who need RAGAS-grade decomposition can drop down to a
 //     custom assertion.
-//  2. The prompt includes the SAME length-debias paragraph as the main judge
-//     prompt (v3-cot-length) — output verbosity is not a quality signal here
-//     either. This is the "auto-inherit length-debias" claim from the  plan.
+//  2. The prompt carries the same debias instructions as the rubric judge
+//     (length + presentation/tone) — verbosity, formatting, and confident tone
+//     are not quality signals here either.
 //  3. Reference resolution:
 //       faithfulness:    sample.context  (or assertion.reference override)
 //       context_recall:  assertion.reference (or sample.context fallback)
 //       answer_relevancy: sample.prompt — no reference needed
 //  4. Threshold defaults to 3 (same as semantic_similarity). User can override.
 
-// RAG 指标(faithfulness / answer_relevancy / context_recall)的长度去偏**恒开**,
-// 按 default-strict 不提供关闭开关:`--no-debias-length` 只作用于 rubric 评委 prompt
-// (v3/v4 切换),不下探到 RAG —— RAG 评的是内容保真/切题/召回,放任长度偏置只会污染这些
-// 指标,没有「关掉它」的正当用例。故 runRagJudge 不收 lengthDebias 参数,这段恒注入。
+// RAG 指标(faithfulness / answer_relevancy / context_recall)的去偏**恒开**,
+// 按 default-strict 不提供关闭开关:`--no-debias-length` 只作用于 rubric 评委 prompt 的长度去偏,
+// 不下探到 RAG —— RAG 评的是内容保真 / 切题 / 召回,放任长度 / 排版 / 语气偏置只会污染这些指标,
+// 没有「关掉它」的正当用例。故 runRagJudge 不收 lengthDebias 参数,两段恒注入。
 const RAG_LENGTH_DEBIAS = [
-  '## 重要:长度不是质量信号',
-  '评分时聚焦内容实质,不要因输出更长就给更高分。',
+  '## 重要：长度不是质量信号',
+  '评分时聚焦内容实质，不要因输出更长就给更高分。',
   '简洁正确的回答与冗长正确的回答应得相同分数。',
+].join('\n');
+
+// 排版 / 语气中性化(format / sycophancy bias),与 RAG_LENGTH_DEBIAS 同 footprint 恒开。
+const RAG_PRESENTATION_NEUTRALITY = [
+  '## 重要：排版与语气不是质量信号',
+  '评分只看内容是否符合上述标准。排版是否精致、语气是否自信、有无自我表扬都不是质量信号 ——',
+  '不要被笃定的口吻带跑：自信但错误的回答不应高于含糊但正确的回答。',
 ].join('\n');
 
 interface RagJudgeOutcome {
@@ -532,6 +539,7 @@ async function runRagJudge(
       output,
       '',
       RAG_LENGTH_DEBIAS,
+      RAG_PRESENTATION_NEUTRALITY,
       '',
       '## 评分流程',
       '1. 列出待评估输出中所有事实性陈述',
@@ -558,6 +566,7 @@ async function runRagJudge(
       output,
       '',
       RAG_LENGTH_DEBIAS,
+      RAG_PRESENTATION_NEUTRALITY,
       '',
       '## 评分',
       '5 = 完整切题回答,无冗余无遗漏',
@@ -586,6 +595,7 @@ async function runRagJudge(
       output,
       '',
       RAG_LENGTH_DEBIAS,
+      RAG_PRESENTATION_NEUTRALITY,
       '',
       '## 评分流程',
       '1. 列出参考中的关键事实(忽略修饰性内容)',

--- a/src/grading/index.ts
+++ b/src/grading/index.ts
@@ -39,10 +39,10 @@ interface GradeOptions {
    */
   judgeRepeat?: number;
   /**
-   * v0.21 length-debias toggle. Defaults to true — judge prompt includes the
-   * "length is not a quality signal" instruction, prompt template version is
-   * v3-cot-length. Set false (via `--no-debias-length`) to revert to the
-   * legacy v2-cot prompt for reproducing historical reports.
+   * length-debias toggle. Defaults to true — judge prompt includes the
+   * "length is not a quality signal" instruction. Set false (via `--no-debias-length`)
+   * to drop it (the debias-off prompt variant) for reproducing older no-length-debias
+   * reports. The presentation/tone neutrality instruction is always on regardless.
    */
   lengthDebias?: boolean;
 }

--- a/src/grading/judge.ts
+++ b/src/grading/judge.ts
@@ -56,37 +56,29 @@ function salvageJudgeResponse(text: string): JudgeResponse | null {
 /**
  * Judge prompt template version.
  *
- *  - 'v2-cot'         — legacy; CoT scoring without explicit length-debias instruction.
- *                       Kept for `--no-debias-length` so users can reproduce historical
- *                       reports byte-for-byte.
- *  - 'v3-cot-length'  — adds a paragraph telling the judge that length is not a quality
- *                       signal. Default on (research consistently shows
- *                       LLM judges over-weight verbosity; explicit instruction mitigates).
+ * The version string encodes WHICH debias / context features the judge sees, so reports
+ * tagged with the same hash are score-comparable; a mismatched hash means "we changed how
+ * we ask the judge to think" and the reports should not be compared blind. Bump it (and the
+ * frozen hashes in `test/grading/judge-hash-frozen.test.ts`) whenever the template's bytes
+ * change — that change is BREAKING-COMPARABILITY.
  *
- * Bump when the prompt's intent or structure changes meaningfully — reports tagged
- * with the same hash are score-comparable; mismatched hashes mean "we changed how we
- * ask the judge to think" and should not be compared blind.
+ * Naming: a single main version (`v5`) + a `-feature` suffix per debias/context capability.
+ * The only asymmetry between the two strings is the `-len` suffix, gated by the
+ * `--no-debias-length` toggle; every other feature is always-on and appears in both.
  */
-// 版本字符串内嵌"判官能看到什么"的语义。bump 时机:
-//   v2-cot           : 仅看 output + rubric + 工具名分布(早期 buildTraceSummary)
-//   v3-cot-length    : 加了 length-debias 指令(v0.21)
-//   v3-cot-toolargs  : 加了 tool input 预览(本次,BREAKING-COMPARABILITY)
-//   v4-cot-len-args  : v3-cot-length 的同步升级(BREAKING-COMPARABILITY)
-//   bump 原因:之前 trace 只给 tool 名 + 分布,wrapper-style skill(mcporter / code-host CLI 等)
-//   被判官当成"只调了 Bash,没用 skill 指定的 MCP 工具"——结论事实错误。
-//   tool input 预览让判官能识别 `Bash: mcporter --tool skylark_xxx` 内的真实语义调用。
-//
-// ⚠️ 命名约定(下次 bump 时执行):
-//   当前 debias OFF: v3-* / debias ON: v4-* 编号不对称(历史上 debias OFF 跑 v2→v3,
-//   debias ON 跑 v3→v4)。这次再 bump 会让两条线持续偏移 v4/v5、v5/v6、…
-//
-//   下次 bump 时统一为单一主序号 + features 后缀,如:
-//     JUDGE_PROMPT_VERSION_DEBIAS_OFF = 'v5-cot-<features>'
-//     JUDGE_PROMPT_VERSION_DEBIAS_ON  = 'v5-cot-<features>-len'
-//   这样 hash 测试自然分两条,主序号清晰对齐,features 字段独立描述差异。
-//   本 PR 不在意命名,只是把约定写下来,避免下次又跟着错误偏移走。
-const JUDGE_PROMPT_VERSION_DEBIAS_OFF = 'v3-cot-toolargs';
-const JUDGE_PROMPT_VERSION_DEBIAS_ON = 'v4-cot-len-args';
+// 版本演进(内嵌"评委看到什么 / 被要求忽略什么"的语义):
+//   v2-cot               : 仅看 output + rubric + 工具名分布(早期 buildTraceSummary)
+//   v3-cot-length        : 加 length-debias 指令
+//   v3-cot-toolargs(off) / v4-cot-len-args(on)
+//                        : 加 tool input 预览(让评委识别 wrapper-style skill 在 Bash 命令里的
+//                          真实语义调用,如 `Bash: mcporter --tool X`,否则误判"只调了 Bash")
+//   v5-cot-toolargs-fmt(off) / v5-cot-toolargs-fmt-len(on)
+//                        : 加排版 / 语气中性化指令(始终开启,不给开关)。研究表明 LLM 评委除了
+//                          偏向更长的回答,还隐性偏向排版精致(标题 / 列表 / 加粗)与语气自信 / 自我
+//                          表扬(谄媚 / 权威偏置)的回答;显式指令要求评委只对照评分标准核内容。
+//                          同时借此把命名统一成单一主序号(v5)+ feature 后缀,`-len` 仍是开关那条。
+const JUDGE_PROMPT_VERSION_DEBIAS_OFF = 'v5-cot-toolargs-fmt';
+const JUDGE_PROMPT_VERSION_DEBIAS_ON = 'v5-cot-toolargs-fmt-len';
 
 const JUDGE_SYSTEM_PROMPT = '你是一个严格的 AI 输出质量评审员。先逐条对照评分标准做推理，再给最终分数。只返回 JSON，不要其他内容。';
 
@@ -95,6 +87,20 @@ const LENGTH_DEBIAS_INSTRUCTION = [
   '评分时聚焦内容实质与正确性。回答的篇幅、行文丰富度、结构复杂度本身不是质量指标 ——',
   '简洁正确的回答不应因短而扣分；冗长但偏题或重复的回答不应因长而加分。',
   '研究显示 LLM 评委容易隐性偏向更长的回答，请在打分前先警觉这一点。',
+].join('\n');
+
+// 始终开启(不给开关):排版与语气都不是质量信号。措辞严格对称 —— 既不奖励精致 / 自信,也不
+// 因朴素 / 含糊而扣分,避免"抗偏置"本身过度矫正成反向偏置。研究表明 LLM 评委除长度外,还隐性
+// 偏向排版精致(format / markdown bias)与语气自信、自我表扬的回答(谄媚 / 权威偏置)。
+const PRESENTATION_NEUTRALITY_INSTRUCTION = [
+  '## 重要：排版与语气不是质量信号',
+  '评分只看内容是否对照评分标准、是否正确。Markdown 排版、标题、列表、加粗、表格等呈现形式',
+  '本身不是质量指标 —— 朴素但正确的回答不应因没有排版而扣分；排版精致但偏题或错误的回答不应',
+  '因好看而加分。',
+  '同样，回答的语气、自信程度、是否自我表扬（如「这是最优方案」）也不是质量信号 —— 不要被笃定',
+  '的口吻或自我评价带跑：自信但错误的回答不应高于含糊但正确的回答，一切结论都要回到评分标准',
+  '逐条核实。',
+  '研究显示 LLM 评委容易隐性偏向排版精致、语气自信的回答，请在打分前先警觉这两点。',
 ].join('\n');
 
 export function buildJudgePrompt(
@@ -108,6 +114,8 @@ export function buildJudgePrompt(
   const traceSection = traceSummary
     ? ['', '## Agent 执行过程', traceSummary, '', '请同时考虑执行过程的合理性（工具选择、步骤效率、错误恢复）。']
     : [];
+  // 排版 / 语气中性化始终开启(不受 --no-debias-length 影响);length-debias 仍受开关控。
+  const neutralitySection = ['', PRESENTATION_NEUTRALITY_INSTRUCTION];
   const debiasSection = lengthDebias ? ['', LENGTH_DEBIAS_INSTRUCTION] : [];
 
   return [
@@ -122,6 +130,7 @@ export function buildJudgePrompt(
     '## AI 输出',
     output,
     ...traceSection,
+    ...neutralitySection,
     ...debiasSection,
     '',
     '## 评分流程',
@@ -139,8 +148,9 @@ export function buildJudgePrompt(
  * Stable hash of the judge prompt template. Saved into ReportMeta.judgePromptHash so
  * downstream readers can detect "the judge prompt changed between these two reports".
  *
- * `lengthDebias` defaults to true (v0.21+ default). Pass false when running under
- * `--no-debias-length` so the hash matches historical v2-cot reports.
+ * `lengthDebias` defaults to true. Pass false (via `--no-debias-length`) to drop the
+ * length-debias instruction; that produces the debias-off prompt variant, whose hash
+ * differs from the default so the two are never compared blind.
  */
 export function getJudgePromptHash(lengthDebias = true): string {
   const version = lengthDebias ? JUDGE_PROMPT_VERSION_DEBIAS_ON : JUDGE_PROMPT_VERSION_DEBIAS_OFF;
@@ -160,9 +170,10 @@ interface LlmJudgeOptions {
   traceSummary?: string | null;
   /**
    * When true (default), the judge prompt includes an explicit
-   * "length is not a quality signal" instruction. Pass false to fall back to
-   * the legacy v2-cot prompt — only useful for reproducing pre-v0.21 reports
-   * or running A/B comparisons with alternate length-debias settings.
+   * "length is not a quality signal" instruction. Pass false to drop it (the
+   * debias-off prompt variant) — only useful for reproducing older no-length-debias
+   * reports or running A/B comparisons with alternate length-debias settings.
+   * (The presentation/tone neutrality instruction is always on, independent of this.)
    */
   lengthDebias?: boolean;
 }

--- a/src/types/eval.ts
+++ b/src/types/eval.ts
@@ -283,7 +283,7 @@ export interface EvalConfig {
   bootstrapSamples?: number;
   /** --gold-dir. After-run automatic comparison against a human-anchor dataset. */
   goldDir?: string;
-  /** --no-debias-length flips this to false. Default true (judge prompt v3-cot-length). */
+  /** --no-debias-length flips this to false. Default true (length-debias instruction on). */
   lengthDebias?: boolean;
   /** --no-strict-baseline flips this to false. Default true (baseline-kind allowedSkills=[]). */
   strictBaseline?: boolean;
@@ -331,9 +331,10 @@ export interface EvaluationRequest {
   bootstrap?: boolean;
   /** --bootstrap-samples N; bootstrap 重采样次数, 默认 1000. > 10000 时 stderr 警告. */
   bootstrapSamples?: number;
-  /** length-debias toggle. Default true (judge prompt v3-cot-length).
-   *  CLI flag --no-debias-length flips to false (legacy v2-cot prompt). The active
-   *  value is reflected in ReportMeta.judgePromptHash and ReportMeta.debiasMode. */
+  /** length-debias toggle. Default true — judge prompt carries the length-debias
+   *  instruction. CLI flag --no-debias-length flips to false (drops that instruction,
+   *  the debias-off prompt variant). The active value is reflected in
+   *  ReportMeta.judgePromptHash and ReportMeta.debiasMode. */
   lengthDebias?: boolean;
   /** hard budget caps. See EvalBudget. */
   budget?: EvalBudget;

--- a/test/grading/judge-hash-frozen.test.ts
+++ b/test/grading/judge-hash-frozen.test.ts
@@ -2,40 +2,41 @@ import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { getJudgePromptHash } from '../../src/grading/judge.js';
 
-// 历史 hash 锚点。v0.20.0 之后任何动 buildJudgePrompt / buildTraceSummary 模板
-// 字节(含标点 / 空白 / version 字符串)都会让这两个值变,从而让历史报告不可比。
-// 除非显式想 bump JUDGE_PROMPT_VERSION_DEBIAS_OFF/ON,否则这两条断言必须永远通过。
+// 历史 hash 锚点。任何动 buildJudgePrompt / buildTraceSummary / LENGTH_DEBIAS_INSTRUCTION /
+// PRESENTATION_NEUTRALITY_INSTRUCTION 模板字节(含标点 / 空白 / version 字符串)都会让这两个值变,
+// 从而让历史报告不可比。除非显式想 bump JUDGE_PROMPT_VERSION_DEBIAS_OFF/ON,否则这两条断言必须永远通过。
 //
 // 历史值(已 archive,仅留底):
 //   v2-cot          : fdc81b19c721
 //   v3-cot-length   : 629bf3b8c41d
+//   v3-cot-toolargs : 9c441e9b6a73   (off,加 tool input 预览)
+//   v4-cot-len-args : bd1d97c86a5f   (on, 加 tool input 预览)
 //
-// v3-cot-toolargs / v4-cot-len-args bump 原因:buildTraceSummary 之前只给判官看
-// "工具名 + 分布",wrapper-style skill(mcporter / code-host CLI / git CLI 等)的真实
-// 语义调用编码在 Bash 命令字符串里(`Bash: mcporter --tool X`),判官看不到 → 错误
-// 结论"只用了 Bash,跳过了指定工具"。本次加 tool input 预览修掉这个事实错误。
-// BREAKING-COMPARABILITY 是诚实而非退路 — 老 hash 对应的判官会判错。
-const FROZEN_HASH_DEBIAS_OFF = '9c441e9b6a73'; // v3-cot-toolargs
-const FROZEN_HASH_DEBIAS_ON = 'bd1d97c86a5f';  // v4-cot-len-args
+// v5-cot-toolargs-fmt / v5-cot-toolargs-fmt-len bump 原因:judge prompt 此前只显式去偏「长度」,
+// 未管「排版 / 语气」。研究表明 LLM 评委还隐性偏向排版精致(format / markdown bias)与语气自信、
+// 自我表扬的回答(谄媚 / 权威偏置)。本次加始终开启的排版 / 语气中性化指令,并借机把命名统一成
+// 单一主序号 v5 + feature 后缀。BREAKING-COMPARABILITY 是诚实而非退路 — 老 hash 对应的评委去偏更弱。
+const FROZEN_HASH_DEBIAS_OFF = '74be4a6a2439'; // v5-cot-toolargs-fmt
+const FROZEN_HASH_DEBIAS_ON = 'bb393197cd41';  // v5-cot-toolargs-fmt-len
 
 describe('judge prompt hash byte-level freeze', () => {
-  it('v3-cot-toolargs (debias=false) hash matches the frozen value', () => {
+  it('v5-cot-toolargs-fmt (debias=false) hash matches the frozen value', () => {
     assert.equal(
       getJudgePromptHash(false),
       FROZEN_HASH_DEBIAS_OFF,
-      '动了 buildJudgePrompt / buildTraceSummary 模板会让历史 v3-cot-toolargs 报告不可比;' +
-        '若确需 bump,先改 JUDGE_PROMPT_VERSION_DEBIAS_OFF 字符串(并新增冻结值),' +
-        '再来更新此测试',
+      '动了 buildJudgePrompt / buildTraceSummary / PRESENTATION_NEUTRALITY_INSTRUCTION 模板会让历史 ' +
+        'v5-cot-toolargs-fmt 报告不可比;若确需 bump,先改 JUDGE_PROMPT_VERSION_DEBIAS_OFF 字符串' +
+        '(并新增冻结值),再来更新此测试',
     );
   });
 
-  it('v4-cot-len-args (debias=true) hash matches the frozen value', () => {
+  it('v5-cot-toolargs-fmt-len (debias=true) hash matches the frozen value', () => {
     assert.equal(
       getJudgePromptHash(true),
       FROZEN_HASH_DEBIAS_ON,
-      '动了 buildJudgePrompt / buildTraceSummary / LENGTH_DEBIAS_INSTRUCTION 会让历史 ' +
-        'v4-cot-len-args 报告不可比;若确需 bump,先改 JUDGE_PROMPT_VERSION_DEBIAS_ON ' +
-        '字符串(并新增冻结值),再来更新此测试',
+      '动了 buildJudgePrompt / buildTraceSummary / LENGTH_DEBIAS_INSTRUCTION / ' +
+        'PRESENTATION_NEUTRALITY_INSTRUCTION 会让历史 v5-cot-toolargs-fmt-len 报告不可比;若确需 bump,' +
+        '先改 JUDGE_PROMPT_VERSION_DEBIAS_ON 字符串(并新增冻结值),再来更新此测试',
     );
   });
 });

--- a/test/grading/judge-prompt-isolation.test.ts
+++ b/test/grading/judge-prompt-isolation.test.ts
@@ -53,7 +53,7 @@ describe('buildJudgePrompt — sample metadata isolation', () => {
     assertNoForbiddenTokens(p);
   });
 
-  it('lengthDebias=false (legacy v2-cot path) also clean', () => {
+  it('lengthDebias=false (debias-off prompt variant) also clean', () => {
     const p = buildJudgePrompt('用户问题', '评分标准', 'AI 回答', null, false);
     assertNoForbiddenTokens(p);
   });

--- a/test/grading/judge-prompt-version.test.ts
+++ b/test/grading/judge-prompt-version.test.ts
@@ -3,16 +3,20 @@ import assert from 'node:assert/strict';
 import { buildJudgePrompt, getJudgePromptHash } from '../../src/grading/judge.js';
 
 describe('judge prompt versioning', () => {
-  it('default builds the v4-cot-len-args prompt', () => {
+  it('default builds the v5-cot-toolargs-fmt-len prompt', () => {
     const text = buildJudgePrompt('p', 'r', 'o', null);
-    assert.match(text, /v4-cot-len-args/);
+    assert.match(text, /v5-cot-toolargs-fmt-len/);
     assert.match(text, /长度不是质量信号/);
+    assert.match(text, /排版与语气不是质量信号/);
   });
 
-  it('lengthDebias=false builds the v3-cot-toolargs prompt without the debias section', () => {
+  it('lengthDebias=false builds the v5-cot-toolargs-fmt prompt without the length-debias section', () => {
     const text = buildJudgePrompt('p', 'r', 'o', null, false);
-    assert.match(text, /v3-cot-toolargs/);
+    // 全角 `）` 紧跟 fmt,确保是 off 版本而非 -len 变体(后者是 fmt 的超串)。
+    assert.match(text, /template v5-cot-toolargs-fmt）/);
     assert.doesNotMatch(text, /长度不是质量信号/);
+    // 排版 / 语气中性化始终开启,即使 length-debias 关掉也在。
+    assert.match(text, /排版与语气不是质量信号/);
   });
 
   it('hashes differ between debias on / off', () => {

--- a/test/grading/rag-metrics.test.ts
+++ b/test/grading/rag-metrics.test.ts
@@ -55,7 +55,7 @@ describe('faithfulness', () => {
     assert.match(noCtx.details[0].message ?? '', /缺少 sample.context/);
   });
 
-  it('prompt includes the length-debias paragraph', async () => {
+  it('prompt includes both the length-debias and presentation/tone neutrality paragraphs', async () => {
     let captured = '';
     const judge: ExecutorFn = async ({ prompt }) => {
       captured = prompt;
@@ -65,6 +65,7 @@ describe('faithfulness', () => {
       executor: judge, judgeModel: 'm', sample, samplesDir: '.',
     });
     assert.match(captured, /长度不是质量信号/);
+    assert.match(captured, /排版与语气不是质量信号/);
   });
 });
 
@@ -146,6 +147,20 @@ describe('context_recall', () => {
     assert.match(captured, /Key fact A/);
   });
 
+});
+
+describe('all three RAG judges carry both debias paragraphs', () => {
+  const sample: Sample = { sample_id: 's', prompt: 'Q?', context: 'ctx' };
+  it.each(['faithfulness', 'answer_relevancy', 'context_recall'] as const)('%s', async (type) => {
+    let captured = '';
+    const judge: ExecutorFn = async ({ prompt }) => {
+      captured = prompt;
+      return ok(JSON.stringify({ score: 5, reason: 'm' }));
+    };
+    await runAsyncAssertions('o', [{ type }], { executor: judge, judgeModel: 'm', sample, samplesDir: '.' });
+    assert.match(captured, /长度不是质量信号/, `${type} 应含长度去偏段`);
+    assert.match(captured, /排版与语气不是质量信号/, `${type} 应含排版 / 语气中性化段`);
+  });
 });
 
 describe('judge cost is accumulated', () => {


### PR DESCRIPTION
## 这在解决什么(大白话)

omk 的 LLM 评委此前只被明确告知一件事：别因为回答长就给高分。但评委还有两个同源毛病没管 —— 被**排版**骗（同样内容，加了标题 / 列表 / 加粗 / 表格的显得更好）和被**语气**骗（回答越自信、越像标准答案、越自我表扬，评委越买账，哪怕内容错）。本 PR 在评委 prompt 里补一段「排版与语气都不是质量信号」，跟既有的长度去偏并排。

这是「评委效度」轴的 J3，承接 J1 + J2（#279 检测同厂商评委 / 单厂商 ensemble 的自我偏好敞口）。

## 用户影响 · 为什么是 BREAKING-COMPARABILITY

评委 prompt 字节变了，`judgePromptHash` 从 `v3-cot-toolargs` / `v4-cot-len-args` bump 到 `v5-cot-toolargs-fmt` / `v5-cot-toolargs-fmt-len`，**历史报告的分数与新报告不可盲比**（hash 不同即不同口径）。这是诚实交代而非退路：老 hash 对应的评委去偏更弱。借这次把版本命名统一成单一主序号 `v5` + feature 后缀，`-len` 仍是 `--no-debias-length` 开关那条。

无需迁移动作：报告元数据已记录 `judgePromptHash`，跨 hash 比较时读者据此识别口径差异。

## 关键决策

中性化指令**始终开启、不给开关**（按 default-strict：影响判分的去偏能力默认且只能 on）。措辞严格对称 —— 既不奖励精致 / 自信，也不因朴素 / 含糊而扣分 —— 避免「抗偏置」本身过度矫正成反向偏置（把自信但正确的判低、含糊但正确的判高）。

覆盖面跟既有 length-debias 的 footprint 对齐：rubric 评委 + 三个 RAG 评委（faithfulness / answer_relevancy / context_recall，它们本就恒开长度去偏）都恒注入；`semantic_similarity` 是相似度指标、非质量判断、本就无 debias，保持不动。

## 构念效度 caveat

这是「研究表明 LLM 评委普遍有此偏置」驱动的 prompt 指令，omk **未对自己的评委做前后对照实测**证明这段真降了偏置；真正验证去偏是否有效的通道是 gold 校准（Krippendorff α vs 人工）。文档（statistical-rigor 中英）已把这点写进去。

附带修掉一处既有 bug：`--no-debias-length` 的 CLI 提示与多处注释仍说「退回 v2-cot / 与 < v0.21 报告 hash 一致」，实际 debias-off 早已不是 v2-cot，本 PR 一并校正为版本无关表述。

## 不碰

其它测量学不变量（Report schema / 五层管道 / bootstrap / α / observe LLM 增强复盘 prompt 的冻结 hash）均未触及。