### PR TITLE
fix(executors): 阻止 Codex mock 失配产生伪证据

### DIFF
--- a/.agents/skills/omk/SKILL.md
+++ b/.agents/skills/omk/SKILL.md
@@ -123,6 +123,8 @@ omk sample skills/my-skill/SKILL.md --focus "重点覆盖搜索失败 / 权限�
 omk sample --batch
 ```
 
+目标执行器不支持工具拦截时，`omk sample` 会自动生成无 mock 用例。当前 `codex` / `codex-sdk` 属于这种情况；不要手工补 `mocks` 或 `mock_hit`。已有 mocks 用例会被 `omk eval` 在模型调用前拒绝，避免把执行器能力缺口误判成模型失败。`environment.files_available` 只提供题设上下文，不会在 `cwd` 物化文件。
+
 输出位置：目录 skill（`<skill>/SKILL.md`）→ `<skill>/.omk/samples.json`（标准）；扁平 `.md` 单次生成 → 当前目录 `eval-samples.json`（项目级兜底）；扁平 `.md` 的 `--batch` 兼容生成 `<skill-dir>/<name>.eval-samples.json`。
 
 ### 观测真实使用

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -602,7 +602,7 @@ omk sample [skillPath] [flags]
 - `--from-traces` `boolean`:from-traces 模式：从 observe inbox 的失败信号回流生成评测用例草稿（provenance: production-trace），落草稿待人工 review。
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
 - `--model` `option`:生成 LLM model 名。Codex 自动读取本机配置；也可用 OMK_MODEL 设置环境偏好。
-- `--no-mock` `boolean`:不生成 mocks，eval 时所有工具调用真实执行。
+- `--no-mock` `boolean`:不生成 mocks。执行器不支持工具拦截时会自动启用，避免产生必然失败的 mock_hit。
 - `--observations-dir` `option`:observe inbox 目录（from-traces 模式用），默认项目 .omk/observe-inbox。
 - `--reports-dir` `option`:报告目录（fix 模式用），默认 ~/.oh-my-knowledge/reports。
 - `--skill` `option`:仅从指定 skill 的 observe inbox 信号生成草稿（仅 from-traces 模式用）。
@@ -689,7 +689,7 @@ omk studio --port 8080 --no-open
 | `construct` | 否 | 测的是什么构念 |
 | `provenance` | 否 | 用例来源（`omk sample` 自动打） |
 | `mocks` | 否 | 工具调用 mock 返回（sandbox 评测） |
-| `environment` | 否 | 评测环境前置「已就绪」声明 |
+| `environment` | 否 | 题设环境声明（仅注入 prompt，不物化） |
 | `tripwire` | 否 | 标记为「故意诱错」样本，failed 时 diagnostic 不建议改 skill |
 
 完整 schema 见 [docs/specs/sample-design-spec.md](https://github.com/lizhiyao/oh-my-knowledge/blob/main/docs/specs/sample-design-spec.md)。

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -426,7 +426,7 @@ omk sample --batch                  # generate for skills missing eval-samples
   --from-traces               from-traces mode: recycle observe-inbox failure signals into draft regression samples (provenance: production-trace) for review.
   --lang <value>              Output language zh|en. Priority: CLI > OMK_LANG env > zh.
   --model <value>             Generation LLM model name. Codex reads the local configured model; OMK_MODEL sets an environment preference.
-  --no-mock                   Skip mock generation; all tool calls execute for real during eval.
+  --no-mock                   Skip mocks. Automatically enabled when the executor cannot intercept tools, preventing impossible mock_hit assertions.
   --observations-dir <value>  Observe inbox dir (from-traces mode), default project .omk/observe-inbox.
   --reports-dir <value>       Reports dir (fix mode), default ~/.oh-my-knowledge/reports.
   --skill <value>             Only draft from observe-inbox signals for the specified skill (from-traces mode only).

--- a/docs/reference/eval-sample-format.md
+++ b/docs/reference/eval-sample-format.md
@@ -72,10 +72,14 @@ A sample can also carry **metadata** (documentation / diagnostics only — these
 | `construct` | `string` | what it measures: `necessity` / `quality` / `capability` (custom allowed) |
 | `provenance` | `'human' \| 'llm-generated' \| 'production-trace'` | data source |
 | `covers` | `{ targetKind, ref }[]` | optional declared skill-structure anchors for high-value samples; used by Skill Map only |
-| `mocks` | `object[]` | tool-call interception list — return fake data instead of really calling the tool |
+| `mocks` | `object[]` | tool-call interception list — requires an executor with mock-interception support |
 | `mocksStrict` | `boolean` | deny any tool call that matches no mock (default `false`) |
 | `tripwire` | `boolean` | trap sample: the LLM is **expected** to fail (default `false`) |
-| `environment` | `object` | declared "already provisioned" preconditions: `cli_available` / `files_available` / `notes` |
+| `environment` | `object` | prompt-only preconditions: `cli_available` / `files_available` / `notes`; does not materialize files or env vars |
+
+The loader also validates cross-field references. Every `mock_hit: "Tool:N"` must identify the Nth declared mock for that exact tool; a missing mock or out-of-range ordinal is a configuration error. Executor compatibility is checked separately before evaluation. See [executors](./executors#sample-mock-compatibility) for the support matrix.
+
+`mocks[].tool` uses the same source-neutral identity namespace as trace assertions (`Bash`, `Read`, `Edit`, and so on). Executor adapters normalize runtime-native names such as `exec_command`, `command_execution`, and `apply_patch` before matching. Exact native names remain accepted for backward compatibility and custom tools.
 
 `covers` is optional and intentionally explicit, not inferred from prompt text. Use it first on critical or high-signal samples, so Studio can draw declared structure edges without forcing every sample to become a maintenance task. Omitting `covers` means the structure edge is undeclared in Skill Map, not proven untested:
 

--- a/docs/reference/executors.md
+++ b/docs/reference/executors.md
@@ -16,6 +16,21 @@ An **executor** is the backend that runs an artifact against a model — it turn
 
 API-direct executors support custom base URLs via env: `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`.
 
+## Sample mock compatibility
+
+`Sample.mocks` requires the executor to intercept a tool call before the underlying tool runs. Tool traces alone are not enough: an executor that can report `Read` after execution cannot safely replace that call with a fixture.
+
+| Executor | `Sample.mocks` support |
+|---|---|
+| `claude` / `claude-sdk` | supported through native hooks |
+| `codex` / `codex-sdk` | unsupported; the current CLI and SDK expose traces but no tool-interception hook |
+| `gemini` / `anthropic-api` / `openai-api` | unsupported |
+| custom command | delegated through `OMK_MOCKS_FILE` / `OMK_MOCK_SETTINGS_FILE`; the command must install or consume the supplied hook |
+
+When the selected executor does not support interception, `omk sample` automatically generates mockless samples and removes positive evidence that would require a simulated call (`mock_hit`, `tools_called`, `tools_count_min`, `tool_input_contains`, and `tool_output_contains`). If a model still emits `environment`, its facts are moved into explicitly non-materialized `context` rather than discarded or presented as fixtures. `omk eval`, including `--dry-run` and `--skip-doctor`, rejects existing samples with mocks before any model call instead of silently turning harness incompatibility into a model failure.
+
+`environment.files_available` is prompt context only. It tells the model what the task statement assumes; it does not create a file in `cwd`. Put a real fixture under the sample working directory when the task must read physical bytes.
+
 ## How the default runtime is selected
 
 Precedence is: explicit CLI flag → `eval.yaml` → `OMK_*` environment preference → automatic detection.

--- a/docs/specs/sample-design-spec.md
+++ b/docs/specs/sample-design-spec.md
@@ -69,7 +69,7 @@ To run evals decoupled from the real external environment (databases / APIs / fi
     - { type: mock_hit, value: "Bash:1", weight: 1 }
   mocksStrict: true              # default true (generator-enforced); an unmatched tool call is denied outright, never passed through to the real call
   tripwire: false                # whether this sample is a "trap sample" (deliberately lures the LLM into the wrong move; failing is expected); default false
-  environment:                   # pre-eval "already provisioned" declaration; the LLM sees it and skips environment probing
+  environment:                   # prompt-only task assumptions; no files or env vars are materialized
     cli_available: ["log-cli"]
     files_available: ["~/.config/log-cli.json"]
     notes: "log-cli is authenticated, token in env var"
@@ -94,9 +94,9 @@ To run evals decoupled from the real external environment (databases / APIs / fi
 
 - **mocksStrict** (`boolean`, default `true`): a tool call that matches no mock is denied outright (the LLM sees a failure result). **Default behavior**: the `omk sample` generator force-writes `true` and the SYSTEM_PROMPT makes it explicit; for hand-written samples, the loader does not force-inject it when absent — an old sample without the field falls back to non-strict (passes through to the real call). **Strongly prefer `true` for new samples**, to avoid a missing mock letting the eval hit a real production system.
 - **tripwire** (`boolean`, default `false`): this sample is a "trap sample" whose prompt deliberately plants a lure that violates the rubric/skill (e.g. "I already know it's X, just use it"), testing whether the LLM blindly follows the user's wrong instruction. The LLM **failing is the expected outcome**; diagnostics seeing `tripwire: true` won't suggest changing the skill, and the UI uses a purple verdict pill to distinguish it from a bug.
-- **environment** (`object`, optional): a "ready" precondition declaration for the eval environment — after reading it the LLM skips environment probing (`which X` / `test -f Y` / `echo $Z`) and goes straight into the workflow. Think of it as a unit test's fixture / setup. **It is only a prompt hint to the LLM; it does not actually create files or export variables.** The doctor health check scans it for physical-path checks (skippable with `--skip-doctor`).
+- **environment** (`object`, optional): prompt-only task assumptions. The LLM may skip availability probes (`which X` / `test -f Y` / `echo $Z`) and go straight into the workflow, but omk does not create files, export variables, or alter `PATH`. It is not a fixture mechanism. The doctor health check can still audit declared physical paths (skippable with `--skip-doctor`).
   - `cli_available: string[]` — assumed already on `PATH`
-  - `files_available: string[]` — assumed-existing files/scripts
+  - `files_available: string[]` — file/script paths referenced by the task statement; use `sample.cwd` or mocks for readable bytes
   - `notes: string` — free-text fallback, describing credential / env-var state, etc.
 - **mocks** (`object[]`, optional): the tool-call interception list. At runtime, mocks are matched in array order, and the first hit returns one of `return` / `return_file` / `return_seq[hitCount]` as the tool_result.
   - **the `tool` field**: tool name (e.g. `"Bash"` / `"Read"` / `"Grep"`). The special value `"*"` wildcards any tool name, paired with `input_contains` for intent-level mocking.
@@ -109,6 +109,8 @@ To run evals decoupled from the real external environment (databases / APIs / fi
     - `input_contains: string` — recursively scans all string values in tool_input; a hit if any contains the substring (case-insensitive). **Pair with `tool: "*"` for intent-level mocking**: when the LLM searches code it might use Bash grep / the Grep tool / Glob / Read / Agent / any tool; use `input_contains` to match intent by keyword instead of enumerating tools one by one. Example: `{tool: "*", match: {input_contains: "MyServiceName"}, return: "<service .../>"}` — any tool hits as long as its input mentions MyServiceName.
   - **`return` has three forms**: string / `{stdout, stderr, exit}` (simulates Bash) / `return_file` external file / `return_seq[]` state machine (the Nth hit on the same mock returns in order, falling back to `return` once exhausted).
 - **assertion-side mock_hit / tool_input_contains**: used together with mocks. `mock_hit: "Bash:2"` means "the 2nd Bash mock must be hit at least once", proving the LLM reached that step. `tool_input_contains: "Bash:logstore_query"` checks that the Bash command string contains `logstore_query`.
+  - Every `mock_hit` must reference a declared per-tool mock ordinal. The loader rejects missing or out-of-range references before execution.
+  - Mock support is an executor capability, not a trace capability. `claude` / `claude-sdk` install interception hooks; `codex`, `codex-sdk`, Gemini, and direct API executors currently do not. Unsupported executors auto-generate mockless samples and reject existing mocked samples before evaluation.
 
 **Relationship to grading / judge**: the sandbox fields (mocks / environment / tripwire / mocksStrict) **never enter the judge prompt** — the judge sees only prompt + rubric + LLM output + trace summary. tripwire only affects the diagnostic's attribution suggestion (the `tripwire_intentional` rootCause); it does not affect the layered scores or the verdict.
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -426,7 +426,7 @@ omk sample --batch                  # 为目录下缺评测集的 skill 批量�
   --from-traces               from-traces 模式：从 observe inbox 的失败信号回流生成评测用例草稿（provenance: production-trace），落草稿待人工 review。
   --lang <value>              输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
   --model <value>             生成 LLM model 名。Codex 自动读取本机配置；也可用 OMK_MODEL 设置环境偏好。
-  --no-mock                   不生成 mocks，eval 时所有工具调用真实执行。
+  --no-mock                   不生成 mocks。执行器不支持工具拦截时会自动启用，避免产生必然失败的 mock_hit。
   --observations-dir <value>  observe inbox 目录（from-traces 模式用），默认项目 .omk/observe-inbox。
   --reports-dir <value>       报告目录（fix 模式用），默认 ~/.oh-my-knowledge/reports。
   --skill <value>             仅从指定 skill 的 observe inbox 信号生成草稿（仅 from-traces 模式用）。

--- a/docs/zh/reference/eval-sample-format.md
+++ b/docs/zh/reference/eval-sample-format.md
@@ -72,10 +72,14 @@ loader 会在任何模型调用前校验完整契约。不支持的断言类型�
 | `construct` | `string` | 测什么：`necessity` / `quality` / `capability`（允许自定义） |
 | `provenance` | `'human' \| 'llm-generated' \| 'production-trace'` | 数据来源 |
 | `covers` | `{ targetKind, ref }[]` | 可选声明的 skill 结构锚点，建议先用于关键用例；仅用于 Skill Map |
-| `mocks` | `object[]` | 工具调用拦截列表 —— 返回假数据而非真调工具 |
+| `mocks` | `object[]` | 工具调用拦截列表 —— 要求执行器支持 mock 拦截 |
 | `mocksStrict` | `boolean` | 未命中任何 mock 的工具调用直接 deny（默认 `false`） |
 | `tripwire` | `boolean` | 诱错样本：LLM **应当** fail（默认 `false`） |
-| `environment` | `object` | 声明性「已就绪」前置：`cli_available` / `files_available` / `notes` |
+| `environment` | `object` | 仅作 prompt 上下文的前置：`cli_available` / `files_available` / `notes`；不会物化文件或环境变量 |
+
+loader 还会校验跨字段引用。每条 `mock_hit: "Tool:N"` 必须指向该工具声明的第 N 条 mock；mock 不存在或序号越界都属于配置错误。执行器兼容性会在评测前单独检查，支持矩阵见[执行器](./executors#sample-mock-兼容性)。
+
+`mocks[].tool` 与 trace 断言使用同一套 source-neutral 工具身份（如 `Bash`、`Read`、`Edit`）。executor adapter 会先把 `exec_command`、`command_execution`、`apply_patch` 等 runtime-native 名称归一化再匹配；为兼容旧用例和自定义工具，原生名称的精确匹配仍然保留。
 
 `covers` 是可选的显式声明字段，不从 prompt 文本里推断。建议先给关键用例、关键 reference / workflow / hard rule 声明它，让 Studio 能画出已声明的结构边，而不是要求每条用例都变成维护负担。不写只表示 Skill Map 暂无这条声明边，不代表该结构一定没被测到：
 

--- a/docs/zh/reference/executors.md
+++ b/docs/zh/reference/executors.md
@@ -16,6 +16,21 @@
 
 API 直调执行器支持通过环境变量自定义 Base URL：`ANTHROPIC_BASE_URL`、`OPENAI_BASE_URL`。
 
+## Sample mock 兼容性
+
+`Sample.mocks` 要求执行器能在底层工具真正运行前拦截调用。仅能事后输出 tool trace 并不等于支持 mock：执行器即使能记录 `Read`，也未必能用 fixture 替换这次调用。
+
+| 执行器 | `Sample.mocks` 支持 |
+|--------|---------------------|
+| `claude` / `claude-sdk` | 支持，通过原生 hooks 拦截 |
+| `codex` / `codex-sdk` | 不支持；当前 CLI 和 SDK 能输出 trace，但没有工具拦截 hook |
+| `gemini` / `anthropic-api` / `openai-api` | 不支持 |
+| 自定义命令 | 通过 `OMK_MOCKS_FILE` / `OMK_MOCK_SETTINGS_FILE` 委托；命令必须安装或消费 omk 提供的 hook |
+
+目标执行器不支持拦截时，`omk sample` 会自动生成无 mock 用例，并移除依赖模拟调用的正向证据（`mock_hit`、`tools_called`、`tools_count_min`、`tool_input_contains`、`tool_output_contains`）。模型若仍输出 `environment`，其中的事实会迁移到明确标注「未物化」的 `context`，不会被丢弃或冒充 fixture。`omk eval` 会在任何模型调用前拒绝已有的 mocks 用例；`--dry-run` 和 `--skip-doctor` 也不能绕过，避免把评测环境不兼容误算成模型失败。
+
+`environment.files_available` 仅是题设上下文，不会在 `cwd` 创建文件。任务必须读取真实字节时，应把 fixture 放进用例工作目录。
+
 ## 默认 runtime 怎么选
 
 CLI、`eval.yaml` 和环境变量的优先级是：显式 CLI flag → `eval.yaml` → `OMK_*` 环境偏好 → 自动检测。

--- a/docs/zh/specs/sample-design-spec.md
+++ b/docs/zh/specs/sample-design-spec.md
@@ -69,7 +69,7 @@ samples:
     - { type: mock_hit, value: "Bash:1", weight: 1 }
   mocksStrict: true              # 默认 true（generator 强制）；未命中的工具调用直接 deny，不透传真调
   tripwire: false                # 此 sample 是否「诱错样本」（故意诱导 LLM 走错，fail 是预期）；默认 false
-  environment:                   # 评测环境前置「已就绪」声明，LLM 看到后跳过环境探测
+  environment:                   # 仅作 prompt 上下文的题设环境声明，不物化文件或环境变量
     cli_available: ["log-cli"]
     files_available: ["~/.config/log-cli.json"]
     notes: "log-cli 已认证，token 在环境变量"
@@ -94,9 +94,9 @@ samples:
 
 - **mocksStrict**（boolean，默认 true）：未命中任何 mock 的工具调用直接 `deny`（LLM 看到失败结果）。**默认行为**：`omk sample` 生成器强制写 true，SYSTEM_PROMPT 明确；手写 sample 缺位时 sample 加载层不强制注入 —— 老 sample 不写默认走非 strict（透传真调）。**新写 sample 强烈建议 true**，避免漏 mock 导致评测打到真生产系统。
 - **tripwire**（boolean，默认 false）：此 sample 是「诱错样本」，prompt 故意藏违反 rubric/skill 的诱导（如 "我已经知道是 X，直接用就行"），测试 LLM 是否会盲从用户错误指示。LLM **fail 是预期**，diagnostic 看到 `tripwire: true` 不会建议改 skill；UI 用紫色 verdict pill 区分，避免误判为 bug。
-- **environment**（object，可选）：评测环境前置「已就绪」声明 —— LLM 看到这段后跳过环境探测（`which X` / `test -f Y` / `echo $Z`）直接进工作流。类比 unit test 的 fixture / setup。**仅作 prompt 提示给 LLM，不实际创建文件 / export 变量**。doctor 健康检查会扫这段做物理路径检查（可用 `--skip-doctor` 跳过）。
+- **environment**（object，可选）：仅作 prompt 上下文的题设环境声明。LLM 可以据此跳过可用性探测（`which X` / `test -f Y` / `echo $Z`）直接进工作流，但 omk 不会创建文件、导出环境变量或修改 `PATH`。它不是 fixture 机制。doctor 仍可审计声明的物理路径（可用 `--skip-doctor` 跳过）。
   - `cli_available: string[]` —— 假定已在 PATH 上
-  - `files_available: string[]` —— 假定已存在的文件/脚本
+  - `files_available: string[]` —— 题设引用的文件 / 脚本路径；需要读取真实字节时应使用 `sample.cwd` 或 mocks
   - `notes: string` —— 自由文本兜底，描述凭证 / 环境变量状态等
 - **mocks**（object[]，可选）：工具调用拦截列表。运行时按数组顺序匹配第一条命中的 mock，返回 `return` / `return_file` / `return_seq[hitCount]` 之一作为 tool_result。
   - **`tool` 字段**：工具名（如 `"Bash"` / `"Read"` / `"Grep"`）。特殊值 `"*"`：通配任何工具名，配合 `input_contains` 做 intent-level mock。
@@ -109,6 +109,8 @@ samples:
     - `input_contains: string` —— 递归扫描 tool_input 所有 string 值，任一含该子串即命中（大小写不敏感）。**配合 `tool: "*"` 做 intent-level mock**：LLM 搜代码时可能用 Bash grep / Grep 工具 / Glob / Read / Agent 等任意工具，用 `input_contains` 按关键词匹配意图，不用逐个枚举工具。示例：`{tool: "*", match: {input_contains: "MyServiceName"}, return: "<service .../>"}` —— 任何工具只要输入提到 MyServiceName 就命中。
   - **`return` 三种形式**：string / `{stdout, stderr, exit}`（模拟 Bash）/ `return_file` 外置文件 / `return_seq[]` 状态机（同 mock 第 N 次命中按序返回，超出回退 `return`）。
 - **断言侧的 mock_hit / tool_input_contains**：配合 mocks 使用。`mock_hit: "Bash:2"` 表示「第 2 条 Bash mock 必须被命中至少一次」，证明 LLM 走到了那一步。`tool_input_contains: "Bash:logstore_query"` 验证 Bash 命令字符串里包含 `logstore_query`。
+  - 每条 `mock_hit` 必须指向该工具已经声明的 mock 序号。引用不存在或越界时，loader 会在执行前拒绝用例。
+  - mock 支持是执行器能力，不是 trace 能力。`claude` / `claude-sdk` 会安装拦截 hooks；`codex`、`codex-sdk`、Gemini 和 API 直调执行器目前不支持。选择不支持的执行器时，生成阶段自动切换为无 mock 用例，评测阶段则在运行前拒绝已有 mocks 用例。
 
 **与 grading / judge 的关系**：沙箱字段（mocks / environment / tripwire / mocksStrict）**不进 judge prompt**，judge 看到的只有 prompt + rubric + LLM 输出 + trace summary。tripwire 仅影响 diagnostic 的归因建议（`tripwire_intentional` rootCause），不影响 layered scores 或 verdict。
 

--- a/src/authoring/generator.ts
+++ b/src/authoring/generator.ts
@@ -1,6 +1,13 @@
 import { createExecutor } from '../executors/index.js';
+import { executorSupportsSampleMocks } from '../executors/capabilities.js';
 import { DEFAULT_GATE_THRESHOLD } from '../eval-core/verdict.js';
-import type { Sample, SampleProvenance, ExecutorFn } from '../types/index.js';
+import { sampleMockReferenceKeys } from '../shared/sample-contract.js';
+import type {
+  Assertion,
+  ExecutorFn,
+  Sample,
+  SampleProvenance,
+} from '../types/index.js';
 import type { ObservationInboxItem } from '../types/observability.js';
 
 const SYSTEM_PROMPT = `你是一个评测用例生成器。你的任务是根据用户提供的 skill（系统提示词）内容，生成高质量的评测用例。
