### PR TITLE
feat(analysis): 定义 dimension 表契约

### DIFF
--- a/src/eval-workflows/runtime-adapter/analysis/dimension-table.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/dimension-table.ts
@@ -1,0 +1,266 @@
+import { z } from 'zod';
+import {
+  IdentifierSchema,
+  SamplingUnitIdsSchema,
+  Sha256DigestSchema,
+  canonicalizeJson,
+  digestCanonicalJson,
+  schemaIdentityKey,
+  type CoreSchemaValidator,
+  type JsonValue,
+} from '../../../evaluation-core/contracts/index.js';
+import {
+  analysisJsonSchema,
+  analysisSchemaIdentity,
+  compareStrings,
+  createAnalysisSchemaValidator,
+  round,
+} from './analysis-support.js';
+
+export const DIMENSION_TABLE_SCHEMA_VERSION = 'omk.dimension-table/v1' as const;
+export const DIMENSION_SCORE_DECIMALS = 2;
+export const DIMENSION_SCORE_MIN = 1;
+export const DIMENSION_SCORE_MAX = 5;
+
+const CountSchema = z.number().int().nonnegative().safe();
+const PositiveCountSchema = z.number().int().positive().safe();
+const ScoreSchema = z.number().finite()
+  .min(DIMENSION_SCORE_MIN)
+  .max(DIMENSION_SCORE_MAX)
+  .refine((value) => round(value, DIMENSION_SCORE_DECIMALS) === value, {
+    message: 'Dimension scores must use the sealed two-decimal precision.',
+  });
+
+const DimensionEntryBaseSchema = z.object({
+  dimensionId: IdentifierSchema,
+  metricId: IdentifierSchema,
+  sourceAnalysisResultId: IdentifierSchema,
+  sourceGroupId: Sha256DigestSchema,
+});
+
+const ObservedDimensionEntrySchema = DimensionEntryBaseSchema.extend({
+  dimensionStatus: z.literal('observed'),
+  consensus: ScoreSchema,
+}).strict();
+
+const MissingDimensionEntrySchema = DimensionEntryBaseSchema.extend({
+  dimensionStatus: z.literal('missing'),
+  reasonCode: z.literal('judge-ensemble-unobserved'),
+}).strict();
+
+const DimensionEntrySchema = z.discriminatedUnion('dimensionStatus', [
+  ObservedDimensionEntrySchema,
+  MissingDimensionEntrySchema,
+]);
+
+const DimensionCoverageSchema = z.object({
+  plannedDimensions: PositiveCountSchema,
+  observedDimensions: CountSchema,
+  missingDimensions: CountSchema,
+}).strict();
+
+const ObservedDimensionAggregateSchema = z.object({
+  aggregateStatus: z.literal('observed'),
+  mean: ScoreSchema,
+}).strict();
+
+const MissingDimensionAggregateSchema = z.object({
+  aggregateStatus: z.literal('missing'),
+  reasonCode: z.literal('dimension-unobserved'),
+}).strict();
+
+const DimensionAggregateSchema = z.discriminatedUnion('aggregateStatus', [
+  ObservedDimensionAggregateSchema,
+  MissingDimensionAggregateSchema,
+]);
+
+const DimensionGroupSchema = z.object({
+  groupId: Sha256DigestSchema,
+  targetId: IdentifierSchema,
+  sampleId: IdentifierSchema,
+  trialIndex: CountSchema,
+  trialId: Sha256DigestSchema,
+  samplingUnitIds: SamplingUnitIdsSchema,
+  dimensions: z.array(DimensionEntrySchema).min(1),
+  coverage: DimensionCoverageSchema,
+  aggregate: DimensionAggregateSchema,
+}).strict();
+
+const DimensionTableValueSchema = z.object({
+  schemaVersion: z.literal(DIMENSION_TABLE_SCHEMA_VERSION),
+  groups: z.array(DimensionGroupSchema).min(1),
+}).strict();
+
+export type DimensionEntry = z.infer<typeof DimensionEntrySchema>;
+export type DimensionCoverage = z.infer<typeof DimensionCoverageSchema>;
+export type DimensionAggregate = z.infer<typeof DimensionAggregateSchema>;
+export type DimensionGroup = z.infer<typeof DimensionGroupSchema>;
+export type DimensionTableValue = z.infer<typeof DimensionTableValueSchema>;
+type Issue = (path: Array<string | number>, message: string) => void;
+
+function unitKey(value: Pick<DimensionGroup,
+  'targetId' | 'sampleId' | 'trialIndex' | 'trialId' | 'samplingUnitIds'
+>): string {
+  return canonicalizeJson([
+    value.targetId,
+    value.sampleId,
+    value.trialIndex,
+    value.trialId,
+    value.samplingUnitIds,
+  ]);
+}
+
+function entryKey(entry: Pick<DimensionEntry,
+  'sourceAnalysisResultId' | 'metricId' | 'dimensionId'
+>): string {
+  return canonicalizeJson([
+    entry.sourceAnalysisResultId,
+    entry.metricId,
+    entry.dimensionId,
+  ]);
+}
+
+export function dimensionCoverage(entries: readonly DimensionEntry[]): DimensionCoverage {
+  const observedDimensions = entries.filter((entry) => (
+    entry.dimensionStatus === 'observed'
+  )).length;
+  return {
+    plannedDimensions: entries.length,
+    observedDimensions,
+    missingDimensions: entries.length - observedDimensions,
+  };
+}
+
+export function dimensionAggregate(entries: readonly DimensionEntry[]): DimensionAggregate {
+  const values = entries.flatMap((entry) => (
+    entry.dimensionStatus === 'observed' ? [entry.consensus] : []
+  ));
+  if (values.length === 0) {
+    return { aggregateStatus: 'missing', reasonCode: 'dimension-unobserved' };
+  }
+  return {
+    aggregateStatus: 'observed',
+    mean: round(
+      values.reduce((sum, value) => sum + value, 0) / values.length,
+      DIMENSION_SCORE_DECIMALS,
+    ),
+  };
+}
+
+export function dimensionGroupId(group: Omit<DimensionGroup, 'groupId'>): string {
+  return digestCanonicalJson({
+    derivation: DIMENSION_TABLE_SCHEMA_VERSION,
+    key: JSON.parse(unitKey(group)) as JsonValue,
+    dimensions: group.dimensions.map((entry) => ({
+      dimensionId: entry.dimensionId,
+      metricId: entry.metricId,
+      sourceAnalysisResultId: entry.sourceAnalysisResultId,
+      sourceGroupId: entry.sourceGroupId,
+    })),
+  });
+}
+
+function assertStableBinding(
+  entries: readonly DimensionEntry[],
+  keyField: 'dimensionId' | 'metricId' | 'sourceAnalysisResultId',
+  issue: Issue,
+): void {
+  const bindings = new Map<string, string>();
+  for (const entry of entries) {
+    const binding = canonicalizeJson({
+      dimensionId: entry.dimensionId,
+      metricId: entry.metricId,
+      sourceAnalysisResultId: entry.sourceAnalysisResultId,
+    });
+    const previous = bindings.get(entry[keyField]);
+    if (previous !== undefined && previous !== binding) {
+      issue(['groups'], `Dimension ${keyField} binding must remain stable across groups.`);
+      return;
+    }
+    bindings.set(entry[keyField], binding);
+  }
+}
+
+function validateDimensionTable(value: DimensionTableValue, issue: Issue): void {
+  const groupKeys = value.groups.map(unitKey);
+  if (new Set(groupKeys).size !== groupKeys.length
+      || canonicalizeJson(groupKeys)
+        !== canonicalizeJson([...groupKeys].sort(compareStrings))) {
+    issue(['groups'], 'Dimension groups must be unique and canonically ordered.');
+  }
+  const allEntries = value.groups.flatMap((group) => group.dimensions);
+  for (const field of ['dimensionId', 'metricId', 'sourceAnalysisResultId'] as const) {
+    assertStableBinding(allEntries, field, issue);
+  }
+  const sourceGroupIds = allEntries.map((entry) => entry.sourceGroupId);
+  if (new Set(sourceGroupIds).size !== sourceGroupIds.length) {
+    issue(['groups'], 'Dimension source group identities must be globally unique.');
+  }
+  for (const [groupIndex, group] of value.groups.entries()) {
+    const entryKeys = group.dimensions.map(entryKey);
+    if (new Set(entryKeys).size !== entryKeys.length
+        || canonicalizeJson(entryKeys)
+          !== canonicalizeJson([...entryKeys].sort(compareStrings))) {
+      issue(
+        ['groups', groupIndex, 'dimensions'],
+        'Dimension entries must be unique and canonically ordered.',
+      );
+    }
+    if (canonicalizeJson(group.coverage)
+        !== canonicalizeJson(dimensionCoverage(group.dimensions))) {
+      issue(['groups', groupIndex, 'coverage'], 'Dimension coverage is not recomputable.');
+    }
+    if (canonicalizeJson(group.aggregate)
+        !== canonicalizeJson(dimensionAggregate(group.dimensions))) {
+      issue(['groups', groupIndex, 'aggregate'], 'Dimension mean is not recomputable.');
+    }
+    if (group.groupId !== dimensionGroupId(group)) {
+      issue(['groups', groupIndex, 'groupId'], 'Dimension group identity does not match lineage.');
+    }
+  }
+}
+
+const DimensionTableEnvelopeSchema = z.object({
+  resultType: z.literal('table'),
+  value: DimensionTableValueSchema,
+}).strict().superRefine((envelope, context) => {
+  validateDimensionTable(envelope.value, (path, message) => {
+    context.addIssue({ code: 'custom', path: ['value', ...path], message });
+  });
+});
+
+export const DIMENSION_TABLE_SCHEMA = analysisSchemaIdentity(
+  DIMENSION_TABLE_SCHEMA_VERSION,
+  'urn:omk:analysis-result:dimension-table:v1',
+  analysisJsonSchema(DimensionTableEnvelopeSchema, [
+    'groups and dimension entries are unique and canonically ordered',
+    'dimension, metric, and upstream Analysis result bindings remain stable across groups',
+    'source ensemble group identities are globally unique',
+    'only dimensions represented by an upstream group are planned for a measurement unit',
+    'coverage exactly conserves observed and missing dimension entries',
+    'source consensus scores use the sealed 2-decimal precision',
+    'the aggregate is the equal mean of observed 1-5 consensus scores rounded to 2 decimals',
+    'zero observed dimensions produces missing rather than numeric zero',
+    'groupId binds the sampling unit, dimension design, and upstream Analysis lineage',
+    'raw judge evidence, usage, cost, and direct Metric row membership are not copied',
+  ]),
+);
+
+export function parseDimensionTableValue(value: unknown): DimensionTableValue {
+  return DimensionTableValueSchema.parse(value);
+}
+
+export function compareDimensionGroups(left: DimensionGroup, right: DimensionGroup): number {
+  return compareStrings(unitKey(left), unitKey(right));
+}
+
+export function createDimensionTableSchemaValidators(): ReadonlyMap<
+  string,
+  CoreSchemaValidator
+> {
+  const validator = createAnalysisSchemaValidator(
+    DIMENSION_TABLE_SCHEMA,
+    (value) => DimensionTableEnvelopeSchema.parse(value) as JsonValue,
+  );
+  return new Map([[schemaIdentityKey(validator.schema), validator]]);
+}

