### PR TITLE
feat(server): 增加 ChatGPT observation 复核组件

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Observe uses the profile's `sessionPersistence` directly, so users do not export
 
 ### Connect ChatGPT (experimental)
 
-`omk-chatgpt-mcp` is a stdio MCP server. During local development, OpenAI's [Secure MCP Tunnel](https://developers.openai.com/plugins/build/mcp-server#secure-mcp-tunnel) can expose it to ChatGPT. It calls `capture_observation` only after the user explicitly asks to record feedback, appends the feedback and optional evidence under `.omk/observe-inbox/captures/`, and makes it available to `omk observe inbox` and Studio for review.
+`omk-chatgpt-mcp` is a stdio MCP server. During local development, OpenAI's [Secure MCP Tunnel](https://developers.openai.com/plugins/build/mcp-server#secure-mcp-tunnel) can expose it to ChatGPT. It calls `capture_observation` only after the user explicitly asks to record feedback, appends the feedback and optional evidence under `.omk/observe-inbox/captures/`, and can render an inline MCP Apps review card for a human verdict and regression-sample draft.
 
 ```bash
 omk-chatgpt-mcp

--- a/README.zh.md
+++ b/README.zh.md
@@ -199,7 +199,7 @@ observe 直接使用 profile 的 `sessionPersistence`，无需导出或定位 JS
 
 ### 连接 ChatGPT（实验性）
 
-`omk-chatgpt-mcp` 提供一个 stdio MCP Server；本地开发时可配合 OpenAI 的 [Secure MCP Tunnel](https://developers.openai.com/plugins/build/mcp-server#secure-mcp-tunnel) 接入 ChatGPT。它只在用户明确要求记录时调用 `capture_observation`，把反馈和可选证据追加到 `.omk/observe-inbox/captures/`；随后可用 `omk observe inbox` 或 Studio 复核。
+`omk-chatgpt-mcp` 提供一个 stdio MCP Server；本地开发时可配合 OpenAI 的 [Secure MCP Tunnel](https://developers.openai.com/plugins/build/mcp-server#secure-mcp-tunnel) 接入 ChatGPT。它只在用户明确要求记录时调用 `capture_observation`，把反馈和可选证据追加到 `.omk/observe-inbox/captures/`，并可渲染对话内 MCP Apps 复核卡片，供人工确认问题和生成 regression sample 草稿。
 
 ```bash
 omk-chatgpt-mcp

--- a/docs/guides/chatgpt-mcp-integration.md
+++ b/docs/guides/chatgpt-mcp-integration.md
@@ -20,10 +20,19 @@ This integration captures only user-authorized feedback submitted through the to
 | `get_observation` | `observation:read` | Returns only evidence, review state, and `partial` coverage from the current principal partition |
 | `record_observation_review` | `observation:review` | Records only `real_issue`, `not_issue`, or `needs_more_context` human decisions |
 | `draft_sample_from_observation` | `observation:draft` | Drafts only from `real_issue`; never writes the formal eval sample set |
+| `render_observation_review` | `observation:read` | Renders the optional inline review component from an authoritative observation snapshot |
 
 For `draft_sample_from_observation`, the current ChatGPT proposes a candidate prompt and rubric from the authorized evidence returned by `get_observation`. OMK owns the review gate, provenance, source-evidence references, and draft status; it does not treat ChatGPT as a controlled judge.
 
 MCP `tools/list` is also filtered by the scopes returned by the resolver: capabilities a user does not have are omitted from that user's tool list.
+
+## Inline review component
+
+The four data tools remain useful in any MCP client without custom UI. `render_observation_review` is a separate presentation tool and is the only tool associated with the versioned `ui://omk/observation-review/v1.html` resource. This prevents capture, reads, and writes from remounting the component unnecessarily.
+
+The component follows the open MCP Apps bridge: it receives structured tool results through `ui/notifications/tool-result` and invokes review, refresh, and draft operations through `tools/call`. It does not keep authoritative review or draft state in browser storage. Every mutation is re-authorized and persisted by the server. The card always displays `coverageStatus: partial` and lists the unavailable event kinds before offering a human verdict.
+
+A typical model flow is `get_observation` followed by `render_observation_review`. The model may include a proposed prompt and rubric based only on the authorized evidence returned by `get_observation`; the user can edit them before creating a draft. See OpenAI's [MCP Apps UI guide](https://developers.openai.com/plugins/build/chatgpt-ui) for the standard resource and bridge contract.
 
 ## Local stdio
 
@@ -92,7 +101,7 @@ With no resolver, the HTTP helper binds to loopback by default and uses the loca
 
 ## Implement another store
 
-`ObservationCaptureStore` is the minimal persistence seam; implementing it registers only `capture_observation`. `ObservationFeedbackStore` adds `get`, `review`, and `draftSample`; the server registers the other three tools only when the store implements that full contract. Existing adapters therefore do not falsely advertise capabilities they have not implemented.
+`ObservationCaptureStore` is the minimal persistence seam; implementing it registers only `capture_observation`. `ObservationFeedbackStore` adds `get`, `review`, and `draftSample`; the server registers the three feedback data tools and the optional review component only when the store implements that full contract. Existing adapters therefore do not falsely advertise capabilities they have not implemented.
 
 OMK also exports helpers that prepare the canonical v1 record and build the canonical result, so a capture adapter does not need to recreate capture hashes, coverage, or Inbox identity.
 
@@ -133,6 +142,6 @@ Start the HTTP service, then run:
 npx @modelcontextprotocol/inspector@latest
 ```
 
-Select **Streamable HTTP**, enter the actual URL returned by `startChatGptObservationHttpServer`, and configure the credential expected by the host resolver. Verify initialization, `tools/list`, the tool annotations, an authorized call, a repeated call with `created: false`, invalid confirmation, missing scope, and invalid credentials. OpenAI's [MCP server guide](https://developers.openai.com/plugins/build/mcp-server#run-and-test-locally) recommends Inspector verification before connecting the endpoint to ChatGPT.
+Select **Streamable HTTP**, enter the actual URL returned by `startChatGptObservationHttpServer`, and configure the credential expected by the host resolver. Verify initialization, `tools/list`, `resources/list`, the component resource MIME type, the tool annotations, an authorized call, a repeated call with `created: false`, invalid confirmation, missing scope, and invalid credentials. Call `get_observation`, then `render_observation_review`; the latter should be the only tool carrying `_meta.ui.resourceUri`. OpenAI's [MCP server guide](https://developers.openai.com/plugins/build/mcp-server#run-and-test-locally) recommends Inspector verification before connecting the endpoint to ChatGPT.
 
 Secure MCP Tunnel can expose a private development server to ChatGPT developer mode. It is a development connection path, not a replacement for the stable public HTTPS endpoint required for public plugin submission.

--- a/docs/guides/chatgpt-mcp-integration.md
+++ b/docs/guides/chatgpt-mcp-integration.md
@@ -30,7 +30,7 @@ MCP `tools/list` is also filtered by the scopes returned by the resolver: capabi
 
 The four data tools remain useful in any MCP client without custom UI. `render_observation_review` is a separate presentation tool and is the only tool associated with the versioned `ui://omk/observation-review/v1.html` resource. This prevents capture, reads, and writes from remounting the component unnecessarily.
 
-The component follows the open MCP Apps bridge: it receives structured tool results through `ui/notifications/tool-result` and invokes review, refresh, and draft operations through `tools/call`. It does not keep authoritative review or draft state in browser storage. Every mutation is re-authorized and persisted by the server. The card always displays `coverageStatus: partial` and lists the unavailable event kinds before offering a human verdict.
+The component follows the open MCP Apps bridge: it receives structured tool results through `ui/notifications/tool-result` and invokes review and draft operations through `tools/call`. It does not keep authoritative review or draft state in browser storage. Every mutation is re-authorized and persisted by the server, and the component updates from the authoritative write result. The card always displays `coverageStatus: partial` and lists the unavailable event kinds before offering a human verdict.
 
 A typical model flow is `get_observation` followed by `render_observation_review`. The model may include a proposed prompt and rubric based only on the authorized evidence returned by `get_observation`; the user can edit them before creating a draft. See OpenAI's [MCP Apps UI guide](https://developers.openai.com/plugins/build/chatgpt-ui) for the standard resource and bridge contract.
 

