### PR TITLE
fix(cli): 补充 sample 首跑失败提示

### DIFF
--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -138,6 +138,49 @@ function formatIdList(ids: string[]): string {
   return shown.join(', ') + suffix;
 }
 
+const CLAUDE_SAMPLE_EXECUTORS = new Set(['claude', 'claude-sdk']);
+const CODEX_SAMPLE_EXECUTORS = new Set(['codex', 'codex-sdk']);
+const OPENAI_API_SAMPLE_EXECUTORS = new Set(['openai-api']);
+const ANTHROPIC_API_SAMPLE_EXECUTORS = new Set(['anthropic-api']);
+
+function looksLikeConnectivityFailure(message: string): boolean {
+  return /auth|login|credential|API[_ ]?KEY|BASE_URL|API error|ENOENT|not found|ECONN|ENOTFOUND|ETIMEDOUT|timeout|timed out|401|403|404/i.test(message);
+}
+
+export function formatSampleGenerationFailureHint(
+  message: string,
+  executorName: string | undefined,
+  lang: CliLang,
+): string {
+  const executor = executorName ?? 'claude';
+  if (!looksLikeConnectivityFailure(message)) return '';
+
+  if (CLAUDE_SAMPLE_EXECUTORS.has(executor)) {
+    return tCli('cli.gen.claude_auth_hint', lang, {
+      codexFlags: '--executor codex --model <codex-model>',
+      openaiFlags: '--executor openai-api --model <openai-model>',
+    });
+  }
+  if (CODEX_SAMPLE_EXECUTORS.has(executor)) {
+    return tCli('cli.gen.codex_auth_hint', lang, {
+      claudeFlags: '--executor claude --model sonnet',
+      openaiFlags: '--executor openai-api --model <openai-model>',
+    });
+  }
+  if (OPENAI_API_SAMPLE_EXECUTORS.has(executor)) {
+    return tCli('cli.gen.openai_api_auth_hint', lang, {
+      claudeFlags: '--executor claude --model sonnet',
+      codexFlags: '--executor codex --model <codex-model>',
+    });
+  }
+  if (ANTHROPIC_API_SAMPLE_EXECUTORS.has(executor)) {
+    return tCli('cli.gen.anthropic_api_auth_hint', lang, {
+      claudeFlags: '--executor claude --model sonnet',
+    });
+  }
+  return '';
+}
+
 // 下面 3 个 helper 在 sample-fix.test.ts 单测内 in-process import 验证 fix 逻辑。
 
 export function collectSampleDesignFailureIds(report: Pick<Report, 'results'>, treatmentName: string): Set<string> {
@@ -472,7 +515,9 @@ export async function runSampleFromTraces(
       : `\n✅ Generated ${samples.length} draft sample(s) → ${outPath} (provenance: production-trace)${cost}\n   ⚠️ Draft only: traces capture failures, a biased sample. Review before merging into your eval-samples; don't use as-is.\n`);
   } catch (err: unknown) {
     if (err instanceof CliExit) throw err;
-    console.error(lang === 'zh' ? `生成失败: ${(err as Error).message}` : `Generation failed: ${(err as Error).message}`);
+    const message = (err as Error).message;
+    console.error((lang === 'zh' ? `生成失败: ${message}` : `Generation failed: ${message}`)
+      + formatSampleGenerationFailureHint(message, flags.executor, lang));
     throw new CliExit(1);
   }
 }
@@ -568,8 +613,9 @@ async function runSample(
         }));
         generated++;
       } catch (err: unknown) {
+        const message = (err as Error).message;
         process.stderr.write(tCli('cli.gen.skill_failed', lang, {
-          name, message: (err as Error).message,
+          name, message: `${message}${formatSampleGenerationFailureHint(message, flags.executor, lang)}`,
         }));
       }
     }