@@ -198,14 +205,14 @@ const SYSTEM_PROMPT = `你是一个评测用例生成器。你的任务是根据
         tool_input_not_contains 或 tools_not_called。
   - { "type": "regex", "pattern": "...", "weight": 1 }
         ↑ 同 contains 限制:只用在固定格式字面量(如 SHA / UUID / 路径模板)。
-- environment: 可选,对象。**评测环境的"已就绪"声明**,LLM 看到后跳过环境探测直接进工作流。
+- environment: 可选,对象。**仅作 prompt 上下文的题设环境声明**,不会修改 PATH、创建文件或物化 fixture。
   字段:
     - cli_available: string[],已在 PATH 上的 CLI(如 ["node", "git", "code-host"])
     - files_available: string[],已存在的文件/脚本(如 ["~/.req-tool-api.json", "$SKILL_DIR/scripts/x.js"])
     - notes: string,自由文本兜底(如"DevAPI 凭证有效,工号 testuser001")
   原则:
-    凡是 skill 跑起来需要的环境(凭证文件 / 业务 CLI / 自带脚本 / API token 等),
-    都写到这里,而不是在 mock 里 mock 它们的探测命令。这让 mock 只关注业务调用本身。
+    只有用例明确把某项环境能力作为题设前提时才写。需要读取真实内容的文件不能放在
+    files_available 里冒充 fixture:应放进 sample.cwd 下的真实 fixture,或由 mock 返回内容。
 - mocksStrict: **必填且必须设为 true**(只要 sample 配了 mocks)。
   原因:mocksStrict=false 时,LLM 调到没匹配 mock 的命令会**透传到真 shell**,
   既可能真调外部接口产生副作用,也可能因二进制不存在(如 mcporter)报噪声错误污染评测信号。
@@ -226,8 +233,8 @@ const SYSTEM_PROMPT = `你是一个评测用例生成器。你的任务是根据
            - 对(✅):写一条宽 mock:\`{tool:"Bash", match:{command_glob:"ls *"},
              return:{stdout:"<模拟目录列表>", exit:0}}\` — \`command_glob\` 用 \`*\` 兜底各种
              ls 参数变体(\`ls\` / \`ls -la\` / \`ls -d\` / \`ls /xx\` 全命中)
-       (c) 单纯"已就绪"声明(凭证文件 / 业务 CLI 是否安装)还是走 \`environment\` 字段,
-           不需要 LLM 真调命令检查 — environment 字段就是告诉 LLM "这些不用检查"。
+       (c) 题设明确声明可用的凭证 / CLI 可写进 \`environment\`,让 LLM 不做可用性探测。
+           该字段只进 prompt,不会真的安装 CLI、创建凭证文件或改变 runtime。
        (d) **intent-level mock(文件搜索/读取类操作)** — LLM 搜代码时会自由选择 Bash grep、
            Grep 工具、Glob+Read 组合、甚至 Agent 子代理,逐个枚举工具写 mock 不可持续。
            正确做法:用 \`tool: "*"\` + \`input_contains: "关键词"\` 按意图匹配:
@@ -371,7 +378,48 @@ const SYSTEM_PROMPT = `你是一个评测用例生成器。你的任务是根据
 - 例：错 → \`"prompt": "查询"Daily"标签..."\`（内部 \`"\` 未转义，JSON 解析失败）
        对 → \`"prompt": "查询「Daily」标签..."\`（全角引号，无转义压力）`;
 
