### PR TITLE
feat(eval-core): 编译并封存不可变 RunPlan

### DIFF
--- a/src/evaluation-core/compiler/errors.ts
+++ b/src/evaluation-core/compiler/errors.ts
@@ -1,0 +1,72 @@
+import type { EvaluationError, JsonValue } from '../contracts/index.js';
+
+export type EvaluationDefinitionErrorCode =
+  | 'EVAL_DEFINITION_SCHEMA_INVALID'
+  | 'EVAL_DEFINITION_DUPLICATE_ID'
+  | 'EVAL_DEFINITION_MISSING_REFERENCE'
+  | 'EVAL_DEFINITION_GRAPH_CYCLE'
+  | 'EVAL_DEFINITION_VALUE_DOMAIN_INVALID'
+  | 'EVAL_DEFINITION_POLICY_INVALID'
+  | 'EVAL_DEFINITION_PROTOCOL_INVALID'
+  | 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED'
+  | 'EVAL_DEFINITION_RUNTIME_RESOLUTION_FAILED'
+  | 'EVAL_DEFINITION_EXTENSION_INVALID';
+
+export type PreparationStage =
+  | 'schema'
+  | 'semantics'
+  | 'runtime-resolution'
+  | 'extension-resolution'
+  | 'sealing';
+
+interface EvaluationDefinitionErrorOptions {
+  code: EvaluationDefinitionErrorCode;
+  stage: 'configuration' | 'infrastructure' | 'internal';
+  preparationStage: PreparationStage;
+  message: string;
+  details?: JsonValue;
+  causes?: EvaluationError[];
+}
+
+export class EvaluationDefinitionError extends Error implements EvaluationError {
+  readonly code: EvaluationDefinitionErrorCode;
+  readonly stage: 'configuration' | 'infrastructure' | 'internal';
+  readonly preparationStage: PreparationStage;
+  readonly details?: JsonValue;
+  readonly causes?: EvaluationError[];
+
+  constructor(options: EvaluationDefinitionErrorOptions) {
+    super(options.message);
+    this.name = 'EvaluationDefinitionError';
+    this.code = options.code;
+    this.stage = options.stage;
+    this.preparationStage = options.preparationStage;
+    this.details = options.details;
+    this.causes = options.causes;
+  }
+
+  toJSON(): EvaluationError & { preparationStage: PreparationStage } {
+    return {
+      code: this.code,
+      stage: this.stage,
+      message: this.message,
+      preparationStage: this.preparationStage,
+      ...(this.details !== undefined ? { details: this.details } : {}),
+      ...(this.causes !== undefined ? { causes: this.causes } : {}),
+    };
+  }
+}
+
+export function definitionError(
+  code: EvaluationDefinitionErrorCode,
+  message: string,
+  details?: JsonValue,
+): EvaluationDefinitionError {
+  return new EvaluationDefinitionError({
+    code,
+    stage: 'configuration',
+    preparationStage: 'semantics',
+    message,
+    ...(details !== undefined ? { details } : {}),
+  });
+}

--- a/src/evaluation-core/compiler/immutability.ts
+++ b/src/evaluation-core/compiler/immutability.ts
@@ -1,0 +1,12 @@
+import { assertCanonicalJson } from '../contracts/index.js';
+
+export function snapshotJson<T>(value: T): T {
+  assertCanonicalJson(value);
+  return structuredClone(value);
+}
+
+export function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+  return Object.freeze(value);
+}

