### PR TITLE
fix(cli): 补充 Codex 模型提示

### DIFF
--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -9,6 +9,7 @@ import { tCli, type CliLang } from '../../lib/i18n.js';
 import { parseRunConfig, type RunConfig } from '../../lib/parse-run-config.js';
 import { makeOnProgress } from '../../lib/progress.js';
 import { computeRunTally } from '../../lib/run-tally.js';
+import { codexModelFlagValue, codexModelHint } from '../../lib/codex-model-hint.js';
 import type { EvalArgs, EvalFlags } from '../../lib/cmd-flags.js';
 import type { BatchEvaluationReport, EvaluationReport, Report, ProgressCallback } from '../../../types/index.js';
 import type { DryRunBatchReport, DryRunReport } from '../../../eval-workflows/run-evaluation.js';
@@ -205,6 +206,7 @@ export function formatConnectivityFailureHint(
   message: string,
   config: Pick<RunConfig, 'executorName' | 'model' | 'judgeModels' | 'noJudge'>,
   lang: CliLang,
+  env: NodeJS.ProcessEnv = process.env,
 ): string {
   const failedTarget = preflightFailedTarget(message);
   if (failedTarget) {
@@ -212,8 +214,10 @@ export function formatConnectivityFailureHint(
     if (matches.length === 0) return '';
 
     if (hasExecutor(matches, CLAUDE_EXECUTORS)) {
+      const codexModel = codexModelFlagValue(env);
       return tCli('cli.run.codex_fallback_hint', lang, {
-        flags: fallbackFlags(matches, 'codex', '<codex-model>', '<codex-model>', shouldSwitchJudgeWithTask(config, CLAUDE_EXECUTORS)),
+        flags: fallbackFlags(matches, 'codex', codexModel, codexModel, shouldSwitchJudgeWithTask(config, CLAUDE_EXECUTORS)),
+        codexModelHint: codexModelHint(lang, env),
       });
     }
     if (hasExecutor(matches, CODEX_EXECUTORS)) {

--- a/src/cli/lib/codex-model-hint.ts
+++ b/src/cli/lib/codex-model-hint.ts
@@ -1,0 +1,53 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface CodexModelSuggestion {
+  model: string;
+  fromConfig: boolean;
+  configPath?: string;
+}
+
+const CODEX_MODEL_PLACEHOLDER = '<codex-model>';
+
+function parseTopLevelCodexModel(configText: string): string | null {
+  for (const line of configText.split(/\r?\n/)) {
+    if (/^\s*\[/.test(line)) return null;
+    const match = line.match(/^\s*model\s*=\s*(?:"([^"]+)"|'([^']+)')\s*(?:#.*)?$/);
+    const model = match?.[1] ?? match?.[2];
+    if (model) return model;
+  }
+  return null;
+}
+
+export function getCodexModelSuggestion(env: NodeJS.ProcessEnv = process.env): CodexModelSuggestion {
+  const codexHome = env.CODEX_HOME || join(homedir(), '.codex');
+  const configPath = join(codexHome, 'config.toml');
+  if (existsSync(configPath)) {
+    try {
+      const model = parseTopLevelCodexModel(readFileSync(configPath, 'utf-8'));
+      if (model) return { model, fromConfig: true, configPath };
+    } catch { /* best-effort hint only */ }
+  }
+  return { model: CODEX_MODEL_PLACEHOLDER, fromConfig: false, configPath };
+}
+
+export function codexModelHint(lang: 'zh' | 'en', env: NodeJS.ProcessEnv = process.env): string {
+  const suggestion = getCodexModelSuggestion(env);
+  if (suggestion.fromConfig) {
+    return lang === 'zh'
+      ? `已按本机 Codex 配置 model=${suggestion.model} 填入。`
+      : `Filled from local Codex config model=${suggestion.model}.`;
+  }
+  return lang === 'zh'
+    ? `把 ${CODEX_MODEL_PLACEHOLDER} 换成本机 Codex 可用模型；可查看 ${suggestion.configPath} 的 model。`
+    : `Replace ${CODEX_MODEL_PLACEHOLDER} with a model your local Codex can run; check model in ${suggestion.configPath}.`;
+}
+
+export function codexModelFlagValue(env: NodeJS.ProcessEnv = process.env): string {
+  return getCodexModelSuggestion(env).model;
+}
+
+export function codexExecutorFlags(env: NodeJS.ProcessEnv = process.env): string {
+  return `--executor codex --model ${codexModelFlagValue(env)}`;
+}

--- a/src/cli/lib/generation-failure-hint.ts
+++ b/src/cli/lib/generation-failure-hint.ts
@@ -1,4 +1,5 @@
 import { tCli, type CliLang } from './i18n.js';
+import { codexExecutorFlags, codexModelFlagValue, codexModelHint } from './codex-model-hint.js';
 
 const CLAUDE_SAMPLE_EXECUTORS = new Set(['claude', 'claude-sdk']);
 const CODEX_SAMPLE_EXECUTORS = new Set(['codex', 'codex-sdk']);
@@ -6,24 +7,39 @@ const OPENAI_API_SAMPLE_EXECUTORS = new Set(['openai-api']);
 const ANTHROPIC_API_SAMPLE_EXECUTORS = new Set(['anthropic-api']);
 
 function looksLikeConnectivityFailure(message: string): boolean {
-  return /auth|login|credential|API[_ ]?KEY|BASE_URL|API error|ENOENT|not found|ECONN|ENOTFOUND|ETIMEDOUT|timeout|timed out|401|403|404/i.test(message);
+  return /auth|login|credential|API[_ ]?KEY|BASE_URL|API error|ENOENT|not found|ECONN|ENOTFOUND|ETIMEDOUT|timeout|timed out|401|403|404|invalid_request_error|model .*not supported|model is not supported/i.test(message);
+}
+
+function looksLikeCodexModelFailure(message: string): boolean {
+  return /model .*not supported|model is not supported|unsupported model|invalid_request_error.*model|model.*invalid_request_error/i.test(message);
 }
 
 export function formatSampleGenerationFailureHint(
   message: string,
   executorName: string | undefined,
   lang: CliLang,
+  env: NodeJS.ProcessEnv = process.env,
 ): string {
   const executor = executorName ?? 'claude';
   if (!looksLikeConnectivityFailure(message)) return '';
 
   if (CLAUDE_SAMPLE_EXECUTORS.has(executor)) {
     return tCli('cli.gen.claude_auth_hint', lang, {
-      codexFlags: '--executor codex --model <codex-model>',
+      codexFlags: codexExecutorFlags(env),
+      codexModelHint: codexModelHint(lang, env),
       openaiFlags: '--executor openai-api --model <openai-model>',
     });
   }
   if (CODEX_SAMPLE_EXECUTORS.has(executor)) {
+    if (looksLikeCodexModelFailure(message)) {
+      return tCli('cli.gen.codex_model_hint', lang, {
+        codexFlags: codexExecutorFlags(env),
+        codexExec: `codex exec -m ${codexModelFlagValue(env)} "hi"`,
+        claudeFlags: '--executor claude --model sonnet',
+        openaiFlags: '--executor openai-api --model <openai-model>',
+        codexModelHint: codexModelHint(lang, env),
+      });
+    }
     return tCli('cli.gen.codex_auth_hint', lang, {
       claudeFlags: '--executor claude --model sonnet',
       openaiFlags: '--executor openai-api --model <openai-model>',
@@ -32,7 +48,8 @@ export function formatSampleGenerationFailureHint(
   if (OPENAI_API_SAMPLE_EXECUTORS.has(executor)) {
     return tCli('cli.gen.openai_api_auth_hint', lang, {
       claudeFlags: '--executor claude --model sonnet',
-      codexFlags: '--executor codex --model <codex-model>',
+      codexFlags: codexExecutorFlags(env),
+      codexModelHint: codexModelHint(lang, env),
     });
   }
   if (ANTHROPIC_API_SAMPLE_EXECUTORS.has(executor)) {

--- a/src/cli/lib/i18n-dict/gen.ts
+++ b/src/cli/lib/i18n-dict/gen.ts
@@ -19,6 +19,7 @@ export type GenMessageKey =
   | 'cli.gen.review_hint'
   | 'cli.gen.claude_auth_hint'
   | 'cli.gen.codex_auth_hint'
+  | 'cli.gen.codex_model_hint'
   | 'cli.gen.openai_api_auth_hint'
   | 'cli.gen.anthropic_api_auth_hint'
   | 'cli.gen.failed'
@@ -90,16 +91,20 @@ export const genDict: Record<GenMessageKey, CliMessage> = {
     en: '\nNext steps:\n  1. Review the generated samples; drop weak cases and add boundary / counterexamples\n  2. Preview the task plan: {command} --dry-run\n  3. Run the eval: {command}',
   },
   'cli.gen.claude_auth_hint': {
-    zh: '\n提示：当前 sample 生成使用 Claude 系列执行器。先确认 Claude Code 已安装并完成登录；如果你在 Codex 环境里，可以改用：{codexFlags}；如果要走 OpenAI API，可以改用：{openaiFlags}，并设置 OPENAI_API_KEY。',
-    en: '\nHint: sample generation is using a Claude-based executor. First confirm Claude Code is installed and authenticated; in a Codex environment, switch to: {codexFlags}; to use the OpenAI API path, switch to: {openaiFlags}, and set OPENAI_API_KEY.',
+    zh: '\n提示：当前 sample 生成使用 Claude 系列执行器。先确认 Claude Code 已安装并完成登录；如果你在 Codex 环境里，可以改用：{codexFlags}（{codexModelHint}）；如果要走 OpenAI API，可以改用：{openaiFlags}，并设置 OPENAI_API_KEY。',
+    en: '\nHint: sample generation is using a Claude-based executor. First confirm Claude Code is installed and authenticated; in a Codex environment, switch to: {codexFlags} ({codexModelHint}); to use the OpenAI API path, switch to: {openaiFlags}, and set OPENAI_API_KEY.',
   },
   'cli.gen.codex_auth_hint': {
     zh: '\n提示：当前 sample 生成使用 Codex 系列执行器。先确认 Codex CLI / SDK 已安装并完成登录；如果你有 Claude Code 可用，可以改用：{claudeFlags}；如果要走 OpenAI API，可以改用：{openaiFlags}，并设置 OPENAI_API_KEY。',
     en: '\nHint: sample generation is using a Codex-based executor. First confirm the Codex CLI / SDK is installed and authenticated; if Claude Code is available, switch to: {claudeFlags}; to use the OpenAI API path, switch to: {openaiFlags}, and set OPENAI_API_KEY.',
   },
+  'cli.gen.codex_model_hint': {
+    zh: '\n提示：当前 sample 生成使用 Codex 系列执行器，但模型名看起来不可用。可以先按本机 Codex 配置重试：{codexFlags}（{codexModelHint}）；也可以先运行 `{codexExec}` 验证模型是否可用。若只是想先跑通，可以改用：{claudeFlags}；或走 OpenAI API：{openaiFlags}，并设置 OPENAI_API_KEY。',
+    en: '\nHint: sample generation is using a Codex-based executor, but the model name appears unavailable. Retry with the local Codex config model: {codexFlags} ({codexModelHint}); you can also run `{codexExec}` to verify the model. To just get a first run through, switch to: {claudeFlags}; or use the OpenAI API path: {openaiFlags}, and set OPENAI_API_KEY.',
+  },
   'cli.gen.openai_api_auth_hint': {
-    zh: '\n提示：当前 sample 生成使用 OpenAI API 执行器。请检查 OPENAI_API_KEY / OPENAI_BASE_URL 是否可用，并确认模型名对当前端点可用；如果只是想先跑通，也可以改用：{claudeFlags}，或：{codexFlags}。',
-    en: '\nHint: sample generation is using the OpenAI API executor. Check OPENAI_API_KEY / OPENAI_BASE_URL and confirm the model is available on that endpoint; to just get a first run through, you can also switch to: {claudeFlags}, or: {codexFlags}.',
+    zh: '\n提示：当前 sample 生成使用 OpenAI API 执行器。请检查 OPENAI_API_KEY / OPENAI_BASE_URL 是否可用，并确认模型名对当前端点可用；如果只是想先跑通，也可以改用：{claudeFlags}，或：{codexFlags}（{codexModelHint}）。',
+    en: '\nHint: sample generation is using the OpenAI API executor. Check OPENAI_API_KEY / OPENAI_BASE_URL and confirm the model is available on that endpoint; to just get a first run through, you can also switch to: {claudeFlags}, or: {codexFlags} ({codexModelHint}).',
   },
   'cli.gen.anthropic_api_auth_hint': {
     zh: '\n提示：当前 sample 生成使用 Anthropic API 执行器。请检查 ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL 是否可用，并确认模型名对当前端点可用；如果你有 Claude Code 可用，也可以改用：{claudeFlags}。',

--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -204,8 +204,8 @@ export const runDict: Record<RunMessageKey, CliMessage> = {
     en: '\n⚠ {warning}\n',
   },
   'cli.run.codex_fallback_hint': {
-    zh: '\n提示：当前失败的是 Claude 系列执行器。先确认 Claude Code 已登录；如果你在 Codex 环境里，也可以把模型运行参数改为：{flags}。把 <codex-model> 换成本机 Codex 可用的模型；codex 执行器目前不会报告 costUSD。',
-    en: '\nHint: the failing runtime is Claude-based. First confirm Claude Code is authenticated; in a Codex environment, you can also switch the model runtime flags to: {flags}. Replace <codex-model> with a model your local Codex can run; the codex executor does not report costUSD yet.',
+    zh: '\n提示：当前失败的是 Claude 系列执行器。先确认 Claude Code 已登录；如果你在 Codex 环境里，也可以把模型运行参数改为：{flags}。{codexModelHint}codex 执行器目前不会报告 costUSD。',
+    en: '\nHint: the failing runtime is Claude-based. First confirm Claude Code is authenticated; in a Codex environment, you can also switch the model runtime flags to: {flags}. {codexModelHint} The codex executor does not report costUSD yet.',
   },
   'cli.run.codex_auth_hint': {
     zh: '\n提示：当前失败的是 Codex 系列执行器。先确认 Codex CLI / SDK 已安装并完成登录；如果你有 Claude Code 可用，可以改走 Claude：{claudeFlags}；如果要继续走 OpenAI API，可以改为：{openaiFlags}，并设置 OPENAI_API_KEY。openai-api 会按 API 响应记录 token / cost。',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -335,7 +335,7 @@ describe('CLI', () => {
           '--model', 'gpt-4o-mini',
           '--count', '1',
           '--lang', 'zh',
-        ], { cwd: dir, env: { ...process.env, OPENAI_API_KEY: '' } }),
+        ], { cwd: dir, env: { ...process.env, OPENAI_API_KEY: '', CODEX_HOME: join(dir, '.codex-empty') } }),
         (err: unknown) => {
           const e = err as ExecError;
           assert.equal(e.code, 1);
@@ -375,7 +375,7 @@ describe('CLI', () => {
           '--model', 'gpt-4o-mini',
           '--count', '1',
           '--lang', 'zh',
-        ], { cwd: dir, env: { ...process.env, OPENAI_API_KEY: '' } }),
+        ], { cwd: dir, env: { ...process.env, OPENAI_API_KEY: '', CODEX_HOME: join(dir, '.codex-empty') } }),
         (err: unknown) => {
           const e = err as ExecError;
           assert.equal(e.code, 1);
@@ -416,7 +416,7 @@ describe('CLI', () => {
           '--skip-doctor',
           '--skip-connectivity',
           '--lang', 'zh',
-        ], { cwd: dir, env: { ...process.env, OPENAI_API_KEY: '' } }),
+        ], { cwd: dir, env: { ...process.env, OPENAI_API_KEY: '', CODEX_HOME: join(dir, '.codex-empty') } }),
         (err: unknown) => {
           const e = err as ExecError;
           assert.equal(e.code, 1);

--- a/test/cli/codex-model-hint.test.ts
+++ b/test/cli/codex-model-hint.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { codexExecutorFlags, codexModelHint, getCodexModelSuggestion } from '../../src/cli/lib/codex-model-hint.js';
+import { formatSampleGenerationFailureHint } from '../../src/cli/lib/generation-failure-hint.js';
+
+describe('codex model hint', () => {
+  it('reads the top-level model from CODEX_HOME/config.toml', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-codex-home-'));
+    await writeFile(join(dir, 'config.toml'), [
+      'model = "gpt-5.5"',
+      'model_reasoning_effort = "xhigh"',
+      '',
+      '[profiles.other]',
+      'model = "ignored"',
+    ].join('\n'));
+
+    const env = { CODEX_HOME: dir };
+
+    assert.deepEqual(getCodexModelSuggestion(env), {
+      model: 'gpt-5.5',
+      fromConfig: true,
+      configPath: join(dir, 'config.toml'),
+    });
+    assert.equal(codexExecutorFlags(env), '--executor codex --model gpt-5.5');
+    assert.ok(codexModelHint('zh', env).includes('model=gpt-5.5'));
+  });
+
+  it('falls back to a placeholder when no local Codex model is configured', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-empty-codex-home-'));
+    await mkdir(join(dir, 'nested'), { recursive: true });
+
+    const hint = codexModelHint('zh', { CODEX_HOME: dir });
+
+    assert.equal(codexExecutorFlags({ CODEX_HOME: dir }), '--executor codex --model <codex-model>');
+    assert.ok(hint.includes('<codex-model>'), hint);
+    assert.ok(hint.includes(join(dir, 'config.toml')), hint);
+  });
+
+  it('gives Codex model-specific guidance when sample generation hits an unsupported model', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-codex-model-hint-'));
+    await writeFile(join(dir, 'config.toml'), 'model = "gpt-5.5"\n');
+
+    const hint = formatSampleGenerationFailureHint(
+      `{"type":"error","status":400,"error":{"message":"The 'gpt-5' model is not supported when using Codex with a ChatGPT account."}}`,
+      'codex',
+      'zh',
+      { CODEX_HOME: dir },
+    );
+
+    assert.ok(hint.includes('模型名看起来不可用'), hint);
+    assert.ok(hint.includes('--executor codex --model gpt-5.5'), hint);
+    assert.ok(hint.includes('codex exec -m gpt-5.5 "hi"'), hint);
+    assert.ok(hint.includes('--executor claude --model sonnet'), hint);
+  });
+});

--- a/test/cli/eval-preflight-hint.test.ts
+++ b/test/cli/eval-preflight-hint.test.ts
@@ -1,8 +1,22 @@
-import { describe, it } from 'vitest';
+import { afterEach, beforeEach, describe, it } from 'vitest';
 import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { formatConnectivityFailureHint } from '../../src/cli/commands/eval/index.js';
 
+const ORIGINAL_CODEX_HOME = process.env.CODEX_HOME;
+
 describe('eval connectivity failure hint', () => {
+  beforeEach(() => {
+    process.env.CODEX_HOME = '/tmp/omk-empty-codex-home-for-tests';
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_CODEX_HOME === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = ORIGINAL_CODEX_HOME;
+  });
+
   it('suggests Codex flags when default Claude preflight fails', () => {
     const hint = formatConnectivityFailureHint(
       'preflight failed [claude:sonnet]: Failed to authenticate. API Error: 401 Invalid authentication credentials',
@@ -17,6 +31,27 @@ describe('eval connectivity failure hint', () => {
 
     assert.ok(hint.includes('--executor codex --model <codex-model> --judge-models codex:<codex-model>'), hint);
     assert.ok(hint.includes('costUSD'), hint);
+  });
+
+  it('fills Codex fallback flags from local Codex config when available', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-codex-eval-hint-'));
+    await writeFile(join(dir, 'config.toml'), 'model = "gpt-5.5"\n');
+
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [claude:sonnet]: auth failed',
+      {
+        executorName: 'claude',
+        model: 'sonnet',
+        judgeModels: [{ executor: 'claude', model: 'haiku' }],
+        noJudge: false,
+      },
+      'zh',
+      { CODEX_HOME: dir },
+    );
+
+    assert.ok(hint.includes('--executor codex --model gpt-5.5 --judge-models codex:gpt-5.5'), hint);
+    assert.ok(hint.includes('model=gpt-5.5'), hint);
+    assert.ok(!hint.includes('<codex-model>'), hint);
   });
 
   it('omits judge flags when the run has --no-judge', () => {

--- a/test/cli/sample-next-eval-command.test.ts
+++ b/test/cli/sample-next-eval-command.test.ts
@@ -68,6 +68,7 @@ describe('formatSampleGenerationFailureHint', () => {
       'OPENAI_API_KEY environment variable is not set',
       'openai-api',
       'zh',
+      { CODEX_HOME: '/tmp/omk-empty-codex-home-for-tests' },
     );
 
     assert.ok(hint.includes('OPENAI_API_KEY / OPENAI_BASE_URL'), hint);
@@ -80,6 +81,7 @@ describe('formatSampleGenerationFailureHint', () => {
       'generation failed after 3 attempts (JSON invalid): JSON 解析失败',
       'claude',
       'zh',
+      { CODEX_HOME: '/tmp/omk-empty-codex-home-for-tests' },
     );
 
     assert.equal(hint, '');
@@ -90,6 +92,7 @@ describe('formatSampleGenerationFailureHint', () => {
       'OPENAI_API_KEY environment variable is not set',
       './sample-generator.sh',
       'zh',
+      { CODEX_HOME: '/tmp/omk-empty-codex-home-for-tests' },
     );
 
     assert.equal(hint, '');


### PR DESCRIPTION
## Purpose

真实跑 Codex 首跑链路时，`gpt-5-codex` / `gpt-5` 在当前 ChatGPT 账号下会返回 model not supported。此前提示只给 `<codex-model>` 占位，用户仍不知道该填什么。本 PR 让 CLI 在可读到本机 Codex 配置时直接填入 `CODEX_HOME/config.toml` 的默认模型；读不到时保留占位并告诉用户去哪里看。

## Changes

- 新增 Codex 模型提示 helper，读取 `$CODEX_HOME/config.toml` 或 `~/.codex/config.toml` 顶层 `model`。
- `sample` / `evolve` 生成失败提示在 Codex 模型不可用时给出专门文案和 `codex exec -m ... "hi"` 验证命令。
- `eval` 的 Claude→Codex fallback 提示改为优先填入本机 Codex 模型，不再默认只展示 `<codex-model>`。

## Testing

- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` passes
- [x] Added / updated tests covering new behavior
- [x] Manually exercised the CLI failure path with real Codex model-not-supported response

## Checklist

- [x] Read `CLAUDE.md`
- [x] Branch is `feat/*`, `fix/*`, `docs/*`, or `chore/*`, cut from `main`（GitHub Flow）
- [x] Target branch is `main`
- [x] Commit message follows the repo convention（`type(scope): subject`）
- [x] PR title / description note user-facing impact + migration if BREAKING（not BREAKING）
- [x] No secrets / internal URLs / personal data in the diff
- [x] If CLI surface or user-facing behavior changed：仅补充错误提示，未新增 flag / command
- [x] Bilingual parity：新增 runtime i18n 文案中英文同步

## Additional context

不改变 report schema、评分 prompt、评分管道或统计口径；没有测量可比性影响。
