### PR TITLE
refactor(studio): 使用图谱摘要命名并补充声明锚点样例

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@
 
 ## 怎么选
 
-- 想理解「知识图谱」需要哪些输入，从 `skill-map-showcase` 开始。当前 main 会先展示 doctor 体检产物；启用 Skill Information Graph 的构建里，同一条 doctor 命令还会生成图谱 sidecar 和 Markdown 证据卡片。
+- 想理解「知识图谱」需要哪些输入，从 `skill-map-showcase` 开始。当前 main 会先展示 doctor 体检产物；启用 Skill Information Graph 的构建里，同一条 doctor 命令还会生成图谱 sidecar 和 Markdown 图谱摘要。
 - 只想确认本机 CLI、样本加载、executor 协议、报告写入都正常，先跑 `custom-executor`。
 - 要向同事解释 omk 的「固定模型，只改知识载体」对照实验模型，用 `code-review-ab`。
 - 你的 artifact 负责基于检索上下文回答问题，用 `rag-eval`。

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@
 
 ## 怎么选
 
-- 想理解「知识图谱」需要哪些输入，从 `skill-map-showcase` 开始。当前 main 会先展示 doctor 体检产物；启用 Skill Information Graph 的构建里，同一条 doctor 命令还会生成图谱 sidecar 和 Markdown Evidence Card。
+- 想理解「知识图谱」需要哪些输入，从 `skill-map-showcase` 开始。当前 main 会先展示 doctor 体检产物；启用 Skill Information Graph 的构建里，同一条 doctor 命令还会生成图谱 sidecar 和 Markdown 证据卡片。
 - 只想确认本机 CLI、样本加载、executor 协议、报告写入都正常，先跑 `custom-executor`。
 - 要向同事解释 omk 的「固定模型，只改知识载体」对照实验模型，用 `code-review-ab`。
 - 你的 artifact 负责基于检索上下文回答问题，用 `rag-eval`。

--- a/examples/skill-map-showcase/README.md
+++ b/examples/skill-map-showcase/README.md
@@ -26,7 +26,7 @@ omk doctor skills/release-readiness --static-only
 - `.omk/graphs/doctor/<skill>-<run>.graph.json`
 - `.omk/graphs/doctor/<skill>-<run>.card.md`
 
-Markdown 文件是可分享的 Evidence Card。它应该展示 references、scripts、workflows、workflow nodes、sample count 和 doctor status。
+Markdown 文件是可分享的证据卡片。它应该展示 references、scripts、workflows、workflow nodes、sample count 和 doctor status。
 
 继续进入评测前，先预览任务计划：
 

--- a/examples/skill-map-showcase/README.md
+++ b/examples/skill-map-showcase/README.md
@@ -9,6 +9,8 @@ skill 目录包含：
 - `scripts/`：存放确定性的 preflight 检查脚本
 - `.omk/samples.json`：随 skill 一起分发的评测用例
 
