### PR TITLE
fix(observability)!: BREAKING-COMPARABILITY 收紧编排证据边界

### DIFF
--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -4678,15 +4678,8 @@ function isOrchestrationRuntimeEvent(event: ExperienceTimelineEvent): boolean {
     return /^(?:Task|Agent)$/i.test(event.toolName ?? '')
       || /runner\.js|send-input\.js|check-session\.js/i.test(text);
   }
-  if (event.kind === 'tool_result') {
-    const trimmed = text.trim();
-    if (/^---\s*\n?\s*name:/i.test(trimmed) || /^---\s+name:/i.test(trimmed)) return false;
-    return /"event"\s*:\s*"started"|Command still running \(session|Process exited with code|Process exited with signal/i.test(text)
-      || /["']?(?:child_?session_?id|agent_?id|thread_?id|session_?id)["']?\s*[:=]/i.test(text)
-      || /\b(?:session|thread|agent)(?:\s+id)?\s*[:=]\s*[a-z0-9][a-z0-9._-]*/i.test(text);
-  }
   if (event.kind === 'assistant_message') {
-    return /ttyd|(?:已启动|启动了|spawned|started).*(?:subagent|sub-agent|child agent|子\s*(?:agent|代理|智能体|Claude|Codex))|(?:subagent|sub-agent|child agent|子\s*(?:agent|代理|智能体|Claude|Codex)).*(?:执行|运行|分析|started|running)/i.test(text)
+    return /ttyd|(?:已启动|启动了|spawned|started).{0,80}(?:subagent|sub-agent|child agent|子\s*(?:agent|代理|智能体|Claude|Codex))|(?:subagent|sub-agent|child agent|子\s*(?:agent|代理|智能体|Claude|Codex)).{0,48}(?:已启动|启动中|正在(?:执行|运行|分析)|spawned|started|running)/i.test(text)
       || /\b(?:session|thread|agent)(?:\s+id)?\s*[:=]\s*[a-z0-9][a-z0-9._-]*/i.test(text);
   }
   return false;
@@ -5314,13 +5307,12 @@ function inferSkillRole(group: ExperienceInvocation[], allInvocations: Experienc
 }
 
 function routingEvidenceEvents(invocation: ExperienceInvocation): ExperienceTimelineEvent[] {
-  return invocation.timeline.filter((event) => {
-    if (event.kind !== 'assistant_message' && event.kind !== 'tool_use') return false;
-    if (isOrchestrationRuntimeEvent(event)) return true;
-    if (isDifferentSkillInvocationEvent(event, invocation.skillName)) return true;
-    const text = event.fullText ?? event.snippet ?? '';
-    return /subagent|sub-agent|child agent|子\s*(?:agent|代理|智能体|Claude|Codex)|子任务|分发|委派|路由|delegate|dispatch|route|调用.+skill|走\s*`?[\w-]+`?\s*skill/i.test(text);
-  }).slice(0, 3);
+  return invocation.timeline
+    .filter((event) =>
+      isOrchestrationRuntimeEvent(event)
+      || isDifferentSkillInvocationEvent(event, invocation.skillName)
+    )
+    .slice(0, 3);
 }
 
 function isDifferentSkillInvocationEvent(

--- a/test/observability/orchestration-contract.test.ts
+++ b/test/observability/orchestration-contract.test.ts
@@ -131,6 +131,93 @@ function writeCodexFixture(root: string, terminal: ChildTerminal): void {
   ]);
 }
 
+function writeCodexStandaloneFixture(root: string): void {
+  writeJsonl(join(root, 'standalone.jsonl'), [
+    {
+      timestamp: '2026-07-28T00:00:00.000Z',
+      type: 'session_meta',
+      payload: {
+        id: 'contract-standalone',
+        cwd: '/repo',
+        originator: 'Codex Desktop',
+        model_provider: 'openai',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:01.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: '<command-name>/research-skill</command-name>\nInspect the release metadata.',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:02.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        call_id: 'inspect-version',
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: 'rg version package.json' }),
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:03.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call_output',
+        call_id: 'inspect-version',
+        output: 'Process exited with code 0\n"version": "0.50.0"',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:04.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: '<command-name>/release-skill</command-name>\nPublish the release.',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:05.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        call_id: 'publish-pr',
+        name: 'exec_command',
+        arguments: JSON.stringify({
+          cmd: 'gh pr create --body "Document the subagent behavior."',
+        }),
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:06.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call_output',
+        call_id: 'publish-pr',
+        output: 'Process exited with code 0\nPull request created\n{"session_id":"inspected-session"}',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:07.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: '已确认 Guardian subagent 的 parent_thread_id；保留快照供后续分析。',
+      },
+    },
+    {
+      timestamp: '2026-07-28T00:00:08.000Z',
+      type: 'event_msg',
+      payload: { type: 'task_complete', turn_id: 'standalone-turn' },
+    },
+  ]);
+}
+
 function writeClaudeFixture(root: string, terminal: ChildTerminal): void {
   const sessionDir = join(root, 'contract-parent');
   const childDir = join(sessionDir, 'subagents');
@@ -324,4 +411,33 @@ describe('source-neutral orchestration contract', () => {
       });
     }
   }
+
+  it('does not infer orchestration from ordinary process output or tool argument prose', () => {
+    writeCodexStandaloneFixture(root);
+    const sessions = loadCcSessions(root);
+    const report = buildObservationExperienceReport({
+      sessions,
+      segments: sessions.flatMap((session) => segmentBySkill(session)),
+      items: [],
+      generatedAt: '2026-07-28T00:00:09.000Z',
+    });
+
+    assert.equal(report.storyContexts.length, 1);
+    const story = report.storyContexts[0];
+    assert.equal(story.subagentDispatches.length, 0);
+    assert.equal(
+      story.episodes.flatMap((episode) => episode.orchestrationEdges).length,
+      0,
+    );
+    const skillSegments = story.episodes.flatMap((episode) => episode.skillSegments);
+    const releaseSegment = skillSegments.find((segment) => segment.skillName === 'release-skill');
+    assert.ok(releaseSegment);
+    assert.equal(releaseSegment.skillType, 'executor');
+    assert.equal(releaseSegment.episodeRole, 'main_executor');
+
+    const session = report.sessions.find((candidate) => candidate.skillName === 'release-skill');
+    assert.ok(session);
+    assert.equal(session.indicators.routerDownstreamCompleted, 0);
+    assert.equal(session.indicators.routerDownstreamFailed, 0);
+  });
 });


### PR DESCRIPTION
## 用户影响

- 普通命令的 `Process exited`、被检查内容中的 session ID，以及工具参数里对 subagent 的说明文字，不再生成虚假的编排边。
- 没有真实 dispatch 的 skill 不再被错误提升为 router，downstream 完成 / 失败计数也不会被假边污染。
- concrete child trace、Task / Agent、已知 runner、Skill 委派和明确的子代理启动消息继续作为正向编排证据。

## 可比性与迁移

不涉及 JSON schema、落盘格式或 CLI 迁移。重新导入历史 trace 后，`skillType` / `episodeRole`、`orchestrationEdges`、`routerDownstreamCompleted` / `routerDownstreamFailed` 可能因假阳性消除而变化；修复前后的这些字段不应视为完全相同的测量口径。

## Construct validity

编排身份现在只来自动作侧或结构侧证据，不再从任意工具结果内容和宽泛说明文字反推。该边界已用实际 `v0.50.0` Codex 发布 trace 复现并验证：Guardian 仍被过滤，主 skill 从假 router 恢复为 main executor，虚假 external child edge 消失。

Closes #358