### PR TITLE
fix(cli): 收紧首跑主路径提示

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -180,9 +180,9 @@ export default class Init extends BaseCommand {
       console.log(tCli('cli.init.next_steps_title', lang));
       console.log(tCli('cli.init.next_step_run', lang, { command: nextEvalCommand(targetDir) }));
       console.log(tCli('cli.init.next_step_executor', lang));
-      console.log(tCli('cli.init.next_step_underpowered', lang));
+      console.log(tCli('cli.init.next_step_report', lang));
       console.log(tCli('cli.init.next_step_customize', lang));
-      console.log(tCli('cli.init.note_codex_executor', lang));
+      console.log(tCli('cli.init.note_skill_injection', lang));
     });
   }
 }

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -610,7 +610,7 @@ async function runSample(
 
     // 已有用例文件:默认报错保护;--append 时追加(下面合并),不报错。
     if (existingFile && !flags.append) {
-      console.error(tCli('cli.gen.samples_already_exists', lang));
+      console.error(tCli('cli.gen.samples_already_exists', lang, { command: sampleNextEvalCommand(resolved) }));
       throw new CliExit(1);
     }
 

--- a/src/cli/lib/i18n-dict/gen.ts
+++ b/src/cli/lib/i18n-dict/gen.ts
@@ -45,16 +45,16 @@ export const genDict: Record<GenMessageKey, CliMessage> = {
     en: 'No eval-samples need generating (all skills already have paired files)',
   },
   'cli.gen.batch_summary': {
-    zh: '\n共生成 {n} 份 eval-samples, 请审查后运行: omk eval --batch',
-    en: '\nGenerated {n} eval-samples files. Review them, then run: omk eval --batch',
+    zh: '\n共生成 {n} 份 eval-samples。下一步：\n  1. 人工审查生成的评测用例，删掉不可信样本，补边界、反例\n  2. 预览任务：omk eval --batch --dry-run\n  3. 跑评测：omk eval --batch',
+    en: '\nGenerated {n} eval-samples files. Next steps:\n  1. Review the generated samples; drop weak cases and add boundary / counterexamples\n  2. Preview the task plan: omk eval --batch --dry-run\n  3. Run the eval: omk eval --batch',
   },
   'cli.gen.specify_skill_path': {
     zh: '请指定 skill 文件路径, 例如: omk sample skills/my-skill.md',
     en: 'Please specify a skill file path, e.g.: omk sample skills/my-skill.md',
   },
   'cli.gen.samples_already_exists': {
-    zh: 'eval-samples.json 已存在。如需覆盖请先删除该文件。',
-    en: 'eval-samples.json already exists. Delete it first if you want to overwrite.',
+    zh: 'eval-samples 已存在。要补场景请加 --append（常配 --focus）；要继续评测，运行：{command}',
+    en: 'eval-samples already exist. To add scenarios, use --append (often with --focus); to continue, run: {command}',
   },
   'cli.gen.single_generating': {
     zh: '🔄 正在生成 {count} 条评测用例...\n',
@@ -77,8 +77,8 @@ export const genDict: Record<GenMessageKey, CliMessage> = {
     en: '--append currently supports single-skill mode only; it cannot be combined with --batch / --from-traces / --fix.\n',
   },
   'cli.gen.review_hint': {
-    zh: '\n请审查生成的评测用例后运行：{command}',
-    en: '\nReview the generated test cases, then run: {command}',
+    zh: '\n下一步：\n  1. 人工审查生成的评测用例，删掉不可信样本，补边界、反例\n  2. 预览任务：{command} --dry-run\n  3. 跑评测：{command}',
+    en: '\nNext steps:\n  1. Review the generated samples; drop weak cases and add boundary / counterexamples\n  2. Preview the task plan: {command} --dry-run\n  3. Run the eval: {command}',
   },
   'cli.gen.failed': {
     zh: '生成失败: {message}',

--- a/src/cli/lib/i18n-dict/init.ts
+++ b/src/cli/lib/i18n-dict/init.ts
@@ -5,9 +5,9 @@ export type InitMessageKey =
   | 'cli.init.next_steps_title'
   | 'cli.init.next_step_run'
   | 'cli.init.next_step_executor'
-  | 'cli.init.next_step_underpowered'
+  | 'cli.init.next_step_report'
   | 'cli.init.next_step_customize'
-  | 'cli.init.note_codex_executor';
+  | 'cli.init.note_skill_injection';
 
 export const initDict: Record<InitMessageKey, CliMessage> = {
   'cli.init.scaffolded': {
@@ -25,20 +25,20 @@ export const initDict: Record<InitMessageKey, CliMessage> = {
     zh: '  1. 直接跑通（无需先改任何文件）：{command}',
     en: '  1. Run it as-is (no edits needed): {command}',
   },
-  'cli.init.next_step_executor': {
-    zh: '     默认执行器与评委用 claude CLI，需先装好并登录；想换别的模型或离线跑（无需 API key）见文档「执行器」。',
-    en: '     The default executor and judge use the claude CLI (install and log in first); to use another model or run offline (no API key) see the Executors docs.',
+  'cli.init.next_step_report': {
+    zh: '  2. 看报告里的 verdict 和“下一步”：PROGRESS 才能发布；UNDERPOWERED / NOISE 先扩样到约 20 条以上后重跑。',
+    en: '  2. Read the report verdict and Next line: PROGRESS can ship; UNDERPOWERED / NOISE means grow to roughly 20+ samples and re-run.',
   },
-  'cli.init.next_step_underpowered': {
-    zh: '     模板只有 3 条用例，首跑出现 UNDERPOWERED 是正常起点；要做发布判断时，把用例扩到约 20 条以上后重跑。',
-    en: '     The starter has only 3 cases, so UNDERPOWERED on the first run is normal; for a release decision, grow to roughly 20+ cases and re-run.',
+  'cli.init.next_step_executor': {
+    zh: '     默认 executor / judge 使用 claude CLI；离线或其它模型见 docs/reference/executors.md。',
+    en: '     The default executor / judge use the claude CLI; for offline or other models see docs/reference/executors.md.',
   },
   'cli.init.next_step_customize': {
-    zh: '  2. 跑通后，把 skills/code-review-v1/SKILL.md 和 skills/code-review-v2/SKILL.md 与 eval-samples.json 换成你自己的 skill 和用例',
-    en: '  2. Once it runs, replace skills/code-review-v1/SKILL.md and skills/code-review-v2/SKILL.md and eval-samples.json with your own skills and cases',
+    zh: '  3. 跑通后，替换为你自己的 skill 和 eval-samples.json；还没有用例时先运行 omk sample <skill-path>。',
+    en: '  3. Once it runs, replace the starter skills and eval-samples.json with your own; if you have no samples yet, run omk sample <skill-path>.',
   },
-  'cli.init.note_codex_executor': {
-    zh: '\n注: omk 评测时把 SKILL.md 整文(含 frontmatter)作为 system prompt 注入——跨 executor 一致(claude / codex / openai-api / gemini 都走同一条路径,不依赖任何 executor 的 native skill auto-discovery 或 Skill 工具机制)。frontmatter 在 prompt 头部对 model 行为无显著影响。\n模板带 Claude Code 兼容的 frontmatter(name + description)是为了让同一份 directory-skill 也能 deploy 到 Claude Code:把整个目录复制到 ~/.claude/skills/code-review-v1/(整目录,不是单个 SKILL.md),Claude SDK 才能识别。这是 omk 评测之外的 bonus,一份文件双向 dogfood。',
-    en: '\nNote: during omk evaluation the full SKILL.md (frontmatter included) is injected as the system prompt — uniformly across executors (claude / codex / openai-api / gemini all take the same path; omk does not rely on any executor\'s native skill auto-discovery or Skill tool). Frontmatter has no measurable impact on model behavior in this position.\nThe template ships with Claude Code-compatible frontmatter (name + description) so the same directory-skill can also be deployed to Claude Code: copy the whole directory to ~/.claude/skills/code-review-v1/ (the directory, not just SKILL.md) so Claude SDK can recognize it. That is a bonus beyond omk evaluation — one source, two-way dogfood.',
+  'cli.init.note_skill_injection': {
+    zh: '     注：omk eval 会把 SKILL.md 作为 system prompt 注入；模板 frontmatter 只是方便同一目录复用为 agent skill。',
+    en: '     Note: omk eval injects SKILL.md as the system prompt; the starter frontmatter only helps reuse the same directory as an agent skill.',
   },
 };

--- a/src/executors/script.ts
+++ b/src/executors/script.ts
@@ -129,8 +129,8 @@ export function createScriptExecutor(command: string): ExecutorFn {
       timeoutMs,
       ...(cwd && { cwd }),
     });
-    child.stdin?.write(input);
-    child.stdin?.end();
+    child.stdin?.on('error', () => undefined);
+    child.stdin?.end(input);
 
     try {
       const r = await done;

--- a/test/cli/init-skill-md.test.ts
+++ b/test/cli/init-skill-md.test.ts
@@ -79,19 +79,16 @@ describe('omk init produces directory-skill SKILL.md layout', () => {
     }
   });
 
-  it('next-step output explains evaluation injection, cross-executor parity, and the directory-level deploy path', () => {
+  it('next-step output keeps evaluation injection as a concise note', () => {
     const output = execFileSync('node', [CLI, 'init', tmpDir], { encoding: 'utf-8' });
-    assert.match(output, /code-review-v1\/SKILL\.md/);
-    assert.match(output, /code-review-v2\/SKILL\.md/);
+    assert.match(output, /看报告里的 verdict|Read the report verdict/);
+    assert.match(output, /omk sample <skill-path>/);
 
     // Evaluation path: omk injects SKILL.md as system prompt uniformly across executors.
     // The note must NOT claim Claude executor goes through native skill auto-discovery,
     // because that's the runtime mechanism (~/.claude/skills/), not omk's eval path.
     assert.match(output, /system prompt|system 注入/);
-    assert.match(output, /跨 executor|cross-executor|claude.*codex|codex.*claude/);
     assert.doesNotMatch(output, /Claude executor 走 native skill/);
-
-    // Deploy path: must point at ~/.claude/skills/<name>/ as a directory, not just the file.
-    assert.match(output, /~\/\.claude\/skills\/code-review-v1|the whole directory|整个目录|整目录/);
+    assert.doesNotMatch(output, /~\/\.claude\/skills\/code-review-v1/);
   });
 });

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -57,6 +57,8 @@ describe('oclif init', () => {
       );
       assert.ok(stdout.includes('UNDERPOWERED'), `stdout should set first-run expectation:\n${stdout}`);
       assert.ok(stdout.includes('20 条以上'), `stdout should suggest growing the sample set before release decisions:\n${stdout}`);
+      assert.ok(stdout.includes('看报告里的 verdict'), `stdout should tell users where to make the release decision:\n${stdout}`);
+      assert.ok(stdout.includes('omk sample <skill-path>'), `stdout should route users with no samples back to sample generation:\n${stdout}`);
       assert.ok(existsSync(join(target, 'skills', 'code-review-v1', 'SKILL.md')), 'skills/code-review-v1/SKILL.md not created');
       assert.ok(existsSync(join(target, 'eval-samples.json')), 'eval-samples.json not created');
       // 预置 .omk/.gitignore:测量 bulk 不入库,managed/ 不被忽略(默认 track)。

--- a/test/cli/sample-next-eval-command.test.ts
+++ b/test/cli/sample-next-eval-command.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { resolve } from 'node:path';
 import { sampleNextEvalCommand } from '../../src/cli/commands/sample.js';
+import { tCli } from '../../src/cli/lib/i18n.js';
 
 describe('sampleNextEvalCommand', () => {
   it('目录 skill 用目录路径作为 treatment', () => {
@@ -46,5 +47,16 @@ describe('sampleNextEvalCommand', () => {
       }),
       "omk eval --control baseline --treatment 'skills/review skill'",
     );
+  });
+
+  it('生成后提示先 dry-run 再正式 eval', () => {
+    const command = "omk eval --control baseline --treatment 'skills/review skill'";
+    const zh = tCli('cli.gen.review_hint', 'zh', { command });
+    assert.match(zh, /预览任务：omk eval --control baseline --treatment 'skills\/review skill' --dry-run/);
+    assert.match(zh, /跑评测：omk eval --control baseline --treatment 'skills\/review skill'/);
+
+    const en = tCli('cli.gen.review_hint', 'en', { command });
+    assert.match(en, /Preview the task plan: omk eval --control baseline --treatment 'skills\/review skill' --dry-run/);
+    assert.match(en, /Run the eval: omk eval --control baseline --treatment 'skills\/review skill'/);
   });
 });


### PR DESCRIPTION
## 用户影响

这个 PR 把第一次跑 omk 的主路径提示收紧到更可执行的三步：直接跑模板、读报告 verdict 与下一步、再替换成自己的 skill 和用例。`omk sample` 生成或遇到已有用例时，也会明确提示先 `--dry-run` 预览任务，再跑正式 `omk eval`。

远端 CI 还暴露了一个自定义执行器边界：对 `/bin/echo` 这类不读 stdin、很快退出的命令，写入 stdin 可能触发 EPIPE。这里一并把 stdin 写入改成可忽略早退错误，退出结果仍由子进程状态决定。

## 迁移说明

无迁移。不改变命令参数、report schema、verdict 计算、历史报告读取或样本加载语义。

## 测量学 caveat

本次不修改评分类 prompt、评分管道、bootstrap / verdict 门控或样本加载语义；首跑提示里继续强调小样本不足以做发布判断，需要扩样后重跑。

## 验证

已通过 `yarn lint && yarn build && yarn test`。