### PR TITLE
feat(eval-core)!: BREAKING-SCHEMA 实现确定性 Execution Runtime

### DIFF
--- a/docs/specs/evaluation-core-vnext.md
+++ b/docs/specs/evaluation-core-vnext.md
@@ -270,8 +270,8 @@ Records use canonical `(targetId, sampleId, trialIndex)` order. Each carries an 
 
 - completed output may be inline, a ContentDescriptor, digest-only, or omitted according to EvidencePolicy; omission does not change execution status;
 - source-neutral trace;
-- usage, provider-reported cost, and timing;
-- retry attempts;
+- trial-level aggregatable usage and timing;
+- retry attempts with exact per-invocation usage and provider-reported cost;
 - execution error;
 - RuntimeIdentity;
 - execution and cache/replay provenance;
@@ -385,11 +385,13 @@ Executors and Evaluators may use `openRun()` to return a run-scoped resource han
 
 Cancellation uses AbortSignal. User cancellation produces honest partial Bundles. Timeout and budget belong to sealed MeasurementPolicy because they affect missingness. Core does not provide cross-process resume; a host may start a new Evaluation stage from a complete ExecutionBundle.
 
-The Execution runtime is an in-memory interpreter of a sealed RunPlan. `startExecution()` synchronously verifies required ports and exact Executor Runtime identities before it exposes a Run. It derives coordinates only from the Plan, uses the sealed root seed for randomized admission, and applies global and per-Executor semaphores scoped to that Run. Paired scheduling blocks reserve their first real invocations atomically; cache hits consume no invocation, while each retry does.
+The Execution runtime is an in-memory interpreter of a sealed RunPlan. `startExecution()` synchronously verifies required ports and exact Executor Runtime identities before it exposes a Run, and captures those Executor references so later registry mutation cannot replace a sealed implementation. It derives coordinates only from the Plan, uses the sealed root seed for randomized admission, and applies global and per-Executor semaphores scoped to that Run. Paired scheduling blocks reserve their first real invocations atomically; cache hits consume no invocation, while each retry does. Failures before `trial.execute()` are run-level resource failures and never fabricate an attempt or consume invocation budget.
 
 Timeout is cooperative: Core aborts the attempt signal, waits for the Executor promise to settle so no late promise is abandoned, and records timeout as the single terminal fact even if the Executor returns success after observing abort. External cancellation has the same single-terminal rule. `maxDurationMs` is a monotonic soft admission deadline: already admitted work settles, while later blocks are censored. Provider-cost limits use only provider-reported facts; an admitted batch may overshoot, after which no new block is admitted and already observed usage is never rewritten.
 
-Execution cache and evidence storage are injected ports rather than filesystem services. `replay-only` misses and invalid cache entries fail closed; transparent hits require the deterministic, verified identity already sealed by prepare. Full, reference, digest-only, and omitted capture are materialized under the classification ceiling. Reference capture verifies the ContentStore descriptor digest before it enters a Bundle. Raw host exception text is not copied into events or Bundles.
+Execution cache and evidence storage are injected ports rather than filesystem services. `replay-only` misses and invalid cache entries fail closed; transparent hits require the deterministic, verified identity already sealed by prepare. Cache writes are deferred until resources tear down successfully and the run has no execution, cancellation, or budget terminal at commit time; only records whose cost audit, evidence materialization, and trial teardown succeeded are eligible. A later terminal-event delivery failure does not retroactively invalidate an already committed Target fact. Full, reference, digest-only, and omitted capture are materialized under the classification ceiling. Reference capture verifies the ContentStore descriptor digest before it enters a Bundle. Raw host exception text is not copied into events or Bundles.
+
+Every attempt retains its exact UsageRecord. The record-level UsageRecord is only an aggregate: token counts and same-currency costs may be summed, while mixed or partial currencies remain solely in the attempt facts and are marked non-comparable in aggregate details. Runtime never deletes an observed cost merely because it cannot produce one scalar total.
 
 ## 9. Event semantics
 
@@ -402,7 +404,7 @@ Execution cache and evidence storage are injected ports rather than filesystem s
 - when full, the journal drops the oldest retained notification; the terminal event is appended last and therefore remains in the final retained window;
 - observations, Bundles, and terminal data never exist only as events;
 - every Event has schemaVersion, eventId, runId, monotonic per-Run sequence, eventKind, time, subject, and data;
-- lossless persistence uses EventWriter. v1 supports blocking backpressure; writer enablement and failure behavior come from sealed EventDeliveryPolicy. A required writer failure stops future admission and changes the authoritative Bundle terminal state even when it occurs while delivering the originally completed terminal event.
+- lossless persistence uses EventWriter. v1 supports blocking backpressure; writer and notification delivery are serialized by per-Run sequence, while enablement and failure behavior come from sealed EventDeliveryPolicy. A required writer failure stops future admission and changes the authoritative Bundle terminal state even when it occurs while delivering the originally completed terminal event.
 
 Adapters may map Events losslessly to CloudEvents. Traces may map to OpenTelemetry/OpenInference and accept W3C Trace Context. Core depends on none of those SDKs.
 

--- a/docs/specs/evaluation-core-vnext.md
+++ b/docs/specs/evaluation-core-vnext.md
@@ -277,7 +277,7 @@ Records use canonical `(targetId, sampleId, trialIndex)` order. Each carries an 
 - execution and cache/replay provenance;
 - parent Plan digest and Bundle digest.
 
-Started records and budget-censored records are disjoint shapes. A censored record has no attempts, timing, output, trace, or usage because invocation never started. A completed attempt terminates its trial and can never be followed by a retry. The Bundle has orthogonal terminal status and coverage counters: `planned = started + budgetCensored + notStarted` and `started = succeeded + failed + cancelled`. A `budget-exhausted` Bundle classifies every coordinate that did not start as budget-censored rather than generic notStarted.
+Started records and budget-censored records are disjoint shapes. A censored record has no attempts, timing, output, trace, or usage because invocation never started. A completed attempt terminates its trial and can never be followed by a retry. The Bundle has orthogonal terminal status and coverage counters: `planned = started + budgetCensored + notStarted` and `started = succeeded + failed + cancelled`. A `budget-exhausted` Bundle classifies every coordinate that did not start as budget-censored rather than generic notStarted. Exhaustion may occur inside the final started trial—for example when a retry cannot be admitted or provider cost is known only after completion—so a valid budget-exhausted Bundle need not invent a censored coordinate.
 
 `parseExecutionBundleDocument()` validates only wire shape, local state-machine invariants, and the digest without external state. Import and materialization must call `parseExecutionBundle()` with the sealed RunPlan to verify parent digests, the complete coordinate universe, trial/seed/sampling/scheduling identities, Target Runtime bindings, retry policy, invocation budget, and atomic paired-block censoring. Bundle-reported blocks and coverage are never trusted on their own.
 
@@ -385,6 +385,12 @@ Executors and Evaluators may use `openRun()` to return a run-scoped resource han
 
 Cancellation uses AbortSignal. User cancellation produces honest partial Bundles. Timeout and budget belong to sealed MeasurementPolicy because they affect missingness. Core does not provide cross-process resume; a host may start a new Evaluation stage from a complete ExecutionBundle.
 
+The Execution runtime is an in-memory interpreter of a sealed RunPlan. `startExecution()` synchronously verifies required ports and exact Executor Runtime identities before it exposes a Run. It derives coordinates only from the Plan, uses the sealed root seed for randomized admission, and applies global and per-Executor semaphores scoped to that Run. Paired scheduling blocks reserve their first real invocations atomically; cache hits consume no invocation, while each retry does.
+
+Timeout is cooperative: Core aborts the attempt signal, waits for the Executor promise to settle so no late promise is abandoned, and records timeout as the single terminal fact even if the Executor returns success after observing abort. External cancellation has the same single-terminal rule. `maxDurationMs` is a monotonic soft admission deadline: already admitted work settles, while later blocks are censored. Provider-cost limits use only provider-reported facts; an admitted batch may overshoot, after which no new block is admitted and already observed usage is never rewritten.
+
+Execution cache and evidence storage are injected ports rather than filesystem services. `replay-only` misses and invalid cache entries fail closed; transparent hits require the deterministic, verified identity already sealed by prepare. Full, reference, digest-only, and omitted capture are materialized under the classification ceiling. Reference capture verifies the ContentStore descriptor digest before it enters a Bundle. Raw host exception text is not copied into events or Bundles.
+
 ## 9. Event semantics
 
 `run.events` is a bounded hot notification stream:
@@ -393,10 +399,10 @@ Cancellation uses AbortSignal. User cancellation produces honest partial Bundles
 - each Run permits one AsyncIterable consumer; hosts provide fan-out;
 - journaling begins when the Run is created and retains 256 events by default; a late subscriber receives the retained window before live events, and may subscribe once after completion to drain the journal;
 - a host may override capacity in start observer options; it does not enter measurement digests because event congestion cannot change Bundles or conclusions;
-- when full, the journal first coalesces pending `progress.updated` events by subject; if still full, it drops the oldest observer event and inserts `observer.events-dropped` with the count and sequence range; the terminal event is always retained;
+- when full, the journal drops the oldest retained notification; the terminal event is appended last and therefore remains in the final retained window;
 - observations, Bundles, and terminal data never exist only as events;
 - every Event has schemaVersion, eventId, runId, monotonic per-Run sequence, eventKind, time, subject, and data;
-- lossless persistence uses EventWriter, whose failure behavior is in sealed EventDeliveryPolicy.
+- lossless persistence uses EventWriter. v1 supports blocking backpressure; writer enablement and failure behavior come from sealed EventDeliveryPolicy. A required writer failure stops future admission and changes the authoritative Bundle terminal state even when it occurs while delivering the originally completed terminal event.
 
 Adapters may map Events losslessly to CloudEvents. Traces may map to OpenTelemetry/OpenInference and accept W3C Trace Context. Core depends on none of those SDKs.
 

