### PR TITLE
feat(studio): 展示 skill map 与证据卡

### DIFF
--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -442,6 +442,35 @@ details.si-pass-card[open] > summary > .si-pass-row1::before { content:'▾ ' }
 .si-sect-fold-body { padding-top:6px;display:flex;flex-direction:column;gap:5px }
 .si-sect-skipped { font-size:11px;color:var(--text-muted);font-style:italic;margin-top:6px }
 
+/* Skill Map：用户视角的轻量图，不暴露完整 graph JSON 拓扑 */
+.sm-sect { border-left-color:#4f46e5 }
+.sm-body { display:grid;grid-template-columns:minmax(0,1.25fr) minmax(280px,.75fr);gap:14px;align-items:stretch }
+@media(max-width:900px){ .sm-body { grid-template-columns:1fr } }
+.sm-canvas { position:relative;display:grid;grid-template-columns:1fr 1fr 1fr;gap:22px;align-items:center;min-height:230px;padding:18px;background:linear-gradient(180deg,#fbfcff 0%,#f7f9fd 100%);border:1px solid #e4e8f1;border-radius:8px;overflow:hidden }
+.sm-canvas::before { content:'';position:absolute;left:18%;right:18%;top:50%;height:2px;background:#dbe2ee;z-index:0 }
+.sm-col { position:relative;z-index:1;display:flex;flex-direction:column;gap:14px;align-items:stretch }
+.sm-col--root { align-items:center }
+.sm-node { min-height:68px;padding:12px 14px;border:1px solid #d8deea;border-radius:8px;background:#fff;box-shadow:0 8px 18px rgba(31,41,55,5%);display:flex;flex-direction:column;justify-content:center;gap:4px;text-align:center }
+.sm-node--skill { width:170px;min-height:96px;border-color:#4f46e5;background:#f7f8ff }
+.sm-node--stage { border-color:#b8c5d8;background:#fff }
+.sm-node--evidence { border-color:#b7d8cf;background:#f4fbf8 }
+.sm-node--pending { border-style:dashed;background:#f8f9fb;color:#637083 }
+.sm-node-title { font-size:13px;font-weight:700;color:#182033;line-height:1.35;word-break:break-word }
+.sm-node-meta { font-size:11.5px;color:#637083;line-height:1.4;word-break:break-word }
+.sm-bind { margin-top:-6px;padding:3px 8px;border-radius:10px;background:#fff;border:1px solid #e4e8f1;color:#637083;font-size:10.5px;font-family:"SF Mono",Menlo,monospace;max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap }
+.sm-side { display:flex;flex-direction:column;gap:12px }
+.sm-summary { padding:11px 12px;background:#f8f9fd;border:1px solid #e4e8f1;border-radius:8px;font-size:13px;line-height:1.55;color:#384255 }
+.sm-kpis { display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px }
+.sm-kpis div { padding:10px 12px;background:#fff;border:1px solid #e4e8f1;border-radius:8px }
+.sm-kpis b { display:block;font-size:20px;line-height:1;color:#182033;font-variant-numeric:tabular-nums }
+.sm-kpis span { display:block;margin-top:5px;font-size:11.5px;color:#637083 }
+.sm-card { border:1px solid #e4e8f1;border-radius:8px;background:#fff;overflow:hidden }
+.sm-card > summary { cursor:pointer;list-style:none;padding:10px 12px;font-size:12.5px;font-weight:600;color:#4f46e5;user-select:none }
+.sm-card > summary::-webkit-details-marker { display:none }
+.sm-card > summary::before { content:'▸ ';color:#94a3b8;font-size:10px }
+.sm-card[open] > summary::before { content:'▾ ' }
+.sm-card textarea { width:100%;min-height:260px;border:0;border-top:1px solid #e4e8f1;background:#fbfcff;padding:12px;font-family:"SF Mono",Menlo,monospace;font-size:11.5px;line-height:1.55;color:#182033;resize:vertical;box-sizing:border-box }
+
 /* doctor 规则展示(用在 doctor section 和 observe section) */
 .sd-grid { display:flex;flex-direction:column;gap:4px }
 .sd-dim { border-radius:6px;border:1px solid var(--border);overflow:hidden }
@@ -1184,6 +1213,174 @@ function renderObserveSection(
   </section>`;
 }
 
+function skillMapBand(entry: SkillIndexEntry): 'green' | 'yellow' | 'red' | 'gray' {
+  if (entry.doctor?.failCount || entry.eval?.failCount) return 'red';
+  if (entry.doctor?.warnCount || (entry.eval?.compositeScore != null && entry.eval.compositeScore < 3.5)) return 'yellow';
+  if (entry.doctor || entry.eval || entry.observe) return 'green';
+  return 'gray';
+}
+
+function stageText(entry: SkillIndexEntry, stage: 'doctor' | 'eval' | 'observe', lang: Lang): string {
+  const zh = lang === 'zh';
+  if (stage === 'doctor') {
+    if (!entry.doctor) return zh ? '未体检' : 'not checked';
+    if (entry.doctor.failCount > 0) return zh ? '未通过' : 'failed';
+    if (entry.doctor.warnCount > 0) return zh ? '有警告' : 'warnings';
+    return zh ? '已通过' : 'passed';
+  }
+  if (stage === 'eval') {
+    if (!entry.eval) return zh ? '未测量' : 'not measured';
+    if (entry.eval.resultsStripped) return entry.eval.compositeScore != null ? `${entry.eval.compositeScore.toFixed(2)}/5` : (zh ? '已测量' : 'measured');
+    return zh
+      ? `${entry.eval.passCount}/${entry.eval.totalSamples} 用例通过`
+      : `${entry.eval.passCount}/${entry.eval.totalSamples} samples pass`;
+  }
+  if (!entry.observe) return zh ? '未观察' : 'not observed';
+  return zh
+    ? `${entry.observe.segmentCount} 段，gap ${Math.round(entry.observe.gapRate * 100)}%`
+    : `${entry.observe.segmentCount} segments, gap ${Math.round(entry.observe.gapRate * 100)}%`;
+}
+
+function mermaidCardLabel(label: string): string {
+  return label.replace(/[&"<>]/g, (ch) => ({ '&': '&amp;', '"': '&quot;', '<': '&lt;', '>': '&gt;' }[ch] ?? ch));
+}
+
+function markdownInline(value: string | undefined): string {
+  if (!value) return '`unknown`';
+  return `\`${value.replaceAll('`', '\\`')}\``;
+}
+
+function sourceCommandArg(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+-]+$/.test(value)) return value;
+  return JSON.stringify(value);
+}
+
+function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string {
+  const zh = lang === 'zh';
+  const graph = entry.graph;
+  const doctor = graph?.doctor;
+  const evalGraph = graph?.eval;
+  const source = graph?.sourceLocator ?? entry.skillName;
+  const sourceArg = sourceCommandArg(source);
+  const doctorStatus = stageText(entry, 'doctor', lang);
+  const evalStatus = stageText(entry, 'eval', lang);
+  const observeStatus = stageText(entry, 'observe', lang);
+  const stepSeparator = zh ? '：' : ':';
+  const summary = zh
+    ? `这个 skill 当前处于「doctor ${doctorStatus}，eval ${evalStatus}，observe ${observeStatus}」状态。`
+    : `Current state: doctor ${doctorStatus}, eval ${evalStatus}, observe ${observeStatus}.`;
+  const nextSteps = [
+    !entry.doctor ? `- ${zh ? '体检结构' : 'Check structure'}${stepSeparator} \`omk doctor ${sourceArg}\`` : '',
+    !entry.eval ? `- ${zh ? '测量效果' : 'Measure impact'}${stepSeparator} \`omk eval --control baseline --treatment ${sourceArg}\`` : '',
+    !entry.observe ? `- ${zh ? '接入观察' : 'Add observation'}${stepSeparator} \`omk observe ingest <trace-dir>\`` : '',
+  ].filter(Boolean);
+
+  return [
+    `## Skill Evidence Card：${entry.skillName}`,
+    '',
+    summary,
+    '',
+    '```mermaid',
+    'flowchart LR',
+    `  skill["SKILL.md: ${mermaidCardLabel(entry.skillName)}"]`,
+    `  doctor["doctor: ${mermaidCardLabel(doctorStatus)}"]`,
+    `  eval["eval: ${mermaidCardLabel(evalStatus)}"]`,
+    `  observe["observe: ${mermaidCardLabel(observeStatus)}"]`,
+    ...(doctor ? [
+      `  refs["references / ${doctor.references}"]`,
+      `  scripts["scripts / ${doctor.scripts}"]`,
+      `  workflows["workflows / ${doctor.workflows}"]`,
+      '  skill --> refs',
+      '  skill --> scripts',
+      '  skill --> workflows',
+    ] : []),
+    ...(evalGraph ? [
+      `  samples["samples / ${evalGraph.samples}"]`,
+      `  assertions["assertions / ${evalGraph.assertions}"]`,
+      '  skill --> samples',
+      '  samples --> assertions',
+    ] : []),
+    '  skill --> doctor',
+    '  doctor --> eval',
+    '  eval --> observe',
+    '```',
+    '',
+    zh ? '### 三阶段状态' : '### Stage Status',
+    '',
+    `| ${zh ? '阶段' : 'Stage'} | ${zh ? '状态' : 'Status'} | ${zh ? '证据' : 'Evidence'} |`,
+    '| --- | --- | --- |',
+    `| doctor | ${doctorStatus} | ${doctor ? `${doctor.nodeCount} nodes / ${doctor.edgeCount} edges` : (zh ? '无 graph' : 'no graph')} |`,
+    `| eval | ${evalStatus} | ${evalGraph ? `${evalGraph.nodeCount} nodes / ${evalGraph.edgeCount} edges` : (zh ? '无 graph' : 'no graph')} |`,
+    `| observe | ${observeStatus} | ${zh ? '未接 production graph' : 'production graph not connected'} |`,
+    '',
+    zh ? '### 关键计数' : '### Key Counts',
+    '',
+    '| references | scripts | workflows | workflow nodes | samples | failed samples |',
+    '| ---: | ---: | ---: | ---: | ---: | ---: |',
+    `| ${doctor?.references ?? 0} | ${doctor?.scripts ?? 0} | ${doctor?.workflows ?? 0} | ${doctor?.workflowNodes ?? 0} | ${entry.eval?.totalSamples ?? 0} | ${entry.eval?.failCount ?? 0} |`,
+    ...(nextSteps.length > 0 ? ['', zh ? '### 下一步' : '### Next Steps', '', ...nextSteps] : []),
+    '',
+    zh ? '### 复现信息' : '### Reproduction',
+    '',
+    `- source：${markdownInline(source)}`,
+    `- artifactHash：${markdownInline(graph?.artifactHash)}`,
+    `- binding：${markdownInline(graph?.bindingStrength)}`,
+    `- doctorGraphId：${markdownInline(doctor?.graphId)}`,
+    `- evalGraphId：${markdownInline(evalGraph?.graphId)}`,
+    '',
+  ].join('\n');
+}
+
+function renderSkillMapSection(entry: SkillIndexEntry, lang: Lang): string {
+  const graph = entry.graph;
+  if (!graph) return '';
+  const zh = lang === 'zh';
+  const doctor = graph.doctor;
+  const evalGraph = graph.eval;
+  const band = skillMapBand(entry);
+  const markdown = renderSkillEvidenceMarkdown(entry, lang);
+  const statusSentence = zh
+    ? `这张图按 ${graph.bindingStrength === 'content-hash' ? '内容哈希' : graph.bindingStrength === 'source-locator' ? '来源路径' : '名称'} 绑定 doctor / eval 证据，展示当前已知结构与测量状态。`
+    : `This map binds doctor / eval evidence by ${graph.bindingStrength} and shows the known structure and measurement state.`;
+  const node = (cls: string, title: string, meta: string): string => `<div class="sm-node sm-node--${cls}"><div class="sm-node-title">${e(title)}</div><div class="sm-node-meta">${e(meta)}</div></div>`;
+  return `<section id="section-skill-map" class="si-sect si-sect--${band} sm-sect">
+    <div class="si-sect-h">
+      <span class="si-sect-title">🗺 ${zh ? 'Skill Map' : 'Skill Map'}</span>
+      <span class="si-sect-meta">${doctor ? `${doctor.nodeCount} definition nodes` : (zh ? 'definition 未生成' : 'definition missing')} · ${evalGraph ? `${evalGraph.nodeCount} measurement nodes` : (zh ? 'measurement 未生成' : 'measurement missing')}</span>
+    </div>
+    <div class="sm-body">
+      <div class="sm-canvas" aria-label="Skill Map">
+        <div class="sm-col">
+          ${node('evidence', zh ? '结构证据' : 'Structure', doctor ? `${doctor.references} refs · ${doctor.scripts} scripts · ${doctor.workflows} workflows` : (zh ? '未生成 doctor graph' : 'doctor graph missing'))}
+          ${node('stage', 'doctor', stageText(entry, 'doctor', lang))}
+        </div>
+        <div class="sm-col sm-col--root">
+          ${node('skill', `SKILL.md`, entry.skillName)}
+          <div class="sm-bind">${e(graph.artifactHash ? `hash ${graph.artifactHash}` : graph.bindingStrength)}</div>
+        </div>
+        <div class="sm-col">
+          ${node('evidence', zh ? '测量证据' : 'Measurement', evalGraph ? `${evalGraph.samples} samples · ${evalGraph.assertions} assertions · ${evalGraph.diagnostics} diagnostics` : (zh ? '未生成 eval graph' : 'eval graph missing'))}
+          ${node('stage', 'eval', stageText(entry, 'eval', lang))}
+          ${node('pending', 'observe', stageText(entry, 'observe', lang))}
+        </div>
+      </div>
+      <div class="sm-side">
+        <div class="sm-summary">${e(statusSentence)}</div>
+        <div class="sm-kpis">
+          <div><b>${doctor?.references ?? 0}</b><span>references</span></div>
+          <div><b>${doctor?.workflows ?? 0}</b><span>workflows</span></div>
+          <div><b>${entry.eval?.totalSamples ?? 0}</b><span>samples</span></div>
+          <div><b>${entry.eval?.failCount ?? 0}</b><span>${zh ? '失败用例' : 'failed'}</span></div>
+        </div>
+        <details class="sm-card">
+          <summary>${zh ? '复制 Markdown Evidence Card' : 'Copy Markdown Evidence Card'}</summary>
+          <textarea readonly>${e(markdown)}</textarea>
+        </details>
+      </div>
+    </div>
+  </section>`;
+}
+
 // ────────── 主入口 ──────────
 
 export function renderSkillDetail(
@@ -1201,6 +1398,7 @@ export function renderSkillDetail(
     <main>
       <a class="si-back" href="/${langQ}">${lang === 'zh' ? '← 返回 Skill 列表' : '← Back to Skills'}</a>
       ${renderHero(entry, insights, lastTs, reportCount, lang)}
+      ${renderSkillMapSection(entry, lang)}
       ${renderDoctorSection(entry.doctor, entry.doctorHistory, entry.skillName, lang)}
       ${renderEvalSection(entry.eval, evalReport, entry.evalHistory, langQ, lang)}
       ${renderObserveSection(entry.observe, langQ, lang)}

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -1242,7 +1242,26 @@ function stageText(entry: SkillIndexEntry, stage: 'doctor' | 'eval' | 'observe',
 }
 
 function mermaidCardLabel(label: string): string {
-  return label.replace(/[&"<>]/g, (ch) => ({ '&': '&amp;', '"': '&quot;', '<': '&lt;', '>': '&gt;' }[ch] ?? ch));
+  const entities: Record<string, string> = {
+    '&': '&amp;',
+    '\\': '&#92;',
+    '"': '&quot;',
+    '[': '&#91;',
+    ']': '&#93;',
+    '(': '&#40;',
+    ')': '&#41;',
+    '{': '&#123;',
+    '}': '&#125;',
+    '|': '&#124;',
+    '#': '&#35;',
+    ';': '&#59;',
+    '<': '&lt;',
+    '>': '&gt;',
+  };
+  return label
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/[&\\"[\](){}|#;<>]/g, (ch) => entities[ch] ?? ch);
 }
 
 function markdownInline(value: string | undefined): string {
@@ -1310,7 +1329,7 @@ function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string
     `| ${zh ? '阶段' : 'Stage'} | ${zh ? '状态' : 'Status'} | ${zh ? '证据' : 'Evidence'} |`,
     '| --- | --- | --- |',
     `| doctor | ${doctorStatus} | ${doctor ? `${doctor.nodeCount} nodes / ${doctor.edgeCount} edges` : (zh ? '无 graph' : 'no graph')} |`,
-    `| eval | ${evalStatus} | ${evalGraph ? `${evalGraph.nodeCount} nodes / ${evalGraph.edgeCount} edges` : (zh ? '无 graph' : 'no graph')} |`,
+    `| eval | ${evalStatus} | ${evalGraph ? `${zh ? 'variant 子图' : 'variant subgraph'}: ${evalGraph.nodeCount} nodes / ${evalGraph.edgeCount} edges` : (zh ? '无 graph' : 'no graph')} |`,
     `| observe | ${observeStatus} | ${zh ? '未接 production graph' : 'production graph not connected'} |`,
     '',
     zh ? '### 关键计数' : '### Key Counts',
@@ -1353,7 +1372,7 @@ function renderSkillMapSection(entry: SkillIndexEntry, lang: Lang): string {
   return `<section id="section-skill-map" class="si-sect si-sect--${band} sm-sect">
     <div class="si-sect-h">
       <span class="si-sect-title">🗺 ${zh ? 'Skill Map' : 'Skill Map'}</span>
-      <span class="si-sect-meta">${doctor ? `${doctor.nodeCount} definition nodes` : (zh ? 'definition 未生成' : 'definition missing')} · ${evalGraph ? `${evalGraph.nodeCount} measurement nodes` : (zh ? 'measurement 未生成' : 'measurement missing')}</span>
+      <span class="si-sect-meta">${doctor ? `${doctor.nodeCount} definition nodes` : (zh ? 'definition 未生成' : 'definition missing')} · ${evalGraph ? `${evalGraph.nodeCount} variant subgraph nodes` : (zh ? 'measurement 未生成' : 'measurement missing')}</span>
     </div>
     <div class="sm-body">
       <div class="sm-canvas" aria-label="Skill Map">

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -1339,9 +1339,16 @@ function renderSkillMapSection(entry: SkillIndexEntry, lang: Lang): string {
   const evalGraph = graph.eval;
   const band = skillMapBand(entry);
   const markdown = renderSkillEvidenceMarkdown(entry, lang);
+  const bindingLabel = graph.bindingStrength === 'content-hash'
+    ? (zh ? '内容哈希' : 'content hash')
+    : graph.bindingStrength === 'source-locator'
+      ? (zh ? '来源路径' : 'source locator')
+      : graph.bindingStrength === 'mixed'
+        ? (zh ? '混合证据' : 'mixed evidence')
+        : (zh ? '名称' : 'name');
   const statusSentence = zh
-    ? `这张图按 ${graph.bindingStrength === 'content-hash' ? '内容哈希' : graph.bindingStrength === 'source-locator' ? '来源路径' : '名称'} 绑定 doctor / eval 证据，展示当前已知结构与测量状态。`
-    : `This map binds doctor / eval evidence by ${graph.bindingStrength} and shows the known structure and measurement state.`;
+    ? `这张图按 ${bindingLabel} 绑定 doctor / eval 证据，展示当前已知结构与测量状态。`
+    : `This map binds doctor / eval evidence by ${bindingLabel} and shows the known structure and measurement state.`;
   const node = (cls: string, title: string, meta: string): string => `<div class="sm-node sm-node--${cls}"><div class="sm-node-title">${e(title)}</div><div class="sm-node-meta">${e(meta)}</div></div>`;
   return `<section id="section-skill-map" class="si-sect si-sect--${band} sm-sect">
     <div class="si-sect-h">

--- a/src/renderer/skill-list-renderer.ts
+++ b/src/renderer/skill-list-renderer.ts
@@ -110,13 +110,8 @@ function renderPanel(a: Agg, lang: Lang): string {
 
 function renderRow(entry: SkillIndexEntry, insights: Insight[], langQ: string, lang: Lang): string {
   const h = assessHealth(entry, insights, lang);
-  // 点行直接进该 skill 最新 eval 报告(无 eval 则最新 doctor);跨维度/历史在报告页内切换。
-  const amp = lang === DEFAULT_LANG ? '' : `&lang=${lang}`;
-  const href = entry.eval
-    ? `/reports/${encodeURIComponent(entry.eval.reportId)}${langQ}`
-    : entry.doctor
-      ? `/doctors/${encodeURIComponent(entry.doctor.reportId)}?skill=${encodeURIComponent(entry.skillName)}${amp}`
-      : `/runs${langQ}`;
+  // 点行先进入 skill hub：Skill Map / 三阶段状态 / Evidence Card 是用户第一视角。
+  const href = `/skills/${encodeURIComponent(entry.skillName)}${langQ}`;
   const dT = entry.doctor ? entry.doctor.passCount + entry.doctor.warnCount + entry.doctor.failCount : 0;
   const dP = dT > 0 ? Math.round(((entry.doctor!.passCount + entry.doctor!.warnCount * 0.5) / dT) * 100) : null;
   const eP = entry.eval?.compositeScore != null ? Math.round((entry.eval.compositeScore / 5) * 100) : null;

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -7,7 +7,7 @@ import { renderSkillList } from '../renderer/skill-list-renderer.js';
 import { renderSkillHealthReport } from '../renderer/skill-health-renderer.js';
 import { renderDoctorDetail } from '../renderer/doctor-detail-renderer.js';
 import type { SkillReportContext } from '../renderer/report-shell.js';
-import { assessHealth } from '../renderer/skill-detail-renderer.js';
+import { assessHealth, renderSkillDetail } from '../renderer/skill-detail-renderer.js';
 import type { SkillIndexEntry, Insight } from '../types/skill-index.js';
 import { renderObservationInboxPage } from '../renderer/observation-inbox-renderer.js';
 import { DEFAULT_LANG, t, layout } from '../renderer/layout.js';
@@ -15,6 +15,7 @@ import { loadAllManagedRecords, resolveManagedDir, managedDir as projectManagedD
 import { renderManagedList, renderManagedHistory } from '../renderer/managed-history-renderer.js';
 import { DEFAULT_JOBS_DIR } from '../eval-core/default-dirs.js';
 import { resolveObserveHealthDir, projectObserveHealthDir, resolveDoctorsDir, projectDoctorsDir, projectReportsDir, globalReportsDir } from '../eval-core/measurement-dirs.js';
+import { evalGraphDirForReportOutput } from '../artifact-graph/eval.js';
 import { listObserveCards, listDoctorCards, listLiveObserveCards } from '../eval-core/artifact-index.js';
 import { isReportFileName, reportFilePath, reportFileStem } from '../eval-core/artifact-file-names.js';
 import { migrateLegacyReportFiles } from '../eval-core/report-file-migration.js';
@@ -704,6 +705,19 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
         ? (): string => doctorsDir
         : (): string => resolveDoctorsDir(projectDoctorsDir());
 
+  const includeReportCards = reportsDir === undefined && store == null;
+  const evalGraphDirs = reportsDir !== undefined
+    ? [evalGraphDirForReportOutput(reportsDir)]
+    : store
+      ? []
+      : [evalGraphDirForReportOutput(projectReportsDir()), evalGraphDirForReportOutput(globalReportsDir())];
+  const skillIndexOptions = (): Parameters<typeof buildSkillIndex>[4] => ({
+    includeObserveCards,
+    includeDoctorCards,
+    includeReportCards,
+    evalGraphDirs,
+  });
+
   async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
     try {
       const parsed = new URL(req.url || '/', 'http://127.0.0.1');
@@ -851,7 +865,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
 
       if (path === '/api/observe-inbox/diagnostics') {
         const runs = await reportStore.list();
-        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, skillIndexOptions());
         res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
         res.end(JSON.stringify({
           sourceCoverage: idx.diagnosisSummary.sourceCoverage,
@@ -940,7 +954,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
         let ctx: SkillReportContext | undefined;
         if (skillName) {
           const runs = await reportStore.list();
-          const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
+          const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, skillIndexOptions());
           const entry = idx.entries.find((en) => en.skillName === skillName);
           if (entry) ctx = buildSkillContext(entry, 'doctor', id, idx.insightsBySkill.get(entry.skillName) ?? [], lang);
         }
@@ -1114,7 +1128,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
         let ctx: SkillReportContext | undefined;
         if (report && report.kind === 'evaluation') {
           const runs = await reportStore.list();
-          const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
+          const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, skillIndexOptions());
           // 按 evalHistory 匹配(非仅最新),历史 eval 报告也能定位到所属 skill。
           const entry = idx.entries.find((en) => en.evalHistory.some((h) => h.reportId === reportId));
           if (entry) ctx = buildSkillContext(entry, 'eval', reportId, idx.insightsBySkill.get(entry.skillName) ?? [], lang);
@@ -1137,7 +1151,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
       // list renderer 直接消费,不再每请求 N×detectInsights 重算。
       if (path === '/') {
         const runs = await reportStore.list();
-        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, skillIndexOptions());
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(renderSkillList(idx, lang));
         return;
@@ -1145,7 +1159,7 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
 
       if (path === '/api/skills') {
         const runs = await reportStore.list();
-        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, skillIndexOptions());
         res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
         res.end(JSON.stringify({
           entries: idx.entries.map((entry) => ({
@@ -1159,16 +1173,29 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
         return;
       }
 
-      // 注:/skills/<name> 详情页(hub)已下线 — 首页点行直接进 eval/doctor 报告,跨维度靠
-      // 报告页 chip 条 +「全部历史」弹框,不再有中间汇总页。该路由不做兼容重定向:Studio
-      // 是本地临时服务器、端口每次启动都变,跨会话书签 localhost:<port> 本就失效,且 PR 内
-      // 已无任何链接指向它。未匹配的 /skills/<name> 直接落到下方通用 404。
+      const skillHubMatch = path.match(/^\/skills\/(.+)$/);
+      if (skillHubMatch) {
+        const skillName = decodeURIComponent(skillHubMatch[1]);
+        const runs = await reportStore.list();
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, skillIndexOptions());
+        const entry = idx.entries.find((en) => en.skillName === skillName);
+        if (!entry) {
+          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+          res.end(lang === 'en' ? 'skill not found' : '未找到该 skill');
+          return;
+        }
+        const report = entry.eval ? await queryRun(reportStore, entry.eval.reportId) : null;
+        const evalReport = report?.kind === 'evaluation' ? report : null;
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(renderSkillDetail(entry, evalReport, lang, idx.insightsBySkill.get(entry.skillName) ?? []));
+        return;
+      }
 
       const skillDiagnosticsApiMatch = path.match(/^\/api\/skills\/(.+)\/diagnostics$/);
       if (skillDiagnosticsApiMatch) {
         const skillName = decodeURIComponent(skillDiagnosticsApiMatch[1]);
         const runs = await reportStore.list();
-        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, { includeObserveCards, includeDoctorCards });
+        const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, skillIndexOptions());
         const diagnostics = idx.diagnosticsBySkill.get(skillName);
         if (!diagnostics) {
           res.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -1175,7 +1175,14 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
 
       const skillHubMatch = path.match(/^\/skills\/(.+)$/);
       if (skillHubMatch) {
-        const skillName = decodeURIComponent(skillHubMatch[1]);
+        let skillName: string;
+        try {
+          skillName = decodeURIComponent(skillHubMatch[1]);
+        } catch {
+          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+          res.end(lang === 'en' ? 'skill not found' : '未找到该 skill');
+          return;
+        }
         const runs = await reportStore.list();
         const idx = buildSkillIndex(runs, analysesDir, doctorsDir, observationsDir, skillIndexOptions());
         const entry = idx.entries.find((en) => en.skillName === skillName);

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -444,19 +444,26 @@ function graphSkillNames(graph: ArtifactGraphDocument): string[] {
   ]);
 }
 
-function graphArtifactHashes(graph: ArtifactGraphDocument): string[] {
-  return uniqueStrings([
-    graph.scope.artifactHash ?? '',
-    ...graphSkillNodes(graph).map((node) => node.binding?.keys?.artifactHash ?? ''),
-  ]);
+function nodeArtifactHash(node: ArtifactGraphNode | undefined): string | undefined {
+  const hash = node?.binding?.keys?.artifactHash;
+  return hash && hash !== 'no-skill' ? hash : undefined;
 }
 
-function graphSourceLocator(graph: ArtifactGraphDocument): string | undefined {
-  const skillDisplay = graphSkillNodes(graph)
-    .map((node) => node.attrs?.display)
-    .find((display) => display && typeof display.sourceLocator === 'string');
-  return graph.scope.sourceLocator
-    ?? (typeof skillDisplay?.sourceLocator === 'string' ? skillDisplay.sourceLocator : undefined);
+function nodeSourceLocator(node: ArtifactGraphNode | undefined): string | undefined {
+  const locator = node?.attrs?.display?.sourceLocator;
+  return typeof locator === 'string' && locator.trim() ? locator : undefined;
+}
+
+function graphSourceLocator(graph: ArtifactGraphDocument, skillNode?: ArtifactGraphNode): string | undefined {
+  if (graph.source.sourceKind === 'eval') {
+    // Eval graph 的 scope.sourceLocator 是 samplesPath；skill 路径在 skill node 上。
+    return nodeSourceLocator(skillNode);
+  }
+  return graph.scope.sourceLocator ?? nodeSourceLocator(skillNode);
+}
+
+function graphNodeMap(graph: ArtifactGraphDocument): Map<string, ArtifactGraphNode> {
+  return new Map(graph.nodes.map((node) => [node.id, node]));
 }
 
 function graphHasSkill(graph: ArtifactGraphDocument, entry: SkillIndexEntry): boolean {
@@ -464,11 +471,30 @@ function graphHasSkill(graph: ArtifactGraphDocument, entry: SkillIndexEntry): bo
   return names.includes(entry.skillName) || (entry.eval ? names.includes(entry.eval.variantName) : false);
 }
 
-function graphMatchesEntry(graph: ArtifactGraphDocument, entry: SkillIndexEntry): boolean {
-  const hashes = graphArtifactHashes(graph);
-  const entryHash = entry.graph?.artifactHash;
-  if (entryHash && hashes.includes(entryHash)) return true;
+function graphMatchesDoctorEntry(graph: ArtifactGraphDocument, entry: SkillIndexEntry): boolean {
   return graphHasSkill(graph, entry);
+}
+
+function evalVariantName(entry: SkillIndexEntry): string | null {
+  return entry.eval?.variantName ?? null;
+}
+
+function evalVariantNode(graph: ArtifactGraphDocument, entry: SkillIndexEntry): ArtifactGraphNode | undefined {
+  const variantName = evalVariantName(entry);
+  if (!variantName) return undefined;
+  return graph.nodes.find((node) => node.nodeKind === 'variant' && node.label === variantName);
+}
+
+function evalSkillNodeForVariant(graph: ArtifactGraphDocument, variantNode: ArtifactGraphNode): ArtifactGraphNode | undefined {
+  const nodesById = graphNodeMap(graph);
+  return graph.edges
+    .filter((edge) => edge.fromNodeId === variantNode.id && edge.edgeKind === 'derived_from')
+    .map((edge) => nodesById.get(edge.toNodeId))
+    .find((node): node is ArtifactGraphNode => node?.nodeKind === 'skill');
+}
+
+function graphMatchesEvalEntry(graph: ArtifactGraphDocument, entry: SkillIndexEntry): boolean {
+  return evalVariantNode(graph, entry) !== undefined;
 }
 
 function pickLatestGraph(graphs: LoadedArtifactGraph[]): LoadedArtifactGraph | null {
@@ -485,9 +511,18 @@ function countGraphNodes(graph: ArtifactGraphDocument, nodeKind: ArtifactGraphNo
   return graph.nodes.filter((node) => node.nodeKind === nodeKind).length;
 }
 
-function sourceStage(graph: ArtifactGraphDocument, path: string): SkillGraphSnapshot['doctor'] | SkillGraphSnapshot['eval'] | undefined {
+interface ProjectedGraphStage<T> {
+  stage: T;
+  artifactHash?: string;
+  sourceLocator?: string;
+}
+
+function projectDoctorStage(graph: ArtifactGraphDocument, path: string): ProjectedGraphStage<NonNullable<SkillGraphSnapshot['doctor']>> | undefined {
+  if (graph.source.sourceKind !== 'doctor') return undefined;
+  const skillNode = graphSkillNodes(graph)[0];
+  const sourceLocator = graphSourceLocator(graph, skillNode);
   const base = {
-    sourceKind: graph.source.sourceKind,
+    sourceKind: 'doctor' as const,
     sourceId: graph.source.sourceId,
     graphId: graph.graphId,
     generatedAt: graph.generatedAt,
@@ -495,64 +530,135 @@ function sourceStage(graph: ArtifactGraphDocument, path: string): SkillGraphSnap
     nodeCount: graph.nodes.length,
     edgeCount: graph.edges.length,
   };
-  if (graph.source.sourceKind === 'doctor') {
-    return {
+  return {
+    stage: {
       ...base,
-      sourceKind: 'doctor',
       references: countGraphNodes(graph, 'reference'),
       scripts: countGraphNodes(graph, 'script'),
       workflows: countGraphNodes(graph, 'workflow'),
       workflowNodes: countGraphNodes(graph, 'workflow_node'),
       hardRules: countGraphNodes(graph, 'hard_rule'),
-    };
+    },
+    ...(graph.scope.artifactHash ? { artifactHash: graph.scope.artifactHash } : {}),
+    ...(sourceLocator ? { sourceLocator } : {}),
+  };
+}
+
+function projectEvalStage(graph: ArtifactGraphDocument, path: string, entry: SkillIndexEntry): ProjectedGraphStage<NonNullable<SkillGraphSnapshot['eval']>> | undefined {
+  if (graph.source.sourceKind !== 'eval') return undefined;
+  const variantNode = evalVariantNode(graph, entry);
+  if (!variantNode) return undefined;
+  const skillNode = evalSkillNodeForVariant(graph, variantNode);
+  const artifactHash = nodeArtifactHash(variantNode) ?? nodeArtifactHash(skillNode);
+  const sourceLocator = graphSourceLocator(graph, skillNode);
+  const nodesById = graphNodeMap(graph);
+  const projectedNodeIds = new Set<string>([variantNode.id]);
+  const projectedEdgeIds = new Set<string>();
+  if (skillNode) projectedNodeIds.add(skillNode.id);
+
+  const addEdge = (edge: ArtifactGraphDocument['edges'][number]): void => {
+    projectedEdgeIds.add(edge.id);
+    projectedNodeIds.add(edge.fromNodeId);
+    projectedNodeIds.add(edge.toNodeId);
+  };
+
+  for (const edge of graph.edges) {
+    if (edge.fromNodeId === variantNode.id && (edge.edgeKind === 'evaluates' || edge.edgeKind === 'derived_from')) {
+      addEdge(edge);
+    }
   }
-  if (graph.source.sourceKind === 'eval') {
-    const variantNode = graph.nodes.find((node) => node.nodeKind === 'variant' && node.binding?.keys?.artifactHash && node.binding.keys.artifactHash !== 'no-skill');
-    return {
-      ...base,
+
+  const evalResultNodes = graph.edges
+    .filter((edge) => edge.toNodeId === variantNode.id && edge.edgeKind === 'derived_from')
+    .map((edge) => nodesById.get(edge.fromNodeId))
+    .filter((node): node is ArtifactGraphNode => node?.nodeKind === 'eval_result');
+  for (const node of evalResultNodes) projectedNodeIds.add(node.id);
+
+  for (const edge of graph.edges) {
+    if (!evalResultNodes.some((node) => node.id === edge.fromNodeId || node.id === edge.toNodeId)) continue;
+    if (edge.edgeKind === 'derived_from' || edge.edgeKind === 'evaluates' || edge.edgeKind === 'passes' || edge.edgeKind === 'fails' || edge.edgeKind === 'diagnoses') {
+      addEdge(edge);
+    }
+  }
+
+  const sampleIds = new Set<string>();
+  const assertionIds = new Set<string>();
+  const diagnosticIds = new Set<string>();
+  let failedAssertionEdges = 0;
+  for (const edge of graph.edges) {
+    if (!projectedEdgeIds.has(edge.id)) continue;
+    const from = nodesById.get(edge.fromNodeId);
+    const to = nodesById.get(edge.toNodeId);
+    if (from?.nodeKind === 'sample') sampleIds.add(from.id);
+    if (to?.nodeKind === 'sample') sampleIds.add(to.id);
+    if (from?.nodeKind === 'assertion') assertionIds.add(from.id);
+    if (to?.nodeKind === 'assertion') assertionIds.add(to.id);
+    if (from?.nodeKind === 'diagnostic') diagnosticIds.add(from.id);
+    if (to?.nodeKind === 'diagnostic') diagnosticIds.add(to.id);
+    if (edge.edgeKind === 'fails') failedAssertionEdges += 1;
+  }
+
+  return {
+    stage: {
       sourceKind: 'eval',
-      variantName: variantNode?.label,
-      samples: countGraphNodes(graph, 'sample'),
-      assertions: countGraphNodes(graph, 'assertion'),
-      failedAssertionEdges: graph.edges.filter((edge) => edge.edgeKind === 'fails').length,
-      diagnostics: countGraphNodes(graph, 'diagnostic'),
-    };
+      sourceId: graph.source.sourceId,
+      graphId: graph.graphId,
+      generatedAt: graph.generatedAt,
+      graphPath: path,
+      nodeCount: projectedNodeIds.size,
+      edgeCount: projectedEdgeIds.size,
+      variantName: variantNode.label,
+      samples: sampleIds.size,
+      assertions: assertionIds.size,
+      failedAssertionEdges,
+      diagnostics: diagnosticIds.size,
+    },
+    ...(artifactHash ? { artifactHash } : {}),
+    ...(sourceLocator ? { sourceLocator } : {}),
+  };
+}
+
+function graphSnapshotBinding(stages: ProjectedGraphStage<unknown>[]): Pick<SkillGraphSnapshot, 'artifactHash' | 'bindingStrength' | 'sourceLocator'> {
+  const hashes = uniqueStrings(stages.map((stage) => stage.artifactHash ?? ''));
+  const locators = uniqueStrings(stages.map((stage) => stage.sourceLocator ?? ''));
+  if (stages.length > 0 && hashes.length === 1 && stages.every((stage) => stage.artifactHash === hashes[0])) {
+    return { bindingStrength: 'content-hash', artifactHash: hashes[0], ...(locators[0] ? { sourceLocator: locators[0] } : {}) };
   }
-  return undefined;
+  if (hashes.length > 0) {
+    return { bindingStrength: 'mixed', ...(locators[0] ? { sourceLocator: locators[0] } : {}) };
+  }
+  if (locators.length > 0) {
+    return { bindingStrength: 'source-locator', sourceLocator: locators[0] };
+  }
+  return { bindingStrength: 'name-only' };
 }
 
 function graphSnapshotForEntry(entry: SkillIndexEntry, graphs: LoadedArtifactGraph[]): SkillGraphSnapshot | undefined {
   const doctorCandidates = graphs.filter(({ graph }) =>
     graph.source.sourceKind === 'doctor'
       && (!entry.doctor || graph.source.sourceId === entry.doctor.reportId)
-      && graphMatchesEntry(graph, entry),
+      && graphMatchesDoctorEntry(graph, entry),
   );
   const evalCandidates = graphs.filter(({ graph }) =>
     graph.source.sourceKind === 'eval'
       && (!entry.eval || graph.source.sourceId === entry.eval.reportId)
-      && graphMatchesEntry(graph, entry),
+      && graphMatchesEvalEntry(graph, entry),
   );
   const doctor = pickLatestGraph(doctorCandidates);
   const evalGraph = pickLatestGraph(evalCandidates);
   if (!doctor && !evalGraph) return undefined;
 
-  const hashes = uniqueStrings([
-    ...(doctor ? graphArtifactHashes(doctor.graph) : []),
-    ...(evalGraph ? graphArtifactHashes(evalGraph.graph) : []),
-  ]);
-  const sourceLocator = doctor ? graphSourceLocator(doctor.graph) : evalGraph ? graphSourceLocator(evalGraph.graph) : undefined;
-  const bindingStrength: SkillGraphSnapshot['bindingStrength'] = hashes.length > 0
-    ? 'content-hash'
-    : sourceLocator
-      ? 'source-locator'
-      : 'name-only';
+  const doctorStage = doctor ? projectDoctorStage(doctor.graph, doctor.path) : undefined;
+  const evalStage = evalGraph ? projectEvalStage(evalGraph.graph, evalGraph.path, entry) : undefined;
+  const projectedStages: ProjectedGraphStage<unknown>[] = [];
+  if (doctorStage) projectedStages.push(doctorStage);
+  if (evalStage) projectedStages.push(evalStage);
+  const binding = graphSnapshotBinding(projectedStages);
 
   return {
-    bindingStrength,
-    ...(hashes[0] ? { artifactHash: hashes[0] } : {}),
-    ...(sourceLocator ? { sourceLocator } : {}),
-    ...(doctor ? { doctor: sourceStage(doctor.graph, doctor.path) as SkillGraphSnapshot['doctor'] } : {}),
-    ...(evalGraph ? { eval: sourceStage(evalGraph.graph, evalGraph.path) as SkillGraphSnapshot['eval'] } : {}),
+    ...binding,
+    ...(doctorStage ? { doctor: doctorStage.stage } : {}),
+    ...(evalStage ? { eval: evalStage.stage } : {}),
   };
 }
 

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -15,8 +15,10 @@
  */
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, isAbsolute, basename, dirname } from 'node:path';
-import { isReportFileName, reportFileStem } from '../eval-core/artifact-file-names.js';
+import { GRAPH_FILE_SUFFIX, graphFileName, isReportFileName, reportFileStem } from '../eval-core/artifact-file-names.js';
 import { migrateLegacyReportFiles } from '../eval-core/report-file-migration.js';
+import { doctorGraphDirForDoctorOutput } from '../artifact-graph/doctor.js';
+import { evalGraphDirForReportOutput } from '../artifact-graph/eval.js';
 import type {
   ReportDocument,
   EvaluationReport,
@@ -26,15 +28,18 @@ import type {
   SkillDoctorSnapshot,
   SkillEvalSnapshot,
   SkillObserveSnapshot,
+  SkillGraphSnapshot,
   SkillIndexEntry,
   SkillIndexSummary,
   SkillIndex,
   Insight,
+  ArtifactGraphDocument,
+  ArtifactGraphNode,
 } from '../types/index.js';
 import type { SkillHealthReport } from '../observability/skill-health-analyzer.js';
 import { confidenceOf } from '../observability/skill-health-analyzer.js';
 import { computeVerdict } from '../eval-core/verdict.js';
-import { artifactIndexDir, listLiveDoctorCards, cardToDoctorSnapshot, listLiveObserveCards, cardTargetSentinel } from '../eval-core/artifact-index.js';
+import { artifactIndexDir, listLiveDoctorCards, cardToDoctorSnapshot, listLiveObserveCards, listLiveReportCards, cardTargetSentinel } from '../eval-core/artifact-index.js';
 import { detectInsights } from './skill-insights.js';
 import { DEFAULT_OBSERVATIONS_DIR, loadLatestObservationInboxReports } from '../observability/inbox.js';
 import { buildStudioDiagnosisSummary, mergeDiagnosisBundles } from '../diagnosis/studio-projection.js';
@@ -129,7 +134,75 @@ function safeDirJsonContentFingerprint(dir: string): string {
   return `${dir}|${dirMtimeMs}|${fileParts.join(',')}`;
 }
 
-function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, doctorsDir: string, observationsDir: string, includeObserveCards: boolean, includeDoctorCards: boolean): string {
+function safeDirGraphContentFingerprint(dir: string): string {
+  let dirMtimeMs: number;
+  let graphFiles: string[];
+  try {
+    dirMtimeMs = statSync(dir).mtimeMs;
+    graphFiles = readdirSync(dir).filter((f) => f.endsWith(GRAPH_FILE_SUFFIX)).sort();
+  } catch {
+    return `missing:${dir}`;
+  }
+  const fileParts = graphFiles.map((f) => {
+    try {
+      const fStat = statSync(join(dir, f));
+      return `${f}:${fStat.mtimeMs}:${fStat.size}`;
+    } catch {
+      return `${f}:?`;
+    }
+  });
+  return `${dir}|${dirMtimeMs}|${fileParts.join(',')}`;
+}
+
+function fileFingerprint(path: string): string {
+  try {
+    const stat = statSync(path);
+    return `${path}:${stat.mtimeMs}:${stat.size}`;
+  } catch {
+    return `${path}:missing`;
+  }
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+
+function graphSidecarPathForReportPath(reportPath: string, reportId: string): string {
+  return join(evalGraphDirForReportOutput(dirname(reportPath)), graphFileName(reportId));
+}
+
+function graphSidecarPathForDoctorCard(cardPath: string, cardId: string): string {
+  return join(doctorGraphDirForDoctorOutput(dirname(cardPath)), graphFileName(cardId));
+}
+
+function buildGraphFingerprint(
+  evalGraphDirs: string[],
+  doctorGraphDirs: string[],
+  includeReportCards: boolean,
+  includeDoctorCards: boolean,
+): string {
+  const dirPart = [
+    ...uniqueStrings(evalGraphDirs).map((dir) => `eg:${safeDirGraphContentFingerprint(dir)}`),
+    ...uniqueStrings(doctorGraphDirs).map((dir) => `dg:${safeDirGraphContentFingerprint(dir)}`),
+  ].join('|');
+  const reportCardPart = includeReportCards
+    ? listLiveReportCards().map((card) => fileFingerprint(graphSidecarPathForReportPath(card.path, card.id))).sort().join('|')
+    : '';
+  const doctorCardPart = includeDoctorCards
+    ? listLiveDoctorCards().map((card) => fileFingerprint(graphSidecarPathForDoctorCard(card.path, card.id))).sort().join('|')
+    : '';
+  return `${dirPart}|erc:${reportCardPart}|drc:${doctorCardPart}`;
+}
+
+function buildIndexFingerprint(
+  reports: ReportDocument[],
+  analysesDir: string,
+  doctorsDir: string,
+  observationsDir: string,
+  includeObserveCards: boolean,
+  includeDoctorCards: boolean,
+  graphFingerprint: string,
+): string {
   // `d:` 跟 `o:` 前缀("d for doctors / o for observability analyses")沿用 pre-fix
   // 字面格式,避免外部 logging / debug 时 grep fingerprint 字符串的格式漂移。
   // 每一段的 right-hand-side 从旧的 "{dir-mtime}-{file-count}" 双标量升级成
@@ -148,7 +221,7 @@ function buildIndexFingerprint(reports: ReportDocument[], analysesDir: string, d
   // 卡片目录指纹 + 真身存在性 sentinel 都纳入:后者使「卡片真身被带外删」也能让缓存失效(否则悬空卡片继续展示)。
   const doctorCardsFp = includeDoctorCards ? `${safeDirJsonContentFingerprint(artifactIndexDir('doctor'))}|t:${cardTargetSentinel('doctor')}` : '';
   const observeCardsFp = includeObserveCards ? `${safeDirJsonContentFingerprint(artifactIndexDir('observe-health'))}|t:${cardTargetSentinel('observe-health')}` : '';
-  return `${reportIds}|d:${doctorsFp}|o:${analysesFp}|obs:${observationsFp}|dc:${doctorCardsFp}|oc:${observeCardsFp}|inc:${includeObserveCards ? 'o' : ''}${includeDoctorCards ? 'd' : ''}`;
+  return `${reportIds}|d:${doctorsFp}|o:${analysesFp}|obs:${observationsFp}|dc:${doctorCardsFp}|oc:${observeCardsFp}|g:${graphFingerprint}|inc:${includeObserveCards ? 'o' : ''}${includeDoctorCards ? 'd' : ''}`;
 }
 
 /** 测试 / 调试用:强制清掉 in-process skill-index 缓存。 */
@@ -293,6 +366,196 @@ function latestEvalSnapshot(list: SkillEvalSnapshot[]): SkillEvalSnapshot | null
   return list[list.length - 1];
 }
 
+interface LoadedArtifactGraph {
+  graph: ArtifactGraphDocument;
+  path: string;
+}
+
+function isArtifactGraphDocument(value: unknown): value is ArtifactGraphDocument {
+  if (!value || typeof value !== 'object') return false;
+  const graph = value as Partial<ArtifactGraphDocument>;
+  return graph.documentKind === 'artifact-graph'
+    && graph.schemaVersion === 1
+    && typeof graph.graphId === 'string'
+    && !!graph.source
+    && (graph.source.sourceKind === 'doctor' || graph.source.sourceKind === 'eval' || graph.source.sourceKind === 'observe')
+    && Array.isArray(graph.nodes)
+    && Array.isArray(graph.edges);
+}
+
+function readArtifactGraph(path: string): LoadedArtifactGraph | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    if (!isArtifactGraphDocument(parsed)) return null;
+    return { graph: parsed, path };
+  } catch {
+    return null;
+  }
+}
+
+function scanGraphDir(dir: string): LoadedArtifactGraph[] {
+  if (!existsSync(dir)) return [];
+  const out: LoadedArtifactGraph[] = [];
+  for (const file of readdirSync(dir).sort()) {
+    if (!file.endsWith(GRAPH_FILE_SUFFIX)) continue;
+    const loaded = readArtifactGraph(join(dir, file));
+    if (loaded) out.push(loaded);
+  }
+  return out;
+}
+
+function loadGraphsForSkillIndex(options: {
+  evalGraphDirs: string[];
+  doctorGraphDirs: string[];
+  includeReportCards: boolean;
+  includeDoctorCards: boolean;
+}): LoadedArtifactGraph[] {
+  const byPath = new Map<string, LoadedArtifactGraph>();
+  const add = (loaded: LoadedArtifactGraph | null): void => {
+    if (loaded) byPath.set(loaded.path, loaded);
+  };
+  for (const dir of uniqueStrings(options.evalGraphDirs)) {
+    for (const graph of scanGraphDir(dir)) add(graph);
+  }
+  for (const dir of uniqueStrings(options.doctorGraphDirs)) {
+    for (const graph of scanGraphDir(dir)) add(graph);
+  }
+  if (options.includeReportCards) {
+    for (const card of listLiveReportCards()) {
+      add(readArtifactGraph(graphSidecarPathForReportPath(card.path, card.id)));
+    }
+  }
+  if (options.includeDoctorCards) {
+    for (const card of listLiveDoctorCards()) {
+      add(readArtifactGraph(graphSidecarPathForDoctorCard(card.path, card.id)));
+    }
+  }
+  return [...byPath.values()];
+}
+
+function graphSkillNodes(graph: ArtifactGraphDocument): ArtifactGraphNode[] {
+  return graph.nodes.filter((node) => node.nodeKind === 'skill');
+}
+
+function graphSkillNames(graph: ArtifactGraphDocument): string[] {
+  return uniqueStrings([
+    graph.scope.skillName ?? '',
+    ...graphSkillNodes(graph).map((node) => node.label),
+  ]);
+}
+
+function graphArtifactHashes(graph: ArtifactGraphDocument): string[] {
+  return uniqueStrings([
+    graph.scope.artifactHash ?? '',
+    ...graphSkillNodes(graph).map((node) => node.binding?.keys?.artifactHash ?? ''),
+  ]);
+}
+
+function graphSourceLocator(graph: ArtifactGraphDocument): string | undefined {
+  const skillDisplay = graphSkillNodes(graph)
+    .map((node) => node.attrs?.display)
+    .find((display) => display && typeof display.sourceLocator === 'string');
+  return graph.scope.sourceLocator
+    ?? (typeof skillDisplay?.sourceLocator === 'string' ? skillDisplay.sourceLocator : undefined);
+}
+
+function graphHasSkill(graph: ArtifactGraphDocument, entry: SkillIndexEntry): boolean {
+  const names = graphSkillNames(graph);
+  return names.includes(entry.skillName) || (entry.eval ? names.includes(entry.eval.variantName) : false);
+}
+
+function graphMatchesEntry(graph: ArtifactGraphDocument, entry: SkillIndexEntry): boolean {
+  const hashes = graphArtifactHashes(graph);
+  const entryHash = entry.graph?.artifactHash;
+  if (entryHash && hashes.includes(entryHash)) return true;
+  return graphHasSkill(graph, entry);
+}
+
+function pickLatestGraph(graphs: LoadedArtifactGraph[]): LoadedArtifactGraph | null {
+  if (graphs.length === 0) return null;
+  return [...graphs].sort((a, b) => {
+    const at = a.graph.generatedAt || '';
+    const bt = b.graph.generatedAt || '';
+    if (at !== bt) return at.localeCompare(bt);
+    return a.graph.graphId.localeCompare(b.graph.graphId);
+  })[graphs.length - 1];
+}
+
+function countGraphNodes(graph: ArtifactGraphDocument, nodeKind: ArtifactGraphNode['nodeKind']): number {
+  return graph.nodes.filter((node) => node.nodeKind === nodeKind).length;
+}
+
+function sourceStage(graph: ArtifactGraphDocument, path: string): SkillGraphSnapshot['doctor'] | SkillGraphSnapshot['eval'] | undefined {
+  const base = {
+    sourceKind: graph.source.sourceKind,
+    sourceId: graph.source.sourceId,
+    graphId: graph.graphId,
+    generatedAt: graph.generatedAt,
+    graphPath: path,
+    nodeCount: graph.nodes.length,
+    edgeCount: graph.edges.length,
+  };
+  if (graph.source.sourceKind === 'doctor') {
+    return {
+      ...base,
+      sourceKind: 'doctor',
+      references: countGraphNodes(graph, 'reference'),
+      scripts: countGraphNodes(graph, 'script'),
+      workflows: countGraphNodes(graph, 'workflow'),
+      workflowNodes: countGraphNodes(graph, 'workflow_node'),
+      hardRules: countGraphNodes(graph, 'hard_rule'),
+    };
+  }
+  if (graph.source.sourceKind === 'eval') {
+    const variantNode = graph.nodes.find((node) => node.nodeKind === 'variant' && node.binding?.keys?.artifactHash && node.binding.keys.artifactHash !== 'no-skill');
+    return {
+      ...base,
+      sourceKind: 'eval',
+      variantName: variantNode?.label,
+      samples: countGraphNodes(graph, 'sample'),
+      assertions: countGraphNodes(graph, 'assertion'),
+      failedAssertionEdges: graph.edges.filter((edge) => edge.edgeKind === 'fails').length,
+      diagnostics: countGraphNodes(graph, 'diagnostic'),
+    };
+  }
+  return undefined;
+}
+
+function graphSnapshotForEntry(entry: SkillIndexEntry, graphs: LoadedArtifactGraph[]): SkillGraphSnapshot | undefined {
+  const doctorCandidates = graphs.filter(({ graph }) =>
+    graph.source.sourceKind === 'doctor'
+      && (!entry.doctor || graph.source.sourceId === entry.doctor.reportId)
+      && graphMatchesEntry(graph, entry),
+  );
+  const evalCandidates = graphs.filter(({ graph }) =>
+    graph.source.sourceKind === 'eval'
+      && (!entry.eval || graph.source.sourceId === entry.eval.reportId)
+      && graphMatchesEntry(graph, entry),
+  );
+  const doctor = pickLatestGraph(doctorCandidates);
+  const evalGraph = pickLatestGraph(evalCandidates);
+  if (!doctor && !evalGraph) return undefined;
+
+  const hashes = uniqueStrings([
+    ...(doctor ? graphArtifactHashes(doctor.graph) : []),
+    ...(evalGraph ? graphArtifactHashes(evalGraph.graph) : []),
+  ]);
+  const sourceLocator = doctor ? graphSourceLocator(doctor.graph) : evalGraph ? graphSourceLocator(evalGraph.graph) : undefined;
+  const bindingStrength: SkillGraphSnapshot['bindingStrength'] = hashes.length > 0
+    ? 'content-hash'
+    : sourceLocator
+      ? 'source-locator'
+      : 'name-only';
+
+  return {
+    bindingStrength,
+    ...(hashes[0] ? { artifactHash: hashes[0] } : {}),
+    ...(sourceLocator ? { sourceLocator } : {}),
+    ...(doctor ? { doctor: sourceStage(doctor.graph, doctor.path) as SkillGraphSnapshot['doctor'] } : {}),
+    ...(evalGraph ? { eval: sourceStage(evalGraph.graph, evalGraph.path) as SkillGraphSnapshot['eval'] } : {}),
+  };
+}
+
 /** 扫 doctorsDir/*.report.json,按 skill 名分桶,**返回该 skill 的所有历史 snapshot**(asc 时序)。
  *  renderer 用最后一项做"当前",前面项画 sparkline。 */
 function scanDoctorReports(dir: string): Record<string, SkillDoctorSnapshot[]> {
@@ -334,6 +597,12 @@ export interface BuildSkillIndexOptions {
   includeObserveCards?: boolean;
   /** 合并别项目 doctor 卡片(机器级模式)。固定 --doctors-dir / --global 时为 false,只看该目录。 */
   includeDoctorCards?: boolean;
+  /** 合并别项目 eval report 卡片对应的 graph sidecar。 */
+  includeReportCards?: boolean;
+  /** 当前可见 eval graph sidecar 目录。 */
+  evalGraphDirs?: string[];
+  /** 当前可见 doctor graph sidecar 目录。默认跟随 doctorsDir 推导。 */
+  doctorGraphDirs?: string[];
 }
 
 export function buildSkillIndex(
@@ -345,8 +614,15 @@ export function buildSkillIndex(
 ): SkillIndex {
   const includeObserveCards = opts.includeObserveCards ?? false;
   const includeDoctorCards = opts.includeDoctorCards ?? false;
+  const includeReportCards = opts.includeReportCards ?? false;
+  const evalGraphDirs = uniqueStrings(opts.evalGraphDirs ?? []);
+  const doctorGraphDirs = uniqueStrings([
+    doctorGraphDirForDoctorOutput(doctorsDir),
+    ...(opts.doctorGraphDirs ?? []),
+  ]);
+  const graphFingerprint = buildGraphFingerprint(evalGraphDirs, doctorGraphDirs, includeReportCards, includeDoctorCards);
   // 命中缓存就直接返回(fingerprint 覆盖 reports + 两个 dir + 卡片 include 模式的变化信号)
-  const fp = buildIndexFingerprint(reports, analysesDir, doctorsDir, observationsDir, includeObserveCards, includeDoctorCards);
+  const fp = buildIndexFingerprint(reports, analysesDir, doctorsDir, observationsDir, includeObserveCards, includeDoctorCards, graphFingerprint);
   if (_indexCache && _indexCache.fingerprint === fp) {
     return _indexCache.result;
   }
@@ -482,6 +758,17 @@ export function buildSkillIndex(
     const hasMed = ins.some((i) => i.severity === 'medium');
     if (hasHigh) ent.band = 'red';
     else if (hasMed) ent.band = 'yellow';
+  }
+
+  const graphs = loadGraphsForSkillIndex({
+    evalGraphDirs,
+    doctorGraphDirs,
+    includeReportCards,
+    includeDoctorCards,
+  });
+  for (const ent of entries) {
+    const graph = graphSnapshotForEntry(ent, graphs);
+    if (graph) ent.graph = graph;
   }
   summary.red = entries.filter((e) => e.band === 'red').length;
   summary.yellow = entries.filter((e) => e.band === 'yellow').length;

--- a/src/types/skill-index.ts
+++ b/src/types/skill-index.ts
@@ -58,7 +58,7 @@ export interface SkillGraphStageSnapshot {
 
 export interface SkillGraphSnapshot {
   /** Studio 聚合 graph sidecar 时实际采用的绑定强度。 */
-  bindingStrength: 'content-hash' | 'source-locator' | 'name-only';
+  bindingStrength: 'content-hash' | 'source-locator' | 'name-only' | 'mixed';
   artifactHash?: string;
   sourceLocator?: string;
   doctor?: SkillGraphStageSnapshot & {

--- a/src/types/skill-index.ts
+++ b/src/types/skill-index.ts
@@ -46,6 +46,37 @@ export interface SkillObserveSnapshot {
   confidence: 'high' | 'low' | 'underpowered';
 }
 
+export interface SkillGraphStageSnapshot {
+  sourceKind: 'doctor' | 'eval' | 'observe';
+  sourceId: string;
+  graphId: string;
+  generatedAt: string;
+  graphPath?: string;
+  nodeCount: number;
+  edgeCount: number;
+}
+
+export interface SkillGraphSnapshot {
+  /** Studio 聚合 graph sidecar 时实际采用的绑定强度。 */
+  bindingStrength: 'content-hash' | 'source-locator' | 'name-only';
+  artifactHash?: string;
+  sourceLocator?: string;
+  doctor?: SkillGraphStageSnapshot & {
+    references: number;
+    scripts: number;
+    workflows: number;
+    workflowNodes: number;
+    hardRules: number;
+  };
+  eval?: SkillGraphStageSnapshot & {
+    variantName?: string;
+    samples: number;
+    assertions: number;
+    failedAssertionEdges: number;
+    diagnostics: number;
+  };
+}
+
 export interface SkillIndexEntry {
   skillName: string;
   /** 当前(最新)snapshot — 等价于对应 history 的最后一项,空时为 null。renderer
@@ -60,6 +91,8 @@ export interface SkillIndexEntry {
   /** 综合健康灯。doctor / eval / observe 任一红 → red;任一黄 → yellow;
    *  全绿 → green;皆未跑 → gray。 */
   band: 'green' | 'yellow' | 'red' | 'gray';
+  /** doctor/eval/observe graph sidecar 的轻量 Studio 投影。 */
+  graph?: SkillGraphSnapshot;
 }
 
 export interface SkillIndexSummary {

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -625,10 +625,9 @@ describe('report-server', () => {
     assert.equal(res.status, 200);
     assert.ok(res.headers['content-type']!.includes('text/html'));
     // 列表页按 skill 聚合,SAMPLE_REPORT 的 variants v1/v2 各成一个 skill 条目;
-    // 点行直接进该 skill 的报告(eval 优先,否则 doctor),不再走中间 hub(/skills 已下线)。
+    // 点行先进入 skill hub,由 hub 展示 Skill Map / 三阶段状态 / Evidence Card。
     // 行跳转走 data-href + 事件委托(非内联 onclick,见 skill-list-renderer)。
-    assert.ok(res.body.includes('data-href="/reports/') || res.body.includes('data-href="/doctors/'));
-    assert.ok(!res.body.includes('data-href="/skills/'));
+    assert.ok(res.body.includes('data-href="/skills/'));
   });
 
   it('GET /reports/:id returns HTML detail page', async () => {
@@ -642,8 +641,8 @@ describe('report-server', () => {
     const list = await fetch(`${baseUrl}/?lang=en`);
     assert.equal(list.status, 200);
     assert.ok(list.body.includes('data-lang="en"'));
-    // 列表行链接到报告(reports/doctors)并保留 ?lang=en
-    assert.ok(/data-href="\/(reports|doctors)\/[^"]*lang=en/.test(list.body));
+    // 列表行链接到 skill hub 并保留 ?lang=en
+    assert.ok(/data-href="\/skills\/[^"]*\?lang=en/.test(list.body));
 
     const detail = await fetch(`${baseUrl}/reports/test-run-001?lang=en`);
     assert.equal(detail.status, 200);
@@ -720,9 +719,12 @@ describe('report-server', () => {
     assert.ok(en.body.includes('doctor report not found'));
   });
 
-  it('GET /skills/:name 已下线(hub 不再存在,不做兼容重定向)→ 404', async () => {
+  it('GET /skills/:name returns the skill hub', async () => {
     const res = await fetch(`${baseUrl}/skills/v1`);
-    assert.equal(res.status, 404);
+    assert.equal(res.status, 200);
+    assert.ok(res.headers['content-type']!.includes('text/html'));
+    assert.ok(res.body.includes('v1'));
+    assert.ok(res.body.includes('Back to Skills') || res.body.includes('返回 Skill 列表'));
   });
 
   it('GET unknown path returns 404', async () => {

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -727,6 +727,12 @@ describe('report-server', () => {
     assert.ok(res.body.includes('Back to Skills') || res.body.includes('返回 Skill 列表'));
   });
 
+  it('GET /skills/:name with malformed encoding returns 404', async () => {
+    const res = await fetch(`${baseUrl}/skills/%`);
+    assert.equal(res.status, 404);
+    assert.ok(res.body.includes('未找到该 skill'));
+  });
+
   it('GET unknown path returns 404', async () => {
     const res = await fetch(`${baseUrl}/unknown`);
     assert.equal(res.status, 404);

--- a/test/server/skill-index-graph.test.ts
+++ b/test/server/skill-index-graph.test.ts
@@ -313,6 +313,7 @@ describe('SkillIndex graph projection', () => {
     assert.match(html, /复制 Markdown Evidence Card/);
     assert.ok(html.includes('references / 1'));
     assert.ok(html.includes('samples / 2'));
+    assert.match(html, /variant 子图/);
     assert.match(html, /doctorGraphId/);
     assert.match(html, /evalGraphId/);
   });

--- a/test/server/skill-index-graph.test.ts
+++ b/test/server/skill-index-graph.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildSkillIndex, _resetSkillIndexCache } from '../../src/server/skill-index.js';
+import { renderSkillDetail } from '../../src/renderer/skill-detail-renderer.js';
+import { renderSkillList } from '../../src/renderer/skill-list-renderer.js';
+import { graphFileName, reportFileName } from '../../src/eval-core/artifact-file-names.js';
+import type { ArtifactGraphDocument, DoctorReport, EvaluationReport, SkillIndex } from '../../src/types/index.js';
+
+function makeEvalReport(): EvaluationReport {
+  return {
+    kind: 'evaluation',
+    id: 'service-guide-20260621T120000-abcd',
+    meta: {
+      variants: ['baseline', 'service-guide'],
+      model: 'fixture',
+      executor: 'fixture',
+      sampleCount: 2,
+      taskCount: 4,
+      totalCostUSD: 0,
+      timestamp: '2026-06-21T12:00:00.000Z',
+      cliVersion: '0.0.0-test',
+      nodeVersion: process.version,
+      artifactHashes: { baseline: 'no-skill', 'service-guide': 'hash-service-guide' },
+      sampleHashes: { s001: 'sample-1', s002: 'sample-2' },
+      judgeModels: [],
+      variantConfigs: [{
+        variant: 'service-guide',
+        artifactKind: 'skill',
+        artifactSource: 'file-path',
+        artifactPath: '/repo/skills/service-guide/SKILL.md',
+        executionStrategy: 'system-prompt',
+        experimentType: 'artifact-injection',
+        experimentRole: 'treatment',
+        hasArtifactContent: true,
+        cwd: null,
+        locator: '/repo/skills/service-guide/SKILL.md',
+      }],
+    },
+    summary: {
+      'service-guide': {
+        totalSamples: 2,
+        successCount: 2,
+        errorCount: 0,
+        errorRate: 0,
+        avgCompositeScore: 3.2,
+      },
+    },
+    sampleSnapshots: {
+      s001: { sample_id: 's001', prompt: '检查发布风险', assertions: [{ type: 'contains_any', values: ['rollback'] }] },
+      s002: { sample_id: 's002', prompt: '处理回滚缺口', assertions: [{ type: 'contains_all', values: ['owner'] }] },
+    },
+    results: [
+      {
+        sample_id: 's001',
+        variants: {
+          'service-guide': {
+            ok: true,
+            durationMs: 10,
+            durationApiMs: 8,
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            execCostUSD: 0,
+            judgeCostUSD: 0,
+            costUSD: 0,
+            numTurns: 1,
+            compositeScore: 4,
+            assertions: { passed: 1, total: 1, score: 5, details: [{ type: 'contains_any', value: 'rollback', weight: 1, passed: true }] },
+          },
+        },
+      },
+      {
+        sample_id: 's002',
+        variants: {
+          'service-guide': {
+            ok: true,
+            durationMs: 10,
+            durationApiMs: 8,
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            execCostUSD: 0,
+            judgeCostUSD: 0,
+            costUSD: 0,
+            numTurns: 1,
+            compositeScore: 2.5,
+            assertions: { passed: 0, total: 1, score: 1, details: [{ type: 'contains_all', value: 'owner', weight: 1, passed: false }] },
+          },
+        },
+      },
+    ],
+  } as unknown as EvaluationReport;
+}
+
+function makeDoctorReport(): DoctorReport {
+  return {
+    kind: 'doctor',
+    schemaVersion: '3.0.0',
+    id: 'service-guide-doctor-20260621T115900-abcd',
+    timestamp: '2026-06-21T11:59:00.000Z',
+    cliVersion: '0.0.0-test',
+    cwd: '/repo',
+    executorName: 'fixture',
+    model: 'fixture',
+    outcome: 'pass',
+    totals: { pass: 1, warn: 0, fail: 0 },
+    ruleStats: { pass: 1, warn: 0, fail: 0, skipped: 0, total: 1 },
+    skills: [{
+      skillName: 'service-guide',
+      skillPath: '/repo/skills/service-guide/SKILL.md',
+      status: 'pass',
+      results: [{
+        ruleId: 'skill_readable',
+        severity: 'fatal',
+        labelKey: 'cli.doctor.rule.skill_readable',
+        status: 'pass',
+        message: 'readable',
+        durationMs: 1,
+      }],
+    }],
+  } as DoctorReport;
+}
+
+function doctorGraph(): ArtifactGraphDocument {
+  return {
+    documentKind: 'artifact-graph',
+    schemaVersion: 1,
+    graphId: 'doctor:service-guide-doctor-20260621T115900-abcd:service-guide',
+    generatedAt: '2026-06-21T11:59:00.000Z',
+    source: { sourceKind: 'doctor', sourceId: 'service-guide-doctor-20260621T115900-abcd', sourcePath: '/repo/.omk/doctors/service-guide.report.json' },
+    scope: { cwd: '/repo', artifactKind: 'skill', skillName: 'service-guide', artifactHash: 'hash-service-guide', sourceLocator: '/repo/skills/service-guide/SKILL.md' },
+    nodes: [
+      { id: 'skill', stableKey: 'v1:skill:hash-service-guide', nodeKind: 'skill', nodeRole: 'entity', layer: 'definition', label: 'service-guide', binding: { bindingStrength: 'content-hash', keys: { artifactHash: 'hash-service-guide' } } },
+      { id: 'ref', stableKey: 'v1:reference:hash-service-guide:references/a.md', nodeKind: 'reference', nodeRole: 'entity', layer: 'definition', label: 'references/a.md' },
+      { id: 'script', stableKey: 'v1:script:hash-service-guide:scripts/a.sh', nodeKind: 'script', nodeRole: 'entity', layer: 'definition', label: 'scripts/a.sh' },
+      { id: 'wf', stableKey: 'v1:workflow:hash-service-guide:release', nodeKind: 'workflow', nodeRole: 'entity', layer: 'definition', label: 'release' },
+      { id: 'wfn', stableKey: 'v1:workflow-node:hash-service-guide:release.check', nodeKind: 'workflow_node', nodeRole: 'entity', layer: 'definition', label: '检查发布' },
+      { id: 'rule', stableKey: 'v1:hard-rule:hash-service-guide:cite', nodeKind: 'hard_rule', nodeRole: 'entity', layer: 'definition', label: 'cite' },
+    ],
+    edges: [
+      { id: 'e1', fromNodeId: 'skill', toNodeId: 'ref', edgeKind: 'references', layer: 'definition' },
+      { id: 'e2', fromNodeId: 'skill', toNodeId: 'script', edgeKind: 'contains', layer: 'definition' },
+    ],
+  };
+}
+
+function evalGraph(): ArtifactGraphDocument {
+  return {
+    documentKind: 'artifact-graph',
+    schemaVersion: 1,
+    graphId: 'eval:service-guide-20260621T120000-abcd',
+    generatedAt: '2026-06-21T12:00:00.000Z',
+    source: { sourceKind: 'eval', sourceId: 'service-guide-20260621T120000-abcd', sourcePath: '/repo/.omk/reports/service-guide.report.json' },
+    scope: { cwd: '/repo', artifactKind: 'skill', sourceLocator: '/repo/.omk/samples.json', sampleSetHash: 'sample-set' },
+    nodes: [
+      { id: 'skill', stableKey: 'v1:skill:hash-service-guide', nodeKind: 'skill', nodeRole: 'entity', layer: 'measurement', label: 'service-guide', binding: { bindingStrength: 'content-hash', keys: { artifactHash: 'hash-service-guide' } } },
+      { id: 'variant', stableKey: 'v1:variant:service-guide-20260621T120000-abcd:service-guide', nodeKind: 'variant', nodeRole: 'entity', layer: 'measurement', label: 'service-guide', binding: { bindingStrength: 'content-hash', keys: { artifactHash: 'hash-service-guide' } } },
+      { id: 's001', stableKey: 'v1:sample:sample-1', nodeKind: 'sample', nodeRole: 'entity', layer: 'measurement', label: 's001' },
+      { id: 's002', stableKey: 'v1:sample:sample-2', nodeKind: 'sample', nodeRole: 'entity', layer: 'measurement', label: 's002' },
+      { id: 'a1', stableKey: 'v1:sample:sample-1:assertion:0', nodeKind: 'assertion', nodeRole: 'entity', layer: 'measurement', label: 'assertion: contains_any' },
+      { id: 'a2', stableKey: 'v1:sample:sample-2:assertion:0', nodeKind: 'assertion', nodeRole: 'entity', layer: 'measurement', label: 'assertion: contains_all' },
+      { id: 'diag', stableKey: 'v1:diagnostic:service-guide-20260621T120000-abcd:service-guide:s002', nodeKind: 'diagnostic', nodeRole: 'observation', layer: 'measurement', label: 'diagnostic: service-guide / s002' },
+    ],
+    edges: [
+      { id: 'e1', fromNodeId: 'variant', toNodeId: 's001', edgeKind: 'evaluates', layer: 'measurement', status: 'ok' },
+      { id: 'e2', fromNodeId: 'variant', toNodeId: 's002', edgeKind: 'evaluates', layer: 'measurement', status: 'failed' },
+      { id: 'e3', fromNodeId: 's002', toNodeId: 'a2', edgeKind: 'fails', layer: 'measurement', status: 'failed' },
+    ],
+  };
+}
+
+describe('SkillIndex graph projection', () => {
+  const cleanup: string[] = [];
+  let oldIndexDir: string | undefined;
+
+  beforeEach(() => {
+    _resetSkillIndexCache();
+    oldIndexDir = process.env.OMK_ARTIFACT_INDEX_DIR;
+    const indexDir = mkdtempSync(join(tmpdir(), 'omk-graph-index-cards-'));
+    process.env.OMK_ARTIFACT_INDEX_DIR = indexDir;
+    cleanup.push(indexDir);
+  });
+
+  afterEach(() => {
+    if (oldIndexDir === undefined) delete process.env.OMK_ARTIFACT_INDEX_DIR;
+    else process.env.OMK_ARTIFACT_INDEX_DIR = oldIndexDir;
+    for (const dir of cleanup.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('merges doctor and eval sidecar graphs into a skill-centric projection', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'omk-skill-map-index-'));
+    cleanup.push(tmp);
+    const doctorsDir = join(tmp, '.omk', 'doctors');
+    const analysesDir = join(tmp, '.omk', 'observe-health');
+    const observationsDir = join(tmp, '.omk', 'observe-inbox');
+    const doctorGraphDir = join(tmp, '.omk', 'graphs', 'doctor');
+    const evalGraphDir = join(tmp, '.omk', 'graphs', 'eval');
+    mkdirSync(doctorsDir, { recursive: true });
+    mkdirSync(doctorGraphDir, { recursive: true });
+    mkdirSync(evalGraphDir, { recursive: true });
+
+    const report = makeEvalReport();
+    const doctor = makeDoctorReport();
+    writeFileSync(join(doctorsDir, reportFileName('service-guide-doctor-20260621T115900-abcd')), JSON.stringify(doctor, null, 2));
+    writeFileSync(join(doctorGraphDir, graphFileName('service-guide-doctor-20260621T115900-abcd')), JSON.stringify(doctorGraph(), null, 2));
+    writeFileSync(join(evalGraphDir, graphFileName(report.id)), JSON.stringify(evalGraph(), null, 2));
+
+    const idx = buildSkillIndex([report], analysesDir, doctorsDir, observationsDir, {
+      evalGraphDirs: [evalGraphDir],
+      doctorGraphDirs: [doctorGraphDir],
+    });
+
+    const entry = idx.entries.find((item) => item.skillName === 'service-guide');
+    assert.ok(entry);
+    assert.equal(entry.graph?.bindingStrength, 'content-hash');
+    assert.equal(entry.graph?.artifactHash, 'hash-service-guide');
+    assert.equal(entry.graph?.doctor?.references, 1);
+    assert.equal(entry.graph?.doctor?.scripts, 1);
+    assert.equal(entry.graph?.doctor?.workflows, 1);
+    assert.equal(entry.graph?.doctor?.workflowNodes, 1);
+    assert.equal(entry.graph?.eval?.samples, 2);
+    assert.equal(entry.graph?.eval?.assertions, 2);
+    assert.equal(entry.graph?.eval?.failedAssertionEdges, 1);
+    assert.equal(entry.graph?.eval?.diagnostics, 1);
+
+    const html = renderSkillDetail(entry, report, 'zh');
+    assert.match(html, /Skill Map/);
+    assert.match(html, /复制 Markdown Evidence Card/);
+    assert.ok(html.includes('references / 1'));
+    assert.ok(html.includes('samples / 2'));
+    assert.match(html, /doctorGraphId/);
+    assert.match(html, /evalGraphId/);
+  });
+
+  it('links the skill list to the skill hub instead of a stage-specific report', () => {
+    const idx: SkillIndex = {
+      entries: [{
+        skillName: 'service-guide',
+        doctor: null,
+        eval: null,
+        observe: null,
+        doctorHistory: [],
+        evalHistory: [],
+        observeHistory: [],
+        band: 'gray',
+      }],
+      summary: { totalSkills: 1, withEval: 0, withObserve: 0, withDoctor: 0, red: 0, yellow: 0, green: 0, gray: 1 },
+      insightsBySkill: new Map(),
+      diagnosticsBySkill: new Map(),
+      diagnosisSummary: {},
+    } as unknown as SkillIndex;
+    const html = renderSkillList(idx, 'zh');
+    assert.ok(html.includes('data-href="/skills/service-guide"'));
+  });
+});

--- a/test/server/skill-index-graph.test.ts
+++ b/test/server/skill-index-graph.test.ts
@@ -14,7 +14,7 @@ function makeEvalReport(): EvaluationReport {
     kind: 'evaluation',
     id: 'service-guide-20260621T120000-abcd',
     meta: {
-      variants: ['baseline', 'service-guide'],
+      variants: ['baseline', 'service-guide', 'release-helper'],
       model: 'fixture',
       executor: 'fixture',
       sampleCount: 2,
@@ -23,21 +23,35 @@ function makeEvalReport(): EvaluationReport {
       timestamp: '2026-06-21T12:00:00.000Z',
       cliVersion: '0.0.0-test',
       nodeVersion: process.version,
-      artifactHashes: { baseline: 'no-skill', 'service-guide': 'hash-service-guide' },
+      artifactHashes: { baseline: 'no-skill', 'service-guide': 'hash-service-guide', 'release-helper': 'hash-release-helper' },
       sampleHashes: { s001: 'sample-1', s002: 'sample-2' },
       judgeModels: [],
-      variantConfigs: [{
-        variant: 'service-guide',
-        artifactKind: 'skill',
-        artifactSource: 'file-path',
-        artifactPath: '/repo/skills/service-guide/SKILL.md',
-        executionStrategy: 'system-prompt',
-        experimentType: 'artifact-injection',
-        experimentRole: 'treatment',
-        hasArtifactContent: true,
-        cwd: null,
-        locator: '/repo/skills/service-guide/SKILL.md',
-      }],
+      variantConfigs: [
+        {
+          variant: 'service-guide',
+          artifactKind: 'skill',
+          artifactSource: 'file-path',
+          artifactPath: '/repo/skills/service-guide/SKILL.md',
+          executionStrategy: 'system-prompt',
+          experimentType: 'artifact-injection',
+          experimentRole: 'treatment',
+          hasArtifactContent: true,
+          cwd: null,
+          locator: '/repo/skills/service-guide/SKILL.md',
+        },
+        {
+          variant: 'release-helper',
+          artifactKind: 'skill',
+          artifactSource: 'file-path',
+          artifactPath: '/repo/skills/release-helper/SKILL.md',
+          executionStrategy: 'system-prompt',
+          experimentType: 'artifact-injection',
+          experimentRole: 'treatment',
+          hasArtifactContent: true,
+          cwd: null,
+          locator: '/repo/skills/release-helper/SKILL.md',
+        },
+      ],
     },
     summary: {
       'service-guide': {
@@ -46,6 +60,13 @@ function makeEvalReport(): EvaluationReport {
         errorCount: 0,
         errorRate: 0,
         avgCompositeScore: 3.2,
+      },
+      'release-helper': {
+        totalSamples: 2,
+        successCount: 2,
+        errorCount: 0,
+        errorRate: 0,
+        avgCompositeScore: 2.1,
       },
     },
     sampleSnapshots: {
@@ -72,6 +93,23 @@ function makeEvalReport(): EvaluationReport {
             compositeScore: 4,
             assertions: { passed: 1, total: 1, score: 5, details: [{ type: 'contains_any', value: 'rollback', weight: 1, passed: true }] },
           },
+          'release-helper': {
+            ok: true,
+            durationMs: 10,
+            durationApiMs: 8,
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            execCostUSD: 0,
+            judgeCostUSD: 0,
+            costUSD: 0,
+            numTurns: 1,
+            compositeScore: 1.5,
+            assertions: { passed: 0, total: 1, score: 1, details: [{ type: 'contains_any', value: 'handoff', weight: 1, passed: false }] },
+            diagnostic: { ok: false, rootCause: ['missing_handoff'], failureModes: ['other'] },
+          },
         },
       },
       {
@@ -92,6 +130,23 @@ function makeEvalReport(): EvaluationReport {
             numTurns: 1,
             compositeScore: 2.5,
             assertions: { passed: 0, total: 1, score: 1, details: [{ type: 'contains_all', value: 'owner', weight: 1, passed: false }] },
+            diagnostic: { ok: true, rootCause: ['missing_owner'], failureModes: ['skill-doc-gap'] },
+          },
+          'release-helper': {
+            ok: true,
+            durationMs: 10,
+            durationApiMs: 8,
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+            execCostUSD: 0,
+            judgeCostUSD: 0,
+            costUSD: 0,
+            numTurns: 1,
+            compositeScore: 2.7,
+            assertions: { passed: 1, total: 1, score: 5, details: [{ type: 'contains_all', value: 'owner', weight: 1, passed: true }] },
           },
         },
       },
@@ -160,18 +215,38 @@ function evalGraph(): ArtifactGraphDocument {
     source: { sourceKind: 'eval', sourceId: 'service-guide-20260621T120000-abcd', sourcePath: '/repo/.omk/reports/service-guide.report.json' },
     scope: { cwd: '/repo', artifactKind: 'skill', sourceLocator: '/repo/.omk/samples.json', sampleSetHash: 'sample-set' },
     nodes: [
-      { id: 'skill', stableKey: 'v1:skill:hash-service-guide', nodeKind: 'skill', nodeRole: 'entity', layer: 'measurement', label: 'service-guide', binding: { bindingStrength: 'content-hash', keys: { artifactHash: 'hash-service-guide' } } },
+      { id: 'skill', stableKey: 'v1:skill:hash-service-guide', nodeKind: 'skill', nodeRole: 'entity', layer: 'measurement', label: 'service-guide', binding: { bindingStrength: 'content-hash', keys: { artifactHash: 'hash-service-guide' } }, attrs: { display: { sourceLocator: '/repo/skills/service-guide/SKILL.md' } } },
       { id: 'variant', stableKey: 'v1:variant:service-guide-20260621T120000-abcd:service-guide', nodeKind: 'variant', nodeRole: 'entity', layer: 'measurement', label: 'service-guide', binding: { bindingStrength: 'content-hash', keys: { artifactHash: 'hash-service-guide' } } },
+      { id: 'skill-other', stableKey: 'v1:skill:hash-release-helper', nodeKind: 'skill', nodeRole: 'entity', layer: 'measurement', label: 'release-helper', binding: { bindingStrength: 'content-hash', keys: { artifactHash: 'hash-release-helper' } }, attrs: { display: { sourceLocator: '/repo/skills/release-helper/SKILL.md' } } },
+      { id: 'variant-other', stableKey: 'v1:variant:service-guide-20260621T120000-abcd:release-helper', nodeKind: 'variant', nodeRole: 'entity', layer: 'measurement', label: 'release-helper', binding: { bindingStrength: 'content-hash', keys: { artifactHash: 'hash-release-helper' } } },
       { id: 's001', stableKey: 'v1:sample:sample-1', nodeKind: 'sample', nodeRole: 'entity', layer: 'measurement', label: 's001' },
       { id: 's002', stableKey: 'v1:sample:sample-2', nodeKind: 'sample', nodeRole: 'entity', layer: 'measurement', label: 's002' },
       { id: 'a1', stableKey: 'v1:sample:sample-1:assertion:0', nodeKind: 'assertion', nodeRole: 'entity', layer: 'measurement', label: 'assertion: contains_any' },
       { id: 'a2', stableKey: 'v1:sample:sample-2:assertion:0', nodeKind: 'assertion', nodeRole: 'entity', layer: 'measurement', label: 'assertion: contains_all' },
+      { id: 'a3', stableKey: 'v1:sample:sample-1:assertion:extra', nodeKind: 'assertion', nodeRole: 'entity', layer: 'measurement', label: 'assertion: contains_any' },
+      { id: 'er1', stableKey: 'v1:eval-result:service-guide-20260621T120000-abcd:service-guide:s001', nodeKind: 'eval_result', nodeRole: 'observation', layer: 'measurement', label: 'service-guide / s001' },
+      { id: 'er2', stableKey: 'v1:eval-result:service-guide-20260621T120000-abcd:service-guide:s002', nodeKind: 'eval_result', nodeRole: 'observation', layer: 'measurement', label: 'service-guide / s002' },
+      { id: 'er-other', stableKey: 'v1:eval-result:service-guide-20260621T120000-abcd:release-helper:s001', nodeKind: 'eval_result', nodeRole: 'observation', layer: 'measurement', label: 'release-helper / s001' },
       { id: 'diag', stableKey: 'v1:diagnostic:service-guide-20260621T120000-abcd:service-guide:s002', nodeKind: 'diagnostic', nodeRole: 'observation', layer: 'measurement', label: 'diagnostic: service-guide / s002' },
+      { id: 'diag-other', stableKey: 'v1:diagnostic:service-guide-20260621T120000-abcd:release-helper:s001', nodeKind: 'diagnostic', nodeRole: 'observation', layer: 'measurement', label: 'diagnostic: release-helper / s001' },
     ],
     edges: [
-      { id: 'e1', fromNodeId: 'variant', toNodeId: 's001', edgeKind: 'evaluates', layer: 'measurement', status: 'ok' },
-      { id: 'e2', fromNodeId: 'variant', toNodeId: 's002', edgeKind: 'evaluates', layer: 'measurement', status: 'failed' },
-      { id: 'e3', fromNodeId: 's002', toNodeId: 'a2', edgeKind: 'fails', layer: 'measurement', status: 'failed' },
+      { id: 'e1', fromNodeId: 'variant', toNodeId: 'skill', edgeKind: 'derived_from', layer: 'measurement' },
+      { id: 'e2', fromNodeId: 'variant-other', toNodeId: 'skill-other', edgeKind: 'derived_from', layer: 'measurement' },
+      { id: 'e3', fromNodeId: 'variant', toNodeId: 's001', edgeKind: 'evaluates', layer: 'measurement', status: 'ok' },
+      { id: 'e4', fromNodeId: 'variant', toNodeId: 's002', edgeKind: 'evaluates', layer: 'measurement', status: 'failed' },
+      { id: 'e5', fromNodeId: 'er1', toNodeId: 'variant', edgeKind: 'derived_from', layer: 'measurement' },
+      { id: 'e6', fromNodeId: 'er1', toNodeId: 's001', edgeKind: 'evaluates', layer: 'measurement' },
+      { id: 'e7', fromNodeId: 'er1', toNodeId: 'a1', edgeKind: 'passes', layer: 'measurement', status: 'ok' },
+      { id: 'e8', fromNodeId: 'er2', toNodeId: 'variant', edgeKind: 'derived_from', layer: 'measurement' },
+      { id: 'e9', fromNodeId: 'er2', toNodeId: 's002', edgeKind: 'evaluates', layer: 'measurement' },
+      { id: 'e10', fromNodeId: 'er2', toNodeId: 'a2', edgeKind: 'fails', layer: 'measurement', status: 'failed' },
+      { id: 'e11', fromNodeId: 'diag', toNodeId: 'er2', edgeKind: 'diagnoses', layer: 'measurement', status: 'warning' },
+      { id: 'e12', fromNodeId: 'variant-other', toNodeId: 's001', edgeKind: 'evaluates', layer: 'measurement', status: 'failed' },
+      { id: 'e13', fromNodeId: 'er-other', toNodeId: 'variant-other', edgeKind: 'derived_from', layer: 'measurement' },
+      { id: 'e14', fromNodeId: 'er-other', toNodeId: 's001', edgeKind: 'evaluates', layer: 'measurement' },
+      { id: 'e15', fromNodeId: 'er-other', toNodeId: 'a3', edgeKind: 'fails', layer: 'measurement', status: 'failed' },
+      { id: 'e16', fromNodeId: 'diag-other', toNodeId: 'er-other', edgeKind: 'diagnoses', layer: 'measurement', status: 'failed' },
     ],
   };
 }
@@ -229,6 +304,9 @@ describe('SkillIndex graph projection', () => {
     assert.equal(entry.graph?.eval?.assertions, 2);
     assert.equal(entry.graph?.eval?.failedAssertionEdges, 1);
     assert.equal(entry.graph?.eval?.diagnostics, 1);
+    assert.equal(entry.graph?.eval?.variantName, 'service-guide');
+    assert.equal(entry.graph?.eval?.nodeCount, 9);
+    assert.equal(entry.graph?.eval?.edgeCount, 10);
 
     const html = renderSkillDetail(entry, report, 'zh');
     assert.match(html, /Skill Map/);
@@ -237,6 +315,64 @@ describe('SkillIndex graph projection', () => {
     assert.ok(html.includes('samples / 2'));
     assert.match(html, /doctorGraphId/);
     assert.match(html, /evalGraphId/);
+  });
+
+  it('does not claim content-hash binding when doctor and eval graphs point to different artifact hashes', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'omk-skill-map-mixed-'));
+    cleanup.push(tmp);
+    const doctorsDir = join(tmp, '.omk', 'doctors');
+    const analysesDir = join(tmp, '.omk', 'observe-health');
+    const observationsDir = join(tmp, '.omk', 'observe-inbox');
+    const doctorGraphDir = join(tmp, '.omk', 'graphs', 'doctor');
+    const evalGraphDir = join(tmp, '.omk', 'graphs', 'eval');
+    mkdirSync(doctorsDir, { recursive: true });
+    mkdirSync(doctorGraphDir, { recursive: true });
+    mkdirSync(evalGraphDir, { recursive: true });
+
+    const report = makeEvalReport();
+    const doctor = makeDoctorReport();
+    const staleDoctorGraph = doctorGraph();
+    staleDoctorGraph.scope.artifactHash = 'hash-stale-service-guide';
+    writeFileSync(join(doctorsDir, reportFileName('service-guide-doctor-20260621T115900-abcd')), JSON.stringify(doctor, null, 2));
+    writeFileSync(join(doctorGraphDir, graphFileName('service-guide-doctor-20260621T115900-abcd')), JSON.stringify(staleDoctorGraph, null, 2));
+    writeFileSync(join(evalGraphDir, graphFileName(report.id)), JSON.stringify(evalGraph(), null, 2));
+
+    const idx = buildSkillIndex([report], analysesDir, doctorsDir, observationsDir, {
+      evalGraphDirs: [evalGraphDir],
+      doctorGraphDirs: [doctorGraphDir],
+    });
+
+    const entry = idx.entries.find((item) => item.skillName === 'service-guide');
+    assert.ok(entry);
+    assert.equal(entry.graph?.bindingStrength, 'mixed');
+    assert.equal(entry.graph?.artifactHash, undefined);
+    const html = renderSkillDetail(entry, report, 'zh');
+    assert.match(html, /混合证据/);
+  });
+
+  it('uses the matched skill node locator for eval-only evidence cards instead of samplesPath', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'omk-skill-map-eval-only-'));
+    cleanup.push(tmp);
+    const doctorsDir = join(tmp, '.omk', 'doctors');
+    const analysesDir = join(tmp, '.omk', 'observe-health');
+    const observationsDir = join(tmp, '.omk', 'observe-inbox');
+    const evalGraphDir = join(tmp, '.omk', 'graphs', 'eval');
+    mkdirSync(evalGraphDir, { recursive: true });
+
+    const report = makeEvalReport();
+    writeFileSync(join(evalGraphDir, graphFileName(report.id)), JSON.stringify(evalGraph(), null, 2));
+
+    const idx = buildSkillIndex([report], analysesDir, doctorsDir, observationsDir, {
+      evalGraphDirs: [evalGraphDir],
+    });
+
+    const entry = idx.entries.find((item) => item.skillName === 'service-guide');
+    assert.ok(entry);
+    assert.equal(entry.graph?.sourceLocator, '/repo/skills/service-guide/SKILL.md');
+    assert.equal(entry.graph?.bindingStrength, 'content-hash');
+    const html = renderSkillDetail(entry, report, 'zh');
+    assert.ok(html.includes('omk doctor /repo/skills/service-guide/SKILL.md'));
+    assert.ok(!html.includes('omk doctor /repo/.omk/samples.json'));
   });
 
   it('links the skill list to the skill hub instead of a stage-specific report', () => {

--- a/test/server/skill-index-graph.test.ts
+++ b/test/server/skill-index-graph.test.ts
@@ -164,7 +164,7 @@ function makeDoctorReport(): DoctorReport {
     cwd: '/repo',
     executorName: 'fixture',
     model: 'fixture',
-    outcome: 'pass',
+    outcome: 'passed',
     totals: { pass: 1, warn: 0, fail: 0 },
     ruleStats: { pass: 1, warn: 0, fail: 0, skipped: 0, total: 1 },
     skills: [{


### PR DESCRIPTION
## 用户影响

- Studio 列表页现在进入 skill hub，而不是直接跳到某个阶段报告，让用户围绕同一个 skill 观察 doctor、eval、observe 的整体状态。
- skill 详情页会读取 doctor / eval 生成的 graph sidecar，展示一张以 `SKILL.md` 为根的轻量 Skill Map，并给出可复制的 Markdown Evidence Card。
- 这版先把结构证据与测量证据合在同一个用户视角里，帮助用户第一时间建立「这个 skill 正在被图谱化理解」的心智。

## 迁移说明

- 不改变既有 report / doctor / observe 落盘 schema，也不要求用户迁移历史报告。
- 没有 graph sidecar 的旧报告仍按原逻辑展示；有 sidecar 时 Studio 追加图谱投影。
- `/skills/<name>` 路径恢复为 skill hub，阶段报告仍可从详情页继续进入。

## 测量学说明

- 本 PR 只在 Studio 聚合层投影 graph sidecar，不改评分管道、评分类 prompt、bootstrap CI、Krippendorff alpha 或 length-debias 语义。
- Skill Map 的绑定强度会显示为 content-hash / source-locator / name-only，避免把弱绑定误读成强证据。
- observe 的 production graph 尚未接入，本版在图里保留 observe 阶段占位，不把缺失观察数据解释为质量结论。

Closes #280
