### PR TITLE
fix(renderer): 保持详情恢复时实时跟随

### DIFF
--- a/src/renderer/knowledge-debugger-renderer.ts
+++ b/src/renderer/knowledge-debugger-renderer.ts
@@ -1158,7 +1158,8 @@ export function renderKnowledgeDebuggerPage(
           })},
           getMode: () => shell.dataset.mode || 'semantic',
           setMode: setTrajectoryMode,
-          isScrollTrackingSuppressed: () => shell.dataset.layoutTransition === 'true',
+          isScrollTrackingSuppressed: () => shell.dataset.layoutTransition === 'true'
+            || shell.dataset.inspectorRestoring === 'true',
           refreshSnapshot: refreshTrajectorySnapshot,
           browserWindow: window,
           browserDocument: document,

--- a/test/server/knowledge-debugger-server.test.ts
+++ b/test/server/knowledge-debugger-server.test.ts
@@ -238,7 +238,10 @@ describe('Knowledge Debugger task trajectory server', () => {
     assert.match(replay.body, /const closeInspector = \(shouldScheduleLayout = true\) =>/);
     assert.match(replay.body, /grid-template-columns:minmax\(0,1fr\) 0;align-items:stretch;transition:grid-template-columns/);
     assert.match(replay.body, /shell\.dataset\.inspectorOpen !== 'true'\) beginLayoutTransition\(\)/);
-    assert.match(replay.body, /isScrollTrackingSuppressed: \(\) => shell\.dataset\.layoutTransition === 'true'/);
+    assert.match(
+      replay.body,
+      /isScrollTrackingSuppressed: \(\) => shell\.dataset\.layoutTransition === 'true'[\s\S]*shell\.dataset\.inspectorRestoring === 'true'/,
+    );
     assert.match(replay.body, /new ResizeObserver\(scheduleOperationLinks\)/);
     assert.match(replay.body, /revealSelectedOperation\(\)/);
     assert.match(replay.body, /if \(!alignFollowingViewport\(\)\) revealSelectedOperation\(\)/);


### PR DESCRIPTION
## 用户影响

实时任务轨迹展开节点详情并收到新快照时，继续保持「跟随中」，不再误切换为「查看更新」。用户主动横向浏览历史位置时，仍会暂停自动跟随。

## 兼容性

不涉及数据 schema、测量语义或迁移。作为 #382 的发布前验收修复。