### PR TITLE
docs(eval-core): 提交 vNext 架构 RFC

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Browse by audience or category. For Chinese docs see [简体中文 index](./zh/R
 
 ## I want to contribute / read design specs
 
+- [Evaluation Core vNext RFC](./specs/evaluation-core-vnext.md)
 - [Sample design spec](./specs/sample-design-spec.md)
 - [Knowledge gap signal spec](./specs/knowledge-gap-signal-spec.md)
 - [RAG metrics spec](./specs/rag-metrics-spec.md)

--- a/docs/specs/evaluation-core-vnext.md
+++ b/docs/specs/evaluation-core-vnext.md
@@ -1,0 +1,555 @@
+# Evaluation Core vNext RFC
+
+> **Status**: Draft. Tracks [#425](https://github.com/lizhiyao/oh-my-knowledge/issues/425) and is the architecture prerequisite for [#424](https://github.com/lizhiyao/oh-my-knowledge/issues/424). This RFC defines a new Evaluation Core domain and measurement contract. It is intentionally incompatible with the current `runEvaluation`, file-based Sample, and Report JSON schema. The old pipeline is evidence for algorithms and failure modes, not a compatibility target.
+
+## 1. Summary
+
+Evaluation Core vNext is a host-neutral, in-memory, re-scorable evaluation kernel. It separates an evaluation into four independently verifiable and recomputable stages:
+
+```text
+EvaluationDefinition + MeasurementPolicy
+        │ prepare / validate / resolve capabilities / seal
+        ▼
+  Immutable RunPlan
+        │
+        ├── execute ──> ExecutionBundle
+        │                  │
+        │                  └── evaluate / re-evaluate
+        ▼
+      EvaluationBundle
+        │
+        └── reduce / compare / infer
+                           ▼
+                    AnalysisBundle
+                           │
+                           └── decide ──> EvaluationReport
+```
+
+Core decisions:
+
+- Execution, Evaluation, Analysis, and Decision are separate stages.
+- Bundles are immutable facts; a Report is a materialized view.
+- Evaluators share one execution protocol, while Metrics, Reducers, and DecisionPolicy remain separate.
+- Gold is isolated through distinct data projections and digests and cannot affect Target execution.
+- Every policy that can change output, missingness, order, or conclusions is sealed before the first external call.
+- Events are side-channel lifecycle notifications, not the sole source of truth.
+- A digest proves content identity; it is not a claim of reproducibility or provenance.
+
+## 2. Problem
+
+The current pipeline joins CLI flags, file parsing, artifact resolution, executors, scoring, statistics, report persistence, and progress callbacks into one workflow. It has validated assertions, LLM judges, paired bootstrap, stability analysis, and runtime fingerprints, but is not a durable public kernel:
+
+- Evaluators cannot be changed without re-running the Target.
+- A Definition containing paths, functions, or host state cannot be reliably serialized or content-addressed.
+- Gold isolation depends on convention rather than a capability boundary.
+- Timeout, budget, retry, and cache can change the measurement but are not represented by one sealed identity.
+- One Report carries facts, analysis, presentation, and persistence concerns.
+- Process-global resources make concurrent Runs difficult to isolate.
+- The current composite's equal weights, mixed scales, and missing-dimension reduction are unsuitable as new-core defaults.
+
+## 3. Goals and non-goals
+
+### Goals
+
+1. Separate pure-JSON intent from trusted Runtime implementations.
+2. Support functions, models, RAG, agents, workflows, and externally executed outputs without host-specific Core branches.
+3. Support re-evaluation, re-analysis, and re-decision with complete derivation lineage.
+4. Make statistical design, missingness, caching, and budgets explicit measurement contracts.
+5. Isolate resources, cancellation, events, and caches between concurrent Runs.
+6. Provide one Core for the package-root embedded API, CLI, Studio, and future hosts.
+
+### Non-goals
+
+- Compatibility with historical APIs, Samples, or Report schemas.
+- CLI, Studio, file paths, databases, queues, tenancy, or UI.
+- Distributed scheduling, checkpoint/resume, or a workflow engine.
+- Online production scoring, general APM, or real-time alerting.
+- Sandboxing untrusted user-uploaded code.
+- Provider-specific fields for a model, RAG product, or FaaS.
+
+## 4. Design principles and measurement invariants
+
+### 4.1 Define the estimand before execution
+
+An evaluation does not run first and decide later what available data means. Definition, SamplingDesign, Metrics, Reducers, Comparisons, and DecisionPolicy define the estimand. A sealed RunPlan must exist before the first Target call.
+
+### 4.2 A unified interface is not a unified score
+
+Assertions, structured scorers, and LLM judges are Evaluator implementations, but may emit values on different scales. Core does not normalize to 0–1, average by default, or silently reweight when a dimension is missing.
+
+### 4.3 Missing is not zero
+
+Execution errors, evaluation errors, cancellation, budget censoring, and unresolved content remain distinct. Every Reducer and DecisionPolicy declares how it handles missing data; unmet assumptions yield an inconclusive result.
+
+### 4.4 A cache hit is not a new trial
+
+A cached stochastic output cannot count as a new independent trial. Replay preserves the original trial identity and provenance. Transparent Execution cache reuse is limited to Targets verified as deterministic.
+
+### 4.5 Comparability is an explicit relation
+
+Different Bundle digests do not automatically mean incomparable, and equal digests do not prove a valid experimental design. ComparabilityPolicy inspects Dataset projections, Targets, Runtimes, Evaluators, SamplingDesign, and DecisionPolicy and returns compatible, conditional, or incompatible with reasons.
+
+### 4.6 Standards-compatible, not standards-shaped
+
+Core domain types remain minimal and host-neutral. CloudEvents, OpenTelemetry/OpenInference, W3C Trace Context, and experiment platforms are adapter mappings, not Core SDK dependencies.
+
+## 5. Domain model
+
+### 5.1 Definition
+
+A Definition is immutable, serializable intent. It contains no function, class instance, absolute path, or process state.
+
+```ts
+interface EvaluationDefinition {
+  schemaVersion: 'omk.evaluation-definition/v1';
+  dataset: EvaluationDataset;
+  targets: readonly TargetDefinition[];
+  evaluators: readonly EvaluatorDefinition[];
+  metrics: readonly MetricDefinition[];
+  analysisGraph: AnalysisGraphDefinition;
+  comparisons: readonly ComparisonDefinition[];
+  decisionPolicy?: DecisionPolicyDefinition;
+  extensions?: Readonly<Record<string, JsonValue>>;
+}
+```
+
+Unknown top-level fields are rejected to catch misspellings. Extensions live only under namespaced `extensions` and declare their own schema URI and digest.
+
+Wire contracts use the repository's existing Zod 4 schemas as the single source of truth and are restricted to the subset that exports completely to JSON Schema 2020-12. CI generates and checks published schemas with `z.toJSONSchema()`. Encountering unrepresentable constructs such as transforms, dates, maps, sets, or custom types is an error and never degrades to `{}`. Cross-field, capability, and statistical-assumption validation belongs to the prepare compiler rather than an unexportable schema refinement.
+
+### 5.2 Dataset and case projections
+
+```ts
+interface EvaluationSample {
+  sampleId: string;
+  input: JsonValue;
+  executionContext?: JsonValue;
+  expected?: JsonValue;
+  evaluationContext?: JsonValue;
+  annotations?: JsonValue;
+}
+```
+
+- An Executor receives only a frozen projection of `input + executionContext`.
+- An Evaluator may declaratively read output/trace/expected/evaluationContext.
+- `annotations` are audit and presentation data and affect neither execution nor scoring.
+- Mappings use restricted JSON Pointer by default and select one value. Multi-value JSONPath is an adapter extension.
+
+A Dataset has three distinct digests:
+
+| Digest | Coverage | Purpose |
+|---|---|---|
+| `datasetRevisionDigest` | complete Dataset | lineage and audit |
+| `executionInputDigest` | `input + executionContext` | ExecutionPlan identity |
+| `evaluationInputDigest` | execution projection plus `expected + evaluationContext` | EvaluationPlan identity |
+
+Changing Gold or evaluator-only metadata cannot change the ExecutionPlan, schedule, or anything observable by an Executor.
+
+### 5.3 Target and Runtime capabilities
+
+```ts
+interface TargetDefinition {
+  targetId: string;
+  targetKind: string;
+  protocolId: string;
+  executorId: string;
+  versionConstraint?: string;
+  config?: JsonValue;
+}
+```
+
+`targetKind` is descriptive and never drives a Core-orchestrator switch. Behavior comes from a versioned protocol family, input/output schemas, and a capability manifest. Capabilities negotiate optional behavior; they do not replace the type system.
+
+v1 defines only two built-in protocol families:
+
+- `omk.invoke/v1`: one structured request/response per trial with an optional source-neutral trace; covers pure functions, models, services, RAG, and stateless workflows.
+- `omk.session/v1`: an isolated session lifecycle per trial with multi-turn messages, tool calls, and partial trajectories; covers agents and stateful workflows.
+
+Importing host-executed results is not a third execution protocol; Core validates and accepts an ExecutionBundle directly. Protocol IDs are immutable contracts. Incompatible changes use a new major path, while optional capabilities may only add behavior without changing existing field semantics.
+
+The Runtime resolves the actual implementation during prepare:
+
+```ts
+interface RuntimeIdentity {
+  implementationId: string;
+  version?: string;
+  fingerprint: string;
+  fingerprintBasis: 'content-derived' | 'environment-derived' | 'self-reported' | 'opaque';
+  assuranceLevel: 'verified' | 'declared' | 'unknown';
+  capabilities: JsonValue;
+}
+```
+
+Caller-supplied versions and fingerprints are requirements, not facts. The Report records the identity resolved by Runtime. Remote model deployment, tools, sandbox, dependencies, and environment live in provenance facets.
+
+### 5.4 ExperimentDesign and SamplingDesign
+
+```ts
+interface SamplingDesign {
+  experimentalUnit: 'sample' | 'run' | 'cluster';
+  pairingKey?: string;
+  clusterKey?: string;
+  stratumKey?: string;
+  repeatedMeasures: boolean;
+  resamplingUnit: 'sample' | 'paired-block' | 'cluster' | 'run';
+  estimatorId: string;
+}
+
+interface ExperimentDesign {
+  trials: number;
+  seed: string;
+  sampling: SamplingDesign;
+  scheduling: SchedulingPolicy;
+}
+```
+
+A trial is one repeated measurement under the same condition. A retry attempt is infrastructure recovery within one trial. They are not interchangeable. Statistical implementations validate that they support the SamplingDesign during prepare and never treat repeated trials as independent samples by default.
+
+Paired comparisons use a scheduling block as the dispatch atom. A block is not started unless budget exists for both sides. Partial blocks are censored and excluded from the primary paired estimator. Reports expose started, completed, comparable, and censored coverage separately.
+
+### 5.5 Evaluator, Metric, Reducer, and DecisionPolicy
+
+```ts
+interface MetricDefinition {
+  metricId: string;
+  valueType: 'numeric' | 'boolean' | 'categorical' | 'text' | 'ranking';
+  scope: 'sample' | 'target' | 'comparison' | 'run';
+  scale?: { min?: number; max?: number };
+  unit?: string;
+  direction?: 'higher-is-better' | 'lower-is-better' | 'target-is-best';
+  missingPolicyId: string;
+}
+```
+
+- An Evaluator is trusted executable code that emits MetricObservations and evidence.
+- MetricDefinition gives values meaning and executes no code.
+- A Reducer derives AnalysisResults from observations.
+- DecisionPolicy consumes named AnalysisResults and produces a verdict.
+- Weights belong only to an explicit composite reducer, never to every Metric.
+
+Complex analysis is a directed acyclic AnalysisGraph. Every node declares inputs, output schema, implementation identity, and parameters. Prepare rejects cycles, missing dependencies, and value-domain mismatches.
+
+v1 keeps its built-in reducers and estimators minimal:
+
+- `descriptive.mean/v1`, `descriptive.rate/v1`, and `descriptive.quantile/v1`;
+- `bootstrap.mean-percentile/v1`;
+- `bootstrap.paired-difference-percentile/v1`;
+- `bootstrap.cluster-percentile/v1`;
+- `bonferroni/v1` for multiple-comparison correction.
+
+Alpha, resample count, resampling unit, and seed enter AnalysisPlan. v1 does not embed parametric methods such as t-tests, ANOVA, or Hotelling T². Future estimators are added through AnalysisRegistry identities without changing observation or Bundle contracts. Prepare fails when an estimator does not support the value domain or SamplingDesign and never switches algorithms implicitly.
+
+Re-analysis and re-decision preserve parent Bundle digest, policy digest, derivation time, and `analysisMode: preregistered | exploratory`. Thresholds or methods chosen after observing results cannot masquerade as pre-sealed release gates.
+
+## 6. Plans, Bundles, and Reports
+
+### 6.1 Sealed RunPlan
+
+```ts
+interface MeasurementPolicy {
+  execution: ExecutionPolicy;
+  retry: RetryPolicy;
+  budget: BudgetPolicy;
+  cache: CachePolicy;
+  evidence: EvidencePolicy;
+  failure: FailurePolicy;
+  eventDelivery: EventDeliveryPolicy;
+}
+```
+
+Every option that can change output, missingness, scheduling, evidence completeness, or conclusions belongs to MeasurementPolicy and enters the RunPlan and relevant digest during prepare. `start()` accepts only an external AbortSignal, annotations, and EventWriter and cannot override measurement policy.
+
+### 6.2 ExecutionBundle
+
+For each `(targetId, sampleId, trialId)`, it records:
+
+- output or ContentDescriptor;
+- source-neutral trace;
+- usage, provider-reported cost, and timing;
+- retry attempts;
+- execution error;
+- RuntimeIdentity;
+- execution and cache/replay provenance;
+- parent Plan digest and Bundle digest.
+
+Cost inferred from a pricing catalog is not a raw execution fact. It is a derived AnalysisResult carrying a pricing fingerprint.
+
+### 6.3 EvaluationBundle
+
+It records:
+
+- evaluator RuntimeIdentity;
+- MetricObservations;
+- evidence or ContentDescriptor;
+- evaluation errors;
+- cache provenance;
+- parent ExecutionBundle digest, EvaluationPlan digest, and its own digest.
+
+### 6.4 AnalysisBundle
+
+It records every AnalysisGraph node result, assumption checks, coverage, confidence intervals, distributions, tables or curves, and the parent EvaluationBundle digest.
+
+### 6.5 EvaluationReport
+
+A Report is a materialized view for people and products. It may inline Bundle summaries or reference Bundles, but is never the only source for re-evaluation or audit.
+
+Reports use three orthogonal status axes:
+
+```ts
+interface EvaluationStatus {
+  runStatus: 'completed' | 'cancelled' | 'budget-exhausted' | 'failed';
+  evidenceStatus: 'complete' | 'partial' | 'unresolvable';
+  conclusionStatus: 'conclusive' | 'inconclusive' | 'not-evaluated';
+}
+```
+
+`runStatus: completed` means only that processing ended. A directional verdict such as PROGRESS or REGRESSION requires the DecisionPolicy's coverage gate, statistical assumptions, and evidence-completeness requirements to pass.
+
+### 6.6 Replayability
+
+Every Bundle declares:
+
+- `self-contained`: everything needed for re-evaluation is inline;
+- `resolvable`: content can be retrieved through an injected ContentResolver and verified by digest;
+- `summary-only`: re-evaluation is not promised.
+
+Imported Bundles also declare provenance trust. Schema and digest validation prove integrity, not that a claimed Target produced the content.
+
+v1 does not implement Bundle signing inside Core. Signing requires identity policy, trust roots, certificate/key lifecycle, and verification material and therefore belongs to host governance. v1 records digest, provenance trust, and assurance level. A host may attach a Sigstore/DSSE-style attestation through a namespaced extension and raise trust through an injected verifier. Without a verifier, signature material is opaque evidence and never becomes verified automatically.
+
+## 7. Identity, canonicalization, and comparability
+
+Definition, Plan, Bundle, Event, and Report each carry a `schemaVersion` and publish JSON Schema 2020-12. TypeScript and runtime schemas come from one source or are guarded by automatic parity tests.
+
+Content-addressed objects are restricted to the RFC 8785 JCS-compatible I-JSON subset. `NaN`, `Infinity`, functions, symbols, cycles, and insertion-order-dependent semantics are invalid. Digests use full `sha256:<hex>` values.
+
+```text
+executionPlanDigest = H(
+  executionInputDigest,
+  target snapshots,
+  executor manifests,
+  SamplingDesign,
+  scheduling + execution policy
+)
+
+evaluationPlanDigest = H(
+  executionPlanDigest,
+  evaluationInputDigest,
+  evaluator manifests,
+  metric definitions,
+  evaluation policy
+)
+
+analysisPlanDigest = H(
+  evaluationPlanDigest,
+  AnalysisGraph,
+  estimator manifests
+)
+
+decisionPlanDigest = H(
+  analysisPlanDigest,
+  comparisons,
+  DecisionPolicy
+)
+
+runContractDigest = H(all plan digests + schema identities)
+```
+
+Annotations such as `project`, `owner`, and `tags` do not enter measurement digests. Evidence capture that changes auditability but not scores has an evidence contract and Bundle provenance. If capture removes an Evaluator input, it belongs in EvaluationPlan.
+
+## 8. Runtime, resources, and cancellation
+
+Core does not read or write files, read environment configuration, write stdout/stderr, load CLI/Studio, create directories, call `process.exit`, or maintain process-global mutable registries by default.
+
+Runtime ports include at least:
+
+- ExecutorRegistry;
+- EvaluatorRegistry;
+- AnalysisRegistry;
+- ContentResolver/ContentStore;
+- Clock, IdGenerator, and RandomSource;
+- optional EventWriter.
+
+Executors and Evaluators may use `openRun()` to return a run-scoped session and asynchronous disposer. Resource ownership is a strict tree: Engine owns registries, Run owns sessions, and tasks/attempts own temporary resources. One Run's cancellation or teardown cannot close another Run's resources.
+
+Cancellation uses AbortSignal. User cancellation produces honest partial Bundles. Timeout and budget belong to sealed MeasurementPolicy because they affect missingness. Core does not provide cross-process resume; a host may start a new Evaluation stage from a complete ExecutionBundle.
+
+## 9. Event semantics
+
+`run.events` is a bounded hot notification stream:
+
+- an unconsumed stream cannot block or change `run.result`;
+- each Run permits one AsyncIterable consumer; hosts provide fan-out;
+- journaling begins when the Run is created and retains 256 events by default; a late subscriber receives the retained window before live events, and may subscribe once after completion to drain the journal;
+- a host may override capacity in start observer options; it does not enter measurement digests because event congestion cannot change Bundles or conclusions;
+- when full, the journal first coalesces pending `progress.updated` events by subject; if still full, it drops the oldest observer event and inserts `observer.events-dropped` with the count and sequence range; the terminal event is always retained;
+- observations, Bundles, and terminal data never exist only as events;
+- every Event has schemaVersion, eventId, runId, monotonic per-Run sequence, eventKind, time, subject, and data;
+- lossless persistence uses EventWriter, whose failure behavior is in sealed EventDeliveryPolicy.
+
+Adapters may map Events losslessly to CloudEvents. Traces may map to OpenTelemetry/OpenInference and accept W3C Trace Context. Core depends on none of those SDKs.
+
+## 10. Errors and failures
+
+Schema, reference, capability, and statistical-assumption errors during prepare throw `EvaluationDefinitionError` and create no Run.
+
+Runtime errors are classified as:
+
+- configuration;
+- infrastructure;
+- execution;
+- evaluation;
+- analysis;
+- internal invariant violation.
+
+Execution and evaluation errors are observations governed by FailurePolicy's continue, fail-fast, or failure-threshold behavior. Quality failure, assertion failure, and treatment regression are valid measurements, not runtime errors.
+
+Raw exception objects are never serialized into Events or Reports. They become a stable error code, stage, public message, controlled details, and cause chain.
+
+## 11. Content, security, and privacy
+
+```ts
+interface ContentDescriptor {
+  mediaType: string;
+  digest: string;
+  size?: number;
+  uri?: string;
+}
+```
+
+Core never dereferences a URI directly. ContentResolver enforces access control, size limits, protocol allowlists, and digest verification.
+
+Content is classified at least as public, sensitive, secret, or gold. EventWriter, Report materializer, ContentStore, and error serializer each declare their maximum accepted classification. Evaluator evidence and errors pass through the same classification and redaction rules.
+
+EvidencePolicy controls full/reference/digest/none capture independently for input, output, trace, expected, and evidence and reports how each choice affects replayability or evidenceStatus.
+
+## 12. Public API sketch
+
+```ts
+const engine = createEvaluationEngine(runtime);
+
+const plan = await engine.prepare(definition, measurementPolicy);
+
+const run = plan.start({
+  signal,
+  annotations,
+  eventWriter,
+  observer: { maxBufferedEvents: 256 },
+});
+
+for await (const event of run.events) {
+  // Optional lifecycle notifications.
+}
+
+const result = await run.result;
+```
+
+Advanced APIs support:
+
+- `execute(plan.execution)`;
+- `evaluate(plan.evaluation, executionBundle)`;
+- `analyze(plan.analysis, evaluationBundle)`;
+- `decide(plan.decision, analysisBundle)`.
+
+The package root also provides a one-call façade. Advanced APIs return serializable Bundles and do not expose mutable schedulers. Public exports are allowlisted through `package.json#exports`; `./dist/*` deep imports are not a contract.
+
+## 13. Conformance and verification
+
+The first conformance fixtures cover:
+
+1. Pure function: structured input/output, no trace.
+2. RAG top-K: retrieval evidence and ranking Metrics.
+3. Agent trajectory: multi-turn messages, tool calls, cancellation, and partial traces.
+
+If the Core orchestrator needs a `targetKind` branch, the protocol abstraction fails acceptance.
+
+Required property tests include:
+
+- JSON property order does not change a digest.
+- Annotation changes do not change measurement digests.
+- Gold changes invalidate only Evaluation and downstream plans.
+- Evaluator changes do not invalidate Execution.
+- Runtime fingerprint changes invalidate the corresponding stage.
+- Replay does not increase stochastic trial count.
+- Repeated trials are not treated as independent experimental units.
+- A slow Event consumer does not change results.
+- Concurrent Runs share no cancellation, cache, or teardown.
+- Budget exhaustion cannot complete only one side of a paired block.
+- Secret/gold data never reaches unauthorized Events, Reports, or errors.
+- Partial evidence cannot pass a coverage gate and produce a directional verdict.
+
+Statistical implementations also use known reference vectors and simulations to test coverage, type-I error, pairing, and cluster resampling rather than relying only on snapshots.
+
+## 14. Rejected alternatives
+
+### 14.1 Add more options to the current `runEvaluation`
+
+Rejected. It preserves CLI, file, global-state, and Report coupling and cannot establish clean Gold and effect boundaries.
+
+### 14.2 Keep one Report and re-score from it
+
+Rejected. Presentation capture would constrain measurement facts, and the Report schema would carry too many responsibilities.
+
+### 14.3 Use the Event Log as the sole source of truth
+
+Rejected. Core does not own a durable event store or recovery protocol. An unconsumed or congested notification stream cannot affect measurement facts.
+
+### 14.4 Normalize all Metrics to 0–1 and average by default
+
+Rejected. Equal ranges do not make constructs comparable and hide scale, direction, and missingness semantics.
+
+### 14.5 Represent every Target with one ever-growing capability list
+
+Rejected. It creates Boolean soup. Use protocol family plus schema plus capability negotiation.
+
+### 14.6 Transparently reuse all Execution caches
+
+Rejected. It can disguise one output as new stochastic trials and corrupt variance and stability measurements.
+
+### 14.7 Build databases, queues, and checkpoints into Core
+
+Rejected. Durability and distributed orchestration belong to hosts. Content-addressed Bundles are the composition boundary.
+
+## 15. Delivery sequence
+
+1. Review this RFC and its blocking ADRs.
+2. Create five child issues: Contracts, Compiler, Execution, Evaluation/Analysis, and Conformance.
+3. Contracts: schemas, types, canonicalization, digests, and status model.
+4. Compiler: projections, capability resolution, and Plan sealing.
+5. Execution: trials, paired scheduling, resources, and ExecutionBundle.
+6. Evaluation/Analysis: re-scoring, AnalysisGraph, statistics, and DecisionPolicy.
+7. Conformance: three Target classes, fault injection, security, and simulation.
+8. Deliver the package-root façade in #424.
+9. Migrate CLI and Studio last.
+
+Each phase depends only on the previous phase's public Plan/Bundle contracts, never its internal implementation.
+
+## 16. RFC decision record
+
+This review closes five blocking questions:
+
+1. **Schema source of truth**: use the fully exportable Zod 4 wire-schema subset; CI generates JSON Schema 2020-12 and semantic validation remains in the prepare compiler.
+2. **Protocol families**: v1 includes only `omk.invoke/v1` and `omk.session/v1`; external results enter through ExecutionBundle rather than an import protocol.
+3. **Event journal**: one consumer, 256 events by default, retained-window replay for late subscribers, progress-first coalescing, and explicit overflow reporting; lossless delivery uses EventWriter.
+4. **Bundle signing**: v1 records digest and trust but does not sign; hosts compose attestations and verifiers through extensions.
+5. **Estimator registry**: v1 includes descriptive reducers, percentile bootstrap for mean/paired-difference/cluster designs, and Bonferroni, with no built-in parametric methods.
+
+These decisions close the architectural choices required before Contracts. Conformance tests and simulations must still validate implementation constants and algorithms.
+
+## 17. Industry references
+
+- [Inspect AI Tasks](https://inspect.aisi.org.uk/tasks.html), [Scorers](https://inspect.aisi.org.uk/scorers.html), and [Eval Logs](https://inspect.aisi.org.uk/eval-logs.html)
+- [Phoenix Experiments](https://arize.com/docs/ax/improve/experiment-in-code)
+- [Pydantic Evals](https://pydantic.dev/docs/ai/evals/evals/) and [Report Evaluators](https://pydantic.dev/docs/ai/evals/evaluators/report-evaluators/)
+- [lm-evaluation-harness Task Guide](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/docs/task_guide.md)
+- [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/) and [OpenInference Semantic Conventions](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md)
+- [CloudEvents](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md) and [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+- [JSON Schema 2020-12](https://json-schema.org/draft/2020-12), [RFC 8785 JCS](https://www.rfc-editor.org/rfc/rfc8785.html), and [RFC 6901 JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901)
+- [Zod 4 JSON Schema](https://zod.dev/json-schema), [Node.js Events](https://nodejs.org/api/events.html), and the [Sigstore Bundle specification](https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto)
+
+## Related documents
+
+- [Scoring pipeline](scoring.md)
+- [Statistical rigor](../explanation/statistical-rigor.md)
+- [Terminology spec](terminology-spec.md)
+- [RAG metrics spec](rag-metrics-spec.md)

--- a/docs/specs/evaluation-core-vnext.md
+++ b/docs/specs/evaluation-core-vnext.md
@@ -257,7 +257,7 @@ interface MeasurementPolicy {
 }
 ```
 
-Every option that can change output, missingness, scheduling, evidence completeness, or conclusions belongs to MeasurementPolicy and enters the RunPlan and relevant digest during prepare. `start()` accepts only an external AbortSignal, annotations, and EventWriter and cannot override measurement policy.
+Every option that can change output, missingness, scheduling, evidence completeness, or conclusions belongs to MeasurementPolicy and enters the RunPlan and relevant digest during prepare. `start()` accepts only an external AbortSignal, annotations, EventWriter, and observer options that cannot affect measurement results; it cannot override measurement policy.
 
 ### 6.2 ExecutionBundle
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -36,6 +36,7 @@
 
 ## 我想贡献 / 看设计 spec
 
+- [Evaluation Core vNext RFC](./specs/evaluation-core-vnext.md)
 - [用例设计科学性指南](./specs/sample-design-spec.md)
 - [知识缺口信号规范](./specs/knowledge-gap-signal-spec.md)
 - [RAG metrics 规范](./specs/rag-metrics-spec.md)

--- a/docs/zh/specs/evaluation-core-vnext.md
+++ b/docs/zh/specs/evaluation-core-vnext.md
@@ -1,0 +1,555 @@
+# Evaluation Core vNext RFC
+
+> **状态**：Draft。关联 [#425](https://github.com/lizhiyao/oh-my-knowledge/issues/425)，并作为 [#424](https://github.com/lizhiyao/oh-my-knowledge/issues/424) 的架构前置。本文定义全新 Evaluation Core 的领域边界和测量契约，不兼容现有 `runEvaluation`、文件型 Sample 或 Report JSON schema。旧实现只作为算法与失败案例的参考。
+
+## 一、摘要
+
+Evaluation Core vNext 是一个宿主无关、纯内存、可重评分的评测内核。它把一次评测拆成四个可独立验证和重算的阶段：
+
+```text
+EvaluationDefinition + MeasurementPolicy
+        │ prepare／validate／resolve capabilities／seal
+        ▼
+  Immutable RunPlan
+        │
+        ├── execute ──> ExecutionBundle
+        │                  │
+        │                  └── evaluate／re-evaluate
+        ▼
+      EvaluationBundle
+        │
+        └── reduce／compare／infer
+                           ▼
+                    AnalysisBundle
+                           │
+                           └── decide ──> EvaluationReport
+```
+
+核心决定：
+
+- Execution、Evaluation、Analysis 和 Decision 是不同阶段；
+- Bundle 是不可变事实记录，Report 是物化视图；
+- Evaluator 统一执行协议，但 Metric、Reducer 和 DecisionPolicy 分离；
+- Gold 通过不同数据投影与 digest 隔离，不能影响 Target 执行；
+- 所有会改变输出、缺失、顺序或结论的策略都在第一次外部调用前封存；
+- Event 是旁路生命周期通知，不是唯一事实源；
+- digest 证明内容身份，不冒充可复现性或来源证明。
+
+## 二、问题
+
+现有 pipeline 把 CLI 参数、文件解析、artifact 解析、执行器、评分、统计、报告落盘和进度回调连在一条流程里。它已经验证了 assertion、LLM 评委、paired bootstrap、稳定性、runtime fingerprint 等能力，但不适合作为长期公共内核：
+
+- 无法在不重跑 Target 的情况下重评分；
+- Definition 混入路径、函数或宿主状态后无法可靠序列化和寻址；
+- Gold 隔离依赖调用约定，缺少能力边界；
+- timeout、budget、retry、cache 等运行选项可能改变测量结果，却没有统一进入测量身份；
+- 单一 Report 同时承担事实、分析、展示和持久化职责；
+- 进程级全局资源使并发 Run 难以隔离；
+- 现有 composite 的等权、混合量表和缺失维度降权不适合作为新内核默认模型。
+
+## 三、目标与非目标
+
+### 目标
+
+1. 用纯 JSON Definition 和可信 Runtime 实现分离配置与代码。
+2. 支持函数、模型、RAG、Agent、Workflow 和外部执行结果，而不在 Core 写宿主分支。
+3. 支持执行结果重评分、重新分析和重新决策，并保留完整 derivation lineage。
+4. 让统计设计、缺失机制、缓存和预算成为显式测量契约。
+5. 让并发 Run 的资源、取消、事件和缓存完全隔离。
+6. 为包根嵌入式 API、CLI、Studio 和未来宿主提供同一套 Core。
+
+### 非目标
+
+- 历史 API、Sample 或 Report schema 兼容；
+- CLI、Studio、文件路径、数据库、队列、租户或 UI；
+- 分布式调度、checkpoint／resume 或工作流引擎；
+- 在线生产评分、通用 APM 或实时告警；
+- 执行不可信用户上传代码的 sandbox；
+- 某个模型供应商、RAG 产品或 FaaS 的专属字段。
+
+## 四、设计原则与测量不变量
+
+### 1．先定义 estimand，再执行任务
+
+评测不是「跑完后看有什么数据就算什么」。Definition、SamplingDesign、Metric、Reducer、Comparison 和 DecisionPolicy 共同定义要估计的量。第一次 Target 调用前必须生成 sealed RunPlan。
+
+### 2．统一接口不等于统一分数
+
+assertion、结构化 scorer 和 LLM 评委都是 Evaluator 实现，但它们的输出可以属于不同量表。Core 不默认归一化到 0–1，不默认求平均，也不在维度缺失时自动降权。
+
+### 3．缺失不是零
+
+execution error、evaluation error、取消、预算截尾和无法解析的内容分别记录。任何 Reducer 和 DecisionPolicy 都必须显式声明自己如何处理缺失；不满足前提时返回 inconclusive，而不是猜测。
+
+### 4．缓存不是新试验
+
+随机系统的 cache hit 不能计作新的独立 trial。replay 保留原始 trial identity 和 provenance；只有经过验证的 deterministic Target 才允许透明复用 Execution cache。
+
+### 5．可比性是显式关系
+
+两个 Bundle digest 不同不代表一定不可比较，相同也不代表实验设计有效。ComparabilityPolicy 根据 Dataset 投影、Target、Runtime、Evaluator、SamplingDesign 和 DecisionPolicy 的变化给出 compatible、conditional 或 incompatible，并解释理由。
+
+### 6．标准兼容，不被标准绑架
+
+Core 的领域类型保持最小且宿主无关。CloudEvents、OpenTelemetry／OpenInference、W3C Trace Context 和外部实验平台只通过 adapter 映射，不成为 Core SDK 依赖。
+
+## 五、领域模型
+
+### 1．Definition
+
+Definition 是不可变、可序列化的意图，不包含函数、类实例、绝对路径或进程状态。
+
+```ts
+interface EvaluationDefinition {
+  schemaVersion: 'omk.evaluation-definition/v1';
+  dataset: EvaluationDataset;
+  targets: readonly TargetDefinition[];
+  evaluators: readonly EvaluatorDefinition[];
+  metrics: readonly MetricDefinition[];
+  analysisGraph: AnalysisGraphDefinition;
+  comparisons: readonly ComparisonDefinition[];
+  decisionPolicy?: DecisionPolicyDefinition;
+  extensions?: Readonly<Record<string, JsonValue>>;
+}
+```
+
+未知顶层字段默认拒绝，防止拼写错误静默生效。扩展只能放在命名空间化 `extensions` 中，并由扩展自己的 schema URI 和 digest 描述。
+
+Wire contract 以仓库现有 Zod 4 schema 为单一来源，并限制在能完整导出 JSON Schema 2020-12 的子集。CI 使用 `z.toJSONSchema()` 生成并检查发布 schema；遇到 `transform`、`date`、`map`、`set`、`custom` 等不可表达类型时直接失败，不允许降级成 `{}`。跨字段、capability 和统计前提校验属于 prepare compiler，不藏在无法导出的 schema refinement 中。
+
+### 2．Dataset 与用例投影
+
+```ts
+interface EvaluationSample {
+  sampleId: string;
+  input: JsonValue;
+  executionContext?: JsonValue;
+  expected?: JsonValue;
+  evaluationContext?: JsonValue;
+  annotations?: JsonValue;
+}
+```
+
+- Executor 只收到 `input + executionContext` 的冻结投影；
+- Evaluator 可以按声明读取 output／trace／expected／evaluationContext；
+- `annotations` 只用于审计和展示，不参与执行或评分；
+- 映射默认使用受限 JSON Pointer，只允许定位一个值；多值 JSONPath 属于 adapter 扩展。
+
+Dataset 具有三个不同 digest：
+
+| Digest | 覆盖内容 | 用途 |
+|---|---|---|
+| `datasetRevisionDigest` | 完整 Dataset | lineage 和审计 |
+| `executionInputDigest` | `input + executionContext` | ExecutionPlan 身份 |
+| `evaluationInputDigest` | 执行投影 + `expected + evaluationContext` | EvaluationPlan 身份 |
+
+Gold 或 evaluator-only metadata 变化不得改变 ExecutionPlan、调度或 Executor 可观察状态。
+
+### 3．Target 与 Runtime capability
+
+```ts
+interface TargetDefinition {
+  targetId: string;
+  targetKind: string;
+  protocolId: string;
+  executorId: string;
+  versionConstraint?: string;
+  config?: JsonValue;
+}
+```
+
+`targetKind` 是描述性分类，不驱动 Core orchestrator 的 switch。行为由版本化 protocol family、输入输出 schema 和 capability manifest 决定。capability 描述可选能力，不替代类型系统。
+
+v1 只内建两个 protocol family：
+
+- `omk.invoke/v1`：一个 trial 对应一次结构化 request／response，可附 source-neutral trace；覆盖纯函数、模型、服务、RAG 和无会话 Workflow；
+- `omk.session/v1`：一个 trial 拥有独立 session lifecycle，支持多轮消息、工具调用和部分 trajectory；覆盖 Agent 和有状态 Workflow。
+
+导入宿主已经执行好的结果不属于第三个执行协议，而是直接校验并接收 ExecutionBundle。protocol ID 是不可变契约；不兼容修改发布新 major path，可选能力只能做不改变既有字段语义的追加。
+
+Runtime 在 prepare 阶段解析实际实现：
+
+```ts
+interface RuntimeIdentity {
+  implementationId: string;
+  version?: string;
+  fingerprint: string;
+  fingerprintBasis: 'content-derived' | 'environment-derived' | 'self-reported' | 'opaque';
+  assuranceLevel: 'verified' | 'declared' | 'unknown';
+  capabilities: JsonValue;
+}
+```
+
+调用方声明的版本或 fingerprint 只是要求，Report 记录 Runtime 实际解析出的身份。远程模型 deployment、工具、sandbox、依赖和环境以 provenance facets 保存。
+
+### 4．ExperimentDesign 与 SamplingDesign
+
+```ts
+interface SamplingDesign {
+  experimentalUnit: 'sample' | 'run' | 'cluster';
+  pairingKey?: string;
+  clusterKey?: string;
+  stratumKey?: string;
+  repeatedMeasures: boolean;
+  resamplingUnit: 'sample' | 'paired-block' | 'cluster' | 'run';
+  estimatorId: string;
+}
+
+interface ExperimentDesign {
+  trials: number;
+  seed: string;
+  sampling: SamplingDesign;
+  scheduling: SchedulingPolicy;
+}
+```
+
+trial 表示同一实验条件的一次重复测量；retry attempt 表示一次 trial 内的基础设施重试，两者不能互换。统计实现必须在 prepare 阶段验证自己支持当前 SamplingDesign，不能把重复 trial 自动视为独立样本。
+
+配对比较以 scheduling block 为调度原子。预算不足时不得只启动 block 的一侧；部分 block 标记为 censored，不进入主要配对估计。报告分别记录 started、completed、comparable 和 censored coverage。
+
+### 5．Evaluator、Metric、Reducer 与 DecisionPolicy
+
+```ts
+interface MetricDefinition {
+  metricId: string;
+  valueType: 'numeric' | 'boolean' | 'categorical' | 'text' | 'ranking';
+  scope: 'sample' | 'target' | 'comparison' | 'run';
+  scale?: { min?: number; max?: number };
+  unit?: string;
+  direction?: 'higher-is-better' | 'lower-is-better' | 'target-is-best';
+  missingPolicyId: string;
+}
+```
+
+- Evaluator 是可信可执行实现，产生 MetricObservation 和 evidence；
+- MetricDefinition 定义值的语义，不执行代码；
+- Reducer 把 observation 归约成 AnalysisResult；
+- DecisionPolicy 消费命名的 AnalysisResult，产生 verdict；
+- weight 只属于明确的 composite reducer，不是 Metric 的通用属性。
+
+复杂分析由有向无环的 AnalysisGraph 表达。每个节点声明输入、输出 schema、实现身份和参数；prepare 检查循环、缺失依赖和值域不匹配。
+
+v1 内建的 reducer／estimator 保持最小：
+
+- `descriptive.mean/v1`、`descriptive.rate/v1`、`descriptive.quantile/v1`；
+- `bootstrap.mean-percentile/v1`；
+- `bootstrap.paired-difference-percentile/v1`；
+- `bootstrap.cluster-percentile/v1`；
+- multiple-comparison correction 的 `bonferroni/v1`。
+
+alpha、重采样次数、resampling unit 和 seed 都进入 AnalysisPlan。v1 不内建 t-test、ANOVA、Hotelling T² 等参数方法；未来通过 AnalysisRegistry 增加新 estimator identity，不改变 observation 或 Bundle 契约。值域或 SamplingDesign 不受某 estimator 支持时，prepare 失败，不自动换算法。
+
+重新分析和重新决策保留 parent bundle digest、policy digest、生成时间以及 `analysisMode: preregistered | exploratory`。执行后修改的阈值或方法不能冒充预先封存的发布门槛。
+
+## 六、计划、Bundle 与 Report
+
+### 1．Sealed RunPlan
+
+```ts
+interface MeasurementPolicy {
+  execution: ExecutionPolicy;
+  retry: RetryPolicy;
+  budget: BudgetPolicy;
+  cache: CachePolicy;
+  evidence: EvidencePolicy;
+  failure: FailurePolicy;
+  eventDelivery: EventDeliveryPolicy;
+}
+```
+
+所有可能改变输出、缺失、调度、证据完整度或结论的配置都属于 MeasurementPolicy，并在 prepare 时进入 RunPlan 和对应 digest。`start()` 只能接收外部 `AbortSignal`、annotations 和 EventWriter，不能覆盖测量策略。
+
+### 2．ExecutionBundle
+
+按 `(targetId, sampleId, trialId)` 保存：
+
+- output 或 ContentDescriptor；
+- source-neutral trace；
+- usage、provider-reported cost、timing；
+- retry attempt 记录；
+- execution error；
+- RuntimeIdentity；
+- execution、cache／replay provenance；
+- 父 Plan digest 和 Bundle digest。
+
+价格目录推算的 cost 不是原始执行事实，应作为带 pricing fingerprint 的派生 AnalysisResult 保存。
+
+### 3．EvaluationBundle
+
+保存：
+
+- evaluator RuntimeIdentity；
+- MetricObservation；
+- evidence 或 ContentDescriptor；
+- evaluation error；
+- cache provenance；
+- parent ExecutionBundle digest、EvaluationPlan digest 和自身 digest。
+
+### 4．AnalysisBundle
+
+保存 AnalysisGraph 各节点的结果、前提检查、coverage、置信区间、分布、表格或曲线，以及 parent EvaluationBundle digest。
+
+### 5．EvaluationReport
+
+Report 是为人和产品消费构造的物化视图。它可以内联 Bundle 摘要或引用 Bundle，但不能成为重评分和审计的唯一数据源。
+
+Report 使用三个正交状态：
+
+```ts
+interface EvaluationStatus {
+  runStatus: 'completed' | 'cancelled' | 'budget-exhausted' | 'failed';
+  evidenceStatus: 'complete' | 'partial' | 'unresolvable';
+  conclusionStatus: 'conclusive' | 'inconclusive' | 'not-evaluated';
+}
+```
+
+`runStatus: completed` 只表示流程结束。只有 coverage gate、统计前提和 evidence 完整度满足 DecisionPolicy 时，才能产生 PROGRESS／REGRESSION 等方向性 verdict。
+
+### 6．Replayability
+
+每个 Bundle 声明：
+
+- `self-contained`：重评分所需内容全部内联；
+- `resolvable`：可由注入的 ContentResolver 取回并验证 digest；
+- `summary-only`：不承诺重评分。
+
+导入 Bundle 还要声明 provenance trust。schema 和 digest 校验只能证明内容完整，不能证明它确实由声称的 Target 产生。
+
+v1 不在 Core 内实现 Bundle 签名。签名要求身份策略、可信根、证书／密钥生命周期和验证材料，属于宿主治理边界。v1 只记录 digest、provenance trust 和 assurance level；宿主可以在命名空间化 extension 中附加 Sigstore／DSSE 等 attestation，并通过注入 verifier 提升 trust。没有 verifier 的签名材料只作为 opaque evidence，不能自动变成 verified。
+
+## 七、身份、规范化与可比性
+
+Definition、Plan、Bundle、Event 和 Report 都带独立 `schemaVersion`，并发布 JSON Schema 2020-12。TypeScript 类型与运行时 schema 必须单一来源生成，或由 parity test 保证一致。
+
+可寻址对象限制为 RFC 8785 JCS 可规范化的 I-JSON 子集，不允许 `NaN`、`Infinity`、函数、symbol、循环引用或依赖属性插入顺序的语义。digest 使用完整 `sha256:<hex>`。
+
+```text
+executionPlanDigest = H(
+  executionInputDigest,
+  target snapshots,
+  executor manifests,
+  SamplingDesign,
+  scheduling + execution policy
+)
+
+evaluationPlanDigest = H(
+  executionPlanDigest,
+  evaluationInputDigest,
+  evaluator manifests,
+  metric definitions,
+  evaluation policy
+)
+
+analysisPlanDigest = H(
+  evaluationPlanDigest,
+  AnalysisGraph,
+  estimator manifests
+)
+
+decisionPlanDigest = H(
+  analysisPlanDigest,
+  comparisons,
+  DecisionPolicy
+)
+
+runContractDigest = H(all plan digests + schema identities)
+```
+
+`project`、`owner`、`tags` 等 annotations 不进入测量 digest。Evidence capture 若不改变评分但改变审计能力，进入独立 evidence contract 和 Bundle provenance；若会让 Evaluator 缺少输入，则必须进入 EvaluationPlan。
+
+## 八、运行时、资源与取消
+
+Core 默认不得读写文件、读取环境配置、写 stdout／stderr、加载 CLI／Studio、创建目录、调用 `process.exit` 或维护进程级可变 registry。
+
+Runtime ports 至少包括：
+
+- ExecutorRegistry；
+- EvaluatorRegistry；
+- AnalysisRegistry；
+- ContentResolver／ContentStore；
+- Clock、IdGenerator 和 RandomSource；
+- 可选 EventWriter。
+
+Executor／Evaluator 可以通过 `openRun()` 返回 run-scoped session 和异步 disposer。资源所有权必须形成严格树：Engine 拥有 registry，Run 拥有 session，task／attempt 拥有临时资源。一个 Run 的取消或 teardown 不能关闭另一个 Run 的资源。
+
+取消统一使用 AbortSignal。用户取消产生诚实的部分 Bundle；timeout 和 budget 因为影响缺失机制，属于 sealed MeasurementPolicy。Core 不提供跨进程 resume；宿主可以从完整 ExecutionBundle 启动新的 Evaluation 阶段。
+
+## 九、Event 语义
+
+`run.events` 是有界的热通知流：
+
+- 未消费事件不得阻塞或改变 `run.result`；
+- 每个 Run 只允许一个 AsyncIterable 消费者；多路 fan-out 由宿主完成；
+- Run 创建时即开始写入内存 journal，默认最多保留 256 条；晚订阅者先收到仍保留的历史事件，再进入实时流；Run 结束后仍可订阅一次并排空 journal；
+- 宿主可以在 start observer options 中调整容量；它不进入测量 digest，因为事件拥塞不能改变 Bundle 或结论；
+- 缓冲满时先按 subject 合并尚未消费的 `progress.updated`，仍超限则丢弃最旧的 observer event，并插入 `observer.events-dropped`，记录数量和 sequence 范围；terminal event 永远保留；
+- observation、Bundle 和 terminal data 不得只存在于事件中；
+- 每个 Event 带 schemaVersion、eventId、runId、单 Run 单调 sequence、eventKind、time、subject 和 data；
+- 需要无损持久化时使用 EventWriter，其失败策略在 sealed EventDeliveryPolicy 中声明。
+
+Event 可以在 adapter 层无损映射到 CloudEvents。Trace 可以映射到 OpenTelemetry／OpenInference，并可接收 W3C Trace Context；Core 不依赖这些 SDK。
+
+## 十、错误与失败
+
+prepare 阶段的 schema、引用、capability 或统计前提错误抛出 `EvaluationDefinitionError`，不创建 Run。
+
+运行中错误分类：
+
+- configuration；
+- infrastructure；
+- execution；
+- evaluation；
+- analysis；
+- internal invariant violation。
+
+execution／evaluation error 是 observation，由 FailurePolicy 决定 continue、fail-fast 或 failure threshold。质量失败、assertion 失败和 treatment 回归都是有效测量，不属于运行错误。
+
+异常对象不能直接序列化进 Event 或 Report；必须转为稳定错误码、阶段、可公开消息、受控 details 和 cause chain。
+
+## 十一、内容、安全与隐私
+
+```ts
+interface ContentDescriptor {
+  mediaType: string;
+  digest: string;
+  size?: number;
+  uri?: string;
+}
+```
+
+Core 不直接解引用 URI。ContentResolver 负责访问控制、大小限制、协议白名单和 digest 校验。
+
+内容至少分为 public、sensitive、secret、gold。EventWriter、Report materializer、ContentStore 和 error serializer 各自声明允许接收的最高分类。Evaluator 产生的 evidence 和错误信息也经过相同分类与 redaction。
+
+EvidencePolicy 分别控制 input、output、trace、expected 和 evidence 的 full／reference／digest／none 捕获方式，并清楚报告这会不会降低 replayability 或 evidenceStatus。
+
+## 十二、公共 API 草案
+
+```ts
+const engine = createEvaluationEngine(runtime);
+
+const plan = await engine.prepare(definition, measurementPolicy);
+
+const run = plan.start({
+  signal,
+  annotations,
+  eventWriter,
+  observer: { maxBufferedEvents: 256 },
+});
+
+for await (const event of run.events) {
+  // 可选的生命周期通知
+}
+
+const result = await run.result;
+```
+
+高级 API 支持：
+
+- `execute(plan.execution)`；
+- `evaluate(plan.evaluation, executionBundle)`；
+- `analyze(plan.analysis, evaluationBundle)`；
+- `decide(plan.decision, analysisBundle)`。
+
+包根另提供一次完成全流程的便捷 façade。高级 API 输出可序列化 Bundle，不暴露可变内部调度器。公共导出通过 `package.json#exports` 白名单管理，不再承诺 `./dist/*` 深层导入。
+
+## 十三、Conformance 与验证
+
+第一组 conformance fixture 同时覆盖：
+
+1. 纯函数：结构化 input／output、无 trace；
+2. RAG top-K：retrieval evidence、ranking Metric；
+3. Agent trajectory：多轮消息、工具调用、取消和部分 trace。
+
+若 Core orchestrator 需要按 `targetKind` 加分支，协议抽象不通过验收。
+
+必须包含以下性质测试：
+
+- JSON 属性顺序变化不改变 digest；
+- annotations 变化不改变测量 digest；
+- Gold 变化只失效 Evaluation 及下游；
+- Evaluator 变化不失效 Execution；
+- Runtime fingerprint 变化必然失效对应阶段；
+- replay 不增加随机 trial 数；
+- repeated trial 不被当作独立 experimental unit；
+- 慢 Event 消费者不改变结果；
+- 并发 Run 不共享取消、cache 或 teardown；
+- paired block 在预算耗尽时不会只完成一侧；
+- secret／gold 不进入未授权 Event、Report 或 error；
+- partial evidence 无法越过 coverage gate 产生方向性 verdict。
+
+统计实现还要使用已知参考向量和 simulation 检查 coverage、I 型错误率、配对和 cluster resampling，而不只锁 snapshot。
+
+## 十四、被否决的方案
+
+### 1．在现有 `runEvaluation` 上继续加 options
+
+否决。它保留了 CLI、文件、全局状态和 Report 耦合，无法建立清晰的 Gold 和 effect 边界。
+
+### 2．只保留一个 Report，重评分时从 Report 取数据
+
+否决。展示捕获策略会反向限制测量事实，Report schema 也会同时承担过多职责。
+
+### 3．把 Event Log 当作唯一事实源
+
+否决。Core 不承担 durable event store 和恢复协议；未消费或拥塞的通知流不能影响测量事实。
+
+### 4．所有 Metric 统一到 0–1 并默认平均
+
+否决。统一范围不等于 construct 可比，会隐藏量表、方向和缺失语义。
+
+### 5．所有 Target 使用一个不断增长的 capability 列表
+
+否决。它会形成 Boolean soup。采用 protocol family + schema + capability negotiation。
+
+### 6．透明复用所有 Execution cache
+
+否决。它会把同一输出伪装成新的随机 trial，破坏方差与稳定性测量。
+
+### 7．在 Core 内实现数据库、队列和 checkpoint
+
+否决。durability 和分布式编排属于宿主；Core 提供可寻址 Bundle 作为组合边界。
+
+## 十五、交付顺序
+
+1. 本 RFC 与关键 ADR 评审通过；
+2. 创建 Contracts、Compiler、Execution、Evaluation／Analysis、Conformance 五个 child Issue；
+3. Contracts：schema、类型、canonicalization、digest 和状态机；
+4. Compiler：projection、capability resolution、Plan sealing；
+5. Execution：trial、paired scheduling、资源和 ExecutionBundle；
+6. Evaluation／Analysis：重评分、AnalysisGraph、统计和 DecisionPolicy；
+7. Conformance：三类 Target、fault injection、安全与 simulation；
+8. #424 包根 façade；
+9. 最后迁移 CLI／Studio。
+
+每一阶段只依赖前一阶段的公开 Bundle／Plan 契约，不直接导入内部实现。
+
+## 十六、RFC 决议记录
+
+本轮评审关闭五个阻断问题：
+
+1. **Schema 单一来源**：采用 Zod 4 可完整导出的 wire-schema 子集；JSON Schema 2020-12 由 CI 生成，语义校验留在 prepare compiler。
+2. **Protocol family**：v1 只有 `omk.invoke/v1` 和 `omk.session/v1`；外部结果通过 ExecutionBundle 导入，不新增 import protocol。
+3. **Event journal**：单消费者、默认 256 条、晚订阅回放保留窗口、progress 优先合并、溢出显式报告；无损需求走 EventWriter。
+4. **Bundle 签名**：v1 不内建签名，只记录 digest 与 trust；签名／attestation 由宿主 extension 和 verifier 组合。
+5. **Estimator registry**：v1 内建描述性 reducer、percentile bootstrap 的 mean／paired-difference／cluster 和 Bonferroni，不内建参数方法。
+
+这些决定关闭 Contracts 开工前的架构选择；实现阶段仍需用 conformance 和 simulation 验证默认常量与算法正确性。
+
+## 十七、行业参考
+
+- [Inspect AI Tasks](https://inspect.aisi.org.uk/tasks.html)、[Scorers](https://inspect.aisi.org.uk/scorers.html)、[Eval Logs](https://inspect.aisi.org.uk/eval-logs.html)；
+- [Phoenix Experiments](https://arize.com/docs/ax/improve/experiment-in-code)；
+- [Pydantic Evals](https://pydantic.dev/docs/ai/evals/evals/)、[Report Evaluators](https://pydantic.dev/docs/ai/evals/evaluators/report-evaluators/)；
+- [lm-evaluation-harness Task Guide](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/docs/task_guide.md)；
+- [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/)、[OpenInference Semantic Conventions](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md)；
+- [CloudEvents](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md)、[W3C Trace Context](https://www.w3.org/TR/trace-context/)；
+- [JSON Schema 2020-12](https://json-schema.org/draft/2020-12)、[RFC 8785 JCS](https://www.rfc-editor.org/rfc/rfc8785.html)、[RFC 6901 JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901)。
+- [Zod 4 JSON Schema](https://zod.dev/json-schema)、[Node.js Events](https://nodejs.org/api/events.html)、[Sigstore Bundle specification](https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto)。
+
+## 相关文档
+
+- [评分公式](scoring.md)；
+- [统计严谨性](../explanation/statistical-rigor.md)；
+- [术语规范](terminology-spec.md)；
+- [RAG metrics 规范](rag-metrics-spec.md)。

--- a/docs/zh/specs/evaluation-core-vnext.md
+++ b/docs/zh/specs/evaluation-core-vnext.md
@@ -257,7 +257,7 @@ interface MeasurementPolicy {
 }
 ```
 
-所有可能改变输出、缺失、调度、证据完整度或结论的配置都属于 MeasurementPolicy，并在 prepare 时进入 RunPlan 和对应 digest。`start()` 只能接收外部 `AbortSignal`、annotations 和 EventWriter，不能覆盖测量策略。
+所有可能改变输出、缺失、调度、证据完整度或结论的配置都属于 MeasurementPolicy，并在 prepare 时进入 RunPlan 和对应 digest。`start()` 只能接收外部 `AbortSignal`、annotations、EventWriter 和不影响测量结果的 observer options，不能覆盖测量策略。
 
 ### 2．ExecutionBundle
 


### PR DESCRIPTION
## 用户影响

新增 Evaluation Core vNext 的中英文架构 RFC，并接入文档索引。RFC 为未来包根嵌入式 API 建立宿主无关的测量契约；本 PR 不改变当前 CLI、评分结果、Report schema 或运行行为。

## 架构范围

RFC 把执行事实、评测观察、统计分析和发布决策拆成可独立重算的阶段，并封存 Gold 投影、SamplingDesign、缓存／replay、预算截尾、Bundle provenance、事件和资源生命周期等边界。

首轮评审同时关闭 schema 单一来源、v1 protocol family、事件 journal、Bundle 签名边界和首批 estimator registry 五个阻断选择。后续实现按 Contracts、Compiler、Execution、Evaluation／Analysis 和 Conformance 独立拆分。

## 测量学说明

本 PR 不修改现有测量不变量，因此不产生历史报告可比性变化。RFC 明确禁止不同量表隐式平均、缺失维度自动降权、cache replay 冒充新 trial，以及在 evidence coverage 不足时产生方向性发布 verdict。

## 迁移说明

当前用户无需迁移。未来 Evaluation Core vNext 将按 RFC 采用不兼容的 Definition、Bundle 和 Report 契约；旧 pipeline 的迁移在独立 PR 中完成，不在新 Core 中加入兼容分支。

Refs #425
Prerequisite for #424
