### PR TITLE
feat(analysis): 实现断言分层节点

### DIFF
--- a/src/eval-workflows/runtime-adapter/analysis/assertion-layer-node.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/assertion-layer-node.ts
@@ -1,0 +1,295 @@
+import {
+  RuntimeIdentitySchema,
+  canonicalizeJson,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  type JsonValue,
+  type RuntimeIdentity,
+} from '../../../evaluation-core/contracts/index.js';
+import type {
+  AnalysisMetricRow,
+  AnalysisNodeExecutionContext,
+  AnalysisNodeImplementation,
+  AnalysisNodeInput,
+} from '../../../evaluation-core/analysis/index.js';
+import {
+  ASSERTION_LAYER_PARAMETERS_SCHEMA,
+  parseAssertionLayerParameters,
+  type AssertionLayerCriterionParameter,
+  type AssertionLayerParameters,
+} from './assertion-layer-parameters.js';
+import {
+  ASSERTION_LAYER_SCORE_DECIMALS,
+  ASSERTION_LAYER_SCORE_MAX,
+  ASSERTION_LAYER_SCORE_MIN,
+  ASSERTION_LAYER_TABLE_SCHEMA,
+  ASSERTION_LAYER_TABLE_SCHEMA_VERSION,
+  ASSERTION_NOT_APPLICABLE_REASON,
+  assertionLayerAggregate,
+  assertionLayerCoverage,
+  assertionLayerGroupId,
+  compareAssertionLayerGroups,
+  parseAssertionLayerTableValue,
+  type AssertionEntry,
+  type AssertionLayerGroup,
+  type AssertionLayerTableValue,
+} from './assertion-layer.js';
+import {
+  compareStrings,
+  createStatelessAnalysisImplementation,
+} from './analysis-support.js';
+
+export const ASSERTION_LAYER_ANALYSIS_IMPLEMENTATION_ID =
+  'omk.assertion-layer-table/v1' as const;
+
+const ALGORITHM_VERSION = 'omk.assertion-layer-aggregation/v1' as const;
+
+const ASSERTION_LAYER_CAPABILITIES: JsonValue = {
+  capabilityKind: 'analysis-node',
+  analysisNodeKinds: ['reducer'],
+  inputDomains: [{
+    inputKind: 'metric-observations',
+    valueTypes: ['boolean'],
+    missingPolicyIds: ['exclude/v1'],
+  }],
+  outputSchema: ASSERTION_LAYER_TABLE_SCHEMA,
+  parameterSchema: ASSERTION_LAYER_PARAMETERS_SCHEMA,
+  inputCardinalities: {
+    metricObservations: { min: 1 },
+    analysisResults: { min: 0, max: 0 },
+    comparisons: { min: 0, max: 0 },
+  },
+  schemas: [],
+};
+
+export const ASSERTION_LAYER_ANALYSIS_IDENTITY: RuntimeIdentity = deepFreezeCanonicalJson(
+  RuntimeIdentitySchema.parse({
+    implementationId: ASSERTION_LAYER_ANALYSIS_IMPLEMENTATION_ID,
+    version: '1.0.0',
+    fingerprint: digestCanonicalJson({
+      implementationId: ASSERTION_LAYER_ANALYSIS_IMPLEMENTATION_ID,
+      algorithmVersion: ALGORITHM_VERSION,
+      scoreMapping: {
+        min: ASSERTION_LAYER_SCORE_MIN,
+        max: ASSERTION_LAYER_SCORE_MAX,
+        decimals: ASSERTION_LAYER_SCORE_DECIMALS,
+      },
+      missingPolicyId: 'exclude/v1',
+      metricContract: { scope: 'sample', direction: 'higher-is-better' },
+      structuralNotApplicableReason: ASSERTION_NOT_APPLICABLE_REASON,
+      samplingUnitLineage: 'preserved-from-analysis-metric-rows',
+      criterionDesign: 'sealed-explicit-parameters',
+      outputSchema: ASSERTION_LAYER_TABLE_SCHEMA,
+      parameterSchema: ASSERTION_LAYER_PARAMETERS_SCHEMA,
+      declaredCapabilities: ASSERTION_LAYER_CAPABILITIES,
+    }),
+    fingerprintBasis: 'self-reported',
+    assuranceLevel: 'declared',
+    capabilities: ASSERTION_LAYER_CAPABILITIES,
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
+  }),
+);
+
+type MetricInput = Extract<AnalysisNodeInput, { inputKind: 'metric-observations' }>;
+
+function metricInputs(context: AnalysisNodeExecutionContext): readonly MetricInput[] {
+  const inputs = context.inputs.filter((input): input is MetricInput => (
+    input.inputKind === 'metric-observations'
+  ));
+  if (inputs.length === 0 || inputs.length !== context.inputs.length) {
+    throw new TypeError('Assertion-layer Analysis requires one or more Metric inputs only.');
+  }
+  for (const input of inputs) {
+    if (input.referenceId !== input.metric.metricId
+        || input.metric.valueType !== 'boolean'
+        || input.metric.scope !== 'sample'
+        || input.metric.direction !== 'higher-is-better'
+        || input.metric.missingPolicyId !== 'exclude/v1') {
+      throw new TypeError(
+        'Assertion-layer Analysis requires reference-aligned, sample-scoped, '
+          + 'higher-is-better, exclude/v1 Boolean Metrics.',
+      );
+    }
+  }
+  return inputs;
+}
+
+function baseUnitKey(row: AnalysisMetricRow): string {
+  return canonicalizeJson([row.targetId, row.sampleId, row.trialIndex, row.trialId]);
+}
+
+function entryFromRow(
+  row: AnalysisMetricRow,
+  criterion: AssertionLayerCriterionParameter,
+): AssertionEntry {
+  const base = {
+    ...criterion,
+    rowId: row.rowId,
+    evaluatorId: row.evaluatorId,
+    censored: row.censored,
+  };
+  if (row.rowStatus === 'observed') {
+    if (typeof row.value !== 'boolean') {
+      throw new TypeError('Observed assertion reading must be Boolean.');
+    }
+    return { ...base, applicability: 'applicable', rowStatus: 'observed', value: row.value };
+  }
+  if (row.reasonCode === ASSERTION_NOT_APPLICABLE_REASON) {
+    if (row.rowStatus !== 'missing' || row.censored) {
+      throw new TypeError('criterion-not-applicable must be a non-censored missing row.');
+    }
+    return {
+      ...base,
+      censored: false,
+      applicability: 'not-applicable',
+      rowStatus: 'missing',
+      reasonCode: ASSERTION_NOT_APPLICABLE_REASON,
+    };
+  }
+  return {
+    ...base,
+    applicability: 'applicable',
+    rowStatus: row.rowStatus,
+    reasonCode: row.reasonCode,
+  };
+}
+
+function validateInputDesign(
+  inputs: readonly MetricInput[],
+  parameters: AssertionLayerParameters,
+): ReadonlyMap<string, AssertionLayerCriterionParameter> {
+  const criteriaByMetric = new Map(parameters.criteria.map((criterion) => [
+    criterion.metricId,
+    criterion,
+  ]));
+  const inputMetricIds = inputs.map((input) => input.metric.metricId);
+  if (new Set(inputMetricIds).size !== inputMetricIds.length
+      || canonicalizeJson([...inputMetricIds].sort(compareStrings))
+        !== canonicalizeJson(parameters.criteria.map((criterion) => criterion.metricId))) {
+    throw new TypeError(
+      'Assertion-layer parameters must map every input Metric exactly once and no others.',
+    );
+  }
+  return criteriaByMetric;
+}
+
+function buildAssertionLayerTable(
+  inputs: readonly MetricInput[],
+  parameters: AssertionLayerParameters,
+  signal: AbortSignal,
+): AssertionLayerTableValue {
+  const criteriaByMetric = validateInputDesign(inputs, parameters);
+  const groupedRows = new Map<string, AnalysisMetricRow[]>();
+  for (const input of inputs) {
+    for (const row of input.rows) {
+      if (signal.aborted) throw signal.reason;
+      if (row.metricId !== input.metric.metricId || row.valueType !== 'boolean') {
+        throw new TypeError('Assertion-layer row identity or value type disagrees with its Metric.');
+      }
+      const key = baseUnitKey(row);
+      const members = groupedRows.get(key) ?? [];
+      members.push(row);
+      groupedRows.set(key, members);
+    }
+  }
+  const groups = [...groupedRows.entries()]
+    .sort(([left], [right]) => compareStrings(left, right))
+    .map(([, rows]): AssertionLayerGroup => {
+      const orderedRows = [...rows].sort((left, right) => (
+        compareStrings(left.metricId, right.metricId)
+      ));
+      const first = orderedRows[0];
+      if (orderedRows.length !== parameters.criteria.length
+          || new Set(orderedRows.map((row) => row.metricId)).size !== orderedRows.length) {
+        throw new TypeError(
+          'Every assertion measurement unit must contain exactly one row per Metric.',
+        );
+      }
+      if (new Set(orderedRows.map((row) => canonicalizeJson(row.samplingUnitIds))).size !== 1) {
+        throw new TypeError('Assertion rows disagree on sealed sampling-unit lineage.');
+      }
+      const entries = orderedRows.map((row) => {
+        const criterion = criteriaByMetric.get(row.metricId);
+        if (criterion === undefined) {
+          throw new TypeError(`Assertion Metric "${row.metricId}" is not mapped by parameters.`);
+        }
+        return entryFromRow(row, criterion);
+      });
+      const fact = entries.filter((entry) => entry.layerDisposition === 'fact');
+      const behavior = entries.filter((entry) => entry.layerDisposition === 'behavior');
+      const excluded = entries.filter((entry) => (
+        entry.layerDisposition === 'excluded-mixed-layer'
+      ));
+      const withoutGroupId: Omit<AssertionLayerGroup, 'groupId'> = {
+        targetId: first.targetId,
+        sampleId: first.sampleId,
+        trialIndex: first.trialIndex,
+        trialId: first.trialId,
+        samplingUnitIds: first.samplingUnitIds,
+        entries,
+        layers: {
+          fact: assertionLayerAggregate(fact),
+          behavior: assertionLayerAggregate(behavior),
+        },
+        excludedMixedLayer: { coverage: assertionLayerCoverage(excluded) },
+      };
+      return { groupId: assertionLayerGroupId(withoutGroupId), ...withoutGroupId };
+    });
+  groups.sort(compareAssertionLayerGroups);
+  return parseAssertionLayerTableValue({
+    schemaVersion: ASSERTION_LAYER_TABLE_SCHEMA_VERSION,
+    groups,
+  });
+}
+
+export function createAssertionLayerAnalysisNodes(): ReadonlyMap<
+  string,
+  AnalysisNodeImplementation
+> {
+  const implementation = createStatelessAnalysisImplementation({
+    identity: ASSERTION_LAYER_ANALYSIS_IDENTITY,
+    outputSchema: ASSERTION_LAYER_TABLE_SCHEMA,
+    parseParameters: (parameters) => { parseAssertionLayerParameters(parameters); },
+    execute(context) {
+      const parameters = parseAssertionLayerParameters(context.node.parameters);
+      const inputs = metricInputs(context);
+      validateInputDesign(inputs, parameters);
+      if (inputs.every((input) => input.rows.length === 0)) {
+        return {
+          analysisStatus: 'inconclusive',
+          reasonCodes: ['assertion-layer-no-planned-rows'],
+          includedRowIds: [],
+          comparableRowIds: [],
+          assumptionChecks: [{
+            assumptionId: 'assertion-layer-contract',
+            checkStatus: 'failed',
+            reasonCode: 'assertion-layer-no-planned-rows',
+          }],
+        };
+      }
+      const table = buildAssertionLayerTable(inputs, parameters, context.signal);
+      const dispositionByMetric = new Map(parameters.criteria.map((criterion) => [
+        criterion.metricId,
+        criterion.layerDisposition,
+      ]));
+      const includedRowIds = inputs.flatMap((input) => input.rows.flatMap((row) => (
+        row.rowStatus === 'observed'
+          && dispositionByMetric.get(row.metricId) !== 'excluded-mixed-layer'
+          ? [row.rowId]
+          : []
+      ))).sort(compareStrings);
+      return {
+        analysisStatus: 'completed',
+        resultType: 'table',
+        value: table,
+        includedRowIds,
+        comparableRowIds: includedRowIds,
+        assumptionChecks: [{
+          assumptionId: 'assertion-layer-contract',
+          checkStatus: 'passed',
+        }],
+      };
+    },
+  });
+  return new Map([[ASSERTION_LAYER_ANALYSIS_IMPLEMENTATION_ID, implementation]]);
+}

