### PR TITLE
chore(release): 发布 0.52.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 Studio 验收修复：原始日志归档提示不再重复或显示“省略 0 条”，短任务时间轴不再渲染重复刻度。

## 迁移说明

无需迁移。

## 测量学说明

本版本仅修复 Studio 展示，不改变 trace、规范化事件、语义轨迹或评测结果的生成语义。