--- a/src/evaluation-core/compiler/index.ts
+++ b/src/evaluation-core/compiler/index.ts
@@ -1,0 +1,854 @@
+import { z } from 'zod';
+import {
+  ANALYSIS_PLAN_SCHEMA_VERSION,
+  DECISION_PLAN_SCHEMA_VERSION,
+  EVALUATION_PLAN_SCHEMA_VERSION,
+  EXECUTION_PLAN_SCHEMA_VERSION,
+  EvaluationDefinitionSchema,
+  MeasurementPolicySchema,
+  RUN_PLAN_SCHEMA_VERSION,
+  RunPlanSchema,
+  canonicalizeJson,
+  computePlanDigests,
+  generateWireSchemaIdentities,
+  parseWireDocument,
+  projectEvaluationInputs,
+  projectExecutionInputs,
+  type ExtensionEntry,
+  type Extensions,
+  type JsonValue,
+  type MeasurementPolicy,
+  type ResolvedRuntime,
+  type RuntimeIdentity,
+  type SchemaIdentity,
+} from '../contracts/index.js';
+import {
+  EvaluationDefinitionError,
+} from './errors.js';
+import { deepFreeze, snapshotJson } from './immutability.js';
+import {
+  AnalysisCapabilitiesSchema,
+  EvaluatorCapabilitiesSchema,
+  ExecutorCapabilitiesSchema,
+  ExtensionResolutionSchema,
+  RuntimeResolutionSchema,
+  type AnalysisCapabilities,
+  type EvaluatorCapabilities,
+  type ExecutorCapabilities,
+  type ExtensionImpactStage,
+  type PreparationRuntime,
+  type SealedRunPlan,
+} from './types.js';
+import {
+  validateAnalysisInputs,
+  validateDefinitionSemantics,
+} from './validation.js';
+
+export * from './errors.js';
+export * from './types.js';
+
+interface StageExtensions {
+  execution?: Extensions;
+  evaluation?: Extensions;
+  analysis?: Extensions;
+  decision?: Extensions;
+  run?: Extensions;
+}
+
+interface ResolvedAnalysisRuntime {
+  runtime: ResolvedRuntime;
+  capabilities: AnalysisCapabilities;
+}
+
+const CONTRACT_PATH_SEGMENTS = new Set([
+  'schemaVersion', 'dataset', 'datasetId', 'samples', 'sampleId', 'input',
+  'executionContext', 'expected', 'evaluationContext', 'annotations', 'targets',
+  'targetId', 'targetKind', 'protocolId', 'executorId', 'versionConstraint', 'config',
+  'evaluators', 'evaluatorId', 'evaluatorKind', 'implementationId', 'metricIds',
+  'inputs', 'bindingId', 'sourceKind', 'pointer', 'metrics', 'metricId', 'valueType',
+  'scope', 'scale', 'min', 'max', 'target', 'unit', 'direction', 'missingPolicyId',
+  'experiment', 'trials', 'seed', 'sampling', 'experimentalUnit', 'pairingKey',
+  'clusterKey', 'stratumKey', 'repeatedMeasures', 'resamplingUnit', 'estimatorId',
+  'scheduling', 'schedulingKind', 'blockSize', 'analysisGraph', 'nodes', 'nodeId',
+  'analysisNodeKind', 'inputKind', 'referenceId', 'outputResultId', 'parameters',
+  'comparisons', 'comparisonId', 'controlTargetId', 'treatmentTargetIds',
+  'decisionPolicy', 'decisionPolicyId', 'analysisResultIds',
+  'multipleComparisonPolicyId', 'minimumEvidenceStatus', 'execution', 'timeoutMs',
+  'maxConcurrency', 'retry', 'maxAttempts', 'retryableErrorCodes', 'backoff',
+  'backoffKind', 'initialDelayMs', 'maxDelayMs', 'budget', 'maxTargetInvocations',
+  'maxDurationMs', 'maxProviderCost', 'amount', 'currency', 'cache', 'executionMode',
+  'evaluationMode', 'evidence', 'output', 'trace', 'maximumClassification', 'failure',
+  'failureMode', 'maxFailures', 'eventDelivery', 'writerMode', 'backpressureMode',
+  'writerFailureMode', 'extensions', 'schemaUri', 'schemaDigest', 'data',
+]);
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function safeSchemaDetails(error: z.ZodError): {
+  issues: Array<{ code: string; path: Array<string | number> }>;
+} {
+  return {
+    issues: error.issues.map((issue) => ({
+      code: issue.code,
+      path: issue.path.map((part) => {
+        if (typeof part === 'number') return part;
+        if (typeof part === 'symbol') return '*';
+        return CONTRACT_PATH_SEGMENTS.has(part) ? part : '*';
+      }),
+    })),
+  };
+}
+
+function sortedUniqueStrings(
+  values: readonly string[],
+  referenceId: string,
+  field: string,
+): string[] {
+  if (new Set(values).size !== values.length) {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      stage: 'configuration',
+      preparationStage: 'runtime-resolution',
+      message: 'Runtime capability manifest 包含重复声明。',
+      details: { referenceId, field },
+    });
+  }
+  return [...values].sort(compareStrings);
+}
+
+function sortedSchemas(identities: readonly SchemaIdentity[]): SchemaIdentity[] {
+  return [...identities].sort((left, right) => (
+    compareStrings(left.schemaUri, right.schemaUri)
+    || compareStrings(left.schemaVersion, right.schemaVersion)
+    || compareStrings(left.schemaDigest, right.schemaDigest)
+  ));
+}
+
+function bindCapabilities(
+  identity: RuntimeIdentity,
+  capabilities: ExecutorCapabilities | EvaluatorCapabilities | AnalysisCapabilities,
+): RuntimeIdentity {
+  return {
+    ...identity,
+    capabilities: snapshotJson(capabilities) as JsonValue,
+  };
+}
+
+function normalizeExecutorCapabilities(
+  capabilities: ExecutorCapabilities,
+): ExecutorCapabilities {
+  return {
+    protocols: [...capabilities.protocols].sort((left, right) => (
+      compareStrings(left.protocolId, right.protocolId)
+    )),
+  };
+}
+
+function normalizeEvaluatorCapabilities(
+  capabilities: EvaluatorCapabilities,
+  referenceId: string,
+): EvaluatorCapabilities {
+  return {
+    inputSourceKinds: sortedUniqueStrings(
+      capabilities.inputSourceKinds,
+      referenceId,
+      'inputSourceKinds',
+    ) as EvaluatorCapabilities['inputSourceKinds'],
+    metricValueTypes: sortedUniqueStrings(
+      capabilities.metricValueTypes,
+      referenceId,
+      'metricValueTypes',
+    ) as EvaluatorCapabilities['metricValueTypes'],
+    schemas: sortedSchemas(capabilities.schemas),
+  };
+}
+
+function normalizeAnalysisCapabilities(
+  capabilities: AnalysisCapabilities,
+  referenceId: string,
+): AnalysisCapabilities {
+  const inputDomains = capabilities.inputDomains.map((domain) => (
+    domain.inputKind === 'metric-observations'
+      ? {
+        ...domain,
+        valueTypes: sortedUniqueStrings(
+          domain.valueTypes,
+          referenceId,
+          'inputDomains.valueTypes',
+        ) as typeof domain.valueTypes,
+        ...(domain.missingPolicyIds !== undefined ? {
+          missingPolicyIds: sortedUniqueStrings(
+            domain.missingPolicyIds,
+            referenceId,
+            'inputDomains.missingPolicyIds',
+          ),
+        } : {}),
+      }
+      : {
+        ...domain,
+        schemaUris: sortedUniqueStrings(
+          domain.schemaUris,
+          referenceId,
+          'inputDomains.schemaUris',
+        ),
+      }
+  )).sort((left, right) => (
+    compareStrings(canonicalizeJson(left), canonicalizeJson(right))
+  ));
+  if (new Set(inputDomains.map((domain) => canonicalizeJson(domain))).size
+      !== inputDomains.length) {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      stage: 'configuration',
+      preparationStage: 'runtime-resolution',
+      message: 'Runtime capability manifest 包含重复 input domain。',
+      details: { referenceId, field: 'inputDomains' },
+    });
+  }
+  if (capabilities.sampling !== undefined
+      && new Set(capabilities.sampling.repeatedMeasures).size
+        !== capabilities.sampling.repeatedMeasures.length) {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      stage: 'configuration',
+      preparationStage: 'runtime-resolution',
+      message: 'Runtime capability manifest 包含重复声明。',
+      details: { referenceId, field: 'sampling.repeatedMeasures' },
+    });
+  }
+  return {
+    analysisNodeKinds: sortedUniqueStrings(
+      capabilities.analysisNodeKinds,
+      referenceId,
+      'analysisNodeKinds',
+    ) as AnalysisCapabilities['analysisNodeKinds'],
+    inputDomains,
+    outputSchema: capabilities.outputSchema,
+    ...(capabilities.sampling !== undefined ? {
+      sampling: {
+        experimentalUnits: sortedUniqueStrings(
+          capabilities.sampling.experimentalUnits,
+          referenceId,
+          'sampling.experimentalUnits',
+        ) as NonNullable<AnalysisCapabilities['sampling']>['experimentalUnits'],
+        repeatedMeasures: [...capabilities.sampling.repeatedMeasures].sort(
+          (left, right) => Number(left) - Number(right),
+        ),
+        resamplingUnits: sortedUniqueStrings(
+          capabilities.sampling.resamplingUnits,
+          referenceId,
+          'sampling.resamplingUnits',
+        ) as NonNullable<AnalysisCapabilities['sampling']>['resamplingUnits'],
+      },
+    } : {}),
+    schemas: sortedSchemas(capabilities.schemas),
+  };
+}
+
+function parseInput<T>(schema: z.ZodType<T>, value: unknown, documentKind: string): T {
+  try {
+    return parseWireDocument(schema, value);
+  } catch (error) {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_SCHEMA_INVALID',
+      stage: 'configuration',
+      preparationStage: 'schema',
+      message: `${documentKind} 不符合 Evaluation Core v1 wire contract。`,
+      ...(error instanceof z.ZodError ? { details: safeSchemaDetails(error) } : {}),
+    });
+  }
+}
+
+async function resolveRuntime(
+  referenceId: string,
+  resolver: () => unknown | Promise<unknown>,
+): Promise<z.infer<typeof RuntimeResolutionSchema>> {
+  let raw: unknown;
+  try {
+    raw = await resolver();
+  } catch {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_RUNTIME_RESOLUTION_FAILED',
+      stage: 'infrastructure',
+      preparationStage: 'runtime-resolution',
+      message: 'Runtime resolver 无法解析所需实现。',
+      details: { referenceId },
+      causes: [{
+        code: 'EVAL_RUNTIME_PROVIDER_FAILURE',
+        stage: 'infrastructure',
+        message: 'Runtime provider 返回失败。',
+      }],
+    });
+  }
+  try {
+    return parseWireDocument(RuntimeResolutionSchema, raw);
+  } catch {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_RUNTIME_RESOLUTION_FAILED',
+      stage: 'infrastructure',
+      preparationStage: 'runtime-resolution',
+      message: 'Runtime resolver 返回了无效的解析结果。',
+      details: { referenceId },
+    });
+  }
+}
+
+function parseCapabilities<T>(
+  schema: z.ZodType<T>,
+  capabilities: JsonValue,
+  referenceId: string,
+): T {
+  const result = schema.safeParse(capabilities);
+  if (result.success) return result.data;
+  throw new EvaluationDefinitionError({
+    code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+    stage: 'configuration',
+    preparationStage: 'runtime-resolution',
+    message: 'Runtime capability manifest 不符合 Compiler 要求。',
+    details: { referenceId, ...safeSchemaDetails(result.error) },
+  });
+}
+
+function assertVersionSatisfied(
+  referenceId: string,
+  versionConstraint: string | undefined,
+  satisfied: boolean,
+): void {
+  if (satisfied) return;
+  throw new EvaluationDefinitionError({
+    code: 'EVAL_DEFINITION_RUNTIME_RESOLUTION_FAILED',
+    stage: 'configuration',
+    preparationStage: 'runtime-resolution',
+    message: '解析出的 Runtime 不满足声明的版本约束。',
+    details: {
+      referenceId,
+      ...(versionConstraint !== undefined ? { versionConstraint } : {}),
+    },
+  });
+}
+
+function addSchemaIdentity(
+  identitiesByUri: Map<string, SchemaIdentity>,
+  identity: SchemaIdentity,
+  referenceId: string,
+): void {
+  const existing = identitiesByUri.get(identity.schemaUri);
+  if (existing === undefined) {
+    identitiesByUri.set(identity.schemaUri, identity);
+    return;
+  }
+  if (existing.schemaVersion === identity.schemaVersion
+      && existing.schemaDigest === identity.schemaDigest) return;
+  throw new EvaluationDefinitionError({
+    code: 'EVAL_DEFINITION_PROTOCOL_INVALID',
+    stage: 'configuration',
+    preparationStage: 'runtime-resolution',
+    message: '同一 schema URI 被解析为冲突的 schema identity。',
+    details: { referenceId, schemaUri: identity.schemaUri },
+  });
+}
+
+function addCapabilitySchemas(
+  identitiesByUri: Map<string, SchemaIdentity>,
+  identities: readonly SchemaIdentity[],
+  referenceId: string,
+): void {
+  for (const identity of identities) addSchemaIdentity(identitiesByUri, identity, referenceId);
+}
+
+async function resolveExecutors(
+  definition: z.infer<typeof EvaluationDefinitionSchema>,
+  policy: MeasurementPolicy,
+  runtime: PreparationRuntime,
+  identitiesByUri: Map<string, SchemaIdentity>,
+): Promise<ResolvedRuntime[]> {
+  const resolved: ResolvedRuntime[] = [];
+  for (const target of definition.targets) {
+    const resolution = await resolveRuntime(
+      target.targetId,
+      () => runtime.resolveExecutor(deepFreeze(snapshotJson({
+        referenceId: target.targetId,
+        executorId: target.executorId,
+        ...(target.versionConstraint !== undefined
+          ? { versionConstraint: target.versionConstraint }
+          : {}),
+        protocolId: target.protocolId,
+      }))),
+    );
+    assertVersionSatisfied(
+      target.targetId,
+      target.versionConstraint,
+      resolution.satisfiesVersionConstraint,
+    );
+    const capabilities = normalizeExecutorCapabilities(
+      parseCapabilities(
+        ExecutorCapabilitiesSchema,
+        resolution.identity.capabilities,
+        target.targetId,
+      ),
+    );
+    const protocolIds = capabilities.protocols.map((protocol) => protocol.protocolId);
+    if (new Set(protocolIds).size !== protocolIds.length) {
+      throw new EvaluationDefinitionError({
+        code: 'EVAL_DEFINITION_PROTOCOL_INVALID',
+        stage: 'configuration',
+        preparationStage: 'runtime-resolution',
+        message: 'Executor capability manifest 包含重复 protocolId。',
+        details: { referenceId: target.targetId },
+      });
+    }
+    const protocol = capabilities.protocols.find(
+      (candidate) => candidate.protocolId === target.protocolId,
+    );
+    if (protocol === undefined) {
+      throw new EvaluationDefinitionError({
+        code: 'EVAL_DEFINITION_PROTOCOL_INVALID',
+        stage: 'configuration',
+        preparationStage: 'runtime-resolution',
+        message: 'Executor 不支持 Target 声明的 protocol。',
+        details: { referenceId: target.targetId, protocolId: target.protocolId },
+      });
+    }
+    if (policy.cache.executionMode === 'transparent-deterministic'
+        && !protocol.deterministic) {
+      throw new EvaluationDefinitionError({
+        code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+        stage: 'configuration',
+        preparationStage: 'runtime-resolution',
+        message: 'transparent-deterministic cache 只能用于已证明确定性的 Target。',
+        details: { referenceId: target.targetId, protocolId: target.protocolId },
+      });
+    }
+    addCapabilitySchemas(
+      identitiesByUri,
+      [
+        protocol.inputSchema,
+        protocol.outputSchema,
+        ...(protocol.traceSchema !== undefined ? [protocol.traceSchema] : []),
+      ],
+      target.targetId,
+    );
+    resolved.push({
+      runtimeKind: 'executor',
+      referenceId: target.targetId,
+      identity: bindCapabilities(resolution.identity, capabilities),
+    });
+  }
+  return resolved;
+}
+
+async function resolveEvaluators(
+  definition: z.infer<typeof EvaluationDefinitionSchema>,
+  runtime: PreparationRuntime,
+  identitiesByUri: Map<string, SchemaIdentity>,
+): Promise<ResolvedRuntime[]> {
+  const metricsById = new Map(definition.metrics.map((metric) => [metric.metricId, metric]));
+  const resolved: ResolvedRuntime[] = [];
+  for (const evaluator of definition.evaluators) {
+    const resolution = await resolveRuntime(
+      evaluator.evaluatorId,
+      () => runtime.resolveEvaluator(deepFreeze(snapshotJson({
+        referenceId: evaluator.evaluatorId,
+        implementationId: evaluator.implementationId,
+        ...(evaluator.versionConstraint !== undefined
+          ? { versionConstraint: evaluator.versionConstraint }
+          : {}),
+      }))),
+    );
+    assertVersionSatisfied(
+      evaluator.evaluatorId,
+      evaluator.versionConstraint,
+      resolution.satisfiesVersionConstraint,
+    );
+    const capabilities = normalizeEvaluatorCapabilities(
+      parseCapabilities(
+        EvaluatorCapabilitiesSchema,
+        resolution.identity.capabilities,
+        evaluator.evaluatorId,
+      ),
+      evaluator.evaluatorId,
+    );
+    for (const binding of evaluator.inputs) {
+      if (capabilities.inputSourceKinds.includes(binding.sourceKind)) continue;
+      throw new EvaluationDefinitionError({
+        code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+        stage: 'configuration',
+        preparationStage: 'runtime-resolution',
+        message: 'Evaluator 不支持声明的 input binding source。',
+        details: {
+          referenceId: evaluator.evaluatorId,
+          bindingId: binding.bindingId,
+          sourceKind: binding.sourceKind,
+        },
+      });
+    }
+    for (const metricId of evaluator.metricIds) {
+      const valueType = metricsById.get(metricId)?.valueType;
+      if (valueType !== undefined && capabilities.metricValueTypes.includes(valueType)) continue;
+      throw new EvaluationDefinitionError({
+        code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+        stage: 'configuration',
+        preparationStage: 'runtime-resolution',
+        message: 'Evaluator 不支持声明的 Metric valueType。',
+        details: { referenceId: evaluator.evaluatorId, metricId },
+      });
+    }
+    addCapabilitySchemas(identitiesByUri, capabilities.schemas, evaluator.evaluatorId);
+    resolved.push({
+      runtimeKind: 'evaluator',
+      referenceId: evaluator.evaluatorId,
+      identity: bindCapabilities(resolution.identity, capabilities),
+    });
+  }
+  return resolved;
+}
+
+async function resolveAnalysisRequirement(
+  runtime: PreparationRuntime,
+  requirement: {
+    referenceId: string;
+    implementationId: string;
+    analysisNodeKind: 'reducer' | 'estimator' | 'correction';
+    requirementKind: 'analysis-node' | 'sampling-estimator';
+  },
+  identitiesByUri: Map<string, SchemaIdentity>,
+): Promise<ResolvedAnalysisRuntime> {
+  const resolution = await resolveRuntime(
+    requirement.referenceId,
+    () => runtime.resolveAnalysis(deepFreeze(snapshotJson(requirement))),
+  );
+  assertVersionSatisfied(requirement.referenceId, undefined, resolution.satisfiesVersionConstraint);
+  const capabilities = normalizeAnalysisCapabilities(
+    parseCapabilities(
+      AnalysisCapabilitiesSchema,
+      resolution.identity.capabilities,
+      requirement.referenceId,
+    ),
+    requirement.referenceId,
+  );
+  if (!capabilities.analysisNodeKinds.includes(requirement.analysisNodeKind)) {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      stage: 'configuration',
+      preparationStage: 'runtime-resolution',
+      message: 'Analysis implementation 不支持声明的 node kind。',
+      details: {
+        referenceId: requirement.referenceId,
+        analysisNodeKind: requirement.analysisNodeKind,
+      },
+    });
+  }
+  addCapabilitySchemas(
+    identitiesByUri,
+    [capabilities.outputSchema, ...capabilities.schemas],
+    requirement.referenceId,
+  );
+  return {
+    runtime: {
+      runtimeKind: 'analysis',
+      referenceId: requirement.referenceId,
+      identity: bindCapabilities(resolution.identity, capabilities),
+    },
+    capabilities,
+  };
+}
+
+async function resolveAnalysisRuntimes(
+  definition: z.infer<typeof EvaluationDefinitionSchema>,
+  runtime: PreparationRuntime,
+  identitiesByUri: Map<string, SchemaIdentity>,
+): Promise<ResolvedRuntime[]> {
+  const byNodeId = new Map<string, ResolvedAnalysisRuntime>();
+  for (const node of definition.analysisGraph.nodes) {
+    byNodeId.set(node.nodeId, await resolveAnalysisRequirement(runtime, {
+      referenceId: node.nodeId,
+      implementationId: node.implementationId,
+      analysisNodeKind: node.analysisNodeKind,
+      requirementKind: 'analysis-node',
+    }, identitiesByUri));
+  }
+
+  const samplingReferenceId = definition.experiment.sampling.estimatorId;
+  const samplingEstimator = await resolveAnalysisRequirement(runtime, {
+    referenceId: samplingReferenceId,
+    implementationId: definition.experiment.sampling.estimatorId,
+    analysisNodeKind: 'estimator',
+    requirementKind: 'sampling-estimator',
+  }, identitiesByUri);
+  const samplingCapabilities = samplingEstimator.capabilities.sampling;
+  const sampling = definition.experiment.sampling;
+  if (samplingCapabilities === undefined
+      || !samplingCapabilities.experimentalUnits.includes(sampling.experimentalUnit)
+      || !samplingCapabilities.repeatedMeasures.includes(sampling.repeatedMeasures)
+      || !samplingCapabilities.resamplingUnits.includes(sampling.resamplingUnit)) {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      stage: 'configuration',
+      preparationStage: 'runtime-resolution',
+      message: 'Estimator 不支持声明的 SamplingDesign。',
+      details: { referenceId: samplingReferenceId },
+    });
+  }
+
+  const metricsById = new Map(definition.metrics.map((metric) => [metric.metricId, metric]));
+  const outputSchemasByResultId = new Map<string, string>();
+  for (const node of definition.analysisGraph.nodes) {
+    const resolved = byNodeId.get(node.nodeId);
+    if (resolved !== undefined) {
+      outputSchemasByResultId.set(
+        node.outputResultId,
+        resolved.capabilities.outputSchema.schemaUri,
+      );
+    }
+  }
+  for (const node of definition.analysisGraph.nodes) {
+    const resolved = byNodeId.get(node.nodeId);
+    if (resolved !== undefined) {
+      validateAnalysisInputs(node, resolved.capabilities, metricsById, outputSchemasByResultId);
+    }
+  }
+
+  return [
+    ...definition.analysisGraph.nodes.map((node) => byNodeId.get(node.nodeId)?.runtime)
+      .filter((entry): entry is ResolvedRuntime => entry !== undefined),
+    samplingEstimator.runtime,
+  ];
+}
+
+function appendExtension(
+  stageExtensions: StageExtensions,
+  stage: Exclude<ExtensionImpactStage, 'audit'>,
+  namespace: string,
+  entry: ExtensionEntry,
+): void {
+  const current = stageExtensions[stage] ?? {};
+  stageExtensions[stage] = { ...current, [namespace]: entry };
+}
+
+async function resolveExtensions(
+  definitionExtensions: Extensions | undefined,
+  policyExtensions: Extensions | undefined,
+  runtime: PreparationRuntime,
+): Promise<StageExtensions> {
+  const requests = [
+    ...Object.entries(definitionExtensions ?? {}).map(([namespace, entry]) => ({
+      namespace,
+      source: 'definition' as const,
+      entry,
+    })),
+    ...Object.entries(policyExtensions ?? {}).map(([namespace, entry]) => ({
+      namespace,
+      source: 'measurement-policy' as const,
+      entry,
+    })),
+  ].sort((left, right) => compareStrings(left.namespace, right.namespace)
+    || compareStrings(left.source, right.source));
+  const namespaces = requests.map((request) => request.namespace);
+  if (new Set(namespaces).size !== namespaces.length) {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_EXTENSION_INVALID',
+      stage: 'configuration',
+      preparationStage: 'extension-resolution',
+      message: 'Definition 与 MeasurementPolicy 不能重复声明同一 extension namespace。',
+    });
+  }
+  if (requests.length > 0 && runtime.validateExtension === undefined) {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_EXTENSION_INVALID',
+      stage: 'configuration',
+      preparationStage: 'extension-resolution',
+      message: '存在 extension，但 PreparationRuntime 未提供 extension validator。',
+    });
+  }
+
+  const stageExtensions: StageExtensions = {};
+  for (const request of requests) {
+    let raw: unknown;
+    try {
+      raw = await runtime.validateExtension?.(deepFreeze(snapshotJson(request)));
+    } catch {
+      throw new EvaluationDefinitionError({
+        code: 'EVAL_DEFINITION_EXTENSION_INVALID',
+        stage: 'configuration',
+        preparationStage: 'extension-resolution',
+        message: 'Extension schema 校验失败。',
+        details: { namespace: request.namespace, source: request.source },
+      });
+    }
+    let resolution: z.infer<typeof ExtensionResolutionSchema>;
+    try {
+      resolution = parseWireDocument(ExtensionResolutionSchema, raw);
+    } catch {
+      throw new EvaluationDefinitionError({
+        code: 'EVAL_DEFINITION_EXTENSION_INVALID',
+        stage: 'configuration',
+        preparationStage: 'extension-resolution',
+        message: 'Extension validator 未返回明确的阶段影响。',
+        details: { namespace: request.namespace, source: request.source },
+      });
+    }
+    if (resolution.impactStage !== 'audit') {
+      appendExtension(
+        stageExtensions,
+        resolution.impactStage,
+        request.namespace,
+        request.entry,
+      );
+    }
+  }
+  return stageExtensions;
+}
+
+function sortSchemaIdentities(
+  identitiesByUri: ReadonlyMap<string, SchemaIdentity>,
+): SchemaIdentity[] {
+  return [...identitiesByUri.values()].sort((left, right) => (
+    compareStrings(left.schemaUri, right.schemaUri)
+    || compareStrings(left.schemaVersion, right.schemaVersion)
+    || compareStrings(left.schemaDigest, right.schemaDigest)
+  ));
+}
+
+export async function prepareEvaluationPlan(
+  definitionInput: unknown,
+  measurementPolicyInput: unknown,
+  runtime: PreparationRuntime,
+): Promise<SealedRunPlan> {
+  const definition = parseInput(
+    EvaluationDefinitionSchema,
+    definitionInput,
+    'EvaluationDefinition',
+  );
+  const measurementPolicy = parseInput(
+    MeasurementPolicySchema,
+    measurementPolicyInput,
+    'MeasurementPolicy',
+  );
+  validateDefinitionSemantics(definition, measurementPolicy);
+
+  const identitiesByUri = new Map<string, SchemaIdentity>();
+  for (const identity of generateWireSchemaIdentities()) {
+    addSchemaIdentity(identitiesByUri, identity, identity.schemaVersion);
+  }
+  const executorRuntimes = await resolveExecutors(
+    definition,
+    measurementPolicy,
+    runtime,
+    identitiesByUri,
+  );
+  const evaluatorRuntimes = await resolveEvaluators(definition, runtime, identitiesByUri);
+  const analysisRuntimes = await resolveAnalysisRuntimes(definition, runtime, identitiesByUri);
+  const stageExtensions = await resolveExtensions(
+    definition.extensions,
+    measurementPolicy.extensions,
+    runtime,
+  );
+  const schemaIdentities = sortSchemaIdentities(identitiesByUri);
+  const digests = computePlanDigests({
+    dataset: definition.dataset,
+    targets: definition.targets,
+    evaluators: definition.evaluators,
+    metrics: definition.metrics,
+    experiment: definition.experiment,
+    analysisGraph: definition.analysisGraph,
+    comparisons: definition.comparisons,
+    ...(definition.decisionPolicy !== undefined
+      ? { decisionPolicy: definition.decisionPolicy }
+      : {}),
+    measurementPolicy,
+    executorRuntimes,
+    evaluatorRuntimes,
+    analysisRuntimes,
+    schemaIdentities,
+    stageExtensions,
+  });
+
+  const execution = {
+    schemaVersion: EXECUTION_PLAN_SCHEMA_VERSION,
+    executionInputDigest: digests.executionInputDigest,
+    samples: projectExecutionInputs(definition.dataset),
+    targets: definition.targets,
+    experiment: definition.experiment,
+    runtimes: executorRuntimes,
+    policy: {
+      execution: measurementPolicy.execution,
+      retry: measurementPolicy.retry,
+      budget: measurementPolicy.budget,
+      executionCacheMode: measurementPolicy.cache.executionMode,
+      failure: measurementPolicy.failure,
+    },
+    executionPlanDigest: digests.executionPlanDigest,
+    ...(stageExtensions.execution !== undefined
+      ? { extensions: stageExtensions.execution }
+      : {}),
+  };
+  const evaluation = {
+    schemaVersion: EVALUATION_PLAN_SCHEMA_VERSION,
+    executionPlanDigest: digests.executionPlanDigest,
+    evaluationInputDigest: digests.evaluationInputDigest,
+    samples: projectEvaluationInputs(definition.dataset),
+    evaluators: definition.evaluators,
+    metrics: definition.metrics,
+    runtimes: evaluatorRuntimes,
+    policy: {
+      evaluationCacheMode: measurementPolicy.cache.evaluationMode,
+      evidence: measurementPolicy.evidence,
+      failure: measurementPolicy.failure,
+    },
+    evaluationPlanDigest: digests.evaluationPlanDigest,
+    ...(stageExtensions.evaluation !== undefined
+      ? { extensions: stageExtensions.evaluation }
+      : {}),
+  };
+  const analysis = {
+    schemaVersion: ANALYSIS_PLAN_SCHEMA_VERSION,
+    evaluationPlanDigest: digests.evaluationPlanDigest,
+    analysisGraph: definition.analysisGraph,
+    sampling: definition.experiment.sampling,
+    runtimes: analysisRuntimes,
+    analysisPlanDigest: digests.analysisPlanDigest,
+    ...(stageExtensions.analysis !== undefined
+      ? { extensions: stageExtensions.analysis }
+      : {}),
+  };
+  const decision = {
+    schemaVersion: DECISION_PLAN_SCHEMA_VERSION,
+    analysisPlanDigest: digests.analysisPlanDigest,
+    comparisons: definition.comparisons,
+    ...(definition.decisionPolicy !== undefined
+      ? { decisionPolicy: definition.decisionPolicy }
+      : {}),
+    decisionPlanDigest: digests.decisionPlanDigest,
+    ...(stageExtensions.decision !== undefined
+      ? { extensions: stageExtensions.decision }
+      : {}),
+  };
+  const plan = {
+    schemaVersion: RUN_PLAN_SCHEMA_VERSION,
+    definition,
+    measurementPolicy,
+    execution,
+    evaluation,
+    analysis,
+    decision,
+    schemaIdentities,
+    digests,
+    ...(stageExtensions.run !== undefined ? { extensions: stageExtensions.run } : {}),
+  };
+
+  try {
+    const parsed = parseWireDocument(RunPlanSchema, plan);
+    return deepFreeze(snapshotJson(parsed)) as SealedRunPlan;
+  } catch {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_SCHEMA_INVALID',
+      stage: 'internal',
+      preparationStage: 'sealing',
+      message: 'Compiler 生成的 RunPlan 未通过内部契约校验。',
+    });
+  }
+}

