### PR TITLE
docs(quickstart): 对齐自然语言示例名称

### DIFF
--- a/docs/quickstart-skill-eval.md
+++ b/docs/quickstart-skill-eval.md
@@ -47,14 +47,14 @@ Both layouts are recognized; mixing them is fine. For a v1 vs v2 A/B, drop in tw
 
 Open Claude Code, `cd` into your project, and say:
 
-> Use omk to benchmark skills/my-skill
+> Use omk to compare skills/my-skill-v1 against skills/my-skill-v2
 
 The omk skill takes care of the rest: it auto-generates samples if `eval-samples.json` is missing, runs the eval, and opens the report in your browser. Other useful phrasings:
 
 - "Use omk to compare skills/my-skill-v1 against skills/my-skill-v2"
 - "Use omk to run a baseline control for skills/audit (with-skill vs without-skill)"
 - "Use omk to batch-evaluate every skill under skills/"
-- "Use omk evolve to auto-improve skills/my-skill over 5 rounds"
+- "Use omk evolve to auto-improve skills/my-skill-v2 over 5 rounds"
 
 ### Path B: command line
 

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -47,14 +47,14 @@ skills/
 
 打开 Claude Code，进入项目目录，直接说一句话：
 
-> 帮我用 omk 给 skills/my-skill 跑一次评测
+> 用 omk 对比 skills/my-skill-v1 跟 skills/my-skill-v2
 
 omk skill 会自动判断：没有 `eval-samples.json` 就先帮你生成用例，然后跑评测，最后把报告浏览器弹出来。常见说法：
 
 - 「用 omk 对比 skills/my-skill-v1 跟 skills/my-skill-v2」
 - 「用 omk 给 skills/audit 跑 baseline 对照（有 skill vs 没 skill）」
 - 「用 omk 跑 skills/ 下面所有 skill 的批量评测」
-- 「用 omk evolve 自动改进 skills/my-skill，跑 5 轮」
+- 「用 omk evolve 自动改进 skills/my-skill-v2，跑 5 轮」
 
 ### 路径 B：直接命令行
 


### PR DESCRIPTION
## 用户影响

- quickstart 的自然语言路径现在和示例布局、命令行路径一致，统一使用 `my-skill-v1` / `my-skill-v2`。
- 避免用户在 agent 模式和命令行模式之间切换时，被 `skills/my-skill`、`my-skill-v1`、`my-skill-v2` 三套名字绕晕。

## 迁移说明

- 无迁移影响，仅文档更新。

## 测量学 caveat

- 本 PR 不改变 CLI 行为、verdict 计算、Report schema、评分管道或任何可比性不变量。

## 验证

- `yarn build:docs:check && yarn lint && yarn build && yarn test`
