### PR TITLE
feat(cli): 串起 doctor 到 eval 发布判断

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -191,7 +191,7 @@ export default class Doctor extends BaseCommand {
       }
 
       const { runDoctor } = await import('../../doctor/index.js');
-      const { renderDoctorReportText, renderDoctorReportJson } = await import('../../doctor/renderer.js');
+      const { renderDoctorReportText, renderDoctorReportJson, renderDoctorActionPlanText } = await import('../../doctor/renderer.js');
       const { getRegisteredRules } = await import('../../doctor/rules.js');
       const { isComposerRule } = await import('../../types/doctor.js');
       // 默认:静态规则 + 在线检查(LLM health composer + endpoint 自定义维度 external=true)。
@@ -252,6 +252,7 @@ export default class Doctor extends BaseCommand {
             ? `doctor failed: ${report.totals.fail} 个 skill 未通过 (${report.totals.warn} warn / ${report.totals.pass} pass)`
             : `doctor failed: ${report.totals.fail} skills did not pass (${report.totals.warn} warn / ${report.totals.pass} pass)`;
           console.error(summary);
+          process.stderr.write(renderDoctorActionPlanText(report, lang));
         }
       } else {
         renderDoctorReportText(report, lang);

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -210,10 +210,10 @@ async function emitBatchVerdict(
   }
   const next = lang === 'zh'
     ? (failed === 0
-      ? '全部通过，可以把这些报告作为发布证据；如果是受管 skill，可以继续 promote。'
+      ? '全部通过，可以进入发布流程：请留存这些报告作为发布证据；如果是受管 skill，再运行 `omk promote`。'
       : '先处理未通过的 skill；逐个打开对应报告，看最差层和失败用例后再重跑。')
     : (failed === 0
-      ? 'all skills passed; keep these reports as release evidence, and promote managed skills when ready.'
+      ? 'all skills passed and are ready for release: keep these reports as release evidence; for managed skills, run `omk promote`.'
       : 'fix the failing skills first; open each report, inspect the weakest layer and failing samples, then re-run.');
   emitVerdictText(tCli('cli.run.batch_verdict_next_step', lang, { next }));
   return failed === 0 ? 0 : 1;

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -208,6 +208,14 @@ async function emitBatchVerdict(
   for (const result of results) {
     emitVerdictText(`  ${result.verdict.level}: ${result.treatment} — ${result.verdict.headline}`);
   }
+  const next = lang === 'zh'
+    ? (failed === 0
+      ? '全部通过，可以把这些报告作为发布证据；如果是受管 skill，可以继续 promote。'
+      : '先处理未通过的 skill；逐个打开对应报告，看最差层和失败用例后再重跑。')
+    : (failed === 0
+      ? 'all skills passed; keep these reports as release evidence, and promote managed skills when ready.'
+      : 'fix the failing skills first; open each report, inspect the weakest layer and failing samples, then re-run.');
+  emitVerdictText(tCli('cli.run.batch_verdict_next_step', lang, { next }));
   return failed === 0 ? 0 : 1;
 }
 

--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -23,6 +23,7 @@ export type RunMessageKey =
   | 'cli.run.run_section'
   | 'cli.run.batch_complete'
   | 'cli.run.batch_verdict_header'
+  | 'cli.run.batch_verdict_next_step'
   | 'cli.run.batch_child_report_missing'
   | 'cli.run.eval_complete'
   | 'cli.run.tally'
@@ -128,6 +129,10 @@ export const runDict: Record<RunMessageKey, CliMessage> = {
   'cli.run.batch_verdict_header': {
     zh: '批量评测结论：{status}（{passed}/{total} 通过）',
     en: 'Batch verdict: {status} ({passed}/{total} passed)',
+  },
+  'cli.run.batch_verdict_next_step': {
+    zh: '  下一步：{next}',
+    en: '  Next: {next}',
   },
   'cli.run.batch_child_report_missing': {
     zh: '⚠ 子报告缺失：{id}，将按不可 ship 处理。\n',

--- a/src/doctor/renderer.ts
+++ b/src/doctor/renderer.ts
@@ -55,6 +55,83 @@ function renderRuleLine(result: DoctorRuleResult, ruleLabel: string, lang: Lang,
   return line;
 }
 
+interface DoctorRepairItem {
+  skillName: string;
+  status: DoctorRuleStatus;
+  label: string;
+  action: string;
+  isSummary: boolean;
+}
+
+function compactActionText(text: string | undefined): string {
+  return (text ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function collectDoctorRepairItems(report: DoctorReport, lang: Lang): { items: DoctorRepairItem[]; total: number } {
+  const allItems: DoctorRepairItem[] = [];
+  for (const skill of report.skills) {
+    for (const result of skill.results) {
+      if (result.status !== 'fail' && result.status !== 'warn') continue;
+      const action = compactActionText(result.hint || result.message);
+      allItems.push({
+        skillName: skill.skillName,
+        status: result.status,
+        label: renderRuleLabel(result, lang),
+        action,
+        isSummary: result.ruleId.endsWith(':_summary'),
+      });
+    }
+  }
+
+  const focusedItems = allItems.filter((item) => !item.isSummary);
+  const source = focusedItems.length > 0 ? focusedItems : allItems;
+  const sorted = [...source].sort((a, b) => STATUS_RANK[a.status] - STATUS_RANK[b.status]);
+  return { items: sorted.slice(0, 6), total: source.length };
+}
+
+export function renderDoctorActionPlanText(report: DoctorReport, lang: Lang): string {
+  const { items, total } = collectDoctorRepairItems(report, lang);
+  if (items.length === 0) {
+    return lang === 'zh'
+      ? '\n下一步：doctor 已通过，可以继续运行 `omk eval`。\n'
+      : '\nNext: doctor passed; continue with `omk eval`.\n';
+  }
+
+  const hasFail = items.some((item) => item.status === 'fail');
+  const lines: string[] = [
+    '',
+    lang === 'zh'
+      ? (hasFail ? '修复清单（先处理阻塞项）：' : '修复清单（建议处理，不阻断 eval）：')
+      : (hasFail ? 'Repair checklist (fix blocking items first):' : 'Repair checklist (recommended; does not block eval):'),
+  ];
+
+  items.forEach((item, index) => {
+    const status = statusLabel(item.status, lang);
+    if (lang === 'zh') {
+      lines.push(`  ${index + 1}. [${item.skillName}] ${status}：${item.label}。${item.action}`);
+    } else {
+      lines.push(`  ${index + 1}. [${item.skillName}] ${status}: ${item.label}. ${item.action}`);
+    }
+  });
+
+  const remaining = total - items.length;
+  if (remaining > 0) {
+    lines.push(lang === 'zh'
+      ? `  ……还有 ${remaining} 项，完整明细见上方 doctor 输出。`
+      : `  ...and ${remaining} more; see the doctor output above for full detail.`);
+  }
+
+  lines.push(hasFail
+    ? (lang === 'zh'
+      ? '下一步：先修阻塞项，重跑 `omk doctor --gate`；通过后再跑 `omk eval`。'
+      : 'Next: fix the blocking items, re-run `omk doctor --gate`, then run `omk eval`.')
+    : (lang === 'zh'
+      ? '下一步：可以先跑 `omk eval`，但发布前建议把这些 warning 处理掉。'
+      : 'Next: you can run `omk eval`, but clear these warnings before shipping.'));
+
+  return `${lines.join('\n')}\n`;
+}
+
 /** 把 result 列表按 groupId 拆成段(普通 rule 段长度 1, composer 段长度 N+1)。
  *  保留原顺序:每个 group 在它第一条 result 出现的位置占位。 */
 interface ResultSegment {
@@ -144,6 +221,7 @@ export function renderDoctorReportText(
     ? `\n总览: ${report.totals.pass} 通过 / ${report.totals.warn} 警告 / ${report.totals.fail} 失败\n`
     : `\nSummary: ${report.totals.pass} pass / ${report.totals.warn} warn / ${report.totals.fail} fail\n`;
   write(summary);
+  write(renderDoctorActionPlanText(report, lang));
 }
 
 export function renderDoctorReportJson(report: DoctorReport): string {

--- a/src/doctor/renderer.ts
+++ b/src/doctor/renderer.ts
@@ -117,8 +117,8 @@ export function renderDoctorActionPlanText(report: DoctorReport, lang: Lang): st
   const remaining = total - items.length;
   if (remaining > 0) {
     lines.push(lang === 'zh'
-      ? `  ……还有 ${remaining} 项，完整明细见上方 doctor 输出。`
-      : `  ...and ${remaining} more; see the doctor output above for full detail.`);
+      ? `  ……还有 ${remaining} 项，运行 \`omk doctor\` 查看完整明细。`
+      : `  ...and ${remaining} more; run \`omk doctor\` for full detail.`);
   }
 
   lines.push(hasFail

--- a/src/eval-core/verdict.ts
+++ b/src/eval-core/verdict.ts
@@ -173,6 +173,7 @@ export function computeVerdict(report: Report, options: VerdictOptions = {}): Ve
         ...(judgeInd.rationale ? { judgeAgreement: judgeInd.rationale } : {}),
         ...(overfit.rationale ? { overfitting: overfit.rationale } : {}),
         ...(gap.rationale ? { gapSignal: gap.rationale } : {}),
+        shipRecommendation: recommendation('SOLO', []),
       },
       ...((overfit.data || gap.data) ? {
         caveats: {
@@ -709,7 +710,7 @@ function releaseNextStep(level: VerdictLevel, lang: Lang): string {
 }
 
 /**
- * Plain-text formatter for the `omk eval` verdict. Stays under 6 lines per the
+ * Plain-text formatter for the `omk eval` verdict. Stays terse for the
  *  spec — one verdict, rationale bullets, one ship recommendation, and one next step.
  */
 export function formatVerdictText(result: VerdictResult, options: { verbose?: boolean; lang?: Lang } = {}): string {

--- a/src/eval-core/verdict.ts
+++ b/src/eval-core/verdict.ts
@@ -679,7 +679,7 @@ function releaseNextStep(level: VerdictLevel, lang: Lang): string {
   if (lang === 'zh') {
     switch (level) {
       case 'PROGRESS':
-        return '把报告作为发布证据留存；如果这是受管 skill，可以继续 promote。';
+        return '可以进入发布流程：请留存本次报告作为发布证据；如果这是受管 skill，再运行 `omk promote`。';
       case 'CAUTIOUS':
         return '先看触发的告警（分层门控、评委分歧、稳定性或 holdout），修完再重跑。';
       case 'REGRESS':
@@ -694,7 +694,7 @@ function releaseNextStep(level: VerdictLevel, lang: Lang): string {
   }
   switch (level) {
     case 'PROGRESS':
-      return 'keep the report as release evidence; for a managed skill, continue to promote.';
+      return 'ready for release: keep this report as release evidence; for a managed skill, run `omk promote`.';
     case 'CAUTIOUS':
       return 'inspect the warnings (layer gates, judge dissent, stability, or holdout), fix them, then re-run.';
     case 'REGRESS':

--- a/src/eval-core/verdict.ts
+++ b/src/eval-core/verdict.ts
@@ -675,9 +675,42 @@ function recommendation(level: VerdictLevel, _perPair: Array<{ level: VerdictLev
   }
 }
 
+function releaseNextStep(level: VerdictLevel, lang: Lang): string {
+  if (lang === 'zh') {
+    switch (level) {
+      case 'PROGRESS':
+        return '把报告作为发布证据留存；如果这是受管 skill，可以继续 promote。';
+      case 'CAUTIOUS':
+        return '先看触发的告警（分层门控、评委分歧、稳定性或 holdout），修完再重跑。';
+      case 'REGRESS':
+        return '不要发布；定位最差层和失败用例，修复后重跑。';
+      case 'NOISE':
+        return '先别发布；增加样本数或提高用例区分度，再重跑。';
+      case 'UNDERPOWERED':
+        return '把样本数加到至少 20，或先按当前规模 2× 扩充后重跑。';
+      case 'SOLO':
+        return '补一个 baseline 对照，再跑 `omk eval --control baseline --treatment <名字>`。';
+    }
+  }
+  switch (level) {
+    case 'PROGRESS':
+      return 'keep the report as release evidence; for a managed skill, continue to promote.';
+    case 'CAUTIOUS':
+      return 'inspect the warnings (layer gates, judge dissent, stability, or holdout), fix them, then re-run.';
+    case 'REGRESS':
+      return 'do not ship; inspect the weakest layer and failing samples, fix them, then re-run.';
+    case 'NOISE':
+      return 'do not ship yet; add samples or sharpen the test set, then re-run.';
+    case 'UNDERPOWERED':
+      return 'increase the sample set to at least 20, or roughly 2x the current size, then re-run.';
+    case 'SOLO':
+      return 'add a baseline control and re-run `omk eval --control baseline --treatment <name>`.';
+  }
+}
+
 /**
  * Plain-text formatter for the `omk eval` verdict. Stays under 6 lines per the
- *  spec — one verdict + four rationale bullets + one ship recommendation.
+ *  spec — one verdict, rationale bullets, one ship recommendation, and one next step.
  */
 export function formatVerdictText(result: VerdictResult, options: { verbose?: boolean; lang?: Lang } = {}): string {
   // lang 默认 'en':保留既有英文输出逐字节不变(verdict.test 与历史 CLI 行为)。zh 只本地化
@@ -695,6 +728,7 @@ export function formatVerdictText(result: VerdictResult, options: { verbose?: bo
   if (result.rationale.gapSignal) lines.push(zh ? `  知识缺口：${result.rationale.gapSignal}` : `  Gap signal:    ${result.rationale.gapSignal}`);
   if (result.rationale.shipRecommendation) {
     lines.push(`  ${zh ? recommendation(result.level, [], 'zh') : result.rationale.shipRecommendation}`);
+    lines.push(zh ? `  下一步：${releaseNextStep(result.level, 'zh')}` : `  Next: ${releaseNextStep(result.level, 'en')}`);
   }
   if (options.verbose && result.perPair && result.perPair.length > 1) {
     lines.push('');

--- a/src/eval-workflows/messages.ts
+++ b/src/eval-workflows/messages.ts
@@ -25,8 +25,8 @@ const MESSAGES: Record<EvalWorkflowMessageCode, MessageEntry> = {
     en: '⚠ --repeat=1: single-run cannot measure stability (CV will be marked "not measured"). Use --repeat 3+ to detect within-variant variance.',
   },
   doctor_gate_blocked: {
-    zh: 'skill 健康检查未通过，评测已中止。doctor 是评测必经环节，无 skip 选项——请修复上述问题后重跑。',
-    en: 'skill health check failed; evaluation aborted. doctor is mandatory and not skippable — fix the issues above and re-run.',
+    zh: '发布前 doctor 门禁未通过，评测已中止。\n下一步：先修复上面的阻塞项，再重跑 `omk eval`。\n原因：这段输入还不值得测，继续比较分数会是 garbage-in。\n如果依赖确实由 mock / stub 提供、doctor 误报，可用 `--skip-doctor` 绕过，但这次结果由你承担不可比风险。',
+    en: 'pre-ship doctor gate failed; evaluation aborted.\nNext: fix the blocking findings above, then re-run `omk eval`.\nWhy: this input is not measurable enough yet, and comparing scores now would be garbage-in.\nIf deps are truly supplied by mocks/stubs and doctor is a false positive, use `--skip-doctor`, but you own the comparability risk.',
   },
 };
 

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -255,7 +255,7 @@ export async function runEvaluation({
       });
       if (doctorReport.outcome === 'failed') {
         renderDoctorReportText(doctorReport, lang);
-        throw new Error(`doctor failed: ${tEvalWorkflowMessage('doctor_gate_blocked', lang)}`);
+        throw new Error(`doctor failed:\n${tEvalWorkflowMessage('doctor_gate_blocked', lang)}`);
       }
     }
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -417,6 +417,7 @@ describe('CLI', () => {
           assert.equal(e.code, 1);
           // 非 TTY:verdict 文案走 stderr,stdout 留作纯 report JSON。verdict 随 lang 本地化(判定：/ Verdict:)。
           assert.ok(/判定：|Verdict:/.test(e.stderr), e.stderr);
+          assert.ok(/下一步：|Next:/.test(e.stderr), e.stderr);
           const parsed = JSON.parse(e.stdout) as { kind?: unknown };
           assert.ok(typeof parsed.kind === 'string', `stdout 应为纯 report JSON:\n${e.stdout.slice(0, 200)}`);
           assert.ok(e.stderr.includes('omk studio'), e.stderr);
@@ -453,6 +454,7 @@ describe('CLI', () => {
       const parsed = JSON.parse(stdout) as { kind?: unknown };
       assert.ok(typeof parsed.kind === 'string', `stdout 应为纯 report JSON:\n${stdout.slice(0, 200)}`);
       assert.ok(/判定：|Verdict:/.test(stderr), stderr);
+      assert.ok(/下一步：|Next:/.test(stderr), stderr);
       assert.ok(stderr.includes('report-only'), stderr);
     } finally {
       await rm(dir, { recursive: true, force: true });
@@ -483,6 +485,7 @@ describe('CLI', () => {
           const parsed = JSON.parse(e.stdout) as { kind?: unknown };
           assert.ok(typeof parsed.kind === 'string', `stdout 应为纯 batch report JSON:\n${e.stdout.slice(0, 200)}`);
           assert.ok(e.stderr.includes('批量评测结论：未通过'), e.stderr);
+          assert.ok(e.stderr.includes('下一步：先处理未通过的 skill'), e.stderr);
           assert.ok(!e.stderr.includes('Batch verdict:'), e.stderr);
           assert.ok(e.stderr.includes('UNDERPOWERED:'), e.stderr);
           assert.ok(e.stderr.includes('omk studio'), e.stderr);

--- a/test/cli/doctor-eval-embed.test.ts
+++ b/test/cli/doctor-eval-embed.test.ts
@@ -70,6 +70,12 @@ describe('omk eval doctor preflight embedding', () => {
           const e = err as ExecError;
           assert.equal(e.code, 1);
           assert.ok(e.stderr.includes('doctor failed:'), `stderr should include 'doctor failed:': ${e.stderr.slice(0, 500)}`);
+          assert.ok(e.stderr.includes('发布前 doctor 门禁未通过'), `stderr should explain the pre-ship gate: ${e.stderr.slice(0, 800)}`);
+          assert.ok(e.stderr.includes('修复清单'), `stderr should include a repair checklist: ${e.stderr.slice(0, 800)}`);
+          assert.ok(e.stderr.includes('omk doctor --gate'), `stderr should explain how to verify doctor fixes: ${e.stderr.slice(0, 800)}`);
+          assert.ok(e.stderr.includes('继续比较分数会是 garbage-in'), `stderr should explain why eval stopped: ${e.stderr.slice(0, 800)}`);
+          assert.ok(e.stderr.includes('重跑 `omk eval`'), `stderr should tell users what to do next: ${e.stderr.slice(0, 800)}`);
+          assert.ok(e.stderr.includes('--skip-doctor'), `stderr should mention the explicit escape hatch: ${e.stderr.slice(0, 800)}`);
           return true;
         },
       );
@@ -94,6 +100,35 @@ describe('omk eval doctor preflight embedding', () => {
           const e = err as ExecError;
           assert.equal(e.code, 1);
           assert.ok(e.stderr.includes('doctor failed:'), `eval should gate on doctor: ${e.stderr.slice(0, 500)}`);
+          assert.ok(e.stderr.includes('发布前 doctor 门禁未通过'), `eval should explain the doctor gate: ${e.stderr.slice(0, 800)}`);
+          return true;
+        },
+      );
+    } finally {
+      rmSync(broken, { recursive: true, force: true });
+    }
+  });
+
+  it('eval doctor gate is actionable in English too', async () => {
+    const broken = setupBrokenSkillDir();
+    try {
+      await assert.rejects(
+        () => execFileAsync('node', [
+          CLI, 'eval',
+          '--samples', join(broken, 'eval-samples.json'),
+          '--skill-dir', join(broken, 'skills'),
+          '--control', 'v1',
+          '--treatment', 'v2',
+          '--dry-run',
+          '--lang', 'en',
+        ], { cwd: broken }),
+        (err: unknown) => {
+          const e = err as ExecError;
+          assert.equal(e.code, 1);
+          assert.ok(e.stderr.includes('pre-ship doctor gate failed'), `stderr should explain the pre-ship gate: ${e.stderr.slice(0, 800)}`);
+          assert.ok(e.stderr.includes('re-run `omk eval`'), `stderr should tell users what to do next: ${e.stderr.slice(0, 800)}`);
+          assert.ok(e.stderr.includes('garbage-in'), `stderr should explain why eval stopped: ${e.stderr.slice(0, 800)}`);
+          assert.ok(e.stderr.includes('--skip-doctor'), `stderr should mention the explicit escape hatch: ${e.stderr.slice(0, 800)}`);
           return true;
         },
       );
@@ -119,8 +154,8 @@ describe('omk eval doctor preflight embedding', () => {
   });
 
   it('--skip-connectivity does not bypass doctor', async () => {
-    // doctor 是强制门禁, 没有 skip flag — broken skill 一定 abort,
-    // --skip-connectivity 只跳 LLM 连通性, 不影响 doctor。
+    // --skip-connectivity 只跳 LLM 连通性，不影响 doctor gate；
+    // 真要绕开 doctor 必须显式用 --skip-doctor。
     const broken = setupBrokenSkillDir();
     try {
       await assert.rejects(
@@ -137,6 +172,7 @@ describe('omk eval doctor preflight embedding', () => {
           const e = err as ExecError;
           assert.equal(e.code, 1);
           assert.ok(e.stderr.includes('doctor failed:'), `doctor should still gate: ${e.stderr.slice(0, 400)}`);
+          assert.ok(e.stderr.includes('发布前 doctor 门禁未通过'), `doctor gate should stay actionable: ${e.stderr.slice(0, 800)}`);
           return true;
         },
       );
@@ -162,6 +198,7 @@ describe('omk eval doctor preflight embedding', () => {
           assert.equal(e.code, 1);
           assert.ok(e.stderr.includes('doctor failed:'), `batch dry-run should gate on doctor: ${e.stderr.slice(0, 500)}`);
           assert.ok(e.stderr.includes('skill=broken'), `error should name the failing skill: ${e.stderr.slice(0, 500)}`);
+          assert.ok(e.stderr.includes('发布前 doctor 门禁未通过'), `batch error should keep the actionable gate text: ${e.stderr.slice(0, 800)}`);
           return true;
         },
       );

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -121,6 +121,9 @@ describe('omk doctor CLI', () => {
           const e = err as ExecError;
           assert.equal(e.code, 1);
           assert.ok(e.stderr.includes('doctor failed:'));
+          assert.ok(e.stderr.includes('修复清单'), e.stderr);
+          assert.ok(e.stderr.includes('下一步：先修阻塞项'), e.stderr);
+          assert.ok(e.stderr.includes('omk doctor --gate'), e.stderr);
           return true;
         },
       );
@@ -138,6 +141,7 @@ describe('omk doctor CLI', () => {
     ]);
     assert.ok(stderr.includes('健康检查'));
     assert.ok(stderr.includes('总览:'));
+    assert.ok(stderr.includes('下一步：doctor 已通过，可以继续运行 `omk eval`。'));
   });
 
   it('persists doctor graph sidecar and Markdown evidence card', async () => {

--- a/test/doctor/renderer.test.ts
+++ b/test/doctor/renderer.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { renderDoctorActionPlanText } from '../../src/doctor/renderer.js';
+import type { DoctorReport, DoctorRuleResult } from '../../src/types/index.js';
+
+const result = (idx: number): DoctorRuleResult => ({
+  ruleId: `rule-${idx}`,
+  severity: 'fatal',
+  labelKey: `rule-${idx}`,
+  status: 'fail',
+  message: `message ${idx}`,
+  hint: `hint ${idx}`,
+  durationMs: 1,
+});
+
+function buildReport(results: DoctorRuleResult[]): DoctorReport {
+  return {
+    kind: 'doctor',
+    schemaVersion: '3.0.0',
+    id: 'doctor-test',
+    timestamp: '2026-07-04T00:00:00.000Z',
+    cliVersion: 'test',
+    cwd: '/tmp/project',
+    executorName: 'test',
+    model: 'test',
+    skills: [{
+      skillName: 'review',
+      skillPath: '/tmp/project/skills/review',
+      status: 'fail',
+      results,
+    }],
+    outcome: 'failed',
+    totals: { pass: 0, warn: 0, fail: 1 },
+    ruleStats: { pass: 0, warn: 0, fail: results.length, skipped: 0, total: results.length },
+  };
+}
+
+describe('doctor renderer', () => {
+  it('truncated action plan points users to rerun doctor for full detail', () => {
+    const text = renderDoctorActionPlanText(buildReport(Array.from({ length: 8 }, (_, i) => result(i + 1))), 'zh');
+    assert.match(text, /还有 2 项/);
+    assert.match(text, /运行 `omk doctor` 查看完整明细/);
+    assert.doesNotMatch(text, /上方 doctor 输出/);
+  });
+});

--- a/test/eval-core/verdict.test.ts
+++ b/test/eval-core/verdict.test.ts
@@ -287,7 +287,7 @@ describe('computeVerdict', () => {
     assert.equal(v.perPair?.length, 2);
   });
 
-  it('formatVerdictText stays under 7 lines for the headline path (含 stability rationale)', () => {
+  it('formatVerdictText stays under 8 lines for the headline path (含 stability rationale + next step)', () => {
     const r = buildReport({
       variants: ['baseline', 'skill'],
       perVariantAvg: {
@@ -302,7 +302,25 @@ describe('computeVerdict', () => {
     const v = computeVerdict(r);
     const text = formatVerdictText(v);
     const lines = text.split('\n');
-    assert.ok(lines.length <= 7, `expected ≤7 lines, got ${lines.length}: ${text}`);
+    assert.ok(lines.length <= 8, `expected ≤8 lines, got ${lines.length}: ${text}`);
+    assert.match(text, /Next: keep the report as release evidence/);
+  });
+
+  it('formatVerdictText gives zh release next step', () => {
+    const r = buildReport({
+      variants: ['baseline', 'skill'],
+      perVariantAvg: {
+        baseline: { fact: 4, behavior: 4, judge: 4, composite: 4 },
+        skill:    { fact: 4.3, behavior: 4.3, judge: 4.3, composite: 4.3 },
+      },
+      pairs: [{
+        control: 'baseline', treatment: 'skill',
+        diffBootstrapCI: { low: 0.1, high: 0.5, estimate: 0.3, samples: 1000, significant: true },
+      }],
+    });
+    const text = formatVerdictText(computeVerdict(r), { lang: 'zh' });
+    assert.match(text, /可发布/);
+    assert.match(text, /下一步：把报告作为发布证据留存/);
   });
 
   it('rationale.stability 在单轮(无 variance)时显式说"未测量"', () => {

--- a/test/eval-core/verdict.test.ts
+++ b/test/eval-core/verdict.test.ts
@@ -303,7 +303,7 @@ describe('computeVerdict', () => {
     const text = formatVerdictText(v);
     const lines = text.split('\n');
     assert.ok(lines.length <= 8, `expected ≤8 lines, got ${lines.length}: ${text}`);
-    assert.match(text, /Next: keep the report as release evidence/);
+    assert.match(text, /Next: ready for release/);
   });
 
   it('formatVerdictText gives zh release next step', () => {
@@ -320,7 +320,7 @@ describe('computeVerdict', () => {
     });
     const text = formatVerdictText(computeVerdict(r), { lang: 'zh' });
     assert.match(text, /可发布/);
-    assert.match(text, /下一步：把报告作为发布证据留存/);
+    assert.match(text, /下一步：可以进入发布流程/);
   });
 
   it('rationale.stability 在单轮(无 variance)时显式说"未测量"', () => {

--- a/test/eval-core/verdict.test.ts
+++ b/test/eval-core/verdict.test.ts
@@ -376,6 +376,20 @@ describe('computeVerdict', () => {
     assert.match(v.rationale.stability ?? '', /未测量/);
   });
 
+  it('formatVerdictText gives SOLO a control-building next step', () => {
+    const r = buildReport({
+      variants: ['solo'],
+      perVariantAvg: { solo: { fact: 4, behavior: 4, judge: 4, composite: 4 } },
+    });
+    const zhText = formatVerdictText(computeVerdict(r), { lang: 'zh' });
+    assert.match(zhText, /缺对照/);
+    assert.match(zhText, /下一步：补一个 baseline 对照/);
+
+    const enText = formatVerdictText(computeVerdict(r), { lang: 'en' });
+    assert.match(enText, /ADD A CONTROL/);
+    assert.match(enText, /Next: add a baseline control/);
+  });
+
   // --- 稳定性门控(PR4)----------------------------------------------------
   // 一个干净的显著正向 PROGRESS,只叠加 variance 数据,隔离稳定性门控这一条。
   const cleanProgressWithVariance = (perVariant: Record<string, { scores: number[]; mean: number; lower: number; upper: number; stddev: number }>, runs = 3): Report => buildReport({


### PR DESCRIPTION
Closes #316

## 背景

#315 已经明确了 omk 的定位：判断一段知识输入（prompt / skill / RAG / agent）好不好，最终要服务发布决策。这个 PR 把 #316 收成一个用户能感知的闭环：先 doctor，能测再 eval，跑完直接告诉用户下一步。

## 用户影响

- 用户在 `doctor` 阶段会看到更明确的修复清单和下一步，不再只拿到诊断结论。
- 用户在 `eval` 被 doctor gate 拦住时，会看到为什么继续评测会污染发布判断，以及 `--skip-doctor` 适合什么风险场景。
- 用户跑完单个或批量 `eval` 后，会直接看到 PROGRESS / CAUTIOUS / REGRESS / NOISE / UNDERPOWERED / SOLO 对应的发布动作建议。

## 改动

- doctor 文本输出增加「修复清单」和下一步：失败时先修阻塞项，重跑 `omk doctor --gate`，再跑 `omk eval`；通过时提示可以继续 eval。
- `omk eval` 被 doctor 拦住时，说明这是发布前门禁、为什么继续测会是 garbage-in，以及 `--skip-doctor` 的风险边界。
- eval verdict 增加发布动作层的「下一步」，把 PROGRESS / CAUTIOUS / REGRESS / NOISE / UNDERPOWERED / SOLO 翻译成用户该做什么。
- batch eval 增加整体下一步，避免只给每个 skill 的 headline。

## 迁移说明

无需迁移。这个 PR 不改 CLI 参数、report JSON schema、落盘数据结构或 public API。

## 测量学说明

这次只增强 CLI 发布判断和下一步文案，不改评分 prompt、report schema、Bootstrap / Krippendorff / length-debias 等可比性口径，也不改 doctor gate 语义或 `--skip-doctor` 行为。因此不标记 `BREAKING-COMPARABILITY`。

## 非目标

- 不改评分 prompt、report schema、Bootstrap / Krippendorff / length-debias 等可比性口径。
- 不改 doctor gate 语义，也不改 `--skip-doctor` 行为。
- 不碰 observe、Studio / report UI 大改版。

## 验证

- `yarn vitest run test/eval-core/verdict.test.ts test/cli/doctor.test.ts test/cli/doctor-eval-embed.test.ts test/cli.test.ts`
- `git diff --check`
- `yarn lint && yarn build && yarn test`