+`.omk/samples.json` 也演示了 `covers` 的推荐用法：只给关键用例声明它主要触达的 reference、hard rule、workflow 或 workflow node。它不是全量维护清单；未声明只表示 Skill Map 里暂时没有这条显式结构边，不代表该节点一定没有被测到。
+
 先跑静态 doctor：
 
 ```bash
@@ -31,3 +33,5 @@ Markdown 文件是可分享的 Evidence Card。它应该展示 references、scri
 ```bash
 omk eval --control baseline --treatment release-readiness --dry-run
 ```
+
+真正跑完 eval 后，Studio 的 Skill Map 会把 sample 里的 `covers` 渲染成声明锚点。你应该能看到 release 决策用例连到 `release-review`、release policy 和 rollback runbook；线上事故用例连到 `incident-response` workflow 和 rollback runbook。

--- a/examples/skill-map-showcase/README.md
+++ b/examples/skill-map-showcase/README.md
@@ -26,7 +26,7 @@ omk doctor skills/release-readiness --static-only
 - `.omk/graphs/doctor/<skill>-<run>.graph.json`
 - `.omk/graphs/doctor/<skill>-<run>.card.md`
 
-Markdown 文件是可分享的证据卡片。它应该展示 references、scripts、workflows、workflow nodes、sample count 和 doctor status。
+Markdown 文件是可分享的图谱摘要。它应该展示 references、scripts、workflows、workflow nodes、sample count 和 doctor status。
 
 继续进入评测前，先预览任务计划：
 

--- a/examples/skill-map-showcase/skills/release-readiness/.omk/samples.json
+++ b/examples/skill-map-showcase/skills/release-readiness/.omk/samples.json
@@ -15,7 +15,37 @@
       }
     ],
     "capability": ["release-readiness", "risk-review"],
-    "construct": "capability"
+    "construct": "capability",
+    "covers": [
+      {
+        "targetKind": "reference",
+        "ref": "references/release-policy.md"
+      },
+      {
+        "targetKind": "reference",
+        "ref": "references/rollback-runbook.md"
+      },
+      {
+        "targetKind": "hard_rule",
+        "ref": "cite-release-policy"
+      },
+      {
+        "targetKind": "workflow",
+        "ref": "release-review"
+      },
+      {
+        "targetKind": "workflow_node",
+        "ref": "release-review.check-policy"
+      },
+      {
+        "targetKind": "workflow_node",
+        "ref": "release-review.verify-rollback"
+      },
+      {
+        "targetKind": "workflow_node",
+        "ref": "release-review.decide"
+      }
+    ]
   },
   {
     "sample_id": "missing-rollback",
@@ -28,7 +58,29 @@
       }
     ],
     "capability": ["release-readiness", "rollback"],
-    "construct": "necessity"
+    "construct": "necessity",
+    "covers": [
+      {
+        "targetKind": "reference",
+        "ref": "references/release-policy.md"
+      },
+      {
+        "targetKind": "reference",
+        "ref": "references/rollback-runbook.md"
+      },
+      {
+        "targetKind": "hard_rule",
+        "ref": "rollback-before-ship"
+      },
+      {
+        "targetKind": "workflow_node",
+        "ref": "release-review.verify-rollback"
+      },
+      {
+        "targetKind": "workflow_node",
+        "ref": "release-review.decide"
+      }
+    ]
   },
   {
     "sample_id": "post-release-incident",
@@ -41,6 +93,28 @@
       }
     ],
     "capability": ["incident-response", "rollback"],
-    "construct": "quality"
+    "construct": "quality",
+    "covers": [
+      {
+        "targetKind": "reference",
+        "ref": "references/rollback-runbook.md"
+      },
+      {
+        "targetKind": "workflow",
+        "ref": "incident-response"
+      },
+      {
+        "targetKind": "workflow_node",
+        "ref": "incident-response.assess-impact"
+      },
+      {
+        "targetKind": "workflow_node",
+        "ref": "incident-response.trigger-rollback"
+      },
+      {
+        "targetKind": "workflow_node",
+        "ref": "incident-response.communicate"
+      }
+    ]
   }
 ]

--- a/src/artifact-graph/doctor.ts
+++ b/src/artifact-graph/doctor.ts
@@ -671,7 +671,7 @@ export function renderDoctorEvidenceCard(graph: ArtifactGraphDocument, skill: Do
   const hiddenStructure = renderStructureDetails(graph, lang);
 
   return [
-    `## ${zh ? '知识证据卡片' : 'Skill Evidence Card'}${zh ? '：' : ': '}${skill.skillName}`,
+    `## ${zh ? '知识图谱摘要' : 'Skill Map Summary'}${zh ? '：' : ': '}${skill.skillName}`,
     '',
     statusSentence,
     '',

