### PR TITLE
chore(release): 准备 0.52.3-oidc.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.52.2",
+  "version": "0.52.3-oidc.0",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 背景

发布一个 prerelease，验证 OMK 已配置的 npm Trusted Publisher 能否通过 GitHub Actions OIDC 完成无 token 发布。

## 用户影响

仅将包版本提升为 0.52.3-oidc.0，不包含功能或可比性变化。该版本发布到 npm 的 next dist-tag，不影响当前 latest。

## 发布说明

合并后创建 v0.52.3-oidc.0 tag 触发发布；验证 provenance 后，再收紧 npm 发布权限并删除 GitHub 的 NPM_TOKEN。