-interface GenerateSamplesOptions {
+const MOCKLESS_SYSTEM_OVERRIDE = `
+
+## 目标执行器能力约束（最高优先级）
+
+目标执行器不支持可靠的工具调用拦截。本节覆盖上文所有要求 mocks、mock_hit、
+files_available 或正向工具调用断言的规则：
+
+- 不要输出 mocks、mocksStrict、environment 字段。
+- 不要输出 mock_hit、tools_called、tools_count_min、tool_input_contains、tool_output_contains。
+- 可以保留 tools_not_called、tools_count_max、tool_input_not_contains 这类负向安全约束。
+- 把必要的输入事实直接写进 context，把可判分结果写进 rubric 或输出内容断言。
+- 不要假装某个文件、CLI 或工具调用已经由 fixture 物化。`;
+
+function generationSystemPrompt(mockless: boolean): string {
+  return mockless ? `${SYSTEM_PROMPT}${MOCKLESS_SYSTEM_OVERRIDE}` : SYSTEM_PROMPT;
+}
+
+const warnedAutoMocklessExecutors = new Set<string>();
+
+function warnAutoMockless(executorName: string | undefined, noMock: boolean | undefined): void {
+  if (
+    noMock
+    || !executorName
+    || executorSupportsSampleMocks(executorName)
+    || warnedAutoMocklessExecutors.has(executorName)
+  ) return;
+  warnedAutoMocklessExecutors.add(executorName);
+  process.stderr.write(
+    `[omk sample] 执行器「${executorName}」不支持工具调用拦截，`
+    + '已自动切换为无 mocks 用例。\n',
+  );
+}
+
+export function sampleGenerationUsesMocks(
+  executorName: string | undefined,
+  noMock = false,
+): boolean {
+  if (noMock) return false;
+  return executorName ? executorSupportsSampleMocks(executorName) : true;
+}
+
+export interface GenerateSamplesOptions {
   skillContent: string;
   count?: number;
   model: string;
@@ -383,6 +431,8 @@ interface GenerateSamplesOptions {
   focus?: string;
   /** 不生成 mocks/mocksStrict，eval 时真实执行所有工具调用。 */
   noMock?: boolean;
+  /** Injectable executor for tests. Defaults to createExecutor(executorName). */
+  executor?: ExecutorFn;
 }
 
 /**
@@ -409,10 +459,21 @@ ${skillContent}
 ${countLine}直接输出 JSON 数组。${focusBlock}${noMockBlock}`;
 }
 
-export async function generateSamples({ skillContent, count, model, executorName, focus, noMock }: GenerateSamplesOptions): Promise<{ samples: Sample[]; costUSD: number }> {
-  const executor = createExecutor(executorName);
+export async function generateSamples({
+  skillContent,
+  count,
+  model,
+  executorName,
+  focus,
+  noMock,
+  executor: injectedExecutor,
+}: GenerateSamplesOptions): Promise<{ samples: Sample[]; costUSD: number }> {
+  const executor = injectedExecutor ?? createExecutor(executorName);
+  const mockless = !sampleGenerationUsesMocks(executorName, noMock);
+  warnAutoMockless(executorName, noMock);
 
-  const prompt = buildSamplesPrompt({ skillContent, count, focus, noMock });
+  const prompt = buildSamplesPrompt({ skillContent, count, focus, noMock: mockless });
+  const system = generationSystemPrompt(mockless);
 
   // 生成场景比单次 eval 调用更重(LLM 要思考结构 + 输出大段 JSON),
   // 默认 120s 对长 skill + count >= 8 经常不够,这里用 5 分钟兜底。
@@ -426,7 +487,7 @@ export async function generateSamples({ skillContent, count, model, executorName
     const attemptPrompt = attempt === 1
       ? prompt
       : `${prompt}\n\n上一次输出解析失败:${lastErr}\n请严格按 JSON 规范输出(字符串内部用「」全角引号),只输出数组,不要包含其他文字。`;
-    const result = await executor({ model, system: SYSTEM_PROMPT, prompt: attemptPrompt, timeoutMs: 300_000, lean: true });
+    const result = await executor({ model, system, prompt: attemptPrompt, timeoutMs: 300_000, lean: true });
     totalCost += result.costUSD || 0;
     if (!result.ok) {
       lastErr = result.error || 'unknown error';
@@ -452,7 +513,10 @@ export async function generateSamples({ skillContent, count, model, executorName
       continue;
     }
     // 通过校验,跳出循环继续后续 sanitize
-    return await finalizeSamples(samples, totalCost, skillContent);
+    return await finalizeSamples(samples, totalCost, {
+      skillContent,
+      mockless,
+    });
   }
   // 不可达 (循环里所有出口都 throw 或 return),保留是为了 TS 类型推断
   throw new Error('unreachable');
@@ -461,7 +525,10 @@ export async function generateSamples({ skillContent, count, model, executorName
 async function finalizeSamples(
   samples: Sample[],
   costUSD: number,
-  skillContent: string,
+  options: {
+    skillContent: string;
+    mockless: boolean;
+  },
 ): Promise<{ samples: Sample[]; costUSD: number }> {
   // Validate required fields + sanitize metadata enums *at generator boundary*
   // (see sanitizeGeneratedSamples). skillContent is passed so the function can
@@ -470,7 +537,10 @@ async function finalizeSamples(
   // the data-security-review v1-v5 regen series (generator kept producing
   // tool_input_contains "WebFetch:语雀URL" even after 7 prompt iterations,
   // because LLM's "URL → fetch" training prior overrides instructional text).
-  const { stripped } = sanitizeGeneratedSamples(samples, { skillContent });
+  const { stripped } = sanitizeGeneratedSamples(samples, {
+    ...options,
+    migrateMocklessEnvironment: true,
+  });
   if (stripped.length > 0) {
     process.stderr.write(
       `[omk sample] LLM-output 含 ${stripped.length} 个非法元数据/断言字段，已剥离避免污染：\n  - ${stripped.join('\n  - ')}\n`,
@@ -531,7 +601,11 @@ export function stratifyTraceSignals(items: TraceSignalItem[]): StratifiedTraceS
  * production failures. The trace text feeds the *generator* only — never the
  * judge prompt — so judge-prompt isolation is unaffected.
  */
-export function buildSamplesFromTracesPrompt(items: TraceSignalItem[], count?: number): string {
+export function buildSamplesFromTracesPrompt(
+  items: TraceSignalItem[],
+  count?: number,
+  options: { noMock?: boolean } = {},
+): string {
   // 先按频次分层（合并重复 + 算占比 + 降序），让模型按「占比」分配配额，而非每信号一刀切。
   const stratified = stratifyTraceSignals(items);
   const sections = stratified.map((it, i) => {
@@ -555,6 +629,9 @@ export function buildSamplesFromTracesPrompt(items: TraceSignalItem[], count?: n
   const countLine = typeof count === 'number'
     ? `共生成约 ${count} 条评测用例，按各信号的「占比」分配配额（高频多、低频少），覆盖整体失败分布。`
     : '按各信号「占比」分配：高频信号多生成、低频少生成，覆盖整体失败分布。';
+  const mocklessBlock = options.noMock
+    ? '\n\n目标执行器不支持工具调用拦截：不要生成 mocks、mocksStrict、environment 或正向工具调用断言；把 trace 证据写入 context 和 rubric。'
+    : '';
 
   return `${TRACE_GEN_INSTRUCTIONS}
 
@@ -562,7 +639,7 @@ export function buildSamplesFromTracesPrompt(items: TraceSignalItem[], count?: n
 
 ${sections}
 
-${countLine}直接输出 JSON 数组。`;
+${countLine}直接输出 JSON 数组。${mocklessBlock}`;
 }
 
 /** Build a sanitize context string from trace evidence so finalizeSamples keeps
@@ -581,6 +658,8 @@ export interface GenerateSamplesFromTracesOptions {
   count?: number;
   model: string;
   executorName?: string;
+  /** 不生成 mocks。目标 executor 不支持时会自动启用。 */
+  noMock?: boolean;
   /** Injectable executor (tests). Defaults to createExecutor(executorName). */
   executor?: ExecutorFn;
 }
@@ -596,6 +675,7 @@ export async function generateSamplesFromTraces({
   count,
   model,
   executorName,
+  noMock,
   executor: injectedExecutor,
 }: GenerateSamplesFromTracesOptions): Promise<{ samples: Sample[]; costUSD: number }> {
   if (items.length === 0) return { samples: [], costUSD: 0 };
@@ -603,7 +683,10 @@ export async function generateSamplesFromTraces({
     throw new Error('executorName is required when no executor is injected');
   }
   const executor = injectedExecutor ?? createExecutor(executorName!);
-  const prompt = buildSamplesFromTracesPrompt(items, count);
+  const mockless = !sampleGenerationUsesMocks(executorName, noMock);
+  warnAutoMockless(executorName, noMock);
+  const prompt = buildSamplesFromTracesPrompt(items, count, { noMock: mockless });
+  const system = generationSystemPrompt(mockless);
   const sanitizeContext = traceSanitizeContext(items);
   const PROVENANCE: SampleProvenance = 'production-trace';
 
@@ -614,7 +697,7 @@ export async function generateSamplesFromTraces({
     const attemptPrompt = attempt === 1
       ? prompt
       : `${prompt}\n\n上一次输出解析失败:${lastErr}\n请严格按 JSON 规范输出(字符串内部用「」全角引号),只输出数组,不要包含其他文字。`;
-    const result = await executor({ model, system: SYSTEM_PROMPT, prompt: attemptPrompt, timeoutMs: 300_000, lean: true });
+    const result = await executor({ model, system, prompt: attemptPrompt, timeoutMs: 300_000, lean: true });
     totalCost += result.costUSD || 0;
     if (!result.ok) {
       lastErr = result.error || 'unknown error';
@@ -644,7 +727,10 @@ export async function generateSamplesFromTraces({
     if (samples.length === 0) return { samples: [], costUSD: totalCost };
     // Stamp provenance before sanitize so it survives (it's a valid enum value).
     for (const s of samples) s.provenance = PROVENANCE;
-    return await finalizeSamples(samples, totalCost, sanitizeContext);
+    return await finalizeSamples(samples, totalCost, {
+      skillContent: sanitizeContext,
+      mockless,
+    });
   }
   throw new Error('unreachable');
 }
@@ -708,6 +794,105 @@ const TEXT_VALUE_TYPES = new Set([
 const TOOL_POSITIVE_TYPES = new Set([
   'tool_input_contains', 'tool_output_contains', 'mock_hit',
 ]);
+const MOCKLESS_POSITIVE_TOOL_TYPES = new Set([
+  'mock_hit',
+  'tools_called',
+  'tools_count_min',
+  'tool_input_contains',
+  'tool_output_contains',
+]);
+
+function stripMocklessPositiveToolAssertions(
+  assertions: Assertion[],
+  label: string,
+  stripped: string[],
+): Assertion[] {
+  const kept: Assertion[] = [];
+  for (const [index, assertion] of assertions.entries()) {
+    const assertionLabel = `${label}[${index}]`;
+    if (assertion?.type === 'assert-set' && Array.isArray(assertion.children)) {
+      const children = stripMocklessPositiveToolAssertions(
+        assertion.children,
+        `${assertionLabel}.children`,
+        stripped,
+      );
+      if (children.length === 0) {
+        stripped.push(`${assertionLabel}.assert-set（无 mock 模式下没有可执行子断言）`);
+        continue;
+      }
+      assertion.children = children;
+      kept.push(assertion);
+      continue;
+    }
+    if (MOCKLESS_POSITIVE_TOOL_TYPES.has(assertion?.type)) {
+      stripped.push(`${assertionLabel}.${assertion.type}（目标执行器不支持 mocks，正向工具证据不可复现）`);
+      continue;
+    }
+    kept.push(assertion);
+  }
+  return kept;
+}
+
+function stripInvalidMockHitAssertions(
+  assertions: Assertion[],
+  mockKeys: ReadonlySet<string>,
+  label: string,
+  stripped: string[],
+): Assertion[] {
+  const kept: Assertion[] = [];
+  for (const [index, assertion] of assertions.entries()) {
+    const assertionLabel = `${label}[${index}]`;
+    if (assertion?.type === 'assert-set' && Array.isArray(assertion.children)) {
+      const children = stripInvalidMockHitAssertions(
+        assertion.children,
+        mockKeys,
+        `${assertionLabel}.children`,
+        stripped,
+      );
+      if (children.length === 0) {
+        stripped.push(`${assertionLabel}.assert-set（没有可执行子断言）`);
+        continue;
+      }
+      assertion.children = children;
+      kept.push(assertion);
+      continue;
+    }
+    if (
+      assertion?.type === 'mock_hit'
+      && typeof assertion.value === 'string'
+      && !mockKeys.has(assertion.value)
+    ) {
+      stripped.push(`${assertionLabel}.mock_hit（未引用实际 mock：${assertion.value}）`);
+      continue;
+    }
+    kept.push(assertion);
+  }
+  return kept;
+}
+
+function environmentAsPromptContext(environment: unknown): string | null {
+  if (!environment || typeof environment !== 'object' || Array.isArray(environment)) {
+    return null;
+  }
+  const env = environment as Record<string, unknown>;
+  const lines = ['题设环境声明（仅作上下文，不会在 cwd 物化）：'];
+  if (
+    Array.isArray(env.cli_available)
+    && env.cli_available.every((item) => typeof item === 'string' && item.length > 0)
+  ) {
+    lines.push(`- 可用 CLI：${env.cli_available.join('、')}`);
+  }
+  if (
+    Array.isArray(env.files_available)
+    && env.files_available.every((item) => typeof item === 'string' && item.length > 0)
+  ) {
+    lines.push(`- 题设引用路径（未物化）：${env.files_available.join('、')}`);
+  }
+  if (typeof env.notes === 'string' && env.notes.trim()) {
+    lines.push(`- 说明：${env.notes.trim()}`);
+  }
+  return lines.length > 1 ? lines.join('\n') : null;
+}
 
 function isAsciiTokenLike(v: unknown): boolean {
   if (typeof v !== 'string') return false;
@@ -730,7 +915,12 @@ function toolNameAppearsInSkill(tool: string, skillContent: string): boolean {
 
 export function sanitizeGeneratedSamples(
   samples: Sample[],
-  opts: { skillContent?: string } = {},
+  opts: {
+    skillContent?: string;
+    mockless?: boolean;
+    migrateMocklessEnvironment?: boolean;
+    preserveMocklessEnvironment?: boolean;
+  } = {},
 ): { stripped: string[] } {
   const VALID_DIFFICULTY = new Set(['easy', 'medium', 'hard']);
   const VALID_PROVENANCE = new Set(['human', 'llm-generated', 'production-trace']);
@@ -772,6 +962,44 @@ export function sanitizeGeneratedSamples(
     if (s.tripwire !== undefined && typeof s.tripwire !== 'boolean') {
       stripped.push(`samples[${i}].tripwire (${typeof s.tripwire})`);
       delete (s as { tripwire?: unknown }).tripwire;
+    }
+
+    if (opts.mockless) {
+      if (Array.isArray(s.mocks) && s.mocks.length > 0) {
+        stripped.push(`samples[${i}].mocks（目标执行器不支持工具调用拦截）`);
+      }
+      delete (s as { mocks?: unknown }).mocks;
+      if (s.mocksStrict !== undefined) {
+        stripped.push(`samples[${i}].mocksStrict（无 mocks）`);
+      }
+      delete (s as { mocksStrict?: unknown }).mocksStrict;
+      if (s.environment !== undefined && !opts.preserveMocklessEnvironment) {
+        const environmentContext = opts.migrateMocklessEnvironment
+          ? environmentAsPromptContext(s.environment)
+          : null;
+        if (environmentContext) {
+          const existingContext = typeof s.context === 'string' ? s.context.trim() : '';
+          s.context = existingContext
+            ? `${existingContext}\n\n${environmentContext}`
+            : environmentContext;
+          stripped.push(`samples[${i}].environment（已迁移到题设 context，未物化）`);
+        } else {
+          stripped.push(`samples[${i}].environment（未物化的环境声明不能充当 fixture）`);
+        }
+      }
+      if (!opts.preserveMocklessEnvironment) {
+        delete (s as { environment?: unknown }).environment;
+      }
+      if (Array.isArray(s.assertions)) {
+        s.assertions = stripMocklessPositiveToolAssertions(
+          s.assertions,
+          `samples[${i}].assertions`,
+          stripped,
+        );
+        if (s.assertions.length === 0) {
+          delete (s as { assertions?: unknown }).assertions;
+        }
+      }
     }
 
     // assertions 校验:loader 会拒掉两类无效断言 — 在 generator boundary 提前 strip,
@@ -899,6 +1127,18 @@ export function sanitizeGeneratedSamples(
         }
         if (validMocks.length > 0) (s as Record<string, unknown>).mocks = validMocks;
         else delete (s as { mocks?: unknown }).mocks;
+      }
+    }
+
+    if (Array.isArray(s.assertions)) {
+      s.assertions = stripInvalidMockHitAssertions(
+        s.assertions,
+        sampleMockReferenceKeys(s.mocks),
+        `samples[${i}].assertions`,
+        stripped,
+      );
+      if (s.assertions.length === 0) {
+        delete (s as { assertions?: unknown }).assertions;
       }
     }
 

--- a/src/authoring/sample-fixer.ts
+++ b/src/authoring/sample-fixer.ts
@@ -34,6 +34,8 @@ export interface FixSamplesOptions {
   }>;
   model: string;
   maxAttemptsPerSample?: number;
+  /** Target executor cannot intercept tool calls; strip mocks and dependent positive evidence. */
+  mockless?: boolean;
 }
 
 export interface FixSamplesResult {
@@ -66,9 +68,22 @@ const FIX_SYSTEM_PROMPT = `你是一个评测用例修复专家。根据诊断�
 第一字符 \`[\`，最后 \`]\`，不要用 \`\`\`json\`\`\` 围栏，不要寒暄。
 如果判断某条是 LLM 行为问题不需要改,也原样放进数组。`;
 
+const MOCKLESS_FIX_OVERRIDE = `
 
-function sanitizeFixedSamples(samples: Record<string, unknown>[], skillContent: string): Record<string, unknown>[] {
-  sanitizeGeneratedSamples(samples as Sample[], { skillContent });
+目标执行器不支持工具调用拦截。不得新增或保留 mocks、mocksStrict、
+mock_hit、tools_called、tools_count_min、tool_input_contains、tool_output_contains。
+environment 仅表示题设上下文，不得当作已物化 fixture；负向安全断言可以保留。`;
+
+function sanitizeFixedSamples(
+  samples: Record<string, unknown>[],
+  skillContent: string,
+  mockless: boolean,
+): Record<string, unknown>[] {
+  sanitizeGeneratedSamples(samples as Sample[], {
+    skillContent,
+    mockless,
+    preserveMocklessEnvironment: true,
+  });
   return samples;
 }
 
@@ -146,7 +161,16 @@ function parseFixedSamples(text: string): Record<string, unknown>[] | null {
 }
 
 export async function fixSamples(options: FixSamplesOptions): Promise<FixSamplesResult> {
-  const { skillContent, samples, report, treatmentKey, executor, model, maxAttemptsPerSample = 2 } = options;
+  const {
+    skillContent,
+    samples,
+    report,
+    treatmentKey,
+    executor,
+    model,
+    maxAttemptsPerSample = 2,
+    mockless = false,
+  } = options;
   const sampleMap = new Map(samples.map((s) => [s.sample_id as string, s]));
 
   // Collect all fixable samples into one batch
@@ -240,7 +264,12 @@ ${sampleSections}
   let incurredCostUSD = 0;
   let incurredCostReported = false;
   try {
-    const result = await executor({ model, system: FIX_SYSTEM_PROMPT, prompt, timeoutMs: 300_000 });
+    const result = await executor({
+      model,
+      system: mockless ? `${FIX_SYSTEM_PROMPT}${MOCKLESS_FIX_OVERRIDE}` : FIX_SYSTEM_PROMPT,
+      prompt,
+      timeoutMs: 300_000,
+    });
     incurredCostUSD = result.costUSD;
     incurredCostReported = result.costReported !== false;
 
@@ -287,7 +316,7 @@ ${sampleSections}
       };
     }
 
-    const sanitizedFixedArr = sanitizeFixedSamples(fixedArr, skillContent);
+    const sanitizedFixedArr = sanitizeFixedSamples(fixedArr, skillContent, mockless);
     const outOfScope = sanitizedFixedArr.find((fixed) => {
       const sid = fixed.sample_id as string;
       const original = sampleMap.get(sid);

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -333,7 +333,10 @@ async function runSampleFix(
 
   process.stderr.write(lang === 'zh' ? `🔧 发现 ${sampleDesignCount} 条 sample_design 失败，开始修复...\n` : `🔧 Found ${sampleDesignCount} sample_design failure(s), fixing...\n`);
 
-  const { createExecutor } = await import('../../executors/index.js');
+  const {
+    createExecutor,
+    executorSupportsSampleMocks,
+  } = await import('../../executors/index.js');
   const exec = createExecutor(executorName);
   const executorFn = async (opts: { model: string; system: string; prompt: string; timeoutMs: number; lean?: boolean }) => {
     const result = await exec({
@@ -358,6 +361,7 @@ async function runSampleFix(
     treatmentKey: treatmentName,
     executor: executorFn,
     model,
+    mockless: !executorSupportsSampleMocks(executorName),
   });
 
   let writtenFiles: string[] = [];
@@ -434,7 +438,13 @@ export async function runSampleFromTraces(
     : `🔭 Found ${items.length}${flags.skill ? ` ${flags.skill}` : ''} failure signal(s); generating regression-sample drafts...\n`);
 
   try {
-    const { samples, costUSD } = await generateSamplesFromTraces({ items, count, model, executorName });
+    const { samples, costUSD } = await generateSamplesFromTraces({
+      items,
+      count,
+      model,
+      executorName,
+      noMock: flags['no-mock'],
+    });
     const cost = costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
     if (samples.length === 0) {
       // The model conservatively skipped every signal (noise / unreproducible). That's a
@@ -740,8 +750,8 @@ export default class Sample extends BaseCommand {
     }),
     'no-mock': Flags.boolean({
       description: bilingual({
-        zh: '不生成 mocks，eval 时所有工具调用真实执行。',
-        en: 'Skip mock generation; all tool calls execute for real during eval.',
+        zh: '不生成 mocks。执行器不支持工具拦截时会自动启用，避免产生必然失败的 mock_hit。',
+        en: 'Skip mocks. Automatically enabled when the executor cannot intercept tools, preventing impossible mock_hit assertions.',
       }),
       default: false,
     }),

--- a/src/eval-core/fact-checker.ts
+++ b/src/eval-core/fact-checker.ts
@@ -132,7 +132,7 @@ export function checkFacts(
         type: 'file-path',
         value: path,
         verified: true,
-        evidence: 'source=fixture(sample.environment.files_available)',
+        evidence: 'source=context(sample.environment.files_available)',
       }];
     }
 

--- a/src/eval-core/mock-hook.cjs
+++ b/src/eval-core/mock-hook.cjs
@@ -92,8 +92,47 @@ function anyStringContains(obj, needle) {
   return false;
 }
 
+const BUILTIN_TOOL_ALIASES = {
+  bash: 'Bash',
+  shell: 'Bash',
+  exec_command: 'Bash',
+  command_execution: 'Bash',
+  read: 'Read',
+  file_read: 'Read',
+  grep: 'Grep',
+  edit: 'Edit',
+  apply_patch: 'Edit',
+  file_change: 'Edit',
+  write: 'Write',
+  file_write: 'Write',
+  view_image: 'ViewImage',
+  viewimage: 'ViewImage',
+  write_stdin: 'WriteStdin',
+  writestdin: 'WriteStdin',
+  web_search: 'WebSearch',
+  websearch: 'WebSearch',
+};
+
+function canonicalToolName(name) {
+  const sourceName = String(name);
+  const builtin = BUILTIN_TOOL_ALIASES[sourceName.toLowerCase()];
+  if (builtin) return builtin;
+  const parts = sourceName.split('__').filter(Boolean);
+  if (parts[0] === 'mcp' && parts.length > 2) {
+    const providerParts = parts.slice(1, -1);
+    if (providerParts[0] === 'codex_apps' && providerParts.length > 1) providerParts.shift();
+    return providerParts.join('.') + '.' + parts[parts.length - 1];
+  }
+  return sourceName;
+}
+
+function toolIdentityMatches(expectedName, runtimeName) {
+  return expectedName === runtimeName
+    || canonicalToolName(expectedName) === canonicalToolName(runtimeName);
+}
+
 function isMockHit(mock, toolName, toolInput) {
-  if (mock.tool !== '*' && mock.tool !== toolName) return false;
+  if (mock.tool !== '*' && !toolIdentityMatches(mock.tool, toolName)) return false;
   const m = mock.match;
   if (!m) return true;
   const ti = toolInput || {};

--- a/src/eval-core/mocks-runtime.ts
+++ b/src/eval-core/mocks-runtime.ts
@@ -20,6 +20,7 @@ import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Mock, MockReturn } from '../types/eval.js';
 import { incrementRecordCount, setOwnRecordValue } from '../shared/record-count.js';
+import { toolIdentityMatches } from '../shared/tool-identity.js';
 
 // ─── Match logic ────────────────────────────────────────────────────────────
 
@@ -106,7 +107,7 @@ function anyStringContains(obj: unknown, needle: string): boolean {
 
 /** 单条 mock 是否命中给定 tool 调用。 */
 export function isMockHit(mock: Mock, toolName: string, toolInput: unknown): boolean {
-  if (mock.tool !== '*' && mock.tool !== toolName) return false;
+  if (mock.tool !== '*' && !toolIdentityMatches(mock.tool, toolName)) return false;
   const m = mock.match;
   if (!m) return true;
   const ti = (toolInput || {}) as Record<string, unknown>;
@@ -467,8 +468,44 @@ function anyStringContains(obj, needle) {
   if (typeof obj === 'object' && obj !== null) return Object.values(obj).some((v) => anyStringContains(v, needle));
   return false;
 }
+const BUILTIN_TOOL_ALIASES = {
+  bash: 'Bash',
+  shell: 'Bash',
+  exec_command: 'Bash',
+  command_execution: 'Bash',
+  read: 'Read',
+  file_read: 'Read',
+  grep: 'Grep',
+  edit: 'Edit',
+  apply_patch: 'Edit',
+  file_change: 'Edit',
+  write: 'Write',
+  file_write: 'Write',
+  view_image: 'ViewImage',
+  viewimage: 'ViewImage',
+  write_stdin: 'WriteStdin',
+  writestdin: 'WriteStdin',
+  web_search: 'WebSearch',
+  websearch: 'WebSearch',
+};
+function canonicalToolName(name) {
+  const sourceName = String(name);
+  const builtin = BUILTIN_TOOL_ALIASES[sourceName.toLowerCase()];
+  if (builtin) return builtin;
+  const parts = sourceName.split('__').filter(Boolean);
+  if (parts[0] === 'mcp' && parts.length > 2) {
+    const providerParts = parts.slice(1, -1);
+    if (providerParts[0] === 'codex_apps' && providerParts.length > 1) providerParts.shift();
+    return providerParts.join('.') + '.' + parts[parts.length - 1];
+  }
+  return sourceName;
+}
+function toolIdentityMatches(expectedName, runtimeName) {
+  return expectedName === runtimeName
+    || canonicalToolName(expectedName) === canonicalToolName(runtimeName);
+}
 function isMockHit(mock, toolName, toolInput) {
-  if (mock.tool !== '*' && mock.tool !== toolName) return false;
+  if (mock.tool !== '*' && !toolIdentityMatches(mock.tool, toolName)) return false;
   const m = mock.match;
   if (!m) return true;
   const ti = toolInput || {};

--- a/src/eval-core/task-planner.ts
+++ b/src/eval-core/task-planner.ts
@@ -2,8 +2,8 @@ import type { Artifact, Sample, SampleEnvironment, Task } from '../types/index.j
 
 /**
  * 把 sample.environment 渲染成自然语言段落,放在用户 prompt 前。
- * 让 LLM 读到"环境已就绪",跳过 Glob / find / which / Read 这些环境探测,
- * 直接进入 skill 描述的工作流 — 评测信号纯,mock 设计也简化(不用 mock 探测命令)。
+ * 这是题设上下文,不会修改 PATH、物化文件或改变 runtime;LLM 可据此跳过
+ * which / test -f 等可用性探测,直接进入 skill 描述的工作流。
  *
  * 输出 null 表示 sample 没声明 environment,prompt 不变。
  */
@@ -11,23 +11,23 @@ export function renderEnvironmentSection(env: SampleEnvironment | undefined): st
   if (!env) return null;
   const lines: string[] = [];
   if (env.cli_available && env.cli_available.length > 0) {
-    lines.push('- 已安装 CLI(已在 PATH,无需 `which` / `command -v` / `type` 探测):');
+    lines.push('- 题设声明可用的 CLI（仅作上下文，不修改 PATH）：');
     for (const c of env.cli_available) lines.push(`  - \`${c}\``);
   }
   if (env.files_available && env.files_available.length > 0) {
-    lines.push('- 已存在文件(无需 Glob / `Read` / `test -f` 探测):');
+    lines.push('- 题设引用的文件路径（仅作上下文，不会在 cwd 物化）：');
     for (const f of env.files_available) lines.push(`  - \`${f}\``);
   }
   if (env.notes && env.notes.trim()) {
-    lines.push(`- 备注:${env.notes.trim()}`);
+    lines.push(`- 备注：${env.notes.trim()}`);
   }
   if (lines.length === 0) return null;
   return [
-    '## 评测环境前置(已就绪,无需探测)',
+    '## 题设环境声明（仅作上下文）',
     '',
     ...lines,
     '',
-    '请直接进入 skill 描述的主流程,**不要做环境检查 / `Glob` / `find` / `which` / `test -f` 等探测**。',
+    '请按以上题设进入 skill 描述的主流程，**不要额外做 `find` / `which` / `test -f` 等可用性探测**。这些声明不会自动创建文件或修改 runtime 环境。',
   ].join('\n');
 }
 

--- a/src/eval-workflows/evaluation-pipeline.ts
+++ b/src/eval-workflows/evaluation-pipeline.ts
@@ -45,6 +45,7 @@ import {
 import { finalizeEvaluationReport } from './evaluation-pipeline/report-finalize.js';
 import { emitIsolationWarnings, emitPowerWarnings } from './evaluation-pipeline/preflight-warnings.js';
 import { ownRecordValue, setOwnRecordValue } from '../shared/record-count.js';
+import { assertSamplesCompatibleWithExecutor } from '../executors/capabilities.js';
 
 // 兼容 re-export:测试与 run-evaluation.ts 动态 import 仍打 evaluation-pipeline.js
 export { buildPowerWarnings, buildIsolationWarnings } from './evaluation-pipeline/preflight-warnings.js';
@@ -165,6 +166,7 @@ export async function executeEvaluationPipeline({
   effort,
   noDiagnostic,
 }: EvaluationPipelineOptions): Promise<{ report: Report; filePath: string | null }> {
+  assertSamplesCompatibleWithExecutor(samples, executorName, lang);
   const variantNames = artifacts.map((artifact) => artifact.name);
   const runState = await initializeEvaluationRunState({
     samplesPath,

--- a/src/eval-workflows/run-evaluation.ts
+++ b/src/eval-workflows/run-evaluation.ts
@@ -1,6 +1,9 @@
 import { resolve } from 'node:path';
 import { DEFAULT_OUTPUT_DIR, persistReport } from '../eval-core/evaluation-reporting.js';
-import { createExecutor } from '../executors/index.js';
+import {
+  assertSamplesCompatibleWithExecutor,
+  createExecutor,
+} from '../executors/index.js';
 import { discoverBatchSkills } from '../inputs/skill-loader.js';
 import { confidenceInterval, tTest, effectSize } from '../eval-core/statistics.js';
 import { executeBatchEvaluationRuns, buildBatchVariantSpecs } from './batch-evaluation-workflow.js';
@@ -220,6 +223,7 @@ export async function runEvaluation({
     mcpConfig,
     strictBaseline,
   });
+  assertSamplesCompatibleWithExecutor(samples, executorName, lang);
 
   // doctor 强制门禁: skill 静态结构 + 元数据 + 依赖 + 用例契约。
   // 在 dryRun 分支之前跑, 让 dry-run 也得到 doctor 覆盖(保护 garbage-in 的 verdict)。

--- a/src/executors/capabilities.ts
+++ b/src/executors/capabilities.ts
@@ -1,0 +1,98 @@
+import type {
+  ExecutorFn,
+  ExecutorInput,
+  Sample,
+} from '../types/index.js';
+
+export type SampleMockSupport =
+  | 'native-hooks'
+  | 'delegated-script'
+  | 'unsupported';
+
+export interface ExecutorCapabilities {
+  sampleMocks: SampleMockSupport;
+}
+
+const BUILTIN_CAPABILITIES: Readonly<Record<string, ExecutorCapabilities>> = {
+  claude: { sampleMocks: 'native-hooks' },
+  'claude-sdk': { sampleMocks: 'native-hooks' },
+  codex: { sampleMocks: 'unsupported' },
+  'codex-sdk': { sampleMocks: 'unsupported' },
+  gemini: { sampleMocks: 'unsupported' },
+  'anthropic-api': { sampleMocks: 'unsupported' },
+  'openai-api': { sampleMocks: 'unsupported' },
+};
+
+/**
+ * Custom script executors receive the OMK_MOCK_* protocol environment and own
+ * the final adapter. Built-ins are explicit so unsupported runtimes can never
+ * silently turn mock assertions into model failures.
+ */
+export function getExecutorCapabilities(executorName: string): ExecutorCapabilities {
+  return BUILTIN_CAPABILITIES[executorName]
+    ?? { sampleMocks: 'delegated-script' };
+}
+
+export function executorSupportsSampleMocks(executorName: string): boolean {
+  return getExecutorCapabilities(executorName).sampleMocks !== 'unsupported';
+}
+
+function unsupportedMocksMessage(
+  executorName: string,
+  sampleIds: string[],
+  lang: 'zh' | 'en',
+): string {
+  const ids = sampleIds.slice(0, 8).join(', ');
+  const overflow = sampleIds.length > 8
+    ? lang === 'zh'
+      ? ` 等 ${sampleIds.length} 条`
+      : ` and ${sampleIds.length - 8} more`
+    : '';
+  if (lang === 'en') {
+    return `Executor "${executorName}" does not support Sample.mocks tool interception. `
+      + `Continuing would make mock_hit assertions structurally impossible and create false evidence. `
+      + `Affected samples: ${ids}${overflow}. `
+      + 'Regenerate them with "omk sample --no-mock", remove mocks/mock_hit, '
+      + 'or evaluate with claude/claude-sdk.';
+  }
+  return `执行器「${executorName}」不支持 Sample.mocks 工具拦截。`
+    + `继续运行会让 mock_hit 在结构上必然失败并产生伪证据。`
+    + `受影响用例：${ids}${overflow}。`
+    + '请用「omk sample --no-mock」重新生成、删除 mocks/mock_hit，'
+    + '或改用 claude/claude-sdk 评测。';
+}
+
+export function assertSamplesCompatibleWithExecutor(
+  samples: Sample[],
+  executorName: string,
+  lang: 'zh' | 'en' = 'zh',
+): void {
+  if (executorSupportsSampleMocks(executorName)) return;
+  const affected = samples
+    .filter((sample) => Array.isArray(sample.mocks) && sample.mocks.length > 0)
+    .map((sample) => sample.sample_id);
+  if (affected.length === 0) return;
+  throw new Error(unsupportedMocksMessage(executorName, affected, lang));
+}
+
+export function assertExecutorInputCapabilities(
+  executorName: string,
+  input: ExecutorInput,
+): void {
+  if (
+    executorSupportsSampleMocks(executorName)
+    || !Array.isArray(input.mocks)
+    || input.mocks.length === 0
+  ) return;
+  throw new Error(unsupportedMocksMessage(executorName, ['<programmatic-input>'], 'zh'));
+}
+
+export function enforceExecutorCapabilities(
+  executorName: string,
+  executor: ExecutorFn,
+): ExecutorFn {
+  return async (input) => {
+    assertExecutorInputCapabilities(executorName, input);
+    return executor(input);
+  };
+}

--- a/src/executors/index.ts
+++ b/src/executors/index.ts
@@ -8,6 +8,7 @@ import { codexSdkExecutor } from './codex-sdk.js';
 import { geminiExecutor } from './gemini.js';
 import { openAiApiExecutor } from './openai-api.js';
 import { createScriptExecutor } from './script.js';
+import { enforceExecutorCapabilities } from './capabilities.js';
 
 // 命名一致性:provider HTTP 路径统一用 `<vendor>-api`(`anthropic-api` / `openai-api`),
 // vendor coding agent CLI 用 vendor 名(`claude` / `codex`)。`openai` 这个不带 -api 后缀的
@@ -23,10 +24,17 @@ const EXECUTOR_REGISTRY: Record<string, ExecutorFn> = {
 };
 
 export { extractAgentTrace, createScriptExecutor };
+export {
+  assertExecutorInputCapabilities,
+  assertSamplesCompatibleWithExecutor,
+  executorSupportsSampleMocks,
+  getExecutorCapabilities,
+} from './capabilities.js';
 
 export function createExecutor(name: string): ExecutorFn {
   if (name.trim().length === 0) {
     throw new Error('executor name or script command is required');
   }
-  return EXECUTOR_REGISTRY[name] || createScriptExecutor(name);
+  const executor = EXECUTOR_REGISTRY[name] || createScriptExecutor(name);
+  return enforceExecutorCapabilities(name, executor);
 }

--- a/src/server/skill-insights.ts
+++ b/src/server/skill-insights.ts
@@ -330,7 +330,7 @@ function detectSkillDocGap(
   const recs: InsightRecommendation[] = [];
   if (depRule) {
     recs.push({
-      action: `在 sample.environment.files_available 加上文件路径,告诉 LLM "这些文件已就绪,无需探测"`,
+      action: '把已知路径写进 sample.context；只有纯题设前提才放 environment.files_available，且不要把它当作已物化 fixture',
       priority: severity,
       patch: {
         target: 'sample-environment',

--- a/src/shared/sample-contract.ts
+++ b/src/shared/sample-contract.ts
@@ -247,6 +247,40 @@ function mockValidationError(value: unknown): string | undefined {
   return undefined;
 }
 
+export function sampleMockReferenceKeys(value: unknown): ReadonlySet<string> {
+  const keys = new Set<string>();
+  if (!Array.isArray(value)) return keys;
+  const countByTool = new Map<string, number>();
+  for (const mock of value) {
+    if (!isRecord(mock) || !isNonEmptyString(mock.tool)) continue;
+    const ordinal = (countByTool.get(mock.tool) ?? 0) + 1;
+    countByTool.set(mock.tool, ordinal);
+    keys.add(`${mock.tool}:${ordinal}`);
+  }
+  return keys;
+}
+
+function mockHitReferenceValidationError(
+  assertions: unknown,
+  mockKeys: ReadonlySet<string>,
+): string | undefined {
+  if (!Array.isArray(assertions)) return undefined;
+  for (const assertion of assertions) {
+    if (!isRecord(assertion)) continue;
+    if (
+      assertion.type === 'mock_hit'
+      && typeof assertion.value === 'string'
+      && !mockKeys.has(assertion.value)
+    ) {
+      const available = mockKeys.size > 0 ? [...mockKeys].join(', ') : '(none)';
+      return `"mock_hit" references missing mock ${JSON.stringify(assertion.value)}; available mock keys: ${available}`;
+    }
+    const childError = mockHitReferenceValidationError(assertion.children, mockKeys);
+    if (childError) return childError;
+  }
+  return undefined;
+}
+
 export function dependencyRequirementsValidationError(value: unknown): string | undefined {
   if (!isRecord(value)) return '"requires" must be an object';
   if (!hasOnlyKeys(value, ['tools', 'files', 'env', 'preflight'])) {
@@ -307,6 +341,11 @@ export function sampleContractValidationError(
       if (error) return `"mocks[${index}]": ${error}`;
     }
   }
+  const mockHitError = mockHitReferenceValidationError(
+    value.assertions,
+    sampleMockReferenceKeys(value.mocks),
+  );
+  if (mockHitError) return mockHitError;
   if (value.mocksStrict !== undefined && typeof value.mocksStrict !== 'boolean') {
     return '"mocksStrict" must be boolean when present';
   }

--- a/src/shared/tool-identity.ts
+++ b/src/shared/tool-identity.ts
@@ -87,6 +87,22 @@ export function normalizeToolIdentity(input: ToolIdentityInput): NormalizedToolI
   };
 }
 
+/**
+ * Match a source-neutral tool identity against a runtime-native tool name.
+ *
+ * Exact matching remains first for legacy/custom tools. Normalization then lets
+ * one mock identity work across adapters such as `Bash` ↔ `exec_command` and
+ * `Edit` ↔ `apply_patch`.
+ */
+export function toolIdentityMatches(
+  expectedName: string,
+  runtimeName: string,
+): boolean {
+  if (expectedName === runtimeName) return true;
+  return normalizeToolIdentity({ sourceName: expectedName }).name
+    === normalizeToolIdentity({ sourceName: runtimeName }).name;
+}
+
 function inferredMcpNamespace(sourceName: string): string | undefined {
   const parts = sourceName.split('__').filter(Boolean);
   return parts[0] === 'mcp' && parts.length > 2

--- a/src/types/eval.ts
+++ b/src/types/eval.ts
@@ -49,12 +49,12 @@ export interface SampleCoverageTarget {
   ref: string;
 }
 
-/** Sample 评测环境前置:声明性"已就绪"清单,LLM 看到后跳过环境探测,直接进入工作流。
- *  类比 unit test 的 fixture / setup —— 评测是测 skill 工作流,不是测环境探测能力。 */
+/** Sample 题设环境声明。仅注入 prompt,不会修改 PATH、物化文件或改变 runtime。 */
 export interface SampleEnvironment {
-  /** 假定已在 PATH 上的 CLI,LLM 不再 which / find / type / command -v 探测。 */
+  /** 题设声明可用的 CLI,LLM 不再 which / find / type / command -v 探测。 */
   cli_available?: string[];
-  /** 假定存在的文件/脚本(支持 ~ / $SKILL_DIR / 绝对路径),LLM 不再 Glob / Read / test -f 探测。 */
+  /** 题设声明存在的文件/脚本(支持 ~ / $SKILL_DIR / 绝对路径),LLM 不再 Glob / Read / test -f 探测。
+   *  这是 prompt context,不会在 cwd 物化文件;需要真实读取时必须提供 sample.cwd 中的 fixture。 */
   files_available?: string[];
   /** 自由文本兜底,场景特殊说明(如"凭证已配""设备 SN xxx 已租"等)。 */
   notes?: string;
@@ -94,7 +94,8 @@ export type MockReturn =
 
 /** 单条 Mock 规则。runtime 拦到匹配的 tool 调用即返回 mocked 结果,不放出去。 */
 export interface Mock {
-  /** 拦截的工具名,如 "Read" / "Bash" / "WebFetch" / "Edit" / "Write" / "Grep" / "Glob"。
+  /** source-neutral 工具身份,如 "Read" / "Bash" / "WebFetch" / "Edit" / "Write" / "Grep" / "Glob"。
+   *  executor adapter 会把 runtime-native 名称（如 exec_command / apply_patch）映射后匹配。
    *  特殊值 `"*"`:通配,匹配任何工具名(配合 match.input_contains 做 intent-level mock)。 */
   tool: string;
   /** 命中规则。所有字段 AND,字段未填即不限制。 */
@@ -151,7 +152,7 @@ export interface Sample {
    *  - true:未命中即 deny(防意外真调外部接口/CLI/MCP/写状态)。
    *  全 mock 评测场景建议 true,部分 mock 探索场景留 false。 */
   mocksStrict?: boolean;
-  /** 环境前置:声明性"已就绪"清单,LLM 跳过探测直接干活。详见 SampleEnvironment。 */
+  /** 题设环境声明,仅作 prompt 上下文。详见 SampleEnvironment。 */
   environment?: SampleEnvironment;
   [key: string]: unknown;  // allow extra fields like mutated prompt/context from URL resolution
 }

--- a/src/types/executor.ts
+++ b/src/types/executor.ts
@@ -96,8 +96,9 @@ export interface ExecutorInput {
    *  - claude-sdk:转 in-process HookCallback 装到 SDK options.hooks.PreToolUse
    *  - claude-cli:物化为临时 settings.json + on-disk hook 脚本,跑完清理
    *  - script(自定义脚本):同样物化临时 settings,通过 env(OMK_MOCK_SETTINGS_FILE /
-   *    OMK_MOCK_MCP_CONFIG_FILE / OMK_MOCKS_FILE)暴露给脚本;脚本若包 Claude Code 兼容
-   *    CLI 可透传 --settings 复用同一 mock hook,否则忽略(不支持的 CLI 静默无 mock) */
+   *    OMK_MOCK_MCP_CONFIG_FILE / OMK_MOCKS_FILE)暴露给脚本;脚本负责消费该协议
+   *  - codex / codex-sdk / gemini / *-api:不支持,executor capability gate 会拒绝,
+   *    绝不静默忽略后把 mock_hit 记成模型失败 */
   mocks?: import('./eval.js').Mock[];
   /** 解析 mock.return_file 的相对路径锚点(默认 sample 文件所在目录)。 */
   mocksBaseDir?: string;

--- a/test/authoring/generator.test.ts
+++ b/test/authoring/generator.test.ts
@@ -1,7 +1,15 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { generateSamples, generateSamplesFromTraces, buildSamplesFromTracesPrompt, stratifyTraceSignals, sanitizeGeneratedSamples, buildSamplesPrompt } from '../../src/authoring/generator.js';
-import type { Sample } from '../../src/types/index.js';
+import {
+  buildSamplesFromTracesPrompt,
+  buildSamplesPrompt,
+  generateSamples,
+  generateSamplesFromTraces,
+  sampleGenerationUsesMocks,
+  sanitizeGeneratedSamples,
+  stratifyTraceSignals,
+} from '../../src/authoring/generator.js';
+import type { ExecutorFn, Sample } from '../../src/types/index.js';
 
 describe('generateSamples', () => {
   it('is a function', () => {
@@ -12,6 +20,60 @@ describe('generateSamples', () => {
     await assert.rejects(
       () => generateSamples({ skillContent: 'test', count: 1, model: 'test-model', executorName: 'nonexistent' }),
       /ENOENT|failed/,
+    );
+  });
+
+  it('forces Codex generation into mockless mode and strips ignored mock output', async () => {
+    let capturedSystem = '';
+    let capturedPrompt = '';
+    const executor: ExecutorFn = async (input) => {
+      capturedSystem = input.system ?? '';
+      capturedPrompt = input.prompt;
+      return {
+        ok: true,
+        output: JSON.stringify([{
+          sample_id: 's001',
+          prompt: 'review the integration',
+          rubric: 'explain the correct result',
+          environment: { files_available: ['app.js'] },
+          mocks: [{ tool: 'Read', return: 'fixture' }],
+          mocksStrict: true,
+          assertions: [
+            { type: 'mock_hit', value: 'Read:1' },
+            { type: 'tools_called', values: ['Read'] },
+            { type: 'tools_not_called', values: ['Write'] },
+            { type: 'contains', value: 'Sentry.init' },
+          ],
+        }]),
+        durationMs: 1,
+        durationApiMs: 1,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        costUSD: 0,
+        stopReason: 'end_turn',
+        numTurns: 1,
+      };
+    };
+
+    const result = await generateSamples({
+      skillContent: 'Use Read only when a fixture exists.',
+      count: 1,
+      model: 'test',
+      executorName: 'codex',
+      executor,
+    });
+
+    assert.match(capturedSystem, /目标执行器能力约束（最高优先级）/);
+    assert.match(capturedPrompt, /不要生成 mocks 和 mocksStrict/);
+    assert.equal(result.samples[0].mocks, undefined);
+    assert.equal(result.samples[0].mocksStrict, undefined);
+    assert.equal(result.samples[0].environment, undefined);
+    assert.match(result.samples[0].context ?? '', /题设引用路径（未物化）：app\.js/);
+    assert.deepEqual(
+      result.samples[0].assertions?.map((assertion) => assertion.type),
+      ['tools_not_called', 'contains'],
     );
   });
 });
@@ -57,6 +119,12 @@ describe('buildSamplesFromTracesPrompt', () => {
     assert.match(buildSamplesFromTracesPrompt(items), /按各信号「占比」分配/);
     // 频次占比写进每个信号段(signal 1 出现 3 次 / 共 4 → 75%）。
     assert.match(buildSamplesFromTracesPrompt(items), /占比 75%/);
+  });
+
+  it('adds a mockless override for trace drafts when requested', () => {
+    const prompt = buildSamplesFromTracesPrompt(items, undefined, { noMock: true });
+    assert.match(prompt, /不要生成 mocks/);
+    assert.match(prompt, /trace 证据写入 context 和 rubric/);
   });
 });
 
@@ -169,6 +237,12 @@ describe('buildSamplesPrompt', () => {
     const prompt = buildSamplesPrompt({ skillContent: 's', count: 3, focus: '  scenario X  \n' });
     assert.ok(prompt.includes('scenario X'));
     assert.ok(!prompt.includes('  scenario X  '));
+  });
+
+  it('disables mocks automatically for unsupported executors', () => {
+    assert.equal(sampleGenerationUsesMocks('claude'), true);
+    assert.equal(sampleGenerationUsesMocks('codex'), false);
+    assert.equal(sampleGenerationUsesMocks('claude', true), false);
   });
 });
 
@@ -428,6 +502,67 @@ describe('sanitizeGeneratedSamples', () => {
     const samples: Sample[] = [{ sample_id: 's1', prompt: 'p' }];
     sanitizeGeneratedSamples(samples);
     assert.equal(samples[0].mocksStrict, undefined);
+  });
+
+  it('mockless mode removes positive tool evidence recursively but keeps safety negatives', () => {
+    const samples: Sample[] = [{
+      sample_id: 's1',
+      prompt: 'p',
+      environment: {
+        cli_available: ['node'],
+        files_available: ['app.js'],
+      },
+      mocks: [{ tool: 'Read', return: 'fixture' }],
+      mocksStrict: true,
+      assertions: [{
+        type: 'assert-set',
+        mode: 'all',
+        children: [
+          { type: 'mock_hit', value: 'Read:1' },
+          { type: 'tools_not_called', values: ['Write'] },
+        ],
+      }],
+    }];
+
+    const { stripped } = sanitizeGeneratedSamples(samples, { mockless: true });
+    assert.equal(samples[0].mocks, undefined);
+    assert.equal(samples[0].mocksStrict, undefined);
+    assert.equal(samples[0].environment, undefined);
+    assert.deepEqual(samples[0].assertions, [{
+      type: 'assert-set',
+      mode: 'all',
+      children: [{ type: 'tools_not_called', values: ['Write'] }],
+    }]);
+    assert.ok(stripped.some((item) => item.includes('mock_hit')));
+    assert.ok(stripped.some((item) => item.includes('未物化')));
+  });
+
+  it('removes mock_hit assertions that do not reference a real per-tool mock ordinal', () => {
+    const samples: Sample[] = [{
+      sample_id: 's1',
+      prompt: 'p',
+      mocks: [
+        { tool: 'Read', return: 'one' },
+        { tool: 'Bash', return: 'two' },
+        { tool: 'Read', return: 'three' },
+      ],
+      assertions: [{
+        type: 'assert-set',
+        mode: 'all',
+        children: [
+          { type: 'mock_hit', value: 'Read:2' },
+          { type: 'mock_hit', value: 'Bash:2' },
+        ],
+      }],
+    }];
+
+    const { stripped } = sanitizeGeneratedSamples(samples);
+    assert.deepEqual(samples[0].assertions, [{
+      type: 'assert-set',
+      mode: 'all',
+      children: [{ type: 'mock_hit', value: 'Read:2' }],
+    }]);
+    assert.ok(stripped.some((item) => item.includes('Bash:2')));
   });
 
   it('preserves valid tripwire boolean', () => {

--- a/test/authoring/sample-fixer.test.ts
+++ b/test/authoring/sample-fixer.test.ts
@@ -175,4 +175,51 @@ describe('fixSamples', () => {
     assert.equal(result.costReported, false);
     assert.match(result.fixes[0].error ?? '', /missing or invalid required prompt/);
   });
+
+  it('removes impossible mocks when fixing samples for a mockless executor', async () => {
+    let capturedSystem = '';
+    const result = await fixSamples({
+      skillContent: 'Do not call Write.',
+      samples: [{
+        sample_id: 's001',
+        prompt: 'p',
+        assertions: [],
+        provenance: 'llm-generated',
+      }],
+      report: reportWithFailedAssertion(),
+      treatmentKey: 'skill',
+      model: 'test-model',
+      mockless: true,
+      executor: async (input) => {
+        capturedSystem = input.system;
+        return {
+          ok: true,
+          costUSD: 0,
+          text: JSON.stringify([{
+            sample_id: 's001',
+            prompt: 'p',
+            provenance: 'llm-generated',
+            environment: { files_available: ['fixture.txt'] },
+            mocks: [{ tool: 'Read', return: 'fixture' }],
+            mocksStrict: true,
+            assertions: [
+              { type: 'mock_hit', value: 'Read:1' },
+              { type: 'tools_not_called', values: ['Write'] },
+            ],
+          }]),
+        };
+      },
+    });
+
+    assert.match(capturedSystem, /目标执行器不支持工具调用拦截/);
+    assert.equal(result.fixedCount, 1);
+    assert.equal(result.samples[0].mocks, undefined);
+    assert.equal(result.samples[0].mocksStrict, undefined);
+    assert.deepEqual(result.samples[0].environment, {
+      files_available: ['fixture.txt'],
+    });
+    assert.deepEqual(result.samples[0].assertions, [
+      { type: 'tools_not_called', values: ['Write'] },
+    ]);
+  });
 });

--- a/test/eval-core/fact-checker.test.ts
+++ b/test/eval-core/fact-checker.test.ts
@@ -71,7 +71,7 @@ describe('fact-checker path extraction', () => {
     assert.equal(result.claims[0].evidence, 'source=context(sample.context)');
   });
 
-  it('labels declarative fixture evidence', () => {
+  it('labels declarative environment evidence as context, not a physical fixture', () => {
     const result = checkFacts(
       'Run scripts/verify.sh.',
       { declaredFiles: ['$SKILL_DIR/scripts/verify.sh'] },
@@ -80,7 +80,7 @@ describe('fact-checker path extraction', () => {
     assert.equal(result.verifiedCount, 1);
     assert.equal(
       result.claims[0].evidence,
-      'source=fixture(sample.environment.files_available)',
+      'source=context(sample.environment.files_available)',
     );
   });
 

--- a/test/eval-core/mocks-runtime.test.ts
+++ b/test/eval-core/mocks-runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
 import { existsSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import {
   isMockHit,
@@ -16,6 +17,21 @@ describe('isMockHit', () => {
     const m: Mock = { tool: 'Read', return: 'x' };
     assert.equal(isMockHit(m, 'Read', { file_path: '/a' }), true);
     assert.equal(isMockHit(m, 'Bash', { command: 'ls' }), false);
+  });
+
+  it('maps runtime-native tool names to the source-neutral mock identity', () => {
+    assert.equal(
+      isMockHit({ tool: 'Bash', return: 'x' }, 'exec_command', { cmd: 'ls' }),
+      true,
+    );
+    assert.equal(
+      isMockHit({ tool: 'Edit', return: 'x' }, 'apply_patch', { patch: '...' }),
+      true,
+    );
+    assert.equal(
+      isMockHit({ tool: 'Read', return: 'x' }, 'file_read', { path: 'a.ts' }),
+      true,
+    );
   });
 
   it('matches file_path with ~ expansion', () => {
@@ -298,6 +314,47 @@ describe('materializeForCliConfigDir', () => {
     createdDirs = [];  // already removed
   });
 
+  it('materialized CLI hook maps runtime-native names to source-neutral mocks', () => {
+    const handle = materializeForCliConfigDir([
+      { tool: 'Bash', return: 'shell fixture' },
+      { tool: 'github.fetch_file', return: 'mcp fixture' },
+    ])!;
+    const dir = dirname(handle.settingsFile);
+    createdDirs.push(dir);
+    const hookScript = join(dir, 'mock-hook.cjs');
+    const invoke = (toolName: string) => spawnSync(
+      process.execPath,
+      [hookScript],
+      {
+        input: JSON.stringify({
+          hook_event_name: 'PreToolUse',
+          tool_name: toolName,
+          tool_input: {},
+        }),
+        encoding: 'utf8',
+        env: { ...process.env, ...handle.env },
+      },
+    );
+
+    const bash = invoke('exec_command');
+    assert.equal(bash.status, 0, bash.stderr);
+    assert.match(
+      JSON.parse(bash.stdout).hookSpecificOutput.permissionDecisionReason,
+      /shell fixture/,
+    );
+
+    const mcp = invoke('mcp__github__fetch_file');
+    assert.equal(mcp.status, 0, mcp.stderr);
+    assert.match(
+      JSON.parse(mcp.stdout).hookSpecificOutput.permissionDecisionReason,
+      /mcp fixture/,
+    );
+    assert.deepEqual(handle.readStats().perMock, {
+      'Bash:1': 1,
+      'github.fetch_file:1': 1,
+    });
+  });
+
   it('cleanup is idempotent (safe to call twice)', () => {
     const handle = materializeForCliConfigDir([{ tool: 'Read', return: 'x' }])!;
     createdDirs.push(dirname(handle.settingsFile));
@@ -358,10 +415,10 @@ describe('renderEnvironmentSection (task-planner)', () => {
   it('renders cli_available', async () => {
     const { renderEnvironmentSection } = await import('../../src/eval-core/task-planner.js');
     const out = renderEnvironmentSection({ cli_available: ['node', 'git'] });
-    assert.ok(out!.includes('已安装 CLI'));
+    assert.ok(out!.includes('题设声明可用的 CLI'));
     assert.ok(out!.includes('`node`'));
     assert.ok(out!.includes('`git`'));
-    assert.ok(out!.includes('不要做环境检查'));
+    assert.ok(out!.includes('不会自动创建文件或修改 runtime 环境'));
   });
 
   it('renders files_available + notes', async () => {
@@ -388,7 +445,7 @@ describe('buildTasksFromArtifacts — environment injection', () => {
       [{ name: 'baseline', kind: 'baseline', source: 'baseline', content: null }],
     );
     assert.equal(tasks.length, 1);
-    assert.ok(tasks[0].prompt.includes('评测环境前置'));
+    assert.ok(tasks[0].prompt.includes('题设环境声明'));
     assert.ok(tasks[0].prompt.includes('`node`'));
     assert.ok(tasks[0].prompt.endsWith('查询Daily标签的工作项'));
   });

--- a/test/executors/capabilities.test.ts
+++ b/test/executors/capabilities.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  assertSamplesCompatibleWithExecutor,
+  enforceExecutorCapabilities,
+  executorSupportsSampleMocks,
+  getExecutorCapabilities,
+} from '../../src/executors/capabilities.js';
+import { createExecutor } from '../../src/executors/index.js';
+import type { ExecutorFn, Sample } from '../../src/types/index.js';
+
+const okExecutor: ExecutorFn = async () => ({
+  ok: true,
+  output: 'ok',
+  durationMs: 1,
+  durationApiMs: 1,
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  costUSD: 0,
+  stopReason: 'end_turn',
+  numTurns: 1,
+});
+
+describe('executor sample-mock capabilities', () => {
+  it('declares built-in support explicitly and delegates custom scripts', () => {
+    assert.equal(getExecutorCapabilities('claude').sampleMocks, 'native-hooks');
+    assert.equal(getExecutorCapabilities('claude-sdk').sampleMocks, 'native-hooks');
+    assert.equal(getExecutorCapabilities('codex').sampleMocks, 'unsupported');
+    assert.equal(getExecutorCapabilities('codex-sdk').sampleMocks, 'unsupported');
+    assert.equal(getExecutorCapabilities('openai-api').sampleMocks, 'unsupported');
+    assert.equal(
+      getExecutorCapabilities('./custom-executor.sh').sampleMocks,
+      'delegated-script',
+    );
+  });
+
+  it('rejects incompatible samples before evaluation starts', () => {
+    const samples: Sample[] = [{
+      sample_id: 'codex-impossible',
+      prompt: 'read a file',
+      mocks: [{ tool: 'Read', return: 'fixture' }],
+      assertions: [{ type: 'mock_hit', value: 'Read:1' }],
+    }];
+
+    assert.throws(
+      () => assertSamplesCompatibleWithExecutor(samples, 'codex'),
+      /不支持 Sample\.mocks.*伪证据.*codex-impossible/,
+    );
+    assert.doesNotThrow(
+      () => assertSamplesCompatibleWithExecutor(samples, 'claude'),
+    );
+  });
+
+  it('guards direct executor calls instead of silently dropping mocks', async () => {
+    const codex = createExecutor('codex');
+    await assert.rejects(
+      () => codex({
+        model: 'test',
+        prompt: 'test',
+        mocks: [{ tool: 'Read', return: 'fixture' }],
+      }),
+      /不支持 Sample\.mocks/,
+    );
+  });
+
+  it('lets a supported executor receive mocks unchanged', async () => {
+    let receivedMocks = 0;
+    const wrapped = enforceExecutorCapabilities('claude', async (input) => {
+      receivedMocks = input.mocks?.length ?? 0;
+      return okExecutor(input);
+    });
+
+    await wrapped({
+      model: 'test',
+      prompt: 'test',
+      mocks: [{ tool: 'Read', return: 'fixture' }],
+    });
+    assert.equal(receivedMocks, 1);
+    assert.equal(executorSupportsSampleMocks('claude'), true);
+    assert.equal(executorSupportsSampleMocks('codex'), false);
+  });
+});

--- a/test/inputs/load-samples.test.ts
+++ b/test/inputs/load-samples.test.ts
@@ -126,6 +126,30 @@ describe('loadSamples', () => {
         error: /mock requires.*return/,
       },
       {
+        name: 'mock_hit must reference an existing mock',
+        sample: { assertions: [{ type: 'mock_hit', value: 'Read:1' }] },
+        error: /mock_hit.*missing mock.*Read:1/,
+      },
+      {
+        name: 'mock_hit ordinal must exist for that tool',
+        sample: {
+          mocks: [{ tool: 'Read', return: 'one' }],
+          assertions: [{ type: 'mock_hit', value: 'Read:2' }],
+        },
+        error: /mock_hit.*missing mock.*Read:2.*Read:1/,
+      },
+      {
+        name: 'nested mock_hit must reference an existing mock',
+        sample: {
+          mocks: [{ tool: 'Read', return: 'one' }],
+          assertions: [{
+            type: 'assert-set',
+            children: [{ type: 'mock_hit', value: 'Bash:1' }],
+          }],
+        },
+        error: /mock_hit.*missing mock.*Bash:1.*Read:1/,
+      },
+      {
         name: 'environment rejects unknown fields',
         sample: { environment: { cli_available: ['git'], typo: true } },
         error: /environment.*invalid shape/,

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -198,6 +198,31 @@ describe('runEvaluation', () => {
     assert.equal(report.executor, 'claude');
   });
 
+  it('dry-run: rejects sample mocks unsupported by the selected executor', async () => {
+    const samplesPath = join(tmpdir(), `omk-codex-mocks-${Date.now()}.json`);
+    writeFileSync(samplesPath, JSON.stringify([{
+      sample_id: 'codex-impossible',
+      prompt: 'read the fixture',
+      mocks: [{ tool: 'Read', return: 'fixture' }],
+      mocksStrict: true,
+      assertions: [{ type: 'mock_hit', value: 'Read:1' }],
+    }]));
+    try {
+      await assert.rejects(
+        () => runEvaluation({
+          samplesPath,
+          skillDir: SKILL_DIR,
+          variantSpecs: asSpecs(['v1']),
+          executorName: 'codex',
+          dryRun: true,
+        }),
+        /不支持 Sample\.mocks.*伪证据.*codex-impossible/,
+      );
+    } finally {
+      rmSync(samplesPath, { force: true });
+    }
+  });
+
   it('dry-run: interleaved scheduling order', async () => {
     const result = await runEvaluation({
       samplesPath: SAMPLES_PATH,

--- a/test/shared/tool-identity.test.ts
+++ b/test/shared/tool-identity.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
-import { normalizeToolIdentity } from '../../src/shared/tool-identity.js';
+import {
+  normalizeToolIdentity,
+  toolIdentityMatches,
+} from '../../src/shared/tool-identity.js';
 
 describe('source-neutral tool identity', () => {
   it('maps provider-specific shell and file events to canonical built-ins', () => {
@@ -85,5 +88,14 @@ describe('source-neutral tool identity', () => {
         displayName: 'github.fetch_file',
       },
     );
+  });
+
+  it('matches source-neutral mock identities against runtime-native aliases', () => {
+    assert.equal(toolIdentityMatches('Bash', 'exec_command'), true);
+    assert.equal(toolIdentityMatches('Edit', 'apply_patch'), true);
+    assert.equal(toolIdentityMatches('Read', 'file_read'), true);
+    assert.equal(toolIdentityMatches('github.fetch_file', 'mcp__github__fetch_file'), true);
+    assert.equal(toolIdentityMatches('Read', 'exec_command'), false);
+    assert.equal(toolIdentityMatches('custom.run', 'custom.run'), true);
   });
 });


### PR DESCRIPTION
## 用户影响

- Codex / Codex SDK 生成用例时会自动进入无 mock 模式，不再产出运行时无法拦截的 Read / Edit mocks 与必然失败的正向工具证据。
- eval 在任何模型调用前校验 executor capability；已有不兼容用例会作为配置错误失败，`--dry-run` 与 `--skip-doctor` 不能绕过。
- `environment` 明确为仅注入 prompt 的题设上下文，不再声称文件已物化；生成器兜底时会把其中事实迁移到显式标注未物化的 `context`。
- `mock_hit` 必须引用真实存在的 per-tool mock 序号，缺失或越界直接拒绝。

## 设计

引入显式 executor mock capability contract，并让 Sample mock 工具名复用 source-neutral identity。executor adapter 会把 `exec_command`、`command_execution`、`apply_patch` 等 runtime-native 名称归一化后再匹配，同时保留旧原生名称兼容。

## 迁移说明

已有 Codex 用例若包含 mocks，需要用 `omk sample --no-mock` 重新生成或删除与 mocks 绑定的断言；确实依赖工具拦截的评测可改用 `claude` / `claude-sdk`。自定义 executor 继续通过 `OMK_MOCK_*` 协议消费 omk 物化的 hook。

## 测量学说明

本次改动阻止 harness mismatch 被计成模型失败，不修改 Report schema、评分 prompt、五层评分管道、bootstrap CI 或 verdict 语义。旧的不兼容运行应视为不可解释证据，不应与修复后的运行直接比较。

Closes #362