### PR TITLE
chore(release): 发布 0.48.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

- 发布 `0.48.0`，包含 `observe → sample` 回流闭环增强。
- `observe inbox` 和 Studio 现在会给出可复制的 `sample --from-traces` 草稿生成指引。
- 单 skill 视图会携带 `--skill`，避免误生成整个 inbox 的样本草稿。

## 迁移说明

无需迁移。新增能力为向后兼容的 CLI / Studio 指引增强。

## 测量学 caveat

本次不改 Report JSON schema、评分类 prompt、五层评分管道、bootstrap CI、Krippendorff alpha 或 length-debias 语义；不标记 `BREAKING-COMPARABILITY`。

## 验证

- `yarn lint && yarn build && yarn test`
