### PR TITLE
feat(analysis): 定义 dimension 参数契约

### DIFF
--- a/src/eval-workflows/runtime-adapter/analysis/dimension-parameters.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/dimension-parameters.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import {
+  IdentifierSchema,
+  schemaIdentityKey,
+  type CoreSchemaValidator,
+  type JsonValue,
+} from '../../../evaluation-core/contracts/index.js';
+import {
+  analysisJsonSchema,
+  analysisSchemaIdentity,
+  compareStrings,
+  createAnalysisSchemaValidator,
+} from './analysis-support.js';
+
+const PARAMETERS_SCHEMA_VERSION = 'omk.parameters.dimension/v1' as const;
+
+export const DimensionParameterSchema = z.object({
+  dimensionId: IdentifierSchema,
+  metricId: IdentifierSchema,
+  analysisResultId: IdentifierSchema,
+}).strict();
+
+const DimensionParametersSchema = z.object({
+  dimensions: z.array(DimensionParameterSchema).min(1),
+}).strict().superRefine((parameters, context) => {
+  for (const field of ['dimensionId', 'metricId', 'analysisResultId'] as const) {
+    const values = parameters.dimensions.map((dimension) => dimension[field]);
+    if (new Set(values).size !== values.length) {
+      context.addIssue({
+        code: 'custom',
+        path: ['dimensions'],
+        message: `Dimension ${field} values must be unique.`,
+      });
+    }
+  }
+});
+
+export type DimensionParameters = z.infer<typeof DimensionParametersSchema>;
+export type DimensionParameter = z.infer<typeof DimensionParameterSchema>;
+
+function compareDimensions(left: DimensionParameter, right: DimensionParameter): number {
+  return compareStrings(left.analysisResultId, right.analysisResultId)
+    || compareStrings(left.metricId, right.metricId)
+    || compareStrings(left.dimensionId, right.dimensionId);
+}
+
+export function parseDimensionParameters(value: unknown): DimensionParameters {
+  const parsed = DimensionParametersSchema.parse(value);
+  return {
+    dimensions: [...parsed.dimensions].sort(compareDimensions),
+  };
+}
+
+export const DIMENSION_PARAMETERS_SCHEMA = analysisSchemaIdentity(
+  PARAMETERS_SCHEMA_VERSION,
+  'urn:omk:parameters:dimension:v1',
+  analysisJsonSchema(DimensionParametersSchema, [
+    'dimensions are normalized by analysisResultId, metricId, and dimensionId before plan sealing',
+    'dimensionId, metricId, and analysisResultId are independently unique',
+    'every dimension binds one explicit upstream Analysis result and one Metric',
+    'dimension identity is never inferred from evaluator, instrument, rubric, or evidence strings',
+  ]),
+);
+
+export function createDimensionParameterSchemaValidators(): ReadonlyMap<
+  string,
+  CoreSchemaValidator
+> {
+  const validator = createAnalysisSchemaValidator(
+    DIMENSION_PARAMETERS_SCHEMA,
+    (value) => parseDimensionParameters(value) as JsonValue,
+  );
+  return new Map([[schemaIdentityKey(validator.schema), validator]]);
+}

--- a/test/eval-workflows/runtime-adapter/dimension-parameters.test.ts
+++ b/test/eval-workflows/runtime-adapter/dimension-parameters.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  schemaIdentityKey,
+} from '../../../src/evaluation-core/contracts/index.js';
+import {
+  DIMENSION_PARAMETERS_SCHEMA,
+  createDimensionParameterSchemaValidators,
+  parseDimensionParameters,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/dimension-parameters.js';
+
+const security = {
+  dimensionId: 'security',
+  metricId: 'rubric-security',
+  analysisResultId: 'ensemble-security',
+} as const;
+const actionability = {
+  dimensionId: 'actionability',
+  metricId: 'rubric-actionability',
+  analysisResultId: 'ensemble-actionability',
+} as const;
+const clarity = {
+  dimensionId: 'clarity',
+  metricId: 'rubric-clarity',
+  analysisResultId: 'ensemble-clarity',
+} as const;
+
+describe('dimension parameter contract', () => {
+  it('normalizes dimensions into one sealed upstream-result order', () => {
+    const expected = { dimensions: [actionability, clarity, security] };
+    expect(parseDimensionParameters({
+      dimensions: [security, actionability, clarity],
+    })).toEqual(expected);
+    expect(parseDimensionParameters({
+      dimensions: [clarity, security, actionability],
+    })).toEqual(expected);
+  });
+
+  it.each([
+    {
+      dimensions: [security, { ...actionability, dimensionId: security.dimensionId }],
+    },
+    {
+      dimensions: [security, { ...actionability, metricId: security.metricId }],
+    },
+    {
+      dimensions: [
+        security,
+        { ...actionability, analysisResultId: security.analysisResultId },
+      ],
+    },
+  ])('rejects ambiguous dimension, metric, or upstream result identities', (parameters) => {
+    expect(() => parseDimensionParameters(parameters)).toThrow();
+  });
+
+  it('rejects empty dimensions, implicit bindings, invalid identifiers, and unknown fields', () => {
+    expect(() => parseDimensionParameters({ dimensions: [] })).toThrow();
+    expect(() => parseDimensionParameters({
+      dimensions: [{ dimensionId: 'security', metricId: 'rubric-security' }],
+    })).toThrow();
+    expect(() => parseDimensionParameters({
+      dimensions: [{ ...security, dimensionId: '' }],
+    })).toThrow();
+    expect(() => parseDimensionParameters({
+      dimensions: [{ ...security, inferredFrom: 'rubric-name' }],
+    })).toThrow();
+  });
+
+  it('registers a validator whose output is the canonical plan materialization', () => {
+    const validator = createDimensionParameterSchemaValidators().get(
+      schemaIdentityKey(DIMENSION_PARAMETERS_SCHEMA),
+    );
+    expect(validator).toBeDefined();
+    expect(validator?.parse({
+      dimensions: [security, actionability, clarity],
+    })).toEqual({ dimensions: [actionability, clarity, security] });
+    expect(validator?.schema.schemaVersion).toBe('omk.parameters.dimension/v1');
+    expect(validator?.schema.schemaUri).toBe('urn:omk:parameters:dimension:v1');
+  });
+});


### PR DESCRIPTION
## 用户影响

为 Evaluation Core 的多 rubric dimension 聚合建立显式、可版本化的设计输入。dimension、Metric 与上游 ensemble Analysis result 形成一一绑定，避免后续运行时通过名称或 evidence 猜测测量设计，也避免同一读数被重复计权。

本 PR 只定义参数契约，不包含聚合表、运行时节点、正式 CLI 或旧 Report 变更，保持可独立审核的小范围。

## 迁移说明

当前正式评测路径不受影响，无需迁移。后续 #505 的 Analysis node 将消费该 sealed 参数；composite 与正式切换继续独立推进。

## 测量学说明

契约固定 legacy 多维评分的等权设计，不引入权重、默认 dimension 或隐式绑定。修改 dimension、Metric 或上游结果身份都会改变 AnalysisPlan，从而保护跨运行可比性。

Closes #505 的 parameter contract 子任务；不关闭 #505。

Parent：#480。
