### PR TITLE
docs(quickstart): 对齐命令行示例名称

### DIFF
--- a/docs/quickstart-skill-eval.md
+++ b/docs/quickstart-skill-eval.md
@@ -59,11 +59,13 @@ The omk skill takes care of the rest: it auto-generates samples if `eval-samples
 ### Path B: command line
 
 ```bash
-omk sample skills/my-skill.md                       # first time: AI-generate eval samples
-omk eval --control v1 --treatment v2 --dry-run      # preview the task plan
-omk eval --control v1 --treatment v2                # run for real
-omk studio                                          # open the report browser
+omk sample skills/my-skill-v2.md                                  # first time: AI-generate eval samples
+omk eval --control my-skill-v1 --treatment my-skill-v2 --dry-run  # preview the task plan
+omk eval --control my-skill-v1 --treatment my-skill-v2            # run for real
+omk studio                                                        # open the report browser
 ```
+
+Variant names come from the skill file or directory names under `skills/`; for the layout above, use `my-skill-v1` and `my-skill-v2`.
 
 `--dry-run` prints expected call count and cost estimates — confirm, drop the flag, and run. `omk eval` runs a doctor health check as a preflight gate by default; if a skill has structural problems it gets blocked early. Pass `--skip-doctor` to bypass when you know what you're doing.
 

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -59,11 +59,13 @@ omk skill 会自动判断：没有 `eval-samples.json` 就先帮你生成用例�
 ### 路径 B：直接命令行
 
 ```bash
-omk sample skills/my-skill.md                       # 第一次:让 AI 给你的 skill 生成评测用例
-omk eval --control v1 --treatment v2 --dry-run      # 预览要跑什么
-omk eval --control v1 --treatment v2                # 真跑
-omk studio                                          # 启动报告浏览器
+omk sample skills/my-skill-v2.md                                  # 第一次:让 AI 给你的 skill 生成评测用例
+omk eval --control my-skill-v1 --treatment my-skill-v2 --dry-run  # 预览要跑什么
+omk eval --control my-skill-v1 --treatment my-skill-v2            # 真跑
+omk studio                                                        # 启动报告浏览器
 ```
+
+variant 名来自 `skills/` 下的 skill 文件名或目录名；按上面的布局，就是 `my-skill-v1` 和 `my-skill-v2`。
 
 `--dry-run` 预览时会告诉你预估调用次数和成本，确认 OK 再去掉 flag 真跑。`omk eval` 默认会先跑一次 doctor 健康度检查当门禁，发现 skill 写法有大问题就直接拦下来；如果你确认知道自己在干嘛，加 `--skip-doctor` 绕过。
 


### PR DESCRIPTION
## 用户影响

- quickstart 的命令行路径现在和前文示例布局一致：`my-skill-v1` / `my-skill-v2` 全程对齐。
- 补充说明 variant 名来自 `skills/` 下的文件名或目录名，减少第一次复制命令时的迷路感。

## 迁移说明

- 无迁移影响，仅文档更新。

## 测量学 caveat

- 本 PR 不改变 CLI 行为、verdict 计算、Report schema、评分管道或任何可比性不变量。

## 验证

- `yarn build:docs:check && yarn lint && yarn build && yarn test`