--- a/src/evaluation-core/compiler/types.ts
+++ b/src/evaluation-core/compiler/types.ts
@@ -1,0 +1,146 @@
+import { z } from 'zod';
+import {
+  RuntimeIdentitySchema,
+  SchemaIdentitySchema,
+  type ExtensionEntry,
+  type JsonValue,
+  type RunPlan,
+} from '../contracts/index.js';
+
+export const ProtocolManifestSchema = z.object({
+  protocolId: z.enum(['omk.invoke/v1', 'omk.session/v1']),
+  inputSchema: SchemaIdentitySchema,
+  outputSchema: SchemaIdentitySchema,
+  traceSchema: SchemaIdentitySchema.optional(),
+  deterministic: z.boolean(),
+}).strict();
+
+export const ExecutorCapabilitiesSchema = z.object({
+  protocols: z.array(ProtocolManifestSchema).min(1),
+}).strict();
+
+export const EvaluatorCapabilitiesSchema = z.object({
+  inputSourceKinds: z.array(z.enum([
+    'output',
+    'trace',
+    'expected',
+    'evaluation-context',
+  ])).min(1),
+  metricValueTypes: z.array(z.enum([
+    'numeric',
+    'boolean',
+    'categorical',
+    'text',
+    'ranking',
+  ])).min(1),
+  schemas: z.array(SchemaIdentitySchema),
+}).strict();
+
+const SamplingCapabilitiesSchema = z.object({
+  experimentalUnits: z.array(z.enum(['sample', 'run', 'cluster'])).min(1),
+  repeatedMeasures: z.array(z.boolean()).min(1),
+  resamplingUnits: z.array(z.enum(['sample', 'paired-block', 'cluster', 'run'])).min(1),
+}).strict();
+
+const MetricObservationInputDomainSchema = z.object({
+  inputKind: z.literal('metric-observations'),
+  valueTypes: z.array(z.enum([
+    'numeric',
+    'boolean',
+    'categorical',
+    'text',
+    'ranking',
+  ])).min(1),
+  missingPolicyIds: z.array(z.string().min(1).max(256)).optional(),
+}).strict();
+
+const AnalysisResultInputDomainSchema = z.object({
+  inputKind: z.literal('analysis-result'),
+  schemaUris: z.array(z.string().regex(/^[A-Za-z][A-Za-z0-9+.-]*:/)).min(1),
+}).strict();
+
+export const AnalysisCapabilitiesSchema = z.object({
+  analysisNodeKinds: z.array(z.enum(['reducer', 'estimator', 'correction'])).min(1),
+  inputDomains: z.array(z.discriminatedUnion('inputKind', [
+    MetricObservationInputDomainSchema,
+    AnalysisResultInputDomainSchema,
+  ])),
+  outputSchema: SchemaIdentitySchema,
+  sampling: SamplingCapabilitiesSchema.optional(),
+  schemas: z.array(SchemaIdentitySchema),
+}).strict();
+
+export const RuntimeResolutionSchema = z.object({
+  identity: RuntimeIdentitySchema,
+  satisfiesVersionConstraint: z.boolean(),
+}).strict();
+
+export const ExtensionImpactStageSchema = z.enum([
+  'execution',
+  'evaluation',
+  'analysis',
+  'decision',
+  'run',
+  'audit',
+]);
+
+export const ExtensionResolutionSchema = z.object({
+  impactStage: ExtensionImpactStageSchema,
+}).strict();
+
+export type ProtocolManifest = z.infer<typeof ProtocolManifestSchema>;
+export type ExecutorCapabilities = z.infer<typeof ExecutorCapabilitiesSchema>;
+export type EvaluatorCapabilities = z.infer<typeof EvaluatorCapabilitiesSchema>;
+export type AnalysisCapabilities = z.infer<typeof AnalysisCapabilitiesSchema>;
+export type RuntimeResolution = z.infer<typeof RuntimeResolutionSchema>;
+export type ExtensionImpactStage = z.infer<typeof ExtensionImpactStageSchema>;
+export type ExtensionResolution = z.infer<typeof ExtensionResolutionSchema>;
+
+export interface ExecutorRuntimeRequirement {
+  referenceId: string;
+  executorId: string;
+  versionConstraint?: string;
+  protocolId: 'omk.invoke/v1' | 'omk.session/v1';
+}
+
+export interface EvaluatorRuntimeRequirement {
+  referenceId: string;
+  implementationId: string;
+  versionConstraint?: string;
+}
+
+export interface AnalysisRuntimeRequirement {
+  referenceId: string;
+  implementationId: string;
+  analysisNodeKind: 'reducer' | 'estimator' | 'correction';
+  requirementKind: 'analysis-node' | 'sampling-estimator';
+}
+
+export interface ExtensionValidationRequest {
+  namespace: string;
+  source: 'definition' | 'measurement-policy';
+  entry: ExtensionEntry;
+}
+
+export interface PreparationRuntime {
+  resolveExecutor(requirement: Readonly<ExecutorRuntimeRequirement>): unknown | Promise<unknown>;
+  resolveEvaluator(requirement: Readonly<EvaluatorRuntimeRequirement>): unknown | Promise<unknown>;
+  resolveAnalysis(requirement: Readonly<AnalysisRuntimeRequirement>): unknown | Promise<unknown>;
+  validateExtension?(
+    request: Readonly<ExtensionValidationRequest>,
+  ): unknown | Promise<unknown>;
+}
+
+export type DeepReadonly<T> = T extends JsonValue
+  ? T extends readonly (infer Item)[]
+    ? readonly DeepReadonly<Item>[]
+    : T extends object
+      ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+      : T
+  : T extends readonly (infer Item)[]
+    ? readonly DeepReadonly<Item>[]
+    : T extends object
+      ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+      : T;
+
+export type SealedRunPlan = DeepReadonly<RunPlan>;

