### PR TITLE
feat(eval-core): 迁移输出型确定性断言

### DIFF
--- a/docs/specs/evaluation-scoring-equivalence.md
+++ b/docs/specs/evaluation-scoring-equivalence.md
@@ -50,13 +50,17 @@ The host owns provider calls, prompt registry access, custom-module loading, and
 
 | Runtime family | Input bindings | Observation | Identity requirements |
 |---|---|---|---|
-| deterministic assertion | output and, when required, trace or evaluation context | Boolean criterion result; assertion detail as evidence | assertion algorithm version and supported type registry |
+| deterministic assertion | output and evaluation context; execution-aware leaves additionally require Core-owned execution facts | Boolean criterion result; assertion detail as evidence | assertion algorithm version and supported type registry |
 | custom assertion | output and evaluation context; verified resource lease | Boolean criterion result or structured evaluator failure | module content identity and sandbox/resource policy |
 | semantic similarity | output, expected/evaluation context | Boolean threshold result; fixed-response parse evidence | semantic prompt hash, model Runtime identity, threshold |
 | RAG metric | output and evaluation context | Boolean threshold result; fixed-response parse evidence | metric-specific prompt hash, model Runtime identity, threshold |
 | rubric judge | output, optional trace, evaluation context | Raw numeric reading on the 1–5 scale | rubric prompt hash, debias variant, ensemble member, replicate index, model Runtime identity |
 
 The Core never imports `PROMPT_REGISTRY`. The composition root resolves a frozen prompt and places its hash in the host Runtime identity. `lengthDebias=false` selects only the existing rubric debias-off instrument. Presentation and tone neutrality remain enabled. RAG and semantic prompts have no length-debias switch.
