### PR TITLE
feat(observe): 支持在 DSH 中查看任务轨迹

### DIFF
--- a/.agents/skills/omk/SKILL.md
+++ b/.agents/skills/omk/SKILL.md
@@ -31,6 +31,8 @@ Codex 是 omk 的一等 runtime。运行在 Codex 任务中时，`omk eval` / `d
 
 如果当前 DSH profile 已安装 `oh-my-knowledge` bundle，使用 `/omk eval <eval.yaml>`。该路径直接复用现有 DSH 的模型、凭证、工具与 sandbox，并为每条用例创建隔离 session；不要要求用户另起 DSH runtime。
 
+查看真实 DSH 任务轨迹时，先运行 `/omk observe` 列出最近已结束的 session，再运行 `/omk observe <session-id>`。OMK 通过当前 profile 的 `sessionPersistence` 只读摄取一致快照，并返回 Studio 任务轨迹链接；不要求用户导出或定位 JSONL／SQLite 文件。首版不实时跟随正在写入的 session，也不默认选择发起 observe 命令的当前 session。
+
 ## 第二步：理解用户意图
 
 根据用户的描述，匹配对应的操作：

--- a/README.md
+++ b/README.md
@@ -186,7 +186,13 @@ dsh plugin --profile web add oh-my-knowledge
 dsh --profile web
 ```
 
