### PR TITLE
chore(release): 切换 npm 可信发布

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,28 +10,30 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # 创建 GitHub Release(npm publish 完成后自动建, release notes 由 GitHub 从 PR 列表自动生成)
-      id-token: write # 使工作流能够通过 OIDC 从 GitHub 获取凭证（npm provenance 必需）
+      id-token: write # npm Trusted Publishing 通过 OIDC 换取短期发布凭证，并自动生成 provenance
 
     steps:
     - name: Checkout Code
       uses: actions/checkout@v7
 
-    # Enable Corepack before setup-node so its `cache: yarn` step resolves the
-    # cache folder via the packageManager-pinned Yarn 4.
-    - name: Enable Corepack
-      run: corepack enable
-
     - name: Setup Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '22.x'
+        node-version: '24.x'
         registry-url: 'https://registry.npmjs.org'
-        cache: yarn
+        package-manager-cache: false
+
+    - name: Setup package managers
+      run: |
+        corepack enable
+        npm install --global 'npm@^11.5.1'
+        node -e "const [major, minor, patch] = process.argv[1].split('.').map(Number); if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) process.exit(1)" "$(npm --version)"
 
     - name: Install dependencies
       run: yarn install --immutable
 
     - name: Validate release tag
+      id: release
       shell: bash
       run: |
         set -euo pipefail
@@ -59,6 +61,12 @@ jobs:
           exit 1
         fi
 
+        if [[ "${package_version}" == *-* ]]; then
+          echo "npm_tag=next" >> "${GITHUB_OUTPUT}"
+        else
+          echo "npm_tag=latest" >> "${GITHUB_OUTPUT}"
+        fi
+
         git fetch --no-tags origin main
         tag_commit="$(git rev-list -n 1 "${tag_ref}")"
         if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
@@ -76,9 +84,7 @@ jobs:
       run: yarn run test
 
     - name: Publish to NPM
-      run: npm publish --access public --provenance
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm publish --access public --tag "${{ steps.release.outputs.npm_tag }}"
 
     # softprops/action-gh-release 是行业通用 GitHub Release action (~17k stars)。
     # generate_release_notes 让 GitHub 直接从 tag 之间的 PR 列表自动生成

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,19 @@ git push -u origin feat/my-feature
 
 ### Releasing a new version
 
+npm 发布使用 GitHub Actions OIDC Trusted Publishing，不保存长期 npm token。首次启用时，在
+`oh-my-knowledge` 的 npm package settings 配置：
+
+- provider：GitHub Actions
+- repository：`lizhiyao/oh-my-knowledge`
+- workflow：`publish.yml`（只填文件名）
+- environment：留空
+- allowed action：仅 `npm publish`
+
+`.github/workflows/publish.yml` 固定使用 GitHub-hosted runner、Node 24 和 npm ≥ 11.5.1。
+`id-token: write` 让 npm 用 OIDC 换取短期发布凭证，provenance 由 npm 自动生成；不要重新加入
+`NPM_TOKEN`、`NODE_AUTH_TOKEN` 或显式 `--provenance`。
+
 ```bash
 # cut a release version-bump branch from main
 git checkout main
@@ -83,6 +96,12 @@ git tag -a v0.28.0 -m "Release v0.28.0"
 # event that fires the tag workflow.
 git push origin v0.28.0
 ```
+
+迁移 Trusted Publishing 时，先发布一个 prerelease（例如 `0.52.3-oidc.0`）验证 OIDC 和
+provenance；workflow 会自动把 prerelease 发布到 `next` dist-tag，不影响 `latest`。验证成功后，
+先执行 `npm access set mfa=publish oh-my-knowledge`，再在 npm package settings 的 Publishing
+access 选择「Require two-factor authentication and disallow tokens」，最后删除 GitHub 仓库中的
+`NPM_TOKEN` secret。不要在验证前删除 token，以便失败时仍可回滚 workflow。
 
 ### Hotfix against a released version
 

