### PR TITLE
feat(server): 建立 Core Studio 只读投影

### DIFF
--- a/docs/specs/evaluation-studio-projection.md
+++ b/docs/specs/evaluation-studio-projection.md
@@ -1,0 +1,46 @@
+# Evaluation Core Studio projection
+
+> Status: read-only catalog and view-model boundary for [#535](https://github.com/lizhiyao/oh-my-knowledge/issues/535). It does not switch Studio routes or renderers and does not read legacy reports.
+
+## 1. Authority boundary
+
+Studio is a consumer of Evaluation Core facts, never a second report model. `CoreRunArtifactStore` remains responsible for schema, digest, content-closure, and lineage validation. `createCoreStudioCatalog()` accepts that store port and adds no filesystem, server, or renderer dependency.
+
+The catalog has three operations:
+
+- `list()` projects validated manifest index cards and never loads full artifacts;
+- `inspect(runId)` performs the same point lookup without claiming content availability;
+- `get(runId)` loads the complete validated artifact set before building a detail view.
+
+Project/global behavior comes from `createOverlayCoreRunArtifactStore()`. Identical artifact sets under one `runId` deduplicate. Different artifact sets fail with the existing stable overlay conflict code. Studio does not invent a weaker conflict policy.
+
+## 2. Versioned views
+
+`omk.studio-core-run-card/v1` contains only manifest facts: run/report identity, artifact-set digest, creation time, orthogonal run/evidence/conclusion status, replayability, and maximum captured classification.
+
+`omk.studio-core-run-detail/v1` additionally projects:
+
+- Dataset identity and sample count, never Sample inputs;
+- Target, Evaluator, measurement, and Metric definitions without config;
+- stage Bundle identity, direct-parent lineage, explicit status, coverage, replayability, budget aggregate, and redacted provenance;
+- Execution and Evaluation coordinate identity, status, duration, safe usage, cache status, and error/reason codes;
+- numeric Metric observations only; boolean, categorical, text, and ranking values remain hidden;
+- Analysis identity, output schema version/digest, coverage, exclusion count, assumption status, and finite scalar numeric values only;
+- registered Decision status, verdict, reason codes, and exact Analysis result references;
+- all five manifest document identities and full-document digests, without filenames or paths.
+
+Both projections are canonical JSON-safe, deeply frozen values. Undefined numeric results are omitted rather than converted to zero.
+
+## 3. Privacy and construct validity
+
+The detail view deliberately omits raw input, execution context, expected value, evaluation context, output, trace, evaluator evidence/metadata, Gold, arbitrary Analysis tables, Runtime capabilities/facets, provenance facets/source identifiers, usage details, extensions, and error messages.
+
+This is a semantic allow-list. A later renderer cannot treat uncaptured evidence as an empty value or expose protected content because those fields never cross the projection boundary. New result types require an explicit schema-specific projection; generic object traversal is prohibited.
+
+View status never derives from score thresholds. Run status, evidence status, and conclusion status remain orthogonal. Stage failures, cancellation, budget exhaustion, missing observations, inconclusive Analysis, and not-decided Decision retain their Core states and reason codes.
+
+## 4. Migration boundary
+
+The Core Studio modules do not import legacy `ReportStore`, `EvaluationReport`, `VariantResult`, or result rows. The current server, skill index, routes, and renderers remain unchanged in this slice. A later PR will switch those consumers to the versioned views in one direction; no legacy reader, adapter, shadow read, or dual view is introduced.
+
+The final `omk eval` and report-wire cutover remains the separate `BREAKING-SCHEMA` step in [#450](https://github.com/lizhiyao/oh-my-knowledge/issues/450). This projection changes no evaluator, analysis formula, prompt, missing-data policy, or verdict semantics and is not `BREAKING-COMPARABILITY`.

--- a/docs/zh/specs/evaluation-studio-projection.md
+++ b/docs/zh/specs/evaluation-studio-projection.md
@@ -1,0 +1,46 @@
+# Evaluation Core Studio 投影
+
+> 状态：[#535](https://github.com/lizhiyao/oh-my-knowledge/issues/535) 的只读 catalog 与 view model 边界。本阶段不切换 Studio route／renderer，也不读取旧报告。
+
+## 一、权威边界
+
+Studio 只是 Evaluation Core 事实的 consumer，不是第二套报告模型。`CoreRunArtifactStore` 继续负责 schema、digest、content closure 与 lineage 校验。`createCoreStudioCatalog()` 只接收该 store port，不引入文件系统、server 或 renderer 依赖。
+
+catalog 提供三种操作：
+
+- `list()` 只投影已校验的 manifest index card，不加载完整 artifacts；
+- `inspect(runId)` 执行同语义的点查询，不声称 content 可用；
+- `get(runId)` 必须先加载并校验完整 artifact set，再构建 detail view。
+
+project／global 行为复用 `createOverlayCoreRunArtifactStore()`。同一 `runId` 的相同 artifact set 去重，不同 artifact set 使用现有稳定 overlay conflict code 显式失败。Studio 不另造更宽松的冲突策略。
+
+## 二、版本化视图
+
+`omk.studio-core-run-card/v1` 只包含 manifest 事实：run／report identity、artifact-set digest、创建时间、正交的 run／evidence／conclusion status、replayability 与最高 captured classification。
+
+`omk.studio-core-run-detail/v1` 进一步投影：
+
+- Dataset identity 与 sample count，不包含 Sample input；
+- Target、Evaluator、measurement 与 Metric definition，不包含 config；
+- stage Bundle identity、直接 parent lineage、显式状态、coverage、replayability、budget aggregate 与脱敏 provenance；
+- Execution／Evaluation coordinate identity、状态、duration、安全 usage、cache status 与 error／reason code；
+- 只投影数值 Metric observation；boolean、categorical、text 与 ranking value 继续隐藏；
+- Analysis identity、output schema version／digest、coverage、exclusion count、assumption status，以及有限 scalar 数值；
+- 已注册 Decision 的状态、verdict、reason code 与精确 Analysis result reference；
+- manifest 中五份文档的 identity 与完整 document digest，不包含 filename 或 path。
+
+两种 projection 都是 canonical、JSON-safe 且深冻结的值。未定义数值不折算为零，而是直接省略。
+
+## 三、隐私与 construct validity
+
+detail view 明确省略原始 input、execution context、expected、evaluation context、output、trace、evaluator evidence／metadata、Gold、任意 Analysis table、Runtime capability／facet、provenance facet／source identifier、usage details、extension 与 error message。
+
+这是语义 allow-list。后续 renderer 无法把未捕获 evidence 当作空值，也无法泄漏受保护内容，因为这些字段不会跨过 projection 边界。新增 result type 必须建立显式的 schema-specific projection，禁止遍历任意对象直接展示。
+
+视图状态不从分数阈值推导。run status、evidence status 与 conclusion status 保持正交；stage failure、cancel、budget exhaustion、missing observation、inconclusive Analysis 与 not-decided Decision 都保留 Core 原始状态和 reason code。
+
+## 四、迁移边界
+
+Core Studio 模块不导入旧 `ReportStore`、`EvaluationReport`、`VariantResult` 或结果行。本切片不修改现有 server、skill index、route 与 renderer；后续 PR 会把 consumer 单向切到版本化 view，不引入 legacy reader、adapter、shadow read 或双视图。
+
+最终 `omk eval` 与报告 wire 切换仍是 [#450](https://github.com/lizhiyao/oh-my-knowledge/issues/450) 下独立的 `BREAKING-SCHEMA` 步骤。本 projection 不改变 evaluator、analysis formula、prompt、missing-data policy 或 verdict 语义，因此不属于 `BREAKING-COMPARABILITY`。

--- a/src/eval-workflows/studio-catalog/catalog.ts
+++ b/src/eval-workflows/studio-catalog/catalog.ts
@@ -1,0 +1,26 @@
+import type { CoreRunArtifactStore } from '../artifact-store/index.js';
+import type { CoreStudioCatalog } from './contracts.js';
+import {
+  projectCoreStudioRunCard,
+  projectCoreStudioRunDetail,
+} from './projection.js';
+
+export function createCoreStudioCatalog(
+  store: CoreRunArtifactStore,
+): CoreStudioCatalog {
+  async function list() {
+    return (await store.list()).map(projectCoreStudioRunCard);
+  }
+
+  async function get(runId: string) {
+    const source = await store.get(runId);
+    return source === undefined ? undefined : projectCoreStudioRunDetail(source);
+  }
+
+  async function inspect(runId: string) {
+    const card = await store.inspect(runId);
+    return card === undefined ? undefined : projectCoreStudioRunCard(card);
+  }
+
+  return Object.freeze({ list, get, inspect });
+}

--- a/src/eval-workflows/studio-catalog/contracts.ts
+++ b/src/eval-workflows/studio-catalog/contracts.ts
@@ -1,0 +1,245 @@
+import type {
+  AnalysisObservationCoverage,
+  AnalysisCoverage,
+  BudgetTermination,
+  EvaluationStatus,
+  ExecutionCoverage,
+  EvaluationCoverage,
+} from '../../evaluation-core/contracts/index.js';
+
+export const CORE_STUDIO_RUN_CARD_SCHEMA_VERSION =
+  'omk.studio-core-run-card/v1' as const;
+export const CORE_STUDIO_RUN_DETAIL_SCHEMA_VERSION =
+  'omk.studio-core-run-detail/v1' as const;
+
+export interface CoreStudioRunCard {
+  readonly cardKind: 'studio-core-run-card';
+  readonly schemaVersion: typeof CORE_STUDIO_RUN_CARD_SCHEMA_VERSION;
+  readonly runId: string;
+  readonly reportId: string;
+  readonly runContractDigest: string;
+  readonly reportDigest: string;
+  readonly artifactSetDigest: string;
+  readonly createdAt: string;
+  readonly status: EvaluationStatus;
+  readonly replayability: {
+    readonly execution: 'self-contained' | 'resolvable' | 'summary-only';
+    readonly evaluation: 'self-contained' | 'resolvable' | 'summary-only';
+  };
+  readonly maximumCapturedClassification: 'public' | 'sensitive' | 'secret' | 'gold';
+}
+
+export interface CoreStudioRuntimeIdentity {
+  readonly implementationId: string;
+  readonly version?: string;
+  readonly fingerprint: string;
+  readonly fingerprintBasis: 'content-derived' | 'environment-derived' | 'self-reported' | 'opaque';
+  readonly assuranceLevel: 'verified' | 'declared' | 'unknown';
+}
+
+export interface CoreStudioProvenance {
+  readonly provenanceKind: 'native' | 'imported' | 'replay' | 'derived';
+  readonly trust: 'verified' | 'declared' | 'untrusted' | 'unknown';
+  readonly parentDigests: readonly string[];
+}
+
+export interface CoreStudioUsage {
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly totalTokens?: number;
+  readonly providerCost?: {
+    readonly amount: number;
+    readonly currency: string;
+  };
+}
+
+export interface CoreStudioBudget {
+  readonly summaryStatus: 'within-budget' | 'exhausted' | 'unverifiable' | 'cancelled' | 'failed';
+  readonly admissionMode: 'strict-reservation' | 'bounded-overshoot';
+  readonly invocations: number;
+  readonly activeDurationMs: number;
+  readonly reportedProviderCosts: readonly {
+    readonly amount: number;
+    readonly currency: string;
+  }[];
+  readonly unreportedProviderCostInvocations: number;
+  readonly wallClock: {
+    readonly elapsedMs: number;
+    readonly limitMs?: number;
+    readonly overshootMs: number;
+  };
+  readonly termination?: {
+    readonly terminationKind: BudgetTermination['terminationKind'];
+    readonly resourceKind?: BudgetTermination['resourceKind'];
+    readonly scopeKind?: BudgetTermination['scopeKind'];
+    readonly reasonCode: string;
+  };
+  readonly ledgerDigest: string;
+}
+
+export interface CoreStudioExecutionRecord {
+  readonly targetId: string;
+  readonly sampleId: string;
+  readonly trialIndex: number;
+  readonly trialId: string;
+  readonly executionStatus: 'completed' | 'failed' | 'cancelled' | 'budget-censored';
+  readonly runtime: CoreStudioRuntimeIdentity;
+  readonly provenance: CoreStudioProvenance;
+  readonly cacheStatus?: 'not-used' | 'miss' | 'replay' | 'transparent-hit';
+  readonly durationMs?: number;
+  readonly usage?: CoreStudioUsage;
+  readonly errorCode?: string;
+  readonly censorReasonCode?: string;
+}
+
+export interface CoreStudioMetricObservation {
+  readonly observationId: string;
+  readonly metricId: string;
+  readonly observationStatus: 'observed' | 'missing' | 'invalid';
+  readonly valueType: 'numeric' | 'boolean' | 'categorical' | 'text' | 'ranking';
+  readonly numericValue?: number;
+  readonly reasonCode?: string;
+}
+
+export interface CoreStudioEvaluationRecord {
+  readonly targetId: string;
+  readonly sampleId: string;
+  readonly trialIndex: number;
+  readonly trialId: string;
+  readonly evaluatorId: string;
+  readonly measurement: {
+    readonly instrumentId: string;
+    readonly ensembleMemberId: string;
+    readonly replicateGroupId: string;
+    readonly replicateIndex: number;
+  };
+  readonly evaluationId: string;
+  readonly evaluationStatus: 'completed' | 'failed' | 'cancelled' | 'not-evaluated';
+  readonly runtime: CoreStudioRuntimeIdentity;
+  readonly provenance: CoreStudioProvenance;
+  readonly cacheStatus?: 'not-used' | 'miss' | 'replay' | 'transparent-hit';
+  readonly durationMs?: number;
+  readonly usage?: CoreStudioUsage;
+  readonly observations: readonly CoreStudioMetricObservation[];
+  readonly errorCode?: string;
+  readonly notEvaluatedReasonCode?: string;
+}
+
+export type CoreStudioAnalysisRecord = {
+  readonly resultId: string;
+  readonly nodeId: string;
+  readonly analysisNodeKind: 'reducer' | 'estimator' | 'correction';
+  readonly analysisStatus: 'completed' | 'inconclusive' | 'failed' | 'not-evaluated';
+  readonly analysisMode: 'preregistered' | 'exploratory';
+  readonly runtime: CoreStudioRuntimeIdentity;
+  readonly outputSchema: {
+    readonly schemaVersion: string;
+    readonly schemaDigest: string;
+  };
+  readonly coverage: AnalysisObservationCoverage;
+  readonly exclusionCount: number;
+  readonly assumptionChecks: readonly {
+    readonly assumptionId: string;
+    readonly checkStatus: 'passed' | 'failed' | 'not-evaluated';
+    readonly reasonCode?: string;
+  }[];
+  readonly recordDigest: string;
+  readonly resultType?: 'scalar' | 'interval' | 'distribution' | 'table' | 'matrix' | 'curve';
+  readonly numericValue?: number;
+  readonly reasonCodes?: readonly string[];
+  readonly errorCode?: string;
+};
+
+export interface CoreStudioDecision {
+  readonly decisionPolicyId: string;
+  readonly decisionStatus: 'decided' | 'not-decided' | 'failed';
+  readonly implementation: CoreStudioRuntimeIdentity;
+  readonly analysisResultIds: readonly string[];
+  readonly decisionDigest: string;
+  readonly verdict?: string;
+  readonly reasonCodes?: readonly string[];
+  readonly errorCode?: string;
+}
+
+export interface CoreStudioRunDetail {
+  readonly detailKind: 'studio-core-run-detail';
+  readonly schemaVersion: typeof CORE_STUDIO_RUN_DETAIL_SCHEMA_VERSION;
+  readonly run: CoreStudioRunCard;
+  readonly dataset: {
+    readonly datasetId: string;
+    readonly datasetRevisionDigest: string;
+    readonly sampleCount: number;
+  };
+  readonly targets: readonly {
+    readonly targetId: string;
+    readonly targetKind: string;
+    readonly protocolId: 'omk.invoke/v1' | 'omk.session/v1';
+    readonly executorId: string;
+  }[];
+  readonly evaluators: readonly {
+    readonly evaluatorId: string;
+    readonly evaluatorKind: string;
+    readonly implementationId: string;
+    readonly metricIds: readonly string[];
+    readonly measurement: {
+      readonly instrumentId: string;
+      readonly ensembleMemberId: string;
+      readonly replicateGroupId: string;
+      readonly replicateIndex: number;
+    };
+  }[];
+  readonly metrics: readonly {
+    readonly metricId: string;
+    readonly valueType: 'numeric' | 'boolean' | 'categorical' | 'text' | 'ranking';
+    readonly scope: 'sample' | 'target' | 'comparison' | 'run';
+    readonly scale?: { readonly min?: number; readonly max?: number; readonly target?: number };
+    readonly unit?: string;
+    readonly direction?: 'higher-is-better' | 'lower-is-better' | 'target-is-best';
+  }[];
+  readonly stages: {
+    readonly execution: {
+      readonly bundleId: string;
+      readonly bundleDigest: string;
+      readonly stageStatus: 'completed' | 'cancelled' | 'budget-exhausted' | 'failed';
+      readonly coverage: ExecutionCoverage;
+      readonly replayability: 'self-contained' | 'resolvable' | 'summary-only';
+      readonly budget: CoreStudioBudget;
+      readonly provenance: CoreStudioProvenance;
+      readonly records: readonly CoreStudioExecutionRecord[];
+    };
+    readonly evaluation: {
+      readonly bundleId: string;
+      readonly bundleDigest: string;
+      readonly parentExecutionBundleDigest: string;
+      readonly stageStatus: 'completed' | 'cancelled' | 'budget-exhausted' | 'failed';
+      readonly coverage: EvaluationCoverage;
+      readonly replayability: 'self-contained' | 'resolvable' | 'summary-only';
+      readonly budget: CoreStudioBudget;
+      readonly provenance: CoreStudioProvenance;
+      readonly records: readonly CoreStudioEvaluationRecord[];
+    };
+    readonly analysis: {
+      readonly bundleId: string;
+      readonly bundleDigest: string;
+      readonly parentEvaluationBundleDigest: string;
+      readonly stageStatus: 'completed' | 'cancelled' | 'failed';
+      readonly coverage: AnalysisCoverage;
+      readonly provenance: CoreStudioProvenance;
+      readonly records: readonly CoreStudioAnalysisRecord[];
+    };
+  };
+  readonly decision?: CoreStudioDecision;
+  readonly reportProvenance: CoreStudioProvenance;
+  readonly lineage: readonly {
+    readonly documentKind: 'run-plan' | 'execution-bundle' | 'evaluation-bundle' | 'analysis-bundle' | 'evaluation-report';
+    readonly schemaVersion: string;
+    readonly identityDigest: string;
+    readonly documentDigest: string;
+  }[];
+}
+
+export interface CoreStudioCatalog {
+  list(): Promise<CoreStudioRunCard[]>;
+  get(runId: string): Promise<CoreStudioRunDetail | undefined>;
+  inspect(runId: string): Promise<CoreStudioRunCard | undefined>;
+}

--- a/src/eval-workflows/studio-catalog/index.ts
+++ b/src/eval-workflows/studio-catalog/index.ts
@@ -1,0 +1,3 @@
+export * from './catalog.js';
+export * from './contracts.js';
+export * from './projection.js';

--- a/src/eval-workflows/studio-catalog/projection.ts
+++ b/src/eval-workflows/studio-catalog/projection.ts
@@ -1,0 +1,357 @@
+import {
+  deepFreezeCanonicalJson,
+  type BudgetSummary,
+  type EvaluationRecord,
+  type ExecutionRecord,
+  type JsonValue,
+  type MetricObservation,
+  type Provenance,
+  type RuntimeIdentity,
+  type UsageRecord,
+} from '../../evaluation-core/contracts/index.js';
+import {
+  projectCoreRunArtifactIndexCard,
+  type CoreRunArtifactIndexCard,
+  type StoredCoreRunArtifacts,
+} from '../artifact-store/index.js';
+import { assertCoreProjectionSource } from '../downstream-projections/source.js';
+import {
+  CORE_STUDIO_RUN_CARD_SCHEMA_VERSION,
+  CORE_STUDIO_RUN_DETAIL_SCHEMA_VERSION,
+  type CoreStudioAnalysisRecord,
+  type CoreStudioBudget,
+  type CoreStudioDecision,
+  type CoreStudioEvaluationRecord,
+  type CoreStudioExecutionRecord,
+  type CoreStudioMetricObservation,
+  type CoreStudioProvenance,
+  type CoreStudioRunCard,
+  type CoreStudioRunDetail,
+  type CoreStudioRuntimeIdentity,
+  type CoreStudioUsage,
+} from './contracts.js';
+
+function freezeView<T>(value: T): T {
+  return deepFreezeCanonicalJson(value as unknown as JsonValue) as unknown as T;
+}
+
+function runtime(identity: RuntimeIdentity): CoreStudioRuntimeIdentity {
+  return {
+    implementationId: identity.implementationId,
+    ...(identity.version === undefined ? {} : { version: identity.version }),
+    fingerprint: identity.fingerprint,
+    fingerprintBasis: identity.fingerprintBasis,
+    assuranceLevel: identity.assuranceLevel,
+  };
+}
+
+function provenance(value: Provenance): CoreStudioProvenance {
+  return {
+    provenanceKind: value.provenanceKind,
+    trust: value.trust,
+    parentDigests: [...value.parentDigests],
+  };
+}
+
+function usage(value: UsageRecord | undefined): CoreStudioUsage | undefined {
+  if (value === undefined) return undefined;
+  return {
+    ...(value.inputTokens === undefined ? {} : { inputTokens: value.inputTokens }),
+    ...(value.outputTokens === undefined ? {} : { outputTokens: value.outputTokens }),
+    ...(value.totalTokens === undefined ? {} : { totalTokens: value.totalTokens }),
+    ...(value.providerCost === undefined ? {} : {
+      providerCost: {
+        amount: value.providerCost.amount,
+        currency: value.providerCost.currency,
+      },
+    }),
+  };
+}
+
+function budget(summary: BudgetSummary): CoreStudioBudget {
+  const run = summary.scopes.find((scope) => scope.scopeKind === 'run');
+  const totals = run?.totals ?? {
+    invocations: summary.entries.length,
+    activeDurationMs: summary.entries.reduce((sum, entry) => (
+      sum + entry.activeDurationMs
+    ), 0),
+    reportedProviderCosts: undefined,
+    unreportedProviderCostInvocations: summary.entries.filter((entry) => (
+      entry.providerCostStatus === 'unreported'
+    )).length,
+  };
+  return {
+    summaryStatus: summary.summaryStatus,
+    admissionMode: summary.admissionMode,
+    invocations: totals.invocations,
+    activeDurationMs: totals.activeDurationMs,
+    reportedProviderCosts: (totals.reportedProviderCosts ?? []).map((cost) => ({
+      amount: cost.amount,
+      currency: cost.currency,
+    })),
+    unreportedProviderCostInvocations: totals.unreportedProviderCostInvocations,
+    wallClock: {
+      elapsedMs: summary.wallClock.elapsedMs,
+      ...(summary.wallClock.limitMs === undefined ? {} : {
+        limitMs: summary.wallClock.limitMs,
+      }),
+      overshootMs: summary.wallClock.overshootMs,
+    },
+    ...(summary.termination === undefined ? {} : {
+      termination: {
+        terminationKind: summary.termination.terminationKind,
+        ...(summary.termination.resourceKind === undefined ? {} : {
+          resourceKind: summary.termination.resourceKind,
+        }),
+        ...(summary.termination.scopeKind === undefined ? {} : {
+          scopeKind: summary.termination.scopeKind,
+        }),
+        reasonCode: summary.termination.reasonCode,
+      },
+    }),
+    ledgerDigest: summary.ledgerDigest,
+  };
+}
+
+function executionRecord(record: ExecutionRecord): CoreStudioExecutionRecord {
+  const base = {
+    targetId: record.targetId,
+    sampleId: record.sampleId,
+    trialIndex: record.trialIndex,
+    trialId: record.trialId,
+    executionStatus: record.executionStatus,
+    runtime: runtime(record.runtime),
+    provenance: provenance(record.provenance),
+  };
+  if (record.executionStatus === 'budget-censored') {
+    return { ...base, censorReasonCode: record.censorReasonCode };
+  }
+  const projectedUsage = usage(record.usage);
+  return {
+    ...base,
+    cacheStatus: record.cache.cacheStatus,
+    ...(record.timing.durationMs === undefined ? {} : {
+      durationMs: record.timing.durationMs,
+    }),
+    ...(projectedUsage === undefined ? {} : { usage: projectedUsage }),
+    ...(record.executionStatus === 'failed' ? { errorCode: record.error.code } : {}),
+    ...(record.executionStatus === 'cancelled' && record.error !== undefined
+      ? { errorCode: record.error.code }
+      : {}),
+  };
+}
+
+function metricObservation(observation: MetricObservation): CoreStudioMetricObservation {
+  return {
+    observationId: observation.observationId,
+    metricId: observation.metricId,
+    observationStatus: observation.observationStatus,
+    valueType: observation.valueType,
+    ...(observation.observationStatus === 'observed'
+      && observation.valueType === 'numeric'
+      ? { numericValue: observation.value }
+      : {}),
+    ...(observation.observationStatus !== 'observed'
+      ? { reasonCode: observation.reasonCode }
+      : {}),
+  };
+}
+
+function evaluationRecord(record: EvaluationRecord): CoreStudioEvaluationRecord {
+  const base = {
+    targetId: record.targetId,
+    sampleId: record.sampleId,
+    trialIndex: record.trialIndex,
+    trialId: record.trialId,
+    evaluatorId: record.evaluatorId,
+    measurement: record.measurement,
+    evaluationId: record.evaluationId,
+    evaluationStatus: record.evaluationStatus,
+    runtime: runtime(record.runtime),
+    provenance: provenance(record.provenance),
+  };
+  if (record.evaluationStatus === 'not-evaluated') {
+    return {
+      ...base,
+      observations: [],
+      notEvaluatedReasonCode: record.notEvaluatedReasonCode,
+    };
+  }
+  const projectedUsage = usage(record.usage);
+  return {
+    ...base,
+    cacheStatus: record.cache.cacheStatus,
+    ...(record.timing.durationMs === undefined ? {} : {
+      durationMs: record.timing.durationMs,
+    }),
+    ...(projectedUsage === undefined ? {} : { usage: projectedUsage }),
+    observations: record.evaluationStatus === 'completed'
+      ? record.observations.map(metricObservation)
+      : [],
+    ...(record.evaluationStatus === 'failed' ? { errorCode: record.error.code } : {}),
+    ...(record.evaluationStatus === 'cancelled' && record.error !== undefined
+      ? { errorCode: record.error.code }
+      : {}),
+  };
+}
+
+function analysisRecord(
+  record: StoredCoreRunArtifacts['analysis']['records'][number],
+): CoreStudioAnalysisRecord {
+  const base = {
+    resultId: record.resultId,
+    nodeId: record.nodeId,
+    analysisNodeKind: record.analysisNodeKind,
+    analysisStatus: record.analysisStatus,
+    analysisMode: record.analysisMode,
+    runtime: runtime(record.implementation),
+    outputSchema: {
+      schemaVersion: record.outputSchema.schemaVersion,
+      schemaDigest: record.outputSchema.schemaDigest,
+    },
+    coverage: record.coverage,
+    exclusionCount: record.exclusions.length,
+    assumptionChecks: record.assumptionChecks.map((check) => ({
+      assumptionId: check.assumptionId,
+      checkStatus: check.checkStatus,
+      ...(check.reasonCode === undefined ? {} : { reasonCode: check.reasonCode }),
+    })),
+    recordDigest: record.recordDigest,
+  };
+  if (record.analysisStatus === 'completed') {
+    return {
+      ...base,
+      resultType: record.resultType,
+      ...(record.resultType === 'scalar'
+        && typeof record.value === 'number'
+        && Number.isFinite(record.value)
+        ? { numericValue: record.value }
+        : {}),
+    };
+  }
+  if (record.analysisStatus === 'failed') {
+    return { ...base, errorCode: record.error.code };
+  }
+  return { ...base, reasonCodes: [...record.reasonCodes] };
+}
+
+function decision(
+  value: StoredCoreRunArtifacts['report']['decision'],
+): CoreStudioDecision | undefined {
+  if (value === undefined) return undefined;
+  const base = {
+    decisionPolicyId: value.decisionPolicyId,
+    decisionStatus: value.decisionStatus,
+    implementation: runtime(value.implementation),
+    analysisResultIds: [...value.analysisResultIds],
+    decisionDigest: value.decisionDigest,
+  };
+  if (value.decisionStatus === 'decided') {
+    return {
+      ...base,
+      verdict: value.verdict,
+      reasonCodes: [...value.reasonCodes],
+    };
+  }
+  if (value.decisionStatus === 'not-decided') {
+    return { ...base, reasonCodes: [...value.reasonCodes] };
+  }
+  return { ...base, errorCode: value.error.code };
+}
+
+export function projectCoreStudioRunCard(
+  card: Readonly<CoreRunArtifactIndexCard>,
+): CoreStudioRunCard {
+  return freezeView({
+    cardKind: 'studio-core-run-card',
+    schemaVersion: CORE_STUDIO_RUN_CARD_SCHEMA_VERSION,
+    runId: card.runId,
+    reportId: card.reportId,
+    runContractDigest: card.runContractDigest,
+    reportDigest: card.reportDigest,
+    artifactSetDigest: card.artifactSetDigest,
+    createdAt: card.createdAt,
+    status: card.status,
+    replayability: card.replayability,
+    maximumCapturedClassification: card.maximumCapturedClassification,
+  });
+}
+
+export function projectCoreStudioRunDetail(
+  source: Readonly<StoredCoreRunArtifacts>,
+): CoreStudioRunDetail {
+  assertCoreProjectionSource(source);
+  const card = projectCoreStudioRunCard(projectCoreRunArtifactIndexCard(source.manifest));
+  const projectedDecision = decision(source.report.decision);
+  return freezeView({
+    detailKind: 'studio-core-run-detail',
+    schemaVersion: CORE_STUDIO_RUN_DETAIL_SCHEMA_VERSION,
+    run: card,
+    dataset: {
+      datasetId: source.plan.definition.dataset.datasetId,
+      datasetRevisionDigest: source.plan.digests.datasetRevisionDigest,
+      sampleCount: source.plan.execution.samples.length,
+    },
+    targets: source.plan.execution.targets.map((target) => ({
+      targetId: target.targetId,
+      targetKind: target.targetKind,
+      protocolId: target.protocolId,
+      executorId: target.executorId,
+    })),
+    evaluators: source.plan.evaluation.evaluators.map((evaluator) => ({
+      evaluatorId: evaluator.evaluatorId,
+      evaluatorKind: evaluator.evaluatorKind,
+      implementationId: evaluator.implementationId,
+      metricIds: [...evaluator.metricIds],
+      measurement: evaluator.measurement,
+    })),
+    metrics: source.plan.evaluation.metrics.map((metric) => ({
+      metricId: metric.metricId,
+      valueType: metric.valueType,
+      scope: metric.scope,
+      ...(metric.scale === undefined ? {} : { scale: metric.scale }),
+      ...(metric.unit === undefined ? {} : { unit: metric.unit }),
+      ...(metric.direction === undefined ? {} : { direction: metric.direction }),
+    })),
+    stages: {
+      execution: {
+        bundleId: source.execution.bundleId,
+        bundleDigest: source.execution.bundleDigest,
+        stageStatus: source.execution.executionBundleStatus,
+        coverage: source.execution.coverage,
+        replayability: source.execution.replayability,
+        budget: budget(source.execution.budgetSummary),
+        provenance: provenance(source.execution.provenance),
+        records: source.execution.records.map(executionRecord),
+      },
+      evaluation: {
+        bundleId: source.evaluation.bundleId,
+        bundleDigest: source.evaluation.bundleDigest,
+        parentExecutionBundleDigest: source.evaluation.executionBundleDigest,
+        stageStatus: source.evaluation.evaluationBundleStatus,
+        coverage: source.evaluation.coverage,
+        replayability: source.evaluation.replayability,
+        budget: budget(source.evaluation.budgetSummary),
+        provenance: provenance(source.evaluation.provenance),
+        records: source.evaluation.records.map(evaluationRecord),
+      },
+      analysis: {
+        bundleId: source.analysis.bundleId,
+        bundleDigest: source.analysis.bundleDigest,
+        parentEvaluationBundleDigest: source.analysis.evaluationBundleDigest,
+        stageStatus: source.analysis.analysisBundleStatus,
+        coverage: source.analysis.coverage,
+        provenance: provenance(source.analysis.provenance),
+        records: source.analysis.records.map(analysisRecord),
+      },
+    },
+    ...(projectedDecision === undefined ? {} : { decision: projectedDecision }),
+    reportProvenance: provenance(source.report.provenance),
+    lineage: source.manifest.documents.map((document) => ({
+      documentKind: document.documentKind,
+      schemaVersion: document.schemaVersion,
+      identityDigest: document.identityDigest,
+      documentDigest: document.documentDigest,
+    })),
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,6 +183,28 @@ export {
   projectCoreArtifactGraph,
   projectCoreEvolutionEvidence,
 } from './eval-workflows/downstream-projections/index.js';
+
+export {
+  CORE_STUDIO_RUN_CARD_SCHEMA_VERSION,
+  CORE_STUDIO_RUN_DETAIL_SCHEMA_VERSION,
+  createCoreStudioCatalog,
+  projectCoreStudioRunCard,
+  projectCoreStudioRunDetail,
+} from './eval-workflows/studio-catalog/index.js';
+export type {
+  CoreStudioAnalysisRecord,
+  CoreStudioBudget,
+  CoreStudioCatalog,
+  CoreStudioDecision,
+  CoreStudioEvaluationRecord,
+  CoreStudioExecutionRecord,
+  CoreStudioMetricObservation,
+  CoreStudioProvenance,
+  CoreStudioRunCard,
+  CoreStudioRunDetail,
+  CoreStudioRuntimeIdentity,
+  CoreStudioUsage,
+} from './eval-workflows/studio-catalog/index.js';
 export type {
   CompareGoldToCoreRunInput,
   CoreGoldDatasetInput,

--- a/test/eval-workflows/studio-catalog-boundary.test.ts
+++ b/test/eval-workflows/studio-catalog-boundary.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('#535 Core Studio catalog boundary', () => {
+  it('does not import legacy report/storage types or switch Studio consumers', () => {
+    const files = [
+      'src/eval-workflows/studio-catalog/catalog.ts',
+      'src/eval-workflows/studio-catalog/contracts.ts',
+      'src/eval-workflows/studio-catalog/projection.ts',
+    ];
+    const source = files.map((file) => readFileSync(file, 'utf8')).join('\n');
+    expect(source).not.toContain('types/report');
+    expect(source).not.toContain('types/storage');
+    expect(source).not.toMatch(/\bReportStore\b/);
+    expect(source).not.toMatch(/\bVariantResult\b/);
+    expect(source).not.toMatch(/\bResultEntry\b/);
+    expect(source).not.toMatch(/\.llmScore\b/);
+    expect(source).not.toMatch(/\.compositeScore\b/);
+
+    const production = [
+      'src/server/report-server.ts',
+      'src/server/report-store.ts',
+      'src/server/skill-index.ts',
+      'src/cli/commands/studio.ts',
+    ].map((file) => readFileSync(file, 'utf8')).join('\n');
+    expect(production).not.toContain('studio-catalog');
+    expect(production).not.toContain('createCoreStudioCatalog');
+    expect(production).not.toContain('projectCoreStudioRunDetail');
+  });
+});

--- a/test/eval-workflows/studio-catalog.test.ts
+++ b/test/eval-workflows/studio-catalog.test.ts
@@ -1,0 +1,279 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'vitest';
+import {
+  CoreDownstreamProjectionError,
+  createCoreStudioCatalog,
+  digestCanonicalJson,
+  projectCoreStudioRunDetail,
+} from '../../src/index.js';
+import {
+  CoreRunArtifactOverlayError,
+  createNodeCoreRunArtifactStore,
+  createOverlayCoreRunArtifactStore,
+  type CoreRunArtifactStore,
+  type StoredCoreRunArtifacts,
+} from '../../src/eval-workflows/artifact-store/index.js';
+import {
+  runConformanceScenario,
+  type ConformanceHarnessOptions,
+  type ConformanceTarget,
+} from '../evaluation-core/conformance/harness.js';
+import { ConformanceFaultInjector } from '../evaluation-core/conformance/fault-injector.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => (
+    rm(path, { recursive: true, force: true })
+  )));
+});
+
+async function temporaryStore(): Promise<CoreRunArtifactStore> {
+  const root = await mkdtemp(join(tmpdir(), 'omk-core-studio-'));
+  temporaryDirectories.push(root);
+  return createNodeCoreRunArtifactStore(root);
+}
+
+async function saveScenario(input: {
+  store: CoreRunArtifactStore;
+  target: ConformanceTarget;
+  runId: string;
+  createdAt: string;
+  options?: Omit<ConformanceHarnessOptions, 'runId'>;
+}): Promise<StoredCoreRunArtifacts> {
+  const result = await runConformanceScenario(input.target, {
+    ...input.options,
+    runId: input.runId,
+  });
+  return input.store.save({
+    runId: input.runId,
+    createdAt: input.createdAt,
+    plan: result.plan,
+    execution: result.execution,
+    evaluation: result.evaluation,
+    analysis: result.analysis,
+    report: result.report,
+  });
+}
+
+describe('Core Studio catalog', () => {
+  it('lists manifest-only cards through the artifact store boundary', async () => {
+    const sourceStore = await temporaryStore();
+    await saveScenario({
+      store: sourceStore,
+      target: 'function',
+      runId: 'manifest-card',
+      createdAt: '2026-08-31T12:00:00.000Z',
+    });
+    let fullReads = 0;
+    const store: CoreRunArtifactStore = {
+      ...sourceStore,
+      async get(runId) {
+        fullReads += 1;
+        return sourceStore.get(runId);
+      },
+    };
+    const catalog = createCoreStudioCatalog(store);
+
+    const cards = await catalog.list();
+    assert.equal(fullReads, 0);
+    assert.equal(cards.length, 1);
+    assert.equal(cards[0].cardKind, 'studio-core-run-card');
+    assert.equal(cards[0].runId, 'manifest-card');
+    assert.equal(cards[0].status.runStatus, 'completed');
+    assert.ok(Object.isFrozen(cards[0]));
+
+    const inspected = await catalog.inspect('manifest-card');
+    assert.equal(fullReads, 0);
+    assert.deepEqual(inspected, cards[0]);
+    assert.equal(await catalog.inspect('missing'), undefined);
+  });
+
+  it('merges project/global cards and preserves overlay conflict failures', async () => {
+    const project = await temporaryStore();
+    const global = await temporaryStore();
+    await saveScenario({
+      store: project,
+      target: 'function',
+      runId: 'project-run',
+      createdAt: '2026-08-31T12:00:00.000Z',
+    });
+    await saveScenario({
+      store: global,
+      target: 'rag',
+      runId: 'global-run',
+      createdAt: '2026-08-31T13:00:00.000Z',
+    });
+    const catalog = createCoreStudioCatalog(
+      createOverlayCoreRunArtifactStore(project, [global]),
+    );
+    assert.deepEqual((await catalog.list()).map((card) => card.runId), [
+      'global-run',
+      'project-run',
+    ]);
+
+    const duplicateProject = await temporaryStore();
+    const duplicateGlobal = await temporaryStore();
+    await saveScenario({
+      store: duplicateProject,
+      target: 'function',
+      runId: 'identical-run',
+      createdAt: '2026-08-31T12:00:00.000Z',
+    });
+    await saveScenario({
+      store: duplicateGlobal,
+      target: 'function',
+      runId: 'identical-run',
+      createdAt: '2026-08-31T12:00:00.000Z',
+    });
+    const duplicateCatalog = createCoreStudioCatalog(
+      createOverlayCoreRunArtifactStore(duplicateProject, [duplicateGlobal]),
+    );
+    assert.deepEqual((await duplicateCatalog.list()).map((card) => card.runId), [
+      'identical-run',
+    ]);
+
+    const conflictingProject = await temporaryStore();
+    const conflictingGlobal = await temporaryStore();
+    await saveScenario({
+      store: conflictingProject,
+      target: 'function',
+      runId: 'same-run',
+      createdAt: '2026-08-31T12:00:00.000Z',
+    });
+    await saveScenario({
+      store: conflictingGlobal,
+      target: 'agent',
+      runId: 'same-run',
+      createdAt: '2026-08-31T12:00:00.000Z',
+    });
+    const conflicting = createCoreStudioCatalog(
+      createOverlayCoreRunArtifactStore(conflictingProject, [conflictingGlobal]),
+    );
+    await assert.rejects(conflicting.list(), (error: unknown) => (
+      error instanceof CoreRunArtifactOverlayError
+        && error.code === 'CORE_RUN_ARTIFACT_OVERLAY_ID_CONFLICT'
+    ));
+  });
+
+  it('projects a JSON-safe detail with exact lineage and no captured content', async () => {
+    const store = await temporaryStore();
+    const source = await saveScenario({
+      store,
+      target: 'agent',
+      runId: 'agent-detail',
+      createdAt: '2026-08-31T12:00:00.000Z',
+    });
+    const detail = await createCoreStudioCatalog(store).get('agent-detail');
+    assert.ok(detail);
+    assert.equal(detail.detailKind, 'studio-core-run-detail');
+    assert.equal(
+      detail.run.artifactSetDigest,
+      digestCanonicalJson(source.manifest.documents),
+    );
+    assert.equal(detail.dataset.sampleCount, 2);
+    assert.equal(detail.lineage.length, 5);
+    assert.equal(detail.stages.execution.records.length, 4);
+    assert.equal(detail.stages.evaluation.records.length, 8);
+    assert.ok(detail.stages.analysis.records.length > 0);
+    assert.ok(detail.decision);
+    assert.ok(Object.isFrozen(detail));
+    assert.ok(Object.isFrozen(detail.stages.execution.records));
+
+    const json = JSON.stringify(detail);
+    assert.doesNotThrow(() => JSON.parse(json) as unknown);
+    for (const protectedValue of [
+      'research evaluation core',
+      'verify measurement validity',
+      'working',
+      'done',
+      'requiredTools',
+      'toolCalls',
+      'capabilities',
+      'provenanceFacets',
+      'implementationManifest',
+    ]) {
+      assert.ok(!json.includes(protectedValue), `unexpected protected value: ${protectedValue}`);
+    }
+    assert.ok(!detail.lineage.some((entry) => 'fileName' in entry));
+    assert.ok(detail.stages.analysis.records.every((record) => (
+      !('schemaUri' in record.outputSchema)
+    )));
+    assert.ok(detail.stages.evaluation.records.every((record) => (
+      record.observations.every((observation) => observation.numericValue === undefined)
+    )));
+  });
+
+  it('exposes numeric observations and aggregate scalar analysis without raw evidence', async () => {
+    const store = await temporaryStore();
+    await saveScenario({
+      store,
+      target: 'rag',
+      runId: 'rag-detail',
+      createdAt: '2026-08-31T12:00:00.000Z',
+    });
+    const detail = await createCoreStudioCatalog(store).get('rag-detail');
+    assert.ok(detail);
+    const observations = detail.stages.evaluation.records.flatMap((record) => (
+      record.observations
+    ));
+    assert.ok(observations.length > 0);
+    assert.ok(observations.every((observation) => (
+      observation.valueType === 'numeric'
+        && typeof observation.numericValue === 'number'
+    )));
+    assert.ok(detail.stages.analysis.records.some((record) => (
+      record.resultType === 'scalar' && typeof record.numericValue === 'number'
+    )));
+    const json = JSON.stringify(detail);
+    assert.ok(!json.includes('calculation'));
+    assert.ok(!json.includes('relevantDocumentIds'));
+  });
+
+  it('keeps failure codes and orthogonal status while redacting error messages', async () => {
+    const store = await temporaryStore();
+    await saveScenario({
+      store,
+      target: 'function',
+      runId: 'failed-detail',
+      createdAt: '2026-08-31T12:00:00.000Z',
+      options: {
+        faults: new ConformanceFaultInjector().fail(
+          'executor-execute',
+          'TOP-SECRET-PROVIDER-MESSAGE',
+        ),
+      },
+    });
+    const detail = await createCoreStudioCatalog(store).get('failed-detail');
+    assert.ok(detail);
+    assert.equal(detail.run.status.runStatus, 'completed');
+    assert.equal(detail.run.status.evidenceStatus, 'unresolvable');
+    assert.equal(detail.run.status.conclusionStatus, 'inconclusive');
+    assert.ok(detail.stages.execution.records.some((record) => (
+      record.executionStatus === 'failed' && record.errorCode === 'executor-error'
+    )));
+    assert.ok(!JSON.stringify(detail).includes('TOP-SECRET-PROVIDER-MESSAGE'));
+  });
+
+  it('rejects a detached or altered artifact chain', async () => {
+    const store = await temporaryStore();
+    const source = await saveScenario({
+      store,
+      target: 'function',
+      runId: 'invalid-detail',
+      createdAt: '2026-08-31T12:00:00.000Z',
+    });
+    const altered = structuredClone(source);
+    altered.report.reportId = 'altered-report';
+    assert.throws(
+      () => projectCoreStudioRunDetail(altered),
+      (error: unknown) => (
+        error instanceof CoreDownstreamProjectionError
+          && error.code === 'CORE_PROJECTION_SOURCE_INVALID'
+      ),
+    );
+  });
+});


### PR DESCRIPTION
Closes #535
Part of #450
Depends on #531

## 用户影响

- 为 Studio 提供只依赖 Evaluation Core artifacts 的只读 catalog，可从 project／global overlay 列出、检查和读取 run。
- 提供版本化 run card 与 detail view model，完整呈现正交状态、coverage、budget、replayability、provenance、lineage、数值 metric、Analysis 与 Decision。
- partial、failed、cancelled、budget-exhausted、unresolvable 与 inconclusive 状态保持原义，不折算为零或成功。

## 架构边界

- 列表和点检查只读 validated manifest card；详情必须加载并闭合完整 Core artifact set。
- project／global 的同事实去重和不同事实冲突直接复用 Core artifact overlay，不建立 Studio 特例。
- 新模块不导入旧 ReportStore、EvaluationReport、VariantResult 或结果行，也未接入现有 route／renderer／production CLI。

## 隐私与 construct validity

- view model 使用语义 allow-list，不包含原始 input、expected、output、trace、evidence、Gold、文本 metric、任意 Analysis table、Runtime capabilities／facets、usage details、extensions 或 error message。
- 只暴露 finite scalar Analysis 值和 numeric Metric observation；未定义数值省略，不伪造为零。
- 状态只来自 Core 显式事实，不根据 score threshold 推导 verdict。

## 迁移说明

本 PR 不读取旧报告、不提供 migration／双读／shadow read，也不切换现有 Studio 页面。下一 PR 将把 Studio route／renderer 单向切到该 view model；最终 `omk eval` 报告 wire 切换仍是 #450 下独立的 BREAKING-SCHEMA 变更。

本变更不修改 evaluator、prompt、统计公式、missing policy 或 DecisionPolicy，不构成 BREAKING-COMPARABILITY。
