### PR TITLE
fix(doctor): 排除可选探测依赖误报

### DIFF
--- a/src/eval-core/dependency-checker.ts
+++ b/src/eval-core/dependency-checker.ts
@@ -46,7 +46,15 @@ const SYSTEM_ENV_VARS = new Set([
   'TMPDIR', 'EDITOR', 'VISUAL', 'HOSTNAME', 'LOGNAME', 'DISPLAY',
   'XDG_CONFIG_HOME', 'XDG_DATA_HOME', 'XDG_CACHE_HOME',
   'NODE_ENV', 'NODE_PATH', 'NODE_OPTIONS', 'NPM_CONFIG_PREFIX',
+  // Agent Skills resolves this placeholder to the active skill directory.
+  // It is not a user-provided environment prerequisite.
+  'SKILL_ROOT',
 ]);
+
+// A shell probe that explicitly tolerates failure is discovering the target
+// project shape. Candidate paths on that line are not hard dependencies of the
+// skill itself.
+const OPTIONAL_PROBE_LINE_REGEX = /(?:2>\s*\/dev\/null|\|\|\s*(?:true|:)(?:\s|$))/;
 
 function extractFromText(text: string): { tools: Set<string>; files: Set<string>; env: Set<string> } {
   const tools = new Set<string>();
@@ -67,21 +75,25 @@ function extractFromText(text: string): { tools: Set<string>; files: Set<string>
     }
   }
 
-  // File paths
-  for (const match of text.matchAll(FILE_PATH_REGEX)) {
-    const path = match[1];
-    // Skip paths that look like URLs, package names, or version strings
-    if (path.startsWith('http') || path.startsWith('node_modules') || /^\d/.test(path)) continue;
-    // Skip very short paths that are likely not real files
-    if (path.length < 5) continue;
-    // Skip extension-mention patterns(`.d.ts` / `.tsx` 这种以点开头的"扩展名讨论"
-    // 不是真路径,SKILL.md 里"查看 .d.ts 文件"会被误识别)
-    if (path.startsWith('.')) continue;
-    // Skip bare filenames without a directory segment(`index.ts` / `package.json`
-    // 这种通用文件名几乎都是示例性提及,真依赖会带路径段。要声明 bare 文件
-    // 走显式 requires)
-    if (!path.includes('/')) continue;
-    files.add(path);
+  // File paths. Keep line context so optional discovery commands do not turn
+  // every candidate project entry point into a fatal preflight requirement.
+  for (const line of text.split(/\r?\n/)) {
+    if (OPTIONAL_PROBE_LINE_REGEX.test(line)) continue;
+    for (const match of line.matchAll(FILE_PATH_REGEX)) {
+      const path = match[1];
+      // Skip paths that look like URLs, package names, or version strings
+      if (path.startsWith('http') || path.startsWith('node_modules') || /^\d/.test(path)) continue;
+      // Skip very short paths that are likely not real files
+      if (path.length < 5) continue;
+      // Skip extension-mention patterns(`.d.ts` / `.tsx` 这种以点开头的"扩展名讨论"
+      // 不是真路径,SKILL.md 里"查看 .d.ts 文件"会被误识别)
+      if (path.startsWith('.')) continue;
+      // Skip bare filenames without a directory segment(`index.ts` / `package.json`
+      // 这种通用文件名几乎都是示例性提及,真依赖会带路径段。要声明 bare 文件
+      // 走显式 requires)
+      if (!path.includes('/')) continue;
+      files.add(path);
+    }
   }
 
   // Environment variables
@@ -391,4 +403,3 @@ export async function preflightDependencies(
 
   return result;
 }
-

--- a/test/dependency-checker.test.ts
+++ b/test/dependency-checker.test.ts
@@ -49,6 +49,26 @@ describe('extractDependencies', () => {
     assert.equal(deps.env, undefined);
   });
 
+  it('排除 Agent Skills 运行时提供的 SKILL_ROOT 占位符', () => {
+    const skill = `读取 \${SKILL_ROOT}/references/tracing.md，上传时使用 $SENTRY_AUTH_TOKEN`;
+    const deps = extractDependencies([skill], []);
+    assert.ok(!deps.env?.includes('SKILL_ROOT'));
+    assert.ok(deps.env?.includes('SENTRY_AUTH_TOKEN'));
+  });
+
+  it('不把允许失败的项目探测命令中的候选路径视为硬依赖', () => {
+    const skill = [
+      'ls app.json src/app.js src/app.ts 2>/dev/null',
+      'cat src/optional/config.ts || true',
+      '请读取 references/tracing.md 后再配置。',
+    ].join('\n');
+    const deps = extractDependencies([skill], []);
+    assert.ok(!deps.files?.includes('src/app.js'));
+    assert.ok(!deps.files?.includes('src/app.ts'));
+    assert.ok(!deps.files?.includes('src/optional/config.ts'));
+    assert.ok(deps.files?.includes('references/tracing.md'));
+  });
+
   it('从 sample assertions 提取 CLI 工具', () => {
     const samples: Sample[] = [{
       sample_id: 's1',


### PR DESCRIPTION
## 用户影响

`omk doctor` 不再把 Agent Skills 运行时提供的 `SKILL_ROOT` 当作缺失环境变量，也不会把显式允许失败的项目结构探测路径当作 skill 硬依赖。跨项目 skill 可以继续用候选入口探测，而不会被 preflight 错误阻断。

## 兼容性

显式 `requires.files` / `requires.env` 仍保持严格校验；普通正文中未标记为可选探测的真实文件依赖仍会检查。此改动不改变评分 prompt、Report schema 或测量口径。

Closes #361