### PR TITLE
feat(eval-workflows): 建立 Core resume 与 batch 边界

### DIFF
--- a/docs/specs/evaluation-artifact-persistence.md
+++ b/docs/specs/evaluation-artifact-persistence.md
@@ -1,6 +1,6 @@
 # Evaluation Core artifact persistence
 
-> Status: host persistence contract for [#531](https://github.com/lizhiyao/oh-my-knowledge/issues/531), slice 1. It does not switch `omk eval`, read legacy reports, or make transported JSON a trusted Core capability.
+> Status: host persistence and reuse contract for [#531](https://github.com/lizhiyao/oh-my-knowledge/issues/531), slices 1–2. It does not switch `omk eval`, read legacy reports, or make transported JSON a trusted Core capability.
 
 ## 1. Boundary
 
@@ -47,11 +47,29 @@ The Node content store implements the existing Execution and Evaluation content 
 
 Resolution revalidates envelope digest, descriptor, canonical value digest, media type, byte size, and classification. Failures use stable, redacted codes; raw filesystem paths and content do not become Core errors.
 
-## 6. Non-goals
+## 6. Resume admission
+
+Resume is complete-fact reuse, not record copying or cross-process checkpoint continuation. The host first prepares the current Definition and MeasurementPolicy to obtain a fresh `SealedRunPlan`. The admission adapter rejects a transported Plan that merely has the same JSON shape, then loads the located run and invokes the Core Execution, Evaluation, Analysis, Decision, and Report verifiers in order.
+
+Only a completed run with complete evidence can be reused. A missing, corrupt, partial, contract-mismatched, under-trusted, cache-indeterminate, or budget-indeterminate source produces a stable reason code. The caller must explicitly choose `fail-closed` or `start-fresh`, a minimum source trust, and whether cache receipts and budget accounting must be verified. Rejection never copies successful rows, creates a new trial, or changes the old lineage.
+
+Verification contexts are independent host evidence. A caller must never construct provenance attestations or cache receipts from Bundle claims. The admission digest records only artifact identities, normalized Core verification facts, and the explicit policy; it excludes raw Dataset, Gold, outputs, traces, and receipt material.
+
+## 7. Project and global overlay
+
+An overlay writes only to its primary store and reads primary before fallback layers. Its index card includes a rebuildable artifact-set digest over the five document references. The same `runId` may appear in multiple layers only when this digest is identical; otherwise `get`, `list`, and `exists` fail explicitly. Writes never shadow an existing fallback ID, including an identical one, so project and global stores cannot silently select different facts.
+
+## 8. Batch child runs
+
+`omk.core-batch-manifest/v1` is a host index, not a Core Report. Each ordered item contains a qualified `batchItemKind`, stable `itemId`, independent child `runId` locator, artifact-set and Report identities, status, and maximum captured-content classification. The child keeps its own Plan, Bundles, Report, provenance, and statistical unit.
+
+Publication resolves and fully verifies every child before atomically publishing the private batch manifest. A missing, corrupt, duplicate, or identity-changed child fails. Full batch reads revalidate child locators; batch listing validates only the manifest and therefore does not claim child evidence availability. Interrupted staging directories remain invisible.
+
+## 9. Non-goals
 
 - legacy `EvaluationReport` readers, migration, or dual writes;
-- resume admission or cache reuse;
-- batch, evolve, gold compare, artifact graph, or Studio projections;
+- partial-record resume or a cross-process checkpoint engine;
+- evolve, gold compare, artifact graph, or Studio projections;
 - the production CLI cutover and old pipeline deletion;
 - artifact signatures or provenance attestation.
 

--- a/docs/zh/specs/evaluation-artifact-persistence.md
+++ b/docs/zh/specs/evaluation-artifact-persistence.md
@@ -1,6 +1,6 @@
 # Evaluation Core 产物持久化
 
-> 状态：[#531](https://github.com/lizhiyao/oh-my-knowledge/issues/531) 第一个切片的宿主持久化契约。本阶段不切换 `omk eval`、不读取旧报告，也不会把传输来的 JSON 伪装成可信 Core capability。
+> 状态：[#531](https://github.com/lizhiyao/oh-my-knowledge/issues/531) 第一、二个切片的宿主持久化与复用契约。本阶段不切换 `omk eval`、不读取旧报告，也不会把传输来的 JSON 伪装成可信 Core capability。
 
 ## 一、边界
 
@@ -47,11 +47,29 @@ Node content store 实现现有 Execution／Evaluation content port。写入前�
 
 解析时重新校验 envelope digest、descriptor、canonical value digest、media type、byte size 与 classification。失败只返回稳定且脱敏的错误码；原始文件路径和内容不会进入 Core error。
 
-## 六、非目标
+## 六、Resume admission
+
+resume 是完整事实复用，不是复制结果行或跨进程续接 checkpoint。宿主先根据当前 Definition 与 MeasurementPolicy prepare，获得新的 `SealedRunPlan`。admission adapter 会拒绝只有相同 JSON 结构的 transported Plan，再按 Execution、Evaluation、Analysis、Decision、Report 的顺序调用 Core verifier。
+
+只有已完成且 evidence 完整的 run 可以复用。source 缺失、损坏、partial、contract 不匹配、信任不足，以及 cache receipt 或预算核算不确定时，都产生稳定原因码。调用方必须显式选择 `fail-closed` 或 `start-fresh`、最低 source trust，以及是否要求 cache receipt 与预算核算为 verified。拒绝不会复制成功结果行、创建新 trial 或改写旧 lineage。
+
+verification context 必须来自独立宿主证据，绝不能根据 Bundle claim 自行构造 provenance attestation 或 cache receipt。admission digest 只记录产物 identity、Core 规范化 verification fact 与显式 policy，不包含原始 Dataset、Gold、output、trace 或 receipt material。
+
+## 七、项目／全局 Overlay
+
+overlay 只写 primary store，读取时 primary 优先于 fallback layer。索引卡片增加根据五份文档引用重建的 artifact-set digest。同一 `runId` 仅可在多个 layer 中指向相同 digest；否则 `get`、`list` 与 `exists` 均显式失败。写入不会遮蔽 fallback 已有 ID，即使两边事实相同也不写，因此项目／全局 store 不会静默选择不同事实。
+
+## 八、Batch child run
+
+`omk.core-batch-manifest/v1` 是宿主索引，不是 Core Report。每个有序 item 只保存限定字段 `batchItemKind`、稳定 `itemId`、独立 child `runId` locator、artifact-set／Report identity、状态和最高 captured-content classification。child 继续拥有自己的 Plan、Bundle、Report、provenance 与统计单位。
+
+发布前必须解析并完整校验全部 child，随后原子发布私有 batch manifest。child 缺失、损坏、重复或 identity 变化都会失败。完整 batch 读取会重新校验 child locator；batch 列表只校验 manifest，因此不声称 child evidence 可用。中断留下的 staging 目录不可见。
+
+## 九、非目标
 
 - 旧 `EvaluationReport` reader、迁移或双写；
-- resume admission 或 cache 复用；
-- batch、evolve、gold compare、artifact graph 或 Studio projection；
+- partial record resume 或跨进程 checkpoint engine；
+- evolve、gold compare、artifact graph 或 Studio projection；
 - 正式 CLI 切换与旧 pipeline 删除；
 - artifact 签名或 provenance attestation。
 

--- a/src/eval-workflows/artifact-store/batch-contracts.ts
+++ b/src/eval-workflows/artifact-store/batch-contracts.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+import {
+  EvaluationStatusSchema,
+  IdentifierSchema,
+  Sha256DigestSchema,
+  TimestampSchema,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  parseWireDocument,
+} from '../../evaluation-core/contracts/index.js';
+
+export const CORE_BATCH_MANIFEST_SCHEMA_VERSION =
+  'omk.core-batch-manifest/v1' as const;
+
+export const CORE_BATCH_MANIFEST_FILE = 'manifest.json' as const;
+
+export const CoreBatchChildReferenceSchema = z.object({
+  batchItemKind: z.literal('core-run'),
+  itemId: IdentifierSchema,
+  ordinal: z.number().int().nonnegative(),
+  locator: z.object({
+    locatorKind: z.literal('core-run'),
+    runId: IdentifierSchema,
+  }).strict(),
+  reportId: IdentifierSchema,
+  runContractDigest: Sha256DigestSchema,
+  reportDigest: Sha256DigestSchema,
+  artifactSetDigest: Sha256DigestSchema,
+  status: EvaluationStatusSchema,
+  maximumCapturedClassification: z.enum([
+    'public',
+    'sensitive',
+    'secret',
+    'gold',
+  ]),
+}).strict();
+
+export const CoreBatchManifestSchema = z.object({
+  schemaVersion: z.literal(CORE_BATCH_MANIFEST_SCHEMA_VERSION),
+  batchManifestKind: z.literal('evaluation-core-child-runs'),
+  batchId: IdentifierSchema,
+  createdAt: TimestampSchema,
+  children: z.array(CoreBatchChildReferenceSchema).min(1),
+  batchManifestDigest: Sha256DigestSchema,
+}).strict();
+
+export type CoreBatchChildReference = z.infer<typeof CoreBatchChildReferenceSchema>;
+export type CoreBatchManifest = z.infer<typeof CoreBatchManifestSchema>;
+
+export const SaveCoreBatchRequestSchema = z.object({
+  batchId: IdentifierSchema,
+  createdAt: TimestampSchema,
+  children: z.array(z.object({
+    itemId: IdentifierSchema,
+    runId: IdentifierSchema,
+  }).strict()).min(1),
+}).strict();
+
+type ParsedSaveCoreBatchRequest = z.infer<typeof SaveCoreBatchRequestSchema>;
+export type SaveCoreBatchRequest = Readonly<
+  Omit<ParsedSaveCoreBatchRequest, 'children'> & {
+    readonly children: readonly Readonly<ParsedSaveCoreBatchRequest['children'][number]>[];
+  }
+>;
+
+export interface CoreBatchIndexCard {
+  readonly batchId: string;
+  readonly createdAt: string;
+  readonly childCount: number;
+  readonly batchManifestDigest: string;
+}
+
+export interface StoredCoreBatch {
+  readonly manifest: CoreBatchManifest;
+}
+
+export interface CoreBatchArtifactStore {
+  save(request: Readonly<SaveCoreBatchRequest>): Promise<StoredCoreBatch>;
+  get(batchId: string): Promise<StoredCoreBatch | undefined>;
+  list(): Promise<CoreBatchIndexCard[]>;
+  exists(batchId: string): Promise<boolean>;
+}
+
+function assertCanonicalChildren(children: readonly CoreBatchChildReference[]): void {
+  if (children.some((child, ordinal) => child.ordinal !== ordinal)
+      || new Set(children.map((child) => child.itemId)).size !== children.length
+      || new Set(children.map((child) => child.locator.runId)).size !== children.length) {
+    throw new TypeError(
+      'Core batch children require canonical ordinals and unique item and run identities.',
+    );
+  }
+}
+
+export function parseCoreBatchManifestDocument(value: unknown): CoreBatchManifest {
+  const manifest = parseWireDocument(CoreBatchManifestSchema, value);
+  assertCanonicalChildren(manifest.children);
+  const { batchManifestDigest, ...payload } = manifest;
+  if (digestCanonicalJson(payload) !== batchManifestDigest) {
+    throw new TypeError('Core batch manifest digest does not match its payload.');
+  }
+  return deepFreezeCanonicalJson(manifest);
+}
+
+export function materializeCoreBatchManifest(
+  input: Omit<CoreBatchManifest, 'batchManifestDigest'>,
+): CoreBatchManifest {
+  return parseCoreBatchManifestDocument({
+    ...input,
+    batchManifestDigest: digestCanonicalJson(input),
+  });
+}
+
+export function projectCoreBatchIndexCard(
+  manifest: CoreBatchManifest,
+): CoreBatchIndexCard {
+  return deepFreezeCanonicalJson({
+    batchId: manifest.batchId,
+    createdAt: manifest.createdAt,
+    childCount: manifest.children.length,
+    batchManifestDigest: manifest.batchManifestDigest,
+  });
+}

--- a/src/eval-workflows/artifact-store/contracts.ts
+++ b/src/eval-workflows/artifact-store/contracts.ts
@@ -128,6 +128,7 @@ export interface CoreRunArtifactIndexCard {
   readonly reportId: string;
   readonly runContractDigest: string;
   readonly reportDigest: string;
+  readonly artifactSetDigest: string;
   readonly createdAt: string;
   readonly status: EvaluationReport['status'];
   readonly replayability: CoreRunArtifactManifest['replayability'];
@@ -143,6 +144,7 @@ export interface SaveCoreRunArtifactsRequest extends CoreRunArtifactSet {
 export interface CoreRunArtifactStore {
   save(request: Readonly<SaveCoreRunArtifactsRequest>): Promise<StoredCoreRunArtifacts>;
   get(runId: string): Promise<StoredCoreRunArtifacts | undefined>;
+  inspect(runId: string): Promise<CoreRunArtifactIndexCard | undefined>;
   list(): Promise<CoreRunArtifactIndexCard[]>;
   exists(runId: string): Promise<boolean>;
 }
@@ -194,6 +196,7 @@ export function projectCoreRunArtifactIndexCard(
     reportId: manifest.reportId,
     runContractDigest: manifest.runContractDigest,
     reportDigest: report.identityDigest,
+    artifactSetDigest: digestCanonicalJson(manifest.documents),
     createdAt: manifest.createdAt,
     status: manifest.status,
     replayability: manifest.replayability,

--- a/src/eval-workflows/artifact-store/index.ts
+++ b/src/eval-workflows/artifact-store/index.ts
@@ -1,3 +1,6 @@
+export * from './batch-contracts.js';
 export * from './contracts.js';
+export * from './node-batch-store.js';
 export * from './node-content-store.js';
 export * from './node-run-store.js';
+export * from './overlay-store.js';

--- a/src/eval-workflows/artifact-store/node-batch-store.ts
+++ b/src/eval-workflows/artifact-store/node-batch-store.ts
@@ -1,0 +1,262 @@
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  access,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+} from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import {
+  canonicalizeJson,
+  digestCanonicalJson,
+} from '../../evaluation-core/contracts/index.js';
+import { KeyedMutex } from '../../shared/keyed-mutex.js';
+import {
+  CORE_BATCH_MANIFEST_FILE,
+  CORE_BATCH_MANIFEST_SCHEMA_VERSION,
+  materializeCoreBatchManifest,
+  parseCoreBatchManifestDocument,
+  projectCoreBatchIndexCard,
+  SaveCoreBatchRequestSchema,
+  type CoreBatchArtifactStore,
+  type CoreBatchChildReference,
+  type CoreBatchIndexCard,
+  type CoreBatchManifest,
+  type SaveCoreBatchRequest,
+  type StoredCoreBatch,
+} from './batch-contracts.js';
+import type { CoreRunArtifactStore } from './contracts.js';
+import {
+  ensurePrivateDirectory,
+  publishPrivateDirectoryExclusive,
+  writePrivateJson,
+} from './private-json-file.js';
+
+export type CoreBatchArtifactStoreErrorCode =
+  | 'CORE_BATCH_INPUT_INVALID'
+  | 'CORE_BATCH_CHILD_NOT_FOUND'
+  | 'CORE_BATCH_CHILD_INVALID'
+  | 'CORE_BATCH_MANIFEST_MISSING'
+  | 'CORE_BATCH_MANIFEST_INVALID'
+  | 'CORE_BATCH_ID_CONFLICT';
+
+export class CoreBatchArtifactStoreError extends TypeError {
+  readonly code: CoreBatchArtifactStoreErrorCode;
+
+  constructor(code: CoreBatchArtifactStoreErrorCode, message: string) {
+    super(message);
+    this.name = 'CoreBatchArtifactStoreError';
+    this.code = code;
+  }
+}
+
+function fail(code: CoreBatchArtifactStoreErrorCode, message: string): never {
+  throw new CoreBatchArtifactStoreError(code, message);
+}
+
+function batchDirectoryName(batchId: string): string {
+  return `batch-${createHash('sha256').update(batchId).digest('hex')}`;
+}
+
+function batchDirectoryPath(rootDir: string, batchId: string): string {
+  return join(rootDir, batchDirectoryName(batchId));
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+async function readManifest(directory: string): Promise<CoreBatchManifest> {
+  let encoded: string;
+  try {
+    encoded = await readFile(join(directory, CORE_BATCH_MANIFEST_FILE), 'utf8');
+  } catch {
+    fail('CORE_BATCH_MANIFEST_MISSING', 'Core batch manifest is missing or unreadable.');
+  }
+  try {
+    return parseCoreBatchManifestDocument(JSON.parse(encoded) as unknown);
+  } catch (error: unknown) {
+    if (error instanceof CoreBatchArtifactStoreError) throw error;
+    fail('CORE_BATCH_MANIFEST_INVALID', 'Core batch manifest is invalid.');
+  }
+}
+
+async function resolveChildren(
+  runStore: CoreRunArtifactStore,
+  request: SaveCoreBatchRequest,
+): Promise<CoreBatchChildReference[]> {
+  if (request.children.length === 0
+      || new Set(request.children.map(({ itemId }) => itemId)).size
+        !== request.children.length
+      || new Set(request.children.map(({ runId }) => runId)).size
+        !== request.children.length) {
+    fail(
+      'CORE_BATCH_INPUT_INVALID',
+      'Core batch requires unique item and child run identities.',
+    );
+  }
+  return Promise.all(request.children.map(async (child, ordinal) => {
+    let artifacts;
+    try {
+      artifacts = await runStore.get(child.runId);
+    } catch {
+      fail('CORE_BATCH_CHILD_INVALID', 'Core batch child run cannot be verified.');
+    }
+    if (artifacts === undefined) {
+      fail('CORE_BATCH_CHILD_NOT_FOUND', 'Core batch child run was not found.');
+    }
+    const card = {
+      batchItemKind: 'core-run' as const,
+      itemId: child.itemId,
+      ordinal,
+      locator: { locatorKind: 'core-run' as const, runId: child.runId },
+      reportId: artifacts.manifest.reportId,
+      runContractDigest: artifacts.manifest.runContractDigest,
+      reportDigest: artifacts.report.reportDigest,
+      artifactSetDigest: digestCanonicalJson(artifacts.manifest.documents),
+      status: artifacts.manifest.status,
+      maximumCapturedClassification: artifacts.manifest.maximumCapturedClassification,
+    };
+    return card;
+  }));
+}
+
+function assertChildrenMatch(
+  manifest: CoreBatchManifest,
+  children: readonly CoreBatchChildReference[],
+): void {
+  if (canonicalizeJson(manifest.children) !== canonicalizeJson(children)) {
+    fail(
+      'CORE_BATCH_CHILD_INVALID',
+      'Core batch child locator no longer resolves to the recorded artifact set.',
+    );
+  }
+}
+
+export function createNodeCoreBatchArtifactStore(
+  rootDir: string,
+  runStore: CoreRunArtifactStore,
+): CoreBatchArtifactStore {
+  const mutations = new KeyedMutex();
+
+  async function loadDirectory(
+    directory: string,
+    expectedBatchId?: string,
+    verifyChildren = true,
+  ): Promise<StoredCoreBatch> {
+    const manifest = await readManifest(directory);
+    if ((expectedBatchId !== undefined && manifest.batchId !== expectedBatchId)
+        || batchDirectoryName(manifest.batchId) !== basename(directory)) {
+      fail(
+        'CORE_BATCH_MANIFEST_INVALID',
+        'Core batch manifest identity differs from its locator.',
+      );
+    }
+    if (verifyChildren) {
+      const children = await resolveChildren(runStore, {
+        batchId: manifest.batchId,
+        createdAt: manifest.createdAt,
+        children: manifest.children.map(({ itemId, locator }) => ({
+          itemId,
+          runId: locator.runId,
+        })),
+      });
+      assertChildrenMatch(manifest, children);
+    }
+    return Object.freeze({ manifest });
+  }
+
+  async function get(batchId: string): Promise<StoredCoreBatch | undefined> {
+    const directory = batchDirectoryPath(rootDir, batchId);
+    if (!await pathExists(directory)) return undefined;
+    return loadDirectory(directory, batchId);
+  }
+
+  async function save(request: Readonly<SaveCoreBatchRequest>): Promise<StoredCoreBatch> {
+    const parsed = SaveCoreBatchRequestSchema.safeParse(request);
+    if (!parsed.success) {
+      fail('CORE_BATCH_INPUT_INVALID', 'Core batch save request is invalid.');
+    }
+    const parsedRequest = parsed.data;
+    return mutations.run(parsedRequest.batchId, async () => {
+      const children = await resolveChildren(runStore, parsedRequest);
+      const existing = await get(parsedRequest.batchId);
+      if (existing !== undefined) {
+        if (canonicalizeJson(existing.manifest.children) === canonicalizeJson(children)) {
+          return existing;
+        }
+        fail('CORE_BATCH_ID_CONFLICT', 'Core batch id identifies different child runs.');
+      }
+      const manifest = materializeCoreBatchManifest({
+        schemaVersion: CORE_BATCH_MANIFEST_SCHEMA_VERSION,
+        batchManifestKind: 'evaluation-core-child-runs',
+        batchId: parsedRequest.batchId,
+        createdAt: parsedRequest.createdAt,
+        children,
+      });
+      await ensurePrivateDirectory(rootDir);
+      const staging = join(
+        rootDir,
+        `.${batchDirectoryName(parsedRequest.batchId)}.${process.pid}.${randomUUID()}.tmp`,
+      );
+      await mkdir(staging, { mode: 0o700 });
+      try {
+        await writePrivateJson(join(staging, CORE_BATCH_MANIFEST_FILE), manifest);
+        const outcome = await publishPrivateDirectoryExclusive(
+          staging,
+          batchDirectoryPath(rootDir, parsedRequest.batchId),
+        );
+        if (outcome === 'exists') {
+          const concurrent = await get(parsedRequest.batchId);
+          if (concurrent !== undefined
+              && canonicalizeJson(concurrent.manifest.children)
+                === canonicalizeJson(children)) return concurrent;
+          fail(
+            'CORE_BATCH_ID_CONFLICT',
+            'Core batch id was concurrently published with different child runs.',
+          );
+        }
+      } finally {
+        await rm(staging, { recursive: true, force: true });
+      }
+      const stored = await get(parsedRequest.batchId);
+      if (stored === undefined) {
+        fail('CORE_BATCH_MANIFEST_MISSING', 'Published Core batch cannot be reloaded.');
+      }
+      return stored;
+    });
+  }
+
+  async function list(): Promise<CoreBatchIndexCard[]> {
+    if (!await pathExists(rootDir)) return [];
+    const entries = (await readdir(rootDir, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory() && /^batch-[0-9a-f]{64}$/.test(entry.name))
+      .map((entry) => entry.name)
+      .sort();
+    const batches = await Promise.all(entries.map((entry) => (
+      loadDirectory(join(rootDir, entry), undefined, false)
+    )));
+    return batches
+      .map(({ manifest }) => projectCoreBatchIndexCard(manifest))
+      .sort((left, right) => (
+        right.createdAt.localeCompare(left.createdAt)
+        || left.batchId.localeCompare(right.batchId)
+      ));
+  }
+
+  async function exists(batchId: string): Promise<boolean> {
+    const directory = batchDirectoryPath(rootDir, batchId);
+    if (!await pathExists(directory)) return false;
+    await loadDirectory(directory, batchId, false);
+    return true;
+  }
+
+  return Object.freeze({ save, get, list, exists });
+}

--- a/src/eval-workflows/artifact-store/node-run-store.ts
+++ b/src/eval-workflows/artifact-store/node-run-store.ts
@@ -706,12 +706,16 @@ export function createNodeCoreRunArtifactStore(
       ));
   }
 
-  async function exists(runId: string): Promise<boolean> {
+  async function inspect(runId: string): Promise<CoreRunArtifactIndexCard | undefined> {
     const directory = runDirectoryPath(rootDir, runId);
-    if (!await pathExists(directory)) return false;
-    await loadDirectory(directory, runId, false);
-    return true;
+    if (!await pathExists(directory)) return undefined;
+    const { manifest } = await loadDirectory(directory, runId, false);
+    return projectCoreRunArtifactIndexCard(manifest);
   }
 
-  return Object.freeze({ save, get, list, exists });
+  async function exists(runId: string): Promise<boolean> {
+    return (await inspect(runId)) !== undefined;
+  }
+
+  return Object.freeze({ save, get, inspect, list, exists });
 }

--- a/src/eval-workflows/artifact-store/overlay-store.ts
+++ b/src/eval-workflows/artifact-store/overlay-store.ts
@@ -1,0 +1,148 @@
+import type {
+  CoreRunArtifactIndexCard,
+  CoreRunArtifactStore,
+  SaveCoreRunArtifactsRequest,
+  StoredCoreRunArtifacts,
+} from './contracts.js';
+
+export type CoreRunArtifactOverlayErrorCode =
+  | 'CORE_RUN_ARTIFACT_OVERLAY_ID_CONFLICT'
+  | 'CORE_RUN_ARTIFACT_OVERLAY_SHADOW_CONFLICT';
+
+export class CoreRunArtifactOverlayError extends TypeError {
+  readonly code: CoreRunArtifactOverlayErrorCode;
+  readonly runId: string;
+
+  constructor(input: {
+    code: CoreRunArtifactOverlayErrorCode;
+    runId: string;
+    message: string;
+  }) {
+    super(input.message);
+    this.name = 'CoreRunArtifactOverlayError';
+    this.code = input.code;
+    this.runId = input.runId;
+  }
+}
+
+interface LocatedCard {
+  readonly store: CoreRunArtifactStore;
+  readonly card: CoreRunArtifactIndexCard;
+}
+
+function assertNoConflict(runId: string, located: readonly LocatedCard[]): void {
+  const digests = new Set(located.map(({ card }) => card.artifactSetDigest));
+  if (digests.size > 1) {
+    throw new CoreRunArtifactOverlayError({
+      code: 'CORE_RUN_ARTIFACT_OVERLAY_ID_CONFLICT',
+      runId,
+      message: 'Core run id resolves to different artifact sets across store layers.',
+    });
+  }
+}
+
+export function createOverlayCoreRunArtifactStore(
+  primary: CoreRunArtifactStore,
+  fallbacks: readonly CoreRunArtifactStore[],
+): CoreRunArtifactStore {
+  const stores = Object.freeze([primary, ...fallbacks]);
+
+  async function locatedCards(runId?: string): Promise<LocatedCard[]> {
+    if (runId !== undefined) {
+      const located = await Promise.all(stores.map(async (store) => ({
+        store,
+        card: await store.inspect(runId),
+      })));
+      return located.filter((entry): entry is LocatedCard => entry.card !== undefined);
+    }
+    const cardsByStore = await Promise.all(stores.map(async (store) => ({
+      store,
+      cards: await store.list(),
+    })));
+    return cardsByStore.flatMap(({ store, cards }) => cards
+      .filter((card) => runId === undefined || card.runId === runId)
+      .map((card) => ({ store, card })));
+  }
+
+  async function get(runId: string): Promise<StoredCoreRunArtifacts | undefined> {
+    const located = await locatedCards(runId);
+    if (located.length === 0) return undefined;
+    assertNoConflict(runId, located);
+    return located[0].store.get(runId);
+  }
+
+  async function list(): Promise<CoreRunArtifactIndexCard[]> {
+    const located = await locatedCards();
+    const byRunId = new Map<string, LocatedCard[]>();
+    for (const entry of located) {
+      const current = byRunId.get(entry.card.runId) ?? [];
+      current.push(entry);
+      byRunId.set(entry.card.runId, current);
+    }
+    const cards: CoreRunArtifactIndexCard[] = [];
+    for (const [runId, entries] of byRunId) {
+      assertNoConflict(runId, entries);
+      cards.push(entries[0].card);
+    }
+    return cards.sort((left, right) => (
+      right.createdAt.localeCompare(left.createdAt)
+      || left.runId.localeCompare(right.runId)
+    ));
+  }
+
+  async function inspect(runId: string): Promise<CoreRunArtifactIndexCard | undefined> {
+    const located = await locatedCards(runId);
+    if (located.length === 0) return undefined;
+    assertNoConflict(runId, located);
+    return located[0].card;
+  }
+
+  async function exists(runId: string): Promise<boolean> {
+    const located = await locatedCards(runId);
+    if (located.length === 0) return false;
+    assertNoConflict(runId, located);
+    return true;
+  }
+
+  async function save(
+    request: Readonly<SaveCoreRunArtifactsRequest>,
+  ): Promise<StoredCoreRunArtifacts> {
+    const fallbackEntries = (await Promise.all(fallbacks.map(async (store) => ({
+      store,
+      card: await store.inspect(request.runId),
+    })))).filter((entry) => entry.card !== undefined);
+    if (fallbackEntries.length > 0) {
+      throw new CoreRunArtifactOverlayError({
+        code: 'CORE_RUN_ARTIFACT_OVERLAY_SHADOW_CONFLICT',
+        runId: request.runId,
+        message: 'Core run id already exists in a read-only fallback store layer.',
+      });
+    }
+    const stored = await primary.save(request);
+    const concurrentFallback = (await locatedCards(request.runId)).filter(
+      ({ store }) => store !== primary,
+    );
+    if (concurrentFallback.length > 0) {
+      const primaryCard = await primary.inspect(request.runId);
+      if (primaryCard === undefined) {
+        throw new CoreRunArtifactOverlayError({
+          code: 'CORE_RUN_ARTIFACT_OVERLAY_SHADOW_CONFLICT',
+          runId: request.runId,
+          message: 'Published primary run index is unavailable during overlay verification.',
+        });
+      }
+      assertNoConflict(request.runId, [
+        { store: primary, card: primaryCard },
+        ...concurrentFallback,
+      ]);
+      throw new CoreRunArtifactOverlayError({
+        code: 'CORE_RUN_ARTIFACT_OVERLAY_SHADOW_CONFLICT',
+        runId: request.runId,
+        message: 'Core run id was concurrently published in a fallback store layer.',
+      });
+    }
+    return stored;
+  }
+
+  return Object.freeze({ save, get, inspect, list, exists });
+}

--- a/src/eval-workflows/resume-admission/admit.ts
+++ b/src/eval-workflows/resume-admission/admit.ts
@@ -1,0 +1,346 @@
+import {
+  EvaluationReportValidationError,
+  digestCanonicalJson,
+  effectiveAnalysisBundleTrust,
+  effectiveDecisionResultTrust,
+  effectiveEvaluationBundleTrust,
+  effectiveExecutionBundleTrust,
+  parseEvaluationReport,
+  parseWireDocument,
+  verifyAnalysisBundle,
+  verifyDecisionResult,
+  verifyEvaluationBundle,
+  verifyExecutionBundle,
+  type CoreSchemaValidator,
+  type Provenance,
+} from '../../evaluation-core/contracts/index.js';
+import { assertSealedRunPlan } from '../../evaluation-core/compiler/index.js';
+import {
+  CoreRunArtifactStoreError,
+  type CoreRunArtifactStore,
+} from '../artifact-store/index.js';
+import {
+  CoreResumeAdmissionError,
+  CoreResumeAdmissionPolicySchema,
+  CoreResumeLocatorSchema,
+  type AdmittedCoreResumeSource,
+  type CoreResumeAdmissionAdapter,
+  type CoreResumeAdmissionPolicy,
+  type CoreResumeAdmissionRequest,
+  type CoreResumeAdmissionResult,
+  type CoreResumeRejectionReasonCode,
+  type RejectedCoreResumeSource,
+} from './contracts.js';
+
+const TRUST_RANK: Record<Provenance['trust'], number> = {
+  untrusted: 0,
+  unknown: 1,
+  declared: 2,
+  verified: 3,
+};
+
+export interface CreateCoreResumeAdmissionAdapterOptions {
+  readonly artifactStore: CoreRunArtifactStore;
+  readonly schemaValidators: ReadonlyMap<string, CoreSchemaValidator>;
+}
+
+function minimumTrust(values: readonly Provenance['trust'][]): Provenance['trust'] {
+  return values.reduce((minimum, value) => (
+    TRUST_RANK[value] < TRUST_RANK[minimum] ? value : minimum
+  ), 'verified');
+}
+
+function rejected(
+  sourceRunId: string,
+  reasonCode: CoreResumeRejectionReasonCode,
+): RejectedCoreResumeSource {
+  return Object.freeze({ disposition: 'start-fresh', sourceRunId, reasonCode });
+}
+
+function reject(
+  sourceRunId: string,
+  policy: CoreResumeAdmissionPolicy,
+  reasonCode: CoreResumeRejectionReasonCode,
+  message: string,
+): RejectedCoreResumeSource {
+  if (policy.rejectionMode === 'fail-closed') {
+    throw new CoreResumeAdmissionError({
+      code: reasonCode,
+      sourceRunId,
+      message,
+    });
+  }
+  return rejected(sourceRunId, reasonCode);
+}
+
+function isComplete(input: {
+  executionBundleStatus: string;
+  evaluationBundleStatus: string;
+  analysisBundleStatus: string;
+  reportStatus: {
+    runStatus: string;
+    evidenceStatus: string;
+  };
+}): boolean {
+  return input.executionBundleStatus === 'completed'
+    && input.evaluationBundleStatus === 'completed'
+    && input.analysisBundleStatus === 'completed'
+    && input.reportStatus.runStatus === 'completed'
+    && input.reportStatus.evidenceStatus === 'complete';
+}
+
+function admissionDigest(input: Omit<AdmittedCoreResumeSource, 'disposition'
+  | 'admissionDigest' | 'artifacts' | 'executionSource' | 'evaluationSource'
+  | 'analysisSource' | 'decisionSource' | 'report'> & {
+    readonly artifacts: AdmittedCoreResumeSource['artifacts'];
+    readonly policy: CoreResumeAdmissionPolicy;
+  }): string {
+  return digestCanonicalJson({
+    derivation: 'omk.core-resume-admission/v1',
+    sourceRunId: input.sourceRunId,
+    runContractDigest: input.artifacts.plan.digests.runContractDigest,
+    executionBundleDigest: input.artifacts.execution.bundleDigest,
+    evaluationBundleDigest: input.artifacts.evaluation.bundleDigest,
+    analysisBundleDigest: input.artifacts.analysis.bundleDigest,
+    reportDigest: input.artifacts.report.reportDigest,
+    verification: input.verification,
+    policy: input.policy,
+  });
+}
+
+export function createCoreResumeAdmissionAdapter(
+  options: Readonly<CreateCoreResumeAdmissionAdapterOptions>,
+): CoreResumeAdmissionAdapter {
+  async function admit(
+    request: Readonly<CoreResumeAdmissionRequest>,
+  ): Promise<CoreResumeAdmissionResult> {
+    const sourceRunId = typeof request?.locator?.runId === 'string'
+      ? request.locator.runId
+      : 'invalid-resume-source';
+    const parsedPolicy = CoreResumeAdmissionPolicySchema.safeParse(request?.policy);
+    if (!parsedPolicy.success) {
+      throw new CoreResumeAdmissionError({
+        code: 'CORE_RESUME_REQUEST_INVALID',
+        sourceRunId,
+        message: 'Core resume admission policy is invalid.',
+      });
+    }
+    const policy = parsedPolicy.data;
+    try {
+      parseWireDocument(CoreResumeLocatorSchema, request.locator);
+      assertSealedRunPlan(request.plan);
+    } catch {
+      return reject(
+        sourceRunId,
+        policy,
+        'CORE_RESUME_REQUEST_INVALID',
+        'Core resume locator or sealed Plan capability is invalid.',
+      );
+    }
+
+    let artifacts;
+    try {
+      artifacts = await options.artifactStore.get(sourceRunId);
+    } catch (error: unknown) {
+      if (error instanceof CoreRunArtifactStoreError
+          && (error.code === 'CORE_RUN_ARTIFACT_CONTENT_RESOLVER_REQUIRED'
+            || error.code === 'CORE_RUN_ARTIFACT_CONTENT_INVALID')) {
+        return reject(
+          sourceRunId,
+          policy,
+          'CORE_RESUME_EVIDENCE_UNAVAILABLE',
+          'Core resume source evidence is unavailable or invalid.',
+        );
+      }
+      return reject(
+        sourceRunId,
+        policy,
+        'CORE_RESUME_SOURCE_INVALID',
+        'Core resume source cannot be loaded and verified.',
+      );
+    }
+    if (artifacts === undefined) {
+      return reject(
+        sourceRunId,
+        policy,
+        'CORE_RESUME_SOURCE_NOT_FOUND',
+        'Core resume source was not found.',
+      );
+    }
+    if (artifacts.plan.digests.runContractDigest
+        !== request.plan.digests.runContractDigest) {
+      return reject(
+        sourceRunId,
+        policy,
+        'CORE_RESUME_CONTRACT_MISMATCH',
+        'Core resume source does not match the freshly sealed RunContract.',
+      );
+    }
+    if (!isComplete({
+      executionBundleStatus: artifacts.execution.executionBundleStatus,
+      evaluationBundleStatus: artifacts.evaluation.evaluationBundleStatus,
+      analysisBundleStatus: artifacts.analysis.analysisBundleStatus,
+      reportStatus: artifacts.report.status,
+    })) {
+      return reject(
+        sourceRunId,
+        policy,
+        'CORE_RESUME_SOURCE_INCOMPLETE',
+        'Core resume requires a completed run with complete evidence.',
+      );
+    }
+
+    let executionSource;
+    let evaluationSource;
+    let analysisSource;
+    try {
+      executionSource = verifyExecutionBundle(
+        artifacts.execution,
+        request.plan,
+        request.verification?.execution,
+      );
+      evaluationSource = verifyEvaluationBundle(
+        artifacts.evaluation,
+        request.plan,
+        executionSource,
+        request.verification?.evaluation,
+      );
+      analysisSource = verifyAnalysisBundle(
+        artifacts.analysis,
+        request.plan,
+        executionSource,
+        evaluationSource,
+        { schemaValidators: options.schemaValidators },
+        request.verification?.analysis,
+      );
+    } catch {
+      return reject(
+        sourceRunId,
+        policy,
+        'CORE_RESUME_SOURCE_INVALID',
+        'Core resume source failed plan-aware verification.',
+      );
+    }
+
+    if (policy.cacheReceiptMode === 'require-verified'
+        && (executionSource.planVerification.cacheReceiptStatus !== 'verified'
+          || evaluationSource.planVerification.cacheReceiptStatus !== 'verified')) {
+      return reject(
+        sourceRunId,
+        policy,
+        'CORE_RESUME_CACHE_RECEIPT_INDETERMINATE',
+        'Core resume source contains cache lineage without verified receipts.',
+      );
+    }
+    if (policy.budgetVerificationMode === 'require-verified'
+        && (executionSource.planVerification.invocationBudgetStatus !== 'verified'
+          || executionSource.planVerification.providerCostBudgetStatus !== 'verified'
+          || evaluationSource.planVerification.invocationBudgetStatus !== 'verified'
+          || evaluationSource.planVerification.providerCostBudgetStatus !== 'verified')) {
+      return reject(
+        sourceRunId,
+        policy,
+        'CORE_RESUME_BUDGET_INDETERMINATE',
+        'Core resume source has indeterminate invocation or provider-cost accounting.',
+      );
+    }
+
+    const upstreamSourceTrust = minimumTrust([
+      effectiveExecutionBundleTrust(executionSource),
+      effectiveEvaluationBundleTrust(evaluationSource),
+      effectiveAnalysisBundleTrust(analysisSource),
+      artifacts.report.provenance.trust,
+    ]);
+    if (TRUST_RANK[upstreamSourceTrust]
+        < TRUST_RANK[policy.minimumSourceTrust]) {
+      return reject(
+        sourceRunId,
+        policy,
+        'CORE_RESUME_PROVENANCE_BELOW_POLICY',
+        'Core resume source provenance is below the explicit admission policy.',
+      );
+    }
+
+    let decisionSource;
+    let report;
+    try {
+      decisionSource = artifacts.report.decision === undefined
+        ? undefined
+        : verifyDecisionResult(
+          artifacts.report.decision,
+          request.plan,
+          executionSource,
+          evaluationSource,
+          analysisSource,
+          request.verification?.decision,
+        );
+      report = parseEvaluationReport(
+        artifacts.report,
+        request.plan,
+        executionSource,
+        evaluationSource,
+        analysisSource,
+        decisionSource,
+      );
+    } catch (error: unknown) {
+      if (error instanceof EvaluationReportValidationError
+          && error.code === 'DECISION_RESULT_VERIFICATION_GATE_FAILED') {
+        return reject(
+          sourceRunId,
+          policy,
+          'CORE_RESUME_VERIFICATION_INDETERMINATE',
+          'Core resume Decision requires verification facts not established by the host.',
+        );
+      }
+      return reject(
+        sourceRunId,
+        policy,
+        'CORE_RESUME_SOURCE_INVALID',
+        'Core resume Decision or Report failed plan-aware verification.',
+      );
+    }
+    const effectiveSourceTrust = minimumTrust([
+      upstreamSourceTrust,
+      ...(decisionSource === undefined ? [] : [effectiveDecisionResultTrust(decisionSource)]),
+    ]);
+    if (TRUST_RANK[effectiveSourceTrust]
+        < TRUST_RANK[policy.minimumSourceTrust]) {
+      return reject(
+        sourceRunId,
+        policy,
+        'CORE_RESUME_PROVENANCE_BELOW_POLICY',
+        'Core resume Decision provenance is below the explicit admission policy.',
+      );
+    }
+
+    const verification = Object.freeze({
+      execution: executionSource.planVerification,
+      evaluation: evaluationSource.planVerification,
+      analysis: analysisSource.planVerification,
+      ...(decisionSource === undefined
+        ? {}
+        : { decision: decisionSource.planVerification }),
+      effectiveSourceTrust,
+    });
+    const digest = admissionDigest({
+      sourceRunId,
+      artifacts,
+      verification,
+      policy,
+    });
+    return Object.freeze({
+      disposition: 'reuse' as const,
+      sourceRunId,
+      admissionDigest: digest,
+      artifacts,
+      executionSource,
+      evaluationSource,
+      analysisSource,
+      ...(decisionSource === undefined ? {} : { decisionSource }),
+      report,
+      verification,
+    });
+  }
+
+  return Object.freeze({ admit });
+}

--- a/src/eval-workflows/resume-admission/contracts.ts
+++ b/src/eval-workflows/resume-admission/contracts.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod';
+import { IdentifierSchema } from '../../evaluation-core/contracts/index.js';
+import type {
+  AnalysisBundleVerificationContext,
+  AnalysisBundleSource,
+  DecisionResultSource,
+  DecisionResultVerificationContext,
+  EvaluationBundleSource,
+  EvaluationBundleVerificationContext,
+  EvaluationReport,
+  ExecutionBundleSource,
+  ExecutionBundleVerificationContext,
+  Provenance,
+} from '../../evaluation-core/contracts/index.js';
+import type { SealedRunPlan } from '../../evaluation-core/compiler/index.js';
+import type { StoredCoreRunArtifacts } from '../artifact-store/index.js';
+
+export const CoreResumeAdmissionPolicySchema = z.object({
+  rejectionMode: z.enum(['fail-closed', 'start-fresh']),
+  minimumSourceTrust: z.enum(['untrusted', 'unknown', 'declared', 'verified']),
+  cacheReceiptMode: z.enum(['require-verified', 'allow-indeterminate']),
+  budgetVerificationMode: z.enum(['require-verified', 'allow-indeterminate']),
+}).strict();
+
+export const CoreResumeLocatorSchema = z.object({
+  locatorKind: z.literal('core-run'),
+  runId: IdentifierSchema,
+}).strict();
+
+export type CoreResumeAdmissionPolicy = z.infer<typeof CoreResumeAdmissionPolicySchema>;
+export type CoreResumeRejectionMode = CoreResumeAdmissionPolicy['rejectionMode'];
+export type CoreResumeLocator = z.infer<typeof CoreResumeLocatorSchema>;
+
+export interface CoreResumeAdmissionRequest {
+  readonly locator: CoreResumeLocator;
+  readonly plan: SealedRunPlan;
+  readonly policy: CoreResumeAdmissionPolicy;
+  readonly verification?: CoreResumeVerificationContexts;
+}
+
+export interface CoreResumeVerificationContexts {
+  readonly execution?: ExecutionBundleVerificationContext;
+  readonly evaluation?: EvaluationBundleVerificationContext;
+  readonly analysis?: AnalysisBundleVerificationContext;
+  readonly decision?: DecisionResultVerificationContext;
+}
+
+export type CoreResumeRejectionReasonCode =
+  | 'CORE_RESUME_REQUEST_INVALID'
+  | 'CORE_RESUME_SOURCE_NOT_FOUND'
+  | 'CORE_RESUME_SOURCE_INVALID'
+  | 'CORE_RESUME_EVIDENCE_UNAVAILABLE'
+  | 'CORE_RESUME_CONTRACT_MISMATCH'
+  | 'CORE_RESUME_SOURCE_INCOMPLETE'
+  | 'CORE_RESUME_CACHE_RECEIPT_INDETERMINATE'
+  | 'CORE_RESUME_BUDGET_INDETERMINATE'
+  | 'CORE_RESUME_VERIFICATION_INDETERMINATE'
+  | 'CORE_RESUME_PROVENANCE_BELOW_POLICY';
+
+export interface CoreResumeVerificationSummary {
+  readonly execution: ExecutionBundleSource['planVerification'];
+  readonly evaluation: EvaluationBundleSource['planVerification'];
+  readonly analysis: AnalysisBundleSource['planVerification'];
+  readonly decision?: DecisionResultSource['planVerification'];
+  readonly effectiveSourceTrust: Provenance['trust'];
+}
+
+export interface AdmittedCoreResumeSource {
+  readonly disposition: 'reuse';
+  readonly sourceRunId: string;
+  readonly admissionDigest: string;
+  readonly artifacts: StoredCoreRunArtifacts;
+  readonly executionSource: ExecutionBundleSource;
+  readonly evaluationSource: EvaluationBundleSource;
+  readonly analysisSource: AnalysisBundleSource;
+  readonly decisionSource?: DecisionResultSource;
+  readonly report: EvaluationReport;
+  readonly verification: CoreResumeVerificationSummary;
+}
+
+export interface RejectedCoreResumeSource {
+  readonly disposition: 'start-fresh';
+  readonly sourceRunId: string;
+  readonly reasonCode: CoreResumeRejectionReasonCode;
+}
+
+export type CoreResumeAdmissionResult =
+  | AdmittedCoreResumeSource
+  | RejectedCoreResumeSource;
+
+export interface CoreResumeAdmissionAdapter {
+  admit(request: Readonly<CoreResumeAdmissionRequest>): Promise<CoreResumeAdmissionResult>;
+}
+
+export class CoreResumeAdmissionError extends TypeError {
+  readonly code: CoreResumeRejectionReasonCode;
+  readonly sourceRunId: string;
+
+  constructor(input: {
+    code: CoreResumeRejectionReasonCode;
+    sourceRunId: string;
+    message: string;
+  }) {
+    super(input.message);
+    this.name = 'CoreResumeAdmissionError';
+    this.code = input.code;
+    this.sourceRunId = input.sourceRunId;
+  }
+}

--- a/src/eval-workflows/resume-admission/index.ts
+++ b/src/eval-workflows/resume-admission/index.ts
@@ -1,0 +1,2 @@
+export * from './admit.js';
+export * from './contracts.js';

--- a/src/evaluation-core/compiler/index.ts
+++ b/src/evaluation-core/compiler/index.ts
@@ -59,6 +59,7 @@ import { sealRunPlan } from '../internal/sealed-run-plan.js';
 
 export * from './errors.js';
 export * from './types.js';
+export { assertSealedRunPlan } from '../internal/sealed-run-plan.js';
 export { validateDefinitionSemantics } from './validation.js';
 
 interface StageExtensions {

--- a/test/eval-workflows/artifact-store.test.ts
+++ b/test/eval-workflows/artifact-store.test.ts
@@ -24,9 +24,12 @@ import {
   CORE_RUN_ARTIFACT_MANIFEST_SCHEMA_VERSION,
   CORE_RUN_DOCUMENT_FILES,
   CoreRunArtifactStoreError,
+  CoreRunArtifactOverlayError,
   NodeCoreContentStoreError,
+  createOverlayCoreRunArtifactStore,
   createNodeCoreContentStore,
   createNodeCoreRunArtifactStore,
+  projectCoreRunArtifactIndexCard,
 } from '../../src/eval-workflows/artifact-store/index.js';
 import {
   InMemoryConformanceArtifactStore,
@@ -109,12 +112,17 @@ describe('Node Core run artifact store', () => {
         ],
       );
       assert.deepEqual(await store.get(runId), stored);
+      assert.deepEqual(
+        await store.inspect(runId),
+        projectCoreRunArtifactIndexCard(stored.manifest),
+      );
       assert.equal(await store.exists(runId), true);
       assert.deepEqual(await store.list(), [{
         runId,
         reportId: result.report.reportId,
         runContractDigest: result.plan.digests.runContractDigest,
         reportDigest: result.report.reportDigest,
+        artifactSetDigest: digestCanonicalJson(stored.manifest.documents),
         createdAt: '2026-08-31T12:00:00.000Z',
         status: result.report.status,
         replayability: {
@@ -288,6 +296,79 @@ describe('Node Core run artifact store', () => {
       indexOnly.get('resolvable-run'),
       expectStoreError('CORE_RUN_ARTIFACT_CONTENT_RESOLVER_REQUIRED'),
     );
+  });
+});
+
+describe('Core run artifact store overlay', () => {
+  it('uses primary precedence when layers contain the exact same artifact set', async () => {
+    const primaryRoot = await temporaryDirectory();
+    const fallbackRoot = await temporaryDirectory();
+    const primary = createNodeCoreRunArtifactStore(primaryRoot);
+    const fallback = createNodeCoreRunArtifactStore(fallbackRoot);
+    const runId = 'overlay-identical';
+    const result = await runConformanceScenario('function', { runId });
+    await fallback.save({
+      ...saveRequest(result, runId),
+      createdAt: '2026-08-31T11:00:00.000Z',
+    });
+    const primaryArtifacts = await primary.save({
+      ...saveRequest(result, runId),
+      createdAt: '2026-08-31T13:00:00.000Z',
+    });
+    const overlay = createOverlayCoreRunArtifactStore(primary, [fallback]);
+
+    assert.deepEqual(await overlay.get(runId), primaryArtifacts);
+    assert.deepEqual(
+      await overlay.inspect(runId),
+      projectCoreRunArtifactIndexCard(primaryArtifacts.manifest),
+    );
+    assert.deepEqual(await overlay.list(), [
+      projectCoreRunArtifactIndexCard(primaryArtifacts.manifest),
+    ]);
+    assert.equal(await overlay.exists(runId), true);
+  });
+
+  it('fails explicitly when one run id resolves to different artifact sets', async () => {
+    const primary = createNodeCoreRunArtifactStore(await temporaryDirectory());
+    const fallback = createNodeCoreRunArtifactStore(await temporaryDirectory());
+    const runId = 'overlay-conflict';
+    const [first, second] = await Promise.all([
+      runConformanceScenario('function', { runId, suffix: 'primary' }),
+      runConformanceScenario('rag', { runId, suffix: 'fallback' }),
+    ]);
+    await primary.save(saveRequest(first, runId));
+    await fallback.save(saveRequest(second, runId));
+    const overlay = createOverlayCoreRunArtifactStore(primary, [fallback]);
+
+    for (const operation of [
+      () => overlay.get(runId),
+      () => overlay.inspect(runId),
+      () => overlay.list(),
+      () => overlay.exists(runId),
+    ]) {
+      await assert.rejects(operation, (error: unknown) => (
+        error instanceof CoreRunArtifactOverlayError
+        && error.code === 'CORE_RUN_ARTIFACT_OVERLAY_ID_CONFLICT'
+      ));
+    }
+  });
+
+  it('never shadows an existing fallback run during writes', async () => {
+    const primary = createNodeCoreRunArtifactStore(await temporaryDirectory());
+    const fallback = createNodeCoreRunArtifactStore(await temporaryDirectory());
+    const runId = 'overlay-shadow';
+    const result = await runConformanceScenario('function', { runId });
+    await fallback.save(saveRequest(result, runId));
+    const overlay = createOverlayCoreRunArtifactStore(primary, [fallback]);
+
+    await assert.rejects(
+      overlay.save(saveRequest(result, runId)),
+      (error: unknown) => (
+        error instanceof CoreRunArtifactOverlayError
+        && error.code === 'CORE_RUN_ARTIFACT_OVERLAY_SHADOW_CONFLICT'
+      ),
+    );
+    assert.equal((await primary.list()).length, 0);
   });
 });
 

--- a/test/eval-workflows/batch-artifact-store.test.ts
+++ b/test/eval-workflows/batch-artifact-store.test.ts
@@ -1,0 +1,240 @@
+import assert from 'node:assert/strict';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'vitest';
+import {
+  CORE_BATCH_MANIFEST_FILE,
+  CORE_BATCH_MANIFEST_SCHEMA_VERSION,
+  CORE_RUN_DOCUMENT_FILES,
+  CoreBatchArtifactStoreError,
+  createNodeCoreBatchArtifactStore,
+  createNodeCoreRunArtifactStore,
+} from '../../src/eval-workflows/artifact-store/index.js';
+import {
+  runConformanceScenario,
+  type ConformanceResult,
+} from '../evaluation-core/conformance/harness.js';
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(path);
+  return path;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => (
+    rm(path, { recursive: true, force: true })
+  )));
+});
+
+function saveRequest(result: ConformanceResult, runId: string) {
+  return {
+    runId,
+    createdAt: '2026-08-31T13:00:00.000Z',
+    plan: result.plan,
+    execution: result.execution,
+    evaluation: result.evaluation,
+    analysis: result.analysis,
+    report: result.report,
+  };
+}
+
+function expectBatchError(code: CoreBatchArtifactStoreError['code']) {
+  return (error: unknown): boolean => (
+    error instanceof CoreBatchArtifactStoreError && error.code === code
+  );
+}
+
+async function publishedBatchDirectory(root: string): Promise<string> {
+  const entry = (await readdir(root)).find((name) => /^batch-[0-9a-f]{64}$/.test(name));
+  if (entry === undefined) throw new Error('missing published batch directory');
+  return join(root, entry);
+}
+
+describe('Node Core batch artifact store', () => {
+  it('publishes independent child locators and a rebuildable batch index', async () => {
+    const runRoot = await temporaryDirectory('omk-core-batch-runs-');
+    const batchRoot = await temporaryDirectory('omk-core-batches-');
+    const runStore = createNodeCoreRunArtifactStore(runRoot);
+    const [functionRun, ragRun] = await Promise.all([
+      runConformanceScenario('function', { runId: 'child-function' }),
+      runConformanceScenario('rag', { runId: 'child-rag' }),
+    ]);
+    await Promise.all([
+      runStore.save(saveRequest(functionRun, 'child-function')),
+      runStore.save(saveRequest(ragRun, 'child-rag')),
+    ]);
+    const batchStore = createNodeCoreBatchArtifactStore(batchRoot, runStore);
+    const stored = await batchStore.save({
+      batchId: 'batch-one',
+      createdAt: '2026-08-31T14:00:00.000Z',
+      children: [
+        { itemId: 'function-item', runId: 'child-function' },
+        { itemId: 'rag-item', runId: 'child-rag' },
+      ],
+    });
+
+    assert.equal(stored.manifest.schemaVersion, CORE_BATCH_MANIFEST_SCHEMA_VERSION);
+    assert.deepEqual(stored.manifest.children.map((child) => ({
+      itemId: child.itemId,
+      ordinal: child.ordinal,
+      runId: child.locator.runId,
+      reportDigest: child.reportDigest,
+    })), [
+      {
+        itemId: 'function-item',
+        ordinal: 0,
+        runId: 'child-function',
+        reportDigest: functionRun.report.reportDigest,
+      },
+      {
+        itemId: 'rag-item',
+        ordinal: 1,
+        runId: 'child-rag',
+        reportDigest: ragRun.report.reportDigest,
+      },
+    ]);
+    assert.deepEqual(await batchStore.get('batch-one'), stored);
+    assert.deepEqual(await batchStore.list(), [{
+      batchId: 'batch-one',
+      createdAt: '2026-08-31T14:00:00.000Z',
+      childCount: 2,
+      batchManifestDigest: stored.manifest.batchManifestDigest,
+    }]);
+    assert.equal(await batchStore.exists('batch-one'), true);
+    const directory = await publishedBatchDirectory(batchRoot);
+    assert.equal((await stat(directory)).mode & 0o077, 0);
+    assert.equal((await stat(join(directory, CORE_BATCH_MANIFEST_FILE))).mode & 0o077, 0);
+    const raw = JSON.parse(await readFile(
+      join(directory, CORE_BATCH_MANIFEST_FILE),
+      'utf8',
+    ));
+    assert.equal(raw.kind, undefined);
+    assert.equal(raw.items, undefined);
+  });
+
+  it('accepts a cancelled child as an honest independent run summary', async () => {
+    const runRoot = await temporaryDirectory('omk-core-batch-runs-');
+    const batchRoot = await temporaryDirectory('omk-core-batches-');
+    const controller = new AbortController();
+    controller.abort('batch child cancellation');
+    const child = await runConformanceScenario('function', {
+      runId: 'cancelled-child',
+      executionSignal: controller.signal,
+    });
+    assert.equal(child.report.status.runStatus, 'cancelled');
+    const runStore = createNodeCoreRunArtifactStore(runRoot);
+    await runStore.save(saveRequest(child, 'cancelled-child'));
+    const batchStore = createNodeCoreBatchArtifactStore(batchRoot, runStore);
+    const stored = await batchStore.save({
+      batchId: 'cancelled-batch',
+      createdAt: '2026-08-31T14:00:00.000Z',
+      children: [{ itemId: 'cancelled-item', runId: 'cancelled-child' }],
+    });
+    assert.equal(stored.manifest.children[0].status.runStatus, 'cancelled');
+  });
+
+  it('is idempotent for the same children and rejects changed or duplicate identity', async () => {
+    const runStore = createNodeCoreRunArtifactStore(
+      await temporaryDirectory('omk-core-batch-runs-'),
+    );
+    const batchStore = createNodeCoreBatchArtifactStore(
+      await temporaryDirectory('omk-core-batches-'),
+      runStore,
+    );
+    const [first, second] = await Promise.all([
+      runConformanceScenario('function', { runId: 'first-child' }),
+      runConformanceScenario('rag', { runId: 'second-child' }),
+    ]);
+    await Promise.all([
+      runStore.save(saveRequest(first, 'first-child')),
+      runStore.save(saveRequest(second, 'second-child')),
+    ]);
+    const request = {
+      batchId: 'stable-batch',
+      createdAt: '2026-08-31T14:00:00.000Z',
+      children: [{ itemId: 'item', runId: 'first-child' }],
+    } as const;
+    const stored = await batchStore.save(request);
+    assert.deepEqual(await batchStore.save(request), stored);
+    await assert.rejects(batchStore.save({
+      ...request,
+      children: [{ itemId: 'item', runId: 'second-child' }],
+    }), expectBatchError('CORE_BATCH_ID_CONFLICT'));
+    await assert.rejects(batchStore.save({
+      batchId: 'duplicate-batch',
+      createdAt: request.createdAt,
+      children: [
+        { itemId: 'same', runId: 'first-child' },
+        { itemId: 'same', runId: 'second-child' },
+      ],
+    }), expectBatchError('CORE_BATCH_INPUT_INVALID'));
+  });
+
+  it('does not publish missing children and fails when a referenced child later corrupts', async () => {
+    const runRoot = await temporaryDirectory('omk-core-batch-runs-');
+    const batchRoot = await temporaryDirectory('omk-core-batches-');
+    const runStore = createNodeCoreRunArtifactStore(runRoot);
+    const batchStore = createNodeCoreBatchArtifactStore(batchRoot, runStore);
+    await assert.rejects(batchStore.save({
+      batchId: 'missing-child-batch',
+      createdAt: '2026-08-31T14:00:00.000Z',
+      children: [{ itemId: 'missing-item', runId: 'missing-child' }],
+    }), expectBatchError('CORE_BATCH_CHILD_NOT_FOUND'));
+    assert.deepEqual(await batchStore.list(), []);
+
+    const child = await runConformanceScenario('function', { runId: 'corrupt-child' });
+    await runStore.save(saveRequest(child, 'corrupt-child'));
+    await batchStore.save({
+      batchId: 'corrupt-child-batch',
+      createdAt: '2026-08-31T14:00:00.000Z',
+      children: [{ itemId: 'corrupt-item', runId: 'corrupt-child' }],
+    });
+    const runDirectory = (await readdir(runRoot)).find((name) => name.startsWith('run-'));
+    assert.ok(runDirectory);
+    await writeFile(
+      join(runRoot, runDirectory, CORE_RUN_DOCUMENT_FILES.manifest),
+      '{}',
+    );
+    await assert.rejects(
+      batchStore.get('corrupt-child-batch'),
+      expectBatchError('CORE_BATCH_CHILD_INVALID'),
+    );
+    assert.equal((await batchStore.list()).length, 1);
+  });
+
+  it('ignores interrupted staging directories and rejects a corrupt published manifest', async () => {
+    const batchRoot = await temporaryDirectory('omk-core-batches-');
+    const runStore = createNodeCoreRunArtifactStore(
+      await temporaryDirectory('omk-core-batch-runs-'),
+    );
+    await mkdir(join(batchRoot, '.batch-interrupted.tmp'));
+    const batchStore = createNodeCoreBatchArtifactStore(batchRoot, runStore);
+    assert.deepEqual(await batchStore.list(), []);
+
+    const child = await runConformanceScenario('function', { runId: 'manifest-child' });
+    await runStore.save(saveRequest(child, 'manifest-child'));
+    await batchStore.save({
+      batchId: 'manifest-batch',
+      createdAt: '2026-08-31T14:00:00.000Z',
+      children: [{ itemId: 'manifest-item', runId: 'manifest-child' }],
+    });
+    const directory = await publishedBatchDirectory(batchRoot);
+    await writeFile(join(directory, CORE_BATCH_MANIFEST_FILE), '{}');
+    await assert.rejects(
+      batchStore.list(),
+      expectBatchError('CORE_BATCH_MANIFEST_INVALID'),
+    );
+  });
+});

--- a/test/eval-workflows/resume-admission.test.ts
+++ b/test/eval-workflows/resume-admission.test.ts
@@ -1,0 +1,354 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'vitest';
+import { createBuiltinAnalysisSchemaValidators } from '../../src/evaluation-core/analysis/index.js';
+import type { SealedRunPlan } from '../../src/evaluation-core/compiler/index.js';
+import type {
+  EvaluationDefinition,
+  MeasurementPolicy,
+  Sha256Digest,
+} from '../../src/evaluation-core/contracts/index.js';
+import {
+  createNodeCoreRunArtifactStore,
+} from '../../src/eval-workflows/artifact-store/index.js';
+import {
+  CoreResumeAdmissionError,
+  createCoreResumeAdmissionAdapter,
+  type CoreResumeAdmissionPolicy,
+  type CoreResumeVerificationContexts,
+} from '../../src/eval-workflows/resume-admission/index.js';
+import {
+  InMemoryConformanceExecutionCache,
+  InMemoryConformanceArtifactStore,
+  prepareConformancePlan,
+  runConformanceScenario,
+  type ConformanceResult,
+} from '../evaluation-core/conformance/harness.js';
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'omk-core-resume-'));
+  temporaryDirectories.push(path);
+  return path;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => (
+    rm(path, { recursive: true, force: true })
+  )));
+});
+
+const strictPolicy: CoreResumeAdmissionPolicy = {
+  rejectionMode: 'fail-closed',
+  minimumSourceTrust: 'declared',
+  cacheReceiptMode: 'require-verified',
+  budgetVerificationMode: 'require-verified',
+};
+
+function trustedVerification(
+  result: ConformanceResult,
+  executionCacheRecordDigests: readonly Sha256Digest[] = [],
+): CoreResumeVerificationContexts {
+  return {
+    execution: {
+      verifiedCacheRecordDigests: new Set(executionCacheRecordDigests),
+      verifiedProvenanceBundleDigests: new Set([
+        result.execution.bundleDigest as Sha256Digest,
+      ]),
+    },
+    evaluation: {
+      verifiedProvenanceBundleDigests: new Set([
+        result.evaluation.bundleDigest as Sha256Digest,
+      ]),
+      executionSourceTrust: 'verified',
+    },
+    analysis: {
+      verifiedProvenanceBundleDigests: new Set([
+        result.analysis.bundleDigest as Sha256Digest,
+      ]),
+      evaluationSourceTrust: 'verified',
+    },
+    ...(result.decision === undefined ? {} : {
+      decision: {
+        verifiedPolicyExecutionDigests: new Set([
+          result.decision.decisionDigest as Sha256Digest,
+        ]),
+        analysisSourceTrust: 'verified' as const,
+      },
+    }),
+  };
+}
+
+function saveRequest(
+  result: ConformanceResult,
+  runId: string,
+) {
+  return {
+    runId,
+    createdAt: '2026-08-31T13:00:00.000Z',
+    plan: result.plan,
+    execution: result.execution,
+    evaluation: result.evaluation,
+    analysis: result.analysis,
+    report: result.report,
+  };
+}
+
+async function saveResult(
+  result: ConformanceResult,
+  root: string,
+  runId: string,
+) {
+  const store = createNodeCoreRunArtifactStore(root);
+  await store.save(saveRequest(result, runId));
+  return store;
+}
+
+describe('Core resume admission', () => {
+  it('re-admits a complete run against a freshly sealed Plan and trusted evidence', async () => {
+    const root = await temporaryDirectory();
+    const sourceRunId = 'resume-source';
+    const result = await runConformanceScenario('function', { runId: sourceRunId });
+    const store = await saveResult(result, root, sourceRunId);
+    const freshPlan = await prepareConformancePlan('function');
+    assert.notEqual(freshPlan, result.plan);
+    assert.equal(
+      freshPlan.digests.runContractDigest,
+      result.plan.digests.runContractDigest,
+    );
+    const adapter = createCoreResumeAdmissionAdapter({
+      artifactStore: store,
+      schemaValidators: createBuiltinAnalysisSchemaValidators(),
+    });
+
+    const admitted = await adapter.admit({
+      locator: { locatorKind: 'core-run', runId: sourceRunId },
+      plan: freshPlan,
+      policy: strictPolicy,
+      verification: trustedVerification(result),
+    });
+
+    assert.equal(admitted.disposition, 'reuse');
+    if (admitted.disposition !== 'reuse') return;
+    assert.equal(admitted.report.reportDigest, result.report.reportDigest);
+    assert.equal(admitted.verification.effectiveSourceTrust, 'declared');
+    assert.match(admitted.admissionDigest, /^sha256:[0-9a-f]{64}$/);
+    assert.deepEqual(admitted.executionSource.bundle, admitted.artifacts.execution);
+  });
+
+  it('returns a stable start-fresh reason when an explicit fallback policy rejects a source', async () => {
+    const root = await temporaryDirectory();
+    const adapter = createCoreResumeAdmissionAdapter({
+      artifactStore: createNodeCoreRunArtifactStore(root),
+      schemaValidators: createBuiltinAnalysisSchemaValidators(),
+    });
+    const result = await adapter.admit({
+      locator: { locatorKind: 'core-run', runId: 'missing-run' },
+      plan: await prepareConformancePlan('function'),
+      policy: { ...strictPolicy, rejectionMode: 'start-fresh' },
+    });
+    assert.deepEqual(result, {
+      disposition: 'start-fresh',
+      sourceRunId: 'missing-run',
+      reasonCode: 'CORE_RESUME_SOURCE_NOT_FOUND',
+    });
+  });
+
+  it('fails closed on a different freshly sealed RunContract', async () => {
+    const root = await temporaryDirectory();
+    const sourceRunId = 'contract-source';
+    const result = await runConformanceScenario('function', { runId: sourceRunId });
+    const store = await saveResult(result, root, sourceRunId);
+    const adapter = createCoreResumeAdmissionAdapter({
+      artifactStore: store,
+      schemaValidators: createBuiltinAnalysisSchemaValidators(),
+    });
+    await assert.rejects(adapter.admit({
+      locator: { locatorKind: 'core-run', runId: sourceRunId },
+      plan: await prepareConformancePlan('rag'),
+      policy: strictPolicy,
+    }), (error: unknown) => (
+      error instanceof CoreResumeAdmissionError
+      && error.code === 'CORE_RESUME_CONTRACT_MISMATCH'
+    ));
+  });
+
+  it('does not grant sealed capability to a transported RunPlan document', async () => {
+    const root = await temporaryDirectory();
+    const sourceRunId = 'transported-plan-source';
+    const result = await runConformanceScenario('function', { runId: sourceRunId });
+    const store = await saveResult(result, root, sourceRunId);
+    const adapter = createCoreResumeAdmissionAdapter({
+      artifactStore: store,
+      schemaValidators: createBuiltinAnalysisSchemaValidators(),
+    });
+    const transportedPlan = structuredClone(result.plan) as unknown as SealedRunPlan;
+    const admission = await adapter.admit({
+      locator: { locatorKind: 'core-run', runId: sourceRunId },
+      plan: transportedPlan,
+      policy: { ...strictPolicy, rejectionMode: 'start-fresh' },
+      verification: trustedVerification(result),
+    });
+    assert.deepEqual(admission, {
+      disposition: 'start-fresh',
+      sourceRunId,
+      reasonCode: 'CORE_RESUME_REQUEST_INVALID',
+    });
+  });
+
+  it('separates provenance policy rejection from indeterminate Decision verification', async () => {
+    const root = await temporaryDirectory();
+    const sourceRunId = 'unattested-source';
+    const result = await runConformanceScenario('function', { runId: sourceRunId });
+    const store = await saveResult(result, root, sourceRunId);
+    const adapter = createCoreResumeAdmissionAdapter({
+      artifactStore: store,
+      schemaValidators: createBuiltinAnalysisSchemaValidators(),
+    });
+    const provenanceRejected = await adapter.admit({
+      locator: { locatorKind: 'core-run', runId: sourceRunId },
+      plan: result.plan,
+      policy: { ...strictPolicy, rejectionMode: 'start-fresh' },
+    });
+    assert.equal(provenanceRejected.disposition, 'start-fresh');
+    if (provenanceRejected.disposition === 'start-fresh') {
+      assert.equal(
+        provenanceRejected.reasonCode,
+        'CORE_RESUME_PROVENANCE_BELOW_POLICY',
+      );
+    }
+    const verificationRejected = await adapter.admit({
+      locator: { locatorKind: 'core-run', runId: sourceRunId },
+      plan: result.plan,
+      policy: {
+        rejectionMode: 'start-fresh',
+        minimumSourceTrust: 'unknown',
+        cacheReceiptMode: 'allow-indeterminate',
+        budgetVerificationMode: 'allow-indeterminate',
+      },
+    });
+    assert.equal(verificationRejected.disposition, 'start-fresh');
+    if (verificationRejected.disposition === 'start-fresh') {
+      assert.equal(
+        verificationRejected.reasonCode,
+        'CORE_RESUME_VERIFICATION_INDETERMINATE',
+      );
+    }
+  });
+
+  it('rejects cancelled or partial Core facts instead of copying successful rows', async () => {
+    const root = await temporaryDirectory();
+    const controller = new AbortController();
+    controller.abort('test cancellation');
+    const sourceRunId = 'partial-source';
+    const result = await runConformanceScenario('function', {
+      runId: sourceRunId,
+      executionSignal: controller.signal,
+    });
+    assert.notEqual(result.report.status.runStatus, 'completed');
+    const store = await saveResult(result, root, sourceRunId);
+    const adapter = createCoreResumeAdmissionAdapter({
+      artifactStore: store,
+      schemaValidators: createBuiltinAnalysisSchemaValidators(),
+    });
+    const admission = await adapter.admit({
+      locator: { locatorKind: 'core-run', runId: sourceRunId },
+      plan: result.plan,
+      policy: { ...strictPolicy, rejectionMode: 'start-fresh' },
+    });
+    assert.equal(admission.disposition, 'start-fresh');
+    if (admission.disposition === 'start-fresh') {
+      assert.equal(admission.reasonCode, 'CORE_RESUME_SOURCE_INCOMPLETE');
+    }
+  });
+
+  it('distinguishes unavailable referenced evidence from a malformed source', async () => {
+    const root = await temporaryDirectory();
+    const sourceRunId = 'referenced-evidence-source';
+    const contentStore = new InMemoryConformanceArtifactStore();
+    const result = await runConformanceScenario('function', {
+      runId: sourceRunId,
+      artifactStore: contentStore,
+      mutate(_definition, policy) {
+        policy.evidence.output = 'reference';
+      },
+    });
+    const writableStore = createNodeCoreRunArtifactStore(root, {
+      contentResolver: contentStore,
+    });
+    await writableStore.save(saveRequest(result, sourceRunId));
+    const adapter = createCoreResumeAdmissionAdapter({
+      artifactStore: createNodeCoreRunArtifactStore(root),
+      schemaValidators: createBuiltinAnalysisSchemaValidators(),
+    });
+    const admission = await adapter.admit({
+      locator: { locatorKind: 'core-run', runId: sourceRunId },
+      plan: result.plan,
+      policy: { ...strictPolicy, rejectionMode: 'start-fresh' },
+      verification: trustedVerification(result),
+    });
+    assert.deepEqual(admission, {
+      disposition: 'start-fresh',
+      sourceRunId,
+      reasonCode: 'CORE_RESUME_EVIDENCE_UNAVAILABLE',
+    });
+  });
+
+  it('requires independent cache receipts for transported replay lineage', async () => {
+    const root = await temporaryDirectory();
+    const cache = new InMemoryConformanceExecutionCache();
+    const mutate = (_definition: EvaluationDefinition, policy: MeasurementPolicy) => {
+      policy.cache.executionMode = 'transparent-deterministic';
+    };
+    await runConformanceScenario('function', {
+      suffix: 'cache-seed',
+      executionCache: cache,
+      mutate,
+    });
+    const sourceRunId = 'cache-replay-source';
+    const replay = await runConformanceScenario('function', {
+      runId: sourceRunId,
+      suffix: 'cache-replay',
+      executionCache: cache,
+      mutate,
+    });
+    const store = await saveResult(replay, root, sourceRunId);
+    const adapter = createCoreResumeAdmissionAdapter({
+      artifactStore: store,
+      schemaValidators: createBuiltinAnalysisSchemaValidators(),
+    });
+    const withoutReceipts = await adapter.admit({
+      locator: { locatorKind: 'core-run', runId: sourceRunId },
+      plan: replay.plan,
+      policy: {
+        ...strictPolicy,
+        rejectionMode: 'start-fresh',
+        minimumSourceTrust: 'unknown',
+      },
+    });
+    assert.equal(withoutReceipts.disposition, 'start-fresh');
+    if (withoutReceipts.disposition === 'start-fresh') {
+      assert.equal(
+        withoutReceipts.reasonCode,
+        'CORE_RESUME_CACHE_RECEIPT_INDETERMINATE',
+      );
+    }
+    const sourceRecordDigests = replay.execution.records.flatMap((record) => (
+      record.executionStatus === 'completed'
+        && record.cache.cacheStatus !== 'not-used'
+        && record.cache.sourceRecordDigest !== undefined
+        ? [record.cache.sourceRecordDigest as Sha256Digest]
+        : []
+    ));
+    const admitted = await adapter.admit({
+      locator: { locatorKind: 'core-run', runId: sourceRunId },
+      plan: replay.plan,
+      policy: strictPolicy,
+      verification: trustedVerification(replay, sourceRecordDigests),
+    });
+    assert.equal(admitted.disposition, 'reuse');
+  });
+});


