### PR TITLE
feat(eval-workflows): 建立 Core 运行时组合根

### DIFF
--- a/docs/specs/evaluation-runtime-adapter.md
+++ b/docs/specs/evaluation-runtime-adapter.md
@@ -1,23 +1,24 @@
 # Evaluation Runtime Adapter
 
-> **Status**: binding-assembly foundation for [#457](https://github.com/lizhiyao/oh-my-knowledge/issues/457). It is additive and does not switch the production `omk eval` pipeline.
+> **Status**: binding assembly, verified resource leases, and the Core composition root for [#457](https://github.com/lizhiyao/oh-my-knowledge/issues/457). It is additive and does not switch the production `omk eval` pipeline.
 
 ## Boundary
 
 The OMK host consumes the complete output of `compileCliEvaluationInput()` and performs effects outside Evaluation Core. Binding assembly does not create a second plan, reinterpret CLI input, or trust a registry declaration as actual Runtime identity.
 
 ```text
-EvaluationDefinition + RuntimeBindingRequest
-                    │ exact coverage and immutable snapshot
+       compileCliEvaluationInput()
+                    │ complete immutable result
                     ▼
-        assembleOmkRuntimeBindings()
-                    │ implementation factory resolution
-                    ▼
-  immutable binding entries + Core Runtime ports
-                    │ actual identity and capabilities
+       createOmkEvaluationRuntime()
+                    │
+        ┌───────────┼────────────────┐
+        ▼           ▼                ▼
+ binding entries  support ports  run lease registry
+        └───────────┼────────────────┘
                     ▼
        createEvaluationEngine().prepare()
-                    │
+                    │ actual identity and capabilities
                     ▼
               SealedRunPlan
 ```
@@ -51,6 +52,7 @@ Every entry records:
 - the captured port;
 - explicit resource lease requirements;
 - a binding-local `sessionIsolationKey` derived from the complete binding and passed to its factory.
+- for Executor and Evaluator factories only, a binding-scoped resource access view that resolves the current Core `runId` and cannot enumerate another binding or analysis-only resources.
 
 Adapters combine `sessionIsolationKey` with Core's `runId` and `trialId`; it is not permission to pool state across runs or bindings.
 
@@ -71,11 +73,30 @@ File identity is SHA-256 over the consumed bytes. Tree identity uses `omk.tree-s
 
 Per-resource and whole-run byte／entry limits include writable overlays. Planned logical bytes are rejected before copying; entry limits are enforced while bounded resources are materialized. Errors carry stable codes and resource／binding identity but never include locator strings, secret bytes, or Gold content. Structurally valid inventory entries that no active binding requests are not opened, hashed, Git-probed, or copied; this preserves the no-Judge side-effect boundary.
 
+The composition root acquires the complete active-binding lease before Core can call any `openRun()`. It validates exact binding and resource coverage, captures immutable map and descriptor snapshots, and only then registers binding-scoped access. Registration is removed after all Core port teardown has settled, followed by one lease-disposal attempt. Acquisition, cancellation-before-start, EventWriter construction, Core start, Core completion, and failure paths share the same idempotent cleanup promise. Duplicate active `runId` values are rejected before a second acquisition. Gold declared for exploratory post-hoc comparison is not materialized by the single-run Core composition; the separate analysis-host workflow requests that lease when it has an actual consumer.
+
+## Core composition and support ports
+
+`createOmkEvaluationRuntime()` consumes one complete `CliEvaluationCompileResult`; callers cannot pass a replacement Definition or Policy to `prepare()` or `start()`. The composition root validates the compiled canonical digests, snapshots all host-owned configuration, merges Core-owned Analysis schema validators and Runtime factories, assembles bindings, and invokes the real `createEvaluationEngine(...).prepare(...)`. It exposes the independent Series assembly separately rather than placing Series ports in the single-run engine.
+
+Support ports are captured as bound immutable method views. Their presence is derived from the sealed Policy without changing it:
+
+- non-disabled execution or evaluation cache mode requires the corresponding cache port and the exact stage-specific source locator compiled under `orchestration.cacheSources`;
+- reference output or trace capture requires an Execution ContentStore;
+- reference evaluator evidence requires an Evaluation ContentStore;
+- an Evaluator that consumes reference-captured output or trace requires a ContentResolver;
+- required EventWriter mode requires a run-scoped writer factory.
+
+Clock and SchemaValidator contracts are checked before factory assembly. Core-owned Analysis validators are always present. A validator key must equal its complete schema identity; reusing one schema URI with another version, digest, or validator fails closed. Built-in Analysis, MissingPolicy, and Decision factories are merged by implementation ID, and a host factory cannot shadow a Core-owned implementation.
+
+EventWriter is deliberately not stored in the static `EvaluationEngineRuntime`. For optional or required delivery, it is created after resource acquisition and before Core start, then passed through `PreparedEvaluation.start()`. Disabled mode never invokes the factory. Missing or malformed Policy-required ports fail before any Runtime factory or run port is invoked. An absent Judge binding therefore causes no Judge factory construction, credential read, connectivity probe, or resource materialization.
+
 ## Failure ownership
 
 - malformed input, coverage, duplicate, Definition mismatch, missing factory, factory failure, and invalid port use stable `OmkRuntimeAssemblyError` codes before a Run starts;
+- compiled-input, support-port, cache-source, schema conflict, writer construction, active-run, and host cleanup failures use stable `OmkEvaluationRuntimeError` codes;
 - capability, schema, protocol support, identity assurance, and version satisfaction remain Core preparation errors;
-- credentials, connectivity, filesystem readiness, and resource materialization belong to later adapter preflight／lease layers;
+- credentials, connectivity, and physical readiness remain separate adapter preflight concerns; verified resource materialization is a run-scoped host failure before Core starts;
 - provider, session, attempt, cancellation, and dispose failures belong to Runtime ports after the Run starts.
 
 This layer does not modify frozen prompts, scoring stages, statistical formulas, cache semantics, Bundle／Report schemas, or the legacy pipeline.

--- a/docs/zh/specs/evaluation-runtime-adapter.md
+++ b/docs/zh/specs/evaluation-runtime-adapter.md
@@ -1,23 +1,24 @@
 # Evaluation Runtime Adapter 规范
 
-> **状态**：作为 [#457](https://github.com/lizhiyao/oh-my-knowledge/issues/457) 的 binding assembly 基础。本层是增量架构，不切换正式 `omk eval` pipeline。
+> **状态**：已建立 [#457](https://github.com/lizhiyao/oh-my-knowledge/issues/457) 的 binding assembly、verified resource lease 与 Core composition root。本层是增量架构，不切换正式 `omk eval` pipeline。
 
 ## 一、边界
 
 OMK 宿主完整消费 `compileCliEvaluationInput()` 的输出，并在 Evaluation Core 外执行 effect。Binding assembly 不创建第二套 plan、不重新解释 CLI 输入，也不把 registry 声明当成 Runtime 实际身份。
 
 ```text
-EvaluationDefinition + RuntimeBindingRequest
-                    │ exact coverage／immutable snapshot
+       compileCliEvaluationInput()
+                    │ 完整不可变产物
                     ▼
-        assembleOmkRuntimeBindings()
-                    │ implementation factory resolution
-                    ▼
-  immutable binding entries + Core Runtime ports
-                    │ actual identity／capabilities
+       createOmkEvaluationRuntime()
+                    │
+        ┌───────────┼────────────────┐
+        ▼           ▼                ▼
+ binding entries  support ports  run lease registry
+        └───────────┼────────────────┘
                     ▼
        createEvaluationEngine().prepare()
-                    │
+                    │ actual identity／capabilities
                     ▼
               SealedRunPlan
 ```
@@ -51,6 +52,7 @@ Factory 返回实际 port identity 和 version resolution。Assembly 校验 port
 - 捕获后的 port；
 - 显式 resource lease requirement；
 - 由完整 binding 派生并传给对应 factory 的 binding-local `sessionIsolationKey`。
+- 仅向 Executor／Evaluator factory 提供 binding-scoped resource access view；它按当前 Core `runId` 取 lease，不能枚举其它 binding 或 analysis-only resource。
 
 Adapter 必须把 `sessionIsolationKey` 与 Core `runId`、`trialId` 组合使用；它不允许跨 run 或 binding 复用有状态 session。
 
@@ -71,11 +73,30 @@ Lease acquisition 在首个 effect 之前同步复制并冻结全部 descriptor 
 
 单资源和整个 run 的字节／条目上限都包含可写 overlay。计划的逻辑字节数在复制前就会被拒绝；条目上限则在有界资源物化过程中执行。错误只携带稳定 code 与 resource／binding identity，不包含 locator、secret 字节或 Gold 内容。结构合法但没有被 active binding 请求的 inventory entry 不会被打开、哈希、Git probe 或复制，以保持 no-Judge 副作用边界。
 
-## 五、错误归属
+Composition root 在 Core 能调用任何 `openRun()` 前取得完整的 active-binding run lease。它验证 binding／resource 精确覆盖，捕获不可变 map 与 descriptor 快照，然后才注册 binding-scoped access。所有 Core port teardown settle 后先撤销注册，再执行一次 lease disposal。Acquisition、Core start 前取消、EventWriter 创建、Core start、正常完成与失败路径共享同一个幂等 cleanup promise。重复 active `runId` 会在第二次 acquisition 前被拒绝。用于 exploratory post-hoc comparison 的 Gold 不会被 single-run Core composition 提前物化；独立 analysis-host workflow 在存在真实消费者时再请求对应 lease。
+
+## 五、Core Composition 与 Support Ports
+
+`createOmkEvaluationRuntime()` 只消费一份完整的 `CliEvaluationCompileResult`；调用方不能在 `prepare()` 或 `start()` 传入替代 Definition／Policy。Composition root 会校验 compiled canonical digest、快照化全部宿主配置、合并 Core-owned Analysis schema validator 与 Runtime factory、装配 binding，并调用真实的 `createEvaluationEngine(...).prepare(...)`。独立 Series assembly 单独暴露，不进入 single-run engine。
+
+Support port 被捕获为绑定原实例方法的不可变 view。是否必需完全由 sealed Policy 推导，且不会改写 Policy：
+
+- execution／evaluation cache mode 非 disabled 时，必须提供对应 cache port，并精确绑定 `orchestration.cacheSources` 编译出的分阶段 source locator；
+- output／trace 使用 reference capture 时，必须提供 Execution ContentStore；
+- evaluator evidence 使用 reference capture 时，必须提供 Evaluation ContentStore；
+- Evaluator 消费 reference-captured output／trace 时，必须提供 ContentResolver；
+- required EventWriter mode 必须提供 run-scoped writer factory。
+
+Clock 与 SchemaValidator contract 在 factory assembly 前校验。Core-owned Analysis validator 恒定合入。Validator key 必须等于完整 schema identity；同一 schema URI 出现另一 version、digest 或 validator 时 fail closed。Built-in Analysis、MissingPolicy 与 Decision factory 按 implementation ID 合并，宿主 factory 不能覆盖 Core-owned implementation。
+
+EventWriter 不进入静态 `EvaluationEngineRuntime`。Optional／required delivery 会在 resource acquisition 后、Core start 前创建 writer，并通过 `PreparedEvaluation.start()` 注入；disabled mode 绝不调用 factory。Policy 要求的 port 缺失或形状错误时，在任何 Runtime factory 或 run port 调用前失败。因此不存在 Judge binding 时，也不会构造 Judge factory、读取凭证、执行 connectivity probe 或物化对应资源。
+
+## 六、错误归属
 
 - malformed input、coverage、duplicate、Definition mismatch、missing factory、factory failure 和 invalid port 在 Run 开始前使用稳定 `OmkRuntimeAssemblyError` code；
+- compiled input、support port、cache source、schema conflict、writer construction、active run 与 host cleanup failure 使用稳定 `OmkEvaluationRuntimeError` code；
 - capability、schema、protocol support、identity assurance 和 version satisfaction 仍由 Core preparation 报错；
-- credential、connectivity、filesystem readiness 和资源物化属于后续 adapter preflight／lease 层；
+- credential、connectivity 与 physical readiness 仍属于独立 adapter preflight；verified resource materialization 是 Core start 前的 run-scoped host failure；
 - provider、session、attempt、cancellation 和 dispose failure 在 Run 开始后属于 Runtime port。
 
 本层不修改冻结 prompt、五层评分、统计公式、cache 语义、Bundle／Report schema 或旧 pipeline。

--- a/src/eval-workflows/runtime-adapter/assembly.ts
+++ b/src/eval-workflows/runtime-adapter/assembly.ts
@@ -29,6 +29,10 @@ import {
   type OmkRuntimePortBinding,
   type RuntimeBindingOf,
 } from './types.js';
+import {
+  createOmkResourceLeaseAccessRegistry,
+  type OmkResourceLeaseAccessRegistry,
+} from './resource-leases/access.js';
 
 type EvaluationBindingKind = Exclude<
   RuntimeBinding['runtimeKind'],
@@ -500,13 +504,20 @@ function contextFor(
   binding: RuntimeBinding,
   expected: ExpectedBinding,
   isolationKey: string,
+  resourceLeaseAccess: OmkResourceLeaseAccessRegistry,
 ): unknown {
   switch (binding.runtimeKind) {
     case 'executor': return Object.freeze({
-      binding, target: expected.subject, sessionIsolationKey: isolationKey,
+      binding,
+      target: expected.subject,
+      sessionIsolationKey: isolationKey,
+      resourceLeases: resourceLeaseAccess.accessFor(binding),
     });
     case 'evaluator': return Object.freeze({
-      binding, evaluator: expected.subject, sessionIsolationKey: isolationKey,
+      binding,
+      evaluator: expected.subject,
+      sessionIsolationKey: isolationKey,
+      resourceLeases: resourceLeaseAccess.accessFor(binding),
     });
     case 'analysis-node': return Object.freeze({
       binding,
@@ -608,6 +619,7 @@ async function materializeEntry(
   binding: RuntimeBinding,
   expected: ExpectedBinding,
   factories: OmkRuntimeBindingFactories,
+  resourceLeaseAccess: OmkResourceLeaseAccessRegistry,
 ): Promise<OmkEvaluationRuntimeBindingEntry | OmkEvaluationSeriesRuntimeBindingEntry> {
   const factory = factoryFor(factories, binding);
   if (factory === undefined) fail({
@@ -620,7 +632,7 @@ async function materializeEntry(
   const isolationKey = sessionIsolationKey(binding);
   try {
     result = await factory(
-      contextFor(binding, expected, isolationKey) as never,
+      contextFor(binding, expected, isolationKey, resourceLeaseAccess) as never,
     ) as OmkRuntimePortBinding<unknown>;
   } catch (cause) {
     fail({
@@ -843,6 +855,11 @@ export async function assembleOmkRuntimeBindings(
     compareStrings(left.bindingId, right.bindingId)
   ));
   assertFactoriesAvailable(ordered, snapshotInput.factories);
+  const resourceLeaseAccess = createOmkResourceLeaseAccessRegistry(
+    ordered.filter((binding): binding is Extract<RuntimeBinding, {
+      runtimeKind: 'executor' | 'evaluator';
+    }> => binding.runtimeKind === 'executor' || binding.runtimeKind === 'evaluator'),
+  );
   const entries: Array<
     OmkEvaluationRuntimeBindingEntry | OmkEvaluationSeriesRuntimeBindingEntry
   > = [];
@@ -851,6 +868,7 @@ export async function assembleOmkRuntimeBindings(
       binding,
       expected.get(keyForBinding(binding)) as ExpectedBinding,
       snapshotInput.factories,
+      resourceLeaseAccess,
     ));
   }
   const evaluationEntries = entries.filter((entry): entry is OmkEvaluationRuntimeBindingEntry => (
@@ -865,6 +883,7 @@ export async function assembleOmkRuntimeBindings(
     evaluation: Object.freeze({
       entries: Object.freeze(evaluationEntries),
       bindings: evaluationResolvers(evaluationEntries),
+      resourceLeaseRegistry: resourceLeaseAccess.lifecycle,
     }),
     ...(snapshotInput.seriesDefinition === undefined ? {} : { series: seriesAssembly(seriesEntries) }),
   });

--- a/src/eval-workflows/runtime-adapter/composition.ts
+++ b/src/eval-workflows/runtime-adapter/composition.ts
@@ -1,0 +1,932 @@
+import {
+  EvaluationDefinitionSchema,
+  IdentifierSchema,
+  MeasurementPolicySchema,
+  SchemaIdentitySchema,
+  canonicalizeJson,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  schemaIdentityKey,
+  type CoreSchemaValidator,
+  type JsonValue,
+} from '../../evaluation-core/contracts/index.js';
+import { createBuiltinAnalysisSchemaValidators } from '../../evaluation-core/analysis/index.js';
+import type { SealedRunPlan } from '../../evaluation-core/compiler/index.js';
+import {
+  createEvaluationEngine,
+  type EvaluationEngineClock,
+  type EvaluationEngineEventWriter,
+  type EvaluationRun,
+  type PreparedEvaluation,
+} from '../../evaluation-core/engine/index.js';
+import type {
+  EvaluationCache,
+  EvaluationContentResolver,
+  EvaluationContentStore,
+} from '../../evaluation-core/evaluation/index.js';
+import type {
+  ExecutionCache,
+  ExecutionContentStore,
+} from '../../evaluation-core/execution/index.js';
+import type {
+  CliEvaluationCompileResult,
+  ResolvedHostResources,
+} from '../input-compilation/index.js';
+import { assembleOmkRuntimeBindings } from './assembly.js';
+import { createBuiltinOmkAnalysisBindingFactories } from './builtins.js';
+import {
+  OmkResourceLeaseError,
+  materializeNodeRunResourceLeases,
+  resourceLeaseRequestsFromBindingEntries,
+  type MaterializeNodeRunResourceLeasesInput,
+  type OmkAnalysisOnlyResourceLeaseRequest,
+  type OmkBindingResourceLease,
+  type OmkLeasedHostResource,
+  type OmkPinnedGitVerifier,
+  type OmkResourceLeaseLimits,
+  type OmkRunResourceLeases,
+} from './resource-leases/index.js';
+import type {
+  OmkEvaluationSeriesRuntimeBindingAssembly,
+  OmkRuntimeBindingFactories,
+} from './types.js';
+
+export interface OmkCachePortBinding<Port> {
+  readonly sourceLocator: string;
+  readonly port: Port;
+}
+
+export interface OmkEvaluationEventWriterContext {
+  readonly runId: string;
+  readonly plan: SealedRunPlan;
+}
+
+export type OmkEvaluationEventWriterFactory = (
+  context: Readonly<OmkEvaluationEventWriterContext>,
+) => EvaluationEngineEventWriter | Promise<EvaluationEngineEventWriter>;
+
+export interface OmkEvaluationRuntimeSupportPorts {
+  readonly clock: EvaluationEngineClock;
+  /** Host validators only; Core-owned built-ins are merged by the composition root. */
+  readonly schemaValidators?: ReadonlyMap<string, CoreSchemaValidator>;
+  readonly executionCache?: OmkCachePortBinding<ExecutionCache>;
+  readonly evaluationCache?: OmkCachePortBinding<EvaluationCache>;
+  readonly executionContentStore?: ExecutionContentStore;
+  readonly evaluationContentStore?: EvaluationContentStore;
+  readonly contentResolver?: EvaluationContentResolver;
+  readonly createEventWriter?: OmkEvaluationEventWriterFactory;
+}
+
+export type OmkRunResourceLeaseMaterializer = (
+  input: Readonly<MaterializeNodeRunResourceLeasesInput>,
+) => Promise<OmkRunResourceLeases>;
+
+export interface OmkEvaluationRuntimeResourceOptions {
+  readonly leaseRoot: string;
+  readonly limits?: Partial<OmkResourceLeaseLimits>;
+  readonly pinnedGitVerifier?: OmkPinnedGitVerifier;
+  /** Platform host boundary; Node snapshot／overlay materialization is the default. */
+  readonly materialize?: OmkRunResourceLeaseMaterializer;
+}
+
+export interface CreateOmkEvaluationRuntimeInput {
+  readonly compiled: CliEvaluationCompileResult;
+  readonly factories: OmkRuntimeBindingFactories;
+  readonly support: OmkEvaluationRuntimeSupportPorts;
+  readonly resources: OmkEvaluationRuntimeResourceOptions;
+}
+
+export interface OmkEvaluationRunOptions {
+  readonly runId: string;
+  readonly signal?: AbortSignal;
+  readonly eventBufferCapacity?: number;
+}
+
+export interface OmkPreparedEvaluation {
+  readonly plan: SealedRunPlan;
+  start(options: Readonly<OmkEvaluationRunOptions>): Promise<EvaluationRun>;
+}
+
+export interface OmkEvaluationRuntime {
+  prepare(): Promise<OmkPreparedEvaluation>;
+  readonly series?: OmkEvaluationSeriesRuntimeBindingAssembly;
+}
+
+interface CapturedResourceOptions {
+  readonly leaseRoot: string;
+  readonly limits?: Readonly<Partial<OmkResourceLeaseLimits>>;
+  readonly pinnedGitVerifier?: OmkPinnedGitVerifier;
+  readonly materialize: OmkRunResourceLeaseMaterializer;
+}
+
+export type OmkEvaluationRuntimeErrorCode =
+  | 'OMK_EVALUATION_RUNTIME_INPUT_INVALID'
+  | 'OMK_EVALUATION_RUNTIME_FACTORY_CONFLICT'
+  | 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_REQUIRED'
+  | 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_INVALID'
+  | 'OMK_EVALUATION_RUNTIME_CACHE_SOURCE_MISMATCH'
+  | 'OMK_EVALUATION_RUNTIME_SCHEMA_VALIDATOR_CONFLICT'
+  | 'OMK_EVALUATION_RUNTIME_RUN_ACTIVE'
+  | 'OMK_EVALUATION_RUNTIME_RUN_ABORTED_BEFORE_START'
+  | 'OMK_EVALUATION_RUNTIME_RESOURCE_LEASE_FAILED'
+  | 'OMK_EVALUATION_RUNTIME_RESOURCE_LEASE_INVALID'
+  | 'OMK_EVALUATION_RUNTIME_EVENT_WRITER_FAILED'
+  | 'OMK_EVALUATION_RUNTIME_START_FAILED'
+  | 'OMK_EVALUATION_RUNTIME_CLEANUP_FAILED';
+
+export class OmkEvaluationRuntimeError extends Error {
+  readonly code: OmkEvaluationRuntimeErrorCode;
+  readonly fieldPath?: string;
+  readonly runId?: string;
+
+  constructor(input: {
+    code: OmkEvaluationRuntimeErrorCode;
+    message: string;
+    fieldPath?: string;
+    runId?: string;
+    cause?: unknown;
+  }) {
+    super(input.message, { cause: input.cause });
+    this.name = 'OmkEvaluationRuntimeError';
+    this.code = input.code;
+    this.fieldPath = input.fieldPath;
+    this.runId = input.runId;
+  }
+}
+
+function fail(input: ConstructorParameters<typeof OmkEvaluationRuntimeError>[0]): never {
+  throw new OmkEvaluationRuntimeError(input);
+}
+
+function record(value: unknown): Readonly<Record<string, unknown>> | undefined {
+  return value !== null && !Array.isArray(value) && typeof value === 'object'
+    ? value as Readonly<Record<string, unknown>>
+    : undefined;
+}
+
+function boundMethod(
+  port: Readonly<Record<string, unknown>>,
+  methodName: string,
+): (...args: never[]) => unknown {
+  const method = port[methodName] as (...args: never[]) => unknown;
+  return (...args: never[]) => Reflect.apply(method, port, args);
+}
+
+function capturePort<Port>(
+  candidate: Port,
+  methods: readonly string[],
+  fieldPath: string,
+): Port {
+  const port = record(candidate);
+  if (port === undefined || methods.some((method) => typeof port[method] !== 'function')) fail({
+    code: 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_INVALID',
+    fieldPath,
+    message: `${fieldPath} 不符合 Core support port contract。`,
+  });
+  return Object.freeze(Object.fromEntries(methods.map((method) => [
+    method,
+    boundMethod(port, method),
+  ]))) as Port;
+}
+
+function readonlyMapSnapshot<Key, Value>(source: ReadonlyMap<Key, Value>): ReadonlyMap<Key, Value> {
+  const snapshot = new Map(source);
+  const view: ReadonlyMap<Key, Value> = Object.freeze({
+    get size() { return snapshot.size; },
+    get(key: Key) { return snapshot.get(key); },
+    has(key: Key) { return snapshot.has(key); },
+    keys() { return snapshot.keys(); },
+    values() { return snapshot.values(); },
+    entries() { return snapshot.entries(); },
+    [Symbol.iterator]() { return snapshot[Symbol.iterator](); },
+    forEach(
+      callback: (value: Value, key: Key, map: ReadonlyMap<Key, Value>) => void,
+      thisArg?: unknown,
+    ) {
+      snapshot.forEach((value, key) => callback.call(thisArg, value, key, view));
+    },
+  });
+  return view;
+}
+
+function snapshotCompiled(input: CliEvaluationCompileResult): CliEvaluationCompileResult {
+  let snapshot: CliEvaluationCompileResult;
+  try {
+    snapshot = deepFreezeCanonicalJson(
+      structuredClone(input) as unknown as JsonValue,
+    ) as unknown as CliEvaluationCompileResult;
+  } catch (cause) {
+    return fail({
+      code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+      message: 'Compiled evaluation input 无法建立规范化不可变快照。',
+      cause,
+    });
+  }
+  const definition = EvaluationDefinitionSchema.safeParse(snapshot.definition);
+  const policy = MeasurementPolicySchema.safeParse(snapshot.policy);
+  if (!definition.success || !policy.success
+      || digestCanonicalJson(snapshot.definition) !== snapshot.canonicalDigests.definition
+      || digestCanonicalJson(snapshot.policy) !== snapshot.canonicalDigests.policy) fail({
+    code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+    message: 'Compiled evaluation input 的 Core schema 或 canonical digest 不一致。',
+  });
+  return snapshot;
+}
+
+function captureResourceOptions(
+  input: OmkEvaluationRuntimeResourceOptions,
+): CapturedResourceOptions {
+  if (record(input) === undefined || typeof input.leaseRoot !== 'string'
+      || input.leaseRoot === ''
+      || (input.materialize !== undefined && typeof input.materialize !== 'function')) fail({
+    code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+    fieldPath: 'resources',
+    message: 'Resource lease options 不合法。',
+  });
+  let limits: Readonly<Partial<OmkResourceLeaseLimits>> | undefined;
+  try {
+    limits = input.limits === undefined
+      ? undefined
+      : Object.freeze(structuredClone(input.limits));
+  } catch (cause) {
+    return fail({
+      code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+      fieldPath: 'resources.limits',
+      message: 'Resource lease limits 无法建立不可变快照。',
+      cause,
+    });
+  }
+  if (limits !== undefined && Object.values(limits).some((value) => (
+    value !== undefined && (!Number.isSafeInteger(value) || value <= 0)
+  ))) fail({
+    code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+    fieldPath: 'resources.limits',
+    message: 'Resource lease limits 必须是正安全整数。',
+  });
+  let pinnedGitVerifier: OmkPinnedGitVerifier | undefined;
+  if (input.pinnedGitVerifier !== undefined) {
+    const verifier = record(input.pinnedGitVerifier);
+    if (typeof verifier?.verifyPinnedCommit !== 'function') fail({
+      code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+      fieldPath: 'resources.pinnedGitVerifier',
+      message: 'Pinned Git verifier 不符合 port contract。',
+    });
+    pinnedGitVerifier = Object.freeze({
+      verifyPinnedCommit: boundMethod(
+        verifier,
+        'verifyPinnedCommit',
+      ) as OmkPinnedGitVerifier['verifyPinnedCommit'],
+    });
+  }
+  const owner = input as unknown as Readonly<Record<string, unknown>>;
+  const materialize = input.materialize === undefined
+    ? materializeNodeRunResourceLeases
+    : boundMethod(owner, 'materialize') as OmkRunResourceLeaseMaterializer;
+  return Object.freeze({
+    leaseRoot: input.leaseRoot,
+    ...(limits === undefined ? {} : { limits }),
+    ...(pinnedGitVerifier === undefined ? {} : { pinnedGitVerifier }),
+    materialize,
+  });
+}
+
+function captureClock(clock: EvaluationEngineClock): EvaluationEngineClock {
+  return capturePort(clock, ['monotonicNow', 'timestamp', 'sleep'], 'support.clock');
+}
+
+function captureSchemaValidators(
+  hostValidators: ReadonlyMap<string, CoreSchemaValidator> | undefined,
+): ReadonlyMap<string, CoreSchemaValidator> {
+  let hostEntries: Array<[string, CoreSchemaValidator]>;
+  try {
+    hostEntries = [...(hostValidators ?? new Map())];
+  } catch (cause) {
+    return fail({
+      code: 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_INVALID',
+      fieldPath: 'support.schemaValidators',
+      message: 'Host SchemaValidator registry 不是可迭代 map。',
+      cause,
+    });
+  }
+  const candidates: Array<readonly [string, CoreSchemaValidator, 'builtin' | 'host']> = [
+    ...[...createBuiltinAnalysisSchemaValidators()].map((entry) => (
+      [entry[0], entry[1], 'builtin'] as const
+    )),
+    ...hostEntries.map((entry) => (
+      [entry[0], entry[1], 'host'] as const
+    )),
+  ];
+  const validators = new Map<string, CoreSchemaValidator>();
+  const byUri = new Map<string, { identity: string; validator: CoreSchemaValidator }>();
+  for (const [key, validator, source] of candidates) {
+    const candidate = record(validator);
+    const parsed = SchemaIdentitySchema.safeParse(candidate?.schema);
+    if (!parsed.success) fail({
+      code: 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_INVALID',
+      fieldPath: 'support.schemaValidators',
+      message: `${source} SchemaValidator 的 schema identity 不合法。`,
+    });
+    if (typeof candidate?.parse !== 'function' || key !== schemaIdentityKey(parsed.data)) fail({
+      code: 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_INVALID',
+      fieldPath: 'support.schemaValidators',
+      message: `${source} SchemaValidator 的 key 或 parse contract 不合法。`,
+    });
+    const identity = canonicalizeJson(parsed.data);
+    const existingByUri = byUri.get(parsed.data.schemaUri);
+    const existingByKey = validators.get(key);
+    if ((existingByUri !== undefined
+          && (existingByUri.identity !== identity || existingByUri.validator !== validator))
+        || (existingByKey !== undefined && existingByKey !== validator)) fail({
+      code: 'OMK_EVALUATION_RUNTIME_SCHEMA_VALIDATOR_CONFLICT',
+      fieldPath: 'support.schemaValidators',
+      message: `Schema URI "${parsed.data.schemaUri}" 存在 identity 或 validator 冲突。`,
+    });
+    if (existingByKey !== undefined) continue;
+    const captured: CoreSchemaValidator = Object.freeze({
+      schema: deepFreezeCanonicalJson(parsed.data),
+      parse: boundMethod(candidate, 'parse') as CoreSchemaValidator['parse'],
+    });
+    validators.set(key, captured);
+    byUri.set(parsed.data.schemaUri, { identity, validator });
+  }
+  return readonlyMapSnapshot(validators);
+}
+
+function captureCachePort<Port>(input: {
+  binding: OmkCachePortBinding<Port> | undefined;
+  expectedSource: string | undefined;
+  enabled: boolean;
+  fieldPath: string;
+}): Port | undefined {
+  if (!input.enabled) {
+    if (input.binding !== undefined) fail({
+      code: 'OMK_EVALUATION_RUNTIME_CACHE_SOURCE_MISMATCH',
+      fieldPath: input.fieldPath,
+      message: `${input.fieldPath} 在 sealed cache policy 为 disabled 时不得注入。`,
+    });
+    return undefined;
+  }
+  if (input.binding === undefined) fail({
+    code: 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_REQUIRED',
+    fieldPath: input.fieldPath,
+    message: `${input.fieldPath} 是 sealed cache policy 的必需 port。`,
+  });
+  const binding = record(input.binding);
+  if (binding === undefined || input.expectedSource === undefined
+      || binding.sourceLocator !== input.expectedSource) fail({
+    code: 'OMK_EVALUATION_RUNTIME_CACHE_SOURCE_MISMATCH',
+    fieldPath: `${input.fieldPath}.sourceLocator`,
+    message: `${input.fieldPath} 未绑定 compiled orchestration 声明的 cache source。`,
+  });
+  return capturePort(binding.port as Port, ['get', 'put'], `${input.fieldPath}.port`);
+}
+
+function requiredPort<Port>(input: {
+  candidate: Port | undefined;
+  required: boolean;
+  fieldPath: string;
+  methods: readonly string[];
+}): Port | undefined {
+  if (input.candidate === undefined) {
+    if (input.required) fail({
+      code: 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_REQUIRED',
+      fieldPath: input.fieldPath,
+      message: `${input.fieldPath} 是 sealed MeasurementPolicy 的必需 port。`,
+    });
+    return undefined;
+  }
+  return capturePort(input.candidate, input.methods, input.fieldPath);
+}
+
+function mergeFactoryMap<Factory>(
+  builtin: ReadonlyMap<string, Factory>,
+  host: ReadonlyMap<string, Factory>,
+  fieldPath: string,
+): ReadonlyMap<string, Factory> {
+  const merged = new Map(builtin);
+  for (const [implementationId, factory] of host) {
+    if (merged.has(implementationId)) fail({
+      code: 'OMK_EVALUATION_RUNTIME_FACTORY_CONFLICT',
+      fieldPath,
+      message: `implementationId "${implementationId}" 与 Core-owned built-in factory 冲突。`,
+    });
+    merged.set(implementationId, factory);
+  }
+  return readonlyMapSnapshot(merged);
+}
+
+function captureFactoryMap<Factory>(
+  source: ReadonlyMap<string, Factory>,
+  fieldPath: string,
+): ReadonlyMap<string, Factory> {
+  let entries: Array<[string, Factory]>;
+  try {
+    entries = [...source];
+  } catch (cause) {
+    return fail({
+      code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+      fieldPath,
+      message: `${fieldPath} 不是可迭代的 factory map。`,
+      cause,
+    });
+  }
+  if (entries.some(([implementationId, factory]) => (
+    implementationId === '' || typeof factory !== 'function'
+  ))) fail({
+    code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+    fieldPath,
+    message: `${fieldPath} 包含不合法 implementationId 或 factory。`,
+  });
+  return readonlyMapSnapshot(new Map(entries));
+}
+
+function withBuiltinFactories(
+  host: OmkRuntimeBindingFactories,
+): OmkRuntimeBindingFactories {
+  if (record(host) === undefined) fail({
+    code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+    fieldPath: 'factories',
+    message: 'Runtime binding factories 不合法。',
+  });
+  const captured = {
+    executorsByImplementationId: captureFactoryMap(
+      host.executorsByImplementationId,
+      'factories.executorsByImplementationId',
+    ),
+    evaluatorsByImplementationId: captureFactoryMap(
+      host.evaluatorsByImplementationId,
+      'factories.evaluatorsByImplementationId',
+    ),
+    analysisNodesByImplementationId: captureFactoryMap(
+      host.analysisNodesByImplementationId,
+      'factories.analysisNodesByImplementationId',
+    ),
+    missingPoliciesByImplementationId: captureFactoryMap(
+      host.missingPoliciesByImplementationId,
+      'factories.missingPoliciesByImplementationId',
+    ),
+    decisionPoliciesByImplementationId: captureFactoryMap(
+      host.decisionPoliciesByImplementationId,
+      'factories.decisionPoliciesByImplementationId',
+    ),
+    seriesAnalysisNodesByImplementationId: captureFactoryMap(
+      host.seriesAnalysisNodesByImplementationId,
+      'factories.seriesAnalysisNodesByImplementationId',
+    ),
+    seriesDecisionPoliciesByImplementationId: captureFactoryMap(
+      host.seriesDecisionPoliciesByImplementationId,
+      'factories.seriesDecisionPoliciesByImplementationId',
+    ),
+  };
+  const builtin = createBuiltinOmkAnalysisBindingFactories();
+  return Object.freeze({
+    ...captured,
+    analysisNodesByImplementationId: mergeFactoryMap(
+      builtin.analysisNodesByImplementationId,
+      captured.analysisNodesByImplementationId,
+      'factories.analysisNodesByImplementationId',
+    ),
+    missingPoliciesByImplementationId: mergeFactoryMap(
+      builtin.missingPoliciesByImplementationId,
+      captured.missingPoliciesByImplementationId,
+      'factories.missingPoliciesByImplementationId',
+    ),
+    decisionPoliciesByImplementationId: mergeFactoryMap(
+      builtin.decisionPoliciesByImplementationId,
+      captured.decisionPoliciesByImplementationId,
+      'factories.decisionPoliciesByImplementationId',
+    ),
+  });
+}
+
+function evaluatorNeedsReferenceResolver(compiled: CliEvaluationCompileResult): boolean {
+  const outputReference = compiled.policy.evidence.output === 'reference';
+  const traceReference = compiled.policy.evidence.trace === 'reference';
+  return compiled.definition.evaluators.some((evaluator) => evaluator.inputs.some((input) => (
+    (input.sourceKind === 'output' && outputReference)
+    || (input.sourceKind === 'trace' && traceReference)
+  )));
+}
+
+function captureMaterializedLeases(
+  leases: OmkRunResourceLeases,
+  runId: string,
+  expectedAnalysisOnly: readonly OmkAnalysisOnlyResourceLeaseRequest[],
+  hostResources: ResolvedHostResources,
+): OmkRunResourceLeases {
+  const bindings = record(leases?.bindingsByBindingId);
+  const analysisOnly = record(leases?.analysisOnlyResourcesByResourceId);
+  if (record(leases) === undefined || leases.runId !== runId
+      || typeof bindings?.get !== 'function' || typeof bindings?.keys !== 'function'
+      || typeof analysisOnly?.get !== 'function' || typeof analysisOnly?.keys !== 'function'
+      || typeof leases.dispose !== 'function') fail({
+    code: 'OMK_EVALUATION_RUNTIME_RESOURCE_LEASE_INVALID',
+    runId,
+    message: 'Resource lease materializer 返回了不合法或 run identity 不一致的 lease。',
+  });
+  let bindingEntries: Array<[string, OmkBindingResourceLease]>;
+  let analysisEntries: Array<[string, OmkLeasedHostResource]>;
+  try {
+    bindingEntries = [...leases.bindingsByBindingId];
+    analysisEntries = [...leases.analysisOnlyResourcesByResourceId];
+  } catch (cause) {
+    return fail({
+      code: 'OMK_EVALUATION_RUNTIME_RESOURCE_LEASE_INVALID',
+      runId,
+      message: 'Resource lease maps 无法建立不可变快照。',
+      cause,
+    });
+  }
+  const expectedAnalysisIds = expectedAnalysisOnly
+    .map((request) => request.resourceId).sort();
+  const actualAnalysisIds = analysisEntries.map(([resourceId]) => resourceId).sort();
+  if (actualAnalysisIds.length !== expectedAnalysisIds.length
+      || actualAnalysisIds.some((resourceId, index) => (
+        resourceId !== expectedAnalysisIds[index]
+      ))) fail({
+    code: 'OMK_EVALUATION_RUNTIME_RESOURCE_LEASE_INVALID',
+    runId,
+    message: 'Analysis-only resource lease 未精确覆盖 compiled orchestration。',
+  });
+  const snapshotResource = (resource: OmkLeasedHostResource): OmkLeasedHostResource => {
+    try {
+      return deepFreezeCanonicalJson(
+        structuredClone(resource) as unknown as JsonValue,
+      ) as unknown as OmkLeasedHostResource;
+    } catch (cause) {
+      return fail({
+        code: 'OMK_EVALUATION_RUNTIME_RESOURCE_LEASE_INVALID',
+        runId,
+        message: 'Leased resource 无法建立规范化不可变快照。',
+        cause,
+      });
+    }
+  };
+  const inventory = new Map(hostResources.resources.map((resource) => [
+    resource.descriptor.resourceId,
+    resource,
+  ]));
+  const assertInventoryIdentity = (resource: OmkLeasedHostResource): void => {
+    try {
+      const expected = inventory.get(resource.resourceId);
+      const snapshotPaths = resource.leaseMode === 'immutable-snapshot'
+        ? [resource.snapshotPath]
+        : [resource.baseSnapshotPath, resource.overlayPath];
+      if (expected !== undefined && resource.resourceKind === expected.resourceKind
+          && canonicalizeJson(resource.descriptor) === canonicalizeJson(expected.descriptor)
+          && !snapshotPaths.includes(expected.locator)) return;
+    } catch {
+      // Normalize malformed custom materializer output to the stable host boundary below.
+    }
+    fail({
+      code: 'OMK_EVALUATION_RUNTIME_RESOURCE_LEASE_INVALID',
+      runId,
+      message: 'Leased resource 与 compiled HostResource identity 不一致或仍指向原 locator。',
+    });
+  };
+  const capturedBindings = new Map<string, OmkBindingResourceLease>();
+  for (const [bindingId, lease] of bindingEntries) {
+    let resourceEntries: Array<[string, OmkLeasedHostResource]>;
+    try {
+      resourceEntries = [...lease.resourcesByResourceId];
+    } catch (cause) {
+      return fail({
+        code: 'OMK_EVALUATION_RUNTIME_RESOURCE_LEASE_INVALID',
+        runId,
+        message: `Binding "${bindingId}" 的 resource map 无法建立快照。`,
+        cause,
+      });
+    }
+    const capturedResources = resourceEntries.map(([resourceId, resource]) => {
+      const captured = snapshotResource(resource);
+      assertInventoryIdentity(captured);
+      return [resourceId, captured] as const;
+    });
+    capturedBindings.set(bindingId, Object.freeze({
+      bindingId: lease.bindingId,
+      consumerKind: lease.consumerKind,
+      resourcesByResourceId: readonlyMapSnapshot(new Map(capturedResources)),
+    }));
+  }
+  const capturedAnalysis = new Map<string, OmkLeasedHostResource>();
+  for (const [resourceId, resource] of analysisEntries) {
+    const captured = snapshotResource(resource);
+    assertInventoryIdentity(captured);
+    if (captured.resourceId !== resourceId || captured.resourceKind !== 'gold-dataset'
+        || captured.descriptor.classification !== 'gold'
+        || captured.leaseMode !== 'immutable-snapshot') fail({
+      code: 'OMK_EVALUATION_RUNTIME_RESOURCE_LEASE_INVALID',
+      runId,
+      message: 'Analysis-only resource lease 的 identity、kind、classification 或 mode 不合法。',
+    });
+    capturedAnalysis.set(resourceId, captured);
+  }
+  const owner = leases as unknown as Readonly<Record<string, unknown>>;
+  return Object.freeze({
+    runId,
+    bindingsByBindingId: readonlyMapSnapshot(capturedBindings),
+    analysisOnlyResourcesByResourceId: readonlyMapSnapshot(capturedAnalysis),
+    dispose: boundMethod(owner, 'dispose') as OmkRunResourceLeases['dispose'],
+  });
+}
+
+function abortedBeforeStart(runId: string): never {
+  fail({
+    code: 'OMK_EVALUATION_RUNTIME_RUN_ABORTED_BEFORE_START',
+    runId,
+    message: `runId "${runId}" 在 Core start 前已取消。`,
+  });
+}
+
+function signalIsAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
+async function eventWriterForRun(input: {
+  factory: OmkEvaluationEventWriterFactory | undefined;
+  writerMode: CliEvaluationCompileResult['policy']['eventDelivery']['writerMode'];
+  runId: string;
+  plan: SealedRunPlan;
+}): Promise<EvaluationEngineEventWriter | undefined> {
+  if (input.writerMode === 'disabled' || input.factory === undefined) return undefined;
+  try {
+    return capturePort(
+      await input.factory(Object.freeze({ runId: input.runId, plan: input.plan })),
+      ['write'],
+      'support.createEventWriter result',
+    );
+  } catch (cause) {
+    if (cause instanceof OmkEvaluationRuntimeError) throw cause;
+    return fail({
+      code: 'OMK_EVALUATION_RUNTIME_EVENT_WRITER_FAILED',
+      runId: input.runId,
+      message: 'Run-scoped EventWriter 创建失败。',
+    });
+  }
+}
+
+function staticRunMetadata(compiled: CliEvaluationCompileResult) {
+  const metadata = compiled.runOptions.metadata;
+  return {
+    ...(metadata?.annotations === undefined ? {} : { annotations: metadata.annotations }),
+    ...(metadata?.summaries === undefined ? {} : { summaries: metadata.summaries }),
+  };
+}
+
+/** Assembles the immutable OMK host boundary without interpreting CLI flags. */
+export async function createOmkEvaluationRuntime(
+  input: Readonly<CreateOmkEvaluationRuntimeInput>,
+): Promise<OmkEvaluationRuntime> {
+  if (record(input) === undefined || record(input.support) === undefined) fail({
+    code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+    message: 'Evaluation Runtime composition input 或 support ports 不合法。',
+  });
+  const compiled = snapshotCompiled(input.compiled);
+  const resources = captureResourceOptions(input.resources);
+  const clock = captureClock(input.support.clock);
+  const schemaValidators = captureSchemaValidators(input.support.schemaValidators);
+  const executionCache = captureCachePort({
+    binding: input.support.executionCache,
+    expectedSource: compiled.orchestration.cacheSources?.executionSourceLocator,
+    enabled: compiled.policy.cache.executionMode !== 'disabled',
+    fieldPath: 'support.executionCache',
+  });
+  const evaluationCache = captureCachePort({
+    binding: input.support.evaluationCache,
+    expectedSource: compiled.orchestration.cacheSources?.evaluationSourceLocator,
+    enabled: compiled.policy.cache.evaluationMode !== 'disabled',
+    fieldPath: 'support.evaluationCache',
+  });
+  const executionContentStore = requiredPort({
+    candidate: input.support.executionContentStore,
+    required: compiled.policy.evidence.output === 'reference'
+      || compiled.policy.evidence.trace === 'reference',
+    fieldPath: 'support.executionContentStore',
+    methods: ['put'],
+  });
+  const evaluationContentStore = requiredPort({
+    candidate: input.support.evaluationContentStore,
+    required: compiled.policy.evidence.evidence === 'reference',
+    fieldPath: 'support.evaluationContentStore',
+    methods: ['put'],
+  });
+  const contentResolver = requiredPort({
+    candidate: input.support.contentResolver,
+    required: evaluatorNeedsReferenceResolver(compiled),
+    fieldPath: 'support.contentResolver',
+    methods: ['resolve'],
+  });
+  const createEventWriter = input.support.createEventWriter;
+  if (compiled.policy.eventDelivery.writerMode === 'required'
+      && typeof createEventWriter !== 'function') fail({
+    code: 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_REQUIRED',
+    fieldPath: 'support.createEventWriter',
+    message: 'Required EventWriter mode 必须装配 run-scoped EventWriter factory。',
+  });
+  if (createEventWriter !== undefined && typeof createEventWriter !== 'function') fail({
+    code: 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_INVALID',
+    fieldPath: 'support.createEventWriter',
+    message: 'Run-scoped EventWriter factory 不合法。',
+  });
+  const eventWriterFactory = createEventWriter === undefined
+    ? undefined
+    : createEventWriter.bind(input.support);
+
+  const factories = withBuiltinFactories(input.factories);
+  const assembly = await assembleOmkRuntimeBindings({
+    definition: compiled.definition,
+    runtimeBinding: compiled.runtimeBinding,
+    factories,
+    ...(compiled.orchestration.independentSeries === undefined ? {} : {
+      seriesDefinition: compiled.orchestration.independentSeries.definition,
+    }),
+  });
+  const engine = createEvaluationEngine({
+    bindings: assembly.evaluation.bindings,
+    clock,
+    schemaValidators,
+    ...(executionCache === undefined ? {} : { executionCache }),
+    ...(evaluationCache === undefined ? {} : { evaluationCache }),
+    ...(executionContentStore === undefined ? {} : { executionContentStore }),
+    ...(evaluationContentStore === undefined ? {} : { evaluationContentStore }),
+    ...(contentResolver === undefined ? {} : { contentResolver }),
+  });
+  const bindingLeaseRequests = resourceLeaseRequestsFromBindingEntries(
+    assembly.evaluation.entries,
+  );
+  // Gold is consumed by the separate exploratory post-hoc workflow, never by a Core run.
+  const analysisOnly: readonly OmkAnalysisOnlyResourceLeaseRequest[] = Object.freeze([]);
+  const activeRunIds = new Set<string>();
+
+  return Object.freeze({
+    ...(assembly.series === undefined ? {} : { series: assembly.series }),
+    async prepare(): Promise<OmkPreparedEvaluation> {
+      const corePrepared: PreparedEvaluation = await engine.prepare(
+        compiled.definition,
+        compiled.policy,
+      );
+      return Object.freeze({
+        plan: corePrepared.plan,
+        async start(options: Readonly<OmkEvaluationRunOptions>): Promise<EvaluationRun> {
+          if (record(options) === undefined || !IdentifierSchema.safeParse(options.runId).success) fail({
+            code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+            fieldPath: 'runId',
+            message: 'runId 不符合 Core identifier contract。',
+          });
+          if (options.eventBufferCapacity !== undefined
+              && (!Number.isSafeInteger(options.eventBufferCapacity)
+                || options.eventBufferCapacity <= 0)) fail({
+            code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+            fieldPath: 'eventBufferCapacity',
+            message: 'eventBufferCapacity 必须是正安全整数。',
+          });
+          if (options.signal !== undefined
+              && (typeof options.signal.aborted !== 'boolean'
+                || typeof options.signal.addEventListener !== 'function')) fail({
+            code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+            fieldPath: 'signal',
+            message: 'signal 不符合 AbortSignal contract。',
+          });
+          const runId = options.runId;
+          if (activeRunIds.has(runId)) fail({
+            code: 'OMK_EVALUATION_RUNTIME_RUN_ACTIVE',
+            runId,
+            message: `runId "${runId}" 已有 active OMK evaluation run。`,
+          });
+          if (signalIsAborted(options.signal)) return abortedBeforeStart(runId);
+          activeRunIds.add(runId);
+          let leases: OmkRunResourceLeases | undefined;
+          let registered = false;
+          let cleanupPromise: Promise<void> | undefined;
+          const cleanup = (): Promise<void> => {
+            cleanupPromise ??= (async () => {
+              let unregisterFailure: unknown;
+              if (registered) {
+                try {
+                  assembly.evaluation.resourceLeaseRegistry.unregister(runId);
+                } catch (cause) {
+                  unregisterFailure = cause;
+                }
+                registered = false;
+              }
+              let disposeFailure: unknown;
+              try {
+                await leases?.dispose();
+              } catch (cause) {
+                disposeFailure = cause;
+              }
+              if (unregisterFailure !== undefined || disposeFailure !== undefined) fail({
+                code: 'OMK_EVALUATION_RUNTIME_CLEANUP_FAILED',
+                runId,
+                message: 'Run resource lease 清理失败。',
+                cause: unregisterFailure === undefined
+                  ? disposeFailure
+                  : disposeFailure === undefined
+                    ? unregisterFailure
+                    : new AggregateError([unregisterFailure, disposeFailure]),
+              });
+            })();
+            return cleanupPromise;
+          };
+          try {
+            try {
+              leases = await resources.materialize({
+                runId,
+                hostResources: compiled.hostResources,
+                bindings: bindingLeaseRequests,
+                analysisOnly,
+                leaseRoot: resources.leaseRoot,
+                ...(resources.limits === undefined ? {} : {
+                  limits: resources.limits,
+                }),
+                ...(resources.pinnedGitVerifier === undefined ? {} : {
+                  pinnedGitVerifier: resources.pinnedGitVerifier,
+                }),
+              });
+            } catch (cause) {
+              if (cause instanceof OmkResourceLeaseError) throw cause;
+              return fail({
+                code: 'OMK_EVALUATION_RUNTIME_RESOURCE_LEASE_FAILED',
+                runId,
+                message: 'Run resource lease acquisition 失败。',
+              });
+            }
+            leases = captureMaterializedLeases(
+              leases,
+              runId,
+              analysisOnly,
+              compiled.hostResources,
+            );
+            assembly.evaluation.resourceLeaseRegistry.register(leases);
+            registered = true;
+            if (signalIsAborted(options.signal)) {
+              await cleanup();
+              return abortedBeforeStart(runId);
+            }
+            const eventWriter = await eventWriterForRun({
+              factory: eventWriterFactory,
+              writerMode: compiled.policy.eventDelivery.writerMode,
+              runId,
+              plan: corePrepared.plan,
+            });
+            let coreRun: EvaluationRun;
+            try {
+              coreRun = corePrepared.start({
+                runId,
+                ...staticRunMetadata(compiled),
+                ...(options.signal === undefined ? {} : { signal: options.signal }),
+                ...(options.eventBufferCapacity === undefined ? {} : {
+                  eventBufferCapacity: options.eventBufferCapacity,
+                }),
+                ...(eventWriter === undefined ? {} : { eventWriter }),
+              });
+            } catch (cause) {
+              return fail({
+                code: 'OMK_EVALUATION_RUNTIME_START_FAILED',
+                runId,
+                message: 'Evaluation Core start 失败。',
+                cause,
+              });
+            }
+            const result = coreRun.result.then(
+              async (value) => {
+                await cleanup();
+                return value;
+              },
+              async (cause) => {
+                try {
+                  await cleanup();
+                } catch (cleanupCause) {
+                  return fail({
+                    code: 'OMK_EVALUATION_RUNTIME_CLEANUP_FAILED',
+                    runId,
+                    message: 'Evaluation Core failure 后的 resource lease 清理失败。',
+                    cause: new AggregateError([cause, cleanupCause]),
+                  });
+                }
+                throw cause;
+              },
+            ).finally(() => {
+              activeRunIds.delete(runId);
+            });
+            return Object.freeze({ events: coreRun.events, result });
+          } catch (cause) {
+            try {
+              await cleanup();
+            } catch (cleanupCause) {
+              activeRunIds.delete(runId);
+              return fail({
+                code: 'OMK_EVALUATION_RUNTIME_CLEANUP_FAILED',
+                runId,
+                message: 'Evaluation Core 启动失败后的 resource lease 清理失败。',
+                cause: new AggregateError([cause, cleanupCause]),
+              });
+            }
+            activeRunIds.delete(runId);
+            throw cause;
+          }
+        },
+      });
+    },
+  });
+}

--- a/src/eval-workflows/runtime-adapter/index.ts
+++ b/src/eval-workflows/runtime-adapter/index.ts
@@ -1,4 +1,5 @@
 export * from './assembly.js';
 export * from './builtins.js';
+export * from './composition.js';
 export * from './resource-leases/index.js';
 export * from './types.js';

--- a/src/eval-workflows/runtime-adapter/resource-leases/access.ts
+++ b/src/eval-workflows/runtime-adapter/resource-leases/access.ts
@@ -1,0 +1,188 @@
+import type { RuntimeBinding } from '../../input-compilation/index.js';
+import {
+  OmkResourceLeaseAccessError,
+  type OmkBindingResourceLeaseAccess,
+  type OmkRunResourceLeaseRegistry,
+  type OmkRunResourceLeases,
+} from './types.js';
+
+type ResourceConsumerBinding = Extract<RuntimeBinding, {
+  runtimeKind: 'executor' | 'evaluator';
+}>;
+
+function fail(
+  input: ConstructorParameters<typeof OmkResourceLeaseAccessError>[0],
+): never {
+  throw new OmkResourceLeaseAccessError(input);
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function resourceKindForRole(
+  role: ResourceConsumerBinding['resourceLeaseRequirements'][number]['resourceRole'],
+) {
+  return role === 'mcp-config'
+    ? 'mcp-config'
+    : role === 'mock-payload'
+      ? 'mock-payload'
+      : role;
+}
+
+export interface OmkResourceLeaseAccessRegistry {
+  readonly lifecycle: OmkRunResourceLeaseRegistry;
+  accessFor(binding: Readonly<ResourceConsumerBinding>): OmkBindingResourceLeaseAccess;
+}
+
+/**
+ * Keeps run leases out of static Runtime ports while giving each factory a least-authority view.
+ */
+export function createOmkResourceLeaseAccessRegistry(
+  bindings: readonly ResourceConsumerBinding[],
+): OmkResourceLeaseAccessRegistry {
+  const expected = new Map(bindings.map((binding) => [
+    binding.bindingId,
+    binding,
+  ]));
+  const active = new Map<string, OmkRunResourceLeases>();
+
+  const activePaths = (): { readOnly: Set<string>; writable: Set<string> } => {
+    const readOnly = new Set<string>();
+    const writable = new Set<string>();
+    for (const leases of active.values()) {
+      for (const binding of leases.bindingsByBindingId.values()) {
+        for (const resource of binding.resourcesByResourceId.values()) {
+          if (resource.leaseMode === 'immutable-snapshot') readOnly.add(resource.snapshotPath);
+          else {
+            readOnly.add(resource.baseSnapshotPath);
+            writable.add(resource.overlayPath);
+          }
+        }
+      }
+    }
+    return { readOnly, writable };
+  };
+
+  const lifecycle: OmkRunResourceLeaseRegistry = Object.freeze({
+    register(leases: OmkRunResourceLeases): void {
+      if (active.has(leases.runId)) fail({
+        code: 'OMK_RESOURCE_LEASE_RUN_ACTIVE',
+        runId: leases.runId,
+        message: `runId "${leases.runId}" 已注册 resource lease。`,
+      });
+      const actualIds = [...leases.bindingsByBindingId.keys()].sort(compareStrings);
+      const expectedIds = [...expected.keys()].sort(compareStrings);
+      if (actualIds.length !== expectedIds.length
+          || actualIds.some((bindingId, index) => bindingId !== expectedIds[index])) fail({
+        code: 'OMK_RESOURCE_LEASE_BINDING_COVERAGE_MISMATCH',
+        runId: leases.runId,
+        message: 'Run resource lease 未精确覆盖 active Executor／Evaluator bindings。',
+      });
+      const occupied = activePaths();
+      const currentReadonly = new Set<string>();
+      const currentWritable = new Set<string>();
+      for (const [bindingId, binding] of expected) {
+        const lease = leases.bindingsByBindingId.get(bindingId);
+        if (lease === undefined || lease.bindingId !== bindingId
+            || lease.consumerKind !== binding.runtimeKind) fail({
+          code: 'OMK_RESOURCE_LEASE_BINDING_COVERAGE_MISMATCH',
+          runId: leases.runId,
+          bindingId,
+          message: 'Run resource lease 的 binding identity 或 consumer kind 不一致。',
+        });
+        const expectedResourceIds = binding.resourceLeaseRequirements
+          .map((requirement) => requirement.resourceId).sort(compareStrings);
+        const actualResourceIds = [...lease.resourcesByResourceId.keys()].sort(compareStrings);
+        if (actualResourceIds.length !== expectedResourceIds.length
+            || actualResourceIds.some((resourceId, index) => (
+              resourceId !== expectedResourceIds[index]
+            ))) fail({
+          code: 'OMK_RESOURCE_LEASE_BINDING_COVERAGE_MISMATCH',
+          runId: leases.runId,
+          bindingId,
+          message: 'Binding resource lease 未精确覆盖声明的 resource requirements。',
+        });
+        for (const requirement of binding.resourceLeaseRequirements) {
+          const resource = lease.resourcesByResourceId.get(requirement.resourceId);
+          if (resource === undefined || resource.resourceId !== requirement.resourceId
+              || resource.leaseMode !== requirement.leaseMode
+              || resource.resourceKind !== resourceKindForRole(requirement.resourceRole)
+              || resource.descriptor?.resourceId !== requirement.resourceId
+              || (resource.leaseMode === 'immutable-snapshot'
+                && (typeof resource.snapshotPath !== 'string' || resource.snapshotPath === ''))
+              || (resource.leaseMode === 'copy-on-write-overlay'
+                && (typeof resource.baseSnapshotPath !== 'string'
+                  || resource.baseSnapshotPath === ''
+                  || typeof resource.overlayPath !== 'string'
+                  || resource.overlayPath === ''
+                  || resource.baseSnapshotPath === resource.overlayPath))
+              || (binding.runtimeKind === 'executor'
+                && resource.descriptor?.classification === 'gold')) fail({
+            code: 'OMK_RESOURCE_LEASE_BINDING_COVERAGE_MISMATCH',
+            runId: leases.runId,
+            bindingId,
+            message: 'Binding resource lease 的 resource identity、mode 或 classification 不合法。',
+          });
+          if (resource.leaseMode === 'immutable-snapshot') {
+            currentReadonly.add(resource.snapshotPath);
+          } else {
+            if (currentWritable.has(resource.overlayPath)
+                || occupied.writable.has(resource.overlayPath)
+                || occupied.readOnly.has(resource.overlayPath)) fail({
+              code: 'OMK_RESOURCE_LEASE_ISOLATION_MISMATCH',
+              runId: leases.runId,
+              bindingId,
+              message: 'Writable resource overlay 与其它 binding／run 路径冲突。',
+            });
+            currentReadonly.add(resource.baseSnapshotPath);
+            currentWritable.add(resource.overlayPath);
+          }
+        }
+      }
+      if ([...currentWritable].some((path) => currentReadonly.has(path))) fail({
+        code: 'OMK_RESOURCE_LEASE_ISOLATION_MISMATCH',
+        runId: leases.runId,
+        message: 'Writable resource overlay 与当前 run 的只读 snapshot 路径冲突。',
+      });
+      active.set(leases.runId, leases);
+    },
+    unregister(runId: string): void {
+      if (!active.delete(runId)) fail({
+        code: 'OMK_RESOURCE_LEASE_RUN_INACTIVE',
+        runId,
+        message: `runId "${runId}" 没有 active resource lease。`,
+      });
+    },
+  });
+
+  return Object.freeze({
+    lifecycle,
+    accessFor(binding: Readonly<ResourceConsumerBinding>): OmkBindingResourceLeaseAccess {
+      if (expected.get(binding.bindingId)?.runtimeKind !== binding.runtimeKind) fail({
+        code: 'OMK_RESOURCE_LEASE_BINDING_COVERAGE_MISMATCH',
+        bindingId: binding.bindingId,
+        message: '无法为 assembly 未声明的 binding 创建 resource lease access。',
+      });
+      return Object.freeze({
+        forRun(runId: string) {
+          const leases = active.get(runId);
+          if (leases === undefined) return fail({
+            code: 'OMK_RESOURCE_LEASE_RUN_INACTIVE',
+            runId,
+            bindingId: binding.bindingId,
+            message: `runId "${runId}" 尚未取得 active resource lease。`,
+          });
+          const lease = leases.bindingsByBindingId.get(binding.bindingId);
+          if (lease === undefined || lease.consumerKind !== binding.runtimeKind) return fail({
+            code: 'OMK_RESOURCE_LEASE_BINDING_COVERAGE_MISMATCH',
+            runId,
+            bindingId: binding.bindingId,
+            message: 'Active resource lease 不包含当前 binding。',
+          });
+          return lease;
+        },
+      });
+    },
+  });
+}

--- a/src/eval-workflows/runtime-adapter/resource-leases/index.ts
+++ b/src/eval-workflows/runtime-adapter/resource-leases/index.ts
@@ -1,2 +1,3 @@
+export * from './access.js';
 export * from './node.js';
 export * from './types.js';

--- a/src/eval-workflows/runtime-adapter/resource-leases/types.ts
+++ b/src/eval-workflows/runtime-adapter/resource-leases/types.ts
@@ -78,6 +78,11 @@ export interface OmkBindingResourceLease {
   readonly resourcesByResourceId: ReadonlyMap<string, OmkLeasedHostResource>;
 }
 
+/** Binding-scoped view captured by one Runtime factory. */
+export interface OmkBindingResourceLeaseAccess {
+  forRun(runId: string): OmkBindingResourceLease;
+}
+
 export interface OmkRunResourceLeases {
   readonly runId: string;
   readonly bindingsByBindingId: ReadonlyMap<string, OmkBindingResourceLease>;
@@ -85,6 +90,37 @@ export interface OmkRunResourceLeases {
   readonly analysisOnlyResourcesByResourceId: ReadonlyMap<string, OmkLeasedHostResource>;
   /** Idempotent API with exactly one underlying cleanup attempt. */
   dispose(): Promise<void>;
+}
+
+/** Host-only lifecycle controller; Runtime factories receive only the scoped access view. */
+export interface OmkRunResourceLeaseRegistry {
+  register(leases: OmkRunResourceLeases): void;
+  unregister(runId: string): void;
+}
+
+export type OmkResourceLeaseAccessErrorCode =
+  | 'OMK_RESOURCE_LEASE_RUN_ACTIVE'
+  | 'OMK_RESOURCE_LEASE_RUN_INACTIVE'
+  | 'OMK_RESOURCE_LEASE_BINDING_COVERAGE_MISMATCH'
+  | 'OMK_RESOURCE_LEASE_ISOLATION_MISMATCH';
+
+export class OmkResourceLeaseAccessError extends Error {
+  readonly code: OmkResourceLeaseAccessErrorCode;
+  readonly runId?: string;
+  readonly bindingId?: string;
+
+  constructor(input: {
+    code: OmkResourceLeaseAccessErrorCode;
+    message: string;
+    runId?: string;
+    bindingId?: string;
+  }) {
+    super(input.message);
+    this.name = 'OmkResourceLeaseAccessError';
+    this.code = input.code;
+    this.runId = input.runId;
+    this.bindingId = input.bindingId;
+  }
 }
 
 export interface MaterializeNodeRunResourceLeasesInput {

--- a/src/eval-workflows/runtime-adapter/types.ts
+++ b/src/eval-workflows/runtime-adapter/types.ts
@@ -25,6 +25,10 @@ import type {
   RuntimeBindingRequest,
   RuntimeResourceLeaseRequirement,
 } from '../input-compilation/index.js';
+import type {
+  OmkBindingResourceLeaseAccess,
+  OmkRunResourceLeaseRegistry,
+} from './resource-leases/types.js';
 
 export type RuntimeBindingOf<RuntimeKind extends RuntimeBinding['runtimeKind']> = Extract<
   RuntimeBinding,
@@ -51,11 +55,13 @@ interface OmkBindingFactoryContext {
 export interface OmkExecutorBindingContext extends OmkBindingFactoryContext {
   readonly binding: RuntimeBindingOf<'executor'>;
   readonly target: EvaluationDefinition['targets'][number];
+  readonly resourceLeases: OmkBindingResourceLeaseAccess;
 }
 
 export interface OmkEvaluatorBindingContext extends OmkBindingFactoryContext {
   readonly binding: RuntimeBindingOf<'evaluator'>;
   readonly evaluator: EvaluationDefinition['evaluators'][number];
+  readonly resourceLeases: OmkBindingResourceLeaseAccess;
 }
 
 export type OmkAnalysisNodeBindingContext =
@@ -159,6 +165,7 @@ export type OmkEvaluationSeriesRuntimeBindingEntry =
 export interface OmkEvaluationRuntimeBindingAssembly {
   readonly entries: readonly OmkEvaluationRuntimeBindingEntry[];
   readonly bindings: EvaluationEngineRuntimeBindings;
+  readonly resourceLeaseRegistry: OmkRunResourceLeaseRegistry;
 }
 
 export interface OmkEvaluationSeriesRuntimeBindingAssembly {

--- a/test/eval-workflows/runtime-adapter/assembly.test.ts
+++ b/test/eval-workflows/runtime-adapter/assembly.test.ts
@@ -1,9 +1,14 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   createEvaluationSeriesDefinition,
   createEvaluationEngine,
   digestCanonicalJson,
   prepareEvaluationSeriesPlan,
+  schemaIdentityKey,
+  type CoreSchemaValidator,
   type JsonValue,
   type RuntimeIdentity,
   type SchemaIdentity,
@@ -24,11 +29,19 @@ import type { SeriesAnalysisNodeRuntime } from '../../../src/evaluation-core/ser
 import {
   assembleOmkRuntimeBindings,
   createBuiltinOmkAnalysisBindingFactories,
+  createOmkEvaluationRuntime,
   resourceLeaseRequestsFromBindingEntries,
+  type OmkBindingResourceLease,
+  type OmkBindingResourceLeaseRequest,
+  type OmkEvaluationRuntimeSupportPorts,
+  type OmkRunResourceLeases,
   type OmkRuntimeBindingFactories,
   type RuntimeBindingOf,
 } from '../../../src/eval-workflows/runtime-adapter/index.js';
-import { compileCliEvaluationInput } from '../../../src/eval-workflows/input-compilation/index.js';
+import {
+  compileCliEvaluationInput,
+  type ResolvedHostResources,
+} from '../../../src/eval-workflows/input-compilation/index.js';
 import { testRuntime } from '../../evaluation-core/compiler/fixtures.js';
 import { validResolvedCliInput } from '../input-compilation/fixtures.js';
 
@@ -322,6 +335,110 @@ function factoriesFor(
   };
 }
 
+function runnableFactoriesFor(
+  compiled: ReturnType<typeof compileCliEvaluationInput>,
+  lifecycle: string[],
+  executeGate?: Promise<void>,
+): OmkRuntimeBindingFactories {
+  const base = factoriesFor(compiled, []);
+  const executors = new Map(base.executorsByImplementationId);
+  for (const [implementationId, factory] of executors) {
+    executors.set(implementationId, async (context) => {
+      const resolved = await factory(context);
+      return {
+        ...resolved,
+        port: {
+          identity: resolved.port.identity,
+          async openRun(runContext) {
+            const lease = context.resourceLeases.forRun(runContext.runId);
+            lifecycle.push(`executor.open:${runContext.runId}:${lease.bindingId}`);
+            return {
+              async openTrial() {
+                return {
+                  async execute() {
+                    if (executeGate !== undefined) await executeGate;
+                    return {
+                      output: {
+                        value: { answer: 'A' },
+                        classification: 'public' as const,
+                      },
+                      trace: {
+                        value: { source: 'test-runtime' },
+                        classification: 'public' as const,
+                      },
+                    };
+                  },
+                  dispose() { lifecycle.push(`executor.trial.dispose:${runContext.runId}`); },
+                };
+              },
+              dispose() { lifecycle.push(`executor.run.dispose:${runContext.runId}`); },
+            };
+          },
+        },
+      };
+    });
+  }
+  const evaluators = new Map(base.evaluatorsByImplementationId);
+  for (const [implementationId, factory] of evaluators) {
+    evaluators.set(implementationId, async (context) => {
+      const resolved = await factory(context);
+      return {
+        ...resolved,
+        port: {
+          identity: resolved.port.identity,
+          async openRun(runContext) {
+            const lease = context.resourceLeases.forRun(runContext.runId);
+            lifecycle.push(`evaluator.open:${runContext.runId}:${lease.bindingId}`);
+            return {
+              async openRecord(recordContext) {
+                return {
+                  async evaluate() {
+                    return {
+                      observations: recordContext.metrics.map((metric) => {
+                        if (metric.valueType === 'numeric') return {
+                          metricId: metric.metricId,
+                          observationStatus: 'observed' as const,
+                          valueType: metric.valueType,
+                          value: 1,
+                        };
+                        if (metric.valueType === 'boolean') return {
+                          metricId: metric.metricId,
+                          observationStatus: 'observed' as const,
+                          valueType: metric.valueType,
+                          value: true,
+                        };
+                        if (metric.valueType === 'ranking') return {
+                          metricId: metric.metricId,
+                          observationStatus: 'observed' as const,
+                          valueType: metric.valueType,
+                          value: ['A'],
+                        };
+                        return {
+                          metricId: metric.metricId,
+                          observationStatus: 'observed' as const,
+                          valueType: metric.valueType,
+                          value: 'A',
+                        };
+                      }),
+                    };
+                  },
+                  dispose() { lifecycle.push(`evaluator.record.dispose:${runContext.runId}`); },
+                };
+              },
+              dispose() { lifecycle.push(`evaluator.run.dispose:${runContext.runId}`); },
+            };
+          },
+        },
+      };
+    });
+  }
+  return {
+    ...base,
+    executorsByImplementationId: executors,
+    evaluatorsByImplementationId: evaluators,
+  };
+}
+
 const clock = {
   monotonicNow: () => 0,
   timestamp: () => '2026-08-30T00:00:00.000Z',
@@ -329,6 +446,79 @@ const clock = {
     if (signal.aborted) throw new Error('aborted');
   },
 };
+
+function compositionInput(options: {
+  judges?: boolean;
+  referenceOutput?: boolean;
+  referenceTrace?: boolean;
+  referenceEvaluationEvidence?: boolean;
+} = {}) {
+  const input = runtimeAssemblyInput();
+  delete input.orchestration.independentSeries;
+  delete input.orchestration.gold;
+  input.judges.enabled = options.judges ?? true;
+  input.policy.evidence = {
+    output: options.referenceOutput === true ? 'reference' : 'full',
+    trace: options.referenceTrace === true ? 'reference' : 'full',
+    evidence: options.referenceEvaluationEvidence === true ? 'reference' : 'full',
+    maximumClassification: 'gold',
+  };
+  return compileCliEvaluationInput(input);
+}
+
+function compositionSupport(): OmkEvaluationRuntimeSupportPorts {
+  return {
+    clock,
+    schemaValidators: testRuntime({
+      evaluatorValueTypes: ['numeric', 'boolean', 'categorical', 'text', 'ranking'],
+    }).schemaValidators,
+  };
+}
+
+function fakeLeases(
+  runId: string,
+  bindings: readonly OmkBindingResourceLeaseRequest[],
+  hostResources: ResolvedHostResources,
+  dispose: () => void,
+): OmkRunResourceLeases {
+  const byBinding = new Map<string, OmkBindingResourceLease>(bindings.map((binding) => [
+    binding.bindingId,
+    Object.freeze({
+      bindingId: binding.bindingId,
+      consumerKind: binding.consumerKind,
+      resourcesByResourceId: new Map(binding.requirements.map((requirement) => {
+        const resolved = hostResources.resources.find((resource) => (
+          resource.descriptor.resourceId === requirement.resourceId
+        ));
+        if (resolved === undefined) throw new Error('missing HostResource fixture');
+        return [requirement.resourceId, requirement.leaseMode === 'copy-on-write-overlay'
+          ? {
+              resourceId: requirement.resourceId,
+              resourceKind: 'workspace' as const,
+              descriptor: resolved.descriptor,
+              snapshotKind: 'directory' as const,
+              leaseMode: requirement.leaseMode,
+              baseSnapshotPath: `/lease/${runId}/${requirement.resourceId}/base`,
+              overlayPath: `/lease/${runId}/${binding.bindingId}/${requirement.resourceId}/overlay`,
+            }
+          : {
+              resourceId: requirement.resourceId,
+              resourceKind: resolved.resourceKind,
+              descriptor: resolved.descriptor,
+              snapshotKind: 'file' as const,
+              leaseMode: requirement.leaseMode,
+              snapshotPath: `/lease/${runId}/${requirement.resourceId}`,
+            }];
+      })),
+    }),
+  ]));
+  return Object.freeze({
+    runId,
+    bindingsByBindingId: byBinding,
+    analysisOnlyResourcesByResourceId: new Map(),
+    async dispose() { dispose(); },
+  });
+}
 
 describe('OMK Evaluation Runtime binding assembly', () => {
   it('assembles exact reference bindings and passes a real Core prepare', async () => {
@@ -709,5 +899,586 @@ describe('OMK Evaluation Runtime binding assembly', () => {
     expect(builtins.analysisNodesByImplementationId.has('bootstrap.mean-percentile/v1')).toBe(true);
     expect(builtins.missingPoliciesByImplementationId.has('exclude/v1')).toBe(true);
     expect(builtins.decisionPoliciesByImplementationId.has('progress/v1')).toBe(true);
+  });
+});
+
+describe('OMK Evaluation Runtime composition root', () => {
+  it('uses the verified Node materializer by default and fails closed on missing sources', async () => {
+    const compiled = compositionInput();
+    const lifecycle: string[] = [];
+    const leaseRoot = await mkdtemp(join(tmpdir(), 'omk-composition-test-'));
+    try {
+      const runtime = await createOmkEvaluationRuntime({
+        compiled,
+        factories: runnableFactoriesFor(compiled, lifecycle),
+        support: compositionSupport(),
+        resources: { leaseRoot },
+      });
+      const prepared = await runtime.prepare();
+
+      await expect(prepared.start({ runId: 'node-materializer' })).rejects.toMatchObject({
+        code: 'OMK_RESOURCE_LEASE_SOURCE_INVALID',
+      });
+      expect(lifecycle.some((entry) => entry.startsWith('executor.open:'))).toBe(false);
+    } finally {
+      await rm(leaseRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('runs real Core prepare and acquires leases before any Runtime port opens', async () => {
+    const compiled = compositionInput();
+    const lifecycle: string[] = [];
+    let disposeCalls = 0;
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, lifecycle),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          lifecycle.push(`lease.acquire:${request.runId}`);
+          return fakeLeases(request.runId, request.bindings, request.hostResources, () => {
+            disposeCalls += 1;
+            lifecycle.push(`lease.dispose:${request.runId}`);
+          });
+        },
+      },
+    });
+
+    const prepared = await runtime.prepare();
+    expect(digestCanonicalJson(prepared.plan.definition)).toBe(compiled.canonicalDigests.definition);
+    expect(lifecycle).toEqual([]);
+    const run = await prepared.start({ runId: 'composition-run' });
+    const result = await run.result;
+
+    expect(result.status).toBe('failed');
+    expect(lifecycle[0]).toBe('lease.acquire:composition-run');
+    expect(lifecycle.findIndex((entry) => entry.startsWith('executor.open:composition-run:')))
+      .toBeGreaterThan(0);
+    expect(lifecycle.at(-1)).toBe('lease.dispose:composition-run');
+    expect(disposeCalls).toBe(1);
+  });
+
+  it('fails missing Policy-required support ports before invoking any Runtime factory', async () => {
+    const compiled = compositionInput({ referenceTrace: true });
+    const factoryCalls: string[] = [];
+
+    await expect(createOmkEvaluationRuntime({
+      compiled,
+      factories: factoriesFor(compiled, factoryCalls),
+      support: compositionSupport(),
+      resources: { leaseRoot: '/unused-test-lease-root' },
+    })).rejects.toMatchObject({
+      code: 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_REQUIRED',
+      fieldPath: 'support.executionContentStore',
+    });
+    expect(factoryCalls).toEqual([]);
+    expect(compiled.policy.evidence.trace).toBe('reference');
+  });
+
+  it.each([
+    {
+      evidence: { referenceOutput: true },
+      support: { executionContentStore: { async put() { throw new Error('unused'); } } },
+      fieldPath: 'support.contentResolver',
+    },
+    {
+      evidence: { referenceEvaluationEvidence: true },
+      support: {},
+      fieldPath: 'support.evaluationContentStore',
+    },
+  ])('fails $fieldPath before factory assembly', async ({ evidence, support, fieldPath }) => {
+    const compiled = compositionInput(evidence);
+    const calls: string[] = [];
+
+    await expect(createOmkEvaluationRuntime({
+      compiled,
+      factories: factoriesFor(compiled, calls),
+      support: { ...compositionSupport(), ...support },
+      resources: { leaseRoot: '/unused-test-lease-root' },
+    })).rejects.toMatchObject({
+      code: 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_REQUIRED',
+      fieldPath,
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it.each(['execution-cache', 'required-writer'] as const)(
+    'fails a missing %s port before factory assembly',
+    async (scenario) => {
+      const input = runtimeAssemblyInput();
+      delete input.orchestration.independentSeries;
+      delete input.orchestration.resumeSourceLocator;
+      delete input.orchestration.gold;
+      input.policy.evidence = {
+        output: 'full', trace: 'full', evidence: 'full', maximumClassification: 'gold',
+      };
+      if (scenario === 'execution-cache') {
+        input.policy.cache.executionMode = 'replay-only';
+        input.orchestration.cacheSources = { executionSourceLocator: '/cache/source' };
+      } else {
+        input.policy.eventDelivery = {
+          writerMode: 'required', backpressureMode: 'block', writerFailureMode: 'fail-run',
+        };
+      }
+      const compiled = compileCliEvaluationInput(input);
+      const calls: string[] = [];
+
+      await expect(createOmkEvaluationRuntime({
+        compiled,
+        factories: factoriesFor(compiled, calls),
+        support: compositionSupport(),
+        resources: { leaseRoot: '/unused-test-lease-root' },
+      })).rejects.toMatchObject({
+        code: 'OMK_EVALUATION_RUNTIME_SUPPORT_PORT_REQUIRED',
+        fieldPath: scenario === 'execution-cache'
+          ? 'support.executionCache'
+          : 'support.createEventWriter',
+      });
+      expect(calls).toEqual([]);
+    },
+  );
+
+  it('does not construct or probe Judge Runtime when no Judge binding exists', async () => {
+    const compiled = compositionInput({ judges: false });
+    const lifecycle: string[] = [];
+    const factories = runnableFactoriesFor(compiled, lifecycle);
+    let judgeSideEffects = 0;
+    const evaluators = new Map(factories.evaluatorsByImplementationId);
+    evaluators.set('test.unbound-judge/v1', () => {
+      judgeSideEffects += 1;
+      throw new Error('credential and connectivity side effect must stay unreachable');
+    });
+
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: { ...factories, evaluatorsByImplementationId: evaluators },
+      support: compositionSupport(),
+      resources: { leaseRoot: '/unused-test-lease-root' },
+    });
+    await runtime.prepare();
+
+    expect(compiled.runtimeBinding.bindings.some((binding) => (
+      binding.runtimeKind === 'evaluator' && binding.qualification !== undefined
+    ))).toBe(false);
+    expect(judgeSideEffects).toBe(0);
+    expect(lifecycle).toEqual([]);
+  });
+
+  it('does not materialize post-hoc Gold for the single-run Core pipeline', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    input.policy.evidence = {
+      output: 'full', trace: 'full', evidence: 'full', maximumClassification: 'gold',
+    };
+    const compiled = compileCliEvaluationInput(input);
+    let materializeCalls = 0;
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, []),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          materializeCalls += 1;
+          expect(request.analysisOnly).toEqual([]);
+          expect(JSON.stringify(request.bindings)).not.toContain('gold-dataset');
+          return fakeLeases(
+            request.runId,
+            request.bindings,
+            request.hostResources,
+            () => {},
+          );
+        },
+      },
+    });
+    const run = await (await runtime.prepare()).start({ runId: 'no-core-gold' });
+    await run.result;
+
+    expect(compiled.orchestration.gold?.comparisonMode).toBe('exploratory-post-hoc');
+    expect(materializeCalls).toBe(1);
+  });
+
+  it('rejects duplicate active runId before acquiring a second lease and isolates cleanup', async () => {
+    const compiled = compositionInput();
+    let releaseExecution: (() => void) | undefined;
+    const executeGate = new Promise<void>((resolve) => { releaseExecution = resolve; });
+    const lifecycle: string[] = [];
+    let acquireCalls = 0;
+    let disposeCalls = 0;
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, lifecycle, executeGate),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          acquireCalls += 1;
+          return fakeLeases(
+            request.runId,
+            request.bindings,
+            request.hostResources,
+            () => { disposeCalls += 1; },
+          );
+        },
+      },
+    });
+    const prepared = await runtime.prepare();
+    const first = await prepared.start({ runId: 'same-run' });
+    await expect(prepared.start({ runId: 'same-run' })).rejects.toMatchObject({
+      code: 'OMK_EVALUATION_RUNTIME_RUN_ACTIVE',
+    });
+    expect(acquireCalls).toBe(1);
+
+    releaseExecution?.();
+    await first.result;
+    expect(disposeCalls).toBe(1);
+  });
+
+  it('rejects invalid run options before resource acquisition', async () => {
+    const compiled = compositionInput();
+    let acquireCalls = 0;
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, []),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          acquireCalls += 1;
+          return fakeLeases(
+            request.runId,
+            request.bindings,
+            request.hostResources,
+            () => {},
+          );
+        },
+      },
+    });
+    const prepared = await runtime.prepare();
+
+    await expect(prepared.start({
+      runId: 'invalid-options',
+      eventBufferCapacity: 0,
+    })).rejects.toMatchObject({
+      code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+      fieldPath: 'eventBufferCapacity',
+    });
+    expect(acquireCalls).toBe(0);
+  });
+
+  it('keeps two concurrent run lease projections and teardown independent', async () => {
+    const compiled = compositionInput();
+    let releaseExecution: (() => void) | undefined;
+    const executeGate = new Promise<void>((resolve) => { releaseExecution = resolve; });
+    const lifecycle: string[] = [];
+    const disposed: string[] = [];
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, lifecycle, executeGate),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          lifecycle.push(`lease.acquire:${request.runId}`);
+          return fakeLeases(
+            request.runId,
+            request.bindings,
+            request.hostResources,
+            () => disposed.push(request.runId),
+          );
+        },
+      },
+    });
+    const prepared = await runtime.prepare();
+    const first = await prepared.start({ runId: 'parallel-a' });
+    const second = await prepared.start({ runId: 'parallel-b' });
+
+    releaseExecution?.();
+    await Promise.all([first.result, second.result]);
+    expect(lifecycle.filter((entry) => entry.startsWith('lease.acquire:')).sort()).toEqual([
+      'lease.acquire:parallel-a',
+      'lease.acquire:parallel-b',
+    ]);
+    expect(lifecycle.some((entry) => entry.startsWith('executor.open:parallel-a:'))).toBe(true);
+    expect(lifecycle.some((entry) => entry.startsWith('executor.open:parallel-b:'))).toBe(true);
+    expect(disposed.sort()).toEqual(['parallel-a', 'parallel-b']);
+  });
+
+  it('rejects writable overlay reuse across active runs before opening the second run', async () => {
+    const compiled = compositionInput();
+    let releaseExecution: (() => void) | undefined;
+    const executeGate = new Promise<void>((resolve) => { releaseExecution = resolve; });
+    const disposed: string[] = [];
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, [], executeGate),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          const leases = fakeLeases(
+            request.runId,
+            request.bindings,
+            request.hostResources,
+            () => disposed.push(request.runId),
+          );
+          for (const binding of leases.bindingsByBindingId.values()) {
+            for (const resource of binding.resourcesByResourceId.values()) {
+              if (resource.leaseMode === 'copy-on-write-overlay') {
+                (resource as { overlayPath: string }).overlayPath =
+                  `/lease/shared-overlay/${binding.bindingId}`;
+              }
+            }
+          }
+          return leases;
+        },
+      },
+    });
+    const prepared = await runtime.prepare();
+    const first = await prepared.start({ runId: 'overlay-a' });
+
+    await expect(prepared.start({ runId: 'overlay-b' })).rejects.toMatchObject({
+      code: 'OMK_RESOURCE_LEASE_ISOLATION_MISMATCH',
+    });
+    releaseExecution?.();
+    await first.result;
+    expect(disposed.sort()).toEqual(['overlay-a', 'overlay-b']);
+  });
+
+  it('cleans an acquired lease without opening a port when cancellation wins acquisition', async () => {
+    const compiled = compositionInput();
+    const lifecycle: string[] = [];
+    const controller = new AbortController();
+    let finishAcquisition: (() => void) | undefined;
+    const acquisitionGate = new Promise<void>((resolve) => { finishAcquisition = resolve; });
+    let disposeCalls = 0;
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, lifecycle),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          lifecycle.push(`lease.acquire:${request.runId}`);
+          await acquisitionGate;
+          return fakeLeases(
+            request.runId,
+            request.bindings,
+            request.hostResources,
+            () => { disposeCalls += 1; },
+          );
+        },
+      },
+    });
+    const prepared = await runtime.prepare();
+    const start = prepared.start({ runId: 'cancel-acquisition', signal: controller.signal });
+    controller.abort();
+    finishAcquisition?.();
+
+    await expect(start).rejects.toMatchObject({
+      code: 'OMK_EVALUATION_RUNTIME_RUN_ABORTED_BEFORE_START',
+    });
+    expect(lifecycle.some((entry) => entry.startsWith('executor.open:'))).toBe(false);
+    expect(disposeCalls).toBe(1);
+  });
+
+  it('rejects incomplete binding resource coverage before opening any Runtime port', async () => {
+    const compiled = compositionInput();
+    const lifecycle: string[] = [];
+    let disposeCalls = 0;
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, lifecycle),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          const leases = fakeLeases(
+            request.runId,
+            request.bindings,
+            request.hostResources,
+            () => { disposeCalls += 1; },
+          );
+          const first = [...leases.bindingsByBindingId.values()].find((lease) => (
+            lease.resourcesByResourceId.size > 0
+          ));
+          if (first === undefined) throw new Error('missing resource lease fixture');
+          const resources = first.resourcesByResourceId as Map<string, unknown>;
+          resources.delete(resources.keys().next().value as string);
+          return leases;
+        },
+      },
+    });
+    const prepared = await runtime.prepare();
+
+    await expect(prepared.start({ runId: 'incomplete-resources' })).rejects.toMatchObject({
+      code: 'OMK_RESOURCE_LEASE_BINDING_COVERAGE_MISMATCH',
+    });
+    expect(lifecycle.some((entry) => entry.startsWith('executor.open:'))).toBe(false);
+    expect(disposeCalls).toBe(1);
+  });
+
+  it('normalizes an unknown materializer exception without exposing sensitive details', async () => {
+    const compiled = compositionInput();
+    const lifecycle: string[] = [];
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, lifecycle),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize() {
+          throw new Error('secret locator and credential details');
+        },
+      },
+    });
+    const prepared = await runtime.prepare();
+
+    const error = await prepared.start({ runId: 'materializer-failure' }).catch((cause) => cause);
+    expect(error).toMatchObject({ code: 'OMK_EVALUATION_RUNTIME_RESOURCE_LEASE_FAILED' });
+    expect(error.message).not.toContain('secret');
+    expect(error.cause).toBeUndefined();
+    expect(lifecycle.some((entry) => entry.startsWith('executor.open:'))).toBe(false);
+  });
+
+  it('cleans an acquired lease exactly once when EventWriter creation fails', async () => {
+    const input = runtimeAssemblyInput();
+    delete input.orchestration.independentSeries;
+    delete input.orchestration.gold;
+    input.policy.evidence = {
+      output: 'full', trace: 'full', evidence: 'full', maximumClassification: 'gold',
+    };
+    input.policy.eventDelivery = {
+      writerMode: 'required', backpressureMode: 'block', writerFailureMode: 'fail-run',
+    };
+    const compiled = compileCliEvaluationInput(input);
+    let disposeCalls = 0;
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, []),
+      support: {
+        ...compositionSupport(),
+        createEventWriter() { throw new Error('writer unavailable'); },
+      },
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          return fakeLeases(
+            request.runId,
+            request.bindings,
+            request.hostResources,
+            () => { disposeCalls += 1; },
+          );
+        },
+      },
+    });
+    const prepared = await runtime.prepare();
+
+    await expect(prepared.start({ runId: 'writer-failure' })).rejects.toMatchObject({
+      code: 'OMK_EVALUATION_RUNTIME_EVENT_WRITER_FAILED',
+    });
+    expect(disposeCalls).toBe(1);
+  });
+
+  it('does not create an EventWriter when sealed writerMode is disabled', async () => {
+    const compiled = compositionInput();
+    let writerCalls = 0;
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, []),
+      support: {
+        ...compositionSupport(),
+        createEventWriter() {
+          writerCalls += 1;
+          return { async write() {} };
+        },
+      },
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          return fakeLeases(
+            request.runId,
+            request.bindings,
+            request.hostResources,
+            () => {},
+          );
+        },
+      },
+    });
+    const run = await (await runtime.prepare()).start({ runId: 'writer-disabled' });
+    await run.result;
+
+    expect(compiled.policy.eventDelivery.writerMode).toBe('disabled');
+    expect(writerCalls).toBe(0);
+  });
+
+  it('reports lease disposal failure without retrying destructive cleanup', async () => {
+    const compiled = compositionInput();
+    let disposeCalls = 0;
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, []),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          return fakeLeases(request.runId, request.bindings, request.hostResources, () => {
+            disposeCalls += 1;
+            throw new Error('cannot remove lease');
+          });
+        },
+      },
+    });
+    const run = await (await runtime.prepare()).start({ runId: 'dispose-failure' });
+
+    await expect(run.result).rejects.toMatchObject({
+      code: 'OMK_EVALUATION_RUNTIME_CLEANUP_FAILED',
+    });
+    expect(disposeCalls).toBe(1);
+  });
+
+  it('fails conflicting SchemaValidator identities and cache sources without rewriting Policy', async () => {
+    const compiled = compositionInput();
+    const support = compositionSupport();
+    const validators = new Map(support.schemaValidators);
+    const first = validators.values().next().value as CoreSchemaValidator;
+    validators.set(schemaIdentityKey({
+      ...first.schema,
+      schemaVersion: `${first.schema.schemaVersion}.conflict`,
+    }), {
+      schema: { ...first.schema, schemaVersion: `${first.schema.schemaVersion}.conflict` },
+      parse: first.parse,
+    });
+
+    await expect(createOmkEvaluationRuntime({
+      compiled,
+      factories: factoriesFor(compiled, []),
+      support: { ...support, schemaValidators: validators },
+      resources: { leaseRoot: '/unused-test-lease-root' },
+    })).rejects.toMatchObject({ code: 'OMK_EVALUATION_RUNTIME_SCHEMA_VALIDATOR_CONFLICT' });
+
+    const cacheInput = runtimeAssemblyInput();
+    delete cacheInput.orchestration.independentSeries;
+    delete cacheInput.orchestration.resumeSourceLocator;
+    cacheInput.policy.cache.executionMode = 'replay-only';
+    cacheInput.orchestration.cacheSources = { executionSourceLocator: '/cache/source-a' };
+    cacheInput.policy.evidence = {
+      output: 'full', trace: 'full', evidence: 'full', maximumClassification: 'gold',
+    };
+    const cacheCompiled = compileCliEvaluationInput(cacheInput);
+    await expect(createOmkEvaluationRuntime({
+      compiled: cacheCompiled,
+      factories: factoriesFor(cacheCompiled, []),
+      support: {
+        ...compositionSupport(),
+        executionCache: {
+          sourceLocator: '/cache/source-b',
+          port: { async get() { return undefined; }, async put() {} },
+        },
+      },
+      resources: { leaseRoot: '/unused-test-lease-root' },
+    })).rejects.toMatchObject({ code: 'OMK_EVALUATION_RUNTIME_CACHE_SOURCE_MISMATCH' });
+    expect(cacheCompiled.policy.cache.executionMode).toBe('replay-only');
   });
 });


### PR DESCRIPTION
## 用户影响

为 #457 增加 OMK 标准宿主的 composition root：完整消费编译产物，装配实际 Runtime identity、Core support ports 与 run-scoped verified resource lease，并通过真实 Core prepare 封存唯一 SealedRunPlan。

Policy 要求的 cache、reference evidence、ContentResolver 或 required EventWriter 缺失时，在 Runtime factory 与业务端口调用前 fail closed。无 Judge binding 不会构造 Judge Runtime、读取凭证、探测连接或物化对应资源。不同 run／binding 的可写 overlay、事件、取消和 teardown 保持隔离；资源获取、启动失败、取消及结果 settle 共享 exactly-once cleanup。

独立 Series ports 保持在 single-run engine 之外；exploratory post-hoc Gold 不会被 Core run 提前物化。

## 迁移说明

本 PR 是增量基础设施，不切换正式 omk eval，不改变旧 pipeline、Report 或持久化布局。后续 Executor／Evaluator adapters 可直接使用 binding-scoped resource lease view，无需读取原始 locator。

## 测量学说明

Runtime 只实现并验证编译后的契约，不改写 EvaluationDefinition 或 MeasurementPolicy。本 PR 不修改冻结 prompt、五层评分语义、Bootstrap／Krippendorff alpha 公式或 length-debias，因此不构成 BREAKING-COMPARABILITY。

Part of #457。