--- a/docs/zh/guides/chatgpt-mcp-integration.md
+++ b/docs/zh/guides/chatgpt-mcp-integration.md
@@ -20,10 +20,19 @@ OMK 为本地 stdio 和标准 Streamable HTTP 暴露同一份 knowledge feedback
 | `get_observation` | `observation:read` | 只返回当前 principal 分区中的证据、复核状态和 `partial` coverage |
 | `record_observation_review` | `observation:review` | 只记录 `real_issue`／`not_issue`／`needs_more_context` 人工结论 |
 | `draft_sample_from_observation` | `observation:draft` | 只允许从 `real_issue` 生成候选草稿；不写正式 eval sample |
+| `render_observation_review` | `observation:read` | 从权威 observation 快照渲染可选的对话内复核组件 |
 
 `draft_sample_from_observation` 由当前 ChatGPT 根据 `get_observation` 返回的授权证据提供候选 prompt 和 rubric。OMK 负责复核门禁、provenance、原始证据引用和草稿状态，不把 ChatGPT 当作受控评委。
 
 MCP `tools/list` 还会按 resolver 返回的 scope 裁剪：用户没有的能力不会出现在工具列表中。
+
+## 对话内复核组件
+
+四个数据工具在不支持自定义 UI 的 MCP 客户端中仍可独立使用。`render_observation_review` 是单独的展示工具，也是唯一关联版本化 `ui://omk/observation-review/v1.html` resource 的工具；capture、读取和写入不会反复挂载组件。
+
+组件遵循开放 MCP Apps bridge：通过 `ui/notifications/tool-result` 接收结构化工具结果，通过 `tools/call` 发起复核、刷新和草稿操作。组件不在浏览器存储中保存权威 review 或 draft 状态；每次变更仍由服务端重新鉴权并持久化。卡片会先展示 `coverageStatus: partial` 和未观测事件，再提供人工结论操作。
+
+典型模型调用顺序是先 `get_observation`，再 `render_observation_review`。模型只能根据 `get_observation` 返回的授权证据提出候选 prompt 和 rubric，用户可在生成草稿前编辑。标准 resource 与 bridge 契约见 OpenAI 的 [MCP Apps UI 指南](https://developers.openai.com/plugins/build/chatgpt-ui)。
 
 ## 本地 stdio
 
@@ -92,7 +101,7 @@ console.log(started.url.href);
 
 ## 实现其它 Store
 
-`ObservationCaptureStore` 是最小持久化接缝；实现它时 MCP Server 只注册 `capture_observation`。`ObservationFeedbackStore` 在此基础上增加 `get`、`review` 和 `draftSample`；实现完整接口时才注册后三个工具。这样旧 adapter 不会被迫虚假承诺未实现的能力。
+`ObservationCaptureStore` 是最小持久化接缝；实现它时 MCP Server 只注册 `capture_observation`。`ObservationFeedbackStore` 在此基础上增加 `get`、`review` 和 `draftSample`；实现完整接口时才注册三个 feedback 数据工具和可选复核组件。这样旧 adapter 不会被迫虚假承诺未实现的能力。
 
 OMK 同时导出准备标准 v1 record 和生成标准结果的 helper，因此 capture adapter 不需要重新实现 capture 哈希、coverage 或 Inbox identity。
 
@@ -133,6 +142,6 @@ const captureStore: ObservationCaptureStore = {
 npx @modelcontextprotocol/inspector@latest
 ```
 
-选择 **Streamable HTTP**，填入 `startChatGptObservationHttpServer` 返回的实际 URL，并配置宿主 resolver 所需的凭据。依次验证初始化、`tools/list`、工具 annotation、授权调用、重复调用返回 `created: false`、无效确认、缺少 scope 和无效凭据。OpenAI 的 [MCP Server 指南](https://developers.openai.com/plugins/build/mcp-server#run-and-test-locally)建议在连接 ChatGPT 前先完成 Inspector 验证。
+选择 **Streamable HTTP**，填入 `startChatGptObservationHttpServer` 返回的实际 URL，并配置宿主 resolver 所需的凭据。依次验证初始化、`tools/list`、`resources/list`、组件 resource 的 MIME type、工具 annotation、授权调用、重复调用返回 `created: false`、无效确认、缺少 scope 和无效凭据。先调用 `get_observation`，再调用 `render_observation_review`；后者应是唯一携带 `_meta.ui.resourceUri` 的工具。OpenAI 的 [MCP Server 指南](https://developers.openai.com/plugins/build/mcp-server#run-and-test-locally)建议在连接 ChatGPT 前先完成 Inspector 验证。
 
 Secure MCP Tunnel 可以在 ChatGPT developer mode 中连接私有开发服务。它是开发连接路径，不能代替公开提交插件所需的稳定公共 HTTPS endpoint。

--- a/docs/zh/guides/chatgpt-mcp-integration.md
+++ b/docs/zh/guides/chatgpt-mcp-integration.md
@@ -30,7 +30,7 @@ MCP `tools/list` 还会按 resolver 返回的 scope 裁剪：用户没有的能�
 
 四个数据工具在不支持自定义 UI 的 MCP 客户端中仍可独立使用。`render_observation_review` 是单独的展示工具，也是唯一关联版本化 `ui://omk/observation-review/v1.html` resource 的工具；capture、读取和写入不会反复挂载组件。
 
-组件遵循开放 MCP Apps bridge：通过 `ui/notifications/tool-result` 接收结构化工具结果，通过 `tools/call` 发起复核、刷新和草稿操作。组件不在浏览器存储中保存权威 review 或 draft 状态；每次变更仍由服务端重新鉴权并持久化。卡片会先展示 `coverageStatus: partial` 和未观测事件，再提供人工结论操作。
+组件遵循开放 MCP Apps bridge：通过 `ui/notifications/tool-result` 接收结构化工具结果，通过 `tools/call` 发起复核和草稿操作。组件不在浏览器存储中保存权威 review 或 draft 状态；每次变更仍由服务端重新鉴权并持久化，组件根据写工具返回的权威结果更新。卡片会先展示 `coverageStatus: partial` 和未观测事件，再提供人工结论操作。
 
 典型模型调用顺序是先 `get_observation`，再 `render_observation_review`。模型只能根据 `get_observation` 返回的授权证据提出候选 prompt 和 rubric，用户可在生成草稿前编辑。标准 resource 与 bridge 契约见 OpenAI 的 [MCP Apps UI 指南](https://developers.openai.com/plugins/build/chatgpt-ui)。
 

--- a/src/chatgpt-plugin/index.ts
+++ b/src/chatgpt-plugin/index.ts
@@ -3,6 +3,7 @@ export * from './feedback-store.js';
 export * from './http.js';
 export * from './mcp-server.js';
 export * from './principal.js';
+export * from './review-component.js';
 export {
   assertCompatibleExplicitObservationCapture,
   ExplicitObservationCaptureConflictError,

--- a/src/chatgpt-plugin/mcp-server.ts
+++ b/src/chatgpt-plugin/mcp-server.ts
@@ -11,6 +11,7 @@ import {
   isObservationFeedbackStore,
   ObservationFeedbackStoreError,
 } from './feedback-store.js';
+import { registerObservationReviewComponent } from './review-component.js';
 import {
   assertObservationCaptureScope,
   assertObservationDraftScope,
@@ -332,5 +333,9 @@ export function registerChatGptObservationTools(
       },
     };
     });
+  }
+
+  if (principal.scopes.includes(OBSERVATION_READ_SCOPE)) {
+    registerObservationReviewComponent(server, { principal, feedbackStore });
   }
 }

--- a/src/chatgpt-plugin/review-component.ts
+++ b/src/chatgpt-plugin/review-component.ts
@@ -523,6 +523,7 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
       let nextRequestId = 1;
       let state;
       let busy = false;
