### PR TITLE
feat(analysis): 定义 composite 参数契约

### DIFF
--- a/src/eval-workflows/runtime-adapter/analysis/composite-parameters.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/composite-parameters.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod';
+import {
+  IdentifierSchema,
+  schemaIdentityKey,
+  type CoreSchemaValidator,
+  type JsonValue,
+} from '../../../evaluation-core/contracts/index.js';
+import {
+  analysisJsonSchema,
+  analysisSchemaIdentity,
+  createAnalysisSchemaValidator,
+} from './analysis-support.js';
+
+const PARAMETERS_SCHEMA_VERSION = 'omk.parameters.composite/v1' as const;
+
+const FactLayerParameterSchema = z.object({
+  layerId: z.literal('fact'),
+  analysisResultId: IdentifierSchema,
+  sourceKind: z.literal('assertion-layer'),
+  selector: z.literal('fact'),
+}).strict();
+
+const BehaviorLayerParameterSchema = z.object({
+  layerId: z.literal('behavior'),
+  analysisResultId: IdentifierSchema,
+  sourceKind: z.literal('assertion-layer'),
+  selector: z.literal('behavior'),
+}).strict();
+
+const EnsembleJudgeLayerParameterSchema = z.object({
+  layerId: z.literal('judge'),
+  analysisResultId: IdentifierSchema,
+  sourceKind: z.literal('judge-ensemble'),
+  selector: z.literal('consensus'),
+}).strict();
+
+const DimensionJudgeLayerParameterSchema = z.object({
+  layerId: z.literal('judge'),
+  analysisResultId: IdentifierSchema,
+  sourceKind: z.literal('dimension'),
+  selector: z.literal('aggregate'),
+}).strict();
+
+export const CompositeLayerParameterSchema = z.discriminatedUnion('selector', [
+  FactLayerParameterSchema,
+  BehaviorLayerParameterSchema,
+  EnsembleJudgeLayerParameterSchema,
+  DimensionJudgeLayerParameterSchema,
+]);
+
+const CompositeParametersSchema = z.object({
+  layers: z.array(CompositeLayerParameterSchema).min(1).max(3),
+}).strict().superRefine((parameters, context) => {
+  const layerIds = parameters.layers.map((layer) => layer.layerId);
+  if (new Set(layerIds).size !== layerIds.length) {
+    context.addIssue({
+      code: 'custom',
+      path: ['layers'],
+      message: 'Composite layerId values must be unique.',
+    });
+  }
+  const fact = parameters.layers.find((layer) => layer.layerId === 'fact');
+  const behavior = parameters.layers.find((layer) => layer.layerId === 'behavior');
+  if (fact !== undefined && behavior !== undefined
+      && fact.analysisResultId !== behavior.analysisResultId) {
+    context.addIssue({
+      code: 'custom',
+      path: ['layers'],
+      message: 'Composite fact and behavior layers must share one assertion-layer result.',
+    });
+  }
+  const sourceKinds = new Map<string, string>();
+  for (const layer of parameters.layers) {
+    const previous = sourceKinds.get(layer.analysisResultId);
+    if (previous !== undefined && previous !== layer.sourceKind) {
+      context.addIssue({
+        code: 'custom',
+        path: ['layers'],
+        message: 'One upstream Analysis result cannot have multiple source kinds.',
+      });
+      break;
+    }
+    sourceKinds.set(layer.analysisResultId, layer.sourceKind);
+  }
+});
+
+export type CompositeParameters = z.infer<typeof CompositeParametersSchema>;
+export type CompositeLayerParameter = z.infer<typeof CompositeLayerParameterSchema>;
+
+const LAYER_ORDER: Readonly<Record<CompositeLayerParameter['layerId'], number>> = {
+  fact: 0,
+  behavior: 1,
+  judge: 2,
+};
+
+export function parseCompositeParameters(value: unknown): CompositeParameters {
+  const parsed = CompositeParametersSchema.parse(value);
+  return {
+    layers: [...parsed.layers].sort((left, right) => (
+      LAYER_ORDER[left.layerId] - LAYER_ORDER[right.layerId]
+    )),
+  };
+}
+
+export const COMPOSITE_PARAMETERS_SCHEMA = analysisSchemaIdentity(
+  PARAMETERS_SCHEMA_VERSION,
+  'urn:omk:parameters:composite:v1',
+  analysisJsonSchema(CompositeParametersSchema, [
+    'layers are normalized in fact, behavior, judge order before plan sealing',
+    'fact, behavior, and judge layer identities are independently unique',
+    'fact and behavior selectors bind the same assertion-layer Analysis result when both exist',
+    'judge explicitly selects either ensemble consensus or dimension aggregate',
+    'one upstream Analysis result has one source schema kind',
+    'layer identity and selectors are never inferred from node, result, Metric, or field names',
+  ]),
+);
+
+export function createCompositeParameterSchemaValidators(): ReadonlyMap<
+  string,
+  CoreSchemaValidator
+> {
+  const validator = createAnalysisSchemaValidator(
+    COMPOSITE_PARAMETERS_SCHEMA,
+    (value) => parseCompositeParameters(value) as JsonValue,
+  );
+  return new Map([[schemaIdentityKey(validator.schema), validator]]);
+}

