### PR TITLE
feat(eval-workflows): 增加 Core 原生下游投影

### DIFF
--- a/docs/specs/evaluation-artifact-persistence.md
+++ b/docs/specs/evaluation-artifact-persistence.md
@@ -1,6 +1,6 @@
 # Evaluation Core artifact persistence
 
-> Status: host persistence and reuse contract for [#531](https://github.com/lizhiyao/oh-my-knowledge/issues/531), slices 1–2. It does not switch `omk eval`, read legacy reports, or make transported JSON a trusted Core capability.
+> Status: host persistence, reuse, and downstream projection contract for [#531](https://github.com/lizhiyao/oh-my-knowledge/issues/531), slices 1–3. It does not switch `omk eval`, read legacy reports, or make transported JSON a trusted Core capability.
 
 ## 1. Boundary
 
@@ -65,12 +65,23 @@ An overlay writes only to its primary store and reads primary before fallback la
 
 Publication resolves and fully verifies every child before atomically publishing the private batch manifest. A missing, corrupt, duplicate, or identity-changed child fails. Full batch reads revalidate child locators; batch listing validates only the manifest and therefore does not claim child evidence availability. Interrupted staging directories remain invisible.
 
-## 9. Non-goals
+## 9. Core-native downstream projections
+
+Downstream consumers read immutable Core facts through pure, side-effect-free projections. These APIs do not import the legacy Report or result-row types and are deliberately not wired into the production consumers before the final CLI cutover.
+
+The artifact graph projection consumes one validated stored run. It emits qualified Core node kinds for Run, Target, Evaluator, Metric, Execution result, Evaluation result, Analysis result, and Decision. Node status comes only from explicit stage state. Numeric observations may appear as view metrics, but no score band or display threshold becomes a verdict. Evidence references bind exact Core document hashes and JSON pointers; raw input, expected value, output, trace, evidence, and error text are omitted.
+
+Gold comparison requires the caller to select one sealed Target, Evaluator, and numeric Metric. Optional trial and measurement coordinates refine that identity, but must match the Plan. Gold and Metric scales must match exactly. A sample resolving to multiple observations fails instead of averaging across trials, ensemble members, or replicates; a scale transformation belongs in a preregistered Analysis. The projection binds a canonical Gold dataset digest and uses `null`, not non-JSON `NaN`, for undefined statistics. The existing Krippendorff alpha, weighted kappa, Pearson, and paired-unit bootstrap formulas remain unchanged.
+
+Evolution evidence consumes one exact Evaluation Series Plan → SeriesAnalysisBundle → EvaluationSeriesReport chain. Series fixes `experimentalUnit = run`; the projection preserves member status, trust, comparability, analysis standards, assumptions, coverage, and registered Decision. It never ranks member runs or infers a winner from display scores. Only a `decided` Series Decision makes the view `decision-ready`; completed analysis without a Decision remains `analysis-only`.
+
+## 10. Non-goals
 
 - legacy `EvaluationReport` readers, migration, or dual writes;
 - partial-record resume or a cross-process checkpoint engine;
-- evolve, gold compare, artifact graph, or Studio projections;
+- Studio projections;
+- wiring the Core projections into legacy evolve, gold, or artifact-graph CLI commands before cutover;
 - the production CLI cutover and old pipeline deletion;
 - artifact signatures or provenance attestation.
 
-Those consumers build on this transport boundary in later #531 slices. The final CLI switch remains a separate `BREAKING-SCHEMA` change under #450.
+These Core-native projections complete the #531 persistence consumer boundary. The final CLI switch remains a separate `BREAKING-SCHEMA` change under #450.

--- a/docs/zh/specs/evaluation-artifact-persistence.md
+++ b/docs/zh/specs/evaluation-artifact-persistence.md
@@ -1,6 +1,6 @@
 # Evaluation Core 产物持久化
 
-> 状态：[#531](https://github.com/lizhiyao/oh-my-knowledge/issues/531) 第一、二个切片的宿主持久化与复用契约。本阶段不切换 `omk eval`、不读取旧报告，也不会把传输来的 JSON 伪装成可信 Core capability。
+> 状态：[#531](https://github.com/lizhiyao/oh-my-knowledge/issues/531) 第一至第三个切片的宿主持久化、复用与下游投影契约。本阶段不切换 `omk eval`、不读取旧报告，也不会把传输来的 JSON 伪装成可信 Core capability。
 
 ## 一、边界
 
@@ -65,12 +65,23 @@ overlay 只写 primary store，读取时 primary 优先于 fallback layer。索�
 
 发布前必须解析并完整校验全部 child，随后原子发布私有 batch manifest。child 缺失、损坏、重复或 identity 变化都会失败。完整 batch 读取会重新校验 child locator；batch 列表只校验 manifest，因此不声称 child evidence 可用。中断留下的 staging 目录不可见。
 
-## 九、非目标
+## 九、Core 原生下游投影
+
+下游 consumer 通过纯函数、无副作用的 projection 读取不可变 Core 事实。这些 API 不导入旧 Report 或结果行类型；在最终 CLI 切换前，也不会接入正式 consumer。
+
+artifact graph projection 消费一组已经校验的持久化 run，输出 Run、Target、Evaluator、Metric、Execution result、Evaluation result、Analysis result 与 Decision 等限定语义节点。节点状态只来自显式 stage 状态。数值 observation 可以作为视图 metric 展示，但分数档位和展示阈值不能变成 verdict。evidence reference 绑定 Core 文档的精确 hash 与 JSON pointer；原始 input、expected、output、trace、evidence 与 error text 一律不进入图。
+
+gold comparison 要求调用方显式选择一个已封存的 Target、Evaluator 与数值 Metric。可选 trial／measurement coordinate 用于进一步限定 identity，但必须与 Plan 一致。Gold 与 Metric 的 scale 必须完全相同。同一样本匹配到多个 observation 时显式失败，不会跨 trial、ensemble member 或 replicate 暗自平均；scale 变换必须进入预注册 Analysis。projection 绑定 canonical Gold dataset digest，并用 `null` 表示未定义统计量，不把非 JSON 的 `NaN` 写入版本化输出。现有 Krippendorff alpha、加权 kappa、Pearson 与配对单位 bootstrap 公式保持不变。
+
+evolution evidence 消费同一条 Evaluation Series Plan → SeriesAnalysisBundle → EvaluationSeriesReport 精确链。Series 固定 `experimentalUnit = run`；projection 保留 member 状态、trust、comparability、analysis standard、assumption、coverage 与已注册 Decision，绝不根据展示分数给 member run 排名或猜测 winner。只有 `decided` 的 Series Decision 才会得到 `decision-ready`；只有已完成 Analysis 而没有 Decision 时仍为 `analysis-only`。
+
+## 十、非目标
 
 - 旧 `EvaluationReport` reader、迁移或双写；
 - partial record resume 或跨进程 checkpoint engine；
-- evolve、gold compare、artifact graph 或 Studio projection；
+- Studio projection；
+- 最终切换前，把 Core projection 接入旧 evolve、gold 或 artifact-graph CLI 命令；
 - 正式 CLI 切换与旧 pipeline 删除；
 - artifact 签名或 provenance attestation。
 
-这些 consumer 在 #531 的后续切片中建立于本传输边界之上。最终 CLI 切换仍是 #450 下独立的 `BREAKING-SCHEMA` 变更。
+这些 Core 原生 projection 完成 #531 的持久化 consumer 边界。最终 CLI 切换仍是 #450 下独立的 `BREAKING-SCHEMA` 变更。

--- a/src/eval-workflows/downstream-projections/artifact-graph.ts
+++ b/src/eval-workflows/downstream-projections/artifact-graph.ts
@@ -1,0 +1,519 @@
+import {
+  digestCanonicalJson,
+  type AnalysisRecord,
+  type EvaluationRecord,
+  type ExecutionRecord,
+} from '../../evaluation-core/contracts/index.js';
+import { parseArtifactGraphDocument } from '../../shared/artifact-graph.js';
+import type {
+  ArtifactGraphDocument,
+  ArtifactGraphEdge,
+  ArtifactGraphEdgeKind,
+  ArtifactGraphEvidenceRef,
+  ArtifactGraphNode,
+  ArtifactGraphNodeKind,
+  ArtifactGraphStatus,
+} from '../../types/artifact-graph.js';
+import type { StoredCoreRunArtifacts } from '../artifact-store/index.js';
+import { CoreDownstreamProjectionError } from './contracts.js';
+import { assertCoreProjectionSource } from './source.js';
+
+export interface ProjectCoreArtifactGraphInput {
+  readonly source: Readonly<StoredCoreRunArtifacts>;
+  readonly cwd: string;
+  readonly generatedAt: string;
+  readonly sourcePath?: string;
+  readonly cliVersion?: string;
+}
+
+function artifactStatus(
+  status: StoredCoreRunArtifacts['report']['status'],
+): ArtifactGraphStatus {
+  if (status.runStatus === 'failed') return 'failed';
+  if (status.runStatus !== 'completed') return 'warning';
+  return status.evidenceStatus === 'complete' && status.conclusionStatus === 'conclusive'
+    ? 'ok'
+    : 'warning';
+}
+
+function executionStatus(record: ExecutionRecord): ArtifactGraphStatus {
+  if (record.executionStatus === 'completed') return 'ok';
+  if (record.executionStatus === 'failed') return 'failed';
+  if (record.executionStatus === 'cancelled') return 'skipped';
+  return 'not_measured';
+}
+
+function evaluationStatus(record: EvaluationRecord): ArtifactGraphStatus {
+  if (record.evaluationStatus === 'completed') return 'ok';
+  if (record.evaluationStatus === 'failed') return 'failed';
+  if (record.evaluationStatus === 'cancelled') return 'skipped';
+  return 'not_measured';
+}
+
+function analysisStatus(record: AnalysisRecord): ArtifactGraphStatus {
+  if (record.analysisStatus === 'completed') return 'ok';
+  if (record.analysisStatus === 'failed') return 'failed';
+  if (record.analysisStatus === 'inconclusive') return 'warning';
+  return 'not_measured';
+}
+
+function evidence(
+  sourceId: string,
+  contentHash: string,
+  path: string,
+  value: string,
+): ArtifactGraphEvidenceRef[] {
+  return [{
+    sourceKind: 'evaluation-core-document',
+    sourceId,
+    path,
+    selector: { selectorKind: 'json-pointer', value },
+    contentHash,
+    redaction: 'redacted',
+  }];
+}
+
+function nodeId(stableKey: string): string {
+  return `node:${digestCanonicalJson({ stableKey })}`;
+}
+
+function edgeId(stableKey: string): string {
+  return `edge:${digestCanonicalJson({ stableKey })}`;
+}
+
+/**
+ * Build a privacy-safe topology view from persisted Core facts. Statuses come
+ * only from explicit stage states; numeric observations are display metrics,
+ * never verdict thresholds.
+ */
+export function projectCoreArtifactGraph(
+  input: Readonly<ProjectCoreArtifactGraphInput>,
+): ArtifactGraphDocument {
+  assertCoreProjectionSource(input.source);
+  const { plan, execution, evaluation, analysis, report, manifest } = input.source;
+  const documentHash = new Map(manifest.documents.map((document) => [
+    document.documentKind,
+    document.documentDigest,
+  ]));
+  const nodes: ArtifactGraphNode[] = [];
+  const edges: ArtifactGraphEdge[] = [];
+  const nodesByStableKey = new Map<string, string>();
+
+  const addNode = (
+    stableKey: string,
+    nodeKind: ArtifactGraphNodeKind,
+    label: string,
+    extra: Omit<Partial<ArtifactGraphNode>, 'id' | 'stableKey' | 'nodeKind' | 'label'> = {},
+  ): string => {
+    const previous = nodesByStableKey.get(stableKey);
+    if (previous !== undefined) return previous;
+    const id = nodeId(stableKey);
+    nodesByStableKey.set(stableKey, id);
+    nodes.push({
+      id,
+      stableKey,
+      nodeKind,
+      nodeRole: 'entity',
+      layer: 'measurement',
+      label,
+      ...extra,
+    });
+    return id;
+  };
+  const addEdge = (
+    stableKey: string,
+    fromNodeId: string,
+    toNodeId: string,
+    edgeKind: ArtifactGraphEdgeKind,
+    extra: Omit<Partial<ArtifactGraphEdge>, 'id' | 'fromNodeId' | 'toNodeId' | 'edgeKind'> = {},
+  ): void => {
+    edges.push({
+      id: edgeId(stableKey),
+      fromNodeId,
+      toNodeId,
+      edgeKind,
+      layer: 'measurement',
+      ...extra,
+    });
+  };
+
+  const runKey = `core:v1:run:${manifest.runId}:${report.reportDigest}`;
+  const runNode = addNode(runKey, 'evaluation_run', report.reportId, {
+    nodeRole: 'aggregate',
+    status: artifactStatus(report.status),
+    binding: {
+      bindingStrength: 'content-hash',
+      keys: {
+        runId: manifest.runId,
+        runContractDigest: plan.digests.runContractDigest,
+        reportDigest: report.reportDigest,
+      },
+    },
+    attrs: { display: { ...report.status } },
+    evidenceRefs: evidence(
+      report.reportId,
+      documentHash.get('evaluation-report')!,
+      'evaluation-report.json',
+      '',
+    ),
+  });
+
+  const targetNodes = new Map(plan.execution.targets.map((target, index) => {
+    const key = `core:v1:target:${plan.digests.executionPlanDigest}:${target.targetId}`;
+    const id = addNode(key, 'target', target.targetId, {
+      binding: { bindingStrength: 'explicit', keys: { targetId: target.targetId } },
+      attrs: {
+        display: {
+          targetKind: target.targetKind,
+          protocolId: target.protocolId,
+          executorId: target.executorId,
+        },
+      },
+      evidenceRefs: evidence(
+        plan.digests.runContractDigest,
+        documentHash.get('run-plan')!,
+        'run-plan.json',
+        `/execution/targets/${index}`,
+      ),
+    });
+    addEdge(`${runKey}:contains:${key}`, runNode, id, 'contains');
+    return [target.targetId, id] as const;
+  }));
+
+  const sampleNodes = new Map(plan.execution.samples.map((sample, index) => {
+    const key = `core:v1:sample:${plan.digests.datasetRevisionDigest}:${sample.sampleId}`;
+    const id = addNode(key, 'sample', sample.sampleId, {
+      binding: { bindingStrength: 'explicit', keys: { sampleId: sample.sampleId } },
+      evidenceRefs: evidence(
+        plan.digests.runContractDigest,
+        documentHash.get('run-plan')!,
+        'run-plan.json',
+        `/execution/samples/${index}`,
+      ),
+    });
+    addEdge(`${runKey}:contains:${key}`, runNode, id, 'contains');
+    return [sample.sampleId, id] as const;
+  }));
+
+  const evaluatorNodes = new Map(plan.evaluation.evaluators.map((evaluator, index) => {
+    const key = `core:v1:evaluator:${plan.digests.evaluationPlanDigest}:${evaluator.evaluatorId}`;
+    const id = addNode(key, 'evaluator', evaluator.evaluatorId, {
+      binding: {
+        bindingStrength: 'explicit',
+        keys: {
+          evaluatorId: evaluator.evaluatorId,
+          instrumentId: evaluator.measurement.instrumentId,
+          ensembleMemberId: evaluator.measurement.ensembleMemberId,
+          replicateGroupId: evaluator.measurement.replicateGroupId,
+          replicateIndex: String(evaluator.measurement.replicateIndex),
+        },
+      },
+      attrs: {
+        producer: {
+          evaluatorKind: evaluator.evaluatorKind,
+          implementationId: evaluator.implementationId,
+        },
+      },
+      evidenceRefs: evidence(
+        plan.digests.runContractDigest,
+        documentHash.get('run-plan')!,
+        'run-plan.json',
+        `/evaluation/evaluators/${index}`,
+      ),
+    });
+    addEdge(`${runKey}:contains:${key}`, runNode, id, 'contains');
+    return [evaluator.evaluatorId, id] as const;
+  }));
+
+  const metricNodes = new Map(plan.evaluation.metrics.map((metric, index) => {
+    const key = `core:v1:metric:${plan.digests.evaluationPlanDigest}:${metric.metricId}`;
+    const id = addNode(key, 'metric', metric.metricId, {
+      binding: { bindingStrength: 'explicit', keys: { metricId: metric.metricId } },
+      attrs: {
+        display: {
+          valueType: metric.valueType,
+          scope: metric.scope,
+          ...(metric.unit === undefined ? {} : { unit: metric.unit }),
+          ...(metric.direction === undefined ? {} : { direction: metric.direction }),
+          ...(metric.scale === undefined ? {} : { scale: metric.scale }),
+        },
+      },
+      evidenceRefs: evidence(
+        plan.digests.runContractDigest,
+        documentHash.get('run-plan')!,
+        'run-plan.json',
+        `/evaluation/metrics/${index}`,
+      ),
+    });
+    addEdge(`${runKey}:contains:${key}`, runNode, id, 'contains');
+    return [metric.metricId, id] as const;
+  }));
+
+  for (const evaluator of plan.evaluation.evaluators) {
+    const evaluatorNode = evaluatorNodes.get(evaluator.evaluatorId);
+    if (evaluatorNode === undefined) continue;
+    for (const metricId of evaluator.metricIds) {
+      const metricNode = metricNodes.get(metricId);
+      if (metricNode !== undefined) {
+        addEdge(
+          `${runKey}:evaluator:${evaluator.evaluatorId}:declares:${metricId}`,
+          evaluatorNode,
+          metricNode,
+          'declares',
+        );
+      }
+    }
+  }
+
+  const executionNodes = new Map<string, string>();
+  execution.records.forEach((record, index) => {
+    const key = `core:v1:execution-result:${execution.bundleDigest}:${record.trialId}`;
+    const id = addNode(key, 'execution_result', `${record.targetId} / ${record.sampleId}`, {
+      nodeRole: 'observation',
+      status: executionStatus(record),
+      binding: { bindingStrength: 'content-hash', keys: { trialId: record.trialId } },
+      metrics: record.executionStatus === 'budget-censored'
+        ? undefined
+        : {
+          ...(record.timing.durationMs === undefined ? {} : {
+            durationMs: record.timing.durationMs,
+          }),
+        },
+      attrs: {
+        display: {
+          executionStatus: record.executionStatus,
+          trialIndex: record.trialIndex,
+        },
+      },
+      evidenceRefs: evidence(
+        execution.bundleId,
+        documentHash.get('execution-bundle')!,
+        'execution-bundle.json',
+        `/records/${index}`,
+      ),
+    });
+    executionNodes.set(record.trialId, id);
+    addEdge(`${runKey}:contains:${key}`, runNode, id, 'contains');
+    const targetNode = targetNodes.get(record.targetId);
+    const sampleNode = sampleNodes.get(record.sampleId);
+    if (targetNode !== undefined) {
+      addEdge(`${key}:derived-from:target`, id, targetNode, 'derived_from');
+    }
+    if (sampleNode !== undefined) {
+      addEdge(`${key}:evaluates:sample`, id, sampleNode, 'evaluates');
+    }
+  });
+
+  evaluation.records.forEach((record, index) => {
+    const key = `core:v1:evaluation-result:${evaluation.bundleDigest}:${record.evaluationId}`;
+    const numericMetrics = record.evaluationStatus === 'completed'
+      ? Object.fromEntries(record.observations.flatMap((observation) => (
+        observation.observationStatus === 'observed'
+          && observation.valueType === 'numeric'
+          && Number.isFinite(observation.value)
+          ? [[observation.metricId, observation.value]]
+          : []
+      )))
+      : undefined;
+    const id = addNode(key, 'evaluation_result', `${record.evaluatorId} / ${record.sampleId}`, {
+      nodeRole: 'observation',
+      status: evaluationStatus(record),
+      binding: {
+        bindingStrength: 'content-hash',
+        keys: { evaluationId: record.evaluationId },
+      },
+      metrics: numericMetrics !== undefined && Object.keys(numericMetrics).length > 0
+        ? numericMetrics
+        : undefined,
+      attrs: {
+        display: {
+          evaluationStatus: record.evaluationStatus,
+          trialIndex: record.trialIndex,
+        },
+      },
+      evidenceRefs: evidence(
+        evaluation.bundleId,
+        documentHash.get('evaluation-bundle')!,
+        'evaluation-bundle.json',
+        `/records/${index}`,
+      ),
+    });
+    addEdge(`${runKey}:contains:${key}`, runNode, id, 'contains');
+    const evaluatorNode = evaluatorNodes.get(record.evaluatorId);
+    const executionNode = executionNodes.get(record.trialId);
+    const sampleNode = sampleNodes.get(record.sampleId);
+    if (evaluatorNode !== undefined) {
+      addEdge(`${key}:derived-from:evaluator`, id, evaluatorNode, 'derived_from');
+    }
+    if (executionNode !== undefined) {
+      addEdge(`${key}:derived-from:execution`, id, executionNode, 'derived_from');
+    }
+    if (sampleNode !== undefined) {
+      addEdge(`${key}:evaluates:sample`, id, sampleNode, 'evaluates');
+    }
+    if (record.evaluationStatus === 'completed') {
+      for (const observation of record.observations) {
+        const metricNode = metricNodes.get(observation.metricId);
+        if (metricNode !== undefined) {
+          addEdge(
+            `${key}:observes:${observation.observationId}`,
+            id,
+            metricNode,
+            'observes',
+          );
+        }
+      }
+    }
+  });
+
+  const analysisNodes = new Map(analysis.records.map((record, index) => {
+    const key = `core:v1:analysis-result:${analysis.bundleDigest}:${record.resultId}`;
+    const id = addNode(key, 'analysis_result', record.resultId, {
+      nodeRole: 'aggregate',
+      status: analysisStatus(record),
+      binding: { bindingStrength: 'content-hash', keys: { recordDigest: record.recordDigest } },
+      attrs: {
+        display: {
+          analysisStatus: record.analysisStatus,
+          analysisNodeKind: record.analysisNodeKind,
+          analysisMode: record.analysisMode,
+          included: record.coverage.included,
+          excluded: record.coverage.excluded,
+        },
+      },
+      evidenceRefs: evidence(
+        analysis.bundleId,
+        documentHash.get('analysis-bundle')!,
+        'analysis-bundle.json',
+        `/records/${index}`,
+      ),
+    });
+    addEdge(`${runKey}:contains:${key}`, runNode, id, 'contains');
+    return [record.resultId, id] as const;
+  }));
+  analysis.records.forEach((record) => {
+    const key = `core:v1:analysis-result:${analysis.bundleDigest}:${record.resultId}`;
+    const id = analysisNodes.get(record.resultId);
+    if (id === undefined) return;
+    for (const reference of record.inputReferences) {
+      if (reference.inputKind === 'metric-observations') {
+        const metricNode = metricNodes.get(reference.referenceId);
+        if (metricNode !== undefined) {
+          addEdge(
+            `${key}:input:metric-observations:${reference.referenceId}`,
+            id,
+            metricNode,
+            'derived_from',
+          );
+        }
+      } else if (reference.inputKind === 'analysis-result') {
+        const parent = analysisNodes.get(reference.referenceId);
+        if (parent !== undefined) {
+          addEdge(
+            `${key}:input:analysis-result:${reference.referenceId}`,
+            id,
+            parent,
+            'derived_from',
+          );
+        }
+      } else {
+        const targetNode = targetNodes.get(reference.treatmentTargetId);
+        const metricNode = metricNodes.get(reference.metricId);
+        if (targetNode !== undefined) {
+          addEdge(
+            `${key}:input:comparison:${reference.referenceId}:target:${reference.treatmentTargetId}`,
+            id,
+            targetNode,
+            'derived_from',
+          );
+        }
+        if (metricNode !== undefined) {
+          addEdge(
+            `${key}:input:comparison:${reference.referenceId}:metric:${reference.metricId}`,
+            id,
+            metricNode,
+            'derived_from',
+          );
+        }
+      }
+    }
+  });
+
+  if (report.decision !== undefined) {
+    const decision = report.decision;
+    const key = `core:v1:decision:${decision.decisionDigest}`;
+    const id = addNode(key, 'decision', decision.decisionPolicyId, {
+      nodeRole: 'aggregate',
+      status: decision.decisionStatus === 'decided'
+        ? 'ok'
+        : decision.decisionStatus === 'failed' ? 'failed' : 'warning',
+      binding: {
+        bindingStrength: 'content-hash',
+        keys: { decisionDigest: decision.decisionDigest },
+      },
+      attrs: {
+        display: {
+          decisionStatus: decision.decisionStatus,
+          ...(decision.decisionStatus === 'decided' ? { verdict: decision.verdict } : {}),
+        },
+      },
+      evidenceRefs: evidence(
+        report.reportId,
+        documentHash.get('evaluation-report')!,
+        'evaluation-report.json',
+        '/decision',
+      ),
+    });
+    addEdge(`${runKey}:contains:${key}`, runNode, id, 'contains');
+    for (const resultId of decision.analysisResultIds) {
+      const analysisNode = analysisNodes.get(resultId);
+      if (analysisNode !== undefined) {
+        addEdge(`${key}:derived-from:${resultId}`, id, analysisNode, 'derived_from');
+      }
+    }
+  }
+
+  const targetKinds = new Set(plan.execution.targets.map((target) => target.targetKind));
+  const artifactKind = targetKinds.size === 1
+    && ['skill', 'prompt', 'agent', 'workflow'].includes([...targetKinds][0])
+    ? [...targetKinds][0] as ArtifactGraphDocument['scope']['artifactKind']
+    : undefined;
+  const document: ArtifactGraphDocument = {
+    documentKind: 'artifact-graph',
+    schemaVersion: 1,
+    graphId: `core-eval:${report.reportDigest}`,
+    generatedAt: input.generatedAt,
+    source: {
+      sourceKind: 'eval',
+      sourceId: report.reportId,
+      ...(input.sourcePath === undefined ? {} : { sourcePath: input.sourcePath }),
+      ...(input.cliVersion === undefined ? {} : { cliVersion: input.cliVersion }),
+    },
+    scope: {
+      cwd: input.cwd,
+      ...(artifactKind === undefined ? {} : { artifactKind }),
+      sampleSetHash: plan.digests.datasetRevisionDigest,
+    },
+    nodes,
+    edges,
+    summaries: [{
+      summaryKind: 'coverage',
+      title: 'Evaluation Core stage coverage',
+      severity: report.status.evidenceStatus === 'complete' ? 'info' : 'medium',
+      nodeIds: [runNode],
+      evidenceRefs: evidence(
+        manifest.reportId,
+        digestCanonicalJson(manifest),
+        'manifest.json',
+        '/status',
+      ),
+    }],
+  };
+  if (parseArtifactGraphDocument(document) === null) {
+    throw new CoreDownstreamProjectionError(
+      'CORE_PROJECTION_SOURCE_INVALID',
+      'Core artifact graph projection produced an invalid graph document.',
+    );
+  }
+  return document;
+}

--- a/src/eval-workflows/downstream-projections/contracts.ts
+++ b/src/eval-workflows/downstream-projections/contracts.ts
@@ -1,0 +1,158 @@
+import type {
+  EvaluationStatus,
+  JsonValue,
+  RuntimeIdentity,
+  SeriesMemberCoverage,
+} from '../../evaluation-core/contracts/index.js';
+
+export const CORE_GOLD_COMPARISON_SCHEMA_VERSION =
+  'omk.core-gold-comparison/v1' as const;
+export const CORE_EVOLUTION_EVIDENCE_SCHEMA_VERSION =
+  'omk.core-evolution-evidence/v1' as const;
+
+export type CoreDownstreamProjectionErrorCode =
+  | 'CORE_PROJECTION_SOURCE_INVALID'
+  | 'CORE_GOLD_SELECTOR_INVALID'
+  | 'CORE_GOLD_SCALE_INCOMPATIBLE'
+  | 'CORE_GOLD_ANNOTATION_INVALID'
+  | 'CORE_GOLD_OBSERVATION_AMBIGUOUS'
+  | 'CORE_SERIES_SOURCE_INVALID';
+
+export class CoreDownstreamProjectionError extends Error {
+  readonly code: CoreDownstreamProjectionErrorCode;
+
+  constructor(code: CoreDownstreamProjectionErrorCode, message: string) {
+    super(message);
+    this.name = 'CoreDownstreamProjectionError';
+    this.code = code;
+  }
+}
+
+export interface CoreGoldMetricSelector {
+  readonly targetId: string;
+  readonly evaluatorId: string;
+  readonly metricId: string;
+  readonly trialIndex?: number;
+  readonly instrumentId?: string;
+  readonly ensembleMemberId?: string;
+  readonly replicateGroupId?: string;
+  readonly replicateIndex?: number;
+}
+
+export interface CoreGoldComparisonRow {
+  readonly sampleId: string;
+  readonly goldScore: number;
+  readonly observedScore: number;
+  readonly difference: number;
+  readonly evaluationId: string;
+  readonly observationId: string;
+}
+
+export interface CoreGoldAgreementResult {
+  readonly alpha: number | null;
+  readonly alphaCI: {
+    readonly low: number | null;
+    readonly high: number | null;
+    readonly estimate: number | null;
+    readonly samples: number;
+  };
+  readonly weightedKappa: number | null;
+  readonly pearson: number | null;
+  readonly sampleCount: number;
+}
+
+export interface CoreGoldComparisonResult {
+  readonly projectionKind: 'core-gold-comparison';
+  readonly schemaVersion: typeof CORE_GOLD_COMPARISON_SCHEMA_VERSION;
+  readonly runContractDigest: string;
+  readonly reportDigest: string;
+  readonly gold: {
+    readonly datasetDigest: string;
+    readonly annotator: string;
+    readonly annotatedAt: string;
+    readonly version: string;
+  };
+  readonly selector: CoreGoldMetricSelector;
+  readonly scale: { readonly min: number; readonly max: number };
+  readonly evaluatorRuntime: RuntimeIdentity;
+  readonly agreement: CoreGoldAgreementResult;
+  readonly rows: readonly CoreGoldComparisonRow[];
+  readonly missingSampleIds: readonly string[];
+  readonly unscoredSampleIds: readonly string[];
+  readonly contaminationWarning?: string;
+}
+
+export interface CoreEvolutionMemberEvidence {
+  readonly memberId: string;
+  readonly replicateIndex: number;
+  readonly reportDigest: string;
+  readonly runContractDigest: string;
+  readonly status: EvaluationStatus;
+  readonly effectiveTrust: 'verified' | 'declared' | 'untrusted' | 'unknown';
+  readonly comparabilityStatus: 'anchor' | 'compatible' | 'conditional' | 'incompatible';
+}
+
+export type CoreEvolutionAnalysisEvidence = {
+  readonly resultId: string;
+  readonly nodeId: string;
+  readonly analysisStandardId: string;
+  readonly memberIds: readonly string[];
+  readonly coverage: SeriesMemberCoverage;
+  readonly assumptionChecks: readonly {
+    readonly assumptionId: string;
+    readonly checkStatus: 'passed' | 'failed' | 'not-evaluated';
+    readonly reasonCode?: string;
+  }[];
+  readonly recordDigest: string;
+} & (
+  | {
+    readonly analysisStatus: 'completed';
+    readonly resultType: 'scalar' | 'interval' | 'distribution' | 'table' | 'matrix' | 'curve';
+    readonly value: JsonValue;
+  }
+  | {
+    readonly analysisStatus: 'inconclusive';
+    readonly reasonCodes: readonly string[];
+  }
+  | {
+    readonly analysisStatus: 'failed';
+    readonly errorCode: string;
+  }
+);
+
+export type CoreEvolutionDecisionEvidence =
+  | {
+    readonly decisionStatus: 'decided';
+    readonly decisionPolicyId: string;
+    readonly verdict: string;
+    readonly reasonCodes: readonly string[];
+    readonly decisionDigest: string;
+  }
+  | {
+    readonly decisionStatus: 'not-decided';
+    readonly decisionPolicyId: string;
+    readonly reasonCodes: readonly string[];
+    readonly decisionDigest: string;
+  }
+  | {
+    readonly decisionStatus: 'failed';
+    readonly decisionPolicyId: string;
+    readonly errorCode: string;
+    readonly decisionDigest: string;
+  };
+
+export interface CoreEvolutionEvidence {
+  readonly projectionKind: 'core-evolution-evidence';
+  readonly schemaVersion: typeof CORE_EVOLUTION_EVIDENCE_SCHEMA_VERSION;
+  readonly seriesId: string;
+  readonly seriesPlanDigest: string;
+  readonly analysisBundleDigest: string;
+  readonly reportDigest: string;
+  readonly analysisMode: 'preregistered' | 'exploratory';
+  readonly experimentalUnit: 'run';
+  readonly evidenceReadiness: 'decision-ready' | 'analysis-only' | 'insufficient';
+  readonly coverage: SeriesMemberCoverage;
+  readonly members: readonly CoreEvolutionMemberEvidence[];
+  readonly analyses: readonly CoreEvolutionAnalysisEvidence[];
+  readonly decision?: CoreEvolutionDecisionEvidence;
+}

--- a/src/eval-workflows/downstream-projections/evolution.ts
+++ b/src/eval-workflows/downstream-projections/evolution.ts
@@ -1,0 +1,207 @@
+import {
+  canonicalizeJson,
+  parseEvaluationSeriesPlan,
+  parseEvaluationSeriesReportDocument,
+  parseSeriesAnalysisBundleDocument,
+  type EvaluationSeriesPlan,
+  type EvaluationSeriesReport,
+  type SeriesAnalysisBundle,
+} from '../../evaluation-core/contracts/index.js';
+import {
+  CORE_EVOLUTION_EVIDENCE_SCHEMA_VERSION,
+  CoreDownstreamProjectionError,
+  type CoreEvolutionAnalysisEvidence,
+  type CoreEvolutionDecisionEvidence,
+  type CoreEvolutionEvidence,
+} from './contracts.js';
+
+export interface ProjectCoreEvolutionEvidenceInput {
+  readonly plan: Readonly<EvaluationSeriesPlan>;
+  readonly analysis: Readonly<SeriesAnalysisBundle>;
+  readonly report: Readonly<EvaluationSeriesReport>;
+}
+
+function fail(): never {
+  throw new CoreDownstreamProjectionError(
+    'CORE_SERIES_SOURCE_INVALID',
+    'Evolution projection requires one exact Evaluation Series Plan, Analysis Bundle, and Report chain.',
+  );
+}
+
+function projectDecision(
+  decision: EvaluationSeriesReport['decision'],
+): CoreEvolutionDecisionEvidence | undefined {
+  if (decision === undefined) return undefined;
+  const base = {
+    decisionPolicyId: decision.decisionPolicyId,
+    decisionDigest: decision.decisionDigest,
+  };
+  if (decision.decisionStatus === 'decided') {
+    return {
+      ...base,
+      decisionStatus: decision.decisionStatus,
+      verdict: decision.verdict,
+      reasonCodes: [...decision.reasonCodes],
+    };
+  }
+  if (decision.decisionStatus === 'not-decided') {
+    return {
+      ...base,
+      decisionStatus: decision.decisionStatus,
+      reasonCodes: [...decision.reasonCodes],
+    };
+  }
+  return {
+    ...base,
+    decisionStatus: decision.decisionStatus,
+    errorCode: decision.error.code,
+  };
+}
+
+/**
+ * Project immutable cross-run evidence for authoring/evolve consumers. The
+ * Series contract keeps `run` as the experimental unit; this view never ranks
+ * members or invents a winner outside the registered Decision result.
+ */
+export function projectCoreEvolutionEvidence(
+  input: Readonly<ProjectCoreEvolutionEvidenceInput>,
+): CoreEvolutionEvidence {
+  let plan: EvaluationSeriesPlan;
+  let analysis: SeriesAnalysisBundle;
+  let report: EvaluationSeriesReport;
+  try {
+    plan = parseEvaluationSeriesPlan(input.plan);
+    analysis = parseSeriesAnalysisBundleDocument(input.analysis);
+    report = parseEvaluationSeriesReportDocument(input.report);
+  } catch {
+    fail();
+  }
+  if (analysis.seriesPlanDigest !== plan.seriesPlanDigest
+      || report.seriesPlanDigest !== plan.seriesPlanDigest
+      || report.analysisBundleDigest !== analysis.bundleDigest
+      || analysis.coverage.planned !== plan.definition.members.length) {
+    fail();
+  }
+
+  const slots = new Map(plan.definition.members.map((member) => [member.memberId, member]));
+  if (analysis.members.some((member) => {
+    const slot = slots.get(member.memberId);
+    return slot === undefined
+      || slot.replicateIndex !== member.replicateIndex
+      || (slot.expectedRunContractDigest !== undefined
+        && slot.expectedRunContractDigest !== member.runContractDigest);
+  })) {
+    fail();
+  }
+  const nodeById = new Map(plan.definition.analysisGraph.nodes.map((node) => [node.nodeId, node]));
+  if (analysis.records.length !== nodeById.size
+      || analysis.records.some((record) => {
+        const node = nodeById.get(record.nodeId);
+        const runtime = plan.runtimes.find((entry) => entry.referenceId === record.nodeId);
+        if (node === undefined || runtime?.runtimeKind !== 'series-analysis-node') return true;
+        return node.outputResultId !== record.resultId
+          || node.analysisStandardId !== record.analysisStandardId
+          || node.implementationId !== record.implementation.implementationId
+          || canonicalizeJson(runtime.identity) !== canonicalizeJson(record.implementation)
+          || canonicalizeJson(runtime.outputSchema) !== canonicalizeJson(record.outputSchema)
+          || record.analysisMode !== plan.definition.analysisMode;
+      })) {
+    fail();
+  }
+  const policy = plan.definition.decisionPolicy;
+  const decisionRuntime = plan.runtimes.find((entry) => (
+    entry.runtimeKind === 'series-decision-policy'
+      && entry.referenceId === policy?.decisionPolicyId
+  ));
+  if ((policy === undefined) !== (report.decision === undefined)
+      || (policy !== undefined && report.decision !== undefined
+        && (decisionRuntime === undefined
+          || policy.decisionPolicyId !== report.decision.decisionPolicyId
+          || policy.implementationId !== report.decision.implementation.implementationId
+          || canonicalizeJson(decisionRuntime.identity)
+            !== canonicalizeJson(report.decision.implementation)
+          || policy.analysisResultIds.length !== report.decision.analysisResultIds.length
+          || policy.analysisResultIds.some((resultId, index) => (
+            resultId !== report.decision?.analysisResultIds[index]
+          ))
+          || report.decision.analysisResultIds.some((resultId) => (
+            !analysis.records.some((record) => record.resultId === resultId)
+          ))))) {
+    fail();
+  }
+
+  const comparability = new Map(analysis.comparability.map((entry) => [
+    entry.memberId,
+    entry.assessment.comparabilityStatus,
+  ]));
+  const anchorId = analysis.comparability[0]?.anchorMemberId
+    ?? analysis.members[0]?.memberId;
+  const members = analysis.members.map((member) => ({
+    memberId: member.memberId,
+    replicateIndex: member.replicateIndex,
+    reportDigest: member.reportDigest,
+    runContractDigest: member.runContractDigest,
+    status: member.status,
+    effectiveTrust: member.effectiveTrust,
+    comparabilityStatus: member.memberId === anchorId
+      ? 'anchor' as const
+      : comparability.get(member.memberId) ?? 'incompatible' as const,
+  }));
+  const analyses: CoreEvolutionAnalysisEvidence[] = analysis.records.map((record) => {
+    const base = {
+      resultId: record.resultId,
+      nodeId: record.nodeId,
+      analysisStandardId: record.analysisStandardId,
+      memberIds: [...record.memberIds],
+      coverage: record.coverage,
+      assumptionChecks: record.assumptionChecks.map((check) => ({
+        assumptionId: check.assumptionId,
+        checkStatus: check.checkStatus,
+        ...(check.reasonCode === undefined ? {} : { reasonCode: check.reasonCode }),
+      })),
+      recordDigest: record.recordDigest,
+    };
+    if (record.analysisStatus === 'completed') {
+      return {
+        ...base,
+        analysisStatus: record.analysisStatus,
+        resultType: record.resultType,
+        value: record.value,
+      };
+    }
+    if (record.analysisStatus === 'inconclusive') {
+      return {
+        ...base,
+        analysisStatus: record.analysisStatus,
+        reasonCodes: [...record.reasonCodes],
+      };
+    }
+    return {
+      ...base,
+      analysisStatus: record.analysisStatus,
+      errorCode: record.error.code,
+    };
+  });
+  const decision = projectDecision(report.decision);
+  const evidenceReadiness = decision?.decisionStatus === 'decided'
+    ? 'decision-ready'
+    : analyses.some((record) => record.analysisStatus === 'completed')
+      ? 'analysis-only'
+      : 'insufficient';
+
+  return {
+    projectionKind: 'core-evolution-evidence',
+    schemaVersion: CORE_EVOLUTION_EVIDENCE_SCHEMA_VERSION,
+    seriesId: plan.definition.seriesId,
+    seriesPlanDigest: plan.seriesPlanDigest,
+    analysisBundleDigest: analysis.bundleDigest,
+    reportDigest: report.reportDigest,
+    analysisMode: plan.definition.analysisMode,
+    experimentalUnit: plan.definition.experimentalUnit,
+    evidenceReadiness,
+    coverage: analysis.coverage,
+    members,
+    analyses,
+    ...(decision === undefined ? {} : { decision }),
+  };
+}

--- a/src/eval-workflows/downstream-projections/gold.ts
+++ b/src/eval-workflows/downstream-projections/gold.ts
@@ -1,0 +1,260 @@
+import {
+  digestCanonicalJson,
+  type EvaluationRecord,
+} from '../../evaluation-core/contracts/index.js';
+import type { GoldDataset } from '../../grading/gold-dataset.js';
+import {
+  computeAgreementWithCI,
+  type RatingPair,
+} from '../../grading/human-gold.js';
+import type { StoredCoreRunArtifacts } from '../artifact-store/index.js';
+import {
+  CORE_GOLD_COMPARISON_SCHEMA_VERSION,
+  CoreDownstreamProjectionError,
+  type CoreGoldComparisonResult,
+  type CoreGoldMetricSelector,
+} from './contracts.js';
+import { assertCoreProjectionSource } from './source.js';
+
+export interface CompareGoldToCoreRunInput {
+  readonly source: Readonly<StoredCoreRunArtifacts>;
+  readonly gold: CoreGoldDatasetInput;
+  readonly selector: Readonly<CoreGoldMetricSelector>;
+  readonly bootstrapSamples?: number;
+  readonly bootstrapSeed?: number;
+}
+
+export interface CoreGoldDatasetInput {
+  readonly metadata: Readonly<GoldDataset['metadata']>;
+  readonly annotations: readonly GoldDataset['annotations'][number][];
+  readonly sourcePaths: readonly string[];
+}
+
+function matchesSelector(
+  record: EvaluationRecord,
+  selector: Readonly<CoreGoldMetricSelector>,
+): boolean {
+  return record.targetId === selector.targetId
+    && record.evaluatorId === selector.evaluatorId
+    && (selector.trialIndex === undefined || record.trialIndex === selector.trialIndex)
+    && (selector.instrumentId === undefined
+      || record.measurement.instrumentId === selector.instrumentId)
+    && (selector.ensembleMemberId === undefined
+      || record.measurement.ensembleMemberId === selector.ensembleMemberId)
+    && (selector.replicateGroupId === undefined
+      || record.measurement.replicateGroupId === selector.replicateGroupId)
+    && (selector.replicateIndex === undefined
+      || record.measurement.replicateIndex === selector.replicateIndex);
+}
+
+function normalizedIdentity(value: string): string {
+  return value.trim().toLocaleLowerCase('en-US');
+}
+
+function jsonNumber(value: number): number | null {
+  return Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Compare one explicitly selected Core numeric observation with external gold.
+ * The projector refuses implicit pooling: every sample must resolve to at most
+ * one observed value after the caller's trial/measurement selector is applied.
+ */
+export function compareGoldToCoreRun(
+  input: Readonly<CompareGoldToCoreRunInput>,
+): CoreGoldComparisonResult {
+  assertCoreProjectionSource(input.source);
+  const { plan, evaluation, report } = input.source;
+  const { selector, gold } = input;
+  const target = plan.execution.targets.find((entry) => entry.targetId === selector.targetId);
+  const evaluator = plan.evaluation.evaluators.find(
+    (entry) => entry.evaluatorId === selector.evaluatorId,
+  );
+  const metric = plan.evaluation.metrics.find((entry) => entry.metricId === selector.metricId);
+  const evaluatorRuntime = plan.evaluation.runtimes.find((runtime) => (
+    runtime.runtimeKind === 'evaluator' && runtime.referenceId === selector.evaluatorId
+  ));
+  if (target === undefined
+      || evaluator === undefined
+      || metric === undefined
+      || evaluatorRuntime === undefined
+      || !evaluator.metricIds.includes(metric.metricId)) {
+    throw new CoreDownstreamProjectionError(
+      'CORE_GOLD_SELECTOR_INVALID',
+      'Gold comparison selector must reference one sealed Target, Evaluator, and owned Metric.',
+    );
+  }
+  const sealedMeasurement = evaluator.measurement;
+  if ((selector.trialIndex !== undefined
+        && (!Number.isInteger(selector.trialIndex) || selector.trialIndex < 0))
+      || (selector.instrumentId !== undefined
+        && selector.instrumentId !== sealedMeasurement.instrumentId)
+      || (selector.ensembleMemberId !== undefined
+        && selector.ensembleMemberId !== sealedMeasurement.ensembleMemberId)
+      || (selector.replicateGroupId !== undefined
+        && selector.replicateGroupId !== sealedMeasurement.replicateGroupId)
+      || (selector.replicateIndex !== undefined
+        && selector.replicateIndex !== sealedMeasurement.replicateIndex)) {
+    throw new CoreDownstreamProjectionError(
+      'CORE_GOLD_SELECTOR_INVALID',
+      'Gold comparison measurement selector must match the Evaluator measurement sealed in the Plan.',
+    );
+  }
+  if (metric.valueType !== 'numeric'
+      || metric.scale?.min === undefined
+      || metric.scale.max === undefined
+      || !Number.isFinite(metric.scale.min)
+      || !Number.isFinite(metric.scale.max)
+      || metric.scale.min >= metric.scale.max) {
+    throw new CoreDownstreamProjectionError(
+      'CORE_GOLD_SCALE_INCOMPATIBLE',
+      'Gold comparison requires a numeric Core Metric with an explicit finite min/max scale.',
+    );
+  }
+  const scale = gold.metadata.scale ?? { min: 1, max: 5 };
+  if (!Number.isFinite(scale.min)
+      || !Number.isFinite(scale.max)
+      || scale.min >= scale.max
+      || scale.min !== metric.scale.min
+      || scale.max !== metric.scale.max) {
+    throw new CoreDownstreamProjectionError(
+      'CORE_GOLD_SCALE_INCOMPATIBLE',
+      'Gold and Core Metric scales must match exactly; rescaling requires a preregistered analysis.',
+    );
+  }
+  const annotationIds = gold.annotations.map((annotation) => annotation.sample_id);
+  if (new Set(annotationIds).size !== annotationIds.length
+      || gold.annotations.some((annotation) => (
+        !annotation.sample_id
+        || !Number.isFinite(annotation.score)
+        || annotation.score < scale.min
+        || annotation.score > scale.max
+      ))) {
+    throw new CoreDownstreamProjectionError(
+      'CORE_GOLD_ANNOTATION_INVALID',
+      'Gold annotations require unique sample IDs and finite scores inside the declared scale.',
+    );
+  }
+
+  const sampleIds = new Set(plan.evaluation.samples.map((sample) => sample.sampleId));
+  const records = evaluation.records.filter((record) => matchesSelector(record, selector));
+  const pairs: RatingPair[] = [];
+  const rows: CoreGoldComparisonResult['rows'][number][] = [];
+  const missingSampleIds: string[] = [];
+  const unscoredSampleIds: string[] = [];
+
+  for (const annotation of [...gold.annotations].sort((left, right) => (
+    left.sample_id.localeCompare(right.sample_id)
+  ))) {
+    if (!sampleIds.has(annotation.sample_id)) {
+      missingSampleIds.push(annotation.sample_id);
+      continue;
+    }
+    const observations = records.flatMap((record) => (
+      record.sampleId === annotation.sample_id && record.evaluationStatus === 'completed'
+        ? record.observations.flatMap((observation) => (
+          observation.metricId === selector.metricId
+            && observation.observationStatus === 'observed'
+            && observation.valueType === 'numeric'
+            ? [{ record, observation }]
+            : []
+        ))
+        : []
+    ));
+    if (observations.length > 1) {
+      throw new CoreDownstreamProjectionError(
+        'CORE_GOLD_OBSERVATION_AMBIGUOUS',
+        'A Gold sample resolves to multiple Core observations; refine the measurement/trial selector.',
+      );
+    }
+    const selected = observations[0];
+    if (selected === undefined) {
+      unscoredSampleIds.push(annotation.sample_id);
+      continue;
+    }
+    if (!Number.isFinite(selected.observation.value)
+        || selected.observation.value < scale.min
+        || selected.observation.value > scale.max) {
+      throw new CoreDownstreamProjectionError(
+        'CORE_PROJECTION_SOURCE_INVALID',
+        'Selected Core observation is outside its sealed Metric scale.',
+      );
+    }
+    pairs.push({
+      unitId: annotation.sample_id,
+      coderA: annotation.score,
+      coderB: selected.observation.value,
+    });
+    rows.push({
+      sampleId: annotation.sample_id,
+      goldScore: annotation.score,
+      observedScore: selected.observation.value,
+      difference: Number((selected.observation.value - annotation.score).toFixed(4)),
+      evaluationId: selected.record.evaluationId,
+      observationId: selected.observation.observationId,
+    });
+  }
+
+  const annotator = normalizedIdentity(gold.metadata.annotator);
+  const runtimeIds = [
+    evaluator.implementationId,
+    evaluatorRuntime.identity.implementationId,
+    evaluatorRuntime.identity.fingerprint,
+  ].map(normalizedIdentity);
+  const contaminationWarning = runtimeIds.includes(annotator)
+    ? `gold annotator "${gold.metadata.annotator}" exactly matches the selected evaluator identity; agreement may be inflated`
+    : undefined;
+  const agreement = computeAgreementWithCI(pairs, {
+    samples: input.bootstrapSamples,
+    seed: input.bootstrapSeed,
+    scale,
+  });
+  const goldDatasetDigest = digestCanonicalJson({
+    metadata: {
+      annotator: gold.metadata.annotator,
+      annotatedAt: gold.metadata.annotatedAt,
+      version: gold.metadata.version,
+      ...(gold.metadata.scale === undefined ? {} : { scale: gold.metadata.scale }),
+      ...(gold.metadata.notes === undefined ? {} : { notes: gold.metadata.notes }),
+    },
+    annotations: [...gold.annotations]
+      .sort((left, right) => left.sample_id.localeCompare(right.sample_id))
+      .map((annotation) => ({
+        sample_id: annotation.sample_id,
+        score: annotation.score,
+        ...(annotation.reason === undefined ? {} : { reason: annotation.reason }),
+      })),
+  });
+
+  return {
+    projectionKind: 'core-gold-comparison',
+    schemaVersion: CORE_GOLD_COMPARISON_SCHEMA_VERSION,
+    runContractDigest: plan.digests.runContractDigest,
+    reportDigest: report.reportDigest,
+    gold: {
+      datasetDigest: goldDatasetDigest,
+      annotator: gold.metadata.annotator,
+      annotatedAt: gold.metadata.annotatedAt,
+      version: gold.metadata.version,
+    },
+    selector: { ...selector },
+    scale: { ...scale },
+    evaluatorRuntime: evaluatorRuntime.identity,
+    agreement: {
+      alpha: jsonNumber(agreement.alpha),
+      alphaCI: {
+        low: jsonNumber(agreement.alphaCI.low),
+        high: jsonNumber(agreement.alphaCI.high),
+        estimate: jsonNumber(agreement.alphaCI.estimate),
+        samples: agreement.alphaCI.samples,
+      },
+      weightedKappa: jsonNumber(agreement.weightedKappa),
+      pearson: jsonNumber(agreement.pearson),
+      sampleCount: agreement.sampleCount,
+    },
+    rows,
+    missingSampleIds,
+    unscoredSampleIds,
+    ...(contaminationWarning === undefined ? {} : { contaminationWarning }),
+  };
+}

--- a/src/eval-workflows/downstream-projections/index.ts
+++ b/src/eval-workflows/downstream-projections/index.ts
@@ -1,0 +1,4 @@
+export * from './artifact-graph.js';
+export * from './contracts.js';
+export * from './evolution.js';
+export * from './gold.js';

--- a/src/eval-workflows/downstream-projections/source.ts
+++ b/src/eval-workflows/downstream-projections/source.ts
@@ -1,0 +1,62 @@
+import {
+  canonicalizeJson,
+  digestCanonicalJson,
+} from '../../evaluation-core/contracts/index.js';
+import type { StoredCoreRunArtifacts } from '../artifact-store/index.js';
+import { CoreDownstreamProjectionError } from './contracts.js';
+
+function fail(): never {
+  throw new CoreDownstreamProjectionError(
+    'CORE_PROJECTION_SOURCE_INVALID',
+    'Core downstream projection requires one exact persisted Plan, Bundle, Report, and manifest chain.',
+  );
+}
+
+export function assertCoreProjectionSource(
+  source: Readonly<StoredCoreRunArtifacts>,
+): void {
+  const { manifest, plan, execution, evaluation, analysis, report } = source;
+  const { manifestDigest, ...manifestPayload } = manifest;
+  const references = [
+    ['run-plan', plan.digests.runContractDigest, digestCanonicalJson(plan)],
+    ['execution-bundle', execution.bundleDigest, digestCanonicalJson(execution)],
+    ['evaluation-bundle', evaluation.bundleDigest, digestCanonicalJson(evaluation)],
+    ['analysis-bundle', analysis.bundleDigest, digestCanonicalJson(analysis)],
+    ['evaluation-report', report.reportDigest, digestCanonicalJson(report)],
+  ] as const;
+  const reportBundles = report.bundles.map((reference) => [
+    reference.bundleKind,
+    reference.bundleDigest,
+  ]);
+
+  if (digestCanonicalJson(manifestPayload) !== manifestDigest
+      || manifest.runContractDigest !== plan.digests.runContractDigest
+      || manifest.reportId !== report.reportId
+      || manifest.status.runStatus !== report.status.runStatus
+      || manifest.status.evidenceStatus !== report.status.evidenceStatus
+      || manifest.status.conclusionStatus !== report.status.conclusionStatus
+      || manifest.replayability.execution !== execution.replayability
+      || manifest.replayability.evaluation !== evaluation.replayability
+      || execution.runContractDigest !== plan.digests.runContractDigest
+      || execution.executionPlanDigest !== plan.digests.executionPlanDigest
+      || evaluation.runContractDigest !== plan.digests.runContractDigest
+      || evaluation.executionBundleDigest !== execution.bundleDigest
+      || evaluation.evaluationPlanDigest !== plan.digests.evaluationPlanDigest
+      || analysis.runContractDigest !== plan.digests.runContractDigest
+      || analysis.evaluationBundleDigest !== evaluation.bundleDigest
+      || analysis.analysisPlanDigest !== plan.digests.analysisPlanDigest
+      || report.runContractDigest !== plan.digests.runContractDigest
+      || canonicalizeJson(reportBundles) !== canonicalizeJson([
+        ['execution', execution.bundleDigest],
+        ['evaluation', evaluation.bundleDigest],
+        ['analysis', analysis.bundleDigest],
+      ])
+      || manifest.documents.length !== references.length
+      || manifest.documents.some((reference, index) => (
+        reference.documentKind !== references[index][0]
+        || reference.identityDigest !== references[index][1]
+        || reference.documentDigest !== references[index][2]
+      ))) {
+    fail();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,30 @@ export {
   createBuiltinMissingPolicies,
   resolveBuiltinAnalysisRuntime,
 } from './evaluation-core/analysis/index.js';
+
+export {
+  CORE_EVOLUTION_EVIDENCE_SCHEMA_VERSION,
+  CORE_GOLD_COMPARISON_SCHEMA_VERSION,
+  CoreDownstreamProjectionError,
+  compareGoldToCoreRun,
+  projectCoreArtifactGraph,
+  projectCoreEvolutionEvidence,
+} from './eval-workflows/downstream-projections/index.js';
+export type {
+  CompareGoldToCoreRunInput,
+  CoreGoldDatasetInput,
+  CoreDownstreamProjectionErrorCode,
+  CoreEvolutionAnalysisEvidence,
+  CoreEvolutionDecisionEvidence,
+  CoreEvolutionEvidence,
+  CoreEvolutionMemberEvidence,
+  CoreGoldComparisonResult,
+  CoreGoldAgreementResult,
+  CoreGoldComparisonRow,
+  CoreGoldMetricSelector,
+  ProjectCoreArtifactGraphInput,
+  ProjectCoreEvolutionEvidenceInput,
+} from './eval-workflows/downstream-projections/index.js';
 export type {
   AnalysisDecisionPolicy,
   AnalysisMetricRow,

--- a/src/shared/artifact-graph.ts
+++ b/src/shared/artifact-graph.ts
@@ -34,6 +34,14 @@ const NODE_KINDS = new Set([
   'skill_invocation',
   'tool_call',
   'gap_signal',
+  'evaluation_run',
+  'target',
+  'evaluator',
+  'metric',
+  'execution_result',
+  'evaluation_result',
+  'analysis_result',
+  'decision',
 ]);
 const STATUSES = new Set(['ok', 'warning', 'failed', 'skipped', 'unknown', 'not_measured']);
 const BINDING_STRENGTHS = new Set([
@@ -69,6 +77,7 @@ const EVIDENCE_SOURCE_KINDS = new Set([
   'observe-report',
   'trace',
   'sample',
+  'evaluation-core-document',
   'managed-record',
 ]);
 const SELECTOR_KINDS = new Set([

--- a/src/types/artifact-graph.ts
+++ b/src/types/artifact-graph.ts
@@ -32,9 +32,9 @@ export type ArtifactGraphLayer = 'definition' | 'measurement' | 'production';
 
 export type ArtifactGraphNodeRole = 'entity' | 'observation' | 'aggregate';
 
-// Schema v1 intentionally reserves eval/observe node and edge kinds. The first
-// doctor producer emits only definition-layer nodes plus doctor_rule_result; eval
-// and observe producers will populate the measurement/production kinds later.
+// Schema v1 intentionally reserves eval/observe node and edge kinds. Enum
+// expansion is additive: Core-native projections use qualified measurement
+// entities instead of overloading legacy variant/result semantics.
 export type ArtifactGraphNodeKind =
   | 'skill'
   | 'skill_file'
@@ -57,7 +57,15 @@ export type ArtifactGraphNodeKind =
   | 'trace_session'
   | 'skill_invocation'
   | 'tool_call'
-  | 'gap_signal';
+  | 'gap_signal'
+  | 'evaluation_run'
+  | 'target'
+  | 'evaluator'
+  | 'metric'
+  | 'execution_result'
+  | 'evaluation_result'
+  | 'analysis_result'
+  | 'decision';
 
 export type ArtifactGraphStatus =
   | 'ok'
@@ -134,6 +142,7 @@ export type ArtifactGraphEvidenceSourceKind =
   | 'observe-report'
   | 'trace'
   | 'sample'
+  | 'evaluation-core-document'
   | 'managed-record';
 
 export type ArtifactGraphEvidenceSelectorKind =

--- a/test/eval-workflows/downstream-projections-boundary.test.ts
+++ b/test/eval-workflows/downstream-projections-boundary.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('#531 Core downstream projection boundary', () => {
+  it('does not import legacy Report/result contracts or switch production consumers', () => {
+    const projectionFiles = [
+      'src/eval-workflows/downstream-projections/artifact-graph.ts',
+      'src/eval-workflows/downstream-projections/contracts.ts',
+      'src/eval-workflows/downstream-projections/evolution.ts',
+      'src/eval-workflows/downstream-projections/gold.ts',
+      'src/eval-workflows/downstream-projections/source.ts',
+    ];
+    const projectionSource = projectionFiles.map((file) => readFileSync(file, 'utf8')).join('\n');
+    expect(projectionSource).not.toContain("src/types/report");
+    expect(projectionSource).not.toContain("types/report.js");
+    expect(projectionSource).not.toMatch(/\bVariantResult\b/);
+    expect(projectionSource).not.toMatch(/\bResultEntry\b/);
+    expect(projectionSource).not.toMatch(/\.llmScore\b/);
+    expect(projectionSource).not.toMatch(/\.compositeScore\b/);
+
+    const legacyConsumers = [
+      'src/artifact-graph/eval.ts',
+      'src/grading/gold-cli.ts',
+      'src/authoring/evolver.ts',
+    ].map((file) => readFileSync(file, 'utf8')).join('\n');
+    expect(legacyConsumers).not.toContain('downstream-projections');
+    expect(legacyConsumers).not.toContain('projectCoreArtifactGraph');
+    expect(legacyConsumers).not.toContain('compareGoldToCoreRun');
+    expect(legacyConsumers).not.toContain('projectCoreEvolutionEvidence');
+  });
+});

--- a/test/eval-workflows/downstream-projections.test.ts
+++ b/test/eval-workflows/downstream-projections.test.ts
@@ -1,0 +1,410 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'vitest';
+import {
+  CoreDownstreamProjectionError,
+  createEvaluationSeriesDefinition,
+  createEvaluationSeriesMemberSource,
+  digestCanonicalJson,
+  prepareEvaluationSeriesPlan,
+  projectCoreArtifactGraph,
+  compareGoldToCoreRun,
+  projectCoreEvolutionEvidence,
+  runEvaluationSeries,
+  schemaIdentityKey,
+  type EvaluationSeriesDefinition,
+  type EvaluationSeriesDefinitionInput,
+  type RuntimeIdentity,
+} from '../../src/index.js';
+import { parseArtifactGraphDocument } from '../../src/shared/artifact-graph.js';
+import {
+  createNodeCoreRunArtifactStore,
+  type StoredCoreRunArtifacts,
+} from '../../src/eval-workflows/artifact-store/index.js';
+import {
+  prepareConformancePlan,
+  runConformanceScenario,
+  type ConformanceResult,
+  type ConformanceHarnessOptions,
+  type ConformanceTarget,
+} from '../evaluation-core/conformance/harness.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => (
+    rm(path, { recursive: true, force: true })
+  )));
+});
+
+async function storedScenario(
+  target: ConformanceTarget,
+  mutate?: ConformanceHarnessOptions['mutate'],
+): Promise<StoredCoreRunArtifacts> {
+  const root = await mkdtemp(join(tmpdir(), 'omk-core-projection-'));
+  temporaryDirectories.push(root);
+  const runId = `projection-${target}`;
+  const result = await runConformanceScenario(target, { runId, mutate });
+  return createNodeCoreRunArtifactStore(root).save({
+    runId,
+    createdAt: '2026-08-31T12:00:00.000Z',
+    plan: result.plan,
+    execution: result.execution,
+    evaluation: result.evaluation,
+    analysis: result.analysis,
+    report: result.report,
+  });
+}
+
+function expectProjectionError(code: CoreDownstreamProjectionError['code']) {
+  return (error: unknown): boolean => (
+    error instanceof CoreDownstreamProjectionError && error.code === code
+  );
+}
+
+describe('Evaluation Core downstream projections', () => {
+  it('projects a Core-native graph without legacy score bands or captured content', async () => {
+    const source = await storedScenario('rag');
+    const graph = projectCoreArtifactGraph({
+      source,
+      cwd: '/workspace/project',
+      generatedAt: '2026-08-31T12:01:00.000Z',
+      sourcePath: '/artifacts/evaluation-report.json',
+      cliVersion: '0.54.0',
+    });
+
+    assert.equal(parseArtifactGraphDocument(graph), graph);
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'evaluation_run'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'target'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'execution_result'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'evaluation_result'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'analysis_result'));
+    assert.ok(graph.nodes.some((node) => node.nodeKind === 'decision'));
+    assert.ok(graph.edges.some((edge) => edge.edgeKind === 'observes'));
+    assert.ok(graph.nodes.every((node) => node.nodeKind !== 'variant'));
+    assert.ok(graph.nodes.every((node) => node.metrics?.llmScore === undefined));
+    assert.ok(graph.nodes.flatMap((node) => node.evidenceRefs ?? []).every(
+      (reference) => reference.sourceKind === 'evaluation-core-document',
+    ));
+    assert.ok(!JSON.stringify(graph).includes('evaluation core'));
+    const runNode = graph.nodes.find((node) => node.nodeKind === 'evaluation_run');
+    const targetNode = graph.nodes.find((node) => node.nodeKind === 'target');
+    assert.ok(runNode?.stableKey.includes(source.manifest.runId));
+    assert.ok(runNode?.stableKey.includes(source.report.reportDigest));
+    assert.ok(targetNode?.stableKey.includes(source.plan.digests.executionPlanDigest));
+
+    const invalid = structuredClone(source);
+    invalid.report.reportId = 'different-report';
+    assert.throws(
+      () => projectCoreArtifactGraph({
+        source: invalid,
+        cwd: '/workspace/project',
+        generatedAt: '2026-08-31T12:01:00.000Z',
+      }),
+      expectProjectionError('CORE_PROJECTION_SOURCE_INVALID'),
+    );
+  });
+
+  it('compares an explicitly selected numeric observation to matching gold', async () => {
+    const source = await storedScenario('rag');
+    const selected = source.evaluation.records.filter((record) => (
+      record.targetId === 'control' && record.evaluationStatus === 'completed'
+    ));
+    const annotations = selected.map((record) => {
+      const observation = record.evaluationStatus === 'completed'
+        ? record.observations.find((entry) => entry.metricId === 'ndcg')
+        : undefined;
+      assert.ok(observation?.observationStatus === 'observed');
+      assert.equal(observation.valueType, 'numeric');
+      return { sample_id: record.sampleId, score: observation.value };
+    });
+    const result = compareGoldToCoreRun({
+      source,
+      gold: {
+        metadata: {
+          annotator: 'independent-human-panel',
+          annotatedAt: '2026-08-30',
+          version: '1',
+          scale: { min: 0, max: 1 },
+        },
+        annotations: [
+          ...annotations,
+          { sample_id: 'missing-sample', score: 0.5 },
+        ],
+        sourcePaths: ['/gold/annotations.yaml'],
+      },
+      selector: {
+        targetId: 'control',
+        evaluatorId: 'retrieval',
+        metricId: 'ndcg',
+        instrumentId: 'retrieval-metrics',
+        ensembleMemberId: 'retrieval-local',
+        replicateGroupId: 'retrieval-primary',
+        replicateIndex: 0,
+        trialIndex: 0,
+      },
+      bootstrapSamples: 20,
+      bootstrapSeed: 42,
+    });
+
+    assert.equal(result.projectionKind, 'core-gold-comparison');
+    assert.equal(result.agreement.sampleCount, 2);
+    assert.equal(result.agreement.alpha, 1);
+    assert.deepEqual(result.missingSampleIds, ['missing-sample']);
+    assert.deepEqual(result.unscoredSampleIds, []);
+    assert.ok(result.rows.every((row) => row.difference === 0));
+    assert.equal(result.contaminationWarning, undefined);
+    assert.match(result.gold.datasetDigest, /^sha256:[0-9a-f]{64}$/);
+
+    const empty = compareGoldToCoreRun({
+      source,
+      gold: {
+        metadata: {
+          annotator: 'independent-human-panel',
+          annotatedAt: '2026-08-30',
+          version: '1',
+          scale: { min: 0, max: 1 },
+        },
+        annotations: [{ sample_id: 'missing-sample', score: 0.5 }],
+        sourcePaths: ['/gold/annotations.yaml'],
+      },
+      selector: {
+        targetId: 'control',
+        evaluatorId: 'retrieval',
+        metricId: 'ndcg',
+        trialIndex: 0,
+      },
+      bootstrapSamples: 20,
+      bootstrapSeed: 42,
+    });
+    assert.equal(empty.agreement.alpha, null);
+    assert.equal(empty.agreement.weightedKappa, null);
+    assert.doesNotThrow(() => JSON.parse(JSON.stringify(empty)) as unknown);
+  });
+
+  it('rejects incompatible scales and implicit pooling across trials', async () => {
+    const source = await storedScenario('rag', (definition) => {
+      definition.experiment.trials = 2;
+      definition.experiment.sampling.repeatedMeasures = true;
+    });
+    const base = {
+      source,
+      gold: {
+        metadata: {
+          annotator: 'human',
+          annotatedAt: '2026-08-30',
+          version: '1',
+          scale: { min: 0, max: 1 },
+        },
+        annotations: [{ sample_id: 'sample-1', score: 1 }],
+        sourcePaths: ['/gold/annotations.yaml'],
+      },
+      selector: {
+        targetId: 'control',
+        evaluatorId: 'retrieval',
+        metricId: 'ndcg',
+      },
+    } as const;
+    let ambiguity: unknown;
+    try {
+      compareGoldToCoreRun(base);
+    } catch (error: unknown) {
+      ambiguity = error;
+    }
+    assert.ok(expectProjectionError('CORE_GOLD_OBSERVATION_AMBIGUOUS')(ambiguity));
+    assert.ok(ambiguity instanceof Error);
+    assert.ok(!ambiguity.message.includes('sample-1'));
+    assert.throws(
+      () => compareGoldToCoreRun({
+        ...base,
+        gold: {
+          ...base.gold,
+          metadata: { ...base.gold.metadata, scale: { min: 1, max: 5 } },
+        },
+        selector: { ...base.selector, trialIndex: 0 },
+      }),
+      expectProjectionError('CORE_GOLD_SCALE_INCOMPATIBLE'),
+    );
+  });
+});
+
+const seriesOutputSchema = {
+  schemaVersion: 'omk.test-series-scalar/v1',
+  schemaUri: 'urn:omk:test-series-scalar:v1',
+  schemaDigest: digestCanonicalJson({ schema: 'test-series-scalar', version: 1 }),
+};
+
+function seriesIdentity(implementationId: string): RuntimeIdentity {
+  return {
+    implementationId,
+    version: '1.0.0',
+    fingerprint: digestCanonicalJson({ implementationId, version: 1 }),
+    fingerprintBasis: 'content-derived',
+    assuranceLevel: 'verified',
+    capabilities: { experimentalUnit: 'run' },
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
+  };
+}
+
+function seriesDefinition(): EvaluationSeriesDefinitionInput {
+  return {
+    schemaVersion: 'omk.evaluation-series-definition/v1',
+    seriesId: 'evolution-series',
+    analysisMode: 'preregistered',
+    experimentalUnit: 'run',
+    members: [
+      { memberId: 'candidate-a', replicateIndex: 0 },
+      { memberId: 'candidate-b', replicateIndex: 1 },
+    ],
+    comparabilityPolicy: {
+      designMode: 'exact-measurement-design',
+      comparisonScope: 'analysis',
+      minimumStatus: 'conditional',
+    },
+    analysisGraph: {
+      nodes: [{
+        nodeId: 'progress-analysis',
+        implementationId: 'series-progress/v1',
+        analysisStandardId: 'series-progress/v1',
+        minimumMemberEvidenceStatus: 'complete',
+        inputs: [{ seriesInputKind: 'members', referenceId: 'evolution-series' }],
+        outputResultId: 'progress-result',
+      }],
+    },
+    decisionPolicy: {
+      decisionPolicyId: 'evolution-gate',
+      implementationId: 'evolution-gate/v1',
+      analysisResultIds: ['progress-result'],
+      minimumCoverageRatio: 1,
+      minimumMemberEvidenceStatus: 'complete',
+    },
+  };
+}
+
+async function seriesMemberResult(
+  series: EvaluationSeriesDefinition,
+  memberId: string,
+  replicateIndex: number,
+): Promise<ConformanceResult> {
+  const plan = await prepareConformancePlan('function', (definition) => {
+    definition.seriesMembership = {
+      seriesDesignDigest: series.seriesDesignDigest,
+      memberId,
+      replicateIndex,
+    };
+  });
+  return runConformanceScenario('function', {
+    runId: `series-${memberId}`,
+    plan,
+  });
+}
+
+describe('Evaluation Core evolution projection', () => {
+  it('preserves run-level Series evidence and only exposes the registered verdict', async () => {
+    const definition = createEvaluationSeriesDefinition(seriesDefinition());
+    const analysisIdentity = seriesIdentity('series-progress/v1');
+    const decisionIdentity = seriesIdentity('evolution-gate/v1');
+    const plan = prepareEvaluationSeriesPlan(definition, [
+      {
+        runtimeKind: 'series-analysis-node',
+        referenceId: 'progress-analysis',
+        identity: analysisIdentity,
+        outputSchema: seriesOutputSchema,
+      },
+      {
+        runtimeKind: 'series-decision-policy',
+        referenceId: 'evolution-gate',
+        identity: decisionIdentity,
+      },
+    ]);
+    const first = await seriesMemberResult(definition, 'candidate-a', 0);
+    const second = await seriesMemberResult(definition, 'candidate-b', 1);
+    const members = [
+      createEvaluationSeriesMemberSource({
+        memberId: 'candidate-a',
+        replicateIndex: 0,
+        plan: first.plan,
+        execution: first.executionSource,
+        evaluation: first.evaluationSource,
+        analysis: first.analysisSource,
+        ...(first.decisionSource === undefined ? {} : { decision: first.decisionSource }),
+        report: first.report,
+      }),
+      createEvaluationSeriesMemberSource({
+        memberId: 'candidate-b',
+        replicateIndex: 1,
+        plan: second.plan,
+        execution: second.executionSource,
+        evaluation: second.evaluationSource,
+        analysis: second.analysisSource,
+        ...(second.decisionSource === undefined ? {} : { decision: second.decisionSource }),
+        report: second.report,
+      }),
+    ];
+    const result = await runEvaluationSeries(plan, members, {
+      analysisNodesByNodeId: new Map([['progress-analysis', {
+        identity: analysisIdentity,
+        outputSchema: seriesOutputSchema,
+        async analyze(context) {
+          return {
+            analysisStatus: 'completed' as const,
+            resultType: 'scalar' as const,
+            value: context.coverage.comparable / context.coverage.planned,
+            assumptionChecks: [{
+              assumptionId: 'all-runs-comparable',
+              checkStatus: 'passed' as const,
+            }],
+          };
+        },
+      }]]),
+      decisionPoliciesByDecisionPolicyId: new Map([['evolution-gate', {
+        identity: decisionIdentity,
+        async decide() {
+          return {
+            decisionStatus: 'decided' as const,
+            verdict: 'progress-supported',
+            reasonCodes: ['series-evidence-passed'],
+          };
+        },
+      }]]),
+      schemaValidators: new Map([[schemaIdentityKey(seriesOutputSchema), {
+        schema: seriesOutputSchema,
+        parse(value: unknown) {
+          return value as never;
+        },
+      }]]),
+    }, {
+      bundleId: 'evolution-analysis',
+      reportId: 'evolution-report',
+    });
+
+    const projection = projectCoreEvolutionEvidence({
+      plan,
+      analysis: result.analysis,
+      report: result.report,
+    });
+    assert.equal(projection.experimentalUnit, 'run');
+    assert.equal(projection.evidenceReadiness, 'decision-ready');
+    assert.deepEqual(projection.members.map((member) => member.comparabilityStatus), [
+      'anchor',
+      'conditional',
+    ]);
+    assert.equal(projection.analyses[0].analysisStatus, 'completed');
+    assert.deepEqual(projection.decision, {
+      decisionStatus: 'decided',
+      decisionPolicyId: 'evolution-gate',
+      verdict: 'progress-supported',
+      reasonCodes: ['series-evidence-passed'],
+      decisionDigest: result.decision?.decisionDigest,
+    });
+
+    const mismatched = structuredClone(result.report);
+    mismatched.seriesPlanDigest = digestCanonicalJson({ mismatch: true });
+    assert.throws(
+      () => projectCoreEvolutionEvidence({ plan, analysis: result.analysis, report: mismatched }),
+      expectProjectionError('CORE_SERIES_SOURCE_INVALID'),
+    );
+  });
+});


### PR DESCRIPTION
Closes #531
Part of #450

## 用户影响

- 为已持久化的 Evaluation Core run 提供原生 artifact graph 投影，图节点和血缘直接来自 Plan、Bundle 与 Report，不再依赖旧结果行语义。
- 为 gold comparison 提供显式 Target／Evaluator／Metric 选择器；多 trial／replicate 匹配歧义与量尺不一致会显式失败，不会暗自平均或换算。
- 为 evolve／authoring 提供基于 Evaluation Series 的跨 run 证据视图，保持 run 为实验单位，只暴露注册 Analysis 与 Decision，不从展示分数推断 winner。

## 架构边界

- 新投影不导入旧 Report、VariantResult 或 ResultEntry，也不接入旧生产 CLI；正式切换仍由 #450 的独立 BREAKING-SCHEMA 变更完成。
- artifact graph 不包含原始 input、expected、output、trace、evidence 或错误文本；evidence reference 绑定精确 Core 文档 hash 与 JSON pointer。
- Series projection 同时校验 Plan、Analysis Bundle、Report、resolved Runtime identity、output schema 与 Decision policy 的精确链路。

## 测量学说明

- 不修改评分 prompt、五层评分管道、Bootstrap CI 或 Krippendorff alpha 公式，不构成 BREAKING-COMPARABILITY。
- 图状态只来自显式 stage 状态；数值 observation 仅作为视图 metric，不按展示阈值生成 verdict。
- Gold 与 Core Metric 的 scale 必须完全一致；需要 rescale 时应进入预注册 Analysis。

## 迁移说明

本 PR 只新增 Core 原生公开 API，无历史数据迁移或双写。旧 evolve、gold、artifact graph 命令继续使用旧 pipeline，直到最终 CLI cutover。
