### PR TITLE
fix(cli): 补充 evolve 自动生成失败提示

### DIFF
--- a/src/cli/commands/evolve.ts
+++ b/src/cli/commands/evolve.ts
@@ -7,6 +7,7 @@ import { enumStringParser, integerStringParser, numberStringParser } from '../oc
 import { CliExit } from '../lib/cli-exit.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
 import { makeOnProgress } from '../lib/progress.js';
+import { formatSampleGenerationFailureHint } from '../lib/generation-failure-hint.js';
 import type { EvolveArgs, EvolveFlags } from '../lib/cmd-flags.js';
 import type { EvolveOutcomeInput, EvolveOutcomeResult } from '../lib/record-evolve-outcome.js';
 import type { ProgressCallback } from '../../types/index.js';
@@ -208,7 +209,10 @@ export async function runEvolve(
         : `Generated ${samples.length} samples${cost}; starting evolution.\n`);
     } catch (err: unknown) {
       if (err instanceof CliExit) throw err;
-      console.error(tCli('cli.common.error_prefix', lang, { message: (err as Error).message }));
+      const message = (err as Error).message;
+      console.error(tCli('cli.common.error_prefix', lang, {
+        message: `${message}${formatSampleGenerationFailureHint(message, flags.executor, lang)}`,
+      }));
       throw new CliExit(1);
     }
   }

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -7,6 +7,7 @@ import { BaseCommand } from '../oclif/base-command.js';
 import { integerStringParser } from '../oclif/parsers.js';
 import { CliExit } from '../lib/cli-exit.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
