### PR TITLE
chore(release): 发布 0.47.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 `0.47.0`，包含上一轮已合入 `main` 的 doctor → eval 发布判断链路改进。

## 迁移说明

无需迁移。本次 release PR 仅 bump `package.json` 版本号。

## 测量学说明

本 release PR 不修改评分 prompt、report schema、Bootstrap / Krippendorff / length-debias 等可比性口径；不标记 `BREAKING-COMPARABILITY`。

## 验证

- `git diff --check`
- `yarn lint && yarn build && yarn test`
