### PR TITLE
perf(executors)!: BREAKING-INSTALL SDK 执行器改为按需安装

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The full docs are published at **[oh-my-knowledge.pages.dev](https://oh-my-knowl
   - Codex: install and authenticate the Codex CLI (`npm i -g @openai/codex`); Codex tasks in the ChatGPT desktop app select it automatically
   - Claude: install and authenticate [Claude Code](https://claude.ai/code)
   - API / other executors: configure them as described in [Executors](docs/reference/executors.md)
+- Advanced `claude-sdk` / `codex-sdk` executors are optional and are not downloaded by the base OMK install. Install the matching SDK in the same local project or global npm prefix only when you select one; see [Executor prerequisites](docs/reference/executors.md#prerequisites).
 
 ## Security notice
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -222,6 +222,7 @@ dsh --profile web
   - Codex：安装并登录 Codex CLI（`npm i -g @openai/codex`）；ChatGPT desktop 的 Codex 任务会自动选择它
   - Claude：安装并登录 [Claude Code](https://claude.ai/code)
   - API / 其它执行器：按[执行器文档](docs/zh/reference/executors.md)配置
+- 高级 `claude-sdk`／`codex-sdk` 执行器是可选能力，OMK 基础安装不再下载它们。仅在明确选择对应 SDK 时，才在 OMK 所在的本地项目或全局 npm prefix 安装；详见[执行器前置要求](docs/zh/reference/executors.md#前置要求)。
 
 ## 安全说明
 

--- a/docs/reference/executors.md
+++ b/docs/reference/executors.md
@@ -117,7 +117,7 @@ The base OMK install omits the optional Agent SDK packages and their large platf
 - **claude**: install [Claude Code](https://claude.ai/code) and authenticate
 - **claude-sdk**: install the optional Agent SDK locally with `npm i @anthropic-ai/claude-agent-sdk@^0.3.143`, or globally beside a global OMK install with `npm i -g @anthropic-ai/claude-agent-sdk@^0.3.143`; then authenticate Claude
 - **codex**: install the Codex CLI (`npm i -g @openai/codex`) and authenticate
-- **codex-sdk**: install the compatible optional SDK locally with `npm i @openai/codex-sdk@0.149.0`, or globally beside a global OMK install with `npm i -g @openai/codex-sdk@0.149.0` (it bundles the `@openai/codex` binary)
+- **codex-sdk**: install the compatible optional SDK locally with `npm i @openai/codex-sdk@^0.149.0`, or globally beside a global OMK install with `npm i -g @openai/codex-sdk@^0.149.0` (it bundles the `@openai/codex` binary)
 - **DSH plugin**: install `oh-my-knowledge` into an existing command-capable DSH profile and use `/omk eval <eval.yaml>`
 - **anthropic-api**: set the `ANTHROPIC_API_KEY` env var
 - **openai-api**: set the `OPENAI_API_KEY` env var

--- a/docs/reference/executors.md
+++ b/docs/reference/executors.md
@@ -112,10 +112,12 @@ omk eval --executor "./my-executor.sh"
 
 ## Prerequisites
 
+The base OMK install omits the optional Agent SDK packages and their large platform binaries. The default `claude` / `codex` CLI executors, API executors, custom executors, and the DSH host plugin do not need them. Install an SDK in the same scope as OMK only when you explicitly select its `*-sdk` executor.
+
 - **claude**: install [Claude Code](https://claude.ai/code) and authenticate
-- **claude-sdk**: install [Claude Code](https://claude.ai/code) and authenticate (uses Agent SDK, no CLI stdout parsing)
+- **claude-sdk**: install the optional Agent SDK locally with `npm i @anthropic-ai/claude-agent-sdk@^0.3.143`, or globally beside a global OMK install with `npm i -g @anthropic-ai/claude-agent-sdk@^0.3.143`; then authenticate Claude
 - **codex**: install the Codex CLI (`npm i -g @openai/codex`) and authenticate
-- **codex-sdk**: `npm i @openai/codex-sdk` (bundles the `@openai/codex` binary)
+- **codex-sdk**: install the compatible optional SDK locally with `npm i @openai/codex-sdk@0.149.0`, or globally beside a global OMK install with `npm i -g @openai/codex-sdk@0.149.0` (it bundles the `@openai/codex` binary)
 - **DSH plugin**: install `oh-my-knowledge` into an existing command-capable DSH profile and use `/omk eval <eval.yaml>`
 - **anthropic-api**: set the `ANTHROPIC_API_KEY` env var
 - **openai-api**: set the `OPENAI_API_KEY` env var

--- a/docs/zh/reference/executors.md
+++ b/docs/zh/reference/executors.md
@@ -117,7 +117,7 @@ OMK 基础安装不再携带可选 Agent SDK 及其大型平台二进制。默�
 - **claude**：安装 [Claude Code](https://claude.ai/code) 并认证
 - **claude-sdk**：本地安装可选 Agent SDK：`npm i @anthropic-ai/claude-agent-sdk@^0.3.143`；如果 OMK 是全局安装，则在同一全局 npm prefix 执行 `npm i -g @anthropic-ai/claude-agent-sdk@^0.3.143`，随后完成 Claude 认证
 - **codex**：安装 Codex CLI（`npm i -g @openai/codex`）并认证
-- **codex-sdk**：本地安装兼容的可选 SDK：`npm i @openai/codex-sdk@0.149.0`；如果 OMK 是全局安装，则执行 `npm i -g @openai/codex-sdk@0.149.0`（自带 `@openai/codex` binary）
+- **codex-sdk**：本地安装兼容的可选 SDK：`npm i @openai/codex-sdk@^0.149.0`；如果 OMK 是全局安装，则执行 `npm i -g @openai/codex-sdk@^0.149.0`（自带 `@openai/codex` binary）
 - **DSH 插件**：在已有 command-capable DSH profile 中安装 `oh-my-knowledge`，使用 `/omk eval <eval.yaml>`
 - **anthropic-api**：设置 `ANTHROPIC_API_KEY` 环境变量
 - **openai-api**：设置 `OPENAI_API_KEY` 环境变量

--- a/docs/zh/reference/executors.md
+++ b/docs/zh/reference/executors.md
@@ -112,10 +112,12 @@ omk eval --executor "./my-executor.sh"
 
 ## 前置要求
 
+OMK 基础安装不再携带可选 Agent SDK 及其大型平台二进制。默认的 `claude`／`codex` CLI 执行器、API 执行器、自定义执行器和 DSH 宿主插件都不需要它们。只有明确选择 `*-sdk` 执行器时，才在 OMK 所在的同一作用域安装对应 SDK。
+
 - **claude**：安装 [Claude Code](https://claude.ai/code) 并认证
-- **claude-sdk**：安装 [Claude Code](https://claude.ai/code) 并认证（使用 Agent SDK，无需 CLI stdout 解析）
+- **claude-sdk**：本地安装可选 Agent SDK：`npm i @anthropic-ai/claude-agent-sdk@^0.3.143`；如果 OMK 是全局安装，则在同一全局 npm prefix 执行 `npm i -g @anthropic-ai/claude-agent-sdk@^0.3.143`，随后完成 Claude 认证
 - **codex**：安装 Codex CLI（`npm i -g @openai/codex`）并认证
-- **codex-sdk**：`npm i @openai/codex-sdk`（自带 `@openai/codex` binary）
+- **codex-sdk**：本地安装兼容的可选 SDK：`npm i @openai/codex-sdk@0.149.0`；如果 OMK 是全局安装，则执行 `npm i -g @openai/codex-sdk@0.149.0`（自带 `@openai/codex` binary）
 - **DSH 插件**：在已有 command-capable DSH profile 中安装 `oh-my-knowledge`，使用 `/omk eval <eval.yaml>`
 - **anthropic-api**：设置 `ANTHROPIC_API_KEY` 环境变量
 - **openai-api**：设置 `OPENAI_API_KEY` 环境变量

--- a/package.json
+++ b/package.json
@@ -104,18 +104,28 @@
   "author": "lizhiyao",
   "license": "MIT",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.143",
     "@anthropic-ai/sdk": "^0.120.0",
     "@inquirer/prompts": "^8.4.3",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@oclif/core": "^4",
-    "@openai/codex-sdk": "0.149.0",
     "ajv": "^8.18.0",
     "chart.js": "^4.5.1",
     "es-module-lexer": "^2.0.0",
     "js-yaml": "^4.1.1",
     "simple-statistics": "^7.8.9",
     "zod": "^4.4.3"
+  },
+  "peerDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.143",
+    "@openai/codex-sdk": "0.149.0"
+  },
+  "peerDependenciesMeta": {
+    "@anthropic-ai/claude-agent-sdk": {
+      "optional": true
+    },
+    "@openai/codex-sdk": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "peerDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.143",
-    "@openai/codex-sdk": "0.149.0"
+    "@openai/codex-sdk": "^0.149.0"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/claude-agent-sdk": {

--- a/src/executors/anthropic/claude/sdk.ts
+++ b/src/executors/anthropic/claude/sdk.ts
@@ -18,6 +18,7 @@ import { buildClaudeResult } from './protocol.js';
 export { normalizeClaudeMeasurements } from './protocol.js';
 
 let sdkQuery: ClaudeSdkModule['query'] | null = null;
+const CLAUDE_AGENT_SDK_PACKAGE = '@anthropic-ai/claude-agent-sdk';
 
 /**
  * Map ExecutorInput.allowedSkills to SDK query options for skill isolation.
@@ -45,7 +46,7 @@ export function buildSdkIsolationOptions(allowedSkills: string[] | undefined): {
 
 async function getSdkQuery(): Promise<ClaudeSdkModule['query']> {
   if (!sdkQuery) {
-    const sdk = await import('@anthropic-ai/claude-agent-sdk') as ClaudeSdkModule;
+    const sdk = await import(CLAUDE_AGENT_SDK_PACKAGE) as ClaudeSdkModule;
     sdkQuery = sdk.query;
   }
   return sdkQuery;

--- a/src/executors/core/optional-dependencies.ts
+++ b/src/executors/core/optional-dependencies.ts
@@ -1,0 +1,49 @@
+import type { ExecutableExecutorName } from './registry.js';
+
+export interface OptionalExecutorDependency {
+  readonly packageName: string;
+  readonly installSpec: string;
+}
+
+const OPTIONAL_EXECUTOR_DEPENDENCIES: Partial<Record<ExecutableExecutorName, OptionalExecutorDependency>> = {
+  'claude-sdk': {
+    packageName: '@anthropic-ai/claude-agent-sdk',
+    installSpec: '@anthropic-ai/claude-agent-sdk@^0.3.143',
+  },
+  'codex-sdk': {
+    packageName: '@openai/codex-sdk',
+    installSpec: '@openai/codex-sdk@0.149.0',
+  },
+};
+
+export function getOptionalExecutorDependency(
+  executorName: ExecutableExecutorName,
+): OptionalExecutorDependency | undefined {
+  return OPTIONAL_EXECUTOR_DEPENDENCIES[executorName];
+}
+
+function packageAvailable(packageName: string): boolean {
+  try {
+    // Use ESM resolution because @openai/codex-sdk only exposes an `import`
+    // condition; createRequire().resolve() reports ERR_PACKAGE_PATH_NOT_EXPORTED
+    // even when that optional peer is correctly installed.
+    import.meta.resolve(packageName);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function assertOptionalExecutorDependency(
+  executorName: ExecutableExecutorName,
+  available: (packageName: string) => boolean = packageAvailable,
+): void {
+  const dependency = getOptionalExecutorDependency(executorName);
+  if (!dependency || available(dependency.packageName)) return;
+
+  throw new Error([
+    `执行器「${executorName}」需要可选依赖「${dependency.packageName}」，但当前 OMK 安装作用域中未找到。`,
+    `本地安装：npm install ${dependency.installSpec}`,
+    `全局安装：npm install -g ${dependency.installSpec}`,
+  ].join('\n'));
+}

--- a/src/executors/core/optional-dependencies.ts
+++ b/src/executors/core/optional-dependencies.ts
@@ -12,7 +12,7 @@ const OPTIONAL_EXECUTOR_DEPENDENCIES: Partial<Record<ExecutableExecutorName, Opt
   },
   'codex-sdk': {
     packageName: '@openai/codex-sdk',
-    installSpec: '@openai/codex-sdk@0.149.0',
+    installSpec: '@openai/codex-sdk@^0.149.0',
   },
 };
 

--- a/src/executors/index.ts
+++ b/src/executors/index.ts
@@ -12,6 +12,7 @@ import {
   getExecutorDescriptor,
   type ExecutableExecutorName,
 } from './core/registry.js';
+import { assertOptionalExecutorDependency } from './core/optional-dependencies.js';
 
 // 命名一致性:provider HTTP 路径统一用 `<vendor>-api`(`anthropic-api` / `openai-api`),
 // vendor coding agent CLI 用 vendor 名(`claude` / `codex`)。`openai` 这个不带 -api 后缀的
@@ -46,6 +47,7 @@ export function createExecutor(name: string): ExecutorFn {
   if (descriptor?.execution === 'host-only') {
     throw new Error('dsh-host 仅供 DeepSeek Harness 宿主插件内部使用；请在 DSH 中运行 /omk eval。');
   }
+  if (descriptor) assertOptionalExecutorDependency(descriptor.name);
   const executor = descriptor
     ? EXECUTOR_FACTORIES[descriptor.name]
     : createScriptExecutor(name);

--- a/src/executors/openai/codex/sdk.ts
+++ b/src/executors/openai/codex/sdk.ts
@@ -2,7 +2,6 @@ import { existsSync } from 'node:fs';
 import { copyFile, mkdtemp, rm } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { Codex, CodexOptions, ThreadEvent } from '@openai/codex-sdk';
 import type { ExecResult, ExecutorInput } from '../../../types/index.js';
 import {
   buildCodexResult,
@@ -20,7 +19,30 @@ import {
 import { registerSigintSubscriber } from '../../core/subprocess.js';
 import { isolateCodexCwd } from './cli.js';
 
-type CodexSdkModule = typeof import('@openai/codex-sdk');
+interface CodexSdkThread {
+  runStreamed(input: string, options?: { signal?: AbortSignal }): Promise<{
+    events: AsyncIterable<unknown>;
+  }>;
+}
+
+export interface CodexSdkClient {
+  startThread(options: ReturnType<typeof buildCodexSdkThreadOptions>): CodexSdkThread;
+}
+
+export interface CodexSdkClientOptions {
+  env: Record<string, string>;
+  codexPathOverride?: string;
+}
+
+interface CodexSdkConstructor {
+  new(options?: CodexSdkClientOptions): CodexSdkClient;
+}
+
+interface CodexSdkModule {
+  Codex: CodexSdkConstructor;
+}
+
+const CODEX_SDK_PACKAGE = '@openai/codex-sdk';
 
 let CodexCtor: CodexSdkModule['Codex'] | null = null;
 let hasWarnedSystem = false;
@@ -28,7 +50,7 @@ let hasWarnedCost = false;
 
 async function getCodexCtor(): Promise<CodexSdkModule['Codex']> {
   if (!CodexCtor) {
-    const sdk = await import('@openai/codex-sdk') as CodexSdkModule;
+    const sdk = await import(CODEX_SDK_PACKAGE) as CodexSdkModule;
     CodexCtor = sdk.Codex;
   }
   return CodexCtor;
@@ -87,7 +109,7 @@ export function buildCodexSdkThreadOptions({ model, cwd }: { model: string; cwd?
   };
 }
 
-export function buildCodexSdkClientOptions(env: NodeJS.ProcessEnv): CodexOptions {
+export function buildCodexSdkClientOptions(env: NodeJS.ProcessEnv): CodexSdkClientOptions {
   return {
     // Leave codexPathOverride unset: the SDK should use its bundled @openai/codex
     // binary, matching the SDK executor contract instead of delegating to PATH.
@@ -95,12 +117,12 @@ export function buildCodexSdkClientOptions(env: NodeJS.ProcessEnv): CodexOptions
   };
 }
 
-export async function createCodexSdkClient(env: NodeJS.ProcessEnv): Promise<Codex> {
+export async function createCodexSdkClient(env: NodeJS.ProcessEnv): Promise<CodexSdkClient> {
   const CodexClient = await getCodexCtor();
   return new CodexClient(buildCodexSdkClientOptions(env));
 }
 
-function normalizeSdkEvent(event: ThreadEvent): CodexEvent {
+function normalizeSdkEvent(event: unknown): CodexEvent {
   return normalizeCodexProtocolEvent(event) ?? {};
 }
 

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -18,13 +18,6 @@ describe('createExecutor', () => {
     assert.equal(typeof exec, 'function');
   });
 
-  it('fails fast with an install command when an optional SDK is absent', () => {
-    assert.throws(
-      () => createExecutor('codex-sdk'),
-      /npm install @openai\/codex-sdk@0\.149\.0/,
-    );
-  });
-
   it('rejects the removed gemini built-in instead of treating it as a custom command', () => {
     assert.throws(() => createExecutor('gemini'), /内置 gemini 执行器已移除/);
   });

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -18,9 +18,11 @@ describe('createExecutor', () => {
     assert.equal(typeof exec, 'function');
   });
 
-  it('returns a function for codex-sdk', () => {
-    const exec = createExecutor('codex-sdk');
-    assert.equal(typeof exec, 'function');
+  it('fails fast with an install command when an optional SDK is absent', () => {
+    assert.throws(
+      () => createExecutor('codex-sdk'),
+      /npm install @openai\/codex-sdk@0\.149\.0/,
+    );
   });
 
   it('rejects the removed gemini built-in instead of treating it as a custom command', () => {

--- a/test/executors/create-executor-optional-dependencies.test.ts
+++ b/test/executors/create-executor-optional-dependencies.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, it, vi } from 'vitest';
+import assert from 'node:assert/strict';
+
+const dependencyGuard = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/executors/core/optional-dependencies.js', () => ({
+  assertOptionalExecutorDependency: dependencyGuard,
+}));
+
+import { createExecutor } from '../../src/executors/index.js';
+
+describe('createExecutor optional dependency wiring', () => {
+  beforeEach(() => {
+    dependencyGuard.mockReset();
+  });
+
+  it('creates both SDK executors when their optional dependencies are available', () => {
+    assert.equal(typeof createExecutor('claude-sdk'), 'function');
+    assert.equal(typeof createExecutor('codex-sdk'), 'function');
+    assert.deepEqual(dependencyGuard.mock.calls, [
+      ['claude-sdk'],
+      ['codex-sdk'],
+    ]);
+  });
+
+  it('propagates the missing dependency error before returning an executor', () => {
+    const missingDependency = new Error('optional SDK missing');
+    dependencyGuard.mockImplementation((executorName: string) => {
+      if (executorName === 'codex-sdk') {
+        throw missingDependency;
+      }
+    });
+
+    assert.throws(
+      () => createExecutor('codex-sdk'),
+      (error: unknown) => error === missingDependency,
+    );
+  });
+});

--- a/test/executors/optional-dependencies.test.ts
+++ b/test/executors/optional-dependencies.test.ts
@@ -37,10 +37,10 @@ describe('optional executor dependencies', () => {
     );
   });
 
-  it('pins the Codex SDK install command to the compatible version', () => {
+  it('uses the compatible Codex SDK patch range in the install command', () => {
     assert.throws(
       () => assertOptionalExecutorDependency('codex-sdk', () => false),
-      /npm install @openai\/codex-sdk@0\.149\.0/,
+      /npm install @openai\/codex-sdk@\^0\.149\.0/,
     );
   });
 

--- a/test/executors/optional-dependencies.test.ts
+++ b/test/executors/optional-dependencies.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  assertOptionalExecutorDependency,
+  getOptionalExecutorDependency,
+} from '../../src/executors/core/optional-dependencies.js';
+
+describe('optional executor dependencies', () => {
+  it('does not inspect dependencies for core CLI and API executors', () => {
+    let inspected = false;
+    assert.doesNotThrow(() => assertOptionalExecutorDependency('codex', () => {
+      inspected = true;
+      return false;
+    }));
+    assert.equal(inspected, false);
+  });
+
+  it('accepts an SDK installed in the same package scope', () => {
+    assert.doesNotThrow(() => assertOptionalExecutorDependency('claude-sdk', (packageName) => {
+      assert.equal(packageName, '@anthropic-ai/claude-agent-sdk');
+      return true;
+    }));
+  });
+
+  it('gives local and global install commands for a missing Claude SDK', () => {
+    assert.throws(
+      () => assertOptionalExecutorDependency('claude-sdk', () => false),
+      (error: unknown) => {
+        const message = (error as Error).message;
+        assert.match(message, /当前 OMK 安装作用域中未找到/);
+        assert.match(message, /npm install @anthropic-ai\/claude-agent-sdk@\^0\.3\.143/);
+        assert.match(message, /npm install -g @anthropic-ai\/claude-agent-sdk@\^0\.3\.143/);
+        return true;
+      },
+    );
+  });
+
+  it('pins the Codex SDK install command to the compatible version', () => {
+    assert.throws(
+      () => assertOptionalExecutorDependency('codex-sdk', () => false),
+      /npm install @openai\/codex-sdk@0\.149\.0/,
+    );
+  });
+
+  it('keeps SDKs out of production and development dependency closures', () => {
+    const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+      peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+    };
+    for (const executorName of ['claude-sdk', 'codex-sdk'] as const) {
+      const dependency = getOptionalExecutorDependency(executorName)!;
+      const peerRange = packageJson.peerDependencies?.[dependency.packageName];
+      assert.equal(dependency.installSpec, `${dependency.packageName}@${peerRange}`);
+      assert.equal(packageJson.peerDependenciesMeta?.[dependency.packageName]?.optional, true);
+      assert.equal(packageJson.dependencies?.[dependency.packageName], undefined);
+      assert.equal(packageJson.devDependencies?.[dependency.packageName], undefined);
+    }
+  });
+});

--- a/test/executors/registry.test.ts
+++ b/test/executors/registry.test.ts
@@ -26,7 +26,7 @@ describe('executor registry', () => {
     assert.equal(new Set(descriptors.map(({ name }) => name)).size, descriptors.length);
   });
 
-  it('binds every executable descriptor to a factory and reserves host-only entries', () => {
+  it('binds core descriptors, guards optional SDKs, and reserves host-only entries', () => {
     for (const descriptor of executorDescriptors()) {
       assert.equal(getExecutorDescriptor(descriptor.name), descriptor);
       assert.equal(isRegisteredExecutorName(descriptor.name), true);
@@ -35,7 +35,11 @@ describe('executor registry', () => {
         descriptor.sampleMocks,
       );
       if (descriptor.execution === 'builtin') {
-        assert.equal(typeof createExecutor(descriptor.name), 'function');
+        if (descriptor.name.endsWith('-sdk')) {
+          assert.throws(() => createExecutor(descriptor.name), /需要可选依赖/);
+        } else {
+          assert.equal(typeof createExecutor(descriptor.name), 'function');
+        }
       } else {
         assert.throws(() => createExecutor(descriptor.name), /宿主插件内部使用/);
       }

--- a/test/executors/registry.test.ts
+++ b/test/executors/registry.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { getExecutorCapabilities } from '../../src/executors/core/capabilities.js';
+import { getOptionalExecutorDependency } from '../../src/executors/core/optional-dependencies.js';
 import { createExecutor } from '../../src/executors/index.js';
 import {
   executorDescriptors,
@@ -24,9 +25,15 @@ describe('executor registry', () => {
       'openai-api',
     ]);
     assert.equal(new Set(descriptors.map(({ name }) => name)).size, descriptors.length);
+    assert.deepEqual(
+      descriptors
+        .filter(({ name }) => getOptionalExecutorDependency(name))
+        .map(({ name }) => name),
+      ['claude-sdk', 'codex-sdk'],
+    );
   });
 
-  it('binds core descriptors, guards optional SDKs, and reserves host-only entries', () => {
+  it('binds core descriptors and reserves host-only entries', () => {
     for (const descriptor of executorDescriptors()) {
       assert.equal(getExecutorDescriptor(descriptor.name), descriptor);
       assert.equal(isRegisteredExecutorName(descriptor.name), true);
@@ -35,9 +42,7 @@ describe('executor registry', () => {
         descriptor.sampleMocks,
       );
       if (descriptor.execution === 'builtin') {
-        if (descriptor.name.endsWith('-sdk')) {
-          assert.throws(() => createExecutor(descriptor.name), /需要可选依赖/);
-        } else {
+        if (!getOptionalExecutorDependency(descriptor.name)) {
           assert.equal(typeof createExecutor(descriptor.name), 'function');
         }
       } else {

--- a/test/executors/registry.test.ts
+++ b/test/executors/registry.test.ts
@@ -27,7 +27,10 @@ describe('executor registry', () => {
     assert.equal(new Set(descriptors.map(({ name }) => name)).size, descriptors.length);
     assert.deepEqual(
       descriptors
-        .filter(({ name }) => getOptionalExecutorDependency(name))
+        .filter((descriptor) => (
+          descriptor.execution === 'builtin'
+          && getOptionalExecutorDependency(descriptor.name)
+        ))
         .map(({ name }) => name),
       ['claude-sdk', 'codex-sdk'],
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,99 +202,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anthropic-ai/claude-agent-sdk-darwin-arm64@npm:0.3.238":
-  version: 0.3.238
-  resolution: "@anthropic-ai/claude-agent-sdk-darwin-arm64@npm:0.3.238"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@anthropic-ai/claude-agent-sdk-darwin-x64@npm:0.3.238":
-  version: 0.3.238
-  resolution: "@anthropic-ai/claude-agent-sdk-darwin-x64@npm:0.3.238"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@anthropic-ai/claude-agent-sdk-linux-arm64-musl@npm:0.3.238":
-  version: 0.3.238
-  resolution: "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@npm:0.3.238"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@anthropic-ai/claude-agent-sdk-linux-arm64@npm:0.3.238":
-  version: 0.3.238
-  resolution: "@anthropic-ai/claude-agent-sdk-linux-arm64@npm:0.3.238"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@anthropic-ai/claude-agent-sdk-linux-x64-musl@npm:0.3.238":
-  version: 0.3.238
-  resolution: "@anthropic-ai/claude-agent-sdk-linux-x64-musl@npm:0.3.238"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@anthropic-ai/claude-agent-sdk-linux-x64@npm:0.3.238":
-  version: 0.3.238
-  resolution: "@anthropic-ai/claude-agent-sdk-linux-x64@npm:0.3.238"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@anthropic-ai/claude-agent-sdk-win32-arm64@npm:0.3.238":
-  version: 0.3.238
-  resolution: "@anthropic-ai/claude-agent-sdk-win32-arm64@npm:0.3.238"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@anthropic-ai/claude-agent-sdk-win32-x64@npm:0.3.238":
-  version: 0.3.238
-  resolution: "@anthropic-ai/claude-agent-sdk-win32-x64@npm:0.3.238"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@anthropic-ai/claude-agent-sdk@npm:^0.3.143":
-  version: 0.3.238
-  resolution: "@anthropic-ai/claude-agent-sdk@npm:0.3.238"
-  dependencies:
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": "npm:0.3.238"
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": "npm:0.3.238"
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": "npm:0.3.238"
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "npm:0.3.238"
-    "@anthropic-ai/claude-agent-sdk-linux-x64": "npm:0.3.238"
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "npm:0.3.238"
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": "npm:0.3.238"
-    "@anthropic-ai/claude-agent-sdk-win32-x64": "npm:0.3.238"
-  peerDependencies:
-    "@anthropic-ai/sdk": ">=0.93.0"
-    "@modelcontextprotocol/sdk": ^1.29.0
-    zod: ^4.0.0
-  dependenciesMeta:
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64":
-      optional: true
-    "@anthropic-ai/claude-agent-sdk-darwin-x64":
-      optional: true
-    "@anthropic-ai/claude-agent-sdk-linux-arm64":
-      optional: true
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl":
-      optional: true
-    "@anthropic-ai/claude-agent-sdk-linux-x64":
-      optional: true
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl":
-      optional: true
-    "@anthropic-ai/claude-agent-sdk-win32-arm64":
-      optional: true
-    "@anthropic-ai/claude-agent-sdk-win32-x64":
-      optional: true
-  checksum: 10c0/79e8f82e4329ea33e26dbe957ae8eb7347e4121a6dfb2a882678667175fd5178a938d8c8af10cc7cb2d590876c845e7a9617b4083e9b046d7d4559c2f02f78fa
-  languageName: node
-  linkType: hard
-
 "@anthropic-ai/sdk@npm:^0.120.0":
   version: 0.120.0
   resolution: "@anthropic-ai/sdk@npm:0.120.0"
@@ -1048,86 +955,6 @@ __metadata:
     wrap-ansi: "npm:^7.0.0"
     wsl-utils: "npm:^0.4.0"
   checksum: 10c0/369407d870740926aa3f26f7dc63eb9c7d55f1fa18da86d57317edd8efaa0e1c97b65ff25bb9468160975e086a775aef72c19f5fbdf10a90366c0fd3d3650a29
-  languageName: node
-  linkType: hard
-
-"@openai/codex-darwin-arm64@npm:@openai/codex@0.149.0-darwin-arm64":
-  version: 0.149.0-darwin-arm64
-  resolution: "@openai/codex@npm:0.149.0-darwin-arm64"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@openai/codex-darwin-x64@npm:@openai/codex@0.149.0-darwin-x64":
-  version: 0.149.0-darwin-x64
-  resolution: "@openai/codex@npm:0.149.0-darwin-x64"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@openai/codex-linux-arm64@npm:@openai/codex@0.149.0-linux-arm64":
-  version: 0.149.0-linux-arm64
-  resolution: "@openai/codex@npm:0.149.0-linux-arm64"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@openai/codex-linux-x64@npm:@openai/codex@0.149.0-linux-x64":
-  version: 0.149.0-linux-x64
-  resolution: "@openai/codex@npm:0.149.0-linux-x64"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@openai/codex-sdk@npm:0.149.0":
-  version: 0.149.0
-  resolution: "@openai/codex-sdk@npm:0.149.0"
-  dependencies:
-    "@openai/codex": "npm:0.149.0"
-  checksum: 10c0/a793ad905de4361dfa96c903707fb27ba0f8b83f93c88926bc0b08e713264c863930fe6a16575e165d4feb570a69d2d0dda8dc6e1bfa07c5a2ed360336f0a686
-  languageName: node
-  linkType: hard
-
-"@openai/codex-win32-arm64@npm:@openai/codex@0.149.0-win32-arm64":
-  version: 0.149.0-win32-arm64
-  resolution: "@openai/codex@npm:0.149.0-win32-arm64"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@openai/codex-win32-x64@npm:@openai/codex@0.149.0-win32-x64":
-  version: 0.149.0-win32-x64
-  resolution: "@openai/codex@npm:0.149.0-win32-x64"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@openai/codex@npm:0.149.0":
-  version: 0.149.0
-  resolution: "@openai/codex@npm:0.149.0"
-  dependencies:
-    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.149.0-darwin-arm64"
-    "@openai/codex-darwin-x64": "npm:@openai/codex@0.149.0-darwin-x64"
-    "@openai/codex-linux-arm64": "npm:@openai/codex@0.149.0-linux-arm64"
-    "@openai/codex-linux-x64": "npm:@openai/codex@0.149.0-linux-x64"
-    "@openai/codex-win32-arm64": "npm:@openai/codex@0.149.0-win32-arm64"
-    "@openai/codex-win32-x64": "npm:@openai/codex@0.149.0-win32-x64"
-  dependenciesMeta:
-    "@openai/codex-darwin-arm64":
-      optional: true
-    "@openai/codex-darwin-x64":
-      optional: true
-    "@openai/codex-linux-arm64":
-      optional: true
-    "@openai/codex-linux-x64":
-      optional: true
-    "@openai/codex-win32-arm64":
-      optional: true
-    "@openai/codex-win32-x64":
-      optional: true
-  bin:
-    codex: bin/codex.js
-  checksum: 10c0/bcbe5d15b959815aaa9963fffcec5960c511a3c552b4767ff438dc6fa2e0773de2666069d7d81b9813cbdb070c8e9c791f749d099f4be9f1d376314746f17438
   languageName: node
   linkType: hard
 
@@ -3917,12 +3744,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "oh-my-knowledge@workspace:."
   dependencies:
-    "@anthropic-ai/claude-agent-sdk": "npm:^0.3.143"
     "@anthropic-ai/sdk": "npm:^0.120.0"
     "@inquirer/prompts": "npm:^8.4.3"
     "@modelcontextprotocol/sdk": "npm:^1.30.0"
     "@oclif/core": "npm:^4"
-    "@openai/codex-sdk": "npm:0.149.0"
     "@types/js-yaml": "npm:^4.0.9"
     "@types/node": "npm:^25.5.0"
     ajv: "npm:^8.18.0"
@@ -3939,6 +3764,14 @@ __metadata:
     vitepress: "npm:^1.6.4"
     vitest: "npm:4.1.11"
     zod: "npm:^4.4.3"
+  peerDependencies:
+    "@anthropic-ai/claude-agent-sdk": ^0.3.143
+    "@openai/codex-sdk": 0.149.0
+  peerDependenciesMeta:
+    "@anthropic-ai/claude-agent-sdk":
+      optional: true
+    "@openai/codex-sdk":
+      optional: true
   bin:
     omk: dist/cli/index.js
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -3766,7 +3766,7 @@ __metadata:
     zod: "npm:^4.4.3"
   peerDependencies:
     "@anthropic-ai/claude-agent-sdk": ^0.3.143
-    "@openai/codex-sdk": 0.149.0
+    "@openai/codex-sdk": ^0.149.0
   peerDependenciesMeta:
     "@anthropic-ai/claude-agent-sdk":
       optional: true


### PR DESCRIPTION
## 用户影响

OMK 基础安装不再无条件下载 Claude Agent SDK、Codex SDK 及其平台原生二进制。默认 CLI／API／自定义执行器和 DSH 宿主插件保持不变；只有明确选择 `claude-sdk` 或 `codex-sdk` 时才需要安装对应可选 SDK。

同机隔离冷缓存消费测试中，Yarn fetch 写入量由 615.7 MiB 降至 40.41 MiB，减少约 93.4%；`node_modules` 由约 634 MiB 降至约 59 MiB。当前网络下冷安装由 18 分 35 秒降至 17.25 秒。热缓存安装均低于 1 秒，本改动不声称改善热缓存性能。

缺少 SDK 时，OMK 会在创建执行器阶段给出同作用域的本地／全局安装命令，不再让每条评测任务分别失败。

## 迁移说明

这是 `BREAKING-INSTALL`：此前依赖 OMK 默认携带 SDK 的 `claude-sdk`／`codex-sdk` 用户，升级后需要在安装 OMK 的同一作用域显式安装对应 SDK：

- `npm install @anthropic-ai/claude-agent-sdk@^0.3.143`
- `npm install @openai/codex-sdk@^0.149.0`

全局安装 OMK 时，对应使用 `npm install -g ...`。默认 `claude`／`codex` CLI 执行器不需要迁移。

不修改评测统计、冻结 prompt 或 Report schema，不构成 `BREAKING-COMPARABILITY`。

关联 issue：#405。
