### PR TITLE
chore(release): 发布 0.53.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.52.3",
+  "version": "0.53.0",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 发布内容

- 新增 DeepSeek Harness 宿主插件：在现有 command-capable DSH profile 中安装 `oh-my-knowledge` 后，可直接运行 `/omk eval <eval.yaml>`，复用宿主的模型、凭证、工具和 sandbox。
- OMK 基础安装不再下载 Claude Agent SDK、Codex SDK 及其平台原生二进制。默认 CLI／API／自定义执行器和 DSH 宿主插件不受影响；冷缓存 fetch 写入量实测由 615.7 MiB 降至 40.41 MiB，减少约 93.4%。
- 移除缺少真实集成验证和测量证据的 Gemini 内置执行器；Gemini agent 的 skill 目录、`GEMINI.md` 和安装目标继续支持。
- 更新 SDK、API client、Oclif、Vitest 等依赖，并缩短全量测试等待时间；这些维护性改动不改变 CLI 或报告语义。

## ⚠️ 迁移说明

### BREAKING-CLI：Gemini 内置执行器已移除

`executor: gemini`、`--executor gemini` 和 `judgeModels` 中的 Gemini 执行器配置不再可用。需要继续通过 Gemini CLI 执行模型时，请使用自定义执行器适配脚本，将 OMK JSON stdin 转为 Gemini CLI 调用，并按 OMK JSON stdout 协议返回结果。

仅使用 Gemini agent 的 skill 目录、`GEMINI.md` 或 `omk install --to gemini` 时无需迁移。

### BREAKING-INSTALL：SDK 执行器改为按需安装

使用 `claude-sdk`／`codex-sdk` 的用户，需要在 OMK 所在的同一本地项目显式安装对应 SDK：

- `npm install @anthropic-ai/claude-agent-sdk@^0.3.143`
- `npm install @openai/codex-sdk@^0.149.0`

全局安装 OMK 时，对应使用 `npm install -g ...`。默认 `claude`／`codex` CLI 执行器无需迁移；缺少 SDK 时，OMK 会直接给出本地和全局安装命令。

## 测量学说明

本版本不修改评分类 prompt、五层评分管道、Bootstrap／Krippendorff 公式或 Report schema，不构成 `BREAKING-COMPARABILITY`。DSH 宿主模式会记录 runtime fingerprint 和部分可审计状态；跨 runtime 报告仍应按现有严格可比性提示解读。

关联 PR：#399、#400、#407。
