### PR TITLE
fix(observability)!: BREAKING-COMPARABILITY 修复父子任务图与 lifecycle 状态

### DIFF
--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -4141,21 +4141,23 @@ function skillSegmentsWithOrchestrationRoles(
   const parentIds = new Set(orchestrationEdges.map((edge) => edge.parentSkillSegmentId).filter((value): value is string => Boolean(value)));
   const executorIds = new Set(orchestrationEdges.map((edge) => edge.executorSkillSegmentId).filter((value): value is string => Boolean(value)));
   return skillSegments.map((segment) => {
-    if (parentIds.has(segment.id) && segment.skillType === 'unknown') {
+    if (parentIds.has(segment.id)) {
+      const inferredFromTrace = !segment.declaredSkillType;
       return {
         ...segment,
-        skillType: 'router',
-        skillTypeSource: 'trace',
-        traceInferredSkillType: 'router',
+        skillType: inferredFromTrace ? 'router' : segment.skillType,
+        skillTypeSource: inferredFromTrace ? 'trace' : segment.skillTypeSource,
+        traceInferredSkillType: inferredFromTrace ? 'router' : segment.traceInferredSkillType,
         episodeRole: 'router',
       };
     }
-    if (executorIds.has(segment.id) && segment.episodeRole === 'supporting') {
+    if (executorIds.has(segment.id)) {
+      const inferredFromTrace = !segment.declaredSkillType;
       return {
         ...segment,
-        skillType: segment.skillType === 'unknown' ? 'executor' : segment.skillType,
-        skillTypeSource: segment.skillType === 'unknown' ? 'trace' : segment.skillTypeSource,
-        traceInferredSkillType: segment.traceInferredSkillType ?? 'executor',
+        skillType: inferredFromTrace ? 'executor' : segment.skillType,
+        skillTypeSource: inferredFromTrace ? 'trace' : segment.skillTypeSource,
+        traceInferredSkillType: inferredFromTrace ? 'executor' : segment.traceInferredSkillType,
         episodeRole: 'main_executor',
       };
     }
@@ -4409,44 +4411,153 @@ function sessionStoryOrchestrationEdges(
       });
     }
   }
-  if (edges.length === 0) {
-    const fallbackEdge = fallbackOrchestrationEdgeFromRuntime(episodeId, skillSegments, invocations);
-    if (fallbackEdge) edges.push(fallbackEdge);
-  }
   for (const dispatch of subagentDispatches) {
-    const parentSegment = delegator ?? router ?? runnerOwner;
-    const executor = skillSegments.find((segment) =>
-      segment.id !== parentSegment?.id
-      && segment.evidenceRefs.some((ref) => ref.traceId === dispatch.traceId)
-    ) ?? skillSegments.find((segment) =>
-      segment.id !== parentSegment?.id && segment.episodeRole === 'main_executor'
+    const executor = skillSegmentForTrace(
+      skillSegments,
+      dispatch.traceId,
+      dispatch.sourceTrace,
     );
-    const dispatchRunnerRef = runnerRef && (
-      !dispatch.attachTo?.callInstanceId
-        ? !dispatch.attachTo?.toolUseId
-          || dispatch.attachTo.toolUseId === runnerRef.toolUseId
-        : dispatch.attachTo.callInstanceId === runnerRef.callInstanceId
-    )
-      ? runnerRef
-      : undefined;
+    const parentSegment = dispatchParentSkillSegment(
+      skillSegments,
+      executor,
+      session,
+      dispatch,
+      router,
+      delegator,
+      runnerOwner,
+    );
+    const distinctExecutor = executor?.id === parentSegment?.id ? undefined : executor;
+    const dispatchRunnerRef = dispatchAttachmentEvidenceRef(session, dispatch);
+    const terminal = dispatchTerminalLifecycle(session, dispatch);
     edges.push({
       id: hashParts('session-story-edge', episodeId, dispatch.id),
       episodeId,
       edgeKind: 'external_child_session',
       parentSkillSegmentId: parentSegment?.id,
-      executorSkillSegmentId: executor?.id,
+      executorSkillSegmentId: distinctExecutor?.id,
       childSessionId: dispatch.childSessionId,
       runnerStartedRef: dispatchRunnerRef,
-      status: 'started',
+      runnerCompletedRef: terminal?.status === 'completed' ? terminal.evidenceRef : undefined,
+      status: terminal?.status ?? 'started',
       evidenceRefs: uniqueEvidenceRefs([
         ...(parentSegment?.evidenceRefs.slice(0, 2) ?? []),
-        ...(executor?.evidenceRefs.slice(0, 2) ?? []),
+        ...(distinctExecutor?.evidenceRefs.slice(0, 2) ?? []),
         ...(dispatchRunnerRef ? [dispatchRunnerRef] : []),
+        ...(terminal ? [terminal.evidenceRef] : []),
         ...dispatch.evidenceRefs,
       ]).slice(0, 6),
     });
   }
+  if (edges.length === 0 && subagentDispatches.length === 0) {
+    const fallbackEdge = fallbackOrchestrationEdgeFromRuntime(episodeId, skillSegments, invocations);
+    if (fallbackEdge) edges.push(fallbackEdge);
+  }
   return edges;
+}
+
+function skillSegmentForTrace(
+  skillSegments: ExperienceSkillSegment[],
+  traceId: string,
+  sourceTrace: string,
+): ExperienceSkillSegment | undefined {
+  return skillSegments
+    .filter((segment) =>
+      (segment.messageRanges ?? []).some((range) =>
+        range.traceId === traceId || range.sourceTrace === sourceTrace
+      )
+      || segment.evidenceRefs.some((ref) =>
+        ref.traceId === traceId || ref.sourceTrace === sourceTrace
+      )
+    )
+    .sort((a, b) => a.order - b.order)[0];
+}
+
+function dispatchParentSkillSegment(
+  skillSegments: ExperienceSkillSegment[],
+  executor: ExperienceSkillSegment | undefined,
+  session: ExperienceSessionSummary,
+  dispatch: ExperienceSessionStorySubagentDispatch,
+  router: ExperienceSkillSegment | undefined,
+  delegator: ExperienceSkillSegment | undefined,
+  runnerOwner: ExperienceSkillSegment | undefined,
+): ExperienceSkillSegment | undefined {
+  const mainTraceIds = new Set(
+    (session.timelineTree?.main ?? [])
+      .map((event) => event.traceId)
+      .filter((value): value is string => Boolean(value)),
+  );
+  const mainSourceTraces = new Set(
+    (session.timelineTree?.main ?? [])
+      .map((event) => event.sourceTrace)
+      .filter(Boolean),
+  );
+  const isMainline = (segment: ExperienceSkillSegment): boolean =>
+    (segment.messageRanges ?? []).some((range) =>
+      Boolean(range.traceId && mainTraceIds.has(range.traceId))
+      || Boolean(range.sourceTrace && mainSourceTraces.has(range.sourceTrace))
+    )
+    || segment.evidenceRefs.some((ref) =>
+      ref.traceRole === 'main'
+      || ref.traceRole === 'standalone'
+      || Boolean(ref.traceId && mainTraceIds.has(ref.traceId))
+      || mainSourceTraces.has(ref.sourceTrace)
+    );
+  const preferred = [router, delegator]
+    .filter((segment): segment is ExperienceSkillSegment => Boolean(segment))
+    .find((segment) => segment.id !== executor?.id && isMainline(segment));
+  if (preferred) return preferred;
+  const dispatchStart = minString(dispatch.evidenceRefs.map((ref) => ref.timestamp));
+  const mainline = skillSegments
+    .filter((segment) => segment.id !== executor?.id && isMainline(segment))
+    .filter((segment) => !dispatchStart || segment.startTimestamp <= dispatchStart)
+    .sort((a, b) =>
+      b.startTimestamp.localeCompare(a.startTimestamp)
+      || b.order - a.order
+    )[0];
+  if (mainline) return mainline;
+  if (runnerOwner?.id !== executor?.id && runnerOwner && isMainline(runnerOwner)) return runnerOwner;
+  return executor && isMainline(executor) ? executor : undefined;
+}
+
+function dispatchAttachmentEvidenceRef(
+  session: ExperienceSessionSummary,
+  dispatch: ExperienceSessionStorySubagentDispatch,
+): ExperienceEvidenceRef | undefined {
+  const attachTo = dispatch.attachTo;
+  if (!attachTo) return undefined;
+  if (!attachTo.callInstanceId && !attachTo.toolUseId && attachTo.messageIndex === undefined) {
+    return undefined;
+  }
+  const event = (session.timelineTree?.main ?? []).find((candidate) => {
+    if (candidate.kind !== 'tool_use') return false;
+    if (attachTo.callInstanceId) {
+      return candidate.callInstanceId === attachTo.callInstanceId;
+    }
+    if (attachTo.toolUseId && candidate.toolUseId !== attachTo.toolUseId) return false;
+    return attachTo.messageIndex === undefined
+      || candidate.messageIndex === attachTo.messageIndex;
+  });
+  return event ? evidenceRefFromTimeline(event) : undefined;
+}
+
+function dispatchTerminalLifecycle(
+  session: ExperienceSessionSummary,
+  dispatch: ExperienceSessionStorySubagentDispatch,
+): { status: 'completed' | 'failed'; evidenceRef: ExperienceEvidenceRef } | undefined {
+  const branch = session.timelineTree?.branches.find((candidate) =>
+    candidate.id === dispatch.branchId
+    || candidate.traceId === dispatch.traceId
+    || candidate.sourceTrace === dispatch.sourceTrace
+  );
+  const event = branch?.events.at(-1);
+  if (event?.kind !== 'runtime_context') return undefined;
+  if (event.label === 'turn_completed' || event.label === 'session_ended') {
+    return { status: 'completed', evidenceRef: evidenceRefFromTimeline(event) };
+  }
+  if (event.label === 'turn_aborted' || event.label === 'turn_interrupted') {
+    return { status: 'failed', evidenceRef: evidenceRefFromTimeline(event) };
+  }
+  return undefined;
 }
 
 function bestPriorUpstreamSkillSegmentForRuntime(

--- a/test/observability/inbox/experience-report.test.ts
+++ b/test/observability/inbox/experience-report.test.ts
@@ -1064,11 +1064,14 @@ expected_tools:
     assert.ok(firstEpisode);
     const applySegment = firstEpisode.skillSegments.find((segment) => segment.skillName === 'apply-cc');
     assert.ok(applySegment);
-    assert.ok(firstEpisode.orchestrationEdges.some((edge) =>
+    const childEdge = firstEpisode.orchestrationEdges.find((edge) =>
       edge.parentSkillSegmentId === applySegment.id
       && edge.edgeKind === 'external_child_session'
       && edge.evidenceRefs.some((ref) => ref.sourceTrace === mainFile && ref.toolUseId === 'task1')
-    ));
+    );
+    assert.ok(childEdge);
+    assert.equal(childEdge.runnerStartedRef?.toolUseId, 'task1');
+    assert.equal(childEdge.status, 'started');
     assert.ok(story.nodes.some((node) => node.kind === 'subagent_branch'));
     assert.deepEqual(story.skillLinks.map((link) => [link.skillName, link.role]).sort(), [
       ['aiprd-task-runner', 'executor'],

--- a/test/observability/orchestration-contract.test.ts
+++ b/test/observability/orchestration-contract.test.ts
@@ -1,0 +1,327 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'vitest';
+import {
+  loadCcSessions,
+  segmentBySkill,
+} from '../../src/observability/trace-adapter.js';
+import {
+  buildObservationExperienceReport,
+  compactObservationExperienceReport,
+  normalizeObservationExperienceReport,
+} from '../../src/observability/experience.js';
+
+type ChildTerminal = 'completed' | 'aborted';
+
+function writeJsonl(path: string, records: unknown[]): void {
+  writeFileSync(path, records.map((record) => JSON.stringify(record)).join('\n'));
+}
+
+function writeCodexFixture(root: string, terminal: ChildTerminal): void {
+  writeJsonl(join(root, 'parent.jsonl'), [
+    {
+      timestamp: '2026-07-28T00:00:00.000Z',
+      type: 'session_meta',
+      payload: {
+        id: 'contract-parent',
+        cwd: '/repo',
+        originator: 'Codex Desktop',
+        model_provider: 'openai',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:01.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: '<command-name>/router-skill</command-name>\nReview the release.',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:02.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        call_id: 'read-router',
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: 'cat .agents/skills/router-skill/SKILL.md' }),
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:03.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call_output',
+        call_id: 'read-router',
+        output: '# Router Skill',
+      },
+    },
+  ]);
+  writeJsonl(join(root, 'child.jsonl'), [
+    {
+      timestamp: '2026-07-28T00:00:04.000Z',
+      type: 'session_meta',
+      payload: {
+        id: 'contract-child',
+        parent_thread_id: 'contract-parent',
+        thread_source: 'subagent',
+        source: { subagent: 'review' },
+        cwd: '/repo',
+        originator: 'Codex Desktop',
+        model_provider: 'openai',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:05.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: '<command-name>/executor-skill</command-name>\nRun the parser check.',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:06.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        call_id: 'read-executor',
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: 'cat .agents/skills/executor-skill/SKILL.md' }),
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:07.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call_output',
+        call_id: 'read-executor',
+        output: '# Executor Skill',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:08.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        call_id: 'run-check',
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: 'node --test parser.test.js' }),
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:09.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call_output',
+        call_id: 'run-check',
+        output: 'Process exited with code 0\nparser tests passed',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:10.000Z',
+      type: 'event_msg',
+      payload: terminal === 'completed'
+        ? { type: 'task_complete', turn_id: 'child-turn' }
+        : { type: 'turn_aborted', turn_id: 'child-turn', reason: 'interrupted' },
+    },
+  ]);
+}
+
+function writeClaudeFixture(root: string, terminal: ChildTerminal): void {
+  const sessionDir = join(root, 'contract-parent');
+  const childDir = join(sessionDir, 'subagents');
+  mkdirSync(childDir, { recursive: true });
+  writeJsonl(join(sessionDir, 'parent.jsonl'), [
+    {
+      type: 'user',
+      uuid: 'parent-user',
+      sessionId: 'contract-parent',
+      timestamp: '2026-07-28T00:00:01.000Z',
+      cwd: '/repo',
+      message: {
+        role: 'user',
+        content: '<command-name>/router-skill</command-name>\nReview the release.',
+      },
+    },
+    {
+      type: 'assistant',
+      uuid: 'parent-read',
+      sessionId: 'contract-parent',
+      timestamp: '2026-07-28T00:00:02.000Z',
+      cwd: '/repo',
+      message: {
+        role: 'assistant',
+        content: [{
+          type: 'tool_use',
+          id: 'read-router',
+          name: 'Read',
+          input: { file_path: '/repo/.agents/skills/router-skill/SKILL.md' },
+        }],
+      },
+    },
+    {
+      type: 'user',
+      uuid: 'parent-read-result',
+      sessionId: 'contract-parent',
+      timestamp: '2026-07-28T00:00:03.000Z',
+      cwd: '/repo',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'read-router', content: '# Router Skill' }],
+      },
+    },
+  ]);
+  writeJsonl(join(childDir, 'child.jsonl'), [
+    {
+      type: 'user',
+      uuid: 'child-user',
+      sessionId: 'contract-child',
+      timestamp: '2026-07-28T00:00:05.000Z',
+      cwd: '/repo',
+      message: {
+        role: 'user',
+        content: '<command-name>/executor-skill</command-name>\nRun the parser check.',
+      },
+    },
+    {
+      type: 'assistant',
+      uuid: 'child-read',
+      sessionId: 'contract-child',
+      timestamp: '2026-07-28T00:00:06.000Z',
+      cwd: '/repo',
+      message: {
+        role: 'assistant',
+        content: [{
+          type: 'tool_use',
+          id: 'read-executor',
+          name: 'Read',
+          input: { file_path: '/repo/.agents/skills/executor-skill/SKILL.md' },
+        }],
+      },
+    },
+    {
+      type: 'user',
+      uuid: 'child-read-result',
+      sessionId: 'contract-child',
+      timestamp: '2026-07-28T00:00:07.000Z',
+      cwd: '/repo',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'read-executor', content: '# Executor Skill' }],
+      },
+    },
+    {
+      type: 'assistant',
+      uuid: 'child-check',
+      sessionId: 'contract-child',
+      timestamp: '2026-07-28T00:00:08.000Z',
+      cwd: '/repo',
+      message: {
+        role: 'assistant',
+        content: [{
+          type: 'tool_use',
+          id: 'run-check',
+          name: 'Bash',
+          input: { command: 'node --test parser.test.js' },
+        }],
+      },
+    },
+    {
+      type: 'user',
+      uuid: 'child-check-result',
+      sessionId: 'contract-child',
+      timestamp: '2026-07-28T00:00:09.000Z',
+      cwd: '/repo',
+      message: {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'run-check',
+          content: 'Process exited with code 0\nparser tests passed',
+        }],
+      },
+    },
+    terminal === 'completed'
+      ? {
+          type: 'system',
+          subtype: 'turn_duration',
+          uuid: 'child-completed',
+          sessionId: 'contract-child',
+          timestamp: '2026-07-28T00:00:10.000Z',
+          durationMs: 5000,
+        }
+      : {
+          type: 'turn_aborted',
+          uuid: 'child-aborted',
+          sessionId: 'contract-child',
+          timestamp: '2026-07-28T00:00:10.000Z',
+          reason: 'interrupted',
+        },
+  ]);
+}
+
+describe('source-neutral orchestration contract', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'omk-orchestration-contract-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  for (const sourceKind of ['codex', 'claude'] as const) {
+    for (const terminal of ['completed', 'aborted'] as const) {
+      it(`${sourceKind} maps a ${terminal} child trace to one directed edge`, () => {
+        const writeFixture = sourceKind === 'codex' ? writeCodexFixture : writeClaudeFixture;
+        writeFixture(root, terminal);
+        const sessions = loadCcSessions(root);
+        const built = buildObservationExperienceReport({
+          sessions,
+          segments: sessions.flatMap((session) => segmentBySkill(session)),
+          items: [],
+          generatedAt: '2026-07-28T00:00:11.000Z',
+        });
+        const report = normalizeObservationExperienceReport(
+          compactObservationExperienceReport(built),
+        );
+        assert.ok(report);
+        assert.deepEqual(
+          [...new Set(sessions.map((session) => session.sourceKind))],
+          [sourceKind],
+        );
+        assert.equal(report.storyContexts.length, 1);
+
+        const episode = report.storyContexts[0].episodes[0];
+        assert.ok(episode);
+        const edges = episode.orchestrationEdges.filter((edge) =>
+          edge.edgeKind === 'external_child_session'
+        );
+        assert.equal(edges.length, 1);
+
+        const edge = edges[0];
+        const segmentById = new Map(episode.skillSegments.map((segment) => [segment.id, segment]));
+        const parentSegment = segmentById.get(edge.parentSkillSegmentId ?? '');
+        const executorSegment = segmentById.get(edge.executorSkillSegmentId ?? '');
+        assert.equal(parentSegment?.skillName, 'router-skill');
+        assert.equal(parentSegment?.episodeRole, 'router');
+        assert.equal(executorSegment?.skillName, 'executor-skill');
+        assert.equal(executorSegment?.episodeRole, 'main_executor');
+        assert.equal(edge.childSessionId, 'contract-child');
+        assert.equal(edge.runnerStartedRef, undefined);
+        assert.equal(edge.status, terminal === 'completed' ? 'completed' : 'failed');
+        assert.equal(edge.runnerCompletedRef?.label, terminal === 'completed' ? 'turn_completed' : undefined);
+
+        const routerSession = report.sessions.find((session) => session.skillName === 'router-skill');
+        assert.ok(routerSession);
+        assert.equal(routerSession.indicators.routerDownstreamCompleted, terminal === 'completed' ? 1 : 0);
+        assert.equal(routerSession.indicators.routerDownstreamFailed, terminal === 'aborted' ? 1 : 0);
+      });
+    }
+  }
+});

