### PR TITLE
test(eval-core): 封存 Runtime adapter 故障隔离矩阵

### DIFF
--- a/docs/specs/evaluation-runtime-adapter.md
+++ b/docs/specs/evaluation-runtime-adapter.md
@@ -190,3 +190,11 @@ EventWriter is deliberately not stored in the static `EvaluationEngineRuntime`. 
 - provider, session, attempt, cancellation, and dispose failures belong to Runtime ports after the Run starts.
 
 This layer does not modify frozen prompts, scoring stages, statistical formulas, cache semantics, Bundle／Report schemas, or the legacy pipeline.
+
+## Fault isolation and dependency boundary
+
+The composition root treats each `runId` as an independent failure domain. Concurrent runs have separate lease registrations, adapter sessions, raw-event mirrors, progress queues, cancellation signals, and teardown promises. Cancelling one in-flight run cannot cancel its peer, publish into the peer's event／progress channels, or release the peer's resources. Both the Runtime port lifecycle and the host lease are still disposed exactly once after their own run settles.
+
+Fault-injection coverage exercises failures before acquisition, during acquisition, while constructing EventWriter, during Core start／execution, in non-authoritative progress rendering, and during Runtime／lease disposal. Every path either performs no effect or joins the same idempotent cleanup promise; no rejected callback, cancellation race, or renderer promise is allowed to leave authoritative work running in the background.
+
+Evaluation Core is also protected by a source dependency guard. Core TypeScript may import only another file under `src/evaluation-core`, `zod`, or `node:crypto`; it may not import the CLI, host orchestration, filesystem APIs, provider SDKs, or ambient `process.env`／`process.cwd()` state. This makes the architectural boundary executable in CI instead of relying on convention.

--- a/test/eval-workflows/runtime-adapter/assembly.test.ts
+++ b/test/eval-workflows/runtime-adapter/assembly.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+  canonicalizeJson,
   createEvaluationSeriesDefinition,
   createEvaluationEngine,
   digestCanonicalJson,
@@ -103,6 +104,39 @@ function bindingIdentity(
       facets: [{ facetId: 'binding-reference', value: referenceId }],
     },
   });
+}
+
+function normalizedAnalysisCapabilities(input: RuntimeIdentity['capabilities']): JsonValue {
+  const capabilities = structuredClone(input) as unknown as Record<string, unknown>;
+  const sortStrings = (value: unknown): void => {
+    if (Array.isArray(value)) (value as string[]).sort();
+  };
+  sortStrings(capabilities.analysisNodeKinds);
+  sortStrings(capabilities.analysisResultSchemaUris);
+  sortStrings(capabilities.multipleComparisonPolicyIds);
+  sortStrings(capabilities.valueTypes);
+  const sampling = capabilities.sampling as Record<string, unknown> | undefined;
+  if (sampling !== undefined) {
+    sortStrings(sampling.experimentalUnits);
+    if (Array.isArray(sampling.repeatedMeasures)) sampling.repeatedMeasures.sort();
+    sortStrings(sampling.resamplingUnits);
+  }
+  if (Array.isArray(capabilities.inputDomains)) {
+    for (const domain of capabilities.inputDomains as Array<Record<string, unknown>>) {
+      sortStrings(domain.valueTypes);
+      sortStrings(domain.missingPolicyIds);
+      sortStrings(domain.schemaUris);
+    }
+    capabilities.inputDomains.sort((left, right) => (
+      canonicalizeJson(left as JsonValue).localeCompare(canonicalizeJson(right as JsonValue))
+    ));
+  }
+  if (Array.isArray(capabilities.schemas)) {
+    capabilities.schemas.sort((left, right) => (
+      canonicalizeJson(left as JsonValue).localeCompare(canonicalizeJson(right as JsonValue))
+    ));
+  }
+  return capabilities as JsonValue;
 }
 
 function analysisRequirement(
@@ -305,10 +339,19 @@ function factoriesFor(
             versionConstraint: request.versionConstraint,
           }),
         })) as RuntimeResolution;
