### PR TITLE
feat(studio): 支持用例覆盖结构锚点

### DIFF
--- a/docs/reference/comparison.md
+++ b/docs/reference/comparison.md
@@ -46,7 +46,7 @@ omk is the only tool surveyed that ships all five rigour pieces. The closest com
 | Three-layer scoring (Fact / Behavior / Judge) isolation | ✓ | ✗ | partial | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Three-layer all-pass CI gate | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Per-variant skill-discovery isolation (construct validity) | ✓ default | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | partial |
-| Sample design metadata (capability / difficulty / construct / provenance) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Sample design metadata + structure anchors (`covers`) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | One-line verdict (PROGRESS / REGRESS / NOISE / ...) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Knowledge gap signals (severity-weighted) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | Sample quality diagnostics (7 issue kinds) | ✓ | low-discrim only | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |

--- a/docs/reference/eval-sample-format.md
+++ b/docs/reference/eval-sample-format.md
@@ -69,13 +69,13 @@ A sample can also carry **metadata** (documentation / diagnostics only — these
 | `difficulty` | `'easy' \| 'medium' \| 'hard'` | difficulty bucket (strict enum) |
 | `construct` | `string` | what it measures: `necessity` / `quality` / `capability` (custom allowed) |
 | `provenance` | `'human' \| 'llm-generated' \| 'production-trace'` | data source |
-| `covers` | `{ targetKind, ref }[]` | explicit skill-structure anchors this sample covers; used by Skill Map only |
+| `covers` | `{ targetKind, ref }[]` | optional declared skill-structure anchors for high-value samples; used by Skill Map only |
 | `mocks` | `object[]` | tool-call interception list — return fake data instead of really calling the tool |
 | `mocksStrict` | `boolean` | deny any tool call that matches no mock (default `false`) |
 | `tripwire` | `boolean` | trap sample: the LLM is **expected** to fail (default `false`) |
 | `environment` | `object` | declared "already provisioned" preconditions: `cli_available` / `files_available` / `notes` |
 
-`covers` is intentionally explicit, not inferred from prompt text. It lets Studio draw which parts of a skill are actually exercised:
+`covers` is optional and intentionally explicit, not inferred from prompt text. Use it first on critical or high-signal samples, so Studio can draw declared structure edges without forcing every sample to become a maintenance task. Omitting `covers` means the structure edge is undeclared in Skill Map, not proven untested:
 
 ```yaml
 - sample_id: release-risk-summary

--- a/docs/reference/eval-sample-format.md
+++ b/docs/reference/eval-sample-format.md
@@ -69,10 +69,27 @@ A sample can also carry **metadata** (documentation / diagnostics only — these
 | `difficulty` | `'easy' \| 'medium' \| 'hard'` | difficulty bucket (strict enum) |
 | `construct` | `string` | what it measures: `necessity` / `quality` / `capability` (custom allowed) |
 | `provenance` | `'human' \| 'llm-generated' \| 'production-trace'` | data source |
+| `covers` | `{ targetKind, ref }[]` | explicit skill-structure anchors this sample covers; used by Skill Map only |
 | `mocks` | `object[]` | tool-call interception list — return fake data instead of really calling the tool |
 | `mocksStrict` | `boolean` | deny any tool call that matches no mock (default `false`) |
 | `tripwire` | `boolean` | trap sample: the LLM is **expected** to fail (default `false`) |
 | `environment` | `object` | declared "already provisioned" preconditions: `cli_available` / `files_available` / `notes` |
+
+`covers` is intentionally explicit, not inferred from prompt text. It lets Studio draw which parts of a skill are actually exercised:
+
+```yaml
+- sample_id: release-risk-summary
+  prompt: "Summarize release risk and rollback plan."
+  covers:
+    - targetKind: reference
+      ref: references/release-policy.md
+    - targetKind: workflow
+      ref: release
+    - targetKind: workflow_node
+      ref: release.check
+```
+
+Allowed `targetKind` values are `skill`, `skill_file`, `frontmatter`, `reference`, `script`, `hard_rule`, `workflow`, and `workflow_node`. For `reference` / `script`, `ref` is the path relative to the skill root. For `hard_rule` / `workflow`, use the rule or workflow id. For `workflow_node`, use `workflowId.nodeId`. This field never enters grading, the judge prompt, the verdict, or the sample fingerprint.
 
 ## URL auto-fetching
 

--- a/docs/specs/sample-design-spec.md
+++ b/docs/specs/sample-design-spec.md
@@ -20,13 +20,18 @@ samples:
       - { type: contains, value: "Line", weight: 1 }
       - { type: regex, pattern: "data", weight: 1 }
 
-    # 4 optional metadata fields (docs/diagnostics only, never enter grading)
+    # Measurement metadata (docs/diagnostics only, never enter grading)
     capability:
       - component-recognition          # string[], capability dimensions, multiple allowed; normalized case/dash/camelCase-insensitive
       - api-selection
     difficulty: easy                    # 'easy' | 'medium' | 'hard' (strict enum, typo-proof)
     construct: necessity                # 'necessity' | 'quality' | 'capability' suggested, custom string allowed
     provenance: human                   # 'human' | 'llm-generated' | 'production-trace'
+    covers:                             # explicit skill-structure anchors for Skill Map
+      - targetKind: reference
+        ref: references/chart-api.md
+      - targetKind: workflow_node
+        ref: chart.render
 ```
 
 ### Field semantics
@@ -39,12 +44,14 @@ samples:
   - `capability`: measures the difference along one concrete capability dimension.
   Custom strings are allowed (e.g. `regression-test` / `cost-efficiency`); the studio won't error on a custom value.
 - **provenance** (enum): data source. `human` (hand-curated) / `llm-generated` (auto-injected by `omk sample`) / `production-trace` (sampled from production traces, which you import yourself).
+- **covers** (`{ targetKind, ref }[]`): explicit skill-structure anchors this sample exercises. This is the structural sibling of `capability`: capability says which ability dimension is tested; covers says which concrete SKILL.md node, reference, script, hard rule, workflow, or workflow node the sample is meant to exercise. Studio uses it to show covered vs uncovered nodes in Skill Map. It is not inferred from prompt text.
 
 ### Never enters grading / judge / verdict
 
-These 4 fields are used only for:
+These metadata fields are used only for:
 
 - the studio coverage block, plus the `rubric_clarity_low` / `capability_thin` issue detectors
+- Skill Map coverage anchors (`covers`)
 - the `report.analysis.sampleQuality` aggregate (for tools to read)
 
 **They never enter the judge prompt** (`buildJudgePrompt(prompt, rubric, output, traceSummary)` has no sample object in its signature, and `test/grading/judge-prompt-isolation.test.ts` guards against regressions). **They never affect the verdict algorithm.** This is a hard requirement for construct-validity protection — a judge seeing "construct: necessity" is a judge that knows the answer key.
@@ -142,6 +149,7 @@ Run through this before an eval; any "no" is a reason to stop and think:
 
 - [ ] **Construct declared**: does each sample know whether it measures necessity / quality / capability?
 - [ ] **Capability coverage**: you claim to test N capability dimensions — does the sample set actually cover N? (the studio coverage block shows the real distribution)
+- [ ] **Structure coverage**: do key references / workflows / hard rules have at least one sample declaring `covers`, so Skill Map can show real test-design blind spots?
 - [ ] **Difficulty stratified**: do you have easy / medium / hard, or is everything hard so noise dominates?
 - [ ] **Provenance transparent**: is the human-curated / LLM-generated / production-trace ratio reasonable? When LLM-generated is > 50%, watch for self-instruct risk (a self-reinforcing judge-bias loop).
 - [ ] **Sample count**: `N < 5` (exploratory) / `N < 20` (only large effects detectable) / `N ≥ 20` (medium effects detectable) — omk pre-flight already warns.
@@ -173,7 +181,7 @@ omk's statistical-rigor stack (Bootstrap CI / Krippendorff α / length-debias / 
 | 1 | **IRT item discrimination**: each item gets a (discrimination) / b (difficulty) / c (guessing) parameters; a < 0.3 is a junk item | [IrtNet (2510.00844)](https://arxiv.org/pdf/2510.00844), [Columbia IRT primer](https://www.publichealth.columbia.edu/research/population-health-methods/item-response-theory) | **out-of-scope** (IRT is unreliable at N<30; left as follow-up — the v1 `flat_scores` heuristic already covers part of it) |
 | 2 | **Difficulty stratification**: stratify samples by difficulty (MMLU-Pro filters difficulty via multi-model majority-correct) | [MMLU-Pro](https://intuitionlabs.ai/articles/mmlu-pro-ai-benchmark-explained) | **in-scope**: `Sample.difficulty` enum + studio bucketing |
 | 3 | **Construct-validity trio** (structural / convergent / discriminant) | [Measuring what Matters (2511.04703)](https://arxiv.org/abs/2511.04703), [Measurement to Meaning (2505.10573)](https://arxiv.org/html/2505.10573v3) | **in-scope**: `Sample.construct` field (suggested: necessity / quality / capability) + verdict-interpretation callout; convergent / discriminant auto-detection is follow-up |
-| 4 | **Capability-matrix coverage** (HELM's 16×7 matrix) | [HELM (2211.09110)](https://arxiv.org/abs/2211.09110) | **partial**: `Sample.capability` string[] field + studio coverage bucketing + `capability_thin` issue; detailed matrix visualization is follow-up |
+| 4 | **Capability-matrix coverage** (HELM's 16×7 matrix) | [HELM (2211.09110)](https://arxiv.org/abs/2211.09110) | **partial**: `Sample.capability` string[] field + studio coverage bucketing + `capability_thin` issue; `Sample.covers` adds explicit structure anchors for Skill Map; detailed matrix visualization is follow-up |
 | 5 | **Contamination detection** (canary / paraphrase / timestamp-locked) | [BIG-Bench canary](https://www.lesswrong.com/posts/kSmHMoaLKGcGgyWzs/big-bench-canary-contamination-in-gpt-4), [LiveBench](https://livebench.ai/livebench.pdf), [contamination survey (2404.00699)](https://arxiv.org/html/2404.00699v4) | **partial**: `Sample.provenance` does "declarative" contamination tracking; real auto-detection is follow-up (needs an embedding model or training-data access) |
 | 6 | **Sample provenance / dataset card** (the annotations_creators standard) | [HF Dataset Cards](https://huggingface.co/docs/hub/datasets-cards), [Synthetic Data survey (2503.14023)](https://arxiv.org/html/2503.14023v1) | **in-scope**: `Sample.provenance` enum + `omk sample` auto-injects `'llm-generated'` |
 | 7 | **Adversarial / failure-driven mining** (Dynabench) | [Dynabench (2104.14337)](https://arxiv.org/abs/2104.14337) | **out-of-scope**: `omk evolve` is currently one-directional; adversarial mining is follow-up |
@@ -194,7 +202,7 @@ omk's statistical-rigor stack (Bootstrap CI / Krippendorff α / length-debias / 
 
 ### 6.3 v2 schema-extension candidates & rejection list
 
-The v1 schema has only 4 fields (capability / difficulty / construct / provenance), all on the **measurement-validity** axis — answering *does this sample measure what it claims to measure?* Another common community ask sits on the **asset-governance** axis: tags / risk_level / expected_facts / source_ids / owner — answering *who owns this sample, where it came from, how important it is.* The two axes are orthogonal and don't conflict, but governance assumes measurement is already solid; v1 chose to solve measurement first. This section records the v2 candidates and the rejection list so future decisions don't re-litigate them.
+The initial schema kept four measurement-validity fields (capability / difficulty / construct / provenance) that answer *does this sample measure what it claims to measure?* `covers` extends that same diagnostic-only philosophy to the structural axis: *which concrete skill nodes does this sample exercise?* Another common community ask sits on the **asset-governance** axis: tags / risk_level / expected_facts / source_ids / owner — answering *who owns this sample, where it came from, how important it is.* The axes are orthogonal and don't conflict, but governance assumes measurement is already solid; v1 chose to solve measurement first. This section records the v2 candidates and the rejection list so future decisions don't re-litigate them.
 
 **v2 candidates (high-value, low-risk; add when real user demand triggers it)**
 
@@ -213,7 +221,7 @@ The v1 schema has only 4 fields (capability / difficulty / construct / provenanc
 - Must not enter the `buildJudgePrompt` signature (`test/grading/judge-prompt-isolation.test.ts` guards the regression)
 - Must not enter the `sampleHash` computation (else it breaks cache-key cross-version comparability)
 - Must not enter the verdict / Δ algorithm
-- Must not semantically overlap the existing 4 fields + `rubric` / `assertions`
+- Must not semantically overlap the existing metadata fields + `rubric` / `assertions`
 
 ### 6.4 Sources
 

--- a/docs/specs/sample-design-spec.md
+++ b/docs/specs/sample-design-spec.md
@@ -27,7 +27,7 @@ samples:
     difficulty: easy                    # 'easy' | 'medium' | 'hard' (strict enum, typo-proof)
     construct: necessity                # 'necessity' | 'quality' | 'capability' suggested, custom string allowed
     provenance: human                   # 'human' | 'llm-generated' | 'production-trace'
-    covers:                             # explicit skill-structure anchors for Skill Map
+    covers:                             # optional declared structure anchors for Skill Map
       - targetKind: reference
         ref: references/chart-api.md
       - targetKind: workflow_node
@@ -44,14 +44,14 @@ samples:
   - `capability`: measures the difference along one concrete capability dimension.
   Custom strings are allowed (e.g. `regression-test` / `cost-efficiency`); the studio won't error on a custom value.
 - **provenance** (enum): data source. `human` (hand-curated) / `llm-generated` (auto-injected by `omk sample`) / `production-trace` (sampled from production traces, which you import yourself).
-- **covers** (`{ targetKind, ref }[]`): explicit skill-structure anchors this sample exercises. This is the structural sibling of `capability`: capability says which ability dimension is tested; covers says which concrete SKILL.md node, reference, script, hard rule, workflow, or workflow node the sample is meant to exercise. Studio uses it to show covered vs uncovered nodes in Skill Map. It is not inferred from prompt text.
+- **covers** (`{ targetKind, ref }[]`): optional declared skill-structure anchors this sample is intended to exercise. This is the structural sibling of `capability`: capability says which ability dimension is tested; covers says which concrete SKILL.md node, reference, script, hard rule, workflow, or workflow node the sample is meant to exercise. Studio uses it to show declared vs undeclared structure edges in Skill Map. It is not inferred from prompt text, and omitting it means "not declared yet", not "not tested".
 
 ### Never enters grading / judge / verdict
 
 These metadata fields are used only for:
 
 - the studio coverage block, plus the `rubric_clarity_low` / `capability_thin` issue detectors
-- Skill Map coverage anchors (`covers`)
+- Skill Map declared anchors (`covers`)
 - the `report.analysis.sampleQuality` aggregate (for tools to read)
 
 **They never enter the judge prompt** (`buildJudgePrompt(prompt, rubric, output, traceSummary)` has no sample object in its signature, and `test/grading/judge-prompt-isolation.test.ts` guards against regressions). **They never affect the verdict algorithm.** This is a hard requirement for construct-validity protection — a judge seeing "construct: necessity" is a judge that knows the answer key.
@@ -149,7 +149,7 @@ Run through this before an eval; any "no" is a reason to stop and think:
 
 - [ ] **Construct declared**: does each sample know whether it measures necessity / quality / capability?
 - [ ] **Capability coverage**: you claim to test N capability dimensions — does the sample set actually cover N? (the studio coverage block shows the real distribution)
-- [ ] **Structure coverage**: do key references / workflows / hard rules have at least one sample declaring `covers`, so Skill Map can show real test-design blind spots?
+- [ ] **Structure anchors**: for key references / workflows / hard rules, do at least 1-2 representative samples declare `covers`, so Skill Map can show which edges are explicit and which are still unstated?
 - [ ] **Difficulty stratified**: do you have easy / medium / hard, or is everything hard so noise dominates?
 - [ ] **Provenance transparent**: is the human-curated / LLM-generated / production-trace ratio reasonable? When LLM-generated is > 50%, watch for self-instruct risk (a self-reinforcing judge-bias loop).
 - [ ] **Sample count**: `N < 5` (exploratory) / `N < 20` (only large effects detectable) / `N ≥ 20` (medium effects detectable) — omk pre-flight already warns.
@@ -181,7 +181,7 @@ omk's statistical-rigor stack (Bootstrap CI / Krippendorff α / length-debias / 
 | 1 | **IRT item discrimination**: each item gets a (discrimination) / b (difficulty) / c (guessing) parameters; a < 0.3 is a junk item | [IrtNet (2510.00844)](https://arxiv.org/pdf/2510.00844), [Columbia IRT primer](https://www.publichealth.columbia.edu/research/population-health-methods/item-response-theory) | **out-of-scope** (IRT is unreliable at N<30; left as follow-up — the v1 `flat_scores` heuristic already covers part of it) |
 | 2 | **Difficulty stratification**: stratify samples by difficulty (MMLU-Pro filters difficulty via multi-model majority-correct) | [MMLU-Pro](https://intuitionlabs.ai/articles/mmlu-pro-ai-benchmark-explained) | **in-scope**: `Sample.difficulty` enum + studio bucketing |
 | 3 | **Construct-validity trio** (structural / convergent / discriminant) | [Measuring what Matters (2511.04703)](https://arxiv.org/abs/2511.04703), [Measurement to Meaning (2505.10573)](https://arxiv.org/html/2505.10573v3) | **in-scope**: `Sample.construct` field (suggested: necessity / quality / capability) + verdict-interpretation callout; convergent / discriminant auto-detection is follow-up |
-| 4 | **Capability-matrix coverage** (HELM's 16×7 matrix) | [HELM (2211.09110)](https://arxiv.org/abs/2211.09110) | **partial**: `Sample.capability` string[] field + studio coverage bucketing + `capability_thin` issue; `Sample.covers` adds explicit structure anchors for Skill Map; detailed matrix visualization is follow-up |
+| 4 | **Capability-matrix coverage** (HELM's 16×7 matrix) | [HELM (2211.09110)](https://arxiv.org/abs/2211.09110) | **partial**: `Sample.capability` string[] field + studio coverage bucketing + `capability_thin` issue; `Sample.covers` adds optional declared structure anchors for Skill Map; detailed matrix visualization is follow-up |
 | 5 | **Contamination detection** (canary / paraphrase / timestamp-locked) | [BIG-Bench canary](https://www.lesswrong.com/posts/kSmHMoaLKGcGgyWzs/big-bench-canary-contamination-in-gpt-4), [LiveBench](https://livebench.ai/livebench.pdf), [contamination survey (2404.00699)](https://arxiv.org/html/2404.00699v4) | **partial**: `Sample.provenance` does "declarative" contamination tracking; real auto-detection is follow-up (needs an embedding model or training-data access) |
 | 6 | **Sample provenance / dataset card** (the annotations_creators standard) | [HF Dataset Cards](https://huggingface.co/docs/hub/datasets-cards), [Synthetic Data survey (2503.14023)](https://arxiv.org/html/2503.14023v1) | **in-scope**: `Sample.provenance` enum + `omk sample` auto-injects `'llm-generated'` |
 | 7 | **Adversarial / failure-driven mining** (Dynabench) | [Dynabench (2104.14337)](https://arxiv.org/abs/2104.14337) | **out-of-scope**: `omk evolve` is currently one-directional; adversarial mining is follow-up |
@@ -202,7 +202,7 @@ omk's statistical-rigor stack (Bootstrap CI / Krippendorff α / length-debias / 
 
 ### 6.3 v2 schema-extension candidates & rejection list
 
-The initial schema kept four measurement-validity fields (capability / difficulty / construct / provenance) that answer *does this sample measure what it claims to measure?* `covers` extends that same diagnostic-only philosophy to the structural axis: *which concrete skill nodes does this sample exercise?* Another common community ask sits on the **asset-governance** axis: tags / risk_level / expected_facts / source_ids / owner — answering *who owns this sample, where it came from, how important it is.* The axes are orthogonal and don't conflict, but governance assumes measurement is already solid; v1 chose to solve measurement first. This section records the v2 candidates and the rejection list so future decisions don't re-litigate them.
+The initial schema kept four measurement-validity fields (capability / difficulty / construct / provenance) that answer *does this sample measure what it claims to measure?* `covers` extends that same diagnostic-only philosophy to the structural axis: *which concrete skill nodes does the author declare this sample is intended to exercise?* Another common community ask sits on the **asset-governance** axis: tags / risk_level / expected_facts / source_ids / owner — answering *who owns this sample, where it came from, how important it is.* The axes are orthogonal and don't conflict, but governance assumes measurement is already solid; v1 chose to solve measurement first. This section records the v2 candidates and the rejection list so future decisions don't re-litigate them.
 
 **v2 candidates (high-value, low-risk; add when real user demand triggers it)**
 

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -115,12 +115,13 @@ Rules:
 
 #### 6.1 Sample metadata fields
 
-The Sample schema has 4 optional metadata fields, purely for documentation / diagnostics; they **do not participate in grading / judge / verdict**. See [docs/specs/sample-design-spec.md](sample-design-spec.md).
+The Sample schema has optional metadata fields, purely for documentation / diagnostics; they **do not participate in grading / judge / verdict**. See [docs/specs/sample-design-spec.md](sample-design-spec.md).
 
 - **`capability?: string[]`** — the capability dimension(s) this sample tests (can be multiple). Normalized case-insensitively, with dash / camelCase / underscore insensitivity.
 - **`difficulty?: 'easy' | 'medium' | 'hard'`** — difficulty bucket (strict enum).
 - **`construct?: string`** — the construct type this sample tests. Suggested: `'necessity'` (tests necessity, baseline-vs-skill) / `'quality'` (tests whether the skill is well-written) / `'capability'` (tests a specific capability). Free-form string allows custom values.
 - **`provenance?: 'human' | 'llm-generated' | 'production-trace'`** — data source.
+- **`covers?: { targetKind: string; ref: string }[]`** — explicit skill-structure anchors this sample exercises, used by Skill Map to show covered / uncovered definition nodes.
 
 **construct vs. capability** (the two fields users most often confuse):
 - **construct** = **what class of thing** this sample tests (necessity / quality / capability). It's the experiment-design level — running baseline-vs-skill tests necessity, running skill-v1-vs-skill-v2 tests quality.

--- a/docs/specs/terminology-spec.md
+++ b/docs/specs/terminology-spec.md
@@ -121,7 +121,7 @@ The Sample schema has optional metadata fields, purely for documentation / diagn
 - **`difficulty?: 'easy' | 'medium' | 'hard'`** — difficulty bucket (strict enum).
 - **`construct?: string`** — the construct type this sample tests. Suggested: `'necessity'` (tests necessity, baseline-vs-skill) / `'quality'` (tests whether the skill is well-written) / `'capability'` (tests a specific capability). Free-form string allows custom values.
 - **`provenance?: 'human' | 'llm-generated' | 'production-trace'`** — data source.
-- **`covers?: { targetKind: string; ref: string }[]`** — explicit skill-structure anchors this sample exercises, used by Skill Map to show covered / uncovered definition nodes.
+- **`covers?: { targetKind: string; ref: string }[]`** — optional declared skill-structure anchors this sample is intended to exercise, used by Skill Map to show declared / undeclared definition nodes.
 
 **construct vs. capability** (the two fields users most often confuse):
 - **construct** = **what class of thing** this sample tests (necessity / quality / capability). It's the experiment-design level — running baseline-vs-skill tests necessity, running skill-v1-vs-skill-v2 tests quality.

--- a/docs/zh/reference/comparison.md
+++ b/docs/zh/reference/comparison.md
@@ -46,7 +46,7 @@ omk 是参与对比中**唯一**把这五件事全做了的工具。最接近的
 | 三层独立评分（事实/行为/评委） | ✓ | ✗ | 部分 | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 三层 all-pass CI gate | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 用例隔离（per-variant skill 隔离 / construct validity） | ✓ 默认开 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | 部分 |
-| 用例设计元数据(capability / difficulty / construct / provenance) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| 用例设计元数据 + 结构锚点（`covers`） | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 一行 verdict(PROGRESS / REGRESS / NOISE / ...) | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 知识缺口信号（严重度加权） | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | 用例质量诊断（7 类 issue） | ✓ | 仅低区分度 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |

--- a/docs/zh/reference/eval-sample-format.md
+++ b/docs/zh/reference/eval-sample-format.md
@@ -69,10 +69,27 @@
 | `difficulty` | `'easy' \| 'medium' \| 'hard'` | 难度分桶（强枚举） |
 | `construct` | `string` | 测什么：`necessity` / `quality` / `capability`（允许自定义） |
 | `provenance` | `'human' \| 'llm-generated' \| 'production-trace'` | 数据来源 |
+| `covers` | `{ targetKind, ref }[]` | 这条用例显式覆盖的 skill 结构锚点，仅用于 Skill Map |
 | `mocks` | `object[]` | 工具调用拦截列表 —— 返回假数据而非真调工具 |
 | `mocksStrict` | `boolean` | 未命中任何 mock 的工具调用直接 deny（默认 `false`） |
 | `tripwire` | `boolean` | 诱错样本：LLM **应当** fail（默认 `false`） |
 | `environment` | `object` | 声明性「已就绪」前置：`cli_available` / `files_available` / `notes` |
+
+`covers` 必须显式声明，不从 prompt 文本里推断。Studio 会用它画出哪些 skill 结构已被用例真正测到：
+
+```yaml
+- sample_id: release-risk-summary
+  prompt: "总结发布风险和回滚方案。"
+  covers:
+    - targetKind: reference
+      ref: references/release-policy.md
+    - targetKind: workflow
+      ref: release
+    - targetKind: workflow_node
+      ref: release.check
+```
+
+`targetKind` 支持 `skill`、`skill_file`、`frontmatter`、`reference`、`script`、`hard_rule`、`workflow`、`workflow_node`。`reference` / `script` 的 `ref` 是相对 skill 根目录的路径；`hard_rule` / `workflow` 使用规则或 workflow id；`workflow_node` 使用 `workflowId.nodeId`。这个字段不进入 grading、评委 prompt、verdict，也不进入 sample 指纹。
 
 ## URL 自动抓取
 

--- a/docs/zh/reference/eval-sample-format.md
+++ b/docs/zh/reference/eval-sample-format.md
@@ -69,13 +69,13 @@
 | `difficulty` | `'easy' \| 'medium' \| 'hard'` | 难度分桶（强枚举） |
 | `construct` | `string` | 测什么：`necessity` / `quality` / `capability`（允许自定义） |
 | `provenance` | `'human' \| 'llm-generated' \| 'production-trace'` | 数据来源 |
-| `covers` | `{ targetKind, ref }[]` | 这条用例显式覆盖的 skill 结构锚点，仅用于 Skill Map |
+| `covers` | `{ targetKind, ref }[]` | 可选声明的 skill 结构锚点，建议先用于关键用例；仅用于 Skill Map |
 | `mocks` | `object[]` | 工具调用拦截列表 —— 返回假数据而非真调工具 |
 | `mocksStrict` | `boolean` | 未命中任何 mock 的工具调用直接 deny（默认 `false`） |
 | `tripwire` | `boolean` | 诱错样本：LLM **应当** fail（默认 `false`） |
 | `environment` | `object` | 声明性「已就绪」前置：`cli_available` / `files_available` / `notes` |
 
-`covers` 必须显式声明，不从 prompt 文本里推断。Studio 会用它画出哪些 skill 结构已被用例真正测到：
+`covers` 是可选的显式声明字段，不从 prompt 文本里推断。建议先给关键用例、关键 reference / workflow / hard rule 声明它，让 Studio 能画出已声明的结构边，而不是要求每条用例都变成维护负担。不写只表示 Skill Map 暂无这条声明边，不代表该结构一定没被测到：
 
 ```yaml
 - sample_id: release-risk-summary

--- a/docs/zh/specs/sample-design-spec.md
+++ b/docs/zh/specs/sample-design-spec.md
@@ -20,13 +20,18 @@ samples:
       - { type: contains, value: "Line", weight: 1 }
       - { type: regex, pattern: "data", weight: 1 }
 
-    # 4 个可选元数据字段（纯文档/诊断，不参与 grading）
+    # 测量元数据（纯文档 / 诊断，不参与 grading）
     capability:
       - component-recognition          # string[]，能力维度，可多个；归一时大小写/短横线/驼峰不敏感
       - api-selection
     difficulty: easy                    # 'easy' | 'medium' | 'hard'（强枚举，防错）
     construct: necessity                # 'necessity' | 'quality' | 'capability' suggested，允许自定义 string
     provenance: human                   # 'human' | 'llm-generated' | 'production-trace'
+    covers:                             # Skill Map 使用的显式 skill 结构锚点
+      - targetKind: reference
+        ref: references/chart-api.md
+      - targetKind: workflow_node
+        ref: chart.render
 ```
 
 ### 字段语义
@@ -39,12 +44,14 @@ samples:
   - `capability`（能力）：测某具体能力维度的差异。
   允许自定义 string（比如 `regression-test` / `cost-efficiency` 等），studio 看到自定义值不报错。
 - **provenance**（enum）：数据来源。`human`（人工 curated）/ `llm-generated`（`omk sample` 自动注入）/ `production-trace`（生产 trace 抽样，需用户自己导入）。
+- **covers**（`{ targetKind, ref }[]`）：这条 sample 显式覆盖的 skill 结构锚点。它是 `capability` 的结构侧补充：capability 说这条用例测哪个能力维度；covers 说这条用例具体测到哪个 SKILL.md 节点、reference、script、hard rule、workflow 或 workflow node。Studio 用它在 Skill Map 中标出已覆盖 / 未覆盖节点。它不会从 prompt 文本里自动推断。
 
 ### 不参与 grading / judge / verdict
 
-这 4 字段只用于：
+这些元数据字段只用于：
 
 - studio coverage 块 + `rubric_clarity_low` / `capability_thin` 两个 issue 检测
+- Skill Map 覆盖锚点（`covers`）
 - `report.analysis.sampleQuality` 聚合数据（供工具读）
 
 **绝对不进 judge prompt**（`buildJudgePrompt(prompt, rubric, output, traceSummary)` signature 不含 sample 对象，且有 `test/grading/judge-prompt-isolation.test.ts` 防御回归）。**绝对不影响 verdict 算法**。这是构造效度保护的硬要求 —— judge 看到 "construct: necessity" 等于知道试题答案。
@@ -142,6 +149,7 @@ studio 把每份报告的 sample design coverage 渲染成下面这种摘要：
 
 - [ ] **Construct 声明**：每个 sample 知道自己测的是 necessity / quality / capability 中哪一类吗？
 - [ ] **Capability 覆盖**：声称要测 N 个能力维度，sample 集真覆盖了 N 个吗？（studio coverage 块给出真实分布）
+- [ ] **结构覆盖**：关键 references / workflows / hard rules 是否至少有一条 sample 声明了 `covers`，让 Skill Map 能暴露真实测试设计盲区？
 - [ ] **Difficulty 分层**：有 easy / medium / hard 都有吗？还是全 hard 让模型 noise 主导？
 - [ ] **Provenance 透明**：human-curated / LLM-generated / production-trace 比例合理吗？LLM-generated 占比 > 50% 时小心 self-instruct 风险（judge bias 自我循环）。
 - [ ] **Sample 数量**：`N < 5`（探索级）/ `N < 20`（只大效应可测）/ `N ≥ 20`（中等效应可测）—— omk pre-flight 已警告。
@@ -173,7 +181,7 @@ omk 的统计严谨性栈（Bootstrap CI / Krippendorff α / length-debias / sat
 | 1 | **IRT item discrimination**：每题给 a (discrimination) / b (difficulty) / c (guessing) 三参数，a < 0.3 是垃圾题 | [IrtNet (2510.00844)](https://arxiv.org/pdf/2510.00844)，[Columbia IRT primer](https://www.publichealth.columbia.edu/research/population-health-methods/item-response-theory) | **out-of-scope**（N<30 IRT 不可靠，留 follow-up；v1 启发式 `flat_scores` 已 cover 部分） |
 | 2 | **Difficulty stratification**：用例分层（MMLU-Pro 用多模型多数答对过滤难度） | [MMLU-Pro](https://intuitionlabs.ai/articles/mmlu-pro-ai-benchmark-explained) | **in-scope**：`Sample.difficulty` enum + studio 分桶呈现 |
 | 3 | **Construct validity 三件套**（structural / convergent / discriminant） | [Measuring what Matters (2511.04703)](https://arxiv.org/abs/2511.04703)，[Measurement to Meaning (2505.10573)](https://arxiv.org/html/2505.10573v3) | **in-scope**：`Sample.construct` 字段（suggested：necessity / quality / capability）+ verdict 解读 callout；convergent / discriminant 自动检测 follow-up |
-| 4 | **Capability matrix coverage**（HELM 16×7 矩阵） | [HELM (2211.09110)](https://arxiv.org/abs/2211.09110) | **partial**：`Sample.capability` string[] 字段 + studio coverage 分桶 + `capability_thin` issue；详细矩阵可视化 follow-up |
+| 4 | **Capability matrix coverage**（HELM 16×7 矩阵） | [HELM (2211.09110)](https://arxiv.org/abs/2211.09110) | **partial**：`Sample.capability` string[] 字段 + studio coverage 分桶 + `capability_thin` issue；`Sample.covers` 为 Skill Map 增加显式结构锚点；详细矩阵可视化 follow-up |
 | 5 | **Contamination 检测**（canary / paraphrase / timestamp-locked） | [BIG-Bench canary](https://www.lesswrong.com/posts/kSmHMoaLKGcGgyWzs/big-bench-canary-contamination-in-gpt-4)，[LiveBench](https://livebench.ai/livebench.pdf)，[contamination survey (2404.00699)](https://arxiv.org/html/2404.00699v4) | **partial**：`Sample.provenance` 做「声明式」contamination tracking，真正自动检测 follow-up（需要 embedding model 或训练数据访问） |
 | 6 | **Sample provenance / dataset card**（annotations_creators 标准） | [HF Dataset Cards](https://huggingface.co/docs/hub/datasets-cards)，[Synthetic Data survey (2503.14023)](https://arxiv.org/html/2503.14023v1) | **in-scope**：`Sample.provenance` enum + `omk sample` 自动注入 `'llm-generated'` |
 | 7 | **Adversarial / failure-driven mining**（Dynabench） | [Dynabench (2104.14337)](https://arxiv.org/abs/2104.14337) | **out-of-scope**：`omk evolve` 当前是单向演化；adversarial mining follow-up |
@@ -194,7 +202,7 @@ omk 的统计严谨性栈（Bootstrap CI / Krippendorff α / length-debias / sat
 
 ### 6.3 v2 schema 扩展候选与拒绝清单
 
-v1 schema 只有 4 字段（capability / difficulty / construct / provenance），都属于「测量学正确性」（measurement validity）轴——回答**这条用例测的事是它声称要测的事吗**。社区另一类常见建议走的是「资产治理」（asset governance）轴：tags / risk_level / expected_facts / source_ids / owner——回答**这条用例归谁、来自哪里、有多重要**。两轴正交不冲突，但治理假设测量学先稳固；v1 选了先解测量学。本节记录 v2 候选字段及拒绝清单，供后续决策时不必重新讨论一遍。
+初始 schema 只有 4 个测量效度字段（capability / difficulty / construct / provenance），回答**这条用例测的事是它声称要测的事吗**。`covers` 延续同一条「仅诊断、不进评分」原则，把能力维度之外的结构轴补上：**这条用例具体测到了哪些 skill 节点**。社区另一类常见建议走的是「资产治理」（asset governance）轴：tags / risk_level / expected_facts / source_ids / owner——回答**这条用例归谁、来自哪里、有多重要**。这些轴正交不冲突，但治理假设测量学先稳固；v1 选了先解测量学。本节记录 v2 候选字段及拒绝清单，供后续决策时不必重新讨论一遍。
 
 **v2 候选（高价值低风险，等真实用户需求触发再加）**
 
@@ -213,7 +221,7 @@ v1 schema 只有 4 字段（capability / difficulty / construct / provenance）�
 - 不进 `buildJudgePrompt` signature（`test/grading/judge-prompt-isolation.test.ts` 防御回归）
 - 不进 `sampleHash` 计算（否则破 cache key 跨版本可比性）
 - 不进 verdict / Δ 算法
-- 跟现有 4 字段 + `rubric` / `assertions` 语义不重叠
+- 跟现有元数据字段 + `rubric` / `assertions` 语义不重叠
 
 ### 6.4 参考
 

--- a/docs/zh/specs/sample-design-spec.md
+++ b/docs/zh/specs/sample-design-spec.md
@@ -27,7 +27,7 @@ samples:
     difficulty: easy                    # 'easy' | 'medium' | 'hard'（强枚举，防错）
     construct: necessity                # 'necessity' | 'quality' | 'capability' suggested，允许自定义 string
     provenance: human                   # 'human' | 'llm-generated' | 'production-trace'
-    covers:                             # Skill Map 使用的显式 skill 结构锚点
+    covers:                             # Skill Map 使用的可选声明结构锚点
       - targetKind: reference
         ref: references/chart-api.md
       - targetKind: workflow_node
@@ -44,14 +44,14 @@ samples:
   - `capability`（能力）：测某具体能力维度的差异。
   允许自定义 string（比如 `regression-test` / `cost-efficiency` 等），studio 看到自定义值不报错。
 - **provenance**（enum）：数据来源。`human`（人工 curated）/ `llm-generated`（`omk sample` 自动注入）/ `production-trace`（生产 trace 抽样，需用户自己导入）。
-- **covers**（`{ targetKind, ref }[]`）：这条 sample 显式覆盖的 skill 结构锚点。它是 `capability` 的结构侧补充：capability 说这条用例测哪个能力维度；covers 说这条用例具体测到哪个 SKILL.md 节点、reference、script、hard rule、workflow 或 workflow node。Studio 用它在 Skill Map 中标出已覆盖 / 未覆盖节点。它不会从 prompt 文本里自动推断。
+- **covers**（`{ targetKind, ref }[]`）：这条 sample 可选声明的 skill 结构锚点。它是 `capability` 的结构侧补充：capability 说这条用例测哪个能力维度；covers 说作者希望声明这条用例具体测到哪个 SKILL.md 节点、reference、script、hard rule、workflow 或 workflow node。Studio 用它在 Skill Map 中标出已声明 / 未声明的结构边。它不会从 prompt 文本里自动推断；不写表示「尚未声明」，不代表「没有测到」。
 
 ### 不参与 grading / judge / verdict
 
 这些元数据字段只用于：
 
 - studio coverage 块 + `rubric_clarity_low` / `capability_thin` 两个 issue 检测
-- Skill Map 覆盖锚点（`covers`）
+- Skill Map 声明锚点（`covers`）
 - `report.analysis.sampleQuality` 聚合数据（供工具读）
 
 **绝对不进 judge prompt**（`buildJudgePrompt(prompt, rubric, output, traceSummary)` signature 不含 sample 对象，且有 `test/grading/judge-prompt-isolation.test.ts` 防御回归）。**绝对不影响 verdict 算法**。这是构造效度保护的硬要求 —— judge 看到 "construct: necessity" 等于知道试题答案。
@@ -149,7 +149,7 @@ studio 把每份报告的 sample design coverage 渲染成下面这种摘要：
 
 - [ ] **Construct 声明**：每个 sample 知道自己测的是 necessity / quality / capability 中哪一类吗？
 - [ ] **Capability 覆盖**：声称要测 N 个能力维度，sample 集真覆盖了 N 个吗？（studio coverage 块给出真实分布）
-- [ ] **结构覆盖**：关键 references / workflows / hard rules 是否至少有一条 sample 声明了 `covers`，让 Skill Map 能暴露真实测试设计盲区？
+- [ ] **结构锚点**：关键 references / workflows / hard rules 是否至少有 1-2 条代表性 sample 声明了 `covers`，让 Skill Map 能看出哪些边界已显式声明、哪些仍未声明？
 - [ ] **Difficulty 分层**：有 easy / medium / hard 都有吗？还是全 hard 让模型 noise 主导？
 - [ ] **Provenance 透明**：human-curated / LLM-generated / production-trace 比例合理吗？LLM-generated 占比 > 50% 时小心 self-instruct 风险（judge bias 自我循环）。
 - [ ] **Sample 数量**：`N < 5`（探索级）/ `N < 20`（只大效应可测）/ `N ≥ 20`（中等效应可测）—— omk pre-flight 已警告。
@@ -181,7 +181,7 @@ omk 的统计严谨性栈（Bootstrap CI / Krippendorff α / length-debias / sat
 | 1 | **IRT item discrimination**：每题给 a (discrimination) / b (difficulty) / c (guessing) 三参数，a < 0.3 是垃圾题 | [IrtNet (2510.00844)](https://arxiv.org/pdf/2510.00844)，[Columbia IRT primer](https://www.publichealth.columbia.edu/research/population-health-methods/item-response-theory) | **out-of-scope**（N<30 IRT 不可靠，留 follow-up；v1 启发式 `flat_scores` 已 cover 部分） |
 | 2 | **Difficulty stratification**：用例分层（MMLU-Pro 用多模型多数答对过滤难度） | [MMLU-Pro](https://intuitionlabs.ai/articles/mmlu-pro-ai-benchmark-explained) | **in-scope**：`Sample.difficulty` enum + studio 分桶呈现 |
 | 3 | **Construct validity 三件套**（structural / convergent / discriminant） | [Measuring what Matters (2511.04703)](https://arxiv.org/abs/2511.04703)，[Measurement to Meaning (2505.10573)](https://arxiv.org/html/2505.10573v3) | **in-scope**：`Sample.construct` 字段（suggested：necessity / quality / capability）+ verdict 解读 callout；convergent / discriminant 自动检测 follow-up |
-| 4 | **Capability matrix coverage**（HELM 16×7 矩阵） | [HELM (2211.09110)](https://arxiv.org/abs/2211.09110) | **partial**：`Sample.capability` string[] 字段 + studio coverage 分桶 + `capability_thin` issue；`Sample.covers` 为 Skill Map 增加显式结构锚点；详细矩阵可视化 follow-up |
+| 4 | **Capability matrix coverage**（HELM 16×7 矩阵） | [HELM (2211.09110)](https://arxiv.org/abs/2211.09110) | **partial**：`Sample.capability` string[] 字段 + studio coverage 分桶 + `capability_thin` issue；`Sample.covers` 为 Skill Map 增加可选声明结构锚点；详细矩阵可视化 follow-up |
 | 5 | **Contamination 检测**（canary / paraphrase / timestamp-locked） | [BIG-Bench canary](https://www.lesswrong.com/posts/kSmHMoaLKGcGgyWzs/big-bench-canary-contamination-in-gpt-4)，[LiveBench](https://livebench.ai/livebench.pdf)，[contamination survey (2404.00699)](https://arxiv.org/html/2404.00699v4) | **partial**：`Sample.provenance` 做「声明式」contamination tracking，真正自动检测 follow-up（需要 embedding model 或训练数据访问） |
 | 6 | **Sample provenance / dataset card**（annotations_creators 标准） | [HF Dataset Cards](https://huggingface.co/docs/hub/datasets-cards)，[Synthetic Data survey (2503.14023)](https://arxiv.org/html/2503.14023v1) | **in-scope**：`Sample.provenance` enum + `omk sample` 自动注入 `'llm-generated'` |
 | 7 | **Adversarial / failure-driven mining**（Dynabench） | [Dynabench (2104.14337)](https://arxiv.org/abs/2104.14337) | **out-of-scope**：`omk evolve` 当前是单向演化；adversarial mining follow-up |
@@ -202,7 +202,7 @@ omk 的统计严谨性栈（Bootstrap CI / Krippendorff α / length-debias / sat
 
 ### 6.3 v2 schema 扩展候选与拒绝清单
 
-初始 schema 只有 4 个测量效度字段（capability / difficulty / construct / provenance），回答**这条用例测的事是它声称要测的事吗**。`covers` 延续同一条「仅诊断、不进评分」原则，把能力维度之外的结构轴补上：**这条用例具体测到了哪些 skill 节点**。社区另一类常见建议走的是「资产治理」（asset governance）轴：tags / risk_level / expected_facts / source_ids / owner——回答**这条用例归谁、来自哪里、有多重要**。这些轴正交不冲突，但治理假设测量学先稳固；v1 选了先解测量学。本节记录 v2 候选字段及拒绝清单，供后续决策时不必重新讨论一遍。
+初始 schema 只有 4 个测量效度字段（capability / difficulty / construct / provenance），回答**这条用例测的事是它声称要测的事吗**。`covers` 延续同一条「仅诊断、不进评分」原则，把能力维度之外的结构轴补上：**作者声明这条用例意图测到哪些 skill 节点**。社区另一类常见建议走的是「资产治理」（asset governance）轴：tags / risk_level / expected_facts / source_ids / owner——回答**这条用例归谁、来自哪里、有多重要**。这些轴正交不冲突，但治理假设测量学先稳固；v1 选了先解测量学。本节记录 v2 候选字段及拒绝清单，供后续决策时不必重新讨论一遍。
 
 **v2 候选（高价值低风险，等真实用户需求触发再加）**
 

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -121,7 +121,7 @@ Sample schema 含一组可选元数据字段，纯文档 / 诊断用，**不参�
 - **`difficulty?: 'easy' | 'medium' | 'hard'`** — 难度分层(强枚举)。
 - **`construct?: string`** — 该 sample 测的 construct 类型。Suggested:`'necessity'`(测必要性,baseline-vs-skill)/ `'quality'`(测 skill 写得好不好)/ `'capability'`(测某具体能力)。Free-form string 允许自定义。
 - **`provenance?: 'human' | 'llm-generated' | 'production-trace'`** — 数据来源。
-- **`covers?: { targetKind: string; ref: string }[]`** — 这条 sample 显式覆盖的 skill 结构锚点，Skill Map 用它展示已覆盖 / 未覆盖的定义节点。
+- **`covers?: { targetKind: string; ref: string }[]`** — 这条 sample 可选声明的 skill 结构锚点，Skill Map 用它展示已声明 / 未声明的定义节点。
 
 **construct 跟 capability 区别**(用户最常混淆的两个字段):
 - **construct** = 这个 sample 测**哪类事**(necessity / quality / capability)。是实验设计的层面 — 你跑 baseline-vs-skill 是测必要性，跑 skill-v1-vs-skill-v2 是测质量。

--- a/docs/zh/specs/terminology-spec.md
+++ b/docs/zh/specs/terminology-spec.md
@@ -115,12 +115,13 @@
 
 #### 6.1 Sample 元数据字段
 
-Sample schema 含 4 个可选元数据字段，纯文档 / 诊断用,**不参与 grading / judge / verdict**。详见 [docs/zh/specs/sample-design-spec.md](sample-design-spec.md)。
+Sample schema 含一组可选元数据字段，纯文档 / 诊断用，**不参与 grading / judge / verdict**。详见 [docs/zh/specs/sample-design-spec.md](sample-design-spec.md)。
 
 - **`capability?: string[]`** — 该 sample 测试的能力维度(可多个)。归一时大小写 / 短横线 / 驼峰 / 下划线不敏感。
 - **`difficulty?: 'easy' | 'medium' | 'hard'`** — 难度分层(强枚举)。
 - **`construct?: string`** — 该 sample 测的 construct 类型。Suggested:`'necessity'`(测必要性,baseline-vs-skill)/ `'quality'`(测 skill 写得好不好)/ `'capability'`(测某具体能力)。Free-form string 允许自定义。
 - **`provenance?: 'human' | 'llm-generated' | 'production-trace'`** — 数据来源。
+- **`covers?: { targetKind: string; ref: string }[]`** — 这条 sample 显式覆盖的 skill 结构锚点，Skill Map 用它展示已覆盖 / 未覆盖的定义节点。
 
 **construct 跟 capability 区别**(用户最常混淆的两个字段):
 - **construct** = 这个 sample 测**哪类事**(necessity / quality / capability)。是实验设计的层面 — 你跑 baseline-vs-skill 是测必要性，跑 skill-v1-vs-skill-v2 是测质量。

--- a/src/artifact-graph/eval.ts
+++ b/src/artifact-graph/eval.ts
@@ -13,6 +13,8 @@ import type {
   ArtifactGraphNodeRole,
   ArtifactGraphStatus,
   EvaluationReport,
+  SampleCoverageTarget,
+  SampleCoverageTargetKind,
   SampleSnapshot,
   VariantConfig,
   VariantResult,
@@ -171,7 +173,81 @@ function sampleAttrs(snapshot: SampleSnapshot | undefined): ArtifactGraphNode['a
   if (snapshot.provenance) display.provenance = snapshot.provenance;
   if (snapshot.tripwire) display.tripwire = true;
   if (snapshot.assertions?.length) display.assertionCount = snapshot.assertions.length;
+  if (snapshot.covers?.length) display.coveredTargetCount = snapshot.covers.length;
   return Object.keys(display).length > 0 ? { display } : undefined;
+}
+
+const COVERAGE_TARGET_NODE_KIND: Record<SampleCoverageTargetKind, ArtifactGraphNodeKind> = {
+  skill: 'skill',
+  skill_file: 'skill_file',
+  frontmatter: 'frontmatter',
+  reference: 'reference',
+  script: 'script',
+  hard_rule: 'hard_rule',
+  workflow: 'workflow',
+  workflow_node: 'workflow_node',
+};
+
+function normalizeCoverageRef(target: SampleCoverageTarget): string {
+  const raw = target.ref.trim().replaceAll('\\', '/');
+  if (target.targetKind === 'reference' || target.targetKind === 'script' || target.targetKind === 'skill_file') {
+    return raw.replace(/^\/+/, '').replace(/^\.\//, '');
+  }
+  return raw;
+}
+
+function coverageTargetStableKey(target: SampleCoverageTarget, artifactHash: string): string {
+  const ref = normalizeCoverageRef(target);
+  switch (target.targetKind) {
+    case 'skill':
+      return `v1:skill:${artifactHash}`;
+    case 'skill_file':
+      return `v1:skill-file:${artifactHash}:${ref || 'SKILL.md'}`;
+    case 'frontmatter':
+      return `v1:frontmatter:${artifactHash}`;
+    case 'reference':
+      return `v1:reference:${artifactHash}:${ref}`;
+    case 'script':
+      return `v1:script:${artifactHash}:${ref}`;
+    case 'hard_rule':
+      return `v1:hard-rule:${artifactHash}:${ref}`;
+    case 'workflow':
+      return `v1:workflow:${artifactHash}:${ref}`;
+    case 'workflow_node':
+      return `v1:workflow-node:${artifactHash}:${ref}`;
+  }
+}
+
+function coverageTargetLabel(target: SampleCoverageTarget): string {
+  const ref = normalizeCoverageRef(target);
+  switch (target.targetKind) {
+    case 'skill':
+      return ref && ref !== 'skill' ? ref : 'SKILL.md';
+    case 'skill_file':
+      return ref || 'SKILL.md';
+    case 'frontmatter':
+      return 'frontmatter';
+    default:
+      return ref;
+  }
+}
+
+function coverageEvidence(
+  report: EvaluationReport,
+  sampleId: string,
+  targetIndex: number,
+  target: SampleCoverageTarget,
+): ArtifactGraphEvidenceRef[] {
+  return [{
+    sourceKind: 'sample',
+    sourceId: sampleId,
+    selector: {
+      selectorKind: 'json-pointer',
+      value: `/sampleSnapshots/${jsonPointerToken(sampleId)}/covers/${targetIndex}`,
+    },
+    contentHash: report.meta.sampleHashes?.[sampleId],
+    label: `${sampleId} covers ${target.targetKind}:${normalizeCoverageRef(target)}`,
+  }];
 }
 
 export function evalGraphDirForReportOutput(reportOutputDir: string): string {
@@ -187,6 +263,18 @@ export function buildEvalArtifactGraph(options: BuildEvalGraphOptions): Artifact
   const edges: ArtifactGraphEdge[] = [];
   const nodeIdsByStableKey = new Map<string, string>();
   const configs = variantConfigByName(report);
+  const skillArtifacts = report.meta.variants
+    .map((variant) => ({
+      variant,
+      artifactHash: report.meta.artifactHashes?.[variant],
+      config: configs.get(variant),
+    }))
+    .filter((item): item is { variant: string; artifactHash: string; config: VariantConfig } =>
+      item.config?.artifactKind === 'skill'
+        && typeof item.artifactHash === 'string'
+        && item.artifactHash.length > 0
+        && item.artifactHash !== 'no-skill',
+    );
 
   const addNode = (
     stableKey: string,
@@ -225,6 +313,54 @@ export function buildEvalArtifactGraph(options: BuildEvalGraphOptions): Artifact
       edgeKind,
       layer: 'measurement',
       ...extra,
+    });
+  };
+
+  const addCoverageEdges = (sampleId: string, sampleNodeId: string, snapshot: SampleSnapshot): void => {
+    if (!snapshot.covers?.length || skillArtifacts.length === 0) return;
+    const seen = new Set<string>();
+    snapshot.covers.forEach((target, targetIndex) => {
+      const targetRef = normalizeCoverageRef(target);
+      if (!targetRef && target.targetKind !== 'skill' && target.targetKind !== 'frontmatter') return;
+      for (const artifact of skillArtifacts) {
+        const stableKey = coverageTargetStableKey(target, artifact.artifactHash);
+        const dedupeKey = `${sampleNodeId}|${stableKey}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        const evidenceRefs = coverageEvidence(report, sampleId, targetIndex, target);
+        const targetNodeId = addNode(
+          stableKey,
+          COVERAGE_TARGET_NODE_KIND[target.targetKind],
+          'entity',
+          coverageTargetLabel(target),
+          {
+            binding: { bindingStrength: 'content-hash', keys: { artifactHash: artifact.artifactHash } },
+            attrs: {
+              display: {
+                targetKind: target.targetKind,
+                ref: targetRef,
+                variant: artifact.variant,
+                sourceLocator: artifact.config.locator,
+              },
+            },
+            evidenceRefs,
+          },
+        );
+        addEdge(sampleNodeId, targetNodeId, 'covers', {
+          confidence: 1,
+          binding: {
+            bindingStrength: 'explicit',
+            keys: {
+              sampleId,
+              targetKind: target.targetKind,
+              targetRef,
+              artifactHash: artifact.artifactHash,
+            },
+          },
+          attrs: { producer: { source: 'sample.covers' } },
+          evidenceRefs,
+        });
+      }
     });
   };
 
@@ -320,6 +456,7 @@ export function buildEvalArtifactGraph(options: BuildEvalGraphOptions): Artifact
       );
       addEdge(sampleNodeId, assertionNodeId, 'contains');
     });
+    addCoverageEdges(sampleId, sampleNodeId, snapshot);
   }
 
   for (const [resultIndex, result] of report.results.entries()) {

--- a/src/artifact-graph/eval.ts
+++ b/src/artifact-graph/eval.ts
@@ -173,7 +173,7 @@ function sampleAttrs(snapshot: SampleSnapshot | undefined): ArtifactGraphNode['a
   if (snapshot.provenance) display.provenance = snapshot.provenance;
   if (snapshot.tripwire) display.tripwire = true;
   if (snapshot.assertions?.length) display.assertionCount = snapshot.assertions.length;
-  if (snapshot.covers?.length) display.coveredTargetCount = snapshot.covers.length;
+  if (snapshot.covers?.length) display.declaredCoverageTargetCount = snapshot.covers.length;
   return Object.keys(display).length > 0 ? { display } : undefined;
 }
 

--- a/src/eval-core/evaluation-reporting.ts
+++ b/src/eval-core/evaluation-reporting.ts
@@ -355,6 +355,7 @@ export function aggregateReport({
       ...(s.difficulty ? { difficulty: s.difficulty } : {}),
       ...(s.construct ? { construct: s.construct } : {}),
       ...(s.provenance ? { provenance: s.provenance } : {}),
+      ...(s.covers && s.covers.length > 0 ? { covers: s.covers } : {}),
       ...(s.tripwire ? { tripwire: true } : {}),
     }])),
   };

--- a/src/inputs/load-samples.ts
+++ b/src/inputs/load-samples.ts
@@ -143,6 +143,16 @@ export function validateSamples(samples: Sample[]): void {
   // Pure documentation/diagnostic fields; do NOT participate in grading/judge/verdict.
   const VALID_DIFFICULTY: ReadonlySet<string> = new Set(['easy', 'medium', 'hard']);
   const VALID_PROVENANCE: ReadonlySet<string> = new Set(['human', 'llm-generated', 'production-trace']);
+  const VALID_COVERAGE_TARGET_KIND: ReadonlySet<string> = new Set([
+    'skill',
+    'skill_file',
+    'frontmatter',
+    'reference',
+    'script',
+    'hard_rule',
+    'workflow',
+    'workflow_node',
+  ]);
 
   for (const [i, sample] of samples.entries()) {
     if (!sample.sample_id || typeof sample.sample_id !== 'string') {
@@ -181,6 +191,31 @@ export function validateSamples(samples: Sample[]): void {
       throw new Error(
         `samples[${i}] (${sample.sample_id}) invalid construct: must be a string (got ${typeof sample.construct})`,
       );
+    }
+    if (sample.covers !== undefined) {
+      if (!Array.isArray(sample.covers)) {
+        throw new Error(
+          `samples[${i}] (${sample.sample_id}) invalid covers: must be an array of coverage target objects`,
+        );
+      }
+      for (const [j, target] of sample.covers.entries()) {
+        if (!target || typeof target !== 'object' || Array.isArray(target)) {
+          throw new Error(
+            `samples[${i}] (${sample.sample_id}) covers[${j}] must be an object with targetKind/ref`,
+          );
+        }
+        const record = target as unknown as Record<string, unknown>;
+        if (typeof record.targetKind !== 'string' || !VALID_COVERAGE_TARGET_KIND.has(record.targetKind)) {
+          throw new Error(
+            `samples[${i}] (${sample.sample_id}) covers[${j}] invalid targetKind: ${JSON.stringify(record.targetKind)}, expected one of [${[...VALID_COVERAGE_TARGET_KIND].join(', ')}]`,
+          );
+        }
+        if (typeof record.ref !== 'string' || !record.ref.trim()) {
+          throw new Error(
+            `samples[${i}] (${sample.sample_id}) covers[${j}] invalid ref: must be a non-empty string`,
+          );
+        }
+      }
     }
 
     // tools_called / tools_not_called: values 必须非空。空 values 在 grader 里

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -480,8 +480,8 @@ details.si-pass-card[open] > summary > .si-pass-row1::before { content:'▾ ' }
 .sm-node--warning { border-color:rgba(217,119,6,.38);background:rgba(217,119,6,.07) }
 .sm-node--failed { border-color:rgba(220,38,38,.38);background:rgba(220,38,38,.06) }
 .sm-node--pending,.sm-node--more { border-style:dashed;background:rgba(248,249,251,.94);color:#637083 }
-.sm-node--covered { border-color:rgba(31,157,99,.42);box-shadow:0 10px 24px rgba(31,157,99,.08) }
-.sm-node--not-covered { border-style:dashed;background:rgba(248,249,251,.94);color:#637083 }
+.sm-node--coverage-declared { border-color:rgba(31,157,99,.42);box-shadow:0 10px 24px rgba(31,157,99,.08) }
+.sm-node--coverage-undeclared { border-style:dashed;background:rgba(248,249,251,.94);color:#637083 }
 .sm-node-title { font-size:12.2px;font-weight:700;color:#182033;line-height:1.28;word-break:break-word;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden }
 .sm-node--skill .sm-node-title { font-size:15px;line-height:1.2 }
 .sm-node-meta { font-size:10.5px;color:#637083;line-height:1.35;word-break:break-word }
@@ -1772,14 +1772,14 @@ function graphNodeStatusClass(node: SkillGraphNodePreview): string {
 }
 
 function graphNodeCoverageClass(node: SkillGraphNodePreview): string {
-  if (node.coverage === 'covered') return ' sm-node--covered';
-  if (node.coverage === 'not_covered') return ' sm-node--not-covered';
+  if (node.coverage === 'declared') return ' sm-node--coverage-declared';
+  if (node.coverage === 'undeclared') return ' sm-node--coverage-undeclared';
   return '';
 }
 
 function graphNodeCoverageLabel(node: SkillGraphNodePreview, lang: Lang): string {
-  if (node.coverage === 'covered') return lang === 'zh' ? '已被用例覆盖' : 'covered by samples';
-  if (node.coverage === 'not_covered') return lang === 'zh' ? '暂无显式覆盖用例' : 'no explicit sample coverage';
+  if (node.coverage === 'declared') return lang === 'zh' ? '已声明覆盖关系' : 'declared coverage';
+  if (node.coverage === 'undeclared') return lang === 'zh' ? '未声明覆盖关系' : 'coverage not declared';
   return '';
 }
 
@@ -1895,32 +1895,32 @@ function orderedPreviewNodes(
     .map(({ node }) => node);
 }
 
-function applyDefinitionCoverage(
+function applyDefinitionCoverageDeclarations(
   nodes: SkillGraphNodePreview[] | undefined,
-  coveredStableKeys: string[] | undefined,
+  declaredStableKeys: string[] | undefined,
 ): SkillGraphNodePreview[] | undefined {
   if (!nodes) return undefined;
-  if (!coveredStableKeys || coveredStableKeys.length === 0) return nodes;
-  const covered = new Set(coveredStableKeys);
+  if (!declaredStableKeys || declaredStableKeys.length === 0) return nodes;
+  const declared = new Set(declaredStableKeys);
   return nodes.map((node) => {
     if (!node.stableKey || !DEFINITION_PREVIEW_KINDS.has(node.nodeKind)) return node;
-    return { ...node, coverage: covered.has(node.stableKey) ? 'covered' : 'not_covered' };
+    return { ...node, coverage: declared.has(node.stableKey) ? 'declared' : 'undeclared' };
   });
 }
 
-function skillMapCoverageSummary(
+function skillMapCoverageDeclarationSummary(
   doctor: NonNullable<SkillGraphSnapshot['doctor']> | undefined,
   evalGraph: NonNullable<SkillGraphSnapshot['eval']> | undefined,
   lang: Lang,
 ): string | null {
-  const coveredKeys = new Set(evalGraph?.coveredDefinitionStableKeys ?? []);
-  if (!doctor || coveredKeys.size === 0) return null;
+  const declaredKeys = new Set(evalGraph?.declaredCoverageStableKeys ?? []);
+  if (!doctor || declaredKeys.size === 0) return null;
   const coverable = doctor.definitionNodes.filter((node) => node.stableKey && DEFINITION_PREVIEW_KINDS.has(node.nodeKind));
   if (coverable.length === 0) return null;
-  const coveredCount = coverable.filter((node) => node.stableKey && coveredKeys.has(node.stableKey)).length;
+  const declaredCount = coverable.filter((node) => node.stableKey && declaredKeys.has(node.stableKey)).length;
   return lang === 'zh'
-    ? `覆盖锚点 ${coveredCount}/${coverable.length}`
-    : `coverage anchors ${coveredCount}/${coverable.length}`;
+    ? `声明锚点 ${declaredCount}/${coverable.length}`
+    : `declared anchors ${declaredCount}/${coverable.length}`;
 }
 
 function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string {
@@ -1942,8 +1942,8 @@ function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string
     !entry.eval ? `- ${zh ? '测量效果' : 'Measure impact'}${stepSeparator} \`omk eval --control baseline --treatment ${sourceArg}\`` : '',
     !entry.observe ? `- ${zh ? '接入观察' : 'Add observation'}${stepSeparator} \`omk observe ingest <trace-dir>\`` : '',
   ].filter(Boolean);
-  const coverageSummary = skillMapCoverageSummary(doctor, evalGraph, lang);
-  const definitionPreview = previewNodes(applyDefinitionCoverage(doctor?.definitionNodes, evalGraph?.coveredDefinitionStableKeys), DEFINITION_PREVIEW_KINDS, 8);
+  const coverageSummary = skillMapCoverageDeclarationSummary(doctor, evalGraph, lang);
+  const definitionPreview = previewNodes(applyDefinitionCoverageDeclarations(doctor?.definitionNodes, evalGraph?.declaredCoverageStableKeys), DEFINITION_PREVIEW_KINDS, 8);
   const measurementPreview = previewNodes(evalGraph?.measurementNodes, MEASUREMENT_PREVIEW_KINDS, 8);
   const previewMermaidLines = [
     ...definitionPreview.visible.flatMap((node, index) => [
@@ -1979,7 +1979,7 @@ function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string
     `| doctor | ${doctorStatus} | ${doctor ? `${doctor.nodeCount} nodes / ${doctor.edgeCount} edges` : (zh ? '无 graph' : 'no graph')} |`,
     `| eval | ${evalStatus} | ${evalGraph ? `${zh ? 'variant 子图' : 'variant subgraph'}: ${evalGraph.nodeCount} nodes / ${evalGraph.edgeCount} edges` : (zh ? '无 graph' : 'no graph')} |`,
     `| observe | ${observeStatus} | ${zh ? '未接 production graph' : 'production graph not connected'} |`,
-    ...(coverageSummary ? ['', zh ? '### 覆盖锚点' : '### Coverage Anchors', '', coverageSummary] : []),
+    ...(coverageSummary ? ['', zh ? '### 声明锚点' : '### Declared Anchors', '', coverageSummary] : []),
     '',
     zh ? '### 关键计数' : '### Key Counts',
     '',
@@ -2007,9 +2007,9 @@ function renderSkillMapSection(entry: SkillIndexEntry, lang: Lang): string {
   const evalGraph = graph.eval;
   const band = skillMapBand(entry);
   const markdown = renderSkillEvidenceMarkdown(entry, lang);
-  const coveredDefinitionNodes = applyDefinitionCoverage(doctor?.definitionNodes, evalGraph?.coveredDefinitionStableKeys);
-  const coverageSummary = skillMapCoverageSummary(doctor, evalGraph, lang);
-  const definitionCandidates = orderedPreviewNodes(coveredDefinitionNodes, DEFINITION_PREVIEW_KINDS, {
+  const definitionNodesWithCoverageDeclarations = applyDefinitionCoverageDeclarations(doctor?.definitionNodes, evalGraph?.declaredCoverageStableKeys);
+  const coverageSummary = skillMapCoverageDeclarationSummary(doctor, evalGraph, lang);
+  const definitionCandidates = orderedPreviewNodes(definitionNodesWithCoverageDeclarations, DEFINITION_PREVIEW_KINDS, {
     reference: 1,
     script: 2,
     workflow: 3,

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -20,6 +20,7 @@ import type {
   SkillDoctorSnapshot,
   SkillEvalSnapshot,
   SkillObserveSnapshot,
+  SkillGraphSnapshot,
   SkillGraphNodePreview,
   Insight,
   InsightIllustration,
@@ -479,6 +480,8 @@ details.si-pass-card[open] > summary > .si-pass-row1::before { content:'▾ ' }
 .sm-node--warning { border-color:rgba(217,119,6,.38);background:rgba(217,119,6,.07) }
 .sm-node--failed { border-color:rgba(220,38,38,.38);background:rgba(220,38,38,.06) }
 .sm-node--pending,.sm-node--more { border-style:dashed;background:rgba(248,249,251,.94);color:#637083 }
+.sm-node--covered { border-color:rgba(31,157,99,.42);box-shadow:0 10px 24px rgba(31,157,99,.08) }
+.sm-node--not-covered { border-style:dashed;background:rgba(248,249,251,.94);color:#637083 }
 .sm-node-title { font-size:12.2px;font-weight:700;color:#182033;line-height:1.28;word-break:break-word;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden }
 .sm-node--skill .sm-node-title { font-size:15px;line-height:1.2 }
 .sm-node-meta { font-size:10.5px;color:#637083;line-height:1.35;word-break:break-word }
@@ -1060,10 +1063,24 @@ const SKILL_MAP_INIT_SCRIPT = `
         var isLeaf = el.getAttribute('data-sm-leaf') === '1';
         var overflowGroup = el.getAttribute('data-sm-overflow-group');
         var shouldHide = !layers[layer] || (isLeaf && !showLeaves) || !overflowGroupExpanded(overflowGroup);
+        el.setAttribute('data-sm-filter-hidden', shouldHide ? '1' : '0');
         el.hidden = shouldHide;
         el.toggleAttribute('hidden', shouldHide);
         el.setAttribute('aria-hidden', shouldHide ? 'true' : 'false');
         el.style.display = shouldHide ? 'none' : '';
+      });
+      map.querySelectorAll('[data-sm-edge-to]').forEach(function(edge){
+        var toId = edge.getAttribute('data-sm-edge-to');
+        var fromId = edge.getAttribute('data-sm-edge-from-node');
+        var toNode = toId ? graph.querySelector('[data-sm-node-id="' + toId + '"]') : null;
+        var fromNode = fromId ? graph.querySelector('[data-sm-node-id="' + fromId + '"]') : null;
+        var filterHidden = edge.getAttribute('data-sm-filter-hidden') === '1';
+        var endpointHidden = (toNode && toNode.hidden) || (fromNode && fromNode.hidden);
+        var shouldHideEdge = filterHidden || endpointHidden;
+        edge.hidden = shouldHideEdge;
+        edge.toggleAttribute('hidden', shouldHideEdge);
+        edge.setAttribute('aria-hidden', shouldHideEdge ? 'true' : 'false');
+        edge.style.display = shouldHideEdge ? 'none' : '';
       });
     }
 
@@ -1754,13 +1771,26 @@ function graphNodeStatusClass(node: SkillGraphNodePreview): string {
   return node.status && SKILL_MAP_STATUS_CLASSES.has(node.status) ? ` sm-node--${node.status}` : '';
 }
 
+function graphNodeCoverageClass(node: SkillGraphNodePreview): string {
+  if (node.coverage === 'covered') return ' sm-node--covered';
+  if (node.coverage === 'not_covered') return ' sm-node--not-covered';
+  return '';
+}
+
+function graphNodeCoverageLabel(node: SkillGraphNodePreview, lang: Lang): string {
+  if (node.coverage === 'covered') return lang === 'zh' ? '已被用例覆盖' : 'covered by samples';
+  if (node.coverage === 'not_covered') return lang === 'zh' ? '暂无显式覆盖用例' : 'no explicit sample coverage';
+  return '';
+}
+
 function positionedNodeStyle(node: Pick<SkillMapPositionedNode, 'x' | 'y'>): string {
   return `left:${node.x}px;top:${node.y}px`;
 }
 
 function renderSkillMapNode(item: SkillMapPositionedNode, lang: Lang): string {
   const title = graphNodeMapLabel(item.node);
-  const fullTitle = graphNodeDisplayLabel(item.node, lang);
+  const coverageLabel = graphNodeCoverageLabel(item.node, lang);
+  const fullTitle = [graphNodeDisplayLabel(item.node, lang), coverageLabel].filter(Boolean).join(' · ');
   const kindClass = item.node.nodeKind === 'more' ? ' sm-node--more' : '';
   const leaf = item.layer === 'definition' || item.layer === 'measurement' ? ' data-sm-leaf="1"' : '';
   const draggable = item.layer === 'definition' || item.layer === 'measurement' ? ' data-sm-draggable="1"' : '';
@@ -1768,7 +1798,7 @@ function renderSkillMapNode(item: SkillMapPositionedNode, lang: Lang): string {
   const moreToggle = item.moreToggle
     ? ` data-sm-more-toggle="${item.moreToggle.group}" data-sm-collapsed-label="${e(item.moreToggle.collapsedLabel)}" data-sm-expanded-label="${e(item.moreToggle.expandedLabel)}" role="button" tabindex="0" aria-expanded="false"`
     : '';
-  return `<div class="sm-node sm-node--${item.layer}${kindClass}${graphNodeStatusClass(item.node)}" data-sm-node-id="${e(item.id)}" data-sm-layer="${item.layer}" data-sm-x="${item.x}" data-sm-y="${item.y}" data-sm-origin-x="${item.x}" data-sm-origin-y="${item.y}"${leaf}${draggable}${overflow}${moreToggle} style="${positionedNodeStyle(item)}" title="${e(fullTitle)}">
+  return `<div class="sm-node sm-node--${item.layer}${kindClass}${graphNodeStatusClass(item.node)}${graphNodeCoverageClass(item.node)}" data-sm-node-id="${e(item.id)}" data-sm-layer="${item.layer}" data-sm-x="${item.x}" data-sm-y="${item.y}" data-sm-origin-x="${item.x}" data-sm-origin-y="${item.y}"${leaf}${draggable}${overflow}${moreToggle} style="${positionedNodeStyle(item)}" title="${e(fullTitle)}">
     <div class="sm-node-kind">${e(nodeKindLabel(item.node.nodeKind, lang))}</div>
     <div class="sm-node-title">${e(title)}</div>
   </div>`;
@@ -1865,6 +1895,34 @@ function orderedPreviewNodes(
     .map(({ node }) => node);
 }
 
+function applyDefinitionCoverage(
+  nodes: SkillGraphNodePreview[] | undefined,
+  coveredStableKeys: string[] | undefined,
+): SkillGraphNodePreview[] | undefined {
+  if (!nodes) return undefined;
+  if (!coveredStableKeys || coveredStableKeys.length === 0) return nodes;
+  const covered = new Set(coveredStableKeys);
+  return nodes.map((node) => {
+    if (!node.stableKey || !DEFINITION_PREVIEW_KINDS.has(node.nodeKind)) return node;
+    return { ...node, coverage: covered.has(node.stableKey) ? 'covered' : 'not_covered' };
+  });
+}
+
+function skillMapCoverageSummary(
+  doctor: NonNullable<SkillGraphSnapshot['doctor']> | undefined,
+  evalGraph: NonNullable<SkillGraphSnapshot['eval']> | undefined,
+  lang: Lang,
+): string | null {
+  const coveredKeys = new Set(evalGraph?.coveredDefinitionStableKeys ?? []);
+  if (!doctor || coveredKeys.size === 0) return null;
+  const coverable = doctor.definitionNodes.filter((node) => node.stableKey && DEFINITION_PREVIEW_KINDS.has(node.nodeKind));
+  if (coverable.length === 0) return null;
+  const coveredCount = coverable.filter((node) => node.stableKey && coveredKeys.has(node.stableKey)).length;
+  return lang === 'zh'
+    ? `覆盖锚点 ${coveredCount}/${coverable.length}`
+    : `coverage anchors ${coveredCount}/${coverable.length}`;
+}
+
 function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string {
   const zh = lang === 'zh';
   const graph = entry.graph;
@@ -1884,7 +1942,8 @@ function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string
     !entry.eval ? `- ${zh ? '测量效果' : 'Measure impact'}${stepSeparator} \`omk eval --control baseline --treatment ${sourceArg}\`` : '',
     !entry.observe ? `- ${zh ? '接入观察' : 'Add observation'}${stepSeparator} \`omk observe ingest <trace-dir>\`` : '',
   ].filter(Boolean);
-  const definitionPreview = previewNodes(doctor?.definitionNodes, DEFINITION_PREVIEW_KINDS, 8);
+  const coverageSummary = skillMapCoverageSummary(doctor, evalGraph, lang);
+  const definitionPreview = previewNodes(applyDefinitionCoverage(doctor?.definitionNodes, evalGraph?.coveredDefinitionStableKeys), DEFINITION_PREVIEW_KINDS, 8);
   const measurementPreview = previewNodes(evalGraph?.measurementNodes, MEASUREMENT_PREVIEW_KINDS, 8);
   const previewMermaidLines = [
     ...definitionPreview.visible.flatMap((node, index) => [
@@ -1920,6 +1979,7 @@ function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string
     `| doctor | ${doctorStatus} | ${doctor ? `${doctor.nodeCount} nodes / ${doctor.edgeCount} edges` : (zh ? '无 graph' : 'no graph')} |`,
     `| eval | ${evalStatus} | ${evalGraph ? `${zh ? 'variant 子图' : 'variant subgraph'}: ${evalGraph.nodeCount} nodes / ${evalGraph.edgeCount} edges` : (zh ? '无 graph' : 'no graph')} |`,
     `| observe | ${observeStatus} | ${zh ? '未接 production graph' : 'production graph not connected'} |`,
+    ...(coverageSummary ? ['', zh ? '### 覆盖锚点' : '### Coverage Anchors', '', coverageSummary] : []),
     '',
     zh ? '### 关键计数' : '### Key Counts',
     '',
@@ -1947,7 +2007,9 @@ function renderSkillMapSection(entry: SkillIndexEntry, lang: Lang): string {
   const evalGraph = graph.eval;
   const band = skillMapBand(entry);
   const markdown = renderSkillEvidenceMarkdown(entry, lang);
-  const definitionCandidates = orderedPreviewNodes(doctor?.definitionNodes, DEFINITION_PREVIEW_KINDS, {
+  const coveredDefinitionNodes = applyDefinitionCoverage(doctor?.definitionNodes, evalGraph?.coveredDefinitionStableKeys);
+  const coverageSummary = skillMapCoverageSummary(doctor, evalGraph, lang);
+  const definitionCandidates = orderedPreviewNodes(coveredDefinitionNodes, DEFINITION_PREVIEW_KINDS, {
     reference: 1,
     script: 2,
     workflow: 3,
@@ -2024,10 +2086,15 @@ function renderSkillMapSection(entry: SkillIndexEntry, lang: Lang): string {
   ];
   const mapNodes = [...definitionNodes, ...measurementNodes];
   const mapDimensions = skillMapDimensions(mapNodes);
+  const topMeta = [
+    coverageSummary,
+    !coverageSummary && doctor ? `${doctor.nodeCount} ${zh ? '结构节点' : 'definition nodes'}` : '',
+    evalGraph ? `${evalGraph.samples} ${zh ? '用例' : 'samples'}` : '',
+  ].filter(Boolean).join(' · ');
   return `<section id="section-skill-map" class="si-sect si-sect--${band} sm-sect">
     <div class="si-sect-h">
       <span class="si-sect-title">🗺 ${zh ? 'Skill Map' : 'Skill Map'}</span>
-      <span class="si-sect-meta">${doctor ? `${doctor.nodeCount} definition nodes` : (zh ? 'definition 未生成' : 'definition missing')} · ${evalGraph ? `${evalGraph.nodeCount} variant subgraph nodes` : (zh ? 'measurement 未生成' : 'measurement missing')}</span>
+      <span class="si-sect-meta">${e(topMeta || (zh ? '图谱数据未生成' : 'graph data missing'))}</span>
     </div>
     <div class="sm-body" data-sm-map data-sm-base-width="${mapDimensions.width}" data-sm-base-height="${mapDimensions.height}" data-sm-root-x="${SKILL_MAP_ROOT.x}" data-sm-root-y="${SKILL_MAP_ROOT.y}">
       ${renderSkillStageRail(entry, lang)}

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -614,7 +614,7 @@ function projectEvalStage(graph: ArtifactGraphDocument, path: string, entry: Ski
     }
   }
 
-  const coveredDefinitionStableKeys = new Set<string>();
+  const declaredCoverageStableKeys = new Set<string>();
   let coverageEdges = 0;
   for (const edge of graph.edges) {
     if (edge.edgeKind !== 'covers') continue;
@@ -625,7 +625,7 @@ function projectEvalStage(graph: ArtifactGraphDocument, path: string, entry: Ski
     if (artifactHash && nodeArtifactHash(to) !== artifactHash) continue;
     addEdge(edge);
     coverageEdges += 1;
-    if (to.stableKey) coveredDefinitionStableKeys.add(to.stableKey);
+    if (to.stableKey) declaredCoverageStableKeys.add(to.stableKey);
   }
 
   const sampleIds = new Set<string>();
@@ -667,7 +667,7 @@ function projectEvalStage(graph: ArtifactGraphDocument, path: string, entry: Ski
       diagnostics: diagnosticIds.size,
       measurementNodes,
       coverageEdges,
-      coveredDefinitionStableKeys: [...coveredDefinitionStableKeys].sort(),
+      declaredCoverageStableKeys: [...declaredCoverageStableKeys].sort(),
     },
     ...(artifactHash ? { artifactHash } : {}),
     ...(sourceLocator ? { sourceLocator } : {}),

--- a/src/server/skill-index.ts
+++ b/src/server/skill-index.ts
@@ -514,6 +514,7 @@ function countGraphNodes(graph: ArtifactGraphDocument, nodeKind: ArtifactGraphNo
 
 function graphNodePreview(node: ArtifactGraphNode): SkillGraphNodePreview {
   return {
+    stableKey: node.stableKey,
     nodeKind: node.nodeKind,
     label: node.label,
     ...(node.status ? { status: node.status } : {}),
@@ -613,6 +614,20 @@ function projectEvalStage(graph: ArtifactGraphDocument, path: string, entry: Ski
     }
   }
 
+  const coveredDefinitionStableKeys = new Set<string>();
+  let coverageEdges = 0;
+  for (const edge of graph.edges) {
+    if (edge.edgeKind !== 'covers') continue;
+    const from = nodesById.get(edge.fromNodeId);
+    const to = nodesById.get(edge.toNodeId);
+    if (from?.nodeKind !== 'sample' || !to) continue;
+    if (!projectedNodeIds.has(from.id)) continue;
+    if (artifactHash && nodeArtifactHash(to) !== artifactHash) continue;
+    addEdge(edge);
+    coverageEdges += 1;
+    if (to.stableKey) coveredDefinitionStableKeys.add(to.stableKey);
+  }
+
   const sampleIds = new Set<string>();
   const assertionIds = new Set<string>();
   const diagnosticIds = new Set<string>();
@@ -651,6 +666,8 @@ function projectEvalStage(graph: ArtifactGraphDocument, path: string, entry: Ski
       failedAssertionEdges,
       diagnostics: diagnosticIds.size,
       measurementNodes,
+      coverageEdges,
+      coveredDefinitionStableKeys: [...coveredDefinitionStableKeys].sort(),
     },
     ...(artifactHash ? { artifactHash } : {}),
     ...(sourceLocator ? { sourceLocator } : {}),

--- a/src/types/artifact-graph.ts
+++ b/src/types/artifact-graph.ts
@@ -68,7 +68,7 @@ export type ArtifactGraphStatus =
   | 'not_measured';
 
 export interface ArtifactGraphBinding {
-  bindingStrength: 'content-hash' | 'source-locator' | 'runtime-trace' | 'name-only' | 'aggregate';
+  bindingStrength: 'content-hash' | 'source-locator' | 'runtime-trace' | 'name-only' | 'aggregate' | 'explicit';
   keys: Record<string, string>;
 }
 

--- a/src/types/eval.ts
+++ b/src/types/eval.ts
@@ -31,6 +31,24 @@ export type SampleProvenance = 'human' | 'llm-generated' | 'production-trace';
 /** sample 难度等级。简单分桶,跟 IRT 风格 fine-grained difficulty 不同。 */
 export type SampleDifficulty = 'easy' | 'medium' | 'hard';
 
+/** Sample 显式覆盖的 skill 结构锚点。用于 Skill Map / 诊断，不参与 grading / judge / verdict。 */
+export type SampleCoverageTargetKind =
+  | 'skill'
+  | 'skill_file'
+  | 'frontmatter'
+  | 'reference'
+  | 'script'
+  | 'hard_rule'
+  | 'workflow'
+  | 'workflow_node';
+
+export interface SampleCoverageTarget {
+  /** 目标类型。避免裸 kind，保持 Artifact.kind 语义唯一。 */
+  targetKind: SampleCoverageTargetKind;
+  /** 稳定引用：路径或 ID。reference/script 用 skill 根相对路径，workflow_node 用 workflowId.nodeId。 */
+  ref: string;
+}
+
 /** Sample 评测环境前置:声明性"已就绪"清单,LLM 看到后跳过环境探测,直接进入工作流。
  *  类比 unit test 的 fixture / setup —— 评测是测 skill 工作流,不是测环境探测能力。 */
 export interface SampleEnvironment {
@@ -117,6 +135,8 @@ export interface Sample {
    *  curated 用 `'human'`,production trace 抽样用 `'production-trace'`。
    *  纯文档 / 诊断用。 */
   provenance?: SampleProvenance;
+  /** 该 sample 显式覆盖的 skill 结构锚点。纯文档 / 图谱诊断用，不进入评分、评委或 verdict。 */
+  covers?: SampleCoverageTarget[];
   /** 诱错样本(tripwire)标记。true = 此 sample 故意设计成 LLM 应该 fail 的诱导陷阱
    *  (如:用户用错误前提诱导 / 跳步骤 / 用错参数类型),用于测 skill 是否能让 LLM
    *  识破并纠正。Diagnostic 看到 tripwire:true 时会建议"无需改 skill"(rootCause:

--- a/src/types/eval.ts
+++ b/src/types/eval.ts
@@ -31,7 +31,7 @@ export type SampleProvenance = 'human' | 'llm-generated' | 'production-trace';
 /** sample 难度等级。简单分桶,跟 IRT 风格 fine-grained difficulty 不同。 */
 export type SampleDifficulty = 'easy' | 'medium' | 'hard';
 
-/** Sample 显式覆盖的 skill 结构锚点。用于 Skill Map / 诊断，不参与 grading / judge / verdict。 */
+/** Sample 可选声明的 skill 结构锚点。用于 Skill Map / 诊断，不参与 grading / judge / verdict。 */
 export type SampleCoverageTargetKind =
   | 'skill'
   | 'skill_file'
@@ -135,7 +135,7 @@ export interface Sample {
    *  curated 用 `'human'`,production trace 抽样用 `'production-trace'`。
    *  纯文档 / 诊断用。 */
   provenance?: SampleProvenance;
-  /** 该 sample 显式覆盖的 skill 结构锚点。纯文档 / 图谱诊断用，不进入评分、评委或 verdict。 */
+  /** 该 sample 可选声明的 skill 结构锚点。纯文档 / 图谱诊断用，不进入评分、评委或 verdict。 */
   covers?: SampleCoverageTarget[];
   /** 诱错样本(tripwire)标记。true = 此 sample 故意设计成 LLM 应该 fail 的诱导陷阱
    *  (如:用户用错误前提诱导 / 跳步骤 / 用错参数类型),用于测 skill 是否能让 LLM

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -325,7 +325,7 @@ export interface ResultEntry {
  *   - assertions: 期望(运行后的 pass/fail 结果在 VariantResult.assertions.details 里)
  *   - mocks: 工具调用模拟返回(LLM 调到匹配的 tool/参数时拿到这段假返回,而不是真去调外部系统)
  *   - capability / construct / difficulty: 元数据
- *   - covers: sample 显式覆盖的 skill 结构锚点
+ *   - covers: sample 可选声明的 skill 结构锚点
  *   - context: 附加上下文(代码片段等)
  *
  * 旧 report 没有这个字段,renderer 据此 fallback(隐藏单测 tab 或提示"无设计快照")。

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -325,6 +325,7 @@ export interface ResultEntry {
  *   - assertions: 期望(运行后的 pass/fail 结果在 VariantResult.assertions.details 里)
  *   - mocks: 工具调用模拟返回(LLM 调到匹配的 tool/参数时拿到这段假返回,而不是真去调外部系统)
  *   - capability / construct / difficulty: 元数据
+ *   - covers: sample 显式覆盖的 skill 结构锚点
  *   - context: 附加上下文(代码片段等)
  *
  * 旧 report 没有这个字段,renderer 据此 fallback(隐藏单测 tab 或提示"无设计快照")。
@@ -340,6 +341,7 @@ export interface SampleSnapshot {
   difficulty?: import('./eval.js').SampleDifficulty;
   construct?: string;
   provenance?: import('./eval.js').SampleProvenance;
+  covers?: import('./eval.js').SampleCoverageTarget[];
   /** Diagnostic 用 — tripwire sample 不该建议改 skill。 */
   tripwire?: boolean;
 }
@@ -466,7 +468,7 @@ export interface AnalysisResult {
   coverage?: Record<string, KnowledgeCoverage>;
   /** Per-variant knowledge gap reports. See docs/specs/knowledge-gap-signal-spec.md */
   gapReports?: Record<string, GapReport>;
-  /** Sample design science aggregate. Built from sample metadata
+  /** Sample design science aggregate. Built from measurement metadata
    *  (capability / difficulty / construct / provenance); persisted on report
    *  for studio to surface coverage gaps. See docs/specs/sample-design-spec.md. */
   sampleQuality?: SampleQualityAggregate;

--- a/src/types/skill-index.ts
+++ b/src/types/skill-index.ts
@@ -61,7 +61,7 @@ export interface SkillGraphNodePreview {
   nodeKind: string;
   label: string;
   status?: string;
-  coverage?: 'covered' | 'not_covered';
+  coverage?: 'declared' | 'undeclared';
 }
 
 export interface SkillGraphSnapshot {
@@ -85,7 +85,7 @@ export interface SkillGraphSnapshot {
     diagnostics: number;
     measurementNodes: SkillGraphNodePreview[];
     coverageEdges: number;
-    coveredDefinitionStableKeys: string[];
+    declaredCoverageStableKeys: string[];
   };
 }
 

--- a/src/types/skill-index.ts
+++ b/src/types/skill-index.ts
@@ -57,9 +57,11 @@ export interface SkillGraphStageSnapshot {
 }
 
 export interface SkillGraphNodePreview {
+  stableKey?: string;
   nodeKind: string;
   label: string;
   status?: string;
+  coverage?: 'covered' | 'not_covered';
 }
 
 export interface SkillGraphSnapshot {
@@ -82,6 +84,8 @@ export interface SkillGraphSnapshot {
     failedAssertionEdges: number;
     diagnostics: number;
     measurementNodes: SkillGraphNodePreview[];
+    coverageEdges: number;
+    coveredDefinitionStableKeys: string[];
   };
 }
 

--- a/test/artifact-graph/eval-graph.test.ts
+++ b/test/artifact-graph/eval-graph.test.ts
@@ -202,6 +202,35 @@ describe('eval artifact graph', () => {
     assert.ok(!graph.edges.some((edge) => edge.edgeKind === 'covers'));
   });
 
+  it('emits explicit sample covers edges to skill definition anchors', () => {
+    const report = makeReport();
+    report.sampleSnapshots!.s001.covers = [
+      { targetKind: 'reference', ref: './references/release-policy.md' },
+      { targetKind: 'workflow_node', ref: 'release.check' },
+    ];
+
+    const graph = buildEvalArtifactGraph({
+      report,
+      sourcePath: '/tmp/.omk/reports/service-guide.report.json',
+      generatedAt: '2026-06-20T10:30:00.000Z',
+    });
+
+    const coversEdges = graph.edges.filter((edge) => edge.edgeKind === 'covers');
+    assert.equal(coversEdges.length, 2);
+    assert.ok(coversEdges.every((edge) => edge.binding?.bindingStrength === 'explicit'));
+    assert.ok(coversEdges.every((edge) => edge.confidence === 1));
+    assert.ok(graph.nodes.some((node) =>
+      node.nodeKind === 'reference'
+        && node.stableKey === 'v1:reference:skillhash1234:references/release-policy.md',
+    ));
+    assert.ok(graph.nodes.some((node) =>
+      node.nodeKind === 'workflow_node'
+        && node.stableKey === 'v1:workflow-node:skillhash1234:release.check',
+    ));
+    const sampleNode = graph.nodes.find((node) => node.nodeKind === 'sample' && node.label === 's001');
+    assert.equal(sampleNode?.attrs?.display?.coveredTargetCount, 2);
+  });
+
   it('points assertion evidence at eval result details when sample snapshot is absent', () => {
     const report = makeReport();
     report.sampleSnapshots = {};

--- a/test/artifact-graph/eval-graph.test.ts
+++ b/test/artifact-graph/eval-graph.test.ts
@@ -228,7 +228,7 @@ describe('eval artifact graph', () => {
         && node.stableKey === 'v1:workflow-node:skillhash1234:release.check',
     ));
     const sampleNode = graph.nodes.find((node) => node.nodeKind === 'sample' && node.label === 's001');
-    assert.equal(sampleNode?.attrs?.display?.coveredTargetCount, 2);
+    assert.equal(sampleNode?.attrs?.display?.declaredCoverageTargetCount, 2);
   });
 
   it('points assertion evidence at eval result details when sample snapshot is absent', () => {

--- a/test/grading/judge-prompt-isolation.test.ts
+++ b/test/grading/judge-prompt-isolation.test.ts
@@ -6,7 +6,7 @@ import { buildJudgePrompt } from '../../src/grading/judge.js';
  * Defensive test (R11 from sample-design plan).
  *
  * Sample design metadata fields (capability / difficulty / construct / provenance /
- * llm-generated / human / production-trace) are PURE DOCUMENTATION — they must NEVER
+ * covers / llm-generated / human / production-trace) are PURE DOCUMENTATION — they must NEVER
  * leak into the judge prompt because:
  *  - They'd let evaluator (judge) see "this sample is testing necessity" → bias scoring
  *  - They'd violate construct validity (judge should be blind to test design intent)
@@ -28,11 +28,15 @@ describe('buildJudgePrompt — sample metadata isolation', () => {
     'difficulty:',
     'construct:',
     'provenance:',
+    'covers:',
+    'targetKind:',
     'sampleId:',
     '"capability"',         // JSON-style key (double-quoted)
     '"difficulty"',
     '"construct"',
     '"provenance"',
+    '"covers"',
+    '"targetKind"',
     "'capability'",         // single-quoted (less common but possible)
     '"llm-generated"',      // unique enum values that wouldn't appear naturally
     '"production-trace"',

--- a/test/inputs/load-samples.test.ts
+++ b/test/inputs/load-samples.test.ts
@@ -62,7 +62,7 @@ describe('loadSamples', () => {
 
   // sample design metadata fields validation
   describe('sample design metadata', () => {
-    it('接受 capability / difficulty / construct / provenance 4 个新字段', () => {
+    it('接受 capability / difficulty / construct / provenance / covers 字段', () => {
       const p = writeJsonSamples('with-meta.json', [{
         sample_id: 's1',
         prompt: 'p',
@@ -70,12 +70,20 @@ describe('loadSamples', () => {
         difficulty: 'medium',
         construct: 'necessity',
         provenance: 'human',
+        covers: [
+          { targetKind: 'reference', ref: 'references/release.md' },
+          { targetKind: 'workflow_node', ref: 'release.check' },
+        ],
       }]);
       const { samples } = loadSamples(p);
       assert.deepEqual(samples[0].capability, ['api-selection', 'error-diagnosis']);
       assert.equal(samples[0].difficulty, 'medium');
       assert.equal(samples[0].construct, 'necessity');
       assert.equal(samples[0].provenance, 'human');
+      assert.deepEqual(samples[0].covers, [
+        { targetKind: 'reference', ref: 'references/release.md' },
+        { targetKind: 'workflow_node', ref: 'release.check' },
+      ]);
     });
 
     it('老 sample(无新字段)仍正常解析', () => {
@@ -111,6 +119,24 @@ describe('loadSamples', () => {
         file: 'bad-cap-elem.json',
         value: [{ sample_id: 's1', prompt: 'p', capability: ['ok', 123] }],
         error: /capability\[1\] must be a non-empty string/,
+      },
+      {
+        name: 'covers is not array',
+        file: 'bad-covers.json',
+        value: [{ sample_id: 's1', prompt: 'p', covers: 'references/a.md' }],
+        error: /invalid covers.*array/,
+      },
+      {
+        name: 'covers targetKind invalid',
+        file: 'bad-covers-kind.json',
+        value: [{ sample_id: 's1', prompt: 'p', covers: [{ targetKind: 'file', ref: 'references/a.md' }] }],
+        error: /covers\[0\] invalid targetKind/,
+      },
+      {
+        name: 'covers ref empty',
+        file: 'bad-covers-ref.json',
+        value: [{ sample_id: 's1', prompt: 'p', covers: [{ targetKind: 'reference', ref: '' }] }],
+        error: /covers\[0\] invalid ref/,
       },
     ];
 

--- a/test/server/skill-index-graph.test.ts
+++ b/test/server/skill-index-graph.test.ts
@@ -316,7 +316,7 @@ describe('SkillIndex graph projection', () => {
     assert.equal(entry.graph?.eval?.nodeCount, 11);
     assert.equal(entry.graph?.eval?.edgeCount, 12);
     assert.equal(entry.graph?.eval?.coverageEdges, 2);
-    assert.deepEqual(entry.graph?.eval?.coveredDefinitionStableKeys, [
+    assert.deepEqual(entry.graph?.eval?.declaredCoverageStableKeys, [
       'v1:reference:hash-service-guide:references/a.md',
       'v1:workflow:hash-service-guide:release',
     ]);
@@ -350,9 +350,9 @@ describe('SkillIndex graph projection', () => {
     assert.ok(!html.includes('class="sm-bind"'));
     assert.ok(!html.includes('alert(1)'));
     assert.ok(!html.includes('sm-node--ok"'));
-    assert.ok(html.includes('sm-node--covered'));
-    assert.ok(html.includes('sm-node--not-covered'));
-    assert.ok(html.includes('覆盖锚点 2/7'));
+    assert.ok(html.includes('sm-node--coverage-declared'));
+    assert.ok(html.includes('sm-node--coverage-undeclared'));
+    assert.ok(html.includes('声明锚点 2/7'));
     assert.ok(html.includes('background-size:auto,28px 28px,28px 28px,auto'));
     assert.ok(html.includes('outline:4px solid rgba(79,70,229,.07)'));
     assert.ok(html.includes('title="sample: s001"'));

--- a/test/server/skill-index-graph.test.ts
+++ b/test/server/skill-index-graph.test.ts
@@ -231,6 +231,9 @@ function evalGraph(): ArtifactGraphDocument {
       { id: 'er-other', stableKey: 'v1:eval-result:service-guide-20260621T120000-abcd:release-helper:s001', nodeKind: 'eval_result', nodeRole: 'observation', layer: 'measurement', label: 'release-helper / s001' },
       { id: 'diag', stableKey: 'v1:diagnostic:service-guide-20260621T120000-abcd:service-guide:s002', nodeKind: 'diagnostic', nodeRole: 'observation', layer: 'measurement', label: 'diagnostic: service-guide / s002' },
       { id: 'diag-other', stableKey: 'v1:diagnostic:service-guide-20260621T120000-abcd:release-helper:s001', nodeKind: 'diagnostic', nodeRole: 'observation', layer: 'measurement', label: 'diagnostic: release-helper / s001' },
+      { id: 'cover-ref', stableKey: 'v1:reference:hash-service-guide:references/a.md', nodeKind: 'reference', nodeRole: 'entity', layer: 'measurement', label: 'references/a.md', binding: { bindingStrength: 'content-hash', keys: { artifactHash: 'hash-service-guide' } } },
+      { id: 'cover-workflow', stableKey: 'v1:workflow:hash-service-guide:release', nodeKind: 'workflow', nodeRole: 'entity', layer: 'measurement', label: 'release', binding: { bindingStrength: 'content-hash', keys: { artifactHash: 'hash-service-guide' } } },
+      { id: 'cover-other', stableKey: 'v1:reference:hash-release-helper:references/a.md', nodeKind: 'reference', nodeRole: 'entity', layer: 'measurement', label: 'references/a.md', binding: { bindingStrength: 'content-hash', keys: { artifactHash: 'hash-release-helper' } } },
     ],
     edges: [
       { id: 'e1', fromNodeId: 'variant', toNodeId: 'skill', edgeKind: 'derived_from', layer: 'measurement' },
@@ -249,6 +252,9 @@ function evalGraph(): ArtifactGraphDocument {
       { id: 'e14', fromNodeId: 'er-other', toNodeId: 's001', edgeKind: 'evaluates', layer: 'measurement' },
       { id: 'e15', fromNodeId: 'er-other', toNodeId: 'a3', edgeKind: 'fails', layer: 'measurement', status: 'failed' },
       { id: 'e16', fromNodeId: 'diag-other', toNodeId: 'er-other', edgeKind: 'diagnoses', layer: 'measurement', status: 'failed' },
+      { id: 'e17', fromNodeId: 's001', toNodeId: 'cover-ref', edgeKind: 'covers', layer: 'measurement', binding: { bindingStrength: 'explicit', keys: { sampleId: 's001', targetKind: 'reference', targetRef: 'references/a.md', artifactHash: 'hash-service-guide' } } },
+      { id: 'e18', fromNodeId: 's002', toNodeId: 'cover-workflow', edgeKind: 'covers', layer: 'measurement', binding: { bindingStrength: 'explicit', keys: { sampleId: 's002', targetKind: 'workflow', targetRef: 'release', artifactHash: 'hash-service-guide' } } },
+      { id: 'e19', fromNodeId: 's001', toNodeId: 'cover-other', edgeKind: 'covers', layer: 'measurement', binding: { bindingStrength: 'explicit', keys: { sampleId: 's001', targetKind: 'reference', targetRef: 'references/a.md', artifactHash: 'hash-release-helper' } } },
     ],
   };
 }
@@ -307,8 +313,13 @@ describe('SkillIndex graph projection', () => {
     assert.equal(entry.graph?.eval?.failedAssertionEdges, 1);
     assert.equal(entry.graph?.eval?.diagnostics, 1);
     assert.equal(entry.graph?.eval?.variantName, 'service-guide');
-    assert.equal(entry.graph?.eval?.nodeCount, 9);
-    assert.equal(entry.graph?.eval?.edgeCount, 10);
+    assert.equal(entry.graph?.eval?.nodeCount, 11);
+    assert.equal(entry.graph?.eval?.edgeCount, 12);
+    assert.equal(entry.graph?.eval?.coverageEdges, 2);
+    assert.deepEqual(entry.graph?.eval?.coveredDefinitionStableKeys, [
+      'v1:reference:hash-service-guide:references/a.md',
+      'v1:workflow:hash-service-guide:release',
+    ]);
 
     const html = renderSkillDetail(entry, report, 'zh');
     assert.match(html, /Skill Map/);
@@ -339,6 +350,9 @@ describe('SkillIndex graph projection', () => {
     assert.ok(!html.includes('class="sm-bind"'));
     assert.ok(!html.includes('alert(1)'));
     assert.ok(!html.includes('sm-node--ok"'));
+    assert.ok(html.includes('sm-node--covered'));
+    assert.ok(html.includes('sm-node--not-covered'));
+    assert.ok(html.includes('覆盖锚点 2/7'));
     assert.ok(html.includes('background-size:auto,28px 28px,28px 28px,auto'));
     assert.ok(html.includes('outline:4px solid rgba(79,70,229,.07)'));
     assert.ok(html.includes('title="sample: s001"'));


### PR DESCRIPTION
## 用户影响

- 新增 `Sample.covers`，让评测用例可以可选声明它与 SKILL.md 结构锚点的关系，包括 reference、script、hard rule、workflow 和 workflow node。
- eval 图谱会把这些声明写成显式 `covers` 边，Studio Skill Map 会据此标出已声明 / 未声明的结构锚点；不写只表示尚未声明，不代表没有测到。
- 隐藏节点类型或叶子节点时，相关边会一起隐藏，避免图里残留无端点连线。

## 迁移说明

- 现有 sample 文件无需迁移；不写 `covers` 时行为与之前一致，不会自动推断声明关系。
- 建议先给关键用例、关键 reference / workflow / hard rule 补充 `covers`，不要求一次性维护全量结构边界。
- 新字段格式为 `{ "targetKind": "reference", "ref": "references/foo.md" }`，其中路径使用 skill 根目录相对路径，workflow node 使用 `workflowId.nodeId`。

## 测量学 caveat

- `covers` 只用于图谱诊断和测试设计盲区展示，不进入 grading、评委 prompt、verdict 或 sample 指纹，因此不会改变历史报告的分数可比性。

Relates #280
