### PR TITLE
chore(release): 发布 0.52.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.52.1",
+  "version": "0.52.2",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 0.52.2，将任务轨迹边界、长任务关键节点保留、跨轮纠正关联和证据下钻的稳定性修复交付给 npm 用户。

## 兼容性

无需迁移已有配置或观测数据。本次为补丁版本，不改变报告 schema 与测量可比性。

包含 #389。