### PR TITLE
fix(cli): 收紧 eval 首跑提示

### DIFF
--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -206,27 +206,29 @@ export function formatConnectivityFailureHint(
   config: Pick<RunConfig, 'executorName' | 'model' | 'judgeModels' | 'noJudge'>,
   lang: CliLang,
 ): string {
+  const failedTarget = preflightFailedTarget(message);
+  if (failedTarget) {
+    const matches = matchingPreflightRuntimes(config, failedTarget);
+    if (matches.length === 0) return '';
+
+    if (hasExecutor(matches, CLAUDE_EXECUTORS)) {
+      return tCli('cli.run.codex_fallback_hint', lang, {
+        flags: fallbackFlags(matches, 'codex', '<codex-model>', '<codex-model>', shouldSwitchJudgeWithTask(config, CLAUDE_EXECUTORS)),
+      });
+    }
+    if (hasExecutor(matches, CODEX_EXECUTORS)) {
+      return tCli('cli.run.codex_auth_hint', lang, {
+        claudeFlags: fallbackFlags(matches, 'claude', 'sonnet', 'haiku', shouldSwitchJudgeWithTask(config, CODEX_EXECUTORS)),
+        openaiFlags: fallbackFlags(matches, 'openai-api', '<openai-model>', '<openai-model>', shouldSwitchJudgeWithTask(config, CODEX_EXECUTORS)),
+      });
+    }
+    if (hasExecutor(matches, OPENAI_API_EXECUTORS)) return tCli('cli.run.openai_api_auth_hint', lang);
+    if (hasExecutor(matches, ANTHROPIC_API_EXECUTORS)) return tCli('cli.run.anthropic_api_auth_hint', lang);
+    return '';
+  }
+
   if (message.includes('OPENAI_API_KEY') && configHasExecutor(config, OPENAI_API_EXECUTORS)) return tCli('cli.run.openai_api_auth_hint', lang);
   if (message.includes('ANTHROPIC_API_KEY') && configHasExecutor(config, ANTHROPIC_API_EXECUTORS)) return tCli('cli.run.anthropic_api_auth_hint', lang);
-
-  const failedTarget = preflightFailedTarget(message);
-  if (!failedTarget) return '';
-  const matches = matchingPreflightRuntimes(config, failedTarget);
-  if (matches.length === 0) return '';
-
-  if (hasExecutor(matches, CLAUDE_EXECUTORS)) {
-    return tCli('cli.run.codex_fallback_hint', lang, {
-      flags: fallbackFlags(matches, 'codex', '<codex-model>', '<codex-model>', shouldSwitchJudgeWithTask(config, CLAUDE_EXECUTORS)),
-    });
-  }
-  if (hasExecutor(matches, CODEX_EXECUTORS)) {
-    return tCli('cli.run.codex_auth_hint', lang, {
-      claudeFlags: fallbackFlags(matches, 'claude', 'sonnet', 'haiku', shouldSwitchJudgeWithTask(config, CODEX_EXECUTORS)),
-      openaiFlags: fallbackFlags(matches, 'openai-api', '<openai-model>', '<openai-model>', shouldSwitchJudgeWithTask(config, CODEX_EXECUTORS)),
-    });
-  }
-  if (hasExecutor(matches, OPENAI_API_EXECUTORS)) return tCli('cli.run.openai_api_auth_hint', lang);
-  if (hasExecutor(matches, ANTHROPIC_API_EXECUTORS)) return tCli('cli.run.anthropic_api_auth_hint', lang);
   return '';
 }
 

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -171,6 +171,14 @@ function hasExecutor(matches: PreflightRuntimeMatch[], executors: Set<string>): 
   return matches.some((match) => executors.has(match.executor));
 }
 
