### PR TITLE
fix(init): 收紧首跑提示

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,4 +1,4 @@
-import { resolve, join, relative } from 'node:path';
+import { resolve, join, relative, sep } from 'node:path';
 import { Args } from '@oclif/core';
 import { LANG_FLAG, bilingual, resolveLang } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
@@ -102,10 +102,15 @@ description: 多维度代码审查,覆盖安全 / 健壮 / 可维护 / 性能,�
 
 const INIT_EVAL_COMMAND = 'omk eval --control code-review-v1 --treatment code-review-v2';
 
+function isOutsideCwd(relPath: string): boolean {
+  return relPath === '..' || relPath.startsWith(`..${sep}`);
+}
+
 function nextEvalCommand(targetDir: string): string {
   const rel = relative(resolve('.'), targetDir);
   if (!rel) return INIT_EVAL_COMMAND;
-  return `cd ${shellQuoteArg(rel)} && ${INIT_EVAL_COMMAND}`;
+  const cdTarget = isOutsideCwd(rel) ? targetDir : rel;
+  return `cd ${shellQuoteArg(cdTarget)} && ${INIT_EVAL_COMMAND}`;
 }
 
 export default class Init extends BaseCommand {

--- a/src/cli/lib/i18n-dict/init.ts
+++ b/src/cli/lib/i18n-dict/init.ts
@@ -30,8 +30,8 @@ export const initDict: Record<InitMessageKey, CliMessage> = {
     en: '  2. Read the report verdict and Next line: PROGRESS can ship; UNDERPOWERED / NOISE means grow to roughly 20+ samples and re-run.',
   },
   'cli.init.next_step_executor': {
-    zh: '     默认 executor / judge 使用 claude CLI；离线或其它模型见 docs/reference/executors.md。',
-    en: '     The default executor / judge use the claude CLI; for offline or other models see docs/reference/executors.md.',
+    zh: '     默认 executor / judge 使用 claude CLI；离线或其它模型见 https://oh-my-knowledge.pages.dev/reference/executors。',
+    en: '     The default executor / judge use the claude CLI; for offline or other models see https://oh-my-knowledge.pages.dev/reference/executors.',
   },
   'cli.init.next_step_customize': {
     zh: '  3. 跑通后，替换为你自己的 skill 和 eval-samples.json；还没有用例时先运行 omk sample <skill-path>。',

--- a/src/cli/lib/i18n-dict/init.ts
+++ b/src/cli/lib/i18n-dict/init.ts
@@ -30,7 +30,7 @@ export const initDict: Record<InitMessageKey, CliMessage> = {
     en: '  2. Read the report verdict and Next line: PROGRESS can ship; UNDERPOWERED / NOISE means grow to roughly 20+ samples and re-run.',
   },
   'cli.init.next_step_executor': {
-    zh: '     默认 executor / judge 使用 claude CLI；离线或其它模型见 https://oh-my-knowledge.pages.dev/reference/executors。',
+    zh: '     默认 executor / judge 使用 claude CLI；离线或其它模型见 https://oh-my-knowledge.pages.dev/zh/reference/executors。',
     en: '     The default executor / judge use the claude CLI; for offline or other models see https://oh-my-knowledge.pages.dev/reference/executors.',
   },
   'cli.init.next_step_customize': {

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -4,7 +4,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
 import { promisify } from 'node:util';
 import { join, dirname } from 'node:path';
@@ -58,6 +58,8 @@ describe('oclif init', () => {
       assert.ok(stdout.includes('UNDERPOWERED'), `stdout should set first-run expectation:\n${stdout}`);
       assert.ok(stdout.includes('20 条以上'), `stdout should suggest growing the sample set before release decisions:\n${stdout}`);
       assert.ok(stdout.includes('看报告里的 verdict'), `stdout should tell users where to make the release decision:\n${stdout}`);
+      assert.ok(stdout.includes('https://oh-my-knowledge.pages.dev/reference/executors'), `stdout should link to public executor docs:\n${stdout}`);
+      assert.ok(!stdout.includes('docs/reference/executors.md'), `stdout should not point a fresh project at a missing local docs path:\n${stdout}`);
       assert.ok(stdout.includes('omk sample <skill-path>'), `stdout should route users with no samples back to sample generation:\n${stdout}`);
       assert.ok(existsSync(join(target, 'skills', 'code-review-v1', 'SKILL.md')), 'skills/code-review-v1/SKILL.md not created');
       assert.ok(existsSync(join(target, 'eval-samples.json')), 'eval-samples.json not created');
@@ -69,6 +71,24 @@ describe('oclif init', () => {
         assert.ok(gi.includes(d), `.omk/.gitignore should ignore ${d}`);
       }
       assert.ok(!/^managed\/?$/m.test(gi), '.omk/.gitignore must not ignore managed/');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('指定当前目录外的目标目录时，下一步命令使用绝对 cd 路径', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-oclif-init-outside-'));
+    try {
+      const cwd = join(dir, 'cwd');
+      const target = join(dir, 'project');
+      await mkdir(cwd);
+      const { stdout } = await execFileAsync('node', [CLI, 'init', target], { cwd });
+      assert.ok(
+        stdout.includes(`cd ${target} && omk eval --control code-review-v1 --treatment code-review-v2`),
+        `stdout should avoid awkward ../ paths for targets outside cwd:\n${stdout}`,
+      );
+      assert.ok(!stdout.includes('..'), `stdout should not ask users to copy a parent-directory cd path:\n${stdout}`);
+      assert.ok(existsSync(target), 'target dir should still be created');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -58,7 +58,8 @@ describe('oclif init', () => {
       assert.ok(stdout.includes('UNDERPOWERED'), `stdout should set first-run expectation:\n${stdout}`);
       assert.ok(stdout.includes('20 条以上'), `stdout should suggest growing the sample set before release decisions:\n${stdout}`);
       assert.ok(stdout.includes('看报告里的 verdict'), `stdout should tell users where to make the release decision:\n${stdout}`);
-      assert.ok(stdout.includes('https://oh-my-knowledge.pages.dev/reference/executors'), `stdout should link to public executor docs:\n${stdout}`);
+      assert.ok(stdout.includes('https://oh-my-knowledge.pages.dev/zh/reference/executors'), `stdout should link zh users to public zh executor docs:\n${stdout}`);
+      assert.ok(!stdout.includes('https://oh-my-knowledge.pages.dev/reference/executors'), `stdout should not link zh users to the en executor docs:\n${stdout}`);
       assert.ok(!stdout.includes('docs/reference/executors.md'), `stdout should not point a fresh project at a missing local docs path:\n${stdout}`);
       assert.ok(stdout.includes('omk sample <skill-path>'), `stdout should route users with no samples back to sample generation:\n${stdout}`);
       assert.ok(existsSync(join(target, 'skills', 'code-review-v1', 'SKILL.md')), 'skills/code-review-v1/SKILL.md not created');
@@ -71,6 +72,18 @@ describe('oclif init', () => {
         assert.ok(gi.includes(d), `.omk/.gitignore should ignore ${d}`);
       }
       assert.ok(!/^managed\/?$/m.test(gi), '.omk/.gitignore must not ignore managed/');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('英文输出链接到英文 executor 文档', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-oclif-init-en-'));
+    try {
+      const { stdout } = await execFileAsync('node', [CLI, 'init', 'project', '--lang', 'en'], { cwd: dir });
+      assert.ok(stdout.includes('https://oh-my-knowledge.pages.dev/reference/executors'), `stdout should link en users to public en executor docs:\n${stdout}`);
+      assert.ok(!stdout.includes('https://oh-my-knowledge.pages.dev/zh/reference/executors'), `stdout should not link en users to the zh executor docs:\n${stdout}`);
+      assert.ok(!stdout.includes('docs/reference/executors.md'), `stdout should not point a fresh project at a missing local docs path:\n${stdout}`);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## 用户影响

这次真实首跑走查发现 `omk init <外部目录>` 的下一步命令会出现较绕的 `../..` 路径；同时 executor 说明指向 `docs/reference/executors.md`，但 fresh project 里没有这个本地 docs 目录。

本 PR 让跨目录初始化时的复制命令改用绝对路径，并把 executor 说明改为公开文档链接。用户从空目录初始化后，第一屏提示更容易直接复制执行，也不会被带到不存在的本地文档路径。

## 迁移说明

无迁移。仅调整 `omk init` 的提示文案和下一步命令展示，不改变生成的项目结构、CLI 参数、report schema 或评测语义。

## 测量学 caveat

不涉及评分、verdict、prompt、样本加载、bootstrap、Krippendorff alpha 或 report schema。只改善首跑引导可达性。

## 验证

已通过 `yarn ci`。另从干净临时目录手动跑过 `omk init` 首屏走查。
