### PR TITLE
fix(executors): 修复脚本执行器裸路径

### DIFF
--- a/src/executors/script.ts
+++ b/src/executors/script.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { isAbsolute, resolve } from 'node:path';
+import { basename, isAbsolute, resolve } from 'node:path';
 import type { ExecResult, ExecutorFn, ExecutorInput } from '../types/index.js';
 import { materializeForCliConfigDir } from '../eval-core/mocks-runtime.js';
 import {
@@ -15,9 +15,17 @@ import {
 // 让用户知道 strict-baseline / 显式 allowedSkills 在 script executor 下静默无效。
 let scriptIsolationWarned = false;
 
-function resolveExecutorPath(part: string, baseCwd: string): string {
+function resolvesBareFileArgs(commandPath: string): boolean {
+  const name = basename(commandPath).toLowerCase().replace(/\.(exe|cmd|bat)$/, '');
+  return new Set(['node', 'python', 'python2', 'python3', 'bash', 'sh', 'zsh', 'ruby', 'perl', 'php', 'bun', 'deno'])
+    .has(name);
+}
+
+function resolveExecutorPath(part: string, baseCwd: string, options: { resolveBare?: boolean } = {}): string {
   if (isAbsolute(part)) return part;
-  if (!part.includes('/') && !part.startsWith('.')) return part;
+  if (part.startsWith('-')) return part;
+  const pathLike = part.includes('/') || part.startsWith('.');
+  if (!pathLike && !options.resolveBare) return part;
   const candidate = resolve(baseCwd, part);
   return existsSync(candidate) ? candidate : part;
 }
@@ -26,9 +34,10 @@ export function createScriptExecutor(command: string): ExecutorFn {
   const baseCwd = process.cwd();
   const parts = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [command];
   const cmd = resolveExecutorPath(parts[0].replace(/^["']|["']$/g, ''), baseCwd);
+  const resolveBareArgs = resolvesBareFileArgs(cmd);
   const args = parts.slice(1)
     .map((a) => a.replace(/^["']|["']$/g, ''))
-    .map((a) => resolveExecutorPath(a, baseCwd));
+    .map((a) => resolveExecutorPath(a, baseCwd, { resolveBare: resolveBareArgs }));
 
   return async function scriptExecutor({ model, system, prompt, cwd, timeoutMs = DEFAULT_TIMEOUT_MS, allowedSkills, mocks, mocksBaseDir, mocksStrict }: ExecutorInput): Promise<ExecResult> {
     if (allowedSkills !== undefined && !scriptIsolationWarned) {

--- a/src/executors/script.ts
+++ b/src/executors/script.ts
@@ -15,10 +15,32 @@ import {
 // 让用户知道 strict-baseline / 显式 allowedSkills 在 script executor 下静默无效。
 let scriptIsolationWarned = false;
 
+const SCRIPT_FILE_INTERPRETERS = new Set([
+  'node',
+  'nodejs',
+  'bash',
+  'sh',
+  'zsh',
+  'ruby',
+  'perl',
+  'php',
+  'bun',
+  'deno',
+]);
+
+const SCRIPTLESS_INTERPRETER_FLAGS_WITH_VALUE = new Set(['-m', '-c', '-e', '-p', '--eval', '--print']);
+
 function resolvesBareFileArgs(commandPath: string): boolean {
   const name = basename(commandPath).toLowerCase().replace(/\.(exe|cmd|bat)$/, '');
-  return new Set(['node', 'python', 'python2', 'python3', 'bash', 'sh', 'zsh', 'ruby', 'perl', 'php', 'bun', 'deno'])
-    .has(name);
+  return SCRIPT_FILE_INTERPRETERS.has(name) || /^python(?:\d+(?:\.\d+)*)?$/.test(name);
+}
+
+function isBareScriptFileArg(part: string): boolean {
+  return !part.includes('/') && !part.startsWith('.') && /\.(?:cjs|cts|js|jsx|mjs|mts|php|pl|py|pyw|rb|sh|ts|tsx)$/i.test(part);
+}
+
+function isInlineScriptlessInterpreterFlag(arg: string): boolean {
+  return /^(?:--eval=|--print=|-[mcep].+)/.test(arg);
 }
 
 function resolveExecutorPath(part: string, baseCwd: string, options: { resolveBare?: boolean } = {}): string {
@@ -30,14 +52,42 @@ function resolveExecutorPath(part: string, baseCwd: string, options: { resolveBa
   return existsSync(candidate) ? candidate : part;
 }
 
+function resolveExecutorArgs(args: string[], commandPath: string, baseCwd: string): string[] {
+  if (!resolvesBareFileArgs(commandPath)) return args.map((a) => resolveExecutorPath(a, baseCwd));
+
+  let scriptResolved = false;
+  let scriptPositionClosed = false;
+  let skipNext = false;
+  return args.map((arg) => {
+    if (skipNext) {
+      skipNext = false;
+      return arg;
+    }
+    if (!scriptResolved && !scriptPositionClosed) {
+      if (SCRIPTLESS_INTERPRETER_FLAGS_WITH_VALUE.has(arg)) {
+        skipNext = true;
+        scriptPositionClosed = true;
+        return arg;
+      }
+      if (isInlineScriptlessInterpreterFlag(arg)) {
+        scriptPositionClosed = true;
+        return arg;
+      }
+      if (arg.startsWith('-') && arg !== '--') return arg;
+      if (arg === '--') return arg;
+      scriptResolved = true;
+      return resolveExecutorPath(arg, baseCwd, { resolveBare: isBareScriptFileArg(arg) });
+    }
+    return resolveExecutorPath(arg, baseCwd);
+  });
+}
+
 export function createScriptExecutor(command: string): ExecutorFn {
   const baseCwd = process.cwd();
   const parts = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [command];
   const cmd = resolveExecutorPath(parts[0].replace(/^["']|["']$/g, ''), baseCwd);
-  const resolveBareArgs = resolvesBareFileArgs(cmd);
-  const args = parts.slice(1)
-    .map((a) => a.replace(/^["']|["']$/g, ''))
-    .map((a) => resolveExecutorPath(a, baseCwd, { resolveBare: resolveBareArgs }));
+  const rawArgs = parts.slice(1).map((a) => a.replace(/^["']|["']$/g, ''));
+  const args = resolveExecutorArgs(rawArgs, cmd, baseCwd);
 
   return async function scriptExecutor({ model, system, prompt, cwd, timeoutMs = DEFAULT_TIMEOUT_MS, allowedSkills, mocks, mocksBaseDir, mocksStrict }: ExecutorInput): Promise<ExecResult> {
     if (allowedSkills !== undefined && !scriptIsolationWarned) {

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createExecutor } from '../src/executors/index.js';
@@ -52,6 +52,53 @@ describe('createExecutor', () => {
       assert.equal(result.output, 'fixture: hello');
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves bare script file args before per-task cwd changes', async () => {
+    const baseCwd = await mkdtemp(join(tmpdir(), 'omk-script-executor-base-'));
+    const taskCwd = await mkdtemp(join(tmpdir(), 'omk-script-executor-task-'));
+    const prevCwd = process.cwd();
+    try {
+      await writeFile(join(baseCwd, 'bare-executor.mjs'), [
+        'import { readFileSync } from "node:fs";',
+        'const req = JSON.parse(readFileSync(0, "utf8"));',
+        'console.log(JSON.stringify({ output: `bare: ${req.prompt}` }));',
+      ].join('\n'));
+      process.chdir(baseCwd);
+      const executor = createExecutor('node bare-executor.mjs');
+      const result = await executor({
+        model: 'test',
+        system: '',
+        prompt: 'hello',
+        cwd: taskCwd,
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.output, 'bare: hello');
+    } finally {
+      process.chdir(prevCwd);
+      await rm(baseCwd, { recursive: true, force: true });
+      await rm(taskCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not rewrite bare args for non-interpreter script commands', async () => {
+    const baseCwd = await mkdtemp(join(tmpdir(), 'omk-script-executor-echo-'));
+    const prevCwd = process.cwd();
+    try {
+      await writeFile(join(baseCwd, 'marker'), 'local file should not turn echo arg absolute');
+      process.chdir(baseCwd);
+      const executor = createExecutor('/bin/echo marker');
+      const result = await executor({
+        model: 'test',
+        system: '',
+        prompt: 'ignored',
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.output, 'marker');
+    } finally {
+      process.chdir(prevCwd);
+      await rm(baseCwd, { recursive: true, force: true });
     }
   });
 

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createExecutor } from '../src/executors/index.js';
@@ -99,6 +99,37 @@ describe('createExecutor', () => {
     } finally {
       process.chdir(prevCwd);
       await rm(baseCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not rewrite interpreter module names as local paths', async () => {
+    const baseCwd = await mkdtemp(join(tmpdir(), 'omk-script-executor-module-'));
+    const taskCwd = await mkdtemp(join(tmpdir(), 'omk-script-executor-module-task-'));
+    const prevCwd = process.cwd();
+    try {
+      await mkdir(join(baseCwd, 'my_provider'));
+      const fakePython = join(baseCwd, 'python');
+      await writeFile(fakePython, [
+        '#!/usr/bin/env node',
+        'import { readFileSync } from "node:fs";',
+        'readFileSync(0, "utf8");',
+        'console.log(JSON.stringify({ output: process.argv.slice(2).join("|") }));',
+      ].join('\n'));
+      await chmod(fakePython, 0o755);
+      process.chdir(baseCwd);
+      const executor = createExecutor('./python -m my_provider');
+      const result = await executor({
+        model: 'test',
+        system: '',
+        prompt: 'hello',
+        cwd: taskCwd,
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.output, '-m|my_provider');
+    } finally {
+      process.chdir(prevCwd);
+      await rm(baseCwd, { recursive: true, force: true });
+      await rm(taskCwd, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## 用户影响

用户按文档或首跑离线路径写 `--executor "node my_provider.mjs"` / `--executor "python my_provider.py"` 时，脚本文件会先按启动 omk 的目录解析成绝对路径，再进入每个 artifact 的隔离 cwd 执行。这样自定义 executor 不会因为 cwd 切到 `~/.oh-my-knowledge/state/trees/...` 而找不到相对脚本。

## 根因

script executor 只会提前解析带 `/` 或 `./` 的路径参数；裸文件参数（如 `offline-executor.mjs`）被原样传给 `node`。eval 运行目录随后切到每个 directory-skill 的隔离副本，导致解释器在隔离树里找脚本并失败。

## 改动

- 对常见解释器命令（node / python / shell / ruby / perl / php / bun / deno）的裸文件参数，如果文件存在于创建 executor 时的 cwd，就固化成绝对路径。
- 保持非解释器命令的裸参数不改写，避免 `echo marker` 这类命令被意外变成绝对路径。
- 补回归测试覆盖上述两个边界。

## 验证

- `yarn test test/executor.test.ts`
- `yarn lint`
- `yarn build`
- `yarn test`
- 临时首跑验证：`omk init` 后使用 `--executor "node offline-executor.mjs"` 跑 eval，不再出现隔离树下找不到 executor 脚本的错误。
