### PR TITLE
fix(observe)!: BREAKING-CLI 修复 Trace IR 回读闭环与默认输出

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -471,6 +471,7 @@ omk observe ingest <traceDir> [flags]
 **Flags:**
 
 - `--global` `boolean`:写入全局 ~/.oh-my-knowledge/observe-inbox，而非项目 .omk/observe-inbox。
+- `--json` `boolean`:把完整 observation inbox 报告输出到 stdout；默认只输出摘要。
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--output-dir` `option`:输出目录，默认 .omk/observe-inbox（项目级，相对于 cwd；--global 写全局）。
 

--- a/src/cli/commands/observe/ingest.ts
+++ b/src/cli/commands/observe/ingest.ts
@@ -4,6 +4,23 @@ import { BaseCommand } from '../../oclif/base-command.js';
 import { LANG_FLAG, bilingual } from '../../oclif/i18n.js';
 import { CliExit } from '../../lib/cli-exit.js';
 import { shellQuoteArg } from '../../../shared/shell-quote.js';
+import type { ObservationInboxReport } from '../../../types/observability.js';
+
+export function formatIngestSummary(report: ObservationInboxReport, lang: 'zh' | 'en'): string {
+  const severityCounts = {
+    high: 0,
+    medium: 0,
+    low: 0,
+    noise: 0,
+  };
+  for (const item of report.items) severityCounts[item.severity]++;
+
+  const sessions = report.meta.sessionCount ?? 0;
+  if (lang === 'zh') {
+    return `observe inbox：会话 ${sessions} · 片段 ${report.meta.segmentCount} · 信号 ${report.meta.itemCount}（高 ${severityCounts.high} / 中 ${severityCounts.medium} / 低 ${severityCounts.low} / 噪声 ${severityCounts.noise}）`;
+  }
+  return `observe inbox: ${sessions} sessions · ${report.meta.segmentCount} segments · ${report.meta.itemCount} signals (high ${severityCounts.high} / medium ${severityCounts.medium} / low ${severityCounts.low} / noise ${severityCounts.noise})`;
+}
 
 export default class ObserveIngest extends BaseCommand {
   static description = bilingual({
@@ -33,6 +50,13 @@ export default class ObserveIngest extends BaseCommand {
       description: bilingual({
         zh: '写入全局 ~/.oh-my-knowledge/observe-inbox，而非项目 .omk/observe-inbox。',
         en: 'Write to global ~/.oh-my-knowledge/observe-inbox instead of project .omk/observe-inbox.',
+      }),
+      default: false,
+    }),
+    json: Flags.boolean({
+      description: bilingual({
+        zh: '把完整 observation inbox 报告输出到 stdout；默认只输出摘要。',
+        en: 'Print the full observation inbox report to stdout; defaults to a concise summary.',
       }),
       default: false,
     }),
@@ -81,7 +105,9 @@ export default class ObserveIngest extends BaseCommand {
       const report = buildObservationInboxReport(tracePath, { reviewState: loadObservationReviewState(outDir) });
       report.diagnostics = buildObserveDiagnosticsFromReport(report);
       const path = saveObservationInboxReport(report, outDir);
-      console.log(JSON.stringify(compactObservationInboxReport(report), null, 2));
+      console.log(flags.json
+        ? JSON.stringify(compactObservationInboxReport(report), null, 2)
+        : formatIngestSummary(report, lang));
       const { traceIngestionNotices } = await import('../../../observability/trace-ingestion.js');
       for (const notice of traceIngestionNotices(report.meta.ingestion, lang)) {
         process.stderr.write(`${notice.text}\n`);

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -474,12 +474,13 @@ export function normalizeObservationExperienceReport(value: unknown): Observatio
     sessions,
     skills: report.skills as ObservationExperienceReport['skills'],
   };
+  const hydrated = hydrateExperienceTimelines(normalized);
   try {
-    if (!validateExperienceReferences(normalized, !isLegacyReport)) return null;
+    if (!validateExperienceReferences(hydrated, !isLegacyReport)) return null;
   } catch {
     return null;
   }
-  return hydrateExperienceTimelines(normalized);
+  return hydrated;
 }
 
 function normalizeExperienceInvocationShells(
@@ -4037,21 +4038,29 @@ function sessionStoryEpisodes(
   const ranges = sessionStoryEpisodeRanges(session, timeline);
   return ranges.map((range, index) => {
     const episodeId = hashParts('session-story-episode', session.id, String(index));
-    const episodeSkillSegments = skillSegments.filter((segment) =>
+    const rangedSkillSegments = skillSegments.filter((segment) =>
       (segment.messageRanges ?? []).some((messageRange) =>
         messageRangeOverlapsEpisodeRange(messageRange, range)
       )
     );
-    const segmentIds = new Set(episodeSkillSegments.map((segment) => segment.id));
+    const rangedSegmentIds = new Set(rangedSkillSegments.map((segment) => segment.id));
     const episodeEdges = orchestrationEdges
       .filter((edge) => {
         if (edge.edgeKind === 'internal_skill' && edge.parentSkillSegmentId && edge.executorSkillSegmentId) {
-          return segmentIds.has(edge.parentSkillSegmentId) && segmentIds.has(edge.executorSkillSegmentId);
+          return rangedSegmentIds.has(edge.parentSkillSegmentId) && rangedSegmentIds.has(edge.executorSkillSegmentId);
         }
-        return (edge.parentSkillSegmentId && segmentIds.has(edge.parentSkillSegmentId))
+        return (edge.parentSkillSegmentId && rangedSegmentIds.has(edge.parentSkillSegmentId))
           || edge.evidenceRefs.some((ref) => episodeRangeContainsRef(range, ref));
       })
       .map((edge) => ({ ...edge, episodeId }));
+    const linkedSegmentIds = new Set(episodeEdges.flatMap((edge) => [
+      edge.parentSkillSegmentId,
+      edge.executorSkillSegmentId,
+    ].filter((id): id is string => Boolean(id))));
+    const episodeSkillSegments = skillSegments.filter((segment) =>
+      rangedSegmentIds.has(segment.id) || linkedSegmentIds.has(segment.id)
+    );
+    const segmentIds = new Set(episodeSkillSegments.map((segment) => segment.id));
     const episodeFeedbackSignals = feedbackSignals
       .filter((signal) => episodeRangeContainsRef(range, signal.evidenceRef))
       .map((signal) => {

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -758,13 +758,17 @@ function compareInboxItems(a: ObservationInboxItem, b: ObservationInboxItem): nu
 }
 
 export function saveObservationInboxReport(report: ObservationInboxReport, outDir: string = DEFAULT_OBSERVATIONS_DIR): string {
+  const compact = compactObservationInboxReport(report);
+  if (!normalizeObservationInboxReport(compact)) {
+    throw new Error('拒绝写入无法回读的 observe inbox 报告。');
+  }
   mkdirSync(outDir, { recursive: true });
   migrateLegacyReportFiles(outDir, 'observe-inbox');
   // 保留毫秒并追加随机段；即使同一毫秒生成两份 report，也不能静默互相覆盖。
   // 例: '2026-05-07T12:00:00.999Z' → '2026-05-07T12-00-00-999'
   const stamp = report.meta.generatedAt.replace(/[:.]/g, '-').replace(/Z$/, '');
   const path = reportFilePath(outDir, `${stamp}-${randomRunToken()}`);
-  writeJsonFileAtomic(path, compactObservationInboxReport(report));
+  writeJsonFileAtomic(path, compact);
   return path;
 }
 

--- a/test/cli/oclif-observe.test.ts
+++ b/test/cli/oclif-observe.test.ts
@@ -6,7 +6,7 @@ import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { mkdtempSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -22,6 +22,43 @@ interface ExecError extends Error {
   stderr: string;
 }
 
+function makeIngestTrace(dir: string): string {
+  mkdirSync(dir, { recursive: true });
+  const records = [
+    {
+      type: 'user',
+      uuid: 'u1',
+      parentUuid: null,
+      sessionId: 's1',
+      timestamp: '2026-07-27T00:00:00.000Z',
+      cwd: '/repo-a',
+      message: { role: 'user', content: '<command-name>/audit</command-name>\nFind revenue schema' },
+    },
+    {
+      type: 'assistant',
+      uuid: 'a1',
+      parentUuid: 'u1',
+      sessionId: 's1',
+      timestamp: '2026-07-27T00:00:01.000Z',
+      cwd: '/repo-a',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 't1', name: 'Grep', input: { pattern: 'revenue_schema', path: '/repo-a' } }],
+      },
+    },
+    {
+      type: 'user',
+      uuid: 'u2',
+      parentUuid: 'a1',
+      sessionId: 's1',
+      timestamp: '2026-07-27T00:00:02.000Z',
+      cwd: '/repo-a',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'No matches found', is_error: false }] },
+    },
+  ];
+  writeFileSync(join(dir, 'session.jsonl'), records.map((record) => JSON.stringify(record)).join('\n'));
+  return dir;
+}
 
 describe('oclif observe', () => {
   it('observe --help (默认 = health 分析)', async () => {
@@ -45,6 +82,35 @@ describe('oclif observe', () => {
     const { stdout } = await execFileAsync('node', [CLI, 'observe', 'ingest', '--help']);
     assert.ok(stdout.includes('ingest 成 observation inbox'), `ingest --help missing zh:\n${stdout}`);
     assert.ok(stdout.includes('TRACEDIR'), 'should list TRACEDIR positional');
+    assert.ok(stdout.includes('--json'), 'should list explicit full JSON output flag');
+  });
+
+  it('observe ingest 默认只输出摘要，--json 才输出完整报告', async () => {
+    const tmpBase = mkdtempSync(join(tmpdir(), 'omk-ingest-output-'));
+    const traceDir = makeIngestTrace(join(tmpBase, 'trace'));
+    try {
+      const summaryDir = join(tmpBase, 'summary');
+      const summary = await execFileAsync(
+        'node',
+        [CLI, 'observe', 'ingest', traceDir, '--output-dir', summaryDir],
+        { cwd: tmpBase },
+      );
+      assert.match(summary.stdout, /^observe inbox：会话 \d+ · 片段 \d+ · 信号 \d+/);
+      assert.ok(summary.stdout.length < 300, `default stdout must stay concise, got ${summary.stdout.length} chars`);
+
+      const jsonDir = join(tmpBase, 'json');
+      const full = await execFileAsync(
+        'node',
+        [CLI, 'observe', 'ingest', traceDir, '--output-dir', jsonDir, '--json'],
+        { cwd: tmpBase },
+      );
+      const parsed = JSON.parse(full.stdout);
+      assert.equal(parsed.kind, 'observe-inbox');
+      assert.ok(Array.isArray(parsed.items));
+      assert.ok(parsed.items.length > 0);
+    } finally {
+      rmSync(tmpBase, { recursive: true, force: true });
+    }
   });
 
   it('observe inbox --help', async () => {

--- a/test/observability/inbox/aggregation.test.ts
+++ b/test/observability/inbox/aggregation.test.ts
@@ -335,6 +335,28 @@ describe('observe inbox - aggregation', () => {
     assert.equal(loadObservationInboxReports(dir).length, 2);
   });
 
+  it('refuses to persist a report that cannot be read back', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-invalid-write-'));
+    const report = {
+      kind: 'observe-inbox' as const,
+      schemaVersion: 2 as const,
+      meta: {
+        tracePath: '/tmp/invalid.jsonl',
+        generatedAt: '2026-05-01T00:00:00.000Z',
+        sessionCount: 1,
+        segmentCount: 1,
+        itemCount: 2,
+      },
+      items: [baseItem({ id: 'invalid-write' })],
+    };
+
+    assert.throws(
+      () => saveObservationInboxReport(report, dir),
+      /拒绝写入无法回读的 observe inbox 报告/,
+    );
+    assert.deepEqual(loadObservationInboxReports(dir), []);
+  });
+
   it('rejects inbox reports whose references or aggregates contradict experience', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-consistency-'));
     const trace = join(dir, 'session.jsonl');

--- a/test/observability/inbox/experience-report.test.ts
+++ b/test/observability/inbox/experience-report.test.ts
@@ -1077,6 +1077,14 @@ expected_tools:
     assert.ok(story.graph.edges.some((edge) => edge.label === '路由'));
     assert.equal(applySession.reviewerReport?.sessionStory.schemaVersion, story.schemaVersion);
     assert.equal(applySession.reviewerReport?.chainSteps.find((step) => step.label === '结果 / 产物')?.status, 'unknown');
+    assert.equal(applySession.indicators.routerDownstreamCompleted, 1);
+    assert.ok(report.experience);
+    const compact = compactObservationExperienceReport(report.experience);
+    assert.equal(compact.storyContexts[0].episodes.length > 0, true);
+    assert.equal('episodes' in compact.sessions[0].sessionStory!, false);
+    const hydrated = normalizeObservationExperienceReport(compact);
+    assert.ok(hydrated);
+    assert.equal(hydrated.sessions[0].indicators.routerDownstreamCompleted, 1);
   });
 
   it('attributes observations to the originating trace when main and subagent invoke the same skill', () => {


### PR DESCRIPTION
## Purpose

修复真实 Codex router / subagent 轨迹在紧凑 Trace IR 落盘后无法回读的问题，并避免大规模 ingest 默认把完整 JSON 灌入终端或 agent 上下文。

## Changes

- `omk observe ingest` 默认输出单行摘要，完整 JSON 改为显式 `--json`。
- 紧凑 Trace IR 在严格校验前恢复 canonical timeline / story context。
- 跨物理 trace 的外部子任务边会把实际连接的上下游 skill segment 一并纳入 episode，避免悬空引用。
- inbox 写入前新增回读门禁，无法被当前 loader 接受的报告不再落盘并伪装成功。

## User impact

真实 Codex 轨迹现在可以完成 `ingest → 持久化 → inbox 回读`，router 派生指标和 episode 证据保持完整。大规模 ingest 的默认 stdout 保持简洁。

## Migration

依赖 `omk observe ingest` stdout JSON 的脚本需要追加 `--json`。历史上已经写入但被 inbox 忽略的无效报告不会静默修补，建议重新执行一次 `omk observe ingest <traceDir>` 生成可校验的新报告。

## Measurement caveat

本次不修改评分类 prompt、评分管道、统计公式或报告比较语义；修复集中在 observe 的 source-neutral Trace IR 引用完整性与 CLI 输出契约。没有为缩小文件而截断 evidence，避免改变复盘依据。

## Testing

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn build`
- [x] `yarn test`（226 个测试文件，2897 个测试）
- [x] npm tarball 隔离安装与真实 Codex router trace 端到端验收

## Checklist

- [x] 已阅读 `AGENTS.md` 与 `CONTRIBUTING.md`
- [x] 分支从 `main` 创建，目标分支为 `main`
- [x] commit message 符合仓库约定
- [x] 已标注用户影响与 BREAKING-CLI 迁移说明
- [x] 无 secrets、内部 URL 或个人数据进入 diff
- [x] CLI reference 已由 oclif source 同步生成