### PR TITLE
test(eval-core): 固化目标与评委中立性

### DIFF
--- a/test/evaluation-core/conformance/harness.ts
+++ b/test/evaluation-core/conformance/harness.ts
@@ -16,6 +16,7 @@ import {
   type RuntimeIdentity,
   type SchemaIdentity,
   type Sha256Digest,
+  type UsageRecord,
   digestCanonicalJson,
   effectiveExecutionBundleTrust,
   parseEvaluationReport,
@@ -180,6 +181,7 @@ export interface ConformanceHarnessOptions {
   evaluationCache?: InMemoryConformanceEvaluationCache;
   runtimeRegistry?: ConformanceRuntimeRegistry;
   executorAssurance?: RuntimeIdentity['assuranceLevel'];
+  evaluatorUsage?: UsageRecord;
 }
 
 export class InMemoryConformanceArtifactStore {
@@ -799,6 +801,7 @@ function makeEvaluator(
   target: ConformanceTarget,
   plan: SealedRunPlan,
   resolveRun: ConformanceRunBindingResolver,
+  usage?: UsageRecord,
 ): EvaluationEvaluator {
   const referenceId = target === 'function'
     ? 'exact'
@@ -828,6 +831,7 @@ function makeEvaluator(
                     valueType: 'boolean' as const,
                     value: binding(context, 'actual') === binding(context, 'gold'),
                   }],
+                  ...(usage === undefined ? {} : { usage: structuredClone(usage) }),
                 };
               }
               if (target === 'rag') {
@@ -846,6 +850,7 @@ function makeEvaluator(
                       classification: 'public' as const,
                     },
                   })),
+                  ...(usage === undefined ? {} : { usage: structuredClone(usage) }),
                 };
               }
               const calls = binding(context, 'tool-calls');
@@ -862,6 +867,7 @@ function makeEvaluator(
                   valueType: 'boolean' as const,
                   value: required.every((name) => calledNames.has(name)),
                 }],
