### PR TITLE
chore(release): 发布 0.43.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 0.43.0，包含最近合入的示例重建、评测用例存放约定收紧，以及 doctor 侧 Skill Information Graph / Evidence Card 伴生产物。

## 迁移说明

- 目录 skill 的标准评测用例位置收敛为 skill 私有 `.omk/samples.json`。
- 历史报告落档命名会按新规范读取与迁移，用户无需手动搬迁。
- 本次不新增一级命令，信息图谱继续伴随 `doctor` / `eval` / `observe` 路径推进。

## 测量学说明

- 不修改评分类 prompt hash。
- 不改变既有 report schema 字段语义。
- 不改变 `doctor` / `eval` / `observe` 的判定口径；图谱与 Evidence Card 是伴生产物，生成失败不应改变主命令结论。

## 关联

- #292
- #293
- #294