### PR TITLE
feat(analysis): 实现 dimension 聚合节点

### DIFF
--- a/src/eval-workflows/runtime-adapter/analysis/dimension-node.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/dimension-node.ts
@@ -1,0 +1,252 @@
+import {
+  RuntimeIdentitySchema,
+  canonicalizeJson,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  type JsonValue,
+  type RuntimeIdentity,
+} from '../../../evaluation-core/contracts/index.js';
+import type {
+  AnalysisNodeExecutionContext,
+  AnalysisNodeImplementation,
+  AnalysisNodeInput,
+} from '../../../evaluation-core/analysis/index.js';
+import {
+  DIMENSION_PARAMETERS_SCHEMA,
+  parseDimensionParameters,
+  type DimensionParameter,
+  type DimensionParameters,
+} from './dimension-parameters.js';
+import {
+  DIMENSION_SCORE_DECIMALS,
+  DIMENSION_SCORE_MAX,
+  DIMENSION_SCORE_MIN,
+  DIMENSION_TABLE_SCHEMA,
+  DIMENSION_TABLE_SCHEMA_VERSION,
+  compareDimensionGroups,
+  dimensionAggregate,
+  dimensionCoverage,
+  dimensionGroupId,
+  parseDimensionTableValue,
+  type DimensionEntry,
+  type DimensionGroup,
+  type DimensionTableValue,
+} from './dimension-table.js';
+import {
+  JUDGE_ENSEMBLE_TABLE_SCHEMA,
+  parseJudgeEnsembleTableEnvelope,
+  type JudgeEnsembleGroup,
+} from './judge-aggregation.js';
+import {
+  compareStrings,
+  createStatelessAnalysisImplementation,
+} from './analysis-support.js';
+
+export const DIMENSION_ANALYSIS_IMPLEMENTATION_ID = 'omk.dimension-table/v1' as const;
+
+const ALGORITHM_VERSION = 'omk.dimension-aggregation/v1' as const;
+
+const DIMENSION_ANALYSIS_CAPABILITIES: JsonValue = {
+  capabilityKind: 'analysis-node',
+  analysisNodeKinds: ['reducer'],
+  inputDomains: [{
+    inputKind: 'analysis-result',
+    schemaUris: [JUDGE_ENSEMBLE_TABLE_SCHEMA.schemaUri],
+  }],
+  outputSchema: DIMENSION_TABLE_SCHEMA,
+  parameterSchema: DIMENSION_PARAMETERS_SCHEMA,
+  inputCardinalities: {
+    metricObservations: { min: 0, max: 0 },
+    analysisResults: { min: 1 },
+    comparisons: { min: 0, max: 0 },
+  },
+  schemas: [JUDGE_ENSEMBLE_TABLE_SCHEMA],
+};
+
+export const DIMENSION_ANALYSIS_IDENTITY: RuntimeIdentity = deepFreezeCanonicalJson(
+  RuntimeIdentitySchema.parse({
+    implementationId: DIMENSION_ANALYSIS_IMPLEMENTATION_ID,
+    version: '1.0.0',
+    fingerprint: digestCanonicalJson({
+      implementationId: DIMENSION_ANALYSIS_IMPLEMENTATION_ID,
+      algorithmVersion: ALGORITHM_VERSION,
+      estimator: 'equal-observed-dimension-mean',
+      scoreScale: { min: DIMENSION_SCORE_MIN, max: DIMENSION_SCORE_MAX },
+      decimals: DIMENSION_SCORE_DECIMALS,
+      missingPolicyId: 'exclude/v1',
+      applicability: 'upstream-group-presence',
+      samplingUnitLineage: 'equal-across-upstream-dimensions',
+      directMetricRowMembership: 'none-analysis-results-only',
+      upstreamSchema: JUDGE_ENSEMBLE_TABLE_SCHEMA,
+      outputSchema: DIMENSION_TABLE_SCHEMA,
+      parameterSchema: DIMENSION_PARAMETERS_SCHEMA,
+      declaredCapabilities: DIMENSION_ANALYSIS_CAPABILITIES,
+    }),
+    fingerprintBasis: 'self-reported',
+    assuranceLevel: 'declared',
+    capabilities: DIMENSION_ANALYSIS_CAPABILITIES,
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
+  }),
+);
+
+type AnalysisResultInput = Extract<AnalysisNodeInput, { inputKind: 'analysis-result' }>;
+
+function analysisResultInputs(
+  context: AnalysisNodeExecutionContext,
+): readonly AnalysisResultInput[] {
+  const inputs = context.inputs.filter((input): input is AnalysisResultInput => (
+    input.inputKind === 'analysis-result'
+  ));
+  if (inputs.length === 0 || inputs.length !== context.inputs.length) {
+    throw new TypeError('Dimension Analysis requires one or more Analysis result inputs only.');
+  }
+  for (const input of inputs) {
+    if (input.record.resultType !== 'table'
+        || canonicalizeJson(input.record.outputSchema)
+          !== canonicalizeJson(JUDGE_ENSEMBLE_TABLE_SCHEMA)) {
+      throw new TypeError('Dimension Analysis requires sealed judge ensemble table inputs.');
+    }
+  }
+  return inputs;
+}
+
+function validateInputDesign(
+  inputs: readonly AnalysisResultInput[],
+  parameters: DimensionParameters,
+): ReadonlyMap<string, DimensionParameter> {
+  const dimensionsByResult = new Map(parameters.dimensions.map((dimension) => [
+    dimension.analysisResultId,
+    dimension,
+  ]));
+  const inputIds = inputs.map((input) => input.referenceId);
+  if (new Set(inputIds).size !== inputIds.length
+      || canonicalizeJson([...inputIds].sort(compareStrings))
+        !== canonicalizeJson(parameters.dimensions.map((dimension) => (
+          dimension.analysisResultId
+        )))) {
+    throw new TypeError(
+      'Dimension parameters must map every upstream Analysis result exactly once and no others.',
+    );
+  }
+  return dimensionsByResult;
+}
+
+function coordinateKey(group: JudgeEnsembleGroup): string {
+  return canonicalizeJson([group.targetId, group.sampleId, group.trialIndex]);
+}
+
+function entryFromGroup(
+  group: JudgeEnsembleGroup,
+  dimension: DimensionParameter,
+): DimensionEntry {
+  const common = {
+    dimensionId: dimension.dimensionId,
+    metricId: dimension.metricId,
+    sourceAnalysisResultId: dimension.analysisResultId,
+    sourceGroupId: group.groupId,
+  } as const;
+  return group.aggregateStatus === 'observed'
+    ? { ...common, dimensionStatus: 'observed', consensus: group.consensus }
+    : { ...common, dimensionStatus: 'missing', reasonCode: group.reasonCode };
+}
+
+interface PendingGroup {
+  targetId: string;
+  sampleId: string;
+  trialIndex: number;
+  trialId: JudgeEnsembleGroup['trialId'];
+  samplingUnitIds: JudgeEnsembleGroup['samplingUnitIds'];
+  dimensions: DimensionEntry[];
+}
+
+function buildDimensionTable(
+  inputs: readonly AnalysisResultInput[],
+  parameters: DimensionParameters,
+  signal: AbortSignal,
+): DimensionTableValue {
+  const dimensionsByResult = validateInputDesign(inputs, parameters);
+  const pending = new Map<string, PendingGroup>();
+  for (const input of inputs) {
+    const dimension = dimensionsByResult.get(input.referenceId);
+    if (dimension === undefined) {
+      throw new TypeError(`Upstream Analysis result "${input.referenceId}" is not mapped.`);
+    }
+    const source = parseJudgeEnsembleTableEnvelope({
+      resultType: input.record.resultType,
+      value: input.record.value,
+    }).value;
+    for (const group of source.groups) {
+      if (signal.aborted) throw signal.reason;
+      if (group.metricId !== dimension.metricId) {
+        throw new TypeError('Upstream ensemble Metric disagrees with dimension parameters.');
+      }
+      const key = coordinateKey(group);
+      const existing = pending.get(key);
+      if (existing === undefined) {
+        pending.set(key, {
+          targetId: group.targetId,
+          sampleId: group.sampleId,
+          trialIndex: group.trialIndex,
+          trialId: group.trialId,
+          samplingUnitIds: group.samplingUnitIds,
+          dimensions: [entryFromGroup(group, dimension)],
+        });
+        continue;
+      }
+      if (existing.trialId !== group.trialId
+          || canonicalizeJson(existing.samplingUnitIds)
+            !== canonicalizeJson(group.samplingUnitIds)) {
+        throw new TypeError('Upstream dimensions disagree on sealed measurement-unit lineage.');
+      }
+      if (existing.dimensions.some((entry) => entry.dimensionId === dimension.dimensionId)) {
+        throw new TypeError('A measurement unit contains duplicate upstream dimension groups.');
+      }
+      existing.dimensions.push(entryFromGroup(group, dimension));
+    }
+  }
+  const groups = [...pending.values()].map((source): DimensionGroup => {
+    const dimensions = [...source.dimensions].sort((left, right) => (
+      compareStrings(left.sourceAnalysisResultId, right.sourceAnalysisResultId)
+      || compareStrings(left.metricId, right.metricId)
+      || compareStrings(left.dimensionId, right.dimensionId)
+    ));
+    const withoutGroupId: Omit<DimensionGroup, 'groupId'> = {
+      ...source,
+      dimensions,
+      coverage: dimensionCoverage(dimensions),
+      aggregate: dimensionAggregate(dimensions),
+    };
+    return { groupId: dimensionGroupId(withoutGroupId), ...withoutGroupId };
+  });
+  groups.sort(compareDimensionGroups);
+  return parseDimensionTableValue({ schemaVersion: DIMENSION_TABLE_SCHEMA_VERSION, groups });
+}
+
+export function createDimensionAnalysisNodes(): ReadonlyMap<
+  string,
+  AnalysisNodeImplementation
+> {
+  const implementation = createStatelessAnalysisImplementation({
+    identity: DIMENSION_ANALYSIS_IDENTITY,
+    outputSchema: DIMENSION_TABLE_SCHEMA,
+    parseParameters: (parameters) => { parseDimensionParameters(parameters); },
+    execute(context) {
+      const parameters = parseDimensionParameters(context.node.parameters);
+      const inputs = analysisResultInputs(context);
+      validateInputDesign(inputs, parameters);
+      const table = buildDimensionTable(inputs, parameters, context.signal);
+      return {
+        analysisStatus: 'completed',
+        resultType: 'table',
+        value: table,
+        includedRowIds: [],
+        comparableRowIds: [],
+        assumptionChecks: [{
+          assumptionId: 'dimension-contract',
+          checkStatus: 'passed',
+        }],
+      };
+    },
+  });
+  return new Map([[DIMENSION_ANALYSIS_IMPLEMENTATION_ID, implementation]]);
+}

