### PR TITLE
chore(release): 发布 0.41.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 这在发什么

v0.40.0 以来积累的测量学审计成果一次性发版。覆盖审计第二轴（构念效度 + 隔离）、第三轴（评委效度）、第四轴（聚合与校准）以及一次 prompt 统一管理重构。含三处破坏性变更，发版后需把下面的迁移说明 hoist 进 GitHub Release notes。

## ⚠️ 破坏性变更（迁移指引）

**接口破坏（非 comparability，分数/CI/verdict 数值不变）**

- **#277 删除 judge blind 模式**：`--blind` flag、eval.yaml `blind` 字段、`EvaluationRequest.blind`、`Report.meta.blind`/`blindMap` 全部移除。用过 `--blind` / `blind: true` 的去掉即可，报告照常出（仅少 A/B 脱敏与「揭晓」按钮）。旧 blind 报告 JSON 仍能读，多余字段被忽略、优雅降级。理由：omk 独立打分天生就盲，`applyBlindMode` 只在报告生成后换名、影响不到打分，功能长期半破且零使用信号。
- **#278 删除非空 skill 白名单**：`allowedSkills` 收为两档 —— `undefined`（不隔离）/ `[]`（全封死）。写过 `allowedSkills: [name, ...]` 的 eval.yaml 现在**加载期 fail-closed 报错**，改用 `[]` 或省略。多 skill 组合实验靠控制评测环境（CI / 隔离副本里只装需要的 skill），不靠白名单。理由：非空白名单封不住子代理 Skill 工具与 cwd 两条 channel，产出「看着干净实则被污染」的报告，比明摆着不支持更危险。

**BREAKING-COMPARABILITY（评委分数口径变，历史报告不可盲比）**

- **#281 评委 prompt 加排版 / 语气中性化**：`judgePromptHash` bump 到 `v5-cot-toolargs-fmt` / `v5-cot-toolargs-fmt-len`。跨此版本的报告分数不可盲比（hash 不同即不同口径，老 hash 去偏更弱）。**无需迁移动作** —— 报告元数据已记录 `judgePromptHash`，读者据此识别口径差异。

## 同版非破坏性改动

- #279 检测同厂商评委 / 单厂商 ensemble 的自我偏好敞口并警告（J1+J2）
- #282 prompt 统一管理：共享去偏块收口 + 评分类 prompt 进 `llm-prompts` + 单一冻结注册表（byte-preserving，hash 不变）
- #284 α 校准「序数加权」误标改 interval + 门控魔数补依据并 drift-guard + 裸 3.5 收口到常量
- #276 删除未接入的 length-debias 校验死代码

## 验证

`yarn ci`（lint + typecheck + build + build:docs:check + test，183 文件 / 2335 用例）本地全过。仅 package.json 版本号 0.40.0 → 0.41.0，无其它硬编码版本号。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
