### PR TITLE
chore(release): 发布 0.54.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 OMK 0.54.0，将 DSH 宿主集成从受控评测扩展到真实任务轨迹观测：用户可以在现有 DSH profile 中通过 /omk observe 列出最近已结束的 session，并通过 /omk observe <session-id> 打开对应的 Studio 任务轨迹。

本版本同时补齐 DSH 社区发现元数据、README 首屏入口，以及 /omk／/omk help 的安装确认和使用引导。

## 迁移说明

无。现有 OMK CLI、/omk eval 和 DSH profile 配置保持兼容；observe 是可选能力，仅在使用时要求 profile 提供 sessionPersistence。

## 测量说明

DSH observe 首版读取已结束 session 的离线一致快照，不实时跟随正在写入的任务。损坏、持续变化或语义不完整的 trace 不会被表示为完整任务。本版本未修改评分管道、统计公式、Report schema 或冻结评分类 prompt，不构成 BREAKING-COMPARABILITY。

合并后需在 main 的合并提交上创建并单独推送 v0.54.0 tag，由 publish.yml 触发 npm Trusted Publishing。