### PR TITLE
docs(quickstart): 收敛首跑最短路径

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,21 @@
 ```bash
 npm i -g oh-my-knowledge
 omk init demo && cd demo
+omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-Runs out of the box — no edits needed first. `omk init` scaffolds two skill variants and three sample cases; `omk eval` runs the controlled A/B and opens an HTML report with a one-line verdict in about five minutes. Once it runs, swap in your own skills and cases.
+Runs out of the box — no edits needed first. `omk init` scaffolds two skill variants and three sample cases; `--dry-run` previews calls and cost; `omk eval` runs the controlled A/B and opens an HTML report with a one-line verdict in about five minutes. Once it runs, swap in your own skills and cases.
 
 Prerequisite: the default executor and judge use the `claude` CLI — install and log in first (see [Requirements](#requirements)); to use another model or run offline (no API key) see [executors](docs/reference/executors.md).
+
+Codex or OpenAI-compatible API users can keep the same flow and add runtime flags, for example `--executor codex --model <codex-model> --judge-models codex:<codex-model>` or `--executor openai-api --model <model> --judge-models openai-api:<model>`.
 
 > The first run has only 3 cases, so the verdict will usually be `UNDERPOWERED` (insufficient data) — that's a normal starting point, not an error; grow to ~20+ cases before trusting a ship/no-ship call.
 
 > The CLI notifies you when a newer version is available (at most once per 20h); set `OMK_SKIP_UPDATE_CHECK=1` to silence it permanently.
 
-Walkthrough: [5-minute quickstart guide](docs/quickstart-skill-eval.md) (recommended for first-time users). More runnable examples (Skill Map, A/B, offline executor, agent runtime, RAG) live in the repo's [example gallery](https://github.com/lizhiyao/oh-my-knowledge/tree/main/examples).
+Walkthrough: [5-minute quickstart guide](docs/quickstart-skill-eval.md) (recommended for first-time users; includes demo → own skill → verdict actions). More runnable examples (Skill Map, A/B, offline executor, agent runtime, RAG) live in the repo's [example gallery](https://github.com/lizhiyao/oh-my-knowledge/tree/main/examples).
 
 Deeper: [who omk is for](docs/explanation/who-omk-is-for.md) · [CLI reference](docs/reference/cli.md) · [how it works](docs/explanation/architecture.md) · [eval sample format](docs/reference/eval-sample-format.md) · [executors](docs/reference/executors.md) · [artifact layout](docs/reference/artifact-layout.md)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,18 +20,21 @@
 ```bash
 npm i -g oh-my-knowledge
 omk init demo && cd demo
+omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-开箱即跑：`omk init` 脚手架好两版 skill 和三条评测用例，不用先改任何文件，`omk eval` 跑控制变量 A/B，约 5 分钟出 HTML 报告 + 一行 verdict；跑通后再把 skill 和用例换成你自己的。
+开箱即跑：`omk init` 脚手架好两版 skill 和三条评测用例，不用先改任何文件；`--dry-run` 预览调用次数和成本；`omk eval` 跑控制变量 A/B，约 5 分钟出 HTML 报告 + 一行 verdict。跑通后再把 skill 和用例换成你自己的。
 
 前置：默认执行器与评委用 `claude` CLI，需先安装并登录（见[系统要求](#系统要求)）；想用别的模型或离线跑（无需 API key）见[执行器](docs/zh/reference/executors.md)。
+
+Codex 或 OpenAI 兼容 API 用户可以继续用同一条流程，只是加 runtime 参数，例如 `--executor codex --model <codex-model> --judge-models codex:<codex-model>`，或 `--executor openai-api --model <model> --judge-models openai-api:<model>`。
 
 > 首跑只有 3 条用例，verdict 多半是「数据不足（UNDERPOWERED）」——这是正常起点而非出错；把用例加到约 20 条以上，再看「可发布」结论。
 
 > 命令行有新版本时会自动提示（每 20 小时最多一次）；想永久关闭该提醒，设环境变量 `OMK_SKIP_UPDATE_CHECK=1` 即可。
 
-手把手教程：[5 分钟快速上手](docs/zh/quickstart-skill-eval.md)（推荐第一次跑评测的用户）。更多可跑示例（Skill Map、A/B、离线执行器、agent runtime、RAG）见仓库的[示例画廊](https://github.com/lizhiyao/oh-my-knowledge/tree/main/examples)。
+手把手教程：[5 分钟快速上手](docs/zh/quickstart-skill-eval.md)（推荐第一次跑评测的用户，覆盖 demo → 自己的 skill → verdict 动作）。更多可跑示例（Skill Map、A/B、离线执行器、agent runtime、RAG）见仓库的[示例画廊](https://github.com/lizhiyao/oh-my-knowledge/tree/main/examples)。
 
 深入：[为谁、解决什么](docs/zh/explanation/who-omk-is-for.md) · [CLI 参考](docs/zh/reference/cli.md) · [工作原理](docs/zh/explanation/architecture.md) · [评测用例格式](docs/zh/reference/eval-sample-format.md) · [执行器](docs/zh/reference/executors.md) · [artifact 布局](docs/zh/reference/artifact-layout.md)
 

--- a/docs/quickstart-skill-eval.md
+++ b/docs/quickstart-skill-eval.md
@@ -35,7 +35,7 @@ omk eval --control code-review-v1 --treatment code-review-v2
 If the default Claude runtime is unavailable, use the same demo with runtime flags:
 
 ```bash
-# Codex CLI / SDK path
+# Codex CLI path
 omk eval --control code-review-v1 --treatment code-review-v2 \
   --executor codex --model <codex-model> \
   --judge-models codex:<codex-model>

--- a/docs/quickstart-skill-eval.md
+++ b/docs/quickstart-skill-eval.md
@@ -1,6 +1,6 @@
-# omk quickstart: benchmark a skill
+# omk quickstart: get to your first verdict
 
-Get your first report in 5 minutes. Target audience: you have one (or several) skill files and want data to answer "is this skill any good?" or "which of v1 vs v2 is the safer bet?"
+Get your first report in 5 minutes, then replace the demo with your own skill. Target audience: you have one (or several) skill files and want data to answer "is this skill any good?", "did v2 improve?", and "can we ship this with evidence?"
 
 ## Setup (1 minute)
 
@@ -9,6 +9,8 @@ npm i oh-my-knowledge -g
 omk --version    # prints a version number once installed
 ```
 
+The default runtime uses the `claude` CLI for both the executor and the judge, so install and log in to Claude Code first. If you are working from Codex or an OpenAI-compatible API instead, keep reading — the first-run commands below show where to swap the runtime flags.
+
 If you want the **agent-driven workflow** (recommended), also install the omk Agent Skill into your coding agent:
 
 ```bash
@@ -16,6 +18,37 @@ omk install omk-agent-skill
 ```
 
 By default, this installs only into detected local targets omk explicitly supports: Codex/AGENTS when `~/.codex` or `~/.agents` exists, and Claude Code when `~/.claude` exists. Use `--to all` to force every target omk currently knows, or `--dest` for a custom skill root. Once installed, the agent auto-loads the SKILL context when you mention "omk", "benchmark", "evaluate", "skill eval", etc.
+
+## Fastest first run: use the demo scaffold
+
+If you are new to omk, start here before using your own files:
+
+```bash
+omk init demo
+cd demo
+omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
+omk eval --control code-review-v1 --treatment code-review-v2
+```
+
+`omk init` creates two skill variants and three sample cases. `--dry-run` previews the task plan and estimated calls; the real run then opens the HTML report. With only three demo samples, the verdict is often `UNDERPOWERED` — that is a normal teaching result, not a failed run.
+
+If the default Claude runtime is unavailable, use the same demo with runtime flags:
+
+```bash
+# Codex CLI / SDK path
+omk eval --control code-review-v1 --treatment code-review-v2 \
+  --executor codex --model <codex-model> \
+  --judge-models codex:<codex-model>
+
+# OpenAI-compatible API path
+export OPENAI_API_KEY="..."
+export OPENAI_BASE_URL="https://api.example.com/v1"
+omk eval --control code-review-v1 --treatment code-review-v2 \
+  --executor openai-api --model <model> \
+  --judge-models openai-api:<model>
+```
+
+For Codex, `<codex-model>` should be a model your local Codex can run; check `~/.codex/config.toml` or `$CODEX_HOME/config.toml` for the configured `model`. For OpenAI-compatible APIs, make sure the model name matches the selected `OPENAI_BASE_URL`.
 
 ## Prepare your skill (1 minute)
 
@@ -41,15 +74,15 @@ skills/
 
 Both layouts are recognized; mixing them is fine. For a v1 vs v2 A/B, drop in two versions. To answer "does this skill help at all" with a baseline control, one version is enough.
 
-## Run the eval (3 minutes)
+## Replace the demo with your own skill
 
 ### Path A: natural language (recommended)
 
-Open Claude Code, `cd` into your project, and say:
+Open your coding agent, `cd` into your project, and say:
 
 > Use omk to compare skills/my-skill-v1 against skills/my-skill-v2
 
-The omk skill takes care of the rest: it auto-generates samples if `eval-samples.json` is missing, runs the eval, and opens the report in your browser. Other useful phrasings:
+The omk skill takes care of the rest: it auto-generates samples if `eval-samples.json` is missing, runs the eval, and opens the report in your browser. In Claude Code you can use the installed omk skill directly; in Codex, ask the agent to run the `omk` CLI. Other useful phrasings:
 
 - "Use omk to compare skills/my-skill-v1 against skills/my-skill-v2"
 - "Use omk to run a baseline control for skills/audit (with-skill vs without-skill)"
@@ -58,6 +91,16 @@ The omk skill takes care of the rest: it auto-generates samples if `eval-samples
 
 ### Path B: command line
 
+If you only have one skill, the shortest useful comparison is "with this skill" vs `baseline`:
+
+```bash
+omk sample skills/my-skill.md                         # first time: AI-generate eval samples
+omk eval --control baseline --treatment my-skill --dry-run
+omk eval --control baseline --treatment my-skill
+```
+
+If you already have two versions, compare v1 vs v2:
+
 ```bash
 omk sample skills/my-skill-v2.md                                  # first time: AI-generate eval samples
 omk eval --control my-skill-v1 --treatment my-skill-v2 --dry-run  # preview the task plan
@@ -65,9 +108,18 @@ omk eval --control my-skill-v1 --treatment my-skill-v2            # run for real
 omk studio                                                        # open the report browser
 ```
 
-Variant names come from the skill file or directory names under `skills/`; for the layout above, use `my-skill-v1` and `my-skill-v2`.
+Variant names come from the skill file or directory names under `skills/`; for `skills/my-skill.md`, use `my-skill`; for the v1/v2 layout above, use `my-skill-v1` and `my-skill-v2`.
 
 `--dry-run` prints expected call count and cost estimates — confirm, drop the flag, and run. `omk eval` runs a doctor health check as a preflight gate by default; if a skill has structural problems it gets blocked early. Pass `--skip-doctor` to bypass when you know what you're doing.
+
+### When the model or executor fails
+
+The CLI now tries to make first-run failures actionable:
+
+- Claude failure: log in to Claude Code, or switch to Codex / OpenAI API with the flags above.
+- Codex model failure: use the model configured in `~/.codex/config.toml` or `$CODEX_HOME/config.toml`, then verify with `codex exec -m <codex-model> "hi"`.
+- OpenAI / Anthropic API model failure: check `--model`, `--judge-models`, the base URL, and whether the account has access to that model.
+- If you only want to validate assertions and report plumbing first, add `--no-judge`; this skips the LLM judge and relies on assertion scores only.
 
 ## Read the report (1 minute)
 

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -1,6 +1,6 @@
-# omk 快速上手：给 skill 跑评测
+# omk 快速上手：跑出第一份 verdict
 
-5 分钟跑出第一份报告。目标读者：手里有一版（或几版）skill，想用数据看看「这版 skill 到底好不好」「v1 跟 v2 哪版更稳」。
+5 分钟跑出第一份报告，然后把 demo 换成你自己的 skill。目标读者：手里有一版（或几版）skill，想用数据看看「这版 skill 到底好不好」「v2 有没有变好」「能不能带证据发布」。
 
 ## 前置（1 分钟）
 
@@ -9,6 +9,8 @@ npm i oh-my-knowledge -g
 omk --version    # 能输出版本号即装好
 ```
 
+默认 runtime 使用 `claude` CLI 作为执行器和评委，所以需要先安装并登录 Claude Code。如果你在 Codex 或 OpenAI 兼容 API 环境里，也可以继续往下看，首跑命令里会标出 runtime 参数怎么替换。
+
 如果你想用「自然语言让 agent 帮你跑」的方式（推荐），还需要把 omk Agent Skill 装到你的 agent 工具里：
 
 ```bash
@@ -16,6 +18,37 @@ omk install omk-agent-skill
 ```
 
 默认只会安装到本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。装好之后，agent 收到含「omk」「评测」「benchmark」之类的关键词就会自动加载 SKILL 上下文。
+
+## 最快首跑：先用 demo 脚手架
+
+如果你第一次用 omk，先不要急着接自己的文件，从这里开始：
+
+```bash
+omk init demo
+cd demo
+omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
+omk eval --control code-review-v1 --treatment code-review-v2
+```
+
+`omk init` 会创建两版 skill 和三条评测用例。`--dry-run` 先预览任务计划和预估调用次数；真跑后会打开 HTML 报告。demo 只有三条用例，verdict 经常是 `UNDERPOWERED`，这是正常教学结果，不是运行失败。
+
+如果默认 Claude runtime 不可用，同一套 demo 可以加 runtime 参数：
+
+```bash
+# Codex CLI / SDK 路径
+omk eval --control code-review-v1 --treatment code-review-v2 \
+  --executor codex --model <codex-model> \
+  --judge-models codex:<codex-model>
+
+# OpenAI 兼容 API 路径
+export OPENAI_API_KEY="..."
+export OPENAI_BASE_URL="https://api.example.com/v1"
+omk eval --control code-review-v1 --treatment code-review-v2 \
+  --executor openai-api --model <model> \
+  --judge-models openai-api:<model>
+```
+
+Codex 的 `<codex-model>` 要换成本机 Codex 可用模型；可查看 `~/.codex/config.toml` 或 `$CODEX_HOME/config.toml` 里的 `model`。OpenAI 兼容 API 则要确认模型名和 `OPENAI_BASE_URL` 指向的端点匹配。
 
 ## 准备 skill（1 分钟）
 
@@ -41,15 +74,15 @@ skills/
 
 两种形式 omk 都能识别，混用也行。要跑 v1 vs v2 对比就按上面放两版；只想看「有 skill vs 没 skill」的差距，放一份就够，用 baseline 对照。
 
-## 跑评测（3 分钟）
+## 把 demo 换成你自己的 skill
 
 ### 路径 A：自然语言（推荐）
 
-打开 Claude Code，进入项目目录，直接说一句话：
+打开你的 coding agent，进入项目目录，直接说一句话：
 
 > 用 omk 对比 skills/my-skill-v1 跟 skills/my-skill-v2
 
-omk skill 会自动判断：没有 `eval-samples.json` 就先帮你生成用例，然后跑评测，最后把报告浏览器弹出来。常见说法：
+omk skill 会自动判断：没有 `eval-samples.json` 就先帮你生成用例，然后跑评测，最后把报告浏览器弹出来。Claude Code 可以直接使用已安装的 omk skill；在 Codex 里则让 agent 执行 `omk` CLI。常见说法：
 
 - 「用 omk 对比 skills/my-skill-v1 跟 skills/my-skill-v2」
 - 「用 omk 给 skills/audit 跑 baseline 对照（有 skill vs 没 skill）」
@@ -58,6 +91,16 @@ omk skill 会自动判断：没有 `eval-samples.json` 就先帮你生成用例�
 
 ### 路径 B：直接命令行
 
+如果你只有一版 skill，最短有用对比是「有这个 skill」vs `baseline`：
+
+```bash
+omk sample skills/my-skill.md                         # 第一次：让 AI 给你的 skill 生成评测用例
+omk eval --control baseline --treatment my-skill --dry-run
+omk eval --control baseline --treatment my-skill
+```
+
+如果你已经有 v1 / v2 两版，再做版本对比：
+
 ```bash
 omk sample skills/my-skill-v2.md                                  # 第一次:让 AI 给你的 skill 生成评测用例
 omk eval --control my-skill-v1 --treatment my-skill-v2 --dry-run  # 预览要跑什么
@@ -65,9 +108,18 @@ omk eval --control my-skill-v1 --treatment my-skill-v2            # 真跑
 omk studio                                                        # 启动报告浏览器
 ```
 
-variant 名来自 `skills/` 下的 skill 文件名或目录名；按上面的布局，就是 `my-skill-v1` 和 `my-skill-v2`。
+variant 名来自 `skills/` 下的 skill 文件名或目录名；`skills/my-skill.md` 对应 `my-skill`，上面的 v1 / v2 布局对应 `my-skill-v1` 和 `my-skill-v2`。
 
 `--dry-run` 预览时会告诉你预估调用次数和成本，确认 OK 再去掉 flag 真跑。`omk eval` 默认会先跑一次 doctor 健康度检查当门禁，发现 skill 写法有大问题就直接拦下来；如果你确认知道自己在干嘛，加 `--skip-doctor` 绕过。
+
+### 模型或执行器失败时
+
+CLI 会尽量把首跑失败变成可执行的下一步：
+
+- Claude 失败：先登录 Claude Code，或按上面的参数切到 Codex / OpenAI API。
+- Codex 模型失败：换成 `~/.codex/config.toml` 或 `$CODEX_HOME/config.toml` 里配置的模型，再用 `codex exec -m <codex-model> "hi"` 验证。
+- OpenAI / Anthropic API 模型失败：检查 `--model`、`--judge-models`、base URL，以及账号是否有该模型权限。
+- 如果只是想先验证断言和报告链路，加 `--no-judge`；它会跳过 LLM 评委，只使用断言分数。
 
 ## 看结果（1 分钟）
 

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -35,7 +35,7 @@ omk eval --control code-review-v1 --treatment code-review-v2
 如果默认 Claude runtime 不可用，同一套 demo 可以加 runtime 参数：
 
 ```bash
-# Codex CLI / SDK 路径
+# Codex CLI 路径
 omk eval --control code-review-v1 --treatment code-review-v2 \
   --executor codex --model <codex-model> \
   --judge-models codex:<codex-model>


### PR DESCRIPTION
## 用户影响

把 README 与快速上手文档里的首跑路径收敛成一条更可复制的链路：先用 `omk init demo` 跑通 demo，再替换成自己的 skill，并明确 `sample → eval --dry-run → eval → verdict action` 的顺序。

同时补充 Codex 与 OpenAI 兼容 API 的 runtime 参数示例，用户遇到 Claude 不可用、Codex 模型不可用或 API 模型不匹配时，可以直接知道下一步怎么换 executor / model。

## 迁移说明

无需迁移。该 PR 只调整 README 与 quickstart 文档，不改变 CLI 参数、report schema、评分类 prompt、评分管线或默认 runtime 行为。

## 测量学说明

不影响任何报告可比性；只是把首跑 demo、真实 skill 路径、dry-run、模型失败处理和 `PROGRESS` 后的发布证据动作串到同一条文档路径里。

## 验证

已通过：
- `yarn lint`
- `yarn build`
- `yarn build:docs:check`
- `yarn docs:build`
- `yarn test test/executors/runtime-fingerprint.test.ts`
- `yarn test test/cli.test.ts test/cli/doctor-eval-embed.test.ts test/cli/oclif-evolve.test.ts test/cli/oclif-init.test.ts test/cli/oclif-install.test.ts test/cli/oclif-observe.test.ts test/cli/oclif-sample.test.ts test/cli/promote-run.test.ts test/cli/strict-unknown-options.test.ts test/inputs/source-resolver.test.ts`
- `yarn test test/inputs/source-resolver.test.ts test/cli/doctor-eval-embed.test.ts`

本地默认完整 `yarn test` 运行两次都出现与本 PR 无关的 full-suite 超时抖动，失败文件在拆分重跑时通过；串行完整测试中止前跑到 198/200 文件通过，剩余两个文件单独重跑也通过。