### PR TITLE
fix(eval-core)!: BREAKING-COMPARABILITY 隔离跨运行随机化身份

### DIFF
--- a/docs/specs/evaluation-core-vnext.md
+++ b/docs/specs/evaluation-core-vnext.md
@@ -179,12 +179,20 @@ interface RuntimeIdentity {
   fingerprintBasis: 'content-derived' | 'environment-derived' | 'self-reported' | 'opaque';
   assuranceLevel: 'verified' | 'declared' | 'unknown';
   capabilities: JsonValue;
-  implementationFacets?: JsonValue;
-  provenanceFacets?: JsonValue;
+  implementationManifest:
+    | { coverageKind: 'fingerprint-complete' }
+    | { coverageKind: 'fingerprint-plus-facets'; facets: Array<{
+        facetId: string;
+        value: JsonValue;
+      }> };
+  provenanceFacets?: {
+    observation?: { observerId?: string; observedAt?: string };
+    attestation?: { attestationDigest: Sha256Digest; attestorId?: string };
+  };
 }
 ```
 
-Caller-supplied versions and fingerprints are requirements, not facts. The Report records the identity resolved by Runtime. `implementationFacets` contains behavior-affecting facts not already committed by `fingerprint`, such as remote model deployment, effective tool schemas, sandbox policy, dependencies, and environment. `provenanceFacets` contains only evidence about how the identity was observed or attested; it must not hide a fact that can change outputs. Prepare rejects a Runtime whose manifest cannot classify a behavior-affecting facet or prove that its fingerprint commits that facet.
+Caller-supplied versions and fingerprints are requirements, not facts. The Report records the identity resolved by Runtime. `implementationManifest.facets` contains behavior-affecting facts not already committed by `fingerprint`, such as remote model deployment, effective tool schemas, sandbox policy, dependencies, and environment. The discriminated manifest makes ambiguous sibling states unrepresentable: `fingerprint-complete` has no facet payload, while `fingerprint-plus-facets` requires a non-empty facet array whose IDs are unique and canonical. `provenanceFacets` is a closed evidence-only shape for observation and attestation metadata, so arbitrary behavior facts cannot be placed there. Prepare rejects missing, ambiguous, non-canonical, or incomplete coverage. The manifest makes classification structurally decidable; assurance and independent host verification still determine whether the Runtime's claims are trustworthy.
 
 ### 5.4 ExperimentDesign and SamplingDesign
 
@@ -527,7 +535,7 @@ interface ComparabilityAssessmentSource {
 
 `ComparabilityCandidateIdentity` records all stage Plan digests for audit, the subject-neutral `randomizationDesignDigest`, the source Bundle or Decision digest when supplied, and only the normalized verification facts actually used. `ComparabilitySourceVerificationFact` is a discriminated union so a cache receipt cannot claim a provenance trust value and a parent trust fact cannot claim `indeterminate`. A missing artifact is represented by absence plus a reason in the Assessment, never by a fake digest or a self-reported verified fact. The identity never copies raw Dataset, Gold, output, trace, attestation material, cost values, or invocation counts.
 
-Runtime comparison uses two separately digested projections. `runtimeIdentityDigest` uses domain `omk.runtime-identity/v1` and covers the complete sealed RuntimeIdentity. `runtimeImplementationDigest` uses domain `omk.runtime-implementation-identity/v1` and covers exactly `implementationId`, `version`, `fingerprint`, `capabilities`, and `implementationFacets`; only this digest participates in design equality. Evidence qualification contains `fingerprintBasis`, sealed/effective assurance, `provenanceFacets`, effective source trust, and source-verification axes. `implementationFacets` is required to contain every behavior-affecting dependency not already committed by `fingerprint`; `provenanceFacets` may contain observation and attestation metadata only. A basis- or assurance-only change therefore cannot masquerade as a changed measurement algorithm, a changed effective dependency cannot hide as evidence metadata, and an equal implementation digest cannot masquerade as authenticated execution.
+Runtime comparison uses two separately digested projections. `runtimeIdentityDigest` uses domain `omk.runtime-identity/v1` and covers the complete sealed RuntimeIdentity. `runtimeImplementationDigest` uses domain `omk.runtime-implementation-identity/v1` and covers exactly `implementationId`, `version`, `fingerprint`, `capabilities`, and the complete `implementationManifest`; only this digest participates in design equality. Evidence qualification contains `fingerprintBasis`, sealed/effective assurance, the closed `provenanceFacets`, effective source trust, and source-verification axes. The implementation manifest must prove structurally that every behavior-affecting dependency is either committed by `fingerprint` or present as a canonical implementation facet; provenance may contain observation and attestation metadata only. A basis- or assurance-only change therefore cannot masquerade as a changed measurement algorithm, a changed effective dependency cannot hide as evidence metadata, and an equal implementation digest cannot masquerade as authenticated execution.
 
 `ComparabilityVerificationContext` is a non-serializable trusted-host input, parallel to existing Bundle verification contexts. Its map key is the complete `runtimeIdentityDigest`; its value is the digest of attestation material already verified by an independent host boundary. Core never accepts raw attestation material, a transported `verifiedByAttestationDigest`, or a caller-supplied effective level as proof. A Runtime may rise above its sealed assurance only when the context contains an exact identity match; Core then records the verified attestation digest in the candidate. Malformed context entries are rejected, while entries for unrelated identities grant no trust and are ignored. New attestation produces a new candidate and Assessment digest rather than mutating an existing artifact.
 

--- a/docs/zh/specs/evaluation-core-vnext.md
+++ b/docs/zh/specs/evaluation-core-vnext.md
@@ -179,12 +179,20 @@ interface RuntimeIdentity {
   fingerprintBasis: 'content-derived' | 'environment-derived' | 'self-reported' | 'opaque';
   assuranceLevel: 'verified' | 'declared' | 'unknown';
   capabilities: JsonValue;
-  implementationFacets?: JsonValue;
-  provenanceFacets?: JsonValue;
+  implementationManifest:
+    | { coverageKind: 'fingerprint-complete' }
+    | { coverageKind: 'fingerprint-plus-facets'; facets: Array<{
+        facetId: string;
+        value: JsonValue;
+      }> };
+  provenanceFacets?: {
+    observation?: { observerId?: string; observedAt?: string };
+    attestation?: { attestationDigest: Sha256Digest; attestorId?: string };
+  };
 }
 ```
 
-调用方声明的版本或 fingerprint 只是要求，Report 记录 Runtime 实际解析出的身份。`implementationFacets` 保存尚未由 `fingerprint` 承诺、且能够改变行为的事实，例如远程模型 deployment、effective tool schema、sandbox policy、依赖和环境；`provenanceFacets` 只保存该身份如何被观测或认证的 evidence，不能隐藏任何会改变输出的事实。Runtime manifest 如果无法对行为相关 facet 完成分类，也无法证明 fingerprint 已经承诺该 facet，prepare 必须拒绝。
+调用方声明的版本或 fingerprint 只是要求，Report 记录 Runtime 实际解析出的身份。`implementationManifest.facets` 保存尚未由 `fingerprint` 承诺、且能够改变行为的事实，例如远程模型 deployment、effective tool schema、sandbox policy、依赖和环境。discriminated manifest 从结构上消除歧义 sibling state：`fingerprint-complete` 不携带 facet payload；`fingerprint-plus-facets` 必须提供非空 facet array，且 ID 唯一、canonical。`provenanceFacets` 是封闭的 evidence-only 结构，只允许 observation 与 attestation metadata，因此不能放入任意行为事实。coverage 缺失、歧义、非 canonical 或不完整时，prepare 必须拒绝。manifest 负责让分类在结构上可判定；Runtime 声明是否可信，仍由 assurance 与独立宿主验证决定。
 
 ### 4．ExperimentDesign 与 SamplingDesign
 
@@ -527,7 +535,7 @@ interface ComparabilityAssessmentSource {
 
 `ComparabilityCandidateIdentity` 为审计记录全部 stage Plan digest、subject-neutral `randomizationDesignDigest`、已提供的 source Bundle 或 Decision digest，以及本次判断实际使用的规范化 verification facts。`ComparabilitySourceVerificationFact` 使用 discriminated union，因此 cache receipt 不能填写 provenance trust，parent trust fact 也不能填写 `indeterminate`。缺少 artifact 时，通过 Assessment 中不存在对应条目并附带 reason 表达，绝不伪造 digest 或自报 verified fact。该 identity 不复制原始 Dataset、Gold、output、trace、attestation material、cost value 或 invocation count。
 
-Runtime 比较使用两个分别计算 digest 的投影。`runtimeIdentityDigest` 使用 `omk.runtime-identity/v1` domain 并覆盖完整 sealed RuntimeIdentity；`runtimeImplementationDigest` 使用 `omk.runtime-implementation-identity/v1` domain，且只覆盖 `implementationId`、`version`、`fingerprint`、`capabilities` 与 `implementationFacets`，只有该 digest 参与 design equality。Evidence qualification 包含 `fingerprintBasis`、sealed／effective assurance、`provenanceFacets`、effective source trust 与 source verification axes。`implementationFacets` 必须包含尚未由 `fingerprint` 承诺的全部行为相关依赖；`provenanceFacets` 只能包含 observation 与 attestation metadata。这样，只改变 basis 或 assurance 不会伪装成测量算法改变，effective dependency 变化不能藏进 evidence metadata，implementation digest 相同也不会伪装成执行已认证。
+Runtime 比较使用两个分别计算 digest 的投影。`runtimeIdentityDigest` 使用 `omk.runtime-identity/v1` domain 并覆盖完整 sealed RuntimeIdentity；`runtimeImplementationDigest` 使用 `omk.runtime-implementation-identity/v1` domain，且只覆盖 `implementationId`、`version`、`fingerprint`、`capabilities` 与完整 `implementationManifest`，只有该 digest 参与 design equality。Evidence qualification 包含 `fingerprintBasis`、sealed／effective assurance、封闭的 `provenanceFacets`、effective source trust 与 source verification axes。implementation manifest 必须在结构上证明每个行为相关依赖已经由 `fingerprint` 承诺，或作为 canonical implementation facet 存在；provenance 只能包含 observation 与 attestation metadata。这样，只改变 basis 或 assurance 不会伪装成测量算法改变，effective dependency 变化不能藏进 evidence metadata，implementation digest 相同也不会伪装成执行已认证。
 
 `ComparabilityVerificationContext` 是不可序列化的 trusted-host 输入，与现有 Bundle verification context 平行。Map key 是完整 `runtimeIdentityDigest`，value 是已经由独立宿主边界验证过的 attestation material digest。Core 绝不把 raw attestation material、transported `verifiedByAttestationDigest` 或调用方自填的 effective level 当作证明。只有 context 精确匹配 Runtime identity 时，effective assurance 才能高于 sealed level；Core 随后把 verified attestation digest 记录到 candidate。畸形 context entry 会被拒绝；与本次 Runtime identity 无关的 entry 不授予任何信任，直接忽略。新增 attestation 会产生新的 candidate／Assessment digest，不能修改旧 artifact。
 

--- a/schemas/evaluation-core/v1/analysis-bundle.schema.json
+++ b/schemas/evaluation-core/v1/analysis-bundle.schema.json
@@ -43,11 +43,65 @@
     "__schema11": {
       "additionalProperties": false,
       "properties": {
+        "coverageKind": {
+          "const": "fingerprint-complete",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coverageKind"
+      ],
+      "type": "object"
+    },
+    "__schema12": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-plus-facets",
+          "type": "string"
+        },
+        "facets": {
+          "items": {
+            "$ref": "#/$defs/__schema13"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "coverageKind",
+        "facets"
+      ],
+      "type": "object"
+    },
+    "__schema13": {
+      "additionalProperties": false,
+      "properties": {
+        "facetId": {
+          "$ref": "#/$defs/__schema1"
+        },
+        "value": {
+          "$ref": "#/$defs/__schema10"
+        }
+      },
+      "required": [
+        "facetId",
+        "value"
+      ],
+      "type": "object"
+    },
+    "__schema14": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+      "type": "string"
+    },
+    "__schema15": {
+      "additionalProperties": false,
+      "properties": {
         "schemaDigest": {
           "$ref": "#/$defs/__schema2"
         },
         "schemaUri": {
-          "$ref": "#/$defs/__schema12"
+          "$ref": "#/$defs/__schema16"
         },
         "schemaVersion": {
           "$ref": "#/$defs/__schema9"
@@ -60,18 +114,18 @@
       ],
       "type": "object"
     },
-    "__schema12": {
+    "__schema16": {
       "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
       "type": "string"
     },
-    "__schema13": {
+    "__schema17": {
       "items": {
-        "$ref": "#/$defs/__schema14"
+        "$ref": "#/$defs/__schema18"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema14": {
+    "__schema18": {
       "oneOf": [
         {
           "additionalProperties": false,
@@ -134,7 +188,7 @@
         }
       ]
     },
-    "__schema15": {
+    "__schema19": {
       "additionalProperties": false,
       "properties": {
         "censored": {
@@ -208,7 +262,11 @@
       ],
       "type": "object"
     },
-    "__schema16": {
+    "__schema2": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema20": {
       "items": {
         "additionalProperties": false,
         "properties": {
@@ -227,7 +285,7 @@
       },
       "type": "array"
     },
-    "__schema17": {
+    "__schema21": {
       "items": {
         "additionalProperties": false,
         "properties": {
@@ -261,7 +319,7 @@
       },
       "type": "array"
     },
-    "__schema18": {
+    "__schema22": {
       "items": {
         "additionalProperties": false,
         "properties": {
@@ -284,34 +342,26 @@
       },
       "type": "array"
     },
-    "__schema19": {
+    "__schema23": {
       "enum": [
         "preregistered",
         "exploratory"
       ],
       "type": "string"
     },
-    "__schema2": {
-      "pattern": "^sha256:[0-9a-f]{64}$",
-      "type": "string"
-    },
-    "__schema20": {
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
-      "type": "string"
-    },
-    "__schema21": {
+    "__schema24": {
       "items": {
         "$ref": "#/$defs/__schema2"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema22": {
+    "__schema25": {
       "additionalProperties": false,
       "properties": {
         "causes": {
           "items": {
-            "$ref": "#/$defs/__schema22"
+            "$ref": "#/$defs/__schema25"
           },
           "type": "array"
         },
@@ -343,7 +393,7 @@
       ],
       "type": "object"
     },
-    "__schema23": {
+    "__schema26": {
       "additionalProperties": false,
       "properties": {
         "facets": {
@@ -384,7 +434,7 @@
       ],
       "type": "object"
     },
-    "__schema24": {
+    "__schema27": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -395,7 +445,7 @@
             "$ref": "#/$defs/__schema2"
           },
           "schemaUri": {
-            "$ref": "#/$defs/__schema12"
+            "$ref": "#/$defs/__schema16"
           }
         },
         "required": [
@@ -406,7 +456,7 @@
         "type": "object"
       },
       "propertyNames": {
-        "$ref": "#/$defs/__schema12"
+        "$ref": "#/$defs/__schema16"
       },
       "type": "object"
     },
@@ -472,7 +522,7 @@
             "additionalProperties": false,
             "properties": {
               "analysisMode": {
-                "$ref": "#/$defs/__schema19"
+                "$ref": "#/$defs/__schema23"
               },
               "analysisNodeKind": {
                 "$ref": "#/$defs/__schema7"
@@ -482,31 +532,31 @@
                 "type": "string"
               },
               "assumptionChecks": {
-                "$ref": "#/$defs/__schema17"
+                "$ref": "#/$defs/__schema21"
               },
               "coverage": {
-                "$ref": "#/$defs/__schema15"
+                "$ref": "#/$defs/__schema19"
               },
               "derivedAt": {
-                "$ref": "#/$defs/__schema20"
+                "$ref": "#/$defs/__schema14"
               },
               "exclusions": {
-                "$ref": "#/$defs/__schema16"
+                "$ref": "#/$defs/__schema20"
               },
               "implementation": {
                 "$ref": "#/$defs/__schema8"
               },
               "inputReferences": {
-                "$ref": "#/$defs/__schema13"
+                "$ref": "#/$defs/__schema17"
               },
               "nodeId": {
                 "$ref": "#/$defs/__schema1"
               },
               "outputSchema": {
-                "$ref": "#/$defs/__schema11"
+                "$ref": "#/$defs/__schema15"
               },
               "parentDigests": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema24"
               },
               "recordDigest": {
                 "$ref": "#/$defs/__schema2"
@@ -526,7 +576,7 @@
                 "type": "string"
               },
               "runtimeDependencies": {
-                "$ref": "#/$defs/__schema18"
+                "$ref": "#/$defs/__schema22"
               },
               "value": {
                 "$ref": "#/$defs/__schema10"
@@ -557,7 +607,7 @@
             "additionalProperties": false,
             "properties": {
               "analysisMode": {
-                "$ref": "#/$defs/__schema19"
+                "$ref": "#/$defs/__schema23"
               },
               "analysisNodeKind": {
                 "$ref": "#/$defs/__schema7"
@@ -567,31 +617,31 @@
                 "type": "string"
               },
               "assumptionChecks": {
-                "$ref": "#/$defs/__schema17"
+                "$ref": "#/$defs/__schema21"
               },
               "coverage": {
-                "$ref": "#/$defs/__schema15"
+                "$ref": "#/$defs/__schema19"
               },
               "derivedAt": {
-                "$ref": "#/$defs/__schema20"
+                "$ref": "#/$defs/__schema14"
               },
               "exclusions": {
-                "$ref": "#/$defs/__schema16"
+                "$ref": "#/$defs/__schema20"
               },
               "implementation": {
                 "$ref": "#/$defs/__schema8"
               },
               "inputReferences": {
-                "$ref": "#/$defs/__schema13"
+                "$ref": "#/$defs/__schema17"
               },
               "nodeId": {
                 "$ref": "#/$defs/__schema1"
               },
               "outputSchema": {
-                "$ref": "#/$defs/__schema11"
+                "$ref": "#/$defs/__schema15"
               },
               "parentDigests": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema24"
               },
               "reasonCodes": {
                 "items": {
@@ -607,7 +657,7 @@
                 "$ref": "#/$defs/__schema1"
               },
               "runtimeDependencies": {
-                "$ref": "#/$defs/__schema18"
+                "$ref": "#/$defs/__schema22"
               }
             },
             "required": [
@@ -634,7 +684,7 @@
             "additionalProperties": false,
             "properties": {
               "analysisMode": {
-                "$ref": "#/$defs/__schema19"
+                "$ref": "#/$defs/__schema23"
               },
               "analysisNodeKind": {
                 "$ref": "#/$defs/__schema7"
@@ -644,34 +694,34 @@
                 "type": "string"
               },
               "assumptionChecks": {
-                "$ref": "#/$defs/__schema17"
+                "$ref": "#/$defs/__schema21"
               },
               "coverage": {
-                "$ref": "#/$defs/__schema15"
+                "$ref": "#/$defs/__schema19"
               },
               "derivedAt": {
-                "$ref": "#/$defs/__schema20"
+                "$ref": "#/$defs/__schema14"
               },
               "error": {
-                "$ref": "#/$defs/__schema22"
+                "$ref": "#/$defs/__schema25"
               },
               "exclusions": {
-                "$ref": "#/$defs/__schema16"
+                "$ref": "#/$defs/__schema20"
               },
               "implementation": {
                 "$ref": "#/$defs/__schema8"
               },
               "inputReferences": {
-                "$ref": "#/$defs/__schema13"
+                "$ref": "#/$defs/__schema17"
               },
               "nodeId": {
                 "$ref": "#/$defs/__schema1"
               },
               "outputSchema": {
-                "$ref": "#/$defs/__schema11"
+                "$ref": "#/$defs/__schema15"
               },
               "parentDigests": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema24"
               },
               "recordDigest": {
                 "$ref": "#/$defs/__schema2"
@@ -680,7 +730,7 @@
                 "$ref": "#/$defs/__schema1"
               },
               "runtimeDependencies": {
-                "$ref": "#/$defs/__schema18"
+                "$ref": "#/$defs/__schema22"
               }
             },
             "required": [
@@ -707,7 +757,7 @@
             "additionalProperties": false,
             "properties": {
               "analysisMode": {
-                "$ref": "#/$defs/__schema19"
+                "$ref": "#/$defs/__schema23"
               },
               "analysisNodeKind": {
                 "$ref": "#/$defs/__schema7"
@@ -717,31 +767,31 @@
                 "type": "string"
               },
               "assumptionChecks": {
-                "$ref": "#/$defs/__schema17"
+                "$ref": "#/$defs/__schema21"
               },
               "coverage": {
-                "$ref": "#/$defs/__schema15"
+                "$ref": "#/$defs/__schema19"
               },
               "derivedAt": {
-                "$ref": "#/$defs/__schema20"
+                "$ref": "#/$defs/__schema14"
               },
               "exclusions": {
-                "$ref": "#/$defs/__schema16"
+                "$ref": "#/$defs/__schema20"
               },
               "implementation": {
                 "$ref": "#/$defs/__schema8"
               },
               "inputReferences": {
-                "$ref": "#/$defs/__schema13"
+                "$ref": "#/$defs/__schema17"
               },
               "nodeId": {
                 "$ref": "#/$defs/__schema1"
               },
               "outputSchema": {
-                "$ref": "#/$defs/__schema11"
+                "$ref": "#/$defs/__schema15"
               },
               "parentDigests": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema24"
               },
               "reasonCodes": {
                 "items": {
@@ -757,7 +807,7 @@
                 "$ref": "#/$defs/__schema1"
               },
               "runtimeDependencies": {
-                "$ref": "#/$defs/__schema18"
+                "$ref": "#/$defs/__schema22"
               }
             },
             "required": [
@@ -818,14 +868,51 @@
           ],
           "type": "string"
         },
-        "implementationFacets": {
-          "$ref": "#/$defs/__schema10"
-        },
         "implementationId": {
           "$ref": "#/$defs/__schema1"
         },
+        "implementationManifest": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/__schema11"
+            },
+            {
+              "$ref": "#/$defs/__schema12"
+            }
+          ]
+        },
         "provenanceFacets": {
-          "$ref": "#/$defs/__schema10"
+          "additionalProperties": false,
+          "properties": {
+            "attestation": {
+              "additionalProperties": false,
+              "properties": {
+                "attestationDigest": {
+                  "$ref": "#/$defs/__schema2"
+                },
+                "attestorId": {
+                  "$ref": "#/$defs/__schema1"
+                }
+              },
+              "required": [
+                "attestationDigest"
+              ],
+              "type": "object"
+            },
+            "observation": {
+              "additionalProperties": false,
+              "properties": {
+                "observedAt": {
+                  "$ref": "#/$defs/__schema14"
+                },
+                "observerId": {
+                  "$ref": "#/$defs/__schema1"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
         },
         "version": {
           "$ref": "#/$defs/__schema9"
@@ -836,7 +923,8 @@
         "fingerprint",
         "fingerprintBasis",
         "assuranceLevel",
-        "capabilities"
+        "capabilities",
+        "implementationManifest"
       ],
       "type": "object"
     },
@@ -868,10 +956,10 @@
       "$ref": "#/$defs/__schema2"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema24"
+      "$ref": "#/$defs/__schema27"
     },
     "provenance": {
-      "$ref": "#/$defs/__schema23"
+      "$ref": "#/$defs/__schema26"
     },
     "records": {
       "$ref": "#/$defs/__schema6"

--- a/schemas/evaluation-core/v1/analysis-bundle.schema.json
+++ b/schemas/evaluation-core/v1/analysis-bundle.schema.json
@@ -818,6 +818,9 @@
           ],
           "type": "string"
         },
+        "implementationFacets": {
+          "$ref": "#/$defs/__schema10"
+        },
         "implementationId": {
           "$ref": "#/$defs/__schema1"
         },

--- a/schemas/evaluation-core/v1/analysis-plan.schema.json
+++ b/schemas/evaluation-core/v1/analysis-plan.schema.json
@@ -227,14 +227,52 @@
                 ],
                 "type": "string"
               },
-              "implementationFacets": {
-                "$ref": "#/$defs/__schema10"
-              },
               "implementationId": {
                 "$ref": "#/$defs/__schema3"
               },
+              "implementationManifest": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/__schema16"
+                  },
+                  {
+                    "$ref": "#/$defs/__schema17"
+                  }
+                ]
+              },
               "provenanceFacets": {
-                "$ref": "#/$defs/__schema10"
+                "additionalProperties": false,
+                "properties": {
+                  "attestation": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "attestationDigest": {
+                        "$ref": "#/$defs/__schema1"
+                      },
+                      "attestorId": {
+                        "$ref": "#/$defs/__schema3"
+                      }
+                    },
+                    "required": [
+                      "attestationDigest"
+                    ],
+                    "type": "object"
+                  },
+                  "observation": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "observedAt": {
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+                        "type": "string"
+                      },
+                      "observerId": {
+                        "$ref": "#/$defs/__schema3"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
               },
               "version": {
                 "$ref": "#/$defs/__schema4"
@@ -245,7 +283,8 @@
               "fingerprint",
               "fingerprintBasis",
               "assuranceLevel",
-              "capabilities"
+              "capabilities",
+              "implementationManifest"
             ],
             "type": "object"
           },
@@ -273,6 +312,56 @@
       "type": "array"
     },
     "__schema16": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-complete",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coverageKind"
+      ],
+      "type": "object"
+    },
+    "__schema17": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-plus-facets",
+          "type": "string"
+        },
+        "facets": {
+          "items": {
+            "$ref": "#/$defs/__schema18"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "coverageKind",
+        "facets"
+      ],
+      "type": "object"
+    },
+    "__schema18": {
+      "additionalProperties": false,
+      "properties": {
+        "facetId": {
+          "$ref": "#/$defs/__schema3"
+        },
+        "value": {
+          "$ref": "#/$defs/__schema10"
+        }
+      },
+      "required": [
+        "facetId",
+        "value"
+      ],
+      "type": "object"
+    },
+    "__schema19": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -283,7 +372,7 @@
             "$ref": "#/$defs/__schema1"
           },
           "schemaUri": {
-            "$ref": "#/$defs/__schema17"
+            "$ref": "#/$defs/__schema20"
           }
         },
         "required": [
@@ -294,13 +383,9 @@
         "type": "object"
       },
       "propertyNames": {
-        "$ref": "#/$defs/__schema17"
+        "$ref": "#/$defs/__schema20"
       },
       "type": "object"
-    },
-    "__schema17": {
-      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
-      "type": "string"
     },
     "__schema2": {
       "items": {
@@ -367,6 +452,10 @@
         "type": "object"
       },
       "type": "array"
+    },
+    "__schema20": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
     },
     "__schema3": {
       "maxLength": 256,
@@ -603,7 +692,7 @@
       "$ref": "#/$defs/__schema11"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema16"
+      "$ref": "#/$defs/__schema19"
     },
     "metrics": {
       "$ref": "#/$defs/__schema2"

--- a/schemas/evaluation-core/v1/analysis-plan.schema.json
+++ b/schemas/evaluation-core/v1/analysis-plan.schema.json
@@ -42,6 +42,13 @@
     "__schema11": {
       "additionalProperties": false,
       "properties": {
+        "randomizationSlots": {
+          "items": {
+            "$ref": "#/$defs/__schema13"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
         "sampling": {
           "additionalProperties": false,
           "properties": {
@@ -130,7 +137,8 @@
         "trials",
         "seed",
         "sampling",
-        "scheduling"
+        "scheduling",
+        "randomizationSlots"
       ],
       "type": "object"
     },
@@ -139,6 +147,22 @@
       "type": "string"
     },
     "__schema13": {
+      "additionalProperties": false,
+      "properties": {
+        "randomizationSlotId": {
+          "$ref": "#/$defs/__schema3"
+        },
+        "targetId": {
+          "$ref": "#/$defs/__schema3"
+        }
+      },
+      "required": [
+        "targetId",
+        "randomizationSlotId"
+      ],
+      "type": "object"
+    },
+    "__schema14": {
       "items": {
         "additionalProperties": false,
         "properties": {
@@ -173,7 +197,7 @@
       },
       "type": "array"
     },
-    "__schema14": {
+    "__schema15": {
       "items": {
         "additionalProperties": false,
         "properties": {
@@ -202,6 +226,9 @@
                   "opaque"
                 ],
                 "type": "string"
+              },
+              "implementationFacets": {
+                "$ref": "#/$defs/__schema10"
               },
               "implementationId": {
                 "$ref": "#/$defs/__schema3"
@@ -245,7 +272,7 @@
       },
       "type": "array"
     },
-    "__schema15": {
+    "__schema16": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -256,7 +283,7 @@
             "$ref": "#/$defs/__schema1"
           },
           "schemaUri": {
-            "$ref": "#/$defs/__schema16"
+            "$ref": "#/$defs/__schema17"
           }
         },
         "required": [
@@ -267,11 +294,11 @@
         "type": "object"
       },
       "propertyNames": {
-        "$ref": "#/$defs/__schema16"
+        "$ref": "#/$defs/__schema17"
       },
       "type": "object"
     },
-    "__schema16": {
+    "__schema17": {
       "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
       "type": "string"
     },
@@ -567,7 +594,7 @@
       "$ref": "#/$defs/__schema1"
     },
     "comparisons": {
-      "$ref": "#/$defs/__schema13"
+      "$ref": "#/$defs/__schema14"
     },
     "evaluationPlanDigest": {
       "$ref": "#/$defs/__schema1"
@@ -576,13 +603,13 @@
       "$ref": "#/$defs/__schema11"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema15"
+      "$ref": "#/$defs/__schema16"
     },
     "metrics": {
       "$ref": "#/$defs/__schema2"
     },
     "runtimes": {
-      "$ref": "#/$defs/__schema14"
+      "$ref": "#/$defs/__schema15"
     },
     "schemaVersion": {
       "$ref": "#/$defs/__schema0"

--- a/schemas/evaluation-core/v1/decision-plan.schema.json
+++ b/schemas/evaluation-core/v1/decision-plan.schema.json
@@ -8,6 +8,52 @@
       "pattern": "^sha256:[0-9a-f]{64}$",
       "type": "string"
     },
+    "__schema10": {
+      "additionalProperties": false,
+      "properties": {
+        "facetId": {
+          "$ref": "#/$defs/__schema3"
+        },
+        "value": {
+          "$ref": "#/$defs/__schema6"
+        }
+      },
+      "required": [
+        "facetId",
+        "value"
+      ],
+      "type": "object"
+    },
+    "__schema11": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema6"
+          },
+          "schemaDigest": {
+            "$ref": "#/$defs/__schema1"
+          },
+          "schemaUri": {
+            "$ref": "#/$defs/__schema12"
+          }
+        },
+        "required": [
+          "schemaUri",
+          "schemaDigest",
+          "data"
+        ],
+        "type": "object"
+      },
+      "propertyNames": {
+        "$ref": "#/$defs/__schema12"
+      },
+      "type": "object"
+    },
+    "__schema12": {
+      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+      "type": "string"
+    },
     "__schema2": {
       "additionalProperties": false,
       "properties": {
@@ -183,14 +229,52 @@
                 ],
                 "type": "string"
               },
-              "implementationFacets": {
-                "$ref": "#/$defs/__schema6"
-              },
               "implementationId": {
                 "$ref": "#/$defs/__schema3"
               },
+              "implementationManifest": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/__schema8"
+                  },
+                  {
+                    "$ref": "#/$defs/__schema9"
+                  }
+                ]
+              },
               "provenanceFacets": {
-                "$ref": "#/$defs/__schema6"
+                "additionalProperties": false,
+                "properties": {
+                  "attestation": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "attestationDigest": {
+                        "$ref": "#/$defs/__schema1"
+                      },
+                      "attestorId": {
+                        "$ref": "#/$defs/__schema3"
+                      }
+                    },
+                    "required": [
+                      "attestationDigest"
+                    ],
+                    "type": "object"
+                  },
+                  "observation": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "observedAt": {
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+                        "type": "string"
+                      },
+                      "observerId": {
+                        "$ref": "#/$defs/__schema3"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
               },
               "version": {
                 "$ref": "#/$defs/__schema4"
@@ -201,7 +285,8 @@
               "fingerprint",
               "fingerprintBasis",
               "assuranceLevel",
-              "capabilities"
+              "capabilities",
+              "implementationManifest"
             ],
             "type": "object"
           },
