### PR TITLE
chore(release): 发布 0.51.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "packageManager": "yarn@4.16.0",
   "description": "Evaluation framework for LLM knowledge inputs — prompts, RAG corpora, skills, agent workflows. Fix the model, vary the artifact. Built-in statistical rigor: bootstrap CI, Krippendorff α, length-debias, saturation curves.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 `v0.51.2`：统一事实检查的共享证据来源，阻止 Codex mock 失配产生伪证据，并更新 Codex SDK 等常规依赖。

## 兼容性

补丁版本，无 CLI、Report schema 或测量口径迁移。