--- a/docs/zh/specs/evaluation-core-vnext.md
+++ b/docs/zh/specs/evaluation-core-vnext.md
@@ -270,8 +270,8 @@ interface MeasurementPolicy {
 
 - completed output 可按 EvidencePolicy 内联、保存 ContentDescriptor、仅保存 digest 或省略；是否省略不改变 executionStatus；
 - source-neutral trace；
-- usage、provider-reported cost、timing；
-- retry attempt 记录；
+- trial 级可聚合 usage 与 timing；
+- 携带每次真实调用精确 usage 和 provider-reported cost 的 retry attempt；
 - execution error；
 - RuntimeIdentity；
 - execution、cache／replay provenance；
@@ -385,11 +385,13 @@ Executor／Evaluator 可以通过 `openRun()` 返回 run-scoped resource handle 
 
 取消统一使用 AbortSignal。用户取消产生诚实的部分 Bundle；timeout 和 budget 因为影响缺失机制，属于 sealed MeasurementPolicy。Core 不提供跨进程 resume；宿主可以从完整 ExecutionBundle 启动新的 Evaluation 阶段。
 
-Execution runtime 是 sealed RunPlan 的纯内存解释器。`startExecution()` 在暴露 Run 前同步检查所需端口和 Executor Runtime identity 是否与 Plan 完全一致。坐标只从 Plan 派生；randomized admission 只使用 sealed root seed；全局与每个 Executor 的 semaphore 均归当前 Run 所有。paired scheduling block 在 admission 时原子预留首次真实调用；cache hit 不消耗调用预算，每次 retry 则单独消耗。
+Execution runtime 是 sealed RunPlan 的纯内存解释器。`startExecution()` 在暴露 Run 前同步检查所需端口和 Executor Runtime identity 是否与 Plan 完全一致，并捕获对应 Executor 引用，后续 registry 变化不能替换 sealed implementation。坐标只从 Plan 派生；randomized admission 只使用 sealed root seed；全局与每个 Executor 的 semaphore 均归当前 Run 所有。paired scheduling block 在 admission 时原子预留首次真实调用；cache hit 不消耗调用预算，每次 retry 则单独消耗。发生在 `trial.execute()` 之前的错误属于 run-level resource failure，不能伪造 attempt 或消耗调用预算。
 
 timeout 采用协作式取消：Core abort attempt signal 后仍等待 Executor promise settle，避免遗留晚到 promise；即使 Executor 在观察到 abort 后返回成功，也只记录一次 timeout terminal fact。外部取消遵循同样的单终态规则。`maxDurationMs` 是基于 monotonic clock 的软 admission deadline：已经获准的工作继续 settle，后续 block 才进入删失。provider cost 上限只使用供应商报告的可审计事实；已获准 batch 可能 overshoot，此后停止新 block admission，但不会回写或删除已经发生的 usage。
 
-Execution cache 与 evidence storage 都是注入端口，不是 Core 内建文件服务。`replay-only` miss 和损坏的 cache entry 均 fail closed；transparent hit 只能使用 prepare 已封存的 deterministic、verified identity。full、reference、digest-only 与省略四种 capture 都服从 classification ceiling；reference 写入 Bundle 前必须核对 ContentStore descriptor digest。宿主原始异常文本不会复制进事件或 Bundle。
+Execution cache 与 evidence storage 都是注入端口，不是 Core 内建文件服务。`replay-only` miss 和损坏的 cache entry 均 fail closed；transparent hit 只能使用 prepare 已封存的 deterministic、verified identity。cache write 推迟到 resource teardown 成功、且 commit 时尚未出现 execution、cancellation 或 budget terminal 之后；只有 cost audit、evidence materialization 和 trial teardown 全部成功的 record 才 eligible。随后发生的 terminal-event delivery failure 不会追溯作废已经提交的 Target fact。full、reference、digest-only 与省略四种 capture 都服从 classification ceiling；reference 写入 Bundle 前必须核对 ContentStore descriptor digest。宿主原始异常文本不会复制进事件或 Bundle。
+
+每个 attempt 保留自己的精确 UsageRecord；record 级 UsageRecord 只负责可聚合摘要。token 与同币种 cost 可以求和；混合币种或部分上报的 cost 只保留在 attempt facts 中，并在 aggregate details 标记为不可直接比较。Runtime 不得因为无法形成一个标量总额而删除已经观察到的 cost。
 
 ## 九、Event 语义
 
@@ -402,7 +404,7 @@ Execution cache 与 evidence storage 都是注入端口，不是 Core 内建文�
 - 缓冲满时丢弃最旧的 retained notification；terminal event 最后追加，因此始终保留在最终窗口中；
 - observation、Bundle 和 terminal data 不得只存在于事件中；
 - 每个 Event 带 schemaVersion、eventId、runId、单 Run 单调 sequence、eventKind、time、subject 和 data；
-- 需要无损持久化时使用 EventWriter。v1 只支持 blocking backpressure；是否启用 writer 及失败策略由 sealed EventDeliveryPolicy 决定。required writer 失败会停止后续 admission，并改变权威 Bundle 的 terminal state；即使失败发生在最初 completed terminal event 的投递阶段也是如此。
+- 需要无损持久化时使用 EventWriter。v1 只支持 blocking backpressure；writer 与 notification delivery 按单 Run sequence 串行化，是否启用 writer 及失败策略由 sealed EventDeliveryPolicy 决定。required writer 失败会停止后续 admission，并改变权威 Bundle 的 terminal state；即使失败发生在最初 completed terminal event 的投递阶段也是如此。
 
 Event 可以在 adapter 层无损映射到 CloudEvents。Trace 可以映射到 OpenTelemetry／OpenInference，并可接收 W3C Trace Context；Core 不依赖这些 SDK。
 

--- a/docs/zh/specs/evaluation-core-vnext.md
+++ b/docs/zh/specs/evaluation-core-vnext.md
@@ -277,7 +277,7 @@ interface MeasurementPolicy {
 - execution、cache／replay provenance；
 - 父 Plan digest 和 Bundle digest。
 
-started record 与 budget-censored record 是互斥结构。后者没有 attempt、timing、output、trace 或 usage，因为对应调用从未开始。completed attempt 必须终止 trial，后续不能再伪造 retry。Bundle 另有正交的 terminal status 与 coverage counters：`planned = started + budgetCensored + notStarted`，`started = succeeded + failed + cancelled`；`budget-exhausted` 必须把所有尚未启动的坐标归类为 budget-censored，而不是笼统的 notStarted。
+started record 与 budget-censored record 是互斥结构。后者没有 attempt、timing、output、trace 或 usage，因为对应调用从未开始。completed attempt 必须终止 trial，后续不能再伪造 retry。Bundle 另有正交的 terminal status 与 coverage counters：`planned = started + budgetCensored + notStarted`，`started = succeeded + failed + cancelled`；`budget-exhausted` 必须把所有尚未启动的坐标归类为 budget-censored，而不是笼统的 notStarted。预算也可能在最后一个已启动 trial 内耗尽，例如 retry 无法获准或 provider cost 只能在完成后得知；此时合法的 budget-exhausted Bundle 不需要伪造一个 censored coordinate。
 
 `parseExecutionBundleDocument()` 只做不依赖外部状态的 wire、局部状态机与 digest 校验。导入或物化必须调用绑定 sealed RunPlan 的 `parseExecutionBundle()`，进一步核对 parent digests、完整 coordinate universe、trial／seed／sampling／scheduling identities、Target Runtime、retry policy、调用预算和 paired-block 原子删失；不能信任 Bundle 自报的 block 或 coverage。
 
@@ -385,6 +385,12 @@ Executor／Evaluator 可以通过 `openRun()` 返回 run-scoped resource handle 
 
 取消统一使用 AbortSignal。用户取消产生诚实的部分 Bundle；timeout 和 budget 因为影响缺失机制，属于 sealed MeasurementPolicy。Core 不提供跨进程 resume；宿主可以从完整 ExecutionBundle 启动新的 Evaluation 阶段。
 
+Execution runtime 是 sealed RunPlan 的纯内存解释器。`startExecution()` 在暴露 Run 前同步检查所需端口和 Executor Runtime identity 是否与 Plan 完全一致。坐标只从 Plan 派生；randomized admission 只使用 sealed root seed；全局与每个 Executor 的 semaphore 均归当前 Run 所有。paired scheduling block 在 admission 时原子预留首次真实调用；cache hit 不消耗调用预算，每次 retry 则单独消耗。
+
+timeout 采用协作式取消：Core abort attempt signal 后仍等待 Executor promise settle，避免遗留晚到 promise；即使 Executor 在观察到 abort 后返回成功，也只记录一次 timeout terminal fact。外部取消遵循同样的单终态规则。`maxDurationMs` 是基于 monotonic clock 的软 admission deadline：已经获准的工作继续 settle，后续 block 才进入删失。provider cost 上限只使用供应商报告的可审计事实；已获准 batch 可能 overshoot，此后停止新 block admission，但不会回写或删除已经发生的 usage。
+
+Execution cache 与 evidence storage 都是注入端口，不是 Core 内建文件服务。`replay-only` miss 和损坏的 cache entry 均 fail closed；transparent hit 只能使用 prepare 已封存的 deterministic、verified identity。full、reference、digest-only 与省略四种 capture 都服从 classification ceiling；reference 写入 Bundle 前必须核对 ContentStore descriptor digest。宿主原始异常文本不会复制进事件或 Bundle。
+
 ## 九、Event 语义
 
 `run.events` 是有界的热通知流：
@@ -393,10 +399,10 @@ Executor／Evaluator 可以通过 `openRun()` 返回 run-scoped resource handle 
 - 每个 Run 只允许一个 AsyncIterable 消费者；多路 fan-out 由宿主完成；
 - Run 创建时即开始写入内存 journal，默认最多保留 256 条；晚订阅者先收到仍保留的历史事件，再进入实时流；Run 结束后仍可订阅一次并排空 journal；
 - 宿主可以在 start observer options 中调整容量；它不进入测量 digest，因为事件拥塞不能改变 Bundle 或结论；
-- 缓冲满时先按 subject 合并尚未消费的 `progress.updated`，仍超限则丢弃最旧的 observer event，并插入 `observer.events-dropped`，记录数量和 sequence 范围；terminal event 永远保留；
+- 缓冲满时丢弃最旧的 retained notification；terminal event 最后追加，因此始终保留在最终窗口中；
 - observation、Bundle 和 terminal data 不得只存在于事件中；
 - 每个 Event 带 schemaVersion、eventId、runId、单 Run 单调 sequence、eventKind、time、subject 和 data；
-- 需要无损持久化时使用 EventWriter，其失败策略在 sealed EventDeliveryPolicy 中声明。
+- 需要无损持久化时使用 EventWriter。v1 只支持 blocking backpressure；是否启用 writer 及失败策略由 sealed EventDeliveryPolicy 决定。required writer 失败会停止后续 admission，并改变权威 Bundle 的 terminal state；即使失败发生在最初 completed terminal event 的投递阶段也是如此。
 
 Event 可以在 adapter 层无损映射到 CloudEvents。Trace 可以映射到 OpenTelemetry／OpenInference，并可接收 W3C Trace Context；Core 不依赖这些 SDK。
 

--- a/schemas/evaluation-core/v1/execution-bundle.schema.json
+++ b/schemas/evaluation-core/v1/execution-bundle.schema.json
@@ -154,6 +154,9 @@
             },
             "timing": {
               "$ref": "#/$defs/__schema17"
+            },
+            "usage": {
+              "$ref": "#/$defs/__schema19"
             }
           },
           "required": [
@@ -178,10 +181,13 @@
               "type": "string"
             },
             "error": {
-              "$ref": "#/$defs/__schema19"
+              "$ref": "#/$defs/__schema21"
             },
             "timing": {
               "$ref": "#/$defs/__schema17"
+            },
+            "usage": {
+              "$ref": "#/$defs/__schema19"
             }
           },
           "required": [
@@ -207,10 +213,13 @@
               "type": "string"
             },
             "error": {
-              "$ref": "#/$defs/__schema19"
+              "$ref": "#/$defs/__schema21"
             },
             "timing": {
               "$ref": "#/$defs/__schema17"
+            },
+            "usage": {
+              "$ref": "#/$defs/__schema19"
             }
           },
           "required": [
@@ -252,41 +261,7 @@
       "type": "string"
     },
     "__schema19": {
-      "additionalProperties": false,
-      "properties": {
-        "causes": {
-          "items": {
-            "$ref": "#/$defs/__schema19"
-          },
-          "type": "array"
-        },
-        "code": {
-          "$ref": "#/$defs/__schema1"
-        },
-        "details": {
-          "$ref": "#/$defs/__schema12"
-        },
-        "message": {
-          "$ref": "#/$defs/__schema11"
-        },
-        "stage": {
-          "enum": [
-            "configuration",
-            "infrastructure",
-            "execution",
-            "evaluation",
-            "analysis",
-            "internal"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "code",
-        "stage",
-        "message"
-      ],
-      "type": "object"
+      "$ref": "#/$defs/__schema20"
     },
     "__schema2": {
       "pattern": "^sha256:[0-9a-f]{64}$",
@@ -340,15 +315,55 @@
       "type": "object"
     },
     "__schema21": {
-      "$ref": "#/$defs/__schema22"
+      "additionalProperties": false,
+      "properties": {
+        "causes": {
+          "items": {
+            "$ref": "#/$defs/__schema21"
+          },
+          "type": "array"
+        },
+        "code": {
+          "$ref": "#/$defs/__schema1"
+        },
+        "details": {
+          "$ref": "#/$defs/__schema12"
+        },
+        "message": {
+          "$ref": "#/$defs/__schema11"
+        },
+        "stage": {
+          "enum": [
+            "configuration",
+            "infrastructure",
+            "execution",
+            "evaluation",
+            "analysis",
+            "internal"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "stage",
+        "message"
+      ],
+      "type": "object"
     },
     "__schema22": {
+      "$ref": "#/$defs/__schema20"
+    },
+    "__schema23": {
+      "$ref": "#/$defs/__schema24"
+    },
+    "__schema24": {
       "oneOf": [
         {
           "additionalProperties": false,
           "properties": {
             "classification": {
-              "$ref": "#/$defs/__schema23"
+              "$ref": "#/$defs/__schema25"
             },
             "contentKind": {
               "const": "inline",
@@ -369,7 +384,7 @@
           "additionalProperties": false,
           "properties": {
             "classification": {
-              "$ref": "#/$defs/__schema23"
+              "$ref": "#/$defs/__schema25"
             },
             "contentKind": {
               "const": "descriptor",
@@ -390,7 +405,7 @@
                   "type": "integer"
                 },
                 "uri": {
-                  "$ref": "#/$defs/__schema24"
+                  "$ref": "#/$defs/__schema26"
                 }
               },
               "required": [
@@ -411,7 +426,7 @@
           "additionalProperties": false,
           "properties": {
             "classification": {
-              "$ref": "#/$defs/__schema23"
+              "$ref": "#/$defs/__schema25"
             },
             "contentKind": {
               "const": "digest-only",
@@ -430,7 +445,7 @@
         }
       ]
     },
-    "__schema23": {
+    "__schema25": {
       "enum": [
         "public",
         "sensitive",
@@ -439,11 +454,11 @@
       ],
       "type": "string"
     },
-    "__schema24": {
+    "__schema26": {
       "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
       "type": "string"
     },
-    "__schema25": {
+    "__schema27": {
       "additionalProperties": false,
       "properties": {
         "cacheKeyDigest": {
@@ -467,7 +482,7 @@
       ],
       "type": "object"
     },
-    "__schema26": {
+    "__schema28": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -478,7 +493,7 @@
             "$ref": "#/$defs/__schema2"
           },
           "schemaUri": {
-            "$ref": "#/$defs/__schema24"
+            "$ref": "#/$defs/__schema26"
           }
         },
         "required": [
@@ -489,7 +504,7 @@
         "type": "object"
       },
       "propertyNames": {
-        "$ref": "#/$defs/__schema24"
+        "$ref": "#/$defs/__schema26"
       },
       "type": "object"
     },
@@ -573,14 +588,14 @@
                 "$ref": "#/$defs/__schema14"
               },
               "cache": {
-                "$ref": "#/$defs/__schema25"
+                "$ref": "#/$defs/__schema27"
               },
               "executionStatus": {
                 "const": "completed",
                 "type": "string"
               },
               "output": {
-                "$ref": "#/$defs/__schema22"
+                "$ref": "#/$defs/__schema24"
               },
               "provenance": {
                 "$ref": "#/$defs/__schema13"
@@ -604,7 +619,7 @@
                 "$ref": "#/$defs/__schema17"
               },
               "trace": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema23"
               },
               "trialId": {
                 "$ref": "#/$defs/__schema2"
@@ -616,7 +631,7 @@
                 "$ref": "#/$defs/__schema2"
               },
               "usage": {
-                "$ref": "#/$defs/__schema20"
+                "$ref": "#/$defs/__schema22"
               }
             },
             "required": [
@@ -643,10 +658,10 @@
                 "$ref": "#/$defs/__schema14"
               },
               "cache": {
-                "$ref": "#/$defs/__schema25"
+                "$ref": "#/$defs/__schema27"
               },
               "error": {
-                "$ref": "#/$defs/__schema19"
+                "$ref": "#/$defs/__schema21"
               },
               "executionStatus": {
                 "const": "failed",
@@ -674,7 +689,7 @@
                 "$ref": "#/$defs/__schema17"
               },
               "trace": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema23"
               },
               "trialId": {
                 "$ref": "#/$defs/__schema2"
@@ -686,7 +701,7 @@
                 "$ref": "#/$defs/__schema2"
               },
               "usage": {
-                "$ref": "#/$defs/__schema20"
+                "$ref": "#/$defs/__schema22"
               }
             },
             "required": [
@@ -714,10 +729,10 @@
                 "$ref": "#/$defs/__schema14"
               },
               "cache": {
-                "$ref": "#/$defs/__schema25"
+                "$ref": "#/$defs/__schema27"
               },
               "error": {
-                "$ref": "#/$defs/__schema19"
+                "$ref": "#/$defs/__schema21"
               },
               "executionStatus": {
                 "const": "cancelled",
@@ -745,7 +760,7 @@
                 "$ref": "#/$defs/__schema17"
               },
               "trace": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema23"
               },
               "trialId": {
                 "$ref": "#/$defs/__schema2"
@@ -757,7 +772,7 @@
                 "$ref": "#/$defs/__schema2"
               },
               "usage": {
-                "$ref": "#/$defs/__schema20"
+                "$ref": "#/$defs/__schema22"
               }
             },
             "required": [
@@ -885,7 +900,7 @@
       "$ref": "#/$defs/__schema2"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema26"
+      "$ref": "#/$defs/__schema28"
     },
     "provenance": {
       "$ref": "#/$defs/__schema13"

--- a/src/evaluation-core/compiler/validation.ts
+++ b/src/evaluation-core/compiler/validation.ts
@@ -2,6 +2,7 @@ import type {
   AnalysisCapabilities,
 } from './types.js';
 import {
+  deriveSchedulingTargetGroups,
   projectExecutionInputs,
   type AnalysisNodeDefinition,
   type EvaluationDefinition,
@@ -232,8 +233,13 @@ function validateSamplingDesign(definition: EvaluationDefinition): void {
   }
   if (sampling.resamplingUnit === 'paired-block'
       && scheduling.schedulingKind === 'randomized-block') {
-    const requiredBlockSize = Math.max(...definition.comparisons.map(
-      (comparison) => 1 + comparison.treatmentTargetIds.length,
+    const schedulingTargetGroups = deriveSchedulingTargetGroups({
+      targetIds: definition.targets.map((target) => target.targetId),
+      comparisons: definition.comparisons,
+      paired: true,
+    });
+    const requiredBlockSize = Math.max(...schedulingTargetGroups.map(
+      (targetIds) => targetIds.length,
     ));
     if ((scheduling.blockSize ?? 0) < requiredBlockSize) {
       throw definitionError(
@@ -316,8 +322,13 @@ function validatePolicy(
   }
 
   if (definition.experiment.sampling.resamplingUnit === 'paired-block') {
-    const smallestBlock = Math.min(...definition.comparisons.map(
-      (comparison) => 1 + comparison.treatmentTargetIds.length,
+    const schedulingTargetGroups = deriveSchedulingTargetGroups({
+      targetIds: definition.targets.map((target) => target.targetId),
+      comparisons: definition.comparisons,
+      paired: true,
+    });
+    const smallestBlock = Math.min(...schedulingTargetGroups.map(
+      (targetIds) => targetIds.length,
     ));
     if (policy.budget.maxTargetInvocations !== undefined
         && policy.budget.maxTargetInvocations < smallestBlock) {

--- a/src/evaluation-core/contracts/artifacts.ts
+++ b/src/evaluation-core/contracts/artifacts.ts
@@ -45,6 +45,7 @@ const ExecutionAttemptBaseSchema = z.object({
   attemptId: Sha256DigestSchema,
   attemptNumber: z.number().int().positive(),
   timing: TimingRecordSchema,
+  usage: UsageRecordSchema.optional(),
 }).strict();
 
 export const ExecutionAttemptSchema = z.discriminatedUnion('attemptStatus', [

--- a/src/evaluation-core/contracts/execution-bundle.ts
+++ b/src/evaluation-core/contracts/execution-bundle.ts
@@ -205,26 +205,23 @@ function assertStatus(bundle: ExecutionBundle): void {
     );
   }
   if (status === 'budget-exhausted'
-      && (coverage.budgetCensored === 0 || coverage.notStarted !== 0)) {
+      && coverage.notStarted !== 0) {
     throw new ExecutionBundleValidationError(
       'EXECUTION_BUNDLE_STATUS_INVALID',
-      'A budget-exhausted ExecutionBundle must classify every unstarted coordinate as budget-censored.',
+      'A budget-exhausted ExecutionBundle must classify every unstarted coordinate as budget-censored; exhaustion during a started trial may leave no censored coordinate.',
     );
   }
   if (status === 'cancelled'
-      && coverage.cancelled + coverage.notStarted === 0) {
+      && coverage.cancelled + coverage.notStarted === 0
+      && coverage.started !== coverage.planned) {
     throw new ExecutionBundleValidationError(
       'EXECUTION_BUNDLE_STATUS_INVALID',
       'A cancelled ExecutionBundle must expose cancelled or unstarted coordinates.',
     );
   }
-  if (status === 'failed'
-      && coverage.failed + coverage.cancelled + coverage.notStarted === 0) {
-    throw new ExecutionBundleValidationError(
-      'EXECUTION_BUNDLE_STATUS_INVALID',
-      'A failed ExecutionBundle must expose failed, cancelled, or unstarted coordinates.',
-    );
-  }
+  // A run-level infrastructure or teardown failure can happen after every
+  // coordinate has completed, so terminationReasonCode is the authoritative
+  // failed-state fact rather than record coverage alone.
 }
 
 function isInline(content: CapturedContent | undefined): boolean {
@@ -381,7 +378,10 @@ export function assertExecutionBundleMatchesPlan(
       planMismatch('ExecutionRecord Runtime does not match its sealed Target binding.');
     }
     if (record.executionStatus === 'budget-censored') continue;
-    invocationCount += record.attempts.length;
+    if (record.cache.cacheStatus !== 'replay'
+        && record.cache.cacheStatus !== 'transparent-hit') {
+      invocationCount += record.attempts.length;
+    }
     if (record.attempts.length > plan.execution.policy.retry.maxAttempts) {
       throw new ExecutionBundleValidationError(
         'EXECUTION_BUNDLE_RETRY_POLICY_INVALID',

--- a/src/evaluation-core/execution/event-stream.ts
+++ b/src/evaluation-core/execution/event-stream.ts
@@ -1,0 +1,56 @@
+import type { EvaluationEvent } from '../contracts/index.js';
+
+interface WaitingConsumer {
+  resolve(result: IteratorResult<EvaluationEvent>): void;
+}
+
+export class BoundedEventStream implements AsyncIterable<EvaluationEvent> {
+  readonly #capacity: number;
+  readonly #queue: EvaluationEvent[] = [];
+  readonly #waiting: WaitingConsumer[] = [];
+  #closed = false;
+  #iteratorCreated = false;
+
+  constructor(capacity: number) {
+    if (!Number.isSafeInteger(capacity) || capacity < 1) {
+      throw new TypeError('eventBufferCapacity must be a positive safe integer');
+    }
+    this.#capacity = capacity;
+  }
+
+  push(event: EvaluationEvent): void {
+    if (this.#closed) return;
+    const consumer = this.#waiting.shift();
+    if (consumer !== undefined) {
+      consumer.resolve({ done: false, value: event });
+      return;
+    }
+    if (this.#queue.length === this.#capacity) this.#queue.shift();
+    this.#queue.push(event);
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const consumer of this.#waiting.splice(0)) {
+      consumer.resolve({ done: true, value: undefined });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<EvaluationEvent> {
+    if (this.#iteratorCreated) {
+      throw new TypeError('Execution event stream supports one consumer');
+    }
+    this.#iteratorCreated = true;
+    return {
+      next: async () => {
+        const event = this.#queue.shift();
+        if (event !== undefined) return { done: false, value: event };
+        if (this.#closed) return { done: true, value: undefined };
+        return new Promise<IteratorResult<EvaluationEvent>>((resolve) => {
+          this.#waiting.push({ resolve });
+        });
+      },
+    };
+  }
+}

--- a/src/evaluation-core/execution/index.ts
+++ b/src/evaluation-core/execution/index.ts
@@ -1,0 +1,3 @@
+export * from './runtime.js';
+export * from './scheduler.js';
+export * from './types.js';

--- a/src/evaluation-core/execution/runtime.ts
+++ b/src/evaluation-core/execution/runtime.ts
@@ -1,0 +1,1401 @@
+import {
+  EVALUATION_EVENT_SCHEMA_VERSION,
+  EXECUTION_BUNDLE_SCHEMA_VERSION,
+  CompletedExecutionRecordSchema,
+  ContentClassificationSchema,
+  ContentDescriptorSchema,
+  EvaluationErrorSchema,
+  EvaluationEventSchema,
+  IdentifierSchema,
+  UsageRecordSchema,
+  canonicalizeJson,
+  deriveAttemptId,
+  digestArtifactPayload,
+  digestCanonicalJson,
+  parseExecutionBundle,
+  parseWireDocument,
+  type CacheProvenance,
+  type CapturedContent,
+  type EvaluationError,
+  type ExecutionAttempt,
+  type ExecutionBundle,
+  type ExecutionRecord,
+  type JsonValue,
+  type PlannedExecutionCoordinate,
+  type RuntimeIdentity,
+  type Sha256Digest,
+  type UsageRecord,
+} from '../contracts/index.js';
+import {
+  ExecutorCapabilitiesSchema,
+  type ProtocolManifest,
+  type SealedRunPlan,
+} from '../compiler/index.js';
+import { deepFreeze, snapshotJson } from '../compiler/immutability.js';
+import { BoundedEventStream } from './event-stream.js';
+import { abortError, Semaphore } from './semaphore.js';
+import { deriveExecutionSchedule, type ExecutionSchedulingBlock } from './scheduler.js';
+import {
+  ExecutionPortFailure,
+  ExecutionRuntimeConfigurationError,
+  type ExecutionCacheEntry,
+  type ExecutionClock,
+  type ExecutionContent,
+  type ExecutionEventKind,
+  type ExecutionEventSubjectKind,
+  type ExecutionExecutor,
+  type ExecutionExecutorRun,
+  type ExecutionExecutorTrial,
+  type ExecutionRun,
+  type ExecutionRunOptions,
+  type ExecutionRuntimePorts,
+  type ExecutorAttemptResult,
+  type ExecutorTrialContext,
+} from './types.js';
+
+type ActiveExecutionRecord = Exclude<ExecutionRecord, { executionStatus: 'budget-censored' }>;
+type CompletedExecutionRecord = Extract<ExecutionRecord, { executionStatus: 'completed' }>;
+
+interface TargetRuntimeBinding {
+  target: SealedRunPlan['execution']['targets'][number];
+  executor: ExecutionExecutor;
+  runtime: RuntimeIdentity;
+  protocol: ProtocolManifest;
+  semaphore: Semaphore;
+}
+
+interface PreparedRuntime {
+  bindings: ReadonlyMap<string, TargetRuntimeBinding>;
+  globalSemaphore: Semaphore;
+}
+
+type StopKind = 'cancelled' | 'budget-exhausted' | 'failed';
+
+interface StopState {
+  stopKind?: StopKind;
+  reason?: string;
+  error?: EvaluationError;
+}
+
+interface PreparedCoordinate {
+  coordinate: PlannedExecutionCoordinate;
+  cached?: CompletedExecutionRecord;
+  reservedInvocation: boolean;
+}
+
+interface PreparedBlock {
+  block: ExecutionSchedulingBlock;
+  coordinates: PreparedCoordinate[];
+}
+
+interface CoordinateResult {
+  record?: ActiveExecutionRecord;
+  failed: boolean;
+}
+
+const CLASSIFICATION_LEVEL = {
+  public: 0,
+  sensitive: 1,
+  secret: 2,
+  gold: 3,
+} as const;
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function compareRecords(left: ExecutionRecord, right: ExecutionRecord): number {
+  return compareStrings(left.targetId, right.targetId)
+    || compareStrings(left.sampleId, right.sampleId)
+    || left.trialIndex - right.trialIndex;
+}
+
+function coordinateKey(coordinate: { trialId: string }): string {
+  return coordinate.trialId;
+}
+
+function configurationError(code: string, message: string): never {
+  throw new ExecutionRuntimeConfigurationError(code, message);
+}
+
+function validateOptions(options: ExecutionRunOptions): void {
+  const runId = IdentifierSchema.safeParse(options.runId);
+  const bundleId = IdentifierSchema.safeParse(options.bundleId);
+  if (!runId.success || !bundleId.success) {
+    configurationError(
+      'EXECUTION_RUNTIME_IDENTIFIER_INVALID',
+      'runId and bundleId must be valid Evaluation Core identifiers.',
+    );
+  }
+  if (options.eventBufferCapacity !== undefined
+      && (!Number.isSafeInteger(options.eventBufferCapacity)
+        || options.eventBufferCapacity < 1)) {
+    configurationError(
+      'EXECUTION_RUNTIME_EVENT_BUFFER_INVALID',
+      'eventBufferCapacity must be a positive safe integer.',
+    );
+  }
+}
+
+function resolvedRuntimeByTarget(plan: SealedRunPlan): Map<string, RuntimeIdentity> {
+  const result = new Map<string, RuntimeIdentity>();
+  for (const runtime of plan.execution.runtimes) {
+    if (runtime.runtimeKind !== 'executor') continue;
+    if (result.has(runtime.referenceId)) {
+      configurationError(
+        'EXECUTION_RUNTIME_BINDING_INVALID',
+        `ExecutionPlan contains duplicate Runtime binding for ${runtime.referenceId}.`,
+      );
+    }
+    result.set(runtime.referenceId, runtime.identity as RuntimeIdentity);
+  }
+  return result;
+}
+
+function protocolForTarget(
+  targetId: string,
+  protocolId: string,
+  runtime: RuntimeIdentity,
+): ProtocolManifest {
+  const capabilities = ExecutorCapabilitiesSchema.safeParse(runtime.capabilities);
+  if (!capabilities.success) {
+    configurationError(
+      'EXECUTION_RUNTIME_CAPABILITY_INVALID',
+      `Sealed Runtime capabilities for ${targetId} are invalid.`,
+    );
+  }
+  const protocol = capabilities.data.protocols.find(
+    (candidate) => candidate.protocolId === protocolId,
+  );
+  if (protocol === undefined) {
+    configurationError(
+      'EXECUTION_RUNTIME_CAPABILITY_INVALID',
+      `Sealed Runtime for ${targetId} does not contain its protocol manifest.`,
+    );
+  }
+  return protocol;
+}
+
+function prepareRuntime(
+  plan: SealedRunPlan,
+  ports: ExecutionRuntimePorts,
+  options: ExecutionRunOptions,
+): PreparedRuntime {
+  validateOptions(options);
+  const cacheMode = plan.execution.policy.executionCacheMode;
+  if (cacheMode !== 'disabled' && ports.cache === undefined) {
+    configurationError(
+      'EXECUTION_RUNTIME_CACHE_REQUIRED',
+      `Execution cache mode ${cacheMode} requires an injected cache port.`,
+    );
+  }
+  const evidence = plan.measurementPolicy.evidence;
+  if ((evidence.output === 'reference' || evidence.trace === 'reference')
+      && ports.contentStore === undefined) {
+    configurationError(
+      'EXECUTION_RUNTIME_CONTENT_STORE_REQUIRED',
+      'Reference evidence capture requires an injected ContentStore.',
+    );
+  }
+  const delivery = plan.measurementPolicy.eventDelivery;
+  if (delivery.writerMode === 'required' && ports.eventWriter === undefined) {
+    configurationError(
+      'EXECUTION_RUNTIME_EVENT_WRITER_REQUIRED',
+      'Required EventWriter mode needs an injected EventWriter.',
+    );
+  }
+
+  const expectedRuntimes = resolvedRuntimeByTarget(plan);
+  const executorLimits = new Map<string, number>();
+  const partialBindings: Array<{
+    target: SealedRunPlan['execution']['targets'][number];
+    executor: ExecutionExecutor;
+    runtime: RuntimeIdentity;
+    protocol: ProtocolManifest;
+  }> = [];
+  for (const target of plan.execution.targets) {
+    const executor = ports.executors.get(target.executorId);
+    if (executor === undefined) {
+      configurationError(
+        'EXECUTION_RUNTIME_EXECUTOR_MISSING',
+        `No Executor is registered for ${target.executorId}.`,
+      );
+    }
+    const expectedRuntime = expectedRuntimes.get(target.targetId);
+    if (expectedRuntime === undefined
+        || canonicalizeJson(executor.identity) !== canonicalizeJson(expectedRuntime)) {
+      configurationError(
+        'EXECUTION_RUNTIME_IDENTITY_MISMATCH',
+        `Executor identity for ${target.targetId} differs from the sealed ExecutionPlan.`,
+      );
+    }
+    const protocol = protocolForTarget(target.targetId, target.protocolId, expectedRuntime);
+    const capabilityLimit = protocol.execution.concurrency.safety === 'serialized'
+      ? 1
+      : (protocol.execution.concurrency.maxInFlight
+        ?? plan.execution.policy.execution.maxConcurrency);
+    const currentLimit = executorLimits.get(target.executorId);
+    executorLimits.set(
+      target.executorId,
+      currentLimit === undefined ? capabilityLimit : Math.min(currentLimit, capabilityLimit),
+    );
+    partialBindings.push({ target, executor, runtime: expectedRuntime, protocol });
+  }
+  const semaphores = new Map(
+    [...executorLimits].map(([executorId, limit]) => [executorId, new Semaphore(limit)]),
+  );
+  return {
+    bindings: new Map(partialBindings.map((binding) => [binding.target.targetId, {
+      ...binding,
+      semaphore: semaphores.get(binding.target.executorId) as Semaphore,
+    }])),
+    globalSemaphore: new Semaphore(plan.execution.policy.execution.maxConcurrency),
+  };
+}
+
+function safeError(error: unknown): EvaluationError {
+  if (error instanceof ExecutionPortFailure) {
+    const parsed = EvaluationErrorSchema.safeParse(error.evaluationError);
+    if (!parsed.success) {
+      return {
+        code: 'executor-error-invalid',
+        stage: 'infrastructure',
+        message: 'Executor returned an invalid structured failure.',
+      };
+    }
+    return {
+      code: parsed.data.code,
+      stage: parsed.data.stage,
+      message: 'Executor reported a structured failure.',
+    };
+  }
+  return {
+    code: error instanceof Error && error.name === 'AbortError'
+      ? 'cancelled'
+      : 'executor-error',
+    stage: error instanceof Error && error.name === 'AbortError'
+      ? 'infrastructure'
+      : 'execution',
+    message: error instanceof Error && error.name === 'AbortError'
+      ? 'Execution was cancelled.'
+      : 'Executor failed without a structured EvaluationError.',
+  };
+}
+
+function durationMs(started: number, completed: number): number {
+  return Math.max(0, completed - started);
+}
+
+function addUsage(left: UsageRecord | undefined, right: UsageRecord | undefined): UsageRecord | undefined {
+  if (left === undefined) return right === undefined ? undefined : snapshotJson(right);
+  if (right === undefined) return left;
+  const providerCost = left.providerCost === undefined
+    ? right.providerCost
+    : right.providerCost === undefined
+      ? left.providerCost
+      : left.providerCost.currency === right.providerCost.currency
+        ? {
+          amount: left.providerCost.amount + right.providerCost.amount,
+          currency: left.providerCost.currency,
+          reportedByProvider: true as const,
+        }
+        : undefined;
+  return {
+    ...(left.inputTokens !== undefined || right.inputTokens !== undefined
+      ? { inputTokens: (left.inputTokens ?? 0) + (right.inputTokens ?? 0) }
+      : {}),
+    ...(left.outputTokens !== undefined || right.outputTokens !== undefined
+      ? { outputTokens: (left.outputTokens ?? 0) + (right.outputTokens ?? 0) }
+      : {}),
+    ...(left.totalTokens !== undefined || right.totalTokens !== undefined
+      ? { totalTokens: (left.totalTokens ?? 0) + (right.totalTokens ?? 0) }
+      : {}),
+    ...(providerCost !== undefined ? { providerCost } : {}),
+  };
+}
+
+class BudgetTracker {
+  readonly #maxInvocations?: number;
+  readonly #maxProviderCost?: { amount: number; currency: string };
+  #invocations = 0;
+  #reserved = 0;
+  #providerCost = 0;
+
+  constructor(plan: SealedRunPlan) {
+    this.#maxInvocations = plan.execution.policy.budget.maxTargetInvocations;
+    this.#maxProviderCost = plan.execution.policy.budget.maxProviderCost;
+  }
+
+  reserveInitial(count: number): boolean {
+    if (this.#maxInvocations !== undefined
+        && this.#invocations + this.#reserved + count > this.#maxInvocations) return false;
+    this.#reserved += count;
+    return true;
+  }
+
+  consumeReserved(): void {
+    if (this.#reserved < 1) throw new Error('Missing invocation reservation');
+    this.#reserved -= 1;
+    this.#invocations += 1;
+  }
+
+  releaseReserved(): void {
+    if (this.#reserved > 0) this.#reserved -= 1;
+  }
+
+  consumeRetry(): boolean {
+    if (this.#maxInvocations !== undefined
+        && this.#invocations + this.#reserved + 1 > this.#maxInvocations) return false;
+    this.#invocations += 1;
+    return true;
+  }
+
+  recordUsage(usage: UsageRecord | undefined): EvaluationError | undefined {
+    if (this.#maxProviderCost === undefined) return undefined;
+    const cost = usage?.providerCost;
+    if (cost === undefined) {
+      return {
+        code: 'provider-cost-unreported',
+        stage: 'infrastructure',
+        message: 'Provider cost budget requires every invocation to report provider cost.',
+      };
+    }
+    if (cost.currency !== this.#maxProviderCost.currency) {
+      return {
+        code: 'provider-cost-currency-mismatch',
+        stage: 'infrastructure',
+        message: 'Provider-reported cost currency differs from the sealed budget currency.',
+      };
+    }
+    this.#providerCost += cost.amount;
+    return undefined;
+  }
+
+  get providerCostExhausted(): boolean {
+    return this.#maxProviderCost !== undefined
+      && this.#providerCost >= this.#maxProviderCost.amount;
+  }
+}
+
+class RunSessions {
+  readonly #ports: ExecutionRuntimePorts;
+  readonly #options: ExecutionRunOptions;
+  readonly #plan: SealedRunPlan;
+  readonly #sessions = new Map<string, Promise<ExecutionExecutorRun>>();
+
+  constructor(
+    plan: SealedRunPlan,
+    ports: ExecutionRuntimePorts,
+    options: ExecutionRunOptions,
+  ) {
+    this.#plan = plan;
+    this.#ports = ports;
+    this.#options = options;
+  }
+
+  get(executorId: string): Promise<ExecutionExecutorRun> {
+    const current = this.#sessions.get(executorId);
+    if (current !== undefined) return current;
+    const executor = this.#ports.executors.get(executorId);
+    if (executor === undefined) throw new Error('Executor disappeared after preflight');
+    const context = deepFreeze(snapshotJson({
+      runId: this.#options.runId,
+      executionPlanDigest: this.#plan.execution.executionPlanDigest as Sha256Digest,
+    }));
+    const session = Promise.resolve(executor.openRun(context));
+    this.#sessions.set(executorId, session);
+    return session;
+  }
+
+  async dispose(): Promise<EvaluationError[]> {
+    const errors: EvaluationError[] = [];
+    for (const sessionPromise of this.#sessions.values()) {
+      try {
+        const session = await sessionPromise;
+        await session.dispose();
+      } catch {
+        errors.push({
+          code: 'executor-run-dispose-failed',
+          stage: 'infrastructure',
+          message: 'Executor run resource disposal failed.',
+        });
+      }
+    }
+    return errors;
+  }
+}
+
+class EventEmitter {
+  readonly #plan: SealedRunPlan;
+  readonly #ports: ExecutionRuntimePorts;
+  readonly #options: ExecutionRunOptions;
+  readonly #stream: BoundedEventStream;
+  readonly #onFatal: (reason: string, error: EvaluationError) => void;
+  #sequence = 0;
+  #writerEnabled: boolean;
+
+  constructor(
+    plan: SealedRunPlan,
+    ports: ExecutionRuntimePorts,
+    options: ExecutionRunOptions,
+    stream: BoundedEventStream,
+    onFatal: (reason: string, error: EvaluationError) => void,
+  ) {
+    this.#plan = plan;
+    this.#ports = ports;
+    this.#options = options;
+    this.#stream = stream;
+    this.#onFatal = onFatal;
+    this.#writerEnabled = plan.measurementPolicy.eventDelivery.writerMode !== 'disabled'
+      && ports.eventWriter !== undefined;
+  }
+
+  async emit(
+    eventKind: ExecutionEventKind,
+    subjectKind: ExecutionEventSubjectKind,
+    subjectId: string,
+    data: JsonValue,
+  ): Promise<boolean> {
+    const sequence = this.#sequence;
+    this.#sequence += 1;
+    const event = deepFreeze(parseWireDocument(EvaluationEventSchema, {
+      schemaVersion: EVALUATION_EVENT_SCHEMA_VERSION,
+      eventId: digestCanonicalJson({
+        derivation: 'omk.evaluation-event-id/v1',
+        runId: this.#options.runId,
+        sequence,
+      }),
+      sequence,
+      runId: this.#options.runId,
+      eventKind,
+      time: this.#ports.clock.timestamp(),
+      subject: { subjectKind, subjectId },
+      data,
+    }));
+    if (!this.#writerEnabled) {
+      this.#stream.push(event);
+      return true;
+    }
+    try {
+      await this.#ports.eventWriter?.write(event);
+    } catch {
+      this.#writerEnabled = false;
+      if (this.#plan.measurementPolicy.eventDelivery.writerFailureMode === 'fail-run') {
+        this.#onFatal('event-writer-failed', {
+          code: 'event-writer-failed',
+          stage: 'infrastructure',
+          message: 'Required EventWriter delivery failed.',
+        });
+        return false;
+      }
+    }
+    this.#stream.push(event);
+    return true;
+  }
+
+  close(): void {
+    this.#stream.close();
+  }
+}
+
+function linkAbortSignal(parent: AbortSignal | undefined, controller: AbortController): () => void {
+  if (parent === undefined) return () => undefined;
+  if (parent.aborted) {
+    controller.abort(parent.reason);
+    return () => undefined;
+  }
+  const onAbort = () => controller.abort(parent.reason);
+  parent.addEventListener('abort', onAbort, { once: true });
+  return () => parent.removeEventListener('abort', onAbort);
+}
+
+async function executeWithTimeout(
+  trial: ExecutionExecutorTrial,
+  attemptId: Sha256Digest,
+  attemptNumber: number,
+  parentSignal: AbortSignal,
+  timeoutMs: number | undefined,
+  clock: ExecutionClock,
+): Promise<{ result?: ExecutorAttemptResult; error?: unknown; timedOut: boolean }> {
+  const controller = new AbortController();
+  const unlink = linkAbortSignal(parentSignal, controller);
+  const timerController = new AbortController();
+  let timedOut = false;
+  const timer = timeoutMs === undefined
+    ? undefined
+    : clock.sleep(timeoutMs, timerController.signal).then(() => {
+      timedOut = true;
+      controller.abort('timeout');
+    }).catch(() => undefined);
+  try {
+    const result = await trial.execute(Object.freeze({
+      attemptId,
+      attemptNumber,
+      signal: controller.signal,
+    }));
+    return { result, timedOut };
+  } catch (error) {
+    return { error, timedOut };
+  } finally {
+    unlink();
+    timerController.abort();
+    await timer;
+  }
+}
+
+function cacheKey(plan: SealedRunPlan, coordinate: PlannedExecutionCoordinate): Sha256Digest {
+  return digestCanonicalJson({
+    derivation: 'omk.execution-cache-key/v1',
+    executionPlanDigest: plan.execution.executionPlanDigest,
+    trialId: coordinate.trialId,
+  });
+}
+
+function assertCachedRecord(
+  entry: ExecutionCacheEntry,
+  key: Sha256Digest,
+  coordinate: PlannedExecutionCoordinate,
+  runtime: RuntimeIdentity,
+): CompletedExecutionRecord {
+  const record = parseWireDocument(CompletedExecutionRecordSchema, entry.record);
+  if (entry.cacheKeyDigest !== key
+      || entry.sourceRecordDigest !== digestCanonicalJson(record)
+      || record.targetId !== coordinate.targetId
+      || record.sampleId !== coordinate.sampleId
+      || record.trialIndex !== coordinate.trialIndex
+      || record.trialId !== coordinate.trialId
+      || record.trialSeed !== coordinate.trialSeed
+      || record.schedulingBlockId !== coordinate.schedulingBlockId
+      || canonicalizeJson(record.samplingUnitIds)
+        !== canonicalizeJson(coordinate.samplingUnitIds)
+      || canonicalizeJson(record.runtime) !== canonicalizeJson(runtime)) {
+    throw new ExecutionRuntimeConfigurationError(
+      'EXECUTION_RUNTIME_CACHE_ENTRY_INVALID',
+      'Execution cache returned a record incompatible with the sealed coordinate.',
+    );
+  }
+  return record;
+}
+
+function replayRecord(
+  entry: ExecutionCacheEntry,
+  sourceRecord: CompletedExecutionRecord,
+  cacheStatus: 'replay' | 'transparent-hit',
+): CompletedExecutionRecord {
+  return {
+    ...snapshotJson(sourceRecord),
+    cache: {
+      cacheStatus,
+      cacheKeyDigest: entry.cacheKeyDigest,
+      sourceRecordDigest: entry.sourceRecordDigest,
+    },
+    provenance: {
+      provenanceKind: 'replay',
+      trust: entry.record.provenance.trust,
+      sourceId: entry.record.trialId,
+      parentDigests: [entry.sourceRecordDigest],
+    },
+  };
+}
+
+async function captureContent(
+  content: ExecutionContent | undefined,
+  mode: 'full' | 'reference' | 'digest' | 'none',
+  maximumClassification: keyof typeof CLASSIFICATION_LEVEL,
+  ports: ExecutionRuntimePorts,
+): Promise<CapturedContent | undefined> {
+  if (content === undefined || mode === 'none') return undefined;
+  const classification = ContentClassificationSchema.parse(content.classification);
+  if (CLASSIFICATION_LEVEL[classification]
+      > CLASSIFICATION_LEVEL[maximumClassification]) return undefined;
+  const value = snapshotJson(content.value);
+  const digest = digestCanonicalJson(value);
+  if (mode === 'full') {
+    return { contentKind: 'inline', classification, value };
+  }
+  if (mode === 'digest') {
+    return { contentKind: 'digest-only', classification, digest };
+  }
+  const mediaType = content.mediaType ?? 'application/json';
+  const descriptor = await ports.contentStore?.put({
+    value,
+    classification,
+    mediaType,
+    digest,
+  });
+  const parsedDescriptor = ContentDescriptorSchema.safeParse(descriptor);
+  if (!parsedDescriptor.success || parsedDescriptor.data.digest !== digest) {
+    throw new ExecutionRuntimeConfigurationError(
+      'EXECUTION_RUNTIME_CONTENT_STORE_INVALID',
+      'ContentStore returned a missing or mismatched descriptor.',
+    );
+  }
+  return {
+    contentKind: 'descriptor',
+    classification,
+    descriptor: snapshotJson(parsedDescriptor.data),
+  };
+}
+
+function validatedUsage(usage: UsageRecord | undefined): UsageRecord | undefined {
+  return usage === undefined ? undefined : parseWireDocument(UsageRecordSchema, usage);
+}
+
+function cacheProvenance(
+  mode: SealedRunPlan['execution']['policy']['executionCacheMode'],
+  key: Sha256Digest,
+): CacheProvenance {
+  return mode === 'disabled'
+    ? { cacheStatus: 'not-used' }
+    : { cacheStatus: 'miss', cacheKeyDigest: key };
+}
+
+function attemptError(
+  outcome: Awaited<ReturnType<typeof executeWithTimeout>>,
+  runSignal: AbortSignal,
+): { status: 'failed' | 'cancelled'; error: EvaluationError; usage?: UsageRecord } {
+  const usage = outcome.result?.usage ?? (outcome.error instanceof ExecutionPortFailure
+    ? outcome.error.usage
+    : undefined);
+  if (outcome.timedOut) {
+    return {
+      status: 'failed',
+      error: {
+        code: 'timeout',
+        stage: 'infrastructure',
+        message: 'Executor attempt exceeded the sealed timeout.',
+      },
+      ...(usage !== undefined ? { usage } : {}),
+    };
+  }
+  if (runSignal.aborted) {
+    return {
+      status: 'cancelled',
+      error: {
+        code: 'cancelled',
+        stage: 'infrastructure',
+        message: 'Execution was cancelled.',
+      },
+      ...(usage !== undefined ? { usage } : {}),
+    };
+  }
+  return {
+    status: 'failed',
+    error: safeError(outcome.error),
+    ...(usage !== undefined ? { usage } : {}),
+  };
+}
+
+function trialContext(
+  plan: SealedRunPlan,
+  binding: TargetRuntimeBinding,
+  coordinate: PlannedExecutionCoordinate,
+): ExecutorTrialContext {
+  const sample = plan.execution.samples.find(
+    (candidate) => candidate.sampleId === coordinate.sampleId,
+  );
+  if (sample === undefined) throw new Error('Planned sample disappeared');
+  const controlled = plan.execution.experiment.sampling.seedCoupling !== 'uncontrolled';
+  return deepFreeze(snapshotJson({
+    targetId: coordinate.targetId,
+    protocolId: binding.target.protocolId,
+    input: sample.input,
+    ...(sample.executionContext !== undefined
+      ? { executionContext: sample.executionContext }
+      : {}),
+    ...(binding.target.config !== undefined ? { targetConfig: binding.target.config } : {}),
+    trialIndex: coordinate.trialIndex,
+    trialId: coordinate.trialId,
+    schedulingBlockId: coordinate.schedulingBlockId,
+    samplingUnitIds: coordinate.samplingUnitIds,
+    ...(controlled ? { trialSeed: coordinate.trialSeed } : {}),
+  })) as ExecutorTrialContext;
+}
+
+async function executeCoordinate(
+  plan: SealedRunPlan,
+  ports: ExecutionRuntimePorts,
+  options: ExecutionRunOptions,
+  prepared: PreparedRuntime,
+  sessions: RunSessions,
+  events: EventEmitter,
+  budget: BudgetTracker,
+  coordinate: PreparedCoordinate,
+  runSignal: AbortSignal,
+  setStop: (kind: StopKind, reason: string, error?: EvaluationError) => void,
+): Promise<CoordinateResult> {
+  if (coordinate.cached !== undefined) {
+    await events.emit('execution.cache.hit', 'trial', coordinate.coordinate.trialId, {
+      trialId: coordinate.coordinate.trialId,
+      cacheStatus: coordinate.cached.cache.cacheStatus,
+    });
+    return { record: coordinate.cached, failed: false };
+  }
+  const binding = prepared.bindings.get(coordinate.coordinate.targetId);
+  if (binding === undefined) throw new Error('Target binding disappeared');
+  const releaseGlobal = await prepared.globalSemaphore.acquire(runSignal).catch(() => undefined);
+  if (releaseGlobal === undefined) {
+    if (coordinate.reservedInvocation) budget.releaseReserved();
+    return { failed: false };
+  }
+  const releaseRuntime = await binding.semaphore.acquire(runSignal).catch(() => undefined);
+  if (releaseRuntime === undefined) {
+    releaseGlobal();
+    if (coordinate.reservedInvocation) budget.releaseReserved();
+    return { failed: false };
+  }
+
+  const attempts: ExecutionAttempt[] = [];
+  let usage: UsageRecord | undefined;
+  let trial: ExecutionExecutorTrial | undefined;
+  const trialStartedAt = ports.clock.timestamp();
+  const trialStartedMonotonic = ports.clock.monotonicNow();
+  let output: CapturedContent | undefined;
+  let trace: CapturedContent | undefined;
+  let terminalError: EvaluationError | undefined;
+  let terminalStatus: 'completed' | 'failed' | 'cancelled' = 'failed';
+  let initialReservationPending = coordinate.reservedInvocation;
+  const key = cacheKey(plan, coordinate.coordinate);
+  try {
+    const trialEventDelivered = await events.emit(
+      'execution.trial.started',
+      'trial',
+      coordinate.coordinate.trialId,
+      {
+      targetId: coordinate.coordinate.targetId,
+      sampleId: coordinate.coordinate.sampleId,
+      trialIndex: coordinate.coordinate.trialIndex,
+      schedulingBlockId: coordinate.coordinate.schedulingBlockId,
+      },
+    );
+    if (!trialEventDelivered || runSignal.aborted) return { failed: false };
+    const runSession = await sessions.get(binding.target.executorId);
+    trial = await runSession.openTrial(trialContext(plan, binding, coordinate.coordinate));
+    const retryPolicy = plan.execution.policy.retry;
+    for (let attemptNumber = 1; attemptNumber <= retryPolicy.maxAttempts; attemptNumber += 1) {
+      if (attemptNumber > 1 && !budget.consumeRetry()) {
+        setStop('budget-exhausted', 'target-invocation-budget-exhausted');
+        break;
+      }
+      const attemptId = deriveAttemptId({
+        trialId: coordinate.coordinate.trialId,
+        attemptNumber,
+      });
+      const startedAt = ports.clock.timestamp();
+      const startedMonotonic = ports.clock.monotonicNow();
+      const attemptEventDelivered = await events.emit('execution.attempt.started', 'attempt', attemptId, {
+        trialId: coordinate.coordinate.trialId,
+        attemptNumber,
+      });
+      if (!attemptEventDelivered || runSignal.aborted) break;
+      if (attemptNumber === 1 && initialReservationPending) {
+        budget.consumeReserved();
+        initialReservationPending = false;
+      }
+      const outcome = runSignal.aborted
+        ? { error: abortError(), timedOut: false }
+        : await executeWithTimeout(
+          trial,
+          attemptId,
+          attemptNumber,
+          runSignal,
+          plan.execution.policy.execution.timeoutMs,
+          ports.clock,
+        );
+      const completedAt = ports.clock.timestamp();
+      const completedMonotonic = ports.clock.monotonicNow();
+      if (outcome.result !== undefined && !outcome.timedOut && !runSignal.aborted) {
+        snapshotJson(outcome.result);
+        const attemptUsage = validatedUsage(outcome.result.usage);
+        usage = addUsage(usage, attemptUsage);
+        const costError = budget.recordUsage(attemptUsage);
+        if (costError !== undefined) setStop('failed', costError.code, costError);
+        attempts.push({
+          attemptId,
+          attemptNumber,
+          attemptStatus: 'completed',
+          timing: {
+            startedAt,
+            completedAt,
+            durationMs: durationMs(startedMonotonic, completedMonotonic),
+          },
+        });
+        terminalStatus = 'completed';
+        try {
+          output = await captureContent(
+            outcome.result.output,
+            plan.measurementPolicy.evidence.output,
+            plan.measurementPolicy.evidence.maximumClassification,
+            ports,
+          );
+          trace = await captureContent(
+            outcome.result.trace,
+            plan.measurementPolicy.evidence.trace,
+            plan.measurementPolicy.evidence.maximumClassification,
+            ports,
+          );
+        } catch {
+          setStop('failed', 'content-materialization-failed', {
+            code: 'content-materialization-failed',
+            stage: 'infrastructure',
+            message: 'Execution content could not be materialized under the sealed policy.',
+          });
+        }
+        await events.emit('execution.attempt.completed', 'attempt', attemptId, {
+          trialId: coordinate.coordinate.trialId,
+          attemptNumber,
+          attemptStatus: 'completed',
+        });
+        break;
+      }
+
+      const failure = attemptError(outcome, runSignal);
+      const attemptUsage = validatedUsage(failure.usage);
+      usage = addUsage(usage, attemptUsage);
+      const costError = budget.recordUsage(attemptUsage);
+      if (costError !== undefined) setStop('failed', costError.code, costError);
+      terminalError = failure.error;
+      terminalStatus = failure.status;
+      attempts.push(failure.status === 'cancelled'
+        ? {
+          attemptId,
+          attemptNumber,
+          attemptStatus: 'cancelled',
+          timing: {
+            startedAt,
+            completedAt,
+            durationMs: durationMs(startedMonotonic, completedMonotonic),
+          },
+          error: failure.error,
+        }
+        : {
+          attemptId,
+          attemptNumber,
+          attemptStatus: 'failed',
+          timing: {
+            startedAt,
+            completedAt,
+            durationMs: durationMs(startedMonotonic, completedMonotonic),
+          },
+          error: failure.error,
+        });
+      await events.emit('execution.attempt.completed', 'attempt', attemptId, {
+        trialId: coordinate.coordinate.trialId,
+        attemptNumber,
+        attemptStatus: failure.status,
+        errorCode: failure.error.code,
+      });
+      if (failure.status === 'cancelled'
+          || !retryPolicy.retryableErrorCodes.includes(failure.error.code)
+          || attemptNumber === retryPolicy.maxAttempts) break;
+      const delay = retryPolicy.backoff.backoffKind === 'none'
+        ? 0
+        : retryPolicy.backoff.backoffKind === 'fixed'
+          ? retryPolicy.backoff.initialDelayMs
+          : Math.min(
+            retryPolicy.backoff.initialDelayMs * (2 ** (attemptNumber - 1)),
+            retryPolicy.backoff.maxDelayMs ?? Number.MAX_SAFE_INTEGER,
+          );
+      await events.emit('execution.retry.scheduled', 'trial', coordinate.coordinate.trialId, {
+        attemptNumber: attemptNumber + 1,
+        delayMs: delay,
+        errorCode: failure.error.code,
+      });
+      if (delay > 0) {
+        try {
+          await ports.clock.sleep(delay, runSignal);
+        } catch {
+          break;
+        }
+      }
+    }
+  } catch (error) {
+    if (attempts.length === 0) {
+      const attemptId = deriveAttemptId({
+        trialId: coordinate.coordinate.trialId,
+        attemptNumber: 1,
+      });
+      const evaluationError = safeError(error);
+      attempts.push({
+        attemptId,
+        attemptNumber: 1,
+        attemptStatus: 'failed',
+        timing: {
+          startedAt: trialStartedAt,
+          completedAt: ports.clock.timestamp(),
+          durationMs: durationMs(trialStartedMonotonic, ports.clock.monotonicNow()),
+        },
+        error: evaluationError,
+      });
+      terminalError = evaluationError;
+      terminalStatus = 'failed';
+    } else {
+      setStop('failed', 'execution-runtime-internal-failed', {
+        code: 'execution-runtime-internal-failed',
+        stage: 'internal',
+        message: 'Execution runtime failed after recording an attempt.',
+      });
+    }
+  } finally {
+    if (initialReservationPending) budget.releaseReserved();
+    if (trial !== undefined) {
+      try {
+        await trial.dispose();
+      } catch {
+        setStop('failed', 'executor-trial-dispose-failed', {
+          code: 'executor-trial-dispose-failed',
+          stage: 'infrastructure',
+          message: 'Executor trial resource disposal failed.',
+        });
+      }
+    }
+    releaseRuntime();
+    releaseGlobal();
+  }
+
+  if (attempts.length === 0) return { failed: false };
+
+  const completedAt = ports.clock.timestamp();
+  const recordBase = {
+    ...coordinate.coordinate,
+    runtime: snapshotJson(binding.runtime),
+    provenance: {
+      provenanceKind: 'native' as const,
+      trust: 'verified' as const,
+      parentDigests: [plan.execution.executionPlanDigest],
+    },
+    attempts,
+    timing: {
+      startedAt: trialStartedAt,
+      completedAt,
+      durationMs: durationMs(trialStartedMonotonic, ports.clock.monotonicNow()),
+    },
+    ...(usage !== undefined ? { usage } : {}),
+    ...(trace !== undefined ? { trace } : {}),
+    cache: cacheProvenance(plan.execution.policy.executionCacheMode, key),
+  };
+  const record: ActiveExecutionRecord = terminalStatus === 'completed'
+    ? {
+      ...recordBase,
+      executionStatus: 'completed',
+      ...(output !== undefined ? { output } : {}),
+    }
+    : terminalStatus === 'cancelled'
+      ? {
+        ...recordBase,
+        executionStatus: 'cancelled',
+        ...(terminalError !== undefined ? { error: terminalError } : {}),
+      }
+      : {
+        ...recordBase,
+        executionStatus: 'failed',
+        error: terminalError ?? {
+          code: 'execution-failed',
+          stage: 'execution',
+          message: 'Execution failed without a terminal error.',
+        },
+      };
+
+  if (record.executionStatus === 'completed'
+      && plan.execution.policy.executionCacheMode === 'transparent-deterministic') {
+    const entry: ExecutionCacheEntry = {
+      cacheKeyDigest: key,
+      sourceRecordDigest: digestCanonicalJson(record),
+      record: snapshotJson(record),
+    };
+    try {
+      await ports.cache?.put(entry);
+    } catch {
+      setStop('failed', 'execution-cache-write-failed', {
+        code: 'execution-cache-write-failed',
+        stage: 'infrastructure',
+        message: 'Execution cache write failed.',
+      });
+    }
+  }
+  await events.emit('execution.trial.completed', 'trial', coordinate.coordinate.trialId, {
+    targetId: coordinate.coordinate.targetId,
+    sampleId: coordinate.coordinate.sampleId,
+    trialIndex: coordinate.coordinate.trialIndex,
+    executionStatus: record.executionStatus,
+  });
+  return { record, failed: record.executionStatus === 'failed' };
+}
+
+async function prepareBlock(
+  plan: SealedRunPlan,
+  ports: ExecutionRuntimePorts,
+  prepared: PreparedRuntime,
+  events: EventEmitter,
+  budget: BudgetTracker,
+  block: ExecutionSchedulingBlock,
+  setStop: (kind: StopKind, reason: string, error?: EvaluationError) => void,
+): Promise<PreparedBlock | undefined> {
+  const mode = plan.execution.policy.executionCacheMode;
+  const coordinates: PreparedCoordinate[] = [];
+  let misses = 0;
+  for (const coordinate of block.coordinates) {
+    if (mode === 'disabled') {
+      coordinates.push({ coordinate, reservedInvocation: true });
+      misses += 1;
+      continue;
+    }
+    const binding = prepared.bindings.get(coordinate.targetId);
+    if (binding === undefined) throw new Error('Target binding disappeared');
+    const key = cacheKey(plan, coordinate);
+    try {
+      const entry = await ports.cache?.get(key);
+      if (entry !== undefined) {
+        const sourceRecord = assertCachedRecord(entry, key, coordinate, binding.runtime);
+        coordinates.push({
+          coordinate,
+          cached: replayRecord(
+            entry,
+            sourceRecord,
+            mode === 'replay-only' ? 'replay' : 'transparent-hit',
+          ),
+          reservedInvocation: false,
+        });
+        continue;
+      }
+    } catch {
+      setStop('failed', 'execution-cache-read-failed', {
+        code: 'execution-cache-read-failed',
+        stage: 'infrastructure',
+        message: 'Execution cache read or validation failed.',
+      });
+      return undefined;
+    }
+    if (mode === 'replay-only') {
+      setStop('failed', 'execution-cache-miss', {
+        code: 'execution-cache-miss',
+        stage: 'infrastructure',
+        message: 'Replay-only Execution cache did not contain every planned coordinate.',
+      });
+      return undefined;
+    }
+    await events.emit('execution.cache.miss', 'trial', coordinate.trialId, {
+      trialId: coordinate.trialId,
+      cacheKeyDigest: key,
+    });
+    coordinates.push({ coordinate, reservedInvocation: true });
+    misses += 1;
+  }
+  if (!budget.reserveInitial(misses)) {
+    setStop('budget-exhausted', 'target-invocation-budget-exhausted');
+    return undefined;
+  }
+  return { block, coordinates };
+}
+
+function censoredRecord(
+  plan: SealedRunPlan,
+  prepared: PreparedRuntime,
+  coordinate: PlannedExecutionCoordinate,
+  censoredAt: string,
+  reason: string,
+): Extract<ExecutionRecord, { executionStatus: 'budget-censored' }> {
+  const binding = prepared.bindings.get(coordinate.targetId);
+  if (binding === undefined) throw new Error('Target binding disappeared');
+  return {
+    ...coordinate,
+    runtime: snapshotJson(binding.runtime),
+    provenance: {
+      provenanceKind: 'native',
+      trust: 'verified',
+      parentDigests: [plan.execution.executionPlanDigest],
+    },
+    executionStatus: 'budget-censored',
+    censorReasonCode: reason,
+    censoredAt,
+  };
+}
+
+function replayability(records: readonly ExecutionRecord[]): ExecutionBundle['replayability'] {
+  const completed = records.filter(
+    (record): record is CompletedExecutionRecord => record.executionStatus === 'completed',
+  );
+  if (completed.length === 0) return 'summary-only';
+  const active = records.filter((record) => record.executionStatus !== 'budget-censored');
+  const captured = active.flatMap((record) => record.executionStatus === 'completed'
+    ? [record.output, record.trace]
+    : [record.trace]).filter(
+    (content): content is CapturedContent => content !== undefined,
+  );
+  if (completed.every((record) => record.output?.contentKind === 'inline')
+      && captured.every((content) => content.contentKind === 'inline')) return 'self-contained';
+  if (completed.every((record) => record.output?.contentKind === 'inline'
+        || record.output?.contentKind === 'descriptor')
+      && captured.every((content) => content.contentKind === 'inline'
+        || content.contentKind === 'descriptor')
+      && captured.some((content) => content.contentKind === 'descriptor')) return 'resolvable';
+  return 'summary-only';
+}
+
+function coverage(
+  planned: number,
+  records: readonly ExecutionRecord[],
+): ExecutionBundle['coverage'] {
+  const succeeded = records.filter((record) => record.executionStatus === 'completed').length;
+  const failed = records.filter((record) => record.executionStatus === 'failed').length;
+  const cancelled = records.filter((record) => record.executionStatus === 'cancelled').length;
+  const budgetCensored = records.filter(
+    (record) => record.executionStatus === 'budget-censored',
+  ).length;
+  return {
+    planned,
+    started: succeeded + failed + cancelled,
+    succeeded,
+    failed,
+    cancelled,
+    budgetCensored,
+    notStarted: planned - records.length,
+  };
+}
+
+function makeBundle(
+  plan: SealedRunPlan,
+  options: ExecutionRunOptions,
+  records: ExecutionRecord[],
+  plannedCount: number,
+  stop: StopState,
+): ExecutionBundle {
+  const sortedRecords = records.sort(compareRecords);
+  const executionBundleStatus = stop.stopKind ?? 'completed';
+  const bundle: ExecutionBundle = {
+    schemaVersion: EXECUTION_BUNDLE_SCHEMA_VERSION,
+    bundleId: options.bundleId,
+    runContractDigest: plan.digests.runContractDigest,
+    executionPlanDigest: plan.digests.executionPlanDigest,
+    datasetRevisionDigest: plan.digests.datasetRevisionDigest,
+    executionInputDigest: plan.digests.executionInputDigest,
+    executionBundleStatus,
+    ...(stop.reason !== undefined ? { terminationReasonCode: stop.reason } : {}),
+    coverage: coverage(plannedCount, sortedRecords),
+    replayability: replayability(sortedRecords),
+    records: sortedRecords,
+    provenance: {
+      provenanceKind: 'native',
+      trust: 'verified',
+      parentDigests: [plan.digests.runContractDigest],
+      ...(stop.error !== undefined
+        ? { facets: snapshotJson({ terminalError: stop.error }) as unknown as JsonValue }
+        : {}),
+    },
+    bundleDigest: `sha256:${'0'.repeat(64)}`,
+  };
+  bundle.bundleDigest = digestArtifactPayload(bundle, 'bundleDigest');
+  return parseExecutionBundle(bundle, plan);
+}
+
+function terminalEventKind(
+  status: ExecutionBundle['executionBundleStatus'],
+): ExecutionEventKind {
+  switch (status) {
+    case 'completed': return 'execution.run.completed';
+    case 'cancelled': return 'execution.run.cancelled';
+    case 'budget-exhausted': return 'execution.run.budget-exhausted';
+    case 'failed': return 'execution.run.failed';
+  }
+}
+
+async function runExecution(
+  plan: SealedRunPlan,
+  ports: ExecutionRuntimePorts,
+  options: ExecutionRunOptions,
+  prepared: PreparedRuntime,
+  stream: BoundedEventStream,
+): Promise<ExecutionBundle> {
+  const schedule = deriveExecutionSchedule(plan);
+  const plannedCoordinates = schedule.flatMap((block) => block.coordinates);
+  const stop: StopState = {};
+  const controller = new AbortController();
+  const setStop = (kind: StopKind, reason: string, error?: EvaluationError): void => {
+    if (stop.stopKind !== undefined) return;
+    stop.stopKind = kind;
+    stop.reason = reason;
+    if (error !== undefined) stop.error = error;
+    if (kind !== 'budget-exhausted') controller.abort(reason);
+  };
+  const onExternalAbort = (): void => {
+    setStop('cancelled', 'external-cancellation');
+  };
+  if (options.signal?.aborted) onExternalAbort();
+  else options.signal?.addEventListener('abort', onExternalAbort, { once: true });
+  const events = new EventEmitter(plan, ports, options, stream, (reason, error) => {
+    setStop('failed', reason, error);
+  });
+  const sessions = new RunSessions(plan, ports, options);
+  const budget = new BudgetTracker(plan);
+  const records = new Map<string, ExecutionRecord>();
+  const durationController = new AbortController();
+  const durationTimer = plan.execution.policy.budget.maxDurationMs === undefined
+    ? undefined
+    : ports.clock.sleep(
+      plan.execution.policy.budget.maxDurationMs,
+      durationController.signal,
+    ).then(() => {
+      setStop('budget-exhausted', 'duration-budget-exhausted');
+    }).catch(() => undefined);
+  try {
+    await events.emit('execution.run.started', 'run', options.runId, {
+      runContractDigest: plan.digests.runContractDigest,
+      executionPlanDigest: plan.execution.executionPlanDigest,
+      planned: plannedCoordinates.length,
+    });
+    const batchSize = plan.execution.policy.execution.maxConcurrency;
+    for (let offset = 0; offset < schedule.length && stop.stopKind === undefined; offset += batchSize) {
+      const batch = schedule.slice(offset, offset + batchSize);
+      const preparedBlocks: PreparedBlock[] = [];
+      for (const block of batch) {
+        if (stop.stopKind !== undefined) break;
+        const preparedBlock = await prepareBlock(
+          plan,
+          ports,
+          prepared,
+          events,
+          budget,
+          block,
+          setStop,
+        );
+        if (preparedBlock !== undefined) preparedBlocks.push(preparedBlock);
+      }
+      const results = await Promise.all(preparedBlocks.map(async (preparedBlock) => {
+        await events.emit('execution.block.started', 'scheduling-block', preparedBlock.block.schedulingBlockId, {
+          coordinateCount: preparedBlock.coordinates.length,
+        });
+        const coordinateResults = await Promise.all(preparedBlock.coordinates.map((coordinate) => (
+          executeCoordinate(
+            plan,
+            ports,
+            options,
+            prepared,
+            sessions,
+            events,
+            budget,
+            coordinate,
+            controller.signal,
+            setStop,
+          )
+        )));
+        for (const result of coordinateResults) {
+          if (result.record !== undefined) {
+            records.set(coordinateKey(result.record), result.record);
+          }
+        }
+        await events.emit('execution.block.completed', 'scheduling-block', preparedBlock.block.schedulingBlockId, {
+          coordinateCount: preparedBlock.coordinates.length,
+          completedCount: coordinateResults.filter((result) => result.record !== undefined).length,
+        });
+        return coordinateResults;
+      }));
+
+      const failedCount = results.flat().filter((result) => result.failed).length;
+      const failurePolicy = plan.execution.policy.failure;
+      const totalFailed = [...records.values()].filter(
+        (record) => record.executionStatus === 'failed',
+      ).length;
+      if (stop.stopKind === undefined
+          && failurePolicy.failureMode === 'fail-fast'
+          && failedCount > 0) {
+        setStop('failed', 'failure-policy-fail-fast');
+      } else if (stop.stopKind === undefined
+          && failurePolicy.failureMode === 'failure-threshold'
+          && totalFailed > (failurePolicy.maxFailures ?? 0)) {
+        setStop('failed', 'failure-policy-threshold');
+      } else if (stop.stopKind === undefined && budget.providerCostExhausted) {
+        setStop('budget-exhausted', 'provider-cost-budget-exhausted');
+      }
+    }
+  } catch {
+    setStop('failed', 'execution-runtime-internal-failed', {
+      code: 'execution-runtime-internal-failed',
+      stage: 'internal',
+      message: 'Execution runtime encountered an internal failure.',
+    });
+  } finally {
+    durationController.abort();
+    await durationTimer;
+    options.signal?.removeEventListener('abort', onExternalAbort);
+    const disposeErrors = await sessions.dispose();
+    if (disposeErrors.length > 0) {
+      setStop('failed', 'executor-run-dispose-failed', disposeErrors[0]);
+    }
+  }
+
+  if (stop.stopKind === 'budget-exhausted') {
+    const censoredAt = ports.clock.timestamp();
+    for (const coordinate of plannedCoordinates) {
+      if (!records.has(coordinateKey(coordinate))) {
+        records.set(coordinateKey(coordinate), censoredRecord(
+          plan,
+          prepared,
+          coordinate,
+          censoredAt,
+          stop.reason ?? 'budget-exhausted',
+        ));
+      }
+    }
+  }
+  let bundle = makeBundle(
+    plan,
+    options,
+    [...records.values()],
+    plannedCoordinates.length,
+    stop,
+  );
+  const terminalDelivered = await events.emit(
+    terminalEventKind(bundle.executionBundleStatus),
+    'run',
+    options.runId,
+    {
+      bundleDigest: bundle.bundleDigest,
+      executionBundleStatus: bundle.executionBundleStatus,
+      coverage: bundle.coverage,
+    },
+  );
+  if (!terminalDelivered) {
+    bundle = makeBundle(
+      plan,
+      options,
+      [...records.values()],
+      plannedCoordinates.length,
+      stop,
+    );
+    await events.emit(
+      terminalEventKind(bundle.executionBundleStatus),
+      'run',
+      options.runId,
+      {
+        bundleDigest: bundle.bundleDigest,
+        executionBundleStatus: bundle.executionBundleStatus,
+        coverage: bundle.coverage,
+      },
+    );
+  }
+  events.close();
+  return bundle;
+}
+
+export function startExecution(
+  plan: SealedRunPlan,
+  ports: ExecutionRuntimePorts,
+  options: ExecutionRunOptions,
+): ExecutionRun {
+  const prepared = prepareRuntime(plan, ports, options);
+  const stream = new BoundedEventStream(options.eventBufferCapacity ?? 256);
+  return {
+    events: stream,
+    result: runExecution(plan, ports, options, prepared, stream),
+  };
+}
+
+export async function executeRunPlan(
+  plan: SealedRunPlan,
+  ports: ExecutionRuntimePorts,
+  options: ExecutionRunOptions,
+): Promise<ExecutionBundle> {
+  return startExecution(plan, ports, options).result;
+}

--- a/src/evaluation-core/execution/runtime.ts
+++ b/src/evaluation-core/execution/runtime.ts
@@ -17,6 +17,7 @@ import {
   type CacheProvenance,
   type CapturedContent,
   type EvaluationError,
+  type EvaluationEvent,
   type ExecutionAttempt,
   type ExecutionBundle,
   type ExecutionRecord,
@@ -90,7 +91,15 @@ interface PreparedBlock {
 
 interface CoordinateResult {
   record?: ActiveExecutionRecord;
+  cacheEntry?: ExecutionCacheEntry;
   failed: boolean;
+}
+
+interface InFlightAttempt {
+  attemptId: Sha256Digest;
+  attemptNumber: number;
+  startedAt: string;
+  startedMonotonic: number;
 }
 
 const CLASSIFICATION_LEVEL = {
@@ -288,31 +297,46 @@ function durationMs(started: number, completed: number): number {
   return Math.max(0, completed - started);
 }
 
-function addUsage(left: UsageRecord | undefined, right: UsageRecord | undefined): UsageRecord | undefined {
-  if (left === undefined) return right === undefined ? undefined : snapshotJson(right);
-  if (right === undefined) return left;
-  const providerCost = left.providerCost === undefined
-    ? right.providerCost
-    : right.providerCost === undefined
-      ? left.providerCost
-      : left.providerCost.currency === right.providerCost.currency
-        ? {
-          amount: left.providerCost.amount + right.providerCost.amount,
-          currency: left.providerCost.currency,
-          reportedByProvider: true as const,
-        }
-        : undefined;
+function aggregateUsage(
+  attempts: readonly (UsageRecord | undefined)[],
+): UsageRecord | undefined {
+  const reported = attempts.filter((usage): usage is UsageRecord => usage !== undefined);
+  if (reported.length === 0) return undefined;
+  if (attempts.length === 1) return snapshotJson(reported[0]);
+  const costs = reported.flatMap((usage) => (
+    usage.providerCost === undefined ? [] : [usage.providerCost]
+  ));
+  const currencies = new Set(costs.map((cost) => cost.currency));
+  const providerCost = costs.length === attempts.length && currencies.size === 1
+    ? {
+      amount: costs.reduce((sum, cost) => sum + cost.amount, 0),
+      currency: costs[0].currency,
+      reportedByProvider: true as const,
+    }
+    : undefined;
   return {
-    ...(left.inputTokens !== undefined || right.inputTokens !== undefined
-      ? { inputTokens: (left.inputTokens ?? 0) + (right.inputTokens ?? 0) }
+    ...(reported.some((usage) => usage.inputTokens !== undefined)
+      ? { inputTokens: reported.reduce((sum, usage) => sum + (usage.inputTokens ?? 0), 0) }
       : {}),
-    ...(left.outputTokens !== undefined || right.outputTokens !== undefined
-      ? { outputTokens: (left.outputTokens ?? 0) + (right.outputTokens ?? 0) }
+    ...(reported.some((usage) => usage.outputTokens !== undefined)
+      ? { outputTokens: reported.reduce((sum, usage) => sum + (usage.outputTokens ?? 0), 0) }
       : {}),
-    ...(left.totalTokens !== undefined || right.totalTokens !== undefined
-      ? { totalTokens: (left.totalTokens ?? 0) + (right.totalTokens ?? 0) }
+    ...(reported.some((usage) => usage.totalTokens !== undefined)
+      ? { totalTokens: reported.reduce((sum, usage) => sum + (usage.totalTokens ?? 0), 0) }
       : {}),
     ...(providerCost !== undefined ? { providerCost } : {}),
+    details: {
+      aggregationKind: 'omk.execution-usage-summary/v1',
+      attemptCount: attempts.length,
+      reportedAttemptCount: reported.length,
+      providerCostAggregation: costs.length === 0
+        ? 'unreported'
+        : costs.length !== attempts.length
+          ? 'partial'
+          : currencies.size === 1
+            ? 'summed'
+            : 'mixed-currency',
+    },
   };
 }
 
@@ -345,13 +369,6 @@ class BudgetTracker {
     if (this.#reserved > 0) this.#reserved -= 1;
   }
 
-  consumeRetry(): boolean {
-    if (this.#maxInvocations !== undefined
-        && this.#invocations + this.#reserved + 1 > this.#maxInvocations) return false;
-    this.#invocations += 1;
-    return true;
-  }
-
   recordUsage(usage: UsageRecord | undefined): EvaluationError | undefined {
     if (this.#maxProviderCost === undefined) return undefined;
     const cost = usage?.providerCost;
@@ -380,26 +397,21 @@ class BudgetTracker {
 }
 
 class RunSessions {
-  readonly #ports: ExecutionRuntimePorts;
   readonly #options: ExecutionRunOptions;
   readonly #plan: SealedRunPlan;
   readonly #sessions = new Map<string, Promise<ExecutionExecutorRun>>();
 
   constructor(
     plan: SealedRunPlan,
-    ports: ExecutionRuntimePorts,
     options: ExecutionRunOptions,
   ) {
     this.#plan = plan;
-    this.#ports = ports;
     this.#options = options;
   }
 
-  get(executorId: string): Promise<ExecutionExecutorRun> {
+  get(executorId: string, executor: ExecutionExecutor): Promise<ExecutionExecutorRun> {
     const current = this.#sessions.get(executorId);
     if (current !== undefined) return current;
-    const executor = this.#ports.executors.get(executorId);
-    if (executor === undefined) throw new Error('Executor disappeared after preflight');
     const context = deepFreeze(snapshotJson({
       runId: this.#options.runId,
       executionPlanDigest: this.#plan.execution.executionPlanDigest as Sha256Digest,
@@ -435,6 +447,7 @@ class EventEmitter {
   readonly #onFatal: (reason: string, error: EvaluationError) => void;
   #sequence = 0;
   #writerEnabled: boolean;
+  #deliveryTail: Promise<void> = Promise.resolve();
 
   constructor(
     plan: SealedRunPlan,
@@ -474,21 +487,25 @@ class EventEmitter {
       subject: { subjectKind, subjectId },
       data,
     }));
-    if (!this.#writerEnabled) {
-      this.#stream.push(event);
-      return true;
-    }
-    try {
-      await this.#ports.eventWriter?.write(event);
-    } catch {
-      this.#writerEnabled = false;
-      if (this.#plan.measurementPolicy.eventDelivery.writerFailureMode === 'fail-run') {
-        this.#onFatal('event-writer-failed', {
-          code: 'event-writer-failed',
-          stage: 'infrastructure',
-          message: 'Required EventWriter delivery failed.',
-        });
-        return false;
+    const delivery = this.#deliveryTail.then(() => this.#deliver(event));
+    this.#deliveryTail = delivery.then(() => undefined, () => undefined);
+    return delivery;
+  }
+
+  async #deliver(event: EvaluationEvent): Promise<boolean> {
+    if (this.#writerEnabled) {
+      try {
+        await this.#ports.eventWriter?.write(event);
+      } catch {
+        this.#writerEnabled = false;
+        if (this.#plan.measurementPolicy.eventDelivery.writerFailureMode === 'fail-run') {
+          this.#onFatal('event-writer-failed', {
+            code: 'event-writer-failed',
+            stage: 'infrastructure',
+            message: 'Required EventWriter delivery failed.',
+          });
+          return false;
+        }
       }
     }
     this.#stream.push(event);
@@ -748,8 +765,9 @@ async function executeCoordinate(
   }
 
   const attempts: ExecutionAttempt[] = [];
-  let usage: UsageRecord | undefined;
+  const attemptUsages: Array<UsageRecord | undefined> = [];
   let trial: ExecutionExecutorTrial | undefined;
+  let inFlightAttempt: InFlightAttempt | undefined;
   const trialStartedAt = ports.clock.timestamp();
   const trialStartedMonotonic = ports.clock.monotonicNow();
   let output: CapturedContent | undefined;
@@ -757,6 +775,7 @@ async function executeCoordinate(
   let terminalError: EvaluationError | undefined;
   let terminalStatus: 'completed' | 'failed' | 'cancelled' = 'failed';
   let initialReservationPending = coordinate.reservedInvocation;
+  let cacheEligible = true;
   const key = cacheKey(plan, coordinate.coordinate);
   try {
     const trialEventDelivered = await events.emit(
@@ -771,13 +790,16 @@ async function executeCoordinate(
       },
     );
     if (!trialEventDelivered || runSignal.aborted) return { failed: false };
-    const runSession = await sessions.get(binding.target.executorId);
+    const runSession = await sessions.get(binding.target.executorId, binding.executor);
     trial = await runSession.openTrial(trialContext(plan, binding, coordinate.coordinate));
     const retryPolicy = plan.execution.policy.retry;
     for (let attemptNumber = 1; attemptNumber <= retryPolicy.maxAttempts; attemptNumber += 1) {
-      if (attemptNumber > 1 && !budget.consumeRetry()) {
-        setStop('budget-exhausted', 'target-invocation-budget-exhausted');
-        break;
+      if (attemptNumber > 1) {
+        if (!budget.reserveInitial(1)) {
+          setStop('budget-exhausted', 'target-invocation-budget-exhausted');
+          break;
+        }
+        initialReservationPending = true;
       }
       const attemptId = deriveAttemptId({
         trialId: coordinate.coordinate.trialId,
@@ -790,10 +812,16 @@ async function executeCoordinate(
         attemptNumber,
       });
       if (!attemptEventDelivered || runSignal.aborted) break;
-      if (attemptNumber === 1 && initialReservationPending) {
+      if (initialReservationPending) {
         budget.consumeReserved();
         initialReservationPending = false;
       }
+      inFlightAttempt = {
+        attemptId,
+        attemptNumber,
+        startedAt,
+        startedMonotonic,
+      };
       const outcome = runSignal.aborted
         ? { error: abortError(), timedOut: false }
         : await executeWithTimeout(
@@ -809,9 +837,12 @@ async function executeCoordinate(
       if (outcome.result !== undefined && !outcome.timedOut && !runSignal.aborted) {
         snapshotJson(outcome.result);
         const attemptUsage = validatedUsage(outcome.result.usage);
-        usage = addUsage(usage, attemptUsage);
+        attemptUsages.push(attemptUsage);
         const costError = budget.recordUsage(attemptUsage);
-        if (costError !== undefined) setStop('failed', costError.code, costError);
+        if (costError !== undefined) {
+          cacheEligible = false;
+          setStop('failed', costError.code, costError);
+        }
         attempts.push({
           attemptId,
           attemptNumber,
@@ -821,7 +852,9 @@ async function executeCoordinate(
             completedAt,
             durationMs: durationMs(startedMonotonic, completedMonotonic),
           },
+          ...(attemptUsage !== undefined ? { usage: attemptUsage } : {}),
         });
+        inFlightAttempt = undefined;
         terminalStatus = 'completed';
         try {
           output = await captureContent(
@@ -837,6 +870,7 @@ async function executeCoordinate(
             ports,
           );
         } catch {
+          cacheEligible = false;
           setStop('failed', 'content-materialization-failed', {
             code: 'content-materialization-failed',
             stage: 'infrastructure',
@@ -853,9 +887,12 @@ async function executeCoordinate(
 
       const failure = attemptError(outcome, runSignal);
       const attemptUsage = validatedUsage(failure.usage);
-      usage = addUsage(usage, attemptUsage);
+      attemptUsages.push(attemptUsage);
       const costError = budget.recordUsage(attemptUsage);
-      if (costError !== undefined) setStop('failed', costError.code, costError);
+      if (costError !== undefined) {
+        cacheEligible = false;
+        setStop('failed', costError.code, costError);
+      }
       terminalError = failure.error;
       terminalStatus = failure.status;
       attempts.push(failure.status === 'cancelled'
@@ -869,6 +906,7 @@ async function executeCoordinate(
             durationMs: durationMs(startedMonotonic, completedMonotonic),
           },
           error: failure.error,
+          ...(attemptUsage !== undefined ? { usage: attemptUsage } : {}),
         }
         : {
           attemptId,
@@ -880,7 +918,9 @@ async function executeCoordinate(
             durationMs: durationMs(startedMonotonic, completedMonotonic),
           },
           error: failure.error,
+          ...(attemptUsage !== undefined ? { usage: attemptUsage } : {}),
         });
+      inFlightAttempt = undefined;
       await events.emit('execution.attempt.completed', 'attempt', attemptId, {
         trialId: coordinate.coordinate.trialId,
         attemptNumber,
@@ -912,26 +952,43 @@ async function executeCoordinate(
       }
     }
   } catch (error) {
-    if (attempts.length === 0) {
-      const attemptId = deriveAttemptId({
-        trialId: coordinate.coordinate.trialId,
-        attemptNumber: 1,
-      });
-      const evaluationError = safeError(error);
+    if (inFlightAttempt !== undefined) {
+      const evaluationError: EvaluationError = {
+        code: 'executor-result-invalid',
+        stage: 'infrastructure',
+        message: 'Executor returned a result that could not be materialized safely.',
+      };
       attempts.push({
-        attemptId,
-        attemptNumber: 1,
+        attemptId: inFlightAttempt.attemptId,
+        attemptNumber: inFlightAttempt.attemptNumber,
         attemptStatus: 'failed',
         timing: {
-          startedAt: trialStartedAt,
+          startedAt: inFlightAttempt.startedAt,
           completedAt: ports.clock.timestamp(),
-          durationMs: durationMs(trialStartedMonotonic, ports.clock.monotonicNow()),
+          durationMs: durationMs(
+            inFlightAttempt.startedMonotonic,
+            ports.clock.monotonicNow(),
+          ),
         },
         error: evaluationError,
       });
+      attemptUsages.push(undefined);
+      inFlightAttempt = undefined;
       terminalError = evaluationError;
       terminalStatus = 'failed';
+      cacheEligible = false;
+      setStop('failed', evaluationError.code, evaluationError);
+    } else if (attempts.length === 0) {
+      const evaluationError = safeError(error);
+      cacheEligible = false;
+      setStop('failed', 'executor-resource-open-failed', {
+        code: 'executor-resource-open-failed',
+        stage: 'infrastructure',
+        message: 'Executor run or trial resource could not be opened.',
+        causes: [evaluationError],
+      });
     } else {
+      cacheEligible = false;
       setStop('failed', 'execution-runtime-internal-failed', {
         code: 'execution-runtime-internal-failed',
         stage: 'internal',
@@ -944,6 +1001,7 @@ async function executeCoordinate(
       try {
         await trial.dispose();
       } catch {
+        cacheEligible = false;
         setStop('failed', 'executor-trial-dispose-failed', {
           code: 'executor-trial-dispose-failed',
           stage: 'infrastructure',
@@ -957,6 +1015,7 @@ async function executeCoordinate(
 
   if (attempts.length === 0) return { failed: false };
 
+  const usage = aggregateUsage(attemptUsages);
   const completedAt = ports.clock.timestamp();
   const recordBase = {
     ...coordinate.coordinate,
@@ -998,30 +1057,26 @@ async function executeCoordinate(
         },
       };
 
-  if (record.executionStatus === 'completed'
-      && plan.execution.policy.executionCacheMode === 'transparent-deterministic') {
-    const entry: ExecutionCacheEntry = {
+  const cacheEntry = record.executionStatus === 'completed'
+      && cacheEligible
+      && plan.execution.policy.executionCacheMode === 'transparent-deterministic'
+    ? {
       cacheKeyDigest: key,
       sourceRecordDigest: digestCanonicalJson(record),
       record: snapshotJson(record),
-    };
-    try {
-      await ports.cache?.put(entry);
-    } catch {
-      setStop('failed', 'execution-cache-write-failed', {
-        code: 'execution-cache-write-failed',
-        stage: 'infrastructure',
-        message: 'Execution cache write failed.',
-      });
-    }
-  }
+    } satisfies ExecutionCacheEntry
+    : undefined;
   await events.emit('execution.trial.completed', 'trial', coordinate.coordinate.trialId, {
     targetId: coordinate.coordinate.targetId,
     sampleId: coordinate.coordinate.sampleId,
     trialIndex: coordinate.coordinate.trialIndex,
     executionStatus: record.executionStatus,
   });
-  return { record, failed: record.executionStatus === 'failed' };
+  return {
+    record,
+    ...(cacheEntry !== undefined ? { cacheEntry } : {}),
+    failed: record.executionStatus === 'failed',
+  };
 }
 
 async function prepareBlock(
@@ -1227,9 +1282,10 @@ async function runExecution(
   const events = new EventEmitter(plan, ports, options, stream, (reason, error) => {
     setStop('failed', reason, error);
   });
-  const sessions = new RunSessions(plan, ports, options);
+  const sessions = new RunSessions(plan, options);
   const budget = new BudgetTracker(plan);
   const records = new Map<string, ExecutionRecord>();
+  const pendingCacheEntries = new Map<Sha256Digest, ExecutionCacheEntry>();
   const durationController = new AbortController();
   const durationTimer = plan.execution.policy.budget.maxDurationMs === undefined
     ? undefined
@@ -1284,6 +1340,9 @@ async function runExecution(
           if (result.record !== undefined) {
             records.set(coordinateKey(result.record), result.record);
           }
+          if (result.cacheEntry !== undefined) {
+            pendingCacheEntries.set(result.cacheEntry.cacheKeyDigest, result.cacheEntry);
+          }
         }
         await events.emit('execution.block.completed', 'scheduling-block', preparedBlock.block.schedulingBlockId, {
           coordinateCount: preparedBlock.coordinates.length,
@@ -1322,6 +1381,22 @@ async function runExecution(
     const disposeErrors = await sessions.dispose();
     if (disposeErrors.length > 0) {
       setStop('failed', 'executor-run-dispose-failed', disposeErrors[0]);
+    }
+    if (disposeErrors.length === 0 && stop.stopKind === undefined) {
+      for (const entry of [...pendingCacheEntries.values()].sort((left, right) => (
+        compareStrings(left.cacheKeyDigest, right.cacheKeyDigest)
+      ))) {
+        try {
+          await ports.cache?.put(entry);
+        } catch {
+          setStop('failed', 'execution-cache-write-failed', {
+            code: 'execution-cache-write-failed',
+            stage: 'infrastructure',
+            message: 'Execution cache write failed.',
+          });
+          break;
+        }
+      }
     }
   }
 

--- a/src/evaluation-core/execution/scheduler.ts
+++ b/src/evaluation-core/execution/scheduler.ts
@@ -1,0 +1,107 @@
+import {
+  derivePlannedExecutionCoordinates,
+  digestCanonicalJson,
+  type PlannedExecutionCoordinate,
+} from '../contracts/index.js';
+import type { SealedRunPlan } from '../compiler/index.js';
+
+export interface ExecutionSchedulingBlock {
+  schedulingBlockId: string;
+  coordinates: readonly PlannedExecutionCoordinate[];
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function interleavedOrder(
+  left: ExecutionSchedulingBlock,
+  right: ExecutionSchedulingBlock,
+): number {
+  const leftCoordinate = left.coordinates[0];
+  const rightCoordinate = right.coordinates[0];
+  return leftCoordinate.trialIndex - rightCoordinate.trialIndex
+    || compareStrings(leftCoordinate.sampleId, rightCoordinate.sampleId)
+    || compareStrings(leftCoordinate.targetId, rightCoordinate.targetId);
+}
+
+function rotate<T>(values: readonly T[], offset: number): T[] {
+  if (values.length < 2) return [...values];
+  const normalized = offset % values.length;
+  return [...values.slice(normalized), ...values.slice(0, normalized)];
+}
+
+function randomRank(seed: string, scope: string, identity: string): string {
+  return digestCanonicalJson({
+    derivation: 'omk.execution-schedule-rank/v1',
+    seed,
+    scope,
+    identity,
+  });
+}
+
+function randomizedBlocks(
+  blocks: readonly ExecutionSchedulingBlock[],
+  seed: string,
+  blockSize: number,
+): ExecutionSchedulingBlock[] {
+  const batches: ExecutionSchedulingBlock[][] = [];
+  let batch: ExecutionSchedulingBlock[] = [];
+  let coordinateCount = 0;
+  for (const block of blocks) {
+    if (block.coordinates.length > blockSize) {
+      throw new TypeError('randomized-block blockSize cannot split a scheduling block');
+    }
+    if (coordinateCount > 0 && coordinateCount + block.coordinates.length > blockSize) {
+      batches.push(batch);
+      batch = [];
+      coordinateCount = 0;
+    }
+    batch.push(block);
+    coordinateCount += block.coordinates.length;
+  }
+  if (batch.length > 0) batches.push(batch);
+
+  return batches.flatMap((currentBatch, batchIndex) => (
+    currentBatch
+      .map((block) => ({
+        ...block,
+        coordinates: [...block.coordinates].sort((left, right) => compareStrings(
+          randomRank(seed, block.schedulingBlockId, left.trialId),
+          randomRank(seed, block.schedulingBlockId, right.trialId),
+        )),
+      }))
+      .sort((left, right) => compareStrings(
+        randomRank(seed, `batch:${batchIndex}`, left.schedulingBlockId),
+        randomRank(seed, `batch:${batchIndex}`, right.schedulingBlockId),
+      ))
+  ));
+}
+
+export function deriveExecutionSchedule(plan: SealedRunPlan): ExecutionSchedulingBlock[] {
+  const coordinates = derivePlannedExecutionCoordinates(plan);
+  const byBlock = new Map<string, PlannedExecutionCoordinate[]>();
+  for (const coordinate of coordinates) {
+    const block = byBlock.get(coordinate.schedulingBlockId) ?? [];
+    block.push(coordinate);
+    byBlock.set(coordinate.schedulingBlockId, block);
+  }
+  const blocks = [...byBlock.entries()].map(([schedulingBlockId, members]) => ({
+    schedulingBlockId,
+    coordinates: members,
+  }));
+  const { scheduling } = plan.execution.experiment;
+  if (scheduling.schedulingKind === 'sequential') return blocks;
+
+  const interleaved = blocks.sort(interleavedOrder).map((block, index) => ({
+    ...block,
+    coordinates: rotate(block.coordinates, index),
+  }));
+  if (scheduling.schedulingKind === 'interleaved') return interleaved;
+  if (scheduling.blockSize === undefined) {
+    throw new TypeError('randomized-block scheduling requires blockSize');
+  }
+  return randomizedBlocks(interleaved, plan.execution.experiment.seed, scheduling.blockSize);
+}

--- a/src/evaluation-core/execution/semaphore.ts
+++ b/src/evaluation-core/execution/semaphore.ts
@@ -1,0 +1,62 @@
+interface Waiter {
+  resolve(release: () => void): void;
+  reject(error: Error): void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+}
+
+export class Semaphore {
+  readonly #limit: number;
+  readonly #waiters: Waiter[] = [];
+  #active = 0;
+
+  constructor(limit: number) {
+    if (!Number.isSafeInteger(limit) || limit < 1) {
+      throw new TypeError('Semaphore limit must be a positive safe integer');
+    }
+    this.#limit = limit;
+  }
+
+  async acquire(signal?: AbortSignal): Promise<() => void> {
+    if (signal?.aborted) throw abortError();
+    if (this.#active < this.#limit) {
+      this.#active += 1;
+      return this.#release();
+    }
+    return new Promise<() => void>((resolve, reject) => {
+      const waiter: Waiter = { resolve, reject, ...(signal !== undefined ? { signal } : {}) };
+      if (signal !== undefined) {
+        waiter.onAbort = () => {
+          const index = this.#waiters.indexOf(waiter);
+          if (index >= 0) this.#waiters.splice(index, 1);
+          reject(abortError());
+        };
+        signal.addEventListener('abort', waiter.onAbort, { once: true });
+      }
+      this.#waiters.push(waiter);
+    });
+  }
+
+  #release(): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const waiter = this.#waiters.shift();
+      if (waiter === undefined) {
+        this.#active -= 1;
+        return;
+      }
+      if (waiter.signal !== undefined && waiter.onAbort !== undefined) {
+        waiter.signal.removeEventListener('abort', waiter.onAbort);
+      }
+      waiter.resolve(this.#release());
+    };
+  }
+}
+
+export function abortError(): Error {
+  const error = new Error('Operation aborted');
+  error.name = 'AbortError';
+  return error;
+}

--- a/src/evaluation-core/execution/types.ts
+++ b/src/evaluation-core/execution/types.ts
@@ -1,0 +1,166 @@
+import type {
+  ContentDescriptor,
+  EvaluationError,
+  EvaluationEvent,
+  ExecutionBundle,
+  ExecutionRecord,
+  JsonValue,
+  RuntimeIdentity,
+  Sha256Digest,
+  UsageRecord,
+} from '../contracts/index.js';
+import type { SealedRunPlan } from '../compiler/index.js';
+
+export const EXECUTION_EVENT_KINDS = [
+  'execution.run.started',
+  'execution.run.completed',
+  'execution.run.cancelled',
+  'execution.run.budget-exhausted',
+  'execution.run.failed',
+  'execution.block.started',
+  'execution.block.completed',
+  'execution.trial.started',
+  'execution.trial.completed',
+  'execution.attempt.started',
+  'execution.attempt.completed',
+  'execution.retry.scheduled',
+  'execution.cache.hit',
+  'execution.cache.miss',
+] as const;
+
+export type ExecutionEventKind = typeof EXECUTION_EVENT_KINDS[number];
+
+export type ExecutionEventSubjectKind =
+  | 'run'
+  | 'scheduling-block'
+  | 'trial'
+  | 'attempt';
+
+export interface ExecutionContent {
+  value: JsonValue;
+  classification: 'public' | 'sensitive' | 'secret' | 'gold';
+  mediaType?: string;
+}
+
+export interface ExecutorRunContext {
+  runId: string;
+  executionPlanDigest: Sha256Digest;
+}
+
+export interface ExecutorTrialContext {
+  targetId: string;
+  protocolId: 'omk.invoke/v1' | 'omk.session/v1';
+  input: JsonValue;
+  executionContext?: JsonValue;
+  targetConfig?: JsonValue;
+  trialIndex: number;
+  trialId: Sha256Digest;
+  schedulingBlockId: Sha256Digest;
+  samplingUnitIds: {
+    pairingBlockId?: Sha256Digest;
+    clusterId?: Sha256Digest;
+    stratumId?: Sha256Digest;
+  };
+  trialSeed?: Sha256Digest;
+}
+
+export interface ExecutorAttemptContext {
+  attemptId: Sha256Digest;
+  attemptNumber: number;
+  signal: AbortSignal;
+}
+
+export interface ExecutorAttemptResult {
+  output?: ExecutionContent;
+  trace?: ExecutionContent;
+  usage?: UsageRecord;
+}
+
+export interface ExecutionExecutorTrial {
+  execute(context: Readonly<ExecutorAttemptContext>): Promise<ExecutorAttemptResult>;
+  dispose(): void | Promise<void>;
+}
+
+export interface ExecutionExecutorRun {
+  openTrial(context: Readonly<ExecutorTrialContext>): Promise<ExecutionExecutorTrial>;
+  dispose(): void | Promise<void>;
+}
+
+export interface ExecutionExecutor {
+  readonly identity: RuntimeIdentity;
+  openRun(context: Readonly<ExecutorRunContext>): Promise<ExecutionExecutorRun>;
+}
+
+export interface ExecutionClock {
+  monotonicNow(): number;
+  timestamp(): string;
+  sleep(delayMs: number, signal: AbortSignal): Promise<void>;
+}
+
+export interface ExecutionCacheEntry {
+  cacheKeyDigest: Sha256Digest;
+  sourceRecordDigest: Sha256Digest;
+  record: Extract<ExecutionRecord, { executionStatus: 'completed' }>;
+}
+
+export interface ExecutionCache {
+  get(cacheKeyDigest: Sha256Digest): Promise<ExecutionCacheEntry | undefined>;
+  put(entry: Readonly<ExecutionCacheEntry>): Promise<void>;
+}
+
+export interface ExecutionContentStoreRequest extends ExecutionContent {
+  digest: Sha256Digest;
+  mediaType: string;
+}
+
+export interface ExecutionContentStore {
+  put(request: Readonly<ExecutionContentStoreRequest>): Promise<ContentDescriptor>;
+}
+
+export interface ExecutionEventWriter {
+  write(event: Readonly<EvaluationEvent>): Promise<void>;
+}
+
+export interface ExecutionRuntimePorts {
+  executors: ReadonlyMap<string, ExecutionExecutor>;
+  clock: ExecutionClock;
+  cache?: ExecutionCache;
+  contentStore?: ExecutionContentStore;
+  eventWriter?: ExecutionEventWriter;
+}
+
+export interface ExecutionRunOptions {
+  runId: string;
+  bundleId: string;
+  signal?: AbortSignal;
+  eventBufferCapacity?: number;
+}
+
+export interface ExecutionRun {
+  events: AsyncIterable<EvaluationEvent>;
+  result: Promise<ExecutionBundle>;
+}
+
+export class ExecutionPortFailure extends Error {
+  readonly evaluationError: EvaluationError;
+  readonly usage?: UsageRecord;
+
+  constructor(error: EvaluationError, usage?: UsageRecord) {
+    super(error.message);
+    this.name = 'ExecutionPortFailure';
+    this.evaluationError = error;
+    this.usage = usage;
+  }
+}
+
+export class ExecutionRuntimeConfigurationError extends TypeError {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'ExecutionRuntimeConfigurationError';
+    this.code = code;
+  }
+}
+
+export type ExecutionPlan = SealedRunPlan;

--- a/test/evaluation-core/compiler/fixtures.ts
+++ b/test/evaluation-core/compiler/fixtures.ts
@@ -164,6 +164,8 @@ interface RuntimeOptions {
   trialState?: 'stateless' | 'isolated';
   traceCapability?: 'unsupported' | 'optional' | 'required';
   seedControl?: 'unsupported' | 'optional' | 'required';
+  concurrencySafety?: 'serialized' | 'parallel-safe';
+  maxInFlight?: number;
   executorProtocols?: Array<'omk.invoke/v1' | 'omk.session/v1'>;
   evaluatorValueTypes?: Array<'numeric' | 'boolean' | 'categorical' | 'text' | 'ranking'>;
   analysisValueTypes?: Array<'numeric' | 'boolean' | 'categorical' | 'text' | 'ranking'>;
@@ -212,7 +214,12 @@ export function testRuntime(options: RuntimeOptions = {}): TestRuntime {
                 ? { traceSchema: schemaIdentity(`${protocolId}:trace`) }
                 : {}),
               execution: {
-                concurrency: { safety: 'parallel-safe' },
+                concurrency: {
+                  safety: options.concurrencySafety ?? 'parallel-safe',
+                  ...(options.maxInFlight !== undefined
+                    ? { maxInFlight: options.maxInFlight }
+                    : {}),
+                },
                 cancellation: options.cancellation ?? 'cooperative',
                 state: {
                   resourceLifecycle: 'per-run',

--- a/test/evaluation-core/compiler/validation.test.ts
+++ b/test/evaluation-core/compiler/validation.test.ts
@@ -130,6 +130,42 @@ describe('Compiler definition validation', () => {
     );
   });
 
+  it('treats overlapping paired comparisons as one atomic scheduling group', async () => {
+    const definition = validDefinition();
+    definition.targets.push({
+      ...structuredClone(definition.targets[1]),
+      targetId: 'treatment-b',
+    });
+    definition.comparisons.push({
+      comparisonId: 'treatment-vs-treatment-b',
+      controlTargetId: 'treatment',
+      treatmentTargetIds: ['treatment-b'],
+      metricIds: ['correct'],
+    });
+    definition.experiment.sampling.pairingKey = '/input/cohort';
+    definition.experiment.sampling.resamplingUnit = 'paired-block';
+    definition.experiment.scheduling = {
+      schedulingKind: 'randomized-block',
+      blockSize: 2,
+    };
+    await expectCode(
+      definition,
+      validPolicy(),
+      'EVAL_DEFINITION_POLICY_INVALID',
+      testRuntime({ samplingResamplingUnits: ['paired-block'] }),
+    );
+
+    definition.experiment.scheduling = { schedulingKind: 'interleaved' };
+    const policy = validPolicy();
+    policy.budget.maxTargetInvocations = 2;
+    await expectCode(
+      definition,
+      policy,
+      'EVAL_DEFINITION_POLICY_INVALID',
+      testRuntime({ samplingResamplingUnits: ['paired-block'] }),
+    );
+  });
+
   it('rejects unsupported protocol, deterministic cache, and evaluator capabilities', async () => {
     const protocol = validDefinition();
     protocol.targets[0].protocolId = 'omk.session/v1';

--- a/test/evaluation-core/contracts/execution-bundle.test.ts
+++ b/test/evaluation-core/contracts/execution-bundle.test.ts
@@ -274,6 +274,13 @@ describe('ExecutionBundle contract', () => {
       ...attempt,
       attemptStatus: 'failed',
     }).success).toBe(false);
+    expect(ExecutionAttemptSchema.safeParse({
+      ...attempt,
+      usage: {
+        inputTokens: 1,
+        providerCost: { amount: 0.01, currency: 'USD', reportedByProvider: true },
+      },
+    }).success).toBe(true);
   });
 
   it('rejects a scheduling block split between active and budget-censored records', () => {

--- a/test/evaluation-core/contracts/execution-bundle.test.ts
+++ b/test/evaluation-core/contracts/execution-bundle.test.ts
@@ -318,6 +318,14 @@ describe('ExecutionBundle contract', () => {
     );
   });
 
+  it('allows budget exhaustion during the final started trial without synthetic censoring', () => {
+    const bundle = finalizeBundle({
+      executionBundleStatus: 'budget-exhausted',
+      terminationReasonCode: 'provider-cost-budget-exhausted',
+    });
+    expect(parseExecutionBundleDocument(bundle)).toEqual(bundle);
+  });
+
   it('rejects coverage and terminal-state contradictions', () => {
     const bundle = finalizeBundle({
       coverage: {

--- a/test/evaluation-core/execution/runtime.test.ts
+++ b/test/evaluation-core/execution/runtime.test.ts
@@ -1,0 +1,1036 @@
+import { describe, expect, it } from 'vitest';
+import {
+  digestCanonicalJson,
+  parseExecutionBundleDocument,
+  type EvaluationEvent,
+  type RuntimeIdentity,
+  type Sha256Digest,
+} from '../../../src/evaluation-core/contracts/index.js';
+import { prepareEvaluationPlan } from '../../../src/evaluation-core/compiler/index.js';
+import {
+  ExecutionPortFailure,
+  ExecutionRuntimeConfigurationError,
+  deriveExecutionSchedule,
+  executeRunPlan,
+  startExecution,
+  type ExecutionCache,
+  type ExecutionCacheEntry,
+  type ExecutionClock,
+  type ExecutionContentStore,
+  type ExecutionExecutor,
+  type ExecutionExecutorRun,
+  type ExecutionExecutorTrial,
+  type ExecutionRuntimePorts,
+  type ExecutorAttemptContext,
+  type ExecutorAttemptResult,
+  type ExecutorRunContext,
+  type ExecutorTrialContext,
+} from '../../../src/evaluation-core/execution/index.js';
+import {
+  testRuntime,
+  validDefinition,
+  validPolicy,
+  type TestRuntime,
+} from '../compiler/fixtures.js';
+
+type Plan = Awaited<ReturnType<typeof prepareEvaluationPlan>>;
+
+class FakeClock implements ExecutionClock {
+  now = 0;
+
+  monotonicNow(): number {
+    return this.now;
+  }
+
+  timestamp(): string {
+    return new Date(Date.UTC(2026, 7, 29) + this.now).toISOString();
+  }
+
+  async sleep(delayMs: number, signal: AbortSignal): Promise<void> {
+    if (signal.aborted) throw abortFailure();
+    this.now += delayMs;
+    await Promise.resolve();
+    if (signal.aborted) throw abortFailure();
+  }
+}
+
+class ManualClock implements ExecutionClock {
+  now = 0;
+  readonly sleepers: Array<{
+    due: number;
+    resolve: () => void;
+    reject: (error: unknown) => void;
+    signal: AbortSignal;
+  }> = [];
+
+  monotonicNow(): number {
+    return this.now;
+  }
+
+  timestamp(): string {
+    return new Date(Date.UTC(2026, 7, 29) + this.now).toISOString();
+  }
+
+  sleep(delayMs: number, signal: AbortSignal): Promise<void> {
+    if (signal.aborted) return Promise.reject(abortFailure());
+    return new Promise<void>((resolve, reject) => {
+      const sleeper = { due: this.now + delayMs, resolve, reject, signal };
+      this.sleepers.push(sleeper);
+      signal.addEventListener('abort', () => {
+        const index = this.sleepers.indexOf(sleeper);
+        if (index >= 0) this.sleepers.splice(index, 1);
+        reject(abortFailure());
+      }, { once: true });
+    });
+  }
+
+  advance(delayMs: number): void {
+    this.now += delayMs;
+    const ready = this.sleepers.filter((sleeper) => sleeper.due <= this.now);
+    for (const sleeper of ready) {
+      const index = this.sleepers.indexOf(sleeper);
+      if (index >= 0) this.sleepers.splice(index, 1);
+      if (!sleeper.signal.aborted) sleeper.resolve();
+    }
+  }
+}
+
+function abortFailure(): Error {
+  const error = new Error('aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+class MemoryCache implements ExecutionCache {
+  readonly entries = new Map<Sha256Digest, ExecutionCacheEntry>();
+  gets = 0;
+  puts = 0;
+
+  async get(key: Sha256Digest): Promise<ExecutionCacheEntry | undefined> {
+    this.gets += 1;
+    return this.entries.get(key);
+  }
+
+  async put(entry: Readonly<ExecutionCacheEntry>): Promise<void> {
+    this.puts += 1;
+    this.entries.set(entry.cacheKeyDigest, structuredClone(entry));
+  }
+}
+
+const contentStore: ExecutionContentStore = {
+  async put(request) {
+    return {
+      mediaType: request.mediaType,
+      digest: request.digest,
+      size: JSON.stringify(request.value).length,
+      uri: `memory:${request.digest}`,
+    };
+  },
+};
+
+interface ExecutorState {
+  runOpens: number;
+  runDisposals: number;
+  trialOpens: number;
+  trialDisposals: number;
+  attempts: number;
+  active: number;
+  maxActive: number;
+  trialContexts: ExecutorTrialContext[];
+}
+
+type AttemptHandler = (
+  trial: ExecutorTrialContext,
+  attempt: Readonly<ExecutorAttemptContext>,
+) => Promise<ExecutorAttemptResult> | ExecutorAttemptResult;
+
+function fakeExecutor(
+  identity: RuntimeIdentity,
+  handler: AttemptHandler = (trial) => ({
+    output: {
+      value: { answer: trial.targetId },
+      classification: 'public',
+    },
+  }),
+): { executor: ExecutionExecutor; state: ExecutorState } {
+  const state: ExecutorState = {
+    runOpens: 0,
+    runDisposals: 0,
+    trialOpens: 0,
+    trialDisposals: 0,
+    attempts: 0,
+    active: 0,
+    maxActive: 0,
+    trialContexts: [],
+  };
+  const executor: ExecutionExecutor = {
+    identity,
+    async openRun(_context: Readonly<ExecutorRunContext>): Promise<ExecutionExecutorRun> {
+      state.runOpens += 1;
+      return {
+        async openTrial(context: Readonly<ExecutorTrialContext>): Promise<ExecutionExecutorTrial> {
+          state.trialOpens += 1;
+          state.trialContexts.push(context as ExecutorTrialContext);
+          return {
+            async execute(attempt): Promise<ExecutorAttemptResult> {
+              state.attempts += 1;
+              state.active += 1;
+              state.maxActive = Math.max(state.maxActive, state.active);
+              try {
+                return await handler(context as ExecutorTrialContext, attempt);
+              } finally {
+                state.active -= 1;
+              }
+            },
+            async dispose() {
+              state.trialDisposals += 1;
+            },
+          };
+        },
+        async dispose() {
+          state.runDisposals += 1;
+        },
+      };
+    },
+  };
+  return { executor, state };
+}
+
+async function makePlan(
+  mutate?: (definition: ReturnType<typeof validDefinition>, policy: ReturnType<typeof validPolicy>) => void,
+  runtime: TestRuntime = testRuntime(),
+): Promise<Plan> {
+  const definition = validDefinition();
+  const policy = validPolicy();
+  delete policy.execution.timeoutMs;
+  mutate?.(definition, policy);
+  return prepareEvaluationPlan(definition, policy, runtime);
+}
+
+function expectedExecutorIdentity(plan: Plan): RuntimeIdentity {
+  const runtime = plan.execution.runtimes.find((candidate) => (
+    candidate.runtimeKind === 'executor' && candidate.referenceId === 'control'
+  ));
+  if (runtime === undefined) throw new Error('missing Runtime identity');
+  return structuredClone(runtime.identity) as RuntimeIdentity;
+}
+
+function portsFor(
+  plan: Plan,
+  handler?: AttemptHandler,
+  overrides: Partial<ExecutionRuntimePorts> = {},
+) {
+  const { executor, state } = fakeExecutor(expectedExecutorIdentity(plan), handler);
+  const ports: ExecutionRuntimePorts = {
+    executors: new Map([['executor-alias', executor]]),
+    clock: new FakeClock(),
+    contentStore,
+    ...overrides,
+  };
+  return { ports, state };
+}
+
+describe('Evaluation Core Execution runtime', () => {
+  it('executes a sealed plan without exposing Gold and materializes a valid Bundle', async () => {
+    const plan = await makePlan();
+    const { ports, state } = portsFor(plan);
+    const run = startExecution(plan, ports, {
+      runId: 'run-success',
+      bundleId: 'bundle-success',
+      eventBufferCapacity: 1,
+    });
+    const bundle = await run.result;
+    const retainedEvents: EvaluationEvent[] = [];
+    for await (const event of run.events) retainedEvents.push(event);
+
+    expect(bundle.executionBundleStatus).toBe('completed');
+    expect(retainedEvents).toHaveLength(1);
+    expect(retainedEvents[0].eventKind).toBe('execution.run.completed');
+    expect(() => run.events[Symbol.asyncIterator]()).toThrow(TypeError);
+    expect(bundle.coverage).toEqual({
+      planned: 2,
+      started: 2,
+      succeeded: 2,
+      failed: 0,
+      cancelled: 0,
+      budgetCensored: 0,
+      notStarted: 0,
+    });
+    expect(bundle.replayability).toBe('self-contained');
+    expect(state).toMatchObject({
+      runOpens: 1,
+      runDisposals: 1,
+      trialOpens: 2,
+      trialDisposals: 2,
+      attempts: 2,
+    });
+    for (const context of state.trialContexts) {
+      expect(Object.isFrozen(context)).toBe(true);
+      expect(context).not.toHaveProperty('expected');
+      expect(context).not.toHaveProperty('evaluationContext');
+      expect(context).not.toHaveProperty('annotations');
+      expect(context.trialSeed).toMatch(/^sha256:/);
+    }
+  });
+
+  it('derives stable sequential, interleaved, and randomized admission schedules', async () => {
+    const sequential = await makePlan((definition) => {
+      definition.dataset.samples.push({
+        ...structuredClone(definition.dataset.samples[0]),
+        sampleId: 'sample-2',
+      });
+      definition.experiment.scheduling = { schedulingKind: 'sequential' };
+    });
+    const interleaved = await makePlan((definition) => {
+      definition.dataset.samples.push({
+        ...structuredClone(definition.dataset.samples[0]),
+        sampleId: 'sample-2',
+      });
+      definition.experiment.scheduling = { schedulingKind: 'interleaved' };
+    });
+    const randomized = await makePlan((definition) => {
+      definition.dataset.samples.push({
+        ...structuredClone(definition.dataset.samples[0]),
+        sampleId: 'sample-2',
+      });
+      definition.experiment.scheduling = {
+        schedulingKind: 'randomized-block',
+        blockSize: 2,
+      };
+    });
+
+    expect(deriveExecutionSchedule(sequential).flatMap((block) => (
+      block.coordinates.map((coordinate) => `${coordinate.targetId}/${coordinate.sampleId}`)
+    ))).toEqual([
+      'control/sample-1',
+      'control/sample-2',
+      'treatment/sample-1',
+      'treatment/sample-2',
+    ]);
+    expect(deriveExecutionSchedule(interleaved).flatMap((block) => (
+      block.coordinates.map((coordinate) => `${coordinate.targetId}/${coordinate.sampleId}`)
+    ))).toEqual([
+      'control/sample-1',
+      'treatment/sample-1',
+      'control/sample-2',
+      'treatment/sample-2',
+    ]);
+    expect(deriveExecutionSchedule(randomized)).toEqual(deriveExecutionSchedule(randomized));
+    expect(new Set(deriveExecutionSchedule(randomized).flatMap((block) => (
+      block.coordinates.map((coordinate) => coordinate.trialId)
+    ))).size).toBe(4);
+  });
+
+  it('retries only within one trial identity and disposes one trial session', async () => {
+    const plan = await makePlan((definition) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+    });
+    let calls = 0;
+    const { ports, state } = portsFor(plan, () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new ExecutionPortFailure({
+          code: 'timeout',
+          stage: 'infrastructure',
+          message: 'retry me',
+        });
+      }
+      return {
+        output: { value: { answer: 'ok' }, classification: 'public' },
+      };
+    });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-retry',
+      bundleId: 'bundle-retry',
+    });
+
+    const record = bundle.records[0];
+    if (record.executionStatus !== 'completed') throw new Error('expected completed record');
+    expect(record.attempts).toHaveLength(2);
+    expect(new Set(record.attempts.map((attempt) => attempt.attemptId)).size).toBe(2);
+    expect(record.trialId).toBe(state.trialContexts[0].trialId);
+    expect(state.trialOpens).toBe(1);
+    expect(state.trialDisposals).toBe(1);
+  });
+
+  it('reuses one isolated omk.session/v1 trial across retry attempts', async () => {
+    const plan = await makePlan((definition) => {
+      definition.targets = [{
+        ...definition.targets[0],
+        protocolId: 'omk.session/v1',
+      }];
+      definition.comparisons = [];
+    }, testRuntime({
+      executorProtocols: ['omk.invoke/v1', 'omk.session/v1'],
+      trialState: 'isolated',
+      traceCapability: 'optional',
+    }));
+    let calls = 0;
+    const { ports, state } = portsFor(plan, (trial) => {
+      expect(trial.protocolId).toBe('omk.session/v1');
+      calls += 1;
+      if (calls === 1) {
+        throw new ExecutionPortFailure({
+          code: 'timeout',
+          stage: 'infrastructure',
+          message: 'retry session turn',
+        });
+      }
+      return {
+        output: {
+          value: { messages: [{ role: 'assistant', content: 'done' }] },
+          classification: 'public',
+        },
+        trace: {
+          value: { toolCalls: [{ name: 'search', status: 'completed' }] },
+          classification: 'public',
+        },
+      };
+    });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-session-retry',
+      bundleId: 'bundle-session-retry',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('completed');
+    expect(bundle.records[0].executionStatus).toBe('completed');
+    expect(state).toMatchObject({ trialOpens: 1, attempts: 2, trialDisposals: 1 });
+  });
+
+  it('records timeout once even when an Executor returns success after observing abort', async () => {
+    const events: EvaluationEvent[] = [];
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.execution.timeoutMs = 25;
+      policy.retry.maxAttempts = 1;
+      policy.eventDelivery.writerMode = 'optional';
+    });
+    const { ports, state } = portsFor(plan, async (_trial, attempt) => {
+      await new Promise<void>((resolve) => {
+        attempt.signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      return {
+        output: { value: { late: true }, classification: 'public' },
+        usage: { inputTokens: 1 },
+      };
+    }, {
+      eventWriter: {
+        async write(event) {
+          events.push(structuredClone(event));
+        },
+      },
+    });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-timeout',
+      bundleId: 'bundle-timeout',
+    });
+
+    const record = bundle.records[0];
+    expect(record.executionStatus).toBe('failed');
+    if (record.executionStatus !== 'failed') throw new Error('expected failed record');
+    expect(record.error.code).toBe('timeout');
+    expect(record.attempts).toHaveLength(1);
+    expect(record.attempts[0]).toMatchObject({
+      attemptStatus: 'failed',
+      error: { code: 'timeout' },
+    });
+    expect('output' in record).toBe(false);
+    expect(record.usage?.inputTokens).toBe(1);
+    expect(state.attempts).toBe(1);
+    expect(events.filter((event) => (
+      event.eventKind === 'execution.attempt.completed'
+    ))).toHaveLength(1);
+  });
+
+  it('censors the next whole paired block before opening an Executor when budget is insufficient', async () => {
+    const plan = await makePlan((definition, policy) => {
+      definition.dataset.samples.push({
+        ...structuredClone(definition.dataset.samples[0]),
+        sampleId: 'sample-2',
+      });
+      definition.experiment.sampling.pairingKey = '/input/cohort';
+      definition.experiment.sampling.resamplingUnit = 'paired-block';
+      policy.budget.maxTargetInvocations = 3;
+    }, testRuntime({ samplingResamplingUnits: ['paired-block'] }));
+    const { ports, state } = portsFor(plan);
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-budget',
+      bundleId: 'bundle-budget',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('budget-exhausted');
+    expect(bundle.coverage).toMatchObject({
+      planned: 4,
+      started: 2,
+      succeeded: 2,
+      budgetCensored: 2,
+    });
+    const censored = bundle.records.filter((record) => (
+      record.executionStatus === 'budget-censored'
+    ));
+    expect(new Set(censored.map((record) => record.schedulingBlockId)).size).toBe(1);
+    expect(state.runOpens).toBe(1);
+    expect(state.attempts).toBe(2);
+  });
+
+  it('returns an honest partial cancelled Bundle and isolates uncontrolled seed designs', async () => {
+    const plan = await makePlan((definition, policy) => {
+      definition.experiment.sampling.seedCoupling = 'uncontrolled';
+      policy.execution.maxConcurrency = 1;
+    }, testRuntime({ deterministic: false, seedControl: 'unsupported' }));
+    const controller = new AbortController();
+    const { ports, state } = portsFor(plan, (_trial, attempt) => {
+      controller.abort();
+      if (attempt.signal.aborted) throw abortFailure();
+      return {};
+    });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-cancelled',
+      bundleId: 'bundle-cancelled',
+      signal: controller.signal,
+    });
+
+    expect(bundle.executionBundleStatus).toBe('cancelled');
+    expect(bundle.coverage.cancelled).toBeGreaterThan(0);
+    expect(bundle.coverage.notStarted).toBeGreaterThan(0);
+    expect(state.trialContexts[0]).not.toHaveProperty('trialSeed');
+    expect(plan.execution.experiment.sampling.seedCoupling).toBe('uncontrolled');
+  });
+
+  it('isolates cancellation and resource ownership across concurrent Runs', async () => {
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.retry.maxAttempts = 1;
+    });
+    const identity = expectedExecutorIdentity(plan);
+    let runCount = 0;
+    let runDisposals = 0;
+    let trialDisposals = 0;
+    let resolveBothOpened: (() => void) | undefined;
+    const bothOpened = new Promise<void>((resolve) => {
+      resolveBothOpened = resolve;
+    });
+    const executor: ExecutionExecutor = {
+      identity,
+      async openRun(context) {
+        runCount += 1;
+        if (runCount === 2) resolveBothOpened?.();
+        const shouldWaitForCancellation = context.runId === 'run-isolated-cancelled';
+        return {
+          async openTrial() {
+            return {
+              async execute(attempt) {
+                if (shouldWaitForCancellation) {
+                  await new Promise<void>((resolve) => {
+                    attempt.signal.addEventListener('abort', () => resolve(), { once: true });
+                  });
+                  throw abortFailure();
+                }
+                return {
+                  output: { value: { runId: context.runId }, classification: 'public' },
+                };
+              },
+              async dispose() {
+                trialDisposals += 1;
+              },
+            };
+          },
+          async dispose() {
+            runDisposals += 1;
+          },
+        };
+      },
+    };
+    const controller = new AbortController();
+    const ports: ExecutionRuntimePorts = {
+      executors: new Map([['executor-alias', executor]]),
+      clock: new FakeClock(),
+      contentStore,
+    };
+    const cancelledRun = startExecution(plan, ports, {
+      runId: 'run-isolated-cancelled',
+      bundleId: 'bundle-isolated-cancelled',
+      signal: controller.signal,
+    });
+    const completedRun = startExecution(plan, ports, {
+      runId: 'run-isolated-completed',
+      bundleId: 'bundle-isolated-completed',
+    });
+    await bothOpened;
+    controller.abort();
+    const [cancelled, completed] = await Promise.all([
+      cancelledRun.result,
+      completedRun.result,
+    ]);
+
+    expect(cancelled.executionBundleStatus).toBe('cancelled');
+    expect(completed.executionBundleStatus).toBe('completed');
+    expect(runCount).toBe(2);
+    expect(runDisposals).toBe(2);
+    expect(trialDisposals).toBe(2);
+  });
+
+  it('honors serialized Runtime capability even when global concurrency is higher', async () => {
+    const plan = await makePlan(undefined, testRuntime({
+      concurrencySafety: 'serialized',
+      maxInFlight: 1,
+    }));
+    const { ports, state } = portsFor(plan, async (trial) => {
+      await Promise.resolve();
+      return {
+        output: { value: { answer: trial.targetId }, classification: 'public' },
+      };
+    });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-serialized',
+      bundleId: 'bundle-serialized',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('completed');
+    expect(state.maxActive).toBe(1);
+  });
+
+  it('reuses deterministic cache records without a second Executor invocation', async () => {
+    const cache = new MemoryCache();
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.cache.executionMode = 'transparent-deterministic';
+    });
+    const { ports, state } = portsFor(plan, undefined, { cache });
+    const first = await executeRunPlan(plan, ports, {
+      runId: 'run-cache-1',
+      bundleId: 'bundle-cache-1',
+    });
+    const second = await executeRunPlan(plan, ports, {
+      runId: 'run-cache-2',
+      bundleId: 'bundle-cache-2',
+    });
+
+    expect(first.records[0].executionStatus).toBe('completed');
+    expect(second.records[0].executionStatus).toBe('completed');
+    if (second.records[0].executionStatus === 'budget-censored') throw new Error('unexpected');
+    expect(second.records[0].cache.cacheStatus).toBe('transparent-hit');
+    expect(state.attempts).toBe(1);
+    expect(cache.puts).toBe(1);
+    expect(cache.gets).toBe(2);
+  });
+
+  it('fails closed on a corrupt cache entry before opening an Executor', async () => {
+    const cache: ExecutionCache = {
+      async get(cacheKeyDigest) {
+        return {
+          cacheKeyDigest,
+          sourceRecordDigest: `sha256:${'0'.repeat(64)}`,
+          record: {} as ExecutionCacheEntry['record'],
+        };
+      },
+      async put() {
+        throw new Error('unexpected cache write');
+      },
+    };
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.cache.executionMode = 'transparent-deterministic';
+    });
+    const { ports, state } = portsFor(plan, undefined, { cache });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-corrupt-cache',
+      bundleId: 'bundle-corrupt-cache',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('failed');
+    expect(bundle.terminationReasonCode).toBe('execution-cache-read-failed');
+    expect(bundle.coverage).toMatchObject({ started: 0, notStarted: 1 });
+    expect(state.runOpens).toBe(0);
+  });
+
+  it('fails closed on a replay-only cache miss without invoking an Executor', async () => {
+    const cache = new MemoryCache();
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.cache.executionMode = 'replay-only';
+    });
+    const { ports, state } = portsFor(plan, undefined, { cache });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-replay-miss',
+      bundleId: 'bundle-replay-miss',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('failed');
+    expect(bundle.terminationReasonCode).toBe('execution-cache-miss');
+    expect(bundle.coverage).toMatchObject({ started: 0, notStarted: 1 });
+    expect(state.attempts).toBe(0);
+  });
+
+  it('stops new admission after auditable provider-cost overshoot', async () => {
+    const plan = await makePlan((definition, policy) => {
+      definition.dataset.samples.push({
+        ...structuredClone(definition.dataset.samples[0]),
+        sampleId: 'sample-2',
+      });
+      policy.budget.maxProviderCost = { amount: 1, currency: 'USD' };
+      policy.execution.maxConcurrency = 2;
+    });
+    const { ports, state } = portsFor(plan, (trial) => ({
+      output: { value: { answer: trial.targetId }, classification: 'public' },
+      usage: {
+        providerCost: { amount: 0.6, currency: 'USD', reportedByProvider: true },
+      },
+    }));
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-provider-budget',
+      bundleId: 'bundle-provider-budget',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('budget-exhausted');
+    expect(bundle.coverage).toMatchObject({
+      planned: 4,
+      started: 2,
+      succeeded: 2,
+      budgetCensored: 2,
+    });
+    expect(state.attempts).toBe(2);
+  });
+
+  it('uses the injected monotonic clock to stop admission at the duration budget', async () => {
+    const clock = new ManualClock();
+    const plan = await makePlan((definition, policy) => {
+      definition.dataset.samples.push({
+        ...structuredClone(definition.dataset.samples[0]),
+        sampleId: 'sample-2',
+      });
+      policy.budget.maxDurationMs = 50;
+      policy.execution.maxConcurrency = 1;
+    });
+    let advanced = false;
+    const { ports, state } = portsFor(plan, (trial) => {
+      if (!advanced) {
+        advanced = true;
+        clock.advance(50);
+      }
+      return {
+        output: { value: { answer: trial.targetId }, classification: 'public' },
+      };
+    }, { clock });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-duration-budget',
+      bundleId: 'bundle-duration-budget',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('budget-exhausted');
+    expect(bundle.terminationReasonCode).toBe('duration-budget-exhausted');
+    expect(bundle.coverage).toMatchObject({ started: 1, budgetCensored: 3 });
+    expect(state.attempts).toBe(1);
+    expect(clock.sleepers).toHaveLength(0);
+  });
+
+  it('applies fail-fast only to future admission and tears down the failed trial', async () => {
+    const plan = await makePlan((_definition, policy) => {
+      policy.execution.maxConcurrency = 1;
+      policy.retry.maxAttempts = 1;
+      policy.failure.failureMode = 'fail-fast';
+    });
+    const { ports, state } = portsFor(plan, () => {
+      throw new ExecutionPortFailure({
+        code: 'non-retryable',
+        stage: 'execution',
+        message: 'stop after this admitted trial',
+      });
+    });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-fail-fast',
+      bundleId: 'bundle-fail-fast',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('failed');
+    expect(bundle.terminationReasonCode).toBe('failure-policy-fail-fast');
+    expect(bundle.coverage).toMatchObject({ started: 1, failed: 1, notStarted: 1 });
+    expect(state).toMatchObject({
+      attempts: 1,
+      trialOpens: 1,
+      trialDisposals: 1,
+      runDisposals: 1,
+    });
+  });
+
+  it('materializes reference evidence through a digest-bound ContentStore', async () => {
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.evidence.output = 'reference';
+      policy.evidence.trace = 'none';
+    });
+    const { ports } = portsFor(plan);
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-reference',
+      bundleId: 'bundle-reference',
+    });
+    const record = bundle.records[0];
+    if (record.executionStatus !== 'completed') throw new Error('expected completed record');
+
+    expect(bundle.replayability).toBe('resolvable');
+    expect(record.output?.contentKind).toBe('descriptor');
+    if (record.output?.contentKind !== 'descriptor') throw new Error('expected descriptor');
+    expect(record.output.descriptor.digest).toBe(digestCanonicalJson({ answer: 'control' }));
+  });
+
+  it('omits content above the sealed classification ceiling and strips raw port errors', async () => {
+    const contentPlan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.evidence.maximumClassification = 'public';
+      policy.evidence.trace = 'none';
+    });
+    const contentPorts = portsFor(contentPlan, () => ({
+      output: { value: { password: 'do-not-leak' }, classification: 'secret' },
+    })).ports;
+    const contentBundle = await executeRunPlan(contentPlan, contentPorts, {
+      runId: 'run-classification',
+      bundleId: 'bundle-classification',
+    });
+    const contentRecord = contentBundle.records[0];
+    if (contentRecord.executionStatus !== 'completed') throw new Error('expected completed');
+    expect(contentRecord.output).toBeUndefined();
+    expect(contentBundle.replayability).toBe('summary-only');
+    expect(JSON.stringify(contentBundle)).not.toContain('do-not-leak');
+
+    const errorPlan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.retry.maxAttempts = 1;
+    });
+    const errorPorts = portsFor(errorPlan, () => {
+      throw new ExecutionPortFailure({
+        code: 'provider-failed',
+        stage: 'execution',
+        message: 'credential do-not-leak',
+        details: { credential: 'do-not-leak' },
+      });
+    }).ports;
+    const errorBundle = await executeRunPlan(errorPlan, errorPorts, {
+      runId: 'run-redacted-error',
+      bundleId: 'bundle-redacted-error',
+    });
+    expect(JSON.stringify(errorBundle)).not.toContain('do-not-leak');
+    expect(parseExecutionBundleDocument(errorBundle)).toEqual(errorBundle);
+  });
+
+  it('materializes digest-only and omitted output without retaining the raw value', async () => {
+    for (const mode of ['digest', 'none'] as const) {
+      const plan = await makePlan((definition, policy) => {
+        definition.targets = [definition.targets[0]];
+        definition.comparisons = [];
+        definition.evaluators[0].inputs = [{
+          bindingId: 'gold',
+          sourceKind: 'expected',
+          pointer: '/answer',
+        }];
+        policy.evidence.output = mode;
+        policy.evidence.trace = 'none';
+      });
+      const { ports } = portsFor(plan, () => ({
+        output: { value: { privateValue: 42 }, classification: 'sensitive' },
+      }));
+      const bundle = await executeRunPlan(plan, ports, {
+        runId: `run-capture-${mode}`,
+        bundleId: `bundle-capture-${mode}`,
+      });
+      const record = bundle.records[0];
+      if (record.executionStatus !== 'completed') throw new Error('expected completed');
+      if (mode === 'digest') {
+        expect(record.output).toEqual({
+          contentKind: 'digest-only',
+          classification: 'sensitive',
+          digest: digestCanonicalJson({ privateValue: 42 }),
+        });
+      } else {
+        expect(record.output).toBeUndefined();
+      }
+      expect(JSON.stringify(bundle)).not.toContain('privateValue');
+    }
+  });
+
+  it('makes a terminal EventWriter failure a run-level failed Bundle after all trials settle', async () => {
+    const written: EvaluationEvent[] = [];
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.eventDelivery.writerMode = 'required';
+      policy.eventDelivery.writerFailureMode = 'fail-run';
+    });
+    const { ports } = portsFor(plan, undefined, {
+      eventWriter: {
+        async write(event) {
+          if (event.eventKind === 'execution.run.completed') throw new Error('writer down');
+          written.push(structuredClone(event));
+        },
+      },
+    });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-writer-failure',
+      bundleId: 'bundle-writer-failure',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('failed');
+    expect(bundle.terminationReasonCode).toBe('event-writer-failed');
+    expect(bundle.coverage.succeeded).toBe(1);
+    expect(bundle.coverage.notStarted).toBe(0);
+    expect(written.length).toBeGreaterThan(0);
+  });
+
+  it('does not open Target resources when the required EventWriter fails at run start', async () => {
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.eventDelivery.writerMode = 'required';
+      policy.eventDelivery.writerFailureMode = 'fail-run';
+    });
+    const { ports, state } = portsFor(plan, undefined, {
+      eventWriter: {
+        async write() {
+          throw new Error('writer down');
+        },
+      },
+    });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-writer-start-failure',
+      bundleId: 'bundle-writer-start-failure',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('failed');
+    expect(bundle.coverage).toMatchObject({ started: 0, notStarted: 1 });
+    expect(state.runOpens).toBe(0);
+    expect(state.attempts).toBe(0);
+  });
+
+  it('does not invoke a Target when durable trial admission cannot be written', async () => {
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.eventDelivery.writerMode = 'required';
+      policy.eventDelivery.writerFailureMode = 'fail-run';
+    });
+    const { ports, state } = portsFor(plan, undefined, {
+      eventWriter: {
+        async write(event) {
+          if (event.eventKind === 'execution.trial.started') {
+            throw new Error('writer down');
+          }
+        },
+      },
+    });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-writer-trial-failure',
+      bundleId: 'bundle-writer-trial-failure',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('failed');
+    expect(bundle.coverage).toMatchObject({ started: 0, notStarted: 1 });
+    expect(state).toMatchObject({ runOpens: 0, trialOpens: 0, attempts: 0 });
+  });
+
+  it('applies blocking EventWriter backpressure before Target admission', async () => {
+    let releaseWriter: (() => void) | undefined;
+    const writerGate = new Promise<void>((resolve) => {
+      releaseWriter = resolve;
+    });
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.eventDelivery.writerMode = 'required';
+      policy.eventDelivery.writerFailureMode = 'fail-run';
+    });
+    const { ports, state } = portsFor(plan, undefined, {
+      eventWriter: {
+        async write(event) {
+          if (event.eventKind === 'execution.run.started') await writerGate;
+        },
+      },
+    });
+    const run = startExecution(plan, ports, {
+      runId: 'run-writer-backpressure',
+      bundleId: 'bundle-writer-backpressure',
+    });
+    await Promise.resolve();
+    expect(state.runOpens).toBe(0);
+    releaseWriter?.();
+    const bundle = await run.result;
+
+    expect(bundle.executionBundleStatus).toBe('completed');
+    expect(state.attempts).toBe(1);
+  });
+
+  it('reports disposer failure after exactly-once trial and run teardown', async () => {
+    const plan = await makePlan((definition) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+    });
+    const base = fakeExecutor(expectedExecutorIdentity(plan));
+    const executor: ExecutionExecutor = {
+      ...base.executor,
+      async openRun(context) {
+        const run = await base.executor.openRun(context);
+        return {
+          ...run,
+          async dispose() {
+            await run.dispose();
+            throw new Error('dispose failed');
+          },
+        };
+      },
+    };
+    const ports: ExecutionRuntimePorts = {
+      executors: new Map([['executor-alias', executor]]),
+      clock: new FakeClock(),
+      contentStore,
+    };
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-dispose-failure',
+      bundleId: 'bundle-dispose-failure',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('failed');
+    expect(bundle.terminationReasonCode).toBe('executor-run-dispose-failed');
+    expect(bundle.coverage.succeeded).toBe(1);
+    expect(base.state).toMatchObject({
+      runOpens: 1,
+      runDisposals: 1,
+      trialOpens: 1,
+      trialDisposals: 1,
+    });
+  });
+
+  it('rejects missing ports and Runtime identity drift before any Target call', async () => {
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.evidence.output = 'reference';
+    });
+    const { ports, state } = portsFor(plan);
+    expect(() => startExecution(plan, { ...ports, contentStore: undefined }, {
+      runId: 'run-missing-store',
+      bundleId: 'bundle-missing-store',
+    })).toThrow(ExecutionRuntimeConfigurationError);
+
+    const drifted = fakeExecutor({
+      ...expectedExecutorIdentity(plan),
+      fingerprint: 'different-fingerprint',
+    });
+    expect(() => startExecution(plan, {
+      ...ports,
+      executors: new Map([['executor-alias', drifted.executor]]),
+    }, {
+      runId: 'run-drifted',
+      bundleId: 'bundle-drifted',
+    })).toThrowError(expect.objectContaining({
+      code: 'EXECUTION_RUNTIME_IDENTITY_MISMATCH',
+    }));
+    expect(state.runOpens).toBe(0);
+  });
+});

--- a/test/evaluation-core/execution/runtime.test.ts
+++ b/test/evaluation-core/execution/runtime.test.ts
@@ -354,6 +354,62 @@ describe('Evaluation Core Execution runtime', () => {
     expect(state.trialDisposals).toBe(1);
   });
 
+  it('retains exact per-attempt usage when retry costs cannot be aggregated', async () => {
+    const plan = await makePlan((definition) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+    });
+    let calls = 0;
+    const { ports } = portsFor(plan, () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new ExecutionPortFailure({
+          code: 'timeout',
+          stage: 'infrastructure',
+          message: 'retry me',
+        }, {
+          inputTokens: 1,
+          providerCost: { amount: 0.1, currency: 'EUR', reportedByProvider: true },
+          details: { requestId: 'first' },
+        });
+      }
+      return {
+        output: { value: { answer: 'ok' }, classification: 'public' },
+        usage: {
+          outputTokens: 2,
+          providerCost: { amount: 0.2, currency: 'USD', reportedByProvider: true },
+          details: { requestId: 'second' },
+        },
+      };
+    });
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-mixed-currency',
+      bundleId: 'bundle-mixed-currency',
+    });
+
+    const record = bundle.records[0];
+    if (record.executionStatus !== 'completed') throw new Error('expected completed record');
+    expect(record.attempts[0].usage).toMatchObject({
+      providerCost: { amount: 0.1, currency: 'EUR' },
+      details: { requestId: 'first' },
+    });
+    expect(record.attempts[1].usage).toMatchObject({
+      providerCost: { amount: 0.2, currency: 'USD' },
+      details: { requestId: 'second' },
+    });
+    expect(record.usage).toMatchObject({
+      inputTokens: 1,
+      outputTokens: 2,
+      details: {
+        aggregationKind: 'omk.execution-usage-summary/v1',
+        attemptCount: 2,
+        reportedAttemptCount: 2,
+        providerCostAggregation: 'mixed-currency',
+      },
+    });
+    expect(record.usage?.providerCost).toBeUndefined();
+  });
+
   it('reuses one isolated omk.session/v1 trial across retry attempts', async () => {
     const plan = await makePlan((definition) => {
       definition.targets = [{
@@ -617,6 +673,36 @@ describe('Evaluation Core Execution runtime', () => {
     expect(state.attempts).toBe(1);
     expect(cache.puts).toBe(1);
     expect(cache.gets).toBe(2);
+  });
+
+  it('does not cache a completed record when sealed provider-cost auditing fails', async () => {
+    const cache = new MemoryCache();
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.cache.executionMode = 'transparent-deterministic';
+      policy.budget.maxProviderCost = { amount: 1, currency: 'USD' };
+    });
+    const { ports, state } = portsFor(plan, (trial) => ({
+      output: { value: { answer: trial.targetId }, classification: 'public' },
+      usage: { inputTokens: 1 },
+    }), { cache });
+    const first = await executeRunPlan(plan, ports, {
+      runId: 'run-cache-ineligible-1',
+      bundleId: 'bundle-cache-ineligible-1',
+    });
+    const second = await executeRunPlan(plan, ports, {
+      runId: 'run-cache-ineligible-2',
+      bundleId: 'bundle-cache-ineligible-2',
+    });
+
+    expect(first.executionBundleStatus).toBe('failed');
+    expect(second.executionBundleStatus).toBe('failed');
+    expect(first.terminationReasonCode).toBe('provider-cost-unreported');
+    expect(second.terminationReasonCode).toBe('provider-cost-unreported');
+    expect(cache.puts).toBe(0);
+    expect(cache.entries.size).toBe(0);
+    expect(state.attempts).toBe(2);
   });
 
   it('fails closed on a corrupt cache entry before opening an Executor', async () => {
@@ -966,10 +1052,146 @@ describe('Evaluation Core Execution runtime', () => {
     expect(state.attempts).toBe(1);
   });
 
-  it('reports disposer failure after exactly-once trial and run teardown', async () => {
-    const plan = await makePlan((definition) => {
+  it('serializes concurrent EventWriter delivery in strict sequence order', async () => {
+    let ready = 0;
+    let releaseAttempts: (() => void) | undefined;
+    const attemptsReady = new Promise<void>((resolve) => {
+      releaseAttempts = resolve;
+    });
+    let releaseFirstCompletion: (() => void) | undefined;
+    const firstCompletionGate = new Promise<void>((resolve) => {
+      releaseFirstCompletion = resolve;
+    });
+    let observeFirstCompletion: (() => void) | undefined;
+    const firstCompletionStarted = new Promise<void>((resolve) => {
+      observeFirstCompletion = resolve;
+    });
+    let blockedFirstCompletion = false;
+    let activeWriters = 0;
+    let maxActiveWriters = 0;
+    const writtenSequences: number[] = [];
+    const plan = await makePlan((_definition, policy) => {
+      policy.eventDelivery.writerMode = 'required';
+      policy.eventDelivery.writerFailureMode = 'fail-run';
+      policy.execution.maxConcurrency = 2;
+    });
+    const { ports } = portsFor(plan, async (trial) => {
+      ready += 1;
+      if (ready === 2) releaseAttempts?.();
+      await attemptsReady;
+      return {
+        output: { value: { answer: trial.targetId }, classification: 'public' },
+      };
+    }, {
+      eventWriter: {
+        async write(event) {
+          activeWriters += 1;
+          maxActiveWriters = Math.max(maxActiveWriters, activeWriters);
+          try {
+            if (event.eventKind === 'execution.attempt.completed'
+                && !blockedFirstCompletion) {
+              blockedFirstCompletion = true;
+              observeFirstCompletion?.();
+              await firstCompletionGate;
+            }
+            writtenSequences.push(event.sequence);
+          } finally {
+            activeWriters -= 1;
+          }
+        },
+      },
+    });
+    const run = startExecution(plan, ports, {
+      runId: 'run-writer-sequence',
+      bundleId: 'bundle-writer-sequence',
+    });
+    await firstCompletionStarted;
+    for (let index = 0; index < 5; index += 1) await Promise.resolve();
+    expect(maxActiveWriters).toBe(1);
+    releaseFirstCompletion?.();
+    const bundle = await run.result;
+
+    expect(bundle.executionBundleStatus).toBe('completed');
+    expect(writtenSequences).toEqual([...writtenSequences].sort((left, right) => left - right));
+    expect(new Set(writtenSequences).size).toBe(writtenSequences.length);
+  });
+
+  it.each(['open-run', 'open-trial'] as const)(
+    'reports %s failure without fabricating an attempt',
+    async (failurePoint) => {
+    const plan = await makePlan((definition, policy) => {
       definition.targets = [definition.targets[0]];
       definition.comparisons = [];
+      policy.budget.maxTargetInvocations = 1;
+    });
+    let runDisposals = 0;
+    const executor: ExecutionExecutor = {
+      identity: expectedExecutorIdentity(plan),
+      async openRun() {
+        if (failurePoint === 'open-run') throw new Error('run bootstrap failed');
+        return {
+          async openTrial(): Promise<ExecutionExecutorTrial> {
+            throw new Error('session bootstrap failed');
+          },
+          async dispose() {
+            runDisposals += 1;
+          },
+        };
+      },
+    };
+    const ports: ExecutionRuntimePorts = {
+      executors: new Map([['executor-alias', executor]]),
+      clock: new FakeClock(),
+      contentStore,
+    };
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: `run-resource-${failurePoint}-failure`,
+      bundleId: `bundle-resource-${failurePoint}-failure`,
+    });
+
+    expect(bundle.executionBundleStatus).toBe('failed');
+    expect(bundle.terminationReasonCode).toBe('executor-resource-open-failed');
+    expect(bundle.coverage).toMatchObject({ started: 0, notStarted: 1 });
+    expect(bundle.records).toHaveLength(0);
+    expect(runDisposals).toBe(failurePoint === 'open-trial' ? 1 : 0);
+    },
+  );
+
+  it('records one consumed attempt when an invoked Executor returns invalid usage', async () => {
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.budget.maxTargetInvocations = 1;
+    });
+    const { ports, state } = portsFor(plan, () => ({
+      output: { value: { answer: 'invalid usage' }, classification: 'public' },
+      usage: { inputTokens: -1 },
+    }));
+    const bundle = await executeRunPlan(plan, ports, {
+      runId: 'run-invalid-executor-result',
+      bundleId: 'bundle-invalid-executor-result',
+    });
+
+    expect(bundle.executionBundleStatus).toBe('failed');
+    expect(bundle.terminationReasonCode).toBe('executor-result-invalid');
+    expect(bundle.coverage).toMatchObject({ started: 1, failed: 1, notStarted: 0 });
+    expect(state.attempts).toBe(1);
+    expect(bundle.records[0]).toMatchObject({
+      executionStatus: 'failed',
+      attempts: [{
+        attemptNumber: 1,
+        attemptStatus: 'failed',
+        error: { code: 'executor-result-invalid' },
+      }],
+    });
+  });
+
+  it('reports disposer failure after exactly-once trial and run teardown', async () => {
+    const cache = new MemoryCache();
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.cache.executionMode = 'transparent-deterministic';
     });
     const base = fakeExecutor(expectedExecutorIdentity(plan));
     const executor: ExecutionExecutor = {
@@ -989,6 +1211,7 @@ describe('Evaluation Core Execution runtime', () => {
       executors: new Map([['executor-alias', executor]]),
       clock: new FakeClock(),
       contentStore,
+      cache,
     };
     const bundle = await executeRunPlan(plan, ports, {
       runId: 'run-dispose-failure',
@@ -998,6 +1221,7 @@ describe('Evaluation Core Execution runtime', () => {
     expect(bundle.executionBundleStatus).toBe('failed');
     expect(bundle.terminationReasonCode).toBe('executor-run-dispose-failed');
     expect(bundle.coverage.succeeded).toBe(1);
+    expect(cache.puts).toBe(0);
     expect(base.state).toMatchObject({
       runOpens: 1,
       runDisposals: 1,
@@ -1032,5 +1256,37 @@ describe('Evaluation Core Execution runtime', () => {
       code: 'EXECUTION_RUNTIME_IDENTITY_MISMATCH',
     }));
     expect(state.runOpens).toBe(0);
+  });
+
+  it('keeps the preflight Executor binding when the host mutates its registry after start', async () => {
+    const plan = await makePlan((definition) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+    });
+    const identity = expectedExecutorIdentity(plan);
+    const original = fakeExecutor(identity, () => ({
+      output: { value: { source: 'sealed' }, classification: 'public' },
+    }));
+    const replacement = fakeExecutor(identity, () => ({
+      output: { value: { source: 'replacement' }, classification: 'public' },
+    }));
+    const registry = new Map([['executor-alias', original.executor]]);
+    const run = startExecution(plan, {
+      executors: registry,
+      clock: new FakeClock(),
+      contentStore,
+    }, {
+      runId: 'run-registry-snapshot',
+      bundleId: 'bundle-registry-snapshot',
+    });
+    registry.set('executor-alias', replacement.executor);
+    const bundle = await run.result;
+
+    const record = bundle.records[0];
+    if (record.executionStatus !== 'completed'
+        || record.output?.contentKind !== 'inline') throw new Error('expected inline output');
+    expect(record.output.value).toEqual({ source: 'sealed' });
+    expect(original.state.attempts).toBe(1);
+    expect(replacement.state.attempts).toBe(0);
   });
 });


### PR DESCRIPTION
## 用户影响

Evaluation Core 现在可以直接消费 sealed RunPlan，在纯内存中调用宿主注入的 Executor，并产出通过 plan-aware validation 的 ExecutionBundle。运行过程具备确定性调度、并发门禁、retry／timeout／budget／cancellation、cache replay、evidence capture、事件投递和资源回收语义，为后续 Evaluation Runtime 提供可信的 Target 执行事实。

## 架构与测量语义

- Executor 只接收 execution-visible 输入、Target config 与 trial identity，不暴露 Gold 或 evaluation-only 数据；启动时捕获通过 identity 校验的 Executor 引用，宿主后续修改 registry 不能替换 sealed implementation。
- admission order、paired block 原子性、trial／attempt／seed identity 和缺失机制全部由 sealed Plan 决定；调用前资源失败不伪造 attempt 或消耗调用预算，完成时序不会反向改变实验设计。
- 每个真实 attempt 保留精确 usage；record 级 usage 只聚合可比较事实，混合币种和部分上报不会丢失原始 provider cost。
- timeout 与取消采用协作式单终态；duration 和 provider cost 只停止后续 admission，不改写已发生事实。
- cache、ContentStore、Clock 与 EventWriter 都是显式注入端口；cache 只在事实审计、evidence materialization 与资源回收成功后提交，EventWriter 按 run sequence 串行投递。
- Bundle 在返回前完成 wire、digest 与原 RunPlan 绑定校验；中英文 RFC 同步公开运行时语义。

## 迁移说明

`ExecutionAttempt` 新增可选的精确 `usage` 字段，`ExecutionRecord.usage` 保持为 trial 级聚合摘要。旧的 strict schema consumer 需要从当前 `schemas/evaluation-core/v1/execution-bundle.schema.json` 重新生成或更新类型后再读取新 Bundle。

这是尚未对外发布的 Evaluation Core v1 新能力，不提供历史 schema 兼容层，也不接入旧 eval pipeline。现有 CLI、Report schema、评分类 prompt 与统计公式不变；本变更不属于 `BREAKING-COMPARABILITY`。

## Construct validity

本 PR 不改变评分构念或分析方法，只物化 Execution 阶段事实。预算耗尽、取消、失败、retry 和 cache replay 均显式保留 provenance、coverage 与逐次调用 usage，避免把未启动坐标、重试、不可比较 cost 或重放误当作新的独立测量。

Closes #433
Parent: #425
