### PR TITLE
feat(eval-core)!: BREAKING-SCHEMA 建立 Target 与 Runtime capability 协商

### DIFF
--- a/docs/specs/cli-evaluation-input-compilation.md
+++ b/docs/specs/cli-evaluation-input-compilation.md
@@ -36,7 +36,7 @@ EvaluationPresentationOptions + static RunOptions metadata
 
 - `EvaluationDefinition` owns data projections, Target behavior, evaluator instruments, metrics, experiment design, analysis, comparisons, and decision policy.
 - `MeasurementPolicy` owns execution/evaluation concurrency, timeout, retry, cache, evidence, failure, event delivery, and the shared Run budget ledger.
-- `RuntimeBindingRequest` v2 contains only implementation and resource-lease requirements derived from Definition／resolved host resources. A registry may resolve them, but cannot override model, effort, prompt variant, protocol, evaluator identity, or behavior config. Its complete assembly contract is specified in [Evaluation Runtime Adapter](./evaluation-runtime-adapter.md).
+- `RuntimeBindingRequest` v3 contains only implementation and resource-lease requirements derived from Definition／resolved host resources. Executor qualification reuses the exact canonical `TargetDefinition.executionRequirements`; it does not maintain a second approximation. A registry may resolve bindings, but cannot override execution requirements, model, effort, prompt variant, protocol, evaluator identity, or behavior config. Its complete assembly contract is specified in [Evaluation Runtime Adapter](./evaluation-runtime-adapter.md).
 - `ResolvedHostResources` binds a stable resource ID and digest to an effect locator. It is not a Core schema and never enters canonical measurement JSON.
 - `EvaluationOrchestrationOptions` owns dry-run, resume locator, batch, independent Series repeats, preflight switches, diagnostic post-processing, gold post-hoc workflows, and managed-evidence append behavior.
 - `EvaluationPresentationOptions` owns output locator, index scope, language, server, verbosity, layered view, and CLI exit presentation. None changes `DecisionResult`.
@@ -49,6 +49,7 @@ EvaluationPresentationOptions + static RunOptions metadata
 Behavior identity and source lineage are separate axes:
 
 - Target config contains the bytes/configuration that affect behavior as `{resourceId, digest, mediaType, classification}` descriptors, plus normalized workspace, tool, mock, sandbox, model, and effort facts.
+- Target `executionRequirements` is derived purely from resolved behavior: explicit system-instruction use, copy-on-write workspace, native MCP config, pre-tool-call mock interception, tool allow-list, skill-discovery policy, and sandbox ID. It enters Definition and ExecutionPlan identity; only Core prepare may compare it with Runtime features.
 - Host resources contain locator, resolved commit, repository origin, and materialization evidence. Moving the same content between absolute/relative paths or machines does not invalidate execution identity.
 - A behavior change changes the Definition digest. A lineage-only change is assessed later by explicit comparability and provenance policy, not smuggled into Target config.
 
@@ -108,6 +109,8 @@ Parse and compilation errors are host `CliEvaluationInputError` values with stab
 ## 6. Migration boundary
 
 This layer is additive. The production `omk eval` command continues to use `RunConfig → runEvaluation → executeEvaluationPipeline`; it does not double-run, shadow-run, persist Core Bundles, or change legacy reports. A later Runtime-adapter change may consume only the contracts emitted here and may not parse CLI inputs again.
+
+Target execution requirements make the migration contracts intentionally incompatible: resolved compiler input is `omk.resolved-cli-evaluation-input/v2`, and binding output is `omk.runtime-binding-request/v3`. Earlier shapes are rejected without inference or a compatibility reader. The Core v1 Definition／Plan JSON Schemas gain a required Target field and this change is released as `BREAKING-SCHEMA`; no scoring or statistical comparability invariant changes.
 
 The legacy `--no-cache`／`noCache` boolean has no faithful Core equivalent: its enabled state meant stochastic read-through execution reuse and said nothing about Evaluation cache. The registry therefore marks it for replacement rather than mapping it to `transparent-deterministic` or `reuse`. The final cutover may remove the old cache files and behavior without a compatibility reader.
 

--- a/docs/specs/evaluation-core-vnext.md
+++ b/docs/specs/evaluation-core-vnext.md
@@ -160,6 +160,15 @@ interface TargetDefinition {
   protocolId: string;
   executorId: string;
   versionConstraint?: string;
+  executionRequirements: {
+    systemInstructions: 'required' | 'not-required';
+    workspace: 'copy-on-write-overlay' | 'not-required';
+    mcp: 'native-config' | 'not-required';
+    mockInterception: 'pre-tool-call' | 'not-required';
+    toolPolicy: 'runtime-default' | 'allow-list';
+    skillDiscovery: 'runtime-default' | 'disabled' | 'allow-list';
+    sandboxId?: string;
+  };
   config?: JsonValue;
 }
 ```
@@ -171,7 +180,11 @@ v1 defines only two built-in protocol families:
 - `omk.invoke/v1`: one structured request/response per trial with an optional source-neutral trace; covers pure functions, models, services, RAG, and stateless workflows.
 - `omk.session/v1`: an isolated session lifecycle per trial with multi-turn messages, tool calls, and partial trajectories; covers agents and stateful workflows.
 
-Every protocol manifest also declares structured execution capabilities: concurrency safety and limits, cancellation semantics, run resource lifecycle, trial state, seed control, determinism, and trace/usage telemetry. Run-scoped resources may reuse infrastructure such as connection pools and clients; business state remains isolated per trial for `omk.session/v1`, while `omk.invoke/v1` remains stateless. A runtime declaring `cancellation: unsupported` cannot be combined with a timeout policy. A stochastic Runtime without seed control can use only an `uncontrolled` seed design. Transparent Execution cache hits require both deterministic capability and verified Runtime assurance.
+Every protocol manifest also declares structured execution capabilities: concurrency safety and limits, cancellation semantics, run resource lifecycle, trial state, seed control, determinism, trace/usage telemetry, and a closed `features` object. `features` records the actual system-instruction delivery mode (`native`, `prepended`, or `unsupported`) plus canonical, duplicate-free sets for workspace lease modes, MCP modes, mock-interception modes, tool-policy modes, skill-discovery modes, and sandbox IDs. Empty sets and `unsupported` are explicit; absence is invalid.
+
+The complete manifest is the independently published `omk.executor-capabilities/v1` wire contract. Its JSON Schema identity is sealed into every Run contract, while each Runtime's concrete capability value remains sealed in `RuntimeIdentity`. Validator semantics and implementation claims therefore cannot change behind unchanged plan identity.
+
+Core matches `executionRequirements` only against the selected protocol during prepare. A mismatch fails with `EVAL_DEFINITION_CAPABILITY_UNSUPPORTED` before any Runtime `openRun()`. System-instruction `native` and `prepended` both satisfy `required`, but the actual mode remains sealed in `RuntimeIdentity`, so they are different execution designs. Model, effort, provider deployment, effective tool schemas, resource bytes, and locators are not capabilities: behavior facts remain in Target config or Runtime implementation identity, while verified resource acquisition remains host-owned. Run-scoped resources may reuse infrastructure such as connection pools and clients; business state remains isolated per trial for `omk.session/v1`, while `omk.invoke/v1` remains stateless. A runtime declaring `cancellation: unsupported` cannot be combined with a timeout policy. A stochastic Runtime without seed control can use only an `uncontrolled` seed design. Transparent Execution cache hits require both deterministic capability and verified Runtime assurance.
 
 Importing host-executed results is not a third execution protocol; Core validates and accepts an ExecutionBundle directly. Protocol IDs are immutable contracts. Incompatible changes use a new major path, while optional capabilities may only add behavior without changing existing field semantics.
 
@@ -854,7 +867,7 @@ These decisions close the architectural choices required before Contracts. Confo
 
 The first implementation phase is tracked by [#427](https://github.com/lizhiyao/oh-my-knowledge/issues/427). Its source of truth is isolated under `src/evaluation-core/contracts/`; it does not import the historical `src/eval-core/`, CLI, executor, grading, renderer, or server layers.
 
-The catalog currently publishes fourteen JSON Schema 2020-12 roots under `schemas/evaluation-core/v1/`: EvaluationDefinition, MeasurementPolicy, four stage Plans plus RunPlan, ComparabilityPolicy, ComparabilityAssessment, Event, three Bundles, and EvaluationReport. TypeScript types are inferred from the same Zod 4 schemas. `yarn build:schemas` regenerates the files, while `yarn build` checks committed output for drift and copies it into the package build.
+The catalog currently publishes twenty JSON Schema 2020-12 roots under `schemas/evaluation-core/v1/`: ExecutorCapabilities, EvaluationDefinition, MeasurementPolicy, four stage Plans plus RunPlan, ComparabilityPolicy, ComparabilityAssessment, Event, BudgetSummary, three single-Run Bundles, EvaluationReport, and four Evaluation Series contracts. TypeScript types are inferred from the same Zod 4 schemas. `yarn build:schemas` regenerates the files, while `yarn build` checks committed output for drift and copies it into the package build.
 
 Wire entry points use `parseWireDocument()` rather than a bare schema parse. It first rejects values that cannot be represented as I-JSON or JCS input, including non-finite numbers, functions, symbols, cycles, sparse arrays, accessor properties, class instances, and unpaired Unicode surrogates, and then applies the Zod schema. Hosts accepting raw JSON text must additionally reject duplicate property names before constructing a JavaScript value because duplicates are no longer observable after ordinary `JSON.parse()`.
 

--- a/docs/specs/evaluation-runtime-adapter.md
+++ b/docs/specs/evaluation-runtime-adapter.md
@@ -36,7 +36,7 @@ Assembly requires one exact binding for every:
 
 An analysis binding carries both `referenceId` and Core's `requirementKind`. Sampling Estimator is therefore not inferred from an AnalysisGraph node or silently resolved from a fallback registry.
 
-This complete shape is `omk.runtime-binding-request/v2`. The incomplete migration-only v1 request is rejected rather than read through a compatibility branch.
+This complete shape is `omk.runtime-binding-request/v3`. The superseded v2 request lacks the canonical Target execution requirements and is rejected rather than read through a compatibility branch.
 
 Before invoking any factory, assembly validates unique binding IDs and reference keys, exact Definition／Series coverage, implementation and version constraints, executor protocol／model／effort／behavior digest, evaluator measurement／config digest, and resource lease requirements. A validation failure causes zero factory calls.
 
@@ -44,7 +44,7 @@ Before invoking any factory, assembly validates unique binding IDs and reference
 
 Assembly first clones and deep-freezes Definition, Series, and RuntimeBindingRequest. Each implementation factory is selected by `implementationId`, but it is called once per binding so two references using the same implementation receive distinct port instances.
 
-The factory returns the actual port identity and version-resolution result. Assembly validates the port shape and implementation identity, captures an immutable identity snapshot, and wraps the port methods around the original instance. The Core preparation resolver and the captured execution port are then projected from the same entry; later registry or request mutation cannot create split-brain resolution.
+The factory returns the actual port identity and version-resolution result. Assembly validates the port shape and implementation identity, captures an immutable identity snapshot, and wraps the port methods around the original instance. Executor binding validation also requires exact equality with `TargetDefinition.executionRequirements`; the qualification object reuses that canonical value rather than re-deriving feature semantics. The Core preparation resolver and the captured execution port are then projected from the same entry; later registry or request mutation cannot create split-brain resolution. Only Core compares those requirements with the actual port capability manifest.
 
 Every entry records:
 

--- a/docs/zh/specs/cli-evaluation-input-compilation.md
+++ b/docs/zh/specs/cli-evaluation-input-compilation.md
@@ -36,7 +36,7 @@ EvaluationPresentationOptions + static RunOptions metadata
 
 - `EvaluationDefinition` 负责数据投影、Target 行为、evaluator instrument、metric、实验设计、分析、比较和决策策略；
 - `MeasurementPolicy` 负责 execution／evaluation concurrency、timeout、retry、cache、evidence、failure、event delivery 和共享 Run 预算账本；
-- `RuntimeBindingRequest` v2 只保存从 Definition／已解析宿主资源派生的 implementation 和 resource lease requirement。宿主 registry 可以解析实现，但不能覆盖 model、effort、prompt variant、protocol、evaluator identity 或行为配置。完整装配契约见 [Evaluation Runtime Adapter 规范](./evaluation-runtime-adapter.md)；
+- `RuntimeBindingRequest` v3 只保存从 Definition／已解析宿主资源派生的 implementation 和 resource lease requirement。Executor qualification 直接复用 canonical `TargetDefinition.executionRequirements`，不维护第二份近似语义。宿主 registry 可以解析 binding，但不能覆盖 execution requirement、model、effort、prompt variant、protocol、evaluator identity 或行为配置。完整装配契约见 [Evaluation Runtime Adapter 规范](./evaluation-runtime-adapter.md)；
 - `ResolvedHostResources` 用稳定 resource ID 和 digest 绑定 effect locator。它不是 Core schema，也不进入 canonical measurement JSON；
 - `EvaluationOrchestrationOptions` 负责 dry-run、resume locator、batch、独立 Series repeat、preflight 开关、diagnostic 后处理、gold post-hoc workflow 和受管证据追加；
 - `EvaluationPresentationOptions` 负责输出 locator、索引范围、语言、server、verbose、layered view 和 CLI exit 展示。这些字段都不能改变 `DecisionResult`；
@@ -49,6 +49,7 @@ EvaluationPresentationOptions + static RunOptions metadata
 行为身份和来源 lineage 是两条不同轴：
 
 - Target config 通过 `{resourceId, digest, mediaType, classification}` descriptor 保存会影响行为的字节／配置，并包含规范化的 workspace、tool、mock、sandbox、model 和 effort 事实；
+- Target `executionRequirements` 从 resolved behavior 纯确定地派生：显式 system instruction 使用、copy-on-write workspace、native MCP config、pre-tool-call mock interception、tool allow-list、skill discovery policy 和 sandbox ID。它进入 Definition 与 ExecutionPlan identity，只有 Core prepare 可以把它与 Runtime feature 做匹配；
 - Host resources 保存 locator、resolved commit、仓库来源和 materialization 证据。同一内容在绝对／相对路径或不同机器间移动，不会让 execution identity 失效；
 - 行为变化会改变 Definition digest。只有 lineage 变化时，后续由显式 comparability／provenance policy 判断，不能偷偷塞进 Target config。
 
@@ -108,6 +109,8 @@ Parse 和 Compile 错误使用宿主 `CliEvaluationInputError`，包含稳定 co
 ## 六、迁移边界
 
 本层是增量架构。正式 `omk eval` 仍走 `RunConfig → runEvaluation → executeEvaluationPipeline`；不双跑、不 shadow run、不持久化 Core Bundle，也不改变旧 Report。后续 Runtime adapter 只能消费这里产出的 contract，不能重新解析 CLI 输入。
+
+Target execution requirement 会让迁移 contract 有意不兼容：resolved compiler input 升级为 `omk.resolved-cli-evaluation-input/v2`，binding output 升级为 `omk.runtime-binding-request/v3`。旧结构会直接被拒绝，不做推断，也不提供 compatibility reader。Core v1 Definition／Plan JSON Schema 增加 Target 必填字段，本次改动按 `BREAKING-SCHEMA` 发布；评分与统计可比性不变量不变。
 
 旧 `--no-cache`／`noCache` boolean 没有忠实的 Core 等价语义：它的 enabled 状态表示 stochastic read-through execution reuse，却没有表达 Evaluation cache。Registry 因此把它标记为 replace，不再映射成 `transparent-deterministic` 或 `reuse`。最终切换可以直接删除旧 cache 文件与旧行为，不保留 compatibility reader。
 

--- a/docs/zh/specs/evaluation-core-vnext.md
+++ b/docs/zh/specs/evaluation-core-vnext.md
@@ -160,6 +160,15 @@ interface TargetDefinition {
   protocolId: string;
   executorId: string;
   versionConstraint?: string;
+  executionRequirements: {
+    systemInstructions: 'required' | 'not-required';
+    workspace: 'copy-on-write-overlay' | 'not-required';
+    mcp: 'native-config' | 'not-required';
+    mockInterception: 'pre-tool-call' | 'not-required';
+    toolPolicy: 'runtime-default' | 'allow-list';
+    skillDiscovery: 'runtime-default' | 'disabled' | 'allow-list';
+    sandboxId?: string;
+  };
   config?: JsonValue;
 }
 ```