--- a/test/eval-workflows/runtime-adapter/dimension-table.test.ts
+++ b/test/eval-workflows/runtime-adapter/dimension-table.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import {
+  digestCanonicalJson,
+  schemaIdentityKey,
+} from '../../../src/evaluation-core/contracts/index.js';
+import {
+  DIMENSION_TABLE_SCHEMA,
+  DIMENSION_TABLE_SCHEMA_VERSION,
+  createDimensionTableSchemaValidators,
+  dimensionAggregate,
+  dimensionCoverage,
+  dimensionGroupId,
+  type DimensionEntry,
+  type DimensionGroup,
+  type DimensionTableValue,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/dimension-table.js';
+
+const trialId = digestCanonicalJson('dimension-trial');
+const securitySource = digestCanonicalJson('security-source');
+const actionabilitySource = digestCanonicalJson('actionability-source');
+
+const security: DimensionEntry = {
+  dimensionId: 'security',
+  metricId: 'rubric-security',
+  sourceAnalysisResultId: 'ensemble-security',
+  sourceGroupId: securitySource,
+  dimensionStatus: 'observed',
+  consensus: 5,
+};
+
+const actionability: DimensionEntry = {
+  dimensionId: 'actionability',
+  metricId: 'rubric-actionability',
+  sourceAnalysisResultId: 'ensemble-actionability',
+  sourceGroupId: actionabilitySource,
+  dimensionStatus: 'observed',
+  consensus: 3,
+};
+
+function group(input: {
+  sampleId?: string;
+  dimensions?: DimensionEntry[];
+  samplingUnitIds?: Record<string, string>;
+} = {}): DimensionGroup {
+  const dimensions = input.dimensions ?? [actionability, security];
+  const value = {
+    targetId: 'candidate',
+    sampleId: input.sampleId ?? 'sample-a',
+    trialIndex: 0,
+    trialId,
+    samplingUnitIds: input.samplingUnitIds ?? { pairingBlockId: digestCanonicalJson('pair-a') },
+    dimensions,
+    coverage: dimensionCoverage(dimensions),
+    aggregate: dimensionAggregate(dimensions),
+  };
+  return { ...value, groupId: dimensionGroupId(value) };
+}
+
+function envelope(groups: DimensionGroup[] = [group()]) {
+  return {
+    resultType: 'table' as const,
+    value: {
+      schemaVersion: DIMENSION_TABLE_SCHEMA_VERSION,
+      groups,
+    } satisfies DimensionTableValue,
+  };
+}
+
+function validator() {
+  const candidate = createDimensionTableSchemaValidators().get(
+    schemaIdentityKey(DIMENSION_TABLE_SCHEMA),
+  );
+  if (candidate === undefined) throw new Error('missing dimension table validator');
+  return candidate;
+}
+
+describe('dimension table contract', () => {
+  it('reproduces the legacy equal mean while retaining every source dimension', () => {
+    const value = group();
+    expect(value.aggregate).toEqual({ aggregateStatus: 'observed', mean: 4 });
+    expect(value.coverage).toEqual({
+      plannedDimensions: 2,
+      observedDimensions: 2,
+      missingDimensions: 0,
+    });
+    expect(() => validator().parse(envelope([value]))).not.toThrow();
+  });
+
+  it('excludes missing dimensions and reports all-missing units without a zero score', () => {
+    const missing: DimensionEntry = {
+      dimensionId: security.dimensionId,
+      metricId: security.metricId,
+      sourceAnalysisResultId: security.sourceAnalysisResultId,
+      sourceGroupId: security.sourceGroupId,
+      dimensionStatus: 'missing',
+      reasonCode: 'judge-ensemble-unobserved',
+    };
+    expect(dimensionAggregate([actionability, missing])).toEqual({
+      aggregateStatus: 'observed',
+      mean: 3,
+    });
+    expect(dimensionAggregate([missing])).toEqual({
+      aggregateStatus: 'missing',
+      reasonCode: 'dimension-unobserved',
+    });
+  });
+
+  it('accepts different applicable dimension sets across measurement units', () => {
+    const first = group();
+    const secondActionability = {
+      ...actionability,
+      sourceGroupId: digestCanonicalJson('actionability-source-b'),
+    };
+    const second = group({
+      sampleId: 'sample-b',
+      dimensions: [secondActionability],
+      samplingUnitIds: { pairingBlockId: digestCanonicalJson('pair-b') },
+    });
+    expect(() => validator().parse(envelope([first, second]))).not.toThrow();
+  });
+
+  it.each([
+    ['mean', (candidate: ReturnType<typeof envelope>) => {
+      const aggregate = candidate.value.groups[0].aggregate;
+      if (aggregate.aggregateStatus === 'observed') aggregate.mean = 4.5;
+    }],
+    ['coverage', (candidate: ReturnType<typeof envelope>) => {
+      candidate.value.groups[0].coverage.missingDimensions = 1;
+    }],
+    ['source precision', (candidate: ReturnType<typeof envelope>) => {
+      const entry = candidate.value.groups[0].dimensions[0];
+      if (entry.dimensionStatus === 'observed') entry.consensus = 3.333;
+    }],
+    ['group identity', (candidate: ReturnType<typeof envelope>) => {
+      candidate.value.groups[0].groupId = digestCanonicalJson('forged');
+    }],
+    ['entry order', (candidate: ReturnType<typeof envelope>) => {
+      candidate.value.groups[0].dimensions.reverse();
+    }],
+  ])('rejects forged %s', (_name, mutate) => {
+    const candidate = structuredClone(envelope());
+    mutate(candidate);
+    expect(() => validator().parse(candidate)).toThrow();
+  });
+
+  it('rejects unstable bindings, duplicate source lineage, and non-canonical group order', () => {
+    const first = group();
+    const unstable = group({
+      sampleId: 'sample-b',
+      dimensions: [{
+        ...actionability,
+        metricId: 'rubric-actionability-v2',
+        sourceGroupId: digestCanonicalJson('actionability-source-b'),
+      }],
+      samplingUnitIds: { pairingBlockId: digestCanonicalJson('pair-b') },
+    });
+    expect(() => validator().parse(envelope([first, unstable]))).toThrow();
+
+    const duplicateSource = group({
+      sampleId: 'sample-b',
+      dimensions: [actionability],
+      samplingUnitIds: { pairingBlockId: digestCanonicalJson('pair-b') },
+    });
+    expect(() => validator().parse(envelope([first, duplicateSource]))).toThrow();
+
+    const later = group({
+      sampleId: 'sample-z',
+      dimensions: [{
+        ...actionability,
+        sourceGroupId: digestCanonicalJson('actionability-source-z'),
+      }],
+      samplingUnitIds: { pairingBlockId: digestCanonicalJson('pair-z') },
+    });
+    expect(() => validator().parse(envelope([later, first]))).toThrow();
+  });
+
+  it('uses a strict versioned schema and rejects raw judge payloads', () => {
+    const candidate = envelope() as ReturnType<typeof envelope> & {
+      value: { groups: Array<DimensionGroup & { judgeReason?: string }> };
+    };
+    candidate.value.groups[0].judgeReason = 'private reasoning';
+    expect(() => validator().parse(candidate)).toThrow();
+    expect(validator().schema.schemaVersion).toBe('omk.dimension-table/v1');
+    expect(validator().schema.schemaUri).toBe('urn:omk:analysis-result:dimension-table:v1');
+  });
+});


### PR DESCRIPTION
## 用户影响

Evaluation Core 现在有了可版本化、自校验的多 rubric dimension 聚合结果契约。它保留每个实际计划 dimension 的上游 Analysis／group provenance、observed／missing 状态与 coverage，并以等权均值重现现有多维评分；全部缺测时明确返回 missing，不制造零分。

本 PR 只定义 table schema、纯聚合规则和 transported validator，不包含 runtime node、生产注册、composite、正式 CLI 或旧 Report 变更。

## 迁移说明

当前正式评测路径不受影响，无需迁移。后续 #505 runtime node 将生成该 table，并通过 source Analysis／group identity 回链 judge provenance；Analysis-result-only 节点不会把间接来源伪装成 direct Metric row coverage。

## 测量学说明

契约固定 legacy 的 observed-dimension 等权均值与两位小数舍入，同时继承 #494 的诚实缺测语义。不同样本允许不同的适用 dimension 集合，但同一 dimension、Metric 与 upstream result 的绑定在整个结果中必须稳定。

Refs #505。
Parent：#480。
