### PR TITLE
docs(brand): 分隔首屏价值与工作流

### DIFF
--- a/docs/.vitepress/theme/landing-body.en.html
+++ b/docs/.vitepress/theme/landing-body.en.html
@@ -7,7 +7,7 @@
 
     <h1>Observe. Measure.<br/><span class="em">Know.</span></h1>
 
-    <p class="sub"><b>OMK makes every knowledge change in your AI application evidence-backed.</b><br/>Observe real-world performance, measure version differences, and determine whether the change is effective and the version is ready to ship. Use <b>doctor → eval → studio</b> before shipping, then close the loop with <b>observe → sample → evolve</b>.</p>
+    <p class="sub"><b>OMK makes every knowledge change in your AI application evidence-backed.</b><br/>Observe real-world performance, measure version differences, and determine whether the change is effective and the version is ready to ship.<span class="hero-workflow">Use <b>doctor → eval → studio</b> before shipping, then close the loop with <b>observe → sample → evolve</b>.</span></p>
 
     <div class="cta">
       <span class="cmd"><span><span class="pfx">$</span> npm i -g oh-my-knowledge</span><span class="copy" onclick="omkCopy('npm i -g oh-my-knowledge', this)">Copy ⧉</span></span>

--- a/docs/.vitepress/theme/landing-body.html
+++ b/docs/.vitepress/theme/landing-body.html
@@ -7,7 +7,7 @@
 
     <h1>Observe. Measure.<br/><span class="em">Know.</span></h1>
 
-    <p class="sub"><b>OMK，让 AI 应用的知识改动有据可依。</b><br/>观测真实表现，量出版本差异，判断改动是否有效、版本能否发布。发布前用 <b>doctor → eval → studio</b> 做判断，发布后用 <b>observe → sample → evolve</b> 闭环。</p>
+    <p class="sub"><b>OMK，让 AI 应用的知识改动有据可依。</b><br/>观测真实表现，量出版本差异，判断改动是否有效、版本能否发布。<span class="hero-workflow">发布前用 <b>doctor → eval → studio</b> 做判断，发布后用 <b>observe → sample → evolve</b> 闭环。</span></p>
 
     <div class="cta">
       <span class="cmd"><span><span class="pfx">$</span> npm i -g oh-my-knowledge</span><span class="copy" onclick="omkCopy('npm i -g oh-my-knowledge', this)">复制 ⧉</span></span>

--- a/docs/.vitepress/theme/landing.css
+++ b/docs/.vitepress/theme/landing.css
@@ -108,6 +108,7 @@
   html[lang="en"] .omk-landing h1 .em{letter-spacing:normal;padding-right:.02em}
   .omk-landing .sub{font-size:clamp(16px,1.7vw,18.5px);color:var(--body);max-width:min(760px,100%);margin:26px 0 0;font-weight:450}
   .omk-landing .sub b{color:var(--ink);font-weight:600}
+  .omk-landing .sub .hero-workflow{display:block;margin-top:8px}
   .omk-landing .cta{display:flex;flex-wrap:wrap;gap:14px 20px;margin-top:34px;align-items:center}
   .omk-landing .lnk{font-weight:600;font-size:14.5px;color:var(--body);display:inline-flex;align-items:center;gap:7px;transition:color .15s}
   .omk-landing .lnk:hover{color:var(--blue)}


### PR DESCRIPTION
## 用户影响

官网首屏将产品价值判断与具体命令工作流强制分行展示，并增加轻微垂直间距，避免宽屏下两类信息挤在同一行。中英文页面保持相同的信息层级，移动端继续自然换行且无横向溢出。

## 迁移说明

无需迁移。仅调整官网首屏排版。

## 测量学影响

无。此次改动不涉及评分类 prompt、报告 schema、统计方法或测量语义。