--- a/src/artifact-graph/doctor.ts
+++ b/src/artifact-graph/doctor.ts
@@ -671,7 +671,7 @@ export function renderDoctorEvidenceCard(graph: ArtifactGraphDocument, skill: Do
   const hiddenStructure = renderStructureDetails(graph, lang);
 
   return [
-    `## ${zh ? 'Skill Evidence Card' : 'Skill Evidence Card'}：${skill.skillName}`,
+    `## ${zh ? '知识证据卡片' : 'Skill Evidence Card'}${zh ? '：' : ': '}${skill.skillName}`,
     '',
     statusSentence,
     '',

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -1964,7 +1964,7 @@ function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string
   ];
 
   return [
-    `## ${zh ? '知识证据卡片' : 'Skill Evidence Card'}${zh ? '：' : ': '}${entry.skillName}`,
+    `## ${zh ? '知识图谱摘要' : 'Skill Map Summary'}${zh ? '：' : ': '}${entry.skillName}`,
     '',
     summary,
     '',
@@ -2131,7 +2131,7 @@ function renderSkillMapSection(entry: SkillIndexEntry, lang: Lang): string {
         </div>
       </div>
       <details class="sm-card">
-        <summary>${zh ? '复制证据卡片' : 'Copy Markdown Evidence Card'}</summary>
+        <summary>${zh ? '复制图谱摘要' : 'Copy Skill Map Summary'}</summary>
         <textarea readonly>${e(markdown)}</textarea>
       </details>
     </div>

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -1778,8 +1778,8 @@ function graphNodeCoverageClass(node: SkillGraphNodePreview): string {
 }
 
 function graphNodeCoverageLabel(node: SkillGraphNodePreview, lang: Lang): string {
-  if (node.coverage === 'declared') return lang === 'zh' ? '已声明覆盖关系' : 'declared coverage';
-  if (node.coverage === 'undeclared') return lang === 'zh' ? '未声明覆盖关系' : 'coverage not declared';
+  if (node.coverage === 'declared') return lang === 'zh' ? '已由评测用例声明' : 'declared by eval samples';
+  if (node.coverage === 'undeclared') return lang === 'zh' ? '尚未由评测用例声明' : 'not declared by eval samples';
   return '';
 }
 
@@ -1920,14 +1920,14 @@ function skillMapCoverageDeclarationSummary(
   const declaredCount = coverable.filter((node) => node.stableKey && declaredKeys.has(node.stableKey)).length;
   const samples = evalGraph?.samples ?? 0;
   return lang === 'zh'
-    ? `${samples} 条用例声明了 ${declaredCount}/${coverable.length} 个结构节点`
-    : `${samples} samples declared ${declaredCount}/${coverable.length} structure nodes`;
+    ? `${samples} 条评测用例声明了 ${declaredCount}/${coverable.length} 个结构节点`
+    : `${samples} eval samples declared ${declaredCount}/${coverable.length} structure nodes`;
 }
 
 function skillMapCoverageDeclarationHint(lang: Lang): string {
   return lang === 'zh'
-    ? '这些声明来自 sample.covers，用于说明用例主要触达哪些 reference、hard rule 或 workflow；未声明不代表没有测到。'
-    : 'These declarations come from sample.covers and show which references, hard rules, or workflows the samples intentionally target; undeclared does not mean untested.';
+    ? '这些关系来自 sample.covers，表示评测用例显式标注的主要触达节点；尚未声明只表示还没有被评测用例显式标注，不应直接视为测试缺口。'
+    : 'These relationships come from sample.covers and show the main nodes explicitly annotated by eval samples; not declared only means not explicitly annotated yet, not necessarily a test gap.';
 }
 
 function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string {

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -1964,7 +1964,7 @@ function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string
   ];
 
   return [
-    `## Skill Evidence Card：${entry.skillName}`,
+    `## ${zh ? '知识证据卡片' : 'Skill Evidence Card'}${zh ? '：' : ': '}${entry.skillName}`,
     '',
     summary,
     '',
@@ -2131,7 +2131,7 @@ function renderSkillMapSection(entry: SkillIndexEntry, lang: Lang): string {
         </div>
       </div>
       <details class="sm-card">
-        <summary>${zh ? '复制 Markdown Evidence Card' : 'Copy Markdown Evidence Card'}</summary>
+        <summary>${zh ? '复制证据卡片' : 'Copy Markdown Evidence Card'}</summary>
         <textarea readonly>${e(markdown)}</textarea>
       </details>
     </div>

--- a/src/renderer/skill-detail-renderer.ts
+++ b/src/renderer/skill-detail-renderer.ts
@@ -1918,9 +1918,16 @@ function skillMapCoverageDeclarationSummary(
   const coverable = doctor.definitionNodes.filter((node) => node.stableKey && DEFINITION_PREVIEW_KINDS.has(node.nodeKind));
   if (coverable.length === 0) return null;
   const declaredCount = coverable.filter((node) => node.stableKey && declaredKeys.has(node.stableKey)).length;
+  const samples = evalGraph?.samples ?? 0;
   return lang === 'zh'
-    ? `声明锚点 ${declaredCount}/${coverable.length}`
-    : `declared anchors ${declaredCount}/${coverable.length}`;
+    ? `${samples} 条用例声明了 ${declaredCount}/${coverable.length} 个结构节点`
+    : `${samples} samples declared ${declaredCount}/${coverable.length} structure nodes`;
+}
+
+function skillMapCoverageDeclarationHint(lang: Lang): string {
+  return lang === 'zh'
+    ? '这些声明来自 sample.covers，用于说明用例主要触达哪些 reference、hard rule 或 workflow；未声明不代表没有测到。'
+    : 'These declarations come from sample.covers and show which references, hard rules, or workflows the samples intentionally target; undeclared does not mean untested.';
 }
 
 function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string {
@@ -1979,7 +1986,7 @@ function renderSkillEvidenceMarkdown(entry: SkillIndexEntry, lang: Lang): string
     `| doctor | ${doctorStatus} | ${doctor ? `${doctor.nodeCount} nodes / ${doctor.edgeCount} edges` : (zh ? '无 graph' : 'no graph')} |`,
     `| eval | ${evalStatus} | ${evalGraph ? `${zh ? 'variant 子图' : 'variant subgraph'}: ${evalGraph.nodeCount} nodes / ${evalGraph.edgeCount} edges` : (zh ? '无 graph' : 'no graph')} |`,
     `| observe | ${observeStatus} | ${zh ? '未接 production graph' : 'production graph not connected'} |`,
-    ...(coverageSummary ? ['', zh ? '### 声明锚点' : '### Declared Anchors', '', coverageSummary] : []),
+    ...(coverageSummary ? ['', zh ? '### 声明锚点' : '### Declared Anchors', '', coverageSummary, '', skillMapCoverageDeclarationHint(lang)] : []),
     '',
     zh ? '### 关键计数' : '### Key Counts',
     '',
@@ -2089,7 +2096,7 @@ function renderSkillMapSection(entry: SkillIndexEntry, lang: Lang): string {
   const topMeta = [
     coverageSummary,
     !coverageSummary && doctor ? `${doctor.nodeCount} ${zh ? '结构节点' : 'definition nodes'}` : '',
-    evalGraph ? `${evalGraph.samples} ${zh ? '用例' : 'samples'}` : '',
+    !coverageSummary && evalGraph ? `${evalGraph.samples} ${zh ? '用例' : 'samples'}` : '',
   ].filter(Boolean).join(' · ');
   return `<section id="section-skill-map" class="si-sect si-sect--${band} sm-sect">
     <div class="si-sect-h">

--- a/src/renderer/skill-list-renderer.ts
+++ b/src/renderer/skill-list-renderer.ts
@@ -110,7 +110,7 @@ function renderPanel(a: Agg, lang: Lang): string {
 
 function renderRow(entry: SkillIndexEntry, insights: Insight[], langQ: string, lang: Lang): string {
   const h = assessHealth(entry, insights, lang);
-  // 点行先进入 skill hub：Skill Map / 三阶段状态 / Evidence Card 是用户第一视角。
+  // 点行先进入 skill hub：Skill Map / 三阶段状态 / 图谱摘要是用户第一视角。
   const href = `/skills/${encodeURIComponent(entry.skillName)}${langQ}`;
   const dT = entry.doctor ? entry.doctor.passCount + entry.doctor.warnCount + entry.doctor.failCount : 0;
   const dP = dT > 0 ? Math.round(((entry.doctor!.passCount + entry.doctor!.warnCount * 0.5) / dT) * 100) : null;

--- a/test/artifact-graph/doctor-graph.test.ts
+++ b/test/artifact-graph/doctor-graph.test.ts
@@ -104,7 +104,7 @@ describe('doctor artifact graph', () => {
       assert.ok(!graph.edges.some((edge) => edge.edgeKind === 'covers'));
 
       const card = renderDoctorEvidenceCard(graph, report.skills[0], 'zh');
-      assert.ok(card.includes('Skill Evidence Card'));
+      assert.ok(card.includes('知识证据卡片'));
       assert.ok(card.includes('doctor 有警告'));
       assert.ok(card.includes('SKILL.md: review-skill'));
       assert.ok(card.includes('file --> refs'));
@@ -150,7 +150,7 @@ describe('doctor artifact graph', () => {
       assert.equal(result.evidenceCardPath, join(doctorGraphDirForDoctorOutput(outputDir), 'review-skill-doctor-test.card.md'));
       const graph = JSON.parse(readFileSync(result.graphPath, 'utf-8')) as { documentKind: string };
       assert.equal(graph.documentKind, 'artifact-graph');
-      assert.ok(readFileSync(result.evidenceCardPath, 'utf-8').includes('Skill Evidence Card'));
+      assert.ok(readFileSync(result.evidenceCardPath, 'utf-8').includes('知识证据卡片'));
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/artifact-graph/doctor-graph.test.ts
+++ b/test/artifact-graph/doctor-graph.test.ts
@@ -104,7 +104,7 @@ describe('doctor artifact graph', () => {
       assert.ok(!graph.edges.some((edge) => edge.edgeKind === 'covers'));
 
       const card = renderDoctorEvidenceCard(graph, report.skills[0], 'zh');
-      assert.ok(card.includes('知识证据卡片'));
+      assert.ok(card.includes('知识图谱摘要'));
       assert.ok(card.includes('doctor 有警告'));
       assert.ok(card.includes('SKILL.md: review-skill'));
       assert.ok(card.includes('file --> refs'));
@@ -150,7 +150,7 @@ describe('doctor artifact graph', () => {
       assert.equal(result.evidenceCardPath, join(doctorGraphDirForDoctorOutput(outputDir), 'review-skill-doctor-test.card.md'));
       const graph = JSON.parse(readFileSync(result.graphPath, 'utf-8')) as { documentKind: string };
       assert.equal(graph.documentKind, 'artifact-graph');
-      assert.ok(readFileSync(result.evidenceCardPath, 'utf-8').includes('知识证据卡片'));
+      assert.ok(readFileSync(result.evidenceCardPath, 'utf-8').includes('知识图谱摘要'));
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -307,7 +307,7 @@ describe('omk doctor CLI', () => {
       assert.ok(graph.nodes.some((node: { nodeKind: string; label: string }) => node.nodeKind === 'reference' && node.label === 'references/rules.md'));
       assert.ok(!graph.edges.some((edge: { edgeKind: string }) => edge.edgeKind === 'covers'));
       const card = readFileSync(join(graphDir, mdFile), 'utf-8');
-      assert.ok(card.includes('Skill Evidence Card'));
+      assert.ok(card.includes('知识证据卡片'));
       assert.ok(card.includes('eval 未测量'));
     } finally {
       rmSync(tmp, { recursive: true, force: true });

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -307,7 +307,7 @@ describe('omk doctor CLI', () => {
       assert.ok(graph.nodes.some((node: { nodeKind: string; label: string }) => node.nodeKind === 'reference' && node.label === 'references/rules.md'));
       assert.ok(!graph.edges.some((edge: { edgeKind: string }) => edge.edgeKind === 'covers'));
       const card = readFileSync(join(graphDir, mdFile), 'utf-8');
-      assert.ok(card.includes('知识证据卡片'));
+      assert.ok(card.includes('知识图谱摘要'));
       assert.ok(card.includes('eval 未测量'));
     } finally {
       rmSync(tmp, { recursive: true, force: true });

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -625,7 +625,7 @@ describe('report-server', () => {
     assert.equal(res.status, 200);
     assert.ok(res.headers['content-type']!.includes('text/html'));
     // 列表页按 skill 聚合,SAMPLE_REPORT 的 variants v1/v2 各成一个 skill 条目;
-    // 点行先进入 skill hub,由 hub 展示 Skill Map / 三阶段状态 / Evidence Card。
+    // 点行先进入 skill hub,由 hub 展示 Skill Map / 三阶段状态 / 图谱摘要。
     // 行跳转走 data-href + 事件委托(非内联 onclick,见 skill-list-renderer)。
     assert.ok(res.body.includes('data-href="/skills/'));
   });

--- a/test/server/skill-index-graph.test.ts
+++ b/test/server/skill-index-graph.test.ts
@@ -323,7 +323,7 @@ describe('SkillIndex graph projection', () => {
 
     const html = renderSkillDetail(entry, report, 'zh');
     assert.match(html, /Skill Map/);
-    assert.match(html, /复制证据卡片/);
+    assert.match(html, /复制图谱摘要/);
     assert.ok(html.includes('class="sm-svg"'));
     assert.ok(html.includes('class="sm-edge sm-edge--definition"'));
     assert.ok(html.includes('class="sm-edge sm-edge--measurement"'));

--- a/test/server/skill-index-graph.test.ts
+++ b/test/server/skill-index-graph.test.ts
@@ -352,8 +352,9 @@ describe('SkillIndex graph projection', () => {
     assert.ok(!html.includes('sm-node--ok"'));
     assert.ok(html.includes('sm-node--coverage-declared'));
     assert.ok(html.includes('sm-node--coverage-undeclared'));
-    assert.ok(html.includes('2 条用例声明了 2/7 个结构节点'));
-    assert.ok(html.includes('这些声明来自 sample.covers'));
+    assert.ok(html.includes('2 条评测用例声明了 2/7 个结构节点'));
+    assert.ok(html.includes('这些关系来自 sample.covers'));
+    assert.ok(html.includes('尚未声明只表示还没有被评测用例显式标注'));
     assert.ok(html.includes('background-size:auto,28px 28px,28px 28px,auto'));
     assert.ok(html.includes('outline:4px solid rgba(79,70,229,.07)'));
     assert.ok(html.includes('title="sample: s001"'));

--- a/test/server/skill-index-graph.test.ts
+++ b/test/server/skill-index-graph.test.ts
@@ -352,7 +352,8 @@ describe('SkillIndex graph projection', () => {
     assert.ok(!html.includes('sm-node--ok"'));
     assert.ok(html.includes('sm-node--coverage-declared'));
     assert.ok(html.includes('sm-node--coverage-undeclared'));
-    assert.ok(html.includes('声明锚点 2/7'));
+    assert.ok(html.includes('2 条用例声明了 2/7 个结构节点'));
+    assert.ok(html.includes('这些声明来自 sample.covers'));
     assert.ok(html.includes('background-size:auto,28px 28px,28px 28px,auto'));
     assert.ok(html.includes('outline:4px solid rgba(79,70,229,.07)'));
     assert.ok(html.includes('title="sample: s001"'));

--- a/test/server/skill-index-graph.test.ts
+++ b/test/server/skill-index-graph.test.ts
@@ -323,7 +323,7 @@ describe('SkillIndex graph projection', () => {
 
     const html = renderSkillDetail(entry, report, 'zh');
     assert.match(html, /Skill Map/);
-    assert.match(html, /复制 Markdown Evidence Card/);
+    assert.match(html, /复制证据卡片/);
     assert.ok(html.includes('class="sm-svg"'));
     assert.ok(html.includes('class="sm-edge sm-edge--definition"'));
     assert.ok(html.includes('class="sm-edge sm-edge--measurement"'));


### PR DESCRIPTION
## 用户影响

- Studio Skill Map 中的可复制内容从「Evidence Card / 证据卡片」统一命名为「图谱摘要 / Skill Map Summary」，中文按钮显示为「复制图谱摘要」，复制出的 Markdown 标题显示为「知识图谱摘要」。
- Skill Map 的声明锚点文案改为「N 条评测用例声明了 N/M 个结构节点」，并补充说明：`sample.covers` 只表示评测用例显式标注的主要触达节点，尚未声明不应直接视为测试缺口。
- `examples/skill-map-showcase` 的 `release-readiness` 样例补充 `Sample.covers`，演示如何低成本声明关键 reference、hard rule、workflow 与 workflow node，方便 dogfood #304 后的 Skill Map 结构边展示。

## 迁移说明

- 不新增命令，不改变 report schema，不改变评分、verdict、sample fingerprint 或任何测量学路径。
- 这是 user-facing Studio UI / Markdown 文案命名调整；已有 `.card.md` 落盘文件名保持不变，只调整新生成内容中的标题与 Studio 按钮文案。
- `sample.covers` 仍是可选声明，不要求用户维护完整覆盖清单；未声明只表示图谱暂无显式标注边。

## 验证

- `git diff --check`
- `yarn lint`
- `yarn build`
- `node node_modules/vitest/vitest.mjs run test/server/skill-index-graph.test.ts test/artifact-graph/doctor-graph.test.ts test/cli/doctor.test.ts test/server/report-server.test.ts`
- `node node_modules/vitest/vitest.mjs run --maxWorkers=1`
- Dogfood：在 `examples/skill-map-showcase` 中跑 `doctor --static-only` 和 no-judge/no-diagnostic echo eval，生成的 eval graph 包含 17 条 `covers` 边；Studio 详情页显示「3 条评测用例声明了 12/15 个结构节点」，并可复制「知识图谱摘要」。

## 测量学 caveat

- 本 PR 只补充样例中的声明锚点和 Studio / Markdown 展示文案，不让 `covers` 进入 grading、评委 prompt、verdict 或新的评分路径。

Relates #280
