### PR TITLE
test(cli): 覆盖首跑主路径

### DIFF
--- a/test/cli/first-run-smoke.test.ts
+++ b/test/cli/first-run-smoke.test.ts
@@ -1,0 +1,115 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const CLI = join(PROJECT_ROOT, 'dist', 'cli', 'index.js');
+
+function parseFirstJsonObject(output: string): unknown {
+  const start = output.indexOf('{');
+  assert.notEqual(start, -1, `stdout should include a JSON object:\n${output}`);
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < output.length; i++) {
+    const ch = output[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = inString;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === '{') depth++;
+    if (ch === '}') {
+      depth--;
+      if (depth === 0) return JSON.parse(output.slice(start, i + 1));
+    }
+  }
+  assert.fail(`stdout JSON object was not closed:\n${output}`);
+}
+
+describe('first-run smoke path', () => {
+  it('runs init -> eval dry-run -> offline eval and writes a report', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omk-first-run-smoke-'));
+    const project = join(root, 'demo');
+    try {
+      const init = await execFileAsync('node', [CLI, 'init', project, '--lang', 'zh']);
+      assert.match(init.stdout, /直接跑通/);
+      assert.match(init.stdout, /看报告里的 verdict/);
+
+      await writeFile(join(project, 'offline-executor.mjs'), [
+        'import { readFileSync } from "node:fs";',
+        'const req = JSON.parse(readFileSync(0, "utf8"));',
+        'const isV2 = req.system.includes("高级代码审查专家");',
+        'const output = isV2',
+        '  ? "SQL injection: use parameterized queries. Handle error status. XSS via innerHTML: use textContent."',
+        '  : "Looks okay."; ',
+        'console.log(JSON.stringify({ output, durationApiMs: 0, inputTokens: 1, outputTokens: 1 }));',
+      ].join('\n'));
+
+      const baseArgs = [
+        'eval',
+        '--control', 'code-review-v1',
+        '--treatment', 'code-review-v2',
+        '--executor', 'node offline-executor.mjs',
+        '--skip-connectivity',
+        '--lang', 'zh',
+      ];
+
+      const dryRun = await execFileAsync('node', [CLI, ...baseArgs, '--dry-run'], { cwd: project });
+      const dryRunReport = parseFirstJsonObject(dryRun.stdout) as { dryRun?: boolean; totalTasks?: number; variants?: string[] };
+      assert.equal(dryRunReport.dryRun, true);
+      assert.equal(dryRunReport.totalTasks, 6);
+      assert.deepEqual(dryRunReport.variants, ['code-review-v1', 'code-review-v2']);
+      assert.match(dryRun.stdout, /eval dry-run：仅预览任务，不检查分数/);
+
+      const run = await execFileAsync('node', [
+        CLI,
+        ...baseArgs,
+        '--no-judge',
+        '--no-diagnostic',
+        '--no-serve',
+        '--bootstrap-samples', '100',
+        '--no-cache',
+        '--report-only',
+      ], { cwd: project });
+      const report = parseFirstJsonObject(run.stdout) as {
+        id: string;
+        kind?: string;
+        meta?: { variants?: string[]; sampleCount?: number };
+        summary?: Record<string, { avgCompositeScore?: number }>;
+        results?: unknown[];
+      };
+
+      assert.equal(report.kind, 'evaluation');
+      assert.deepEqual(report.meta?.variants, ['code-review-v1', 'code-review-v2']);
+      assert.equal(report.meta?.sampleCount, 3);
+      assert.equal(report.results?.length, 3);
+      assert.ok(
+        (report.summary?.['code-review-v2']?.avgCompositeScore ?? 0)
+        > (report.summary?.['code-review-v1']?.avgCompositeScore ?? 0),
+        'v2 should score higher than the starter v1 in the offline smoke executor',
+      );
+      assert.match(run.stderr, /判定：/);
+      assert.match(run.stderr, /下一步：/);
+      assert.ok(existsSync(join(project, '.omk', 'reports', `${report.id}.report.json`)));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -102,6 +102,17 @@ describe('createExecutor', () => {
     }
   });
 
+  it('does not surface stdin EPIPE when a script command exits without reading input', async () => {
+    const executor = createExecutor('/bin/echo \'{"output":"done"}\'');
+    const result = await executor({
+      model: 'test',
+      system: '',
+      prompt: 'ignored',
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.output, 'done');
+  });
+
   it('does not rewrite interpreter module names as local paths', async () => {
     const baseCwd = await mkdtemp(join(tmpdir(), 'omk-script-executor-module-'));
     const taskCwd = await mkdtemp(join(tmpdir(), 'omk-script-executor-module-task-'));


### PR DESCRIPTION
## 用户影响

这个 PR 把首跑链路固化成 CI smoke：`omk init` 生成 starter skill 后，继续跑 `omk eval --dry-run` 和一次离线正式 `omk eval`，验证报告落盘、verdict 与下一步提示能输出。这样后续再改 init / eval / report 输出时，首跑断链会被测试直接拦住。

同时给 script executor 补了一个显式回归：命令很快退出且不读取 stdin 时，不应再把 stdin EPIPE 暴露成未处理错误。

## 迁移说明

无迁移。仅新增测试，不改变 CLI 参数、report schema、verdict 计算、样本加载或执行器语义。

## 测量学 caveat

测试使用 `omk init` 的 code-review starter 和离线 script executor，只验证首跑控制流和报告产物，不把这组分数作为质量基准。评分类 prompt、bootstrap / verdict 门控和报告 schema 均未修改。

## 验证

已通过 `yarn lint && yarn build && yarn test`。