### PR TITLE
feat(observe): 串起 trace 到样本草稿指引

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -604,6 +604,7 @@ omk sample [skillPath] [flags]
 - `--no-mock` `boolean`:不生成 mocks，eval 时所有工具调用真实执行。
 - `--observations-dir` `option`:observe inbox 目录（from-traces 模式用），默认项目 .omk/observe-inbox。
 - `--reports-dir` `option`:报告目录（fix 模式用），默认 ~/.oh-my-knowledge/reports。
+- `--skill` `option`:仅从指定 skill 的 observe inbox 信号生成草稿（仅 from-traces 模式用）。
 - `--skill-dir` `option` (默认 `skills`):skill 根目录，默认 skills。batch 模式扫此目录。
 - `--treatment` `option`:指定 treatment 名（fix 模式用），默认推断自 skill 路径。
 

--- a/docs/guides/observe-production.md
+++ b/docs/guides/observe-production.md
@@ -21,7 +21,7 @@ Scope the window with `--last 7d` / `--from … --to …`, and narrow to specifi
 
 ## B. Inbox: the reviewer loop
 
-When you want to triage observations one by one (and feed the good ones back as regression cases), use the inbox. The whole pipeline is local-only and LLM-free.
+When you want to triage observations one by one, use the inbox. Steps 1-3 below are local-only and LLM-free; drafting regression samples is a separate optional authoring step that calls a generation model.
 
 ```bash
 # 1. Parse traces, aggregate + de-noise signals, write to .omk/observe-inbox/
@@ -45,6 +45,14 @@ Supported trace formats: Claude Code session JSONL, OpenClaw session JSONL, and 
 ## Turning observations into samples
 
 Confirmed gaps from observe are exactly the failures your eval set is missing. `omk sample --from-traces` can draft regression cases from those signals — closing the observe → eval loop.
+
+This command calls the sample generator through your configured executor and model, so trace-derived evidence is sent to that model and may incur generation cost:
+
+```bash
+omk sample --from-traces
+```
+
+It writes `.omk/observe-inbox/sample-drafts.json`. Treat the file as a review queue: inspect the draft, keep only reproducible cases, then merge the accepted ones into your real `eval-samples` file.
 
 ## Related
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -422,6 +422,7 @@ omk sample --batch                  # generate for skills missing eval-samples
   --no-mock                   Skip mock generation; all tool calls execute for real during eval.
   --observations-dir <value>  Observe inbox dir (from-traces mode), default project .omk/observe-inbox.
   --reports-dir <value>       Reports dir (fix mode), default ~/.oh-my-knowledge/reports.
+  --skill <value>             Only draft from observe-inbox signals for the specified skill (from-traces mode only).
   --skill-dir <value>         Skill root dir, default skills. Used by batch mode.
   --treatment <value>         Treatment name (fix mode), defaults to skill-path inference.
 ```

--- a/docs/zh/guides/observe-production.md
+++ b/docs/zh/guides/observe-production.md
@@ -21,7 +21,7 @@ omk observe ~/.claude/projects/my-project --kb /path/to/project   # KB-aware 分
 
 ## B. inbox：reviewer 闭环
 
-当你想逐条 triage observation（把好的回流成回归用例），用 inbox。整条链路纯本地、零 LLM。
+当你想逐条 triage observation，用 inbox。下面步骤 1-3 纯本地、零 LLM；生成回归用例草稿是单独的可选 authoring 步骤，会调用生成模型。
 
 ```bash
 # 1. 解析 trace，聚合 + 降噪信号，落盘到 .omk/observe-inbox/
@@ -45,6 +45,14 @@ omk observe show <inbox_id>
 ## 把 observation 变成用例
 
 observe 确认的缺口，正是你 eval 集缺的那些失败。`omk sample --from-traces` 能从这些信号草拟回归用例——把 observe → eval 的闭环合上。
+
+这个命令会通过你配置的 executor 和 model 调用 sample 生成器，因此 trace 派生证据会发送给该模型，也可能产生生成成本：
+
+```bash
+omk sample --from-traces
+```
+
+它会写 `.omk/observe-inbox/sample-drafts.json`。把这个文件当 review 队列：先看草稿，只保留可复现的用例，再合入正式 `eval-samples` 文件。
 
 ## 相关
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -422,6 +422,7 @@ omk sample --batch                  # 为目录下缺评测集的 skill 批量�
   --no-mock                   不生成 mocks，eval 时所有工具调用真实执行。
   --observations-dir <value>  observe inbox 目录（from-traces 模式用），默认项目 .omk/observe-inbox。
   --reports-dir <value>       报告目录（fix 模式用），默认 ~/.oh-my-knowledge/reports。
+  --skill <value>             仅从指定 skill 的 observe inbox 信号生成草稿（仅 from-traces 模式用）。
   --skill-dir <value>         skill 根目录，默认 skills。batch 模式扫此目录。
   --treatment <value>         指定 treatment 名（fix 模式用），默认推断自 skill 路径。
 ```

