### PR TITLE
feat(analysis): 适配 composite 上游表

### DIFF
--- a/src/eval-workflows/runtime-adapter/analysis/assertion-layer.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/assertion-layer.ts
@@ -358,7 +358,14 @@ export function createAssertionLayerTableSchemaValidators(): ReadonlyMap<
 > {
   const validator = createAnalysisSchemaValidator(
     ASSERTION_LAYER_TABLE_SCHEMA,
-    (value) => AssertionLayerEnvelopeSchema.parse(value) as JsonValue,
+    (value) => parseAssertionLayerTableEnvelope(value) as JsonValue,
   );
   return new Map([[schemaIdentityKey(validator.schema), validator]]);
+}
+
+export function parseAssertionLayerTableEnvelope(value: unknown): Readonly<{
+  resultType: 'table';
+  value: AssertionLayerTableValue;
+}> {
+  return AssertionLayerEnvelopeSchema.parse(value);
 }

--- a/src/eval-workflows/runtime-adapter/analysis/composite-source-adapter.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/composite-source-adapter.ts
@@ -1,0 +1,88 @@
+import type { SchemaIdentity } from '../../../evaluation-core/contracts/index.js';
+import {
+  ASSERTION_LAYER_TABLE_SCHEMA,
+  parseAssertionLayerTableEnvelope,
+} from './assertion-layer.js';
+import type { CompositeLayerParameter } from './composite-parameters.js';
+import type { CompositeGroup, CompositeLayerEntry } from './composite-table.js';
+import {
+  DIMENSION_TABLE_SCHEMA,
+  parseDimensionTableEnvelope,
+} from './dimension-table.js';
+import {
+  JUDGE_ENSEMBLE_TABLE_SCHEMA,
+  parseJudgeEnsembleTableEnvelope,
+} from './judge-aggregation.js';
+
+export type CompositeSourceLayerGroup = Readonly<Pick<CompositeGroup,
+  'targetId' | 'sampleId' | 'trialIndex' | 'trialId' | 'samplingUnitIds'
+> & { layer: CompositeLayerEntry }>;
+
+export const COMPOSITE_SOURCE_SCHEMAS = Object.freeze([
+  ASSERTION_LAYER_TABLE_SCHEMA,
+  JUDGE_ENSEMBLE_TABLE_SCHEMA,
+  DIMENSION_TABLE_SCHEMA,
+]);
+
+export function compositeSourceSchema(
+  binding: CompositeLayerParameter,
+): SchemaIdentity {
+  switch (binding.sourceKind) {
+    case 'assertion-layer': return ASSERTION_LAYER_TABLE_SCHEMA;
+    case 'judge-ensemble': return JUDGE_ENSEMBLE_TABLE_SCHEMA;
+    case 'dimension': return DIMENSION_TABLE_SCHEMA;
+  }
+}
+
+function sourceGroup(
+  group: Pick<CompositeGroup,
+    'targetId' | 'sampleId' | 'trialIndex' | 'trialId' | 'samplingUnitIds'
+  >,
+  layer: CompositeLayerEntry,
+): CompositeSourceLayerGroup {
+  return {
+    targetId: group.targetId,
+    sampleId: group.sampleId,
+    trialIndex: group.trialIndex,
+    trialId: group.trialId,
+    samplingUnitIds: group.samplingUnitIds,
+    layer,
+  };
+}
+
+export function extractCompositeSourceLayers(
+  binding: CompositeLayerParameter,
+  envelope: unknown,
+  signal?: AbortSignal,
+): readonly CompositeSourceLayerGroup[] {
+  switch (binding.sourceKind) {
+    case 'assertion-layer':
+      return parseAssertionLayerTableEnvelope(envelope).value.groups.map((group) => {
+        if (signal?.aborted === true) throw signal.reason;
+        const aggregate = group.layers[binding.selector];
+        const common = { binding, sourceGroupId: group.groupId } as const;
+        const layer: CompositeLayerEntry = aggregate.layerStatus === 'observed'
+          ? { ...common, layerStatus: 'observed', score: aggregate.score }
+          : { ...common, layerStatus: 'missing', reasonCode: aggregate.reasonCode };
+        return sourceGroup(group, layer);
+      });
+    case 'judge-ensemble':
+      return parseJudgeEnsembleTableEnvelope(envelope).value.groups.map((group) => {
+        if (signal?.aborted === true) throw signal.reason;
+        const common = { binding, sourceGroupId: group.groupId } as const;
+        const layer: CompositeLayerEntry = group.aggregateStatus === 'observed'
+          ? { ...common, layerStatus: 'observed', score: group.consensus }
+          : { ...common, layerStatus: 'missing', reasonCode: group.reasonCode };
+        return sourceGroup(group, layer);
+      });
+    case 'dimension':
+      return parseDimensionTableEnvelope(envelope).value.groups.map((group) => {
+        if (signal?.aborted === true) throw signal.reason;
+        const common = { binding, sourceGroupId: group.groupId } as const;
+        const layer: CompositeLayerEntry = group.aggregate.aggregateStatus === 'observed'
+          ? { ...common, layerStatus: 'observed', score: group.aggregate.mean }
+          : { ...common, layerStatus: 'missing', reasonCode: group.aggregate.reasonCode };
+        return sourceGroup(group, layer);
+      });
+  }
+}

