### PR TITLE
feat(analysis): 定义断言分层表契约

### DIFF
--- a/src/eval-workflows/runtime-adapter/analysis/assertion-layer.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/assertion-layer.ts
@@ -1,0 +1,364 @@
+import { z } from 'zod';
+import {
+  IdentifierSchema,
+  SamplingUnitIdsSchema,
+  Sha256DigestSchema,
+  canonicalizeJson,
+  digestCanonicalJson,
+  schemaIdentityKey,
+  type CoreSchemaValidator,
+  type JsonValue,
+} from '../../../evaluation-core/contracts/index.js';
+import {
+  analysisJsonSchema,
+  analysisSchemaIdentity,
+  compareStrings,
+  createAnalysisSchemaValidator,
+  round,
+} from './analysis-support.js';
+import { AssertionLayerDispositionSchema } from './assertion-layer-parameters.js';
+
+export const ASSERTION_LAYER_TABLE_SCHEMA_VERSION =
+  'omk.assertion-layer-table/v1' as const;
+
+export const ASSERTION_LAYER_SCORE_DECIMALS = 2;
+export const ASSERTION_LAYER_SCORE_MIN = 1;
+export const ASSERTION_LAYER_SCORE_MAX = 5;
+export const ASSERTION_NOT_APPLICABLE_REASON = 'criterion-not-applicable' as const;
+
+const CountSchema = z.number().int().nonnegative().safe();
+const FiniteNonnegativeSchema = z.number().finite().nonnegative();
+const PositiveWeightSchema = z.number().finite().positive();
+const UnobservedRowStatusSchema = z.enum([
+  'missing',
+  'invalid',
+  'evaluation-failed',
+  'source-unavailable',
+  'not-started',
+]);
+const EntryBaseSchema = z.object({
+  criterionId: IdentifierSchema,
+  metricId: IdentifierSchema,
+  layerDisposition: AssertionLayerDispositionSchema,
+  weight: PositiveWeightSchema,
+  rowId: Sha256DigestSchema,
+  evaluatorId: IdentifierSchema,
+  censored: z.boolean(),
+});
+
+const ObservedEntrySchema = EntryBaseSchema.extend({
+  applicability: z.literal('applicable'),
+  rowStatus: z.literal('observed'),
+  value: z.boolean(),
+}).strict();
+
+const NotApplicableEntrySchema = EntryBaseSchema.extend({
+  applicability: z.literal('not-applicable'),
+  rowStatus: z.literal('missing'),
+  censored: z.literal(false),
+  reasonCode: z.literal(ASSERTION_NOT_APPLICABLE_REASON),
+}).strict();
+
+const UnobservedEntrySchema = EntryBaseSchema.extend({
+  applicability: z.literal('applicable'),
+  rowStatus: UnobservedRowStatusSchema,
+  reasonCode: IdentifierSchema,
+}).strict();
+
+const AssertionEntrySchema = z.union([
+  ObservedEntrySchema,
+  NotApplicableEntrySchema,
+  UnobservedEntrySchema,
+]);
+
+const CoverageSchema = z.object({
+  declaredCriteria: CountSchema,
+  declaredWeight: FiniteNonnegativeSchema,
+  notApplicableCriteria: CountSchema,
+  notApplicableWeight: FiniteNonnegativeSchema,
+  applicableCriteria: CountSchema,
+  plannedWeight: FiniteNonnegativeSchema,
+  observedCriteria: CountSchema,
+  observedWeight: FiniteNonnegativeSchema,
+  passedWeight: FiniteNonnegativeSchema,
+  missingCriteria: CountSchema,
+  missingWeight: FiniteNonnegativeSchema,
+  invalidCriteria: CountSchema,
+  invalidWeight: FiniteNonnegativeSchema,
+  evaluationFailedCriteria: CountSchema,
+  evaluationFailedWeight: FiniteNonnegativeSchema,
+  sourceUnavailableCriteria: CountSchema,
+  sourceUnavailableWeight: FiniteNonnegativeSchema,
+  notStartedCriteria: CountSchema,
+  notStartedWeight: FiniteNonnegativeSchema,
+  censoredCriteria: CountSchema,
+  censoredWeight: FiniteNonnegativeSchema,
+}).strict();
+
+const LayerBaseSchema = z.object({ coverage: CoverageSchema }).strict();
+const ObservedLayerSchema = LayerBaseSchema.extend({
+  layerStatus: z.literal('observed'),
+  score: z.number().finite().min(ASSERTION_LAYER_SCORE_MIN).max(ASSERTION_LAYER_SCORE_MAX),
+}).strict();
+const MissingLayerSchema = LayerBaseSchema.extend({
+  layerStatus: z.literal('missing'),
+  reasonCode: z.literal('assertion-layer-unobserved'),
+}).strict();
+const LayerSchema = z.discriminatedUnion('layerStatus', [
+  ObservedLayerSchema,
+  MissingLayerSchema,
+]);
+
+const GroupSchema = z.object({
+  groupId: Sha256DigestSchema,
+  targetId: IdentifierSchema,
+  sampleId: IdentifierSchema,
+  trialIndex: CountSchema,
+  trialId: Sha256DigestSchema,
+  samplingUnitIds: SamplingUnitIdsSchema,
+  entries: z.array(AssertionEntrySchema).min(1),
+  layers: z.object({
+    fact: LayerSchema,
+    behavior: LayerSchema,
+  }).strict(),
+  excludedMixedLayer: z.object({ coverage: CoverageSchema }).strict(),
+}).strict();
+
+const AssertionLayerTableValueSchema = z.object({
+  schemaVersion: z.literal(ASSERTION_LAYER_TABLE_SCHEMA_VERSION),
+  groups: z.array(GroupSchema).min(1),
+}).strict();
+
+export type AssertionEntry = z.infer<typeof AssertionEntrySchema>;
+export type AssertionLayerGroup = z.infer<typeof GroupSchema>;
+export type AssertionLayerTableValue = z.infer<typeof AssertionLayerTableValueSchema>;
+export type AssertionLayerCoverage = z.infer<typeof CoverageSchema>;
+type Issue = (path: Array<string | number>, message: string) => void;
+
+function unitKey(value: Pick<AssertionLayerGroup,
+  'targetId' | 'sampleId' | 'trialIndex' | 'trialId' | 'samplingUnitIds'
+>): string {
+  return canonicalizeJson([
+    value.targetId,
+    value.sampleId,
+    value.trialIndex,
+    value.trialId,
+    value.samplingUnitIds,
+  ]);
+}
+
+function entryKey(entry: Pick<AssertionEntry, 'metricId' | 'criterionId'>): string {
+  return canonicalizeJson([entry.metricId, entry.criterionId]);
+}
+
+function criterionDesignKey(entries: readonly AssertionEntry[]): string {
+  return canonicalizeJson(entries.map((entry) => ({
+    criterionId: entry.criterionId,
+    metricId: entry.metricId,
+    layerDisposition: entry.layerDisposition,
+    weight: entry.weight,
+  })));
+}
+
+function emptyCoverage(): AssertionLayerCoverage {
+  return {
+    declaredCriteria: 0,
+    declaredWeight: 0,
+    notApplicableCriteria: 0,
+    notApplicableWeight: 0,
+    applicableCriteria: 0,
+    plannedWeight: 0,
+    observedCriteria: 0,
+    observedWeight: 0,
+    passedWeight: 0,
+    missingCriteria: 0,
+    missingWeight: 0,
+    invalidCriteria: 0,
+    invalidWeight: 0,
+    evaluationFailedCriteria: 0,
+    evaluationFailedWeight: 0,
+    sourceUnavailableCriteria: 0,
+    sourceUnavailableWeight: 0,
+    notStartedCriteria: 0,
+    notStartedWeight: 0,
+    censoredCriteria: 0,
+    censoredWeight: 0,
+  };
+}
+
+export function assertionLayerCoverage(
+  entries: readonly AssertionEntry[],
+): AssertionLayerCoverage {
+  const coverage = emptyCoverage();
+  for (const entry of entries) {
+    coverage.declaredCriteria += 1;
+    coverage.declaredWeight += entry.weight;
+    if (entry.applicability === 'not-applicable') {
+      coverage.notApplicableCriteria += 1;
+      coverage.notApplicableWeight += entry.weight;
+      continue;
+    }
+    coverage.applicableCriteria += 1;
+    coverage.plannedWeight += entry.weight;
+    if (entry.censored) {
+      coverage.censoredCriteria += 1;
+      coverage.censoredWeight += entry.weight;
+    }
+    if (entry.rowStatus === 'observed') {
+      coverage.observedCriteria += 1;
+      coverage.observedWeight += entry.weight;
+      if (entry.value) coverage.passedWeight += entry.weight;
+      continue;
+    }
+    const prefix = entry.rowStatus === 'evaluation-failed'
+      ? 'evaluationFailed'
+      : entry.rowStatus === 'source-unavailable'
+        ? 'sourceUnavailable'
+        : entry.rowStatus === 'not-started'
+          ? 'notStarted'
+          : entry.rowStatus;
+    const countKey = `${prefix}Criteria` as keyof AssertionLayerCoverage;
+    const weightKey = `${prefix}Weight` as keyof AssertionLayerCoverage;
+    coverage[countKey] += 1;
+    coverage[weightKey] += entry.weight;
+  }
+  return coverage;
+}
+
+export function assertionLayerAggregate(
+  entries: readonly AssertionEntry[],
+): z.infer<typeof LayerSchema> {
+  const coverage = assertionLayerCoverage(entries);
+  if (coverage.observedWeight === 0) {
+    return {
+      layerStatus: 'missing',
+      reasonCode: 'assertion-layer-unobserved',
+      coverage,
+    };
+  }
+  return {
+    layerStatus: 'observed',
+    score: round(
+      ASSERTION_LAYER_SCORE_MIN
+        + (coverage.passedWeight / coverage.observedWeight)
+          * (ASSERTION_LAYER_SCORE_MAX - ASSERTION_LAYER_SCORE_MIN),
+      ASSERTION_LAYER_SCORE_DECIMALS,
+    ),
+    coverage,
+  };
+}
+
+export function assertionLayerGroupId(group: Omit<AssertionLayerGroup, 'groupId'>): string {
+  return digestCanonicalJson({
+    derivation: ASSERTION_LAYER_TABLE_SCHEMA_VERSION,
+    key: JSON.parse(unitKey(group)) as JsonValue,
+    criteria: group.entries.map((entry) => ({
+      criterionId: entry.criterionId,
+      metricId: entry.metricId,
+      layerDisposition: entry.layerDisposition,
+      weight: entry.weight,
+      rowId: entry.rowId,
+    })),
+  });
+}
+
+function validateAssertionLayerTable(value: AssertionLayerTableValue, issue: Issue): void {
+  const groupKeys = value.groups.map(unitKey);
+  if (new Set(groupKeys).size !== groupKeys.length
+      || canonicalizeJson(groupKeys)
+        !== canonicalizeJson([...groupKeys].sort(compareStrings))) {
+    issue(['groups'], 'Assertion-layer groups must be unique and canonically ordered.');
+  }
+  const rowIds = value.groups.flatMap((group) => group.entries.map((entry) => entry.rowId));
+  if (new Set(rowIds).size !== rowIds.length) {
+    issue(['groups'], 'Assertion source row identities must be globally unique.');
+  }
+  const sealedCriterionDesign = criterionDesignKey(value.groups[0].entries);
+  for (const [groupIndex, group] of value.groups.entries()) {
+    const entryKeys = group.entries.map(entryKey);
+    if (new Set(entryKeys).size !== entryKeys.length
+        || canonicalizeJson(entryKeys)
+          !== canonicalizeJson([...entryKeys].sort(compareStrings))) {
+      issue(['groups', groupIndex, 'entries'], 'Assertion entries must be unique and sorted.');
+    }
+    if (criterionDesignKey(group.entries) !== sealedCriterionDesign) {
+      issue(
+        ['groups', groupIndex, 'entries'],
+        'Every measurement group must use the same sealed criterion design.',
+      );
+    }
+    const fact = group.entries.filter((entry) => entry.layerDisposition === 'fact');
+    const behavior = group.entries.filter((entry) => entry.layerDisposition === 'behavior');
+    const excluded = group.entries.filter((entry) => (
+      entry.layerDisposition === 'excluded-mixed-layer'
+    ));
+    if (canonicalizeJson(group.layers.fact) !== canonicalizeJson(assertionLayerAggregate(fact))) {
+      issue(['groups', groupIndex, 'layers', 'fact'], 'Fact score or coverage is not recomputable.');
+    }
+    if (canonicalizeJson(group.layers.behavior)
+        !== canonicalizeJson(assertionLayerAggregate(behavior))) {
+      issue(
+        ['groups', groupIndex, 'layers', 'behavior'],
+        'Behavior score or coverage is not recomputable.',
+      );
+    }
+    if (canonicalizeJson(group.excludedMixedLayer.coverage)
+        !== canonicalizeJson(assertionLayerCoverage(excluded))) {
+      issue(
+        ['groups', groupIndex, 'excludedMixedLayer', 'coverage'],
+        'Excluded mixed-layer coverage is not recomputable.',
+      );
+    }
+    if (group.groupId !== assertionLayerGroupId(group)) {
+      issue(['groups', groupIndex, 'groupId'], 'Assertion-layer identity does not match lineage.');
+    }
+  }
+}
+
+const AssertionLayerEnvelopeSchema = z.object({
+  resultType: z.literal('table'),
+  value: AssertionLayerTableValueSchema,
+}).strict().superRefine((envelope, context) => {
+  validateAssertionLayerTable(envelope.value, (path, message) => {
+    context.addIssue({ code: 'custom', path: ['value', ...path], message });
+  });
+});
+
+export const ASSERTION_LAYER_TABLE_SCHEMA = analysisSchemaIdentity(
+  ASSERTION_LAYER_TABLE_SCHEMA_VERSION,
+  'urn:omk:analysis-result:assertion-layer-table:v1',
+  analysisJsonSchema(AssertionLayerEnvelopeSchema, [
+    'groups and criterion entries are unique and canonically ordered',
+    'sampling-unit lineage is identical across every criterion in a measurement unit',
+    'criterion identity, metric identity, layer disposition, and positive weight are explicit',
+    'every measurement group uses the same sealed criterion design',
+    'criterion-not-applicable is structural and excluded from planned and observed coverage',
+    'coverage exactly conserves every applicable source row status and weight',
+    'mixed-layer criteria remain visible but are excluded from fact and behavior scores',
+    'fact and behavior scores map observed weighted pass ratio onto 1-5 and round to 2 decimals',
+    'zero observed weight produces a missing layer rather than numeric zero',
+    'groupId binds the sampling unit, criterion design, and source row lineage',
+  ]),
+);
+
+export function parseAssertionLayerTableValue(value: unknown): AssertionLayerTableValue {
+  return AssertionLayerTableValueSchema.parse(value);
+}
+
+export function compareAssertionLayerGroups(
+  left: AssertionLayerGroup,
+  right: AssertionLayerGroup,
+): number {
+  return compareStrings(unitKey(left), unitKey(right));
+}
+
+export function createAssertionLayerTableSchemaValidators(): ReadonlyMap<
+  string,
+  CoreSchemaValidator
+> {
+  const validator = createAnalysisSchemaValidator(
+    ASSERTION_LAYER_TABLE_SCHEMA,
+    (value) => AssertionLayerEnvelopeSchema.parse(value) as JsonValue,
+  );
+  return new Map([[schemaIdentityKey(validator.schema), validator]]);
+}