--- a/src/eval-workflows/runtime-adapter/analysis/index.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/index.ts
@@ -1,3 +1,4 @@
 export * from './assertion-layer-parameters.js';
 export * from './assertion-layer.js';
+export * from './assertion-layer-node.js';
 export * from './judge-aggregation.js';

--- a/test/eval-workflows/runtime-adapter/assertion-layer-node.test.ts
+++ b/test/eval-workflows/runtime-adapter/assertion-layer-node.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalizeJson,
+  digestCanonicalJson,
+  schemaIdentityKey,
+  type JsonValue,
+  type SamplingUnitIds,
+} from '../../../src/evaluation-core/contracts/index.js';
+import { AnalysisNodeCapabilitiesSchema } from '../../../src/evaluation-core/compiler/index.js';
+import type {
+  AnalysisMetricRow,
+  AnalysisNodeExecutionContext,
+  AnalysisNodeExecutionResult,
+  AnalysisNodeInput,
+} from '../../../src/evaluation-core/analysis/index.js';
+import {
+  ASSERTION_LAYER_ANALYSIS_IDENTITY,
+  ASSERTION_LAYER_ANALYSIS_IMPLEMENTATION_ID,
+  createAssertionLayerAnalysisNodes,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/assertion-layer-node.js';
+import {
+  ASSERTION_LAYER_PARAMETERS_SCHEMA,
+  type AssertionLayerCriterionParameter,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/assertion-layer-parameters.js';
+import {
+  ASSERTION_LAYER_TABLE_SCHEMA,
+  createAssertionLayerTableSchemaValidators,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/assertion-layer.js';
+
+const ANALYSIS_PLAN_DIGEST = digestCanonicalJson({ fixture: 'assertion-plan' });
+const EVALUATION_BUNDLE_DIGEST = digestCanonicalJson({ fixture: 'assertion-evaluation' });
+const TRIAL_ID = digestCanonicalJson({ fixture: 'assertion-trial' });
+const PAIRING_BLOCK_ID = digestCanonicalJson({ fixture: 'assertion-pair' });
+
+interface Criterion extends AssertionLayerCriterionParameter {
+  value?: boolean;
+  rowStatus?: Exclude<AnalysisMetricRow['rowStatus'], 'observed'>;
+  reasonCode?: string;
+}
+
+const criteria: Criterion[] = [{
+  criterionId: 'contains-hello',
+  metricId: 'assert-contains-hello',
+  layerDisposition: 'fact',
+  weight: 2,
+  value: true,
+}, {
+  criterionId: 'contains-missing',
+  metricId: 'assert-contains-missing',
+  layerDisposition: 'fact',
+  weight: 3,
+  value: false,
+}, {
+  criterionId: 'fact-set',
+  metricId: 'assert-fact-set',
+  layerDisposition: 'fact',
+  weight: 2,
+  value: true,
+}, {
+  criterionId: 'max-length',
+  metricId: 'assert-max-length',
+  layerDisposition: 'behavior',
+  weight: 1,
+  value: true,
+}, {
+  criterionId: 'mixed-set',
+  metricId: 'assert-mixed-set',
+  layerDisposition: 'excluded-mixed-layer',
+  weight: 4,
+  value: true,
+}];
+
+function parameters(source: readonly Criterion[] = criteria): JsonValue {
+  return {
+    criteria: source.map(({ value: _value, rowStatus: _status, reasonCode: _reason, ...criterion }) => (
+      criterion
+    )),
+  };
+}
+
+function row(
+  criterion: Criterion,
+  samplingUnitIds: SamplingUnitIds = { pairingBlockId: PAIRING_BLOCK_ID },
+): AnalysisMetricRow {
+  const common = {
+    rowId: digestCanonicalJson({ criterionId: criterion.criterionId }),
+    targetId: 'target-a',
+    sampleId: 'sample-a',
+    trialIndex: 0,
+    trialId: TRIAL_ID,
+    evaluatorId: `evaluator-${criterion.criterionId}`,
+    measurement: {
+      instrumentId: criterion.criterionId,
+      ensembleMemberId: 'deterministic',
+      replicateGroupId: 'primary',
+      replicateIndex: 0,
+    },
+    cohortIds: [],
+    metricId: criterion.metricId,
+    valueType: 'boolean' as const,
+    samplingUnitIds,
+    censored: false,
+  };
+  return criterion.rowStatus === undefined
+    ? { ...common, rowStatus: 'observed', value: criterion.value ?? false }
+    : {
+        ...common,
+        rowStatus: criterion.rowStatus,
+        reasonCode: criterion.reasonCode ?? 'assertion-evaluation-failed',
+      };
+}
+
+function metricInput(criterion: Criterion): Extract<
+  AnalysisNodeInput,
+  { inputKind: 'metric-observations' }
+> {
+  return {
+    inputKind: 'metric-observations',
+    referenceId: criterion.metricId,
+    metric: {
+      metricId: criterion.metricId,
+      valueType: 'boolean',
+      scope: 'sample',
+      direction: 'higher-is-better',
+      missingPolicyId: 'exclude/v1',
+    },
+    rows: [row(criterion)],
+  } as Extract<AnalysisNodeInput, { inputKind: 'metric-observations' }>;
+}
+
+function context(
+  source: readonly Criterion[] = criteria,
+  signal: AbortSignal = new AbortController().signal,
+): AnalysisNodeExecutionContext {
+  const inputs = source.map(metricInput);
+  return {
+    node: {
+      analysisNodeKind: 'reducer',
+      nodeId: 'assertion-layer-table',
+      implementationId: ASSERTION_LAYER_ANALYSIS_IMPLEMENTATION_ID,
+      inputs: inputs.map((input) => ({
+        inputKind: input.inputKind,
+        referenceId: input.referenceId,
+      })),
+      outputResultId: 'assertion-layer-table',
+      parameters: parameters(source),
+    } as AnalysisNodeExecutionContext['node'],
+    inputs,
+    analysisPlanDigest: ANALYSIS_PLAN_DIGEST,
+    sampling: {
+      experimentalUnit: 'sample',
+      repeatedMeasures: false,
+      resamplingUnit: 'sample',
+      estimatorId: 'bootstrap.mean-percentile/v1',
+      seedCoupling: 'independent-by-target',
+    } as AnalysisNodeExecutionContext['sampling'],
+    rootSeed: 'root-seed',
+    samples: [] as unknown as AnalysisNodeExecutionContext['samples'],
+    cohorts: [],
+    signal,
+  };
+}
+
+async function execute(
+  executionContext: AnalysisNodeExecutionContext,
+): Promise<AnalysisNodeExecutionResult> {
+  const implementation = createAssertionLayerAnalysisNodes().get(
+    ASSERTION_LAYER_ANALYSIS_IMPLEMENTATION_ID,
+  );
+  if (implementation === undefined) throw new Error('missing assertion-layer implementation');
+  const run = await implementation.openRun({
+    runId: 'run-a',
+    analysisPlanDigest: ANALYSIS_PLAN_DIGEST,
+    evaluationBundleDigest: EVALUATION_BUNDLE_DIGEST,
+    analysisMode: 'preregistered',
+  });
+  try {
+    return await run.execute(executionContext);
+  } finally {
+    await run.dispose();
+  }
+}
+
+function completedValue(result: AnalysisNodeExecutionResult): JsonValue {
+  if (result.analysisStatus !== 'completed') throw new Error('expected completed result');
+  return result.value;
+}
+
+describe('assertion-layer Analysis node', () => {
+  it('declares a compiler-valid, fingerprint-bound Boolean reducer contract', () => {
+    const capabilities = AnalysisNodeCapabilitiesSchema.parse(
+      ASSERTION_LAYER_ANALYSIS_IDENTITY.capabilities,
+    );
+    expect(capabilities.inputDomains).toEqual([{
+      inputKind: 'metric-observations',
+      valueTypes: ['boolean'],
+      missingPolicyIds: ['exclude/v1'],
+    }]);
+    expect(capabilities.outputSchema).toEqual(ASSERTION_LAYER_TABLE_SCHEMA);
+    expect(capabilities.parameterSchema).toEqual(ASSERTION_LAYER_PARAMETERS_SCHEMA);
+    expect(Object.isFrozen(ASSERTION_LAYER_ANALYSIS_IDENTITY)).toBe(true);
+    expect(Object.isFrozen(ASSERTION_LAYER_ANALYSIS_IDENTITY.capabilities)).toBe(true);
+  });
+
+  it('builds canonical layer evidence and excludes mixed-layer rows from included lineage', async () => {
+    const forward = await execute(context());
+    expect(forward).toMatchObject({
+      analysisStatus: 'completed',
+      includedRowIds: expect.any(Array),
+      assumptionChecks: [{
+        assumptionId: 'assertion-layer-contract',
+        checkStatus: 'passed',
+      }],
+    });
+    if (forward.analysisStatus !== 'completed') return;
+    expect(forward.includedRowIds).toHaveLength(4);
+    expect(forward.comparableRowIds).toEqual(forward.includedRowIds);
+    expect(forward.value).toMatchObject({
+      groups: [{
+        samplingUnitIds: { pairingBlockId: PAIRING_BLOCK_ID },
+        layers: {
+          fact: expect.objectContaining({ layerStatus: 'observed', score: 3.29 }),
+          behavior: expect.objectContaining({ layerStatus: 'observed', score: 5 }),
+        },
+        excludedMixedLayer: { coverage: expect.objectContaining({ declaredWeight: 4 }) },
+      }],
+    });
+    const validator = createAssertionLayerTableSchemaValidators().get(
+      schemaIdentityKey(ASSERTION_LAYER_TABLE_SCHEMA),
+    );
+    expect(() => validator?.parse({ resultType: 'table', value: forward.value })).not.toThrow();
+
+    const reverse = await execute(context([...criteria].reverse()));
+    expect(canonicalizeJson(completedValue(reverse))).toBe(canonicalizeJson(forward.value));
+  });
+
+  it('keeps structural non-applicability distinct from applicable failures', async () => {
+    const source: Criterion[] = [{
+      ...criteria[0],
+      value: undefined,
+      rowStatus: 'missing',
+      reasonCode: 'criterion-not-applicable',
+    }, {
+      ...criteria[1],
+      value: undefined,
+      rowStatus: 'evaluation-failed',
+      reasonCode: 'provider-failed',
+    }];
+    const result = await execute(context(source));
+    expect(completedValue(result)).toMatchObject({
+      groups: [{
+        layers: {
+          fact: {
+            layerStatus: 'missing',
+            reasonCode: 'assertion-layer-unobserved',
+            coverage: expect.objectContaining({
+              notApplicableCriteria: 1,
+              applicableCriteria: 1,
+              evaluationFailedCriteria: 1,
+              observedWeight: 0,
+            }),
+          },
+          behavior: expect.objectContaining({ layerStatus: 'missing' }),
+        },
+      }],
+    });
+    expect(result.includedRowIds).toEqual([]);
+  });
+
+  it('fails closed on mapping ambiguity, incomplete units, and sampling disagreement', async () => {
+    const mismatchBase = context();
+    const mismatch = {
+      ...mismatchBase,
+      node: {
+        ...mismatchBase.node,
+        parameters: parameters(criteria.slice(1)),
+      },
+    };
+    await expect(execute(mismatch)).rejects.toThrow('map every input Metric exactly once');
+
+    const incomplete = context();
+    incomplete.inputs = incomplete.inputs.slice(1);
+    await expect(execute(incomplete)).rejects.toThrow('map every input Metric exactly once');
+
+    const disagreement = context();
+    const second = disagreement.inputs[1] as Extract<
+      AnalysisNodeInput,
+      { inputKind: 'metric-observations' }
+    >;
+    disagreement.inputs = [
+      disagreement.inputs[0],
+      { ...second, rows: [row(criteria[1], {})] },
+      ...disagreement.inputs.slice(2),
+    ];
+    await expect(execute(disagreement)).rejects.toThrow('sampling-unit lineage');
+
+    const wrongDomain = context();
+    const first = wrongDomain.inputs[0] as Extract<
+      AnalysisNodeInput,
+      { inputKind: 'metric-observations' }
+    >;
+    wrongDomain.inputs = [{
+      ...first,
+      metric: { ...first.metric, direction: 'lower-is-better' },
+    }, ...wrongDomain.inputs.slice(1)];
+    await expect(execute(wrongDomain)).rejects.toThrow('higher-is-better');
+
+    const wrongReading = context();
+    const readingInput = wrongReading.inputs[0] as Extract<
+      AnalysisNodeInput,
+      { inputKind: 'metric-observations' }
+    >;
+    const reading = readingInput.rows[0];
+    wrongReading.inputs = [{
+      ...readingInput,
+      rows: [{ ...reading, rowStatus: 'observed', value: 'true' }],
+    }, ...wrongReading.inputs.slice(1)];
+    await expect(execute(wrongReading)).rejects.toThrow('must be Boolean');
+  });
+
+  it('returns inconclusive for no rows and honors cancellation before parameter parsing', async () => {
+    const empty = context();
+    empty.inputs = empty.inputs.map((input) => ({
+      ...input,
+      rows: [],
+    })) as AnalysisNodeExecutionContext['inputs'];
+    await expect(execute(empty)).resolves.toMatchObject({
+      analysisStatus: 'inconclusive',
+      reasonCodes: ['assertion-layer-no-planned-rows'],
+    });
+
+    const emptyMismatch = {
+      ...empty,
+      node: { ...empty.node, parameters: parameters(criteria.slice(1)) },
+    };
+    await expect(execute(emptyMismatch)).rejects.toThrow('map every input Metric exactly once');
+
+    const cancelledBase = context();
+    const controller = new AbortController();
+    controller.abort(new Error('cancelled-fixture'));
+    const cancelled = {
+      ...cancelledBase,
+      node: { ...cancelledBase.node, parameters: { invalid: true } },
+      signal: controller.signal,
+    };
+    await expect(execute(cancelled)).rejects.toThrow('cancelled-fixture');
+  });
+});


### PR DESCRIPTION
## 变更说明

为 #496 实现 `omk.assertion-layer-table/v1` Analysis 节点与 fingerprint-bound runtime identity。节点消费 sealed criterion 参数和一组 sample-scoped Boolean Metric rows，按 target／sample／trial 组装已发布的 assertion-layer table 契约。

## 用户影响

本 PR 仅提供节点实现并导出模块，尚不加入 OMK builtins 或 schema validator composition，因此现有计划、CLI 与报告行为不变。注册与真实 Evaluation Core DAG 验证将单独提交。

## 测量学说明

节点在任何数据状态下都先核对参数与 Metric 一一映射，并要求 sample scope、higher-is-better、Boolean、exclude/v1。每个测量单元必须恰有一个 criterion row，samplingUnitIds 必须一致；混层 observed row 不进入 included／comparable lineage，结构性不适用不伪装成缺测。runtime fingerprint 绑定算法版本、分数映射、参数／输出 schema 与 Metric 契约。

无需迁移，未触及评分 prompt、Report schema 或统计公式。关联 #496。