### PR TITLE
refactor(eval): BREAKING-COMPARABILITY 分离 LLM assertion 基础设施失败

### DIFF
--- a/docs/specs/evaluation-scoring-equivalence.md
+++ b/docs/specs/evaluation-scoring-equivalence.md
@@ -58,6 +58,10 @@ The host owns provider calls, prompt registry access, custom-module loading, and
 
 The Core never imports `PROMPT_REGISTRY`. The composition root resolves a frozen prompt and places its hash in the host Runtime identity. `lengthDebias=false` selects only the existing rubric debias-off instrument. Presentation and tone neutrality remain enabled. RAG and semantic prompts have no length-debias switch.
 
+Semantic and RAG assertions use `omk.llm-assertions/v1`. One Evaluator coordinate owns exactly one criterion and one Boolean Metric, so a provider failure cannot suppress or falsify an unrelated criterion. The sealed criterion retains threshold, positive weight, and fact-layer identity for downstream aggregation. The sealed instrument records the assertion type, registry prompt ID, and frozen prompt hash; the Runtime fingerprint additionally binds the selected model configuration and the host invocation Runtime identity. The host invocation port performs exactly one cooperative-cancellation-aware call. It has no retry, timeout, budget, or cache policy of its own.
+
+A strict integer reading in `[1, 5]` with a non-empty explanation produces an observed Boolean threshold result. Non-JSON, malformed JSON, malformed score, out-of-range score, and missing explanation produce distinct invalid observations. Provider failure produces a failed Evaluation record with a redacted stable code. Core timeout and cancellation remain attempt states, and admission failure remains budget censoring. Unknown usage or provider cost stays absent. This is the intentional `BREAKING-COMPARABILITY` correction owned by [#481](https://github.com/lizhiyao/oh-my-knowledge/issues/481); no compatibility mode or legacy reader is provided.
+
 Deterministic assertions are split into two independently identified families. The output-only family binds only output and evaluation context. The execution-aware family recursively computes each assertion tree's least-authority source union, then binds only the required subset of output, Core-owned `execution-facts`, source-neutral trace, and evaluation context. Criteria with different dependency signatures are separate Evaluator groups so unavailable trace cannot suppress a facts-only metric.
 
 Cost uses only a complete provider-reported USD aggregate from `ExecutionFacts.usage.providerCost`; unreported, partial, or mixed-currency cost is a missing observation, never zero. Latency uses trial wall-clock duration from `ExecutionFacts.timing.wallClockDurationMs`. Turn assertions use `omk.source-neutral-trace/v2`'s independent provider/runtime `numTurns` field, never transcript breadth (`fullNumTurns`), attempt count, or retry count. Tool assertions use source-neutral `toolCalls`; mock-hit assertions require source-neutral `mockStats` captured by the configured interception boundary. Missing telemetry remains missing rather than becoming a failed quality assertion. The v2 cutover is intentional and has no v1 compatibility reader: reusing the v1 identity for a different required-field set would make persisted evidence ambiguous.
@@ -92,7 +96,9 @@ Planned nodes are:
 
 Mixed-layer `assert-set` criteria remain visible assertion observations but are excluded from both fact and behavior. Zero total weight yields a missing layer. A failed rubric judge is missing, not score zero.
 
-The legacy RAG and semantic paths currently convert provider/parse failure into a failed Boolean assertion. That behavior is frozen by the equivalence fixture, but it is a measurement defect: infrastructure failure is not evidence that the answer failed the criterion. [#481](https://github.com/lizhiyao/oh-my-knowledge/issues/481) owns the separate `BREAKING-COMPARABILITY` correction; the Core representation must retain enough failure provenance to make that future correction possible.
+The legacy RAG and semantic paths convert provider/parse failure into a failed Boolean assertion. That behavior remains frozen only as historical differential evidence. The Core deliberately does not reproduce it: invalid readings and failed attempts are excluded from assertion-layer pass ratios and reduce coverage instead. A valid reading below the threshold remains observed `false`, so negative content evidence is still counted.
+
+The legacy async path also ignores the otherwise-public `Assertion.not` contract. That independent Boolean-semantics defect is tracked by [#489](https://github.com/lizhiyao/oh-my-knowledge/issues/489) and is not folded into the #481 failure-state correction.
 
 ## 7. Statistical standards
 
@@ -150,6 +156,8 @@ The first baseline is `test/fixtures/evaluation-core/scoring-equivalence-v1.json
 - interval Krippendorff alpha, weighted kappa, Pearson, and alpha bootstrap.
 
 Later migration tests consume the same fixture through the new Core path and compare observations, coverage, evidence, per-unit tables, interval results, usage provenance, and reason codes. Exact identity and status comparisons never use numeric tolerance. Floating-point tolerance is allowed only in formula property tests that are not artifact equality tests.
+
+The semantic/RAG conformance vectors additionally freeze the intentional failure-semantic break: valid pass, valid threshold fail, provider failure, non-JSON, malformed JSON, malformed score, out-of-range score, missing explanation, timeout, cancellation, budget censoring, unknown usage/cost, and the invariant that adding an infrastructure failure cannot lower an observed content pass rate.
 
 ## 11. Delivery slices
 

--- a/src/eval-workflows/runtime-adapter/evaluators/index.ts
+++ b/src/eval-workflows/runtime-adapter/evaluators/index.ts
@@ -1,2 +1,3 @@
 export * from './execution-assertions.js';
+export * from './llm-assertions.js';
 export * from './output-assertions.js';

--- a/src/eval-workflows/runtime-adapter/evaluators/llm-assertions.ts
+++ b/src/eval-workflows/runtime-adapter/evaluators/llm-assertions.ts
@@ -1,0 +1,786 @@
+import {
+  IdentifierSchema,
+  RuntimeIdentitySchema,
+  UsageRecordSchema,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  type JsonValue,
+  type RuntimeIdentity,
+  type UsageRecord,
+} from '../../../evaluation-core/contracts/index.js';
+import {
+  EvaluationPortFailure,
+  type EvaluatorBindingValue,
+  type EvaluatorObservation,
+} from '../../../evaluation-core/evaluation/index.js';
+import {
+  buildRagJudgePrompt,
+  buildSemanticSimilarityPrompt,
+  getRagJudgePromptHash,
+  getSemanticPromptHash,
+  SEMANTIC_SIMILARITY_SYSTEM,
+  type RagJudgeType,
+} from '../../../shared/llm-prompts/judge-prompts.js';
+import type { SameProcessEvaluatorImplementation } from '../adapters/same-process.js';
+import { createSameProcessEvaluatorAdapter } from '../adapters/same-process.js';
+import type {
+  OmkEvaluatorBindingContext,
+  OmkRuntimePortBinding,
+  OmkRuntimePreflightDeclaration,
+} from '../types.js';
+import {
+  assertionSchemaIdentity,
+  mostRestrictedAssertionClassification,
+} from './assertion-common.js';
+
+export const LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID =
+  'omk.llm-assertions/v1' as const;
+export const LLM_ASSERTION_INSTRUMENT_SCHEMA_VERSION =
+  'omk.llm-assertion-instrument/v1' as const;
+export const LLM_ASSERTION_CONTEXT_SCHEMA_VERSION =
+  'omk.llm-assertion-context/v1' as const;
+export const LLM_ASSERTION_EVIDENCE_SCHEMA_VERSION =
+  'omk.llm-assertion-evidence/v1' as const;
+export const LLM_ASSERTION_BINDINGS = Object.freeze({
+  actual: 'actual',
+  criterion: 'criterion',
+});
+
+export type LlmAssertionType =
+  | 'semantic_similarity'
+  | 'faithfulness'
+  | 'answer_relevancy'
+  | 'context_recall';
+
+interface LlmAssertionInstrument {
+  readonly schemaVersion: typeof LLM_ASSERTION_INSTRUMENT_SCHEMA_VERSION;
+  readonly assertionType: LlmAssertionType;
+  readonly promptId: string;
+  readonly promptHash: string;
+}
+
+interface LlmAssertionRuntimeConfig {
+  readonly executorId: string;
+  readonly model: string;
+  readonly effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+  readonly promptVariant: string;
+}
+
+interface LlmAssertionConfig {
+  readonly evaluator: {
+    readonly classification: 'public' | 'sensitive';
+    readonly value: LlmAssertionInstrument;
+  };
+  readonly runtime: LlmAssertionRuntimeConfig;
+}
+
+interface LlmAssertionCriterion {
+  readonly schemaVersion: typeof LLM_ASSERTION_CONTEXT_SCHEMA_VERSION;
+  readonly criterionId: string;
+  readonly assertionType: LlmAssertionType;
+  readonly threshold: number;
+  readonly weight: number;
+  readonly reference?: string;
+  readonly context?: string;
+  readonly question?: string;
+}
+
+export interface OmkLlmJudgeInvocationRequest {
+  readonly executorId: string;
+  readonly model: string;
+  readonly effort?: LlmAssertionRuntimeConfig['effort'];
+  readonly system: string;
+  readonly prompt: string;
+  readonly promptId: string;
+  readonly promptHash: string;
+  readonly signal: AbortSignal;
+}
+
+export type OmkLlmJudgeInvocationResult =
+  | {
+      readonly invocationStatus: 'completed';
+      readonly output: string;
+      readonly usage?: UsageRecord;
+    }
+  | {
+      readonly invocationStatus: 'failed';
+      /** Stable, non-sensitive provider failure category. */
+      readonly reasonCode: string;
+      readonly usage?: UsageRecord;
+    };
+
+/**
+ * Host-owned provider boundary. It must perform exactly one invocation and honor
+ * the supplied AbortSignal; retry, timeout, budget, and cache remain Core-owned.
+ */
+export interface OmkLlmJudgeInvocationPort {
+  readonly identity: RuntimeIdentity;
+  readonly providerCost: {
+    readonly reporting: 'unsupported' | 'optional' | 'required';
+    readonly trustedUpperBound?: { readonly amount: number; readonly currency: string };
+  };
+  invoke(
+    request: Readonly<OmkLlmJudgeInvocationRequest>,
+  ): Promise<OmkLlmJudgeInvocationResult>;
+}
+
+export interface OmkLlmJudgeInvocationBinding {
+  readonly port: OmkLlmJudgeInvocationPort;
+  readonly preflightDeclarations: readonly OmkRuntimePreflightDeclaration[];
+}
+
+export type OmkLlmJudgeInvocationResolver = (
+  context: Readonly<OmkEvaluatorBindingContext>,
+) => OmkLlmJudgeInvocationBinding | Promise<OmkLlmJudgeInvocationBinding>;
+
+const INSTRUMENT_SCHEMA_DOCUMENT: JsonValue = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'urn:omk:llm-assertion-instrument:v1',
+  type: 'object',
+  additionalProperties: false,
+  required: ['schemaVersion', 'assertionType', 'promptId', 'promptHash'],
+  properties: {
+    schemaVersion: { const: LLM_ASSERTION_INSTRUMENT_SCHEMA_VERSION },
+    assertionType: {
+      enum: ['semantic_similarity', 'faithfulness', 'answer_relevancy', 'context_recall'],
+    },
+    promptId: { type: 'string', minLength: 1 },
+    promptHash: { type: 'string', pattern: '^[0-9a-f]{12}$' },
+  },
+};
+
+const CONTEXT_SCHEMA_DOCUMENT: JsonValue = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'urn:omk:llm-assertion-context:v1',
+  type: 'object',
+  additionalProperties: false,
+  required: ['schemaVersion', 'criterionId', 'assertionType', 'threshold', 'weight'],
+  properties: {
+    schemaVersion: { const: LLM_ASSERTION_CONTEXT_SCHEMA_VERSION },
+    criterionId: { type: 'string', minLength: 1, maxLength: 256 },
+    assertionType: {
+      enum: ['semantic_similarity', 'faithfulness', 'answer_relevancy', 'context_recall'],
+    },
+    threshold: { type: 'number', minimum: 1, maximum: 5 },
+    weight: { type: 'number', exclusiveMinimum: 0 },
+    reference: { type: 'string', minLength: 1 },
+    context: { type: 'string', minLength: 1 },
+    question: { type: 'string', minLength: 1 },
+  },
+  oneOf: [
+    {
+      properties: { assertionType: { const: 'semantic_similarity' } },
+      required: ['reference'],
+    },
+    {
+      properties: { assertionType: { const: 'faithfulness' } },
+      required: ['context'],
+    },
+    {
+      properties: { assertionType: { const: 'answer_relevancy' } },
+      required: ['question'],
+    },
+    {
+      properties: { assertionType: { const: 'context_recall' } },
+      required: ['reference'],
+    },
+  ],
+};
+
+const EVIDENCE_SCHEMA_DOCUMENT: JsonValue = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'urn:omk:llm-assertion-evidence:v1',
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'schemaVersion',
+    'criterionId',
+    'assertionType',
+    'threshold',
+    'weight',
+    'layer',
+    'promptId',
+    'promptHash',
+    'score',
+    'reason',
+  ],
+  properties: {
+    schemaVersion: { const: LLM_ASSERTION_EVIDENCE_SCHEMA_VERSION },
+    criterionId: { type: 'string' },
+    assertionType: { type: 'string' },
+    threshold: { type: 'number' },
+    weight: { type: 'number', exclusiveMinimum: 0 },
+    layer: { const: 'fact' },
+    promptId: { type: 'string' },
+    promptHash: { type: 'string' },
+    score: { type: 'integer', minimum: 1, maximum: 5 },
+    reason: { type: 'string', minLength: 1 },
+  },
+};
+
+export const LLM_ASSERTION_INSTRUMENT_SCHEMA = assertionSchemaIdentity(
+  LLM_ASSERTION_INSTRUMENT_SCHEMA_VERSION,
+  'urn:omk:llm-assertion-instrument:v1',
+  INSTRUMENT_SCHEMA_DOCUMENT,
+);
+export const LLM_ASSERTION_CONTEXT_SCHEMA = assertionSchemaIdentity(
+  LLM_ASSERTION_CONTEXT_SCHEMA_VERSION,
+  'urn:omk:llm-assertion-context:v1',
+  CONTEXT_SCHEMA_DOCUMENT,
+);
+export const LLM_ASSERTION_EVIDENCE_SCHEMA = assertionSchemaIdentity(
+  LLM_ASSERTION_EVIDENCE_SCHEMA_VERSION,
+  'urn:omk:llm-assertion-evidence:v1',
+  EVIDENCE_SCHEMA_DOCUMENT,
+);
+
+const INSTRUMENTS: Readonly<Record<LlmAssertionType, Readonly<{
+  promptId: string;
+  promptHash: string;
+}>>> = Object.freeze({
+  semantic_similarity: {
+    promptId: 'semantic-similarity',
+    promptHash: getSemanticPromptHash(),
+  },
+  faithfulness: {
+    promptId: 'rag-faithfulness',
+    promptHash: getRagJudgePromptHash('faithfulness'),
+  },
+  answer_relevancy: {
+    promptId: 'rag-answer-relevancy',
+    promptHash: getRagJudgePromptHash('answer_relevancy'),
+  },
+  context_recall: {
+    promptId: 'rag-context-recall',
+    promptHash: getRagJudgePromptHash('context_recall'),
+  },
+});
+
+const ALGORITHM_VERSION = 'omk.llm-assertion-reading/v1' as const;
+const LLM_ASSERTION_TYPES = new Set<LlmAssertionType>([
+  'semantic_similarity',
+  'faithfulness',
+  'answer_relevancy',
+  'context_recall',
+]);
+
+interface RecordState {
+  readonly actual: string;
+  readonly criterion: LlmAssertionCriterion;
+  readonly instrument: LlmAssertionInstrument;
+  readonly runtime: LlmAssertionRuntimeConfig;
+  readonly metricId: string;
+  readonly evidenceClassification: EvaluatorBindingValue['classification'];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const canonical = [...expected].sort();
+  return actual.length === canonical.length
+    && actual.every((key, index) => key === canonical[index]);
+}
+
+function failure(code: string, message: string, usage?: UsageRecord): never {
+  throw new EvaluationPortFailure({ code, stage: 'evaluation', message }, usage);
+}
+
+function parseInstrument(value: unknown): LlmAssertionInstrument {
+  if (!isRecord(value)
+      || !exactKeys(value, ['schemaVersion', 'assertionType', 'promptId', 'promptHash'])
+      || value.schemaVersion !== LLM_ASSERTION_INSTRUMENT_SCHEMA_VERSION
+      || typeof value.assertionType !== 'string'
+      || !LLM_ASSERTION_TYPES.has(value.assertionType as LlmAssertionType)
+      || typeof value.promptId !== 'string'
+      || typeof value.promptHash !== 'string') {
+    return failure(
+      'omk-llm-assertion-instrument-invalid',
+      'LLM assertion instrument configuration is invalid.',
+    );
+  }
+  const assertionType = value.assertionType as LlmAssertionType;
+  const expected = INSTRUMENTS[assertionType];
+  if (value.promptId !== expected.promptId || value.promptHash !== expected.promptHash) {
+    return failure(
+      'omk-llm-assertion-prompt-identity-mismatch',
+      'LLM assertion prompt identity differs from the frozen registry.',
+    );
+  }
+  return Object.freeze({
+    schemaVersion: LLM_ASSERTION_INSTRUMENT_SCHEMA_VERSION,
+    assertionType,
+    promptId: value.promptId,
+    promptHash: value.promptHash,
+  });
+}
+
+function parseRuntime(value: unknown): LlmAssertionRuntimeConfig {
+  if (!isRecord(value)
+      || !exactKeys(value, [
+        'executorId',
+        'model',
+        'promptVariant',
+        ...('effort' in value ? ['effort'] : []),
+      ])
+      || typeof value.executorId !== 'string' || value.executorId === ''
+      || typeof value.model !== 'string' || value.model === ''
+      || typeof value.promptVariant !== 'string' || value.promptVariant === ''
+      || (value.effort !== undefined
+        && !['low', 'medium', 'high', 'xhigh', 'max'].includes(String(value.effort)))) {
+    return failure(
+      'omk-llm-assertion-runtime-invalid',
+      'LLM assertion runtime configuration is invalid.',
+    );
+  }
+  return Object.freeze({
+    executorId: value.executorId,
+    model: value.model,
+    promptVariant: value.promptVariant,
+    ...(value.effort === undefined
+      ? {}
+      : { effort: value.effort as LlmAssertionRuntimeConfig['effort'] }),
+  });
+}
+
+function parseConfig(value: unknown): LlmAssertionConfig {
+  if (!isRecord(value)
+      || !exactKeys(value, ['evaluator', 'runtime'])
+      || !isRecord(value.evaluator)
+      || !exactKeys(value.evaluator, ['classification', 'value'])
+      || !['public', 'sensitive'].includes(String(value.evaluator.classification))) {
+    return failure(
+      'omk-llm-assertion-config-invalid',
+      'LLM assertion Evaluator requires a sealed instrument and runtime configuration.',
+    );
+  }
+  const instrument = parseInstrument(value.evaluator.value);
+  const runtime = parseRuntime(value.runtime);
+  if (runtime.promptVariant !== instrument.promptId) {
+    return failure(
+      'omk-llm-assertion-prompt-variant-mismatch',
+      'LLM assertion runtime prompt variant differs from the sealed instrument.',
+    );
+  }
+  return Object.freeze({
+    evaluator: {
+      classification: value.evaluator.classification as 'public' | 'sensitive',
+      value: instrument,
+    },
+    runtime,
+  });
+}
+
+function parseCriterion(value: unknown): LlmAssertionCriterion {
+  if (!isRecord(value)
+      || !exactKeys(value, [
+        'schemaVersion',
+        'criterionId',
+        'assertionType',
+        'threshold',
+        'weight',
+        ...('reference' in value ? ['reference'] : []),
+        ...('context' in value ? ['context'] : []),
+        ...('question' in value ? ['question'] : []),
+      ])
+      || value.schemaVersion !== LLM_ASSERTION_CONTEXT_SCHEMA_VERSION
+      || typeof value.criterionId !== 'string'
+      || !IdentifierSchema.safeParse(value.criterionId).success
+      || typeof value.assertionType !== 'string'
+      || !LLM_ASSERTION_TYPES.has(value.assertionType as LlmAssertionType)
+      || typeof value.threshold !== 'number'
+      || !Number.isFinite(value.threshold)
+      || value.threshold < 1 || value.threshold > 5
+      || typeof value.weight !== 'number'
+      || !Number.isFinite(value.weight)
+      || value.weight <= 0) {
+    return failure(
+      'omk-llm-assertion-criterion-invalid',
+      'LLM assertion criterion is invalid.',
+    );
+  }
+  const assertionType = value.assertionType as LlmAssertionType;
+  const expectedField = assertionType === 'faithfulness'
+    ? 'context'
+    : assertionType === 'answer_relevancy'
+      ? 'question'
+      : 'reference';
+  const textFields = ['reference', 'context', 'question'] as const;
+  if (textFields.some((field) => (
+    value[field] !== undefined
+    && (typeof value[field] !== 'string' || value[field] === '')
+  ))
+      || typeof value[expectedField] !== 'string'
+      || value[expectedField] === ''
+      || textFields.some((field) => field !== expectedField && value[field] !== undefined)) {
+    return failure(
+      'omk-llm-assertion-criterion-input-invalid',
+      'LLM assertion criterion does not contain its exact required reference input.',
+    );
+  }
+  return Object.freeze({
+    schemaVersion: LLM_ASSERTION_CONTEXT_SCHEMA_VERSION,
+    criterionId: value.criterionId,
+    assertionType,
+    threshold: value.threshold,
+    weight: value.weight,
+    [expectedField]: value[expectedField],
+  }) as unknown as LlmAssertionCriterion;
+}
+
+function binding(
+  bindings: readonly EvaluatorBindingValue[],
+  bindingId: string,
+  sourceKind: EvaluatorBindingValue['sourceKind'],
+): EvaluatorBindingValue {
+  const candidates = bindings.filter((candidate) => candidate.bindingId === bindingId);
+  if (candidates.length !== 1 || candidates[0].sourceKind !== sourceKind) {
+    return failure(
+      'omk-llm-assertion-binding-invalid',
+      'LLM assertion Evaluator received an invalid binding set.',
+    );
+  }
+  return candidates[0];
+}
+
+function buildPrompt(
+  criterion: LlmAssertionCriterion,
+  actual: string,
+): { system: string; prompt: string } {
+  if (criterion.assertionType === 'semantic_similarity') {
+    return {
+      system: SEMANTIC_SIMILARITY_SYSTEM,
+      prompt: buildSemanticSimilarityPrompt(criterion.reference as string, actual),
+    };
+  }
+  const type = criterion.assertionType as RagJudgeType;
+  if (type === 'faithfulness') {
+    return buildRagJudgePrompt(type, { output: actual, context: criterion.context });
+  }
+  if (type === 'answer_relevancy') {
+    return buildRagJudgePrompt(type, { output: actual, question: criterion.question });
+  }
+  return buildRagJudgePrompt(type, { output: actual, reference: criterion.reference });
+}
+
+type JudgeReading = { readonly score: number; readonly reason: string };
+
+function invalidObservation(
+  state: RecordState,
+  reasonCode: string,
+): EvaluatorObservation {
+  return {
+    metricId: state.metricId,
+    observationStatus: 'invalid',
+    valueType: 'boolean',
+    reasonCode,
+  };
+}
+
+function parseReading(
+  state: RecordState,
+  output: string,
+): JudgeReading | EvaluatorObservation {
+  const match = output.trim().match(/\{[\s\S]*\}/);
+  if (match === null) return invalidObservation(state, 'judge-response-non-json');
+  let value: unknown;
+  try {
+    value = JSON.parse(match[0]);
+  } catch {
+    return invalidObservation(state, 'judge-response-malformed-json');
+  }
+  if (!isRecord(value) || typeof value.score !== 'number' || !Number.isInteger(value.score)) {
+    return invalidObservation(state, 'judge-score-malformed');
+  }
+  if (value.score < 1 || value.score > 5) {
+    return invalidObservation(state, 'judge-score-out-of-range');
+  }
+  if (typeof value.reason !== 'string' || value.reason.trim() === '') {
+    return invalidObservation(state, 'judge-reason-missing');
+  }
+  return { score: value.score, reason: value.reason };
+}
+
+function usage(value: UsageRecord | undefined): UsageRecord | undefined {
+  if (value === undefined) return undefined;
+  const parsed = UsageRecordSchema.safeParse(value);
+  if (!parsed.success) {
+    return failure(
+      'omk-llm-assertion-usage-invalid',
+      'LLM judge returned invalid usage telemetry.',
+    );
+  }
+  return parsed.data;
+}
+
+function failureUsage(value: UsageRecord | undefined): UsageRecord | undefined {
+  const measured = usage(value);
+  if (measured === undefined) return undefined;
+  return {
+    ...(measured.inputTokens === undefined ? {} : { inputTokens: measured.inputTokens }),
+    ...(measured.outputTokens === undefined ? {} : { outputTokens: measured.outputTokens }),
+    ...(measured.totalTokens === undefined ? {} : { totalTokens: measured.totalTokens }),
+    ...(measured.providerCost === undefined ? {} : { providerCost: measured.providerCost }),
+  };
+}
+
+function captureInvocationPort(
+  value: OmkLlmJudgeInvocationPort,
+): OmkLlmJudgeInvocationPort {
+  const identity = RuntimeIdentitySchema.safeParse(value?.identity);
+  const providerCost = value?.providerCost;
+  const trustedUpperBound = providerCost?.trustedUpperBound;
+  if (!identity.success
+      || typeof value?.invoke !== 'function'
+      || !['unsupported', 'optional', 'required'].includes(String(providerCost?.reporting))
+      || (trustedUpperBound !== undefined
+        && (providerCost.reporting !== 'required'
+          || !Number.isFinite(trustedUpperBound.amount)
+          || trustedUpperBound.amount < 0
+          || !/^[A-Z]{3}$/.test(trustedUpperBound.currency)))) {
+    return failure(
+      'omk-llm-assertion-provider-port-invalid',
+      'LLM judge invocation port is invalid.',
+    );
+  }
+  const invoke = value.invoke;
+  return Object.freeze({
+    identity: deepFreezeCanonicalJson(identity.data),
+    providerCost: Object.freeze({
+      reporting: providerCost.reporting,
+      ...(trustedUpperBound === undefined ? {} : {
+        trustedUpperBound: Object.freeze({ ...trustedUpperBound }),
+      }),
+    }),
+    invoke: (request: Readonly<OmkLlmJudgeInvocationRequest>) => Reflect.apply(
+      invoke,
+      value,
+      [request],
+    ) as Promise<
+      OmkLlmJudgeInvocationResult
+    >,
+  });
+}
+
+function assertInvocationResult(value: unknown): asserts value is OmkLlmJudgeInvocationResult {
+  if (!isRecord(value)
+      || !['completed', 'failed'].includes(String(value.invocationStatus))
+      || (value.invocationStatus === 'completed' && typeof value.output !== 'string')
+      || (value.invocationStatus === 'failed'
+        && (typeof value.reasonCode !== 'string'
+          || !IdentifierSchema.safeParse(value.reasonCode).success))) {
+    return failure(
+      'omk-llm-assertion-provider-result-invalid',
+      'LLM judge invocation port returned an invalid result.',
+    );
+  }
+}
+
+function observed(
+  state: RecordState,
+  reading: JudgeReading,
+): EvaluatorObservation {
+  return {
+    metricId: state.metricId,
+    observationStatus: 'observed',
+    valueType: 'boolean',
+    value: reading.score >= state.criterion.threshold,
+    evidence: {
+      value: {
+        schemaVersion: LLM_ASSERTION_EVIDENCE_SCHEMA_VERSION,
+        criterionId: state.criterion.criterionId,
+        assertionType: state.criterion.assertionType,
+        threshold: state.criterion.threshold,
+        weight: state.criterion.weight,
+        layer: 'fact',
+        promptId: state.instrument.promptId,
+        promptHash: state.instrument.promptHash,
+        score: reading.score,
+        reason: reading.reason,
+      },
+      classification: state.evidenceClassification,
+    },
+  };
+}
+
+export function createLlmAssertionEvaluatorIdentity(input: Readonly<{
+  instrument: LlmAssertionInstrument;
+  runtime: LlmAssertionRuntimeConfig;
+  invocation: OmkLlmJudgeInvocationPort;
+}>): RuntimeIdentity {
+  const invocation = captureInvocationPort(input.invocation);
+  const capabilities: JsonValue = {
+    inputSourceKinds: ['evaluation-context', 'output'],
+    metricValueTypes: ['boolean'],
+    schemas: [
+      LLM_ASSERTION_CONTEXT_SCHEMA,
+      LLM_ASSERTION_EVIDENCE_SCHEMA,
+      LLM_ASSERTION_INSTRUMENT_SCHEMA,
+    ],
+    providerCost: invocation.providerCost,
+  };
+  return deepFreezeCanonicalJson(RuntimeIdentitySchema.parse({
+    implementationId: LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+    version: '1.0.0',
+    fingerprint: digestCanonicalJson({
+      implementationId: LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+      algorithmVersion: ALGORITHM_VERSION,
+      instrument: input.instrument,
+      runtime: input.runtime,
+      invocationRuntime: invocation.identity,
+      capabilities,
+    }),
+    fingerprintBasis: 'content-derived',
+    assuranceLevel: invocation.identity.assuranceLevel,
+    capabilities,
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
+  }));
+}
+
+export function createLlmAssertionEvaluatorImplementation(
+  invocation: OmkLlmJudgeInvocationPort,
+): SameProcessEvaluatorImplementation<undefined, RecordState> {
+  const capturedInvocation = captureInvocationPort(invocation);
+  const implementation: SameProcessEvaluatorImplementation<undefined, RecordState> = {
+    openRun: () => undefined,
+    openRecord({ record }): RecordState {
+      if (record.bindings.length !== 2 || record.evaluatorConfig === undefined) {
+        return failure(
+          'omk-llm-assertion-record-invalid',
+          'LLM assertion Evaluator received an unsupported record configuration.',
+        );
+      }
+      const config = parseConfig(record.evaluatorConfig);
+      const actual = binding(record.bindings, LLM_ASSERTION_BINDINGS.actual, 'output');
+      const criterionBinding = binding(
+        record.bindings,
+        LLM_ASSERTION_BINDINGS.criterion,
+        'evaluation-context',
+      );
+      const criterion = parseCriterion(criterionBinding.value);
+      if (typeof actual.value !== 'string'
+          || criterion.assertionType !== config.evaluator.value.assertionType
+          || record.metrics.length !== 1
+          || record.metrics[0].valueType !== 'boolean'
+          || record.metrics[0].direction !== 'higher-is-better') {
+        return failure(
+          'omk-llm-assertion-contract-mismatch',
+          'LLM assertion record differs from its sealed instrument or Metric contract.',
+        );
+      }
+      return Object.freeze({
+        actual: actual.value,
+        criterion,
+        instrument: config.evaluator.value,
+        runtime: config.runtime,
+        metricId: record.metrics[0].metricId,
+        evidenceClassification: mostRestrictedAssertionClassification(
+          actual.classification,
+          criterionBinding.classification,
+        ),
+      });
+    },
+    async evaluate({ recordState, attempt }) {
+      if (attempt.signal.aborted) throw attempt.signal.reason;
+      const built = buildPrompt(recordState.criterion, recordState.actual);
+      let result: OmkLlmJudgeInvocationResult;
+      try {
+        result = await capturedInvocation.invoke({
+          executorId: recordState.runtime.executorId,
+          model: recordState.runtime.model,
+          ...(recordState.runtime.effort === undefined
+            ? {}
+            : { effort: recordState.runtime.effort }),
+          system: built.system,
+          prompt: built.prompt,
+          promptId: recordState.instrument.promptId,
+          promptHash: recordState.instrument.promptHash,
+          signal: attempt.signal,
+        });
+      } catch {
+        if (attempt.signal.aborted) throw attempt.signal.reason;
+        return failure(
+          'judge-provider-failure',
+          'LLM judge provider invocation failed.',
+        );
+      }
+      if (attempt.signal.aborted) throw attempt.signal.reason;
+      assertInvocationResult(result);
+      if (result.invocationStatus === 'failed') {
+        return failure(
+          'judge-provider-failure',
+          'LLM judge provider reported a structured failure.',
+          failureUsage(result.usage),
+        );
+      }
+      const measuredUsage = usage(result.usage);
+      const reading = parseReading(recordState, result.output);
+      return {
+        observations: ['observationStatus' in reading
+          ? reading
+          : observed(recordState, reading)],
+        ...(measuredUsage === undefined ? {} : { usage: measuredUsage }),
+      };
+    },
+    disposeRecord: () => undefined,
+    disposeRun: () => undefined,
+  };
+  return Object.freeze(implementation);
+}
+
+/** Builds the host factory without introducing a second control plane for model calls. */
+export function createLlmAssertionEvaluatorBindingFactory(
+  resolveInvocation: OmkLlmJudgeInvocationResolver,
+): (
+  context: Readonly<OmkEvaluatorBindingContext>,
+) => Promise<OmkRuntimePortBinding<ReturnType<typeof createSameProcessEvaluatorAdapter>>> {
+  return async (context) => {
+    const config = parseConfig(context.evaluator.config);
+    const qualification = context.binding.qualification;
+    if (qualification === undefined
+        || qualification.executorId !== config.runtime.executorId
+        || qualification.model !== config.runtime.model
+        || qualification.effort !== config.runtime.effort
+        || qualification.promptVariant !== config.runtime.promptVariant) {
+      return failure(
+        'omk-llm-assertion-runtime-binding-mismatch',
+        'LLM assertion Runtime binding differs from the sealed Evaluator configuration.',
+      );
+    }
+    const resolved = await resolveInvocation(context);
+    const invocation = captureInvocationPort(resolved.port);
+    if (invocation.identity.implementationId !== config.runtime.executorId) {
+      return failure(
+        'omk-llm-assertion-provider-identity-mismatch',
+        'LLM judge invocation Runtime identity differs from the selected executor.',
+      );
+    }
+    const identity = createLlmAssertionEvaluatorIdentity({
+      instrument: config.evaluator.value,
+      runtime: config.runtime,
+      invocation,
+    });
+    return {
+      port: createSameProcessEvaluatorAdapter({
+        identity,
+        sessionIsolationKey: context.sessionIsolationKey,
+        resourceLeases: context.resourceLeases,
+        implementation: createLlmAssertionEvaluatorImplementation(invocation),
+      }),
+      satisfiesVersionConstraint: true,
+      preflightDeclarations: resolved.preflightDeclarations,
+    };
+  };
+}
+
+export function llmAssertionInstrument(assertionType: LlmAssertionType): LlmAssertionInstrument {
+  const instrument = INSTRUMENTS[assertionType];
+  return deepFreezeCanonicalJson({
+    schemaVersion: LLM_ASSERTION_INSTRUMENT_SCHEMA_VERSION,
+    assertionType,
+    promptId: instrument.promptId,
+    promptHash: instrument.promptHash,
+  });
+}

--- a/test/eval-workflows/runtime-adapter/llm-assertions.test.ts
+++ b/test/eval-workflows/runtime-adapter/llm-assertions.test.ts
@@ -1,0 +1,782 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  EvaluationDefinition,
+  JsonValue,
+  MeasurementPolicy,
+  RuntimeIdentity,
+  UsageRecord,
+} from '../../../src/evaluation-core/contracts/index.js';
+import {
+  RuntimeIdentitySchema,
+  digestCanonicalJson,
+} from '../../../src/evaluation-core/contracts/index.js';
+import {
+  prepareEvaluationPlan,
+  type PreparationRuntime,
+} from '../../../src/evaluation-core/compiler/index.js';
+import {
+  executeRunPlanSource,
+  InMemoryRuntimeEventSequencer,
+  type ExecutionClock,
+  type ExecutionExecutor,
+} from '../../../src/evaluation-core/execution/index.js';
+import {
+  evaluateExecutionBundle,
+  type EvaluationCache,
+  type EvaluationCacheEntry,
+} from '../../../src/evaluation-core/evaluation/index.js';
+import {
+  createLlmAssertionEvaluatorBindingFactory,
+  createLlmAssertionEvaluatorIdentity,
+  createLlmAssertionEvaluatorImplementation,
+  createSameProcessEvaluatorAdapter,
+  llmAssertionInstrument,
+  LLM_ASSERTION_BINDINGS,
+  LLM_ASSERTION_CONTEXT_SCHEMA_VERSION,
+  LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+  type LlmAssertionType,
+  type OmkLlmJudgeInvocationPort,
+  type OmkLlmJudgeInvocationRequest,
+  type OmkLlmJudgeInvocationResult,
+} from '../../../src/eval-workflows/runtime-adapter/index.js';
+import {
+  getRagJudgePromptHash,
+  getSemanticPromptHash,
+} from '../../../src/shared/llm-prompts/judge-prompts.js';
+import { runAsyncAssertions } from '../../../src/grading/assertions.js';
+import type { ExecutorFn } from '../../../src/types/index.js';
+import { testRuntime, validDefinition, validPolicy } from '../../evaluation-core/compiler/fixtures.js';
+
+const PROVIDER_IMPLEMENTATION_ID = 'test.llm-provider/v1';
+const METRIC_ID = 'llm-assertion-pass';
+
+type InvocationHandler = (
+  request: Readonly<OmkLlmJudgeInvocationRequest>,
+) => Promise<OmkLlmJudgeInvocationResult>;
+
+class TestClock implements ExecutionClock {
+  #now = 0;
+  readonly #timeoutImmediately: boolean;
+
+  constructor(timeoutImmediately = false) {
+    this.#timeoutImmediately = timeoutImmediately;
+  }
+
+  monotonicNow(): number {
+    const value = this.#now;
+    this.#now += 1;
+    return value;
+  }
+
+  timestamp(): string {
+    return '2026-08-31T00:00:00.000Z';
+  }
+
+  async sleep(_delayMs: number, signal: AbortSignal): Promise<void> {
+    if (signal.aborted) throw signal.reason;
+    if (this.#timeoutImmediately) return;
+    await new Promise<never>((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    });
+  }
+}
+
+class MemoryEvaluationCache implements EvaluationCache {
+  readonly #entries = new Map<string, EvaluationCacheEntry>();
+
+  async get(cacheKeyDigest: string): Promise<EvaluationCacheEntry | undefined> {
+    const entry = this.#entries.get(cacheKeyDigest);
+    return entry === undefined ? undefined : structuredClone(entry);
+  }
+
+  async put(entry: Readonly<EvaluationCacheEntry>): Promise<void> {
+    this.#entries.set(entry.cacheKeyDigest, structuredClone(entry));
+  }
+}
+
+function providerIdentity(): RuntimeIdentity {
+  return RuntimeIdentitySchema.parse({
+    implementationId: PROVIDER_IMPLEMENTATION_ID,
+    version: '1.0.0',
+    fingerprint: digestCanonicalJson({ provider: PROVIDER_IMPLEMENTATION_ID, version: 1 }),
+    fingerprintBasis: 'content-derived',
+    assuranceLevel: 'verified',
+    capabilities: { invocation: 'single-call', cancellation: 'cooperative' },
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
+  });
+}
+
+function invocationPort(
+  handler: InvocationHandler,
+  reporting: 'unsupported' | 'optional' | 'required' = 'optional',
+): OmkLlmJudgeInvocationPort {
+  return Object.freeze({
+    identity: providerIdentity(),
+    providerCost: { reporting },
+    invoke: handler,
+  });
+}
+
+function criterion(
+  assertionType: LlmAssertionType,
+  threshold = 3,
+): JsonValue {
+  let source: Record<string, JsonValue>;
+  if (assertionType === 'faithfulness') {
+    source = { context: 'The answer is grounded in this context.' };
+  } else if (assertionType === 'answer_relevancy') {
+    source = { question: 'What is the answer?' };
+  } else {
+    source = { reference: 'Expected answer' };
+  }
+  return {
+    schemaVersion: LLM_ASSERTION_CONTEXT_SCHEMA_VERSION,
+    criterionId: `${assertionType.replaceAll('_', '-')}-criterion`,
+    assertionType,
+    threshold,
+    weight: 1,
+    ...source,
+  };
+}
+
+function evaluatorConfig(assertionType: LlmAssertionType): JsonValue {
+  const instrument = llmAssertionInstrument(assertionType);
+  return {
+    evaluator: {
+      classification: 'public',
+      value: instrument as unknown as JsonValue,
+    },
+    runtime: {
+      executorId: PROVIDER_IMPLEMENTATION_ID,
+      model: 'judge-model',
+      effort: 'low',
+      promptVariant: instrument.promptId,
+    },
+  } as JsonValue;
+}
+
+function definition(assertionType: LlmAssertionType): EvaluationDefinition {
+  const value = validDefinition();
+  value.dataset.samples[0].evaluationContext = {
+    llmAssertion: criterion(assertionType),
+  };
+  value.evaluators = [{
+    evaluatorId: 'llm-assertion',
+    evaluatorKind: assertionType,
+    implementationId: LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+    measurement: {
+      instrumentId: llmAssertionInstrument(assertionType).promptId,
+      ensembleMemberId: 'provider-member',
+      replicateGroupId: `${assertionType.replaceAll('_', '-')}-primary`,
+      replicateIndex: 0,
+    },
+    metricIds: [METRIC_ID],
+    inputs: [
+      { bindingId: LLM_ASSERTION_BINDINGS.actual, sourceKind: 'output', pointer: '/answer' },
+      {
+        bindingId: LLM_ASSERTION_BINDINGS.criterion,
+        sourceKind: 'evaluation-context',
+        pointer: '/llmAssertion',
+      },
+    ],
+    config: evaluatorConfig(assertionType),
+  }];
+  value.metrics = [{
+    metricId: METRIC_ID,
+    valueType: 'boolean',
+    scope: 'sample',
+    direction: 'higher-is-better',
+    missingPolicyId: 'exclude/v1',
+  }];
+  value.analysisGraph.nodes = [{
+    analysisNodeKind: 'reducer',
+    nodeId: 'llm-assertion-rate',
+    implementationId: 'descriptive.rate/v1',
+    inputs: [{ inputKind: 'metric-observations', referenceId: METRIC_ID }],
+    outputResultId: 'llm-assertion-rate',
+  }];
+  value.comparisons[0].metricIds = [METRIC_ID];
+  value.decisionPolicy = {
+    decisionPolicyId: 'release-gate',
+    implementationId: 'progress/v1',
+    analysisResultIds: ['llm-assertion-rate'],
+    minimumEvidenceStatus: 'complete',
+    parameters: { threshold: 0 },
+  };
+  return value;
+}
+
+function policy(input: {
+  timeout?: boolean;
+  evaluationInvocations?: number;
+  retryProviderFailure?: boolean;
+} = {}): MeasurementPolicy {
+  const value = validPolicy();
+  value.retry.maxAttempts = 1;
+  delete value.execution.timeoutMs;
+  value.evaluation.retry.maxAttempts = 1;
+  value.evaluation.retry.retryableErrorCodes = [];
+  if (input.retryProviderFailure === true) {
+    value.evaluation.retry.maxAttempts = 2;
+    value.evaluation.retry.retryableErrorCodes = ['judge-provider-failure'];
+    value.evaluation.retry.backoff = {
+      backoffKind: 'none',
+      initialDelayMs: 0,
+    };
+  }
+  if (input.timeout === true) value.evaluation.timeoutMs = 1;
+  else delete value.evaluation.timeoutMs;
+  value.evidence.trace = 'none';
+  value.evidence.evidence = 'full';
+  value.evidence.maximumClassification = 'gold';
+  if (input.evaluationInvocations !== undefined) {
+    value.budget.stages.evaluation.maxInvocations = input.evaluationInvocations;
+  }
+  return value;
+}
+
+function evaluatorIdentity(
+  assertionType: LlmAssertionType,
+  port: OmkLlmJudgeInvocationPort,
+): RuntimeIdentity {
+  const config = evaluatorConfig(assertionType) as unknown as {
+    evaluator: { value: ReturnType<typeof llmAssertionInstrument> };
+    runtime: {
+      executorId: string;
+      model: string;
+      effort: 'low';
+      promptVariant: string;
+    };
+  };
+  return createLlmAssertionEvaluatorIdentity({
+    instrument: config.evaluator.value,
+    runtime: config.runtime,
+    invocation: port,
+  });
+}
+
+function preparationRuntime(identity: RuntimeIdentity): PreparationRuntime {
+  const base = testRuntime();
+  return {
+    ...base,
+    resolveEvaluator() {
+      return { identity, satisfiesVersionConstraint: true };
+    },
+  };
+}
+
+function runtimeIdentity(
+  plan: Awaited<ReturnType<typeof prepareEvaluationPlan>>,
+  runtimeKind: 'executor' | 'evaluator',
+  referenceId: string,
+): RuntimeIdentity {
+  const stage = runtimeKind === 'executor' ? plan.execution : plan.evaluation;
+  const runtime = stage.runtimes.find((candidate) => (
+    candidate.runtimeKind === runtimeKind && candidate.referenceId === referenceId
+  ));
+  if (runtime === undefined) throw new Error(`Missing ${runtimeKind} runtime ${referenceId}`);
+  return RuntimeIdentitySchema.parse(structuredClone(runtime.identity));
+}
+
+function executor(
+  plan: Awaited<ReturnType<typeof prepareEvaluationPlan>>,
+): ExecutionExecutor {
+  return {
+    identity: runtimeIdentity(plan, 'executor', 'control'),
+    async openRun() {
+      return {
+        async openTrial() {
+          return {
+            async execute() {
+              return {
+                output: {
+                  value: { answer: 'Actual answer' },
+                  classification: 'public' as const,
+                },
+              };
+            },
+            dispose() {},
+          };
+        },
+        dispose() {},
+      };
+    },
+  };
+}
+
+async function runCore(input: {
+  assertionType?: LlmAssertionType;
+  handler: InvocationHandler;
+  policy?: MeasurementPolicy;
+  clock?: TestClock;
+  signal?: AbortSignal;
+  reporting?: 'unsupported' | 'optional' | 'required';
+  cache?: EvaluationCache;
+}) {
+  const assertionType = input.assertionType ?? 'semantic_similarity';
+  const provider = invocationPort(input.handler, input.reporting);
+  const identity = evaluatorIdentity(assertionType, provider);
+  const sealed = await prepareEvaluationPlan(
+    definition(assertionType),
+    input.policy ?? policy(),
+    preparationRuntime(identity),
+  );
+  const clock = input.clock ?? new TestClock();
+  const eventSequencer = new InMemoryRuntimeEventSequencer();
+  const execution = await executeRunPlanSource(sealed, {
+    executorsByTargetId: new Map(sealed.execution.targets.map((target) => [
+      target.targetId,
+      executor(sealed),
+    ])),
+    clock,
+    eventSequencer,
+  }, { runId: 'llm-assertion-run', bundleId: 'llm-assertion-execution' });
+  const evaluator = createSameProcessEvaluatorAdapter({
+    identity,
+    sessionIsolationKey: 'llm-assertion-session',
+    resourceLeases: {
+      forRun: () => ({
+        bindingId: 'llm-assertion-binding',
+        consumerKind: 'evaluator',
+        resourcesByResourceId: new Map(),
+      }),
+    },
+    implementation: createLlmAssertionEvaluatorImplementation(provider),
+  });
+  const lifecycle = { runDisposals: 0, recordDisposals: 0 };
+  const instrumentedEvaluator = {
+    identity: evaluator.identity,
+    async openRun(context: Parameters<typeof evaluator.openRun>[0]) {
+      const run = await evaluator.openRun(context);
+      return {
+        async openRecord(recordContext: Parameters<typeof run.openRecord>[0]) {
+          const record = await run.openRecord(recordContext);
+          return {
+            evaluate: record.evaluate.bind(record),
+            async dispose() {
+              lifecycle.recordDisposals += 1;
+              await record.dispose();
+            },
+          };
+        },
+        async dispose() {
+          lifecycle.runDisposals += 1;
+          await run.dispose();
+        },
+      };
+    },
+  };
+  const evaluation = await evaluateExecutionBundle(sealed, execution, {
+    evaluatorsByEvaluatorId: new Map([['llm-assertion', instrumentedEvaluator]]),
+    clock,
+    eventSequencer,
+    ...(input.cache === undefined ? {} : { cache: input.cache }),
+  }, {
+    runId: 'llm-assertion-run',
+    bundleId: 'llm-assertion-evaluation',
+    ...(input.signal === undefined ? {} : { signal: input.signal }),
+  });
+  return { sealed, execution, evaluation, provider, lifecycle };
+}
+
+function completedObservations(
+  result: Awaited<ReturnType<typeof runCore>>,
+) {
+  return result.evaluation.records.flatMap((record) => (
+    record.evaluationStatus === 'completed' ? record.observations : []
+  ));
+}
+
+const COMPLETE_USAGE: UsageRecord = {
+  inputTokens: 10,
+  outputTokens: 5,
+  totalTokens: 15,
+  providerCost: { amount: 0.001, currency: 'USD', reportedByProvider: true },
+};
+
+describe('provider-neutral LLM assertion Evaluator', () => {
+  it.each([
+    ['semantic_similarity', 'semantic-similarity', getSemanticPromptHash()],
+    ['faithfulness', 'rag-faithfulness', getRagJudgePromptHash('faithfulness')],
+    ['answer_relevancy', 'rag-answer-relevancy', getRagJudgePromptHash('answer_relevancy')],
+    ['context_recall', 'rag-context-recall', getRagJudgePromptHash('context_recall')],
+  ] as const)('uses the frozen %s instrument without copying its prompt', async (
+    assertionType,
+    promptId,
+    promptHash,
+  ) => {
+    const requests: OmkLlmJudgeInvocationRequest[] = [];
+    const result = await runCore({
+      assertionType,
+      handler: async (request) => {
+        requests.push(request);
+        return {
+          invocationStatus: 'completed',
+          output: '{"score":4,"reason":"valid reading"}',
+          usage: COMPLETE_USAGE,
+        };
+      },
+    });
+    expect(requests).toHaveLength(2);
+    expect(result.lifecycle).toEqual({ runDisposals: 1, recordDisposals: 2 });
+    expect(requests[0]).toMatchObject({
+      executorId: PROVIDER_IMPLEMENTATION_ID,
+      model: 'judge-model',
+      effort: 'low',
+      promptId,
+      promptHash,
+    });
+    expect(requests[0].signal).toBeInstanceOf(AbortSignal);
+    expect(completedObservations(result)).toHaveLength(2);
+    for (const observation of completedObservations(result)) {
+      expect(observation).toMatchObject({
+        metricId: METRIC_ID,
+        observationStatus: 'observed',
+        valueType: 'boolean',
+        value: true,
+        evidence: {
+          classification: 'gold',
+          contentKind: 'inline',
+          value: {
+            assertionType,
+            promptId,
+            promptHash,
+            score: 4,
+            reason: 'valid reading',
+            weight: 1,
+            layer: 'fact',
+          },
+        },
+      });
+    }
+    for (const record of result.evaluation.records) {
+      if (record.evaluationStatus !== 'completed') continue;
+      expect(record.usage).toMatchObject(COMPLETE_USAGE);
+    }
+  });
+
+  it('keeps a valid below-threshold reading as observed false', async () => {
+    const result = await runCore({
+      handler: async () => ({
+        invocationStatus: 'completed',
+        output: '{"score":2,"reason":"content differs"}',
+      }),
+    });
+    expect(completedObservations(result)).toEqual([
+      expect.objectContaining({ observationStatus: 'observed', value: false }),
+      expect.objectContaining({ observationStatus: 'observed', value: false }),
+    ]);
+  });
+
+  it.each([
+    ['plain text', 'judge-response-non-json'],
+    ['prefix {bad json} suffix', 'judge-response-malformed-json'],
+    ['{"score":"4","reason":"wrong type"}', 'judge-score-malformed'],
+    ['{"score":6,"reason":"out of range"}', 'judge-score-out-of-range'],
+    ['{"score":4}', 'judge-reason-missing'],
+  ])('returns invalid, not false, for %s', async (output, reasonCode) => {
+    const result = await runCore({
+      handler: async () => ({ invocationStatus: 'completed', output }),
+    });
+    expect(completedObservations(result)).toEqual([
+      expect.objectContaining({ observationStatus: 'invalid', reasonCode }),
+      expect.objectContaining({ observationStatus: 'invalid', reasonCode }),
+    ]);
+    expect(completedObservations(result).some((observation) => (
+      observation.observationStatus === 'observed'
+    ))).toBe(false);
+  });
+
+  it('records provider failure separately, redacts raw errors, and retains known usage', async () => {
+    const result = await runCore({
+      handler: async () => ({
+        invocationStatus: 'failed',
+        reasonCode: 'provider-overloaded',
+        usage: {
+          ...COMPLETE_USAGE,
+          details: { rawProviderError: 'secret-provider-message' },
+        },
+      }),
+    });
+    expect(result.evaluation.records).toHaveLength(2);
+    for (const record of result.evaluation.records) {
+      expect(record).toMatchObject({
+        evaluationStatus: 'failed',
+        error: {
+          code: 'judge-provider-failure',
+          stage: 'evaluation',
+          message: 'Evaluator reported a structured failure.',
+        },
+        usage: COMPLETE_USAGE,
+      });
+      expect(JSON.stringify(record)).not.toContain('provider-overloaded');
+      expect(JSON.stringify(record)).not.toContain('secret-provider-message');
+    }
+  });
+
+  it('freezes the intended comparability break from legacy false to Core failure', async () => {
+    const legacyExecutor: ExecutorFn = async () => ({
+      ok: false,
+      output: null,
+      error: 'raw provider failure',
+      durationMs: 1,
+      durationApiMs: 1,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      tokenUsageReportedByExecutor: false,
+      costUSD: 0,
+      costReportedByExecutor: false,
+      stopReason: 'error',
+      numTurns: 0,
+    });
+    const legacy = await runAsyncAssertions(
+      'Actual answer',
+      [{ type: 'semantic_similarity', reference: 'Expected answer' }],
+      {
+        executor: legacyExecutor,
+        judgeModel: 'judge-model',
+        sample: { sample_id: 'sample-1', prompt: 'Question' },
+        samplesDir: '.',
+      },
+    );
+    expect(legacy.details[0]).toMatchObject({ passed: false });
+
+    const core = await runCore({
+      handler: async () => ({
+        invocationStatus: 'failed',
+        reasonCode: 'provider-unavailable',
+      }),
+    });
+    expect(core.evaluation.records.every((record) => (
+      record.evaluationStatus === 'failed'
+      && record.error.code === 'judge-provider-failure'
+    ))).toBe(true);
+    expect(completedObservations(core)).toEqual([]);
+  });
+
+  it('keeps unknown provider usage and cost absent rather than writing zero', async () => {
+    const result = await runCore({
+      handler: async () => ({
+        invocationStatus: 'completed',
+        output: '{"score":5,"reason":"valid"}',
+      }),
+      reporting: 'unsupported',
+    });
+    for (const record of result.evaluation.records) {
+      if (record.evaluationStatus !== 'completed') continue;
+      expect(record.usage).toBeUndefined();
+      expect(record.attempts[0].usage).toBeUndefined();
+    }
+  });
+
+  it('delegates retry exclusively to the sealed Core retry policy', async () => {
+    let calls = 0;
+    const result = await runCore({
+      handler: async () => {
+        calls += 1;
+        return calls <= 2
+          ? { invocationStatus: 'failed', reasonCode: 'provider-unavailable' }
+          : {
+              invocationStatus: 'completed',
+              output: '{"score":5,"reason":"recovered"}',
+            };
+      },
+      policy: policy({ retryProviderFailure: true }),
+    });
+    expect(calls).toBe(4);
+    for (const record of result.evaluation.records) {
+      expect(record).toMatchObject({
+        evaluationStatus: 'completed',
+        observations: [expect.objectContaining({
+          observationStatus: 'observed',
+          value: true,
+        })],
+      });
+      if (record.evaluationStatus !== 'completed') continue;
+      expect(record.attempts.map((attempt) => attempt.attemptStatus)).toEqual([
+        'failed',
+        'completed',
+      ]);
+    }
+  });
+
+  it('replays only through the sealed Core evaluation cache', async () => {
+    const cache = new MemoryEvaluationCache();
+    const cachedPolicy = policy();
+    cachedPolicy.cache.evaluationMode = 'reuse';
+    let calls = 0;
+    const request = {
+      handler: async (): Promise<OmkLlmJudgeInvocationResult> => {
+        calls += 1;
+        return {
+          invocationStatus: 'completed' as const,
+          output: '{"score":5,"reason":"cacheable"}',
+        };
+      },
+      policy: cachedPolicy,
+      cache,
+    };
+    const first = await runCore(request);
+    expect(calls).toBe(2);
+    expect(first.evaluation.records.every((record) => (
+      record.evaluationStatus === 'completed'
+      && record.cache.cacheStatus === 'miss'
+    ))).toBe(true);
+
+    const second = await runCore(request);
+    expect(calls).toBe(2);
+    expect(second.evaluation.records.every((record) => (
+      record.evaluationStatus === 'completed'
+      && record.cache.cacheStatus === 'transparent-hit'
+    ))).toBe(true);
+  });
+
+  it('lets Core own timeout and waits for cooperative provider cancellation', async () => {
+    let cancellations = 0;
+    const result = await runCore({
+      handler: async (request) => new Promise<OmkLlmJudgeInvocationResult>((_resolve, reject) => {
+        request.signal.addEventListener('abort', () => {
+          cancellations += 1;
+          reject(request.signal.reason);
+        }, { once: true });
+      }),
+      policy: policy({ timeout: true }),
+      clock: new TestClock(true),
+    });
+    expect(cancellations).toBe(2);
+    for (const record of result.evaluation.records) {
+      expect(record).toMatchObject({
+        evaluationStatus: 'failed',
+        error: { code: 'timeout', stage: 'evaluation' },
+      });
+    }
+  });
+
+  it('lets Core own cancellation and does not turn it into provider failure', async () => {
+    const controller = new AbortController();
+    let cancellations = 0;
+    const result = await runCore({
+      handler: async (request) => {
+        controller.abort(new Error('cancel run'));
+        return new Promise<OmkLlmJudgeInvocationResult>((_resolve, reject) => {
+          if (request.signal.aborted) {
+            cancellations += 1;
+            reject(request.signal.reason);
+          } else {
+            request.signal.addEventListener('abort', () => {
+              cancellations += 1;
+              reject(request.signal.reason);
+            }, { once: true });
+          }
+        });
+      },
+      signal: controller.signal,
+    });
+    expect(cancellations).toBeGreaterThan(0);
+    expect(result.evaluation.evaluationBundleStatus).toBe('cancelled');
+    expect(result.evaluation.records.every((record) => (
+      record.evaluationStatus === 'cancelled'
+    ))).toBe(true);
+  });
+
+  it('lets Core censor unstarted coordinates at the sealed evaluation budget', async () => {
+    let calls = 0;
+    const result = await runCore({
+      handler: async () => {
+        calls += 1;
+        return {
+          invocationStatus: 'completed',
+          output: '{"score":5,"reason":"valid"}',
+        };
+      },
+      policy: policy({ evaluationInvocations: 1 }),
+    });
+    expect(calls).toBe(1);
+    expect(result.evaluation.evaluationBundleStatus).toBe('budget-exhausted');
+    expect(result.evaluation.coverage).toMatchObject({
+      planned: 2,
+      completed: 1,
+      notStarted: 1,
+    });
+  });
+
+  it('cannot lower observed content score by adding an infrastructure failure', async () => {
+    let calls = 0;
+    const result = await runCore({
+      handler: async () => {
+        calls += 1;
+        return calls === 1
+          ? {
+              invocationStatus: 'completed',
+              output: '{"score":5,"reason":"valid"}',
+            }
+          : {
+              invocationStatus: 'failed',
+              reasonCode: 'provider-unavailable',
+            };
+      },
+    });
+    const observed = completedObservations(result).filter((observation) => (
+      observation.observationStatus === 'observed'
+    ));
+    expect(observed).toHaveLength(1);
+    expect(observed[0]).toMatchObject({ value: true });
+    expect(result.evaluation.records.some((record) => (
+      record.evaluationStatus === 'completed'
+    ))).toBe(true);
+    expect(result.evaluation.records.some((record) => (
+      record.evaluationStatus === 'failed'
+      && record.error.code === 'judge-provider-failure'
+    ))).toBe(true);
+  });
+
+  it('builds a production host factory with sealed qualification and prompt identity', async () => {
+    const definitionValue = definition('semantic_similarity');
+    const provider = invocationPort(async () => ({
+      invocationStatus: 'completed',
+      output: '{"score":5,"reason":"valid"}',
+    }));
+    const factory = createLlmAssertionEvaluatorBindingFactory(async () => ({
+      port: provider,
+      preflightDeclarations: [{
+        preflightKind: 'connectivity',
+        preflightDisposition: 'check',
+        checkId: 'judge-connectivity',
+        run: () => undefined,
+      }],
+    }));
+    const resolved = await factory({
+      sessionIsolationKey: 'llm-assertion-factory-session',
+      binding: {
+        runtimeKind: 'evaluator',
+        bindingId: 'llm-assertion-binding',
+        evaluatorId: 'llm-assertion',
+        implementationId: LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+        measurement: definitionValue.evaluators[0].measurement,
+        configDigest: digestCanonicalJson(definitionValue.evaluators[0].config as JsonValue),
+        resourceLeaseRequirements: [],
+        qualification: {
+          executorId: PROVIDER_IMPLEMENTATION_ID,
+          model: 'judge-model',
+          effort: 'low',
+          promptVariant: 'semantic-similarity',
+          resourceIntegrity: 'digest-before-use',
+        },
+      },
+      evaluator: definitionValue.evaluators[0],
+      resourceLeases: {
+        forRun: () => ({
+          bindingId: 'llm-assertion-binding',
+          consumerKind: 'evaluator',
+          resourcesByResourceId: new Map(),
+        }),
+      },
+    });
+    expect(resolved.port.identity).toEqual(evaluatorIdentity('semantic_similarity', provider));
+    expect(resolved.preflightDeclarations).toEqual([
+      expect.objectContaining({ checkId: 'judge-connectivity', preflightDisposition: 'check' }),
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #481。

Part of #480。

## 用户影响

Evaluation Core 的 `semantic_similarity`、`faithfulness`、`answer_relevancy` 与 `context_recall` 现在只在评委返回合法的 1–5 整数 reading 且带解释时产生 Boolean observation。合法 reading 低于 threshold 仍是内容失败；provider failure、解析失败、越界、超时、取消与预算截断不再伪装成内容 `false`。

正式 `omk eval` 尚未切换到新 Core，因此本 PR 不改变现有 CLI 输出或旧 Report。未来切换后，基础设施失败会降低 coverage，而不会直接拉低 fact-layer 内容分数。

## 架构与测量边界

- 使用独立的 `omk.llm-assertions/v1` 宿主 Evaluator family，一条 criterion 对应一个 Evaluator coordinate 与 Boolean Metric，避免一次 provider failure 污染无关 criterion。
- prompt 文本继续来自既有单一来源，四个冻结 hash 均不变化；instrument、threshold、weight、fact layer、模型配置与 provider Runtime identity 均进入 sealed identity／evidence。
- provider port 只执行一次可协作取消的调用；retry、timeout、budget 与 cache 继续仅由 Evaluation Core policy 管理。
- provider 原始错误不落盘；已报告 usage／cost 保留，未知值保持 absent，不写占位零。

## 可比性与迁移

这是有意修正 legacy measurement defect 的 `BREAKING-COMPARABILITY` 变更：过去 provider／parse failure 会进入加权 pass ratio 成为 `false`，新 Core 将其表达为 failed 或 invalid，并由后续 missing／coverage policy 处理。不提供旧 reader、兼容开关、双路径或 Report migration。

CR 另发现 async assertion 的 `not` public contract 在 legacy 路径未生效，已独立登记为 #489，本 PR 不夹带该项 Boolean 语义变化。

## 验证

完整 `yarn ci` 通过。覆盖固定 provider replay、结构化失败、usage／cost、Core retry／cache／timeout／cancel／budget、classification、identity 与生命周期。