+        const capabilities = structuredClone(resolved.identity.capabilities) as {
+          inputSourceKinds: string[];
+          metricValueTypes: string[];
+          schemas: SchemaIdentity[];
+        };
+        capabilities.inputSourceKinds.sort();
+        capabilities.metricValueTypes.sort();
+        capabilities.schemas.sort((left, right) => left.schemaUri.localeCompare(right.schemaUri));
         const identity = bindingIdentity(
           request.implementationId,
           request.evaluatorId,
           resolved.identity,
+          capabilities,
         );
         const port: EvaluationEvaluator = {
           identity,
@@ -375,7 +418,7 @@ function factoriesFor(
           request.implementationId,
           request.referenceId,
           resolved.identity,
-          capabilities,
+          normalizedAnalysisCapabilities(capabilities),
         );
         const port: AnalysisNodeImplementation = {
           identity,
@@ -398,6 +441,7 @@ function factoriesFor(
             request.implementationId,
             request.policyId,
             resolved.identity,
+            normalizedAnalysisCapabilities(resolved.identity.capabilities),
           ),
           decide: () => 'exclude',
         };
@@ -420,6 +464,7 @@ function factoriesFor(
             request.implementationId,
             request.decisionPolicyId,
             resolved.identity,
+            normalizedAnalysisCapabilities(resolved.identity.capabilities),
           ),
           async decide() {
             return { decisionStatus: 'not-decided', reasonCodes: ['test-only'] };
@@ -577,10 +622,31 @@ function runnableFactoriesFor(
       };
     });
   }
+  const analysisNodes = new Map(base.analysisNodesByImplementationId);
+  for (const [implementationId, factory] of analysisNodes) {
+    analysisNodes.set(implementationId, async (context) => {
+      const resolved = await factory(context);
+      return {
+        ...resolved,
+        port: {
+          ...resolved.port,
+          async openRun() {
+            return {
+              async execute() {
+                return { analysisStatus: 'inconclusive' as const, reasonCodes: ['test-only'] };
+              },
+              dispose() {},
+            };
+          },
+        },
+      };
+    });
+  }
   return {
     ...base,
     executorsByImplementationId: executors,
     evaluatorsByImplementationId: evaluators,
+    analysisNodesByImplementationId: analysisNodes,
   };
 }
 
