### PR TITLE
fix(eval): 缺少用例时提示生成命令

### DIFF
--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
 import { Flags } from '@oclif/core';
 import { LANG_FLAG, bilingual } from '../../oclif/i18n.js';
 import { BaseCommand } from '../../oclif/base-command.js';
@@ -18,6 +20,7 @@ import {
   findSingleTreatmentDeprecatedSamplesHint,
   hasUsableSamplesPath,
 } from '../../../inputs/sample-locator.js';
+import { shellQuoteArg } from '../../../shared/shell-quote.js';
 
 // oclif 版 eval(默认 = run 模式) — 单次 typed parse 之后业务 inline。flag schema
 // 镜像 RUN_OPTIONS + eval-runner extra = 41 flag。具体语义跟约束在 parseRunConfig 里。
@@ -73,6 +76,28 @@ function applyGateExitCode(code: number, values: ParsedValues, lang: CliLang): n
   if (!reportOnlyMode(values)) return code;
   process.stderr.write(tCli('cli.run.report_only_gate_skipped', lang));
   return 0;
+}
+
+function userFacingPath(path: string): string {
+  const rel = relative(process.cwd(), path);
+  if (rel && rel !== '..' && !rel.startsWith(`..${sep}`)) return rel;
+  return path;
+}
+
+function sampleCommandForSingleTreatment(treatment: string, skillDir: string): string | null {
+  if (existsSync(treatment)) return `omk sample ${shellQuoteArg(treatment)}`;
+
+  const dirSkillPath = join(skillDir, treatment);
+  if (existsSync(join(dirSkillPath, 'SKILL.md'))) {
+    return `omk sample ${shellQuoteArg(userFacingPath(dirSkillPath))}`;
+  }
+
+  const flatSkillPath = join(skillDir, `${treatment}.md`);
+  if (existsSync(flatSkillPath)) {
+    return `omk sample ${shellQuoteArg(userFacingPath(flatSkillPath))}`;
+  }
+
+  return null;
 }
 
 /**
@@ -277,8 +302,15 @@ async function runEval(
         newPath: deprecatedSamplesHint.newPath,
       }));
     }
+    const sampleCommand = !deprecatedSamplesHint && !values.samples && !evalConfig?.samples && treatments.length === 1
+      ? sampleCommandForSingleTreatment(treatments[0], config.skillDir)
+      : null;
+    const missingSamplesMessage = [
+      tCli('cli.common.samples_not_found', lang, { path: config.samplesPath }),
+      sampleCommand ? tCli('cli.common.samples_not_found_hint', lang, { command: sampleCommand }) : '',
+    ].filter(Boolean).join('\n');
     console.error(tCli('cli.common.error_prefix', lang, {
-      message: tCli('cli.common.samples_not_found', lang, { path: config.samplesPath }),
+      message: missingSamplesMessage,
     }));
     throw new CliExit(1);
   }

--- a/src/cli/lib/i18n-dict/common.ts
+++ b/src/cli/lib/i18n-dict/common.ts
@@ -12,6 +12,7 @@ export type CommonMessageKey =
   | 'cli.common.warn_load_samples_failed'
   | 'cli.common.deprecated_skill_samples_path'
   | 'cli.common.samples_not_found'
+  | 'cli.common.samples_not_found_hint'
   | 'cli.update.new_version_available'
   | 'cli.update.box_title'
   | 'cli.update.box_version_line'
@@ -71,6 +72,10 @@ export const commonDict: Record<CommonMessageKey, CliMessage> = {
   'cli.common.samples_not_found': {
     zh: '未找到评测用例：{path}。请通过 --samples 指定文件，或创建项目级 eval-samples.json；单 treatment 目录 skill 请使用 <skill>/.omk/samples.json。',
     en: 'Eval samples not found: {path}. Pass --samples, create project-level eval-samples.json, or use <skill>/.omk/samples.json for a single-treatment directory skill.',
+  },
+  'cli.common.samples_not_found_hint': {
+    zh: '下一步：先运行 {command} 生成用例，人工 review 后再重跑 omk eval。',
+    en: 'Next: run {command} to generate samples, review them, then re-run omk eval.',
   },
   'cli.update.new_version_available': {
     zh: '\n💡 新版本可用：{old} → {new}，运行 npm i -g oh-my-knowledge@latest 升级\n\n',

--- a/test/cli/oclif-eval.test.ts
+++ b/test/cli/oclif-eval.test.ts
@@ -128,6 +128,8 @@ describe('oclif eval', () => {
           const e = err as ExecError;
           assert.equal(e.code, 1, `expected exit 1, got ${e.code}`);
           assert.ok(e.stderr.includes('未找到评测用例'), e.stderr);
+          assert.ok(e.stderr.includes('下一步'), e.stderr);
+          assert.ok(e.stderr.includes('omk sample skills/review'), e.stderr);
           assert.ok(!e.stderr.includes('ENOENT'), e.stderr);
           return true;
         },
@@ -164,6 +166,7 @@ describe('oclif eval', () => {
           assert.ok(e.stderr.includes('发现旧的目录 skill 用例位置'), e.stderr);
           assert.ok(e.stderr.includes(join(skillRoot, 'eval-samples.json')), e.stderr);
           assert.ok(e.stderr.includes(join(skillRoot, '.omk', 'samples.json')), e.stderr);
+          assert.ok(!e.stderr.includes('omk sample skills/review'), e.stderr);
           assert.ok(!e.stderr.includes('ENOENT'), e.stderr);
           return true;
         },


### PR DESCRIPTION
## 用户影响

`omk eval` 找不到评测用例时，错误信息现在会直接给出可执行的下一步。例如 `--treatment review --skill-dir skills` 会提示先运行 `omk sample skills/review` 生成用例，人工 review 后再重跑 `omk eval`。

这样新用户在缺 `eval-samples.json` 或目录 skill 私有 samples 时，可以从错误信息继续往下走，不必再回头查 quickstart。

## 根因

原来的缺 samples 错误只说明缺少用例文件，并列出可用布局；对第一次跑 eval 的用户来说，还需要自己推导应该跑哪条 `omk sample` 命令。eval 的 treatment 短名和 sample 的路径参数也不完全一样，容易误写成 `omk sample review`。

## 说明

发现旧目录 skill 用例位置时，仍保持迁移提示，不额外建议重新生成用例，避免把路径迁移和样本生成混在一起。

## 验证

- `yarn build`
- `yarn test test/cli/oclif-eval.test.ts`
- `yarn lint`
- `yarn test`