### PR TITLE
feat(chatgpt-plugin): 补全 observation 复核与用例草稿

### DIFF
--- a/docs/guides/chatgpt-mcp-integration.md
+++ b/docs/guides/chatgpt-mcp-integration.md
@@ -1,6 +1,6 @@
 # Compose the ChatGPT MCP integration
 
-OMK exposes one `capture_observation` tool contract for both local stdio and standard Streamable HTTP. The public boundary keeps observation semantics in OMK while allowing a private host to supply identity, policy, persistence, and deployment.
+OMK exposes one knowledge-feedback-loop contract over local stdio and standard Streamable HTTP. The public boundary keeps observation semantics, the human-review gate, and the sample-draft lifecycle in OMK while allowing a private host to supply identity, policy, persistence, and deployment.
 
 This integration captures only user-authorized feedback submitted through the tool. Every result remains `coverageStatus: partial`; it does not imply access to a complete conversation, other tool calls, or hidden reasoning.
 
@@ -11,6 +11,19 @@ This integration captures only user-authorized feedback submitted through the to
 | Local stdio | Fixed local principal and the existing `.omk/observe-inbox` v1 File Store | One developer using OMK locally |
 | Private host | Host-provided `PrincipalResolver` and `ObservationCaptureStore` over Streamable HTTP | Multiple users behind a host-owned authentication and persistence boundary |
 | Hosted OMK service | Not provided | Possible future service; do not infer it from the current package |
+
+## Tools and domain gates
+
+| Tool | Scope | OMK guarantee |
+| --- | --- | --- |
+| `capture_observation` | `observation:capture` | Accepts only explicitly confirmed, user-visible evidence and writes idempotently |
+| `get_observation` | `observation:read` | Returns only evidence, review state, and `partial` coverage from the current principal partition |
+| `record_observation_review` | `observation:review` | Records only `real_issue`, `not_issue`, or `needs_more_context` human decisions |
+| `draft_sample_from_observation` | `observation:draft` | Drafts only from `real_issue`; never writes the formal eval sample set |
+
+For `draft_sample_from_observation`, the current ChatGPT proposes a candidate prompt and rubric from the authorized evidence returned by `get_observation`. OMK owns the review gate, provenance, source-evidence references, and draft status; it does not treat ChatGPT as a controlled judge.
+
+MCP `tools/list` is also filtered by the scopes returned by the resolver: capabilities a user does not have are omitted from that user's tool list.
 
 ## Local stdio
 
@@ -29,8 +42,11 @@ The package exports its integration contract from `oh-my-knowledge/chatgpt-plugi
 ```ts
 import type { IncomingMessage } from 'node:http';
 import {
-  FileObservationCaptureStore,
+  FileObservationFeedbackStore,
   OBSERVATION_CAPTURE_SCOPE,
+  OBSERVATION_DRAFT_SCOPE,
+  OBSERVATION_READ_SCOPE,
+  OBSERVATION_REVIEW_SCOPE,
   ObservationPrincipalError,
   startChatGptObservationHttpServer,
   type PrincipalResolver,
@@ -48,7 +64,12 @@ const principalResolver: PrincipalResolver<IncomingMessage> = {
     return {
       tenantId: subject.tenantId,
       principalId: subject.stableSubjectId,
-      scopes: [OBSERVATION_CAPTURE_SCOPE],
+      scopes: [
+        OBSERVATION_CAPTURE_SCOPE,
+        OBSERVATION_READ_SCOPE,
+        OBSERVATION_REVIEW_SCOPE,
+        OBSERVATION_DRAFT_SCOPE,
+      ],
     };
   },
 };
