### PR TITLE
feat(eval-workflows): 建立同进程 Core Runtime 适配器

### DIFF
--- a/docs/specs/evaluation-runtime-adapter.md
+++ b/docs/specs/evaluation-runtime-adapter.md
@@ -56,6 +56,16 @@ Every entry records:
 
 Adapters combine `sessionIsolationKey` with Core's `runId` and `trialId`; it is not permission to pool state across runs or bindings.
 
+## Same-process Runtime adapter
+
+`createSameProcessExecutorAdapter()` and `createSameProcessEvaluatorAdapter()` are the reference bridge for binding-local in-process implementations. The host must supply an explicit `RuntimeIdentity` and every lifecycle callback; the adapter does not infer capabilities from the Definition or provide a scoring algorithm.
+
+At construction, the bridge validates and freezes the identity, captures the lease resolver and callback functions, and derives separate content-addressed isolation keys for each run and trial／evaluation record. Later mutation of a factory object therefore cannot change the executing implementation behind an already sealed identity. Duplicate active run and operation identities fail closed, and every disposal callback is invoked at most once even when callers race or retry cleanup.
+
+The Core attempt `AbortSignal`, trial seed, target／Evaluator configuration, verified binding lease, and optional result usage are forwarded without reinterpretation. Missing usage stays missing. The bridge has no timeout, retry, budget, cache, or cancellation race of its own; those remain exclusively owned by the sealed Core policy, and a cooperative implementation must settle its underlying operation after the forwarded signal aborts.
+
+Composition-root conformance uses implementations under the `test.*` namespace whose outputs are derived from their inputs and bindings. They exercise real Core prepare and run paths but are not exported or represented as production Executor／Evaluator algorithms.
+
 ## Resource requirements
 
 RuntimeBindingRequest records resource role and intended lease mode, not locators or content:

--- a/docs/zh/specs/evaluation-runtime-adapter.md
+++ b/docs/zh/specs/evaluation-runtime-adapter.md
@@ -56,7 +56,17 @@ Factory 返回实际 port identity 和 version resolution。Assembly 校验 port
 
 Adapter 必须把 `sessionIsolationKey` 与 Core `runId`、`trialId` 组合使用；它不允许跨 run 或 binding 复用有状态 session。
 
-## 四、资源需求
+## 四、Same-process Runtime adapter
+
+`createSameProcessExecutorAdapter()` 与 `createSameProcessEvaluatorAdapter()` 是 binding-local 同进程实现的基准桥接层。宿主必须显式提供 `RuntimeIdentity` 和全部生命周期回调；adapter 不从 Definition 推断 capability，也不提供评分算法。
+
+桥接层会在构造时校验并冻结 identity，捕获 lease resolver 与回调函数，并为每个 run、trial／evaluation record 派生独立的内容寻址隔离键。因此，工厂对象后续发生变更，也不能在已封存的 identity 背后替换实际执行实现。重复的 active run 与 operation identity 会 fail closed；即使调用方并发或重试清理，每个 dispose 回调也至多执行一次。
+
+Core attempt 的 `AbortSignal`、trial seed、Target／Evaluator 配置、已验证的 binding lease 与可选 usage 会原样转交。未报告 usage 时仍保持缺失。桥接层不拥有独立 timeout、retry、budget、cache 或 cancellation race；这些行为只由 sealed Core Policy 驱动。Cooperative implementation 收到转交 signal 的 abort 后，必须让底层操作真正收敛。
+
+Composition root conformance 使用 `test.*` 命名空间下、根据输入和 binding 动态生成结果的实现。它们会经过真实 Core prepare 与 run 路径，但不会被导出或伪装成生产 Executor／Evaluator 算法。
+
+## 五、资源需求
 
 RuntimeBindingRequest 只记录资源角色和预期 lease mode，不记录 locator 或内容：
 
@@ -75,7 +85,7 @@ Lease acquisition 在首个 effect 之前同步复制并冻结全部 descriptor 
 
 Composition root 在 Core 能调用任何 `openRun()` 前取得完整的 active-binding run lease。它验证 binding／resource 精确覆盖，捕获不可变 map 与 descriptor 快照，然后才注册 binding-scoped access。所有 Core port teardown settle 后先撤销注册，再执行一次 lease disposal。Acquisition、Core start 前取消、EventWriter 创建、Core start、正常完成与失败路径共享同一个幂等 cleanup promise。重复 active `runId` 会在第二次 acquisition 前被拒绝。用于 exploratory post-hoc comparison 的 Gold 不会被 single-run Core composition 提前物化；独立 analysis-host workflow 在存在真实消费者时再请求对应 lease。
 
-## 五、Core Composition 与 Support Ports
+## 六、Core Composition 与 Support Ports
 
 `createOmkEvaluationRuntime()` 只消费一份完整的 `CliEvaluationCompileResult`；调用方不能在 `prepare()` 或 `start()` 传入替代 Definition／Policy。Composition root 会校验 compiled canonical digest、快照化全部宿主配置、合并 Core-owned Analysis schema validator 与 Runtime factory、装配 binding，并调用真实的 `createEvaluationEngine(...).prepare(...)`。独立 Series assembly 单独暴露，不进入 single-run engine。
 
@@ -91,7 +101,7 @@ Clock 与 SchemaValidator contract 在 factory assembly 前校验。Core-owned A
 
 EventWriter 不进入静态 `EvaluationEngineRuntime`。Optional／required delivery 会在 resource acquisition 后、Core start 前创建 writer，并通过 `PreparedEvaluation.start()` 注入；disabled mode 绝不调用 factory。Policy 要求的 port 缺失或形状错误时，在任何 Runtime factory 或 run port 调用前失败。因此不存在 Judge binding 时，也不会构造 Judge factory、读取凭证、执行 connectivity probe 或物化对应资源。
 
-## 六、错误归属
+## 七、错误归属
 
 - malformed input、coverage、duplicate、Definition mismatch、missing factory、factory failure 和 invalid port 在 Run 开始前使用稳定 `OmkRuntimeAssemblyError` code；
 - compiled input、support port、cache source、schema conflict、writer construction、active run 与 host cleanup failure 使用稳定 `OmkEvaluationRuntimeError` code；

--- a/src/eval-workflows/runtime-adapter/adapters/index.ts
+++ b/src/eval-workflows/runtime-adapter/adapters/index.ts
@@ -1,0 +1,1 @@
+export * from './same-process.js';

