### PR TITLE
chore(release): 发布 0.50.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 发布范围

- 提供可复现的 Codex 父任务 / subagent observe 案例，便于验证 source-neutral Trace IR。
- 修复不同 skill 父子 trace 的重复反向边、错误启动证据与 lifecycle 状态归因。
- 将包版本更新为 `0.50.0`。

## 可比性与迁移

不涉及 JSON schema、落盘格式或 CLI 迁移。重新导入历史 trace 后，`routerDownstreamCompleted` / `routerDownstreamFailed` 可能因 lifecycle 归因纠正而变化；`v0.49.x` 与 `v0.50.0` 的这两个指标不应视为完全相同的测量口径。

发布后需要把该可比性说明提升到 GitHub Release notes，并核验 npm provenance 与 `latest` dist-tag。