### PR TITLE
fix(observe): 适配 Codex Desktop exec trace

### DIFF
--- a/src/observability/codex-exec-command.ts
+++ b/src/observability/codex-exec-command.ts
@@ -1,0 +1,135 @@
+/** Static extraction for Codex Desktop's JavaScript exec bridge. */
+
+function skipJsString(source: string, start: number): number {
+  const quote = source[start];
+  let index = start + 1;
+  while (index < source.length) {
+    if (source[index] === '\\') {
+      index += 2;
+      continue;
+    }
+    if (source[index] === quote) return index + 1;
+    index += 1;
+  }
+  return source.length;
+}
+
+function skipJsTrivia(source: string, start: number): number {
+  let index = start;
+  while (index < source.length) {
+    if (/\s/.test(source[index])) {
+      index += 1;
+      continue;
+    }
+    if (source.startsWith('//', index)) {
+      const newline = source.indexOf('\n', index + 2);
+      return newline < 0 ? source.length : skipJsTrivia(source, newline + 1);
+    }
+    if (source.startsWith('/*', index)) {
+      const end = source.indexOf('*/', index + 2);
+      return end < 0 ? source.length : skipJsTrivia(source, end + 2);
+    }
+    break;
+  }
+  return index;
+}
+
+function commandPropertyEnd(source: string, index: number): number | null {
+  const bareKey = source.startsWith('cmd', index)
+    && !/[\w$]/.test(source[index - 1] ?? '')
+    && !/[\w$]/.test(source[index + 3] ?? '');
+  if (bareKey) return index + 3;
+
+  const quote = source[index];
+  if (quote !== '"' && quote !== "'") return null;
+  const end = skipJsString(source, index);
+  return source.slice(index + 1, end - 1) === 'cmd' ? end : null;
+}
+
+function commandLiteralValue(source: string, start: number, end: number): string {
+  const literal = source.slice(start, end);
+  if (source[start] === '"') {
+    try {
+      const parsed = JSON.parse(literal);
+      if (typeof parsed === 'string') return parsed;
+    } catch {
+      // Fall through to the lossless source slice for non-JSON JS escapes.
+    }
+  }
+  return source.slice(start + 1, Math.max(start + 1, end - 1));
+}
+
+function extractExecCommandLiteral(source: string, callStart: number): string | null {
+  let index = skipJsTrivia(source, callStart + 'tools.exec_command'.length);
+  if (source[index] !== '(') return null;
+  index = skipJsTrivia(source, index + 1);
+  if (source[index] !== '{') return null;
+
+  let depth = 1;
+  index += 1;
+  while (index < source.length && depth > 0) {
+    index = skipJsTrivia(source, index);
+    const char = source[index];
+    if (depth === 1) {
+      const keyEnd = commandPropertyEnd(source, index);
+      if (keyEnd !== null) {
+        let valueStart = skipJsTrivia(source, keyEnd);
+        if (source[valueStart] !== ':') {
+          index = keyEnd;
+          continue;
+        }
+        valueStart = skipJsTrivia(source, valueStart + 1);
+        const quote = source[valueStart];
+        if (quote !== '"' && quote !== "'" && quote !== '`') return null;
+        const end = skipJsString(source, valueStart);
+        return commandLiteralValue(source, valueStart, end);
+      }
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      index = skipJsString(source, index);
+      continue;
+    }
+    if (char === '{') {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (char === '}') {
+      depth -= 1;
+      index += 1;
+      continue;
+    }
+    index += 1;
+  }
+  return null;
+}
+
+/**
+ * Extract only literal `cmd` values from real `tools.exec_command(...)` calls.
+ * The bridge source is never evaluated, and examples inside strings/comments
+ * remain ignored.
+ */
+export function extractCodexExecCommands(source: string): string[] {
+  const commands: string[] = [];
+  let index = 0;
+  while (index < source.length) {
+    index = skipJsTrivia(source, index);
+    const char = source[index];
+    if (char === '"' || char === "'" || char === '`') {
+      index = skipJsString(source, index);
+      continue;
+    }
+    if (
+      source.startsWith('tools.exec_command', index)
+      && !/[\w$.]/.test(source[index - 1] ?? '')
+      && !/[\w$]/.test(source[index + 'tools.exec_command'.length] ?? '')
+    ) {
+      const command = extractExecCommandLiteral(source, index);
+      if (command) commands.push(command);
+      index += 'tools.exec_command'.length;
+      continue;
+    }
+    index += 1;
+  }
+  return commands;
+}

--- a/src/observability/codex-trace-adapter.ts
+++ b/src/observability/codex-trace-adapter.ts
@@ -23,6 +23,7 @@ import {
   tokenCount,
 } from '../shared/token-usage.js';
 import { normalizeToolIdentity } from '../shared/tool-identity.js';
+import { extractCodexExecCommands } from './codex-exec-command.js';
 
 interface CodexRecord {
   timestamp?: unknown;
@@ -379,8 +380,10 @@ function convertCodexRecords(rawRecords: unknown[], runId: string): TraceEvent[]
       const explicitStatus = runtimeOutcome.present
         ? runtimeOutcome.status
         : statusFromCodex(payloadStatus);
-      const inferredFailure = isToolResultFailureText(output) || codexToolOutputFailed(output);
-      const inferredSuccess = !inferredFailure && codexToolOutputSucceeded(output);
+      const bridgeFailure = codexToolOutputFailed(output);
+      const bridgeSuccess = !bridgeFailure && codexToolOutputSucceeded(output);
+      const inferredFailure = bridgeFailure || (!bridgeSuccess && isToolResultFailureText(output));
+      const inferredSuccess = bridgeSuccess;
       const completedExternalCall = externalEnds.byOccurrence.has(
         mcpCallOccurrenceKey(callId, externalOccurrence),
       );
@@ -794,6 +797,10 @@ function normalizeCodexTool(
   sourceNamespace?: string,
 ): { tool: TraceToolRef; input: Record<string, unknown> } {
   const input = parseToolInput(rawInput);
+  const sourceInput = stringValue(input.input);
+  const execCommands = sourceName.toLowerCase() === 'exec' && sourceInput
+    ? extractCodexExecCommands(sourceInput)
+    : [];
   // Codex desktop's orchestration wrapper names its JavaScript command bridge
   // `exec`. This mapping is source-specific: a generic tool named `exec` must not
   // become shell execution outside the Codex adapter.
@@ -814,10 +821,13 @@ function normalizeCodexTool(
       tool,
       input: {
         ...input,
-        command: stringValue(input.command)
-          ?? stringValue(input.cmd)
-          ?? stringValue(input.input)
-          ?? '',
+        command: execCommands.length > 0
+          ? execCommands.join('\n')
+          : stringValue(input.command)
+            ?? stringValue(input.cmd)
+            ?? sourceInput
+            ?? '',
+        ...(execCommands.length > 0 ? { commands: execCommands } : {}),
       },
     };
   }

--- a/src/observability/trace-attribution.ts
+++ b/src/observability/trace-attribution.ts
@@ -2,6 +2,7 @@
 
 import type { CcAssistantRecord, CcUserRecord } from './trace-source.js';
 import type { TraceMessageEvent, TraceToolCallEvent } from './trace-ir.js';
+import { extractCodexExecCommands } from './codex-exec-command.js';
 
 // ---------- Skill signal detection ----------
 
@@ -210,112 +211,6 @@ function extractInstalledSkillReadRef(text: string): SkillRef | null {
   return null;
 }
 
-function skipJsString(source: string, start: number): number {
-  const quote = source[start];
-  let index = start + 1;
-  while (index < source.length) {
-    if (source[index] === '\\') {
-      index += 2;
-      continue;
-    }
-    if (source[index] === quote) return index + 1;
-    index += 1;
-  }
-  return source.length;
-}
-
-function skipJsTrivia(source: string, start: number): number {
-  let index = start;
-  while (index < source.length) {
-    if (/\s/.test(source[index])) {
-      index += 1;
-      continue;
-    }
-    if (source.startsWith('//', index)) {
-      const newline = source.indexOf('\n', index + 2);
-      return newline < 0 ? source.length : skipJsTrivia(source, newline + 1);
-    }
-    if (source.startsWith('/*', index)) {
-      const end = source.indexOf('*/', index + 2);
-      return end < 0 ? source.length : skipJsTrivia(source, end + 2);
-    }
-    break;
-  }
-  return index;
-}
-
-function extractExecCommandLiteral(source: string, callStart: number): string | null {
-  let index = skipJsTrivia(source, callStart + 'tools.exec_command'.length);
-  if (source[index] !== '(') return null;
-  index = skipJsTrivia(source, index + 1);
-  if (source[index] !== '{') return null;
-
-  let depth = 1;
-  index += 1;
-  while (index < source.length && depth > 0) {
-    index = skipJsTrivia(source, index);
-    const char = source[index];
-    if (char === '"' || char === "'" || char === '`') {
-      index = skipJsString(source, index);
-      continue;
-    }
-    if (char === '{') {
-      depth += 1;
-      index += 1;
-      continue;
-    }
-    if (char === '}') {
-      depth -= 1;
-      index += 1;
-      continue;
-    }
-    if (
-      depth === 1
-      && source.startsWith('cmd', index)
-      && !/[\w$]/.test(source[index - 1] ?? '')
-      && !/[\w$]/.test(source[index + 3] ?? '')
-    ) {
-      let valueStart = skipJsTrivia(source, index + 3);
-      if (source[valueStart] !== ':') {
-        index += 3;
-        continue;
-      }
-      valueStart = skipJsTrivia(source, valueStart + 1);
-      const quote = source[valueStart];
-      if (quote !== '"' && quote !== "'" && quote !== '`') return null;
-      const end = skipJsString(source, valueStart);
-      return source.slice(valueStart + 1, Math.max(valueStart + 1, end - 1));
-    }
-    index += 1;
-  }
-  return null;
-}
-
-function extractExecCommandLiterals(source: string): string[] {
-  const commands: string[] = [];
-  let index = 0;
-  while (index < source.length) {
-    index = skipJsTrivia(source, index);
-    const char = source[index];
-    if (char === '"' || char === "'" || char === '`') {
-      index = skipJsString(source, index);
-      continue;
-    }
-    if (
-      source.startsWith('tools.exec_command', index)
-      && !/[\w$.]/.test(source[index - 1] ?? '')
-      && !/[\w$]/.test(source[index + 'tools.exec_command'.length] ?? '')
-    ) {
-      const command = extractExecCommandLiteral(source, index);
-      if (command) commands.push(command);
-      index += 'tools.exec_command'.length;
-      continue;
-    }
-    index += 1;
-  }
-  return commands;
-}
-
 function splitShellCommandSegments(command: string): string[] {
   const segments: string[] = [];
   let start = 0;
@@ -401,7 +296,7 @@ export function extractSkillReadFileRef(record: CcAssistantRecord): SkillRef | n
         ? []
         : part.name === 'Bash'
           ? [rawCommand]
-          : extractExecCommandLiterals(rawCommand);
+          : extractCodexExecCommands(rawCommand);
       for (const command of commands) {
         const skillRef = extractShellSkillReadRef(command);
         if (skillRef) return skillRef;
@@ -432,7 +327,7 @@ export function extractSkillScriptCommandRef(record: CcUserRecord | CcAssistantR
           : part.input?.code ?? part.input?.command;
         if (typeof rawCommand === 'string') {
           texts.push(...(part.name?.toLowerCase() === 'exec'
-            ? extractExecCommandLiterals(rawCommand)
+            ? extractCodexExecCommands(rawCommand)
             : [rawCommand]));
         }
       }
@@ -493,9 +388,14 @@ export function extractSkillReadFileRefFromEvent(event: TraceToolCallEvent): Ski
     || sourceName === 'js'
     || event.tool.name === 'node_repl.js'
     || event.tool.name.toLowerCase() === 'js';
-  const commands = isOrchestrationWrapper
-    ? extractExecCommandLiterals(rawCommand)
-    : [rawCommand];
+  const normalizedCommands = Array.isArray(event.input.commands)
+    ? event.input.commands.filter((value): value is string => typeof value === 'string')
+    : [];
+  const commands = normalizedCommands.length > 0
+    ? normalizedCommands
+    : isOrchestrationWrapper
+      ? extractCodexExecCommands(rawCommand)
+      : [rawCommand];
   for (const command of commands) {
     const skillRef = extractShellSkillReadRef(command);
     if (skillRef) return skillRef;

--- a/test/observability/inbox/trace-ingestion.test.ts
+++ b/test/observability/inbox/trace-ingestion.test.ts
@@ -178,31 +178,31 @@ describe('observe inbox - trace ingestion', () => {
         timestamp: '2026-07-25T00:00:02.000Z',
         type: 'response_item',
         payload: {
-          type: 'function_call',
+          type: 'custom_tool_call',
           call_id: 'read-skill',
-          name: 'exec_command',
-          arguments: JSON.stringify({ cmd: "sed -n '1,200p' .agents/skills/audit/SKILL.md" }),
+          name: 'exec',
+          input: 'const result = await tools.exec_command({"cmd":"sed -n \'1,200p\' .agents/skills/audit/SKILL.md"});',
         },
       },
       {
         timestamp: '2026-07-25T00:00:03.000Z',
         type: 'response_item',
-        payload: { type: 'function_call_output', call_id: 'read-skill', output: '# Audit Skill' },
+        payload: { type: 'custom_tool_call_output', call_id: 'read-skill', output: '# Audit Skill' },
       },
       {
         timestamp: '2026-07-25T00:00:04.000Z',
         type: 'response_item',
         payload: {
-          type: 'function_call',
+          type: 'custom_tool_call',
           call_id: 'search-1',
-          name: 'exec_command',
-          arguments: JSON.stringify({ cmd: 'rg revenue_schema src' }),
+          name: 'exec',
+          input: 'const result = await tools.exec_command({"cmd":"rg revenue_schema src"});',
         },
       },
       {
         timestamp: '2026-07-25T00:00:05.000Z',
         type: 'response_item',
-        payload: { type: 'function_call_output', call_id: 'search-1', output: 'No matches found' },
+        payload: { type: 'custom_tool_call_output', call_id: 'search-1', output: 'No matches found' },
       },
     ];
     writeFileSync(file, records.map((record) => JSON.stringify(record)).join('\n'));

--- a/test/observability/trace-adapter.test.ts
+++ b/test/observability/trace-adapter.test.ts
@@ -476,6 +476,42 @@ describe('loadCcSessions', () => {
     assert.equal(corpus.ingestion.unknownEventCount, 0);
   });
 
+  it('treats a completed Codex exec envelope as success despite failure-shaped source text', () => {
+    const path = writeSession(tmpDir, 'codex-exec-completed.jsonl', [
+      {
+        timestamp: '2026-07-25T00:00:00.000Z',
+        type: 'session_meta',
+        payload: { id: 'codex-exec-completed' },
+      },
+      {
+        timestamp: '2026-07-25T00:00:01.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'custom_tool_call',
+          call_id: 'exec-1',
+          name: 'exec',
+          input: 'const result = await tools.exec_command({"cmd":"rg status src"});',
+        },
+      },
+      {
+        timestamp: '2026-07-25T00:00:02.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'custom_tool_call_output',
+          call_id: 'exec-1',
+          output: 'Script completed\nOutput:\nstatus: failure is a source field',
+        },
+      },
+    ]);
+
+    const corpus = loadTraceCorpus(path);
+    const result = corpus.sessions[0].events.find((event) => event.eventKind === 'tool_result');
+    assert.equal(result?.eventKind, 'tool_result');
+    if (result?.eventKind !== 'tool_result') assert.fail('expected tool result');
+    assert.equal(result.status, 'success');
+    assert.equal(result.statusSource, 'inferred');
+  });
+
   it('recovers a complete apply_patch pair from a truncated patch_apply_end', () => {
     const path = writeSession(tmpDir, 'codex-truncated-patch.jsonl', [
       {
@@ -1357,7 +1393,7 @@ describe('loadCcSessions', () => {
           type: 'custom_tool_call',
           call_id: 'read-alpha',
           name: 'exec',
-          input: 'const result = await tools.exec_command({cmd: "sed -n \'1,200p\' .agents/skills/alpha/SKILL.md"});',
+          input: 'const result = await tools.exec_command({"cmd": "sed -n \'1,200p\' .agents/skills/alpha/SKILL.md"});',
         },
       },
       {
@@ -1399,7 +1435,7 @@ describe('loadCcSessions', () => {
           type: 'custom_tool_call',
           call_id: 'read-beta',
           name: 'exec',
-          input: 'const result = await tools.exec_command({cmd: "cat .agents/skills/beta/SKILL.md"});',
+          input: "const result = await tools.exec_command({'cmd': 'cat .agents/skills/beta/SKILL.md'});",
         },
       },
       {
@@ -1484,6 +1520,11 @@ describe('loadCcSessions', () => {
     assert.equal(alpha.attribution?.source, 'read-skill-md');
     assert.equal(alpha.toolCalls[0].tool, 'Bash');
     assert.equal(alpha.toolCalls[0].sourceTool, 'exec');
+    assert.deepEqual(alpha.toolCalls[0].input, {
+      input: 'const result = await tools.exec_command({"cmd": "sed -n \'1,200p\' .agents/skills/alpha/SKILL.md"});',
+      command: "sed -n '1,200p' .agents/skills/alpha/SKILL.md",
+      commands: ["sed -n '1,200p' .agents/skills/alpha/SKILL.md"],
+    });
     assert.equal(alpha.metrics.inputTokens, 100);
     assert.equal(alpha.metrics.outputTokens, 10);
     assert.equal(alpha.sourceMetadata?.model, 'gpt-5.5');


### PR DESCRIPTION
## 用户影响

`omk observe` 现在能从当前 Codex Desktop rollout 的 `custom_tool_call` 中识别项目级 skill 读取，不再把真实 invocation 降成 `general` 后丢弃。Codex JavaScript 桥接层会在 source adapter 中静态解包为实际 shell command，原始 wrapper 仍保留作审计证据。

同时，外层 `Script completed` / 非零退出标记优先于命令输出中的源码文本，避免读取含 `status: failure` 等字样的文件时制造工具失败和知识缺口。

## 兼容性与测量说明

旧的 `{cmd: ...}` 与新的 `{"cmd": ...}` / `{'cmd': ...}` 都可读取；解析器只提取静态字符串，不执行 trace 中的 JavaScript。此改动不触及评分 prompt、Report schema 或 eval 可比性，仅修正 Codex observe 的归因召回率和工具结果准确性。

Closes #365