--- a/src/eval-workflows/runtime-adapter/adapters/same-process.ts
+++ b/src/eval-workflows/runtime-adapter/adapters/same-process.ts
@@ -1,0 +1,431 @@
+import {
+  RuntimeIdentitySchema,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  type RuntimeIdentity,
+  type Sha256Digest,
+} from '../../../evaluation-core/contracts/index.js';
+import type {
+  EvaluationEvaluator,
+  EvaluationEvaluatorRecord,
+  EvaluationEvaluatorRun,
+  EvaluatorAttemptContext,
+  EvaluatorAttemptResult,
+  EvaluatorRecordContext,
+  EvaluatorRunContext,
+} from '../../../evaluation-core/evaluation/index.js';
+import type {
+  ExecutionExecutor,
+  ExecutionExecutorRun,
+  ExecutionExecutorTrial,
+  ExecutorAttemptContext,
+  ExecutorAttemptResult,
+  ExecutorRunContext,
+  ExecutorTrialContext,
+} from '../../../evaluation-core/execution/index.js';
+import type {
+  OmkBindingResourceLease,
+  OmkBindingResourceLeaseAccess,
+} from '../resource-leases/types.js';
+
+type MaybePromise<Value> = Value | Promise<Value>;
+
+export interface SameProcessRunScope {
+  readonly sessionIsolationKey: string;
+  readonly runIsolationKey: Sha256Digest;
+}
+
+export interface SameProcessOperationScope extends SameProcessRunScope {
+  readonly operationIsolationKey: Sha256Digest;
+}
+
+export interface SameProcessExecutorImplementation<RunState, TrialState> {
+  openRun(context: Readonly<{
+    run: Readonly<ExecutorRunContext>;
+    scope: SameProcessRunScope;
+    resources: OmkBindingResourceLease;
+  }>): MaybePromise<RunState>;
+  openTrial(context: Readonly<{
+    run: Readonly<ExecutorRunContext>;
+    runState: RunState;
+    trial: Readonly<ExecutorTrialContext>;
+    scope: SameProcessOperationScope;
+    resources: OmkBindingResourceLease;
+  }>): MaybePromise<TrialState>;
+  execute(context: Readonly<{
+    run: Readonly<ExecutorRunContext>;
+    runState: RunState;
+    trial: Readonly<ExecutorTrialContext>;
+    trialState: TrialState;
+    attempt: Readonly<ExecutorAttemptContext>;
+    scope: SameProcessOperationScope;
+    resources: OmkBindingResourceLease;
+  }>): Promise<ExecutorAttemptResult>;
+  disposeTrial(context: Readonly<{
+    run: Readonly<ExecutorRunContext>;
+    runState: RunState;
+    trial: Readonly<ExecutorTrialContext>;
+    trialState: TrialState;
+    scope: SameProcessOperationScope;
+    resources: OmkBindingResourceLease;
+  }>): MaybePromise<void>;
+  disposeRun(context: Readonly<{
+    run: Readonly<ExecutorRunContext>;
+    runState: RunState;
+    scope: SameProcessRunScope;
+    resources: OmkBindingResourceLease;
+  }>): MaybePromise<void>;
+}
+
+export interface SameProcessEvaluatorImplementation<RunState, RecordState> {
+  openRun(context: Readonly<{
+    run: Readonly<EvaluatorRunContext>;
+    scope: SameProcessRunScope;
+    resources: OmkBindingResourceLease;
+  }>): MaybePromise<RunState>;
+  openRecord(context: Readonly<{
+    run: Readonly<EvaluatorRunContext>;
+    runState: RunState;
+    record: Readonly<EvaluatorRecordContext>;
+    scope: SameProcessOperationScope;
+    resources: OmkBindingResourceLease;
+  }>): MaybePromise<RecordState>;
+  evaluate(context: Readonly<{
+    run: Readonly<EvaluatorRunContext>;
+    runState: RunState;
+    record: Readonly<EvaluatorRecordContext>;
+    recordState: RecordState;
+    attempt: Readonly<EvaluatorAttemptContext>;
+    scope: SameProcessOperationScope;
+    resources: OmkBindingResourceLease;
+  }>): Promise<EvaluatorAttemptResult>;
+  disposeRecord(context: Readonly<{
+    run: Readonly<EvaluatorRunContext>;
+    runState: RunState;
+    record: Readonly<EvaluatorRecordContext>;
+    recordState: RecordState;
+    scope: SameProcessOperationScope;
+    resources: OmkBindingResourceLease;
+  }>): MaybePromise<void>;
+  disposeRun(context: Readonly<{
+    run: Readonly<EvaluatorRunContext>;
+    runState: RunState;
+    scope: SameProcessRunScope;
+    resources: OmkBindingResourceLease;
+  }>): MaybePromise<void>;
+}
+
+export interface CreateSameProcessExecutorAdapterInput<RunState, TrialState> {
+  readonly identity: RuntimeIdentity;
+  readonly sessionIsolationKey: string;
+  readonly resourceLeases: OmkBindingResourceLeaseAccess;
+  readonly implementation: SameProcessExecutorImplementation<RunState, TrialState>;
+}
+
+export interface CreateSameProcessEvaluatorAdapterInput<RunState, RecordState> {
+  readonly identity: RuntimeIdentity;
+  readonly sessionIsolationKey: string;
+  readonly resourceLeases: OmkBindingResourceLeaseAccess;
+  readonly implementation: SameProcessEvaluatorImplementation<RunState, RecordState>;
+}
+
+function captureIdentity(identity: RuntimeIdentity): RuntimeIdentity {
+  return deepFreezeCanonicalJson(RuntimeIdentitySchema.parse(structuredClone(identity)));
+}
+
+function assertSessionIsolationKey(value: string): void {
+  if (value.trim() === '') {
+    throw new TypeError('Same-process adapter requires a non-empty sessionIsolationKey.');
+  }
+}
+
+function runScope(sessionIsolationKey: string, runId: string): SameProcessRunScope {
+  return Object.freeze({
+    sessionIsolationKey,
+    runIsolationKey: digestCanonicalJson({
+      derivation: 'omk.same-process-run-isolation/v1',
+      sessionIsolationKey,
+      runId,
+    }),
+  });
+}
+
+function operationScope(
+  scope: SameProcessRunScope,
+  operationKind: 'trial' | 'evaluation-record',
+  operationId: Sha256Digest,
+): SameProcessOperationScope {
+  return Object.freeze({
+    ...scope,
+    operationIsolationKey: digestCanonicalJson({
+      derivation: 'omk.same-process-operation-isolation/v1',
+      runIsolationKey: scope.runIsolationKey,
+      operationKind,
+      operationId,
+    }),
+  });
+}
+
+function once(callback: () => MaybePromise<void>): () => Promise<void> {
+  let result: Promise<void> | undefined;
+  return () => {
+    if (result === undefined) {
+      try {
+        result = Promise.resolve(callback());
+      } catch (error) {
+        result = Promise.reject(error);
+      }
+    }
+    return result;
+  };
+}
+
+function bindMethod<Arguments extends readonly unknown[], Result>(
+  owner: object,
+  method: (...arguments_: Arguments) => Result,
+): (...arguments_: Arguments) => Result {
+  if (typeof method !== 'function') {
+    throw new TypeError('Same-process adapter requires every lifecycle callback.');
+  }
+  return (...arguments_) => Reflect.apply(method, owner, arguments_) as Result;
+}
+
+/**
+ * Bridges a binding-local in-process implementation into the Core Executor port.
+ * Core remains the only owner of retries, timeouts, budgets, and cancellation.
+ */
+export function createSameProcessExecutorAdapter<RunState, TrialState>(
+  input: Readonly<CreateSameProcessExecutorAdapterInput<RunState, TrialState>>,
+): ExecutionExecutor {
+  assertSessionIsolationKey(input.sessionIsolationKey);
+  const identity = captureIdentity(input.identity);
+  const sessionIsolationKey = input.sessionIsolationKey;
+  const resolveResources = bindMethod(input.resourceLeases, input.resourceLeases.forRun);
+  const implementation = Object.freeze({
+    openRun: bindMethod(input.implementation, input.implementation.openRun),
+    openTrial: bindMethod(input.implementation, input.implementation.openTrial),
+    execute: bindMethod(input.implementation, input.implementation.execute),
+    disposeTrial: bindMethod(input.implementation, input.implementation.disposeTrial),
+    disposeRun: bindMethod(input.implementation, input.implementation.disposeRun),
+  });
+  const activeRuns = new Set<string>();
+
+  return Object.freeze({
+    identity,
+    async openRun(run: Readonly<ExecutorRunContext>): Promise<ExecutionExecutorRun> {
+      if (activeRuns.has(run.runId)) {
+        throw new TypeError(`Same-process Executor already owns run "${run.runId}".`);
+      }
+      activeRuns.add(run.runId);
+      const scope = runScope(sessionIsolationKey, run.runId);
+      const activeTrials = new Set<Sha256Digest>();
+      let runDisposed = false;
+      const releaseRunReservation = (): void => {
+        if (runDisposed && activeTrials.size === 0) activeRuns.delete(run.runId);
+      };
+      let resources: OmkBindingResourceLease;
+      let runState: RunState;
+      try {
+        resources = resolveResources(run.runId);
+        runState = await implementation.openRun(Object.freeze({ run, scope, resources }));
+      } catch (error) {
+        activeRuns.delete(run.runId);
+        throw error;
+      }
+      const disposeRun = once(async () => {
+        runDisposed = true;
+        try {
+          await implementation.disposeRun(Object.freeze({ run, runState, scope, resources }));
+        } finally {
+          releaseRunReservation();
+        }
+      });
+
+      return Object.freeze({
+        async openTrial(trial: Readonly<ExecutorTrialContext>): Promise<ExecutionExecutorTrial> {
+          if (runDisposed) {
+            throw new TypeError('Same-process Executor run is already disposed.');
+          }
+          if (activeTrials.has(trial.trialId)) {
+            throw new TypeError(`Same-process Executor already owns trial "${trial.trialId}".`);
+          }
+          activeTrials.add(trial.trialId);
+          const trialScope = operationScope(scope, 'trial', trial.trialId);
+          let trialState: TrialState;
+          try {
+            trialState = await implementation.openTrial(Object.freeze({
+              run,
+              runState,
+              trial,
+              scope: trialScope,
+              resources,
+            }));
+          } catch (error) {
+            activeTrials.delete(trial.trialId);
+            releaseRunReservation();
+            throw error;
+          }
+          let trialDisposed = false;
+          const disposeTrial = once(async () => {
+            trialDisposed = true;
+            try {
+              await implementation.disposeTrial(Object.freeze({
+                run,
+                runState,
+                trial,
+                trialState,
+                scope: trialScope,
+                resources,
+              }));
+            } finally {
+              activeTrials.delete(trial.trialId);
+              releaseRunReservation();
+            }
+          });
+          return Object.freeze({
+            execute: async (attempt: Readonly<ExecutorAttemptContext>) => {
+              if (runDisposed || trialDisposed) {
+                throw new TypeError('Same-process Executor trial is already disposed.');
+              }
+              return implementation.execute(Object.freeze({
+                run,
+                runState,
+                trial,
+                trialState,
+                attempt,
+                scope: trialScope,
+                resources,
+              }));
+            },
+            dispose: disposeTrial,
+          });
+        },
+        dispose: disposeRun,
+      });
+    },
+  });
+}
+
+/**
+ * Bridges a binding-local in-process implementation into the Core Evaluator port.
+ * Returned observations and optional usage stay untouched for Core validation.
+ */
+export function createSameProcessEvaluatorAdapter<RunState, RecordState>(
+  input: Readonly<CreateSameProcessEvaluatorAdapterInput<RunState, RecordState>>,
+): EvaluationEvaluator {
+  assertSessionIsolationKey(input.sessionIsolationKey);
+  const identity = captureIdentity(input.identity);
+  const sessionIsolationKey = input.sessionIsolationKey;
+  const resolveResources = bindMethod(input.resourceLeases, input.resourceLeases.forRun);
+  const implementation = Object.freeze({
+    openRun: bindMethod(input.implementation, input.implementation.openRun),
+    openRecord: bindMethod(input.implementation, input.implementation.openRecord),
+    evaluate: bindMethod(input.implementation, input.implementation.evaluate),
+    disposeRecord: bindMethod(input.implementation, input.implementation.disposeRecord),
+    disposeRun: bindMethod(input.implementation, input.implementation.disposeRun),
+  });
+  const activeRuns = new Set<string>();
+
+  return Object.freeze({
+    identity,
+    async openRun(run: Readonly<EvaluatorRunContext>): Promise<EvaluationEvaluatorRun> {
+      if (activeRuns.has(run.runId)) {
+        throw new TypeError(`Same-process Evaluator already owns run "${run.runId}".`);
+      }
+      activeRuns.add(run.runId);
+      const scope = runScope(sessionIsolationKey, run.runId);
+      const activeRecords = new Set<Sha256Digest>();
+      let runDisposed = false;
+      const releaseRunReservation = (): void => {
+        if (runDisposed && activeRecords.size === 0) activeRuns.delete(run.runId);
+      };
+      let resources: OmkBindingResourceLease;
+      let runState: RunState;
+      try {
+        resources = resolveResources(run.runId);
+        runState = await implementation.openRun(Object.freeze({ run, scope, resources }));
+      } catch (error) {
+        activeRuns.delete(run.runId);
+        throw error;
+      }
+      const disposeRun = once(async () => {
+        runDisposed = true;
+        try {
+          await implementation.disposeRun(Object.freeze({ run, runState, scope, resources }));
+        } finally {
+          releaseRunReservation();
+        }
+      });
+
+      return Object.freeze({
+        async openRecord(
+          record: Readonly<EvaluatorRecordContext>,
+        ): Promise<EvaluationEvaluatorRecord> {
+          if (runDisposed) {
+            throw new TypeError('Same-process Evaluator run is already disposed.');
+          }
+          if (activeRecords.has(record.evaluationId)) {
+            throw new TypeError(
+              `Same-process Evaluator already owns record "${record.evaluationId}".`,
+            );
+          }
+          activeRecords.add(record.evaluationId);
+          const recordScope = operationScope(
+            scope,
+            'evaluation-record',
+            record.evaluationId,
+          );
+          let recordState: RecordState;
+          try {
+            recordState = await implementation.openRecord(Object.freeze({
+              run,
+              runState,
+              record,
+              scope: recordScope,
+              resources,
+            }));
+          } catch (error) {
+            activeRecords.delete(record.evaluationId);
+            releaseRunReservation();
+            throw error;
+          }
+          let recordDisposed = false;
+          const disposeRecord = once(async () => {
+            recordDisposed = true;
+            try {
+              await implementation.disposeRecord(Object.freeze({
+                run,
+                runState,
+                record,
+                recordState,
+                scope: recordScope,
+                resources,
+              }));
+            } finally {
+              activeRecords.delete(record.evaluationId);
+              releaseRunReservation();
+            }
+          });
+          return Object.freeze({
+            evaluate: async (attempt: Readonly<EvaluatorAttemptContext>) => {
+              if (runDisposed || recordDisposed) {
+                throw new TypeError('Same-process Evaluator record is already disposed.');
+              }
+              return implementation.evaluate(Object.freeze({
+                run,
+                runState,
+                record,
+                recordState,
+                attempt,
+                scope: recordScope,
+                resources,
+              }));
+            },
+            dispose: disposeRecord,
+          });
+        },
+        dispose: disposeRun,
+      });
+    },
+  });
+}