--- a/test/eval-workflows/runtime-adapter/composite-parameters.test.ts
+++ b/test/eval-workflows/runtime-adapter/composite-parameters.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { schemaIdentityKey } from '../../../src/evaluation-core/contracts/index.js';
+import {
+  COMPOSITE_PARAMETERS_SCHEMA,
+  createCompositeParameterSchemaValidators,
+  parseCompositeParameters,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/composite-parameters.js';
+
+const fact = {
+  layerId: 'fact',
+  analysisResultId: 'assertion-layers',
+  sourceKind: 'assertion-layer',
+  selector: 'fact',
+} as const;
+const behavior = {
+  layerId: 'behavior',
+  analysisResultId: 'assertion-layers',
+  sourceKind: 'assertion-layer',
+  selector: 'behavior',
+} as const;
+const dimensionJudge = {
+  layerId: 'judge',
+  analysisResultId: 'dimension-table',
+  sourceKind: 'dimension',
+  selector: 'aggregate',
+} as const;
+const ensembleJudge = {
+  layerId: 'judge',
+  analysisResultId: 'ensemble-table',
+  sourceKind: 'judge-ensemble',
+  selector: 'consensus',
+} as const;
+
+describe('composite parameter contract', () => {
+  it('normalizes every valid layer combination into fact, behavior, judge order', () => {
+    const expected = { layers: [fact, behavior, dimensionJudge] };
+    expect(parseCompositeParameters({
+      layers: [dimensionJudge, behavior, fact],
+    })).toEqual(expected);
+    expect(parseCompositeParameters({ layers: [fact] })).toEqual({ layers: [fact] });
+    expect(parseCompositeParameters({ layers: [ensembleJudge] })).toEqual({
+      layers: [ensembleJudge],
+    });
+  });
+
+  it('rejects duplicate layers and independently configured fact/behavior sources', () => {
+    expect(() => parseCompositeParameters({ layers: [fact, { ...fact }] })).toThrow();
+    expect(() => parseCompositeParameters({
+      layers: [fact, { ...behavior, analysisResultId: 'other-assertion-layers' }],
+    })).toThrow('share one assertion-layer result');
+    expect(() => parseCompositeParameters({
+      layers: [dimensionJudge, ensembleJudge],
+    })).toThrow();
+    expect(() => parseCompositeParameters({
+      layers: [fact, { ...dimensionJudge, analysisResultId: fact.analysisResultId }],
+    })).toThrow('multiple source kinds');
+  });
+
+  it('rejects implicit selectors, invalid source combinations, empty designs, and unknown fields', () => {
+    expect(() => parseCompositeParameters({ layers: [] })).toThrow();
+    expect(() => parseCompositeParameters({
+      layers: [{ layerId: 'fact', analysisResultId: 'assertion-layers' }],
+    })).toThrow();
+    expect(() => parseCompositeParameters({
+      layers: [{ ...fact, selector: 'consensus' }],
+    })).toThrow();
+    expect(() => parseCompositeParameters({
+      layers: [{ ...dimensionJudge, weight: 0.5 }],
+    })).toThrow();
+  });
+
+  it('registers a validator whose output is the canonical plan materialization', () => {
+    const validator = createCompositeParameterSchemaValidators().get(
+      schemaIdentityKey(COMPOSITE_PARAMETERS_SCHEMA),
+    );
+    expect(validator).toBeDefined();
+    expect(validator?.parse({ layers: [dimensionJudge, fact, behavior] })).toEqual({
+      layers: [fact, behavior, dimensionJudge],
+    });
+    expect(validator?.schema.schemaVersion).toBe('omk.parameters.composite/v1');
+    expect(validator?.schema.schemaUri).toBe('urn:omk:parameters:composite:v1');
+  });
+});


### PR DESCRIPTION
## 用户影响

为 Evaluation Core 的顶层 composite 建立显式、版本化的 layer-source 设计输入。fact、behavior 与 judge 分别绑定到明确 upstream Analysis result／schema／selector，避免运行时根据字段名或输入顺序猜评分层。

本 PR 只定义 parameter contract，不包含 output table、runtime node、registry、正式 CLI 或旧 Report 变更。

## 迁移说明

当前正式评测路径不受影响，无需迁移。fact 与 behavior 若同时参与，必须来自同一个 assertion-layer result；judge 显式选择 single-rubric ensemble consensus 或 multi-rubric dimension aggregate。

## 测量学说明

契约固定 legacy 的三层身份和来源，不引入权重、默认 selector、minimum coverage 或 normalization。同一 upstream result 不能冒充多种 source schema，参数顺序不改变 AnalysisPlan materialization。

Refs #512。
Parent：#480。
