### PR TITLE
feat(analysis): 封口断言分层参数契约

### DIFF
--- a/src/eval-workflows/runtime-adapter/analysis/assertion-layer-parameters.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/assertion-layer-parameters.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+import {
+  IdentifierSchema,
+  schemaIdentityKey,
+  type CoreSchemaValidator,
+  type JsonValue,
+} from '../../../evaluation-core/contracts/index.js';
+import {
+  analysisJsonSchema,
+  analysisSchemaIdentity,
+  compareStrings,
+  createAnalysisSchemaValidator,
+} from './analysis-support.js';
+
+const PARAMETERS_SCHEMA_VERSION = 'omk.parameters.assertion-layer/v1' as const;
+
+export const AssertionLayerDispositionSchema = z.enum([
+  'fact',
+  'behavior',
+  'excluded-mixed-layer',
+]);
+
+export const AssertionLayerCriterionParameterSchema = z.object({
+  criterionId: IdentifierSchema,
+  metricId: IdentifierSchema,
+  layerDisposition: AssertionLayerDispositionSchema,
+  weight: z.number().finite().positive(),
+}).strict();
+
+const AssertionLayerParametersSchema = z.object({
+  criteria: z.array(AssertionLayerCriterionParameterSchema).min(1),
+}).strict().superRefine((parameters, context) => {
+  for (const field of ['criterionId', 'metricId'] as const) {
+    const values = parameters.criteria.map((criterion) => criterion[field]);
+    if (new Set(values).size !== values.length) {
+      context.addIssue({
+        code: 'custom',
+        path: ['criteria'],
+        message: `Assertion-layer ${field} values must be unique.`,
+      });
+    }
+  }
+});
+
+export type AssertionLayerParameters = z.infer<typeof AssertionLayerParametersSchema>;
+export type AssertionLayerCriterionParameter = z.infer<
+  typeof AssertionLayerCriterionParameterSchema
+>;
+
+function compareCriteria(
+  left: AssertionLayerCriterionParameter,
+  right: AssertionLayerCriterionParameter,
+): number {
+  return compareStrings(left.metricId, right.metricId)
+    || compareStrings(left.criterionId, right.criterionId);
+}
+
+export function parseAssertionLayerParameters(value: unknown): AssertionLayerParameters {
+  const parsed = AssertionLayerParametersSchema.parse(value);
+  return {
+    criteria: [...parsed.criteria].sort(compareCriteria),
+  };
+}
+
+export const ASSERTION_LAYER_PARAMETERS_SCHEMA = analysisSchemaIdentity(
+  PARAMETERS_SCHEMA_VERSION,
+  'urn:omk:parameters:assertion-layer:v1',
+  analysisJsonSchema(AssertionLayerParametersSchema, [
+    'criteria are normalized by metricId and criterionId before plan sealing',
+    'criterionId and metricId are independently unique',
+    'layer disposition is explicit and never inferred from evaluator or assertion strings',
+    'weights are finite and strictly positive',
+  ]),
+);
+
+export function createAssertionLayerParameterSchemaValidators(): ReadonlyMap<
+  string,
+  CoreSchemaValidator
+> {
+  const validator = createAnalysisSchemaValidator(
+    ASSERTION_LAYER_PARAMETERS_SCHEMA,
+    (value) => parseAssertionLayerParameters(value) as JsonValue,
+  );
+  return new Map([[schemaIdentityKey(validator.schema), validator]]);
+}
+

--- a/test/eval-workflows/runtime-adapter/assertion-layer-parameters.test.ts
+++ b/test/eval-workflows/runtime-adapter/assertion-layer-parameters.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  schemaIdentityKey,
+} from '../../../src/evaluation-core/contracts/index.js';
+import {
+  ASSERTION_LAYER_PARAMETERS_SCHEMA,
+  createAssertionLayerParameterSchemaValidators,
+  parseAssertionLayerParameters,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/assertion-layer-parameters.js';
+
+const fact = {
+  criterionId: 'fact-a',
+  metricId: 'metric-z',
+  layerDisposition: 'fact',
+  weight: 2,
+} as const;
+const behavior = {
+  criterionId: 'behavior-a',
+  metricId: 'metric-a',
+  layerDisposition: 'behavior',
+  weight: 1,
+} as const;
+const mixed = {
+  criterionId: 'mixed-a',
+  metricId: 'metric-m',
+  layerDisposition: 'excluded-mixed-layer',
+  weight: 4,
+} as const;
+
+describe('assertion-layer parameter contract', () => {
+  it('normalizes criterion order into one sealed representation', () => {
+    const expected = { criteria: [behavior, mixed, fact] };
+    expect(parseAssertionLayerParameters({ criteria: [fact, behavior, mixed] })).toEqual(expected);
+    expect(parseAssertionLayerParameters({ criteria: [mixed, fact, behavior] })).toEqual(expected);
+  });
+
+  it.each([
+    {
+      criteria: [fact, { ...behavior, criterionId: fact.criterionId }],
+    },
+    {
+      criteria: [fact, { ...behavior, metricId: fact.metricId }],
+    },
+  ])('rejects ambiguous criterion or metric identities', (parameters) => {
+    expect(() => parseAssertionLayerParameters(parameters)).toThrow();
+  });
+
+  it.each([0, -1, Number.POSITIVE_INFINITY, Number.NaN])(
+    'rejects non-positive or non-finite weight %s',
+    (weight) => {
+      expect(() => parseAssertionLayerParameters({
+        criteria: [{ ...fact, weight }],
+      })).toThrow();
+    },
+  );
+
+  it('rejects empty criteria, implicit layer inference, and unknown fields', () => {
+    expect(() => parseAssertionLayerParameters({ criteria: [] })).toThrow();
+    expect(() => parseAssertionLayerParameters({
+      criteria: [{ criterionId: 'a', metricId: 'm', weight: 1 }],
+    })).toThrow();
+    expect(() => parseAssertionLayerParameters({
+      criteria: [{ ...fact, inferredFrom: 'assertion-type' }],
+    })).toThrow();
+  });
+
+  it('registers a validator whose output is the canonical plan materialization', () => {
+    const validator = createAssertionLayerParameterSchemaValidators().get(
+      schemaIdentityKey(ASSERTION_LAYER_PARAMETERS_SCHEMA),
+    );
+    expect(validator).toBeDefined();
+    expect(validator?.parse({ criteria: [fact, behavior, mixed] })).toEqual({
+      criteria: [behavior, mixed, fact],
+    });
+    expect(validator?.schema.schemaVersion).toBe('omk.parameters.assertion-layer/v1');
+    expect(validator?.schema.schemaUri).toBe('urn:omk:parameters:assertion-layer:v1');
+  });
+});
+


### PR DESCRIPTION
## 变更说明

为 #496 增加独立的 assertion-layer v1 参数 schema 与 validator。每个 criterion 必须显式声明 criterionId、metricId、fact／behavior／excluded-mixed-layer 归属和正权重；validator 在计划封口时按 metricId／criterionId 规范排序。

## 用户影响

本 PR 只建立参数契约，不注册 Analysis 节点，也不改变现有 CLI 或报告行为。后续输出 table 与节点实现将分别提交。

## 迁移与可比性

无需迁移。归层不从 evaluatorId、assertion type 或 evidence 字符串推断，避免知识配置变化造成静默归类漂移；未触及评分 prompt、Report schema 与统计公式。

关联 #496。