--- a/test/observability/trace-adapter.test.ts
+++ b/test/observability/trace-adapter.test.ts
@@ -3005,6 +3005,12 @@ describe('source-neutral Trace IR', () => {
       .filter((edge) => edge.childSessionId === 'child-run');
     assert.equal(childEdges?.length, 1);
     assert.equal(childEdges?.[0].edgeKind, 'external_child_session');
+    const auditSegment = report.sessions[0].sessionStory?.episodes
+      ?.flatMap((episode) => episode.skillSegments)
+      .find((segment) => segment.skillName === 'audit');
+    assert.ok(auditSegment);
+    assert.equal(childEdges?.[0].parentSkillSegmentId, auditSegment.id);
+    assert.equal(childEdges?.[0].executorSkillSegmentId, undefined);
     assert.ok(normalizeObservationExperienceReport(
       compactObservationExperienceReport(report),
     ));


### PR DESCRIPTION
## 用户影响

- Codex 与 Claude 的父任务 / subagent trace 现在只生成一条方向正确的 `external_child_session` 边。
- parent 优先归属于主 trace，executor 优先归属于 child trace；同一 skill 的父子 trace 会折叠而不会形成自环。
- 没有真实 attach point 时，不再把 child 内普通工具成功结果误当成 runner 启动证据。
- child 的 source-neutral 完成 / 中断 lifecycle 会驱动编排边状态以及 router downstream 计数。

## 迁移与可比性

不涉及 JSON schema、落盘格式或 CLI 迁移。重新导入历史 trace 后，`routerDownstreamCompleted` / `routerDownstreamFailed` 可能因生命周期归因纠正而变化；修复前后的这两个计数不应视为同一测量口径，后续应随 minor 版本发布。

## Construct validity

只有当 child 分支最后一个事件是明确的 source-neutral terminal lifecycle 时，边才标记为 `completed` 或 `failed`；缺少终态证据时继续保留为 `started`，避免把普通工具结果推断成任务完成。

Closes #354