+import { formatSampleGenerationFailureHint } from '../lib/generation-failure-hint.js';
 import { projectReportsDir, globalReportsDir } from '../../eval-core/measurement-dirs.js';
 import { loadSamples, parseYaml, listSampleFilesInDir, type LoadSamplesResult } from '../../inputs/load-samples.js';
 import {
@@ -136,49 +137,6 @@ function formatIdList(ids: string[]): string {
   const shown = ids.slice(0, 5);
   const suffix = ids.length > shown.length ? ` +${ids.length - shown.length}` : '';
   return shown.join(', ') + suffix;
-}
-
-const CLAUDE_SAMPLE_EXECUTORS = new Set(['claude', 'claude-sdk']);
-const CODEX_SAMPLE_EXECUTORS = new Set(['codex', 'codex-sdk']);
-const OPENAI_API_SAMPLE_EXECUTORS = new Set(['openai-api']);
-const ANTHROPIC_API_SAMPLE_EXECUTORS = new Set(['anthropic-api']);
-
-function looksLikeConnectivityFailure(message: string): boolean {
-  return /auth|login|credential|API[_ ]?KEY|BASE_URL|API error|ENOENT|not found|ECONN|ENOTFOUND|ETIMEDOUT|timeout|timed out|401|403|404/i.test(message);
-}
-
-export function formatSampleGenerationFailureHint(
-  message: string,
-  executorName: string | undefined,
-  lang: CliLang,
-): string {
-  const executor = executorName ?? 'claude';
-  if (!looksLikeConnectivityFailure(message)) return '';
-
-  if (CLAUDE_SAMPLE_EXECUTORS.has(executor)) {
-    return tCli('cli.gen.claude_auth_hint', lang, {
-      codexFlags: '--executor codex --model <codex-model>',
-      openaiFlags: '--executor openai-api --model <openai-model>',
-    });
-  }
-  if (CODEX_SAMPLE_EXECUTORS.has(executor)) {
-    return tCli('cli.gen.codex_auth_hint', lang, {
-      claudeFlags: '--executor claude --model sonnet',
-      openaiFlags: '--executor openai-api --model <openai-model>',
-    });
-  }
-  if (OPENAI_API_SAMPLE_EXECUTORS.has(executor)) {
-    return tCli('cli.gen.openai_api_auth_hint', lang, {
-      claudeFlags: '--executor claude --model sonnet',
-      codexFlags: '--executor codex --model <codex-model>',
-    });
-  }
-  if (ANTHROPIC_API_SAMPLE_EXECUTORS.has(executor)) {
-    return tCli('cli.gen.anthropic_api_auth_hint', lang, {
-      claudeFlags: '--executor claude --model sonnet',
-    });
-  }
-  return '';
 }
 
 // 下面 3 个 helper 在 sample-fix.test.ts 单测内 in-process import 验证 fix 逻辑。

--- a/src/cli/lib/generation-failure-hint.ts
+++ b/src/cli/lib/generation-failure-hint.ts
@@ -1,0 +1,44 @@
+import { tCli, type CliLang } from './i18n.js';
+
+const CLAUDE_SAMPLE_EXECUTORS = new Set(['claude', 'claude-sdk']);
+const CODEX_SAMPLE_EXECUTORS = new Set(['codex', 'codex-sdk']);
+const OPENAI_API_SAMPLE_EXECUTORS = new Set(['openai-api']);
+const ANTHROPIC_API_SAMPLE_EXECUTORS = new Set(['anthropic-api']);
+
+function looksLikeConnectivityFailure(message: string): boolean {
+  return /auth|login|credential|API[_ ]?KEY|BASE_URL|API error|ENOENT|not found|ECONN|ENOTFOUND|ETIMEDOUT|timeout|timed out|401|403|404/i.test(message);
+}
+
+export function formatSampleGenerationFailureHint(
+  message: string,
+  executorName: string | undefined,
+  lang: CliLang,
+): string {
+  const executor = executorName ?? 'claude';
+  if (!looksLikeConnectivityFailure(message)) return '';
+
+  if (CLAUDE_SAMPLE_EXECUTORS.has(executor)) {
+    return tCli('cli.gen.claude_auth_hint', lang, {
+      codexFlags: '--executor codex --model <codex-model>',
+      openaiFlags: '--executor openai-api --model <openai-model>',
+    });
+  }
+  if (CODEX_SAMPLE_EXECUTORS.has(executor)) {
+    return tCli('cli.gen.codex_auth_hint', lang, {
+      claudeFlags: '--executor claude --model sonnet',
+      openaiFlags: '--executor openai-api --model <openai-model>',
+    });
+  }
+  if (OPENAI_API_SAMPLE_EXECUTORS.has(executor)) {
+    return tCli('cli.gen.openai_api_auth_hint', lang, {
+      claudeFlags: '--executor claude --model sonnet',
+      codexFlags: '--executor codex --model <codex-model>',
+    });
+  }
+  if (ANTHROPIC_API_SAMPLE_EXECUTORS.has(executor)) {
+    return tCli('cli.gen.anthropic_api_auth_hint', lang, {
+      claudeFlags: '--executor claude --model sonnet',
+    });
+  }
+  return '';
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -390,6 +390,49 @@ describe('CLI', () => {
     }
   });
 
+  it('evolve 自动生成 openai-api 缺 key 时给出认证和切换提示', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-evolve-auth-hint-'));
+    try {
+      const skillDir = join(dir, 'skills', 'triage');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: triage',
+        'description: 判断用户问题优先级并给出处理建议',
+        '---',
+        '',
+        '# Triage',
+        '',
+        '把用户问题分为 P0、P1、P2，并给出下一步处理建议。',
+      ].join('\n'));
+
+      await assert.rejects(
+        () => execFileAsync('node', [
+          CLI, 'evolve', 'skills/triage',
+          '--executor', 'openai-api',
+          '--model', 'gpt-4o-mini',
+          '--judge-models', 'openai-api:gpt-4o-mini',
+          '--rounds', '1',
+          '--skip-doctor',
+          '--skip-connectivity',
+          '--lang', 'zh',
+        ], { cwd: dir, env: { ...process.env, OPENAI_API_KEY: '' } }),
+        (err: unknown) => {
+          const e = err as ExecError;
+          assert.equal(e.code, 1);
+          assert.ok(e.stderr.includes('未发现评测用例，正在自动生成到'), e.stderr);
+          assert.ok(e.stderr.includes('OPENAI_API_KEY environment variable is not set'), e.stderr);
+          assert.ok(e.stderr.includes('OPENAI_API_KEY / OPENAI_BASE_URL'), e.stderr);
+          assert.ok(e.stderr.includes('--executor claude --model sonnet'), e.stderr);
+          assert.ok(e.stderr.includes('--executor codex --model <codex-model>'), e.stderr);
+          return true;
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('studio --help shows local workbench usage', async () => {
     const { stdout } = await execFileAsync('node', [CLI, 'studio', '--help']);
     assert.ok(stdout.includes('omk studio'));

--- a/test/cli/sample-next-eval-command.test.ts
+++ b/test/cli/sample-next-eval-command.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { resolve } from 'node:path';
-import { formatSampleGenerationFailureHint, sampleNextEvalCommand } from '../../src/cli/commands/sample.js';
+import { sampleNextEvalCommand } from '../../src/cli/commands/sample.js';
+import { formatSampleGenerationFailureHint } from '../../src/cli/lib/generation-failure-hint.js';
 import { tCli } from '../../src/cli/lib/i18n.js';
 
 describe('sampleNextEvalCommand', () => {


### PR DESCRIPTION
## Purpose

`omk evolve` 在首跑没有 samples 时会自动进入 sample 生成，但生成执行器认证失败时只输出裸错误，用户看不出该认证哪个执行器，也不知道可以怎样切换路径。本 PR 让这条首跑路径复用 `omk sample` 的认证与备选执行器提示，降低第一次跑通 evolve 的摩擦。

## Changes

- 把 sample 生成失败提示抽到共享 CLI helper。
- `omk evolve` 自动生成 samples 失败时追加认证与切换提示。
- 增加 CLI 覆盖，锁定 OpenAI API 缺 key 时的 evolve 首跑提示。

## Testing

- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` passes
- [x] Added / updated tests covering new behavior
- [x] Manually exercised the feature end-to-end for the CLI failure path

## Checklist

- [x] Read `CLAUDE.md`
- [x] Branch is `feat/*`, `fix/*`, `docs/*`, or `chore/*`, cut from `main`（GitHub Flow）
- [x] Target branch is `main`
- [x] Commit message follows the repo convention（`type(scope): subject`）
- [x] PR title / description note user-facing impact + migration if BREAKING（not BREAKING）
- [x] No secrets / internal URLs / personal data in the diff
- [x] If CLI surface or user-facing behavior changed：仅补充错误提示，沿用现有 i18n 文案，无需文档迁移
- [x] Bilingual parity：未新增文档；共享现有中英文提示

## Additional context

不改变 report schema、评分 prompt、评分管道或统计口径；没有测量可比性影响。
