### PR TITLE
fix(eval-core)!: BREAKING-COMPARABILITY 收紧 v1 证据捕获契约

### DIFF
--- a/docs/specs/evaluation-core-vnext.md
+++ b/docs/specs/evaluation-core-vnext.md
@@ -392,7 +392,7 @@ decisionPlanDigest = H(
 runContractDigest = H(all plan digests + schema identities)
 ```
 
-Annotations such as `project`, `owner`, and `tags` do not enter measurement digests. Output/trace capture mode and their classification ceiling enter ExecutionPlan identity because they change the durable Execution facts and cache key; the complete EvidencePolicy also enters EvaluationPlan because it determines evaluator bindings and evaluation evidence. Evaluation-only input/expected/evidence capture does not invalidate Execution.
+Annotations such as `project`, `owner`, and `tags` do not enter measurement digests. Output/trace capture mode and their classification ceiling enter ExecutionPlan identity because they change the durable Execution facts and cache key. The complete v1 EvidencePolicy also enters EvaluationPlan because evaluator-produced evidence is an Evaluation fact. Dataset input and expected values are sealed stage inputs rather than EvidencePolicy capture targets: `executionInputDigest` binds executor-visible input, while `evaluationInputDigest` additionally binds expected and evaluation context. Evaluator-evidence capture does not invalidate Execution.
 
 ### 7.1 ADR: compare a declared subject under an invariant measurement system
 
@@ -710,7 +710,17 @@ Core never dereferences a URI directly. ContentResolver enforces access control,
 
 Content is classified at least as public, sensitive, secret, or gold. EventWriter, Report materializer, ContentStore, and error serializer each declare their maximum accepted classification. Evaluator evidence and errors pass through the same classification and redaction rules.
 
-EvidencePolicy controls full/reference/digest/none capture independently for input, output, trace, expected, and evidence and reports how each choice affects replayability or evidenceStatus.
+EvidencePolicy v1 controls full/reference/digest/none capture independently for executor output, execution trace, and evaluator-produced evidence. Dataset input and expected values are sealed plan inputs, not capture envelopes.
+
+### 11.1 ADR: keep Dataset inputs out of EvidencePolicy v1
+
+**Status:** accepted for v1; tracked by [#441](https://github.com/lizhiyao/oh-my-knowledge/issues/441).
+
+EvidencePolicy v1 does not expose `input` or `expected` capture modes. Earlier drafts included both fields, but changing them only changed EvaluationPlan identity: no Runtime captured a corresponding artifact, no Bundle recorded the choice, and durable import could not revalidate it. v1 therefore rejects those fields as unknown instead of retaining aliases, deprecation paths, or no-op compatibility behavior.
+
+Dataset input remains bound by `executionInputDigest`; expected and evaluation context remain bound by `evaluationInputDigest`. The sealed EvaluationPlan supplies the requested bindings to Evaluators, while Gold stays absent from Executor contexts and execution artifacts. This preserves measurement identity and Gold isolation without pretending that plan-resident values are durable evidence captures.
+
+A future full/reference/digest/none policy for Dataset content requires a separate, content-addressed artifact model that avoids per-trial and per-Evaluator duplication. It must define ContentStore/ContentResolver authorization, digest and media-type verification, classification and redaction, replayability and evidence-status consequences, and durable-import revalidation. Dataset/Gold persistence and presentation are therefore deferred to an explicit artifact or host policy; adding them requires a new wire-schema revision rather than silently restoring v1 fields.
 
 ## 12. Public API sketch
 

--- a/docs/zh/specs/evaluation-core-vnext.md
+++ b/docs/zh/specs/evaluation-core-vnext.md
@@ -392,7 +392,7 @@ decisionPlanDigest = H(
 runContractDigest = H(all plan digests + schema identities)
 ```
 
-`project`、`owner`、`tags` 等 annotations 不进入测量 digest。output／trace 的捕获方式及其 classification ceiling 会改变持久化 Execution 事实和 cache key，因此进入 ExecutionPlan 身份；完整 EvidencePolicy 同时进入 EvaluationPlan，因为它决定 Evaluator binding 与评测 evidence。仅影响 Evaluation 的 input／expected／evidence 捕获不失效 Execution。
+`project`、`owner`、`tags` 等 annotations 不进入测量 digest。output／trace 的捕获方式及其 classification ceiling 会改变持久化 Execution 事实和 cache key，因此进入 ExecutionPlan 身份。完整的 v1 EvidencePolicy 同时进入 EvaluationPlan，因为 Evaluator 产生的 evidence 属于 Evaluation 事实。Dataset 的 input 和 expected 是 sealed stage input，不是 EvidencePolicy 捕获目标：`executionInputDigest` 绑定 Executor 可见的 input，`evaluationInputDigest` 进一步绑定 expected 和 evaluation context。Evaluator evidence 的捕获方式不失效 Execution。
 
 ### 1．ADR：在不变测量系统下比较显式声明的研究对象
 
@@ -710,7 +710,17 @@ Core 不直接解引用 URI。ContentResolver 负责访问控制、大小限制�
 
 内容至少分为 public、sensitive、secret、gold。EventWriter、Report materializer、ContentStore 和 error serializer 各自声明允许接收的最高分类。Evaluator 产生的 evidence 和错误信息也经过相同分类与 redaction。
 
-EvidencePolicy 分别控制 input、output、trace、expected 和 evidence 的 full／reference／digest／none 捕获方式，并清楚报告这会不会降低 replayability 或 evidenceStatus。
+EvidencePolicy v1 分别控制 Executor output、execution trace 和 Evaluator 产生的 evidence 的 full／reference／digest／none 捕获方式。Dataset 的 input 和 expected 是 sealed plan input，不是 capture envelope。
+
+### 十一．一 ADR：v1 EvidencePolicy 不承载 Dataset input
+
+**状态**：v1 已接受，由 [#441](https://github.com/lizhiyao/oh-my-knowledge/issues/441) 跟踪。
+
+EvidencePolicy v1 不暴露 `input` 或 `expected` 捕获方式。早期草案包含这两个字段，但改变它们只会改变 EvaluationPlan identity：Runtime 不捕获对应 artifact，Bundle 不记录该选择，durable import 也无法重验。v1 因此把这些字段作为未知字段拒绝，不保留 alias、deprecated path 或无行为的兼容逻辑。
+
+Dataset input 继续由 `executionInputDigest` 绑定；expected 和 evaluation context 继续由 `evaluationInputDigest` 绑定。sealed EvaluationPlan 向 Evaluator 提供其声明的 binding，同时 Gold 不进入 Executor context 和 execution artifact。这样既保持测量身份与 Gold 隔离，也不会把 plan 内的数据伪装成持久化 evidence capture。
+
+未来若要为 Dataset 内容提供 full／reference／digest／none policy，需要单独设计内容寻址 artifact model，并避免按 trial 和 Evaluator 重复放大数据。该模型必须定义 ContentStore／ContentResolver 授权、digest 与 media type 校验、classification 与 redaction、replayability 与 evidence status 后果，以及 durable import 重验。Dataset／Gold 的持久化与展示因此留给显式 artifact 或 host policy；若要增加这项能力，必须发布新的 wire schema revision，不能静默恢复 v1 字段。
 
 ## 十二、公共 API 草案
 

--- a/schemas/evaluation-core/v1/evaluation-plan.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-plan.schema.json
@@ -74,12 +74,6 @@
             "evidence": {
               "$ref": "#/$defs/__schema14"
             },
-            "expected": {
-              "$ref": "#/$defs/__schema14"
-            },
-            "input": {
-              "$ref": "#/$defs/__schema14"
-            },
             "maximumClassification": {
               "enum": [
                 "public",
@@ -97,10 +91,8 @@
             }
           },
           "required": [
-            "input",
             "output",
             "trace",
-            "expected",
             "evidence",
             "maximumClassification"
           ],

--- a/schemas/evaluation-core/v1/measurement-policy.schema.json
+++ b/schemas/evaluation-core/v1/measurement-policy.schema.json
@@ -260,12 +260,6 @@
         "evidence": {
           "$ref": "#/$defs/__schema7"
         },
-        "expected": {
-          "$ref": "#/$defs/__schema7"
-        },
-        "input": {
-          "$ref": "#/$defs/__schema7"
-        },
         "maximumClassification": {
           "enum": [
             "public",
@@ -283,10 +277,8 @@
         }
       },
       "required": [
-        "input",
         "output",
         "trace",
-        "expected",
         "evidence",
         "maximumClassification"
       ],

--- a/schemas/evaluation-core/v1/run-plan.schema.json
+++ b/schemas/evaluation-core/v1/run-plan.schema.json
@@ -1086,12 +1086,6 @@
         "evidence": {
           "$ref": "#/$defs/__schema54"
         },
-        "expected": {
-          "$ref": "#/$defs/__schema54"
-        },
-        "input": {
-          "$ref": "#/$defs/__schema54"
-        },
         "maximumClassification": {
           "$ref": "#/$defs/__schema55"
         },
@@ -1103,10 +1097,8 @@
         }
       },
       "required": [
-        "input",
         "output",
         "trace",
-        "expected",
         "evidence",
         "maximumClassification"
       ],