--- a/src/evaluation-core/compiler/validation.ts
+++ b/src/evaluation-core/compiler/validation.ts
@@ -1,0 +1,492 @@
+import type {
+  AnalysisCapabilities,
+} from './types.js';
+import {
+  projectExecutionInputs,
+  type AnalysisNodeDefinition,
+  type EvaluationDefinition,
+  type MeasurementPolicy,
+  type MetricDefinition,
+} from '../contracts/index.js';
+import { definitionError } from './errors.js';
+
+function assertUnique(
+  values: readonly string[],
+  namespace: string,
+): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      throw definitionError(
+        'EVAL_DEFINITION_DUPLICATE_ID',
+        `“${namespace}”命名空间中存在重复 ID。`,
+        { namespace, duplicateId: value },
+      );
+    }
+    seen.add(value);
+  }
+}
+
+function assertReference(
+  known: ReadonlySet<string>,
+  referenceId: string,
+  location: string,
+  referenceKind: string,
+): void {
+  if (known.has(referenceId)) return;
+  throw definitionError(
+    'EVAL_DEFINITION_MISSING_REFERENCE',
+    `“${location}”引用了不存在的${referenceKind}。`,
+    { location, referenceKind, referenceId },
+  );
+}
+
+function decodePointerToken(token: string): string {
+  return token.replaceAll('~1', '/').replaceAll('~0', '~');
+}
+
+function resolvesPointer(value: unknown, pointer: string): boolean {
+  if (pointer === '') return true;
+  let current = value;
+  for (const encodedToken of pointer.slice(1).split('/')) {
+    const token = decodePointerToken(encodedToken);
+    if (current === null || typeof current !== 'object') return false;
+    if (Array.isArray(current)) {
+      if (!/^(?:0|[1-9]\d*)$/.test(token)) return false;
+      const index = Number(token);
+      if (index >= current.length) return false;
+      current = current[index];
+      continue;
+    }
+    if (!Object.prototype.hasOwnProperty.call(current, token)) return false;
+    current = (current as Record<string, unknown>)[token];
+  }
+  return true;
+}
+
+function validateDesignPointers(definition: EvaluationDefinition): void {
+  const executionSamples = projectExecutionInputs(definition.dataset);
+  const pointers = [
+    ['pairingKey', definition.experiment.sampling.pairingKey],
+    ['clusterKey', definition.experiment.sampling.clusterKey],
+    ['stratumKey', definition.experiment.sampling.stratumKey],
+  ] as const;
+
+  for (const [field, pointer] of pointers) {
+    if (pointer === undefined) continue;
+    for (const sample of executionSamples) {
+      if (!resolvesPointer(sample, pointer)) {
+        throw definitionError(
+          'EVAL_DEFINITION_MISSING_REFERENCE',
+          `SamplingDesign.${field} 无法在 execution-visible sample 中定位值。`,
+          {
+            location: `experiment.sampling.${field}`,
+            sampleId: sample.sampleId,
+          },
+        );
+      }
+    }
+  }
+}
+
+function validateEvaluatorBindings(definition: EvaluationDefinition): void {
+  for (const evaluator of definition.evaluators) {
+    assertUnique(
+      evaluator.inputs.map((binding) => binding.bindingId),
+      `evaluator:${evaluator.evaluatorId}:binding`,
+    );
+    for (const binding of evaluator.inputs) {
+      if (binding.sourceKind !== 'expected' && binding.sourceKind !== 'evaluation-context') {
+        continue;
+      }
+      const field = binding.sourceKind === 'expected' ? 'expected' : 'evaluationContext';
+      const samplesWithSource = definition.dataset.samples.filter(
+        (sample) => sample[field] !== undefined,
+      );
+      if (samplesWithSource.length === 0) {
+        throw definitionError(
+          'EVAL_DEFINITION_MISSING_REFERENCE',
+          `Evaluator binding 引用了 Dataset 中不存在的“${binding.sourceKind}”数据源。`,
+          {
+            evaluatorId: evaluator.evaluatorId,
+            bindingId: binding.bindingId,
+            sourceKind: binding.sourceKind,
+          },
+        );
+      }
+      for (const sample of samplesWithSource) {
+        if (resolvesPointer(sample[field], binding.pointer)) continue;
+        throw definitionError(
+          'EVAL_DEFINITION_MISSING_REFERENCE',
+          'Evaluator binding 的 JSON Pointer 无法定位数据。',
+          {
+            evaluatorId: evaluator.evaluatorId,
+            bindingId: binding.bindingId,
+            sampleId: sample.sampleId,
+          },
+        );
+      }
+    }
+  }
+}
+
+function validateMetric(metric: MetricDefinition): void {
+  if (metric.valueType !== 'numeric' && metric.scale !== undefined) {
+    throw definitionError(
+      'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+      '只有 numeric Metric 可以声明 scale。',
+      { metricId: metric.metricId },
+    );
+  }
+  if (metric.scale?.min !== undefined && metric.scale.max !== undefined
+      && metric.scale.min > metric.scale.max) {
+    throw definitionError(
+      'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+      'Metric scale 的 min 不能大于 max。',
+      { metricId: metric.metricId },
+    );
+  }
+  if (metric.direction === 'target-is-best' && metric.scale?.target === undefined) {
+    throw definitionError(
+      'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+      'target-is-best Metric 必须声明 scale.target。',
+      { metricId: metric.metricId },
+    );
+  }
+  const target = metric.scale?.target;
+  if (target !== undefined && (
+    (metric.scale?.min !== undefined && target < metric.scale.min)
+    || (metric.scale?.max !== undefined && target > metric.scale.max)
+  )) {
+    throw definitionError(
+      'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+      'Metric scale.target 必须位于声明的 scale 范围内。',
+      { metricId: metric.metricId },
+    );
+  }
+}
+
+function validateSamplingDesign(definition: EvaluationDefinition): void {
+  const { experiment } = definition;
+  const { sampling, scheduling } = experiment;
+  if (experiment.trials > 1 && !sampling.repeatedMeasures) {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      'trials 大于 1 时必须显式声明 repeatedMeasures。',
+      { location: 'experiment.sampling.repeatedMeasures' },
+    );
+  }
+  if (sampling.resamplingUnit === 'paired-block') {
+    if (sampling.pairingKey === undefined || definition.comparisons.length === 0) {
+      throw definitionError(
+        'EVAL_DEFINITION_POLICY_INVALID',
+        'paired-block 重采样要求 pairingKey 和至少一个 Comparison。',
+        { location: 'experiment.sampling' },
+      );
+    }
+  } else if (sampling.pairingKey !== undefined) {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      'pairingKey 只能与 paired-block 重采样一起使用。',
+      { location: 'experiment.sampling.pairingKey' },
+    );
+  }
+  if (sampling.experimentalUnit === 'cluster' || sampling.resamplingUnit === 'cluster') {
+    if (sampling.clusterKey === undefined
+        || sampling.experimentalUnit !== 'cluster'
+        || sampling.resamplingUnit !== 'cluster') {
+      throw definitionError(
+        'EVAL_DEFINITION_POLICY_INVALID',
+        'cluster 设计要求 experimentalUnit、resamplingUnit 和 clusterKey 一致声明。',
+        { location: 'experiment.sampling' },
+      );
+    }
+  } else if (sampling.clusterKey !== undefined) {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      'clusterKey 只能用于 cluster experimental unit。',
+      { location: 'experiment.sampling.clusterKey' },
+    );
+  }
+  if ((sampling.experimentalUnit === 'run') !== (sampling.resamplingUnit === 'run')) {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      'run experimental unit 必须使用 run resampling unit，反之亦然。',
+      { location: 'experiment.sampling' },
+    );
+  }
+  if (scheduling.schedulingKind === 'randomized-block') {
+    if (scheduling.blockSize === undefined) {
+      throw definitionError(
+        'EVAL_DEFINITION_POLICY_INVALID',
+        'randomized-block scheduling 必须声明 blockSize。',
+        { location: 'experiment.scheduling.blockSize' },
+      );
+    }
+  } else if (scheduling.blockSize !== undefined) {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      'blockSize 只能用于 randomized-block scheduling。',
+      { location: 'experiment.scheduling.blockSize' },
+    );
+  }
+  if (sampling.resamplingUnit === 'paired-block'
+      && scheduling.schedulingKind === 'randomized-block') {
+    const requiredBlockSize = Math.max(...definition.comparisons.map(
+      (comparison) => 1 + comparison.treatmentTargetIds.length,
+    ));
+    if ((scheduling.blockSize ?? 0) < requiredBlockSize) {
+      throw definitionError(
+        'EVAL_DEFINITION_POLICY_INVALID',
+        'randomized block 必须容纳完整的 control／treatment scheduling block。',
+        { location: 'experiment.scheduling.blockSize', requiredMinimum: requiredBlockSize },
+      );
+    }
+  }
+  validateDesignPointers(definition);
+}
+
+function validatePolicy(
+  definition: EvaluationDefinition,
+  policy: MeasurementPolicy,
+): void {
+  if (policy.failure.failureMode === 'failure-threshold') {
+    if (policy.failure.maxFailures === undefined) {
+      throw definitionError(
+        'EVAL_DEFINITION_POLICY_INVALID',
+        'failure-threshold 模式必须声明 maxFailures。',
+        { location: 'failure.maxFailures' },
+      );
+    }
+  } else if (policy.failure.maxFailures !== undefined) {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      'maxFailures 只能用于 failure-threshold 模式。',
+      { location: 'failure.maxFailures' },
+    );
+  }
+
+  const { backoff } = policy.retry;
+  if (backoff.backoffKind === 'none'
+      && (backoff.initialDelayMs !== 0 || backoff.maxDelayMs !== undefined)) {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      'none backoff 必须使用 0 initialDelayMs 且不声明 maxDelayMs。',
+      { location: 'retry.backoff' },
+    );
+  }
+  if (backoff.maxDelayMs !== undefined && backoff.maxDelayMs < backoff.initialDelayMs) {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      'maxDelayMs 不能小于 initialDelayMs。',
+      { location: 'retry.backoff.maxDelayMs' },
+    );
+  }
+
+  const { eventDelivery } = policy;
+  if (eventDelivery.writerMode === 'disabled'
+      && eventDelivery.writerFailureMode !== 'ignore') {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      'EventWriter 禁用时 writerFailureMode 必须为 ignore。',
+      { location: 'eventDelivery' },
+    );
+  }
+  if (eventDelivery.writerMode === 'required'
+      && eventDelivery.writerFailureMode !== 'fail-run') {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      '必需的 EventWriter 失败时必须 fail-run。',
+      { location: 'eventDelivery' },
+    );
+  }
+
+  if (definition.experiment.sampling.resamplingUnit === 'paired-block') {
+    const smallestBlock = Math.min(...definition.comparisons.map(
+      (comparison) => 1 + comparison.treatmentTargetIds.length,
+    ));
+    if (policy.budget.maxTargetInvocations !== undefined
+        && policy.budget.maxTargetInvocations < smallestBlock) {
+      throw definitionError(
+        'EVAL_DEFINITION_POLICY_INVALID',
+        'Target invocation budget 不足以启动一个完整的 paired block。',
+        { location: 'budget.maxTargetInvocations', requiredMinimum: smallestBlock },
+      );
+    }
+  }
+}
+
+function validateGraph(
+  nodes: readonly AnalysisNodeDefinition[],
+  metricIds: ReadonlySet<string>,
+): void {
+  const resultProducer = new Map<string, string>();
+  for (const node of nodes) resultProducer.set(node.outputResultId, node.nodeId);
+  const dependencies = new Map<string, Set<string>>();
+  for (const node of nodes) {
+    const nodeDependencies = new Set<string>();
+    for (const input of node.inputs) {
+      if (input.inputKind === 'metric-observations') {
+        assertReference(
+          metricIds,
+          input.referenceId,
+          `analysisGraph.nodes.${node.nodeId}.inputs`,
+          'Metric',
+        );
+      } else {
+        const producer = resultProducer.get(input.referenceId);
+        if (producer === undefined) {
+          throw definitionError(
+            'EVAL_DEFINITION_MISSING_REFERENCE',
+            'Analysis input 引用了不存在的 AnalysisResult。',
+            {
+              location: `analysisGraph.nodes.${node.nodeId}.inputs`,
+              referenceKind: 'AnalysisResult',
+              referenceId: input.referenceId,
+            },
+          );
+        }
+        nodeDependencies.add(producer);
+      }
+    }
+    dependencies.set(node.nodeId, nodeDependencies);
+  }
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const visit = (nodeId: string): void => {
+    if (visiting.has(nodeId)) {
+      throw definitionError(
+        'EVAL_DEFINITION_GRAPH_CYCLE',
+        'AnalysisGraph 必须是无环图。',
+        { nodeId },
+      );
+    }
+    if (visited.has(nodeId)) return;
+    visiting.add(nodeId);
+    for (const dependency of dependencies.get(nodeId) ?? []) visit(dependency);
+    visiting.delete(nodeId);
+    visited.add(nodeId);
+  };
+  for (const node of nodes) visit(node.nodeId);
+}
+
+export function validateDefinitionSemantics(
+  definition: EvaluationDefinition,
+  policy: MeasurementPolicy,
+): void {
+  assertUnique(definition.dataset.samples.map((sample) => sample.sampleId), 'sample');
+  assertUnique(definition.targets.map((target) => target.targetId), 'target');
+  assertUnique(definition.evaluators.map((evaluator) => evaluator.evaluatorId), 'evaluator');
+  assertUnique(definition.metrics.map((metric) => metric.metricId), 'metric');
+  assertUnique(definition.analysisGraph.nodes.map((node) => node.nodeId), 'analysis-node');
+  assertUnique(
+    definition.analysisGraph.nodes.map((node) => node.outputResultId),
+    'analysis-result',
+  );
+  assertUnique(definition.comparisons.map((comparison) => comparison.comparisonId), 'comparison');
+
+  const targetIds = new Set(definition.targets.map((target) => target.targetId));
+  const metricIds = new Set(definition.metrics.map((metric) => metric.metricId));
+  const resultIds = new Set(
+    definition.analysisGraph.nodes.map((node) => node.outputResultId),
+  );
+
+  for (const evaluator of definition.evaluators) {
+    assertUnique(evaluator.metricIds, `evaluator:${evaluator.evaluatorId}:metric`);
+    for (const metricId of evaluator.metricIds) {
+      assertReference(
+        metricIds,
+        metricId,
+        `evaluators.${evaluator.evaluatorId}.metricIds`,
+        'Metric',
+      );
+    }
+  }
+  for (const comparison of definition.comparisons) {
+    assertReference(
+      targetIds,
+      comparison.controlTargetId,
+      `comparisons.${comparison.comparisonId}.controlTargetId`,
+      'Target',
+    );
+    assertUnique(
+      comparison.treatmentTargetIds,
+      `comparison:${comparison.comparisonId}:treatment-target`,
+    );
+    for (const targetId of comparison.treatmentTargetIds) {
+      assertReference(
+        targetIds,
+        targetId,
+        `comparisons.${comparison.comparisonId}.treatmentTargetIds`,
+        'Target',
+      );
+      if (targetId === comparison.controlTargetId) {
+        throw definitionError(
+          'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+          'Comparison 的 control 与 treatment 必须是不同 Target。',
+          { comparisonId: comparison.comparisonId, targetId },
+        );
+      }
+    }
+    assertUnique(comparison.metricIds, `comparison:${comparison.comparisonId}:metric`);
+    for (const metricId of comparison.metricIds) {
+      assertReference(
+        metricIds,
+        metricId,
+        `comparisons.${comparison.comparisonId}.metricIds`,
+        'Metric',
+      );
+    }
+  }
+  if (definition.decisionPolicy !== undefined) {
+    assertUnique(definition.decisionPolicy.analysisResultIds, 'decision-policy:analysis-result');
+    for (const resultId of definition.decisionPolicy.analysisResultIds) {
+      assertReference(
+        resultIds,
+        resultId,
+        'decisionPolicy.analysisResultIds',
+        'AnalysisResult',
+      );
+    }
+  }
+  for (const metric of definition.metrics) validateMetric(metric);
+  validateEvaluatorBindings(definition);
+  validateSamplingDesign(definition);
+  validateGraph(definition.analysisGraph.nodes, metricIds);
+  validatePolicy(definition, policy);
+}
+
+export function validateAnalysisInputs(
+  node: AnalysisNodeDefinition,
+  capabilities: AnalysisCapabilities,
+  metricsById: ReadonlyMap<string, MetricDefinition>,
+  outputSchemasByResultId: ReadonlyMap<string, string>,
+): void {
+  for (const input of node.inputs) {
+    if (input.inputKind === 'metric-observations') {
+      const metric = metricsById.get(input.referenceId);
+      const compatible = capabilities.inputDomains.some((domain) => (
+        domain.inputKind === 'metric-observations'
+        && metric !== undefined
+        && domain.valueTypes.includes(metric.valueType)
+        && (domain.missingPolicyIds === undefined
+          || domain.missingPolicyIds.includes(metric.missingPolicyId))
+      ));
+      if (compatible) continue;
+    } else {
+      const schemaUri = outputSchemasByResultId.get(input.referenceId);
+      const compatible = capabilities.inputDomains.some((domain) => (
+        domain.inputKind === 'analysis-result'
+        && schemaUri !== undefined
+        && domain.schemaUris.includes(schemaUri)
+      ));
+      if (compatible) continue;
+    }
+    throw definitionError(
+      'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+      'Analysis implementation 不接受声明的输入值域。',
+      { nodeId: node.nodeId, inputKind: input.inputKind, referenceId: input.referenceId },
+    );
+  }
+}

