### PR TITLE
fix(cli): 冷启动首跑修复 —— 脚手架可跑、verdict 中文化、终端不刷 JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ omk init demo && cd demo
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-That's it — no editing required. `omk init` scaffolds two skill variants and three sample cases; `omk eval` runs the controlled A/B and opens an HTML report with a one-line verdict in about five minutes.
+Runs out of the box — no edits needed first. `omk init` scaffolds two skill variants and three sample cases; `omk eval` runs the controlled A/B and opens an HTML report with a one-line verdict in about five minutes. Once it runs, swap in your own skills and cases.
+
+Prerequisite: the default executor and judge use the `claude` CLI — install and log in first (see [Requirements](#requirements)); to use another model or run offline (no API key) see [executors](docs/reference/executors.md).
+
+> The first run has only 3 cases, so the verdict will usually be `UNDERPOWERED` (insufficient data) — that's a normal starting point, not an error; grow to ~20+ cases before trusting a ship/no-ship call.
 
 > The CLI notifies you when a newer version is available (at most once per 20h); set `OMK_SKIP_UPDATE_CHECK=1` to silence it permanently.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -23,7 +23,11 @@ omk init demo && cd demo
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-不用改任何文件 —— `omk init` 帮你脚手架两版 skill 和三条评测用例；`omk eval` 跑控制变量 A/B，5 分钟内出 HTML 报告 + 一行 verdict。
+开箱即跑：`omk init` 脚手架好两版 skill 和三条评测用例，不用先改任何文件，`omk eval` 跑控制变量 A/B，约 5 分钟出 HTML 报告 + 一行 verdict；跑通后再把 skill 和用例换成你自己的。
+
+前置：默认执行器与评委用 `claude` CLI，需先安装并登录（见[系统要求](#系统要求)）；想用别的模型或离线跑（无需 API key）见[执行器](docs/zh/reference/executors.md)。
+
+> 首跑只有 3 条用例，verdict 多半是「数据不足（UNDERPOWERED）」——这是正常起点而非出错；把用例加到约 20 条以上，再看「可发布」结论。
 
 > 命令行有新版本时会自动提示（每 20 小时最多一次）；想永久关闭该提醒，设环境变量 `OMK_SKIP_UPDATE_CHECK=1` 即可。
 

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -71,10 +71,21 @@ function applyGateExitCode(code: number, values: ParsedValues, lang: CliLang): n
   return 0;
 }
 
+/**
+ * 完整 report JSON 是**机器输出**:重定向 / 管道(`omk eval > r.json`、`| jq`)时吐到 stdout 供下游消费。
+ * 交互式 TTY 下报告已存盘、(默认)还起了 report server,再刷上千行 JSON 只会把 verdict 淹没在屏幕外 ——
+ * 故只在非 TTY(stdout 被重定向 / 管道)时 dump。dry-run 的 JSON 是用户显式索取的产物,不走此门控。
+ */
+function emitReportJson(report: unknown): void {
+  if (!process.stdout.isTTY) {
+    console.log(JSON.stringify(report, null, 2));
+  }
+}
+
 async function emitEvaluationVerdict(report: EvaluationReport, values: ParsedValues, lang: CliLang): Promise<number> {
   const { computeVerdict, formatVerdictText } = await import('../../../eval-core/verdict.js');
   const result = computeVerdict(report, verdictOptions(values));
-  console.log(formatVerdictText(result, { verbose: true }));
+  console.log(formatVerdictText(result, { verbose: true, lang }));
   await recordEvidenceSafely(report, result.level, values, lang);
   return verdictPasses(result.level, result.headline) ? 0 : 1;
 }
@@ -309,11 +320,12 @@ async function runEval(
           }
         },
       }) as { report: BatchEvaluationReport | DryRunBatchReport; filePath: string | null };
-      console.log(JSON.stringify(report, null, 2));
       if (isDryRunBatchReport(report)) {
+        console.log(JSON.stringify(report, null, 2));
         console.log(tCli('cli.run.dry_run_no_scores', lang));
         throw new CliExit(0);
       }
+      emitReportJson(report);
       if (filePath) {
         await announceSavedReport({ report, filePath, reportsDir: config.outputDir, values, lang });
       }
@@ -372,7 +384,7 @@ async function runEval(
       }
     }
 
