### PR TITLE
fix(eval-core): 统一事实检查的共享证据来源

### DIFF
--- a/src/eval-core/evaluation-execution.ts
+++ b/src/eval-core/evaluation-execution.ts
@@ -381,13 +381,14 @@ export async function executeTasks({
 
     let factCheck: FactCheckResult | undefined;
     if (execResult!.ok && execResult!.output) {
-      const sampleRoot = samplesBaseDir ?? dirname(resolve(samplesPath));
       const sharedEvidence: FactCheckEvidence = {
         ...(task._sample.context && { context: task._sample.context }),
         ...(task._sample.environment?.files_available?.length && {
           declaredFiles: task._sample.environment.files_available,
         }),
-        ...(task._sample.cwd && { cwd: resolve(sampleRoot, task._sample.cwd) }),
+        // Resolve exactly like the executor's cwd. samplesBaseDir is for bundle
+        // assets such as mocks, not for changing Sample.cwd path semantics.
+        ...(task._sample.cwd && { cwd: resolve(task._sample.cwd) }),
       };
       factCheck = checkFacts(execResult!.output, sharedEvidence);
     }

--- a/src/eval-core/evaluation-execution.ts
+++ b/src/eval-core/evaluation-execution.ts
@@ -3,7 +3,7 @@ import { buildVariantResult } from './schema.js';
 import { safeSliceForJson } from '../util/safe-slice.js';
 import { grade } from '../grading/index.js';
 import { checkFacts } from './fact-checker.js';
-import type { FactCheckResult } from './fact-checker.js';
+import type { FactCheckEvidence, FactCheckResult } from './fact-checker.js';
 import { resolveExecutionStrategy } from './execution-strategy.js';
 import { DEFAULT_CACHE_DIR, DEFAULT_ISOLATED_CWD_DIR } from './default-dirs.js';
 import { getExecutorRuntimeFingerprint } from '../executors/runtime-fingerprint.js';
@@ -380,8 +380,16 @@ export async function executeTasks({
     }
 
     let factCheck: FactCheckResult | undefined;
-    if (execResult!.ok && execResult!.output && task.cwd) {
-      factCheck = checkFacts(execResult!.output, resolve(task.cwd));
+    if (execResult!.ok && execResult!.output) {
+      const sampleRoot = samplesBaseDir ?? dirname(resolve(samplesPath));
+      const sharedEvidence: FactCheckEvidence = {
+        ...(task._sample.context && { context: task._sample.context }),
+        ...(task._sample.environment?.files_available?.length && {
+          declaredFiles: task._sample.environment.files_available,
+        }),
+        ...(task._sample.cwd && { cwd: resolve(sampleRoot, task._sample.cwd) }),
+      };
+      factCheck = checkFacts(execResult!.output, sharedEvidence);
     }
 
     const sampleResults = ownRecordValue(results, task.sample_id)

--- a/src/eval-core/fact-checker.ts
+++ b/src/eval-core/fact-checker.ts
@@ -20,6 +20,15 @@ export interface FactCheckResult {
   verifiedRate: number;
 }
 
+export interface FactCheckEvidence {
+  /** Shared sample fixture root. Arm-specific execution directories must not be used. */
+  cwd?: string;
+  /** Facts supplied to both arms in the sample context. */
+  context?: string;
+  /** Declarative fixture paths from sample.environment.files_available. */
+  declaredFiles?: string[];
+}
+
 // Patterns that look like file/directory paths in agent output
 const PATH_PATTERNS = [
   // Explicit code paths: repos/xxx, src/xxx, lib/xxx, packages/xxx
@@ -40,6 +49,11 @@ const IGNORE_PATTERNS = [
   /^index\.\w+$/,
 ];
 
+// Product/runtime names that happen to end in a supported source extension.
+const NON_PATH_REFERENCES = new Set([
+  'node.js',
+]);
+
 /**
  * Extract file path claims from agent output text.
  */
@@ -55,7 +69,11 @@ export function extractPathClaims(output: string): string[] {
       path = path.replace(/[.,;:!?）)]+$/, '');
       // Clean trailing backtick/quote
       path = path.replace(/[`'"]+$/, '');
-      if (path.length > 3 && !IGNORE_PATTERNS.some((p) => p.test(path))) {
+      if (
+        path.length > 3
+        && !NON_PATH_REFERENCES.has(path.toLowerCase())
+        && !IGNORE_PATTERNS.some((p) => p.test(path))
+      ) {
         paths.add(path);
       }
     }
@@ -64,29 +82,87 @@ export function extractPathClaims(output: string): string[] {
   return [...paths];
 }
 
-/**
- * Check facts in agent output by verifying file paths exist in cwd.
- */
-export function checkFacts(output: string, cwd: string): FactCheckResult {
-  const pathClaims = extractPathClaims(output);
-  const root = resolve(cwd);
+function normalizeEvidencePath(path: string): string {
+  return path
+    .trim()
+    .replace(/^['"`]+|['"`]+$/g, '')
+    .replace(/\\/g, '/')
+    .replace(/^(?:\$SKILL_DIR|~)\//, '')
+    .replace(/^\.\//, '')
+    .replace(/\/+$/, '');
+}
 
-  const claims: FactClaim[] = pathClaims.map((path) => {
-    const fullPath = resolve(root, path);
-    const relativePath = relative(root, fullPath);
-    const insideCwd = relativePath === ''
-      || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
-    const exists = insideCwd && existsSync(fullPath);
-    return {
-      type: 'file-path',
-      value: path,
-      verified: exists,
-      ...(!exists && {
+function isRootedEvidencePath(path: string): boolean {
+  return path.startsWith('/') || /^[a-zA-Z]:\//.test(path);
+}
+
+function refersToSamePath(left: string, right: string): boolean {
+  const a = normalizeEvidencePath(left);
+  const b = normalizeEvidencePath(right);
+  return a === b
+    || (isRootedEvidencePath(a) && !isRootedEvidencePath(b) && a.endsWith(`/${b}`))
+    || (isRootedEvidencePath(b) && !isRootedEvidencePath(a) && b.endsWith(`/${a}`));
+}
+
+/**
+ * Check file-path facts against sample-level evidence shared by every arm.
+ *
+ * A string keeps the legacy direct-filesystem API for callers outside the
+ * evaluation pipeline. The pipeline passes structured evidence and deliberately
+ * excludes each artifact's execution cwd, because that directory is not a
+ * comparable source of truth across control and treatment arms.
+ */
+export function checkFacts(
+  output: string,
+  evidence: string | FactCheckEvidence,
+): FactCheckResult {
+  const pathClaims = extractPathClaims(output);
+  const sources: FactCheckEvidence = typeof evidence === 'string'
+    ? { cwd: evidence }
+    : evidence;
+  const root = sources.cwd ? resolve(sources.cwd) : null;
+  const contextClaims = sources.context
+    ? extractPathClaims(sources.context)
+    : [];
+  const declaredFiles = sources.declaredFiles ?? [];
+
+  const claims = pathClaims.flatMap<FactClaim>((path) => {
+    if (declaredFiles.some((declared) => refersToSamePath(path, declared))) {
+      return [{
+        type: 'file-path',
+        value: path,
+        verified: true,
+        evidence: 'source=fixture(sample.environment.files_available)',
+      }];
+    }
+
+    if (root) {
+      const fullPath = resolve(root, path);
+      const relativePath = relative(root, fullPath);
+      const insideCwd = relativePath === ''
+        || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+      const exists = insideCwd && existsSync(fullPath);
+      return [{
+        type: 'file-path',
+        value: path,
+        verified: exists,
         evidence: insideCwd
-          ? `${fullPath} not found`
-          : `${path} is outside the evaluation cwd`,
-      }),
-    };
+          ? `source=runtime-filesystem(sample.cwd); ${fullPath} ${exists ? 'exists' : 'not found'}`
+          : `source=runtime-filesystem(sample.cwd); ${path} is outside the evaluation cwd`,
+      }];
+    }
+
+    if (contextClaims.some((contextPath) => refersToSamePath(path, contextPath))) {
+      return [{
+        type: 'file-path',
+        value: path,
+        verified: true,
+        evidence: 'source=context(sample.context)',
+      }];
+    }
+
+    // Without a shared fixture, absence from context is unknown rather than false.
+    return [];
   });
 
   const verifiedCount = claims.filter((c) => c.verified).length;

--- a/src/eval-core/fact-checker.ts
+++ b/src/eval-core/fact-checker.ts
@@ -147,8 +147,8 @@ export function checkFacts(
         value: path,
         verified: exists,
         evidence: insideCwd
-          ? `source=runtime-filesystem(sample.cwd); ${fullPath} ${exists ? 'exists' : 'not found'}`
-          : `source=runtime-filesystem(sample.cwd); ${path} is outside the evaluation cwd`,
+          ? `source=runtime-filesystem; ${fullPath} ${exists ? 'exists' : 'not found'}`
+          : `source=runtime-filesystem; ${path} is outside the evaluation cwd`,
       }];
     }
 

--- a/test/eval-core/fact-checker.test.ts
+++ b/test/eval-core/fact-checker.test.ts
@@ -111,7 +111,7 @@ describe('fact-checker path extraction', () => {
       assert.equal(result.verifiedCount, 1);
       assert.match(
         result.claims[0].evidence || '',
-        /^source=runtime-filesystem\(sample\.cwd\); .*\/app\.js exists$/,
+        /^source=runtime-filesystem; .*\/app\.js exists$/,
       );
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/test/eval-core/fact-checker.test.ts
+++ b/test/eval-core/fact-checker.test.ts
@@ -7,6 +7,9 @@ import {
   checkFacts,
   extractPathClaims,
 } from '../../src/eval-core/fact-checker.js';
+import { executeTasks } from '../../src/eval-core/evaluation-execution.js';
+import { buildTasksFromArtifacts } from '../../src/eval-core/task-planner.js';
+import type { Artifact, ExecutorFn, Sample } from '../../src/types/index.js';
 
 describe('fact-checker path extraction', () => {
   it('does not treat method calls as file paths', () => {
@@ -18,6 +21,11 @@ describe('fact-checker path extraction', () => {
     const claims = extractPathClaims('Update eval-samples.json and src/cli/index.ts.');
     assert.ok(claims.includes('eval-samples.json'));
     assert.ok(claims.includes('src/cli/index.ts'));
+  });
+
+  it('does not treat Node.js as a file path', () => {
+    const claims = extractPathClaims('The Node.js service sends traces to app.ts.');
+    assert.deepEqual(claims, ['app.ts']);
   });
 
   it('extracts neutral and provider-compatible agent paths', () => {
@@ -51,5 +59,118 @@ describe('fact-checker path extraction', () => {
       rmSync(root, { recursive: true, force: true });
       rmSync(outside, { recursive: true, force: true });
     }
+  });
+
+  it('labels facts supplied by the shared sample context', () => {
+    const result = checkFacts(
+      'Initialize Sentry in src/app.ts.',
+      { context: 'The confirmed application entry is src/app.ts.' },
+    );
+
+    assert.equal(result.verifiedCount, 1);
+    assert.equal(result.claims[0].evidence, 'source=context(sample.context)');
+  });
+
+  it('labels declarative fixture evidence', () => {
+    const result = checkFacts(
+      'Run scripts/verify.sh.',
+      { declaredFiles: ['$SKILL_DIR/scripts/verify.sh'] },
+    );
+
+    assert.equal(result.verifiedCount, 1);
+    assert.equal(
+      result.claims[0].evidence,
+      'source=fixture(sample.environment.files_available)',
+    );
+  });
+
+  it('does not turn an uncheckable path into a failed fact', () => {
+    const result = checkFacts(
+      'Consider adding src/optional.ts.',
+      { context: 'The confirmed application entry is src/app.ts.' },
+    );
+
+    assert.equal(result.totalCount, 0);
+  });
+
+  it('does not equate different relative paths by basename alone', () => {
+    const result = checkFacts(
+      'Use src/app.ts.',
+      { context: 'The legacy entry is app.ts.' },
+    );
+
+    assert.equal(result.totalCount, 0);
+  });
+
+  it('labels checks against the shared sample filesystem', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omk-fact-fixture-'));
+    try {
+      writeFileSync(join(root, 'app.js'), 'App({});');
+      const result = checkFacts('Use app.js.', { cwd: root });
+
+      assert.equal(result.verifiedCount, 1);
+      assert.match(
+        result.claims[0].evidence || '',
+        /^source=runtime-filesystem\(sample\.cwd\); .*\/app\.js exists$/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the same shared evidence for control and treatment arms', async () => {
+    const sample: Sample = {
+      sample_id: 'symmetric-facts',
+      prompt: 'Describe the integration.',
+      context: 'app.js is the confirmed application entry.',
+    };
+    const artifacts: Artifact[] = [
+      { name: 'baseline', kind: 'baseline', source: 'baseline', content: null },
+      {
+        name: 'treatment',
+        kind: 'skill',
+        source: 'custom',
+        content: 'Use the project entry.',
+        skillRoot: '/tmp/arm-specific-skill-tree',
+      },
+    ];
+    const executor: ExecutorFn = async () => ({
+      ok: true,
+      output: 'Update app.js for the Node.js service.',
+      durationMs: 1,
+      durationApiMs: 1,
+      inputTokens: 1,
+      outputTokens: 1,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUSD: 0,
+      stopReason: 'end_turn',
+      numTurns: 1,
+    });
+    const tasks = buildTasksFromArtifacts([sample], artifacts);
+
+    const { results } = await executeTasks({
+      tasks,
+      executor,
+      executorName: 'test',
+      model: 'test-model',
+      noJudge: true,
+      samplesPath: '/tmp/samples.json',
+      concurrency: 1,
+      noCache: true,
+      verbose: false,
+      judgeModels: [{ executor: 'test', model: 'test-judge' }],
+      judgeExecutors: { test: executor },
+    });
+
+    const baseline = results['symmetric-facts'].baseline.factCheck;
+    const treatment = results['symmetric-facts'].treatment.factCheck;
+    assert.deepEqual(treatment, baseline);
+    assert.deepEqual(baseline?.claims, [{
+      type: 'file-path',
+      value: 'app.js',
+      verified: true,
+      evidence: 'source=context(sample.context)',
+    }]);
   });
 });


### PR DESCRIPTION
## 用户影响

修复 A/B 评测中事实检查只惩罚 treatment 的系统性偏差。控制组与实验组现在只使用样本级共享证据，不再把某个知识载体的隔离执行目录当作事实真值。

样本 `context`、`environment.files_available` 和 `sample.cwd` 会在报告的既有 `evidence` 字段中标明来源；无法由共享证据判断的路径保持未知，不再按事实错误扣分。`Node.js` 等技术名称也不会再被误识别为文件路径。

## 测量学说明

本修复不改 Report schema、评分 prompt、评分公式或长度去偏语义。它移除 arm-specific 证据造成的 construct contamination，并保持旧的 `checkFacts(output, cwd)` 调用兼容。

Closes #363