### PR TITLE
feat(renderer): 对话任务支持倒序浏览与状态刷新

### DIFF
--- a/src/observability/codex-conversation-index.ts
+++ b/src/observability/codex-conversation-index.ts
@@ -9,7 +9,7 @@ import {
 
 const READ_CHUNK_BYTES = 256 * 1024;
 const MAX_RECORD_BYTES = 32 * 1024 * 1024;
-const INDEX_SCHEMA_VERSION = 11;
+const INDEX_SCHEMA_VERSION = 12;
 const MAX_CURRENT_INDEX_ATTEMPTS = 4;
 
 export interface CodexIndexedTask {
@@ -28,7 +28,7 @@ export interface CodexIndexedTask {
 }
 
 export interface CodexRolloutIndex {
-  schemaVersion: 11;
+  schemaVersion: 12;
   sourcePath: string;
   /** File size observed when the index was produced. */
   sourceSize: number;

--- a/src/observability/codex-protocol.ts
+++ b/src/observability/codex-protocol.ts
@@ -35,6 +35,14 @@ const EVENT_MESSAGE_TYPES: ReadonlySet<string> = new Set([
 
 const IN_APP_BROWSER_CONTEXT_RE = /<in-app-browser-context\b[^>]*>[\s\S]*?<\/in-app-browser-context>/gi;
 const CODEX_RUNTIME_MESSAGE_RE = /^# AGENTS\.md instructions\b|^<(?:app-context|environment_context|permissions instructions|collaboration_mode|apps_instructions|plugins_instructions|skills_instructions|recommended_plugins)>/i;
+const CODEX_USER_REQUEST_HEADING_RE = /^## My request(?: for Codex)?:\s*$/im;
+const CODEX_USER_FILES_HEADING_RE = /^# Files mentioned by the user:\s*$/im;
+const IMAGE_ATTACHMENT_RE = /\.(?:avif|bmp|gif|heic|heif|jpe?g|png|webp)$/i;
+
+export interface CodexUserAttachment {
+  attachmentKind: 'image' | 'file';
+  name: string;
+}
 
 export function isCodexResponseItemType(value: string | undefined): boolean {
   return value !== undefined && RESPONSE_ITEM_TYPES.has(value);
@@ -46,8 +54,7 @@ export function isCodexEventMessageType(value: string | undefined): boolean {
 
 /** Preserve source text separately while removing Codex UI transport envelopes from semantic display. */
 export function codexUserDisplayText(text: string): string | undefined {
-  const requestHeading = /^## My request for Codex:\s*$/im;
-  const requestMatch = requestHeading.exec(text);
+  const requestMatch = CODEX_USER_REQUEST_HEADING_RE.exec(text);
   const request = requestMatch
     ? text.slice(requestMatch.index + requestMatch[0].length)
     : text;
@@ -58,6 +65,44 @@ export function codexUserDisplayText(text: string): string | undefined {
     .replace(/\n{3,}/g, '\n\n')
     .trim();
   return visible || undefined;
+}
+
+/** Extract privacy-safe attachment metadata without projecting local paths into Trace IR. */
+export function codexUserAttachments(text: string): CodexUserAttachment[] {
+  const attachments = new Map<string, CodexUserAttachment>();
+  const requestMatch = CODEX_USER_REQUEST_HEADING_RE.exec(text);
+  const filesMatch = CODEX_USER_FILES_HEADING_RE.exec(text);
+  if (filesMatch && (!requestMatch || filesMatch.index < requestMatch.index)) {
+    const sectionEnd = requestMatch?.index ?? text.length;
+    const section = text.slice(filesMatch.index + filesMatch[0].length, sectionEnd);
+    for (const match of section.matchAll(/^##\s+(.+?):\s+(.+)\s*$/gm)) {
+      addCodexUserAttachment(attachments, match[1], match[2]);
+    }
+  }
+
+  for (const match of text.matchAll(/<image\b[^>]*\bpath="([^"]+)"[^>]*>/gi)) {
+    addCodexUserAttachment(attachments, undefined, match[1]);
+  }
+  return [...attachments.values()];
+}
+
+function addCodexUserAttachment(
+  attachments: Map<string, CodexUserAttachment>,
+  declaredName: string | undefined,
+  sourcePath: string | undefined,
+): void {
+  const normalizedPath = sourcePath?.trim();
+  const inferredName = normalizedPath?.split(/[\\/]/).at(-1);
+  const name = declaredName?.trim() || inferredName?.trim();
+  if (!name) return;
+  const key = name.toLocaleLowerCase('en-US');
+  if (attachments.has(key)) return;
+  attachments.set(key, {
+    attachmentKind: IMAGE_ATTACHMENT_RE.test(name) || IMAGE_ATTACHMENT_RE.test(normalizedPath ?? '')
+      ? 'image'
+      : 'file',
+    name,
+  });
 }
 
 export function codexUserMessageOrigin(text: string): 'human' | 'runtime' {

--- a/src/observability/codex-trace-adapter.ts
+++ b/src/observability/codex-trace-adapter.ts
@@ -23,6 +23,7 @@ import {
 import { normalizeToolIdentity } from '../shared/tool-identity.js';
 import { extractCodexExecCommands } from './codex-exec-command.js';
 import {
+  codexUserAttachments,
   codexUserDisplayText,
   codexUserMessageOrigin,
   isCodexEventMessageType,
@@ -320,6 +321,7 @@ function convertCodexRecords(rawRecords: unknown[], runId: string): TraceEvent[]
             : normalizedRole === 'system' ? 'runtime' : 'synthetic',
           text,
           displayText: normalizedRole === 'user' ? codexUserDisplayText(text) : undefined,
+          attachments: normalizedRole === 'user' ? codexUserAttachments(text) : undefined,
           model: normalizedRole === 'assistant' ? activeModel : undefined,
         });
       }
@@ -603,6 +605,7 @@ function convertCodexRecords(rawRecords: unknown[], runId: string): TraceEvent[]
           origin: codexUserMessageOrigin(text),
           text,
           displayText: codexUserDisplayText(text),
+          attachments: codexUserAttachments(text),
         });
       }
       return;
@@ -1200,6 +1203,7 @@ function indexDuplicateEventMessages(records: unknown[]): Set<number> {
       : payloadType === 'agent_message' ? 'assistant' : undefined;
     const text = stringValue(payload.message);
     if (!role || !text) return;
+    const mirrorText = role === 'user' ? codexUserDisplayText(text) : text;
     const nearbyRecords = [-1, 1].flatMap((direction) => {
       let candidateIndex = sourceIndex + direction;
       while (candidateIndex >= 0 && candidateIndex < records.length) {
@@ -1213,9 +1217,12 @@ function indexDuplicateEventMessages(records: unknown[]): Set<number> {
       const adjacent = asCodexRecord(candidate);
       if (adjacent?.type !== 'response_item') return false;
       const adjacentPayload = isObject(adjacent.payload) ? adjacent.payload : {};
-      return adjacentPayload.type === 'message'
-        && adjacentPayload.role === role
-        && codexContentText(adjacentPayload.content) === text;
+      if (adjacentPayload.type !== 'message' || adjacentPayload.role !== role) return false;
+      const adjacentText = codexContentText(adjacentPayload.content);
+      if (!adjacentText) return false;
+      return role === 'user'
+        ? Boolean(mirrorText) && codexUserDisplayText(adjacentText) === mirrorText
+        : adjacentText === text;
     });
     if (mirrored) duplicateIndexes.add(sourceIndex);
   });

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -1329,11 +1329,21 @@ function isTimelineEvent(value: unknown): value is ExperienceTimelineEvent {
     !optionalStrings.every((field) => field === undefined || typeof field === 'string')
     || !isOptionalTimestamp(value.timestamp)
     || (value.isError !== undefined && typeof value.isError !== 'boolean')
+    || (value.attachments !== undefined && !isTimelineAttachmentArray(value.attachments))
   ) return false;
   return value.kind !== 'tool_result'
     || value.toolStatus === undefined
     || value.isError === undefined
     || value.isError === (value.toolStatus === 'failure');
+}
+
+function isTimelineAttachmentArray(value: unknown): value is NonNullable<ExperienceTimelineEvent['attachments']> {
+  return Array.isArray(value) && value.every((attachment) => (
+    isObjectRecord(attachment)
+    && (attachment.attachmentKind === 'image' || attachment.attachmentKind === 'file')
+    && typeof attachment.name === 'string'
+    && attachment.name.length > 0
+  ));
 }
 
 function isTimelineEventArray(value: unknown): value is ExperienceTimelineEvent[] {
@@ -3426,6 +3436,7 @@ function userTimelineEvents(
     order: order + (commandEnvelope ? 1 : 0),
     snippet: snippet(semanticText, 700),
     fullText: fullText(semanticText),
+    attachments: event.attachments,
     label: userTextEventLabel(kind),
   }));
   return events;

--- a/src/observability/trace-ir.ts
+++ b/src/observability/trace-ir.ts
@@ -23,6 +23,12 @@ export type TraceModelActivityContentSource = 'summary' | 'content' | 'text';
 export type TraceRuntimeContextKind = 'session_context' | 'execution_context' | 'settings' | 'goal';
 export type TraceAgentActivityKind = 'communication' | 'status';
 
+export interface TraceMessageAttachment {
+  attachmentKind: 'image' | 'file';
+  /** Privacy-safe display name. Source-local paths remain available only in raw logs. */
+  name: string;
+}
+
 /** Source-neutral tool identity, including provider namespaces when present. */
 export type TraceToolRef = NormalizedToolIdentity;
 
@@ -43,6 +49,7 @@ export interface TraceMessageEvent extends TraceEventBase {
   text: string;
   /** Human-facing text after a source adapter removes transport/UI envelopes. */
   displayText?: string;
+  attachments?: TraceMessageAttachment[];
   model?: string;
   attributionSkill?: string;
 }

--- a/src/renderer/conversation-renderer.ts
+++ b/src/renderer/conversation-renderer.ts
@@ -16,6 +16,13 @@ export interface ConversationActivitySnapshot {
   runningCount: number;
 }
 
+export interface ConversationDetailActivitySnapshot {
+  schemaVersion: 1;
+  revision: string;
+  taskCount: number;
+  runningCount: number;
+}
+
 export function buildConversationActivitySnapshot(
   model: ConversationIndexViewModel,
 ): ConversationActivitySnapshot {
@@ -34,6 +41,23 @@ export function buildConversationActivitySnapshot(
     schemaVersion: 1,
     revision: createHash('sha256').update(JSON.stringify(state)).digest('hex').slice(0, 24),
     runningCount,
+  };
+}
+
+export function buildConversationDetailActivitySnapshot(
+  conversation: ConversationListItem,
+): ConversationDetailActivitySnapshot {
+  const state = conversation.tasks.map((task) => [
+    task.turnId,
+    task.status,
+    task.startTimestamp ?? null,
+    task.endTimestamp ?? null,
+  ]);
+  return {
+    schemaVersion: 1,
+    revision: createHash('sha256').update(JSON.stringify(state)).digest('hex').slice(0, 24),
+    taskCount: conversation.tasks.length,
+    runningCount: conversation.tasks.filter((task) => task.status === 'open').length,
   };
 }
 
@@ -122,11 +146,12 @@ export function renderConversationDetailPage(
 ): string {
   const zh = lang === 'zh';
   const langSuffix = lang === DEFAULT_LANG ? '' : '?lang=en';
+  const activity = buildConversationDetailActivitySnapshot(conversation);
   const taskRows = conversationTaskEntries(conversation.tasks)
     .map(({ task, ordinal }) => renderTaskRow(task, ordinal, lang))
     .join('');
   return layout(zh ? '对话任务' : 'Conversation tasks', `
-    <main class="conversation-page conversation-detail-page">
+    <main class="conversation-page conversation-detail-page" data-activity-revision="${e(activity.revision)}" data-activity-endpoint="/api/conversations/${encodeURIComponent(conversation.threadId)}/activity${langSuffix}">
       <header class="conversation-page-head conversation-detail-head">
         <div>
           <a class="back-link" href="/conversations${langSuffix}">${zh ? '返回对话总览' : 'Back to conversations'}</a>
@@ -142,11 +167,12 @@ export function renderConversationDetailPage(
         </div>
       </header>
       <section class="task-list" aria-label="${zh ? '任务列表' : 'Task list'}">
-        <header class="task-list-head"><span>${zh ? '任务' : 'Task'}</span><span>${zh ? '时间' : 'Time'}</span><span>${zh ? '执行' : 'Execution'}</span><span></span></header>
+        <header class="task-list-head"><span>${zh ? '任务' : 'Task'}</span><span>${zh ? '时间' : 'Time'}</span><span>${zh ? '执行' : 'Execution'}</span><button type="button" class="task-order-toggle" data-task-order-toggle data-task-order="desc" aria-label="${zh ? '切换为最早优先' : 'Switch to oldest first'}" title="${zh ? '切换为最早优先' : 'Switch to oldest first'}">${icon('arrow-up-down', { size: 14 })}<span data-task-order-label>${zh ? '最新优先' : 'Newest first'}</span></button></header>
         ${taskRows || `<div class="empty-state"><strong>${zh ? '没有识别到任务边界' : 'No task boundaries found'}</strong><span>${zh ? '该对话的原始日志可能尚未写入完整的 turn 生命周期。' : 'The raw log may not contain complete turn lifecycle records yet.'}</span></div>`}
       </section>
     </main>
     <style>${CSS}</style>
+    <script>${conversationDetailScript(lang)}</script>
   `, lang);
 }
 
@@ -193,23 +219,108 @@ function conversationTaskEntries(
 ): Array<{ task: ConversationTaskItem; ordinal: number }> {
   return tasks
     .map((task, index) => ({ task, ordinal: index + 1 }))
-    .sort((left, right) => (
-      Number(right.task.status === 'open') - Number(left.task.status === 'open')
-      || left.ordinal - right.ordinal
-    ));
+    .sort((left, right) => right.ordinal - left.ordinal);
 }
 
 function renderTaskRow(task: ConversationTaskItem, ordinal: number, lang: Lang): string {
   const zh = lang === 'zh';
   const href = taskTrajectoryHref(task, lang) ?? '#';
   const status = statusLabel(task.status, lang);
-  return `<article class="task-row${task.status === 'open' ? ' is-running' : ''}" data-task-status="${e(task.status)}">
+  return `<article class="task-row${task.status === 'open' ? ' is-running' : ''}" data-task-status="${e(task.status)}" data-task-ordinal="${ordinal}">
     <div class="task-index">${String(ordinal).padStart(2, '0')}</div>
     <div class="task-main"><div class="task-title">${renderSafeInlineMarkdown(task.title, { links: 'text' })}</div><div class="task-context">${task.eventCount} ${zh ? '条原始日志' : 'raw records'}</div></div>
     <div class="task-time"><span>${e(formatTime(task.startTimestamp))}</span><small>${e(formatDuration(task.durationMs, lang))}</small></div>
     <div class="task-execution"><span class="task-status status-${e(task.status)}">${e(status)}</span><small>${task.toolCallCount} ${zh ? '次调用' : 'calls'}${task.toolFailureCount > 0 ? ` · ${task.toolFailureCount} ${zh ? '次失败' : 'failures'}` : ''}</small></div>
     <a class="trajectory-link" href="${e(href)}">${zh ? '查看任务轨迹' : 'View trajectory'} →</a>
   </article>`;
+}
+
+function conversationDetailScript(lang: Lang): string {
+  const newestLabel = lang === 'zh' ? '最新优先' : 'Newest first';
+  const oldestLabel = lang === 'zh' ? '最早优先' : 'Oldest first';
+  const switchToNewest = lang === 'zh' ? '切换为最新优先' : 'Switch to newest first';
+  const switchToOldest = lang === 'zh' ? '切换为最早优先' : 'Switch to oldest first';
+  return `
+(() => {
+  const root = document.querySelector('.conversation-detail-page');
+  const taskList = root?.querySelector('.task-list');
+  const toggle = root?.querySelector('[data-task-order-toggle]');
+  const label = toggle?.querySelector('[data-task-order-label]');
+  const rows = [...(taskList?.querySelectorAll('.task-row') || [])];
+  const preferenceKey = 'omk.conversationTaskOrder';
+  let activityTimer;
+  let activityRequest;
+  let activityStopped = false;
+
+  const applyOrder = (order) => {
+    if (!taskList || !toggle) return;
+    const sorted = [...rows].sort((left, right) => {
+      const leftOrdinal = Number(left.dataset.taskOrdinal || 0);
+      const rightOrdinal = Number(right.dataset.taskOrdinal || 0);
+      return order === 'asc' ? leftOrdinal - rightOrdinal : rightOrdinal - leftOrdinal;
+    });
+    for (const row of sorted) taskList.append(row);
+    toggle.dataset.taskOrder = order;
+    if (label) label.textContent = order === 'asc' ? '${oldestLabel}' : '${newestLabel}';
+    const actionLabel = order === 'asc' ? '${switchToNewest}' : '${switchToOldest}';
+    toggle.setAttribute('aria-label', actionLabel);
+    toggle.setAttribute('title', actionLabel);
+  };
+
+  let initialOrder = 'desc';
+  try {
+    const storedOrder = sessionStorage.getItem(preferenceKey);
+    if (storedOrder === 'asc' || storedOrder === 'desc') initialOrder = storedOrder;
+  } catch { /* Storage can be unavailable in hardened browser contexts. */ }
+  applyOrder(initialOrder);
+  toggle?.addEventListener('click', () => {
+    const order = toggle.dataset.taskOrder === 'asc' ? 'desc' : 'asc';
+    applyOrder(order);
+    try { sessionStorage.setItem(preferenceKey, order); } catch { /* Ignore unavailable storage. */ }
+  });
+
+  const stopActivityPolling = () => {
+    activityStopped = true;
+    if (activityTimer) clearTimeout(activityTimer);
+    activityRequest?.abort();
+  };
+  const scheduleActivityPoll = (delay = 5000) => {
+    if (activityStopped) return;
+    if (activityTimer) clearTimeout(activityTimer);
+    activityTimer = setTimeout(pollActivity, delay);
+  };
+  const pollActivity = async () => {
+    if (activityStopped) return;
+    if (document.hidden) {
+      scheduleActivityPoll();
+      return;
+    }
+    const endpoint = root?.dataset.activityEndpoint;
+    if (!endpoint) return;
+    activityRequest?.abort();
+    activityRequest = new AbortController();
+    try {
+      const response = await fetch(endpoint, {
+        cache: 'no-store',
+        signal: activityRequest.signal,
+      });
+      if (!response.ok) throw new Error('conversation activity unavailable');
+      const snapshot = await response.json();
+      if (snapshot.revision && snapshot.revision !== root?.dataset.activityRevision) {
+        window.location.reload();
+        return;
+      }
+    } catch (cause) {
+      if (cause?.name === 'AbortError') return;
+    }
+    scheduleActivityPoll();
+  };
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) scheduleActivityPoll(0);
+  });
+  window.addEventListener('pagehide', stopActivityPolling, { once: true });
+  scheduleActivityPoll();
+})();`;
 }
 
 function taskTrajectoryHref(task: ConversationTaskItem, lang: Lang): string | undefined {
@@ -428,7 +539,7 @@ const CSS = `
 .conversation-activity{display:flex;flex-direction:column;min-width:0}.conversation-activity strong{font-size:12px;font-weight:650;white-space:nowrap}.conversation-activity span{color:var(--text-muted);font:500 11px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.running-label{display:flex;align-items:center;gap:6px;color:var(--accent)}.running-label i,.live-task-link i{width:6px;height:6px;border-radius:50%;background:var(--accent);box-shadow:0 0 0 3px rgba(79,70,229,.1)}
 .conversation-main{min-width:0}.conversation-title{display:block;font-size:14px;font-weight:650;line-height:1.35;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin:0}.conversation-main:has(.conversation-context) .conversation-title{margin-bottom:4px}.conversation-title code,.task-title code{padding:1px 3px;border-radius:3px;background:var(--bg-elevated);font:600 .92em ui-monospace,SFMono-Regular,Menlo,monospace}.inline-markdown-link{color:var(--accent);text-decoration:underline;text-decoration-color:rgba(79,70,229,.28);text-underline-offset:3px}.inline-markdown-link:hover{text-decoration-color:currentColor}.conversation-meta,.conversation-context,.detail-meta{display:flex;align-items:center;gap:8px;color:var(--text-muted);font-size:11px;min-width:0}.conversation-meta span+span:before,.conversation-context span+span:before,.detail-meta span+span:before{content:'·';margin-right:8px}.source-mark{color:var(--accent);font-weight:700}.conversation-workspace{min-width:0;color:var(--text-secondary);font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .conversation-counts{display:flex;flex-direction:column;justify-content:center;align-items:flex-end;gap:2px;color:var(--text-secondary);font-size:11px;white-space:nowrap}.conversation-counts span{display:flex;gap:4px;align-items:baseline}.conversation-counts b{font-size:14px;color:var(--text-primary);font-variant-numeric:tabular-nums}.live-task-link{z-index:3!important;display:flex;align-items:center;gap:6px;color:var(--accent);font-weight:650;text-decoration:none;pointer-events:auto!important}.live-task-link:hover{text-decoration:underline}.failure-count{color:var(--red)!important}.index-pending{color:var(--text-muted)}.row-arrow{display:flex;align-items:center;justify-content:center;color:var(--text-faint);transition:color .14s,transform .14s}.conversation-row:hover .row-arrow{color:var(--accent);transform:translateX(2px)}.empty-state{display:flex;flex-direction:column;gap:4px;padding:36px;border:1px solid var(--border);border-radius:8px;background:var(--bg-surface);color:var(--text-secondary)}.empty-state strong{color:var(--text-primary)}
-.conversation-detail-head{align-items:flex-start}.conversation-detail-head h1{max-width:920px;font-size:24px}.detail-meta{margin-top:10px}.task-list-head,.task-row{display:grid;grid-template-columns:minmax(0,1fr) 140px 160px 150px;gap:18px;align-items:center}.task-list-head{padding:10px 22px 10px 72px;color:var(--text-muted);font-size:12px;background:var(--bg-elevated);border-bottom:1px solid var(--border)}.task-row{position:relative;padding:17px 22px 17px 72px;border-bottom:1px solid var(--border)}.task-row.is-running{background:rgba(79,70,229,.035);box-shadow:inset 3px 0 0 var(--accent)}.task-row:last-child{border-bottom:0}.task-index{position:absolute;left:22px;top:19px;font:700 12px ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--text-muted)}.task-row.is-running .task-index{color:var(--accent)}.task-main{min-width:0}.task-title{display:block;font-weight:650;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:6px}.task-context{color:var(--text-muted);font-size:12px}.task-time,.task-execution{display:flex;flex-direction:column;gap:3px}.task-time small,.task-execution small{color:var(--text-muted)}.task-status{font-weight:650}.status-aborted,.status-interrupted{color:var(--red)}.status-open{color:var(--accent)}.status-unknown{color:var(--yellow)}.status-completed{color:var(--green)}.trajectory-link{text-align:right;font-size:13px;white-space:nowrap}.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+.conversation-detail-head{align-items:flex-start}.conversation-detail-head h1{max-width:920px;font-size:24px}.detail-meta{margin-top:10px}.task-list-head,.task-row{display:grid;grid-template-columns:minmax(0,1fr) 140px 160px 150px;gap:18px;align-items:center}.task-list-head{padding:8px 22px 8px 72px;color:var(--text-muted);font-size:12px;background:var(--bg-elevated);border-bottom:1px solid var(--border)}.task-order-toggle{justify-self:end;display:inline-flex;align-items:center;gap:6px;height:28px;padding:0 8px;border:1px solid transparent;border-radius:5px;background:transparent;color:var(--text-secondary);font:inherit;font-size:12px;font-weight:600;cursor:pointer;white-space:nowrap}.task-order-toggle:hover{border-color:var(--border);background:var(--bg-surface);color:var(--text-primary)}.task-order-toggle:focus-visible{outline:2px solid rgba(79,70,229,.42);outline-offset:1px}.task-row{position:relative;padding:17px 22px 17px 72px;border-bottom:1px solid var(--border)}.task-row.is-running{background:rgba(79,70,229,.035);box-shadow:inset 3px 0 0 var(--accent)}.task-row:last-child{border-bottom:0}.task-index{position:absolute;left:22px;top:19px;font:700 12px ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--text-muted)}.task-row.is-running .task-index{color:var(--accent)}.task-main{min-width:0}.task-title{display:block;font-weight:650;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-bottom:6px}.task-context{color:var(--text-muted);font-size:12px}.task-time,.task-execution{display:flex;flex-direction:column;gap:3px}.task-time small,.task-execution small{color:var(--text-muted)}.task-status{font-weight:650}.status-aborted,.status-interrupted{color:var(--red)}.status-open{color:var(--accent)}.status-unknown{color:var(--yellow)}.status-completed{color:var(--green)}.trajectory-link{text-align:right;font-size:13px;white-space:nowrap}.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 
 html:has(.conversation-index-app),body:has(.conversation-index-app){height:100%;overflow:hidden;scrollbar-gutter:auto}
 body:has(.conversation-index-app) .app-bar{display:none}

--- a/src/renderer/icons.ts
+++ b/src/renderer/icons.ts
@@ -17,6 +17,7 @@ const PATHS: Record<string, string> = {
   chip: '<rect x="4" y="4" width="16" height="16" rx="3"/><path d="M8 12h8"/>',
   'chevron-right': '<path d="M9 6l6 6-6 6"/>',
   'chevron-left': '<path d="M15 18l-6-6 6-6"/>',
+  'arrow-up-down': '<path d="M7 20V4M3 8l4-4 4 4M17 4v16M13 16l4 4 4-4"/>',
   'zoom-in': '<circle cx="11" cy="11" r="8"/><path d="M21 21l-4.4-4.4M11 8v6M8 11h6"/>',
   'zoom-out': '<circle cx="11" cy="11" r="8"/><path d="M21 21l-4.4-4.4M8 11h6"/>',
   'maximize-2': '<path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7"/>',

--- a/src/renderer/knowledge-debugger-renderer.ts
+++ b/src/renderer/knowledge-debugger-renderer.ts
@@ -1480,6 +1480,8 @@ function projectReplay(
         ? 'failure'
         : conversation ? 'message' : 'result';
     const opaqueModelActivity = modelActivity && event?.contentVisibility === 'opaque';
+    const messageAttachments = event?.attachments ?? [];
+    const messageAttachmentLabel = attachmentSummary(messageAttachments, lang);
     const text = eventPreview(event, opaqueModelActivity
       ? (zh ? '不可见' : 'Unavailable')
       : (zh ? '没有可展示的事件内容。' : 'No event content available.'));
@@ -1496,7 +1498,7 @@ function projectReplay(
         : STEP_LABELS[step.stepKind][lang],
       model: eventModel,
       title: text,
-      detail: '',
+      detail: messageAttachmentLabel,
       facetIds: operationFacetIds,
       rawId: event ? `${event.kind} · ${event.id}` : step.id, primary: true,
       compact: opaqueModelActivity,
@@ -1538,6 +1540,11 @@ function projectReplay(
           { label: zh ? '角色' : 'Role', value: roleLabel(event, lang), detail: event?.kind ?? step.stepKind },
           { label: zh ? '时间' : 'Time', value: formatRelativeTimestamp(step.timestamp, startTimestamp), detail: formatDisplayTimestamp(step.timestamp, lang) },
           ...(eventModel ? [{ label: zh ? '模型' : 'Model', value: eventModel, detail: zh ? '由 trace 明确记录的事件模型' : 'Event model explicitly recorded by the trace' }] : []),
+          ...(messageAttachments.length > 0 ? [{
+            label: zh ? '附件' : 'Attachments',
+            value: messageAttachmentLabel,
+            detail: messageAttachments.map((attachment) => attachment.name).join('\n'),
+          }] : []),
           {
             label: zh ? '内容' : 'Content',
             value: text,
@@ -1639,6 +1646,18 @@ function replayEventModel(
   return step.stepKind === 'assistant_message' || step.stepKind === 'model_activity'
     ? event?.model?.trim() || undefined
     : undefined;
+}
+
+function attachmentSummary(
+  attachments: NonNullable<ExperienceTimelineEvent['attachments']>,
+  lang: Lang,
+): string {
+  const imageCount = attachments.filter((attachment) => attachment.attachmentKind === 'image').length;
+  const fileCount = attachments.length - imageCount;
+  const parts = lang === 'zh'
+    ? [imageCount > 0 ? `图片 ${imageCount} 张` : '', fileCount > 0 ? `文件 ${fileCount} 个` : '']
+    : [imageCount > 0 ? `${imageCount} image${imageCount === 1 ? '' : 's'}` : '', fileCount > 0 ? `${fileCount} file${fileCount === 1 ? '' : 's'}` : ''];
+  return parts.filter(Boolean).join(' · ');
 }
 
 function replayCardWidth(step: TaskReplayStep, lang: Lang, pendingToolResults: boolean): number {

--- a/src/server/report-server.ts
+++ b/src/server/report-server.ts
@@ -13,6 +13,7 @@ import { renderObservationInboxPage } from '../renderer/observation-inbox-render
 import { renderKnowledgeDebuggerPage } from '../renderer/knowledge-debugger-renderer.js';
 import {
   buildConversationActivitySnapshot,
+  buildConversationDetailActivitySnapshot,
   renderConversationDetailPage,
   renderConversationIndexPage,
 } from '../renderer/conversation-renderer.js';
@@ -1053,6 +1054,24 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
         return;
       }
 
+      const conversationActivityMatch = path.match(/^\/api\/conversations\/([^/]+)\/activity$/);
+      if (conversationActivityMatch) {
+        let threadId = '';
+        try { threadId = decodeURIComponent(conversationActivityMatch[1]); } catch { /* invalid path */ }
+        const conversation = threadId ? await resolvedConversationCatalog.getConversation(threadId) : undefined;
+        if (!conversation) {
+          res.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
+          res.end(JSON.stringify({ error: 'conversation_not_found' }));
+          return;
+        }
+        res.writeHead(200, {
+          'Content-Type': 'application/json; charset=utf-8',
+          'Cache-Control': 'no-store',
+        });
+        res.end(JSON.stringify(buildConversationDetailActivitySnapshot(conversation)));
+        return;
+      }
+
       if (path === '/conversations') {
         const html = renderConversationIndexPage(await resolvedConversationCatalog.listConversations(), lang);
         res.writeHead(200, {
@@ -1230,7 +1249,10 @@ export function createReportServer({ port, host: hostOption, reportsDir, analyse
           res.end(lang === 'en' ? 'conversation not found' : '对话不存在');
           return;
         }
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.writeHead(200, {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Cache-Control': 'no-store',
+        });
         res.end(renderConversationDetailPage(conversation, lang));
         return;
       }

--- a/src/types/observability.ts
+++ b/src/types/observability.ts
@@ -542,6 +542,10 @@ export interface ExperienceTimelineEvent extends ExperienceEvidenceRef {
   toolStatus?: ToolCallStatus;
   isError?: boolean;
   fullText?: string;
+  attachments?: Array<{
+    attachmentKind: 'image' | 'file';
+    name: string;
+  }>;
 }
 
 // ---------- Knowledge Debugger task trajectory ----------

--- a/test/observability/conversation-catalog.test.ts
+++ b/test/observability/conversation-catalog.test.ts
@@ -125,6 +125,33 @@ describe('Codex conversation catalog', () => {
     assert.equal(index.tasks[0]?.title, '用户真正发送的任务');
   });
 
+  it('uses the request body instead of the attachment envelope as the task title', () => {
+    const root = temporaryRoot();
+    const rolloutPath = join(root, 'rollout-user-attachment.jsonl');
+    const message = [
+      '# Files mentioned by the user:',
+      '',
+      '## codex-clipboard-example.png:',
+      '/private/tmp/codex-clipboard-example.png',
+      '',
+      '## My request:',
+      '这种展示要优化不',
+    ].join('\n');
+    const records = [
+      { timestamp: '2026-08-10T00:00:00.000Z', type: 'event_msg', payload: { type: 'task_started', turn_id: 'turn-a' } },
+      { timestamp: '2026-08-10T00:00:00.100Z', type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: message }] } },
+      { timestamp: '2026-08-10T00:00:00.200Z', type: 'event_msg', payload: { type: 'user_message', message } },
+      { timestamp: '2026-08-10T00:00:00.300Z', type: 'event_msg', payload: { type: 'task_complete', turn_id: 'turn-a' } },
+    ];
+    writeFileSync(rolloutPath, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`);
+
+    const index = buildCodexRolloutIndex(rolloutPath, 'main-thread');
+
+    assert.equal(index.schemaVersion, 12);
+    assert.equal(index.tasks[0]?.title, '这种展示要优化不');
+    assert.doesNotMatch(index.tasks[0]?.title ?? '', /Files mentioned|private\/tmp/);
+  });
+
   it('does not invent a task for runtime context before a native turn', () => {
     const rolloutPath = new URL('../fixtures/codex-knowledge-debugger-failure.jsonl', import.meta.url).pathname;
 

--- a/test/observability/trace-adapter.test.ts
+++ b/test/observability/trace-adapter.test.ts
@@ -342,7 +342,7 @@ describe('loadCcSessions', () => {
       '',
       '## screenshot.png: /private/tmp/screenshot.png',
       '',
-      '## My request for Codex:',
+      '## My request:',
       '为什么插件不可用？',
       '',
       '<image name=[Image #1] path="/private/tmp/screenshot.png">',
@@ -366,6 +366,53 @@ describe('loadCcSessions', () => {
     assert.equal(
       message?.eventKind === 'message' ? message.displayText : undefined,
       '为什么插件不可用？',
+    );
+    assert.deepEqual(
+      message?.eventKind === 'message' ? message.attachments : undefined,
+      [{ attachmentKind: 'image', name: 'screenshot.png' }],
+    );
+  });
+
+  it('deduplicates mirrored Codex attachment messages by their semantic request', () => {
+    const envelope = [
+      '# Files mentioned by the user:',
+      '',
+      '## timeline.png: /private/tmp/timeline.png',
+      '',
+      '## My request:',
+      '优化任务轨迹中的附件展示',
+    ].join('\n');
+    const path = writeSession(tmpDir, 'codex-attachment-mirror.jsonl', [
+      {
+        timestamp: '2026-07-25T00:00:01.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: envelope },
+            { type: 'input_text', text: '<image name="[Image #1]" path="/private/tmp/timeline.png">' },
+            { type: 'input_image', image_url: 'data:image/png;base64,redacted' },
+            { type: 'input_text', text: '</image>' },
+          ],
+        },
+      },
+      {
+        timestamp: '2026-07-25T00:00:01.100Z',
+        type: 'event_msg',
+        payload: { type: 'user_message', message: envelope },
+      },
+    ]);
+
+    const [session] = loadCcSessions(path);
+    const messages = session.events.filter((event) => event.eventKind === 'message');
+    assert.equal(messages.length, 1);
+    const [message] = messages;
+    assert.equal(message?.eventKind, 'message');
+    assert.equal(message?.eventKind === 'message' ? message.displayText : undefined, '优化任务轨迹中的附件展示');
+    assert.deepEqual(
+      message?.eventKind === 'message' ? message.attachments : undefined,
+      [{ attachmentKind: 'image', name: 'timeline.png' }],
     );
   });
 

--- a/test/renderer/conversation-renderer.test.ts
+++ b/test/renderer/conversation-renderer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import {
+  buildConversationDetailActivitySnapshot,
   renderConversationDetailPage,
   renderConversationIndexPage,
 } from '../../src/renderer/conversation-renderer.js';
@@ -98,7 +99,7 @@ describe('conversation overview renderer', () => {
 });
 
 describe('conversation detail renderer', () => {
-  it('surfaces open tasks first while preserving their chronological ordinals', () => {
+  it('renders tasks newest first while preserving their chronological ordinals', () => {
     const model = conversation('thread', '对话', 'completed');
     const firstTask = { ...model.tasks[0], turnId: 'first', title: '最早任务' };
     const runningTask = {
@@ -113,10 +114,34 @@ describe('conversation detail renderer', () => {
 
     const html = renderConversationDetailPage(model, 'zh');
 
+    assert.ok(html.indexOf('最近历史任务') < html.indexOf('当前任务'));
     assert.ok(html.indexOf('当前任务') < html.indexOf('最早任务'));
-    assert.ok(html.indexOf('最早任务') < html.indexOf('最近历史任务'));
     assert.ok(html.includes('class="task-row is-running" data-task-status="open"'));
     assert.ok(html.includes('<div class="task-index">02</div>'));
+    assert.ok(html.includes('data-task-order="desc"'));
+    assert.ok(html.includes('最新优先'));
+    assert.ok(html.includes('data-task-ordinal="3"'));
+    assert.ok(html.includes('sessionStorage.setItem(preferenceKey, order)'));
+    assert.ok(html.includes('data-activity-endpoint="/api/conversations/thread/activity"'));
+    assert.ok(html.includes('window.location.reload()'));
+  });
+
+  it('changes the activity revision only when task boundaries or states change', () => {
+    const model = conversation('thread', '对话', 'open');
+    const initial = buildConversationDetailActivitySnapshot(model);
+    const withMoreEvents = buildConversationDetailActivitySnapshot({
+      ...model,
+      tasks: model.tasks.map((task) => ({ ...task, eventCount: task.eventCount + 1, toolCallCount: 2 })),
+    });
+    const completed = buildConversationDetailActivitySnapshot({
+      ...model,
+      tasks: model.tasks.map((task) => ({ ...task, status: 'completed' as const })),
+    });
+
+    assert.equal(withMoreEvents.revision, initial.revision);
+    assert.notEqual(completed.revision, initial.revision);
+    assert.equal(initial.runningCount, 1);
+    assert.equal(completed.runningCount, 0);
   });
 
   it('describes unknown terminal evidence without implying the task is still running', () => {

--- a/test/server/conversation-activity-server.test.ts
+++ b/test/server/conversation-activity-server.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, it } from 'vitest';
+import type { ConversationCatalog } from '../../src/observability/conversation-catalog.js';
+import { createReportServer } from '../../src/server/report-server.js';
+import type { ConversationListItem } from '../../src/types/index.js';
+
+describe('Conversation activity server', () => {
+  const root = mkdtempSync(join(tmpdir(), 'omk-conversation-activity-'));
+  const threadId = 'thread/activity';
+  let server: ReturnType<typeof createReportServer> | undefined;
+  let baseUrl = '';
+  let conversation: ConversationListItem = {
+    threadId,
+    sourceThreadId: threadId,
+    sourceKind: 'codex',
+    title: '进行中的对话',
+    archived: false,
+    turnCount: 1,
+    toolCallCount: 0,
+    toolFailureCount: 0,
+    relatedSkillNames: [],
+    tasks: [{
+      turnId: 'turn-1',
+      title: '当前任务',
+      status: 'open',
+      startTimestamp: '2026-08-10T00:00:00.000Z',
+      eventCount: 2,
+      toolCallCount: 0,
+      toolFailureCount: 0,
+      relatedSkillNames: [],
+    }],
+  };
+
+  beforeAll(async () => {
+    for (const directory of ['reports', 'jobs', 'observations']) {
+      mkdirSync(join(root, directory), { recursive: true });
+    }
+    const catalog: ConversationCatalog = {
+      async listConversations() {
+        return {
+          conversations: [conversation],
+          totalTurnCount: conversation.turnCount ?? 0,
+          totalToolCallCount: conversation.toolCallCount ?? 0,
+          totalToolFailureCount: conversation.toolFailureCount ?? 0,
+        };
+      },
+      async getConversation(id) {
+        return id === threadId ? conversation : undefined;
+      },
+      async loadTaskTrajectory() {
+        return undefined;
+      },
+    };
+    server = createReportServer({
+      port: 0,
+      reportsDir: join(root, 'reports'),
+      jobsDir: join(root, 'jobs'),
+      observationsDir: join(root, 'observations'),
+      conversationCatalog: catalog,
+    });
+    baseUrl = await server.start();
+  });
+
+  afterAll(async () => {
+    await server?.stop();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('reports task lifecycle changes for one conversation without tracking event growth', async () => {
+    const endpoint = `${baseUrl}/api/conversations/${encodeURIComponent(threadId)}/activity`;
+    const initialResponse = await fetch(endpoint);
+    const initial = await initialResponse.json() as Record<string, unknown>;
+
+    assert.equal(initialResponse.status, 200);
+    assert.equal(initialResponse.headers.get('cache-control'), 'no-store');
+    assert.equal(initial.taskCount, 1);
+    assert.equal(initial.runningCount, 1);
+    assert.match(String(initial.revision), /^[a-f0-9]{24}$/u);
+
+    conversation = {
+      ...conversation,
+      tasks: conversation.tasks.map((task) => ({ ...task, eventCount: 20, toolCallCount: 4 })),
+    };
+    const eventGrowth = await (await fetch(endpoint)).json() as Record<string, unknown>;
+    assert.equal(eventGrowth.revision, initial.revision);
+
+    conversation = {
+      ...conversation,
+      tasks: conversation.tasks.map((task) => ({
+        ...task,
+        status: 'completed' as const,
+        endTimestamp: '2026-08-10T00:01:00.000Z',
+      })),
+    };
+    const completed = await (await fetch(endpoint)).json() as Record<string, unknown>;
+    assert.notEqual(completed.revision, initial.revision);
+    assert.equal(completed.runningCount, 0);
+  });
+
+  it('prevents the conversation detail page from being restored from stale cache', async () => {
+    const response = await fetch(`${baseUrl}/conversations/${encodeURIComponent(threadId)}`);
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('cache-control'), 'no-store');
+    assert.match(await response.text(), /data-activity-endpoint="\/api\/conversations\/thread%2Factivity\/activity"/u);
+  });
+
+  it('returns 404 for an unknown conversation', async () => {
+    const response = await fetch(`${baseUrl}/api/conversations/missing/activity`);
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: 'conversation_not_found' });
+  });
+});

--- a/test/server/knowledge-debugger-server.test.ts
+++ b/test/server/knowledge-debugger-server.test.ts
@@ -457,6 +457,34 @@ describe('Knowledge Debugger task trajectory server', () => {
     assert.match(html, /<div class="trajectory-field-content"><strong>Complete answer<\/strong>[\s\S]*DETAIL_END_MARKER<\/div>/);
   });
 
+  it('renders user attachments as safe metadata instead of transport envelopes', () => {
+    const userStep = debuggerModel.steps.find((step) =>
+      step.stepKind === 'user_request' || step.stepKind === 'user_message');
+    assert.ok(userStep);
+    const html = renderKnowledgeDebuggerPage({
+      ...debuggerModel,
+      steps: debuggerModel.steps.map((step) => step.id === userStep.id
+        ? {
+            ...step,
+            events: step.events.map((event, index) => index === 0
+              ? {
+                  ...event,
+                  fullText: '优化任务轨迹中的附件展示',
+                  snippet: '优化任务轨迹中的附件展示',
+                  attachments: [{ attachmentKind: 'image' as const, name: 'timeline.png' }],
+                }
+              : event),
+          }
+        : step),
+    });
+
+    assert.match(html, /优化任务轨迹中的附件展示/);
+    assert.match(html, /图片 1 张/);
+    assert.match(html, /<span class="trajectory-field-label">附件<\/span>/);
+    assert.match(html, /timeline\.png/);
+    assert.doesNotMatch(html, /\/private\/tmp\/timeline\.png/);
+  });
+
   it('shows observable context content in the inspector and distinguishes missing source content', () => {
     const contextStep = debuggerModel.steps.find((step) => step.stepKind === 'runtime_context');
     assert.ok(contextStep);


### PR DESCRIPTION
## 用户影响

- 对话详情默认按最新任务优先展示，并提供「最新优先 / 最早优先」切换；同一浏览器会话会保留用户选择。
- 页面会定期检测任务新增、完成、中断等生命周期变化，并自动刷新任务状态。
- 状态接口与对话详情页均禁用缓存，避免刷新后仍展示旧状态。

## 设计说明

状态检测只跟踪任务边界与生命周期，不因进行中任务的日志持续增长而整页刷新，避免把实时轨迹更新放大为对话页抖动。轮询请求在页面隐藏时暂停，并在页面退出时取消，防止留下无效请求。

无需迁移，不改变落盘 schema 或测量语义。

关联 #381