@@ -597,6 +663,9 @@ function compositionInput(options: {
   referenceOutput?: boolean;
   referenceTrace?: boolean;
   referenceEvaluationEvidence?: boolean;
+  executionTimeout?: boolean;
+  evaluationTimeout?: boolean;
+  providerCostBudget?: boolean;
 } = {}) {
   const input = runtimeAssemblyInput();
   delete input.orchestration.independentSeries;
@@ -608,6 +677,13 @@ function compositionInput(options: {
     evidence: options.referenceEvaluationEvidence === true ? 'reference' : 'full',
     maximumClassification: 'gold',
   };
+  if (options.executionTimeout === false) delete input.policy.executionTimeoutMs;
+  if (options.evaluationTimeout === false) delete input.policy.evaluationTimeoutMs;
+  if (options.providerCostBudget === false) {
+    if (input.policy.budget === undefined) throw new Error('missing test budget');
+    delete input.policy.budget.totalProviderCostUSD;
+    delete input.policy.budget.perCoordinateProviderCostUSD;
+  }
   return compileCliEvaluationInput(input);
 }
 
@@ -1878,6 +1954,104 @@ describe('OMK Evaluation Runtime composition root', () => {
     expect(lifecycle.some((entry) => entry.startsWith('executor.open:parallel-a:'))).toBe(true);
     expect(lifecycle.some((entry) => entry.startsWith('executor.open:parallel-b:'))).toBe(true);
     expect(disposed.sort()).toEqual(['parallel-a', 'parallel-b']);
+  });
+
+  it('isolates cancellation, events, progress and teardown across concurrent runs', async () => {
+    const compiled = compositionInput({
+      executionTimeout: false,
+      evaluationTimeout: false,
+      providerCostBudget: false,
+    });
+    let releaseExecution: (() => void) | undefined;
+    const executeGate = new Promise<void>((resolve) => { releaseExecution = resolve; });
+    const lifecycle: string[] = [];
+    const disposed: string[] = [];
+    const controller = new AbortController();
+    const progress = { isolatedA: [] as string[], isolatedB: [] as string[] };
+    const closed = { isolatedA: false, isolatedB: false };
+    const runtime = await createOmkEvaluationRuntime({
+      compiled,
+      factories: runnableFactoriesFor(compiled, lifecycle, executeGate),
+      support: compositionSupport(),
+      resources: {
+        leaseRoot: '/unused-test-lease-root',
+        async materialize(request) {
+          return fakeLeases(
+            request.runId,
+            request.bindings,
+            request.hostResources,
+            () => disposed.push(request.runId),
+          );
+        },
+      },
+    });
+    const prepared = await runtime.prepare();
+    const first = await prepared.start({
+      runId: 'isolated-a',
+      signal: controller.signal,
+      progressSink: {
+        render(update) { progress.isolatedA.push(update.runId); },
+        close() { closed.isolatedA = true; },
+      },
+    });
+    const second = await prepared.start({
+      runId: 'isolated-b',
+      progressSink: {
+        render(update) { progress.isolatedB.push(update.runId); },
+        close() { closed.isolatedB = true; },
+      },
+    });
+    const firstEvents: Array<{ runId: string; eventKind: string }> = [];
+    const secondEvents: Array<{ runId: string; eventKind: string }> = [];
+    const firstDrain = (async () => {
+      for await (const event of first.events) firstEvents.push(event);
+    })();
+    const secondDrain = (async () => {
+      for await (const event of second.events) secondEvents.push(event);
+    })();
+
+    await expect.poll(() => lifecycle.some(
+      (entry) => entry.startsWith('executor.open:isolated-a:'),
+    )).toBe(true);
+    await expect.poll(() => lifecycle.some(
+      (entry) => entry.startsWith('executor.open:isolated-b:'),
+    )).toBe(true);
+    controller.abort();
+    releaseExecution?.();
+    const [firstResult, secondResult] = await Promise.all([first.result, second.result]);
+    await Promise.all([firstDrain, secondDrain]);
+    await expect.poll(() => closed.isolatedA && closed.isolatedB).toBe(true);
+
+    expect(firstResult.status).toBe('cancelled');
+    expect(secondResult.status).toBe('completed');
+    expect(firstEvents.length).toBeGreaterThan(0);
+    expect(secondEvents.length).toBeGreaterThan(0);
+    expect(firstEvents.every((event) => event.runId === 'isolated-a')).toBe(true);
+    expect(secondEvents.every((event) => event.runId === 'isolated-b')).toBe(true);
+    expect(firstEvents).toContainEqual(expect.objectContaining({
+      eventKind: 'execution.run.cancelled',
+    }));
+    expect(secondEvents.some((event) => event.eventKind === 'execution.run.cancelled')).toBe(false);
+    expect(secondEvents).toContainEqual(expect.objectContaining({
+      eventKind: 'execution.run.completed',
+    }));
+    expect(secondEvents).toContainEqual(expect.objectContaining({
+      eventKind: 'evaluation.run.completed',
+    }));
+    expect(progress.isolatedA.length).toBeGreaterThan(0);
+    expect(progress.isolatedB.length).toBeGreaterThan(0);
+    expect(progress.isolatedA.every((runId) => runId === 'isolated-a')).toBe(true);
+    expect(progress.isolatedB.every((runId) => runId === 'isolated-b')).toBe(true);
+    for (const runId of ['isolated-a', 'isolated-b']) {
+      for (const runtimeKind of ['executor', 'evaluator']) {
+        expect(lifecycle.filter((entry) => (
+          entry.startsWith(`${runtimeKind}.run.dispose:${runId}`)
+        ))).toHaveLength(lifecycle.filter((entry) => (
+          entry.startsWith(`${runtimeKind}.open:${runId}:`)
+        )).length);
+      }
+    }
+    expect(disposed.sort()).toEqual(['isolated-a', 'isolated-b']);
   });
 
   it('rejects writable overlay reuse across active runs before opening the second run', async () => {

--- a/test/scripts/evaluation-core-dependency-guard.test.ts
+++ b/test/scripts/evaluation-core-dependency-guard.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, extname, resolve, sep } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const CORE_ROOT = resolve('src/evaluation-core');
+const ALLOWED_EXTERNAL_IMPORTS = new Set(['zod', 'node:crypto']);
+const TYPESCRIPT_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts']);
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return entry.isFile() && TYPESCRIPT_EXTENSIONS.has(extname(entry.name)) ? [path] : [];
+  });
+}
+
+function hasNonLiteralDependency(source: string): boolean {
+  return /\b(?:import|require)\s*\(\s*[^\s'"]/.test(source);
+}
+
+function importsFrom(source: string): string[] {
+  const imports = new Set<string>();
+  const patterns = [
+    /(?:\bfrom\s*|\bimport\s*\()\s*['"]([^'"]+)['"]/g,
+    /\bimport\s*['"]([^'"]+)['"]/g,
+    /\brequire\s*\(\s*['"]([^'"]+)['"]/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      if (match[1] !== undefined) imports.add(match[1]);
+    }
+  }
+  return [...imports];
+}
+
+describe('Evaluation Core dependency boundary', () => {
+  it('recognizes every dependency syntax that the boundary prohibits', () => {
+    const source = [
+      "import value from 'static-package';",
+      "export { value } from './relative-export.js';",
+      "import 'side-effect-package';",
+      "await import('dynamic-package');",
+      "require('commonjs-package');",
+    ].join('\n');
+
+    expect(importsFrom(source).sort()).toEqual([
+      './relative-export.js',
+      'commonjs-package',
+      'dynamic-package',
+      'side-effect-package',
+      'static-package',
+    ]);
+    expect(hasNonLiteralDependency(source)).toBe(false);
+    expect(hasNonLiteralDependency('await import(dynamicSpecifier);')).toBe(true);
+    expect(hasNonLiteralDependency('require(dynamicSpecifier);')).toBe(true);
+  });
+
+  it('does not reverse-import host, filesystem, environment, or provider dependencies', () => {
+    const violations: string[] = [];
+    for (const file of sourceFiles(CORE_ROOT)) {
+      const source = readFileSync(file, 'utf8');
+      if (/\bprocess\.(?:env|cwd)\b/.test(source)) {
+        violations.push(`${file}: ambient process state`);
+      }
+      if (hasNonLiteralDependency(source)) {
+        violations.push(`${file}: non-literal dependency`);
+      }
+      for (const specifier of importsFrom(source)) {
+        if (specifier.startsWith('.')) {
+          const target = resolve(dirname(file), specifier);
+          if (target !== CORE_ROOT && !target.startsWith(`${CORE_ROOT}${sep}`)) {
+            violations.push(`${file}: ${specifier}`);
+          }
+          continue;
+        }
+        if (!ALLOWED_EXTERNAL_IMPORTS.has(specifier)) {
+          violations.push(`${file}: ${specifier}`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 用户影响

封存 Evaluation Core Runtime adapter 的最终并发、取消、事件、进度与资源清理隔离边界，并把 Core 不得反向依赖宿主／provider 的架构约束纳入 CI。至此，#457 的 Runtime adapter 基础设施具备可重复验证的故障边界。正式 `omk eval` 仍使用旧 pipeline，不发生用户侧切换。

## 架构与测量边界

- 每个 run 保持独立的取消、事件、进度、Runtime session 与资源 lease；一个 run 的取消或 teardown 不影响并发 peer。
- UI progress 继续是非权威投影，不参与结果、预算、重试或清理。
- Evaluation Core 只允许内部依赖、`zod` 与纯哈希所需的 `node:crypto`，不读取 CLI、文件系统、环境变量或 provider SDK。
- 不修改 Report／Bundle schema、冻结 prompt、五层评分、统计公式、length-debias 或 measurement identity。

## 迁移说明

无迁移操作。本 PR 不接管正式 CLI、不持久化新 Bundle／Report，也不双跑新旧 pipeline。

Closes #457