### PR TITLE
feat(observe): 支持 ChatGPT 显式反馈采集

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ RAG-specific evals: see RAGAS (separate niche, complementary to omk). Full compa
 | **RAG metrics** | `faithfulness` / `answer_relevancy` / `context_recall` — anti-hallucination + answer relevance + context coverage |
 | **LLM health audit** | `omk doctor` grades 7 builtin dimensions; repeats the audit (`--repeat`) and merges findings by k/n consensus |
 | **Production observability** | normalize Codex, Claude Code, OpenClaw, and markdown logs into source-neutral Trace IR; measure per-skill outcomes / latency / token use / knowledge-gap signals |
+| **Explicit ChatGPT feedback capture (experimental)** | use an MCP tool to write user-authorized knowledge feedback into Observation Inbox in real time, always marked `coverage: partial` |
 | **Knowledge-gap detection** | severity-weighted signals quantify risk exposure instead of claiming completeness |
 | **Construct-validity isolation** | `--strict-baseline` (default ON) cuts three contamination channels so baseline doesn't silently see the skill it's being compared against |
 | **Git & remote sources** | install / eval from a local git ref or a remote git URL (`--git-url`); directory-skills run in a content-addressed **isolated copy** so `references/` assets are real measured input, not just `SKILL.md` |
@@ -195,6 +196,16 @@ Inside DSH:
 - `/omk observe <session-id>` reads a consistent snapshot and returns its Studio Task Trajectory URL.
 
 Observe uses the profile's `sessionPersistence` directly, so users do not export or locate JSONL / SQLite files. The first version is offline-only and does not live-follow a session that is still being written. See the [executor guide](docs/reference/executors.md#deepseek-harness-prefer-the-host-plugin) and [observe guide](docs/guides/observe-production.md#inspect-a-task-inside-deepseek-harness).
+
+### Connect ChatGPT (experimental)
+
+`omk-chatgpt-mcp` is a stdio MCP server. During local development, OpenAI's [Secure MCP Tunnel](https://developers.openai.com/plugins/build/mcp-server#secure-mcp-tunnel) can expose it to ChatGPT. It calls `capture_observation` only after the user explicitly asks to record feedback, appends the feedback and optional evidence under `.omk/observe-inbox/captures/`, and makes it available to `omk observe inbox` and Studio for review.
+
+```bash
+omk-chatgpt-mcp
+```
+
+This is not full-conversation monitoring. Every record carries `coverageStatus: partial`: OMK observes its tool boundary, submitted feedback, and optional evidence, but not the full conversation, other tool calls, or hidden reasoning. Conversation IDs, turn IDs, and idempotency keys are hashed rather than persisted verbatim.
 
 ## Documentation
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -167,6 +167,7 @@ RAG 专项评测请看 RAGAS（独立 niche，跟 omk 互补）。完整对比�
 | **RAG metrics** | `faithfulness` / `answer_relevancy` / `context_recall` 三 metric — 反幻觉 + 切题度 + context 覆盖 |
 | **LLM 健康度审计** | `omk doctor` 给 7 个内置维度独立打分；重复采样（`--repeat`）+ k/n 共识归并 |
 | **线上 session 观测** | 将 Codex、Claude Code、OpenClaw 与 markdown 日志统一为 source-neutral Trace IR，测量各 skill 的执行结果、耗时、token 使用和知识缺口信号 |
+| **ChatGPT 显式反馈采集（实验性）** | 通过 MCP 工具把用户明确授权的 knowledge 反馈实时写入 Observation Inbox，并固定标记 `coverage: partial` |
 | **知识缺口识别** | 严重度加权的信号量化风险敞口，不宣称完备性 |
 | **用例隔离 (construct validity)** | `--strict-baseline`（默认开）三堵 baseline 拿到被测 skill 的污染路径 |
 | **Git / 远端源** | install / eval 支持本地 git ref 或远端 git URL（`--git-url`）；目录-skill 在内容寻址**隔离副本**里执行，`references/` 资产是真实测量输入，不只是 `SKILL.md` |