+function configHasExecutor(
+  config: Pick<RunConfig, 'executorName' | 'judgeModels' | 'noJudge'>,
+  executors: Set<string>,
+): boolean {
+  if (config.executorName && executors.has(config.executorName)) return true;
+  return !config.noJudge && config.judgeModels.some((judge) => executors.has(judge.executor));
+}
+
 function shouldSwitchJudgeWithTask(
   config: Pick<RunConfig, 'judgeModels' | 'noJudge'>,
   executors: Set<string>,
@@ -198,6 +206,9 @@ export function formatConnectivityFailureHint(
   config: Pick<RunConfig, 'executorName' | 'model' | 'judgeModels' | 'noJudge'>,
   lang: CliLang,
 ): string {
+  if (message.includes('OPENAI_API_KEY') && configHasExecutor(config, OPENAI_API_EXECUTORS)) return tCli('cli.run.openai_api_auth_hint', lang);
+  if (message.includes('ANTHROPIC_API_KEY') && configHasExecutor(config, ANTHROPIC_API_EXECUTORS)) return tCli('cli.run.anthropic_api_auth_hint', lang);
+
   const failedTarget = preflightFailedTarget(message);
   if (!failedTarget) return '';
   const matches = matchingPreflightRuntimes(config, failedTarget);

--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -116,8 +116,8 @@ export const runDict: Record<RunMessageKey, CliMessage> = {
     en: '⚠ --bootstrap-samples {n} is large and may take several seconds. 1000 is the industry standard and usually sufficient.\n',
   },
   'cli.run.dry_run_no_scores': {
-    zh: 'eval dry-run：仅预览任务，不检查分数',
-    en: 'Eval dry-run: no scores to check',
+    zh: 'eval dry-run：仅预览任务，不检查分数。下一步：确认任务无误后，去掉 --dry-run 运行正式评测。',
+    en: 'Eval dry-run: no scores checked. Next: remove --dry-run to run the eval.',
   },
   'cli.run.skill_section': {
     zh: '\n=== [{i}/{n}] Skill: {skill} ===\n',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -378,6 +378,7 @@ describe('CLI', () => {
       '--lang', 'zh',
     ]);
     assert.ok(stdout.includes('eval dry-run'));
+    assert.ok(stdout.includes('去掉 --dry-run 运行正式评测'));
     assert.ok(stderr.includes('只能识别很大的效果'));
     assert.ok(!stderr.includes('exploration-only'));
   });

--- a/test/cli/eval-preflight-hint.test.ts
+++ b/test/cli/eval-preflight-hint.test.ts
@@ -97,6 +97,53 @@ describe('eval connectivity failure hint', () => {
     assert.ok(!hint.includes('--executor codex'), hint);
   });
 
+  it('suggests OpenAI API key checks for direct executor configuration errors', () => {
+    const hint = formatConnectivityFailureHint(
+      'OPENAI_API_KEY environment variable is not set',
+      {
+        executorName: 'openai-api',
+        model: 'gpt-4o-mini',
+        judgeModels: [{ executor: 'openai-api', model: 'gpt-4o-mini' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.ok(hint.includes('OPENAI_API_KEY'), hint);
+    assert.ok(hint.includes('OPENAI_BASE_URL'), hint);
+  });
+
+  it('suggests Anthropic API key checks for direct executor configuration errors', () => {
+    const hint = formatConnectivityFailureHint(
+      'ANTHROPIC_API_KEY environment variable is not set',
+      {
+        executorName: 'anthropic-api',
+        model: 'claude-sonnet-4-5',
+        judgeModels: [{ executor: 'anthropic-api', model: 'claude-haiku-4-5' }],
+        noJudge: false,
+      },
+      'en',
+    );
+
+    assert.ok(hint.includes('ANTHROPIC_API_KEY'), hint);
+    assert.ok(hint.includes('ANTHROPIC_BASE_URL'), hint);
+  });
+
+  it('does not treat API-key text as connectivity guidance for unrelated runtimes', () => {
+    const hint = formatConnectivityFailureHint(
+      'doctor failed: sample text mentions OPENAI_API_KEY',
+      {
+        executorName: 'claude',
+        model: 'sonnet',
+        judgeModels: [{ executor: 'claude', model: 'haiku' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.equal(hint, '');
+  });
+
   it('suggests only judge flags when a Claude judge fails even if the task executor is custom', () => {
     const hint = formatConnectivityFailureHint(
       'preflight failed [claude:haiku]: auth failed',

--- a/test/cli/eval-preflight-hint.test.ts
+++ b/test/cli/eval-preflight-hint.test.ts
@@ -97,6 +97,23 @@ describe('eval connectivity failure hint', () => {
     assert.ok(!hint.includes('--executor codex'), hint);
   });
 
+  it('honors the preflight target before API-key fallback text in mixed runs', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [codex:gpt-5-codex]: missing OPENAI_API_KEY',
+      {
+        executorName: 'codex',
+        model: 'gpt-5-codex',
+        judgeModels: [{ executor: 'openai-api', model: 'gpt-4o-mini' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.ok(hint.includes('Codex CLI / SDK'), hint);
+    assert.ok(hint.includes('--executor claude --model sonnet'), hint);
+    assert.ok(!hint.includes('当前失败的是 OpenAI API 执行器'), hint);
+  });
+
   it('suggests OpenAI API key checks for direct executor configuration errors', () => {
     const hint = formatConnectivityFailureHint(
       'OPENAI_API_KEY environment variable is not set',


### PR DESCRIPTION
## 用户影响

- `omk eval --dry-run` 结束时会明确提示下一步去掉 `--dry-run` 运行正式评测，首跑用户不容易停在预览态。
- `openai-api` / `anthropic-api` 缺少密钥时会补充认证与 base URL 检查提示，和 Codex / Claude 预检失败后的指引保持一致。

## 迁移说明

无。此次只补充 CLI 提示文案，不改变命令参数、报告格式或落盘数据。

## 测量学 caveat

不修改报告 schema、评分 prompt、统计公式或五层评分管道语义，仅改善首跑失败后的可操作性提示，不影响历史报告可比性。

## 验证

- `yarn build && yarn test test/cli/eval-preflight-hint.test.ts test/cli.test.ts`
- `yarn ci`