### PR TITLE
feat(eval-workflows): 建立 Core run 产物存储

### DIFF
--- a/docs/specs/evaluation-artifact-persistence.md
+++ b/docs/specs/evaluation-artifact-persistence.md
@@ -1,0 +1,58 @@
+# Evaluation Core artifact persistence
+
+> Status: host persistence contract for [#531](https://github.com/lizhiyao/oh-my-knowledge/issues/531), slice 1. It does not switch `omk eval`, read legacy reports, or make transported JSON a trusted Core capability.
+
+## 1. Boundary
+
+Evaluation Core remains pure and in-memory. The host persists one immutable run artifact set:
+
+1. the versioned `RunPlan` wire document;
+2. `ExecutionBundle`;
+3. `EvaluationBundle`;
+4. `AnalysisBundle`;
+5. `EvaluationReport`.
+
+The Plan is required because Bundle digests identify a sealed measurement contract but cannot reconstruct it. Persisting only results would force resume to trust summaries or recompile against ambient state. The host manifest is a locator and integrity projection, not a sixth measurement fact.
+
+## 2. Authority and verification
+
+On publication and full read, the store validates:
+
+- every wire schema and native artifact digest;
+- the Plan's recomputed dataset, stage, randomization, and run-contract digests;
+- Execution → Evaluation → Analysis → Report parent digests;
+- Report Bundle references, status, budget summary, Decision binding, and provenance parents;
+- manifest document digests and maximum captured-content classification;
+- every referenced content descriptor through an injected resolver.
+
+This proves transport integrity and exact lineage, not provenance authenticity. A persisted `RunPlan` is returned as a wire document and is never rebranded as `SealedRunPlan`. Resume must prepare the current Definition and MeasurementPolicy, obtain a fresh sealed Plan capability, and run the Core plan-aware Bundle verifiers before reuse. Digest equality alone cannot mint source trust, cache receipts, or Runtime attestation.
+
+## 3. Atomic publication
+
+Each run uses an opaque directory derived from the SHA-256 of `runId`; user identifiers never become path segments. The host writes all five documents and the manifest into a private staging directory, writes the manifest last, then publishes the directory with one same-filesystem rename. Readers enumerate only published `run-<digest>` directories. Interrupted hidden staging directories are invisible and can be cleaned independently.
+
+A `runId` is immutable. Re-publishing the exact document set is idempotent; a different set under the same ID fails. In-process writes are serialized per run, and the directory publication step also resolves cross-process races to one complete winner. Corrupt published runs fail explicitly instead of disappearing from list results.
+
+Directories use owner-only permissions and files use owner read/write permissions because a full Plan can contain expected or evaluation-only inputs. Paths are host effects and never enter Core documents or measurement digests.
+
+## 4. Manifest and index
+
+`omk.core-run-artifact-manifest/v1` uses qualified discriminants (`manifestKind`, `documentKind`). Its five references have fixed relative filenames, schema identity, native identity digest, and a canonical full-document digest. It also records run/report identity, run-contract digest, orthogonal Report status, Execution/Evaluation replayability, creation time, and maximum captured-content classification.
+
+An index card is a pure projection of a validated manifest. Listing may rebuild cards without resolving large content because it does not claim evidence availability. Loading a full run requires descriptor closure; a missing resolver or corrupt content fails instead of projecting empty evidence.
+
+## 5. Host content store
+
+The Node content store implements the existing Execution and Evaluation content ports. It verifies the caller-provided value digest before writing and stores a private, content-addressed envelope. Identity includes value digest, media type, and classification so the same bytes classified as `public` and `gold` cannot alias or downgrade each other. Descriptors use an opaque `omk-content:` URI and never expose a filesystem path.
+
+Resolution revalidates envelope digest, descriptor, canonical value digest, media type, byte size, and classification. Failures use stable, redacted codes; raw filesystem paths and content do not become Core errors.
+
+## 6. Non-goals
+
+- legacy `EvaluationReport` readers, migration, or dual writes;
+- resume admission or cache reuse;
+- batch, evolve, gold compare, artifact graph, or Studio projections;
+- the production CLI cutover and old pipeline deletion;
+- artifact signatures or provenance attestation.
+
+Those consumers build on this transport boundary in later #531 slices. The final CLI switch remains a separate `BREAKING-SCHEMA` change under #450.

--- a/docs/zh/specs/evaluation-artifact-persistence.md
+++ b/docs/zh/specs/evaluation-artifact-persistence.md
@@ -1,0 +1,58 @@
+# Evaluation Core 产物持久化
+
+> 状态：[#531](https://github.com/lizhiyao/oh-my-knowledge/issues/531) 第一个切片的宿主持久化契约。本阶段不切换 `omk eval`、不读取旧报告，也不会把传输来的 JSON 伪装成可信 Core capability。
+
+## 一、边界
+
+Evaluation Core 继续保持纯内存。宿主为每个 run 持久化一组不可变产物：
+
+1. 版本化 `RunPlan` wire document；
+2. `ExecutionBundle`；
+3. `EvaluationBundle`；
+4. `AnalysisBundle`；
+5. `EvaluationReport`。
+
+必须保存 Plan，因为 Bundle digest 只能标识已封存的测量契约，不能重建契约本身。若只保存结果，resume 将被迫信任摘要或依赖环境重新编译。宿主 manifest 只是定位和完整性投影，不是第六类测量事实。
+
+## 二、权威性与校验
+
+发布和完整读取时，store 校验：
+
+- 每份 wire schema 与原生产物 digest；
+- 根据 Plan 重新计算的 Dataset、stage、randomization 与 run-contract digest；
+- Execution → Evaluation → Analysis → Report 父 digest 链；
+- Report 的 Bundle 引用、状态、预算摘要、Decision 绑定与 provenance parent；
+- manifest 的文档 digest 与最高 captured-content classification；
+- 通过注入 resolver 解析并校验每个 content descriptor。
+
+这些校验证明传输完整性与精确 lineage，不证明 provenance 真实性。持久化 `RunPlan` 读取后仍是 wire document，绝不重新授予 `SealedRunPlan` brand。resume 必须用当前 Definition 与 MeasurementPolicy 重新 prepare，获得新的 sealed Plan capability，再调用 Core 的 plan-aware Bundle verifier 决定是否复用。digest 相等不能凭空生成 source trust、cache receipt 或 Runtime attestation。
+
+## 三、原子发布
+
+每个 run 使用由 `runId` 的 SHA-256 派生出的 opaque 目录，用户 ID 不直接成为路径片段。宿主先把五份文档和 manifest 写入私有 staging 目录，manifest 最后写入，再通过同文件系统的一次 rename 发布整个目录。读取方只枚举已发布的 `run-<digest>` 目录；进程中断留下的隐藏 staging 目录不可见，可独立清理。
+
+`runId` 不可变。完全相同的文档集合重复发布是幂等操作；同一 ID 对应不同集合时失败。进程内写入按 run 串行化，目录发布同时把跨进程竞态收敛为一个完整 winner。已发布 run 损坏时显式失败，不从列表里静默消失。
+
+完整 Plan 可能包含 expected 或 evaluator-only 输入，因此目录只允许 owner 访问，文件只允许 owner 读写。路径属于宿主 effect，不进入 Core 文档或测量 digest。
+
+## 四、Manifest 与索引
+
+`omk.core-run-artifact-manifest/v1` 使用限定判别字段 `manifestKind` 与 `documentKind`。五个文档引用具有固定相对文件名、schema identity、原生 identity digest 和完整文档 canonical digest；manifest 另行记录 run／report identity、run-contract digest、Report 三轴状态、Execution／Evaluation replayability、创建时间与 captured content 的最高分级。
+
+索引卡片只是已校验 manifest 的纯 projection。列表重建卡片时可以不解析大 content，因为列表不声称 evidence 可用；完整读取 run 时必须闭合 descriptor，缺 resolver 或 content 损坏都会失败，不能投影为空证据。
+
+## 五、宿主 ContentStore
+
+Node content store 实现现有 Execution／Evaluation content port。写入前校验调用方提供的 value digest，并持久化私有的内容寻址 envelope。identity 同时绑定 value digest、media type 与 classification，因此相同 bytes 的 `public` 与 `gold` 内容不会 alias 或互相降级。descriptor 使用 opaque `omk-content:` URI，不泄漏文件系统路径。
+
+解析时重新校验 envelope digest、descriptor、canonical value digest、media type、byte size 与 classification。失败只返回稳定且脱敏的错误码；原始文件路径和内容不会进入 Core error。
+
+## 六、非目标
+
+- 旧 `EvaluationReport` reader、迁移或双写；
+- resume admission 或 cache 复用；
+- batch、evolve、gold compare、artifact graph 或 Studio projection；
+- 正式 CLI 切换与旧 pipeline 删除；
+- artifact 签名或 provenance attestation。
+
+这些 consumer 在 #531 的后续切片中建立于本传输边界之上。最终 CLI 切换仍是 #450 下独立的 `BREAKING-SCHEMA` 变更。

--- a/src/eval-workflows/artifact-store/contracts.ts
+++ b/src/eval-workflows/artifact-store/contracts.ts
@@ -1,0 +1,202 @@
+import { z } from 'zod';
+import {
+  ANALYSIS_BUNDLE_SCHEMA_VERSION,
+  EVALUATION_BUNDLE_SCHEMA_VERSION,
+  EVALUATION_REPORT_SCHEMA_VERSION,
+  EXECUTION_BUNDLE_SCHEMA_VERSION,
+  RUN_PLAN_SCHEMA_VERSION,
+  EvaluationStatusSchema,
+  IdentifierSchema,
+  ReplayabilitySchema,
+  Sha256DigestSchema,
+  TimestampSchema,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  parseWireDocument,
+  type AnalysisBundle,
+  type EvaluationBundle,
+  type EvaluationReport,
+  type ExecutionBundle,
+  type RunPlan,
+} from '../../evaluation-core/contracts/index.js';
+import type { SealedRunPlan } from '../../evaluation-core/compiler/index.js';
+
+export const CORE_RUN_ARTIFACT_MANIFEST_SCHEMA_VERSION =
+  'omk.core-run-artifact-manifest/v1' as const;
+
+export const CORE_RUN_DOCUMENT_FILES = Object.freeze({
+  runPlan: 'run-plan.json',
+  executionBundle: 'execution-bundle.json',
+  evaluationBundle: 'evaluation-bundle.json',
+  analysisBundle: 'analysis-bundle.json',
+  evaluationReport: 'evaluation-report.json',
+  manifest: 'manifest.json',
+});
+
+const RunPlanDocumentReferenceSchema = z.object({
+  documentKind: z.literal('run-plan'),
+  fileName: z.literal(CORE_RUN_DOCUMENT_FILES.runPlan),
+  schemaVersion: z.literal(RUN_PLAN_SCHEMA_VERSION),
+  identityDigest: Sha256DigestSchema,
+  documentDigest: Sha256DigestSchema,
+}).strict();
+
+const ExecutionBundleDocumentReferenceSchema = z.object({
+  documentKind: z.literal('execution-bundle'),
+  fileName: z.literal(CORE_RUN_DOCUMENT_FILES.executionBundle),
+  schemaVersion: z.literal(EXECUTION_BUNDLE_SCHEMA_VERSION),
+  identityDigest: Sha256DigestSchema,
+  documentDigest: Sha256DigestSchema,
+}).strict();
+
+const EvaluationBundleDocumentReferenceSchema = z.object({
+  documentKind: z.literal('evaluation-bundle'),
+  fileName: z.literal(CORE_RUN_DOCUMENT_FILES.evaluationBundle),
+  schemaVersion: z.literal(EVALUATION_BUNDLE_SCHEMA_VERSION),
+  identityDigest: Sha256DigestSchema,
+  documentDigest: Sha256DigestSchema,
+}).strict();
+
+const AnalysisBundleDocumentReferenceSchema = z.object({
+  documentKind: z.literal('analysis-bundle'),
+  fileName: z.literal(CORE_RUN_DOCUMENT_FILES.analysisBundle),
+  schemaVersion: z.literal(ANALYSIS_BUNDLE_SCHEMA_VERSION),
+  identityDigest: Sha256DigestSchema,
+  documentDigest: Sha256DigestSchema,
+}).strict();
+
+const EvaluationReportDocumentReferenceSchema = z.object({
+  documentKind: z.literal('evaluation-report'),
+  fileName: z.literal(CORE_RUN_DOCUMENT_FILES.evaluationReport),
+  schemaVersion: z.literal(EVALUATION_REPORT_SCHEMA_VERSION),
+  identityDigest: Sha256DigestSchema,
+  documentDigest: Sha256DigestSchema,
+}).strict();
+
+export const CoreRunDocumentReferenceSchema = z.discriminatedUnion('documentKind', [
+  RunPlanDocumentReferenceSchema,
+  ExecutionBundleDocumentReferenceSchema,
+  EvaluationBundleDocumentReferenceSchema,
+  AnalysisBundleDocumentReferenceSchema,
+  EvaluationReportDocumentReferenceSchema,
+]);
+
+export const CoreRunArtifactManifestSchema = z.object({
+  schemaVersion: z.literal(CORE_RUN_ARTIFACT_MANIFEST_SCHEMA_VERSION),
+  manifestKind: z.literal('evaluation-core-run-artifacts'),
+  runId: IdentifierSchema,
+  reportId: IdentifierSchema,
+  runContractDigest: Sha256DigestSchema,
+  createdAt: TimestampSchema,
+  status: EvaluationStatusSchema,
+  replayability: z.object({
+    execution: ReplayabilitySchema,
+    evaluation: ReplayabilitySchema,
+  }).strict(),
+  maximumCapturedClassification: z.enum([
+    'public',
+    'sensitive',
+    'secret',
+    'gold',
+  ]),
+  documents: z.array(CoreRunDocumentReferenceSchema).length(5),
+  manifestDigest: Sha256DigestSchema,
+}).strict();
+
+export type CoreRunDocumentReference = z.infer<typeof CoreRunDocumentReferenceSchema>;
+export type CoreRunArtifactManifest = z.infer<typeof CoreRunArtifactManifestSchema>;
+
+export interface CoreRunArtifactSet {
+  readonly plan: SealedRunPlan;
+  readonly execution: ExecutionBundle;
+  readonly evaluation: EvaluationBundle;
+  readonly analysis: AnalysisBundle;
+  readonly report: EvaluationReport;
+}
+
+export interface StoredCoreRunArtifacts {
+  readonly manifest: CoreRunArtifactManifest;
+  readonly plan: RunPlan;
+  readonly execution: ExecutionBundle;
+  readonly evaluation: EvaluationBundle;
+  readonly analysis: AnalysisBundle;
+  readonly report: EvaluationReport;
+}
+
+export interface CoreRunArtifactIndexCard {
+  readonly runId: string;
+  readonly reportId: string;
+  readonly runContractDigest: string;
+  readonly reportDigest: string;
+  readonly createdAt: string;
+  readonly status: EvaluationReport['status'];
+  readonly replayability: CoreRunArtifactManifest['replayability'];
+  readonly maximumCapturedClassification:
+    CoreRunArtifactManifest['maximumCapturedClassification'];
+}
+
+export interface SaveCoreRunArtifactsRequest extends CoreRunArtifactSet {
+  readonly runId: string;
+  readonly createdAt: string;
+}
+
+export interface CoreRunArtifactStore {
+  save(request: Readonly<SaveCoreRunArtifactsRequest>): Promise<StoredCoreRunArtifacts>;
+  get(runId: string): Promise<StoredCoreRunArtifacts | undefined>;
+  list(): Promise<CoreRunArtifactIndexCard[]>;
+  exists(runId: string): Promise<boolean>;
+}
+
+const DOCUMENT_ORDER: readonly CoreRunDocumentReference['documentKind'][] = [
+  'run-plan',
+  'execution-bundle',
+  'evaluation-bundle',
+  'analysis-bundle',
+  'evaluation-report',
+];
+
+export function parseCoreRunArtifactManifestDocument(
+  value: unknown,
+): CoreRunArtifactManifest {
+  const manifest = parseWireDocument(CoreRunArtifactManifestSchema, value);
+  if (manifest.documents.some((document, index) => (
+    document.documentKind !== DOCUMENT_ORDER[index]
+  ))) {
+    throw new TypeError('Core run artifact manifest documents are not canonically ordered.');
+  }
+  const { manifestDigest, ...payload } = manifest;
+  if (digestCanonicalJson(payload) !== manifestDigest) {
+    throw new TypeError('Core run artifact manifest digest does not match its payload.');
+  }
+  return deepFreezeCanonicalJson(manifest);
+}
+
+export function materializeCoreRunArtifactManifest(
+  input: Omit<CoreRunArtifactManifest, 'manifestDigest'>,
+): CoreRunArtifactManifest {
+  return parseCoreRunArtifactManifestDocument({
+    ...input,
+    manifestDigest: digestCanonicalJson(input),
+  });
+}
+
+export function projectCoreRunArtifactIndexCard(
+  manifest: CoreRunArtifactManifest,
+): CoreRunArtifactIndexCard {
+  const report = manifest.documents.find((document) => (
+    document.documentKind === 'evaluation-report'
+  ));
+  if (report === undefined) {
+    throw new TypeError('Core run artifact manifest is missing its EvaluationReport.');
+  }
+  return deepFreezeCanonicalJson({
+    runId: manifest.runId,
+    reportId: manifest.reportId,
+    runContractDigest: manifest.runContractDigest,
+    reportDigest: report.identityDigest,
+    createdAt: manifest.createdAt,
+    status: manifest.status,
+    replayability: manifest.replayability,
+    maximumCapturedClassification: manifest.maximumCapturedClassification,
+  });
+}

--- a/src/eval-workflows/artifact-store/index.ts
+++ b/src/eval-workflows/artifact-store/index.ts
@@ -1,0 +1,3 @@
+export * from './contracts.js';
+export * from './node-content-store.js';
+export * from './node-run-store.js';

--- a/src/eval-workflows/artifact-store/node-content-store.ts
+++ b/src/eval-workflows/artifact-store/node-content-store.ts
@@ -1,0 +1,235 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { z } from 'zod';
+import {
+  ContentClassificationSchema,
+  ContentDescriptorSchema,
+  JsonValueSchema,
+  canonicalizeJson,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  parseWireDocument,
+  type ContentDescriptor,
+  type JsonValue,
+} from '../../evaluation-core/contracts/index.js';
+import type {
+  ExecutionContent,
+  ExecutionContentStoreRequest,
+} from '../../evaluation-core/execution/index.js';
+import type {
+  EvaluationContent,
+  EvaluationContentStoreRequest,
+} from '../../evaluation-core/evaluation/index.js';
+import {
+  ensurePrivateDirectory,
+  publishPrivateJsonExclusive,
+} from './private-json-file.js';
+
+const CONTENT_DOCUMENT_SCHEMA_VERSION = 'omk.host-content-document/v1' as const;
+const CONTENT_URI_PREFIX = 'omk-content:';
+
+const ContentDocumentSchema = z.object({
+  schemaVersion: z.literal(CONTENT_DOCUMENT_SCHEMA_VERSION),
+  contentDocumentKind: z.literal('evaluation-captured-content'),
+  descriptor: ContentDescriptorSchema,
+  classification: ContentClassificationSchema,
+  value: JsonValueSchema,
+  contentDocumentDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/),
+}).strict();
+
+type ContentDocument = z.infer<typeof ContentDocumentSchema>;
+
+export type NodeCoreContentStore = {
+  put(request: Readonly<
+    ExecutionContentStoreRequest | EvaluationContentStoreRequest
+  >): Promise<ContentDescriptor>;
+  resolve(descriptor: Readonly<ContentDescriptor>): Promise<
+    ExecutionContent | EvaluationContent
+  >;
+};
+
+export type NodeCoreContentStoreErrorCode =
+  | 'CORE_CONTENT_REQUEST_INVALID'
+  | 'CORE_CONTENT_DESCRIPTOR_INVALID'
+  | 'CORE_CONTENT_UNAVAILABLE'
+  | 'CORE_CONTENT_DOCUMENT_INVALID'
+  | 'CORE_CONTENT_IDENTITY_CONFLICT';
+
+export class NodeCoreContentStoreError extends TypeError {
+  readonly code: NodeCoreContentStoreErrorCode;
+
+  constructor(code: NodeCoreContentStoreErrorCode, message: string) {
+    super(message);
+    this.name = 'NodeCoreContentStoreError';
+    this.code = code;
+  }
+}
+
+function fail(code: NodeCoreContentStoreErrorCode, message: string): never {
+  throw new NodeCoreContentStoreError(code, message);
+}
+
+function contentKey(input: {
+  digest: string;
+  mediaType: string;
+  classification: string;
+}): string {
+  return digestCanonicalJson({
+    derivation: 'omk.host-content-key/v1',
+    digest: input.digest,
+    mediaType: input.mediaType,
+    classification: input.classification,
+  }).slice('sha256:'.length);
+}
+
+function contentFilePath(rootDir: string, key: string): string {
+  return join(rootDir, 'content', `${key}.content.json`);
+}
+
+function parseContentKey(descriptor: ContentDescriptor): string {
+  const uri = descriptor.uri;
+  if (uri === undefined || !uri.startsWith(CONTENT_URI_PREFIX)) {
+    fail(
+      'CORE_CONTENT_DESCRIPTOR_INVALID',
+      'Content descriptor is not owned by this host content store.',
+    );
+  }
+  const key = uri.slice(CONTENT_URI_PREFIX.length);
+  if (!/^[0-9a-f]{64}$/.test(key)) {
+    fail('CORE_CONTENT_DESCRIPTOR_INVALID', 'Content descriptor URI is invalid.');
+  }
+  return key;
+}
+
+function parseContentDocument(value: unknown): ContentDocument {
+  const document = parseWireDocument(ContentDocumentSchema, value);
+  const { contentDocumentDigest, ...payload } = document;
+  if (digestCanonicalJson(payload) !== contentDocumentDigest) {
+    fail(
+      'CORE_CONTENT_DOCUMENT_INVALID',
+      'Content document digest does not match its payload.',
+    );
+  }
+  const canonical = canonicalizeJson(document.value);
+  if (digestCanonicalJson(document.value) !== document.descriptor.digest
+      || Buffer.byteLength(canonical, 'utf8') !== document.descriptor.size) {
+    fail(
+      'CORE_CONTENT_DOCUMENT_INVALID',
+      'Content document does not match its descriptor.',
+    );
+  }
+  const expectedKey = contentKey({
+    digest: document.descriptor.digest,
+    mediaType: document.descriptor.mediaType,
+    classification: document.classification,
+  });
+  if (document.descriptor.uri !== `${CONTENT_URI_PREFIX}${expectedKey}`) {
+    fail(
+      'CORE_CONTENT_DOCUMENT_INVALID',
+      'Content document URI does not match its identity.',
+    );
+  }
+  return deepFreezeCanonicalJson(document);
+}
+
+export function createNodeCoreContentStore(rootDir: string): NodeCoreContentStore {
+  async function resolve(
+    rawDescriptor: Readonly<ContentDescriptor>,
+  ): Promise<ExecutionContent | EvaluationContent> {
+    let descriptor: ContentDescriptor;
+    try {
+      descriptor = parseWireDocument(ContentDescriptorSchema, rawDescriptor);
+    } catch {
+      fail('CORE_CONTENT_DESCRIPTOR_INVALID', 'Content descriptor is invalid.');
+    }
+    const key = parseContentKey(descriptor);
+    let encoded: string;
+    try {
+      encoded = await readFile(contentFilePath(rootDir, key), 'utf8');
+    } catch {
+      fail('CORE_CONTENT_UNAVAILABLE', 'Captured content is unavailable.');
+    }
+    let document: ContentDocument;
+    try {
+      document = parseContentDocument(JSON.parse(encoded) as unknown);
+    } catch (error: unknown) {
+      if (error instanceof NodeCoreContentStoreError) throw error;
+      fail('CORE_CONTENT_DOCUMENT_INVALID', 'Captured content document is invalid.');
+    }
+    if (canonicalizeJson(document.descriptor) !== canonicalizeJson(descriptor)) {
+      fail(
+        'CORE_CONTENT_DOCUMENT_INVALID',
+        'Resolved content descriptor differs from the requested descriptor.',
+      );
+    }
+    return deepFreezeCanonicalJson({
+      value: document.value,
+      classification: document.classification,
+      mediaType: document.descriptor.mediaType,
+    });
+  }
+
+  async function put(request: Readonly<
+    ExecutionContentStoreRequest | EvaluationContentStoreRequest
+  >): Promise<ContentDescriptor> {
+    if (request.mediaType === '') {
+      fail('CORE_CONTENT_REQUEST_INVALID', 'Content media type must not be empty.');
+    }
+    let value: JsonValue;
+    try {
+      value = parseWireDocument(JsonValueSchema, request.value) as JsonValue;
+    } catch {
+      fail('CORE_CONTENT_REQUEST_INVALID', 'Content value is not canonical JSON.');
+    }
+    if (digestCanonicalJson(value) !== request.digest) {
+      fail(
+        'CORE_CONTENT_REQUEST_INVALID',
+        'Content store request digest does not match its value.',
+      );
+    }
+    const size = Buffer.byteLength(canonicalizeJson(value), 'utf8');
+    const key = contentKey({
+      digest: request.digest,
+      mediaType: request.mediaType,
+      classification: request.classification,
+    });
+    const descriptor = parseWireDocument(ContentDescriptorSchema, {
+      digest: request.digest,
+      mediaType: request.mediaType,
+      size,
+      uri: `${CONTENT_URI_PREFIX}${key}`,
+    });
+    const payload = {
+      schemaVersion: CONTENT_DOCUMENT_SCHEMA_VERSION,
+      contentDocumentKind: 'evaluation-captured-content' as const,
+      descriptor,
+      classification: request.classification,
+      value,
+    };
+    const document = parseContentDocument({
+      ...payload,
+      contentDocumentDigest: digestCanonicalJson(payload),
+    });
+    await ensurePrivateDirectory(join(rootDir, 'content'));
+    const outcome = await publishPrivateJsonExclusive(
+      contentFilePath(rootDir, key),
+      document,
+    );
+    if (outcome === 'exists') {
+      const existing = await resolve(descriptor);
+      if (canonicalizeJson(existing) !== canonicalizeJson({
+        value,
+        classification: request.classification,
+        mediaType: request.mediaType,
+      })) {
+        fail(
+          'CORE_CONTENT_IDENTITY_CONFLICT',
+          'Content identity collides with different persisted content.',
+        );
+      }
+    }
+    return deepFreezeCanonicalJson(descriptor);
+  }
+
+  return Object.freeze({ put, resolve });
+}

--- a/src/eval-workflows/artifact-store/node-run-store.ts
+++ b/src/eval-workflows/artifact-store/node-run-store.ts
@@ -1,0 +1,717 @@
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  access,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+} from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import {
+  RunPlanSchema,
+  canonicalizeJson,
+  computeAnalysisPlanDigest,
+  computeDecisionPlanDigest,
+  computeEvaluationPlanDigest,
+  computeExecutionPlanDigest,
+  computePlanDigests,
+  computeRandomizationDesignDigest,
+  computeRunContractDigest,
+  deepFreezeCanonicalJson,
+  deriveEvaluationStatus,
+  digestCanonicalJson,
+  evaluationRecordCapturedContents,
+  parseAnalysisBundleDocument,
+  parseEvaluationBundleDocument,
+  parseEvaluationReportDocument,
+  parseExecutionBundleDocument,
+  parseWireDocument,
+  type CapturedContent,
+  type ContentDescriptor,
+  type RunPlan,
+  type Sha256Digest,
+} from '../../evaluation-core/contracts/index.js';
+import type { EvaluationContentResolver } from '../../evaluation-core/evaluation/index.js';
+import { KeyedMutex } from '../../shared/keyed-mutex.js';
+import {
+  CORE_RUN_ARTIFACT_MANIFEST_SCHEMA_VERSION,
+  CORE_RUN_DOCUMENT_FILES,
+  CoreRunArtifactManifestSchema,
+  materializeCoreRunArtifactManifest,
+  parseCoreRunArtifactManifestDocument,
+  projectCoreRunArtifactIndexCard,
+  type CoreRunArtifactIndexCard,
+  type CoreRunArtifactManifest,
+  type CoreRunArtifactStore,
+  type CoreRunDocumentReference,
+  type SaveCoreRunArtifactsRequest,
+  type StoredCoreRunArtifacts,
+} from './contracts.js';
+import {
+  ensurePrivateDirectory,
+  publishPrivateDirectoryExclusive,
+  writePrivateJson,
+} from './private-json-file.js';
+
+const CLASSIFICATION_RANK = {
+  public: 0,
+  sensitive: 1,
+  secret: 2,
+  gold: 3,
+} as const;
+
+export type CoreRunArtifactStoreErrorCode =
+  | 'CORE_RUN_ARTIFACT_INPUT_INVALID'
+  | 'CORE_RUN_ARTIFACT_PLAN_INVALID'
+  | 'CORE_RUN_ARTIFACT_SOURCE_CHAIN_INVALID'
+  | 'CORE_RUN_ARTIFACT_MANIFEST_INVALID'
+  | 'CORE_RUN_ARTIFACT_DOCUMENT_MISSING'
+  | 'CORE_RUN_ARTIFACT_DOCUMENT_INVALID'
+  | 'CORE_RUN_ARTIFACT_DOCUMENT_DIGEST_MISMATCH'
+  | 'CORE_RUN_ARTIFACT_CONTENT_RESOLVER_REQUIRED'
+  | 'CORE_RUN_ARTIFACT_CONTENT_INVALID'
+  | 'CORE_RUN_ARTIFACT_RUN_ID_CONFLICT';
+
+export class CoreRunArtifactStoreError extends TypeError {
+  readonly code: CoreRunArtifactStoreErrorCode;
+
+  constructor(code: CoreRunArtifactStoreErrorCode, message: string) {
+    super(message);
+    this.name = 'CoreRunArtifactStoreError';
+    this.code = code;
+  }
+}
+
+export interface NodeCoreRunArtifactStoreOptions {
+  readonly contentResolver?: EvaluationContentResolver;
+}
+
+type ParsedCoreRunArtifacts = Omit<StoredCoreRunArtifacts, 'manifest'>;
+
+function fail(code: CoreRunArtifactStoreErrorCode, message: string): never {
+  throw new CoreRunArtifactStoreError(code, message);
+}
+
+function runDirectoryName(runId: string): string {
+  return `run-${createHash('sha256').update(runId).digest('hex')}`;
+}
+
+function sha256(value: string): Sha256Digest {
+  return value as Sha256Digest;
+}
+
+function runDirectoryPath(rootDir: string, runId: string): string {
+  return join(rootDir, runDirectoryName(runId));
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function assertPlanDocument(plan: RunPlan): void {
+  const definition = plan.definition;
+  const expectedDigests = computePlanDigests({
+    dataset: definition.dataset,
+    targets: definition.targets,
+    evaluators: definition.evaluators,
+    metrics: definition.metrics,
+    experiment: definition.experiment,
+    analysisGraph: definition.analysisGraph,
+    comparisons: definition.comparisons,
+    ...(definition.decisionPolicy === undefined
+      ? {}
+      : { decisionPolicy: definition.decisionPolicy }),
+    measurementPolicy: plan.measurementPolicy,
+    executorRuntimes: plan.execution.runtimes,
+    evaluatorRuntimes: plan.evaluation.runtimes,
+    analysisRuntimes: plan.analysis.runtimes,
+    decisionRuntimes: plan.decision.runtimes,
+    schemaIdentities: plan.schemaIdentities,
+    ...(definition.seriesMembership === undefined
+      ? {}
+      : { seriesMembership: definition.seriesMembership }),
+    stageExtensions: {
+      ...(plan.execution.extensions === undefined
+        ? {}
+        : { execution: plan.execution.extensions }),
+      ...(plan.evaluation.extensions === undefined
+        ? {}
+        : { evaluation: plan.evaluation.extensions }),
+      ...(plan.analysis.extensions === undefined
+        ? {}
+        : { analysis: plan.analysis.extensions }),
+      ...(plan.decision.extensions === undefined
+        ? {}
+        : { decision: plan.decision.extensions }),
+      ...(plan.extensions === undefined ? {} : { run: plan.extensions }),
+    },
+  });
+  const actualRandomizationDesignDigest = computeRandomizationDesignDigest({
+    executionInputDigest: sha256(plan.execution.executionInputDigest),
+    samples: plan.execution.samples,
+    schedulingTargetGroups: plan.execution.schedulingTargetGroups,
+    experiment: {
+      ...plan.execution.experiment,
+      sampling: {
+        ...plan.execution.experiment.sampling,
+        estimatorId: definition.experiment.sampling.estimatorId,
+      },
+    },
+  });
+  const actualExecutionPlanDigest = computeExecutionPlanDigest({
+    executionInputDigest: sha256(plan.execution.executionInputDigest),
+    randomizationDesignDigest: sha256(plan.execution.randomizationDesignDigest),
+    targets: plan.execution.targets,
+    schedulingTargetGroups: plan.execution.schedulingTargetGroups,
+    executorRuntimes: plan.execution.runtimes,
+    experiment: plan.execution.experiment,
+    policy: plan.execution.policy,
+    ...(plan.execution.extensions === undefined
+      ? {}
+      : { extensions: plan.execution.extensions }),
+  });
+  const actualEvaluationPlanDigest = computeEvaluationPlanDigest({
+    executionPlanDigest: sha256(plan.evaluation.executionPlanDigest),
+    evaluationInputDigest: sha256(plan.evaluation.evaluationInputDigest),
+    evaluators: plan.evaluation.evaluators,
+    metrics: plan.evaluation.metrics,
+    evaluatorRuntimes: plan.evaluation.runtimes,
+    policy: plan.evaluation.policy,
+    ...(plan.evaluation.extensions === undefined
+      ? {}
+      : { extensions: plan.evaluation.extensions }),
+  });
+  const actualAnalysisPlanDigest = computeAnalysisPlanDigest({
+    evaluationPlanDigest: sha256(plan.analysis.evaluationPlanDigest),
+    analysisInputDigest: sha256(plan.analysis.analysisInputDigest),
+    samples: plan.analysis.samples,
+    cohorts: plan.analysis.cohorts,
+    metrics: plan.analysis.metrics,
+    analysisGraph: plan.analysis.analysisGraph,
+    experiment: plan.analysis.experiment,
+    comparisons: plan.analysis.comparisons,
+    analysisRuntimes: plan.analysis.runtimes,
+    ...(plan.analysis.extensions === undefined
+      ? {}
+      : { extensions: plan.analysis.extensions }),
+  });
+  const actualDecisionPlanDigest = computeDecisionPlanDigest({
+    analysisPlanDigest: sha256(plan.decision.analysisPlanDigest),
+    analysisInputDigest: sha256(plan.decision.analysisInputDigest),
+    ...(plan.decision.decisionPolicy === undefined
+      ? {}
+      : { decisionPolicy: plan.decision.decisionPolicy }),
+    decisionRuntimes: plan.decision.runtimes,
+    ...(plan.decision.extensions === undefined
+      ? {}
+      : { extensions: plan.decision.extensions }),
+  });
+  const actualRunContractDigest = computeRunContractDigest({
+    executionPlanDigest: sha256(plan.execution.executionPlanDigest),
+    evaluationPlanDigest: sha256(plan.evaluation.evaluationPlanDigest),
+    analysisPlanDigest: sha256(plan.analysis.analysisPlanDigest),
+    decisionPlanDigest: sha256(plan.decision.decisionPlanDigest),
+    schemaIdentities: plan.schemaIdentities,
+    eventDeliveryPolicy: plan.measurementPolicy.eventDelivery,
+    ...(plan.definition.seriesMembership === undefined
+      ? {}
+      : { seriesMembership: plan.definition.seriesMembership }),
+    ...(plan.extensions === undefined ? {} : { extensions: plan.extensions }),
+  });
+  const actualExecutionInputDigest = digestCanonicalJson({
+    datasetId: plan.definition.dataset.datasetId,
+    samples: plan.execution.samples,
+  });
+  const actualEvaluationInputDigest = digestCanonicalJson({
+    datasetId: plan.definition.dataset.datasetId,
+    samples: plan.evaluation.samples,
+  });
+  const actualAnalysisInputDigest = digestCanonicalJson({
+    datasetId: plan.definition.dataset.datasetId,
+    cohorts: plan.analysis.cohorts,
+    samples: plan.analysis.samples,
+  });
+  if (canonicalizeJson(plan.digests) !== canonicalizeJson(expectedDigests)
+      || actualExecutionInputDigest !== plan.digests.executionInputDigest
+      || actualEvaluationInputDigest !== plan.digests.evaluationInputDigest
+      || actualAnalysisInputDigest !== plan.digests.analysisInputDigest
+      || actualRandomizationDesignDigest !== plan.digests.randomizationDesignDigest
+      || actualExecutionPlanDigest !== plan.execution.executionPlanDigest
+      || actualEvaluationPlanDigest !== plan.evaluation.evaluationPlanDigest
+      || actualAnalysisPlanDigest !== plan.analysis.analysisPlanDigest
+      || actualDecisionPlanDigest !== plan.decision.decisionPlanDigest
+      || actualRunContractDigest !== plan.digests.runContractDigest
+      || plan.execution.executionPlanDigest !== expectedDigests.executionPlanDigest
+      || plan.evaluation.executionPlanDigest !== expectedDigests.executionPlanDigest
+      || plan.evaluation.evaluationPlanDigest !== expectedDigests.evaluationPlanDigest
+      || plan.analysis.evaluationPlanDigest !== expectedDigests.evaluationPlanDigest
+      || plan.analysis.analysisPlanDigest !== expectedDigests.analysisPlanDigest
+      || plan.decision.analysisPlanDigest !== expectedDigests.analysisPlanDigest
+      || plan.decision.decisionPlanDigest !== expectedDigests.decisionPlanDigest) {
+    fail(
+      'CORE_RUN_ARTIFACT_PLAN_INVALID',
+      'Persisted RunPlan digests do not match its sealed measurement contract.',
+    );
+  }
+}
+
+function exactBundleReferences(
+  input: ParsedCoreRunArtifacts,
+): boolean {
+  return canonicalizeJson(input.report.bundles.map((reference) => ({
+    bundleKind: reference.bundleKind,
+    schemaVersion: reference.schemaVersion,
+    bundleDigest: reference.bundleDigest,
+  }))) === canonicalizeJson([
+    {
+      bundleKind: 'execution',
+      schemaVersion: input.execution.schemaVersion,
+      bundleDigest: input.execution.bundleDigest,
+    },
+    {
+      bundleKind: 'evaluation',
+      schemaVersion: input.evaluation.schemaVersion,
+      bundleDigest: input.evaluation.bundleDigest,
+    },
+    {
+      bundleKind: 'analysis',
+      schemaVersion: input.analysis.schemaVersion,
+      bundleDigest: input.analysis.bundleDigest,
+    },
+  ]);
+}
+
+function assertSourceChain(input: ParsedCoreRunArtifacts): void {
+  const { plan, execution, evaluation, analysis, report } = input;
+  const parentDigests = [
+    execution.bundleDigest,
+    evaluation.bundleDigest,
+    analysis.bundleDigest,
+    ...(report.decision === undefined ? [] : [report.decision.decisionDigest]),
+  ];
+  const expectedStatus = deriveEvaluationStatus({
+    execution,
+    evaluation,
+    analysis,
+    ...(report.decision === undefined ? {} : { decision: report.decision }),
+  });
+  if (execution.runContractDigest !== plan.digests.runContractDigest
+      || execution.executionPlanDigest !== plan.digests.executionPlanDigest
+      || execution.datasetRevisionDigest !== plan.digests.datasetRevisionDigest
+      || execution.executionInputDigest !== plan.digests.executionInputDigest
+      || evaluation.runContractDigest !== plan.digests.runContractDigest
+      || evaluation.executionBundleDigest !== execution.bundleDigest
+      || evaluation.evaluationPlanDigest !== plan.digests.evaluationPlanDigest
+      || evaluation.evaluationInputDigest !== plan.digests.evaluationInputDigest
+      || analysis.runContractDigest !== plan.digests.runContractDigest
+      || analysis.evaluationBundleDigest !== evaluation.bundleDigest
+      || analysis.analysisPlanDigest !== plan.digests.analysisPlanDigest
+      || report.runContractDigest !== plan.digests.runContractDigest
+      || !exactBundleReferences(input)
+      || canonicalizeJson(report.budgetSummary) !== canonicalizeJson(evaluation.budgetSummary)
+      || canonicalizeJson(report.status) !== canonicalizeJson(expectedStatus)
+      || canonicalizeJson(report.provenance.parentDigests)
+        !== canonicalizeJson(parentDigests)
+      || (report.decision !== undefined
+        && (report.decision.analysisBundleDigest !== analysis.bundleDigest
+          || report.decision.decisionPlanDigest !== plan.digests.decisionPlanDigest))) {
+    fail(
+      'CORE_RUN_ARTIFACT_SOURCE_CHAIN_INVALID',
+      'Persisted Core artifacts do not form one exact Plan and parent-digest chain.',
+    );
+  }
+}
+
+function executionCapturedContents(
+  input: ParsedCoreRunArtifacts['execution'],
+): CapturedContent[] {
+  return input.records.flatMap((record) => {
+    if (record.executionStatus === 'budget-censored') return [];
+    return [
+      ...(record.executionStatus === 'completed' && record.output !== undefined
+        ? [record.output]
+        : []),
+      ...(record.trace === undefined ? [] : [record.trace]),
+    ];
+  });
+}
+
+function capturedContents(input: ParsedCoreRunArtifacts): CapturedContent[] {
+  return [
+    ...executionCapturedContents(input.execution),
+    ...input.evaluation.records.flatMap(evaluationRecordCapturedContents),
+  ];
+}
+
+function maximumCapturedClassification(
+  input: ParsedCoreRunArtifacts,
+): CoreRunArtifactManifest['maximumCapturedClassification'] {
+  return capturedContents(input).reduce<
+    CoreRunArtifactManifest['maximumCapturedClassification']
+  >((current, content) => (
+    CLASSIFICATION_RANK[content.classification] > CLASSIFICATION_RANK[current]
+      ? content.classification
+      : current
+  ), 'public');
+}
+
+async function assertContentClosure(
+  input: ParsedCoreRunArtifacts,
+  resolver: EvaluationContentResolver | undefined,
+): Promise<void> {
+  const descriptors = new Map<string, {
+    descriptor: ContentDescriptor;
+    classification: CapturedContent['classification'];
+  }>();
+  for (const content of capturedContents(input)) {
+    if (content.contentKind !== 'descriptor') continue;
+    const key = canonicalizeJson(content.descriptor);
+    const existing = descriptors.get(key);
+    if (existing !== undefined && existing.classification !== content.classification) {
+      fail(
+        'CORE_RUN_ARTIFACT_CONTENT_INVALID',
+        'One content descriptor is assigned conflicting classifications.',
+      );
+    }
+    descriptors.set(key, {
+      descriptor: content.descriptor,
+      classification: content.classification,
+    });
+  }
+  if (descriptors.size === 0) return;
+  if (resolver === undefined) {
+    fail(
+      'CORE_RUN_ARTIFACT_CONTENT_RESOLVER_REQUIRED',
+      'Resolvable Core artifacts require a host content resolver before publication.',
+    );
+  }
+  for (const { descriptor, classification } of descriptors.values()) {
+    let resolved;
+    try {
+      resolved = await resolver.resolve(descriptor);
+    } catch {
+      fail(
+        'CORE_RUN_ARTIFACT_CONTENT_INVALID',
+        'A captured content descriptor cannot be resolved.',
+      );
+    }
+    if (digestCanonicalJson(resolved.value) !== descriptor.digest
+        || resolved.classification !== classification
+        || (resolved.mediaType !== undefined && resolved.mediaType !== descriptor.mediaType)) {
+      fail(
+        'CORE_RUN_ARTIFACT_CONTENT_INVALID',
+        'Resolved captured content does not match its descriptor and classification.',
+      );
+    }
+  }
+}
+
+function documents(input: ParsedCoreRunArtifacts): CoreRunDocumentReference[] {
+  return [
+    {
+      documentKind: 'run-plan',
+      fileName: CORE_RUN_DOCUMENT_FILES.runPlan,
+      schemaVersion: input.plan.schemaVersion,
+      identityDigest: input.plan.digests.runContractDigest,
+      documentDigest: digestCanonicalJson(input.plan),
+    },
+    {
+      documentKind: 'execution-bundle',
+      fileName: CORE_RUN_DOCUMENT_FILES.executionBundle,
+      schemaVersion: input.execution.schemaVersion,
+      identityDigest: input.execution.bundleDigest,
+      documentDigest: digestCanonicalJson(input.execution),
+    },
+    {
+      documentKind: 'evaluation-bundle',
+      fileName: CORE_RUN_DOCUMENT_FILES.evaluationBundle,
+      schemaVersion: input.evaluation.schemaVersion,
+      identityDigest: input.evaluation.bundleDigest,
+      documentDigest: digestCanonicalJson(input.evaluation),
+    },
+    {
+      documentKind: 'analysis-bundle',
+      fileName: CORE_RUN_DOCUMENT_FILES.analysisBundle,
+      schemaVersion: input.analysis.schemaVersion,
+      identityDigest: input.analysis.bundleDigest,
+      documentDigest: digestCanonicalJson(input.analysis),
+    },
+    {
+      documentKind: 'evaluation-report',
+      fileName: CORE_RUN_DOCUMENT_FILES.evaluationReport,
+      schemaVersion: input.report.schemaVersion,
+      identityDigest: input.report.reportDigest,
+      documentDigest: digestCanonicalJson(input.report),
+    },
+  ];
+}
+
+function parseArtifactSet(input: {
+  plan: unknown;
+  execution: unknown;
+  evaluation: unknown;
+  analysis: unknown;
+  report: unknown;
+}): ParsedCoreRunArtifacts {
+  try {
+    const parsed = deepFreezeCanonicalJson({
+      plan: parseWireDocument(RunPlanSchema, input.plan),
+      execution: parseExecutionBundleDocument(input.execution),
+      evaluation: parseEvaluationBundleDocument(input.evaluation),
+      analysis: parseAnalysisBundleDocument(input.analysis),
+      report: parseEvaluationReportDocument(input.report),
+    });
+    assertPlanDocument(parsed.plan);
+    assertSourceChain(parsed);
+    return parsed;
+  } catch (error: unknown) {
+    if (error instanceof CoreRunArtifactStoreError) throw error;
+    fail(
+      'CORE_RUN_ARTIFACT_DOCUMENT_INVALID',
+      'A persisted Core wire document is invalid.',
+    );
+  }
+}
+
+async function readJson(path: string, code: CoreRunArtifactStoreErrorCode): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(path, 'utf8')) as unknown;
+  } catch {
+    fail(code, 'A required Core run artifact document is missing or unreadable.');
+  }
+}
+
+function assertManifestMatchesArtifacts(
+  manifest: CoreRunArtifactManifest,
+  artifacts: ParsedCoreRunArtifacts,
+): void {
+  if (manifest.reportId !== artifacts.report.reportId
+      || manifest.runContractDigest !== artifacts.plan.digests.runContractDigest
+      || canonicalizeJson(manifest.status) !== canonicalizeJson(artifacts.report.status)
+      || canonicalizeJson(manifest.replayability) !== canonicalizeJson({
+        execution: artifacts.execution.replayability,
+        evaluation: artifacts.evaluation.replayability,
+      })
+      || manifest.maximumCapturedClassification
+        !== maximumCapturedClassification(artifacts)) {
+    fail(
+      'CORE_RUN_ARTIFACT_MANIFEST_INVALID',
+      'Core run artifact manifest does not match its referenced documents.',
+    );
+  }
+  const expected = documents(artifacts);
+  if (manifest.documents.some((document, index) => (
+    canonicalizeJson(document) !== canonicalizeJson(expected[index])
+  ))) {
+    fail(
+      'CORE_RUN_ARTIFACT_DOCUMENT_DIGEST_MISMATCH',
+      'Core run artifact document digest differs from its published manifest.',
+    );
+  }
+}
+
+export function createNodeCoreRunArtifactStore(
+  rootDir: string,
+  options: NodeCoreRunArtifactStoreOptions = {},
+): CoreRunArtifactStore {
+  const mutations = new KeyedMutex();
+
+  async function loadDirectory(
+    directory: string,
+    expectedRunId?: string,
+    verifyContentClosure = true,
+  ): Promise<StoredCoreRunArtifacts> {
+    let manifest: CoreRunArtifactManifest;
+    try {
+      manifest = parseCoreRunArtifactManifestDocument(await readJson(
+        join(directory, CORE_RUN_DOCUMENT_FILES.manifest),
+        'CORE_RUN_ARTIFACT_DOCUMENT_MISSING',
+      ));
+    } catch (error: unknown) {
+      if (error instanceof CoreRunArtifactStoreError) throw error;
+      fail(
+        'CORE_RUN_ARTIFACT_MANIFEST_INVALID',
+        'Core run artifact manifest is invalid.',
+      );
+    }
+    if ((expectedRunId !== undefined && manifest.runId !== expectedRunId)
+        || runDirectoryName(manifest.runId) !== basename(directory)) {
+      fail(
+        'CORE_RUN_ARTIFACT_MANIFEST_INVALID',
+        'Core run artifact manifest identity differs from its locator.',
+      );
+    }
+    const artifacts = parseArtifactSet({
+      plan: await readJson(
+        join(directory, CORE_RUN_DOCUMENT_FILES.runPlan),
+        'CORE_RUN_ARTIFACT_DOCUMENT_MISSING',
+      ),
+      execution: await readJson(
+        join(directory, CORE_RUN_DOCUMENT_FILES.executionBundle),
+        'CORE_RUN_ARTIFACT_DOCUMENT_MISSING',
+      ),
+      evaluation: await readJson(
+        join(directory, CORE_RUN_DOCUMENT_FILES.evaluationBundle),
+        'CORE_RUN_ARTIFACT_DOCUMENT_MISSING',
+      ),
+      analysis: await readJson(
+        join(directory, CORE_RUN_DOCUMENT_FILES.analysisBundle),
+        'CORE_RUN_ARTIFACT_DOCUMENT_MISSING',
+      ),
+      report: await readJson(
+        join(directory, CORE_RUN_DOCUMENT_FILES.evaluationReport),
+        'CORE_RUN_ARTIFACT_DOCUMENT_MISSING',
+      ),
+    });
+    assertManifestMatchesArtifacts(manifest, artifacts);
+    if (verifyContentClosure) {
+      await assertContentClosure(artifacts, options.contentResolver);
+    }
+    return deepFreezeCanonicalJson({ manifest, ...artifacts });
+  }
+
+  async function get(runId: string): Promise<StoredCoreRunArtifacts | undefined> {
+    const directory = runDirectoryPath(rootDir, runId);
+    if (!await pathExists(directory)) return undefined;
+    return loadDirectory(directory, runId);
+  }
+
+  async function save(
+    request: Readonly<SaveCoreRunArtifactsRequest>,
+  ): Promise<StoredCoreRunArtifacts> {
+    return mutations.run(request.runId, async () => {
+      let artifacts: ParsedCoreRunArtifacts;
+      try {
+        artifacts = parseArtifactSet(request);
+        parseWireDocument(
+          CoreRunArtifactManifestSchema.shape.runId,
+          request.runId,
+        );
+        parseWireDocument(
+          CoreRunArtifactManifestSchema.shape.createdAt,
+          request.createdAt,
+        );
+      } catch (error: unknown) {
+        if (error instanceof CoreRunArtifactStoreError) throw error;
+        fail(
+          'CORE_RUN_ARTIFACT_INPUT_INVALID',
+          'Core run artifact save request is invalid.',
+        );
+      }
+      await assertContentClosure(artifacts, options.contentResolver);
+      const existing = await get(request.runId);
+      if (existing !== undefined) {
+        if (canonicalizeJson(documents(existing)) === canonicalizeJson(documents(artifacts))) {
+          return existing;
+        }
+        fail(
+          'CORE_RUN_ARTIFACT_RUN_ID_CONFLICT',
+          'Core run id already identifies a different artifact set.',
+        );
+      }
+
+      await ensurePrivateDirectory(rootDir);
+      const staging = join(
+        rootDir,
+        `.${runDirectoryName(request.runId)}.${process.pid}.${randomUUID()}.tmp`,
+      );
+      await mkdir(staging, { mode: 0o700 });
+      try {
+        await Promise.all([
+          writePrivateJson(join(staging, CORE_RUN_DOCUMENT_FILES.runPlan), artifacts.plan),
+          writePrivateJson(
+            join(staging, CORE_RUN_DOCUMENT_FILES.executionBundle),
+            artifacts.execution,
+          ),
+          writePrivateJson(
+            join(staging, CORE_RUN_DOCUMENT_FILES.evaluationBundle),
+            artifacts.evaluation,
+          ),
+          writePrivateJson(
+            join(staging, CORE_RUN_DOCUMENT_FILES.analysisBundle),
+            artifacts.analysis,
+          ),
+          writePrivateJson(
+            join(staging, CORE_RUN_DOCUMENT_FILES.evaluationReport),
+            artifacts.report,
+          ),
+        ]);
+        const manifest = materializeCoreRunArtifactManifest({
+          schemaVersion: CORE_RUN_ARTIFACT_MANIFEST_SCHEMA_VERSION,
+          manifestKind: 'evaluation-core-run-artifacts',
+          runId: request.runId,
+          reportId: artifacts.report.reportId,
+          runContractDigest: artifacts.plan.digests.runContractDigest,
+          createdAt: request.createdAt,
+          status: artifacts.report.status,
+          replayability: {
+            execution: artifacts.execution.replayability,
+            evaluation: artifacts.evaluation.replayability,
+          },
+          maximumCapturedClassification: maximumCapturedClassification(artifacts),
+          documents: documents(artifacts),
+        });
+        await writePrivateJson(
+          join(staging, CORE_RUN_DOCUMENT_FILES.manifest),
+          manifest,
+        );
+        const outcome = await publishPrivateDirectoryExclusive(
+          staging,
+          runDirectoryPath(rootDir, request.runId),
+        );
+        if (outcome === 'exists') {
+          const concurrent = await get(request.runId);
+          if (concurrent !== undefined
+              && canonicalizeJson(documents(concurrent))
+                === canonicalizeJson(documents(artifacts))) return concurrent;
+          fail(
+            'CORE_RUN_ARTIFACT_RUN_ID_CONFLICT',
+            'Core run id was concurrently published with different artifacts.',
+          );
+        }
+      } finally {
+        await rm(staging, { recursive: true, force: true });
+      }
+      const stored = await get(request.runId);
+      if (stored === undefined) {
+        fail(
+          'CORE_RUN_ARTIFACT_DOCUMENT_MISSING',
+          'Published Core run artifacts cannot be reloaded.',
+        );
+      }
+      return stored;
+    });
+  }
+
+  async function list(): Promise<CoreRunArtifactIndexCard[]> {
+    if (!await pathExists(rootDir)) return [];
+    const entries = (await readdir(rootDir, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory() && /^run-[0-9a-f]{64}$/.test(entry.name))
+      .map((entry) => entry.name)
+      .sort();
+    const artifacts = await Promise.all(entries.map((entry) => (
+      loadDirectory(join(rootDir, entry), undefined, false)
+    )));
+    return artifacts
+      .map(({ manifest }) => projectCoreRunArtifactIndexCard(manifest))
+      .sort((left, right) => (
+        right.createdAt.localeCompare(left.createdAt)
+        || left.runId.localeCompare(right.runId)
+      ));
+  }
+
+  async function exists(runId: string): Promise<boolean> {
+    const directory = runDirectoryPath(rootDir, runId);
+    if (!await pathExists(directory)) return false;
+    await loadDirectory(directory, runId, false);
+    return true;
+  }
+
+  return Object.freeze({ save, get, list, exists });
+}

--- a/src/eval-workflows/artifact-store/private-json-file.ts
+++ b/src/eval-workflows/artifact-store/private-json-file.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'node:crypto';
+import {
+  chmod,
+  link,
+  mkdir,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+export async function ensurePrivateDirectory(path: string): Promise<void> {
+  await mkdir(path, { recursive: true, mode: 0o700 });
+  await chmod(path, 0o700);
+}
+
+export async function writePrivateJson(path: string, value: unknown): Promise<void> {
+  await ensurePrivateDirectory(dirname(path));
+  await writeFile(path, JSON.stringify(value, null, 2), {
+    encoding: 'utf8',
+    flag: 'wx',
+    mode: 0o600,
+  });
+}
+
+export async function publishPrivateJsonExclusive(
+  path: string,
+  value: unknown,
+): Promise<'published' | 'exists'> {
+  await ensurePrivateDirectory(dirname(path));
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, JSON.stringify(value, null, 2), {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+    try {
+      await link(temporary, path);
+      return 'published';
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') return 'exists';
+      throw error;
+    }
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+export async function publishPrivateDirectoryExclusive(
+  stagingPath: string,
+  finalPath: string,
+): Promise<'published' | 'exists'> {
+  try {
+    await rename(stagingPath, finalPath);
+    return 'published';
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST' || code === 'ENOTEMPTY') return 'exists';
+    throw error;
+  }
+}

--- a/test/eval-workflows/artifact-store.test.ts
+++ b/test/eval-workflows/artifact-store.test.ts
@@ -1,0 +1,380 @@
+import assert from 'node:assert/strict';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'vitest';
+import {
+  digestArtifactPayload,
+  digestCanonicalJson,
+  type EvaluationBundle,
+  type EvaluationReport,
+  type RunPlan,
+} from '../../src/evaluation-core/contracts/index.js';
+import type { SealedRunPlan } from '../../src/evaluation-core/compiler/index.js';
+import {
+  CORE_RUN_ARTIFACT_MANIFEST_SCHEMA_VERSION,
+  CORE_RUN_DOCUMENT_FILES,
+  CoreRunArtifactStoreError,
+  NodeCoreContentStoreError,
+  createNodeCoreContentStore,
+  createNodeCoreRunArtifactStore,
+} from '../../src/eval-workflows/artifact-store/index.js';
+import {
+  InMemoryConformanceArtifactStore,
+  runConformanceScenario,
+  type ConformanceResult,
+  type ConformanceTarget,
+} from '../evaluation-core/conformance/harness.js';
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'omk-core-artifacts-'));
+  temporaryDirectories.push(path);
+  return path;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => (
+    rm(path, { recursive: true, force: true })
+  )));
+});
+
+function saveRequest(result: ConformanceResult, runId: string) {
+  return {
+    runId,
+    createdAt: '2026-08-31T12:00:00.000Z',
+    plan: result.plan,
+    execution: result.execution,
+    evaluation: result.evaluation,
+    analysis: result.analysis,
+    report: result.report,
+  };
+}
+
+async function publishedRunDirectory(root: string): Promise<string> {
+  const entry = (await readdir(root)).find((name) => /^run-[0-9a-f]{64}$/.test(name));
+  if (entry === undefined) throw new Error('missing published run directory');
+  return join(root, entry);
+}
+
+function expectStoreError(code: CoreRunArtifactStoreError['code']) {
+  return (error: unknown): boolean => (
+    error instanceof CoreRunArtifactStoreError && error.code === code
+  );
+}
+
+function expectContentStoreError(code: NodeCoreContentStoreError['code']) {
+  return (error: unknown): boolean => (
+    error instanceof NodeCoreContentStoreError && error.code === code
+  );
+}
+
+describe('Node Core run artifact store', () => {
+  it.each(['function', 'rag', 'agent'] as const)(
+    'round-trips an exact %s Plan, Bundle chain, Report, manifest, and index card',
+    async (target: ConformanceTarget) => {
+      const root = await temporaryDirectory();
+      const runId = `artifact-round-trip-${target}`;
+      const result = await runConformanceScenario(target, { runId });
+      const store = createNodeCoreRunArtifactStore(root);
+
+      const stored = await store.save(saveRequest(result, runId));
+      assert.deepEqual(stored.plan, result.plan);
+      assert.deepEqual(stored.execution, result.execution);
+      assert.deepEqual(stored.evaluation, result.evaluation);
+      assert.deepEqual(stored.analysis, result.analysis);
+      assert.deepEqual(stored.report, result.report);
+      assert.equal(
+        stored.manifest.schemaVersion,
+        CORE_RUN_ARTIFACT_MANIFEST_SCHEMA_VERSION,
+      );
+      assert.deepEqual(
+        stored.manifest.documents.map((document) => document.documentKind),
+        [
+          'run-plan',
+          'execution-bundle',
+          'evaluation-bundle',
+          'analysis-bundle',
+          'evaluation-report',
+        ],
+      );
+      assert.deepEqual(await store.get(runId), stored);
+      assert.equal(await store.exists(runId), true);
+      assert.deepEqual(await store.list(), [{
+        runId,
+        reportId: result.report.reportId,
+        runContractDigest: result.plan.digests.runContractDigest,
+        reportDigest: result.report.reportDigest,
+        createdAt: '2026-08-31T12:00:00.000Z',
+        status: result.report.status,
+        replayability: {
+          execution: result.execution.replayability,
+          evaluation: result.evaluation.replayability,
+        },
+        maximumCapturedClassification: target === 'agent' ? 'sensitive' : 'public',
+      }]);
+      const runDirectory = await publishedRunDirectory(root);
+      assert.equal((await stat(runDirectory)).mode & 0o077, 0);
+      for (const fileName of Object.values(CORE_RUN_DOCUMENT_FILES)) {
+        assert.equal((await stat(join(runDirectory, fileName))).mode & 0o077, 0);
+      }
+    },
+  );
+
+  it('is idempotent for the same run identity and rejects a different artifact set', async () => {
+    const root = await temporaryDirectory();
+    const store = createNodeCoreRunArtifactStore(root);
+    const first = await runConformanceScenario('function', {
+      runId: 'shared-run',
+      suffix: 'first',
+    });
+    const second = await runConformanceScenario('rag', {
+      runId: 'shared-run',
+      suffix: 'second',
+    });
+    const request = saveRequest(first, 'shared-run');
+    const stored = await store.save(request);
+    assert.deepEqual(await store.save(request), stored);
+    await assert.rejects(
+      store.save(saveRequest(second, 'shared-run')),
+      expectStoreError('CORE_RUN_ARTIFACT_RUN_ID_CONFLICT'),
+    );
+    assert.deepEqual(await store.get('shared-run'), stored);
+  });
+
+  it('publishes one complete winner under concurrent conflicting writers', async () => {
+    const root = await temporaryDirectory();
+    const store = createNodeCoreRunArtifactStore(root);
+    const [first, second] = await Promise.all([
+      runConformanceScenario('function', { runId: 'concurrent-run', suffix: 'first' }),
+      runConformanceScenario('agent', { runId: 'concurrent-run', suffix: 'second' }),
+    ]);
+    const outcomes = await Promise.allSettled([
+      store.save(saveRequest(first, 'concurrent-run')),
+      store.save(saveRequest(second, 'concurrent-run')),
+    ]);
+    assert.equal(outcomes.filter((outcome) => outcome.status === 'fulfilled').length, 1);
+    const rejection = outcomes.find((outcome) => outcome.status === 'rejected');
+    assert.ok(rejection?.status === 'rejected');
+    assert.ok(expectStoreError('CORE_RUN_ARTIFACT_RUN_ID_CONFLICT')(rejection.reason));
+    const loaded = await store.get('concurrent-run');
+    assert.ok(loaded);
+    assert.ok([
+      first.report.reportDigest,
+      second.report.reportDigest,
+    ].includes(loaded.report.reportDigest));
+  });
+
+  it('ignores unpublished staging directories but fails explicitly on a corrupt published run', async () => {
+    const root = await temporaryDirectory();
+    await mkdir(join(root, '.run-interrupted.tmp'), { recursive: true });
+    await writeFile(
+      join(root, '.run-interrupted.tmp', CORE_RUN_DOCUMENT_FILES.runPlan),
+      '{}',
+    );
+    const store = createNodeCoreRunArtifactStore(root);
+    assert.deepEqual(await store.list(), []);
+
+    const result = await runConformanceScenario('function', { runId: 'corrupt-run' });
+    await store.save(saveRequest(result, 'corrupt-run'));
+    const directory = await publishedRunDirectory(root);
+    await writeFile(join(directory, CORE_RUN_DOCUMENT_FILES.manifest), '{}');
+    await assert.rejects(
+      store.list(),
+      expectStoreError('CORE_RUN_ARTIFACT_MANIFEST_INVALID'),
+    );
+  });
+
+  it('detects a valid document whose digest differs from the published manifest', async () => {
+    const root = await temporaryDirectory();
+    const result = await runConformanceScenario('function', { runId: 'tampered-run' });
+    const store = createNodeCoreRunArtifactStore(root);
+    await store.save(saveRequest(result, 'tampered-run'));
+    const directory = await publishedRunDirectory(root);
+    const report = structuredClone(result.report) as EvaluationReport;
+    report.annotations = { tampered: true };
+    report.reportDigest = digestArtifactPayload(report, 'reportDigest');
+    await writeFile(
+      join(directory, CORE_RUN_DOCUMENT_FILES.evaluationReport),
+      JSON.stringify(report),
+    );
+    await assert.rejects(
+      store.get('tampered-run'),
+      expectStoreError('CORE_RUN_ARTIFACT_DOCUMENT_DIGEST_MISMATCH'),
+    );
+  });
+
+  it('rejects a recomputed Bundle that breaks the authenticated parent chain', async () => {
+    const root = await temporaryDirectory();
+    const result = await runConformanceScenario('function', { runId: 'chain-run' });
+    const evaluation = structuredClone(result.evaluation) as EvaluationBundle;
+    evaluation.executionBundleDigest = digestCanonicalJson({ wrong: 'parent' });
+    evaluation.bundleDigest = digestArtifactPayload(evaluation, 'bundleDigest');
+    const store = createNodeCoreRunArtifactStore(root);
+    await assert.rejects(
+      store.save({
+        ...saveRequest(result, 'chain-run'),
+        evaluation,
+      }),
+      expectStoreError('CORE_RUN_ARTIFACT_SOURCE_CHAIN_INVALID'),
+    );
+    assert.equal(await store.exists('chain-run'), false);
+  });
+
+  it('rejects a RunPlan whose declared digest no longer matches its design', async () => {
+    const root = await temporaryDirectory();
+    const result = await runConformanceScenario('function', { runId: 'plan-run' });
+    const plan = structuredClone(result.plan) as unknown as RunPlan;
+    plan.digests.runContractDigest = digestCanonicalJson({ wrong: 'contract' });
+    const store = createNodeCoreRunArtifactStore(root);
+    await assert.rejects(
+      store.save({
+        ...saveRequest(result, 'plan-run'),
+        plan: plan as unknown as SealedRunPlan,
+      }),
+      expectStoreError('CORE_RUN_ARTIFACT_PLAN_INVALID'),
+    );
+  });
+
+  it('rejects stage payload tampering even when every declared Plan digest is unchanged', async () => {
+    const root = await temporaryDirectory();
+    const result = await runConformanceScenario('function', { runId: 'stage-plan-run' });
+    const plan = structuredClone(result.plan) as unknown as RunPlan;
+    plan.execution.samples[0].input = { tampered: true };
+    const store = createNodeCoreRunArtifactStore(root);
+    await assert.rejects(
+      store.save({
+        ...saveRequest(result, 'stage-plan-run'),
+        plan: plan as unknown as SealedRunPlan,
+      }),
+      expectStoreError('CORE_RUN_ARTIFACT_PLAN_INVALID'),
+    );
+  });
+
+  it('requires every descriptor to resolve before publishing a resolvable run', async () => {
+    const root = await temporaryDirectory();
+    const artifactStore = new InMemoryConformanceArtifactStore();
+    const result = await runConformanceScenario('function', {
+      runId: 'resolvable-run',
+      artifactStore,
+      mutate(_definition, policy) {
+        policy.evidence.output = 'reference';
+      },
+    });
+    const withoutResolver = createNodeCoreRunArtifactStore(root);
+    await assert.rejects(
+      withoutResolver.save(saveRequest(result, 'resolvable-run')),
+      expectStoreError('CORE_RUN_ARTIFACT_CONTENT_RESOLVER_REQUIRED'),
+    );
+    const withResolver = createNodeCoreRunArtifactStore(root, {
+      contentResolver: artifactStore,
+    });
+    const stored = await withResolver.save(saveRequest(result, 'resolvable-run'));
+    assert.equal(stored.execution.replayability, 'resolvable');
+    const indexOnly = createNodeCoreRunArtifactStore(root);
+    assert.equal((await indexOnly.list()).length, 1);
+    assert.equal(await indexOnly.exists('resolvable-run'), true);
+    await assert.rejects(
+      indexOnly.get('resolvable-run'),
+      expectStoreError('CORE_RUN_ARTIFACT_CONTENT_RESOLVER_REQUIRED'),
+    );
+  });
+});
+
+describe('Node Core content store', () => {
+  it('content-addresses values without conflating classification and enforces private modes', async () => {
+    const root = await temporaryDirectory();
+    const store = createNodeCoreContentStore(root);
+    const value = { answer: 42 };
+    const digest = digestCanonicalJson(value);
+    const publicDescriptor = await store.put({
+      value,
+      digest,
+      mediaType: 'application/json',
+      classification: 'public',
+    });
+    const goldDescriptor = await store.put({
+      value,
+      digest,
+      mediaType: 'application/json',
+      classification: 'gold',
+    });
+    assert.notEqual(publicDescriptor.uri, goldDescriptor.uri);
+    assert.deepEqual(await store.resolve(publicDescriptor), {
+      value,
+      classification: 'public',
+      mediaType: 'application/json',
+    });
+    assert.deepEqual(await store.resolve(goldDescriptor), {
+      value,
+      classification: 'gold',
+      mediaType: 'application/json',
+    });
+    const contentDirectory = join(root, 'content');
+    assert.equal((await stat(contentDirectory)).mode & 0o077, 0);
+    for (const file of await readdir(contentDirectory)) {
+      assert.equal((await stat(join(contentDirectory, file))).mode & 0o077, 0);
+    }
+  });
+
+  it('rejects mismatched input digests and corrupted stored content', async () => {
+    const root = await temporaryDirectory();
+    const store = createNodeCoreContentStore(root);
+    await assert.rejects(store.put({
+      value: { answer: 42 },
+      digest: digestCanonicalJson({ answer: 41 }),
+      mediaType: 'application/json',
+      classification: 'public',
+    }), /digest does not match/);
+
+    const descriptor = await store.put({
+      value: { answer: 42 },
+      digest: digestCanonicalJson({ answer: 42 }),
+      mediaType: 'application/json',
+      classification: 'sensitive',
+    });
+    const contentDirectory = join(root, 'content');
+    const file = (await readdir(contentDirectory))[0];
+    const document = JSON.parse(await readFile(join(contentDirectory, file), 'utf8'));
+    document.value = { answer: 99 };
+    await chmod(join(contentDirectory, file), 0o600);
+    await writeFile(join(contentDirectory, file), JSON.stringify(document));
+    await assert.rejects(
+      store.resolve(descriptor),
+      expectContentStoreError('CORE_CONTENT_DOCUMENT_INVALID'),
+    );
+  });
+
+  it('distinguishes unavailable content from a malformed content document', async () => {
+    const root = await temporaryDirectory();
+    const store = createNodeCoreContentStore(root);
+    const descriptor = await store.put({
+      value: { answer: 42 },
+      digest: digestCanonicalJson({ answer: 42 }),
+      mediaType: 'application/json',
+      classification: 'public',
+    });
+    const contentDirectory = join(root, 'content');
+    const file = (await readdir(contentDirectory))[0];
+    await writeFile(join(contentDirectory, file), '{');
+    await assert.rejects(
+      store.resolve(descriptor),
+      expectContentStoreError('CORE_CONTENT_DOCUMENT_INVALID'),
+    );
+    await rm(join(contentDirectory, file));
+    await assert.rejects(
+      store.resolve(descriptor),
+      expectContentStoreError('CORE_CONTENT_UNAVAILABLE'),
+    );
+  });
+});