--- a/test/evaluation-core/compiler/compiler.test.ts
+++ b/test/evaluation-core/compiler/compiler.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EvaluationDefinitionError,
+  prepareEvaluationPlan,
+} from '../../../src/evaluation-core/compiler/index.js';
+import type { JsonValue } from '../../../src/evaluation-core/contracts/index.js';
+import {
+  testRuntime,
+  validDefinition,
+  validPolicy,
+} from './fixtures.js';
+
+function extension(data: JsonValue) {
+  return {
+    schemaUri: 'urn:example:schema:extension:v1',
+    schemaDigest: `sha256:${'a'.repeat(64)}` as const,
+    data,
+  };
+}
+
+describe('prepareEvaluationPlan', () => {
+  it('resolves actual runtime facts and produces a deterministic sealed plan', async () => {
+    const definition = validDefinition();
+    const policy = validPolicy();
+    const runtime = testRuntime();
+    const first = await prepareEvaluationPlan(definition, policy, runtime);
+    const second = await prepareEvaluationPlan(
+      structuredClone(definition),
+      structuredClone(policy),
+      testRuntime(),
+    );
+
+    expect(second).toEqual(first);
+    expect(first.execution.runtimes).toHaveLength(2);
+    expect(first.execution.runtimes[0].identity.implementationId).toBe('actual-executor/v1');
+    expect(first.schemaIdentities.some(
+      (identity) => identity.schemaUri === 'urn:example:schema:omk.invoke/v1:input:v1',
+    )).toBe(true);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first.execution.samples[0].input)).toBe(true);
+    expect(() => {
+      (first.execution.samples[0].input as { question: string }).question = 'mutated';
+    }).toThrow();
+  });
+
+  it('takes an independent snapshot of inputs and resolver results', async () => {
+    const definition = validDefinition();
+    const policy = validPolicy();
+    const runtime = testRuntime();
+    const plan = await prepareEvaluationPlan(definition, policy, runtime);
+    const originalDigest = plan.digests.runContractDigest;
+
+    (definition.dataset.samples[0].expected as { answer: string }).answer = 'changed';
+    policy.execution.maxConcurrency = 99;
+    runtime.returnedIdentities[0].fingerprint = 'mutated-after-prepare';
+
+    expect(plan.evaluation.samples[0].expected).toEqual({ answer: 'A' });
+    expect(plan.measurementPolicy.execution.maxConcurrency).toBe(2);
+    expect(plan.execution.runtimes[0].identity.fingerprint).toBe('executor-fingerprint-1');
+    expect(plan.digests.runContractDigest).toBe(originalDigest);
+  });
+
+  it('keeps Gold, evaluation context, and annotations out of ExecutionPlan', async () => {
+    const plan = await prepareEvaluationPlan(
+      validDefinition(),
+      validPolicy(),
+      testRuntime(),
+    );
+
+    expect(plan.execution.samples[0]).toEqual({
+      sampleId: 'sample-1',
+      input: { question: 'Q', cohort: 'a' },
+      executionContext: { locale: 'zh-CN' },
+    });
+    expect(plan.execution.samples[0]).not.toHaveProperty('expected');
+    expect(plan.execution.samples[0]).not.toHaveProperty('evaluationContext');
+    expect(plan.execution.samples[0]).not.toHaveProperty('annotations');
+    expect(plan.evaluation.samples[0]).toMatchObject({
+      expected: { answer: 'A' },
+      evaluationContext: { rubric: 'correctness' },
+    });
+    expect(plan.evaluation.samples[0]).not.toHaveProperty('annotations');
+  });
+
+  it('routes validated extensions only to their declared impact stage', async () => {
+    const definition = validDefinition();
+    definition.extensions = {
+      'urn:example:execution-extension': extension({ temperature: 0 }),
+    };
+    const policy = validPolicy();
+    policy.extensions = {
+      'urn:example:audit-extension': extension({ ticket: 'ABC-1' }),
+      'urn:example:run-extension': extension({ governance: 'strict' }),
+    };
+    const runtime = testRuntime({
+      extensionStages: {
+        'urn:example:execution-extension': 'execution',
+        'urn:example:audit-extension': 'audit',
+        'urn:example:run-extension': 'run',
+      },
+    });
+
+    const plan = await prepareEvaluationPlan(definition, policy, runtime);
+
+    expect(plan.execution.extensions).toHaveProperty('urn:example:execution-extension');
+    expect(plan.extensions).toHaveProperty('urn:example:run-extension');
+    expect(plan.extensions).not.toHaveProperty('urn:example:audit-extension');
+    expect(plan.measurementPolicy.extensions).toHaveProperty('urn:example:audit-extension');
+    expect(runtime.calls.extension).toBe(3);
+  });
+
+  it('does not branch on descriptive targetKind', async () => {
+    const definition = validDefinition();
+    definition.targets[0].targetKind = 'future-target-kind';
+
+    const plan = await prepareEvaluationPlan(definition, validPolicy(), testRuntime());
+
+    expect(plan.execution.targets[0].targetKind).toBe('future-target-kind');
+    expect(plan.execution.runtimes[0].identity.implementationId).toBe('actual-executor/v1');
+  });
+
+  it('selects invoke and session behavior through protocol manifests', async () => {
+    const definition = validDefinition();
+    definition.targets[0].protocolId = 'omk.session/v1';
+    const plan = await prepareEvaluationPlan(
+      definition,
+      validPolicy(),
+      testRuntime({ executorProtocols: ['omk.invoke/v1', 'omk.session/v1'] }),
+    );
+
+    expect(plan.execution.targets.map((target) => target.protocolId)).toEqual([
+      'omk.session/v1',
+      'omk.invoke/v1',
+    ]);
+  });
+
+  it('normalizes set-like capability manifest ordering deterministically', async () => {
+    const definition = validDefinition();
+    const first = await prepareEvaluationPlan(
+      definition,
+      validPolicy(),
+      testRuntime({ executorProtocols: ['omk.invoke/v1', 'omk.session/v1'] }),
+    );
+    const second = await prepareEvaluationPlan(
+      definition,
+      validPolicy(),
+      testRuntime({ executorProtocols: ['omk.session/v1', 'omk.invoke/v1'] }),
+    );
+
+    expect(second).toEqual(first);
+  });
+
+  it('redacts resolver exceptions from the public error and cause chain', async () => {
+    await expect(prepareEvaluationPlan(
+      validDefinition(),
+      validPolicy(),
+      testRuntime({ throwExecutor: true }),
+    )).rejects.toMatchObject({
+      code: 'EVAL_DEFINITION_RUNTIME_RESOLUTION_FAILED',
+      stage: 'infrastructure',
+      preparationStage: 'runtime-resolution',
+    });
+    try {
+      await prepareEvaluationPlan(
+        validDefinition(),
+        validPolicy(),
+        testRuntime({ throwExecutor: true }),
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(EvaluationDefinitionError);
+      expect(JSON.stringify(error)).not.toContain('secret provider response');
+    }
+  });
+});

