### PR TITLE
feat(eval-workflows)!: BREAKING-SCHEMA 建立 Runtime binding 装配基础

### DIFF
--- a/docs/specs/cli-evaluation-input-compilation.md
+++ b/docs/specs/cli-evaluation-input-compilation.md
@@ -36,7 +36,7 @@ EvaluationPresentationOptions + static RunOptions metadata
 
 - `EvaluationDefinition` owns data projections, Target behavior, evaluator instruments, metrics, experiment design, analysis, comparisons, and decision policy.
 - `MeasurementPolicy` owns execution/evaluation concurrency, timeout, retry, cache, evidence, failure, event delivery, and the shared Run budget ledger.
-- `RuntimeBindingRequest` contains only implementation requirements derived from Definition. A registry may resolve them, but cannot override model, effort, prompt variant, protocol, evaluator identity, or behavior config.
+- `RuntimeBindingRequest` v2 contains only implementation and resource-lease requirements derived from Definition／resolved host resources. A registry may resolve them, but cannot override model, effort, prompt variant, protocol, evaluator identity, or behavior config. Its complete assembly contract is specified in [Evaluation Runtime Adapter](./evaluation-runtime-adapter.md).
 - `ResolvedHostResources` binds a stable resource ID and digest to an effect locator. It is not a Core schema and never enters canonical measurement JSON.
 - `EvaluationOrchestrationOptions` owns dry-run, resume locator, batch, independent Series repeats, preflight switches, diagnostic post-processing, gold post-hoc workflows, and managed-evidence append behavior.
 - `EvaluationPresentationOptions` owns output locator, index scope, language, server, verbosity, layered view, and CLI exit presentation. None changes `DecisionResult`.

