### PR TITLE
chore(release): 升级 Release action 到 Node.js 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'v*' # 仅在推送以 'v' 开头的 Tag 时触发，例如 v0.19.0
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -88,6 +85,6 @@ jobs:
     # "What's Changed" + "Full Changelog: compare URL"。不再维护单独的 CHANGELOG.md —
     # PR title / description 是唯一信息源, BREAKING / migration 在 PR 描述里写清楚。
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         generate_release_notes: true


### PR DESCRIPTION
## 用户影响

发布流程不再因 `softprops/action-gh-release@v2` 使用 Node.js 20 而产生弃用告警，自动生成 GitHub Release notes 的行为保持不变。

## 迁移说明

无需用户迁移。发布工作流改用上游已切换到 Node.js 24 的 v3，并移除过渡期的强制运行时环境变量。