### PR TITLE
docs(eval-core): 冻结评分迁移等价基线

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -74,6 +74,7 @@ export default defineConfig({
               { text: 'Sample design spec', link: '/specs/sample-design-spec' },
               { text: 'Knowledge gap signal spec', link: '/specs/knowledge-gap-signal-spec' },
               { text: 'RAG metrics spec', link: '/specs/rag-metrics-spec' },
+              { text: 'Scoring equivalence RFC', link: '/specs/evaluation-scoring-equivalence' },
               { text: 'Terminology spec', link: '/specs/terminology-spec' },
               { text: 'Storage layout spec', link: '/specs/storage-layout-spec' },
             ],

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Browse by audience or category. For Chinese docs see [简体中文 index](./zh/R
 ## I want to contribute / read design specs
 
 - [Evaluation Core vNext RFC](./specs/evaluation-core-vnext.md)
+- [Evaluation scoring equivalence RFC](./specs/evaluation-scoring-equivalence.md)
 - [CLI evaluation input compilation](./specs/cli-evaluation-input-compilation.md)
 - [Sample design spec](./specs/sample-design-spec.md)
 - [Knowledge gap signal spec](./specs/knowledge-gap-signal-spec.md)

--- a/docs/specs/evaluation-core-vnext.md
+++ b/docs/specs/evaluation-core-vnext.md
@@ -1034,6 +1034,7 @@ This design follows resource-quota admission practice rather than billing dashbo
 ## Related documents
 
 - [Scoring pipeline](scoring.md)
+- [Scoring equivalence migration RFC](evaluation-scoring-equivalence.md)
 - [Statistical rigor](../explanation/statistical-rigor.md)
 - [Terminology spec](terminology-spec.md)
 - [RAG metrics spec](rag-metrics-spec.md)

--- a/docs/specs/evaluation-scoring-equivalence.md
+++ b/docs/specs/evaluation-scoring-equivalence.md
@@ -1,0 +1,158 @@
+# Evaluation scoring equivalence RFC
+
+> Status: migration contract for [#480](https://github.com/lizhiyao/oh-my-knowledge/issues/480). This RFC does not switch `omk eval`, persist Evaluation Core artifacts, or change the legacy Report schema.
+
+## 1. Decision
+
+The current scoring and release semantics will be re-expressed as an Evaluation Core pipeline with four explicit boundaries:
+
+```text
+sealed sample evaluation context
+  -> host Evaluators: criterion observations and raw judge readings
+  -> AnalysisGraph: replicate, ensemble, layer, dimension, and composite derivations
+  -> statistical Analysis nodes: intervals, agreement, and corrections
+  -> DecisionPolicy: release verdict
+```
+
+The migration is validated offline against fixed execution outputs and fixed provider responses. Production dual-run, dual-write, fallback selection, and old-artifact migration are out of scope.
+
+The old pipeline remains the equivalence oracle only while #480 is in progress. New code must not import legacy graders as its implementation. Once production cutover is complete, the duplicated legacy path can be removed instead of becoming a compatibility layer.
+
+## 2. Construct model
+
+The historical term “five-layer scoring” describes five identities, not five consecutive averages:
+
+| Identity | Current meaning | Core role |
+|---|---|---|
+| assertion | Weighted pass/fail criterion; later classified as fact or behavior | Evaluator observation plus evidence |
+| llm | One raw 1–5 reading from one judge invocation | Numeric Evaluator observation |
+| judge | Successful replicate mean, then successful ensemble-member mean | Per-unit Analysis results |
+| dimension | Named rubric result; dimensions are averaged into the sample judge score | Per-unit Analysis result |
+| composite | Equal mean of the present fact, behavior, and judge scores | Per-unit Analysis result |
+
+`dimension` does not currently enter `composite` as an additional fourth score. It is one route for obtaining the judge-layer score. A migration that averages assertion → llm → judge → dimension → composite in sequence would measure a different construct and is rejected.
+
+## 3. Sealed input and applicability
+
+Legacy scoring criteria vary by sample, while Core Evaluator definitions are run-plan-wide. The compiler therefore materializes a scoring projection in each sample's `evaluationContext` and a union of stable Metric definitions for the dataset.
+
+Evaluator families are run-plan-wide and declare only the inputs they need. For a sample to which a declared metric does not apply, the Evaluator emits `missing` with reason `criterion-not-applicable`. It must not emit zero or fabricate a pass. The sample evaluation context, prompt hashes, evaluator configuration, and Metric union are covered by the EvaluationPlan identity before the first Target invocation.
+
+This design avoids three invalid alternatives:
+
+- runtime-created Evaluators, which would evade the sealed plan;
+- encoding sample, retry, or repeat state into `evaluatorId` conventions;
+- one opaque grader observation containing only the final legacy score.
+
+## 4. Runtime families
+
+The host owns provider calls, prompt registry access, custom-module loading, and content parsing. Evaluation Core owns scheduling, retry, timeout, budget, cache, input binding, evidence policy, cancellation, and lifecycle.
+
+| Runtime family | Input bindings | Observation | Identity requirements |
+|---|---|---|---|
+| deterministic assertion | output and, when required, trace or evaluation context | Boolean criterion result; assertion detail as evidence | assertion algorithm version and supported type registry |
+| custom assertion | output and evaluation context; verified resource lease | Boolean criterion result or structured evaluator failure | module content identity and sandbox/resource policy |
+| semantic similarity | output, expected/evaluation context | Boolean threshold result; fixed-response parse evidence | semantic prompt hash, model Runtime identity, threshold |
+| RAG metric | output and evaluation context | Boolean threshold result; fixed-response parse evidence | metric-specific prompt hash, model Runtime identity, threshold |
+| rubric judge | output, optional trace, evaluation context | Raw numeric reading on the 1–5 scale | rubric prompt hash, debias variant, ensemble member, replicate index, model Runtime identity |
+
+The Core never imports `PROMPT_REGISTRY`. The composition root resolves a frozen prompt and places its hash in the host Runtime identity. `lengthDebias=false` selects only the existing rubric debias-off instrument. Presentation and tone neutrality remain enabled. RAG and semantic prompts have no length-debias switch.
+
+## 5. Identity and statistical units
+
+| Legacy concept | Core identity |
+|---|---|
+| execution `--repeat` | Target `trialIndex` and `trialId` |
+| `--judge-repeat` | Evaluator `replicateGroupId` and `replicateIndex` |
+| judge model in an ensemble | `ensembleMemberId` plus resolved Runtime identity |
+| provider retry | `attemptNumber` inside one `evaluationId` |
+| sample | `sampleId` and sampling-unit identities |
+| paired control/treatment observation | `pairingBlockId` |
+| batch child evaluation | independent Run identity |
+
+Retry never creates a new measurement replicate. A failed judge replicate remains failed and is not silently replaced by an extra successful call. Aggregators consume only the explicitly planned replicate coordinates and preserve failure counts.
+
+## 6. AnalysisGraph
+
+Per-unit derivations use versioned table envelopes. Each row binds target, sample, trial, metric or dimension identity, input observation IDs, value or structured missing reason, and the exact rounding stage. Downstream nodes consume these tables as Analysis results; they do not create new MetricObservations after Evaluation has completed.
+
+Planned nodes are:
+
+1. `judge-replicate-mean`: mean and sample standard deviation over successful raw readings; zero successful readings is missing.
+2. `judge-ensemble-mean`: equal mean over successful member means; member rows and failures remain in the input lineage.
+3. `dimension-mean`: equal mean over present dimension scores, rounded to two decimals.
+4. `assertion-layer-score`: weighted pass ratio separately for fact and behavior, mapped with `1 + ratio * 4`, rounded to two decimals.
+5. `composite-score`: equal mean over present fact, behavior, and judge rows, rounded to two decimals; no present layer yields the historical zero sentinel only in the legacy projection, while the authoritative Core result is inconclusive/missing.
+
+Mixed-layer `assert-set` criteria remain visible assertion observations but are excluded from both fact and behavior. Zero total weight yields a missing layer. A failed rubric judge is missing, not score zero.
+
+The legacy RAG and semantic paths currently convert provider/parse failure into a failed Boolean assertion. That behavior is frozen by the equivalence fixture, but it is a measurement defect: infrastructure failure is not evidence that the answer failed the criterion. [#481](https://github.com/lizhiyao/oh-my-knowledge/issues/481) owns the separate `BREAKING-COMPARABILITY` correction; the Core representation must retain enough failure provenance to make that future correction possible.
+
+## 7. Statistical standards
+
+The exact migration standards are distinct from similarly named generic Core built-ins when their random stream or conclusion contract differs.
+
+| Legacy standard | Direct Core built-in reuse? | Reason |
+|---|---|---|
+| arithmetic mean/rate | yes, where no per-unit derived table is required | Same estimand and missing exclusion |
+| mean/independent/paired percentile bootstrap | no for exact golden equivalence | Legacy uses Mulberry32 with integer seed `20260616` and rounds endpoints to four decimals; Core `bootstrap.* /v1` domain-separates SHA-derived draws |
+| Bonferroni alpha/K | no for exact legacy equivalence | Legacy computes each interval at `alpha/K` and has no p-value table; Core `bonferroni/v1` consumes p-values |
+| Krippendorff alpha | new interval-distance Analysis standard | Existing formula is not a Core built-in and undefined cases must become inconclusive |
+| release verdict | new OMK release DecisionPolicy | Core `progress/v1` is a single-effect three-way policy, not the six-tier legacy contract |
+
+The equivalence bootstrap standard resamples the declared experimental unit, preserves pairing, uses the frozen random stream, and exposes point estimate, rounded bounds, resample count, alpha, and significance derived from the rounded bounds. It must never fall back to an unpaired estimator. A comparison family seals its members and effective `alpha/K` before interval estimation; it does not manufacture p-values to fit the generic correction built-in.
+
+Degenerate inputs are part of the standard rather than implementation accidents. A legacy mean interval over one observation is the point interval with `samples=0`; a paired difference over one complete pair performs the requested resamples and returns the constant difference. Empty inputs map to an inconclusive authoritative Core result, with the historical all-zero object allowed only in the legacy projection. These cases receive separate golden vectors before the statistical implementation lands.
+
+Krippendorff alpha uses interval distance `delta^2=(c-k)^2`; nominal or ordinal variants are not equivalent. Empty input, one total rating pair, or zero expected disagreement is inconclusive, not numeric zero. The alpha bootstrap resamples paired rating units.
+
+## 8. DecisionPolicy boundary
+
+The release DecisionPolicy consumes named, plan-bound Analysis results and explicit evidence gates. It must reproduce the legacy six verdicts and reason precedence without reading a legacy Report object.
+
+Before a directional conclusion, it checks coverage, required results, assumptions, source trust, and the comparison family. The policy then applies paired confidence intervals, layer gates, sample-size/power status, judge disagreement, stability, and holdout-gap rules. Presentation strings and CLI next-step text remain outside the policy; stable reason codes are authoritative.
+
+`SOLO`, `UNDERPOWERED`, `NOISE`, `PROGRESS`, `CAUTIOUS`, and `REGRESSION` are conclusions, not run statuses. Infrastructure failure remains a failed or not-decided decision.
+
+## 9. Field mapping and rejection rules
+
+| Legacy field/fact | Core artifact | Rejection rule |
+|---|---|---|
+| `AssertionDetail.type/value/weight/passed/layer` | Boolean observation plus classified evidence | unsupported or malformed type fails during compile/prepare |
+| `llmScoreSamples` | raw replicate observations | sample order cannot be inferred from completion order |
+| `llmScoreFailures` | failed replicate coverage | failure cannot become an extra zero reading |
+| `llmEnsemble` | member-scoped observations and per-member Analysis rows | member identity/model mismatch is incompatible |
+| `dimensions[name]` | named metric and dimension table row | empty rubric or undeclared dimension is rejected |
+| `layeredScores` | fact/behavior/judge Analysis rows | mixed assertion set cannot be assigned to one layer |
+| `compositeScore` | composite Analysis row plus coverage | missing layers cannot be silently reweighted without recording the included set |
+| `bootstrapCI`/pairwise CI | interval Analysis records | wrong unit, seed standard, alpha, or pairing is incompatible |
+| `humanAgreement.alpha` | agreement Analysis record | non-interval distance standard is incompatible |
+| verdict and rationale | DecisionResult reason codes | incomplete evidence cannot yield a directional verdict |
+| cost value plus reported flag | Usage provenance | unreported cost remains absent/unknown, never numeric zero |
+
+Host diagnostics that do not affect a Metric or decision remain post-processing. Any diagnostic that changes a conclusion must become a sealed Analysis input or DecisionPolicy parameter.
+
+## 10. Conformance evidence
+
+The first baseline is `test/fixtures/evaluation-core/scoring-equivalence-v1.json`, anchored to commit `38648427`. It freezes:
+
+- all six scoring prompt hashes;
+- deterministic assertions, nested same-layer and mixed-layer `assert-set` behavior, weighting, layer mapping, and rounding;
+- fixed-response semantic and RAG outcomes and usage;
+- judge replicate failures, sample standard deviation, ensemble member evidence, and consensus;
+- independent and paired bootstrap vectors under the legacy random stream;
+- interval Krippendorff alpha, weighted kappa, Pearson, and alpha bootstrap.
+
+Later migration tests consume the same fixture through the new Core path and compare observations, coverage, evidence, per-unit tables, interval results, usage provenance, and reason codes. Exact identity and status comparisons never use numeric tolerance. Floating-point tolerance is allowed only in formula property tests that are not artifact equality tests.
+
+## 11. Delivery slices
+
+1. Baseline RFC and immutable legacy fixture.
+2. Deterministic and custom assertion Evaluators.
+3. Semantic, RAG, and rubric Evaluators using fixed-response replay.
+4. Replicate, ensemble, dimension, assertion-layer, and composite Analysis nodes.
+5. Exact bootstrap and agreement Analysis standards.
+6. Six-tier release DecisionPolicy.
+7. Full offline old/new differential conformance and dependency audit.
+
+Every implementation slice must exercise a prepared Core plan and real Runtime lifecycle, including cancellation and exactly-once disposal. Test implementations use the `test.*` namespace. Production `omk eval`, legacy Report readers/writers, Studio, resume, batch, evolve, gold compare, and artifact graph stay untouched until the separate cutover phase.

--- a/test/evaluation-core/scoring-equivalence-baseline.test.ts
+++ b/test/evaluation-core/scoring-equivalence-baseline.test.ts
@@ -1,0 +1,231 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'vitest';
+import {
+  runAssertions,
+  runAsyncAssertions,
+} from '../../src/grading/assertions.js';
+import { computeLayeredScores } from '../../src/grading/layered-scores.js';
+import { llmJudgeEnsemble, llmJudgeRepeat } from '../../src/grading/judge.js';
+import {
+  bootstrapDiffCI,
+  bootstrapMeanCI,
+  bootstrapPairedDiffCI,
+} from '../../src/eval-core/bootstrap.js';
+import { computeAgreementWithCI } from '../../src/grading/human-gold.js';
+import { PROMPT_REGISTRY } from '../../src/shared/llm-prompts/registry.js';
+import type {
+  Assertion,
+  ExecResult,
+  ExecutorFn,
+  JudgeConfig,
+  Sample,
+  ToolCallInfo,
+} from '../../src/types/index.js';
+
+interface Fixture {
+  schemaVersion: string;
+  legacyBaseline: {
+    commit: string;
+    bootstrapSeed: number;
+    promptHashes: Record<string, string>;
+  };
+  deterministicAssertions: {
+    output: string;
+    context: { toolCalls: ToolCallInfo[] };
+    assertions: Assertion[];
+    expected: unknown;
+    expectedLayered: unknown;
+  };
+  fixedResponseAssertions: {
+    output: string;
+    sample: Sample;
+    assertions: Assertion[];
+    replayScores: number[];
+    expected: unknown;
+  };
+  judgeRepeat: { replayScores: number[]; expected: unknown };
+  judgeEnsemble: {
+    members: Array<JudgeConfig & { replayScores: number[] }>;
+    expected: unknown;
+  };
+  statistics: {
+    control: number[];
+    treatment: number[];
+    resamples: number;
+    alpha: number;
+    mean: unknown;
+    independentDifference: unknown;
+    pairedDifference: unknown;
+    degenerate: {
+      emptyMean: unknown;
+      singletonMean: unknown;
+      emptyDifference: unknown;
+      singletonPairedDifference: unknown;
+      constantAgreement: 'NaN';
+    };
+    ratings: Array<[number, number]>;
+    agreement: unknown;
+  };
+}
+
+const fixturePath = fileURLToPath(new URL(
+  '../fixtures/evaluation-core/scoring-equivalence-v1.json',
+  import.meta.url,
+));
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf8')) as Fixture;
+
+function replayExecutor(scores: readonly number[]): ExecutorFn {
+  let cursor = 0;
+  return async (): Promise<ExecResult> => {
+    const score = scores[cursor];
+    cursor += 1;
+    if (score === undefined) throw new Error('fixed-response replay exhausted');
+    return {
+      ok: true,
+      output: JSON.stringify({
+        score,
+        reason: `score ${score}`,
+        reasoning: `reasoning ${score}`,
+      }),
+      durationMs: 1,
+      durationApiMs: 1,
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUSD: 0.001,
+      stopReason: 'end_turn',
+      numTurns: 1,
+    };
+  };
+}
+
+describe('Evaluation Core scoring migration legacy baseline', () => {
+  it('binds the fixture format and legacy source revision', () => {
+    assert.equal(fixture.schemaVersion, 'omk.evaluation-scoring-equivalence-fixture/v1');
+    assert.equal(fixture.legacyBaseline.commit, '38648427');
+  });
+
+  it('freezes every scoring prompt identity used by the migration', () => {
+    const scoringPrompts = PROMPT_REGISTRY.filter((entry) => (
+      entry.measurementInvariant
+      && entry.module === 'src/shared/llm-prompts/judge-prompts.ts'
+    ));
+    assert.deepEqual(
+      scoringPrompts.map((entry) => entry.promptId).sort(),
+      Object.keys(fixture.legacyBaseline.promptHashes).sort(),
+    );
+    const actual = Object.fromEntries(scoringPrompts
+      .map((entry) => [entry.promptId, entry.getHash?.()]));
+    assert.deepEqual(actual, fixture.legacyBaseline.promptHashes);
+  });
+
+  it('freezes deterministic assertion details and layered aggregation', () => {
+    const input = fixture.deterministicAssertions;
+    const result = runAssertions(input.output, input.assertions, input.context);
+    assert.deepEqual(result, input.expected);
+    assert.deepEqual(
+      computeLayeredScores({ assertions: result, llmScore: 4 }),
+      input.expectedLayered,
+    );
+  });
+
+  it('freezes semantic and RAG assertions under fixed provider responses', async () => {
+    const input = fixture.fixedResponseAssertions;
+    const result = await runAsyncAssertions(input.output, input.assertions, {
+      executor: replayExecutor(input.replayScores),
+      judgeModel: 'fixture:judge',
+      sample: input.sample,
+      samplesDir: '.',
+    });
+    assert.deepEqual(result, input.expected);
+  });
+
+  it('freezes judge replicate failures, aggregation, and usage', async () => {
+    const result = await llmJudgeRepeat({
+      output: 'fixture output',
+      rubric: 'fixture rubric',
+      prompt: 'fixture prompt',
+      executor: replayExecutor(fixture.judgeRepeat.replayScores),
+      model: 'fixture:judge',
+    }, fixture.judgeRepeat.replayScores.length);
+    assert.deepEqual(result, fixture.judgeRepeat.expected);
+  });
+
+  it('freezes ensemble member aggregation without collapsing member evidence', async () => {
+    const executors = Object.fromEntries(fixture.judgeEnsemble.members.map((member) => [
+      member.executor,
+      replayExecutor(member.replayScores),
+    ]));
+    const judges = fixture.judgeEnsemble.members.map(({ executor, model }) => ({ executor, model }));
+    const result = await llmJudgeEnsemble({
+      output: 'fixture output',
+      rubric: 'fixture rubric',
+      prompt: 'fixture prompt',
+      executor: executors[judges[0].executor],
+      model: judges[0].model,
+    }, judges, (name) => executors[name], 2);
+    assert.deepEqual(result, fixture.judgeEnsemble.expected);
+  });
+
+  it('freezes bootstrap random stream, pairing, rounding, and alpha scale', () => {
+    const input = fixture.statistics;
+    const seed = fixture.legacyBaseline.bootstrapSeed;
+    const pairs = input.control.map((a, index) => ({ a, b: input.treatment[index] }));
+    assert.deepEqual(
+      bootstrapMeanCI(input.treatment, input.alpha, input.resamples, seed),
+      input.mean,
+    );
+    assert.deepEqual(
+      bootstrapDiffCI(input.control, input.treatment, input.alpha, input.resamples, seed),
+      input.independentDifference,
+    );
+    assert.deepEqual(
+      bootstrapPairedDiffCI(pairs, input.alpha, input.resamples, seed),
+      input.pairedDifference,
+    );
+    assert.deepEqual(computeAgreementWithCI(
+      input.ratings.map(([coderA, coderB], index) => ({
+        unitId: `u${index}`,
+        coderA,
+        coderB,
+      })),
+      { samples: input.resamples, seed, alpha: input.alpha },
+    ), input.agreement);
+  });
+
+  it('freezes statistical behavior for empty, singleton, and constant inputs', () => {
+    const input = fixture.statistics;
+    const seed = fixture.legacyBaseline.bootstrapSeed;
+    assert.deepEqual(
+      bootstrapMeanCI([], input.alpha, input.resamples, seed),
+      input.degenerate.emptyMean,
+    );
+    assert.deepEqual(
+      bootstrapMeanCI([4], input.alpha, input.resamples, seed),
+      input.degenerate.singletonMean,
+    );
+    assert.deepEqual(
+      bootstrapDiffCI([], [4], input.alpha, input.resamples, seed),
+      input.degenerate.emptyDifference,
+    );
+    assert.deepEqual(
+      bootstrapPairedDiffCI([{ a: 2, b: 4 }], input.alpha, input.resamples, seed),
+      input.degenerate.singletonPairedDifference,
+    );
+    const constantAgreement = computeAgreementWithCI([
+      { unitId: 'u0', coderA: 3, coderB: 3 },
+      { unitId: 'u1', coderA: 3, coderB: 3 },
+    ], { samples: input.resamples, seed, alpha: input.alpha });
+    assert.equal(input.degenerate.constantAgreement, 'NaN');
+    assert.ok(Number.isNaN(constantAgreement.alpha));
+    assert.ok(Number.isNaN(constantAgreement.alphaCI.low));
+    assert.ok(Number.isNaN(constantAgreement.alphaCI.high));
+    assert.ok(Number.isNaN(constantAgreement.alphaCI.estimate));
+    assert.ok(Number.isNaN(constantAgreement.weightedKappa));
+    assert.ok(Number.isNaN(constantAgreement.pearson));
+    assert.equal(constantAgreement.sampleCount, 2);
+  });
+});

--- a/test/fixtures/evaluation-core/scoring-equivalence-v1.json
+++ b/test/fixtures/evaluation-core/scoring-equivalence-v1.json
@@ -1,0 +1,166 @@
+{
+  "schemaVersion": "omk.evaluation-scoring-equivalence-fixture/v1",
+  "legacyBaseline": {
+    "commit": "38648427",
+    "bootstrapSeed": 20260616,
+    "promptHashes": {
+      "rubric-judge-debias-on": "bb393197cd41",
+      "rubric-judge-debias-off": "74be4a6a2439",
+      "semantic-similarity": "e0d0931c6ee6",
+      "rag-faithfulness": "f1d37fd8e3d6",
+      "rag-answer-relevancy": "f776a5d12b5c",
+      "rag-context-recall": "a1ad34978824"
+    }
+  },
+  "deterministicAssertions": {
+    "output": "Hello world",
+    "context": {
+      "toolCalls": [
+        {
+          "tool": "Bash",
+          "input": { "command": "pwd" },
+          "output": "ok"
+        }
+      ]
+    },
+    "assertions": [
+      { "type": "contains", "value": "Hello", "weight": 2 },
+      { "type": "max_length", "value": 40 },
+      { "type": "contains", "value": "missing", "weight": 3 },
+      {
+        "type": "assert-set",
+        "mode": "all",
+        "weight": 2,
+        "children": [
+          { "type": "contains", "value": "hello" },
+          { "type": "not_contains", "value": "forbidden" }
+        ]
+      },
+      {
+        "type": "assert-set",
+        "mode": "any",
+        "weight": 4,
+        "children": [
+          { "type": "contains", "value": "missing" },
+          { "type": "tools_called", "values": ["Bash"] }
+        ]
+      }
+    ],
+    "expected": {
+      "passed": 4,
+      "total": 5,
+      "score": 4,
+      "details": [
+        { "type": "contains", "value": "Hello", "weight": 2, "passed": true },
+        { "type": "max_length", "value": 40, "weight": 1, "passed": true },
+        { "type": "contains", "value": "missing", "weight": 3, "passed": false },
+        { "type": "assert-set", "value": "", "weight": 2, "passed": true, "layer": "fact" },
+        { "type": "assert-set", "value": "", "weight": 4, "passed": true }
+      ]
+    },
+    "expectedLayered": {
+      "compositeScore": 4.1,
+      "layeredScores": {
+        "factScore": 3.29,
+        "behaviorScore": 5,
+        "judgeScore": 4
+      }
+    }
+  },
+  "fixedResponseAssertions": {
+    "output": "Hello world",
+    "sample": {
+      "sample_id": "s",
+      "prompt": "Say hello",
+      "context": "Hello world is grounded."
+    },
+    "assertions": [
+      { "type": "semantic_similarity", "reference": "Hello", "threshold": 4 },
+      { "type": "faithfulness" },
+      { "type": "answer_relevancy" },
+      { "type": "context_recall", "threshold": 4 }
+    ],
+    "replayScores": [4, 2, 5, 3],
+    "expected": {
+      "passed": 2,
+      "total": 4,
+      "score": 3,
+      "details": [
+        { "type": "semantic_similarity", "value": "Hello", "weight": 1, "passed": true, "message": "score 4" },
+        { "type": "faithfulness", "value": "", "weight": 1, "passed": false, "message": "score 2" },
+        { "type": "answer_relevancy", "value": "", "weight": 1, "passed": true, "message": "score 5" },
+        { "type": "context_recall", "value": "", "weight": 1, "passed": false, "message": "score 3" }
+      ],
+      "judgeCostUSD": 0.004
+    }
+  },
+  "judgeRepeat": {
+    "replayScores": [5, 0, 3],
+    "expected": {
+      "score": 4,
+      "reason": "score 5",
+      "reasoning": "reasoning 5",
+      "judgeCostUSD": 0.003,
+      "scoreSamples": [5, 0, 3],
+      "scoreStddev": 1.414,
+      "judgeFailureCount": 1
+    }
+  },
+  "judgeEnsemble": {
+    "members": [
+      { "executor": "alpha", "model": "a", "replayScores": [4, 5] },
+      { "executor": "beta", "model": "b", "replayScores": [2, 4] }
+    ],
+    "expected": {
+      "score": 3.75,
+      "reason": "consensus across 2 judges",
+      "reasoning": "reasoning 4",
+      "judgeCostUSD": 0.004,
+      "ensemble": [
+        {
+          "judge": "alpha:a",
+          "score": 4.5,
+          "scoreStddev": 0.707,
+          "scoreSamples": [4, 5],
+          "judgeFailureCount": 0,
+          "reasoning": "reasoning 4",
+          "costUSD": 0.002
+        },
+        {
+          "judge": "beta:b",
+          "score": 3,
+          "scoreStddev": 1.414,
+          "scoreSamples": [2, 4],
+          "judgeFailureCount": 0,
+          "reasoning": "reasoning 2",
+          "costUSD": 0.002
+        }
+      ],
+      "agreement": { "meanAbsDiff": 1.5, "pairCount": 1 }
+    }
+  },
+  "statistics": {
+    "control": [2, 3, 4, 5, 3],
+    "treatment": [3, 4, 4, 5, 5],
+    "resamples": 500,
+    "alpha": 0.05,
+    "mean": { "low": 3.6, "high": 4.8, "estimate": 4.2, "samples": 500 },
+    "independentDifference": { "low": -0.4, "high": 2, "estimate": 0.8, "samples": 500, "significant": false },
+    "pairedDifference": { "low": 0.2, "high": 1.4, "estimate": 0.8, "samples": 500, "significant": true },
+    "degenerate": {
+      "emptyMean": { "low": 0, "high": 0, "estimate": 0, "samples": 0 },
+      "singletonMean": { "low": 4, "high": 4, "estimate": 4, "samples": 0 },
+      "emptyDifference": { "low": 0, "high": 0, "estimate": 0, "samples": 0, "significant": false },
+      "singletonPairedDifference": { "low": 2, "high": 2, "estimate": 2, "samples": 500, "significant": true },
+      "constantAgreement": "NaN"
+    },
+    "ratings": [[1, 2], [2, 2], [3, 4], [4, 4], [5, 5], [2, 3]],
+    "agreement": {
+      "alpha": 0.8546,
+      "alphaCI": { "low": 0.3373, "high": 0.9651, "estimate": 0.8546, "samples": 500 },
+      "weightedKappa": 0.8475,
+      "pearson": 0.9349,
+      "sampleCount": 6
+    }
+  }
+}


### PR DESCRIPTION
## 用户影响

为 #480 建立评分与统计迁移的可审计基线：明确 assertion、原始 LLM 读数、评委聚合、dimension 与 composite 的职责边界，并冻结现有评分 prompt、固定响应、分层聚合、评委重复／集成、Bootstrap 与人类金标一致性结果。此 PR 不切换正式 `omk eval`，不写入新 Core artifact，也不修改旧 Report。

## 架构与测量说明

- sample 级 criteria 通过 sealed `evaluationContext` 进入计划，Evaluator family 与 Metric union 在首次 Target 调用前固定。
- per-sample 派生结果保留统计单位和输入 lineage，再交给下游统计节点，避免先全局平均导致配对与缺失结构丢失。
- 明确记录旧 Bootstrap 随机流和 Core built-in 不等价、旧六级 verdict 不能由 `progress/v1` 代替、旧 Bonferroni 没有 p-value 中间量。
- 空集、单例与常量评分均有显式语义；Core 权威结果不会把缺失折算成零，历史零哨兵只允许存在于旧投影。

## Construct-validity caveat

本阶段冻结的是当前比较信号，不为等权 composite、混合量表或缺层自动缩减补充新的效度主张。semantic／RAG assertion 把基础设施失败计为内容失败的问题已拆为 #481，后续将以 `BREAKING-COMPARABILITY` 独立修正。

Closes no issue；推进 #480。
