### PR TITLE
fix(cli): 区分 API 模型不可用提示

### DIFF
--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -10,6 +10,7 @@ import { parseRunConfig, type RunConfig } from '../../lib/parse-run-config.js';
 import { makeOnProgress } from '../../lib/progress.js';
 import { computeRunTally } from '../../lib/run-tally.js';
 import { codexModelFlagValue, codexModelHint } from '../../lib/codex-model-hint.js';
+import { looksLikeModelUnavailableFailure } from '../../lib/llm-failure-classifier.js';
 import type { EvalArgs, EvalFlags } from '../../lib/cmd-flags.js';
 import type { BatchEvaluationReport, EvaluationReport, Report, ProgressCallback } from '../../../types/index.js';
 import type { DryRunBatchReport, DryRunReport } from '../../../eval-workflows/run-evaluation.js';
@@ -221,13 +222,27 @@ export function formatConnectivityFailureHint(
       });
     }
     if (hasExecutor(matches, CODEX_EXECUTORS)) {
+      if (looksLikeModelUnavailableFailure(message)) {
+        const codexModel = codexModelFlagValue(env);
+        return tCli('cli.run.codex_model_hint', lang, {
+          codexFlags: fallbackFlags(matches, 'codex', codexModel, codexModel, shouldSwitchJudgeWithTask(config, CODEX_EXECUTORS)),
+          codexExec: `codex exec -m ${codexModel} "hi"`,
+          claudeFlags: fallbackFlags(matches, 'claude', 'sonnet', 'haiku', shouldSwitchJudgeWithTask(config, CODEX_EXECUTORS)),
+          openaiFlags: fallbackFlags(matches, 'openai-api', '<openai-model>', '<openai-model>', shouldSwitchJudgeWithTask(config, CODEX_EXECUTORS)),
+          codexModelHint: codexModelHint(lang, env),
+        });
+      }
       return tCli('cli.run.codex_auth_hint', lang, {
         claudeFlags: fallbackFlags(matches, 'claude', 'sonnet', 'haiku', shouldSwitchJudgeWithTask(config, CODEX_EXECUTORS)),
         openaiFlags: fallbackFlags(matches, 'openai-api', '<openai-model>', '<openai-model>', shouldSwitchJudgeWithTask(config, CODEX_EXECUTORS)),
       });
     }
-    if (hasExecutor(matches, OPENAI_API_EXECUTORS)) return tCli('cli.run.openai_api_auth_hint', lang);
-    if (hasExecutor(matches, ANTHROPIC_API_EXECUTORS)) return tCli('cli.run.anthropic_api_auth_hint', lang);
+    if (hasExecutor(matches, OPENAI_API_EXECUTORS)) {
+      return tCli(looksLikeModelUnavailableFailure(message) ? 'cli.run.openai_api_model_hint' : 'cli.run.openai_api_auth_hint', lang);
+    }
+    if (hasExecutor(matches, ANTHROPIC_API_EXECUTORS)) {
+      return tCli(looksLikeModelUnavailableFailure(message) ? 'cli.run.anthropic_api_model_hint' : 'cli.run.anthropic_api_auth_hint', lang);
+    }
     return '';
   }
 

--- a/src/cli/lib/generation-failure-hint.ts
+++ b/src/cli/lib/generation-failure-hint.ts
@@ -1,18 +1,11 @@
 import { tCli, type CliLang } from './i18n.js';
 import { codexExecutorFlags, codexModelFlagValue, codexModelHint } from './codex-model-hint.js';
+import { looksLikeLlmSetupFailure, looksLikeModelUnavailableFailure } from './llm-failure-classifier.js';
 
 const CLAUDE_SAMPLE_EXECUTORS = new Set(['claude', 'claude-sdk']);
 const CODEX_SAMPLE_EXECUTORS = new Set(['codex', 'codex-sdk']);
 const OPENAI_API_SAMPLE_EXECUTORS = new Set(['openai-api']);
 const ANTHROPIC_API_SAMPLE_EXECUTORS = new Set(['anthropic-api']);
