### PR TITLE
fix(eval-core): 明确 verdict 发布下一步

### DIFF
--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -13,6 +13,7 @@ import type { EvalArgs, EvalFlags } from '../../lib/cmd-flags.js';
 import type { BatchEvaluationReport, EvaluationReport, Report, ProgressCallback } from '../../../types/index.js';
 import type { DryRunBatchReport, DryRunReport } from '../../../eval-workflows/run-evaluation.js';
 import type { EvalResult, ReportServer } from '../../lib/shared.js';
+import type { VerdictResult } from '../../../eval-core/verdict.js';
 import { DEFAULT_BOOTSTRAP_SAMPLES } from '../../../eval-core/bootstrap.js';
 import { DEFAULT_GATE_THRESHOLD } from '../../../eval-core/verdict.js';
 import { EVALUATION_REPORT_SCHEMA_VERSION } from '../../../eval-core/evaluation-reporting.js';
@@ -41,6 +42,12 @@ interface RepeatProgressInfo {
 }
 
 type ParsedValues = Record<string, string | boolean | undefined>;
+
+interface RecordedEvidenceForPrompt {
+  name: string;
+  variant: string;
+  bound: boolean;
+}
 
 function isDryRunReport(report: unknown): report is DryRunReport {
   return Boolean(report && typeof report === 'object' && (report as { dryRun?: unknown }).dryRun === true);
@@ -122,11 +129,36 @@ function emitVerdictText(text: string): void {
   stream.write(text + '\n');
 }
 
+function treatmentVariantFromVerdict(result: Pick<VerdictResult, 'level' | 'representative' | 'variants'>): string | undefined {
+  if (result.representative?.treatment) return result.representative.treatment;
+  if (result.level === 'SOLO') return result.variants[0];
+  return result.variants[1];
+}
+
+function promoteTargetFromEvidence(
+  result: Pick<VerdictResult, 'level' | 'representative' | 'variants'>,
+  records: RecordedEvidenceForPrompt[],
+): string | undefined {
+  const treatment = treatmentVariantFromVerdict(result);
+  const matched = treatment ? records.filter((r) => r.variant === treatment) : records;
+  const names = new Set(matched.filter((r) => r.bound).map((r) => r.name));
+  return names.size === 1 ? [...names][0] : undefined;
+}
+
+function emitRecordedEvidence(records: RecordedEvidenceForPrompt[], lang: CliLang): void {
+  for (const w of records) {
+    process.stderr.write(
+      tCli(w.bound ? 'cli.run.evidence_recorded' : 'cli.run.evidence_recorded_unbound', lang, { name: w.name }),
+    );
+  }
+}
+
 async function emitEvaluationVerdict(report: EvaluationReport, values: ParsedValues, lang: CliLang): Promise<number> {
   const { computeVerdict, formatVerdictText } = await import('../../../eval-core/verdict.js');
   const result = computeVerdict(report, verdictOptions(values));
-  emitVerdictText(formatVerdictText(result, { verbose: true, lang }));
-  await recordEvidenceSafely(report, result.level, values, lang);
+  const written = await recordEvidenceSafely(report, result.level, values);
+  emitVerdictText(formatVerdictText(result, { verbose: true, lang, promoteTarget: promoteTargetFromEvidence(result, written) }));
+  emitRecordedEvidence(written, lang);
   return verdictPasses(result.level, result.headline) ? 0 : 1;
 }
 
@@ -139,19 +171,14 @@ async function recordEvidenceSafely(
   report: EvaluationReport,
   verdict: string,
   values: ParsedValues,
-  lang: CliLang,
-): Promise<void> {
-  if (values['no-evidence'] === true) return;
+): Promise<RecordedEvidenceForPrompt[]> {
+  if (values['no-evidence'] === true) return [];
   try {
     const { recordEvalEvidence } = await import('../../../managed/index.js');
-    const written = recordEvalEvidence(report, verdict, new Date().toISOString());
-    for (const w of written) {
-      process.stderr.write(
-        tCli(w.bound ? 'cli.run.evidence_recorded' : 'cli.run.evidence_recorded_unbound', lang, { name: w.name }),
-      );
-    }
+    return recordEvalEvidence(report, verdict, new Date().toISOString());
   } catch {
     // 证据写入是旁路,任何异常都不该让评测失败
+    return [];
   }
 }
 
@@ -217,7 +244,7 @@ async function emitBatchVerdict(
   // batch 每个子报告各自是一份独立 skill 的评测 → 各自写证据。
   for (const child of childReports) {
     const v = results.find((r) => r.id === child.id)?.verdict.level ?? 'SOLO';
-    await recordEvidenceSafely(child, v, values, lang);
+    emitRecordedEvidence(await recordEvidenceSafely(child, v, values), lang);
   }
   const passed = results.filter((r) => verdictPasses(r.verdict.level, r.verdict.headline)).length;
   const failed = results.length - passed;

--- a/src/eval-core/verdict.ts
+++ b/src/eval-core/verdict.ts
@@ -33,6 +33,7 @@ import { evaluateLayerGates } from './layer-gates.js';
 import { ciLevelLabel } from './bootstrap.js';
 import { analyzeJudgeIndependence } from './judge-independence.js';
 import { MIN_HOLDOUT_SUBSET } from './holdout.js';
+import { shellQuoteArg } from '../shared/shell-quote.js';
 
 /**
  * Below this sample count a non-significant diff is read as UNDERPOWERED
@@ -676,13 +677,21 @@ function recommendation(level: VerdictLevel, _perPair: Array<{ level: VerdictLev
   }
 }
 
-function releaseNextStep(level: VerdictLevel, lang: Lang): string {
+function nextStepTreatmentName(result: Pick<VerdictResult, 'level' | 'representative' | 'variants'>): string {
+  if (result.representative?.treatment) return result.representative.treatment;
+  if (result.level === 'SOLO') return result.variants[0] ?? '<name>';
+  return result.variants[1] ?? '<name>';
+}
+
+function releaseNextStep(result: Pick<VerdictResult, 'level' | 'representative' | 'variants'>, lang: Lang): string {
+  const treatment = nextStepTreatmentName(result);
+  const treatmentArg = shellQuoteArg(treatment);
   if (lang === 'zh') {
-    switch (level) {
+    switch (result.level) {
       case 'PROGRESS':
-        return '可以进入发布流程：请留存本次报告作为发布证据；如果这是受管 skill，再运行 `omk promote`。';
+        return `可以发布：按你的正常发布流程发布，并留存本次报告作为发布证据；如果这是受管 skill，继续运行 \`omk promote ${treatmentArg}\` 记录接受决定。`;
       case 'CAUTIOUS':
-        return '先看触发的告警（分层门控、评委分歧、稳定性或 holdout），修完再重跑。';
+        return '不要直接发布；先看触发的告警（分层门控、评委分歧、稳定性或 holdout），修完再重跑。';
       case 'REGRESS':
         return '不要发布；定位最差层和失败用例，修复后重跑。';
       case 'NOISE':
@@ -690,14 +699,14 @@ function releaseNextStep(level: VerdictLevel, lang: Lang): string {
       case 'UNDERPOWERED':
         return '把样本数加到至少 20，或先按当前规模 2× 扩充后重跑。';
       case 'SOLO':
-        return '补一个 baseline 对照，再跑 `omk eval --control baseline --treatment <名字>`。';
+        return `补一个 baseline 对照，再跑 \`omk eval --control baseline --treatment ${treatmentArg}\`。`;
     }
   }
-  switch (level) {
+  switch (result.level) {
     case 'PROGRESS':
-      return 'ready for release: keep this report as release evidence; for a managed skill, run `omk promote`.';
+      return `ship through your normal release path and keep this report as release evidence; for a managed skill, run \`omk promote ${treatmentArg}\` to record acceptance.`;
     case 'CAUTIOUS':
-      return 'inspect the warnings (layer gates, judge dissent, stability, or holdout), fix them, then re-run.';
+      return 'do not ship directly; inspect the warnings (layer gates, judge dissent, stability, or holdout), fix them, then re-run.';
     case 'REGRESS':
       return 'do not ship; inspect the weakest layer and failing samples, fix them, then re-run.';
     case 'NOISE':
@@ -705,7 +714,7 @@ function releaseNextStep(level: VerdictLevel, lang: Lang): string {
     case 'UNDERPOWERED':
       return 'increase the sample set to at least 20, or roughly 2x the current size, then re-run.';
     case 'SOLO':
-      return 'add a baseline control and re-run `omk eval --control baseline --treatment <name>`.';
+      return `add a baseline control and re-run \`omk eval --control baseline --treatment ${treatmentArg}\`.`;
   }
 }
 
@@ -729,7 +738,7 @@ export function formatVerdictText(result: VerdictResult, options: { verbose?: bo
   if (result.rationale.gapSignal) lines.push(zh ? `  知识缺口：${result.rationale.gapSignal}` : `  Gap signal:    ${result.rationale.gapSignal}`);
   if (result.rationale.shipRecommendation) {
     lines.push(`  ${zh ? recommendation(result.level, [], 'zh') : result.rationale.shipRecommendation}`);
-    lines.push(zh ? `  下一步：${releaseNextStep(result.level, 'zh')}` : `  Next: ${releaseNextStep(result.level, 'en')}`);
+    lines.push(zh ? `  下一步：${releaseNextStep(result, 'zh')}` : `  Next: ${releaseNextStep(result, 'en')}`);
   }
   if (options.verbose && result.perPair && result.perPair.length > 1) {
     lines.push('');

--- a/src/eval-core/verdict.ts
+++ b/src/eval-core/verdict.ts
@@ -683,13 +683,25 @@ function nextStepTreatmentName(result: Pick<VerdictResult, 'level' | 'representa
   return result.variants[1] ?? '<name>';
 }
 
-function releaseNextStep(result: Pick<VerdictResult, 'level' | 'representative' | 'variants'>, lang: Lang): string {
+interface VerdictTextOptions {
+  verbose?: boolean;
+  lang?: Lang;
+  /** Managed skill NAME from `omk list`; omitted when the formatter cannot know it safely. */
+  promoteTarget?: string;
+}
+
+function promoteCommand(target: string | undefined): string {
+  return target ? `omk promote ${shellQuoteArg(target)}` : 'omk promote <name>';
+}
+
+function releaseNextStep(result: Pick<VerdictResult, 'level' | 'representative' | 'variants'>, lang: Lang, promoteTarget?: string): string {
   const treatment = nextStepTreatmentName(result);
   const treatmentArg = shellQuoteArg(treatment);
+  const promote = promoteCommand(promoteTarget);
   if (lang === 'zh') {
     switch (result.level) {
       case 'PROGRESS':
-        return `可以发布：按你的正常发布流程发布，并留存本次报告作为发布证据；如果这是受管 skill，继续运行 \`omk promote ${treatmentArg}\` 记录接受决定。`;
+        return `可以发布：按你的正常发布流程发布，并留存本次报告作为发布证据；如果这是受管 skill，继续运行 \`${promote}\` 记录接受决定（name 以 \`omk list\` 的 NAME 为准）。`;
       case 'CAUTIOUS':
         return '不要直接发布；先看触发的告警（分层门控、评委分歧、稳定性或 holdout），修完再重跑。';
       case 'REGRESS':
@@ -704,7 +716,7 @@ function releaseNextStep(result: Pick<VerdictResult, 'level' | 'representative' 
   }
   switch (result.level) {
     case 'PROGRESS':
-      return `ship through your normal release path and keep this report as release evidence; for a managed skill, run \`omk promote ${treatmentArg}\` to record acceptance.`;
+      return `ship through your normal release path and keep this report as release evidence; for a managed skill, run \`${promote}\` to record acceptance (name is the NAME from \`omk list\`).`;
     case 'CAUTIOUS':
       return 'do not ship directly; inspect the warnings (layer gates, judge dissent, stability, or holdout), fix them, then re-run.';
     case 'REGRESS':
@@ -722,7 +734,7 @@ function releaseNextStep(result: Pick<VerdictResult, 'level' | 'representative' 
  * Plain-text formatter for the `omk eval` verdict. Stays terse for the
  *  spec — one verdict, rationale bullets, one ship recommendation, and one next step.
  */
-export function formatVerdictText(result: VerdictResult, options: { verbose?: boolean; lang?: Lang } = {}): string {
+export function formatVerdictText(result: VerdictResult, options: VerdictTextOptions = {}): string {
   // lang 默认 'en':保留既有英文输出逐字节不变(verdict.test 与历史 CLI 行为)。zh 只本地化
   //  标签与 ship 建议;headline 是 Δ/CI/N 统计记号 —— 跨语言中性、且会随 report 持久化,
   //  不翻译(翻它=改可比性锚点)。recommendation 在 format 时按 lang 重新派生,不动 computeVerdict。
@@ -738,7 +750,7 @@ export function formatVerdictText(result: VerdictResult, options: { verbose?: bo
   if (result.rationale.gapSignal) lines.push(zh ? `  知识缺口：${result.rationale.gapSignal}` : `  Gap signal:    ${result.rationale.gapSignal}`);
   if (result.rationale.shipRecommendation) {
     lines.push(`  ${zh ? recommendation(result.level, [], 'zh') : result.rationale.shipRecommendation}`);
-    lines.push(zh ? `  下一步：${releaseNextStep(result, 'zh')}` : `  Next: ${releaseNextStep(result, 'en')}`);
+    lines.push(zh ? `  下一步：${releaseNextStep(result, 'zh', options.promoteTarget)}` : `  Next: ${releaseNextStep(result, 'en', options.promoteTarget)}`);
   }
   if (options.verbose && result.perPair && result.perPair.length > 1) {
     lines.push('');

--- a/src/managed/evidence.ts
+++ b/src/managed/evidence.ts
@@ -86,6 +86,7 @@ export function buildEvidenceRef(
 export interface RecordedEvidence {
   recordId: string;
   name: string;
+  variant: string;
   contentHash: string;
   /** true ⇒ evidence.contentHash 等于记录当前 contentHash → deriveManagedState 计为当前证据 →
    *  measurable。false ⇒ 测的是旧内容(已 drift),证据留存但不绑当前版本。 */
@@ -164,7 +165,7 @@ export function recordEvalEvidence(
     if (!ref) continue;
     const merged = appendManagedEvidence(dir, rec.id, ref);
     if (!merged) continue;
-    out.push({ recordId: rec.id, name: rec.name, contentHash: ref.contentHash, bound: ref.contentHash === merged.contentHash });
+    out.push({ recordId: rec.id, name: rec.name, variant: variantKey, contentHash: ref.contentHash, bound: ref.contentHash === merged.contentHash });
   }
   return out;
 }

--- a/test/eval-core/verdict.test.ts
+++ b/test/eval-core/verdict.test.ts
@@ -303,7 +303,8 @@ describe('computeVerdict', () => {
     const text = formatVerdictText(v);
     const lines = text.split('\n');
     assert.ok(lines.length <= 8, `expected ≤8 lines, got ${lines.length}: ${text}`);
-    assert.match(text, /Next: ready for release/);
+    assert.match(text, /Next: ship through your normal release path/);
+    assert.match(text, /omk promote skill/);
   });
 
   it('formatVerdictText gives zh release next step', () => {
@@ -320,7 +321,31 @@ describe('computeVerdict', () => {
     });
     const text = formatVerdictText(computeVerdict(r), { lang: 'zh' });
     assert.match(text, /可发布/);
-    assert.match(text, /下一步：可以进入发布流程/);
+    assert.match(text, /下一步：可以发布/);
+    assert.match(text, /omk promote skill/);
+  });
+
+  it('formatVerdictText shell-quotes action commands when variant names need it', () => {
+    const progressReport = buildReport({
+      variants: ['baseline', 'review skill'],
+      perVariantAvg: {
+        baseline: { fact: 4, behavior: 4, judge: 4, composite: 4 },
+        'review skill': { fact: 4.3, behavior: 4.3, judge: 4.3, composite: 4.3 },
+      },
+      pairs: [{
+        control: 'baseline', treatment: 'review skill',
+        diffBootstrapCI: { low: 0.1, high: 0.5, estimate: 0.3, samples: 1000, significant: true },
+      }],
+    });
+    const progressText = formatVerdictText(computeVerdict(progressReport), { lang: 'zh' });
+    assert.match(progressText, /omk promote 'review skill'/);
+
+    const soloReport = buildReport({
+      variants: ['review skill'],
+      perVariantAvg: { 'review skill': { fact: 4, behavior: 4, judge: 4, composite: 4 } },
+    });
+    const soloText = formatVerdictText(computeVerdict(soloReport), { lang: 'en' });
+    assert.match(soloText, /omk eval --control baseline --treatment 'review skill'/);
   });
 
   it('rationale.stability 在单轮(无 variance)时显式说"未测量"', () => {
@@ -384,10 +409,12 @@ describe('computeVerdict', () => {
     const zhText = formatVerdictText(computeVerdict(r), { lang: 'zh' });
     assert.match(zhText, /缺对照/);
     assert.match(zhText, /下一步：补一个 baseline 对照/);
+    assert.match(zhText, /omk eval --control baseline --treatment solo/);
 
     const enText = formatVerdictText(computeVerdict(r), { lang: 'en' });
     assert.match(enText, /ADD A CONTROL/);
     assert.match(enText, /Next: add a baseline control/);
+    assert.match(enText, /omk eval --control baseline --treatment solo/);
   });
 
   // --- 稳定性门控(PR4)----------------------------------------------------

--- a/test/eval-core/verdict.test.ts
+++ b/test/eval-core/verdict.test.ts
@@ -304,7 +304,8 @@ describe('computeVerdict', () => {
     const lines = text.split('\n');
     assert.ok(lines.length <= 8, `expected ≤8 lines, got ${lines.length}: ${text}`);
     assert.match(text, /Next: ship through your normal release path/);
-    assert.match(text, /omk promote skill/);
+    assert.match(text, /omk promote <name>/);
+    assert.doesNotMatch(text, /omk promote skill/);
   });
 
   it('formatVerdictText gives zh release next step', () => {
@@ -322,10 +323,11 @@ describe('computeVerdict', () => {
     const text = formatVerdictText(computeVerdict(r), { lang: 'zh' });
     assert.match(text, /可发布/);
     assert.match(text, /下一步：可以发布/);
-    assert.match(text, /omk promote skill/);
+    assert.match(text, /omk promote <name>/);
+    assert.match(text, /omk list/);
   });
 
-  it('formatVerdictText shell-quotes action commands when variant names need it', () => {
+  it('formatVerdictText shell-quotes next-step commands when names need it', () => {
     const progressReport = buildReport({
       variants: ['baseline', 'review skill'],
       perVariantAvg: {
@@ -337,8 +339,9 @@ describe('computeVerdict', () => {
         diffBootstrapCI: { low: 0.1, high: 0.5, estimate: 0.3, samples: 1000, significant: true },
       }],
     });
-    const progressText = formatVerdictText(computeVerdict(progressReport), { lang: 'zh' });
-    assert.match(progressText, /omk promote 'review skill'/);
+    const progressText = formatVerdictText(computeVerdict(progressReport), { lang: 'zh', promoteTarget: 'managed skill' });
+    assert.match(progressText, /omk promote 'managed skill'/);
+    assert.doesNotMatch(progressText, /omk promote 'review skill'/);
 
     const soloReport = buildReport({
       variants: ['review skill'],

--- a/test/managed/evidence.test.ts
+++ b/test/managed/evidence.test.ts
@@ -183,6 +183,7 @@ describe('managed evidence — recordEvalEvidence(install→eval→measurable �
     const written = recordEvalEvidence(report, 'PROGRESS', '2026-06-08T00:00:00.000Z', { dir: managed });
     assert.equal(written.length, 1, '匹配到一条受管记录');
     assert.equal(written[0].name, 'review');
+    assert.equal(written[0].variant, 'review');
     assert.equal(written[0].bound, true, '指纹同空间 → 绑定当前版本');
 
     const rec = loadManagedRecord(managed, managedRecordId('skill', 'review'))!;
@@ -217,6 +218,7 @@ describe('managed evidence — recordEvalEvidence(install→eval→measurable �
     const written = recordEvalEvidence(report, 'PROGRESS', 'now', { dir: managed });
     assert.equal(written.length, 1, '按 contentHash 连接,不靠 variant 名');
     assert.equal(written[0].name, 'review', 'CLI 提示用受管记录名而非 git 表达式');
+    assert.equal(written[0].variant, 'git:HEAD:skills/review', '同时保留报告里的 treatment variant 供 CLI 对齐');
     assert.equal(written[0].bound, true);
     const rec = loadManagedRecord(managed, managedRecordId('skill', 'review'))!;
     assert.equal(deriveManagedState({ record: rec, currentContentHash: realHash }).label, 'measurable');
@@ -231,6 +233,8 @@ describe('managed evidence — recordEvalEvidence(install→eval→measurable �
     });
     const written = recordEvalEvidence(report, 'PROGRESS', 'now', { dir: managed });
     assert.equal(written.length, 1, '别名与记录名不同也能按指纹绑定');
+    assert.equal(written[0].name, 'review');
+    assert.equal(written[0].variant, 'candidate');
     assert.equal(written[0].bound, true);
   });
 


### PR DESCRIPTION
## 用户影响

`omk eval` 的单次 verdict 输出现在会给出更清楚的下一步：

- `PROGRESS` 明确写「可以发布」，提醒按正常发布流程发布并留存报告作为发布证据。
- 如果是受管 skill，提示具体的 `omk promote <name>` 命令来记录接受决定。
- `SOLO` 不再只给 `<name>` 占位，而是用当前 variant 名生成可复制的 baseline 对照命令。
- 命令里的 variant 名会 shell quote，避免含空格的名字不可复制。

## 迁移说明

无迁移成本；只调整 CLI verdict 的人类可读行动指引。

## 测量学说明

不修改 `computeVerdict` 判定规则、Report schema、评分类 prompt、评分管道或统计口径。

## 验证

- `yarn test test/eval-core/verdict.test.ts test/shared/shell-quote.test.ts`
- `yarn build`
- `yarn lint && yarn build && yarn test`