--- a/test/evaluation-core/compiler/digests.test.ts
+++ b/test/evaluation-core/compiler/digests.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { prepareEvaluationPlan } from '../../../src/evaluation-core/compiler/index.js';
+import { testRuntime, validDefinition, validPolicy } from './fixtures.js';
+
+async function compile(
+  mutateDefinition?: (definition: ReturnType<typeof validDefinition>) => void,
+  mutatePolicy?: (policy: ReturnType<typeof validPolicy>) => void,
+  runtime = testRuntime(),
+) {
+  const definition = validDefinition();
+  const policy = validPolicy();
+  mutateDefinition?.(definition);
+  mutatePolicy?.(policy);
+  return prepareEvaluationPlan(definition, policy, runtime);
+}
+
+function expectStages(
+  before: Awaited<ReturnType<typeof compile>>,
+  after: Awaited<ReturnType<typeof compile>>,
+  changed: Array<'execution' | 'evaluation' | 'analysis' | 'decision' | 'run'>,
+): void {
+  const fields = {
+    execution: 'executionPlanDigest',
+    evaluation: 'evaluationPlanDigest',
+    analysis: 'analysisPlanDigest',
+    decision: 'decisionPlanDigest',
+    run: 'runContractDigest',
+  } as const;
+  for (const [stage, field] of Object.entries(fields)) {
+    if (changed.includes(stage as keyof typeof fields)) {
+      expect(after.digests[field], `${stage} should change`).not.toBe(before.digests[field]);
+    } else {
+      expect(after.digests[field], `${stage} should remain stable`).toBe(before.digests[field]);
+    }
+  }
+}
+
+describe('Compiler digest invalidation boundaries', () => {
+  it('keeps property order and annotations out of measurement identity', async () => {
+    const before = await compile();
+    const reordered = await compile((definition) => {
+      definition.dataset.samples[0].input = { cohort: 'a', question: 'Q' };
+      definition.dataset.samples[0].annotations = { owner: 'team-b' };
+      definition.dataset.annotations = { project: 'changed' };
+    });
+
+    expectStages(before, reordered, []);
+    expect(reordered.digests.datasetRevisionDigest).not.toBe(before.digests.datasetRevisionDigest);
+  });
+
+  it('invalidates Evaluation and downstream for Gold', async () => {
+    const before = await compile();
+    const after = await compile((definition) => {
+      definition.dataset.samples[0].expected = { answer: 'B' };
+    });
+    expectStages(before, after, ['evaluation', 'analysis', 'decision', 'run']);
+  });
+
+  it('invalidates Evaluation and downstream for Evaluator and Metric changes', async () => {
+    const before = await compile();
+    const after = await compile((definition) => {
+      definition.evaluators[0].config = { strict: true };
+    });
+    expectStages(before, after, ['evaluation', 'analysis', 'decision', 'run']);
+  });
+
+  it('invalidates Analysis and downstream for AnalysisGraph changes', async () => {
+    const before = await compile();
+    const after = await compile((definition) => {
+      definition.analysisGraph.nodes[0].parameters = { minimumCoverage: 0.9 };
+    });
+    expectStages(before, after, ['analysis', 'decision', 'run']);
+  });
+
+  it('invalidates only Decision and root for Comparison or DecisionPolicy changes', async () => {
+    const before = await compile();
+    const after = await compile((definition) => {
+      definition.decisionPolicy!.parameters = { threshold: 0.1 };
+    });
+    expectStages(before, after, ['decision', 'run']);
+  });
+
+  it('keeps evaluation cache out of Execution identity', async () => {
+    const before = await compile();
+    const after = await compile(undefined, (policy) => {
+      policy.cache.evaluationMode = 'reuse';
+    });
+    expectStages(before, after, ['evaluation', 'analysis', 'decision', 'run']);
+  });
+
+  it('keeps EventDeliveryPolicy out of all stage plans and binds it at root', async () => {
+    const before = await compile();
+    const after = await compile(undefined, (policy) => {
+      policy.eventDelivery = {
+        writerMode: 'required',
+        backpressureMode: 'block',
+        writerFailureMode: 'fail-run',
+      };
+    });
+    expectStages(before, after, ['run']);
+  });
+
+  it('invalidates Execution and all downstream plans for executor fingerprint changes', async () => {
+    const before = await compile();
+    const after = await compile(undefined, undefined, testRuntime({
+      executorFingerprint: 'executor-fingerprint-2',
+    }));
+    expectStages(before, after, ['execution', 'evaluation', 'analysis', 'decision', 'run']);
+  });
+
+  it('binds extensions only to the stage declared by their validator', async () => {
+    const namespace = 'urn:example:stage-extension';
+    const compileExtension = async (data: string, impactStage: 'execution' | 'audit') => {
+      const definition = validDefinition();
+      definition.extensions = {
+        [namespace]: {
+          schemaUri: 'urn:example:schema:stage-extension:v1',
+          schemaDigest: `sha256:${'a'.repeat(64)}`,
+          data: { value: data },
+        },
+      };
+      return prepareEvaluationPlan(
+        definition,
+        validPolicy(),
+        testRuntime({ extensionStages: { [namespace]: impactStage } }),
+      );
+    };
+    const executionBefore = await compileExtension('a', 'execution');
+    const executionAfter = await compileExtension('b', 'execution');
+    expectStages(
+      executionBefore,
+      executionAfter,
+      ['execution', 'evaluation', 'analysis', 'decision', 'run'],
+    );
+
+    const auditBefore = await compileExtension('a', 'audit');
+    const auditAfter = await compileExtension('b', 'audit');
+    expectStages(auditBefore, auditAfter, []);
+  });
+
+  it('binds runtime schema identity changes into the affected stage and root contract', async () => {
+    const before = await compile();
+    const runtime = testRuntime();
+    const originalResolve = runtime.resolveEvaluator.bind(runtime);
+    runtime.resolveEvaluator = async (requirement) => {
+      const resolution = await originalResolve(requirement) as {
+        identity: { capabilities: { schemas: Array<{ schemaDigest: string }> } };
+      } & Record<string, unknown>;
+      resolution.identity.capabilities.schemas[0].schemaDigest = `sha256:${'f'.repeat(64)}`;
+      return resolution;
+    };
+    const after = await compile(undefined, undefined, runtime);
+
+    expectStages(before, after, ['evaluation', 'analysis', 'decision', 'run']);
+    expect(after.schemaIdentities).not.toEqual(before.schemaIdentities);
+  });
+});