-Then run `/omk eval eval.yaml` inside DSH. Each sample gets an isolated DSH session while OMK still owns the report and statistics. See the [executor guide](docs/reference/executors.md#deepseek-harness-prefer-the-host-plugin).
+Inside DSH:
+
+- `/omk eval eval.yaml` runs every sample in an isolated DSH session while OMK owns the report and statistics;
+- `/omk observe` lists recent terminal sessions;
+- `/omk observe <session-id>` reads a consistent snapshot and returns its Studio Task Trajectory URL.
+
+Observe uses the profile's `sessionPersistence` directly, so users do not export or locate JSONL / SQLite files. The first version is offline-only and does not live-follow a session that is still being written. See the [executor guide](docs/reference/executors.md#deepseek-harness-prefer-the-host-plugin) and [observe guide](docs/guides/observe-production.md#inspect-a-task-inside-deepseek-harness).
 
 ## Documentation
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -186,7 +186,13 @@ dsh plugin --profile web add oh-my-knowledge
 dsh --profile web
 ```
 
-进入 DSH 后运行 `/omk eval eval.yaml`。每条用例会使用独立 DSH session，报告仍由 OMK 生成。详见[执行器文档](docs/zh/reference/executors.md#deepseek-harness优先使用宿主插件)。
+进入 DSH 后：
+
+- `/omk eval eval.yaml`：每条用例使用独立 DSH session，报告仍由 OMK 生成；
+- `/omk observe`：列出最近已结束的 session；
+- `/omk observe <session-id>`：只读摄取一致快照，并返回 Studio 任务轨迹链接。
+
+observe 直接使用 profile 的 `sessionPersistence`，无需导出或定位 JSONL／SQLite 文件；首版不实时跟随正在写入的 session。详见[执行器文档](docs/zh/reference/executors.md#deepseek-harness优先使用宿主插件)与[观测指南](docs/zh/guides/observe-production.md#在-deepseek-harness-中查看任务轨迹)。
 
 ## 文档
 

--- a/docs/guides/observe-production.md
+++ b/docs/guides/observe-production.md
@@ -49,6 +49,19 @@ Supported trace formats: Codex rollout JSONL, Claude Code session JSONL, OpenCla
 
 Both workflows persist an ingestion summary. If the source contains malformed records, valid JSON values that are not records, or events the current adapter cannot recognize, the CLI and Studio show a completeness notice. Review that notice before treating absence of a signal as evidence that no problem occurred. Runtime guardian sessions are counted separately as intentional filters.
 
+## Inspect a task inside DeepSeek Harness
+
+When the OMK bundle is installed and the profile provides `sessionPersistence`, no DSH log export is needed:
+
+```text
+/omk observe
+/omk observe <session-id>
+```
+
+The first command lists recent terminal root sessions and excludes the current command session. The second reads the root and descendant logical logs through DSH's read-only `listSnapshots()` / `inspect()` seam, obtains a consistent snapshot, and returns its Studio Task Trajectory URL. JSONL, zstd, and SQLite backends are transparent to the user.
+
+The first version is offline-only and does not follow a session that is still being written. Continuous revision changes, unknown required events, sequence gaps, unclosed turns / steps, or missing tool results prevent OMK from presenting the trace as complete. The page retains observable cwd, provider / model, message origins, tool outcomes, terminal status, and subagent lineage without inferring hidden reasoning.
+
 ## Inspect one task
 
 Start `omk studio` directly; `observe ingest` is not required. Studio reads the local Codex conversation index and organizes Codex rollouts as **Thread → Turn**:

--- a/docs/reference/executors.md
+++ b/docs/reference/executors.md
@@ -74,6 +74,8 @@ Then run this inside DSH:
 
 ```text
 /omk eval eval.yaml
+/omk observe
+/omk observe <session-id>
 ```
 
 The config path is resolved from the current DSH session `cwd`. Omit the top-level `executor` from `eval.yaml`: the measured executor is always the current DSH host. The evaluated model inherits the current session unless `model` is explicit in the config. A judge can use the public `executor: dsh` alias; `dsh-host` is an internal OMK identifier and is rejected in user config. For every sample, the plugin creates a fresh DSH agent/session and reuses the profile's provider, credentials, tools, sandbox, and persistence. OMK installs a complete system-prompt section for the control/treatment, suppresses runtime context and the ambient `skill` tool, maps DSH `session/event` records in host-observed order into token/turn/tool/subagent evidence, and writes reports under the project's `.omk/reports`.
@@ -81,6 +83,8 @@ The config path is resolved from the current DSH session `cwd`. Omit the top-lev
 The plugin composes each measurement agent from the initiating session's active agent preset before applying OMK isolation. When the model is inherited and every judge reuses that same DSH model, the live interactive session itself is the connectivity evidence, so OMK creates no extra probe sessions; an explicit measured-model override, a different DSH judge model, or an external judge still receives connectivity preflight. Omit `effort` from this host-mode config: DSH reasoning effort identifiers are provider-owned and cannot be mapped losslessly to OMK's five generic levels. Fix the desired reasoning behavior in the DSH profile instead. `goldDir` remains supported and attaches human-gold agreement to the persisted report.
 
 This PoC exposes `/omk` through DSH's human-command registry, so the profile needs `ctx.commands` and a command adapter. The built-in `web` profile satisfies that requirement; headless, ACP, and JSON-RPC surfaces do not currently consume the command. `Sample.mocks` remains unsupported. The runtime fingerprint includes the DSH host version, OMK adapter version, provider, agent preset, and effective tool schemas. DSH does not expose a canonical digest for every plugin and policy, so the fingerprint is explicitly marked partially auditable and strict comparability checks emit a warning instead of claiming full runtime parity.
+
+`/omk observe` additionally requires `ctx.sessionPersistence`. It lists recent terminal root sessions while excluding the command's current session. `/omk observe <session-id>` obtains the logical event stream through read-only `listSnapshots()` / `inspect()` calls, compares revisions around the read, converts a stable view into `sourceKind: dsh` Trace IR, and returns a Studio Task Trajectory URL under the actual listening address. DSH backends own JSONL, zstd, and SQLite physical formats; OMK parses none of them. Continuous writes, unknown required events, sequence gaps, unclosed turns / steps, and missing tool results prevent a “complete trajectory” claim. This first version is an offline snapshot and does not live-follow a running session.
 
 For a local checkout, build it and link it directly into the profile:
 

--- a/docs/zh/guides/observe-production.md
+++ b/docs/zh/guides/observe-production.md
@@ -49,6 +49,19 @@ omk observe show <inbox_id>
 
 两条工作流都会持久化摄取摘要。源数据包含格式损坏记录、不是对象的合法 JSON 值，或当前 adapter 无法识别的事件时，CLI 与 Studio 会显示完整性提示。把「没有发现信号」解释成「没有问题」之前，应先复核这项提示。运行时守护会话属于有意过滤，会单独计数。
 
+## 在 DeepSeek Harness 中查看任务轨迹
+
+已安装 OMK bundle 且 profile 启用了 `sessionPersistence` 时，无需导出 DSH 日志：
+
+```text
+/omk observe
+/omk observe <session-id>
+```
+
+第一条命令列出最近已结束的 root session，并排除正在承载命令的当前 session。第二条命令通过 DSH 的 `listSnapshots()`／`inspect()` 只读读取 root 与子 agent 的逻辑事件流，取得一致快照后返回 Studio 任务轨迹链接。JSONL、zstd 或 SQLite backend 对用户透明。
+
+首版只观察离线快照，不实时跟随正在写入的 session。revision 持续变化、required 未知事件、seq 不连续、未闭合 turn／step 或缺失 tool result 时，OMK 会拒绝把它展示为完整轨迹。页面保留 DSH 的 cwd、provider／model、消息来源、工具结果、终态与子 agent lineage，只陈述可核验事实。
+
 ## 查看一次任务
 
 直接启动 `omk studio` 即可，不需要先运行 `observe ingest`。Studio 会读取本机 Codex 会话索引，在首页按「对话(Thread) → 任务(Turn)」组织 Codex rollout：

--- a/docs/zh/reference/executors.md
+++ b/docs/zh/reference/executors.md
@@ -74,6 +74,8 @@ dsh --profile web
 
 ```text
 /omk eval eval.yaml
+/omk observe
+/omk observe <session-id>
 ```
 
 `eval.yaml` 相对当前 DSH session 的 `cwd` 解析。配置中应省略顶层 `executor`，被测执行器始终是当前 DSH 宿主。被测模型默认继承当前 session；也可以在配置中显式写 `model`。评委需要复用当前 DSH 时，可使用面向用户的 `executor: dsh` 别名；`dsh-host` 是 OMK 内部标识，不能写入用户配置。插件为每条 sample 创建新的 DSH agent／session，复用当前 profile 已配置的 provider、凭证、工具、sandbox 与持久化，同时用 complete system-prompt section 注入 control／treatment、关闭 runtime context 和环境 `skill` 工具。DSH 的 `session/event` 按宿主观测顺序映射为 OMK 的 token、turn、tool call 与子 agent 证据，报告写入项目的 `.omk/reports`。
@@ -81,6 +83,8 @@ dsh --profile web
 插件会先从发起命令的 session 组合 active agent preset，再叠加 OMK 的测量隔离。继承当前 session 模型且评委均复用同一个 DSH 模型时，当前交互 session 本身即作为连通性证据，不会额外创建探测 session；显式覆盖被测模型、使用不同 DSH 评委模型或外部评委时仍会执行连通性预检。宿主模式的配置应省略 `effort`：DSH 的 reasoning effort 是 provider-owned 枚举，无法与 OMK 的五档通用级别无损映射；需要在 DSH profile 中固定目标推理配置。`goldDir` 仍受支持，并会把人工 gold 一致性写回持久化报告。
 
 当前 PoC 通过 DSH 的人类命令注册表提供 `/omk`，因此要求 profile 组合 `ctx.commands` 及其命令适配器；内置 `web` profile 满足这一条件，headless／ACP／JSON-RPC surface 暂不消费该命令。`Sample.mocks` 仍不支持。runtime 指纹包含 DSH 宿主版本、OMK 适配器版本、provider、agent preset 和有效工具 schema。由于 DSH 尚未提供覆盖全部插件与策略的规范组合摘要，该指纹会明确标记为仅部分可审计，严格可比性检查将给出警告，而不会声称运行时完全一致。
+
+`/omk observe` 还要求 profile 提供 `ctx.sessionPersistence`。它列出最近已结束的 root session，并排除发起命令的当前 session；`/omk observe <session-id>` 通过 `listSnapshots()`／`inspect()` 只读取得逻辑事件流，比较读取前后的 revision，稳定后转换为 `sourceKind: dsh` 的 Trace IR，并返回实际监听地址下的 Studio 任务轨迹链接。JSONL、zstd 与 SQLite 的物理格式均由 DSH backend 负责，OMK 不解析这些文件。持续写入、required 未知事件、序号断裂、未闭合 turn／step 或缺失 tool result 都会拒绝“完整轨迹”结论。首版是离线快照，不实时跟随正在运行的 session。
 
 本地开发 checkout 可以先构建，再直接链接到 profile：
 

--- a/src/dsh-plugin/index.ts
+++ b/src/dsh-plugin/index.ts
@@ -10,6 +10,7 @@ import {
 } from './host-executor.js';
 import {
   createDshConversationCatalog,
+  dshTraceIngestionSummary,
   listDshObserveCandidates,
   readDshObservedGroup,
   type DshSessionPersistenceLike,
@@ -293,19 +294,10 @@ async function executeObserveCommand(
   } = await import('../observability/inbox.js');
   const { loadObservationReviewState } = await import('../observability/review-state.js');
   const { buildObserveDiagnosticsFromReport } = await import('../diagnosis/observe-producer.js');
-  const sourceRecordCount = group.inspections.reduce((sum, item) => sum + item.events.length + 1, 0);
   const report = buildObservationInboxReportFromTraceSessions(
     `dsh:${group.rootSessionId}`,
     group.traces.map((trace) => trace.session),
-    {
-      fileCount: group.traces.length,
-      sourceRecordCount,
-      parsedRecordCount: sourceRecordCount,
-      malformedRecordCount: 0,
-      ignoredValueCount: group.traces.reduce((sum, trace) => sum + trace.integrity.ignoredChunkCount, 0),
-      unknownEventCount: group.traces.reduce((sum, trace) => sum + trace.integrity.unknownEventCount, 0),
-      filteredSessionCount: 0,
-    },
+    dshTraceIngestionSummary(group),
     { reviewState: loadObservationReviewState(observationsDir) },
   );
   report.diagnostics = buildObserveDiagnosticsFromReport(report);

--- a/src/dsh-plugin/index.ts
+++ b/src/dsh-plugin/index.ts
@@ -8,6 +8,12 @@ import {
   type DshAgentLike,
   type DshHostContextLike,
 } from './host-executor.js';
+import {
+  createDshConversationCatalog,
+  listDshObserveCandidates,
+  readDshObservedGroup,
+  type DshSessionPersistenceLike,
+} from './observe.js';
 
 interface DshCommandInvocationLike {
   readonly agent: DshAgentLike;
@@ -21,6 +27,7 @@ type DshCommandResultLike =
   | Readonly<Record<'kind', 'error'> & { text: string }>;
 
 interface DshPluginContextLike extends DshHostContextLike {
+  get?(name: 'sessionPersistence'): DshSessionPersistenceLike | undefined;
   readonly commands: {
     register(definition: {
       readonly name: string;
@@ -36,18 +43,31 @@ interface DshPluginContextLike extends DshHostContextLike {
 export const name = 'omk-dsh-plugin';
 export const inject = ['agentPresets', 'agents', 'commands', 'tools'];
 
-const USAGE = '用法：/omk eval <eval.yaml>';
+const USAGE = '用法：/omk eval <eval.yaml> 或 /omk observe [session-id]';
 
-function commandPath(rawInput: string): string | undefined {
-  const match = /^\s*eval\s+(.+?)\s*$/u.exec(rawInput);
-  if (!match) return undefined;
-  const value = match[1]?.trim();
-  if (!value) return undefined;
+function unquote(value: string): string {
   if ((value.startsWith('"') && value.endsWith('"'))
     || (value.startsWith("'") && value.endsWith("'"))) {
     return value.slice(1, -1);
   }
   return value;
+}
+
+type DshCommand =
+  | { commandKind: 'eval'; path: string }
+  | { commandKind: 'observe'; sessionId?: string };
+
+function parseCommand(rawInput: string): DshCommand | undefined {
+  const evalMatch = /^\s*eval\s+(.+?)\s*$/u.exec(rawInput);
+  const evalPath = evalMatch?.[1]?.trim();
+  if (evalPath) return { commandKind: 'eval', path: unquote(evalPath) };
+  const observeMatch = /^\s*observe(?:\s+(.+?))?\s*$/u.exec(rawInput);
+  if (!observeMatch) return undefined;
+  const sessionId = observeMatch[1]?.trim();
+  return {
+    commandKind: 'observe',
+    ...(sessionId ? { sessionId: unquote(sessionId) } : {}),
+  };
 }
 
 function projectRoot(configPath: string): string {
@@ -175,17 +195,149 @@ async function executeEvalCommand(
   };
 }
 
-/** Register `/omk eval <eval.yaml>` in every DSH command-capable surface. */
-export function apply(ctx: DshPluginContextLike): void {
-  ctx.commands.register({
+interface DshStudioServer {
+  start(): Promise<string>;
+  stop(): Promise<void>;
+  getUrl(): string | null;
+}
+
+interface DshObserveState {
+  readonly catalog: ReturnType<typeof createDshConversationCatalog>;
+  server?: DshStudioServer;
+  serverUrl?: string;
+}
+
+function persistenceFor(ctx: DshPluginContextLike): DshSessionPersistenceLike {
+  const persistence = ctx.get?.('sessionPersistence');
+  if (!persistence) {
+    throw new Error('当前 DSH profile 没有启用 sessionPersistence；/omk eval 仍可使用，但任务轨迹需要配置 JSONL 或 SQLite persistence backend。');
+  }
+  return persistence;
+}
+
+async function studioUrl(
+  invocation: DshCommandInvocationLike,
+  state: DshObserveState,
+): Promise<string> {
+  if (state.serverUrl) return state.serverUrl;
+  const cwd = invocation.agent.session.header.cwd ?? process.cwd();
+  const omkDir = join(cwd, '.omk');
+  const { createReportServer } = await import('../server/report-server.js');
+  state.server = createReportServer({
+    port: 0,
+    reportsDir: join(omkDir, 'reports'),
+    analysesDir: join(omkDir, 'observe-health'),
+    doctorsDir: join(omkDir, 'doctors'),
+    observationsDir: join(omkDir, 'observe-inbox'),
+    jobsDir: join(omkDir, 'jobs'),
+    managedDir: join(omkDir, 'managed'),
+    conversationCatalog: state.catalog,
+  });
+  state.serverUrl = await state.server.start();
+  return state.serverUrl;
+}
+
+async function executeObserveCommand(
+  ctx: DshPluginContextLike,
+  invocation: DshCommandInvocationLike,
+  sessionId: string | undefined,
+  state: DshObserveState,
+): Promise<DshCommandResultLike> {
+  const persistence = persistenceFor(ctx);
+  if (!sessionId) {
+    const candidates = await listDshObserveCandidates(persistence, {
+      excludeSessionId: String(invocation.agent.session.id),
+      signal: invocation.signal,
+    });
+    if (candidates.length === 0) {
+      return {
+        kind: 'success',
+        text: '没有找到可观测的已结束 DSH session。完成一个任务后再运行 /omk observe。',
+      };
+    }
+    return {
+      kind: 'success',
+      text: [
+        '最近可观测的 DSH session：',
+        ...candidates.map((candidate) => (
+          `- ${candidate.sessionId}　${candidate.status}　${candidate.createdAt}${candidate.cwd ? `　${candidate.cwd}` : ''}`
+        )),
+        '',
+        '查看轨迹：/omk observe <session-id>',
+      ].join('\n'),
+    };
+  }
+  const group = await readDshObservedGroup(persistence, sessionId, invocation.signal);
+  const selected = group.traces.find((trace) => trace.session.runId === sessionId);
+  if (!selected) throw new Error(`DSH session 一致快照缺少目标 session：${sessionId}。`);
+  const incomplete = group.traces.filter((trace) => !trace.integrity.complete);
+  if (incomplete.length > 0) {
+    const details = incomplete.map((trace) => {
+      const integrity = trace.integrity;
+      const reasons = [
+        integrity.openTurnCount > 0 ? `未闭合 turn=${integrity.openTurnCount}` : '',
+        integrity.openStepCount > 0 ? `未闭合 step=${integrity.openStepCount}` : '',
+        integrity.unmatchedToolCallCount > 0 ? `缺失 tool result=${integrity.unmatchedToolCallCount}` : '',
+        integrity.unmatchedToolResultCount > 0 ? `孤立 tool result=${integrity.unmatchedToolResultCount}` : '',
+        integrity.status === 'unknown' ? '终态未知' : '',
+      ].filter(Boolean).join('；');
+      return `${trace.session.runId}（${reasons || '完整性检查未通过'}）`;
+    }).join('；');
+    throw new Error(`DSH session group 无法形成完整任务轨迹：${details}。`);
+  }
+  const cwd = invocation.agent.session.header.cwd ?? process.cwd();
+  const observationsDir = join(cwd, '.omk', 'observe-inbox');
+  const {
+    buildObservationInboxReportFromTraceSessions,
+    saveObservationInboxReport,
+  } = await import('../observability/inbox.js');
+  const { loadObservationReviewState } = await import('../observability/review-state.js');
+  const { buildObserveDiagnosticsFromReport } = await import('../diagnosis/observe-producer.js');
+  const sourceRecordCount = group.inspections.reduce((sum, item) => sum + item.events.length + 1, 0);
+  const report = buildObservationInboxReportFromTraceSessions(
+    `dsh:${group.rootSessionId}`,
+    group.traces.map((trace) => trace.session),
+    {
+      fileCount: group.traces.length,
+      sourceRecordCount,
+      parsedRecordCount: sourceRecordCount,
+      malformedRecordCount: 0,
+      ignoredValueCount: group.traces.reduce((sum, trace) => sum + trace.integrity.ignoredChunkCount, 0),
+      unknownEventCount: group.traces.reduce((sum, trace) => sum + trace.integrity.unknownEventCount, 0),
+      filteredSessionCount: 0,
+    },
+    { reviewState: loadObservationReviewState(observationsDir) },
+  );
+  report.diagnostics = buildObserveDiagnosticsFromReport(report);
+  const inboxPath = saveObservationInboxReport(report, observationsDir);
+  const target = state.catalog.upsert(group);
+  const baseUrl = await studioUrl(invocation, state);
+  const trajectoryUrl = `${baseUrl}/conversations/${encodeURIComponent(target.threadId)}/tasks/${encodeURIComponent(target.turnId)}`;
+  return {
+    kind: 'success',
+    text: [
+      `已只读摄取 DSH session：${sessionId}`,
+      `任务状态：${selected.integrity.status}`,
+      `任务轨迹：${trajectoryUrl}`,
+      `观测收件箱：${inboxPath}`,
+    ].join('\n'),
+  };
+}
+
+/** Register `/omk eval` and `/omk observe` in every DSH command-capable surface. */
+export function apply(ctx: DshPluginContextLike): () => void {
+  const observeState: DshObserveState = { catalog: createDshConversationCatalog() };
+  const disposeCommand = ctx.commands.register({
     name: 'omk',
-    description: '在当前 DeepSeek Harness 中运行 OMK 对照评测',
-    input: { hint: 'eval <eval.yaml>' },
+    description: '在当前 DeepSeek Harness 中运行 OMK 对照评测或查看任务轨迹',
+    input: { hint: 'eval <eval.yaml> | observe [session-id]' },
     async handler(invocation) {
-      const path = commandPath(invocation.rawInput);
-      if (!path) return { kind: 'error', text: USAGE };
+      const command = parseCommand(invocation.rawInput);
+      if (!command) return { kind: 'error', text: USAGE };
       try {
-        return await executeEvalCommand(ctx, invocation, path);
+        return command.commandKind === 'eval'
+          ? await executeEvalCommand(ctx, invocation, command.path)
+          : await executeObserveCommand(ctx, invocation, command.sessionId, observeState);
       } catch (error) {
         return {
           kind: 'error',
@@ -194,4 +346,8 @@ export function apply(ctx: DshPluginContextLike): void {
       }
     },
   });
+  return () => {
+    disposeCommand();
+    void observeState.server?.stop().catch(() => undefined);
+  };
 }

--- a/src/dsh-plugin/observe.ts
+++ b/src/dsh-plugin/observe.ts
@@ -1,0 +1,451 @@
+import type {
+  ConversationIndexViewModel,
+  ConversationListItem,
+  ConversationTaskItem,
+  ExperienceTimelineEvent,
+  ExperienceTurnSummary,
+  ObservationSourceRecord,
+  ObservationSourceRecordArchiveView,
+} from '../types/index.js';
+import { durationMsBetween } from '../shared/time.js';
+import {
+  projectTraceSessionTimeline,
+} from '../observability/experience.js';
+import { reconstructExperienceTurns } from '../observability/turn-index.js';
+import { observationSourceRecordFromLine } from '../observability/source-record-archive.js';
+import type {
+  ConversationCatalog,
+  ConversationTaskTrajectory,
+} from '../observability/conversation-catalog.js';
+import {
+  adaptDshSession,
+  type DshSessionEventLike,
+  type DshSessionHeaderLike,
+  type DshTraceAdapterResult,
+} from './trace-adapter.js';
+
+const MAX_STABLE_READ_ATTEMPTS = 3;
+const DEFAULT_LIST_LIMIT = 8;
+const LIST_INSPECTION_LIMIT = 24;
+const MAX_SOURCE_RECORD_BYTES = 16 * 1024 * 1024;
+
+export interface DshPersistenceSnapshotLike {
+  readonly header: DshSessionHeaderLike;
+  readonly revision: unknown;
+}
+
+export interface DshSessionInspectionLike {
+  readonly meta: DshSessionHeaderLike;
+  readonly events: readonly DshSessionEventLike[];
+}
+
+export interface DshSessionPersistenceLike {
+  listSnapshots(signal?: AbortSignal): Promise<readonly DshPersistenceSnapshotLike[]>;
+  inspect(id: string, signal?: AbortSignal): Promise<DshSessionInspectionLike>;
+}
+
+export interface DshObserveCandidate {
+  sessionId: string;
+  createdAt: string;
+  cwd?: string;
+  status: 'completed' | 'failed' | 'aborted' | 'interrupted';
+}
+
+export interface DshObservedGroup {
+  rootSessionId: string;
+  selectedSessionId: string;
+  revision: string;
+  traces: DshTraceAdapterResult[];
+  inspections: DshSessionInspectionLike[];
+}
+
+function snapshotMap(
+  snapshots: readonly DshPersistenceSnapshotLike[],
+): Map<string, DshPersistenceSnapshotLike> {
+  return new Map(snapshots.map((snapshot) => [String(snapshot.header.id), snapshot]));
+}
+
+function rootSessionId(
+  sessionId: string,
+  snapshots: Map<string, DshPersistenceSnapshotLike>,
+): string {
+  const seen = new Set<string>();
+  let current = sessionId;
+  while (true) {
+    if (seen.has(current)) throw new Error(`DSH session lineage 存在循环：${sessionId}。`);
+    seen.add(current);
+    const parent = snapshots.get(current)?.header.parentSession;
+    if (!parent) return current;
+    if (!snapshots.has(String(parent))) {
+      throw new Error(`DSH session lineage 缺少 parent session：${String(parent)}。`);
+    }
+    current = String(parent);
+  }
+}
+
+function groupSessionIds(
+  rootId: string,
+  snapshots: Map<string, DshPersistenceSnapshotLike>,
+): string[] {
+  const ids = new Set([rootId]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [id, snapshot] of snapshots) {
+      const parent = snapshot.header.parentSession ? String(snapshot.header.parentSession) : undefined;
+      if (!parent || !ids.has(parent) || ids.has(id)) continue;
+      ids.add(id);
+      changed = true;
+    }
+  }
+  return Array.from(ids).sort((left, right) => {
+    if (left === rootId) return -1;
+    if (right === rootId) return 1;
+    const depthDiff = (snapshots.get(left)?.header.delegationDepth ?? 0)
+      - (snapshots.get(right)?.header.delegationDepth ?? 0);
+    return depthDiff || left.localeCompare(right);
+  });
+}
+
+function sameRevision(left: unknown, right: unknown): boolean {
+  return Object.is(left, right);
+}
+
+function stableGroup(
+  before: Map<string, DshPersistenceSnapshotLike>,
+  after: Map<string, DshPersistenceSnapshotLike>,
+  rootId: string,
+): boolean {
+  const beforeIds = groupSessionIds(rootId, before);
+  const afterIds = groupSessionIds(rootId, after);
+  if (beforeIds.length !== afterIds.length
+    || beforeIds.some((id, index) => id !== afterIds[index])) return false;
+  return beforeIds.every((id) => {
+    const left = before.get(id);
+    const right = after.get(id);
+    return left !== undefined && right !== undefined && sameRevision(left.revision, right.revision);
+  });
+}
+
+function revisionLabel(
+  snapshots: Map<string, DshPersistenceSnapshotLike>,
+  ids: readonly string[],
+): string {
+  return ids.map((id) => `${id}:${String(snapshots.get(id)?.revision ?? 'missing')}`).join('|');
+}
+
+/** Read one root+descendant group through the logical persistence seam without mutating it. */
+export async function readDshObservedGroup(
+  persistence: DshSessionPersistenceLike,
+  selectedSessionId: string,
+  signal?: AbortSignal,
+): Promise<DshObservedGroup> {
+  for (let attempt = 1; attempt <= MAX_STABLE_READ_ATTEMPTS; attempt += 1) {
+    signal?.throwIfAborted();
+    const before = snapshotMap(await persistence.listSnapshots(signal));
+    if (!before.has(selectedSessionId)) throw new Error(`DSH session 不存在：${selectedSessionId}。`);
+    const rootId = rootSessionId(selectedSessionId, before);
+    const ids = groupSessionIds(rootId, before);
+    const inspections = await Promise.all(ids.map((id) => persistence.inspect(id, signal)));
+    signal?.throwIfAborted();
+    const after = snapshotMap(await persistence.listSnapshots(signal));
+    if (!stableGroup(before, after, rootId)) continue;
+    const traces = inspections.map((inspection) => adaptDshSession(inspection.meta, inspection.events, {
+      rootRunId: rootId,
+      role: String(inspection.meta.id) === rootId ? 'main' : 'subagent',
+      groupPath: `dsh:${rootId}`,
+    }));
+    return {
+      rootSessionId: rootId,
+      selectedSessionId,
+      revision: revisionLabel(after, ids),
+      traces,
+      inspections,
+    };
+  }
+  throw new Error(`DSH session 在读取期间持续变化，${MAX_STABLE_READ_ATTEMPTS} 次一致快照均失败：${selectedSessionId}。`);
+}
+
+async function inspectCandidate(
+  persistence: DshSessionPersistenceLike,
+  snapshot: DshPersistenceSnapshotLike,
+  signal?: AbortSignal,
+): Promise<DshObserveCandidate | undefined> {
+  const sessionId = String(snapshot.header.id);
+  try {
+    const group = await readDshObservedGroup(persistence, sessionId, signal);
+    const trace = group.traces.find((item) => item.session.runId === sessionId);
+    if (!trace) return undefined;
+    if (group.traces.some((item) => !item.integrity.complete)) return undefined;
+    const status = trace.integrity.status;
+    if (status !== 'completed' && status !== 'failed' && status !== 'aborted' && status !== 'interrupted') {
+      return undefined;
+    }
+    return {
+      sessionId,
+      createdAt: new Date(snapshot.header.createdAt).toISOString(),
+      cwd: snapshot.header.cwd,
+      status,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/** List recent terminal root sessions; the command's own live session stays out of the default result. */
+export async function listDshObserveCandidates(
+  persistence: DshSessionPersistenceLike,
+  options: { excludeSessionId?: string; limit?: number; signal?: AbortSignal } = {},
+): Promise<DshObserveCandidate[]> {
+  const limit = Math.max(1, options.limit ?? DEFAULT_LIST_LIMIT);
+  const snapshots = [...await persistence.listSnapshots(options.signal)]
+    .filter((snapshot) => !snapshot.header.parentSession && String(snapshot.header.id) !== options.excludeSessionId)
+    .sort((left, right) => right.header.createdAt - left.header.createdAt)
+    .slice(0, Math.max(limit, LIST_INSPECTION_LIMIT));
+  const candidates: DshObserveCandidate[] = [];
+  for (const snapshot of snapshots) {
+    options.signal?.throwIfAborted();
+    const candidate = await inspectCandidate(persistence, snapshot, options.signal);
+    if (candidate) candidates.push(candidate);
+    if (candidates.length >= limit) break;
+  }
+  return candidates;
+}
+
+function mergedTimeline(group: DshObservedGroup): ExperienceTimelineEvent[] {
+  const ranked = group.traces.flatMap((trace, traceRank) => (
+    projectTraceSessionTimeline(trace.session).map((event) => ({ event, traceRank }))
+  ));
+  ranked.sort((left, right) => {
+    if (left.event.timestamp && right.event.timestamp && left.event.timestamp !== right.event.timestamp) {
+      return left.event.timestamp.localeCompare(right.event.timestamp);
+    }
+    return left.traceRank - right.traceRank || left.event.order - right.event.order;
+  });
+  return ranked.map(({ event }, index) => ({ ...event, order: index * 10 }));
+}
+
+function attachDescendantsToRootTurns(
+  turns: ExperienceTurnSummary[],
+  timeline: ExperienceTimelineEvent[],
+  rootTraceId: string,
+): ExperienceTurnSummary[] {
+  const rootTurns = turns.filter((turn) => turn.traceId === rootTraceId);
+  const childEvents = timeline.filter((event) => event.traceId !== rootTraceId);
+  if (rootTurns.length === 0 || childEvents.length === 0) return turns;
+  const eventById = new Map(timeline.map((event) => [event.id, event]));
+  return turns.map((turn) => {
+    if (turn.traceId !== rootTraceId) return turn;
+    const related = childEvents.filter((event) => {
+      if (rootTurns.length === 1) return true;
+      if (!event.timestamp || !turn.startTimestamp) return false;
+      return event.timestamp >= turn.startTimestamp
+        && (!turn.endTimestamp || event.timestamp <= turn.endTimestamp);
+    });
+    if (related.length === 0) return turn;
+    const eventIds = Array.from(new Set([...turn.eventIds, ...related.map((event) => event.id)]))
+      .sort((left, right) => (eventById.get(left)?.order ?? 0) - (eventById.get(right)?.order ?? 0));
+    return {
+      ...turn,
+      eventIds,
+      toolCallCount: eventIds.filter((id) => eventById.get(id)?.kind === 'tool_use').length,
+      toolFailureCount: eventIds.filter((id) => {
+        const event = eventById.get(id);
+        return event?.kind === 'tool_result' && (event.toolStatus === 'failure' || event.isError);
+      }).length,
+    };
+  });
+}
+
+function sourceRecords(group: DshObservedGroup): ObservationSourceRecordArchiveView {
+  let byteCount = 0;
+  let omittedRecordCount = 0;
+  const records: ObservationSourceRecord[] = [];
+  group.traces.forEach((trace, traceIndex) => {
+    const inspection = group.inspections[traceIndex];
+    if (!inspection) return;
+    const values: unknown[] = [{ type: 'session/header', ...inspection.meta }, ...inspection.events];
+    values.forEach((value, sourceIndex) => {
+      const raw = JSON.stringify(value);
+      const event = sourceIndex === 0 ? undefined : inspection.events[sourceIndex - 1];
+      const base = observationSourceRecordFromLine(
+        raw,
+        sourceIndex,
+        trace.session.traceId,
+        trace.session.sourcePath,
+      );
+      if (byteCount + base.byteCount > MAX_SOURCE_RECORD_BYTES) {
+        omittedRecordCount += 1;
+        return;
+      }
+      records.push({
+        ...base,
+        sourceType: sourceIndex === 0 ? 'session/header' : event?.type ?? 'unknown',
+        sourceEventId: event ? `${String(inspection.meta.id)}:${event.seq}` : String(inspection.meta.id),
+        timestamp: sourceIndex === 0
+          ? new Date(inspection.meta.createdAt).toISOString()
+          : event ? new Date(event.time).toISOString() : undefined,
+      });
+      byteCount += base.byteCount;
+    });
+  });
+  return {
+    status: omittedRecordCount > 0 ? 'partial' : 'available',
+    recordCount: records.length,
+    records,
+    omittedRecordCount,
+    byteCount,
+    truncated: omittedRecordCount > 0,
+    ...(omittedRecordCount > 0 ? { reason: 'archive_limit' as const } : {}),
+  };
+}
+
+interface CatalogEntry {
+  group: DshObservedGroup;
+  conversation: ConversationListItem;
+  turns: ExperienceTurnSummary[];
+  timeline: ExperienceTimelineEvent[];
+  records: ObservationSourceRecordArchiveView;
+}
+
+function taskItem(threadId: string, turn: ExperienceTurnSummary): ConversationTaskItem {
+  return {
+    turnId: turn.turnId,
+    sourceTurnId: turn.sourceTurnId,
+    trajectoryHref: `/conversations/${encodeURIComponent(threadId)}/tasks/${encodeURIComponent(turn.turnId)}`,
+    title: turn.title,
+    startTimestamp: turn.startTimestamp,
+    endTimestamp: turn.endTimestamp,
+    durationMs: durationMsBetween(turn.startTimestamp, turn.endTimestamp),
+    status: turn.status,
+    eventCount: turn.eventIds.length,
+    toolCallCount: turn.toolCallCount,
+    toolFailureCount: turn.toolFailureCount,
+    relatedSkillNames: [],
+  };
+}
+
+function catalogEntry(group: DshObservedGroup): CatalogEntry {
+  const rootTrace = group.traces.find((trace) => trace.session.runId === group.rootSessionId)
+    ?? group.traces[0];
+  if (!rootTrace) throw new Error(`DSH session group 为空：${group.rootSessionId}。`);
+  const timeline = mergedTimeline(group);
+  const turns = attachDescendantsToRootTurns(
+    reconstructExperienceTurns(timeline),
+    timeline,
+    rootTrace.session.traceId,
+  );
+  const rootTimeline = timeline.filter((event) => event.traceId === rootTrace.session.traceId);
+  const firstUser = rootTimeline.find((event) => event.kind === 'user_message');
+  const title = firstUser?.fullText?.trim() || firstUser?.snippet?.trim() || `DSH session ${group.rootSessionId}`;
+  const tasks = turns.map((turn) => taskItem(group.rootSessionId, turn));
+  const startTimestamp = rootTrace.session.startTimestamp;
+  const endTimestamp = rootTrace.session.endTimestamp;
+  return {
+    group,
+    turns,
+    timeline,
+    records: sourceRecords(group),
+    conversation: {
+      threadId: group.rootSessionId,
+      sourceThreadId: group.rootSessionId,
+      sourceKind: 'dsh',
+      title: title.replace(/\s+/g, ' ').slice(0, 160),
+      preview: title.replace(/\s+/g, ' ').slice(0, 240),
+      cwd: rootTrace.session.cwd,
+      model: rootTrace.session.sourceMetadata?.model,
+      childThreadCount: Math.max(0, group.traces.length - 1),
+      startTimestamp,
+      endTimestamp,
+      durationMs: durationMsBetween(startTimestamp, endTimestamp),
+      turnCount: tasks.length,
+      toolCallCount: tasks.reduce((sum, task) => sum + task.toolCallCount, 0),
+      toolFailureCount: tasks.reduce((sum, task) => sum + task.toolFailureCount, 0),
+      relatedSkillNames: [],
+      tasks,
+    },
+  };
+}
+
+export interface DshCatalogTarget {
+  threadId: string;
+  turnId: string;
+}
+
+export interface MutableDshConversationCatalog extends ConversationCatalog {
+  upsert(group: DshObservedGroup): DshCatalogTarget;
+}
+
+/** Static snapshot catalog used by Studio; importing another session updates it without adding a parallel UI. */
+export function createDshConversationCatalog(): MutableDshConversationCatalog {
+  const entries = new Map<string, CatalogEntry>();
+  return {
+    upsert(group) {
+      const entry = catalogEntry(group);
+      entries.set(group.rootSessionId, entry);
+      const selectedTrace = group.traces.find((trace) => trace.session.runId === group.selectedSessionId);
+      const selectedTurn = [...entry.turns].reverse().find((turn) => turn.traceId === selectedTrace?.session.traceId)
+        ?? entry.turns.at(-1);
+      if (!selectedTurn) throw new Error(`DSH session 没有可展示的任务：${group.selectedSessionId}。`);
+      return { threadId: group.rootSessionId, turnId: selectedTurn.turnId };
+    },
+    async listConversations(): Promise<ConversationIndexViewModel> {
+      const conversations = Array.from(entries.values())
+        .map((entry) => entry.conversation)
+        .sort((left, right) => (right.endTimestamp ?? '').localeCompare(left.endTimestamp ?? ''));
+      return {
+        conversations,
+        totalTurnCount: conversations.reduce((sum, item) => sum + (item.turnCount ?? 0), 0),
+        totalToolCallCount: conversations.reduce((sum, item) => sum + (item.toolCallCount ?? 0), 0),
+        totalToolFailureCount: conversations.reduce((sum, item) => sum + (item.toolFailureCount ?? 0), 0),
+        indexedConversationCount: conversations.length,
+        unarchivedConversationCount: conversations.length,
+        archivedConversationCount: 0,
+        workspaceCount: new Set(conversations.flatMap((item) => item.cwd ? [item.cwd] : [])).size,
+      };
+    },
+    async getConversation(threadId) {
+      return entries.get(threadId)?.conversation;
+    },
+    async loadTaskTrajectory(threadId, turnId): Promise<ConversationTaskTrajectory | undefined> {
+      const entry = entries.get(threadId);
+      const turn = entry?.turns.find((candidate) => candidate.turnId === turnId);
+      if (!entry || !turn) return undefined;
+      const rootTrace = entry.group.traces.find((trace) => trace.session.runId === entry.group.rootSessionId)
+        ?? entry.group.traces[0];
+      if (!rootTrace) return undefined;
+      return {
+        revision: entry.group.revision,
+        status: turn.status,
+        liveObservable: false,
+        session: {
+          id: `dsh:${threadId}`,
+          threadId,
+          sourceThreadId: entry.group.rootSessionId,
+          sessionId: entry.group.selectedSessionId,
+          sourceTrace: rootTrace.session.sourcePath,
+          sourceKind: 'dsh',
+          entrypoint: 'dsh',
+          sourceMetadata: rootTrace.session.sourceMetadata,
+          cwd: rootTrace.session.cwd,
+          startTimestamp: rootTrace.session.startTimestamp,
+          endTimestamp: rootTrace.session.endTimestamp,
+          attributedEventIds: [],
+          turns: entry.turns,
+          fullSessionTimeline: entry.timeline,
+          indicators: { userCorrectionCount: 0 },
+        },
+        ingestion: {
+          fileCount: entry.group.traces.length,
+          sourceRecordCount: entry.group.inspections.reduce((sum, item) => sum + item.events.length + 1, 0),
+          parsedRecordCount: entry.group.inspections.reduce((sum, item) => sum + item.events.length + 1, 0),
+          malformedRecordCount: 0,
+          ignoredValueCount: entry.group.traces.reduce((sum, item) => sum + item.integrity.ignoredChunkCount, 0),
+          unknownEventCount: entry.group.traces.reduce((sum, item) => sum + item.integrity.unknownEventCount, 0),
+          filteredSessionCount: 0,
+        },
+        sourceRecords: entry.records,
+      };
+    },
+  };
+}

--- a/src/dsh-plugin/observe.ts
+++ b/src/dsh-plugin/observe.ts
@@ -92,7 +92,9 @@ function rootSessionId(
   while (true) {
     if (seen.has(current)) throw new Error(`DSH session lineage 存在循环：${sessionId}。`);
     seen.add(current);
-    const parent = snapshots.get(current)?.header.parentSession;
+    const currentHeader = snapshots.get(current)?.header;
+    if (currentHeader?.origin !== 'subagent') return current;
+    const parent = currentHeader.parentSession;
     if (!parent) return current;
     if (!snapshots.has(String(parent))) {
       throw new Error(`DSH session lineage 缺少 parent session：${String(parent)}。`);
@@ -111,7 +113,7 @@ function groupSessionIds(
     changed = false;
     for (const [id, snapshot] of snapshots) {
       const parent = snapshot.header.parentSession ? String(snapshot.header.parentSession) : undefined;
-      if (!parent || !ids.has(parent) || ids.has(id)) continue;
+      if (snapshot.header.origin !== 'subagent' || !parent || !ids.has(parent) || ids.has(id)) continue;
       ids.add(id);
       changed = true;
     }
@@ -217,7 +219,8 @@ export async function listDshObserveCandidates(
 ): Promise<DshObserveCandidate[]> {
   const limit = Math.max(1, options.limit ?? DEFAULT_LIST_LIMIT);
   const snapshots = [...await persistence.listSnapshots(options.signal)]
-    .filter((snapshot) => !snapshot.header.parentSession && String(snapshot.header.id) !== options.excludeSessionId)
+    .filter((snapshot) => snapshot.header.origin !== 'subagent'
+      && String(snapshot.header.id) !== options.excludeSessionId)
     .sort((left, right) => right.header.createdAt - left.header.createdAt)
     .slice(0, Math.max(limit, LIST_INSPECTION_LIMIT));
   const candidates: DshObserveCandidate[] = [];

--- a/src/dsh-plugin/observe.ts
+++ b/src/dsh-plugin/observe.ts
@@ -6,6 +6,7 @@ import type {
   ExperienceTurnSummary,
   ObservationSourceRecord,
   ObservationSourceRecordArchiveView,
+  TraceIngestionSummary,
 } from '../types/index.js';
 import { durationMsBetween } from '../shared/time.js';
 import {
@@ -57,6 +58,23 @@ export interface DshObservedGroup {
   revision: string;
   traces: DshTraceAdapterResult[];
   inspections: DshSessionInspectionLike[];
+}
+
+/** Count every valid DSH logical record as parsed, including chunks consolidated into messages. */
+export function dshTraceIngestionSummary(group: DshObservedGroup): TraceIngestionSummary {
+  const sourceRecordCount = group.inspections.reduce((sum, item) => sum + item.events.length + 1, 0);
+  return {
+    fileCount: group.traces.length,
+    sourceRecordCount,
+    parsedRecordCount: sourceRecordCount,
+    malformedRecordCount: 0,
+    ignoredValueCount: 0,
+    unknownEventCount: group.traces.reduce(
+      (sum, item) => sum + item.integrity.unknownEventCount,
+      0,
+    ),
+    filteredSessionCount: 0,
+  };
 }
 
 function snapshotMap(
@@ -435,15 +453,7 @@ export function createDshConversationCatalog(): MutableDshConversationCatalog {
           fullSessionTimeline: entry.timeline,
           indicators: { userCorrectionCount: 0 },
         },
-        ingestion: {
-          fileCount: entry.group.traces.length,
-          sourceRecordCount: entry.group.inspections.reduce((sum, item) => sum + item.events.length + 1, 0),
-          parsedRecordCount: entry.group.inspections.reduce((sum, item) => sum + item.events.length + 1, 0),
-          malformedRecordCount: 0,
-          ignoredValueCount: entry.group.traces.reduce((sum, item) => sum + item.integrity.ignoredChunkCount, 0),
-          unknownEventCount: entry.group.traces.reduce((sum, item) => sum + item.integrity.unknownEventCount, 0),
-          filteredSessionCount: 0,
-        },
+        ingestion: dshTraceIngestionSummary(entry.group),
         sourceRecords: entry.records,
       };
     },

--- a/src/dsh-plugin/trace-adapter.ts
+++ b/src/dsh-plugin/trace-adapter.ts
@@ -96,6 +96,28 @@ const AUXILIARY_EVENT_TYPES = new Set([
   'web/deepseek-search-llm-request',
 ]);
 
+const PROJECTED_EVENT_TYPES = new Set([
+  'assistant/chunk',
+  'assistant/message',
+  'request/context',
+  'request/header',
+  'session/end-seed',
+  'step/end',
+  'step/start',
+  'todo/write',
+  'tool/call',
+  'tool/result',
+  'turn/end',
+  'turn/start',
+  'user/message',
+]);
+
+function supportsEventType(eventType: string): boolean {
+  return PROJECTED_EVENT_TYPES.has(eventType)
+    || AUXILIARY_EVENT_TYPES.has(eventType)
+    || eventType.startsWith('compaction/');
+}
+
 function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -316,10 +338,17 @@ export function adaptDshSession(
 ): DshTraceAdapterResult {
   const runId = String(header.id);
   if (!runId.trim()) throw new Error('DSH session header 缺少 id。');
+  const seedLength = header.seedLength === undefined ? 0 : nonNegativeInteger(header.seedLength);
+  if (seedLength === undefined || seedLength > inputEvents.length) {
+    throw new Error(`DSH session header seedLength 非法：${String(header.seedLength)}。`);
+  }
+  inputEvents.forEach(validateEnvelope);
+  const activeEvents = inputEvents.slice(seedLength);
+  const isSubagent = header.origin === 'subagent';
   const sourcePath = `dsh:${runId}`;
   const traceId = createTraceId({ sourceKind: 'dsh', runId, sourcePath });
-  const rootRunId = options.rootRunId ?? header.parentSession ?? runId;
-  const role = options.role ?? (header.parentSession || header.origin === 'subagent' ? 'subagent' : 'main');
+  const rootRunId = options.rootRunId ?? (isSubagent ? header.parentSession : undefined) ?? runId;
+  const role = options.role ?? (isSubagent ? 'subagent' : 'main');
   const events: TraceEvent[] = [{
     eventKind: 'lifecycle',
     eventId: `${runId}:header:session-started`,
@@ -336,7 +365,7 @@ export function adaptDshSession(
     runtimeKind: 'session_context',
     runtimeName: 'DeepSeek Harness',
     cwd: header.cwd,
-    parentRunId: header.parentSession,
+    parentRunId: isSubagent ? header.parentSession : undefined,
     delegationDepth: header.delegationDepth,
     sourceOrigin: header.origin,
     historyMode: header.seedLength === undefined ? undefined : `seed:${header.seedLength}`,
@@ -359,7 +388,7 @@ export function adaptDshSession(
   let observedModel: string | undefined;
   let observedProvider: string | undefined;
 
-  for (const event of inputEvents) {
+  for (const event of activeEvents) {
     if (event.type !== 'assistant/message') continue;
     const data = isRecord(event.data) ? event.data : {};
     const turn = nonNegativeInteger(data.turn);
@@ -367,8 +396,14 @@ export function adaptDshSession(
     if (turn !== undefined && step !== undefined) assembledSteps.add(`${turn}:${step}`);
   }
 
-  inputEvents.forEach((event, index) => {
-    validateEnvelope(event, index);
+  inputEvents.slice(0, seedLength).forEach((event) => {
+    if (event.ignorable !== true && !supportsEventType(event.type)) {
+      throw new DshTraceUnsupportedEventError(event.type, event.seq);
+    }
+  });
+
+  activeEvents.forEach((event, activeIndex) => {
+    const index = seedLength + activeIndex;
     const sourceIndex = index + 1;
     const data = isRecord(event.data) ? event.data : {};
     const base = (suffix: string) => eventBase(runId, event, sourceIndex, suffix);
@@ -607,7 +642,7 @@ export function adaptDshSession(
     session: {
       runId,
       rootRunId,
-      ...(header.parentSession ? { parentRunId: header.parentSession } : {}),
+      ...(isSubagent && header.parentSession ? { parentRunId: header.parentSession } : {}),
       traceId,
       groupPath: options.groupPath ?? `dsh:${rootRunId}`,
       role,

--- a/src/dsh-plugin/trace-adapter.ts
+++ b/src/dsh-plugin/trace-adapter.ts
@@ -1,0 +1,637 @@
+import type { ExperienceTurnStatus } from '../types/index.js';
+import { normalizeToolIdentity } from '../shared/tool-identity.js';
+import {
+  correlateTraceToolEvents,
+  createTraceId,
+  traceTimestampBounds,
+  type TraceEvent,
+  type TraceMessageOrigin,
+  type TraceSession,
+} from '../observability/trace-ir.js';
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface DshSessionHeaderLike {
+  readonly version: number;
+  readonly id: string;
+  readonly createdAt: number;
+  readonly cwd?: string;
+  readonly parentSession?: string;
+  readonly seedLength?: number;
+  readonly origin?: string;
+  readonly delegationDepth?: number;
+  readonly agentPreset?: string;
+}
+
+export interface DshSessionEventLike {
+  readonly type: string;
+  readonly seq: number;
+  readonly time: number;
+  readonly data: unknown;
+  readonly ignorable?: true;
+  readonly sourceEventSeqs?: readonly number[];
+  readonly surfaceOp?: unknown;
+}
+
+export interface DshTraceIntegrity {
+  complete: boolean;
+  status: ExperienceTurnStatus;
+  unknownEventCount: number;
+  ignoredChunkCount: number;
+  unmatchedToolCallCount: number;
+  unmatchedToolResultCount: number;
+  openTurnCount: number;
+  openStepCount: number;
+}
+
+export interface DshTraceAdapterOptions {
+  rootRunId?: string;
+  role?: TraceSession['role'];
+  groupPath?: string;
+}
+
+export interface DshTraceAdapterResult {
+  session: TraceSession;
+  integrity: DshTraceIntegrity;
+}
+
+export class DshTraceUnsupportedEventError extends Error {
+  constructor(readonly eventType: string, readonly seq: number) {
+    super(`DSH session 包含 OMK 尚不认识的 required event：${eventType}（seq=${seq}）。`);
+    this.name = 'DshTraceUnsupportedEventError';
+  }
+}
+
+const AUXILIARY_EVENT_TYPES = new Set([
+  'agent-preset/selected',
+  'agent/inbox/spliced',
+  'approval/asked',
+  'approval/decided',
+  'approval/policy',
+  'command/done',
+  'command/run',
+  'feedback/record',
+  'goal/change',
+  'hook/invoked',
+  'hook/result',
+  'llm/retry',
+  'llm/retry-started',
+  'permission/preset',
+  'plan/mode',
+  'sandbox/mode',
+  'schedule/change',
+  'session/title',
+  'session/title-llm-request',
+  'subagent/descriptor',
+  'team/member',
+  'team/message/delivered',
+  'team/message/queued',
+  'team/task',
+  'tool-workflow/agent-end',
+  'tool-workflow/agent-start',
+  'tool-workflow/run-end',
+  'tool-workflow/run-start',
+  'tool/code-dispatch',
+  'tool/code-dispatch-start',
+  'web/deepseek-search-llm-request',
+]);
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function nonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function timestamp(value: unknown): string | undefined {
+  const milliseconds = nonNegativeInteger(value);
+  if (milliseconds === undefined) return undefined;
+  return new Date(milliseconds).toISOString();
+}
+
+function textFromContent(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (!Array.isArray(value)) return '';
+  return value.flatMap((block) => (
+    isRecord(block) && block.type === 'text' && typeof block.text === 'string'
+      ? [block.text]
+      : []
+  )).join('');
+}
+
+function reasoningFromContent(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((block) => (
+    isRecord(block) && block.type === 'reasoning' && typeof block.text === 'string'
+      ? [block.text]
+      : []
+  ));
+}
+
+function jsonText(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value ?? '');
+  }
+}
+
+function objectInput(value: unknown): Record<string, unknown> {
+  if (isRecord(value)) return value;
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (isRecord(parsed)) return parsed;
+    } catch {
+      // Preserve the exact provider output below.
+    }
+    return { rawArguments: value };
+  }
+  return { rawArguments: value ?? null };
+}
+
+function turnId(runId: string, data: UnknownRecord): string | undefined {
+  const turn = nonNegativeInteger(data.turn);
+  return turn === undefined ? undefined : `dsh:${runId}:turn:${turn}`;
+}
+
+function eventBase(
+  runId: string,
+  event: DshSessionEventLike,
+  sourceIndex: number,
+  suffix: string,
+): Pick<TraceEvent, 'eventId' | 'sourceIndex' | 'sourceType' | 'timestamp' | 'turnId'> {
+  const data = isRecord(event.data) ? event.data : {};
+  return {
+    eventId: `${runId}:${event.seq}:${suffix}`,
+    sourceIndex,
+    sourceType: event.type,
+    timestamp: timestamp(event.time),
+    turnId: turnId(runId, data),
+  };
+}
+
+function messageOrigin(source: unknown): TraceMessageOrigin {
+  if (!isRecord(source)) return 'synthetic';
+  const sourceKind = stringValue(source.kind);
+  if (sourceKind === 'user') return 'human';
+  if (sourceKind === 'skill-invocation' || sourceKind === 'skill-catalog') return 'skill-context';
+  if (sourceKind?.includes('skill')) return 'skill-context';
+  if (sourceKind === 'plugin' || sourceKind === 'agent-instructions') return 'runtime';
+  return 'synthetic';
+}
+
+function turnEndProjection(reason: unknown): {
+  phase: Extract<TraceEvent, { eventKind: 'lifecycle' }>['phase'];
+  status: ExperienceTurnStatus;
+  reason: string;
+} {
+  const record = isRecord(reason) ? reason : {};
+  const reasonKind = stringValue(record.kind) ?? 'unknown';
+  if (reasonKind === 'completed') return { phase: 'turn_completed', status: 'completed', reason: reasonKind };
+  if (reasonKind === 'aborted') return { phase: 'turn_aborted', status: 'aborted', reason: jsonText(record) };
+  if (reasonKind === 'interrupted') return { phase: 'turn_interrupted', status: 'interrupted', reason: reasonKind };
+  if (reasonKind === 'error' || reasonKind === 'blocked' || reasonKind === 'max-tokens') {
+    return { phase: 'turn_failed', status: 'failed', reason: jsonText(record) };
+  }
+  return {
+    phase: 'turn_ended_unknown',
+    status: 'unknown',
+    reason: `unknown terminal reason: ${jsonText(record)}`,
+  };
+}
+
+function requestFacts(data: UnknownRecord): {
+  model?: string;
+  provider?: string;
+  reasoningEffort?: string;
+  contextWindowId?: string;
+} {
+  if (isRecord(data.header)) {
+    const config = isRecord(data.header.config) ? data.header.config : {};
+    return {
+      model: stringValue(config.model),
+      provider: stringValue(config.provider),
+      reasoningEffort: stringValue(config.reasoningEffort),
+    };
+  }
+  return {
+    model: stringValue(data.model),
+    provider: stringValue(data.provider),
+    contextWindowId: nonNegativeInteger(data.contextWindow)?.toString(),
+  };
+}
+
+function compactionEvents(
+  runId: string,
+  event: DshSessionEventLike,
+  sourceIndex: number,
+): TraceEvent[] {
+  const data = isRecord(event.data) ? event.data : {};
+  if (event.type === 'compaction/summary') {
+    return [{
+      ...eventBase(runId, event, sourceIndex, 'compaction-summary'),
+      eventKind: 'context_compaction',
+      summary: textFromContent(data.summary),
+      replacementItemCount: Array.isArray(data.shadowedSeqs) ? data.shadowedSeqs.length : undefined,
+    }];
+  }
+  return [{
+    ...eventBase(runId, event, sourceIndex, 'compaction'),
+    eventKind: 'runtime_context',
+    runtimeKind: 'execution_context',
+    summary: `${event.type}: ${jsonText(data)}`,
+  }];
+}
+
+function auxiliaryEvent(
+  runId: string,
+  event: DshSessionEventLike,
+  sourceIndex: number,
+): TraceEvent {
+  const data = isRecord(event.data) ? event.data : {};
+  const agentActivity = event.type.startsWith('subagent/')
+    || event.type.startsWith('team/')
+    || event.type.startsWith('tool-workflow/');
+  if (agentActivity) {
+    return {
+      ...eventBase(runId, event, sourceIndex, 'agent-activity'),
+      eventKind: 'agent_activity',
+      activityKind: event.type.includes('message') ? 'communication' : 'status',
+      activity: event.type,
+      agentId: stringValue(data.agentId) ?? stringValue(data.memberId),
+      author: stringValue(data.author),
+      recipient: stringValue(data.recipient),
+      text: jsonText(data),
+    };
+  }
+  return {
+    ...eventBase(runId, event, sourceIndex, 'runtime-context'),
+    eventKind: 'runtime_context',
+    runtimeKind: event.type.startsWith('goal/') || event.type === 'todo/write' ? 'goal' : 'execution_context',
+    goal: event.type.startsWith('goal/') || event.type === 'todo/write' ? jsonText(data) : undefined,
+    summary: `${event.type}: ${jsonText(data)}`,
+  };
+}
+
+function toolResultData(data: UnknownRecord): {
+  callId?: string;
+  output: string;
+  failed: boolean;
+} {
+  const message = isRecord(data.message) ? data.message : {};
+  const blocks = Array.isArray(message.content) ? message.content.filter(isRecord) : [];
+  const result = blocks.find((block) => block.type === 'tool-result');
+  const content = isRecord(result) ? result.content : undefined;
+  const output = textFromContent(content) || jsonText(content ?? result ?? data);
+  return {
+    callId: isRecord(result) ? stringValue(result.toolCallId) : undefined,
+    output,
+    failed: data.error !== undefined || (isRecord(result) && result.isError === true),
+  };
+}
+
+function validateEnvelope(event: DshSessionEventLike, expectedSeq: number): void {
+  if (!Number.isSafeInteger(event.seq) || event.seq !== expectedSeq) {
+    throw new Error(`DSH session event seq 不连续：期望 ${expectedSeq}，实际 ${String(event.seq)}。`);
+  }
+  if (!Number.isSafeInteger(event.time) || event.time < 0) {
+    throw new Error(`DSH session event time 非法：seq=${event.seq}。`);
+  }
+  if (!event.type.trim()) throw new Error(`DSH session event type 为空：seq=${event.seq}。`);
+}
+
+/** Project one validated, backend-neutral DSH logical log into OMK Trace IR. */
+export function adaptDshSession(
+  header: DshSessionHeaderLike,
+  inputEvents: readonly DshSessionEventLike[],
+  options: DshTraceAdapterOptions = {},
+): DshTraceAdapterResult {
+  const runId = String(header.id);
+  if (!runId.trim()) throw new Error('DSH session header 缺少 id。');
+  const sourcePath = `dsh:${runId}`;
+  const traceId = createTraceId({ sourceKind: 'dsh', runId, sourcePath });
+  const rootRunId = options.rootRunId ?? header.parentSession ?? runId;
+  const role = options.role ?? (header.parentSession || header.origin === 'subagent' ? 'subagent' : 'main');
+  const events: TraceEvent[] = [{
+    eventKind: 'lifecycle',
+    eventId: `${runId}:header:session-started`,
+    sourceIndex: 0,
+    sourceType: 'session/header',
+    timestamp: timestamp(header.createdAt),
+    phase: 'session_started',
+  }, {
+    eventKind: 'runtime_context',
+    eventId: `${runId}:header:context`,
+    sourceIndex: 0,
+    sourceType: 'session/header',
+    timestamp: timestamp(header.createdAt),
+    runtimeKind: 'session_context',
+    runtimeName: 'DeepSeek Harness',
+    cwd: header.cwd,
+    parentRunId: header.parentSession,
+    delegationDepth: header.delegationDepth,
+    sourceOrigin: header.origin,
+    historyMode: header.seedLength === undefined ? undefined : `seed:${header.seedLength}`,
+    summary: jsonText({
+      agentPreset: header.agentPreset,
+      parentSession: header.parentSession,
+      origin: header.origin,
+      delegationDepth: header.delegationDepth,
+      seedLength: header.seedLength,
+    }),
+  }];
+  const pendingTools = new Set<string>();
+  const openTurns = new Set<number>();
+  const openSteps = new Set<string>();
+  const assembledSteps = new Set<string>();
+  let unknownEventCount = 0;
+  let ignoredChunkCount = 0;
+  let unmatchedToolResultCount = 0;
+  const terminal: { status: ExperienceTurnStatus } = { status: 'unknown' };
+  let observedModel: string | undefined;
+  let observedProvider: string | undefined;
+
+  for (const event of inputEvents) {
+    if (event.type !== 'assistant/message') continue;
+    const data = isRecord(event.data) ? event.data : {};
+    const turn = nonNegativeInteger(data.turn);
+    const step = nonNegativeInteger(data.step);
+    if (turn !== undefined && step !== undefined) assembledSteps.add(`${turn}:${step}`);
+  }
+
+  inputEvents.forEach((event, index) => {
+    validateEnvelope(event, index);
+    const sourceIndex = index + 1;
+    const data = isRecord(event.data) ? event.data : {};
+    const base = (suffix: string) => eventBase(runId, event, sourceIndex, suffix);
+    const sourceEventId = (value: unknown): { sourceEventId?: string } => {
+      const id = stringValue(value);
+      return id ? { sourceEventId: id } : {};
+    };
+
+    if (event.type === 'turn/start') {
+      const turn = nonNegativeInteger(data.turn);
+      if (turn === undefined) throw new Error(`DSH turn/start 缺少 turn：seq=${event.seq}。`);
+      openTurns.add(turn);
+      terminal.status = 'open';
+      events.push({ ...base('turn-start'), eventKind: 'lifecycle', phase: 'turn_started' });
+      return;
+    }
+    if (event.type === 'turn/end') {
+      const turn = nonNegativeInteger(data.turn);
+      if (turn === undefined) throw new Error(`DSH turn/end 缺少 turn：seq=${event.seq}。`);
+      openTurns.delete(turn);
+      const projection = turnEndProjection(data.reason);
+      terminal.status = projection.status;
+      events.push({
+        ...base('turn-end'),
+        eventKind: 'lifecycle',
+        phase: projection.phase,
+        reason: projection.reason,
+      });
+      return;
+    }
+    if (event.type === 'step/start' || event.type === 'step/end') {
+      const turn = nonNegativeInteger(data.turn);
+      const step = nonNegativeInteger(data.step);
+      if (turn === undefined || step === undefined) {
+        throw new Error(`DSH ${event.type} 缺少 turn／step：seq=${event.seq}。`);
+      }
+      const key = `${turn}:${step}`;
+      if (event.type === 'step/start') openSteps.add(key);
+      else openSteps.delete(key);
+      events.push({
+        ...base(event.type === 'step/start' ? 'step-start' : 'step-end'),
+        eventKind: 'lifecycle',
+        phase: event.type === 'step/start' ? 'step_started' : 'step_completed',
+        reason: `step=${step}`,
+      });
+      return;
+    }
+    if (event.type === 'user/message') {
+      const text = textFromContent(data.content);
+      const source = isRecord(data.source) ? data.source : undefined;
+      events.push({
+        ...base('user-message'),
+        ...sourceEventId(data.id),
+        eventKind: 'message',
+        role: 'user',
+        origin: messageOrigin(source),
+        text,
+        attributionSkill: source?.kind === 'skill-invocation' ? stringValue(source.name) : undefined,
+      });
+      return;
+    }
+    if (event.type === 'assistant/message') {
+      const message = isRecord(data.message) ? data.message : {};
+      const source = isRecord(message.source) ? message.source : {};
+      const model = stringValue(source.model);
+      const provider = stringValue(source.provider);
+      observedModel = model ?? observedModel;
+      observedProvider = provider ?? observedProvider;
+      const text = textFromContent(message.content);
+      if (text) {
+        events.push({
+          ...base('assistant-message'),
+          ...sourceEventId(message.id),
+          eventKind: 'message',
+          role: 'assistant',
+          origin: 'synthetic',
+          text,
+          model,
+        });
+      }
+      reasoningFromContent(message.content).forEach((reasoning, reasoningIndex) => {
+        events.push({
+          ...base(`reasoning-${reasoningIndex}`),
+          ...sourceEventId(message.id),
+          eventKind: 'model_activity',
+          activityKind: 'reasoning',
+          contentVisibility: 'plaintext',
+          contentSource: 'content',
+          text: reasoning,
+          model,
+        });
+      });
+      if (isRecord(data.usage)) {
+        const inputTokens = nonNegativeInteger(data.usage.inputTokens);
+        const outputTokens = nonNegativeInteger(data.usage.outputTokens);
+        if (inputTokens === undefined || outputTokens === undefined) {
+          throw new Error(`DSH assistant/message usage 非法：seq=${event.seq}。`);
+        }
+        events.push({
+          ...base('usage'),
+          eventKind: 'usage',
+          model,
+          inputTokens,
+          outputTokens,
+          cacheReadTokens: nonNegativeInteger(data.usage.cacheReadTokens),
+          cacheCreationTokens: nonNegativeInteger(data.usage.cacheWriteTokens),
+          reasoningTokens: nonNegativeInteger(data.usage.reasoningTokens),
+        });
+      }
+      return;
+    }
+    if (event.type === 'assistant/chunk') {
+      const turn = nonNegativeInteger(data.turn);
+      const step = nonNegativeInteger(data.step);
+      const chunk = isRecord(data.chunk) ? data.chunk : {};
+      if (turn !== undefined && step !== undefined && assembledSteps.has(`${turn}:${step}`)) {
+        ignoredChunkCount += 1;
+        return;
+      }
+      if (chunk.type === 'reasoning-delta' && typeof chunk.text === 'string' && chunk.text) {
+        events.push({
+          ...base('reasoning-delta'),
+          eventKind: 'model_activity',
+          activityKind: 'reasoning',
+          contentVisibility: 'plaintext',
+          contentSource: 'text',
+          text: chunk.text,
+          model: observedModel,
+        });
+      } else if (chunk.type === 'text-delta' && typeof chunk.text === 'string' && chunk.text) {
+        events.push({
+          ...base('text-delta'),
+          eventKind: 'message',
+          role: 'assistant',
+          origin: 'synthetic',
+          text: chunk.text,
+          model: observedModel,
+        });
+      } else {
+        ignoredChunkCount += 1;
+      }
+      return;
+    }
+    if (event.type === 'tool/call') {
+      const callId = stringValue(data.callId);
+      const name = stringValue(data.name);
+      if (!callId || !name) throw new Error(`DSH tool/call 缺少 callId／name：seq=${event.seq}。`);
+      pendingTools.add(callId);
+      events.push({
+        ...base('tool-call'),
+        ...sourceEventId(callId),
+        eventKind: 'tool_call',
+        callId,
+        callInstanceId: `${runId}:${callId}`,
+        tool: normalizeToolIdentity({ sourceName: name }),
+        input: objectInput(data.arguments),
+        model: observedModel,
+      });
+      return;
+    }
+    if (event.type === 'tool/result') {
+      const result = toolResultData(data);
+      if (!result.callId) throw new Error(`DSH tool/result 缺少 toolCallId：seq=${event.seq}。`);
+      if (!pendingTools.delete(result.callId)) unmatchedToolResultCount += 1;
+      events.push({
+        ...base('tool-result'),
+        ...sourceEventId(result.callId),
+        eventKind: 'tool_result',
+        callId: result.callId,
+        callInstanceId: `${runId}:${result.callId}`,
+        output: result.output,
+        status: result.failed ? 'failure' : 'success',
+        statusSource: 'runtime',
+      });
+      return;
+    }
+    if (event.type === 'request/header' || event.type === 'request/context') {
+      const facts = requestFacts(data);
+      observedModel = facts.model ?? observedModel;
+      observedProvider = facts.provider ?? observedProvider;
+      events.push({
+        ...base('request-context'),
+        eventKind: 'runtime_context',
+        runtimeKind: 'execution_context',
+        runtimeName: 'DeepSeek Harness',
+        model: facts.model,
+        modelProvider: facts.provider,
+        reasoningEffort: facts.reasoningEffort,
+        contextWindowId: facts.contextWindowId,
+        summary: `${event.type}: ${jsonText(data)}`,
+      });
+      return;
+    }
+    if (event.type === 'session/end-seed') {
+      events.push({
+        ...base('seed-boundary'),
+        eventKind: 'runtime_context',
+        runtimeKind: 'session_context',
+        historyMode: `seed-boundary:${event.seq}`,
+        summary: 'DSH session seed boundary',
+      });
+      return;
+    }
+    if (event.type.startsWith('compaction/')) {
+      events.push(...compactionEvents(runId, event, sourceIndex));
+      return;
+    }
+    if (event.type === 'todo/write' || AUXILIARY_EVENT_TYPES.has(event.type)) {
+      events.push(auxiliaryEvent(runId, event, sourceIndex));
+      return;
+    }
+    if (event.ignorable === true) {
+      unknownEventCount += 1;
+      events.push({
+        ...base('unknown'),
+        eventKind: 'unknown',
+        raw: event,
+      });
+      return;
+    }
+    throw new DshTraceUnsupportedEventError(event.type, event.seq);
+  });
+
+  const correlated = correlateTraceToolEvents(events);
+  const bounds = traceTimestampBounds(correlated.map((event) => event.timestamp));
+  const unmatchedToolCallCount = pendingTools.size;
+  const openTurnCount = openTurns.size;
+  const openStepCount = openSteps.size;
+  const complete = unmatchedToolCallCount === 0
+    && unmatchedToolResultCount === 0
+    && openTurnCount === 0
+    && openStepCount === 0
+    && terminal.status !== 'open'
+    && terminal.status !== 'unknown';
+  return {
+    session: {
+      runId,
+      rootRunId,
+      ...(header.parentSession ? { parentRunId: header.parentSession } : {}),
+      traceId,
+      groupPath: options.groupPath ?? `dsh:${rootRunId}`,
+      role,
+      label: role === 'subagent' ? `DSH subagent ${runId}` : `DSH session ${runId}`,
+      sourcePath,
+      sourceKind: 'dsh',
+      events: correlated,
+      cwd: header.cwd,
+      entrypoint: 'dsh',
+      sourceMetadata: {
+        provider: observedProvider,
+        model: observedModel,
+      },
+      ...bounds,
+    },
+    integrity: {
+      complete,
+      status: terminal.status,
+      unknownEventCount,
+      ignoredChunkCount,
+      unmatchedToolCallCount,
+      unmatchedToolResultCount,
+      openTurnCount,
+      openStepCount,
+    },
+  };
+}

--- a/src/observability/conversation-catalog.ts
+++ b/src/observability/conversation-catalog.ts
@@ -683,7 +683,7 @@ function trajectoryRevisionFromStat(
 }
 
 function isTerminalTaskStatus(status: ExperienceTurnStatus): boolean {
-  return status === 'completed' || status === 'aborted' || status === 'interrupted';
+  return status === 'completed' || status === 'failed' || status === 'aborted' || status === 'interrupted';
 }
 
 function secondsToMs(value: unknown): number | undefined {

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -1366,6 +1366,7 @@ function isExperienceTurnSummaryArray(value: unknown): value is ExperienceTurnSu
     && isOptionalTimestamp(turn.endTimestamp)
     && (
       turn.status === 'completed'
+      || turn.status === 'failed'
       || turn.status === 'aborted'
       || turn.status === 'interrupted'
       || turn.status === 'open'
@@ -3301,6 +3302,9 @@ function timelineEventsFromTraceEvent(
       memoryMode: event.memoryMode,
       historyMode: event.historyMode,
       contextWindowId: event.contextWindowId,
+      parentRunId: event.parentRunId,
+      delegationDepth: event.delegationDepth,
+      sourceOrigin: event.sourceOrigin,
       availableTools: event.availableTools,
       instructions: event.instructions,
       goal: event.goal,

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -19,11 +19,13 @@ import type {
   ObservationSignalType,
   ObservationSkillRollup,
   ObservationSourceKind,
+  TraceIngestionSummary,
   ToolCallInfo,
 } from '../types/index.js';
 import { extractGapSignalsFromTrace } from '../analysis/gap-analyzer.js';
 import {
   loadTraceSessions,
+  segmentTraceBySkill,
   tracesToResultEntries,
   skillSegmentTimestampObserved,
   type TraceSession,
@@ -441,7 +443,18 @@ function skillSessionCountKey(segment: SkillSegment): string {
  * `buildObserveDiagnosticsFromReport(report)` 写入 `report.diagnostics`。
  */
 export function buildObservationInboxReport(tracePath: string, options: BuildObservationInboxReportOptions = {}): ObservationInboxReport {
-  const { sessions, segments, ingestion } = tracesToResultEntries(tracePath);
+  const { sessions, ingestion } = tracesToResultEntries(tracePath);
+  return buildObservationInboxReportFromTraceSessions(tracePath, sessions, ingestion, options);
+}
+
+/** Build the existing inbox artifact from an in-memory source-neutral corpus. */
+export function buildObservationInboxReportFromTraceSessions(
+  tracePath: string,
+  sessions: TraceSession[],
+  ingestion: TraceIngestionSummary,
+  options: BuildObservationInboxReportOptions = {},
+): ObservationInboxReport {
+  const segments = sessions.flatMap(segmentTraceBySkill);
   const skillSegments = segments.filter((segment) => segment.skillName !== 'general');
   const generatedAt = new Date().toISOString();
   const sessionTimeRanges = buildSessionTimeRanges(sessions);

--- a/src/observability/trace-ir.ts
+++ b/src/observability/trace-ir.ts
@@ -77,8 +77,8 @@ export interface TraceUsageEvent extends TraceEventBase {
   model?: string;
   inputTokens: number;
   outputTokens: number;
-  cacheReadTokens: number;
-  cacheCreationTokens: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
   reasoningTokens?: number;
 }
 
@@ -93,7 +93,17 @@ export interface TraceModelActivityEvent extends TraceEventBase {
 
 export interface TraceLifecycleEvent extends TraceEventBase {
   eventKind: 'lifecycle';
-  phase: 'session_started' | 'session_ended' | 'turn_started' | 'turn_completed' | 'turn_aborted' | 'turn_interrupted';
+  phase:
+    | 'session_started'
+    | 'session_ended'
+    | 'turn_started'
+    | 'turn_completed'
+    | 'turn_failed'
+    | 'turn_aborted'
+    | 'turn_interrupted'
+    | 'turn_ended_unknown'
+    | 'step_started'
+    | 'step_completed';
   reason?: string;
   durationMs?: number;
 }
@@ -125,6 +135,9 @@ export interface TraceRuntimeContextEvent extends TraceEventBase {
   memoryMode?: string;
   historyMode?: string;
   contextWindowId?: string;
+  parentRunId?: string;
+  delegationDepth?: number;
+  sourceOrigin?: string;
   availableTools?: string[];
   instructions?: string;
   goal?: string;

--- a/src/observability/turn-index.ts
+++ b/src/observability/turn-index.ts
@@ -21,8 +21,10 @@ interface IndexedEvent {
 
 const TERMINAL_LIFECYCLE_LABELS = new Set([
   'turn_completed',
+  'turn_failed',
   'turn_aborted',
   'turn_interrupted',
+  'turn_ended_unknown',
 ]);
 
 /** Reconstruct every observable task without consulting Skill attribution. */
@@ -178,6 +180,7 @@ function syntheticTurnId(value: TurnCandidate): string {
 function turnStatus(events: ExperienceTimelineEvent[]): ExperienceTurnStatus {
   const labels = new Set(events.map((event) => event.label));
   if (labels.has('turn_completed')) return 'completed';
+  if (labels.has('turn_failed')) return 'failed';
   if (labels.has('turn_aborted')) return 'aborted';
   if (labels.has('turn_interrupted')) return 'interrupted';
   if (labels.has('turn_started')) return 'open';

--- a/src/renderer/conversation-renderer.ts
+++ b/src/renderer/conversation-renderer.ts
@@ -87,9 +87,9 @@ export function renderConversationIndexPage(
   const rows = conversations.map((conversation) => renderConversationRow(conversation, lang)).join('');
   const content = model.conversations.length > 0
     ? `<div class="conversation-list" role="list">${rows}</div>`
-    : `<div class="empty-state"><strong>${zh ? '还没有可浏览的 Codex 对话' : 'No Codex conversations yet'}</strong><span>${zh ? 'Studio 会直接读取 Codex 的本机会话索引，不需要先运行 observe。' : 'Studio reads the local Codex conversation index directly; observe is not required.'}</span></div>`;
+    : `<div class="empty-state"><strong>${zh ? '还没有可浏览的对话' : 'No conversations yet'}</strong><span>${zh ? '从受支持的 runtime 摄取任务轨迹后，会话会显示在这里。' : 'Sessions appear here after a supported runtime supplies task trajectories.'}</span></div>`;
 
-  return layout(zh ? 'Codex 对话' : 'Codex conversations', `
+  return layout(zh ? '对话' : 'Conversations', `
     <main class="conversation-page conversation-index-app" data-activity-revision="${e(activity.revision)}">
       <header class="conversation-app-head">
         <a class="conversation-app-brand" href="/${langQuery}">
@@ -101,7 +101,7 @@ export function renderConversationIndexPage(
         </nav>
       </header>
       <div class="conversation-app-body">
-        <section class="conversation-browser" aria-label="${zh ? 'Codex 对话' : 'Codex conversations'}">
+        <section class="conversation-browser" aria-label="${zh ? '对话' : 'Conversations'}">
           <header class="conversation-toolbar">
             <div class="conversation-browser-title">
               <h1>${zh ? '对话' : 'Conversations'}</h1>
@@ -155,7 +155,7 @@ export function renderConversationDetailPage(
       <header class="conversation-page-head conversation-detail-head">
         <div>
           <a class="back-link" href="/conversations${langSuffix}">${zh ? '返回对话总览' : 'Back to conversations'}</a>
-          <p class="conversation-eyebrow">CODEX · ${e(shortThreadId(conversation.sourceThreadId))}</p>
+          <p class="conversation-eyebrow">${e(sourceLabel(conversation))} · ${e(shortThreadId(conversation.sourceThreadId))}</p>
           <h1>${renderSafeInlineMarkdown(conversation.title)}</h1>
           <div class="detail-meta">
             ${conversation.model ? `<span>${e(conversation.model)}</span>` : ''}
@@ -196,8 +196,8 @@ function renderConversationRow(conversation: ConversationListItem, lang: Lang): 
     ? '<span class="index-pending">—</span>'
     : `<span><b>${conversation.turnCount}</b>${zh ? '任务' : 'tasks'}</span>`;
   const activity = openTask
-    ? `<strong class="running-label"><i aria-hidden="true"></i>${zh ? '进行中' : 'Running'}</strong><span>${e(updated)} · ${e(conversation.model ?? 'Codex')}</span>`
-    : `<strong>${e(updated)}</strong><span>${e(conversation.model ?? 'Codex')}</span>`;
+    ? `<strong class="running-label"><i aria-hidden="true"></i>${zh ? '进行中' : 'Running'}</strong><span>${e(updated)} · ${e(conversation.model ?? sourceLabel(conversation))}</span>`
+    : `<strong>${e(updated)}</strong><span>${e(conversation.model ?? sourceLabel(conversation))}</span>`;
   const liveTaskLink = openTaskHref
     ? `<a class="live-task-link" href="${e(openTaskHref)}" aria-label="${zh ? '查看进行中任务的实时轨迹' : 'View the live trajectory for the running task'}"><i aria-hidden="true"></i>${zh ? '查看实时轨迹' : 'View live'}</a>`
     : '';
@@ -389,10 +389,20 @@ function shortThreadId(value: string): string {
   return value.length > 18 ? `${value.slice(0, 8)}…${value.slice(-6)}` : value;
 }
 
+function sourceLabel(conversation: ConversationListItem): string {
+  if (conversation.sourceKind === 'dsh') return 'DeepSeek Harness';
+  if (conversation.sourceKind === 'codex') return 'Codex';
+  if (conversation.sourceKind === 'claude') return 'Claude';
+  if (conversation.sourceKind === 'openclaw') return 'OpenClaw';
+  if (conversation.sourceKind === 'markdown_log') return 'Markdown';
+  return 'Runtime';
+}
+
 function statusLabel(status: ExperienceTurnStatus, lang: Lang): string {
   const zh = lang === 'zh';
   const labels: Record<ExperienceTurnStatus, [string, string]> = {
     completed: ['已完成', 'Completed'],
+    failed: ['已失败', 'Failed'],
     aborted: ['已中止', 'Aborted'],
     interrupted: ['已打断', 'Interrupted'],
     open: ['进行中', 'Open'],

--- a/src/renderer/knowledge-debugger-renderer.ts
+++ b/src/renderer/knowledge-debugger-renderer.ts
@@ -1223,6 +1223,7 @@ export function renderKnowledgeDebuggerPage(
             syncing: zh ? '同步中' : 'Syncing',
             reconnecting: zh ? '重连中' : 'Reconnecting',
             failed: zh ? '实时更新失败' : 'Live update failed',
+            taskFailed: zh ? '任务已失败' : 'Task failed',
             following: zh ? '跟随中' : 'Following',
             resume: zh ? '跟随最新' : 'Follow latest',
             pending: zh ? '查看更新' : 'View update',
@@ -1604,8 +1605,12 @@ function lifecycleEventLabel(label: string | undefined, lang: Lang): string {
     session_ended: { zh: '会话结束', en: 'Session ended' },
     turn_started: { zh: '本轮开始', en: 'Turn started' },
     turn_completed: { zh: '本轮完成', en: 'Turn completed' },
+    turn_failed: { zh: '本轮失败', en: 'Turn failed' },
     turn_aborted: { zh: '本轮中止', en: 'Turn aborted' },
     turn_interrupted: { zh: '本轮被打断', en: 'Turn interrupted' },
+    turn_ended_unknown: { zh: '本轮结束状态未知', en: 'Turn ended with unknown status' },
+    step_started: { zh: '步骤开始', en: 'Step started' },
+    step_completed: { zh: '步骤完成', en: 'Step completed' },
   };
   return labels[label ?? '']?.[lang] ?? (label || (lang === 'zh' ? '运行状态变化' : 'Lifecycle event'));
 }
@@ -1613,7 +1618,7 @@ function lifecycleEventLabel(label: string | undefined, lang: Lang): string {
 function lifecycleMilestoneTone(label: string | undefined): ReplayMilestoneTone {
   if (label === 'session_started' || label === 'turn_started') return 'start';
   if (label === 'session_ended' || label === 'turn_completed') return 'end';
-  if (label === 'turn_aborted' || label === 'turn_interrupted') return 'warning';
+  if (label === 'turn_failed' || label === 'turn_aborted' || label === 'turn_interrupted') return 'warning';
   return 'neutral';
 }
 

--- a/src/renderer/observation-inbox-renderer.ts
+++ b/src/renderer/observation-inbox-renderer.ts
@@ -262,8 +262,8 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
     </div>`;
   };
   const renderSourceBadge = (item: ObservationInboxItem): string => {
-    const label = item.sourceKind === 'openclaw' ? 'OpenClaw' : item.sourceKind === 'codex' ? 'Codex' : item.sourceKind === 'markdown_log' ? 'Markdown log' : item.sourceKind === 'claude' ? 'Claude' : 'Unknown';
-    const color = item.sourceKind === 'openclaw' ? '#7c3aed' : item.sourceKind === 'codex' ? '#1677ff' : item.sourceKind === 'markdown_log' ? 'var(--green)' : item.sourceKind === 'claude' ? 'var(--accent)' : 'var(--text-muted)';
+    const label = item.sourceKind === 'dsh' ? 'DeepSeek Harness' : item.sourceKind === 'openclaw' ? 'OpenClaw' : item.sourceKind === 'codex' ? 'Codex' : item.sourceKind === 'markdown_log' ? 'Markdown log' : item.sourceKind === 'claude' ? 'Claude' : 'Unknown';
+    const color = item.sourceKind === 'dsh' ? '#0f766e' : item.sourceKind === 'openclaw' ? '#7c3aed' : item.sourceKind === 'codex' ? '#1677ff' : item.sourceKind === 'markdown_log' ? 'var(--green)' : item.sourceKind === 'claude' ? 'var(--accent)' : 'var(--text-muted)';
     return `<span title="调用日志来源：${e(label)}" style="display:inline-flex;margin-top:4px;padding:2px 6px;border-radius:999px;background:var(--bg-muted);color:${color};font-size:11px;font-weight:650">${e(label)}</span>`;
   };
   const confidenceHeaderHelp = '判断把握：OMK 对“这条 过程发现 是否需要处理/是否高风险/需关注”的规则判断有多确定。归属把握：OMK 把这条 过程发现 归到当前 skill 名下有多确定，例如明确调用 skill 通常更高。';

--- a/src/renderer/trajectory-live.ts
+++ b/src/renderer/trajectory-live.ts
@@ -4,6 +4,7 @@ export interface TrajectoryLiveLabels {
   syncing: string;
   reconnecting: string;
   failed: string;
+  taskFailed: string;
   following: string;
   resume: string;
   pending: string;
@@ -58,7 +59,7 @@ export function createTrajectoryLiveController(options: TrajectoryLiveClientOpti
   const lifecycle = new AbortController();
   let followLatest = Boolean(liveEndpoint);
   let pendingRevision = '';
-  let terminalState: 'completed' | 'aborted' | 'interrupted' | 'unknown' | undefined;
+  let terminalState: 'completed' | 'failed' | 'aborted' | 'interrupted' | 'unknown' | undefined;
   let refreshTimer: number | undefined;
   let scrollReleaseTimer: number | undefined;
   let suppressScrollTracking = false;
@@ -97,7 +98,9 @@ export function createTrajectoryLiveController(options: TrajectoryLiveClientOpti
     const state = terminalState ?? (!followLatest && pendingRevision
       ? 'pending'
       : (followLatest ? 'following' : 'paused'));
-    const terminalLabel = terminalState ? labels[terminalState] : undefined;
+    const terminalLabel = terminalState
+      ? terminalState === 'failed' ? labels.taskFailed : labels[terminalState]
+      : undefined;
     followButton.dataset.state = state;
     followButton.dataset.following = String(followLatest);
     followButton.setAttribute('aria-pressed', String(followLatest));
@@ -248,11 +251,12 @@ export function createTrajectoryLiveController(options: TrajectoryLiveClientOpti
           liveObservable?: boolean;
         };
         const explicitTerminal = update.status === 'completed'
+          || update.status === 'failed'
           || update.status === 'aborted'
           || update.status === 'interrupted';
         const streamTerminal = update.liveObservable === false || explicitTerminal;
         terminalState = explicitTerminal
-          ? update.status as 'completed' | 'aborted' | 'interrupted'
+          ? update.status as 'completed' | 'failed' | 'aborted' | 'interrupted'
           : update.liveObservable === false ? 'unknown' : undefined;
         if (streamTerminal) {
           source.close();
@@ -261,7 +265,7 @@ export function createTrajectoryLiveController(options: TrajectoryLiveClientOpti
         if (!update.revision || update.revision === shell.dataset.liveRevision) {
           const quiet = update.status === 'unknown';
           const connectionLabel = terminalState
-            ? labels[terminalState]
+            ? terminalState === 'failed' ? labels.taskFailed : labels[terminalState]
             : quiet ? labels.reconnecting : labels.live;
           setConnectionState(
             terminalState ?? (quiet ? 'reconnecting' : 'live'),

--- a/src/shared/trace-source-kind.ts
+++ b/src/shared/trace-source-kind.ts
@@ -3,6 +3,7 @@ import type { TraceSourceKind } from '../types/trace.js';
 const TRACE_SOURCE_KINDS = new Set<TraceSourceKind>([
   'claude',
   'codex',
+  'dsh',
   'openclaw',
   'markdown_log',
   'unknown',

--- a/src/types/observability.ts
+++ b/src/types/observability.ts
@@ -583,6 +583,7 @@ export type TaskWindowBasis =
 
 export type ExperienceTurnStatus =
   | 'completed'
+  | 'failed'
   | 'aborted'
   | 'interrupted'
   | 'open'

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -2,6 +2,7 @@
 export type TraceSourceKind =
   | 'claude'
   | 'codex'
+  | 'dsh'
   | 'openclaw'
   | 'markdown_log'
   | 'unknown';

--- a/test/dsh-plugin/observe.test.ts
+++ b/test/dsh-plugin/observe.test.ts
@@ -1,0 +1,309 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'vitest';
+import { apply } from '../../src/dsh-plugin/index.js';
+import {
+  createDshConversationCatalog,
+  listDshObserveCandidates,
+  readDshObservedGroup,
+  type DshPersistenceSnapshotLike,
+  type DshSessionInspectionLike,
+  type DshSessionPersistenceLike,
+} from '../../src/dsh-plugin/observe.js';
+import {
+  adaptDshSession,
+  DshTraceUnsupportedEventError,
+  type DshSessionEventLike,
+  type DshSessionHeaderLike,
+} from '../../src/dsh-plugin/trace-adapter.js';
+
+const BASE_TIME = Date.UTC(2026, 7, 24, 8, 0, 0);
+
+function header(
+  id: string,
+  overrides: Partial<DshSessionHeaderLike> = {},
+): DshSessionHeaderLike {
+  return {
+    version: 0,
+    id,
+    createdAt: BASE_TIME,
+    cwd: '/workspace/demo',
+    delegationDepth: 0,
+    ...overrides,
+  };
+}
+
+function event(
+  seq: number,
+  type: string,
+  data: unknown,
+  overrides: Partial<DshSessionEventLike> = {},
+): DshSessionEventLike {
+  return {
+    type,
+    seq,
+    time: BASE_TIME + seq * 100,
+    data,
+    ...overrides,
+  };
+}
+
+function completedEvents(prompt = '检查任务轨迹'): DshSessionEventLike[] {
+  return [
+    event(0, 'turn/start', { turn: 1 }),
+    event(1, 'step/start', { turn: 1, step: 1 }),
+    event(2, 'user/message', {
+      id: 'user-1',
+      role: 'user',
+      content: [{ type: 'text', text: prompt }],
+      source: { kind: 'user' },
+    }),
+    event(3, 'request/context', {
+      provider: 'deepseek',
+      model: 'deepseek-v4',
+      contextWindow: 128_000,
+    }),
+    event(4, 'tool/call', {
+      turn: 1,
+      step: 1,
+      callId: 'call-1',
+      name: 'read',
+      arguments: '{"path":"README.md"}',
+    }),
+    event(5, 'tool/result', {
+      turn: 1,
+      step: 1,
+      message: {
+        content: [{
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          content: [{ type: 'text', text: 'README content' }],
+          isError: false,
+        }],
+      },
+    }),
+    event(6, 'assistant/message', {
+      turn: 1,
+      step: 1,
+      message: {
+        id: 'assistant-1',
+        role: 'assistant',
+        source: { kind: 'model', provider: 'deepseek', model: 'deepseek-v4' },
+        content: [
+          { type: 'reasoning', text: '可见的推理摘要' },
+          { type: 'text', text: '任务已完成' },
+        ],
+      },
+      usage: { inputTokens: 20, outputTokens: 8 },
+    }),
+    event(7, 'step/end', { turn: 1, step: 1 }),
+    event(8, 'turn/end', { turn: 1, reason: { kind: 'completed' } }),
+  ];
+}
+
+class FakePersistence implements DshSessionPersistenceLike {
+  listCalls = 0;
+
+  constructor(
+    readonly inspections: Map<string, DshSessionInspectionLike>,
+    private readonly mutateRevisionOnce = false,
+  ) {}
+
+  async listSnapshots(): Promise<readonly DshPersistenceSnapshotLike[]> {
+    this.listCalls += 1;
+    return Array.from(this.inspections.values()).map((inspection) => ({
+      header: inspection.meta,
+      revision: this.mutateRevisionOnce && this.listCalls === 1
+        ? `stale:${inspection.meta.id}`
+        : `stable:${inspection.meta.id}`,
+    }));
+  }
+
+  async inspect(id: string): Promise<DshSessionInspectionLike> {
+    const inspection = this.inspections.get(id);
+    if (!inspection) throw new Error(`missing ${id}`);
+    return inspection;
+  }
+}
+
+function persistenceWithGroup(mutateRevisionOnce = false): FakePersistence {
+  const root = header('root-session');
+  const child = header('child-session', {
+    parentSession: 'root-session',
+    origin: 'subagent',
+    delegationDepth: 1,
+    createdAt: BASE_TIME + 250,
+  });
+  return new FakePersistence(new Map([
+    ['root-session', { meta: root, events: completedEvents() }],
+    ['child-session', { meta: child, events: completedEvents('子任务') }],
+  ]), mutateRevisionOnce);
+}
+
+describe('DSH Trace IR adapter', () => {
+  it('preserves durable messages, runtime facts, tools, usage, terminal status, and lineage', () => {
+    const result = adaptDshSession(header('child', {
+      parentSession: 'root',
+      origin: 'subagent',
+      delegationDepth: 1,
+    }), [
+      ...completedEvents(),
+      event(9, 'plugin/telemetry-note', { note: 'safe to skip' }, { ignorable: true }),
+    ], { rootRunId: 'root', role: 'subagent' });
+
+    assert.equal(result.session.sourceKind, 'dsh');
+    assert.equal(result.session.rootRunId, 'root');
+    assert.equal(result.session.parentRunId, 'root');
+    assert.equal(result.session.role, 'subagent');
+    assert.equal(result.session.sourceMetadata?.provider, 'deepseek');
+    assert.equal(result.session.sourceMetadata?.model, 'deepseek-v4');
+    assert.equal(result.integrity.status, 'completed');
+    assert.equal(result.integrity.complete, true);
+    assert.equal(result.integrity.unknownEventCount, 1);
+    const user = result.session.events.find((item) => item.eventKind === 'message' && item.role === 'user');
+    assert.equal(user?.eventKind, 'message');
+    if (user?.eventKind === 'message') assert.equal(user.origin, 'human');
+    const call = result.session.events.find((item) => item.eventKind === 'tool_call');
+    assert.deepEqual(call?.input, { path: 'README.md' });
+    const toolResult = result.session.events.find((item) => item.eventKind === 'tool_result');
+    assert.equal(toolResult?.status, 'success');
+    const usage = result.session.events.find((item) => item.eventKind === 'usage');
+    assert.equal(usage?.inputTokens, 20);
+    assert.equal(usage?.cacheReadTokens, undefined);
+    assert.ok(result.session.events.some((item) => item.eventKind === 'model_activity'));
+  });
+
+  it('distinguishes runtime, skill-context, and synthetic user-role messages', () => {
+    const result = adaptDshSession(header('origins'), [
+      event(0, 'user/message', { content: [{ type: 'text', text: 'runtime' }], source: { kind: 'agent-instructions' } }),
+      event(1, 'user/message', { content: [{ type: 'text', text: 'skill' }], source: { kind: 'skill-invocation', name: 'review' } }),
+      event(2, 'user/message', { content: [{ type: 'text', text: 'synthetic' }], source: { kind: 'cron' } }),
+    ]);
+    const origins = result.session.events
+      .filter((item) => item.eventKind === 'message')
+      .map((item) => item.origin);
+    assert.deepEqual(origins, ['runtime', 'skill-context', 'synthetic']);
+  });
+
+  it('refuses unknown required events and sequence gaps', () => {
+    assert.throws(
+      () => adaptDshSession(header('required'), [event(0, 'plugin/required', {})]),
+      DshTraceUnsupportedEventError,
+    );
+    assert.throws(
+      () => adaptDshSession(header('gap'), [event(1, 'turn/start', { turn: 1 })]),
+      /seq 不连续/,
+    );
+  });
+
+  it('does not represent open turns or missing tool results as complete', () => {
+    const result = adaptDshSession(header('partial'), [
+      event(0, 'turn/start', { turn: 1 }),
+      event(1, 'step/start', { turn: 1, step: 1 }),
+      event(2, 'tool/call', { turn: 1, step: 1, callId: 'pending', name: 'read', arguments: '{}' }),
+    ]);
+    assert.equal(result.integrity.complete, false);
+    assert.equal(result.integrity.status, 'open');
+    assert.equal(result.integrity.openTurnCount, 1);
+    assert.equal(result.integrity.openStepCount, 1);
+    assert.equal(result.integrity.unmatchedToolCallCount, 1);
+  });
+});
+
+describe('DSH persistence observation', () => {
+  it('retries a changing revision and maps root plus descendants through one logical seam', async () => {
+    const persistence = persistenceWithGroup(true);
+    const group = await readDshObservedGroup(persistence, 'child-session');
+    assert.ok(persistence.listCalls >= 4);
+    assert.equal(group.rootSessionId, 'root-session');
+    assert.equal(group.traces.length, 2);
+    assert.deepEqual(group.traces.map((item) => item.session.role), ['main', 'subagent']);
+  });
+
+  it('returns equivalent Trace IR for backend implementations exposing the same logical events', async () => {
+    const jsonl = await readDshObservedGroup(persistenceWithGroup(), 'root-session');
+    const sqlite = await readDshObservedGroup(persistenceWithGroup(), 'root-session');
+    assert.deepEqual(jsonl.traces.map((item) => item.session), sqlite.traces.map((item) => item.session));
+  });
+
+  it('lists terminal roots and excludes the current command session', async () => {
+    const current = header('current-session', { createdAt: BASE_TIME + 10_000 });
+    const persistence = persistenceWithGroup();
+    persistence.inspections.set('current-session', { meta: current, events: completedEvents('当前命令') });
+    const rows = await listDshObserveCandidates(persistence, { excludeSessionId: 'current-session' });
+    assert.deepEqual(rows.map((item) => item.sessionId), ['root-session']);
+  });
+
+  it('does not list a root while one descendant trace is incomplete', async () => {
+    const persistence = persistenceWithGroup();
+    const child = persistence.inspections.get('child-session');
+    assert.ok(child);
+    persistence.inspections.set('child-session', {
+      meta: child.meta,
+      events: [event(0, 'turn/start', { turn: 1 })],
+    });
+    assert.deepEqual(await listDshObserveCandidates(persistence), []);
+  });
+
+  it('feeds the existing source-neutral Studio catalog', async () => {
+    const group = await readDshObservedGroup(persistenceWithGroup(), 'root-session');
+    const catalog = createDshConversationCatalog();
+    const target = catalog.upsert(group);
+    const index = await catalog.listConversations();
+    const trajectory = await catalog.loadTaskTrajectory(target.threadId, target.turnId);
+    assert.equal(index.conversations[0]?.sourceKind, 'dsh');
+    assert.equal(index.conversations[0]?.childThreadCount, 1);
+    assert.equal(trajectory?.session.sourceKind, 'dsh');
+    assert.ok(trajectory?.session.fullSessionTimeline.some((item) => item.traceRole === 'subagent'));
+    assert.equal(trajectory?.sourceRecords.status, 'available');
+  });
+});
+
+describe('DSH /omk observe command', () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    while (cleanups.length > 0) cleanups.pop()?.();
+  });
+
+  it('lists sessions, imports one, and returns a live Studio trajectory URL', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-dsh-observe-'));
+    const persistence = persistenceWithGroup();
+    let handler: ((invocation: Record<string, unknown>) => Promise<{ kind: string; text?: string }>) | undefined;
+    const dispose = apply({
+      commands: {
+        register(definition: { handler: typeof handler }) {
+          handler = definition.handler;
+          return () => undefined;
+        },
+      },
+      get(name: 'sessionPersistence') {
+        return name === 'sessionPersistence' ? persistence : undefined;
+      },
+    } as never);
+    cleanups.push(() => {
+      dispose();
+      rmSync(dir, { recursive: true, force: true });
+    });
+    assert.ok(handler);
+    const invocation = {
+      agent: {
+        id: 'command-session',
+        session: { id: 'command-session', header: { cwd: dir }, events: [] },
+      },
+      signal: new AbortController().signal,
+    };
+    const listed = await handler({ ...invocation, rawInput: 'observe' });
+    assert.equal(listed.kind, 'success');
+    assert.match(listed.text ?? '', /root-session/);
+    const observed = await handler({ ...invocation, rawInput: 'observe root-session' });
+    assert.equal(observed.kind, 'success');
+    const url = /任务轨迹：(http:\/\/[^\s]+)/u.exec(observed.text ?? '')?.[1];
+    assert.ok(url);
+    const response = await fetch(url);
+    assert.equal(response.status, 200);
+    assert.match(await response.text(), /检查任务轨迹/);
+  });
+});

--- a/test/dsh-plugin/observe.test.ts
+++ b/test/dsh-plugin/observe.test.ts
@@ -109,6 +109,42 @@ function completedEvents(prompt = '检查任务轨迹'): DshSessionEventLike[] {
   ];
 }
 
+function completedEventsAfterSeed(
+  seedPrompt = '父任务历史',
+  activePrompt = '执行子任务',
+): DshSessionEventLike[] {
+  return [
+    ...completedEvents(seedPrompt),
+    event(10, 'session/end-seed', {}),
+    event(11, 'turn/start', { turn: 2 }),
+    event(12, 'step/start', { turn: 2, step: 1 }),
+    event(13, 'user/message', {
+      id: 'user-2',
+      role: 'user',
+      content: [{ type: 'text', text: activePrompt }],
+      source: { kind: 'user' },
+    }),
+    event(14, 'request/context', {
+      provider: 'deepseek',
+      model: 'deepseek-v4',
+      contextWindow: 128_000,
+    }),
+    event(15, 'assistant/message', {
+      turn: 2,
+      step: 1,
+      message: {
+        id: 'assistant-2',
+        role: 'assistant',
+        source: { kind: 'model', provider: 'deepseek', model: 'deepseek-v4' },
+        content: [{ type: 'text', text: '子任务已完成' }],
+      },
+      usage: { inputTokens: 2, outputTokens: 1 },
+    }),
+    event(16, 'step/end', { turn: 2, step: 1 }),
+    event(17, 'turn/end', { turn: 2, reason: { kind: 'completed' } }),
+  ];
+}
+
 class FakePersistence implements DshSessionPersistenceLike {
   listCalls = 0;
 
@@ -182,6 +218,39 @@ describe('DSH Trace IR adapter', () => {
     assert.ok(result.session.events.some((item) => item.eventKind === 'model_activity'));
   });
 
+  it('does not project inherited seed records as child task activity', () => {
+    const result = adaptDshSession(header('seeded-child', {
+      parentSession: 'root',
+      origin: 'subagent',
+      delegationDepth: 1,
+      seedLength: 10,
+      createdAt: BASE_TIME + 1_000,
+    }), completedEventsAfterSeed(), { rootRunId: 'root', role: 'subagent' });
+
+    const messages = result.session.events
+      .filter((item) => item.eventKind === 'message')
+      .map((item) => item.text);
+    assert.deepEqual(messages, ['执行子任务', '子任务已完成']);
+    assert.equal(result.session.events.some((item) => item.eventKind === 'tool_call'), false);
+    assert.deepEqual(
+      result.session.events.filter((item) => item.eventKind === 'usage').map((item) => item.inputTokens),
+      [2],
+    );
+    assert.equal(result.session.events.some((item) => item.sourceIndex > 0 && item.sourceIndex <= 10), false);
+    assert.equal(result.integrity.status, 'completed');
+    assert.equal(result.integrity.complete, true);
+  });
+
+  it('keeps an ordinary fork standalone outside subagent grouping semantics', () => {
+    const result = adaptDshSession(header('ordinary-fork', {
+      parentSession: 'source-session',
+      seedLength: 0,
+    }), completedEvents());
+    assert.equal(result.session.rootRunId, 'ordinary-fork');
+    assert.equal(result.session.parentRunId, undefined);
+    assert.equal(result.session.role, 'main');
+  });
+
   it('distinguishes runtime, skill-context, and synthetic user-role messages', () => {
     const result = adaptDshSession(header('origins'), [
       event(0, 'user/message', { content: [{ type: 'text', text: 'runtime' }], source: { kind: 'agent-instructions' } }),
@@ -202,6 +271,10 @@ describe('DSH Trace IR adapter', () => {
     assert.throws(
       () => adaptDshSession(header('gap'), [event(1, 'turn/start', { turn: 1 })]),
       /seq 不连续/,
+    );
+    assert.throws(
+      () => adaptDshSession(header('required-seed', { seedLength: 1 }), [event(0, 'plugin/required', {})]),
+      DshTraceUnsupportedEventError,
     );
   });
 
@@ -262,6 +335,42 @@ describe('DSH persistence observation', () => {
     assert.deepEqual(await listDshObserveCandidates(persistence), []);
   });
 
+  it('keeps ordinary forks independent while grouping their own durable subagents', async () => {
+    const persistence = persistenceWithGroup();
+    persistence.inspections.set('fork-session', {
+      meta: header('fork-session', {
+        parentSession: 'root-session',
+        createdAt: BASE_TIME + 20_000,
+      }),
+      events: completedEvents('普通 fork 任务'),
+    });
+    persistence.inspections.set('fork-child', {
+      meta: header('fork-child', {
+        parentSession: 'fork-session',
+        origin: 'subagent',
+        delegationDepth: 1,
+        createdAt: BASE_TIME + 20_250,
+      }),
+      events: completedEvents('fork 子任务'),
+    });
+
+    const rootGroup = await readDshObservedGroup(persistence, 'root-session');
+    assert.deepEqual(rootGroup.traces.map((item) => item.session.runId), [
+      'root-session',
+      'child-session',
+    ]);
+    const forkGroup = await readDshObservedGroup(persistence, 'fork-child');
+    assert.equal(forkGroup.rootSessionId, 'fork-session');
+    assert.deepEqual(forkGroup.traces.map((item) => item.session.runId), [
+      'fork-session',
+      'fork-child',
+    ]);
+    assert.deepEqual(forkGroup.traces.map((item) => item.session.role), ['main', 'subagent']);
+
+    const candidates = await listDshObserveCandidates(persistence);
+    assert.deepEqual(candidates.map((item) => item.sessionId), ['fork-session', 'root-session']);
+  });
+
   it('feeds the existing source-neutral Studio catalog', async () => {
     const group = await readDshObservedGroup(persistenceWithGroup(), 'root-session');
     const catalog = createDshConversationCatalog();
@@ -314,7 +423,7 @@ describe('DSH /omk observe command', () => {
     assert.equal(listed.kind, 'success');
     assert.match(listed.text ?? '', /root-session/);
     const observed = await handler({ ...invocation, rawInput: 'observe root-session' });
-    assert.equal(observed.kind, 'success');
+    assert.equal(observed.kind, 'success', observed.text);
     const url = /任务轨迹：(http:\/\/[^\s]+)/u.exec(observed.text ?? '')?.[1];
     assert.ok(url);
     const response = await fetch(url);

--- a/test/dsh-plugin/observe.test.ts
+++ b/test/dsh-plugin/observe.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, it } from 'vitest';
 import { apply } from '../../src/dsh-plugin/index.js';
 import {
   createDshConversationCatalog,
+  dshTraceIngestionSummary,
   listDshObserveCandidates,
   readDshObservedGroup,
   type DshPersistenceSnapshotLike,
@@ -84,7 +85,12 @@ function completedEvents(prompt = '检查任务轨迹'): DshSessionEventLike[] {
         }],
       },
     }),
-    event(6, 'assistant/message', {
+    event(6, 'assistant/chunk', {
+      turn: 1,
+      step: 1,
+      chunk: { type: 'text-delta', text: '任务已完成' },
+    }),
+    event(7, 'assistant/message', {
       turn: 1,
       step: 1,
       message: {
@@ -98,8 +104,8 @@ function completedEvents(prompt = '检查任务轨迹'): DshSessionEventLike[] {
       },
       usage: { inputTokens: 20, outputTokens: 8 },
     }),
-    event(7, 'step/end', { turn: 1, step: 1 }),
-    event(8, 'turn/end', { turn: 1, reason: { kind: 'completed' } }),
+    event(8, 'step/end', { turn: 1, step: 1 }),
+    event(9, 'turn/end', { turn: 1, reason: { kind: 'completed' } }),
   ];
 }
 
@@ -150,7 +156,7 @@ describe('DSH Trace IR adapter', () => {
       delegationDepth: 1,
     }), [
       ...completedEvents(),
-      event(9, 'plugin/telemetry-note', { note: 'safe to skip' }, { ignorable: true }),
+      event(10, 'plugin/telemetry-note', { note: 'safe to skip' }, { ignorable: true }),
     ], { rootRunId: 'root', role: 'subagent' });
 
     assert.equal(result.session.sourceKind, 'dsh');
@@ -162,6 +168,7 @@ describe('DSH Trace IR adapter', () => {
     assert.equal(result.integrity.status, 'completed');
     assert.equal(result.integrity.complete, true);
     assert.equal(result.integrity.unknownEventCount, 1);
+    assert.equal(result.integrity.ignoredChunkCount, 1);
     const user = result.session.events.find((item) => item.eventKind === 'message' && item.role === 'user');
     assert.equal(user?.eventKind, 'message');
     if (user?.eventKind === 'message') assert.equal(user.origin, 'human');
@@ -226,6 +233,14 @@ describe('DSH persistence observation', () => {
     const jsonl = await readDshObservedGroup(persistenceWithGroup(), 'root-session');
     const sqlite = await readDshObservedGroup(persistenceWithGroup(), 'root-session');
     assert.deepEqual(jsonl.traces.map((item) => item.session), sqlite.traces.map((item) => item.session));
+  });
+
+  it('counts consolidated assistant chunks as parsed logical records', async () => {
+    const group = await readDshObservedGroup(persistenceWithGroup(), 'root-session');
+    const ingestion = dshTraceIngestionSummary(group);
+    assert.equal(ingestion.parsedRecordCount, ingestion.sourceRecordCount);
+    assert.equal(ingestion.ignoredValueCount, 0);
+    assert.ok(group.traces.every((item) => item.integrity.ignoredChunkCount === 1));
   });
 
   it('lists terminal roots and excludes the current command session', async () => {

--- a/test/observability/trace-adapter.test.ts
+++ b/test/observability/trace-adapter.test.ts
@@ -3875,7 +3875,7 @@ describe('segmentBySkill', () => {
       ],
     });
 
-    const summaries = (['claude', 'codex', 'openclaw', 'unknown'] as const).map((sourceKind) => {
+    const summaries = (['claude', 'codex', 'dsh', 'openclaw', 'unknown'] as const).map((sourceKind) => {
       const segments = segmentBySkill(makeSession(sourceKind));
       return {
         skills: segments.map((segment) => segment.skillName),

--- a/test/renderer/trajectory-live.test.ts
+++ b/test/renderer/trajectory-live.test.ts
@@ -10,6 +10,7 @@ import {
 const labels: TrajectoryLiveLabels = {
   connecting: '连接中', live: '实时', syncing: '同步中', reconnecting: '重连中',
   failed: '实时更新失败',
+  taskFailed: '任务失败',
   following: '跟随中', resume: '跟随最新', pending: '查看更新', completed: '任务已结束',
   aborted: '任务已中止', interrupted: '任务已中断', unknown: '状态未知',
   pauseTitle: '暂停自动跟随',

--- a/test/server/report-server.test.ts
+++ b/test/server/report-server.test.ts
@@ -1090,11 +1090,11 @@ describe('report-server', () => {
     assert.equal(res.status, 404);
   });
 
-  it('GET / returns the Codex conversation overview', async () => {
+  it('GET / returns the conversation overview', async () => {
     const res = await fetch(`${baseUrl}/`);
     assert.equal(res.status, 200);
     assert.ok(res.headers['content-type']!.includes('text/html'));
-    assert.ok(res.body.includes('Codex 对话'));
+    assert.ok(res.body.includes('<title>OMK · 对话</title>'));
     assert.ok(res.body.includes('conversation-app-nav'));
     assert.ok(res.body.includes('<h1>对话</h1>'));
     assert.ok(res.body.includes('conversation-index-app'));


### PR DESCRIPTION
## 用户影响

DSH 用户现在可以留在当前宿主中，通过 /omk observe 列出最近已结束的任务，再通过 /omk observe <session-id> 打开对应的 OMK Studio 任务轨迹。OMK 直接只读使用 profile 已有的 sessionPersistence，无需用户导出或定位 JSONL、zstd、SQLite 文件；root 与子 agent 会按显式 lineage 合并展示。

## 迁移说明

现有 /omk eval 行为与配置不变。observe 是可选能力，仅在使用时要求当前 profile 提供 sessionPersistence；缺失时会返回明确提示。

## 边界与测量说明

首版只读取已结束 session 的一致离线快照，不实时跟随正在写入的任务。revision 持续变化、required 未知事件、事件序号断裂、任一 root／子 agent 生命周期未闭合或工具结果缺失时，OMK 不会宣称轨迹完整。本改动不改变 Report schema、评分管道或冻结评分类 prompt，不影响历史评测可比性。

Related to #409。