--- a/src/eval-workflows/runtime-adapter/index.ts
+++ b/src/eval-workflows/runtime-adapter/index.ts
@@ -1,4 +1,5 @@
 export * from './assembly.js';
+export * from './adapters/index.js';
 export * from './builtins.js';
 export * from './composition.js';
 export * from './resource-leases/index.js';

--- a/test/eval-workflows/runtime-adapter/assembly.test.ts
+++ b/test/eval-workflows/runtime-adapter/assembly.test.ts
@@ -30,6 +30,8 @@ import {
   assembleOmkRuntimeBindings,
   createBuiltinOmkAnalysisBindingFactories,
   createOmkEvaluationRuntime,
+  createSameProcessEvaluatorAdapter,
+  createSameProcessExecutorAdapter,
   resourceLeaseRequestsFromBindingEntries,
   type OmkBindingResourceLease,
   type OmkBindingResourceLeaseRequest,
@@ -347,34 +349,41 @@ function runnableFactoriesFor(
       const resolved = await factory(context);
       return {
         ...resolved,
-        port: {
+        port: createSameProcessExecutorAdapter({
           identity: resolved.port.identity,
-          async openRun(runContext) {
-            const lease = context.resourceLeases.forRun(runContext.runId);
-            lifecycle.push(`executor.open:${runContext.runId}:${lease.bindingId}`);
-            return {
-              async openTrial() {
-                return {
-                  async execute() {
-                    if (executeGate !== undefined) await executeGate;
-                    return {
-                      output: {
-                        value: { answer: 'A' },
-                        classification: 'public' as const,
-                      },
-                      trace: {
-                        value: { source: 'test-runtime' },
-                        classification: 'public' as const,
-                      },
-                    };
-                  },
-                  dispose() { lifecycle.push(`executor.trial.dispose:${runContext.runId}`); },
-                };
-              },
-              dispose() { lifecycle.push(`executor.run.dispose:${runContext.runId}`); },
-            };
+          sessionIsolationKey: context.sessionIsolationKey,
+          resourceLeases: context.resourceLeases,
+          implementation: {
+            openRun({ run, resources }) {
+              lifecycle.push(`executor.open:${run.runId}:${resources.bindingId}`);
+              return { runId: run.runId };
+            },
+            openTrial({ trial }) { return { trialId: trial.trialId }; },
+            async execute({ trial, attempt }) {
+              if (attempt.signal.aborted) throw attempt.signal.reason;
+              if (executeGate !== undefined) await executeGate;
+              if (attempt.signal.aborted) throw attempt.signal.reason;
+              const trialInput = trial.input as Readonly<Record<string, JsonValue>>;
+              const answer = typeof trialInput.question === 'string'
+                ? trialInput.question.replace(/^Q/, 'A')
+                : 'test-output';
+              return {
+                output: {
+                  value: { answer },
+                  classification: 'public' as const,
+                },
+                trace: {
+                  value: { source: 'test.omk.same-process-executor/v1' },
+                  classification: 'public' as const,
+                },
+              };
+            },
+            disposeTrial({ run }) {
+              lifecycle.push(`executor.trial.dispose:${run.runId}`);
+            },
+            disposeRun({ run }) { lifecycle.push(`executor.run.dispose:${run.runId}`); },
           },
-        },
+        }),
       };
     });
   }
