### PR TITLE
chore(release): 发布 0.51.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 发布内容

发布 `oh-my-knowledge@0.51.1`，包含：

- #364：doctor 不再把 `SKILL_ROOT` 和显式允许失败的项目探测路径误判为硬依赖。
- #366：observe 正确归因当前 Codex Desktop exec trace，并避免命令输出中的源码文本制造工具失败。

## 兼容性

这是向后兼容的 patch release，不改变 Report schema、评分 prompt 或 eval 测量口径，没有迁移步骤。合并后由 annotated tag `v0.51.1` 触发 npm provenance 发布与 GitHub Release。