--- a/test/scripts/publish-workflow-security.test.ts
+++ b/test/scripts/publish-workflow-security.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+import { describe, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const WORKFLOW_PATH = join(PROJECT_ROOT, '.github', 'workflows', 'publish.yml');
+
+interface WorkflowStep {
+  name?: string;
+  uses?: string;
+  run?: string;
+  env?: Record<string, unknown>;
+  with?: Record<string, unknown>;
+}
+
+interface PublishWorkflow {
+  jobs?: {
+    publish?: {
+      'runs-on'?: string;
+      permissions?: Record<string, unknown>;
+      steps?: WorkflowStep[];
+    };
+  };
+}
+
+function loadWorkflow(): { source: string; workflow: PublishWorkflow } {
+  const source = readFileSync(WORKFLOW_PATH, 'utf8');
+  return { source, workflow: yaml.load(source) as PublishWorkflow };
+}
+
+describe('npm 发布供应链', () => {
+  it('通过 GitHub OIDC Trusted Publishing 发布，不依赖长期 npm token', () => {
+    const { source, workflow } = loadWorkflow();
+    const job = workflow.jobs?.publish;
+    const steps = job?.steps ?? [];
+    const setupNode = steps.find((step) => step.uses?.startsWith('actions/setup-node@'));
+    const setupPackageManagers = steps.find((step) => step.name === 'Setup package managers');
+    const publish = steps.find((step) => step.name === 'Publish to NPM');
+
+    assert.equal(job?.['runs-on'], 'ubuntu-latest', 'Trusted Publishing 只支持 GitHub-hosted runner');
+    assert.equal(job?.permissions?.['id-token'], 'write', '发布 job 必须允许签发 OIDC ID token');
+    assert.equal(setupNode?.with?.['node-version'], '24.x');
+    assert.equal(setupNode?.with?.['package-manager-cache'], false, '发布构建不应复用包管理器缓存');
+    assert.match(setupPackageManagers?.run ?? '', /npm@\^11\.5\.1/, 'Trusted Publishing 要求 npm >= 11.5.1');
+    assert.match(publish?.run ?? '', /^npm publish\b/);
+    assert.doesNotMatch(publish?.run ?? '', /--provenance\b/, 'OIDC 发布会自动生成 provenance');
+    assert.equal(publish?.env, undefined, 'npm publish 不应注入 token 环境变量');
+    assert.doesNotMatch(source, /NPM_TOKEN|NODE_AUTH_TOKEN/, '发布 workflow 不应引用长期 npm token');
+  });
+
+  it('prerelease 使用 next dist-tag，正式版本使用 latest', () => {
+    const { workflow } = loadWorkflow();
+    const steps = workflow.jobs?.publish?.steps ?? [];
+    const validate = steps.find((step) => step.name === 'Validate release tag');
+    const publish = steps.find((step) => step.name === 'Publish to NPM');
+
+    assert.match(validate?.run ?? '', /npm_tag=next/);
+    assert.match(validate?.run ?? '', /npm_tag=latest/);
+    assert.match(publish?.run ?? '', /steps\.release\.outputs\.npm_tag/);
+  });
+});


### PR DESCRIPTION
## 背景

当前 npm 发布依赖长期 `NPM_TOKEN`。本次改为 npm Trusted Publishing，通过 GitHub Actions OIDC 获取短期发布凭证，并由 npm 自动生成 provenance。

## 用户影响

- 正式版本继续发布到 `latest`。
- prerelease 自动发布到 `next`，不会覆盖正式版本。
- 发布流程不再读取 GitHub `NPM_TOKEN`。

## 迁移说明

npm Trusted Publisher 已配置为 `lizhiyao/oh-my-knowledge`、`publish.yml`，且仅允许 `npm publish`。合并后先发布 prerelease 验证 OIDC 与 provenance；成功后启用发布 MFA、禁止 token，并删除 GitHub `NPM_TOKEN` secret。

官方文档：https://docs.npmjs.com/trusted-publishers/