@@ -384,51 +393,60 @@ function runnableFactoriesFor(
       const resolved = await factory(context);
       return {
         ...resolved,
-        port: {
+        port: createSameProcessEvaluatorAdapter({
           identity: resolved.port.identity,
-          async openRun(runContext) {
-            const lease = context.resourceLeases.forRun(runContext.runId);
-            lifecycle.push(`evaluator.open:${runContext.runId}:${lease.bindingId}`);
-            return {
-              async openRecord(recordContext) {
-                return {
-                  async evaluate() {
-                    return {
-                      observations: recordContext.metrics.map((metric) => {
-                        if (metric.valueType === 'numeric') return {
-                          metricId: metric.metricId,
-                          observationStatus: 'observed' as const,
-                          valueType: metric.valueType,
-                          value: 1,
-                        };
-                        if (metric.valueType === 'boolean') return {
-                          metricId: metric.metricId,
-                          observationStatus: 'observed' as const,
-                          valueType: metric.valueType,
-                          value: true,
-                        };
-                        if (metric.valueType === 'ranking') return {
-                          metricId: metric.metricId,
-                          observationStatus: 'observed' as const,
-                          valueType: metric.valueType,
-                          value: ['A'],
-                        };
-                        return {
-                          metricId: metric.metricId,
-                          observationStatus: 'observed' as const,
-                          valueType: metric.valueType,
-                          value: 'A',
-                        };
-                      }),
-                    };
-                  },
-                  dispose() { lifecycle.push(`evaluator.record.dispose:${runContext.runId}`); },
-                };
-              },
-              dispose() { lifecycle.push(`evaluator.run.dispose:${runContext.runId}`); },
-            };
+          sessionIsolationKey: context.sessionIsolationKey,
+          resourceLeases: context.resourceLeases,
+          implementation: {
+            openRun({ run, resources }) {
+              lifecycle.push(`evaluator.open:${run.runId}:${resources.bindingId}`);
+              return { runId: run.runId };
+            },
+            openRecord({ record }) { return { evaluationId: record.evaluationId }; },
+            async evaluate({ record, attempt }) {
+              if (attempt.signal.aborted) throw attempt.signal.reason;
+              const actual = record.bindings.find((binding) => binding.bindingId === 'actual')?.value;
+              const expected = record.bindings.find((binding) => (
+                binding.bindingId === 'expected'
+              ))?.value;
+              const equivalent = actual === undefined || expected === undefined
+                ? record.bindings.length > 0
+                : JSON.stringify(actual) === JSON.stringify(expected);
+              return {
+                observations: record.metrics.map((metric) => {
+                  if (metric.valueType === 'numeric') return {
+                    metricId: metric.metricId,
+                    observationStatus: 'observed' as const,
+                    valueType: metric.valueType,
+                    value: equivalent ? (metric.scale?.max ?? 1) : (metric.scale?.min ?? 0),
+                  };
+                  if (metric.valueType === 'boolean') return {
+                    metricId: metric.metricId,
+                    observationStatus: 'observed' as const,
+                    valueType: metric.valueType,
+                    value: equivalent,
+                  };
+                  if (metric.valueType === 'ranking') return {
+                    metricId: metric.metricId,
+                    observationStatus: 'observed' as const,
+                    valueType: metric.valueType,
+                    value: record.bindings.map((binding) => binding.bindingId),
+                  };
+                  return {
+                    metricId: metric.metricId,
+                    observationStatus: 'observed' as const,
+                    valueType: metric.valueType,
+                    value: equivalent ? 'equivalent' : 'different',
+                  };
+                }),
+              };
+            },
+            disposeRecord({ run }) {
+              lifecycle.push(`evaluator.record.dispose:${run.runId}`);
+            },
+            disposeRun({ run }) { lifecycle.push(`evaluator.run.dispose:${run.runId}`); },
           },
-        },
+        }),
       };
     });
   }

