### PR TITLE
chore(release): 发布 0.46.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 `0.46.0`，纳入 `v0.45.0` 之后已经合入 `main` 的 Skill Map 展示改进、doctor 多采样共识体检，以及本地测试依赖与 startup 短路径稳定性修复。

## 迁移说明

`doctor` 命令语义已调整为静态规则 + 在线健康审计的组合体检；需要只跑离线静态规则时使用 `--static-only`。历史 `--samples` 入口已移除，多采样使用 `--repeat` 表达。

## 测量学说明

本次 release 包含 doctor 健康审计流程调整，会影响 doctor 诊断输出形态；eval/report 评分 schema 与评分类 prompt 冻结项未在本 release bump 中改动。