@@ -229,34 +314,38 @@
       "type": "array"
     },
     "__schema8": {
-      "additionalProperties": {
-        "additionalProperties": false,
-        "properties": {
-          "data": {
-            "$ref": "#/$defs/__schema6"
-          },
-          "schemaDigest": {
-            "$ref": "#/$defs/__schema1"
-          },
-          "schemaUri": {
-            "$ref": "#/$defs/__schema9"
-          }
-        },
-        "required": [
-          "schemaUri",
-          "schemaDigest",
-          "data"
-        ],
-        "type": "object"
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-complete",
+          "type": "string"
+        }
       },
-      "propertyNames": {
-        "$ref": "#/$defs/__schema9"
-      },
+      "required": [
+        "coverageKind"
+      ],
       "type": "object"
     },
     "__schema9": {
-      "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
-      "type": "string"
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-plus-facets",
+          "type": "string"
+        },
+        "facets": {
+          "items": {
+            "$ref": "#/$defs/__schema10"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "coverageKind",
+        "facets"
+      ],
+      "type": "object"
     }
   },
   "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/decision-plan.schema.json",
@@ -273,7 +362,7 @@
       "$ref": "#/$defs/__schema2"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema8"
+      "$ref": "#/$defs/__schema11"
     },
     "runtimes": {
       "$ref": "#/$defs/__schema7"

--- a/schemas/evaluation-core/v1/decision-plan.schema.json
+++ b/schemas/evaluation-core/v1/decision-plan.schema.json
@@ -183,6 +183,9 @@
                 ],
                 "type": "string"
               },
+              "implementationFacets": {
+                "$ref": "#/$defs/__schema6"
+              },
               "implementationId": {
                 "$ref": "#/$defs/__schema3"
               },

--- a/schemas/evaluation-core/v1/evaluation-bundle.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-bundle.schema.json
@@ -1125,6 +1125,9 @@
           ],
           "type": "string"
         },
+        "implementationFacets": {
+          "$ref": "#/$defs/__schema11"
+        },
         "implementationId": {
           "$ref": "#/$defs/__schema1"
         },

--- a/schemas/evaluation-core/v1/evaluation-bundle.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-bundle.schema.json
@@ -47,6 +47,60 @@
     "__schema12": {
       "additionalProperties": false,
       "properties": {
+        "coverageKind": {
+          "const": "fingerprint-complete",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coverageKind"
+      ],
+      "type": "object"
+    },
+    "__schema13": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-plus-facets",
+          "type": "string"
+        },
+        "facets": {
+          "items": {
+            "$ref": "#/$defs/__schema14"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "coverageKind",
+        "facets"
+      ],
+      "type": "object"
+    },
+    "__schema14": {
+      "additionalProperties": false,
+      "properties": {
+        "facetId": {
+          "$ref": "#/$defs/__schema1"
+        },
+        "value": {
+          "$ref": "#/$defs/__schema11"
+        }
+      },
+      "required": [
+        "facetId",
+        "value"
+      ],
+      "type": "object"
+    },
+    "__schema15": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+      "type": "string"
+    },
+    "__schema16": {
+      "additionalProperties": false,
+      "properties": {
         "facets": {
           "$ref": "#/$defs/__schema11"
         },
@@ -85,14 +139,14 @@
       ],
       "type": "object"
     },
-    "__schema13": {
+    "__schema17": {
       "items": {
-        "$ref": "#/$defs/__schema14"
+        "$ref": "#/$defs/__schema18"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema14": {
+    "__schema18": {
       "oneOf": [
         {
           "additionalProperties": false,
@@ -101,17 +155,17 @@
               "$ref": "#/$defs/__schema2"
             },
             "attemptNumber": {
-              "$ref": "#/$defs/__schema15"
+              "$ref": "#/$defs/__schema19"
             },
             "attemptStatus": {
               "const": "completed",
               "type": "string"
             },
             "timing": {
-              "$ref": "#/$defs/__schema16"
+              "$ref": "#/$defs/__schema20"
             },
             "usage": {
-              "$ref": "#/$defs/__schema18"
+              "$ref": "#/$defs/__schema21"
             }
           },
           "required": [
@@ -129,20 +183,20 @@
               "$ref": "#/$defs/__schema2"
             },
             "attemptNumber": {
-              "$ref": "#/$defs/__schema15"
+              "$ref": "#/$defs/__schema19"
             },
             "attemptStatus": {
               "const": "failed",
               "type": "string"
             },
             "error": {
-              "$ref": "#/$defs/__schema20"
+              "$ref": "#/$defs/__schema23"
             },
             "timing": {
-              "$ref": "#/$defs/__schema16"
+              "$ref": "#/$defs/__schema20"
             },
             "usage": {
-              "$ref": "#/$defs/__schema18"
+              "$ref": "#/$defs/__schema21"
             }
           },
           "required": [
@@ -161,20 +215,20 @@
               "$ref": "#/$defs/__schema2"
             },
             "attemptNumber": {
-              "$ref": "#/$defs/__schema15"
+              "$ref": "#/$defs/__schema19"
             },
             "attemptStatus": {
               "const": "cancelled",
               "type": "string"
             },
             "error": {
-              "$ref": "#/$defs/__schema20"
+              "$ref": "#/$defs/__schema23"
             },
             "timing": {
-              "$ref": "#/$defs/__schema16"
+              "$ref": "#/$defs/__schema20"
             },
             "usage": {
-              "$ref": "#/$defs/__schema18"
+              "$ref": "#/$defs/__schema21"
             }
           },
           "required": [
@@ -187,23 +241,27 @@
         }
       ]
     },