+      let reviewNoteDirty = false;
 
       const zh = (navigator.language || "").toLowerCase().startsWith("zh");
       const copy = zh ? {
@@ -563,6 +564,8 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
         draftFailed: "生成草稿失败：",
         draftPermission: "当前连接没有生成草稿的权限。",
         emptyEvidence: "没有可展示的授权证据。",
+        invalidReviewResponse: "复核服务未返回权威状态。",
+        invalidDraftResponse: "草稿服务未返回有效结果。",
         unknownError: "未知错误"
       } : {
         loading: "Preparing observation review…",
@@ -602,6 +605,8 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
         draftFailed: "Draft failed: ",
         draftPermission: "This connection cannot create drafts.",
         emptyEvidence: "No authorized evidence is available.",
+        invalidReviewResponse: "The review service did not return authoritative state.",
+        invalidDraftResponse: "The draft service did not return a valid result.",
         unknownError: "Unknown error"
       };
 
@@ -616,6 +621,13 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
 
       function errorText(error) {
         return error && typeof error.message === "string" ? error.message : copy.unknownError;
+      }
+
+      function toolResultError(result) {
+        const textItem = result && Array.isArray(result.content)
+          ? result.content.find((item) => item && item.type === "text" && typeof item.text === "string")
+          : undefined;
+        return new Error(textItem && textItem.text ? textItem.text : copy.unknownError);
       }
 
       function setStatus(id, message, tone) {
@@ -695,7 +707,11 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
 
         document.getElementById("review-heading").textContent = copy.review;
         document.getElementById("note-label").textContent = copy.note;
-        document.getElementById("review-note").placeholder = copy.notePlaceholder;
+        const reviewNote = document.getElementById("review-note");
+        reviewNote.placeholder = copy.notePlaceholder;
+        if (!reviewNoteDirty && document.activeElement !== reviewNote) {
+          reviewNote.value = String((observation.review && observation.review.note) || "");
+        }
         const verdict = observation.review && observation.review.verdict;
         document.getElementById("current-verdict").textContent = verdict
           ? copy.verdict[verdict] || verdict
@@ -706,7 +722,7 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
           button.dataset.active = String(value === verdict);
           button.hidden = !state.actions.canReview;
         });
-        document.getElementById("review-note").hidden = !state.actions.canReview;
+        reviewNote.hidden = !state.actions.canReview;
         document.getElementById("note-label").hidden = !state.actions.canReview;
         if (!state.actions.canReview) setStatus("review-status", copy.readOnly, "");
 
@@ -729,27 +745,13 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
         if (draftVisible && !state.actions.canDraft) setStatus("draft-status", copy.draftPermission, "");
       }
 