-    console.log(JSON.stringify(report, null, 2));
+    emitReportJson(report);
     if (filePath) {
       await announceSavedReport({ report, filePath, reportsDir: config.outputDir, values, lang });
     }

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -82,10 +82,21 @@ function emitReportJson(report: unknown): void {
   }
 }
 
+/**
+ * 给人读的 verdict 文案:stdout 是 TTY 时进 stdout(交互终端没有 JSON,verdict 就是答案),
+ * 否则进 stderr —— 与 emitReportJson 配对,保证非 TTY 的 stdout 是**纯 report JSON**,
+ * `omk eval | jq` / `> report.json` 不会被末尾拼上的人类文案噎住(否则 JSON.parse 直接失败)。
+ */
+function emitVerdictText(text: string): void {
+  // 与 console.log 等价(对单个字符串 = write(text + '\n')),只切换目标流,逐字节保留既有文案。
+  const stream = process.stdout.isTTY ? process.stdout : process.stderr;
+  stream.write(text + '\n');
+}
+
 async function emitEvaluationVerdict(report: EvaluationReport, values: ParsedValues, lang: CliLang): Promise<number> {
   const { computeVerdict, formatVerdictText } = await import('../../../eval-core/verdict.js');
   const result = computeVerdict(report, verdictOptions(values));
-  console.log(formatVerdictText(result, { verbose: true, lang }));
+  emitVerdictText(formatVerdictText(result, { verbose: true, lang }));
   await recordEvidenceSafely(report, result.level, values, lang);
   return verdictPasses(result.level, result.headline) ? 0 : 1;
 }