--- a/test/eval-workflows/runtime-adapter/same-process.test.ts
+++ b/test/eval-workflows/runtime-adapter/same-process.test.ts
@@ -1,0 +1,563 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  digestCanonicalJson,
+  type JsonValue,
+  type RuntimeIdentity,
+  type SchemaIdentity,
+  type Sha256Digest,
+} from '../../../src/index.js';
+import type {
+  EvaluatorRecordContext,
+  EvaluatorRunContext,
+} from '../../../src/evaluation-core/evaluation/index.js';
+import type {
+  ExecutorRunContext,
+  ExecutorTrialContext,
+} from '../../../src/evaluation-core/execution/index.js';
+import {
+  createSameProcessEvaluatorAdapter,
+  createSameProcessExecutorAdapter,
+  type OmkBindingResourceLease,
+  type OmkBindingResourceLeaseAccess,
+  type SameProcessOperationScope,
+} from '../../../src/eval-workflows/runtime-adapter/index.js';
+
+function digest(value: JsonValue): Sha256Digest {
+  return digestCanonicalJson(value);
+}
+
+function schema(name: string): SchemaIdentity {
+  return {
+    schemaVersion: `test.omk.${name}/v1`,
+    schemaUri: `urn:test:omk:${name}:v1`,
+    schemaDigest: digest({ name }),
+  };
+}
+
+function executorIdentity(implementationId = 'test.omk.same-process-executor/v1'): RuntimeIdentity {
+  const capabilities = {
+    protocols: [{
+      protocolId: 'omk.invoke/v1' as const,
+      inputSchema: schema('invoke-input'),
+      outputSchema: schema('invoke-output'),
+      execution: {
+        concurrency: { safety: 'parallel-safe' as const },
+        cancellation: 'cooperative' as const,
+        state: {
+          resourceLifecycle: 'per-run' as const,
+          trialState: 'isolated' as const,
+        },
+        seedControl: 'optional' as const,
+        determinism: 'deterministic' as const,
+        telemetry: {
+          trace: 'optional' as const,
+          usage: 'optional' as const,
+        },
+      },
+    }],
+  };
+  return {
+    implementationId,
+    version: '1.0.0',
+    fingerprint: digest({ implementationId, capabilities }),
+    fingerprintBasis: 'content-derived',
+    assuranceLevel: 'verified',
+    capabilities,
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
+  };
+}
+
+function evaluatorIdentity(): RuntimeIdentity {
+  const implementationId = 'test.omk.same-process-evaluator/v1';
+  const capabilities = {
+    inputSourceKinds: ['output', 'expected'] as const,
+    metricValueTypes: ['boolean'] as const,
+    schemas: [],
+  };
+  return {
+    implementationId,
+    version: '1.0.0',
+    fingerprint: digest({ implementationId, capabilities }),
+    fingerprintBasis: 'content-derived',
+    assuranceLevel: 'verified',
+    capabilities,
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
+  };
+}
+
+function resourceAccess(
+  bindingId: string,
+  consumerKind: 'executor' | 'evaluator',
+  calls: string[] = [],
+): OmkBindingResourceLeaseAccess {
+  return {
+    forRun(runId): OmkBindingResourceLease {
+      calls.push(`${bindingId}:${runId}`);
+      return Object.freeze({
+        bindingId,
+        consumerKind,
+        resourcesByResourceId: new Map(),
+      });
+    },
+  };
+}
+
+function executorRun(runId = 'run-a'): ExecutorRunContext {
+  return {
+    runId,
+    executionPlanDigest: digest({ runId, stage: 'execution' }),
+  };
+}
+
+function executorTrial(trialLabel = 'trial-a'): ExecutorTrialContext {
+  return {
+    targetId: 'target-a',
+    protocolId: 'omk.invoke/v1',
+    input: { prompt: 'hello' },
+    targetConfig: { runtime: { model: 'test-model' } },
+    trialIndex: 0,
+    trialId: digest({ trialLabel }),
+    schedulingBlockId: digest({ trialLabel, block: 0 }),
+    samplingUnitIds: {},
+    trialSeed: digest({ trialLabel, seed: 0 }),
+  };
+}
+
+function evaluatorRun(runId = 'run-a'): EvaluatorRunContext {
+  return {
+    runId,
+    evaluationPlanDigest: digest({ runId, stage: 'evaluation' }),
+  };
+}
+
+function evaluatorRecord(recordLabel = 'record-a'): EvaluatorRecordContext {
+  return {
+    targetId: 'target-a',
+    sampleId: 'sample-a',
+    trialIndex: 0,
+    trialId: digest({ recordLabel, trial: 0 }),
+    evaluatorId: 'exact',
+    measurement: {
+      instrumentId: 'test.omk.exact/v1',
+      ensembleMemberId: 'local',
+      replicateGroupId: 'primary',
+      replicateIndex: 0,
+    },
+    evaluationId: digest({ recordLabel }),
+    bindings: [{
+      bindingId: 'actual',
+      sourceKind: 'output',
+      value: { answer: 'A' },
+      classification: 'public',
+    }, {
+      bindingId: 'expected',
+      sourceKind: 'expected',
+      value: { answer: 'A' },
+      classification: 'gold',
+    }],
+    metrics: [{
+      metricId: 'correct',
+      valueType: 'boolean',
+      scope: 'sample',
+      direction: 'higher-is-better',
+      missingPolicyId: 'exclude/v1',
+    }],
+  };
+}
+
+describe('same-process Runtime adapters', () => {
+  it('forwards the native Executor signal and sealed contexts without retries or usage synthesis', async () => {
+    const leaseCalls: string[] = [];
+    const callbackOrder: string[] = [];
+    let capturedSignal: AbortSignal | undefined;
+    let capturedScope: SameProcessOperationScope | undefined;
+    const identity = executorIdentity();
+    const port = createSameProcessExecutorAdapter({
+      identity,
+      sessionIsolationKey: 'binding-scope-a',
+      resourceLeases: resourceAccess('executor-a', 'executor', leaseCalls),
+      implementation: {
+        openRun({ run, resources }) {
+          callbackOrder.push(`run.open:${run.runId}:${resources.bindingId}`);
+          return { opened: run.runId };
+        },
+        openTrial({ trial, runState, scope }) {
+          callbackOrder.push(`trial.open:${runState.opened}:${trial.targetId}`);
+          capturedScope = scope;
+          return { seed: trial.trialSeed };
+        },
+        async execute({ attempt, trial, trialState, scope }) {
+          callbackOrder.push(`execute:${attempt.attemptNumber}`);
+          capturedSignal = attempt.signal;
+          expect(trialState.seed).toBe(trial.trialSeed);
+          expect(scope).toBe(capturedScope);
+          return {
+            output: { value: { echoed: trial.input }, classification: 'public' },
+          };
+        },
+        disposeTrial({ run }) { callbackOrder.push(`trial.dispose:${run.runId}`); },
+        disposeRun({ run }) { callbackOrder.push(`run.dispose:${run.runId}`); },
+      },
+    });
+    const runContext = executorRun();
+    const trialContext = executorTrial();
+    const run = await port.openRun(runContext);
+    const trial = await run.openTrial(trialContext);
+    const controller = new AbortController();
+    const result = await trial.execute({
+      attemptId: digest({ attempt: 1 }),
+      attemptNumber: 1,
+      signal: controller.signal,
+    });
+
+    expect(capturedSignal).toBe(controller.signal);
+    expect(capturedScope?.sessionIsolationKey).toBe('binding-scope-a');
+    expect(capturedScope?.runIsolationKey).not.toBe(capturedScope?.operationIsolationKey);
+    expect(result).not.toHaveProperty('usage');
+    expect(leaseCalls).toEqual(['executor-a:run-a']);
+    await trial.dispose();
+    await trial.dispose();
+    await run.dispose();
+    await run.dispose();
+    expect(callbackOrder).toEqual([
+      'run.open:run-a:executor-a',
+      'trial.open:run-a:target-a',
+      'execute:1',
+      'trial.dispose:run-a',
+      'run.dispose:run-a',
+    ]);
+  });
+
+  it('lets cooperative Executor cancellation reach and settle the underlying call', async () => {
+    const executeCalls = vi.fn();
+    let observedSignal: AbortSignal | undefined;
+    const port = createSameProcessExecutorAdapter({
+      identity: executorIdentity(),
+      sessionIsolationKey: 'binding-scope-a',
+      resourceLeases: resourceAccess('executor-a', 'executor'),
+      implementation: {
+        openRun() { return {}; },
+        openTrial() { return {}; },
+        async execute({ attempt }) {
+          executeCalls();
+          observedSignal = attempt.signal;
+          await new Promise<never>((_resolve, reject) => {
+            if (attempt.signal.aborted) reject(attempt.signal.reason);
+            else attempt.signal.addEventListener(
+              'abort',
+              () => reject(attempt.signal.reason),
+              { once: true },
+            );
+          });
+          throw new Error('unreachable');
+        },
+        disposeTrial() {},
+        disposeRun() {},
+      },
+    });
+    const run = await port.openRun(executorRun());
+    const trial = await run.openTrial(executorTrial());
+    const controller = new AbortController();
+    const cause = new Error('stop underlying work');
+    const executing = trial.execute({
+      attemptId: digest({ attempt: 'cancel' }),
+      attemptNumber: 1,
+      signal: controller.signal,
+    });
+    controller.abort(cause);
+
+    await expect(executing).rejects.toBe(cause);
+    expect(observedSignal).toBe(controller.signal);
+    expect(executeCalls).toHaveBeenCalledTimes(1);
+    await trial.dispose();
+    await run.dispose();
+  });
+
+  it('isolates concurrent runs and binding instances with derived scope keys', async () => {
+    const scopes: Array<{ bindingId: string; runId: string; scope: SameProcessOperationScope }> = [];
+    const implementation = {
+      openRun: ({ run }: { run: Readonly<ExecutorRunContext> }) => ({ runId: run.runId }),
+      openTrial: ({ scope, resources, runState }: {
+        scope: SameProcessOperationScope;
+        resources: OmkBindingResourceLease;
+        runState: { runId: string };
+      }) => {
+        scopes.push({ bindingId: resources.bindingId, runId: runState.runId, scope });
+        return {};
+      },
+      async execute() { return {}; },
+      disposeTrial() {},
+      disposeRun() {},
+    };
+    const first = createSameProcessExecutorAdapter({
+      identity: executorIdentity(),
+      sessionIsolationKey: 'binding-scope-a',
+      resourceLeases: resourceAccess('executor-a', 'executor'),
+      implementation,
+    });
+    const second = createSameProcessExecutorAdapter({
+      identity: executorIdentity(),
+      sessionIsolationKey: 'binding-scope-b',
+      resourceLeases: resourceAccess('executor-b', 'executor'),
+      implementation,
+    });
+    const [runA, runB, runC] = await Promise.all([
+      first.openRun(executorRun('run-a')),
+      first.openRun(executorRun('run-b')),
+      second.openRun(executorRun('run-a')),
+    ]);
+    const [trialA, trialB, trialC] = await Promise.all([
+      runA.openTrial(executorTrial('trial-a')),
+      runB.openTrial(executorTrial('trial-a')),
+      runC.openTrial(executorTrial('trial-a')),
+    ]);
+
+    expect(new Set(scopes.map((entry) => entry.scope.runIsolationKey)).size).toBe(3);
+    expect(new Set(scopes.map((entry) => entry.scope.operationIsolationKey)).size).toBe(3);
+    expect(scopes.map(({ bindingId, runId }) => `${bindingId}:${runId}`).sort()).toEqual([
+      'executor-a:run-a',
+      'executor-a:run-b',
+      'executor-b:run-a',
+    ]);
+    await Promise.all([trialA.dispose(), trialB.dispose(), trialC.dispose()]);
+    await Promise.all([runA.dispose(), runB.dispose(), runC.dispose()]);
+  });
+
+  it('releases a failed openRun reservation and captures an immutable identity snapshot', async () => {
+    const sourceIdentity = executorIdentity();
+    let calls = 0;
+    const leaseResolver = resourceAccess('executor-a', 'executor') as {
+      forRun(runId: string): OmkBindingResourceLease;
+    };
+    const implementation = {
+      openRun() {
+        calls += 1;
+        if (calls === 1) throw new Error('open failed');
+        return {};
+      },
+      openTrial() { return {}; },
+      async execute() { return {}; },
+      disposeTrial() {},
+      disposeRun() {},
+    };
+    const port = createSameProcessExecutorAdapter({
+      identity: sourceIdentity,
+      sessionIsolationKey: 'binding-scope-a',
+      resourceLeases: leaseResolver,
+      implementation,
+    });
+    sourceIdentity.implementationId = 'test.omk.mutated/v1';
+    implementation.openRun = () => { throw new Error('mutated implementation'); };
+    leaseResolver.forRun = () => { throw new Error('mutated lease resolver'); };
+
+    await expect(port.openRun(executorRun())).rejects.toThrow('open failed');
+    const reopened = await port.openRun(executorRun());
+    expect(port.identity.implementationId).toBe('test.omk.same-process-executor/v1');
+    expect(Object.isFrozen(port.identity)).toBe(true);
+    expect(calls).toBe(2);
+    await reopened.dispose();
+  });
+
+  it('closes Executor lifecycle boundaries without releasing a live trial reservation', async () => {
+    let trialDisposals = 0;
+    let runDisposals = 0;
+    const port = createSameProcessExecutorAdapter({
+      identity: executorIdentity(),
+      sessionIsolationKey: 'binding-scope-a',
+      resourceLeases: resourceAccess('executor-a', 'executor'),
+      implementation: {
+        openRun() { return {}; },
+        openTrial() { return {}; },
+        async execute() { return {}; },
+        disposeTrial() { trialDisposals += 1; },
+        disposeRun() { runDisposals += 1; },
+      },
+    });
+    const run = await port.openRun(executorRun());
+    const trial = await run.openTrial(executorTrial());
+    await expect(run.openTrial(executorTrial())).rejects.toThrow('already owns trial');
+    const disposingRun = run.dispose();
+
+    await expect(run.openTrial(executorTrial('trial-b'))).rejects.toThrow('already disposed');
+    await expect(trial.execute({
+      attemptId: digest({ attempt: 'after-run-dispose' }),
+      attemptNumber: 1,
+      signal: new AbortController().signal,
+    })).rejects.toThrow('already disposed');
+    await expect(port.openRun(executorRun())).rejects.toThrow('already owns run');
+    await disposingRun;
+
+    const disposingTrial = trial.dispose();
+    await expect(trial.execute({
+      attemptId: digest({ attempt: 'during-trial-dispose' }),
+      attemptNumber: 1,
+      signal: new AbortController().signal,
+    })).rejects.toThrow('already disposed');
+    await disposingTrial;
+    const reopened = await port.openRun(executorRun());
+    await reopened.dispose();
+    expect(trialDisposals).toBe(1);
+    expect(runDisposals).toBe(2);
+  });
+
+  it('releases a disposed run when an in-flight trial open subsequently fails', async () => {
+    let rejectTrial: ((error: Error) => void) | undefined;
+    const port = createSameProcessExecutorAdapter({
+      identity: executorIdentity(),
+      sessionIsolationKey: 'binding-scope-a',
+      resourceLeases: resourceAccess('executor-a', 'executor'),
+      implementation: {
+        openRun() { return {}; },
+        openTrial() {
+          return new Promise<never>((_resolve, reject) => { rejectTrial = reject; });
+        },
+        async execute() { return {}; },
+        disposeTrial() {},
+        disposeRun() {},
+      },
+    });
+    const run = await port.openRun(executorRun());
+    const opening = expect(run.openTrial(executorTrial())).rejects.toThrow('trial failed');
+    await run.dispose();
+    await expect(port.openRun(executorRun())).rejects.toThrow('already owns run');
+    rejectTrial?.(new Error('trial failed'));
+    await opening;
+
+    const reopened = await port.openRun(executorRun());
+    await reopened.dispose();
+  });
+
+  it('forwards Evaluator records and signal without manufacturing usage or scores', async () => {
+    const callbacks: string[] = [];
+    let observedSignal: AbortSignal | undefined;
+    const port = createSameProcessEvaluatorAdapter({
+      identity: evaluatorIdentity(),
+      sessionIsolationKey: 'evaluator-scope-a',
+      resourceLeases: resourceAccess('evaluator-a', 'evaluator'),
+      implementation: {
+        openRun({ run }) {
+          callbacks.push(`run.open:${run.runId}`);
+          return { runId: run.runId };
+        },
+        openRecord({ record }) {
+          callbacks.push(`record.open:${record.evaluationId}`);
+          return { actual: record.bindings[0]?.value };
+        },
+        async evaluate({ record, recordState, attempt }) {
+          observedSignal = attempt.signal;
+          const expected = record.bindings.find((binding) => (
+            binding.bindingId === 'expected'
+          ))?.value;
+          return {
+            observations: [{
+              metricId: 'correct',
+              observationStatus: 'observed',
+              valueType: 'boolean',
+              value: JSON.stringify(recordState.actual) === JSON.stringify(expected),
+            }],
+          };
+        },
+        disposeRecord() { callbacks.push('record.dispose'); },
+        disposeRun() { callbacks.push('run.dispose'); },
+      },
+    });
+    const run = await port.openRun(evaluatorRun());
+    const record = await run.openRecord(evaluatorRecord());
+    const controller = new AbortController();
+    const result = await record.evaluate({
+      attemptId: digest({ evaluatorAttempt: 1 }),
+      attemptNumber: 1,
+      signal: controller.signal,
+    });
+
+    expect(observedSignal).toBe(controller.signal);
+    expect(result.observations).toEqual([expect.objectContaining({ value: true })]);
+    expect(result).not.toHaveProperty('usage');
+    await record.dispose();
+    await record.dispose();
+    await run.dispose();
+    await run.dispose();
+    expect(callbacks).toEqual([
+      'run.open:run-a',
+      `record.open:${evaluatorRecord().evaluationId}`,
+      'record.dispose',
+      'run.dispose',
+    ]);
+  });
+
+  it('closes Evaluator lifecycle boundaries and releases failed record opens', async () => {
+    let recordOpenCalls = 0;
+    const port = createSameProcessEvaluatorAdapter({
+      identity: evaluatorIdentity(),
+      sessionIsolationKey: 'evaluator-scope-a',
+      resourceLeases: resourceAccess('evaluator-a', 'evaluator'),
+      implementation: {
+        openRun() { return {}; },
+        openRecord() {
+          recordOpenCalls += 1;
+          if (recordOpenCalls === 1) throw new Error('record open failed');
+          return {};
+        },
+        async evaluate() { return { observations: [] }; },
+        disposeRecord() {},
+        disposeRun() {},
+      },
+    });
+    const run = await port.openRun(evaluatorRun());
+    await expect(run.openRecord(evaluatorRecord())).rejects.toThrow('record open failed');
+    const record = await run.openRecord(evaluatorRecord());
+    await expect(run.openRecord(evaluatorRecord())).rejects.toThrow('already owns record');
+    await record.dispose();
+    await run.dispose();
+
+    await expect(run.openRecord(evaluatorRecord('record-b'))).rejects.toThrow('already disposed');
+    await expect(record.evaluate({
+      attemptId: digest({ attempt: 'after-record-dispose' }),
+      attemptNumber: 1,
+      signal: new AbortController().signal,
+    })).rejects.toThrow('already disposed');
+    expect(recordOpenCalls).toBe(2);
+  });
+
+  it('fails invalid adapter configuration before resolving any run lease', () => {
+    const leaseCalls: string[] = [];
+    const invalidIdentity = { ...executorIdentity(), fingerprint: '' };
+    expect(() => createSameProcessExecutorAdapter({
+      identity: invalidIdentity,
+      sessionIsolationKey: 'binding-scope-a',
+      resourceLeases: resourceAccess('executor-a', 'executor', leaseCalls),
+      implementation: {
+        openRun() { return {}; },
+        openTrial() { return {}; },
+        async execute() { return {}; },
+        disposeTrial() {},
+        disposeRun() {},
+      },
+    })).toThrow();
+    expect(() => createSameProcessExecutorAdapter({
+      identity: executorIdentity(),
+      sessionIsolationKey: '   ',
+      resourceLeases: resourceAccess('executor-a', 'executor', leaseCalls),
+      implementation: {
+        openRun() { return {}; },
+        openTrial() { return {}; },
+        async execute() { return {}; },
+        disposeTrial() {},
+        disposeRun() {},
+      },
+    })).toThrow('non-empty sessionIsolationKey');
+    expect(() => createSameProcessExecutorAdapter({
+      identity: executorIdentity(),
+      sessionIsolationKey: 'binding-scope-a',
+      resourceLeases: resourceAccess('executor-a', 'executor', leaseCalls),
+      implementation: {
+        openRun() { return {}; },
+        openTrial() { return {}; },
+        execute: undefined,
+        disposeTrial() {},
+        disposeRun() {},
+      },
+    } as never)).toThrow('every lifecycle callback');
+    expect(leaseCalls).toEqual([]);
+  });
+});

