### PR TITLE
chore(release): 发布 0.49.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## Purpose

发布 `v0.49.0`，交付 Codex 一等支持、source-neutral Trace IR，以及真实 Codex router / subagent 轨迹的可持久化回读闭环。

关联变更：#349、#352。

## User impact

- Codex 用户可以不依赖 Claude 账号完成 doctor、eval、sample、evolve 与 observe 链路。
- 不同 agent 来源先归一到同一 Trace IR，再生成可审计的观测与评测资产。
- `omk observe ingest` 默认只输出简洁摘要，避免大规模摄取把完整 JSON 注入终端或 agent 上下文。

## Migration

- Report schema 升级到 v5。旧报告仍可读取，但不能直接 resume 到新运行；需要继续实验时重新执行 eval。
- Node API 调用者需为评测、生成、修复、evolve 与 LLM 增强分析显式提供 runtime。
- 升级前后的 observe 指标属于口径迁移，不应把差值直接解释为线上行为变化。
- 依赖 `omk observe ingest` stdout JSON 的脚本需追加 `--json`。
- 历史上已写入但无法回读的 observe inbox 报告建议重新 ingest。

## Measurement caveat

本版本修正 Trace IR 的人类消息、runtime 注入、父子任务、工具终态与摄取完整性语义，历史 observe 指标可能变化。评分类 prompt、五层评分语义、Bootstrap CI 与 Krippendorff alpha 公式未修改。

## Verification

GitHub CI 在 Node 22 与 Node 24 上执行 `lint`、`typecheck`、`build`、文档同步检查和完整测试；全部通过后才会合并并创建发布 tag。