### PR TITLE
chore(release): 发布 0.42.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 这一版发什么

0.41.0 之后累积的改进打包发版，覆盖外部效度、覆盖度诊断与冷启动首跑体验。无 BREAKING-COMPARABILITY，老报告与评分口径不变。

主要内容（自 0.41.0）：

- 评测加 opt-in holdout + 过拟合硬门控 + 知识缺口软提示接进 verdict（#286）。
- 用例构成偏度诊断 + observe→trace 回灌按频次分层，外部效度第五轴收官，纯加法（#287）。
- examples 测试 fixture 解耦进 test/fixtures，examples 重策划成冷启动学习路径（#288、#289）。
- 冷启动首跑修复：`omk init` 脚手架开箱能跑、verdict 中文化、交互终端不再刷报告 JSON、非 git 目录不漏 git fatal、README/init 文案对齐（#290）。

## 用户影响

新用户照「快速开始」走 `omk init → omk eval` 现在开箱即跑、终端清爽；脚本管道 `omk eval | jq` 拿到的是纯 report JSON。测量学不变量（report schema / judge prompt hash / bootstrap / α / 五层管道 / verdict 分级）均未改动。

合并后打 tag `v0.42.0` 触发 npm 发布。