### PR TITLE
fix(cli): 提示 Codex 预检备选

### DIFF
--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -6,7 +6,7 @@ import { BaseCommand } from '../../oclif/base-command.js';
 import { enumStringParser, integerStringParser, numberStringParser } from '../../oclif/parsers.js';
 import { CliExit } from '../../lib/cli-exit.js';
 import { tCli, type CliLang } from '../../lib/i18n.js';
-import { parseRunConfig } from '../../lib/parse-run-config.js';
+import { parseRunConfig, type RunConfig } from '../../lib/parse-run-config.js';
 import { makeOnProgress } from '../../lib/progress.js';
 import { computeRunTally } from '../../lib/run-tally.js';
 import type { EvalArgs, EvalFlags } from '../../lib/cmd-flags.js';
@@ -43,11 +43,21 @@ interface RepeatProgressInfo {
 
 type ParsedValues = Record<string, string | boolean | undefined>;
 
+const CLAUDE_EXECUTORS = new Set(['claude', 'claude-sdk']);
+const CODEX_EXECUTORS = new Set(['codex', 'codex-sdk']);
+const OPENAI_API_EXECUTORS = new Set(['openai-api']);
+const ANTHROPIC_API_EXECUTORS = new Set(['anthropic-api']);
+
 interface RecordedEvidenceForPrompt {
   name: string;
   variant: string;
   bound: boolean;
 }
+
+type PreflightRuntimeMatch = {
+  executor: string;
+  role: 'task' | 'judge';
+};
 
 function isDryRunReport(report: unknown): report is DryRunReport {
   return Boolean(report && typeof report === 'object' && (report as { dryRun?: unknown }).dryRun === true);
@@ -127,6 +137,86 @@ function emitVerdictText(text: string): void {
   // 与 console.log 等价(对单个字符串 = write(text + '\n')),只切换目标流,逐字节保留既有文案。
   const stream = process.stdout.isTTY ? process.stdout : process.stderr;
   stream.write(text + '\n');
+}
+
+function preflightFailedTarget(message: string): string | null {
+  return message.match(/(^|\n)preflight failed \[([^\]]+)\]:/)?.[2] ?? null;
+}
+
+function runtimeKey(executor: string, model: string): string {
+  return `${executor}:${model}`;
+}
+
+function matchesPreflightTarget(target: string, executor: string, model: string): boolean {
+  return target.includes(':') ? target === runtimeKey(executor, model) : target === model;
+}
+
+function matchingPreflightRuntimes(
+  config: Pick<RunConfig, 'executorName' | 'model' | 'judgeModels' | 'noJudge'>,
+  failedTarget: string,
+): PreflightRuntimeMatch[] {
+  const matches: PreflightRuntimeMatch[] = [];
+  if (config.executorName && matchesPreflightTarget(failedTarget, config.executorName, config.model ?? '')) {
+    matches.push({ executor: config.executorName, role: 'task' });
+  }
+  if (!config.noJudge) {
+    for (const judge of config.judgeModels) {
+      if (matchesPreflightTarget(failedTarget, judge.executor, judge.model)) matches.push({ executor: judge.executor, role: 'judge' });
+    }
+  }
+  return matches;
+}
+
+function hasExecutor(matches: PreflightRuntimeMatch[], executors: Set<string>): boolean {
+  return matches.some((match) => executors.has(match.executor));
+}
+
+function shouldSwitchJudgeWithTask(
+  config: Pick<RunConfig, 'judgeModels' | 'noJudge'>,
+  executors: Set<string>,
+): boolean {
+  return !config.noJudge && config.judgeModels.length === 1 && executors.has(config.judgeModels[0].executor);
+}
+
+function fallbackFlags(
+  matches: PreflightRuntimeMatch[],
+  executor: string,
+  taskModel: string,
+  judgeModel: string,
+  includeJudgeWithTask: boolean,
+): string {
+  const hasTask = matches.some((match) => match.role === 'task');
+  const hasJudge = matches.some((match) => match.role === 'judge') || (hasTask && includeJudgeWithTask);
+  return [
+    hasTask ? `--executor ${executor} --model ${taskModel}` : '',
+    hasJudge ? `--judge-models ${executor}:${judgeModel}` : '',
+  ].filter(Boolean).join(' ');
+}
+
+export function formatConnectivityFailureHint(
+  message: string,
+  config: Pick<RunConfig, 'executorName' | 'model' | 'judgeModels' | 'noJudge'>,
+  lang: CliLang,
+): string {
+  const failedTarget = preflightFailedTarget(message);
+  if (!failedTarget) return '';
+  const matches = matchingPreflightRuntimes(config, failedTarget);
+  if (matches.length === 0) return '';
+
+  if (hasExecutor(matches, CLAUDE_EXECUTORS)) {
+    return tCli('cli.run.codex_fallback_hint', lang, {
+      flags: fallbackFlags(matches, 'codex', '<codex-model>', '<codex-model>', shouldSwitchJudgeWithTask(config, CLAUDE_EXECUTORS)),
+    });
+  }
+  if (hasExecutor(matches, CODEX_EXECUTORS)) {
+    return tCli('cli.run.codex_auth_hint', lang, {
+      claudeFlags: fallbackFlags(matches, 'claude', 'sonnet', 'haiku', shouldSwitchJudgeWithTask(config, CODEX_EXECUTORS)),
+      openaiFlags: fallbackFlags(matches, 'openai-api', '<openai-model>', '<openai-model>', shouldSwitchJudgeWithTask(config, CODEX_EXECUTORS)),
+    });
+  }
+  if (hasExecutor(matches, OPENAI_API_EXECUTORS)) return tCli('cli.run.openai_api_auth_hint', lang);
+  if (hasExecutor(matches, ANTHROPIC_API_EXECUTORS)) return tCli('cli.run.anthropic_api_auth_hint', lang);
+  return '';
 }
 
 function treatmentVariantFromVerdict(result: Pick<VerdictResult, 'level' | 'representative' | 'variants'>): string | undefined {
@@ -496,7 +586,10 @@ async function runEval(
     throw new CliExit(applyGateExitCode(exitCode, values, lang));
   } catch (err: unknown) {
     if (err instanceof CliExit) throw err;
-    console.error(tCli('cli.common.error_prefix', lang, { message: (err as Error).message }));
+    const message = (err as Error).message;
+    console.error(tCli('cli.common.error_prefix', lang, {
+      message: `${message}${formatConnectivityFailureHint(message, config, lang)}`,
+    }));
     throw new CliExit(1);
   }
 }

--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -40,6 +40,10 @@ export type RunMessageKey =
   | 'cli.run.gold_load_failed'
   | 'cli.run.gold_load_issue'
   | 'cli.run.contamination_warning'
+  | 'cli.run.codex_fallback_hint'
+  | 'cli.run.codex_auth_hint'
+  | 'cli.run.openai_api_auth_hint'
+  | 'cli.run.anthropic_api_auth_hint'
   | 'cli.run.skip_connectivity_warning';
 
 export const runDict: Record<RunMessageKey, CliMessage> = {
@@ -198,6 +202,22 @@ export const runDict: Record<RunMessageKey, CliMessage> = {
   'cli.run.contamination_warning': {
     zh: '\n⚠ {warning}\n',
     en: '\n⚠ {warning}\n',
+  },
+  'cli.run.codex_fallback_hint': {
+    zh: '\n提示：当前失败的是 Claude 系列执行器。先确认 Claude Code 已登录；如果你在 Codex 环境里，也可以把模型运行参数改为：{flags}。把 <codex-model> 换成本机 Codex 可用的模型；codex 执行器目前不会报告 costUSD。',
+    en: '\nHint: the failing runtime is Claude-based. First confirm Claude Code is authenticated; in a Codex environment, you can also switch the model runtime flags to: {flags}. Replace <codex-model> with a model your local Codex can run; the codex executor does not report costUSD yet.',
+  },
+  'cli.run.codex_auth_hint': {
+    zh: '\n提示：当前失败的是 Codex 系列执行器。先确认 Codex CLI / SDK 已安装并完成登录；如果你有 Claude Code 可用，可以改走 Claude：{claudeFlags}；如果要继续走 OpenAI API，可以改为：{openaiFlags}，并设置 OPENAI_API_KEY。openai-api 会按 API 响应记录 token / cost。',
+    en: '\nHint: the failing runtime is Codex-based. First confirm the Codex CLI / SDK is installed and authenticated; if Claude Code is available, switch to Claude: {claudeFlags}; to stay on the OpenAI API path, switch to: {openaiFlags}, and set OPENAI_API_KEY. openai-api records token / cost from API responses.',
+  },
+  'cli.run.openai_api_auth_hint': {
+    zh: '\n提示：当前失败的是 OpenAI API 执行器。请检查 OPENAI_API_KEY / OPENAI_BASE_URL 是否可用，并确认模型名对当前端点可用。',
+    en: '\nHint: the failing runtime is the OpenAI API executor. Check OPENAI_API_KEY / OPENAI_BASE_URL and confirm the model is available on that endpoint.',
+  },
+  'cli.run.anthropic_api_auth_hint': {
+    zh: '\n提示：当前失败的是 Anthropic API 执行器。请检查 ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL 是否可用，并确认模型名对当前端点可用。',
+    en: '\nHint: the failing runtime is the Anthropic API executor. Check ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL and confirm the model is available on that endpoint.',
   },
   'cli.run.skip_connectivity_warning': {
     zh: '⚠️  --skip-connectivity 已启用: 跳过 LLM 模型连通性检测。请确保 executor / judge 已通过其他方式验证可达。',

--- a/src/eval-core/evaluation-execution.ts
+++ b/src/eval-core/evaluation-execution.ts
@@ -397,7 +397,7 @@ export async function executeTasks({
   return { results, totalCostUSD, skipped, budgetExhausted };
 }
 
-export async function preflight(executor: ExecutorFn, model: string, timeoutMs: number = 180000): Promise<void> {
+export async function preflight(executor: ExecutorFn, model: string, timeoutMs: number = 180000, label?: string): Promise<void> {
   const result = await executor({
     model,
     system: '',
@@ -406,7 +406,7 @@ export async function preflight(executor: ExecutorFn, model: string, timeoutMs: 
     timeoutMs,
   });
   if (!result.ok) {
-    throw new Error(`preflight failed [${model}]: ${result.error}`);
+    throw new Error(`preflight failed [${label ?? model}]: ${result.error}`);
   }
 }
 
@@ -436,6 +436,6 @@ export async function preflightAllJudges(
     if (!exec) {
       throw new Error(`preflight: no executor registered for "${jc.executor}" (judge "${key}"); pipeline must populate judgeExecutors before preflight`);
     }
-    await preflight(exec, jc.model, timeoutMs);
+    await preflight(exec, jc.model, timeoutMs, key);
   }
 }

--- a/src/eval-core/evaluation-execution.ts
+++ b/src/eval-core/evaluation-execution.ts
@@ -18,6 +18,16 @@ import type {
   VariantResult,
 } from '../types/index.js';
 
+const PREFLIGHT_RUNTIME_LABEL_EXECUTORS = new Set([
+  'claude',
+  'claude-sdk',
+  'codex',
+  'codex-sdk',
+  'gemini',
+  'anthropic-api',
+  'openai-api',
+]);
+
 export interface ExecuteTasksOptions {
   tasks: Task[];
   executor: ExecutorFn;
@@ -397,6 +407,10 @@ export async function executeTasks({
   return { results, totalCostUSD, skipped, budgetExhausted };
 }
 
+export function preflightRuntimeLabel(executorName: string, model: string): string {
+  return PREFLIGHT_RUNTIME_LABEL_EXECUTORS.has(executorName) ? `${executorName}:${model}` : `custom:${model}`;
+}
+
 export async function preflight(executor: ExecutorFn, model: string, timeoutMs: number = 180000, label?: string): Promise<void> {
   const result = await executor({
     model,
@@ -436,6 +450,6 @@ export async function preflightAllJudges(
     if (!exec) {
       throw new Error(`preflight: no executor registered for "${jc.executor}" (judge "${key}"); pipeline must populate judgeExecutors before preflight`);
     }
-    await preflight(exec, jc.model, timeoutMs, key);
+    await preflight(exec, jc.model, timeoutMs, preflightRuntimeLabel(jc.executor, jc.model));
   }
 }

--- a/src/eval-workflows/evaluation-pipeline.ts
+++ b/src/eval-workflows/evaluation-pipeline.ts
@@ -223,7 +223,7 @@ export async function executeEvaluationPipeline({
       if (onProgress) onProgress({ phase: 'preflight', jobId: runState.jobId });
       // LLM 连通性: eval 唯一职责。doctor 在 runEvaluation 上游已跑,
       // 包含 dep / 结构 / 元数据 / 契约检查。这里只剩 executor + 所有 judge。
-      await preflight(executor, model);
+      await preflight(executor, model, undefined, `${executorName}:${model}`);
       if (!noJudge) {
         await preflightAllJudges(resolvedJudgeModels, resolvedJudgeExecutors);
       }

--- a/src/eval-workflows/evaluation-pipeline.ts
+++ b/src/eval-workflows/evaluation-pipeline.ts
@@ -23,7 +23,7 @@
  */
 
 import { aggregateReport, DEFAULT_OUTPUT_DIR, generateRunId, persistReport } from '../eval-core/evaluation-reporting.js';
-import { executeTasks, preflight, preflightAllJudges } from '../eval-core/evaluation-execution.js';
+import { executeTasks, preflight, preflightAllJudges, preflightRuntimeLabel } from '../eval-core/evaluation-execution.js';
 import type { DependencyRequirements } from '../eval-core/dependency-checker.js';
 import { stopAllServers } from '../inputs/mcp-resolver.js';
 import type {
@@ -223,7 +223,7 @@ export async function executeEvaluationPipeline({
       if (onProgress) onProgress({ phase: 'preflight', jobId: runState.jobId });
       // LLM 连通性: eval 唯一职责。doctor 在 runEvaluation 上游已跑,
       // 包含 dep / 结构 / 元数据 / 契约检查。这里只剩 executor + 所有 judge。
-      await preflight(executor, model, undefined, `${executorName}:${model}`);
+      await preflight(executor, model, undefined, preflightRuntimeLabel(executorName, model));
       if (!noJudge) {
         await preflightAllJudges(resolvedJudgeModels, resolvedJudgeExecutors);
       }

--- a/test/cli/eval-preflight-hint.test.ts
+++ b/test/cli/eval-preflight-hint.test.ts
@@ -1,0 +1,183 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { formatConnectivityFailureHint } from '../../src/cli/commands/eval/index.js';
+
+describe('eval connectivity failure hint', () => {
+  it('suggests Codex flags when default Claude preflight fails', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [claude:sonnet]: Failed to authenticate. API Error: 401 Invalid authentication credentials',
+      {
+        executorName: 'claude',
+        model: 'sonnet',
+        judgeModels: [{ executor: 'claude', model: 'haiku' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.ok(hint.includes('--executor codex --model <codex-model> --judge-models codex:<codex-model>'), hint);
+    assert.ok(hint.includes('costUSD'), hint);
+  });
+
+  it('omits judge flags when the run has --no-judge', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [claude:sonnet]: auth failed',
+      {
+        executorName: 'claude',
+        model: 'sonnet',
+        judgeModels: [{ executor: 'claude', model: 'haiku' }],
+        noJudge: true,
+      },
+      'en',
+    );
+
+    assert.ok(hint.includes('--executor codex --model <codex-model>'), hint);
+    assert.ok(!hint.includes('--judge-models'), hint);
+  });
+
+  it('keeps an explicit non-Claude judge when the Claude task runtime fails', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [claude:sonnet]: auth failed',
+      {
+        executorName: 'claude',
+        model: 'sonnet',
+        judgeModels: [{ executor: 'openai-api', model: 'gpt-4o' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.ok(hint.includes('--executor codex --model <codex-model>'), hint);
+    assert.ok(!hint.includes('--judge-models'), hint);
+  });
+
+  it('does not suggest Codex for non-Claude executor failures', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [./my-executor.sh:sonnet]: custom executor failed',
+      {
+        executorName: './my-executor.sh',
+        model: 'sonnet',
+        judgeModels: [{ executor: './judge.sh', model: 'judge' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.equal(hint, '');
+  });
+
+  it('does not suggest Codex for non-preflight errors', () => {
+    const hint = formatConnectivityFailureHint(
+      'doctor failed: samples contract mismatch',
+      {
+        executorName: 'claude',
+        model: 'sonnet',
+        judgeModels: [{ executor: 'claude', model: 'haiku' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.equal(hint, '');
+  });
+
+  it('suggests API-key checks instead of Codex when an OpenAI API judge fails in a mixed run', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [openai-api:gpt-4o]: missing OPENAI_API_KEY',
+      {
+        executorName: 'claude',
+        model: 'sonnet',
+        judgeModels: [{ executor: 'openai-api', model: 'gpt-4o' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.ok(hint.includes('OPENAI_API_KEY'), hint);
+    assert.ok(!hint.includes('--executor codex'), hint);
+  });
+
+  it('suggests only judge flags when a Claude judge fails even if the task executor is custom', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [claude:haiku]: auth failed',
+      {
+        executorName: './my-executor.sh',
+        model: 'local-model',
+        judgeModels: [{ executor: 'claude', model: 'haiku' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.ok(hint.includes('--judge-models codex:<codex-model>'), hint);
+    assert.ok(!hint.includes('--executor codex'), hint);
+  });
+
+  it('suggests Claude and OpenAI API fallbacks when Codex task runtime is unavailable', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [codex:gpt-5-codex]: authentication failed',
+      {
+        executorName: 'codex',
+        model: 'gpt-5-codex',
+        judgeModels: [{ executor: 'codex', model: 'gpt-5-codex' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.ok(hint.includes('OPENAI_API_KEY'), hint);
+    assert.ok(hint.includes('--executor claude --model sonnet --judge-models claude:haiku'), hint);
+    assert.ok(hint.includes('--executor openai-api --model <openai-model> --judge-models openai-api:<openai-model>'), hint);
+  });
+
+  it('suggests only judge flags for Claude and OpenAI API when a Codex judge is unavailable', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [codex:gpt-5-codex]: authentication failed',
+      {
+        executorName: './my-executor.sh',
+        model: 'local-model',
+        judgeModels: [{ executor: 'codex', model: 'gpt-5-codex' }],
+        noJudge: false,
+      },
+      'en',
+    );
+
+    assert.ok(hint.includes('OPENAI_API_KEY'), hint);
+    assert.ok(hint.includes('--judge-models claude:haiku'), hint);
+    assert.ok(hint.includes('--judge-models openai-api:<openai-model>'), hint);
+    assert.ok(!hint.includes('--executor claude'), hint);
+    assert.ok(!hint.includes('--executor openai-api'), hint);
+  });
+
+  it('uses executor:model target when task and judge share a model name', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [openai-api:gpt-5-codex]: missing OPENAI_API_KEY',
+      {
+        executorName: 'codex',
+        model: 'gpt-5-codex',
+        judgeModels: [{ executor: 'openai-api', model: 'gpt-5-codex' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.ok(hint.includes('OPENAI_API_KEY'), hint);
+    assert.ok(!hint.includes('Codex CLI'), hint);
+    assert.ok(!hint.includes('--executor claude'), hint);
+  });
+
+  it('keeps compatibility with legacy model-only preflight errors', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [sonnet]: auth failed',
+      {
+        executorName: 'claude',
+        model: 'sonnet',
+        judgeModels: [{ executor: 'claude', model: 'haiku' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.ok(hint.includes('--executor codex --model <codex-model>'), hint);
+  });
+});

--- a/test/cli/eval-preflight-hint.test.ts
+++ b/test/cli/eval-preflight-hint.test.ts
@@ -53,7 +53,7 @@ describe('eval connectivity failure hint', () => {
 
   it('does not suggest Codex for non-Claude executor failures', () => {
     const hint = formatConnectivityFailureHint(
-      'preflight failed [./my-executor.sh:sonnet]: custom executor failed',
+      'preflight failed [custom:sonnet]: custom executor failed',
       {
         executorName: './my-executor.sh',
         model: 'sonnet',

--- a/test/eval-core/preflight-ensemble.test.ts
+++ b/test/eval-core/preflight-ensemble.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { preflightAllJudges } from '../../src/eval-core/evaluation-execution.js';
+import { preflight, preflightAllJudges } from '../../src/eval-core/evaluation-execution.js';
 import type { ExecResult, ExecutorFn, JudgeConfig } from '../../src/types/index.js';
 
 const okResult: ExecResult = {
@@ -32,6 +32,14 @@ function failingExecutor(name: string, calls: string[]): ExecutorFn {
 }
 
 describe('preflightAllJudges', () => {
+  it('includes the explicit runtime label in preflight errors', async () => {
+    const calls: string[] = [];
+    await assert.rejects(
+      () => preflight(failingExecutor('exec-task', calls), 'shared-model', 5000, 'codex:shared-model'),
+      /preflight failed \[codex:shared-model\]: auth failed/,
+    );
+  });
+
   it('preflights every unique (executor, model) judge in an ensemble', async () => {
     const calls: string[] = [];
     const judgeExecutors = {
@@ -84,7 +92,7 @@ describe('preflightAllJudges', () => {
         ],
         judgeExecutors,
       ),
-      /preflight failed/,
+      /preflight failed \[exec-bad:m-fail\]: auth failed/,
     );
 
     // m-ok 通过 → 然后 m-fail 抛错 → m-after-fail 不被探测(fail-fast)。

--- a/test/eval-core/preflight-ensemble.test.ts
+++ b/test/eval-core/preflight-ensemble.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { preflight, preflightAllJudges } from '../../src/eval-core/evaluation-execution.js';
+import { preflight, preflightAllJudges, preflightRuntimeLabel } from '../../src/eval-core/evaluation-execution.js';
 import type { ExecResult, ExecutorFn, JudgeConfig } from '../../src/types/index.js';
 
 const okResult: ExecResult = {
@@ -32,11 +32,38 @@ function failingExecutor(name: string, calls: string[]): ExecutorFn {
 }
 
 describe('preflightAllJudges', () => {
+  it('keeps built-in executor names in runtime labels', () => {
+    assert.equal(preflightRuntimeLabel('codex', 'gpt-5-codex'), 'codex:gpt-5-codex');
+  });
+
+  it('uses a generic label for custom executor commands', () => {
+    assert.equal(preflightRuntimeLabel('TOKEN=secret ./judge.sh', 'local-model'), 'custom:local-model');
+  });
+
   it('includes the explicit runtime label in preflight errors', async () => {
     const calls: string[] = [];
     await assert.rejects(
       () => preflight(failingExecutor('exec-task', calls), 'shared-model', 5000, 'codex:shared-model'),
       /preflight failed \[codex:shared-model\]: auth failed/,
+    );
+  });
+
+  it('does not leak custom judge executor commands in preflight errors', async () => {
+    const calls: string[] = [];
+    const executorName = 'TOKEN=secret ./judge.sh';
+
+    await assert.rejects(
+      () => preflightAllJudges(
+        [{ executor: executorName, model: 'local-judge' }],
+        { [executorName]: failingExecutor('custom-judge', calls) },
+      ),
+      (error: unknown) => {
+        const message = (error as Error).message;
+        assert.match(message, /preflight failed \[custom:local-judge\]: auth failed/);
+        assert.doesNotMatch(message, /TOKEN=secret/);
+        assert.doesNotMatch(message, /judge\.sh/);
+        return true;
+      },
     );
   });
 
@@ -79,24 +106,24 @@ describe('preflightAllJudges', () => {
   it('throws fail-fast when any judge fails preflight (does not silently continue)', async () => {
     const calls: string[] = [];
     const judgeExecutors = {
-      'exec-a': trackingExecutor('exec-a', calls),
-      'exec-bad': failingExecutor('exec-bad', calls),
+      claude: trackingExecutor('claude', calls),
+      'openai-api': failingExecutor('openai-api', calls),
     };
 
     await assert.rejects(
       () => preflightAllJudges(
         [
-          { executor: 'exec-a', model: 'm-ok' },
-          { executor: 'exec-bad', model: 'm-fail' },
-          { executor: 'exec-a', model: 'm-after-fail' },
+          { executor: 'claude', model: 'm-ok' },
+          { executor: 'openai-api', model: 'm-fail' },
+          { executor: 'claude', model: 'm-after-fail' },
         ],
         judgeExecutors,
       ),
-      /preflight failed \[exec-bad:m-fail\]: auth failed/,
+      /preflight failed \[openai-api:m-fail\]: auth failed/,
     );
 
     // m-ok 通过 → 然后 m-fail 抛错 → m-after-fail 不被探测(fail-fast)。
-    assert.deepEqual(calls, ['exec-a:m-ok', 'exec-bad:m-fail']);
+    assert.deepEqual(calls, ['claude:m-ok', 'openai-api:m-fail']);
   });
 
   it('throws when judge entry references an executor missing from the map', async () => {


### PR DESCRIPTION
## 用户影响
- 当 `omk eval` 的 LLM 连通性预检因为默认 Claude executor / judge 失败时，错误信息会直接给出切到 Codex 的参数组合。
- `--no-judge` 场景只提示 executor / model，不提示 `--judge-models`。

## 迁移说明
- 无默认 executor / judge 变更；现有命令语义不变。

## 测量学 caveat
- Codex 只是失败后的替代运行路径提示；一次 run 内仍需固定 executor / judge。codex 执行器当前不报告 costUSD，提示中明确说明。