--- a/src/evaluation-core/contracts/definition.ts
+++ b/src/evaluation-core/contracts/definition.ts
@@ -260,10 +260,8 @@ export const CachePolicySchema = z.object({
 export const CaptureModeSchema = z.enum(['full', 'reference', 'digest', 'none']);
 
 export const EvidencePolicySchema = z.object({
-  input: CaptureModeSchema,
   output: CaptureModeSchema,
   trace: CaptureModeSchema,
-  expected: CaptureModeSchema,
   evidence: CaptureModeSchema,
   maximumClassification: ContentClassificationSchema,
 }).strict();

--- a/test/evaluation-core/compiler/digests.test.ts
+++ b/test/evaluation-core/compiler/digests.test.ts
@@ -118,12 +118,20 @@ describe('Compiler digest invalidation boundaries', () => {
     expectStages(before, after, ['execution', 'evaluation', 'analysis', 'decision', 'run']);
   });
 
-  it('keeps Evaluation-only evidence capture out of Execution identity', async () => {
+  it('keeps evaluator-produced evidence capture out of Execution identity', async () => {
     const before = await compile();
     const after = await compile(undefined, (policy) => {
-      policy.evidence.expected = 'digest';
       policy.evidence.evidence = 'digest';
     });
+
+    expect(before.evaluation.policy.evidence).toEqual({
+      output: 'full',
+      trace: 'reference',
+      evidence: 'full',
+      maximumClassification: 'gold',
+    });
+    expect(before.evaluation.policy.evidence).not.toHaveProperty('input');
+    expect(before.evaluation.policy.evidence).not.toHaveProperty('expected');
     expectStages(before, after, ['evaluation', 'analysis', 'decision', 'run']);
   });
 

--- a/test/evaluation-core/compiler/fixtures.ts
+++ b/test/evaluation-core/compiler/fixtures.ts
@@ -164,10 +164,8 @@ export function validPolicy(): MeasurementPolicy {
     },
     cache: { executionMode: 'disabled', evaluationMode: 'disabled' },
     evidence: {
-      input: 'digest',
       output: 'full',
       trace: 'reference',
-      expected: 'digest',
       evidence: 'full',
       maximumClassification: 'gold',
     },

--- a/test/evaluation-core/compiler/validation.test.ts
+++ b/test/evaluation-core/compiler/validation.test.ts
@@ -49,6 +49,25 @@ describe('Compiler definition validation', () => {
     expect(semanticRuntime.calls).toEqual({ executor: 0, evaluator: 0, analysis: 0, extension: 0 });
   });
 
+  it.each(['input', 'expected'] as const)(
+    'rejects the removed EvidencePolicy.%s field without compatibility parsing',
+    async (field) => {
+      const policy = structuredClone(validPolicy()) as unknown as {
+        evidence: Record<string, unknown>;
+      };
+      policy.evidence[field] = 'full';
+      const runtime = testRuntime();
+
+      await expectCode(
+        validDefinition(),
+        policy,
+        'EVAL_DEFINITION_SCHEMA_INVALID',
+        runtime,
+      );
+      expect(runtime.calls).toEqual({ executor: 0, evaluator: 0, analysis: 0, extension: 0 });
+    },
+  );
+
   it('rejects missing references and invalid Metric value domains', async () => {
     const missing = validDefinition();
     missing.evaluators[0].metricIds = ['missing'];

--- a/test/evaluation-core/conformance/harness.ts
+++ b/test/evaluation-core/conformance/harness.ts
@@ -658,10 +658,8 @@ function scenarioPolicy(target: ConformanceTarget): MeasurementPolicy {
   delete policy.evaluation.timeoutMs;
   policy.retry.maxAttempts = 1;
   policy.evaluation.retry.maxAttempts = 1;
-  policy.evidence.input = 'full';
   policy.evidence.output = 'full';
   policy.evidence.trace = target === 'agent' ? 'full' : 'none';
-  policy.evidence.expected = 'full';
   policy.evidence.evidence = 'full';
   return policy;
 }

--- a/test/evaluation-core/contracts/digests.test.ts
+++ b/test/evaluation-core/contracts/digests.test.ts
@@ -50,10 +50,8 @@ const policy: MeasurementPolicy = {
   },
   cache: { executionMode: 'disabled', evaluationMode: 'disabled' },
   evidence: {
-    input: 'digest',
     output: 'full',
     trace: 'reference',
-    expected: 'digest',
     evidence: 'full',
     maximumClassification: 'gold',
   },


### PR DESCRIPTION
## 用户影响

- `EvidencePolicy` v1 只保留真实影响持久化事实的 output、trace、Evaluator evidence 与 classification ceiling。
- 旧的 input／expected capture 字段现在按未知字段拒绝，不再产生「digest 改变、Runtime 行为不变」的虚假配置。
- Dataset input、expected 与 evaluation context 仍分别由 execution／evaluation input digest 绑定，并继续通过 sealed plan 向对应 Runtime 提供；Gold 隔离不变。

## 迁移说明

删除 MeasurementPolicy.evidence 中的 input 和 expected 配置。当前无历史兼容负担，因此不提供 deprecated alias、兼容读取或双写路径。

## 架构与测量学说明

中英文 RFC 增加 accepted ADR：Dataset 内容捕获若要支持 full／reference／digest／none，必须先建立内容寻址 artifact、授权 resolver／store、分类与脱敏、replayability／evidence status 以及 durable import 重验语义。v1 不用无行为字段预占这套能力。

这是 BREAKING-COMPARABILITY 变更：MeasurementPolicy、EvaluationPlan 与 RunPlan 的 wire schema identity 会变化，相关 plan／root digest 也会重新计算。Dataset／Gold 本身的测量身份没有被移除。

完整 lint、typecheck、build 与 test 门禁已通过。

Refs #441
Tracks #425