@@ -171,7 +180,11 @@ v1 只内建两个 protocol family：
 - `omk.invoke/v1`：一个 trial 对应一次结构化 request／response，可附 source-neutral trace；覆盖纯函数、模型、服务、RAG 和无会话 Workflow；
 - `omk.session/v1`：一个 trial 拥有独立 session lifecycle，支持多轮消息、工具调用和部分 trajectory；覆盖 Agent 和有状态 Workflow。
 
-每个 protocol manifest 还必须声明结构化 execution capability：并发安全性与上限、取消语义、run resource lifecycle、trial state、seed control、determinism，以及 trace／usage telemetry。run-scoped resource 只允许连接池、客户端等基础设施复用；`omk.session/v1` 的业务状态始终按 trial 隔离，`omk.invoke/v1` 的 trial state 始终 stateless。声明 `cancellation: unsupported` 的实现不能与 timeout policy 组合；随机 Runtime 若不支持 seed，只能使用 `uncontrolled` seed design；只有 determinism 与 Runtime assurance 都为 verified 的实现才能透明命中 Execution cache。
+每个 protocol manifest 还必须声明结构化 execution capability：并发安全性与上限、取消语义、run resource lifecycle、trial state、seed control、determinism、trace／usage telemetry，以及封闭的 `features` object。`features` 保存实际 system instruction 投递模式（`native`、`prepended` 或 `unsupported`），以及 workspace lease mode、MCP mode、mock interception mode、tool policy mode、skill discovery mode 和 sandbox ID 的 canonical、无重复集合。空集合与 `unsupported` 必须显式表达，字段缺失属于非法。
+
+完整 manifest 是独立发布的 `omk.executor-capabilities/v1` wire contract。它的 JSON Schema identity 会进入每份 Run contract，而各 Runtime 的实际 capability value 仍封存在 `RuntimeIdentity` 中。因此，validator 语义与实现声明都不能藏在未变化的 plan identity 背后漂移。
+
+Core 只在 prepare 阶段把 `executionRequirements` 与选中的 protocol 做匹配。任何不满足都以 `EVAL_DEFINITION_CAPABILITY_UNSUPPORTED` 在 Runtime `openRun()` 前 fail closed。System instruction 的 `native` 与 `prepended` 都能满足 `required`，但实际 mode 会进入 sealed `RuntimeIdentity`，因此仍属于不同 execution design。Model、effort、provider deployment、effective tool schema、资源字节和 locator 都不能伪装成 capability：行为事实留在 Target config 或 Runtime implementation identity，verified resource acquisition 继续由宿主持有。run-scoped resource 只允许连接池、客户端等基础设施复用；`omk.session/v1` 的业务状态始终按 trial 隔离，`omk.invoke/v1` 的 trial state 始终 stateless。声明 `cancellation: unsupported` 的实现不能与 timeout policy 组合；随机 Runtime 若不支持 seed，只能使用 `uncontrolled` seed design；只有 determinism 与 Runtime assurance 都为 verified 的实现才能透明命中 Execution cache。
 
 导入宿主已经执行好的结果不属于第三个执行协议，而是直接校验并接收 ExecutionBundle。protocol ID 是不可变契约；不兼容修改发布新 major path，可选能力只能做不改变既有字段语义的追加。
 