@@ -185,13 +196,13 @@ async function emitBatchVerdict(
   const status = lang === 'zh'
     ? (failed === 0 ? '通过' : '未通过')
     : (failed === 0 ? 'PASS' : 'FAIL');
-  console.log(tCli('cli.run.batch_verdict_header', lang, {
+  emitVerdictText(tCli('cli.run.batch_verdict_header', lang, {
     status,
     passed,
     total: results.length,
   }));
   for (const result of results) {
-    console.log(`  ${result.verdict.level}: ${result.treatment} — ${result.verdict.headline}`);
+    emitVerdictText(`  ${result.verdict.level}: ${result.treatment} — ${result.verdict.headline}`);
   }
   return failed === 0 ? 0 : 1;
 }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -14,17 +14,21 @@ const INIT_OMK_GITIGNORE = `# omk 测量 bulk + doctor --fix 备份(项目本地
 /backups/
 `;
 
+// 脚手架用例必须过 omk 自身的断言合规校验(load-samples.ts Rule A),否则新用户照
+// 快速开始跑的第一条 omk eval 会直接硬报错。约束:contains / not_contains 的 value
+// 只能是单个 ASCII token(长度 [2,40]、无内部空白、无 CJK);多词 / 中文语义匹配一律
+// 走 rubric 交评委判;regex pattern 不能含 CJK。改这里前先跑 `omk eval --dry-run`
+// (非 lenient 合规 oracle)与 test/cli/init-scaffold-conformance 回归测试。
 const INIT_SAMPLES = `[
   {
     "sample_id": "s001",
     "prompt": "审查以下代码",
     "context": "function authenticate(username, password) {\\n  const query = \`SELECT * FROM users WHERE name='\${username}' AND pass='\${password}'\`;\\n  return db.execute(query);\\n}",
-    "rubric": "应识别 SQL 注入风险，建议使用参数化查询",
+    "rubric": "应识别 SQL 注入风险，建议使用参数化查询；不应把这段代码判为安全无问题。",
     "assertions": [
       { "type": "contains", "value": "SQL", "weight": 1 },
       { "type": "contains", "value": "injection", "weight": 1 },
-      { "type": "regex", "pattern": "parameterized|prepared|placeholder|bind", "flags": "i", "weight": 0.5 },
-      { "type": "not_contains", "value": "looks good", "weight": 0.5 }
+      { "type": "regex", "pattern": "parameterized|prepared|placeholder|bind", "flags": "i", "weight": 0.5 }
     ],
     "dimensions": {
       "security": "是否准确识别出 SQL 注入漏洞并说明其危害",
@@ -37,8 +41,7 @@ const INIT_SAMPLES = `[
     "context": "async function fetchData(url) {\\n  const res = await fetch(url);\\n  const data = await res.json();\\n  return data;\\n}",
     "rubric": "应指出缺少错误处理（网络异常、非 JSON 响应、HTTP 错误状态码）",
     "assertions": [
-      { "type": "contains", "value": "error handling", "weight": 1 },
-      { "type": "regex", "pattern": "try[\\\\s\\\\S]*catch|exception|error", "flags": "i", "weight": 1 },
+      { "type": "regex", "pattern": "try[\\\\s\\\\S]*catch|catch|exception|error", "flags": "i", "weight": 1 },
       { "type": "contains", "value": "status", "weight": 0.5 }
     ],
     "dimensions": {
@@ -165,9 +168,9 @@ export default class Init extends BaseCommand {
       console.log(tCli('cli.init.scaffolded', lang, { dir: targetDir }));
       console.log('');
       console.log(tCli('cli.init.next_steps_title', lang));
-      console.log(tCli('cli.init.next_step_edit_samples', lang));
-      console.log(tCli('cli.init.next_step_edit_skills', lang));
       console.log(tCli('cli.init.next_step_run', lang));
+      console.log(tCli('cli.init.next_step_executor', lang));
+      console.log(tCli('cli.init.next_step_customize', lang));
       console.log(tCli('cli.init.note_codex_executor', lang));
     });
   }

--- a/src/cli/lib/i18n-dict/init.ts
+++ b/src/cli/lib/i18n-dict/init.ts
@@ -3,31 +3,34 @@ import type { CliMessage } from './types.js';
 export type InitMessageKey =
   | 'cli.init.scaffolded'
   | 'cli.init.next_steps_title'
-  | 'cli.init.next_step_edit_samples'
-  | 'cli.init.next_step_edit_skills'
   | 'cli.init.next_step_run'
+  | 'cli.init.next_step_executor'
+  | 'cli.init.next_step_customize'
   | 'cli.init.note_codex_executor';
 
 export const initDict: Record<InitMessageKey, CliMessage> = {
   'cli.init.scaffolded': {
-    zh: '已初始化 omk 项目: {dir}',
+    zh: '已初始化 omk 项目：{dir}',
     en: 'omk project initialized at: {dir}',
   },
   'cli.init.next_steps_title': {
-    zh: '下一步:',
+    zh: '下一步：',
     en: 'Next steps:',
   },
-  'cli.init.next_step_edit_samples': {
-    zh: '  1. 编辑 eval-samples.json，加入你要测的评测用例',
-    en: '  1. Edit eval-samples.json to add your test cases',
-  },
-  'cli.init.next_step_edit_skills': {
-    zh: '  2. 编辑 skills/code-review-v1/SKILL.md 和 skills/code-review-v2/SKILL.md, 为两个 skill 版本填入实际内容',
-    en: '  2. Edit skills/code-review-v1/SKILL.md and skills/code-review-v2/SKILL.md with your skill versions',
-  },
+  // 先让用户「无需改任何文件直接跑通」——脚手架的用例与 skill 本身可跑(已过合规校验),
+  // 跑出第一份报告是冷启动最该先发生的事;「换成你自己的」放到跑通之后。这也消除了
+  // 主 README「不用改任何文件」与旧 init「先编辑」的矛盾。
   'cli.init.next_step_run': {
-    zh: '  3. 运行: omk eval --control code-review-v1 --treatment code-review-v2',
-    en: '  3. Run: omk eval --control code-review-v1 --treatment code-review-v2',
+    zh: '  1. 直接跑通（无需先改任何文件）：omk eval --control code-review-v1 --treatment code-review-v2',
+    en: '  1. Run it as-is (no edits needed): omk eval --control code-review-v1 --treatment code-review-v2',
+  },
+  'cli.init.next_step_executor': {
+    zh: '     默认执行器与评委用 claude CLI，需先装好并登录；想换别的模型或离线跑（无需 API key）见文档「执行器」。',
+    en: '     The default executor and judge use the claude CLI (install and log in first); to use another model or run offline (no API key) see the Executors docs.',
+  },
+  'cli.init.next_step_customize': {
+    zh: '  2. 跑通后，把 skills/code-review-v1/SKILL.md 和 skills/code-review-v2/SKILL.md 与 eval-samples.json 换成你自己的 skill 和用例',
+    en: '  2. Once it runs, replace skills/code-review-v1/SKILL.md and skills/code-review-v2/SKILL.md and eval-samples.json with your own skills and cases',
   },
   'cli.init.note_codex_executor': {
     zh: '\n注: omk 评测时把 SKILL.md 整文(含 frontmatter)作为 system prompt 注入——跨 executor 一致(claude / codex / openai-api / gemini 都走同一条路径,不依赖任何 executor 的 native skill auto-discovery 或 Skill 工具机制)。frontmatter 在 prompt 头部对 model 行为无显著影响。\n模板带 Claude Code 兼容的 frontmatter(name + description)是为了让同一份 directory-skill 也能 deploy 到 Claude Code:把整个目录复制到 ~/.claude/skills/code-review-v1/(整目录,不是单个 SKILL.md),Claude SDK 才能识别。这是 omk 评测之外的 bonus,一份文件双向 dogfood。',

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -85,10 +85,14 @@ export function getCliVersion(): string {
 }
 
 export function getGitInfo(): GitInfo | null {
+  // stdio 静默 stderr:在非 git 目录(如 omk init 出来的 demo)里 rev-parse 会打印
+  // `fatal: not a git repository` 到终端。catch 已把失败兜成 null(报告省略 git 信息),
+  // 这条 fatal 对用户是纯噪声,吞掉它。与 skill-loader 的 GIT_PROBE_STDIO 同口径。
+  const gitProbeStdio: ['ignore', 'pipe', 'ignore'] = ['ignore', 'pipe', 'ignore'];
   try {
-    const commit = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim();
-    const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf-8' }).trim();
-    const dirty = execFileSync('git', ['status', '--porcelain'], { encoding: 'utf-8' }).trim().length > 0;
+    const commit = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8', stdio: gitProbeStdio }).trim();
+    const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf-8', stdio: gitProbeStdio }).trim();
+    const dirty = execFileSync('git', ['status', '--porcelain'], { encoding: 'utf-8', stdio: gitProbeStdio }).trim().length > 0;
     return { commit, commitShort: commit.slice(0, 7), branch, dirty };
   } catch {
     return null;

--- a/src/eval-core/verdict.ts
+++ b/src/eval-core/verdict.ts
@@ -28,7 +28,7 @@
  * empirical) is documented inline so users can audit and override.
  */
 
-import type { GapReport, Report, VariantPairComparison, VariantSummary } from '../types/index.js';
+import type { GapReport, Lang, Report, VariantPairComparison, VariantSummary } from '../types/index.js';
 import { evaluateLayerGates } from './layer-gates.js';
 import { ciLevelLabel } from './bootstrap.js';
 import { analyzeJudgeIndependence } from './judge-independence.js';
@@ -642,7 +642,23 @@ function gapSignalCaveat(report: Report): {
   };
 }
 
-function recommendation(level: VerdictLevel, _perPair: Array<{ level: VerdictLevel }>): string {
+function recommendation(level: VerdictLevel, _perPair: Array<{ level: VerdictLevel }>, lang: Lang = 'en'): string {
+  if (lang === 'zh') {
+    switch (level) {
+      case 'PROGRESS':
+        return '可发布 —— 实验组显著更优，且通过所有分层门控。';
+      case 'CAUTIOUS':
+        return '需排查 —— 提升是真的，但至少触发了一条告警（门控破损 / 提升微不足道 / 仅部分恢复 / 评委分歧 / 跨轮不稳 / 训练-留出过拟合）。不要盲发。';
+      case 'REGRESS':
+        return '勿发布 —— 实验组退步。检查最差的那一层，修好再重跑。';
+      case 'NOISE':
+        return '不下结论 —— 差异置信区间跨过 0，当前 N 下分辨不出效果。';
+      case 'UNDERPOWERED':
+        return '数据不足 —— 增加用例数（建议 2× 当前）后重跑。';
+      case 'SOLO':
+        return '缺对照 —— 单变体报告。用 --control baseline --treatment <名字> 重跑。';
+    }
+  }
   switch (level) {
     case 'PROGRESS':
       return 'SHIP — treatment is significantly better and passes all layer gates.';
@@ -663,20 +679,26 @@ function recommendation(level: VerdictLevel, _perPair: Array<{ level: VerdictLev
  * Plain-text formatter for the `omk eval` verdict. Stays under 6 lines per the
  *  spec — one verdict + four rationale bullets + one ship recommendation.
  */
-export function formatVerdictText(result: VerdictResult, options: { verbose?: boolean } = {}): string {
+export function formatVerdictText(result: VerdictResult, options: { verbose?: boolean; lang?: Lang } = {}): string {
+  // lang 默认 'en':保留既有英文输出逐字节不变(verdict.test 与历史 CLI 行为)。zh 只本地化
+  //  标签与 ship 建议;headline 是 Δ/CI/N 统计记号 —— 跨语言中性、且会随 report 持久化,
+  //  不翻译(翻它=改可比性锚点)。recommendation 在 format 时按 lang 重新派生,不动 computeVerdict。
+  const zh = options.lang === 'zh';
   const lines: string[] = [];
-  lines.push(`Verdict: ${result.level}`);
+  lines.push(zh ? `判定：${result.level}` : `Verdict: ${result.level}`);
   lines.push(`  ${result.headline}`);
-  if (result.rationale.layerWinners) lines.push(`  Layer winners: ${result.rationale.layerWinners}`);
-  if (result.rationale.sampleSize) lines.push(`  Sample size:   ${result.rationale.sampleSize}`);
-  if (result.rationale.stability) lines.push(`  Stability:     ${result.rationale.stability}`);
-  if (result.rationale.judgeAgreement) lines.push(`  Judge α:       ${result.rationale.judgeAgreement}`);
-  if (result.rationale.overfitting) lines.push(`  Overfitting:   ${result.rationale.overfitting}`);
-  if (result.rationale.gapSignal) lines.push(`  Gap signal:    ${result.rationale.gapSignal}`);
-  if (result.rationale.shipRecommendation) lines.push(`  ${result.rationale.shipRecommendation}`);
+  if (result.rationale.layerWinners) lines.push(zh ? `  分层优胜：${result.rationale.layerWinners}` : `  Layer winners: ${result.rationale.layerWinners}`);
+  if (result.rationale.sampleSize) lines.push(zh ? `  用例规模：${result.rationale.sampleSize}` : `  Sample size:   ${result.rationale.sampleSize}`);
+  if (result.rationale.stability) lines.push(zh ? `  跨轮稳定：${result.rationale.stability}` : `  Stability:     ${result.rationale.stability}`);
+  if (result.rationale.judgeAgreement) lines.push(zh ? `  评委 α：${result.rationale.judgeAgreement}` : `  Judge α:       ${result.rationale.judgeAgreement}`);
+  if (result.rationale.overfitting) lines.push(zh ? `  过拟合：${result.rationale.overfitting}` : `  Overfitting:   ${result.rationale.overfitting}`);
+  if (result.rationale.gapSignal) lines.push(zh ? `  知识缺口：${result.rationale.gapSignal}` : `  Gap signal:    ${result.rationale.gapSignal}`);
+  if (result.rationale.shipRecommendation) {
+    lines.push(`  ${zh ? recommendation(result.level, [], 'zh') : result.rationale.shipRecommendation}`);
+  }
   if (options.verbose && result.perPair && result.perPair.length > 1) {
     lines.push('');
-    lines.push('  Per-pair detail:');
+    lines.push(zh ? '  逐对明细：' : '  Per-pair detail:');
     for (const p of result.perPair) {
       lines.push(`    ${p.level}: ${p.treatment} vs ${p.control} — ${p.headline}`);
     }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -433,7 +433,8 @@ describe('CLI', () => {
         (err: unknown) => {
           const e = err as ExecError;
           assert.equal(e.code, 1);
-          assert.ok(e.stdout.includes('Verdict:'), e.stdout);
+          // verdict 文案随 lang 本地化(判定：/ Verdict:),这里只验「打印了 verdict 行」,与语言无关。
+          assert.ok(/判定：|Verdict:/.test(e.stdout), e.stdout);
           assert.ok(e.stderr.includes('omk studio'), e.stderr);
           assert.ok(e.stderr.includes(`--reports-dir ${join(dir, 'reports')}`), e.stderr);
           return true;
@@ -463,7 +464,8 @@ describe('CLI', () => {
         env: { ...process.env, HOME: dir },
         maxBuffer: 2 * 1024 * 1024,
       });
-      assert.ok(stdout.includes('Verdict:'), stdout);
+      // verdict 文案随 lang 本地化(判定：/ Verdict:),这里只验「打印了 verdict 行」,与语言无关。
+      assert.ok(/判定：|Verdict:/.test(stdout), stdout);
       assert.ok(stderr.includes('report-only'), stderr);
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -433,8 +433,10 @@ describe('CLI', () => {
         (err: unknown) => {
           const e = err as ExecError;
           assert.equal(e.code, 1);
-          // verdict 文案随 lang 本地化(判定：/ Verdict:),这里只验「打印了 verdict 行」,与语言无关。
-          assert.ok(/判定：|Verdict:/.test(e.stdout), e.stdout);
+          // 非 TTY:verdict 文案走 stderr,stdout 留作纯 report JSON。verdict 随 lang 本地化(判定：/ Verdict:)。
+          assert.ok(/判定：|Verdict:/.test(e.stderr), e.stderr);
+          const parsed = JSON.parse(e.stdout) as { kind?: unknown };
+          assert.ok(typeof parsed.kind === 'string', `stdout 应为纯 report JSON:\n${e.stdout.slice(0, 200)}`);
           assert.ok(e.stderr.includes('omk studio'), e.stderr);
           assert.ok(e.stderr.includes(`--reports-dir ${join(dir, 'reports')}`), e.stderr);
           return true;
@@ -464,8 +466,11 @@ describe('CLI', () => {
         env: { ...process.env, HOME: dir },
         maxBuffer: 2 * 1024 * 1024,
       });
-      // verdict 文案随 lang 本地化(判定：/ Verdict:),这里只验「打印了 verdict 行」,与语言无关。
-      assert.ok(/判定：|Verdict:/.test(stdout), stdout);
+      // 回归(reviewer #290):非 TTY 下 stdout 必须是纯 report JSON,`omk eval | jq` 能直接消费;
+      // verdict 文案走 stderr,不再拼到 stdout 末尾把 JSON.parse 噎死。
+      const parsed = JSON.parse(stdout) as { kind?: unknown };
+      assert.ok(typeof parsed.kind === 'string', `stdout 应为纯 report JSON:\n${stdout.slice(0, 200)}`);
+      assert.ok(/判定：|Verdict:/.test(stderr), stderr);
       assert.ok(stderr.includes('report-only'), stderr);
     } finally {
       await rm(dir, { recursive: true, force: true });
@@ -492,9 +497,12 @@ describe('CLI', () => {
         (err: unknown) => {
           const e = err as ExecError;
           assert.equal(e.code, 1);
-          assert.ok(e.stdout.includes('批量评测结论：未通过'), e.stdout);
-          assert.ok(!e.stdout.includes('Batch verdict:'), e.stdout);
-          assert.ok(e.stdout.includes('UNDERPOWERED:'), e.stdout);
+          // 非 TTY:批量结论文案走 stderr,stdout 留作纯 batch report JSON(machine 消费)。
+          const parsed = JSON.parse(e.stdout) as { kind?: unknown };
+          assert.ok(typeof parsed.kind === 'string', `stdout 应为纯 batch report JSON:\n${e.stdout.slice(0, 200)}`);
+          assert.ok(e.stderr.includes('批量评测结论：未通过'), e.stderr);
+          assert.ok(!e.stderr.includes('Batch verdict:'), e.stderr);
+          assert.ok(e.stderr.includes('UNDERPOWERED:'), e.stderr);
           assert.ok(e.stderr.includes('omk studio'), e.stderr);
           return true;
         },

--- a/test/cli/init-scaffold-conformance.test.ts
+++ b/test/cli/init-scaffold-conformance.test.ts
@@ -1,0 +1,56 @@
+/**
+ * 回归:`omk init` 脚手架出来的 eval-samples.json 必须过 omk 自身的**严格**断言合规
+ * 校验(load-samples.ts Rule A)。
+ *
+ * 为什么需要这条:vitest 全局设了 OMK_LENIENT_ASSERTIONS=1(让历史 fixture 继续加载),
+ * 于是脚手架里违规的断言(多词 contains / not_contains)在测试里被降级成 warning、悄悄
+ * 漏过——而真实用户照「快速开始」跑的第一条 omk eval 是**非 lenient** 的,会直接硬报错。
+ * 本测试显式删掉 lenient 开关,在用户实际经历的严格路径上锁住脚手架用例的合规性。
+ */
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { loadSamples } from '../../src/inputs/load-samples.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = join(__dirname, '..', '..', 'dist', 'cli', 'index.js');
+
+// 在严格(非 lenient)模式下执行 fn:存档并临时删掉全局的 OMK_LENIENT_ASSERTIONS,
+// 复刻真实用户的非 lenient 路径,结束后还原。
+function withStrictAssertions(fn: () => void): void {
+  const orig = process.env.OMK_LENIENT_ASSERTIONS;
+  delete process.env.OMK_LENIENT_ASSERTIONS;
+  try { fn(); }
+  finally {
+    if (orig === undefined) delete process.env.OMK_LENIENT_ASSERTIONS;
+    else process.env.OMK_LENIENT_ASSERTIONS = orig;
+  }
+}
+
+describe('omk init scaffold passes strict assertion conformance', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'omk-init-conformance-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('scaffolded eval-samples.json loads without hard error in strict mode', () => {
+    execFileSync('node', [CLI, 'init', tmpDir], { stdio: 'pipe' });
+    const samplesPath = join(tmpDir, 'eval-samples.json');
+
+    withStrictAssertions(() => {
+      // 不抛即为合规:用户照快速开始跑的第一条 omk eval 不会在这里硬报错。
+      const result = loadSamples(samplesPath);
+      // sanity:确认校验确实跑在非空用例上(空数组会 vacuously 通过,起不到守护作用)。
+      assert.ok(result.samples.length >= 3, `expected ≥3 scaffolded samples, got ${result.samples.length}`);
+    });
+  });
+});


### PR DESCRIPTION
## 这在解决啥

我以一个全新用户的身份，照 README「快速开始」一字不差走了一遍 `omk init → omk eval`，结果**文档化的主路径开箱即坏**：第一条 `omk eval` 直接硬报错，绕过去之后终端又被上千行 JSON 刷屏、verdict 被淹没。这个 PR 把这条首跑路径上撞到的卡点一并修掉，让新用户真能在几分钟内拿到第一份报告。

## 用户影响

- **开箱能跑了**：`omk init` 脚手架的评测用例之前带了违规断言（多词 `contains` / `not_contains`），新用户跑的第一条 `omk eval`（非 lenient）会直接 ❌ 硬报错。现在脚手架用例全部合规，照快速开始跑能直接出报告。
- **终端清爽了**：`omk eval` 之前无条件把整份报告 JSON（约一千行）倒进终端、把 verdict 顶到屏幕外。现在交互终端只留 verdict + 报告路径 + report server；JSON 只在被管道 / 重定向时输出（`omk eval > r.json`、`| jq` 照旧）。
- **中文用户不再读英文 verdict**：CLI 的 verdict 文案随语言本地化（判定 / 用例规模 / 发布建议等），不再中英混排。
- **少了一句吓人的报错**：在非 git 目录（比如 `omk init` 出来的 demo）里不再向终端漏 `fatal: not a git repository`。
- **首跑预期对齐**：`omk init` 的下一步改成「先直接跑通（无需改文件）→ 跑通后再换成你自己的」并补上执行器前置说明，消除了与 README「不用改任何文件」的矛盾；README 也说明了「首跑只有 3 条用例、verdict 多半是 UNDERPOWERED 属正常起点」，避免第一份结论让人误以为出错。

## 测量学 caveat

不涉及任何测量学不变量：report JSON schema、judge prompt hash、bootstrap / α、五层管道、verdict 分级与阈值都没动。verdict 文案的本地化只改展示层——英文输出逐字节不变，headline 的 Δ/CI/N 统计记号跨语言中性、保持原样，`computeVerdict` 与落盘报告内容不变。故非 `BREAKING-COMPARABILITY`。

## 防回归

新增严格模式回归测试，锁住「脚手架用例必须过非 lenient 合规校验」——当初这颗雷漏出，正是因为 vitest 全局开了 lenient 把违规降级成了 warning。

延续此前冷启动方向（examples 重策划 #288 / #289）：那两个 PR 修的是次要面（仓库示例画廊），这个 PR 修的是 npm 用户就地可跑的主入口 `omk init`。