### PR TITLE
chore(release): 发布 0.45.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -8,8 +8,9 @@
  * CLI 据此 exit 1 / abort eval。
  */
 
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { runFileSuffix } from '../eval-core/artifact-file-names.js';
 import { discoverVariants, resolveArtifacts } from '../inputs/skill-loader.js';
 import type {
@@ -25,6 +26,8 @@ import type {
 } from '../types/index.js';
 import { DOCTOR_REPORT_SCHEMA_VERSION, isComposerRule } from '../types/doctor.js';
 import { getRegisteredRules } from './rules.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ---------------------------------------------------------------------------
 // Target resolution
@@ -185,9 +188,24 @@ function nextReportId(): string {
   return `doctor-${runFileSuffix()}`;
 }
 
+function findPackageJson(startDir: string): string {
+  let dir = startDir;
+  for (let i = 0; i < 5; i += 1) {
+    const candidate = join(dir, 'package.json');
+    if (existsSync(candidate)) return candidate;
+    dir = dirname(dir);
+  }
+  return join(startDir, '..', 'package.json');
+}
+
 function readCliVersion(): string {
-  // 不依赖 package.json import(避免 type 解析复杂度);用环境变量或退回 'unknown'
-  return process.env.npm_package_version ?? '0.0.0';
+  const envVersion = process.env.npm_package_version;
+  if (envVersion) return envVersion;
+  try {
+    const pkg = JSON.parse(readFileSync(findPackageJson(__dirname), 'utf-8')) as { version?: unknown };
+    if (typeof pkg.version === 'string' && pkg.version.length > 0) return pkg.version;
+  } catch { /* fall through */ }
+  return '0.0.0';
 }
 
 export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -11,6 +11,7 @@ import type { ComposerRule, DoctorRule, DoctorProgressInfo } from '../../src/typ
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const EXAMPLE_SKILLS_DIR = join(__dirname, '..', 'fixtures', 'code-review', 'skills');
+const PACKAGE_VERSION = (JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8')) as { version: string }).version;
 
 const passingRule: DoctorRule = {
   id: 'test_pass',
@@ -354,6 +355,26 @@ describe('runDoctor', () => {
         assert.equal(typeof r.message, 'string');
         assert.equal(typeof r.durationMs, 'number');
       }
+    }
+  });
+
+  it('uses package version when npm package env is absent', async () => {
+    const originalVersion = process.env.npm_package_version;
+    delete process.env.npm_package_version;
+    try {
+      const report = await runDoctor({
+        target: EXAMPLE_SKILLS_DIR,
+        cwd: '/tmp',
+        executorName: 'claude',
+        model: 'sonnet',
+        timeoutMs: 8000,
+        lang: 'zh',
+        rules: [passingRule],
+      });
+      assert.equal(report.cliVersion, PACKAGE_VERSION);
+    } finally {
+      if (originalVersion === undefined) delete process.env.npm_package_version;
+      else process.env.npm_package_version = originalVersion;
     }
   });
 


### PR DESCRIPTION
## 用户影响

- 发布 0.45.0，承接 0.44.0 之后的 Skill Map 增强：用例 `sample.covers` 可以声明触达的结构锚点，Studio 会把声明锚点显示在 Skill Map 中。
- Studio 中可复制内容命名为「图谱摘要 / Skill Map Summary」，降低「Evidence Card / 证据卡片」这类内部术语带来的理解成本。
- `examples/skill-map-showcase` 增加 release-readiness 样例 covers，可作为 doctor → eval → studio 的演示入口。
- 修复 `doctor` 报告在直接运行 CLI 时 `cliVersion` 可能落成 `0.0.0` 的问题，现在会 fallback 读取 package.json 版本，与 eval 报告保持一致。

## 迁移说明

- 不新增命令，不改变 report schema，不改变评分、verdict、sample fingerprint 或评委 prompt。
- `.card.md` 文件名保持不变；只调整新生成 Markdown 内容标题与 Studio 按钮文案。
- `sample.covers` 是可选声明，不要求用户维护完整覆盖清单；未声明只表示图谱没有显式标注边，不应直接视为测试缺口。

## 本次包含

- #300 chore(deps): bump actions/checkout from 4 to 7
- #301 chore(deps): bump the npm-minor-patch group with 7 updates
- #304 feat(studio): 支持用例覆盖结构锚点
- #305 refactor(studio): 使用图谱摘要命名并补充声明锚点样例
- 本 PR：bump 0.45.0，并修复 doctor CLI version fallback

## 验证

- `git diff --check`
- `yarn lint`
- `yarn build`
- `node node_modules/vitest/vitest.mjs run test/doctor/index.test.ts`
- `node node_modules/vitest/vitest.mjs run --maxWorkers=1`（191 files / 2408 tests）
- Dogfood：`examples/skill-map-showcase` 中跑通 `doctor --static-only`、no-judge/no-diagnostic echo eval，并在 Studio 详情页确认「3 条评测用例声明了 12/15 个结构节点」「复制图谱摘要」和 17 条 covers 边。

## 测量学 caveat

- 本次 release 不改变 grading、judge、bootstrap、verdict、length-debias 或任何统计可比性路径。
