### PR TITLE
feat(eval-workflows): 增加 OpenAI Responses API Core 适配器

### DIFF
--- a/src/eval-workflows/runtime-adapter/adapters/api-http.ts
+++ b/src/eval-workflows/runtime-adapter/adapters/api-http.ts
@@ -60,10 +60,46 @@ export class ApiResponseBodyError extends Error {
   }
 }
 
+export function requiredApiHeaderValue(value: string, label: string): string {
+  if (
+    typeof value !== 'string'
+    || value.trim() === ''
+    || /[\u0000-\u001f\u007f]/.test(value)
+  ) throw new TypeError(`${label} must be a non-empty header-safe string.`);
+  return value;
+}
+
+export function normalizeCoreApiEndpoint(value: string, label: string): string {
+  if (typeof value !== 'string') {
+    throw new TypeError(`${label} must be an absolute HTTP(S) URL.`);
+  }
+  let endpoint: URL;
+  try {
+    endpoint = new URL(value);
+  } catch {
+    throw new TypeError(`${label} must be an absolute HTTP(S) URL.`);
+  }
+  if (
+    !['http:', 'https:'].includes(endpoint.protocol)
+    || endpoint.username !== ''
+    || endpoint.password !== ''
+    || endpoint.hash !== ''
+    || endpoint.search !== ''
+  ) throw new TypeError(`${label} must be an absolute credential-free HTTP(S) URL.`);
+  const loopback = endpoint.hostname === 'localhost'
+    || endpoint.hostname === '127.0.0.1'
+    || endpoint.hostname === '[::1]';
+  if (endpoint.protocol !== 'https:' && !loopback) {
+    throw new TypeError(`${label} must use HTTPS unless it is loopback-only.`);
+  }
+  return endpoint.toString();
+}
+
 function defaultTransport(): CoreApiTransport {
   if (typeof globalThis.fetch !== 'function') {
     throw new TypeError('API Core adapters require a global fetch implementation.');
   }
+  const fetchImplementation = globalThis.fetch.bind(globalThis);
   const nodeVersion = process.versions.node;
   return {
     identity: {
@@ -80,7 +116,7 @@ function defaultTransport(): CoreApiTransport {
       retrySemantics: 'none',
     },
     request(input) {
-      return globalThis.fetch(input.endpoint, {
+      return fetchImplementation(input.endpoint, {
         method: 'POST',
         headers: { ...input.headers },
         body: input.body,

--- a/src/eval-workflows/runtime-adapter/adapters/index.ts
+++ b/src/eval-workflows/runtime-adapter/adapters/index.ts
@@ -4,4 +4,5 @@ export * from './claude-sdk.js';
 export * from './codex-cli.js';
 export * from './codex-sdk.js';
 export * from './custom-command.js';
+export * from './openai-api.js';
 export * from './same-process.js';

--- a/src/eval-workflows/runtime-adapter/adapters/openai-api-protocol.ts
+++ b/src/eval-workflows/runtime-adapter/adapters/openai-api-protocol.ts
@@ -1,0 +1,291 @@
+import {
+  UsageRecordSchema,
+  type JsonValue,
+  type UsageRecord,
+} from '../../../evaluation-core/contracts/index.js';
+import { ExecutionPortFailure } from '../../../evaluation-core/execution/index.js';
+import {
+  createStatelessApiCoreSchemaValidators,
+  statelessApiExecutorCapabilities,
+  type StatelessApiProtocolProfile,
+} from './api-protocol-core.js';
+
+export const OPENAI_API_CORE_ADAPTER_IMPLEMENTATION_VERSION = '1.0.0' as const;
+
+export const OPENAI_API_PROTOCOL_PROFILE = Object.freeze({
+  providerId: 'openai-api',
+  sourceProtocol: 'OpenAI Responses API',
+}) satisfies StatelessApiProtocolProfile;
+
+export function createOpenAIApiCoreSchemaValidators() {
+  return createStatelessApiCoreSchemaValidators(OPENAI_API_PROTOCOL_PROFILE);
+}
+
+export function openAIApiExecutorCapabilities() {
+  return statelessApiExecutorCapabilities(OPENAI_API_PROTOCOL_PROFILE);
+}
+
+export interface ParsedOpenAIApiResponse {
+  readonly output: string;
+  readonly trace: JsonValue;
+  readonly usage: UsageRecord;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function tokenCount(value: unknown): number | undefined {
+  return Number.isSafeInteger(value) && (value as number) >= 0 ? value as number : undefined;
+}
+
+function fail(message: string, usage?: UsageRecord, code = 'OMK_OPENAI_API_PROTOCOL_INVALID'): never {
+  throw new ExecutionPortFailure({ code, stage: 'execution', message }, usage);
+}
+
+function optionalNonEmptyString(value: unknown, label: string): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string' || value.trim() === '') {
+    fail(`OpenAI API reported an invalid ${label}.`);
+  }
+  return value;
+}
+
+function parseEffectiveEffort(
+  rawReasoning: unknown,
+  requestedEffort: string | undefined,
+): string | undefined {
+  if (rawReasoning === undefined || rawReasoning === null) return requestedEffort;
+  if (!isRecord(rawReasoning)) fail('OpenAI API reported invalid reasoning metadata.');
+  return optionalNonEmptyString(rawReasoning.effort, 'reasoning effort') ?? requestedEffort;
+}
+
+function parseUsage(
+  rawUsage: unknown,
+  responseModel: string,
+  responseStatus: string,
+  serviceTier: string | undefined,
+  effectiveEffort: string | undefined,
+): UsageRecord {
+  if (rawUsage === undefined || rawUsage === null) {
+    return UsageRecordSchema.parse({
+      details: {
+        provider: 'openai',
+        responseModel,
+        responseStatus,
+        tokenAccounting: 'inclusive-provider-totals',
+        ...(serviceTier === undefined ? {} : { serviceTier }),
+        ...(effectiveEffort === undefined ? {} : { effectiveEffort }),
+      },
+    });
+  }
+  if (!isRecord(rawUsage)) fail('OpenAI API reported invalid usage.');
+  const inputTokens = tokenCount(rawUsage.input_tokens);
+  const outputTokens = tokenCount(rawUsage.output_tokens);
+  const totalTokens = tokenCount(rawUsage.total_tokens);
+  if (
+    inputTokens === undefined
+    || outputTokens === undefined
+    || totalTokens === undefined
+    || !Number.isSafeInteger(inputTokens + outputTokens)
+    || inputTokens + outputTokens !== totalTokens
+  ) fail('OpenAI API reported inconsistent usage.');
+
+  let cachedInputTokens: number | undefined;
+  let cacheWriteInputTokens: number | undefined;
+  if (rawUsage.input_tokens_details !== undefined && rawUsage.input_tokens_details !== null) {
+    if (!isRecord(rawUsage.input_tokens_details)) {
+      fail('OpenAI API reported invalid input token details.');
+    }
+    const details = rawUsage.input_tokens_details;
+    if (details.cached_tokens !== undefined && details.cached_tokens !== null) {
+      cachedInputTokens = tokenCount(details.cached_tokens);
+      if (cachedInputTokens === undefined || cachedInputTokens > inputTokens) {
+        fail('OpenAI API reported invalid cached input token usage.');
+      }
+    }
+    if (details.cache_write_tokens !== undefined && details.cache_write_tokens !== null) {
+      cacheWriteInputTokens = tokenCount(details.cache_write_tokens);
+      if (cacheWriteInputTokens === undefined || cacheWriteInputTokens > inputTokens) {
+        fail('OpenAI API reported invalid cache write token usage.');
+      }
+    }
+  }
+
+  let reasoningOutputTokens: number | undefined;
+  if (rawUsage.output_tokens_details !== undefined && rawUsage.output_tokens_details !== null) {
+    if (!isRecord(rawUsage.output_tokens_details)) {
+      fail('OpenAI API reported invalid output token details.');
+    }
+    const reasoningTokens = rawUsage.output_tokens_details.reasoning_tokens;
+    if (reasoningTokens !== undefined && reasoningTokens !== null) {
+      reasoningOutputTokens = tokenCount(reasoningTokens);
+      if (reasoningOutputTokens === undefined || reasoningOutputTokens > outputTokens) {
+        fail('OpenAI API reported invalid reasoning token usage.');
+      }
+    }
+  }
+
+  return UsageRecordSchema.parse({
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    details: {
+      provider: 'openai',
+      responseModel,
+      responseStatus,
+      tokenAccounting: 'inclusive-provider-totals',
+      ...(cachedInputTokens === undefined ? {} : { cachedInputTokens }),
+      ...(cacheWriteInputTokens === undefined ? {} : { cacheWriteInputTokens }),
+      ...(reasoningOutputTokens === undefined ? {} : { reasoningOutputTokens }),
+      ...(serviceTier === undefined ? {} : { serviceTier }),
+      ...(effectiveEffort === undefined ? {} : { effectiveEffort }),
+    },
+  });
+}
+
+function validateStatelessEnvelope(value: Record<string, unknown>, usage: UsageRecord): void {
+  if (value.store !== undefined && value.store !== false) {
+    fail('OpenAI API unexpectedly stored the response.', usage);
+  }
+  if (value.background !== undefined && value.background !== false) {
+    fail('OpenAI API unexpectedly used background execution.', usage);
+  }
+  if (value.previous_response_id !== undefined && value.previous_response_id !== null) {
+    fail('OpenAI API unexpectedly linked server-side response state.', usage);
+  }
+  if (value.conversation !== undefined && value.conversation !== null) {
+    fail('OpenAI API unexpectedly linked a server-side conversation.', usage);
+  }
+  if (value.tools !== undefined && (!Array.isArray(value.tools) || value.tools.length !== 0)) {
+    fail('OpenAI API unexpectedly enabled tools.', usage);
+  }
+  if (value.tool_choice !== undefined && value.tool_choice !== 'none') {
+    fail('OpenAI API unexpectedly enabled tool choice.', usage);
+  }
+  if (value.parallel_tool_calls !== undefined && value.parallel_tool_calls !== false) {
+    fail('OpenAI API unexpectedly enabled parallel tool calls.', usage);
+  }
+  if (value.truncation !== undefined && value.truncation !== 'disabled') {
+    fail('OpenAI API unexpectedly changed truncation semantics.', usage);
+  }
+}
+
+function validateReasoningItem(item: Record<string, unknown>, usage: UsageRecord): void {
+  if (typeof item.id !== 'string' || item.id.trim() === '') {
+    fail('OpenAI API returned invalid reasoning output.', usage);
+  }
+  if (item.summary !== undefined && !Array.isArray(item.summary)) {
+    fail('OpenAI API returned invalid reasoning summary metadata.', usage);
+  }
+}
+
+function parseAssistantMessage(item: Record<string, unknown>, usage: UsageRecord): string {
+  if (
+    typeof item.id !== 'string'
+    || item.id.trim() === ''
+    || item.status !== 'completed'
+    || item.role !== 'assistant'
+    || !Array.isArray(item.content)
+  ) fail('OpenAI API returned an invalid assistant message.', usage);
+  const text: string[] = [];
+  for (const content of item.content) {
+    if (!isRecord(content) || typeof content.type !== 'string') {
+      fail('OpenAI API returned invalid assistant content.', usage);
+    }
+    if (content.type === 'output_text') {
+      if (typeof content.text !== 'string') {
+        fail('OpenAI API returned invalid output text.', usage);
+      }
+      text.push(content.text);
+    } else if (content.type === 'refusal') {
+      fail('OpenAI API completed with a refusal instead of assistant text.', usage);
+    } else {
+      fail('OpenAI API returned unsupported assistant content.', usage);
+    }
+  }
+  const output = text.join('');
+  if (output.trim() === '') fail('OpenAI API completed without assistant text.', usage);
+  return output;
+}
+
+export function parseOpenAIApiResponse(
+  value: JsonValue,
+  requestedEffort?: string,
+): ParsedOpenAIApiResponse {
+  if (
+    !isRecord(value)
+    || value.object !== 'response'
+    || typeof value.model !== 'string'
+    || value.model.trim() === ''
+    || typeof value.status !== 'string'
+    || value.status.trim() === ''
+    || !Array.isArray(value.output)
+  ) fail('OpenAI API returned an invalid Response envelope.');
+
+  const serviceTier = optionalNonEmptyString(value.service_tier, 'service tier');
+  const effectiveEffort = parseEffectiveEffort(value.reasoning, requestedEffort);
+  const usage = parseUsage(
+    value.usage,
+    value.model,
+    value.status,
+    serviceTier,
+    effectiveEffort,
+  );
+  if (
+    requestedEffort !== undefined
+    && effectiveEffort !== undefined
+    && effectiveEffort !== requestedEffort
+  ) fail('OpenAI API changed the requested reasoning effort.', usage);
+  validateStatelessEnvelope(value, usage);
+  if (value.error !== undefined && value.error !== null) {
+    fail(
+      'OpenAI API response failed.',
+      usage,
+      'OMK_OPENAI_API_RESPONSE_FAILED',
+    );
+  }
+  if (value.status === 'incomplete') {
+    fail(
+      'OpenAI API response was incomplete.',
+      usage,
+      'OMK_OPENAI_API_RESPONSE_INCOMPLETE',
+    );
+  }
+  if (value.status !== 'completed') {
+    fail(
+      'OpenAI API response did not complete.',
+      usage,
+      'OMK_OPENAI_API_RESPONSE_FAILED',
+    );
+  }
+
+  let output: string | undefined;
+  for (const item of value.output) {
+    if (!isRecord(item) || typeof item.type !== 'string' || item.type.trim() === '') {
+      fail('OpenAI API returned an invalid output item.', usage);
+    }
+    if (item.type === 'reasoning') {
+      validateReasoningItem(item, usage);
+    } else if (item.type === 'message') {
+      if (output !== undefined) {
+        fail('OpenAI API returned multiple assistant messages.', usage);
+      }
+      output = parseAssistantMessage(item, usage);
+    } else {
+      fail('OpenAI API returned an unsupported output item.', usage);
+    }
+  }
+  if (output === undefined) fail('OpenAI API completed without an assistant message.', usage);
+  return Object.freeze({
+    output,
+    trace: {
+      schemaVersion: 'omk.source-neutral-trace/v1',
+      turns: [{ role: 'assistant', content: output }],
+      toolCalls: [],
+      fullNumTurns: 1,
+      numSubAgents: 0,
+    },
+    usage,
+  });
+}

--- a/src/eval-workflows/runtime-adapter/adapters/openai-api.ts
+++ b/src/eval-workflows/runtime-adapter/adapters/openai-api.ts
@@ -33,10 +33,10 @@ import {
   type CoreApiTransport,
 } from './api-http.js';
 import {
-  ANTHROPIC_API_CORE_ADAPTER_IMPLEMENTATION_VERSION,
-  anthropicApiExecutorCapabilities,
-  parseAnthropicApiMessage,
-} from './anthropic-api-protocol.js';
+  OPENAI_API_CORE_ADAPTER_IMPLEMENTATION_VERSION,
+  openAIApiExecutorCapabilities,
+  parseOpenAIApiResponse,
+} from './openai-api-protocol.js';
 import {
   captureStatelessApiRunState,
   captureStatelessApiTarget,
@@ -48,51 +48,42 @@ import {
 import { createSameProcessExecutorAdapter } from './same-process.js';
 
 export {
-  ANTHROPIC_API_CORE_ADAPTER_IMPLEMENTATION_VERSION,
-  createAnthropicApiCoreSchemaValidators,
-} from './anthropic-api-protocol.js';
-export type {
-  ApiTransportIdentity,
-  CoreApiTransport,
-  CoreApiTransportRequest,
-} from './api-http.js';
+  OPENAI_API_CORE_ADAPTER_IMPLEMENTATION_VERSION,
+  createOpenAIApiCoreSchemaValidators,
+} from './openai-api-protocol.js';
 
-export const DEFAULT_ANTHROPIC_API_ENDPOINT = 'https://api.anthropic.com/v1/messages';
-export const DEFAULT_ANTHROPIC_API_MAX_REQUEST_BYTES = 2 * 1024 * 1024;
-export const DEFAULT_ANTHROPIC_API_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
-export const DEFAULT_ANTHROPIC_API_MAX_OUTPUT_TOKENS = 8192;
-export const ANTHROPIC_API_VERSION = '2023-06-01';
+export const DEFAULT_OPENAI_API_ENDPOINT = 'https://api.openai.com/v1/responses';
+export const DEFAULT_OPENAI_API_MAX_REQUEST_BYTES = 2 * 1024 * 1024;
+export const DEFAULT_OPENAI_API_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+export const DEFAULT_OPENAI_API_MAX_OUTPUT_TOKENS = 8192;
 
 const RESOURCE_PROFILE = Object.freeze({
-  adapterLabel: 'Anthropic API',
-  errorPrefix: 'OMK_ANTHROPIC_API',
-  promptSchemaVersion: 'omk.anthropic-api-prompt/v1',
+  adapterLabel: 'OpenAI API',
+  errorPrefix: 'OMK_OPENAI_API',
+  promptSchemaVersion: 'omk.openai-api-prompt/v1',
 });
 
-const AnthropicRequestPolicySchema = z.object({
+const OpenAIRequestPolicySchema = z.object({
   maxOutputTokens: z.number().int().positive().max(Number.MAX_SAFE_INTEGER).optional(),
-  stopSequences: z.array(z.string().min(1)).min(1).superRefine((values, context) => {
-    if (new Set(values).size !== values.length) {
-      context.addIssue({ code: 'custom', message: 'stopSequences must not contain duplicates.' });
-    }
-  }).optional(),
 }).strict();
 
-export interface AnthropicApiCoreConfiguration {
+export interface OpenAIApiCoreConfiguration {
   /** Explicit credential. The adapter never reads process.env. */
   readonly apiKey: string;
-  /** Complete Messages endpoint, not a mutable ambient base URL. */
+  /** Complete Responses endpoint, not a mutable ambient base URL. */
   readonly endpoint?: string;
+  readonly organization?: string;
+  readonly project?: string;
   readonly maxRequestBytes?: number;
   readonly maxResponseBytes?: number;
   /** Trusted host seam for offline conformance tests and custom transports. */
   readonly transport?: CoreApiTransport;
 }
 
-export interface CreateAnthropicApiExecutorAdapterInput {
+export interface CreateOpenAIApiExecutorAdapterInput {
   readonly target: EvaluationDefinition['targets'][number];
   readonly binding: RuntimeBindingOf<'executor'>;
-  readonly api: AnthropicApiCoreConfiguration;
+  readonly api: OpenAIApiCoreConfiguration;
   readonly sessionIsolationKey: string;
   readonly resourceLeases: OmkBindingResourceLeaseAccess;
 }
@@ -100,6 +91,8 @@ export interface CreateAnthropicApiExecutorAdapterInput {
 interface CapturedConfiguration {
   readonly apiKey: string;
   readonly endpoint: string;
+  readonly organization?: string;
+  readonly project?: string;
   readonly environmentIdentity: JsonValue[];
   readonly environmentOutputClassification: 'public' | 'sensitive' | 'secret';
   readonly maxRequestBytes: number;
@@ -107,9 +100,8 @@ interface CapturedConfiguration {
   readonly transport: CapturedCoreApiTransport;
 }
 
-interface AnthropicRequestPolicy {
+interface OpenAIRequestPolicy {
   readonly maxOutputTokens: number;
-  readonly stopSequences?: readonly string[];
 }
 
 function fail(
@@ -122,67 +114,76 @@ function fail(
 
 function positiveSafeInteger(value: number, label: string): number {
   if (!Number.isSafeInteger(value) || value <= 0) {
-    throw new TypeError(`Anthropic API ${label} must be a positive safe integer.`);
+    throw new TypeError(`OpenAI API ${label} must be a positive safe integer.`);
   }
   return value;
 }
 
-function captureConfiguration(input: AnthropicApiCoreConfiguration): CapturedConfiguration {
-  const apiKey = requiredApiHeaderValue(input.apiKey, 'Anthropic API apiKey');
+function captureConfiguration(input: OpenAIApiCoreConfiguration): CapturedConfiguration {
+  const apiKey = requiredApiHeaderValue(input.apiKey, 'OpenAI API apiKey');
   const endpoint = normalizeCoreApiEndpoint(
-    input.endpoint ?? DEFAULT_ANTHROPIC_API_ENDPOINT,
-    'Anthropic API endpoint',
+    input.endpoint ?? DEFAULT_OPENAI_API_ENDPOINT,
+    'OpenAI API endpoint',
   );
+  const organization = input.organization === undefined
+    ? undefined
+    : requiredApiHeaderValue(input.organization, 'OpenAI API organization');
+  const project = input.project === undefined
+    ? undefined
+    : requiredApiHeaderValue(input.project, 'OpenAI API project');
   const environment = captureClassifiedEnvironment({
-    ANTHROPIC_API_KEY: {
-      value: apiKey,
-      identity: { identityKind: 'credential' },
-    },
-    ANTHROPIC_API_ENDPOINT: {
-      value: endpoint,
-      identity: { identityKind: 'effect-locator' },
-    },
+    OPENAI_API_KEY: { value: apiKey, identity: { identityKind: 'credential' } },
+    OPENAI_API_ENDPOINT: { value: endpoint, identity: { identityKind: 'effect-locator' } },
+    ...(organization === undefined ? {} : {
+      OPENAI_ORGANIZATION: {
+        value: organization,
+        identity: { identityKind: 'effect-locator' as const },
+      },
+    }),
+    ...(project === undefined ? {} : {
+      OPENAI_PROJECT: {
+        value: project,
+        identity: { identityKind: 'effect-locator' as const },
+      },
+    }),
   });
   return Object.freeze({
-    apiKey: environment.values.ANTHROPIC_API_KEY!,
-    endpoint: environment.values.ANTHROPIC_API_ENDPOINT!,
+    apiKey: environment.values.OPENAI_API_KEY!,
+    endpoint: environment.values.OPENAI_API_ENDPOINT!,
+    ...(organization === undefined ? {} : { organization: environment.values.OPENAI_ORGANIZATION! }),
+    ...(project === undefined ? {} : { project: environment.values.OPENAI_PROJECT! }),
     environmentIdentity: environment.identity,
     environmentOutputClassification: environment.outputClassification,
     maxRequestBytes: positiveSafeInteger(
-      input.maxRequestBytes ?? DEFAULT_ANTHROPIC_API_MAX_REQUEST_BYTES,
+      input.maxRequestBytes ?? DEFAULT_OPENAI_API_MAX_REQUEST_BYTES,
       'maxRequestBytes',
     ),
     maxResponseBytes: positiveSafeInteger(
-      input.maxResponseBytes ?? DEFAULT_ANTHROPIC_API_MAX_RESPONSE_BYTES,
+      input.maxResponseBytes ?? DEFAULT_OPENAI_API_MAX_RESPONSE_BYTES,
       'maxResponseBytes',
     ),
     transport: captureCoreApiTransport(input.transport),
   });
 }
 
-function captureRequestPolicy(target: CapturedStatelessApiTarget): AnthropicRequestPolicy {
-  const parsed = AnthropicRequestPolicySchema.parse(
-    target.config.behavior.config?.value ?? {},
-  );
+function captureRequestPolicy(target: CapturedStatelessApiTarget): OpenAIRequestPolicy {
+  const parsed = OpenAIRequestPolicySchema.parse(target.config.behavior.config?.value ?? {});
   return Object.freeze({
-    maxOutputTokens: parsed.maxOutputTokens ?? DEFAULT_ANTHROPIC_API_MAX_OUTPUT_TOKENS,
-    ...(parsed.stopSequences === undefined
-      ? {}
-      : { stopSequences: Object.freeze([...parsed.stopSequences]) }),
+    maxOutputTokens: parsed.maxOutputTokens ?? DEFAULT_OPENAI_API_MAX_OUTPUT_TOKENS,
   });
 }
 
 function identityManifest(
   configuration: CapturedConfiguration,
   target: CapturedStatelessApiTarget,
-  policy: AnthropicRequestPolicy,
+  policy: OpenAIRequestPolicy,
 ): RuntimeIdentity['implementationManifest'] {
   const facets: RuntimeImplementationFacet[] = [{
     facetId: 'adapter.composition',
     value: {
-      adapterVersion: ANTHROPIC_API_CORE_ADAPTER_IMPLEMENTATION_VERSION,
+      adapterVersion: OPENAI_API_CORE_ADAPTER_IMPLEMENTATION_VERSION,
       cancellation: 'fetch-abort-signal',
-      sourceProtocol: 'Anthropic Messages API',
+      sourceProtocol: 'OpenAI Responses API',
     },
   }, {
     facetId: 'adapter.environment',
@@ -191,9 +192,9 @@ function identityManifest(
     facetId: 'adapter.input-projection',
     value: {
       directoryEntrypoint: 'SKILL.md',
-      promptTransport: 'messages-user-text',
+      promptTransport: 'responses-input-text',
       supportingFiles: 'canonical-user-envelope',
-      systemInstructions: 'top-level-system',
+      systemInstructions: 'top-level-instructions',
       version: RESOURCE_PROFILE.promptSchemaVersion,
     },
   }, {
@@ -203,13 +204,17 @@ function identityManifest(
       maxResponseBytes: configuration.maxResponseBytes,
     },
   }, {
-    facetId: 'anthropic.request',
+    facetId: 'openai.request',
     value: {
-      apiVersion: ANTHROPIC_API_VERSION,
+      background: false,
       effort: target.binding.qualification.effort ?? null,
       maxOutputTokens: policy.maxOutputTokens,
-      stopSequences: policy.stopSequences === undefined ? null : [...policy.stopSequences],
+      parallelToolCalls: false,
+      store: false,
       streaming: false,
+      toolChoice: 'none',
+      tools: 'none',
+      truncation: 'disabled',
     },
   }, {
     facetId: 'runtime.binding',
@@ -234,27 +239,22 @@ function identityManifest(
 function resolveIdentity(
   configuration: CapturedConfiguration,
   target: CapturedStatelessApiTarget,
-  policy: AnthropicRequestPolicy,
+  policy: OpenAIRequestPolicy,
 ): RuntimeIdentity {
-  const capabilities = anthropicApiExecutorCapabilities();
+  const capabilities = openAIApiExecutorCapabilities();
   return deepFreezeCanonicalJson(RuntimeIdentitySchema.parse({
     implementationId: target.binding.implementationId,
-    version: ANTHROPIC_API_CORE_ADAPTER_IMPLEMENTATION_VERSION,
+    version: OPENAI_API_CORE_ADAPTER_IMPLEMENTATION_VERSION,
     fingerprint: digestCanonicalJson({
-      derivation: 'omk.anthropic-api-runtime-fingerprint/v1',
-      adapterVersion: ANTHROPIC_API_CORE_ADAPTER_IMPLEMENTATION_VERSION,
+      derivation: 'omk.openai-api-runtime-fingerprint/v1',
+      adapterVersion: OPENAI_API_CORE_ADAPTER_IMPLEMENTATION_VERSION,
       capabilities,
       environmentIdentity: configuration.environmentIdentity,
       limits: {
         maxRequestBytes: configuration.maxRequestBytes,
         maxResponseBytes: configuration.maxResponseBytes,
       },
-      requestPolicy: {
-        maxOutputTokens: policy.maxOutputTokens,
-        ...(policy.stopSequences === undefined
-          ? {}
-          : { stopSequences: [...policy.stopSequences] }),
-      },
+      requestPolicy: { maxOutputTokens: policy.maxOutputTokens },
       targetBindingDigest: digestCanonicalJson(target.binding),
       transportIdentity: configuration.transport.identity,
     }),
@@ -267,44 +267,47 @@ function resolveIdentity(
 
 function requestBody(
   target: CapturedStatelessApiTarget,
-  policy: AnthropicRequestPolicy,
+  policy: OpenAIRequestPolicy,
   runState: StatelessApiRunState,
   trialState: StatelessApiTrialState,
 ): string {
   return JSON.stringify({
     model: target.binding.qualification.model,
-    max_tokens: policy.maxOutputTokens,
-    messages: [{ role: 'user', content: trialState.prompt }],
-    stream: false,
+    input: trialState.prompt,
     ...(runState.systemInstructions === undefined
       ? {}
-      : { system: runState.systemInstructions }),
+      : { instructions: runState.systemInstructions }),
+    max_output_tokens: policy.maxOutputTokens,
+    stream: false,
+    store: false,
+    background: false,
+    tools: [],
+    tool_choice: 'none',
+    parallel_tool_calls: false,
+    truncation: 'disabled',
     ...(target.binding.qualification.effort === undefined
       ? {}
-      : { output_config: { effort: target.binding.qualification.effort } }),
-    ...(policy.stopSequences === undefined
-      ? {}
-      : { stop_sequences: policy.stopSequences }),
+      : { reasoning: { effort: target.binding.qualification.effort } }),
   });
 }
 
-async function executeAnthropic(
+async function executeOpenAI(
   configuration: CapturedConfiguration,
   target: CapturedStatelessApiTarget,
-  policy: AnthropicRequestPolicy,
+  policy: OpenAIRequestPolicy,
   runState: StatelessApiRunState,
   trialState: StatelessApiTrialState,
   attempt: Readonly<ExecutorAttemptContext>,
 ): Promise<ExecutorAttemptResult> {
   if (attempt.signal.aborted) {
-    fail('OMK_ANTHROPIC_API_CANCELLED', 'execution', 'Anthropic API execution was cancelled.');
+    fail('OMK_OPENAI_API_CANCELLED', 'execution', 'OpenAI API execution was cancelled.');
   }
   const body = requestBody(target, policy, runState, trialState);
   if (Buffer.byteLength(body) > configuration.maxRequestBytes) {
     fail(
-      'OMK_ANTHROPIC_API_INPUT_LIMIT_EXCEEDED',
+      'OMK_OPENAI_API_INPUT_LIMIT_EXCEEDED',
       'infrastructure',
-      'Anthropic API request exceeded the adapter byte limit.',
+      'OpenAI API request exceeded the adapter byte limit.',
     );
   }
   let response: Response;
@@ -313,70 +316,71 @@ async function executeAnthropic(
       endpoint: configuration.endpoint,
       headers: {
         accept: 'application/json',
+        authorization: `Bearer ${configuration.apiKey}`,
         'content-type': 'application/json',
-        'x-api-key': configuration.apiKey,
-        'anthropic-version': ANTHROPIC_API_VERSION,
+        ...(configuration.organization === undefined
+          ? {}
+          : { 'openai-organization': configuration.organization }),
+        ...(configuration.project === undefined
+          ? {}
+          : { 'openai-project': configuration.project }),
       },
       body,
       signal: attempt.signal,
     });
   } catch {
     if (attempt.signal.aborted) {
-      fail('OMK_ANTHROPIC_API_CANCELLED', 'execution', 'Anthropic API execution was cancelled.');
+      fail('OMK_OPENAI_API_CANCELLED', 'execution', 'OpenAI API execution was cancelled.');
     }
-    fail('transport-error', 'infrastructure', 'Anthropic API transport failed.');
+    fail('transport-error', 'infrastructure', 'OpenAI API transport failed.');
   }
   if (!(response instanceof Response)) {
-    fail('OMK_ANTHROPIC_API_TRANSPORT_INVALID', 'infrastructure', 'Anthropic API transport returned an invalid response.');
+    fail('OMK_OPENAI_API_TRANSPORT_INVALID', 'infrastructure', 'OpenAI API transport returned an invalid response.');
   }
   if (!response.ok) {
     await discardApiResponse(response);
     if (response.status === 429 || response.status >= 500) {
-      fail('transport-error', 'infrastructure', 'Anthropic API transport is temporarily unavailable.');
+      fail('transport-error', 'infrastructure', 'OpenAI API transport is temporarily unavailable.');
     }
     if (response.status === 401 || response.status === 403) {
-      fail('OMK_ANTHROPIC_API_AUTH_FAILED', 'execution', 'Anthropic API rejected the configured credential.');
+      fail('OMK_OPENAI_API_AUTH_FAILED', 'execution', 'OpenAI API rejected the configured credential.');
     }
-    fail('OMK_ANTHROPIC_API_REQUEST_REJECTED', 'execution', 'Anthropic API rejected the request.');
+    fail('OMK_OPENAI_API_REQUEST_REJECTED', 'execution', 'OpenAI API rejected the request.');
   }
   const contentType = response.headers.get('content-type')?.toLowerCase();
   if (contentType === undefined || !contentType.startsWith('application/json')) {
     await discardApiResponse(response);
-    fail('OMK_ANTHROPIC_API_PROTOCOL_INVALID', 'execution', 'Anthropic API returned a non-JSON response.');
+    fail('OMK_OPENAI_API_PROTOCOL_INVALID', 'execution', 'OpenAI API returned a non-JSON response.');
   }
   let value;
   try {
     value = await readBoundedJsonResponse(response, configuration.maxResponseBytes);
   } catch (error) {
     if (attempt.signal.aborted) {
-      fail('OMK_ANTHROPIC_API_CANCELLED', 'execution', 'Anthropic API execution was cancelled.');
+      fail('OMK_OPENAI_API_CANCELLED', 'execution', 'OpenAI API execution was cancelled.');
     }
     if (error instanceof ApiResponseLimitError) {
       fail(
-        'OMK_ANTHROPIC_API_OUTPUT_LIMIT_EXCEEDED',
+        'OMK_OPENAI_API_OUTPUT_LIMIT_EXCEEDED',
         'infrastructure',
-        'Anthropic API response exceeded the adapter byte limit.',
+        'OpenAI API response exceeded the adapter byte limit.',
       );
     }
     if (error instanceof ApiResponseBodyError) {
-      fail('OMK_ANTHROPIC_API_PROTOCOL_INVALID', 'execution', 'Anthropic API returned invalid JSON.');
+      fail('OMK_OPENAI_API_PROTOCOL_INVALID', 'execution', 'OpenAI API returned invalid JSON.');
     }
-    fail('transport-error', 'infrastructure', 'Anthropic API response transport failed.');
+    fail('transport-error', 'infrastructure', 'OpenAI API response transport failed.');
   }
   if (value === null) {
-    fail('OMK_ANTHROPIC_API_PROTOCOL_INVALID', 'execution', 'Anthropic API returned an empty response.');
+    fail('OMK_OPENAI_API_PROTOCOL_INVALID', 'execution', 'OpenAI API returned an empty response.');
   }
-  const parsed = parseAnthropicApiMessage(value);
+  const parsed = parseOpenAIApiResponse(value, target.binding.qualification.effort);
   const classification = mergeOutputClassification(
     runState.classification,
     configuration.environmentOutputClassification,
   );
   return {
-    output: {
-      value: parsed.output,
-      classification,
-      mediaType: 'text/plain',
-    },
+    output: { value: parsed.output, classification, mediaType: 'text/plain' },
     trace: {
       value: parsed.trace,
       classification,
@@ -386,20 +390,18 @@ async function executeAnthropic(
   };
 }
 
-/** Creates a binding-local Anthropic Messages API Core Executor. */
-export async function createAnthropicApiExecutorAdapter(
-  input: Readonly<CreateAnthropicApiExecutorAdapterInput>,
+/** Creates a binding-local OpenAI Responses API Core Executor. */
+export async function createOpenAIApiExecutorAdapter(
+  input: Readonly<CreateOpenAIApiExecutorAdapterInput>,
 ): Promise<ExecutionExecutor> {
   if (typeof input.sessionIsolationKey !== 'string' || input.sessionIsolationKey.trim() === '') {
-    throw new TypeError('Anthropic API adapter requires a non-empty sessionIsolationKey.');
+    throw new TypeError('OpenAI API adapter requires a non-empty sessionIsolationKey.');
   }
   const target = captureStatelessApiTarget(input.target, input.binding, RESOURCE_PROFILE);
   const configuration = captureConfiguration(input.api);
   const policy = captureRequestPolicy(target);
   const identity = resolveIdentity(configuration, target, policy);
-  const resourceLeases = Object.freeze({
-    forRun: input.resourceLeases.forRun.bind(input.resourceLeases),
-  });
+  const resourceLeases = Object.freeze({ forRun: input.resourceLeases.forRun.bind(input.resourceLeases) });
   return createSameProcessExecutorAdapter({
     identity,
     sessionIsolationKey: input.sessionIsolationKey,
@@ -421,9 +423,9 @@ export async function createAnthropicApiExecutorAdapter(
             !== canonicalizeJson(target.target.config ?? null)
         ) {
           fail(
-            'OMK_ANTHROPIC_API_TRIAL_MISMATCH',
+            'OMK_OPENAI_API_TRIAL_MISMATCH',
             'infrastructure',
-            'Anthropic API trial does not match the sealed Target binding.',
+            'OpenAI API trial does not match the sealed Target binding.',
           );
         }
         return openStatelessApiTrial(
@@ -434,14 +436,7 @@ export async function createAnthropicApiExecutorAdapter(
         );
       },
       execute({ runState, trialState, attempt }) {
-        return executeAnthropic(
-          configuration,
-          target,
-          policy,
-          runState,
-          trialState,
-          attempt,
-        );
+        return executeOpenAI(configuration, target, policy, runState, trialState, attempt);
       },
       disposeTrial() {},
       disposeRun() {},

--- a/test/eval-workflows/runtime-adapter/openai-api.test.ts
+++ b/test/eval-workflows/runtime-adapter/openai-api.test.ts
@@ -1,0 +1,664 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  digestCanonicalJson,
+  schemaIdentityKey,
+  type EvaluationDefinition,
+  type JsonValue,
+  type SchemaIdentity,
+  type Sha256Digest,
+} from '../../../src/evaluation-core/contracts/index.js';
+import { prepareEvaluationPlan } from '../../../src/evaluation-core/compiler/index.js';
+import {
+  InMemoryRuntimeEventSequencer,
+  executeRunPlan,
+  type ExecutionExecutor,
+  type ExecutorAttemptResult,
+} from '../../../src/evaluation-core/execution/index.js';
+import {
+  createOpenAIApiCoreSchemaValidators,
+  createOpenAIApiExecutorAdapter,
+  type CoreApiTransport,
+  type CoreApiTransportRequest,
+  type OmkBindingResourceLease,
+  type OmkBindingResourceLeaseAccess,
+  type OmkLeasedHostResource,
+  type OpenAIApiCoreConfiguration,
+  type RuntimeBindingOf,
+} from '../../../src/eval-workflows/runtime-adapter/index.js';
+import {
+  testRuntime,
+  validDefinition,
+  validPolicy,
+} from '../../evaluation-core/compiler/fixtures.js';
+
+const roots = new Set<string>();
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  await Promise.all([...roots].map((root) => rm(root, { recursive: true, force: true })));
+  roots.clear();
+});
+
+function digest(value: JsonValue): Sha256Digest {
+  return digestCanonicalJson(value);
+}
+
+interface Observations {
+  readonly requests: CoreApiTransportRequest[];
+  response(request: CoreApiTransportRequest): Promise<Response>;
+}
+
+interface Fixture {
+  readonly target: EvaluationDefinition['targets'][number];
+  readonly binding: RuntimeBindingOf<'executor'>;
+  readonly resourceAccess: OmkBindingResourceLeaseAccess;
+  readonly observations: Observations;
+  readonly transport: CoreApiTransport;
+}
+
+function successResponse(input: Readonly<{
+  output?: unknown[];
+  usage?: unknown;
+  model?: string;
+  status?: string;
+  error?: unknown;
+  statePatch?: Record<string, unknown>;
+}> = {}): Response {
+  return new Response(JSON.stringify({
+    id: 'resp_fixture',
+    object: 'response',
+    model: input.model ?? 'gpt-5.6-fixture-resolved',
+    status: input.status ?? 'completed',
+    output: input.output ?? [{
+      id: 'rs_fixture',
+      type: 'reasoning',
+      summary: [],
+    }, {
+      id: 'msg_fixture',
+      type: 'message',
+      status: 'completed',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'fixture answer', annotations: [] }],
+    }],
+    service_tier: 'default',
+    reasoning: { effort: 'xhigh', summary: null },
+    store: false,
+    background: false,
+    previous_response_id: null,
+    conversation: null,
+    tools: [],
+    tool_choice: 'none',
+    parallel_tool_calls: false,
+    truncation: 'disabled',
+    error: input.error ?? null,
+    ...(input.usage === undefined ? {
+      usage: {
+        input_tokens: 13,
+        input_tokens_details: { cached_tokens: 3, cache_write_tokens: 4 },
+        output_tokens: 7,
+        output_tokens_details: { reasoning_tokens: 2 },
+        total_tokens: 20,
+      },
+    } : { usage: input.usage }),
+    ...(input.statePatch ?? {}),
+  }), { headers: { 'content-type': 'application/json' } });
+}
+
+async function fixture(options: Readonly<{
+  behaviorConfig?: JsonValue;
+  behaviorPatch?: Record<string, JsonValue>;
+  requirementPatch?: Record<string, JsonValue>;
+  response?: (request: CoreApiTransportRequest) => Promise<Response>;
+}> = {}): Promise<Fixture> {
+  const root = await mkdtemp(join(tmpdir(), 'omk-openai-api-core-test-'));
+  roots.add(root);
+  const artifact = '# Knowledge\nUse the OpenAI API fixture rule.';
+  const artifactPath = join(root, 'artifact.md');
+  await writeFile(artifactPath, artifact);
+  const descriptor = {
+    resourceId: 'artifact-a',
+    digest: digest({ artifact }),
+    mediaType: 'text/markdown',
+    classification: 'public' as const,
+    size: Buffer.byteLength(artifact),
+  };
+  const behavior = {
+    artifact: descriptor,
+    ...(options.behaviorConfig === undefined ? {} : {
+      config: { classification: 'public' as const, value: options.behaviorConfig },
+    }),
+    ...(options.behaviorPatch ?? {}),
+  };
+  const config = {
+    behavior,
+    runtime: { model: 'gpt-5.6-fixture', effort: 'xhigh' as const },
+  };
+  const executionRequirements = {
+    systemInstructions: 'required' as const,
+    workspace: 'not-required' as const,
+    mcp: 'not-required' as const,
+    mockInterception: 'not-required' as const,
+    toolPolicy: 'runtime-default' as const,
+    skillDiscovery: 'runtime-default' as const,
+    ...(options.requirementPatch ?? {}),
+  };
+  const target = {
+    targetId: 'target-a',
+    targetKind: 'skill',
+    protocolId: 'omk.invoke/v1',
+    executorId: 'test.omk.openai-api/v1',
+    executionRequirements,
+    config,
+  } as EvaluationDefinition['targets'][number];
+  const binding: RuntimeBindingOf<'executor'> = {
+    runtimeKind: 'executor',
+    bindingId: 'executor-target-a',
+    targetId: 'target-a',
+    implementationId: 'test.omk.openai-api/v1',
+    protocolId: 'omk.invoke/v1',
+    behaviorConfigDigest: digest(config),
+    resourceLeaseRequirements: [{
+      resourceId: 'artifact-a',
+      resourceRole: 'artifact',
+      leaseMode: 'immutable-snapshot',
+    }],
+    qualification: {
+      model: 'gpt-5.6-fixture',
+      effort: 'xhigh',
+      executionRequirements,
+      resourceIntegrity: 'digest-before-use',
+    },
+  };
+  const resource: OmkLeasedHostResource = {
+    resourceId: 'artifact-a',
+    resourceKind: 'artifact',
+    descriptor,
+    snapshotKind: 'file',
+    leaseMode: 'immutable-snapshot',
+    snapshotPath: artifactPath,
+  };
+  const lease: OmkBindingResourceLease = Object.freeze({
+    bindingId: binding.bindingId,
+    consumerKind: 'executor',
+    resourcesByResourceId: new Map([['artifact-a', resource]]),
+  });
+  const observations: Observations = {
+    requests: [],
+    response: options.response ?? (async () => successResponse()),
+  };
+  const transport: CoreApiTransport = {
+    identity: {
+      transportId: 'test.openai-api-transport',
+      version: '1.0.0',
+      fingerprint: digest({ transport: 'fixture' }),
+      fingerprintBasis: 'content-derived',
+      assuranceLevel: 'verified',
+      concurrencySafety: 'parallel-safe',
+      cancellation: 'cooperative',
+      retrySemantics: 'none',
+    },
+    async request(request) {
+      observations.requests.push(request);
+      return observations.response(request);
+    },
+  };
+  return {
+    target,
+    binding,
+    observations,
+    transport,
+    resourceAccess: {
+      forRun(runId) {
+        expect(runId).toBe('run-a');
+        return lease;
+      },
+    },
+  };
+}
+
+async function createAdapter(
+  value: Fixture,
+  api: Partial<OpenAIApiCoreConfiguration> = {},
+): Promise<ExecutionExecutor> {
+  return createOpenAIApiExecutorAdapter({
+    target: value.target,
+    binding: value.binding,
+    api: { apiKey: 'fixture-secret-key', transport: value.transport, ...api },
+    sessionIsolationKey: 'openai-api-session-a',
+    resourceLeases: value.resourceAccess,
+  });
+}
+
+async function execute(
+  port: ExecutionExecutor,
+  targetConfig: JsonValue,
+  signal: AbortSignal = new AbortController().signal,
+): Promise<ExecutorAttemptResult> {
+  const run = await port.openRun({ runId: 'run-a', executionPlanDigest: digest({ plan: 'a' }) });
+  const trial = await run.openTrial({
+    targetId: 'target-a',
+    protocolId: 'omk.invoke/v1',
+    input: { question: 'Q' },
+    executionContext: { locale: 'zh-CN' },
+    targetConfig,
+    trialIndex: 0,
+    trialId: digest({ trial: 'a' }),
+    schedulingBlockId: digest({ block: 'a' }),
+    samplingUnitIds: {},
+  });
+  try {
+    return await trial.execute({
+      attemptId: digest({ attempt: 'a' }),
+      attemptNumber: 1,
+      signal,
+    });
+  } finally {
+    await trial.dispose();
+    await run.dispose();
+  }
+}
+
+describe('OpenAI API Core Executor adapter', () => {
+  it('keeps credentials identity-invariant while effect locators change identity', async () => {
+    const value = await fixture();
+    const first = await createAdapter(value, { apiKey: 'first-secret' });
+    const rotated = await createAdapter(value, { apiKey: 'rotated-secret' });
+    const relocated = await createAdapter(value, {
+      apiKey: 'first-secret',
+      endpoint: 'https://proxy.example.test/openai/responses',
+      organization: 'org-sensitive',
+      project: 'proj-sensitive',
+    });
+
+    expect(first.identity).toEqual(rotated.identity);
+    expect(first.identity.fingerprint).not.toBe(relocated.identity.fingerprint);
+    expect(JSON.stringify(first.identity)).not.toContain('first-secret');
+    expect(JSON.stringify(relocated.identity)).not.toMatch(/proxy\.example|org-sensitive|proj-sensitive/);
+    expect(first.identity).toMatchObject({
+      implementationId: 'test.omk.openai-api/v1',
+      version: '1.0.0',
+      fingerprintBasis: 'opaque',
+      assuranceLevel: 'unknown',
+      capabilities: {
+        protocols: [{
+          protocolId: 'omk.invoke/v1',
+          execution: {
+            concurrency: { safety: 'parallel-safe' },
+            cancellation: 'cooperative',
+          },
+        }],
+      },
+    });
+  });
+
+  it('projects the sealed target into a stateless Responses API request', async () => {
+    const value = await fixture({ behaviorConfig: { maxOutputTokens: 321 } });
+    const result = await execute(await createAdapter(value, {
+      organization: 'org-fixture',
+      project: 'proj-fixture',
+    }), value.target.config as JsonValue);
+
+    expect(result.output).toEqual({
+      value: 'fixture answer',
+      classification: 'secret',
+      mediaType: 'text/plain',
+    });
+    expect(result.trace?.value).toEqual({
+      schemaVersion: 'omk.source-neutral-trace/v1',
+      turns: [{ role: 'assistant', content: 'fixture answer' }],
+      toolCalls: [],
+      fullNumTurns: 1,
+      numSubAgents: 0,
+    });
+    const request = value.observations.requests[0]!;
+    expect(request.endpoint).toBe('https://api.openai.com/v1/responses');
+    expect(request.headers).toEqual({
+      accept: 'application/json',
+      authorization: 'Bearer fixture-secret-key',
+      'content-type': 'application/json',
+      'openai-organization': 'org-fixture',
+      'openai-project': 'proj-fixture',
+    });
+    expect(request.signal).toBeInstanceOf(AbortSignal);
+    expect(JSON.parse(request.body)).toMatchObject({
+      model: 'gpt-5.6-fixture',
+      input: expect.stringContaining('omk.openai-api-prompt/v1'),
+      instructions: '# Knowledge\nUse the OpenAI API fixture rule.',
+      max_output_tokens: 321,
+      stream: false,
+      store: false,
+      background: false,
+      tools: [],
+      tool_choice: 'none',
+      parallel_tool_calls: false,
+      truncation: 'disabled',
+      reasoning: { effort: 'xhigh' },
+    });
+    expect(request.body).not.toContain('fixture-secret-key');
+  });
+
+  it('preserves inclusive usage subsets and leaves provider cost unknown', async () => {
+    const value = await fixture();
+    const result = await execute(await createAdapter(value), value.target.config as JsonValue);
+
+    expect(result.usage).toEqual({
+      inputTokens: 13,
+      outputTokens: 7,
+      totalTokens: 20,
+      details: {
+        provider: 'openai',
+        responseModel: 'gpt-5.6-fixture-resolved',
+        responseStatus: 'completed',
+        tokenAccounting: 'inclusive-provider-totals',
+        cachedInputTokens: 3,
+        cacheWriteInputTokens: 4,
+        reasoningOutputTokens: 2,
+        serviceTier: 'default',
+        effectiveEffort: 'xhigh',
+      },
+    });
+    expect(result.usage).not.toHaveProperty('providerCost');
+  });
+
+  it('keeps absent usage and token details unknown', async () => {
+    const absent = await fixture({ response: async () => successResponse({ usage: null }) });
+    const absentResult = await execute(
+      await createAdapter(absent),
+      absent.target.config as JsonValue,
+    );
+    expect(absentResult.usage).toEqual({
+      details: {
+        provider: 'openai',
+        responseModel: 'gpt-5.6-fixture-resolved',
+        responseStatus: 'completed',
+        tokenAccounting: 'inclusive-provider-totals',
+        serviceTier: 'default',
+        effectiveEffort: 'xhigh',
+      },
+    });
+    expect(absentResult.usage).not.toHaveProperty('inputTokens');
+
+    const noDetails = await fixture({
+      response: async () => successResponse({
+        usage: { input_tokens: 13, output_tokens: 7, total_tokens: 20 },
+      }),
+    });
+    const noDetailsResult = await execute(
+      await createAdapter(noDetails),
+      noDetails.target.config as JsonValue,
+    );
+    expect(noDetailsResult.usage).toMatchObject({ inputTokens: 13, outputTokens: 7 });
+    expect(noDetailsResult.usage?.details).not.toHaveProperty('cachedInputTokens');
+    expect(noDetailsResult.usage?.details).not.toHaveProperty('reasoningOutputTokens');
+  });
+
+  it('preserves usage on incomplete and failed responses without leaking provider details', async () => {
+    const incomplete = await fixture({
+      response: async () => successResponse({
+        status: 'incomplete',
+        output: [],
+        statePatch: { incomplete_details: { reason: 'sensitive reason' } },
+      }),
+    });
+    await expect(execute(
+      await createAdapter(incomplete),
+      incomplete.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: {
+        code: 'OMK_OPENAI_API_RESPONSE_INCOMPLETE',
+        message: 'OpenAI API response was incomplete.',
+      },
+      usage: { inputTokens: 13, outputTokens: 7, totalTokens: 20 },
+    });
+
+    const failed = await fixture({
+      response: async () => successResponse({
+        status: 'failed',
+        output: [],
+        error: { message: 'sensitive provider failure' },
+      }),
+    });
+    await expect(execute(
+      await createAdapter(failed),
+      failed.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: {
+        code: 'OMK_OPENAI_API_RESPONSE_FAILED',
+        message: 'OpenAI API response failed.',
+      },
+      usage: { inputTokens: 13, outputTokens: 7, totalTokens: 20 },
+    });
+  });
+
+  it('rejects tools, refusals, hidden state, and inconsistent usage', async () => {
+    const tool = await fixture({
+      response: async () => successResponse({
+        output: [{ id: 'call_fixture', type: 'function_call', name: 'hidden', arguments: '{}' }],
+      }),
+    });
+    await expect(execute(
+      await createAdapter(tool),
+      tool.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_OPENAI_API_PROTOCOL_INVALID' },
+      usage: { inputTokens: 13 },
+    });
+
+    const refusal = await fixture({
+      response: async () => successResponse({
+        output: [{
+          id: 'msg_fixture',
+          type: 'message',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'refusal', refusal: 'sensitive refusal' }],
+        }],
+      }),
+    });
+    await expect(execute(
+      await createAdapter(refusal),
+      refusal.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_OPENAI_API_PROTOCOL_INVALID' },
+    });
+
+    const stateful = await fixture({
+      response: async () => successResponse({ statePatch: { store: true } }),
+    });
+    await expect(execute(
+      await createAdapter(stateful),
+      stateful.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_OPENAI_API_PROTOCOL_INVALID' },
+    });
+
+    const inconsistent = await fixture({
+      response: async () => successResponse({
+        usage: { input_tokens: 13, output_tokens: 7, total_tokens: 19 },
+      }),
+    });
+    await expect(execute(
+      await createAdapter(inconsistent),
+      inconsistent.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_OPENAI_API_PROTOCOL_INVALID' },
+    });
+
+    const changedEffort = await fixture({
+      response: async () => successResponse({ statePatch: { reasoning: { effort: 'high' } } }),
+    });
+    await expect(execute(
+      await createAdapter(changedEffort),
+      changedEffort.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_OPENAI_API_PROTOCOL_INVALID' },
+      usage: { details: { effectiveEffort: 'high' } },
+    });
+  });
+
+  it('redacts HTTP error bodies and fails oversized success responses closed', async () => {
+    const rejected = await fixture({
+      response: async () => new Response(
+        JSON.stringify({ error: { message: 'sensitive provider rejection' } }),
+        { status: 400, headers: { 'content-type': 'application/json' } },
+      ),
+    });
+    await expect(execute(
+      await createAdapter(rejected),
+      rejected.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: {
+        code: 'OMK_OPENAI_API_REQUEST_REJECTED',
+        message: 'OpenAI API rejected the request.',
+      },
+    });
+
+    const overloaded = await fixture({
+      response: async () => new Response('sensitive overload', { status: 500 }),
+    });
+    await expect(execute(
+      await createAdapter(overloaded),
+      overloaded.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'transport-error', stage: 'infrastructure' },
+    });
+
+    const oversized = await fixture();
+    await expect(execute(
+      await createAdapter(oversized, { maxResponseBytes: 32 }),
+      oversized.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_OPENAI_API_OUTPUT_LIMIT_EXCEEDED' },
+    });
+  });
+
+  it('forwards cancellation to the transport and waits for settlement', async () => {
+    let started = false;
+    let settled = false;
+    const value = await fixture({
+      response: async (request) => new Promise<Response>((_resolve, reject) => {
+        started = true;
+        request.signal.addEventListener('abort', () => {
+          settled = true;
+          reject(new DOMException('sensitive abort reason', 'AbortError'));
+        }, { once: true });
+      }),
+    });
+    const controller = new AbortController();
+    const promise = execute(
+      await createAdapter(value),
+      value.target.config as JsonValue,
+      controller.signal,
+    );
+    await expect.poll(() => started).toBe(true);
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_OPENAI_API_CANCELLED' },
+    });
+    expect(settled).toBe(true);
+  });
+
+  it('captures the default fetch implementation and disables redirects', async () => {
+    const value = await fixture();
+    const capturedFetch = vi.fn(async (
+      _input: string | URL | Request,
+      _init?: RequestInit,
+    ) => successResponse());
+    const replacementFetch = vi.fn(async (
+      _input: string | URL | Request,
+      _init?: RequestInit,
+    ) => successResponse());
+    vi.stubGlobal('fetch', capturedFetch);
+    const port = await createAdapter(value, { transport: undefined });
+    vi.stubGlobal('fetch', replacementFetch);
+
+    await execute(port, value.target.config as JsonValue);
+
+    expect(capturedFetch).toHaveBeenCalledOnce();
+    expect(replacementFetch).not.toHaveBeenCalled();
+    expect(capturedFetch.mock.calls[0]?.[0]).toBe('https://api.openai.com/v1/responses');
+    expect(capturedFetch.mock.calls[0]?.[1]).toMatchObject({
+      method: 'POST',
+      redirect: 'error',
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('rejects ambient credentials, insecure endpoints, and unsupported controls before calls', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'ambient-secret');
+    const value = await fixture();
+    await expect(createAdapter(value, {
+      apiKey: undefined as unknown as string,
+    })).rejects.toThrow(/apiKey/);
+    await expect(createAdapter(value, {
+      endpoint: 'http://provider.example.test/v1/responses',
+    })).rejects.toThrow(/must use HTTPS/);
+    await expect(createAdapter(value, {
+      endpoint: 'https://api.example.test/v1/responses?api_key=secret',
+    })).rejects.toThrow(/credential-free/);
+    await expect(createAdapter(value, {
+      organization: 'org-fixture\nAuthorization: injected',
+    })).rejects.toThrow(/header-safe/);
+
+    const temperature = await fixture({ behaviorConfig: { temperature: 0 } });
+    await expect(createAdapter(temperature)).rejects.toThrow();
+    const tools = await fixture({
+      behaviorPatch: { allowedTools: [] },
+      requirementPatch: { toolPolicy: 'allow-list' },
+    });
+    await expect(createAdapter(tools)).rejects.toThrow(/supports no workspace, MCP, mocks/);
+    expect(value.observations.requests).toHaveLength(0);
+    expect(temperature.observations.requests).toHaveLength(0);
+    expect(tools.observations.requests).toHaveLength(0);
+  });
+
+  it('passes real Core prepare and execution with the advertised contract', async () => {
+    const value = await fixture();
+    const port = await createAdapter(value);
+    const definition = validDefinition();
+    definition.targets = [{ ...value.target }];
+    definition.experiment.randomizationSlots = [{
+      targetId: value.target.targetId,
+      randomizationSlotId: 'slot-target-a',
+    }];
+    definition.experiment.sampling.seedCoupling = 'uncontrolled';
+    definition.comparisons = [];
+    const policy = validPolicy();
+    policy.cache.executionMode = 'disabled';
+    policy.evidence.trace = 'full';
+    policy.evidence.maximumClassification = 'secret';
+    delete policy.execution.timeoutMs;
+    policy.retry.maxAttempts = 1;
+    const runtime = testRuntime();
+    runtime.resolveExecutor = () => ({ identity: port.identity, satisfiesVersionConstraint: true });
+    for (const validator of createOpenAIApiCoreSchemaValidators()) {
+      (runtime.schemaValidators as Map<string, {
+        schema: SchemaIdentity;
+        parse(value: unknown): JsonValue;
+      }>).set(schemaIdentityKey(validator.schema), validator);
+    }
+    const plan = await prepareEvaluationPlan(definition, policy, runtime);
+    const bundle = await executeRunPlan(plan, {
+      executorsByTargetId: new Map([['target-a', port]]),
+      eventSequencer: new InMemoryRuntimeEventSequencer(),
+      clock: {
+        monotonicNow: () => performance.now(),
+        timestamp: () => new Date().toISOString(),
+        sleep: async (_delayMs, signal) => {
+          if (signal.aborted) throw new Error('aborted');
+        },
+      },
+    }, { runId: 'run-a', bundleId: 'bundle-openai-api' });
+
+    expect(bundle.executionBundleStatus).toBe('completed');
+    expect(bundle.records[0]).toMatchObject({
+      executionStatus: 'completed',
+      output: { value: 'fixture answer', classification: 'secret' },
+    });
+  });
+});


### PR DESCRIPTION
## 用户影响

为 #457 增加面向 Evaluation Core 的 OpenAI Responses API Executor adapter。宿主现在可以用显式 credential、完整 endpoint 与可选 organization／project 装配 binding-local OpenAI Runtime，并由真实 Core prepare 校验其 identity、capability 与 schema。

适配器固定使用无状态请求：关闭 response storage、background、工具调用、parallel tool calls 与自动截断；取消信号直接到达底层 HTTP transport，adapter 不建立第二套 timeout、retry、budget 或 cache policy。provider body 与原始异常不会进入结构化错误。

## 迁移说明

本 PR 不接管正式 `omk eval`，不修改旧 OpenAI-compatible Chat Completions executor，也不改变现有环境变量或 Report。Core 宿主需显式提供 API 配置；后续 preflight 负责 credential 与 connectivity，不由 adapter 读取 ambient env。

## Construct validity

OpenAI 的 input／output total 是 inclusive provider totals；cached 与 cache-write token 作为 input 子集保留，reasoning token 作为 output 子集保留，避免重复计数。未报告 usage／cost 保持 unknown。远端 model／deployment 无法由本地完整证明，因此 identity 保持 opaque／unknown；endpoint、organization 与 project 作为 effect locator 进入摘要身份，credential rotation 不改变实验身份。provider 若回报 reasoning effort 漂移、隐藏工具／会话状态或不一致 usage，执行 fail closed。

Refs #457。