--- a/test/eval-workflows/runtime-adapter/same-process.test.ts
+++ b/test/eval-workflows/runtime-adapter/same-process.test.ts
@@ -69,9 +69,9 @@ function executorIdentity(implementationId = 'test.omk.same-process-executor/v1'
 
 function evaluatorIdentity(): RuntimeIdentity {
   const implementationId = 'test.omk.same-process-evaluator/v1';
-  const capabilities = {
-    inputSourceKinds: ['output', 'expected'] as const,
-    metricValueTypes: ['boolean'] as const,
+  const capabilities: JsonValue = {
+    inputSourceKinds: ['output', 'expected'],
+    metricValueTypes: ['boolean'],
     schemas: [],
   };
   return {


### PR DESCRIPTION
## 用户影响

- 为 Evaluation Core 宿主增加 binding-local 的 same-process Executor／Evaluator 基准适配层，显式传递 identity、资源 lease、隔离键与原生取消信号。
- 正式 `omk eval`、旧 Report 与旧 pipeline 不变，不双跑、不双写。

## 迁移说明

本次是增量内部能力，不改变现有 CLI 或已发布 schema，无需迁移。

## 测量与架构说明

- retry、timeout、budget、cache 与取消策略仍只由 sealed Core Policy 驱动；adapter 不建立第二套策略。
- identity、实现回调和 lease resolver 在构造期捕获，避免封存身份与实际算法发生 split-brain。
- 未报告 usage／cost 保持缺失，不投影为测量零值。
- conformance 实现位于独立 `test.*` namespace，结果由输入与 binding 派生，仅验证真实 Core prepare／run 接线，不冒充生产评分算法。

Refs #457。