### PR TITLE
fix(cli): 提示 sample 生成后的评测命令

### DIFF
--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -1,4 +1,4 @@
-import { resolve, join, basename, dirname, extname } from 'node:path';
+import { resolve, join, basename, dirname, extname, relative, sep } from 'node:path';
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import yaml from 'js-yaml';
 import { Args, Flags } from '@oclif/core';
@@ -17,8 +17,10 @@ import {
 } from '../../inputs/sample-locator.js';
 import { hashSample } from '../../eval-core/evaluation-reporting.js';
 import { hashArtifactSource } from '../../inputs/content-hash.js';
+import { shellQuoteArg } from '../../shared/shell-quote.js';
 import type { SampleArgs, SampleFlags } from '../lib/cmd-flags.js';
 import type { Report, Sample as SampleType } from '../../types/index.js';
+import type { ResolvedSkillInput } from '../lib/resolve-skill-input.js';
 
 interface GenerateSamplesResult {
   samples: unknown[];
@@ -47,6 +49,19 @@ function getSamplesArray(document: unknown, filePath: string): SampleType[] {
 function stringifySampleDocument(filePath: string, document: unknown): string {
   if (isYamlPath(filePath)) return yaml.dump(document, { lineWidth: -1, noRefs: true });
   return JSON.stringify(document, null, 2);
+}
+
+function userFacingPath(filePath: string): string {
+  const rel = relative(process.cwd(), filePath);
+  if (rel && rel !== '..' && !rel.startsWith(`..${sep}`)) return rel;
+  return filePath;
+}
+
+export function sampleNextEvalCommand(
+  resolved: Pick<ResolvedSkillInput, 'isDirectorySkill' | 'skillDir' | 'skillPath'>,
+): string {
+  const treatmentPath = resolved.isDirectorySkill ? resolved.skillDir : resolved.skillPath;
+  return `omk eval --control baseline --treatment ${shellQuoteArg(userFacingPath(treatmentPath))}`;
 }
 
 /** --append 合并:已有用例原样保留,新用例逐条接在后面;sample_id 撞已有(或本批已用)时
@@ -624,7 +639,7 @@ async function runSample(
           n: samples.length, path: outputPath, cost,
         }));
       }
-      console.log(tCli('cli.gen.review_hint', lang));
+      console.log(tCli('cli.gen.review_hint', lang, { command: sampleNextEvalCommand(resolved) }));
     } catch (err: unknown) {
       if (err instanceof CliExit) throw err;
       console.error(tCli('cli.gen.failed', lang, { message: (err as Error).message }));

--- a/src/cli/lib/i18n-dict/gen.ts
+++ b/src/cli/lib/i18n-dict/gen.ts
@@ -77,8 +77,8 @@ export const genDict: Record<GenMessageKey, CliMessage> = {
     en: '--append currently supports single-skill mode only; it cannot be combined with --batch / --from-traces / --fix.\n',
   },
   'cli.gen.review_hint': {
-    zh: '\n请审查生成的评测用例后运行: omk eval',
-    en: '\nReview the generated test cases, then run: omk eval',
+    zh: '\n请审查生成的评测用例后运行：{command}',
+    en: '\nReview the generated test cases, then run: {command}',
   },
   'cli.gen.failed': {
     zh: '生成失败: {message}',

--- a/test/cli/sample-next-eval-command.test.ts
+++ b/test/cli/sample-next-eval-command.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { sampleNextEvalCommand } from '../../src/cli/commands/sample.js';
+
+describe('sampleNextEvalCommand', () => {
+  it('目录 skill 用目录路径作为 treatment', () => {
+    assert.equal(
+      sampleNextEvalCommand({
+        isDirectorySkill: true,
+        skillDir: resolve('skills/review'),
+        skillPath: resolve('skills/review/SKILL.md'),
+      }),
+      'omk eval --control baseline --treatment skills/review',
+    );
+  });
+
+  it('传内部 SKILL.md 的目录 skill 仍提示目录路径', () => {
+    assert.equal(
+      sampleNextEvalCommand({
+        isDirectorySkill: true,
+        skillDir: resolve('skills/review'),
+        skillPath: resolve('skills/review/SKILL.md'),
+      }),
+      'omk eval --control baseline --treatment skills/review',
+    );
+  });
+
+  it('扁平 .md skill 用文件路径作为 treatment', () => {
+    assert.equal(
+      sampleNextEvalCommand({
+        isDirectorySkill: false,
+        skillDir: resolve('skills'),
+        skillPath: resolve('skills/review.md'),
+      }),
+      'omk eval --control baseline --treatment skills/review.md',
+    );
+  });
+
+  it('路径含空格时 shell quote，保证可复制运行', () => {
+    assert.equal(
+      sampleNextEvalCommand({
+        isDirectorySkill: true,
+        skillDir: resolve('skills/review skill'),
+        skillPath: resolve('skills/review skill/SKILL.md'),
+      }),
+      "omk eval --control baseline --treatment 'skills/review skill'",
+    );
+  });
+});


### PR DESCRIPTION
## 用户影响

单 skill 运行 `omk sample` 生成用例后，CLI 现在会直接提示可复制的 `omk eval --control baseline --treatment <skill>` 命令。目录 skill 会提示目录路径，扁平 `.md` skill 会提示文件路径，路径带空格时会自动 shell quote。

## 迁移说明

无迁移成本；只调整成功提示文案，不改变生成、评分或报告 schema。

## 测量学说明

不修改评分类 prompt、Report schema、评分管道或统计口径，只改善 sample → eval 的引导。

## 验证

- `yarn test test/cli/sample-next-eval-command.test.ts`
- `yarn build`
- `yarn lint && yarn test`