--- a/test/evaluation-core/compiler/fixtures.ts
+++ b/test/evaluation-core/compiler/fixtures.ts
@@ -1,0 +1,262 @@
+import {
+  EVALUATION_DEFINITION_SCHEMA_VERSION,
+  MEASUREMENT_POLICY_SCHEMA_VERSION,
+  digestCanonicalJson,
+  type EvaluationDefinition,
+  type MeasurementPolicy,
+  type RuntimeIdentity,
+  type SchemaIdentity,
+} from '../../../src/evaluation-core/contracts/index.js';
+import type {
+  AnalysisRuntimeRequirement,
+  ExtensionValidationRequest,
+  PreparationRuntime,
+} from '../../../src/evaluation-core/compiler/index.js';
+
+function schemaIdentity(name: string): SchemaIdentity {
+  return {
+    schemaVersion: `example.${name}/v1`,
+    schemaUri: `urn:example:schema:${name}:v1`,
+    schemaDigest: digestCanonicalJson({ name, version: 1 }),
+  };
+}
+
+function identity(
+  implementationId: string,
+  fingerprint: string,
+  capabilities: RuntimeIdentity['capabilities'],
+): RuntimeIdentity {
+  return {
+    implementationId,
+    version: '1.0.0',
+    fingerprint,
+    fingerprintBasis: 'content-derived',
+    assuranceLevel: 'verified',
+    capabilities,
+  };
+}
+
+export function validDefinition(): EvaluationDefinition {
+  return {
+    schemaVersion: EVALUATION_DEFINITION_SCHEMA_VERSION,
+    dataset: {
+      datasetId: 'dataset-1',
+      samples: [{
+        sampleId: 'sample-1',
+        input: { question: 'Q', cohort: 'a' },
+        executionContext: { locale: 'zh-CN' },
+        expected: { answer: 'A' },
+        evaluationContext: { rubric: 'correctness' },
+        annotations: { owner: 'team-a' },
+      }],
+      annotations: { project: 'omk' },
+    },
+    targets: [
+      {
+        targetId: 'control',
+        targetKind: 'function',
+        protocolId: 'omk.invoke/v1',
+        executorId: 'executor-alias',
+        versionConstraint: '^1.0.0',
+      },
+      {
+        targetId: 'treatment',
+        targetKind: 'agent',
+        protocolId: 'omk.invoke/v1',
+        executorId: 'executor-alias',
+        versionConstraint: '^1.0.0',
+      },
+    ],
+    evaluators: [{
+      evaluatorId: 'exact',
+      evaluatorKind: 'assertion',
+      implementationId: 'exact/v1',
+      versionConstraint: '^1.0.0',
+      metricIds: ['correct'],
+      inputs: [
+        { bindingId: 'actual', sourceKind: 'output', pointer: '/answer' },
+        { bindingId: 'gold', sourceKind: 'expected', pointer: '/answer' },
+      ],
+    }],
+    metrics: [{
+      metricId: 'correct',
+      valueType: 'boolean',
+      scope: 'sample',
+      direction: 'higher-is-better',
+      missingPolicyId: 'exclude/v1',
+    }],
+    experiment: {
+      trials: 1,
+      seed: 'seed-1',
+      sampling: {
+        experimentalUnit: 'sample',
+        repeatedMeasures: false,
+        resamplingUnit: 'sample',
+        estimatorId: 'bootstrap.mean-percentile/v1',
+      },
+      scheduling: { schedulingKind: 'interleaved' },
+    },
+    analysisGraph: {
+      nodes: [{
+        analysisNodeKind: 'reducer',
+        nodeId: 'mean-correct',
+        implementationId: 'descriptive.rate/v1',
+        inputs: [{ inputKind: 'metric-observations', referenceId: 'correct' }],
+        outputResultId: 'correct-rate',
+        parameters: { minimumCoverage: 0.8 },
+      }],
+    },
+    comparisons: [{
+      comparisonId: 'control-vs-treatment',
+      controlTargetId: 'control',
+      treatmentTargetIds: ['treatment'],
+      metricIds: ['correct'],
+    }],
+    decisionPolicy: {
+      decisionPolicyId: 'release-gate',
+      implementationId: 'progress/v1',
+      analysisResultIds: ['correct-rate'],
+      minimumEvidenceStatus: 'complete',
+      parameters: { threshold: 0 },
+    },
+  };
+}
+
+export function validPolicy(): MeasurementPolicy {
+  return {
+    schemaVersion: MEASUREMENT_POLICY_SCHEMA_VERSION,
+    execution: { maxConcurrency: 2, timeoutMs: 10_000 },
+    retry: {
+      maxAttempts: 2,
+      retryableErrorCodes: ['timeout'],
+      backoff: {
+        backoffKind: 'exponential',
+        initialDelayMs: 10,
+        maxDelayMs: 100,
+      },
+    },
+    budget: { maxTargetInvocations: 100 },
+    cache: { executionMode: 'disabled', evaluationMode: 'disabled' },
+    evidence: {
+      input: 'digest',
+      output: 'full',
+      trace: 'reference',
+      expected: 'digest',
+      evidence: 'full',
+      maximumClassification: 'gold',
+    },
+    failure: { failureMode: 'continue' },
+    eventDelivery: {
+      writerMode: 'disabled',
+      backpressureMode: 'block',
+      writerFailureMode: 'ignore',
+    },
+  };
+}
+
+interface RuntimeOptions {
+  executorFingerprint?: string;
+  deterministic?: boolean;
+  executorProtocols?: Array<'omk.invoke/v1' | 'omk.session/v1'>;
+  evaluatorValueTypes?: Array<'numeric' | 'boolean' | 'categorical' | 'text' | 'ranking'>;
+  analysisValueTypes?: Array<'numeric' | 'boolean' | 'categorical' | 'text' | 'ranking'>;
+  samplingResamplingUnits?: Array<'sample' | 'paired-block' | 'cluster' | 'run'>;
+  versionSatisfied?: boolean;
+  throwExecutor?: boolean;
+  extensionStages?: Record<string, 'execution' | 'evaluation' | 'analysis' | 'decision' | 'run' | 'audit'>;
+  rejectExtension?: string;
+}
+
+export interface TestRuntime extends PreparationRuntime {
+  calls: {
+    executor: number;
+    evaluator: number;
+    analysis: number;
+    extension: number;
+  };
+  returnedIdentities: RuntimeIdentity[];
+}
+
+export function testRuntime(options: RuntimeOptions = {}): TestRuntime {
+  const calls = { executor: 0, evaluator: 0, analysis: 0, extension: 0 };
+  const returnedIdentities: RuntimeIdentity[] = [];
+  const remember = (value: RuntimeIdentity): RuntimeIdentity => {
+    returnedIdentities.push(value);
+    return value;
+  };
+  return {
+    calls,
+    returnedIdentities,
+    resolveExecutor(requirement) {
+      calls.executor += 1;
+      if (options.throwExecutor) throw new Error('secret provider response');
+      if (!Object.isFrozen(requirement)) throw new Error('requirement is mutable');
+      const protocols = options.executorProtocols ?? ['omk.invoke/v1'];
+      return {
+        identity: remember(identity(
+          'actual-executor/v1',
+          options.executorFingerprint ?? 'executor-fingerprint-1',
+          {
+            protocols: protocols.map((protocolId) => ({
+              protocolId,
+              inputSchema: schemaIdentity(`${protocolId}:input`),
+              outputSchema: schemaIdentity(`${protocolId}:output`),
+              deterministic: options.deterministic ?? true,
+            })),
+          },
+        )),
+        satisfiesVersionConstraint: options.versionSatisfied ?? true,
+      };
+    },
+    resolveEvaluator(requirement) {
+      calls.evaluator += 1;
+      if (!Object.isFrozen(requirement)) throw new Error('requirement is mutable');
+      return {
+        identity: remember(identity('actual-evaluator/v1', 'evaluator-fingerprint-1', {
+          inputSourceKinds: ['output', 'trace', 'expected', 'evaluation-context'],
+          metricValueTypes: options.evaluatorValueTypes ?? ['boolean'],
+          schemas: [schemaIdentity('evaluator-io')],
+        })),
+        satisfiesVersionConstraint: options.versionSatisfied ?? true,
+      };
+    },
+    resolveAnalysis(requirement: Readonly<AnalysisRuntimeRequirement>) {
+      calls.analysis += 1;
+      if (!Object.isFrozen(requirement)) throw new Error('requirement is mutable');
+      const isSampling = requirement.requirementKind === 'sampling-estimator';
+      return {
+        identity: remember(identity(
+          `actual-${isSampling ? 'estimator' : 'analysis'}/v1`,
+          `${isSampling ? 'estimator' : 'analysis'}-fingerprint-1`,
+          {
+            analysisNodeKinds: [isSampling ? 'estimator' : requirement.analysisNodeKind],
+            inputDomains: isSampling ? [] : [{
+              inputKind: 'metric-observations',
+              valueTypes: options.analysisValueTypes ?? ['boolean'],
+              missingPolicyIds: ['exclude/v1'],
+            }],
+            outputSchema: schemaIdentity(isSampling ? 'estimator-output' : 'analysis-output'),
+            ...(isSampling ? {
+              sampling: {
+                experimentalUnits: ['sample'],
+                repeatedMeasures: [false],
+                resamplingUnits: options.samplingResamplingUnits ?? ['sample'],
+              },
+            } : {}),
+            schemas: [],
+          },
+        )),
+        satisfiesVersionConstraint: options.versionSatisfied ?? true,
+      };
+    },
+    validateExtension(request: Readonly<ExtensionValidationRequest>) {
+      calls.extension += 1;
+      if (!Object.isFrozen(request) || !Object.isFrozen(request.entry)) {
+        throw new Error('extension request is mutable');
+      }
+      if (options.rejectExtension === request.namespace) throw new Error('invalid extension');
+      const impactStage = options.extensionStages?.[request.namespace];
+      return impactStage === undefined ? {} : { impactStage };
+    },
+  };
+}