@@ -195,6 +196,16 @@ dsh --profile web
 - `/omk observe <session-id>`：只读摄取一致快照，并返回 Studio 任务轨迹链接。
 
 observe 直接使用 profile 的 `sessionPersistence`，无需导出或定位 JSONL／SQLite 文件；首版不实时跟随正在写入的 session。详见[执行器文档](docs/zh/reference/executors.md#deepseek-harness优先使用宿主插件)与[观测指南](docs/zh/guides/observe-production.md#在-deepseek-harness-中查看任务轨迹)。
+
+### 连接 ChatGPT（实验性）
+
+`omk-chatgpt-mcp` 提供一个 stdio MCP Server；本地开发时可配合 OpenAI 的 [Secure MCP Tunnel](https://developers.openai.com/plugins/build/mcp-server#secure-mcp-tunnel) 接入 ChatGPT。它只在用户明确要求记录时调用 `capture_observation`，把反馈和可选证据追加到 `.omk/observe-inbox/captures/`；随后可用 `omk observe inbox` 或 Studio 复核。
+
+```bash
+omk-chatgpt-mcp
+```
+
+这不是完整对话监听。每条记录都固定携带 `coverageStatus: partial`：已观测的是 OMK 工具边界、用户提交的反馈及可选证据；未观测的是完整对话、其他工具调用和隐藏推理。对话 ID、turn ID 与幂等键只用于生成哈希，不会原样落盘。
 
 ## 文档
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",
   "bin": {
-    "omk": "dist/cli/index.js"
+    "omk": "dist/cli/index.js",
+    "omk-chatgpt-mcp": "dist/chatgpt-plugin/stdio.js"
   },
   "engines": {
     "node": ">=22"

--- a/src/chatgpt-plugin/mcp-server.ts
+++ b/src/chatgpt-plugin/mcp-server.ts
@@ -1,0 +1,97 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  captureExplicitObservation,
+  type ExplicitObservationCaptureOptions,
+} from '../observability/explicit-capture.js';
+
+const observedEventKindSchema = z.enum([
+  'tool_boundary',
+  'user_feedback',
+  'submitted_evidence',
+]);
+const unavailableEventKindSchema = z.enum([
+  'full_conversation',
+  'external_tool_calls',
+  'hidden_reasoning',
+]);
+
+export type ChatGptObservationMcpServerOptions = ExplicitObservationCaptureOptions;
+
+export function createChatGptObservationMcpServer(
+  options: ChatGptObservationMcpServerOptions = {},
+): McpServer {
+  const server = new McpServer({
+    name: 'omk-chatgpt-observation-capture',
+    version: '0.1.0',
+  });
+
+  server.registerTool('capture_observation', {
+    title: 'Capture an explicit OMK observation',
+    description: [
+      'Record knowledge feedback only after the user explicitly asks to save it.',
+      'This captures the submitted feedback and optional evidence at the OMK tool boundary.',
+      'It does not capture the full ChatGPT conversation, other tool calls, or hidden reasoning.',
+    ].join(' '),
+    inputSchema: {
+      skillName: z.string().trim().min(1).max(120)
+        .describe('OMK knowledge artifact or skill name under review.'),
+      userFeedback: z.string().trim().min(1).max(4_000)
+        .describe('The user-authorized knowledge issue or feedback to record.'),
+      evidenceSnippet: z.string().trim().min(1).max(8_000).optional()
+        .describe('Optional user-authorized excerpt supporting the feedback.'),
+      artifactVersion: z.string().trim().min(1).max(256).optional(),
+      artifactHash: z.string().trim().min(1).max(256).optional(),
+      cwd: z.string().trim().min(1).max(2_048).optional(),
+      sourceConversationId: z.string().trim().min(1).max(512).optional()
+        .describe('Optional opaque conversation identity used only for idempotency; OMK stores a hash.'),
+      sourceTurnId: z.string().trim().min(1).max(512).optional()
+        .describe('Optional opaque turn identity used only for idempotency; OMK stores a hash.'),
+      captureId: z.string().trim().min(1).max(512).optional()
+        .describe('Optional stable idempotency key. OMK stores a hash, not this raw value.'),
+      confirmedByUser: z.literal(true)
+        .describe('Must be true: the user explicitly requested that this feedback be recorded.'),
+    },
+    outputSchema: {
+      observationId: z.string(),
+      capturedAt: z.string(),
+      created: z.boolean(),
+      reviewPath: z.string(),
+      captureCoverage: z.object({
+        coverageStatus: z.literal('partial'),
+        capturePath: z.literal('explicit_tool_call'),
+        observedEventKinds: z.array(observedEventKindSchema),
+        unavailableEventKinds: z.array(unavailableEventKindSchema),
+      }),
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  }, async (input) => {
+    const result = captureExplicitObservation({
+      ...input,
+      captureSourceKind: 'chatgpt_plugin',
+    }, options);
+    const structuredContent = {
+      observationId: result.observationId,
+      capturedAt: result.capturedAt,
+      created: result.created,
+      reviewPath: result.reviewPath,
+      captureCoverage: result.captureCoverage,
+    };
+    return {
+      content: [{
+        type: 'text' as const,
+        text: result.created
+          ? '已记录显式 knowledge observation。覆盖范围为 partial：不包含完整对话、其他工具调用或隐藏推理。'
+          : '该 observation 已记录，本次按幂等键返回已有结果。覆盖范围仍为 partial。',
+      }],
+      structuredContent,
+    };
+  });
+
+  return server;
+}

--- a/src/chatgpt-plugin/stdio.ts
+++ b/src/chatgpt-plugin/stdio.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createChatGptObservationMcpServer } from './mcp-server.js';
+
+async function main(): Promise<void> {
+  const server = createChatGptObservationMcpServer();
+  await server.connect(new StdioServerTransport());
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+

--- a/src/chatgpt-plugin/stdio.ts
+++ b/src/chatgpt-plugin/stdio.ts
@@ -12,4 +12,3 @@ main().catch((error: unknown) => {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;
 });
-

--- a/src/observability/capture-coverage.ts
+++ b/src/observability/capture-coverage.ts
@@ -1,0 +1,46 @@
+import type { ObservationCaptureCoverage } from '../types/index.js';
+
+export function buildExplicitObservationCaptureCoverage(
+  hasSubmittedEvidence: boolean,
+): ObservationCaptureCoverage {
+  return {
+    coverageStatus: 'partial',
+    capturePath: 'explicit_tool_call',
+    observedEventKinds: [
+      'tool_boundary',
+      'user_feedback',
+      ...(hasSubmittedEvidence ? ['submitted_evidence' as const] : []),
+    ],
+    unavailableEventKinds: ['full_conversation', 'external_tool_calls', 'hidden_reasoning'],
+  };
+}
+
+export function isObservationCaptureCoverage(
+  value: unknown,
+): value is ObservationCaptureCoverage {
+  if (!isRecord(value)) return false;
+  const observed = value.observedEventKinds;
+  const unavailable = value.unavailableEventKinds;
+  return value.coverageStatus === 'partial'
+    && value.capturePath === 'explicit_tool_call'
+    && Array.isArray(observed)
+    && observed.length === new Set(observed).size
+    && observed.includes('tool_boundary')
+    && observed.includes('user_feedback')
+    && observed.every((item) =>
+      item === 'tool_boundary' || item === 'user_feedback' || item === 'submitted_evidence'
+    )
+    && Array.isArray(unavailable)
+    && unavailable.length === new Set(unavailable).size
+    && unavailable.includes('full_conversation')
+    && unavailable.includes('external_tool_calls')
+    && unavailable.includes('hidden_reasoning')
+    && unavailable.every((item) =>
+      item === 'full_conversation' || item === 'external_tool_calls' || item === 'hidden_reasoning'
+    );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+

--- a/src/observability/capture-coverage.ts
+++ b/src/observability/capture-coverage.ts
@@ -43,4 +43,3 @@ export function isObservationCaptureCoverage(
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
-

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -3498,7 +3498,16 @@ function observationEvidenceRef(item: ObservationInboxItem): ExperienceEvidenceR
     timestamp: item.evidence.segmentTimestamp,
     role: 'other',
     label: `${item.signalType}/${item.signalSubtype}`,
-    snippet: snippet(item.evidence.query || item.evidence.path || item.evidence.assistantSnippet || item.evidence.outputSnippet || item.evidence.markerToken, 700),
+    snippet: snippet(
+      item.evidence.userFeedbackSnippet
+      || item.evidence.submittedEvidenceSnippet
+      || item.evidence.query
+      || item.evidence.path
+      || item.evidence.assistantSnippet
+      || item.evidence.outputSnippet
+      || item.evidence.markerToken,
+      700,
+    ),
   };
 }
 

--- a/src/observability/explicit-capture.ts
+++ b/src/observability/explicit-capture.ts
@@ -1,0 +1,311 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type {
+  ObservationCaptureCoverage,
+  ObservationEvidence,
+  ObservationInboxItem,
+} from '../types/index.js';
+import { writeJsonFileAtomic } from '../shared/atomic-json.js';
+import { withFileLock } from '../shared/file-lock.js';
+import {
+  buildExplicitObservationCaptureCoverage,
+  isObservationCaptureCoverage,
+} from './capture-coverage.js';
+import { aggregateObservationInboxItemId } from './inbox-identity.js';
+import {
+  DEFAULT_GLOBAL_OBSERVATIONS_DIR,
+  DEFAULT_OBSERVATIONS_DIR,
+  DEFAULT_PROJECT_OBSERVATIONS_DIR,
+} from './observation-paths.js';
+
+const CAPTURE_SCHEMA_VERSION = 1;
+const CAPTURES_DIR_NAME = 'captures';
+const CAPTURE_FILE_SUFFIX = '.capture.json';
+
+export type ObservationCaptureSourceKind = 'chatgpt_plugin';
+
+export interface ExplicitObservationCaptureInput {
+  captureSourceKind: ObservationCaptureSourceKind;
+  skillName: string;
+  userFeedback: string;
+  evidenceSnippet?: string;
+  artifactVersion?: string;
+  artifactHash?: string;
+  cwd?: string;
+  sourceConversationId?: string;
+  sourceTurnId?: string;
+  captureId?: string;
+  confirmedByUser: boolean;
+}
+
+export interface ExplicitObservationCaptureOptions {
+  observationsDir?: string;
+  now?: () => Date;
+}
+
+export interface ExplicitObservationCaptureResult {
+  observationId: string;
+  capturedAt: string;
+  captureCoverage: ObservationCaptureCoverage;
+  reviewPath: string;
+  created: boolean;
+}
+
+export interface ExplicitObservationCaptureRecord {
+  captureKind: 'explicit_observation';
+  schemaVersion: 1;
+  captureId: string;
+  payloadHash: string;
+  capturedAt: string;
+  captureSourceKind: 'chatgpt_plugin';
+  skillName: string;
+  userFeedback: string;
+  evidenceSnippet?: string;
+  artifactVersion: string;
+  artifactHash?: string;
+  cwd?: string;
+  captureCoverage: ObservationCaptureCoverage;
+}
+
+export function captureExplicitObservation(
+  rawInput: ExplicitObservationCaptureInput,
+  options: ExplicitObservationCaptureOptions = {},
+): ExplicitObservationCaptureResult {
+  const input = normalizeCaptureInput(rawInput);
+  const observationsDir = options.observationsDir ?? DEFAULT_OBSERVATIONS_DIR;
+  const capturedAt = (options.now ?? (() => new Date()))().toISOString();
+  const payloadHash = hashJson({
+    skillName: input.skillName,
+    userFeedback: input.userFeedback,
+    evidenceSnippet: input.evidenceSnippet,
+    artifactVersion: input.artifactVersion,
+    artifactHash: input.artifactHash,
+    cwd: input.cwd,
+  });
+  const turnIdentity = [input.sourceConversationId, input.sourceTurnId]
+    .filter(Boolean)
+    .join('\u0000');
+  const sourceIdentity = `${input.captureSourceKind}\u0000${input.captureId ?? (turnIdentity || payloadHash)}`;
+  const captureId = hashText(`explicit-observation\u0000${sourceIdentity}`);
+  const captureCoverage = buildExplicitObservationCaptureCoverage(Boolean(input.evidenceSnippet));
+  const record: ExplicitObservationCaptureRecord = {
+    captureKind: 'explicit_observation',
+    schemaVersion: CAPTURE_SCHEMA_VERSION,
+    captureId,
+    payloadHash,
+    capturedAt,
+    captureSourceKind: input.captureSourceKind,
+    skillName: input.skillName,
+    userFeedback: input.userFeedback,
+    evidenceSnippet: input.evidenceSnippet,
+    artifactVersion: input.artifactVersion,
+    artifactHash: input.artifactHash,
+    cwd: input.cwd,
+    captureCoverage,
+  };
+  const recordPath = explicitCaptureRecordPath(observationsDir, captureId);
+
+  return withFileLock(`${recordPath}.lock`, () => {
+    const existing = loadExplicitObservationCaptureRecord(recordPath);
+    if (existing) {
+      if (existing.payloadHash !== payloadHash) {
+        throw new Error('captureId 或对话 turn identity 已用于不同的 observation payload。');
+      }
+      return captureResult(existing, false);
+    }
+    if (existsSync(recordPath)) {
+      throw new Error('目标 capture record 已存在但无法解析，拒绝覆盖。');
+    }
+    writeJsonFileAtomic(recordPath, record);
+    return captureResult(record, true);
+  }, { label: 'explicit observation capture' });
+}
+
+export function loadExplicitObservationCaptureRecords(
+  observationsDir: string = DEFAULT_OBSERVATIONS_DIR,
+): ExplicitObservationCaptureRecord[] {
+  const capturesDir = join(observationsDir, CAPTURES_DIR_NAME);
+  if (!existsSync(capturesDir)) {
+    if (
+      observationsDir === DEFAULT_PROJECT_OBSERVATIONS_DIR
+      && !existsSync(observationsDir)
+    ) return loadExplicitObservationCaptureRecords(DEFAULT_GLOBAL_OBSERVATIONS_DIR);
+    return [];
+  }
+  return readdirSync(capturesDir)
+    .filter((file) => file.endsWith(CAPTURE_FILE_SUFFIX))
+    .sort()
+    .flatMap((file) => {
+      const record = loadExplicitObservationCaptureRecord(join(capturesDir, file));
+      return record ? [record] : [];
+    });
+}
+
+export function loadExplicitObservationCaptureItems(
+  observationsDir: string = DEFAULT_OBSERVATIONS_DIR,
+): ObservationInboxItem[] {
+  return loadExplicitObservationCaptureRecords(observationsDir).map(projectCaptureRecord);
+}
+
+function explicitCaptureRecordPath(observationsDir: string, captureId: string): string {
+  return join(observationsDir, CAPTURES_DIR_NAME, `${captureId}${CAPTURE_FILE_SUFFIX}`);
+}
+
+function loadExplicitObservationCaptureRecord(path: string): ExplicitObservationCaptureRecord | null {
+  try {
+    return normalizeExplicitObservationCaptureRecord(JSON.parse(readFileSync(path, 'utf-8')));
+  } catch {
+    return null;
+  }
+}
+
+function normalizeExplicitObservationCaptureRecord(value: unknown): ExplicitObservationCaptureRecord | null {
+  if (!isRecord(value)) return null;
+  if (
+    value.captureKind !== 'explicit_observation'
+    || value.schemaVersion !== CAPTURE_SCHEMA_VERSION
+    || value.captureSourceKind !== 'chatgpt_plugin'
+    || !isBoundedText(value.captureId, 64)
+    || !isBoundedText(value.payloadHash, 64)
+    || !isIsoTimestamp(value.capturedAt)
+    || !isBoundedText(value.skillName, 120)
+    || !isBoundedText(value.userFeedback, 4_000)
+    || !isOptionalBoundedText(value.evidenceSnippet, 8_000)
+    || !isBoundedText(value.artifactVersion, 256)
+    || !isOptionalBoundedText(value.artifactHash, 256)
+    || !isOptionalBoundedText(value.cwd, 2_048)
+    || !isObservationCaptureCoverage(value.captureCoverage)
+  ) return null;
+  return value as unknown as ExplicitObservationCaptureRecord;
+}
+
+interface NormalizedCaptureInput {
+  captureSourceKind: ObservationCaptureSourceKind;
+  skillName: string;
+  userFeedback: string;
+  evidenceSnippet?: string;
+  artifactVersion: string;
+  artifactHash?: string;
+  cwd?: string;
+  sourceConversationId?: string;
+  sourceTurnId?: string;
+  captureId?: string;
+}
+
+function normalizeCaptureInput(input: ExplicitObservationCaptureInput): NormalizedCaptureInput {
+  if (input.confirmedByUser !== true) {
+    throw new Error('只有用户明确要求记录时，才能 capture observation。');
+  }
+  return {
+    captureSourceKind: normalizeCaptureSourceKind(input.captureSourceKind),
+    skillName: requiredText(input.skillName, 'skillName', 120),
+    userFeedback: requiredText(input.userFeedback, 'userFeedback', 4_000),
+    evidenceSnippet: optionalText(input.evidenceSnippet, 'evidenceSnippet', 8_000),
+    artifactVersion: optionalText(input.artifactVersion, 'artifactVersion', 256) ?? 'unknown',
+    artifactHash: optionalText(input.artifactHash, 'artifactHash', 256),
+    cwd: optionalText(input.cwd, 'cwd', 2_048),
+    sourceConversationId: optionalText(input.sourceConversationId, 'sourceConversationId', 512),
+    sourceTurnId: optionalText(input.sourceTurnId, 'sourceTurnId', 512),
+    captureId: optionalText(input.captureId, 'captureId', 512),
+  };
+}
+
+function normalizeCaptureSourceKind(value: unknown): ObservationCaptureSourceKind {
+  if (value !== 'chatgpt_plugin') throw new Error('不支持的 captureSourceKind。');
+  return value;
+}
+
+function requiredText(value: unknown, field: string, maxLength: number): string {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${field} 不能为空。`);
+  const normalized = value.trim();
+  if (normalized.length > maxLength) throw new Error(`${field} 不能超过 ${maxLength} 个字符。`);
+  return normalized;
+}
+
+function optionalText(value: unknown, field: string, maxLength: number): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  return requiredText(value, field, maxLength);
+}
+
+function projectCaptureRecord(record: ExplicitObservationCaptureRecord): ObservationInboxItem {
+  const sessionId = `explicit-capture:${record.captureId}`;
+  const sourceTrace = `chatgpt-plugin:${record.captureId}`;
+  const evidence: ObservationEvidence = {
+    traceId: record.captureId,
+    sessionId,
+    sourceTrace,
+    sourceKind: 'unknown',
+    markerToken: `user-feedback:${hashText(record.userFeedback)}`,
+    userFeedbackSnippet: record.userFeedback,
+    submittedEvidenceSnippet: record.evidenceSnippet,
+    callInstanceId: record.captureId,
+    segmentTimestamp: record.capturedAt,
+  };
+  return {
+    id: hashText(`capture-occurrence\u0000${record.captureId}`),
+    skillName: record.skillName,
+    artifactVersion: record.artifactVersion,
+    artifactHash: record.artifactHash,
+    cwd: record.cwd,
+    sessionId,
+    traceId: record.captureId,
+    sourceTrace,
+    sourceKind: 'unknown',
+    signalType: 'user_feedback',
+    signalSubtype: 'explicit_user_feedback',
+    confidence: 0.9,
+    attributionConfidence: 0.8,
+    severity: 'high',
+    severityReasonCode: 'user_reported_knowledge_issue',
+    captureCoverage: record.captureCoverage,
+    evidence,
+    firstSeen: record.capturedAt,
+    lastSeen: record.capturedAt,
+    occurrences: 1,
+    timestampedOccurrences: 1,
+    recentSessionIds: [sessionId],
+    recentTraceIds: [record.captureId],
+    representativeEvidence: [evidence],
+  };
+}
+
+function captureResult(
+  record: ExplicitObservationCaptureRecord,
+  created: boolean,
+): ExplicitObservationCaptureResult {
+  const item = projectCaptureRecord(record);
+  return {
+    observationId: aggregateObservationInboxItemId(item),
+    capturedAt: record.capturedAt,
+    captureCoverage: record.captureCoverage,
+    reviewPath: `/observe-inbox?skill=${encodeURIComponent(record.skillName)}`,
+    created,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isBoundedText(value: unknown, maxLength: number): value is string {
+  return typeof value === 'string' && Boolean(value.trim()) && value.length <= maxLength;
+}
+
+function isOptionalBoundedText(value: unknown, maxLength: number): boolean {
+  return value === undefined || isBoundedText(value, maxLength);
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  return typeof value === 'string'
+    && !Number.isNaN(Date.parse(value))
+    && new Date(value).toISOString() === value;
+}
+
+function hashJson(value: unknown): string {
+  return hashText(JSON.stringify(value));
+}
+
+function hashText(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 24);
+}

--- a/src/observability/inbox-identity.ts
+++ b/src/observability/inbox-identity.ts
@@ -51,4 +51,3 @@ export function aggregateObservationInboxItemId(item: ObservationIdentityInput):
     .digest('hex')
     .slice(0, 16);
 }
-

--- a/src/observability/inbox-identity.ts
+++ b/src/observability/inbox-identity.ts
@@ -1,0 +1,54 @@
+import { createHash } from 'node:crypto';
+import type { ObservationInboxItem } from '../types/index.js';
+
+type ObservationIdentityInput = Pick<
+  ObservationInboxItem,
+  'skillName' | 'cwd' | 'sourceKind' | 'signalType' | 'signalSubtype' | 'evidence'
+>;
+
+export function normalizeObservationKeyInput(value: unknown): string {
+  const raw = typeof value === 'string'
+    ? value
+    : value === null || value === undefined
+      ? ''
+      : typeof value === 'object'
+        ? JSON.stringify(value)
+        : String(value);
+  const trimmed = raw.trim();
+  const protocolMatch = trimmed.match(/^([a-z][a-z0-9+.-]*:\/\/)(.*)$/i);
+  const prefix = protocolMatch?.[1] ?? '';
+  const body = protocolMatch?.[2] ?? trimmed;
+  return (prefix + body
+    .toLowerCase()
+    .replace(/^['"`]|['"`]$/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/:\d+(:\d+)?\b/g, '')
+    .replace(/\/+/g, '/')
+    .replace(/\/$/, ''));
+}
+
+export function observationInboxItemKey(item: ObservationIdentityInput): string {
+  const raw = item.signalSubtype === 'bash_probe'
+    ? 'bash_probe'
+    : item.signalType === 'user_feedback'
+      ? item.evidence.markerToken || item.evidence.userFeedbackSnippet || item.signalSubtype
+      : item.signalType === 'explicit_marker'
+        ? item.evidence.markerToken || item.signalSubtype
+        : item.evidence.query || item.evidence.path || item.evidence.assistantSnippet || '';
+  return [
+    item.sourceKind,
+    item.skillName,
+    item.cwd ?? '',
+    item.signalType,
+    item.signalSubtype,
+    normalizeObservationKeyInput(raw),
+  ].join('\u0000');
+}
+
+export function aggregateObservationInboxItemId(item: ObservationIdentityInput): string {
+  return createHash('sha256')
+    .update(`aggregate\u0000${observationInboxItemKey(item)}`)
+    .digest('hex')
+    .slice(0, 16);
+}
+

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -1,12 +1,12 @@
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { OMK_HOME } from '../eval-core/default-dirs.js';
 import { isReportFileName, randomRunToken, reportFilePath } from '../eval-core/artifact-file-names.js';
 import { migrateLegacyReportFiles } from '../eval-core/report-file-migration.js';
 import type {
   BuildObservationInboxReportOptions,
   GapSignalRef,
+  ObservationCaptureCoverage,
   ObservationEvidence,
   ObservationExperienceReport,
   ObservationInboxItem,
@@ -54,9 +54,28 @@ import { createTraceSessionIndex, traceSessionRefIdentity } from './trace-sessio
 import { isInstalledSkillAssetPath } from './trace-attribution.js';
 import { writeJsonFileAtomic } from '../shared/atomic-json.js';
 import { writeObservationSourceRecordArchives } from './source-record-archive.js';
+import { loadExplicitObservationCaptureItems } from './explicit-capture.js';
+import { isObservationCaptureCoverage } from './capture-coverage.js';
+import {
+  normalizeObservationKeyInput,
+  observationInboxItemKey,
+} from './inbox-identity.js';
+import {
+  DEFAULT_GLOBAL_OBSERVATIONS_DIR,
+  DEFAULT_OBSERVATIONS_DIR,
+  DEFAULT_PROJECT_OBSERVATIONS_DIR,
+} from './observation-paths.js';
+
+export {
+  DEFAULT_GLOBAL_OBSERVATIONS_DIR,
+  DEFAULT_OBSERVATIONS_DIR,
+  DEFAULT_PROJECT_OBSERVATIONS_DIR,
+  normalizeObservationKeyInput,
+};
 
 export type {
   BuildObservationInboxReportOptions,
+  ObservationCaptureCoverage,
   ObservationEvidence,
   ObservationInboxItem,
   ObservationInboxReport,
@@ -77,35 +96,11 @@ export type PersistedObservationInboxReport = Omit<ObservationInboxReport, 'expe
 // observe inbox（观测收件箱）产物根目录。导出名沿用 *_OBSERVATIONS_DIR 以少动 importer,
 // 但落盘目录已统一到 observe-inbox 词根(命令 omk observe inbox / kind observe-inbox)。
 // 项目级 .omk/observe-inbox 优先、全局兜底 —— 这套 project/global 归属是既有正常行为,本次只改名不改归属。
-export const DEFAULT_PROJECT_OBSERVATIONS_DIR = join(process.cwd(), '.omk', 'observe-inbox');
-export const DEFAULT_GLOBAL_OBSERVATIONS_DIR = join(OMK_HOME, 'observe-inbox');
-export const DEFAULT_OBSERVATIONS_DIR = DEFAULT_PROJECT_OBSERVATIONS_DIR;
 const OBSERVATION_INBOX_SCHEMA_VERSION = 2;
 const UNOBSERVED_TIMESTAMP = '1970-01-01T00:00:00.000Z';
 
 function hashString(input: string): string {
   return createHash('sha256').update(input).digest('hex').slice(0, 16);
-}
-
-export function normalizeObservationKeyInput(value: unknown): string {
-  const raw = typeof value === 'string'
-    ? value
-    : value === null || value === undefined
-      ? ''
-      : typeof value === 'object'
-        ? JSON.stringify(value)
-        : String(value);
-  const trimmed = raw.trim();
-  const protocolMatch = trimmed.match(/^([a-z][a-z0-9+.-]*:\/\/)(.*)$/i);
-  const prefix = protocolMatch?.[1] ?? '';
-  const body = protocolMatch?.[2] ?? trimmed;
-  return (prefix + body
-    .toLowerCase()
-    .replace(/^['"`]|['"`]$/g, '')
-    .replace(/\s+/g, ' ')
-    .replace(/:\d+(:\d+)?\b/g, '')
-    .replace(/\/+/g, '/')
-    .replace(/\/$/, ''));
 }
 
 /** Legacy migration only. New reports take sourceKind from Trace IR. */
@@ -116,22 +111,6 @@ export function inferObservationSourceKind(sourceTrace: string): ObservationSour
   if (/(?:^|\/)\.?claude(?:\/|$)/.test(normalized)) return 'claude';
   if (normalized.endsWith('.log')) return 'markdown_log';
   return 'unknown';
-}
-
-function keyFor(item: Pick<ObservationInboxItem, 'skillName' | 'cwd' | 'sourceKind' | 'signalType' | 'signalSubtype' | 'evidence'>): string {
-  const raw = item.signalSubtype === 'bash_probe'
-    ? 'bash_probe'
-    : item.signalType === 'explicit_marker'
-    ? item.evidence.markerToken || item.signalSubtype
-    : item.evidence.query || item.evidence.path || item.evidence.assistantSnippet || '';
-  return [
-    item.sourceKind,
-    item.skillName,
-    item.cwd ?? '',
-    item.signalType,
-    item.signalSubtype,
-    normalizeObservationKeyInput(raw),
-  ].join('\u0000');
 }
 
 function markerTokenFromSignal(signal: GapSignalRef): string {
@@ -248,7 +227,7 @@ function confidenceForSubtype(subtype: ObservationSignalSubtype, signal?: GapSig
 }
 
 function severityFor(signalType: ObservationSignalType, subtype: ObservationSignalSubtype, confidence: number): ObservationInboxItem['severity'] {
-  if (signalType === 'repeated_failure' || signalType === 'explicit_marker') return 'high';
+  if (signalType === 'repeated_failure' || signalType === 'explicit_marker' || signalType === 'user_feedback') return 'high';
   if (subtype === 'hard_miss') return 'high';
   if (signalType === 'hedging' && confidence >= 0.7) return 'high';
   if (subtype === 'exploratory_miss' || subtype === 'bash_probe') return 'medium';
@@ -292,6 +271,7 @@ const SEVERITY_REASON_ZH: Record<ObservationSeverityReasonCode, string> = {
   exploratory_probe: 'skill 运行过程中出现了试路径、试目录或前序失败后后续成功的行为；先抽样确认，不直接判为要改 skill。',
   skill_asset_unavailable: '读取该 skill 自身资源失败，可能是路径错位、资源未提交或 ignore 配置问题。',
   soft_hedging_signal: '模型文本里出现了不确定表达，属于低置信文本信号，需要结合上下文人工判断。',
+  user_reported_knowledge_issue: '用户明确提交了真实使用中的 knowledge 问题；当前只保留用户授权提交的部分证据，需人工复核后再进入样本集。',
   tool_or_runtime_noise: '更像路径、权限、文件太大、临时文件或工具运行问题；通常不作为 skill 内容缺失。',
 };
 
@@ -302,6 +282,7 @@ const SEVERITY_REASON_EN: Record<ObservationSeverityReasonCode, string> = {
   exploratory_probe: 'The event looks like path probing, directory probing, or an earlier miss followed by later success; sample it before changing the skill.',
   skill_asset_unavailable: 'The agent failed to read an asset inside the skill itself; check path alignment, committed resources, or ignore rules.',
   soft_hedging_signal: 'The agent used uncertain wording; treat this as a low-confidence text signal.',
+  user_reported_knowledge_issue: 'The user explicitly submitted a knowledge issue from real usage; only the authorized partial evidence is retained until human review.',
   tool_or_runtime_noise: 'This looks like a path, permission, token limit, transient file, or runtime tool issue rather than missing skill content.',
 };
 
@@ -331,6 +312,7 @@ export function legacySeverityReasonFor(item: Pick<ObservationInboxItem, 'signal
 }
 
 export function severityReasonCodeFor(item: Pick<ObservationInboxItem, 'signalType' | 'signalSubtype' | 'severity' | 'confidence'>): ObservationSeverityReasonCode {
+  if (item.signalType === 'user_feedback') return 'user_reported_knowledge_issue';
   if (item.signalSubtype === 'repeated_failure') return 'repeated_failure_suspected';
   if (item.signalType === 'explicit_marker') return 'explicit_gap_marker';
   if (item.signalSubtype === 'hard_miss') return 'knowledge_gap_suspected';
@@ -542,7 +524,7 @@ export function buildObservationInboxReportFromTraceSessions(
   // 中解析，同时保留本次发生的 trace/session/timestamp 作为归因事实。
   const experienceItems = occurrenceItems.map((item) => ({
     ...item,
-    id: aggregationState.byKey.get(keyFor(item))?.id ?? item.id,
+    id: aggregationState.byKey.get(observationInboxItemKey(item))?.id ?? item.id,
   }));
   const experience = buildObservationExperienceReport({
     sessions,
@@ -596,7 +578,7 @@ function createInboxAggregationState(): InboxAggregationState {
 
 function addInboxItemsToState(state: InboxAggregationState, items: ObservationInboxItem[]): void {
   for (const item of items) {
-    const key = keyFor(item);
+    const key = observationInboxItemKey(item);
     const sessionLastSeen = state.sessionLastSeenByKey.get(key) ?? new Map<string, string>();
     const traceLastSeen = state.traceLastSeenByKey.get(key) ?? new Map<string, string>();
     const traceIdentity = item.traceId
@@ -665,6 +647,7 @@ function addInboxItemsToState(state: InboxAggregationState, items: ObservationIn
       replaceOptionalProperty(existing, 'messageWindow', item.messageWindow);
       replaceOptionalProperty(existing, 'traceId', item.traceId);
       replaceOptionalProperty(existing, 'cwd', item.cwd);
+      replaceOptionalProperty(existing, 'captureCoverage', item.captureCoverage);
     }
     existing.confidence = Math.max(existing.confidence, item.confidence);
     existing.attributionConfidence = Math.max(existing.attributionConfidence, item.attributionConfidence);
@@ -732,6 +715,8 @@ function observationEvidenceIdentity(value: ObservationEvidence): string {
     value.path ?? '',
     value.outputSnippet ?? '',
     value.assistantSnippet ?? '',
+    value.userFeedbackSnippet ?? '',
+    value.submittedEvidenceSnippet ?? '',
     value.markerToken ?? '',
     value.messageIndex ?? null,
     value.messageUuid ?? '',
@@ -1189,6 +1174,10 @@ function isObservationInboxItem(value: unknown): value is ObservationInboxItem {
       && !isObservationSeverityReasonCode(value.severityReasonCode)
     )
     || (value.severityReason !== undefined && typeof value.severityReason !== 'string')
+    || (
+      value.captureCoverage !== undefined
+      && !isObservationCaptureCoverage(value.captureCoverage)
+    )
     || !isObservationEvidence(value.evidence)
     || !isInboxTimestampRange(value.firstSeen, value.lastSeen)
     || !isInboxCount(value.occurrences)
@@ -1234,6 +1223,8 @@ function isObservationEvidence(value: unknown): boolean {
     value.path,
     value.outputSnippet,
     value.assistantSnippet,
+    value.userFeedbackSnippet,
+    value.submittedEvidenceSnippet,
     value.markerToken,
     value.messageUuid,
     value.callInstanceId,
@@ -1281,7 +1272,8 @@ function isObservationSignalType(value: unknown): value is ObservationSignalType
   return value === 'failed_search'
     || value === 'repeated_failure'
     || value === 'hedging'
-    || value === 'explicit_marker';
+    || value === 'explicit_marker'
+    || value === 'user_feedback';
 }
 
 function isObservationSignalSubtype(value: unknown): value is ObservationSignalSubtype {
@@ -1299,7 +1291,8 @@ function isObservationSignalSubtype(value: unknown): value is ObservationSignalS
     || value === 'tool_failure'
     || value === 'regex_only'
     || value === 'llm_classified'
-    || value === 'marker';
+    || value === 'marker'
+    || value === 'explicit_user_feedback';
 }
 
 function isObservationSeverity(value: unknown): boolean {
@@ -1313,6 +1306,7 @@ function isObservationSeverityReasonCode(value: unknown): boolean {
     || value === 'exploratory_probe'
     || value === 'skill_asset_unavailable'
     || value === 'soft_hedging_signal'
+    || value === 'user_reported_knowledge_issue'
     || value === 'tool_or_runtime_noise';
 }
 
@@ -1394,7 +1388,10 @@ export function loadLatestObservationInboxReports(dir: string = DEFAULT_OBSERVAT
 
 export function queryObservationInbox(dir: string = DEFAULT_OBSERVATIONS_DIR): ObservationInboxItem[] {
   const reports = loadLatestObservationInboxReports(dir);
-  return aggregateInboxItems(reports.flatMap((report) => report.items));
+  return aggregateInboxItems([
+    ...reports.flatMap((report) => report.items),
+    ...loadExplicitObservationCaptureItems(dir),
+  ]);
 }
 
 export function summarizeObservationInboxBySkill(
@@ -1449,7 +1446,10 @@ export function findObservationInboxItem(id: string, dir: string = DEFAULT_OBSER
   for (const item of [...reports].reverse().flatMap((report) => report.items)) {
     if (item.id === id) return item;
   }
-  return aggregateInboxItems(reports.flatMap((report) => report.items)).find((item) => item.id === id) ?? null;
+  return aggregateInboxItems([
+    ...reports.flatMap((report) => report.items),
+    ...loadExplicitObservationCaptureItems(dir),
+  ]).find((item) => item.id === id) ?? null;
 }
 
 export function buildObservationMessageWindow(
@@ -1504,6 +1504,19 @@ export function formatObservationShow(item: ObservationInboxItem): string {
     item.severityReasonCode ? `reason=${item.severityReasonCode}` : '',
     '',
   ].filter(Boolean);
+  if (item.captureCoverage) {
+    lines.push(
+      `coverage=${item.captureCoverage.coverageStatus} capture=${item.captureCoverage.capturePath}`,
+      `observed=${item.captureCoverage.observedEventKinds.join(',')}`,
+      `unavailable=${item.captureCoverage.unavailableEventKinds.join(',')}`,
+    );
+  }
+  if (item.evidence.userFeedbackSnippet) {
+    lines.push(`userFeedback=${item.evidence.userFeedbackSnippet}`);
+  }
+  if (item.evidence.submittedEvidenceSnippet) {
+    lines.push(`submittedEvidence=${item.evidence.submittedEvidenceSnippet}`);
+  }
   if (!window) {
     lines.push('No message window available for this observation.');
     return lines.join('\n');

--- a/src/observability/observation-paths.ts
+++ b/src/observability/observation-paths.ts
@@ -1,0 +1,7 @@
+import { join } from 'node:path';
+import { OMK_HOME } from '../eval-core/default-dirs.js';
+
+export const DEFAULT_PROJECT_OBSERVATIONS_DIR = join(process.cwd(), '.omk', 'observe-inbox');
+export const DEFAULT_GLOBAL_OBSERVATIONS_DIR = join(OMK_HOME, 'observe-inbox');
+export const DEFAULT_OBSERVATIONS_DIR = DEFAULT_PROJECT_OBSERVATIONS_DIR;
+

--- a/src/observability/observation-paths.ts
+++ b/src/observability/observation-paths.ts
@@ -4,4 +4,3 @@ import { OMK_HOME } from '../eval-core/default-dirs.js';
 export const DEFAULT_PROJECT_OBSERVATIONS_DIR = join(process.cwd(), '.omk', 'observe-inbox');
 export const DEFAULT_GLOBAL_OBSERVATIONS_DIR = join(OMK_HOME, 'observe-inbox');
 export const DEFAULT_OBSERVATIONS_DIR = DEFAULT_PROJECT_OBSERVATIONS_DIR;
-

--- a/src/types/observability.ts
+++ b/src/types/observability.ts
@@ -211,7 +211,7 @@ export interface SkillChainAdvisory {
 
 // ---------- inbox ----------
 
-export type ObservationSignalType = 'failed_search' | 'repeated_failure' | 'hedging' | 'explicit_marker';
+export type ObservationSignalType = 'failed_search' | 'repeated_failure' | 'hedging' | 'explicit_marker' | 'user_feedback';
 /** @deprecated Prefer TraceSourceKind for new source-neutral APIs. */
 export type ObservationSourceKind = TraceSourceKind;
 export type ObservationSeverityReasonCode =
@@ -221,6 +221,7 @@ export type ObservationSeverityReasonCode =
   | 'exploratory_probe'
   | 'skill_asset_unavailable'
   | 'soft_hedging_signal'
+  | 'user_reported_knowledge_issue'
   | 'tool_or_runtime_noise';
 export type ObservationSignalSubtype =
   | 'hard_miss'
@@ -237,7 +238,25 @@ export type ObservationSignalSubtype =
   | 'tool_failure'
   | 'regex_only'
   | 'llm_classified'
-  | 'marker';
+  | 'marker'
+  | 'explicit_user_feedback';
+
+export type ObservationCaptureObservedEventKind =
+  | 'tool_boundary'
+  | 'user_feedback'
+  | 'submitted_evidence';
+
+export type ObservationCaptureUnavailableEventKind =
+  | 'full_conversation'
+  | 'external_tool_calls'
+  | 'hidden_reasoning';
+
+export interface ObservationCaptureCoverage {
+  coverageStatus: 'partial';
+  capturePath: 'explicit_tool_call';
+  observedEventKinds: ObservationCaptureObservedEventKind[];
+  unavailableEventKinds: ObservationCaptureUnavailableEventKind[];
+}
 
 export interface ObservationEvidence {
   traceId?: string;
@@ -249,6 +268,8 @@ export interface ObservationEvidence {
   path?: string;
   outputSnippet?: string;
   assistantSnippet?: string;
+  userFeedbackSnippet?: string;
+  submittedEvidenceSnippet?: string;
   markerToken?: string;
   messageIndex?: number;
   messageUuid?: string;
@@ -290,6 +311,7 @@ export interface ObservationInboxItem {
   severity: 'high' | 'medium' | 'low' | 'noise';
   severityReasonCode?: ObservationSeverityReasonCode;
   severityReason?: string;
+  captureCoverage?: ObservationCaptureCoverage;
   evidence: ObservationEvidence;
   messageWindow?: ObservationMessageWindow;
   firstSeen: string;

--- a/test/chatgpt-plugin/mcp-server.test.ts
+++ b/test/chatgpt-plugin/mcp-server.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { describe, it } from 'vitest';
+import { createChatGptObservationMcpServer } from '../../src/chatgpt-plugin/mcp-server.js';
+import { queryObservationInbox } from '../../src/observability/inbox.js';
+
+describe('ChatGPT observation MCP server', () => {
+  it('advertises a focused, accurately annotated capture tool', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-chatgpt-mcp-list-'));
+    const server = createChatGptObservationMcpServer({ observationsDir: dir });
+    const client = new Client({ name: 'omk-test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      const tools = await client.listTools();
+      assert.equal(tools.tools.length, 1);
+      const [tool] = tools.tools;
+      assert.equal(tool.name, 'capture_observation');
+      assert.deepEqual(tool.annotations, {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+      assert.equal(tool.inputSchema.required?.includes('confirmedByUser'), true);
+      assert.ok(tool.outputSchema);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('captures authorized feedback and returns explicit partial coverage', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-chatgpt-mcp-call-'));
+    const server = createChatGptObservationMcpServer({
+      observationsDir: dir,
+      now: () => new Date('2026-08-24T02:03:04.000Z'),
+    });
+    const client = new Client({ name: 'omk-test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      const response = await client.callTool({
+        name: 'capture_observation',
+        arguments: {
+          skillName: 'omk',
+          userFeedback: '报告需要解释 coverage: partial。',
+          evidenceSnippet: '用户询问 partial 的含义。',
+          captureId: 'mcp-call-1',
+          confirmedByUser: true,
+        },
+      });
+      assert.notEqual(response.isError, true);
+      const structuredContent = response.structuredContent as Record<string, unknown> | undefined;
+      assert.deepEqual(structuredContent?.captureCoverage, {
+        coverageStatus: 'partial',
+        capturePath: 'explicit_tool_call',
+        observedEventKinds: ['tool_boundary', 'user_feedback', 'submitted_evidence'],
+        unavailableEventKinds: ['full_conversation', 'external_tool_calls', 'hidden_reasoning'],
+      });
+      assert.equal(queryObservationInbox(dir)[0]?.evidence.userFeedbackSnippet, '报告需要解释 coverage: partial。');
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('rejects calls without explicit confirmation', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-chatgpt-mcp-reject-'));
+    const server = createChatGptObservationMcpServer({ observationsDir: dir });
+    const client = new Client({ name: 'omk-test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      const response = await client.callTool({
+        name: 'capture_observation',
+        arguments: {
+          skillName: 'omk',
+          userFeedback: '不应落盘。',
+          confirmedByUser: false,
+        },
+      });
+      assert.equal(response.isError, true);
+      assert.equal(queryObservationInbox(dir).length, 0);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/test/observability/explicit-capture.test.ts
+++ b/test/observability/explicit-capture.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'vitest';
+import {
+  captureExplicitObservation,
+  loadExplicitObservationCaptureRecords,
+} from '../../src/observability/explicit-capture.js';
+import {
+  findObservationInboxItem,
+  formatObservationShow,
+  loadLatestObservationInboxReports,
+  queryObservationInbox,
+  saveObservationInboxReport,
+} from '../../src/observability/inbox.js';
+import { baseItem } from './inbox/_helpers.js';
+
+describe('explicit observation capture', () => {
+  it('persists an append-only record and projects it into the inbox', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-explicit-capture-'));
+    const result = captureExplicitObservation({
+      captureSourceKind: 'chatgpt_plugin',
+      skillName: 'docs-skill',
+      userFeedback: '这个回答遗漏了升级步骤。',
+      evidenceSnippet: '用户要求从 1.x 升级到 2.x。',
+      artifactVersion: '2.0.0',
+      captureId: 'capture-1',
+      confirmedByUser: true,
+    }, {
+      observationsDir: dir,
+      now: () => new Date('2026-08-24T01:02:03.000Z'),
+    });
+
+    assert.equal(result.created, true);
+    assert.equal(result.captureCoverage.coverageStatus, 'partial');
+    assert.deepEqual(result.captureCoverage.observedEventKinds, [
+      'tool_boundary',
+      'user_feedback',
+      'submitted_evidence',
+    ]);
+    assert.deepEqual(result.captureCoverage.unavailableEventKinds, [
+      'full_conversation',
+      'external_tool_calls',
+      'hidden_reasoning',
+    ]);
+    assert.equal(loadLatestObservationInboxReports(dir).length, 0);
+
+    const [item] = queryObservationInbox(dir);
+    assert.ok(item);
+    assert.equal(item.id, result.observationId);
+    assert.equal(item.signalType, 'user_feedback');
+    assert.equal(item.signalSubtype, 'explicit_user_feedback');
+    assert.equal(item.evidence.userFeedbackSnippet, '这个回答遗漏了升级步骤。');
+    assert.equal(item.evidence.submittedEvidenceSnippet, '用户要求从 1.x 升级到 2.x。');
+    assert.equal(findObservationInboxItem(result.observationId, dir)?.id, result.observationId);
+    assert.match(formatObservationShow(item), /coverage=partial capture=explicit_tool_call/);
+    assert.match(formatObservationShow(item), /unavailable=full_conversation,external_tool_calls,hidden_reasoning/);
+    assert.match(formatObservationShow(item), /userFeedback=这个回答遗漏了升级步骤。/);
+  });
+
+  it('is idempotent and rejects identity reuse with another payload', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-explicit-capture-idempotency-'));
+    const input = {
+      captureSourceKind: 'chatgpt_plugin',
+      skillName: 'demo-skill',
+      userFeedback: '缺少边界条件。',
+      captureId: 'stable-tool-call-id',
+      confirmedByUser: true,
+    } as const;
+    const first = captureExplicitObservation(input, { observationsDir: dir });
+    const second = captureExplicitObservation(input, { observationsDir: dir });
+
+    assert.equal(first.created, true);
+    assert.equal(second.created, false);
+    assert.equal(second.observationId, first.observationId);
+    assert.equal(loadExplicitObservationCaptureRecords(dir).length, 1);
+    assert.throws(
+      () => captureExplicitObservation({
+        ...input,
+        userFeedback: '同一个 identity 下的另一条反馈。',
+      }, { observationsDir: dir }),
+      /已用于不同的 observation payload/,
+    );
+  });
+
+  it('requires explicit user confirmation', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-explicit-capture-confirmation-'));
+    assert.throws(
+      () => captureExplicitObservation({
+        captureSourceKind: 'chatgpt_plugin',
+        skillName: 'demo-skill',
+        userFeedback: '不应被记录。',
+        confirmedByUser: false,
+      }, { observationsDir: dir }),
+      /用户明确要求记录/,
+    );
+  });
+
+  it('keeps trace reports unchanged and ignores malformed capture records', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-explicit-capture-projection-'));
+    saveObservationInboxReport({
+      kind: 'observe-inbox',
+      schemaVersion: 2,
+      meta: {
+        tracePath: '/tmp/trace.jsonl',
+        generatedAt: '2026-08-24T00:00:00.000Z',
+        sessionCount: 1,
+        segmentCount: 1,
+        itemCount: 1,
+      },
+      items: [baseItem({ id: 'trace-item', skillName: 'trace-skill' })],
+    }, dir);
+    captureExplicitObservation({
+      captureSourceKind: 'chatgpt_plugin',
+      skillName: 'captured-skill',
+      userFeedback: '这里的术语已经过期。',
+      captureId: 'capture-2',
+      confirmedByUser: true,
+    }, { observationsDir: dir });
+    writeFileSync(join(dir, 'captures', 'malformed.capture.json'), '{not-json');
+
+    const [latest] = loadLatestObservationInboxReports(dir);
+    assert.ok(latest);
+    assert.equal(latest.meta.tracePath, '/tmp/trace.jsonl');
+    assert.equal(latest.meta.sessionCount, 1);
+    assert.equal(latest.meta.segmentCount, 1);
+    assert.deepEqual(
+      queryObservationInbox(dir).map((item) => item.skillName).sort(),
+      ['captured-skill', 'trace-skill'],
+    );
+    assert.equal(readdirSync(join(dir, 'captures')).filter((file) => file.endsWith('.capture.json')).length, 2);
+    assert.equal(loadExplicitObservationCaptureRecords(dir).length, 1);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3774,6 +3774,7 @@ __metadata:
       optional: true
   bin:
     omk: dist/cli/index.js
+    omk-chatgpt-mcp: dist/chatgpt-plugin/stdio.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## 用户影响

- 新增 `capture_observation` MCP 工具，让 ChatGPT 等 MCP client 在用户明确授权后，把真实 knowledge 反馈写入 Observation Inbox。
- 新增 `omk-chatgpt-mcp` stdio 入口，可直接由 MCP Inspector 或 Secure MCP Tunnel 启动。
- Inbox 和 observation 详情明确展示 `coverage: partial`，避免把工具边界事件包装成完整对话轨迹。

## 兼容性与测量边界

- 显式反馈使用独立的 append-only capture record，再在读取时投影到 Inbox；不伪造 trace report，也不改变既有 `sessionCount`／`segmentCount` 语义。
- observation 仅包含用户提交的反馈和可选证据；完整对话、其他工具调用及隐藏推理明确标记为不可观测。
- conversation／turn identity 和幂等键只用于生成 hash，不原样落盘。
- 采集结果仍是待复核 observation，不会自动写入正式 sample、修改 knowledge artifact 或影响受控 eval。
- 现有报告无需迁移，新增字段均为可选兼容扩展。

## 当前范围

这是 #415 的首个纵向 PoC，完成用户显式触发、持久化、Inbox 投影和 stdio MCP adapter。`get_observation`、review 写入、sample draft、对话内 component，以及 ChatGPT Secure MCP Tunnel 端到端验收仍留在 #415 后续完成。

验证：`yarn lint && yarn build && yarn test`，以及 MCP Inspector 首次写入／重复幂等调用。

关联 #415
关联 #414