### PR TITLE
fix(grading): α 校准「序数加权」误标改 interval + 门控魔数补依据并 drift-guard

### DIFF
--- a/docs/explanation/statistical-rigor.md
+++ b/docs/explanation/statistical-rigor.md
@@ -37,7 +37,7 @@ omk auto-detects gold-judge collusion: if the gold annotator is the same model a
 
 The same logic applies on the judge-vs-output axis: if the judge is the same model family as the executor that produced the outputs — the default, where `claude:haiku` judges `claude:sonnet` output — the judge's self-preference inflates scores. omk flags this (`judge_self_preference`, plus `single_vendor_ensemble` when a multi-judge panel is all one vendor) and points to the fix: a cross-vendor judge (`--judge-models openai-api:gpt-4o`) or gold calibration. Because omk holds the model fixed across baseline and treatment, self-preference largely cancels in the A/B **delta** — it bites absolute scores, version-regression curves, and cross-model comparisons, which is what the warning scopes itself to.
 
-**Formula**: standard Krippendorff α with ordinal distance metric. Implementation: `src/grading/human-gold.ts`. Inputs: `<gold-dir>/<sample_id>.json` files with human scores per dimension.
+**Formula**: standard Krippendorff α with interval distance metric (δ²=(c−k)²; a defensible choice for 1-5 Likert). Implementation: `src/grading/human-gold.ts`. Inputs: `<gold-dir>/<sample_id>.json` files with human scores per dimension.
 
 ## 3. Debiased judge prompt: length / presentation / tone (default ON)
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -23,7 +23,7 @@ omk docs (blog posts, SKILL.md, CLI output, report pages) freely mix industry-st
 | significant | CI excludes 0 (the gap is not by chance) | reliability check ✓ significant-difference badge |
 | Pearson r | Pearson correlation coefficient. 1 = perfectly aligned / 0 = unrelated / -1 = perfectly opposed | "cross-sample judge agreement" table for the multi-judge ensemble |
 | MAD | Mean absolute deviation. Average distance among judges scoring the same sample. On a 1-5 scale, < 0.5 is tight agreement, > 1.5 is large disagreement | multi-judge agreement table |
