### PR TITLE
feat(analysis): 定义 composite 表契约

### DIFF
--- a/src/eval-workflows/runtime-adapter/analysis/composite-table.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/composite-table.ts
@@ -1,0 +1,280 @@
+import { z } from 'zod';
+import {
+  IdentifierSchema,
+  SamplingUnitIdsSchema,
+  Sha256DigestSchema,
+  canonicalizeJson,
+  digestCanonicalJson,
+  schemaIdentityKey,
+  type CoreSchemaValidator,
+  type JsonValue,
+} from '../../../evaluation-core/contracts/index.js';
+import {
+  analysisJsonSchema,
+  analysisSchemaIdentity,
+  compareStrings,
+  createAnalysisSchemaValidator,
+  round,
+} from './analysis-support.js';
+import {
+  CompositeLayerParameterSchema,
+  type CompositeLayerParameter,
+} from './composite-parameters.js';
+
+export const COMPOSITE_TABLE_SCHEMA_VERSION = 'omk.composite-table/v1' as const;
+export const COMPOSITE_SCORE_DECIMALS = 2;
+export const COMPOSITE_SCORE_MIN = 1;
+export const COMPOSITE_SCORE_MAX = 5;
+
+const CountSchema = z.number().int().nonnegative().safe();
+const PositiveCountSchema = z.number().int().positive().safe();
+const ScoreSchema = z.number().finite()
+  .min(COMPOSITE_SCORE_MIN)
+  .max(COMPOSITE_SCORE_MAX)
+  .refine((value) => round(value, COMPOSITE_SCORE_DECIMALS) === value, {
+    message: 'Composite layer scores must use the sealed two-decimal precision.',
+  });
+
+const CompositeLayerEntryBaseSchema = z.object({
+  binding: CompositeLayerParameterSchema,
+  sourceGroupId: Sha256DigestSchema,
+});
+
+const ObservedCompositeLayerEntrySchema = CompositeLayerEntryBaseSchema.extend({
+  layerStatus: z.literal('observed'),
+  score: ScoreSchema,
+}).strict();
+
+const MissingCompositeLayerEntrySchema = CompositeLayerEntryBaseSchema.extend({
+  layerStatus: z.literal('missing'),
+  reasonCode: IdentifierSchema,
+}).strict();
+
+const CompositeLayerEntrySchema = z.discriminatedUnion('layerStatus', [
+  ObservedCompositeLayerEntrySchema,
+  MissingCompositeLayerEntrySchema,
+]);
+
+const CompositeCoverageSchema = z.object({
+  plannedLayers: PositiveCountSchema,
+  observedLayers: CountSchema,
+  missingLayers: CountSchema,
+}).strict();
+
+const ObservedCompositeAggregateSchema = z.object({
+  aggregateStatus: z.literal('observed'),
+  score: ScoreSchema,
+}).strict();
+
+const MissingCompositeAggregateSchema = z.object({
+  aggregateStatus: z.literal('missing'),
+  reasonCode: z.literal('composite-unobserved'),
+}).strict();
+
+const CompositeAggregateSchema = z.discriminatedUnion('aggregateStatus', [
+  ObservedCompositeAggregateSchema,
+  MissingCompositeAggregateSchema,
+]);
+
+const CompositeGroupSchema = z.object({
+  groupId: Sha256DigestSchema,
+  targetId: IdentifierSchema,
+  sampleId: IdentifierSchema,
+  trialIndex: CountSchema,
+  trialId: Sha256DigestSchema,
+  samplingUnitIds: SamplingUnitIdsSchema,
+  layers: z.array(CompositeLayerEntrySchema).min(1).max(3),
+  coverage: CompositeCoverageSchema,
+  aggregate: CompositeAggregateSchema,
+}).strict();
+
+const CompositeTableValueSchema = z.object({
+  schemaVersion: z.literal(COMPOSITE_TABLE_SCHEMA_VERSION),
+  groups: z.array(CompositeGroupSchema).min(1),
+}).strict();
+
+export type CompositeLayerEntry = z.infer<typeof CompositeLayerEntrySchema>;
+export type CompositeCoverage = z.infer<typeof CompositeCoverageSchema>;
+export type CompositeAggregate = z.infer<typeof CompositeAggregateSchema>;
+export type CompositeGroup = z.infer<typeof CompositeGroupSchema>;
+export type CompositeTableValue = z.infer<typeof CompositeTableValueSchema>;
+type Issue = (path: Array<string | number>, message: string) => void;
+
+const LAYER_ORDER: Readonly<Record<CompositeLayerParameter['layerId'], number>> = {
+  fact: 0,
+  behavior: 1,
+  judge: 2,
+};
+
+const MISSING_REASON_BY_SELECTOR: Readonly<Record<
+  CompositeLayerParameter['selector'],
+  string
+>> = {
+  fact: 'assertion-layer-unobserved',
+  behavior: 'assertion-layer-unobserved',
+  consensus: 'judge-ensemble-unobserved',
+  aggregate: 'dimension-unobserved',
+};
+
+function unitKey(value: Pick<CompositeGroup,
+  'targetId' | 'sampleId' | 'trialIndex' | 'trialId' | 'samplingUnitIds'
+>): string {
+  return canonicalizeJson([
+    value.targetId,
+    value.sampleId,
+    value.trialIndex,
+    value.trialId,
+    value.samplingUnitIds,
+  ]);
+}
+
+export function compareCompositeLayerEntries(
+  left: CompositeLayerEntry,
+  right: CompositeLayerEntry,
+): number {
+  return LAYER_ORDER[left.binding.layerId] - LAYER_ORDER[right.binding.layerId];
+}
+
+export function compositeCoverage(entries: readonly CompositeLayerEntry[]): CompositeCoverage {
+  const observedLayers = entries.filter((entry) => entry.layerStatus === 'observed').length;
+  return {
+    plannedLayers: entries.length,
+    observedLayers,
+    missingLayers: entries.length - observedLayers,
+  };
+}
+
+export function compositeAggregate(entries: readonly CompositeLayerEntry[]): CompositeAggregate {
+  const scores = entries.flatMap((entry) => (
+    entry.layerStatus === 'observed' ? [entry.score] : []
+  ));
+  if (scores.length === 0) {
+    return { aggregateStatus: 'missing', reasonCode: 'composite-unobserved' };
+  }
+  return {
+    aggregateStatus: 'observed',
+    score: round(
+      scores.reduce((sum, score) => sum + score, 0) / scores.length,
+      COMPOSITE_SCORE_DECIMALS,
+    ),
+  };
+}
+
+export function compositeGroupId(group: Omit<CompositeGroup, 'groupId'>): string {
+  return digestCanonicalJson({
+    derivation: COMPOSITE_TABLE_SCHEMA_VERSION,
+    key: JSON.parse(unitKey(group)) as JsonValue,
+    layers: group.layers.map((entry) => ({
+      binding: entry.binding,
+      sourceGroupId: entry.sourceGroupId,
+    })),
+  });
+}
+
+function validateCompositeTable(value: CompositeTableValue, issue: Issue): void {
+  const groupKeys = value.groups.map(unitKey);
+  if (new Set(groupKeys).size !== groupKeys.length
+      || canonicalizeJson(groupKeys)
+        !== canonicalizeJson([...groupKeys].sort(compareStrings))) {
+    issue(['groups'], 'Composite groups must be unique and canonically ordered.');
+  }
+  const bindings = new Map<string, string>();
+  const sourceSelectors = new Set<string>();
+  for (const [groupIndex, group] of value.groups.entries()) {
+    const layerIds = group.layers.map((entry) => entry.binding.layerId);
+    if (new Set(layerIds).size !== layerIds.length
+        || canonicalizeJson(layerIds)
+          !== canonicalizeJson([...layerIds].sort((left, right) => (
+            LAYER_ORDER[left] - LAYER_ORDER[right]
+          )))) {
+      issue(['groups', groupIndex, 'layers'], 'Composite layers must be unique and ordered.');
+    }
+    for (const [entryIndex, entry] of group.layers.entries()) {
+      const binding = canonicalizeJson(entry.binding);
+      const previous = bindings.get(entry.binding.layerId);
+      if (previous !== undefined && previous !== binding) {
+        issue(
+          ['groups', groupIndex, 'layers', entryIndex, 'binding'],
+          'Composite layer binding must remain stable across groups.',
+        );
+      }
+      bindings.set(entry.binding.layerId, binding);
+      const sourceSelector = canonicalizeJson([
+        entry.binding.analysisResultId,
+        entry.sourceGroupId,
+        entry.binding.selector,
+      ]);
+      if (sourceSelectors.has(sourceSelector)) {
+        issue(
+          ['groups', groupIndex, 'layers', entryIndex, 'sourceGroupId'],
+          'Composite source group selector lineage must be globally unique.',
+        );
+      }
+      sourceSelectors.add(sourceSelector);
+      if (entry.layerStatus === 'missing'
+          && entry.reasonCode !== MISSING_REASON_BY_SELECTOR[entry.binding.selector]) {
+        issue(
+          ['groups', groupIndex, 'layers', entryIndex, 'reasonCode'],
+          'Composite missing reason must match the selected upstream aggregate.',
+        );
+      }
+    }
+    if (canonicalizeJson(group.coverage)
+        !== canonicalizeJson(compositeCoverage(group.layers))) {
+      issue(['groups', groupIndex, 'coverage'], 'Composite coverage is not recomputable.');
+    }
+    if (canonicalizeJson(group.aggregate)
+        !== canonicalizeJson(compositeAggregate(group.layers))) {
+      issue(['groups', groupIndex, 'aggregate'], 'Composite score is not recomputable.');
+    }
+    if (group.groupId !== compositeGroupId(group)) {
+      issue(['groups', groupIndex, 'groupId'], 'Composite group identity does not match lineage.');
+    }
+  }
+}
+
+const CompositeTableEnvelopeSchema = z.object({
+  resultType: z.literal('table'),
+  value: CompositeTableValueSchema,
+}).strict().superRefine((envelope, context) => {
+  validateCompositeTable(envelope.value, (path, message) => {
+    context.addIssue({ code: 'custom', path: ['value', ...path], message });
+  });
+});
+
+export const COMPOSITE_TABLE_SCHEMA = analysisSchemaIdentity(
+  COMPOSITE_TABLE_SCHEMA_VERSION,
+  'urn:omk:analysis-result:composite-table:v1',
+  analysisJsonSchema(CompositeTableEnvelopeSchema, [
+    'groups and layer entries are unique and canonically ordered',
+    'fact, behavior, and judge bindings remain stable across groups',
+    'source Analysis result, group, and selector lineage is explicit and unique',
+    'only layers represented by an upstream group are planned for a measurement unit',
+    'missing reason codes exactly match the selected upstream aggregate',
+    'coverage exactly conserves observed and missing layer entries',
+    'layer scores use the sealed 1-5 scale and 2-decimal precision',
+    'the aggregate is the equal mean of observed layer scores rounded to 2 decimals',
+    'zero observed layers produces missing rather than numeric zero',
+    'groupId binds the sampling unit, layer design, and upstream Analysis lineage',
+    'raw evidence, usage, cost, and direct Metric row membership are not copied',
+  ]),
+);
+
+export function parseCompositeTableValue(value: unknown): CompositeTableValue {
+  return CompositeTableValueSchema.parse(value);
+}
+
+export function compareCompositeGroups(left: CompositeGroup, right: CompositeGroup): number {
+  return compareStrings(unitKey(left), unitKey(right));
+}
+
+export function createCompositeTableSchemaValidators(): ReadonlyMap<
+  string,
+  CoreSchemaValidator
+> {
+  const validator = createAnalysisSchemaValidator(
+    COMPOSITE_TABLE_SCHEMA,
+    (value) => CompositeTableEnvelopeSchema.parse(value) as JsonValue,
+  );
+  return new Map([[schemaIdentityKey(validator.schema), validator]]);
+}