### PR DESCRIPTION
## 目标

在 Core run 持久化之上建立完整事实 resume、项目／全局 overlay 与 batch child-run 总览，让后续生产切换能够复用同一套权威 Plan／Bundle／Report lineage，而不回到旧结果行模型。

## 用户影响

- resume 必须使用当前 Definition／MeasurementPolicy freshly prepare 的 `SealedRunPlan`，再逐层执行 Core verifier；transported Plan 无法获得 capability。
- source 缺失、损坏、partial、contract 不匹配、evidence 不可用、cache／budget／Decision verification 不确定或 provenance 低于 policy 时，按显式 `fail-closed`／`start-fresh` 策略处理并返回稳定原因码。
- 项目／全局 overlay 对同 `runId` 的不同 artifact set 显式报错，且不会写入遮蔽 fallback 的事实。
- batch 总览只保存独立 child-run locator 与可重建摘要，不创建 Core batch report，也不改变 child 的统计单位。

## 迁移说明

本 PR 不接管 `omk eval`，不读取或双写旧 `EvaluationReport`，不复制旧 `VariantResult`，也不实现 partial-record checkpoint resume。现有生产行为不变；后续接入只需把已编译 locator 与 fresh Plan 交给本 admission adapter。

## 测量学说明

resume 是既有完整事实的重新接纳，不产生新 trial 或独立样本。cache receipt 与 provenance attestation 必须来自独立宿主证据，不能从 Bundle claim 自行构造；admission digest 不包含 Dataset、Gold、output 或 trace。batch child 始终保持独立 run identity。

## 验证

本地 `yarn ci` 通过：334 个测试文件、4038 个测试。

Part of #531
Parent: #450