### PR TITLE
refactor(eval)!: BREAKING-COMPARABILITY 修正异步 assertion 的 not 语义

### DIFF
--- a/docs/reference/eval-sample-format.md
+++ b/docs/reference/eval-sample-format.md
@@ -55,7 +55,7 @@ Compatibility note: flat-skill sidecars such as `skills/<name>.eval-samples.json
 | `assertions[].threshold` | `number` | no | Pass threshold; default depends on type — `3` for LLM-scored types, `0.5` for `rouge_n_min` / `bleu_min`, `1` for `mock_hit` |
 | `assertions[].fn` | `string` | depends | Path to a custom assertion JS file (required for `custom`) |
 | `assertions[].weight` | `number` | no | Weight (default 1) |
-| `assertions[].not` | `boolean` | no | Invert this assertion's pass/fail; works with any type |
+| `assertions[].not` | `boolean` | no | Invert a valid pass/fail reading; works with any type |
 | `assertions[].n` | `number` | no | n-gram order for `rouge_n_min` (default 1) |
 | `dimensions` | `object` | no | Multi-dimension scoring; key = dimension name, value = scoring guideline |
 
@@ -213,6 +213,8 @@ Any assertion takes `not: true` to invert (replaces paired `not_contains` / `not
   pattern: "TODO|FIXME"
   not: true              # output must NOT contain TODO/FIXME
 ```
+
+For async judge-backed and custom assertions, inversion happens only after a valid raw pass/fail reading exists. Provider failure, timeout, cancellation, budget censoring, missing input, and invalid output remain failures or missing evidence; `not: true` never turns infrastructure or protocol failure into a pass.
 
 **Composition (assert-set):**
 

--- a/docs/specs/evaluation-scoring-equivalence.md
+++ b/docs/specs/evaluation-scoring-equivalence.md
@@ -52,13 +52,13 @@ The host owns provider calls, prompt registry access, custom-module loading, and
 |---|---|---|---|
 | deterministic assertion | output and evaluation context; execution-aware leaves additionally require Core-owned execution facts | Boolean criterion result; assertion detail as evidence | assertion algorithm version and supported type registry |
 | custom assertion | output and evaluation context; verified resource lease | Boolean criterion result or structured evaluator failure | module content identity and sandbox/resource policy |
-| semantic similarity | output, expected/evaluation context | Boolean threshold result; fixed-response parse evidence | semantic prompt hash, model Runtime identity, threshold |
-| RAG metric | output and evaluation context | Boolean threshold result; fixed-response parse evidence | metric-specific prompt hash, model Runtime identity, threshold |
+| semantic similarity | output, expected/evaluation context | Boolean threshold result; fixed-response parse evidence | semantic prompt hash, model Runtime identity, threshold, negation |
+| RAG metric | output and evaluation context | Boolean threshold result; fixed-response parse evidence | metric-specific prompt hash, model Runtime identity, threshold, negation |
 | rubric judge | output, optional trace, evaluation context | Raw numeric reading on the 1–5 scale | rubric prompt hash, debias variant, ensemble member, replicate index, model Runtime identity |
 
 The Core never imports `PROMPT_REGISTRY`. The composition root resolves a frozen prompt and places its hash in the host Runtime identity. `lengthDebias=false` selects only the existing rubric debias-off instrument. Presentation and tone neutrality remain enabled. RAG and semantic prompts have no length-debias switch.
 
-Semantic and RAG assertions use `omk.llm-assertions/v1`. One Evaluator coordinate owns exactly one criterion and one Boolean Metric, so a provider failure cannot suppress or falsify an unrelated criterion. The sealed criterion retains threshold, positive weight, and fact-layer identity for downstream aggregation. The sealed instrument records the assertion type, registry prompt ID, and frozen prompt hash; the Runtime fingerprint additionally binds the selected model configuration and the host invocation Runtime identity. The host invocation port performs exactly one cooperative-cancellation-aware call. It has no retry, timeout, budget, or cache policy of its own.
+Semantic and RAG assertions use `omk.llm-assertions/v2`. One Evaluator coordinate owns exactly one criterion and one Boolean Metric, so a provider failure cannot suppress or falsify an unrelated criterion. The sealed criterion retains threshold, positive weight, explicit negation, and fact-layer identity for downstream aggregation. Negation is applied only after a valid raw score is compared with the threshold; evidence retains both `rawPassed` and `negated`, and provider failure, invalid response, timeout, cancellation, or budget censoring cannot become an observed pass. The sealed instrument records the assertion type, registry prompt ID, and frozen prompt hash; the Runtime fingerprint additionally binds the selected model configuration and the host invocation Runtime identity. The host invocation port performs exactly one cooperative-cancellation-aware call. It has no retry, timeout, budget, or cache policy of its own.
 
 A strict integer reading in `[1, 5]` with a non-empty explanation produces an observed Boolean threshold result. Non-JSON, malformed JSON, malformed score, out-of-range score, and missing explanation produce distinct invalid observations. Provider failure produces a failed Evaluation record with a redacted stable code. Core timeout and cancellation remain attempt states, and admission failure remains budget censoring. Unknown usage or provider cost stays absent. This is the intentional `BREAKING-COMPARABILITY` correction owned by [#481](https://github.com/lizhiyao/oh-my-knowledge/issues/481); no compatibility mode or legacy reader is provided.
 
@@ -110,7 +110,7 @@ Mixed-layer `assert-set` criteria remain visible assertion observations but are 
 
 The legacy RAG and semantic paths convert provider/parse failure into a failed Boolean assertion. That behavior remains frozen only as historical differential evidence. The Core deliberately does not reproduce it: invalid readings and failed attempts are excluded from assertion-layer pass ratios and reduce coverage instead. A valid reading below the threshold remains observed `false`, so negative content evidence is still counted.
 
-The legacy async path also ignores the otherwise-public `Assertion.not` contract. That independent Boolean-semantics defect is tracked by [#489](https://github.com/lizhiyao/oh-my-knowledge/issues/489) and is not folded into the #481 failure-state correction.
+The legacy async path now applies the public `Assertion.not` contract only to valid semantic, RAG, or custom pass/fail readings. Provider failure, malformed or incomplete judge output, missing RAG input, custom exceptions, and invalid custom results remain failed under negation. The Core seals the same Boolean criterion rule into its v2 Definition and evidence contract. This independent `BREAKING-COMPARABILITY` correction is owned by [#489](https://github.com/lizhiyao/oh-my-knowledge/issues/489); it does not weaken the #481 rule that Core infrastructure and protocol failures remain structured missing evidence instead of observed Boolean false.
 
 ## 7. Statistical standards
 
@@ -175,7 +175,7 @@ The first baseline is `test/fixtures/evaluation-core/scoring-equivalence-v1.json
 
 Later migration tests consume the same fixture through the new Core path and compare observations, coverage, evidence, per-unit tables, interval results, usage provenance, and reason codes. Exact identity and status comparisons never use numeric tolerance. Floating-point tolerance is allowed only in formula property tests that are not artifact equality tests.
 