@@ -853,7 +866,7 @@ ExecutionBundle 以 `runContractDigest` 和 `datasetRevisionDigest` 记录产出
 
 第一阶段实现由 [#427](https://github.com/lizhiyao/oh-my-knowledge/issues/427) 跟踪。单一来源隔离在 `src/evaluation-core/contracts/`，不导入历史 `src/eval-core/`、CLI、executor、grading、renderer 或 server 层。
 
-Catalog 当前在 `schemas/evaluation-core/v1/` 发布十四个 JSON Schema 2020-12 根契约：EvaluationDefinition、MeasurementPolicy、四个阶段 Plan 与 RunPlan、ComparabilityPolicy、ComparabilityAssessment、Event、三个 Bundle、EvaluationReport。TypeScript 类型从同一组 Zod 4 schema 推导。`yarn build:schemas` 重新生成文件；`yarn build` 检查已提交产物是否漂移，并把它们复制到 package build。
+Catalog 当前在 `schemas/evaluation-core/v1/` 发布二十个 JSON Schema 2020-12 根契约：ExecutorCapabilities、EvaluationDefinition、MeasurementPolicy、四个阶段 Plan 与 RunPlan、ComparabilityPolicy、ComparabilityAssessment、Event、BudgetSummary、三个单 Run Bundle、EvaluationReport，以及四个 Evaluation Series 契约。TypeScript 类型从同一组 Zod 4 schema 推导。`yarn build:schemas` 重新生成文件；`yarn build` 检查已提交产物是否漂移，并把它们复制到 package build。
 
 Wire 入口使用 `parseWireDocument()`，不直接裸调 schema parse。它先拒绝不能表示为 I-JSON 或 JCS 输入的值，包括非有限数、函数、symbol、循环引用、稀疏数组、accessor property、class instance 和未配对 Unicode surrogate，再执行 Zod schema 校验。宿主若接收原始 JSON 文本，还必须在构造 JavaScript 值前拒绝重复属性名，因为普通 `JSON.parse()` 完成后已无法观测重复键。
 

--- a/docs/zh/specs/evaluation-runtime-adapter.md
+++ b/docs/zh/specs/evaluation-runtime-adapter.md
@@ -36,7 +36,7 @@ Assembly 要求以下每个引用都有且只有一个 binding：
 
 Analysis binding 同时携带 `referenceId` 和 Core `requirementKind`。Sampling Estimator 不再从 AnalysisGraph node 猜测，也不能由 fallback registry 静默解析。
 
-完整结构使用 `omk.runtime-binding-request/v2`。不完整的迁移期 v1 request 会被直接拒绝，不增加 compatibility 分支。
+完整结构使用 `omk.runtime-binding-request/v3`。已被取代的 v2 request 缺少 canonical Target execution requirement，会被直接拒绝，不增加 compatibility 分支。
 
 调用任何 factory 前，assembly 会验证 binding ID／reference key 唯一性、Definition／Series 精确覆盖、implementation／version、executor protocol／model／effort／behavior digest、evaluator measurement／config digest，以及 resource lease requirement。验证失败时 factory 调用次数必须为零。
 
@@ -44,7 +44,7 @@ Analysis binding 同时携带 `referenceId` 和 Core `requirementKind`。Samplin
 
 Assembly 首先复制并深度冻结 Definition、Series 和 RuntimeBindingRequest。Factory 按 `implementationId` 查找，但按 binding 分别调用，因此共享同一实现的两个 reference 仍得到不同 port instance。
 
-Factory 返回实际 port identity 和 version resolution。Assembly 校验 port 形状与 implementation identity，捕获不可变 identity snapshot，并用原始实例的方法包装 port。Core preparation resolver 和运行 port 由同一个 entry 投影；后续 registry 或请求对象变化不能造成 split-brain。
+Factory 返回实际 port identity 和 version resolution。Assembly 校验 port 形状与 implementation identity，捕获不可变 identity snapshot，并用原始实例的方法包装 port。Executor binding 还必须与 `TargetDefinition.executionRequirements` 精确相等；qualification 直接复用该 canonical 值，不重新派生 feature 语义。Core preparation resolver 和运行 port 由同一个 entry 投影；后续 registry 或请求对象变化不能造成 split-brain。只有 Core 能把 requirements 与实际 port capability manifest 做匹配。
 
 每个 entry 保存：
 

--- a/schemas/evaluation-core/v1/evaluation-definition.schema.json
+++ b/schemas/evaluation-core/v1/evaluation-definition.schema.json
@@ -835,6 +835,66 @@
         "config": {
           "$ref": "#/$defs/__schema4"
         },
+        "executionRequirements": {
+          "additionalProperties": false,
+          "properties": {
+            "mcp": {
+              "enum": [
+                "not-required",
+                "native-config"
+              ],
+              "type": "string"
+            },
+            "mockInterception": {
+              "enum": [
+                "not-required",
+                "pre-tool-call"
+              ],
+              "type": "string"
+            },
+            "sandboxId": {
+              "$ref": "#/$defs/__schema2"
+            },
+            "skillDiscovery": {
+              "enum": [
+                "runtime-default",
+                "disabled",
+                "allow-list"
+              ],
+              "type": "string"
+            },
+            "systemInstructions": {
+              "enum": [
+                "required",
+                "not-required"
+              ],
+              "type": "string"
+            },
+            "toolPolicy": {
+              "enum": [
+                "runtime-default",
+                "allow-list"
+              ],
+              "type": "string"
+            },
+            "workspace": {
+              "enum": [
+                "not-required",
+                "copy-on-write-overlay"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "systemInstructions",
+            "workspace",
+            "mcp",
+            "mockInterception",
+            "toolPolicy",
+            "skillDiscovery"
+          ],
+          "type": "object"
+        },
         "executorId": {
           "$ref": "#/$defs/__schema2"
         },
@@ -859,7 +919,8 @@
         "targetId",
         "targetKind",
         "protocolId",
-        "executorId"
+        "executorId",
+        "executionRequirements"
       ],
       "type": "object"
     },

--- a/schemas/evaluation-core/v1/execution-plan.schema.json
+++ b/schemas/evaluation-core/v1/execution-plan.schema.json
@@ -694,6 +694,66 @@
         "config": {
           "$ref": "#/$defs/__schema5"
         },
+        "executionRequirements": {
+          "additionalProperties": false,
+          "properties": {
+            "mcp": {
+              "enum": [
+                "not-required",
+                "native-config"
+              ],
+              "type": "string"
+            },
+            "mockInterception": {
+              "enum": [
+                "not-required",
+                "pre-tool-call"
+              ],
+              "type": "string"
+            },
+            "sandboxId": {
+              "$ref": "#/$defs/__schema4"
+            },
+            "skillDiscovery": {
+              "enum": [
+                "runtime-default",
+                "disabled",
+                "allow-list"
+              ],
+              "type": "string"
+            },
+            "systemInstructions": {
+              "enum": [
+                "required",
+                "not-required"
+              ],
+              "type": "string"
+            },
+            "toolPolicy": {
+              "enum": [
+                "runtime-default",
+                "allow-list"
+              ],
+              "type": "string"
+            },
+            "workspace": {
+              "enum": [
+                "not-required",
+                "copy-on-write-overlay"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "systemInstructions",
+            "workspace",
+            "mcp",
+            "mockInterception",
+            "toolPolicy",
+            "skillDiscovery"
+          ],
+          "type": "object"
+        },
         "executorId": {
           "$ref": "#/$defs/__schema4"
         },
@@ -718,7 +778,8 @@
         "targetId",
         "targetKind",
         "protocolId",
-        "executorId"
+        "executorId",
+        "executionRequirements"
       ],
       "type": "object"
     },

--- a/schemas/evaluation-core/v1/executor-capabilities.schema.json
+++ b/schemas/evaluation-core/v1/executor-capabilities.schema.json
@@ -1,0 +1,307 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.executor-capabilities/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "items": {
+        "$ref": "#/$defs/__schema2"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema2": {
+      "additionalProperties": false,
+      "properties": {
+        "execution": {
+          "additionalProperties": false,
+          "properties": {
+            "cancellation": {
+              "enum": [
+                "cooperative",
+                "best-effort",
+                "unsupported"
+              ],
+              "type": "string"
+            },
+            "concurrency": {
+              "additionalProperties": false,
+              "properties": {
+                "maxInFlight": {
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991,
+                  "type": "integer"
+                },
+                "safety": {
+                  "enum": [
+                    "serialized",
+                    "parallel-safe"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "safety"
+              ],
+              "type": "object"
+            },
+            "determinism": {
+              "enum": [
+                "deterministic",
+                "stochastic",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "features": {
+              "additionalProperties": false,
+              "properties": {
+                "mcp": {
+                  "items": {
+                    "const": "native-config",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "mockInterception": {
+                  "items": {
+                    "const": "pre-tool-call",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "sandboxIds": {
+                  "items": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "skillDiscovery": {
+                  "items": {
+                    "enum": [
+                      "runtime-default",
+                      "disabled",
+                      "allow-list"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "systemInstructions": {
+                  "enum": [
+                    "native",
+                    "prepended",
+                    "unsupported"
+                  ],
+                  "type": "string"
+                },
+                "toolPolicies": {
+                  "items": {
+                    "enum": [
+                      "runtime-default",
+                      "allow-list"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "workspace": {
+                  "items": {
+                    "const": "copy-on-write-overlay",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "systemInstructions",
+                "workspace",
+                "mcp",
+                "mockInterception",
+                "toolPolicies",
+                "skillDiscovery",
+                "sandboxIds"
+              ],
+              "type": "object"
+            },
+            "seedControl": {
+              "enum": [
+                "unsupported",
+                "optional",
+                "required"
+              ],
+              "type": "string"
+            },
+            "state": {
+              "additionalProperties": false,
+              "properties": {
+                "resourceLifecycle": {
+                  "enum": [
+                    "per-invocation",
+                    "per-run"
+                  ],
+                  "type": "string"
+                },
+                "trialState": {
+                  "enum": [
+                    "stateless",
+                    "isolated"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "resourceLifecycle",
+                "trialState"
+              ],
+              "type": "object"
+            },
+            "telemetry": {
+              "additionalProperties": false,
+              "properties": {
+                "providerCost": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "reporting": {
+                      "$ref": "#/$defs/__schema4"
+                    },
+                    "trustedUpperBound": {
+                      "$ref": "#/$defs/__schema5"
+                    }
+                  },
+                  "required": [
+                    "reporting"
+                  ],
+                  "type": "object"
+                },
+                "trace": {
+                  "enum": [
+                    "unsupported",
+                    "optional",
+                    "required"
+                  ],
+                  "type": "string"
+                },
+                "usage": {
+                  "enum": [
+                    "unsupported",
+                    "optional",
+                    "required"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "trace",
+                "usage"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "concurrency",
+            "cancellation",
+            "state",
+            "seedControl",
+            "determinism",
+            "features",
+            "telemetry"
+          ],
+          "type": "object"
+        },
+        "inputSchema": {
+          "$ref": "#/$defs/__schema3"
+        },
+        "outputSchema": {
+          "$ref": "#/$defs/__schema3"
+        },
+        "protocolId": {
+          "enum": [
+            "omk.invoke/v1",
+            "omk.session/v1"
+          ],
+          "type": "string"
+        },
+        "traceSchema": {
+          "$ref": "#/$defs/__schema3"
+        }
+      },
+      "required": [
+        "protocolId",
+        "inputSchema",
+        "outputSchema",
+        "execution"
+      ],
+      "type": "object"
+    },
+    "__schema3": {
+      "additionalProperties": false,
+      "properties": {
+        "schemaDigest": {
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "schemaUri": {
+          "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+          "type": "string"
+        },
+        "schemaVersion": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "schemaUri",
+        "schemaDigest"
+      ],
+      "type": "object"
+    },
+    "__schema4": {
+      "enum": [
+        "unsupported",
+        "optional",
+        "required"
+      ],
+      "type": "string"
+    },
+    "__schema5": {
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "minimum": 0,
+          "type": "number"
+        },
+        "currency": {
+          "pattern": "^[A-Z]{3}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "amount",
+        "currency"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/evaluation-core/v1/executor-capabilities.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "protocols": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "protocols"
+  ],
+  "title": "OMK Executor Capabilities v1",
+  "type": "object"
+}

--- a/schemas/evaluation-core/v1/run-plan.schema.json
+++ b/schemas/evaluation-core/v1/run-plan.schema.json
@@ -334,6 +334,66 @@
         "config": {
           "$ref": "#/$defs/__schema6"
         },
+        "executionRequirements": {
+          "additionalProperties": false,
+          "properties": {
+            "mcp": {
+              "enum": [
+                "not-required",
+                "native-config"
+              ],
+              "type": "string"
+            },
+            "mockInterception": {
+              "enum": [
+                "not-required",
+                "pre-tool-call"
+              ],
+              "type": "string"
+            },
+            "sandboxId": {
+              "$ref": "#/$defs/__schema4"
+            },
+            "skillDiscovery": {
+              "enum": [
+                "runtime-default",
+                "disabled",
+                "allow-list"
+              ],
+              "type": "string"
+            },
+            "systemInstructions": {
+              "enum": [
+                "required",
+                "not-required"
+              ],
+              "type": "string"
+            },
+            "toolPolicy": {
+              "enum": [
+                "runtime-default",
+                "allow-list"
+              ],
+              "type": "string"
+            },
+            "workspace": {
+              "enum": [
+                "not-required",
+                "copy-on-write-overlay"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "systemInstructions",
+            "workspace",
+            "mcp",
+            "mockInterception",
+            "toolPolicy",
+            "skillDiscovery"
+          ],
+          "type": "object"
+        },
         "executorId": {
           "$ref": "#/$defs/__schema4"
         },
@@ -358,7 +418,8 @@
         "targetId",
         "targetKind",
         "protocolId",
-        "executorId"
+        "executorId",
+        "executionRequirements"
       ],
       "type": "object"
     },

--- a/src/eval-workflows/input-compilation/compile.ts
+++ b/src/eval-workflows/input-compilation/compile.ts
@@ -12,6 +12,7 @@ import {
   type JsonValue,
   type MeasurementPolicy,
   type Sha256Digest,
+  type TargetExecutionRequirements,
 } from '../../evaluation-core/contracts/index.js';
 import {
   EvaluationDefinitionError,
@@ -472,6 +473,26 @@ function behaviorConfig(
   });
 }
 
+function executionRequirementsForBehavior(
+  behavior: ResolvedTargetBehavior,
+): TargetExecutionRequirements {
+  return {
+    systemInstructions: behavior.systemInstructions,
+    workspace: behavior.workspace === undefined ? 'not-required' : 'copy-on-write-overlay',
+    mcp: behavior.mcpConfig === undefined ? 'not-required' : 'native-config',
+    mockInterception: (behavior.mocks?.length ?? 0) === 0
+      ? 'not-required'
+      : 'pre-tool-call',
+    toolPolicy: behavior.allowedTools === undefined ? 'runtime-default' : 'allow-list',
+    skillDiscovery: behavior.allowedSkills === undefined
+      ? 'runtime-default'
+      : behavior.allowedSkills.length === 0
+        ? 'disabled'
+        : 'allow-list',
+    ...(behavior.sandbox === undefined ? {} : { sandboxId: behavior.sandbox.sandboxId }),
+  };
+}
+
 function evaluatorConfig(
   template: ResolvedEvaluatorTemplate,
   member?: ResolvedJudgeMember,
@@ -621,6 +642,7 @@ function compileDefinition(input: ResolvedCliEvaluationInput): EvaluationDefinit
       ...(target.executor.versionConstraint === undefined
         ? {}
         : { versionConstraint: target.executor.versionConstraint }),
+      executionRequirements: executionRequirementsForBehavior(target.behavior),
       config: behaviorConfig(target.behavior, target.executor),
     }));
   const analysisNodes = [...input.analysisGraph.nodes]
@@ -930,18 +952,7 @@ function compileRuntimeBinding(
       qualification: {
         model: resolved.executor.model,
         ...(resolved.executor.effort === undefined ? {} : { effort: resolved.executor.effort }),
-        workspace: resolved.behavior.workspace === undefined ? 'not-required' : 'required',
-        mcp: resolved.behavior.mcpConfig === undefined ? 'not-required' : 'required',
-        mockInterception: resolved.behavior.mocks === undefined ? 'not-required' : 'required',
-        toolPolicy: resolved.behavior.allowedTools === undefined ? 'runtime-default' : 'allow-list',
-        skillDiscovery: resolved.behavior.allowedSkills === undefined
-          ? 'runtime-default'
-          : resolved.behavior.allowedSkills.length === 0
-            ? 'disabled'
-            : 'allow-list',
-        ...(resolved.behavior.sandbox === undefined
-          ? {}
-          : { sandboxId: resolved.behavior.sandbox.sandboxId }),
+        executionRequirements: target.executionRequirements,
         resourceIntegrity: 'digest-before-use',
       },
     });

--- a/src/eval-workflows/input-compilation/types.ts
+++ b/src/eval-workflows/input-compilation/types.ts
@@ -11,16 +11,17 @@ import type {
   MeasurementPolicy,
   MetricDefinition,
   Sha256Digest,
+  TargetExecutionRequirements,
 } from '../../evaluation-core/contracts/index.js';
 
 export const CLI_EVALUATION_REQUEST_SCHEMA_VERSION =
   'omk.cli-evaluation-request/v1' as const;
 export const RESOLVED_CLI_EVALUATION_INPUT_SCHEMA_VERSION =
-  'omk.resolved-cli-evaluation-input/v1' as const;
+  'omk.resolved-cli-evaluation-input/v2' as const;
 export const RESOLVED_HOST_RESOURCES_SCHEMA_VERSION =
   'omk.resolved-host-resources/v2' as const;
 export const RUNTIME_BINDING_REQUEST_SCHEMA_VERSION =
-  'omk.runtime-binding-request/v2' as const;
+  'omk.runtime-binding-request/v3' as const;
 
 export type CliEvaluationFieldSource = { readonly normalizedField: string } & (
   | {
@@ -179,6 +180,7 @@ export interface ResolvedInlineConfig {
 }
 
 export interface ResolvedTargetBehavior {
+  readonly systemInstructions: TargetExecutionRequirements['systemInstructions'];
   readonly artifact: ResolvedResourceDescriptor;
   readonly workspace?: ResolvedResourceDescriptor;
   readonly mcpConfig?: ResolvedResourceDescriptor;
@@ -362,12 +364,7 @@ export type RuntimeBinding =
       readonly qualification: {
         readonly model: string;
         readonly effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
-        readonly workspace: 'required' | 'not-required';
-        readonly mcp: 'required' | 'not-required';
-        readonly mockInterception: 'required' | 'not-required';
-        readonly toolPolicy: 'allow-list' | 'runtime-default';
-        readonly skillDiscovery: 'disabled' | 'allow-list' | 'runtime-default';
-        readonly sandboxId?: string;
+        readonly executionRequirements: TargetExecutionRequirements;
         readonly resourceIntegrity: 'digest-before-use';
       };
     }

--- a/src/eval-workflows/runtime-adapter/assembly.ts
+++ b/src/eval-workflows/runtime-adapter/assembly.ts
@@ -286,6 +286,8 @@ function assertExecutorBinding(
       || binding.behaviorConfigDigest !== digestCanonicalJson(target.config ?? null)
       || canonicalizeJson(binding.resourceLeaseRequirements)
         !== canonicalizeJson(expectedExecutorResourceRequirements(target))
+      || canonicalizeJson(binding.qualification.executionRequirements)
+        !== canonicalizeJson(target.executionRequirements)
       || binding.qualification.model !== runtime?.model
       || binding.qualification.effort !== expectedEffort) fail({
     code: 'OMK_RUNTIME_BINDING_DEFINITION_MISMATCH',
@@ -686,7 +688,10 @@ function sameRequirement(
         ? requirement.versionConstraint
         : undefined)) return false;
   if (binding.runtimeKind === 'executor') {
-    return 'protocolId' in requirement && binding.protocolId === requirement.protocolId;
+    return 'protocolId' in requirement
+      && binding.protocolId === requirement.protocolId
+      && canonicalizeJson(binding.qualification.executionRequirements)
+        === canonicalizeJson(requirement.executionRequirements);
   }
   if (binding.runtimeKind === 'analysis-node') {
     return 'requirementKind' in requirement

--- a/src/evaluation-core/compiler/index.ts
+++ b/src/evaluation-core/compiler/index.ts
@@ -28,6 +28,7 @@ import {
   type ResolvedRuntime,
   type RuntimeIdentity,
   type SchemaIdentity,
+  type TargetExecutionRequirements,
 } from '../contracts/index.js';
 import {
   EvaluationDefinitionError,
@@ -79,6 +80,12 @@ const CONTRACT_PATH_SEGMENTS = new Set([
   'cohortId', 'cohortSetId', 'cohortSetKind', 'classification', 'disclosure',
   'derivation', 'algorithmId', 'membershipValue', 'context', 'annotations', 'targets',
   'targetId', 'targetKind', 'protocolId', 'executorId', 'versionConstraint', 'config',
+  'executionRequirements', 'systemInstructions', 'workspace', 'mcp',
+  'mockInterception', 'toolPolicy', 'toolPolicies', 'skillDiscovery',
+  'sandboxId', 'sandboxIds', 'protocols', 'inputSchema', 'outputSchema', 'traceSchema',
+  'concurrency', 'safety', 'maxInFlight', 'cancellation', 'state',
+  'resourceLifecycle', 'trialState', 'seedControl', 'determinism', 'features',
+  'telemetry', 'usage', 'providerCost', 'reporting', 'trustedUpperBound',
   'evaluators', 'evaluatorId', 'evaluatorKind', 'implementationId', 'measurement',
   'instrumentId', 'ensembleMemberId', 'replicateGroupId', 'replicateIndex', 'metricIds',
   'inputs', 'bindingId', 'sourceKind', 'pointer', 'metrics', 'metricId', 'valueType',
@@ -162,12 +169,99 @@ function bindCapabilities(
 
 function normalizeExecutorCapabilities(
   capabilities: ExecutorCapabilities,
+  referenceId: string,
 ): ExecutorCapabilities {
   return {
-    protocols: [...capabilities.protocols].sort((left, right) => (
-      compareStrings(left.protocolId, right.protocolId)
-    )),
+    schemaVersion: capabilities.schemaVersion,
+    protocols: capabilities.protocols.map((protocol) => ({
+      ...protocol,
+      execution: {
+        ...protocol.execution,
+        features: {
+          ...protocol.execution.features,
+          workspace: sortedUniqueStrings(
+            protocol.execution.features.workspace,
+            referenceId,
+            `${protocol.protocolId}.features.workspace`,
+          ) as typeof protocol.execution.features.workspace,
+          mcp: sortedUniqueStrings(
+            protocol.execution.features.mcp,
+            referenceId,
+            `${protocol.protocolId}.features.mcp`,
+          ) as typeof protocol.execution.features.mcp,
+          mockInterception: sortedUniqueStrings(
+            protocol.execution.features.mockInterception,
+            referenceId,
+            `${protocol.protocolId}.features.mockInterception`,
+          ) as typeof protocol.execution.features.mockInterception,
+          toolPolicies: sortedUniqueStrings(
+            protocol.execution.features.toolPolicies,
+            referenceId,
+            `${protocol.protocolId}.features.toolPolicies`,
+          ) as typeof protocol.execution.features.toolPolicies,
+          skillDiscovery: sortedUniqueStrings(
+            protocol.execution.features.skillDiscovery,
+            referenceId,
+            `${protocol.protocolId}.features.skillDiscovery`,
+          ) as typeof protocol.execution.features.skillDiscovery,
+          sandboxIds: sortedUniqueStrings(
+            protocol.execution.features.sandboxIds,
+            referenceId,
+            `${protocol.protocolId}.features.sandboxIds`,
+          ),
+        },
+      },
+    })).sort((left, right) => compareStrings(left.protocolId, right.protocolId)),
   };
+}
+
+function assertExecutionRequirementsSupported(
+  referenceId: string,
+  requirements: TargetExecutionRequirements,
+  features: ExecutorCapabilities['protocols'][number]['execution']['features'],
+): void {
+  const unsupported = (
+    field: keyof TargetExecutionRequirements,
+    required: string,
+    supported: readonly string[],
+  ): never => {
+    throw new EvaluationDefinitionError({
+      code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      stage: 'configuration',
+      preparationStage: 'runtime-resolution',
+      message: 'Target execution requirement 不受 Runtime 支持。',
+      details: { referenceId, field, required, supported: [...supported] },
+    });
+  };
+  if (requirements.systemInstructions === 'required'
+      && features.systemInstructions === 'unsupported') {
+    unsupported('systemInstructions', 'required', [features.systemInstructions]);
+  }
+  if (requirements.workspace !== 'not-required'
+      && !features.workspace.includes(requirements.workspace)) {
+    unsupported('workspace', requirements.workspace, features.workspace);
+  }
+  if (requirements.mcp !== 'not-required' && !features.mcp.includes(requirements.mcp)) {
+    unsupported('mcp', requirements.mcp, features.mcp);
+  }
+  if (requirements.mockInterception !== 'not-required'
+      && !features.mockInterception.includes(requirements.mockInterception)) {
+    unsupported(
+      'mockInterception',
+      requirements.mockInterception,
+      features.mockInterception,
+    );
+  }
+  if (!features.toolPolicies.includes(requirements.toolPolicy)) {
+    unsupported('toolPolicy', requirements.toolPolicy, features.toolPolicies);
+  }
+  if (!features.skillDiscovery.includes(requirements.skillDiscovery)) {
+    unsupported('skillDiscovery', requirements.skillDiscovery, features.skillDiscovery);
+  }
+  if (requirements.sandboxId !== undefined
+      && !features.sandboxIds.includes(requirements.sandboxId)) {
+    unsupported('sandboxId', requirements.sandboxId, features.sandboxIds);
+  }
 }
 
 function normalizeEvaluatorCapabilities(
@@ -451,6 +545,7 @@ async function resolveExecutors(
           ? { versionConstraint: target.versionConstraint }
           : {}),
         protocolId: target.protocolId,
+        executionRequirements: target.executionRequirements,
       }))),
     );
     assertVersionSatisfied(
@@ -464,6 +559,7 @@ async function resolveExecutors(
         resolution.identity.capabilities,
         target.targetId,
       ),
+      target.targetId,
     );
     const protocolIds = capabilities.protocols.map((protocol) => protocol.protocolId);
     if (new Set(protocolIds).size !== protocolIds.length) {
@@ -487,6 +583,11 @@ async function resolveExecutors(
         details: { referenceId: target.targetId, protocolId: target.protocolId },
       });
     }
+    assertExecutionRequirementsSupported(
+      target.targetId,
+      target.executionRequirements,
+      protocol.execution.features,
+    );
     const expectedTrialState = target.protocolId === 'omk.session/v1'
       ? 'isolated'
       : 'stateless';

--- a/src/evaluation-core/compiler/types.ts
+++ b/src/evaluation-core/compiler/types.ts
@@ -1,49 +1,19 @@
 import { z } from 'zod';
 import {
+  ExecutorCapabilitiesSchema,
+  ProtocolManifestSchema,
   RuntimeIdentitySchema,
   SchemaIdentitySchema,
   type CoreSchemaValidator,
+  type ExecutorCapabilities,
   type ExtensionEntry,
+  type ProtocolManifest,
+  type TargetExecutionRequirements,
 } from '../contracts/index.js';
 export type { DeepReadonly, SealedRunPlan } from '../internal/sealed-run-plan.js';
 
-export const ProtocolManifestSchema = z.object({
-  protocolId: z.enum(['omk.invoke/v1', 'omk.session/v1']),
-  inputSchema: SchemaIdentitySchema,
-  outputSchema: SchemaIdentitySchema,
-  traceSchema: SchemaIdentitySchema.optional(),
-  execution: z.object({
-    concurrency: z.object({
-      safety: z.enum(['serialized', 'parallel-safe']),
-      maxInFlight: z.number().int().positive().optional(),
-    }).strict(),
-    cancellation: z.enum(['cooperative', 'best-effort', 'unsupported']),
-    state: z.object({
-      resourceLifecycle: z.enum(['per-invocation', 'per-run']),
-      trialState: z.enum(['stateless', 'isolated']),
-    }).strict(),
-    seedControl: z.enum(['unsupported', 'optional', 'required']),
-    determinism: z.enum(['deterministic', 'stochastic', 'unknown']),
-    telemetry: z.object({
-      trace: z.enum(['unsupported', 'optional', 'required']),
-      usage: z.enum(['unsupported', 'optional', 'required']),
-      providerCost: z.object({
-        reporting: z.enum(['unsupported', 'optional', 'required']),
-        trustedUpperBound: z.object({
-          amount: z.number().nonnegative(),
-          currency: z.string().regex(/^[A-Z]{3}$/),
-        }).strict().optional(),
-      }).strict().refine(
-        (value) => value.trustedUpperBound === undefined || value.reporting === 'required',
-        { message: 'A trusted provider-cost bound requires required reporting.' },
-      ).optional(),
-    }).strict(),
-  }).strict(),
-}).strict();
-
-export const ExecutorCapabilitiesSchema = z.object({
-  protocols: z.array(ProtocolManifestSchema).min(1),
-}).strict();
+export { ExecutorCapabilitiesSchema, ProtocolManifestSchema };
+export type { ExecutorCapabilities, ProtocolManifest };
 
 export const EvaluatorCapabilitiesSchema = z.object({
   inputSourceKinds: z.array(z.enum([
@@ -172,8 +142,6 @@ export const ExtensionResolutionSchema = z.object({
   impactStage: ExtensionImpactStageSchema,
 }).strict();
 
-export type ProtocolManifest = z.infer<typeof ProtocolManifestSchema>;
-export type ExecutorCapabilities = z.infer<typeof ExecutorCapabilitiesSchema>;
 export type EvaluatorCapabilities = z.infer<typeof EvaluatorCapabilitiesSchema>;
 export type AnalysisCapabilities = z.infer<typeof AnalysisCapabilitiesSchema>;
 export type AnalysisNodeCapabilities = z.infer<typeof AnalysisNodeCapabilitiesSchema>;
@@ -188,6 +156,7 @@ export interface ExecutorRuntimeRequirement {
   executorId: string;
   versionConstraint?: string;
   protocolId: 'omk.invoke/v1' | 'omk.session/v1';
+  executionRequirements: TargetExecutionRequirements;
 }
 
 export interface EvaluatorRuntimeRequirement {

--- a/src/evaluation-core/contracts/definition.ts
+++ b/src/evaluation-core/contracts/definition.ts
@@ -60,12 +60,23 @@ export const EvaluationSeriesMembershipSchema = z.object({
   replicateIndex: z.number().int().nonnegative(),
 }).strict();
 
+export const TargetExecutionRequirementsSchema = z.object({
+  systemInstructions: z.enum(['required', 'not-required']),
+  workspace: z.enum(['not-required', 'copy-on-write-overlay']),
+  mcp: z.enum(['not-required', 'native-config']),
+  mockInterception: z.enum(['not-required', 'pre-tool-call']),
+  toolPolicy: z.enum(['runtime-default', 'allow-list']),
+  skillDiscovery: z.enum(['runtime-default', 'disabled', 'allow-list']),
+  sandboxId: IdentifierSchema.optional(),
+}).strict();
+
 export const TargetDefinitionSchema = z.object({
   targetId: IdentifierSchema,
   targetKind: IdentifierSchema,
   protocolId: z.enum(['omk.invoke/v1', 'omk.session/v1']),
   executorId: IdentifierSchema,
   versionConstraint: NonEmptyStringSchema.optional(),
+  executionRequirements: TargetExecutionRequirementsSchema,
   config: JsonValueSchema.optional(),
 }).strict();
 
@@ -368,6 +379,7 @@ export type EvaluationSample = z.infer<typeof EvaluationSampleSchema>;
 export type AnalysisCohortDefinition = z.infer<typeof AnalysisCohortDefinitionSchema>;
 export type AnalysisSampleInput = z.infer<typeof AnalysisSampleInputSchema>;
 export type EvaluationDataset = z.infer<typeof EvaluationDatasetSchema>;
+export type TargetExecutionRequirements = z.infer<typeof TargetExecutionRequirementsSchema>;
 export type TargetDefinition = z.infer<typeof TargetDefinitionSchema>;
 export type EvaluatorDefinition = z.infer<typeof EvaluatorDefinitionSchema>;
 export type MetricDefinition = z.infer<typeof MetricDefinitionSchema>;

--- a/src/evaluation-core/contracts/index.ts
+++ b/src/evaluation-core/contracts/index.ts
@@ -14,4 +14,5 @@ export * from './evaluation-report.js';
 export * from './json-schema.js';
 export * from './json.js';
 export * from './plans.js';
+export * from './runtime-capabilities.js';
 export * from './series.js';

--- a/src/evaluation-core/contracts/json-schema.ts
+++ b/src/evaluation-core/contracts/json-schema.ts
@@ -51,6 +51,10 @@ import {
   SERIES_ANALYSIS_BUNDLE_SCHEMA_VERSION,
   SeriesAnalysisBundleSchema,
 } from './series.js';
+import {
+  EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
+  ExecutorCapabilitiesSchema,
+} from './runtime-capabilities.js';
 
 export interface WireSchemaCatalogEntry {
   fileName: string;
@@ -60,6 +64,11 @@ export interface WireSchemaCatalogEntry {
 }
 
 export const WIRE_SCHEMA_CATALOG: readonly WireSchemaCatalogEntry[] = [
+  {
+    fileName: 'executor-capabilities.schema.json',
+    schemaVersion: EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
+    schema: ExecutorCapabilitiesSchema,
+  },
   {
     fileName: 'evaluation-definition.schema.json',
     schemaVersion: EVALUATION_DEFINITION_SCHEMA_VERSION,

--- a/src/evaluation-core/contracts/runtime-capabilities.ts
+++ b/src/evaluation-core/contracts/runtime-capabilities.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import { IdentifierSchema, SchemaIdentitySchema } from './common.js';
+
+export const EXECUTOR_CAPABILITIES_SCHEMA_VERSION =
+  'omk.executor-capabilities/v1' as const;
+
+export const ProtocolManifestSchema = z.object({
+  protocolId: z.enum(['omk.invoke/v1', 'omk.session/v1']),
+  inputSchema: SchemaIdentitySchema,
+  outputSchema: SchemaIdentitySchema,
+  traceSchema: SchemaIdentitySchema.optional(),
+  execution: z.object({
+    concurrency: z.object({
+      safety: z.enum(['serialized', 'parallel-safe']),
+      maxInFlight: z.number().int().positive().optional(),
+    }).strict(),
+    cancellation: z.enum(['cooperative', 'best-effort', 'unsupported']),
+    state: z.object({
+      resourceLifecycle: z.enum(['per-invocation', 'per-run']),
+      trialState: z.enum(['stateless', 'isolated']),
+    }).strict(),
+    seedControl: z.enum(['unsupported', 'optional', 'required']),
+    determinism: z.enum(['deterministic', 'stochastic', 'unknown']),
+    features: z.object({
+      systemInstructions: z.enum(['native', 'prepended', 'unsupported']),
+      workspace: z.array(z.literal('copy-on-write-overlay')),
+      mcp: z.array(z.literal('native-config')),
+      mockInterception: z.array(z.literal('pre-tool-call')),
+      toolPolicies: z.array(z.enum(['runtime-default', 'allow-list'])),
+      skillDiscovery: z.array(z.enum(['runtime-default', 'disabled', 'allow-list'])),
+      sandboxIds: z.array(IdentifierSchema),
+    }).strict(),
+    telemetry: z.object({
+      trace: z.enum(['unsupported', 'optional', 'required']),
+      usage: z.enum(['unsupported', 'optional', 'required']),
+      providerCost: z.object({
+        reporting: z.enum(['unsupported', 'optional', 'required']),
+        trustedUpperBound: z.object({
+          amount: z.number().nonnegative(),
+          currency: z.string().regex(/^[A-Z]{3}$/),
+        }).strict().optional(),
+      }).strict().refine(
+        (value) => value.trustedUpperBound === undefined || value.reporting === 'required',
+        { message: 'A trusted provider-cost bound requires required reporting.' },
+      ).optional(),
+    }).strict(),
+  }).strict(),
+}).strict();
+
+export const ExecutorCapabilitiesSchema = z.object({
+  schemaVersion: z.literal(EXECUTOR_CAPABILITIES_SCHEMA_VERSION),
+  protocols: z.array(ProtocolManifestSchema).min(1),
+}).strict().meta({
+  title: 'OMK Executor Capabilities v1',
+});
+
+export type ProtocolManifest = z.infer<typeof ProtocolManifestSchema>;
+export type ExecutorCapabilities = z.infer<typeof ExecutorCapabilitiesSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export {
   EVALUATION_DEFINITION_SCHEMA_VERSION,
   EVALUATION_EVENT_SCHEMA_VERSION,
   EVALUATION_REPORT_SCHEMA_VERSION,
+  EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
   EVALUATION_SERIES_DEFINITION_SCHEMA_VERSION,
   EVALUATION_SERIES_PLAN_SCHEMA_VERSION,
   EVALUATION_SERIES_REPORT_SCHEMA_VERSION,
@@ -86,6 +87,7 @@ export type {
   SchemaIdentity,
   Sha256Digest,
   TargetDefinition,
+  TargetExecutionRequirements,
   UsageRecord,
   EvaluationSeriesDefinition,
   EvaluationSeriesDefinitionInput,
@@ -123,6 +125,7 @@ export type {
   ExecutorRuntimeRequirement,
   ExtensionResolution,
   PreparationRuntime,
+  ProtocolManifest,
   RuntimeResolution,
   SealedRunPlan,
 } from './evaluation-core/compiler/index.js';

--- a/test/eval-workflows/input-compilation/compile.test.ts
+++ b/test/eval-workflows/input-compilation/compile.test.ts
@@ -31,6 +31,18 @@ function expectDeepFrozen(value: unknown): void {
 }
 
 describe('compileCliEvaluationInput', () => {
+  it('rejects the superseded resolved-input v1 shape without inference', () => {
+    const input = deepClone(validResolvedCliInput()) as { schemaVersion: string };
+    input.schemaVersion = 'omk.resolved-cli-evaluation-input/v1';
+
+    expect(() => compileCliEvaluationInput(
+      input as ReturnType<typeof validResolvedCliInput>,
+    )).toThrowError(expect.objectContaining({
+      code: 'CLI_INPUT_INVALID',
+      fieldPath: 'schemaVersion',
+    }));
+  });
+
   it('produces schema-valid, immutable and independently owned contracts', () => {
     const result = compileCliEvaluationInput(validResolvedCliInput());
 
@@ -431,6 +443,25 @@ describe('compileCliEvaluationInput', () => {
 
   it('derives Runtime bindings from Definition requirements without override fields', () => {
     const result = compileCliEvaluationInput(validResolvedCliInput());
+    expect(result.definition.targets.find((target) => target.targetId === 'treatment')
+      ?.executionRequirements).toEqual({
+      systemInstructions: 'required',
+      workspace: 'copy-on-write-overlay',
+      mcp: 'native-config',
+      mockInterception: 'pre-tool-call',
+      toolPolicy: 'allow-list',
+      skillDiscovery: 'runtime-default',
+      sandboxId: 'omk.local-sandbox/v1',
+    });
+    expect(result.definition.targets.find((target) => target.targetId === 'control')
+      ?.executionRequirements).toEqual({
+      systemInstructions: 'not-required',
+      workspace: 'copy-on-write-overlay',
+      mcp: 'native-config',
+      mockInterception: 'pre-tool-call',
+      toolPolicy: 'allow-list',
+      skillDiscovery: 'disabled',
+    });
     for (const target of result.definition.targets) {
       const binding = result.runtimeBinding.bindings.find((candidate) => (
         candidate.runtimeKind === 'executor' && candidate.targetId === target.targetId
@@ -448,19 +479,25 @@ describe('compileCliEvaluationInput', () => {
         expect(binding.qualification).toMatchObject({
           model: 'gpt-example',
           effort: 'low',
-          workspace: 'required',
-          mcp: 'required',
-          mockInterception: 'required',
-          toolPolicy: 'allow-list',
+          executionRequirements: {
+            workspace: 'copy-on-write-overlay',
+            mcp: 'native-config',
+            mockInterception: 'pre-tool-call',
+            toolPolicy: 'allow-list',
+          },
           resourceIntegrity: 'digest-before-use',
         });
+        expect(binding.qualification.executionRequirements)
+          .toEqual(target.executionRequirements);
       }
     }
     const treatmentBinding = result.runtimeBinding.bindings.find((binding) => (
       binding.runtimeKind === 'executor' && binding.targetId === 'treatment'
     ));
     expect(treatmentBinding).toMatchObject({
-      qualification: { sandboxId: 'omk.local-sandbox/v1' },
+      qualification: {
+        executionRequirements: { sandboxId: 'omk.local-sandbox/v1' },
+      },
     });
     const judgeBinding = result.runtimeBinding.bindings.find((binding) => (
       binding.runtimeKind === 'evaluator' && binding.implementationId === 'anthropic-judge-adapter/v1'
@@ -474,7 +511,7 @@ describe('compileCliEvaluationInput', () => {
       },
     });
     const bindingJson = canonicalizeJson(result.runtimeBinding);
-    expect(result.runtimeBinding.schemaVersion).toBe('omk.runtime-binding-request/v2');
+    expect(result.runtimeBinding.schemaVersion).toBe('omk.runtime-binding-request/v3');
     expect(bindingJson).not.toContain('capabilities');
     expect(bindingJson).not.toContain('fingerprint');
     expect(bindingJson).not.toContain('assuranceLevel');
@@ -492,6 +529,20 @@ describe('compileCliEvaluationInput', () => {
       analysisNodeKind: 'estimator',
       implementationId: 'bootstrap.mean-difference/v1',
     });
+  });
+
+  it('does not claim mock interception for an explicitly empty mock set', () => {
+    const input = deepClone(validResolvedCliInput());
+    for (const target of input.targets) target.behavior.mocks = [];
+    const result = compileCliEvaluationInput(input);
+
+    expect(result.definition.targets.every((target) => (
+      target.executionRequirements.mockInterception === 'not-required'
+    ))).toBe(true);
+    expect(result.runtimeBinding.bindings.filter((binding) => binding.runtimeKind === 'executor')
+      .every((binding) => (
+        binding.qualification.executionRequirements.mockInterception === 'not-required'
+      ))).toBe(true);
   });
 
   it('rejects inline secret evaluator or target configuration', () => {

--- a/test/eval-workflows/input-compilation/fixtures.ts
+++ b/test/eval-workflows/input-compilation/fixtures.ts
@@ -139,6 +139,7 @@ export function validResolvedCliInput(): ResolvedCliEvaluationInput {
           effort: 'low',
         },
         behavior: {
+          systemInstructions: 'required',
           artifact: treatmentArtifact,
           workspace,
           mcpConfig: mcp,
@@ -166,6 +167,7 @@ export function validResolvedCliInput(): ResolvedCliEvaluationInput {
           effort: 'low',
         },
         behavior: {
+          systemInstructions: 'not-required',
           artifact: controlArtifact,
           workspace,
           mcpConfig: mcp,

--- a/test/eval-workflows/runtime-adapter/assembly.test.ts
+++ b/test/eval-workflows/runtime-adapter/assembly.test.ts
@@ -159,6 +159,7 @@ function factoriesFor(
             versionConstraint: request.versionConstraint,
           }),
           protocolId: request.protocolId,
+          executionRequirements: request.qualification.executionRequirements,
         })) as RuntimeResolution;
         const identity = bindingIdentity(
           request.implementationId,
@@ -613,7 +614,7 @@ describe('OMK Evaluation Runtime binding assembly', () => {
     expect(executors[0].port).not.toBe(executors[1].port);
   });
 
-  it.each(['missing', 'mismatched', 'resource-mismatched'] as const)(
+  it.each(['missing', 'mismatched', 'resource-mismatched', 'requirement-mismatched'] as const)(
     'fails before invoking factories for a %s Definition binding',
     async (scenario) => {
       const input = runtimeAssemblyInput();
@@ -627,10 +628,17 @@ describe('OMK Evaluation Runtime binding assembly', () => {
         executor.protocolId = executor.protocolId === 'omk.invoke/v1'
           ? 'omk.session/v1'
           : 'omk.invoke/v1';
-      } else {
+      } else if (scenario === 'resource-mismatched') {
         const executor = request.bindings.find((binding) => binding.runtimeKind === 'executor');
         if (executor?.runtimeKind !== 'executor') throw new Error('missing fixture binding');
         executor.resourceLeaseRequirements.pop();
+      } else {
+        const executor = request.bindings.find((binding) => binding.runtimeKind === 'executor');
+        if (executor?.runtimeKind !== 'executor') throw new Error('missing fixture binding');
+        executor.qualification.executionRequirements.systemInstructions =
+          executor.qualification.executionRequirements.systemInstructions === 'required'
+            ? 'not-required'
+            : 'required';
       }
       const calls: string[] = [];
 
@@ -663,12 +671,12 @@ describe('OMK Evaluation Runtime binding assembly', () => {
     expect(calls).toEqual([]);
   });
 
-  it('rejects the incomplete v1 binding request without compatibility inference', async () => {
+  it('rejects the superseded v2 binding request without compatibility inference', async () => {
     const input = runtimeAssemblyInput();
     delete input.orchestration.independentSeries;
     const compiled = compileCliEvaluationInput(input);
     const request = clone(compiled.runtimeBinding) as { schemaVersion: string };
-    request.schemaVersion = 'omk.runtime-binding-request/v1';
+    request.schemaVersion = 'omk.runtime-binding-request/v2';
     const calls: string[] = [];
 
     await expect(assembleOmkRuntimeBindings({
@@ -802,6 +810,7 @@ describe('OMK Evaluation Runtime binding assembly', () => {
         versionConstraint: compiled.definition.targets[0].versionConstraint,
       }),
       protocolId: compiled.definition.targets[0].protocolId,
+      executionRequirements: compiled.definition.targets[0].executionRequirements,
     });
     (factories.executorsByImplementationId as Map<string, unknown>).clear();
     const after = await assembly.evaluation.bindings.resolveExecutor({
@@ -811,6 +820,7 @@ describe('OMK Evaluation Runtime binding assembly', () => {
         versionConstraint: compiled.definition.targets[0].versionConstraint,
       }),
       protocolId: compiled.definition.targets[0].protocolId,
+      executionRequirements: compiled.definition.targets[0].executionRequirements,
     });
 
     expect(after.port).toBe(before.port);
@@ -921,6 +931,48 @@ describe('OMK Evaluation Runtime binding assembly', () => {
 });
 
 describe('OMK Evaluation Runtime composition root', () => {
+  it('fails capability mismatch during Core prepare before any Executor opens', async () => {
+    const compiled = compositionInput();
+    const factories = factoriesFor(compiled, []);
+    const executors = new Map(factories.executorsByImplementationId);
+    const implementationId = compiled.definition.targets[0].executorId;
+    const original = executors.get(implementationId);
+    if (original === undefined) throw new Error('missing fixture executor factory');
+    let opens = 0;
+    executors.set(implementationId, async (context) => {
+      const resolved = await original(context);
+      const capabilities = clone(resolved.port.identity.capabilities) as {
+        protocols: Array<{ execution: { features: { mcp: string[] } } }>;
+      };
+      for (const protocol of capabilities.protocols) protocol.execution.features.mcp = [];
+      const identity = RuntimeIdentitySchema.parse({
+        ...resolved.port.identity,
+        capabilities,
+      });
+      const port: ExecutionExecutor = {
+        ...resolved.port,
+        identity,
+        async openRun(runContext) {
+          opens += 1;
+          return resolved.port.openRun(runContext);
+        },
+      };
+      return { ...resolved, port };
+    });
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: { ...factories, executorsByImplementationId: executors },
+      support: compositionSupport(),
+      resources: { leaseRoot: '/unused-test-lease-root' },
+    });
+
+    await expect(runtime.prepare()).rejects.toMatchObject({
+      code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      preparationStage: 'runtime-resolution',
+    });
+    expect(opens).toBe(0);
+  });
+
   it('uses the verified Node materializer by default and fails closed on missing sources', async () => {
     const compiled = compositionInput();
     const lifecycle: string[] = [];

--- a/test/eval-workflows/runtime-adapter/same-process.test.ts
+++ b/test/eval-workflows/runtime-adapter/same-process.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
   digestCanonicalJson,
   type JsonValue,
   type RuntimeIdentity,
@@ -36,6 +37,7 @@ function schema(name: string): SchemaIdentity {
 
 function executorIdentity(implementationId = 'test.omk.same-process-executor/v1'): RuntimeIdentity {
   const capabilities = {
+    schemaVersion: EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
     protocols: [{
       protocolId: 'omk.invoke/v1' as const,
       inputSchema: schema('invoke-input'),
@@ -45,10 +47,19 @@ function executorIdentity(implementationId = 'test.omk.same-process-executor/v1'
         cancellation: 'cooperative' as const,
         state: {
           resourceLifecycle: 'per-run' as const,
-          trialState: 'isolated' as const,
+          trialState: 'stateless' as const,
         },
         seedControl: 'optional' as const,
         determinism: 'deterministic' as const,
+        features: {
+          systemInstructions: 'unsupported' as const,
+          workspace: [],
+          mcp: [],
+          mockInterception: [],
+          toolPolicies: ['runtime-default' as const],
+          skillDiscovery: ['runtime-default' as const],
+          sandboxIds: [],
+        },
         telemetry: {
           trace: 'optional' as const,
           usage: 'optional' as const,

--- a/test/evaluation-core/compiler/fixtures.ts
+++ b/test/evaluation-core/compiler/fixtures.ts
@@ -1,5 +1,6 @@
 import {
   EVALUATION_DEFINITION_SCHEMA_VERSION,
+  EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
   MEASUREMENT_POLICY_SCHEMA_VERSION,
   digestCanonicalJson,
   schemaIdentityKey,
@@ -64,6 +65,14 @@ export function validDefinition(): EvaluationDefinition {
         protocolId: 'omk.invoke/v1',
         executorId: 'executor-alias',
         versionConstraint: '^1.0.0',
+        executionRequirements: {
+          systemInstructions: 'not-required',
+          workspace: 'not-required',
+          mcp: 'not-required',
+          mockInterception: 'not-required',
+          toolPolicy: 'runtime-default',
+          skillDiscovery: 'runtime-default',
+        },
       },
       {
         targetId: 'treatment',
@@ -71,6 +80,14 @@ export function validDefinition(): EvaluationDefinition {
         protocolId: 'omk.invoke/v1',
         executorId: 'executor-alias',
         versionConstraint: '^1.0.0',
+        executionRequirements: {
+          systemInstructions: 'not-required',
+          workspace: 'not-required',
+          mcp: 'not-required',
+          mockInterception: 'not-required',
+          toolPolicy: 'runtime-default',
+          skillDiscovery: 'runtime-default',
+        },
       },
     ],
     evaluators: [{
@@ -212,6 +229,14 @@ interface RuntimeOptions {
     reporting: 'unsupported' | 'optional' | 'required';
     trustedUpperBound?: { amount: number; currency: string };
   };
+  systemInstructions?: 'native' | 'prepended' | 'unsupported';
+  workspace?: Array<'copy-on-write-overlay'>;
+  mcp?: Array<'native-config'>;
+  mockInterception?: Array<'pre-tool-call'>;
+  toolPolicies?: Array<'runtime-default' | 'allow-list'>;
+  skillDiscovery?: Array<'runtime-default' | 'disabled' | 'allow-list'>;
+  sandboxIds?: string[];
+  omitExecutorCapabilitySchemaVersion?: boolean;
   evaluatorValueTypes?: Array<'numeric' | 'boolean' | 'categorical' | 'text' | 'ranking'>;
   evaluatorProviderCost?: {
     reporting: 'unsupported' | 'optional' | 'required';
@@ -269,6 +294,9 @@ export function testRuntime(options: RuntimeOptions = {}): TestRuntime {
           'actual-executor/v1',
           options.executorFingerprint ?? 'executor-fingerprint-1',
           {
+            ...(options.omitExecutorCapabilitySchemaVersion
+              ? {}
+              : { schemaVersion: EXECUTOR_CAPABILITIES_SCHEMA_VERSION }),
             protocols: protocols.map((protocolId) => ({
               protocolId,
               inputSchema: schemaIdentity(`${protocolId}:input`),
@@ -293,6 +321,16 @@ export function testRuntime(options: RuntimeOptions = {}): TestRuntime {
                 determinism: (options.deterministic ?? true)
                   ? 'deterministic'
                   : 'stochastic',
+                features: {
+                  systemInstructions: options.systemInstructions ?? 'native',
+                  workspace: options.workspace ?? ['copy-on-write-overlay'],
+                  mcp: options.mcp ?? ['native-config'],
+                  mockInterception: options.mockInterception ?? ['pre-tool-call'],
+                  toolPolicies: options.toolPolicies ?? ['allow-list', 'runtime-default'],
+                  skillDiscovery: options.skillDiscovery
+                    ?? ['allow-list', 'disabled', 'runtime-default'],
+                  sandboxIds: options.sandboxIds ?? ['omk.local-sandbox/v1'],
+                },
                 telemetry: {
                   trace: options.traceCapability ?? 'unsupported',
                   usage: 'optional',

--- a/test/evaluation-core/compiler/validation.test.ts
+++ b/test/evaluation-core/compiler/validation.test.ts
@@ -271,6 +271,175 @@ describe('Compiler definition validation', () => {
     });
   });
 
+  it.each(['native', 'prepended'] as const)(
+    'accepts %s system-instruction delivery and seals the actual mode',
+    async (systemInstructions) => {
+      const definition = validDefinition();
+      definition.targets[0].executionRequirements.systemInstructions = 'required';
+      const plan = await prepareEvaluationPlan(
+        definition,
+        validPolicy(),
+        testRuntime({ systemInstructions }),
+      );
+      const runtime = plan.execution.runtimes.find((candidate) => (
+        candidate.runtimeKind === 'executor' && candidate.referenceId === 'control'
+      ));
+      expect(runtime?.identity.capabilities).toMatchObject({
+        protocols: [{ execution: { features: { systemInstructions } } }],
+      });
+    },
+  );
+
+  it('treats the actual system-instruction delivery mode as execution design identity', async () => {
+    const definition = validDefinition();
+    definition.targets[0].executionRequirements.systemInstructions = 'required';
+    const native = await prepareEvaluationPlan(
+      definition,
+      validPolicy(),
+      testRuntime({ systemInstructions: 'native' }),
+    );
+    const prepended = await prepareEvaluationPlan(
+      definition,
+      validPolicy(),
+      testRuntime({ systemInstructions: 'prepended' }),
+    );
+
+    expect(prepended.execution.executionPlanDigest)
+      .not.toBe(native.execution.executionPlanDigest);
+  });
+
+  it('matches every Target execution requirement against the selected protocol', async () => {
+    const required = validDefinition();
+    required.targets[0].executionRequirements = {
+      systemInstructions: 'required',
+      workspace: 'copy-on-write-overlay',
+      mcp: 'native-config',
+      mockInterception: 'pre-tool-call',
+      toolPolicy: 'allow-list',
+      skillDiscovery: 'disabled',
+      sandboxId: 'sandbox-required',
+    };
+
+    await expectCode(
+      required,
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ systemInstructions: 'unsupported', sandboxIds: ['sandbox-required'] }),
+    );
+    await expectCode(
+      required,
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ workspace: [], sandboxIds: ['sandbox-required'] }),
+    );
+    await expectCode(
+      required,
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ mcp: [], sandboxIds: ['sandbox-required'] }),
+    );
+    await expectCode(
+      required,
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ mockInterception: [], sandboxIds: ['sandbox-required'] }),
+    );
+    await expectCode(
+      required,
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ toolPolicies: ['runtime-default'], sandboxIds: ['sandbox-required'] }),
+    );
+    await expectCode(
+      required,
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ skillDiscovery: ['runtime-default'], sandboxIds: ['sandbox-required'] }),
+    );
+    await expectCode(
+      required,
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ sandboxIds: [] }),
+    );
+
+    await expect(prepareEvaluationPlan(
+      required,
+      validPolicy(),
+      testRuntime({ sandboxIds: ['sandbox-required'] }),
+    )).resolves.toBeDefined();
+
+    const skillAllowList = structuredClone(required);
+    skillAllowList.targets[0].executionRequirements.skillDiscovery = 'allow-list';
+    await expectCode(
+      skillAllowList,
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({
+        skillDiscovery: ['disabled', 'runtime-default'],
+        sandboxIds: ['sandbox-required'],
+      }),
+    );
+    await expect(prepareEvaluationPlan(
+      skillAllowList,
+      validPolicy(),
+      testRuntime({ sandboxIds: ['sandbox-required'] }),
+    )).resolves.toBeDefined();
+  });
+
+  it('does not require optional features when the Target declares none', async () => {
+    await expect(prepareEvaluationPlan(
+      validDefinition(),
+      validPolicy(),
+      testRuntime({
+        systemInstructions: 'unsupported',
+        workspace: [],
+        mcp: [],
+        mockInterception: [],
+        toolPolicies: ['runtime-default'],
+        skillDiscovery: ['runtime-default'],
+        sandboxIds: [],
+      }),
+    )).resolves.toBeDefined();
+  });
+
+  it('rejects duplicate feature declarations and seals canonical capability order', async () => {
+    await expectCode(
+      validDefinition(),
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ omitExecutorCapabilitySchemaVersion: true }),
+    );
+    await expectCode(
+      validDefinition(),
+      validPolicy(),
+      'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      testRuntime({ toolPolicies: ['runtime-default', 'runtime-default'] }),
+    );
+
+    const plan = await prepareEvaluationPlan(
+      validDefinition(),
+      validPolicy(),
+      testRuntime({
+        toolPolicies: ['runtime-default', 'allow-list'],
+        skillDiscovery: ['runtime-default', 'disabled', 'allow-list'],
+        sandboxIds: ['sandbox-z', 'sandbox-a'],
+      }),
+    );
+    const runtime = plan.execution.runtimes[0];
+    expect(runtime.identity.capabilities).toMatchObject({
+      protocols: [{
+        execution: {
+          features: {
+            toolPolicies: ['allow-list', 'runtime-default'],
+            skillDiscovery: ['allow-list', 'disabled', 'runtime-default'],
+            sandboxIds: ['sandbox-a', 'sandbox-z'],
+          },
+        },
+      }],
+    });
+  });
+
   it('rejects unsupported protocol, deterministic cache, and evaluator capabilities', async () => {
     const protocol = validDefinition();
     protocol.targets[0].protocolId = 'omk.session/v1';

--- a/test/evaluation-core/contracts/digests.test.ts
+++ b/test/evaluation-core/contracts/digests.test.ts
@@ -90,6 +90,14 @@ const definition: EvaluationDefinition = {
     targetKind: 'function',
     protocolId: 'omk.invoke/v1',
     executorId: 'local',
+    executionRequirements: {
+      systemInstructions: 'not-required',
+      workspace: 'not-required',
+      mcp: 'not-required',
+      mockInterception: 'not-required',
+      toolPolicy: 'runtime-default',
+      skillDiscovery: 'runtime-default',
+    },
   }],
   evaluators: [{
     evaluatorId: 'exact',
@@ -157,6 +165,26 @@ function planDigests(current: EvaluationDefinition, currentPolicy = policy) {
 }
 
 describe('Evaluation Core layered digests', () => {
+  it('binds Target execution requirements into Execution and downstream plan identity', () => {
+    const first = planDigests(definition);
+    const second = planDigests({
+      ...definition,
+      targets: definition.targets.map((target) => ({
+        ...target,
+        executionRequirements: {
+          ...target.executionRequirements,
+          systemInstructions: 'required',
+        },
+      })),
+    });
+
+    expect(second.executionPlanDigest).not.toBe(first.executionPlanDigest);
+    expect(second.evaluationPlanDigest).not.toBe(first.evaluationPlanDigest);
+    expect(second.analysisPlanDigest).not.toBe(first.analysisPlanDigest);
+    expect(second.decisionPlanDigest).not.toBe(first.decisionPlanDigest);
+    expect(second.runContractDigest).not.toBe(first.runContractDigest);
+  });
+
   it('separates Runtime behavior identity from evidence qualification', () => {
     const runtime = {
       implementationId: 'remote-model/v1',

--- a/test/evaluation-core/contracts/schemas.test.ts
+++ b/test/evaluation-core/contracts/schemas.test.ts
@@ -4,6 +4,7 @@ import _Ajv2020 from 'ajv/dist/2020.js';
 import { describe, expect, it } from 'vitest';
 import {
   EVALUATION_DEFINITION_SCHEMA_VERSION,
+  EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
   EvaluationDefinitionSchema,
   EvaluationStatusSchema,
   MetricObservationSchema,
@@ -54,6 +55,7 @@ describe('Evaluation Core wire schemas', () => {
     );
     expect(versions).not.toContain('omk.comparability-policy/v1');
     expect(versions).not.toContain('omk.comparability-assessment/v1');
+    expect(versions).toContain(EXECUTOR_CAPABILITIES_SCHEMA_VERSION);
   });
 
   it('keeps opaque Runtime fingerprints distinct from OMK content digests', () => {
@@ -114,6 +116,14 @@ describe('Evaluation Core wire schemas', () => {
         targetKind: 'function',
         protocolId: 'omk.invoke/v1',
         executorId: 'e',
+        executionRequirements: {
+          systemInstructions: 'not-required',
+          workspace: 'not-required',
+          mcp: 'not-required',
+          mockInterception: 'not-required',
+          toolPolicy: 'runtime-default',
+          skillDiscovery: 'runtime-default',
+        },
       }],
       evaluators: [],
       metrics: [],
@@ -191,6 +201,14 @@ describe('Evaluation Core wire schemas', () => {
         targetKind: 'function',
         protocolId: 'omk.invoke/v1',
         executorId: 'e',
+        executionRequirements: {
+          systemInstructions: 'not-required',
+          workspace: 'not-required',
+          mcp: 'not-required',
+          mockInterception: 'not-required',
+          toolPolicy: 'runtime-default',
+          skillDiscovery: 'runtime-default',
+        },
       }],
       evaluators: [],
       metrics: [],
@@ -217,6 +235,9 @@ describe('Evaluation Core wire schemas', () => {
         },
       },
     });
-    expect(parsed.success).toBe(true);
+    expect(
+      parsed.success,
+      parsed.success ? undefined : JSON.stringify(parsed.error.issues),
+    ).toBe(true);
   });
 });

--- a/test/evaluation-core/engine/runtime.test.ts
+++ b/test/evaluation-core/engine/runtime.test.ts
@@ -309,6 +309,7 @@ describe('embedded Evaluation Engine', () => {
       executorId: 'executor-alias',
       versionConstraint: '^1.0.0',
       protocolId: 'omk.invoke/v1',
+      executionRequirements: fixture.definition.targets[0].executionRequirements,
     });
     const attempts: string[] = [];
     const port = (source: string): Executor => ({

--- a/test/evaluation-core/fixtures/embedded-host.mjs
+++ b/test/evaluation-core/fixtures/embedded-host.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {
   EVALUATION_DEFINITION_SCHEMA_VERSION,
+  EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
   MEASUREMENT_POLICY_SCHEMA_VERSION,
   createBuiltinAnalysisNodes,
   createBuiltinAnalysisSchemaValidators,
@@ -34,6 +35,7 @@ function runtimeIdentity(implementationId, capabilities) {
 
 function executorIdentity() {
   return runtimeIdentity('host.same-process/v1', {
+    schemaVersion: EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
     protocols: [{
       protocolId: 'omk.invoke/v1',
       inputSchema: schemaIdentity('invoke-input'),
@@ -45,6 +47,15 @@ function executorIdentity() {
         state: { resourceLifecycle: 'per-run', trialState: 'stateless' },
         seedControl: 'optional',
         determinism: 'deterministic',
+        features: {
+          systemInstructions: 'unsupported',
+          workspace: [],
+          mcp: [],
+          mockInterception: [],
+          toolPolicies: ['runtime-default'],
+          skillDiscovery: ['runtime-default'],
+          sandboxIds: [],
+        },
         telemetry: { trace: 'optional', usage: 'optional' },
       },
     }],
@@ -309,6 +320,14 @@ function definition(targetKind) {
       protocolId: 'omk.invoke/v1',
       executorId: 'same-process',
       versionConstraint: '^1.0.0',
+      executionRequirements: {
+        systemInstructions: 'not-required',
+        workspace: 'not-required',
+        mcp: 'not-required',
+        mockInterception: 'not-required',
+        toolPolicy: 'runtime-default',
+        skillDiscovery: 'runtime-default',
+      },
     })),
     evaluators: [{
       evaluatorId: 'deterministic',


### PR DESCRIPTION
## 用户影响

Evaluation Core 现在把 Target 对 system instruction、workspace、MCP、mock interception、tool policy、skill discovery 与 sandbox 的要求作为显式测量事实，并在 prepare 阶段与选中 protocol 的实际 Runtime capability 做唯一一次 fail-closed 协商。Capability 不满足时不会打开 Runtime run，也不会由 adapter 静默降级。

Executor capability 作为独立的 `omk.executor-capabilities/v1` wire contract 发布，其 JSON Schema identity 进入 sealed Run contract；实际 capability mode 继续进入 Runtime implementation identity。因此 `native` 与 `prepended` 等行为差异不会被错误视为同一 execution design。

## 迁移说明

- `TargetDefinition.executionRequirements` 变为必填；现有 Core v1 Definition／ExecutionPlan／RunPlan 文档需要重新生成。
- Executor capability manifest 必须声明 `schemaVersion: omk.executor-capabilities/v1` 和完整、封闭的 `features`。空集合与 `unsupported` 必须显式表达。
- resolved compiler input 升级为 `omk.resolved-cli-evaluation-input/v2`。
- Runtime binding request 升级为 `omk.runtime-binding-request/v3`，executor qualification 直接复用 Definition 中的 canonical requirements。
- 不提供旧结构 fallback、推断或兼容 reader。

## 测量学说明

Requirements、实际 capability mode 与 capability schema identity 都进入 ExecutionPlan 及下游 digest，因此相关行为变化会建立新的 design identity。资源 digest／lease 仍由宿主验证，model、effort、deployment 与 effective tool schema 仍属于 Target config／Runtime implementation identity。

本变更不修改评分类 prompt、五层评分、Bootstrap、Krippendorff alpha、missing policy 或 length-debias，不属于 `BREAKING-COMPARABILITY`。

Closes #466
Refs #457