+                ...(usage === undefined ? {} : { usage: structuredClone(usage) }),
               };
             },
             async dispose() {
@@ -882,6 +888,7 @@ function makeEvaluator(
 function makeOutputOnlyAgentEvaluator(
   plan: SealedRunPlan,
   resolveRun: ConformanceRunBindingResolver,
+  usage?: UsageRecord,
 ): EvaluationEvaluator {
   return {
     identity: runtimeIdentity(plan, 'evaluator', 'answer-shape'),
@@ -906,6 +913,7 @@ function makeOutputOnlyAgentEvaluator(
                   valueType: 'boolean' as const,
                   value: Array.isArray(answer) && answer.length > 0,
                 }],
+                ...(usage === undefined ? {} : { usage: structuredClone(usage) }),
               };
             },
             async dispose() {
@@ -971,15 +979,22 @@ function makeEvaluatorRegistry(
   target: ConformanceTarget,
   plan: SealedRunPlan,
   resolveRun: ConformanceRunBindingResolver,
+  usage?: UsageRecord,
 ): Map<string, EvaluationEvaluator> {
   const evaluatorId = target === 'function'
     ? 'exact/v1'
     : target === 'rag'
       ? 'retrieval/v1'
       : 'trajectory/v1';
-  const evaluators = new Map([[evaluatorId, makeEvaluator(target, plan, resolveRun)]]);
+  const evaluators = new Map([[
+    evaluatorId,
+    makeEvaluator(target, plan, resolveRun, usage),
+  ]]);
   if (target === 'agent') {
-    evaluators.set('answer-shape/v1', makeOutputOnlyAgentEvaluator(plan, resolveRun));
+    evaluators.set(
+      'answer-shape/v1',
+      makeOutputOnlyAgentEvaluator(plan, resolveRun, usage),
+    );
   }
   return evaluators;
 }
@@ -1129,7 +1144,7 @@ export async function runConformanceScenario(
   const executors = registry?.executors
     ?? new Map([['executor-alias', makeExecutor(target, plan, localBinding)]]);
   const evaluators = registry?.evaluators
-    ?? makeEvaluatorRegistry(target, plan, localBinding);
+    ?? makeEvaluatorRegistry(target, plan, localBinding, options.evaluatorUsage);
   const eventSequencer = registry?.eventSequencer ?? new InMemoryRuntimeEventSequencer();
   const eventWriter = registry?.eventWriter ?? (options.faults === undefined
     ? undefined

--- a/test/evaluation-core/conformance/neutrality.test.ts
+++ b/test/evaluation-core/conformance/neutrality.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from 'vitest';
+import type { EvaluationRecord } from '../../../src/evaluation-core/contracts/index.js';
+import { ConformanceFaultInjector } from './fault-injector.js';
+import {
+  InMemoryConformanceEvaluationCache,
+  prepareConformancePlan,
+  runConformanceScenario,
+  type ConformanceResult,
+} from './harness.js';
+
+const TARGET_KIND_ALIASES = [
+  'function',
+  'service',
+  'model',
+  'rag',
+  'agent',
+  'workflow',
+  'future-target-7f3d',
+] as const;
+
+const EVALUATOR_KIND_ALIASES = [
+  'assertion',
+  'structured-scorer',
+  'llm-judge',
+] as const;
+
+const EVALUATOR_USAGE = {
+  inputTokens: 3,
+  outputTokens: 2,
+  totalTokens: 5,
+  details: { source: 'deterministic-test-double' },
+} as const;
+
+function evaluationRecordProjection(record: EvaluationRecord) {
+  if (record.evaluationStatus !== 'completed') {
+    return {
+      targetId: record.targetId,
+      sampleId: record.sampleId,
+      trialIndex: record.trialIndex,
+      evaluatorId: record.evaluatorId,
+      evaluationStatus: record.evaluationStatus,
+      errorCode: 'error' in record ? record.error?.code : undefined,
+    };
+  }
+  return {
+    targetId: record.targetId,
+    sampleId: record.sampleId,
+    trialIndex: record.trialIndex,
+    evaluatorId: record.evaluatorId,
+    evaluationStatus: record.evaluationStatus,
+    observations: record.observations.map(({ observationId: _observationId, ...observation }) => (
+      observation
+    )),
+    usage: record.usage,
+    attemptStatuses: record.attempts.map((attempt) => attempt.attemptStatus),
+  };
+}
+
+function orchestrationSignature(result: ConformanceResult) {
+  return {
+    protocols: result.plan.execution.targets.map((target) => target.protocolId),
+    executorRuntimes: result.plan.execution.runtimes
+      .filter((runtime) => runtime.runtimeKind === 'executor')
+      .map((runtime) => ({
+        referenceId: runtime.referenceId,
+        identity: runtime.identity,
+      })),
+    lifecycle: {
+      executorRunOpens: result.state.executorRunOpens,
+      executorRunDisposals: result.state.executorRunDisposals,
+      trialOpens: result.state.trialOpens,
+      trialDisposals: result.state.trialDisposals,
+      executorAttempts: result.state.executorAttempts,
+      evaluatorRunOpens: result.state.evaluatorRunOpens,
+      evaluatorRunDisposals: result.state.evaluatorRunDisposals,
+      recordOpens: result.state.recordOpens,
+      recordDisposals: result.state.recordDisposals,
+      evaluatorAttempts: result.state.evaluatorAttempts,
+    },
+    trialViews: result.state.trialContexts.map((context) => ({
+      targetId: context.targetId,
+      protocolId: context.protocolId,
+      input: context.input,
+      executionContext: context.executionContext,
+      targetConfig: context.targetConfig,
+      trialIndex: context.trialIndex,
+      samplingUnitIds: context.samplingUnitIds,
+    })),
+    evaluatorViews: result.state.recordContexts.map((context) => ({
+      targetId: context.targetId,
+      sampleId: context.sampleId,
+      trialIndex: context.trialIndex,
+      evaluatorId: context.evaluatorId,
+      evaluatorConfig: context.evaluatorConfig,
+      bindings: context.bindings,
+      metrics: context.metrics,
+    })),
+    execution: {
+      status: result.execution.executionBundleStatus,
+      coverage: result.execution.coverage,
+      records: result.execution.records.map((record) => ({
+        targetId: record.targetId,
+        sampleId: record.sampleId,
+        trialIndex: record.trialIndex,
+        executionStatus: record.executionStatus,
+        output: record.executionStatus === 'completed' ? record.output : undefined,
+        trace: record.executionStatus === 'completed' ? record.trace : undefined,
+        attemptStatuses: record.executionStatus === 'budget-censored'
+          ? []
+          : record.attempts.map((attempt) => attempt.attemptStatus),
+      })),
+    },
+    evaluation: {
+      status: result.evaluation.evaluationBundleStatus,
+      coverage: result.evaluation.coverage,
+      records: result.evaluation.records.map(evaluationRecordProjection),
+    },
+    decision: result.decision === undefined ? undefined : {
+      status: result.decision.decisionStatus,
+      verdict: result.decision.decisionStatus === 'decided'
+        ? result.decision.verdict
+        : undefined,
+    },
+    reportStatus: result.report.status,
+    eventProtocol: result.events.map((event) => ({
+      eventKind: event.eventKind,
+      subjectKind: event.subject.subjectKind,
+    })),
+  };
+}
+
+describe('Evaluation Core Target／Evaluator neutrality conformance', () => {
+  it('keeps orchestration invariant across descriptive targetKind aliases', async () => {
+    const results = await Promise.all(TARGET_KIND_ALIASES.map(async (targetKind) => (
+      runConformanceScenario('function', {
+        suffix: `target-kind-${targetKind}`,
+        mutate(definition) {
+          definition.targets = definition.targets.map((target) => ({
+            ...target,
+            targetKind,
+          }));
+        },
+      })
+    )));
+    const baseline = orchestrationSignature(results[0]);
+
+    for (const [index, result] of results.entries()) {
+      expect(result.plan.execution.targets.map((target) => target.targetKind)).toEqual([
+        TARGET_KIND_ALIASES[index],
+        TARGET_KIND_ALIASES[index],
+      ]);
+      expect(orchestrationSignature(result)).toEqual(baseline);
+    }
+  });
+
+  it('uses one lifecycle, binding, usage, cache, and teardown contract for Evaluator kinds', async () => {
+    const results = await Promise.all(EVALUATOR_KIND_ALIASES.map(async (evaluatorKind) => {
+      const cache = new InMemoryConformanceEvaluationCache();
+      const plan = await prepareConformancePlan('function', (definition, policy) => {
+        definition.evaluators = definition.evaluators.map((evaluator) => ({
+          ...evaluator,
+          evaluatorKind,
+        }));
+        policy.cache.evaluationMode = 'reuse';
+      });
+      const source = await runConformanceScenario('function', {
+        plan,
+        runId: `evaluator-${evaluatorKind}-source`,
+        suffix: `evaluator-${evaluatorKind}-source`,
+        evaluationCache: new InMemoryConformanceEvaluationCache(),
+        evaluatorUsage: EVALUATOR_USAGE,
+      });
+      const first = await runConformanceScenario('function', {
+        plan,
+        runId: `evaluator-${evaluatorKind}-first`,
+        suffix: `evaluator-${evaluatorKind}-first`,
+        execution: source.execution,
+        evaluationCache: cache,
+        evaluatorUsage: EVALUATOR_USAGE,
+      });
+      const replay = await runConformanceScenario('function', {
+        plan,
+        runId: `evaluator-${evaluatorKind}-replay`,
+        suffix: `evaluator-${evaluatorKind}-replay`,
+        execution: source.execution,
+        evaluationCache: cache,
+        evaluatorUsage: EVALUATOR_USAGE,
+      });
+      return { evaluatorKind, first, replay };
+    }));
+    const baseline = orchestrationSignature(results[0].first);
+
+    for (const { evaluatorKind, first, replay } of results) {
+      expect(first.plan.evaluation.evaluators.map((evaluator) => evaluator.evaluatorKind)).toEqual([
+        evaluatorKind,
+      ]);
+      expect(orchestrationSignature(first)).toEqual(baseline);
+      expect(first.state).toMatchObject({
+        evaluatorRunOpens: 1,
+        evaluatorRunDisposals: 1,
+        recordOpens: 4,
+        recordDisposals: 4,
+        evaluatorAttempts: 4,
+      });
+      expect(first.state.recordContexts.every((context) => (
+        context.bindings.map((binding) => binding.sourceKind).sort().join(',')
+          === 'expected,output'
+      ))).toBe(true);
+      expect(first.evaluation.records.every((record) => (
+        record.evaluationStatus === 'completed'
+        && record.usage?.totalTokens === EVALUATOR_USAGE.totalTokens
+        && record.attempts[0]?.usage?.totalTokens === EVALUATOR_USAGE.totalTokens
+      ))).toBe(true);
+      expect(replay.state).toMatchObject({
+        evaluatorRunOpens: 0,
+        evaluatorRunDisposals: 0,
+        recordOpens: 0,
+        recordDisposals: 0,
+        evaluatorAttempts: 0,
+      });
+      expect(replay.evaluation.records.every((record) => (
+        record.evaluationStatus === 'completed'
+        && record.cache.cacheStatus === 'transparent-hit'
+        && record.provenance.provenanceKind === 'replay'
+      ))).toBe(true);
+    }
+  });
+
+  it('contains Evaluator failures identically without a provider-specific path', async () => {
+    const results = await Promise.all(EVALUATOR_KIND_ALIASES.map(async (evaluatorKind) => {
+      const marker = `provider-secret-${evaluatorKind}`;
+      const faults = new ConformanceFaultInjector().fail('evaluator-evaluate', marker);
+      const result = await runConformanceScenario('function', {
+        suffix: `evaluator-${evaluatorKind}-failure`,
+        faults,
+        evaluatorUsage: EVALUATOR_USAGE,
+        mutate(definition) {
+          definition.evaluators = definition.evaluators.map((evaluator) => ({
+            ...evaluator,
+            evaluatorKind,
+          }));
+        },
+      });
+      return { evaluatorKind, marker, faults, result };
+    }));
+
+    for (const { evaluatorKind, marker, faults, result } of results) {
+      expect(result.plan.evaluation.evaluators[0].evaluatorKind).toBe(evaluatorKind);
+      expect(result.evaluation.coverage).toMatchObject({ failed: 1, completed: 3 });
+      expect(result.evaluation.records.find((record) => (
+        record.evaluationStatus === 'failed'
+      ))).toMatchObject({
+        error: { code: 'evaluator-error', stage: 'evaluation' },
+      });
+      expect(result.state).toMatchObject({
+        recordDisposals: 4,
+        evaluatorRunDisposals: 1,
+      });
+      expect(faults.count('evaluator-evaluate')).toBe(4);
+      expect(JSON.stringify(result)).not.toContain(marker);
+    }
+  });
+});


### PR DESCRIPTION
## 用户影响

- function、service、model、RAG、agent、workflow 和未来 Target alias 在 protocol、schema 与 Runtime 相同时，完整 Evaluation Core 流水线保持同一编排行为。
- assertion、structured scorer 与 test-double LLM 评委统一经过相同的 lifecycle、binding、usage、cache、错误隔离和 teardown 契约。
- Core 不新增按 `targetKind`／`evaluatorKind` 分派的宿主专属路径，也不调用真实模型供应商。

## 架构与测量语义

本 PR 只补充 conformance 证据与测试夹具能力，不修改生产 Core、public schema、评分类 prompt 或统计计算。

描述性 kind 仍属于 sealed plan identity：kind 改变时 plan digest 与派生 observation identity 按契约变化；metamorphic 对照只证明在相同 protocol／schema／Runtime 下，调度、能力投影、事实结果、事件协议和资源生命周期不发生隐式分叉。该区分避免把身份完整性与编排中立性混为一谈。

## 迁移说明

无。没有运行时 API 或落盘格式变化。

## 验证

`yarn ci`：281 个测试文件、3414 条测试全部通过。

Refs #441
Tracks #425
