### PR TITLE
feat(eval-core): 建立非阻塞 Event progress 投影

### DIFF
--- a/docs/specs/evaluation-runtime-adapter.md
+++ b/docs/specs/evaluation-runtime-adapter.md
@@ -1,6 +1,6 @@
 # Evaluation Runtime Adapter
 
-> **Status**: binding assembly, verified resource leases, adapter preflight, and the Core composition root for [#457](https://github.com/lizhiyao/oh-my-knowledge/issues/457). It is additive and does not switch the production `omk eval` pipeline.
+> **Status**: binding assembly, verified resource leases, adapter preflight, non-blocking event projection, and the Core composition root for [#457](https://github.com/lizhiyao/oh-my-knowledge/issues/457). It is additive and does not switch the production `omk eval` pipeline.
 
 ## Boundary
 
@@ -78,6 +78,21 @@ The runner consumes the compiled orchestration modes, never CLI flags. The compo
 The exact caller signal is forwarded. On cancellation, the active check must settle before preflight rejects; the runner does not use a race that leaves a credential, network, or filesystem operation in the background. The resulting immutable records stay on `OmkPreparedEvaluation.preflight`. Definition, MeasurementPolicy, RuntimeBinding, immutable binding entries, and `SealedRunPlan` remain unchanged and are never passed to a check.
 
 Preflight proves readiness only at the time of the probe. It does not turn a locator into content identity and does not reserve a resource for a later run. Run start therefore still acquires and revalidates verified resource leases against the actual bytes or tree. Similarly, the absence of a Judge binding means its factory is never invoked, so no Judge declaration, credential read, or connectivity probe can occur.
+
+## Event projection
+
+CLI progress is not an `EventWriter`. EventWriter delivery is part of the sealed MeasurementPolicy: it may apply blocking backpressure and a configured writer failure may fail the run. Presentation must never acquire either authority. The host instead drains Core's bounded `EvaluationRun.events` stream and projects those already-published events into an independent display path.
+
+The projection preserves `eventId`, `sequence`, `runId`, `eventKind`, time, and subject so output remains traceable to the Core event. It derives only a source-neutral stage and status from `eventKind`. Arbitrary event `data` is deliberately excluded: provider errors, evidence, coverage payloads, and future extension content do not become an unclassified UI channel. Subject and run identifiers remain the canonical non-secret identifiers defined by the Core event contract.
+
+When a progress sink is attached, the host immediately drains the single-consumer Core stream into two bounded, non-authoritative paths:
+
+- a raw-event mirror with the same drop-oldest behavior for callers;
+- a detached renderer queue with its own capacity.
+
+A slow or never-settling renderer can fill and overwrite only its display queue. A caller that never consumes the raw mirror can lose only old presentation history. Renderer rejection, synchronous exception, close failure, event-consumer failure, or an already closed sink cannot alter `EvaluationRunResult`, resource cleanup, cancellation, budgets, retries, EventWriter policy, or terminal artifacts. Sink method identity is captured before run-start effects, so later object mutation cannot replace the renderer behind an active run.
+
+Same-process JavaScript cannot isolate a callback that deliberately blocks the event loop with synchronous CPU work. The sink contract therefore requires `render()` to return promptly and place expensive rendering behind its own asynchronous boundary. Promise latency and failure are isolated by the host queue; CPU isolation would require a worker or process and is outside this adapter boundary.
 
 ## Same-process Runtime adapter
 

--- a/src/eval-workflows/runtime-adapter/composition.ts
+++ b/src/eval-workflows/runtime-adapter/composition.ts
@@ -56,6 +56,12 @@ import {
   type OmkEvaluationPreflightOptions,
   type OmkEvaluationPreflightResult,
 } from './preflight.js';
+import {
+  attachOmkEvaluationProgressProjection,
+  captureOmkEvaluationProgressProjection,
+  type CapturedOmkEvaluationProgressProjection,
+  type OmkEvaluationProgressSink,
+} from './event-projection.js';
 
 export interface OmkCachePortBinding<Port> {
   readonly sourceLocator: string;
@@ -106,6 +112,8 @@ export interface OmkEvaluationRunOptions {
   readonly runId: string;
   readonly signal?: AbortSignal;
   readonly eventBufferCapacity?: number;
+  readonly progressSink?: OmkEvaluationProgressSink;
+  readonly progressBufferCapacity?: number;
 }
 
 export interface OmkPreparedEvaluation {
@@ -812,32 +820,85 @@ export async function createOmkEvaluationRuntime(
         plan: corePrepared.plan,
         preflight,
         async start(options: Readonly<OmkEvaluationRunOptions>): Promise<EvaluationRun> {
-          if (record(options) === undefined || !IdentifierSchema.safeParse(options.runId).success) fail({
+          if (record(options) === undefined) fail({
+            code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+            message: 'Evaluation run options 不合法。',
+          });
+          let capturedOptions: OmkEvaluationRunOptions;
+          try {
+            capturedOptions = Object.freeze({
+              runId: options.runId,
+              ...(options.signal === undefined ? {} : { signal: options.signal }),
+              ...(options.eventBufferCapacity === undefined ? {} : {
+                eventBufferCapacity: options.eventBufferCapacity,
+              }),
+              ...(options.progressSink === undefined ? {} : {
+                progressSink: options.progressSink,
+              }),
+              ...(options.progressBufferCapacity === undefined ? {} : {
+                progressBufferCapacity: options.progressBufferCapacity,
+              }),
+            });
+          } catch {
+            return fail({
+              code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+              message: 'Evaluation run options 无法安全捕获。',
+            });
+          }
+          const {
+            runId,
+            signal,
+            eventBufferCapacity,
+            progressSink,
+            progressBufferCapacity,
+          } = capturedOptions;
+          if (!IdentifierSchema.safeParse(runId).success) fail({
             code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
             fieldPath: 'runId',
             message: 'runId 不符合 Core identifier contract。',
           });
-          if (options.eventBufferCapacity !== undefined
-              && (!Number.isSafeInteger(options.eventBufferCapacity)
-                || options.eventBufferCapacity <= 0)) fail({
+          if (eventBufferCapacity !== undefined
+              && (!Number.isSafeInteger(eventBufferCapacity)
+                || eventBufferCapacity <= 0)) fail({
             code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
             fieldPath: 'eventBufferCapacity',
             message: 'eventBufferCapacity 必须是正安全整数。',
           });
-          if (options.signal !== undefined
-              && (typeof options.signal.aborted !== 'boolean'
-                || typeof options.signal.addEventListener !== 'function')) fail({
+          if (signal !== undefined
+              && (typeof signal.aborted !== 'boolean'
+                || typeof signal.addEventListener !== 'function'
+                || typeof signal.removeEventListener !== 'function')) fail({
             code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
             fieldPath: 'signal',
             message: 'signal 不符合 AbortSignal contract。',
           });
-          const runId = options.runId;
+          let progressProjection: CapturedOmkEvaluationProgressProjection | undefined;
+          if (progressSink !== undefined) {
+            try {
+              progressProjection = captureOmkEvaluationProgressProjection(
+                progressSink,
+                progressBufferCapacity === undefined ? {} : {
+                  progressBufferCapacity,
+                },
+              );
+            } catch {
+              fail({
+                code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+                fieldPath: 'progressSink',
+                message: 'Evaluation progress sink 或 buffer capacity 不合法。',
+              });
+            }
+          } else if (progressBufferCapacity !== undefined) fail({
+            code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+            fieldPath: 'progressBufferCapacity',
+            message: '未提供 progress sink 时不能配置 progress buffer。',
+          });
           if (activeRunIds.has(runId)) fail({
             code: 'OMK_EVALUATION_RUNTIME_RUN_ACTIVE',
             runId,
             message: `runId "${runId}" 已有 active OMK evaluation run。`,
           });
-          if (signalIsAborted(options.signal)) return abortedBeforeStart(runId);
+          if (signalIsAborted(signal)) return abortedBeforeStart(runId);
           activeRunIds.add(runId);
           let leases: OmkRunResourceLeases | undefined;
           let registered = false;
@@ -903,7 +964,7 @@ export async function createOmkEvaluationRuntime(
             );
             assembly.evaluation.resourceLeaseRegistry.register(leases);
             registered = true;
-            if (signalIsAborted(options.signal)) {
+            if (signalIsAborted(signal)) {
               await cleanup();
               return abortedBeforeStart(runId);
             }
@@ -918,9 +979,9 @@ export async function createOmkEvaluationRuntime(
               coreRun = corePrepared.start({
                 runId,
                 ...staticRunMetadata(compiled),
-                ...(options.signal === undefined ? {} : { signal: options.signal }),
-                ...(options.eventBufferCapacity === undefined ? {} : {
-                  eventBufferCapacity: options.eventBufferCapacity,
+                ...(signal === undefined ? {} : { signal }),
+                ...(eventBufferCapacity === undefined ? {} : {
+                  eventBufferCapacity,
                 }),
                 ...(eventWriter === undefined ? {} : { eventWriter }),
               });
@@ -953,7 +1014,14 @@ export async function createOmkEvaluationRuntime(
             ).finally(() => {
               activeRunIds.delete(runId);
             });
-            return Object.freeze({ events: coreRun.events, result });
+            const hostRun = Object.freeze({ events: coreRun.events, result });
+            return progressProjection === undefined
+              ? hostRun
+              : attachOmkEvaluationProgressProjection(
+                  hostRun,
+                  progressProjection,
+                  eventBufferCapacity,
+                );
           } catch (cause) {
             try {
               await cleanup();

--- a/src/eval-workflows/runtime-adapter/event-projection.ts
+++ b/src/eval-workflows/runtime-adapter/event-projection.ts
@@ -1,0 +1,216 @@
+import type { EvaluationEvent } from '../../evaluation-core/contracts/index.js';
+import type { EvaluationRun } from '../../evaluation-core/engine/index.js';
+
+const DEFAULT_PROGRESS_BUFFER_CAPACITY = 64;
+const DEFAULT_EVENT_MIRROR_CAPACITY = 256;
+
+export type OmkEvaluationProgressStage =
+  | 'execution' | 'evaluation' | 'analysis' | 'decision' | 'report' | 'runtime';
+
+export type OmkEvaluationProgressStatus =
+  | 'started' | 'completed' | 'failed' | 'cancelled' | 'budget-exhausted'
+  | 'retry-scheduled' | 'cache-hit' | 'cache-miss' | 'inconclusive'
+  | 'not-evaluated' | 'not-decided' | 'activity';
+
+export interface OmkEvaluationProgressUpdate {
+  readonly eventId: string;
+  readonly sequence: number;
+  readonly runId: string;
+  readonly eventKind: string;
+  readonly time: string;
+  readonly subject: Readonly<{ subjectKind: string; subjectId: string }>;
+  readonly progressStage: OmkEvaluationProgressStage;
+  readonly progressStatus: OmkEvaluationProgressStatus;
+}
+
+export interface OmkEvaluationProgressSink {
+  readonly render: (
+    update: Readonly<OmkEvaluationProgressUpdate>,
+  ) => void | Promise<void>;
+  readonly close?: () => void | Promise<void>;
+}
+
+export interface OmkEvaluationProgressProjectionOptions {
+  readonly progressBufferCapacity?: number;
+}
+
+function stageFor(eventKind: string): OmkEvaluationProgressStage {
+  const stage = eventKind.split('.', 1)[0];
+  return ['execution', 'evaluation', 'analysis', 'decision', 'report'].includes(stage)
+    ? stage as OmkEvaluationProgressStage
+    : 'runtime';
+}
+
+function statusFor(eventKind: string): OmkEvaluationProgressStatus {
+  if (eventKind.endsWith('.retry.scheduled')) return 'retry-scheduled';
+  if (eventKind.endsWith('.cache.hit')) return 'cache-hit';
+  if (eventKind.endsWith('.cache.miss')) return 'cache-miss';
+  const suffix = eventKind.split('.').at(-1);
+  if (suffix === 'started' || suffix === 'completed' || suffix === 'failed'
+      || suffix === 'cancelled' || suffix === 'inconclusive') return suffix;
+  if (suffix === 'budget-exhausted') return 'budget-exhausted';
+  if (suffix === 'not-evaluated') return 'not-evaluated';
+  if (suffix === 'not-decided') return 'not-decided';
+  return 'activity';
+}
+
+/** Pure, source-neutral projection. Event data is deliberately not a display channel. */
+export function projectOmkEvaluationEvent(
+  event: Readonly<EvaluationEvent>,
+): Readonly<OmkEvaluationProgressUpdate> {
+  return Object.freeze({
+    eventId: event.eventId,
+    sequence: event.sequence,
+    runId: event.runId,
+    eventKind: event.eventKind,
+    time: event.time,
+    subject: Object.freeze({ ...event.subject }),
+    progressStage: stageFor(event.eventKind),
+    progressStatus: statusFor(event.eventKind),
+  });
+}
+
+export interface CapturedOmkEvaluationProgressProjection {
+  offer(event: Readonly<EvaluationEvent>): void;
+  close(): void;
+}
+
+function validCapacity(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+/** Captures sink identity and owns a bounded, detached renderer queue. */
+export function captureOmkEvaluationProgressProjection(
+  sink: Readonly<OmkEvaluationProgressSink>,
+  options: Readonly<OmkEvaluationProgressProjectionOptions> = {},
+): CapturedOmkEvaluationProgressProjection {
+  const capacity = options.progressBufferCapacity ?? DEFAULT_PROGRESS_BUFFER_CAPACITY;
+  if (sink === null || typeof sink !== 'object' || !validCapacity(capacity)) {
+    throw new TypeError('Evaluation progress projection input is invalid.');
+  }
+  const render = sink.render;
+  const closeSink = sink.close;
+  if (typeof render !== 'function'
+      || (closeSink !== undefined && typeof closeSink !== 'function')) {
+    throw new TypeError('Evaluation progress projection input is invalid.');
+  }
+  const queue: Array<Readonly<OmkEvaluationProgressUpdate>> = [];
+  let rendering = false;
+  let accepting = true;
+  let sinkEnabled = true;
+
+  const drain = async (): Promise<void> => {
+    while (queue.length > 0 && sinkEnabled) {
+      const update = queue.shift();
+      if (update === undefined) break;
+      try {
+        await Reflect.apply(render, undefined, [update]);
+      } catch {
+        sinkEnabled = false;
+        queue.splice(0);
+      }
+    }
+    rendering = false;
+    if (!accepting && sinkEnabled && closeSink !== undefined) {
+      sinkEnabled = false;
+      try {
+        await Reflect.apply(closeSink, undefined, []);
+      } catch {
+        // Presentation teardown is intentionally non-authoritative.
+      }
+    }
+  };
+
+  return Object.freeze({
+    offer(event: Readonly<EvaluationEvent>): void {
+      if (!accepting || !sinkEnabled) return;
+      if (queue.length === capacity) queue.shift();
+      queue.push(projectOmkEvaluationEvent(event));
+      if (rendering) return;
+      rendering = true;
+      queueMicrotask(() => { void drain(); });
+    },
+    close(): void {
+      if (!accepting) return;
+      accepting = false;
+      if (!rendering) {
+        rendering = true;
+        queueMicrotask(() => { void drain(); });
+      }
+    },
+  });
+}
+
+interface WaitingConsumer {
+  resolve(result: IteratorResult<EvaluationEvent>): void;
+}
+
+class DroppingEventMirror implements AsyncIterable<EvaluationEvent> {
+  readonly #capacity: number;
+  readonly #queue: EvaluationEvent[] = [];
+  readonly #waiting: WaitingConsumer[] = [];
+  #closed = false;
+  #iteratorCreated = false;
+
+  constructor(capacity: number) {
+    if (!validCapacity(capacity)) throw new TypeError('Event mirror capacity is invalid.');
+    this.#capacity = capacity;
+  }
+
+  push(event: EvaluationEvent): void {
+    if (this.#closed) return;
+    const waiting = this.#waiting.shift();
+    if (waiting !== undefined) {
+      waiting.resolve({ done: false, value: event });
+      return;
+    }
+    if (this.#queue.length === this.#capacity) this.#queue.shift();
+    this.#queue.push(event);
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const waiting of this.#waiting.splice(0)) {
+      waiting.resolve({ done: true, value: undefined });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<EvaluationEvent> {
+    if (this.#iteratorCreated) throw new TypeError('Event mirror supports one consumer.');
+    this.#iteratorCreated = true;
+    return {
+      next: async () => {
+        const event = this.#queue.shift();
+        if (event !== undefined) return { done: false, value: event };
+        if (this.#closed) return { done: true, value: undefined };
+        return new Promise<IteratorResult<EvaluationEvent>>((resolve) => {
+          this.#waiting.push({ resolve });
+        });
+      },
+    };
+  }
+}
+
+/** Drains Core events immediately and retains a bounded raw-event mirror for callers. */
+export function attachOmkEvaluationProgressProjection(
+  run: EvaluationRun,
+  projection: CapturedOmkEvaluationProgressProjection,
+  eventMirrorCapacity = DEFAULT_EVENT_MIRROR_CAPACITY,
+): EvaluationRun {
+  const mirror = new DroppingEventMirror(eventMirrorCapacity);
+  void (async () => {
+    try {
+      for await (const event of run.events) {
+        mirror.push(event);
+        projection.offer(event);
+      }
+    } catch {
+      // Event observation is presentation-only and cannot alter the authoritative result.
+    } finally {
+      mirror.close();
+      projection.close();
+    }
+  })();
+  return Object.freeze({ events: mirror, result: run.result });
+}

--- a/src/eval-workflows/runtime-adapter/index.ts
+++ b/src/eval-workflows/runtime-adapter/index.ts
@@ -3,6 +3,13 @@ export * from './adapters/index.js';
 export * from './builtins.js';
 export * from './composition.js';
 export {
+  projectOmkEvaluationEvent,
+  type OmkEvaluationProgressSink,
+  type OmkEvaluationProgressStage,
+  type OmkEvaluationProgressStatus,
+  type OmkEvaluationProgressUpdate,
+} from './event-projection.js';
+export {
   OmkEvaluationPreflightError,
   type OmkEvaluationPreflightErrorCode,
   type OmkEvaluationPreflightOptions,

--- a/test/eval-workflows/runtime-adapter/assembly.test.ts
+++ b/test/eval-workflows/runtime-adapter/assembly.test.ts
@@ -1832,6 +1832,13 @@ describe('OMK Evaluation Runtime composition root', () => {
       code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
       fieldPath: 'eventBufferCapacity',
     });
+    await expect(prepared.start({
+      runId: 'invalid-progress-options',
+      progressBufferCapacity: 1,
+    })).rejects.toMatchObject({
+      code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
+      fieldPath: 'progressBufferCapacity',
+    });
     expect(acquireCalls).toBe(0);
   });
 
@@ -2079,6 +2086,51 @@ describe('OMK Evaluation Runtime composition root', () => {
 
     expect(compiled.policy.eventDelivery.writerMode).toBe('disabled');
     expect(writerCalls).toBe(0);
+  });
+
+  it('keeps a never-settling progress renderer outside Core result and lease cleanup', async () => {
+    const compiled = compositionInput();
+    let disposeCalls = 0;
+    let renderCalls = 0;
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, []),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          return fakeLeases(
+            request.runId,
+            request.bindings,
+            request.hostResources,
+            () => { disposeCalls += 1; },
+          );
+        },
+      },
+    });
+    const run = await (await runtime.prepare()).start({
+      runId: 'detached-progress',
+      progressBufferCapacity: 1,
+      progressSink: {
+        render() {
+          renderCalls += 1;
+          return new Promise<void>(() => {});
+        },
+      },
+    });
+    const observedEvents: string[] = [];
+    const drainEvents = (async () => {
+      for await (const candidate of run.events) observedEvents.push(candidate.eventKind);
+    })();
+
+    await expect(run.result).resolves.toHaveProperty('status');
+    await drainEvents;
+    expect(renderCalls).toBe(1);
+    expect(observedEvents).toContain('execution.run.started');
+    expect(observedEvents.some((eventKind) => (
+      eventKind.startsWith('execution.run.') && eventKind !== 'execution.run.started'
+    ))).toBe(true);
+    expect(disposeCalls).toBe(1);
   });
 
   it('reports lease disposal failure without retrying destructive cleanup', async () => {

--- a/test/eval-workflows/runtime-adapter/event-projection.test.ts
+++ b/test/eval-workflows/runtime-adapter/event-projection.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EVALUATION_EVENT_SCHEMA_VERSION,
+  EvaluationEventSchema,
+  type EvaluationEvent,
+} from '../../../src/evaluation-core/contracts/index.js';
+import type {
+  EvaluationRun,
+  EvaluationRunResult,
+} from '../../../src/evaluation-core/engine/index.js';
+import {
+  attachOmkEvaluationProgressProjection,
+  captureOmkEvaluationProgressProjection,
+  projectOmkEvaluationEvent,
+} from '../../../src/eval-workflows/runtime-adapter/event-projection.js';
+
+function event(
+  sequence: number,
+  eventKind: string,
+  subjectKind = 'run',
+  subjectId = 'run-1',
+): EvaluationEvent {
+  return EvaluationEventSchema.parse({
+    schemaVersion: EVALUATION_EVENT_SCHEMA_VERSION,
+    eventId: `event-${sequence}`,
+    sequence,
+    runId: 'run-1',
+    eventKind,
+    time: `2026-08-31T00:00:0${sequence}.000Z`,
+    subject: { subjectKind, subjectId },
+    data: { secret: 'must-not-enter-progress' },
+  });
+}
+
+function failedResult(): Promise<EvaluationRunResult> {
+  return Promise.resolve({
+    status: 'failed',
+    error: { code: 'test-failure', stage: 'internal', message: 'test only' },
+  });
+}
+
+function runWith(events: readonly EvaluationEvent[]): EvaluationRun {
+  return {
+    events: {
+      async *[Symbol.asyncIterator]() {
+        yield* events;
+      },
+    },
+    result: failedResult(),
+  };
+}
+
+async function collect(run: EvaluationRun): Promise<EvaluationEvent[]> {
+  const events: EvaluationEvent[] = [];
+  for await (const candidate of run.events) events.push(candidate);
+  return events;
+}
+
+describe('Evaluation event progress projection', () => {
+  it('preserves the event envelope while excluding arbitrary event data', () => {
+    const projected = projectOmkEvaluationEvent(event(
+      1,
+      'execution.retry.scheduled',
+      'trial',
+      'trial-1',
+    ));
+
+    expect(projected).toEqual({
+      eventId: 'event-1',
+      sequence: 1,
+      runId: 'run-1',
+      eventKind: 'execution.retry.scheduled',
+      time: '2026-08-31T00:00:01.000Z',
+      subject: { subjectKind: 'trial', subjectId: 'trial-1' },
+      progressStage: 'execution',
+      progressStatus: 'retry-scheduled',
+    });
+    expect(projected).not.toHaveProperty('data');
+    expect(Object.isFrozen(projected)).toBe(true);
+    expect(Object.isFrozen(projected.subject)).toBe(true);
+  });
+
+  it('keeps a never-settling renderer outside the authoritative result and raw event stream', async () => {
+    let renderStarted = false;
+    const projection = captureOmkEvaluationProgressProjection({
+      render() {
+        renderStarted = true;
+        return new Promise<void>(() => {});
+      },
+    }, { progressBufferCapacity: 1 });
+    const source = runWith([
+      event(0, 'execution.run.started'),
+      event(1, 'execution.run.completed'),
+      event(2, 'report.materialized', 'report', 'report-1'),
+    ]);
+    const projected = attachOmkEvaluationProgressProjection(source, projection, 8);
+
+    expect(projected.result).toBe(source.result);
+    await expect(projected.result).resolves.toMatchObject({ status: 'failed' });
+    await expect.poll(() => renderStarted).toBe(true);
+    await expect(collect(projected)).resolves.toEqual([
+      event(0, 'execution.run.started'),
+      event(1, 'execution.run.completed'),
+      event(2, 'report.materialized', 'report', 'report-1'),
+    ]);
+  });
+
+  it('isolates renderer failure from the run result', async () => {
+    let calls = 0;
+    let closes = 0;
+    const projection = captureOmkEvaluationProgressProjection({
+      render() {
+        calls += 1;
+        throw new Error('renderer failed');
+      },
+      close() {
+        closes += 1;
+        throw new Error('renderer close failed');
+      },
+    });
+    const source = runWith([event(0, 'evaluation.run.started')]);
+    const projected = attachOmkEvaluationProgressProjection(source, projection);
+
+    await expect(projected.result).resolves.toMatchObject({ status: 'failed' });
+    await collect(projected);
+    await expect.poll(() => calls).toBe(1);
+    expect(closes).toBe(0);
+  });
+
+  it('isolates close failure after a successful render queue drain', async () => {
+    let closes = 0;
+    const projection = captureOmkEvaluationProgressProjection({
+      render() {},
+      close() {
+        closes += 1;
+        throw new Error('renderer close failed');
+      },
+    });
+    const source = runWith([event(0, 'evaluation.run.started')]);
+    const projected = attachOmkEvaluationProgressProjection(source, projection);
+
+    await collect(projected);
+    await expect.poll(() => closes).toBe(1);
+    await expect(projected.result).resolves.toMatchObject({ status: 'failed' });
+  });
+
+  it('closes the mirror without changing result when event observation fails', async () => {
+    const source: EvaluationRun = {
+      events: {
+        async *[Symbol.asyncIterator]() {
+          yield event(0, 'execution.run.started');
+          throw new Error('event consumer failed');
+        },
+      },
+      result: failedResult(),
+    };
+    const projection = captureOmkEvaluationProgressProjection({ render() {} });
+    const projected = attachOmkEvaluationProgressProjection(source, projection);
+
+    await expect(collect(projected)).resolves.toEqual([event(0, 'execution.run.started')]);
+    await expect(projected.result).resolves.toMatchObject({ status: 'failed' });
+  });
+
+  it('bounds an unconsumed raw-event mirror by dropping only presentation history', async () => {
+    let projectionClosed = false;
+    const projection = captureOmkEvaluationProgressProjection({
+      render() {},
+      close() { projectionClosed = true; },
+    });
+    const source = runWith([
+      event(0, 'execution.run.started'),
+      event(1, 'execution.block.started', 'scheduling-block', 'block-1'),
+      event(2, 'execution.block.completed', 'scheduling-block', 'block-1'),
+    ]);
+    const projected = attachOmkEvaluationProgressProjection(source, projection, 2);
+    await expect.poll(() => projectionClosed).toBe(true);
+
+    await expect(collect(projected)).resolves.toEqual([
+      event(1, 'execution.block.started', 'scheduling-block', 'block-1'),
+      event(2, 'execution.block.completed', 'scheduling-block', 'block-1'),
+    ]);
+    await expect(projected.result).resolves.toMatchObject({ status: 'failed' });
+  });
+
+  it('captures renderer method identity before asynchronous event delivery', async () => {
+    let original = 0;
+    let replacement = 0;
+    const sink = {
+      render() { original += 1; },
+    };
+    const projection = captureOmkEvaluationProgressProjection(sink);
+    sink.render = () => { replacement += 1; };
+    const projected = attachOmkEvaluationProgressProjection(
+      runWith([event(0, 'analysis.run.started')]),
+      projection,
+    );
+
+    await collect(projected);
+    await expect.poll(() => original).toBe(1);
+    expect(replacement).toBe(0);
+  });
+});


### PR DESCRIPTION
## 用户影响

为 Evaluation Core 宿主建立独立的 Core event → progress 展示投影。未来正式 CLI 接线后，慢速、未消费、关闭、抛错或永不 settle 的 renderer 都不会反压评测计算，也不会改变结果、预算、取消、资源清理或 terminal artifacts。正式 `omk eval` 仍使用旧 pipeline。

## 架构边界

CLI progress 不复用受 sealed MeasurementPolicy 管辖的 `EventWriter`。宿主只消费 Core 已发布的 bounded event stream，并把事件送入彼此独立的有界 raw-event mirror 与 renderer queue；丢弃仅影响展示历史。投影保留 eventId、sequence、runId、eventKind、time 与 subject，只从 eventKind 推导 source-neutral stage／status，不转发任意 event data，避免形成未分级证据通道。

renderer 方法与整组 run-start options 在任何异步 effect 前单次捕获，后续对象 mutation 不会替换 active run 的展示实现或改变 buffer／signal。same-process 同步 CPU 阻塞无法由 Promise 隔离，因此 sink contract 要求 render 迅速返回；异步延迟与失败由宿主有界队列隔离。

## 迁移说明

新宿主可在 `OmkEvaluationRunOptions` 传入可选 `progressSink` 与独立 buffer capacity；不传时保持原始 Core event stream 行为。当前未切换正式 CLI，无历史数据或用户配置迁移。

本改动不修改 Event wire schema、Report schema、冻结 prompt、五层评分、统计公式或 length-debias，不构成 `BREAKING-COMPARABILITY`。

推进 #457