### PR TITLE
chore(release): 发布 0.52.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.52.3-oidc.0",
+  "version": "0.52.3",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 背景

0.52.3-oidc.0 已通过 npm Trusted Publishing 完成无 token 发布，并验证 SLSA provenance、next dist-tag 与 GitHub prerelease。

## 用户影响

将已验证版本提升为正式版 0.52.3。合并后创建 v0.52.3 annotated tag，发布到 npm latest；不包含功能或可比性变化。

## 迁移说明

无需迁移。