--- a/test/eval-workflows/runtime-adapter/composite-table.test.ts
+++ b/test/eval-workflows/runtime-adapter/composite-table.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import { digestCanonicalJson, schemaIdentityKey } from '../../../src/evaluation-core/contracts/index.js';
+import {
+  COMPOSITE_TABLE_SCHEMA,
+  COMPOSITE_TABLE_SCHEMA_VERSION,
+  compositeAggregate,
+  compositeCoverage,
+  compositeGroupId,
+  createCompositeTableSchemaValidators,
+  type CompositeGroup,
+  type CompositeLayerEntry,
+  type CompositeTableValue,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/composite-table.js';
+
+const assertionSource = digestCanonicalJson('assertion-source');
+const judgeSource = digestCanonicalJson('judge-source');
+const trialId = digestCanonicalJson('composite-trial');
+
+const fact: CompositeLayerEntry = {
+  binding: {
+    layerId: 'fact', analysisResultId: 'assertion-layers',
+    sourceKind: 'assertion-layer', selector: 'fact',
+  },
+  sourceGroupId: assertionSource,
+  layerStatus: 'observed',
+  score: 3.29,
+};
+const behavior: CompositeLayerEntry = {
+  binding: {
+    layerId: 'behavior', analysisResultId: 'assertion-layers',
+    sourceKind: 'assertion-layer', selector: 'behavior',
+  },
+  sourceGroupId: assertionSource,
+  layerStatus: 'observed',
+  score: 5,
+};
+const judge: CompositeLayerEntry = {
+  binding: {
+    layerId: 'judge', analysisResultId: 'dimension-table',
+    sourceKind: 'dimension', selector: 'aggregate',
+  },
+  sourceGroupId: judgeSource,
+  layerStatus: 'observed',
+  score: 4,
+};
+
+function group(input: { sampleId?: string; layers?: CompositeLayerEntry[] } = {}): CompositeGroup {
+  const layers = input.layers ?? [fact, behavior, judge];
+  const value = {
+    targetId: 'candidate',
+    sampleId: input.sampleId ?? 'sample-a',
+    trialIndex: 0,
+    trialId,
+    samplingUnitIds: { pairingBlockId: digestCanonicalJson(input.sampleId ?? 'sample-a') },
+    layers,
+    coverage: compositeCoverage(layers),
+    aggregate: compositeAggregate(layers),
+  };
+  return { ...value, groupId: compositeGroupId(value) };
+}
+
+function envelope(groups: CompositeGroup[] = [group()]) {
+  return {
+    resultType: 'table' as const,
+    value: {
+      schemaVersion: COMPOSITE_TABLE_SCHEMA_VERSION,
+      groups,
+    } satisfies CompositeTableValue,
+  };
+}
+
+function validator() {
+  const candidate = createCompositeTableSchemaValidators().get(
+    schemaIdentityKey(COMPOSITE_TABLE_SCHEMA),
+  );
+  if (candidate === undefined) throw new Error('missing composite table validator');
+  return candidate;
+}
+
+describe('composite table contract', () => {
+  it('reproduces the frozen fact + behavior + judge composite exactly', () => {
+    const value = group();
+    expect(value.aggregate).toEqual({ aggregateStatus: 'observed', score: 4.1 });
+    expect(value.coverage).toEqual({ plannedLayers: 3, observedLayers: 3, missingLayers: 0 });
+    expect(() => validator().parse(envelope([value]))).not.toThrow();
+  });
+
+  it('excludes missing layers and preserves all-missing without a zero score', () => {
+    const missingJudge: CompositeLayerEntry = {
+      binding: judge.binding,
+      sourceGroupId: judge.sourceGroupId,
+      layerStatus: 'missing',
+      reasonCode: 'dimension-unobserved',
+    };
+    expect(compositeAggregate([fact, missingJudge])).toEqual({
+      aggregateStatus: 'observed', score: 3.29,
+    });
+    expect(compositeAggregate([missingJudge])).toEqual({
+      aggregateStatus: 'missing', reasonCode: 'composite-unobserved',
+    });
+  });
+
+  it('keeps equal-mean semantics for two layers, one layer, and input order', () => {
+    expect(compositeAggregate([
+      { ...fact, score: 3 },
+      behavior,
+    ])).toEqual({ aggregateStatus: 'observed', score: 4 });
+    expect(compositeAggregate([behavior])).toEqual({ aggregateStatus: 'observed', score: 5 });
+    expect(compositeAggregate([judge])).toEqual({ aggregateStatus: 'observed', score: 4 });
+    expect(compositeAggregate([judge, behavior, fact])).toEqual(
+      compositeAggregate([fact, behavior, judge]),
+    );
+  });
+
+  it('accepts different structurally applicable layer sets across units', () => {
+    const secondJudge = {
+      ...judge,
+      sourceGroupId: digestCanonicalJson('judge-source-b'),
+    };
+    expect(() => validator().parse(envelope([
+      group(),
+      group({ sampleId: 'sample-b', layers: [secondJudge] }),
+    ]))).not.toThrow();
+  });
+
+  it.each([
+    ['score', (candidate: ReturnType<typeof envelope>) => {
+      const aggregate = candidate.value.groups[0].aggregate;
+      if (aggregate.aggregateStatus === 'observed') aggregate.score = 4.5;
+    }],
+    ['source precision', (candidate: ReturnType<typeof envelope>) => {
+      const entry = candidate.value.groups[0].layers[0];
+      if (entry.layerStatus === 'observed') entry.score = 3.291;
+    }],
+    ['coverage', (candidate: ReturnType<typeof envelope>) => {
+      candidate.value.groups[0].coverage.missingLayers = 1;
+    }],
+    ['group identity', (candidate: ReturnType<typeof envelope>) => {
+      candidate.value.groups[0].groupId = digestCanonicalJson('forged');
+    }],
+    ['layer order', (candidate: ReturnType<typeof envelope>) => {
+      candidate.value.groups[0].layers.reverse();
+    }],
+    ['missing reason', (candidate: ReturnType<typeof envelope>) => {
+      const entry = candidate.value.groups[0].layers[2];
+      candidate.value.groups[0].layers[2] = {
+        binding: entry.binding,
+        sourceGroupId: entry.sourceGroupId,
+        layerStatus: 'missing',
+        reasonCode: 'assertion-layer-unobserved',
+      };
+      candidate.value.groups[0].coverage = compositeCoverage(candidate.value.groups[0].layers);
+      candidate.value.groups[0].aggregate = compositeAggregate(candidate.value.groups[0].layers);
+      candidate.value.groups[0].groupId = compositeGroupId(candidate.value.groups[0]);
+    }],
+  ])('rejects forged %s', (_name, mutate) => {
+    const candidate = structuredClone(envelope());
+    mutate(candidate);
+    expect(() => validator().parse(candidate)).toThrow();
+  });
+
+  it('rejects unstable bindings, duplicate source selectors, and raw payloads', () => {
+    const unstableJudge: CompositeLayerEntry = {
+      ...judge,
+      binding: { ...judge.binding, analysisResultId: 'dimension-table-v2' },
+      sourceGroupId: digestCanonicalJson('judge-source-b'),
+    };
+    expect(() => validator().parse(envelope([
+      group(),
+      group({ sampleId: 'sample-b', layers: [unstableJudge] }),
+    ]))).toThrow('binding must remain stable');
+
+    const duplicate = group({ sampleId: 'sample-b', layers: [judge] });
+    expect(() => validator().parse(envelope([group(), duplicate]))).toThrow(
+      'selector lineage must be globally unique',
+    );
+
+    const later = group({
+      sampleId: 'sample-z',
+      layers: [{ ...judge, sourceGroupId: digestCanonicalJson('judge-source-z') }],
+    });
+    expect(() => validator().parse(envelope([later, group()]))).toThrow(
+      'canonically ordered',
+    );
+
+    const raw = envelope() as ReturnType<typeof envelope> & {
+      value: { groups: Array<CompositeGroup & { judgeReason?: string }> };
+    };
+    raw.value.groups[0].judgeReason = 'private';
+    expect(() => validator().parse(raw)).toThrow();
+  });
+});


### PR DESCRIPTION
## 用户影响

Evaluation Core 新增严格、版本化的 `omk.composite-table/v1`，把逐测量单元的 fact／behavior／judge 等权组合结果表达为可校验的 Analysis table。表中显式保留 layer binding、上游 group lineage、observed／missing 状态、coverage 与 content-derived identity，避免消费端隐式重算。

## 测量学边界

仅对实际出现且 observed 的 1–5 分 layer 做等权平均并舍入到两位；缺测不折算为零，全部缺测保持结构化 missing。missing reason 与上游 selector 严格对应，canonical ordering、stable binding、source lineage、coverage、precision 和 aggregate 均可重验。

本 PR 只定义 output contract 与纯聚合规则，不包含 runtime node、registry 接线、正式 CLI／Report cutover，也不引入权重、门槛、Bootstrap、alpha 或 release verdict。

Part of #512。