-      async function refreshObservation() {
-        const result = await request("tools/call", {
-          name: "get_observation",
-          arguments: { observationId: state.observation.observationId }
-        });
-        if (result && result.structuredContent) {
-          render({
-            observation: result.structuredContent,
-            actions: state.actions,
-            proposal: state.proposal
-          });
-        }
-      }
-
       document.querySelectorAll("[data-verdict]").forEach((button) => {
         button.addEventListener("click", async () => {
           if (busy || !state || !state.actions.canReview) return;
           setBusy(true);
           setStatus("review-status", "", "");
           try {
-            await request("tools/call", {
+            const result = await request("tools/call", {
               name: "record_observation_review",
               arguments: {
                 observationId: state.observation.observationId,
@@ -757,7 +759,14 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
                 note: document.getElementById("review-note").value.trim() || undefined
               }
             });
-            await refreshObservation();
+            const review = result && result.structuredContent && result.structuredContent.review;
+            if (!review) throw new Error(copy.invalidReviewResponse);
+            reviewNoteDirty = false;
+            render({
+              observation: { ...state.observation, review },
+              actions: state.actions,
+              proposal: state.proposal
+            });
             setStatus("review-status", copy.reviewSaved, "success");
           } catch (error) {
             setStatus("review-status", copy.reviewFailed + errorText(error), "error");
@@ -765,6 +774,10 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
             setBusy(false);
           }
         });
+      });
+
+      document.getElementById("review-note").addEventListener("input", () => {
+        reviewNoteDirty = true;
       });
 
       document.getElementById("draft-button").addEventListener("click", async () => {
@@ -778,7 +791,7 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
         setBusy(true);
         setStatus("draft-status", "", "");
         try {
-          await request("tools/call", {
+          const result = await request("tools/call", {
             name: "draft_sample_from_observation",
             arguments: {
               observationId: state.observation.observationId,
@@ -786,6 +799,9 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
               rubric: rubric || undefined
             }
           });
+          if (!result || !result.structuredContent || result.structuredContent.status !== "draft") {
+            throw new Error(copy.invalidDraftResponse);
+          }
           setStatus("draft-status", copy.draftSaved, "success");
         } catch (error) {
           setStatus("draft-status", copy.draftFailed + errorText(error), "error");
@@ -802,7 +818,9 @@ export const observationReviewComponentHtml = String.raw`<!doctype html>
           const pending = pendingRequests.get(message.id);
           pendingRequests.delete(message.id);
           if (message.error) pending.reject(message.error);
-          else pending.resolve(message.result);
+          else if (message.result && message.result.isError) {
+            pending.reject(toolResultError(message.result));
+          } else pending.resolve(message.result);
           return;
         }
         if (message.method === "ui/notifications/tool-result") {

--- a/src/chatgpt-plugin/review-component.ts
+++ b/src/chatgpt-plugin/review-component.ts
@@ -1,0 +1,817 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type {
+  ObservationDetail,
+  ObservationFeedbackStore,
+} from './feedback-store.js';
+import {
+  OBSERVATION_DRAFT_SCOPE,
+  OBSERVATION_REVIEW_SCOPE,
+  type ObservationPrincipal,
+} from './principal.js';
+
+export const OBSERVATION_REVIEW_RESOURCE_URI = 'ui://omk/observation-review/v1.html';
+export const MCP_APP_HTML_MIME_TYPE = 'text/html;profile=mcp-app';
+
+const observedEventKindSchema = z.enum([
+  'tool_boundary',
+  'user_feedback',
+  'submitted_evidence',
+]);
+const unavailableEventKindSchema = z.enum([
+  'full_conversation',
+  'external_tool_calls',
+  'hidden_reasoning',
+]);
+const reviewVerdictSchema = z.enum([
+  'reviewed',
+  'real_issue',
+  'not_issue',
+  'needs_more_context',
+]);
+const reviewComponentOutputSchema = {
+  observation: z.object({
+    observationId: z.string(),
+    skillName: z.string(),
+    artifactVersion: z.string(),
+    firstSeen: z.string(),
+    lastSeen: z.string(),
+    occurrences: z.number().int().positive(),
+    captureCoverage: z.object({
+      coverageStatus: z.literal('partial'),
+      capturePath: z.literal('explicit_tool_call'),
+      observedEventKinds: z.array(observedEventKindSchema),
+      unavailableEventKinds: z.array(unavailableEventKindSchema),
+    }),
+    evidence: z.array(z.object({
+      captureId: z.string(),
+      capturedAt: z.string(),
+      userFeedback: z.string(),
+      evidenceSnippet: z.string().optional(),
+    })),
+    review: z.object({
+      verdict: reviewVerdictSchema,
+      reviewedAt: z.string(),
+      note: z.string().optional(),
+    }).optional(),
+  }),
+  actions: z.object({
+    canReview: z.boolean(),
+    canDraft: z.boolean(),
+  }),
+  proposal: z.object({
+    prompt: z.string(),
+    rubric: z.string().optional(),
+  }).optional(),
+};
+
+export interface ObservationReviewComponentOptions {
+  principal: ObservationPrincipal;
+  feedbackStore: ObservationFeedbackStore;
+}
+
+export function registerObservationReviewComponent(
+  server: McpServer,
+  options: ObservationReviewComponentOptions,
+): void {
+  server.registerResource('omk-observation-review', OBSERVATION_REVIEW_RESOURCE_URI, {
+    title: 'OMK observation review',
+    description: 'Inspect explicit evidence, record a human verdict, and draft a regression sample.',
+    mimeType: MCP_APP_HTML_MIME_TYPE,
+  }, async () => ({
+    contents: [{
+      uri: OBSERVATION_REVIEW_RESOURCE_URI,
+      mimeType: MCP_APP_HTML_MIME_TYPE,
+      text: observationReviewComponentHtml,
+      _meta: {
+        ui: {
+          prefersBorder: true,
+        },
+      },
+    }],
+  }));
+
+  server.registerTool('render_observation_review', {
+    title: 'Render an OMK observation review',
+    description: [
+      'Render the inline review component for an observation.',
+      'First call get_observation, propose a regression prompt only from its authorized evidence,',
+      'then pass the observationId and optional proposal to this tool.',
+    ].join(' '),
+    inputSchema: {
+      observationId: z.string().trim().min(1).max(128),
+      candidatePrompt: z.string().trim().min(1).max(16_000).optional(),
+      candidateRubric: z.string().trim().min(1).max(8_000).optional(),
+    },
+    outputSchema: reviewComponentOutputSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    _meta: {
+      ui: { resourceUri: OBSERVATION_REVIEW_RESOURCE_URI },
+      'openai/toolInvocation/invoking': 'Preparing observation review…',
+      'openai/toolInvocation/invoked': 'Observation review ready.',
+    },
+  }, async ({ observationId, candidatePrompt, candidateRubric }) => {
+    const detail = await options.feedbackStore.get(options.principal, observationId);
+    const structuredContent = {
+      observation: projectObservationForComponent(detail),
+      actions: {
+        canReview: options.principal.scopes.includes(OBSERVATION_REVIEW_SCOPE),
+        canDraft: options.principal.scopes.includes(OBSERVATION_DRAFT_SCOPE),
+      },
+      proposal: candidatePrompt ? {
+        prompt: candidatePrompt,
+        rubric: candidateRubric,
+      } : undefined,
+    };
+    return {
+      content: [{
+        type: 'text' as const,
+        text: `已准备 observation ${detail.observationId} 的复核卡片；覆盖范围为 partial。`,
+      }],
+      structuredContent,
+    };
+  });
+}
+
+function projectObservationForComponent(detail: ObservationDetail) {
+  return {
+    observationId: detail.observationId,
+    skillName: detail.skillName,
+    artifactVersion: detail.artifactVersion,
+    firstSeen: detail.firstSeen,
+    lastSeen: detail.lastSeen,
+    occurrences: detail.occurrences,
+    captureCoverage: detail.captureCoverage,
+    evidence: detail.evidence.map((item) => ({
+      captureId: item.captureId,
+      capturedAt: item.capturedAt,
+      userFeedback: item.userFeedback,
+      evidenceSnippet: item.evidenceSnippet,
+    })),
+    review: detail.review ? {
+      verdict: detail.review.verdict,
+      reviewedAt: detail.review.reviewedAt,
+      note: detail.review.note,
+    } : undefined,
+  };
+}
+
+export const observationReviewComponentHtml = String.raw`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OMK observation review</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --canvas: #eef4f6;
+      --surface: #fbfdfe;
+      --surface-raised: #ffffff;
+      --ink: #17212b;
+      --muted: #5e6e7c;
+      --line: #ccd8de;
+      --accent: #2457c5;
+      --accent-strong: #173f99;
+      --accent-soft: #e3ebff;
+      --warning: #9a4d05;
+      --warning-soft: #fff0d6;
+      --success: #087668;
+      --danger: #a33a32;
+      --focus: #8bb3ff;
+      --radius: 14px;
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      padding: 10px;
+      color: var(--ink);
+      background: transparent;
+    }
+
+    button, textarea, input { font: inherit; }
+
+    button:focus-visible, textarea:focus-visible, summary:focus-visible {
+      outline: 3px solid var(--focus);
+      outline-offset: 2px;
+    }
+
+    .card {
+      position: relative;
+      overflow: hidden;
+      max-width: 760px;
+      margin: 0 auto;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: 0 8px 24px rgba(24, 49, 64, 0.09);
+    }
+
+    .coverage-rail {
+      display: grid;
+      grid-template-columns: 8px 1fr;
+      background: var(--warning-soft);
+      border-bottom: 1px solid #e5c68e;
+    }
+
+    .coverage-rail::before {
+      content: "";
+      background: repeating-linear-gradient(
+        -45deg,
+        var(--warning) 0,
+        var(--warning) 5px,
+        #e9a94d 5px,
+        #e9a94d 10px
+      );
+    }
+
+    .coverage-copy { padding: 11px 14px 11px 12px; }
+
+    .coverage-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin: 0 0 3px;
+      color: #683100;
+      font-size: 12px;
+      font-weight: 760;
+      letter-spacing: 0.035em;
+      text-transform: uppercase;
+    }
+
+    .coverage-copy p {
+      margin: 0;
+      color: #704414;
+      font-size: 12px;
+      line-height: 1.45;
+    }
+
+    .header {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 14px;
+      align-items: start;
+      padding: 18px 20px 14px;
+    }
+
+    .eyebrow {
+      margin: 0 0 5px;
+      color: var(--accent);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(20px, 4vw, 28px);
+      line-height: 1.08;
+      letter-spacing: -0.025em;
+    }
+
+    .meta {
+      margin: 7px 0 0;
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 11px;
+      overflow-wrap: anywhere;
+    }
+
+    .count {
+      min-width: 70px;
+      padding: 9px 10px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: var(--surface-raised);
+      text-align: center;
+    }
+
+    .count strong { display: block; font-size: 24px; line-height: 1; }
+    .count span { color: var(--muted); font-size: 10px; }
+
+    .section {
+      margin: 0 20px;
+      padding: 15px 0;
+      border-top: 1px solid var(--line);
+    }
+
+    .section-heading {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 12px;
+      margin-bottom: 10px;
+    }
+
+    h2 { margin: 0; font-size: 13px; letter-spacing: 0.01em; }
+    .section-hint { color: var(--muted); font-size: 11px; }
+
+    .evidence-list { display: grid; gap: 9px; }
+
+    .evidence {
+      padding: 12px 13px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: var(--surface-raised);
+    }
+
+    .evidence-time {
+      margin: 0 0 7px;
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 10px;
+    }
+
+    .evidence p { margin: 0; font-size: 13px; line-height: 1.55; white-space: pre-wrap; }
+
+    .snippet {
+      margin-top: 8px !important;
+      padding-left: 10px;
+      border-left: 3px solid var(--accent);
+      color: var(--muted);
+    }
+
+    .verdict {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .button {
+      min-height: 38px;
+      padding: 8px 12px;
+      border: 1px solid var(--line);
+      border-radius: 9px;
+      color: var(--ink);
+      background: var(--surface-raised);
+      cursor: pointer;
+      transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+    }
+
+    .button:hover:not(:disabled) { transform: translateY(-1px); border-color: var(--accent); }
+    .button:disabled { cursor: not-allowed; opacity: 0.55; }
+    .button.primary { color: #fff; border-color: var(--accent); background: var(--accent); }
+    .button.primary:hover:not(:disabled) { background: var(--accent-strong); }
+    .button[data-active="true"] { border-color: var(--success); box-shadow: inset 0 0 0 1px var(--success); }
+
+    .field { display: grid; gap: 6px; margin-top: 11px; }
+    .field label { color: var(--muted); font-size: 11px; font-weight: 700; }
+
+    textarea {
+      width: 100%;
+      min-height: 72px;
+      resize: vertical;
+      padding: 10px 11px;
+      border: 1px solid var(--line);
+      border-radius: 9px;
+      color: var(--ink);
+      background: var(--surface-raised);
+      line-height: 1.45;
+    }
+
+    .draft-panel {
+      display: none;
+      margin-top: 13px;
+      padding: 13px;
+      border: 1px solid #b9c8ef;
+      border-radius: 10px;
+      background: var(--accent-soft);
+    }
+
+    .draft-panel[data-visible="true"] { display: block; }
+    .draft-panel h3 { margin: 0; font-size: 13px; }
+    .draft-panel p { margin: 4px 0 0; color: var(--muted); font-size: 11px; line-height: 1.45; }
+    .draft-actions { display: flex; align-items: center; gap: 10px; margin-top: 11px; }
+
+    .status {
+      min-height: 18px;
+      margin: 10px 0 0;
+      color: var(--muted);
+      font-size: 11px;
+      line-height: 1.4;
+    }
+
+    .status[data-tone="error"] { color: var(--danger); }
+    .status[data-tone="success"] { color: var(--success); }
+
+    details { margin-top: 8px; color: var(--muted); font-size: 11px; }
+    summary { width: fit-content; cursor: pointer; }
+    .unavailable { margin: 7px 0 0; padding-left: 18px; line-height: 1.6; }
+
+    .loading { padding: 26px 20px; color: var(--muted); font-size: 13px; }
+
+    @media (max-width: 520px) {
+      body { padding: 6px; }
+      .header { grid-template-columns: 1fr; padding: 16px 15px 12px; }
+      .count { display: flex; align-items: baseline; gap: 6px; width: fit-content; }
+      .count strong { font-size: 18px; }
+      .section { margin: 0 15px; }
+      .verdict { display: grid; }
+      .button { width: 100%; }
+      .draft-actions { display: grid; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .button { transition: none; }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --canvas: #172127;
+        --surface: #172127;
+        --surface-raised: #202d34;
+        --ink: #edf5f7;
+        --muted: #adbbc2;
+        --line: #3a4a52;
+        --accent: #7ca6ff;
+        --accent-strong: #507fde;
+        --accent-soft: #23365d;
+        --warning: #e5a24b;
+        --warning-soft: #3b2d1d;
+        --success: #64cdbd;
+        --danger: #ff9187;
+        --focus: #9fbeff;
+      }
+      .coverage-rail { border-bottom-color: #654c2c; }
+      .coverage-title, .coverage-copy p { color: #f2c17d; }
+      .button.primary { color: #10203d; }
+      .draft-panel { border-color: #415c93; }
+    }
+  </style>
+</head>
+<body>
+  <main class="card" aria-live="polite">
+    <div id="loading" class="loading">Preparing observation review…</div>
+    <div id="content" hidden>
+      <section class="coverage-rail" aria-labelledby="coverage-title">
+        <div class="coverage-copy">
+          <h2 id="coverage-title" class="coverage-title"></h2>
+          <p id="coverage-description"></p>
+          <details>
+            <summary id="coverage-details-label"></summary>
+            <ul id="unavailable-list" class="unavailable"></ul>
+          </details>
+        </div>
+      </section>
+
+      <header class="header">
+        <div>
+          <p id="eyebrow" class="eyebrow"></p>
+          <h1 id="skill-name"></h1>
+          <p id="observation-meta" class="meta"></p>
+        </div>
+        <div class="count"><strong id="occurrences"></strong><span id="occurrences-label"></span></div>
+      </header>
+
+      <section class="section" aria-labelledby="evidence-heading">
+        <div class="section-heading">
+          <h2 id="evidence-heading"></h2>
+          <span id="evidence-count" class="section-hint"></span>
+        </div>
+        <div id="evidence-list" class="evidence-list"></div>
+      </section>
+
+      <section class="section" aria-labelledby="review-heading">
+        <div class="section-heading">
+          <h2 id="review-heading"></h2>
+          <span id="current-verdict" class="section-hint"></span>
+        </div>
+        <div id="verdict-actions" class="verdict">
+          <button class="button" type="button" data-verdict="real_issue"></button>
+          <button class="button" type="button" data-verdict="not_issue"></button>
+          <button class="button" type="button" data-verdict="needs_more_context"></button>
+        </div>
+        <div class="field">
+          <label id="note-label" for="review-note"></label>
+          <textarea id="review-note" maxlength="500"></textarea>
+        </div>
+        <p id="review-status" class="status" role="status"></p>
+
+        <div id="draft-panel" class="draft-panel">
+          <h3 id="draft-heading"></h3>
+          <p id="draft-description"></p>
+          <div class="field">
+            <label id="prompt-label" for="candidate-prompt"></label>
+            <textarea id="candidate-prompt" maxlength="16000"></textarea>
+          </div>
+          <div class="field">
+            <label id="rubric-label" for="candidate-rubric"></label>
+            <textarea id="candidate-rubric" maxlength="8000"></textarea>
+          </div>
+          <div class="draft-actions">
+            <button id="draft-button" class="button primary" type="button"></button>
+            <span id="draft-status" class="status" role="status"></span>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <script>
+    (() => {
+      const pendingRequests = new Map();
+      let nextRequestId = 1;
+      let state;
+      let busy = false;
+
+      const zh = (navigator.language || "").toLowerCase().startsWith("zh");
+      const copy = zh ? {
+        loading: "正在准备 observation 复核…",
+        coverageTitle: "覆盖范围：部分",
+        coverageDescription: "只包含用户明确提交到 OMK 的反馈与证据，不代表完整 ChatGPT 对话。",
+        coverageDetails: "查看未观测内容",
+        unavailable: {
+          full_conversation: "完整 ChatGPT 对话",
+          external_tool_calls: "其它工具调用",
+          hidden_reasoning: "隐藏推理"
+        },
+        eyebrow: "显式 knowledge observation",
+        occurrences: "次捕获",
+        evidence: "用户授权证据",
+        evidenceCount: "条",
+        review: "人工复核",
+        notReviewed: "尚未复核",
+        verdict: {
+          reviewed: "已复核",
+          real_issue: "真实问题",
+          not_issue: "不是问题",
+          needs_more_context: "需要更多上下文"
+        },
+        note: "复核备注（可选）",
+        notePlaceholder: "记录判断依据，最多 500 字。",
+        reviewSaved: "复核结论已保存。",
+        reviewFailed: "复核失败：",
+        readOnly: "当前连接只有读取权限。",
+        draftHeading: "回归样本草稿",
+        draftDescription: "只生成候选草稿，不写入正式评测集。请先检查 prompt 与 rubric。",
+        prompt: "候选 prompt",
+        rubric: "成功标准 rubric（可选）",
+        promptPlaceholder: "输入可复现该 knowledge gap 的问题。",
+        rubricPlaceholder: "输入可审查的成功标准。",
+        createDraft: "生成 sample 草稿",
+        draftSaved: "sample 草稿已保存，状态仍为 draft。",
+        draftFailed: "生成草稿失败：",
+        draftPermission: "当前连接没有生成草稿的权限。",
+        emptyEvidence: "没有可展示的授权证据。",
+        unknownError: "未知错误"
+      } : {
+        loading: "Preparing observation review…",
+        coverageTitle: "Coverage: partial",
+        coverageDescription: "Includes only feedback and evidence explicitly submitted to OMK, not the complete ChatGPT conversation.",
+        coverageDetails: "See what was not observed",
+        unavailable: {
+          full_conversation: "Complete ChatGPT conversation",
+          external_tool_calls: "Other tool calls",
+          hidden_reasoning: "Hidden reasoning"
+        },
+        eyebrow: "Explicit knowledge observation",
+        occurrences: "captures",
+        evidence: "User-authorized evidence",
+        evidenceCount: "items",
+        review: "Human review",
+        notReviewed: "Not reviewed",
+        verdict: {
+          reviewed: "Reviewed",
+          real_issue: "Real issue",
+          not_issue: "Not an issue",
+          needs_more_context: "Needs more context"
+        },
+        note: "Review note (optional)",
+        notePlaceholder: "Record the reason for this decision, up to 500 characters.",
+        reviewSaved: "Review saved.",
+        reviewFailed: "Review failed: ",
+        readOnly: "This connection has read-only access.",
+        draftHeading: "Regression sample draft",
+        draftDescription: "Creates a candidate draft only; it does not change the formal eval set. Review the prompt and rubric first.",
+        prompt: "Candidate prompt",
+        rubric: "Success rubric (optional)",
+        promptPlaceholder: "Enter a prompt that reproduces this knowledge gap.",
+        rubricPlaceholder: "Enter reviewable success criteria.",
+        createDraft: "Create sample draft",
+        draftSaved: "Sample saved as a draft; the formal eval set is unchanged.",
+        draftFailed: "Draft failed: ",
+        draftPermission: "This connection cannot create drafts.",
+        emptyEvidence: "No authorized evidence is available.",
+        unknownError: "Unknown error"
+      };
+
+      document.documentElement.lang = zh ? "zh-CN" : "en";
+      document.getElementById("loading").textContent = copy.loading;
+
+      function request(method, params) {
+        const id = nextRequestId++;
+        window.parent.postMessage({ jsonrpc: "2.0", id, method, params }, "*");
+        return new Promise((resolve, reject) => pendingRequests.set(id, { resolve, reject }));
+      }
+
+      function errorText(error) {
+        return error && typeof error.message === "string" ? error.message : copy.unknownError;
+      }
+
+      function setStatus(id, message, tone) {
+        const element = document.getElementById(id);
+        element.textContent = message;
+        element.dataset.tone = tone || "";
+      }
+
+      function setBusy(nextBusy) {
+        busy = nextBusy;
+        document.querySelectorAll("button").forEach((button) => {
+          button.disabled = busy;
+        });
+      }
+
+      function formatTime(value) {
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString();
+      }
+
+      function renderEvidence(observation) {
+        const list = document.getElementById("evidence-list");
+        list.replaceChildren();
+        if (!Array.isArray(observation.evidence) || observation.evidence.length === 0) {
+          const empty = document.createElement("p");
+          empty.className = "section-hint";
+          empty.textContent = copy.emptyEvidence;
+          list.append(empty);
+          return;
+        }
+        observation.evidence.forEach((item) => {
+          const article = document.createElement("article");
+          article.className = "evidence";
+          const time = document.createElement("p");
+          time.className = "evidence-time";
+          time.textContent = formatTime(item.capturedAt);
+          const feedback = document.createElement("p");
+          feedback.textContent = String(item.userFeedback || "");
+          article.append(time, feedback);
+          if (item.evidenceSnippet) {
+            const snippet = document.createElement("p");
+            snippet.className = "snippet";
+            snippet.textContent = String(item.evidenceSnippet);
+            article.append(snippet);
+          }
+          list.append(article);
+        });
+      }
+
+      function render(nextState) {
+        if (!nextState || !nextState.observation || !nextState.actions) return;
+        state = nextState;
+        const observation = state.observation;
+        const coverage = observation.captureCoverage || {};
+        document.getElementById("loading").hidden = true;
+        document.getElementById("content").hidden = false;
+        document.getElementById("coverage-title").textContent = copy.coverageTitle;
+        document.getElementById("coverage-description").textContent = copy.coverageDescription;
+        document.getElementById("coverage-details-label").textContent = copy.coverageDetails;
+        const unavailable = document.getElementById("unavailable-list");
+        unavailable.replaceChildren();
+        (coverage.unavailableEventKinds || []).forEach((eventKind) => {
+          const item = document.createElement("li");
+          item.textContent = copy.unavailable[eventKind] || String(eventKind);
+          unavailable.append(item);
+        });
+        document.getElementById("eyebrow").textContent = copy.eyebrow;
+        document.getElementById("skill-name").textContent = String(observation.skillName || "OMK");
+        document.getElementById("observation-meta").textContent =
+          String(observation.observationId || "") + " · " + String(observation.artifactVersion || "unknown");
+        document.getElementById("occurrences").textContent = String(observation.occurrences || 0);
+        document.getElementById("occurrences-label").textContent = copy.occurrences;
+        document.getElementById("evidence-heading").textContent = copy.evidence;
+        document.getElementById("evidence-count").textContent =
+          String((observation.evidence || []).length) + " " + copy.evidenceCount;
+        renderEvidence(observation);
+
+        document.getElementById("review-heading").textContent = copy.review;
+        document.getElementById("note-label").textContent = copy.note;
+        document.getElementById("review-note").placeholder = copy.notePlaceholder;
+        const verdict = observation.review && observation.review.verdict;
+        document.getElementById("current-verdict").textContent = verdict
+          ? copy.verdict[verdict] || verdict
+          : copy.notReviewed;
+        document.querySelectorAll("[data-verdict]").forEach((button) => {
+          const value = button.dataset.verdict;
+          button.textContent = copy.verdict[value] || value;
+          button.dataset.active = String(value === verdict);
+          button.hidden = !state.actions.canReview;
+        });
+        document.getElementById("review-note").hidden = !state.actions.canReview;
+        document.getElementById("note-label").hidden = !state.actions.canReview;
+        if (!state.actions.canReview) setStatus("review-status", copy.readOnly, "");
+
+        const draftVisible = verdict === "real_issue";
+        const draftPanel = document.getElementById("draft-panel");
+        draftPanel.dataset.visible = String(draftVisible);
+        document.getElementById("draft-heading").textContent = copy.draftHeading;
+        document.getElementById("draft-description").textContent = copy.draftDescription;
+        document.getElementById("prompt-label").textContent = copy.prompt;
+        document.getElementById("rubric-label").textContent = copy.rubric;
+        const prompt = document.getElementById("candidate-prompt");
+        const rubric = document.getElementById("candidate-rubric");
+        prompt.placeholder = copy.promptPlaceholder;
+        rubric.placeholder = copy.rubricPlaceholder;
+        if (state.proposal && !prompt.value) prompt.value = String(state.proposal.prompt || "");
+        if (state.proposal && !rubric.value) rubric.value = String(state.proposal.rubric || "");
+        const draftButton = document.getElementById("draft-button");
+        draftButton.textContent = copy.createDraft;
+        draftButton.hidden = !state.actions.canDraft;
+        if (draftVisible && !state.actions.canDraft) setStatus("draft-status", copy.draftPermission, "");
+      }
+
+      async function refreshObservation() {
+        const result = await request("tools/call", {
+          name: "get_observation",
+          arguments: { observationId: state.observation.observationId }
+        });
+        if (result && result.structuredContent) {
+          render({
+            observation: result.structuredContent,
+            actions: state.actions,
+            proposal: state.proposal
+          });
+        }
+      }
+
+      document.querySelectorAll("[data-verdict]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          if (busy || !state || !state.actions.canReview) return;
+          setBusy(true);
+          setStatus("review-status", "", "");
+          try {
+            await request("tools/call", {
+              name: "record_observation_review",
+              arguments: {
+                observationId: state.observation.observationId,
+                verdict: button.dataset.verdict,
+                note: document.getElementById("review-note").value.trim() || undefined
+              }
+            });
+            await refreshObservation();
+            setStatus("review-status", copy.reviewSaved, "success");
+          } catch (error) {
+            setStatus("review-status", copy.reviewFailed + errorText(error), "error");
+          } finally {
+            setBusy(false);
+          }
+        });
+      });
+
+      document.getElementById("draft-button").addEventListener("click", async () => {
+        if (busy || !state || !state.actions.canDraft) return;
+        const prompt = document.getElementById("candidate-prompt").value.trim();
+        const rubric = document.getElementById("candidate-rubric").value.trim();
+        if (!prompt) {
+          document.getElementById("candidate-prompt").focus();
+          return;
+        }
+        setBusy(true);
+        setStatus("draft-status", "", "");
+        try {
+          await request("tools/call", {
+            name: "draft_sample_from_observation",
+            arguments: {
+              observationId: state.observation.observationId,
+              prompt,
+              rubric: rubric || undefined
+            }
+          });
+          setStatus("draft-status", copy.draftSaved, "success");
+        } catch (error) {
+          setStatus("draft-status", copy.draftFailed + errorText(error), "error");
+        } finally {
+          setBusy(false);
+        }
+      });
+
+      window.addEventListener("message", (event) => {
+        if (event.source !== window.parent) return;
+        const message = event.data;
+        if (!message || message.jsonrpc !== "2.0") return;
+        if (message.id !== undefined && pendingRequests.has(message.id)) {
+          const pending = pendingRequests.get(message.id);
+          pendingRequests.delete(message.id);
+          if (message.error) pending.reject(message.error);
+          else pending.resolve(message.result);
+          return;
+        }
+        if (message.method === "ui/notifications/tool-result") {
+          render(message.params && message.params.structuredContent);
+        }
+      }, { passive: true });
+
+      if (window.openai && window.openai.toolOutput) render(window.openai.toolOutput);
+    })();
+  </script>
+</body>
+</html>`;

--- a/test/chatgpt-plugin/http.test.ts
+++ b/test/chatgpt-plugin/http.test.ts
@@ -84,6 +84,7 @@ describe('ChatGPT observation Streamable HTTP server', () => {
         'get_observation',
         'record_observation_review',
         'draft_sample_from_observation',
+        'render_observation_review',
       ]);
 
       const first = await clientA.client.callTool(captureRequest());

--- a/test/chatgpt-plugin/mcp-server.test.ts
+++ b/test/chatgpt-plugin/mcp-server.test.ts
@@ -8,7 +8,14 @@ import { describe, it } from 'vitest';
 import { createChatGptObservationMcpServer } from '../../src/chatgpt-plugin/mcp-server.js';
 import { FileObservationCaptureStore } from '../../src/chatgpt-plugin/capture-store.js';
 import { FileObservationFeedbackStore } from '../../src/chatgpt-plugin/feedback-store.js';
-import { OBSERVATION_CAPTURE_SCOPE } from '../../src/chatgpt-plugin/principal.js';
+import {
+  OBSERVATION_CAPTURE_SCOPE,
+  OBSERVATION_READ_SCOPE,
+} from '../../src/chatgpt-plugin/principal.js';
+import {
+  MCP_APP_HTML_MIME_TYPE,
+  OBSERVATION_REVIEW_RESOURCE_URI,
+} from '../../src/chatgpt-plugin/review-component.js';
 import { queryObservationInbox } from '../../src/observability/inbox.js';
 
 describe('ChatGPT observation MCP server', () => {
@@ -25,6 +32,7 @@ describe('ChatGPT observation MCP server', () => {
         'get_observation',
         'record_observation_review',
         'draft_sample_from_observation',
+        'render_observation_review',
       ]);
       const tool = tools.tools[0];
       assert.ok(tool);
@@ -39,6 +47,25 @@ describe('ChatGPT observation MCP server', () => {
       assert.equal(JSON.stringify(tool.inputSchema).includes('tenantId'), false);
       assert.equal(JSON.stringify(tool.inputSchema).includes('principalId'), false);
       assert.ok(tool.outputSchema);
+
+      const renderTool = tools.tools.at(-1);
+      assert.deepEqual(renderTool?._meta?.ui, {
+        resourceUri: OBSERVATION_REVIEW_RESOURCE_URI,
+      });
+      assert.equal(tools.tools.slice(0, -1).some((item) => item._meta?.ui), false);
+
+      const resources = await client.listResources();
+      assert.deepEqual(resources.resources.map((resource) => resource.uri), [
+        OBSERVATION_REVIEW_RESOURCE_URI,
+      ]);
+      const resource = await client.readResource({ uri: OBSERVATION_REVIEW_RESOURCE_URI });
+      const component = resource.contents[0];
+      assert.equal(component?.mimeType, MCP_APP_HTML_MIME_TYPE);
+      assert.equal(component?.uri, OBSERVATION_REVIEW_RESOURCE_URI);
+      assert.ok(component && 'text' in component);
+      assert.equal(component.text.includes('tools/call'), true);
+      assert.equal(component.text.includes('localStorage'), false);
+      assert.equal(component.text.includes('innerHTML'), false);
     } finally {
       await client.close();
       await server.close();
@@ -115,6 +142,43 @@ describe('ChatGPT observation MCP server', () => {
       assert.deepEqual((await client.listTools()).tools.map((tool) => tool.name), [
         'capture_observation',
       ]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('renders a read-only component without advertising review or draft actions', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-chatgpt-mcp-read-only-'));
+    const principal = {
+      tenantId: 'tenant',
+      principalId: 'reader',
+      scopes: [OBSERVATION_READ_SCOPE],
+    };
+    const store = new FileObservationFeedbackStore({ observationsDir: dir });
+    const captured = await store.create(principal, {
+      skillName: 'omk',
+      userFeedback: '需要展示只读复核卡片。',
+      confirmedByUser: true,
+      captureSourceKind: 'chatgpt_plugin',
+    });
+    const server = createChatGptObservationMcpServer({ principal, captureStore: store });
+    const client = new Client({ name: 'omk-test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      assert.deepEqual((await client.listTools()).tools.map((tool) => tool.name), [
+        'get_observation',
+        'render_observation_review',
+      ]);
+      const rendered = await client.callTool({
+        name: 'render_observation_review',
+        arguments: { observationId: captured.observationId },
+      });
+      assert.deepEqual(
+        (rendered.structuredContent as { actions: Record<string, boolean> }).actions,
+        { canReview: false, canDraft: false },
+      );
     } finally {
       await client.close();
       await server.close();
@@ -221,6 +285,28 @@ describe('ChatGPT observation MCP server', () => {
       assert.equal(detailContent.occurrences, 1);
       assert.equal(detailContent.review?.verdict, 'real_issue');
       assert.equal(detailContent.captureCoverage.coverageStatus, 'partial');
+
+      const rendered = await client.callTool({
+        name: 'render_observation_review',
+        arguments: {
+          observationId,
+          candidatePrompt: '说明公共 OMK 与私有宿主的边界。',
+          candidateRubric: '必须明确通用能力与宿主责任。',
+        },
+      });
+      assert.notEqual(rendered.isError, true);
+      const renderedContent = rendered.structuredContent as {
+        observation: { observationId: string; captureCoverage: { coverageStatus: string } };
+        actions: { canReview: boolean; canDraft: boolean };
+        proposal?: { prompt: string; rubric?: string };
+      };
+      assert.equal(renderedContent.observation.observationId, observationId);
+      assert.equal(renderedContent.observation.captureCoverage.coverageStatus, 'partial');
+      assert.deepEqual(renderedContent.actions, { canReview: true, canDraft: true });
+      assert.deepEqual(renderedContent.proposal, {
+        prompt: '说明公共 OMK 与私有宿主的边界。',
+        rubric: '必须明确通用能力与宿主责任。',
+      });
     } finally {
       await client.close();
       await server.close();

--- a/test/chatgpt-plugin/review-component.test.ts
+++ b/test/chatgpt-plugin/review-component.test.ts
@@ -1,0 +1,265 @@
+import assert from 'node:assert/strict';
+import { runInNewContext } from 'node:vm';
+import { describe, it } from 'vitest';
+import { observationReviewComponentHtml } from '../../src/chatgpt-plugin/review-component.js';
+
+type EventHandler = (event?: unknown) => unknown;
+
+class FakeElement {
+  textContent = '';
+  value = '';
+  placeholder = '';
+  className = '';
+  hidden = false;
+  disabled = false;
+  dataset: Record<string, string> = {};
+  children: FakeElement[] = [];
+  private readonly listeners = new Map<string, EventHandler[]>();
+
+  constructor(readonly ownerDocument: FakeDocument) {}
+
+  addEventListener(type: string, handler: EventHandler): void {
+    const handlers = this.listeners.get(type) ?? [];
+    handlers.push(handler);
+    this.listeners.set(type, handlers);
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  replaceChildren(...children: FakeElement[]): void {
+    this.children = children;
+  }
+
+  focus(): void {
+    this.ownerDocument.activeElement = this;
+  }
+
+  async dispatch(type: string): Promise<void> {
+    await Promise.all((this.listeners.get(type) ?? []).map((handler) => handler({ target: this })));
+  }
+}
+
+class FakeDocument {
+  readonly documentElement = { lang: '' };
+  readonly elements = new Map<string, FakeElement>();
+  readonly verdictButtons: FakeElement[];
+  readonly buttons: FakeElement[];
+  activeElement: FakeElement | null = null;
+
+  constructor() {
+    const ids = [
+      'loading',
+      'content',
+      'coverage-title',
+      'coverage-description',
+      'coverage-details-label',
+      'unavailable-list',
+      'eyebrow',
+      'skill-name',
+      'observation-meta',
+      'occurrences',
+      'occurrences-label',
+      'evidence-heading',
+      'evidence-count',
+      'evidence-list',
+      'review-heading',
+      'current-verdict',
+      'note-label',
+      'review-note',
+      'review-status',
+      'draft-panel',
+      'draft-heading',
+      'draft-description',
+      'prompt-label',
+      'candidate-prompt',
+      'rubric-label',
+      'candidate-rubric',
+      'draft-button',
+      'draft-status',
+    ];
+    ids.forEach((id) => this.elements.set(id, new FakeElement(this)));
+    this.verdictButtons = [
+      this.verdictButton('real_issue'),
+      this.verdictButton('not_issue'),
+      this.verdictButton('needs_more_context'),
+    ];
+    this.buttons = [...this.verdictButtons, this.getElementById('draft-button')];
+  }
+
+  createElement(): FakeElement {
+    return new FakeElement(this);
+  }
+
+  getElementById(id: string): FakeElement {
+    const element = this.elements.get(id);
+    if (!element) throw new Error(`Unknown fake element: ${id}`);
+    return element;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    if (selector === '[data-verdict]') return this.verdictButtons;
+    if (selector === 'button') return this.buttons;
+    return [];
+  }
+
+  private verdictButton(verdict: string): FakeElement {
+    const button = new FakeElement(this);
+    button.dataset.verdict = verdict;
+    return button;
+  }
+}
+
+interface BridgeRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params: {
+    name?: string;
+    arguments?: Record<string, unknown>;
+  };
+}
+
+function createBridgeHarness() {
+  const document = new FakeDocument();
+  const requests: BridgeRequest[] = [];
+  let messageHandler: EventHandler | undefined;
+  const parent = {
+    postMessage(message: BridgeRequest): void {
+      requests.push(message);
+    },
+  };
+  const window = {
+    parent,
+    openai: undefined,
+    addEventListener(type: string, handler: EventHandler): void {
+      if (type === 'message') messageHandler = handler;
+    },
+  };
+  const script = extractComponentScript();
+  runInNewContext(script, {
+    document,
+    navigator: { language: 'en' },
+    window,
+  });
+
+  function send(data: Record<string, unknown>): void {
+    if (!messageHandler) throw new Error('Component did not register a message handler.');
+    messageHandler({ source: parent, data: { jsonrpc: '2.0', ...data } });
+  }
+
+  return {
+    document,
+    requests,
+    notify(structuredContent: Record<string, unknown>): void {
+      send({
+        method: 'ui/notifications/tool-result',
+        params: { structuredContent },
+      });
+    },
+    respond(id: number, result: Record<string, unknown>): void {
+      send({ id, result });
+    },
+  };
+}
+
+function extractComponentScript(): string {
+  const match = observationReviewComponentHtml.match(/<script>([\s\S]*?)<\/script>/);
+  if (!match?.[1]) throw new Error('Observation review component script is missing.');
+  return match[1];
+}
+
+function componentState(options: {
+  verdict?: 'real_issue' | 'not_issue' | 'needs_more_context';
+  note?: string;
+} = {}): Record<string, unknown> {
+  return {
+    observation: {
+      observationId: 'observation-1',
+      skillName: 'omk',
+      artifactVersion: 'v1',
+      occurrences: 1,
+      captureCoverage: {
+        coverageStatus: 'partial',
+        unavailableEventKinds: ['full_conversation', 'external_tool_calls', 'hidden_reasoning'],
+      },
+      evidence: [{
+        capturedAt: '2026-08-25T10:00:00.000Z',
+        userFeedback: 'The answer missed an important boundary.',
+      }],
+      ...(options.verdict ? {
+        review: {
+          verdict: options.verdict,
+          reviewedAt: '2026-08-25T10:01:00.000Z',
+          note: options.note,
+        },
+      } : {}),
+    },
+    actions: { canReview: true, canDraft: true },
+    proposal: {
+      prompt: 'Explain the observation boundary.',
+      rubric: 'Must explain partial coverage.',
+    },
+  };
+}
+
+describe('ChatGPT observation review component bridge', () => {
+  it('preserves an existing note and updates from the authoritative review result', async () => {
+    const harness = createBridgeHarness();
+    harness.notify(componentState({ verdict: 'needs_more_context', note: 'Original note.' }));
+    const note = harness.document.getElementById('review-note');
+    assert.equal(note.value, 'Original note.');
+
+    note.value = 'Edited note.';
+    await note.dispatch('input');
+    harness.notify(componentState({ verdict: 'needs_more_context', note: 'Stale server note.' }));
+    assert.equal(note.value, 'Edited note.');
+
+    const realIssue = harness.document.verdictButtons[0];
+    const action = realIssue?.dispatch('click');
+    assert.ok(action);
+    assert.equal(harness.requests.length, 1);
+    const request = harness.requests[0];
+    assert.equal(request?.params.name, 'record_observation_review');
+    assert.deepEqual(JSON.parse(JSON.stringify(request?.params.arguments)), {
+      observationId: 'observation-1',
+      verdict: 'real_issue',
+      note: 'Edited note.',
+    });
+    harness.respond(request?.id ?? 0, {
+      structuredContent: {
+        observationId: 'observation-1',
+        review: {
+          verdict: 'real_issue',
+          reviewedAt: '2026-08-25T10:02:00.000Z',
+          note: 'Edited note.',
+        },
+      },
+    });
+    await action;
+
+    assert.equal(harness.requests.length, 1, 'review success must not trigger a second refresh call');
+    assert.equal(note.value, 'Edited note.');
+    assert.equal(harness.document.getElementById('current-verdict').textContent, 'Real issue');
+    assert.equal(harness.document.getElementById('review-status').textContent, 'Review saved.');
+  });
+
+  it('surfaces tool-level draft errors instead of reporting success', async () => {
+    const harness = createBridgeHarness();
+    harness.notify(componentState({ verdict: 'real_issue', note: 'Confirmed.' }));
+    const draftButton = harness.document.getElementById('draft-button');
+    const action = draftButton.dispatch('click');
+    const request = harness.requests[0];
+    assert.equal(request?.params.name, 'draft_sample_from_observation');
+    harness.respond(request?.id ?? 0, {
+      isError: true,
+      content: [{ type: 'text', text: 'Draft rejected by the server.' }],
+    });
+    await action;
+
+    const status = harness.document.getElementById('draft-status');
+    assert.equal(status.textContent, 'Draft failed: Draft rejected by the server.');
+    assert.equal(status.dataset.tone, 'error');
+  });
+});


### PR DESCRIPTION
## 用户影响

- ChatGPT 可在对话内展示 observation 的授权证据、人工复核状态和 regression sample 候选草稿。
- 数据工具继续独立可用；只有单独的 render tool 关联 MCP Apps resource，避免普通读写反复挂载组件。
- 组件按 principal scope 显示可用操作，所有 review 和 draft 写入仍由服务端鉴权并持久化。

## 迁移说明

无破坏性迁移。只实现 `ObservationCaptureStore` 的宿主仍只暴露 capture；完整 `ObservationFeedbackStore` 会额外暴露可选 review component。若私有宿主维护 MCP tool allowlist，需要加入 `render_observation_review`。

## 测量与隐私边界

卡片固定展示 `coverageStatus: partial` 与未观测事件，不把工具边界证据包装成完整 ChatGPT trajectory。组件只接收用户授权证据的最小投影，不包含 workspace 路径、原始 principal 标识或任何公司内部实现；身份、存储、OAuth 与部署继续由私有宿主注入。候选 sample 始终保持 draft，不进入正式评测集。

Refs #415