### PR TITLE
chore(release): 发布 0.51.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 发布范围

- 收紧 source-neutral 编排证据边界，消除普通命令结果、被检查的 session 元数据和说明文字产生的假 router / 假 child edge。
- 将包版本更新为 `0.51.0`。

## 可比性与迁移

不涉及 JSON schema、落盘格式或 CLI 迁移。重新导入历史 trace 后，`skillType` / `episodeRole`、`orchestrationEdges`、`routerDownstreamCompleted` / `routerDownstreamFailed` 可能因假阳性消除而变化。`v0.50.0` 与 `v0.51.0` 的这些字段不应视为完全相同的测量口径；跨版本比较应使用同一 omk 版本重新生成基线。

该修复已使用真实 `v0.50.0` Codex 发布 trace 验证：Guardian 仍被过滤，主 skill 从假 router 恢复为 main executor，虚假 external child edge 消失。