+
+The first deterministic family is deliberately output-only. Cost, latency, turn, tool-call, tool-input/output, and mock-hit assertions cannot treat provider trace as an authoritative substitute for Core timing and usage. [#483](https://github.com/lizhiyao/oh-my-knowledge/issues/483) adds a qualified `execution-facts` binding owned by Core; those leaves remain a fail-closed family boundary until that contract exists.
+
+Each Core `json_schema` criterion compiles in an isolated validator session. The legacy module-global Ajv registry can retain `$id` state across otherwise-independent criteria and make results depend on process history; reproducing that contamination would violate run and binding isolation. [#484](https://github.com/lizhiyao/oh-my-knowledge/issues/484) owns the explicit `BREAKING-COMPARABILITY` inventory and formal-cutover treatment of this edge case.
 
 ## 5. Identity and statistical units
 
@@ -148,7 +152,7 @@ Later migration tests consume the same fixture through the new Core path and com
 ## 11. Delivery slices
 
 1. Baseline RFC and immutable legacy fixture.
-2. Deterministic and custom assertion Evaluators.
+2. Output-only deterministic assertion Evaluator, followed by execution-aware assertions after #483 and the custom assertion Evaluator.
 3. Semantic, RAG, and rubric Evaluators using fixed-response replay.
 4. Replicate, ensemble, dimension, assertion-layer, and composite Analysis nodes.
 5. Exact bootstrap and agreement Analysis standards.

--- a/src/eval-workflows/runtime-adapter/builtins.ts
+++ b/src/eval-workflows/runtime-adapter/builtins.ts
@@ -3,6 +3,12 @@ import {
   createBuiltinDecisionPolicies,
   createBuiltinMissingPolicies,
 } from '../../evaluation-core/analysis/index.js';
+import { createSameProcessEvaluatorAdapter } from './adapters/same-process.js';
+import {
+  createOutputAssertionEvaluatorImplementation,
+  OUTPUT_ASSERTION_EVALUATOR_IDENTITY,
+  OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+} from './evaluators/output-assertions.js';
 import type { OmkRuntimeBindingFactories } from './types.js';
 
 export type OmkBuiltinAnalysisBindingFactories = Pick<
@@ -11,6 +17,43 @@ export type OmkBuiltinAnalysisBindingFactories = Pick<
   | 'missingPoliciesByImplementationId'
   | 'decisionPoliciesByImplementationId'
 >;
+
+export type OmkBuiltinScoringBindingFactories = Pick<
+  OmkRuntimeBindingFactories,
+  'evaluatorsByImplementationId'
+>;
+
+/** OMK-owned production Evaluators; provider-backed families land in later #480 slices. */
+export function createBuiltinOmkScoringBindingFactories(): OmkBuiltinScoringBindingFactories {
+  return {
+    evaluatorsByImplementationId: new Map([[
+      OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+      (context) => ({
+        port: createSameProcessEvaluatorAdapter({
+          identity: OUTPUT_ASSERTION_EVALUATOR_IDENTITY,
+          sessionIsolationKey: context.sessionIsolationKey,
+          resourceLeases: context.resourceLeases,
+          implementation: createOutputAssertionEvaluatorImplementation(),
+        }),
+        satisfiesVersionConstraint: true,
+        preflightDeclarations: [
+          {
+            preflightKind: 'credential',
+            preflightDisposition: 'not-required',
+            checkId: 'omk-output-assertion-credential',
+            reasonCode: 'local-deterministic-evaluator',
+          },
+          {
+            preflightKind: 'connectivity',
+            preflightDisposition: 'not-required',
+            checkId: 'omk-output-assertion-connectivity',
+            reasonCode: 'local-deterministic-evaluator',
+          },
+        ],
+      }),
+    ]]),
+  };
+}
 
 /** Binds Core-owned analysis implementations without copying their algorithms into the host. */
 export function createBuiltinOmkAnalysisBindingFactories(): OmkBuiltinAnalysisBindingFactories {

--- a/src/eval-workflows/runtime-adapter/composition.ts
+++ b/src/eval-workflows/runtime-adapter/composition.ts
@@ -34,7 +34,10 @@ import type {
   ResolvedHostResources,
 } from '../input-compilation/index.js';
 import { assembleOmkRuntimeBindings } from './assembly.js';
-import { createBuiltinOmkAnalysisBindingFactories } from './builtins.js';
+import {
+  createBuiltinOmkAnalysisBindingFactories,
+  createBuiltinOmkScoringBindingFactories,
+} from './builtins.js';
 import {
   OmkResourceLeaseError,
   materializeNodeRunResourceLeases,
@@ -424,7 +427,7 @@ function mergeFactoryMap<Factory>(
     if (merged.has(implementationId)) fail({
       code: 'OMK_EVALUATION_RUNTIME_FACTORY_CONFLICT',
       fieldPath,
-      message: `implementationId "${implementationId}" 与 Core-owned built-in factory 冲突。`,
+      message: `implementationId "${implementationId}" 与 OMK built-in factory 冲突。`,
     });
     merged.set(implementationId, factory);
   }
@@ -494,21 +497,27 @@ function withBuiltinFactories(
       'factories.seriesDecisionPoliciesByImplementationId',
     ),
   };
-  const builtin = createBuiltinOmkAnalysisBindingFactories();
+  const analysisBuiltin = createBuiltinOmkAnalysisBindingFactories();
+  const scoringBuiltin = createBuiltinOmkScoringBindingFactories();
   return Object.freeze({
     ...captured,
+    evaluatorsByImplementationId: mergeFactoryMap(
+      scoringBuiltin.evaluatorsByImplementationId,
+      captured.evaluatorsByImplementationId,
+      'factories.evaluatorsByImplementationId',
+    ),
     analysisNodesByImplementationId: mergeFactoryMap(
-      builtin.analysisNodesByImplementationId,
+      analysisBuiltin.analysisNodesByImplementationId,
       captured.analysisNodesByImplementationId,
       'factories.analysisNodesByImplementationId',
     ),
     missingPoliciesByImplementationId: mergeFactoryMap(
-      builtin.missingPoliciesByImplementationId,
+      analysisBuiltin.missingPoliciesByImplementationId,
       captured.missingPoliciesByImplementationId,
       'factories.missingPoliciesByImplementationId',
     ),
     decisionPoliciesByImplementationId: mergeFactoryMap(
-      builtin.decisionPoliciesByImplementationId,
+      analysisBuiltin.decisionPoliciesByImplementationId,
       captured.decisionPoliciesByImplementationId,
       'factories.decisionPoliciesByImplementationId',
     ),

--- a/src/eval-workflows/runtime-adapter/evaluators/index.ts
+++ b/src/eval-workflows/runtime-adapter/evaluators/index.ts
@@ -1,0 +1,1 @@
+export * from './output-assertions.js';

--- a/src/eval-workflows/runtime-adapter/evaluators/output-assertions.ts
+++ b/src/eval-workflows/runtime-adapter/evaluators/output-assertions.ts
@@ -1,0 +1,359 @@
+import { createRequire } from 'node:module';
+import {
+  IdentifierSchema,
+  RuntimeIdentitySchema,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  type JsonValue,
+  type RuntimeIdentity,
+  type SchemaIdentity,
+} from '../../../evaluation-core/contracts/index.js';
+import {
+  EvaluationPortFailure,
+  type EvaluatorBindingValue,
+  type EvaluatorObservation,
+} from '../../../evaluation-core/evaluation/index.js';
+import {
+  DETERMINISTIC_ASSERTION_ALGORITHM_VERSION,
+  OUTPUT_ONLY_SYNC_ASSERTION_TYPE_NAMES,
+  assertionUsesOnlyOutput,
+  createIsolatedDeterministicAssertionEvaluator,
+  type DeterministicAssertionContext,
+} from '../../../shared/assertions/deterministic.js';
+import { resolveAssertionLayer } from '../../../shared/assertions/layers.js';
+import { assertionContractValidationError } from '../../../shared/sample-contract.js';
+import type { Assertion } from '../../../types/index.js';
+import type { SameProcessEvaluatorImplementation } from '../adapters/same-process.js';
+
+export const OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID =
+  'omk.assertions.output/v1' as const;
+export const OUTPUT_ASSERTION_CONTEXT_SCHEMA_VERSION =
+  'omk.output-assertion-context/v1' as const;
+export const OUTPUT_ASSERTION_EVIDENCE_SCHEMA_VERSION =
+  'omk.output-assertion-evidence/v1' as const;
+export const OUTPUT_ASSERTION_BINDINGS = Object.freeze({
+  actual: 'actual',
+  criteria: 'criteria',
+});
+
+const requireFromHere = createRequire(import.meta.url);
+const AJV_PACKAGE_VERSION = (requireFromHere('ajv/package.json') as { version: string }).version;
+
+const CONTEXT_SCHEMA_DOCUMENT: JsonValue = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'urn:omk:output-assertion-context:v1',
+  type: 'object',
+  additionalProperties: false,
+  required: ['schemaVersion', 'criteria'],
+  properties: {
+    schemaVersion: { const: OUTPUT_ASSERTION_CONTEXT_SCHEMA_VERSION },
+    criteria: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['criterionId', 'metricId', 'assertion'],
+        properties: {
+          criterionId: { type: 'string', minLength: 1, maxLength: 256 },
+          metricId: { type: 'string', minLength: 1, maxLength: 256 },
+          assertion: { type: 'object' },
+        },
+      },
+    },
+  },
+  'x-omk-invariants': [
+    'criterionId and metricId are unique identifiers',
+    'every assertion satisfies the OMK assertion contract',
+    'every assertion recursively uses output-only deterministic leaves',
+  ],
+};
+
+const EVIDENCE_SCHEMA_DOCUMENT: JsonValue = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'urn:omk:output-assertion-evidence:v1',
+  type: 'object',
+  additionalProperties: false,
+  required: ['schemaVersion', 'criterionId', 'assertion', 'detail'],
+  properties: {
+    schemaVersion: { const: OUTPUT_ASSERTION_EVIDENCE_SCHEMA_VERSION },
+    criterionId: { type: 'string' },
+    assertion: { type: 'object' },
+    detail: { type: 'object' },
+  },
+};
+
+function schemaIdentity(
+  schemaVersion: string,
+  schemaUri: string,
+  schema: JsonValue,
+): SchemaIdentity {
+  return deepFreezeCanonicalJson({
+    schemaVersion,
+    schemaUri,
+    schemaDigest: digestCanonicalJson(schema),
+  });
+}
+
+export const OUTPUT_ASSERTION_CONTEXT_SCHEMA = schemaIdentity(
+  OUTPUT_ASSERTION_CONTEXT_SCHEMA_VERSION,
+  'urn:omk:output-assertion-context:v1',
+  CONTEXT_SCHEMA_DOCUMENT,
+);
+
+export const OUTPUT_ASSERTION_EVIDENCE_SCHEMA = schemaIdentity(
+  OUTPUT_ASSERTION_EVIDENCE_SCHEMA_VERSION,
+  'urn:omk:output-assertion-evidence:v1',
+  EVIDENCE_SCHEMA_DOCUMENT,
+);
+
+const CAPABILITIES: JsonValue = {
+  inputSourceKinds: ['evaluation-context', 'output'],
+  metricValueTypes: ['boolean'],
+  schemas: [OUTPUT_ASSERTION_CONTEXT_SCHEMA, OUTPUT_ASSERTION_EVIDENCE_SCHEMA],
+};
+
+const OUTPUT_ASSERTION_RUNTIME_IDENTITY: RuntimeIdentity = deepFreezeCanonicalJson(
+  RuntimeIdentitySchema.parse({
+    implementationId: OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+    version: '1.0.0',
+    fingerprint: digestCanonicalJson({
+      standardId: OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+      algorithmVersion: DETERMINISTIC_ASSERTION_ALGORITHM_VERSION,
+      assertionTypes: [...OUTPUT_ONLY_SYNC_ASSERTION_TYPE_NAMES],
+      dependencies: { ajv: AJV_PACKAGE_VERSION },
+      contextSchema: OUTPUT_ASSERTION_CONTEXT_SCHEMA,
+      evidenceSchema: OUTPUT_ASSERTION_EVIDENCE_SCHEMA,
+      capabilities: CAPABILITIES,
+    }),
+    fingerprintBasis: 'self-reported',
+    assuranceLevel: 'declared',
+    capabilities: CAPABILITIES,
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
+  }),
+);
+
+export const OUTPUT_ASSERTION_EVALUATOR_IDENTITY: RuntimeIdentity =
+  OUTPUT_ASSERTION_RUNTIME_IDENTITY;
+
+interface Criterion {
+  readonly criterionId: string;
+  readonly metricId: string;
+  readonly assertion: Assertion;
+}
+
+interface RecordState {
+  readonly output: string;
+  readonly evaluateAssertion: (
+    output: string,
+    assertion: Assertion,
+    context?: DeterministicAssertionContext,
+  ) => boolean;
+  readonly criteriaByMetricId: ReadonlyMap<string, Criterion>;
+  readonly metricIds: readonly string[];
+  readonly evidenceClassification: EvaluatorBindingValue['classification'];
+}
+
+const CLASSIFICATION_LEVEL = { public: 0, sensitive: 1, secret: 2, gold: 3 } as const;
+
+function mostRestrictedClassification(
+  ...values: readonly EvaluatorBindingValue['classification'][]
+): EvaluatorBindingValue['classification'] {
+  return values.reduce((highest, candidate) => (
+    CLASSIFICATION_LEVEL[candidate] > CLASSIFICATION_LEVEL[highest] ? candidate : highest
+  ), 'public');
+}
+
+function fail(code: string, message: string, details?: JsonValue): never {
+  throw new EvaluationPortFailure({
+    code,
+    stage: 'evaluation',
+    message,
+    ...(details === undefined ? {} : { details }),
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const canonical = [...expected].sort();
+  return actual.length === canonical.length
+    && actual.every((key, index) => key === canonical[index]);
+}
+
+function binding(
+  bindings: readonly EvaluatorBindingValue[],
+  bindingId: string,
+  sourceKind: EvaluatorBindingValue['sourceKind'],
+): EvaluatorBindingValue {
+  const candidates = bindings.filter((candidate) => candidate.bindingId === bindingId);
+  if (candidates.length !== 1 || candidates[0].sourceKind !== sourceKind) {
+    return fail(
+      'omk-output-assertion-binding-invalid',
+      'Output assertion Evaluator received an invalid binding set.',
+      { bindingId, sourceKind },
+    );
+  }
+  return candidates[0];
+}
+
+function parseCriteria(value: JsonValue): Criterion[] {
+  if (!isRecord(value)
+      || !hasExactKeys(value, ['schemaVersion', 'criteria'])
+      || value.schemaVersion !== OUTPUT_ASSERTION_CONTEXT_SCHEMA_VERSION
+      || !Array.isArray(value.criteria)) {
+    return fail(
+      'omk-output-assertion-context-invalid',
+      'Output assertion criteria do not match the sealed context schema.',
+    );
+  }
+  const criteria: Criterion[] = [];
+  const criterionIds = new Set<string>();
+  const metricIds = new Set<string>();
+  for (const [index, candidate] of value.criteria.entries()) {
+    if (!isRecord(candidate)
+        || !hasExactKeys(candidate, ['criterionId', 'metricId', 'assertion'])
+        || typeof candidate.criterionId !== 'string'
+        || !IdentifierSchema.safeParse(candidate.criterionId).success
+        || typeof candidate.metricId !== 'string'
+        || !IdentifierSchema.safeParse(candidate.metricId).success) {
+      return fail(
+        'omk-output-assertion-criterion-invalid',
+        'Output assertion criterion is malformed.',
+        { index },
+      );
+    }
+    if (criterionIds.has(candidate.criterionId) || metricIds.has(candidate.metricId)) {
+      return fail(
+        'omk-output-assertion-criterion-duplicate',
+        'Output assertion criteria contain duplicate identities.',
+        { index },
+      );
+    }
+    const assertionError = assertionContractValidationError(candidate.assertion);
+    if (assertionError !== undefined
+        || !assertionUsesOnlyOutput(candidate.assertion as unknown as Assertion)) {
+      return fail(
+        'omk-output-assertion-contract-invalid',
+        'Output assertion criterion is unsupported by this Evaluator.',
+        { index },
+      );
+    }
+    criterionIds.add(candidate.criterionId);
+    metricIds.add(candidate.metricId);
+    criteria.push({
+      criterionId: candidate.criterionId,
+      metricId: candidate.metricId,
+      assertion: structuredClone(candidate.assertion) as unknown as Assertion,
+    });
+  }
+  return criteria;
+}
+
+function detail(criterion: Criterion, passed: boolean): JsonValue {
+  const assertion = criterion.assertion;
+  const layer = assertion.type === 'assert-set'
+    ? resolveAssertionLayer(assertion)
+    : undefined;
+  return {
+    type: assertion.type,
+    value: assertion.value ?? assertion.pattern ?? assertion.values?.join(', ') ?? '',
+    weight: assertion.weight ?? 1,
+    passed,
+    ...(layer === undefined ? {} : { layer }),
+  };
+}
+
+function observed(
+  state: RecordState,
+  criterion: Criterion,
+): EvaluatorObservation {
+  const passed = state.evaluateAssertion(state.output, criterion.assertion);
+  return {
+    metricId: criterion.metricId,
+    observationStatus: 'observed',
+    valueType: 'boolean',
+    value: passed,
+    evidence: {
+      value: {
+        schemaVersion: OUTPUT_ASSERTION_EVIDENCE_SCHEMA_VERSION,
+        criterionId: criterion.criterionId,
+        assertion: structuredClone(criterion.assertion) as unknown as JsonValue,
+        detail: detail(criterion, passed),
+      },
+      classification: state.evidenceClassification,
+    },
+  };
+}
+
+export function createOutputAssertionEvaluatorImplementation(): SameProcessEvaluatorImplementation<
+  undefined,
+  RecordState
+> {
+  const implementation: SameProcessEvaluatorImplementation<undefined, RecordState> = {
+    openRun: () => undefined,
+    openRecord({ record }): RecordState {
+      if (record.evaluatorConfig !== undefined || record.bindings.length !== 2) {
+        return fail(
+          'omk-output-assertion-record-invalid',
+          'Output assertion Evaluator received an unsupported record configuration.',
+        );
+      }
+      const actual = binding(record.bindings, OUTPUT_ASSERTION_BINDINGS.actual, 'output');
+      const criteriaBinding = binding(
+        record.bindings,
+        OUTPUT_ASSERTION_BINDINGS.criteria,
+        'evaluation-context',
+      );
+      if (typeof actual.value !== 'string') {
+        return fail(
+          'omk-output-assertion-actual-invalid',
+          'Output assertion Evaluator requires a string output.',
+        );
+      }
+      const criteria = parseCriteria(criteriaBinding.value);
+      const declaredMetricIds = new Set(record.metrics.map((metric) => metric.metricId));
+      if (record.metrics.some((metric) => (
+        metric.valueType !== 'boolean' || metric.direction !== 'higher-is-better'
+      ))
+          || criteria.some((criterion) => !declaredMetricIds.has(criterion.metricId))) {
+        return fail(
+          'omk-output-assertion-metric-invalid',
+          'Output assertion criteria require declared higher-is-better Boolean Metrics.',
+        );
+      }
+      return Object.freeze({
+        output: actual.value,
+        evaluateAssertion: createIsolatedDeterministicAssertionEvaluator(),
+        criteriaByMetricId: new Map(criteria.map((criterion) => [criterion.metricId, criterion])),
+        metricIds: record.metrics.map((metric) => metric.metricId),
+        evidenceClassification: mostRestrictedClassification(
+          actual.classification,
+          criteriaBinding.classification,
+        ),
+      });
+    },
+    async evaluate({ recordState, attempt }) {
+      const observations: EvaluatorObservation[] = [];
+      for (const metricId of recordState.metricIds) {
+        if (attempt.signal.aborted) throw attempt.signal.reason;
+        const criterion = recordState.criteriaByMetricId.get(metricId);
+        observations.push(criterion === undefined
+          ? {
+              metricId,
+              observationStatus: 'missing',
+              valueType: 'boolean',
+              reasonCode: 'criterion-not-applicable',
+            }
+          : observed(recordState, criterion));
+      }
+      if (attempt.signal.aborted) throw attempt.signal.reason;
+      return { observations };
+    },
+    disposeRecord: () => undefined,
+    disposeRun: () => undefined,
+  };
+  return Object.freeze(implementation);
+}

--- a/src/eval-workflows/runtime-adapter/index.ts
+++ b/src/eval-workflows/runtime-adapter/index.ts
@@ -2,6 +2,7 @@ export * from './assembly.js';
 export * from './adapters/index.js';
 export * from './builtins.js';
 export * from './composition.js';
+export * from './evaluators/index.js';
 export {
   projectOmkEvaluationEvent,
   type OmkEvaluationProgressSink,

--- a/src/grading/assertions.ts
+++ b/src/grading/assertions.ts
@@ -1,7 +1,5 @@
 import { resolve } from 'node:path';
-import _Ajv from 'ajv';
 import type { Assertion, AssertionDetail, AssertionResults, ExecutorFn, Sample, ToolCallInfo } from '../types/index.js';
-import { ASSERTION_LAYER } from './layered-scores.js';
 import { buildSemanticSimilarityPrompt, SEMANTIC_SIMILARITY_SYSTEM, buildRagJudgePrompt } from '../shared/llm-prompts/judge-prompts.js';
 import {
   assertionContractValidationError,
@@ -10,11 +8,21 @@ import {
   ASYNC_ASSERTION_TYPES,
   SYNC_ASSERTION_TYPES,
 } from '../shared/assertion-types.js';
+import {
+  evaluateDeterministicAssertion,
+  ratioToScore,
+} from '../shared/assertions/deterministic.js';
+import { resolveAssertionLayer } from '../shared/assertions/layers.js';
 
 export { ASYNC_ASSERTION_TYPES } from '../shared/assertion-types.js';
+export {
+  bleu,
+  levenshtein,
+  ratioToScore,
+  rougeN,
+  validateJsonSchema,
+} from '../shared/assertions/deterministic.js';
 
-const Ajv = _Ajv.default ?? _Ajv;
-const ajv = new Ajv();
 const CUSTOM_ASSERTION_TIMEOUT_MS = 30_000;
 
 export interface AsyncAssertionContext {
@@ -46,274 +54,6 @@ function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-export function ratioToScore(ratio: number): number {
-  return Number((1 + ratio * 4).toFixed(2));
-}
-
-// ===========================================================================
-// Deterministic similarity metrics
-// ===========================================================================
-
-/** Tokenizer: Latin words/numbers as units; CJK chars as single-char units. */
-function tokenize(s: string): string[] {
-  const m = s.toLowerCase().match(/[a-z0-9]+|[一-龥]/g);
-  return m ?? [];
-}
-
-function ngrams(tokens: string[], n: number): string[] {
-  if (n <= 0 || tokens.length < n) return [];
-  const out: string[] = new Array(tokens.length - n + 1);
-  for (let i = 0; i <= tokens.length - n; i++) {
-    out[i] = tokens.slice(i, i + n).join(' ');
-  }
-  return out;
-}
-
-function clippedOverlap(candNgrams: string[], refNgrams: string[]): number {
-  if (candNgrams.length === 0 || refNgrams.length === 0) return 0;
-  const candCount = new Map<string, number>();
-  const refCount = new Map<string, number>();
-  for (const g of candNgrams) candCount.set(g, (candCount.get(g) ?? 0) + 1);
-  for (const g of refNgrams) refCount.set(g, (refCount.get(g) ?? 0) + 1);
-  let total = 0;
-  for (const [g, cc] of candCount) {
-    total += Math.min(cc, refCount.get(g) ?? 0);
-  }
-  return total;
-}
-
-/**
- * ROUGE-N (recall-oriented). N-gram overlap divided by the reference's
- * n-gram count. Multi-set form per Lin 2004 — repeated n-grams are clipped
- * to their reference count, so a candidate that repeats a single matching
- * n-gram many times can't game the score above 1.
- */
-export function rougeN(candidate: string, reference: string, n: number): number {
-  const cn = ngrams(tokenize(candidate), n);
-  const rn = ngrams(tokenize(reference), n);
-  if (rn.length === 0) return 0;
-  return clippedOverlap(cn, rn) / rn.length;
-}
-
-/** Standard Levenshtein edit distance with O(min(m,n)) memory. */
-export function levenshtein(a: string, b: string): number {
-  if (a === b) return 0;
-  if (a.length === 0) return b.length;
-  if (b.length === 0) return a.length;
-  // Ensure b is the shorter one for memory.
-  if (a.length < b.length) [a, b] = [b, a];
-  const m = a.length, n = b.length;
-  let prev = new Array<number>(n + 1);
-  let curr = new Array<number>(n + 1);
-  for (let j = 0; j <= n; j++) prev[j] = j;
-  for (let i = 1; i <= m; i++) {
-    curr[0] = i;
-    for (let j = 1; j <= n; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
-    }
-    [prev, curr] = [curr, prev];
-  }
-  return prev[n];
-}
-
-/**
- * BLEU score (corpus-level form, single reference). Geometric mean of
- * precision at n=1..maxN, multiplied by the brevity penalty for short
- * candidates. Unsmoothed — returns 0 if any n-gram precision is 0, which
- * is a known sharpness of the original BLEU; threshold accordingly.
- */
-export function bleu(candidate: string, reference: string, maxN = 4): number {
-  const ct = tokenize(candidate);
-  const rt = tokenize(reference);
-  if (ct.length === 0 || rt.length === 0) return 0;
-
-  let logSum = 0;
-  for (let n = 1; n <= maxN; n++) {
-    const cn = ngrams(ct, n);
-    const rn = ngrams(rt, n);
-    if (cn.length === 0) return 0;
-    const overlap = clippedOverlap(cn, rn);
-    if (overlap === 0) return 0;
-    logSum += Math.log(overlap / cn.length);
-  }
-  const bp = ct.length >= rt.length ? 1 : Math.exp(1 - rt.length / ct.length);
-  return bp * Math.exp(logSum / maxN);
-}
-
-export function validateJsonSchema(data: unknown, schema: Record<string, unknown>): boolean {
-  if (!schema || typeof schema !== 'object') return true;
-  try {
-    const validate = ajv.compile(schema);
-    return validate(data) as boolean;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Evaluate a single assertion against the output. Returns the raw pass/fail
- * BEFORE applying `not`. Pulled out of `runAssertions` so `assert-set` can
- * recurse on children without rebuilding the context.
- *
- * Universal negation (`not: true`) and `assert-set` (any/all combinator) are
- * supported here. Legacy `not_contains` / `not_equals` / etc. still work;
- * their negation is hard-coded inline as before.
- */
-function evalAssertion(
-  output: string,
-  assertion: Assertion,
-  ctx: { outputLower: string; toolCalls: ToolCallInfo[]; toolNames: string[]; costUSD?: number; durationMs?: number; numTurns?: number; mockStats?: { hits: number; misses: number; perMock: Record<string, number> } },
-): boolean {
-  const { outputLower, toolCalls, toolNames } = ctx;
-
-  if (assertion.type === 'assert-set') {
-    const children = assertion.children ?? [];
-    if (children.length === 0) return false;
-    const mode = assertion.mode ?? 'all';
-    const childPasses = children.map((c) => {
-      const raw = evalAssertion(output, c, ctx);
-      return c.not ? !raw : raw;
-    });
-    return mode === 'any' ? childPasses.some(Boolean) : childPasses.every(Boolean);
-  }
-
-  switch (assertion.type) {
-    case 'contains':
-      return outputLower.includes(String(assertion.value).toLowerCase());
-    case 'not_contains':
-      return !outputLower.includes(String(assertion.value).toLowerCase());
-    case 'regex': {
-      const flags = assertion.flags || 'i';
-      const re = new RegExp(assertion.pattern!, flags);
-      return re.test(output);
-    }
-    case 'min_length':
-      return output.length >= (assertion.value as number);
-    case 'max_length':
-      return output.length <= (assertion.value as number);
-    case 'json_valid':
-      try { JSON.parse(output); return true; } catch { return false; }
-    case 'json_schema':
-      try {
-        const data = JSON.parse(output);
-        return validateJsonSchema(data, assertion.schema!);
-      } catch { return false; }
-    case 'starts_with':
-      return outputLower.startsWith(String(assertion.value).toLowerCase());
-    case 'ends_with':
-      return outputLower.endsWith(String(assertion.value).toLowerCase());
-    case 'equals':
-      return output.trim() === String(assertion.value).trim();
-    case 'not_equals':
-      return output.trim() !== String(assertion.value).trim();
-    case 'word_count_min':
-      return output.split(/\s+/).filter(Boolean).length >= (assertion.value as number);
-    case 'word_count_max':
-      return output.split(/\s+/).filter(Boolean).length <= (assertion.value as number);
-    case 'contains_all':
-      return (assertion.values || []).every((v) => outputLower.includes(String(v).toLowerCase()));
-    case 'contains_any':
-      return (assertion.values || []).some((v) => outputLower.includes(String(v).toLowerCase()));
-    case 'cost_max':
-      return (ctx.costUSD ?? Infinity) <= (assertion.value as number);
-    case 'latency_max':
-      return (ctx.durationMs ?? Infinity) <= (assertion.value as number);
-    case 'turns_max':
-      return (ctx.numTurns ?? Infinity) <= (assertion.value as number);
-    case 'turns_min':
-      return (ctx.numTurns ?? 0) >= (assertion.value as number);
-    case 'tools_called':
-      return (assertion.values || []).every((v) => toolNames.includes(String(v).toLowerCase()));
-    case 'tools_not_called':
-      return (assertion.values || []).every((v) => !toolNames.includes(String(v).toLowerCase()));
-    case 'tools_count_max':
-      return toolCalls.length <= (assertion.value as number);
-    case 'tools_count_min':
-      return toolCalls.length >= (assertion.value as number);
-    case 'tool_output_contains': {
-      const sep = String(assertion.value).indexOf(':');
-      if (sep <= 0) return false;
-      const targetTool = String(assertion.value).slice(0, sep).toLowerCase();
-      const expected = String(assertion.value).slice(sep + 1).toLowerCase();
-      return toolCalls.some((tc) =>
-        tc.tool.toLowerCase() === targetTool &&
-        String(tc.output || '').toLowerCase().includes(expected),
-      );
-    }
-    case 'tool_input_contains': {
-      const sep = String(assertion.value).indexOf(':');
-      if (sep <= 0) return false;
-      const targetTool = String(assertion.value).slice(0, sep).toLowerCase();
-      const expected = String(assertion.value).slice(sep + 1).toLowerCase();
-      return toolCalls.some((tc) =>
-        tc.tool.toLowerCase() === targetTool &&
-        JSON.stringify(tc.input || '').toLowerCase().includes(expected),
-      );
-    }
-    case 'tool_input_not_contains': {
-      const sep = String(assertion.value).indexOf(':');
-      // value 必须是 "Tool:needle" 格式。无冒号(generator 偶尔产 "--force" / "lastTaskPatrol"
-      // 这种裸 needle)在 _contains 语义里算 false(没法判定哪个工具),但 _not_contains 语义
-      // 应该 trivially pass(没有匹配 = 没传 needle = 满足"不应包含"约束)。否则会变成
-      // 假阳性失败,扭曲通过率。loader 已加格式校验拒绝这种 value,这里是 grader 兜底。
-      if (sep <= 0) return true;
-      const targetTool = String(assertion.value).slice(0, sep).toLowerCase();
-      const expected = String(assertion.value).slice(sep + 1).toLowerCase();
-      return !toolCalls.some((tc) =>
-        tc.tool.toLowerCase() === targetTool &&
-        JSON.stringify(tc.input || '').toLowerCase().includes(expected),
-      );
-    }
-    // mock_hit:校验"驱动流程"——指定 mock 是否被命中至少 N 次
-    // value 是 mockStats.perMock 的 key,格式 "Tool:N"(N 为 sample.mocks 数组里的 1-based 序号)
-    // threshold 可选,默认 >=1
-    // 例: { type: 'mock_hit', value: 'Bash:2' } 检查第 2 条 Bash mock 被调过
-    case 'mock_hit': {
-      const stats = ctx.mockStats;
-      if (!stats) return false;
-      const key = String(assertion.value);
-      const hits = stats.perMock[key] ?? 0;
-      const min = assertion.threshold ?? 1;
-      return hits >= min;
-    }
-    case 'rouge_n_min':
-      return rougeN(output, String(assertion.reference ?? assertion.value ?? ''), assertion.n ?? 1)
-        >= (assertion.threshold ?? 0.5);
-    case 'levenshtein_max':
-      return levenshtein(output, String(assertion.reference ?? assertion.value ?? ''))
-        <= (assertion.value as number ?? Infinity);
-    case 'bleu_min':
-      return bleu(output, String(assertion.reference ?? assertion.value ?? ''))
-        >= (assertion.threshold ?? 0.5);
-    default:
-      return false;
-  }
-}
-
-/**
- * assert-set 是布尔组合器,不是叶子断言,没有静态的「层」。它在 runAssertions 里只产出一条聚合明细
- * (`type: 'assert-set'`、aggregate pass/fail),computeLayeredScores 无法据此判 fact / behavior。
- * 这里在 grading 期(能看到 children 树时)按**叶子子断言**的层解析:递归收集所有叶子(穿透嵌套 assert-set),
- *   - 同层(全 fact 或全 behavior)→ 返回该层:聚合 pass/fail 归这一层,与 any/all 模式无关(同层信号无歧义)。
- *   - 混层 / 空 / 含未分类叶子 → 返回 undefined:不归层(混层组合器塞进单层会引入口径偏差,诚实做法是不计入分层)。
- * 解析结果落到 detail.layer,computeLayeredScores 优先读它。
- */
-function resolveAssertSetLayer(assertion: Assertion): 'fact' | 'behavior' | undefined {
-  const layers = new Set<'fact' | 'behavior' | 'unknown'>();
-  const collect = (a: Assertion): void => {
-    if (a.type === 'assert-set') {
-      for (const c of a.children ?? []) collect(c);
-      return;
-    }
-    layers.add(ASSERTION_LAYER[a.type] ?? 'unknown');
-  };
-  collect(assertion);
-  if (layers.size !== 1) return undefined; // 0 / 混层 → 不归层
-  const [only] = [...layers];
-  return only === 'unknown' ? undefined : only;
-}
-
 export function runAssertions(
   output: string,
   assertions: Assertion[],
@@ -326,18 +66,12 @@ export function runAssertions(
       throw new TypeError(`assertions[${index}]: async assertion ${JSON.stringify(assertion.type)} requires runAsyncAssertions()`);
     }
   });
-  const outputLower = output.toLowerCase();
-  const toolCalls = context.toolCalls || [];
-  const toolNames = toolCalls.map((tc) => tc.tool.toLowerCase());
-  const ctx = { outputLower, toolCalls, toolNames, costUSD: context.costUSD, durationMs: context.durationMs, numTurns: context.numTurns, mockStats: context.mockStats };
-
   const details: AssertionDetail[] = [];
   for (const assertion of assertions) {
     const weight = assertion.weight ?? 1;
-    const raw = evalAssertion(output, assertion, ctx);
-    const passed = assertion.not ? !raw : raw;
+    const passed = evaluateDeterministicAssertion(output, assertion, context);
     // assert-set 组合器:在此(能看到 children)解析其层,供 computeLayeredScores 用;叶子断言按静态映射归层、不带 layer。
-    const layer = assertion.type === 'assert-set' ? resolveAssertSetLayer(assertion) : undefined;
+    const layer = assertion.type === 'assert-set' ? resolveAssertionLayer(assertion) : undefined;
     details.push({
       type: assertion.type,
       value: assertion.value ?? assertion.pattern ?? assertion.values?.join(', ') ?? '',

--- a/src/grading/layered-scores.ts
+++ b/src/grading/layered-scores.ts
@@ -1,4 +1,7 @@
 import type { AssertionDetail, LayeredScores } from '../types/index.js';
+import { ASSERTION_LAYER } from '../shared/assertions/layers.js';
+
+export { ASSERTION_LAYER } from '../shared/assertions/layers.js';
 
 /**
  * 每个 assertion 类型归到事实层 / 行为层。**单一来源**:`computeLayeredScores` 据此把 assertion 明细拆进
@@ -9,51 +12,10 @@ import type { AssertionDetail, LayeredScores } from '../types/index.js';
  * 不变量:**runner 支持的每个 assertion 类型都必须能被归层**,否则该类型的 pass/fail 会被 computeLayeredScores
  * 从 fact 与 behavior 同时漏掉 —— 既不报错也不进 composite,静默丢分(曾漏掉七类:mock_hit / rouge_n_min /
  * bleu_min / levenshtein_max + RAG 三件套 faithfulness / answer_relevancy / context_recall)。叶子断言在此静态
- * 分类;组合器 `assert-set` 没有静态层,由 `assertions.ts` 的 resolveAssertSetLayer 在 grading 期按其叶子 children
+ * 分类;组合器 `assert-set` 没有静态层,由共享 `resolveAssertionLayer` 在 grading 期按其叶子 children
  * 解析(同层→归层、混层→不计),结果落 detail.layer。共享注册表 `shared/assertion-types.ts` 是支持类型的真源；
- * `test/grading/layered-scores-exhaustiveness.test.ts` 守住新增类型必须在本映射或组合器集合中显式处理。
+ * `test/grading/layered-scores-exhaustiveness.test.ts` 守住新增类型必须在共享映射或组合器集合中显式处理。
  */
-export const ASSERTION_LAYER: Record<string, 'fact' | 'behavior'> = {
-  contains: 'fact',
-  not_contains: 'fact',
-  regex: 'fact',
-  json_valid: 'fact',
-  json_schema: 'fact',
-  equals: 'fact',
-  not_equals: 'fact',
-  contains_all: 'fact',
-  contains_any: 'fact',
-  semantic_similarity: 'fact',
-  tool_output_contains: 'fact',
-  tool_input_contains: 'fact',
-  tool_input_not_contains: 'fact',
-  // 文本相似度指标:衡量输出与参考答案的内容贴合度 = 内容保真 → 事实层。
-  rouge_n_min: 'fact',
-  bleu_min: 'fact',
-  levenshtein_max: 'fact',
-  // RAG 评委指标:都评输出内容质量(忠实度 / 答非所问 / 关键事实召回),= 内容正确性 → 事实层。
-  faithfulness: 'fact',
-  answer_relevancy: 'fact',
-  context_recall: 'fact',
-  starts_with: 'behavior',
-  ends_with: 'behavior',
-  min_length: 'behavior',
-  max_length: 'behavior',
-  word_count_min: 'behavior',
-  word_count_max: 'behavior',
-  cost_max: 'behavior',
-  latency_max: 'behavior',
-  turns_min: 'behavior',
-  turns_max: 'behavior',
-  tools_called: 'behavior',
-  tools_not_called: 'behavior',
-  tools_count_min: 'behavior',
-  tools_count_max: 'behavior',
-  custom: 'behavior',
-  // 必经工具 / 步骤里程碑(value 形如 "Tool:N"):测"有没有走到那一步" = 做事方式 → 行为层(类同 tools_called)。
-  mock_hit: 'behavior',
-};
-
 function ratioToScore(ratio: number): number {
   return Number((1 + ratio * 4).toFixed(2));
 }

--- a/src/shared/assertions/deterministic.ts
+++ b/src/shared/assertions/deterministic.ts
@@ -1,0 +1,331 @@
+import _Ajv from 'ajv';
+import type { SyncAssertionType } from '../assertion-types.js';
+import type { Assertion, ToolCallInfo } from '../../types/index.js';
+
+const Ajv = _Ajv.default ?? _Ajv;
+const ajv = new Ajv();
+
+type JsonSchemaValidator = (
+  data: unknown,
+  schema: Record<string, unknown>,
+) => boolean;
+
+export const DETERMINISTIC_ASSERTION_ALGORITHM_VERSION =
+  'omk.deterministic-assertions/v1' as const;
+
+export interface DeterministicAssertionContext {
+  readonly costUSD?: number;
+  readonly durationMs?: number;
+  readonly numTurns?: number;
+  readonly toolCalls?: readonly ToolCallInfo[];
+  readonly mockStats?: {
+    readonly hits: number;
+    readonly misses: number;
+    readonly perMock: Readonly<Record<string, number>>;
+  };
+}
+
+export const OUTPUT_ONLY_SYNC_ASSERTION_TYPE_NAMES = [
+  'contains',
+  'not_contains',
+  'regex',
+  'min_length',
+  'max_length',
+  'json_valid',
+  'json_schema',
+  'starts_with',
+  'ends_with',
+  'equals',
+  'not_equals',
+  'word_count_min',
+  'word_count_max',
+  'contains_all',
+  'contains_any',
+  'rouge_n_min',
+  'levenshtein_max',
+  'bleu_min',
+  'assert-set',
+] as const satisfies readonly SyncAssertionType[];
+
+export const EXECUTION_AWARE_SYNC_ASSERTION_TYPE_NAMES = [
+  'cost_max',
+  'latency_max',
+  'turns_max',
+  'turns_min',
+  'tools_called',
+  'tools_not_called',
+  'tools_count_max',
+  'tools_count_min',
+  'tool_output_contains',
+  'tool_input_contains',
+  'tool_input_not_contains',
+  'mock_hit',
+] as const satisfies readonly SyncAssertionType[];
+
+export const OUTPUT_ONLY_SYNC_ASSERTION_TYPES: ReadonlySet<string> = new Set(
+  OUTPUT_ONLY_SYNC_ASSERTION_TYPE_NAMES,
+);
+
+export const EXECUTION_AWARE_SYNC_ASSERTION_TYPES: ReadonlySet<string> = new Set(
+  EXECUTION_AWARE_SYNC_ASSERTION_TYPE_NAMES,
+);
+
+export function ratioToScore(ratio: number): number {
+  return Number((1 + ratio * 4).toFixed(2));
+}
+
+function tokenize(value: string): string[] {
+  return value.toLowerCase().match(/[a-z0-9]+|[一-龥]/g) ?? [];
+}
+
+function ngrams(tokens: readonly string[], n: number): string[] {
+  if (n <= 0 || tokens.length < n) return [];
+  const result = new Array<string>(tokens.length - n + 1);
+  for (let index = 0; index <= tokens.length - n; index += 1) {
+    result[index] = tokens.slice(index, index + n).join(' ');
+  }
+  return result;
+}
+
+function clippedOverlap(candidate: readonly string[], reference: readonly string[]): number {
+  if (candidate.length === 0 || reference.length === 0) return 0;
+  const candidateCounts = new Map<string, number>();
+  const referenceCounts = new Map<string, number>();
+  for (const value of candidate) {
+    candidateCounts.set(value, (candidateCounts.get(value) ?? 0) + 1);
+  }
+  for (const value of reference) {
+    referenceCounts.set(value, (referenceCounts.get(value) ?? 0) + 1);
+  }
+  let total = 0;
+  for (const [value, count] of candidateCounts) {
+    total += Math.min(count, referenceCounts.get(value) ?? 0);
+  }
+  return total;
+}
+
+export function rougeN(candidate: string, reference: string, n: number): number {
+  const candidateNgrams = ngrams(tokenize(candidate), n);
+  const referenceNgrams = ngrams(tokenize(reference), n);
+  if (referenceNgrams.length === 0) return 0;
+  return clippedOverlap(candidateNgrams, referenceNgrams) / referenceNgrams.length;
+}
+
+export function levenshtein(left: string, right: string): number {
+  if (left === right) return 0;
+  if (left.length === 0) return right.length;
+  if (right.length === 0) return left.length;
+  let a = left;
+  let b = right;
+  if (a.length < b.length) [a, b] = [b, a];
+  const rows = b.length;
+  let previous = new Array<number>(rows + 1);
+  let current = new Array<number>(rows + 1);
+  for (let column = 0; column <= rows; column += 1) previous[column] = column;
+  for (let row = 1; row <= a.length; row += 1) {
+    current[0] = row;
+    for (let column = 1; column <= rows; column += 1) {
+      const cost = a[row - 1] === b[column - 1] ? 0 : 1;
+      current[column] = Math.min(
+        previous[column] + 1,
+        current[column - 1] + 1,
+        previous[column - 1] + cost,
+      );
+    }
+    [previous, current] = [current, previous];
+  }
+  return previous[rows];
+}
+
+export function bleu(candidate: string, reference: string, maxN = 4): number {
+  const candidateTokens = tokenize(candidate);
+  const referenceTokens = tokenize(reference);
+  if (candidateTokens.length === 0 || referenceTokens.length === 0) return 0;
+  let logSum = 0;
+  for (let n = 1; n <= maxN; n += 1) {
+    const candidateNgrams = ngrams(candidateTokens, n);
+    const referenceNgrams = ngrams(referenceTokens, n);
+    if (candidateNgrams.length === 0) return 0;
+    const overlap = clippedOverlap(candidateNgrams, referenceNgrams);
+    if (overlap === 0) return 0;
+    logSum += Math.log(overlap / candidateNgrams.length);
+  }
+  const brevityPenalty = candidateTokens.length >= referenceTokens.length
+    ? 1
+    : Math.exp(1 - referenceTokens.length / candidateTokens.length);
+  return brevityPenalty * Math.exp(logSum / maxN);
+}
+
+function validateJsonSchemaWith(
+  validator: InstanceType<typeof Ajv>,
+  data: unknown,
+  schema: Record<string, unknown>,
+): boolean {
+  if (!schema || typeof schema !== 'object') return true;
+  try {
+    const validate = validator.compile(schema);
+    return validate(data) as boolean;
+  } catch {
+    return false;
+  }
+}
+
+/** Legacy-compatible module session used only by the existing grader entrypoint. */
+export function validateJsonSchema(
+  data: unknown,
+  schema: Record<string, unknown>,
+): boolean {
+  return validateJsonSchemaWith(ajv, data, schema);
+}
+
+function evaluateRaw(
+  output: string,
+  assertion: Assertion,
+  context: Required<Pick<DeterministicAssertionContext, 'toolCalls'>>
+    & DeterministicAssertionContext
+    & {
+      outputLower: string;
+      toolNames: readonly string[];
+      validateSchema: JsonSchemaValidator;
+    },
+): boolean {
+  if (assertion.type === 'assert-set') {
+    const children = assertion.children ?? [];
+    if (children.length === 0) return false;
+    const childPasses = children.map((child) => {
+      const raw = evaluateRaw(output, child, context);
+      return child.not ? !raw : raw;
+    });
+    return (assertion.mode ?? 'all') === 'any'
+      ? childPasses.some(Boolean)
+      : childPasses.every(Boolean);
+  }
+
+  switch (assertion.type) {
+    case 'contains':
+      return context.outputLower.includes(String(assertion.value).toLowerCase());
+    case 'not_contains':
+      return !context.outputLower.includes(String(assertion.value).toLowerCase());
+    case 'regex':
+      return new RegExp(assertion.pattern!, assertion.flags || 'i').test(output);
+    case 'min_length': return output.length >= (assertion.value as number);
+    case 'max_length': return output.length <= (assertion.value as number);
+    case 'json_valid':
+      try { JSON.parse(output); return true; } catch { return false; }
+    case 'json_schema':
+      try { return context.validateSchema(JSON.parse(output), assertion.schema!); } catch { return false; }
+    case 'starts_with':
+      return context.outputLower.startsWith(String(assertion.value).toLowerCase());
+    case 'ends_with':
+      return context.outputLower.endsWith(String(assertion.value).toLowerCase());
+    case 'equals': return output.trim() === String(assertion.value).trim();
+    case 'not_equals': return output.trim() !== String(assertion.value).trim();
+    case 'word_count_min':
+      return output.split(/\s+/).filter(Boolean).length >= (assertion.value as number);
+    case 'word_count_max':
+      return output.split(/\s+/).filter(Boolean).length <= (assertion.value as number);
+    case 'contains_all':
+      return (assertion.values ?? []).every(
+        (value) => context.outputLower.includes(value.toLowerCase()),
+      );
+    case 'contains_any':
+      return (assertion.values ?? []).some(
+        (value) => context.outputLower.includes(value.toLowerCase()),
+      );
+    case 'cost_max': return (context.costUSD ?? Infinity) <= (assertion.value as number);
+    case 'latency_max':
+      return (context.durationMs ?? Infinity) <= (assertion.value as number);
+    case 'turns_max': return (context.numTurns ?? Infinity) <= (assertion.value as number);
+    case 'turns_min': return (context.numTurns ?? 0) >= (assertion.value as number);
+    case 'tools_called':
+      return (assertion.values ?? []).every(
+        (value) => context.toolNames.includes(value.toLowerCase()),
+      );
+    case 'tools_not_called':
+      return (assertion.values ?? []).every(
+        (value) => !context.toolNames.includes(value.toLowerCase()),
+      );
+    case 'tools_count_max': return context.toolCalls.length <= (assertion.value as number);
+    case 'tools_count_min': return context.toolCalls.length >= (assertion.value as number);
+    case 'tool_output_contains': {
+      const separator = String(assertion.value).indexOf(':');
+      if (separator <= 0) return false;
+      const tool = String(assertion.value).slice(0, separator).toLowerCase();
+      const expected = String(assertion.value).slice(separator + 1).toLowerCase();
+      return context.toolCalls.some((call) => (
+        call.tool.toLowerCase() === tool
+        && String(call.output || '').toLowerCase().includes(expected)
+      ));
+    }
+    case 'tool_input_contains':
+    case 'tool_input_not_contains': {
+      const separator = String(assertion.value).indexOf(':');
+      if (separator <= 0) return assertion.type === 'tool_input_not_contains';
+      const tool = String(assertion.value).slice(0, separator).toLowerCase();
+      const expected = String(assertion.value).slice(separator + 1).toLowerCase();
+      const found = context.toolCalls.some((call) => (
+        call.tool.toLowerCase() === tool
+        && JSON.stringify(call.input || '').toLowerCase().includes(expected)
+      ));
+      return assertion.type === 'tool_input_not_contains' ? !found : found;
+    }
+    case 'mock_hit': {
+      const hits = context.mockStats?.perMock[String(assertion.value)] ?? 0;
+      return context.mockStats !== undefined && hits >= (assertion.threshold ?? 1);
+    }
+    case 'rouge_n_min':
+      return rougeN(output, String(assertion.reference ?? assertion.value ?? ''), assertion.n ?? 1)
+        >= (assertion.threshold ?? 0.5);
+    case 'levenshtein_max':
+      return levenshtein(output, String(assertion.reference ?? assertion.value ?? ''))
+        <= (assertion.value as number ?? Infinity);
+    case 'bleu_min':
+      return bleu(output, String(assertion.reference ?? assertion.value ?? ''))
+        >= (assertion.threshold ?? 0.5);
+    default: return false;
+  }
+}
+
+export function evaluateDeterministicAssertion(
+  output: string,
+  assertion: Assertion,
+  context: DeterministicAssertionContext = {},
+): boolean {
+  const toolCalls = [...(context.toolCalls ?? [])];
+  const raw = evaluateRaw(output, assertion, {
+    ...context,
+    toolCalls,
+    outputLower: output.toLowerCase(),
+    toolNames: toolCalls.map((call) => call.tool.toLowerCase()),
+    validateSchema: validateJsonSchema,
+  });
+  return assertion.not ? !raw : raw;
+}
+
+/** Creates an evaluator whose schema compilation has no cross-criterion, record, or run state. */
+export function createIsolatedDeterministicAssertionEvaluator(): (
+  output: string,
+  assertion: Assertion,
+  context?: DeterministicAssertionContext,
+) => boolean {
+  const validateSchema: JsonSchemaValidator = (data, schema) => (
+    validateJsonSchemaWith(new Ajv(), data, schema)
+  );
+  return (output, assertion, context = {}) => {
+    const toolCalls = [...(context.toolCalls ?? [])];
+    const raw = evaluateRaw(output, assertion, {
+      ...context,
+      toolCalls,
+      outputLower: output.toLowerCase(),
+      toolNames: toolCalls.map((call) => call.tool.toLowerCase()),
+      validateSchema,
+    });
+    return assertion.not ? !raw : raw;
+  };
+}
+
+export function assertionUsesOnlyOutput(assertion: Assertion): boolean {
+  if (!OUTPUT_ONLY_SYNC_ASSERTION_TYPES.has(assertion.type)) return false;
+  return assertion.type !== 'assert-set'
+    || (assertion.children ?? []).every(assertionUsesOnlyOutput);
+}

--- a/src/shared/assertions/layers.ts
+++ b/src/shared/assertions/layers.ts
@@ -1,0 +1,58 @@
+import type { Assertion } from '../../types/index.js';
+
+/** Leaf assertion construct classification. `assert-set` is resolved from its leaves. */
+export const ASSERTION_LAYER: Readonly<Record<string, 'fact' | 'behavior'>> = Object.freeze({
+  contains: 'fact',
+  not_contains: 'fact',
+  regex: 'fact',
+  json_valid: 'fact',
+  json_schema: 'fact',
+  equals: 'fact',
+  not_equals: 'fact',
+  contains_all: 'fact',
+  contains_any: 'fact',
+  semantic_similarity: 'fact',
+  tool_output_contains: 'fact',
+  tool_input_contains: 'fact',
+  tool_input_not_contains: 'fact',
+  rouge_n_min: 'fact',
+  bleu_min: 'fact',
+  levenshtein_max: 'fact',
+  faithfulness: 'fact',
+  answer_relevancy: 'fact',
+  context_recall: 'fact',
+  starts_with: 'behavior',
+  ends_with: 'behavior',
+  min_length: 'behavior',
+  max_length: 'behavior',
+  word_count_min: 'behavior',
+  word_count_max: 'behavior',
+  cost_max: 'behavior',
+  latency_max: 'behavior',
+  turns_min: 'behavior',
+  turns_max: 'behavior',
+  tools_called: 'behavior',
+  tools_not_called: 'behavior',
+  tools_count_min: 'behavior',
+  tools_count_max: 'behavior',
+  custom: 'behavior',
+  mock_hit: 'behavior',
+});
+
+/** Mixed, empty, or unknown assertion sets deliberately have no layer. */
+export function resolveAssertionLayer(
+  assertion: Assertion,
+): 'fact' | 'behavior' | undefined {
+  const layers = new Set<'fact' | 'behavior' | 'unknown'>();
+  const collect = (candidate: Assertion): void => {
+    if (candidate.type === 'assert-set') {
+      for (const child of candidate.children ?? []) collect(child);
+      return;
+    }
+    layers.add(ASSERTION_LAYER[candidate.type] ?? 'unknown');
+  };
+  collect(assertion);
+  if (layers.size !== 1) return undefined;
+  const [only] = [...layers];
+  return only === 'unknown' ? undefined : only;
+}

--- a/test/eval-workflows/runtime-adapter/assembly.test.ts
+++ b/test/eval-workflows/runtime-adapter/assembly.test.ts
@@ -31,6 +31,7 @@ import {
   assembleOmkRuntimeBindings,
   createBuiltinOmkAnalysisBindingFactories,
   createOmkEvaluationRuntime,
+  OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
   createSameProcessEvaluatorAdapter,
   createSameProcessExecutorAdapter,
   resourceLeaseRequestsFromBindingEntries,
@@ -1137,6 +1138,25 @@ describe('OMK Evaluation Runtime binding assembly', () => {
 });
 
 describe('OMK Evaluation Runtime composition root', () => {
+  it('reserves the built-in output assertion Evaluator identity', async () => {
+    const compiled = compositionInput();
+    const factories = factoriesFor(compiled, []);
+    const existingFactory = factories.evaluatorsByImplementationId.values().next().value;
+    if (existingFactory === undefined) throw new Error('missing fixture evaluator factory');
+    const evaluators = new Map(factories.evaluatorsByImplementationId);
+    evaluators.set(OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID, existingFactory);
+
+    await expect(createOmkEvaluationRuntime({
+      compiled,
+      factories: { ...factories, evaluatorsByImplementationId: evaluators },
+      support: compositionSupport(),
+      resources: { leaseRoot: '/unused-test-lease-root' },
+    })).rejects.toMatchObject({
+      code: 'OMK_EVALUATION_RUNTIME_FACTORY_CONFLICT',
+      fieldPath: 'factories.evaluatorsByImplementationId',
+    });
+  });
+
   it('fails capability mismatch during Core prepare before any Executor opens', async () => {
     const compiled = compositionInput();
     const factories = factoriesFor(compiled, []);

--- a/test/eval-workflows/runtime-adapter/output-assertions.test.ts
+++ b/test/eval-workflows/runtime-adapter/output-assertions.test.ts
@@ -1,0 +1,533 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import type {
+  EvaluationDefinition,
+  JsonValue,
+  MeasurementPolicy,
+  RuntimeIdentity,
+} from '../../../src/evaluation-core/contracts/index.js';
+import {
+  RuntimeIdentitySchema,
+  digestCanonicalJson,
+} from '../../../src/evaluation-core/contracts/index.js';
+import {
+  prepareEvaluationPlan,
+  type PreparationRuntime,
+} from '../../../src/evaluation-core/compiler/index.js';
+import {
+  executeRunPlanSource,
+  InMemoryRuntimeEventSequencer,
+  type ExecutionClock,
+  type ExecutionExecutor,
+} from '../../../src/evaluation-core/execution/index.js';
+import {
+  evaluateExecutionBundle,
+  type EvaluationEvaluator,
+} from '../../../src/evaluation-core/evaluation/index.js';
+import {
+  createSameProcessEvaluatorAdapter,
+  createBuiltinOmkScoringBindingFactories,
+  createOutputAssertionEvaluatorImplementation,
+  OUTPUT_ASSERTION_BINDINGS,
+  OUTPUT_ASSERTION_CONTEXT_SCHEMA_VERSION,
+  OUTPUT_ASSERTION_EVALUATOR_IDENTITY,
+  OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+} from '../../../src/eval-workflows/runtime-adapter/index.js';
+import { SYNC_ASSERTION_TYPE_NAMES } from '../../../src/shared/assertion-types.js';
+import {
+  EXECUTION_AWARE_SYNC_ASSERTION_TYPE_NAMES,
+  OUTPUT_ONLY_SYNC_ASSERTION_TYPE_NAMES,
+  createIsolatedDeterministicAssertionEvaluator,
+} from '../../../src/shared/assertions/deterministic.js';
+import type { Assertion, AssertionDetail } from '../../../src/types/index.js';
+import { testRuntime, validDefinition, validPolicy } from '../../evaluation-core/compiler/fixtures.js';
+
+interface ScoringFixture {
+  deterministicAssertions: {
+    output: string;
+    assertions: Assertion[];
+    expected: { details: AssertionDetail[] };
+  };
+}
+
+const scoringFixture = JSON.parse(readFileSync(fileURLToPath(new URL(
+  '../../fixtures/evaluation-core/scoring-equivalence-v1.json',
+  import.meta.url,
+)), 'utf8')) as ScoringFixture;
+
+const OUTPUT_METRIC_IDS = [
+  'contains-hello',
+  'short-enough',
+  'contains-missing',
+  'fact-set',
+] as const;
+
+const VALID_CRITERIA: JsonValue[] = scoringFixture.deterministicAssertions.assertions
+  .slice(0, OUTPUT_METRIC_IDS.length)
+  .map((assertion, index) => ({
+    criterionId: OUTPUT_METRIC_IDS[index],
+    metricId: OUTPUT_METRIC_IDS[index],
+    assertion: structuredClone(assertion) as unknown as JsonValue,
+  }));
+
+class DeterministicClock implements ExecutionClock {
+  #now = 0;
+
+  monotonicNow(): number {
+    const value = this.#now;
+    this.#now += 1;
+    return value;
+  }
+
+  timestamp(): string {
+    return '2026-08-31T00:00:00.000Z';
+  }
+
+  async sleep(_delayMs: number, signal: AbortSignal): Promise<void> {
+    if (signal.aborted) throw signal.reason;
+    await new Promise<never>((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    });
+  }
+}
+
+function definitionWithCriteria(criteria: readonly JsonValue[]): EvaluationDefinition {
+  const definition = validDefinition();
+  definition.dataset.samples[0].evaluationContext = {
+    outputAssertions: {
+      schemaVersion: OUTPUT_ASSERTION_CONTEXT_SCHEMA_VERSION,
+      criteria: [...criteria],
+    },
+  };
+  definition.evaluators = [{
+    evaluatorId: 'output-assertions',
+    evaluatorKind: 'assertion',
+    implementationId: OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+    measurement: {
+      instrumentId: 'omk-output-assertions',
+      ensembleMemberId: 'deterministic-local',
+      replicateGroupId: 'deterministic-primary',
+      replicateIndex: 0,
+    },
+    metricIds: [...OUTPUT_METRIC_IDS, 'not-applicable'],
+    inputs: [
+      { bindingId: OUTPUT_ASSERTION_BINDINGS.actual, sourceKind: 'output', pointer: '/answer' },
+      {
+        bindingId: OUTPUT_ASSERTION_BINDINGS.criteria,
+        sourceKind: 'evaluation-context',
+        pointer: '/outputAssertions',
+      },
+    ],
+  }];
+  definition.metrics = definition.evaluators[0].metricIds.map((metricId) => ({
+    metricId,
+    valueType: 'boolean' as const,
+    scope: 'sample' as const,
+    direction: 'higher-is-better' as const,
+    missingPolicyId: 'exclude/v1',
+  }));
+  definition.analysisGraph.nodes = [{
+    analysisNodeKind: 'reducer',
+    nodeId: 'contains-rate',
+    implementationId: 'descriptive.rate/v1',
+    inputs: [{ inputKind: 'metric-observations', referenceId: 'contains-hello' }],
+    outputResultId: 'contains-rate',
+  }];
+  definition.comparisons[0].metricIds = ['contains-hello'];
+  definition.decisionPolicy = {
+    decisionPolicyId: 'release-gate',
+    implementationId: 'progress/v1',
+    analysisResultIds: ['contains-rate'],
+    minimumEvidenceStatus: 'complete',
+    parameters: { threshold: 0 },
+  };
+  return definition;
+}
+
+function policy(maximumClassification: 'public' | 'gold' = 'gold'): MeasurementPolicy {
+  const value = validPolicy();
+  value.retry.maxAttempts = 1;
+  value.evaluation.retry.maxAttempts = 1;
+  value.evidence.trace = 'none';
+  value.evidence.evidence = 'full';
+  value.evidence.maximumClassification = maximumClassification;
+  return value;
+}
+
+function preparationRuntime(): PreparationRuntime {
+  const base = testRuntime();
+  return {
+    ...base,
+    resolveEvaluator() {
+      return {
+        identity: OUTPUT_ASSERTION_EVALUATOR_IDENTITY,
+        satisfiesVersionConstraint: true,
+      };
+    },
+  };
+}
+
+function runtimeIdentity(
+  plan: Awaited<ReturnType<typeof prepareEvaluationPlan>>,
+  runtimeKind: 'executor' | 'evaluator',
+  referenceId: string,
+): RuntimeIdentity {
+  const stage = runtimeKind === 'executor' ? plan.execution : plan.evaluation;
+  const runtime = stage.runtimes.find((candidate) => (
+    candidate.runtimeKind === runtimeKind && candidate.referenceId === referenceId
+  ));
+  if (runtime === undefined) throw new Error(`Missing ${runtimeKind} runtime ${referenceId}`);
+  return RuntimeIdentitySchema.parse(structuredClone(runtime.identity));
+}
+
+function executor(
+  plan: Awaited<ReturnType<typeof prepareEvaluationPlan>>,
+): ExecutionExecutor {
+  return {
+    identity: runtimeIdentity(plan, 'executor', 'control'),
+    async openRun() {
+      return {
+        async openTrial() {
+          return {
+            async execute() {
+              return {
+                output: {
+                  value: { answer: scoringFixture.deterministicAssertions.output },
+                  classification: 'public' as const,
+                },
+              };
+            },
+            dispose() {},
+          };
+        },
+        dispose() {},
+      };
+    },
+  };
+}
+
+function instrumentLifecycle(
+  port: EvaluationEvaluator,
+  faults: { recordDispose?: boolean } = {},
+) {
+  const counts = {
+    runOpens: 0,
+    runDisposals: 0,
+    recordOpens: 0,
+    recordDisposals: 0,
+    evaluations: 0,
+  };
+  const instrumented: EvaluationEvaluator = {
+    identity: port.identity,
+    async openRun(context) {
+      counts.runOpens += 1;
+      const run = await port.openRun(context);
+      return {
+        async openRecord(recordContext) {
+          counts.recordOpens += 1;
+          const record = await run.openRecord(recordContext);
+          return {
+            async evaluate(attempt) {
+              counts.evaluations += 1;
+              return record.evaluate(attempt);
+            },
+            async dispose() {
+              counts.recordDisposals += 1;
+              await record.dispose();
+              if (faults.recordDispose === true) throw new Error('injected record dispose failure');
+            },
+          };
+        },
+        async dispose() {
+          counts.runDisposals += 1;
+          await run.dispose();
+        },
+      };
+    },
+  };
+  return { port: instrumented, counts };
+}
+
+async function runCore(
+  criteria: readonly JsonValue[],
+  maximumClassification: 'public' | 'gold' = 'gold',
+  lifecycleFaults: { recordDispose?: boolean } = {},
+) {
+  const plan = await prepareEvaluationPlan(
+    definitionWithCriteria(criteria),
+    policy(maximumClassification),
+    preparationRuntime(),
+  );
+  const clock = new DeterministicClock();
+  const eventSequencer = new InMemoryRuntimeEventSequencer();
+  const executionPort = executor(plan);
+  const execution = await executeRunPlanSource(plan, {
+    executorsByTargetId: new Map(plan.execution.targets.map((target) => [
+      target.targetId,
+      executionPort,
+    ])),
+    clock,
+    eventSequencer,
+  }, { runId: 'output-assertion-run', bundleId: 'output-assertion-execution' });
+  const adapted = createSameProcessEvaluatorAdapter({
+    identity: OUTPUT_ASSERTION_EVALUATOR_IDENTITY,
+    sessionIsolationKey: 'output-assertion-session',
+    resourceLeases: {
+      forRun: () => ({
+        bindingId: 'output-assertions-binding',
+        consumerKind: 'evaluator',
+        resourcesByResourceId: new Map(),
+      }),
+    },
+    implementation: createOutputAssertionEvaluatorImplementation(),
+  });
+  const instrumented = instrumentLifecycle(adapted, lifecycleFaults);
+  const evaluation = await evaluateExecutionBundle(plan, execution, {
+    evaluatorsByEvaluatorId: new Map([['output-assertions', instrumented.port]]),
+    clock,
+    eventSequencer,
+  }, { runId: 'output-assertion-run', bundleId: 'output-assertion-evaluation' });
+  return { plan, execution, evaluation, counts: instrumented.counts };
+}
+
+describe('output-only deterministic assertion Evaluator', () => {
+  it('runs through a prepared Core plan and preserves observations, evidence, and missingness', async () => {
+    const result = await runCore(VALID_CRITERIA);
+    expect(result.evaluation.evaluationBundleStatus).toBe('completed');
+    expect(result.evaluation.coverage).toMatchObject({ eligible: 2, completed: 2 });
+    expect(result.counts).toEqual({
+      runOpens: 1,
+      runDisposals: 1,
+      recordOpens: 2,
+      recordDisposals: 2,
+      evaluations: 2,
+    });
+    for (const record of result.evaluation.records) {
+      expect(record.evaluationStatus).toBe('completed');
+      if (record.evaluationStatus !== 'completed') continue;
+      expect(record.observations.map((observation) => ({
+        metricId: observation.metricId,
+        observationStatus: observation.observationStatus,
+        value: observation.observationStatus === 'observed' ? observation.value : undefined,
+        reasonCode: observation.observationStatus === 'missing'
+          ? observation.reasonCode
+          : undefined,
+      }))).toEqual([
+        { metricId: 'contains-hello', observationStatus: 'observed', value: true, reasonCode: undefined },
+        { metricId: 'short-enough', observationStatus: 'observed', value: true, reasonCode: undefined },
+        { metricId: 'contains-missing', observationStatus: 'observed', value: false, reasonCode: undefined },
+        { metricId: 'fact-set', observationStatus: 'observed', value: true, reasonCode: undefined },
+        { metricId: 'not-applicable', observationStatus: 'missing', value: undefined, reasonCode: 'criterion-not-applicable' },
+      ]);
+      record.observations.slice(0, OUTPUT_METRIC_IDS.length).forEach((observation, index) => {
+        expect(observation.evidence).toMatchObject({
+          contentKind: 'inline',
+          classification: 'gold',
+          value: {
+            schemaVersion: 'omk.output-assertion-evidence/v1',
+            criterionId: OUTPUT_METRIC_IDS[index],
+            detail: scoringFixture.deterministicAssertions.expected.details[index],
+          },
+        });
+      });
+    }
+  });
+
+  it('fails closed when an execution-aware assertion is routed to the output-only family', async () => {
+    const result = await runCore([{
+      criterionId: 'cost-gate',
+      metricId: 'contains-hello',
+      assertion: { type: 'cost_max', value: 0.1 },
+    }]);
+    expect(result.evaluation.evaluationBundleStatus).toBe('failed');
+    expect(result.evaluation.coverage).toMatchObject({ notStarted: 2, completed: 0 });
+    expect(result.evaluation.records).toEqual([]);
+    expect(result.counts).toMatchObject({
+      runOpens: 1,
+      runDisposals: 1,
+      recordOpens: 2,
+      recordDisposals: 0,
+      evaluations: 0,
+    });
+  });
+
+  it('lets Core enforce the sealed evidence classification ceiling', async () => {
+    const result = await runCore(VALID_CRITERIA, 'public');
+    expect(result.evaluation.evaluationBundleStatus).toBe('completed');
+    expect(result.evaluation.coverage).toMatchObject({ failed: 2, completed: 0 });
+    for (const record of result.evaluation.records) {
+      expect(record).toMatchObject({
+        evaluationStatus: 'failed',
+        error: { code: 'evidence-classification-exceeded', stage: 'infrastructure' },
+      });
+    }
+  });
+
+  it('fails the Core run when record disposal is not clean', async () => {
+    const result = await runCore(VALID_CRITERIA, 'gold', { recordDispose: true });
+    expect(result.evaluation).toMatchObject({
+      evaluationBundleStatus: 'failed',
+      terminationReasonCode: 'evaluator-record-dispose-failed',
+      coverage: { failed: 0, completed: 2 },
+    });
+    expect(result.counts).toMatchObject({
+      runOpens: 1,
+      runDisposals: 1,
+      recordOpens: 2,
+      recordDisposals: 2,
+      evaluations: 2,
+    });
+  });
+
+  it('keeps every synchronous assertion type in exactly one execution-input family', () => {
+    const outputTypes = new Set<string>(OUTPUT_ONLY_SYNC_ASSERTION_TYPE_NAMES);
+    const executionTypes = new Set<string>(EXECUTION_AWARE_SYNC_ASSERTION_TYPE_NAMES);
+    expect([...outputTypes].filter((type) => executionTypes.has(type))).toEqual([]);
+    expect([...outputTypes, ...executionTypes].sort()).toEqual(
+      [...SYNC_ASSERTION_TYPE_NAMES].sort(),
+    );
+  });
+
+  it('raises derived evidence classification and cooperates with cancellation', async () => {
+    const implementation = createOutputAssertionEvaluatorImplementation();
+    const run = {
+      runId: 'direct-output-assertion-run',
+      evaluationPlanDigest: digestCanonicalJson({ plan: 'direct-output-assertion' }),
+    };
+    const scope = {
+      sessionIsolationKey: 'direct-session',
+      runIsolationKey: digestCanonicalJson({ run: 'direct-output-assertion' }),
+      operationIsolationKey: digestCanonicalJson({ operation: 'direct-output-assertion' }),
+    };
+    const resources = {
+      bindingId: 'output-assertions-binding',
+      consumerKind: 'evaluator' as const,
+      resourcesByResourceId: new Map(),
+    };
+    const record = {
+      targetId: 'control',
+      sampleId: 'sample-1',
+      trialIndex: 0,
+      trialId: digestCanonicalJson({ trial: 'direct-output-assertion' }),
+      evaluatorId: 'output-assertions',
+      measurement: {
+        instrumentId: 'omk-output-assertions',
+        ensembleMemberId: 'deterministic-local',
+        replicateGroupId: 'deterministic-primary',
+        replicateIndex: 0,
+      },
+      evaluationId: digestCanonicalJson({ evaluation: 'direct-output-assertion' }),
+      bindings: [{
+        bindingId: OUTPUT_ASSERTION_BINDINGS.actual,
+        sourceKind: 'output' as const,
+        value: scoringFixture.deterministicAssertions.output,
+        classification: 'secret' as const,
+      }, {
+        bindingId: OUTPUT_ASSERTION_BINDINGS.criteria,
+        sourceKind: 'evaluation-context' as const,
+        value: {
+          schemaVersion: OUTPUT_ASSERTION_CONTEXT_SCHEMA_VERSION,
+          criteria: VALID_CRITERIA,
+        },
+        classification: 'public' as const,
+      }],
+      metrics: definitionWithCriteria(VALID_CRITERIA).metrics,
+    };
+    const runState = await implementation.openRun({ run, scope, resources });
+    const recordState = await implementation.openRecord({
+      run,
+      runState,
+      record,
+      scope,
+      resources,
+    });
+    const activeController = new AbortController();
+    const attempt = {
+      attemptId: digestCanonicalJson({ attempt: 'direct-output-assertion' }),
+      attemptNumber: 1,
+      signal: activeController.signal,
+    };
+    const result = await implementation.evaluate({
+      run,
+      runState,
+      record,
+      recordState,
+      attempt,
+      scope,
+      resources,
+    });
+    expect(result.observations[0].evidence?.classification).toBe('secret');
+
+    const cancellation = new Error('cancel output assertion');
+    const cancelledController = new AbortController();
+    cancelledController.abort(cancellation);
+    await expect(implementation.evaluate({
+      run,
+      runState,
+      record,
+      recordState,
+      attempt: { ...attempt, signal: cancelledController.signal },
+      scope,
+      resources,
+    })).rejects.toBe(cancellation);
+  });
+
+  it('isolates JSON Schema registries between independent criteria', () => {
+    const evaluateAssertion = createIsolatedDeterministicAssertionEvaluator();
+    const schemaId = 'https://example.com/omk/output-assertion';
+    expect(evaluateAssertion('{"value":"text"}', {
+      type: 'json_schema',
+      schema: {
+        $id: schemaId,
+        type: 'object',
+        properties: { value: { type: 'string' } },
+        required: ['value'],
+      },
+    })).toBe(true);
+    expect(evaluateAssertion('{"value":42}', {
+      type: 'json_schema',
+      schema: {
+        $id: schemaId,
+        type: 'object',
+        properties: { value: { type: 'number' } },
+        required: ['value'],
+      },
+    })).toBe(true);
+  });
+
+  it('registers a production factory with explicit local preflight dispositions', async () => {
+    const factory = createBuiltinOmkScoringBindingFactories()
+      .evaluatorsByImplementationId.get(OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID);
+    expect(factory).toBeDefined();
+    const resolved = await factory!({
+      sessionIsolationKey: 'factory-session',
+      binding: {
+        runtimeKind: 'evaluator',
+        bindingId: 'output-assertions-binding',
+        evaluatorId: 'output-assertions',
+        implementationId: OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+        measurement: {
+          instrumentId: 'omk-output-assertions',
+          ensembleMemberId: 'deterministic-local',
+          replicateGroupId: 'deterministic-primary',
+          replicateIndex: 0,
+        },
+        resourceLeaseRequirements: [],
+      },
+      evaluator: definitionWithCriteria(VALID_CRITERIA).evaluators[0],
+      resourceLeases: {
+        forRun: () => ({
+          bindingId: 'output-assertions-binding',
+          consumerKind: 'evaluator',
+          resourcesByResourceId: new Map(),
+        }),
+      },
+    });
+    expect(resolved.port.identity).toEqual(OUTPUT_ASSERTION_EVALUATOR_IDENTITY);
+    expect(resolved.preflightDeclarations).toEqual([
+      expect.objectContaining({ preflightKind: 'credential', preflightDisposition: 'not-required' }),
+      expect.objectContaining({ preflightKind: 'connectivity', preflightDisposition: 'not-required' }),
+    ]);
+  });
+});


### PR DESCRIPTION
## 用户影响

为 Evaluation Core 增加首个生产评分 Runtime family：输出型确定性断言现在可以在 prepared Core plan 中产生逐 criterion 的 Boolean observation、分级 evidence 与明确 missingness。正式 `omk eval` 仍走旧 pipeline，本 PR 不切换 CLI、不双跑、不持久化新 Bundle，也不修改旧 Report。

## Construct validity

- assertion 只测量 criterion 是否通过，不在 Evaluator 内生成 assertion layer、dimension 或 composite；
- 样本不适用的 dataset-wide Metric 明确输出 `criterion-not-applicable`，不折算为零；
- cost、latency、turn、tool 与 mock 断言需要 Core-owned execution facts，在 #483 完成前严格拒绝路由到 output-only family；
- 新 Core 的 `json_schema` validator 不共享 Ajv registry，避免 criterion／record／run 之间被 `$id` 状态污染；该有意的旧语义差异由 #484 以 `BREAKING-COMPARABILITY` 单独跟踪。

## 测量与安全边界

Runtime identity 覆盖断言算法版本、支持类型、context／evidence schema 与实际 Ajv 版本。派生 evidence 继承所有输入中的最高 classification；Core 继续唯一拥有 retry、timeout、budget、cache、cancellation 与 lifecycle。冻结 prompt、统计公式、五层聚合口径和 length-debias 均未修改。

## 迁移说明

这是 #480 的独立实现切片，无历史 Core artifact 需要迁移。执行事实类断言后续依赖 #483；正式切换时必须同时处理 #484 的可比性说明。

Part of #480.
Related to #483 and #484.
