### PR TITLE
fix(release): 标记预发布版本

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,8 +63,10 @@ jobs:
 
         if [[ "${package_version}" == *-* ]]; then
           echo "npm_tag=next" >> "${GITHUB_OUTPUT}"
+          echo "github_prerelease=true" >> "${GITHUB_OUTPUT}"
         else
           echo "npm_tag=latest" >> "${GITHUB_OUTPUT}"
+          echo "github_prerelease=false" >> "${GITHUB_OUTPUT}"
         fi
 
         git fetch --no-tags origin main
@@ -94,3 +96,4 @@ jobs:
       uses: softprops/action-gh-release@v3
       with:
         generate_release_notes: true
+        prerelease: ${{ steps.release.outputs.github_prerelease }}

--- a/test/scripts/publish-workflow-security.test.ts
+++ b/test/scripts/publish-workflow-security.test.ts
@@ -52,14 +52,21 @@ describe('npm 发布供应链', () => {
     assert.doesNotMatch(source, /NPM_TOKEN|NODE_AUTH_TOKEN/, '发布 workflow 不应引用长期 npm token');
   });
 
-  it('prerelease 使用 next dist-tag，正式版本使用 latest', () => {
+  it('prerelease 使用 next dist-tag 并创建 GitHub prerelease，正式版本使用 latest', () => {
     const { workflow } = loadWorkflow();
     const steps = workflow.jobs?.publish?.steps ?? [];
     const validate = steps.find((step) => step.name === 'Validate release tag');
     const publish = steps.find((step) => step.name === 'Publish to NPM');
+    const githubRelease = steps.find((step) => step.name === 'Create GitHub Release');
 
     assert.match(validate?.run ?? '', /npm_tag=next/);
     assert.match(validate?.run ?? '', /npm_tag=latest/);
+    assert.match(validate?.run ?? '', /github_prerelease=true/);
+    assert.match(validate?.run ?? '', /github_prerelease=false/);
     assert.match(publish?.run ?? '', /steps\.release\.outputs\.npm_tag/);
+    assert.equal(
+      githubRelease?.with?.prerelease,
+      '${{ steps.release.outputs.github_prerelease }}',
+    );
   });
 });


### PR DESCRIPTION
## 背景

0.52.3-oidc.0 已正确发布到 npm next 并生成 provenance，但 GitHub Release 未同步标记为 prerelease。

## 用户影响

后续含预发布标识的版本会同时使用 npm next dist-tag 和 GitHub prerelease；正式版本仍使用 latest 并创建普通 Release。

Closes no issue.