--- a/src/eval-workflows/runtime-adapter/analysis/dimension-table.ts
+++ b/src/eval-workflows/runtime-adapter/analysis/dimension-table.ts
@@ -260,7 +260,14 @@ export function createDimensionTableSchemaValidators(): ReadonlyMap<
 > {
   const validator = createAnalysisSchemaValidator(
     DIMENSION_TABLE_SCHEMA,
-    (value) => DimensionTableEnvelopeSchema.parse(value) as JsonValue,
+    (value) => parseDimensionTableEnvelope(value) as JsonValue,
   );
   return new Map([[schemaIdentityKey(validator.schema), validator]]);
+}
+
+export function parseDimensionTableEnvelope(value: unknown): Readonly<{
+  resultType: 'table';
+  value: DimensionTableValue;
+}> {
+  return DimensionTableEnvelopeSchema.parse(value);
 }

--- a/test/eval-workflows/runtime-adapter/composite-source-adapter.test.ts
+++ b/test/eval-workflows/runtime-adapter/composite-source-adapter.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalizeJson,
+  digestCanonicalJson,
+} from '../../../src/evaluation-core/contracts/index.js';
+import {
+  ASSERTION_LAYER_TABLE_SCHEMA,
+  ASSERTION_LAYER_TABLE_SCHEMA_VERSION,
+  assertionLayerAggregate,
+  assertionLayerCoverage,
+  assertionLayerGroupId,
+  type AssertionEntry,
+  type AssertionLayerGroup,
+  type AssertionLayerTableValue,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/assertion-layer.js';
+import type { CompositeLayerParameter } from '../../../src/eval-workflows/runtime-adapter/analysis/composite-parameters.js';
+import {
+  compositeSourceSchema,
+  extractCompositeSourceLayers,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/composite-source-adapter.js';
+import {
+  DIMENSION_TABLE_SCHEMA,
+  DIMENSION_TABLE_SCHEMA_VERSION,
+  dimensionAggregate,
+  dimensionCoverage,
+  dimensionGroupId,
+  type DimensionEntry,
+  type DimensionGroup,
+  type DimensionTableValue,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/dimension-table.js';
+import {
+  JUDGE_ENSEMBLE_TABLE_SCHEMA,
+  JUDGE_ENSEMBLE_TABLE_SCHEMA_VERSION,
+  type JudgeEnsembleTableValue,
+} from '../../../src/eval-workflows/runtime-adapter/analysis/judge-aggregation.js';
+
+const trialId = digestCanonicalJson('composite-source-trial');
+const samplingUnitIds = { pairingBlockId: digestCanonicalJson('composite-source-pair') };
+
+const factBinding: CompositeLayerParameter = {
+  layerId: 'fact', analysisResultId: 'assertion-layers',
+  sourceKind: 'assertion-layer', selector: 'fact',
+};
+const behaviorBinding: CompositeLayerParameter = {
+  layerId: 'behavior', analysisResultId: 'assertion-layers',
+  sourceKind: 'assertion-layer', selector: 'behavior',
+};
+const ensembleBinding: CompositeLayerParameter = {
+  layerId: 'judge', analysisResultId: 'judge-ensemble',
+  sourceKind: 'judge-ensemble', selector: 'consensus',
+};
+const dimensionBinding: CompositeLayerParameter = {
+  layerId: 'judge', analysisResultId: 'dimension-table',
+  sourceKind: 'dimension', selector: 'aggregate',
+};
+
+function assertionEnvelope() {
+  const entries: AssertionEntry[] = [{
+    criterionId: 'fact-check',
+    metricId: 'assert-fact-check',
+    layerDisposition: 'fact',
+    weight: 1,
+    rowId: digestCanonicalJson('assertion-row'),
+    evaluatorId: 'assertion-evaluator',
+    censored: false,
+    applicability: 'applicable',
+    rowStatus: 'observed',
+    value: true,
+  }];
+  const withoutGroupId: Omit<AssertionLayerGroup, 'groupId'> = {
+    targetId: 'candidate', sampleId: 'sample-a', trialIndex: 0, trialId,
+    samplingUnitIds,
+    entries,
+    layers: {
+      fact: assertionLayerAggregate(entries),
+      behavior: assertionLayerAggregate([]),
+    },
+    excludedMixedLayer: { coverage: assertionLayerCoverage([]) },
+  };
+  return {
+    resultType: 'table' as const,
+    value: {
+      schemaVersion: ASSERTION_LAYER_TABLE_SCHEMA_VERSION,
+      groups: [{ groupId: assertionLayerGroupId(withoutGroupId), ...withoutGroupId }],
+    } satisfies AssertionLayerTableValue,
+  };
+}
+
+function ensembleEnvelope() {
+  const sourceGroupId = digestCanonicalJson('replicate-group');
+  const sourceRowId = digestCanonicalJson('judge-row');
+  const group = {
+    groupId: digestCanonicalJson({
+      derivation: JUDGE_ENSEMBLE_TABLE_SCHEMA_VERSION,
+      key: [
+        'candidate', 'sample-a', 0, trialId, samplingUnitIds,
+        'rubric-quality', 'quality-instrument', 'primary',
+      ],
+      sourceGroupIds: [sourceGroupId],
+    }),
+    targetId: 'candidate', sampleId: 'sample-a', trialIndex: 0, trialId,
+    samplingUnitIds,
+    metricId: 'rubric-quality',
+    instrumentId: 'quality-instrument',
+    replicateGroupId: 'primary',
+    coverage: { plannedMembers: 1, observedMembers: 1, missingMembers: 0 },
+    members: [{
+      ensembleMemberId: 'member-a', sourceGroupId, sourceRowIds: [sourceRowId],
+      coverage: {
+        planned: 1, observed: 1, missing: 0, invalid: 0,
+        evaluationFailed: 0, sourceUnavailable: 0, notStarted: 0, censored: 0,
+      },
+      memberStatus: 'observed' as const,
+      mean: 4,
+      sampleStddev: 0,
+    }],
+    agreement: {
+      agreementStatus: 'missing' as const,
+      reasonCode: 'judge-agreement-insufficient-members' as const,
+      pairCount: 0 as const,
+    },
+    aggregateStatus: 'observed' as const,
+    consensus: 4,
+  };
+  return {
+    resultType: 'table' as const,
+    value: {
+      schemaVersion: JUDGE_ENSEMBLE_TABLE_SCHEMA_VERSION,
+      groups: [group],
+    } satisfies JudgeEnsembleTableValue,
+  };
+}
+
+function dimensionEnvelope(missing = false) {
+  const entry: DimensionEntry = missing
+    ? {
+        dimensionId: 'quality', metricId: 'rubric-quality',
+        sourceAnalysisResultId: 'judge-ensemble',
+        sourceGroupId: digestCanonicalJson('dimension-source'),
+        dimensionStatus: 'missing', reasonCode: 'judge-ensemble-unobserved',
+      }
+    : {
+        dimensionId: 'quality', metricId: 'rubric-quality',
+        sourceAnalysisResultId: 'judge-ensemble',
+        sourceGroupId: digestCanonicalJson('dimension-source'),
+        dimensionStatus: 'observed', consensus: 3.5,
+      };
+  const withoutGroupId: Omit<DimensionGroup, 'groupId'> = {
+    targetId: 'candidate', sampleId: 'sample-a', trialIndex: 0, trialId,
+    samplingUnitIds,
+    dimensions: [entry],
+    coverage: dimensionCoverage([entry]),
+    aggregate: dimensionAggregate([entry]),
+  };
+  return {
+    resultType: 'table' as const,
+    value: {
+      schemaVersion: DIMENSION_TABLE_SCHEMA_VERSION,
+      groups: [{ groupId: dimensionGroupId(withoutGroupId), ...withoutGroupId }],
+    } satisfies DimensionTableValue,
+  };
+}
+
+describe('composite source adapter', () => {
+  it('binds every source kind to its exact sealed schema', () => {
+    expect(canonicalizeJson(compositeSourceSchema(factBinding)))
+      .toBe(canonicalizeJson(ASSERTION_LAYER_TABLE_SCHEMA));
+    expect(canonicalizeJson(compositeSourceSchema(ensembleBinding)))
+      .toBe(canonicalizeJson(JUDGE_ENSEMBLE_TABLE_SCHEMA));
+    expect(canonicalizeJson(compositeSourceSchema(dimensionBinding)))
+      .toBe(canonicalizeJson(DIMENSION_TABLE_SCHEMA));
+  });
+
+  it('selects fact and behavior independently from one assertion source group', () => {
+    const fact = extractCompositeSourceLayers(factBinding, assertionEnvelope())[0];
+    const behavior = extractCompositeSourceLayers(behaviorBinding, assertionEnvelope())[0];
+    expect(fact.layer).toMatchObject({
+      binding: factBinding,
+      sourceGroupId: behavior.layer.sourceGroupId,
+      layerStatus: 'observed',
+      score: 5,
+    });
+    expect(behavior.layer).toMatchObject({
+      binding: behaviorBinding,
+      layerStatus: 'missing',
+      reasonCode: 'assertion-layer-unobserved',
+    });
+  });
+
+  it('maps ensemble consensus and dimension aggregate without normalization', () => {
+    expect(extractCompositeSourceLayers(ensembleBinding, ensembleEnvelope())[0].layer)
+      .toMatchObject({ layerStatus: 'observed', score: 4 });
+    expect(extractCompositeSourceLayers(dimensionBinding, dimensionEnvelope())[0].layer)
+      .toMatchObject({ layerStatus: 'observed', score: 3.5 });
+    expect(extractCompositeSourceLayers(dimensionBinding, dimensionEnvelope(true))[0].layer)
+      .toMatchObject({ layerStatus: 'missing', reasonCode: 'dimension-unobserved' });
+  });
+
+  it('validates upstream semantics and never infers a source schema from payload shape', () => {
+    const forged = structuredClone(dimensionEnvelope());
+    const aggregate = forged.value.groups[0].aggregate;
+    if (aggregate.aggregateStatus === 'observed') aggregate.mean = 4.5;
+    expect(() => extractCompositeSourceLayers(dimensionBinding, forged)).toThrow();
+    expect(() => extractCompositeSourceLayers(ensembleBinding, dimensionEnvelope())).toThrow();
+  });
+
+  it('propagates cancellation before converting source groups', () => {
+    const controller = new AbortController();
+    const reason = new Error('cancel composite extraction');
+    controller.abort(reason);
+    expect(() => extractCompositeSourceLayers(
+      dimensionBinding,
+      dimensionEnvelope(),
+      controller.signal,
+    )).toThrow(reason);
+  });
+});


### PR DESCRIPTION
## 用户影响

Evaluation Core 的 composite 迁移新增独立 source adapter，以显式 binding 从 assertion-layer、judge-ensemble 或 dimension 的版本化 Analysis table 提取统一 layer entry。fact 与 behavior 可从同一 assertion group 独立选择，judge 则严格选择 ensemble consensus 或 dimension aggregate。

## 架构与测量边界

adapter 先执行各上游表的完整语义校验，再原样映射 observed／missing、score、reason code、统计单元与 source group lineage；不做归一化、不猜 payload 类型，也不读取 Analysis record 或合并 measurement unit。取消信号逐 source group 传播。

本 PR 是 #512 runtime node 的前置小切片，不包含 node identity、input 双射、unit 合并、registry、Core DAG 或正式 CLI／Report cutover。

Part of #512。