### PR TITLE
feat(eval-core): 建立 v1 契约与分层摘要

### DIFF
--- a/docs/specs/evaluation-core-vnext.md
+++ b/docs/specs/evaluation-core-vnext.md
@@ -1,6 +1,6 @@
 # Evaluation Core vNext RFC
 
-> **Status**: Draft. Tracks [#425](https://github.com/lizhiyao/oh-my-knowledge/issues/425) and is the architecture prerequisite for [#424](https://github.com/lizhiyao/oh-my-knowledge/issues/424). This RFC defines a new Evaluation Core domain and measurement contract. It is intentionally incompatible with the current `runEvaluation`, file-based Sample, and Report JSON schema. The old pipeline is evidence for algorithms and failure modes, not a compatibility target.
+> **Status**: Accepted by [#426](https://github.com/lizhiyao/oh-my-knowledge/pull/426). Tracks [#425](https://github.com/lizhiyao/oh-my-knowledge/issues/425) and is the architecture prerequisite for [#424](https://github.com/lizhiyao/oh-my-knowledge/issues/424). This RFC defines a new Evaluation Core domain and measurement contract. It is intentionally incompatible with the current `runEvaluation`, file-based Sample, and Report JSON schema. The old pipeline is evidence for algorithms and failure modes, not a compatibility target.
 
 ## 1. Summary
 
@@ -536,7 +536,27 @@ This review closes five blocking questions:
 
 These decisions close the architectural choices required before Contracts. Conformance tests and simulations must still validate implementation constants and algorithms.
 
-## 17. Industry references
+## 17. Contracts v1 implementation baseline
+
+The first implementation phase is tracked by [#427](https://github.com/lizhiyao/oh-my-knowledge/issues/427). Its source of truth is isolated under `src/evaluation-core/contracts/`; it does not import the historical `src/eval-core/`, CLI, executor, grading, renderer, or server layers.
+
+The catalog currently publishes twelve JSON Schema 2020-12 roots under `schemas/evaluation-core/v1/`: EvaluationDefinition, MeasurementPolicy, four stage Plans plus RunPlan, Event, three Bundles, and EvaluationReport. TypeScript types are inferred from the same Zod 4 schemas. `yarn build:schemas` regenerates the files, while `yarn build` checks committed output for drift and copies it into the package build.
+
+Wire entry points use `parseWireDocument()` rather than a bare schema parse. It first rejects values that cannot be represented as I-JSON or JCS input, including non-finite numbers, functions, symbols, cycles, sparse arrays, accessor properties, class instances, and unpaired Unicode surrogates, and then applies the Zod schema. Hosts accepting raw JSON text must additionally reject duplicate property names before constructing a JavaScript value because duplicates are no longer observable after ordinary `JSON.parse()`.
+
+Digest boundaries are executable contracts:
+
+| Identity | Includes | Excludes |
+|---|---|---|
+| `datasetRevisionDigest` | complete Dataset | nothing |
+| `executionInputDigest` | `sampleId`, `input`, `executionContext` | Gold, evaluator context, annotations |
+| `evaluationInputDigest` | execution projection, `expected`, `evaluationContext` | annotations |
+| stage Plan digests | previous-stage identity plus stage definitions, resolved Runtime identities, and relevant sealed policy | later-stage policy and audit annotations |
+| `runContractDigest` | all stage Plan digests, schema identities, and EventDeliveryPolicy | Report annotations and observer-only options |
+
+Every digest is the full lowercase `sha256:<hex>` of RFC 8785 canonical UTF-8 bytes. It proves content identity only. Provenance trust, fingerprint basis, and assurance level remain separate fields, and v1 does not implement signing.
+
+## 18. Industry references
 
 - [Inspect AI Tasks](https://inspect.aisi.org.uk/tasks.html), [Scorers](https://inspect.aisi.org.uk/scorers.html), and [Eval Logs](https://inspect.aisi.org.uk/eval-logs.html)
 - [Phoenix Experiments](https://arize.com/docs/ax/improve/experiment-in-code)

--- a/docs/zh/specs/evaluation-core-vnext.md
+++ b/docs/zh/specs/evaluation-core-vnext.md
@@ -1,6 +1,6 @@
 # Evaluation Core vNext RFC
 
-> **状态**：Draft。关联 [#425](https://github.com/lizhiyao/oh-my-knowledge/issues/425)，并作为 [#424](https://github.com/lizhiyao/oh-my-knowledge/issues/424) 的架构前置。本文定义全新 Evaluation Core 的领域边界和测量契约，不兼容现有 `runEvaluation`、文件型 Sample 或 Report JSON schema。旧实现只作为算法与失败案例的参考。
+> **状态**：已由 [#426](https://github.com/lizhiyao/oh-my-knowledge/pull/426) 接受。关联 [#425](https://github.com/lizhiyao/oh-my-knowledge/issues/425)，并作为 [#424](https://github.com/lizhiyao/oh-my-knowledge/issues/424) 的架构前置。本文定义全新 Evaluation Core 的领域边界和测量契约，不兼容现有 `runEvaluation`、文件型 Sample 或 Report JSON schema。旧实现只作为算法与失败案例的参考。
 
 ## 一、摘要
 
@@ -536,7 +536,27 @@ const result = await run.result;
 
 这些决定关闭 Contracts 开工前的架构选择；实现阶段仍需用 conformance 和 simulation 验证默认常量与算法正确性。
 
-## 十七、行业参考
+## 十七、Contracts v1 实现基线
+
+第一阶段实现由 [#427](https://github.com/lizhiyao/oh-my-knowledge/issues/427) 跟踪。单一来源隔离在 `src/evaluation-core/contracts/`，不导入历史 `src/eval-core/`、CLI、executor、grading、renderer 或 server 层。
+
+Catalog 当前在 `schemas/evaluation-core/v1/` 发布十二个 JSON Schema 2020-12 根契约：EvaluationDefinition、MeasurementPolicy、四个阶段 Plan 与 RunPlan、Event、三个 Bundle、EvaluationReport。TypeScript 类型从同一组 Zod 4 schema 推导。`yarn build:schemas` 重新生成文件；`yarn build` 检查已提交产物是否漂移，并把它们复制到 package build。
+
+Wire 入口使用 `parseWireDocument()`，不直接裸调 schema parse。它先拒绝不能表示为 I-JSON 或 JCS 输入的值，包括非有限数、函数、symbol、循环引用、稀疏数组、accessor property、class instance 和未配对 Unicode surrogate，再执行 Zod schema 校验。宿主若接收原始 JSON 文本，还必须在构造 JavaScript 值前拒绝重复属性名，因为普通 `JSON.parse()` 完成后已无法观测重复键。
+
+Digest 边界是可执行契约：
+
+| Identity | 包含 | 排除 |
+|---|---|---|
+| `datasetRevisionDigest` | 完整 Dataset | 无 |
+| `executionInputDigest` | `sampleId`、`input`、`executionContext` | Gold、evaluator context、annotations |
+| `evaluationInputDigest` | execution projection、`expected`、`evaluationContext` | annotations |
+| 各阶段 Plan digest | 前序阶段 identity、当前阶段定义、实际解析的 Runtime identity、相关 sealed policy | 后续阶段 policy、审计 annotations |
+| `runContractDigest` | 全部阶段 Plan digest、schema identity、EventDeliveryPolicy | Report annotations、仅 observer 使用的选项 |
+
+所有 digest 都是 RFC 8785 canonical UTF-8 bytes 的完整小写 `sha256:<hex>`。它只证明内容身份。Provenance trust、fingerprint basis 与 assurance level 保持独立字段；v1 不实现签名。
+
+## 十八、行业参考
 
 - [Inspect AI Tasks](https://inspect.aisi.org.uk/tasks.html)、[Scorers](https://inspect.aisi.org.uk/scorers.html)、[Eval Logs](https://inspect.aisi.org.uk/eval-logs.html)；
 - [Phoenix Experiments](https://arize.com/docs/ax/improve/experiment-in-code)；

--- a/package.json
+++ b/package.json
@@ -29,9 +29,12 @@
   },
   "scripts": {
     "clean": "rm -rf dist dist-scripts node_modules/.cache/omk",
-    "build": "run-s build:src build:scripts build:assets",
+    "build": "run-s build:src build:scripts schemas:check build:assets",
     "build:src": "tsc -p tsconfig.build.json",
     "build:scripts": "tsc -p tsconfig.scripts.json",
+    "build:schemas": "run-s build:src schemas:write",
+    "schemas:write": "node scripts/build-evaluation-core-schemas.mjs --write",
+    "schemas:check": "node scripts/build-evaluation-core-schemas.mjs --check",
     "build:assets": "node scripts/copy-assets.cjs",
     "build:docs": "node dist-scripts/build-docs.js --write",
     "build:docs:check": "node dist-scripts/build-docs.js --check",

--- a/schemas/evaluation-core/v1/analysis-bundle.schema.json
+++ b/schemas/evaluation-core/v1/analysis-bundle.schema.json
@@ -1,0 +1,345 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.analysis-bundle/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema10": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    },
+    "__schema2": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema3": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "analysisMode": {
+            "enum": [
+              "preregistered",
+              "exploratory"
+            ],
+            "type": "string"
+          },
+          "derivedAt": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+            "type": "string"
+          },
+          "implementation": {
+            "additionalProperties": false,
+            "properties": {
+              "assuranceLevel": {
+                "enum": [
+                  "verified",
+                  "declared",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "capabilities": {
+                "$ref": "#/$defs/__schema4"
+              },
+              "fingerprint": {
+                "$ref": "#/$defs/__schema5"
+              },
+              "fingerprintBasis": {
+                "enum": [
+                  "content-derived",
+                  "environment-derived",
+                  "self-reported",
+                  "opaque"
+                ],
+                "type": "string"
+              },
+              "implementationId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "provenanceFacets": {
+                "$ref": "#/$defs/__schema4"
+              },
+              "version": {
+                "$ref": "#/$defs/__schema5"
+              }
+            },
+            "required": [
+              "implementationId",
+              "fingerprint",
+              "fingerprintBasis",
+              "assuranceLevel",
+              "capabilities"
+            ],
+            "type": "object"
+          },
+          "nodeId": {
+            "$ref": "#/$defs/__schema1"
+          },
+          "parentDigests": {
+            "items": {
+              "$ref": "#/$defs/__schema2"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "resultId": {
+            "$ref": "#/$defs/__schema1"
+          },
+          "resultType": {
+            "enum": [
+              "scalar",
+              "interval",
+              "distribution",
+              "table",
+              "matrix",
+              "curve"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/$defs/__schema4"
+          }
+        },
+        "required": [
+          "resultId",
+          "nodeId",
+          "resultType",
+          "value",
+          "implementation",
+          "parentDigests",
+          "analysisMode",
+          "derivedAt"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "__schema4": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema5": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema6": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "assumptionId": {
+            "$ref": "#/$defs/__schema1"
+          },
+          "checkStatus": {
+            "enum": [
+              "passed",
+              "failed",
+              "not-evaluated"
+            ],
+            "type": "string"
+          },
+          "details": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "message": {
+            "$ref": "#/$defs/__schema5"
+          }
+        },
+        "required": [
+          "assumptionId",
+          "checkStatus"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "__schema7": {
+      "additionalProperties": false,
+      "properties": {
+        "censored": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "comparable": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "completed": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "missing": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "started": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "started",
+        "completed",
+        "comparable",
+        "censored",
+        "missing"
+      ],
+      "type": "object"
+    },
+    "__schema8": {
+      "additionalProperties": false,
+      "properties": {
+        "facets": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "parentDigests": {
+          "items": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "type": "array"
+        },
+        "provenanceKind": {
+          "enum": [
+            "native",
+            "imported",
+            "replay",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "sourceId": {
+          "$ref": "#/$defs/__schema5"
+        },
+        "trust": {
+          "enum": [
+            "verified",
+            "declared",
+            "untrusted",
+            "unknown"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "provenanceKind",
+        "trust",
+        "parentDigests"
+      ],
+      "type": "object"
+    },
+    "__schema9": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "schemaDigest": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema10"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema10"
+      },
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/analysis-bundle.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "analysisPlanDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "assumptionChecks": {
+      "$ref": "#/$defs/__schema6"
+    },
+    "bundleDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "bundleId": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "coverage": {
+      "$ref": "#/$defs/__schema7"
+    },
+    "evaluationBundleDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema9"
+    },
+    "provenance": {
+      "$ref": "#/$defs/__schema8"
+    },
+    "results": {
+      "$ref": "#/$defs/__schema3"
+    },
+    "runContractDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "bundleId",
+    "runContractDigest",
+    "evaluationBundleDigest",
+    "analysisPlanDigest",
+    "results",
+    "assumptionChecks",
+    "coverage",
+    "provenance",
+    "bundleDigest"
+  ],
+  "title": "OMK Analysis Bundle v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/analysis-plan.schema.json
+++ b/schemas/evaluation-core/v1/analysis-plan.schema.json
@@ -1,0 +1,378 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.analysis-plan/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema10": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "identity": {
+            "additionalProperties": false,
+            "properties": {
+              "assuranceLevel": {
+                "enum": [
+                  "verified",
+                  "declared",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "capabilities": {
+                "$ref": "#/$defs/__schema7"
+              },
+              "fingerprint": {
+                "$ref": "#/$defs/__schema11"
+              },
+              "fingerprintBasis": {
+                "enum": [
+                  "content-derived",
+                  "environment-derived",
+                  "self-reported",
+                  "opaque"
+                ],
+                "type": "string"
+              },
+              "implementationId": {
+                "$ref": "#/$defs/__schema3"
+              },
+              "provenanceFacets": {
+                "$ref": "#/$defs/__schema7"
+              },
+              "version": {
+                "$ref": "#/$defs/__schema11"
+              }
+            },
+            "required": [
+              "implementationId",
+              "fingerprint",
+              "fingerprintBasis",
+              "assuranceLevel",
+              "capabilities"
+            ],
+            "type": "object"
+          },
+          "referenceId": {
+            "$ref": "#/$defs/__schema3"
+          },
+          "runtimeKind": {
+            "enum": [
+              "executor",
+              "evaluator",
+              "analysis"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "runtimeKind",
+          "referenceId",
+          "identity"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "__schema11": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema12": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema7"
+          },
+          "schemaDigest": {
+            "$ref": "#/$defs/__schema1"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema13"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema13"
+      },
+      "type": "object"
+    },
+    "__schema13": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    },
+    "__schema2": {
+      "additionalProperties": false,
+      "properties": {
+        "nodes": {
+          "items": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "analysisNodeKind": {
+                    "const": "reducer",
+                    "type": "string"
+                  },
+                  "implementationId": {
+                    "$ref": "#/$defs/__schema3"
+                  },
+                  "inputs": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "nodeId": {
+                    "$ref": "#/$defs/__schema3"
+                  },
+                  "outputResultId": {
+                    "$ref": "#/$defs/__schema3"
+                  },
+                  "parameters": {
+                    "$ref": "#/$defs/__schema6"
+                  }
+                },
+                "required": [
+                  "nodeId",
+                  "implementationId",
+                  "inputs",
+                  "outputResultId",
+                  "analysisNodeKind"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "analysisNodeKind": {
+                    "const": "estimator",
+                    "type": "string"
+                  },
+                  "implementationId": {
+                    "$ref": "#/$defs/__schema3"
+                  },
+                  "inputs": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "nodeId": {
+                    "$ref": "#/$defs/__schema3"
+                  },
+                  "outputResultId": {
+                    "$ref": "#/$defs/__schema3"
+                  },
+                  "parameters": {
+                    "$ref": "#/$defs/__schema6"
+                  }
+                },
+                "required": [
+                  "nodeId",
+                  "implementationId",
+                  "inputs",
+                  "outputResultId",
+                  "analysisNodeKind"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "analysisNodeKind": {
+                    "const": "correction",
+                    "type": "string"
+                  },
+                  "implementationId": {
+                    "$ref": "#/$defs/__schema3"
+                  },
+                  "inputs": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "nodeId": {
+                    "$ref": "#/$defs/__schema3"
+                  },
+                  "outputResultId": {
+                    "$ref": "#/$defs/__schema3"
+                  },
+                  "parameters": {
+                    "$ref": "#/$defs/__schema6"
+                  }
+                },
+                "required": [
+                  "nodeId",
+                  "implementationId",
+                  "inputs",
+                  "outputResultId",
+                  "analysisNodeKind"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "nodes"
+      ],
+      "type": "object"
+    },
+    "__schema3": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema4": {
+      "items": {
+        "$ref": "#/$defs/__schema5"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema5": {
+      "additionalProperties": false,
+      "properties": {
+        "inputKind": {
+          "enum": [
+            "metric-observations",
+            "analysis-result"
+          ],
+          "type": "string"
+        },
+        "referenceId": {
+          "$ref": "#/$defs/__schema3"
+        }
+      },
+      "required": [
+        "inputKind",
+        "referenceId"
+      ],
+      "type": "object"
+    },
+    "__schema6": {
+      "$ref": "#/$defs/__schema7"
+    },
+    "__schema7": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema7"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema7"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema8": {
+      "additionalProperties": false,
+      "properties": {
+        "clusterKey": {
+          "$ref": "#/$defs/__schema9"
+        },
+        "estimatorId": {
+          "$ref": "#/$defs/__schema3"
+        },
+        "experimentalUnit": {
+          "enum": [
+            "sample",
+            "run",
+            "cluster"
+          ],
+          "type": "string"
+        },
+        "pairingKey": {
+          "$ref": "#/$defs/__schema9"
+        },
+        "repeatedMeasures": {
+          "type": "boolean"
+        },
+        "resamplingUnit": {
+          "enum": [
+            "sample",
+            "paired-block",
+            "cluster",
+            "run"
+          ],
+          "type": "string"
+        },
+        "stratumKey": {
+          "$ref": "#/$defs/__schema9"
+        }
+      },
+      "required": [
+        "experimentalUnit",
+        "repeatedMeasures",
+        "resamplingUnit",
+        "estimatorId"
+      ],
+      "type": "object"
+    },
+    "__schema9": {
+      "pattern": "^(?:\\/(?:[^~/]|~[01])*)*$",
+      "type": "string"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/analysis-plan.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "analysisGraph": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "analysisPlanDigest": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "evaluationPlanDigest": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema12"
+    },
+    "runtimes": {
+      "$ref": "#/$defs/__schema10"
+    },
+    "sampling": {
+      "$ref": "#/$defs/__schema8"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "evaluationPlanDigest",
+    "analysisGraph",
+    "sampling",
+    "runtimes",
+    "analysisPlanDigest"
+  ],
+  "title": "OMK Analysis Plan v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/decision-plan.schema.json
+++ b/schemas/evaluation-core/v1/decision-plan.schema.json
@@ -1,0 +1,183 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.decision-plan/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema2": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "comparisonId": {
+            "$ref": "#/$defs/__schema3"
+          },
+          "controlTargetId": {
+            "$ref": "#/$defs/__schema3"
+          },
+          "metricIds": {
+            "items": {
+              "$ref": "#/$defs/__schema3"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "treatmentTargetIds": {
+            "items": {
+              "$ref": "#/$defs/__schema3"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "comparisonId",
+          "controlTargetId",
+          "treatmentTargetIds",
+          "metricIds"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "__schema3": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema4": {
+      "additionalProperties": false,
+      "properties": {
+        "analysisResultIds": {
+          "items": {
+            "$ref": "#/$defs/__schema3"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "decisionPolicyId": {
+          "$ref": "#/$defs/__schema3"
+        },
+        "implementationId": {
+          "$ref": "#/$defs/__schema3"
+        },
+        "minimumEvidenceStatus": {
+          "enum": [
+            "complete",
+            "partial",
+            "unresolvable"
+          ],
+          "type": "string"
+        },
+        "multipleComparisonPolicyId": {
+          "$ref": "#/$defs/__schema3"
+        },
+        "parameters": {
+          "$ref": "#/$defs/__schema5"
+        }
+      },
+      "required": [
+        "decisionPolicyId",
+        "implementationId",
+        "analysisResultIds",
+        "minimumEvidenceStatus"
+      ],
+      "type": "object"
+    },
+    "__schema5": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema6": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "schemaDigest": {
+            "$ref": "#/$defs/__schema1"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema7"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema7"
+      },
+      "type": "object"
+    },
+    "__schema7": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/decision-plan.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "analysisPlanDigest": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "comparisons": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "decisionPlanDigest": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "decisionPolicy": {
+      "$ref": "#/$defs/__schema4"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema6"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "analysisPlanDigest",
+    "comparisons",
+    "decisionPlanDigest"
+  ],
+  "title": "OMK Decision Plan v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/evaluation-bundle.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-bundle.schema.json
@@ -1,0 +1,803 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.evaluation-bundle/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema10": {
+      "$ref": "#/$defs/__schema11"
+    },
+    "__schema11": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "classification": {
+              "$ref": "#/$defs/__schema12"
+            },
+            "contentKind": {
+              "const": "inline",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/__schema7"
+            }
+          },
+          "required": [
+            "contentKind",
+            "classification",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "classification": {
+              "$ref": "#/$defs/__schema12"
+            },
+            "contentKind": {
+              "const": "descriptor",
+              "type": "string"
+            },
+            "descriptor": {
+              "additionalProperties": false,
+              "properties": {
+                "digest": {
+                  "$ref": "#/$defs/__schema2"
+                },
+                "mediaType": {
+                  "$ref": "#/$defs/__schema6"
+                },
+                "size": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "uri": {
+                  "$ref": "#/$defs/__schema13"
+                }
+              },
+              "required": [
+                "mediaType",
+                "digest"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "contentKind",
+            "classification",
+            "descriptor"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "classification": {
+              "$ref": "#/$defs/__schema12"
+            },
+            "contentKind": {
+              "const": "digest-only",
+              "type": "string"
+            },
+            "digest": {
+              "$ref": "#/$defs/__schema2"
+            }
+          },
+          "required": [
+            "contentKind",
+            "classification",
+            "digest"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "__schema12": {
+      "enum": [
+        "public",
+        "sensitive",
+        "secret",
+        "gold"
+      ],
+      "type": "string"
+    },
+    "__schema13": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    },
+    "__schema14": {
+      "additionalProperties": false,
+      "properties": {
+        "facets": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "parentDigests": {
+          "items": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "type": "array"
+        },
+        "provenanceKind": {
+          "enum": [
+            "native",
+            "imported",
+            "replay",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "sourceId": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "trust": {
+          "enum": [
+            "verified",
+            "declared",
+            "untrusted",
+            "unknown"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "provenanceKind",
+        "trust",
+        "parentDigests"
+      ],
+      "type": "object"
+    },
+    "__schema15": {
+      "additionalProperties": false,
+      "properties": {
+        "cacheKeyDigest": {
+          "$ref": "#/$defs/__schema2"
+        },
+        "cacheStatus": {
+          "enum": [
+            "not-used",
+            "miss",
+            "replay",
+            "transparent-hit"
+          ],
+          "type": "string"
+        },
+        "sourceRecordDigest": {
+          "$ref": "#/$defs/__schema2"
+        }
+      },
+      "required": [
+        "cacheStatus"
+      ],
+      "type": "object"
+    },
+    "__schema16": {
+      "$ref": "#/$defs/__schema11"
+    },
+    "__schema17": {
+      "$ref": "#/$defs/__schema7"
+    },
+    "__schema18": {
+      "additionalProperties": false,
+      "properties": {
+        "causes": {
+          "items": {
+            "$ref": "#/$defs/__schema18"
+          },
+          "type": "array"
+        },
+        "code": {
+          "$ref": "#/$defs/__schema1"
+        },
+        "details": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "message": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "stage": {
+          "enum": [
+            "configuration",
+            "infrastructure",
+            "execution",
+            "evaluation",
+            "analysis",
+            "internal"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "stage",
+        "message"
+      ],
+      "type": "object"
+    },
+    "__schema19": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema7"
+          },
+          "schemaDigest": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema13"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema13"
+      },
+      "type": "object"
+    },
+    "__schema2": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema3": {
+      "enum": [
+        "self-contained",
+        "resolvable",
+        "summary-only"
+      ],
+      "type": "string"
+    },
+    "__schema4": {
+      "items": {
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "cache": {
+                "$ref": "#/$defs/__schema15"
+              },
+              "evaluationStatus": {
+                "const": "completed",
+                "type": "string"
+              },
+              "evaluatorId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "evidence": {
+                "$ref": "#/$defs/__schema10"
+              },
+              "observations": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "evidence": {
+                          "$ref": "#/$defs/__schema16"
+                        },
+                        "metadata": {
+                          "$ref": "#/$defs/__schema17"
+                        },
+                        "metricId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationStatus": {
+                          "const": "observed",
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "number"
+                        },
+                        "valueType": {
+                          "const": "numeric",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "observationId",
+                        "metricId",
+                        "observationStatus",
+                        "valueType",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "evidence": {
+                          "$ref": "#/$defs/__schema16"
+                        },
+                        "metadata": {
+                          "$ref": "#/$defs/__schema17"
+                        },
+                        "metricId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationStatus": {
+                          "const": "observed",
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "boolean"
+                        },
+                        "valueType": {
+                          "const": "boolean",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "observationId",
+                        "metricId",
+                        "observationStatus",
+                        "valueType",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "evidence": {
+                          "$ref": "#/$defs/__schema16"
+                        },
+                        "metadata": {
+                          "$ref": "#/$defs/__schema17"
+                        },
+                        "metricId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationStatus": {
+                          "const": "observed",
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "valueType": {
+                          "const": "categorical",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "observationId",
+                        "metricId",
+                        "observationStatus",
+                        "valueType",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "evidence": {
+                          "$ref": "#/$defs/__schema16"
+                        },
+                        "metadata": {
+                          "$ref": "#/$defs/__schema17"
+                        },
+                        "metricId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationStatus": {
+                          "const": "observed",
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "valueType": {
+                          "const": "text",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "observationId",
+                        "metricId",
+                        "observationStatus",
+                        "valueType",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "evidence": {
+                          "$ref": "#/$defs/__schema16"
+                        },
+                        "metadata": {
+                          "$ref": "#/$defs/__schema17"
+                        },
+                        "metricId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationStatus": {
+                          "const": "observed",
+                          "type": "string"
+                        },
+                        "value": {
+                          "items": {
+                            "$ref": "#/$defs/__schema1"
+                          },
+                          "type": "array"
+                        },
+                        "valueType": {
+                          "const": "ranking",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "observationId",
+                        "metricId",
+                        "observationStatus",
+                        "valueType",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "evidence": {
+                          "$ref": "#/$defs/__schema16"
+                        },
+                        "metadata": {
+                          "$ref": "#/$defs/__schema17"
+                        },
+                        "metricId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationStatus": {
+                          "const": "missing",
+                          "type": "string"
+                        },
+                        "reasonCode": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "valueType": {
+                          "enum": [
+                            "numeric",
+                            "boolean",
+                            "categorical",
+                            "text",
+                            "ranking"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "observationId",
+                        "metricId",
+                        "observationStatus",
+                        "valueType",
+                        "reasonCode"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "evidence": {
+                          "$ref": "#/$defs/__schema16"
+                        },
+                        "invalidValue": {
+                          "$ref": "#/$defs/__schema11"
+                        },
+                        "metadata": {
+                          "$ref": "#/$defs/__schema17"
+                        },
+                        "metricId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationId": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "observationStatus": {
+                          "const": "invalid",
+                          "type": "string"
+                        },
+                        "reasonCode": {
+                          "$ref": "#/$defs/__schema1"
+                        },
+                        "valueType": {
+                          "enum": [
+                            "numeric",
+                            "boolean",
+                            "categorical",
+                            "text",
+                            "ranking"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "observationId",
+                        "metricId",
+                        "observationStatus",
+                        "valueType",
+                        "reasonCode"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              "provenance": {
+                "$ref": "#/$defs/__schema14"
+              },
+              "runtime": {
+                "$ref": "#/$defs/__schema5"
+              },
+              "sampleId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "targetId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "timing": {
+                "$ref": "#/$defs/__schema8"
+              },
+              "trialId": {
+                "$ref": "#/$defs/__schema1"
+              }
+            },
+            "required": [
+              "targetId",
+              "sampleId",
+              "trialId",
+              "evaluatorId",
+              "runtime",
+              "timing",
+              "provenance",
+              "cache",
+              "evaluationStatus",
+              "observations"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "cache": {
+                "$ref": "#/$defs/__schema15"
+              },
+              "error": {
+                "$ref": "#/$defs/__schema18"
+              },
+              "evaluationStatus": {
+                "const": "failed",
+                "type": "string"
+              },
+              "evaluatorId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "evidence": {
+                "$ref": "#/$defs/__schema10"
+              },
+              "provenance": {
+                "$ref": "#/$defs/__schema14"
+              },
+              "runtime": {
+                "$ref": "#/$defs/__schema5"
+              },
+              "sampleId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "targetId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "timing": {
+                "$ref": "#/$defs/__schema8"
+              },
+              "trialId": {
+                "$ref": "#/$defs/__schema1"
+              }
+            },
+            "required": [
+              "targetId",
+              "sampleId",
+              "trialId",
+              "evaluatorId",
+              "runtime",
+              "timing",
+              "provenance",
+              "cache",
+              "evaluationStatus",
+              "error"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "__schema5": {
+      "additionalProperties": false,
+      "properties": {
+        "assuranceLevel": {
+          "enum": [
+            "verified",
+            "declared",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "fingerprint": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "fingerprintBasis": {
+          "enum": [
+            "content-derived",
+            "environment-derived",
+            "self-reported",
+            "opaque"
+          ],
+          "type": "string"
+        },
+        "implementationId": {
+          "$ref": "#/$defs/__schema1"
+        },
+        "provenanceFacets": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "version": {
+          "$ref": "#/$defs/__schema6"
+        }
+      },
+      "required": [
+        "implementationId",
+        "fingerprint",
+        "fingerprintBasis",
+        "assuranceLevel",
+        "capabilities"
+      ],
+      "type": "object"
+    },
+    "__schema6": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema7": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema7"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema7"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema8": {
+      "additionalProperties": false,
+      "properties": {
+        "completedAt": {
+          "$ref": "#/$defs/__schema9"
+        },
+        "durationMs": {
+          "minimum": 0,
+          "type": "number"
+        },
+        "startedAt": {
+          "$ref": "#/$defs/__schema9"
+        }
+      },
+      "required": [
+        "startedAt"
+      ],
+      "type": "object"
+    },
+    "__schema9": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+      "type": "string"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/evaluation-bundle.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "bundleDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "bundleId": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "evaluationInputDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "evaluationPlanDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "executionBundleDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema19"
+    },
+    "provenance": {
+      "$ref": "#/$defs/__schema14"
+    },
+    "records": {
+      "$ref": "#/$defs/__schema4"
+    },
+    "replayability": {
+      "$ref": "#/$defs/__schema3"
+    },
+    "runContractDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "bundleId",
+    "runContractDigest",
+    "executionBundleDigest",
+    "evaluationPlanDigest",
+    "evaluationInputDigest",
+    "replayability",
+    "records",
+    "provenance",
+    "bundleDigest"
+  ],
+  "title": "OMK Evaluation Bundle v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/evaluation-definition.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-definition.schema.json
@@ -1,0 +1,657 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.evaluation-definition/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "datasetId": {
+          "$ref": "#/$defs/__schema2"
+        },
+        "samples": {
+          "items": {
+            "$ref": "#/$defs/__schema3"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "datasetId",
+        "samples"
+      ],
+      "type": "object"
+    },
+    "__schema10": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "direction": {
+            "enum": [
+              "higher-is-better",
+              "lower-is-better",
+              "target-is-best"
+            ],
+            "type": "string"
+          },
+          "metricId": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "missingPolicyId": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "scale": {
+            "additionalProperties": false,
+            "properties": {
+              "max": {
+                "type": "number"
+              },
+              "min": {
+                "type": "number"
+              },
+              "target": {
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "scope": {
+            "enum": [
+              "sample",
+              "target",
+              "comparison",
+              "run"
+            ],
+            "type": "string"
+          },
+          "unit": {
+            "$ref": "#/$defs/__schema7"
+          },
+          "valueType": {
+            "enum": [
+              "numeric",
+              "boolean",
+              "categorical",
+              "text",
+              "ranking"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "metricId",
+          "valueType",
+          "scope",
+          "missingPolicyId"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "__schema11": {
+      "additionalProperties": false,
+      "properties": {
+        "sampling": {
+          "additionalProperties": false,
+          "properties": {
+            "clusterKey": {
+              "$ref": "#/$defs/__schema9"
+            },
+            "estimatorId": {
+              "$ref": "#/$defs/__schema2"
+            },
+            "experimentalUnit": {
+              "enum": [
+                "sample",
+                "run",
+                "cluster"
+              ],
+              "type": "string"
+            },
+            "pairingKey": {
+              "$ref": "#/$defs/__schema9"
+            },
+            "repeatedMeasures": {
+              "type": "boolean"
+            },
+            "resamplingUnit": {
+              "enum": [
+                "sample",
+                "paired-block",
+                "cluster",
+                "run"
+              ],
+              "type": "string"
+            },
+            "stratumKey": {
+              "$ref": "#/$defs/__schema9"
+            }
+          },
+          "required": [
+            "experimentalUnit",
+            "repeatedMeasures",
+            "resamplingUnit",
+            "estimatorId"
+          ],
+          "type": "object"
+        },
+        "scheduling": {
+          "additionalProperties": false,
+          "properties": {
+            "blockSize": {
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer"
+            },
+            "schedulingKind": {
+              "enum": [
+                "sequential",
+                "interleaved",
+                "randomized-block"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "schedulingKind"
+          ],
+          "type": "object"
+        },
+        "seed": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "trials": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "trials",
+        "seed",
+        "sampling",
+        "scheduling"
+      ],
+      "type": "object"
+    },
+    "__schema12": {
+      "additionalProperties": false,
+      "properties": {
+        "nodes": {
+          "items": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "analysisNodeKind": {
+                    "const": "reducer",
+                    "type": "string"
+                  },
+                  "implementationId": {
+                    "$ref": "#/$defs/__schema2"
+                  },
+                  "inputs": {
+                    "$ref": "#/$defs/__schema13"
+                  },
+                  "nodeId": {
+                    "$ref": "#/$defs/__schema2"
+                  },
+                  "outputResultId": {
+                    "$ref": "#/$defs/__schema2"
+                  },
+                  "parameters": {
+                    "$ref": "#/$defs/__schema15"
+                  }
+                },
+                "required": [
+                  "nodeId",
+                  "implementationId",
+                  "inputs",
+                  "outputResultId",
+                  "analysisNodeKind"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "analysisNodeKind": {
+                    "const": "estimator",
+                    "type": "string"
+                  },
+                  "implementationId": {
+                    "$ref": "#/$defs/__schema2"
+                  },
+                  "inputs": {
+                    "$ref": "#/$defs/__schema13"
+                  },
+                  "nodeId": {
+                    "$ref": "#/$defs/__schema2"
+                  },
+                  "outputResultId": {
+                    "$ref": "#/$defs/__schema2"
+                  },
+                  "parameters": {
+                    "$ref": "#/$defs/__schema15"
+                  }
+                },
+                "required": [
+                  "nodeId",
+                  "implementationId",
+                  "inputs",
+                  "outputResultId",
+                  "analysisNodeKind"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "analysisNodeKind": {
+                    "const": "correction",
+                    "type": "string"
+                  },
+                  "implementationId": {
+                    "$ref": "#/$defs/__schema2"
+                  },
+                  "inputs": {
+                    "$ref": "#/$defs/__schema13"
+                  },
+                  "nodeId": {
+                    "$ref": "#/$defs/__schema2"
+                  },
+                  "outputResultId": {
+                    "$ref": "#/$defs/__schema2"
+                  },
+                  "parameters": {
+                    "$ref": "#/$defs/__schema15"
+                  }
+                },
+                "required": [
+                  "nodeId",
+                  "implementationId",
+                  "inputs",
+                  "outputResultId",
+                  "analysisNodeKind"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "nodes"
+      ],
+      "type": "object"
+    },
+    "__schema13": {
+      "items": {
+        "$ref": "#/$defs/__schema14"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema14": {
+      "additionalProperties": false,
+      "properties": {
+        "inputKind": {
+          "enum": [
+            "metric-observations",
+            "analysis-result"
+          ],
+          "type": "string"
+        },
+        "referenceId": {
+          "$ref": "#/$defs/__schema2"
+        }
+      },
+      "required": [
+        "inputKind",
+        "referenceId"
+      ],
+      "type": "object"
+    },
+    "__schema15": {
+      "$ref": "#/$defs/__schema4"
+    },
+    "__schema16": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "comparisonId": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "controlTargetId": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "metricIds": {
+            "items": {
+              "$ref": "#/$defs/__schema2"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "treatmentTargetIds": {
+            "items": {
+              "$ref": "#/$defs/__schema2"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "comparisonId",
+          "controlTargetId",
+          "treatmentTargetIds",
+          "metricIds"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "__schema17": {
+      "additionalProperties": false,
+      "properties": {
+        "analysisResultIds": {
+          "items": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "decisionPolicyId": {
+          "$ref": "#/$defs/__schema2"
+        },
+        "implementationId": {
+          "$ref": "#/$defs/__schema2"
+        },
+        "minimumEvidenceStatus": {
+          "enum": [
+            "complete",
+            "partial",
+            "unresolvable"
+          ],
+          "type": "string"
+        },
+        "multipleComparisonPolicyId": {
+          "$ref": "#/$defs/__schema2"
+        },
+        "parameters": {
+          "$ref": "#/$defs/__schema4"
+        }
+      },
+      "required": [
+        "decisionPolicyId",
+        "implementationId",
+        "analysisResultIds",
+        "minimumEvidenceStatus"
+      ],
+      "type": "object"
+    },
+    "__schema18": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "schemaDigest": {
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema19"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema19"
+      },
+      "type": "object"
+    },
+    "__schema19": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    },
+    "__schema2": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema3": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "evaluationContext": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "executionContext": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "expected": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "input": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "sampleId": {
+          "$ref": "#/$defs/__schema2"
+        }
+      },
+      "required": [
+        "sampleId",
+        "input"
+      ],
+      "type": "object"
+    },
+    "__schema4": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema5": {
+      "items": {
+        "$ref": "#/$defs/__schema6"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema6": {
+      "additionalProperties": false,
+      "properties": {
+        "config": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "executorId": {
+          "$ref": "#/$defs/__schema2"
+        },
+        "protocolId": {
+          "enum": [
+            "omk.invoke/v1",
+            "omk.session/v1"
+          ],
+          "type": "string"
+        },
+        "targetId": {
+          "$ref": "#/$defs/__schema2"
+        },
+        "targetKind": {
+          "$ref": "#/$defs/__schema2"
+        },
+        "versionConstraint": {
+          "$ref": "#/$defs/__schema7"
+        }
+      },
+      "required": [
+        "targetId",
+        "targetKind",
+        "protocolId",
+        "executorId"
+      ],
+      "type": "object"
+    },
+    "__schema7": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema8": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "evaluatorId": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "evaluatorKind": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "implementationId": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "inputs": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "bindingId": {
+                  "$ref": "#/$defs/__schema2"
+                },
+                "pointer": {
+                  "$ref": "#/$defs/__schema9"
+                },
+                "sourceKind": {
+                  "enum": [
+                    "output",
+                    "trace",
+                    "expected",
+                    "evaluation-context"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bindingId",
+                "sourceKind",
+                "pointer"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "metricIds": {
+            "items": {
+              "$ref": "#/$defs/__schema2"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "versionConstraint": {
+            "$ref": "#/$defs/__schema7"
+          }
+        },
+        "required": [
+          "evaluatorId",
+          "evaluatorKind",
+          "implementationId",
+          "metricIds",
+          "inputs"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "__schema9": {
+      "pattern": "^(?:\\/(?:[^~/]|~[01])*)*$",
+      "type": "string"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/evaluation-definition.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "analysisGraph": {
+      "$ref": "#/$defs/__schema12"
+    },
+    "comparisons": {
+      "$ref": "#/$defs/__schema16"
+    },
+    "dataset": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "decisionPolicy": {
+      "$ref": "#/$defs/__schema17"
+    },
+    "evaluators": {
+      "$ref": "#/$defs/__schema8"
+    },
+    "experiment": {
+      "$ref": "#/$defs/__schema11"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema18"
+    },
+    "metrics": {
+      "$ref": "#/$defs/__schema10"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    },
+    "targets": {
+      "$ref": "#/$defs/__schema5"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "dataset",
+    "targets",
+    "evaluators",
+    "metrics",
+    "experiment",
+    "analysisGraph",
+    "comparisons"
+  ],
+  "title": "OMK Evaluation Definition v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/evaluation-event.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-event.schema.json
@@ -1,0 +1,144 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.evaluation-event/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema2": {
+      "maximum": 9007199254740991,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "__schema3": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+      "type": "string"
+    },
+    "__schema4": {
+      "additionalProperties": false,
+      "properties": {
+        "subjectId": {
+          "$ref": "#/$defs/__schema1"
+        },
+        "subjectKind": {
+          "$ref": "#/$defs/__schema1"
+        }
+      },
+      "required": [
+        "subjectKind",
+        "subjectId"
+      ],
+      "type": "object"
+    },
+    "__schema5": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema6": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "schemaDigest": {
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema7"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema7"
+      },
+      "type": "object"
+    },
+    "__schema7": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/evaluation-event.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "data": {
+      "$ref": "#/$defs/__schema5"
+    },
+    "eventId": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "eventKind": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema6"
+    },
+    "runId": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    },
+    "sequence": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "subject": {
+      "$ref": "#/$defs/__schema4"
+    },
+    "time": {
+      "$ref": "#/$defs/__schema3"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "eventId",
+    "sequence",
+    "runId",
+    "eventKind",
+    "time",
+    "subject",
+    "data"
+  ],
+  "title": "OMK Evaluation Event v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/evaluation-plan.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-plan.schema.json
@@ -1,0 +1,453 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.evaluation-plan/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema10": {
+      "additionalProperties": false,
+      "properties": {
+        "evaluationCacheMode": {
+          "enum": [
+            "disabled",
+            "reuse"
+          ],
+          "type": "string"
+        },
+        "evidence": {
+          "additionalProperties": false,
+          "properties": {
+            "evidence": {
+              "$ref": "#/$defs/__schema11"
+            },
+            "expected": {
+              "$ref": "#/$defs/__schema11"
+            },
+            "input": {
+              "$ref": "#/$defs/__schema11"
+            },
+            "maximumClassification": {
+              "enum": [
+                "public",
+                "sensitive",
+                "secret",
+                "gold"
+              ],
+              "type": "string"
+            },
+            "output": {
+              "$ref": "#/$defs/__schema11"
+            },
+            "trace": {
+              "$ref": "#/$defs/__schema11"
+            }
+          },
+          "required": [
+            "input",
+            "output",
+            "trace",
+            "expected",
+            "evidence",
+            "maximumClassification"
+          ],
+          "type": "object"
+        },
+        "failure": {
+          "additionalProperties": false,
+          "properties": {
+            "failureMode": {
+              "enum": [
+                "continue",
+                "fail-fast",
+                "failure-threshold"
+              ],
+              "type": "string"
+            },
+            "maxFailures": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "failureMode"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "evaluationCacheMode",
+        "evidence",
+        "failure"
+      ],
+      "type": "object"
+    },
+    "__schema11": {
+      "enum": [
+        "full",
+        "reference",
+        "digest",
+        "none"
+      ],
+      "type": "string"
+    },
+    "__schema12": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "schemaDigest": {
+            "$ref": "#/$defs/__schema1"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema13"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema13"
+      },
+      "type": "object"
+    },
+    "__schema13": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    },
+    "__schema2": {
+      "items": {
+        "$ref": "#/$defs/__schema3"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema3": {
+      "additionalProperties": false,
+      "properties": {
+        "evaluationContext": {
+          "$ref": "#/$defs/__schema5"
+        },
+        "executionContext": {
+          "$ref": "#/$defs/__schema5"
+        },
+        "expected": {
+          "$ref": "#/$defs/__schema5"
+        },
+        "input": {
+          "$ref": "#/$defs/__schema5"
+        },
+        "sampleId": {
+          "$ref": "#/$defs/__schema4"
+        }
+      },
+      "required": [
+        "sampleId",
+        "input"
+      ],
+      "type": "object"
+    },
+    "__schema4": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema5": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema6": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "evaluatorId": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "evaluatorKind": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "implementationId": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "inputs": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "bindingId": {
+                  "$ref": "#/$defs/__schema4"
+                },
+                "pointer": {
+                  "pattern": "^(?:\\/(?:[^~/]|~[01])*)*$",
+                  "type": "string"
+                },
+                "sourceKind": {
+                  "enum": [
+                    "output",
+                    "trace",
+                    "expected",
+                    "evaluation-context"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bindingId",
+                "sourceKind",
+                "pointer"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "metricIds": {
+            "items": {
+              "$ref": "#/$defs/__schema4"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "versionConstraint": {
+            "$ref": "#/$defs/__schema7"
+          }
+        },
+        "required": [
+          "evaluatorId",
+          "evaluatorKind",
+          "implementationId",
+          "metricIds",
+          "inputs"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "__schema7": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema8": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "direction": {
+            "enum": [
+              "higher-is-better",
+              "lower-is-better",
+              "target-is-best"
+            ],
+            "type": "string"
+          },
+          "metricId": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "missingPolicyId": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "scale": {
+            "additionalProperties": false,
+            "properties": {
+              "max": {
+                "type": "number"
+              },
+              "min": {
+                "type": "number"
+              },
+              "target": {
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "scope": {
+            "enum": [
+              "sample",
+              "target",
+              "comparison",
+              "run"
+            ],
+            "type": "string"
+          },
+          "unit": {
+            "$ref": "#/$defs/__schema7"
+          },
+          "valueType": {
+            "enum": [
+              "numeric",
+              "boolean",
+              "categorical",
+              "text",
+              "ranking"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "metricId",
+          "valueType",
+          "scope",
+          "missingPolicyId"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "__schema9": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "identity": {
+            "additionalProperties": false,
+            "properties": {
+              "assuranceLevel": {
+                "enum": [
+                  "verified",
+                  "declared",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "capabilities": {
+                "$ref": "#/$defs/__schema5"
+              },
+              "fingerprint": {
+                "$ref": "#/$defs/__schema7"
+              },
+              "fingerprintBasis": {
+                "enum": [
+                  "content-derived",
+                  "environment-derived",
+                  "self-reported",
+                  "opaque"
+                ],
+                "type": "string"
+              },
+              "implementationId": {
+                "$ref": "#/$defs/__schema4"
+              },
+              "provenanceFacets": {
+                "$ref": "#/$defs/__schema5"
+              },
+              "version": {
+                "$ref": "#/$defs/__schema7"
+              }
+            },
+            "required": [
+              "implementationId",
+              "fingerprint",
+              "fingerprintBasis",
+              "assuranceLevel",
+              "capabilities"
+            ],
+            "type": "object"
+          },
+          "referenceId": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "runtimeKind": {
+            "enum": [
+              "executor",
+              "evaluator",
+              "analysis"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "runtimeKind",
+          "referenceId",
+          "identity"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/evaluation-plan.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "evaluationInputDigest": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "evaluationPlanDigest": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "evaluators": {
+      "$ref": "#/$defs/__schema6"
+    },
+    "executionPlanDigest": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema12"
+    },
+    "metrics": {
+      "$ref": "#/$defs/__schema8"
+    },
+    "policy": {
+      "$ref": "#/$defs/__schema10"
+    },
+    "runtimes": {
+      "$ref": "#/$defs/__schema9"
+    },
+    "samples": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "executionPlanDigest",
+    "evaluationInputDigest",
+    "samples",
+    "evaluators",
+    "metrics",
+    "runtimes",
+    "policy",
+    "evaluationPlanDigest"
+  ],
+  "title": "OMK Evaluation Plan v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/evaluation-report.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-report.schema.json
@@ -1,0 +1,299 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.evaluation-report/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema10": {
+      "$ref": "#/$defs/__schema9"
+    },
+    "__schema11": {
+      "additionalProperties": false,
+      "properties": {
+        "facets": {
+          "$ref": "#/$defs/__schema9"
+        },
+        "parentDigests": {
+          "items": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "type": "array"
+        },
+        "provenanceKind": {
+          "enum": [
+            "native",
+            "imported",
+            "replay",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "sourceId": {
+          "$ref": "#/$defs/__schema5"
+        },
+        "trust": {
+          "enum": [
+            "verified",
+            "declared",
+            "untrusted",
+            "unknown"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "provenanceKind",
+        "trust",
+        "parentDigests"
+      ],
+      "type": "object"
+    },
+    "__schema12": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema9"
+          },
+          "schemaDigest": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema6"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema6"
+      },
+      "type": "object"
+    },
+    "__schema2": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema3": {
+      "additionalProperties": false,
+      "properties": {
+        "conclusionStatus": {
+          "enum": [
+            "conclusive",
+            "inconclusive",
+            "not-evaluated"
+          ],
+          "type": "string"
+        },
+        "evidenceStatus": {
+          "enum": [
+            "complete",
+            "partial",
+            "unresolvable"
+          ],
+          "type": "string"
+        },
+        "runStatus": {
+          "enum": [
+            "completed",
+            "cancelled",
+            "budget-exhausted",
+            "failed"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "runStatus",
+        "evidenceStatus",
+        "conclusionStatus"
+      ],
+      "type": "object"
+    },
+    "__schema4": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "bundleDigest": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "bundleKind": {
+            "enum": [
+              "execution",
+              "evaluation",
+              "analysis"
+            ],
+            "type": "string"
+          },
+          "schemaVersion": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "uri": {
+            "$ref": "#/$defs/__schema6"
+          }
+        },
+        "required": [
+          "bundleKind",
+          "schemaVersion",
+          "bundleDigest"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "__schema5": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema6": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    },
+    "__schema7": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "analysisResultIds": {
+              "items": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "decisionStatus": {
+              "const": "decided",
+              "type": "string"
+            },
+            "policyDigest": {
+              "$ref": "#/$defs/__schema2"
+            },
+            "verdict": {
+              "$ref": "#/$defs/__schema1"
+            }
+          },
+          "required": [
+            "decisionStatus",
+            "verdict",
+            "policyDigest",
+            "analysisResultIds"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "decisionStatus": {
+              "const": "not-decided",
+              "type": "string"
+            },
+            "reasonCodes": {
+              "items": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "required": [
+            "decisionStatus",
+            "reasonCodes"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "__schema8": {
+      "$ref": "#/$defs/__schema9"
+    },
+    "__schema9": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema9"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema9"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/evaluation-report.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "annotations": {
+      "$ref": "#/$defs/__schema10"
+    },
+    "bundles": {
+      "$ref": "#/$defs/__schema4"
+    },
+    "decision": {
+      "$ref": "#/$defs/__schema7"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema12"
+    },
+    "provenance": {
+      "$ref": "#/$defs/__schema11"
+    },
+    "reportDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "reportId": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "runContractDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    },
+    "status": {
+      "$ref": "#/$defs/__schema3"
+    },
+    "summaries": {
+      "$ref": "#/$defs/__schema8"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "reportId",
+    "runContractDigest",
+    "status",
+    "bundles",
+    "provenance",
+    "reportDigest"
+  ],
+  "title": "OMK Evaluation Report v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/execution-bundle.schema.json
+++ b/schemas/evaluation-core/v1/execution-bundle.schema.json
@@ -1,0 +1,726 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.execution-bundle/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema10": {
+      "additionalProperties": false,
+      "properties": {
+        "completedAt": {
+          "$ref": "#/$defs/__schema11"
+        },
+        "durationMs": {
+          "minimum": 0,
+          "type": "number"
+        },
+        "startedAt": {
+          "$ref": "#/$defs/__schema11"
+        }
+      },
+      "required": [
+        "startedAt"
+      ],
+      "type": "object"
+    },
+    "__schema11": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+      "type": "string"
+    },
+    "__schema12": {
+      "additionalProperties": false,
+      "properties": {
+        "causes": {
+          "items": {
+            "$ref": "#/$defs/__schema12"
+          },
+          "type": "array"
+        },
+        "code": {
+          "$ref": "#/$defs/__schema1"
+        },
+        "details": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "message": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "stage": {
+          "enum": [
+            "configuration",
+            "infrastructure",
+            "execution",
+            "evaluation",
+            "analysis",
+            "internal"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "stage",
+        "message"
+      ],
+      "type": "object"
+    },
+    "__schema13": {
+      "additionalProperties": false,
+      "properties": {
+        "details": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "inputTokens": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "outputTokens": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "providerCost": {
+          "additionalProperties": false,
+          "properties": {
+            "amount": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "currency": {
+              "pattern": "^[A-Z]{3}$",
+              "type": "string"
+            },
+            "reportedByProvider": {
+              "const": true,
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "amount",
+            "currency",
+            "reportedByProvider"
+          ],
+          "type": "object"
+        },
+        "totalTokens": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "__schema14": {
+      "$ref": "#/$defs/__schema15"
+    },
+    "__schema15": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "classification": {
+              "$ref": "#/$defs/__schema16"
+            },
+            "contentKind": {
+              "const": "inline",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/__schema7"
+            }
+          },
+          "required": [
+            "contentKind",
+            "classification",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "classification": {
+              "$ref": "#/$defs/__schema16"
+            },
+            "contentKind": {
+              "const": "descriptor",
+              "type": "string"
+            },
+            "descriptor": {
+              "additionalProperties": false,
+              "properties": {
+                "digest": {
+                  "$ref": "#/$defs/__schema2"
+                },
+                "mediaType": {
+                  "$ref": "#/$defs/__schema6"
+                },
+                "size": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "uri": {
+                  "$ref": "#/$defs/__schema17"
+                }
+              },
+              "required": [
+                "mediaType",
+                "digest"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "contentKind",
+            "classification",
+            "descriptor"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "classification": {
+              "$ref": "#/$defs/__schema16"
+            },
+            "contentKind": {
+              "const": "digest-only",
+              "type": "string"
+            },
+            "digest": {
+              "$ref": "#/$defs/__schema2"
+            }
+          },
+          "required": [
+            "contentKind",
+            "classification",
+            "digest"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "__schema16": {
+      "enum": [
+        "public",
+        "sensitive",
+        "secret",
+        "gold"
+      ],
+      "type": "string"
+    },
+    "__schema17": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    },
+    "__schema18": {
+      "additionalProperties": false,
+      "properties": {
+        "facets": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "parentDigests": {
+          "items": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "type": "array"
+        },
+        "provenanceKind": {
+          "enum": [
+            "native",
+            "imported",
+            "replay",
+            "derived"
+          ],
+          "type": "string"
+        },
+        "sourceId": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "trust": {
+          "enum": [
+            "verified",
+            "declared",
+            "untrusted",
+            "unknown"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "provenanceKind",
+        "trust",
+        "parentDigests"
+      ],
+      "type": "object"
+    },
+    "__schema19": {
+      "additionalProperties": false,
+      "properties": {
+        "cacheKeyDigest": {
+          "$ref": "#/$defs/__schema2"
+        },
+        "cacheStatus": {
+          "enum": [
+            "not-used",
+            "miss",
+            "replay",
+            "transparent-hit"
+          ],
+          "type": "string"
+        },
+        "sourceRecordDigest": {
+          "$ref": "#/$defs/__schema2"
+        }
+      },
+      "required": [
+        "cacheStatus"
+      ],
+      "type": "object"
+    },
+    "__schema2": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema20": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema7"
+          },
+          "schemaDigest": {
+            "$ref": "#/$defs/__schema2"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema17"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema17"
+      },
+      "type": "object"
+    },
+    "__schema3": {
+      "enum": [
+        "self-contained",
+        "resolvable",
+        "summary-only"
+      ],
+      "type": "string"
+    },
+    "__schema4": {
+      "items": {
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "attempts": {
+                "$ref": "#/$defs/__schema8"
+              },
+              "cache": {
+                "$ref": "#/$defs/__schema19"
+              },
+              "executionStatus": {
+                "const": "completed",
+                "type": "string"
+              },
+              "output": {
+                "$ref": "#/$defs/__schema15"
+              },
+              "provenance": {
+                "$ref": "#/$defs/__schema18"
+              },
+              "runtime": {
+                "$ref": "#/$defs/__schema5"
+              },
+              "sampleId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "targetId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "timing": {
+                "$ref": "#/$defs/__schema10"
+              },
+              "trace": {
+                "$ref": "#/$defs/__schema14"
+              },
+              "trialId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "usage": {
+                "$ref": "#/$defs/__schema13"
+              }
+            },
+            "required": [
+              "targetId",
+              "sampleId",
+              "trialId",
+              "runtime",
+              "attempts",
+              "timing",
+              "provenance",
+              "cache",
+              "executionStatus",
+              "output"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "attempts": {
+                "$ref": "#/$defs/__schema8"
+              },
+              "cache": {
+                "$ref": "#/$defs/__schema19"
+              },
+              "error": {
+                "$ref": "#/$defs/__schema12"
+              },
+              "executionStatus": {
+                "const": "failed",
+                "type": "string"
+              },
+              "provenance": {
+                "$ref": "#/$defs/__schema18"
+              },
+              "runtime": {
+                "$ref": "#/$defs/__schema5"
+              },
+              "sampleId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "targetId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "timing": {
+                "$ref": "#/$defs/__schema10"
+              },
+              "trace": {
+                "$ref": "#/$defs/__schema14"
+              },
+              "trialId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "usage": {
+                "$ref": "#/$defs/__schema13"
+              }
+            },
+            "required": [
+              "targetId",
+              "sampleId",
+              "trialId",
+              "runtime",
+              "attempts",
+              "timing",
+              "provenance",
+              "cache",
+              "executionStatus",
+              "error"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "attempts": {
+                "$ref": "#/$defs/__schema8"
+              },
+              "cache": {
+                "$ref": "#/$defs/__schema19"
+              },
+              "error": {
+                "$ref": "#/$defs/__schema12"
+              },
+              "executionStatus": {
+                "const": "cancelled",
+                "type": "string"
+              },
+              "provenance": {
+                "$ref": "#/$defs/__schema18"
+              },
+              "runtime": {
+                "$ref": "#/$defs/__schema5"
+              },
+              "sampleId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "targetId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "timing": {
+                "$ref": "#/$defs/__schema10"
+              },
+              "trace": {
+                "$ref": "#/$defs/__schema14"
+              },
+              "trialId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "usage": {
+                "$ref": "#/$defs/__schema13"
+              }
+            },
+            "required": [
+              "targetId",
+              "sampleId",
+              "trialId",
+              "runtime",
+              "attempts",
+              "timing",
+              "provenance",
+              "cache",
+              "executionStatus"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "attempts": {
+                "$ref": "#/$defs/__schema8"
+              },
+              "cache": {
+                "$ref": "#/$defs/__schema19"
+              },
+              "censorReason": {
+                "$ref": "#/$defs/__schema6"
+              },
+              "executionStatus": {
+                "const": "budget-censored",
+                "type": "string"
+              },
+              "provenance": {
+                "$ref": "#/$defs/__schema18"
+              },
+              "runtime": {
+                "$ref": "#/$defs/__schema5"
+              },
+              "sampleId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "targetId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "timing": {
+                "$ref": "#/$defs/__schema10"
+              },
+              "trace": {
+                "$ref": "#/$defs/__schema14"
+              },
+              "trialId": {
+                "$ref": "#/$defs/__schema1"
+              },
+              "usage": {
+                "$ref": "#/$defs/__schema13"
+              }
+            },
+            "required": [
+              "targetId",
+              "sampleId",
+              "trialId",
+              "runtime",
+              "attempts",
+              "timing",
+              "provenance",
+              "cache",
+              "executionStatus",
+              "censorReason"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "__schema5": {
+      "additionalProperties": false,
+      "properties": {
+        "assuranceLevel": {
+          "enum": [
+            "verified",
+            "declared",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "fingerprint": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "fingerprintBasis": {
+          "enum": [
+            "content-derived",
+            "environment-derived",
+            "self-reported",
+            "opaque"
+          ],
+          "type": "string"
+        },
+        "implementationId": {
+          "$ref": "#/$defs/__schema1"
+        },
+        "provenanceFacets": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "version": {
+          "$ref": "#/$defs/__schema6"
+        }
+      },
+      "required": [
+        "implementationId",
+        "fingerprint",
+        "fingerprintBasis",
+        "assuranceLevel",
+        "capabilities"
+      ],
+      "type": "object"
+    },
+    "__schema6": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema7": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema7"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema7"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema8": {
+      "items": {
+        "$ref": "#/$defs/__schema9"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema9": {
+      "additionalProperties": false,
+      "properties": {
+        "attemptId": {
+          "$ref": "#/$defs/__schema1"
+        },
+        "attemptNumber": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        },
+        "attemptStatus": {
+          "enum": [
+            "completed",
+            "failed",
+            "cancelled"
+          ],
+          "type": "string"
+        },
+        "error": {
+          "$ref": "#/$defs/__schema12"
+        },
+        "timing": {
+          "$ref": "#/$defs/__schema10"
+        }
+      },
+      "required": [
+        "attemptId",
+        "attemptNumber",
+        "attemptStatus",
+        "timing"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/execution-bundle.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "bundleDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "bundleId": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "datasetRevisionDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "executionInputDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "executionPlanDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema20"
+    },
+    "provenance": {
+      "$ref": "#/$defs/__schema18"
+    },
+    "records": {
+      "$ref": "#/$defs/__schema4"
+    },
+    "replayability": {
+      "$ref": "#/$defs/__schema3"
+    },
+    "runContractDigest": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "bundleId",
+    "runContractDigest",
+    "executionPlanDigest",
+    "datasetRevisionDigest",
+    "executionInputDigest",
+    "replayability",
+    "records",
+    "provenance",
+    "bundleDigest"
+  ],
+  "title": "OMK Execution Bundle v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/execution-plan.schema.json
+++ b/schemas/evaluation-core/v1/execution-plan.schema.json
@@ -1,0 +1,499 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.execution-plan/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema10": {
+      "pattern": "^(?:\\/(?:[^~/]|~[01])*)*$",
+      "type": "string"
+    },
+    "__schema11": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "identity": {
+            "additionalProperties": false,
+            "properties": {
+              "assuranceLevel": {
+                "enum": [
+                  "verified",
+                  "declared",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "capabilities": {
+                "$ref": "#/$defs/__schema5"
+              },
+              "fingerprint": {
+                "$ref": "#/$defs/__schema8"
+              },
+              "fingerprintBasis": {
+                "enum": [
+                  "content-derived",
+                  "environment-derived",
+                  "self-reported",
+                  "opaque"
+                ],
+                "type": "string"
+              },
+              "implementationId": {
+                "$ref": "#/$defs/__schema4"
+              },
+              "provenanceFacets": {
+                "$ref": "#/$defs/__schema5"
+              },
+              "version": {
+                "$ref": "#/$defs/__schema8"
+              }
+            },
+            "required": [
+              "implementationId",
+              "fingerprint",
+              "fingerprintBasis",
+              "assuranceLevel",
+              "capabilities"
+            ],
+            "type": "object"
+          },
+          "referenceId": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "runtimeKind": {
+            "enum": [
+              "executor",
+              "evaluator",
+              "analysis"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "runtimeKind",
+          "referenceId",
+          "identity"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "__schema12": {
+      "additionalProperties": false,
+      "properties": {
+        "budget": {
+          "additionalProperties": false,
+          "properties": {
+            "maxDurationMs": {
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer"
+            },
+            "maxProviderCost": {
+              "additionalProperties": false,
+              "properties": {
+                "amount": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "currency": {
+                  "pattern": "^[A-Z]{3}$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "amount",
+                "currency"
+              ],
+              "type": "object"
+            },
+            "maxTargetInvocations": {
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "execution": {
+          "additionalProperties": false,
+          "properties": {
+            "maxConcurrency": {
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer"
+            },
+            "timeoutMs": {
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "maxConcurrency"
+          ],
+          "type": "object"
+        },
+        "executionCacheMode": {
+          "enum": [
+            "disabled",
+            "replay-only",
+            "transparent-deterministic"
+          ],
+          "type": "string"
+        },
+        "failure": {
+          "additionalProperties": false,
+          "properties": {
+            "failureMode": {
+              "enum": [
+                "continue",
+                "fail-fast",
+                "failure-threshold"
+              ],
+              "type": "string"
+            },
+            "maxFailures": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "failureMode"
+          ],
+          "type": "object"
+        },
+        "retry": {
+          "additionalProperties": false,
+          "properties": {
+            "backoff": {
+              "additionalProperties": false,
+              "properties": {
+                "backoffKind": {
+                  "enum": [
+                    "none",
+                    "fixed",
+                    "exponential"
+                  ],
+                  "type": "string"
+                },
+                "initialDelayMs": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "maxDelayMs": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "backoffKind",
+                "initialDelayMs"
+              ],
+              "type": "object"
+            },
+            "maxAttempts": {
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer"
+            },
+            "retryableErrorCodes": {
+              "items": {
+                "$ref": "#/$defs/__schema4"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "maxAttempts",
+            "retryableErrorCodes",
+            "backoff"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "execution",
+        "retry",
+        "budget",
+        "executionCacheMode",
+        "failure"
+      ],
+      "type": "object"
+    },
+    "__schema13": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "schemaDigest": {
+            "$ref": "#/$defs/__schema1"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema14"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema14"
+      },
+      "type": "object"
+    },
+    "__schema14": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    },
+    "__schema2": {
+      "items": {
+        "$ref": "#/$defs/__schema3"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema3": {
+      "additionalProperties": false,
+      "properties": {
+        "executionContext": {
+          "$ref": "#/$defs/__schema5"
+        },
+        "input": {
+          "$ref": "#/$defs/__schema5"
+        },
+        "sampleId": {
+          "$ref": "#/$defs/__schema4"
+        }
+      },
+      "required": [
+        "sampleId",
+        "input"
+      ],
+      "type": "object"
+    },
+    "__schema4": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema5": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema6": {
+      "items": {
+        "$ref": "#/$defs/__schema7"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema7": {
+      "additionalProperties": false,
+      "properties": {
+        "config": {
+          "$ref": "#/$defs/__schema5"
+        },
+        "executorId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "protocolId": {
+          "enum": [
+            "omk.invoke/v1",
+            "omk.session/v1"
+          ],
+          "type": "string"
+        },
+        "targetId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "targetKind": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "versionConstraint": {
+          "$ref": "#/$defs/__schema8"
+        }
+      },
+      "required": [
+        "targetId",
+        "targetKind",
+        "protocolId",
+        "executorId"
+      ],
+      "type": "object"
+    },
+    "__schema8": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema9": {
+      "additionalProperties": false,
+      "properties": {
+        "sampling": {
+          "additionalProperties": false,
+          "properties": {
+            "clusterKey": {
+              "$ref": "#/$defs/__schema10"
+            },
+            "estimatorId": {
+              "$ref": "#/$defs/__schema4"
+            },
+            "experimentalUnit": {
+              "enum": [
+                "sample",
+                "run",
+                "cluster"
+              ],
+              "type": "string"
+            },
+            "pairingKey": {
+              "$ref": "#/$defs/__schema10"
+            },
+            "repeatedMeasures": {
+              "type": "boolean"
+            },
+            "resamplingUnit": {
+              "enum": [
+                "sample",
+                "paired-block",
+                "cluster",
+                "run"
+              ],
+              "type": "string"
+            },
+            "stratumKey": {
+              "$ref": "#/$defs/__schema10"
+            }
+          },
+          "required": [
+            "experimentalUnit",
+            "repeatedMeasures",
+            "resamplingUnit",
+            "estimatorId"
+          ],
+          "type": "object"
+        },
+        "scheduling": {
+          "additionalProperties": false,
+          "properties": {
+            "blockSize": {
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer"
+            },
+            "schedulingKind": {
+              "enum": [
+                "sequential",
+                "interleaved",
+                "randomized-block"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "schedulingKind"
+          ],
+          "type": "object"
+        },
+        "seed": {
+          "$ref": "#/$defs/__schema8"
+        },
+        "trials": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "trials",
+        "seed",
+        "sampling",
+        "scheduling"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/execution-plan.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "executionInputDigest": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "executionPlanDigest": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "experiment": {
+      "$ref": "#/$defs/__schema9"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema13"
+    },
+    "policy": {
+      "$ref": "#/$defs/__schema12"
+    },
+    "runtimes": {
+      "$ref": "#/$defs/__schema11"
+    },
+    "samples": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    },
+    "targets": {
+      "$ref": "#/$defs/__schema6"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "executionInputDigest",
+    "samples",
+    "targets",
+    "experiment",
+    "runtimes",
+    "policy",
+    "executionPlanDigest"
+  ],
+  "title": "OMK Execution Plan v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/measurement-policy.schema.json
+++ b/schemas/evaluation-core/v1/measurement-policy.schema.json
@@ -1,0 +1,345 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.measurement-policy/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "additionalProperties": false,
+      "properties": {
+        "maxConcurrency": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        },
+        "timeoutMs": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "maxConcurrency"
+      ],
+      "type": "object"
+    },
+    "__schema10": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    },
+    "__schema11": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema11"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema11"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema2": {
+      "additionalProperties": false,
+      "properties": {
+        "backoff": {
+          "additionalProperties": false,
+          "properties": {
+            "backoffKind": {
+              "enum": [
+                "none",
+                "fixed",
+                "exponential"
+              ],
+              "type": "string"
+            },
+            "initialDelayMs": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxDelayMs": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "backoffKind",
+            "initialDelayMs"
+          ],
+          "type": "object"
+        },
+        "maxAttempts": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        },
+        "retryableErrorCodes": {
+          "items": {
+            "maxLength": 256,
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "maxAttempts",
+        "retryableErrorCodes",
+        "backoff"
+      ],
+      "type": "object"
+    },
+    "__schema3": {
+      "additionalProperties": false,
+      "properties": {
+        "maxDurationMs": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        },
+        "maxProviderCost": {
+          "additionalProperties": false,
+          "properties": {
+            "amount": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "currency": {
+              "pattern": "^[A-Z]{3}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "amount",
+            "currency"
+          ],
+          "type": "object"
+        },
+        "maxTargetInvocations": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "__schema4": {
+      "additionalProperties": false,
+      "properties": {
+        "evaluationMode": {
+          "enum": [
+            "disabled",
+            "reuse"
+          ],
+          "type": "string"
+        },
+        "executionMode": {
+          "enum": [
+            "disabled",
+            "replay-only",
+            "transparent-deterministic"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "executionMode",
+        "evaluationMode"
+      ],
+      "type": "object"
+    },
+    "__schema5": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "expected": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "input": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "maximumClassification": {
+          "enum": [
+            "public",
+            "sensitive",
+            "secret",
+            "gold"
+          ],
+          "type": "string"
+        },
+        "output": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "trace": {
+          "$ref": "#/$defs/__schema6"
+        }
+      },
+      "required": [
+        "input",
+        "output",
+        "trace",
+        "expected",
+        "evidence",
+        "maximumClassification"
+      ],
+      "type": "object"
+    },
+    "__schema6": {
+      "enum": [
+        "full",
+        "reference",
+        "digest",
+        "none"
+      ],
+      "type": "string"
+    },
+    "__schema7": {
+      "additionalProperties": false,
+      "properties": {
+        "failureMode": {
+          "enum": [
+            "continue",
+            "fail-fast",
+            "failure-threshold"
+          ],
+          "type": "string"
+        },
+        "maxFailures": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "failureMode"
+      ],
+      "type": "object"
+    },
+    "__schema8": {
+      "additionalProperties": false,
+      "properties": {
+        "backpressureMode": {
+          "enum": [
+            "block"
+          ],
+          "type": "string"
+        },
+        "writerFailureMode": {
+          "enum": [
+            "ignore",
+            "fail-run"
+          ],
+          "type": "string"
+        },
+        "writerMode": {
+          "enum": [
+            "disabled",
+            "optional",
+            "required"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "writerMode",
+        "backpressureMode",
+        "writerFailureMode"
+      ],
+      "type": "object"
+    },
+    "__schema9": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema11"
+          },
+          "schemaDigest": {
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema10"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema10"
+      },
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/measurement-policy.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "budget": {
+      "$ref": "#/$defs/__schema3"
+    },
+    "cache": {
+      "$ref": "#/$defs/__schema4"
+    },
+    "eventDelivery": {
+      "$ref": "#/$defs/__schema8"
+    },
+    "evidence": {
+      "$ref": "#/$defs/__schema5"
+    },
+    "execution": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema9"
+    },
+    "failure": {
+      "$ref": "#/$defs/__schema7"
+    },
+    "retry": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "execution",
+    "retry",
+    "budget",
+    "cache",
+    "evidence",
+    "failure",
+    "eventDelivery"
+  ],
+  "title": "OMK Measurement Policy v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/run-plan.schema.json
+++ b/schemas/evaluation-core/v1/run-plan.schema.json
@@ -1,0 +1,1501 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.run-plan/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "additionalProperties": false,
+      "properties": {
+        "analysisGraph": {
+          "$ref": "#/$defs/__schema20"
+        },
+        "comparisons": {
+          "$ref": "#/$defs/__schema24"
+        },
+        "dataset": {
+          "$ref": "#/$defs/__schema3"
+        },
+        "decisionPolicy": {
+          "$ref": "#/$defs/__schema26"
+        },
+        "evaluators": {
+          "$ref": "#/$defs/__schema13"
+        },
+        "experiment": {
+          "$ref": "#/$defs/__schema18"
+        },
+        "extensions": {
+          "$ref": "#/$defs/__schema28"
+        },
+        "metrics": {
+          "$ref": "#/$defs/__schema16"
+        },
+        "schemaVersion": {
+          "$ref": "#/$defs/__schema2"
+        },
+        "targets": {
+          "$ref": "#/$defs/__schema10"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "dataset",
+        "targets",
+        "evaluators",
+        "metrics",
+        "experiment",
+        "analysisGraph",
+        "comparisons"
+      ],
+      "title": "OMK Evaluation Definition v1",
+      "type": "object"
+    },
+    "__schema10": {
+      "items": {
+        "$ref": "#/$defs/__schema11"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema11": {
+      "additionalProperties": false,
+      "properties": {
+        "config": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "executorId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "protocolId": {
+          "enum": [
+            "omk.invoke/v1",
+            "omk.session/v1"
+          ],
+          "type": "string"
+        },
+        "targetId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "targetKind": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "versionConstraint": {
+          "$ref": "#/$defs/__schema12"
+        }
+      },
+      "required": [
+        "targetId",
+        "targetKind",
+        "protocolId",
+        "executorId"
+      ],
+      "type": "object"
+    },
+    "__schema12": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema13": {
+      "items": {
+        "$ref": "#/$defs/__schema14"
+      },
+      "type": "array"
+    },
+    "__schema14": {
+      "additionalProperties": false,
+      "properties": {
+        "config": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "evaluatorId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "evaluatorKind": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "implementationId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "inputs": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "bindingId": {
+                "$ref": "#/$defs/__schema4"
+              },
+              "pointer": {
+                "$ref": "#/$defs/__schema15"
+              },
+              "sourceKind": {
+                "enum": [
+                  "output",
+                  "trace",
+                  "expected",
+                  "evaluation-context"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "bindingId",
+              "sourceKind",
+              "pointer"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "metricIds": {
+          "items": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "versionConstraint": {
+          "$ref": "#/$defs/__schema12"
+        }
+      },
+      "required": [
+        "evaluatorId",
+        "evaluatorKind",
+        "implementationId",
+        "metricIds",
+        "inputs"
+      ],
+      "type": "object"
+    },
+    "__schema15": {
+      "pattern": "^(?:\\/(?:[^~/]|~[01])*)*$",
+      "type": "string"
+    },
+    "__schema16": {
+      "items": {
+        "$ref": "#/$defs/__schema17"
+      },
+      "type": "array"
+    },
+    "__schema17": {
+      "additionalProperties": false,
+      "properties": {
+        "direction": {
+          "enum": [
+            "higher-is-better",
+            "lower-is-better",
+            "target-is-best"
+          ],
+          "type": "string"
+        },
+        "metricId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "missingPolicyId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "scale": {
+          "additionalProperties": false,
+          "properties": {
+            "max": {
+              "type": "number"
+            },
+            "min": {
+              "type": "number"
+            },
+            "target": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "scope": {
+          "enum": [
+            "sample",
+            "target",
+            "comparison",
+            "run"
+          ],
+          "type": "string"
+        },
+        "unit": {
+          "$ref": "#/$defs/__schema12"
+        },
+        "valueType": {
+          "enum": [
+            "numeric",
+            "boolean",
+            "categorical",
+            "text",
+            "ranking"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "metricId",
+        "valueType",
+        "scope",
+        "missingPolicyId"
+      ],
+      "type": "object"
+    },
+    "__schema18": {
+      "additionalProperties": false,
+      "properties": {
+        "sampling": {
+          "$ref": "#/$defs/__schema19"
+        },
+        "scheduling": {
+          "additionalProperties": false,
+          "properties": {
+            "blockSize": {
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer"
+            },
+            "schedulingKind": {
+              "enum": [
+                "sequential",
+                "interleaved",
+                "randomized-block"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "schedulingKind"
+          ],
+          "type": "object"
+        },
+        "seed": {
+          "$ref": "#/$defs/__schema12"
+        },
+        "trials": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "trials",
+        "seed",
+        "sampling",
+        "scheduling"
+      ],
+      "type": "object"
+    },
+    "__schema19": {
+      "additionalProperties": false,
+      "properties": {
+        "clusterKey": {
+          "$ref": "#/$defs/__schema15"
+        },
+        "estimatorId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "experimentalUnit": {
+          "enum": [
+            "sample",
+            "run",
+            "cluster"
+          ],
+          "type": "string"
+        },
+        "pairingKey": {
+          "$ref": "#/$defs/__schema15"
+        },
+        "repeatedMeasures": {
+          "type": "boolean"
+        },
+        "resamplingUnit": {
+          "enum": [
+            "sample",
+            "paired-block",
+            "cluster",
+            "run"
+          ],
+          "type": "string"
+        },
+        "stratumKey": {
+          "$ref": "#/$defs/__schema15"
+        }
+      },
+      "required": [
+        "experimentalUnit",
+        "repeatedMeasures",
+        "resamplingUnit",
+        "estimatorId"
+      ],
+      "type": "object"
+    },
+    "__schema2": {
+      "const": "omk.evaluation-definition/v1",
+      "type": "string"
+    },
+    "__schema20": {
+      "additionalProperties": false,
+      "properties": {
+        "nodes": {
+          "items": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "analysisNodeKind": {
+                    "const": "reducer",
+                    "type": "string"
+                  },
+                  "implementationId": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "inputs": {
+                    "$ref": "#/$defs/__schema21"
+                  },
+                  "nodeId": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "outputResultId": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "parameters": {
+                    "$ref": "#/$defs/__schema23"
+                  }
+                },
+                "required": [
+                  "nodeId",
+                  "implementationId",
+                  "inputs",
+                  "outputResultId",
+                  "analysisNodeKind"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "analysisNodeKind": {
+                    "const": "estimator",
+                    "type": "string"
+                  },
+                  "implementationId": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "inputs": {
+                    "$ref": "#/$defs/__schema21"
+                  },
+                  "nodeId": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "outputResultId": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "parameters": {
+                    "$ref": "#/$defs/__schema23"
+                  }
+                },
+                "required": [
+                  "nodeId",
+                  "implementationId",
+                  "inputs",
+                  "outputResultId",
+                  "analysisNodeKind"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "analysisNodeKind": {
+                    "const": "correction",
+                    "type": "string"
+                  },
+                  "implementationId": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "inputs": {
+                    "$ref": "#/$defs/__schema21"
+                  },
+                  "nodeId": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "outputResultId": {
+                    "$ref": "#/$defs/__schema4"
+                  },
+                  "parameters": {
+                    "$ref": "#/$defs/__schema23"
+                  }
+                },
+                "required": [
+                  "nodeId",
+                  "implementationId",
+                  "inputs",
+                  "outputResultId",
+                  "analysisNodeKind"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "nodes"
+      ],
+      "type": "object"
+    },
+    "__schema21": {
+      "items": {
+        "$ref": "#/$defs/__schema22"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema22": {
+      "additionalProperties": false,
+      "properties": {
+        "inputKind": {
+          "enum": [
+            "metric-observations",
+            "analysis-result"
+          ],
+          "type": "string"
+        },
+        "referenceId": {
+          "$ref": "#/$defs/__schema4"
+        }
+      },
+      "required": [
+        "inputKind",
+        "referenceId"
+      ],
+      "type": "object"
+    },
+    "__schema23": {
+      "$ref": "#/$defs/__schema6"
+    },
+    "__schema24": {
+      "items": {
+        "$ref": "#/$defs/__schema25"
+      },
+      "type": "array"
+    },
+    "__schema25": {
+      "additionalProperties": false,
+      "properties": {
+        "comparisonId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "controlTargetId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "metricIds": {
+          "items": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "treatmentTargetIds": {
+          "items": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "comparisonId",
+        "controlTargetId",
+        "treatmentTargetIds",
+        "metricIds"
+      ],
+      "type": "object"
+    },
+    "__schema26": {
+      "$ref": "#/$defs/__schema27"
+    },
+    "__schema27": {
+      "additionalProperties": false,
+      "properties": {
+        "analysisResultIds": {
+          "items": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "decisionPolicyId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "implementationId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "minimumEvidenceStatus": {
+          "enum": [
+            "complete",
+            "partial",
+            "unresolvable"
+          ],
+          "type": "string"
+        },
+        "multipleComparisonPolicyId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "parameters": {
+          "$ref": "#/$defs/__schema6"
+        }
+      },
+      "required": [
+        "decisionPolicyId",
+        "implementationId",
+        "analysisResultIds",
+        "minimumEvidenceStatus"
+      ],
+      "type": "object"
+    },
+    "__schema28": {
+      "$ref": "#/$defs/__schema29"
+    },
+    "__schema29": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema6"
+          },
+          "schemaDigest": {
+            "$ref": "#/$defs/__schema31"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema30"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema30"
+      },
+      "type": "object"
+    },
+    "__schema3": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "datasetId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "samples": {
+          "items": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "datasetId",
+        "samples"
+      ],
+      "type": "object"
+    },
+    "__schema30": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    },
+    "__schema31": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema32": {
+      "additionalProperties": false,
+      "properties": {
+        "budget": {
+          "$ref": "#/$defs/__schema36"
+        },
+        "cache": {
+          "$ref": "#/$defs/__schema37"
+        },
+        "eventDelivery": {
+          "$ref": "#/$defs/__schema43"
+        },
+        "evidence": {
+          "$ref": "#/$defs/__schema40"
+        },
+        "execution": {
+          "$ref": "#/$defs/__schema34"
+        },
+        "extensions": {
+          "$ref": "#/$defs/__schema44"
+        },
+        "failure": {
+          "$ref": "#/$defs/__schema42"
+        },
+        "retry": {
+          "$ref": "#/$defs/__schema35"
+        },
+        "schemaVersion": {
+          "$ref": "#/$defs/__schema33"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "execution",
+        "retry",
+        "budget",
+        "cache",
+        "evidence",
+        "failure",
+        "eventDelivery"
+      ],
+      "title": "OMK Measurement Policy v1",
+      "type": "object"
+    },
+    "__schema33": {
+      "const": "omk.measurement-policy/v1",
+      "type": "string"
+    },
+    "__schema34": {
+      "additionalProperties": false,
+      "properties": {
+        "maxConcurrency": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        },
+        "timeoutMs": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "maxConcurrency"
+      ],
+      "type": "object"
+    },
+    "__schema35": {
+      "additionalProperties": false,
+      "properties": {
+        "backoff": {
+          "additionalProperties": false,
+          "properties": {
+            "backoffKind": {
+              "enum": [
+                "none",
+                "fixed",
+                "exponential"
+              ],
+              "type": "string"
+            },
+            "initialDelayMs": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxDelayMs": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "backoffKind",
+            "initialDelayMs"
+          ],
+          "type": "object"
+        },
+        "maxAttempts": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        },
+        "retryableErrorCodes": {
+          "items": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "maxAttempts",
+        "retryableErrorCodes",
+        "backoff"
+      ],
+      "type": "object"
+    },
+    "__schema36": {
+      "additionalProperties": false,
+      "properties": {
+        "maxDurationMs": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        },
+        "maxProviderCost": {
+          "additionalProperties": false,
+          "properties": {
+            "amount": {
+              "minimum": 0,
+              "type": "number"
+            },
+            "currency": {
+              "pattern": "^[A-Z]{3}$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "amount",
+            "currency"
+          ],
+          "type": "object"
+        },
+        "maxTargetInvocations": {
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "__schema37": {
+      "additionalProperties": false,
+      "properties": {
+        "evaluationMode": {
+          "$ref": "#/$defs/__schema39"
+        },
+        "executionMode": {
+          "$ref": "#/$defs/__schema38"
+        }
+      },
+      "required": [
+        "executionMode",
+        "evaluationMode"
+      ],
+      "type": "object"
+    },
+    "__schema38": {
+      "enum": [
+        "disabled",
+        "replay-only",
+        "transparent-deterministic"
+      ],
+      "type": "string"
+    },
+    "__schema39": {
+      "enum": [
+        "disabled",
+        "reuse"
+      ],
+      "type": "string"
+    },
+    "__schema4": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema40": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence": {
+          "$ref": "#/$defs/__schema41"
+        },
+        "expected": {
+          "$ref": "#/$defs/__schema41"
+        },
+        "input": {
+          "$ref": "#/$defs/__schema41"
+        },
+        "maximumClassification": {
+          "enum": [
+            "public",
+            "sensitive",
+            "secret",
+            "gold"
+          ],
+          "type": "string"
+        },
+        "output": {
+          "$ref": "#/$defs/__schema41"
+        },
+        "trace": {
+          "$ref": "#/$defs/__schema41"
+        }
+      },
+      "required": [
+        "input",
+        "output",
+        "trace",
+        "expected",
+        "evidence",
+        "maximumClassification"
+      ],
+      "type": "object"
+    },
+    "__schema41": {
+      "enum": [
+        "full",
+        "reference",
+        "digest",
+        "none"
+      ],
+      "type": "string"
+    },
+    "__schema42": {
+      "additionalProperties": false,
+      "properties": {
+        "failureMode": {
+          "enum": [
+            "continue",
+            "fail-fast",
+            "failure-threshold"
+          ],
+          "type": "string"
+        },
+        "maxFailures": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "failureMode"
+      ],
+      "type": "object"
+    },
+    "__schema43": {
+      "additionalProperties": false,
+      "properties": {
+        "backpressureMode": {
+          "enum": [
+            "block"
+          ],
+          "type": "string"
+        },
+        "writerFailureMode": {
+          "enum": [
+            "ignore",
+            "fail-run"
+          ],
+          "type": "string"
+        },
+        "writerMode": {
+          "enum": [
+            "disabled",
+            "optional",
+            "required"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "writerMode",
+        "backpressureMode",
+        "writerFailureMode"
+      ],
+      "type": "object"
+    },
+    "__schema44": {
+      "$ref": "#/$defs/__schema29"
+    },
+    "__schema45": {
+      "additionalProperties": false,
+      "properties": {
+        "executionInputDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "executionPlanDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "experiment": {
+          "$ref": "#/$defs/__schema18"
+        },
+        "extensions": {
+          "$ref": "#/$defs/__schema53"
+        },
+        "policy": {
+          "$ref": "#/$defs/__schema52"
+        },
+        "runtimes": {
+          "$ref": "#/$defs/__schema50"
+        },
+        "samples": {
+          "$ref": "#/$defs/__schema47"
+        },
+        "schemaVersion": {
+          "$ref": "#/$defs/__schema46"
+        },
+        "targets": {
+          "$ref": "#/$defs/__schema49"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "executionInputDigest",
+        "samples",
+        "targets",
+        "experiment",
+        "runtimes",
+        "policy",
+        "executionPlanDigest"
+      ],
+      "title": "OMK Execution Plan v1",
+      "type": "object"
+    },
+    "__schema46": {
+      "const": "omk.execution-plan/v1",
+      "type": "string"
+    },
+    "__schema47": {
+      "items": {
+        "$ref": "#/$defs/__schema48"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema48": {
+      "additionalProperties": false,
+      "properties": {
+        "executionContext": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "input": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "sampleId": {
+          "$ref": "#/$defs/__schema4"
+        }
+      },
+      "required": [
+        "sampleId",
+        "input"
+      ],
+      "type": "object"
+    },
+    "__schema49": {
+      "items": {
+        "$ref": "#/$defs/__schema11"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema5": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "evaluationContext": {
+          "$ref": "#/$defs/__schema9"
+        },
+        "executionContext": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "expected": {
+          "$ref": "#/$defs/__schema8"
+        },
+        "input": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "sampleId": {
+          "$ref": "#/$defs/__schema4"
+        }
+      },
+      "required": [
+        "sampleId",
+        "input"
+      ],
+      "type": "object"
+    },
+    "__schema50": {
+      "items": {
+        "$ref": "#/$defs/__schema51"
+      },
+      "type": "array"
+    },
+    "__schema51": {
+      "additionalProperties": false,
+      "properties": {
+        "identity": {
+          "additionalProperties": false,
+          "properties": {
+            "assuranceLevel": {
+              "enum": [
+                "verified",
+                "declared",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "capabilities": {
+              "$ref": "#/$defs/__schema6"
+            },
+            "fingerprint": {
+              "$ref": "#/$defs/__schema12"
+            },
+            "fingerprintBasis": {
+              "enum": [
+                "content-derived",
+                "environment-derived",
+                "self-reported",
+                "opaque"
+              ],
+              "type": "string"
+            },
+            "implementationId": {
+              "$ref": "#/$defs/__schema4"
+            },
+            "provenanceFacets": {
+              "$ref": "#/$defs/__schema6"
+            },
+            "version": {
+              "$ref": "#/$defs/__schema12"
+            }
+          },
+          "required": [
+            "implementationId",
+            "fingerprint",
+            "fingerprintBasis",
+            "assuranceLevel",
+            "capabilities"
+          ],
+          "type": "object"
+        },
+        "referenceId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "runtimeKind": {
+          "enum": [
+            "executor",
+            "evaluator",
+            "analysis"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "runtimeKind",
+        "referenceId",
+        "identity"
+      ],
+      "type": "object"
+    },
+    "__schema52": {
+      "additionalProperties": false,
+      "properties": {
+        "budget": {
+          "$ref": "#/$defs/__schema36"
+        },
+        "execution": {
+          "$ref": "#/$defs/__schema34"
+        },
+        "executionCacheMode": {
+          "$ref": "#/$defs/__schema38"
+        },
+        "failure": {
+          "$ref": "#/$defs/__schema42"
+        },
+        "retry": {
+          "$ref": "#/$defs/__schema35"
+        }
+      },
+      "required": [
+        "execution",
+        "retry",
+        "budget",
+        "executionCacheMode",
+        "failure"
+      ],
+      "type": "object"
+    },
+    "__schema53": {
+      "$ref": "#/$defs/__schema29"
+    },
+    "__schema54": {
+      "additionalProperties": false,
+      "properties": {
+        "evaluationInputDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "evaluationPlanDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "evaluators": {
+          "$ref": "#/$defs/__schema58"
+        },
+        "executionPlanDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "extensions": {
+          "$ref": "#/$defs/__schema62"
+        },
+        "metrics": {
+          "$ref": "#/$defs/__schema59"
+        },
+        "policy": {
+          "$ref": "#/$defs/__schema61"
+        },
+        "runtimes": {
+          "$ref": "#/$defs/__schema60"
+        },
+        "samples": {
+          "$ref": "#/$defs/__schema56"
+        },
+        "schemaVersion": {
+          "$ref": "#/$defs/__schema55"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "executionPlanDigest",
+        "evaluationInputDigest",
+        "samples",
+        "evaluators",
+        "metrics",
+        "runtimes",
+        "policy",
+        "evaluationPlanDigest"
+      ],
+      "title": "OMK Evaluation Plan v1",
+      "type": "object"
+    },
+    "__schema55": {
+      "const": "omk.evaluation-plan/v1",
+      "type": "string"
+    },
+    "__schema56": {
+      "items": {
+        "$ref": "#/$defs/__schema57"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema57": {
+      "additionalProperties": false,
+      "properties": {
+        "evaluationContext": {
+          "$ref": "#/$defs/__schema9"
+        },
+        "executionContext": {
+          "$ref": "#/$defs/__schema7"
+        },
+        "expected": {
+          "$ref": "#/$defs/__schema8"
+        },
+        "input": {
+          "$ref": "#/$defs/__schema6"
+        },
+        "sampleId": {
+          "$ref": "#/$defs/__schema4"
+        }
+      },
+      "required": [
+        "sampleId",
+        "input"
+      ],
+      "type": "object"
+    },
+    "__schema58": {
+      "items": {
+        "$ref": "#/$defs/__schema14"
+      },
+      "type": "array"
+    },
+    "__schema59": {
+      "items": {
+        "$ref": "#/$defs/__schema17"
+      },
+      "type": "array"
+    },
+    "__schema6": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema6"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema6"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema60": {
+      "items": {
+        "$ref": "#/$defs/__schema51"
+      },
+      "type": "array"
+    },
+    "__schema61": {
+      "additionalProperties": false,
+      "properties": {
+        "evaluationCacheMode": {
+          "$ref": "#/$defs/__schema39"
+        },
+        "evidence": {
+          "$ref": "#/$defs/__schema40"
+        },
+        "failure": {
+          "$ref": "#/$defs/__schema42"
+        }
+      },
+      "required": [
+        "evaluationCacheMode",
+        "evidence",
+        "failure"
+      ],
+      "type": "object"
+    },
+    "__schema62": {
+      "$ref": "#/$defs/__schema29"
+    },
+    "__schema63": {
+      "additionalProperties": false,
+      "properties": {
+        "analysisGraph": {
+          "$ref": "#/$defs/__schema20"
+        },
+        "analysisPlanDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "evaluationPlanDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "extensions": {
+          "$ref": "#/$defs/__schema66"
+        },
+        "runtimes": {
+          "$ref": "#/$defs/__schema65"
+        },
+        "sampling": {
+          "$ref": "#/$defs/__schema19"
+        },
+        "schemaVersion": {
+          "$ref": "#/$defs/__schema64"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "evaluationPlanDigest",
+        "analysisGraph",
+        "sampling",
+        "runtimes",
+        "analysisPlanDigest"
+      ],
+      "title": "OMK Analysis Plan v1",
+      "type": "object"
+    },
+    "__schema64": {
+      "const": "omk.analysis-plan/v1",
+      "type": "string"
+    },
+    "__schema65": {
+      "items": {
+        "$ref": "#/$defs/__schema51"
+      },
+      "type": "array"
+    },
+    "__schema66": {
+      "$ref": "#/$defs/__schema29"
+    },
+    "__schema67": {
+      "additionalProperties": false,
+      "properties": {
+        "analysisPlanDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "comparisons": {
+          "$ref": "#/$defs/__schema69"
+        },
+        "decisionPlanDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "decisionPolicy": {
+          "$ref": "#/$defs/__schema70"
+        },
+        "extensions": {
+          "$ref": "#/$defs/__schema71"
+        },
+        "schemaVersion": {
+          "$ref": "#/$defs/__schema68"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "analysisPlanDigest",
+        "comparisons",
+        "decisionPlanDigest"
+      ],
+      "title": "OMK Decision Plan v1",
+      "type": "object"
+    },
+    "__schema68": {
+      "const": "omk.decision-plan/v1",
+      "type": "string"
+    },
+    "__schema69": {
+      "items": {
+        "$ref": "#/$defs/__schema25"
+      },
+      "type": "array"
+    },
+    "__schema7": {
+      "$ref": "#/$defs/__schema6"
+    },
+    "__schema70": {
+      "$ref": "#/$defs/__schema27"
+    },
+    "__schema71": {
+      "$ref": "#/$defs/__schema29"
+    },
+    "__schema72": {
+      "items": {
+        "$ref": "#/$defs/__schema73"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema73": {
+      "additionalProperties": false,
+      "properties": {
+        "schemaDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "schemaUri": {
+          "$ref": "#/$defs/__schema30"
+        },
+        "schemaVersion": {
+          "$ref": "#/$defs/__schema12"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "schemaUri",
+        "schemaDigest"
+      ],
+      "type": "object"
+    },
+    "__schema74": {
+      "additionalProperties": false,
+      "properties": {
+        "analysisPlanDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "datasetRevisionDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "decisionPlanDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "evaluationInputDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "evaluationPlanDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "executionInputDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "executionPlanDigest": {
+          "$ref": "#/$defs/__schema31"
+        },
+        "runContractDigest": {
+          "$ref": "#/$defs/__schema31"
+        }
+      },
+      "required": [
+        "datasetRevisionDigest",
+        "executionInputDigest",
+        "evaluationInputDigest",
+        "executionPlanDigest",
+        "evaluationPlanDigest",
+        "analysisPlanDigest",
+        "decisionPlanDigest",
+        "runContractDigest"
+      ],
+      "type": "object"
+    },
+    "__schema75": {
+      "$ref": "#/$defs/__schema29"
+    },
+    "__schema8": {
+      "$ref": "#/$defs/__schema6"
+    },
+    "__schema9": {
+      "$ref": "#/$defs/__schema6"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/run-plan.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "analysis": {
+      "$ref": "#/$defs/__schema63"
+    },
+    "decision": {
+      "$ref": "#/$defs/__schema67"
+    },
+    "definition": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "digests": {
+      "$ref": "#/$defs/__schema74"
+    },
+    "evaluation": {
+      "$ref": "#/$defs/__schema54"
+    },
+    "execution": {
+      "$ref": "#/$defs/__schema45"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema75"
+    },
+    "measurementPolicy": {
+      "$ref": "#/$defs/__schema32"
+    },
+    "schemaIdentities": {
+      "$ref": "#/$defs/__schema72"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "definition",
+    "measurementPolicy",
+    "execution",
+    "evaluation",
+    "analysis",
+    "decision",
+    "schemaIdentities",
+    "digests"
+  ],
+  "title": "OMK Run Plan v1",
+  "type": "object"
+}

--- a/scripts/build-evaluation-core-schemas.mjs
+++ b/scripts/build-evaluation-core-schemas.mjs
@@ -1,0 +1,68 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { resolve } from 'node:path';
+import { generateWireJsonSchemas } from '../dist/evaluation-core/contracts/json-schema.js';
+
+const mode = process.argv[2];
+if (mode !== '--write' && mode !== '--check') {
+  throw new Error('Usage: node scripts/build-evaluation-core-schemas.mjs <--write|--check>');
+}
+
+const schemaDir = resolve('schemas/evaluation-core/v1');
+const schemas = generateWireJsonSchemas();
+
+function sortJson(value) {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (value === null || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, sortJson(value[key])]),
+  );
+}
+
+const rendered = Object.fromEntries(
+  Object.entries(schemas).map(([fileName, schema]) => [
+    fileName,
+    `${JSON.stringify(sortJson(schema), null, 2)}\n`,
+  ]),
+);
+
+if (mode === '--write') {
+  mkdirSync(schemaDir, { recursive: true });
+  const expected = new Set(Object.keys(rendered));
+  for (const fileName of readdirSync(schemaDir)) {
+    if (fileName.endsWith('.schema.json') && !expected.has(fileName)) {
+      rmSync(resolve(schemaDir, fileName));
+    }
+  }
+  for (const [fileName, contents] of Object.entries(rendered)) {
+    writeFileSync(resolve(schemaDir, fileName), contents);
+  }
+  console.log(`Generated ${Object.keys(rendered).length} Evaluation Core schemas.`);
+  process.exit(0);
+}
+
+const errors = [];
+const actualFiles = existsSync(schemaDir)
+  ? readdirSync(schemaDir).filter((fileName) => fileName.endsWith('.schema.json')).sort()
+  : [];
+const expectedFiles = Object.keys(rendered).sort();
+if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+  errors.push(`schema file set differs: expected ${expectedFiles.join(', ')}, found ${actualFiles.join(', ')}`);
+}
+for (const [fileName, contents] of Object.entries(rendered)) {
+  const filePath = resolve(schemaDir, fileName);
+  if (!existsSync(filePath)) continue;
+  if (readFileSync(filePath, 'utf8') !== contents) errors.push(`${fileName} is stale`);
+}
+if (errors.length > 0) {
+  console.error(errors.join('\n'));
+  console.error('Run `yarn build:schemas` and commit the generated files.');
+  process.exit(1);
+}
+console.log(`Checked ${expectedFiles.length} Evaluation Core schemas.`);

--- a/scripts/copy-assets.cjs
+++ b/scripts/copy-assets.cjs
@@ -22,6 +22,7 @@ for (const [src, dst] of ASSETS) {
 
 const DIR_ASSETS = [
   ['.agents/skills/omk', 'dist/assets/agent-skills/omk'],
+  ['schemas/evaluation-core/v1', 'dist/evaluation-core/contracts/schemas/v1'],
 ];
 
 for (const [src, dst] of DIR_ASSETS) {

--- a/src/evaluation-core/contracts/artifacts.ts
+++ b/src/evaluation-core/contracts/artifacts.ts
@@ -1,0 +1,331 @@
+import { z } from 'zod';
+import {
+  CacheProvenanceSchema,
+  CapturedContentSchema,
+  EvaluationErrorSchema,
+  ExtensionsSchema,
+  IdentifierSchema,
+  NonEmptyStringSchema,
+  ProvenanceSchema,
+  ReplayabilitySchema,
+  RuntimeIdentitySchema,
+  Sha256DigestSchema,
+  TimestampSchema,
+  UriSchema,
+} from './common.js';
+import { JsonValueSchema } from './json.js';
+
+export const EVALUATION_EVENT_SCHEMA_VERSION = 'omk.evaluation-event/v1' as const;
+export const EXECUTION_BUNDLE_SCHEMA_VERSION = 'omk.execution-bundle/v1' as const;
+export const EVALUATION_BUNDLE_SCHEMA_VERSION = 'omk.evaluation-bundle/v1' as const;
+export const ANALYSIS_BUNDLE_SCHEMA_VERSION = 'omk.analysis-bundle/v1' as const;
+export const EVALUATION_REPORT_SCHEMA_VERSION = 'omk.evaluation-report/v1' as const;
+
+export const TimingRecordSchema = z.object({
+  startedAt: TimestampSchema,
+  completedAt: TimestampSchema.optional(),
+  durationMs: z.number().nonnegative().optional(),
+}).strict();
+
+export const ProviderCostSchema = z.object({
+  amount: z.number().nonnegative(),
+  currency: z.string().regex(/^[A-Z]{3}$/),
+  reportedByProvider: z.literal(true),
+}).strict();
+
+export const UsageRecordSchema = z.object({
+  inputTokens: z.number().int().nonnegative().optional(),
+  outputTokens: z.number().int().nonnegative().optional(),
+  totalTokens: z.number().int().nonnegative().optional(),
+  providerCost: ProviderCostSchema.optional(),
+  details: JsonValueSchema.optional(),
+}).strict();
+
+export const ExecutionAttemptSchema = z.object({
+  attemptId: IdentifierSchema,
+  attemptNumber: z.number().int().positive(),
+  attemptStatus: z.enum(['completed', 'failed', 'cancelled']),
+  timing: TimingRecordSchema,
+  error: EvaluationErrorSchema.optional(),
+}).strict();
+
+const ExecutionRecordBaseSchema = z.object({
+  targetId: IdentifierSchema,
+  sampleId: IdentifierSchema,
+  trialId: IdentifierSchema,
+  runtime: RuntimeIdentitySchema,
+  attempts: z.array(ExecutionAttemptSchema).min(1),
+  timing: TimingRecordSchema,
+  usage: UsageRecordSchema.optional(),
+  trace: CapturedContentSchema.optional(),
+  provenance: ProvenanceSchema,
+  cache: CacheProvenanceSchema,
+}).strict();
+
+export const CompletedExecutionRecordSchema = ExecutionRecordBaseSchema.extend({
+  executionStatus: z.literal('completed'),
+  output: CapturedContentSchema,
+}).strict();
+
+export const FailedExecutionRecordSchema = ExecutionRecordBaseSchema.extend({
+  executionStatus: z.literal('failed'),
+  error: EvaluationErrorSchema,
+}).strict();
+
+export const CancelledExecutionRecordSchema = ExecutionRecordBaseSchema.extend({
+  executionStatus: z.literal('cancelled'),
+  error: EvaluationErrorSchema.optional(),
+}).strict();
+
+export const CensoredExecutionRecordSchema = ExecutionRecordBaseSchema.extend({
+  executionStatus: z.literal('budget-censored'),
+  censorReason: NonEmptyStringSchema,
+}).strict();
+
+export const ExecutionRecordSchema = z.discriminatedUnion('executionStatus', [
+  CompletedExecutionRecordSchema,
+  FailedExecutionRecordSchema,
+  CancelledExecutionRecordSchema,
+  CensoredExecutionRecordSchema,
+]);
+
+export const ExecutionBundleSchema = z.object({
+  schemaVersion: z.literal(EXECUTION_BUNDLE_SCHEMA_VERSION),
+  bundleId: IdentifierSchema,
+  runContractDigest: Sha256DigestSchema,
+  executionPlanDigest: Sha256DigestSchema,
+  datasetRevisionDigest: Sha256DigestSchema,
+  executionInputDigest: Sha256DigestSchema,
+  replayability: ReplayabilitySchema,
+  records: z.array(ExecutionRecordSchema),
+  provenance: ProvenanceSchema,
+  bundleDigest: Sha256DigestSchema,
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Execution Bundle v1',
+});
+
+const MetricObservationBaseSchema = z.object({
+  observationId: IdentifierSchema,
+  metricId: IdentifierSchema,
+  evidence: CapturedContentSchema.optional(),
+  metadata: JsonValueSchema.optional(),
+}).strict();
+
+export const NumericMetricObservationSchema = MetricObservationBaseSchema.extend({
+  observationStatus: z.literal('observed'),
+  valueType: z.literal('numeric'),
+  value: z.number(),
+}).strict();
+
+export const BooleanMetricObservationSchema = MetricObservationBaseSchema.extend({
+  observationStatus: z.literal('observed'),
+  valueType: z.literal('boolean'),
+  value: z.boolean(),
+}).strict();
+
+export const CategoricalMetricObservationSchema = MetricObservationBaseSchema.extend({
+  observationStatus: z.literal('observed'),
+  valueType: z.literal('categorical'),
+  value: z.string(),
+}).strict();
+
+export const TextMetricObservationSchema = MetricObservationBaseSchema.extend({
+  observationStatus: z.literal('observed'),
+  valueType: z.literal('text'),
+  value: z.string(),
+}).strict();
+
+export const RankingMetricObservationSchema = MetricObservationBaseSchema.extend({
+  observationStatus: z.literal('observed'),
+  valueType: z.literal('ranking'),
+  value: z.array(IdentifierSchema),
+}).strict();
+
+export const MissingMetricObservationSchema = MetricObservationBaseSchema.extend({
+  observationStatus: z.literal('missing'),
+  valueType: z.enum(['numeric', 'boolean', 'categorical', 'text', 'ranking']),
+  reasonCode: IdentifierSchema,
+}).strict();
+
+export const InvalidMetricObservationSchema = MetricObservationBaseSchema.extend({
+  observationStatus: z.literal('invalid'),
+  valueType: z.enum(['numeric', 'boolean', 'categorical', 'text', 'ranking']),
+  reasonCode: IdentifierSchema,
+  invalidValue: CapturedContentSchema.optional(),
+}).strict();
+
+export const MetricObservationSchema = z.union([
+  NumericMetricObservationSchema,
+  BooleanMetricObservationSchema,
+  CategoricalMetricObservationSchema,
+  TextMetricObservationSchema,
+  RankingMetricObservationSchema,
+  MissingMetricObservationSchema,
+  InvalidMetricObservationSchema,
+]);
+
+const EvaluationRecordBaseSchema = z.object({
+  targetId: IdentifierSchema,
+  sampleId: IdentifierSchema,
+  trialId: IdentifierSchema,
+  evaluatorId: IdentifierSchema,
+  runtime: RuntimeIdentitySchema,
+  timing: TimingRecordSchema,
+  evidence: CapturedContentSchema.optional(),
+  provenance: ProvenanceSchema,
+  cache: CacheProvenanceSchema,
+}).strict();
+
+export const CompletedEvaluationRecordSchema = EvaluationRecordBaseSchema.extend({
+  evaluationStatus: z.literal('completed'),
+  observations: z.array(MetricObservationSchema),
+}).strict();
+
+export const FailedEvaluationRecordSchema = EvaluationRecordBaseSchema.extend({
+  evaluationStatus: z.literal('failed'),
+  error: EvaluationErrorSchema,
+}).strict();
+
+export const EvaluationRecordSchema = z.discriminatedUnion('evaluationStatus', [
+  CompletedEvaluationRecordSchema,
+  FailedEvaluationRecordSchema,
+]);
+
+export const EvaluationBundleSchema = z.object({
+  schemaVersion: z.literal(EVALUATION_BUNDLE_SCHEMA_VERSION),
+  bundleId: IdentifierSchema,
+  runContractDigest: Sha256DigestSchema,
+  executionBundleDigest: Sha256DigestSchema,
+  evaluationPlanDigest: Sha256DigestSchema,
+  evaluationInputDigest: Sha256DigestSchema,
+  replayability: ReplayabilitySchema,
+  records: z.array(EvaluationRecordSchema),
+  provenance: ProvenanceSchema,
+  bundleDigest: Sha256DigestSchema,
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Evaluation Bundle v1',
+});
+
+export const AnalysisResultSchema = z.object({
+  resultId: IdentifierSchema,
+  nodeId: IdentifierSchema,
+  resultType: z.enum([
+    'scalar',
+    'interval',
+    'distribution',
+    'table',
+    'matrix',
+    'curve',
+  ]),
+  value: JsonValueSchema,
+  implementation: RuntimeIdentitySchema,
+  parentDigests: z.array(Sha256DigestSchema).min(1),
+  analysisMode: z.enum(['preregistered', 'exploratory']),
+  derivedAt: TimestampSchema,
+}).strict();
+
+export const AssumptionCheckSchema = z.object({
+  assumptionId: IdentifierSchema,
+  checkStatus: z.enum(['passed', 'failed', 'not-evaluated']),
+  message: NonEmptyStringSchema.optional(),
+  details: JsonValueSchema.optional(),
+}).strict();
+
+export const CoverageRecordSchema = z.object({
+  started: z.number().int().nonnegative(),
+  completed: z.number().int().nonnegative(),
+  comparable: z.number().int().nonnegative(),
+  censored: z.number().int().nonnegative(),
+  missing: z.number().int().nonnegative(),
+}).strict();
+
+export const AnalysisBundleSchema = z.object({
+  schemaVersion: z.literal(ANALYSIS_BUNDLE_SCHEMA_VERSION),
+  bundleId: IdentifierSchema,
+  runContractDigest: Sha256DigestSchema,
+  evaluationBundleDigest: Sha256DigestSchema,
+  analysisPlanDigest: Sha256DigestSchema,
+  results: z.array(AnalysisResultSchema),
+  assumptionChecks: z.array(AssumptionCheckSchema),
+  coverage: CoverageRecordSchema,
+  provenance: ProvenanceSchema,
+  bundleDigest: Sha256DigestSchema,
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Analysis Bundle v1',
+});
+
+export const EvaluationStatusSchema = z.object({
+  runStatus: z.enum(['completed', 'cancelled', 'budget-exhausted', 'failed']),
+  evidenceStatus: z.enum(['complete', 'partial', 'unresolvable']),
+  conclusionStatus: z.enum(['conclusive', 'inconclusive', 'not-evaluated']),
+}).strict();
+
+export const BundleReferenceSchema = z.object({
+  bundleKind: z.enum(['execution', 'evaluation', 'analysis']),
+  schemaVersion: NonEmptyStringSchema,
+  bundleDigest: Sha256DigestSchema,
+  uri: UriSchema.optional(),
+}).strict();
+
+export const DecisionResultSchema = z.discriminatedUnion('decisionStatus', [
+  z.object({
+    decisionStatus: z.literal('decided'),
+    verdict: IdentifierSchema,
+    policyDigest: Sha256DigestSchema,
+    analysisResultIds: z.array(IdentifierSchema).min(1),
+  }).strict(),
+  z.object({
+    decisionStatus: z.literal('not-decided'),
+    reasonCodes: z.array(IdentifierSchema).min(1),
+  }).strict(),
+]);
+
+export const EvaluationReportSchema = z.object({
+  schemaVersion: z.literal(EVALUATION_REPORT_SCHEMA_VERSION),
+  reportId: IdentifierSchema,
+  runContractDigest: Sha256DigestSchema,
+  status: EvaluationStatusSchema,
+  bundles: z.array(BundleReferenceSchema),
+  decision: DecisionResultSchema.optional(),
+  summaries: JsonValueSchema.optional(),
+  annotations: JsonValueSchema.optional(),
+  provenance: ProvenanceSchema,
+  reportDigest: Sha256DigestSchema,
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Evaluation Report v1',
+});
+
+export const EvaluationEventSchema = z.object({
+  schemaVersion: z.literal(EVALUATION_EVENT_SCHEMA_VERSION),
+  eventId: IdentifierSchema,
+  sequence: z.number().int().nonnegative(),
+  runId: IdentifierSchema,
+  eventKind: IdentifierSchema,
+  time: TimestampSchema,
+  subject: z.object({
+    subjectKind: IdentifierSchema,
+    subjectId: IdentifierSchema,
+  }).strict(),
+  data: JsonValueSchema,
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Evaluation Event v1',
+});
+
+export type TimingRecord = z.infer<typeof TimingRecordSchema>;
+export type UsageRecord = z.infer<typeof UsageRecordSchema>;
+export type ExecutionAttempt = z.infer<typeof ExecutionAttemptSchema>;
+export type ExecutionRecord = z.infer<typeof ExecutionRecordSchema>;
+export type ExecutionBundle = z.infer<typeof ExecutionBundleSchema>;
+export type MetricObservation = z.infer<typeof MetricObservationSchema>;
+export type EvaluationRecord = z.infer<typeof EvaluationRecordSchema>;
+export type EvaluationBundle = z.infer<typeof EvaluationBundleSchema>;
+export type AnalysisResult = z.infer<typeof AnalysisResultSchema>;
+export type AnalysisBundle = z.infer<typeof AnalysisBundleSchema>;
+export type EvaluationStatus = z.infer<typeof EvaluationStatusSchema>;
+export type EvaluationReport = z.infer<typeof EvaluationReportSchema>;
+export type EvaluationEvent = z.infer<typeof EvaluationEventSchema>;

--- a/src/evaluation-core/contracts/common.ts
+++ b/src/evaluation-core/contracts/common.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod';
+import { JsonValueSchema, type JsonValue } from './json.js';
+
+export const NonEmptyStringSchema = z.string().min(1);
+export const IdentifierSchema = z.string().min(1).max(256);
+export const Sha256DigestSchema = z.string().regex(/^sha256:[0-9a-f]{64}$/);
+export const UriSchema = z.string().regex(/^[A-Za-z][A-Za-z0-9+.-]*:/);
+export const TimestampSchema = z.string().regex(
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/,
+);
+export const JsonPointerSchema = z.string().regex(/^(?:\/(?:[^~/]|~[01])*)*$/);
+
+export const SchemaIdentitySchema = z.object({
+  schemaVersion: NonEmptyStringSchema,
+  schemaUri: UriSchema,
+  schemaDigest: Sha256DigestSchema,
+}).strict();
+
+export const ExtensionEntrySchema = z.object({
+  schemaUri: UriSchema,
+  schemaDigest: Sha256DigestSchema,
+  data: JsonValueSchema,
+}).strict();
+
+export const ExtensionsSchema = z.record(
+  UriSchema,
+  ExtensionEntrySchema,
+);
+
+export const RuntimeIdentitySchema = z.object({
+  implementationId: IdentifierSchema,
+  version: NonEmptyStringSchema.optional(),
+  fingerprint: NonEmptyStringSchema,
+  fingerprintBasis: z.enum([
+    'content-derived',
+    'environment-derived',
+    'self-reported',
+    'opaque',
+  ]),
+  assuranceLevel: z.enum(['verified', 'declared', 'unknown']),
+  capabilities: JsonValueSchema,
+  provenanceFacets: JsonValueSchema.optional(),
+}).strict();
+
+export const ProvenanceSchema = z.object({
+  provenanceKind: z.enum(['native', 'imported', 'replay', 'derived']),
+  trust: z.enum(['verified', 'declared', 'untrusted', 'unknown']),
+  sourceId: NonEmptyStringSchema.optional(),
+  parentDigests: z.array(Sha256DigestSchema),
+  facets: JsonValueSchema.optional(),
+}).strict();
+
+export const CacheProvenanceSchema = z.object({
+  cacheStatus: z.enum(['not-used', 'miss', 'replay', 'transparent-hit']),
+  cacheKeyDigest: Sha256DigestSchema.optional(),
+  sourceRecordDigest: Sha256DigestSchema.optional(),
+}).strict();
+
+export const ContentDescriptorSchema = z.object({
+  mediaType: NonEmptyStringSchema,
+  digest: Sha256DigestSchema,
+  size: z.number().int().nonnegative().optional(),
+  uri: UriSchema.optional(),
+}).strict();
+
+export const ContentClassificationSchema = z.enum([
+  'public',
+  'sensitive',
+  'secret',
+  'gold',
+]);
+
+export const CapturedContentSchema = z.discriminatedUnion('contentKind', [
+  z.object({
+    contentKind: z.literal('inline'),
+    classification: ContentClassificationSchema,
+    value: JsonValueSchema,
+  }).strict(),
+  z.object({
+    contentKind: z.literal('descriptor'),
+    classification: ContentClassificationSchema,
+    descriptor: ContentDescriptorSchema,
+  }).strict(),
+  z.object({
+    contentKind: z.literal('digest-only'),
+    classification: ContentClassificationSchema,
+    digest: Sha256DigestSchema,
+  }).strict(),
+]);
+
+export const ReplayabilitySchema = z.enum([
+  'self-contained',
+  'resolvable',
+  'summary-only',
+]);
+
+export interface EvaluationError {
+  code: string;
+  stage: 'configuration' | 'infrastructure' | 'execution' | 'evaluation' | 'analysis' | 'internal';
+  message: string;
+  details?: JsonValue;
+  causes?: EvaluationError[];
+}
+
+export const EvaluationErrorSchema: z.ZodType<EvaluationError> = z.lazy(() => z.object({
+  code: IdentifierSchema,
+  stage: z.enum([
+    'configuration',
+    'infrastructure',
+    'execution',
+    'evaluation',
+    'analysis',
+    'internal',
+  ]),
+  message: NonEmptyStringSchema,
+  details: JsonValueSchema.optional(),
+  causes: z.array(EvaluationErrorSchema).optional(),
+}).strict());
+
+export type SchemaIdentity = z.infer<typeof SchemaIdentitySchema>;
+export type ExtensionEntry = z.infer<typeof ExtensionEntrySchema>;
+export type Extensions = z.infer<typeof ExtensionsSchema>;
+export type RuntimeIdentity = z.infer<typeof RuntimeIdentitySchema>;
+export type Provenance = z.infer<typeof ProvenanceSchema>;
+export type CacheProvenance = z.infer<typeof CacheProvenanceSchema>;
+export type ContentDescriptor = z.infer<typeof ContentDescriptorSchema>;
+export type CapturedContent = z.infer<typeof CapturedContentSchema>;
+export type Replayability = z.infer<typeof ReplayabilitySchema>;

--- a/src/evaluation-core/contracts/definition.ts
+++ b/src/evaluation-core/contracts/definition.ts
@@ -1,0 +1,238 @@
+import { z } from 'zod';
+import {
+  ContentClassificationSchema,
+  ExtensionsSchema,
+  IdentifierSchema,
+  JsonPointerSchema,
+  NonEmptyStringSchema,
+} from './common.js';
+import { JsonValueSchema } from './json.js';
+
+export const EVALUATION_DEFINITION_SCHEMA_VERSION = 'omk.evaluation-definition/v1' as const;
+export const MEASUREMENT_POLICY_SCHEMA_VERSION = 'omk.measurement-policy/v1' as const;
+
+export const EvaluationSampleSchema = z.object({
+  sampleId: IdentifierSchema,
+  input: JsonValueSchema,
+  executionContext: JsonValueSchema.optional(),
+  expected: JsonValueSchema.optional(),
+  evaluationContext: JsonValueSchema.optional(),
+  annotations: JsonValueSchema.optional(),
+}).strict();
+
+export const EvaluationDatasetSchema = z.object({
+  datasetId: IdentifierSchema,
+  samples: z.array(EvaluationSampleSchema).min(1),
+  annotations: JsonValueSchema.optional(),
+}).strict();
+
+export const TargetDefinitionSchema = z.object({
+  targetId: IdentifierSchema,
+  targetKind: IdentifierSchema,
+  protocolId: z.enum(['omk.invoke/v1', 'omk.session/v1']),
+  executorId: IdentifierSchema,
+  versionConstraint: NonEmptyStringSchema.optional(),
+  config: JsonValueSchema.optional(),
+}).strict();
+
+export const EvaluatorInputBindingSchema = z.object({
+  bindingId: IdentifierSchema,
+  sourceKind: z.enum(['output', 'trace', 'expected', 'evaluation-context']),
+  pointer: JsonPointerSchema,
+}).strict();
+
+export const EvaluatorDefinitionSchema = z.object({
+  evaluatorId: IdentifierSchema,
+  evaluatorKind: IdentifierSchema,
+  implementationId: IdentifierSchema,
+  versionConstraint: NonEmptyStringSchema.optional(),
+  metricIds: z.array(IdentifierSchema).min(1),
+  inputs: z.array(EvaluatorInputBindingSchema),
+  config: JsonValueSchema.optional(),
+}).strict();
+
+export const MetricDefinitionSchema = z.object({
+  metricId: IdentifierSchema,
+  valueType: z.enum(['numeric', 'boolean', 'categorical', 'text', 'ranking']),
+  scope: z.enum(['sample', 'target', 'comparison', 'run']),
+  scale: z.object({
+    min: z.number().optional(),
+    max: z.number().optional(),
+    target: z.number().optional(),
+  }).strict().optional(),
+  unit: NonEmptyStringSchema.optional(),
+  direction: z.enum([
+    'higher-is-better',
+    'lower-is-better',
+    'target-is-best',
+  ]).optional(),
+  missingPolicyId: IdentifierSchema,
+}).strict();
+
+export const SamplingDesignSchema = z.object({
+  experimentalUnit: z.enum(['sample', 'run', 'cluster']),
+  pairingKey: JsonPointerSchema.optional(),
+  clusterKey: JsonPointerSchema.optional(),
+  stratumKey: JsonPointerSchema.optional(),
+  repeatedMeasures: z.boolean(),
+  resamplingUnit: z.enum(['sample', 'paired-block', 'cluster', 'run']),
+  estimatorId: IdentifierSchema,
+}).strict();
+
+export const SchedulingPolicySchema = z.object({
+  schedulingKind: z.enum(['sequential', 'interleaved', 'randomized-block']),
+  blockSize: z.number().int().positive().optional(),
+}).strict();
+
+export const ExperimentDesignSchema = z.object({
+  trials: z.number().int().positive(),
+  seed: NonEmptyStringSchema,
+  sampling: SamplingDesignSchema,
+  scheduling: SchedulingPolicySchema,
+}).strict();
+
+export const AnalysisInputReferenceSchema = z.object({
+  inputKind: z.enum(['metric-observations', 'analysis-result']),
+  referenceId: IdentifierSchema,
+}).strict();
+
+const AnalysisNodeBaseSchema = z.object({
+  nodeId: IdentifierSchema,
+  implementationId: IdentifierSchema,
+  inputs: z.array(AnalysisInputReferenceSchema).min(1),
+  outputResultId: IdentifierSchema,
+  parameters: JsonValueSchema.optional(),
+}).strict();
+
+export const ReducerDefinitionSchema = AnalysisNodeBaseSchema.extend({
+  analysisNodeKind: z.literal('reducer'),
+}).strict();
+
+export const EstimatorDefinitionSchema = AnalysisNodeBaseSchema.extend({
+  analysisNodeKind: z.literal('estimator'),
+}).strict();
+
+export const CorrectionDefinitionSchema = AnalysisNodeBaseSchema.extend({
+  analysisNodeKind: z.literal('correction'),
+}).strict();
+
+export const AnalysisNodeDefinitionSchema = z.discriminatedUnion('analysisNodeKind', [
+  ReducerDefinitionSchema,
+  EstimatorDefinitionSchema,
+  CorrectionDefinitionSchema,
+]);
+
+export const AnalysisGraphDefinitionSchema = z.object({
+  nodes: z.array(AnalysisNodeDefinitionSchema),
+}).strict();
+
+export const ComparisonDefinitionSchema = z.object({
+  comparisonId: IdentifierSchema,
+  controlTargetId: IdentifierSchema,
+  treatmentTargetIds: z.array(IdentifierSchema).min(1),
+  metricIds: z.array(IdentifierSchema).min(1),
+}).strict();
+
+export const DecisionPolicyDefinitionSchema = z.object({
+  decisionPolicyId: IdentifierSchema,
+  implementationId: IdentifierSchema,
+  analysisResultIds: z.array(IdentifierSchema).min(1),
+  multipleComparisonPolicyId: IdentifierSchema.optional(),
+  minimumEvidenceStatus: z.enum(['complete', 'partial', 'unresolvable']),
+  parameters: JsonValueSchema.optional(),
+}).strict();
+
+export const EvaluationDefinitionSchema = z.object({
+  schemaVersion: z.literal(EVALUATION_DEFINITION_SCHEMA_VERSION),
+  dataset: EvaluationDatasetSchema,
+  targets: z.array(TargetDefinitionSchema).min(1),
+  evaluators: z.array(EvaluatorDefinitionSchema),
+  metrics: z.array(MetricDefinitionSchema),
+  experiment: ExperimentDesignSchema,
+  analysisGraph: AnalysisGraphDefinitionSchema,
+  comparisons: z.array(ComparisonDefinitionSchema),
+  decisionPolicy: DecisionPolicyDefinitionSchema.optional(),
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Evaluation Definition v1',
+});
+
+export const ExecutionPolicySchema = z.object({
+  timeoutMs: z.number().int().positive().optional(),
+  maxConcurrency: z.number().int().positive(),
+}).strict();
+
+export const RetryPolicySchema = z.object({
+  maxAttempts: z.number().int().positive(),
+  retryableErrorCodes: z.array(IdentifierSchema),
+  backoff: z.object({
+    backoffKind: z.enum(['none', 'fixed', 'exponential']),
+    initialDelayMs: z.number().int().nonnegative(),
+    maxDelayMs: z.number().int().nonnegative().optional(),
+  }).strict(),
+}).strict();
+
+export const BudgetPolicySchema = z.object({
+  maxTargetInvocations: z.number().int().positive().optional(),
+  maxDurationMs: z.number().int().positive().optional(),
+  maxProviderCost: z.object({
+    amount: z.number().nonnegative(),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+  }).strict().optional(),
+}).strict();
+
+export const CachePolicySchema = z.object({
+  executionMode: z.enum(['disabled', 'replay-only', 'transparent-deterministic']),
+  evaluationMode: z.enum(['disabled', 'reuse']),
+}).strict();
+
+export const CaptureModeSchema = z.enum(['full', 'reference', 'digest', 'none']);
+
+export const EvidencePolicySchema = z.object({
+  input: CaptureModeSchema,
+  output: CaptureModeSchema,
+  trace: CaptureModeSchema,
+  expected: CaptureModeSchema,
+  evidence: CaptureModeSchema,
+  maximumClassification: ContentClassificationSchema,
+}).strict();
+
+export const FailurePolicySchema = z.object({
+  failureMode: z.enum(['continue', 'fail-fast', 'failure-threshold']),
+  maxFailures: z.number().int().nonnegative().optional(),
+}).strict();
+
+export const EventDeliveryPolicySchema = z.object({
+  writerMode: z.enum(['disabled', 'optional', 'required']),
+  backpressureMode: z.enum(['block']),
+  writerFailureMode: z.enum(['ignore', 'fail-run']),
+}).strict();
+
+export const MeasurementPolicySchema = z.object({
+  schemaVersion: z.literal(MEASUREMENT_POLICY_SCHEMA_VERSION),
+  execution: ExecutionPolicySchema,
+  retry: RetryPolicySchema,
+  budget: BudgetPolicySchema,
+  cache: CachePolicySchema,
+  evidence: EvidencePolicySchema,
+  failure: FailurePolicySchema,
+  eventDelivery: EventDeliveryPolicySchema,
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Measurement Policy v1',
+});
+
+export type EvaluationSample = z.infer<typeof EvaluationSampleSchema>;
+export type EvaluationDataset = z.infer<typeof EvaluationDatasetSchema>;
+export type TargetDefinition = z.infer<typeof TargetDefinitionSchema>;
+export type EvaluatorDefinition = z.infer<typeof EvaluatorDefinitionSchema>;
+export type MetricDefinition = z.infer<typeof MetricDefinitionSchema>;
+export type SamplingDesign = z.infer<typeof SamplingDesignSchema>;
+export type ExperimentDesign = z.infer<typeof ExperimentDesignSchema>;
+export type ReducerDefinition = z.infer<typeof ReducerDefinitionSchema>;
+export type AnalysisNodeDefinition = z.infer<typeof AnalysisNodeDefinitionSchema>;
+export type AnalysisGraphDefinition = z.infer<typeof AnalysisGraphDefinitionSchema>;
+export type ComparisonDefinition = z.infer<typeof ComparisonDefinitionSchema>;
+export type DecisionPolicyDefinition = z.infer<typeof DecisionPolicyDefinitionSchema>;
+export type EvaluationDefinition = z.infer<typeof EvaluationDefinitionSchema>;
+export type MeasurementPolicy = z.infer<typeof MeasurementPolicySchema>;

--- a/src/evaluation-core/contracts/digests.ts
+++ b/src/evaluation-core/contracts/digests.ts
@@ -1,0 +1,319 @@
+import type {
+  AnalysisGraphDefinition,
+  ComparisonDefinition,
+  DecisionPolicyDefinition,
+  EvaluationDataset,
+  EvaluatorDefinition,
+  ExperimentDesign,
+  MeasurementPolicy,
+  MetricDefinition,
+  TargetDefinition,
+} from './definition.js';
+import {
+  ANALYSIS_PLAN_SCHEMA_VERSION,
+  DECISION_PLAN_SCHEMA_VERSION,
+  EVALUATION_PLAN_SCHEMA_VERSION,
+  EXECUTION_PLAN_SCHEMA_VERSION,
+  RUN_PLAN_SCHEMA_VERSION,
+  type EvaluationInputSample,
+  type ExecutionInputSample,
+  type PlanDigests,
+  type ResolvedRuntime,
+} from './plans.js';
+import type { Extensions, SchemaIdentity } from './common.js';
+import {
+  assertCanonicalJson,
+  digestCanonicalJson,
+  type Sha256Digest,
+} from './json.js';
+
+export interface DatasetDigests {
+  datasetRevisionDigest: Sha256Digest;
+  executionInputDigest: Sha256Digest;
+  evaluationInputDigest: Sha256Digest;
+}
+
+export function projectExecutionInputs(
+  dataset: EvaluationDataset,
+): ExecutionInputSample[] {
+  return dataset.samples.map((sample) => ({
+    sampleId: sample.sampleId,
+    input: sample.input,
+    ...(sample.executionContext !== undefined
+      ? { executionContext: sample.executionContext }
+      : {}),
+  }));
+}
+
+export function projectEvaluationInputs(
+  dataset: EvaluationDataset,
+): EvaluationInputSample[] {
+  return dataset.samples.map((sample) => ({
+    sampleId: sample.sampleId,
+    input: sample.input,
+    ...(sample.executionContext !== undefined
+      ? { executionContext: sample.executionContext }
+      : {}),
+    ...(sample.expected !== undefined ? { expected: sample.expected } : {}),
+    ...(sample.evaluationContext !== undefined
+      ? { evaluationContext: sample.evaluationContext }
+      : {}),
+  }));
+}
+
+export function computeDatasetDigests(dataset: EvaluationDataset): DatasetDigests {
+  return {
+    datasetRevisionDigest: digestCanonicalJson(dataset),
+    executionInputDigest: digestCanonicalJson({
+      datasetId: dataset.datasetId,
+      samples: projectExecutionInputs(dataset),
+    }),
+    evaluationInputDigest: digestCanonicalJson({
+      datasetId: dataset.datasetId,
+      samples: projectEvaluationInputs(dataset),
+    }),
+  };
+}
+
+export interface ExecutionPlanIdentityInput {
+  executionInputDigest: Sha256Digest;
+  targets: TargetDefinition[];
+  executorRuntimes: ResolvedRuntime[];
+  experiment: ExperimentDesign;
+  policy: {
+    execution: MeasurementPolicy['execution'];
+    retry: MeasurementPolicy['retry'];
+    budget: MeasurementPolicy['budget'];
+    executionCacheMode: MeasurementPolicy['cache']['executionMode'];
+    failure: MeasurementPolicy['failure'];
+  };
+  extensions?: Extensions;
+}
+
+export function computeExecutionPlanDigest(
+  input: ExecutionPlanIdentityInput,
+): Sha256Digest {
+  return digestCanonicalJson({
+    schemaVersion: EXECUTION_PLAN_SCHEMA_VERSION,
+    executionInputDigest: input.executionInputDigest,
+    targets: input.targets,
+    executorRuntimes: input.executorRuntimes,
+    experiment: input.experiment,
+    policy: input.policy,
+    ...(input.extensions !== undefined ? { extensions: input.extensions } : {}),
+  });
+}
+
+export interface EvaluationPlanIdentityInput {
+  executionPlanDigest: Sha256Digest;
+  evaluationInputDigest: Sha256Digest;
+  evaluators: EvaluatorDefinition[];
+  metrics: MetricDefinition[];
+  evaluatorRuntimes: ResolvedRuntime[];
+  policy: {
+    evaluationCacheMode: MeasurementPolicy['cache']['evaluationMode'];
+    evidence: MeasurementPolicy['evidence'];
+    failure: MeasurementPolicy['failure'];
+  };
+  extensions?: Extensions;
+}
+
+export function computeEvaluationPlanDigest(
+  input: EvaluationPlanIdentityInput,
+): Sha256Digest {
+  return digestCanonicalJson({
+    schemaVersion: EVALUATION_PLAN_SCHEMA_VERSION,
+    executionPlanDigest: input.executionPlanDigest,
+    evaluationInputDigest: input.evaluationInputDigest,
+    evaluators: input.evaluators,
+    metrics: input.metrics,
+    evaluatorRuntimes: input.evaluatorRuntimes,
+    policy: input.policy,
+    ...(input.extensions !== undefined ? { extensions: input.extensions } : {}),
+  });
+}
+
+export interface AnalysisPlanIdentityInput {
+  evaluationPlanDigest: Sha256Digest;
+  analysisGraph: AnalysisGraphDefinition;
+  sampling: ExperimentDesign['sampling'];
+  analysisRuntimes: ResolvedRuntime[];
+  extensions?: Extensions;
+}
+
+export function computeAnalysisPlanDigest(
+  input: AnalysisPlanIdentityInput,
+): Sha256Digest {
+  return digestCanonicalJson({
+    schemaVersion: ANALYSIS_PLAN_SCHEMA_VERSION,
+    evaluationPlanDigest: input.evaluationPlanDigest,
+    analysisGraph: input.analysisGraph,
+    sampling: input.sampling,
+    analysisRuntimes: input.analysisRuntimes,
+    ...(input.extensions !== undefined ? { extensions: input.extensions } : {}),
+  });
+}
+
+export interface DecisionPlanIdentityInput {
+  analysisPlanDigest: Sha256Digest;
+  comparisons: ComparisonDefinition[];
+  decisionPolicy?: DecisionPolicyDefinition;
+  extensions?: Extensions;
+}
+
+export function computeDecisionPlanDigest(
+  input: DecisionPlanIdentityInput,
+): Sha256Digest {
+  return digestCanonicalJson({
+    schemaVersion: DECISION_PLAN_SCHEMA_VERSION,
+    analysisPlanDigest: input.analysisPlanDigest,
+    comparisons: input.comparisons,
+    ...(input.decisionPolicy !== undefined
+      ? { decisionPolicy: input.decisionPolicy }
+      : {}),
+    ...(input.extensions !== undefined ? { extensions: input.extensions } : {}),
+  });
+}
+
+export interface RunContractIdentityInput {
+  executionPlanDigest: Sha256Digest;
+  evaluationPlanDigest: Sha256Digest;
+  analysisPlanDigest: Sha256Digest;
+  decisionPlanDigest: Sha256Digest;
+  schemaIdentities: SchemaIdentity[];
+  eventDeliveryPolicy: MeasurementPolicy['eventDelivery'];
+  extensions?: Extensions;
+}
+
+export function computeRunContractDigest(
+  input: RunContractIdentityInput,
+): Sha256Digest {
+  return digestCanonicalJson({
+    schemaVersion: RUN_PLAN_SCHEMA_VERSION,
+    executionPlanDigest: input.executionPlanDigest,
+    evaluationPlanDigest: input.evaluationPlanDigest,
+    analysisPlanDigest: input.analysisPlanDigest,
+    decisionPlanDigest: input.decisionPlanDigest,
+    schemaIdentities: [...input.schemaIdentities].sort((left, right) => {
+      if (left.schemaVersion < right.schemaVersion) return -1;
+      if (left.schemaVersion > right.schemaVersion) return 1;
+      if (left.schemaUri < right.schemaUri) return -1;
+      if (left.schemaUri > right.schemaUri) return 1;
+      if (left.schemaDigest < right.schemaDigest) return -1;
+      if (left.schemaDigest > right.schemaDigest) return 1;
+      return 0;
+    }),
+    eventDeliveryPolicy: input.eventDeliveryPolicy,
+    ...(input.extensions !== undefined ? { extensions: input.extensions } : {}),
+  });
+}
+
+export interface PlanDigestInput {
+  dataset: EvaluationDataset;
+  targets: TargetDefinition[];
+  evaluators: EvaluatorDefinition[];
+  metrics: MetricDefinition[];
+  experiment: ExperimentDesign;
+  analysisGraph: AnalysisGraphDefinition;
+  comparisons: ComparisonDefinition[];
+  decisionPolicy?: DecisionPolicyDefinition;
+  measurementPolicy: MeasurementPolicy;
+  executorRuntimes: ResolvedRuntime[];
+  evaluatorRuntimes: ResolvedRuntime[];
+  analysisRuntimes: ResolvedRuntime[];
+  schemaIdentities: SchemaIdentity[];
+  stageExtensions?: {
+    execution?: Extensions;
+    evaluation?: Extensions;
+    analysis?: Extensions;
+    decision?: Extensions;
+    run?: Extensions;
+  };
+}
+
+export function computePlanDigests(input: PlanDigestInput): PlanDigests {
+  const dataset = computeDatasetDigests(input.dataset);
+  const executionPlanDigest = computeExecutionPlanDigest({
+    executionInputDigest: dataset.executionInputDigest,
+    targets: input.targets,
+    executorRuntimes: input.executorRuntimes,
+    experiment: input.experiment,
+    policy: {
+      execution: input.measurementPolicy.execution,
+      retry: input.measurementPolicy.retry,
+      budget: input.measurementPolicy.budget,
+      executionCacheMode: input.measurementPolicy.cache.executionMode,
+      failure: input.measurementPolicy.failure,
+    },
+    ...(input.stageExtensions?.execution !== undefined
+      ? { extensions: input.stageExtensions.execution }
+      : {}),
+  });
+  const evaluationPlanDigest = computeEvaluationPlanDigest({
+    executionPlanDigest,
+    evaluationInputDigest: dataset.evaluationInputDigest,
+    evaluators: input.evaluators,
+    metrics: input.metrics,
+    evaluatorRuntimes: input.evaluatorRuntimes,
+    policy: {
+      evaluationCacheMode: input.measurementPolicy.cache.evaluationMode,
+      evidence: input.measurementPolicy.evidence,
+      failure: input.measurementPolicy.failure,
+    },
+    ...(input.stageExtensions?.evaluation !== undefined
+      ? { extensions: input.stageExtensions.evaluation }
+      : {}),
+  });
+  const analysisPlanDigest = computeAnalysisPlanDigest({
+    evaluationPlanDigest,
+    analysisGraph: input.analysisGraph,
+    sampling: input.experiment.sampling,
+    analysisRuntimes: input.analysisRuntimes,
+    ...(input.stageExtensions?.analysis !== undefined
+      ? { extensions: input.stageExtensions.analysis }
+      : {}),
+  });
+  const decisionPlanDigest = computeDecisionPlanDigest({
+    analysisPlanDigest,
+    comparisons: input.comparisons,
+    ...(input.decisionPolicy !== undefined
+      ? { decisionPolicy: input.decisionPolicy }
+      : {}),
+    ...(input.stageExtensions?.decision !== undefined
+      ? { extensions: input.stageExtensions.decision }
+      : {}),
+  });
+  const runContractDigest = computeRunContractDigest({
+    executionPlanDigest,
+    evaluationPlanDigest,
+    analysisPlanDigest,
+    decisionPlanDigest,
+    schemaIdentities: input.schemaIdentities,
+    eventDeliveryPolicy: input.measurementPolicy.eventDelivery,
+    ...(input.stageExtensions?.run !== undefined
+      ? { extensions: input.stageExtensions.run }
+      : {}),
+  });
+
+  return {
+    ...dataset,
+    executionPlanDigest,
+    evaluationPlanDigest,
+    analysisPlanDigest,
+    decisionPlanDigest,
+    runContractDigest,
+  };
+}
+
+export function digestArtifactPayload(
+  artifact: unknown,
+  digestField: 'bundleDigest' | 'reportDigest',
+): Sha256Digest {
+  assertCanonicalJson(artifact);
+  if (artifact === null || Array.isArray(artifact) || typeof artifact !== 'object') {
+    throw new TypeError('A Bundle or Report digest payload must be a JSON object.');
+  }
+  const payload = { ...artifact };
+  delete payload[digestField];
+  return digestCanonicalJson(payload);
+}

--- a/src/evaluation-core/contracts/index.ts
+++ b/src/evaluation-core/contracts/index.ts
@@ -1,0 +1,7 @@
+export * from './artifacts.js';
+export * from './common.js';
+export * from './definition.js';
+export * from './digests.js';
+export * from './json-schema.js';
+export * from './json.js';
+export * from './plans.js';

--- a/src/evaluation-core/contracts/json-schema.ts
+++ b/src/evaluation-core/contracts/json-schema.ts
@@ -1,0 +1,148 @@
+import { z } from 'zod';
+import {
+  ANALYSIS_BUNDLE_SCHEMA_VERSION,
+  AnalysisBundleSchema,
+  EVALUATION_BUNDLE_SCHEMA_VERSION,
+  EVALUATION_EVENT_SCHEMA_VERSION,
+  EVALUATION_REPORT_SCHEMA_VERSION,
+  EXECUTION_BUNDLE_SCHEMA_VERSION,
+  EvaluationBundleSchema,
+  EvaluationEventSchema,
+  EvaluationReportSchema,
+  ExecutionBundleSchema,
+} from './artifacts.js';
+import {
+  EVALUATION_DEFINITION_SCHEMA_VERSION,
+  EvaluationDefinitionSchema,
+  MEASUREMENT_POLICY_SCHEMA_VERSION,
+  MeasurementPolicySchema,
+} from './definition.js';
+import { digestCanonicalJson, type JsonValue } from './json.js';
+import {
+  ANALYSIS_PLAN_SCHEMA_VERSION,
+  AnalysisPlanSchema,
+  DECISION_PLAN_SCHEMA_VERSION,
+  DecisionPlanSchema,
+  EVALUATION_PLAN_SCHEMA_VERSION,
+  EXECUTION_PLAN_SCHEMA_VERSION,
+  EvaluationPlanSchema,
+  ExecutionPlanSchema,
+  RUN_PLAN_SCHEMA_VERSION,
+  RunPlanSchema,
+} from './plans.js';
+import type { SchemaIdentity } from './common.js';
+
+export interface WireSchemaCatalogEntry {
+  fileName: string;
+  schemaVersion: string;
+  schema: z.ZodType;
+}
+
+export const WIRE_SCHEMA_CATALOG: readonly WireSchemaCatalogEntry[] = [
+  {
+    fileName: 'evaluation-definition.schema.json',
+    schemaVersion: EVALUATION_DEFINITION_SCHEMA_VERSION,
+    schema: EvaluationDefinitionSchema,
+  },
+  {
+    fileName: 'measurement-policy.schema.json',
+    schemaVersion: MEASUREMENT_POLICY_SCHEMA_VERSION,
+    schema: MeasurementPolicySchema,
+  },
+  {
+    fileName: 'execution-plan.schema.json',
+    schemaVersion: EXECUTION_PLAN_SCHEMA_VERSION,
+    schema: ExecutionPlanSchema,
+  },
+  {
+    fileName: 'evaluation-plan.schema.json',
+    schemaVersion: EVALUATION_PLAN_SCHEMA_VERSION,
+    schema: EvaluationPlanSchema,
+  },
+  {
+    fileName: 'analysis-plan.schema.json',
+    schemaVersion: ANALYSIS_PLAN_SCHEMA_VERSION,
+    schema: AnalysisPlanSchema,
+  },
+  {
+    fileName: 'decision-plan.schema.json',
+    schemaVersion: DECISION_PLAN_SCHEMA_VERSION,
+    schema: DecisionPlanSchema,
+  },
+  {
+    fileName: 'run-plan.schema.json',
+    schemaVersion: RUN_PLAN_SCHEMA_VERSION,
+    schema: RunPlanSchema,
+  },
+  {
+    fileName: 'evaluation-event.schema.json',
+    schemaVersion: EVALUATION_EVENT_SCHEMA_VERSION,
+    schema: EvaluationEventSchema,
+  },
+  {
+    fileName: 'execution-bundle.schema.json',
+    schemaVersion: EXECUTION_BUNDLE_SCHEMA_VERSION,
+    schema: ExecutionBundleSchema,
+  },
+  {
+    fileName: 'evaluation-bundle.schema.json',
+    schemaVersion: EVALUATION_BUNDLE_SCHEMA_VERSION,
+    schema: EvaluationBundleSchema,
+  },
+  {
+    fileName: 'analysis-bundle.schema.json',
+    schemaVersion: ANALYSIS_BUNDLE_SCHEMA_VERSION,
+    schema: AnalysisBundleSchema,
+  },
+  {
+    fileName: 'evaluation-report.schema.json',
+    schemaVersion: EVALUATION_REPORT_SCHEMA_VERSION,
+    schema: EvaluationReportSchema,
+  },
+] as const;
+
+const SCHEMA_BASE_URI = 'https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1';
+
+function assertNoEmptySchemaNode(value: unknown, path = '$'): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoEmptySchemaNode(entry, `${path}[${index}]`));
+    return;
+  }
+  if (value === null || typeof value !== 'object') return;
+  const entries = Object.entries(value);
+  if (entries.length === 0) {
+    throw new Error(`JSON Schema generation produced an unconstrained {} node at ${path}`);
+  }
+  entries.forEach(([key, entry]) => assertNoEmptySchemaNode(entry, `${path}/${key}`));
+}
+
+export function generateWireJsonSchemas(): Readonly<Record<string, JsonValue>> {
+  return Object.fromEntries(WIRE_SCHEMA_CATALOG.map((entry) => {
+    const generated = z.toJSONSchema(entry.schema, {
+      target: 'draft-2020-12',
+      unrepresentable: 'throw',
+      cycles: 'ref',
+      reused: 'ref',
+    });
+    const schemaUri = `${SCHEMA_BASE_URI}/${entry.fileName}`;
+    const schema = { ...generated, $id: schemaUri };
+    assertNoEmptySchemaNode(schema);
+    return [entry.fileName, schema as unknown as JsonValue];
+  }));
+}
+
+export function generateWireSchemaIdentities(): SchemaIdentity[] {
+  const schemas = generateWireJsonSchemas();
+  return WIRE_SCHEMA_CATALOG.map((entry) => {
+    const schema = schemas[entry.fileName] as Record<string, JsonValue>;
+    const schemaUri = schema.$id;
+    if (typeof schemaUri !== 'string') {
+      throw new Error(`${entry.fileName} does not declare a JSON Schema $id`);
+    }
+    return {
+      schemaVersion: entry.schemaVersion,
+      schemaUri,
+      schemaDigest: digestCanonicalJson(schema),
+    };
+  });
+}

--- a/src/evaluation-core/contracts/json.ts
+++ b/src/evaluation-core/contracts/json.ts
@@ -1,0 +1,168 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+
+export type JsonPrimitive = null | boolean | number | string;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() => z.union([
+  z.null(),
+  z.boolean(),
+  z.number(),
+  z.string(),
+  z.array(JsonValueSchema),
+  z.record(z.string(), JsonValueSchema),
+]));
+
+export class InvalidCanonicalJsonError extends TypeError {
+  readonly path: string;
+
+  constructor(path: string, reason: string) {
+    super(`Invalid RFC 8785 JSON value at ${path}: ${reason}`);
+    this.name = 'InvalidCanonicalJsonError';
+    this.path = path;
+  }
+}
+
+function childPath(path: string, key: string | number): string {
+  if (typeof key === 'number') return `${path}[${key}]`;
+  return `${path}/${key.replaceAll('~', '~0').replaceAll('/', '~1')}`;
+}
+
+function assertUnicodeScalarString(value: string, path: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new InvalidCanonicalJsonError(path, 'string contains an unpaired high surrogate');
+      }
+      index += 1;
+      continue;
+    }
+    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      throw new InvalidCanonicalJsonError(path, 'string contains an unpaired low surrogate');
+    }
+  }
+}
+
+function assertDataProperty(
+  owner: object,
+  key: string,
+  path: string,
+): PropertyDescriptor {
+  const descriptor = Object.getOwnPropertyDescriptor(owner, key);
+  if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) {
+    throw new InvalidCanonicalJsonError(path, 'properties must be enumerable data properties');
+  }
+  return descriptor;
+}
+
+function assertCanonicalJsonValue(
+  value: unknown,
+  path: string,
+  ancestors: Set<object>,
+): asserts value is JsonValue {
+  if (value === null || typeof value === 'boolean') return;
+  if (typeof value === 'string') {
+    assertUnicodeScalarString(value, path);
+    return;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new InvalidCanonicalJsonError(path, 'numbers must be finite IEEE 754 doubles');
+    }
+    return;
+  }
+  if (typeof value !== 'object') {
+    throw new InvalidCanonicalJsonError(path, `unsupported ${typeof value} value`);
+  }
+  if (ancestors.has(value)) {
+    throw new InvalidCanonicalJsonError(path, 'cyclic references are not JSON');
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const ownKeys = Reflect.ownKeys(value);
+      if (ownKeys.some((key) => typeof key === 'symbol')) {
+        throw new InvalidCanonicalJsonError(path, 'symbol properties are not JSON');
+      }
+      const stringKeys = ownKeys.filter((key): key is string => typeof key === 'string');
+      const expectedKeys = [...value.keys()].map(String);
+      const nonLengthKeys = stringKeys.filter((key) => key !== 'length');
+      if (
+        value.length !== nonLengthKeys.length
+        || expectedKeys.some((key, index) => nonLengthKeys[index] !== key)
+      ) {
+        throw new InvalidCanonicalJsonError(path, 'arrays must be dense and have no extra properties');
+      }
+      for (let index = 0; index < value.length; index += 1) {
+        const itemPath = childPath(path, index);
+        const descriptor = assertDataProperty(value, String(index), itemPath);
+        assertCanonicalJsonValue(descriptor.value, itemPath, ancestors);
+      }
+      return;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new InvalidCanonicalJsonError(path, 'objects must have Object.prototype or a null prototype');
+    }
+    const ownKeys = Reflect.ownKeys(value);
+    if (ownKeys.some((key) => typeof key === 'symbol')) {
+      throw new InvalidCanonicalJsonError(path, 'symbol properties are not JSON');
+    }
+    for (const key of ownKeys as string[]) {
+      const propertyPath = childPath(path, key);
+      assertUnicodeScalarString(key, propertyPath);
+      const descriptor = assertDataProperty(value, key, propertyPath);
+      assertCanonicalJsonValue(descriptor.value, propertyPath, ancestors);
+    }
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+export function assertCanonicalJson(value: unknown): asserts value is JsonValue {
+  assertCanonicalJsonValue(value, '$', new Set());
+}
+
+export function isCanonicalJson(value: unknown): value is JsonValue {
+  try {
+    assertCanonicalJson(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function parseWireDocument<T>(schema: z.ZodType<T>, value: unknown): T {
+  assertCanonicalJson(value);
+  return schema.parse(value);
+}
+
+function serializeCanonical(value: JsonValue): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(serializeCanonical).join(',')}]`;
+
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${serializeCanonical(value[key])}`)
+    .join(',')}}`;
+}
+
+export function canonicalizeJson(value: unknown): string {
+  assertCanonicalJson(value);
+  return serializeCanonical(value);
+}
+
+export function canonicalizeJsonBytes(value: unknown): Uint8Array {
+  return Buffer.from(canonicalizeJson(value), 'utf8');
+}
+
+export type Sha256Digest = `sha256:${string}`;
+
+export function digestCanonicalJson(value: unknown): Sha256Digest {
+  const hex = createHash('sha256').update(canonicalizeJsonBytes(value)).digest('hex');
+  return `sha256:${hex}`;
+}

--- a/src/evaluation-core/contracts/plans.ts
+++ b/src/evaluation-core/contracts/plans.ts
@@ -1,0 +1,154 @@
+import { z } from 'zod';
+import {
+  ExtensionsSchema,
+  IdentifierSchema,
+  RuntimeIdentitySchema,
+  SchemaIdentitySchema,
+  Sha256DigestSchema,
+} from './common.js';
+import {
+  AnalysisGraphDefinitionSchema,
+  BudgetPolicySchema,
+  CachePolicySchema,
+  ComparisonDefinitionSchema,
+  DecisionPolicyDefinitionSchema,
+  EvidencePolicySchema,
+  EvaluationDefinitionSchema,
+  EvaluationSampleSchema,
+  EvaluatorDefinitionSchema,
+  ExperimentDesignSchema,
+  ExecutionPolicySchema,
+  FailurePolicySchema,
+  MeasurementPolicySchema,
+  MetricDefinitionSchema,
+  RetryPolicySchema,
+  TargetDefinitionSchema,
+} from './definition.js';
+
+export const EXECUTION_PLAN_SCHEMA_VERSION = 'omk.execution-plan/v1' as const;
+export const EVALUATION_PLAN_SCHEMA_VERSION = 'omk.evaluation-plan/v1' as const;
+export const ANALYSIS_PLAN_SCHEMA_VERSION = 'omk.analysis-plan/v1' as const;
+export const DECISION_PLAN_SCHEMA_VERSION = 'omk.decision-plan/v1' as const;
+export const RUN_PLAN_SCHEMA_VERSION = 'omk.run-plan/v1' as const;
+
+export const ExecutionInputSampleSchema = EvaluationSampleSchema.pick({
+  sampleId: true,
+  input: true,
+  executionContext: true,
+}).strict();
+
+export const EvaluationInputSampleSchema = EvaluationSampleSchema.pick({
+  sampleId: true,
+  input: true,
+  executionContext: true,
+  expected: true,
+  evaluationContext: true,
+}).strict();
+
+export const ResolvedRuntimeSchema = z.object({
+  runtimeKind: z.enum(['executor', 'evaluator', 'analysis']),
+  referenceId: IdentifierSchema,
+  identity: RuntimeIdentitySchema,
+}).strict();
+
+export const ExecutionPlanPolicySchema = z.object({
+  execution: ExecutionPolicySchema,
+  retry: RetryPolicySchema,
+  budget: BudgetPolicySchema,
+  executionCacheMode: CachePolicySchema.shape.executionMode,
+  failure: FailurePolicySchema,
+}).strict();
+
+export const EvaluationPlanPolicySchema = z.object({
+  evaluationCacheMode: CachePolicySchema.shape.evaluationMode,
+  evidence: EvidencePolicySchema,
+  failure: FailurePolicySchema,
+}).strict();
+
+export const ExecutionPlanSchema = z.object({
+  schemaVersion: z.literal(EXECUTION_PLAN_SCHEMA_VERSION),
+  executionInputDigest: Sha256DigestSchema,
+  samples: z.array(ExecutionInputSampleSchema).min(1),
+  targets: z.array(TargetDefinitionSchema).min(1),
+  experiment: ExperimentDesignSchema,
+  runtimes: z.array(ResolvedRuntimeSchema),
+  policy: ExecutionPlanPolicySchema,
+  executionPlanDigest: Sha256DigestSchema,
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Execution Plan v1',
+});
+
+export const EvaluationPlanSchema = z.object({
+  schemaVersion: z.literal(EVALUATION_PLAN_SCHEMA_VERSION),
+  executionPlanDigest: Sha256DigestSchema,
+  evaluationInputDigest: Sha256DigestSchema,
+  samples: z.array(EvaluationInputSampleSchema).min(1),
+  evaluators: z.array(EvaluatorDefinitionSchema),
+  metrics: z.array(MetricDefinitionSchema),
+  runtimes: z.array(ResolvedRuntimeSchema),
+  policy: EvaluationPlanPolicySchema,
+  evaluationPlanDigest: Sha256DigestSchema,
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Evaluation Plan v1',
+});
+
+export const AnalysisPlanSchema = z.object({
+  schemaVersion: z.literal(ANALYSIS_PLAN_SCHEMA_VERSION),
+  evaluationPlanDigest: Sha256DigestSchema,
+  analysisGraph: AnalysisGraphDefinitionSchema,
+  sampling: ExperimentDesignSchema.shape.sampling,
+  runtimes: z.array(ResolvedRuntimeSchema),
+  analysisPlanDigest: Sha256DigestSchema,
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Analysis Plan v1',
+});
+
+export const DecisionPlanSchema = z.object({
+  schemaVersion: z.literal(DECISION_PLAN_SCHEMA_VERSION),
+  analysisPlanDigest: Sha256DigestSchema,
+  comparisons: z.array(ComparisonDefinitionSchema),
+  decisionPolicy: DecisionPolicyDefinitionSchema.optional(),
+  decisionPlanDigest: Sha256DigestSchema,
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Decision Plan v1',
+});
+
+export const PlanDigestsSchema = z.object({
+  datasetRevisionDigest: Sha256DigestSchema,
+  executionInputDigest: Sha256DigestSchema,
+  evaluationInputDigest: Sha256DigestSchema,
+  executionPlanDigest: Sha256DigestSchema,
+  evaluationPlanDigest: Sha256DigestSchema,
+  analysisPlanDigest: Sha256DigestSchema,
+  decisionPlanDigest: Sha256DigestSchema,
+  runContractDigest: Sha256DigestSchema,
+}).strict();
+
+export const RunPlanSchema = z.object({
+  schemaVersion: z.literal(RUN_PLAN_SCHEMA_VERSION),
+  definition: EvaluationDefinitionSchema,
+  measurementPolicy: MeasurementPolicySchema,
+  execution: ExecutionPlanSchema,
+  evaluation: EvaluationPlanSchema,
+  analysis: AnalysisPlanSchema,
+  decision: DecisionPlanSchema,
+  schemaIdentities: z.array(SchemaIdentitySchema).min(1),
+  digests: PlanDigestsSchema,
+  extensions: ExtensionsSchema.optional(),
+}).strict().meta({
+  title: 'OMK Run Plan v1',
+});
+
+export type ExecutionInputSample = z.infer<typeof ExecutionInputSampleSchema>;
+export type EvaluationInputSample = z.infer<typeof EvaluationInputSampleSchema>;
+export type ResolvedRuntime = z.infer<typeof ResolvedRuntimeSchema>;
+export type ExecutionPlan = z.infer<typeof ExecutionPlanSchema>;
+export type EvaluationPlan = z.infer<typeof EvaluationPlanSchema>;
+export type AnalysisPlan = z.infer<typeof AnalysisPlanSchema>;
+export type DecisionPlan = z.infer<typeof DecisionPlanSchema>;
+export type PlanDigests = z.infer<typeof PlanDigestsSchema>;
+export type RunPlan = z.infer<typeof RunPlanSchema>;

--- a/test/architecture/import-boundaries.test.ts
+++ b/test/architecture/import-boundaries.test.ts
@@ -33,6 +33,46 @@ interface ForbiddenRule {
 
 const RULES: ForbiddenRule[] = [
   {
+    from: 'evaluation-core/',
+    to: 'eval-core/',
+    reason: 'Evaluation Core vNext 必须与旧 eval-core pipeline 物理隔离，旧实现只作为算法与失败案例参考。',
+  },
+  {
+    from: 'evaluation-core/',
+    to: 'eval-workflows/',
+    reason: 'Evaluation Core vNext 是宿主无关内核，不依赖旧 workflow 装配层。',
+  },
+  {
+    from: 'evaluation-core/',
+    to: 'types/',
+    reason: 'Evaluation Core vNext 拥有独立 wire contracts，不复用历史 public schema 或领域 DTO。',
+  },
+  {
+    from: 'evaluation-core/',
+    to: 'cli/',
+    reason: 'Evaluation Core vNext 不得依赖 CLI、配置或命令装配。',
+  },
+  {
+    from: 'evaluation-core/',
+    to: 'executors/',
+    reason: 'Contracts 只描述 Runtime identity 与 capability，不依赖具体 executor 实现。',
+  },
+  {
+    from: 'evaluation-core/',
+    to: 'grading/',
+    reason: 'Evaluation Core vNext 的 Evaluator／Metric 契约不复用旧 grading pipeline。',
+  },
+  {
+    from: 'evaluation-core/',
+    to: 'server/',
+    reason: 'Evaluation Core vNext 不依赖持久化、HTTP 或 Studio host。',
+  },
+  {
+    from: 'evaluation-core/',
+    to: 'renderer/',
+    reason: 'Bundle 是事实契约，Report renderer 属于宿主物化视图。',
+  },
+  {
     from: 'types/',
     to: 'eval-core/',
     reason: 'types/ 是底层契约层,不应反向 import 业务实现 (eval-core)。DTO 应该下沉到 types/。',

--- a/test/evaluation-core/contracts/digests.test.ts
+++ b/test/evaluation-core/contracts/digests.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EVALUATION_DEFINITION_SCHEMA_VERSION,
+  MEASUREMENT_POLICY_SCHEMA_VERSION,
+  computeDatasetDigests,
+  computePlanDigests,
+  computeRunContractDigest,
+  digestArtifactPayload,
+  digestCanonicalJson,
+  generateWireSchemaIdentities,
+  projectEvaluationInputs,
+  projectExecutionInputs,
+  type EvaluationDataset,
+  type EvaluationDefinition,
+  type MeasurementPolicy,
+} from '../../../src/evaluation-core/contracts/index.js';
+
+const dataset: EvaluationDataset = {
+  datasetId: 'support-cases',
+  samples: [{
+    sampleId: 's1',
+    input: { question: 'Q' },
+    executionContext: { locale: 'zh-CN' },
+    expected: { answer: 'A' },
+    evaluationContext: { rubric: 'correctness' },
+    annotations: { owner: 'team-a' },
+  }],
+  annotations: { project: 'omk' },
+};
+
+const policy: MeasurementPolicy = {
+  schemaVersion: MEASUREMENT_POLICY_SCHEMA_VERSION,
+  execution: { maxConcurrency: 2, timeoutMs: 10_000 },
+  retry: {
+    maxAttempts: 1,
+    retryableErrorCodes: [],
+    backoff: { backoffKind: 'none', initialDelayMs: 0 },
+  },
+  budget: {},
+  cache: { executionMode: 'disabled', evaluationMode: 'disabled' },
+  evidence: {
+    input: 'digest',
+    output: 'full',
+    trace: 'reference',
+    expected: 'digest',
+    evidence: 'full',
+    maximumClassification: 'gold',
+  },
+  failure: { failureMode: 'continue' },
+  eventDelivery: {
+    writerMode: 'disabled',
+    backpressureMode: 'block',
+    writerFailureMode: 'ignore',
+  },
+};
+
+const definition: EvaluationDefinition = {
+  schemaVersion: EVALUATION_DEFINITION_SCHEMA_VERSION,
+  dataset,
+  targets: [{
+    targetId: 'control',
+    targetKind: 'function',
+    protocolId: 'omk.invoke/v1',
+    executorId: 'local',
+  }],
+  evaluators: [{
+    evaluatorId: 'exact',
+    evaluatorKind: 'assertion',
+    implementationId: 'exact/v1',
+    metricIds: ['correct'],
+    inputs: [
+      { bindingId: 'output', sourceKind: 'output', pointer: '' },
+      { bindingId: 'expected', sourceKind: 'expected', pointer: '' },
+    ],
+  }],
+  metrics: [{
+    metricId: 'correct',
+    valueType: 'boolean',
+    scope: 'sample',
+    direction: 'higher-is-better',
+    missingPolicyId: 'exclude/v1',
+  }],
+  experiment: {
+    trials: 1,
+    seed: 'seed-1',
+    sampling: {
+      experimentalUnit: 'sample',
+      repeatedMeasures: false,
+      resamplingUnit: 'sample',
+      estimatorId: 'bootstrap.mean-percentile/v1',
+    },
+    scheduling: { schedulingKind: 'sequential' },
+  },
+  analysisGraph: { nodes: [] },
+  comparisons: [],
+};
+
+function planDigests(current: EvaluationDefinition, currentPolicy = policy) {
+  return computePlanDigests({
+    dataset: current.dataset,
+    targets: current.targets,
+    evaluators: current.evaluators,
+    metrics: current.metrics,
+    experiment: current.experiment,
+    analysisGraph: current.analysisGraph,
+    comparisons: current.comparisons,
+    decisionPolicy: current.decisionPolicy,
+    measurementPolicy: currentPolicy,
+    executorRuntimes: [],
+    evaluatorRuntimes: [],
+    analysisRuntimes: [],
+    schemaIdentities: generateWireSchemaIdentities(),
+  });
+}
+
+describe('Evaluation Core layered digests', () => {
+  it('projects Gold away from executor-visible inputs', () => {
+    expect(projectExecutionInputs(dataset)).toEqual([{
+      sampleId: 's1',
+      input: { question: 'Q' },
+      executionContext: { locale: 'zh-CN' },
+    }]);
+    expect(projectEvaluationInputs(dataset)[0]).toMatchObject({
+      expected: { answer: 'A' },
+      evaluationContext: { rubric: 'correctness' },
+    });
+    expect(projectEvaluationInputs(dataset)[0]).not.toHaveProperty('annotations');
+  });
+
+  it('changes lineage and evaluation identities for Gold without changing execution identity', () => {
+    const first = computeDatasetDigests(dataset);
+    const changedGold: EvaluationDataset = {
+      ...dataset,
+      samples: [{ ...dataset.samples[0], expected: { answer: 'B' } }],
+    };
+    const second = computeDatasetDigests(changedGold);
+
+    expect(second.datasetRevisionDigest).not.toBe(first.datasetRevisionDigest);
+    expect(second.evaluationInputDigest).not.toBe(first.evaluationInputDigest);
+    expect(second.executionInputDigest).toBe(first.executionInputDigest);
+  });
+
+  it('keeps audit annotations out of all measurement plan digests', () => {
+    const first = planDigests(definition);
+    const annotated: EvaluationDefinition = {
+      ...definition,
+      dataset: {
+        ...definition.dataset,
+        annotations: { project: 'changed' },
+        samples: [{ ...definition.dataset.samples[0], annotations: { owner: 'team-b' } }],
+      },
+    };
+    const second = planDigests(annotated);
+
+    expect(second.datasetRevisionDigest).not.toBe(first.datasetRevisionDigest);
+    expect(second.executionPlanDigest).toBe(first.executionPlanDigest);
+    expect(second.evaluationPlanDigest).toBe(first.evaluationPlanDigest);
+    expect(second.analysisPlanDigest).toBe(first.analysisPlanDigest);
+    expect(second.decisionPlanDigest).toBe(first.decisionPlanDigest);
+    expect(second.runContractDigest).toBe(first.runContractDigest);
+  });
+
+  it('invalidates only Evaluation and downstream plans when an evaluator changes', () => {
+    const first = planDigests(definition);
+    const changed: EvaluationDefinition = {
+      ...definition,
+      evaluators: [{ ...definition.evaluators[0], implementationId: 'exact/v2' }],
+    };
+    const second = planDigests(changed);
+
+    expect(second.executionPlanDigest).toBe(first.executionPlanDigest);
+    expect(second.evaluationPlanDigest).not.toBe(first.evaluationPlanDigest);
+    expect(second.analysisPlanDigest).not.toBe(first.analysisPlanDigest);
+    expect(second.decisionPlanDigest).not.toBe(first.decisionPlanDigest);
+  });
+
+  it('invalidates Execution and every downstream plan when execution policy changes', () => {
+    const first = planDigests(definition);
+    const changedPolicy: MeasurementPolicy = {
+      ...policy,
+      execution: { ...policy.execution, timeoutMs: 20_000 },
+    };
+    const second = planDigests(definition, changedPolicy);
+
+    expect(second.executionPlanDigest).not.toBe(first.executionPlanDigest);
+    expect(second.evaluationPlanDigest).not.toBe(first.evaluationPlanDigest);
+    expect(second.analysisPlanDigest).not.toBe(first.analysisPlanDigest);
+    expect(second.decisionPlanDigest).not.toBe(first.decisionPlanDigest);
+  });
+
+  it('keeps evaluation cache policy out of Execution identity', () => {
+    const first = planDigests(definition);
+    const changedPolicy: MeasurementPolicy = {
+      ...policy,
+      cache: { ...policy.cache, evaluationMode: 'reuse' },
+    };
+    const second = planDigests(definition, changedPolicy);
+
+    expect(second.executionPlanDigest).toBe(first.executionPlanDigest);
+    expect(second.evaluationPlanDigest).not.toBe(first.evaluationPlanDigest);
+    expect(second.analysisPlanDigest).not.toBe(first.analysisPlanDigest);
+    expect(second.decisionPlanDigest).not.toBe(first.decisionPlanDigest);
+  });
+
+  it('keeps EventWriter delivery policy out of stage identities but binds the root contract', () => {
+    const first = planDigests(definition);
+    const changedPolicy: MeasurementPolicy = {
+      ...policy,
+      eventDelivery: {
+        writerMode: 'required',
+        backpressureMode: 'block',
+        writerFailureMode: 'fail-run',
+      },
+    };
+    const second = planDigests(definition, changedPolicy);
+
+    expect(second.executionPlanDigest).toBe(first.executionPlanDigest);
+    expect(second.evaluationPlanDigest).toBe(first.evaluationPlanDigest);
+    expect(second.analysisPlanDigest).toBe(first.analysisPlanDigest);
+    expect(second.decisionPlanDigest).toBe(first.decisionPlanDigest);
+    expect(second.runContractDigest).not.toBe(first.runContractDigest);
+  });
+
+  it('invalidates Execution and every downstream plan when an executor fingerprint changes', () => {
+    const identities = generateWireSchemaIdentities();
+    const base = {
+      dataset: definition.dataset,
+      targets: definition.targets,
+      evaluators: definition.evaluators,
+      metrics: definition.metrics,
+      experiment: definition.experiment,
+      analysisGraph: definition.analysisGraph,
+      comparisons: definition.comparisons,
+      measurementPolicy: policy,
+      evaluatorRuntimes: [],
+      analysisRuntimes: [],
+      schemaIdentities: identities,
+    };
+    const runtime = {
+      runtimeKind: 'executor' as const,
+      referenceId: 'local',
+      identity: {
+        implementationId: 'local/v1',
+        fingerprint: `sha256:${'1'.repeat(64)}`,
+        fingerprintBasis: 'content-derived' as const,
+        assuranceLevel: 'verified' as const,
+        capabilities: {},
+      },
+    };
+    const first = computePlanDigests({ ...base, executorRuntimes: [runtime] });
+    const second = computePlanDigests({
+      ...base,
+      executorRuntimes: [{
+        ...runtime,
+        identity: { ...runtime.identity, fingerprint: `sha256:${'2'.repeat(64)}` },
+      }],
+    });
+
+    expect(second.executionPlanDigest).not.toBe(first.executionPlanDigest);
+    expect(second.evaluationPlanDigest).not.toBe(first.evaluationPlanDigest);
+    expect(second.analysisPlanDigest).not.toBe(first.analysisPlanDigest);
+    expect(second.decisionPlanDigest).not.toBe(first.decisionPlanDigest);
+  });
+
+  it('invalidates only Analysis and Decision when the analysis graph changes', () => {
+    const first = planDigests(definition);
+    const changed: EvaluationDefinition = {
+      ...definition,
+      analysisGraph: {
+        nodes: [{
+          analysisNodeKind: 'reducer',
+          nodeId: 'mean-correct',
+          implementationId: 'descriptive.mean/v1',
+          inputs: [{ inputKind: 'metric-observations', referenceId: 'correct' }],
+          outputResultId: 'mean-correct',
+        }],
+      },
+    };
+    const second = planDigests(changed);
+
+    expect(second.executionPlanDigest).toBe(first.executionPlanDigest);
+    expect(second.evaluationPlanDigest).toBe(first.evaluationPlanDigest);
+    expect(second.analysisPlanDigest).not.toBe(first.analysisPlanDigest);
+    expect(second.decisionPlanDigest).not.toBe(first.decisionPlanDigest);
+  });
+
+  it('invalidates only Decision when a comparison changes', () => {
+    const first = planDigests(definition);
+    const changed: EvaluationDefinition = {
+      ...definition,
+      comparisons: [{
+        comparisonId: 'control-vs-treatment',
+        controlTargetId: 'control',
+        treatmentTargetIds: ['treatment'],
+        metricIds: ['correct'],
+      }],
+    };
+    const second = planDigests(changed);
+
+    expect(second.executionPlanDigest).toBe(first.executionPlanDigest);
+    expect(second.evaluationPlanDigest).toBe(first.evaluationPlanDigest);
+    expect(second.analysisPlanDigest).toBe(first.analysisPlanDigest);
+    expect(second.decisionPlanDigest).not.toBe(first.decisionPlanDigest);
+  });
+
+  it('computes Bundle and Report identities without self-referencing digest fields', () => {
+    const artifact = {
+      schemaVersion: 'omk.example/v1',
+      value: { answer: 42 },
+      bundleDigest: `sha256:${'a'.repeat(64)}`,
+    };
+
+    expect(digestArtifactPayload(artifact, 'bundleDigest')).toBe(digestCanonicalJson({
+      schemaVersion: 'omk.example/v1',
+      value: { answer: 42 },
+    }));
+  });
+
+  it('treats schema identities as an order-independent set in the root contract', () => {
+    const schemaIdentities = generateWireSchemaIdentities();
+    const digest = `sha256:${'a'.repeat(64)}` as const;
+    const input = {
+      executionPlanDigest: digest,
+      evaluationPlanDigest: digest,
+      analysisPlanDigest: digest,
+      decisionPlanDigest: digest,
+      eventDeliveryPolicy: policy.eventDelivery,
+    };
+
+    expect(computeRunContractDigest({ ...input, schemaIdentities })).toBe(
+      computeRunContractDigest({ ...input, schemaIdentities: [...schemaIdentities].reverse() }),
+    );
+  });
+});

--- a/test/evaluation-core/contracts/json.test.ts
+++ b/test/evaluation-core/contracts/json.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InvalidCanonicalJsonError,
+  canonicalizeJson,
+  digestCanonicalJson,
+  isCanonicalJson,
+} from '../../../src/evaluation-core/contracts/json.js';
+
+describe('Evaluation Core RFC 8785 JSON', () => {
+  it('matches the RFC 8785 primitive serialization example', () => {
+    const input = {
+      numbers: [333333333.33333329, 1e30, 4.50, 2e-3, 1e-27],
+      string: '€$\u000f\nA\'B"\\\\"/',
+      literals: [null, true, false],
+    };
+
+    expect(canonicalizeJson(input)).toBe(
+      '{"literals":[null,true,false],"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27],"string":"€$\\u000f\\nA\'B\\"\\\\\\\\\\"/"}',
+    );
+  });
+
+  it('sorts object names by raw UTF-16 code units and preserves array order', () => {
+    const value = {
+      '\u20ac': 'Euro Sign',
+      '\r': 'Carriage Return',
+      '\ufb33': 'Hebrew Letter Dalet With Dagesh',
+      1: 'One',
+      '😀': 'Emoji: Grinning Face',
+      '\u0080': 'Control',
+      ö: 'Latin Small Letter O With Diaeresis',
+      nested: [{ z: 1, a: 2 }],
+    };
+
+    const canonical = canonicalizeJson(value);
+    const expectedOrder = [
+      '\r',
+      '1',
+      'nested',
+      '\u0080',
+      'ö',
+      '€',
+      '😀',
+      'דּ',
+    ];
+    const offsets = expectedOrder.map((key) => canonical.indexOf(`${JSON.stringify(key)}:`));
+    expect(offsets).toEqual([...offsets].sort((left, right) => left - right));
+    const parsed = JSON.parse(canonical);
+    expect(parsed.nested).toEqual([{ a: 2, z: 1 }]);
+  });
+
+  it('produces stable full sha256 digests independent of property order', () => {
+    const first = digestCanonicalJson({ b: 2, a: { y: 2, x: 1 } });
+    const second = digestCanonicalJson({ a: { x: 1, y: 2 }, b: 2 });
+
+    expect(first).toBe(second);
+    expect(first).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it.each([
+    NaN,
+    Infinity,
+    -Infinity,
+    undefined,
+    1n,
+    Symbol('x'),
+    () => undefined,
+    new Date(),
+  ])('rejects non-I-JSON value %s', (value) => {
+    expect(() => canonicalizeJson(value)).toThrow(InvalidCanonicalJsonError);
+    expect(isCanonicalJson(value)).toBe(false);
+  });
+
+  it('rejects cycles, sparse arrays, extra properties, accessors, and symbols', () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const sparse = Array(2);
+    const withExtra = [1] as number[] & { extra?: number };
+    withExtra.extra = 2;
+    const accessor = {};
+    Object.defineProperty(accessor, 'value', { enumerable: true, get: () => 1 });
+    const symbolProperty = { value: 1, [Symbol('secret')]: 2 };
+
+    for (const value of [cyclic, sparse, withExtra, accessor, symbolProperty]) {
+      expect(() => canonicalizeJson(value)).toThrow(InvalidCanonicalJsonError);
+    }
+  });
+
+  it('rejects unpaired Unicode surrogates in values and property names', () => {
+    expect(() => canonicalizeJson('\ud800')).toThrow(/unpaired high surrogate/);
+    expect(() => canonicalizeJson('\udc00')).toThrow(/unpaired low surrogate/);
+    expect(() => canonicalizeJson({ ['\ud800']: true })).toThrow(/unpaired high surrogate/);
+  });
+
+  it('uses the ECMAScript representation for negative zero', () => {
+    expect(canonicalizeJson(-0)).toBe('0');
+  });
+});

--- a/test/evaluation-core/contracts/schemas.test.ts
+++ b/test/evaluation-core/contracts/schemas.test.ts
@@ -1,0 +1,170 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import _Ajv2020 from 'ajv/dist/2020.js';
+import { describe, expect, it } from 'vitest';
+import {
+  EVALUATION_DEFINITION_SCHEMA_VERSION,
+  EvaluationDefinitionSchema,
+  EvaluationStatusSchema,
+  MetricObservationSchema,
+  RuntimeIdentitySchema,
+  WIRE_SCHEMA_CATALOG,
+  canonicalizeJson,
+  generateWireJsonSchemas,
+  generateWireSchemaIdentities,
+  parseWireDocument,
+} from '../../../src/evaluation-core/contracts/index.js';
+
+const Ajv2020 = _Ajv2020 as unknown as typeof _Ajv2020.default;
+
+describe('Evaluation Core wire schemas', () => {
+  it('exports every catalog entry as deterministic JSON Schema 2020-12', () => {
+    const generated = generateWireJsonSchemas();
+    const schemaDir = resolve('schemas/evaluation-core/v1');
+    const files = readdirSync(schemaDir).filter((name) => name.endsWith('.schema.json')).sort();
+
+    expect(files).toEqual(WIRE_SCHEMA_CATALOG.map((entry) => entry.fileName).sort());
+    for (const [fileName, schema] of Object.entries(generated)) {
+      expect(schema).toMatchObject({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+      });
+      expect(JSON.parse(readFileSync(resolve(schemaDir, fileName), 'utf8'))).toEqual(schema);
+      expect(canonicalizeJson(schema)).not.toContain(':{}');
+    }
+  });
+
+  it('compiles every generated schema with a JSON Schema 2020-12 validator', () => {
+    for (const schema of Object.values(generateWireJsonSchemas())) {
+      const ajv = new Ajv2020({ strict: false });
+      expect(() => ajv.compile(schema as object)).not.toThrow();
+    }
+  });
+
+  it('derives full schema identities from generated schema bytes', () => {
+    const identities = generateWireSchemaIdentities();
+    expect(identities).toHaveLength(WIRE_SCHEMA_CATALOG.length);
+    expect(new Set(identities.map((identity) => identity.schemaVersion)).size).toBe(identities.length);
+    expect(identities.every((identity) => /^sha256:[0-9a-f]{64}$/.test(identity.schemaDigest))).toBe(true);
+  });
+
+  it('keeps opaque Runtime fingerprints distinct from OMK content digests', () => {
+    expect(RuntimeIdentitySchema.parse({
+      implementationId: 'remote-model',
+      fingerprint: 'provider-deployment:2026-08-28',
+      fingerprintBasis: 'opaque',
+      assuranceLevel: 'declared',
+      capabilities: {},
+    }).fingerprint).toBe('provider-deployment:2026-08-28');
+  });
+
+  it('rejects unknown Definition fields and non-JSON values', () => {
+    const base = {
+      schemaVersion: EVALUATION_DEFINITION_SCHEMA_VERSION,
+      dataset: { datasetId: 'd', samples: [{ sampleId: 's', input: null }] },
+      targets: [{
+        targetId: 't',
+        targetKind: 'function',
+        protocolId: 'omk.invoke/v1',
+        executorId: 'e',
+      }],
+      evaluators: [],
+      metrics: [],
+      experiment: {
+        trials: 1,
+        seed: 'seed',
+        sampling: {
+          experimentalUnit: 'sample',
+          repeatedMeasures: false,
+          resamplingUnit: 'sample',
+          estimatorId: 'bootstrap.mean-percentile/v1',
+        },
+        scheduling: { schedulingKind: 'sequential' },
+      },
+      analysisGraph: { nodes: [] },
+      comparisons: [],
+    };
+
+    expect(EvaluationDefinitionSchema.safeParse({ ...base, typo: true }).success).toBe(false);
+    expect(EvaluationDefinitionSchema.safeParse({
+      ...base,
+      dataset: { datasetId: 'd', samples: [{ sampleId: 's', input: () => null }] },
+    }).success).toBe(false);
+    const withAccessor = {
+      ...base,
+      dataset: { datasetId: 'd', samples: [{ sampleId: 's', input: {} }] },
+    };
+    Object.defineProperty(withAccessor.dataset.samples[0].input, 'hidden', {
+      enumerable: true,
+      get: () => 'effectful',
+    });
+    expect(() => parseWireDocument(EvaluationDefinitionSchema, withAccessor)).toThrow(
+      /enumerable data properties/,
+    );
+  });
+
+  it('keeps Metric values native and represents missing separately from zero', () => {
+    expect(MetricObservationSchema.parse({
+      observationId: 'o1',
+      metricId: 'score',
+      observationStatus: 'observed',
+      valueType: 'numeric',
+      value: 0,
+    })).toMatchObject({ observationStatus: 'observed', value: 0 });
+    expect(MetricObservationSchema.parse({
+      observationId: 'o2',
+      metricId: 'score',
+      observationStatus: 'missing',
+      valueType: 'numeric',
+      reasonCode: 'evaluator-error',
+    })).not.toHaveProperty('value');
+  });
+
+  it('allows all three status axes to vary independently', () => {
+    expect(EvaluationStatusSchema.parse({
+      runStatus: 'completed',
+      evidenceStatus: 'partial',
+      conclusionStatus: 'inconclusive',
+    })).toEqual({
+      runStatus: 'completed',
+      evidenceStatus: 'partial',
+      conclusionStatus: 'inconclusive',
+    });
+  });
+
+  it('accepts only URI-namespaced extensions with declared schemas and digests', () => {
+    const digest = `sha256:${'a'.repeat(64)}`;
+    const parsed = EvaluationDefinitionSchema.safeParse({
+      schemaVersion: EVALUATION_DEFINITION_SCHEMA_VERSION,
+      dataset: { datasetId: 'd', samples: [{ sampleId: 's', input: null }] },
+      targets: [{
+        targetId: 't',
+        targetKind: 'function',
+        protocolId: 'omk.invoke/v1',
+        executorId: 'e',
+      }],
+      evaluators: [],
+      metrics: [],
+      experiment: {
+        trials: 1,
+        seed: 'seed',
+        sampling: {
+          experimentalUnit: 'sample',
+          repeatedMeasures: false,
+          resamplingUnit: 'sample',
+          estimatorId: 'bootstrap.mean-percentile/v1',
+        },
+        scheduling: { schedulingKind: 'sequential' },
+      },
+      analysisGraph: { nodes: [] },
+      comparisons: [],
+      extensions: {
+        'urn:example:attestation': {
+          schemaUri: 'https://example.com/attestation.schema.json',
+          schemaDigest: digest,
+          data: { statement: 'opaque until a host verifies it' },
+        },
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## 用户影响

建立 Evaluation Core vNext 的首版可执行 Contracts 基线。后续 Compiler、Execution 与 Evaluation／Analysis 可以依赖稳定的 Definition、Plan、Bundle、Observation、Event、Report、schema version 和分层 digest 语义，不再借用旧 CLI pipeline 的文件型领域模型。

当前 CLI、Studio 和历史 Report 行为不变；本 PR 不暴露最终包根 façade。

## 架构边界

- 新 Core 隔离在 `src/evaluation-core/`，架构守门禁止其反向依赖旧 `src/eval-core/`、workflow、CLI、executor、grading、renderer、server 或历史 public schema；
- Zod 4 是 TypeScript／runtime wire contract 的单一来源，生成并提交十二个 JSON Schema 2020-12 根契约；构建会拒绝 schema 漂移与不可表达的 `{}` 降级；
- Wire 入口先校验 I-JSON／RFC 8785 JCS 输入，再执行领域 schema；canonical UTF-8 bytes 使用完整 `sha256:<hex>`；
- Dataset、Execution、Evaluation、Analysis、Decision 与根 Run contract 使用分层 identity；Gold、annotations、cache 和 EventDeliveryPolicy 按各自阶段边界失效；
- Runtime fingerprint、provenance trust、fingerprint basis 和 assurance level 与内容 digest 分离，Core v1 不内建签名。

## 测量学说明

MetricObservation 保留原生值域，missing／invalid 不折算为零。`runStatus`、`evidenceStatus`、`conclusionStatus` 保持正交；`completed` 不隐含证据完整或结论成立。

Digest 只证明规范化内容身份，不证明来源真实性或可复现性。原始 JSON 文本的重复属性名必须由宿主在构造 JavaScript 值前拒绝；普通 `JSON.parse()` 后无法恢复该信息。

## 迁移说明

无历史兼容或数据迁移。本实现与旧 API、Sample 和 Report schema 物理隔离；包根 façade 继续由 #424 跟踪。

## 验证

`yarn lint`、`yarn build`、`yarn docs:build`、`yarn test` 全部通过；全量测试为 261 个文件、3118 个测试。

Closes #427

Part of #425