--- a/test/evaluation-core/compiler/validation.test.ts
+++ b/test/evaluation-core/compiler/validation.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EvaluationDefinitionError,
+  prepareEvaluationPlan,
+} from '../../../src/evaluation-core/compiler/index.js';
+import { testRuntime, validDefinition, validPolicy } from './fixtures.js';
+
+async function expectCode(
+  definition: unknown,
+  policy: unknown,
+  code: string,
+  runtime = testRuntime(),
+): Promise<void> {
+  try {
+    await prepareEvaluationPlan(definition, policy, runtime);
+    throw new Error('expected prepareEvaluationPlan to fail');
+  } catch (error) {
+    expect(error).toBeInstanceOf(EvaluationDefinitionError);
+    expect(error).toMatchObject({ code });
+  }
+}
+
+describe('Compiler definition validation', () => {
+  it('rejects schema and semantic failures before any runtime resolution', async () => {
+    const schemaRuntime = testRuntime();
+    await expectCode(
+      { ...validDefinition(), typo: true },
+      validPolicy(),
+      'EVAL_DEFINITION_SCHEMA_INVALID',
+      schemaRuntime,
+    );
+    expect(schemaRuntime.calls).toEqual({ executor: 0, evaluator: 0, analysis: 0, extension: 0 });
+
+    const duplicate = validDefinition();
+    duplicate.dataset.samples.push(structuredClone(duplicate.dataset.samples[0]));
+    const semanticRuntime = testRuntime();
+    await expectCode(
+      duplicate,
+      validPolicy(),
+      'EVAL_DEFINITION_DUPLICATE_ID',
+      semanticRuntime,
+    );
+    expect(semanticRuntime.calls).toEqual({ executor: 0, evaluator: 0, analysis: 0, extension: 0 });
+  });
+
+  it('rejects missing references and invalid Metric value domains', async () => {
+    const missing = validDefinition();
+    missing.evaluators[0].metricIds = ['missing'];
+    await expectCode(
+      missing,
+      validPolicy(),
+      'EVAL_DEFINITION_MISSING_REFERENCE',
+    );
+
+    const invalidDomain = validDefinition();
+    invalidDomain.metrics[0] = {
+      ...invalidDomain.metrics[0],
+      valueType: 'boolean',
+      scale: { min: 0, max: 1 },
+    };
+    await expectCode(
+      invalidDomain,
+      validPolicy(),
+      'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+    );
+  });
+
+  it('rejects AnalysisGraph cycles and duplicate outputs', async () => {
+    const cycle = validDefinition();
+    cycle.analysisGraph.nodes = [
+      {
+        analysisNodeKind: 'reducer',
+        nodeId: 'a',
+        implementationId: 'reducer-a/v1',
+        inputs: [{ inputKind: 'analysis-result', referenceId: 'result-b' }],
+        outputResultId: 'result-a',
+      },
+      {
+        analysisNodeKind: 'reducer',
+        nodeId: 'b',
+        implementationId: 'reducer-b/v1',
+        inputs: [{ inputKind: 'analysis-result', referenceId: 'result-a' }],
+        outputResultId: 'result-b',
+      },
+    ];
+    cycle.decisionPolicy!.analysisResultIds = ['result-a'];
+    await expectCode(cycle, validPolicy(), 'EVAL_DEFINITION_GRAPH_CYCLE');
+
+    const duplicate = validDefinition();
+    duplicate.analysisGraph.nodes.push({
+      ...structuredClone(duplicate.analysisGraph.nodes[0]),
+      nodeId: 'second-node',
+    });
+    await expectCode(
+      duplicate,
+      validPolicy(),
+      'EVAL_DEFINITION_DUPLICATE_ID',
+    );
+  });
+
+  it('rejects inconsistent SamplingDesign and MeasurementPolicy combinations', async () => {
+    const sampling = validDefinition();
+    sampling.experiment.trials = 2;
+    await expectCode(
+      sampling,
+      validPolicy(),
+      'EVAL_DEFINITION_POLICY_INVALID',
+    );
+
+    const policy = validPolicy();
+    policy.failure = { failureMode: 'failure-threshold' };
+    await expectCode(
+      validDefinition(),
+      policy,
+      'EVAL_DEFINITION_POLICY_INVALID',
+    );
+  });
+
+  it('keeps scheduling pointers inside the execution-visible projection', async () => {
+    const definition = validDefinition();
+    definition.experiment.sampling = {
+      ...definition.experiment.sampling,
+      pairingKey: '/expected/answer',
+      resamplingUnit: 'paired-block',
+    };
+    await expectCode(
+      definition,
+      validPolicy(),
+      'EVAL_DEFINITION_MISSING_REFERENCE',
+    );
+  });
+
+  it('rejects unsupported protocol, deterministic cache, and evaluator capabilities', async () => {
+    const protocol = validDefinition();
+    protocol.targets[0].protocolId = 'omk.session/v1';
+    await expectCode(
+      protocol,
+      validPolicy(),
+      'EVAL_DEFINITION_PROTOCOL_INVALID',
+    );
+
+    const cachePolicy = validPolicy();
+    cachePolicy.cache.executionMode = 'transparent-deterministic';
+    await expectCode(
+      validDefinition(),
+      cachePolicy,
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ deterministic: false }),
+    );
+
+    await expectCode(
+      validDefinition(),
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ evaluatorValueTypes: ['numeric'] }),
+    );
+  });
+
+  it('rejects Analysis value-domain and SamplingDesign capability mismatches', async () => {
+    await expectCode(
+      validDefinition(),
+      validPolicy(),
+      'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+      testRuntime({ analysisValueTypes: ['numeric'] }),
+    );
+    await expectCode(
+      validDefinition(),
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ samplingResamplingUnits: ['cluster'] }),
+    );
+  });
+
+  it('rejects unresolved versions and invalid extensions', async () => {
+    await expectCode(
+      validDefinition(),
+      validPolicy(),
+      'EVAL_DEFINITION_RUNTIME_RESOLUTION_FAILED',
+      testRuntime({ versionSatisfied: false }),
+    );
+
+    const definition = validDefinition();
+    definition.extensions = {
+      'urn:example:unknown': {
+        schemaUri: 'urn:example:schema:extension:v1',
+        schemaDigest: `sha256:${'a'.repeat(64)}`,
+        data: { enabled: true },
+      },
+    };
+    await expectCode(
+      definition,
+      validPolicy(),
+      'EVAL_DEFINITION_EXTENSION_INVALID',
+      testRuntime(),
+    );
+    await expectCode(
+      definition,
+      validPolicy(),
+      'EVAL_DEFINITION_EXTENSION_INVALID',
+      testRuntime({
+        extensionStages: { 'urn:example:unknown': 'execution' },
+        rejectExtension: 'urn:example:unknown',
+      }),
+    );
+  });
+
+  it('returns equivalent error identity for property-order variations', async () => {
+    const first = validDefinition();
+    first.evaluators[0].metricIds = ['missing'];
+    const second = structuredClone(first);
+    second.dataset.samples[0].input = { cohort: 'a', question: 'Q' };
+
+    const errors: EvaluationDefinitionError[] = [];
+    for (const definition of [first, second]) {
+      try {
+        await prepareEvaluationPlan(definition, validPolicy(), testRuntime());
+      } catch (error) {
+        errors.push(error as EvaluationDefinitionError);
+      }
+    }
+    expect(errors).toHaveLength(2);
+    expect(errors[1].code).toBe(errors[0].code);
+    expect(errors[1].details).toEqual(errors[0].details);
+  });
+});


### PR DESCRIPTION
## 用户影响

- 新增宿主无关的 `prepareEvaluationPlan()`，把 EvaluationDefinition、MeasurementPolicy 与实际 Runtime resolution 编译成确定性、深度不可变的 v1 RunPlan。
- prepare 在任何 Target／Evaluator 测量入口之前完成 schema、引用、DAG、值域、SamplingDesign、policy、protocol、capability 与 extension 校验，并以稳定的结构化错误失败。
- ExecutionPlan 只保留 execution-visible sample 投影；Gold、evaluationContext 与 annotations 不进入 Executor 可见对象。
- 现有 CLI、Studio、旧 eval pipeline 与 Report schema 均不接线、不迁移，当前用户行为和历史报告可比性不受影响。

## 架构与测量边界

- Runtime requirement 通过注入的 PreparationRuntime 逐次解析，Plan 绑定实际 identity、fingerprint、fingerprint basis、assurance、protocol／capability manifest 与 schema identity，不信任 Definition 自报事实。
- 分层 digest 按 Execution、Evaluation、Analysis、Decision 和根 contract 封存；Gold、Evaluator、Analysis、Decision、cache、EventDelivery、extension、annotation 与 Runtime fingerprint 的失效边界分别受测试约束。
- extension 必须由宿主 validator 按 schema URI／digest 验证并返回明确影响阶段；纯审计 extension 不进入测量 digest。
- Compiler 不读写文件、环境变量或全局 registry，不创建 Run、session、Event stream、Bundle 或 Report。

## 迁移与 construct-validity 说明

本 PR 只建立全新 Evaluation Core 的 Compiler 层，没有 legacy adapter 或双写路径，因此没有现有用户迁移步骤。后续 Execution 层应只消费 sealed ExecutionPlan，不得在 `start()` 覆盖测量策略或重新解析 Runtime。

本层只验证设计与 capability 前提，不执行 Target、Evaluator、Reducer、统计推断或 DecisionPolicy；Runtime resolver 和 extension validator 仍属于宿主信任边界，实际 assurance level 会原样进入 Plan，Compiler 不把 declared／opaque 身份提升为 verified。

Closes #429
Parent #425
Depends on #427 / #428