@@ -642,7 +688,10 @@ async function runSample(
       console.log(tCli('cli.gen.review_hint', lang, { command: sampleNextEvalCommand(resolved) }));
     } catch (err: unknown) {
       if (err instanceof CliExit) throw err;
-      console.error(tCli('cli.gen.failed', lang, { message: (err as Error).message }));
+      const message = (err as Error).message;
+      console.error(tCli('cli.gen.failed', lang, {
+        message: `${message}${formatSampleGenerationFailureHint(message, flags.executor, lang)}`,
+      }));
       throw new CliExit(1);
     }
   }

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -566,6 +566,7 @@ async function runSample(
 
     const entries: string[] = readdirSync(skillDir);
     let generated: number = 0;
+    let failed: number = 0;
 
     for (const entry of entries) {
       let name: string;
@@ -613,6 +614,7 @@ async function runSample(
         }));
         generated++;
       } catch (err: unknown) {
+        failed++;
         const message = (err as Error).message;
         process.stderr.write(tCli('cli.gen.skill_failed', lang, {
           name, message: `${message}${formatSampleGenerationFailureHint(message, flags.executor, lang)}`,
@@ -620,6 +622,10 @@ async function runSample(
       }
     }
 
+    if (failed > 0) {
+      console.error(tCli('cli.gen.batch_failed_summary', lang, { generated, failed }));
+      throw new CliExit(1);
+    }
     if (generated === 0) {
       console.log(tCli('cli.gen.batch_none_needed', lang));
     } else {

--- a/src/cli/lib/i18n-dict/gen.ts
+++ b/src/cli/lib/i18n-dict/gen.ts
@@ -7,6 +7,7 @@ export type GenMessageKey =
   | 'cli.gen.skill_done'
   | 'cli.gen.skill_failed'
   | 'cli.gen.batch_none_needed'
+  | 'cli.gen.batch_failed_summary'
   | 'cli.gen.batch_summary'
   | 'cli.gen.specify_skill_path'
   | 'cli.gen.samples_already_exists'
@@ -47,6 +48,10 @@ export const genDict: Record<GenMessageKey, CliMessage> = {
   'cli.gen.batch_none_needed': {
     zh: '没有需要生成的 eval-samples (所有 skill 都已有配对文件)',
     en: 'No eval-samples need generating (all skills already have paired files)',
+  },
+  'cli.gen.batch_failed_summary': {
+    zh: '\n生成未完成：已生成 {generated} 份，失败 {failed} 份。请按上面的错误提示修复后重试；全部生成成功后再运行 omk eval --batch --dry-run。',
+    en: '\nGeneration incomplete: generated {generated}, failed {failed}. Fix the errors above and retry; once everything succeeds, run omk eval --batch --dry-run.',
   },
   'cli.gen.batch_summary': {
     zh: '\n共生成 {n} 份 eval-samples。下一步：\n  1. 人工审查生成的评测用例，删掉不可信样本，补边界、反例\n  2. 预览任务：omk eval --batch --dry-run\n  3. 跑评测：omk eval --batch',

--- a/src/cli/lib/i18n-dict/gen.ts
+++ b/src/cli/lib/i18n-dict/gen.ts
@@ -16,6 +16,10 @@ export type GenMessageKey =
   | 'cli.gen.append_done'
   | 'cli.gen.append_single_only'
   | 'cli.gen.review_hint'
+  | 'cli.gen.claude_auth_hint'
+  | 'cli.gen.codex_auth_hint'
+  | 'cli.gen.openai_api_auth_hint'
+  | 'cli.gen.anthropic_api_auth_hint'
   | 'cli.gen.failed'
   | 'cli.gen.focus_applied';
 
@@ -79,6 +83,22 @@ export const genDict: Record<GenMessageKey, CliMessage> = {
   'cli.gen.review_hint': {
     zh: '\n下一步：\n  1. 人工审查生成的评测用例，删掉不可信样本，补边界、反例\n  2. 预览任务：{command} --dry-run\n  3. 跑评测：{command}',
     en: '\nNext steps:\n  1. Review the generated samples; drop weak cases and add boundary / counterexamples\n  2. Preview the task plan: {command} --dry-run\n  3. Run the eval: {command}',
+  },
+  'cli.gen.claude_auth_hint': {
+    zh: '\n提示：当前 sample 生成使用 Claude 系列执行器。先确认 Claude Code 已安装并完成登录；如果你在 Codex 环境里，可以改用：{codexFlags}；如果要走 OpenAI API，可以改用：{openaiFlags}，并设置 OPENAI_API_KEY。',
+    en: '\nHint: sample generation is using a Claude-based executor. First confirm Claude Code is installed and authenticated; in a Codex environment, switch to: {codexFlags}; to use the OpenAI API path, switch to: {openaiFlags}, and set OPENAI_API_KEY.',
+  },
+  'cli.gen.codex_auth_hint': {
+    zh: '\n提示：当前 sample 生成使用 Codex 系列执行器。先确认 Codex CLI / SDK 已安装并完成登录；如果你有 Claude Code 可用，可以改用：{claudeFlags}；如果要走 OpenAI API，可以改用：{openaiFlags}，并设置 OPENAI_API_KEY。',
+    en: '\nHint: sample generation is using a Codex-based executor. First confirm the Codex CLI / SDK is installed and authenticated; if Claude Code is available, switch to: {claudeFlags}; to use the OpenAI API path, switch to: {openaiFlags}, and set OPENAI_API_KEY.',
+  },
+  'cli.gen.openai_api_auth_hint': {
+    zh: '\n提示：当前 sample 生成使用 OpenAI API 执行器。请检查 OPENAI_API_KEY / OPENAI_BASE_URL 是否可用，并确认模型名对当前端点可用；如果只是想先跑通，也可以改用：{claudeFlags}，或：{codexFlags}。',
+    en: '\nHint: sample generation is using the OpenAI API executor. Check OPENAI_API_KEY / OPENAI_BASE_URL and confirm the model is available on that endpoint; to just get a first run through, you can also switch to: {claudeFlags}, or: {codexFlags}.',
+  },
+  'cli.gen.anthropic_api_auth_hint': {
+    zh: '\n提示：当前 sample 生成使用 Anthropic API 执行器。请检查 ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL 是否可用，并确认模型名对当前端点可用；如果你有 Claude Code 可用，也可以改用：{claudeFlags}。',
+    en: '\nHint: sample generation is using the Anthropic API executor. Check ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL and confirm the model is available on that endpoint; if Claude Code is available, you can also switch to: {claudeFlags}.',
   },
   'cli.gen.failed': {
     zh: '生成失败: {message}',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -312,6 +312,45 @@ describe('CLI', () => {
     );
   });
 
+  it('sample openai-api 缺 key 时给出认证和切换提示', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-sample-auth-hint-'));
+    try {
+      const skillDir = join(dir, 'skills', 'triage');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: triage',
+        'description: 判断用户问题优先级并给出处理建议',
+        '---',
+        '',
+        '# Triage',
+        '',
+        '把用户问题分为 P0、P1、P2，并给出下一步处理建议。',
+      ].join('\n'));
+
+      await assert.rejects(
+        () => execFileAsync('node', [
+          CLI, 'sample', 'skills/triage',
+          '--executor', 'openai-api',
+          '--model', 'gpt-4o-mini',
+          '--count', '1',
+          '--lang', 'zh',
+        ], { cwd: dir, env: { ...process.env, OPENAI_API_KEY: '' } }),
+        (err: unknown) => {
+          const e = err as ExecError;
+          assert.equal(e.code, 1);
+          assert.ok(e.stderr.includes('OPENAI_API_KEY environment variable is not set'), e.stderr);
+          assert.ok(e.stderr.includes('OPENAI_API_KEY / OPENAI_BASE_URL'), e.stderr);
+          assert.ok(e.stderr.includes('--executor claude --model sonnet'), e.stderr);
+          assert.ok(e.stderr.includes('--executor codex --model <codex-model>'), e.stderr);
+          return true;
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('studio --help shows local workbench usage', async () => {
     const { stdout } = await execFileAsync('node', [CLI, 'studio', '--help']);
     assert.ok(stdout.includes('omk studio'));

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -351,6 +351,45 @@ describe('CLI', () => {
     }
   });
 
+  it('sample --batch 生成失败时不误报为无需生成', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-sample-batch-fail-'));
+    try {
+      const skillDir = join(dir, 'skills', 'triage');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: triage',
+        'description: 判断用户问题优先级',
+        '---',
+        '',
+        '# Triage',
+        '',
+        '把用户问题分为 P0、P1、P2。',
+      ].join('\n'));
+
+      await assert.rejects(
+        () => execFileAsync('node', [
+          CLI, 'sample', '--batch',
+          '--skill-dir', 'skills',
+          '--executor', 'openai-api',
+          '--model', 'gpt-4o-mini',
+          '--count', '1',
+          '--lang', 'zh',
+        ], { cwd: dir, env: { ...process.env, OPENAI_API_KEY: '' } }),
+        (err: unknown) => {
+          const e = err as ExecError;
+          assert.equal(e.code, 1);
+          assert.ok(e.stderr.includes('OPENAI_API_KEY / OPENAI_BASE_URL'), e.stderr);
+          assert.ok(e.stderr.includes('生成未完成：已生成 0 份，失败 1 份'), e.stderr);
+          assert.ok(!e.stdout.includes('没有需要生成的 eval-samples'), e.stdout);
+          return true;
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('studio --help shows local workbench usage', async () => {
     const { stdout } = await execFileAsync('node', [CLI, 'studio', '--help']);
     assert.ok(stdout.includes('omk studio'));

--- a/test/cli/sample-next-eval-command.test.ts
+++ b/test/cli/sample-next-eval-command.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { resolve } from 'node:path';
-import { sampleNextEvalCommand } from '../../src/cli/commands/sample.js';
+import { formatSampleGenerationFailureHint, sampleNextEvalCommand } from '../../src/cli/commands/sample.js';
 import { tCli } from '../../src/cli/lib/i18n.js';
 
 describe('sampleNextEvalCommand', () => {
@@ -58,5 +58,39 @@ describe('sampleNextEvalCommand', () => {
     const en = tCli('cli.gen.review_hint', 'en', { command });
     assert.match(en, /Preview the task plan: omk eval --control baseline --treatment 'skills\/review skill' --dry-run/);
     assert.match(en, /Run the eval: omk eval --control baseline --treatment 'skills\/review skill'/);
+  });
+});
+
+describe('formatSampleGenerationFailureHint', () => {
+  it('adds API-key guidance for OpenAI API sample generation failures', () => {
+    const hint = formatSampleGenerationFailureHint(
+      'OPENAI_API_KEY environment variable is not set',
+      'openai-api',
+      'zh',
+    );
+
+    assert.ok(hint.includes('OPENAI_API_KEY / OPENAI_BASE_URL'), hint);
+    assert.ok(hint.includes('--executor claude --model sonnet'), hint);
+    assert.ok(hint.includes('--executor codex --model <codex-model>'), hint);
+  });
+
+  it('does not misclassify model-output JSON errors as auth failures', () => {
+    const hint = formatSampleGenerationFailureHint(
+      'generation failed after 3 attempts (JSON invalid): JSON 解析失败',
+      'claude',
+      'zh',
+    );
+
+    assert.equal(hint, '');
+  });
+
+  it('does not add vendor guidance for custom script executors', () => {
+    const hint = formatSampleGenerationFailureHint(
+      'OPENAI_API_KEY environment variable is not set',
+      './sample-generator.sh',
+      'zh',
+    );
+
+    assert.equal(hint, '');
   });
 });


### PR DESCRIPTION
## 用户影响

- `omk sample` 在生成用例时如果卡在 Claude / Codex / OpenAI API / Anthropic API 的安装、登录、密钥或端点问题上，会补充对应的认证检查和可切换 executor flags。
- 成功路径保持原样：生成后仍提示先人工审查样本，再运行 `omk eval ... --dry-run`，最后去掉 `--dry-run` 正式评测。

## 迁移说明

无。此次只补充 CLI 失败提示，不改变命令参数、样本格式、报告格式或落盘数据。

## 测量学 caveat

不修改评分 prompt、报告 schema、样本加载语义、统计公式或 verdict 规则。改动仅发生在 sample 生成失败后的用户指引，不影响历史报告可比性。

## 验证

- fresh 项目手动走通：`omk sample` 成功生成 skill-local samples 后，`omk eval --control baseline --treatment skills/triage --dry-run` 可自动发现 `<skill>/.omk/`。
- 手动验证 `openai-api` 缺 `OPENAI_API_KEY` 时会提示 key / base URL 检查和 Claude / Codex 切换 flags。
- `yarn build && yarn test test/cli/sample-next-eval-command.test.ts test/cli.test.ts`
- `yarn ci`