-The semantic/RAG conformance vectors additionally freeze the intentional failure-semantic break: valid pass, valid threshold fail, provider failure, non-JSON, malformed JSON, malformed score, out-of-range score, missing explanation, timeout, cancellation, budget censoring, unknown usage/cost, and the invariant that adding an infrastructure failure cannot lower an observed content pass rate.
+The semantic/RAG conformance vectors additionally freeze the intentional failure-semantic break: valid pass, valid threshold fail, valid negation, provider failure, non-JSON, malformed JSON, malformed score, out-of-range score, missing explanation, timeout, cancellation, budget censoring, unknown usage/cost, and the invariant that adding an infrastructure failure cannot lower an observed content pass rate. Legacy custom assertion vectors cover valid pass/fail, negation, thrown and timed-out modules, and invalid result objects.
 
 The final offline differential harness is
 `test/evaluation-core/scoring-equivalence-differential.test.ts`, delivered by
@@ -207,11 +207,11 @@ comparison.
 | [#481](https://github.com/lizhiyao/oh-my-knowledge/issues/481) | accepted | Provider or parse failure remains failed/invalid/missing evidence instead of a Boolean content failure. The full-chain failure probe checks both projections and downstream coverage. |
 | [#484](https://github.com/lizhiyao/oh-my-knowledge/issues/484) | accepted | `json_schema` validator sessions are isolated instead of sharing legacy process-global state. |
 | [#492](https://github.com/lizhiyao/oh-my-knowledge/issues/492) | accepted | Malformed, coerced, out-of-range, empty-reason, and zero-sentinel rubric responses are not valid readings. |
-| [#489](https://github.com/lizhiyao/oh-my-knowledge/issues/489) | **blocking** | The legacy async-assertion `not` defect is not an acceptable cutover baseline. Formal cutover stays blocked until its separately marked comparability change lands. |
+| [#489](https://github.com/lizhiyao/oh-my-knowledge/issues/489) | accepted | Async assertion negation is sealed and applies only after a valid raw pass/fail reading; invalidity and infrastructure failure cannot become success. |
 
 This inventory is not a compatibility mode. Accepted entries describe the authoritative Core
-semantics, while the single blocking entry prevents the harness from declaring formal cutover
-ready. The production dependency direction remains Core contracts/runtime inward and host
+semantics, and the harness has no remaining differential exception blocking formal cutover.
+The production dependency direction remains Core contracts/runtime inward and host
 adapters outward: Evaluation Core does not import the legacy Report, CLI, provider SDK,
 environment, filesystem, or prompt-registry text. Provider invocation and prompt construction
 remain injected host ports; only sealed identities and captured artifacts cross the boundary.

--- a/docs/zh/reference/eval-sample-format.md
+++ b/docs/zh/reference/eval-sample-format.md
@@ -55,7 +55,7 @@
 | `assertions[].threshold` | `number` | 否 | 通过阈值；默认值随类型而定 —— LLM 打分类为 `3`，`rouge_n_min` / `bleu_min` 为 `0.5`，`mock_hit` 为 `1` |
 | `assertions[].fn` | `string` | 视类型 | 自定义断言 JS 文件路径（`custom` 必填） |
 | `assertions[].weight` | `number` | 否 | 权重（默认 1） |
-| `assertions[].not` | `boolean` | 否 | 反转该断言的通过/失败，适用于任意类型 |
+| `assertions[].not` | `boolean` | 否 | 反转有效的通过／失败读数，适用于任意类型 |
 | `assertions[].n` | `number` | 否 | `rouge_n_min` 的 n-gram 阶数（默认 1） |
 | `dimensions` | `object` | 否 | 多维度评分，key 为维度名，value 为评分标准文本 |
 
@@ -213,6 +213,8 @@ Studio 的 Skill Map 节点详情也会读取这个声明：选中图中的节�
   pattern: "TODO|FIXME"
   not: true              # 必须不含 TODO/FIXME
 ```
+
+对于异步评委断言和 custom 断言，仅在得到有效的原始通过／失败读数后执行反转。Provider 失败、超时、取消、预算截断、缺少输入和无效输出仍是失败或缺失证据；`not: true` 绝不会把基础设施或协议失败变成通过。
 
 **断言组合（assert-set）：**
 

--- a/src/eval-workflows/runtime-adapter/evaluators/llm-assertions.ts
+++ b/src/eval-workflows/runtime-adapter/evaluators/llm-assertions.ts
@@ -49,13 +49,13 @@ export type {
 } from './llm-judge-invocation.js';
 
 export const LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID =
-  'omk.llm-assertions/v1' as const;
+  'omk.llm-assertions/v2' as const;
 export const LLM_ASSERTION_INSTRUMENT_SCHEMA_VERSION =
   'omk.llm-assertion-instrument/v1' as const;
 export const LLM_ASSERTION_CONTEXT_SCHEMA_VERSION =
-  'omk.llm-assertion-context/v1' as const;
+  'omk.llm-assertion-context/v2' as const;
 export const LLM_ASSERTION_EVIDENCE_SCHEMA_VERSION =
-  'omk.llm-assertion-evidence/v1' as const;
+  'omk.llm-assertion-evidence/v2' as const;
 export const LLM_ASSERTION_BINDINGS = Object.freeze({
   actual: 'actual',
   criterion: 'criterion',
@@ -95,6 +95,7 @@ interface LlmAssertionCriterion {
   readonly assertionType: LlmAssertionType;
   readonly threshold: number;
   readonly weight: number;
+  readonly negated: boolean;
   readonly reference?: string;
   readonly context?: string;
   readonly question?: string;
@@ -118,10 +119,17 @@ const INSTRUMENT_SCHEMA_DOCUMENT: JsonValue = {
 
 const CONTEXT_SCHEMA_DOCUMENT: JsonValue = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'urn:omk:llm-assertion-context:v1',
+  $id: 'urn:omk:llm-assertion-context:v2',
   type: 'object',
   additionalProperties: false,
-  required: ['schemaVersion', 'criterionId', 'assertionType', 'threshold', 'weight'],
+  required: [
+    'schemaVersion',
+    'criterionId',
+    'assertionType',
+    'threshold',
+    'weight',
+    'negated',
+  ],
   properties: {
     schemaVersion: { const: LLM_ASSERTION_CONTEXT_SCHEMA_VERSION },
     criterionId: { type: 'string', minLength: 1, maxLength: 256 },
@@ -130,6 +138,7 @@ const CONTEXT_SCHEMA_DOCUMENT: JsonValue = {
     },
     threshold: { type: 'number', minimum: 1, maximum: 5 },
     weight: { type: 'number', exclusiveMinimum: 0 },
+    negated: { type: 'boolean' },
     reference: { type: 'string', minLength: 1 },
     context: { type: 'string', minLength: 1 },
     question: { type: 'string', minLength: 1 },
@@ -156,7 +165,7 @@ const CONTEXT_SCHEMA_DOCUMENT: JsonValue = {
 
 const EVIDENCE_SCHEMA_DOCUMENT: JsonValue = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'urn:omk:llm-assertion-evidence:v1',
+  $id: 'urn:omk:llm-assertion-evidence:v2',
   type: 'object',
   additionalProperties: false,
   required: [
@@ -165,10 +174,12 @@ const EVIDENCE_SCHEMA_DOCUMENT: JsonValue = {
     'assertionType',
     'threshold',
     'weight',
+    'negated',
     'layer',
     'promptId',
     'promptHash',
     'score',
+    'rawPassed',
     'reason',
   ],
   properties: {
@@ -177,10 +188,12 @@ const EVIDENCE_SCHEMA_DOCUMENT: JsonValue = {
     assertionType: { type: 'string' },
     threshold: { type: 'number' },
     weight: { type: 'number', exclusiveMinimum: 0 },
+    negated: { type: 'boolean' },
     layer: { const: 'fact' },
     promptId: { type: 'string' },
     promptHash: { type: 'string' },
     score: { type: 'integer', minimum: 1, maximum: 5 },
+    rawPassed: { type: 'boolean' },
     reason: { type: 'string', minLength: 1 },
   },
 };
@@ -192,12 +205,12 @@ export const LLM_ASSERTION_INSTRUMENT_SCHEMA = assertionSchemaIdentity(
 );
 export const LLM_ASSERTION_CONTEXT_SCHEMA = assertionSchemaIdentity(
   LLM_ASSERTION_CONTEXT_SCHEMA_VERSION,
-  'urn:omk:llm-assertion-context:v1',
+  'urn:omk:llm-assertion-context:v2',
   CONTEXT_SCHEMA_DOCUMENT,
 );
 export const LLM_ASSERTION_EVIDENCE_SCHEMA = assertionSchemaIdentity(
   LLM_ASSERTION_EVIDENCE_SCHEMA_VERSION,
-  'urn:omk:llm-assertion-evidence:v1',
+  'urn:omk:llm-assertion-evidence:v2',
   EVIDENCE_SCHEMA_DOCUMENT,
 );
 
@@ -223,7 +236,7 @@ const INSTRUMENTS: Readonly<Record<LlmAssertionType, Readonly<{
   },
 });
 
-const ALGORITHM_VERSION = 'omk.llm-assertion-reading/v1' as const;
+const ALGORITHM_VERSION = 'omk.llm-assertion-reading/v2' as const;
 const LLM_ASSERTION_TYPES = new Set<LlmAssertionType>([
   'semantic_similarity',
   'faithfulness',
@@ -348,6 +361,7 @@ function parseCriterion(value: unknown): LlmAssertionCriterion {
         'assertionType',
         'threshold',
         'weight',
+        'negated',
         ...('reference' in value ? ['reference'] : []),
         ...('context' in value ? ['context'] : []),
         ...('question' in value ? ['question'] : []),
@@ -369,6 +383,12 @@ function parseCriterion(value: unknown): LlmAssertionCriterion {
     );
   }
   const assertionType = value.assertionType as LlmAssertionType;
+  if (typeof value.negated !== 'boolean') {
+    return failure(
+      'omk-llm-assertion-criterion-invalid',
+      'LLM assertion criterion negation must be explicit.',
+    );
+  }
   const expectedField = assertionType === 'faithfulness'
     ? 'context'
     : assertionType === 'answer_relevancy'
@@ -393,6 +413,7 @@ function parseCriterion(value: unknown): LlmAssertionCriterion {
     assertionType,
     threshold: value.threshold,
     weight: value.weight,
+    negated: value.negated,
     [expectedField]: value[expectedField],
   }) as unknown as LlmAssertionCriterion;
 }
@@ -474,11 +495,12 @@ function observed(
   state: RecordState,
   reading: JudgeReading,
 ): EvaluatorObservation {
+  const rawPassed = reading.score >= state.criterion.threshold;
   return {
     metricId: state.metricId,
     observationStatus: 'observed',
     valueType: 'boolean',
-    value: reading.score >= state.criterion.threshold,
+    value: state.criterion.negated ? !rawPassed : rawPassed,
     evidence: {
       value: {
         schemaVersion: LLM_ASSERTION_EVIDENCE_SCHEMA_VERSION,
@@ -486,10 +508,12 @@ function observed(
         assertionType: state.criterion.assertionType,
         threshold: state.criterion.threshold,
         weight: state.criterion.weight,
+        negated: state.criterion.negated,
         layer: 'fact',
         promptId: state.instrument.promptId,
         promptHash: state.instrument.promptHash,
         score: reading.score,
+        rawPassed,
         reason: reading.reason,
       },
       classification: state.evidenceClassification,

--- a/src/grading/assertions.ts
+++ b/src/grading/assertions.ts
@@ -110,6 +110,7 @@ export async function runAsyncAssertions(output: string, assertions: Assertion[]
     const weight = assertion.weight ?? 1;
     let passed = false;
     let message = '';
+    let hasValidRawReading = false;
 
     if (assertion.type === 'semantic_similarity') {
       const reference = assertion.reference || '';
@@ -130,6 +131,12 @@ export async function runAsyncAssertions(output: string, assertions: Assertion[]
             const threshold = assertion.threshold ?? 3;
             passed = score >= threshold;
             message = parsed.reason || '';
+            hasValidRawReading = typeof parsed.score === 'number'
+              && Number.isInteger(parsed.score)
+              && parsed.score >= 1
+              && parsed.score <= 5
+              && typeof parsed.reason === 'string'
+              && parsed.reason.trim() !== '';
           } else {
             process.stderr.write(`[omk] semantic_similarity judge returned non-JSON: ${result.output!.slice(0, 100)}\n`);
           }
@@ -147,6 +154,7 @@ export async function runAsyncAssertions(output: string, assertions: Assertion[]
       if (ragResult.costReportedByExecutor === false) anyCostUnreported = true;
       passed = ragResult.passed;
       message = ragResult.message;
+      hasValidRawReading = ragResult.hasValidRawReading;
     } else if (assertion.type === 'custom') {
       try {
         const fnPath = resolve(samplesDir, assertion.fn!);
@@ -159,10 +167,15 @@ export async function runAsyncAssertions(output: string, assertions: Assertion[]
         ]);
         passed = Boolean(result.pass);
         message = result.message || '';
+        hasValidRawReading = typeof result.pass === 'boolean';
       } catch (err: unknown) {
         passed = false;
         message = `custom assertion error: ${getErrorMessage(err)}`;
       }
+    }
+
+    if (assertion.not === true) {
+      passed = hasValidRawReading ? !passed : false;
     }
 
     details.push({
@@ -221,6 +234,7 @@ export async function runAsyncAssertions(output: string, assertions: Assertion[]
 
 interface RagJudgeOutcome {
   passed: boolean;
+  hasValidRawReading: boolean;
   message: string;
   costUSD: number;
   /** False = judge executor 不报 cost(如 codex)→ costUSD 是占位 0。 */
@@ -242,7 +256,12 @@ async function runRagJudge(
   if (assertion.type === 'faithfulness') {
     const context = assertion.reference || sample.context || '';
     if (!context) {
-      return { passed: false, message: 'faithfulness: 缺少 sample.context 或 assertion.reference', costUSD: 0 };
+      return {
+        passed: false,
+        hasValidRawReading: false,
+        message: 'faithfulness: 缺少 sample.context 或 assertion.reference',
+        costUSD: 0,
+      };
     }
     ({ system, prompt } = buildRagJudgePrompt('faithfulness', { output, context }));
   } else if (assertion.type === 'answer_relevancy') {
@@ -251,7 +270,12 @@ async function runRagJudge(
     // context_recall
     const reference = assertion.reference || sample.context || '';
     if (!reference) {
-      return { passed: false, message: 'context_recall: 缺少 assertion.reference 或 sample.context', costUSD: 0 };
+      return {
+        passed: false,
+        hasValidRawReading: false,
+        message: 'context_recall: 缺少 assertion.reference 或 sample.context',
+        costUSD: 0,
+      };
     }
     ({ system, prompt } = buildRagJudgePrompt('context_recall', { output, reference }));
   }
@@ -261,6 +285,7 @@ async function runRagJudge(
   if (!result.ok) {
     return {
       passed: false,
+      hasValidRawReading: false,
       message: `${assertion.type} judge error: ${result.error}`,
       costUSD: result.costUSD || 0,
       ...reported,
@@ -272,18 +297,37 @@ async function runRagJudge(
     const jsonMatch = text.match(/\{[\s\S]*\}/);
     if (!jsonMatch) {
       process.stderr.write(`[omk] ${assertion.type} judge returned non-JSON: ${text.slice(0, 100)}\n`);
-      return { passed: false, message: 'judge returned non-JSON', costUSD: result.costUSD || 0, ...reported };
+      return {
+        passed: false,
+        hasValidRawReading: false,
+        message: 'judge returned non-JSON',
+        costUSD: result.costUSD || 0,
+        ...reported,
+      };
     }
     const parsed = JSON.parse(jsonMatch[0]) as JudgeResponse;
     const score = Number(parsed.score) || 0;
+    const hasValidRawReading = typeof parsed.score === 'number'
+      && Number.isInteger(parsed.score)
+      && parsed.score >= 1
+      && parsed.score <= 5
+      && typeof parsed.reason === 'string'
+      && parsed.reason.trim() !== '';
     return {
       passed: score >= threshold,
+      hasValidRawReading,
       message: parsed.reason ? String(parsed.reason) : '',
       costUSD: result.costUSD || 0,
       ...reported,
     };
   } catch (parseErr: unknown) {
     process.stderr.write(`[omk] ${assertion.type} judge parse error: ${getErrorMessage(parseErr)}\n`);
-    return { passed: false, message: 'failed to parse judge response', costUSD: result.costUSD || 0, ...reported };
+    return {
+      passed: false,
+      hasValidRawReading: false,
+      message: 'failed to parse judge response',
+      costUSD: result.costUSD || 0,
+      ...reported,
+    };
   }
 }

--- a/src/types/eval.ts
+++ b/src/types/eval.ts
@@ -11,9 +11,10 @@ export interface Assertion {
   fn?: string;
   reference?: string;
   threshold?: number;
-  /** When true, the assertion's pass/fail is inverted. Works with any type,
-   *  including legacy `not_contains` (which becomes a redundant but still
-   *  supported double-negation). */
+  /** When true, a valid assertion pass/fail reading is inverted. Provider
+   *  failure, timeout, invalid output, and missing input remain failures.
+   *  Works with any type, including legacy `not_contains` (which becomes a
+   *  redundant but still supported double-negation). */
   not?: boolean;
   /** Only used by type='assert-set'. 'any' = at least one child must pass;
    *  'all' = every child must pass. Children may be any assertion type,

--- a/test/eval-workflows/runtime-adapter/llm-assertions.test.ts
+++ b/test/eval-workflows/runtime-adapter/llm-assertions.test.ts
@@ -120,6 +120,7 @@ function invocationPort(
 function criterion(
   assertionType: LlmAssertionType,
   threshold = 3,
+  negated = false,
 ): JsonValue {
   let source: Record<string, JsonValue>;
   if (assertionType === 'faithfulness') {
@@ -135,6 +136,7 @@ function criterion(
     assertionType,
     threshold,
     weight: 1,
+    negated,
     ...source,
   };
 }
@@ -155,10 +157,13 @@ function evaluatorConfig(assertionType: LlmAssertionType): JsonValue {
   } as JsonValue;
 }
 
-function definition(assertionType: LlmAssertionType): EvaluationDefinition {
+function definition(
+  assertionType: LlmAssertionType,
+  negated = false,
+): EvaluationDefinition {
   const value = validDefinition();
   value.dataset.samples[0].evaluationContext = {
-    llmAssertion: criterion(assertionType),
+    llmAssertion: criterion(assertionType, 3, negated),
   };
   value.evaluators = [{
     evaluatorId: 'llm-assertion',
@@ -306,6 +311,7 @@ function executor(
 
 async function runCore(input: {
   assertionType?: LlmAssertionType;
+  negated?: boolean;
   handler: InvocationHandler;
   policy?: MeasurementPolicy;
   clock?: TestClock;
@@ -317,7 +323,7 @@ async function runCore(input: {
   const provider = invocationPort(input.handler, input.reporting);
   const identity = evaluatorIdentity(assertionType, provider);
   const sealed = await prepareEvaluationPlan(
-    definition(assertionType),
+    definition(assertionType, input.negated ?? false),
     input.policy ?? policy(),
     preparationRuntime(identity),
   );
@@ -442,8 +448,10 @@ describe('provider-neutral LLM assertion Evaluator', () => {
             promptId,
             promptHash,
             score: 4,
+            rawPassed: true,
             reason: 'valid reading',
             weight: 1,
+            negated: false,
             layer: 'fact',
           },
         },
@@ -469,13 +477,91 @@ describe('provider-neutral LLM assertion Evaluator', () => {
   });
 
   it.each([
+    'semantic_similarity',
+    'faithfulness',
+    'answer_relevancy',
+    'context_recall',
+  ] as const)('applies negation only after a valid %s reading', async (assertionType) => {
+    const rawPass = await runCore({
+      assertionType,
+      negated: true,
+      handler: async () => ({
+        invocationStatus: 'completed',
+        output: '{"score":5,"reason":"valid pass"}',
+      }),
+    });
+    expect(completedObservations(rawPass)).toEqual([
+      expect.objectContaining({
+        observationStatus: 'observed',
+        value: false,
+        evidence: expect.objectContaining({
+          value: expect.objectContaining({ negated: true, rawPassed: true }),
+        }),
+      }),
+      expect.objectContaining({
+        observationStatus: 'observed',
+        value: false,
+        evidence: expect.objectContaining({
+          value: expect.objectContaining({ negated: true, rawPassed: true }),
+        }),
+      }),
+    ]);
+
+    const rawFail = await runCore({
+      assertionType,
+      negated: true,
+      handler: async () => ({
+        invocationStatus: 'completed',
+        output: '{"score":2,"reason":"valid fail"}',
+      }),
+    });
+    expect(completedObservations(rawFail)).toEqual([
+      expect.objectContaining({
+        observationStatus: 'observed',
+        value: true,
+        evidence: expect.objectContaining({
+          value: expect.objectContaining({ negated: true, rawPassed: false }),
+        }),
+      }),
+      expect.objectContaining({
+        observationStatus: 'observed',
+        value: true,
+        evidence: expect.objectContaining({
+          value: expect.objectContaining({ negated: true, rawPassed: false }),
+        }),
+      }),
+    ]);
+  });
+
+  it('seals negation into the EvaluationPlan identity', async () => {
+    const provider = invocationPort(async () => ({
+      invocationStatus: 'completed',
+      output: '{"score":5,"reason":"valid"}',
+    }));
+    const identity = evaluatorIdentity('semantic_similarity', provider);
+    const positive = await prepareEvaluationPlan(
+      definition('semantic_similarity', false),
+      policy(),
+      preparationRuntime(identity),
+    );
+    const negated = await prepareEvaluationPlan(
+      definition('semantic_similarity', true),
+      policy(),
+      preparationRuntime(identity),
+    );
+    expect(positive.evaluation.evaluationPlanDigest)
+      .not.toBe(negated.evaluation.evaluationPlanDigest);
+  });
+
+  it.each([
     ['plain text', 'judge-response-non-json'],
     ['prefix {bad json} suffix', 'judge-response-malformed-json'],
     ['{"score":"4","reason":"wrong type"}', 'judge-score-malformed'],
     ['{"score":6,"reason":"out of range"}', 'judge-score-out-of-range'],
     ['{"score":4}', 'judge-reason-missing'],
-  ])('returns invalid, not false, for %s', async (output, reasonCode) => {
+  ])('returns invalid, not false, for %s even when negated', async (output, reasonCode) => {
     const result = await runCore({
+      negated: true,
       handler: async () => ({ invocationStatus: 'completed', output }),
     });
     expect(completedObservations(result)).toEqual([
@@ -487,8 +573,9 @@ describe('provider-neutral LLM assertion Evaluator', () => {
     ))).toBe(false);
   });
 
-  it('records provider failure separately, redacts raw errors, and retains known usage', async () => {
+  it('does not invert provider failure, redacts raw errors, and retains known usage', async () => {
     const result = await runCore({
+      negated: true,
       handler: async () => ({
         invocationStatus: 'failed',
         reasonCode: 'provider-overloaded',
@@ -633,7 +720,7 @@ describe('provider-neutral LLM assertion Evaluator', () => {
     ))).toBe(true);
   });
 
-  it('lets Core own timeout and waits for cooperative provider cancellation', async () => {
+  it('keeps negated timeout failed and waits for cooperative provider cancellation', async () => {
     let cancellations = 0;
     const result = await runCore({
       handler: async (request) => new Promise<OmkLlmJudgeInvocationResult>((_resolve, reject) => {
@@ -642,6 +729,7 @@ describe('provider-neutral LLM assertion Evaluator', () => {
           reject(request.signal.reason);
         }, { once: true });
       }),
+      negated: true,
       policy: policy({ timeout: true }),
       clock: new TestClock(true),
     });
@@ -654,7 +742,7 @@ describe('provider-neutral LLM assertion Evaluator', () => {
     }
   });
 
-  it('lets Core own cancellation and does not turn it into provider failure', async () => {
+  it('keeps negated cancellation cancelled instead of turning it into a pass', async () => {
     const controller = new AbortController();
     let cancellations = 0;
     const result = await runCore({
@@ -672,6 +760,7 @@ describe('provider-neutral LLM assertion Evaluator', () => {
           }
         });
       },
+      negated: true,
       signal: controller.signal,
     });
     expect(cancellations).toBeGreaterThan(0);
@@ -681,7 +770,7 @@ describe('provider-neutral LLM assertion Evaluator', () => {
     ))).toBe(true);
   });
 
-  it('lets Core censor unstarted coordinates at the sealed evaluation budget', async () => {
+  it('keeps negated budget censoring as unstarted evidence', async () => {
     let calls = 0;
     const result = await runCore({
       handler: async () => {
@@ -691,6 +780,7 @@ describe('provider-neutral LLM assertion Evaluator', () => {
           output: '{"score":5,"reason":"valid"}',
         };
       },
+      negated: true,
       policy: policy({ evaluationInvocations: 1 }),
     });
     expect(calls).toBe(1);

--- a/test/evaluation-core/scoring-equivalence-differential.test.ts
+++ b/test/evaluation-core/scoring-equivalence-differential.test.ts
@@ -137,7 +137,7 @@ interface DifferentialException {
   readonly reason: string;
 }
 
-const DIFFERENTIAL_EXCEPTIONS = Object.freeze([
+const DIFFERENTIAL_EXCEPTIONS: readonly DifferentialException[] = Object.freeze([
   {
     exceptionId: 'issue-481',
     status: 'accepted',
@@ -152,9 +152,9 @@ const DIFFERENTIAL_EXCEPTIONS = Object.freeze([
   },
   {
     exceptionId: 'issue-489',
-    status: 'blocking',
+    status: 'accepted',
     owningIssue: 'https://github.com/lizhiyao/oh-my-knowledge/issues/489',
-    reason: 'Legacy async assertion not semantics are not accepted as the Core cutover baseline.',
+    reason: 'Async assertion negation applies only after a valid raw pass/fail reading.',
   },
   {
     exceptionId: 'issue-492',
@@ -162,7 +162,7 @@ const DIFFERENTIAL_EXCEPTIONS = Object.freeze([
     owningIssue: 'https://github.com/lizhiyao/oh-my-knowledge/issues/492',
     reason: 'Malformed, coerced, and zero-sentinel rubric responses are not valid readings.',
   },
-] as const satisfies readonly DifferentialException[]);
+]);
 
 class DeterministicClock implements EvaluationEngineClock {
   #now = 0;
@@ -249,6 +249,7 @@ function llmCriterion(type: LlmAssertionType, threshold: number): JsonValue {
     assertionType: type,
     threshold,
     weight: 1,
+    negated: false,
     ...source,
   } as unknown as JsonValue;
 }
@@ -1046,13 +1047,11 @@ async function runCore(failingPromptId?: string) {
 }
 
 describe('Evaluation Core complete legacy differential conformance', () => {
-  it('keeps every intentional difference typed, owned, and the unresolved not semantics blocking', () => {
+  it('keeps every intentional difference typed, owned, and accepted for cutover', () => {
     expect(DIFFERENTIAL_EXCEPTIONS.map((entry) => entry.exceptionId)).toEqual([
       'issue-481', 'issue-484', 'issue-489', 'issue-492',
     ]);
-    expect(DIFFERENTIAL_EXCEPTIONS.filter((entry) => entry.status === 'blocking')).toEqual([
-      expect.objectContaining({ exceptionId: 'issue-489' }),
-    ]);
+    expect(DIFFERENTIAL_EXCEPTIONS.filter((entry) => entry.status === 'blocking')).toEqual([]);
     expect(DIFFERENTIAL_EXCEPTIONS.every((entry) => entry.reason.length > 0)).toBe(true);
   });
 
@@ -1244,15 +1243,17 @@ describe('Evaluation Core complete legacy differential conformance', () => {
         .toEqual(expected.executionAssertions.details);
       LLM_CASES.forEach(([type, threshold, score], index) => {
         expect(evidenceValues(`llm-${type.replaceAll('_', '-')}`)).toEqual([{
-          schemaVersion: 'omk.llm-assertion-evidence/v1',
+          schemaVersion: 'omk.llm-assertion-evidence/v2',
           criterionId: `${type.replaceAll('_', '-')}-criterion`,
           assertionType: type,
           threshold,
           weight: 1,
+          negated: false,
           layer: 'fact',
           promptId: llmAssertionInstrument(type).promptId,
           promptHash: llmAssertionInstrument(type).promptHash,
           score,
+          rawPassed: score >= threshold,
           reason: expected.asyncAssertions.details[index].message,
         }]);
       });

--- a/test/fixtures/custom-assertion-outcomes.mjs
+++ b/test/fixtures/custom-assertion-outcomes.mjs
@@ -1,0 +1,15 @@
+export default function (_output, { assertion }) {
+  if (assertion.value === 'throw') {
+    throw new Error('fixture custom failure');
+  }
+  if (assertion.value === 'invalid') {
+    return { message: 'fixture invalid result' };
+  }
+  if (assertion.value === 'timeout') {
+    return new Promise(() => {});
+  }
+  return {
+    pass: assertion.value === 'pass',
+    message: `fixture ${String(assertion.value)}`,
+  };
+}

--- a/test/grading/async-assertion-not.test.ts
+++ b/test/grading/async-assertion-not.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { describe, it, vi } from 'vitest';
+import { runAsyncAssertions } from '../../src/grading/assertions.js';
+import type {
+  Assertion,
+  ExecResult,
+  ExecutorFn,
+  Sample,
+} from '../../src/types/index.js';
+
+const samplesDir = fileURLToPath(new URL('../', import.meta.url));
+const sample: Sample = {
+  sample_id: 'async-not',
+  prompt: 'What is the answer?',
+  context: 'Grounded reference context.',
+};
+
+function completed(output: string): ExecutorFn {
+  return async (): Promise<ExecResult> => ({
+    ok: true,
+    output,
+    durationMs: 1,
+    durationApiMs: 1,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    costUSD: 0,
+    stopReason: 'end_turn',
+    numTurns: 1,
+  });
+}
+
+const failed: ExecutorFn = async (): Promise<ExecResult> => ({
+  ok: false,
+  output: null,
+  error: 'fixture provider failure',
+  durationMs: 1,
+  durationApiMs: 1,
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  costUSD: 0,
+  stopReason: 'error',
+  numTurns: 0,
+});
+
+async function run(assertion: Assertion, executor: ExecutorFn) {
+  return runAsyncAssertions('Actual answer', [assertion], {
+    executor,
+    judgeModel: 'judge-model',
+    sample,
+    samplesDir,
+  });
+}
+
+describe('legacy async assertion negation', () => {
+  it.each([
+    'semantic_similarity',
+    'faithfulness',
+    'answer_relevancy',
+    'context_recall',
+  ])('inverts only valid pass/fail readings for %s', async (type) => {
+    const rawPass = await run(
+      { type, not: true, reference: 'Expected answer' },
+      completed('{"score":5,"reason":"valid pass"}'),
+    );
+    assert.equal(rawPass.details[0].passed, false);
+
+    const rawFail = await run(
+      { type, not: true, reference: 'Expected answer' },
+      completed('{"score":2,"reason":"valid fail"}'),
+    );
+    assert.equal(rawFail.details[0].passed, true);
+  });
+
+  it.each([
+    'semantic_similarity',
+    'faithfulness',
+    'answer_relevancy',
+    'context_recall',
+  ])('keeps provider failure failed for negated %s', async (type) => {
+    const result = await run(
+      { type, not: true, reference: 'Expected answer' },
+      failed,
+    );
+    assert.equal(result.details[0].passed, false);
+  });
+
+  it.each([
+    'plain text',
+    '{"score":"5","reason":"coerced"}',
+    '{"score":6,"reason":"out of range"}',
+    '{"score":5}',
+  ])('keeps invalid semantic readings failed under not: true: %s', async (output) => {
+    const result = await run(
+      { type: 'semantic_similarity', not: true, reference: 'Expected answer' },
+      completed(output),
+    );
+    assert.equal(result.details[0].passed, false);
+  });
+
+  it.each([
+    'faithfulness',
+    'answer_relevancy',
+    'context_recall',
+  ])('keeps invalid RAG readings failed under not: true for %s', async (type) => {
+    const result = await run(
+      { type, not: true, reference: 'Expected answer' },
+      completed('{"score":"5","reason":"coerced"}'),
+    );
+    assert.equal(result.details[0].passed, false);
+  });
+
+  it.each([
+    ['pass', true],
+    ['fail', false],
+  ] as const)('preserves a valid custom %s result without negation', async (
+    value,
+    expected,
+  ) => {
+    const result = await run({
+      type: 'custom',
+      fn: 'fixtures/custom-assertion-outcomes.mjs',
+      value,
+    }, completed('{}'));
+    assert.equal(result.details[0].passed, expected);
+  });
+
+  it.each([
+    ['pass', false],
+    ['fail', true],
+    ['throw', false],
+    ['invalid', false],
+  ] as const)('handles custom raw outcome %s without turning invalidity into success', async (
+    value,
+    expected,
+  ) => {
+    const result = await run({
+      type: 'custom',
+      fn: 'fixtures/custom-assertion-outcomes.mjs',
+      value,
+      not: true,
+    }, completed('{}'));
+    assert.equal(result.details[0].passed, expected);
+  });
+
+  it('keeps a negated custom timeout failed', async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = run({
+        type: 'custom',
+        fn: 'fixtures/custom-assertion-outcomes.mjs',
+        value: 'timeout',
+        not: true,
+      }, completed('{}'));
+      await vi.advanceTimersByTimeAsync(30_000);
+      const result = await pending;
+      assert.equal(result.details[0].passed, false);
+      assert.match(result.details[0].message ?? '', /timed out/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(['faithfulness', 'context_recall'])('does not invert missing input for %s', async (type) => {
+    const result = await runAsyncAssertions('Actual answer', [{ type, not: true }], {
+      executor: completed('{"score":1,"reason":"must not run"}'),
+      judgeModel: 'judge-model',
+      sample: { sample_id: 'missing-input', prompt: 'Question' },
+      samplesDir,
+    });
+    assert.equal(result.details[0].passed, false);
+  });
+});


### PR DESCRIPTION
## Purpose

修正异步 assertion 长期忽略 `not: true` 的语义缺陷，使 semantic／RAG／custom 与公开 sample contract 一致，同时避免把基础设施或协议失败误判为内容通过。

Fixes #489
Parent #480

## Changes

- 仅在得到合法原始通过／失败读数后执行反转；provider 失败、无效或缺失读数、超时、取消和预算截断不反转为成功。
- 将 negation 封入 Evaluation Core v2 criterion、EvaluationPlan identity 与 evidence，并保留 `rawPassed` 以支持审计。
- 同步 sample contract、双语用户文档和正式 cutover comparability inventory。

## User impact and migration

这是 `BREAKING-COMPARABILITY` 修正：使用异步 assertion 且配置 `not: true` 的历史评测结果可能变化，需要重新建立受影响的比较基线。没有兼容 flag、旧 reader、双路径或 Report migration。内部 Core Definition 生产者必须改用 `omk.llm-assertion-context/v2` 并显式提供 `negated`；v1 不再接受。冻结的评分类 prompt 文本和 hash 均未变化。

## Construct-validity caveat

`not` 只否定一个合法的内容判断，不否定“本次测量是否成功”。因此 provider／协议／输入失败不会成为反向命题的正证据；Core 继续把这些状态保留为失败、无效或缺失证据。

## Testing

- [x] `yarn ci`
- [x] 331 个测试文件、4008 个测试通过
- [x] lint、build、双语文档同步与 21 个 Evaluation Core schema 校验通过

## Checklist

- [x] 已阅读 `AGENTS.md` 与 `CONTRIBUTING.md`
- [x] 分支从 `main` 切出，目标分支为 `main`
- [x] commit message 符合仓库约定
- [x] 已说明用户影响、迁移方式与测量学 caveat
- [x] diff 不包含 secret、内部 URL 或个人数据
- [x] 英中双语文档保持一致