--- a/src/cli/commands/observe/inbox.ts
+++ b/src/cli/commands/observe/inbox.ts
@@ -8,6 +8,7 @@ import type { ObserveInboxArgs, ObserveInboxFlags } from '../../lib/cmd-flags.js
 import type { ObservationInboxViewModel } from '../../../observability/inbox-view-model.js';
 import type { ExperienceTimelineEvent } from '../../../observability/experience.js';
 import type { SkillLlmEnhancedRuntimeEvidence } from '../../../observability/soft-standards/index.js';
+import { shellQuoteArg } from '../../../shared/shell-quote.js';
 
 function pickSkillCount(value: Record<string, number> | undefined, skillName: string): Record<string, number> | undefined {
   if (!value || value[skillName] == null) return undefined;
@@ -71,6 +72,11 @@ export async function runObserveInbox(
   if (flags.skill) {
     items = items.filter((item) => item.skillName === flags.skill);
   }
+  const recyclableCount = items.filter((item) => item.severity !== 'noise').length;
+  const sampleCommandBase = `omk sample --from-traces --observations-dir ${shellQuoteArg(dir)}`;
+  const sampleCommand = flags.skill
+    ? `${sampleCommandBase} --skill ${shellQuoteArg(flags.skill)}`
+    : sampleCommandBase;
   if (flags['by-skill']) {
     const reports = flags.skill
       ? loadLatestObservationInboxReports(dir).map((report) => ({
@@ -96,6 +102,11 @@ export async function runObserveInbox(
     console.log(lang === 'zh' ? 'observe inbox by skill:' : 'observe inbox by skill:');
     for (const row of rows) {
       console.log(`- ${row.skillName} invocations=${row.invocationCount} sessions=${row.sessionCount} processFindings=${row.observationCount} high=${row.highCount} medium=${row.mediumCount} low=${row.lowCount} noise=${row.noiseCount}${row.latestSeen ? ` latest=${row.latestSeen}` : ''}`);
+    }
+    if (recyclableCount > 0) {
+      console.log(lang === 'zh'
+        ? `提示：确认信号后生成回归用例草稿：${sampleCommand}`
+        : `Tip: after confirming signals, draft regression samples: ${sampleCommand}`);
     }
     return;
   }
@@ -130,6 +141,11 @@ export async function runObserveInbox(
   console.log(lang === 'zh'
     ? 'Tip: omk observe inbox --explore 10 --include-noise  # 显式包含 noise 桶'
     : 'Tip: omk observe inbox --explore 10 --include-noise  # explicitly include the noise bucket');
+  if (recyclableCount > 0) {
+    console.log(lang === 'zh'
+      ? `提示：确认高风险或抽样信号后生成回归用例草稿：${sampleCommand}`
+      : `Tip: after confirming high-risk / sampled signals, draft regression samples: ${sampleCommand}`);
+  }
 }
 
 function hasLlmEnhancedRuntimeEvidence(evidence: SkillLlmEnhancedRuntimeEvidence): boolean {

--- a/src/cli/commands/observe/ingest.ts
+++ b/src/cli/commands/observe/ingest.ts
@@ -3,6 +3,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../oclif/base-command.js';
 import { LANG_FLAG, bilingual } from '../../oclif/i18n.js';
 import { CliExit } from '../../lib/cli-exit.js';
+import { shellQuoteArg } from '../../../shared/shell-quote.js';
 
 export default class ObserveIngest extends BaseCommand {
   static description = bilingual({
@@ -75,9 +76,11 @@ export default class ObserveIngest extends BaseCommand {
       report.diagnostics = buildObserveDiagnosticsFromReport(report);
       const path = saveObservationInboxReport(report, outDir);
       console.log(JSON.stringify(report, null, 2));
+      const inboxCommand = `omk observe inbox --input-dir ${shellQuoteArg(outDir)}`;
+      const sampleCommand = `omk sample --from-traces --observations-dir ${shellQuoteArg(outDir)}`;
       process.stderr.write(lang === 'zh'
-        ? `observe inbox 已写入: ${path}\n`
-        : `observe inbox written to: ${path}\n`);
+        ? `observe inbox 已写入：${path}\n下一步：${inboxCommand}\n确认高风险或抽样信号后，可生成回归用例草稿：${sampleCommand}\n`
+        : `observe inbox written to: ${path}\nNext: ${inboxCommand}\nAfter confirming high-risk / sampled signals, draft regression samples: ${sampleCommand}\n`);
     });
   }
 }

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -398,7 +398,7 @@ async function runSampleFix(
     : `\n🔧 Fix complete: ${result.fixedCount}/${sampleDesignCount} fixed → ${outputTarget}${cost}\n`);
 }
 
-async function runSampleFromTraces(
+export async function runSampleFromTraces(
   flags: SampleFlags,
   lang: CliLang,
 ): Promise<void> {
@@ -415,11 +415,14 @@ async function runSampleFromTraces(
 
   // Drop noise-tier signals up front: they're exactly what the generator is told to
   // skip, so filtering here avoids feeding junk to the LLM and keeps the no-op path clean.
-  const items = queryObservationInbox(obsDir).filter((it) => it.severity !== 'noise');
+  let items = queryObservationInbox(obsDir).filter((it) => it.severity !== 'noise');
+  if (flags.skill) {
+    items = items.filter((it) => it.skillName === flags.skill);
+  }
   if (items.length === 0) {
     process.stderr.write(lang === 'zh'
-      ? `✅ ${obsDir} 没有可回流的失败信号（噪声级已跳过）\n`
-      : `✅ No recyclable failure signals in ${obsDir} (noise-level skipped)\n`);
+      ? `✅ ${obsDir}${flags.skill ? ` 中 ${flags.skill}` : ''} 没有可回流的失败信号（噪声级已跳过）\n`
+      : `✅ No recyclable failure signals${flags.skill ? ` for ${flags.skill}` : ''} in ${obsDir} (noise-level skipped)\n`);
     return;
   }
 
@@ -433,8 +436,8 @@ async function runSampleFromTraces(
 
   const count: number | undefined = flags.count !== undefined ? Math.max(1, Number(flags.count) || 5) : undefined;
   process.stderr.write(lang === 'zh'
-    ? `🔭 发现 ${items.length} 个失败信号，正在生成回归用例草稿...\n`
-    : `🔭 Found ${items.length} failure signal(s); generating regression-sample drafts...\n`);
+    ? `🔭 发现 ${items.length} 个${flags.skill ? ` ${flags.skill} 的` : ''}失败信号，正在生成回归用例草稿...\n`
+    : `🔭 Found ${items.length}${flags.skill ? ` ${flags.skill}` : ''} failure signal(s); generating regression-sample drafts...\n`);
 
   try {
     const { samples, costUSD } = await generateSamplesFromTraces({ items, count, model: flags.model, executorName: flags.executor });
@@ -464,6 +467,10 @@ async function runSample(
   flags: SampleFlags,
   lang: CliLang,
 ): Promise<void> {
+  if (flags.skill && !flags['from-traces']) {
+    console.error(lang === 'zh' ? '--skill 仅支持 --from-traces 模式。' : '--skill is only supported with --from-traces.');
+    throw new CliExit(2);
+  }
   // --append 目前只在单 skill 生成路径实现;batch / from-traces / fix 不处理它,
   // 静默忽略会误导(用户以为在追加,实际没有)。提前互斥校验,明确报错。
   if (flags.append && (flags.batch || flags['from-traces'] || flags.fix)) {
@@ -759,6 +766,12 @@ export default class Sample extends BaseCommand {
       description: bilingual({
         zh: 'observe inbox 目录（from-traces 模式用），默认项目 .omk/observe-inbox。',
         en: 'Observe inbox dir (from-traces mode), default project .omk/observe-inbox.',
+      }),
+    }),
+    skill: Flags.string({
+      description: bilingual({
+        zh: '仅从指定 skill 的 observe inbox 信号生成草稿（仅 from-traces 模式用）。',
+        en: 'Only draft from observe-inbox signals for the specified skill (from-traces mode only).',
       }),
     }),
   };

--- a/src/cli/lib/cmd-flags.ts
+++ b/src/cli/lib/cmd-flags.ts
@@ -182,6 +182,7 @@ export interface SampleFlags {
   treatment?: string;
   'from-traces': boolean;
   'observations-dir'?: string;
+  skill?: string;
 }
 
 // ── eval gold(3 sub-sub) ─────────────────────────────────────────────────────

--- a/src/observability/inbox-view-model.ts
+++ b/src/observability/inbox-view-model.ts
@@ -20,6 +20,7 @@ import {
 import { durationMsBetween } from '../shared/time.js';
 
 export interface ObservationInboxViewModel {
+  observationsDir?: string;
   activeSkill?: string;
   allItems: ObservationInboxItem[];
   items: ObservationInboxItem[];
@@ -121,6 +122,7 @@ export function buildObservationInboxViewModel(observationsDir: string, options:
   }
 
   return {
+    observationsDir,
     activeSkill,
     allItems,
     items,

--- a/src/renderer/observation-inbox-renderer.ts
+++ b/src/renderer/observation-inbox-renderer.ts
@@ -42,6 +42,7 @@ import {
   skillAnchor,
   truncateText,
 } from './observation-inbox/helpers.js';
+import { shellQuoteArg } from '../shared/shell-quote.js';
 export { renderFeedbackAttributionLabel } from './observation-inbox/helpers.js';
 import type {
   ExperienceAssistiveInference,
@@ -69,6 +70,7 @@ import type {
 
 export function renderObservationInboxPage(model: ObservationInboxViewModel, lang: Lang = DEFAULT_LANG): string {
 	  const {
+	    observationsDir,
 	    activeSkill,
 	    allItems,
 	    items,
@@ -5121,6 +5123,22 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
 	  const empty = items.length === 0 && !experience
 	    ? `<p style="color:var(--text-muted);margin-top:24px">${activeSkill ? `当前 skill 没有可展示的调用或过程发现：${e(activeSkill)}` : (lang === 'zh' ? '暂无 inbox item。运行 omk observe ingest <sessions-dir> 生成。' : 'No inbox items. Run omk observe ingest <sessions-dir> first.')}</p>`
 	    : '';
+  const recyclableObservationCount = allItems.filter((item) => item.severity !== 'noise').reduce((sum, item) => sum + item.occurrences, 0);
+  const sampleFromTracesBaseCommand = `omk sample --from-traces --observations-dir ${shellQuoteArg(observationsDir || '.omk/observe-inbox')}`;
+  const sampleFromTracesCommand = activeSkill
+    ? `${sampleFromTracesBaseCommand} --skill ${shellQuoteArg(activeSkill)}`
+    : sampleFromTracesBaseCommand;
+  const observeLoopCta = recyclableObservationCount > 0
+    ? `<section data-observe-feedback-loop style="margin-top:14px;border:1px solid var(--border);border-radius:8px;background:var(--bg-muted);padding:12px 14px;font-size:13px;line-height:1.55">
+        <div style="display:flex;justify-content:space-between;gap:12px;align-items:flex-start;flex-wrap:wrap">
+          <div>
+            <div style="font-weight:700;color:var(--text-primary)">${lang === 'zh' ? '把已确认的 observe gap 回流成 eval sample' : 'Recycle confirmed observe gaps into eval samples'}</div>
+            <div style="color:var(--text-muted);margin-top:3px">${lang === 'zh' ? `当前有 ${recyclableObservationCount} 个非噪声信号。先 review 高风险或抽样信号，确认可复现后生成草稿。` : `${recyclableObservationCount} non-noise signal(s) are available. Review high-risk / sampled signals first, then draft reproducible cases.`}</div>
+          </div>
+          <code style="display:block;max-width:100%;overflow:auto;white-space:nowrap;padding:6px 8px;border:1px solid var(--border);border-radius:6px;background:var(--bg-surface);color:var(--text-primary)">${e(sampleFromTracesCommand)}</code>
+        </div>
+      </section>`
+    : '';
   const v0SummarySection = `
       <section class="observe-summary-grid" style="display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px;margin-top:14px">
         <div style="padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--bg-surface)">
@@ -5176,6 +5194,7 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
         <div class="metric-guide-body">${metricGuideHtml}</div>
       </aside>
       ${empty}
+      ${observeLoopCta}
       ${experienceSection}
       <div data-v0-observation-view style="display:none">
       <div class="report-version-divider" aria-label="1.0 和 2.0 报告分隔">

--- a/src/shared/shell-quote.ts
+++ b/src/shared/shell-quote.ts
@@ -1,0 +1,7 @@
+const SAFE_SHELL_ARG_RE = /^[A-Za-z0-9_./:@%+=,-]+$/;
+
+/** Format one POSIX shell argument for user-facing copy/paste commands. */
+export function shellQuoteArg(value: string): string {
+  if (value && SAFE_SHELL_ARG_RE.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/test/cli/observe.test.ts
+++ b/test/cli/observe.test.ts
@@ -70,4 +70,126 @@ describe('observe CLI', () => {
     const output = JSON.parse(logs.join('\n')) as { rows: Array<{ skillName: string }> };
     assert.deepEqual(output.rows.map((row) => row.skillName), ['audit']);
   });
+
+  it('prints the observe → sample draft command for recyclable signals', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-observe-cli-'));
+    writeFileSync(join(dir, reportFileName('20260507T000000-a111')), JSON.stringify({
+      kind: 'observe-inbox',
+      schemaVersion: 2,
+      meta: {
+        tracePath: '/tmp/trace',
+        generatedAt: '2026-05-07T00:00:00.000Z',
+        segmentCount: 1,
+        itemCount: 1,
+      },
+      items: [{
+        id: 'obs-audit',
+        skillName: 'audit',
+        artifactVersion: 'unknown',
+        cwd: '/repo',
+        sessionId: 's1',
+        sourceTrace: '/tmp/trace/session.jsonl',
+        sourceKind: 'claude',
+        signalType: 'failed_search',
+        signalSubtype: 'hard_miss',
+        confidence: 0.9,
+        attributionConfidence: 0.85,
+        severity: 'high',
+        severityReasonCode: 'knowledge_gap_suspected',
+        evidence: { tool: 'Grep', query: 'schema' },
+        firstSeen: '2026-05-07T00:00:00.000Z',
+        lastSeen: '2026-05-07T00:00:00.000Z',
+        occurrences: 2,
+        recentSessionIds: ['s1'],
+        representativeEvidence: [{ tool: 'Grep', query: 'schema' }],
+      }],
+    }, null, 2));
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (value?: unknown) => { logs.push(String(value)); };
+    try {
+      await runObserveInbox(
+        {},
+        {
+          lang: 'zh',
+          'input-dir': dir,
+          global: false,
+          'include-noise': false,
+          'by-skill': false,
+          'llm-enhanced-review': false,
+          refresh: false,
+          json: false,
+        },
+        'zh',
+      );
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = logs.join('\n');
+    assert.match(output, /确认高风险或抽样信号后生成回归用例草稿/);
+    assert.ok(output.includes(`omk sample --from-traces --observations-dir ${dir}`), output);
+  });
+
+  it('prints a skill-scoped sample draft command when inbox is filtered by skill', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-observe-cli-'));
+    writeFileSync(join(dir, reportFileName('20260507T000000-a111')), JSON.stringify({
+      kind: 'observe-inbox',
+      schemaVersion: 2,
+      meta: {
+        tracePath: '/tmp/trace',
+        generatedAt: '2026-05-07T00:00:00.000Z',
+        segmentCount: 1,
+        itemCount: 1,
+      },
+      items: [{
+        id: 'obs-audit',
+        skillName: 'audit skill',
+        artifactVersion: 'unknown',
+        cwd: '/repo',
+        sessionId: 's1',
+        sourceTrace: '/tmp/trace/session.jsonl',
+        sourceKind: 'claude',
+        signalType: 'failed_search',
+        signalSubtype: 'hard_miss',
+        confidence: 0.9,
+        attributionConfidence: 0.85,
+        severity: 'high',
+        severityReasonCode: 'knowledge_gap_suspected',
+        evidence: { tool: 'Grep', query: 'schema' },
+        firstSeen: '2026-05-07T00:00:00.000Z',
+        lastSeen: '2026-05-07T00:00:00.000Z',
+        occurrences: 1,
+        recentSessionIds: ['s1'],
+        representativeEvidence: [{ tool: 'Grep', query: 'schema' }],
+      }],
+    }, null, 2));
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (value?: unknown) => { logs.push(String(value)); };
+    try {
+      await runObserveInbox(
+        {},
+        {
+          lang: 'zh',
+          'input-dir': dir,
+          global: false,
+          skill: 'audit skill',
+          'include-noise': false,
+          'by-skill': false,
+          'llm-enhanced-review': false,
+          refresh: false,
+          json: false,
+        },
+        'zh',
+      );
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = logs.join('\n');
+    assert.ok(output.includes(`omk sample --from-traces --observations-dir ${dir} --skill 'audit skill'`), output);
+  });
 });

--- a/test/cli/oclif-sample.test.ts
+++ b/test/cli/oclif-sample.test.ts
@@ -30,11 +30,13 @@ describe('oclif sample', () => {
     assert.ok(stdout.includes('为指定 skill 生成评测用例'), `stdout missing zh description:\n${stdout}`);
     assert.ok(stdout.includes('--batch'), 'stdout missing --batch flag');
     assert.ok(stdout.includes('--fix'), 'stdout missing --fix flag');
+    assert.ok(stdout.includes('--skill'), 'stdout missing --skill flag');
   });
 
   it('--help --lang en 切英文', async () => {
     const { stdout } = await execFileAsync('node', [CLI, 'sample', '--help', '--lang', 'en']);
     assert.ok(stdout.includes('Generate eval samples'), 'stdout should contain en description');
+    assert.ok(stdout.includes('specified skill'), 'stdout should describe --skill in English');
   });
 
   it('缺 positional + 非 batch + 非 fix → exit 1 (生产 execute 透传)', async () => {
@@ -61,6 +63,20 @@ describe('oclif sample', () => {
       assert.ok(
         e.stderr.includes('--append') && e.stderr.includes('单 skill'),
         `stderr missing append-single-only hint:\n${e.stderr}`,
+      );
+    }
+  });
+
+  it('--skill 仅支持 --from-traces → exit 2 + 中文提示', async () => {
+    try {
+      await execFileAsync('node', [CLI, 'sample', 'skills/demo/SKILL.md', '--skill', 'audit']);
+      assert.fail('expected non-zero exit');
+    } catch (err) {
+      const e = err as ExecError;
+      assert.equal(e.code, 2, `expected exit 2, got ${e.code}:\n${e.stderr}`);
+      assert.ok(
+        e.stderr.includes('--skill') && e.stderr.includes('--from-traces'),
+        `stderr missing skill-from-traces-only hint:\n${e.stderr}`,
       );
     }
   });

--- a/test/cli/sample-from-traces.test.ts
+++ b/test/cli/sample-from-traces.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runSampleFromTraces } from '../../src/cli/commands/sample.js';
+import { reportFileName } from '../../src/eval-core/artifact-file-names.js';
+import { withCapturedStderr } from '../helpers/stderr.js';
+
+describe('sample --from-traces', () => {
+  it('filters observe inbox signals by --skill before drafting samples', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-sample-from-traces-'));
+    writeFileSync(join(dir, reportFileName('20260507T000000-a111')), JSON.stringify({
+      kind: 'observe-inbox',
+      schemaVersion: 2,
+      meta: {
+        tracePath: '/tmp/trace',
+        generatedAt: '2026-05-07T00:00:00.000Z',
+        segmentCount: 1,
+        itemCount: 1,
+      },
+      items: [{
+        id: 'obs-wiki',
+        skillName: 'wiki',
+        artifactVersion: 'unknown',
+        cwd: '/repo',
+        sessionId: 's1',
+        sourceTrace: '/tmp/trace/session.jsonl',
+        sourceKind: 'claude',
+        signalType: 'failed_search',
+        signalSubtype: 'hard_miss',
+        confidence: 0.9,
+        attributionConfidence: 0.85,
+        severity: 'high',
+        severityReasonCode: 'knowledge_gap_suspected',
+        evidence: { tool: 'Grep', query: 'schema' },
+        firstSeen: '2026-05-07T00:00:00.000Z',
+        lastSeen: '2026-05-07T00:00:00.000Z',
+        occurrences: 1,
+        recentSessionIds: ['s1'],
+        representativeEvidence: [{ tool: 'Grep', query: 'schema' }],
+      }],
+    }, null, 2));
+
+    const { stderr } = await withCapturedStderr(async () => {
+      await runSampleFromTraces({
+        lang: 'zh',
+        batch: false,
+        model: 'sonnet',
+        'skill-dir': 'skills',
+        append: false,
+        'no-mock': false,
+        fix: false,
+        'from-traces': true,
+        'observations-dir': dir,
+        skill: 'audit',
+      }, 'zh');
+    });
+
+    assert.match(stderr, /audit 没有可回流的失败信号/);
+    assert.equal(existsSync(join(dir, 'sample-drafts.json')), false);
+  });
+});

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -558,6 +558,21 @@ describe('report-server', () => {
     assert.equal(data[0].severity, 'high');
   });
 
+  it('GET /observe-inbox exposes the observe → sample draft next action', async () => {
+    const res = await fetch(`${baseUrl}/observe-inbox`);
+    assert.equal(res.status, 200);
+    assert.match(res.body, /data-observe-feedback-loop/);
+    assert.match(res.body, /把已确认的 observe gap 回流成 eval sample/);
+    assert.match(res.body, /omk sample --from-traces --observations-dir/);
+  });
+
+  it('GET /observe-inbox?skill exposes a skill-scoped sample draft command', async () => {
+    const res = await fetch(`${baseUrl}/observe-inbox?skill=audit`);
+    assert.equal(res.status, 200);
+    assert.match(res.body, /data-observe-feedback-loop/);
+    assert.match(res.body, /omk sample --from-traces --observations-dir[^<]*--skill audit/);
+  });
+
   it('GET /api/observe-inbox/diagnostics exposes observe-backed Diagnosis data', async () => {
     const res = await fetch(`${baseUrl}/api/observe-inbox/diagnostics`);
     assert.equal(res.status, 200);

--- a/test/shared/shell-quote.test.ts
+++ b/test/shared/shell-quote.test.ts
@@ -1,0 +1,13 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { shellQuoteArg } from '../../src/shared/shell-quote.js';
+
+describe('shellQuoteArg', () => {
+  it('keeps simple path-like arguments readable', () => {
+    assert.equal(shellQuoteArg('/tmp/omk-observe-inbox'), '/tmp/omk-observe-inbox');
+  });
+
+  it('single-quotes arguments with spaces or apostrophes', () => {
+    assert.equal(shellQuoteArg("/tmp/omk inbox/user's trace"), "'/tmp/omk inbox/user'\\''s trace'");
+  });
+});


### PR DESCRIPTION
## 用户影响

- `omk observe ingest` 写入 inbox 后，会直接提示下一步查看 inbox，以及确认信号后如何生成回归用例草稿。
- `omk observe inbox` 在存在非噪声信号时，会提示 `omk sample --from-traces`，让 observe gap 更容易回流到 eval sample。
- Studio 的 observe inbox 页面会在有非噪声信号时展示同一条回流命令，用户从页面也能知道下一步该补什么。

## 迁移说明

无需迁移。现有 observe inbox JSON、eval report、sample schema 都保持兼容；新增的是展示层和 CLI 提示。

## 测量学说明

不改变 Report JSON schema、评分 prompt、verdict、bootstrap、Krippendorff alpha 或 length-debias 语义；只是把已有 `sample --from-traces` 草稿入口显性化。`production-trace` 生成物仍是草稿，需人工 review 后再合入正式 eval samples，避免把失败抽样偏差直接并入评测集。

Closes #313

## 验证

已通过 `yarn lint && yarn build && yarn test`。