-
-function looksLikeConnectivityFailure(message: string): boolean {
-  return /auth|login|credential|API[_ ]?KEY|BASE_URL|API error|ENOENT|not found|ECONN|ENOTFOUND|ETIMEDOUT|timeout|timed out|401|403|404|invalid_request_error|model .*not supported|model is not supported/i.test(message);
-}
-
-function looksLikeCodexModelFailure(message: string): boolean {
-  return /model .*not supported|model is not supported|unsupported model|invalid_request_error.*model|model.*invalid_request_error/i.test(message);
-}
 
 export function formatSampleGenerationFailureHint(
   message: string,
@@ -21,7 +14,7 @@ export function formatSampleGenerationFailureHint(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
   const executor = executorName ?? 'claude';
-  if (!looksLikeConnectivityFailure(message)) return '';
+  if (!looksLikeLlmSetupFailure(message)) return '';
 
   if (CLAUDE_SAMPLE_EXECUTORS.has(executor)) {
     return tCli('cli.gen.claude_auth_hint', lang, {
@@ -31,7 +24,7 @@ export function formatSampleGenerationFailureHint(
     });
   }
   if (CODEX_SAMPLE_EXECUTORS.has(executor)) {
-    if (looksLikeCodexModelFailure(message)) {
+    if (looksLikeModelUnavailableFailure(message)) {
       return tCli('cli.gen.codex_model_hint', lang, {
         codexFlags: codexExecutorFlags(env),
         codexExec: `codex exec -m ${codexModelFlagValue(env)} "hi"`,
@@ -46,6 +39,13 @@ export function formatSampleGenerationFailureHint(
     });
   }
   if (OPENAI_API_SAMPLE_EXECUTORS.has(executor)) {
+    if (looksLikeModelUnavailableFailure(message)) {
+      return tCli('cli.gen.openai_api_model_hint', lang, {
+        claudeFlags: '--executor claude --model sonnet',
+        codexFlags: codexExecutorFlags(env),
+        codexModelHint: codexModelHint(lang, env),
+      });
+    }
     return tCli('cli.gen.openai_api_auth_hint', lang, {
       claudeFlags: '--executor claude --model sonnet',
       codexFlags: codexExecutorFlags(env),
@@ -53,6 +53,11 @@ export function formatSampleGenerationFailureHint(
     });
   }
   if (ANTHROPIC_API_SAMPLE_EXECUTORS.has(executor)) {
+    if (looksLikeModelUnavailableFailure(message)) {
+      return tCli('cli.gen.anthropic_api_model_hint', lang, {
+        claudeFlags: '--executor claude --model sonnet',
+      });
+    }
     return tCli('cli.gen.anthropic_api_auth_hint', lang, {
       claudeFlags: '--executor claude --model sonnet',
     });

--- a/src/cli/lib/i18n-dict/gen.ts
+++ b/src/cli/lib/i18n-dict/gen.ts
@@ -21,7 +21,9 @@ export type GenMessageKey =
   | 'cli.gen.codex_auth_hint'
   | 'cli.gen.codex_model_hint'
   | 'cli.gen.openai_api_auth_hint'
+  | 'cli.gen.openai_api_model_hint'
   | 'cli.gen.anthropic_api_auth_hint'
+  | 'cli.gen.anthropic_api_model_hint'
   | 'cli.gen.failed'
   | 'cli.gen.focus_applied';
 
@@ -106,9 +108,17 @@ export const genDict: Record<GenMessageKey, CliMessage> = {
     zh: '\n提示：当前 sample 生成使用 OpenAI API 执行器。请检查 OPENAI_API_KEY / OPENAI_BASE_URL 是否可用，并确认模型名对当前端点可用；如果只是想先跑通，也可以改用：{claudeFlags}，或：{codexFlags}（{codexModelHint}）。',
     en: '\nHint: sample generation is using the OpenAI API executor. Check OPENAI_API_KEY / OPENAI_BASE_URL and confirm the model is available on that endpoint; to just get a first run through, you can also switch to: {claudeFlags}, or: {codexFlags} ({codexModelHint}).',
   },
+  'cli.gen.openai_api_model_hint': {
+    zh: '\n提示：当前 sample 生成使用 OpenAI API 执行器，但模型名看起来对当前端点不可用。请检查 --model、OPENAI_BASE_URL 与账号权限是否匹配；如果只是想先跑通，也可以改用：{claudeFlags}，或：{codexFlags}（{codexModelHint}）。',
+    en: '\nHint: sample generation is using the OpenAI API executor, but the model name appears unavailable on the current endpoint. Check --model, OPENAI_BASE_URL, and account access; to just get a first run through, you can also switch to: {claudeFlags}, or: {codexFlags} ({codexModelHint}).',
+  },
   'cli.gen.anthropic_api_auth_hint': {
     zh: '\n提示：当前 sample 生成使用 Anthropic API 执行器。请检查 ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL 是否可用，并确认模型名对当前端点可用；如果你有 Claude Code 可用，也可以改用：{claudeFlags}。',
     en: '\nHint: sample generation is using the Anthropic API executor. Check ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL and confirm the model is available on that endpoint; if Claude Code is available, you can also switch to: {claudeFlags}.',
+  },
+  'cli.gen.anthropic_api_model_hint': {
+    zh: '\n提示：当前 sample 生成使用 Anthropic API 执行器，但模型名看起来对当前端点不可用。请检查 --model、ANTHROPIC_BASE_URL 与账号权限是否匹配；如果你有 Claude Code 可用，也可以改用：{claudeFlags}。',
+    en: '\nHint: sample generation is using the Anthropic API executor, but the model name appears unavailable on the current endpoint. Check --model, ANTHROPIC_BASE_URL, and account access; if Claude Code is available, you can also switch to: {claudeFlags}.',
   },
   'cli.gen.failed': {
     zh: '生成失败: {message}',

--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -42,8 +42,11 @@ export type RunMessageKey =
   | 'cli.run.contamination_warning'
   | 'cli.run.codex_fallback_hint'
   | 'cli.run.codex_auth_hint'
+  | 'cli.run.codex_model_hint'
   | 'cli.run.openai_api_auth_hint'
+  | 'cli.run.openai_api_model_hint'
   | 'cli.run.anthropic_api_auth_hint'
+  | 'cli.run.anthropic_api_model_hint'
   | 'cli.run.skip_connectivity_warning';
 
 export const runDict: Record<RunMessageKey, CliMessage> = {
@@ -211,13 +214,25 @@ export const runDict: Record<RunMessageKey, CliMessage> = {
     zh: '\n提示：当前失败的是 Codex 系列执行器。先确认 Codex CLI / SDK 已安装并完成登录；如果你有 Claude Code 可用，可以改走 Claude：{claudeFlags}；如果要继续走 OpenAI API，可以改为：{openaiFlags}，并设置 OPENAI_API_KEY。openai-api 会按 API 响应记录 token / cost。',
     en: '\nHint: the failing runtime is Codex-based. First confirm the Codex CLI / SDK is installed and authenticated; if Claude Code is available, switch to Claude: {claudeFlags}; to stay on the OpenAI API path, switch to: {openaiFlags}, and set OPENAI_API_KEY. openai-api records token / cost from API responses.',
   },
+  'cli.run.codex_model_hint': {
+    zh: '\n提示：当前失败的是 Codex 系列执行器，但模型名看起来不可用。可以先按本机 Codex 配置重试：{codexFlags}（{codexModelHint}）；也可以先运行 `{codexExec}` 验证模型是否可用。若只是想先跑通，可以改走 Claude：{claudeFlags}；或继续走 OpenAI API：{openaiFlags}，并设置 OPENAI_API_KEY。',
+    en: '\nHint: the failing runtime is Codex-based, but the model name appears unavailable. Retry with the local Codex config model: {codexFlags} ({codexModelHint}); you can also run `{codexExec}` to verify the model. To just get a first run through, switch to Claude: {claudeFlags}; or stay on the OpenAI API path: {openaiFlags}, and set OPENAI_API_KEY.',
+  },
   'cli.run.openai_api_auth_hint': {
     zh: '\n提示：当前失败的是 OpenAI API 执行器。请检查 OPENAI_API_KEY / OPENAI_BASE_URL 是否可用，并确认模型名对当前端点可用。',
     en: '\nHint: the failing runtime is the OpenAI API executor. Check OPENAI_API_KEY / OPENAI_BASE_URL and confirm the model is available on that endpoint.',
   },
+  'cli.run.openai_api_model_hint': {
+    zh: '\n提示：当前失败的是 OpenAI API 执行器，但模型名看起来对当前端点不可用。请检查 --model / --judge-models、OPENAI_BASE_URL 与账号权限是否匹配。',
+    en: '\nHint: the failing runtime is the OpenAI API executor, but the model name appears unavailable on the current endpoint. Check --model / --judge-models, OPENAI_BASE_URL, and account access.',
+  },
   'cli.run.anthropic_api_auth_hint': {
     zh: '\n提示：当前失败的是 Anthropic API 执行器。请检查 ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL 是否可用，并确认模型名对当前端点可用。',
     en: '\nHint: the failing runtime is the Anthropic API executor. Check ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL and confirm the model is available on that endpoint.',
+  },
+  'cli.run.anthropic_api_model_hint': {
+    zh: '\n提示：当前失败的是 Anthropic API 执行器，但模型名看起来对当前端点不可用。请检查 --model / --judge-models、ANTHROPIC_BASE_URL 与账号权限是否匹配。',
+    en: '\nHint: the failing runtime is the Anthropic API executor, but the model name appears unavailable on the current endpoint. Check --model / --judge-models, ANTHROPIC_BASE_URL, and account access.',
   },
   'cli.run.skip_connectivity_warning': {
     zh: '⚠️  --skip-connectivity 已启用: 跳过 LLM 模型连通性检测。请确保 executor / judge 已通过其他方式验证可达。',

--- a/src/cli/lib/llm-failure-classifier.ts
+++ b/src/cli/lib/llm-failure-classifier.ts
@@ -1,0 +1,11 @@
+const SETUP_FAILURE_RE = /auth|login|credential|API[_ ]?KEY|BASE_URL|API error|ENOENT|not found|ECONN|ENOTFOUND|ETIMEDOUT|timeout|timed out|401|403|404|invalid_request_error/i;
+
+const MODEL_UNAVAILABLE_RE = /model .*not supported|model is not supported|unsupported model|invalid_request_error.*model|model.*invalid_request_error|model_not_found|model .*not found|model .*does not exist|no such model|not have access to (the )?model|model .*not available|model .*is not available/i;
+
+export function looksLikeModelUnavailableFailure(message: string): boolean {
+  return MODEL_UNAVAILABLE_RE.test(message);
+}
+
+export function looksLikeLlmSetupFailure(message: string): boolean {
+  return SETUP_FAILURE_RE.test(message) || looksLikeModelUnavailableFailure(message);
+}

--- a/test/cli/eval-preflight-hint.test.ts
+++ b/test/cli/eval-preflight-hint.test.ts
@@ -165,6 +165,23 @@ describe('eval connectivity failure hint', () => {
     assert.ok(hint.includes('OPENAI_BASE_URL'), hint);
   });
 
+  it('suggests OpenAI API model checks for preflight model failures', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [openai-api:gpt-5]: invalid_request_error: The model `gpt-5` does not exist or you do not have access to it.',
+      {
+        executorName: 'openai-api',
+        model: 'gpt-5',
+        judgeModels: [{ executor: 'openai-api', model: 'gpt-5' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.ok(hint.includes('模型名看起来对当前端点不可用'), hint);
+    assert.ok(hint.includes('--model / --judge-models、OPENAI_BASE_URL 与账号权限'), hint);
+    assert.ok(!hint.includes('OPENAI_API_KEY / OPENAI_BASE_URL'), hint);
+  });
+
   it('suggests Anthropic API key checks for direct executor configuration errors', () => {
     const hint = formatConnectivityFailureHint(
       'ANTHROPIC_API_KEY environment variable is not set',
@@ -179,6 +196,45 @@ describe('eval connectivity failure hint', () => {
 
     assert.ok(hint.includes('ANTHROPIC_API_KEY'), hint);
     assert.ok(hint.includes('ANTHROPIC_BASE_URL'), hint);
+  });
+
+  it('suggests Anthropic API model checks for preflight model failures', () => {
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [anthropic-api:claude-unknown]: unsupported model: claude-unknown is not available for this account',
+      {
+        executorName: 'anthropic-api',
+        model: 'claude-unknown',
+        judgeModels: [{ executor: 'anthropic-api', model: 'claude-unknown' }],
+        noJudge: false,
+      },
+      'zh',
+    );
+
+    assert.ok(hint.includes('模型名看起来对当前端点不可用'), hint);
+    assert.ok(hint.includes('--model / --judge-models、ANTHROPIC_BASE_URL 与账号权限'), hint);
+    assert.ok(!hint.includes('ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL'), hint);
+  });
+
+  it('suggests local Codex model checks for preflight model failures', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-codex-model-eval-hint-'));
+    await writeFile(join(dir, 'config.toml'), 'model = "gpt-5.5"\n');
+
+    const hint = formatConnectivityFailureHint(
+      'preflight failed [codex:gpt-5]: invalid_request_error: The model `gpt-5` is not supported when using Codex with a ChatGPT account.',
+      {
+        executorName: 'codex',
+        model: 'gpt-5',
+        judgeModels: [{ executor: 'codex', model: 'gpt-5' }],
+        noJudge: false,
+      },
+      'zh',
+      { CODEX_HOME: dir },
+    );
+
+    assert.ok(hint.includes('模型名看起来不可用'), hint);
+    assert.ok(hint.includes('--executor codex --model gpt-5.5 --judge-models codex:gpt-5.5'), hint);
+    assert.ok(hint.includes('codex exec -m gpt-5.5 "hi"'), hint);
+    assert.ok(!hint.includes('先确认 Codex CLI / SDK 已安装并完成登录'), hint);
   });
 
   it('does not treat API-key text as connectivity guidance for unrelated runtimes', () => {

--- a/test/cli/sample-next-eval-command.test.ts
+++ b/test/cli/sample-next-eval-command.test.ts
@@ -76,6 +76,35 @@ describe('formatSampleGenerationFailureHint', () => {
     assert.ok(hint.includes('--executor codex --model <codex-model>'), hint);
   });
 
+  it('adds model guidance for OpenAI API sample generation model failures', () => {
+    const hint = formatSampleGenerationFailureHint(
+      'invalid_request_error: The model `gpt-5` does not exist or you do not have access to it.',
+      'openai-api',
+      'zh',
+      { CODEX_HOME: '/tmp/omk-empty-codex-home-for-tests' },
+    );
+
+    assert.ok(hint.includes('模型名看起来对当前端点不可用'), hint);
+    assert.ok(hint.includes('--model、OPENAI_BASE_URL 与账号权限'), hint);
+    assert.ok(!hint.includes('OPENAI_API_KEY / OPENAI_BASE_URL'), hint);
+    assert.ok(hint.includes('--executor claude --model sonnet'), hint);
+    assert.ok(hint.includes('--executor codex --model <codex-model>'), hint);
+  });
+
+  it('adds model guidance for Anthropic API sample generation model failures', () => {
+    const hint = formatSampleGenerationFailureHint(
+      'unsupported model: claude-unknown is not available for this account',
+      'anthropic-api',
+      'zh',
+      { CODEX_HOME: '/tmp/omk-empty-codex-home-for-tests' },
+    );
+
+    assert.ok(hint.includes('模型名看起来对当前端点不可用'), hint);
+    assert.ok(hint.includes('--model、ANTHROPIC_BASE_URL 与账号权限'), hint);
+    assert.ok(!hint.includes('ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL'), hint);
+    assert.ok(hint.includes('--executor claude --model sonnet'), hint);
+  });
+
   it('does not misclassify model-output JSON errors as auth failures', () => {
     const hint = formatSampleGenerationFailureHint(
       'generation failed after 3 attempts (JSON invalid): JSON 解析失败',


### PR DESCRIPTION
## 用户影响

当 `sample` 生成或 `eval` 预检遇到模型名不可用时，CLI 会明确提示检查模型名、base URL / 端点和账号权限，不再泛化成鉴权失败。Codex 路径也会在 `eval` 预检里复用本机 Codex 配置模型，给出可直接重试和验证的命令。

## 迁移说明

无需迁移。该 PR 只调整失败提示和错误分类，不改变 CLI 参数、report schema、评分类 prompt 或评分管线。

## 测量学说明

不影响 doctor / eval / observe 的统计口径，也不改变评分结果，仅改善首跑失败时的下一步指引。

## 关联

延续 #341 对 Codex 模型提示的收敛，把同类模型不可用提示补齐到 OpenAI API / Anthropic API 路径。

## 验证

已运行 `yarn build`、`yarn lint`、`yarn test test/cli/sample-next-eval-command.test.ts test/cli/eval-preflight-hint.test.ts test/cli/codex-model-hint.test.ts`、`yarn test`。