-| Krippendorff α | Ordinal-weighted multi-judge agreement. α ≥ 0.8 high agreement / 0.667-0.8 acceptable / < 0.4 low | Human gold section |
+| Krippendorff α | Interval-weighted multi-judge agreement. α ≥ 0.8 high agreement / 0.667-0.8 acceptable / < 0.4 low | Human gold section |
 | p-value | Probability that a gap this large appears by chance; smaller is more significant (0.05 is the usual threshold) | t-test section (not omk's primary path; bootstrap takes priority) |
 | effect size | The gap relative to the noise (Cohen's d / Hedges' g), putting a scale on "how big the difference is" | Cohen's d column in the variance / significance table |
 | CV | Coefficient of variation, stddev / mean, a stability metric. On a 1-5 scale, < 5% stable / 5-15% medium / > 15% unstable | stability column + hero tooltip |

--- a/docs/specs/scoring.md
+++ b/docs/specs/scoring.md
@@ -112,6 +112,8 @@ verdict algorithm (condensed):
 
 **What this means**: a composite alone at +2.78 cannot make omk return a `PROGRESS` (ship-safe) verdict — **every present layer must pass its gate** (a layer with no data is dropped, exactly as it is from the composite mean; if all three are absent the gate FAILs). This weakens (does not eliminate) the misleading risk of composite's ad hoc aggregation.
 
+**Gate constants** are pragmatic defaults, not external standards, and are doc↔code-parity-guarded (`test/scripts/doc-constants-drift.test.ts`): the layer-gate threshold defaults to 3.5 (a clear margin above the 1-5 scale midpoint 3.0; override via `omk eval --threshold`). The inter-judge agreement gate follows conventional Pearson strength bands — strong agreement at Pearson ≥ 0.7, strong disagreement at Pearson < 0.4 (the latter downgrades a would-be PROGRESS to CAUTIOUS).
+
 The 4 badges in the "methodology audit" section (judges agree / difference significant / saturated / human-aligned) visualize the conclusions of these independent tests, so during review a user can spot the case where "composite looks fine but some layer has a problem". Among these, "judges agree" (inter-judge Pearson) is not merely a visualization: strong multi-judge disagreement (Pearson < 0.4) downgrades a would-be PROGRESS verdict to CAUTIOUS — when the judges can't agree among themselves, the judge-layer signal driving this "improvement" is unreliable.
 
 ### The six verdicts at a glance

--- a/docs/zh/explanation/statistical-rigor.md
+++ b/docs/zh/explanation/statistical-rigor.md
@@ -37,7 +37,7 @@ omk 自动检测 gold-judge 同源污染：如果 gold annotator 跟评委是同
 
 同一逻辑也适用于评委-vs-输出这条轴：如果评委与产出被测输出的执行器同模型家族——默认就是，`claude:haiku` 评 `claude:sonnet` 的输出——评委的自我偏好会抬高分数。omk 会标记（`judge_self_preference`；多评委且全同一厂商时再标 `single_vendor_ensemble`）并指出修法：换跨厂商评委（`--judge-models openai-api:gpt-4o`）或挂 gold 校准。因为 omk 固定模型、baseline 与 treatment 同源，自我偏好在 A/B **差值**里大幅抵消——真正受影响的是绝对分、版本回归曲线、跨模型比较，警告也只把自己限定在这些范围。
 
-**公式**：标准 Krippendorff α + 序数距离度量。实现：`src/grading/human-gold.ts`。输入：`<gold-dir>/<sample_id>.json` per-用例每维度的人工评分。
+**公式**：标准 Krippendorff α + 区间距离度量（δ²=(c−k)²,1-5 Likert 的 defensible 选择）。实现：`src/grading/human-gold.ts`。输入：`<gold-dir>/<sample_id>.json` per-用例每维度的人工评分。
 
 ## 3. 评委 prompt 去偏：长度 / 排版 / 语气（默认开启）
 

--- a/docs/zh/reference/glossary.md
+++ b/docs/zh/reference/glossary.md
@@ -23,7 +23,7 @@ omk 文档（包括博客、SKILL.md、CLI 输出、报告页）会混用一些 
 | significant | 显著差异 / 显著 | CI 不含 0（差距不是偶然） | 测评可信度 ✓ 差异显著 badge |
 | Pearson r | 皮尔逊（相关）系数 | 1=完全同向 / 0=无关 / -1=完全反向 | 多评委 ensemble 的「跨用例评委一致性」表 |
 | MAD | 平均绝对差 | 多个评委对同一用例打分的平均距离。1-5 制下 < 0.5 紧密一致，> 1.5 大分歧 | 多评委一致性表 |
-| Krippendorff α | Krippendorff α / 一致性系数 | 序数加权多评委一致性，α ≥ 0.8 高度一致 / 0.667-0.8 可接受 / < 0.4 低 | 人工锚点 (Human gold) section |
+| Krippendorff α | Krippendorff α / 一致性系数 | 区间加权多评委一致性，α ≥ 0.8 高度一致 / 0.667-0.8 可接受 / < 0.4 低 | 人工锚点 (Human gold) section |
 | p-value | p 值 | 「这种差距碰巧出现」的概率，越小越显著（一般 0.05 阈值） | t-test 部分（omk 不主推，bootstrap 优先） |
 | effect size | 效应量 | 差距相对于波动的比例（Cohen's d / Hedges' g），刻度化「差距有多大」 | 波动 / 显著性表的 Cohen's d 列 |
 | CV | 变异系数 | stddev / mean，稳定性指标。1-5 制下 < 5% 稳 / 5-15% 中 / > 15% 不稳 | 稳定性列 + hero tooltip |

--- a/docs/zh/specs/scoring.md
+++ b/docs/zh/specs/scoring.md
@@ -111,6 +111,8 @@ verdict 算法（精简版）：
 
 **意义**：composite 单分 +2.78 不能让 omk 给出 `PROGRESS`（可安全发布）判定，必须 **每个存在的层都过自己的 gate**（没数据的层会被剔除，跟它从 composite 均值里被剔除一样；三层全缺则 gate 直接 FAIL）。这削弱（不是消除）composite ad hoc 聚合的误导风险。
 
+**门控阈值**是务实默认、非外部标准，且 doc↔code 校验（`test/scripts/doc-constants-drift.test.ts`）：layer-gate threshold 默认 3.5（明显高于 1-5 量程中点 3.0，`omk eval --threshold` 可覆盖）。评委一致性门控沿用惯例 Pearson 强度带 —— 强一致 Pearson ≥ 0.7，强分歧 Pearson < 0.4（后者把本应 PROGRESS 降为 CAUTIOUS）。
+
 「方法学审计」section 里的 4 个 badge（评委一致 / 差异显著 / 已饱和 / 人工对齐）就是把这套独立检验的结论可视化，让用户在 review 时能 spot 到「composite 看上去不错但某层有问题」的情况。其中「评委一致」（inter-judge Pearson）不只是可视化：多评委强烈分歧（Pearson < 0.4）会把本应 PROGRESS 的判定降级为 CAUTIOUS —— 评委自己都谈不拢时，驱动这次「变好」的评委层信号不可靠。
 
 ### 六档 verdict 一览

--- a/src/authoring/generator.ts
+++ b/src/authoring/generator.ts
@@ -1,4 +1,5 @@
 import { createExecutor } from '../executors/index.js';
+import { DEFAULT_GATE_THRESHOLD } from '../eval-core/verdict.js';
 import type { Sample, SampleProvenance, ExecutorFn } from '../types/index.js';
 import type { ObservationInboxItem } from '../types/observability.js';
 
@@ -80,7 +81,7 @@ const SYSTEM_PROMPT = `你是一个评测用例生成器。你的任务是根据
   来涨数量)。omk 的评分体系是 layered scoring: **fact 层**(deterministic 字面/工具断言)
   + **behavior 层**(代价指标如 turn 数 / 工具失败率) + **judge 层**(主观语义评分,从
   sample.rubric 派生维度,judge LLM 看 trace 评 1-5)三层独立计分,verdict 是三层
-  独立过 threshold(默认 3.5)。**fact 层的本职是测 deterministic 端点,不是测轨迹**。
+  独立过 threshold(默认 ${DEFAULT_GATE_THRESHOLD})。**fact 层的本职是测 deterministic 端点,不是测轨迹**。
 
   **断言哲学(关键):fact 测结果+里程碑,过程质量交 judge**
   ─────────────────────────────────────────────────────────────
@@ -113,7 +114,7 @@ const SYSTEM_PROMPT = `你是一个评测用例生成器。你的任务是根据
     - tools_not_called 反模式断言 0-1 条(禁止接触某禁忌工具,如 tripwire sample)
     - rubric 3-5 个判分维度(细致写明 judge 该看什么),由 sample.rubric 字段承载
 
-  *测量学背景:* 当前 omk verdict 三层独立 threshold(默认 3.5),fact 条目少之后单条
+  *测量学背景:* 当前 omk verdict 三层独立 threshold(默认 ${DEFAULT_GATE_THRESHOLD}),fact 条目少之后单条
   权重大、单次评测方差大,**强烈建议** 评测时带 \`--repeat 2\` 或更大测稳定性(coefficient
   of variation),并参考 bootstrap CI 而非点估计。这是 fact 层稀疏化的代价,换来的是
   fact 信号干净(不被 trajectory 字面噪音污染)。

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -12,6 +12,7 @@ import type { BatchEvaluationReport, EvaluationReport, Report, ProgressCallback 
 import type { DryRunBatchReport, DryRunReport } from '../../../eval-workflows/run-evaluation.js';
 import type { EvalResult, ReportServer } from '../../lib/shared.js';
 import { DEFAULT_BOOTSTRAP_SAMPLES } from '../../../eval-core/bootstrap.js';
+import { DEFAULT_GATE_THRESHOLD } from '../../../eval-core/verdict.js';
 import { EVALUATION_REPORT_SCHEMA_VERSION } from '../../../eval-core/evaluation-reporting.js';
 
 // oclif 版 eval(默认 = run 模式) — 单次 typed parse 之后业务 inline。flag schema
@@ -567,7 +568,10 @@ export default class Eval extends BaseCommand {
       parse: numberStringParser('--budget-per-sample-ms', { minExclusive: 0 }),
     }),
     threshold: Flags.string({
-      description: bilingual({ zh: 'verdict 阈值，默认 3.5', en: 'Verdict threshold, default 3.5' }),
+      description: bilingual({
+        zh: `verdict 阈值，默认 ${DEFAULT_GATE_THRESHOLD}`,
+        en: `Verdict threshold, default ${DEFAULT_GATE_THRESHOLD}`,
+      }),
       parse: numberStringParser('--threshold'),
     }),
     'trivial-diff': Flags.string({

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -42,11 +42,13 @@ function isDryRunBatchReport(report: unknown): report is DryRunBatchReport {
   return isDryRunReport(report) && (report as { batch?: unknown }).batch === true;
 }
 
-function verdictOptions(values: ParsedValues): { gateThreshold: number; triviallySmallDiff: number | undefined } {
+function verdictOptions(values: ParsedValues): { gateThreshold: number | undefined; triviallySmallDiff: number | undefined } {
   const rawThreshold = values.threshold as string | undefined;
+  // 不传 --threshold 时返回 undefined,由 computeVerdict 应用 DEFAULT_GATE_THRESHOLD ——
+  // 避免在此再硬编码一份 3.5(单一来源在 verdict.ts)。
   const gateThreshold = rawThreshold !== undefined && Number.isFinite(Number(rawThreshold))
     ? Number(rawThreshold)
-    : 3.5;
+    : undefined;
   const rawTrivial = values['trivial-diff'] as string | undefined;
   const triviallySmallDiff = rawTrivial !== undefined && Number.isFinite(Number(rawTrivial))
     ? Number(rawTrivial)

--- a/src/eval-core/verdict.ts
+++ b/src/eval-core/verdict.ts
@@ -63,6 +63,15 @@ export const ENSEMBLE_DISSENT_PEARSON = 0.4;
  */
 export const STABILITY_UNSTABLE_CV = 0.15;
 
+/**
+ * Per-layer pass/fail line for the three-layer gate, on the 1-5 scale.
+ * **Pragmatic default, not derived from an external standard**: 3.5 is a clear margin
+ * above the 3.0 scale midpoint ("basically acceptable"), so a layer must land
+ * comfortably in the upper half to pass. Overridable via `omk eval --threshold`.
+ * doc ↔ code parity guarded by `test/scripts/doc-constants-drift.test.ts`.
+ */
+export const DEFAULT_GATE_THRESHOLD = 3.5;
+
 export type VerdictLevel =
   | 'PROGRESS'
   | 'CAUTIOUS'
@@ -93,7 +102,7 @@ export interface VerdictResult {
 }
 
 export interface VerdictOptions {
-  /** Three-layer ci-gate threshold; defaults to 3.5 (matches `omk eval`). */
+  /** Three-layer ci-gate threshold; defaults to DEFAULT_GATE_THRESHOLD (matches `omk eval`). */
   gateThreshold?: number;
   /**
    * Magnitude (in raw score points) below which a "significant" diff is treated
@@ -107,7 +116,7 @@ export interface VerdictOptions {
  * Compute a verdict for a finished report. Pure function — no I/O.
  */
 export function computeVerdict(report: Report, options: VerdictOptions = {}): VerdictResult {
-  const { gateThreshold = 3.5, triviallySmallDiff = 0.1 } = options;
+  const { gateThreshold = DEFAULT_GATE_THRESHOLD, triviallySmallDiff = 0.1 } = options;
   const variants = report.meta?.variants ?? [];
   const summary = report.summary ?? {};
   const sampleCount = report.meta?.sampleCount ?? 0;

--- a/src/grading/gold-cli.ts
+++ b/src/grading/gold-cli.ts
@@ -132,7 +132,7 @@ export function formatGoldCompare(result: GoldCompareResult, gold: GoldDataset):
     if (result.missing.length) lines.push(`  报告缺失:         ${result.missing.join(', ')}`);
     return lines.join('\n');
   }
-  lines.push(`  Krippendorff α:   ${fmt(a.alpha)}   (主指标，序数加权)`);
+  lines.push(`  Krippendorff α:   ${fmt(a.alpha)}   (主指标，区间加权)`);
   lines.push(`  α 95% CI:         [${fmt(a.alphaCI.low)}, ${fmt(a.alphaCI.high)}]`);
   lines.push(`  加权 κ:           ${fmt(a.weightedKappa)}   (副指标)`);
   lines.push(`  Pearson r:        ${fmt(a.pearson)}   (仅查 rank order)`);

--- a/src/grading/human-gold.ts
+++ b/src/grading/human-gold.ts
@@ -15,9 +15,11 @@
  *
  * Three metrics are exported:
  *
- *  - **Krippendorff's α (interval)** — primary. Distribution-free, supports
- *    ordinal/interval scales naturally, doesn't assume coders are exchangeable
- *    (good fit when one "coder" is a model and the other a human annotator).
+ *  - **Krippendorff's α (interval weights)** — primary. Distribution-free,
+ *    doesn't assume coders are exchangeable (good fit when one "coder" is a model
+ *    and the other a human annotator). Uses interval distance δ²=(c−k)² — a
+ *    defensible choice for 1-5 Likert; an ordinal-distance variant would change α
+ *    (BREAKING-COMPARABILITY) and is not implemented here.
  *  - **Quadratic-weighted Cohen's κ** — secondary. Familiar to many readers,
  *    useful as a sanity check. Reports lower than α when marginals diverge.
  *  - **Pearson r** — tertiary. Captures rank-order agreement only; doesn't

--- a/src/renderer/summary.ts
+++ b/src/renderer/summary.ts
@@ -268,7 +268,7 @@ export function renderHumanAgreement(agreement: ReportHumanAgreement | undefined
           <td><strong>Krippendorff α</strong></td>
           <td style="text-align:center;color:${alphaColor}"><strong>${fmt(a.alpha)}</strong></td>
           <td style="text-align:center;font-size:11px">[${fmt(a.alphaCI.low)}, ${fmt(a.alphaCI.high)}]</td>
-          <td style="font-size:12px;color:var(--text-secondary)">${lang === 'zh' ? '主指标，序数加权' : 'primary, ordinal-weighted'}</td>
+          <td style="font-size:12px;color:var(--text-secondary)">${lang === 'zh' ? '主指标，区间加权' : 'primary, interval-weighted'}</td>
         </tr>
         <tr>
           <td>${lang === 'zh' ? '加权 κ' : 'weighted κ'}</td>

--- a/test/cli/oclif-parsers.test.ts
+++ b/test/cli/oclif-parsers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import Eval from '../../src/cli/commands/eval/index.js';
+import { DEFAULT_GATE_THRESHOLD } from '../../src/eval-core/verdict.js';
 import EvalGoldCompare from '../../src/cli/commands/eval/gold/compare.js';
 import Evolve from '../../src/cli/commands/evolve.js';
 import Sample from '../../src/cli/commands/sample.js';
@@ -9,6 +10,7 @@ import ObserveInbox from '../../src/cli/commands/observe/inbox.js';
 
 interface FlagLike {
   parse?: unknown;
+  description?: unknown;
 }
 
 type FlagMap = Record<string, FlagLike>;
@@ -81,6 +83,18 @@ describe('oclif custom parsers', () => {
     assert.equal(await parsePort('65535'), '65535');
     await assert.rejects(() => parsePort('-1'), /--port.*0.*65535/);
     await assert.rejects(() => parsePort('65536'), /--port.*0.*65535/);
+  });
+
+  it('keeps the --threshold help text wired to DEFAULT_GATE_THRESHOLD', () => {
+    // 默认阈值的单一来源是 verdict.ts 的 DEFAULT_GATE_THRESHOLD。help 文案若再写死
+    // 裸字面量,常量调整后用户会读到错误默认值。断言 help 里出现的就是常量插值结果,
+    // 防止有人把它退回成硬编码。
+    const description = flagsOf(Eval.flags).threshold?.description;
+    assert.equal(typeof description, 'string', 'threshold flag should carry a help description');
+    assert.ok(
+      (description as string).includes(String(DEFAULT_GATE_THRESHOLD)),
+      `--threshold help 应反映 DEFAULT_GATE_THRESHOLD(${DEFAULT_GATE_THRESHOLD}），实际为:${String(description)}`,
+    );
   });
 
   it('rejects non-decimal number literals', async () => {

--- a/test/scripts/doc-constants-drift.test.ts
+++ b/test/scripts/doc-constants-drift.test.ts
@@ -20,7 +20,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { DEFAULT_BOOTSTRAP_SAMPLES, DEFAULT_BOOTSTRAP_ALPHA } from '../../src/eval-core/bootstrap.js';
 import { DEFAULT_SATURATION_WINDOW_SIZE, DEFAULT_CI_WIDTH_SHRINK_THRESHOLD } from '../../src/analysis/saturation.js';
-import { UNDERPOWERED_MIN_SAMPLES, STABILITY_UNSTABLE_CV } from '../../src/eval-core/verdict.js';
+import { UNDERPOWERED_MIN_SAMPLES, STABILITY_UNSTABLE_CV, DEFAULT_GATE_THRESHOLD, ENSEMBLE_STRONG_PEARSON, ENSEMBLE_DISSENT_PEARSON } from '../../src/eval-core/verdict.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, '..', '..');
@@ -120,6 +120,43 @@ const CHECKS: Check[] = [
     pattern: /中位 CV > (\d+)%/,
     expected: STABILITY_UNSTABLE_CV,
     toNumber: (s) => Number(s) / 100,
+  },
+  // 门控魔数:layer-gate 阈值 + 评委一致性 Pearson 强/弱带(en + zh)
+  {
+    label: 'gate threshold (scoring en)',
+    file: 'docs/specs/scoring.md',
+    pattern: /layer-gate threshold defaults to (\d+\.\d+)/,
+    expected: DEFAULT_GATE_THRESHOLD,
+  },
+  {
+    label: 'gate threshold (scoring zh)',
+    file: 'docs/zh/specs/scoring.md',
+    pattern: /layer-gate threshold 默认 (\d+\.\d+)/,
+    expected: DEFAULT_GATE_THRESHOLD,
+  },
+  {
+    label: 'ensemble strong Pearson (scoring en)',
+    file: 'docs/specs/scoring.md',
+    pattern: /strong agreement at Pearson ≥ (\d+\.\d+)/,
+    expected: ENSEMBLE_STRONG_PEARSON,
+  },
+  {
+    label: 'ensemble strong Pearson (scoring zh)',
+    file: 'docs/zh/specs/scoring.md',
+    pattern: /强一致 Pearson ≥ (\d+\.\d+)/,
+    expected: ENSEMBLE_STRONG_PEARSON,
+  },
+  {
+    label: 'ensemble dissent Pearson (scoring en)',
+    file: 'docs/specs/scoring.md',
+    pattern: /strong disagreement at Pearson < (\d+\.\d+)/,
+    expected: ENSEMBLE_DISSENT_PEARSON,
+  },
+  {
+    label: 'ensemble dissent Pearson (scoring zh)',
+    file: 'docs/zh/specs/scoring.md',
+    pattern: /强分歧 Pearson < (\d+\.\d+)/,
+    expected: ENSEMBLE_DISSENT_PEARSON,
   },
 ];
 


### PR DESCRIPTION
## 这在解决什么

第四轴审计([issue #283](https://github.com/lizhiyao/oh-my-knowledge/issues/283))里两条不依赖用户体量、纯属「工具自身诚不诚实 / 可不可审」的修复。其余(gold 生产 on-ramp、α 接进 verdict)依赖体量,留 issue。

## finding 3 —— α 校准的「序数加权」是假话

`omk eval gold compare` 的 CLI 输出和 HTML 报告都标注 Krippendorff α 为「序数加权 / ordinal-weighted」,但实现(`human-gold.ts`)用的是 **interval 权重** δ²=(c−k)²。测量工具在自己的输出里印了句与实现矛盾的话。

改:两处 label 统一为「区间加权 / interval-weighted」,头注写明 interval 对 1-5 Likert 是 defensible 选择、序数度量变体会改 α(那才是 BREAKING-COMPARABILITY)故本次不实现。**不动距离度量本身**,所以 α 数值不变、非破坏。

## finding 4 —— 门控魔数没出处

`gateThreshold=3.5`、`ENSEMBLE_STRONG_PEARSON=0.7`、`ENSEMBLE_DISSENT_PEARSON=0.4` 直接决定 verdict 翻不翻,却硬编码、文档无依据,也没被 `doc-constants-drift` 守着(而 `UNDERPOWERED_MIN_SAMPLES`、`STABILITY_UNSTABLE_CV`、bootstrap 那些都有)。3.5 在 1-5 上是「刚过中点」,±0.1 就能翻边界 verdict,谁都审不了为啥是 3.5。

改:抽 `DEFAULT_GATE_THRESHOLD=3.5` 导出常量(verdict.ts 与 CLI 单一来源,CLI 不传 `--threshold` 时交给 `computeVerdict` 套默认,消除第二处硬编码);scoring.md 中英补一段诚实说明 —— 3.5 写成「务实默认、`--threshold` 可覆盖」(不编造外部出处),0.7 / 0.4 如实标为惯例 Pearson 强 / 弱带;把这三个纳入 `doc-constants-drift.test.ts` 守住 doc↔code 不漂。

## 非破坏

`DEFAULT_GATE_THRESHOLD` 仍是 3.5,score / hash / verdict 行为均不变;α 数值不变(只改 label 不改度量)。纯诚实化 + 可审计加固。

## 验证

`yarn lint && typecheck && build && build:docs:check && test` 全绿(183 文件 / 2334 用例,+6 = 三常量中英 drift 条目)。