### PR TITLE
fix(cli): 提示 evidence 后 promote 命令

### DIFF
--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -145,11 +145,14 @@ function promoteTargetFromEvidence(
   return names.size === 1 ? [...names][0] : undefined;
 }
 
-function emitRecordedEvidence(records: RecordedEvidenceForPrompt[], lang: CliLang): void {
+function emitRecordedEvidence(records: RecordedEvidenceForPrompt[], lang: CliLang, verdict: string): void {
   for (const w of records) {
     const command = `omk promote ${shellQuoteArg(w.name)}`;
+    const key = w.bound && verdict === 'PROGRESS'
+      ? 'cli.run.evidence_recorded_promotable'
+      : (w.bound ? 'cli.run.evidence_recorded' : 'cli.run.evidence_recorded_unbound');
     process.stderr.write(
-      tCli(w.bound ? 'cli.run.evidence_recorded' : 'cli.run.evidence_recorded_unbound', lang, { name: w.name, command }),
+      tCli(key, lang, { name: w.name, command }),
     );
   }
 }
@@ -159,7 +162,7 @@ async function emitEvaluationVerdict(report: EvaluationReport, values: ParsedVal
   const result = computeVerdict(report, verdictOptions(values));
   const written = await recordEvidenceSafely(report, result.level, values);
   emitVerdictText(formatVerdictText(result, { verbose: true, lang, promoteTarget: promoteTargetFromEvidence(result, written) }));
-  emitRecordedEvidence(written, lang);
+  emitRecordedEvidence(written, lang, result.level);
   return verdictPasses(result.level, result.headline) ? 0 : 1;
 }
 
@@ -245,7 +248,7 @@ async function emitBatchVerdict(
   // batch 每个子报告各自是一份独立 skill 的评测 → 各自写证据。
   for (const child of childReports) {
     const v = results.find((r) => r.id === child.id)?.verdict.level ?? 'SOLO';
-    emitRecordedEvidence(await recordEvidenceSafely(child, v, values), lang);
+    emitRecordedEvidence(await recordEvidenceSafely(child, v, values), lang, v);
   }
   const passed = results.filter((r) => verdictPasses(r.verdict.level, r.verdict.headline)).length;
   const failed = results.length - passed;

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -147,8 +147,9 @@ function promoteTargetFromEvidence(
 
 function emitRecordedEvidence(records: RecordedEvidenceForPrompt[], lang: CliLang): void {
   for (const w of records) {
+    const command = `omk promote ${shellQuoteArg(w.name)}`;
     process.stderr.write(
-      tCli(w.bound ? 'cli.run.evidence_recorded' : 'cli.run.evidence_recorded_unbound', lang, { name: w.name }),
+      tCli(w.bound ? 'cli.run.evidence_recorded' : 'cli.run.evidence_recorded_unbound', lang, { name: w.name, command }),
     );
   }
 }

--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -29,6 +29,7 @@ export type RunMessageKey =
   | 'cli.run.tally'
   | 'cli.run.report_saved'
   | 'cli.run.evidence_recorded'
+  | 'cli.run.evidence_recorded_promotable'
   | 'cli.run.evidence_recorded_unbound'
   | 'cli.run.report_only_gate_skipped'
   | 'cli.run.report_server_running'
@@ -151,6 +152,10 @@ export const runDict: Record<RunMessageKey, CliMessage> = {
     en: '📄 Report saved to: {path}\n',
   },
   'cli.run.evidence_recorded': {
+    zh: '🔖 已为受管 skill「{name}」记录评测证据 → measurable\n',
+    en: '🔖 Recorded eval evidence for managed skill "{name}" → measurable\n',
+  },
+  'cli.run.evidence_recorded_promotable': {
     zh: '🔖 已为受管 skill「{name}」记录评测证据 → measurable。运行 {command} 接受当前版本。\n',
     en: '🔖 Recorded eval evidence for managed skill "{name}" → measurable. Run {command} to accept this version.\n',
   },

--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -151,8 +151,8 @@ export const runDict: Record<RunMessageKey, CliMessage> = {
     en: '📄 Report saved to: {path}\n',
   },
   'cli.run.evidence_recorded': {
-    zh: '🔖 已为受管 skill「{name}」记录评测证据 → measurable\n',
-    en: '🔖 Recorded eval evidence for managed skill "{name}" → measurable\n',
+    zh: '🔖 已为受管 skill「{name}」记录评测证据 → measurable。运行 {command} 接受当前版本。\n',
+    en: '🔖 Recorded eval evidence for managed skill "{name}" → measurable. Run {command} to accept this version.\n',
   },
   'cli.run.evidence_recorded_unbound': {
     zh: '🔖 受管 skill「{name}」：评测内容与当前安装版本指纹不一致，证据已留存但不绑当前版本\n',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -531,7 +531,7 @@ describe('CLI', () => {
       assert.match(stderr, /Verdict: PROGRESS/, stderr);
       assert.ok(stderr.includes('omk promote review'), stderr);
       assert.ok(!stderr.includes('omk promote candidate'), stderr);
-      assert.ok(stderr.includes('Recorded eval evidence for managed skill "review"'), stderr);
+      assert.ok(stderr.includes('Recorded eval evidence for managed skill "review" → measurable. Run omk promote review to accept this version.'), stderr);
 
       const managedDir = join(dir, '.omk', 'managed');
       const managedFiles = (await readdir(managedDir)).filter((file) => file.endsWith('.json'));

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -137,6 +137,96 @@ async function writeProductTreeReport(reportsDir: string): Promise<string> {
   return report.id;
 }
 
+async function runManagedSkillEvalFixture(dir: string, candidatePasses: boolean): Promise<{
+  stdout: string;
+  stderr: string;
+  record: { evidence?: unknown[] };
+}> {
+  const skillsDir = join(dir, 'skills', 'review');
+  await mkdir(skillsDir, { recursive: true });
+  await writeFile(join(skillsDir, 'SKILL.md'), [
+    '---',
+    'name: review',
+    'description: e2e promote target fixture',
+    '---',
+    '# review',
+    '',
+    'PROMOTE_TARGET_E2E',
+  ].join('\n'));
+
+  const samples = Array.from({ length: 20 }, (_, i) => ({
+    sample_id: `s${String(i + 1).padStart(2, '0')}`,
+    prompt: 'Return the pass token.',
+    assertions: [{ type: 'contains', value: 'PASS', weight: 1 }],
+  }));
+  await writeFile(join(dir, 'samples.json'), JSON.stringify(samples, null, 2));
+
+  const candidateOutput = candidatePasses ? 'PASS' : 'FAIL';
+  const baselineOutput = candidatePasses ? 'FAIL' : 'PASS';
+  const executor = join(dir, 'executor.mjs');
+  await writeFile(executor, [
+    'import { readFileSync } from "node:fs";',
+    'const req = JSON.parse(readFileSync(0, "utf8"));',
+    `const output = req.system.includes("PROMOTE_TARGET_E2E") ? ${JSON.stringify(candidateOutput)} : ${JSON.stringify(baselineOutput)};`,
+    'console.log(JSON.stringify({ output }));',
+  ].join('\n'));
+
+  await writeFile(join(dir, 'eval.yaml'), [
+    'samples: ./samples.json',
+    `executor: ${JSON.stringify(`node ${executor}`)}`,
+    'noJudge: true',
+    'noDiagnostic: true',
+    'skipDoctor: true',
+    'bootstrap: true',
+    'bootstrapSamples: 100',
+    'variants:',
+    '  - name: baseline',
+    '    role: control',
+    '    artifact: baseline',
+    '    allowedSkills: []',
+    '  - name: candidate',
+    '    role: treatment',
+    '    artifact: ./skills/review',
+  ].join('\n'));
+
+  await execFileAsync('node', [CLI, 'install', 'skills/review', '--dest', join(dir, 'dist-skills')], {
+    cwd: dir,
+    env: { ...process.env, HOME: dir, OMK_SKIP_UPDATE_CHECK: '1' },
+  });
+
+  let stdout: string;
+  let stderr: string;
+  try {
+    const result = await execFileAsync('node', [
+      CLI, 'eval',
+      '--config', 'eval.yaml',
+      '--output-dir', join(dir, 'reports'),
+      '--skip-connectivity',
+      '--no-serve',
+      '--lang', 'en',
+    ], {
+      cwd: dir,
+      env: { ...process.env, HOME: dir, OMK_SKIP_UPDATE_CHECK: '1' },
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    stdout = result.stdout;
+    stderr = result.stderr;
+    assert.equal(candidatePasses, true, `expected non-PROGRESS eval to exit 1:\n${stderr}`);
+  } catch (err) {
+    const e = err as ExecError;
+    assert.equal(candidatePasses, false, e.stderr);
+    assert.equal(e.code, 1, e.stderr);
+    stdout = e.stdout;
+    stderr = e.stderr;
+  }
+
+  const managedDir = join(dir, '.omk', 'managed');
+  const managedFiles = (await readdir(managedDir)).filter((file) => file.endsWith('.json'));
+  assert.equal(managedFiles.length, 1, `expected one managed record, got ${managedFiles.join(', ')}`);
+  const record = JSON.parse(await readFile(join(managedDir, managedFiles[0]), 'utf8')) as { evidence?: unknown[] };
+  return { stdout, stderr, record };
+}
+
 describe('CLI', () => {
   it('--help shows usage', async () => {
     // omk --help 走 oclif,COMMANDS / TOPICS 列出 7 个产品命令。
@@ -464,80 +554,29 @@ describe('CLI', () => {
   it('eval config alias promotes the managed skill NAME, not the treatment label', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'omk-cli-promote-target-'));
     try {
-      const skillsDir = join(dir, 'skills', 'review');
-      await mkdir(skillsDir, { recursive: true });
-      await writeFile(join(skillsDir, 'SKILL.md'), [
-        '---',
-        'name: review',
-        'description: e2e promote target fixture',
-        '---',
-        '# review',
-        '',
-        'PROMOTE_TARGET_E2E',
-      ].join('\n'));
-
-      const samples = Array.from({ length: 20 }, (_, i) => ({
-        sample_id: `s${String(i + 1).padStart(2, '0')}`,
-        prompt: 'Return the pass token.',
-        assertions: [{ type: 'contains', value: 'PASS', weight: 1 }],
-      }));
-      await writeFile(join(dir, 'samples.json'), JSON.stringify(samples, null, 2));
-
-      const executor = join(dir, 'executor.mjs');
-      await writeFile(executor, [
-        'import { readFileSync } from "node:fs";',
-        'const req = JSON.parse(readFileSync(0, "utf8"));',
-        'const output = req.system.includes("PROMOTE_TARGET_E2E") ? "PASS" : "FAIL";',
-        'console.log(JSON.stringify({ output }));',
-      ].join('\n'));
-
-      await writeFile(join(dir, 'eval.yaml'), [
-        'samples: ./samples.json',
-        `executor: ${JSON.stringify(`node ${executor}`)}`,
-        'noJudge: true',
-        'noDiagnostic: true',
-        'skipDoctor: true',
-        'bootstrap: true',
-        'bootstrapSamples: 100',
-        'variants:',
-        '  - name: baseline',
-        '    role: control',
-        '    artifact: baseline',
-        '    allowedSkills: []',
-        '  - name: candidate',
-        '    role: treatment',
-        '    artifact: ./skills/review',
-      ].join('\n'));
-
-      await execFileAsync('node', [CLI, 'install', 'skills/review', '--dest', join(dir, 'dist-skills')], {
-        cwd: dir,
-        env: { ...process.env, HOME: dir, OMK_SKIP_UPDATE_CHECK: '1' },
-      });
-
-      const { stdout, stderr } = await execFileAsync('node', [
-        CLI, 'eval',
-        '--config', 'eval.yaml',
-        '--output-dir', join(dir, 'reports'),
-        '--skip-connectivity',
-        '--no-serve',
-        '--lang', 'en',
-      ], {
-        cwd: dir,
-        env: { ...process.env, HOME: dir, OMK_SKIP_UPDATE_CHECK: '1' },
-        maxBuffer: 2 * 1024 * 1024,
-      });
+      const { stdout, stderr, record } = await runManagedSkillEvalFixture(dir, true);
 
       assert.equal((JSON.parse(stdout) as { kind?: unknown }).kind, 'evaluation', `stdout 应为 report JSON:\n${stdout.slice(0, 200)}`);
       assert.match(stderr, /Verdict: PROGRESS/, stderr);
       assert.ok(stderr.includes('omk promote review'), stderr);
       assert.ok(!stderr.includes('omk promote candidate'), stderr);
       assert.ok(stderr.includes('Recorded eval evidence for managed skill "review" → measurable. Run omk promote review to accept this version.'), stderr);
-
-      const managedDir = join(dir, '.omk', 'managed');
-      const managedFiles = (await readdir(managedDir)).filter((file) => file.endsWith('.json'));
-      assert.equal(managedFiles.length, 1, `expected one managed record, got ${managedFiles.join(', ')}`);
-      const record = JSON.parse(await readFile(join(managedDir, managedFiles[0]), 'utf8')) as { evidence?: unknown[] };
       assert.equal(record.evidence?.length, 1, 'eval should append evidence to the managed review record');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('eval does not suggest default promote for non-PROGRESS managed evidence', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-cli-promote-target-'));
+    try {
+      const { stdout, stderr, record } = await runManagedSkillEvalFixture(dir, false);
+
+      assert.equal((JSON.parse(stdout) as { kind?: unknown }).kind, 'evaluation', `stdout 应为 report JSON:\n${stdout.slice(0, 200)}`);
+      assert.match(stderr, /Verdict: (REGRESS|CAUTIOUS|NOISE|UNDERPOWERED)/, stderr);
+      assert.ok(stderr.includes('Recorded eval evidence for managed skill "review" → measurable'), stderr);
+      assert.ok(!stderr.includes('Run omk promote review to accept this version.'), stderr);
+      assert.equal(record.evidence?.length, 1, 'eval should still append non-PROGRESS evidence to the managed review record');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## 用户影响

`omk eval` 成功把当前版本写入受管 evidence 后，提示会直接给出下一步命令：运行 `omk promote <name>` 接受当前版本。用户不需要再从 `measurable` 状态反推下一步。

## 迁移说明

无迁移需求。只增强 CLI 提示；unbound evidence 仍不会提示 promote，避免把旧内容证据误当成当前版本可接受。

## 测量学说明

不改变评分、verdict、报告 schema 或 evidence 写入语义，只补充 evidence 写入后的操作指引。命令目标仍来自真实受管记录名，并经过 shell quoting，延续 #330 / #331 的受管 NAME 口径。

## 验证

`yarn lint && yarn build && yarn test` 已通过。
