### PR TITLE
feat(eval-core): 增加 DSH Host Core 适配器

### DIFF
--- a/src/dsh-plugin/core-adapter.ts
+++ b/src/dsh-plugin/core-adapter.ts
@@ -1,0 +1,949 @@
+import { randomUUID } from 'node:crypto';
+import {
+  JsonValueSchema,
+  RuntimeIdentitySchema,
+  canonicalizeJson,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  type EvaluationDefinition,
+  type JsonValue,
+  type RuntimeIdentity,
+  type RuntimeImplementationFacet,
+  type UsageRecord,
+} from '../evaluation-core/contracts/index.js';
+import {
+  ExecutionPortFailure,
+  type ExecutionExecutor,
+  type ExecutorAttemptContext,
+  type ExecutorAttemptResult,
+} from '../evaluation-core/execution/index.js';
+import { createDshHostRuntimeFingerprint } from '../executors/core/runtime-fingerprint.js';
+import {
+  captureClaudeCliRunState,
+  captureClaudeCliTarget,
+  disposeClaudeCliTrial,
+  openClaudeCliTrial,
+  type CapturedClaudeCliTarget,
+  type ClaudeCliRunState,
+  type ClaudeCliTrialState,
+  type ClaudeResourceProjectionProfile,
+} from '../eval-workflows/runtime-adapter/adapters/claude-cli-resources.js';
+import { createSameProcessExecutorAdapter } from '../eval-workflows/runtime-adapter/adapters/same-process.js';
+import type { OmkBindingResourceLeaseAccess } from '../eval-workflows/runtime-adapter/resource-leases/types.js';
+import type { RuntimeBindingOf } from '../eval-workflows/runtime-adapter/types.js';
+import {
+  DSH_HOST_CORE_ADAPTER_IMPLEMENTATION_VERSION,
+  dshHostCoreExecutorCapabilities,
+  parseDshHostCoreResult,
+} from './core-protocol.js';
+import type {
+  DshAgentLike,
+  DshHostContextLike,
+  DshSessionLike,
+} from './host-executor.js';
+import type { DshHostRunResult } from './protocol.js';
+import { supportsDshTraceEventType } from './trace-adapter.js';
+
+export {
+  DSH_HOST_CORE_ADAPTER_IMPLEMENTATION_VERSION,
+  createDshHostCoreSchemaValidators,
+} from './core-protocol.js';
+
+export const DEFAULT_DSH_HOST_CORE_MAX_INPUT_BYTES = 2 * 1024 * 1024;
+export const DEFAULT_DSH_HOST_CORE_MAX_EVENT_BYTES = 10 * 1024 * 1024;
+
+const RESOURCE_PROFILE = Object.freeze({
+  adapterLabel: 'DSH Host',
+  errorPrefix: 'OMK_DSH_HOST',
+  mcpMockMode: 'hook-existing-tool',
+  promptSchemaVersion: 'omk.dsh-host-prompt/v1',
+}) satisfies ClaudeResourceProjectionProfile;
+
+export interface DshHostCoreConfiguration {
+  /** Interactive host session whose effective provider and preset are inherited. */
+  readonly parentAgent?: DshAgentLike;
+  /** Explicit host provider route when no parent session supplies one. */
+  readonly provider?: string;
+  readonly maxInputBytes?: number;
+  readonly maxEventBytes?: number;
+}
+
+export interface CreateDshHostCoreExecutorAdapterInput {
+  readonly target: EvaluationDefinition['targets'][number];
+  readonly binding: RuntimeBindingOf<'executor'>;
+  readonly host: DshHostContextLike;
+  readonly dsh?: DshHostCoreConfiguration;
+  readonly sessionIsolationKey: string;
+  readonly resourceLeases: OmkBindingResourceLeaseAccess;
+}
+
+interface CapturedToolSchema {
+  readonly name: string;
+  readonly value: JsonValue;
+}
+
+interface CapturedHost {
+  readonly createAgent: DshHostContextLike['agents']['create'];
+  readonly subscribeCreated: (listener: (session: DshSessionLike) => void) => () => void;
+  readonly subscribeEvent: (
+    listener: (session: DshSessionLike, event: Record<string, unknown>) => void,
+  ) => () => void;
+  readonly readToolSchemas: () => readonly Record<string, unknown>[];
+  readonly readActiveAgentPreset?: () => string | undefined;
+  readonly composeFrom?: (agentContext: object) => string | undefined;
+  readonly parentAgentId?: string;
+  readonly provider: string;
+  readonly activeAgentPreset?: string;
+  readonly effectiveToolSchemas: readonly CapturedToolSchema[];
+  readonly maxInputBytes: number;
+  readonly maxEventBytes: number;
+}
+
+function record(value: unknown): Readonly<Record<string, unknown>> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Readonly<Record<string, unknown>>
+    : undefined;
+}
+
+function positiveSafeInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`DSH Host ${label} must be a positive safe integer.`);
+  }
+  return value;
+}
+
+function optionalNonEmptyString(value: string | undefined, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.trim() === '' || value.includes('\0')) {
+    throw new TypeError(`DSH Host ${label} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function fail(
+  code: string,
+  stage: 'infrastructure' | 'execution',
+  message: string,
+  usage?: UsageRecord,
+): never {
+  throw new ExecutionPortFailure({ code, stage, message }, usage);
+}
+
+function validateDshTargetSubset(
+  target: EvaluationDefinition['targets'][number],
+): void {
+  const config = record(target.config);
+  const behavior = record(config?.behavior);
+  const runtime = record(config?.runtime);
+  if (behavior === undefined || runtime === undefined) {
+    throw new TypeError('DSH Host Target config is invalid.');
+  }
+  if (runtime.effort !== undefined) {
+    throw new TypeError(
+      'DSH Host Core adapter cannot map the generic reasoning effort to the host provider.',
+    );
+  }
+  if (behavior.mcpConfig !== undefined || behavior.mocks !== undefined) {
+    throw new TypeError('DSH Host Core adapter does not inject MCP config or mock interception.');
+  }
+  if (behavior.sandbox !== undefined) {
+    throw new TypeError('DSH Host Core adapter does not provide a verifiable sandbox.');
+  }
+  if (behavior.config !== undefined) {
+    throw new TypeError('DSH Host Core adapter does not accept opaque provider config.');
+  }
+  const requirements = target.executionRequirements;
+  const expectedWorkspace = behavior.workspace === undefined
+    ? 'not-required'
+    : 'copy-on-write-overlay';
+  const expectedToolPolicy = behavior.allowedTools === undefined
+    ? 'runtime-default'
+    : 'allow-list';
+  const expectedSkillDiscovery = behavior.allowedSkills === undefined
+    ? 'runtime-default'
+    : Array.isArray(behavior.allowedSkills) && behavior.allowedSkills.length === 0
+      ? 'disabled'
+      : 'allow-list';
+  if (
+    requirements.workspace !== expectedWorkspace
+    || requirements.mcp !== 'not-required'
+    || requirements.mockInterception !== 'not-required'
+    || requirements.toolPolicy !== expectedToolPolicy
+    || requirements.skillDiscovery !== expectedSkillDiscovery
+    || requirements.sandboxId !== undefined
+  ) {
+    throw new TypeError('DSH Host behavior and execution requirements are inconsistent.');
+  }
+}
+
+function toolSchemas(
+  values: readonly Record<string, unknown>[],
+): readonly CapturedToolSchema[] {
+  const captured: CapturedToolSchema[] = [];
+  const names = new Set<string>();
+  for (const value of values) {
+    if (typeof value.name !== 'string' || value.name.trim() === '' || names.has(value.name)) {
+      throw new TypeError('DSH Host tool schemas must have unique non-empty names.');
+    }
+    let schema: JsonValue;
+    try {
+      schema = JsonValueSchema.parse(structuredClone(value));
+    } catch {
+      throw new TypeError('DSH Host tool schemas must be canonical JSON values.');
+    }
+    names.add(value.name);
+    captured.push(Object.freeze({ name: value.name, value: schema }));
+  }
+  return Object.freeze(captured);
+}
+
+function effectiveToolSchemas(
+  schemas: readonly CapturedToolSchema[],
+  target: CapturedClaudeCliTarget,
+): readonly CapturedToolSchema[] {
+  const allowedTools = target.config.behavior.allowedTools;
+  const disableSkills = target.config.behavior.allowedSkills !== undefined;
+  if (disableSkills && allowedTools?.includes('skill')) {
+    throw new TypeError('DSH Host disabled skills conflict with the skill tool allow-list.');
+  }
+  const available = new Set(schemas.map(({ name }) => name));
+  if (allowedTools?.some((name) => !available.has(name))) {
+    throw new TypeError('DSH Host tool allow-list references an unavailable host tool.');
+  }
+  if (allowedTools !== undefined
+      && target.config.behavior.allowedSkills === undefined
+      && !allowedTools.includes('skill')) {
+    throw new TypeError(
+      'DSH Host runtime-default skill discovery requires the skill tool in a tool allow-list.',
+    );
+  }
+  return Object.freeze(schemas.filter(({ name }) => (
+    (allowedTools === undefined || allowedTools.includes(name))
+    && (!disableSkills || name !== 'skill')
+  )));
+}
+
+function captureHost(
+  input: Readonly<CreateDshHostCoreExecutorAdapterInput>,
+  target: CapturedClaudeCliTarget,
+): CapturedHost {
+  if (typeof input.host?.agents?.create !== 'function'
+      || typeof input.host.on !== 'function'
+      || typeof input.host.agentPresets?.composedPreset !== 'function'
+      || typeof input.host.agentPresets?.composeFrom !== 'function'
+      || typeof input.host.tools?.schemas !== 'function') {
+    throw new TypeError('DSH Host Core adapter requires agents, events, presets, and tool schemas.');
+  }
+  const configuration = input.dsh ?? {};
+  const parentAgent = configuration.parentAgent;
+  const provider = optionalNonEmptyString(
+    configuration.provider ?? parentAgent?.options.provider,
+    'provider',
+  );
+  if (provider === undefined) {
+    throw new TypeError(
+      'DSH Host Core adapter requires an explicit or parent-inherited provider route.',
+    );
+  }
+  let activeAgentPreset: string | undefined;
+  try {
+    activeAgentPreset = parentAgent === undefined
+      ? undefined
+      : optionalNonEmptyString(
+          input.host.agentPresets.composedPreset(parentAgent.ctx),
+          'agent preset',
+        );
+  } catch {
+    throw new TypeError('DSH Host Core adapter could not capture the effective agent preset.');
+  }
+  const createAgent = input.host.agents.create.bind(input.host.agents);
+  const subscribe = input.host.on.bind(input.host) as DshHostContextLike['on'];
+  const readSchemas = input.host.tools.schemas.bind(input.host.tools, parentAgent);
+  const composeFrom = input.host.agentPresets.composeFrom;
+  const composedPreset = input.host.agentPresets.composedPreset;
+  let capturedSchemas: readonly CapturedToolSchema[];
+  try {
+    capturedSchemas = toolSchemas(readSchemas());
+  } catch {
+    throw new TypeError('DSH Host Core adapter could not capture effective tool schemas.');
+  }
+  return Object.freeze({
+    createAgent,
+    subscribeCreated(listener: (session: DshSessionLike) => void) {
+      return subscribe('session/created', listener);
+    },
+    subscribeEvent(
+      listener: (session: DshSessionLike, event: Record<string, unknown>) => void,
+    ) {
+      return subscribe('session/event', listener);
+    },
+    readToolSchemas: readSchemas,
+    ...(parentAgent === undefined ? {} : {
+      readActiveAgentPreset() {
+        return Reflect.apply(
+          composedPreset,
+          input.host.agentPresets,
+          [parentAgent.ctx],
+        ) as string | undefined;
+      },
+    }),
+    ...(parentAgent === undefined ? {} : {
+      composeFrom(agentContext: object) {
+        return Reflect.apply(
+          composeFrom,
+          input.host.agentPresets,
+          [agentContext, parentAgent.ctx],
+        ) as string | undefined;
+      },
+    }),
+    ...(parentAgent === undefined ? {} : { parentAgentId: String(parentAgent.id) }),
+    provider,
+    ...(activeAgentPreset === undefined ? {} : { activeAgentPreset }),
+    effectiveToolSchemas: effectiveToolSchemas(capturedSchemas, target),
+    maxInputBytes: positiveSafeInteger(
+      configuration.maxInputBytes ?? DEFAULT_DSH_HOST_CORE_MAX_INPUT_BYTES,
+      'maxInputBytes',
+    ),
+    maxEventBytes: positiveSafeInteger(
+      configuration.maxEventBytes ?? DEFAULT_DSH_HOST_CORE_MAX_EVENT_BYTES,
+      'maxEventBytes',
+    ),
+  });
+}
+
+function legacyEvidence(
+  target: CapturedClaudeCliTarget,
+  host: CapturedHost,
+) {
+  return createDshHostRuntimeFingerprint(target.binding.qualification.model, {
+    provider: host.provider,
+    ...(host.activeAgentPreset === undefined ? {} : { agentPreset: host.activeAgentPreset }),
+    toolSchemas: host.effectiveToolSchemas.map(({ value }) => value),
+  });
+}
+
+function resolveIdentity(
+  target: CapturedClaudeCliTarget,
+  host: CapturedHost,
+): RuntimeIdentity {
+  const capabilities = dshHostCoreExecutorCapabilities();
+  const evidence = legacyEvidence(target, host);
+  const facets: RuntimeImplementationFacet[] = [{
+    facetId: 'adapter.composition',
+    value: {
+      adapterVersion: DSH_HOST_CORE_ADAPTER_IMPLEMENTATION_VERSION,
+      cancellation: 'host-cancel-then-await-idle',
+      processIsolation: 'host-agent-per-attempt',
+      sourceProtocol: 'DeepSeek Harness host session events',
+    },
+  }, {
+    facetId: 'adapter.input-projection',
+    value: {
+      artifact: 'complete-system-prompt-section-plus-supporting-files',
+      directoryEntrypoint: 'SKILL.md',
+      promptTransport: 'agent-followup',
+      runtimeContext: 'suppressed',
+      version: RESOURCE_PROFILE.promptSchemaVersion,
+    },
+  }, {
+    facetId: 'adapter.limits',
+    value: {
+      maxEventBytes: host.maxEventBytes,
+      maxInputBytes: host.maxInputBytes,
+    },
+  }, {
+    facetId: 'dsh.host-coverage',
+    value: {
+      auditability: 'partial',
+      dshPackageVersion: evidence.binary?.version ?? null,
+      hostCompositionDigest: evidence.binary?.contentHash ?? null,
+      omkPackageVersion: evidence.sdk?.version ?? null,
+      provider: host.provider,
+      presetDigest: host.activeAgentPreset === undefined
+        ? null
+        : digestCanonicalJson(host.activeAgentPreset),
+      revalidation: 'effective-preset-and-tool-schemas-before-each-agent',
+      toolSchemaDigest: digestCanonicalJson(
+        host.effectiveToolSchemas.map(({ value }) => value),
+      ),
+      toolSchemaCount: host.effectiveToolSchemas.length,
+    },
+  }, {
+    facetId: 'dsh.tool-policy',
+    value: {
+      skillDiscovery: target.config.behavior.allowedSkills === undefined
+        ? 'runtime-default'
+        : 'disabled',
+      toolPolicy: target.config.behavior.allowedTools === undefined
+        ? 'runtime-default'
+        : 'allow-list',
+    },
+  }, {
+    facetId: 'runtime.binding',
+    value: {
+      behaviorConfigDigest: target.binding.behaviorConfigDigest,
+      deploymentCoverage: 'remote-provider-and-host-plugins-partial',
+      effort: null,
+      model: target.binding.qualification.model,
+      protocolId: target.binding.protocolId,
+      providerTransportRetries: 'runtime-opaque',
+      sandbox: 'none',
+      workspace: target.config.behavior.workspace === undefined
+        ? 'private-ephemeral-run'
+        : 'copy-on-write-overlay',
+    },
+  }];
+  return deepFreezeCanonicalJson(RuntimeIdentitySchema.parse({
+    implementationId: target.binding.implementationId,
+    ...(evidence.binary?.version === undefined ? {} : { version: evidence.binary.version }),
+    fingerprint: digestCanonicalJson({
+      derivation: 'omk.dsh-host-core-runtime-fingerprint/v1',
+      adapterVersion: DSH_HOST_CORE_ADAPTER_IMPLEMENTATION_VERSION,
+      capabilities,
+      bindingDigest: digestCanonicalJson(target.binding),
+      hostEvidence: {
+        legacyFingerprint: evidence.fingerprint,
+        compositionHash: evidence.binary?.contentHash ?? null,
+        dshVersion: evidence.binary?.version ?? null,
+        omkVersion: evidence.sdk?.version ?? null,
+      },
+      limits: { maxEventBytes: host.maxEventBytes, maxInputBytes: host.maxInputBytes },
+      provider: host.provider,
+      presetDigest: host.activeAgentPreset === undefined
+        ? null
+        : digestCanonicalJson(host.activeAgentPreset),
+      toolSchemas: host.effectiveToolSchemas.map(({ value }) => value),
+    }),
+    fingerprintBasis: 'environment-derived',
+    assuranceLevel: 'declared',
+    capabilities,
+    implementationManifest: { coverageKind: 'fingerprint-plus-facets', facets },
+  }));
+}
+
+function currentToolPolicy(host: CapturedHost, target: CapturedClaudeCliTarget): {
+  readonly effective: readonly CapturedToolSchema[];
+  readonly denied: readonly string[];
+} {
+  let rawSchemas: readonly Record<string, unknown>[];
+  try {
+    rawSchemas = host.readToolSchemas();
+  } catch {
+    fail(
+      'OMK_DSH_HOST_IDENTITY_REVALIDATION_FAILED',
+      'infrastructure',
+      'DSH Host effective tool schemas could not be revalidated.',
+    );
+  }
+  let all: readonly CapturedToolSchema[];
+  let effective: readonly CapturedToolSchema[];
+  try {
+    all = toolSchemas(rawSchemas);
+    effective = effectiveToolSchemas(all, target);
+  } catch {
+    fail(
+      'OMK_DSH_HOST_IDENTITY_CHANGED',
+      'infrastructure',
+      'DSH Host effective tool schemas changed after adapter assembly.',
+    );
+  }
+  const effectiveNames = new Set(effective.map(({ name }) => name));
+  return {
+    effective,
+    denied: Object.freeze(all.map(({ name }) => name).filter((name) => !effectiveNames.has(name))),
+  };
+}
+
+function assertHostCompositionUnchanged(
+  host: CapturedHost,
+  target: CapturedClaudeCliTarget,
+  signal: AbortSignal,
+): readonly string[] {
+  if (signal.aborted) {
+    fail('OMK_DSH_HOST_CANCELLED', 'execution', 'DSH Host execution was cancelled.');
+  }
+  const policy = currentToolPolicy(host, target);
+  if (canonicalizeJson(policy.effective.map(({ value }) => value))
+      !== canonicalizeJson(host.effectiveToolSchemas.map(({ value }) => value))) {
+    fail(
+      'OMK_DSH_HOST_IDENTITY_CHANGED',
+      'infrastructure',
+      'DSH Host effective tool schemas changed after adapter assembly.',
+    );
+  }
+  if (host.readActiveAgentPreset !== undefined) {
+    let activePreset: string | undefined;
+    try {
+      activePreset = host.readActiveAgentPreset();
+    } catch {
+      fail(
+        'OMK_DSH_HOST_IDENTITY_REVALIDATION_FAILED',
+        'infrastructure',
+        'DSH Host effective agent preset could not be revalidated.',
+      );
+    }
+    if (activePreset !== host.activeAgentPreset) {
+      fail(
+        'OMK_DSH_HOST_IDENTITY_CHANGED',
+        'infrastructure',
+        'DSH Host effective agent preset changed after adapter assembly.',
+      );
+    }
+  }
+  return policy.denied;
+}
+
+function createPromptMessage(prompt: string): Record<string, unknown> {
+  return Object.freeze({
+    id: randomUUID(),
+    role: 'user',
+    content: [Object.freeze({ type: 'text', text: prompt })],
+    // `source.kind` mirrors the host-owned DSH message protocol.
+    source: Object.freeze({ kind: 'user' }),
+  });
+}
+
+function textFromContent(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (!Array.isArray(value)) return '';
+  return value.flatMap((block) => {
+    const item = record(block);
+    return item?.type === 'text' && typeof item.text === 'string' ? [item.text] : [];
+  }).join('');
+}
+
+function lastRootAssistantText(result: DshHostRunResult): string {
+  for (let index = result.events.length - 1; index >= 0; index -= 1) {
+    const item = result.events[index];
+    if (item?.sessionId !== result.rootSessionId || item.event.type !== 'assistant/message') {
+      continue;
+    }
+    const data = record(item.event.data);
+    const message = record(data?.message);
+    const text = textFromContent(message?.content);
+    if (text !== '') return text;
+  }
+  return '';
+}
+
+async function waitForIdleOrCancellation(
+  agent: DshAgentLike,
+  signal: AbortSignal,
+): Promise<'idle' | 'cancelled'> {
+  let removeAbortListener: (() => void) | undefined;
+  const idle = agent.whenIdle();
+  if (signal.aborted) {
+    try { agent.cancel({ kind: 'hook', reason: 'OMK Core attempt was cancelled' }); } catch { /* settle below */ }
+    await idle;
+    return 'cancelled';
+  }
+  let outcome: 'idle' | 'cancelled';
+  try {
+    outcome = await Promise.race([
+      idle.then(() => 'idle' as const),
+      new Promise<'cancelled'>((resolve) => {
+        const onAbort = (): void => resolve('cancelled');
+        signal.addEventListener('abort', onAbort, { once: true });
+        removeAbortListener = () => signal.removeEventListener('abort', onAbort);
+        if (signal.aborted) onAbort();
+      }),
+    ]);
+  } finally {
+    removeAbortListener?.();
+  }
+  if (outcome === 'idle') return outcome;
+  try { agent.cancel({ kind: 'hook', reason: 'OMK Core attempt was cancelled' }); } catch { /* settle below */ }
+  await idle;
+  return outcome;
+}
+
+function executionFailure(error: unknown, signal: AbortSignal): ExecutionPortFailure {
+  if (error instanceof ExecutionPortFailure) return error;
+  if (signal.aborted) {
+    return new ExecutionPortFailure({
+      code: 'OMK_DSH_HOST_CANCELLED',
+      stage: 'execution',
+      message: 'DSH Host execution was cancelled.',
+    });
+  }
+  return new ExecutionPortFailure({
+    code: 'OMK_DSH_HOST_SESSION_FAILED',
+    stage: 'execution',
+    message: 'DSH Host session failed.',
+  });
+}
+
+async function executeDshHost(
+  host: CapturedHost,
+  target: CapturedClaudeCliTarget,
+  runState: ClaudeCliRunState,
+  trialState: ClaudeCliTrialState,
+  attempt: Readonly<ExecutorAttemptContext>,
+  operationIsolationKey: string,
+): Promise<ExecutorAttemptResult> {
+  const deniedTools = assertHostCompositionUnchanged(host, target, attempt.signal);
+  const allowedTools = target.config.behavior.allowedTools;
+  const skillsDisabled = target.config.behavior.allowedSkills !== undefined;
+  const effectiveToolNames = Object.freeze(
+    host.effectiveToolSchemas.map(({ name }) => name),
+  );
+  const effectiveToolNameSet = new Set(effectiveToolNames);
+  const rootSessionId = `omk-core-${digestCanonicalJson({
+    derivation: 'omk.dsh-host-attempt-session/v1',
+    operationIsolationKey,
+    attemptId: attempt.attemptId,
+  }).replace(/^sha256:/, '')}`;
+  const descendants = new Set<string>();
+  const events: DshHostRunResult['events'] = [];
+  let handle: Awaited<ReturnType<DshHostContextLike['agents']['create']>> | undefined;
+  let eventBytes = 0;
+  let eventCaptureInvalid = false;
+  let eventEnvelopeInvalid = false;
+  let eventLimitExceeded = false;
+  let eventProtocolUnsupported = false;
+  const expectedSequenceBySession = new Map<string, number>();
+  let cancellationRequested = false;
+  const requestCancellation = (): void => {
+    if (cancellationRequested || handle === undefined) return;
+    cancellationRequested = true;
+    try {
+      handle.agent.cancel({ kind: 'hook', reason: 'OMK Core rejected the host event stream' });
+    } catch {
+      // The adapter still awaits host settlement and reports the bounded failure.
+    }
+  };
+  let disposeCreated: () => void = () => undefined;
+  let disposeEvents: () => void = () => undefined;
+  try {
+    disposeCreated = host.subscribeCreated((session) => {
+      const parent = session.header.parentSession;
+      if (parent !== rootSessionId && (parent === undefined || !descendants.has(parent))) return;
+      descendants.add(String(session.id));
+    });
+    disposeEvents = host.subscribeEvent((session, event) => {
+      if (
+        eventCaptureInvalid
+        || eventEnvelopeInvalid
+        || eventLimitExceeded
+        || eventProtocolUnsupported
+      ) return;
+      const sessionId = String(session.id);
+      const traceRole = sessionId === rootSessionId
+        ? 'main'
+        : descendants.has(sessionId)
+          ? 'subagent'
+          : undefined;
+      if (traceRole === undefined) return;
+      try {
+        const captured = JsonValueSchema.parse(structuredClone(event));
+        const capturedRecord = record(captured);
+        if (capturedRecord === undefined) throw new TypeError('event must be an object');
+        if (typeof capturedRecord.type !== 'string' || capturedRecord.type === '') {
+          throw new TypeError('event type must be a non-empty string');
+        }
+        const expectedSequence = expectedSequenceBySession.get(sessionId) ?? 0;
+        if (
+          !Number.isSafeInteger(capturedRecord.seq)
+          || capturedRecord.seq !== expectedSequence
+          || !Number.isSafeInteger(capturedRecord.time)
+          || (capturedRecord.time as number) < 0
+        ) {
+          eventEnvelopeInvalid = true;
+          requestCancellation();
+          return;
+        }
+        const nextEventBytes = eventBytes + Buffer.byteLength(canonicalizeJson(captured));
+        if (!Number.isSafeInteger(nextEventBytes) || nextEventBytes > host.maxEventBytes) {
+          eventLimitExceeded = true;
+          requestCancellation();
+          return;
+        }
+        eventBytes = nextEventBytes;
+        expectedSequenceBySession.set(sessionId, expectedSequence + 1);
+        events.push({
+          sessionId,
+          event: capturedRecord as Record<string, unknown>,
+          traceRole,
+        });
+        if (
+          capturedRecord.ignorable !== true
+          && !supportsDshTraceEventType(capturedRecord.type)
+        ) {
+          eventProtocolUnsupported = true;
+          requestCancellation();
+        }
+      } catch {
+        eventCaptureInvalid = true;
+        requestCancellation();
+      }
+    });
+  } catch {
+    try { disposeEvents(); } catch { /* subscription setup already failed */ }
+    try { disposeCreated(); } catch { /* subscription setup already failed */ }
+    fail(
+      'OMK_DSH_HOST_SUBSCRIPTION_FAILED',
+      'infrastructure',
+      'DSH Host session event subscriptions could not be established.',
+    );
+  }
+
+  let result: ExecutorAttemptResult | undefined;
+  let pendingFailure: ExecutionPortFailure | undefined;
+  let parsedUsage: UsageRecord | undefined;
+  try {
+    if (attempt.signal.aborted) {
+      fail('OMK_DSH_HOST_CANCELLED', 'execution', 'DSH Host execution was cancelled.');
+    }
+    try {
+      handle = await host.createAgent({
+        sessionId: rootSessionId,
+        meta: {
+          cwd: runState.workingDirectory,
+          ...(host.parentAgentId === undefined ? {} : { parentSession: host.parentAgentId }),
+          ...(host.activeAgentPreset === undefined ? {} : {
+            agentPreset: host.activeAgentPreset,
+          }),
+        },
+        agentOptions: {
+          provider: host.provider,
+          model: target.binding.qualification.model,
+        },
+        signal: attempt.signal,
+        setup(agentContext) {
+          if (host.composeFrom !== undefined) {
+            const currentPreset = host.composeFrom(agentContext);
+            if (currentPreset !== host.activeAgentPreset) {
+              fail(
+                'OMK_DSH_HOST_IDENTITY_CHANGED',
+                'infrastructure',
+                'DSH Host effective agent preset changed during session setup.',
+              );
+            }
+          }
+          agentContext.systemPrompt.section({
+            name: 'omk:evaluation-core',
+            order: 0,
+            text: runState.systemInstructions ?? '',
+            complete: true,
+          });
+          agentContext.systemPrompt.suppressRuntimeContext();
+          if (allowedTools !== undefined || skillsDisabled) {
+            if (
+              agentContext.tools === undefined
+              || typeof agentContext.tools.guard !== 'function'
+            ) {
+              fail(
+                'OMK_DSH_HOST_TOOL_POLICY_UNAVAILABLE',
+                'infrastructure',
+                'DSH Host tool policy enforcement is unavailable during session setup.',
+              );
+            }
+            if (allowedTools !== undefined && effectiveToolNames.length > 0) {
+              agentContext.tools.restrict({ allow: effectiveToolNames });
+            } else if (deniedTools.length > 0) {
+              agentContext.tools.restrict({ deny: deniedTools });
+            }
+            agentContext.tools.guard(({ name }) => {
+              if (skillsDisabled && name === 'skill') {
+                return 'OMK evaluation policy disabled skill discovery.';
+              }
+              if (allowedTools !== undefined && !effectiveToolNameSet.has(name)) {
+                return 'OMK evaluation tool allow-list denied this tool.';
+              }
+              return undefined;
+            });
+          }
+        },
+      });
+    } catch (error) {
+      if (error instanceof ExecutionPortFailure) throw error;
+      if (attempt.signal.aborted) throw error;
+      fail(
+        'OMK_DSH_HOST_SESSION_CREATE_FAILED',
+        'infrastructure',
+        'DSH Host measurement session could not be created.',
+      );
+    }
+    if (
+      String(handle.agent.id) !== rootSessionId
+      || String(handle.agent.session.id) !== rootSessionId
+    ) {
+      fail(
+        'OMK_DSH_HOST_SESSION_ID_MISMATCH',
+        'infrastructure',
+        'DSH Host measurement session did not preserve the requested session identity.',
+      );
+    }
+    if (
+      eventCaptureInvalid
+      || eventEnvelopeInvalid
+      || eventLimitExceeded
+      || eventProtocolUnsupported
+    ) {
+      requestCancellation();
+    } else if (attempt.signal.aborted) {
+      try { handle.agent.cancel({ kind: 'hook', reason: 'OMK Core attempt was cancelled' }); } catch { /* settle below */ }
+    } else {
+      handle.agent.followup(createPromptMessage(trialState.prompt));
+    }
+    const outcome = await waitForIdleOrCancellation(handle.agent, attempt.signal);
+    if (eventCaptureInvalid) {
+      fail(
+        'OMK_DSH_HOST_PROTOCOL_INVALID',
+        'execution',
+        'DSH Host returned a non-JSON session event.',
+      );
+    }
+    if (eventEnvelopeInvalid) {
+      fail(
+        'OMK_DSH_HOST_PROTOCOL_INVALID',
+        'execution',
+        'DSH Host returned an invalid session event envelope.',
+      );
+    }
+    if (eventLimitExceeded) {
+      fail(
+        'OMK_DSH_HOST_OUTPUT_LIMIT_EXCEEDED',
+        'infrastructure',
+        'DSH Host session events exceeded the adapter byte limit.',
+      );
+    }
+    if (eventProtocolUnsupported) {
+      fail(
+        'OMK_DSH_HOST_PROTOCOL_INVALID',
+        'execution',
+        'DSH Host returned an unsupported required session event.',
+      );
+    }
+    const partialRunResult: DshHostRunResult = {
+      rootSessionId,
+      finalResponse: '',
+      events,
+      childSessionIds: [...descendants],
+    };
+    const runResult: DshHostRunResult = {
+      ...partialRunResult,
+      finalResponse: lastRootAssistantText(partialRunResult),
+    };
+    const parsed = parseDshHostCoreResult(runResult, {
+      model: target.binding.qualification.model,
+      provider: host.provider,
+    });
+    parsedUsage = parsed.usage;
+    if (Buffer.byteLength(canonicalizeJson(parsed.trace)) > host.maxEventBytes) {
+      fail(
+        'OMK_DSH_HOST_OUTPUT_LIMIT_EXCEEDED',
+        'infrastructure',
+        'DSH Host session events exceeded the adapter byte limit.',
+        parsed.usage,
+      );
+    }
+    if (outcome === 'cancelled' || attempt.signal.aborted) {
+      fail(
+        'OMK_DSH_HOST_CANCELLED',
+        'execution',
+        'DSH Host execution was cancelled.',
+        parsed.usage,
+      );
+    }
+    if (parsed.terminalStatus !== 'completed' || parsed.output === undefined) {
+      fail(
+        'OMK_DSH_HOST_EXECUTION_FAILED',
+        'execution',
+        'DSH Host execution did not complete successfully.',
+        parsed.usage,
+      );
+    }
+    result = {
+      output: { value: parsed.output, classification: 'secret', mediaType: 'text/plain' },
+      trace: {
+        value: parsed.trace,
+        classification: 'secret',
+        mediaType: 'application/vnd.omk.source-neutral-trace+json',
+      },
+      usage: parsed.usage,
+    };
+  } catch (error) {
+    pendingFailure = executionFailure(error, attempt.signal);
+  }
+
+  let disposalFailed = false;
+  try { disposeEvents(); } catch { disposalFailed = true; }
+  try { disposeCreated(); } catch { disposalFailed = true; }
+  if (handle !== undefined) {
+    try { await handle.dispose(); } catch { disposalFailed = true; }
+  }
+  if (disposalFailed) {
+    fail(
+      'OMK_DSH_HOST_ATTEMPT_DISPOSE_FAILED',
+      'infrastructure',
+      'DSH Host measurement session could not be disposed.',
+      parsedUsage ?? pendingFailure?.usage,
+    );
+  }
+  if (pendingFailure !== undefined) throw pendingFailure;
+  return result!;
+}
+
+/** Creates the DSH-plugin-owned Core adapter; it is intentionally absent from generic factories. */
+export async function createDshHostCoreExecutorAdapter(
+  input: Readonly<CreateDshHostCoreExecutorAdapterInput>,
+): Promise<ExecutionExecutor> {
+  if (typeof input.sessionIsolationKey !== 'string' || input.sessionIsolationKey.trim() === '') {
+    throw new TypeError('DSH Host Core adapter requires a non-empty sessionIsolationKey.');
+  }
+  validateDshTargetSubset(input.target);
+  const target = captureClaudeCliTarget(input.target, input.binding, RESOURCE_PROFILE);
+  const host = captureHost(input, target);
+  const identity = resolveIdentity(target, host);
+  const resourceLeases = Object.freeze({
+    forRun: input.resourceLeases.forRun.bind(input.resourceLeases),
+  });
+  return createSameProcessExecutorAdapter({
+    identity,
+    sessionIsolationKey: input.sessionIsolationKey,
+    resourceLeases,
+    implementation: {
+      openRun({ resources }) {
+        return captureClaudeCliRunState(resources, target, host.maxInputBytes, RESOURCE_PROFILE);
+      },
+      async openTrial({ runState, trial }) {
+        if (
+          trial.protocolId !== target.binding.protocolId
+          || trial.targetId !== target.binding.targetId
+          || canonicalizeJson(trial.targetConfig ?? null)
+            !== canonicalizeJson(target.target.config ?? null)
+        ) {
+          fail(
+            'OMK_DSH_HOST_TRIAL_MISMATCH',
+            'infrastructure',
+            'DSH Host trial does not match the sealed Target binding.',
+          );
+        }
+        runState.acquireTrial();
+        try {
+          return openClaudeCliTrial(trial, runState, host.maxInputBytes, RESOURCE_PROFILE);
+        } catch (error) {
+          await runState.releaseTrial();
+          throw error;
+        }
+      },
+      execute({ runState, trialState, attempt, scope }) {
+        return executeDshHost(
+          host,
+          target,
+          runState,
+          trialState,
+          attempt,
+          scope.operationIsolationKey,
+        );
+      },
+      disposeTrial({ runState }) {
+        return disposeClaudeCliTrial(runState, RESOURCE_PROFILE);
+      },
+      disposeRun({ runState }) {
+        return runState.requestDispose();
+      },
+    },
+  });
+}

--- a/src/dsh-plugin/core-protocol.ts
+++ b/src/dsh-plugin/core-protocol.ts
@@ -1,0 +1,304 @@
+import { z } from 'zod';
+import {
+  EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
+  ExecutorCapabilitiesSchema,
+  JsonValueSchema,
+  UsageRecordSchema,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  type CoreSchemaValidator,
+  type ExecutorCapabilities,
+  type JsonValue,
+  type SchemaIdentity,
+  type UsageRecord,
+} from '../evaluation-core/contracts/index.js';
+import { ExecutionPortFailure } from '../evaluation-core/execution/index.js';
+import {
+  isValidToolCallInfo,
+  isValidTurnInfo,
+} from '../shared/executor-result.js';
+import { buildDshHostResult, type DshHostRunResult } from './protocol.js';
+import { supportsDshTraceEventType } from './trace-adapter.js';
+
+export const DSH_HOST_CORE_ADAPTER_IMPLEMENTATION_VERSION = '1.0.0' as const;
+
+export interface ParsedDshHostCoreResult {
+  readonly output?: string;
+  readonly trace: JsonValue;
+  readonly usage: UsageRecord;
+  readonly terminalStatus: 'completed' | 'failed';
+  readonly stopReason: string;
+}
+
+const DshTraceSchema = z.object({
+  schemaVersion: z.literal('omk.source-neutral-trace/v1'),
+  turns: z.array(z.custom<JsonValue>(isValidTurnInfo)),
+  toolCalls: z.array(z.custom<JsonValue>(isValidToolCallInfo)),
+  fullNumTurns: z.number().int().nonnegative(),
+  numSubAgents: z.number().int().nonnegative(),
+}).strict();
+
+const SCHEMA_DESCRIPTORS = {
+  input: { valueKind: 'json-value' },
+  output: { valueKind: 'string' },
+  trace: {
+    schemaVersion: 'omk.source-neutral-trace/v1',
+    fields: ['fullNumTurns', 'numSubAgents', 'schemaVersion', 'toolCalls', 'turns'],
+    turnAndToolCallItems: 'source-neutral-executor-trace/v1',
+  },
+} as const satisfies Readonly<Record<'input' | 'output' | 'trace', JsonValue>>;
+
+function schemaIdentity(name: 'input' | 'output' | 'trace'): SchemaIdentity {
+  const schemaVersion = `omk.dsh-host-${name}/v1`;
+  return {
+    schemaVersion,
+    schemaUri: `urn:omk:runtime:dsh-host:${name}:v1`,
+    schemaDigest: digestCanonicalJson({
+      schemaVersion,
+      sourceProtocol: 'DeepSeek Harness host session events',
+      contract: SCHEMA_DESCRIPTORS[name],
+    }),
+  };
+}
+
+export function createDshHostCoreSchemaValidators(): readonly CoreSchemaValidator[] {
+  return Object.freeze([
+    Object.freeze({
+      schema: deepFreezeCanonicalJson(schemaIdentity('input')),
+      parse(value: unknown): JsonValue {
+        return JsonValueSchema.parse(value);
+      },
+    }),
+    Object.freeze({
+      schema: deepFreezeCanonicalJson(schemaIdentity('output')),
+      parse(value: unknown): JsonValue {
+        return z.string().parse(value);
+      },
+    }),
+    Object.freeze({
+      schema: deepFreezeCanonicalJson(schemaIdentity('trace')),
+      parse(value: unknown): JsonValue {
+        return DshTraceSchema.parse(value) as JsonValue;
+      },
+    }),
+  ]);
+}
+
+export function dshHostCoreExecutorCapabilities(): ExecutorCapabilities {
+  return deepFreezeCanonicalJson(ExecutorCapabilitiesSchema.parse({
+    schemaVersion: EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
+    protocols: [{
+      protocolId: 'omk.invoke/v1',
+      inputSchema: schemaIdentity('input'),
+      outputSchema: schemaIdentity('output'),
+      traceSchema: schemaIdentity('trace'),
+      execution: {
+        concurrency: { safety: 'serialized', maxInFlight: 1 },
+        cancellation: 'best-effort',
+        state: { resourceLifecycle: 'per-invocation', trialState: 'stateless' },
+        seedControl: 'unsupported',
+        determinism: 'stochastic',
+        features: {
+          systemInstructions: 'native',
+          workspace: ['copy-on-write-overlay'],
+          mcp: [],
+          mockInterception: [],
+          toolPolicies: ['allow-list', 'runtime-default'],
+          skillDiscovery: ['disabled', 'runtime-default'],
+          sandboxIds: [],
+        },
+        telemetry: {
+          trace: 'required',
+          usage: 'optional',
+          providerCost: { reporting: 'unsupported' },
+        },
+      },
+    }],
+  })) as ExecutorCapabilities;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function tokenCount(value: unknown): number | undefined {
+  return Number.isSafeInteger(value) && (value as number) >= 0 ? value as number : undefined;
+}
+
+function checkedSum(values: readonly number[]): number | undefined {
+  let sum = 0;
+  for (const value of values) {
+    sum += value;
+    if (!Number.isSafeInteger(sum)) return undefined;
+  }
+  return sum;
+}
+
+function fail(message: string, usage?: UsageRecord): never {
+  throw new ExecutionPortFailure({
+    code: 'OMK_DSH_HOST_PROTOCOL_INVALID',
+    stage: 'execution',
+    message,
+  }, usage);
+}
+
+function validateEvents(result: DshHostRunResult): void {
+  const childSessionIds = new Set(result.childSessionIds);
+  if (
+    childSessionIds.size !== result.childSessionIds.length
+    || childSessionIds.has(result.rootSessionId)
+    || [...childSessionIds].some((sessionId) => sessionId.trim() === '')
+  ) fail('DSH Host returned invalid session lineage.');
+  const expectedSequenceBySession = new Map<string, number>();
+  for (const record of result.events) {
+    const captured = JsonValueSchema.safeParse(record.event);
+    const expectedRole = record.sessionId === result.rootSessionId ? 'main' : 'subagent';
+    const sequence = tokenCount(record.event.seq);
+    const eventTime = tokenCount(record.event.time);
+    const expectedSequence = expectedSequenceBySession.get(record.sessionId) ?? 0;
+    if (
+      !captured.success
+      || record.sessionId.trim() === ''
+      || record.traceRole !== expectedRole
+      || (expectedRole === 'subagent' && !childSessionIds.has(record.sessionId))
+      || typeof record.event.type !== 'string'
+      || record.event.type === ''
+      || sequence !== expectedSequence
+      || eventTime === undefined
+    ) {
+      fail('DSH Host returned an invalid session event.');
+    }
+    expectedSequenceBySession.set(record.sessionId, expectedSequence + 1);
+    if (
+      record.event.ignorable !== true
+      && !supportsDshTraceEventType(record.event.type)
+    ) fail('DSH Host returned an unsupported required session event.');
+  }
+}
+
+function usageFromEvents(
+  result: DshHostRunResult,
+  model: string,
+  provider: string | undefined,
+  stopReason: string,
+): UsageRecord {
+  let assistantMessages = 0;
+  let completeUsage = true;
+  let completeReasoningUsage = true;
+  let uncachedInputTokens = 0;
+  let cacheReadInputTokens = 0;
+  let cacheCreationInputTokens = 0;
+  let outputTokens = 0;
+  let reasoningOutputTokens = 0;
+  for (const record of result.events) {
+    if (record.event.type !== 'assistant/message') continue;
+    assistantMessages += 1;
+    const data = isRecord(record.event.data) ? record.event.data : undefined;
+    const rawUsage = data?.usage;
+    if (rawUsage === undefined || rawUsage === null) {
+      completeUsage = false;
+      completeReasoningUsage = false;
+      continue;
+    }
+    if (!isRecord(rawUsage)) fail('DSH Host reported invalid usage.');
+    const nextInput = tokenCount(rawUsage.inputTokens);
+    const nextOutput = tokenCount(rawUsage.outputTokens);
+    const nextCacheRead = rawUsage.cacheReadTokens === undefined
+      || rawUsage.cacheReadTokens === null
+      ? 0
+      : tokenCount(rawUsage.cacheReadTokens);
+    const nextCacheWrite = rawUsage.cacheWriteTokens === undefined
+      || rawUsage.cacheWriteTokens === null
+      ? 0
+      : tokenCount(rawUsage.cacheWriteTokens);
+    if (
+      nextInput === undefined
+      || nextOutput === undefined
+      || nextCacheRead === undefined
+      || nextCacheWrite === undefined
+    ) fail('DSH Host reported invalid usage.');
+    const inputSum = checkedSum([uncachedInputTokens, nextInput]);
+    const outputSum = checkedSum([outputTokens, nextOutput]);
+    const cacheReadSum = checkedSum([cacheReadInputTokens, nextCacheRead]);
+    const cacheWriteSum = checkedSum([cacheCreationInputTokens, nextCacheWrite]);
+    if (
+      inputSum === undefined
+      || outputSum === undefined
+      || cacheReadSum === undefined
+      || cacheWriteSum === undefined
+    ) fail('DSH Host reported overflowing usage.');
+    uncachedInputTokens = inputSum;
+    outputTokens = outputSum;
+    cacheReadInputTokens = cacheReadSum;
+    cacheCreationInputTokens = cacheWriteSum;
+    if (rawUsage.reasoningTokens === undefined || rawUsage.reasoningTokens === null) {
+      completeReasoningUsage = false;
+    } else {
+      const nextReasoning = tokenCount(rawUsage.reasoningTokens);
+      if (nextReasoning === undefined || nextReasoning > nextOutput) {
+        fail('DSH Host reported invalid reasoning token usage.');
+      }
+      const reasoningSum = checkedSum([reasoningOutputTokens, nextReasoning]);
+      if (reasoningSum === undefined) fail('DSH Host reported overflowing usage.');
+      reasoningOutputTokens = reasoningSum;
+    }
+  }
+  const details = {
+    provider: 'dsh-host',
+    model,
+    ...(provider === undefined ? {} : { providerRoute: provider }),
+    stopReason,
+    tokenAccounting: 'exclusive-cache-input-buckets',
+  };
+  if (assistantMessages === 0 || !completeUsage) {
+    return UsageRecordSchema.parse({ details });
+  }
+  const inputTokens = checkedSum([
+    uncachedInputTokens,
+    cacheReadInputTokens,
+    cacheCreationInputTokens,
+  ]);
+  const totalTokens = inputTokens === undefined
+    ? undefined
+    : checkedSum([inputTokens, outputTokens]);
+  if (inputTokens === undefined || totalTokens === undefined) {
+    fail('DSH Host reported overflowing usage.');
+  }
+  return UsageRecordSchema.parse({
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    details: {
+      ...details,
+      uncachedInputTokens,
+      cacheReadInputTokens,
+      cacheCreationInputTokens,
+      ...(completeReasoningUsage ? { reasoningOutputTokens } : {}),
+    },
+  });
+}
+
+export function parseDshHostCoreResult(
+  result: DshHostRunResult,
+  input: Readonly<{ model: string; provider?: string }>,
+): ParsedDshHostCoreResult {
+  validateEvents(result);
+  const projected = buildDshHostResult(result, 0);
+  const usage = usageFromEvents(result, input.model, input.provider, projected.stopReason);
+  const trace = DshTraceSchema.parse({
+    schemaVersion: 'omk.source-neutral-trace/v1',
+    turns: projected.turns ?? [],
+    toolCalls: projected.toolCalls ?? [],
+    fullNumTurns: projected.fullNumTurns ?? 0,
+    numSubAgents: projected.numSubAgents ?? 0,
+  }) as JsonValue;
+  return Object.freeze({
+    ...(typeof projected.output === 'string' && projected.output.trim() !== ''
+      ? { output: projected.output }
+      : {}),
+    trace,
+    usage,
+    terminalStatus: projected.ok ? 'completed' : 'failed',
+    stopReason: projected.stopReason,
+  });
+}

--- a/src/dsh-plugin/host-executor.ts
+++ b/src/dsh-plugin/host-executor.ts
@@ -43,7 +43,11 @@ interface DshAgentScopeLike {
   };
   readonly tools?: {
     get(name: string, agent?: DshAgentLike): unknown;
-    restrict(filter: { readonly deny: readonly string[] }): () => void;
+    restrict(filter: {
+      readonly allow?: readonly string[];
+      readonly deny?: readonly string[];
+    }): () => void;
+    guard?(guard: (execution: Readonly<{ name: string }>) => string | undefined): () => void;
   };
 }
 
@@ -71,6 +75,7 @@ export interface DshHostContextLike {
         readonly provider?: string;
         readonly model: string;
       };
+      readonly signal?: AbortSignal;
       readonly setup: (ctx: DshAgentScopeLike) => void;
     }): Promise<DshAgentHandleLike>;
   };

--- a/src/dsh-plugin/index.ts
+++ b/src/dsh-plugin/index.ts
@@ -8,6 +8,14 @@ import {
   type DshAgentLike,
   type DshHostContextLike,
 } from './host-executor.js';
+
+export {
+  DSH_HOST_CORE_ADAPTER_IMPLEMENTATION_VERSION,
+  createDshHostCoreExecutorAdapter,
+  createDshHostCoreSchemaValidators,
+  type CreateDshHostCoreExecutorAdapterInput,
+  type DshHostCoreConfiguration,
+} from './core-adapter.js';
 import {
   createDshConversationCatalog,
   dshTraceIngestionSummary,

--- a/src/dsh-plugin/trace-adapter.ts
+++ b/src/dsh-plugin/trace-adapter.ts
@@ -112,7 +112,7 @@ const PROJECTED_EVENT_TYPES = new Set([
   'user/message',
 ]);
 
-function supportsEventType(eventType: string): boolean {
+export function supportsDshTraceEventType(eventType: string): boolean {
   return PROJECTED_EVENT_TYPES.has(eventType)
     || AUXILIARY_EVENT_TYPES.has(eventType)
     || eventType.startsWith('compaction/');
@@ -397,7 +397,7 @@ export function adaptDshSession(
   }
 
   inputEvents.slice(0, seedLength).forEach((event) => {
-    if (event.ignorable !== true && !supportsEventType(event.type)) {
+    if (event.ignorable !== true && !supportsDshTraceEventType(event.type)) {
       throw new DshTraceUnsupportedEventError(event.type, event.seq);
     }
   });

--- a/src/eval-workflows/runtime-adapter/adapters/claude-cli-resources.ts
+++ b/src/eval-workflows/runtime-adapter/adapters/claude-cli-resources.ts
@@ -111,10 +111,13 @@ export interface ClaudeCliTrialState {
 }
 
 export interface ClaudeResourceProjectionProfile {
-  readonly adapterLabel: 'Claude CLI' | 'Claude SDK';
-  readonly errorPrefix: 'OMK_CLAUDE_CLI' | 'OMK_CLAUDE_SDK';
+  readonly adapterLabel: 'Claude CLI' | 'Claude SDK' | 'DSH Host';
+  readonly errorPrefix: 'OMK_CLAUDE_CLI' | 'OMK_CLAUDE_SDK' | 'OMK_DSH_HOST';
   readonly mcpMockMode: 'synthetic-server' | 'hook-existing-tool';
-  readonly promptSchemaVersion: 'omk.claude-cli-prompt/v1' | 'omk.claude-sdk-prompt/v1';
+  readonly promptSchemaVersion:
+    | 'omk.claude-cli-prompt/v1'
+    | 'omk.claude-sdk-prompt/v1'
+    | 'omk.dsh-host-prompt/v1';
 }
 
 export const CLAUDE_CLI_RESOURCE_PROFILE = Object.freeze({

--- a/test/dsh-plugin/core-adapter.test.ts
+++ b/test/dsh-plugin/core-adapter.test.ts
@@ -1,0 +1,828 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  digestCanonicalJson,
+  schemaIdentityKey,
+  type EvaluationDefinition,
+  type JsonValue,
+  type SchemaIdentity,
+  type Sha256Digest,
+} from '../../src/evaluation-core/contracts/index.js';
+import { prepareEvaluationPlan } from '../../src/evaluation-core/compiler/index.js';
+import {
+  InMemoryRuntimeEventSequencer,
+  executeRunPlan,
+  type ExecutionExecutor,
+  type ExecutorAttemptResult,
+} from '../../src/evaluation-core/execution/index.js';
+import {
+  createDshHostCoreExecutorAdapter,
+  createDshHostCoreSchemaValidators,
+} from '../../src/dsh-plugin/index.js';
+import type {
+  DshAgentLike,
+  DshHostContextLike,
+  DshSessionLike,
+} from '../../src/dsh-plugin/host-executor.js';
+import type {
+  OmkBindingResourceLease,
+  OmkBindingResourceLeaseAccess,
+  OmkLeasedHostResource,
+  RuntimeBindingOf,
+} from '../../src/eval-workflows/runtime-adapter/index.js';
+import {
+  testRuntime,
+  validDefinition,
+  validPolicy,
+} from '../evaluation-core/compiler/fixtures.js';
+
+type UnknownRecord = Record<string, unknown>;
+
+const roots = new Set<string>();
+
+afterEach(async () => {
+  await Promise.all([...roots].map((root) => rm(root, { recursive: true, force: true })));
+  roots.clear();
+});
+
+function digest(value: JsonValue): Sha256Digest {
+  return digestCanonicalJson(value);
+}
+
+interface HostBehavior {
+  readonly createWaitsForAbort?: boolean;
+  readonly hang?: boolean;
+  readonly disposeFails?: boolean;
+  readonly idleFails?: boolean;
+  readonly mutateAssistantEvent?: boolean;
+  readonly oversizedEvent?: boolean;
+  readonly requiredUnknownEvent?: boolean;
+  readonly schemaReadFailsAfter?: number;
+  readonly sessionIdMismatch?: boolean;
+  readonly setupPreset?: string;
+  readonly subscriptionFailsOn?: 'created' | 'event';
+  readonly toolGuardUnavailable?: boolean;
+}
+
+class FakeCoreDshHost implements DshHostContextLike {
+  currentPreset = 'standard-sensitive';
+  currentSchemas: UnknownRecord[] = [
+    { name: 'read', description: 'read files', parameters: { type: 'object' } },
+    { name: 'write', description: 'write files', parameters: { type: 'object' } },
+    { name: 'skill', description: 'ambient skills', parameters: { type: 'object' } },
+  ];
+  readonly created: Array<{
+    sessionId: string;
+    cwd: string;
+    parentSession?: string;
+    agentPreset?: string;
+    provider?: string;
+    model: string;
+  }> = [];
+  readonly creationSignals: Array<AbortSignal | undefined> = [];
+  readonly promptSections: UnknownRecord[] = [];
+  readonly prompts: UnknownRecord[] = [];
+  readonly allowedToolSets: string[][] = [];
+  readonly deniedTools: string[][] = [];
+  readonly toolGuards: Array<(execution: Readonly<{ name: string }>) => string | undefined> = [];
+  cancelled = 0;
+  disposed = 0;
+  schemaReads = 0;
+  private readonly eventListeners = new Set<(
+    session: DshSessionLike,
+    event: UnknownRecord,
+  ) => void>();
+  private readonly createdListeners = new Set<(session: DshSessionLike) => void>();
+
+  constructor(private readonly behavior: HostBehavior = {}) {}
+
+  readonly agentPresets = {
+    composedPreset: () => this.currentPreset,
+    composeFrom: () => this.behavior.setupPreset ?? this.currentPreset,
+  };
+
+  readonly tools = {
+    schemas: () => {
+      this.schemaReads += 1;
+      if (
+        this.behavior.schemaReadFailsAfter !== undefined
+        && this.schemaReads > this.behavior.schemaReadFailsAfter
+      ) throw new Error('sensitive schema read failure');
+      return structuredClone(this.currentSchemas);
+    },
+  };
+
+  readonly agents = {
+    create: async (options: Parameters<DshHostContextLike['agents']['create']>[0]) => {
+      this.creationSignals.push(options.signal);
+      if (this.behavior.createWaitsForAbort) {
+        await new Promise<never>((_resolve, reject) => {
+          if (options.signal?.aborted) {
+            reject(new Error('sensitive creation cancellation'));
+            return;
+          }
+          options.signal?.addEventListener('abort', () => {
+            reject(new Error('sensitive creation cancellation'));
+          }, { once: true });
+        });
+      }
+      const events: UnknownRecord[] = [];
+      const actualSessionId = this.behavior.sessionIdMismatch
+        ? `${options.sessionId}-changed`
+        : options.sessionId;
+      const session: DshSessionLike = {
+        id: actualSessionId,
+        events,
+        header: {
+          cwd: options.meta.cwd,
+          ...(options.meta.parentSession === undefined
+            ? {}
+            : { parentSession: options.meta.parentSession }),
+          ...(options.meta.agentPreset === undefined
+            ? {}
+            : { agentPreset: options.meta.agentPreset }),
+        },
+      };
+      let sequence = 0;
+      let settle: (() => void) | undefined;
+      let idle = Promise.resolve();
+      type SetupContext = Parameters<typeof options.setup>[0];
+      const scope = { agent: undefined as DshAgentLike | undefined };
+      const agentContext: SetupContext = {
+        get agent() { return scope.agent; },
+        systemPrompt: {
+          section: (section) => {
+            this.promptSections.push(section);
+            return () => undefined;
+          },
+          suppressRuntimeContext: () => () => undefined,
+        },
+        tools: {
+          get: () => ({}),
+          restrict: ({ allow, deny }) => {
+            if (allow !== undefined) this.allowedToolSets.push([...allow]);
+            if (deny !== undefined) this.deniedTools.push([...deny]);
+            return () => undefined;
+          },
+          ...(this.behavior.toolGuardUnavailable ? {} : {
+            guard: (guard: (execution: Readonly<{ name: string }>) => string | undefined) => {
+              this.toolGuards.push(guard);
+              return () => undefined;
+            },
+          }),
+        },
+      };
+      const emit = (type: string, data: UnknownRecord, ignorable?: true): UnknownRecord => {
+        const event = {
+          type,
+          seq: sequence,
+          time: 1_800_000_000_000 + sequence,
+          data,
+          ...(ignorable === undefined ? {} : { ignorable }),
+        };
+        sequence += 1;
+        events.push(event);
+        for (const listener of this.eventListeners) listener(session, event);
+        return event;
+      };
+      const agent: DshAgentLike = {
+        id: actualSessionId,
+        options: options.agentOptions,
+        ctx: agentContext,
+        session,
+        followup: (message) => {
+          this.prompts.push(message);
+          idle = this.behavior.idleFails
+            ? Promise.reject(new Error('sensitive idle failure'))
+            : new Promise<void>((resolve) => { settle = resolve; });
+          emit('user/message', message);
+          if (this.behavior.oversizedEvent) {
+            emit('plugin/telemetry-note', { blob: 'x'.repeat(8_192) }, true);
+          }
+          if (this.behavior.requiredUnknownEvent) {
+            emit('future/semantic-boundary', { secret: 'must not leak' });
+          }
+          if (this.behavior.hang) return;
+          const assistantEvent = emit('assistant/message', {
+            message: { content: [{ type: 'text', text: 'host core answer' }] },
+            usage: {
+              inputTokens: 9,
+              outputTokens: 4,
+              cacheReadTokens: 2,
+              cacheWriteTokens: 1,
+              reasoningTokens: 1,
+            },
+          });
+          if (this.behavior.mutateAssistantEvent) {
+            const data = assistantEvent.data as UnknownRecord;
+            const assistantMessage = data.message as UnknownRecord;
+            assistantMessage.content = [{ type: 'text', text: 'mutated after delivery' }];
+            (data.usage as UnknownRecord).inputTokens = 999;
+          }
+          emit('turn/end', { reason: { kind: 'completed' } });
+          settle?.();
+        },
+        whenIdle: () => idle,
+        cancel: () => {
+          this.cancelled += 1;
+          emit('turn/end', { reason: { kind: 'aborted' } });
+          settle?.();
+        },
+      };
+      scope.agent = agent;
+      options.setup(agentContext);
+      this.created.push({
+        sessionId: options.sessionId,
+        cwd: options.meta.cwd,
+        ...(options.meta.parentSession === undefined
+          ? {}
+          : { parentSession: options.meta.parentSession }),
+        ...(options.meta.agentPreset === undefined
+          ? {}
+          : { agentPreset: options.meta.agentPreset }),
+        ...(options.agentOptions.provider === undefined
+          ? {}
+          : { provider: options.agentOptions.provider }),
+        model: options.agentOptions.model,
+      });
+      for (const listener of this.createdListeners) listener(session);
+      return {
+        agent,
+        dispose: async () => {
+          this.disposed += 1;
+          if (this.behavior.disposeFails) throw new Error('sensitive dispose failure');
+        },
+      };
+    },
+  };
+
+  on(
+    event: 'session/event' | 'session/created',
+    listener: ((session: DshSessionLike, entry: UnknownRecord) => void)
+      | ((session: DshSessionLike) => void),
+  ): () => void {
+    if (event === 'session/event') {
+      if (this.behavior.subscriptionFailsOn === 'event') {
+        throw new Error('sensitive event subscription failure');
+      }
+      const typed = listener as (session: DshSessionLike, entry: UnknownRecord) => void;
+      this.eventListeners.add(typed);
+      return () => this.eventListeners.delete(typed);
+    }
+    if (this.behavior.subscriptionFailsOn === 'created') {
+      throw new Error('sensitive created subscription failure');
+    }
+    const typed = listener as (session: DshSessionLike) => void;
+    this.createdListeners.add(typed);
+    return () => this.createdListeners.delete(typed);
+  }
+
+  activeListenerCount(): number {
+    return this.eventListeners.size + this.createdListeners.size;
+  }
+}
+
+const parentAgent = {
+  id: 'interactive-session',
+  options: { provider: 'configured-provider', model: 'configured-model' },
+  ctx: { name: 'interactive-agent-context' },
+  session: {
+    id: 'interactive-session',
+    events: [],
+    header: { cwd: '/project', agentPreset: 'stale-preset' },
+  },
+  followup() {},
+  whenIdle: () => Promise.resolve(),
+  cancel() {},
+} satisfies DshAgentLike;
+
+interface Fixture {
+  readonly target: EvaluationDefinition['targets'][number];
+  readonly binding: RuntimeBindingOf<'executor'>;
+  readonly resourceAccess: OmkBindingResourceLeaseAccess;
+}
+
+async function fixture(options: Readonly<{
+  allowedTools?: string[];
+  allowedSkills?: string[];
+  behaviorPatch?: Record<string, JsonValue>;
+  runtimePatch?: Record<string, JsonValue>;
+  requirementPatch?: Record<string, JsonValue>;
+}> = {}): Promise<Fixture> {
+  const root = await mkdtemp(join(tmpdir(), 'omk-dsh-core-test-'));
+  roots.add(root);
+  const artifact = '# Knowledge\nUse the DSH Core fixture rule.';
+  const artifactPath = join(root, 'artifact.md');
+  await writeFile(artifactPath, artifact);
+  const descriptor = {
+    resourceId: 'artifact-a',
+    digest: digest({ artifact }),
+    mediaType: 'text/markdown',
+    classification: 'public' as const,
+    size: Buffer.byteLength(artifact),
+  };
+  const behavior = {
+    artifact: descriptor,
+    ...(options.allowedTools === undefined ? {} : { allowedTools: options.allowedTools }),
+    ...(options.allowedSkills === undefined ? { allowedSkills: [] } : {
+      allowedSkills: options.allowedSkills,
+    }),
+    ...(options.behaviorPatch ?? {}),
+  };
+  const config = {
+    behavior,
+    runtime: { model: 'dsh-model', ...(options.runtimePatch ?? {}) },
+  };
+  const executionRequirements = {
+    systemInstructions: 'required' as const,
+    workspace: 'not-required' as const,
+    mcp: 'not-required' as const,
+    mockInterception: 'not-required' as const,
+    toolPolicy: options.allowedTools === undefined ? 'runtime-default' as const : 'allow-list' as const,
+    skillDiscovery: options.allowedSkills === undefined || options.allowedSkills.length === 0
+      ? 'disabled' as const
+      : 'allow-list' as const,
+    ...(options.requirementPatch ?? {}),
+  };
+  const target = {
+    targetId: 'target-a',
+    targetKind: 'skill',
+    protocolId: 'omk.invoke/v1',
+    executorId: 'test.omk.dsh-host/v1',
+    executionRequirements,
+    config,
+  } as EvaluationDefinition['targets'][number];
+  const binding: RuntimeBindingOf<'executor'> = {
+    runtimeKind: 'executor',
+    bindingId: 'executor-target-a',
+    targetId: 'target-a',
+    implementationId: 'test.omk.dsh-host/v1',
+    protocolId: 'omk.invoke/v1',
+    behaviorConfigDigest: digest(config),
+    resourceLeaseRequirements: [{
+      resourceId: 'artifact-a',
+      resourceRole: 'artifact',
+      leaseMode: 'immutable-snapshot',
+    }],
+    qualification: {
+      model: 'dsh-model',
+      executionRequirements,
+      resourceIntegrity: 'digest-before-use',
+    },
+  };
+  const resource: OmkLeasedHostResource = {
+    resourceId: 'artifact-a',
+    resourceKind: 'artifact',
+    descriptor,
+    snapshotKind: 'file',
+    leaseMode: 'immutable-snapshot',
+    snapshotPath: artifactPath,
+  };
+  const lease: OmkBindingResourceLease = Object.freeze({
+    bindingId: binding.bindingId,
+    consumerKind: 'executor',
+    resourcesByResourceId: new Map([['artifact-a', resource]]),
+  });
+  return {
+    target,
+    binding,
+    resourceAccess: {
+      forRun(runId) {
+        expect(runId).toMatch(/^run-/u);
+        return lease;
+      },
+    },
+  };
+}
+
+async function createAdapter(
+  value: Fixture,
+  host: FakeCoreDshHost,
+  patch: Readonly<{ maxEventBytes?: number }> = {},
+): Promise<ExecutionExecutor> {
+  return createDshHostCoreExecutorAdapter({
+    target: value.target,
+    binding: value.binding,
+    host,
+    dsh: { parentAgent, ...patch },
+    sessionIsolationKey: 'dsh-host-session-a',
+    resourceLeases: value.resourceAccess,
+  });
+}
+
+async function execute(
+  port: ExecutionExecutor,
+  targetConfig: JsonValue,
+  signal: AbortSignal = new AbortController().signal,
+  runId = 'run-a',
+): Promise<ExecutorAttemptResult> {
+  const run = await port.openRun({ runId, executionPlanDigest: digest({ plan: 'a' }) });
+  const trial = await run.openTrial({
+    targetId: 'target-a',
+    protocolId: 'omk.invoke/v1',
+    input: { question: 'Q' },
+    executionContext: { locale: 'zh-CN' },
+    targetConfig,
+    trialIndex: 0,
+    trialId: digest({ trial: 'a' }),
+    schedulingBlockId: digest({ block: 'a' }),
+    samplingUnitIds: {},
+  });
+  try {
+    return await trial.execute({
+      attemptId: digest({ attempt: 'a' }),
+      attemptNumber: 1,
+      signal,
+    });
+  } finally {
+    await trial.dispose();
+    await run.dispose();
+  }
+}
+
+describe('DSH host-only Core Executor adapter', () => {
+  it('seals partial host identity without exposing preset or tool schema values', async () => {
+    const value = await fixture();
+    const firstHost = new FakeCoreDshHost();
+    const first = await createAdapter(value, firstHost);
+    const changedHost = new FakeCoreDshHost();
+    changedHost.currentPreset = 'other-sensitive-preset';
+    const changed = await createAdapter(value, changedHost);
+
+    expect(first.identity.fingerprint).not.toBe(changed.identity.fingerprint);
+    expect(first.identity).toMatchObject({
+      implementationId: 'test.omk.dsh-host/v1',
+      fingerprintBasis: 'environment-derived',
+      assuranceLevel: 'declared',
+      capabilities: {
+        protocols: [{
+          protocolId: 'omk.invoke/v1',
+          execution: {
+            concurrency: { safety: 'serialized', maxInFlight: 1 },
+            cancellation: 'best-effort',
+          },
+        }],
+      },
+      implementationManifest: { coverageKind: 'fingerprint-plus-facets' },
+    });
+    expect(JSON.stringify(first.identity)).not.toContain('standard-sensitive');
+    expect(JSON.stringify(first.identity)).not.toContain('read files');
+  });
+
+  it('requires a sealed provider route when no parent agent supplies one', async () => {
+    const value = await fixture();
+    const host = new FakeCoreDshHost();
+    const base = {
+      target: value.target,
+      binding: value.binding,
+      host,
+      sessionIsolationKey: 'dsh-host-session-a',
+      resourceLeases: value.resourceAccess,
+    };
+    await expect(createDshHostCoreExecutorAdapter({ ...base, dsh: {} })).rejects.toThrow(
+      'requires an explicit or parent-inherited provider route',
+    );
+
+    const explicit = await createDshHostCoreExecutorAdapter({
+      ...base,
+      dsh: { provider: 'explicit-route' },
+    });
+    expect(JSON.stringify(explicit.identity)).toContain('explicit-route');
+  });
+
+  it('projects a controlled session with exclusive usage normalized to Core totals', async () => {
+    const value = await fixture();
+    const host = new FakeCoreDshHost();
+    const result = await execute(await createAdapter(value, host), value.target.config as JsonValue);
+
+    expect(result.output).toEqual({
+      value: 'host core answer',
+      classification: 'secret',
+      mediaType: 'text/plain',
+    });
+    expect(result.trace?.value).toMatchObject({
+      schemaVersion: 'omk.source-neutral-trace/v1',
+      fullNumTurns: 1,
+      numSubAgents: 0,
+      toolCalls: [],
+    });
+    expect(result.usage).toEqual({
+      inputTokens: 12,
+      outputTokens: 4,
+      totalTokens: 16,
+      details: {
+        provider: 'dsh-host',
+        model: 'dsh-model',
+        providerRoute: 'configured-provider',
+        stopReason: 'completed',
+        tokenAccounting: 'exclusive-cache-input-buckets',
+        uncachedInputTokens: 9,
+        cacheReadInputTokens: 2,
+        cacheCreationInputTokens: 1,
+        reasoningOutputTokens: 1,
+      },
+    });
+    expect(result.usage).not.toHaveProperty('providerCost');
+    expect(host.created[0]).toMatchObject({
+      parentSession: 'interactive-session',
+      agentPreset: 'standard-sensitive',
+      provider: 'configured-provider',
+      model: 'dsh-model',
+    });
+    expect(host.promptSections).toEqual([{
+      name: 'omk:evaluation-core',
+      order: 0,
+      text: '# Knowledge\nUse the DSH Core fixture rule.',
+      complete: true,
+    }]);
+    expect(host.prompts[0]).toMatchObject({
+      role: 'user',
+      content: [{ type: 'text', text: expect.stringContaining('omk.dsh-host-prompt/v1') }],
+    });
+    expect(host.deniedTools).toEqual([['skill']]);
+    expect(host.toolGuards[0]?.({ name: 'skill' })).toContain('disabled skill discovery');
+    expect(host.disposed).toBe(1);
+  });
+
+  it('captures immutable event snapshots instead of retaining host-owned objects', async () => {
+    const value = await fixture();
+    const host = new FakeCoreDshHost({ mutateAssistantEvent: true });
+    const result = await execute(await createAdapter(value, host), value.target.config as JsonValue);
+
+    expect(result.output).toMatchObject({ value: 'host core answer' });
+    expect(result.usage).toMatchObject({ inputTokens: 12, outputTokens: 4, totalTokens: 16 });
+  });
+
+  it('bounds event capture, cancels the host, and disposes the attempt', async () => {
+    const value = await fixture();
+    const host = new FakeCoreDshHost({ oversizedEvent: true });
+
+    await expect(execute(
+      await createAdapter(value, host, { maxEventBytes: 2_048 }),
+      value.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_DSH_HOST_OUTPUT_LIMIT_EXCEEDED' },
+    });
+    expect(host.cancelled).toBe(1);
+    expect(host.disposed).toBe(1);
+  });
+
+  it('enforces a host tool allow-list before dispatch', async () => {
+    const value = await fixture({ allowedTools: ['read'] });
+    const host = new FakeCoreDshHost();
+    await execute(await createAdapter(value, host), value.target.config as JsonValue);
+
+    expect(host.allowedToolSets).toEqual([['read']]);
+    expect(host.toolGuards[0]?.({ name: 'read' })).toBeUndefined();
+    expect(host.toolGuards[0]?.({ name: 'write' })).toContain('allow-list denied');
+  });
+
+  it('derives distinct host session identities for the same trial across runs', async () => {
+    const value = await fixture();
+    const host = new FakeCoreDshHost();
+    const port = await createAdapter(value, host);
+
+    await execute(port, value.target.config as JsonValue, undefined, 'run-a');
+    await execute(port, value.target.config as JsonValue, undefined, 'run-b');
+
+    expect(host.created).toHaveLength(2);
+    expect(host.created[0]?.sessionId).not.toBe(host.created[1]?.sessionId);
+  });
+
+  it('forwards cancellation and waits for host idle before disposal', async () => {
+    const value = await fixture();
+    const host = new FakeCoreDshHost({ hang: true });
+    const controller = new AbortController();
+    const promise = execute(
+      await createAdapter(value, host),
+      value.target.config as JsonValue,
+      controller.signal,
+    );
+    await expect.poll(() => host.prompts.length).toBe(1);
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_DSH_HOST_CANCELLED' },
+    });
+    expect(host.cancelled).toBe(1);
+    expect(host.disposed).toBe(1);
+  });
+
+  it('forwards cancellation while the host is still creating the agent', async () => {
+    const value = await fixture();
+    const host = new FakeCoreDshHost({ createWaitsForAbort: true });
+    const controller = new AbortController();
+    const promise = execute(
+      await createAdapter(value, host),
+      value.target.config as JsonValue,
+      controller.signal,
+    );
+    await expect.poll(() => host.creationSignals.length).toBe(1);
+    expect(host.creationSignals[0]).toBe(controller.signal);
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_DSH_HOST_CANCELLED' },
+    });
+    expect(host.created).toHaveLength(0);
+    expect(host.disposed).toBe(0);
+  });
+
+  it('fails identity drift before creating a measurement session', async () => {
+    const value = await fixture();
+    const host = new FakeCoreDshHost();
+    const port = await createAdapter(value, host);
+    host.currentSchemas[0] = { ...host.currentSchemas[0], description: 'changed after assembly' };
+
+    await expect(execute(port, value.target.config as JsonValue)).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_DSH_HOST_IDENTITY_CHANGED' },
+    });
+    expect(host.created).toHaveLength(0);
+  });
+
+  it('redacts host identity capture and revalidation failures', async () => {
+    const value = await fixture();
+    const assemblyHost = new FakeCoreDshHost({ schemaReadFailsAfter: 0 });
+    await expect(createAdapter(value, assemblyHost)).rejects.toThrow(
+      'DSH Host Core adapter could not capture effective tool schemas.',
+    );
+
+    const executionHost = new FakeCoreDshHost({ schemaReadFailsAfter: 1 });
+    const port = await createAdapter(value, executionHost);
+    await expect(execute(port, value.target.config as JsonValue)).rejects.toMatchObject({
+      evaluationError: {
+        code: 'OMK_DSH_HOST_IDENTITY_REVALIDATION_FAILED',
+        message: 'DSH Host effective tool schemas could not be revalidated.',
+      },
+    });
+    expect(executionHost.created).toHaveLength(0);
+  });
+
+  it('rolls back partial subscriptions and rejects unavailable tool guards', async () => {
+    const value = await fixture();
+    const subscriptionHost = new FakeCoreDshHost({ subscriptionFailsOn: 'event' });
+    await expect(execute(
+      await createAdapter(value, subscriptionHost),
+      value.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_DSH_HOST_SUBSCRIPTION_FAILED' },
+    });
+    expect(subscriptionHost.activeListenerCount()).toBe(0);
+    expect(subscriptionHost.created).toHaveLength(0);
+
+    const policyHost = new FakeCoreDshHost({ toolGuardUnavailable: true });
+    await expect(execute(
+      await createAdapter(value, policyHost),
+      value.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_DSH_HOST_TOOL_POLICY_UNAVAILABLE' },
+    });
+    expect(policyHost.created).toHaveLength(0);
+  });
+
+  it('classifies setup-time preset drift and session identity drift as infrastructure failures', async () => {
+    const value = await fixture();
+    const presetHost = new FakeCoreDshHost({ setupPreset: 'changed-during-setup' });
+    await expect(execute(
+      await createAdapter(value, presetHost),
+      value.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_DSH_HOST_IDENTITY_CHANGED' },
+    });
+
+    const sessionHost = new FakeCoreDshHost({ sessionIdMismatch: true });
+    await expect(execute(
+      await createAdapter(value, sessionHost),
+      value.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: { code: 'OMK_DSH_HOST_SESSION_ID_MISMATCH' },
+    });
+    expect(sessionHost.prompts).toHaveLength(0);
+    expect(sessionHost.disposed).toBe(1);
+  });
+
+  it('redacts host idle failures, removes cancellation listeners, and disposes', async () => {
+    const value = await fixture();
+    const host = new FakeCoreDshHost({ idleFails: true });
+    const controller = new AbortController();
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener');
+
+    await expect(execute(
+      await createAdapter(value, host),
+      value.target.config as JsonValue,
+      controller.signal,
+    )).rejects.toMatchObject({
+      evaluationError: {
+        code: 'OMK_DSH_HOST_SESSION_FAILED',
+        message: 'DSH Host session failed.',
+      },
+    });
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(host.disposed).toBe(1);
+  });
+
+  it('redacts required protocol evolution and disposal failures', async () => {
+    const value = await fixture();
+    const unknown = new FakeCoreDshHost({ requiredUnknownEvent: true });
+    await expect(execute(
+      await createAdapter(value, unknown),
+      value.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: {
+        code: 'OMK_DSH_HOST_PROTOCOL_INVALID',
+        message: 'DSH Host returned an unsupported required session event.',
+      },
+    });
+    expect(unknown.cancelled).toBe(1);
+    expect(unknown.disposed).toBe(1);
+
+    const disposal = new FakeCoreDshHost({ disposeFails: true });
+    await expect(execute(
+      await createAdapter(value, disposal),
+      value.target.config as JsonValue,
+    )).rejects.toMatchObject({
+      evaluationError: {
+        code: 'OMK_DSH_HOST_ATTEMPT_DISPOSE_FAILED',
+        message: 'DSH Host measurement session could not be disposed.',
+      },
+      usage: { inputTokens: 12 },
+    });
+  });
+
+  it('rejects unsupported or split-brain controls before host side effects', async () => {
+    const effort = await fixture({ runtimePatch: { effort: 'high' } });
+    const effortHost = new FakeCoreDshHost();
+    await expect(createAdapter(effort, effortHost)).rejects.toThrow(/cannot map/);
+
+    const mcp = await fixture({ behaviorPatch: {
+      mcpConfig: {
+        resourceId: 'mcp-a',
+        digest: digest({ mcp: true }),
+        mediaType: 'application/json',
+        classification: 'public',
+        size: 2,
+      },
+    } });
+    const mcpHost = new FakeCoreDshHost();
+    await expect(createAdapter(mcp, mcpHost)).rejects.toThrow(/does not inject MCP/);
+
+    const mismatch = await fixture({ requirementPatch: { toolPolicy: 'allow-list' } });
+    const mismatchHost = new FakeCoreDshHost();
+    await expect(createAdapter(mismatch, mismatchHost)).rejects.toThrow(/inconsistent/);
+    const conflictingTools = await fixture({ allowedTools: ['skill'] });
+    await expect(createAdapter(conflictingTools, new FakeCoreDshHost())).rejects.toThrow(
+      /disabled skills conflict/,
+    );
+    expect(effortHost.created).toHaveLength(0);
+    expect(mcpHost.created).toHaveLength(0);
+    expect(mismatchHost.created).toHaveLength(0);
+  });
+
+  it('passes real Core prepare and execution without entering a generic factory', async () => {
+    const value = await fixture();
+    const host = new FakeCoreDshHost();
+    const port = await createAdapter(value, host);
+    const definition = validDefinition();
+    definition.targets = [{ ...value.target }];
+    definition.experiment.randomizationSlots = [{
+      targetId: value.target.targetId,
+      randomizationSlotId: 'slot-target-a',
+    }];
+    definition.experiment.sampling.seedCoupling = 'uncontrolled';
+    definition.comparisons = [];
+    const policy = validPolicy();
+    policy.cache.executionMode = 'disabled';
+    policy.evidence.trace = 'full';
+    policy.evidence.maximumClassification = 'secret';
+    delete policy.execution.timeoutMs;
+    policy.retry.maxAttempts = 1;
+    const runtime = testRuntime();
+    runtime.resolveExecutor = () => ({ identity: port.identity, satisfiesVersionConstraint: true });
+    for (const validator of createDshHostCoreSchemaValidators()) {
+      (runtime.schemaValidators as Map<string, {
+        schema: SchemaIdentity;
+        parse(value: unknown): JsonValue;
+      }>).set(schemaIdentityKey(validator.schema), validator);
+    }
+    const plan = await prepareEvaluationPlan(definition, policy, runtime);
+    const bundle = await executeRunPlan(plan, {
+      executorsByTargetId: new Map([['target-a', port]]),
+      eventSequencer: new InMemoryRuntimeEventSequencer(),
+      clock: {
+        monotonicNow: () => performance.now(),
+        timestamp: () => new Date().toISOString(),
+        sleep: async (_delayMs, signal) => {
+          if (signal.aborted) throw new Error('aborted');
+        },
+      },
+    }, { runId: 'run-a', bundleId: 'bundle-dsh-host-core' });
+
+    expect(bundle.executionBundleStatus).toBe('completed');
+    expect(bundle.records[0]).toMatchObject({
+      executionStatus: 'completed',
+      output: { value: 'host core answer', classification: 'secret' },
+    });
+  });
+});

--- a/test/dsh-plugin/core-protocol.test.ts
+++ b/test/dsh-plugin/core-protocol.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { parseDshHostCoreResult } from '../../src/dsh-plugin/core-protocol.js';
+import type { DshHostRunResult } from '../../src/dsh-plugin/protocol.js';
+
+type UnknownRecord = Record<string, unknown>;
+
+function run(events: readonly UnknownRecord[]): DshHostRunResult {
+  return {
+    rootSessionId: 'root',
+    finalResponse: 'answer',
+    childSessionIds: [],
+    events: events.map((event) => ({ sessionId: 'root', event, traceRole: 'main' })),
+  };
+}
+
+function event(type: string, data: UnknownRecord, sequence: number): UnknownRecord {
+  return { type, data, seq: sequence, time: 1_800_000_000_000 + sequence };
+}
+
+function assistant(usage: unknown, sequence: number): UnknownRecord {
+  return event('assistant/message', {
+    message: { content: [{ type: 'text', text: 'answer' }] },
+    ...(usage === undefined ? {} : { usage }),
+  }, sequence);
+}
+
+function completed(...middle: UnknownRecord[]): DshHostRunResult {
+  return run([
+    event('user/message', { content: [{ type: 'text', text: 'question' }] }, 0),
+    ...middle,
+    event('turn/end', { reason: { kind: 'completed' } }, middle.length + 1),
+  ]);
+}
+
+describe('DSH Host Core protocol projection', () => {
+  it('keeps partially reported usage unknown instead of persisting zero or a partial total', () => {
+    const parsed = parseDshHostCoreResult(completed(
+      assistant({ inputTokens: 3, outputTokens: 2 }, 1),
+      assistant(undefined, 2),
+    ), { model: 'dsh-model' });
+
+    expect(parsed.usage).toEqual({
+      details: {
+        provider: 'dsh-host',
+        model: 'dsh-model',
+        stopReason: 'completed',
+        tokenAccounting: 'exclusive-cache-input-buckets',
+      },
+    });
+    expect(parsed.usage).not.toHaveProperty('inputTokens');
+    expect(parsed.usage).not.toHaveProperty('providerCost');
+  });
+
+  it('normalizes disjoint cache buckets and omits incomplete reasoning details', () => {
+    const parsed = parseDshHostCoreResult(completed(
+      assistant({
+        inputTokens: 5,
+        outputTokens: 3,
+        cacheReadTokens: 2,
+        cacheWriteTokens: 1,
+        reasoningTokens: 1,
+      }, 1),
+      assistant({ inputTokens: 4, outputTokens: 2 }, 2),
+    ), { model: 'dsh-model', provider: 'route-a' });
+
+    expect(parsed.usage).toMatchObject({
+      inputTokens: 12,
+      outputTokens: 5,
+      totalTokens: 17,
+      details: {
+        uncachedInputTokens: 9,
+        cacheReadInputTokens: 2,
+        cacheCreationInputTokens: 1,
+        providerRoute: 'route-a',
+      },
+    });
+    expect(parsed.usage.details).not.toHaveProperty('reasoningOutputTokens');
+  });
+
+  it('rejects reasoning subsets larger than output and aggregate overflow', () => {
+    expect(() => parseDshHostCoreResult(completed(
+      assistant({ inputTokens: 1, outputTokens: 1, reasoningTokens: 2 }, 1),
+    ), { model: 'dsh-model' })).toThrow('DSH Host reported invalid reasoning token usage.');
+
+    expect(() => parseDshHostCoreResult(completed(
+      assistant({ inputTokens: Number.MAX_SAFE_INTEGER, outputTokens: 0 }, 1),
+      assistant({ inputTokens: 1, outputTokens: 0 }, 2),
+    ), { model: 'dsh-model' })).toThrow('DSH Host reported overflowing usage.');
+  });
+
+  it('accepts ignorable protocol extensions but rejects required and non-JSON events', () => {
+    const ignorable = event('future/telemetry', { note: 'ignored' }, 1);
+    ignorable.ignorable = true;
+    expect(parseDshHostCoreResult(completed(
+      ignorable,
+      assistant({ inputTokens: 1, outputTokens: 1 }, 2),
+    ), { model: 'dsh-model' }).terminalStatus).toBe('completed');
+
+    expect(() => parseDshHostCoreResult(completed(
+      event('future/required', {}, 1),
+    ), { model: 'dsh-model' })).toThrow(
+      'DSH Host returned an unsupported required session event.',
+    );
+    expect(() => parseDshHostCoreResult(completed(
+      event('assistant/message', { invalid: 1n }, 1),
+    ), { model: 'dsh-model' })).toThrow('DSH Host returned an invalid session event.');
+  });
+
+  it('rejects non-contiguous envelopes and inconsistent session lineage', () => {
+    expect(() => parseDshHostCoreResult(run([
+      event('user/message', { content: [] }, 0),
+      event('turn/end', { reason: { kind: 'completed' } }, 2),
+    ]), { model: 'dsh-model' })).toThrow('DSH Host returned an invalid session event.');
+
+    const invalidLineage = completed(
+      assistant({ inputTokens: 1, outputTokens: 1 }, 1),
+    );
+    invalidLineage.childSessionIds.push('root');
+    expect(() => parseDshHostCoreResult(invalidLineage, { model: 'dsh-model' })).toThrow(
+      'DSH Host returned invalid session lineage.',
+    );
+  });
+});

--- a/test/dsh-plugin/host-executor.test.ts
+++ b/test/dsh-plugin/host-executor.test.ts
@@ -82,7 +82,7 @@ class FakeDshHost implements DshHostContextLike {
         tools: {
           get: (name) => name === 'skill' ? {} : undefined,
           restrict: (filter) => {
-            this.deniedTools.push([...filter.deny]);
+            this.deniedTools.push([...(filter.deny ?? [])]);
             return () => undefined;
           },
         },


### PR DESCRIPTION
## 用户影响

- 为 DSH 宿主入口增加 Evaluation Core Executor adapter，使宿主可以把受控的 DSH agent session 交给 Core prepare 与 execution。
- 适配器保持 host-only，不进入通用 Executor factory，也不改变正式 `omk eval`、旧 Report 或旧 pipeline。
- DSH 输出和 trace 按 `secret` 分类；未报告的 usage／cost 保持 unknown，不写成零值。

## 架构与测量语义

- provider、model、agent preset、有效 tool schema、binding 与 adapter composition 共同进入 partial Runtime identity；provider 未显式提供或无法从 parent agent 继承时 fail closed。
- Core `AbortSignal` 同时覆盖 agent 创建和运行；adapter 不拥有第二套 timeout／retry／budget／cache，并在取消或协议失败后等待宿主 quiescence 再释放。
- tool／skill policy 同时使用宿主可见性 restriction 与单调 execution guard，避免 scoped 或动态工具绕过 allow-list。
- DSH append-only event 经过不可变快照、字节上限、required-event、session lineage 与逐 session sequence 校验，再投影为 source-neutral trace。
- DSH token bucket 按宿主协议的互斥语义归一化；cache read／write 计入 Core input total，reasoning 保持 output 子集，缺失或不完整统计不生成部分总量。

## 迁移说明

这是新的 `oh-my-knowledge/dsh-plugin` API，没有历史数据迁移。调用方需要提供 parent agent，或显式提供 provider route；同时继续通过 binding-local resource lease 和 session isolation key 装配。

推进 #457。