### PR TITLE
docs(init): 补充首跑数据不足提示

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -171,6 +171,7 @@ export default class Init extends BaseCommand {
       console.log(tCli('cli.init.next_steps_title', lang));
       console.log(tCli('cli.init.next_step_run', lang));
       console.log(tCli('cli.init.next_step_executor', lang));
+      console.log(tCli('cli.init.next_step_underpowered', lang));
       console.log(tCli('cli.init.next_step_customize', lang));
       console.log(tCli('cli.init.note_codex_executor', lang));
     });

--- a/src/cli/lib/i18n-dict/init.ts
+++ b/src/cli/lib/i18n-dict/init.ts
@@ -5,6 +5,7 @@ export type InitMessageKey =
   | 'cli.init.next_steps_title'
   | 'cli.init.next_step_run'
   | 'cli.init.next_step_executor'
+  | 'cli.init.next_step_underpowered'
   | 'cli.init.next_step_customize'
   | 'cli.init.note_codex_executor';
 
@@ -27,6 +28,10 @@ export const initDict: Record<InitMessageKey, CliMessage> = {
   'cli.init.next_step_executor': {
     zh: '     默认执行器与评委用 claude CLI，需先装好并登录；想换别的模型或离线跑（无需 API key）见文档「执行器」。',
     en: '     The default executor and judge use the claude CLI (install and log in first); to use another model or run offline (no API key) see the Executors docs.',
+  },
+  'cli.init.next_step_underpowered': {
+    zh: '     模板只有 3 条用例，首跑出现 UNDERPOWERED 是正常起点；要做发布判断时，把用例扩到约 20 条以上后重跑。',
+    en: '     The starter has only 3 cases, so UNDERPOWERED on the first run is normal; for a release decision, grow to roughly 20+ cases and re-run.',
   },
   'cli.init.next_step_customize': {
     zh: '  2. 跑通后，把 skills/code-review-v1/SKILL.md 和 skills/code-review-v2/SKILL.md 与 eval-samples.json 换成你自己的 skill 和用例',

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -51,6 +51,8 @@ describe('oclif init', () => {
       const target = join(dir, 'project');
       const { stdout } = await execFileAsync('node', [CLI, 'init', target]);
       assert.ok(stdout.includes('已初始化 omk 项目'), `stdout missing scaffolded msg:\n${stdout}`);
+      assert.ok(stdout.includes('UNDERPOWERED'), `stdout should set first-run expectation:\n${stdout}`);
+      assert.ok(stdout.includes('20 条以上'), `stdout should suggest growing the sample set before release decisions:\n${stdout}`);
       assert.ok(existsSync(join(target, 'skills', 'code-review-v1', 'SKILL.md')), 'skills/code-review-v1/SKILL.md not created');
       assert.ok(existsSync(join(target, 'eval-samples.json')), 'eval-samples.json not created');
       // 预置 .omk/.gitignore:测量 bulk 不入库,managed/ 不被忽略(默认 track)。


### PR DESCRIPTION
## 用户影响

- `omk init` 成功后会提醒：内置模板只有 3 条用例，首跑出现 `UNDERPOWERED` 是正常起点。
- 提示用户在做发布判断前，把用例扩到约 20 条以上后重跑，和 README / quickstart 的首跑预期保持一致。

## 迁移说明

- 无迁移影响。仅增加 CLI 成功提示和对应测试。

## 测量学 caveat

- 本 PR 不改变 verdict 计算、Report schema、评分管道、评委 prompt 或任何可比性不变量。
- 新增内容只是解释当前模板的样本量限制。

## 验证

- `yarn build && yarn test test/cli/oclif-init.test.ts`
- `yarn build:docs:check && yarn lint && yarn build && yarn test`
