### PR TITLE
feat(eval-core): 生成 eval 信息图谱伴生产物

### DIFF
--- a/docs/specs/storage-layout-spec.md
+++ b/docs/specs/storage-layout-spec.md
@@ -32,10 +32,12 @@ In one line: keep + tied to a project → local; rebuildable → toss into the w
 
 The measurement outputs in the first row are placed the same way (project-local default + global fallback on read + gitignored). Primary writers reach global through the `--global` switch: `reports` / `observe-health` / `doctors` write global when scoring against a standard sample set (see section 4), and `observe-inbox` supports it too (`omk observe ingest --global` to write, `omk observe inbox --global` to read), completing the observation loop for a global skill. Sidecar trees such as `graphs` inherit the output root of the writer that produced them, instead of inventing their own routing. `managed` is the exception — no switch, routing by where the governed skill is installed.
 
-Doctor graph sidecars keep the sibling layout for the standard report directory:
-`.omk/doctors` → `.omk/graphs/doctor`. If a user passes an arbitrary custom
-`--output-dir` that is not named `doctors`, graph sidecars stay inside that
-explicit directory: `<output-dir>/graphs/doctor`.
+Doctor and eval graph sidecars keep the sibling layout for standard report
+directories: `.omk/doctors` → `.omk/graphs/doctor`, and `.omk/reports` →
+`.omk/graphs/eval`. If a user passes an arbitrary custom `--output-dir` that is
+not named after the standard writer directory, graph sidecars stay inside that
+explicit directory, for example `<output-dir>/graphs/doctor` or
+`<output-dir>/graphs/eval`.
 
 ## 3. What it ends up looking like
 
@@ -62,7 +64,7 @@ explicit directory: `<output-dir>/graphs/doctor`.
 Directories and filenames deliberately carry different bits of meaning:
 
 - **The directory carries the product domain.** For example, `.omk/doctors/` already says "doctor", and `.omk/graphs/doctor/` already says "doctor graph sidecar"; filenames do not repeat those domain words.
-- **Every run-derived artifact uses `<subject>-<runSuffix>.<artifactKind>.<ext>`.** `subject` is usually the skill or artifact name, `runSuffix` is the timestamp/counter/random tail that makes the run unique, `artifactKind` says what the file is, and `ext` says how to parse it.
+- **Every run-derived artifact uses `<subject>-<runSuffix>.<artifactKind>.<ext>`.** `subject` is usually the skill or artifact name (for eval, the primary non-baseline treatment rather than the full control-vs-treatment relationship), `runSuffix` is the timestamp + random tail that makes the run unique, `artifactKind` says what the file is, and `ext` says how to parse it.
 - **Human and machine twins must differ before the extension.** Prefer `.graph.json`, `.card.md`, `.summary.json`, etc. over sibling files that only differ by `.json` versus `.md`.
 - **Fixed source/config files keep human names.** `eval-samples.json`, `<skill>/.omk/samples.json`, `eval.yaml`, `metadata.yaml`, and `review-state.json` are source/config/state conventions, not run sidecars, so they do not need the run-derived grammar.
 
@@ -75,12 +77,13 @@ directories are skipped.
 Examples:
 
 ```
-.omk/reports/baseline-vs-service-guide-20260620-105109-aqgq.report.json
-.omk/doctors/service-guide-20260620T105109-1-aqgq.report.json
+.omk/reports/service-guide-20260620T105109-aqgq.report.json
+.omk/doctors/service-guide-20260620T105109-aqgq.report.json
 .omk/observe-health/20260620T105109-aqgq.report.json
 .omk/observe-inbox/20260620T105109-aqgq.report.json
-.omk/graphs/doctor/service-guide-20260620T051909-1-aqgq.graph.json
-.omk/graphs/doctor/service-guide-20260620T051909-1-aqgq.card.md
+.omk/graphs/eval/service-guide-20260620T105109-aqgq.graph.json
+.omk/graphs/doctor/service-guide-20260620T051909-aqgq.graph.json
+.omk/graphs/doctor/service-guide-20260620T051909-aqgq.card.md
 ```
 
 ## 4. Skill, measurement, governance are three layers — don't mix them into one column