-    "__schema15": {
+    "__schema19": {
       "exclusiveMinimum": 0,
       "maximum": 9007199254740991,
       "type": "integer"
     },
-    "__schema16": {
+    "__schema2": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema20": {
       "additionalProperties": false,
       "properties": {
         "completedAt": {
-          "$ref": "#/$defs/__schema17"
+          "$ref": "#/$defs/__schema15"
         },
         "durationMs": {
           "minimum": 0,
           "type": "number"
         },
         "startedAt": {
-          "$ref": "#/$defs/__schema17"
+          "$ref": "#/$defs/__schema15"
         }
       },
       "required": [
@@ -211,14 +269,10 @@
       ],
       "type": "object"
     },
-    "__schema17": {
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
-      "type": "string"
+    "__schema21": {
+      "$ref": "#/$defs/__schema22"
     },
-    "__schema18": {
-      "$ref": "#/$defs/__schema19"
-    },
-    "__schema19": {
+    "__schema22": {
       "additionalProperties": false,
       "properties": {
         "details": {
@@ -265,16 +319,12 @@
       },
       "type": "object"
     },
-    "__schema2": {
-      "pattern": "^sha256:[0-9a-f]{64}$",
-      "type": "string"
-    },
-    "__schema20": {
+    "__schema23": {
       "additionalProperties": false,
       "properties": {
         "causes": {
           "items": {
-            "$ref": "#/$defs/__schema20"
+            "$ref": "#/$defs/__schema23"
           },
           "type": "array"
         },
@@ -306,19 +356,19 @@
       ],
       "type": "object"
     },
-    "__schema21": {
-      "$ref": "#/$defs/__schema19"
+    "__schema24": {
+      "$ref": "#/$defs/__schema22"
     },
-    "__schema22": {
-      "$ref": "#/$defs/__schema23"
+    "__schema25": {
+      "$ref": "#/$defs/__schema26"
     },
-    "__schema23": {
+    "__schema26": {
       "oneOf": [
         {
           "additionalProperties": false,
           "properties": {
             "classification": {
-              "$ref": "#/$defs/__schema24"
+              "$ref": "#/$defs/__schema27"
             },
             "contentKind": {
               "const": "inline",
@@ -339,7 +389,7 @@
           "additionalProperties": false,
           "properties": {
             "classification": {
-              "$ref": "#/$defs/__schema24"
+              "$ref": "#/$defs/__schema27"
             },
             "contentKind": {
               "const": "descriptor",
@@ -360,7 +410,7 @@
                   "type": "integer"
                 },
                 "uri": {
-                  "$ref": "#/$defs/__schema25"
+                  "$ref": "#/$defs/__schema28"
                 }
               },
               "required": [
@@ -381,7 +431,7 @@
           "additionalProperties": false,
           "properties": {
             "classification": {
-              "$ref": "#/$defs/__schema24"
+              "$ref": "#/$defs/__schema27"
             },
             "contentKind": {
               "const": "digest-only",
@@ -400,7 +450,7 @@
         }
       ]
     },
-    "__schema24": {
+    "__schema27": {
       "enum": [
         "public",
         "sensitive",
@@ -409,11 +459,11 @@
       ],
       "type": "string"
     },
-    "__schema25": {
+    "__schema28": {
       "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
       "type": "string"
     },
-    "__schema26": {
+    "__schema29": {
       "additionalProperties": false,
       "properties": {
         "cacheKeyDigest": {
@@ -437,13 +487,22 @@
       ],
       "type": "object"
     },
-    "__schema27": {
-      "$ref": "#/$defs/__schema23"
+    "__schema3": {
+      "enum": [
+        "completed",
+        "cancelled",
+        "budget-exhausted",
+        "failed"
+      ],
+      "type": "string"
     },
-    "__schema28": {
-      "$ref": "#/$defs/__schema23"
+    "__schema30": {
+      "$ref": "#/$defs/__schema26"
     },
-    "__schema29": {
+    "__schema31": {
+      "$ref": "#/$defs/__schema26"
+    },
+    "__schema32": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -454,7 +513,7 @@
             "$ref": "#/$defs/__schema2"
           },
           "schemaUri": {
-            "$ref": "#/$defs/__schema25"
+            "$ref": "#/$defs/__schema28"
           }
         },
         "required": [
@@ -465,18 +524,9 @@
         "type": "object"
       },
       "propertyNames": {
-        "$ref": "#/$defs/__schema25"
+        "$ref": "#/$defs/__schema28"
       },
       "type": "object"
-    },
-    "__schema3": {
-      "enum": [
-        "completed",
-        "cancelled",
-        "budget-exhausted",
-        "failed"
-      ],
-      "type": "string"
     },
     "__schema4": {
       "$ref": "#/$defs/__schema1"
@@ -552,10 +602,10 @@
             "additionalProperties": false,
             "properties": {
               "attempts": {
-                "$ref": "#/$defs/__schema13"
+                "$ref": "#/$defs/__schema17"
               },
               "cache": {
-                "$ref": "#/$defs/__schema26"
+                "$ref": "#/$defs/__schema29"
               },
               "evaluationId": {
                 "$ref": "#/$defs/__schema2"
@@ -568,7 +618,7 @@
                 "$ref": "#/$defs/__schema1"
               },
               "evidence": {
-                "$ref": "#/$defs/__schema22"
+                "$ref": "#/$defs/__schema25"
               },
               "observations": {
                 "items": {
@@ -577,10 +627,10 @@
                       "additionalProperties": false,
                       "properties": {
                         "evidence": {
-                          "$ref": "#/$defs/__schema27"
+                          "$ref": "#/$defs/__schema30"
                         },
                         "metadata": {
-                          "$ref": "#/$defs/__schema28"
+                          "$ref": "#/$defs/__schema31"
                         },
                         "metricId": {
                           "$ref": "#/$defs/__schema1"
@@ -613,10 +663,10 @@
                       "additionalProperties": false,
                       "properties": {
                         "evidence": {
-                          "$ref": "#/$defs/__schema27"
+                          "$ref": "#/$defs/__schema30"
                         },
                         "metadata": {
-                          "$ref": "#/$defs/__schema28"
+                          "$ref": "#/$defs/__schema31"
                         },
                         "metricId": {
                           "$ref": "#/$defs/__schema1"
@@ -649,10 +699,10 @@
                       "additionalProperties": false,
                       "properties": {
                         "evidence": {
-                          "$ref": "#/$defs/__schema27"
+                          "$ref": "#/$defs/__schema30"
                         },
                         "metadata": {
-                          "$ref": "#/$defs/__schema28"
+                          "$ref": "#/$defs/__schema31"
                         },
                         "metricId": {
                           "$ref": "#/$defs/__schema1"
@@ -685,10 +735,10 @@
                       "additionalProperties": false,
                       "properties": {
                         "evidence": {
-                          "$ref": "#/$defs/__schema27"
+                          "$ref": "#/$defs/__schema30"
                         },
                         "metadata": {
-                          "$ref": "#/$defs/__schema28"
+                          "$ref": "#/$defs/__schema31"
                         },
                         "metricId": {
                           "$ref": "#/$defs/__schema1"
@@ -721,10 +771,10 @@
                       "additionalProperties": false,
                       "properties": {
                         "evidence": {
-                          "$ref": "#/$defs/__schema27"
+                          "$ref": "#/$defs/__schema30"
                         },
                         "metadata": {
-                          "$ref": "#/$defs/__schema28"
+                          "$ref": "#/$defs/__schema31"
                         },
                         "metricId": {
                           "$ref": "#/$defs/__schema1"
@@ -760,10 +810,10 @@
                       "additionalProperties": false,
                       "properties": {
                         "evidence": {
-                          "$ref": "#/$defs/__schema27"
+                          "$ref": "#/$defs/__schema30"
                         },
                         "metadata": {
-                          "$ref": "#/$defs/__schema28"
+                          "$ref": "#/$defs/__schema31"
                         },
                         "metricId": {
                           "$ref": "#/$defs/__schema1"
@@ -802,13 +852,13 @@
                       "additionalProperties": false,
                       "properties": {
                         "evidence": {
-                          "$ref": "#/$defs/__schema27"
+                          "$ref": "#/$defs/__schema30"
                         },
                         "invalidValue": {
-                          "$ref": "#/$defs/__schema23"
+                          "$ref": "#/$defs/__schema26"
                         },
                         "metadata": {
-                          "$ref": "#/$defs/__schema28"
+                          "$ref": "#/$defs/__schema31"
                         },
                         "metricId": {
                           "$ref": "#/$defs/__schema1"
@@ -848,7 +898,7 @@
                 "type": "array"
               },
               "provenance": {
-                "$ref": "#/$defs/__schema12"
+                "$ref": "#/$defs/__schema16"
               },
               "runtime": {
                 "$ref": "#/$defs/__schema9"
@@ -863,7 +913,7 @@
                 "$ref": "#/$defs/__schema1"
               },
               "timing": {
-                "$ref": "#/$defs/__schema16"
+                "$ref": "#/$defs/__schema20"
               },
               "trialId": {
                 "$ref": "#/$defs/__schema2"
@@ -872,7 +922,7 @@
                 "$ref": "#/$defs/__schema8"
               },
               "usage": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema24"
               }
             },
             "required": [
@@ -897,13 +947,13 @@
             "additionalProperties": false,
             "properties": {
               "attempts": {
-                "$ref": "#/$defs/__schema13"
+                "$ref": "#/$defs/__schema17"
               },
               "cache": {
-                "$ref": "#/$defs/__schema26"
+                "$ref": "#/$defs/__schema29"
               },
               "error": {
-                "$ref": "#/$defs/__schema20"
+                "$ref": "#/$defs/__schema23"
               },
               "evaluationId": {
                 "$ref": "#/$defs/__schema2"
@@ -916,10 +966,10 @@
                 "$ref": "#/$defs/__schema1"
               },
               "evidence": {
-                "$ref": "#/$defs/__schema22"
+                "$ref": "#/$defs/__schema25"
               },
               "provenance": {
-                "$ref": "#/$defs/__schema12"
+                "$ref": "#/$defs/__schema16"
               },
               "runtime": {
                 "$ref": "#/$defs/__schema9"
@@ -934,7 +984,7 @@
                 "$ref": "#/$defs/__schema1"
               },
               "timing": {
-                "$ref": "#/$defs/__schema16"
+                "$ref": "#/$defs/__schema20"
               },
               "trialId": {
                 "$ref": "#/$defs/__schema2"
@@ -943,7 +993,7 @@
                 "$ref": "#/$defs/__schema8"
               },
               "usage": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema24"
               }
             },
             "required": [
@@ -968,13 +1018,13 @@
             "additionalProperties": false,
             "properties": {
               "attempts": {
-                "$ref": "#/$defs/__schema13"
+                "$ref": "#/$defs/__schema17"
               },
               "cache": {
-                "$ref": "#/$defs/__schema26"
+                "$ref": "#/$defs/__schema29"
               },
               "error": {
-                "$ref": "#/$defs/__schema20"
+                "$ref": "#/$defs/__schema23"
               },
               "evaluationId": {
                 "$ref": "#/$defs/__schema2"
@@ -987,10 +1037,10 @@
                 "$ref": "#/$defs/__schema1"
               },
               "evidence": {
-                "$ref": "#/$defs/__schema22"
+                "$ref": "#/$defs/__schema25"
               },
               "provenance": {
-                "$ref": "#/$defs/__schema12"
+                "$ref": "#/$defs/__schema16"
               },
               "runtime": {
                 "$ref": "#/$defs/__schema9"
@@ -1005,7 +1055,7 @@
                 "$ref": "#/$defs/__schema1"
               },
               "timing": {
-                "$ref": "#/$defs/__schema16"
+                "$ref": "#/$defs/__schema20"
               },
               "trialId": {
                 "$ref": "#/$defs/__schema2"
@@ -1014,7 +1064,7 @@
                 "$ref": "#/$defs/__schema8"
               },
               "usage": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema24"
               }
             },
             "required": [
@@ -1048,13 +1098,13 @@
                 "$ref": "#/$defs/__schema1"
               },
               "notEvaluatedAt": {
-                "$ref": "#/$defs/__schema17"
+                "$ref": "#/$defs/__schema15"
               },
               "notEvaluatedReasonCode": {
                 "$ref": "#/$defs/__schema1"
               },
               "provenance": {
-                "$ref": "#/$defs/__schema12"
+                "$ref": "#/$defs/__schema16"
               },
               "runtime": {
                 "$ref": "#/$defs/__schema9"
@@ -1125,14 +1175,51 @@
           ],
           "type": "string"
         },
-        "implementationFacets": {
-          "$ref": "#/$defs/__schema11"
-        },
         "implementationId": {
           "$ref": "#/$defs/__schema1"
         },
+        "implementationManifest": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/__schema12"
+            },
+            {
+              "$ref": "#/$defs/__schema13"
+            }
+          ]
+        },
         "provenanceFacets": {
-          "$ref": "#/$defs/__schema11"
+          "additionalProperties": false,
+          "properties": {
+            "attestation": {
+              "additionalProperties": false,
+              "properties": {
+                "attestationDigest": {
+                  "$ref": "#/$defs/__schema2"
+                },
+                "attestorId": {
+                  "$ref": "#/$defs/__schema1"
+                }
+              },
+              "required": [
+                "attestationDigest"
+              ],
+              "type": "object"
+            },
+            "observation": {
+              "additionalProperties": false,
+              "properties": {
+                "observedAt": {
+                  "$ref": "#/$defs/__schema15"
+                },
+                "observerId": {
+                  "$ref": "#/$defs/__schema1"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
         },
         "version": {
           "$ref": "#/$defs/__schema10"
@@ -1143,7 +1230,8 @@
         "fingerprint",
         "fingerprintBasis",
         "assuranceLevel",
-        "capabilities"
+        "capabilities",
+        "implementationManifest"
       ],
       "type": "object"
     }
@@ -1174,10 +1262,10 @@
       "$ref": "#/$defs/__schema2"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema29"
+      "$ref": "#/$defs/__schema32"
     },
     "provenance": {
-      "$ref": "#/$defs/__schema12"
+      "$ref": "#/$defs/__schema16"
     },
     "records": {
       "$ref": "#/$defs/__schema7"

--- a/schemas/evaluation-core/v1/evaluation-definition.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-definition.schema.json
@@ -96,6 +96,13 @@
     "__schema11": {
       "additionalProperties": false,
       "properties": {
+        "randomizationSlots": {
+          "items": {
+            "$ref": "#/$defs/__schema12"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
         "sampling": {
           "additionalProperties": false,
           "properties": {
@@ -184,11 +191,28 @@
         "trials",
         "seed",
         "sampling",
-        "scheduling"
+        "scheduling",
+        "randomizationSlots"
       ],
       "type": "object"
     },
     "__schema12": {
+      "additionalProperties": false,
+      "properties": {
+        "randomizationSlotId": {
+          "$ref": "#/$defs/__schema2"
+        },
+        "targetId": {
+          "$ref": "#/$defs/__schema2"
+        }
+      },
+      "required": [
+        "targetId",
+        "randomizationSlotId"
+      ],
+      "type": "object"
+    },
+    "__schema13": {
       "additionalProperties": false,
       "properties": {
         "analysisMode": {
@@ -212,7 +236,7 @@
                     "$ref": "#/$defs/__schema2"
                   },
                   "inputs": {
-                    "$ref": "#/$defs/__schema14"
+                    "$ref": "#/$defs/__schema15"
                   },
                   "nodeId": {
                     "$ref": "#/$defs/__schema2"
@@ -221,10 +245,10 @@
                     "$ref": "#/$defs/__schema2"
                   },
                   "parameters": {
-                    "$ref": "#/$defs/__schema16"
+                    "$ref": "#/$defs/__schema17"
                   },
                   "versionConstraint": {
-                    "$ref": "#/$defs/__schema13"
+                    "$ref": "#/$defs/__schema14"
                   }
                 },
                 "required": [
@@ -247,7 +271,7 @@
                     "$ref": "#/$defs/__schema2"
                   },
                   "inputs": {
-                    "$ref": "#/$defs/__schema14"
+                    "$ref": "#/$defs/__schema15"
                   },
                   "nodeId": {
                     "$ref": "#/$defs/__schema2"
@@ -256,10 +280,10 @@
                     "$ref": "#/$defs/__schema2"
                   },
                   "parameters": {
-                    "$ref": "#/$defs/__schema16"
+                    "$ref": "#/$defs/__schema17"
                   },
                   "versionConstraint": {
-                    "$ref": "#/$defs/__schema13"
+                    "$ref": "#/$defs/__schema14"
                   }
                 },
                 "required": [
@@ -282,7 +306,7 @@
                     "$ref": "#/$defs/__schema2"
                   },
                   "inputs": {
-                    "$ref": "#/$defs/__schema14"
+                    "$ref": "#/$defs/__schema15"
                   },
                   "nodeId": {
                     "$ref": "#/$defs/__schema2"
@@ -291,10 +315,10 @@
                     "$ref": "#/$defs/__schema2"
                   },
                   "parameters": {
-                    "$ref": "#/$defs/__schema16"
+                    "$ref": "#/$defs/__schema17"
                   },
                   "versionConstraint": {
-                    "$ref": "#/$defs/__schema13"
+                    "$ref": "#/$defs/__schema14"
                   }
                 },
                 "required": [
@@ -317,17 +341,17 @@
       ],
       "type": "object"
     },
-    "__schema13": {
+    "__schema14": {
       "$ref": "#/$defs/__schema7"
     },
-    "__schema14": {
+    "__schema15": {
       "items": {
-        "$ref": "#/$defs/__schema15"
+        "$ref": "#/$defs/__schema16"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema15": {
+    "__schema16": {
       "oneOf": [
         {
           "additionalProperties": false,
@@ -390,10 +414,10 @@
         }
       ]
     },
-    "__schema16": {
+    "__schema17": {
       "$ref": "#/$defs/__schema4"
     },
-    "__schema17": {
+    "__schema18": {
       "items": {
         "additionalProperties": false,
         "properties": {
@@ -428,7 +452,7 @@
       },
       "type": "array"
     },
-    "__schema18": {
+    "__schema19": {
       "additionalProperties": false,
       "properties": {
         "analysisResultIds": {
@@ -440,7 +464,7 @@
         },
         "comparisonFamily": {
           "items": {
-            "$ref": "#/$defs/__schema19"
+            "$ref": "#/$defs/__schema20"
           },
           "minItems": 1,
           "type": "array"
@@ -477,7 +501,12 @@
       ],
       "type": "object"
     },
-    "__schema19": {
+    "__schema2": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema20": {
       "anyOf": [
         {
           "additionalProperties": false,
@@ -533,12 +562,7 @@
         }
       ]
     },
-    "__schema2": {
-      "maxLength": 256,
-      "minLength": 1,
-      "type": "string"
-    },
-    "__schema20": {
+    "__schema21": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -550,7 +574,7 @@
             "type": "string"
           },
           "schemaUri": {
-            "$ref": "#/$defs/__schema21"
+            "$ref": "#/$defs/__schema22"
           }
         },
         "required": [
@@ -561,11 +585,11 @@
         "type": "object"
       },
       "propertyNames": {
-        "$ref": "#/$defs/__schema21"
+        "$ref": "#/$defs/__schema22"
       },
       "type": "object"
     },
-    "__schema21": {
+    "__schema22": {
       "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
       "type": "string"
     },
@@ -750,16 +774,16 @@
   "additionalProperties": false,
   "properties": {
     "analysisGraph": {
-      "$ref": "#/$defs/__schema12"
+      "$ref": "#/$defs/__schema13"
     },
     "comparisons": {
-      "$ref": "#/$defs/__schema17"
+      "$ref": "#/$defs/__schema18"
     },
     "dataset": {
       "$ref": "#/$defs/__schema1"
     },
     "decisionPolicy": {
-      "$ref": "#/$defs/__schema18"
+      "$ref": "#/$defs/__schema19"
     },
     "evaluators": {
       "$ref": "#/$defs/__schema8"
@@ -768,7 +792,7 @@
       "$ref": "#/$defs/__schema11"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema20"
+      "$ref": "#/$defs/__schema21"
     },
     "metrics": {
       "$ref": "#/$defs/__schema10"

--- a/schemas/evaluation-core/v1/evaluation-plan.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-plan.schema.json
@@ -11,6 +11,56 @@
     "__schema10": {
       "additionalProperties": false,
       "properties": {
+        "coverageKind": {
+          "const": "fingerprint-complete",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coverageKind"
+      ],
+      "type": "object"
+    },
+    "__schema11": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-plus-facets",
+          "type": "string"
+        },
+        "facets": {
+          "items": {
+            "$ref": "#/$defs/__schema12"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "coverageKind",
+        "facets"
+      ],
+      "type": "object"
+    },
+    "__schema12": {
+      "additionalProperties": false,
+      "properties": {
+        "facetId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "value": {
+          "$ref": "#/$defs/__schema5"
+        }
+      },
+      "required": [
+        "facetId",
+        "value"
+      ],
+      "type": "object"
+    },
+    "__schema13": {
+      "additionalProperties": false,
+      "properties": {
         "evaluationCacheMode": {
           "enum": [
             "disabled",
@@ -22,13 +72,13 @@
           "additionalProperties": false,
           "properties": {
             "evidence": {
-              "$ref": "#/$defs/__schema11"
+              "$ref": "#/$defs/__schema14"
             },
             "expected": {
-              "$ref": "#/$defs/__schema11"
+              "$ref": "#/$defs/__schema14"
             },
             "input": {
-              "$ref": "#/$defs/__schema11"
+              "$ref": "#/$defs/__schema14"
             },
             "maximumClassification": {
               "enum": [
@@ -40,10 +90,10 @@
               "type": "string"
             },
             "output": {
-              "$ref": "#/$defs/__schema11"
+              "$ref": "#/$defs/__schema14"
             },
             "trace": {
-              "$ref": "#/$defs/__schema11"
+              "$ref": "#/$defs/__schema14"
             }
           },
           "required": [
@@ -192,7 +242,7 @@
       ],
       "type": "object"
     },
-    "__schema11": {
+    "__schema14": {
       "enum": [
         "full",
         "reference",
@@ -201,7 +251,7 @@
       ],
       "type": "string"
     },
-    "__schema12": {
+    "__schema15": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -212,7 +262,7 @@
             "$ref": "#/$defs/__schema1"
           },
           "schemaUri": {
-            "$ref": "#/$defs/__schema13"
+            "$ref": "#/$defs/__schema16"
           }
         },
         "required": [
@@ -223,11 +273,11 @@
         "type": "object"
       },
       "propertyNames": {
-        "$ref": "#/$defs/__schema13"
+        "$ref": "#/$defs/__schema16"
       },
       "type": "object"
     },
-    "__schema13": {
+    "__schema16": {
       "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
       "type": "string"
     },
@@ -467,14 +517,52 @@
                 ],
                 "type": "string"
               },
-              "implementationFacets": {
-                "$ref": "#/$defs/__schema5"
-              },
               "implementationId": {
                 "$ref": "#/$defs/__schema4"
               },
+              "implementationManifest": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/__schema10"
+                  },
+                  {
+                    "$ref": "#/$defs/__schema11"
+                  }
+                ]
+              },
               "provenanceFacets": {
-                "$ref": "#/$defs/__schema5"
+                "additionalProperties": false,
+                "properties": {
+                  "attestation": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "attestationDigest": {
+                        "$ref": "#/$defs/__schema1"
+                      },
+                      "attestorId": {
+                        "$ref": "#/$defs/__schema4"
+                      }
+                    },
+                    "required": [
+                      "attestationDigest"
+                    ],
+                    "type": "object"
+                  },
+                  "observation": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "observedAt": {
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+                        "type": "string"
+                      },
+                      "observerId": {
+                        "$ref": "#/$defs/__schema4"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
               },
               "version": {
                 "$ref": "#/$defs/__schema7"
@@ -485,7 +573,8 @@
               "fingerprint",
               "fingerprintBasis",
               "assuranceLevel",
-              "capabilities"
+              "capabilities",
+              "implementationManifest"
             ],
             "type": "object"
           },
@@ -530,13 +619,13 @@
       "$ref": "#/$defs/__schema1"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema12"
+      "$ref": "#/$defs/__schema15"
     },
     "metrics": {
       "$ref": "#/$defs/__schema8"
     },
     "policy": {
-      "$ref": "#/$defs/__schema10"
+      "$ref": "#/$defs/__schema13"
     },
     "runtimes": {
       "$ref": "#/$defs/__schema9"

--- a/schemas/evaluation-core/v1/evaluation-plan.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-plan.schema.json
@@ -467,6 +467,9 @@
                 ],
                 "type": "string"
               },
+              "implementationFacets": {
+                "$ref": "#/$defs/__schema5"
+              },
               "implementationId": {
                 "$ref": "#/$defs/__schema4"
               },

--- a/schemas/evaluation-core/v1/evaluation-report.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-report.schema.json
@@ -10,22 +10,72 @@
       "type": "string"
     },
     "__schema10": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-complete",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coverageKind"
+      ],
+      "type": "object"
+    },
+    "__schema11": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-plus-facets",
+          "type": "string"
+        },
+        "facets": {
+          "items": {
+            "$ref": "#/$defs/__schema12"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "coverageKind",
+        "facets"
+      ],
+      "type": "object"
+    },
+    "__schema12": {
+      "additionalProperties": false,
+      "properties": {
+        "facetId": {
+          "$ref": "#/$defs/__schema1"
+        },
+        "value": {
+          "$ref": "#/$defs/__schema9"
+        }
+      },
+      "required": [
+        "facetId",
+        "value"
+      ],
+      "type": "object"
+    },
+    "__schema13": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+      "type": "string"
+    },
+    "__schema14": {
       "items": {
         "$ref": "#/$defs/__schema1"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema11": {
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
-      "type": "string"
-    },
-    "__schema12": {
+    "__schema15": {
       "additionalProperties": false,
       "properties": {
         "causes": {
           "items": {
-            "$ref": "#/$defs/__schema12"
+            "$ref": "#/$defs/__schema15"
           },
           "type": "array"
         },
@@ -57,13 +107,13 @@
       ],
       "type": "object"
     },
-    "__schema13": {
+    "__schema16": {
       "$ref": "#/$defs/__schema9"
     },
-    "__schema14": {
+    "__schema17": {
       "$ref": "#/$defs/__schema9"
     },
-    "__schema15": {
+    "__schema18": {
       "additionalProperties": false,
       "properties": {
         "facets": {
@@ -104,7 +154,7 @@
       ],
       "type": "object"
     },
-    "__schema16": {
+    "__schema19": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -218,10 +268,10 @@
               "$ref": "#/$defs/__schema2"
             },
             "analysisResultIds": {
-              "$ref": "#/$defs/__schema10"
+              "$ref": "#/$defs/__schema14"
             },
             "decidedAt": {
-              "$ref": "#/$defs/__schema11"
+              "$ref": "#/$defs/__schema13"
             },
             "decisionDigest": {
               "$ref": "#/$defs/__schema2"
@@ -267,10 +317,10 @@
               "$ref": "#/$defs/__schema2"
             },
             "analysisResultIds": {
-              "$ref": "#/$defs/__schema10"
+              "$ref": "#/$defs/__schema14"
             },
             "decidedAt": {
-              "$ref": "#/$defs/__schema11"
+              "$ref": "#/$defs/__schema13"
             },
             "decisionDigest": {
               "$ref": "#/$defs/__schema2"
@@ -320,10 +370,10 @@
               "$ref": "#/$defs/__schema2"
             },
             "analysisResultIds": {
-              "$ref": "#/$defs/__schema10"
+              "$ref": "#/$defs/__schema14"
             },
             "decidedAt": {
-              "$ref": "#/$defs/__schema11"
+              "$ref": "#/$defs/__schema13"
             },
             "decisionDigest": {
               "$ref": "#/$defs/__schema2"
@@ -339,7 +389,7 @@
               "type": "string"
             },
             "error": {
-              "$ref": "#/$defs/__schema12"
+              "$ref": "#/$defs/__schema15"
             },
             "implementation": {
               "$ref": "#/$defs/__schema8"
@@ -390,14 +440,51 @@
           ],
           "type": "string"
         },
-        "implementationFacets": {
-          "$ref": "#/$defs/__schema9"
-        },
         "implementationId": {
           "$ref": "#/$defs/__schema1"
         },
+        "implementationManifest": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/__schema10"
+            },
+            {
+              "$ref": "#/$defs/__schema11"
+            }
+          ]
+        },
         "provenanceFacets": {
-          "$ref": "#/$defs/__schema9"
+          "additionalProperties": false,
+          "properties": {
+            "attestation": {
+              "additionalProperties": false,
+              "properties": {
+                "attestationDigest": {
+                  "$ref": "#/$defs/__schema2"
+                },
+                "attestorId": {
+                  "$ref": "#/$defs/__schema1"
+                }
+              },
+              "required": [
+                "attestationDigest"
+              ],
+              "type": "object"
+            },
+            "observation": {
+              "additionalProperties": false,
+              "properties": {
+                "observedAt": {
+                  "$ref": "#/$defs/__schema13"
+                },
+                "observerId": {
+                  "$ref": "#/$defs/__schema1"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
         },
         "version": {
           "$ref": "#/$defs/__schema5"
@@ -408,7 +495,8 @@
         "fingerprint",
         "fingerprintBasis",
         "assuranceLevel",
-        "capabilities"
+        "capabilities",
+        "implementationManifest"
       ],
       "type": "object"
     },
@@ -449,7 +537,7 @@
   "additionalProperties": false,
   "properties": {
     "annotations": {
-      "$ref": "#/$defs/__schema14"
+      "$ref": "#/$defs/__schema17"
     },
     "bundles": {
       "$ref": "#/$defs/__schema4"
@@ -458,10 +546,10 @@
       "$ref": "#/$defs/__schema7"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema16"
+      "$ref": "#/$defs/__schema19"
     },
     "provenance": {
-      "$ref": "#/$defs/__schema15"
+      "$ref": "#/$defs/__schema18"
     },
     "reportDigest": {
       "$ref": "#/$defs/__schema2"
@@ -479,7 +567,7 @@
       "$ref": "#/$defs/__schema3"
     },
     "summaries": {
-      "$ref": "#/$defs/__schema13"
+      "$ref": "#/$defs/__schema16"
     }
   },
   "required": [

--- a/schemas/evaluation-core/v1/evaluation-report.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-report.schema.json
@@ -390,6 +390,9 @@
           ],
           "type": "string"
         },
+        "implementationFacets": {
+          "$ref": "#/$defs/__schema9"
+        },
         "implementationId": {
           "$ref": "#/$defs/__schema1"
         },

--- a/schemas/evaluation-core/v1/execution-bundle.schema.json
+++ b/schemas/evaluation-core/v1/execution-bundle.schema.json
@@ -35,6 +35,9 @@
           ],
           "type": "string"
         },
+        "implementationFacets": {
+          "$ref": "#/$defs/__schema12"
+        },
         "implementationId": {
           "$ref": "#/$defs/__schema1"
         },
@@ -600,6 +603,9 @@
               "provenance": {
                 "$ref": "#/$defs/__schema13"
               },
+              "randomizationSlotId": {
+                "$ref": "#/$defs/__schema1"
+              },
               "runtime": {
                 "$ref": "#/$defs/__schema10"
               },
@@ -636,6 +642,7 @@
             },
             "required": [
               "targetId",
+              "randomizationSlotId",
               "sampleId",
               "trialIndex",
               "trialId",
@@ -670,6 +677,9 @@
               "provenance": {
                 "$ref": "#/$defs/__schema13"
               },
+              "randomizationSlotId": {
+                "$ref": "#/$defs/__schema1"
+              },
               "runtime": {
                 "$ref": "#/$defs/__schema10"
               },
@@ -706,6 +716,7 @@
             },
             "required": [
               "targetId",
+              "randomizationSlotId",
               "sampleId",
               "trialIndex",
               "trialId",
@@ -741,6 +752,9 @@
               "provenance": {
                 "$ref": "#/$defs/__schema13"
               },
+              "randomizationSlotId": {
+                "$ref": "#/$defs/__schema1"
+              },
               "runtime": {
                 "$ref": "#/$defs/__schema10"
               },
@@ -777,6 +791,7 @@
             },
             "required": [
               "targetId",
+              "randomizationSlotId",
               "sampleId",
               "trialIndex",
               "trialId",
@@ -808,6 +823,9 @@
               "provenance": {
                 "$ref": "#/$defs/__schema13"
               },
+              "randomizationSlotId": {
+                "$ref": "#/$defs/__schema1"
+              },
               "runtime": {
                 "$ref": "#/$defs/__schema10"
               },
@@ -835,6 +853,7 @@
             },
             "required": [
               "targetId",
+              "randomizationSlotId",
               "sampleId",
               "trialIndex",
               "trialId",

--- a/schemas/evaluation-core/v1/execution-bundle.schema.json
+++ b/schemas/evaluation-core/v1/execution-bundle.schema.json
@@ -35,14 +35,51 @@
           ],
           "type": "string"
         },
-        "implementationFacets": {
-          "$ref": "#/$defs/__schema12"
-        },
         "implementationId": {
           "$ref": "#/$defs/__schema1"
         },
+        "implementationManifest": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/__schema13"
+            },
+            {
+              "$ref": "#/$defs/__schema14"
+            }
+          ]
+        },
         "provenanceFacets": {
-          "$ref": "#/$defs/__schema12"
+          "additionalProperties": false,
+          "properties": {
+            "attestation": {
+              "additionalProperties": false,
+              "properties": {
+                "attestationDigest": {
+                  "$ref": "#/$defs/__schema2"
+                },
+                "attestorId": {
+                  "$ref": "#/$defs/__schema1"
+                }
+              },
+              "required": [
+                "attestationDigest"
+              ],
+              "type": "object"
+            },
+            "observation": {
+              "additionalProperties": false,
+              "properties": {
+                "observedAt": {
+                  "$ref": "#/$defs/__schema16"
+                },
+                "observerId": {
+                  "$ref": "#/$defs/__schema1"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
         },
         "version": {
           "$ref": "#/$defs/__schema11"
@@ -53,7 +90,8 @@
         "fingerprint",
         "fingerprintBasis",
         "assuranceLevel",
-        "capabilities"
+        "capabilities",
+        "implementationManifest"
       ],
       "type": "object"
     },
@@ -95,6 +133,60 @@
     "__schema13": {
       "additionalProperties": false,
       "properties": {
+        "coverageKind": {
+          "const": "fingerprint-complete",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coverageKind"
+      ],
+      "type": "object"
+    },
+    "__schema14": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-plus-facets",
+          "type": "string"
+        },
+        "facets": {
+          "items": {
+            "$ref": "#/$defs/__schema15"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "coverageKind",
+        "facets"
+      ],
+      "type": "object"
+    },
+    "__schema15": {
+      "additionalProperties": false,
+      "properties": {
+        "facetId": {
+          "$ref": "#/$defs/__schema1"
+        },
+        "value": {
+          "$ref": "#/$defs/__schema12"
+        }
+      },
+      "required": [
+        "facetId",
+        "value"
+      ],
+      "type": "object"
+    },
+    "__schema16": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+      "type": "string"
+    },
+    "__schema17": {
+      "additionalProperties": false,
+      "properties": {
         "facets": {
           "$ref": "#/$defs/__schema12"
         },
@@ -133,14 +225,14 @@
       ],
       "type": "object"
     },
-    "__schema14": {
+    "__schema18": {
       "items": {
-        "$ref": "#/$defs/__schema15"
+        "$ref": "#/$defs/__schema19"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema15": {
+    "__schema19": {
       "oneOf": [
         {
           "additionalProperties": false,
@@ -149,17 +241,17 @@
               "$ref": "#/$defs/__schema2"
             },
             "attemptNumber": {
-              "$ref": "#/$defs/__schema16"
+              "$ref": "#/$defs/__schema20"
             },
             "attemptStatus": {
               "const": "completed",
               "type": "string"
             },
             "timing": {
-              "$ref": "#/$defs/__schema17"
+              "$ref": "#/$defs/__schema21"
             },
             "usage": {
-              "$ref": "#/$defs/__schema19"
+              "$ref": "#/$defs/__schema22"
             }
           },
           "required": [
@@ -177,20 +269,20 @@
               "$ref": "#/$defs/__schema2"
             },
             "attemptNumber": {
-              "$ref": "#/$defs/__schema16"
+              "$ref": "#/$defs/__schema20"
             },
             "attemptStatus": {
               "const": "failed",
               "type": "string"
             },
             "error": {
-              "$ref": "#/$defs/__schema21"
+              "$ref": "#/$defs/__schema24"
             },
             "timing": {
-              "$ref": "#/$defs/__schema17"
+              "$ref": "#/$defs/__schema21"
             },
             "usage": {
-              "$ref": "#/$defs/__schema19"
+              "$ref": "#/$defs/__schema22"
             }
           },
           "required": [
@@ -209,20 +301,20 @@
               "$ref": "#/$defs/__schema2"
             },
             "attemptNumber": {
-              "$ref": "#/$defs/__schema16"
+              "$ref": "#/$defs/__schema20"
             },
             "attemptStatus": {
               "const": "cancelled",
               "type": "string"
             },
             "error": {
-              "$ref": "#/$defs/__schema21"
+              "$ref": "#/$defs/__schema24"
             },
             "timing": {
-              "$ref": "#/$defs/__schema17"
+              "$ref": "#/$defs/__schema21"
             },
             "usage": {
-              "$ref": "#/$defs/__schema19"
+              "$ref": "#/$defs/__schema22"
             }
           },
           "required": [
@@ -235,23 +327,27 @@
         }
       ]
     },
-    "__schema16": {
+    "__schema2": {
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "__schema20": {
       "exclusiveMinimum": 0,
       "maximum": 9007199254740991,
       "type": "integer"
     },
-    "__schema17": {
+    "__schema21": {
       "additionalProperties": false,
       "properties": {
         "completedAt": {
-          "$ref": "#/$defs/__schema18"
+          "$ref": "#/$defs/__schema16"
         },
         "durationMs": {
           "minimum": 0,
           "type": "number"
         },
         "startedAt": {
-          "$ref": "#/$defs/__schema18"
+          "$ref": "#/$defs/__schema16"
         }
       },
       "required": [
@@ -259,18 +355,10 @@
       ],
       "type": "object"
     },
-    "__schema18": {
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
-      "type": "string"
+    "__schema22": {
+      "$ref": "#/$defs/__schema23"
     },
-    "__schema19": {
-      "$ref": "#/$defs/__schema20"
-    },
-    "__schema2": {
-      "pattern": "^sha256:[0-9a-f]{64}$",
-      "type": "string"
-    },
-    "__schema20": {
+    "__schema23": {
       "additionalProperties": false,
       "properties": {
         "details": {
@@ -317,12 +405,12 @@
       },
       "type": "object"
     },
-    "__schema21": {
+    "__schema24": {
       "additionalProperties": false,
       "properties": {
         "causes": {
           "items": {
-            "$ref": "#/$defs/__schema21"
+            "$ref": "#/$defs/__schema24"
           },
           "type": "array"
         },
@@ -354,19 +442,19 @@
       ],
       "type": "object"
     },
-    "__schema22": {
-      "$ref": "#/$defs/__schema20"
+    "__schema25": {
+      "$ref": "#/$defs/__schema23"
     },
-    "__schema23": {
-      "$ref": "#/$defs/__schema24"
+    "__schema26": {
+      "$ref": "#/$defs/__schema27"
     },
-    "__schema24": {
+    "__schema27": {
       "oneOf": [
         {
           "additionalProperties": false,
           "properties": {
             "classification": {
-              "$ref": "#/$defs/__schema25"
+              "$ref": "#/$defs/__schema28"
             },
             "contentKind": {
               "const": "inline",
@@ -387,7 +475,7 @@
           "additionalProperties": false,
           "properties": {
             "classification": {
-              "$ref": "#/$defs/__schema25"
+              "$ref": "#/$defs/__schema28"
             },
             "contentKind": {
               "const": "descriptor",
@@ -408,7 +496,7 @@
                   "type": "integer"
                 },
                 "uri": {
-                  "$ref": "#/$defs/__schema26"
+                  "$ref": "#/$defs/__schema29"
                 }
               },
               "required": [
@@ -429,7 +517,7 @@
           "additionalProperties": false,
           "properties": {
             "classification": {
-              "$ref": "#/$defs/__schema25"
+              "$ref": "#/$defs/__schema28"
             },
             "contentKind": {
               "const": "digest-only",
@@ -448,7 +536,7 @@
         }
       ]
     },
-    "__schema25": {
+    "__schema28": {
       "enum": [
         "public",
         "sensitive",
@@ -457,11 +545,20 @@
       ],
       "type": "string"
     },
-    "__schema26": {
+    "__schema29": {
       "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
       "type": "string"
     },
-    "__schema27": {
+    "__schema3": {
+      "enum": [
+        "completed",
+        "cancelled",
+        "budget-exhausted",
+        "failed"
+      ],
+      "type": "string"
+    },
+    "__schema30": {
       "additionalProperties": false,
       "properties": {
         "cacheKeyDigest": {
@@ -485,7 +582,7 @@
       ],
       "type": "object"
     },
-    "__schema28": {
+    "__schema31": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -496,7 +593,7 @@
             "$ref": "#/$defs/__schema2"
           },
           "schemaUri": {
-            "$ref": "#/$defs/__schema26"
+            "$ref": "#/$defs/__schema29"
           }
         },
         "required": [
@@ -507,18 +604,9 @@
         "type": "object"
       },
       "propertyNames": {
-        "$ref": "#/$defs/__schema26"
+        "$ref": "#/$defs/__schema29"
       },
       "type": "object"
-    },
-    "__schema3": {
-      "enum": [
-        "completed",
-        "cancelled",
-        "budget-exhausted",
-        "failed"
-      ],
-      "type": "string"
     },
     "__schema4": {
       "$ref": "#/$defs/__schema1"
@@ -588,20 +676,20 @@
             "additionalProperties": false,
             "properties": {
               "attempts": {
-                "$ref": "#/$defs/__schema14"
+                "$ref": "#/$defs/__schema18"
               },
               "cache": {
-                "$ref": "#/$defs/__schema27"
+                "$ref": "#/$defs/__schema30"
               },
               "executionStatus": {
                 "const": "completed",
                 "type": "string"
               },
               "output": {
-                "$ref": "#/$defs/__schema24"
+                "$ref": "#/$defs/__schema27"
               },
               "provenance": {
-                "$ref": "#/$defs/__schema13"
+                "$ref": "#/$defs/__schema17"
               },
               "randomizationSlotId": {
                 "$ref": "#/$defs/__schema1"
@@ -622,10 +710,10 @@
                 "$ref": "#/$defs/__schema1"
               },
               "timing": {
-                "$ref": "#/$defs/__schema17"
+                "$ref": "#/$defs/__schema21"
               },
               "trace": {
-                "$ref": "#/$defs/__schema23"
+                "$ref": "#/$defs/__schema26"
               },
               "trialId": {
                 "$ref": "#/$defs/__schema2"
@@ -637,7 +725,7 @@
                 "$ref": "#/$defs/__schema2"
               },
               "usage": {
-                "$ref": "#/$defs/__schema22"
+                "$ref": "#/$defs/__schema25"
               }
             },
             "required": [
@@ -662,20 +750,20 @@
             "additionalProperties": false,
             "properties": {
               "attempts": {
-                "$ref": "#/$defs/__schema14"
+                "$ref": "#/$defs/__schema18"
               },
               "cache": {
-                "$ref": "#/$defs/__schema27"
+                "$ref": "#/$defs/__schema30"
               },
               "error": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema24"
               },
               "executionStatus": {
                 "const": "failed",
                 "type": "string"
               },
               "provenance": {
-                "$ref": "#/$defs/__schema13"
+                "$ref": "#/$defs/__schema17"
               },
               "randomizationSlotId": {
                 "$ref": "#/$defs/__schema1"
@@ -696,10 +784,10 @@
                 "$ref": "#/$defs/__schema1"
               },
               "timing": {
-                "$ref": "#/$defs/__schema17"
+                "$ref": "#/$defs/__schema21"
               },
               "trace": {
-                "$ref": "#/$defs/__schema23"
+                "$ref": "#/$defs/__schema26"
               },
               "trialId": {
                 "$ref": "#/$defs/__schema2"
@@ -711,7 +799,7 @@
                 "$ref": "#/$defs/__schema2"
               },
               "usage": {
-                "$ref": "#/$defs/__schema22"
+                "$ref": "#/$defs/__schema25"
               }
             },
             "required": [
@@ -737,20 +825,20 @@
             "additionalProperties": false,
             "properties": {
               "attempts": {
-                "$ref": "#/$defs/__schema14"
+                "$ref": "#/$defs/__schema18"
               },
               "cache": {
-                "$ref": "#/$defs/__schema27"
+                "$ref": "#/$defs/__schema30"
               },
               "error": {
-                "$ref": "#/$defs/__schema21"
+                "$ref": "#/$defs/__schema24"
               },
               "executionStatus": {
                 "const": "cancelled",
                 "type": "string"
               },
               "provenance": {
-                "$ref": "#/$defs/__schema13"
+                "$ref": "#/$defs/__schema17"
               },
               "randomizationSlotId": {
                 "$ref": "#/$defs/__schema1"
@@ -771,10 +859,10 @@
                 "$ref": "#/$defs/__schema1"
               },
               "timing": {
-                "$ref": "#/$defs/__schema17"
+                "$ref": "#/$defs/__schema21"
               },
               "trace": {
-                "$ref": "#/$defs/__schema23"
+                "$ref": "#/$defs/__schema26"
               },
               "trialId": {
                 "$ref": "#/$defs/__schema2"
@@ -786,7 +874,7 @@
                 "$ref": "#/$defs/__schema2"
               },
               "usage": {
-                "$ref": "#/$defs/__schema22"
+                "$ref": "#/$defs/__schema25"
               }
             },
             "required": [
@@ -814,14 +902,14 @@
                 "$ref": "#/$defs/__schema1"
               },
               "censoredAt": {
-                "$ref": "#/$defs/__schema18"
+                "$ref": "#/$defs/__schema16"
               },
               "executionStatus": {
                 "const": "budget-censored",
                 "type": "string"
               },
               "provenance": {
-                "$ref": "#/$defs/__schema13"
+                "$ref": "#/$defs/__schema17"
               },
               "randomizationSlotId": {
                 "$ref": "#/$defs/__schema1"
@@ -919,10 +1007,10 @@
       "$ref": "#/$defs/__schema2"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema28"
+      "$ref": "#/$defs/__schema31"
     },
     "provenance": {
-      "$ref": "#/$defs/__schema13"
+      "$ref": "#/$defs/__schema17"
     },
     "records": {
       "$ref": "#/$defs/__schema7"

--- a/schemas/evaluation-core/v1/execution-plan.schema.json
+++ b/schemas/evaluation-core/v1/execution-plan.schema.json
@@ -168,14 +168,52 @@
                 ],
                 "type": "string"
               },
-              "implementationFacets": {
-                "$ref": "#/$defs/__schema5"
-              },
               "implementationId": {
                 "$ref": "#/$defs/__schema4"
               },
+              "implementationManifest": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/__schema15"
+                  },
+                  {
+                    "$ref": "#/$defs/__schema16"
+                  }
+                ]
+              },
               "provenanceFacets": {
-                "$ref": "#/$defs/__schema5"
+                "additionalProperties": false,
+                "properties": {
+                  "attestation": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "attestationDigest": {
+                        "$ref": "#/$defs/__schema1"
+                      },
+                      "attestorId": {
+                        "$ref": "#/$defs/__schema4"
+                      }
+                    },
+                    "required": [
+                      "attestationDigest"
+                    ],
+                    "type": "object"
+                  },
+                  "observation": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "observedAt": {
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+                        "type": "string"
+                      },
+                      "observerId": {
+                        "$ref": "#/$defs/__schema4"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
               },
               "version": {
                 "$ref": "#/$defs/__schema8"
@@ -186,7 +224,8 @@
               "fingerprint",
               "fingerprintBasis",
               "assuranceLevel",
-              "capabilities"
+              "capabilities",
+              "implementationManifest"
             ],
             "type": "object"
           },
@@ -214,6 +253,56 @@
       "type": "array"
     },
     "__schema15": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-complete",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coverageKind"
+      ],
+      "type": "object"
+    },
+    "__schema16": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-plus-facets",
+          "type": "string"
+        },
+        "facets": {
+          "items": {
+            "$ref": "#/$defs/__schema17"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "coverageKind",
+        "facets"
+      ],
+      "type": "object"
+    },
+    "__schema17": {
+      "additionalProperties": false,
+      "properties": {
+        "facetId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "value": {
+          "$ref": "#/$defs/__schema5"
+        }
+      },
+      "required": [
+        "facetId",
+        "value"
+      ],
+      "type": "object"
+    },
+    "__schema18": {
       "additionalProperties": false,
       "properties": {
         "budget": {
@@ -263,10 +352,10 @@
               "type": "string"
             },
             "output": {
-              "$ref": "#/$defs/__schema16"
+              "$ref": "#/$defs/__schema19"
             },
             "trace": {
-              "$ref": "#/$defs/__schema16"
+              "$ref": "#/$defs/__schema19"
             }
           },
           "required": [
@@ -386,7 +475,7 @@
       ],
       "type": "object"
     },
-    "__schema16": {
+    "__schema19": {
       "enum": [
         "full",
         "reference",
@@ -395,7 +484,14 @@
       ],
       "type": "string"
     },
-    "__schema17": {
+    "__schema2": {
+      "items": {
+        "$ref": "#/$defs/__schema3"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema20": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -406,7 +502,7 @@
             "$ref": "#/$defs/__schema1"
           },
           "schemaUri": {
-            "$ref": "#/$defs/__schema18"
+            "$ref": "#/$defs/__schema21"
           }
         },
         "required": [
@@ -417,20 +513,13 @@
         "type": "object"
       },
       "propertyNames": {
-        "$ref": "#/$defs/__schema18"
+        "$ref": "#/$defs/__schema21"
       },
       "type": "object"
     },
-    "__schema18": {
+    "__schema21": {
       "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
       "type": "string"
-    },
-    "__schema2": {
-      "items": {
-        "$ref": "#/$defs/__schema3"
-      },
-      "minItems": 1,
-      "type": "array"
     },
     "__schema3": {
       "additionalProperties": false,
@@ -554,10 +643,10 @@
       "$ref": "#/$defs/__schema11"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema17"
+      "$ref": "#/$defs/__schema20"
     },
     "policy": {
-      "$ref": "#/$defs/__schema15"
+      "$ref": "#/$defs/__schema18"
     },
     "randomizationDesignDigest": {
       "$ref": "#/$defs/__schema1"

--- a/schemas/evaluation-core/v1/execution-plan.schema.json
+++ b/schemas/evaluation-core/v1/execution-plan.schema.json
@@ -18,6 +18,13 @@
     "__schema11": {
       "additionalProperties": false,
       "properties": {
+        "randomizationSlots": {
+          "items": {
+            "$ref": "#/$defs/__schema13"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
         "sampling": {
           "additionalProperties": false,
           "properties": {
@@ -106,7 +113,8 @@
         "trials",
         "seed",
         "sampling",
-        "scheduling"
+        "scheduling",
+        "randomizationSlots"
       ],
       "type": "object"
     },
@@ -115,6 +123,22 @@
       "type": "string"
     },
     "__schema13": {
+      "additionalProperties": false,
+      "properties": {
+        "randomizationSlotId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "targetId": {
+          "$ref": "#/$defs/__schema4"
+        }
+      },
+      "required": [
+        "targetId",
+        "randomizationSlotId"
+      ],
+      "type": "object"
+    },
+    "__schema14": {
       "items": {
         "additionalProperties": false,
         "properties": {
@@ -143,6 +167,9 @@
                   "opaque"
                 ],
                 "type": "string"
+              },
+              "implementationFacets": {
+                "$ref": "#/$defs/__schema5"
               },
               "implementationId": {
                 "$ref": "#/$defs/__schema4"
@@ -186,7 +213,7 @@
       },
       "type": "array"
     },
-    "__schema14": {
+    "__schema15": {
       "additionalProperties": false,
       "properties": {
         "budget": {
@@ -236,10 +263,10 @@
               "type": "string"
             },
             "output": {
-              "$ref": "#/$defs/__schema15"
+              "$ref": "#/$defs/__schema16"
             },
             "trace": {
-              "$ref": "#/$defs/__schema15"
+              "$ref": "#/$defs/__schema16"
             }
           },
           "required": [
@@ -359,7 +386,7 @@
       ],
       "type": "object"
     },
-    "__schema15": {
+    "__schema16": {
       "enum": [
         "full",
         "reference",
@@ -368,7 +395,7 @@
       ],
       "type": "string"
     },
-    "__schema16": {
+    "__schema17": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -379,7 +406,7 @@
             "$ref": "#/$defs/__schema1"
           },
           "schemaUri": {
-            "$ref": "#/$defs/__schema17"
+            "$ref": "#/$defs/__schema18"
           }
         },
         "required": [
@@ -390,11 +417,11 @@
         "type": "object"
       },
       "propertyNames": {
-        "$ref": "#/$defs/__schema17"
+        "$ref": "#/$defs/__schema18"
       },
       "type": "object"
     },
-    "__schema17": {
+    "__schema18": {
       "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
       "type": "string"
     },
@@ -527,13 +554,16 @@
       "$ref": "#/$defs/__schema11"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema16"
+      "$ref": "#/$defs/__schema17"
     },
     "policy": {
-      "$ref": "#/$defs/__schema14"
+      "$ref": "#/$defs/__schema15"
+    },
+    "randomizationDesignDigest": {
+      "$ref": "#/$defs/__schema1"
     },
     "runtimes": {
-      "$ref": "#/$defs/__schema13"
+      "$ref": "#/$defs/__schema14"
     },
     "samples": {
       "$ref": "#/$defs/__schema2"
@@ -551,6 +581,7 @@
   "required": [
     "schemaVersion",
     "executionInputDigest",
+    "randomizationDesignDigest",
     "samples",
     "targets",
     "schedulingTargetGroups",

--- a/schemas/evaluation-core/v1/run-plan.schema.json
+++ b/schemas/evaluation-core/v1/run-plan.schema.json
@@ -8,16 +8,16 @@
       "additionalProperties": false,
       "properties": {
         "analysisGraph": {
-          "$ref": "#/$defs/__schema19"
+          "$ref": "#/$defs/__schema20"
         },
         "comparisons": {
-          "$ref": "#/$defs/__schema24"
+          "$ref": "#/$defs/__schema25"
         },
         "dataset": {
           "$ref": "#/$defs/__schema3"
         },
         "decisionPolicy": {
-          "$ref": "#/$defs/__schema26"
+          "$ref": "#/$defs/__schema27"
         },
         "evaluators": {
           "$ref": "#/$defs/__schema13"
@@ -26,7 +26,7 @@
           "$ref": "#/$defs/__schema18"
         },
         "extensions": {
-          "$ref": "#/$defs/__schema29"
+          "$ref": "#/$defs/__schema30"
         },
         "metrics": {
           "$ref": "#/$defs/__schema16"
@@ -242,6 +242,13 @@
     "__schema18": {
       "additionalProperties": false,
       "properties": {
+        "randomizationSlots": {
+          "items": {
+            "$ref": "#/$defs/__schema19"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
         "sampling": {
           "additionalProperties": false,
           "properties": {
@@ -330,11 +337,32 @@
         "trials",
         "seed",
         "sampling",
-        "scheduling"
+        "scheduling",
+        "randomizationSlots"
       ],
       "type": "object"
     },
     "__schema19": {
+      "additionalProperties": false,
+      "properties": {
+        "randomizationSlotId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "targetId": {
+          "$ref": "#/$defs/__schema4"
+        }
+      },
+      "required": [
+        "targetId",
+        "randomizationSlotId"
+      ],
+      "type": "object"
+    },
+    "__schema2": {
+      "const": "omk.evaluation-definition/v1",
+      "type": "string"
+    },
+    "__schema20": {
       "additionalProperties": false,
       "properties": {
         "analysisMode": {
@@ -358,7 +386,7 @@
                     "$ref": "#/$defs/__schema4"
                   },
                   "inputs": {
-                    "$ref": "#/$defs/__schema21"
+                    "$ref": "#/$defs/__schema22"
                   },
                   "nodeId": {
                     "$ref": "#/$defs/__schema4"
@@ -367,10 +395,10 @@
                     "$ref": "#/$defs/__schema4"
                   },
                   "parameters": {
-                    "$ref": "#/$defs/__schema23"
+                    "$ref": "#/$defs/__schema24"
                   },
                   "versionConstraint": {
-                    "$ref": "#/$defs/__schema20"
+                    "$ref": "#/$defs/__schema21"
                   }
                 },
                 "required": [
@@ -393,7 +421,7 @@
                     "$ref": "#/$defs/__schema4"
                   },
                   "inputs": {
-                    "$ref": "#/$defs/__schema21"
+                    "$ref": "#/$defs/__schema22"
                   },
                   "nodeId": {
                     "$ref": "#/$defs/__schema4"
@@ -402,10 +430,10 @@
                     "$ref": "#/$defs/__schema4"
                   },
                   "parameters": {
-                    "$ref": "#/$defs/__schema23"
+                    "$ref": "#/$defs/__schema24"
                   },
                   "versionConstraint": {
-                    "$ref": "#/$defs/__schema20"
+                    "$ref": "#/$defs/__schema21"
                   }
                 },
                 "required": [
@@ -428,7 +456,7 @@
                     "$ref": "#/$defs/__schema4"
                   },
                   "inputs": {
-                    "$ref": "#/$defs/__schema21"
+                    "$ref": "#/$defs/__schema22"
                   },
                   "nodeId": {
                     "$ref": "#/$defs/__schema4"
@@ -437,10 +465,10 @@
                     "$ref": "#/$defs/__schema4"
                   },
                   "parameters": {
-                    "$ref": "#/$defs/__schema23"
+                    "$ref": "#/$defs/__schema24"
                   },
                   "versionConstraint": {
-                    "$ref": "#/$defs/__schema20"
+                    "$ref": "#/$defs/__schema21"
                   }
                 },
                 "required": [
@@ -463,21 +491,17 @@
       ],
       "type": "object"
     },
-    "__schema2": {
-      "const": "omk.evaluation-definition/v1",
-      "type": "string"
-    },
-    "__schema20": {
+    "__schema21": {
       "$ref": "#/$defs/__schema12"
     },
-    "__schema21": {
+    "__schema22": {
       "items": {
-        "$ref": "#/$defs/__schema22"
+        "$ref": "#/$defs/__schema23"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema22": {
+    "__schema23": {
       "oneOf": [
         {
           "additionalProperties": false,
@@ -540,16 +564,16 @@
         }
       ]
     },
-    "__schema23": {
+    "__schema24": {
       "$ref": "#/$defs/__schema6"
     },
-    "__schema24": {
+    "__schema25": {
       "items": {
-        "$ref": "#/$defs/__schema25"
+        "$ref": "#/$defs/__schema26"
       },
       "type": "array"
     },
-    "__schema25": {
+    "__schema26": {
       "additionalProperties": false,
       "properties": {
         "comparisonId": {
@@ -581,10 +605,10 @@
       ],
       "type": "object"
     },
-    "__schema26": {
-      "$ref": "#/$defs/__schema27"
-    },
     "__schema27": {
+      "$ref": "#/$defs/__schema28"
+    },
+    "__schema28": {
       "additionalProperties": false,
       "properties": {
         "analysisResultIds": {
@@ -596,7 +620,7 @@
         },
         "comparisonFamily": {
           "items": {
-            "$ref": "#/$defs/__schema28"
+            "$ref": "#/$defs/__schema29"
           },
           "minItems": 1,
           "type": "array"
@@ -633,7 +657,7 @@
       ],
       "type": "object"
     },
-    "__schema28": {
+    "__schema29": {
       "anyOf": [
         {
           "additionalProperties": false,
@@ -689,9 +713,6 @@
         }
       ]
     },
-    "__schema29": {
-      "$ref": "#/$defs/__schema30"
-    },
     "__schema3": {
       "additionalProperties": false,
       "properties": {
@@ -716,6 +737,9 @@
       "type": "object"
     },
     "__schema30": {
+      "$ref": "#/$defs/__schema31"
+    },
+    "__schema31": {
       "additionalProperties": {
         "additionalProperties": false,
         "properties": {
@@ -723,10 +747,10 @@
             "$ref": "#/$defs/__schema6"
           },
           "schemaDigest": {
-            "$ref": "#/$defs/__schema32"
+            "$ref": "#/$defs/__schema33"
           },
           "schemaUri": {
-            "$ref": "#/$defs/__schema31"
+            "$ref": "#/$defs/__schema32"
           }
         },
         "required": [
@@ -737,50 +761,50 @@
         "type": "object"
       },
       "propertyNames": {
-        "$ref": "#/$defs/__schema31"
+        "$ref": "#/$defs/__schema32"
       },
       "type": "object"
     },
-    "__schema31": {
+    "__schema32": {
       "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
       "type": "string"
     },
-    "__schema32": {
+    "__schema33": {
       "pattern": "^sha256:[0-9a-f]{64}$",
       "type": "string"
     },
-    "__schema33": {
+    "__schema34": {
       "additionalProperties": false,
       "properties": {
         "budget": {
-          "$ref": "#/$defs/__schema37"
-        },
-        "cache": {
-          "$ref": "#/$defs/__schema39"
-        },
-        "evaluation": {
           "$ref": "#/$defs/__schema38"
         },
+        "cache": {
+          "$ref": "#/$defs/__schema40"
+        },
+        "evaluation": {
+          "$ref": "#/$defs/__schema39"
+        },
         "eventDelivery": {
-          "$ref": "#/$defs/__schema46"
-        },
-        "evidence": {
-          "$ref": "#/$defs/__schema42"
-        },
-        "execution": {
-          "$ref": "#/$defs/__schema35"
-        },
-        "extensions": {
           "$ref": "#/$defs/__schema47"
         },
-        "failure": {
-          "$ref": "#/$defs/__schema45"
+        "evidence": {
+          "$ref": "#/$defs/__schema43"
         },
-        "retry": {
+        "execution": {
           "$ref": "#/$defs/__schema36"
         },
+        "extensions": {
+          "$ref": "#/$defs/__schema48"
+        },
+        "failure": {
+          "$ref": "#/$defs/__schema46"
+        },
+        "retry": {
+          "$ref": "#/$defs/__schema37"
+        },
         "schemaVersion": {
-          "$ref": "#/$defs/__schema34"
+          "$ref": "#/$defs/__schema35"
         }
       },
       "required": [
@@ -797,11 +821,11 @@
       "title": "OMK Measurement Policy v1",
       "type": "object"
     },
-    "__schema34": {
+    "__schema35": {
       "const": "omk.measurement-policy/v1",
       "type": "string"
     },
-    "__schema35": {
+    "__schema36": {
       "additionalProperties": false,
       "properties": {
         "maxConcurrency": {
@@ -820,7 +844,7 @@
       ],
       "type": "object"
     },
-    "__schema36": {
+    "__schema37": {
       "additionalProperties": false,
       "properties": {
         "backoff": {
@@ -870,7 +894,7 @@
       ],
       "type": "object"
     },
-    "__schema37": {
+    "__schema38": {
       "additionalProperties": false,
       "properties": {
         "maxDurationMs": {
@@ -904,7 +928,7 @@
       },
       "type": "object"
     },
-    "__schema38": {
+    "__schema39": {
       "additionalProperties": false,
       "properties": {
         "budget": {
@@ -947,7 +971,7 @@
           "type": "integer"
         },
         "retry": {
-          "$ref": "#/$defs/__schema36"
+          "$ref": "#/$defs/__schema37"
         },
         "timeoutMs": {
           "exclusiveMinimum": 0,
@@ -962,14 +986,19 @@
       ],
       "type": "object"
     },
-    "__schema39": {
+    "__schema4": {
+      "maxLength": 256,
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema40": {
       "additionalProperties": false,
       "properties": {
         "evaluationMode": {
-          "$ref": "#/$defs/__schema41"
+          "$ref": "#/$defs/__schema42"
         },
         "executionMode": {
-          "$ref": "#/$defs/__schema40"
+          "$ref": "#/$defs/__schema41"
         }
       },
       "required": [
@@ -978,12 +1007,7 @@
       ],
       "type": "object"
     },
-    "__schema4": {
-      "maxLength": 256,
-      "minLength": 1,
-      "type": "string"
-    },
-    "__schema40": {
+    "__schema41": {
       "enum": [
         "disabled",
         "replay-only",
@@ -991,33 +1015,33 @@
       ],
       "type": "string"
     },
-    "__schema41": {
+    "__schema42": {
       "enum": [
         "disabled",
         "reuse"
       ],
       "type": "string"
     },
-    "__schema42": {
+    "__schema43": {
       "additionalProperties": false,
       "properties": {
         "evidence": {
-          "$ref": "#/$defs/__schema43"
-        },
-        "expected": {
-          "$ref": "#/$defs/__schema43"
-        },
-        "input": {
-          "$ref": "#/$defs/__schema43"
-        },
-        "maximumClassification": {
           "$ref": "#/$defs/__schema44"
         },
+        "expected": {
+          "$ref": "#/$defs/__schema44"
+        },
+        "input": {
+          "$ref": "#/$defs/__schema44"
+        },
+        "maximumClassification": {
+          "$ref": "#/$defs/__schema45"
+        },
         "output": {
-          "$ref": "#/$defs/__schema43"
+          "$ref": "#/$defs/__schema44"
         },
         "trace": {
-          "$ref": "#/$defs/__schema43"
+          "$ref": "#/$defs/__schema44"
         }
       },
       "required": [
@@ -1030,7 +1054,7 @@
       ],
       "type": "object"
     },
-    "__schema43": {
+    "__schema44": {
       "enum": [
         "full",
         "reference",
@@ -1039,7 +1063,7 @@
       ],
       "type": "string"
     },
-    "__schema44": {
+    "__schema45": {
       "enum": [
         "public",
         "sensitive",
@@ -1048,7 +1072,7 @@
       ],
       "type": "string"
     },
-    "__schema45": {
+    "__schema46": {
       "additionalProperties": false,
       "properties": {
         "failureMode": {
@@ -1070,7 +1094,7 @@
       ],
       "type": "object"
     },
-    "__schema46": {
+    "__schema47": {
       "additionalProperties": false,
       "properties": {
         "backpressureMode": {
@@ -1102,46 +1126,50 @@
       ],
       "type": "object"
     },
-    "__schema47": {
-      "$ref": "#/$defs/__schema30"
-    },
     "__schema48": {
+      "$ref": "#/$defs/__schema31"
+    },
+    "__schema49": {
       "additionalProperties": false,
       "properties": {
         "executionInputDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "executionPlanDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "experiment": {
           "$ref": "#/$defs/__schema18"
         },
         "extensions": {
-          "$ref": "#/$defs/__schema58"
+          "$ref": "#/$defs/__schema59"
         },
         "policy": {
-          "$ref": "#/$defs/__schema57"
+          "$ref": "#/$defs/__schema58"
+        },
+        "randomizationDesignDigest": {
+          "$ref": "#/$defs/__schema33"
         },
         "runtimes": {
-          "$ref": "#/$defs/__schema55"
+          "$ref": "#/$defs/__schema56"
         },
         "samples": {
-          "$ref": "#/$defs/__schema50"
+          "$ref": "#/$defs/__schema51"
         },
         "schedulingTargetGroups": {
-          "$ref": "#/$defs/__schema53"
+          "$ref": "#/$defs/__schema54"
         },
         "schemaVersion": {
-          "$ref": "#/$defs/__schema49"
+          "$ref": "#/$defs/__schema50"
         },
         "targets": {
-          "$ref": "#/$defs/__schema52"
+          "$ref": "#/$defs/__schema53"
         }
       },
       "required": [
         "schemaVersion",
         "executionInputDigest",
+        "randomizationDesignDigest",
         "samples",
         "targets",
         "schedulingTargetGroups",
@@ -1152,10 +1180,6 @@
       ],
       "title": "OMK Execution Plan v1",
       "type": "object"
-    },
-    "__schema49": {
-      "const": "omk.execution-plan/v1",
-      "type": "string"
     },
     "__schema5": {
       "additionalProperties": false,
@@ -1186,13 +1210,17 @@
       "type": "object"
     },
     "__schema50": {
+      "const": "omk.execution-plan/v1",
+      "type": "string"
+    },
+    "__schema51": {
       "items": {
-        "$ref": "#/$defs/__schema51"
+        "$ref": "#/$defs/__schema52"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema51": {
+    "__schema52": {
       "additionalProperties": false,
       "properties": {
         "executionContext": {
@@ -1211,34 +1239,34 @@
       ],
       "type": "object"
     },
-    "__schema52": {
+    "__schema53": {
       "items": {
         "$ref": "#/$defs/__schema11"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema53": {
-      "items": {
-        "$ref": "#/$defs/__schema54"
-      },
-      "minItems": 1,
-      "type": "array"
-    },
     "__schema54": {
       "items": {
-        "$ref": "#/$defs/__schema4"
+        "$ref": "#/$defs/__schema55"
       },
       "minItems": 1,
       "type": "array"
     },
     "__schema55": {
       "items": {
-        "$ref": "#/$defs/__schema56"
+        "$ref": "#/$defs/__schema4"
       },
+      "minItems": 1,
       "type": "array"
     },
     "__schema56": {
+      "items": {
+        "$ref": "#/$defs/__schema57"
+      },
+      "type": "array"
+    },
+    "__schema57": {
       "additionalProperties": false,
       "properties": {
         "identity": {
@@ -1266,6 +1294,9 @@
                 "opaque"
               ],
               "type": "string"
+            },
+            "implementationFacets": {
+              "$ref": "#/$defs/__schema6"
             },
             "implementationId": {
               "$ref": "#/$defs/__schema4"
@@ -1307,23 +1338,23 @@
       ],
       "type": "object"
     },
-    "__schema57": {
+    "__schema58": {
       "additionalProperties": false,
       "properties": {
         "budget": {
-          "$ref": "#/$defs/__schema37"
+          "$ref": "#/$defs/__schema38"
         },
         "evidence": {
           "additionalProperties": false,
           "properties": {
             "maximumClassification": {
-              "$ref": "#/$defs/__schema44"
+              "$ref": "#/$defs/__schema45"
             },
             "output": {
-              "$ref": "#/$defs/__schema43"
+              "$ref": "#/$defs/__schema44"
             },
             "trace": {
-              "$ref": "#/$defs/__schema43"
+              "$ref": "#/$defs/__schema44"
             }
           },
           "required": [
@@ -1334,16 +1365,16 @@
           "type": "object"
         },
         "execution": {
-          "$ref": "#/$defs/__schema35"
+          "$ref": "#/$defs/__schema36"
         },
         "executionCacheMode": {
-          "$ref": "#/$defs/__schema40"
+          "$ref": "#/$defs/__schema41"
         },
         "failure": {
-          "$ref": "#/$defs/__schema45"
+          "$ref": "#/$defs/__schema46"
         },
         "retry": {
-          "$ref": "#/$defs/__schema36"
+          "$ref": "#/$defs/__schema37"
         }
       },
       "required": [
@@ -1356,56 +1387,8 @@
       ],
       "type": "object"
     },
-    "__schema58": {
-      "$ref": "#/$defs/__schema30"
-    },
     "__schema59": {
-      "additionalProperties": false,
-      "properties": {
-        "evaluationInputDigest": {
-          "$ref": "#/$defs/__schema32"
-        },
-        "evaluationPlanDigest": {
-          "$ref": "#/$defs/__schema32"
-        },
-        "evaluators": {
-          "$ref": "#/$defs/__schema63"
-        },
-        "executionPlanDigest": {
-          "$ref": "#/$defs/__schema32"
-        },
-        "extensions": {
-          "$ref": "#/$defs/__schema67"
-        },
-        "metrics": {
-          "$ref": "#/$defs/__schema64"
-        },
-        "policy": {
-          "$ref": "#/$defs/__schema66"
-        },
-        "runtimes": {
-          "$ref": "#/$defs/__schema65"
-        },
-        "samples": {
-          "$ref": "#/$defs/__schema61"
-        },
-        "schemaVersion": {
-          "$ref": "#/$defs/__schema60"
-        }
-      },
-      "required": [
-        "schemaVersion",
-        "executionPlanDigest",
-        "evaluationInputDigest",
-        "samples",
-        "evaluators",
-        "metrics",
-        "runtimes",
-        "policy",
-        "evaluationPlanDigest"
-      ],
-      "title": "OMK Evaluation Plan v1",
-      "type": "object"
+      "$ref": "#/$defs/__schema31"
     },
     "__schema6": {
       "anyOf": [
@@ -1439,17 +1422,65 @@
       ]
     },
     "__schema60": {
+      "additionalProperties": false,
+      "properties": {
+        "evaluationInputDigest": {
+          "$ref": "#/$defs/__schema33"
+        },
+        "evaluationPlanDigest": {
+          "$ref": "#/$defs/__schema33"
+        },
+        "evaluators": {
+          "$ref": "#/$defs/__schema64"
+        },
+        "executionPlanDigest": {
+          "$ref": "#/$defs/__schema33"
+        },
+        "extensions": {
+          "$ref": "#/$defs/__schema68"
+        },
+        "metrics": {
+          "$ref": "#/$defs/__schema65"
+        },
+        "policy": {
+          "$ref": "#/$defs/__schema67"
+        },
+        "runtimes": {
+          "$ref": "#/$defs/__schema66"
+        },
+        "samples": {
+          "$ref": "#/$defs/__schema62"
+        },
+        "schemaVersion": {
+          "$ref": "#/$defs/__schema61"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "executionPlanDigest",
+        "evaluationInputDigest",
+        "samples",
+        "evaluators",
+        "metrics",
+        "runtimes",
+        "policy",
+        "evaluationPlanDigest"
+      ],
+      "title": "OMK Evaluation Plan v1",
+      "type": "object"
+    },
+    "__schema61": {
       "const": "omk.evaluation-plan/v1",
       "type": "string"
     },
-    "__schema61": {
+    "__schema62": {
       "items": {
-        "$ref": "#/$defs/__schema62"
+        "$ref": "#/$defs/__schema63"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema62": {
+    "__schema63": {
       "additionalProperties": false,
       "properties": {
         "evaluationContext": {
@@ -1474,38 +1505,38 @@
       ],
       "type": "object"
     },
-    "__schema63": {
+    "__schema64": {
       "items": {
         "$ref": "#/$defs/__schema14"
       },
       "type": "array"
     },
-    "__schema64": {
+    "__schema65": {
       "items": {
         "$ref": "#/$defs/__schema17"
       },
       "type": "array"
     },
-    "__schema65": {
+    "__schema66": {
       "items": {
-        "$ref": "#/$defs/__schema56"
+        "$ref": "#/$defs/__schema57"
       },
       "type": "array"
     },
-    "__schema66": {
+    "__schema67": {
       "additionalProperties": false,
       "properties": {
         "evaluationCacheMode": {
-          "$ref": "#/$defs/__schema41"
-        },
-        "evidence": {
           "$ref": "#/$defs/__schema42"
         },
+        "evidence": {
+          "$ref": "#/$defs/__schema43"
+        },
         "failure": {
-          "$ref": "#/$defs/__schema45"
+          "$ref": "#/$defs/__schema46"
         },
         "runtime": {
-          "$ref": "#/$defs/__schema38"
+          "$ref": "#/$defs/__schema39"
         }
       },
       "required": [
@@ -1516,38 +1547,38 @@
       ],
       "type": "object"
     },
-    "__schema67": {
-      "$ref": "#/$defs/__schema30"
-    },
     "__schema68": {
+      "$ref": "#/$defs/__schema31"
+    },
+    "__schema69": {
       "additionalProperties": false,
       "properties": {
         "analysisGraph": {
-          "$ref": "#/$defs/__schema19"
+          "$ref": "#/$defs/__schema20"
         },
         "analysisPlanDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "comparisons": {
-          "$ref": "#/$defs/__schema71"
+          "$ref": "#/$defs/__schema72"
         },
         "evaluationPlanDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "experiment": {
           "$ref": "#/$defs/__schema18"
         },
         "extensions": {
-          "$ref": "#/$defs/__schema73"
+          "$ref": "#/$defs/__schema74"
         },
         "metrics": {
-          "$ref": "#/$defs/__schema70"
+          "$ref": "#/$defs/__schema71"
         },
         "runtimes": {
-          "$ref": "#/$defs/__schema72"
+          "$ref": "#/$defs/__schema73"
         },
         "schemaVersion": {
-          "$ref": "#/$defs/__schema69"
+          "$ref": "#/$defs/__schema70"
         }
       },
       "required": [
@@ -1563,54 +1594,54 @@
       "title": "OMK Analysis Plan v1",
       "type": "object"
     },
-    "__schema69": {
-      "const": "omk.analysis-plan/v1",
-      "type": "string"
-    },
     "__schema7": {
       "$ref": "#/$defs/__schema6"
     },
     "__schema70": {
+      "const": "omk.analysis-plan/v1",
+      "type": "string"
+    },
+    "__schema71": {
       "items": {
         "$ref": "#/$defs/__schema17"
       },
       "type": "array"
     },
-    "__schema71": {
-      "items": {
-        "$ref": "#/$defs/__schema25"
-      },
-      "type": "array"
-    },
     "__schema72": {
       "items": {
-        "$ref": "#/$defs/__schema56"
+        "$ref": "#/$defs/__schema26"
       },
       "type": "array"
     },
     "__schema73": {
-      "$ref": "#/$defs/__schema30"
+      "items": {
+        "$ref": "#/$defs/__schema57"
+      },
+      "type": "array"
     },
     "__schema74": {
+      "$ref": "#/$defs/__schema31"
+    },
+    "__schema75": {
       "additionalProperties": false,
       "properties": {
         "analysisPlanDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "decisionPlanDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "decisionPolicy": {
-          "$ref": "#/$defs/__schema76"
-        },
-        "extensions": {
-          "$ref": "#/$defs/__schema78"
-        },
-        "runtimes": {
           "$ref": "#/$defs/__schema77"
         },
+        "extensions": {
+          "$ref": "#/$defs/__schema79"
+        },
+        "runtimes": {
+          "$ref": "#/$defs/__schema78"
+        },
         "schemaVersion": {
-          "$ref": "#/$defs/__schema75"
+          "$ref": "#/$defs/__schema76"
         }
       },
       "required": [
@@ -1622,40 +1653,40 @@
       "title": "OMK Decision Plan v1",
       "type": "object"
     },
-    "__schema75": {
+    "__schema76": {
       "const": "omk.decision-plan/v1",
       "type": "string"
     },
-    "__schema76": {
-      "$ref": "#/$defs/__schema27"
-    },
     "__schema77": {
-      "items": {
-        "$ref": "#/$defs/__schema56"
-      },
-      "type": "array"
+      "$ref": "#/$defs/__schema28"
     },
     "__schema78": {
-      "$ref": "#/$defs/__schema30"
+      "items": {
+        "$ref": "#/$defs/__schema57"
+      },
+      "type": "array"
     },
     "__schema79": {
-      "items": {
-        "$ref": "#/$defs/__schema80"
-      },
-      "minItems": 1,
-      "type": "array"
+      "$ref": "#/$defs/__schema31"
     },
     "__schema8": {
       "$ref": "#/$defs/__schema6"
     },
     "__schema80": {
+      "items": {
+        "$ref": "#/$defs/__schema81"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema81": {
       "additionalProperties": false,
       "properties": {
         "schemaDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "schemaUri": {
-          "$ref": "#/$defs/__schema31"
+          "$ref": "#/$defs/__schema32"
         },
         "schemaVersion": {
           "$ref": "#/$defs/__schema12"
@@ -1668,38 +1699,42 @@
       ],
       "type": "object"
     },
-    "__schema81": {
+    "__schema82": {
       "additionalProperties": false,
       "properties": {
         "analysisPlanDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "datasetRevisionDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "decisionPlanDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "evaluationInputDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "evaluationPlanDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "executionInputDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         },
         "executionPlanDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
+        },
+        "randomizationDesignDigest": {
+          "$ref": "#/$defs/__schema33"
         },
         "runContractDigest": {
-          "$ref": "#/$defs/__schema32"
+          "$ref": "#/$defs/__schema33"
         }
       },
       "required": [
         "datasetRevisionDigest",
         "executionInputDigest",
         "evaluationInputDigest",
+        "randomizationDesignDigest",
         "executionPlanDigest",
         "evaluationPlanDigest",
         "analysisPlanDigest",
@@ -1708,8 +1743,8 @@
       ],
       "type": "object"
     },
-    "__schema82": {
-      "$ref": "#/$defs/__schema30"
+    "__schema83": {
+      "$ref": "#/$defs/__schema31"
     },
     "__schema9": {
       "$ref": "#/$defs/__schema6"
@@ -1720,31 +1755,31 @@
   "additionalProperties": false,
   "properties": {
     "analysis": {
-      "$ref": "#/$defs/__schema68"
+      "$ref": "#/$defs/__schema69"
     },
     "decision": {
-      "$ref": "#/$defs/__schema74"
+      "$ref": "#/$defs/__schema75"
     },
     "definition": {
       "$ref": "#/$defs/__schema1"
     },
     "digests": {
-      "$ref": "#/$defs/__schema81"
-    },
-    "evaluation": {
-      "$ref": "#/$defs/__schema59"
-    },
-    "execution": {
-      "$ref": "#/$defs/__schema48"
-    },
-    "extensions": {
       "$ref": "#/$defs/__schema82"
     },
+    "evaluation": {
+      "$ref": "#/$defs/__schema60"
+    },
+    "execution": {
+      "$ref": "#/$defs/__schema49"
+    },
+    "extensions": {
+      "$ref": "#/$defs/__schema83"
+    },
     "measurementPolicy": {
-      "$ref": "#/$defs/__schema33"
+      "$ref": "#/$defs/__schema34"
     },
     "schemaIdentities": {
-      "$ref": "#/$defs/__schema79"
+      "$ref": "#/$defs/__schema80"
     },
     "schemaVersion": {
       "$ref": "#/$defs/__schema0"

--- a/schemas/evaluation-core/v1/run-plan.schema.json
+++ b/schemas/evaluation-core/v1/run-plan.schema.json
@@ -1142,10 +1142,10 @@
           "$ref": "#/$defs/__schema18"
         },
         "extensions": {
-          "$ref": "#/$defs/__schema59"
+          "$ref": "#/$defs/__schema62"
         },
         "policy": {
-          "$ref": "#/$defs/__schema58"
+          "$ref": "#/$defs/__schema61"
         },
         "randomizationDesignDigest": {
           "$ref": "#/$defs/__schema33"
@@ -1295,14 +1295,52 @@
               ],
               "type": "string"
             },
-            "implementationFacets": {
-              "$ref": "#/$defs/__schema6"
-            },
             "implementationId": {
               "$ref": "#/$defs/__schema4"
             },
+            "implementationManifest": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/__schema58"
+                },
+                {
+                  "$ref": "#/$defs/__schema59"
+                }
+              ]
+            },
             "provenanceFacets": {
-              "$ref": "#/$defs/__schema6"
+              "additionalProperties": false,
+              "properties": {
+                "attestation": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "attestationDigest": {
+                      "$ref": "#/$defs/__schema33"
+                    },
+                    "attestorId": {
+                      "$ref": "#/$defs/__schema4"
+                    }
+                  },
+                  "required": [
+                    "attestationDigest"
+                  ],
+                  "type": "object"
+                },
+                "observation": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "observedAt": {
+                      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$",
+                      "type": "string"
+                    },
+                    "observerId": {
+                      "$ref": "#/$defs/__schema4"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             },
             "version": {
               "$ref": "#/$defs/__schema12"
@@ -1313,7 +1351,8 @@
             "fingerprint",
             "fingerprintBasis",
             "assuranceLevel",
-            "capabilities"
+            "capabilities",
+            "implementationManifest"
           ],
           "type": "object"
         },
@@ -1339,6 +1378,87 @@
       "type": "object"
     },
     "__schema58": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-complete",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coverageKind"
+      ],
+      "type": "object"
+    },
+    "__schema59": {
+      "additionalProperties": false,
+      "properties": {
+        "coverageKind": {
+          "const": "fingerprint-plus-facets",
+          "type": "string"
+        },
+        "facets": {
+          "items": {
+            "$ref": "#/$defs/__schema60"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "coverageKind",
+        "facets"
+      ],
+      "type": "object"
+    },
+    "__schema6": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema6"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema6"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema60": {
+      "additionalProperties": false,
+      "properties": {
+        "facetId": {
+          "$ref": "#/$defs/__schema4"
+        },
+        "value": {
+          "$ref": "#/$defs/__schema6"
+        }
+      },
+      "required": [
+        "facetId",
+        "value"
+      ],
+      "type": "object"
+    },
+    "__schema61": {
       "additionalProperties": false,
       "properties": {
         "budget": {
@@ -1387,41 +1507,10 @@
       ],
       "type": "object"
     },
-    "__schema59": {
+    "__schema62": {
       "$ref": "#/$defs/__schema31"
     },
-    "__schema6": {
-      "anyOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "number"
-        },
-        {
-          "type": "string"
-        },
-        {
-          "items": {
-            "$ref": "#/$defs/__schema6"
-          },
-          "type": "array"
-        },
-        {
-          "additionalProperties": {
-            "$ref": "#/$defs/__schema6"
-          },
-          "propertyNames": {
-            "type": "string"
-          },
-          "type": "object"
-        }
-      ]
-    },
-    "__schema60": {
+    "__schema63": {
       "additionalProperties": false,
       "properties": {
         "evaluationInputDigest": {
@@ -1431,28 +1520,28 @@
           "$ref": "#/$defs/__schema33"
         },
         "evaluators": {
-          "$ref": "#/$defs/__schema64"
+          "$ref": "#/$defs/__schema67"
         },
         "executionPlanDigest": {
           "$ref": "#/$defs/__schema33"
         },
         "extensions": {
-          "$ref": "#/$defs/__schema68"
+          "$ref": "#/$defs/__schema71"
         },
         "metrics": {
-          "$ref": "#/$defs/__schema65"
+          "$ref": "#/$defs/__schema68"
         },
         "policy": {
-          "$ref": "#/$defs/__schema67"
+          "$ref": "#/$defs/__schema70"
         },
         "runtimes": {
-          "$ref": "#/$defs/__schema66"
+          "$ref": "#/$defs/__schema69"
         },
         "samples": {
-          "$ref": "#/$defs/__schema62"
+          "$ref": "#/$defs/__schema65"
         },
         "schemaVersion": {
-          "$ref": "#/$defs/__schema61"
+          "$ref": "#/$defs/__schema64"
         }
       },
       "required": [
@@ -1469,18 +1558,18 @@
       "title": "OMK Evaluation Plan v1",
       "type": "object"
     },
-    "__schema61": {
+    "__schema64": {
       "const": "omk.evaluation-plan/v1",
       "type": "string"
     },
-    "__schema62": {
+    "__schema65": {
       "items": {
-        "$ref": "#/$defs/__schema63"
+        "$ref": "#/$defs/__schema66"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema63": {
+    "__schema66": {
       "additionalProperties": false,
       "properties": {
         "evaluationContext": {
@@ -1505,25 +1594,28 @@
       ],
       "type": "object"
     },
-    "__schema64": {
+    "__schema67": {
       "items": {
         "$ref": "#/$defs/__schema14"
       },
       "type": "array"
     },
-    "__schema65": {
+    "__schema68": {
       "items": {
         "$ref": "#/$defs/__schema17"
       },
       "type": "array"
     },
-    "__schema66": {
+    "__schema69": {
       "items": {
         "$ref": "#/$defs/__schema57"
       },
       "type": "array"
     },
-    "__schema67": {
+    "__schema7": {
+      "$ref": "#/$defs/__schema6"
+    },
+    "__schema70": {
       "additionalProperties": false,
       "properties": {
         "evaluationCacheMode": {
@@ -1547,10 +1639,10 @@
       ],
       "type": "object"
     },
-    "__schema68": {
+    "__schema71": {
       "$ref": "#/$defs/__schema31"
     },
-    "__schema69": {
+    "__schema72": {
       "additionalProperties": false,
       "properties": {
         "analysisGraph": {
@@ -1560,7 +1652,7 @@
           "$ref": "#/$defs/__schema33"
         },
         "comparisons": {
-          "$ref": "#/$defs/__schema72"
+          "$ref": "#/$defs/__schema75"
         },
         "evaluationPlanDigest": {
           "$ref": "#/$defs/__schema33"
@@ -1569,16 +1661,16 @@
           "$ref": "#/$defs/__schema18"
         },
         "extensions": {
-          "$ref": "#/$defs/__schema74"
+          "$ref": "#/$defs/__schema77"
         },
         "metrics": {
-          "$ref": "#/$defs/__schema71"
+          "$ref": "#/$defs/__schema74"
         },
         "runtimes": {
-          "$ref": "#/$defs/__schema73"
+          "$ref": "#/$defs/__schema76"
         },
         "schemaVersion": {
-          "$ref": "#/$defs/__schema70"
+          "$ref": "#/$defs/__schema73"
         }
       },
       "required": [
@@ -1594,35 +1686,32 @@
       "title": "OMK Analysis Plan v1",
       "type": "object"
     },
-    "__schema7": {
-      "$ref": "#/$defs/__schema6"
-    },
-    "__schema70": {
+    "__schema73": {
       "const": "omk.analysis-plan/v1",
       "type": "string"
     },
-    "__schema71": {
+    "__schema74": {
       "items": {
         "$ref": "#/$defs/__schema17"
       },
       "type": "array"
     },
-    "__schema72": {
+    "__schema75": {
       "items": {
         "$ref": "#/$defs/__schema26"
       },
       "type": "array"
     },
-    "__schema73": {
+    "__schema76": {
       "items": {
         "$ref": "#/$defs/__schema57"
       },
       "type": "array"
     },
-    "__schema74": {
+    "__schema77": {
       "$ref": "#/$defs/__schema31"
     },
-    "__schema75": {
+    "__schema78": {
       "additionalProperties": false,
       "properties": {
         "analysisPlanDigest": {
@@ -1632,16 +1721,16 @@
           "$ref": "#/$defs/__schema33"
         },
         "decisionPolicy": {
-          "$ref": "#/$defs/__schema77"
+          "$ref": "#/$defs/__schema80"
         },
         "extensions": {
-          "$ref": "#/$defs/__schema79"
+          "$ref": "#/$defs/__schema82"
         },
         "runtimes": {
-          "$ref": "#/$defs/__schema78"
+          "$ref": "#/$defs/__schema81"
         },
         "schemaVersion": {
-          "$ref": "#/$defs/__schema76"
+          "$ref": "#/$defs/__schema79"
         }
       },
       "required": [
@@ -1653,33 +1742,33 @@
       "title": "OMK Decision Plan v1",
       "type": "object"
     },
-    "__schema76": {
+    "__schema79": {
       "const": "omk.decision-plan/v1",
       "type": "string"
-    },
-    "__schema77": {
-      "$ref": "#/$defs/__schema28"
-    },
-    "__schema78": {
-      "items": {
-        "$ref": "#/$defs/__schema57"
-      },
-      "type": "array"
-    },
-    "__schema79": {
-      "$ref": "#/$defs/__schema31"
     },
     "__schema8": {
       "$ref": "#/$defs/__schema6"
     },
     "__schema80": {
+      "$ref": "#/$defs/__schema28"
+    },
+    "__schema81": {
       "items": {
-        "$ref": "#/$defs/__schema81"
+        "$ref": "#/$defs/__schema57"
+      },
+      "type": "array"
+    },
+    "__schema82": {
+      "$ref": "#/$defs/__schema31"
+    },
+    "__schema83": {
+      "items": {
+        "$ref": "#/$defs/__schema84"
       },
       "minItems": 1,
       "type": "array"
     },
-    "__schema81": {
+    "__schema84": {
       "additionalProperties": false,
       "properties": {
         "schemaDigest": {
@@ -1699,7 +1788,7 @@
       ],
       "type": "object"
     },
-    "__schema82": {
+    "__schema85": {
       "additionalProperties": false,
       "properties": {
         "analysisPlanDigest": {
@@ -1743,7 +1832,7 @@
       ],
       "type": "object"
     },
-    "__schema83": {
+    "__schema86": {
       "$ref": "#/$defs/__schema31"
     },
     "__schema9": {
@@ -1755,31 +1844,31 @@
   "additionalProperties": false,
   "properties": {
     "analysis": {
-      "$ref": "#/$defs/__schema69"
+      "$ref": "#/$defs/__schema72"
     },
     "decision": {
-      "$ref": "#/$defs/__schema75"
+      "$ref": "#/$defs/__schema78"
     },
     "definition": {
       "$ref": "#/$defs/__schema1"
     },
     "digests": {
-      "$ref": "#/$defs/__schema82"
+      "$ref": "#/$defs/__schema85"
     },
     "evaluation": {
-      "$ref": "#/$defs/__schema60"
+      "$ref": "#/$defs/__schema63"
     },
     "execution": {
       "$ref": "#/$defs/__schema49"
     },
     "extensions": {
-      "$ref": "#/$defs/__schema83"
+      "$ref": "#/$defs/__schema86"
     },
     "measurementPolicy": {
       "$ref": "#/$defs/__schema34"
     },
     "schemaIdentities": {
-      "$ref": "#/$defs/__schema80"
+      "$ref": "#/$defs/__schema83"
     },
     "schemaVersion": {
       "$ref": "#/$defs/__schema0"

--- a/src/evaluation-core/analysis/builtins.ts
+++ b/src/evaluation-core/analysis/builtins.ts
@@ -198,6 +198,7 @@ function runtimeIdentity(
     fingerprintBasis: 'self-reported',
     assuranceLevel: 'declared',
     capabilities,
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
   };
 }
 

--- a/src/evaluation-core/compiler/index.ts
+++ b/src/evaluation-core/compiler/index.ts
@@ -76,7 +76,7 @@ const CONTRACT_PATH_SEGMENTS = new Set([
   'scope', 'scale', 'min', 'max', 'target', 'unit', 'direction', 'missingPolicyId',
   'experiment', 'trials', 'seed', 'sampling', 'experimentalUnit', 'pairingKey',
   'clusterKey', 'stratumKey', 'repeatedMeasures', 'resamplingUnit', 'estimatorId',
-  'seedCoupling', 'schedulingTargetGroups',
+  'seedCoupling', 'randomizationSlots', 'randomizationSlotId', 'schedulingTargetGroups',
   'scheduling', 'schedulingKind', 'blockSize', 'analysisGraph', 'analysisMode', 'nodes', 'nodeId',
   'analysisNodeKind', 'inputKind', 'referenceId', 'outputResultId', 'parameters',
   'comparisons', 'comparisonId', 'controlTargetId', 'treatmentTargetIds',
@@ -1153,6 +1153,7 @@ export async function prepareEvaluationPlan(
   const execution = {
     schemaVersion: EXECUTION_PLAN_SCHEMA_VERSION,
     executionInputDigest: digests.executionInputDigest,
+    randomizationDesignDigest: digests.randomizationDesignDigest,
     samples: projectExecutionInputs(definition.dataset),
     targets: definition.targets,
     schedulingTargetGroups,

--- a/src/evaluation-core/compiler/validation.ts
+++ b/src/evaluation-core/compiler/validation.ts
@@ -171,6 +171,46 @@ function validateMetric(metric: MetricDefinition): void {
 function validateSamplingDesign(definition: EvaluationDefinition): void {
   const { experiment } = definition;
   const { sampling, scheduling } = experiment;
+  const targetIds = definition.targets.map((target) => target.targetId);
+  assertUnique(
+    experiment.randomizationSlots.map((slot) => slot.targetId),
+    'experiment:randomization-slot-target',
+  );
+  assertUnique(
+    experiment.randomizationSlots.map((slot) => slot.randomizationSlotId),
+    'experiment:randomization-slot',
+  );
+  const targetIdSet = new Set(targetIds);
+  for (const slot of experiment.randomizationSlots) {
+    assertReference(
+      targetIdSet,
+      slot.targetId,
+      'experiment.randomizationSlots',
+      'Target',
+    );
+  }
+  const mappedTargetIds = new Set(experiment.randomizationSlots.map((slot) => slot.targetId));
+  if (mappedTargetIds.size !== targetIds.length) {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      '每个 Target 必须恰好声明一个 randomization slot。',
+      { location: 'experiment.randomizationSlots' },
+    );
+  }
+  const canonicalSlots = [...experiment.randomizationSlots].sort((left, right) => (
+    left.randomizationSlotId < right.randomizationSlotId ? -1
+      : left.randomizationSlotId > right.randomizationSlotId ? 1
+        : left.targetId < right.targetId ? -1
+          : left.targetId > right.targetId ? 1
+            : 0
+  ));
+  if (canonicalizeJson(canonicalSlots) !== canonicalizeJson(experiment.randomizationSlots)) {
+    throw definitionError(
+      'EVAL_DEFINITION_POLICY_INVALID',
+      'randomizationSlots 必须按 randomizationSlotId、targetId 的 canonical 顺序排列。',
+      { location: 'experiment.randomizationSlots' },
+    );
+  }
   if (experiment.trials > 1 && !sampling.repeatedMeasures) {
     throw definitionError(
       'EVAL_DEFINITION_POLICY_INVALID',

--- a/src/evaluation-core/contracts/artifacts.ts
+++ b/src/evaluation-core/contracts/artifacts.ts
@@ -70,6 +70,7 @@ export const SamplingUnitIdsSchema = z.object({
 
 const ExecutionRecordIdentitySchema = z.object({
   targetId: IdentifierSchema,
+  randomizationSlotId: IdentifierSchema,
   sampleId: IdentifierSchema,
   trialIndex: z.number().int().nonnegative(),
   trialId: Sha256DigestSchema,

--- a/src/evaluation-core/contracts/common.ts
+++ b/src/evaluation-core/contracts/common.ts
@@ -56,6 +56,7 @@ export const RuntimeIdentitySchema = z.object({
   ]),
   assuranceLevel: z.enum(['verified', 'declared', 'unknown']),
   capabilities: JsonValueSchema,
+  implementationFacets: JsonValueSchema.optional(),
   provenanceFacets: JsonValueSchema.optional(),
 }).strict();
 

--- a/src/evaluation-core/contracts/common.ts
+++ b/src/evaluation-core/contracts/common.ts
@@ -44,6 +44,43 @@ export const ExtensionsSchema = z.record(
   ExtensionEntrySchema,
 );
 
+export const RuntimeImplementationFacetSchema = z.object({
+  facetId: IdentifierSchema,
+  value: JsonValueSchema,
+}).strict();
+
+export const RuntimeImplementationManifestSchema = z.discriminatedUnion('coverageKind', [
+  z.object({
+    coverageKind: z.literal('fingerprint-complete'),
+  }).strict(),
+  z.object({
+    coverageKind: z.literal('fingerprint-plus-facets'),
+    facets: z.array(RuntimeImplementationFacetSchema).min(1),
+  }).strict(),
+]).superRefine((manifest, context) => {
+  if (manifest.coverageKind === 'fingerprint-complete') return;
+  const facetIds = manifest.facets.map((facet) => facet.facetId);
+  const canonicalFacetIds = [...new Set(facetIds)].sort();
+  if (canonicalizeJson(facetIds) !== canonicalizeJson(canonicalFacetIds)) {
+    context.addIssue({
+      code: 'custom',
+      path: ['facets'],
+      message: 'Runtime implementation facets must be unique and canonical by facetId',
+    });
+  }
+});
+
+export const RuntimeProvenanceFacetsSchema = z.object({
+  observation: z.object({
+    observerId: IdentifierSchema.optional(),
+    observedAt: TimestampSchema.optional(),
+  }).strict().optional(),
+  attestation: z.object({
+    attestationDigest: Sha256DigestSchema,
+    attestorId: IdentifierSchema.optional(),
+  }).strict().optional(),
+}).strict();
+
 export const RuntimeIdentitySchema = z.object({
   implementationId: IdentifierSchema,
   version: NonEmptyStringSchema.optional(),
@@ -56,8 +93,8 @@ export const RuntimeIdentitySchema = z.object({
   ]),
   assuranceLevel: z.enum(['verified', 'declared', 'unknown']),
   capabilities: JsonValueSchema,
-  implementationFacets: JsonValueSchema.optional(),
-  provenanceFacets: JsonValueSchema.optional(),
+  implementationManifest: RuntimeImplementationManifestSchema,
+  provenanceFacets: RuntimeProvenanceFacetsSchema.optional(),
 }).strict();
 
 export const ProvenanceSchema = z.object({
@@ -138,6 +175,9 @@ export const EvaluationErrorSchema: z.ZodType<EvaluationError> = z.lazy(() => z.
 export type SchemaIdentity = z.infer<typeof SchemaIdentitySchema>;
 export type ExtensionEntry = z.infer<typeof ExtensionEntrySchema>;
 export type Extensions = z.infer<typeof ExtensionsSchema>;
+export type RuntimeImplementationFacet = z.infer<typeof RuntimeImplementationFacetSchema>;
+export type RuntimeImplementationManifest = z.infer<typeof RuntimeImplementationManifestSchema>;
+export type RuntimeProvenanceFacets = z.infer<typeof RuntimeProvenanceFacetsSchema>;
 export type RuntimeIdentity = z.infer<typeof RuntimeIdentitySchema>;
 export type Provenance = z.infer<typeof ProvenanceSchema>;
 export type CacheProvenance = z.infer<typeof CacheProvenanceSchema>;

--- a/src/evaluation-core/contracts/definition.ts
+++ b/src/evaluation-core/contracts/definition.ts
@@ -91,11 +91,17 @@ export const SchedulingPolicySchema = z.object({
   blockSize: z.number().int().positive().optional(),
 }).strict();
 
+export const RandomizationSlotSchema = z.object({
+  targetId: IdentifierSchema,
+  randomizationSlotId: IdentifierSchema,
+}).strict();
+
 export const ExperimentDesignSchema = z.object({
   trials: z.number().int().positive(),
   seed: NonEmptyStringSchema,
   sampling: SamplingDesignSchema,
   scheduling: SchedulingPolicySchema,
+  randomizationSlots: z.array(RandomizationSlotSchema).min(1),
 }).strict();
 
 const AnalysisMetricInputReferenceSchema = z.object({
@@ -287,6 +293,7 @@ export type EvaluatorDefinition = z.infer<typeof EvaluatorDefinitionSchema>;
 export type MetricDefinition = z.infer<typeof MetricDefinitionSchema>;
 export type SeedCoupling = z.infer<typeof SeedCouplingSchema>;
 export type SamplingDesign = z.infer<typeof SamplingDesignSchema>;
+export type RandomizationSlot = z.infer<typeof RandomizationSlotSchema>;
 export type ExperimentDesign = z.infer<typeof ExperimentDesignSchema>;
 export type ReducerDefinition = z.infer<typeof ReducerDefinitionSchema>;
 export type AnalysisNodeDefinition = z.infer<typeof AnalysisNodeDefinitionSchema>;

--- a/src/evaluation-core/contracts/digests.ts
+++ b/src/evaluation-core/contracts/digests.ts
@@ -20,10 +20,12 @@ import {
   type PlanDigests,
   type ResolvedRuntime,
 } from './plans.js';
-import type { Extensions, SchemaIdentity } from './common.js';
+import type { Extensions, RuntimeIdentity, SchemaIdentity } from './common.js';
 import {
   assertCanonicalJson,
+  canonicalizeJson,
   digestCanonicalJson,
+  type JsonValue,
   type Sha256Digest,
 } from './json.js';
 import { deriveSchedulingTargetGroups } from './execution-identities.js';
@@ -32,6 +34,30 @@ export interface DatasetDigests {
   datasetRevisionDigest: Sha256Digest;
   executionInputDigest: Sha256Digest;
   evaluationInputDigest: Sha256Digest;
+}
+
+export function computeRuntimeIdentityDigest(
+  identity: RuntimeIdentity,
+): Sha256Digest {
+  return digestCanonicalJson({
+    derivation: 'omk.runtime-identity/v1',
+    identity,
+  });
+}
+
+export function computeRuntimeImplementationDigest(
+  identity: RuntimeIdentity,
+): Sha256Digest {
+  return digestCanonicalJson({
+    derivation: 'omk.runtime-implementation-identity/v1',
+    implementationId: identity.implementationId,
+    ...(identity.version !== undefined ? { version: identity.version } : {}),
+    fingerprint: identity.fingerprint,
+    capabilities: identity.capabilities,
+    ...(identity.implementationFacets !== undefined
+      ? { implementationFacets: identity.implementationFacets }
+      : {}),
+  });
 }
 
 export function projectExecutionInputs(
@@ -78,6 +104,7 @@ export function computeDatasetDigests(dataset: EvaluationDataset): DatasetDigest
 
 export interface ExecutionPlanIdentityInput {
   executionInputDigest: Sha256Digest;
+  randomizationDesignDigest: Sha256Digest;
   targets: TargetDefinition[];
   schedulingTargetGroups: string[][];
   executorRuntimes: ResolvedRuntime[];
@@ -99,12 +126,111 @@ export function computeExecutionPlanDigest(
   return digestCanonicalJson({
     schemaVersion: EXECUTION_PLAN_SCHEMA_VERSION,
     executionInputDigest: input.executionInputDigest,
+    randomizationDesignDigest: input.randomizationDesignDigest,
     targets: input.targets,
     schedulingTargetGroups: input.schedulingTargetGroups,
     executorRuntimes: input.executorRuntimes,
     experiment: input.experiment,
     policy: input.policy,
     ...(input.extensions !== undefined ? { extensions: input.extensions } : {}),
+  });
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function resolveSamplingPointer(value: unknown, pointer: string): JsonValue {
+  let current = value;
+  if (pointer !== '') {
+    for (const encodedToken of pointer.slice(1).split('/')) {
+      const token = encodedToken.replaceAll('~1', '/').replaceAll('~0', '~');
+      if (current === null || typeof current !== 'object') {
+        throw new TypeError(`Sampling pointer ${pointer} does not resolve`);
+      }
+      if (Array.isArray(current)) {
+        if (!/^(?:0|[1-9]\d*)$/.test(token)) {
+          throw new TypeError(`Sampling pointer ${pointer} does not resolve`);
+        }
+        current = current[Number(token)];
+      } else {
+        if (!Object.prototype.hasOwnProperty.call(current, token)) {
+          throw new TypeError(`Sampling pointer ${pointer} does not resolve`);
+        }
+        current = (current as Record<string, unknown>)[token];
+      }
+    }
+  }
+  assertCanonicalJson(current);
+  return current as JsonValue;
+}
+
+function projectSamplingMemberships(
+  samples: readonly ExecutionInputSample[],
+  pointer: string | undefined,
+): string[][] {
+  if (pointer === undefined) return [];
+  const groups = new Map<string, string[]>();
+  for (const sample of samples) {
+    const key = canonicalizeJson(resolveSamplingPointer(sample, pointer));
+    const members = groups.get(key) ?? [];
+    members.push(sample.sampleId);
+    groups.set(key, members);
+  }
+  return [...groups.values()]
+    .map((members) => [...members].sort(compareStrings))
+    .sort((left, right) => compareStrings(canonicalizeJson(left), canonicalizeJson(right)));
+}
+
+export interface RandomizationDesignIdentityInput {
+  executionInputDigest: Sha256Digest;
+  samples: readonly ExecutionInputSample[];
+  schedulingTargetGroups: readonly (readonly string[])[];
+  experiment: ExperimentDesign;
+}
+
+export function computeRandomizationDesignDigest(
+  input: RandomizationDesignIdentityInput,
+): Sha256Digest {
+  const targetToSlot = new Map(input.experiment.randomizationSlots.map((slot) => [
+    slot.targetId,
+    slot.randomizationSlotId,
+  ]));
+  if (targetToSlot.size !== input.experiment.randomizationSlots.length) {
+    throw new TypeError('randomizationSlots must map every Target at most once');
+  }
+  const slotIds = input.experiment.randomizationSlots
+    .map((slot) => slot.randomizationSlotId)
+    .sort(compareStrings);
+  if (new Set(slotIds).size !== slotIds.length) {
+    throw new TypeError('randomizationSlots must use unique randomizationSlotId values');
+  }
+  const schedulingSlotGroups = input.schedulingTargetGroups.map((group) => (
+    group.map((targetId) => {
+      const slotId = targetToSlot.get(targetId);
+      if (slotId === undefined) {
+        throw new TypeError(`Missing randomization slot for Target ${targetId}`);
+      }
+      return slotId;
+    }).sort(compareStrings)
+  )).sort((left, right) => compareStrings(canonicalizeJson(left), canonicalizeJson(right)));
+  const { sampling } = input.experiment;
+  return digestCanonicalJson({
+    derivation: 'omk.randomization-design/v1',
+    executionInputDigest: input.executionInputDigest,
+    trials: input.experiment.trials,
+    rootSeed: input.experiment.seed,
+    sampling,
+    scheduling: input.experiment.scheduling,
+    randomizationSlotIds: slotIds,
+    schedulingSlotGroups,
+    samplingMemberships: {
+      pairing: projectSamplingMemberships(input.samples, sampling.pairingKey),
+      cluster: projectSamplingMemberships(input.samples, sampling.clusterKey),
+      stratum: projectSamplingMemberships(input.samples, sampling.stratumKey),
+    },
   });
 }
 
@@ -248,8 +374,16 @@ export function computePlanDigests(input: PlanDigestInput): PlanDigests {
     comparisons: input.comparisons,
     paired: input.experiment.sampling.resamplingUnit === 'paired-block',
   });
+  const executionSamples = projectExecutionInputs(input.dataset);
+  const randomizationDesignDigest = computeRandomizationDesignDigest({
+    executionInputDigest: dataset.executionInputDigest,
+    samples: executionSamples,
+    schedulingTargetGroups,
+    experiment: input.experiment,
+  });
   const executionPlanDigest = computeExecutionPlanDigest({
     executionInputDigest: dataset.executionInputDigest,
+    randomizationDesignDigest,
     targets: input.targets,
     schedulingTargetGroups,
     executorRuntimes: input.executorRuntimes,
@@ -321,6 +455,7 @@ export function computePlanDigests(input: PlanDigestInput): PlanDigests {
 
   return {
     ...dataset,
+    randomizationDesignDigest,
     executionPlanDigest,
     evaluationPlanDigest,
     analysisPlanDigest,

--- a/src/evaluation-core/contracts/digests.ts
+++ b/src/evaluation-core/contracts/digests.ts
@@ -54,9 +54,7 @@ export function computeRuntimeImplementationDigest(
     ...(identity.version !== undefined ? { version: identity.version } : {}),
     fingerprint: identity.fingerprint,
     capabilities: identity.capabilities,
-    ...(identity.implementationFacets !== undefined
-      ? { implementationFacets: identity.implementationFacets }
-      : {}),
+    implementationManifest: identity.implementationManifest,
   });
 }
 

--- a/src/evaluation-core/contracts/execution-bundle.ts
+++ b/src/evaluation-core/contracts/execution-bundle.ts
@@ -25,6 +25,7 @@ import {
 export type ExecutionBundleValidationErrorCode =
   | 'EXECUTION_BUNDLE_DUPLICATE_COORDINATE'
   | 'EXECUTION_BUNDLE_IDENTITY_MISMATCH'
+  | 'EXECUTION_BUNDLE_RANDOMIZATION_SLOT_INVALID'
   | 'EXECUTION_BUNDLE_RECORD_ORDER_INVALID'
   | 'EXECUTION_BUNDLE_ATTEMPT_ORDER_INVALID'
   | 'EXECUTION_BUNDLE_BLOCK_ATOMICITY_INVALID'
@@ -81,7 +82,20 @@ function assertCanonicalRecordOrder(records: readonly ExecutionRecord[]): void {
 function assertRecordIdentities(bundle: ExecutionBundle): void {
   const trialIds = new Set<string>();
   const attemptIds = new Set<string>();
+  const slotsByTarget = new Map<string, string>();
+  const targetsBySlot = new Map<string, string>();
   for (const record of bundle.records) {
+    const targetSlot = slotsByTarget.get(record.targetId);
+    const slotTarget = targetsBySlot.get(record.randomizationSlotId);
+    if ((targetSlot !== undefined && targetSlot !== record.randomizationSlotId)
+        || (slotTarget !== undefined && slotTarget !== record.targetId)) {
+      throw new ExecutionBundleValidationError(
+        'EXECUTION_BUNDLE_RANDOMIZATION_SLOT_INVALID',
+        'ExecutionBundle must preserve a one-to-one Target and randomization slot mapping.',
+      );
+    }
+    slotsByTarget.set(record.targetId, record.randomizationSlotId);
+    targetsBySlot.set(record.randomizationSlotId, record.targetId);
     const expectedTrialId = deriveTrialId({
       executionPlanDigest: bundle.executionPlanDigest as Sha256Digest,
       targetId: record.targetId,
@@ -725,6 +739,7 @@ export function assertExecutionBundleMatchesPlan(
       planMismatch('ExecutionBundle contains a coordinate outside the sealed ExecutionPlan.');
     }
     if (record.trialId !== expected.trialId
+        || record.randomizationSlotId !== expected.randomizationSlotId
         || record.trialSeed !== expected.trialSeed
         || record.schedulingBlockId !== expected.schedulingBlockId
         || canonicalizeJson(record.samplingUnitIds)

--- a/src/evaluation-core/contracts/execution-identities.ts
+++ b/src/evaluation-core/contracts/execution-identities.ts
@@ -121,38 +121,38 @@ export function deriveTrialId(input: TrialIdentityInput): Sha256Digest {
 }
 
 export type TrialSeedIdentityInput = {
-  rootSeed: string;
+  randomizationDesignDigest: Sha256Digest;
   seedCoupling: 'shared-within-block';
-  schedulingBlockId: Sha256Digest;
+  trialIndex: number;
   sampleId: string;
 } | {
-  rootSeed: string;
+  randomizationDesignDigest: Sha256Digest;
   seedCoupling: 'independent-by-target';
-  schedulingBlockId: Sha256Digest;
+  trialIndex: number;
   sampleId: string;
-  targetId: string;
+  randomizationSlotId: string;
 } | {
-  rootSeed: string;
+  randomizationDesignDigest: Sha256Digest;
   seedCoupling: 'uncontrolled';
-  schedulingBlockId: Sha256Digest;
+  trialIndex: number;
   sampleId: string;
-  targetId: string;
+  randomizationSlotId: string;
 };
 
 export function deriveTrialSeed(input: TrialSeedIdentityInput): Sha256Digest {
-  assertNonEmpty(input.rootSeed, 'rootSeed');
+  assertTrialIndex(input.trialIndex);
   assertNonEmpty(input.sampleId, 'sampleId');
   if (input.seedCoupling !== 'shared-within-block') {
-    assertNonEmpty(input.targetId, 'targetId');
+    assertNonEmpty(input.randomizationSlotId, 'randomizationSlotId');
   }
   return digestCanonicalJson({
     derivation: 'omk.trial-seed/v1',
-    rootSeed: input.rootSeed,
+    randomizationDesignDigest: input.randomizationDesignDigest,
     seedCoupling: input.seedCoupling,
-    schedulingBlockId: input.schedulingBlockId,
+    trialIndex: input.trialIndex,
     sampleId: input.sampleId,
     ...(input.seedCoupling !== 'shared-within-block'
-      ? { targetId: input.targetId }
+      ? { randomizationSlotId: input.randomizationSlotId }
       : {}),
   });
 }
@@ -176,6 +176,7 @@ export function deriveAttemptId(input: AttemptIdentityInput): Sha256Digest {
 export interface ExecutionIdentityPlanContext {
   execution: {
     executionPlanDigest: string;
+    randomizationDesignDigest: string;
     samples: readonly {
       sampleId: string;
       input: unknown;
@@ -186,6 +187,10 @@ export interface ExecutionIdentityPlanContext {
     experiment: {
       trials: number;
       seed: string;
+      randomizationSlots: readonly {
+        targetId: string;
+        randomizationSlotId: string;
+      }[];
       sampling: {
         pairingKey?: string;
         clusterKey?: string;
@@ -199,6 +204,7 @@ export interface ExecutionIdentityPlanContext {
 
 export interface PlannedExecutionCoordinate {
   targetId: string;
+  randomizationSlotId: string;
   sampleId: string;
   trialIndex: number;
   trialId: Sha256Digest;
@@ -358,11 +364,12 @@ function comparePlannedCoordinates(
   left: PlannedExecutionCoordinate,
   right: PlannedExecutionCoordinate,
 ): number {
-  if (left.targetId < right.targetId) return -1;
-  if (left.targetId > right.targetId) return 1;
+  if (left.randomizationSlotId < right.randomizationSlotId) return -1;
+  if (left.randomizationSlotId > right.randomizationSlotId) return 1;
   if (left.sampleId < right.sampleId) return -1;
   if (left.sampleId > right.sampleId) return 1;
-  return left.trialIndex - right.trialIndex;
+  return left.trialIndex - right.trialIndex
+    || (left.targetId < right.targetId ? -1 : left.targetId > right.targetId ? 1 : 0);
 }
 
 export function derivePlannedExecutionCoordinates(
@@ -378,6 +385,9 @@ export function derivePlannedExecutionCoordinates(
   const clusterBySample = deriveMembershipBySample(plan, 'cluster', sampling.clusterKey);
   const stratumBySample = deriveMembershipBySample(plan, 'stratum', sampling.stratumKey);
   const targetGroups = validateSchedulingTargetGroups(plan);
+  const randomizationSlotByTarget = new Map(execution.experiment.randomizationSlots.map(
+    (slot) => [slot.targetId, slot.randomizationSlotId],
+  ));
   const coordinates: PlannedExecutionCoordinate[] = [];
 
   for (let trialIndex = 0; trialIndex < execution.experiment.trials; trialIndex += 1) {
@@ -405,6 +415,10 @@ export function derivePlannedExecutionCoordinates(
           ...samplingUnitIds,
         });
         for (const { targetId, sampleId } of blockCoordinates) {
+          const randomizationSlotId = randomizationSlotByTarget.get(targetId);
+          if (randomizationSlotId === undefined) {
+            throw new TypeError(`Missing randomization slot for Target ${targetId}`);
+          }
           const trialId = deriveTrialId({
             executionPlanDigest: execution.executionPlanDigest as Sha256Digest,
             targetId,
@@ -413,20 +427,21 @@ export function derivePlannedExecutionCoordinates(
           });
           const trialSeed = sampling.seedCoupling === 'shared-within-block'
             ? deriveTrialSeed({
-              rootSeed: execution.experiment.seed,
+              randomizationDesignDigest: execution.randomizationDesignDigest as Sha256Digest,
               seedCoupling: sampling.seedCoupling,
-              schedulingBlockId,
+              trialIndex,
               sampleId,
             })
             : deriveTrialSeed({
-              rootSeed: execution.experiment.seed,
+              randomizationDesignDigest: execution.randomizationDesignDigest as Sha256Digest,
               seedCoupling: sampling.seedCoupling,
-              schedulingBlockId,
+              trialIndex,
               sampleId,
-              targetId,
+              randomizationSlotId,
             });
           coordinates.push({
             targetId,
+            randomizationSlotId,
             sampleId,
             trialIndex,
             trialId,

--- a/src/evaluation-core/contracts/plans.ts
+++ b/src/evaluation-core/contracts/plans.ts
@@ -83,6 +83,7 @@ export const SchedulingTargetGroupSchema = z.array(IdentifierSchema).min(1);
 export const ExecutionPlanSchema = z.object({
   schemaVersion: z.literal(EXECUTION_PLAN_SCHEMA_VERSION),
   executionInputDigest: Sha256DigestSchema,
+  randomizationDesignDigest: Sha256DigestSchema,
   samples: z.array(ExecutionInputSampleSchema).min(1),
   targets: z.array(TargetDefinitionSchema).min(1),
   schedulingTargetGroups: z.array(SchedulingTargetGroupSchema).min(1),
@@ -139,6 +140,7 @@ export const PlanDigestsSchema = z.object({
   datasetRevisionDigest: Sha256DigestSchema,
   executionInputDigest: Sha256DigestSchema,
   evaluationInputDigest: Sha256DigestSchema,
+  randomizationDesignDigest: Sha256DigestSchema,
   executionPlanDigest: Sha256DigestSchema,
   evaluationPlanDigest: Sha256DigestSchema,
   analysisPlanDigest: Sha256DigestSchema,

--- a/src/evaluation-core/execution/runtime.ts
+++ b/src/evaluation-core/execution/runtime.ts
@@ -507,6 +507,7 @@ function assertCachedRecord(
   if (entry.cacheKeyDigest !== key
       || entry.sourceRecordDigest !== digestCanonicalJson(record)
       || record.targetId !== coordinate.targetId
+      || record.randomizationSlotId !== coordinate.randomizationSlotId
       || record.sampleId !== coordinate.sampleId
       || record.trialIndex !== coordinate.trialIndex
       || record.trialId !== coordinate.trialId

--- a/src/evaluation-core/execution/scheduler.ts
+++ b/src/evaluation-core/execution/scheduler.ts
@@ -1,4 +1,5 @@
 import {
+  canonicalizeJson,
   derivePlannedExecutionCoordinates,
   digestCanonicalJson,
   type PlannedExecutionCoordinate,
@@ -24,7 +25,7 @@ function interleavedOrder(
   const rightCoordinate = right.coordinates[0];
   return leftCoordinate.trialIndex - rightCoordinate.trialIndex
     || compareStrings(leftCoordinate.sampleId, rightCoordinate.sampleId)
-    || compareStrings(leftCoordinate.targetId, rightCoordinate.targetId);
+    || compareStrings(leftCoordinate.randomizationSlotId, rightCoordinate.randomizationSlotId);
 }
 
 function rotate<T>(values: readonly T[], offset: number): T[] {
@@ -33,10 +34,14 @@ function rotate<T>(values: readonly T[], offset: number): T[] {
   return [...values.slice(normalized), ...values.slice(0, normalized)];
 }
 
-function randomRank(seed: string, scope: string, identity: string): string {
+function randomRank(
+  randomizationDesignDigest: string,
+  scope: 'coordinate' | 'block',
+  identity: unknown,
+): string {
   return digestCanonicalJson({
     derivation: 'omk.execution-schedule-rank/v1',
-    seed,
+    randomizationDesignDigest,
     scope,
     identity,
   });
@@ -44,7 +49,7 @@ function randomRank(seed: string, scope: string, identity: string): string {
 
 function randomizedBlocks(
   blocks: readonly ExecutionSchedulingBlock[],
-  seed: string,
+  randomizationDesignDigest: string,
   blockSize: number,
 ): ExecutionSchedulingBlock[] {
   const batches: ExecutionSchedulingBlock[][] = [];
@@ -69,13 +74,41 @@ function randomizedBlocks(
       .map((block) => ({
         ...block,
         coordinates: [...block.coordinates].sort((left, right) => compareStrings(
-          randomRank(seed, block.schedulingBlockId, left.trialId),
-          randomRank(seed, block.schedulingBlockId, right.trialId),
+          randomRank(randomizationDesignDigest, 'coordinate', {
+            trialIndex: left.trialIndex,
+            sampleId: left.sampleId,
+            randomizationSlotId: left.randomizationSlotId,
+          }),
+          randomRank(randomizationDesignDigest, 'coordinate', {
+            trialIndex: right.trialIndex,
+            sampleId: right.sampleId,
+            randomizationSlotId: right.randomizationSlotId,
+          }),
         )),
       }))
       .sort((left, right) => compareStrings(
-        randomRank(seed, `batch:${batchIndex}`, left.schedulingBlockId),
-        randomRank(seed, `batch:${batchIndex}`, right.schedulingBlockId),
+        randomRank(randomizationDesignDigest, 'block', {
+          batchIndex,
+          coordinates: left.coordinates.map((coordinate) => ({
+            trialIndex: coordinate.trialIndex,
+            sampleId: coordinate.sampleId,
+            randomizationSlotId: coordinate.randomizationSlotId,
+          })).sort((first, second) => compareStrings(
+            canonicalizeJson(first),
+            canonicalizeJson(second),
+          )),
+        }),
+        randomRank(randomizationDesignDigest, 'block', {
+          batchIndex,
+          coordinates: right.coordinates.map((coordinate) => ({
+            trialIndex: coordinate.trialIndex,
+            sampleId: coordinate.sampleId,
+            randomizationSlotId: coordinate.randomizationSlotId,
+          })).sort((first, second) => compareStrings(
+            canonicalizeJson(first),
+            canonicalizeJson(second),
+          )),
+        }),
       ))
   ));
 }
@@ -103,5 +136,9 @@ export function deriveExecutionSchedule(plan: SealedRunPlan): ExecutionSchedulin
   if (scheduling.blockSize === undefined) {
     throw new TypeError('randomized-block scheduling requires blockSize');
   }
-  return randomizedBlocks(interleaved, plan.execution.experiment.seed, scheduling.blockSize);
+  return randomizedBlocks(
+    interleaved,
+    plan.execution.randomizationDesignDigest,
+    scheduling.blockSize,
+  );
 }

--- a/test/evaluation-core/analysis/runtime.test.ts
+++ b/test/evaluation-core/analysis/runtime.test.ts
@@ -106,6 +106,18 @@ async function makePlan(mutate?: (
   delete policy.evaluation.timeoutMs;
   policy.evidence.trace = 'full';
   mutate?.(definition, policy);
+  const targetIds = new Set(definition.targets.map((target) => target.targetId));
+  const slotTargetIds = new Set(
+    definition.experiment.randomizationSlots.map((slot) => slot.targetId),
+  );
+  if (targetIds.size !== slotTargetIds.size
+      || [...targetIds].some((targetId) => !slotTargetIds.has(targetId))) {
+    definition.experiment.randomizationSlots = definition.targets
+      .map((target, index) => ({
+        targetId: target.targetId,
+        randomizationSlotId: `slot-${String(index).padStart(4, '0')}`,
+      }));
+  }
   return prepareEvaluationPlan(definition, policy, runtime);
 }
 

--- a/test/evaluation-core/analysis/runtime.test.ts
+++ b/test/evaluation-core/analysis/runtime.test.ts
@@ -309,6 +309,7 @@ describe('Evaluation Core Analysis and Decision Runtime', () => {
       fingerprint: digestCanonicalJson({ implementationId: 'test.hypothesis-table/v1' }),
       fingerprintBasis: 'content-derived',
       assuranceLevel: 'verified',
+      implementationManifest: { coverageKind: 'fingerprint-complete' },
       capabilities: {
         capabilityKind: 'analysis-node',
         analysisNodeKinds: ['reducer'],

--- a/test/evaluation-core/compiler/execution-bundle.test.ts
+++ b/test/evaluation-core/compiler/execution-bundle.test.ts
@@ -190,6 +190,18 @@ describe('ExecutionBundle RunPlan binding', () => {
     expect(Object.isFrozen(source.planVerification)).toBe(true);
   });
 
+  it('rejects a re-signed Bundle whose randomization slot contradicts the Plan', async () => {
+    const plan = await makePlan();
+    const bundle = mutableJson(makeBundle(plan));
+    bundle.records[0].randomizationSlotId = 'slot-forged';
+    resign(bundle);
+
+    expect(parseExecutionBundleDocument(bundle)).toEqual(bundle);
+    expect(() => parseExecutionBundle(bundle, plan)).toThrowError(
+      expect.objectContaining({ code: 'EXECUTION_BUNDLE_PLAN_MISMATCH' }),
+    );
+  });
+
   it('rejects provenance above the sealed Executor Runtime assurance', async () => {
     const definition = validDefinition();
     const policy = validPolicy();

--- a/test/evaluation-core/compiler/execution-bundle.test.ts
+++ b/test/evaluation-core/compiler/execution-bundle.test.ts
@@ -4,7 +4,6 @@ import {
   deriveAttemptId,
   derivePlannedExecutionCoordinates,
   deriveTrialId,
-  deriveTrialSeed,
   digestArtifactPayload,
   digestCanonicalJson,
   parseExecutionBundle,
@@ -450,13 +449,6 @@ describe('ExecutionBundle RunPlan binding', () => {
     expect(bundle.records[0].schedulingBlockId).toBe(bundle.records[1].schedulingBlockId);
     const record = bundle.records[1];
     record.schedulingBlockId = `sha256:${'e'.repeat(64)}`;
-    record.trialSeed = deriveTrialSeed({
-      rootSeed: plan.execution.experiment.seed,
-      seedCoupling: 'independent-by-target',
-      schedulingBlockId: record.schedulingBlockId as Sha256Digest,
-      sampleId: record.sampleId,
-      targetId: record.targetId,
-    });
     resign(bundle);
     expect(parseExecutionBundleDocument(bundle)).toEqual(bundle);
     expect(() => parseExecutionBundle(bundle, plan)).toThrowError(
@@ -525,6 +517,7 @@ describe('ExecutionBundle RunPlan binding', () => {
     const first = original.records[0];
     const censored: ExecutionRecord = {
       targetId: first.targetId,
+      randomizationSlotId: first.randomizationSlotId,
       sampleId: first.sampleId,
       trialIndex: first.trialIndex,
       trialId: first.trialId,

--- a/test/evaluation-core/compiler/fixtures.ts
+++ b/test/evaluation-core/compiler/fixtures.ts
@@ -92,6 +92,10 @@ export function validDefinition(): EvaluationDefinition {
     experiment: {
       trials: 1,
       seed: 'seed-1',
+      randomizationSlots: [
+        { targetId: 'control', randomizationSlotId: 'slot-control' },
+        { targetId: 'treatment', randomizationSlotId: 'slot-treatment' },
+      ],
       sampling: {
         experimentalUnit: 'sample',
         repeatedMeasures: false,

--- a/test/evaluation-core/compiler/fixtures.ts
+++ b/test/evaluation-core/compiler/fixtures.ts
@@ -37,6 +37,7 @@ function identity(
     fingerprintBasis: 'content-derived',
     assuranceLevel,
     capabilities,
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
   };
 }
 

--- a/test/evaluation-core/compiler/validation.test.ts
+++ b/test/evaluation-core/compiler/validation.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   EvaluationDefinitionError,
   prepareEvaluationPlan,
+  type PreparationRuntime,
 } from '../../../src/evaluation-core/compiler/index.js';
+import type { RuntimeIdentity } from '../../../src/evaluation-core/contracts/index.js';
 import {
   validateAnalysisInputs,
   validateDefinitionSemantics,
@@ -13,7 +15,7 @@ async function expectCode(
   definition: unknown,
   policy: unknown,
   code: string,
-  runtime = testRuntime(),
+  runtime: PreparationRuntime = testRuntime(),
 ): Promise<void> {
   try {
     await prepareEvaluationPlan(definition, policy, runtime);
@@ -135,6 +137,33 @@ describe('Compiler definition validation', () => {
     const nonCanonical = validDefinition();
     nonCanonical.experiment.randomizationSlots.reverse();
     await expectCode(nonCanonical, validPolicy(), 'EVAL_DEFINITION_POLICY_INVALID');
+  });
+
+  it('rejects a Runtime that hides behavior-affecting facts in provenance facets', async () => {
+    const base = testRuntime();
+    const runtime: PreparationRuntime = {
+      ...base,
+      async resolveExecutor(requirement) {
+        const resolution = await base.resolveExecutor(requirement) as {
+          identity: RuntimeIdentity;
+          satisfiesVersionConstraint: boolean;
+        };
+        return {
+          ...resolution,
+          identity: {
+            ...resolution.identity,
+            provenanceFacets: { deployment: 'hidden-behavior-change' },
+          },
+        };
+      },
+    };
+
+    await expectCode(
+      validDefinition(),
+      validPolicy(),
+      'EVAL_DEFINITION_RUNTIME_RESOLUTION_FAILED',
+      runtime,
+    );
   });
 
   it('keeps scheduling pointers inside the execution-visible projection', async () => {

--- a/test/evaluation-core/compiler/validation.test.ts
+++ b/test/evaluation-core/compiler/validation.test.ts
@@ -120,6 +120,23 @@ describe('Compiler definition validation', () => {
     );
   });
 
+  it('requires a canonical one-to-one randomization slot for every Target', async () => {
+    const missing = validDefinition();
+    missing.experiment.randomizationSlots.pop();
+    await expectCode(missing, validPolicy(), 'EVAL_DEFINITION_POLICY_INVALID');
+
+    const duplicate = validDefinition();
+    duplicate.experiment.randomizationSlots[1] = {
+      ...duplicate.experiment.randomizationSlots[1],
+      randomizationSlotId: duplicate.experiment.randomizationSlots[0].randomizationSlotId,
+    };
+    await expectCode(duplicate, validPolicy(), 'EVAL_DEFINITION_DUPLICATE_ID');
+
+    const nonCanonical = validDefinition();
+    nonCanonical.experiment.randomizationSlots.reverse();
+    await expectCode(nonCanonical, validPolicy(), 'EVAL_DEFINITION_POLICY_INVALID');
+  });
+
   it('keeps scheduling pointers inside the execution-visible projection', async () => {
     const definition = validDefinition();
     definition.experiment.sampling = {
@@ -139,6 +156,10 @@ describe('Compiler definition validation', () => {
     definition.targets.push({
       ...structuredClone(definition.targets[1]),
       targetId: 'treatment-b',
+    });
+    definition.experiment.randomizationSlots.push({
+      targetId: 'treatment-b',
+      randomizationSlotId: 'slot-treatment-b',
     });
     definition.comparisons.push({
       comparisonId: 'treatment-vs-treatment-b',
@@ -375,6 +396,10 @@ describe('Compiler definition validation', () => {
     definition.targets.push({
       ...structuredClone(definition.targets[1]),
       targetId: 'treatment-secondary',
+    });
+    definition.experiment.randomizationSlots.push({
+      targetId: 'treatment-secondary',
+      randomizationSlotId: 'slot-treatment-secondary',
     });
     definition.comparisons[0].treatmentTargetIds.push('treatment-secondary');
     definition.analysisGraph.nodes = [

--- a/test/evaluation-core/conformance/harness.ts
+++ b/test/evaluation-core/conformance/harness.ts
@@ -352,6 +352,7 @@ function conformanceRuntimeIdentity(
     fingerprintBasis: 'self-reported',
     assuranceLevel: 'declared',
     capabilities,
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
   };
 }
 

--- a/test/evaluation-core/contracts/digests.test.ts
+++ b/test/evaluation-core/contracts/digests.test.ts
@@ -139,18 +139,32 @@ describe('Evaluation Core layered digests', () => {
       fingerprintBasis: 'self-reported' as const,
       assuranceLevel: 'declared' as const,
       capabilities: { protocol: 'omk.invoke/v1' },
-      implementationFacets: { toolSchemaDigest: `sha256:${'1'.repeat(64)}` },
-      provenanceFacets: { attestation: 'pending' },
+      implementationManifest: {
+        coverageKind: 'fingerprint-plus-facets' as const,
+        facets: [{
+          facetId: 'toolSchemaDigest',
+          value: `sha256:${'1'.repeat(64)}`,
+        }],
+      },
+      provenanceFacets: { observation: { observerId: 'runtime-resolver' } },
     };
     const requalified = {
       ...runtime,
       fingerprintBasis: 'content-derived' as const,
       assuranceLevel: 'verified' as const,
-      provenanceFacets: { attestation: 'verified' },
+      provenanceFacets: {
+        attestation: { attestationDigest: `sha256:${'3'.repeat(64)}` },
+      },
     };
     const changedBehavior = {
       ...runtime,
-      implementationFacets: { toolSchemaDigest: `sha256:${'2'.repeat(64)}` },
+      implementationManifest: {
+        coverageKind: 'fingerprint-plus-facets' as const,
+        facets: [{
+          facetId: 'toolSchemaDigest',
+          value: `sha256:${'2'.repeat(64)}`,
+        }],
+      },
     };
 
     expect(computeRuntimeIdentityDigest(requalified)).not.toBe(
@@ -296,6 +310,7 @@ describe('Evaluation Core layered digests', () => {
         fingerprintBasis: 'content-derived' as const,
         assuranceLevel: 'verified' as const,
         capabilities: {},
+        implementationManifest: { coverageKind: 'fingerprint-complete' as const },
       },
     };
     const first = computePlanDigests({ ...base, executorRuntimes: [runtime] });

--- a/test/evaluation-core/contracts/digests.test.ts
+++ b/test/evaluation-core/contracts/digests.test.ts
@@ -5,6 +5,8 @@ import {
   computeDatasetDigests,
   computePlanDigests,
   computeRunContractDigest,
+  computeRuntimeIdentityDigest,
+  computeRuntimeImplementationDigest,
   digestArtifactPayload,
   digestCanonicalJson,
   generateWireSchemaIdentities,
@@ -92,6 +94,10 @@ const definition: EvaluationDefinition = {
   experiment: {
     trials: 1,
     seed: 'seed-1',
+    randomizationSlots: [{
+      targetId: 'control',
+      randomizationSlotId: 'slot-control',
+    }],
     sampling: {
       experimentalUnit: 'sample',
       repeatedMeasures: false,
@@ -125,6 +131,39 @@ function planDigests(current: EvaluationDefinition, currentPolicy = policy) {
 }
 
 describe('Evaluation Core layered digests', () => {
+  it('separates Runtime behavior identity from evidence qualification', () => {
+    const runtime = {
+      implementationId: 'remote-model/v1',
+      version: '1.0.0',
+      fingerprint: 'deployment:primary',
+      fingerprintBasis: 'self-reported' as const,
+      assuranceLevel: 'declared' as const,
+      capabilities: { protocol: 'omk.invoke/v1' },
+      implementationFacets: { toolSchemaDigest: `sha256:${'1'.repeat(64)}` },
+      provenanceFacets: { attestation: 'pending' },
+    };
+    const requalified = {
+      ...runtime,
+      fingerprintBasis: 'content-derived' as const,
+      assuranceLevel: 'verified' as const,
+      provenanceFacets: { attestation: 'verified' },
+    };
+    const changedBehavior = {
+      ...runtime,
+      implementationFacets: { toolSchemaDigest: `sha256:${'2'.repeat(64)}` },
+    };
+
+    expect(computeRuntimeIdentityDigest(requalified)).not.toBe(
+      computeRuntimeIdentityDigest(runtime),
+    );
+    expect(computeRuntimeImplementationDigest(requalified)).toBe(
+      computeRuntimeImplementationDigest(runtime),
+    );
+    expect(computeRuntimeImplementationDigest(changedBehavior)).not.toBe(
+      computeRuntimeImplementationDigest(runtime),
+    );
+  });
+
   it('projects Gold away from executor-visible inputs', () => {
     expect(projectExecutionInputs(dataset)).toEqual([{
       sampleId: 's1',
@@ -326,9 +365,14 @@ describe('Evaluation Core layered digests', () => {
       ],
       experiment: {
         ...definition.experiment,
+        randomizationSlots: [
+          { targetId: 'control', randomizationSlotId: 'slot-control' },
+          { targetId: 'variant-a', randomizationSlotId: 'slot-variant-a' },
+          { targetId: 'variant-b', randomizationSlotId: 'slot-variant-b' },
+        ],
         sampling: {
           ...definition.experiment.sampling,
-          pairingKey: '/input/cohort',
+          pairingKey: '/sampleId',
           resamplingUnit: 'paired-block',
         },
       },
@@ -364,9 +408,13 @@ describe('Evaluation Core layered digests', () => {
       ],
       experiment: {
         ...definition.experiment,
+        randomizationSlots: [
+          { targetId: 'control', randomizationSlotId: 'slot-control' },
+          { targetId: 'treatment', randomizationSlotId: 'slot-treatment' },
+        ],
         sampling: {
           ...definition.experiment.sampling,
-          pairingKey: '/input/cohort',
+          pairingKey: '/sampleId',
           resamplingUnit: 'paired-block',
         },
       },

--- a/test/evaluation-core/contracts/execution-bundle.test.ts
+++ b/test/evaluation-core/contracts/execution-bundle.test.ts
@@ -42,6 +42,7 @@ const runtime = {
   fingerprintBasis: 'content-derived' as const,
   assuranceLevel: 'verified' as const,
   capabilities: {},
+  implementationManifest: { coverageKind: 'fingerprint-complete' as const },
 };
 
 function makeCompletedRecord(
@@ -130,6 +131,32 @@ describe('ExecutionBundle contract', () => {
   it('accepts a canonical self-contained completed bundle', () => {
     const bundle = finalizeBundle();
     expect(parseExecutionBundleDocument(JSON.parse(JSON.stringify(bundle)))).toEqual(bundle);
+  });
+
+  it('requires a one-to-one Target and randomization slot mapping within the Bundle', () => {
+    const first = makeCompletedRecord('target-a', 'sample-a');
+    const conflictingTarget = makeCompletedRecord('target-a', 'sample-b');
+    conflictingTarget.randomizationSlotId = 'slot-forged';
+    const duplicateSlot = makeCompletedRecord('target-b', 'sample-a');
+    duplicateSlot.randomizationSlotId = first.randomizationSlotId;
+
+    for (const records of [[first, conflictingTarget], [first, duplicateSlot]]) {
+      const bundle = finalizeBundle({
+        coverage: {
+          planned: 2,
+          started: 2,
+          succeeded: 2,
+          failed: 0,
+          cancelled: 0,
+          budgetCensored: 0,
+          notStarted: 0,
+        },
+        records,
+      });
+      expect(() => parseExecutionBundleDocument(bundle)).toThrowError(
+        expect.objectContaining({ code: 'EXECUTION_BUNDLE_RANDOMIZATION_SLOT_INVALID' }),
+      );
+    }
   });
 
   it('keeps summary-only output omission distinct from execution failure', () => {

--- a/test/evaluation-core/contracts/execution-bundle.test.ts
+++ b/test/evaluation-core/contracts/execution-bundle.test.ts
@@ -61,6 +61,7 @@ function makeCompletedRecord(
   });
   return {
     targetId,
+    randomizationSlotId: `slot-${targetId}`,
     sampleId,
     trialIndex: 0,
     trialId,
@@ -180,6 +181,7 @@ describe('ExecutionBundle contract', () => {
     const error = { code: 'provider-error', stage: 'execution' as const, message: 'failed' };
     const failed: ExecutionRecord = {
       targetId: 'target-b',
+      randomizationSlotId: 'slot-target-b',
       sampleId: 'sample-a',
       trialIndex: 0,
       trialId,
@@ -231,6 +233,7 @@ describe('ExecutionBundle contract', () => {
     });
     const censored: ExecutionRecord = {
       targetId: 'target-a',
+      randomizationSlotId: 'slot-target-a',
       sampleId: 'sample-a',
       trialIndex: 0,
       trialId,
@@ -299,6 +302,7 @@ describe('ExecutionBundle contract', () => {
     });
     const censored: ExecutionRecord = {
       targetId: 'target-b',
+      randomizationSlotId: 'slot-target-b',
       sampleId: 'sample-a',
       trialIndex: 0,
       trialId,

--- a/test/evaluation-core/contracts/execution-identities.test.ts
+++ b/test/evaluation-core/contracts/execution-identities.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../src/evaluation-core/contracts/index.js';
 
 const executionPlanDigest = `sha256:${'1'.repeat(64)}` as Sha256Digest;
+const randomizationDesignDigest = `sha256:${'3'.repeat(64)}` as Sha256Digest;
 
 describe('Execution identity derivation', () => {
   it('matches the v1 domain-separated golden vector', () => {
@@ -44,30 +45,30 @@ describe('Execution identity derivation', () => {
       'sha256:6627fa21a900f74e3d5c6aa726ca5e5090595c0617d2385fff59afcf0b84dfa8',
     );
     expect(deriveTrialSeed({
-      rootSeed: 'seed-1',
+      randomizationDesignDigest,
       seedCoupling: 'shared-within-block',
-      schedulingBlockId,
+      trialIndex: 0,
       sampleId: 's1',
     })).toBe(
-      'sha256:e42e56fb54bfc0f8dd1351bc498c20aab65ae326a9461b406b23b60ed6f08d3d',
+      'sha256:5ebf2f47afac73711928a5bd7f079dcc500800f342d7bbf9e558d8bbecb2d2a7',
     );
     expect(deriveTrialSeed({
-      rootSeed: 'seed-1',
+      randomizationDesignDigest,
       seedCoupling: 'independent-by-target',
-      schedulingBlockId,
+      trialIndex: 0,
       sampleId: 's1',
-      targetId: 'control',
+      randomizationSlotId: 'slot-control',
     })).toBe(
-      'sha256:a626240acc0b900f5a9c3b8522b1a1f939eea1909b8504d56e1ce501e850c45f',
+      'sha256:d06893a19334e92784c221806803a724914f2108281b0b7641f3e6331826cb2c',
     );
     expect(deriveTrialSeed({
-      rootSeed: 'seed-1',
+      randomizationDesignDigest,
       seedCoupling: 'uncontrolled',
-      schedulingBlockId,
+      trialIndex: 0,
       sampleId: 's1',
-      targetId: 'control',
+      randomizationSlotId: 'slot-control',
     })).toBe(
-      'sha256:3da1ced0b792b5a67dc18d33e6dd7ccd37f1e1bd50232c9321fc870e0f26ad8c',
+      'sha256:f1b4f0911478ff68d7c94ad818dbb4ca145f69cfbbd7626d1e8fa46ff4c70b9d',
     );
     expect(deriveAttemptId({ trialId, attemptNumber: 1 })).toBe(
       'sha256:f664c308f4675c875006748ec0893aa279b47a2eb97d52e8845a13fcd27cc833',
@@ -145,26 +146,25 @@ describe('Execution identity derivation', () => {
   });
 
   it('makes seed coupling an explicit construct-validity choice', () => {
-    const schedulingBlockId = `sha256:${'2'.repeat(64)}` as Sha256Digest;
     const shared = deriveTrialSeed({
-      rootSeed: 'root',
+      randomizationDesignDigest,
       seedCoupling: 'shared-within-block',
-      schedulingBlockId,
+      trialIndex: 0,
       sampleId: 'sample',
     });
     const control = deriveTrialSeed({
-      rootSeed: 'root',
+      randomizationDesignDigest,
       seedCoupling: 'independent-by-target',
-      schedulingBlockId,
+      trialIndex: 0,
       sampleId: 'sample',
-      targetId: 'control',
+      randomizationSlotId: 'slot-control',
     });
     const treatment = deriveTrialSeed({
-      rootSeed: 'root',
+      randomizationDesignDigest,
       seedCoupling: 'independent-by-target',
-      schedulingBlockId,
+      trialIndex: 0,
       sampleId: 'sample',
-      targetId: 'treatment',
+      randomizationSlotId: 'slot-treatment',
     });
 
     expect(control).not.toBe(treatment);

--- a/test/evaluation-core/contracts/schemas.test.ts
+++ b/test/evaluation-core/contracts/schemas.test.ts
@@ -54,7 +54,46 @@ describe('Evaluation Core wire schemas', () => {
       fingerprintBasis: 'opaque',
       assuranceLevel: 'declared',
       capabilities: {},
+      implementationManifest: {
+        coverageKind: 'fingerprint-plus-facets',
+        facets: [{
+          facetId: 'deployment',
+          value: 'provider-deployment:2026-08-28',
+        }],
+      },
     }).fingerprint).toBe('provider-deployment:2026-08-28');
+  });
+
+  it('requires complete and unambiguous Runtime implementation facet coverage', () => {
+    const base = {
+      implementationId: 'remote-model',
+      fingerprint: 'provider-deployment:2026-08-28',
+      fingerprintBasis: 'self-reported' as const,
+      assuranceLevel: 'declared' as const,
+      capabilities: {},
+    };
+
+    expect(() => RuntimeIdentitySchema.parse(base)).toThrow();
+    expect(() => RuntimeIdentitySchema.parse({
+      ...base,
+      implementationManifest: { coverageKind: 'fingerprint-complete' },
+      implementationFacets: { deployment: 'primary' },
+    })).toThrow();
+    expect(() => RuntimeIdentitySchema.parse({
+      ...base,
+      implementationManifest: {
+        coverageKind: 'fingerprint-plus-facets',
+        facets: [
+          { facetId: 'tools', value: 'v1' },
+          { facetId: 'deployment', value: 'primary' },
+        ],
+      },
+    })).toThrow();
+    expect(() => RuntimeIdentitySchema.parse({
+      ...base,
+      implementationManifest: { coverageKind: 'fingerprint-complete' },
+      provenanceFacets: { deployment: 'hidden-behavior-change' },
+    })).toThrow();
   });
 
   it('rejects unknown Definition fields and non-JSON values', () => {

--- a/test/evaluation-core/contracts/schemas.test.ts
+++ b/test/evaluation-core/contracts/schemas.test.ts
@@ -72,6 +72,7 @@ describe('Evaluation Core wire schemas', () => {
       experiment: {
         trials: 1,
         seed: 'seed',
+        randomizationSlots: [{ targetId: 't', randomizationSlotId: 'slot-t' }],
         sampling: {
           experimentalUnit: 'sample',
           repeatedMeasures: false,
@@ -148,6 +149,7 @@ describe('Evaluation Core wire schemas', () => {
       experiment: {
         trials: 1,
         seed: 'seed',
+        randomizationSlots: [{ targetId: 't', randomizationSlotId: 'slot-t' }],
         sampling: {
           experimentalUnit: 'sample',
           repeatedMeasures: false,

--- a/test/evaluation-core/evaluation/runtime.test.ts
+++ b/test/evaluation-core/evaluation/runtime.test.ts
@@ -71,6 +71,18 @@ async function makePlan(
   delete policy.execution.timeoutMs;
   delete policy.evaluation.timeoutMs;
   mutate?.(definition, policy);
+  const targetIds = new Set(definition.targets.map((target) => target.targetId));
+  const slotTargetIds = new Set(
+    definition.experiment.randomizationSlots.map((slot) => slot.targetId),
+  );
+  if (targetIds.size !== slotTargetIds.size
+      || [...targetIds].some((targetId) => !slotTargetIds.has(targetId))) {
+    definition.experiment.randomizationSlots = definition.targets
+      .map((target, index) => ({
+        targetId: target.targetId,
+        randomizationSlotId: `slot-${String(index).padStart(4, '0')}`,
+      }));
+  }
   return prepareEvaluationPlan(definition, policy, runtime);
 }
 

--- a/test/evaluation-core/execution/runtime.test.ts
+++ b/test/evaluation-core/execution/runtime.test.ts
@@ -206,6 +206,18 @@ async function makePlan(
   const policy = validPolicy();
   delete policy.execution.timeoutMs;
   mutate?.(definition, policy);
+  const targetIds = new Set(definition.targets.map((target) => target.targetId));
+  const slotTargetIds = new Set(
+    definition.experiment.randomizationSlots.map((slot) => slot.targetId),
+  );
+  if (targetIds.size !== slotTargetIds.size
+      || [...targetIds].some((targetId) => !slotTargetIds.has(targetId))) {
+    definition.experiment.randomizationSlots = definition.targets
+      .map((target, index) => ({
+        targetId: target.targetId,
+        randomizationSlotId: `slot-${String(index).padStart(4, '0')}`,
+      }));
+  }
   return prepareEvaluationPlan(definition, policy, runtime);
 }
 
@@ -322,6 +334,52 @@ describe('Evaluation Core Execution runtime', () => {
     expect(new Set(deriveExecutionSchedule(randomized).flatMap((block) => (
       block.coordinates.map((coordinate) => coordinate.trialId)
     ))).size).toBe(4);
+  });
+
+  it('keeps controlled seeds and admission order stable across a declared subject rename', async () => {
+    const configure = (definition: ReturnType<typeof validDefinition>): void => {
+      definition.dataset.samples.push({
+        ...structuredClone(definition.dataset.samples[0]),
+        sampleId: 'sample-2',
+      });
+      definition.experiment.scheduling = {
+        schedulingKind: 'randomized-block',
+        blockSize: 2,
+      };
+    };
+    const original = await makePlan(configure);
+    const renamed = await makePlan((definition) => {
+      configure(definition);
+      definition.targets[1] = {
+        ...definition.targets[1],
+        targetId: 'candidate-v2',
+        config: { revision: 2 },
+      };
+      definition.comparisons[0] = {
+        ...definition.comparisons[0],
+        treatmentTargetIds: ['candidate-v2'],
+      };
+      definition.experiment.randomizationSlots[1] = {
+        targetId: 'candidate-v2',
+        randomizationSlotId: 'slot-treatment',
+      };
+    });
+    const randomizationProjection = (plan: Plan) => deriveExecutionSchedule(plan).flatMap(
+      (block) => block.coordinates.map((coordinate) => ({
+        trialIndex: coordinate.trialIndex,
+        sampleId: coordinate.sampleId,
+        randomizationSlotId: coordinate.randomizationSlotId,
+        trialSeed: coordinate.trialSeed,
+      })),
+    );
+
+    expect(renamed.execution.executionPlanDigest).not.toBe(
+      original.execution.executionPlanDigest,
+    );
+    expect(renamed.execution.randomizationDesignDigest).toBe(
+      original.execution.randomizationDesignDigest,
+    );
+    expect(randomizationProjection(renamed)).toEqual(randomizationProjection(original));
   });
 
   it('retries only within one trial identity and disposes one trial session', async () => {

--- a/test/evaluation-core/execution/runtime.test.ts
+++ b/test/evaluation-core/execution/runtime.test.ts
@@ -755,6 +755,36 @@ describe('Evaluation Core Execution runtime', () => {
     expect(cache.gets).toBe(2);
   });
 
+  it('fails closed when a cached record claims a different randomization slot', async () => {
+    const cache = new MemoryCache();
+    const plan = await makePlan((definition, policy) => {
+      definition.targets = [definition.targets[0]];
+      definition.comparisons = [];
+      policy.cache.executionMode = 'transparent-deterministic';
+    });
+    const seeded = portsFor(plan, undefined, { cache });
+    await executeRunPlan(plan, seeded.ports, {
+      runId: 'run-cache-slot-seed',
+      bundleId: 'bundle-cache-slot-seed',
+    });
+    const entry = cache.entries.values().next().value;
+    if (entry === undefined) throw new Error('missing cache entry');
+    entry.record.randomizationSlotId = 'slot-forged';
+    entry.sourceRecordDigest = digestCanonicalJson(entry.record);
+
+    const replayed = portsFor(plan, undefined, { cache });
+    const bundle = await executeRunPlan(plan, replayed.ports, {
+      runId: 'run-cache-slot-replay',
+      bundleId: 'bundle-cache-slot-replay',
+    });
+
+    expect(bundle).toMatchObject({
+      executionBundleStatus: 'failed',
+      terminationReasonCode: 'execution-cache-read-failed',
+    });
+    expect(replayed.state.attempts).toBe(0);
+  });
+
   it('fails closed on a cached attempt chain that violates the sealed retry policy', async () => {
     const cache = new MemoryCache();
     const plan = await makePlan((definition, policy) => {


### PR DESCRIPTION
## 用户影响

Evaluation Core 现在为每个 Target 要求一个稳定且一对一的 `randomizationSlotId`，并通过 `omk.randomization-design/v1` 单独封印随机化设计。trial seed 与 randomized admission rank 只依赖 execution-visible input、sampling／scheduling design、trial／sample identity 和稳定 slot，不再依赖 `executionPlanDigest`、Target ID、trial ID 或 scheduling block artifact ID。

因此，显式研究对象发生 Target rename 或实现变化时，Execution identity 仍会正确变化，但对应 coordinate 的受控随机条件和 admission order 不会被连带扰动。ExecutionRecord 同时记录 `randomizationSlotId`；document 校验保证 Bundle 内 Target↔slot 一一对应，plan-aware import 与 cache admission 则把该字段重新绑定 sealed coordinate，避免伪造随机化审计事实。

RuntimeIdentity 使用 discriminated `implementationManifest` 分离行为身份与证据资格：`fingerprint-complete` 表示行为事实已由 fingerprint 完整承诺；`fingerprint-plus-facets` 必须提供非空、唯一且 canonical 的 facet。`provenanceFacets` 收紧为封闭的 observation／attestation evidence 结构，不能承载任意行为事实。Runtime implementation digest 覆盖完整 manifest，而 `fingerprintBasis`、assurance 和 provenance 只影响完整身份／证据资格。

## 迁移说明

`BREAKING-COMPARABILITY`：EvaluationDefinition 的 `experiment.randomizationSlots`、ExecutionPlan／PlanDigests 的 `randomizationDesignDigest`，以及 ExecutionRecord 的 `randomizationSlotId` 现在是必填字段；trial seed 与 randomized schedule 的派生结果也会变化。

RuntimeIdentity 现在必须声明 `implementationManifest`。原先独立的任意 JSON `implementationFacets` 不再存在；未被 fingerprint 承诺的行为事实改为放入 `implementationManifest.facets`。`provenanceFacets` 只接受结构化 observation／attestation metadata。

Evaluation Core v1 尚未公开发布，按项目约定不保留旧 schema、旧 seed 或双读兼容路径。调用方必须为每个 Target 声明稳定 slot；比较同一研究对象的后续实现时，即使 Target ID 改名也必须保留该 slot。

## Construct-validity caveat

稳定 slot 只表示实验随机化条件，不表示 control／treatment 角色，也不能证明 Runtime provenance 可信。`seedCoupling: uncontrolled` 仍然不构成跨 Run 的 exact controlled comparison；后续 ComparabilityPolicy 实现会据此 fail closed。

implementation manifest 让 facet 分类在结构上可判定，但不能凭自报内容证明事实为真；真实性仍由 sealed assurance、独立 attestation 与 authenticated source boundary 资格化。

本 PR 是 #441 的底层前置，只闭合 randomization identity 与 Runtime implementation projection；ComparabilityPolicy／Assessment wire contract、认证 source boundary 和完整变化矩阵将在后续 PR 落地。

Refs #441
