### PR TITLE
feat(docs): 新增 knowledge 交互式原理实验室

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
           {
             text: 'Understand how it works',
             items: [
+              { text: 'How AI comes to understand', link: '/explanation/how-ai-knows' },
               { text: 'Who omk is for', link: '/explanation/who-omk-is-for' },
               { text: 'The three stages', link: '/explanation/three-stage-workflow' },
               { text: 'Architecture', link: '/explanation/architecture' },
@@ -123,6 +124,7 @@ export default defineConfig({
           {
             text: '我想懂工作原理',
             items: [
+              { text: 'AI 是怎么「懂」的', link: '/zh/explanation/how-ai-knows' },
               { text: '为谁、解决什么', link: '/zh/explanation/who-omk-is-for' },
               { text: '三阶段', link: '/zh/explanation/three-stage-workflow' },
               { text: '工作原理', link: '/zh/explanation/architecture' },

--- a/docs/.vitepress/theme/KnowledgeExplainer.vue
+++ b/docs/.vitepress/theme/KnowledgeExplainer.vue
@@ -1,0 +1,676 @@
+<script setup>
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useData } from 'vitepress'
+import './knowledge-explainer.css'
+
+const isZh = useData().lang.value.startsWith('zh')
+const pick = (zh, en) => (isZh ? zh : en)
+
+const copy = {
+  eyebrow: pick('交互式原理实验室', 'Interactive systems lab'),
+  title: pick('AI 是怎么「懂」的？', 'How does AI come to “understand”?'),
+  intro: pick(
+    '沿着同一条请求，依次观察 Transformer 如何计算、Agent 如何行动，以及 knowledge 如何进入、缺失和改变结果。',
+    'Follow one request through Transformer computation, Agent action, and the way knowledge enters, goes missing, and changes the result.',
+  ),
+  requestLabel: pick('贯穿全程的请求', 'The request we will follow'),
+  request: pick(
+    '请按照这个项目的规范修复登录失败问题。',
+    'Fix the login failure according to this project’s rules.',
+  ),
+  play: pick('播放', 'Play'),
+  pause: pick('暂停', 'Pause'),
+  previous: pick('上一步', 'Previous step'),
+  next: pick('下一步', 'Next step'),
+  restart: pick('重新开始', 'Restart'),
+  simulated: pick('教学模拟', 'Teaching simulation'),
+  observed: pick('观测事实', 'Observed fact'),
+  inferred: pick('系统推断', 'System inference'),
+  unavailable: pick('不可观测', 'Unavailable'),
+  phaseStatus: pick('当前视角', 'Current lens'),
+  transformerLead: pick(
+    '先看语言模型如何把上下文变成下一 token 的概率。',
+    'First, see how a language model turns context into probabilities for the next token.',
+  ),
+  agentLead: pick(
+    '再拉远视角，看模型如何在上下文和工具之间循环工作。',
+    'Then zoom out to see the model loop through context and tools.',
+  ),
+  knowledgeLead: pick(
+    '最后只看 knowledge：它从哪里来、解决什么未知，又怎样改变行动。',
+    'Finally, look only at knowledge: where it comes from, which unknown it resolves, and how it changes action.',
+  ),
+  originalText: pick('原始文字', 'Original text'),
+  toyTokens: pick('教学 token', 'Teaching tokens'),
+  selectedToken: pick('当前 token', 'Selected token'),
+  attentionHint: pick('点击任意 token，查看它与上下文的关联权重。', 'Select any token to inspect its contextual weights.'),
+  formula: 'softmax(QKᵀ / √d)',
+  candidateLabel: pick('下一 token 的概率示意', 'Illustrative next-token probabilities'),
+  agentContext: pick('此刻进入上下文', 'Now entering context'),
+  noContext: pick('尚未获得新的任务证据', 'No new task evidence yet'),
+  contextCount: pick('上下文证据', 'Context evidence'),
+  knowledgeRuleToggle: pick('允许读取项目规范', 'Allow project rules'),
+  knowledgeRuleHelp: pick(
+    '移除这条 knowledge，观察同一任务会怎样改变。',
+    'Remove this knowledge and see how the same task changes.',
+  ),
+  outcome: pick('当前行动', 'Current action'),
+  evidence: pick('可用依据', 'Available basis'),
+  unresolved: pick('仍未解决', 'Still unresolved'),
+  insightTitle: pick('三种 knowledge，不是同一回事', 'Three kinds of knowledge are not the same'),
+  parameterTitle: pick('参数中的 knowledge', 'Knowledge in parameters'),
+  parameterBody: pick(
+    '训练形成的语言和模式能力，不能像文档一样直接列出。',
+    'Language and behavioral patterns learned in training, not a browsable document store.',
+  ),
+  contextTitle: pick('上下文中的 knowledge', 'Knowledge in context'),
+  contextBody: pick(
+    '当前可控的指令、项目文件、memory、RAG 与 skill。',
+    'Controllable instructions, project files, memory, RAG, and skills available now.',
+  ),
+  runtimeTitle: pick('运行中获得的 knowledge', 'Knowledge gained at runtime'),
+  runtimeBody: pick(
+    '读取文件、检索、工具结果和真实环境反馈带来的新证据。',
+    'New evidence from files, retrieval, tool results, and the real environment.',
+  ),
+  boundaryTitle: pick('哪些内容是真的可见？', 'What is actually visible?'),
+  boundaryIntro: pick(
+    '界面始终区分事实、模拟和推断，不把生成的解释冒充模型真实思维。',
+    'The interface keeps facts, simulations, and inferences separate. Generated explanations are not presented as the model’s true thoughts.',
+  ),
+  boundaryItems: [
+    {
+      kind: 'simulated',
+      label: pick('教学模拟', 'Teaching simulation'),
+      body: pick('微型 Transformer 的标准计算与人为简化示例。', 'Standard miniature Transformer mechanics with deliberate simplifications.'),
+    },
+    {
+      kind: 'observed',
+      label: pick('观测事实', 'Observed fact'),
+      body: pick('真实 Agent 的上下文、文件、工具调用和输出。', 'Real Agent context, files, tool calls, and outputs.'),
+    },
+    {
+      kind: 'inferred',
+      label: pick('系统推断', 'System inference'),
+      body: pick('根据 trace 判断哪些 knowledge 可能影响了行为。', 'Trace-based estimates of which knowledge may have affected behavior.'),
+    },
+    {
+      kind: 'unavailable',
+      label: pick('不可观测', 'Unavailable'),
+      body: pick('闭源模型内部的权重、激活和完整因果机制。', 'Weights, activations, and complete causal mechanisms inside a closed model.'),
+    },
+  ],
+  sources: pick('继续阅读', 'Further reading'),
+}
+
+const phases = [
+  {
+    short: 'Transformer',
+    title: pick('模型怎样生成', 'How the model generates'),
+    lead: copy.transformerLead,
+    steps: [
+      pick('切成 token', 'Split into tokens'),
+      pick('形成表示', 'Build representations'),
+      pick('上下文关联', 'Mix context'),
+      pick('预测下一 token', 'Predict next token'),
+    ],
+  },
+  {
+    short: 'Agent',
+    title: pick('Agent 怎样工作', 'How the Agent works'),
+    lead: copy.agentLead,
+    steps: [
+      pick('收到请求', 'Receive request'),
+      pick('装配上下文', 'Assemble context'),
+      pick('搜索代码', 'Search code'),
+      pick('读取规范', 'Read rules'),
+      pick('修改并验证', 'Edit and verify'),
+      pick('返回结果', 'Return result'),
+    ],
+  },
+  {
+    short: 'Knowledge',
+    title: pick('Knowledge 怎样流动', 'How knowledge flows'),
+    lead: copy.knowledgeLead,
+    steps: [
+      pick('参数基础', 'Parameter base'),
+      pick('上下文注入', 'Context injection'),
+      pick('运行时求证', 'Runtime evidence'),
+      pick('任务后沉淀', 'Post-task learning'),
+    ],
+  },
+]
+
+const zhTokens = ['请', '按', '项目', '规范', '修复', '登录', '问题']
+const enTokens = ['Please', 'follow', 'project', 'rules', 'fix', 'login', 'failure']
+const tokens = isZh ? zhTokens : enTokens
+
+const candidateTokens = isZh
+  ? [
+      { token: '先', value: 46 },
+      { token: '读取', value: 31 },
+      { token: '我', value: 15 },
+      { token: '直接', value: 8 },
+    ]
+  : [
+      { token: 'I', value: 42 },
+      { token: 'First', value: 34 },
+      { token: 'Let', value: 16 },
+      { token: 'Directly', value: 8 },
+    ]
+
+const agentEvents = [
+  {
+    title: pick('用户请求', 'User request'),
+    meta: 'user',
+    gained: pick('任务目标', 'Task goal'),
+    detail: pick('模型收到修复目标，但还不知道代码位置和项目约束。', 'The model has the goal, but not the code location or project constraints.'),
+  },
+  {
+    title: pick('系统与项目指令', 'System and project instructions'),
+    meta: 'context',
+    gained: pick('工具边界、仓库约定', 'Tool boundaries, repository conventions'),
+    detail: pick('运行时装配系统指令、项目级说明和当前工作目录。', 'The runtime assembles system instructions, project guidance, and the working directory.'),
+  },
+  {
+    title: pick('搜索登录代码', 'Search login code'),
+    meta: 'tool',
+    gained: pick('相关文件位置', 'Relevant file locations'),
+    detail: pick('Agent 发起搜索，工具结果作为新证据返回上下文。', 'The Agent searches, and tool results return to context as new evidence.'),
+  },
+  {
+    title: pick('读取项目规范', 'Read project rules'),
+    meta: 'file',
+    gained: pick('错误处理与测试要求', 'Error handling and test requirements'),
+    detail: pick('项目规范把通用修复能力约束成当前仓库认可的做法。', 'Project rules constrain generic repair ability to the repository’s accepted practice.'),
+  },
+  {
+    title: pick('修改并运行测试', 'Edit and run tests'),
+    meta: 'tool',
+    gained: pick('真实运行反馈', 'Real execution feedback'),
+    detail: pick('代码改动接受真实测试反馈，失败会再次进入上下文。', 'The edit receives real test feedback, and failures re-enter the context.'),
+  },
+  {
+    title: pick('返回有依据的结果', 'Return an evidenced result'),
+    meta: 'answer',
+    gained: pick('改动、测试与剩余风险', 'Changes, tests, and residual risk'),
+    detail: pick('最终回答来自模型能力、上下文 knowledge 和运行证据的共同作用。', 'The final answer combines model capability, contextual knowledge, and runtime evidence.'),
+  },
+]
+
+const knowledgeSources = [
+  {
+    kind: 'parameter',
+    title: pick('参数', 'Parameters'),
+    subtitle: pick('语言与代码模式', 'Language and code patterns'),
+    detail: pick('模型在训练中形成的通用语言、代码和问题求解模式。', 'General language, code, and problem-solving patterns formed during training.'),
+  },
+  {
+    kind: 'context',
+    title: pick('上下文', 'Context'),
+    subtitle: pick('项目规范与指令', 'Project rules and instructions'),
+    detail: pick('当前任务显式提供、能够检查和替换的 knowledge。', 'Knowledge explicitly supplied to this task and available for inspection or replacement.'),
+  },
+  {
+    kind: 'runtime',
+    title: pick('运行证据', 'Runtime evidence'),
+    subtitle: pick('代码、搜索与测试', 'Code, search, and tests'),
+    detail: pick('Agent 在真实环境中读取和验证后获得的新事实。', 'New facts obtained by reading and validating against the real environment.'),
+  },
+  {
+    kind: 'candidate',
+    title: pick('任务后候选', 'Post-task candidate'),
+    subtitle: pick('纠正与失败经验', 'Corrections and failures'),
+    detail: pick('本次工作暴露出的可复用理解，尚未自动写入任何载体。', 'Reusable understanding exposed by the task, not yet written into any artifact.'),
+  },
+]
+
+const activePhase = ref(0)
+const activeStep = ref(0)
+const selectedToken = ref(4)
+const isPlaying = ref(false)
+const includeProjectRules = ref(true)
+let timer = null
+
+const currentPhase = computed(() => phases[activePhase.value])
+const currentStepLabel = computed(() => currentPhase.value.steps[activeStep.value])
+const progressText = computed(
+  () => `${activeStep.value + 1} / ${currentPhase.value.steps.length}`,
+)
+const activeAgentEvent = computed(() => agentEvents[activeStep.value])
+const activeKnowledgeSource = computed(() => knowledgeSources[activeStep.value])
+
+const attentionWeights = computed(() => {
+  const semanticLinks = {
+    0: [1, 4],
+    1: [2, 3, 4],
+    2: [1, 3, 4],
+    3: [1, 2, 4],
+    4: [2, 3, 5, 6],
+    5: [4, 6],
+    6: [4, 5],
+  }
+  const links = semanticLinks[selectedToken.value] || []
+  const raw = tokens.map((_, index) => {
+    const self = index === selectedToken.value ? 0.34 : 0
+    const semantic = links.includes(index) ? 0.28 : 0
+    const proximity = 0.1 / (Math.abs(index - selectedToken.value) + 1)
+    return 0.025 + self + semantic + proximity
+  })
+  const total = raw.reduce((sum, value) => sum + value, 0)
+  return raw.map((value) => value / total)
+})
+
+const vectorRows = computed(() =>
+  tokens.map((_, tokenIndex) =>
+    Array.from({ length: 6 }, (_, vectorIndex) => {
+      const value = ((tokenIndex + 2) * (vectorIndex + 3) * 17) % 91
+      return 18 + value * 0.72
+    }),
+  ),
+)
+
+const knowledgeOutcome = computed(() => {
+  if (includeProjectRules.value) {
+    return {
+      tone: 'grounded',
+      action: pick('先读取规范，再定位代码并运行测试。', 'Read the rules, locate the code, then run tests.'),
+      basis: pick('通用代码能力 + 项目规范 + 运行证据', 'General coding ability + project rules + runtime evidence'),
+      unresolved: pick('登录失败的具体根因，等待代码与测试确认', 'The concrete root cause, pending code and test evidence'),
+    }
+  }
+  return {
+    tone: 'uncertain',
+    action: pick('直接按通用经验修改，项目约束缺失。', 'Edit from generic experience while project constraints are missing.'),
+    basis: pick('通用代码能力 + 部分运行证据', 'General coding ability + partial runtime evidence'),
+    unresolved: pick('项目认可的做法、测试要求与禁止事项', 'Accepted project practice, test requirements, and prohibited actions'),
+  }
+})
+
+const sceneExplanation = computed(() => {
+  if (activePhase.value === 0) {
+    const details = [
+      pick('真实 tokenizer 因模型而异。这里用可读词片展示「文字先变成离散 token」这一过程。', 'Real tokenizers vary by model. Readable pieces show how text first becomes discrete tokens.'),
+      pick('每个 token 被映射成一组数值。图中的条形只是表示维度，不对应可直接命名的概念。', 'Each token maps to a vector. The bars represent dimensions, not directly named concepts.'),
+      pick('attention 让当前 token 根据其它位置更新表示。权重高不等于完整的因果解释。', 'Attention updates a token from other positions. High weight is not a complete causal explanation.'),
+      pick('模型把最终表示映射成词表概率，再选择一个 token，重复这一过程继续生成。', 'The model maps its final representation to vocabulary probabilities, chooses one token, and repeats.'),
+    ]
+    return details[activeStep.value]
+  }
+  if (activePhase.value === 1) return activeAgentEvent.value.detail
+  return activeKnowledgeSource.value.detail
+})
+
+const sceneTruthKind = computed(() => {
+  if (activePhase.value === 0) return copy.simulated
+  if (activePhase.value === 1) return copy.observed
+  return activeStep.value === 3 ? copy.inferred : copy.observed
+})
+
+function attentionX(index) {
+  return 60 + index * 90
+}
+
+function attentionPath(index) {
+  const from = attentionX(selectedToken.value)
+  const to = attentionX(index)
+  if (from === to) return `M ${from} 116 C ${from - 20} 68, ${from + 20} 68, ${to} 116`
+  const lift = 42 - Math.min(24, Math.abs(from - to) * 0.04)
+  return `M ${from} 116 Q ${(from + to) / 2} ${lift} ${to} 116`
+}
+
+function selectPhase(index) {
+  stopPlayback()
+  activePhase.value = index
+  activeStep.value = 0
+}
+
+function previousStep() {
+  stopPlayback()
+  if (activeStep.value > 0) {
+    activeStep.value -= 1
+    return
+  }
+  if (activePhase.value > 0) {
+    activePhase.value -= 1
+    activeStep.value = phases[activePhase.value].steps.length - 1
+  }
+}
+
+function nextStep({ fromPlayback = false } = {}) {
+  if (!fromPlayback) stopPlayback()
+  if (activeStep.value < currentPhase.value.steps.length - 1) {
+    activeStep.value += 1
+    return
+  }
+  if (activePhase.value < phases.length - 1) {
+    activePhase.value += 1
+    activeStep.value = 0
+    return
+  }
+  if (fromPlayback) {
+    stopPlayback()
+    return
+  }
+  activePhase.value = 0
+  activeStep.value = 0
+}
+
+function startPlayback() {
+  if (timer) return
+  isPlaying.value = true
+  timer = window.setInterval(() => nextStep({ fromPlayback: true }), 2200)
+}
+
+function stopPlayback() {
+  isPlaying.value = false
+  if (timer) {
+    window.clearInterval(timer)
+    timer = null
+  }
+}
+
+function togglePlayback() {
+  if (isPlaying.value) stopPlayback()
+  else startPlayback()
+}
+
+function restart() {
+  stopPlayback()
+  activePhase.value = 0
+  activeStep.value = 0
+  selectedToken.value = 4
+  includeProjectRules.value = true
+}
+
+onMounted(() => {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) stopPlayback()
+})
+onUnmounted(stopPlayback)
+</script>
+
+<template>
+  <main class="omk-knowledge-explainer">
+    <section class="kx-intro">
+      <div class="kx-wrap">
+        <p class="kx-eyebrow">{{ copy.eyebrow }}</p>
+        <h1>{{ copy.title }}</h1>
+        <p class="kx-lead">{{ copy.intro }}</p>
+        <div class="kx-request">
+          <span>{{ copy.requestLabel }}</span>
+          <strong>{{ copy.request }}</strong>
+        </div>
+      </div>
+    </section>
+
+    <section class="kx-lab-section">
+      <div class="kx-wrap">
+        <div class="kx-lab">
+          <header class="kx-lab-header">
+            <div class="kx-phase-switch" role="tablist" :aria-label="copy.phaseStatus">
+              <button
+                v-for="(phase, index) in phases"
+                :key="phase.short"
+                type="button"
+                role="tab"
+                :aria-selected="activePhase === index"
+                :class="{ active: activePhase === index }"
+                @click="selectPhase(index)"
+              >
+                <span>{{ index + 1 }}</span>
+                {{ phase.short }}
+              </button>
+              <i class="kx-phase-packet" :style="{ left: `${(activePhase + 0.5) * 33.3333}%` }" aria-hidden="true"></i>
+            </div>
+
+            <div class="kx-playback">
+              <button type="button" class="kx-icon-button" :title="copy.previous" :aria-label="copy.previous" @click="previousStep">
+                <span aria-hidden="true">←</span>
+              </button>
+              <button type="button" class="kx-play-button" @click="togglePlayback">
+                <span aria-hidden="true">{{ isPlaying ? 'Ⅱ' : '▶' }}</span>
+                {{ isPlaying ? copy.pause : copy.play }}
+              </button>
+              <button type="button" class="kx-icon-button" :title="copy.next" :aria-label="copy.next" @click="nextStep()">
+                <span aria-hidden="true">→</span>
+              </button>
+              <button type="button" class="kx-icon-button" :title="copy.restart" :aria-label="copy.restart" @click="restart">
+                <span aria-hidden="true">↺</span>
+              </button>
+            </div>
+          </header>
+
+          <div class="kx-scene-head">
+            <div>
+              <span>{{ copy.phaseStatus }} · {{ activePhase + 1 }}</span>
+              <h2>{{ currentPhase.title }}</h2>
+              <p>{{ currentPhase.lead }}</p>
+            </div>
+            <div class="kx-step-state" aria-live="polite">
+              <strong>{{ currentStepLabel }}</strong>
+              <span>{{ progressText }}</span>
+            </div>
+          </div>
+
+          <div class="kx-step-rail" :style="{ '--step-count': currentPhase.steps.length }">
+            <button
+              v-for="(label, index) in currentPhase.steps"
+              :key="label"
+              type="button"
+              :class="{ active: activeStep === index, done: activeStep > index }"
+              @click="stopPlayback(); activeStep = index"
+            >
+              <i aria-hidden="true"></i>
+              <span>{{ label }}</span>
+            </button>
+          </div>
+
+          <div class="kx-scene">
+            <div class="kx-visual">
+              <div v-if="activePhase === 0" class="kx-transformer-scene">
+                <div class="kx-original">
+                  <span>{{ copy.originalText }}</span>
+                  <p>{{ copy.request }}</p>
+                </div>
+
+                <div v-if="activeStep === 0" class="kx-tokenization">
+                  <p>{{ copy.toyTokens }}</p>
+                  <div class="kx-token-row">
+                    <span v-for="(token, index) in tokens" :key="`${token}-${index}`" :style="{ '--delay': `${index * 55}ms` }">
+                      {{ token }}
+                    </span>
+                  </div>
+                </div>
+
+                <div v-else-if="activeStep === 1" class="kx-vector-field">
+                  <div v-for="(token, tokenIndex) in tokens" :key="`${token}-vector`" class="kx-vector-token">
+                    <strong>{{ token }}</strong>
+                    <div class="kx-vector-bars" aria-hidden="true">
+                      <i
+                        v-for="(value, vectorIndex) in vectorRows[tokenIndex]"
+                        :key="vectorIndex"
+                        :style="{ height: `${value}%`, opacity: 0.38 + vectorIndex * 0.08 }"
+                      ></i>
+                    </div>
+                  </div>
+                </div>
+
+                <div v-else-if="activeStep === 2" class="kx-attention">
+                  <div class="kx-attention-meta">
+                    <span>{{ copy.selectedToken }}：<strong>{{ tokens[selectedToken] }}</strong></span>
+                    <code>{{ copy.formula }}</code>
+                  </div>
+                  <svg viewBox="0 0 660 154" role="img" :aria-label="copy.attentionHint">
+                    <path
+                      v-for="(_, index) in tokens"
+                      :key="`path-${index}`"
+                      :d="attentionPath(index)"
+                      :class="{ selected: index === selectedToken }"
+                      :style="{
+                        '--weight': attentionWeights[index],
+                        strokeWidth: 1.5 + attentionWeights[index] * 15,
+                        opacity: 0.18 + attentionWeights[index] * 1.7,
+                      }"
+                    />
+                    <circle
+                      v-for="(_, index) in tokens"
+                      :key="`node-${index}`"
+                      :cx="attentionX(index)"
+                      cy="116"
+                      :r="index === selectedToken ? 8 : 5"
+                      :class="{ selected: index === selectedToken }"
+                    />
+                  </svg>
+                  <div class="kx-token-selector">
+                    <button
+                      v-for="(token, index) in tokens"
+                      :key="`${token}-selector`"
+                      type="button"
+                      :class="{ active: selectedToken === index }"
+                      :aria-pressed="selectedToken === index"
+                      @click="selectedToken = index"
+                    >
+                      <span>{{ token }}</span>
+                      <small>{{ Math.round(attentionWeights[index] * 100) }}%</small>
+                    </button>
+                  </div>
+                  <p class="kx-inline-hint">{{ copy.attentionHint }}</p>
+                </div>
+
+                <div v-else class="kx-probabilities">
+                  <p>{{ copy.candidateLabel }}</p>
+                  <div v-for="candidate in candidateTokens" :key="candidate.token" class="kx-probability-row">
+                    <strong>{{ candidate.token }}</strong>
+                    <span><i :style="{ width: `${candidate.value}%` }"></i></span>
+                    <em>{{ candidate.value }}%</em>
+                  </div>
+                </div>
+              </div>
+
+              <div v-else-if="activePhase === 1" class="kx-agent-scene">
+                <div class="kx-agent-track">
+                  <div
+                    v-for="(event, index) in agentEvents"
+                    :key="event.title"
+                    :class="['kx-agent-event', { active: activeStep === index, done: activeStep > index }]"
+                  >
+                    <span>{{ event.meta }}</span>
+                    <strong>{{ event.title }}</strong>
+                    <i v-if="index < agentEvents.length - 1" aria-hidden="true">→</i>
+                  </div>
+                </div>
+                <div class="kx-context-strip">
+                  <div>
+                    <span>{{ copy.agentContext }}</span>
+                    <strong>{{ activeAgentEvent.gained || copy.noContext }}</strong>
+                  </div>
+                  <div class="kx-context-meter">
+                    <span>{{ copy.contextCount }}</span>
+                    <i><b :style="{ width: `${18 + activeStep * 15}%` }"></b></i>
+                    <strong>{{ activeStep + 1 }}</strong>
+                  </div>
+                </div>
+              </div>
+
+              <div v-else class="kx-knowledge-scene">
+                <div class="kx-knowledge-river">
+                  <div
+                    v-for="(source, index) in knowledgeSources"
+                    :key="source.kind"
+                    :class="['kx-knowledge-source', source.kind, { active: activeStep === index, muted: index === 1 && !includeProjectRules }]"
+                  >
+                    <span>{{ index + 1 }}</span>
+                    <strong>{{ source.title }}</strong>
+                    <small>{{ source.subtitle }}</small>
+                  </div>
+                  <i class="kx-knowledge-packet" :style="{ left: `${(activeStep + 0.5) * 25}%` }" aria-hidden="true"></i>
+                </div>
+
+                <label class="kx-rule-toggle">
+                  <input v-model="includeProjectRules" type="checkbox">
+                  <span aria-hidden="true"><i></i></span>
+                  <strong>{{ copy.knowledgeRuleToggle }}</strong>
+                  <small>{{ copy.knowledgeRuleHelp }}</small>
+                </label>
+
+                <div :class="['kx-outcome', knowledgeOutcome.tone]">
+                  <div>
+                    <span>{{ copy.outcome }}</span>
+                    <strong>{{ knowledgeOutcome.action }}</strong>
+                  </div>
+                  <dl>
+                    <div>
+                      <dt>{{ copy.evidence }}</dt>
+                      <dd>{{ knowledgeOutcome.basis }}</dd>
+                    </div>
+                    <div>
+                      <dt>{{ copy.unresolved }}</dt>
+                      <dd>{{ knowledgeOutcome.unresolved }}</dd>
+                    </div>
+                  </dl>
+                </div>
+              </div>
+            </div>
+
+            <aside class="kx-inspector" aria-live="polite">
+              <span :class="['kx-truth-badge', `phase-${activePhase}`]">{{ sceneTruthKind }}</span>
+              <p class="kx-inspector-step">{{ currentStepLabel }}</p>
+              <p>{{ sceneExplanation }}</p>
+              <div v-if="activePhase === 2" class="kx-source-detail">
+                <span>{{ activeKnowledgeSource.title }}</span>
+                <strong>{{ activeKnowledgeSource.subtitle }}</strong>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="kx-insight-section">
+      <div class="kx-wrap">
+        <p class="kx-eyebrow">{{ copy.insightTitle }}</p>
+        <div class="kx-insight-grid">
+          <article>
+            <span>01</span>
+            <h2>{{ copy.parameterTitle }}</h2>
+            <p>{{ copy.parameterBody }}</p>
+          </article>
+          <article>
+            <span>02</span>
+            <h2>{{ copy.contextTitle }}</h2>
+            <p>{{ copy.contextBody }}</p>
+          </article>
+          <article>
+            <span>03</span>
+            <h2>{{ copy.runtimeTitle }}</h2>
+            <p>{{ copy.runtimeBody }}</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="kx-boundary-section">
+      <div class="kx-wrap">
+        <div class="kx-boundary-head">
+          <p class="kx-eyebrow">{{ copy.boundaryTitle }}</p>
+          <p>{{ copy.boundaryIntro }}</p>
+        </div>
+        <div class="kx-boundary-grid">
+          <article v-for="item in copy.boundaryItems" :key="item.kind" :class="item.kind">
+            <i aria-hidden="true"></i>
+            <div>
+              <h2>{{ item.label }}</h2>
+              <p>{{ item.body }}</p>
+            </div>
+          </article>
+        </div>
+        <nav class="kx-sources" :aria-label="copy.sources">
+          <span>{{ copy.sources }}</span>
+          <a href="https://arxiv.org/abs/1706.03762" target="_blank" rel="noreferrer">Attention Is All You Need</a>
+          <a href="https://arxiv.org/abs/2305.04388" target="_blank" rel="noreferrer">Chain-of-Thought Faithfulness</a>
+          <a href="https://www.anthropic.com/research/mapping-mind-language-model" target="_blank" rel="noreferrer">Mechanistic Interpretability</a>
+        </nav>
+      </div>
+    </section>
+  </main>
+</template>

--- a/docs/.vitepress/theme/KnowledgeExplainer.vue
+++ b/docs/.vitepress/theme/KnowledgeExplainer.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useData } from 'vitepress'
 import './knowledge-explainer.css'
 
@@ -7,381 +7,344 @@ const isZh = useData().lang.value.startsWith('zh')
 const pick = (zh, en) => (isZh ? zh : en)
 
 const copy = {
-  eyebrow: pick('交互式原理实验室', 'Interactive systems lab'),
-  title: pick('AI 是怎么「懂」的？', 'How does AI come to “understand”?'),
+  eyebrow: pick('一个可探索的 AI 工作现场', 'An explorable AI workbench'),
+  title: pick('一条请求，AI 究竟知道什么？', 'One request. What does AI actually know?'),
   intro: pick(
-    '沿着同一条请求，依次观察 Transformer 如何计算、Agent 如何行动，以及 knowledge 如何进入、缺失和改变结果。',
-    'Follow one request through Transformer computation, Agent action, and the way knowledge enters, goes missing, and changes the result.',
+    '不要把它当成三张流程图。播放同一条请求，看文字怎样变成行动、外部 knowledge 怎样进入上下文，以及少一条规范为什么会改变结果。',
+    'Do not treat this as three flowcharts. Follow one request as text becomes action, external knowledge enters context, and one missing rule changes the result.',
   ),
-  requestLabel: pick('贯穿全程的请求', 'The request we will follow'),
   request: pick(
     '请按照这个项目的规范修复登录失败问题。',
     'Fix the login failure according to this project’s rules.',
   ),
   play: pick('播放', 'Play'),
   pause: pick('暂停', 'Pause'),
-  previous: pick('上一步', 'Previous step'),
-  next: pick('下一步', 'Next step'),
+  previous: pick('上一步', 'Previous'),
+  next: pick('下一步', 'Next'),
   restart: pick('重新开始', 'Restart'),
-  simulated: pick('教学模拟', 'Teaching simulation'),
-  observed: pick('观测事实', 'Observed fact'),
-  inferred: pick('系统推断', 'System inference'),
-  unavailable: pick('不可观测', 'Unavailable'),
-  phaseStatus: pick('当前视角', 'Current lens'),
-  transformerLead: pick(
-    '先看语言模型如何把上下文变成下一 token 的概率。',
-    'First, see how a language model turns context into probabilities for the next token.',
+  timeline: pick('动画进度', 'Animation progress'),
+  scene: pick('场景', 'Scene'),
+  truth: pick('这一幕是什么', 'What this scene represents'),
+  ruleToggle: pick('项目规范', 'Project rules'),
+  ruleOn: pick('已进入上下文', 'in context'),
+  ruleOff: pick('已从上下文移除', 'removed'),
+  ruleHelp: pick(
+    '切换后，模型不变，只有可用 knowledge 改变。',
+    'The model stays fixed. Only the available knowledge changes.',
   ),
-  agentLead: pick(
-    '再拉远视角，看模型如何在上下文和工具之间循环工作。',
-    'Then zoom out to see the model loop through context and tools.',
-  ),
-  knowledgeLead: pick(
-    '最后只看 knowledge：它从哪里来、解决什么未知，又怎样改变行动。',
-    'Finally, look only at knowledge: where it comes from, which unknown it resolves, and how it changes action.',
-  ),
-  originalText: pick('原始文字', 'Original text'),
-  toyTokens: pick('教学 token', 'Teaching tokens'),
-  selectedToken: pick('当前 token', 'Selected token'),
-  attentionHint: pick('点击任意 token，查看它与上下文的关联权重。', 'Select any token to inspect its contextual weights.'),
-  formula: 'softmax(QKᵀ / √d)',
-  candidateLabel: pick('下一 token 的概率示意', 'Illustrative next-token probabilities'),
-  agentContext: pick('此刻进入上下文', 'Now entering context'),
-  noContext: pick('尚未获得新的任务证据', 'No new task evidence yet'),
-  contextCount: pick('上下文证据', 'Context evidence'),
-  knowledgeRuleToggle: pick('允许读取项目规范', 'Allow project rules'),
-  knowledgeRuleHelp: pick(
-    '移除这条 knowledge，观察同一任务会怎样改变。',
-    'Remove this knowledge and see how the same task changes.',
-  ),
-  outcome: pick('当前行动', 'Current action'),
-  evidence: pick('可用依据', 'Available basis'),
-  unresolved: pick('仍未解决', 'Still unresolved'),
-  insightTitle: pick('三种 knowledge，不是同一回事', 'Three kinds of knowledge are not the same'),
-  parameterTitle: pick('参数中的 knowledge', 'Knowledge in parameters'),
-  parameterBody: pick(
-    '训练形成的语言和模式能力，不能像文档一样直接列出。',
-    'Language and behavioral patterns learned in training, not a browsable document store.',
-  ),
-  contextTitle: pick('上下文中的 knowledge', 'Knowledge in context'),
-  contextBody: pick(
-    '当前可控的指令、项目文件、memory、RAG 与 skill。',
-    'Controllable instructions, project files, memory, RAG, and skills available now.',
-  ),
-  runtimeTitle: pick('运行中获得的 knowledge', 'Knowledge gained at runtime'),
-  runtimeBody: pick(
-    '读取文件、检索、工具结果和真实环境反馈带来的新证据。',
-    'New evidence from files, retrieval, tool results, and the real environment.',
-  ),
-  boundaryTitle: pick('哪些内容是真的可见？', 'What is actually visible?'),
-  boundaryIntro: pick(
-    '界面始终区分事实、模拟和推断，不把生成的解释冒充模型真实思维。',
-    'The interface keeps facts, simulations, and inferences separate. Generated explanations are not presented as the model’s true thoughts.',
-  ),
-  boundaryItems: [
+  userRequest: pick('用户请求', 'User request'),
+  workingContext: pick('工作上下文', 'Working context'),
+  contextEmpty: pick('等待外部证据', 'Waiting for external evidence'),
+  model: pick('微型 Transformer', 'Toy Transformer'),
+  modelMeta: pick('固定参数', 'fixed parameters'),
+  attention: 'self-attention',
+  actionCandidates: pick('下一动作概率', 'Next-action probabilities'),
+  realWorld: pick('真实环境', 'Real environment'),
+  toolIdle: pick('工具尚未调用', 'No tool call yet'),
+  toolReading: pick('读取项目文件', 'Reading project files'),
+  toolTesting: pick('运行登录测试', 'Running login tests'),
+  knowledgeSources: pick('可用 knowledge', 'Available knowledge'),
+  parameter: pick('参数模式', 'Parameter patterns'),
+  projectRule: pick('项目规范', 'Project rules'),
+  runtimeEvidence: pick('运行证据', 'Runtime evidence'),
+  candidate: pick('经验候选', 'Experience candidate'),
+  nextAction: pick('下一行动', 'Next action'),
+  withRule: pick('有项目规范', 'With project rules'),
+  withoutRule: pick('没有项目规范', 'Without project rules'),
+  groundedAction: pick('先按仓库约定处理错误，再运行登录测试。', 'Apply the repository error policy, then run the login tests.'),
+  genericAction: pick('按通用经验直接修改登录逻辑。', 'Edit the login logic from generic experience.'),
+  observedResult: pick('测试暴露：刷新令牌失效时必须清除本地会话。', 'Test evidence: an expired refresh token must clear the local session.'),
+  contextSystem: pick('工具边界', 'Tool boundaries'),
+  contextRule: pick('错误处理规范', 'Error-handling policy'),
+  contextFile: 'auth/session.ts',
+  contextTest: pick('登录测试失败', 'Login test failed'),
+  outputTool: pick('读取 AGENTS.md', 'Read AGENTS.md'),
+  outputSearch: pick('搜索登录逻辑', 'Search login logic'),
+  outputEdit: pick('直接修改代码', 'Edit code now'),
+  outputAnswer: pick('直接回答', 'Answer now'),
+  selectedToken: pick('点击 token，观察关联', 'Select a token to inspect attention'),
+  summaryEyebrow: pick('把尺度分开，才不会把 knowledge 混成一团', 'Separate the scales before discussing knowledge'),
+  summaryTitle: pick('模型提供能力，环境提供事实，knowledge 提供具体依据。', 'The model supplies capability, the environment supplies facts, and knowledge supplies situated guidance.'),
+  layers: [
     {
-      kind: 'simulated',
-      label: pick('教学模拟', 'Teaching simulation'),
-      body: pick('微型 Transformer 的标准计算与人为简化示例。', 'Standard miniature Transformer mechanics with deliberate simplifications.'),
+      key: 'parameters',
+      index: '01',
+      title: pick('参数中的 knowledge', 'Knowledge in parameters'),
+      body: pick('训练形成的语言与代码模式。它影响能力，但不是一个可以逐条打开的文档库。', 'Language and code patterns formed during training. They shape capability but are not a browsable document store.'),
     },
     {
-      kind: 'observed',
-      label: pick('观测事实', 'Observed fact'),
-      body: pick('真实 Agent 的上下文、文件、工具调用和输出。', 'Real Agent context, files, tool calls, and outputs.'),
+      key: 'context',
+      index: '02',
+      title: pick('上下文中的 knowledge', 'Knowledge in context'),
+      body: pick('指令、项目文件、memory、RAG 与 skill。它们可检查、可替换，也最适合受控比较。', 'Instructions, project files, memory, RAG, and skills. They are inspectable, replaceable, and suitable for controlled comparison.'),
     },
     {
-      kind: 'inferred',
-      label: pick('系统推断', 'System inference'),
-      body: pick('根据 trace 判断哪些 knowledge 可能影响了行为。', 'Trace-based estimates of which knowledge may have affected behavior.'),
+      key: 'runtime',
+      index: '03',
+      title: pick('运行中获得的 knowledge', 'Knowledge gained at runtime'),
+      body: pick('文件内容、搜索结果、测试反馈与真实环境状态。它们通过工具返回上下文。', 'File contents, search results, test feedback, and environment state. Tools return them to context.'),
     },
     {
-      kind: 'unavailable',
-      label: pick('不可观测', 'Unavailable'),
-      body: pick('闭源模型内部的权重、激活和完整因果机制。', 'Weights, activations, and complete causal mechanisms inside a closed model.'),
+      key: 'candidate',
+      index: '04',
+      title: pick('工作后形成的候选', 'Post-task candidates'),
+      body: pick('纠正、失败经验与隐性标准。它们值得复核，但不会自动成为可靠 knowledge。', 'Corrections, failures, and tacit standards. They deserve review but do not automatically become reliable knowledge.'),
     },
   ],
-  sources: pick('继续阅读', 'Further reading'),
+  boundaryEyebrow: pick('别把可视化冒充读心术', 'Visualization is not mind reading'),
+  boundaryTitle: pick('我们只展示能够诚实说明的部分。', 'Show only what can be represented honestly.'),
+  boundaries: [
+    {
+      key: 'simulated',
+      title: pick('教学模拟', 'Teaching simulation'),
+      body: pick('token、attention 和动作概率使用可解释的微型示例。', 'Tokens, attention, and action probabilities use an interpretable toy example.'),
+    },
+    {
+      key: 'observed',
+      title: pick('观测事实', 'Observed fact'),
+      body: pick('请求、上下文、工具调用、文件和测试结果可以被 trace 记录。', 'Requests, context, tool calls, files, and test results can be recorded in traces.'),
+    },
+    {
+      key: 'inferred',
+      title: pick('系统推断', 'System inference'),
+      body: pick('移除 knowledge 后的影响需要通过受控比较建立证据。', 'The effect of removing knowledge requires evidence from controlled comparison.'),
+    },
+    {
+      key: 'unavailable',
+      title: pick('不可观测', 'Unavailable'),
+      body: pick('闭源模型的完整激活、权重因果链和所谓「真实内心独白」。', 'Complete activations, causal weight paths, and any supposed inner monologue of a closed model.'),
+    },
+  ],
+  omkEyebrow: 'OMK',
+  omkTitle: pick('OMK 观察的，正是可控 knowledge 与真实结果之间的这段距离。', 'OMK observes the distance between controllable knowledge and real outcomes.'),
+  omkBody: pick(
+    '它不解释闭源模型脑内发生了什么；它固定模型与评测用例，改变知识载体，记录 trace，并比较版本差异是否真的成立。',
+    'It does not explain what happens inside a closed model. It fixes the model and evaluation cases, changes the knowledge artifact, records traces, and tests whether a version difference is real.',
+  ),
+  sources: pick('参考', 'Sources'),
 }
 
-const phases = [
+const scenes = [
   {
-    short: 'Transformer',
-    title: pick('模型怎样生成', 'How the model generates'),
-    lead: copy.transformerLead,
-    steps: [
-      pick('切成 token', 'Split into tokens'),
-      pick('形成表示', 'Build representations'),
-      pick('上下文关联', 'Mix context'),
-      pick('预测下一 token', 'Predict next token'),
-    ],
+    key: 'request',
+    short: pick('请求', 'Request'),
+    title: pick('任务从一句自然语言开始', 'The task begins as natural language'),
+    body: pick(
+      'Agent 此刻只有目标。代码在哪里、项目允许怎样修改、真正的根因是什么，都还是未知。',
+      'The Agent has a goal, but the code location, accepted project practice, and concrete root cause are still unknown.',
+    ),
+    truth: pick('观测事实', 'Observed fact'),
+    truthKind: 'observed',
   },
   {
-    short: 'Agent',
-    title: pick('Agent 怎样工作', 'How the Agent works'),
-    lead: copy.agentLead,
-    steps: [
-      pick('收到请求', 'Receive request'),
-      pick('装配上下文', 'Assemble context'),
-      pick('搜索代码', 'Search code'),
-      pick('读取规范', 'Read rules'),
-      pick('修改并验证', 'Edit and verify'),
-      pick('返回结果', 'Return result'),
-    ],
+    key: 'tokens',
+    short: 'Token',
+    title: pick('文字先被切成 token', 'Text first becomes tokens'),
+    body: pick(
+      '模型不会直接读取完整句意。token 被映射为数值表示，沿同一条路径进入模型。',
+      'The model does not ingest a finished sentence meaning. Tokens become numerical representations and enter the model together.',
+    ),
+    truth: pick('教学模拟', 'Teaching simulation'),
+    truthKind: 'simulated',
   },
   {
+    key: 'attention',
+    short: 'Attention',
+    title: pick('上下文改变每个 token 的表示', 'Context changes each token representation'),
+    body: pick(
+      '点击 token 查看 attention 关联。线更强只表示这个微型示例中的权重更高，不等于完整因果解释。',
+      'Select a token to inspect attention. A stronger line only means a higher weight in this toy example, not a complete causal explanation.',
+    ),
+    truth: pick('教学模拟', 'Teaching simulation'),
+    truthKind: 'simulated',
+  },
+  {
+    key: 'decision',
+    short: pick('动作', 'Action'),
+    title: pick('模型生成的下一项，可以是工具调用', 'The next generated item can be a tool call'),
+    body: pick(
+      '真实 Agent 能观测到工具调用；这里的概率只是教学模拟。项目规范在上下文中时，「先读取规范」更可能被选择。',
+      'A real Agent exposes the tool call; the probabilities here are illustrative. When project rules are in context, reading them first becomes more likely.',
+    ),
+    truth: pick('模拟概率／可观测动作', 'Simulated probability / observed action'),
+    truthKind: 'mixed',
+  },
+  {
+    key: 'evidence',
+    short: pick('证据', 'Evidence'),
+    title: pick('工具把真实世界带回上下文', 'Tools bring the real world back into context'),
+    body: pick(
+      '文件内容和测试失败不是模型参数里的记忆。它们在运行时被读取，作为新证据返回下一轮模型调用。',
+      'File contents and test failures are not memories stored in model parameters. They are read at runtime and returned as evidence for the next model call.',
+    ),
+    truth: pick('观测事实', 'Observed fact'),
+    truthKind: 'observed',
+  },
+  {
+    key: 'knowledge',
     short: 'Knowledge',
-    title: pick('Knowledge 怎样流动', 'How knowledge flows'),
-    lead: copy.knowledgeLead,
-    steps: [
-      pick('参数基础', 'Parameter base'),
-      pick('上下文注入', 'Context injection'),
-      pick('运行时求证', 'Runtime evidence'),
-      pick('任务后沉淀', 'Post-task learning'),
-    ],
+    title: pick('项目 knowledge 进入同一个上下文', 'Project knowledge enters the same context'),
+    body: pick(
+      '参数没有改变。Agent 只是多了一条当前项目认可的错误处理规范，它因此有了更具体的行动依据。',
+      'The parameters did not change. The Agent gained one accepted error-handling rule for this project, giving it more specific grounds for action.',
+    ),
+    truth: pick('观测事实', 'Observed fact'),
+    truthKind: 'observed',
+  },
+  {
+    key: 'fork',
+    short: pick('分叉', 'Fork'),
+    title: pick('同一个模型，不同 knowledge，不同行动', 'Same model, different knowledge, different action'),
+    body: pick(
+      '切换「项目规范」开关。这个对照展示产品假设；要证明真实效果，还需要固定模型和用例做重复评测。',
+      'Toggle project rules. This contrast illustrates the product hypothesis; proving a real effect still requires repeated evaluation with a fixed model and cases.',
+    ),
+    truth: pick('系统推断', 'System inference'),
+    truthKind: 'inferred',
+  },
+  {
+    key: 'candidate',
+    short: pick('沉淀', 'Candidate'),
+    title: pick('一次任务结束，新的 knowledge 只是一名候选', 'A finished task yields only a knowledge candidate'),
+    body: pick(
+      '测试暴露的规律、用户纠正和失败经验可以进入待复核池。复用之前，仍要判断它是否稳定、适用且真的有效。',
+      'Patterns exposed by tests, user corrections, and failures can enter a review pool. Before reuse, they still need evidence of stability, scope, and effectiveness.',
+    ),
+    truth: pick('系统推断', 'System inference'),
+    truthKind: 'inferred',
   },
 ]
 
-const zhTokens = ['请', '按', '项目', '规范', '修复', '登录', '问题']
-const enTokens = ['Please', 'follow', 'project', 'rules', 'fix', 'login', 'failure']
-const tokens = isZh ? zhTokens : enTokens
+const tokens = isZh
+  ? ['请', '按', '项目', '规范', '修复', '登录', '问题']
+  : ['Fix', 'login', 'using', 'project', 'rules', 'please', '.']
 
-const candidateTokens = isZh
-  ? [
-      { token: '先', value: 46 },
-      { token: '读取', value: 31 },
-      { token: '我', value: 15 },
-      { token: '直接', value: 8 },
-    ]
-  : [
-      { token: 'I', value: 42 },
-      { token: 'First', value: 34 },
-      { token: 'Let', value: 16 },
-      { token: 'Directly', value: 8 },
-    ]
-
-const agentEvents = [
-  {
-    title: pick('用户请求', 'User request'),
-    meta: 'user',
-    gained: pick('任务目标', 'Task goal'),
-    detail: pick('模型收到修复目标，但还不知道代码位置和项目约束。', 'The model has the goal, but not the code location or project constraints.'),
-  },
-  {
-    title: pick('系统与项目指令', 'System and project instructions'),
-    meta: 'context',
-    gained: pick('工具边界、仓库约定', 'Tool boundaries, repository conventions'),
-    detail: pick('运行时装配系统指令、项目级说明和当前工作目录。', 'The runtime assembles system instructions, project guidance, and the working directory.'),
-  },
-  {
-    title: pick('搜索登录代码', 'Search login code'),
-    meta: 'tool',
-    gained: pick('相关文件位置', 'Relevant file locations'),
-    detail: pick('Agent 发起搜索，工具结果作为新证据返回上下文。', 'The Agent searches, and tool results return to context as new evidence.'),
-  },
-  {
-    title: pick('读取项目规范', 'Read project rules'),
-    meta: 'file',
-    gained: pick('错误处理与测试要求', 'Error handling and test requirements'),
-    detail: pick('项目规范把通用修复能力约束成当前仓库认可的做法。', 'Project rules constrain generic repair ability to the repository’s accepted practice.'),
-  },
-  {
-    title: pick('修改并运行测试', 'Edit and run tests'),
-    meta: 'tool',
-    gained: pick('真实运行反馈', 'Real execution feedback'),
-    detail: pick('代码改动接受真实测试反馈，失败会再次进入上下文。', 'The edit receives real test feedback, and failures re-enter the context.'),
-  },
-  {
-    title: pick('返回有依据的结果', 'Return an evidenced result'),
-    meta: 'answer',
-    gained: pick('改动、测试与剩余风险', 'Changes, tests, and residual risk'),
-    detail: pick('最终回答来自模型能力、上下文 knowledge 和运行证据的共同作用。', 'The final answer combines model capability, contextual knowledge, and runtime evidence.'),
-  },
-]
-
-const knowledgeSources = [
-  {
-    kind: 'parameter',
-    title: pick('参数', 'Parameters'),
-    subtitle: pick('语言与代码模式', 'Language and code patterns'),
-    detail: pick('模型在训练中形成的通用语言、代码和问题求解模式。', 'General language, code, and problem-solving patterns formed during training.'),
-  },
-  {
-    kind: 'context',
-    title: pick('上下文', 'Context'),
-    subtitle: pick('项目规范与指令', 'Project rules and instructions'),
-    detail: pick('当前任务显式提供、能够检查和替换的 knowledge。', 'Knowledge explicitly supplied to this task and available for inspection or replacement.'),
-  },
-  {
-    kind: 'runtime',
-    title: pick('运行证据', 'Runtime evidence'),
-    subtitle: pick('代码、搜索与测试', 'Code, search, and tests'),
-    detail: pick('Agent 在真实环境中读取和验证后获得的新事实。', 'New facts obtained by reading and validating against the real environment.'),
-  },
-  {
-    kind: 'candidate',
-    title: pick('任务后候选', 'Post-task candidate'),
-    subtitle: pick('纠正与失败经验', 'Corrections and failures'),
-    detail: pick('本次工作暴露出的可复用理解，尚未自动写入任何载体。', 'Reusable understanding exposed by the task, not yet written into any artifact.'),
-  },
-]
-
-const activePhase = ref(0)
-const activeStep = ref(0)
-const selectedToken = ref(4)
+const activeScene = ref(0)
+const selectedToken = ref(isZh ? 3 : 4)
 const isPlaying = ref(false)
-const includeProjectRules = ref(true)
-let timer = null
+const rulesEnabled = ref(true)
+let timer
 
-const currentPhase = computed(() => phases[activePhase.value])
-const currentStepLabel = computed(() => currentPhase.value.steps[activeStep.value])
-const progressText = computed(
-  () => `${activeStep.value + 1} / ${currentPhase.value.steps.length}`,
-)
-const activeAgentEvent = computed(() => agentEvents[activeStep.value])
-const activeKnowledgeSource = computed(() => knowledgeSources[activeStep.value])
+const scene = computed(() => scenes[activeScene.value])
+const stageClass = computed(() => [
+  `scene-${activeScene.value}`,
+  `scene-${scene.value.key}`,
+  rulesEnabled.value ? 'rules-on' : 'rules-off',
+])
+const sceneProgress = computed(() => ((activeScene.value + 1) / scenes.length) * 100)
+const showAttention = computed(() => activeScene.value === 2)
+const showProbabilities = computed(() => activeScene.value >= 3)
 
 const attentionWeights = computed(() => {
-  const semanticLinks = {
-    0: [1, 4],
-    1: [2, 3, 4],
-    2: [1, 3, 4],
-    3: [1, 2, 4],
-    4: [2, 3, 5, 6],
-    5: [4, 6],
-    6: [4, 5],
-  }
-  const links = semanticLinks[selectedToken.value] || []
-  const raw = tokens.map((_, index) => {
-    const self = index === selectedToken.value ? 0.34 : 0
-    const semantic = links.includes(index) ? 0.28 : 0
+  const links = isZh
+    ? {
+        0: [1, 4],
+        1: [2, 3, 4],
+        2: [1, 3, 4],
+        3: [1, 2, 4],
+        4: [2, 3, 5, 6],
+        5: [4, 6],
+        6: [4, 5],
+      }
+    : {
+        0: [1, 2, 5],
+        1: [0, 2, 6],
+        2: [0, 1, 3, 4],
+        3: [2, 4],
+        4: [2, 3],
+        5: [0, 6],
+        6: [1, 5],
+      }
+  const related = links[selectedToken.value] || []
+  const values = tokens.map((_, index) => {
+    const self = index === selectedToken.value ? 0.36 : 0
+    const semantic = related.includes(index) ? 0.25 : 0
     const proximity = 0.1 / (Math.abs(index - selectedToken.value) + 1)
-    return 0.025 + self + semantic + proximity
+    return 0.02 + self + semantic + proximity
   })
-  const total = raw.reduce((sum, value) => sum + value, 0)
-  return raw.map((value) => value / total)
+  const total = values.reduce((sum, value) => sum + value, 0)
+  return values.map((value) => value / total)
 })
 
-const vectorRows = computed(() =>
-  tokens.map((_, tokenIndex) =>
-    Array.from({ length: 6 }, (_, vectorIndex) => {
-      const value = ((tokenIndex + 2) * (vectorIndex + 3) * 17) % 91
-      return 18 + value * 0.72
-    }),
-  ),
-)
-
-const knowledgeOutcome = computed(() => {
-  if (includeProjectRules.value) {
-    return {
-      tone: 'grounded',
-      action: pick('先读取规范，再定位代码并运行测试。', 'Read the rules, locate the code, then run tests.'),
-      basis: pick('通用代码能力 + 项目规范 + 运行证据', 'General coding ability + project rules + runtime evidence'),
-      unresolved: pick('登录失败的具体根因，等待代码与测试确认', 'The concrete root cause, pending code and test evidence'),
-    }
-  }
-  return {
-    tone: 'uncertain',
-    action: pick('直接按通用经验修改，项目约束缺失。', 'Edit from generic experience while project constraints are missing.'),
-    basis: pick('通用代码能力 + 部分运行证据', 'General coding ability + partial runtime evidence'),
-    unresolved: pick('项目认可的做法、测试要求与禁止事项', 'Accepted project practice, test requirements, and prohibited actions'),
-  }
-})
-
-const sceneExplanation = computed(() => {
-  if (activePhase.value === 0) {
-    const details = [
-      pick('真实 tokenizer 因模型而异。这里用可读词片展示「文字先变成离散 token」这一过程。', 'Real tokenizers vary by model. Readable pieces show how text first becomes discrete tokens.'),
-      pick('每个 token 被映射成一组数值。图中的条形只是表示维度，不对应可直接命名的概念。', 'Each token maps to a vector. The bars represent dimensions, not directly named concepts.'),
-      pick('attention 让当前 token 根据其它位置更新表示。权重高不等于完整的因果解释。', 'Attention updates a token from other positions. High weight is not a complete causal explanation.'),
-      pick('模型把最终表示映射成词表概率，再选择一个 token，重复这一过程继续生成。', 'The model maps its final representation to vocabulary probabilities, chooses one token, and repeats.'),
+const actionCandidates = computed(() => {
+  if (rulesEnabled.value) {
+    return [
+      { label: copy.outputTool, value: 56, kind: 'primary' },
+      { label: copy.outputSearch, value: 27, kind: 'secondary' },
+      { label: copy.outputEdit, value: 11, kind: 'warning' },
+      { label: copy.outputAnswer, value: 6, kind: 'muted' },
     ]
-    return details[activeStep.value]
   }
-  if (activePhase.value === 1) return activeAgentEvent.value.detail
-  return activeKnowledgeSource.value.detail
-})
-
-const sceneTruthKind = computed(() => {
-  if (activePhase.value === 0) return copy.simulated
-  if (activePhase.value === 1) return copy.observed
-  return activeStep.value === 3 ? copy.inferred : copy.observed
+  return [
+    { label: copy.outputSearch, value: 39, kind: 'secondary' },
+    { label: copy.outputEdit, value: 35, kind: 'warning' },
+    { label: copy.outputAnswer, value: 18, kind: 'muted' },
+    { label: copy.outputTool, value: 8, kind: 'primary' },
+  ]
 })
 
 function attentionX(index) {
-  return 60 + index * 90
+  return 22 + index * 39
 }
 
 function attentionPath(index) {
   const from = attentionX(selectedToken.value)
   const to = attentionX(index)
-  if (from === to) return `M ${from} 116 C ${from - 20} 68, ${from + 20} 68, ${to} 116`
-  const lift = 42 - Math.min(24, Math.abs(from - to) * 0.04)
-  return `M ${from} 116 Q ${(from + to) / 2} ${lift} ${to} 116`
-}
-
-function selectPhase(index) {
-  stopPlayback()
-  activePhase.value = index
-  activeStep.value = 0
-}
-
-function previousStep() {
-  stopPlayback()
-  if (activeStep.value > 0) {
-    activeStep.value -= 1
-    return
-  }
-  if (activePhase.value > 0) {
-    activePhase.value -= 1
-    activeStep.value = phases[activePhase.value].steps.length - 1
-  }
-}
-
-function nextStep({ fromPlayback = false } = {}) {
-  if (!fromPlayback) stopPlayback()
-  if (activeStep.value < currentPhase.value.steps.length - 1) {
-    activeStep.value += 1
-    return
-  }
-  if (activePhase.value < phases.length - 1) {
-    activePhase.value += 1
-    activeStep.value = 0
-    return
-  }
-  if (fromPlayback) {
-    stopPlayback()
-    return
-  }
-  activePhase.value = 0
-  activeStep.value = 0
-}
-
-function startPlayback() {
-  if (timer) return
-  isPlaying.value = true
-  timer = window.setInterval(() => nextStep({ fromPlayback: true }), 2200)
+  if (from === to) return `M ${from} 76 C ${from - 12} 42, ${from + 12} 42, ${to} 76`
+  return `M ${from} 76 Q ${(from + to) / 2} ${18 + Math.abs(from - to) * 0.04} ${to} 76`
 }
 
 function stopPlayback() {
   isPlaying.value = false
   if (timer) {
     window.clearInterval(timer)
-    timer = null
+    timer = undefined
   }
 }
 
+function goToScene(index, { keepPlayback = false } = {}) {
+  if (!keepPlayback) stopPlayback()
+  activeScene.value = Math.max(0, Math.min(scenes.length - 1, Number(index)))
+}
+
+function previousScene() {
+  goToScene(activeScene.value > 0 ? activeScene.value - 1 : scenes.length - 1)
+}
+
+function nextScene({ fromPlayback = false } = {}) {
+  const atEnd = activeScene.value === scenes.length - 1
+  if (atEnd && fromPlayback) {
+    stopPlayback()
+    return
+  }
+  goToScene(atEnd ? 0 : activeScene.value + 1, { keepPlayback: fromPlayback })
+}
+
 function togglePlayback() {
-  if (isPlaying.value) stopPlayback()
-  else startPlayback()
+  if (isPlaying.value) {
+    stopPlayback()
+    return
+  }
+  if (activeScene.value === scenes.length - 1) activeScene.value = 0
+  isPlaying.value = true
+  timer = window.setInterval(() => nextScene({ fromPlayback: true }), 3200)
 }
 
 function restart() {
   stopPlayback()
-  activePhase.value = 0
-  activeStep.value = 0
-  selectedToken.value = 4
-  includeProjectRules.value = true
+  activeScene.value = 0
+  selectedToken.value = isZh ? 3 : 4
+  rulesEnabled.value = true
 }
+
+function toggleRules() {
+  stopPlayback()
+  rulesEnabled.value = !rulesEnabled.value
+}
+
+watch(activeScene, (value) => {
+  if (value === 6 && isPlaying.value) stopPlayback()
+})
 
 onMounted(() => {
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) stopPlayback()
@@ -396,254 +359,266 @@ onUnmounted(stopPlayback)
         <p class="kx-eyebrow">{{ copy.eyebrow }}</p>
         <h1>{{ copy.title }}</h1>
         <p class="kx-lead">{{ copy.intro }}</p>
-        <div class="kx-request">
-          <span>{{ copy.requestLabel }}</span>
-          <strong>{{ copy.request }}</strong>
-        </div>
       </div>
     </section>
 
-    <section class="kx-lab-section">
+    <section class="kx-theater-section">
       <div class="kx-wrap">
-        <div class="kx-lab">
-          <header class="kx-lab-header">
-            <div class="kx-phase-switch" role="tablist" :aria-label="copy.phaseStatus">
+        <div class="kx-theater">
+          <header class="kx-story-head">
+            <div>
+              <span>{{ copy.scene }} {{ activeScene + 1 }} / {{ scenes.length }}</span>
+              <h2>{{ scene.title }}</h2>
+              <p>{{ scene.body }}</p>
+            </div>
+            <div :class="['kx-truth', scene.truthKind]">
+              <small>{{ copy.truth }}</small>
+              <strong>{{ scene.truth }}</strong>
+            </div>
+          </header>
+
+          <div :class="['kx-stage', ...stageClass]" aria-live="polite">
+            <svg class="kx-stage-connections" viewBox="0 0 1200 620" preserveAspectRatio="none" aria-hidden="true">
+              <defs>
+                <marker id="kx-arrow-blue" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                  <path d="M 0 0 L 10 5 L 0 10 z" class="kx-marker blue"></path>
+                </marker>
+                <marker id="kx-arrow-cyan" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                  <path d="M 0 0 L 10 5 L 0 10 z" class="kx-marker cyan"></path>
+                </marker>
+                <marker id="kx-arrow-amber" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                  <path d="M 0 0 L 10 5 L 0 10 z" class="kx-marker amber"></path>
+                </marker>
+              </defs>
+
+              <path class="kx-flow request-model" d="M 298 128 C 365 128, 390 230, 454 230" marker-end="url(#kx-arrow-blue)"></path>
+              <path class="kx-flow model-tool" d="M 746 236 C 792 236, 807 164, 850 164" marker-end="url(#kx-arrow-blue)"></path>
+              <path class="kx-flow tool-context" d="M 994 278 C 914 350, 530 407, 324 380" marker-end="url(#kx-arrow-cyan)"></path>
+              <path class="kx-flow context-model" d="M 324 360 C 380 342, 400 300, 454 294" marker-end="url(#kx-arrow-cyan)"></path>
+              <path class="kx-flow knowledge-context" d="M 568 520 C 510 472, 400 430, 276 418" marker-end="url(#kx-arrow-amber)"></path>
+              <path class="kx-flow model-outcome" d="M 746 310 C 810 328, 814 422, 858 438" marker-end="url(#kx-arrow-blue)"></path>
+              <path class="kx-flow result-candidate" d="M 998 502 C 916 560, 790 574, 706 548" marker-end="url(#kx-arrow-amber)"></path>
+
+              <circle class="kx-packet request-packet" r="6">
+                <animateMotion dur="1.4s" repeatCount="indefinite" path="M 298 128 C 365 128, 390 230, 454 230"></animateMotion>
+              </circle>
+              <circle class="kx-packet tool-packet" r="6">
+                <animateMotion dur="1.5s" repeatCount="indefinite" path="M 746 236 C 792 236, 807 164, 850 164"></animateMotion>
+              </circle>
+              <circle class="kx-packet evidence-packet" r="6">
+                <animateMotion dur="2.1s" repeatCount="indefinite" path="M 994 278 C 914 350, 530 407, 324 380"></animateMotion>
+              </circle>
+              <circle class="kx-packet knowledge-packet" r="6">
+                <animateMotion dur="1.7s" repeatCount="indefinite" path="M 568 520 C 510 472, 400 430, 276 418"></animateMotion>
+              </circle>
+              <circle class="kx-packet candidate-packet" r="6">
+                <animateMotion dur="1.8s" repeatCount="indefinite" path="M 998 502 C 916 560, 790 574, 706 548"></animateMotion>
+              </circle>
+            </svg>
+
+            <section class="kx-stage-node kx-request-node">
+              <span class="kx-node-kicker">01 · REQUEST</span>
+              <p>{{ copy.request }}</p>
+              <div class="kx-request-caret" aria-hidden="true"></div>
+            </section>
+
+            <div class="kx-travel-tokens" aria-label="tokens">
               <button
-                v-for="(phase, index) in phases"
-                :key="phase.short"
+                v-for="(token, index) in tokens"
+                :key="`${token}-${index}`"
                 type="button"
-                role="tab"
-                :aria-selected="activePhase === index"
-                :class="{ active: activePhase === index }"
-                @click="selectPhase(index)"
+                :class="{ selected: selectedToken === index }"
+                :disabled="!showAttention"
+                :aria-pressed="selectedToken === index"
+                :title="copy.selectedToken"
+                @click="selectedToken = index"
               >
-                <span>{{ index + 1 }}</span>
-                {{ phase.short }}
+                {{ token }}
               </button>
-              <i class="kx-phase-packet" :style="{ left: `${(activePhase + 0.5) * 33.3333}%` }" aria-hidden="true"></i>
             </div>
 
+            <section class="kx-stage-node kx-context-node">
+              <div class="kx-node-title">
+                <span class="kx-node-kicker">CONTEXT</span>
+                <strong>{{ copy.workingContext }}</strong>
+              </div>
+              <div class="kx-context-stack">
+                <span class="system">{{ copy.contextSystem }}</span>
+                <span :class="['rule', { absent: !rulesEnabled }]">{{ copy.contextRule }}</span>
+                <span class="file">{{ copy.contextFile }}</span>
+                <span class="test">{{ copy.contextTest }}</span>
+              </div>
+              <small>{{ copy.contextEmpty }}</small>
+            </section>
+
+            <section class="kx-stage-node kx-model-node">
+              <div class="kx-node-title">
+                <span class="kx-node-kicker">MODEL</span>
+                <strong>{{ copy.model }}</strong>
+                <small>{{ copy.modelMeta }}</small>
+              </div>
+
+              <div class="kx-model-stack" aria-hidden="true">
+                <i>embedding</i>
+                <i>{{ copy.attention }}</i>
+                <i>MLP + residual</i>
+                <i>softmax</i>
+              </div>
+
+              <div :class="['kx-model-detail', { probabilities: showProbabilities }]">
+                <div class="kx-attention-view">
+                  <svg viewBox="0 0 280 92" role="img" :aria-label="copy.selectedToken">
+                    <path
+                      v-for="(_, index) in tokens"
+                      :key="`attention-${index}`"
+                      :d="attentionPath(index)"
+                      :class="{ selected: selectedToken === index }"
+                      :style="{
+                        strokeWidth: 1 + attentionWeights[index] * 12,
+                        opacity: 0.16 + attentionWeights[index] * 2,
+                      }"
+                    ></path>
+                    <circle
+                      v-for="(_, index) in tokens"
+                      :key="`attention-node-${index}`"
+                      :cx="attentionX(index)"
+                      cy="76"
+                      :r="selectedToken === index ? 6 : 4"
+                      :class="{ selected: selectedToken === index }"
+                    ></circle>
+                  </svg>
+                  <small>{{ copy.selectedToken }}</small>
+                </div>
+
+                <div class="kx-probability-view">
+                  <span>{{ copy.actionCandidates }}</span>
+                  <div v-for="candidate in actionCandidates" :key="candidate.label" class="kx-probability">
+                    <strong>{{ candidate.label }}</strong>
+                    <i><b :class="candidate.kind" :style="{ width: `${candidate.value}%` }"></b></i>
+                    <em>{{ candidate.value }}%</em>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section class="kx-stage-node kx-tool-node">
+              <div class="kx-node-title">
+                <span class="kx-node-kicker">TOOLS + ENV</span>
+                <strong>{{ copy.realWorld }}</strong>
+              </div>
+              <div class="kx-terminal">
+                <span class="idle">{{ copy.toolIdle }}</span>
+                <span class="reading"><i>$</i> {{ copy.toolReading }}</span>
+                <span class="testing"><i>$</i> {{ copy.toolTesting }}</span>
+                <strong>{{ copy.observedResult }}</strong>
+              </div>
+            </section>
+
+            <section class="kx-stage-node kx-knowledge-node">
+              <div class="kx-node-title">
+                <span class="kx-node-kicker">KNOWLEDGE</span>
+                <strong>{{ copy.knowledgeSources }}</strong>
+              </div>
+              <div class="kx-knowledge-items">
+                <span class="parameter">{{ copy.parameter }}</span>
+                <span :class="['project', { absent: !rulesEnabled }]">{{ copy.projectRule }}</span>
+                <span class="runtime">{{ copy.runtimeEvidence }}</span>
+                <span class="candidate">{{ copy.candidate }}</span>
+              </div>
+            </section>
+
+            <section class="kx-stage-node kx-outcome-node">
+              <span class="kx-node-kicker">OUTCOME</span>
+              <strong>{{ copy.nextAction }}</strong>
+              <div class="kx-outcome-paths">
+                <article :class="{ active: rulesEnabled }">
+                  <span>{{ copy.withRule }}</span>
+                  <p>{{ copy.groundedAction }}</p>
+                </article>
+                <article :class="{ active: !rulesEnabled }">
+                  <span>{{ copy.withoutRule }}</span>
+                  <p>{{ copy.genericAction }}</p>
+                </article>
+              </div>
+            </section>
+
+            <div class="kx-stage-label request">{{ copy.userRequest }}</div>
+            <div class="kx-stage-label model">{{ copy.model }}</div>
+            <div class="kx-stage-label evidence">{{ copy.runtimeEvidence }}</div>
+          </div>
+
+          <div class="kx-control-deck">
             <div class="kx-playback">
-              <button type="button" class="kx-icon-button" :title="copy.previous" :aria-label="copy.previous" @click="previousStep">
+              <button type="button" class="kx-icon-button" :title="copy.previous" :aria-label="copy.previous" @click="previousScene">
                 <span aria-hidden="true">←</span>
               </button>
               <button type="button" class="kx-play-button" @click="togglePlayback">
                 <span aria-hidden="true">{{ isPlaying ? 'Ⅱ' : '▶' }}</span>
                 {{ isPlaying ? copy.pause : copy.play }}
               </button>
-              <button type="button" class="kx-icon-button" :title="copy.next" :aria-label="copy.next" @click="nextStep()">
+              <button type="button" class="kx-icon-button" :title="copy.next" :aria-label="copy.next" @click="nextScene()">
                 <span aria-hidden="true">→</span>
               </button>
               <button type="button" class="kx-icon-button" :title="copy.restart" :aria-label="copy.restart" @click="restart">
                 <span aria-hidden="true">↺</span>
               </button>
             </div>
-          </header>
 
-          <div class="kx-scene-head">
-            <div>
-              <span>{{ copy.phaseStatus }} · {{ activePhase + 1 }}</span>
-              <h2>{{ currentPhase.title }}</h2>
-              <p>{{ currentPhase.lead }}</p>
+            <div class="kx-scrubber">
+              <input
+                :value="activeScene"
+                type="range"
+                min="0"
+                :max="scenes.length - 1"
+                step="1"
+                :aria-label="copy.timeline"
+                :style="{ '--progress': `${sceneProgress}%` }"
+                @input="goToScene($event.target.value)"
+              >
+              <div class="kx-chapters">
+                <button
+                  v-for="(item, index) in scenes"
+                  :key="item.key"
+                  type="button"
+                  :class="{ active: activeScene === index, done: activeScene > index }"
+                  @click="goToScene(index)"
+                >
+                  <i aria-hidden="true"></i>
+                  <span>{{ item.short }}</span>
+                </button>
+              </div>
             </div>
-            <div class="kx-step-state" aria-live="polite">
-              <strong>{{ currentStepLabel }}</strong>
-              <span>{{ progressText }}</span>
-            </div>
-          </div>
 
-          <div class="kx-step-rail" :style="{ '--step-count': currentPhase.steps.length }">
             <button
-              v-for="(label, index) in currentPhase.steps"
-              :key="label"
               type="button"
-              :class="{ active: activeStep === index, done: activeStep > index }"
-              @click="stopPlayback(); activeStep = index"
+              role="switch"
+              :aria-checked="rulesEnabled"
+              :disabled="activeScene < 5"
+              :class="['kx-rule-switch', { active: rulesEnabled, revealed: activeScene >= 5 }]"
+              @click="toggleRules"
             >
-              <i aria-hidden="true"></i>
-              <span>{{ label }}</span>
+              <span aria-hidden="true"><i></i></span>
+              <strong>{{ copy.ruleToggle }}</strong>
+              <small>{{ rulesEnabled ? copy.ruleOn : copy.ruleOff }}</small>
             </button>
           </div>
 
-          <div class="kx-scene">
-            <div class="kx-visual">
-              <div v-if="activePhase === 0" class="kx-transformer-scene">
-                <div class="kx-original">
-                  <span>{{ copy.originalText }}</span>
-                  <p>{{ copy.request }}</p>
-                </div>
-
-                <div v-if="activeStep === 0" class="kx-tokenization">
-                  <p>{{ copy.toyTokens }}</p>
-                  <div class="kx-token-row">
-                    <span v-for="(token, index) in tokens" :key="`${token}-${index}`" :style="{ '--delay': `${index * 55}ms` }">
-                      {{ token }}
-                    </span>
-                  </div>
-                </div>
-
-                <div v-else-if="activeStep === 1" class="kx-vector-field">
-                  <div v-for="(token, tokenIndex) in tokens" :key="`${token}-vector`" class="kx-vector-token">
-                    <strong>{{ token }}</strong>
-                    <div class="kx-vector-bars" aria-hidden="true">
-                      <i
-                        v-for="(value, vectorIndex) in vectorRows[tokenIndex]"
-                        :key="vectorIndex"
-                        :style="{ height: `${value}%`, opacity: 0.38 + vectorIndex * 0.08 }"
-                      ></i>
-                    </div>
-                  </div>
-                </div>
-
-                <div v-else-if="activeStep === 2" class="kx-attention">
-                  <div class="kx-attention-meta">
-                    <span>{{ copy.selectedToken }}：<strong>{{ tokens[selectedToken] }}</strong></span>
-                    <code>{{ copy.formula }}</code>
-                  </div>
-                  <svg viewBox="0 0 660 154" role="img" :aria-label="copy.attentionHint">
-                    <path
-                      v-for="(_, index) in tokens"
-                      :key="`path-${index}`"
-                      :d="attentionPath(index)"
-                      :class="{ selected: index === selectedToken }"
-                      :style="{
-                        '--weight': attentionWeights[index],
-                        strokeWidth: 1.5 + attentionWeights[index] * 15,
-                        opacity: 0.18 + attentionWeights[index] * 1.7,
-                      }"
-                    />
-                    <circle
-                      v-for="(_, index) in tokens"
-                      :key="`node-${index}`"
-                      :cx="attentionX(index)"
-                      cy="116"
-                      :r="index === selectedToken ? 8 : 5"
-                      :class="{ selected: index === selectedToken }"
-                    />
-                  </svg>
-                  <div class="kx-token-selector">
-                    <button
-                      v-for="(token, index) in tokens"
-                      :key="`${token}-selector`"
-                      type="button"
-                      :class="{ active: selectedToken === index }"
-                      :aria-pressed="selectedToken === index"
-                      @click="selectedToken = index"
-                    >
-                      <span>{{ token }}</span>
-                      <small>{{ Math.round(attentionWeights[index] * 100) }}%</small>
-                    </button>
-                  </div>
-                  <p class="kx-inline-hint">{{ copy.attentionHint }}</p>
-                </div>
-
-                <div v-else class="kx-probabilities">
-                  <p>{{ copy.candidateLabel }}</p>
-                  <div v-for="candidate in candidateTokens" :key="candidate.token" class="kx-probability-row">
-                    <strong>{{ candidate.token }}</strong>
-                    <span><i :style="{ width: `${candidate.value}%` }"></i></span>
-                    <em>{{ candidate.value }}%</em>
-                  </div>
-                </div>
-              </div>
-
-              <div v-else-if="activePhase === 1" class="kx-agent-scene">
-                <div class="kx-agent-track">
-                  <div
-                    v-for="(event, index) in agentEvents"
-                    :key="event.title"
-                    :class="['kx-agent-event', { active: activeStep === index, done: activeStep > index }]"
-                  >
-                    <span>{{ event.meta }}</span>
-                    <strong>{{ event.title }}</strong>
-                    <i v-if="index < agentEvents.length - 1" aria-hidden="true">→</i>
-                  </div>
-                </div>
-                <div class="kx-context-strip">
-                  <div>
-                    <span>{{ copy.agentContext }}</span>
-                    <strong>{{ activeAgentEvent.gained || copy.noContext }}</strong>
-                  </div>
-                  <div class="kx-context-meter">
-                    <span>{{ copy.contextCount }}</span>
-                    <i><b :style="{ width: `${18 + activeStep * 15}%` }"></b></i>
-                    <strong>{{ activeStep + 1 }}</strong>
-                  </div>
-                </div>
-              </div>
-
-              <div v-else class="kx-knowledge-scene">
-                <div class="kx-knowledge-river">
-                  <div
-                    v-for="(source, index) in knowledgeSources"
-                    :key="source.kind"
-                    :class="['kx-knowledge-source', source.kind, { active: activeStep === index, muted: index === 1 && !includeProjectRules }]"
-                  >
-                    <span>{{ index + 1 }}</span>
-                    <strong>{{ source.title }}</strong>
-                    <small>{{ source.subtitle }}</small>
-                  </div>
-                  <i class="kx-knowledge-packet" :style="{ left: `${(activeStep + 0.5) * 25}%` }" aria-hidden="true"></i>
-                </div>
-
-                <label class="kx-rule-toggle">
-                  <input v-model="includeProjectRules" type="checkbox">
-                  <span aria-hidden="true"><i></i></span>
-                  <strong>{{ copy.knowledgeRuleToggle }}</strong>
-                  <small>{{ copy.knowledgeRuleHelp }}</small>
-                </label>
-
-                <div :class="['kx-outcome', knowledgeOutcome.tone]">
-                  <div>
-                    <span>{{ copy.outcome }}</span>
-                    <strong>{{ knowledgeOutcome.action }}</strong>
-                  </div>
-                  <dl>
-                    <div>
-                      <dt>{{ copy.evidence }}</dt>
-                      <dd>{{ knowledgeOutcome.basis }}</dd>
-                    </div>
-                    <div>
-                      <dt>{{ copy.unresolved }}</dt>
-                      <dd>{{ knowledgeOutcome.unresolved }}</dd>
-                    </div>
-                  </dl>
-                </div>
-              </div>
-            </div>
-
-            <aside class="kx-inspector" aria-live="polite">
-              <span :class="['kx-truth-badge', `phase-${activePhase}`]">{{ sceneTruthKind }}</span>
-              <p class="kx-inspector-step">{{ currentStepLabel }}</p>
-              <p>{{ sceneExplanation }}</p>
-              <div v-if="activePhase === 2" class="kx-source-detail">
-                <span>{{ activeKnowledgeSource.title }}</span>
-                <strong>{{ activeKnowledgeSource.subtitle }}</strong>
-              </div>
-            </aside>
-          </div>
+          <p v-if="activeScene >= 5" class="kx-rule-help">{{ copy.ruleHelp }}</p>
         </div>
       </div>
     </section>
 
-    <section class="kx-insight-section">
+    <section class="kx-summary-section">
       <div class="kx-wrap">
-        <p class="kx-eyebrow">{{ copy.insightTitle }}</p>
-        <div class="kx-insight-grid">
-          <article>
-            <span>01</span>
-            <h2>{{ copy.parameterTitle }}</h2>
-            <p>{{ copy.parameterBody }}</p>
-          </article>
-          <article>
-            <span>02</span>
-            <h2>{{ copy.contextTitle }}</h2>
-            <p>{{ copy.contextBody }}</p>
-          </article>
-          <article>
-            <span>03</span>
-            <h2>{{ copy.runtimeTitle }}</h2>
-            <p>{{ copy.runtimeBody }}</p>
+        <p class="kx-eyebrow">{{ copy.summaryEyebrow }}</p>
+        <h2>{{ copy.summaryTitle }}</h2>
+        <div class="kx-layer-list">
+          <article v-for="layer in copy.layers" :key="layer.key" :class="layer.key">
+            <span>{{ layer.index }}</span>
+            <div>
+              <h3>{{ layer.title }}</h3>
+              <p>{{ layer.body }}</p>
+            </div>
           </article>
         </div>
       </div>
@@ -652,23 +627,35 @@ onUnmounted(stopPlayback)
     <section class="kx-boundary-section">
       <div class="kx-wrap">
         <div class="kx-boundary-head">
-          <p class="kx-eyebrow">{{ copy.boundaryTitle }}</p>
-          <p>{{ copy.boundaryIntro }}</p>
+          <div>
+            <p class="kx-eyebrow">{{ copy.boundaryEyebrow }}</p>
+            <h2>{{ copy.boundaryTitle }}</h2>
+          </div>
+          <div class="kx-boundary-list">
+            <article v-for="item in copy.boundaries" :key="item.key" :class="item.key">
+              <i aria-hidden="true"></i>
+              <div>
+                <h3>{{ item.title }}</h3>
+                <p>{{ item.body }}</p>
+              </div>
+            </article>
+          </div>
         </div>
-        <div class="kx-boundary-grid">
-          <article v-for="item in copy.boundaryItems" :key="item.kind" :class="item.kind">
-            <i aria-hidden="true"></i>
-            <div>
-              <h2>{{ item.label }}</h2>
-              <p>{{ item.body }}</p>
-            </div>
-          </article>
+
+        <div class="kx-omk-note">
+          <span>{{ copy.omkEyebrow }}</span>
+          <div>
+            <h2>{{ copy.omkTitle }}</h2>
+            <p>{{ copy.omkBody }}</p>
+          </div>
         </div>
+
         <nav class="kx-sources" :aria-label="copy.sources">
           <span>{{ copy.sources }}</span>
-          <a href="https://arxiv.org/abs/1706.03762" target="_blank" rel="noreferrer">Attention Is All You Need</a>
-          <a href="https://arxiv.org/abs/2305.04388" target="_blank" rel="noreferrer">Chain-of-Thought Faithfulness</a>
-          <a href="https://www.anthropic.com/research/mapping-mind-language-model" target="_blank" rel="noreferrer">Mechanistic Interpretability</a>
+          <a href="https://poloclub.github.io/transformer-explainer/" target="_blank" rel="noreferrer">Transformer Explainer</a>
+          <a href="https://www.3blue1brown.com/lessons/attention/" target="_blank" rel="noreferrer">3Blue1Brown · Attention</a>
+          <a href="https://distill.pub/about/" target="_blank" rel="noreferrer">Distill</a>
+          <a href="https://arxiv.org/abs/2305.04388" target="_blank" rel="noreferrer">CoT Faithfulness</a>
         </nav>
       </div>
     </section>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@ import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import { useData } from 'vitepress'
 import Landing from './Landing.vue'
+import KnowledgeExplainer from './KnowledgeExplainer.vue'
 
 // frontmatter `landing: true` 的页面:沿用 VitePress 默认主题(顶栏 + 页脚),
 // 落地内容经 `layout-top` 槽位全宽插在导航与页脚之间。其它页面照常走默认主题。
@@ -12,10 +13,13 @@ export default {
     // key 绑定 lang:中英首页都是 landing 页、共用同一 layout-top 槽位,SPA 切换语言时
     // Vue 会复用同一个 Landing 实例导致内容停在旧语言;key 变化强制重新挂载,
     // 让 setup 按新 locale 重算 HTML、onMounted 重跑交互 JS。
-    return h(
-      DefaultTheme.Layout,
-      null,
-      frontmatter.value.landing ? { 'layout-top': () => h(Landing, { key: lang.value }) } : {},
-    )
+    let layoutTop
+    if (frontmatter.value.landing) {
+      layoutTop = () => h(Landing, { key: lang.value })
+    } else if (frontmatter.value.knowledgeExplainer) {
+      layoutTop = () => h(KnowledgeExplainer, { key: lang.value })
+    }
+
+    return h(DefaultTheme.Layout, null, layoutTop ? { 'layout-top': layoutTop } : {})
   },
 }

--- a/docs/.vitepress/theme/knowledge-explainer.css
+++ b/docs/.vitepress/theme/knowledge-explainer.css
@@ -1,27 +1,32 @@
 .omk-knowledge-explainer {
-  --kx-blue: #2563eb;
-  --kx-blue-soft: #eaf0ff;
-  --kx-green: #0f8f72;
-  --kx-green-soft: #e7f7f2;
-  --kx-amber: #c66b05;
-  --kx-amber-soft: #fff4dc;
-  --kx-coral: #d85040;
-  --kx-coral-soft: #fff0ed;
-  --kx-ink: #101827;
-  --kx-body: #4b5b70;
-  --kx-muted: #7b899c;
-  --kx-line: #dbe2eb;
-  --kx-line-strong: #c4cedb;
-  --kx-canvas: #f7f9fc;
+  --kx-blue: #2468e5;
+  --kx-blue-soft: #eaf1ff;
+  --kx-violet: #7158d9;
+  --kx-violet-soft: #f0edff;
+  --kx-cyan: #008e9b;
+  --kx-cyan-soft: #e2f6f5;
+  --kx-amber: #bd6900;
+  --kx-amber-soft: #fff2d9;
+  --kx-green: #15805f;
+  --kx-green-soft: #e5f5ed;
+  --kx-coral: #c94d3c;
+  --kx-coral-soft: #ffede9;
+  --kx-ink: #111827;
+  --kx-body: #4b586c;
+  --kx-muted: #778397;
+  --kx-line: #d8e0ea;
+  --kx-line-strong: #bdc9d8;
+  --kx-page: #ffffff;
+  --kx-canvas: #f5f7fb;
   --kx-surface: #ffffff;
-  --kx-surface-raised: #ffffff;
-  --kx-grid: rgba(28, 45, 70, 0.055);
-  --kx-shadow: 0 18px 50px -28px rgba(19, 37, 67, 0.34);
+  --kx-stage: #eef2f7;
+  --kx-grid: rgba(33, 55, 86, 0.055);
+  --kx-shadow: 0 28px 70px -44px rgba(26, 43, 70, 0.48);
   width: 100%;
   max-width: 100vw;
   overflow-x: hidden;
   padding-top: var(--vp-nav-height);
-  background: var(--kx-surface);
+  background: var(--kx-page);
   color: var(--kx-ink);
   font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
   line-height: 1.6;
@@ -29,23 +34,28 @@
 
 .dark .omk-knowledge-explainer {
   --kx-blue: #78a4ff;
-  --kx-blue-soft: #172846;
-  --kx-green: #43d1ad;
-  --kx-green-soft: #12342d;
-  --kx-amber: #f1b84b;
-  --kx-amber-soft: #382b13;
-  --kx-coral: #ff8b7c;
-  --kx-coral-soft: #3b211f;
+  --kx-blue-soft: #192944;
+  --kx-violet: #aa93ff;
+  --kx-violet-soft: #2b2546;
+  --kx-cyan: #4ccbd2;
+  --kx-cyan-soft: #12363a;
+  --kx-amber: #f1b650;
+  --kx-amber-soft: #3b2d14;
+  --kx-green: #54c89f;
+  --kx-green-soft: #15392e;
+  --kx-coral: #ff8d7c;
+  --kx-coral-soft: #402521;
   --kx-ink: #eef3fa;
-  --kx-body: #b3bfd0;
-  --kx-muted: #7d8ca2;
-  --kx-line: #2a3545;
-  --kx-line-strong: #3b4a60;
+  --kx-body: #b5c0d0;
+  --kx-muted: #8290a4;
+  --kx-line: #2c3747;
+  --kx-line-strong: #405068;
+  --kx-page: #0b1019;
   --kx-canvas: #0e1420;
-  --kx-surface: #0b1019;
-  --kx-surface-raised: #131b28;
-  --kx-grid: rgba(174, 193, 218, 0.055);
-  --kx-shadow: 0 18px 50px -28px rgba(0, 0, 0, 0.8);
+  --kx-surface: #121a27;
+  --kx-stage: #0b111b;
+  --kx-grid: rgba(172, 192, 220, 0.055);
+  --kx-shadow: 0 28px 70px -44px rgba(0, 0, 0, 0.9);
 }
 
 .omk-knowledge-explainer,
@@ -56,10 +66,11 @@
 .omk-knowledge-explainer button,
 .omk-knowledge-explainer input {
   font: inherit;
+  letter-spacing: 0;
 }
 
 .omk-knowledge-explainer button {
-  letter-spacing: 0;
+  color: inherit;
 }
 
 .omk-knowledge-explainer a {
@@ -72,183 +83,1139 @@
   margin: 0 auto;
 }
 
+.kx-eyebrow {
+  margin: 0;
+  color: var(--kx-blue);
+  font-size: 12px;
+  font-weight: 760;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
 .kx-intro {
-  position: relative;
-  padding: 52px 0 38px;
+  padding: 38px 0 30px;
   border-bottom: 1px solid var(--kx-line);
-  background-color: var(--kx-surface);
+  background-color: var(--kx-page);
+  background-image:
+    linear-gradient(var(--kx-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--kx-grid) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+.kx-intro h1 {
+  max-width: 900px;
+  margin: 8px 0 0;
+  font-size: 42px;
+  font-weight: 780;
+  line-height: 1.16;
+  letter-spacing: 0;
+}
+
+.kx-lead {
+  max-width: 900px;
+  margin: 12px 0 0;
+  color: var(--kx-body);
+  font-size: 16px;
+}
+
+.kx-theater-section {
+  padding: 26px 0 76px;
+  background: var(--kx-canvas);
+}
+
+.kx-theater {
+  overflow: hidden;
+  border: 1px solid var(--kx-line-strong);
+  border-radius: 8px;
+  background: var(--kx-surface);
+  box-shadow: var(--kx-shadow);
+}
+
+.kx-story-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 210px;
+  align-items: end;
+  gap: 40px;
+  min-height: 146px;
+  padding: 24px 30px 22px;
+  border-bottom: 1px solid var(--kx-line);
+  background: var(--kx-surface);
+}
+
+.kx-story-head > div:first-child {
+  min-width: 0;
+}
+
+.kx-story-head > div:first-child > span,
+.kx-node-kicker {
+  color: var(--kx-muted);
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.kx-story-head h2 {
+  margin: 5px 0 0;
+  font-size: 25px;
+  font-weight: 760;
+  line-height: 1.3;
+  letter-spacing: 0;
+}
+
+.kx-story-head p {
+  max-width: 760px;
+  margin: 7px 0 0;
+  color: var(--kx-body);
+  font-size: 13px;
+}
+
+.kx-truth {
+  padding: 12px 0 2px 16px;
+  border-left: 3px solid var(--kx-blue);
+}
+
+.kx-truth small,
+.kx-truth strong {
+  display: block;
+}
+
+.kx-truth small {
+  color: var(--kx-muted);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.kx-truth strong {
+  margin-top: 3px;
+  color: var(--kx-blue);
+  font-size: 12px;
+}
+
+.kx-truth.observed {
+  border-color: var(--kx-green);
+}
+
+.kx-truth.observed strong {
+  color: var(--kx-green);
+}
+
+.kx-truth.inferred {
+  border-color: var(--kx-amber);
+}
+
+.kx-truth.inferred strong {
+  color: var(--kx-amber);
+}
+
+.kx-truth.mixed {
+  border-color: var(--kx-violet);
+}
+
+.kx-truth.mixed strong {
+  color: var(--kx-violet);
+}
+
+.kx-stage {
+  position: relative;
+  height: 620px;
+  overflow: hidden;
+  isolation: isolate;
+  background-color: var(--kx-stage);
   background-image:
     linear-gradient(var(--kx-grid) 1px, transparent 1px),
     linear-gradient(90deg, var(--kx-grid) 1px, transparent 1px);
   background-size: 30px 30px;
 }
 
-.kx-intro::after {
+.kx-stage::after {
   position: absolute;
-  right: max(24px, calc((100vw - 1180px) / 2));
-  bottom: -1px;
-  width: 128px;
-  height: 3px;
-  background: linear-gradient(90deg, var(--kx-blue) 0 42%, var(--kx-green) 42% 72%, var(--kx-amber) 72%);
+  z-index: 0;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  background: color-mix(in srgb, var(--kx-line), transparent 62%);
   content: "";
 }
 
-.kx-eyebrow {
-  margin: 0;
-  color: var(--kx-blue);
-  font-size: 12px;
-  font-weight: 750;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.kx-stage-connections {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
 }
 
-.kx-intro h1 {
-  max-width: 780px;
-  margin: 12px 0 0;
-  font-size: 50px;
-  font-weight: 760;
-  line-height: 1.14;
-  letter-spacing: 0;
+.kx-flow {
+  fill: none;
+  stroke: var(--kx-line-strong);
+  stroke-width: 1.5;
+  stroke-dasharray: 6 9;
+  opacity: 0.08;
+  vector-effect: non-scaling-stroke;
+  transition: opacity 520ms ease, stroke 520ms ease, stroke-width 520ms ease;
 }
 
-.kx-lead {
-  max-width: 820px;
-  margin: 16px 0 0;
-  color: var(--kx-body);
-  font-size: 18px;
+.kx-marker {
+  stroke: none;
 }
 
-.kx-request {
-  display: flex;
+.kx-marker.blue {
+  fill: var(--kx-blue);
+}
+
+.kx-marker.cyan {
+  fill: var(--kx-cyan);
+}
+
+.kx-marker.amber {
+  fill: var(--kx-amber);
+}
+
+.kx-packet {
+  fill: var(--kx-blue);
+  opacity: 0;
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--kx-blue), transparent 28%));
+  transition: opacity 260ms;
+}
+
+.kx-packet.evidence-packet {
+  fill: var(--kx-cyan);
+}
+
+.kx-packet.knowledge-packet,
+.kx-packet.candidate-packet {
+  fill: var(--kx-amber);
+}
+
+.scene-tokens .request-model,
+.scene-attention .request-model {
+  stroke: var(--kx-blue);
+  stroke-width: 2;
+  opacity: 0.72;
+  animation: kx-flow 1.1s linear infinite;
+}
+
+.scene-decision .model-tool {
+  stroke: var(--kx-blue);
+  stroke-width: 2;
+  opacity: 0.72;
+  animation: kx-flow 1.1s linear infinite;
+}
+
+.scene-evidence .tool-context,
+.scene-evidence .context-model,
+.scene-knowledge .context-model,
+.scene-fork .context-model {
+  stroke: var(--kx-cyan);
+  stroke-width: 2;
+  opacity: 0.76;
+  animation: kx-flow 1.1s linear infinite;
+}
+
+.scene-knowledge .knowledge-context,
+.scene-fork .knowledge-context {
+  stroke: var(--kx-amber);
+  stroke-width: 2;
+  opacity: 0.8;
+  animation: kx-flow 1.1s linear infinite;
+}
+
+.rules-off.scene-knowledge .knowledge-context,
+.rules-off.scene-fork .knowledge-context {
+  opacity: 0.16;
+  animation: none;
+}
+
+.scene-fork .model-outcome {
+  stroke: var(--kx-blue);
+  stroke-width: 2;
+  opacity: 0.8;
+  animation: kx-flow 1.1s linear infinite;
+}
+
+.scene-candidate .result-candidate {
+  stroke: var(--kx-amber);
+  stroke-width: 2;
+  opacity: 0.82;
+  animation: kx-flow 1.1s linear infinite;
+}
+
+.scene-tokens .request-packet,
+.scene-attention .request-packet,
+.scene-decision .tool-packet,
+.scene-evidence .evidence-packet,
+.scene-knowledge.rules-on .knowledge-packet,
+.scene-fork.rules-on .knowledge-packet,
+.scene-candidate .candidate-packet {
+  opacity: 1;
+}
+
+@keyframes kx-flow {
+  to {
+    stroke-dashoffset: -30;
+  }
+}
+
+.kx-stage-node {
+  position: absolute;
+  z-index: 3;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--kx-line);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--kx-surface), transparent 2%);
+  box-shadow: 0 18px 40px -34px rgba(20, 40, 70, 0.66);
+  opacity: 0.18;
+  filter: saturate(0.45);
+  transform: scale(0.985);
+  transition:
+    opacity 520ms ease,
+    border-color 520ms ease,
+    background 520ms ease,
+    filter 520ms ease,
+    transform 520ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 520ms ease;
+}
+
+.kx-stage-node::after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  background: var(--kx-blue);
+  opacity: 0;
+  content: "";
+  transition: opacity 420ms;
+}
+
+.kx-stage-node.active,
+.scene-request .kx-request-node,
+.scene-tokens .kx-request-node,
+.scene-tokens .kx-model-node,
+.scene-attention .kx-model-node,
+.scene-attention .kx-context-node,
+.scene-decision .kx-model-node,
+.scene-decision .kx-tool-node,
+.scene-evidence .kx-tool-node,
+.scene-evidence .kx-context-node,
+.scene-evidence .kx-model-node,
+.scene-knowledge .kx-knowledge-node,
+.scene-knowledge .kx-context-node,
+.scene-knowledge .kx-model-node,
+.scene-fork .kx-model-node,
+.scene-fork .kx-context-node,
+.scene-fork .kx-knowledge-node,
+.scene-fork .kx-outcome-node,
+.scene-candidate .kx-context-node,
+.scene-candidate .kx-knowledge-node,
+.scene-candidate .kx-outcome-node {
+  border-color: var(--kx-line-strong);
+  opacity: 1;
+  filter: none;
+  transform: none;
+}
+
+.scene-request .kx-request-node,
+.scene-tokens .kx-request-node {
+  border-color: color-mix(in srgb, var(--kx-blue), var(--kx-line) 45%);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--kx-blue), transparent 86%);
+}
+
+.scene-request .kx-request-node::after,
+.scene-tokens .kx-request-node::after,
+.scene-attention .kx-model-node::after,
+.scene-decision .kx-model-node::after,
+.scene-evidence .kx-tool-node::after,
+.scene-knowledge .kx-knowledge-node::after,
+.scene-fork .kx-outcome-node::after,
+.scene-candidate .kx-knowledge-node::after {
+  opacity: 1;
+}
+
+.scene-attention .kx-model-node {
+  border-color: color-mix(in srgb, var(--kx-violet), var(--kx-line) 42%);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--kx-violet), transparent 86%);
+}
+
+.scene-attention .kx-model-node::after {
+  background: var(--kx-violet);
+}
+
+.scene-evidence .kx-tool-node,
+.scene-evidence .kx-context-node {
+  border-color: color-mix(in srgb, var(--kx-cyan), var(--kx-line) 42%);
+}
+
+.scene-evidence .kx-tool-node::after {
+  background: var(--kx-cyan);
+}
+
+.scene-knowledge .kx-knowledge-node {
+  border-color: color-mix(in srgb, var(--kx-amber), var(--kx-line) 42%);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--kx-amber), transparent 86%);
+}
+
+.scene-knowledge .kx-knowledge-node::after,
+.scene-candidate .kx-knowledge-node::after {
+  background: var(--kx-amber);
+}
+
+.scene-fork .kx-outcome-node {
+  border-color: color-mix(in srgb, var(--kx-green), var(--kx-line) 45%);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--kx-green), transparent 86%);
+}
+
+.scene-fork .kx-outcome-node::after {
+  background: var(--kx-green);
+}
+
+.kx-request-node {
+  top: 54px;
+  left: 3.5%;
+  width: 23.5%;
+  min-height: 116px;
+  padding: 17px 18px;
+}
+
+.kx-request-node p {
+  margin: 9px 0 0;
+  font-size: 14px;
+  font-weight: 680;
+  line-height: 1.55;
+}
+
+.kx-request-caret {
+  width: 2px;
+  height: 17px;
+  margin-top: 8px;
+  background: var(--kx-blue);
+  animation: kx-caret 920ms steps(1) infinite;
+}
+
+@keyframes kx-caret {
+  50% {
+    opacity: 0;
+  }
+}
+
+.kx-context-node {
+  top: 306px;
+  left: 3.5%;
+  width: 24%;
+  min-height: 214px;
+  padding: 16px 17px;
+}
+
+.kx-model-node {
+  top: 136px;
+  left: 38%;
+  width: 25.5%;
+  min-height: 276px;
+  padding: 15px 17px 16px;
+}
+
+.kx-tool-node {
+  top: 58px;
+  right: 3.5%;
+  width: 24%;
+  min-height: 220px;
+  padding: 16px 17px;
+}
+
+.kx-knowledge-node {
+  bottom: 30px;
+  left: 32%;
+  width: 36%;
+  min-height: 118px;
+  padding: 15px 17px;
+}
+
+.kx-outcome-node {
+  right: 3.5%;
+  bottom: 30px;
+  width: 25%;
+  min-height: 236px;
+  padding: 16px 17px;
+}
+
+.kx-node-title {
+  display: grid;
+  grid-template-columns: 1fr auto;
   align-items: baseline;
-  gap: 16px;
-  margin-top: 26px;
-  padding-top: 18px;
+  gap: 2px 10px;
+}
+
+.kx-node-title .kx-node-kicker {
+  grid-column: 1 / -1;
+}
+
+.kx-node-title strong {
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.kx-node-title small {
+  color: var(--kx-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+}
+
+.kx-travel-tokens {
+  position: absolute;
+  z-index: 6;
+  top: 170px;
+  left: 7%;
+  display: flex;
+  gap: 4px;
+  max-width: 295px;
+  opacity: 0;
+  transform: translateY(8px);
+  transition:
+    top 800ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    left 800ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 360ms,
+    transform 800ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.kx-travel-tokens button {
+  display: grid;
+  min-width: 31px;
+  height: 31px;
+  flex: 1;
+  place-items: center;
+  padding: 0 2px;
+  border: 1px solid color-mix(in srgb, var(--kx-blue), var(--kx-line) 42%);
+  border-radius: 4px;
+  background: var(--kx-blue-soft);
+  color: var(--kx-blue);
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 760;
+  opacity: 0;
+  transform: translateX(-10px);
+  transition:
+    border-color 180ms,
+    background 180ms,
+    transform 360ms,
+    opacity 360ms;
+}
+
+.scene-tokens .kx-travel-tokens,
+.scene-attention .kx-travel-tokens {
+  top: 190px;
+  left: 39.5%;
+  opacity: 1;
+  transform: none;
+}
+
+.scene-attention .kx-travel-tokens {
+  pointer-events: auto;
+}
+
+.scene-tokens .kx-travel-tokens button,
+.scene-attention .kx-travel-tokens button {
+  opacity: 1;
+  transform: none;
+}
+
+.scene-tokens .kx-travel-tokens button:nth-child(2),
+.scene-attention .kx-travel-tokens button:nth-child(2) {
+  transition-delay: 60ms;
+}
+
+.scene-tokens .kx-travel-tokens button:nth-child(3),
+.scene-attention .kx-travel-tokens button:nth-child(3) {
+  transition-delay: 120ms;
+}
+
+.scene-tokens .kx-travel-tokens button:nth-child(4),
+.scene-attention .kx-travel-tokens button:nth-child(4) {
+  transition-delay: 180ms;
+}
+
+.scene-tokens .kx-travel-tokens button:nth-child(5),
+.scene-attention .kx-travel-tokens button:nth-child(5) {
+  transition-delay: 240ms;
+}
+
+.scene-tokens .kx-travel-tokens button:nth-child(6),
+.scene-attention .kx-travel-tokens button:nth-child(6) {
+  transition-delay: 300ms;
+}
+
+.scene-tokens .kx-travel-tokens button:nth-child(7),
+.scene-attention .kx-travel-tokens button:nth-child(7) {
+  transition-delay: 360ms;
+}
+
+.kx-travel-tokens button:not(:disabled):hover,
+.kx-travel-tokens button.selected {
+  border-color: var(--kx-violet);
+  background: var(--kx-violet-soft);
+  color: var(--kx-violet);
+  transform: translateY(-3px);
+}
+
+.kx-travel-tokens button:disabled {
+  cursor: default;
+}
+
+.kx-context-stack {
+  display: grid;
+  gap: 6px;
+  margin-top: 13px;
+}
+
+.kx-context-stack span {
+  display: flex;
+  min-height: 27px;
+  align-items: center;
+  padding: 4px 8px;
+  border-left: 2px solid var(--kx-line-strong);
+  background: var(--kx-canvas);
+  color: var(--kx-muted);
+  font-size: 10px;
+  font-weight: 650;
+  opacity: 0.18;
+  transform: translateX(-7px);
+  transition: opacity 420ms, transform 420ms, border-color 420ms, color 420ms, background 420ms;
+}
+
+.scene-attention .kx-context-stack .system,
+.scene-decision .kx-context-stack .system,
+.scene-evidence .kx-context-stack .system,
+.scene-knowledge .kx-context-stack .system,
+.scene-fork .kx-context-stack .system,
+.scene-candidate .kx-context-stack .system {
+  border-color: var(--kx-blue);
+  color: var(--kx-body);
+  opacity: 1;
+  transform: none;
+}
+
+.scene-evidence .kx-context-stack .file,
+.scene-evidence .kx-context-stack .test,
+.scene-knowledge .kx-context-stack .file,
+.scene-knowledge .kx-context-stack .test,
+.scene-fork .kx-context-stack .file,
+.scene-fork .kx-context-stack .test,
+.scene-candidate .kx-context-stack .file,
+.scene-candidate .kx-context-stack .test {
+  border-color: var(--kx-cyan);
+  background: var(--kx-cyan-soft);
+  color: var(--kx-cyan);
+  opacity: 1;
+  transform: none;
+}
+
+.scene-knowledge.rules-on .kx-context-stack .rule,
+.scene-fork.rules-on .kx-context-stack .rule,
+.scene-candidate.rules-on .kx-context-stack .rule {
+  border-color: var(--kx-amber);
+  background: var(--kx-amber-soft);
+  color: var(--kx-amber);
+  opacity: 1;
+  transform: none;
+  animation: kx-rule-enter 720ms both;
+}
+
+.kx-context-stack .rule.absent {
+  border-style: dashed;
+  opacity: 0.25 !important;
+  text-decoration: line-through;
+  transform: translateX(-7px) !important;
+}
+
+@keyframes kx-rule-enter {
+  from {
+    opacity: 0;
+    transform: translate(120px, 70px);
+  }
+}
+
+.kx-context-node > small {
+  display: block;
+  margin-top: 11px;
+  color: var(--kx-muted);
+  font-size: 9px;
+}
+
+.scene-evidence .kx-context-node > small,
+.scene-knowledge .kx-context-node > small,
+.scene-fork .kx-context-node > small,
+.scene-candidate .kx-context-node > small {
+  display: none;
+}
+
+.kx-model-stack {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 4px;
+  margin-top: 13px;
+}
+
+.scene-tokens .kx-model-stack,
+.scene-attention .kx-model-stack {
+  margin-top: 61px;
+}
+
+.kx-model-stack i {
+  display: grid;
+  min-height: 35px;
+  place-items: center;
+  padding: 4px;
+  border: 1px solid var(--kx-line);
+  border-radius: 4px;
+  background: var(--kx-canvas);
+  color: var(--kx-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 7px;
+  font-style: normal;
+  text-align: center;
+}
+
+.scene-tokens .kx-model-stack i,
+.scene-attention .kx-model-stack i,
+.scene-decision .kx-model-stack i,
+.scene-evidence .kx-model-stack i,
+.scene-knowledge .kx-model-stack i,
+.scene-fork .kx-model-stack i,
+.scene-candidate .kx-model-stack i {
+  border-color: color-mix(in srgb, var(--kx-violet), var(--kx-line) 58%);
+  background: var(--kx-violet-soft);
+  color: var(--kx-violet);
+  animation: kx-layer-pulse 1.8s ease-in-out infinite;
+}
+
+.kx-model-stack i:nth-child(2) {
+  animation-delay: 180ms !important;
+}
+
+.kx-model-stack i:nth-child(3) {
+  animation-delay: 360ms !important;
+}
+
+.kx-model-stack i:nth-child(4) {
+  animation-delay: 540ms !important;
+}
+
+@keyframes kx-layer-pulse {
+  50% {
+    border-color: var(--kx-violet);
+    transform: translateY(-2px);
+  }
+}
+
+.kx-model-detail {
+  position: relative;
+  height: 145px;
+  margin-top: 8px;
+  overflow: hidden;
   border-top: 1px solid var(--kx-line);
 }
 
-.kx-request span {
-  flex: none;
+.kx-attention-view,
+.kx-probability-view {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 420ms, transform 520ms;
+}
+
+.scene-attention .kx-attention-view {
+  opacity: 1;
+  transform: none;
+}
+
+.scene-decision .kx-probability-view,
+.scene-evidence .kx-probability-view,
+.scene-knowledge .kx-probability-view,
+.scene-fork .kx-probability-view,
+.scene-candidate .kx-probability-view {
+  opacity: 1;
+  transform: none;
+}
+
+.kx-attention-view svg {
+  display: block;
+  width: 100%;
+  height: 102px;
+  overflow: visible;
+}
+
+.kx-attention-view path {
+  fill: none;
+  stroke: var(--kx-violet);
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+  transition: stroke-width 240ms, opacity 240ms;
+}
+
+.kx-attention-view path.selected {
+  stroke: var(--kx-amber);
+}
+
+.kx-attention-view circle {
+  fill: var(--kx-violet);
+  stroke: var(--kx-surface);
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
+}
+
+.kx-attention-view circle.selected {
+  fill: var(--kx-amber);
+}
+
+.kx-attention-view small {
+  display: block;
+  margin-top: -5px;
   color: var(--kx-muted);
-  font-size: 12px;
+  font-size: 8px;
+  text-align: center;
+}
+
+.kx-probability-view {
+  padding-top: 9px;
+}
+
+.kx-probability-view > span {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--kx-muted);
+  font-size: 8px;
   font-weight: 700;
+  text-transform: uppercase;
 }
 
-.kx-request strong {
-  font-size: 16px;
-  font-weight: 650;
+.kx-probability {
+  display: grid;
+  grid-template-columns: 78px 1fr 28px;
+  align-items: center;
+  gap: 6px;
+  min-height: 26px;
 }
 
-.kx-lab-section {
-  padding: 38px 0 72px;
-  background: var(--kx-canvas);
-}
-
-.kx-lab {
+.kx-probability strong {
   overflow: hidden;
-  border: 1px solid var(--kx-line-strong);
-  border-radius: 8px;
-  background: var(--kx-surface-raised);
-  box-shadow: var(--kx-shadow);
+  font-size: 8px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.kx-lab-header {
-  display: flex;
-  min-height: 64px;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--kx-line);
-  background: var(--kx-surface);
-}
-
-.kx-phase-switch {
-  position: relative;
-  display: grid;
-  width: min(560px, 100%);
-  grid-template-columns: repeat(3, 1fr);
-  padding-bottom: 7px;
-}
-
-.kx-phase-switch::after {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  height: 1px;
+.kx-probability > i {
+  height: 5px;
+  overflow: hidden;
+  border-radius: 3px;
   background: var(--kx-line);
-  content: "";
 }
 
-.kx-phase-switch button {
-  position: relative;
-  z-index: 1;
-  display: inline-flex;
-  min-width: 0;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  height: 40px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--kx-muted);
-  cursor: pointer;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.kx-phase-switch button span {
-  display: grid;
-  width: 20px;
-  height: 20px;
-  place-items: center;
-  border: 1px solid var(--kx-line-strong);
-  border-radius: 50%;
-  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
-}
-
-.kx-phase-switch button:hover,
-.kx-phase-switch button.active {
-  color: var(--kx-ink);
-}
-
-.kx-phase-switch button.active span {
-  border-color: var(--kx-blue);
+.kx-probability > i b {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
   background: var(--kx-blue);
-  color: #ffffff;
+  transition: width 620ms cubic-bezier(0.2, 0.8, 0.2, 1), background 300ms;
 }
 
-.kx-phase-switch button:focus-visible,
-.kx-playback button:focus-visible,
-.kx-step-rail button:focus-visible,
-.kx-token-selector button:focus-visible,
-.kx-rule-toggle input:focus-visible + span {
-  outline: 3px solid color-mix(in srgb, var(--kx-blue), transparent 62%);
-  outline-offset: 2px;
+.kx-probability > i b.secondary {
+  background: var(--kx-cyan);
 }
 
-.kx-phase-packet {
+.kx-probability > i b.warning {
+  background: var(--kx-amber);
+}
+
+.kx-probability > i b.muted {
+  background: var(--kx-muted);
+}
+
+.kx-probability em {
+  color: var(--kx-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 8px;
+  font-style: normal;
+  text-align: right;
+}
+
+.kx-terminal {
+  display: grid;
+  gap: 7px;
+  min-height: 143px;
+  margin-top: 13px;
+  padding: 12px;
+  border: 1px solid var(--kx-line);
+  border-radius: 4px;
+  background: var(--kx-stage);
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.kx-terminal span,
+.kx-terminal strong {
+  display: none;
+  overflow-wrap: anywhere;
+  font-size: 9px;
+}
+
+.kx-terminal .idle {
+  display: block;
+  color: var(--kx-muted);
+}
+
+.scene-decision .kx-terminal .idle {
+  display: none;
+}
+
+.scene-decision .kx-terminal .reading,
+.scene-evidence .kx-terminal .reading,
+.scene-knowledge .kx-terminal .reading,
+.scene-fork .kx-terminal .reading,
+.scene-candidate .kx-terminal .reading {
+  display: block;
+  color: var(--kx-blue);
+  animation: kx-terminal-in 440ms both;
+}
+
+.scene-evidence .kx-terminal .testing,
+.scene-knowledge .kx-terminal .testing,
+.scene-fork .kx-terminal .testing,
+.scene-candidate .kx-terminal .testing {
+  display: block;
+  color: var(--kx-cyan);
+  animation: kx-terminal-in 440ms 180ms both;
+}
+
+.scene-evidence .kx-terminal strong,
+.scene-knowledge .kx-terminal strong,
+.scene-fork .kx-terminal strong,
+.scene-candidate .kx-terminal strong {
+  display: block;
+  margin-top: 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--kx-line);
+  color: var(--kx-cyan);
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-weight: 680;
+  animation: kx-terminal-in 440ms 360ms both;
+}
+
+.kx-terminal i {
+  color: var(--kx-muted);
+  font-style: normal;
+}
+
+@keyframes kx-terminal-in {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+}
+
+.kx-knowledge-items {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 7px;
+  margin-top: 12px;
+}
+
+.kx-knowledge-items span {
+  display: grid;
+  min-height: 47px;
+  place-items: center;
+  padding: 6px;
+  border: 1px solid var(--kx-line);
+  border-radius: 4px;
+  background: var(--kx-canvas);
+  color: var(--kx-muted);
+  font-size: 9px;
+  font-weight: 700;
+  text-align: center;
+  opacity: 0.28;
+  transition: opacity 420ms, transform 420ms, color 420ms, border-color 420ms, background 420ms;
+}
+
+.scene-tokens .kx-knowledge-items .parameter,
+.scene-attention .kx-knowledge-items .parameter,
+.scene-decision .kx-knowledge-items .parameter,
+.scene-evidence .kx-knowledge-items .parameter,
+.scene-knowledge .kx-knowledge-items .parameter,
+.scene-fork .kx-knowledge-items .parameter,
+.scene-candidate .kx-knowledge-items .parameter {
+  border-color: color-mix(in srgb, var(--kx-violet), var(--kx-line) 48%);
+  background: var(--kx-violet-soft);
+  color: var(--kx-violet);
+  opacity: 1;
+}
+
+.scene-evidence .kx-knowledge-items .runtime,
+.scene-knowledge .kx-knowledge-items .runtime,
+.scene-fork .kx-knowledge-items .runtime,
+.scene-candidate .kx-knowledge-items .runtime {
+  border-color: color-mix(in srgb, var(--kx-cyan), var(--kx-line) 45%);
+  background: var(--kx-cyan-soft);
+  color: var(--kx-cyan);
+  opacity: 1;
+}
+
+.scene-knowledge.rules-on .kx-knowledge-items .project,
+.scene-fork.rules-on .kx-knowledge-items .project,
+.scene-candidate.rules-on .kx-knowledge-items .project {
+  border-color: color-mix(in srgb, var(--kx-amber), var(--kx-line) 38%);
+  background: var(--kx-amber-soft);
+  color: var(--kx-amber);
+  opacity: 1;
+  transform: translateY(-5px);
+}
+
+.kx-knowledge-items .project.absent {
+  border-style: dashed;
+  background: transparent !important;
+  color: var(--kx-muted) !important;
+  opacity: 0.24 !important;
+  text-decoration: line-through;
+  transform: none !important;
+}
+
+.scene-candidate .kx-knowledge-items .candidate {
+  border-color: color-mix(in srgb, var(--kx-coral), var(--kx-line) 40%);
+  background: var(--kx-coral-soft);
+  color: var(--kx-coral);
+  opacity: 1;
+  animation: kx-candidate-arrive 820ms both;
+}
+
+@keyframes kx-candidate-arrive {
+  from {
+    opacity: 0;
+    transform: translate(230px, -80px);
+  }
+}
+
+.kx-outcome-node > strong {
+  display: block;
+  margin-top: 2px;
+  font-size: 13px;
+}
+
+.kx-outcome-paths {
+  display: grid;
+  gap: 7px;
+  margin-top: 12px;
+  min-width: 0;
+}
+
+.kx-outcome-paths article {
+  min-width: 0;
+  min-height: 75px;
+  overflow: hidden;
+  padding: 9px 10px;
+  border: 1px solid var(--kx-line);
+  border-left-width: 3px;
+  border-radius: 4px;
+  background: var(--kx-stage);
+  opacity: 0.36;
+  transform: translateY(3px);
+  transition: opacity 420ms, transform 420ms, border-color 420ms, background 420ms;
+}
+
+.kx-outcome-paths article:first-child {
+  border-left-color: var(--kx-green);
+}
+
+.kx-outcome-paths article:last-child {
+  border-left-color: var(--kx-coral);
+}
+
+.kx-outcome-paths article.active {
+  background: var(--kx-surface);
+  opacity: 1;
+  transform: none;
+}
+
+.kx-outcome-paths article:first-child.active {
+  border-color: color-mix(in srgb, var(--kx-green), var(--kx-line) 42%);
+  border-left-color: var(--kx-green);
+}
+
+.kx-outcome-paths article:last-child.active {
+  border-color: color-mix(in srgb, var(--kx-coral), var(--kx-line) 42%);
+  border-left-color: var(--kx-coral);
+}
+
+.kx-outcome-paths span {
+  color: var(--kx-muted);
+  font-size: 8px;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.kx-outcome-paths p {
+  margin: 3px 0 0;
+  font-size: 9px;
+  font-weight: 650;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.kx-stage-label {
   position: absolute;
-  z-index: 2;
-  bottom: -3px;
-  width: 9px;
-  height: 9px;
-  border: 2px solid var(--kx-surface);
-  border-radius: 50%;
-  background: var(--kx-green);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--kx-green), transparent 75%);
-  transform: translateX(-50%);
-  transition: left 440ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  z-index: 5;
+  padding: 3px 6px;
+  background: var(--kx-stage);
+  color: var(--kx-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 8px;
+  font-weight: 700;
+  opacity: 0;
+  transition: opacity 360ms;
+}
+
+.kx-stage-label.request {
+  top: 177px;
+  left: 30%;
+  color: var(--kx-blue);
+}
+
+.kx-stage-label.model {
+  top: 107px;
+  left: 44%;
+  color: var(--kx-violet);
+}
+
+.kx-stage-label.evidence {
+  top: 336px;
+  left: 66%;
+  color: var(--kx-cyan);
+}
+
+.scene-tokens .kx-stage-label.request,
+.scene-attention .kx-stage-label.model,
+.scene-evidence .kx-stage-label.evidence {
+  opacity: 1;
+}
+
+.kx-control-deck {
+  display: grid;
+  grid-template-columns: 176px minmax(0, 1fr) 210px;
+  align-items: center;
+  gap: 22px;
+  min-height: 112px;
+  padding: 14px 22px;
+  border-top: 1px solid var(--kx-line);
+  background: var(--kx-surface);
 }
 
 .kx-playback {
   display: flex;
-  flex: none;
   align-items: center;
-  gap: 7px;
+  gap: 6px;
 }
 
 .kx-playback button {
@@ -259,7 +1226,6 @@
   border: 1px solid var(--kx-line-strong);
   border-radius: 6px;
   background: var(--kx-surface);
-  color: var(--kx-ink);
   cursor: pointer;
 }
 
@@ -272,709 +1238,156 @@
   width: 36px;
   padding: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 17px;
+  font-size: 16px;
 }
 
 .kx-play-button {
-  gap: 8px;
-  min-width: 86px;
-  padding: 0 14px;
+  gap: 7px;
+  min-width: 84px;
+  padding: 0 12px;
   border-color: var(--kx-ink) !important;
   background: var(--kx-ink) !important;
-  color: var(--kx-surface) !important;
-  font-size: 13px;
+  color: var(--kx-page) !important;
+  font-size: 12px;
   font-weight: 750;
 }
 
-.kx-scene-head {
-  display: flex;
-  min-height: 124px;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 24px;
-  padding: 28px 32px 22px;
+.dark .kx-play-button {
+  color: #101827 !important;
 }
 
-.kx-scene-head > div:first-child {
+.kx-scrubber {
   min-width: 0;
 }
 
-.kx-scene-head span {
-  color: var(--kx-muted);
-  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
+.kx-scrubber input {
+  width: 100%;
+  height: 18px;
+  margin: 0;
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
 }
 
-.kx-scene-head h2 {
-  margin: 4px 0 0;
-  font-size: 28px;
-  font-weight: 760;
-  letter-spacing: 0;
+.kx-scrubber input::-webkit-slider-runnable-track {
+  height: 3px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, var(--kx-blue) 0 var(--progress), var(--kx-line) var(--progress) 100%);
 }
 
-.kx-scene-head p {
-  max-width: 680px;
-  margin: 6px 0 0;
-  color: var(--kx-body);
-  font-size: 14px;
+.kx-scrubber input::-moz-range-track {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--kx-line);
 }
 
-.kx-step-state {
-  display: flex;
-  flex: none;
-  align-items: center;
-  gap: 12px;
+.kx-scrubber input::-moz-range-progress {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--kx-blue);
 }
 
-.kx-step-state strong {
-  color: var(--kx-blue);
-  font-size: 13px;
+.kx-scrubber input::-webkit-slider-thumb {
+  width: 15px;
+  height: 15px;
+  margin-top: -6px;
+  appearance: none;
+  border: 3px solid var(--kx-surface);
+  border-radius: 50%;
+  background: var(--kx-blue);
+  box-shadow: 0 0 0 1px var(--kx-blue);
 }
 
-.kx-step-state span {
-  min-width: 44px;
-  padding: 3px 8px;
-  border: 1px solid var(--kx-line);
-  border-radius: 5px;
-  background: var(--kx-canvas);
-  text-align: center;
+.kx-scrubber input::-moz-range-thumb {
+  width: 11px;
+  height: 11px;
+  border: 3px solid var(--kx-surface);
+  border-radius: 50%;
+  background: var(--kx-blue);
+  box-shadow: 0 0 0 1px var(--kx-blue);
 }
 
-.kx-step-rail {
+.kx-chapters {
   display: grid;
-  grid-template-columns: repeat(var(--step-count), 1fr);
-  margin: 0 32px;
-  border-top: 1px solid var(--kx-line);
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  margin-top: 3px;
 }
 
-.kx-step-rail button {
-  position: relative;
-  display: flex;
+.kx-chapters button {
+  display: grid;
   min-width: 0;
-  align-items: flex-start;
-  gap: 9px;
-  padding: 13px 8px 12px 0;
+  justify-items: center;
+  gap: 4px;
+  padding: 0 2px;
   border: 0;
   background: transparent;
   color: var(--kx-muted);
   cursor: pointer;
-  text-align: left;
 }
 
-.kx-step-rail button::before {
-  position: absolute;
-  top: -1px;
-  right: 0;
-  left: 0;
-  height: 2px;
-  background: transparent;
-  content: "";
-}
-
-.kx-step-rail button i {
-  width: 8px;
-  height: 8px;
-  flex: none;
-  margin-top: 6px;
-  border: 1px solid var(--kx-line-strong);
+.kx-chapters button i {
+  width: 5px;
+  height: 5px;
   border-radius: 50%;
-  background: var(--kx-surface);
+  background: var(--kx-line-strong);
 }
 
-.kx-step-rail button span {
-  overflow-wrap: anywhere;
-  font-size: 12px;
+.kx-chapters button span {
+  overflow: hidden;
+  max-width: 100%;
+  font-size: 8px;
   font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.kx-step-rail button.done {
-  color: var(--kx-body);
-}
-
-.kx-step-rail button.done i {
-  border-color: var(--kx-green);
+.kx-chapters button.done i {
   background: var(--kx-green);
 }
 
-.kx-step-rail button.active {
+.kx-chapters button.active {
   color: var(--kx-ink);
 }
 
-.kx-step-rail button.active::before {
-  background: var(--kx-blue);
-}
-
-.kx-step-rail button.active i {
-  border-color: var(--kx-blue);
+.kx-chapters button.active i {
+  width: 7px;
+  height: 7px;
   background: var(--kx-blue);
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--kx-blue), transparent 82%);
 }
 
-.kx-scene {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 280px;
-  min-height: 440px;
-  border-top: 1px solid var(--kx-line);
-  background-color: var(--kx-canvas);
-  background-image:
-    linear-gradient(var(--kx-grid) 1px, transparent 1px),
-    linear-gradient(90deg, var(--kx-grid) 1px, transparent 1px);
-  background-size: 28px 28px;
-}
-
-.kx-visual {
-  display: grid;
-  min-width: 0;
-  min-height: 440px;
-  place-items: center;
-  padding: 34px;
-}
-
-.kx-transformer-scene,
-.kx-agent-scene,
-.kx-knowledge-scene {
-  width: 100%;
-  max-width: 800px;
-}
-
-.kx-original {
-  display: grid;
-  grid-template-columns: 112px 1fr;
-  align-items: baseline;
-  gap: 16px;
-  padding-bottom: 18px;
-  border-bottom: 1px solid var(--kx-line);
-}
-
-.kx-original span,
-.kx-tokenization > p,
-.kx-probabilities > p {
-  margin: 0;
-  color: var(--kx-muted);
-  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
-.kx-original p {
-  margin: 0;
-  color: var(--kx-ink);
-  font-size: 16px;
-  font-weight: 650;
-}
-
-.kx-tokenization {
-  padding-top: 54px;
-}
-
-.kx-token-row {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 9px;
-  margin-top: 18px;
-}
-
-.kx-token-row span {
-  display: grid;
-  min-height: 62px;
-  place-items: center;
-  padding: 8px 4px;
-  border: 1px solid var(--kx-line-strong);
-  border-radius: 6px;
-  background: var(--kx-surface);
-  box-shadow: 0 8px 20px -18px rgba(15, 35, 65, 0.6);
-  color: var(--kx-ink);
-  font-size: 15px;
-  font-weight: 700;
-  overflow-wrap: anywhere;
-  animation: kx-token-in 360ms both;
-  animation-delay: var(--delay);
-}
-
-@keyframes kx-token-in {
-  from {
-    opacity: 0;
-    transform: translateY(9px);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-.kx-vector-field {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 9px;
-  padding-top: 38px;
-}
-
-.kx-vector-token {
-  min-width: 0;
-  text-align: center;
-}
-
-.kx-vector-token strong {
-  display: block;
-  min-height: 42px;
-  overflow-wrap: anywhere;
-  color: var(--kx-body);
-  font-size: 12px;
-}
-
-.kx-vector-bars {
-  display: flex;
-  height: 126px;
-  align-items: flex-end;
-  justify-content: center;
-  gap: 3px;
-  padding: 12px 7px;
-  border: 1px solid var(--kx-line);
-  border-radius: 6px;
-  background: var(--kx-surface);
-}
-
-.kx-vector-bars i {
-  width: 8px;
-  max-width: 14%;
-  border-radius: 2px 2px 0 0;
-  background: var(--kx-blue);
-  transform-origin: bottom;
-  animation: kx-vector-grow 520ms both;
-}
-
-@keyframes kx-vector-grow {
-  from {
-    transform: scaleY(0);
-  }
-  to {
-    transform: scaleY(1);
-  }
-}
-
-.kx-attention {
-  padding-top: 22px;
-}
-
-.kx-attention-meta {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  color: var(--kx-body);
-  font-size: 13px;
-}
-
-.kx-attention-meta strong {
-  color: var(--kx-blue);
-}
-
-.kx-attention-meta code {
-  padding: 4px 8px;
-  border: 1px solid var(--kx-line);
-  border-radius: 5px;
-  background: var(--kx-surface);
-  color: var(--kx-muted);
-  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-}
-
-.kx-attention svg {
-  display: block;
-  width: 100%;
-  height: 160px;
-  overflow: visible;
-}
-
-.kx-attention path {
-  fill: none;
-  stroke: var(--kx-blue);
-  stroke-linecap: round;
-  vector-effect: non-scaling-stroke;
-  transition: opacity 240ms, stroke-width 240ms;
-}
-
-.kx-attention path.selected {
-  stroke: var(--kx-green);
-}
-
-.kx-attention circle {
-  fill: var(--kx-blue);
-  stroke: var(--kx-surface);
-  stroke-width: 3;
-  vector-effect: non-scaling-stroke;
-}
-
-.kx-attention circle.selected {
-  fill: var(--kx-green);
-}
-
-.kx-token-selector {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 7px;
-  margin-top: -20px;
-}
-
-.kx-token-selector button {
-  min-width: 0;
-  min-height: 54px;
-  padding: 6px 3px;
-  border: 1px solid var(--kx-line);
-  border-radius: 6px;
-  background: var(--kx-surface);
-  color: var(--kx-body);
-  cursor: pointer;
-}
-
-.kx-token-selector button:hover,
-.kx-token-selector button.active {
-  border-color: var(--kx-blue);
-  color: var(--kx-ink);
-}
-
-.kx-token-selector button span {
-  display: block;
-  overflow-wrap: anywhere;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.kx-token-selector button small {
-  display: block;
-  margin-top: 2px;
-  color: var(--kx-muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
-}
-
-.kx-inline-hint {
-  margin: 12px 0 0;
-  color: var(--kx-muted);
-  font-size: 12px;
-  text-align: center;
-}
-
-.kx-probabilities {
-  max-width: 620px;
-  margin: 0 auto;
-  padding-top: 38px;
-}
-
-.kx-probabilities > p {
-  margin-bottom: 18px;
-}
-
-.kx-probability-row {
-  display: grid;
-  grid-template-columns: 84px minmax(0, 1fr) 48px;
-  align-items: center;
-  gap: 12px;
-  min-height: 48px;
-  border-top: 1px solid var(--kx-line);
-}
-
-.kx-probability-row strong {
-  overflow-wrap: anywhere;
-  font-size: 13px;
-}
-
-.kx-probability-row > span {
-  height: 8px;
-  overflow: hidden;
-  border-radius: 4px;
-  background: var(--kx-line);
-}
-
-.kx-probability-row > span i {
-  display: block;
-  height: 100%;
-  border-radius: inherit;
-  background: var(--kx-blue);
-  animation: kx-probability-grow 620ms both;
-}
-
-.kx-probability-row:nth-child(3) > span i {
-  background: var(--kx-green);
-}
-
-.kx-probability-row:nth-child(4) > span i {
-  background: var(--kx-amber);
-}
-
-.kx-probability-row:nth-child(5) > span i {
-  background: var(--kx-coral);
-}
-
-.kx-probability-row em {
-  color: var(--kx-muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  font-style: normal;
-  text-align: right;
-}
-
-@keyframes kx-probability-grow {
-  from {
-    width: 0;
-  }
-}
-
-.kx-agent-track {
-  display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  align-items: stretch;
-  gap: 18px;
-}
-
-.kx-agent-event {
-  position: relative;
-  display: flex;
-  min-width: 0;
-  min-height: 136px;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 14px 11px;
-  border: 1px solid var(--kx-line);
-  border-radius: 6px;
-  background: var(--kx-surface);
-  color: var(--kx-muted);
-  transition: border-color 220ms, background 220ms, transform 220ms;
-}
-
-.kx-agent-event > span {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
-  text-transform: uppercase;
-}
-
-.kx-agent-event > strong {
-  overflow-wrap: anywhere;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.kx-agent-event > i {
-  position: absolute;
-  z-index: 2;
-  top: 50%;
-  right: -17px;
-  color: var(--kx-line-strong);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 18px;
-  font-style: normal;
-  transform: translate(50%, -50%);
-}
-
-.kx-agent-event.done {
-  border-color: color-mix(in srgb, var(--kx-green), var(--kx-line) 52%);
-  background: var(--kx-green-soft);
-  color: var(--kx-green);
-}
-
-.kx-agent-event.active {
-  border-color: var(--kx-blue);
-  background: var(--kx-blue-soft);
-  color: var(--kx-ink);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--kx-blue), transparent 84%);
-  transform: translateY(-4px);
-}
-
-.kx-agent-event.active > span {
-  color: var(--kx-blue);
-}
-
-.kx-context-strip {
-  display: grid;
-  grid-template-columns: 1fr minmax(220px, 0.7fr);
-  align-items: center;
-  gap: 28px;
-  margin-top: 34px;
-  padding-top: 22px;
-  border-top: 1px solid var(--kx-line);
-}
-
-.kx-context-strip > div:first-child span,
-.kx-context-meter > span {
-  display: block;
-  color: var(--kx-muted);
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
-.kx-context-strip > div:first-child strong {
-  display: block;
-  margin-top: 5px;
-  font-size: 14px;
-}
-
-.kx-context-meter {
-  display: grid;
-  grid-template-columns: 1fr 36px;
-  align-items: center;
-  gap: 7px 12px;
-}
-
-.kx-context-meter > span {
-  grid-column: 1 / -1;
-}
-
-.kx-context-meter > i {
-  height: 7px;
-  overflow: hidden;
-  border-radius: 4px;
-  background: var(--kx-line);
-}
-
-.kx-context-meter > i b {
-  display: block;
-  height: 100%;
-  border-radius: inherit;
-  background: var(--kx-green);
-  transition: width 380ms ease;
-}
-
-.kx-context-meter > strong {
-  color: var(--kx-green);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
-  text-align: right;
-}
-
-.kx-knowledge-river {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 14px;
-  padding-bottom: 28px;
-}
-
-.kx-knowledge-river::before {
-  position: absolute;
-  right: 10%;
-  bottom: 13px;
-  left: 10%;
-  height: 2px;
-  background: var(--kx-line-strong);
-  content: "";
-}
-
-.kx-knowledge-source {
-  min-width: 0;
-  min-height: 118px;
-  padding: 14px;
-  border: 1px solid var(--kx-line);
-  border-radius: 6px;
-  background: var(--kx-surface);
-  color: var(--kx-body);
-  transition: border-color 220ms, background 220ms, opacity 220ms, transform 220ms;
-}
-
-.kx-knowledge-source > span {
-  display: grid;
-  width: 22px;
-  height: 22px;
-  place-items: center;
-  border: 1px solid var(--kx-line);
-  border-radius: 50%;
-  color: var(--kx-muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
-}
-
-.kx-knowledge-source strong,
-.kx-knowledge-source small {
-  display: block;
-  overflow-wrap: anywhere;
-}
-
-.kx-knowledge-source strong {
-  margin-top: 13px;
-  color: var(--kx-ink);
-  font-size: 14px;
-}
-
-.kx-knowledge-source small {
-  margin-top: 3px;
-  color: var(--kx-muted);
-  font-size: 11px;
-}
-
-.kx-knowledge-source.active {
-  border-color: var(--kx-blue);
-  background: var(--kx-blue-soft);
-  transform: translateY(-4px);
-}
-
-.kx-knowledge-source.context.active {
-  border-color: var(--kx-green);
-  background: var(--kx-green-soft);
-}
-
-.kx-knowledge-source.runtime.active {
-  border-color: var(--kx-amber);
-  background: var(--kx-amber-soft);
-}
-
-.kx-knowledge-source.candidate.active {
-  border-color: var(--kx-coral);
-  background: var(--kx-coral-soft);
-}
-
-.kx-knowledge-source.muted {
-  border-style: dashed;
-  opacity: 0.45;
-}
-
-.kx-knowledge-packet {
-  position: absolute;
-  z-index: 2;
-  bottom: 8px;
-  width: 12px;
-  height: 12px;
-  border: 3px solid var(--kx-canvas);
-  border-radius: 50%;
-  background: var(--kx-blue);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--kx-blue), transparent 76%);
-  transform: translateX(-50%);
-  transition: left 440ms cubic-bezier(0.2, 0.8, 0.2, 1), background 220ms;
-}
-
-.kx-rule-toggle {
+.kx-rule-switch {
   display: grid;
   grid-template-columns: 38px 1fr;
-  gap: 0 12px;
+  gap: 0 10px;
   align-items: center;
-  width: 100%;
-  padding: 15px 0;
-  border-top: 1px solid var(--kx-line);
-  border-bottom: 1px solid var(--kx-line);
+  min-width: 0;
+  padding: 8px;
+  border: 0;
+  background: transparent;
   cursor: pointer;
+  opacity: 0.28;
+  pointer-events: none;
+  text-align: left;
+  transition: opacity 360ms;
 }
 
-.kx-rule-toggle input {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  opacity: 0;
+.kx-rule-switch.revealed {
+  opacity: 1;
+  pointer-events: auto;
 }
 
-.kx-rule-toggle > span {
+.kx-rule-switch > span {
   position: relative;
   grid-row: 1 / 3;
   width: 38px;
   height: 22px;
   border-radius: 11px;
   background: var(--kx-line-strong);
-  transition: background 180ms;
+  transition: background 220ms;
 }
 
-.kx-rule-toggle > span i {
+.kx-rule-switch > span i {
   position: absolute;
   top: 3px;
   left: 3px;
@@ -983,271 +1396,206 @@
   border-radius: 50%;
   background: #ffffff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.35);
-  transition: transform 180ms;
+  transition: transform 220ms;
 }
 
-.kx-rule-toggle input:checked + span {
-  background: var(--kx-green);
+.kx-rule-switch.active > span {
+  background: var(--kx-amber);
 }
 
-.kx-rule-toggle input:checked + span i {
+.kx-rule-switch.active > span i {
   transform: translateX(16px);
 }
 
-.kx-rule-toggle > strong {
-  font-size: 13px;
-}
-
-.kx-rule-toggle > small {
-  color: var(--kx-muted);
+.kx-rule-switch strong {
+  overflow: hidden;
   font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.kx-outcome {
-  display: grid;
-  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
-  gap: 24px;
-  margin-top: 20px;
-  padding: 18px;
-  border: 1px solid var(--kx-line-strong);
-  border-left-width: 4px;
-  border-radius: 6px;
-  background: var(--kx-surface);
+.kx-rule-switch small {
+  overflow: hidden;
+  color: var(--kx-muted);
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.kx-outcome.grounded {
-  border-left-color: var(--kx-green);
+.kx-playback button:focus-visible,
+.kx-chapters button:focus-visible,
+.kx-rule-switch:focus-visible,
+.kx-travel-tokens button:focus-visible,
+.kx-scrubber input:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--kx-blue), transparent 62%);
+  outline-offset: 2px;
 }
 
-.kx-outcome.uncertain {
-  border-left-color: var(--kx-coral);
-}
-
-.kx-outcome > div > span {
-  display: block;
+.kx-rule-help {
+  margin: -8px 22px 14px;
   color: var(--kx-muted);
   font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
+  text-align: right;
 }
 
-.kx-outcome > div > strong {
-  display: block;
-  margin-top: 5px;
-  font-size: 14px;
+.kx-summary-section {
+  padding: 78px 0;
+  border-top: 1px solid var(--kx-line);
+  background: var(--kx-page);
 }
 
-.kx-outcome dl,
-.kx-outcome dl div {
-  margin: 0;
-}
-
-.kx-outcome dl {
-  display: grid;
-  gap: 9px;
-}
-
-.kx-outcome dl div {
-  display: grid;
-  grid-template-columns: 96px 1fr;
-  gap: 10px;
-}
-
-.kx-outcome dt {
-  color: var(--kx-muted);
-  font-size: 11px;
-}
-
-.kx-outcome dd {
-  margin: 0;
-  color: var(--kx-body);
-  font-size: 12px;
-}
-
-.kx-inspector {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  justify-content: center;
-  padding: 30px 26px;
-  border-left: 1px solid var(--kx-line);
-  background: color-mix(in srgb, var(--kx-surface), transparent 3%);
-}
-
-.kx-truth-badge {
-  align-self: flex-start;
-  padding: 4px 8px;
-  border: 1px solid var(--kx-line);
-  border-radius: 5px;
-  background: var(--kx-canvas);
-  color: var(--kx-blue);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
-  font-weight: 700;
-}
-
-.kx-truth-badge.phase-1 {
-  color: var(--kx-green);
-}
-
-.kx-truth-badge.phase-2 {
-  color: var(--kx-amber);
-}
-
-.kx-inspector-step {
-  margin: 22px 0 0;
-  color: var(--kx-ink) !important;
-  font-size: 17px !important;
-  font-weight: 750;
-}
-
-.kx-inspector > p:last-of-type {
+.kx-summary-section > .kx-wrap > h2 {
+  max-width: 860px;
   margin: 10px 0 0;
-  color: var(--kx-body);
-  font-size: 13px;
-}
-
-.kx-source-detail {
-  margin-top: 22px;
-  padding-top: 18px;
-  border-top: 1px solid var(--kx-line);
-}
-
-.kx-source-detail span,
-.kx-source-detail strong {
-  display: block;
-}
-
-.kx-source-detail span {
-  color: var(--kx-muted);
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
-.kx-source-detail strong {
-  margin-top: 4px;
-  font-size: 13px;
-}
-
-.kx-insight-section {
-  padding: 72px 0;
-  border-top: 1px solid var(--kx-line);
-  background: var(--kx-surface);
-}
-
-.kx-insight-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  margin-top: 24px;
-  border-top: 1px solid var(--kx-line-strong);
-  border-bottom: 1px solid var(--kx-line-strong);
-}
-
-.kx-insight-grid article {
-  min-width: 0;
-  padding: 28px 28px 30px 0;
-}
-
-.kx-insight-grid article + article {
-  padding-left: 28px;
-  border-left: 1px solid var(--kx-line);
-}
-
-.kx-insight-grid article > span {
-  color: var(--kx-blue);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  font-weight: 700;
-}
-
-.kx-insight-grid article:nth-child(2) > span {
-  color: var(--kx-green);
-}
-
-.kx-insight-grid article:nth-child(3) > span {
-  color: var(--kx-amber);
-}
-
-.kx-insight-grid h2 {
-  margin: 12px 0 0;
-  font-size: 20px;
-  font-weight: 750;
+  font-size: 30px;
+  font-weight: 760;
+  line-height: 1.35;
   letter-spacing: 0;
 }
 
-.kx-insight-grid p {
-  margin: 10px 0 0;
+.kx-layer-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 40px;
+  margin-top: 34px;
+  border-top: 1px solid var(--kx-line-strong);
+}
+
+.kx-layer-list article {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 14px;
+  min-width: 0;
+  padding: 24px 0;
+  border-bottom: 1px solid var(--kx-line);
+}
+
+.kx-layer-list article > span {
+  color: var(--kx-violet);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  font-weight: 750;
+}
+
+.kx-layer-list article.context > span {
+  color: var(--kx-amber);
+}
+
+.kx-layer-list article.runtime > span {
+  color: var(--kx-cyan);
+}
+
+.kx-layer-list article.candidate > span {
+  color: var(--kx-coral);
+}
+
+.kx-layer-list h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 750;
+}
+
+.kx-layer-list p {
+  margin: 6px 0 0;
   color: var(--kx-body);
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .kx-boundary-section {
-  padding: 70px 0 84px;
+  padding: 74px 0 84px;
   border-top: 1px solid var(--kx-line);
   background: var(--kx-canvas);
 }
 
 .kx-boundary-head {
   display: grid;
-  grid-template-columns: minmax(220px, 0.7fr) minmax(0, 1.3fr);
-  gap: 40px;
-  align-items: start;
+  grid-template-columns: minmax(260px, 0.75fr) minmax(0, 1.25fr);
+  gap: 60px;
 }
 
-.kx-boundary-head > p:last-child {
-  max-width: 680px;
-  margin: 0;
-  color: var(--kx-body);
-  font-size: 16px;
+.kx-boundary-head h2 {
+  max-width: 380px;
+  margin: 10px 0 0;
+  font-size: 27px;
+  font-weight: 760;
+  line-height: 1.35;
+  letter-spacing: 0;
 }
 
-.kx-boundary-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0 28px;
-  margin-top: 34px;
+.kx-boundary-list {
   border-top: 1px solid var(--kx-line-strong);
 }
 
-.kx-boundary-grid article {
+.kx-boundary-list article {
   display: grid;
-  grid-template-columns: 12px 1fr;
-  gap: 14px;
-  min-width: 0;
-  padding: 22px 0;
+  grid-template-columns: 10px 128px 1fr;
+  gap: 12px;
+  align-items: baseline;
+  padding: 16px 0;
   border-bottom: 1px solid var(--kx-line);
 }
 
-.kx-boundary-grid article > i {
-  width: 9px;
-  height: 9px;
-  margin-top: 7px;
+.kx-boundary-list article > i {
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background: var(--kx-blue);
 }
 
-.kx-boundary-grid article.observed > i {
+.kx-boundary-list article.observed > i {
   background: var(--kx-green);
 }
 
-.kx-boundary-grid article.inferred > i {
+.kx-boundary-list article.inferred > i {
   background: var(--kx-amber);
 }
 
-.kx-boundary-grid article.unavailable > i {
+.kx-boundary-list article.unavailable > i {
   border: 2px solid var(--kx-coral);
   background: transparent;
 }
 
-.kx-boundary-grid h2 {
+.kx-boundary-list h3 {
   margin: 0;
-  font-size: 15px;
+  font-size: 13px;
   font-weight: 750;
 }
 
-.kx-boundary-grid p {
-  margin: 4px 0 0;
+.kx-boundary-list p {
+  margin: 0;
+  color: var(--kx-body);
+  font-size: 12px;
+}
+
+.kx-omk-note {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 28px;
+  margin-top: 52px;
+  padding: 28px 0;
+  border-top: 1px solid var(--kx-line-strong);
+  border-bottom: 1px solid var(--kx-line-strong);
+}
+
+.kx-omk-note > span {
+  color: var(--kx-blue);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.kx-omk-note h2 {
+  max-width: 800px;
+  margin: 0;
+  font-size: 20px;
+  font-weight: 750;
+  line-height: 1.45;
+  letter-spacing: 0;
+}
+
+.kx-omk-note p {
+  max-width: 820px;
+  margin: 8px 0 0;
   color: var(--kx-body);
   font-size: 13px;
 }
@@ -1256,15 +1604,13 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px 18px;
-  margin-top: 34px;
-  padding-top: 20px;
-  border-top: 1px solid var(--kx-line-strong);
+  margin-top: 24px;
   color: var(--kx-muted);
-  font-size: 12px;
+  font-size: 11px;
 }
 
-.kx-sources span {
-  font-weight: 700;
+.kx-sources > span {
+  font-weight: 750;
 }
 
 .kx-sources a {
@@ -1279,260 +1625,335 @@
 }
 
 @media (max-width: 960px) {
-  .kx-lab-header {
-    align-items: stretch;
-    flex-direction: column;
+  .kx-story-head {
+    grid-template-columns: 1fr 180px;
   }
 
-  .kx-phase-switch {
-    width: 100%;
+  .kx-model-node {
+    left: 36.5%;
+    width: 28%;
   }
 
-  .kx-playback {
-    justify-content: flex-end;
+  .kx-context-node,
+  .kx-tool-node {
+    width: 26%;
   }
 
-  .kx-scene {
-    grid-template-columns: 1fr;
+  .kx-request-node {
+    width: 25%;
   }
 
-  .kx-visual {
-    min-height: 420px;
+  .kx-outcome-node {
+    width: 27%;
   }
 
-  .kx-inspector {
-    min-height: 168px;
-    border-top: 1px solid var(--kx-line);
-    border-left: 0;
+  .kx-control-deck {
+    grid-template-columns: 176px 1fr;
   }
 
-  .kx-agent-track {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 14px;
-  }
-
-  .kx-agent-event:nth-child(3) > i {
-    display: none;
+  .kx-rule-switch {
+    grid-column: 2;
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 800px) {
   .kx-wrap {
-    width: min(calc(100% - 28px), 1180px);
+    width: min(100% - 28px, 1180px);
   }
 
   .kx-intro {
-    padding: 36px 0 30px;
+    padding: 32px 0 26px;
   }
 
   .kx-intro h1 {
-    font-size: 38px;
+    font-size: 35px;
   }
 
-  .kx-lead {
-    font-size: 16px;
+  .kx-story-head {
+    grid-template-columns: 1fr;
+    gap: 14px;
+    min-height: 0;
+    padding: 20px;
   }
 
-  .kx-request {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 5px;
+  .kx-story-head h2 {
+    font-size: 22px;
   }
 
-  .kx-lab-section {
-    padding: 20px 0 52px;
+  .kx-truth {
+    padding: 7px 0 0 12px;
   }
 
-  .kx-phase-switch button {
-    flex-direction: column;
-    gap: 2px;
-    height: 50px;
-    font-size: 11px;
+  .kx-stage {
+    height: 1250px;
   }
 
-  .kx-phase-switch button span {
-    width: 18px;
-    height: 18px;
+  .kx-stage::after {
+    top: 148px;
+    bottom: 68px;
+    left: 50%;
+    background: var(--kx-line);
+  }
+
+  .kx-stage-connections,
+  .kx-stage-label {
+    display: none;
+  }
+
+  .kx-stage-node {
+    right: 18px;
+    left: 18px;
+    width: auto;
+  }
+
+  .kx-request-node {
+    top: 24px;
+    min-height: 112px;
+  }
+
+  .kx-model-node {
+    top: 220px;
+    min-height: 252px;
+  }
+
+  .kx-tool-node {
+    top: 500px;
+    min-height: 180px;
+  }
+
+  .kx-context-node {
+    top: 708px;
+    min-height: 188px;
+  }
+
+  .kx-knowledge-node {
+    top: 924px;
+    bottom: auto;
+    min-height: 120px;
+  }
+
+  .kx-outcome-node {
+    top: 1072px;
+    bottom: auto;
+    min-height: 154px;
+  }
+
+  .kx-travel-tokens,
+  .scene-tokens .kx-travel-tokens,
+  .scene-attention .kx-travel-tokens {
+    top: 164px;
+    left: 50%;
+    width: calc(100% - 56px);
+    max-width: none;
+    justify-content: center;
+    transform: translateX(-50%);
+  }
+
+  .kx-travel-tokens button {
+    max-width: 56px;
+  }
+
+  .scene-attention .kx-travel-tokens {
+    top: 282px;
+    z-index: 7;
+    width: calc(100% - 86px);
+  }
+
+  .kx-model-stack {
+    margin-top: 51px;
+  }
+
+  .scene-attention .kx-model-stack {
+    margin-top: 54px;
+  }
+
+  .kx-model-detail {
+    height: 110px;
+  }
+
+  .kx-attention-view svg {
+    height: 76px;
+  }
+
+  .kx-attention-view small {
+    display: none;
+  }
+
+  .kx-terminal {
+    min-height: 105px;
+  }
+
+  .kx-outcome-paths {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .kx-outcome-paths article {
+    min-height: 78px;
+  }
+
+  .kx-control-deck {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    padding: 18px;
   }
 
   .kx-playback {
     justify-content: center;
   }
 
-  .kx-scene-head {
-    min-height: 0;
-    align-items: flex-start;
-    flex-direction: column;
-    padding: 22px 18px 18px;
+  .kx-rule-switch {
+    grid-column: 1;
+    width: min(250px, 100%);
+    margin: 0 auto;
   }
 
-  .kx-scene-head h2 {
-    font-size: 23px;
+  .kx-rule-help {
+    margin: -4px 18px 16px;
+    text-align: center;
   }
 
-  .kx-step-state {
-    width: 100%;
-    justify-content: space-between;
-  }
-
-  .kx-step-rail {
-    margin: 0 18px;
-  }
-
-  .kx-step-rail button {
-    justify-content: center;
-    padding-right: 0;
-  }
-
-  .kx-step-rail button span {
-    display: none;
-  }
-
-  .kx-visual {
-    min-height: 460px;
-    padding: 24px 16px;
-  }
-
-  .kx-original {
+  .kx-layer-list {
     grid-template-columns: 1fr;
-    gap: 4px;
-  }
-
-  .kx-token-row,
-  .kx-vector-field {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
-  .kx-token-row span:last-child,
-  .kx-vector-token:last-child {
-    grid-column: 2;
-  }
-
-  .kx-vector-token strong {
-    min-height: 34px;
-  }
-
-  .kx-vector-bars {
-    height: 86px;
-  }
-
-  .kx-attention svg {
-    height: 130px;
-  }
-
-  .kx-token-selector {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    margin-top: -10px;
-  }
-
-  .kx-attention-meta {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 5px;
-  }
-
-  .kx-agent-track {
-    grid-template-columns: 1fr;
-    gap: 18px;
-  }
-
-  .kx-agent-event {
-    min-height: 82px;
-  }
-
-  .kx-agent-event > i {
-    top: auto;
-    right: 50%;
-    bottom: -18px;
-    transform: translate(50%, 50%) rotate(90deg);
-  }
-
-  .kx-agent-event:nth-child(3) > i {
-    display: block;
-  }
-
-  .kx-context-strip {
-    grid-template-columns: 1fr;
-  }
-
-  .kx-knowledge-river {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .kx-knowledge-river::before,
-  .kx-knowledge-packet {
-    display: none;
-  }
-
-  .kx-outcome {
-    grid-template-columns: 1fr;
-  }
-
-  .kx-outcome dl div {
-    grid-template-columns: 1fr;
-    gap: 2px;
-  }
-
-  .kx-inspector {
-    padding: 24px 20px;
-  }
-
-  .kx-insight-section,
-  .kx-boundary-section {
-    padding: 54px 0;
-  }
-
-  .kx-insight-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .kx-insight-grid article,
-  .kx-insight-grid article + article {
-    padding: 22px 0;
-    border-left: 0;
-  }
-
-  .kx-insight-grid article + article {
-    border-top: 1px solid var(--kx-line);
   }
 
   .kx-boundary-head {
     grid-template-columns: 1fr;
-    gap: 12px;
+    gap: 30px;
   }
 
-  .kx-boundary-grid {
-    grid-template-columns: 1fr;
+  .kx-boundary-head h2 {
+    max-width: 620px;
   }
 }
 
-@media (max-width: 420px) {
+@media (max-width: 520px) {
   .kx-wrap {
     width: min(calc(100% - 20px), 1180px);
   }
 
   .kx-intro h1 {
-    font-size: 33px;
+    font-size: 31px;
   }
 
-  .kx-phase-switch button {
-    overflow-wrap: anywhere;
+  .kx-lead {
+    font-size: 15px;
   }
 
-  .kx-playback {
-    gap: 5px;
+  .kx-theater-section {
+    padding-top: 16px;
   }
 
-  .kx-play-button {
-    min-width: 80px;
+  .kx-stage {
+    height: 1280px;
   }
 
-  .kx-icon-button {
-    width: 34px;
+  .kx-story-head {
+    padding: 18px 16px;
   }
 
-  .kx-probability-row {
-    grid-template-columns: 64px minmax(0, 1fr) 42px;
+  .kx-story-head h2 {
+    font-size: 20px;
+  }
+
+  .kx-stage-node {
+    right: 12px;
+    left: 12px;
+  }
+
+  .kx-request-node {
+    top: 18px;
+  }
+
+  .kx-model-node {
+    top: 218px;
+  }
+
+  .kx-tool-node {
+    top: 500px;
+  }
+
+  .kx-context-node {
+    top: 710px;
+  }
+
+  .kx-knowledge-node {
+    top: 928px;
+  }
+
+  .kx-outcome-node {
+    top: 1082px;
+    min-height: 170px;
+  }
+
+  .kx-travel-tokens,
+  .scene-tokens .kx-travel-tokens,
+  .scene-attention .kx-travel-tokens {
+    width: calc(100% - 32px);
+  }
+
+  .scene-attention .kx-travel-tokens {
+    width: calc(100% - 56px);
+  }
+
+  .kx-travel-tokens button {
+    min-width: 0;
+    padding: 0 3px;
+  }
+
+  .kx-model-stack i {
+    font-size: 6px;
+  }
+
+  .kx-knowledge-items {
+    gap: 4px;
+  }
+
+  .kx-knowledge-items span {
+    padding: 4px 2px;
+    font-size: 8px;
+  }
+
+  .kx-outcome-paths p {
+    font-size: 8px;
+  }
+
+  .kx-chapters button span {
+    display: none;
+  }
+
+  .kx-chapters button {
+    min-height: 18px;
+  }
+
+  .kx-summary-section,
+  .kx-boundary-section {
+    padding: 54px 0;
+  }
+
+  .kx-summary-section > .kx-wrap > h2,
+  .kx-boundary-head h2 {
+    font-size: 24px;
+  }
+
+  .kx-layer-list {
+    gap: 0;
+  }
+
+  .kx-boundary-list article {
+    grid-template-columns: 10px 1fr;
+  }
+
+  .kx-boundary-list article > div {
+    grid-column: 2;
+  }
+
+  .kx-boundary-list p {
+    margin-top: 4px;
+  }
+
+  .kx-omk-note {
+    grid-template-columns: 1fr;
+    gap: 8px;
   }
 }
 
@@ -1544,5 +1965,9 @@
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .kx-packet {
+    display: none;
   }
 }

--- a/docs/.vitepress/theme/knowledge-explainer.css
+++ b/docs/.vitepress/theme/knowledge-explainer.css
@@ -1,0 +1,1548 @@
+.omk-knowledge-explainer {
+  --kx-blue: #2563eb;
+  --kx-blue-soft: #eaf0ff;
+  --kx-green: #0f8f72;
+  --kx-green-soft: #e7f7f2;
+  --kx-amber: #c66b05;
+  --kx-amber-soft: #fff4dc;
+  --kx-coral: #d85040;
+  --kx-coral-soft: #fff0ed;
+  --kx-ink: #101827;
+  --kx-body: #4b5b70;
+  --kx-muted: #7b899c;
+  --kx-line: #dbe2eb;
+  --kx-line-strong: #c4cedb;
+  --kx-canvas: #f7f9fc;
+  --kx-surface: #ffffff;
+  --kx-surface-raised: #ffffff;
+  --kx-grid: rgba(28, 45, 70, 0.055);
+  --kx-shadow: 0 18px 50px -28px rgba(19, 37, 67, 0.34);
+  width: 100%;
+  max-width: 100vw;
+  overflow-x: hidden;
+  padding-top: var(--vp-nav-height);
+  background: var(--kx-surface);
+  color: var(--kx-ink);
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  line-height: 1.6;
+}
+
+.dark .omk-knowledge-explainer {
+  --kx-blue: #78a4ff;
+  --kx-blue-soft: #172846;
+  --kx-green: #43d1ad;
+  --kx-green-soft: #12342d;
+  --kx-amber: #f1b84b;
+  --kx-amber-soft: #382b13;
+  --kx-coral: #ff8b7c;
+  --kx-coral-soft: #3b211f;
+  --kx-ink: #eef3fa;
+  --kx-body: #b3bfd0;
+  --kx-muted: #7d8ca2;
+  --kx-line: #2a3545;
+  --kx-line-strong: #3b4a60;
+  --kx-canvas: #0e1420;
+  --kx-surface: #0b1019;
+  --kx-surface-raised: #131b28;
+  --kx-grid: rgba(174, 193, 218, 0.055);
+  --kx-shadow: 0 18px 50px -28px rgba(0, 0, 0, 0.8);
+}
+
+.omk-knowledge-explainer,
+.omk-knowledge-explainer * {
+  box-sizing: border-box;
+}
+
+.omk-knowledge-explainer button,
+.omk-knowledge-explainer input {
+  font: inherit;
+}
+
+.omk-knowledge-explainer button {
+  letter-spacing: 0;
+}
+
+.omk-knowledge-explainer a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.kx-wrap {
+  width: min(1180px, calc(100% - 48px));
+  margin: 0 auto;
+}
+
+.kx-intro {
+  position: relative;
+  padding: 52px 0 38px;
+  border-bottom: 1px solid var(--kx-line);
+  background-color: var(--kx-surface);
+  background-image:
+    linear-gradient(var(--kx-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--kx-grid) 1px, transparent 1px);
+  background-size: 30px 30px;
+}
+
+.kx-intro::after {
+  position: absolute;
+  right: max(24px, calc((100vw - 1180px) / 2));
+  bottom: -1px;
+  width: 128px;
+  height: 3px;
+  background: linear-gradient(90deg, var(--kx-blue) 0 42%, var(--kx-green) 42% 72%, var(--kx-amber) 72%);
+  content: "";
+}
+
+.kx-eyebrow {
+  margin: 0;
+  color: var(--kx-blue);
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.kx-intro h1 {
+  max-width: 780px;
+  margin: 12px 0 0;
+  font-size: 50px;
+  font-weight: 760;
+  line-height: 1.14;
+  letter-spacing: 0;
+}
+
+.kx-lead {
+  max-width: 820px;
+  margin: 16px 0 0;
+  color: var(--kx-body);
+  font-size: 18px;
+}
+
+.kx-request {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  margin-top: 26px;
+  padding-top: 18px;
+  border-top: 1px solid var(--kx-line);
+}
+
+.kx-request span {
+  flex: none;
+  color: var(--kx-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.kx-request strong {
+  font-size: 16px;
+  font-weight: 650;
+}
+
+.kx-lab-section {
+  padding: 38px 0 72px;
+  background: var(--kx-canvas);
+}
+
+.kx-lab {
+  overflow: hidden;
+  border: 1px solid var(--kx-line-strong);
+  border-radius: 8px;
+  background: var(--kx-surface-raised);
+  box-shadow: var(--kx-shadow);
+}
+
+.kx-lab-header {
+  display: flex;
+  min-height: 64px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--kx-line);
+  background: var(--kx-surface);
+}
+
+.kx-phase-switch {
+  position: relative;
+  display: grid;
+  width: min(560px, 100%);
+  grid-template-columns: repeat(3, 1fr);
+  padding-bottom: 7px;
+}
+
+.kx-phase-switch::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 1px;
+  background: var(--kx-line);
+  content: "";
+}
+
+.kx-phase-switch button {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  height: 40px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--kx-muted);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.kx-phase-switch button span {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  border: 1px solid var(--kx-line-strong);
+  border-radius: 50%;
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+}
+
+.kx-phase-switch button:hover,
+.kx-phase-switch button.active {
+  color: var(--kx-ink);
+}
+
+.kx-phase-switch button.active span {
+  border-color: var(--kx-blue);
+  background: var(--kx-blue);
+  color: #ffffff;
+}
+
+.kx-phase-switch button:focus-visible,
+.kx-playback button:focus-visible,
+.kx-step-rail button:focus-visible,
+.kx-token-selector button:focus-visible,
+.kx-rule-toggle input:focus-visible + span {
+  outline: 3px solid color-mix(in srgb, var(--kx-blue), transparent 62%);
+  outline-offset: 2px;
+}
+
+.kx-phase-packet {
+  position: absolute;
+  z-index: 2;
+  bottom: -3px;
+  width: 9px;
+  height: 9px;
+  border: 2px solid var(--kx-surface);
+  border-radius: 50%;
+  background: var(--kx-green);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--kx-green), transparent 75%);
+  transform: translateX(-50%);
+  transition: left 440ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.kx-playback {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 7px;
+}
+
+.kx-playback button {
+  display: inline-flex;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--kx-line-strong);
+  border-radius: 6px;
+  background: var(--kx-surface);
+  color: var(--kx-ink);
+  cursor: pointer;
+}
+
+.kx-playback button:hover {
+  border-color: var(--kx-blue);
+  color: var(--kx-blue);
+}
+
+.kx-icon-button {
+  width: 36px;
+  padding: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 17px;
+}
+
+.kx-play-button {
+  gap: 8px;
+  min-width: 86px;
+  padding: 0 14px;
+  border-color: var(--kx-ink) !important;
+  background: var(--kx-ink) !important;
+  color: var(--kx-surface) !important;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.kx-scene-head {
+  display: flex;
+  min-height: 124px;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 28px 32px 22px;
+}
+
+.kx-scene-head > div:first-child {
+  min-width: 0;
+}
+
+.kx-scene-head span {
+  color: var(--kx-muted);
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.kx-scene-head h2 {
+  margin: 4px 0 0;
+  font-size: 28px;
+  font-weight: 760;
+  letter-spacing: 0;
+}
+
+.kx-scene-head p {
+  max-width: 680px;
+  margin: 6px 0 0;
+  color: var(--kx-body);
+  font-size: 14px;
+}
+
+.kx-step-state {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 12px;
+}
+
+.kx-step-state strong {
+  color: var(--kx-blue);
+  font-size: 13px;
+}
+
+.kx-step-state span {
+  min-width: 44px;
+  padding: 3px 8px;
+  border: 1px solid var(--kx-line);
+  border-radius: 5px;
+  background: var(--kx-canvas);
+  text-align: center;
+}
+
+.kx-step-rail {
+  display: grid;
+  grid-template-columns: repeat(var(--step-count), 1fr);
+  margin: 0 32px;
+  border-top: 1px solid var(--kx-line);
+}
+
+.kx-step-rail button {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 13px 8px 12px 0;
+  border: 0;
+  background: transparent;
+  color: var(--kx-muted);
+  cursor: pointer;
+  text-align: left;
+}
+
+.kx-step-rail button::before {
+  position: absolute;
+  top: -1px;
+  right: 0;
+  left: 0;
+  height: 2px;
+  background: transparent;
+  content: "";
+}
+
+.kx-step-rail button i {
+  width: 8px;
+  height: 8px;
+  flex: none;
+  margin-top: 6px;
+  border: 1px solid var(--kx-line-strong);
+  border-radius: 50%;
+  background: var(--kx-surface);
+}
+
+.kx-step-rail button span {
+  overflow-wrap: anywhere;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.kx-step-rail button.done {
+  color: var(--kx-body);
+}
+
+.kx-step-rail button.done i {
+  border-color: var(--kx-green);
+  background: var(--kx-green);
+}
+
+.kx-step-rail button.active {
+  color: var(--kx-ink);
+}
+
+.kx-step-rail button.active::before {
+  background: var(--kx-blue);
+}
+
+.kx-step-rail button.active i {
+  border-color: var(--kx-blue);
+  background: var(--kx-blue);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--kx-blue), transparent 82%);
+}
+
+.kx-scene {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  min-height: 440px;
+  border-top: 1px solid var(--kx-line);
+  background-color: var(--kx-canvas);
+  background-image:
+    linear-gradient(var(--kx-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--kx-grid) 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
+.kx-visual {
+  display: grid;
+  min-width: 0;
+  min-height: 440px;
+  place-items: center;
+  padding: 34px;
+}
+
+.kx-transformer-scene,
+.kx-agent-scene,
+.kx-knowledge-scene {
+  width: 100%;
+  max-width: 800px;
+}
+
+.kx-original {
+  display: grid;
+  grid-template-columns: 112px 1fr;
+  align-items: baseline;
+  gap: 16px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--kx-line);
+}
+
+.kx-original span,
+.kx-tokenization > p,
+.kx-probabilities > p {
+  margin: 0;
+  color: var(--kx-muted);
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.kx-original p {
+  margin: 0;
+  color: var(--kx-ink);
+  font-size: 16px;
+  font-weight: 650;
+}
+
+.kx-tokenization {
+  padding-top: 54px;
+}
+
+.kx-token-row {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 9px;
+  margin-top: 18px;
+}
+
+.kx-token-row span {
+  display: grid;
+  min-height: 62px;
+  place-items: center;
+  padding: 8px 4px;
+  border: 1px solid var(--kx-line-strong);
+  border-radius: 6px;
+  background: var(--kx-surface);
+  box-shadow: 0 8px 20px -18px rgba(15, 35, 65, 0.6);
+  color: var(--kx-ink);
+  font-size: 15px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+  animation: kx-token-in 360ms both;
+  animation-delay: var(--delay);
+}
+
+@keyframes kx-token-in {
+  from {
+    opacity: 0;
+    transform: translateY(9px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.kx-vector-field {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 9px;
+  padding-top: 38px;
+}
+
+.kx-vector-token {
+  min-width: 0;
+  text-align: center;
+}
+
+.kx-vector-token strong {
+  display: block;
+  min-height: 42px;
+  overflow-wrap: anywhere;
+  color: var(--kx-body);
+  font-size: 12px;
+}
+
+.kx-vector-bars {
+  display: flex;
+  height: 126px;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 3px;
+  padding: 12px 7px;
+  border: 1px solid var(--kx-line);
+  border-radius: 6px;
+  background: var(--kx-surface);
+}
+
+.kx-vector-bars i {
+  width: 8px;
+  max-width: 14%;
+  border-radius: 2px 2px 0 0;
+  background: var(--kx-blue);
+  transform-origin: bottom;
+  animation: kx-vector-grow 520ms both;
+}
+
+@keyframes kx-vector-grow {
+  from {
+    transform: scaleY(0);
+  }
+  to {
+    transform: scaleY(1);
+  }
+}
+
+.kx-attention {
+  padding-top: 22px;
+}
+
+.kx-attention-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  color: var(--kx-body);
+  font-size: 13px;
+}
+
+.kx-attention-meta strong {
+  color: var(--kx-blue);
+}
+
+.kx-attention-meta code {
+  padding: 4px 8px;
+  border: 1px solid var(--kx-line);
+  border-radius: 5px;
+  background: var(--kx-surface);
+  color: var(--kx-muted);
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+}
+
+.kx-attention svg {
+  display: block;
+  width: 100%;
+  height: 160px;
+  overflow: visible;
+}
+
+.kx-attention path {
+  fill: none;
+  stroke: var(--kx-blue);
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+  transition: opacity 240ms, stroke-width 240ms;
+}
+
+.kx-attention path.selected {
+  stroke: var(--kx-green);
+}
+
+.kx-attention circle {
+  fill: var(--kx-blue);
+  stroke: var(--kx-surface);
+  stroke-width: 3;
+  vector-effect: non-scaling-stroke;
+}
+
+.kx-attention circle.selected {
+  fill: var(--kx-green);
+}
+
+.kx-token-selector {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 7px;
+  margin-top: -20px;
+}
+
+.kx-token-selector button {
+  min-width: 0;
+  min-height: 54px;
+  padding: 6px 3px;
+  border: 1px solid var(--kx-line);
+  border-radius: 6px;
+  background: var(--kx-surface);
+  color: var(--kx-body);
+  cursor: pointer;
+}
+
+.kx-token-selector button:hover,
+.kx-token-selector button.active {
+  border-color: var(--kx-blue);
+  color: var(--kx-ink);
+}
+
+.kx-token-selector button span {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.kx-token-selector button small {
+  display: block;
+  margin-top: 2px;
+  color: var(--kx-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+}
+
+.kx-inline-hint {
+  margin: 12px 0 0;
+  color: var(--kx-muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.kx-probabilities {
+  max-width: 620px;
+  margin: 0 auto;
+  padding-top: 38px;
+}
+
+.kx-probabilities > p {
+  margin-bottom: 18px;
+}
+
+.kx-probability-row {
+  display: grid;
+  grid-template-columns: 84px minmax(0, 1fr) 48px;
+  align-items: center;
+  gap: 12px;
+  min-height: 48px;
+  border-top: 1px solid var(--kx-line);
+}
+
+.kx-probability-row strong {
+  overflow-wrap: anywhere;
+  font-size: 13px;
+}
+
+.kx-probability-row > span {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 4px;
+  background: var(--kx-line);
+}
+
+.kx-probability-row > span i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--kx-blue);
+  animation: kx-probability-grow 620ms both;
+}
+
+.kx-probability-row:nth-child(3) > span i {
+  background: var(--kx-green);
+}
+
+.kx-probability-row:nth-child(4) > span i {
+  background: var(--kx-amber);
+}
+
+.kx-probability-row:nth-child(5) > span i {
+  background: var(--kx-coral);
+}
+
+.kx-probability-row em {
+  color: var(--kx-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-style: normal;
+  text-align: right;
+}
+
+@keyframes kx-probability-grow {
+  from {
+    width: 0;
+  }
+}
+
+.kx-agent-track {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  align-items: stretch;
+  gap: 18px;
+}
+
+.kx-agent-event {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  min-height: 136px;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 11px;
+  border: 1px solid var(--kx-line);
+  border-radius: 6px;
+  background: var(--kx-surface);
+  color: var(--kx-muted);
+  transition: border-color 220ms, background 220ms, transform 220ms;
+}
+
+.kx-agent-event > span {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.kx-agent-event > strong {
+  overflow-wrap: anywhere;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.kx-agent-event > i {
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  right: -17px;
+  color: var(--kx-line-strong);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 18px;
+  font-style: normal;
+  transform: translate(50%, -50%);
+}
+
+.kx-agent-event.done {
+  border-color: color-mix(in srgb, var(--kx-green), var(--kx-line) 52%);
+  background: var(--kx-green-soft);
+  color: var(--kx-green);
+}
+
+.kx-agent-event.active {
+  border-color: var(--kx-blue);
+  background: var(--kx-blue-soft);
+  color: var(--kx-ink);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--kx-blue), transparent 84%);
+  transform: translateY(-4px);
+}
+
+.kx-agent-event.active > span {
+  color: var(--kx-blue);
+}
+
+.kx-context-strip {
+  display: grid;
+  grid-template-columns: 1fr minmax(220px, 0.7fr);
+  align-items: center;
+  gap: 28px;
+  margin-top: 34px;
+  padding-top: 22px;
+  border-top: 1px solid var(--kx-line);
+}
+
+.kx-context-strip > div:first-child span,
+.kx-context-meter > span {
+  display: block;
+  color: var(--kx-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.kx-context-strip > div:first-child strong {
+  display: block;
+  margin-top: 5px;
+  font-size: 14px;
+}
+
+.kx-context-meter {
+  display: grid;
+  grid-template-columns: 1fr 36px;
+  align-items: center;
+  gap: 7px 12px;
+}
+
+.kx-context-meter > span {
+  grid-column: 1 / -1;
+}
+
+.kx-context-meter > i {
+  height: 7px;
+  overflow: hidden;
+  border-radius: 4px;
+  background: var(--kx-line);
+}
+
+.kx-context-meter > i b {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--kx-green);
+  transition: width 380ms ease;
+}
+
+.kx-context-meter > strong {
+  color: var(--kx-green);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  text-align: right;
+}
+
+.kx-knowledge-river {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  padding-bottom: 28px;
+}
+
+.kx-knowledge-river::before {
+  position: absolute;
+  right: 10%;
+  bottom: 13px;
+  left: 10%;
+  height: 2px;
+  background: var(--kx-line-strong);
+  content: "";
+}
+
+.kx-knowledge-source {
+  min-width: 0;
+  min-height: 118px;
+  padding: 14px;
+  border: 1px solid var(--kx-line);
+  border-radius: 6px;
+  background: var(--kx-surface);
+  color: var(--kx-body);
+  transition: border-color 220ms, background 220ms, opacity 220ms, transform 220ms;
+}
+
+.kx-knowledge-source > span {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border: 1px solid var(--kx-line);
+  border-radius: 50%;
+  color: var(--kx-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+}
+
+.kx-knowledge-source strong,
+.kx-knowledge-source small {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.kx-knowledge-source strong {
+  margin-top: 13px;
+  color: var(--kx-ink);
+  font-size: 14px;
+}
+
+.kx-knowledge-source small {
+  margin-top: 3px;
+  color: var(--kx-muted);
+  font-size: 11px;
+}
+
+.kx-knowledge-source.active {
+  border-color: var(--kx-blue);
+  background: var(--kx-blue-soft);
+  transform: translateY(-4px);
+}
+
+.kx-knowledge-source.context.active {
+  border-color: var(--kx-green);
+  background: var(--kx-green-soft);
+}
+
+.kx-knowledge-source.runtime.active {
+  border-color: var(--kx-amber);
+  background: var(--kx-amber-soft);
+}
+
+.kx-knowledge-source.candidate.active {
+  border-color: var(--kx-coral);
+  background: var(--kx-coral-soft);
+}
+
+.kx-knowledge-source.muted {
+  border-style: dashed;
+  opacity: 0.45;
+}
+
+.kx-knowledge-packet {
+  position: absolute;
+  z-index: 2;
+  bottom: 8px;
+  width: 12px;
+  height: 12px;
+  border: 3px solid var(--kx-canvas);
+  border-radius: 50%;
+  background: var(--kx-blue);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--kx-blue), transparent 76%);
+  transform: translateX(-50%);
+  transition: left 440ms cubic-bezier(0.2, 0.8, 0.2, 1), background 220ms;
+}
+
+.kx-rule-toggle {
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 0 12px;
+  align-items: center;
+  width: 100%;
+  padding: 15px 0;
+  border-top: 1px solid var(--kx-line);
+  border-bottom: 1px solid var(--kx-line);
+  cursor: pointer;
+}
+
+.kx-rule-toggle input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.kx-rule-toggle > span {
+  position: relative;
+  grid-row: 1 / 3;
+  width: 38px;
+  height: 22px;
+  border-radius: 11px;
+  background: var(--kx-line-strong);
+  transition: background 180ms;
+}
+
+.kx-rule-toggle > span i {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.35);
+  transition: transform 180ms;
+}
+
+.kx-rule-toggle input:checked + span {
+  background: var(--kx-green);
+}
+
+.kx-rule-toggle input:checked + span i {
+  transform: translateX(16px);
+}
+
+.kx-rule-toggle > strong {
+  font-size: 13px;
+}
+
+.kx-rule-toggle > small {
+  color: var(--kx-muted);
+  font-size: 11px;
+}
+
+.kx-outcome {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  gap: 24px;
+  margin-top: 20px;
+  padding: 18px;
+  border: 1px solid var(--kx-line-strong);
+  border-left-width: 4px;
+  border-radius: 6px;
+  background: var(--kx-surface);
+}
+
+.kx-outcome.grounded {
+  border-left-color: var(--kx-green);
+}
+
+.kx-outcome.uncertain {
+  border-left-color: var(--kx-coral);
+}
+
+.kx-outcome > div > span {
+  display: block;
+  color: var(--kx-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.kx-outcome > div > strong {
+  display: block;
+  margin-top: 5px;
+  font-size: 14px;
+}
+
+.kx-outcome dl,
+.kx-outcome dl div {
+  margin: 0;
+}
+
+.kx-outcome dl {
+  display: grid;
+  gap: 9px;
+}
+
+.kx-outcome dl div {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 10px;
+}
+
+.kx-outcome dt {
+  color: var(--kx-muted);
+  font-size: 11px;
+}
+
+.kx-outcome dd {
+  margin: 0;
+  color: var(--kx-body);
+  font-size: 12px;
+}
+
+.kx-inspector {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  padding: 30px 26px;
+  border-left: 1px solid var(--kx-line);
+  background: color-mix(in srgb, var(--kx-surface), transparent 3%);
+}
+
+.kx-truth-badge {
+  align-self: flex-start;
+  padding: 4px 8px;
+  border: 1px solid var(--kx-line);
+  border-radius: 5px;
+  background: var(--kx-canvas);
+  color: var(--kx-blue);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.kx-truth-badge.phase-1 {
+  color: var(--kx-green);
+}
+
+.kx-truth-badge.phase-2 {
+  color: var(--kx-amber);
+}
+
+.kx-inspector-step {
+  margin: 22px 0 0;
+  color: var(--kx-ink) !important;
+  font-size: 17px !important;
+  font-weight: 750;
+}
+
+.kx-inspector > p:last-of-type {
+  margin: 10px 0 0;
+  color: var(--kx-body);
+  font-size: 13px;
+}
+
+.kx-source-detail {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid var(--kx-line);
+}
+
+.kx-source-detail span,
+.kx-source-detail strong {
+  display: block;
+}
+
+.kx-source-detail span {
+  color: var(--kx-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.kx-source-detail strong {
+  margin-top: 4px;
+  font-size: 13px;
+}
+
+.kx-insight-section {
+  padding: 72px 0;
+  border-top: 1px solid var(--kx-line);
+  background: var(--kx-surface);
+}
+
+.kx-insight-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin-top: 24px;
+  border-top: 1px solid var(--kx-line-strong);
+  border-bottom: 1px solid var(--kx-line-strong);
+}
+
+.kx-insight-grid article {
+  min-width: 0;
+  padding: 28px 28px 30px 0;
+}
+
+.kx-insight-grid article + article {
+  padding-left: 28px;
+  border-left: 1px solid var(--kx-line);
+}
+
+.kx-insight-grid article > span {
+  color: var(--kx-blue);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.kx-insight-grid article:nth-child(2) > span {
+  color: var(--kx-green);
+}
+
+.kx-insight-grid article:nth-child(3) > span {
+  color: var(--kx-amber);
+}
+
+.kx-insight-grid h2 {
+  margin: 12px 0 0;
+  font-size: 20px;
+  font-weight: 750;
+  letter-spacing: 0;
+}
+
+.kx-insight-grid p {
+  margin: 10px 0 0;
+  color: var(--kx-body);
+  font-size: 14px;
+}
+
+.kx-boundary-section {
+  padding: 70px 0 84px;
+  border-top: 1px solid var(--kx-line);
+  background: var(--kx-canvas);
+}
+
+.kx-boundary-head {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.7fr) minmax(0, 1.3fr);
+  gap: 40px;
+  align-items: start;
+}
+
+.kx-boundary-head > p:last-child {
+  max-width: 680px;
+  margin: 0;
+  color: var(--kx-body);
+  font-size: 16px;
+}
+
+.kx-boundary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0 28px;
+  margin-top: 34px;
+  border-top: 1px solid var(--kx-line-strong);
+}
+
+.kx-boundary-grid article {
+  display: grid;
+  grid-template-columns: 12px 1fr;
+  gap: 14px;
+  min-width: 0;
+  padding: 22px 0;
+  border-bottom: 1px solid var(--kx-line);
+}
+
+.kx-boundary-grid article > i {
+  width: 9px;
+  height: 9px;
+  margin-top: 7px;
+  border-radius: 50%;
+  background: var(--kx-blue);
+}
+
+.kx-boundary-grid article.observed > i {
+  background: var(--kx-green);
+}
+
+.kx-boundary-grid article.inferred > i {
+  background: var(--kx-amber);
+}
+
+.kx-boundary-grid article.unavailable > i {
+  border: 2px solid var(--kx-coral);
+  background: transparent;
+}
+
+.kx-boundary-grid h2 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 750;
+}
+
+.kx-boundary-grid p {
+  margin: 4px 0 0;
+  color: var(--kx-body);
+  font-size: 13px;
+}
+
+.kx-sources {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  margin-top: 34px;
+  padding-top: 20px;
+  border-top: 1px solid var(--kx-line-strong);
+  color: var(--kx-muted);
+  font-size: 12px;
+}
+
+.kx-sources span {
+  font-weight: 700;
+}
+
+.kx-sources a {
+  color: var(--kx-body);
+  text-decoration: underline;
+  text-decoration-color: var(--kx-line-strong);
+  text-underline-offset: 3px;
+}
+
+.kx-sources a:hover {
+  color: var(--kx-blue);
+}
+
+@media (max-width: 960px) {
+  .kx-lab-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .kx-phase-switch {
+    width: 100%;
+  }
+
+  .kx-playback {
+    justify-content: flex-end;
+  }
+
+  .kx-scene {
+    grid-template-columns: 1fr;
+  }
+
+  .kx-visual {
+    min-height: 420px;
+  }
+
+  .kx-inspector {
+    min-height: 168px;
+    border-top: 1px solid var(--kx-line);
+    border-left: 0;
+  }
+
+  .kx-agent-track {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 14px;
+  }
+
+  .kx-agent-event:nth-child(3) > i {
+    display: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .kx-wrap {
+    width: min(calc(100% - 28px), 1180px);
+  }
+
+  .kx-intro {
+    padding: 36px 0 30px;
+  }
+
+  .kx-intro h1 {
+    font-size: 38px;
+  }
+
+  .kx-lead {
+    font-size: 16px;
+  }
+
+  .kx-request {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .kx-lab-section {
+    padding: 20px 0 52px;
+  }
+
+  .kx-phase-switch button {
+    flex-direction: column;
+    gap: 2px;
+    height: 50px;
+    font-size: 11px;
+  }
+
+  .kx-phase-switch button span {
+    width: 18px;
+    height: 18px;
+  }
+
+  .kx-playback {
+    justify-content: center;
+  }
+
+  .kx-scene-head {
+    min-height: 0;
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 22px 18px 18px;
+  }
+
+  .kx-scene-head h2 {
+    font-size: 23px;
+  }
+
+  .kx-step-state {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .kx-step-rail {
+    margin: 0 18px;
+  }
+
+  .kx-step-rail button {
+    justify-content: center;
+    padding-right: 0;
+  }
+
+  .kx-step-rail button span {
+    display: none;
+  }
+
+  .kx-visual {
+    min-height: 460px;
+    padding: 24px 16px;
+  }
+
+  .kx-original {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+
+  .kx-token-row,
+  .kx-vector-field {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .kx-token-row span:last-child,
+  .kx-vector-token:last-child {
+    grid-column: 2;
+  }
+
+  .kx-vector-token strong {
+    min-height: 34px;
+  }
+
+  .kx-vector-bars {
+    height: 86px;
+  }
+
+  .kx-attention svg {
+    height: 130px;
+  }
+
+  .kx-token-selector {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    margin-top: -10px;
+  }
+
+  .kx-attention-meta {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .kx-agent-track {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .kx-agent-event {
+    min-height: 82px;
+  }
+
+  .kx-agent-event > i {
+    top: auto;
+    right: 50%;
+    bottom: -18px;
+    transform: translate(50%, 50%) rotate(90deg);
+  }
+
+  .kx-agent-event:nth-child(3) > i {
+    display: block;
+  }
+
+  .kx-context-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .kx-knowledge-river {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .kx-knowledge-river::before,
+  .kx-knowledge-packet {
+    display: none;
+  }
+
+  .kx-outcome {
+    grid-template-columns: 1fr;
+  }
+
+  .kx-outcome dl div {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+
+  .kx-inspector {
+    padding: 24px 20px;
+  }
+
+  .kx-insight-section,
+  .kx-boundary-section {
+    padding: 54px 0;
+  }
+
+  .kx-insight-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .kx-insight-grid article,
+  .kx-insight-grid article + article {
+    padding: 22px 0;
+    border-left: 0;
+  }
+
+  .kx-insight-grid article + article {
+    border-top: 1px solid var(--kx-line);
+  }
+
+  .kx-boundary-head {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .kx-boundary-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .kx-wrap {
+    width: min(calc(100% - 20px), 1180px);
+  }
+
+  .kx-intro h1 {
+    font-size: 33px;
+  }
+
+  .kx-phase-switch button {
+    overflow-wrap: anywhere;
+  }
+
+  .kx-playback {
+    gap: 5px;
+  }
+
+  .kx-play-button {
+    min-width: 80px;
+  }
+
+  .kx-icon-button {
+    width: 34px;
+  }
+
+  .kx-probability-row {
+    grid-template-columns: 64px minmax(0, 1fr) 42px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .omk-knowledge-explainer *,
+  .omk-knowledge-explainer *::before,
+  .omk-knowledge-explainer *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/docs/explanation/how-ai-knows.md
+++ b/docs/explanation/how-ai-knows.md
@@ -1,0 +1,8 @@
+---
+layout: page
+sidebar: false
+aside: false
+knowledgeExplainer: true
+title: How AI comes to understand
+description: An interactive journey through Transformer computation, Agent work, and the flow of knowledge.
+---

--- a/docs/zh/explanation/how-ai-knows.md
+++ b/docs/zh/explanation/how-ai-knows.md
@@ -1,0 +1,8 @@
+---
+layout: page
+sidebar: false
+aside: false
+knowledgeExplainer: true
+title: AI 是怎么懂的
+description: 沿着同一条请求，交互理解 Transformer、Agent 与 knowledge 如何共同工作。
+---


### PR DESCRIPTION
## 用户影响

新增中英文可探索教学动画。读者沿同一条请求，在一个连续舞台中观察文字如何成为 token、上下文如何影响下一动作、工具证据和项目 knowledge 如何进入上下文，以及相同模型为什么会因 knowledge 不同走向不同结果。

页面提供八幕分镜、自动播放、进度拖动、attention 教学交互和项目规范开关；自动播放会在 knowledge 分叉处暂停，鼓励读者亲自做对照。

## 准确性边界

Transformer 内部视图明确标注为教学模拟；请求、上下文、工具调用与结果只按可观测事实展示；knowledge 的因果影响标注为需要受控评测验证的系统推断。页面不会把生成解释冒充模型的隐藏思维，并明确列出闭源模型内部不可观测的部分。

## 兼容性

仅重构文档教学页面，不改变 OMK 的运行时行为、报告 schema 或测量可比性。

Closes #378