@@ -130,7 +133,7 @@ A few points:
 - **Escape hatches don't mix in cards**: `--global` and an explicit `--reports-dir` / `--doctors-dir` / `--analyses-dir` look only at the one directory you named, no cards merged — clean.
 - **`observe-inbox` is deliberately not indexed**: the `domain`s are only `report` / `doctor` / `observe-health`, not `observe-inbox`. The discovery index serves *comparable review artifacts* (conclusions you'd browse and compare across projects); the inbox is the current project's triage workbench, and browsing project B's to-do queue inside project A's studio is low-value and easy to act on by mistake. So the summary (observe-health) is indexed while the raw queue (observe-inbox) is not — an intentional boundary; it still supports `--global` write / read, it just isn't aggregated machine-wide.
 
-Separately, `id`s get a uniform random suffix to prevent name collisions (two projects producing artifacts in the same second could collide, and dedup would wrongly merge them and silently lose data): report uses "second + random", doctor uses "second + counter + random", observe-health filenames carry a random segment. An `id` is just a label, not a computed score, so this change **does not affect cross-version comparability**.
+Separately, `id`s get a uniform random suffix to prevent name collisions (two projects producing artifacts in the same second could collide, and dedup would wrongly merge them and silently lose data): report, doctor, and observe-health filenames all carry "second + random". An `id` is just a label, not a computed score, so this change **does not affect cross-version comparability**.
 
 ## 7. What gets auto-cleaned vs kept forever
 

--- a/docs/zh/specs/storage-layout-spec.md
+++ b/docs/zh/specs/storage-layout-spec.md
@@ -32,7 +32,7 @@
 
 第一行测量产物放法一致（项目本地默认 + 全局兜底读 + 默认 gitignore）。主写入命令用 `--global` 写全局：`reports` / `observe-health` / `doctors` 拿标准用例集跑分时写全局（见第四节），`observe-inbox` 也支持（`omk observe ingest --global` 写、`omk observe inbox --global` 读），补全全局 skill 的观测闭环。`graphs` 这类 sidecar 跟随产生它的主产物输出根目录，不另起一套路由。`managed` 是例外，不靠开关，按被治理 skill 装在哪自动走。
 
-doctor graph sidecar 对标准报告目录保留 sibling 布局：`.omk/doctors` → `.omk/graphs/doctor`。如果用户传入的自定义 `--output-dir` 不是名为 `doctors` 的标准目录，graph sidecar 留在显式目录内部：`<output-dir>/graphs/doctor`。
+doctor 和 eval graph sidecar 对标准报告目录保留 sibling 布局：`.omk/doctors` → `.omk/graphs/doctor`，`.omk/reports` → `.omk/graphs/eval`。如果用户传入的自定义 `--output-dir` 不是对应主写入命令的标准目录，graph sidecar 留在显式目录内部，例如 `<output-dir>/graphs/doctor` 或 `<output-dir>/graphs/eval`。
 
 ## 三、最终长这样
 
@@ -59,7 +59,7 @@ doctor graph sidecar 对标准报告目录保留 sibling 布局：`.omk/doctors`
 目录和文件名各自承载不同含义：
 
 - **目录表达产品域**。例如 `.omk/doctors/` 已经说明这是 doctor，`.omk/graphs/doctor/` 已经说明这是 doctor 产生的图谱 sidecar；文件名不再重复这些 domain 词。
-- **所有 run-derived artifact 都用 `<subject>-<runSuffix>.<artifactKind>.<ext>`**。`subject` 通常是 skill 或 artifact 名，`runSuffix` 是让本次运行唯一的时间戳 / 计数 / 随机后缀，`artifactKind` 说明文件是什么，`ext` 说明怎么解析。
+- **所有 run-derived artifact 都用 `<subject>-<runSuffix>.<artifactKind>.<ext>`**。`subject` 通常是 skill 或 artifact 名（eval 取主评测对象，也就是非 baseline treatment，而不是完整 control-vs-treatment 关系），`runSuffix` 是让本次运行唯一的时间戳 + 随机后缀，`artifactKind` 说明文件是什么，`ext` 说明怎么解析。
 - **人读 / 机读双文件要在扩展名前区分**。优先用 `.graph.json`、`.card.md`、`.summary.json`，不要只靠 `.json` 和 `.md` 区分一对 sidecar。
 - **固定源文件 / 配置文件保留人类可读名**。`eval-samples.json`、`<skill>/.omk/samples.json`、`eval.yaml`、`metadata.yaml`、`review-state.json` 是源数据 / 配置 / 状态约定，不套 run-derived 语法。
 
@@ -68,12 +68,13 @@ doctor graph sidecar 对标准报告目录保留 sibling 布局：`.omk/doctors`
 示例：
 
 ```
-.omk/reports/baseline-vs-service-guide-20260620-105109-aqgq.report.json
-.omk/doctors/service-guide-20260620T105109-1-aqgq.report.json
+.omk/reports/service-guide-20260620T105109-aqgq.report.json
+.omk/doctors/service-guide-20260620T105109-aqgq.report.json
 .omk/observe-health/20260620T105109-aqgq.report.json
 .omk/observe-inbox/20260620T105109-aqgq.report.json
-.omk/graphs/doctor/service-guide-20260620T051909-1-aqgq.graph.json
-.omk/graphs/doctor/service-guide-20260620T051909-1-aqgq.card.md
+.omk/graphs/eval/service-guide-20260620T105109-aqgq.graph.json
+.omk/graphs/doctor/service-guide-20260620T051909-aqgq.graph.json
+.omk/graphs/doctor/service-guide-20260620T051909-aqgq.card.md
 ```
 
 ## 四、skill、测量、治理是三层，别混成一栏
@@ -123,7 +124,7 @@ doctor graph sidecar 对标准报告目录保留 sibling 布局：`.omk/doctors`
 - **逃生舱不掺卡片**：`--global` 和显式指定的 `--reports-dir` / `--doctors-dir` / `--analyses-dir` 只看你点名的那一个目录，不并卡片，干净。
 - **`observe-inbox` 故意不进索引**：`domain` 只有 `report` / `doctor` / `observe-health` 三类、没有 `observe-inbox`。发现索引服务的是「可比的复盘产物」（你会跨项目浏览、对照的结论）；收件箱是当前项目的 triage 工作台，在 A 项目的 studio 里翻 B 项目的待办队列价值低又容易误操作。所以汇总（observe-health）进索引、原始待办（observe-inbox）不进，是有意的边界——它照样支持 `--global` 写 / 读，只是不做机器级跨项目聚合。
 
-另外 `id` 统一加了随机后缀防撞名（两个项目同一秒出产物，撞了 id 会被去重误并、悄悄丢数据）：report 用「秒 + 随机」、doctor 用「秒 + 计数 + 随机」、observe-health 文件名带随机段。`id` 只是个标签、不是算出来的分数，这个改动**不影响跨版本可比性**。
+另外 `id` 统一加了随机后缀防撞名（两个项目同一秒出产物，撞了 id 会被去重误并、悄悄丢数据）：report、doctor、observe-health 文件名都带「秒 + 随机」。`id` 只是个标签、不是算出来的分数，这个改动**不影响跨版本可比性**。
 
 ## 七、什么自动清、什么永远留
 

--- a/src/artifact-graph/eval.ts
+++ b/src/artifact-graph/eval.ts
@@ -1,0 +1,466 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { graphFileName } from '../eval-core/artifact-file-names.js';
+import type {
+  ArtifactGraphBinding,
+  ArtifactGraphDocument,
+  ArtifactGraphEdge,
+  ArtifactGraphEdgeKind,
+  ArtifactGraphEvidenceRef,
+  ArtifactGraphNode,
+  ArtifactGraphNodeKind,
+  ArtifactGraphNodeRole,
+  ArtifactGraphStatus,
+  EvaluationReport,
+  SampleSnapshot,
+  VariantConfig,
+  VariantResult,
+} from '../types/index.js';
+
+export interface BuildEvalGraphOptions {
+  report: EvaluationReport;
+  sourcePath: string;
+  generatedAt?: string;
+}
+
+export interface PersistEvalGraphOptions extends BuildEvalGraphOptions {
+  outputDir: string;
+  fileStem?: string;
+}
+
+export interface PersistEvalGraphResult {
+  graphPath: string;
+}
+
+function shortHash(input: string): string {
+  return createHash('sha256').update(input).digest('hex').slice(0, 12);
+}
+
+function jsonPointerToken(value: string): string {
+  return value.replaceAll('~', '~0').replaceAll('/', '~1');
+}
+
+function sampleSetHash(sampleHashes: Record<string, string> | undefined): string | undefined {
+  if (!sampleHashes || Object.keys(sampleHashes).length === 0) return undefined;
+  const canonical = Object.entries(sampleHashes)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([id, hash]) => `${id}:${hash}`)
+    .join('|');
+  return shortHash(canonical);
+}
+
+function statusFromScore(score: number | undefined): ArtifactGraphStatus {
+  // Display band only. This is not the verdict gate and intentionally does not
+  // reference DEFAULT_GATE_THRESHOLD or statistical significance decisions.
+  if (score === undefined || !Number.isFinite(score)) return 'unknown';
+  if (score >= 4) return 'ok';
+  if (score >= 3) return 'warning';
+  return 'failed';
+}
+
+function assertionStatus(result: VariantResult): ArtifactGraphStatus {
+  // Assertion topology status only. Pure LLM-scored samples have no assertion
+  // pass/fail edge, so they stay unknown here even when compositeScore is high.
+  if (result.error || !result.ok) return 'failed';
+  const details = result.assertions?.details;
+  if (!details || details.length === 0) return 'unknown';
+  return details.every((detail) => detail.passed) ? 'ok' : 'failed';
+}
+
+function artifactBinding(variant: string, hash: string | undefined): ArtifactGraphBinding {
+  if (hash && hash !== 'no-skill') {
+    return { bindingStrength: 'content-hash', keys: { artifactHash: hash } };
+  }
+  return { bindingStrength: 'name-only', keys: { variantName: variant } };
+}
+
+function sampleBinding(sampleId: string, hash: string | undefined): ArtifactGraphBinding {
+  if (hash) {
+    return { bindingStrength: 'content-hash', keys: { sampleHash: hash } };
+  }
+  return { bindingStrength: 'name-only', keys: { sampleId } };
+}
+
+function variantConfigByName(report: EvaluationReport): Map<string, VariantConfig> {
+  return new Map((report.meta.variantConfigs ?? []).map((config) => [config.variant, config]));
+}
+
+function scopeArtifactKind(report: EvaluationReport): ArtifactGraphDocument['scope']['artifactKind'] {
+  const kinds = new Set((report.meta.variantConfigs ?? [])
+    .map((config) => config.artifactKind)
+    .filter((kind) => kind !== 'baseline'));
+  return kinds.size === 1 ? [...kinds][0] : undefined;
+}
+
+function sampleEvidence(report: EvaluationReport, sampleId: string): ArtifactGraphEvidenceRef[] {
+  return [{
+    sourceKind: 'sample',
+    sourceId: sampleId,
+    selector: { selectorKind: 'sample-id', value: sampleId },
+    contentHash: report.meta.sampleHashes?.[sampleId],
+    label: sampleId,
+  }];
+}
+
+function evalResultEvidence(report: EvaluationReport, resultIndex: number, variant: string): ArtifactGraphEvidenceRef[] {
+  return [{
+    sourceKind: 'eval-report',
+    sourceId: report.id,
+    selector: {
+      selectorKind: 'json-pointer',
+      value: `/results/${resultIndex}/variants/${jsonPointerToken(variant)}`,
+    },
+    label: `${variant} result`,
+  }];
+}
+
+function assertionEvidence(
+  report: EvaluationReport,
+  sampleId: string,
+  index: number,
+  resultIndex?: number,
+  variant?: string,
+): ArtifactGraphEvidenceRef[] {
+  if (report.sampleSnapshots?.[sampleId]?.assertions?.[index]) {
+    return [{
+      sourceKind: 'sample',
+      sourceId: sampleId,
+      selector: {
+        selectorKind: 'json-pointer',
+        value: `/sampleSnapshots/${jsonPointerToken(sampleId)}/assertions/${index}`,
+      },
+      contentHash: report.meta.sampleHashes?.[sampleId],
+      label: `assertion ${index + 1}`,
+    }];
+  }
+  if (resultIndex !== undefined && variant !== undefined) {
+    return [{
+      sourceKind: 'eval-report',
+      sourceId: report.id,
+      selector: {
+        selectorKind: 'json-pointer',
+        value: `/results/${resultIndex}/variants/${jsonPointerToken(variant)}/assertions/details/${index}`,
+      },
+      label: `${variant} assertion ${index + 1}`,
+    }];
+  }
+  return [{
+    sourceKind: 'sample',
+    sourceId: sampleId,
+    contentHash: report.meta.sampleHashes?.[sampleId],
+    label: `assertion ${index + 1}`,
+  }];
+}
+
+function sampleStableKey(report: EvaluationReport, sampleId: string): string {
+  const hash = report.meta.sampleHashes?.[sampleId];
+  return hash ? `v1:sample:${hash}` : `v1:sample:${report.id}:${sampleId}`;
+}
+
+function assertionStableKey(report: EvaluationReport, sampleId: string, index: number): string {
+  return `${sampleStableKey(report, sampleId)}:assertion:${index}`;
+}
+
+function sampleAttrs(snapshot: SampleSnapshot | undefined): ArtifactGraphNode['attrs'] | undefined {
+  if (!snapshot) return undefined;
+  const display: Record<string, unknown> = {};
+  if (snapshot.capability?.length) display.capability = snapshot.capability;
+  if (snapshot.construct) display.construct = snapshot.construct;
+  if (snapshot.difficulty) display.difficulty = snapshot.difficulty;
+  if (snapshot.provenance) display.provenance = snapshot.provenance;
+  if (snapshot.tripwire) display.tripwire = true;
+  if (snapshot.assertions?.length) display.assertionCount = snapshot.assertions.length;
+  return Object.keys(display).length > 0 ? { display } : undefined;
+}
+
+export function evalGraphDirForReportOutput(reportOutputDir: string): string {
+  return basename(reportOutputDir) === 'reports'
+    ? join(dirname(reportOutputDir), 'graphs', 'eval')
+    : join(reportOutputDir, 'graphs', 'eval');
+}
+
+export function buildEvalArtifactGraph(options: BuildEvalGraphOptions): ArtifactGraphDocument {
+  const { report, sourcePath } = options;
+  const generatedAt = options.generatedAt ?? new Date().toISOString();
+  const nodes: ArtifactGraphNode[] = [];
+  const edges: ArtifactGraphEdge[] = [];
+  const nodeIdsByStableKey = new Map<string, string>();
+  const configs = variantConfigByName(report);
+
+  const addNode = (
+    stableKey: string,
+    nodeKind: ArtifactGraphNodeKind,
+    nodeRole: ArtifactGraphNodeRole,
+    label: string,
+    extra: Partial<ArtifactGraphNode> = {},
+  ): string => {
+    const existing = nodeIdsByStableKey.get(stableKey);
+    if (existing) return existing;
+    const id = `node:${shortHash(stableKey)}`;
+    nodeIdsByStableKey.set(stableKey, id);
+    nodes.push({
+      id,
+      stableKey,
+      nodeKind,
+      nodeRole,
+      layer: 'measurement',
+      label,
+      ...extra,
+    });
+    return id;
+  };
+
+  const addEdge = (
+    fromNodeId: string,
+    toNodeId: string,
+    edgeKind: ArtifactGraphEdgeKind,
+    extra: Partial<ArtifactGraphEdge> = {},
+  ): void => {
+    const id = `edge:${shortHash(`${fromNodeId}|${edgeKind}|${toNodeId}|${edges.length}`)}`;
+    edges.push({
+      id,
+      fromNodeId,
+      toNodeId,
+      edgeKind,
+      layer: 'measurement',
+      ...extra,
+    });
+  };
+
+  const variantNodeIds = new Map<string, string>();
+  for (const variant of report.meta.variants) {
+    const artifactHash = report.meta.artifactHashes?.[variant];
+    const config = configs.get(variant);
+    const variantNodeId = addNode(
+      `v1:variant:${report.id}:${variant}`,
+      'variant',
+      'entity',
+      variant,
+      {
+        status: statusFromScore(report.summary?.[variant]?.avgCompositeScore),
+        binding: artifactBinding(variant, artifactHash),
+        metrics: {
+          ...(report.summary?.[variant]?.avgCompositeScore !== undefined
+            ? { avgCompositeScore: report.summary[variant].avgCompositeScore as number }
+            : {}),
+          ...(report.summary?.[variant]?.totalSamples !== undefined
+            ? { totalSamples: report.summary[variant].totalSamples }
+            : {}),
+        },
+        attrs: {
+          display: {
+            ...(config ? {
+              artifactKind: config.artifactKind,
+              artifactSource: config.artifactSource,
+              experimentRole: config.experimentRole,
+              executionStrategy: config.executionStrategy,
+            } : {}),
+          },
+        },
+        evidenceRefs: [{
+          sourceKind: 'eval-report',
+          sourceId: report.id,
+          selector: { selectorKind: 'json-pointer', value: `/summary/${jsonPointerToken(variant)}` },
+          label: `${variant} summary`,
+        }],
+      },
+    );
+    variantNodeIds.set(variant, variantNodeId);
+
+    if (config?.artifactKind === 'skill' && artifactHash && artifactHash !== 'no-skill') {
+      const skillNodeId = addNode(
+        `v1:skill:${artifactHash}`,
+        'skill',
+        'entity',
+        variant,
+        {
+          binding: { bindingStrength: 'content-hash', keys: { artifactHash } },
+          attrs: {
+            display: {
+              variant,
+              sourceLocator: config.locator,
+            },
+          },
+          evidenceRefs: [{
+            sourceKind: 'eval-report',
+            sourceId: report.id,
+            selector: { selectorKind: 'json-pointer', value: `/meta/artifactHashes/${jsonPointerToken(variant)}` },
+            contentHash: artifactHash,
+            label: `${variant} artifact hash`,
+          }],
+        },
+      );
+      addEdge(variantNodeId, skillNodeId, 'derived_from');
+    }
+  }
+
+  for (const [sampleId, snapshot] of Object.entries(report.sampleSnapshots ?? {})) {
+    const sampleNodeId = addNode(
+      sampleStableKey(report, sampleId),
+      'sample',
+      'entity',
+      sampleId,
+      {
+        binding: sampleBinding(sampleId, report.meta.sampleHashes?.[sampleId]),
+        attrs: sampleAttrs(snapshot),
+        evidenceRefs: sampleEvidence(report, sampleId),
+      },
+    );
+    snapshot.assertions?.forEach((assertion, index) => {
+      const assertionNodeId = addNode(
+        assertionStableKey(report, sampleId, index),
+        'assertion',
+        'entity',
+        `assertion: ${assertion.type}`,
+        {
+          attrs: { display: { type: assertion.type, weight: assertion.weight ?? 1 } },
+          evidenceRefs: assertionEvidence(report, sampleId, index),
+        },
+      );
+      addEdge(sampleNodeId, assertionNodeId, 'contains');
+    });
+  }
+
+  for (const [resultIndex, result] of report.results.entries()) {
+    const sampleNodeId = addNode(
+      sampleStableKey(report, result.sample_id),
+      'sample',
+      'entity',
+      result.sample_id,
+      {
+        binding: sampleBinding(result.sample_id, report.meta.sampleHashes?.[result.sample_id]),
+        attrs: sampleAttrs(report.sampleSnapshots?.[result.sample_id]),
+        evidenceRefs: sampleEvidence(report, result.sample_id),
+      },
+    );
+
+    for (const [variant, variantResult] of Object.entries(result.variants)) {
+      const variantNodeId = variantNodeIds.get(variant);
+      if (!variantNodeId) continue;
+      addEdge(variantNodeId, sampleNodeId, 'evaluates', {
+        status: assertionStatus(variantResult),
+        evidenceRefs: evalResultEvidence(report, resultIndex, variant),
+      });
+
+      const evalResultNodeId = addNode(
+        `v1:eval-result:${report.id}:${variant}:${result.sample_id}`,
+        'eval_result',
+        'observation',
+        `${variant} / ${result.sample_id}`,
+        {
+          status: assertionStatus(variantResult),
+          metrics: {
+            durationMs: variantResult.durationMs,
+            costUSD: variantResult.costUSD,
+            ...(variantResult.compositeScore !== undefined ? { compositeScore: variantResult.compositeScore } : {}),
+            ...(variantResult.llmScore !== undefined ? { llmScore: variantResult.llmScore } : {}),
+            ...(variantResult.assertions ? { assertionScore: variantResult.assertions.score } : {}),
+          },
+          attrs: {
+            display: {
+              ok: variantResult.ok,
+              ...(variantResult.error ? { error: variantResult.error } : {}),
+            },
+          },
+          evidenceRefs: evalResultEvidence(report, resultIndex, variant),
+        },
+      );
+      addEdge(evalResultNodeId, variantNodeId, 'derived_from');
+      addEdge(evalResultNodeId, sampleNodeId, 'evaluates');
+
+      variantResult.assertions?.details.forEach((detail, index) => {
+        const assertionNodeId = addNode(
+          assertionStableKey(report, result.sample_id, index),
+          'assertion',
+          'entity',
+          `assertion: ${detail.type}`,
+          {
+            attrs: { display: { type: detail.type, weight: detail.weight } },
+            evidenceRefs: assertionEvidence(report, result.sample_id, index, resultIndex, variant),
+          },
+        );
+        addEdge(evalResultNodeId, assertionNodeId, detail.passed ? 'passes' : 'fails', {
+          status: detail.passed ? 'ok' : 'failed',
+          evidenceRefs: evalResultEvidence(report, resultIndex, variant),
+        });
+      });
+
+      for (const [dimension, dimensionResult] of Object.entries(variantResult.dimensions ?? {})) {
+        const dimensionNodeId = addNode(
+          `v1:judge-dimension:${report.id}:${variant}:${result.sample_id}:${dimension}`,
+          'judge_dimension',
+          'observation',
+          dimension,
+          {
+            status: statusFromScore(dimensionResult.score),
+            metrics: { score: dimensionResult.score },
+            attrs: { display: { reason: dimensionResult.reason } },
+            evidenceRefs: evalResultEvidence(report, resultIndex, variant),
+          },
+        );
+        addEdge(dimensionNodeId, evalResultNodeId, 'derived_from');
+      }
+
+      if (variantResult.diagnostic) {
+        const diagnosticNodeId = addNode(
+          `v1:diagnostic:${report.id}:${variant}:${result.sample_id}`,
+          'diagnostic',
+          'observation',
+          `diagnostic: ${variant} / ${result.sample_id}`,
+          {
+            status: variantResult.diagnostic.ok ? 'warning' : 'failed',
+            attrs: {
+              display: {
+                rootCause: variantResult.diagnostic.rootCause,
+                failureModes: variantResult.diagnostic.failureModes ?? [],
+              },
+            },
+            evidenceRefs: evalResultEvidence(report, resultIndex, variant),
+          },
+        );
+        addEdge(diagnosticNodeId, evalResultNodeId, 'diagnoses', {
+          status: variantResult.diagnostic.ok ? 'warning' : 'failed',
+        });
+      }
+    }
+  }
+
+  return {
+    documentKind: 'artifact-graph',
+    schemaVersion: 1,
+    graphId: `eval:${report.id}`,
+    generatedAt,
+    source: {
+      sourceKind: 'eval',
+      sourceId: report.id,
+      sourcePath,
+      cliVersion: report.meta.cliVersion,
+    },
+    scope: {
+      cwd: process.cwd(),
+      artifactKind: scopeArtifactKind(report),
+      sourceLocator: report.meta.request?.samplesPath,
+      sampleSetHash: sampleSetHash(report.meta.sampleHashes),
+    },
+    nodes,
+    edges,
+    summaries: [{
+      summaryKind: 'coverage',
+      title: 'Eval measurement graph',
+      severity: report.results.some((result) => Object.values(result.variants).some((variant) => assertionStatus(variant) === 'failed'))
+        ? 'medium'
+        : 'info',
+    }],
+  };
+}
+
+export function persistEvalGraphSidecar(options: PersistEvalGraphOptions): PersistEvalGraphResult {
+  const graphDir = evalGraphDirForReportOutput(options.outputDir);
+  if (!existsSync(graphDir)) mkdirSync(graphDir, { recursive: true });
+  const fileStem = options.fileStem ?? options.report.id;
+  const graphPath = join(graphDir, graphFileName(fileStem));
+  const graph = buildEvalArtifactGraph(options);
+  writeFileSync(graphPath, JSON.stringify(graph, null, 2));
+  return { graphPath };
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -10,6 +10,7 @@
 
 import { existsSync, statSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
+import { runFileSuffix } from '../eval-core/artifact-file-names.js';
 import { discoverVariants, resolveArtifacts } from '../inputs/skill-loader.js';
 import type {
   Artifact,
@@ -180,14 +181,8 @@ function inferSkillPath(artifact: Artifact, baseDir: string): string {
 // Public entry
 // ---------------------------------------------------------------------------
 
-let reportIdCounter = 0;
 function nextReportId(): string {
-  reportIdCounter += 1;
-  const ts = new Date().toISOString().replace(/[-:.]/g, '').slice(0, 15);
-  // 进程内计数器只防同进程同秒撞;跨进程同秒(两个 omk doctor 并发 / 不同项目)仍会撞同 id,
-  // 经机器级卡片 dedup 当唯一键用时会静默并掉一份。加 4 位随机根治跨进程撞名(id 是标签非测量数)。
-  const rand = Math.random().toString(36).slice(2, 6);
-  return `doctor-${ts}-${reportIdCounter}-${rand}`;
+  return `doctor-${runFileSuffix()}`;
 }
 
 function readCliVersion(): string {

--- a/src/eval-core/artifact-file-names.ts
+++ b/src/eval-core/artifact-file-names.ts
@@ -43,9 +43,8 @@ export function randomRunToken(): string {
   return Math.random().toString(36).slice(2, 6);
 }
 
-export function runFileSuffix(counter?: number): string {
-  const middle = counter === undefined ? '' : `-${counter}`;
-  return `${runTimestamp()}${middle}-${randomRunToken()}`;
+export function runFileSuffix(): string {
+  return `${runTimestamp()}-${randomRunToken()}`;
 }
 
 export function stripDomainPrefix(id: string, domain: string): string {

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -5,7 +5,8 @@ import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { DEFAULT_REPORTS_DIR } from './default-dirs.js';
 import { indexReportWrite } from './artifact-index.js';
-import { reportFilePath } from './artifact-file-names.js';
+import { randomRunToken, reportFilePath, runTimestamp } from './artifact-file-names.js';
+import { persistEvalGraphSidecar } from '../artifact-graph/eval.js';
 import { buildVariantSummary } from './schema.js';
 import { buildVariantConfig, resolveExecutionStrategy } from './execution-strategy.js';
 import { getJudgePromptHash } from '../grading/judge.js';
@@ -25,6 +26,7 @@ import type {
   VariantSummary,
   VariantPairComparison,
   GitInfo,
+  EvaluationReport,
   EvaluationJob,
   EvaluationRequest,
   EvaluationRun,
@@ -362,11 +364,26 @@ export interface PersistableReport {
   id: string;
 }
 
+function isEvaluationReport(report: PersistableReport): report is EvaluationReport {
+  return (report as unknown as Record<string, unknown>)['kind'] === 'evaluation';
+}
+
+function persistEvalGraphSidecarSafely(report: PersistableReport, outputDir: string, sourcePath: string): void {
+  if (!isEvaluationReport(report)) return;
+  try {
+    persistEvalGraphSidecar({ report, outputDir, sourcePath, fileStem: report.id });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[omk] 写入 eval 图谱失败：${message}\n`);
+  }
+}
+
 export function persistReport(report: PersistableReport, outputDir: string | null): string | null {
   if (!outputDir) return null;
   if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
   const filePath = reportFilePath(outputDir, report.id);
   writeFileSync(filePath, JSON.stringify(report, null, 2));
+  persistEvalGraphSidecarSafely(report, outputDir, filePath);
   // 产物发现索引:报告落项目本地后,best-effort 追加全局轻卡片,让 omk studio 跨项目聚合成机器级总览。
   // 永不抛、永不阻断报告落盘(正文是 source of truth)。
   indexReportWrite(report, filePath, outputDir);
@@ -374,23 +391,28 @@ export function persistReport(report: PersistableReport, outputDir: string | nul
 }
 
 /**
- * run id 的时间戳后缀 `YYYYMMDD-HHmmss-rand4`。
+ * run id 的时间戳后缀 `YYYYMMDDTHHmmss-rand4`。
  * 含秒 + 4 位随机:id 是 run 标签(非测量数),但被 studio 机器级 dedup 与 managed 证据 (reportId,
  * contentHash) 去重当唯一键用。分钟级会让跨项目 / 同分钟重跑撞同 id → 索引静默顶掉一份、managed 错并一条。
  * 秒+随机根治撞名,保证每次 run 全局唯一。供 generateRunId 与 evolve 合并 id 共用,避免靠 split 反解格式。
  */
 export function runIdSuffix(): string {
-  const d = new Date();
-  const pad = (n: number): string => String(n).padStart(2, '0');
-  const date = `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}`;
-  const time = `${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`;
-  const rand = Math.random().toString(36).slice(2, 6);
-  return `${date}-${time}-${rand}`;
+  return `${runTimestamp()}-${randomRunToken()}`;
+}
+
+function safeRunSubject(subject: string): string {
+  const sanitized = subject
+    .replaceAll(/[\\/:]/g, '-')
+    .replaceAll(/[^a-zA-Z0-9._@-]/g, '_')
+    .replace(/^-+|-+$/g, '');
+  return sanitized || 'run';
+}
+
+function primaryRunSubject(variants: string[]): string {
+  const nonBaseline = variants.filter((variant) => variant !== 'baseline');
+  return nonBaseline.at(-1) ?? variants.at(-1) ?? 'run';
 }
 
 export function generateRunId(variants: string[]): string {
-  const variantPart = variants
-    .map((variant) => variant.replaceAll(/[\\/:]/g, '-').replaceAll(/[^a-zA-Z0-9._@-]/g, '_'))
-    .join('-vs-');
-  return `${variantPart}-${runIdSuffix()}`;
+  return `${safeRunSubject(primaryRunSubject(variants))}-${runIdSuffix()}`;
 }

--- a/src/renderer/html-renderer.ts
+++ b/src/renderer/html-renderer.ts
@@ -171,9 +171,10 @@ export function renderRunList(runs: ReportDocument[], lang: Lang = DEFAULT_LANG)
   // 顶部 verdict pill 主导视觉,id+date 是身份,scores 是成绩,底部 meta 是元数据,
   // delete 默认隐藏在 hover 出现避免误点。批量报告共用同一组件,batch pill 替代 verdict。
   const formatDateFromId = (id: string, fallbackTs?: string): string => {
-    // 兼容两代 run id 后缀:旧 `…YYYYMMDD-HHmm`、新 `…YYYYMMDD-HHmmss-rand4`(含秒+随机)。
+    // 兼容三代 run id 后缀:旧 `…YYYYMMDD-HHmm`、过渡期 `…YYYYMMDD-HHmmss-rand4`、
+    // 统一后 `…YYYYMMDDTHHmmss-rand4`(含秒+随机)。
     // 都从 id 直接派生本地展示时间(确定性,不走时区敏感的 toLocaleString);新增的秒段 + 随机后缀可选匹配。
-    const idMatch = id.match(/(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(?:\d{2}-[a-z0-9]+)?$/);
+    const idMatch = id.match(/(\d{4})(\d{2})(\d{2})(?:T|-)(\d{2})(\d{2})(?:\d{2})?(?:-[a-z0-9]+)?$/);
     if (idMatch) return `${idMatch[2]}/${idMatch[3]} ${idMatch[4]}:${idMatch[5]}`;
     return fallbackTs ? new Date(fallbackTs).toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' }) : '';
   };

--- a/test/__snapshots__/html-renderer.test.ts.snap
+++ b/test/__snapshots__/html-renderer.test.ts.snap
@@ -464,7 +464,7 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
     <div class="rs-hero-left">
       <div class="rs-hero-kind"><span class="rs-hero-icon" style="color:#7c3aed"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 11l2 2 4-4"/></svg></span> Eval Report</div>
       <h1 class="rs-hero-name">v2</h1>
-      <div class="rs-hero-meta"><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> [TIMESTAMP]</span><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="3"/><path d="M8 12h8"/></svg> sonnet</span><span>test-run-20260325-100000-abcd</span></div>
+      <div class="rs-hero-meta"><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> [TIMESTAMP]</span><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="3"/><path d="M8 12h8"/></svg> sonnet</span><span>test-run-20260325T100000-abcd</span></div>
     </div>
     <div class="rs-hero-score">
       <div class="rs-hero-num" style="color:#1f9d63">4.80</div>
@@ -1609,7 +1609,7 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
     <div class="rs-hero-left">
       <div class="rs-hero-kind"><span class="rs-hero-icon" style="color:#7c3aed"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 11l2 2 4-4"/></svg></span> 用例评测报告</div>
       <h1 class="rs-hero-name">v2</h1>
-      <div class="rs-hero-meta"><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> [TIMESTAMP]</span><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="3"/><path d="M8 12h8"/></svg> sonnet</span><span>test-run-20260325-100000-abcd</span></div>
+      <div class="rs-hero-meta"><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> [TIMESTAMP]</span><span><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="3"/><path d="M8 12h8"/></svg> sonnet</span><span>test-run-20260325T100000-abcd</span></div>
     </div>
     <div class="rs-hero-score">
       <div class="rs-hero-num" style="color:#1f9d63">4.80</div>
@@ -2769,17 +2769,17 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
       <p style="font-size:11px;color:var(--text-muted);margin:14px 0 0;line-height:1.6">Full derivation / five-layer scoring pipeline / multi-layer gate & composite relationship: <a href="https://github.com/lizhiyao/oh-my-knowledge/blob/main/docs/specs/scoring.md" target="_blank" rel="noopener">docs/specs/scoring.md</a></p>
     </div>
   </div>
-    <div id="run-list" class="run-list"><a class="run-card verdict-CAUTIOUS" href="/reports/test-run-20260325-100000-abcd?lang=en">
+    <div id="run-list" class="run-list"><a class="run-card verdict-CAUTIOUS" href="/reports/test-run-20260325T100000-abcd?lang=en">
       <div class="run-card-h">
         <span class="run-status verdict-CAUTIOUS" title="Treatment slightly above control — small gap or layer below gate" aria-label="CAUTIOUS — Treatment slightly above control — small gap or layer below gate"><span class="run-status-dot" aria-hidden="true">▲</span>CAUTIOUS</span>
-        <span class="run-card-id">test-run-20260325-100000-abcd</span>
+        <span class="run-card-id">test-run-20260325T100000-abcd</span>
         <span class="run-card-date">03/25 10:00</span>
       </div>
       <div class="run-card-meta">sonnet · 2 samples · v1 · v2</div>
       <div class="run-card-scores"><div class="rc-score-row"><span class="rc-score-label" title="v1">v1</span><div class="rc-score-bar"><div class="rc-score-bar-fill rc-score-bar-fill--pass" style="width:80%"></div></div><span class="rc-score-num rc-score-num--pass">4.00</span></div><div class="rc-score-row"><span class="rc-score-label" title="v2">v2</span><div class="rc-score-bar"><div class="rc-score-bar-fill rc-score-bar-fill--pass" style="width:96%"></div></div><span class="rc-score-num rc-score-num--pass">4.80</span></div></div>
       <div class="run-card-foot">
         <span class="run-card-stat">10.0s</span>
-        <button class="run-card-delete" onclick="event.preventDefault();event.stopPropagation();deleteRun('test-run-20260325-100000-abcd',this)" data-i18n="deleteBtnText" aria-label="Delete">×</button>
+        <button class="run-card-delete" onclick="event.preventDefault();event.stopPropagation();deleteRun('test-run-20260325T100000-abcd',this)" data-i18n="deleteBtnText" aria-label="Delete">×</button>
       </div>
     </a></div>
     <style>
@@ -3366,17 +3366,17 @@ a:focus-visible,.badge:focus-visible{outline:2px solid var(--accent);outline-off
       <p style="font-size:11px;color:var(--text-muted);margin:14px 0 0;line-height:1.6">完整推导 / 五层评分管道架构 / 多层 gate 与综合分的关系：<a href="https://github.com/lizhiyao/oh-my-knowledge/blob/main/docs/zh/specs/scoring.md" target="_blank" rel="noopener">docs/zh/specs/scoring.md</a></p>
     </div>
   </div>
-    <div id="run-list" class="run-list"><a class="run-card verdict-CAUTIOUS" href="/reports/test-run-20260325-100000-abcd">
+    <div id="run-list" class="run-list"><a class="run-card verdict-CAUTIOUS" href="/reports/test-run-20260325T100000-abcd">
       <div class="run-card-h">
         <span class="run-status verdict-CAUTIOUS" title="实验组略优于对照组,但差距小或某层未达 gate" aria-label="略微进步 — 实验组略优于对照组,但差距小或某层未达 gate"><span class="run-status-dot" aria-hidden="true">▲</span>略微进步</span>
-        <span class="run-card-id">test-run-20260325-100000-abcd</span>
+        <span class="run-card-id">test-run-20260325T100000-abcd</span>
         <span class="run-card-date">03/25 10:00</span>
       </div>
       <div class="run-card-meta">sonnet · 2 用例 · v1 · v2</div>
       <div class="run-card-scores"><div class="rc-score-row"><span class="rc-score-label" title="v1">v1</span><div class="rc-score-bar"><div class="rc-score-bar-fill rc-score-bar-fill--pass" style="width:80%"></div></div><span class="rc-score-num rc-score-num--pass">4.00</span></div><div class="rc-score-row"><span class="rc-score-label" title="v2">v2</span><div class="rc-score-bar"><div class="rc-score-bar-fill rc-score-bar-fill--pass" style="width:96%"></div></div><span class="rc-score-num rc-score-num--pass">4.80</span></div></div>
       <div class="run-card-foot">
         <span class="run-card-stat">10.0s</span>
-        <button class="run-card-delete" onclick="event.preventDefault();event.stopPropagation();deleteRun('test-run-20260325-100000-abcd',this)" data-i18n="deleteBtnText" aria-label="删除">×</button>
+        <button class="run-card-delete" onclick="event.preventDefault();event.stopPropagation();deleteRun('test-run-20260325T100000-abcd',this)" data-i18n="deleteBtnText" aria-label="删除">×</button>
       </div>
     </a></div>
     <style>

--- a/test/artifact-graph/eval-graph.test.ts
+++ b/test/artifact-graph/eval-graph.test.ts
@@ -1,0 +1,255 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  buildEvalArtifactGraph,
+  evalGraphDirForReportOutput,
+} from '../../src/artifact-graph/eval.js';
+import { persistReport } from '../../src/eval-core/evaluation-reporting.js';
+import type { EvaluationReport, VariantResult } from '../../src/types/index.js';
+
+function variantResult(overrides: Partial<VariantResult> = {}): VariantResult {
+  return {
+    ok: true,
+    durationMs: 10,
+    durationApiMs: 8,
+    inputTokens: 100,
+    outputTokens: 20,
+    totalTokens: 120,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    execCostUSD: 0.01,
+    judgeCostUSD: 0.001,
+    costUSD: 0.011,
+    numTurns: 1,
+    outputPreview: 'ok',
+    ...overrides,
+  };
+}
+
+function makeReport(): EvaluationReport {
+  return {
+    kind: 'evaluation',
+    id: 'service-guide-20260620T103000-abcd',
+    meta: {
+      variants: ['baseline', 'service-guide'],
+      model: 'fixture-model',
+      executor: 'fixture',
+      sampleCount: 1,
+      taskCount: 2,
+      totalCostUSD: 0.03,
+      timestamp: '2026-06-20T10:30:00.000Z',
+      cliVersion: '0.0.0-test',
+      nodeVersion: 'v24.0.0',
+      artifactHashes: {
+        baseline: 'no-skill',
+        'service-guide': 'skillhash1234',
+      },
+      sampleHashes: {
+        s001: 'samplehash01',
+      },
+      judgeModels: [{ executor: 'fixture', model: 'judge' }],
+      variantConfigs: [
+        {
+          variant: 'baseline',
+          artifactKind: 'baseline',
+          artifactSource: 'baseline',
+          executionStrategy: 'baseline',
+          experimentType: 'baseline',
+          experimentRole: 'control',
+          hasArtifactContent: false,
+          cwd: null,
+        },
+        {
+          variant: 'service-guide',
+          artifactKind: 'skill',
+          artifactSource: 'file-path',
+          executionStrategy: 'system-prompt',
+          experimentType: 'artifact-injection',
+          experimentRole: 'treatment',
+          hasArtifactContent: true,
+          cwd: null,
+          locator: 'examples/customer-service/skills/service-guide/SKILL.md',
+        },
+      ],
+      request: {
+        samplesPath: '/fixture/project/eval-samples.json',
+        skillDir: '/fixture/project/skills',
+        artifacts: [],
+        model: 'fixture-model',
+        executor: 'fixture',
+        noJudge: false,
+        concurrency: 1,
+        noCache: false,
+        dryRun: false,
+        judgeModels: [{ executor: 'fixture', model: 'judge' }],
+      },
+    },
+    summary: {
+      baseline: {
+        totalSamples: 1,
+        successCount: 1,
+        errorCount: 0,
+        errorRate: 0,
+        avgDurationMs: 10,
+        avgInputTokens: 100,
+        avgOutputTokens: 20,
+        avgTotalTokens: 120,
+        totalCostUSD: 0.011,
+        totalExecCostUSD: 0.01,
+        totalJudgeCostUSD: 0.001,
+        avgCostPerSample: 0.011,
+        avgNumTurns: 1,
+        avgCompositeScore: 4.5,
+      },
+      'service-guide': {
+        totalSamples: 1,
+        successCount: 1,
+        errorCount: 0,
+        errorRate: 0,
+        avgDurationMs: 12,
+        avgInputTokens: 120,
+        avgOutputTokens: 30,
+        avgTotalTokens: 150,
+        totalCostUSD: 0.019,
+        totalExecCostUSD: 0.017,
+        totalJudgeCostUSD: 0.002,
+        avgCostPerSample: 0.019,
+        avgNumTurns: 1,
+        avgCompositeScore: 2.5,
+      },
+    },
+    sampleSnapshots: {
+      s001: {
+        sample_id: 's001',
+        prompt: '检查服务流程是否包含回滚策略。',
+        assertions: [{ type: 'contains_all', values: ['回滚', '发布'] }],
+        capability: ['release-readiness'],
+        construct: 'capability',
+        difficulty: 'medium',
+        provenance: 'human',
+      },
+    },
+    results: [{
+      sample_id: 's001',
+      variants: {
+        baseline: variantResult({
+          compositeScore: 4.5,
+          assertions: {
+            passed: 1,
+            total: 1,
+            score: 5,
+            details: [{ type: 'contains_all', value: '回滚,发布', weight: 1, passed: true }],
+          },
+        }),
+        'service-guide': variantResult({
+          compositeScore: 2.5,
+          assertions: {
+            passed: 0,
+            total: 1,
+            score: 1,
+            details: [{ type: 'contains_all', value: '回滚,发布', weight: 1, passed: false, message: '缺少回滚' }],
+          },
+          dimensions: {
+            workflow: { score: 2, reason: '漏掉回滚步骤' },
+          },
+          diagnostic: {
+            summary: '没有覆盖回滚策略。',
+            expected: '回答需要包含发布与回滚。',
+            actual: '只说明发布检查。',
+            rootCause: ['skill_doc_missing'],
+            failureModes: ['工作流跳步'],
+            suggestion: { skill: '补充回滚步骤。', sample: '', none: '' },
+            ok: true,
+          },
+        }),
+      },
+    }],
+  };
+}
+
+describe('eval artifact graph', () => {
+  it('builds a measurement-layer graph without inferred covers edges', () => {
+    const report = makeReport();
+    const graph = buildEvalArtifactGraph({
+      report,
+      sourcePath: '/tmp/.omk/reports/service-guide.report.json',
+      generatedAt: '2026-06-20T10:30:00.000Z',
+    });
+
+    assert.equal(graph.documentKind, 'artifact-graph');
+    assert.equal(graph.schemaVersion, 1);
+    assert.equal(graph.source.sourceKind, 'eval');
+    assert.equal(graph.source.sourceId, report.id);
+    assert.equal(graph.scope.cwd, process.cwd());
+    assert.equal(graph.scope.sourceLocator, '/fixture/project/eval-samples.json');
+    assert.equal(graph.scope.sampleSetHash, '186c7ae74946');
+    assert.ok(graph.nodes.every((node) => node.layer === 'measurement'));
+    assert.ok(graph.edges.every((edge) => edge.layer === 'measurement'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'variant' && node.label === 'service-guide'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'skill' && node.stableKey === 'v1:skill:skillhash1234'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'sample' && node.stableKey === 'v1:sample:samplehash01'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'assertion' && node.label === 'assertion: contains_all'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'eval_result' && node.status === 'failed'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'diagnostic' && node.status === 'warning'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'judge_dimension' && node.status === 'failed'));
+    assert.ok(graph.edges.some((edge) => edge.edgeKind === 'evaluates'));
+    assert.ok(graph.edges.some((edge) => edge.edgeKind === 'passes'));
+    assert.ok(graph.edges.some((edge) => edge.edgeKind === 'fails'));
+    assert.ok(graph.edges.some((edge) => edge.edgeKind === 'diagnoses'));
+    assert.ok(!graph.edges.some((edge) => edge.edgeKind === 'covers'));
+  });
+
+  it('points assertion evidence at eval result details when sample snapshot is absent', () => {
+    const report = makeReport();
+    report.sampleSnapshots = {};
+    delete report.results[0].variants.baseline.assertions;
+
+    const graph = buildEvalArtifactGraph({
+      report,
+      sourcePath: '/tmp/.omk/reports/service-guide.report.json',
+      generatedAt: '2026-06-20T10:30:00.000Z',
+    });
+    const assertionNode = graph.nodes.find((node) => node.nodeKind === 'assertion');
+    const evidence = assertionNode?.evidenceRefs?.[0];
+    assert.equal(evidence?.sourceKind, 'eval-report');
+    assert.equal(
+      evidence?.selector?.value,
+      '/results/0/variants/service-guide/assertions/details/0',
+    );
+  });
+
+  it('persists eval graph sidecars when reports are written', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'omk-eval-graph-'));
+    try {
+      const report = makeReport();
+      const outputDir = join(tmp, '.omk', 'reports');
+      const reportPath = persistReport(report, outputDir);
+      assert.equal(reportPath, join(outputDir, `${report.id}.report.json`));
+
+      const graphPath = join(tmp, '.omk', 'graphs', 'eval', `${report.id}.graph.json`);
+      assert.ok(existsSync(graphPath));
+      const graph = JSON.parse(readFileSync(graphPath, 'utf-8')) as { documentKind: string; source: { sourceKind: string } };
+      assert.equal(graph.documentKind, 'artifact-graph');
+      assert.equal(graph.source.sourceKind, 'eval');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('puts eval graph sidecars inside non-standard custom output dirs', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'omk-eval-graph-custom-out-'));
+    try {
+      const outputDir = join(tmp, 'custom-output');
+      assert.equal(evalGraphDirForReportOutput(outputDir), join(outputDir, 'graphs', 'eval'));
+      assert.equal(
+        evalGraphDirForReportOutput(join(tmp, '.omk', 'reports')),
+        join(tmp, '.omk', 'graphs', 'eval'),
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -299,7 +299,8 @@ describe('omk doctor CLI', () => {
       const mdFile = files.find((file) => file.endsWith('.card.md'));
       assert.ok(jsonFile, `expected graph json, got: ${files.join(', ')}`);
       assert.ok(mdFile, `expected evidence card markdown, got: ${files.join(', ')}`);
-      assert.match(jsonFile, /^review-\d{8}T\d{6}-\d+-[a-z0-9]{4}\.graph\.json$/);
+      assert.match(jsonFile, /^review-\d{8}T\d{6}-[a-z0-9]{4}\.graph\.json$/);
+      assert.equal(mdFile, jsonFile.replace(/\.graph\.json$/, '.card.md'));
       const graph = JSON.parse(readFileSync(join(graphDir, jsonFile), 'utf-8'));
       assert.equal(graph.documentKind, 'artifact-graph');
       assert.equal(graph.source.sourceKind, 'doctor');

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -343,7 +343,7 @@ describe('runDoctor', () => {
       rules: [passingRule],
     });
     assert.equal(typeof report.id, 'string');
-    assert.ok(report.id.startsWith('doctor-'));
+    assert.match(report.id, /^doctor-\d{8}T\d{6}-[a-z0-9]{4}$/);
     assert.equal(typeof report.timestamp, 'string');
     assert.equal(typeof report.cliVersion, 'string');
     for (const skill of report.skills) {

--- a/test/eval-core/report-variant-keys.golden.test.ts
+++ b/test/eval-core/report-variant-keys.golden.test.ts
@@ -254,11 +254,14 @@ describe('GOLDEN report variant keys', () => {
     expect(projectVariantSurfaces(report)).toMatchSnapshot();
   });
 
-  it('generateRunId encodes variant names in order, sanitized', () => {
-    // 格式:<variants>-<YYYYMMDD>-<HHmmss>-<rand4>。秒 + 4 位随机后缀保证跨项目 / 同分钟重跑全局唯一。
-    assert.match(generateRunId(['baseline', 'greeter']), /^baseline-vs-greeter-\d{8}-\d{6}-[a-z0-9]{4}$/);
-    assert.match(generateRunId(['v1/greeter', 'v2/greeter']), /^v1-greeter-vs-v2-greeter-\d{8}-\d{6}-[a-z0-9]{4}$/);
-    assert.match(generateRunId(['git:HEAD:greeter']), /^git-HEAD-greeter-\d{8}-\d{6}-[a-z0-9]{4}$/);
+  it('generateRunId uses the primary subject, not the full variant relationship', () => {
+    // 格式:<subject>-<YYYYMMDDTHHmmss>-<rand4>。baseline / 对照关系留在 report JSON 里,
+    // 文件名只表达主评测对象和本次运行唯一性。
+    const baselineRunId = generateRunId(['baseline', 'greeter']);
+    assert.match(baselineRunId, /^greeter-\d{8}T\d{6}-[a-z0-9]{4}$/);
+    assert.doesNotMatch(baselineRunId, /^baseline-vs-/);
+    assert.match(generateRunId(['v1/greeter', 'v2/greeter']), /^v2-greeter-\d{8}T\d{6}-[a-z0-9]{4}$/);
+    assert.match(generateRunId(['git:HEAD:greeter']), /^git-HEAD-greeter-\d{8}T\d{6}-[a-z0-9]{4}$/);
   });
 
   it('generateRunId 同时刻两次产出不同 id(撞名根治)', () => {

--- a/test/evolver.test.ts
+++ b/test/evolver.test.ts
@@ -67,8 +67,8 @@ describe('mergeEvolveReports', () => {
     // totalCostUSD
     assert.equal(merged.meta.totalCostUSD, 1.5);
 
-    // id = evolve-<skill>-YYYYMMDD-HHmmss-rand4(含日期,可追溯 / 可扫读)
-    assert.match(merged.id, /^evolve-test-skill-\d{8}-\d{6}-[a-z0-9]{4}$/);
+    // id = evolve-<skill>-YYYYMMDDTHHmmss-rand4(含日期,可追溯 / 可扫读)
+    assert.match(merged.id, /^evolve-test-skill-\d{8}T\d{6}-[a-z0-9]{4}$/);
   });
 
   it('单轮（仅 baseline）也能正常生成报告', () => {

--- a/test/html-renderer.test.ts
+++ b/test/html-renderer.test.ts
@@ -14,10 +14,10 @@ function normalizeForSnapshot(html: string): string {
 
 const SAMPLE_REPORT: Report = {
   kind: 'evaluation',
-  // 用生产 id 格式 YYYYMMDD-HHmmss-rand4(含秒+随机),让列表页 row 时间走 formatDateFromId
+  // 用生产 id 格式 YYYYMMDDTHHmmss-rand4(含秒+随机),让列表页 row 时间走 formatDateFromId
   // 的 id 直接提取路径 (deterministic, 不走时区敏感的 toLocaleString — 后者会让 snapshot 在 CI UTC
   // 和本地 CST 之间不一致)。秒段在展示时被丢弃,派生出的 MM/DD HH:MM 与旧格式一致,快照稳定。
-  id: 'test-run-20260325-100000-abcd',
+  id: 'test-run-20260325T100000-abcd',
   meta: {
     variants: ['v1', 'v2'],
     model: 'sonnet',
@@ -102,9 +102,9 @@ describe('renderRunList', () => {
 
   it('renders run list with data', () => {
     const html = renderRunList([SAMPLE_REPORT]);
-    assert.ok(html.includes('test-run-20260325-1000'));
+    assert.ok(html.includes('test-run-20260325T1000'));
     assert.ok(html.includes('sonnet'));
-    assert.ok(html.includes('test-run-20260325-1000'));
+    assert.ok(html.includes('test-run-20260325T1000'));
   });
 
   it('includes delete button', () => {

--- a/test/renderer/card-shell-eval-render.test.ts
+++ b/test/renderer/card-shell-eval-render.test.ts
@@ -14,7 +14,7 @@ function cardShellEntry(): SkillIndexEntry {
     skillName: 'cross-project-skill',
     doctor: null,
     eval: {
-      reportId: 'baseline-vs-x-20260614-141600-ab12',
+      reportId: 'x-20260614T141600-ab12',
       timestamp: '2026-06-14T14:16:00Z',
       variantName: 'x',
       verdictLevel: 'PROGRESS',


### PR DESCRIPTION
## 用户影响

`omk eval` 在写主评测报告时，会额外 best-effort 写入 measurement layer 信息图谱 sidecar。标准项目输出路径为 `.omk/graphs/eval/<reportId>.graph.json`，`--global` 或自定义 `--output-dir` 时跟随主报告输出根目录。

这让 #280 的第二阶段可以先沉淀稳定数据：variant、sample、assertion、eval_result、judge_dimension、diagnostic 及它们之间的证据关系。

## 迁移说明

无需迁移。主 `EvaluationReport` schema 不变，已有报告读取逻辑不变。graph 写入失败只会 warning，不改变 eval verdict、report 写入或 exit code。

本 PR 同步统一新落档文件命名：新生成的 eval / doctor / observe 运行产物使用 `<subject>-YYYYMMDDTHHmmss-rand4.<artifactKind>.<ext>`。eval 的 `subject` 取主评测对象，不再把 `baseline-vs` 这类对照关系写进文件名；对照关系仍保留在 report JSON 和 Studio 展示里。旧报告 id 原样保留且仍可读取。

## 测量学说明

- 不修改评分类 prompt hash。
- 不改变评分、verdict、bootstrap CI、diagnostic 的计算口径。
- 不生成 `sample covers workflow_node/reference` 这类内部覆盖边，避免在没有显式锚点时伪造覆盖结论。
- graph 只保存证据关系和轻量指标，不复制完整 prompt、trace 或 LLM 输出。

## 验证

- `yarn lint && yarn build && yarn test`
- `yarn build:docs:check`

## 关联

- #280