### PR TITLE
chore(release): 发布 0.44.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 本次发版内容

0.43.0 → 0.44.0（minor）。自上版以来合入三个 `feat`，把 Skill Information Graph（#280）的 phase-1 补齐：

- #296 feat(eval-core): 生成 eval 信息图谱伴生产物 —— eval 在写主报告时 best-effort 落 measurement-layer graph sidecar（`.omk/graphs/eval/<id>.graph.json`）。
- #297 feat(studio): 展示 skill map 与证据卡 —— Studio 读取 doctor/eval graph sidecar，`/skills/<name>` 作为 skill hub 展示 Skill Map + 可复制 Markdown Evidence Card。
- #298 feat(studio): 以 SKILL.md 根节点展示图谱 —— Skill Map v1 改为以 `SKILL.md` 为根的可交互 SVG 知识图（缩放/拖拽/图层开关）。

## 测量学说明

- 无 BREAKING-COMPARABILITY。三个 PR 都只新增 graph sidecar 与 Studio 展示/投影，不改评分类 prompt、评分管道、verdict、bootstrap CI、Krippendorff α、length-debias 或报告 schema 语义。
- 既有报告可比性不受影响；graph 写入失败只 warning，不改 doctor/eval outcome 或 exit code。

## 验证

`yarn lint && yarn build && yarn test` 本地全绿。

合并后在 main 上打 `v0.44.0` tag 单独 push 触发 publish。