--- a/src/eval-workflows/runtime-adapter/analysis/index.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/index.ts
@@ -1,1 +1,3 @@
+export * from './assertion-layer-parameters.js';
+export * from './assertion-layer.js';
 export * from './judge-aggregation.js';

--- a/test/eval-workflows/runtime-adapter/assertion-layer.test.ts
+++ b/test/eval-workflows/runtime-adapter/assertion-layer.test.ts
@@ -1,0 +1,275 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  digestCanonicalJson,
+  schemaIdentityKey,
+  type JsonValue,
+} from '../../../src/evaluation-core/contracts/index.js';
+import {
+  ASSERTION_LAYER_TABLE_SCHEMA,
+  ASSERTION_LAYER_TABLE_SCHEMA_VERSION,
+  assertionLayerAggregate,
+  assertionLayerCoverage,
+  assertionLayerGroupId,
+  createAssertionLayerTableSchemaValidators,
+  type AssertionEntry,
+  type AssertionLayerGroup,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/assertion-layer.js';
+
+const TRIAL_ID = digestCanonicalJson({ fixture: 'assertion-layer-trial' });
+const PAIRING_BLOCK_ID = digestCanonicalJson({ fixture: 'assertion-layer-pair' });
+
+const scoringFixture = JSON.parse(readFileSync(fileURLToPath(new URL(
+  '../../fixtures/evaluation-core/scoring-equivalence-v1.json',
+  import.meta.url,
+)), 'utf8')) as {
+  deterministicAssertions: {
+    expectedLayered: { layeredScores: { factScore: number; behaviorScore: number } };
+  };
+};
+
+function observed(input: Readonly<{
+  criterionId: string;
+  metricId: string;
+  layerDisposition: AssertionEntry['layerDisposition'];
+  weight: number;
+  value: boolean;
+}>): AssertionEntry {
+  return {
+    ...input,
+    rowId: digestCanonicalJson({ row: input.criterionId }),
+    evaluatorId: `evaluator-${input.criterionId}`,
+    censored: false,
+    applicability: 'applicable',
+    rowStatus: 'observed',
+  };
+}
+
+const entries: AssertionEntry[] = [
+  observed({ criterionId: 'contains-hello', metricId: 'assert-contains-hello', layerDisposition: 'fact', weight: 2, value: true }),
+  observed({ criterionId: 'contains-missing', metricId: 'assert-contains-missing', layerDisposition: 'fact', weight: 3, value: false }),
+  observed({ criterionId: 'fact-set', metricId: 'assert-fact-set', layerDisposition: 'fact', weight: 2, value: true }),
+  observed({ criterionId: 'max-length', metricId: 'assert-max-length', layerDisposition: 'behavior', weight: 1, value: true }),
+  observed({ criterionId: 'mixed-set', metricId: 'assert-mixed-set', layerDisposition: 'excluded-mixed-layer', weight: 4, value: true }),
+];
+
+function group(
+  sourceEntries: readonly AssertionEntry[] = entries,
+  sampleId = 'sample-a',
+): AssertionLayerGroup {
+  const fact = sourceEntries.filter((entry) => entry.layerDisposition === 'fact');
+  const behavior = sourceEntries.filter((entry) => entry.layerDisposition === 'behavior');
+  const excluded = sourceEntries.filter((entry) => entry.layerDisposition === 'excluded-mixed-layer');
+  const withoutGroupId: Omit<AssertionLayerGroup, 'groupId'> = {
+    targetId: 'target-a',
+    sampleId,
+    trialIndex: 0,
+    trialId: TRIAL_ID,
+    samplingUnitIds: { pairingBlockId: PAIRING_BLOCK_ID },
+    entries: [...sourceEntries],
+    layers: {
+      fact: assertionLayerAggregate(fact),
+      behavior: assertionLayerAggregate(behavior),
+    },
+    excludedMixedLayer: { coverage: assertionLayerCoverage(excluded) },
+  };
+  return { groupId: assertionLayerGroupId(withoutGroupId), ...withoutGroupId };
+}
+
+function envelope(sourceGroup: AssertionLayerGroup = group()): JsonValue {
+  return {
+    resultType: 'table',
+    value: {
+      schemaVersion: ASSERTION_LAYER_TABLE_SCHEMA_VERSION,
+      groups: [sourceGroup],
+    },
+  };
+}
+
+function validator() {
+  const candidate = createAssertionLayerTableSchemaValidators().get(
+    schemaIdentityKey(ASSERTION_LAYER_TABLE_SCHEMA),
+  );
+  if (candidate === undefined) throw new Error('missing assertion-layer table validator');
+  return candidate;
+}
+
+interface MutableEnvelope {
+  value: {
+    groups: Array<{
+      samplingUnitIds: Record<string, string>;
+      entries: Array<{
+        weight: number;
+        applicability: string;
+        rowStatus: string;
+        censored: boolean;
+        reasonCode?: string;
+        value?: boolean;
+      }>;
+      layers: { fact: { score: number; coverage: { passedWeight: number } } };
+    }>;
+  };
+}
+
+describe('assertion-layer table contract', () => {
+  it('reproduces frozen layer scores while preserving mixed-layer evidence', () => {
+    const result = group();
+    expect(result.layers.fact).toMatchObject({
+      layerStatus: 'observed',
+      score: scoringFixture.deterministicAssertions.expectedLayered.layeredScores.factScore,
+      coverage: { declaredCriteria: 3, observedWeight: 7, passedWeight: 4 },
+    });
+    expect(result.layers.behavior).toMatchObject({
+      layerStatus: 'observed',
+      score: scoringFixture.deterministicAssertions.expectedLayered.layeredScores.behaviorScore,
+      coverage: { declaredCriteria: 1, observedWeight: 1, passedWeight: 1 },
+    });
+    expect(result.excludedMixedLayer.coverage).toMatchObject({
+      declaredCriteria: 1,
+      declaredWeight: 4,
+      observedCriteria: 1,
+      passedWeight: 4,
+    });
+    expect(() => validator().parse(envelope(result))).not.toThrow();
+  });
+
+  it('separates structural non-applicability from applicable missing evidence', () => {
+    const source: AssertionEntry[] = [{
+      criterionId: 'not-applicable',
+      metricId: 'metric-a',
+      layerDisposition: 'fact',
+      weight: 2,
+      rowId: digestCanonicalJson('not-applicable'),
+      evaluatorId: 'evaluator-a',
+      censored: false,
+      applicability: 'not-applicable',
+      rowStatus: 'missing',
+      reasonCode: 'criterion-not-applicable',
+    }, {
+      criterionId: 'failed',
+      metricId: 'metric-b',
+      layerDisposition: 'fact',
+      weight: 3,
+      rowId: digestCanonicalJson('failed'),
+      evaluatorId: 'evaluator-b',
+      censored: true,
+      applicability: 'applicable',
+      rowStatus: 'evaluation-failed',
+      reasonCode: 'provider-failed',
+    }];
+    const result = group(source);
+    expect(result.layers.fact).toMatchObject({
+      layerStatus: 'missing',
+      reasonCode: 'assertion-layer-unobserved',
+      coverage: {
+        declaredCriteria: 2,
+        declaredWeight: 5,
+        notApplicableCriteria: 1,
+        notApplicableWeight: 2,
+        applicableCriteria: 1,
+        plannedWeight: 3,
+        evaluationFailedCriteria: 1,
+        evaluationFailedWeight: 3,
+        censoredCriteria: 1,
+        censoredWeight: 3,
+        observedWeight: 0,
+      },
+    });
+    expect(() => validator().parse(envelope(result))).not.toThrow();
+  });
+
+  it('conserves every applicable non-observed status and its weight', () => {
+    const statuses = [
+      ['missing', 'missing'],
+      ['invalid', 'invalid'],
+      ['evaluation-failed', 'evaluationFailed'],
+      ['source-unavailable', 'sourceUnavailable'],
+      ['not-started', 'notStarted'],
+    ] as const;
+    const source = statuses.map(([rowStatus], index): AssertionEntry => ({
+      criterionId: `criterion-${index}`,
+      metricId: `metric-${index}`,
+      layerDisposition: 'fact',
+      weight: index + 1,
+      rowId: digestCanonicalJson({ status: rowStatus }),
+      evaluatorId: `evaluator-${index}`,
+      censored: index === 4,
+      applicability: 'applicable',
+      rowStatus,
+      reasonCode: `reason-${index}`,
+    }));
+    const coverage = assertionLayerCoverage(source);
+    expect(coverage).toMatchObject({
+      declaredCriteria: 5,
+      declaredWeight: 15,
+      applicableCriteria: 5,
+      plannedWeight: 15,
+      observedCriteria: 0,
+      observedWeight: 0,
+      censoredCriteria: 1,
+      censoredWeight: 5,
+    });
+    for (const [, prefix] of statuses) {
+      expect(coverage[`${prefix}Criteria`]).toBe(1);
+    }
+    expect(() => validator().parse(envelope(group(source)))).not.toThrow();
+  });
+
+  it('rejects score, coverage, ordering, design, and sampling-lineage tampering', () => {
+    const valid = envelope();
+    const mutations: Array<(candidate: MutableEnvelope) => void> = [
+      (candidate) => { candidate.value.groups[0].layers.fact.score = 5; },
+      (candidate) => { candidate.value.groups[0].layers.fact.coverage.passedWeight = 7; },
+      (candidate) => { candidate.value.groups[0].entries.reverse(); },
+      (candidate) => { candidate.value.groups[0].entries[0].weight = 99; },
+      (candidate) => { candidate.value.groups[0].samplingUnitIds = {}; },
+    ];
+    for (const mutate of mutations) {
+      const candidate = structuredClone(valid) as unknown as MutableEnvelope;
+      mutate(candidate);
+      expect(() => validator().parse(candidate)).toThrow();
+    }
+  });
+
+  it('rejects duplicate source row lineage across measurement groups', () => {
+    const second = group(entries, 'sample-b');
+    const candidate = envelope() as unknown as { value: { groups: AssertionLayerGroup[] } };
+    candidate.value.groups.push(second);
+    expect(() => validator().parse(candidate)).toThrow('source row identities');
+  });
+
+  it('rejects internally valid groups that disagree on the sealed criterion design', () => {
+    const secondEntries = entries.map((entry): AssertionEntry => ({
+      ...entry,
+      rowId: digestCanonicalJson({ row: entry.criterionId, sampleId: 'sample-b' }),
+      ...(entry.criterionId === 'contains-hello' ? { weight: 9 } : {}),
+    }));
+    const candidate = envelope() as unknown as { value: { groups: AssertionLayerGroup[] } };
+    candidate.value.groups.push(group(secondEntries, 'sample-b'));
+    expect(() => validator().parse(candidate)).toThrow('same sealed criterion design');
+  });
+
+  it('rejects a structurally not-applicable criterion marked as censored', () => {
+    const candidate = structuredClone(envelope()) as unknown as MutableEnvelope;
+    const entry = candidate.value.groups[0].entries[0];
+    entry.applicability = 'not-applicable';
+    entry.rowStatus = 'missing';
+    entry.censored = true;
+    entry.reasonCode = 'criterion-not-applicable';
+    delete entry.value;
+    expect(() => validator().parse(candidate)).toThrow();
+  });
+
+  it('publishes a strict, digest-bound v1 schema identity', () => {
+    expect(ASSERTION_LAYER_TABLE_SCHEMA).toMatchObject({
+      schemaVersion: 'omk.assertion-layer-table/v1',
+      schemaUri: 'urn:omk:analysis-result:assertion-layer-table:v1',
+    });
+    expect(ASSERTION_LAYER_TABLE_SCHEMA.schemaDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(() => validator().parse({
+      ...(envelope() as Record<string, JsonValue>),
+      unknown: true,
+    })).toThrow();
+  });
+});


### PR DESCRIPTION
## 变更说明

为 #496 增加 assertion-layer table v1 输出 schema 与可重算 validator。表按测量单元保留 source row 和 samplingUnitIds，显式区分 fact、behavior、excluded-mixed-layer，并完整守恒 observed／missing／invalid／evaluation-failed／source-unavailable／not-started、censored 与 criterion-not-applicable 的数量和权重。

## 用户影响

本 PR 只发布数据契约和纯计算函数，不注册 Analysis runtime，也不改变现有 CLI 或报告行为。后续执行节点将单独提交。

## 测量学说明

层分只使用 observed applicable 权重，按 `1 + passRatio * 4` 映射到 1–5 并保留两位小数；零 observed weight 输出 missing，不使用数值 0。混层 criterion 保留证据但不进入 fact／behavior。groupId 绑定采样单元、criterion 设计与 source row lineage，validator 可重新计算 coverage、分数与 identity。

无需迁移，未触及评分 prompt、Report schema 或统计公式。关联 #496。