### PR TITLE
feat(analysis): 注册 dimension 聚合运行时

### DIFF
--- a/src/eval-workflows/runtime-adapter/analysis/index.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/index.ts
@@ -1,4 +1,7 @@
 export * from './assertion-layer-parameters.js';
 export * from './assertion-layer.js';
 export * from './assertion-layer-node.js';
+export * from './dimension-parameters.js';
+export * from './dimension-table.js';
+export * from './dimension-node.js';
 export * from './judge-aggregation.js';

--- a/src/eval-workflows/runtime-adapter/builtins.ts
+++ b/src/eval-workflows/runtime-adapter/builtins.ts
@@ -17,6 +17,7 @@ import {
 import type { OmkRuntimeBindingFactories } from './types.js';
 import { createJudgeAggregationAnalysisNodes } from './analysis/judge-aggregation.js';
 import { createAssertionLayerAnalysisNodes } from './analysis/assertion-layer-node.js';
+import { createDimensionAnalysisNodes } from './analysis/dimension-node.js';
 
 export type OmkBuiltinAnalysisBindingFactories = Pick<
   OmkRuntimeBindingFactories,
@@ -90,6 +91,7 @@ export function createBuiltinOmkAnalysisBindingFactories(): OmkBuiltinAnalysisBi
     ...createBuiltinAnalysisNodes(),
     ...createAssertionLayerAnalysisNodes(),
     ...createJudgeAggregationAnalysisNodes(),
+    ...createDimensionAnalysisNodes(),
   ]);
   const missingPolicies = createBuiltinMissingPolicies();
   const decisionPolicies = createBuiltinDecisionPolicies();

--- a/src/eval-workflows/runtime-adapter/composition.ts
+++ b/src/eval-workflows/runtime-adapter/composition.ts
@@ -15,6 +15,8 @@ import { createBuiltinAnalysisSchemaValidators } from '../../evaluation-core/ana
 import { createJudgeAggregationSchemaValidators } from './analysis/judge-aggregation.js';
 import { createAssertionLayerParameterSchemaValidators } from './analysis/assertion-layer-parameters.js';
 import { createAssertionLayerTableSchemaValidators } from './analysis/assertion-layer.js';
+import { createDimensionParameterSchemaValidators } from './analysis/dimension-parameters.js';
+import { createDimensionTableSchemaValidators } from './analysis/dimension-table.js';
 import type { SealedRunPlan } from '../../evaluation-core/compiler/index.js';
 import {
   createEvaluationEngine,
@@ -341,6 +343,12 @@ function captureSchemaValidators(
       [entry[0], entry[1], 'builtin'] as const
     )),
     ...[...createJudgeAggregationSchemaValidators()].map((entry) => (
+      [entry[0], entry[1], 'builtin'] as const
+    )),
+    ...[...createDimensionParameterSchemaValidators()].map((entry) => (
+      [entry[0], entry[1], 'builtin'] as const
+    )),
+    ...[...createDimensionTableSchemaValidators()].map((entry) => (
       [entry[0], entry[1], 'builtin'] as const
     )),
     ...hostEntries.map((entry) => (

--- a/test/eval-workflows/runtime-adapter/assembly.test.ts
+++ b/test/eval-workflows/runtime-adapter/assembly.test.ts
@@ -35,6 +35,7 @@ import {
   createSameProcessEvaluatorAdapter,
   createSameProcessExecutorAdapter,
   ASSERTION_LAYER_ANALYSIS_IMPLEMENTATION_ID,
+  DIMENSION_ANALYSIS_IMPLEMENTATION_ID,
   JUDGE_ENSEMBLE_ANALYSIS_IMPLEMENTATION_ID,
   JUDGE_REPLICATE_ANALYSIS_IMPLEMENTATION_ID,
   resourceLeaseRequestsFromBindingEntries,
@@ -1143,6 +1144,9 @@ describe('OMK Evaluation Runtime binding assembly', () => {
     )).toBe(true);
     expect(builtins.analysisNodesByImplementationId.has(
       JUDGE_ENSEMBLE_ANALYSIS_IMPLEMENTATION_ID,
+    )).toBe(true);
+    expect(builtins.analysisNodesByImplementationId.has(
+      DIMENSION_ANALYSIS_IMPLEMENTATION_ID,
     )).toBe(true);
     expect(builtins.missingPoliciesByImplementationId.has('exclude/v1')).toBe(true);
     expect(builtins.decisionPoliciesByImplementationId.has('progress/v1')).toBe(true);


### PR DESCRIPTION
## 用户影响

将已完成单元验证的 dimension Analysis node、parameter schema 与 output table schema 接入 OMK 宿主 builtin registries，使后续显式 AnalysisGraph 能解析并绑定这一运行时。

本 PR 只有 registry／export 接线与存在性断言，不增加端到端 fixture，不修改评分算法、composite、正式 CLI 或旧 Report。

## 迁移说明

当前正式评测路径不受影响，无需迁移。真实 Core DAG、transported Bundle 重验、阻塞／取消／生命周期 conformance 将在 #505 的下一独立 test-only PR 完成。

## 测量学说明

注册的是已封存 fingerprint、parameter schema 与 table schema 的同一 v1 实现，不引入 ambient default、兼容 reader 或算法副本。

Refs #505。
Parent：#480。