--- a/docs/specs/evaluation-runtime-adapter.md
+++ b/docs/specs/evaluation-runtime-adapter.md
@@ -1,0 +1,75 @@
+# Evaluation Runtime Adapter
+
+> **Status**: binding-assembly foundation for [#457](https://github.com/lizhiyao/oh-my-knowledge/issues/457). It is additive and does not switch the production `omk eval` pipeline.
+
+## Boundary
+
+The OMK host consumes the complete output of `compileCliEvaluationInput()` and performs effects outside Evaluation Core. Binding assembly does not create a second plan, reinterpret CLI input, or trust a registry declaration as actual Runtime identity.
+
+```text
+EvaluationDefinition + RuntimeBindingRequest
+                    │ exact coverage and immutable snapshot
+                    ▼
+        assembleOmkRuntimeBindings()
+                    │ implementation factory resolution
+                    ▼
+  immutable binding entries + Core Runtime ports
+                    │ actual identity and capabilities
+                    ▼
+       createEvaluationEngine().prepare()
+                    │
+                    ▼
+              SealedRunPlan
+```
+
+Independent Series analysis is assembled as `EvaluationSeriesRuntimePorts`; it never enters `EvaluationEngineRuntimeBindings`.
+
+## Binding coverage
+
+Assembly requires one exact binding for every:
+
+- Target executor and Evaluator reference;
+- AnalysisGraph node and the separate Sampling Estimator requirement;
+- MissingPolicy and DecisionPolicy reference;
+- Series analysis node and Series decision policy reference.
+
+An analysis binding carries both `referenceId` and Core's `requirementKind`. Sampling Estimator is therefore not inferred from an AnalysisGraph node or silently resolved from a fallback registry.
+
+This complete shape is `omk.runtime-binding-request/v2`. The incomplete migration-only v1 request is rejected rather than read through a compatibility branch.
+
+Before invoking any factory, assembly validates unique binding IDs and reference keys, exact Definition／Series coverage, implementation and version constraints, executor protocol／model／effort／behavior digest, evaluator measurement／config digest, and resource lease requirements. A validation failure causes zero factory calls.
+
+## Immutable entries and identity
+
+Assembly first clones and deep-freezes Definition, Series, and RuntimeBindingRequest. Each implementation factory is selected by `implementationId`, but it is called once per binding so two references using the same implementation receive distinct port instances.
+
+The factory returns the actual port identity and version-resolution result. Assembly validates the port shape and implementation identity, captures an immutable identity snapshot, and wraps the port methods around the original instance. The Core preparation resolver and the captured execution port are then projected from the same entry; later registry or request mutation cannot create split-brain resolution.
+
+Every entry records:
+
+- the complete binding and actual `RuntimeResolution`;
+- the captured port;
+- explicit resource lease requirements;
+- a binding-local `sessionIsolationKey` derived from the complete binding and passed to its factory.
+
+Adapters combine `sessionIsolationKey` with Core's `runId` and `trialId`; it is not permission to pool state across runs or bindings.
+
+## Resource requirements
+
+RuntimeBindingRequest records resource role and intended lease mode, not locators or content:
+
+| Role | Lease mode |
+|---|---|
+| artifact, MCP config, mock payload, evaluator content | immutable snapshot |
+| workspace | verified base plus copy-on-write overlay |
+
+These are acquisition requirements only. The verified HostResource lease layer remains responsible for checking kind, classification, size, digest, actual bytes／tree, isolation, and exactly-once release before a port can open a run. Gold resources never appear in executor or evaluator binding requirements.
+
+## Failure ownership
+
+- malformed input, coverage, duplicate, Definition mismatch, missing factory, factory failure, and invalid port use stable `OmkRuntimeAssemblyError` codes before a Run starts;
+- capability, schema, protocol support, identity assurance, and version satisfaction remain Core preparation errors;
+- credentials, connectivity, filesystem readiness, and resource materialization belong to later adapter preflight／lease layers;
+- provider, session, attempt, cancellation, and dispose failures belong to Runtime ports after the Run starts.
+
+This layer does not modify frozen prompts, scoring stages, statistical formulas, cache semantics, Bundle／Report schemas, or the legacy pipeline.

--- a/docs/zh/specs/cli-evaluation-input-compilation.md
+++ b/docs/zh/specs/cli-evaluation-input-compilation.md
@@ -36,7 +36,7 @@ EvaluationPresentationOptions + static RunOptions metadata
 
 - `EvaluationDefinition` 负责数据投影、Target 行为、evaluator instrument、metric、实验设计、分析、比较和决策策略；
 - `MeasurementPolicy` 负责 execution／evaluation concurrency、timeout、retry、cache、evidence、failure、event delivery 和共享 Run 预算账本；
-- `RuntimeBindingRequest` 只保存从 Definition 派生的 implementation requirement。宿主 registry 可以解析实现，但不能覆盖 model、effort、prompt variant、protocol、evaluator identity 或行为配置；
+- `RuntimeBindingRequest` v2 只保存从 Definition／已解析宿主资源派生的 implementation 和 resource lease requirement。宿主 registry 可以解析实现，但不能覆盖 model、effort、prompt variant、protocol、evaluator identity 或行为配置。完整装配契约见 [Evaluation Runtime Adapter 规范](./evaluation-runtime-adapter.md)；
 - `ResolvedHostResources` 用稳定 resource ID 和 digest 绑定 effect locator。它不是 Core schema，也不进入 canonical measurement JSON；
 - `EvaluationOrchestrationOptions` 负责 dry-run、resume locator、batch、独立 Series repeat、preflight 开关、diagnostic 后处理、gold post-hoc workflow 和受管证据追加；
 - `EvaluationPresentationOptions` 负责输出 locator、索引范围、语言、server、verbose、layered view 和 CLI exit 展示。这些字段都不能改变 `DecisionResult`；

--- a/docs/zh/specs/evaluation-runtime-adapter.md
+++ b/docs/zh/specs/evaluation-runtime-adapter.md
@@ -1,0 +1,75 @@
+# Evaluation Runtime Adapter 规范
+
+> **状态**：作为 [#457](https://github.com/lizhiyao/oh-my-knowledge/issues/457) 的 binding assembly 基础。本层是增量架构，不切换正式 `omk eval` pipeline。
+
+## 一、边界
+
+OMK 宿主完整消费 `compileCliEvaluationInput()` 的输出，并在 Evaluation Core 外执行 effect。Binding assembly 不创建第二套 plan、不重新解释 CLI 输入，也不把 registry 声明当成 Runtime 实际身份。
+
+```text
+EvaluationDefinition + RuntimeBindingRequest
+                    │ exact coverage／immutable snapshot
+                    ▼
+        assembleOmkRuntimeBindings()
+                    │ implementation factory resolution
+                    ▼
+  immutable binding entries + Core Runtime ports
+                    │ actual identity／capabilities
+                    ▼
+       createEvaluationEngine().prepare()
+                    │
+                    ▼
+              SealedRunPlan
+```
+
+独立 Series 分析装配为 `EvaluationSeriesRuntimePorts`，绝不进入 `EvaluationEngineRuntimeBindings`。
+
+## 二、Binding 完整覆盖
+
+Assembly 要求以下每个引用都有且只有一个 binding：
+
+- Target executor 和 Evaluator；
+- AnalysisGraph node，以及独立的 Sampling Estimator requirement；
+- MissingPolicy 和 DecisionPolicy；
+- Series analysis node 和 Series decision policy。
+
+Analysis binding 同时携带 `referenceId` 和 Core `requirementKind`。Sampling Estimator 不再从 AnalysisGraph node 猜测，也不能由 fallback registry 静默解析。
+
+完整结构使用 `omk.runtime-binding-request/v2`。不完整的迁移期 v1 request 会被直接拒绝，不增加 compatibility 分支。
+
+调用任何 factory 前，assembly 会验证 binding ID／reference key 唯一性、Definition／Series 精确覆盖、implementation／version、executor protocol／model／effort／behavior digest、evaluator measurement／config digest，以及 resource lease requirement。验证失败时 factory 调用次数必须为零。
+
+## 三、不可变 Entry 与身份
+
+Assembly 首先复制并深度冻结 Definition、Series 和 RuntimeBindingRequest。Factory 按 `implementationId` 查找，但按 binding 分别调用，因此共享同一实现的两个 reference 仍得到不同 port instance。
+
+Factory 返回实际 port identity 和 version resolution。Assembly 校验 port 形状与 implementation identity，捕获不可变 identity snapshot，并用原始实例的方法包装 port。Core preparation resolver 和运行 port 由同一个 entry 投影；后续 registry 或请求对象变化不能造成 split-brain。
+
+每个 entry 保存：
+
+- 完整 binding 和实际 `RuntimeResolution`；
+- 捕获后的 port；
+- 显式 resource lease requirement；
+- 由完整 binding 派生并传给对应 factory 的 binding-local `sessionIsolationKey`。
+
+Adapter 必须把 `sessionIsolationKey` 与 Core `runId`、`trialId` 组合使用；它不允许跨 run 或 binding 复用有状态 session。
+
+## 四、资源需求
+
+RuntimeBindingRequest 只记录资源角色和预期 lease mode，不记录 locator 或内容：
+
+| 角色 | Lease mode |
+|---|---|
+| artifact、MCP config、mock payload、evaluator content | immutable snapshot |
+| workspace | verified base + copy-on-write overlay |
+
+这些只是 acquisition requirement。后续 Verified HostResource lease 层仍须在 port 打开 run 前验证 kind、classification、size、digest、实际字节／目录树、隔离和 exactly-once release。Gold resource 不得出现在 executor 或 evaluator binding requirement 中。
+
+## 五、错误归属
+
+- malformed input、coverage、duplicate、Definition mismatch、missing factory、factory failure 和 invalid port 在 Run 开始前使用稳定 `OmkRuntimeAssemblyError` code；
+- capability、schema、protocol support、identity assurance 和 version satisfaction 仍由 Core preparation 报错；
+- credential、connectivity、filesystem readiness 和资源物化属于后续 adapter preflight／lease 层；
+- provider、session、attempt、cancellation 和 dispose failure 在 Run 开始后属于 Runtime port。
+
+本层不修改冻结 prompt、五层评分、统计公式、cache 语义、Bundle／Report schema 或旧 pipeline。

--- a/src/eval-workflows/input-compilation/compile.ts
+++ b/src/eval-workflows/input-compilation/compile.ts
@@ -297,15 +297,6 @@ function validateHostOptions(input: ResolvedCliEvaluationInput): void {
   );
 }
 
-function allBehaviorDescriptors(behavior: ResolvedTargetBehavior): ResolvedResourceDescriptor[] {
-  return [
-    behavior.artifact,
-    ...(behavior.workspace === undefined ? [] : [behavior.workspace]),
-    ...(behavior.mcpConfig === undefined ? [] : [behavior.mcpConfig]),
-    ...(behavior.mocks ?? []).flatMap((mock) => mock.payloads),
-  ];
-}
-
 function validateResourceReferences(
   input: ResolvedCliEvaluationInput,
   hostResources: ResolvedHostResources,
@@ -777,8 +768,38 @@ function compilePolicy(input: ResolvedCliEvaluationInput): MeasurementPolicy {
   }
 }
 
-function resourceIdsForBehavior(behavior: ResolvedTargetBehavior): string[] {
-  return allBehaviorDescriptors(behavior).map((descriptor) => descriptor.resourceId).sort(compareStrings);
+function resourceLeaseRequirementsForBehavior(
+  behavior: ResolvedTargetBehavior,
+): Extract<RuntimeBinding, { runtimeKind: 'executor' }>['resourceLeaseRequirements'] {
+  const requirements = [
+    {
+      resourceId: behavior.artifact.resourceId,
+      resourceRole: 'artifact' as const,
+      leaseMode: 'immutable-snapshot' as const,
+    },
+    ...(behavior.workspace === undefined ? [] : [{
+      resourceId: behavior.workspace.resourceId,
+      resourceRole: 'workspace' as const,
+      leaseMode: 'copy-on-write-overlay' as const,
+    }]),
+    ...(behavior.mcpConfig === undefined ? [] : [{
+      resourceId: behavior.mcpConfig.resourceId,
+      resourceRole: 'mcp-config' as const,
+      leaseMode: 'immutable-snapshot' as const,
+    }]),
+    ...(behavior.mocks ?? []).flatMap((mock) => mock.payloads.map((payload) => ({
+      resourceId: payload.resourceId,
+      resourceRole: 'mock-payload' as const,
+      leaseMode: 'immutable-snapshot' as const,
+    }))),
+  ];
+  return [...new Map(requirements.map((requirement) => [
+    `${requirement.resourceRole}\u0000${requirement.resourceId}`,
+    requirement,
+  ])).values()].sort((left, right) => (
+    compareStrings(left.resourceRole, right.resourceRole)
+    || compareStrings(left.resourceId, right.resourceId)
+  ));
 }
 
 function compileSeries(
@@ -879,7 +900,7 @@ function compileRuntimeBinding(
       ...(target.versionConstraint === undefined ? {} : { versionConstraint: target.versionConstraint }),
       protocolId: target.protocolId,
       behaviorConfigDigest: digestCanonicalJson(target.config ?? null),
-      resourceIds: resourceIdsForBehavior(resolved.behavior),
+      resourceLeaseRequirements: resourceLeaseRequirementsForBehavior(resolved.behavior),
       qualification: {
         model: resolved.executor.model,
         ...(resolved.executor.effort === undefined ? {} : { effort: resolved.executor.effort }),
@@ -912,9 +933,14 @@ function compileRuntimeBinding(
       ...(evaluator.versionConstraint === undefined ? {} : { versionConstraint: evaluator.versionConstraint }),
       measurement: evaluator.measurement,
       ...(evaluator.config === undefined ? {} : { configDigest: digestCanonicalJson(evaluator.config) }),
-      resourceIds: [...(template?.resources ?? [])]
-        .map((descriptor) => descriptor.resourceId)
-        .sort(compareStrings),
+      resourceLeaseRequirements: [...new Map([...(template?.resources ?? [])]
+        .map((descriptor) => [descriptor.resourceId, descriptor])).values()]
+        .map((descriptor) => ({
+          resourceId: descriptor.resourceId,
+          resourceRole: 'content' as const,
+          leaseMode: 'immutable-snapshot' as const,
+        }))
+        .sort((left, right) => compareStrings(left.resourceId, right.resourceId)),
       ...(judgeMember === undefined ? {} : {
         qualification: {
           executorId: judgeMember.executorId,
@@ -930,9 +956,29 @@ function compileRuntimeBinding(
     bindings.push({
       runtimeKind: 'analysis-node',
       bindingId: `analysis-${node.nodeId}`,
-      nodeId: node.nodeId,
+      referenceId: node.nodeId,
+      requirementKind: 'analysis-node',
+      analysisNodeKind: node.analysisNodeKind,
       implementationId: node.implementationId,
       ...(node.versionConstraint === undefined ? {} : { versionConstraint: node.versionConstraint }),
+    });
+  }
+  bindings.push({
+    runtimeKind: 'analysis-node',
+    bindingId: `sampling-estimator-${definition.experiment.sampling.estimatorId}`,
+    referenceId: definition.experiment.sampling.estimatorId,
+    requirementKind: 'sampling-estimator',
+    analysisNodeKind: 'estimator',
+    implementationId: definition.experiment.sampling.estimatorId,
+  });
+  for (const policyId of [...new Set(definition.metrics.map((metric) => (
+    metric.missingPolicyId
+  )))].sort(compareStrings)) {
+    bindings.push({
+      runtimeKind: 'missing-policy',
+      bindingId: `missing-policy-${policyId}`,
+      policyId,
+      implementationId: policyId,
     });
   }
   if (definition.decisionPolicy !== undefined) {
@@ -952,6 +998,14 @@ function compileRuntimeBinding(
       bindingId: `series-analysis-${node.nodeId}`,
       nodeId: node.nodeId,
       implementationId: node.implementationId,
+    });
+  }
+  if (series?.definition.decisionPolicy !== undefined) {
+    bindings.push({
+      runtimeKind: 'series-decision-policy',
+      bindingId: `series-decision-${series.definition.decisionPolicy.decisionPolicyId}`,
+      decisionPolicyId: series.definition.decisionPolicy.decisionPolicyId,
+      implementationId: series.definition.decisionPolicy.implementationId,
     });
   }
   return deepFreezeCanonicalJson(canonicalSnapshot({

--- a/src/eval-workflows/input-compilation/types.ts
+++ b/src/eval-workflows/input-compilation/types.ts
@@ -20,7 +20,7 @@ export const RESOLVED_CLI_EVALUATION_INPUT_SCHEMA_VERSION =
 export const RESOLVED_HOST_RESOURCES_SCHEMA_VERSION =
   'omk.resolved-host-resources/v1' as const;
 export const RUNTIME_BINDING_REQUEST_SCHEMA_VERSION =
-  'omk.runtime-binding-request/v1' as const;
+  'omk.runtime-binding-request/v2' as const;
 
 export type CliEvaluationFieldSource = { readonly normalizedField: string } & (
   | {
@@ -317,6 +317,32 @@ export interface ResolvedCliEvaluationInput {
   };
 }
 
+export interface RuntimeResourceLeaseRequirement {
+  readonly resourceId: string;
+  readonly resourceRole: 'artifact' | 'workspace' | 'mcp-config' | 'mock-payload' | 'content';
+  readonly leaseMode: 'immutable-snapshot' | 'copy-on-write-overlay';
+}
+
+export type AnalysisRuntimeBinding =
+  | {
+      readonly runtimeKind: 'analysis-node';
+      readonly bindingId: string;
+      readonly referenceId: string;
+      readonly requirementKind: 'analysis-node';
+      readonly analysisNodeKind: 'reducer' | 'estimator' | 'correction';
+      readonly implementationId: string;
+      readonly versionConstraint?: string;
+    }
+  | {
+      readonly runtimeKind: 'analysis-node';
+      readonly bindingId: string;
+      readonly referenceId: string;
+      readonly requirementKind: 'sampling-estimator';
+      readonly analysisNodeKind: 'estimator';
+      readonly implementationId: string;
+      readonly versionConstraint?: string;
+    };
+
 export type RuntimeBinding =
   | {
       readonly runtimeKind: 'executor';
@@ -326,7 +352,7 @@ export type RuntimeBinding =
       readonly versionConstraint?: string;
       readonly protocolId: ResolvedCliTarget['protocolId'];
       readonly behaviorConfigDigest: Sha256Digest;
-      readonly resourceIds: readonly string[];
+      readonly resourceLeaseRequirements: readonly RuntimeResourceLeaseRequirement[];
       readonly qualification: {
         readonly model: string;
         readonly effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
@@ -347,7 +373,7 @@ export type RuntimeBinding =
       readonly versionConstraint?: string;
       readonly measurement: EvaluatorDefinition['measurement'];
       readonly configDigest?: Sha256Digest;
-      readonly resourceIds: readonly string[];
+      readonly resourceLeaseRequirements: readonly RuntimeResourceLeaseRequirement[];
       readonly qualification?: {
         readonly executorId: string;
         readonly model: string;
@@ -356,12 +382,12 @@ export type RuntimeBinding =
         readonly resourceIntegrity: 'digest-before-use';
       };
     }
+  | AnalysisRuntimeBinding
   | {
-      readonly runtimeKind: 'analysis-node';
+      readonly runtimeKind: 'missing-policy';
       readonly bindingId: string;
-      readonly nodeId: string;
+      readonly policyId: string;
       readonly implementationId: string;
-      readonly versionConstraint?: string;
     }
   | {
       readonly runtimeKind: 'decision-policy';
@@ -374,6 +400,12 @@ export type RuntimeBinding =
       readonly runtimeKind: 'series-analysis-node';
       readonly bindingId: string;
       readonly nodeId: string;
+      readonly implementationId: string;
+    }
+  | {
+      readonly runtimeKind: 'series-decision-policy';
+      readonly bindingId: string;
+      readonly decisionPolicyId: string;
       readonly implementationId: string;
     };
 

--- a/src/eval-workflows/runtime-adapter/assembly.ts
+++ b/src/eval-workflows/runtime-adapter/assembly.ts
@@ -1,0 +1,871 @@
+import {
+  RuntimeIdentitySchema,
+  SchemaIdentitySchema,
+  canonicalizeJson,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  type EvaluationDefinition,
+  type EvaluationSeriesDefinition,
+  type RuntimeIdentity,
+} from '../../evaluation-core/contracts/index.js';
+import type {
+  AnalysisRuntimeRequirement,
+  EvaluatorRuntimeRequirement,
+  ExecutorRuntimeRequirement,
+  RuntimeResolution,
+} from '../../evaluation-core/compiler/index.js';
+import {
+  RUNTIME_BINDING_REQUEST_SCHEMA_VERSION,
+  type RuntimeBinding,
+  type RuntimeResourceLeaseRequirement,
+} from '../input-compilation/index.js';
+import {
+  OmkRuntimeAssemblyError,
+  type AssembleOmkRuntimeBindingsInput,
+  type OmkEvaluationRuntimeBindingEntry,
+  type OmkEvaluationSeriesRuntimeBindingEntry,
+  type OmkRuntimeBindingAssembly,
+  type OmkRuntimeBindingFactories,
+  type OmkRuntimePortBinding,
+  type RuntimeBindingOf,
+} from './types.js';
+
+type EvaluationBindingKind = Exclude<
+  RuntimeBinding['runtimeKind'],
+  'series-analysis-node' | 'series-decision-policy'
+>;
+
+interface ExpectedBinding {
+  readonly runtimeKind: RuntimeBinding['runtimeKind'];
+  readonly referenceId: string;
+  readonly implementationId: string;
+  readonly versionConstraint?: string;
+  readonly analysisRequirementKind?: 'analysis-node' | 'sampling-estimator';
+  readonly analysisNodeKind?: 'reducer' | 'estimator' | 'correction';
+  readonly subject: unknown;
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function fail(input: ConstructorParameters<typeof OmkRuntimeAssemblyError>[0]): never {
+  throw new OmkRuntimeAssemblyError(input);
+}
+
+function record(value: unknown): Readonly<Record<string, unknown>> | undefined {
+  return value !== null && !Array.isArray(value) && typeof value === 'object'
+    ? value as Readonly<Record<string, unknown>>
+    : undefined;
+}
+
+function bindingReferenceId(binding: RuntimeBinding): string {
+  switch (binding.runtimeKind) {
+    case 'executor': return binding.targetId;
+    case 'evaluator': return binding.evaluatorId;
+    case 'analysis-node': return binding.referenceId;
+    case 'series-analysis-node': return binding.nodeId;
+    case 'missing-policy': return binding.policyId;
+    case 'decision-policy':
+    case 'series-decision-policy': return binding.decisionPolicyId;
+  }
+}
+
+function bindingKey(
+  runtimeKind: RuntimeBinding['runtimeKind'],
+  referenceId: string,
+  analysisRequirementKind?: 'analysis-node' | 'sampling-estimator',
+): string {
+  return runtimeKind === 'analysis-node'
+    ? `${runtimeKind}\u0000${analysisRequirementKind ?? ''}\u0000${referenceId}`
+    : `${runtimeKind}\u0000${referenceId}`;
+}
+
+function keyForBinding(binding: RuntimeBinding): string {
+  return bindingKey(
+    binding.runtimeKind,
+    bindingReferenceId(binding),
+    binding.runtimeKind === 'analysis-node' ? binding.requirementKind : undefined,
+  );
+}
+
+function keyForExpected(binding: ExpectedBinding): string {
+  return bindingKey(
+    binding.runtimeKind,
+    binding.referenceId,
+    binding.analysisRequirementKind,
+  );
+}
+
+function expectedBindings(
+  definition: EvaluationDefinition,
+  seriesDefinition: EvaluationSeriesDefinition | undefined,
+): Map<string, ExpectedBinding> {
+  const expected = new Map<string, ExpectedBinding>();
+  const add = (binding: ExpectedBinding): void => {
+    const key = keyForExpected(binding);
+    if (expected.has(key)) fail({
+      code: 'OMK_RUNTIME_BINDING_DEFINITION_MISMATCH',
+      referenceId: binding.referenceId,
+      message: 'Definition 包含重复 Runtime reference。',
+    });
+    expected.set(key, binding);
+  };
+  for (const target of definition.targets) add({
+    runtimeKind: 'executor',
+    referenceId: target.targetId,
+    implementationId: target.executorId,
+    ...(target.versionConstraint === undefined ? {} : { versionConstraint: target.versionConstraint }),
+    subject: target,
+  });
+  for (const evaluator of definition.evaluators) add({
+    runtimeKind: 'evaluator',
+    referenceId: evaluator.evaluatorId,
+    implementationId: evaluator.implementationId,
+    ...(evaluator.versionConstraint === undefined ? {} : {
+      versionConstraint: evaluator.versionConstraint,
+    }),
+    subject: evaluator,
+  });
+  for (const node of definition.analysisGraph.nodes) add({
+    runtimeKind: 'analysis-node',
+    referenceId: node.nodeId,
+    implementationId: node.implementationId,
+    ...(node.versionConstraint === undefined ? {} : { versionConstraint: node.versionConstraint }),
+    analysisRequirementKind: 'analysis-node',
+    analysisNodeKind: node.analysisNodeKind,
+    subject: node,
+  });
+  add({
+    runtimeKind: 'analysis-node',
+    referenceId: definition.experiment.sampling.estimatorId,
+    implementationId: definition.experiment.sampling.estimatorId,
+    analysisRequirementKind: 'sampling-estimator',
+    analysisNodeKind: 'estimator',
+    subject: definition.experiment.sampling,
+  });
+  const metricsByMissingPolicy = new Map<string, string[]>();
+  for (const metric of definition.metrics) {
+    const metricIds = metricsByMissingPolicy.get(metric.missingPolicyId) ?? [];
+    metricIds.push(metric.metricId);
+    metricsByMissingPolicy.set(metric.missingPolicyId, metricIds);
+  }
+  for (const [policyId, metricIds] of [...metricsByMissingPolicy].sort(([left], [right]) => (
+    compareStrings(left, right)
+  ))) add({
+    runtimeKind: 'missing-policy',
+    referenceId: policyId,
+    implementationId: policyId,
+    subject: Object.freeze(metricIds.sort(compareStrings)),
+  });
+  if (definition.decisionPolicy !== undefined) add({
+    runtimeKind: 'decision-policy',
+    referenceId: definition.decisionPolicy.decisionPolicyId,
+    implementationId: definition.decisionPolicy.implementationId,
+    ...(definition.decisionPolicy.versionConstraint === undefined ? {} : {
+      versionConstraint: definition.decisionPolicy.versionConstraint,
+    }),
+    subject: definition.decisionPolicy,
+  });
+  for (const node of seriesDefinition?.analysisGraph.nodes ?? []) add({
+    runtimeKind: 'series-analysis-node',
+    referenceId: node.nodeId,
+    implementationId: node.implementationId,
+    subject: node,
+  });
+  if (seriesDefinition?.decisionPolicy !== undefined) add({
+    runtimeKind: 'series-decision-policy',
+    referenceId: seriesDefinition.decisionPolicy.decisionPolicyId,
+    implementationId: seriesDefinition.decisionPolicy.implementationId,
+    subject: seriesDefinition.decisionPolicy,
+  });
+  return expected;
+}
+
+function sameOptionalString(left: string | undefined, right: string | undefined): boolean {
+  return left === right;
+}
+
+function descriptorResourceId(value: unknown): string | undefined {
+  const descriptor = record(value);
+  return typeof descriptor?.resourceId === 'string' && descriptor.resourceId !== ''
+    ? descriptor.resourceId
+    : undefined;
+}
+
+function expectedExecutorResourceRequirements(
+  target: EvaluationDefinition['targets'][number],
+): RuntimeResourceLeaseRequirement[] {
+  const config = record(target.config);
+  const behavior = record(config?.behavior);
+  const artifactId = descriptorResourceId(behavior?.artifact);
+  if (artifactId === undefined) fail({
+    code: 'OMK_RUNTIME_BINDING_DEFINITION_MISMATCH',
+    referenceId: target.targetId,
+    message: 'Target behavior 缺少 artifact resource descriptor。',
+  });
+  const requirements: RuntimeResourceLeaseRequirement[] = [{
+    resourceId: artifactId,
+    resourceRole: 'artifact',
+    leaseMode: 'immutable-snapshot',
+  }];
+  const workspaceId = descriptorResourceId(behavior?.workspace);
+  if (workspaceId !== undefined) requirements.push({
+    resourceId: workspaceId,
+    resourceRole: 'workspace',
+    leaseMode: 'copy-on-write-overlay',
+  });
+  const mcpConfigId = descriptorResourceId(behavior?.mcpConfig);
+  if (mcpConfigId !== undefined) requirements.push({
+    resourceId: mcpConfigId,
+    resourceRole: 'mcp-config',
+    leaseMode: 'immutable-snapshot',
+  });
+  if (Array.isArray(behavior?.mocks)) {
+    for (const mockValue of behavior.mocks) {
+      const mock = record(mockValue);
+      if (!Array.isArray(mock?.payloads)) continue;
+      for (const payload of mock.payloads) {
+        const resourceId = descriptorResourceId(payload);
+        if (resourceId !== undefined) requirements.push({
+          resourceId,
+          resourceRole: 'mock-payload',
+          leaseMode: 'immutable-snapshot',
+        });
+      }
+    }
+  }
+  return [...new Map(requirements.map((requirement) => [
+    `${requirement.resourceRole}\u0000${requirement.resourceId}`,
+    requirement,
+  ])).values()].sort((left, right) => (
+    compareStrings(left.resourceRole, right.resourceRole)
+    || compareStrings(left.resourceId, right.resourceId)
+  ));
+}
+
+function assertResourceRequirements(
+  binding: RuntimeBindingOf<'executor'> | RuntimeBindingOf<'evaluator'>,
+): void {
+  const keys = new Set<string>();
+  for (const requirement of binding.resourceLeaseRequirements) {
+    const expectedMode = requirement.resourceRole === 'workspace'
+      ? 'copy-on-write-overlay'
+      : 'immutable-snapshot';
+    const allowedRole = binding.runtimeKind === 'executor'
+      ? ['artifact', 'workspace', 'mcp-config', 'mock-payload'].includes(requirement.resourceRole)
+      : requirement.resourceRole === 'content';
+    const key = `${requirement.resourceRole}\u0000${requirement.resourceId}`;
+    if (requirement.resourceId === '' || !allowedRole
+        || requirement.leaseMode !== expectedMode || keys.has(key)) fail({
+      code: 'OMK_RUNTIME_BINDING_DEFINITION_MISMATCH',
+      bindingId: binding.bindingId,
+      referenceId: binding.runtimeKind === 'executor' ? binding.targetId : binding.evaluatorId,
+      message: 'Runtime binding 的 resource lease requirement 非法或重复。',
+    });
+    keys.add(key);
+  }
+}
+
+function assertExecutorBinding(
+  binding: RuntimeBindingOf<'executor'>,
+  target: EvaluationDefinition['targets'][number],
+): void {
+  assertResourceRequirements(binding);
+  const config = record(target.config);
+  const runtime = record(config?.runtime);
+  const expectedEffort = typeof runtime?.effort === 'string' ? runtime.effort : undefined;
+  if (binding.targetId !== target.targetId
+      || binding.implementationId !== target.executorId
+      || !sameOptionalString(binding.versionConstraint, target.versionConstraint)
+      || binding.protocolId !== target.protocolId
+      || binding.behaviorConfigDigest !== digestCanonicalJson(target.config ?? null)
+      || canonicalizeJson(binding.resourceLeaseRequirements)
+        !== canonicalizeJson(expectedExecutorResourceRequirements(target))
+      || binding.qualification.model !== runtime?.model
+      || binding.qualification.effort !== expectedEffort) fail({
+    code: 'OMK_RUNTIME_BINDING_DEFINITION_MISMATCH',
+    bindingId: binding.bindingId,
+    referenceId: binding.targetId,
+    message: 'Executor binding 与 Target Definition 不一致。',
+  });
+}
+
+function assertEvaluatorBinding(
+  binding: RuntimeBindingOf<'evaluator'>,
+  evaluator: EvaluationDefinition['evaluators'][number],
+): void {
+  assertResourceRequirements(binding);
+  const expectedConfigDigest = evaluator.config === undefined
+    ? undefined
+    : digestCanonicalJson(evaluator.config);
+  if (binding.evaluatorId !== evaluator.evaluatorId
+      || binding.implementationId !== evaluator.implementationId
+      || !sameOptionalString(binding.versionConstraint, evaluator.versionConstraint)
+      || canonicalizeJson(binding.measurement) !== canonicalizeJson(evaluator.measurement)
+      || binding.configDigest !== expectedConfigDigest) fail({
+    code: 'OMK_RUNTIME_BINDING_DEFINITION_MISMATCH',
+    bindingId: binding.bindingId,
+    referenceId: binding.evaluatorId,
+    message: 'Evaluator binding 与 Evaluator Definition 不一致。',
+  });
+}
+
+function validateBindingAgainstDefinition(binding: RuntimeBinding, expected: ExpectedBinding): void {
+  if (binding.runtimeKind !== expected.runtimeKind
+      || binding.implementationId !== expected.implementationId
+      || !sameOptionalString(
+        'versionConstraint' in binding ? binding.versionConstraint : undefined,
+        expected.versionConstraint,
+      )) fail({
+    code: 'OMK_RUNTIME_BINDING_DEFINITION_MISMATCH',
+    bindingId: binding.bindingId,
+    referenceId: expected.referenceId,
+    message: 'Runtime binding implementation 与 Definition 不一致。',
+  });
+  if (binding.runtimeKind === 'executor') {
+    assertExecutorBinding(
+      binding,
+      expected.subject as EvaluationDefinition['targets'][number],
+    );
+  } else if (binding.runtimeKind === 'evaluator') {
+    assertEvaluatorBinding(
+      binding,
+      expected.subject as EvaluationDefinition['evaluators'][number],
+    );
+  } else if (binding.runtimeKind === 'analysis-node'
+      && (binding.requirementKind !== expected.analysisRequirementKind
+        || binding.analysisNodeKind !== expected.analysisNodeKind
+        || binding.referenceId !== expected.referenceId)) fail({
+    code: 'OMK_RUNTIME_BINDING_DEFINITION_MISMATCH',
+    bindingId: binding.bindingId,
+    referenceId: binding.referenceId,
+    message: 'Analysis binding 与 Core Runtime requirement 不一致。',
+  });
+}
+
+const RUNTIME_KINDS = new Set<RuntimeBinding['runtimeKind']>([
+  'executor',
+  'evaluator',
+  'analysis-node',
+  'missing-policy',
+  'decision-policy',
+  'series-analysis-node',
+  'series-decision-policy',
+]);
+
+function isRuntimeKind(value: unknown): value is RuntimeBinding['runtimeKind'] {
+  return typeof value === 'string' && RUNTIME_KINDS.has(value as RuntimeBinding['runtimeKind']);
+}
+
+function missingReferenceFromKey(key: string): string | undefined {
+  const parts = key.split('\u0000');
+  return parts.at(-1);
+}
+
+function assertRuntimeBindingShape(binding: unknown): asserts binding is RuntimeBinding {
+  const candidate = record(binding);
+  if (candidate === undefined
+      || typeof candidate.bindingId !== 'string' || candidate.bindingId === ''
+      || typeof candidate.implementationId !== 'string' || candidate.implementationId === ''
+      || !isRuntimeKind(candidate.runtimeKind)) fail({
+    code: 'OMK_RUNTIME_BINDING_REQUEST_INVALID',
+    message: 'Runtime binding 缺少合法 kind、bindingId 或 implementationId。',
+  });
+  const referenceId = candidate.runtimeKind === 'executor'
+    ? candidate.targetId
+    : candidate.runtimeKind === 'evaluator'
+      ? candidate.evaluatorId
+      : candidate.runtimeKind === 'analysis-node'
+        ? candidate.referenceId
+        : candidate.runtimeKind === 'missing-policy'
+          ? candidate.policyId
+          : candidate.runtimeKind === 'decision-policy'
+            || candidate.runtimeKind === 'series-decision-policy'
+            ? candidate.decisionPolicyId
+            : candidate.nodeId;
+  if (typeof referenceId !== 'string' || referenceId === ''
+      || ('versionConstraint' in candidate
+        && candidate.versionConstraint !== undefined
+        && typeof candidate.versionConstraint !== 'string')
+      || ((candidate.runtimeKind === 'executor' || candidate.runtimeKind === 'evaluator')
+        && !Array.isArray(candidate.resourceLeaseRequirements))) fail({
+    code: 'OMK_RUNTIME_BINDING_REQUEST_INVALID',
+    bindingId: candidate.bindingId,
+    message: 'Runtime binding 缺少合法 reference、version 或 resource requirement。',
+  });
+  if (candidate.runtimeKind === 'analysis-node'
+      && (typeof candidate.referenceId !== 'string' || candidate.referenceId === ''
+        || !['analysis-node', 'sampling-estimator'].includes(String(candidate.requirementKind))
+        || !['reducer', 'estimator', 'correction'].includes(String(candidate.analysisNodeKind)))) fail({
+    code: 'OMK_RUNTIME_BINDING_REQUEST_INVALID',
+    bindingId: candidate.bindingId,
+    message: 'Analysis binding 缺少合法 reference 或 requirement discriminator。',
+  });
+}
+
+function validateRequest(input: AssembleOmkRuntimeBindingsInput): Map<string, ExpectedBinding> {
+  const request = input.runtimeBinding;
+  if (request === null || typeof request !== 'object'
+      || request.schemaVersion !== RUNTIME_BINDING_REQUEST_SCHEMA_VERSION
+      || !Array.isArray(request.bindings)) fail({
+    code: 'OMK_RUNTIME_BINDING_REQUEST_INVALID',
+    message: 'RuntimeBindingRequest 版本或结构不受支持。',
+  });
+  const expected = expectedBindings(input.definition, input.seriesDefinition);
+  const bindingIds = new Set<string>();
+  const keys = new Set<string>();
+  for (const candidate of request.bindings) {
+    assertRuntimeBindingShape(candidate);
+    const binding = candidate;
+    const referenceId = bindingReferenceId(binding);
+    const key = keyForBinding(binding);
+    if (bindingIds.has(binding.bindingId) || keys.has(key)) fail({
+      code: 'OMK_RUNTIME_BINDING_DUPLICATE',
+      bindingId: binding.bindingId,
+      referenceId,
+      message: 'RuntimeBindingRequest 包含重复 bindingId 或 reference。',
+    });
+    bindingIds.add(binding.bindingId);
+    keys.add(key);
+    const expectedBinding = expected.get(key);
+    if (expectedBinding === undefined) fail({
+      code: 'OMK_RUNTIME_BINDING_COVERAGE_MISMATCH',
+      bindingId: binding.bindingId,
+      referenceId,
+      message: 'RuntimeBindingRequest 包含 Definition 未声明的 binding。',
+    });
+    try {
+      validateBindingAgainstDefinition(binding, expectedBinding);
+    } catch (cause) {
+      if (cause instanceof OmkRuntimeAssemblyError) throw cause;
+      fail({
+        code: 'OMK_RUNTIME_BINDING_REQUEST_INVALID',
+        bindingId: binding.bindingId,
+        referenceId,
+        message: 'Runtime binding 结构不合法。',
+        cause,
+      });
+    }
+  }
+  const missing = [...expected.keys()].filter((key) => !keys.has(key));
+  if (missing.length > 0 || keys.size !== expected.size) fail({
+    code: 'OMK_RUNTIME_BINDING_COVERAGE_MISMATCH',
+    referenceId: missing[0] === undefined ? undefined : missingReferenceFromKey(missing[0]),
+    message: 'RuntimeBindingRequest 未精确覆盖 Definition／Series 所需 Runtime。',
+  });
+  return expected;
+}
+
+function factoryFor(
+  factories: OmkRuntimeBindingFactories,
+  binding: RuntimeBinding,
+): ((context: never) => unknown) | undefined {
+  switch (binding.runtimeKind) {
+    case 'executor': return factories.executorsByImplementationId.get(binding.implementationId);
+    case 'evaluator': return factories.evaluatorsByImplementationId.get(binding.implementationId);
+    case 'analysis-node': return factories.analysisNodesByImplementationId.get(binding.implementationId);
+    case 'missing-policy': return factories.missingPoliciesByImplementationId.get(binding.implementationId);
+    case 'decision-policy': return factories.decisionPoliciesByImplementationId.get(binding.implementationId);
+    case 'series-analysis-node': return factories.seriesAnalysisNodesByImplementationId
+      .get(binding.implementationId);
+    case 'series-decision-policy': return factories.seriesDecisionPoliciesByImplementationId
+      .get(binding.implementationId);
+  }
+}
+
+function assertFactoriesAvailable(
+  bindings: readonly RuntimeBinding[],
+  factories: OmkRuntimeBindingFactories,
+): void {
+  for (const binding of bindings) {
+    if (factoryFor(factories, binding) !== undefined) continue;
+    fail({
+      code: 'OMK_RUNTIME_BINDING_FACTORY_MISSING',
+      bindingId: binding.bindingId,
+      referenceId: bindingReferenceId(binding),
+      message: '没有 Runtime factory 能解析声明的 implementationId。',
+    });
+  }
+}
+
+function sessionIsolationKey(binding: RuntimeBinding): string {
+  return digestCanonicalJson({
+    derivation: 'omk.runtime-binding-session-isolation/v1',
+    binding,
+  });
+}
+
+function contextFor(
+  binding: RuntimeBinding,
+  expected: ExpectedBinding,
+  isolationKey: string,
+): unknown {
+  switch (binding.runtimeKind) {
+    case 'executor': return Object.freeze({
+      binding, target: expected.subject, sessionIsolationKey: isolationKey,
+    });
+    case 'evaluator': return Object.freeze({
+      binding, evaluator: expected.subject, sessionIsolationKey: isolationKey,
+    });
+    case 'analysis-node': return Object.freeze({
+      binding,
+      sessionIsolationKey: isolationKey,
+      requirement: Object.freeze({
+        referenceId: binding.referenceId,
+        implementationId: binding.implementationId,
+        ...(binding.versionConstraint === undefined ? {} : {
+          versionConstraint: binding.versionConstraint,
+        }),
+        analysisNodeKind: binding.analysisNodeKind,
+        requirementKind: binding.requirementKind,
+      }),
+      subject: expected.subject,
+    });
+    case 'missing-policy': return Object.freeze({
+      binding, metricIds: expected.subject, sessionIsolationKey: isolationKey,
+    });
+    case 'decision-policy': return Object.freeze({
+      binding, policy: expected.subject, sessionIsolationKey: isolationKey,
+    });
+    case 'series-analysis-node': return Object.freeze({
+      binding, node: expected.subject, sessionIsolationKey: isolationKey,
+    });
+    case 'series-decision-policy': return Object.freeze({
+      binding, policy: expected.subject, sessionIsolationKey: isolationKey,
+    });
+  }
+}
+
+function assertPortShape(
+  binding: RuntimeBinding,
+  port: Readonly<Record<string, unknown>>,
+  identity: RuntimeIdentity,
+): void {
+  const callable = (name: string): boolean => typeof port[name] === 'function';
+  const portOutputSchema = SchemaIdentitySchema.safeParse(port.outputSchema);
+  const identityOutputSchema = SchemaIdentitySchema.safeParse(
+    record(identity.capabilities)?.outputSchema,
+  );
+  const valid = binding.runtimeKind === 'executor' || binding.runtimeKind === 'evaluator'
+    ? callable('openRun')
+    : binding.runtimeKind === 'analysis-node'
+      ? callable('openRun')
+        && portOutputSchema.success
+        && identityOutputSchema.success
+        && canonicalizeJson(portOutputSchema.data) === canonicalizeJson(identityOutputSchema.data)
+      : binding.runtimeKind === 'missing-policy'
+        ? callable('decide')
+        : binding.runtimeKind === 'decision-policy'
+          ? callable('decide')
+          : binding.runtimeKind === 'series-analysis-node'
+            ? callable('analyze') && SchemaIdentitySchema.safeParse(port.outputSchema).success
+            : callable('decide');
+  if (!valid) fail({
+    code: 'OMK_RUNTIME_BINDING_PORT_INVALID',
+    bindingId: binding.bindingId,
+    referenceId: bindingReferenceId(binding),
+    message: 'Runtime binding factory 返回了不符合 kind contract 的 port。',
+  });
+}
+
+function boundMethod(
+  port: Readonly<Record<string, unknown>>,
+  methodName: string,
+): (...args: never[]) => unknown {
+  const method = port[methodName] as (...args: never[]) => unknown;
+  return (...args: never[]) => Reflect.apply(method, port, args);
+}
+
+function capturePort(
+  binding: RuntimeBinding,
+  port: Readonly<Record<string, unknown>>,
+  identity: RuntimeIdentity,
+): unknown {
+  switch (binding.runtimeKind) {
+    case 'executor':
+    case 'evaluator': return Object.freeze({ identity, openRun: boundMethod(port, 'openRun') });
+    case 'analysis-node': return Object.freeze({
+      identity,
+      outputSchema: deepFreezeCanonicalJson(SchemaIdentitySchema.parse(port.outputSchema)),
+      openRun: boundMethod(port, 'openRun'),
+    });
+    case 'missing-policy':
+    case 'decision-policy':
+    case 'series-decision-policy': return Object.freeze({
+      identity,
+      decide: boundMethod(port, 'decide'),
+    });
+    case 'series-analysis-node': return Object.freeze({
+      identity,
+      outputSchema: deepFreezeCanonicalJson(SchemaIdentitySchema.parse(port.outputSchema)),
+      analyze: boundMethod(port, 'analyze'),
+    });
+  }
+}
+
+async function materializeEntry(
+  binding: RuntimeBinding,
+  expected: ExpectedBinding,
+  factories: OmkRuntimeBindingFactories,
+): Promise<OmkEvaluationRuntimeBindingEntry | OmkEvaluationSeriesRuntimeBindingEntry> {
+  const factory = factoryFor(factories, binding);
+  if (factory === undefined) fail({
+    code: 'OMK_RUNTIME_BINDING_FACTORY_MISSING',
+    bindingId: binding.bindingId,
+    referenceId: bindingReferenceId(binding),
+    message: '没有 Runtime factory 能解析声明的 implementationId。',
+  });
+  let result: OmkRuntimePortBinding<unknown>;
+  const isolationKey = sessionIsolationKey(binding);
+  try {
+    result = await factory(
+      contextFor(binding, expected, isolationKey) as never,
+    ) as OmkRuntimePortBinding<unknown>;
+  } catch (cause) {
+    fail({
+      code: 'OMK_RUNTIME_BINDING_FACTORY_FAILED',
+      bindingId: binding.bindingId,
+      referenceId: bindingReferenceId(binding),
+      message: 'Runtime binding factory 装配失败。',
+      cause,
+    });
+  }
+  const port = record(result?.port);
+  const identity = RuntimeIdentitySchema.safeParse(port?.identity);
+  if (port === undefined || !identity.success
+      || typeof result.satisfiesVersionConstraint !== 'boolean'
+      || identity.data.implementationId !== binding.implementationId) fail({
+    code: 'OMK_RUNTIME_BINDING_PORT_INVALID',
+    bindingId: binding.bindingId,
+    referenceId: bindingReferenceId(binding),
+    message: 'Runtime port identity 或 version resolution 与 binding 不一致。',
+  });
+  assertPortShape(binding, port, identity.data);
+  const capturedIdentity = deepFreezeCanonicalJson(identity.data);
+  const capturedPort = capturePort(binding, port, capturedIdentity);
+  const resolution: RuntimeResolution = Object.freeze({
+    identity: capturedIdentity,
+    satisfiesVersionConstraint: result.satisfiesVersionConstraint,
+  });
+  const resourceLeaseRequirements = 'resourceLeaseRequirements' in binding
+    ? binding.resourceLeaseRequirements
+    : Object.freeze([]);
+  return Object.freeze({
+    runtimeKind: binding.runtimeKind,
+    binding,
+    resolution,
+    port: capturedPort,
+    resourceLeaseRequirements,
+    sessionIsolationKey: isolationKey,
+  }) as OmkEvaluationRuntimeBindingEntry | OmkEvaluationSeriesRuntimeBindingEntry;
+}
+
+function sameRequirement(
+  binding: RuntimeBinding,
+  requirement: ExecutorRuntimeRequirement | EvaluatorRuntimeRequirement | AnalysisRuntimeRequirement,
+): boolean {
+  if (bindingReferenceId(binding) !== requirement.referenceId
+      || binding.implementationId !== ('executorId' in requirement
+        ? requirement.executorId
+        : requirement.implementationId)) return false;
+  if ('versionConstraint' in binding
+      && binding.versionConstraint !== ('versionConstraint' in requirement
+        ? requirement.versionConstraint
+        : undefined)) return false;
+  if (binding.runtimeKind === 'executor') {
+    return 'protocolId' in requirement && binding.protocolId === requirement.protocolId;
+  }
+  if (binding.runtimeKind === 'analysis-node') {
+    return 'requirementKind' in requirement
+      && (requirement.requirementKind === 'analysis-node'
+      || requirement.requirementKind === 'sampling-estimator')
+      && binding.requirementKind === requirement.requirementKind
+      && binding.analysisNodeKind === requirement.analysisNodeKind;
+  }
+  return true;
+}
+
+function missingResolvedBinding(referenceId: string): never {
+  fail({
+    code: 'OMK_RUNTIME_BINDING_COVERAGE_MISMATCH',
+    referenceId,
+    message: 'Core 请求了装配快照中不存在或不一致的 Runtime binding。',
+  });
+}
+
+function evaluationResolvers(entries: readonly OmkEvaluationRuntimeBindingEntry[]) {
+  const executors = new Map(entries.filter((entry) => entry.runtimeKind === 'executor')
+    .map((entry) => [entry.binding.targetId, entry]));
+  const evaluators = new Map(entries.filter((entry) => entry.runtimeKind === 'evaluator')
+    .map((entry) => [entry.binding.evaluatorId, entry]));
+  const analysis = new Map(entries.filter((entry) => (
+    entry.runtimeKind === 'analysis-node'
+    || entry.runtimeKind === 'missing-policy'
+    || entry.runtimeKind === 'decision-policy'
+  )).map((entry) => [keyForBinding(entry.binding), entry]));
+  return Object.freeze({
+    resolveExecutor(requirement: Readonly<ExecutorRuntimeRequirement>) {
+      const entry = executors.get(requirement.referenceId);
+      if (entry === undefined || !sameRequirement(entry.binding, requirement)) {
+        return missingResolvedBinding(requirement.referenceId);
+      }
+      return { runtimeKind: 'executor' as const, resolution: entry.resolution, port: entry.port };
+    },
+    resolveEvaluator(requirement: Readonly<EvaluatorRuntimeRequirement>) {
+      const entry = evaluators.get(requirement.referenceId);
+      if (entry === undefined || !sameRequirement(entry.binding, requirement)) {
+        return missingResolvedBinding(requirement.referenceId);
+      }
+      return { runtimeKind: 'evaluator' as const, resolution: entry.resolution, port: entry.port };
+    },
+    resolveAnalysis(requirement: Readonly<AnalysisRuntimeRequirement>) {
+      const runtimeKind: EvaluationBindingKind = requirement.requirementKind === 'missing-policy'
+        ? 'missing-policy'
+        : requirement.requirementKind === 'decision-policy'
+          ? 'decision-policy'
+          : 'analysis-node';
+      const entry = analysis.get(bindingKey(
+        runtimeKind,
+        requirement.referenceId,
+        requirement.requirementKind === 'analysis-node'
+          || requirement.requirementKind === 'sampling-estimator'
+          ? requirement.requirementKind
+          : undefined,
+      ));
+      if (entry === undefined || !sameRequirement(entry.binding, requirement)) {
+        return missingResolvedBinding(requirement.referenceId);
+      }
+      if (entry.runtimeKind === 'analysis-node') return {
+        runtimeKind: 'analysis-node' as const,
+        resolution: entry.resolution,
+        port: entry.port,
+      };
+      if (entry.runtimeKind === 'missing-policy') return {
+        runtimeKind: 'missing-policy' as const,
+        resolution: entry.resolution,
+        port: entry.port,
+      };
+      if (entry.runtimeKind === 'decision-policy') return {
+        runtimeKind: 'decision-policy' as const,
+        resolution: entry.resolution,
+        port: entry.port,
+      };
+      return missingResolvedBinding(requirement.referenceId);
+    },
+  });
+}
+
+function seriesAssembly(entries: readonly OmkEvaluationSeriesRuntimeBindingEntry[]) {
+  const analysisNodesByNodeId = new Map<string, Extract<
+    OmkEvaluationSeriesRuntimeBindingEntry,
+    { runtimeKind: 'series-analysis-node' }
+  >['port']>();
+  const decisionPoliciesByDecisionPolicyId = new Map<string, Extract<
+    OmkEvaluationSeriesRuntimeBindingEntry,
+    { runtimeKind: 'series-decision-policy' }
+  >['port']>();
+  const runtimes = entries.map((entry) => {
+    if (entry.runtimeKind === 'series-analysis-node') {
+      analysisNodesByNodeId.set(entry.binding.nodeId, entry.port);
+      return Object.freeze({
+        runtimeKind: entry.runtimeKind,
+        referenceId: entry.binding.nodeId,
+        identity: entry.resolution.identity as RuntimeIdentity,
+        outputSchema: entry.port.outputSchema,
+      });
+    }
+    decisionPoliciesByDecisionPolicyId.set(entry.binding.decisionPolicyId, entry.port);
+    return Object.freeze({
+      runtimeKind: entry.runtimeKind,
+      referenceId: entry.binding.decisionPolicyId,
+      identity: entry.resolution.identity as RuntimeIdentity,
+    });
+  });
+  return Object.freeze({
+    entries: Object.freeze([...entries]),
+    runtimes: Object.freeze(runtimes),
+    ports: Object.freeze({
+      analysisNodesByNodeId: readonlyMapSnapshot(analysisNodesByNodeId),
+      decisionPoliciesByDecisionPolicyId: readonlyMapSnapshot(
+        decisionPoliciesByDecisionPolicyId,
+      ),
+    }),
+  });
+}
+
+function readonlyMapSnapshot<Key, Value>(source: ReadonlyMap<Key, Value>): ReadonlyMap<Key, Value> {
+  const snapshot = new Map(source);
+  const view: ReadonlyMap<Key, Value> = Object.freeze({
+    get size() { return snapshot.size; },
+    get(key: Key) { return snapshot.get(key); },
+    has(key: Key) { return snapshot.has(key); },
+    keys() { return snapshot.keys(); },
+    values() { return snapshot.values(); },
+    entries() { return snapshot.entries(); },
+    [Symbol.iterator]() { return snapshot[Symbol.iterator](); },
+    forEach(
+      callback: (value: Value, key: Key, map: ReadonlyMap<Key, Value>) => void,
+      thisArg?: unknown,
+    ) {
+      snapshot.forEach((value, key) => callback.call(thisArg, value, key, view));
+    },
+  });
+  return view;
+}
+
+/**
+ * Validates the complete Definition／binding request before invoking any factory,
+ * then captures one immutable binding snapshot for Core prepare and execution.
+ */
+export async function assembleOmkRuntimeBindings(
+  input: Readonly<AssembleOmkRuntimeBindingsInput>,
+): Promise<OmkRuntimeBindingAssembly> {
+  let snapshotInput: AssembleOmkRuntimeBindingsInput;
+  try {
+    snapshotInput = {
+      definition: deepFreezeCanonicalJson(structuredClone(input.definition)),
+      runtimeBinding: deepFreezeCanonicalJson(structuredClone(input.runtimeBinding)),
+      factories: input.factories,
+      ...(input.seriesDefinition === undefined ? {} : {
+        seriesDefinition: deepFreezeCanonicalJson(structuredClone(input.seriesDefinition)),
+      }),
+    };
+  } catch (cause) {
+    fail({
+      code: 'OMK_RUNTIME_ASSEMBLY_INPUT_INVALID',
+      message: 'Runtime assembly 输入无法建立规范化不可变快照。',
+      cause,
+    });
+  }
+  const expected = validateRequest(snapshotInput);
+  const ordered = [...snapshotInput.runtimeBinding.bindings].sort((left, right) => (
+    compareStrings(left.bindingId, right.bindingId)
+  ));
+  assertFactoriesAvailable(ordered, snapshotInput.factories);
+  const entries: Array<
+    OmkEvaluationRuntimeBindingEntry | OmkEvaluationSeriesRuntimeBindingEntry
+  > = [];
+  for (const binding of ordered) {
+    entries.push(await materializeEntry(
+      binding,
+      expected.get(keyForBinding(binding)) as ExpectedBinding,
+      snapshotInput.factories,
+    ));
+  }
+  const evaluationEntries = entries.filter((entry): entry is OmkEvaluationRuntimeBindingEntry => (
+    entry.runtimeKind !== 'series-analysis-node'
+    && entry.runtimeKind !== 'series-decision-policy'
+  ));
+  const seriesEntries = entries.filter((entry): entry is OmkEvaluationSeriesRuntimeBindingEntry => (
+    entry.runtimeKind === 'series-analysis-node'
+    || entry.runtimeKind === 'series-decision-policy'
+  ));
+  return Object.freeze({
+    evaluation: Object.freeze({
+      entries: Object.freeze(evaluationEntries),
+      bindings: evaluationResolvers(evaluationEntries),
+    }),
+    ...(snapshotInput.seriesDefinition === undefined ? {} : { series: seriesAssembly(seriesEntries) }),
+  });
+}

--- a/src/eval-workflows/runtime-adapter/builtins.ts
+++ b/src/eval-workflows/runtime-adapter/builtins.ts
@@ -1,0 +1,34 @@
+import {
+  createBuiltinAnalysisNodes,
+  createBuiltinDecisionPolicies,
+  createBuiltinMissingPolicies,
+} from '../../evaluation-core/analysis/index.js';
+import type { OmkRuntimeBindingFactories } from './types.js';
+
+export type OmkBuiltinAnalysisBindingFactories = Pick<
+  OmkRuntimeBindingFactories,
+  | 'analysisNodesByImplementationId'
+  | 'missingPoliciesByImplementationId'
+  | 'decisionPoliciesByImplementationId'
+>;
+
+/** Binds Core-owned analysis implementations without copying their algorithms into the host. */
+export function createBuiltinOmkAnalysisBindingFactories(): OmkBuiltinAnalysisBindingFactories {
+  const analysisNodes = createBuiltinAnalysisNodes();
+  const missingPolicies = createBuiltinMissingPolicies();
+  const decisionPolicies = createBuiltinDecisionPolicies();
+  return {
+    analysisNodesByImplementationId: new Map([...analysisNodes].map(([implementationId, port]) => [
+      implementationId,
+      () => ({ port, satisfiesVersionConstraint: true }),
+    ])),
+    missingPoliciesByImplementationId: new Map([...missingPolicies].map(([
+      implementationId,
+      port,
+    ]) => [implementationId, () => ({ port, satisfiesVersionConstraint: true })])),
+    decisionPoliciesByImplementationId: new Map([...decisionPolicies].map(([
+      implementationId,
+      port,
+    ]) => [implementationId, () => ({ port, satisfiesVersionConstraint: true })])),
+  };
+}

--- a/src/eval-workflows/runtime-adapter/index.ts
+++ b/src/eval-workflows/runtime-adapter/index.ts
@@ -1,0 +1,3 @@
+export * from './assembly.js';
+export * from './builtins.js';
+export * from './types.js';

--- a/src/eval-workflows/runtime-adapter/types.ts
+++ b/src/eval-workflows/runtime-adapter/types.ts
@@ -1,0 +1,225 @@
+import type {
+  EvaluationDefinition,
+  EvaluationSeriesDefinition,
+  RuntimeIdentity,
+} from '../../evaluation-core/contracts/index.js';
+import type {
+  AnalysisRuntimeRequirement,
+  RuntimeResolution,
+} from '../../evaluation-core/compiler/index.js';
+import type {
+  AnalysisDecisionPolicy,
+  AnalysisMissingPolicy,
+  AnalysisNodeImplementation,
+} from '../../evaluation-core/analysis/index.js';
+import type { EvaluationEngineRuntimeBindings } from '../../evaluation-core/engine/index.js';
+import type { EvaluationEvaluator } from '../../evaluation-core/evaluation/index.js';
+import type { ExecutionExecutor } from '../../evaluation-core/execution/index.js';
+import type {
+  EvaluationSeriesRuntimePorts,
+  SeriesAnalysisNodeRuntime,
+  SeriesDecisionRuntime,
+} from '../../evaluation-core/series/index.js';
+import type {
+  RuntimeBinding,
+  RuntimeBindingRequest,
+  RuntimeResourceLeaseRequirement,
+} from '../input-compilation/index.js';
+
+export type RuntimeBindingOf<RuntimeKind extends RuntimeBinding['runtimeKind']> = Extract<
+  RuntimeBinding,
+  { runtimeKind: RuntimeKind }
+>;
+
+type AnalysisRuntimeBindingOf<RequirementKind extends 'analysis-node' | 'sampling-estimator'> =
+  Extract<RuntimeBinding, {
+    runtimeKind: 'analysis-node';
+    requirementKind: RequirementKind;
+  }>;
+
+export interface OmkRuntimePortBinding<Port> {
+  readonly port: Port;
+  /** Resolved by the implementation that owns the actual Runtime version. */
+  readonly satisfiesVersionConstraint: boolean;
+}
+
+interface OmkBindingFactoryContext {
+  /** Binding-local scope to combine with Core runId and trialId. */
+  readonly sessionIsolationKey: string;
+}
+
+export interface OmkExecutorBindingContext extends OmkBindingFactoryContext {
+  readonly binding: RuntimeBindingOf<'executor'>;
+  readonly target: EvaluationDefinition['targets'][number];
+}
+
+export interface OmkEvaluatorBindingContext extends OmkBindingFactoryContext {
+  readonly binding: RuntimeBindingOf<'evaluator'>;
+  readonly evaluator: EvaluationDefinition['evaluators'][number];
+}
+
+export type OmkAnalysisNodeBindingContext =
+  | {
+      readonly sessionIsolationKey: string;
+      readonly binding: AnalysisRuntimeBindingOf<'analysis-node'>;
+      readonly requirement: Extract<AnalysisRuntimeRequirement, {
+        requirementKind: 'analysis-node';
+      }>;
+      readonly subject: EvaluationDefinition['analysisGraph']['nodes'][number];
+    }
+  | {
+      readonly sessionIsolationKey: string;
+      readonly binding: AnalysisRuntimeBindingOf<'sampling-estimator'>;
+      readonly requirement: Extract<AnalysisRuntimeRequirement, {
+        requirementKind: 'sampling-estimator';
+      }>;
+      readonly subject: EvaluationDefinition['experiment']['sampling'];
+    };
+
+export interface OmkMissingPolicyBindingContext extends OmkBindingFactoryContext {
+  readonly binding: RuntimeBindingOf<'missing-policy'>;
+  readonly metricIds: readonly string[];
+}
+
+export interface OmkDecisionPolicyBindingContext extends OmkBindingFactoryContext {
+  readonly binding: RuntimeBindingOf<'decision-policy'>;
+  readonly policy: NonNullable<EvaluationDefinition['decisionPolicy']>;
+}
+
+export interface OmkSeriesAnalysisNodeBindingContext extends OmkBindingFactoryContext {
+  readonly binding: RuntimeBindingOf<'series-analysis-node'>;
+  readonly node: EvaluationSeriesDefinition['analysisGraph']['nodes'][number];
+}
+
+export interface OmkSeriesDecisionPolicyBindingContext extends OmkBindingFactoryContext {
+  readonly binding: RuntimeBindingOf<'series-decision-policy'>;
+  readonly policy: NonNullable<EvaluationSeriesDefinition['decisionPolicy']>;
+}
+
+type Factory<Context, Port> = (
+  context: Readonly<Context>,
+) => OmkRuntimePortBinding<Port> | Promise<OmkRuntimePortBinding<Port>>;
+
+export interface OmkRuntimeBindingFactories {
+  readonly executorsByImplementationId: ReadonlyMap<
+    string,
+    Factory<OmkExecutorBindingContext, ExecutionExecutor>
+  >;
+  readonly evaluatorsByImplementationId: ReadonlyMap<
+    string,
+    Factory<OmkEvaluatorBindingContext, EvaluationEvaluator>
+  >;
+  readonly analysisNodesByImplementationId: ReadonlyMap<
+    string,
+    Factory<OmkAnalysisNodeBindingContext, AnalysisNodeImplementation>
+  >;
+  readonly missingPoliciesByImplementationId: ReadonlyMap<
+    string,
+    Factory<OmkMissingPolicyBindingContext, AnalysisMissingPolicy>
+  >;
+  readonly decisionPoliciesByImplementationId: ReadonlyMap<
+    string,
+    Factory<OmkDecisionPolicyBindingContext, AnalysisDecisionPolicy>
+  >;
+  readonly seriesAnalysisNodesByImplementationId: ReadonlyMap<
+    string,
+    Factory<OmkSeriesAnalysisNodeBindingContext, SeriesAnalysisNodeRuntime>
+  >;
+  readonly seriesDecisionPoliciesByImplementationId: ReadonlyMap<
+    string,
+    Factory<OmkSeriesDecisionPolicyBindingContext, SeriesDecisionRuntime>
+  >;
+}
+
+interface OmkRuntimeBindingEntryBase<
+  RuntimeKind extends RuntimeBinding['runtimeKind'],
+  Port,
+> {
+  readonly runtimeKind: RuntimeKind;
+  readonly binding: RuntimeBindingOf<RuntimeKind>;
+  readonly resolution: RuntimeResolution;
+  readonly port: Port;
+  /** Resources that must be acquired before this binding may open a run. */
+  readonly resourceLeaseRequirements: readonly RuntimeResourceLeaseRequirement[];
+  /** Binding-local session scope; adapters combine it with Core's runId and trialId. */
+  readonly sessionIsolationKey: string;
+}
+
+export type OmkEvaluationRuntimeBindingEntry =
+  | OmkRuntimeBindingEntryBase<'executor', ExecutionExecutor>
+  | OmkRuntimeBindingEntryBase<'evaluator', EvaluationEvaluator>
+  | OmkRuntimeBindingEntryBase<'analysis-node', AnalysisNodeImplementation>
+  | OmkRuntimeBindingEntryBase<'missing-policy', AnalysisMissingPolicy>
+  | OmkRuntimeBindingEntryBase<'decision-policy', AnalysisDecisionPolicy>;
+
+export type OmkEvaluationSeriesRuntimeBindingEntry =
+  | OmkRuntimeBindingEntryBase<'series-analysis-node', SeriesAnalysisNodeRuntime>
+  | OmkRuntimeBindingEntryBase<'series-decision-policy', SeriesDecisionRuntime>;
+
+export interface OmkEvaluationRuntimeBindingAssembly {
+  readonly entries: readonly OmkEvaluationRuntimeBindingEntry[];
+  readonly bindings: EvaluationEngineRuntimeBindings;
+}
+
+export interface OmkEvaluationSeriesRuntimeBindingAssembly {
+  readonly entries: readonly OmkEvaluationSeriesRuntimeBindingEntry[];
+  readonly runtimes: readonly (
+    | {
+        readonly runtimeKind: 'series-analysis-node';
+        readonly referenceId: string;
+        readonly identity: RuntimeIdentity;
+        readonly outputSchema: SeriesAnalysisNodeRuntime['outputSchema'];
+      }
+    | {
+        readonly runtimeKind: 'series-decision-policy';
+        readonly referenceId: string;
+        readonly identity: RuntimeIdentity;
+      }
+  )[];
+  readonly ports: Pick<
+    EvaluationSeriesRuntimePorts,
+    'analysisNodesByNodeId' | 'decisionPoliciesByDecisionPolicyId'
+  >;
+}
+
+export interface OmkRuntimeBindingAssembly {
+  readonly evaluation: OmkEvaluationRuntimeBindingAssembly;
+  readonly series?: OmkEvaluationSeriesRuntimeBindingAssembly;
+}
+
+export interface AssembleOmkRuntimeBindingsInput {
+  readonly definition: EvaluationDefinition;
+  readonly runtimeBinding: RuntimeBindingRequest;
+  readonly factories: OmkRuntimeBindingFactories;
+  readonly seriesDefinition?: EvaluationSeriesDefinition;
+}
+
+export type OmkRuntimeAssemblyErrorCode =
+  | 'OMK_RUNTIME_ASSEMBLY_INPUT_INVALID'
+  | 'OMK_RUNTIME_BINDING_REQUEST_INVALID'
+  | 'OMK_RUNTIME_BINDING_DUPLICATE'
+  | 'OMK_RUNTIME_BINDING_COVERAGE_MISMATCH'
+  | 'OMK_RUNTIME_BINDING_DEFINITION_MISMATCH'
+  | 'OMK_RUNTIME_BINDING_FACTORY_MISSING'
+  | 'OMK_RUNTIME_BINDING_FACTORY_FAILED'
+  | 'OMK_RUNTIME_BINDING_PORT_INVALID';
+
+export class OmkRuntimeAssemblyError extends TypeError {
+  readonly code: OmkRuntimeAssemblyErrorCode;
+  readonly bindingId?: string;
+  readonly referenceId?: string;
+
+  constructor(input: {
+    code: OmkRuntimeAssemblyErrorCode;
+    message: string;
+    bindingId?: string;
+    referenceId?: string;
+    cause?: unknown;
+  }) {
+    super(input.message, { cause: input.cause });
+    this.name = 'OmkRuntimeAssemblyError';
+    this.code = input.code;
+    this.bindingId = input.bindingId;
+    this.referenceId = input.referenceId;
+  }
+}

--- a/test/eval-workflows/input-compilation/compile.test.ts
+++ b/test/eval-workflows/input-compilation/compile.test.ts
@@ -449,9 +449,24 @@ describe('compileCliEvaluationInput', () => {
       },
     });
     const bindingJson = canonicalizeJson(result.runtimeBinding);
+    expect(result.runtimeBinding.schemaVersion).toBe('omk.runtime-binding-request/v2');
     expect(bindingJson).not.toContain('capabilities');
     expect(bindingJson).not.toContain('fingerprint');
     expect(bindingJson).not.toContain('assuranceLevel');
+    expect(result.runtimeBinding.bindings).toContainEqual({
+      runtimeKind: 'missing-policy',
+      bindingId: 'missing-policy-exclude/v1',
+      policyId: 'exclude/v1',
+      implementationId: 'exclude/v1',
+    });
+    expect(result.runtimeBinding.bindings).toContainEqual({
+      runtimeKind: 'analysis-node',
+      bindingId: 'sampling-estimator-bootstrap.mean-difference/v1',
+      referenceId: 'bootstrap.mean-difference/v1',
+      requirementKind: 'sampling-estimator',
+      analysisNodeKind: 'estimator',
+      implementationId: 'bootstrap.mean-difference/v1',
+    });
   });
 
   it('rejects inline secret evaluator or target configuration', () => {

--- a/test/eval-workflows/runtime-adapter/assembly.test.ts
+++ b/test/eval-workflows/runtime-adapter/assembly.test.ts
@@ -1,0 +1,705 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createEvaluationSeriesDefinition,
+  createEvaluationEngine,
+  digestCanonicalJson,
+  prepareEvaluationSeriesPlan,
+  type JsonValue,
+  type RuntimeIdentity,
+  type SchemaIdentity,
+} from '../../../src/index.js';
+import { RuntimeIdentitySchema } from '../../../src/evaluation-core/contracts/index.js';
+import type {
+  AnalysisDecisionPolicy,
+  AnalysisMissingPolicy,
+  AnalysisNodeImplementation,
+} from '../../../src/evaluation-core/analysis/index.js';
+import type {
+  AnalysisRuntimeRequirement,
+  RuntimeResolution,
+} from '../../../src/evaluation-core/compiler/index.js';
+import type { EvaluationEvaluator } from '../../../src/evaluation-core/evaluation/index.js';
+import type { ExecutionExecutor } from '../../../src/evaluation-core/execution/index.js';
+import type { SeriesAnalysisNodeRuntime } from '../../../src/evaluation-core/series/index.js';
+import {
+  assembleOmkRuntimeBindings,
+  createBuiltinOmkAnalysisBindingFactories,
+  type OmkRuntimeBindingFactories,
+  type RuntimeBindingOf,
+} from '../../../src/eval-workflows/runtime-adapter/index.js';
+import { compileCliEvaluationInput } from '../../../src/eval-workflows/input-compilation/index.js';
+import { testRuntime } from '../../evaluation-core/compiler/fixtures.js';
+import { validResolvedCliInput } from '../input-compilation/fixtures.js';
+
+type Mutable<Value> = Value extends readonly (infer Item)[]
+  ? Mutable<Item>[]
+  : Value extends object
+    ? { -readonly [Key in keyof Value]: Mutable<Value[Key]> }
+    : Value;
+
+function clone<Value>(value: Value): Mutable<Value> {
+  return structuredClone(value) as Mutable<Value>;
+}
+
+function runtimeAssemblyInput(): Mutable<ReturnType<typeof validResolvedCliInput>> {
+  const input = clone(validResolvedCliInput());
+  for (const target of input.targets) target.executor.implementationId = 'test.executor/v1';
+  for (const template of input.evaluatorTemplates) {
+    if (template.implementationId !== undefined) {
+      template.implementationId = `test.evaluator.${template.evaluatorId}/v1`;
+    }
+  }
+  for (const member of input.judges.members) {
+    member.implementationId = `test.evaluator.${member.ensembleMemberId}/v1`;
+  }
+  for (const metric of input.metrics) metric.missingPolicyId = 'test.missing.exclude/v1';
+  for (const node of input.analysisGraph.nodes) {
+    node.implementationId = `test.analysis.${node.nodeId}/v1`;
+  }
+  input.experiment.sampling.estimatorId = 'test.analysis.sampling-estimator/v1';
+  if (input.decisionPolicy !== undefined) {
+    input.decisionPolicy.implementationId = 'test.decision/v1';
+  }
+  return input;
+}
+
+function bindingIdentity(
+  implementationId: string,
+  referenceId: string,
+  base: RuntimeIdentity,
+  capabilities: RuntimeIdentity['capabilities'] = base.capabilities,
+): RuntimeIdentity {
+  return RuntimeIdentitySchema.parse({
+    ...structuredClone(base),
+    implementationId,
+    capabilities,
+    fingerprint: digestCanonicalJson({
+      base: base.fingerprint,
+      capabilities,
+      implementationId,
+      referenceId,
+    }),
+    implementationManifest: {
+      coverageKind: 'fingerprint-plus-facets',
+      facets: [{ facetId: 'binding-reference', value: referenceId }],
+    },
+  });
+}
+
+function analysisRequirement(
+  binding: RuntimeBindingOf<'analysis-node'>,
+): AnalysisRuntimeRequirement {
+  return Object.freeze({
+    requirementKind: binding.requirementKind,
+    referenceId: binding.referenceId,
+    implementationId: binding.implementationId,
+    ...(binding.versionConstraint === undefined ? {} : {
+      versionConstraint: binding.versionConstraint,
+    }),
+    analysisNodeKind: binding.analysisNodeKind,
+  });
+}
+
+function outputSchema(identity: RuntimeIdentity): SchemaIdentity {
+  const capabilities = identity.capabilities as { outputSchema?: SchemaIdentity };
+  if (capabilities.outputSchema === undefined) throw new Error('missing output schema');
+  return capabilities.outputSchema;
+}
+
+function factoriesFor(
+  compiled: ReturnType<typeof compileCliEvaluationInput>,
+  calls: string[],
+): OmkRuntimeBindingFactories {
+  const preparation = testRuntime({
+    evaluatorValueTypes: ['numeric', 'boolean', 'categorical', 'text', 'ranking'],
+  });
+  const executors = new Map<string, OmkRuntimeBindingFactories[
+    'executorsByImplementationId'
+  ] extends ReadonlyMap<string, infer Factory> ? Factory : never>();
+  const evaluators = new Map<string, OmkRuntimeBindingFactories[
+    'evaluatorsByImplementationId'
+  ] extends ReadonlyMap<string, infer Factory> ? Factory : never>();
+  const analysisNodes = new Map<string, OmkRuntimeBindingFactories[
+    'analysisNodesByImplementationId'
+  ] extends ReadonlyMap<string, infer Factory> ? Factory : never>();
+  const missingPolicies = new Map<string, OmkRuntimeBindingFactories[
+    'missingPoliciesByImplementationId'
+  ] extends ReadonlyMap<string, infer Factory> ? Factory : never>();
+  const decisionPolicies = new Map<string, OmkRuntimeBindingFactories[
+    'decisionPoliciesByImplementationId'
+  ] extends ReadonlyMap<string, infer Factory> ? Factory : never>();
+  const seriesAnalysisNodes = new Map<string, OmkRuntimeBindingFactories[
+    'seriesAnalysisNodesByImplementationId'
+  ] extends ReadonlyMap<string, infer Factory> ? Factory : never>();
+
+  for (const binding of compiled.runtimeBinding.bindings) {
+    if (binding.runtimeKind === 'executor' && !executors.has(binding.implementationId)) {
+      executors.set(binding.implementationId, async ({ binding: request }) => {
+        calls.push(request.bindingId);
+        const resolved = await preparation.resolveExecutor(Object.freeze({
+          referenceId: request.targetId,
+          executorId: request.implementationId,
+          ...(request.versionConstraint === undefined ? {} : {
+            versionConstraint: request.versionConstraint,
+          }),
+          protocolId: request.protocolId,
+        })) as RuntimeResolution;
+        const identity = bindingIdentity(
+          request.implementationId,
+          request.targetId,
+          resolved.identity,
+        );
+        const port: ExecutionExecutor = {
+          identity,
+          async openRun() { throw new Error('test prepare must not open an Executor'); },
+        };
+        return { port, satisfiesVersionConstraint: true };
+      });
+    } else if (binding.runtimeKind === 'evaluator'
+        && !evaluators.has(binding.implementationId)) {
+      evaluators.set(binding.implementationId, async ({ binding: request }) => {
+        calls.push(request.bindingId);
+        const resolved = await preparation.resolveEvaluator(Object.freeze({
+          referenceId: request.evaluatorId,
+          implementationId: request.implementationId,
+          ...(request.versionConstraint === undefined ? {} : {
+            versionConstraint: request.versionConstraint,
+          }),
+        })) as RuntimeResolution;
+        const identity = bindingIdentity(
+          request.implementationId,
+          request.evaluatorId,
+          resolved.identity,
+        );
+        const port: EvaluationEvaluator = {
+          identity,
+          async openRun() { throw new Error('test prepare must not open an Evaluator'); },
+        };
+        return { port, satisfiesVersionConstraint: true };
+      });
+    } else if (binding.runtimeKind === 'analysis-node'
+        && !analysisNodes.has(binding.implementationId)) {
+      analysisNodes.set(binding.implementationId, async ({ binding: request }) => {
+        calls.push(request.bindingId);
+        const resolved = await preparation.resolveAnalysis(
+          analysisRequirement(request),
+        ) as RuntimeResolution;
+        const baseCapabilities = resolved.identity.capabilities as unknown as {
+          outputSchema: SchemaIdentity;
+          parameterSchema: SchemaIdentity;
+          schemas: SchemaIdentity[];
+        };
+        const capabilities: JsonValue = request.requirementKind === 'sampling-estimator'
+          ? {
+              ...baseCapabilities,
+              capabilityKind: 'analysis-node' as const,
+              analysisNodeKinds: ['estimator'],
+              inputDomains: [],
+              inputCardinalities: {
+                metricObservations: { min: 0, max: 0 },
+                analysisResults: { min: 0, max: 0 },
+                comparisons: { min: 0, max: 0 },
+              },
+              sampling: {
+                experimentalUnits: [compiled.definition.experiment.sampling.experimentalUnit],
+                repeatedMeasures: [compiled.definition.experiment.sampling.repeatedMeasures],
+                resamplingUnits: [compiled.definition.experiment.sampling.resamplingUnit],
+              },
+            }
+          : {
+              ...baseCapabilities,
+              capabilityKind: 'analysis-node' as const,
+              analysisNodeKinds: [request.analysisNodeKind],
+              inputDomains: [
+                {
+                  inputKind: 'metric-observations' as const,
+                  valueTypes: ['numeric', 'boolean', 'categorical', 'text', 'ranking'],
+                  missingPolicyIds: ['test.missing.exclude/v1'],
+                },
+                { inputKind: 'comparison' as const },
+                {
+                  inputKind: 'analysis-result' as const,
+                  schemaUris: [baseCapabilities.outputSchema.schemaUri],
+                },
+              ],
+              inputCardinalities: {
+                metricObservations: { min: 0, max: 100 },
+                analysisResults: { min: 0, max: 100 },
+                comparisons: { min: 0, max: 100 },
+              },
+            };
+        const identity = bindingIdentity(
+          request.implementationId,
+          request.referenceId,
+          resolved.identity,
+          capabilities,
+        );
+        const port: AnalysisNodeImplementation = {
+          identity,
+          outputSchema: outputSchema(identity),
+          async openRun() { throw new Error('test prepare must not open Analysis'); },
+        };
+        return { port, satisfiesVersionConstraint: true };
+      });
+    } else if (binding.runtimeKind === 'missing-policy'
+        && !missingPolicies.has(binding.implementationId)) {
+      missingPolicies.set(binding.implementationId, async ({ binding: request }) => {
+        calls.push(request.bindingId);
+        const resolved = await preparation.resolveAnalysis(Object.freeze({
+          requirementKind: 'missing-policy',
+          referenceId: request.policyId,
+          implementationId: request.implementationId,
+        })) as RuntimeResolution;
+        const port: AnalysisMissingPolicy = {
+          identity: bindingIdentity(
+            request.implementationId,
+            request.policyId,
+            resolved.identity,
+          ),
+          decide: () => 'exclude',
+        };
+        return { port, satisfiesVersionConstraint: true };
+      });
+    } else if (binding.runtimeKind === 'decision-policy'
+        && !decisionPolicies.has(binding.implementationId)) {
+      decisionPolicies.set(binding.implementationId, async ({ binding: request }) => {
+        calls.push(request.bindingId);
+        const resolved = await preparation.resolveAnalysis(Object.freeze({
+          requirementKind: 'decision-policy',
+          referenceId: request.decisionPolicyId,
+          implementationId: request.implementationId,
+          ...(request.versionConstraint === undefined ? {} : {
+            versionConstraint: request.versionConstraint,
+          }),
+        })) as RuntimeResolution;
+        const port: AnalysisDecisionPolicy = {
+          identity: bindingIdentity(
+            request.implementationId,
+            request.decisionPolicyId,
+            resolved.identity,
+          ),
+          async decide() {
+            return { decisionStatus: 'not-decided', reasonCodes: ['test-only'] };
+          },
+        };
+        return { port, satisfiesVersionConstraint: true };
+      });
+    } else if (binding.runtimeKind === 'series-analysis-node'
+        && !seriesAnalysisNodes.has(binding.implementationId)) {
+      seriesAnalysisNodes.set(binding.implementationId, ({ binding: request }) => {
+        calls.push(request.bindingId);
+        const schema: SchemaIdentity = {
+          schemaVersion: 'test.series-output/v1',
+          schemaUri: 'urn:test:series-output:v1',
+          schemaDigest: digestCanonicalJson({ schema: 'series-output' }),
+        };
+        const identity = RuntimeIdentitySchema.parse({
+          implementationId: request.implementationId,
+          fingerprint: digestCanonicalJson({ implementationId: request.implementationId }),
+          fingerprintBasis: 'content-derived',
+          assuranceLevel: 'verified',
+          capabilities: { experimentalUnit: 'run' },
+          implementationManifest: { coverageKind: 'fingerprint-complete' },
+        });
+        const port: SeriesAnalysisNodeRuntime = {
+          identity,
+          outputSchema: schema,
+          async analyze() { return { analysisStatus: 'inconclusive', reasonCodes: ['test-only'] }; },
+        };
+        return { port, satisfiesVersionConstraint: true };
+      });
+    }
+  }
+  return {
+    executorsByImplementationId: executors,
+    evaluatorsByImplementationId: evaluators,
+    analysisNodesByImplementationId: analysisNodes,
+    missingPoliciesByImplementationId: missingPolicies,
+    decisionPoliciesByImplementationId: decisionPolicies,
+    seriesAnalysisNodesByImplementationId: seriesAnalysisNodes,
+    seriesDecisionPoliciesByImplementationId: new Map(),
+  };
+}
+
+const clock = {
+  monotonicNow: () => 0,
+  timestamp: () => '2026-08-30T00:00:00.000Z',
+  async sleep(_delayMs: number, signal: AbortSignal) {
+    if (signal.aborted) throw new Error('aborted');
+  },
+};
+
+describe('OMK Evaluation Runtime binding assembly', () => {
+  it('assembles exact reference bindings and passes a real Core prepare', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    const compiled = compileCliEvaluationInput(input);
+    const calls: string[] = [];
+    const factories = factoriesFor(compiled, calls);
+
+    const assembly = await assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding: compiled.runtimeBinding,
+      factories,
+    });
+    const preparation = testRuntime();
+    const prepared = await createEvaluationEngine({
+      bindings: assembly.evaluation.bindings,
+      clock,
+      schemaValidators: preparation.schemaValidators,
+    }).prepare(compiled.definition, compiled.policy);
+
+    expect(prepared.plan.execution.targets).toEqual(compiled.definition.targets);
+    expect(assembly.evaluation.entries).toHaveLength(compiled.runtimeBinding.bindings.length);
+    expect(calls).toHaveLength(compiled.runtimeBinding.bindings.length);
+    expect(new Set(assembly.evaluation.entries.map((entry) => entry.sessionIsolationKey)).size)
+      .toBe(assembly.evaluation.entries.length);
+    for (const entry of assembly.evaluation.entries) {
+      expect(Object.isFrozen(entry.binding)).toBe(true);
+      expect(Object.isFrozen(entry.resolution.identity)).toBe(true);
+      expect(entry.port.identity).toBe(entry.resolution.identity);
+    }
+    const treatmentEntry = assembly.evaluation.entries.find((entry) => (
+      entry.runtimeKind === 'executor' && entry.binding.targetId === 'treatment'
+    ));
+    expect(treatmentEntry?.resourceLeaseRequirements.map((requirement) => (
+      `${requirement.resourceRole}:${requirement.leaseMode}`
+    ))).toEqual([
+      'artifact:immutable-snapshot',
+      'mcp-config:immutable-snapshot',
+      'mock-payload:immutable-snapshot',
+      'workspace:copy-on-write-overlay',
+    ]);
+    expect(assembly.evaluation.entries.some((entry) => (
+      entry.runtimeKind === 'missing-policy'
+      && entry.binding.policyId === 'test.missing.exclude/v1'
+    ))).toBe(true);
+  });
+
+  it('creates distinct binding entries for targets sharing one implementation', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    const compiled = compileCliEvaluationInput(input);
+    const assembly = await assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding: compiled.runtimeBinding,
+      factories: factoriesFor(compiled, []),
+    });
+    const executors = assembly.evaluation.entries.filter((entry) => (
+      entry.runtimeKind === 'executor'
+    ));
+
+    expect(executors).toHaveLength(2);
+    expect(executors[0].binding.implementationId).toBe(executors[1].binding.implementationId);
+    expect(executors[0].binding.targetId).not.toBe(executors[1].binding.targetId);
+    expect(executors[0].resolution.identity.fingerprint)
+      .not.toBe(executors[1].resolution.identity.fingerprint);
+    expect(executors[0].port).not.toBe(executors[1].port);
+  });
+
+  it.each(['missing', 'mismatched', 'resource-mismatched'] as const)(
+    'fails before invoking factories for a %s Definition binding',
+    async (scenario) => {
+      const input = runtimeAssemblyInput();
+      delete input.orchestration.independentSeries;
+      const compiled = compileCliEvaluationInput(input);
+      const request = clone(compiled.runtimeBinding);
+      if (scenario === 'missing') request.bindings.pop();
+      else if (scenario === 'mismatched') {
+        const executor = request.bindings.find((binding) => binding.runtimeKind === 'executor');
+        if (executor?.runtimeKind !== 'executor') throw new Error('missing fixture binding');
+        executor.protocolId = executor.protocolId === 'omk.invoke/v1'
+          ? 'omk.session/v1'
+          : 'omk.invoke/v1';
+      } else {
+        const executor = request.bindings.find((binding) => binding.runtimeKind === 'executor');
+        if (executor?.runtimeKind !== 'executor') throw new Error('missing fixture binding');
+        executor.resourceLeaseRequirements.pop();
+      }
+      const calls: string[] = [];
+
+      await expect(assembleOmkRuntimeBindings({
+        definition: compiled.definition,
+        runtimeBinding: request,
+        factories: factoriesFor(compiled, calls),
+      })).rejects.toMatchObject({
+        code: scenario === 'missing'
+          ? 'OMK_RUNTIME_BINDING_COVERAGE_MISMATCH'
+          : 'OMK_RUNTIME_BINDING_DEFINITION_MISMATCH',
+      });
+      expect(calls).toEqual([]);
+    },
+  );
+
+  it('rejects an unknown binding discriminator before invoking factories', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    const compiled = compileCliEvaluationInput(input);
+    const request = clone(compiled.runtimeBinding);
+    (request.bindings[0] as { runtimeKind: string }).runtimeKind = 'unknown-runtime';
+    const calls: string[] = [];
+
+    await expect(assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding: request as typeof compiled.runtimeBinding,
+      factories: factoriesFor(compiled, calls),
+    })).rejects.toMatchObject({ code: 'OMK_RUNTIME_BINDING_REQUEST_INVALID' });
+    expect(calls).toEqual([]);
+  });
+
+  it('rejects the incomplete v1 binding request without compatibility inference', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    const compiled = compileCliEvaluationInput(input);
+    const request = clone(compiled.runtimeBinding) as { schemaVersion: string };
+    request.schemaVersion = 'omk.runtime-binding-request/v1';
+    const calls: string[] = [];
+
+    await expect(assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding: request as typeof compiled.runtimeBinding,
+      factories: factoriesFor(compiled, calls),
+    })).rejects.toMatchObject({ code: 'OMK_RUNTIME_BINDING_REQUEST_INVALID' });
+    expect(calls).toEqual([]);
+  });
+
+  it('rejects a factory whose actual port identity names another implementation', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    const compiled = compileCliEvaluationInput(input);
+    const factories = factoriesFor(compiled, []);
+    const implementationId = compiled.runtimeBinding.bindings.find((binding) => (
+      binding.runtimeKind === 'executor'
+    ))?.implementationId;
+    if (implementationId === undefined) throw new Error('missing fixture implementation');
+    const wrongIdentity = RuntimeIdentitySchema.parse({
+      implementationId: 'test.wrong-implementation/v1',
+      fingerprint: 'wrong',
+      fingerprintBasis: 'opaque',
+      assuranceLevel: 'unknown',
+      capabilities: {},
+      implementationManifest: { coverageKind: 'fingerprint-complete' },
+    });
+    const port: ExecutionExecutor = {
+      identity: wrongIdentity,
+      async openRun() { throw new Error('must not run'); },
+    };
+    const executors = new Map(factories.executorsByImplementationId);
+    executors.set(implementationId, () => ({ port, satisfiesVersionConstraint: true }));
+
+    await expect(assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding: compiled.runtimeBinding,
+      factories: { ...factories, executorsByImplementationId: executors },
+    })).rejects.toMatchObject({ code: 'OMK_RUNTIME_BINDING_PORT_INVALID' });
+  });
+
+  it('rejects an Analysis port whose output schema differs from its identity capability', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    const compiled = compileCliEvaluationInput(input);
+    const factories = factoriesFor(compiled, []);
+    const binding = compiled.runtimeBinding.bindings.find((candidate) => (
+      candidate.runtimeKind === 'analysis-node'
+      && candidate.requirementKind === 'analysis-node'
+    ));
+    if (binding?.runtimeKind !== 'analysis-node') throw new Error('missing Analysis binding');
+    const originalFactory = factories.analysisNodesByImplementationId
+      .get(binding.implementationId);
+    if (originalFactory === undefined) throw new Error('missing Analysis factory');
+    const analysisNodes = new Map(factories.analysisNodesByImplementationId);
+    analysisNodes.set(binding.implementationId, async (context) => {
+      const result = await originalFactory(context);
+      return {
+        ...result,
+        port: {
+          ...result.port,
+          outputSchema: {
+            schemaVersion: 'test.mismatched/v1',
+            schemaUri: 'urn:test:mismatched:v1',
+            schemaDigest: digestCanonicalJson({ schema: 'mismatched' }),
+          },
+        },
+      };
+    });
+
+    await expect(assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding: compiled.runtimeBinding,
+      factories: { ...factories, analysisNodesByImplementationId: analysisNodes },
+    })).rejects.toMatchObject({ code: 'OMK_RUNTIME_BINDING_PORT_INVALID' });
+  });
+
+  it('checks complete factory coverage before invoking any factory', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    const compiled = compileCliEvaluationInput(input);
+    const calls: string[] = [];
+    const factories = factoriesFor(compiled, calls);
+    const executors = new Map(factories.executorsByImplementationId);
+    executors.clear();
+
+    await expect(assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding: compiled.runtimeBinding,
+      factories: { ...factories, executorsByImplementationId: executors },
+    })).rejects.toMatchObject({ code: 'OMK_RUNTIME_BINDING_FACTORY_MISSING' });
+    expect(calls).toEqual([]);
+  });
+
+  it('keeps factory failures distinct from invalid returned ports', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    const compiled = compileCliEvaluationInput(input);
+    const factories = factoriesFor(compiled, []);
+    const first = [...compiled.runtimeBinding.bindings]
+      .sort((left, right) => left.bindingId.localeCompare(right.bindingId))[0];
+    if (first.runtimeKind !== 'analysis-node') throw new Error('unexpected fixture ordering');
+    const analysisNodes = new Map(factories.analysisNodesByImplementationId);
+    analysisNodes.set(first.implementationId, () => { throw new Error('factory failed'); });
+
+    await expect(assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding: compiled.runtimeBinding,
+      factories: { ...factories, analysisNodesByImplementationId: analysisNodes },
+    })).rejects.toMatchObject({
+      code: 'OMK_RUNTIME_BINDING_FACTORY_FAILED',
+      bindingId: first.bindingId,
+    });
+  });
+
+  it('captures ports independently from later factory registry mutation', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    const compiled = compileCliEvaluationInput(input);
+    const factories = factoriesFor(compiled, []);
+    const assembly = await assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding: compiled.runtimeBinding,
+      factories,
+    });
+    const targetId = compiled.definition.targets[0].targetId;
+    const before = await assembly.evaluation.bindings.resolveExecutor({
+      referenceId: targetId,
+      executorId: compiled.definition.targets[0].executorId,
+      ...(compiled.definition.targets[0].versionConstraint === undefined ? {} : {
+        versionConstraint: compiled.definition.targets[0].versionConstraint,
+      }),
+      protocolId: compiled.definition.targets[0].protocolId,
+    });
+    (factories.executorsByImplementationId as Map<string, unknown>).clear();
+    const after = await assembly.evaluation.bindings.resolveExecutor({
+      referenceId: targetId,
+      executorId: compiled.definition.targets[0].executorId,
+      ...(compiled.definition.targets[0].versionConstraint === undefined ? {} : {
+        versionConstraint: compiled.definition.targets[0].versionConstraint,
+      }),
+      protocolId: compiled.definition.targets[0].protocolId,
+    });
+
+    expect(after.port).toBe(before.port);
+    expect(after.resolution).toBe(before.resolution);
+  });
+
+  it('preserves version resolution for Core to reject during preparation', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    const compiled = compileCliEvaluationInput(input);
+    const factories = factoriesFor(compiled, []);
+    const implementationId = compiled.definition.targets[0].executorId;
+    const originalFactory = factories.executorsByImplementationId.get(implementationId);
+    if (originalFactory === undefined) throw new Error('missing executor factory');
+    const executors = new Map(factories.executorsByImplementationId);
+    executors.set(implementationId, async (context) => ({
+      ...await originalFactory(context),
+      satisfiesVersionConstraint: false,
+    }));
+    const assembly = await assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding: compiled.runtimeBinding,
+      factories: { ...factories, executorsByImplementationId: executors },
+    });
+    const preparation = testRuntime();
+
+    await expect(createEvaluationEngine({
+      bindings: assembly.evaluation.bindings,
+      clock,
+      schemaValidators: preparation.schemaValidators,
+    }).prepare(compiled.definition, compiled.policy)).rejects.toMatchObject({
+      code: 'EVAL_DEFINITION_RUNTIME_RESOLUTION_FAILED',
+      preparationStage: 'runtime-resolution',
+    });
+  });
+
+  it('captures an immutable request snapshot before factories can observe later mutation', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    const compiled = compileCliEvaluationInput(input);
+    const request = clone(compiled.runtimeBinding);
+    const assembly = await assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding: request,
+      factories: factoriesFor(compiled, []),
+    });
+    const mutableExecutor = request.bindings.find((binding) => binding.runtimeKind === 'executor');
+    if (mutableExecutor?.runtimeKind !== 'executor') throw new Error('missing executor binding');
+    mutableExecutor.protocolId = 'omk.session/v1';
+    const captured = assembly.evaluation.entries.find((entry) => (
+      entry.runtimeKind === 'executor' && entry.binding.bindingId === mutableExecutor.bindingId
+    ));
+
+    expect(captured?.runtimeKind).toBe('executor');
+    if (captured?.runtimeKind !== 'executor') throw new Error('missing captured binding');
+    expect(captured.binding.protocolId).toBe('omk.invoke/v1');
+    expect(captured.binding).not.toBe(mutableExecutor);
+  });
+
+  it('assembles Series ports outside EvaluationEngineRuntime', async () => {
+    const compiled = compileCliEvaluationInput(runtimeAssemblyInput());
+    const series = compiled.orchestration.independentSeries;
+    if (series === undefined) throw new Error('missing fixture Series');
+    const { seriesDesignDigest: _seriesDesignDigest, ...seriesInput } = clone(series.definition);
+    expect(_seriesDesignDigest).toBe(series.definition.seriesDesignDigest);
+    seriesInput.analysisGraph.nodes[0].implementationId = 'test.series.analysis/v1';
+    const seriesDefinition = createEvaluationSeriesDefinition(seriesInput);
+    const runtimeBinding = clone(compiled.runtimeBinding);
+    const seriesBinding = runtimeBinding.bindings.find((binding) => (
+      binding.runtimeKind === 'series-analysis-node'
+    ));
+    if (seriesBinding?.runtimeKind !== 'series-analysis-node') {
+      throw new Error('missing Series binding');
+    }
+    const originalImplementationId = seriesBinding.implementationId;
+    seriesBinding.implementationId = 'test.series.analysis/v1';
+    const factories = factoriesFor(compiled, []);
+    const seriesFactory = factories.seriesAnalysisNodesByImplementationId
+      .get(originalImplementationId);
+    if (seriesFactory === undefined) throw new Error('missing Series factory');
+    const seriesFactories = new Map(factories.seriesAnalysisNodesByImplementationId);
+    seriesFactories.delete(originalImplementationId);
+    seriesFactories.set(seriesBinding.implementationId, seriesFactory);
+    const assembly = await assembleOmkRuntimeBindings({
+      definition: compiled.definition,
+      runtimeBinding,
+      seriesDefinition,
+      factories: { ...factories, seriesAnalysisNodesByImplementationId: seriesFactories },
+    });
+    if (assembly.series === undefined) throw new Error('missing Series assembly');
+
+    const plan = prepareEvaluationSeriesPlan(seriesDefinition, assembly.series.runtimes);
+    expect(plan.definition.seriesDesignDigest).toBe(seriesDefinition.seriesDesignDigest);
+    expect(assembly.series.ports.analysisNodesByNodeId.has('run-variance')).toBe(true);
+    expect((assembly.series.ports.analysisNodesByNodeId as unknown as { set?: unknown }).set)
+      .toBeUndefined();
+    expect(assembly.evaluation.entries.some((entry) => (
+      entry.runtimeKind === ('series-analysis-node' as string)
+    ))).toBe(false);
+  });
+
+  it('reuses Core built-in analysis ports without host algorithm copies', () => {
+    const builtins = createBuiltinOmkAnalysisBindingFactories();
+    expect(builtins.analysisNodesByImplementationId.has('bootstrap.mean-percentile/v1')).toBe(true);
+    expect(builtins.missingPoliciesByImplementationId.has('exclude/v1')).toBe(true);
+    expect(builtins.decisionPoliciesByImplementationId.has('progress/v1')).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #457。

前置：#458、#459 已合并。

## 用户影响

建立 OMK 作为 Evaluation Core 宿主的第一段可运行边界：RuntimeBindingRequest v2 精确覆盖 executor、evaluator、Analysis／Sampling、MissingPolicy、DecisionPolicy 与独立 Series runtime，并由同一份不可变 binding entry 投影 Core preparation resolver 和运行 port。编译后的测试实现已通过真实 Core prepare。

本 PR 不切换正式 omk eval，不双跑或持久化 Core Bundle／Report，也不修改评分类 prompt、五层评分、统计公式或 cache 语义。

## 迁移说明

宿主侧 RuntimeBindingRequest 从 v1 升为 v2。v1 缺少完整 runtime 覆盖和按角色区分的 resource lease requirement，本次直接拒绝 v1，不提供兼容读取。

## 架构与测量学说明

Runtime 只能实现 Definition，不能覆盖 model、effort、protocol、prompt variant 或 behavior config。所有 Definition／binding／实际 port 不一致在业务调用前 fail closed；实际 identity 与 Analysis output schema 由 assembly 捕获，再交给 Core 做 capability、version、assurance 和 sealed measurement design 校验。

资源这里只声明 acquisition requirement，实际 digest、classification、TOCTOU 隔离和 exactly-once release 留给 #457 的下一段 Verified HostResource lease。该边界不改变测量结果与可比性口径。