### PR TITLE
fix(init): 提示进入初始化目录后评测

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,8 +1,9 @@
-import { resolve, join } from 'node:path';
+import { resolve, join, relative } from 'node:path';
 import { Args } from '@oclif/core';
 import { LANG_FLAG, bilingual, resolveLang } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { tCli } from '../lib/i18n.js';
+import { shellQuoteArg } from '../../shared/shell-quote.js';
 
 // 预置 .omk/.gitignore:测量 bulk + doctor --fix 备份(项目本地、不该入库)默认不入库;
 // managed/ 治理档案 + 配置不在此列,默认 track。
@@ -99,6 +100,14 @@ description: 多维度代码审查,覆盖安全 / 健壮 / 可维护 / 性能,�
 对每个维度给出具体的改进建议，并标注严重程度（高/中/低）。
 `;
 
+const INIT_EVAL_COMMAND = 'omk eval --control code-review-v1 --treatment code-review-v2';
+
+function nextEvalCommand(targetDir: string): string {
+  const rel = relative(resolve('.'), targetDir);
+  if (!rel) return INIT_EVAL_COMMAND;
+  return `cd ${shellQuoteArg(rel)} && ${INIT_EVAL_COMMAND}`;
+}
+
 export default class Init extends BaseCommand {
   static description = bilingual({
     zh: '初始化一个 omk 项目：在目标目录铺好待测知识载体（skills/）与评测用例（eval-samples.json），供 omk eval / doctor / evolve / observe / list 操作。默认是两版 code-review skill 的 A/B 起步模板。',
@@ -169,7 +178,7 @@ export default class Init extends BaseCommand {
       console.log(tCli('cli.init.scaffolded', lang, { dir: targetDir }));
       console.log('');
       console.log(tCli('cli.init.next_steps_title', lang));
-      console.log(tCli('cli.init.next_step_run', lang));
+      console.log(tCli('cli.init.next_step_run', lang, { command: nextEvalCommand(targetDir) }));
       console.log(tCli('cli.init.next_step_executor', lang));
       console.log(tCli('cli.init.next_step_underpowered', lang));
       console.log(tCli('cli.init.next_step_customize', lang));

--- a/src/cli/lib/i18n-dict/init.ts
+++ b/src/cli/lib/i18n-dict/init.ts
@@ -22,8 +22,8 @@ export const initDict: Record<InitMessageKey, CliMessage> = {
   // 跑出第一份报告是冷启动最该先发生的事;「换成你自己的」放到跑通之后。这也消除了
   // 主 README「不用改任何文件」与旧 init「先编辑」的矛盾。
   'cli.init.next_step_run': {
-    zh: '  1. 直接跑通（无需先改任何文件）：omk eval --control code-review-v1 --treatment code-review-v2',
-    en: '  1. Run it as-is (no edits needed): omk eval --control code-review-v1 --treatment code-review-v2',
+    zh: '  1. 直接跑通（无需先改任何文件）：{command}',
+    en: '  1. Run it as-is (no edits needed): {command}',
   },
   'cli.init.next_step_executor': {
     zh: '     默认执行器与评委用 claude CLI，需先装好并登录；想换别的模型或离线跑（无需 API key）见文档「执行器」。',

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -49,8 +49,12 @@ describe('oclif init', () => {
     const dir = await mkdtemp(join(tmpdir(), 'omk-oclif-init-'));
     try {
       const target = join(dir, 'project');
-      const { stdout } = await execFileAsync('node', [CLI, 'init', target]);
+      const { stdout } = await execFileAsync('node', [CLI, 'init', 'project'], { cwd: dir });
       assert.ok(stdout.includes('已初始化 omk 项目'), `stdout missing scaffolded msg:\n${stdout}`);
+      assert.ok(
+        stdout.includes(`cd project && omk eval --control code-review-v1 --treatment code-review-v2`),
+        `stdout should include a copy/paste command that enters the target dir first:\n${stdout}`,
+      );
       assert.ok(stdout.includes('UNDERPOWERED'), `stdout should set first-run expectation:\n${stdout}`);
       assert.ok(stdout.includes('20 条以上'), `stdout should suggest growing the sample set before release decisions:\n${stdout}`);
       assert.ok(existsSync(join(target, 'skills', 'code-review-v1', 'SKILL.md')), 'skills/code-review-v1/SKILL.md not created');
@@ -63,6 +67,21 @@ describe('oclif init', () => {
         assert.ok(gi.includes(d), `.omk/.gitignore should ignore ${d}`);
       }
       assert.ok(!/^managed\/?$/m.test(gi), '.omk/.gitignore must not ignore managed/');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('指定目录带空格时，下一步命令会 shell quote cd 目标', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-oclif-init-'));
+    try {
+      const target = join(dir, 'project with spaces');
+      const { stdout } = await execFileAsync('node', [CLI, 'init', 'project with spaces'], { cwd: dir });
+      assert.ok(
+        stdout.includes(`cd 'project with spaces' && omk eval --control code-review-v1 --treatment code-review-v2`),
+        `stdout should quote the target dir in the copy/paste command:\n${stdout}`,
+      );
+      assert.ok(existsSync(target), 'target dir should still be created');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## 用户影响

`omk init my-project` 之后，下一步提示现在会给出可直接复制的 `cd my-project && omk eval ...` 命令。用户把 starter 初始化到子目录时，不会照着提示在原目录运行而找不到 `skills/` 和 `eval-samples.json`。

## 根因

init 输出之前固定展示 `omk eval --control code-review-v1 --treatment code-review-v2`，没有根据初始化目标目录调整工作目录。当前目录初始化没有问题，但指定目录初始化会让首跑路径变得不直观。

## 验证

- `yarn build`
- `yarn test test/cli/oclif-init.test.ts test/cli/init-skill-md.test.ts test/inputs/assertion-language.test.ts`
- `yarn lint`
- `yarn test`

说明：第一次全量 `yarn test` 中 `test/executors/sigint-propagation.test.ts` 出现一次 SIGTERM 超时时序失败；单独重跑该文件通过，随后第二次全量 `yarn test` 通过。