### PR TITLE
test(eval-core): 固化能力与宿主副作用边界

### DIFF
--- a/test/architecture/import-boundaries.test.ts
+++ b/test/architecture/import-boundaries.test.ts
@@ -14,9 +14,12 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative, normalize, sep, dirname } from 'node:path';
+import ts from 'typescript';
 
 const REPO_ROOT = join(__dirname, '..', '..');
 const SRC_DIR = join(REPO_ROOT, 'src');
+const EVALUATION_CORE_DIR = join(SRC_DIR, 'evaluation-core');
+const EVALUATION_CORE_DIR_NORMALIZED = EVALUATION_CORE_DIR.replace(/\\/g, '/');
 
 interface ForbiddenRule {
   /** 源 layer 前缀(src-relative,以 `/` 结尾的目录或具体文件路径前缀)。 */
@@ -214,6 +217,149 @@ function collectViolations(): Violation[] {
   return violations;
 }
 
+interface CoreCapabilityViolation {
+  file: string;
+  detail: string;
+}
+
+const ALLOWED_CORE_EXTERNAL_IMPORTS = new Set(['zod', 'node:crypto']);
+const FORBIDDEN_HOST_GLOBALS = new Set([
+  'process',
+  'console',
+  'globalThis',
+  'window',
+  'document',
+  'navigator',
+  'localStorage',
+  'sessionStorage',
+  'fetch',
+  'WebSocket',
+  'EventSource',
+  'XMLHttpRequest',
+  'setTimeout',
+  'setInterval',
+  'setImmediate',
+  'queueMicrotask',
+  'require',
+  'eval',
+  'Function',
+  'Deno',
+  'Bun',
+]);
+
+function moduleSpecifier(node: ts.Node): ts.Expression | undefined {
+  if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+    return node.moduleSpecifier;
+  }
+  if (ts.isCallExpression(node)
+      && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+    return node.arguments[0];
+  }
+  return undefined;
+}
+
+function isPropertyName(identifier: ts.Identifier): boolean {
+  const parent = identifier.parent;
+  return (ts.isPropertyAccessExpression(parent) && parent.name === identifier)
+    || ((ts.isPropertyAssignment(parent)
+      || ts.isMethodDeclaration(parent)
+      || ts.isPropertyDeclaration(parent)
+      || ts.isPropertySignature(parent)) && parent.name === identifier);
+}
+
+function isLocallyDeclared(
+  identifier: ts.Identifier,
+  checker: ts.TypeChecker,
+  source: ts.SourceFile,
+): boolean {
+  return checker.getSymbolAtLocation(identifier)?.declarations?.some(
+    (declaration) => declaration.getSourceFile() === source,
+  ) ?? false;
+}
+
+function collectEvaluationCoreCapabilityViolations(): CoreCapabilityViolation[] {
+  const violations: CoreCapabilityViolation[] = [];
+  const files = listTsFiles(EVALUATION_CORE_DIR);
+  const program = ts.createProgram(files, {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.Node16,
+    moduleResolution: ts.ModuleResolutionKind.Node16,
+    types: ['node'],
+    skipLibCheck: true,
+  });
+  const checker = program.getTypeChecker();
+  for (const file of files) {
+    const fileName = toSrcRelative(file);
+    const source = program.getSourceFile(file);
+    if (source === undefined) throw new Error(`无法解析 Evaluation Core 源文件：${fileName}`);
+    const report = (detail: string): void => {
+      violations.push({ file: fileName, detail });
+    };
+    const visit = (node: ts.Node): void => {
+      const specifier = moduleSpecifier(node);
+      if (specifier !== undefined) {
+        if (!ts.isStringLiteralLike(specifier)) {
+          report('使用了非字面量 dynamic import，无法证明依赖闭包。');
+        } else if (specifier.text.startsWith('.')) {
+          const resolved = resolveSpecifier(file, specifier.text);
+          if (resolved === null
+              || (!resolved.startsWith(`${EVALUATION_CORE_DIR_NORMALIZED}/`)
+                && resolved !== EVALUATION_CORE_DIR_NORMALIZED)) {
+            report(`跨出 Evaluation Core 的依赖：${specifier.text}`);
+          }
+        } else if (!ALLOWED_CORE_EXTERNAL_IMPORTS.has(specifier.text)) {
+          report(`未获准的外部依赖：${specifier.text}`);
+        } else if (specifier.text === 'node:crypto') {
+          if (!ts.isImportDeclaration(node)
+              || node.importClause?.name !== undefined
+              || node.importClause?.namedBindings === undefined
+              || !ts.isNamedImports(node.importClause.namedBindings)
+              || node.importClause.namedBindings.elements.some((element) => (
+                (element.propertyName?.text ?? element.name.text) !== 'createHash'
+              ))) {
+            report('node:crypto 只允许具名导入确定性的 createHash。');
+          }
+        }
+      }
+
+      if (ts.isIdentifier(node)
+          && FORBIDDEN_HOST_GLOBALS.has(node.text)
+          && !isPropertyName(node)
+          && !isLocallyDeclared(node, checker, source)) {
+        report(`访问了宿主全局能力：${node.text}`);
+      }
+      if (ts.isPropertyAccessExpression(node)) {
+        const owner = node.expression.getText(source);
+        const member = node.name.text;
+        if ((owner === 'Date' && member === 'now')
+            || (owner === 'Math' && member === 'random')
+            || (owner === 'performance' && member === 'now')
+            || (owner === 'crypto' && ['getRandomValues', 'randomUUID'].includes(member))) {
+          report(`访问了非确定性宿主能力：${owner}.${member}`);
+        }
+      }
+      if (ts.isCallExpression(node)
+          && ts.isIdentifier(node.expression)
+          && node.expression.text === 'Date') {
+        report('访问了隐式 wall clock：Date()');
+      }
+      if (ts.isNewExpression(node)
+          && ts.isIdentifier(node.expression)
+          && node.expression.text === 'Date'
+          && (node.arguments === undefined || node.arguments.length === 0)) {
+        report('访问了隐式 wall clock：new Date()');
+      }
+      if (ts.isMetaProperty(node)
+          && node.keywordToken === ts.SyntaxKind.ImportKeyword) {
+        report('访问了宿主模块位置：import.meta');
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+  return violations;
+}
+
 describe('架构边界守门', () => {
   it('禁止反向 / 跨层 import(规则集见本文件 RULES)', () => {
     const violations = collectViolations();
@@ -256,5 +402,18 @@ describe('架构边界守门', () => {
       throw new Error(`whitelist 中有 ${dead.length} 条不再对应真实 import,请清理:\n${dead.join('\n')}`);
     }
     expect(dead).toEqual([]);
+  });
+
+  it('Evaluation Core 只依赖内部模块、Zod 和确定性哈希', () => {
+    const violations = collectEvaluationCoreCapabilityViolations();
+    if (violations.length > 0) {
+      throw new Error([
+        `发现 ${violations.length} 处 Evaluation Core 宿主能力越界：`,
+        ...violations.map((violation) => `  ${violation.file}：${violation.detail}`),
+        '',
+        'Core 必须通过显式注入的 port 获得时间、文件、网络、环境和外部 Runtime 能力。',
+      ].join('\n'));
+    }
+    expect(violations).toEqual([]);
   });
 });

--- a/test/evaluation-core/fixtures/core-side-effect-probe.mjs
+++ b/test/evaluation-core/fixtures/core-side-effect-probe.mjs
@@ -1,0 +1,110 @@
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+const [repositoryRoot] = process.argv.slice(2);
+if (repositoryRoot === undefined) throw new Error('repository root is required');
+
+const moduleUrls = [
+  'contracts/index.js',
+  'compiler/index.js',
+  'execution/index.js',
+  'evaluation/index.js',
+  'analysis/index.js',
+].map((entry) => pathToFileURL(resolve(
+  repositoryRoot,
+  'dist/evaluation-core',
+  entry,
+)).href);
+
+const watchedSignals = [
+  'beforeExit',
+  'exit',
+  'SIGINT',
+  'SIGTERM',
+  'uncaughtException',
+  'unhandledRejection',
+];
+const listenersBefore = new Map(watchedSignals.map((signal) => (
+  [signal, process.rawListeners(signal)]
+)));
+const originalCwd = process.cwd;
+const originalEnv = process.env;
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+function restoreHostCapabilities() {
+  process.cwd = originalCwd;
+  process.env = originalEnv;
+}
+
+try {
+  const [contracts, compiler, execution] = await Promise.all(
+    moduleUrls.map((url) => import(url)),
+  );
+
+  // Node 的 ESM loader 自身会读取环境变量；Core 源码的导入期环境访问由静态
+  // dependency-closure guard 证明不存在。加载完成后再封锁宿主能力，验证运行期。
+  process.cwd = () => {
+    throw new Error('Evaluation Core accessed process.cwd()');
+  };
+  process.env = new Proxy(Object.create(null), {
+    get(_target, property) {
+      throw new Error(`Evaluation Core read process.env.${String(property)}`);
+    },
+    has(_target, property) {
+      throw new Error(`Evaluation Core inspected process.env.${String(property)}`);
+    },
+    ownKeys() {
+      throw new Error('Evaluation Core enumerated process.env');
+    },
+  });
+
+  const canonical = contracts.canonicalizeJson({ z: 1, a: ['memory-only'] });
+  const digest = contracts.digestCanonicalJson({ z: 1, a: ['memory-only'] });
+  if (canonical !== '{"a":["memory-only"],"z":1}'
+      || !digest.startsWith('sha256:')) {
+    throw new Error('Evaluation Core pure-memory contract operation failed');
+  }
+
+  const sequencer = new execution.InMemoryRuntimeEventSequencer();
+  if (sequencer.next('isolated-run') !== 0
+      || sequencer.next('isolated-run') !== 1) {
+    throw new Error('Evaluation Core pure-memory runtime operation failed');
+  }
+
+  let rejectedInvalidDefinition = false;
+  try {
+    await compiler.prepareEvaluationPlan({}, {}, {
+      schemaValidators: new Map(),
+      resolveExecutor() {
+        throw new Error('invalid input must fail before Runtime resolution');
+      },
+      resolveEvaluator() {
+        throw new Error('invalid input must fail before Runtime resolution');
+      },
+      resolveAnalysis() {
+        throw new Error('invalid input must fail before Runtime resolution');
+      },
+    });
+  } catch (error) {
+    rejectedInvalidDefinition = error instanceof compiler.EvaluationDefinitionError;
+  }
+  if (!rejectedInvalidDefinition) {
+    throw new Error('Evaluation Core compiler did not run its in-memory validation');
+  }
+
+  for (const signal of watchedSignals) {
+    const before = listenersBefore.get(signal) ?? [];
+    const after = process.rawListeners(signal);
+    if (after.length !== before.length
+        || after.some((listener, index) => listener !== before[index])) {
+      throw new Error(`Evaluation Core registered a process hook: ${signal}`);
+    }
+  }
+
+  restoreHostCapabilities();
+} catch (error) {
+  restoreHostCapabilities();
+  const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  originalStderrWrite(`${detail}\n`);
+  process.exitCode = 1;
+}

--- a/test/evaluation-core/runtime-side-effects.test.ts
+++ b/test/evaluation-core/runtime-side-effects.test.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const PROBE_PATH = join(
+  REPO_ROOT,
+  'test/evaluation-core/fixtures/core-side-effect-probe.mjs',
+);
+const CORE_DIST_ENTRY = join(REPO_ROOT, 'dist/evaluation-core/contracts/index.js');
+
+function directorySnapshot(root: string): string[] {
+  const snapshot: string[] = [];
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      const kind = entry.isDirectory() ? 'directory' : entry.isFile() ? 'file' : 'other';
+      const size = entry.isFile() ? statSync(path).size : 0;
+      snapshot.push(`${relative(root, path)}:${kind}:${size}`);
+      if (entry.isDirectory()) visit(path);
+    }
+  };
+  visit(root);
+  return snapshot.sort();
+}
+
+describe('Evaluation Core 宿主副作用边界', () => {
+  it('在隔离进程导入内部入口并运行纯内存操作时零宿主副作用', () => {
+    if (!existsSync(CORE_DIST_ENTRY)) {
+      throw new Error('缺少 dist/evaluation-core；请先运行 yarn build。');
+    }
+
+    const sandboxRoot = mkdtempSync(join(tmpdir(), 'omk-core-side-effects-'));
+    const workingDirectory = join(sandboxRoot, 'cwd');
+    const userDirectory = join(sandboxRoot, 'home');
+    const configDirectory = join(userDirectory, '.config');
+    const tempDirectory = join(sandboxRoot, 'tmp');
+    mkdirSync(workingDirectory);
+    mkdirSync(configDirectory, { recursive: true });
+    mkdirSync(tempDirectory);
+    const before = directorySnapshot(sandboxRoot);
+
+    try {
+      const result = spawnSync(process.execPath, [PROBE_PATH, REPO_ROOT], {
+        cwd: workingDirectory,
+        encoding: 'utf8',
+        env: {
+          HOME: userDirectory,
+          USERPROFILE: userDirectory,
+          XDG_CONFIG_HOME: configDirectory,
+          OMK_HOME: userDirectory,
+          TMPDIR: tempDirectory,
+        },
+        timeout: 30_000,
+      });
+
+      expect({
+        status: result.status,
+        signal: result.signal,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        error: result.error?.message,
+      }).toEqual({
+        status: 0,
+        signal: null,
+        stdout: '',
+        stderr: '',
+        error: undefined,
+      });
+      expect(directorySnapshot(sandboxRoot)).toEqual(before);
+    } finally {
+      rmSync(sandboxRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/evaluation-core/types/capability-boundary.compile.ts
+++ b/test/evaluation-core/types/capability-boundary.compile.ts
@@ -1,0 +1,49 @@
+import type {
+  AnalysisRunOptions,
+  DecisionOptions,
+  EvaluationReportRunOptions,
+} from '../../../src/evaluation-core/analysis/index.js';
+import type {
+  ExecutionRunOptions,
+  ExecutorTrialContext,
+} from '../../../src/evaluation-core/execution/index.js';
+import type {
+  EvaluationRunOptions,
+} from '../../../src/evaluation-core/evaluation/index.js';
+
+declare const executorContext: ExecutorTrialContext;
+
+// @ts-expect-error Executor 只能看到执行输入，不能获得 Gold。
+void executorContext.expected;
+
+// @ts-expect-error Executor 不能获得只供评测阶段使用的上下文。
+void executorContext.evaluationContext;
+
+type KeysOfUnion<Value> = Value extends unknown ? keyof Value : never;
+
+type CoreRunOptions =
+  | ExecutionRunOptions
+  | EvaluationRunOptions
+  | AnalysisRunOptions
+  | DecisionOptions
+  | EvaluationReportRunOptions;
+
+type AllowedRunOptionKey =
+  | 'runId'
+  | 'bundleId'
+  | 'reportId'
+  | 'signal'
+  | 'eventBufferCapacity'
+  | 'annotations'
+  | 'summaries';
+
+type AssertNever<Value extends never> = Value;
+
+/**
+ * RunOptions 只承载本次运行的身份、取消和物化参数；测量策略必须来自已密封计划。
+ * 新增任何策略覆写字段都会让 `yarn typecheck` 失败。
+ */
+export type RunOptionsPolicyBoundary = AssertNever<Exclude<
+  KeysOfUnion<CoreRunOptions>,
+  AllowedRunOptionKey
+>>;


### PR DESCRIPTION
## 用户影响

- Evaluation Core 的内部入口现在有可执行的宿主无副作用边界，后续引入文件、网络、环境变量、进程 hook 或隐式全局能力会在 CI 阶段被阻断。
- Executor 的 Gold 隔离与 RunOptions 不可覆写密封测量策略，均从接口约定提升为编译期约束。
- #425 只验收内部 Core；package-root façade、公开 exports 和独立 npm consumer 仍由 #424 负责。

## 架构与测量语义

本 PR 只加固能力边界，不改变 Definition、MeasurementPolicy、RunPlan、Bundle、Report、评分类 prompt 或任何统计计算语义，因此不产生跨版本测量可比性变化。Core 的 effect 继续只通过显式 Runtime port 注入；允许的内部运行时依赖收敛为 Zod 与确定性 SHA-256 哈希。

隔离进程验收把 Core 自身行为与 Node.js ESM loader 的宿主行为分开：导入期依赖闭包由静态守卫证明，运行期环境与 cwd 访问被动态封锁，同时验证临时用户目录、stdout／stderr 与 process hook 保持不变。

## 迁移说明

无。没有 public schema 或运行时 API 变更。

## 验证

`yarn ci`：280 个测试文件、3411 条测试全部通过。

Refs #441
Tracks #425