@@ -57,7 +78,7 @@ const started = await startChatGptObservationHttpServer({
   host: '127.0.0.1',
   port: 0,
   principalResolver,
-  captureStore: new FileObservationCaptureStore({
+  captureStore: new FileObservationFeedbackStore({
     observationsDir: '/srv/omk/observations',
   }),
 });
@@ -71,7 +92,9 @@ With no resolver, the HTTP helper binds to loopback by default and uses the loca
 
 ## Implement another store
 
-`ObservationCaptureStore` is the persistence seam. OMK also exports helpers that prepare the canonical v1 record and build the canonical result, so an adapter does not need to recreate capture hashes, coverage, or Inbox identity.
+`ObservationCaptureStore` is the minimal persistence seam; implementing it registers only `capture_observation`. `ObservationFeedbackStore` adds `get`, `review`, and `draftSample`; the server registers the other three tools only when the store implements that full contract. Existing adapters therefore do not falsely advertise capabilities they have not implemented.
+
+OMK also exports helpers that prepare the canonical v1 record and build the canonical result, so a capture adapter does not need to recreate capture hashes, coverage, or Inbox identity.
 
 ```ts
 import {
@@ -95,6 +118,8 @@ const captureStore: ObservationCaptureStore = {
 ```
 
 `insertOrLoad` must be atomic. A duplicate key returns the existing record; reusing the same identity with another payload must fail closed. The persistence implementation belongs to the host and is not included in OMK.
+
+A full private adapter should implement `ObservationFeedbackStore` with the same invariants as `FileObservationFeedbackStore`: isolate every operation by `(tenantId, principalId)`; fail closed for unknown observations; draft only from `real_issue`; preserve source-evidence hashes in every draft; and never merge a draft directly into the formal evaluation set.
 
 ## Authentication boundary
 

--- a/docs/zh/guides/chatgpt-mcp-integration.md
+++ b/docs/zh/guides/chatgpt-mcp-integration.md
@@ -1,6 +1,6 @@
 # 组合 ChatGPT MCP 集成
 
-OMK 为本地 stdio 和标准 Streamable HTTP 暴露同一份 `capture_observation` 工具契约。公共边界把 observation 语义留在 OMK，让私有宿主注入身份、策略、持久化和部署能力。
+OMK 为本地 stdio 和标准 Streamable HTTP 暴露同一份 knowledge feedback loop 契约。公共边界把 observation 语义、人工复核门禁和 sample 草稿生命周期留在 OMK，让私有宿主只注入身份、策略、持久化和部署能力。
 
 该集成只采集用户明确授权并通过工具提交的反馈。所有结果仍是 `coverageStatus: partial`；它不代表 OMK 能读取完整对话、其他工具调用或隐藏推理。
 
@@ -11,6 +11,19 @@ OMK 为本地 stdio 和标准 Streamable HTTP 暴露同一份 `capture_observati
 | 本地 stdio | 固定本地主体和既有 `.omk/observe-inbox` v1 File Store | 单个开发者在本机使用 OMK |
 | 私有宿主 | 宿主提供 `PrincipalResolver` 和 `ObservationCaptureStore`，通过 Streamable HTTP 提供服务 | 多用户共享宿主自己的认证和持久化边界 |
 | OMK 托管服务 | 当前未提供 | 可能的未来服务；不能从当前 npm 包推断其存在 |
+
+## 工具与领域门禁
+
+| 工具 | Scope | OMK 保证 |
+| --- | --- | --- |
+| `capture_observation` | `observation:capture` | 只接受用户明确确认的可见证据，幂等写入 |
+| `get_observation` | `observation:read` | 只返回当前 principal 分区中的证据、复核状态和 `partial` coverage |
+| `record_observation_review` | `observation:review` | 只记录 `real_issue`／`not_issue`／`needs_more_context` 人工结论 |
+| `draft_sample_from_observation` | `observation:draft` | 只允许从 `real_issue` 生成候选草稿；不写正式 eval sample |
+
+`draft_sample_from_observation` 由当前 ChatGPT 根据 `get_observation` 返回的授权证据提供候选 prompt 和 rubric。OMK 负责复核门禁、provenance、原始证据引用和草稿状态，不把 ChatGPT 当作受控评委。
+
+MCP `tools/list` 还会按 resolver 返回的 scope 裁剪：用户没有的能力不会出现在工具列表中。
 
 ## 本地 stdio
 
@@ -29,8 +42,11 @@ omk-chatgpt-mcp
 ```ts
 import type { IncomingMessage } from 'node:http';
 import {
-  FileObservationCaptureStore,
+  FileObservationFeedbackStore,
   OBSERVATION_CAPTURE_SCOPE,
+  OBSERVATION_DRAFT_SCOPE,
+  OBSERVATION_READ_SCOPE,
+  OBSERVATION_REVIEW_SCOPE,
   ObservationPrincipalError,
   startChatGptObservationHttpServer,
   type PrincipalResolver,
@@ -48,7 +64,12 @@ const principalResolver: PrincipalResolver<IncomingMessage> = {
     return {
       tenantId: subject.tenantId,
       principalId: subject.stableSubjectId,
-      scopes: [OBSERVATION_CAPTURE_SCOPE],
+      scopes: [
+        OBSERVATION_CAPTURE_SCOPE,
+        OBSERVATION_READ_SCOPE,
+        OBSERVATION_REVIEW_SCOPE,
+        OBSERVATION_DRAFT_SCOPE,
+      ],
     };
   },
 };
@@ -57,7 +78,7 @@ const started = await startChatGptObservationHttpServer({
   host: '127.0.0.1',
   port: 0,
   principalResolver,
-  captureStore: new FileObservationCaptureStore({
+  captureStore: new FileObservationFeedbackStore({
     observationsDir: '/srv/omk/observations',
   }),
 });
@@ -71,7 +92,9 @@ console.log(started.url.href);
 
 ## 实现其它 Store
 
-`ObservationCaptureStore` 是持久化接缝。OMK 同时导出准备标准 v1 record 和生成标准结果的 helper，因此 adapter 不需要重新实现 capture 哈希、coverage 或 Inbox identity。
+`ObservationCaptureStore` 是最小持久化接缝；实现它时 MCP Server 只注册 `capture_observation`。`ObservationFeedbackStore` 在此基础上增加 `get`、`review` 和 `draftSample`；实现完整接口时才注册后三个工具。这样旧 adapter 不会被迫虚假承诺未实现的能力。
+
+OMK 同时导出准备标准 v1 record 和生成标准结果的 helper，因此 capture adapter 不需要重新实现 capture 哈希、coverage 或 Inbox identity。
 
 ```ts
 import {
@@ -95,6 +118,8 @@ const captureStore: ObservationCaptureStore = {
 ```
 
 `insertOrLoad` 必须是原子操作。重复键返回已有 record；同一 identity 对应不同 payload 时必须 fail closed。持久化实现属于宿主，不包含在 OMK 中。
+
+完整私有 adapter 应实现 `ObservationFeedbackStore`，并保持与 `FileObservationFeedbackStore` 相同的不变量：所有操作按 `(tenantId, principalId)` 隔离；不存在的 observation fail closed；只有 `real_issue` 可写草稿；草稿持续保留 source evidence hash，且不能直接混入正式评测集。
 
 ## 认证边界
 

--- a/src/chatgpt-plugin/capture-store.ts
+++ b/src/chatgpt-plugin/capture-store.ts
@@ -42,8 +42,8 @@ export interface FileObservationCaptureStoreOptions extends ExplicitObservationC
 }
 
 export class FileObservationCaptureStore implements ObservationCaptureStore {
-  private readonly observationsDir: string;
-  private readonly now?: () => Date;
+  protected readonly observationsDir: string;
+  protected readonly now?: () => Date;
   private readonly partition: 'principal' | 'shared';
 
   constructor(options: FileObservationCaptureStoreOptions = {}) {
@@ -57,15 +57,7 @@ export class FileObservationCaptureStore implements ObservationCaptureStore {
     capture: ExplicitObservationCaptureInput,
   ): Promise<ExplicitObservationCaptureResult> {
     const principal = validateObservationPrincipal(rawPrincipal);
-    const observationsDir = this.partition === 'shared'
-      ? this.observationsDir
-      : join(
-        this.observationsDir,
-        'tenants',
-        hashPartition('tenant', principal.tenantId),
-        'principals',
-        hashPartition('principal', principal.principalId),
-      );
+    const observationsDir = this.resolveObservationsDir(principal);
     try {
       return captureExplicitObservation(capture, {
         observationsDir,
@@ -79,6 +71,18 @@ export class FileObservationCaptureStore implements ObservationCaptureStore {
         { cause: error },
       );
     }
+  }
+
+  protected resolveObservationsDir(principal: ObservationPrincipal): string {
+    return this.partition === 'shared'
+      ? this.observationsDir
+      : join(
+        this.observationsDir,
+        'tenants',
+        hashPartition('tenant', principal.tenantId),
+        'principals',
+        hashPartition('principal', principal.principalId),
+      );
   }
 }
 

--- a/src/chatgpt-plugin/feedback-store.ts
+++ b/src/chatgpt-plugin/feedback-store.ts
@@ -1,0 +1,407 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  explicitObservationCaptureResult,
+  loadExplicitObservationCaptureRecords,
+  type ExplicitObservationCaptureRecord,
+} from '../observability/explicit-capture.js';
+import {
+  loadObservationReviewState,
+  observationReviewStateKey,
+  updateObservationReviewState,
+} from '../observability/review-state.js';
+import { writeJsonFileAtomic } from '../shared/atomic-json.js';
+import { withFileLock } from '../shared/file-lock.js';
+import type {
+  ObservationCaptureCoverage,
+  ObservationReviewStateEntry,
+} from '../types/index.js';
+import {
+  FileObservationCaptureStore,
+  type FileObservationCaptureStoreOptions,
+  type ObservationCaptureStore,
+} from './capture-store.js';
+import {
+  validateObservationPrincipal,
+  type ObservationPrincipal,
+} from './principal.js';
+
+export type ObservationFeedbackReviewVerdict =
+  | 'real_issue'
+  | 'not_issue'
+  | 'needs_more_context';
+
+export interface ObservationCaptureEvidence {
+  captureId: string;
+  payloadHash: string;
+  capturedAt: string;
+  userFeedback: string;
+  evidenceSnippet?: string;
+}
+
+export interface ObservationDetail {
+  observationId: string;
+  skillName: string;
+  artifactVersion: string;
+  artifactHash?: string;
+  cwd?: string;
+  firstSeen: string;
+  lastSeen: string;
+  occurrences: number;
+  captureCoverage: ObservationCaptureCoverage;
+  evidence: ObservationCaptureEvidence[];
+  review?: ObservationReviewStateEntry;
+}
+
+export interface ObservationReviewInput {
+  observationId: string;
+  verdict: ObservationFeedbackReviewVerdict;
+  note?: string;
+}
+
+export interface ObservationReviewResult {
+  observationId: string;
+  review: ObservationReviewStateEntry;
+}
+
+export interface ObservationSampleDraftInput {
+  observationId: string;
+  prompt: string;
+  rubric?: string;
+  sampleId?: string;
+  draftId?: string;
+}
+
+export interface ObservationSampleDraft {
+  draftKind: 'observation_sample_draft';
+  schemaVersion: 1;
+  draftId: string;
+  payloadHash: string;
+  createdAt: string;
+  status: 'draft';
+  observationId: string;
+  sourceEvidence: Array<Pick<ObservationCaptureEvidence, 'captureId' | 'payloadHash' | 'capturedAt'>>;
+  sample: {
+    sample_id: string;
+    prompt: string;
+    rubric?: string;
+    provenance: 'production-trace';
+  };
+}
+
+export interface ObservationSampleDraftResult {
+  draft: ObservationSampleDraft;
+  created: boolean;
+}
+
+export interface ObservationFeedbackStore extends ObservationCaptureStore {
+  get(principal: ObservationPrincipal, observationId: string): Promise<ObservationDetail>;
+  review(
+    principal: ObservationPrincipal,
+    input: ObservationReviewInput,
+  ): Promise<ObservationReviewResult>;
+  draftSample(
+    principal: ObservationPrincipal,
+    input: ObservationSampleDraftInput,
+  ): Promise<ObservationSampleDraftResult>;
+}
+
+export type ObservationFeedbackStoreErrorCode =
+  | 'observation_not_found'
+  | 'observation_review_required'
+  | 'draft_conflict'
+  | 'feedback_store_failed';
+
+export class ObservationFeedbackStoreError extends Error {
+  constructor(
+    readonly code: ObservationFeedbackStoreErrorCode,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(message, options);
+    this.name = 'ObservationFeedbackStoreError';
+  }
+}
+
+export class FileObservationFeedbackStore
+  extends FileObservationCaptureStore
+  implements ObservationFeedbackStore {
+  constructor(options: FileObservationCaptureStoreOptions = {}) {
+    super(options);
+  }
+
+  async get(
+    rawPrincipal: ObservationPrincipal,
+    observationId: string,
+  ): Promise<ObservationDetail> {
+    const principal = validateObservationPrincipal(rawPrincipal);
+    const observationsDir = this.resolveObservationsDir(principal);
+    const records = findObservationRecords(observationsDir, observationId);
+    if (records.length === 0) {
+      throw new ObservationFeedbackStoreError('observation_not_found', 'Observation 不存在。');
+    }
+    return projectObservationDetail(observationsDir, observationId, records);
+  }
+
+  async review(
+    rawPrincipal: ObservationPrincipal,
+    rawInput: ObservationReviewInput,
+  ): Promise<ObservationReviewResult> {
+    const principal = validateObservationPrincipal(rawPrincipal);
+    const input = normalizeReviewInput(rawInput);
+    const observationsDir = this.resolveObservationsDir(principal);
+    if (findObservationRecords(observationsDir, input.observationId).length === 0) {
+      throw new ObservationFeedbackStoreError('observation_not_found', 'Observation 不存在。');
+    }
+    try {
+      const state = updateObservationReviewState(observationsDir, {
+        targetType: 'inbox_item',
+        targetId: input.observationId,
+        verdict: input.verdict,
+        note: input.note,
+      }, this.now?.().toISOString());
+      const review = state.entries[observationReviewStateKey('inbox_item', input.observationId)];
+      if (!review) throw new Error('复核状态未落盘。');
+      return { observationId: input.observationId, review };
+    } catch (error) {
+      if (error instanceof ObservationFeedbackStoreError) throw error;
+      throw new ObservationFeedbackStoreError(
+        'feedback_store_failed',
+        'Observation 复核写入失败。',
+        { cause: error },
+      );
+    }
+  }
+
+  async draftSample(
+    rawPrincipal: ObservationPrincipal,
+    rawInput: ObservationSampleDraftInput,
+  ): Promise<ObservationSampleDraftResult> {
+    const principal = validateObservationPrincipal(rawPrincipal);
+    const input = normalizeSampleDraftInput(rawInput);
+    const observationsDir = this.resolveObservationsDir(principal);
+    const records = findObservationRecords(observationsDir, input.observationId);
+    if (records.length === 0) {
+      throw new ObservationFeedbackStoreError('observation_not_found', 'Observation 不存在。');
+    }
+    const review = loadObservationReviewState(observationsDir).entries[
+      observationReviewStateKey('inbox_item', input.observationId)
+    ];
+    if (review?.verdict !== 'real_issue') {
+      throw new ObservationFeedbackStoreError(
+        'observation_review_required',
+        '只有人工确认为 real_issue 的 observation 才能生成 sample 草稿。',
+      );
+    }
+
+    const draft = prepareSampleDraft(input, records, this.now?.() ?? new Date());
+    const path = join(observationsDir, 'drafts', `${draft.draftId}.sample-draft.json`);
+    try {
+      return withFileLock(`${path}.lock`, () => {
+        const existing = loadSampleDraft(path);
+        if (existing) {
+          if (existing.payloadHash !== draft.payloadHash) {
+            throw new ObservationFeedbackStoreError(
+              'draft_conflict',
+              'draftId 已用于不同的 sample 草稿。',
+            );
+          }
+          return { draft: existing, created: false };
+        }
+        if (existsSync(path)) {
+          throw new ObservationFeedbackStoreError(
+            'draft_conflict',
+            '目标 sample 草稿已存在但无法解析，拒绝覆盖。',
+          );
+        }
+        writeJsonFileAtomic(path, draft);
+        return { draft, created: true };
+      }, { label: 'observation sample draft' });
+    } catch (error) {
+      if (error instanceof ObservationFeedbackStoreError) throw error;
+      throw new ObservationFeedbackStoreError(
+        'feedback_store_failed',
+        'Sample 草稿写入失败。',
+        { cause: error },
+      );
+    }
+  }
+}
+
+export function isObservationFeedbackStore(
+  store: ObservationCaptureStore,
+): store is ObservationFeedbackStore {
+  const candidate = store as Partial<ObservationFeedbackStore>;
+  return typeof candidate.get === 'function'
+    && typeof candidate.review === 'function'
+    && typeof candidate.draftSample === 'function';
+}
+
+function findObservationRecords(
+  observationsDir: string,
+  observationId: string,
+): ExplicitObservationCaptureRecord[] {
+  const normalizedId = requiredText(observationId, 'observationId', 128);
+  return loadExplicitObservationCaptureRecords(observationsDir)
+    .filter((record) => explicitObservationCaptureResult(record, false).observationId === normalizedId)
+    .sort((a, b) => a.capturedAt.localeCompare(b.capturedAt));
+}
+
+function projectObservationDetail(
+  observationsDir: string,
+  observationId: string,
+  records: ExplicitObservationCaptureRecord[],
+): ObservationDetail {
+  const first = records[0];
+  const last = records.at(-1);
+  if (!first || !last) throw new Error('Observation records 不能为空。');
+  const review = loadObservationReviewState(observationsDir).entries[
+    observationReviewStateKey('inbox_item', observationId)
+  ];
+  return {
+    observationId,
+    skillName: last.skillName,
+    artifactVersion: last.artifactVersion,
+    artifactHash: last.artifactHash,
+    cwd: last.cwd,
+    firstSeen: first.capturedAt,
+    lastSeen: last.capturedAt,
+    occurrences: records.length,
+    captureCoverage: last.captureCoverage,
+    evidence: records.map((record) => ({
+      captureId: record.captureId,
+      payloadHash: record.payloadHash,
+      capturedAt: record.capturedAt,
+      userFeedback: record.userFeedback,
+      evidenceSnippet: record.evidenceSnippet,
+    })),
+    review,
+  };
+}
+
+function normalizeReviewInput(input: ObservationReviewInput): ObservationReviewInput {
+  if (!['real_issue', 'not_issue', 'needs_more_context'].includes(input.verdict)) {
+    throw new ObservationFeedbackStoreError('feedback_store_failed', '不支持的 observation review verdict。');
+  }
+  return {
+    observationId: requiredText(input.observationId, 'observationId', 128),
+    verdict: input.verdict,
+    note: optionalText(input.note, 'note', 500),
+  };
+}
+
+function normalizeSampleDraftInput(input: ObservationSampleDraftInput): ObservationSampleDraftInput {
+  return {
+    observationId: requiredText(input.observationId, 'observationId', 128),
+    prompt: requiredText(input.prompt, 'prompt', 16_000),
+    rubric: optionalText(input.rubric, 'rubric', 8_000),
+    sampleId: optionalText(input.sampleId, 'sampleId', 200),
+    draftId: optionalText(input.draftId, 'draftId', 512),
+  };
+}
+
+function prepareSampleDraft(
+  input: ObservationSampleDraftInput,
+  records: ExplicitObservationCaptureRecord[],
+  now: Date,
+): ObservationSampleDraft {
+  const sourceEvidence = records.map((record) => ({
+    captureId: record.captureId,
+    payloadHash: record.payloadHash,
+    capturedAt: record.capturedAt,
+  }));
+  const sample = {
+    sample_id: input.sampleId ?? `observation-${input.observationId.slice(0, 16)}`,
+    prompt: input.prompt,
+    ...(input.rubric ? { rubric: input.rubric } : {}),
+    provenance: 'production-trace' as const,
+  };
+  const payloadHash = hashJson({ observationId: input.observationId, sourceEvidence, sample });
+  return {
+    draftKind: 'observation_sample_draft',
+    schemaVersion: 1,
+    draftId: hashText(`observation-sample-draft\u0000${input.draftId ?? payloadHash}`),
+    payloadHash,
+    createdAt: now.toISOString(),
+    status: 'draft',
+    observationId: input.observationId,
+    sourceEvidence,
+    sample,
+  };
+}
+
+function loadSampleDraft(path: string): ObservationSampleDraft | null {
+  try {
+    const value = JSON.parse(readFileSync(path, 'utf8')) as Partial<ObservationSampleDraft>;
+    if (
+      value.draftKind !== 'observation_sample_draft'
+      || value.schemaVersion !== 1
+      || !isBoundedText(value.draftId, 64)
+      || !isBoundedText(value.payloadHash, 64)
+      || !isIsoTimestamp(value.createdAt)
+      || value.status !== 'draft'
+      || !isBoundedText(value.observationId, 128)
+      || !Array.isArray(value.sourceEvidence)
+      || !value.sourceEvidence.every(isSourceEvidenceRef)
+      || !isSampleDraftValue(value.sample)
+    ) return null;
+    return value as ObservationSampleDraft;
+  } catch {
+    return null;
+  }
+}
+
+function isSourceEvidenceRef(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const ref = value as Record<string, unknown>;
+  return isBoundedText(ref.captureId, 64)
+    && isBoundedText(ref.payloadHash, 64)
+    && isIsoTimestamp(ref.capturedAt);
+}
+
+function isSampleDraftValue(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const sample = value as Record<string, unknown>;
+  return isBoundedText(sample.sample_id, 200)
+    && isBoundedText(sample.prompt, 16_000)
+    && (sample.rubric === undefined || isBoundedText(sample.rubric, 8_000))
+    && sample.provenance === 'production-trace';
+}
+
+function requiredText(value: unknown, field: string, maxLength: number): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new ObservationFeedbackStoreError('feedback_store_failed', `${field} 不能为空。`);
+  }
+  const normalized = value.trim();
+  if (normalized.length > maxLength) {
+    throw new ObservationFeedbackStoreError(
+      'feedback_store_failed',
+      `${field} 不能超过 ${maxLength} 个字符。`,
+    );
+  }
+  return normalized;
+}
+
+function optionalText(value: unknown, field: string, maxLength: number): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  return requiredText(value, field, maxLength);
+}
+
+function isBoundedText(value: unknown, maxLength: number): value is string {
+  return typeof value === 'string' && Boolean(value.trim()) && value.length <= maxLength;
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  return typeof value === 'string'
+    && !Number.isNaN(Date.parse(value))
+    && new Date(value).toISOString() === value;
+}
+
+function hashJson(value: unknown): string {
+  return hashText(JSON.stringify(value));
+}
+
+function hashText(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 24);
+}

--- a/src/chatgpt-plugin/http.ts
+++ b/src/chatgpt-plugin/http.ts
@@ -10,7 +10,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import type { ObservationCaptureStore } from './capture-store.js';
 import { createChatGptObservationMcpServer } from './mcp-server.js';
 import {
-  assertObservationCaptureScope,
+  assertObservationAccessScope,
   LOCAL_OBSERVATION_PRINCIPAL,
   ObservationPrincipalError,
   validateObservationPrincipal,
@@ -107,7 +107,7 @@ export function createChatGptObservationHttpHandler(
     activeRequests += 1;
     try {
       const principal = validateObservationPrincipal(await resolver.resolve(request));
-      assertObservationCaptureScope(principal);
+      assertObservationAccessScope(principal);
       const body = await readJsonBody(request, bodyLimit, timeoutMs);
       const server = createChatGptObservationMcpServer({
         principal,

--- a/src/chatgpt-plugin/index.ts
+++ b/src/chatgpt-plugin/index.ts
@@ -1,4 +1,5 @@
 export * from './capture-store.js';
+export * from './feedback-store.js';
 export * from './http.js';
 export * from './mcp-server.js';
 export * from './principal.js';

--- a/src/chatgpt-plugin/mcp-server.ts
+++ b/src/chatgpt-plugin/mcp-server.ts
@@ -4,12 +4,23 @@ import {
   type ExplicitObservationCaptureOptions,
 } from '../observability/explicit-capture.js';
 import {
-  FileObservationCaptureStore,
   type ObservationCaptureStore,
 } from './capture-store.js';
 import {
+  FileObservationFeedbackStore,
+  isObservationFeedbackStore,
+  ObservationFeedbackStoreError,
+} from './feedback-store.js';
+import {
   assertObservationCaptureScope,
+  assertObservationDraftScope,
+  assertObservationReadScope,
+  assertObservationReviewScope,
   LOCAL_OBSERVATION_PRINCIPAL,
+  OBSERVATION_CAPTURE_SCOPE,
+  OBSERVATION_DRAFT_SCOPE,
+  OBSERVATION_READ_SCOPE,
+  OBSERVATION_REVIEW_SCOPE,
   validateObservationPrincipal,
   type ObservationPrincipal,
 } from './principal.js';
@@ -24,6 +35,19 @@ const unavailableEventKindSchema = z.enum([
   'external_tool_calls',
   'hidden_reasoning',
 ]);
+const reviewVerdictSchema = z.enum(['real_issue', 'not_issue', 'needs_more_context']);
+const reviewStateVerdictSchema = z.enum([
+  'reviewed',
+  'real_issue',
+  'not_issue',
+  'needs_more_context',
+]);
+const captureCoverageSchema = z.object({
+  coverageStatus: z.literal('partial'),
+  capturePath: z.literal('explicit_tool_call'),
+  observedEventKinds: z.array(observedEventKindSchema),
+  unavailableEventKinds: z.array(unavailableEventKindSchema),
+});
 
 export interface ChatGptObservationToolOptions {
   principal: ObservationPrincipal;
@@ -49,7 +73,7 @@ export function createChatGptObservationMcpServer(
   const principal = validateObservationPrincipal(
     options.principal ?? LOCAL_OBSERVATION_PRINCIPAL,
   );
-  const captureStore = options.captureStore ?? new FileObservationCaptureStore({
+  const captureStore = options.captureStore ?? new FileObservationFeedbackStore({
     observationsDir: options.observationsDir,
     now: options.now,
     partition: options.principal ? 'principal' : 'shared',
@@ -65,7 +89,8 @@ export function registerChatGptObservationTools(
 ): void {
   const principal = validateObservationPrincipal(options.principal);
 
-  server.registerTool('capture_observation', {
+  if (principal.scopes.includes(OBSERVATION_CAPTURE_SCOPE)) {
+    server.registerTool('capture_observation', {
     title: 'Capture an explicit OMK observation',
     description: [
       'Record knowledge feedback only after the user explicitly asks to save it.',
@@ -96,12 +121,7 @@ export function registerChatGptObservationTools(
       capturedAt: z.string(),
       created: z.boolean(),
       reviewPath: z.string(),
-      captureCoverage: z.object({
-        coverageStatus: z.literal('partial'),
-        capturePath: z.literal('explicit_tool_call'),
-        observedEventKinds: z.array(observedEventKindSchema),
-        unavailableEventKinds: z.array(unavailableEventKindSchema),
-      }),
+      captureCoverage: captureCoverageSchema,
     },
     annotations: {
       readOnlyHint: false,
@@ -131,5 +151,186 @@ export function registerChatGptObservationTools(
       }],
       structuredContent,
     };
-  });
+    });
+  }
+
+  if (!isObservationFeedbackStore(options.captureStore)) return;
+  const feedbackStore = options.captureStore;
+
+  if (principal.scopes.includes(OBSERVATION_READ_SCOPE)) {
+    server.registerTool('get_observation', {
+    title: 'Get an OMK observation',
+    description: [
+      'Read one explicitly captured observation, its user-authorized evidence, partial coverage,',
+      'and current human review state. This never returns a complete ChatGPT transcript or hidden reasoning.',
+    ].join(' '),
+    inputSchema: {
+      observationId: z.string().trim().min(1).max(128),
+    },
+    outputSchema: {
+      observationId: z.string(),
+      skillName: z.string(),
+      artifactVersion: z.string(),
+      artifactHash: z.string().optional(),
+      cwd: z.string().optional(),
+      firstSeen: z.string(),
+      lastSeen: z.string(),
+      occurrences: z.number().int().positive(),
+      captureCoverage: captureCoverageSchema,
+      evidence: z.array(z.object({
+        captureId: z.string(),
+        payloadHash: z.string(),
+        capturedAt: z.string(),
+        userFeedback: z.string(),
+        evidenceSnippet: z.string().optional(),
+      })),
+      review: z.object({
+        verdict: reviewStateVerdictSchema,
+        reviewedAt: z.string(),
+        note: z.string().optional(),
+      }).optional(),
+    },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  }, async ({ observationId }) => {
+    assertObservationReadScope(principal);
+    const detail = await feedbackStore.get(principal, observationId);
+    return {
+      content: [{
+        type: 'text' as const,
+        text: `Observation ${detail.observationId} 共有 ${detail.occurrences} 次显式捕获；覆盖范围为 partial。`,
+      }],
+      structuredContent: {
+        ...detail,
+        review: detail.review ? {
+          verdict: detail.review.verdict,
+          reviewedAt: detail.review.reviewedAt,
+          note: detail.review.note,
+        } : undefined,
+      },
+    };
+    });
+  }
+
+  if (principal.scopes.includes(OBSERVATION_REVIEW_SCOPE)) {
+    server.registerTool('record_observation_review', {
+    title: 'Record a human review for an OMK observation',
+    description: [
+      'Record the user or reviewer decision for a captured observation.',
+      'Use real_issue only after a human confirms the knowledge gap.',
+    ].join(' '),
+    inputSchema: {
+      observationId: z.string().trim().min(1).max(128),
+      verdict: reviewVerdictSchema,
+      note: z.string().trim().min(1).max(500).optional(),
+    },
+    outputSchema: {
+      observationId: z.string(),
+      review: z.object({
+        verdict: reviewVerdictSchema,
+        reviewedAt: z.string(),
+        note: z.string().optional(),
+      }),
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  }, async (input) => {
+    assertObservationReviewScope(principal);
+    const result = await feedbackStore.review(principal, input);
+    return {
+      content: [{
+        type: 'text' as const,
+        text: `已记录 observation 复核结论：${result.review.verdict}。`,
+      }],
+      structuredContent: {
+        observationId: result.observationId,
+        review: {
+          verdict: result.review.verdict,
+          reviewedAt: result.review.reviewedAt,
+          note: result.review.note,
+        },
+      },
+    };
+    });
+  }
+
+  if (principal.scopes.includes(OBSERVATION_DRAFT_SCOPE)) {
+    server.registerTool('draft_sample_from_observation', {
+    title: 'Draft a regression sample from an OMK observation',
+    description: [
+      'Persist a candidate regression sample proposed from a human-confirmed observation.',
+      'The result remains a draft and never changes the formal eval sample set.',
+      'Base the prompt and rubric only on user-authorized evidence returned by get_observation.',
+    ].join(' '),
+    inputSchema: {
+      observationId: z.string().trim().min(1).max(128),
+      prompt: z.string().trim().min(1).max(16_000)
+        .describe('Proposed reproducible evaluation prompt.'),
+      rubric: z.string().trim().min(1).max(8_000).optional()
+        .describe('Optional reviewable success criteria.'),
+      sampleId: z.string().trim().min(1).max(200).optional(),
+      draftId: z.string().trim().min(1).max(512).optional()
+        .describe('Optional stable idempotency key. OMK stores only its hash.'),
+    },
+    outputSchema: {
+      draftId: z.string(),
+      createdAt: z.string(),
+      created: z.boolean(),
+      status: z.literal('draft'),
+      observationId: z.string(),
+      sourceEvidence: z.array(z.object({
+        captureId: z.string(),
+        payloadHash: z.string(),
+        capturedAt: z.string(),
+      })),
+      sample: z.object({
+        sample_id: z.string(),
+        prompt: z.string(),
+        rubric: z.string().optional(),
+        provenance: z.literal('production-trace'),
+      }),
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  }, async (input) => {
+    assertObservationDraftScope(principal);
+    const observation = await feedbackStore.get(principal, input.observationId);
+    if (observation.review?.verdict !== 'real_issue') {
+      throw new ObservationFeedbackStoreError(
+        'observation_review_required',
+        '只有人工确认为 real_issue 的 observation 才能生成 sample 草稿。',
+      );
+    }
+    const result = await feedbackStore.draftSample(principal, input);
+    return {
+      content: [{
+        type: 'text' as const,
+        text: result.created
+          ? '已生成 regression sample 草稿；未写入正式评测集。'
+          : '该 regression sample 草稿已存在，本次返回幂等结果。',
+      }],
+      structuredContent: {
+        draftId: result.draft.draftId,
+        createdAt: result.draft.createdAt,
+        created: result.created,
+        status: result.draft.status,
+        observationId: result.draft.observationId,
+        sourceEvidence: result.draft.sourceEvidence,
+        sample: result.draft.sample,
+      },
+    };
+    });
+  }
 }

--- a/src/chatgpt-plugin/principal.ts
+++ b/src/chatgpt-plugin/principal.ts
@@ -1,4 +1,14 @@
 export const OBSERVATION_CAPTURE_SCOPE = 'observation:capture';
+export const OBSERVATION_READ_SCOPE = 'observation:read';
+export const OBSERVATION_REVIEW_SCOPE = 'observation:review';
+export const OBSERVATION_DRAFT_SCOPE = 'observation:draft';
+
+const OBSERVATION_SCOPES = [
+  OBSERVATION_CAPTURE_SCOPE,
+  OBSERVATION_READ_SCOPE,
+  OBSERVATION_REVIEW_SCOPE,
+  OBSERVATION_DRAFT_SCOPE,
+] as const;
 
 export interface ObservationPrincipal {
   tenantId: string;
@@ -33,7 +43,7 @@ export class ObservationPrincipalError extends Error {
 export const LOCAL_OBSERVATION_PRINCIPAL: ObservationPrincipal = Object.freeze({
   tenantId: 'local',
   principalId: 'local-user',
-  scopes: Object.freeze([OBSERVATION_CAPTURE_SCOPE]),
+  scopes: Object.freeze([...OBSERVATION_SCOPES]),
 });
 
 export function validateObservationPrincipal(value: unknown): ObservationPrincipal {
@@ -54,11 +64,33 @@ export function validateObservationPrincipal(value: unknown): ObservationPrincip
 }
 
 export function assertObservationCaptureScope(principal: ObservationPrincipal): void {
-  if (!principal.scopes.includes(OBSERVATION_CAPTURE_SCOPE)) {
+  assertObservationScope(principal, OBSERVATION_CAPTURE_SCOPE);
+}
+
+export function assertObservationReadScope(principal: ObservationPrincipal): void {
+  assertObservationScope(principal, OBSERVATION_READ_SCOPE);
+}
+
+export function assertObservationReviewScope(principal: ObservationPrincipal): void {
+  assertObservationScope(principal, OBSERVATION_REVIEW_SCOPE);
+}
+
+export function assertObservationDraftScope(principal: ObservationPrincipal): void {
+  assertObservationScope(principal, OBSERVATION_DRAFT_SCOPE);
+}
+
+export function assertObservationAccessScope(principal: ObservationPrincipal): void {
+  if (!OBSERVATION_SCOPES.some((scope) => principal.scopes.includes(scope))) {
     throw new ObservationPrincipalError(
       'forbidden',
-      `Principal 缺少 ${OBSERVATION_CAPTURE_SCOPE} scope。`,
+      'Principal 缺少 observation scope。',
     );
+  }
+}
+
+function assertObservationScope(principal: ObservationPrincipal, scope: string): void {
+  if (!principal.scopes.includes(scope)) {
+    throw new ObservationPrincipalError('forbidden', `Principal 缺少 ${scope} scope。`);
   }
 }
 

--- a/src/chatgpt-plugin/stdio.ts
+++ b/src/chatgpt-plugin/stdio.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { FileObservationCaptureStore } from './capture-store.js';
+import { FileObservationFeedbackStore } from './feedback-store.js';
 import { createChatGptObservationMcpServer } from './mcp-server.js';
 import { LOCAL_OBSERVATION_PRINCIPAL } from './principal.js';
 
 async function main(): Promise<void> {
   const server = createChatGptObservationMcpServer({
     principal: LOCAL_OBSERVATION_PRINCIPAL,
-    captureStore: new FileObservationCaptureStore({ partition: 'shared' }),
+    captureStore: new FileObservationFeedbackStore({ partition: 'shared' }),
   });
   await server.connect(new StdioServerTransport());
 }

--- a/test/chatgpt-plugin/capture-store.test.ts
+++ b/test/chatgpt-plugin/capture-store.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'vitest';
 import { FileObservationCaptureStore } from '../../src/chatgpt-plugin/capture-store.js';
+import { FileObservationFeedbackStore } from '../../src/chatgpt-plugin/feedback-store.js';
 import { OBSERVATION_CAPTURE_SCOPE } from '../../src/chatgpt-plugin/principal.js';
 
 const CAPTURE = {
@@ -46,5 +47,69 @@ describe('file observation capture store', () => {
     const records = files.map((path) => readFileSync(join(dir, path), 'utf8'));
     assert.equal(records.some((record) => /tenant-secret|principal-secret/.test(record)), false);
     assert.equal(records.every((record) => JSON.parse(record).schemaVersion === 1), true);
+  });
+
+  it('keeps read, review, and sample drafts inside the same principal partition', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-feedback-store-'));
+    const store = new FileObservationFeedbackStore({
+      observationsDir: dir,
+      now: () => new Date('2026-08-25T01:02:03.000Z'),
+    });
+    const principalA = {
+      tenantId: 'tenant-a',
+      principalId: 'principal-a',
+      scopes: [OBSERVATION_CAPTURE_SCOPE],
+    };
+    const principalB = {
+      tenantId: 'tenant-a',
+      principalId: 'principal-b',
+      scopes: [OBSERVATION_CAPTURE_SCOPE],
+    };
+    const captured = await store.create(principalA, {
+      ...CAPTURE,
+      evidenceSnippet: '用户授权的可见证据。',
+    });
+
+    await assert.rejects(
+      () => store.get(principalB, captured.observationId),
+      (error: unknown) => (error as { code?: string }).code === 'observation_not_found',
+    );
+    await assert.rejects(
+      () => store.draftSample(principalA, {
+        observationId: captured.observationId,
+        prompt: '生成草稿。',
+      }),
+      (error: unknown) => (error as { code?: string }).code === 'observation_review_required',
+    );
+
+    const review = await store.review(principalA, {
+      observationId: captured.observationId,
+      verdict: 'real_issue',
+      note: '已复核。',
+    });
+    assert.equal(review.review.verdict, 'real_issue');
+    const firstDraft = await store.draftSample(principalA, {
+      observationId: captured.observationId,
+      prompt: '重现该 knowledge gap。',
+      rubric: '回答应满足已确认的知识要求。',
+      draftId: 'stable-draft-id',
+    });
+    const duplicateDraft = await store.draftSample(principalA, {
+      observationId: captured.observationId,
+      prompt: '重现该 knowledge gap。',
+      rubric: '回答应满足已确认的知识要求。',
+      draftId: 'stable-draft-id',
+    });
+    assert.equal(firstDraft.created, true);
+    assert.equal(duplicateDraft.created, false);
+    assert.equal(firstDraft.draft.status, 'draft');
+    assert.equal(firstDraft.draft.sample.provenance, 'production-trace');
+    assert.equal(firstDraft.draft.sourceEvidence[0]?.captureId.length, 24);
+
+    const detail = await store.get(principalA, captured.observationId);
+    assert.equal(detail.review?.verdict, 'real_issue');
+    assert.equal(detail.evidence[0]?.evidenceSnippet, '用户授权的可见证据。');
+    assert.equal(detail.captureCoverage.coverageStatus, 'partial');
+    assert.equal(existsSync(join(dir, 'sample-drafts.json')), false);
   });
 });

--- a/test/chatgpt-plugin/http.test.ts
+++ b/test/chatgpt-plugin/http.test.ts
@@ -7,11 +7,15 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { describe, it } from 'vitest';
 import { FileObservationCaptureStore } from '../../src/chatgpt-plugin/capture-store.js';
+import { FileObservationFeedbackStore } from '../../src/chatgpt-plugin/feedback-store.js';
 import {
   startChatGptObservationHttpServer,
 } from '../../src/chatgpt-plugin/http.js';
 import {
   OBSERVATION_CAPTURE_SCOPE,
+  OBSERVATION_DRAFT_SCOPE,
+  OBSERVATION_READ_SCOPE,
+  OBSERVATION_REVIEW_SCOPE,
   ObservationPrincipalError,
   type ObservationPrincipal,
   type PrincipalResolver,
@@ -21,12 +25,22 @@ const TOKEN_PRINCIPALS: Record<string, ObservationPrincipal> = {
   'token-a': {
     tenantId: 'tenant-a',
     principalId: 'principal-a',
-    scopes: [OBSERVATION_CAPTURE_SCOPE],
+    scopes: [
+      OBSERVATION_CAPTURE_SCOPE,
+      OBSERVATION_READ_SCOPE,
+      OBSERVATION_REVIEW_SCOPE,
+      OBSERVATION_DRAFT_SCOPE,
+    ],
   },
   'token-b': {
     tenantId: 'tenant-a',
     principalId: 'principal-b',
-    scopes: [OBSERVATION_CAPTURE_SCOPE],
+    scopes: [
+      OBSERVATION_CAPTURE_SCOPE,
+      OBSERVATION_READ_SCOPE,
+      OBSERVATION_REVIEW_SCOPE,
+      OBSERVATION_DRAFT_SCOPE,
+    ],
   },
   'token-no-scope': {
     tenantId: 'tenant-a',
@@ -57,7 +71,7 @@ describe('ChatGPT observation Streamable HTTP server', () => {
   it('uses one tool contract and isolates idempotency by server-resolved principal', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-http-mcp-'));
     const started = await startChatGptObservationHttpServer({
-      captureStore: new FileObservationCaptureStore({ observationsDir: dir }),
+      captureStore: new FileObservationFeedbackStore({ observationsDir: dir }),
       principalResolver: resolver,
     });
     const clientA = createClient(started.url, 'token-a');
@@ -65,7 +79,12 @@ describe('ChatGPT observation Streamable HTTP server', () => {
     try {
       await Promise.all([clientA.connect(), clientB.connect()]);
       const tools = await clientA.client.listTools();
-      assert.deepEqual(tools.tools.map((tool) => tool.name), ['capture_observation']);
+      assert.deepEqual(tools.tools.map((tool) => tool.name), [
+        'capture_observation',
+        'get_observation',
+        'record_observation_review',
+        'draft_sample_from_observation',
+      ]);
 
       const first = await clientA.client.callTool(captureRequest());
       const duplicate = await clientA.client.callTool(captureRequest());

--- a/test/chatgpt-plugin/mcp-server.test.ts
+++ b/test/chatgpt-plugin/mcp-server.test.ts
@@ -6,6 +6,9 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { describe, it } from 'vitest';
 import { createChatGptObservationMcpServer } from '../../src/chatgpt-plugin/mcp-server.js';
+import { FileObservationCaptureStore } from '../../src/chatgpt-plugin/capture-store.js';
+import { FileObservationFeedbackStore } from '../../src/chatgpt-plugin/feedback-store.js';
+import { OBSERVATION_CAPTURE_SCOPE } from '../../src/chatgpt-plugin/principal.js';
 import { queryObservationInbox } from '../../src/observability/inbox.js';
 
 describe('ChatGPT observation MCP server', () => {
@@ -17,8 +20,14 @@ describe('ChatGPT observation MCP server', () => {
     await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
     try {
       const tools = await client.listTools();
-      assert.equal(tools.tools.length, 1);
-      const [tool] = tools.tools;
+      assert.deepEqual(tools.tools.map((tool) => tool.name), [
+        'capture_observation',
+        'get_observation',
+        'record_observation_review',
+        'draft_sample_from_observation',
+      ]);
+      const tool = tools.tools[0];
+      assert.ok(tool);
       assert.equal(tool.name, 'capture_observation');
       assert.deepEqual(tool.annotations, {
         readOnlyHint: false,
@@ -71,6 +80,47 @@ describe('ChatGPT observation MCP server', () => {
     }
   });
 
+  it('advertises only the tools allowed by the resolved principal scopes', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-chatgpt-mcp-scopes-'));
+    const server = createChatGptObservationMcpServer({
+      principal: {
+        tenantId: 'tenant',
+        principalId: 'capture-only',
+        scopes: [OBSERVATION_CAPTURE_SCOPE],
+      },
+      captureStore: new FileObservationFeedbackStore({ observationsDir: dir }),
+    });
+    const client = new Client({ name: 'omk-test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      assert.deepEqual((await client.listTools()).tools.map((tool) => tool.name), [
+        'capture_observation',
+      ]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('keeps capture-only store adapters backward compatible', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-chatgpt-mcp-capture-only-'));
+    const server = createChatGptObservationMcpServer({
+      captureStore: new FileObservationCaptureStore({ observationsDir: dir }),
+    });
+    const client = new Client({ name: 'omk-test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      assert.deepEqual((await client.listTools()).tools.map((tool) => tool.name), [
+        'capture_observation',
+      ]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
   it('rejects calls without explicit confirmation', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-chatgpt-mcp-reject-'));
     const server = createChatGptObservationMcpServer({ observationsDir: dir });
@@ -88,6 +138,89 @@ describe('ChatGPT observation MCP server', () => {
       });
       assert.equal(response.isError, true);
       assert.equal(queryObservationInbox(dir).length, 0);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('reads, reviews, and drafts without promoting unconfirmed feedback', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-chatgpt-mcp-feedback-'));
+    const server = createChatGptObservationMcpServer({
+      observationsDir: dir,
+      now: () => new Date('2026-08-24T02:03:04.000Z'),
+    });
+    const client = new Client({ name: 'omk-test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      const captured = await client.callTool({
+        name: 'capture_observation',
+        arguments: {
+          skillName: 'omk',
+          userFeedback: '缺少公司内部宿主的通用接入边界。',
+          evidenceSnippet: '私有系统只应注入 identity 和 storage。',
+          captureId: 'feedback-loop-1',
+          confirmedByUser: true,
+        },
+      });
+      const observationId = (captured.structuredContent as { observationId: string }).observationId;
+
+      const beforeReview = await client.callTool({
+        name: 'draft_sample_from_observation',
+        arguments: { observationId, prompt: '说明公共 OMK 与私有宿主的边界。' },
+      });
+      assert.equal(beforeReview.isError, true);
+
+      const reviewed = await client.callTool({
+        name: 'record_observation_review',
+        arguments: { observationId, verdict: 'real_issue', note: '人工确认。' },
+      });
+      assert.notEqual(reviewed.isError, true);
+
+      const drafted = await client.callTool({
+        name: 'draft_sample_from_observation',
+        arguments: {
+          observationId,
+          prompt: '说明公共 OMK 与私有宿主的边界。',
+          rubric: '必须明确身份、存储和部署由宿主负责。',
+          draftId: 'feedback-loop-draft-1',
+        },
+      });
+      assert.notEqual(drafted.isError, true);
+      assert.deepEqual(drafted.structuredContent, {
+        draftId: (drafted.structuredContent as { draftId: string }).draftId,
+        createdAt: '2026-08-24T02:03:04.000Z',
+        created: true,
+        status: 'draft',
+        observationId,
+        sourceEvidence: [{
+          captureId: (drafted.structuredContent as { sourceEvidence: Array<{ captureId: string }> })
+            .sourceEvidence[0]?.captureId,
+          payloadHash: (drafted.structuredContent as { sourceEvidence: Array<{ payloadHash: string }> })
+            .sourceEvidence[0]?.payloadHash,
+          capturedAt: '2026-08-24T02:03:04.000Z',
+        }],
+        sample: {
+          sample_id: `observation-${observationId.slice(0, 16)}`,
+          prompt: '说明公共 OMK 与私有宿主的边界。',
+          rubric: '必须明确身份、存储和部署由宿主负责。',
+          provenance: 'production-trace',
+        },
+      });
+
+      const detail = await client.callTool({
+        name: 'get_observation',
+        arguments: { observationId },
+      });
+      const detailContent = detail.structuredContent as {
+        occurrences: number;
+        review?: { verdict: string };
+        captureCoverage: { coverageStatus: string };
+      };
+      assert.equal(detailContent.occurrences, 1);
+      assert.equal(detailContent.review?.verdict, 'real_issue');
+      assert.equal(detailContent.captureCoverage.coverageStatus, 'partial');
     } finally {
       await client.close();
       await server.close();

--- a/test/chatgpt-plugin/principal.test.ts
+++ b/test/chatgpt-plugin/principal.test.ts
@@ -1,8 +1,15 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import {
+  assertObservationAccessScope,
   assertObservationCaptureScope,
+  assertObservationDraftScope,
+  assertObservationReadScope,
+  assertObservationReviewScope,
   OBSERVATION_CAPTURE_SCOPE,
+  OBSERVATION_DRAFT_SCOPE,
+  OBSERVATION_READ_SCOPE,
+  OBSERVATION_REVIEW_SCOPE,
   ObservationPrincipalError,
   validateObservationPrincipal,
 } from '../../src/chatgpt-plugin/principal.js';
@@ -39,5 +46,19 @@ describe('observation principal', () => {
       (error: unknown) => error instanceof ObservationPrincipalError
         && error.code === 'forbidden',
     );
+  });
+
+  it('keeps read, review, and draft permissions independent', () => {
+    const principal = {
+      tenantId: 'tenant',
+      principalId: 'subject',
+      scopes: [OBSERVATION_READ_SCOPE, OBSERVATION_REVIEW_SCOPE],
+    };
+    assert.doesNotThrow(() => assertObservationAccessScope(principal));
+    assert.doesNotThrow(() => assertObservationReadScope(principal));
+    assert.doesNotThrow(() => assertObservationReviewScope(principal));
+    assert.throws(() => assertObservationCaptureScope(principal), ObservationPrincipalError);
+    assert.throws(() => assertObservationDraftScope(principal), ObservationPrincipalError);
+    assert.equal(OBSERVATION_DRAFT_SCOPE, 'observation:draft');
   });
 });


### PR DESCRIPTION
## 用户影响

ChatGPT／MCP 用户现在可以在显式采集后读取 observation、记录人工复核结论，并从已确认的真实问题生成候选 regression sample 草稿。草稿保留原始 evidence hash 和 `production-trace` provenance，不会写入正式评测集。

## 架构边界

- 保留 capture-only `ObservationCaptureStore`，新增独立的 `ObservationFeedbackStore`，避免既有 adapter 被迫承诺未实现能力。
- 工具面同时受 Store capability 和 principal scope 裁剪；身份解析、组织权限、持久化和 HTTPS 部署继续由外部宿主注入。
- 内置 File Store 按 tenant／principal 哈希分区；所有读取、复核和草稿操作都保持同一隔离边界。
- 只有人工复核为 `real_issue` 的 observation 才能生成草稿；该门禁在 MCP 应用层和 File Store 重复执行。

## 迁移说明

现有 `ObservationCaptureStore` adapter 无需修改，仍只暴露 `capture_observation`。需要完整闭环的宿主改为实现 `ObservationFeedbackStore`，并分别授予 `observation:read`、`observation:review` 和 `observation:draft` scope。

## 观测与测量 caveat

ChatGPT 来源继续固定标记为 `coverageStatus: partial`。候选 sample 由当前 ChatGPT 基于用户授权证据提出，不把当前对话模型视为受控 executor 或评委，也不会未经人工确认污染正式基准集。

Closes part of #415
Related to #414