--- a/src/eval-workflows/runtime-adapter/analysis/judge-aggregation.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/judge-aggregation.ts
@@ -227,6 +227,8 @@ type ReplicateTableValue = z.infer<typeof ReplicateTableValueSchema>;
 type ReplicateGroup = z.infer<typeof ReplicateGroupSchema>;
 type EnsembleTableValue = z.infer<typeof EnsembleTableValueSchema>;
 type EnsembleGroup = z.infer<typeof EnsembleGroupSchema>;
+export type JudgeEnsembleTableValue = EnsembleTableValue;
+export type JudgeEnsembleGroup = EnsembleGroup;
 type Issue = (path: Array<string | number>, message: string) => void;
 
 function mean(values: readonly number[]): number {
@@ -905,4 +907,11 @@ export function createJudgeAggregationSchemaValidators(): ReadonlyMap<
     schemaIdentityKey(candidate.schema),
     candidate,
   ]));
+}
+
+export function parseJudgeEnsembleTableEnvelope(value: unknown): Readonly<{
+  resultType: 'table';
+  value: JudgeEnsembleTableValue;
+}> {
+  return EnsembleEnvelopeSchema.parse(value);
 }

--- a/test/eval-workflows/runtime-adapter/dimension-node.test.ts
+++ b/test/eval-workflows/runtime-adapter/dimension-node.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalizeJson,
+  digestCanonicalJson,
+  schemaIdentityKey,
+  type JsonValue,
+  type SamplingUnitIds,
+} from '../../../src/evaluation-core/contracts/index.js';
+import { AnalysisNodeCapabilitiesSchema } from '../../../src/evaluation-core/compiler/index.js';
+import type {
+  AnalysisNodeExecutionContext,
+  AnalysisNodeExecutionResult,
+  AnalysisNodeInput,
+} from '../../../src/evaluation-core/analysis/index.js';
+import {
+  DIMENSION_ANALYSIS_IDENTITY,
+  DIMENSION_ANALYSIS_IMPLEMENTATION_ID,
+  createDimensionAnalysisNodes,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/dimension-node.js';
+import {
+  DIMENSION_PARAMETERS_SCHEMA,
+  type DimensionParameter,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/dimension-parameters.js';
+import {
+  DIMENSION_TABLE_SCHEMA,
+  createDimensionTableSchemaValidators,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/dimension-table.js';
+import {
+  JUDGE_ENSEMBLE_TABLE_SCHEMA,
+  JUDGE_ENSEMBLE_TABLE_SCHEMA_VERSION,
+  parseJudgeEnsembleTableEnvelope,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/judge-aggregation.js';
+
+const ANALYSIS_PLAN_DIGEST = digestCanonicalJson('dimension-analysis-plan');
+const EVALUATION_BUNDLE_DIGEST = digestCanonicalJson('dimension-evaluation-bundle');
+const TRIAL_ID = digestCanonicalJson('dimension-trial');
+const PAIRING_BLOCK_ID = digestCanonicalJson('dimension-pair');
+
+const security: DimensionParameter = {
+  dimensionId: 'security',
+  metricId: 'rubric-security',
+  analysisResultId: 'ensemble-security',
+};
+const actionability: DimensionParameter = {
+  dimensionId: 'actionability',
+  metricId: 'rubric-actionability',
+  analysisResultId: 'ensemble-actionability',
+};
+
+interface SourceOptions {
+  sampleId?: string;
+  trialId?: string;
+  samplingUnitIds?: SamplingUnitIds;
+  score?: number;
+  missing?: boolean;
+  suffix?: string;
+  instrumentId?: string;
+}
+
+function sourceGroup(dimension: DimensionParameter, options: SourceOptions = {}) {
+  const sampleId = options.sampleId ?? 'sample-a';
+  const trialId = options.trialId ?? TRIAL_ID;
+  const samplingUnitIds = options.samplingUnitIds ?? { pairingBlockId: PAIRING_BLOCK_ID };
+  const suffix = options.suffix ?? sampleId;
+  const instrumentId = options.instrumentId ?? `instrument-${dimension.dimensionId}`;
+  const sourceGroupId = digestCanonicalJson({ dimension: dimension.dimensionId, suffix });
+  const sourceRowId = digestCanonicalJson({ row: dimension.dimensionId, suffix });
+  const member = options.missing
+    ? {
+        ensembleMemberId: 'member-a',
+        sourceGroupId,
+        sourceRowIds: [sourceRowId],
+        coverage: {
+          planned: 1,
+          observed: 0,
+          missing: 0,
+          invalid: 0,
+          evaluationFailed: 1,
+          sourceUnavailable: 0,
+          notStarted: 0,
+          censored: 0,
+        },
+        memberStatus: 'missing' as const,
+        reasonCode: 'judge-replicates-unobserved' as const,
+      }
+    : {
+        ensembleMemberId: 'member-a',
+        sourceGroupId,
+        sourceRowIds: [sourceRowId],
+        coverage: {
+          planned: 1,
+          observed: 1,
+          missing: 0,
+          invalid: 0,
+          evaluationFailed: 0,
+          sourceUnavailable: 0,
+          notStarted: 0,
+          censored: 0,
+        },
+        memberStatus: 'observed' as const,
+        mean: options.score ?? 4,
+        sampleStddev: 0,
+      };
+  const common = {
+    groupId: digestCanonicalJson({
+      derivation: JUDGE_ENSEMBLE_TABLE_SCHEMA_VERSION,
+      key: [
+        'candidate', sampleId, 0, trialId, samplingUnitIds, dimension.metricId,
+        instrumentId, 'primary',
+      ],
+      sourceGroupIds: [sourceGroupId],
+    }),
+    targetId: 'candidate',
+    sampleId,
+    trialIndex: 0,
+    trialId,
+    samplingUnitIds,
+    metricId: dimension.metricId,
+    instrumentId,
+    replicateGroupId: 'primary',
+    coverage: {
+      plannedMembers: 1,
+      observedMembers: options.missing ? 0 : 1,
+      missingMembers: options.missing ? 1 : 0,
+    },
+    members: [member],
+    agreement: {
+      agreementStatus: 'missing' as const,
+      reasonCode: 'judge-agreement-insufficient-members' as const,
+      pairCount: 0 as const,
+    },
+  };
+  return options.missing
+    ? {
+        ...common,
+        aggregateStatus: 'missing' as const,
+        reasonCode: 'judge-ensemble-unobserved' as const,
+      }
+    : { ...common, aggregateStatus: 'observed' as const, consensus: options.score ?? 4 };
+}
+
+type AnalysisResultInput = Extract<AnalysisNodeInput, { inputKind: 'analysis-result' }>;
+
+function input(dimension: DimensionParameter, options: SourceOptions = {}): AnalysisResultInput {
+  const value = {
+    schemaVersion: JUDGE_ENSEMBLE_TABLE_SCHEMA_VERSION,
+    groups: [sourceGroup(dimension, options)],
+  };
+  parseJudgeEnsembleTableEnvelope({ resultType: 'table', value });
+  return {
+    inputKind: 'analysis-result',
+    referenceId: dimension.analysisResultId,
+    record: {
+      analysisStatus: 'completed',
+      resultType: 'table',
+      value,
+      outputSchema: JUDGE_ENSEMBLE_TABLE_SCHEMA,
+    } as unknown as AnalysisResultInput['record'],
+  };
+}
+
+function parameters(dimensions: readonly DimensionParameter[] = [security, actionability]): JsonValue {
+  return { dimensions: dimensions.map((dimension) => ({ ...dimension })) };
+}
+
+function context(
+  inputs: readonly AnalysisResultInput[] = [input(security, { score: 5 }), input(actionability, { score: 3 })],
+  dimensions: readonly DimensionParameter[] = [security, actionability],
+  signal: AbortSignal = new AbortController().signal,
+): AnalysisNodeExecutionContext {
+  return {
+    node: {
+      analysisNodeKind: 'reducer',
+      nodeId: 'dimension-table',
+      implementationId: DIMENSION_ANALYSIS_IMPLEMENTATION_ID,
+      inputs: inputs.map((source) => ({
+        inputKind: source.inputKind,
+        referenceId: source.referenceId,
+      })),
+      outputResultId: 'dimension-table',
+      parameters: parameters(dimensions),
+    } as AnalysisNodeExecutionContext['node'],
+    inputs,
+    analysisPlanDigest: ANALYSIS_PLAN_DIGEST,
+    sampling: {
+      experimentalUnit: 'sample',
+      repeatedMeasures: false,
+      resamplingUnit: 'sample',
+      estimatorId: 'bootstrap.mean-percentile/v1',
+      seedCoupling: 'independent-by-target',
+    } as AnalysisNodeExecutionContext['sampling'],
+    rootSeed: 'root-seed',
+    samples: [] as unknown as AnalysisNodeExecutionContext['samples'],
+    cohorts: [],
+    signal,
+  };
+}
+
+async function execute(
+  executionContext: AnalysisNodeExecutionContext,
+): Promise<AnalysisNodeExecutionResult> {
+  const implementation = createDimensionAnalysisNodes().get(
+    DIMENSION_ANALYSIS_IMPLEMENTATION_ID,
+  );
+  if (implementation === undefined) throw new Error('missing dimension implementation');
+  const run = await implementation.openRun({
+    runId: 'run-a',
+    analysisPlanDigest: ANALYSIS_PLAN_DIGEST,
+    evaluationBundleDigest: EVALUATION_BUNDLE_DIGEST,
+    analysisMode: 'preregistered',
+  });
+  try {
+    return await run.execute(executionContext);
+  } finally {
+    await run.dispose();
+  }
+}
+
+describe('dimension Analysis node', () => {
+  it('declares a compiler-valid, fingerprint-bound Analysis-result reducer contract', () => {
+    const capabilities = AnalysisNodeCapabilitiesSchema.parse(
+      DIMENSION_ANALYSIS_IDENTITY.capabilities,
+    );
+    expect(capabilities.inputDomains).toEqual([{
+      inputKind: 'analysis-result',
+      schemaUris: [JUDGE_ENSEMBLE_TABLE_SCHEMA.schemaUri],
+    }]);
+    expect(capabilities.outputSchema).toEqual(DIMENSION_TABLE_SCHEMA);
+    expect(capabilities.parameterSchema).toEqual(DIMENSION_PARAMETERS_SCHEMA);
+    expect(Object.isFrozen(DIMENSION_ANALYSIS_IDENTITY)).toBe(true);
+    expect(Object.isFrozen(DIMENSION_ANALYSIS_IDENTITY.capabilities)).toBe(true);
+  });
+
+  it('builds a canonical 5 + 3 → 4 table without direct Metric row membership', async () => {
+    const forward = await execute(context());
+    const reverse = await execute(context([
+      input(actionability, { score: 3 }),
+      input(security, { score: 5 }),
+    ]));
+    expect(forward).toEqual(reverse);
+    expect(forward).toMatchObject({
+      analysisStatus: 'completed',
+      includedRowIds: [],
+      comparableRowIds: [],
+      assumptionChecks: [{ assumptionId: 'dimension-contract', checkStatus: 'passed' }],
+      value: {
+        groups: [{
+          aggregate: { aggregateStatus: 'observed', mean: 4 },
+          coverage: { plannedDimensions: 2, observedDimensions: 2, missingDimensions: 0 },
+        }],
+      },
+    });
+    if (forward.analysisStatus !== 'completed') return;
+    const validator = createDimensionTableSchemaValidators().get(
+      schemaIdentityKey(DIMENSION_TABLE_SCHEMA),
+    );
+    expect(() => validator?.parse({ resultType: 'table', value: forward.value })).not.toThrow();
+  });
+
+  it('excludes missing dimensions and preserves all-missing as missing', async () => {
+    const partial = await execute(context([
+      input(security, { missing: true }),
+      input(actionability, { score: 3 }),
+    ]));
+    expect(partial).toMatchObject({
+      value: { groups: [{ aggregate: { aggregateStatus: 'observed', mean: 3 } }] },
+    });
+    const missing = await execute(context([
+      input(security, { missing: true }),
+      input(actionability, { missing: true }),
+    ]));
+    expect(missing).toMatchObject({
+      value: {
+        groups: [{
+          aggregate: { aggregateStatus: 'missing', reasonCode: 'dimension-unobserved' },
+          coverage: { plannedDimensions: 2, observedDimensions: 0, missingDimensions: 2 },
+        }],
+      },
+    });
+  });
+
+  it('treats absent upstream groups as structural non-applicability per unit', async () => {
+    const result = await execute(context([
+      input(security, { sampleId: 'sample-a', score: 5 }),
+      input(actionability, {
+        sampleId: 'sample-b',
+        score: 3,
+        samplingUnitIds: { pairingBlockId: digestCanonicalJson('pair-b') },
+      }),
+    ]));
+    if (result.analysisStatus !== 'completed') throw new Error('expected completed result');
+    const groups = (result.value as { groups: Array<{ coverage: unknown }> }).groups;
+    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.coverage)).toEqual([
+      { plannedDimensions: 1, observedDimensions: 1, missingDimensions: 0 },
+      { plannedDimensions: 1, observedDimensions: 1, missingDimensions: 0 },
+    ]);
+  });
+
+  it('rejects incomplete input mappings, wrong schemas, and mismatched Metrics', async () => {
+    await expect(execute(context([input(security)], [security, actionability]))).rejects.toThrow(
+      'map every upstream Analysis result exactly once',
+    );
+    const wrongSchema = structuredClone(input(security));
+    wrongSchema.record.outputSchema = DIMENSION_TABLE_SCHEMA;
+    await expect(execute(context([wrongSchema], [security]))).rejects.toThrow(
+      'sealed judge ensemble table inputs',
+    );
+    const wrongMetric = input({ ...security, metricId: 'rubric-security-v2' });
+    await expect(execute(context([wrongMetric], [security]))).rejects.toThrow(
+      'Upstream ensemble Metric disagrees with dimension parameters',
+    );
+  });
+
+  it('rejects duplicate dimension groups and conflicting unit lineage', async () => {
+    const duplicate = input(security);
+    const duplicateValue = duplicate.record.value as { groups: unknown[] };
+    duplicateValue.groups.push(sourceGroup(security, {
+      suffix: 'duplicate',
+      instrumentId: 'instrument-security-v2',
+    }));
+    await expect(execute(context([duplicate], [security]))).rejects.toThrow(
+      'duplicate upstream dimension groups',
+    );
+
+    await expect(execute(context([
+      input(security),
+      input(actionability, {
+        trialId: digestCanonicalJson('other-trial'),
+      }),
+    ]))).rejects.toThrow('disagree on sealed measurement-unit lineage');
+  });
+
+  it('cooperatively aborts before building source groups', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('dimension-cancelled'));
+    await expect(execute(context(undefined, undefined, controller.signal))).rejects.toThrow(
+      'dimension-cancelled',
+    );
+  });
+
+  it('does not mutate source envelopes while aggregating', async () => {
+    const inputs = [input(security, { score: 5 }), input(actionability, { score: 3 })];
+    const before = canonicalizeJson(inputs);
+    await execute(context(inputs));
+    expect(canonicalizeJson(inputs)).toBe(before);
+  });
+});


### PR DESCRIPTION
## 用户影响

Evaluation Core 宿主现在具备一个未注册的 dimension 聚合节点实现：它只接受 sealed judge-ensemble tables，通过显式参数把每个 upstream result 绑定到唯一 dimension／Metric，并为每个 target／sample／trial 生成可审计的等权聚合表。

本 PR 不注册 builtin、不接正式 Core DAG、不修改 composite、CLI 或旧 Report。生产可用性与真实 Runtime conformance 留给 #505 的下一独立 PR。

## 迁移说明

当前正式评测路径不受影响，无需迁移。节点明确拒绝输入／参数非双射、错误 upstream schema、Metric 不匹配、同一 unit 的重复 dimension group，以及 trial／sampling lineage 冲突。

## 测量学说明

实现固定 observed dimension 等权均值、两位小数、missing 排除和“upstream group 缺席即结构性不适用”。节点只消费 Analysis results，因此 direct Metric row membership 为空；provenance 通过 source Analysis／group identity 回链，不复制 raw judge 载荷。

Refs #505。
Parent：#480。