### PR DESCRIPTION
## 目标

为 Evaluation Core 建立独立于旧 Report store 的持久化边界，让一次 run 的 sealed Plan、Bundle 链与 Report 能作为不可变整体发布、校验和索引，为后续 resume、batch 与 downstream 投影提供统一事实来源。

## 用户影响

- 新增版本化 Core run manifest、私有原子文件存储与 content-addressed content store。
- 完整读取会校验 Plan 内部摘要、Bundle／Report 父链、manifest 文档摘要和外置证据闭包；索引查询不依赖 content resolver。
- run ID 不进入文件路径，Plan 与 captured content 使用 owner-only 权限，错误不暴露原始内容路径。
- 中英文架构契约明确传输完整性与来源可信度的边界。

## 迁移说明

本 PR 不切换 `omk eval`，不读取或双写旧报告，也不提供兼容层；现有用户行为不变。后续 resume 必须重新 prepare 当前 Definition／MeasurementPolicy，并通过 Core 的 plan-aware verifier 后才能复用持久化 Bundle，磁盘 JSON 不会被重新授予 `SealedRunPlan` capability。

## 测量学说明

本切片不修改评分 prompt、统计公式或五层评分语义。它固定持久化的测量契约与证据 lineage，避免 resume 依赖环境重编译或未经验证的摘要，从而保护跨运行可比性。

## 验证

本地 `yarn ci` 通过：332 个测试文件、4022 个测试。

Part of #531
Parent: #450