### PR TITLE
feat(server): 实现 Core Studio 独立路由

### DIFF
--- a/docs/specs/evaluation-studio-projection.md
+++ b/docs/specs/evaluation-studio-projection.md
@@ -1,6 +1,6 @@
 # Evaluation Core Studio projection
 
-> Status: read-only catalog and view-model boundary for [#535](https://github.com/lizhiyao/oh-my-knowledge/issues/535). It does not switch Studio routes or renderers and does not read legacy reports.
+> Status: read-only catalog/view-model boundary from [#535](https://github.com/lizhiyao/oh-my-knowledge/issues/535), plus the isolated renderer/route adapter from [#537](https://github.com/lizhiyao/oh-my-knowledge/issues/537). It does not switch production Studio routes and does not read legacy reports.
 
 ## 1. Authority boundary
 
@@ -39,8 +39,16 @@ This is a semantic allow-list. A later renderer cannot treat uncaptured evidence
 
 View status never derives from score thresholds. Run status, evidence status, and conclusion status remain orthogonal. Stage failures, cancellation, budget exhaustion, missing observations, inconclusive Analysis, and not-decided Decision retain their Core states and reason codes.
 
-## 4. Migration boundary
+## 4. Renderer and route adapter
 
-The Core Studio modules do not import legacy `ReportStore`, `EvaluationReport`, `VariantResult`, or result rows. The current server, skill index, routes, and renderers remain unchanged in this slice. A later PR will switch those consumers to the versioned views in one direction; no legacy reader, adapter, shadow read, or dual view is introduced.
+`renderCoreRunList()` and `renderCoreRunDetail()` consume only the two versioned views. The list presents run, evidence, and conclusion status as three separate axes. The detail presents plan identity, stage coverage and budgets, safe records and numeric observations, Analysis, Decision, and the complete five-document lineage. It never infers an overall quality state from scores.
+
+The renderer escapes every projected value. All navigation paths come from a caller-provided `CoreStudioRenderRoutes`; it contains no host, port, or deployment assumption. Tables use captions and scoped column headers, status groups have accessible labels, and both Chinese and English views retain the same facts.
+
+`createCoreStudioRouteHandler()` is a pure HTTP-shaped adapter over `CoreStudioCatalog`. It returns an immutable response envelope instead of depending on Node request/response objects, so a later host can mount it without giving the catalog server authority. Separate caller-provided HTML/API base paths expose list and detail resources. Unmatched paths return `undefined`, invalid or missing identifiers return stable 404 responses, unsupported methods return 405, and source failures return a redacted `core_studio_source_unavailable` response without exception text or filesystem paths.
+
+## 5. Migration boundary
+
+The Core Studio modules do not import legacy `ReportStore`, `EvaluationReport`, `VariantResult`, or result rows. The current production server, skill index, routes, and legacy renderer remain unchanged in this slice. A later PR will mount the independent handler and switch consumers to the versioned views in one direction; no legacy reader, adapter, shadow read, or dual view is introduced.
 
 The final `omk eval` and report-wire cutover remains the separate `BREAKING-SCHEMA` step in [#450](https://github.com/lizhiyao/oh-my-knowledge/issues/450). This projection changes no evaluator, analysis formula, prompt, missing-data policy, or verdict semantics and is not `BREAKING-COMPARABILITY`.

--- a/docs/zh/specs/evaluation-studio-projection.md
+++ b/docs/zh/specs/evaluation-studio-projection.md
@@ -1,6 +1,6 @@
 # Evaluation Core Studio 投影
 
-> 状态：[#535](https://github.com/lizhiyao/oh-my-knowledge/issues/535) 的只读 catalog 与 view model 边界。本阶段不切换 Studio route／renderer，也不读取旧报告。
+> 状态：[#535](https://github.com/lizhiyao/oh-my-knowledge/issues/535) 的只读 catalog／view model 边界，以及 [#537](https://github.com/lizhiyao/oh-my-knowledge/issues/537) 的隔离 renderer／route adapter。本阶段不切换生产 Studio route，也不读取旧报告。
 
 ## 一、权威边界
 
@@ -39,8 +39,16 @@ detail view 明确省略原始 input、execution context、expected、evaluation
 
 视图状态不从分数阈值推导。run status、evidence status 与 conclusion status 保持正交；stage failure、cancel、budget exhaustion、missing observation、inconclusive Analysis 与 not-decided Decision 都保留 Core 原始状态和 reason code。
 
-## 四、迁移边界
+## 四、Renderer 与 route adapter
 
-Core Studio 模块不导入旧 `ReportStore`、`EvaluationReport`、`VariantResult` 或结果行。本切片不修改现有 server、skill index、route 与 renderer；后续 PR 会把 consumer 单向切到版本化 view，不引入 legacy reader、adapter、shadow read 或双视图。
+`renderCoreRunList()` 与 `renderCoreRunDetail()` 只消费两种版本化 view。列表把 run、evidence 与 conclusion status 作为三个独立状态轴展示；详情展示 plan identity、阶段 coverage／budget、安全记录与数值 observation、Analysis、Decision，以及完整的五文档 lineage。它不会从分数推导一个总体质量状态。
+
+renderer 会转义所有投影值。全部导航路径都由调用方通过 `CoreStudioRenderRoutes` 注入，不假设 host、port 或部署方式。表格具备 caption 与限定作用域的列标题，status group 带无障碍标签，中英文视图保留完全相同的事实。
+
+`createCoreStudioRouteHandler()` 是 `CoreStudioCatalog` 之上的纯 HTTP 形状 adapter。它返回不可变 response envelope，不依赖 Node request／response object，因此后续 host 可以挂载它，而不必把 server authority 交给 catalog。调用方分别提供 HTML／API base path，并暴露列表与详情资源。不匹配的路径返回 `undefined`，非法或不存在的 identifier 返回稳定 404，不支持的方法返回 405；source failure 只返回脱敏的 `core_studio_source_unavailable`，不暴露 exception text 或 filesystem path。
+
+## 五、迁移边界
+
+Core Studio 模块不导入旧 `ReportStore`、`EvaluationReport`、`VariantResult` 或结果行。本切片不修改现有生产 server、skill index、route 与旧 renderer；后续 PR 会挂载独立 handler，并把 consumer 单向切到版本化 view，不引入 legacy reader、adapter、shadow read 或双视图。
 
 最终 `omk eval` 与报告 wire 切换仍是 [#450](https://github.com/lizhiyao/oh-my-knowledge/issues/450) 下独立的 `BREAKING-SCHEMA` 步骤。本 projection 不改变 evaluator、analysis formula、prompt、missing-data policy 或 verdict 语义，因此不属于 `BREAKING-COMPARABILITY`。

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,6 +205,20 @@ export type {
   CoreStudioRuntimeIdentity,
   CoreStudioUsage,
 } from './eval-workflows/studio-catalog/index.js';
+export {
+  coreStudioSourceUnavailableMessage,
+  renderCoreRunDetail,
+  renderCoreRunList,
+  renderCoreStudioError,
+} from './renderer/core-run-renderer.js';
+export type { CoreStudioRenderRoutes } from './renderer/core-run-renderer.js';
+export { createCoreStudioRouteHandler } from './server/core-studio-route-handler.js';
+export type {
+  CoreStudioRouteHandler,
+  CoreStudioRouteHandlerOptions,
+  CoreStudioRouteRequest,
+  CoreStudioRouteResponse,
+} from './server/core-studio-route-handler.js';
 export type {
   CompareGoldToCoreRunInput,
   CoreGoldDatasetInput,

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,10 +206,8 @@ export type {
   CoreStudioUsage,
 } from './eval-workflows/studio-catalog/index.js';
 export {
-  coreStudioSourceUnavailableMessage,
   renderCoreRunDetail,
   renderCoreRunList,
-  renderCoreStudioError,
 } from './renderer/core-run-renderer.js';
 export type { CoreStudioRenderRoutes } from './renderer/core-run-renderer.js';
 export { createCoreStudioRouteHandler } from './server/core-studio-route-handler.js';

--- a/src/renderer/core-run-renderer.ts
+++ b/src/renderer/core-run-renderer.ts
@@ -77,6 +77,8 @@ const COPY = {
     unit: '单位',
     scale: '量尺',
     bundle: '产物包',
+    bundleId: '产物包 ID',
+    bundleDigest: '产物包摘要',
     parent: '父产物',
     provenance: '来源',
     cache: '缓存',
@@ -91,6 +93,7 @@ const COPY = {
     identityDigest: '身份摘要',
     documentDigest: '文档摘要',
     digest: '摘要',
+    methodNotAllowed: '仅支持 GET 请求。',
     sourceUnavailable: 'Core 产物当前不可读取。',
   },
   en: {
@@ -157,6 +160,8 @@ const COPY = {
     unit: 'Unit',
     scale: 'Scale',
     bundle: 'Bundle',
+    bundleId: 'Bundle ID',
+    bundleDigest: 'Bundle digest',
     parent: 'Parent',
     provenance: 'Provenance',
     cache: 'Cache',
@@ -171,6 +176,7 @@ const COPY = {
     identityDigest: 'Identity digest',
     documentDigest: 'Document digest',
     digest: 'Digest',
+    methodNotAllowed: 'Only GET requests are supported.',
     sourceUnavailable: 'Core artifacts are currently unavailable.',
   },
 } as const;
@@ -189,6 +195,10 @@ function c(lang: Lang): Copy {
 function withLang(path: string, lang: Lang): string {
   if (lang !== 'en') return path;
   return `${path}${path.includes('?') ? '&' : '?'}lang=en`;
+}
+
+function separator(lang: Lang): string {
+  return lang === 'zh' ? '：' : ': ';
 }
 
 function tone(value: string): 'ok' | 'warn' | 'error' | 'neutral' {
@@ -241,9 +251,16 @@ function formatBudget(budget: CoreStudioBudget): string {
     `<code>active=${e(fmtDuration(budget.activeDurationMs))}</code>`,
     `<code>wall=${e(fmtDuration(budget.wallClock.elapsedMs))}</code>`,
     budget.wallClock.limitMs === undefined ? '' : `<code>limit=${e(fmtDuration(budget.wallClock.limitMs))}</code>`,
+    `<code>overshoot=${e(fmtDuration(budget.wallClock.overshootMs))}</code>`,
     costs ? `<code>cost=${e(costs)}</code>` : '',
     budget.unreportedProviderCostInvocations > 0 ? `<code>unreported-cost=${budget.unreportedProviderCostInvocations}</code>` : '',
-    budget.termination === undefined ? '' : `<code>termination=${e(budget.termination.terminationKind)}:${e(budget.termination.reasonCode)}</code>`,
+    budget.termination === undefined ? '' : `<code>termination=${e([
+      budget.termination.terminationKind,
+      budget.termination.resourceKind,
+      budget.termination.scopeKind,
+      budget.termination.reasonCode,
+    ].filter(Boolean).join(':'))}</code>`,
+    `<code>ledger=${e(budget.ledgerDigest)}</code>`,
   ].filter(Boolean).join(' ');
 }
 
@@ -274,12 +291,13 @@ function header(label: string): string {
 
 function runCard(card: CoreStudioRunCard, lang: Lang, routes: CoreStudioRenderRoutes, copy: Copy): string {
   const href = withLang(routes.detailPath(card.runId), lang);
+  const colon = separator(lang);
   return `<a class="core-run-card" href="${e(href)}">
     <div class="core-run-head"><span class="core-run-id">${e(card.runId)}</span><time class="core-date" datetime="${e(card.createdAt)}">${e(card.createdAt)}</time></div>
     ${statusAxes(card, copy)}
-    <div class="core-meta">${e(copy.replayability)}：${e(copy.execution)} ${chip(card.replayability.execution)} · ${e(copy.evaluation)} ${chip(card.replayability.evaluation)}</div>
-    <div class="core-meta">${e(copy.classification)}：${chip(card.maximumCapturedClassification)} · ${e(copy.reportId)}：${e(card.reportId)}</div>
-    <div class="core-meta core-digest">${e(copy.artifactSetDigest)}：${e(card.artifactSetDigest)}</div>
+    <div class="core-meta">${e(copy.replayability)}${colon}${e(copy.execution)} ${chip(card.replayability.execution)} · ${e(copy.evaluation)} ${chip(card.replayability.evaluation)}</div>
+    <div class="core-meta">${e(copy.classification)}${colon}${chip(card.maximumCapturedClassification)} · ${e(copy.reportId)}${colon}${e(card.reportId)}</div>
+    <div class="core-meta core-digest">${e(copy.artifactSetDigest)}${colon}${e(card.artifactSetDigest)}</div>
   </a>`;
 }
 
@@ -353,7 +371,8 @@ function renderStages(detail: CoreStudioRunDetail, copy: Copy): string {
       [copy.provenance, formatProvenance(stage.value.provenance, copy)],
       ...(stage.replayability ? [[copy.replayability, chip(stage.replayability)] as const] : []),
       ...(stage.budget ? [[copy.budget, `<span class="core-inline-list">${formatBudget(stage.budget)}</span>`] as const] : []),
-      [copy.bundle, `<span class="core-digest">${e(stage.value.bundleDigest)}</span>`],
+      [copy.bundleId, `<span class="core-table-code">${e(stage.value.bundleId)}</span>`],
+      [copy.bundleDigest, `<span class="core-digest">${e(stage.value.bundleDigest)}</span>`],
       ...(stage.parent ? [[copy.parent, `<span class="core-digest">${e(stage.parent)}</span>`] as const] : []),
     ])}</article>`
   )).join('')}</div></section>`;
@@ -377,9 +396,9 @@ function renderEvaluationRecords(detail: CoreStudioRunDetail, copy: Copy): strin
       return `<code>${e(observation.metricId)}:${e(observation.observationStatus)}${e(value)}${e(reason)}</code>`;
     }).join('');
     const measurement = record.measurement;
-    return `<tr><td>${e(record.evaluationId)}</td><td>${e(record.targetId)}</td><td>${e(record.sampleId)}</td><td>${record.trialIndex}</td><td>${e(record.trialId)}</td><td>${e(record.evaluatorId)}</td><td>${e(measurement.instrumentId)} / ${e(measurement.ensembleMemberId)} / ${e(measurement.replicateGroupId)} / ${measurement.replicateIndex}</td><td>${chip(record.evaluationStatus)}</td><td>${formatRuntime(record.runtime, copy)}</td><td>${formatProvenance(record.provenance, copy)}</td><td>${e(record.cacheStatus ?? copy.notAvailable)}</td><td><span class="core-observations">${observations}</span></td><td>${e(record.errorCode ?? record.notEvaluatedReasonCode ?? copy.notAvailable)}</td></tr>`;
+    return `<tr><td>${e(record.evaluationId)}</td><td>${e(record.targetId)}</td><td>${e(record.sampleId)}</td><td>${record.trialIndex}</td><td>${e(record.trialId)}</td><td>${e(record.evaluatorId)}</td><td>${e(measurement.instrumentId)} / ${e(measurement.ensembleMemberId)} / ${e(measurement.replicateGroupId)} / ${measurement.replicateIndex}</td><td>${chip(record.evaluationStatus)}</td><td>${formatRuntime(record.runtime, copy)}</td><td>${formatProvenance(record.provenance, copy)}</td><td>${e(record.cacheStatus ?? copy.notAvailable)}</td><td>${record.durationMs === undefined ? copy.notAvailable : e(fmtDuration(record.durationMs))}</td><td>${formatUsage(record.usage, copy)}</td><td><span class="core-observations">${observations}</span></td><td>${e(record.errorCode ?? record.notEvaluatedReasonCode ?? copy.notAvailable)}</td></tr>`;
   }).join('');
-  return `<section><h2>${e(copy.evaluationRecords)}</h2><div class="table-wrap"><table><caption class="core-table-caption">${e(copy.evaluationRecords)}</caption><thead><tr>${[copy.evaluationId, copy.target, copy.sample, copy.trial, copy.trialId, copy.evaluator, copy.measurement, copy.status, copy.runtime, copy.provenance, copy.cache, copy.observations, copy.reasons].map(header).join('')}</tr></thead><tbody>${rows}</tbody></table></div></section>`;
+  return `<section><h2>${e(copy.evaluationRecords)}</h2><div class="table-wrap"><table><caption class="core-table-caption">${e(copy.evaluationRecords)}</caption><thead><tr>${[copy.evaluationId, copy.target, copy.sample, copy.trial, copy.trialId, copy.evaluator, copy.measurement, copy.status, copy.runtime, copy.provenance, copy.cache, copy.duration, copy.usage, copy.observations, copy.reasons].map(header).join('')}</tr></thead><tbody>${rows}</tbody></table></div></section>`;
 }
 
 function analysisResult(record: CoreStudioAnalysisRecord, copy: Copy): string {
@@ -455,4 +474,8 @@ export function renderCoreStudioError(
 
 export function coreStudioSourceUnavailableMessage(lang: Lang): string {
   return c(lang).sourceUnavailable;
+}
+
+export function coreStudioMethodNotAllowedMessage(lang: Lang): string {
+  return c(lang).methodNotAllowed;
 }

--- a/src/renderer/core-run-renderer.ts
+++ b/src/renderer/core-run-renderer.ts
@@ -1,0 +1,458 @@
+import type {
+  CoreStudioAnalysisRecord,
+  CoreStudioBudget,
+  CoreStudioRunCard,
+  CoreStudioRunDetail,
+} from '../eval-workflows/studio-catalog/index.js';
+import type { Lang } from '../types/index.js';
+import { e, fmtDuration, layout } from './layout.js';
+
+export interface CoreStudioRenderRoutes {
+  readonly listPath: string;
+  detailPath(runId: string): string;
+}
+
+const COPY = {
+  zh: {
+    title: 'Evaluation Core 运行记录',
+    subtitle: '基于版本化 Core 产物的只读测量视图。三个状态轴相互独立，不合成为单一“成功”结论。',
+    empty: '暂无 Evaluation Core 运行记录。',
+    back: '← 返回运行记录',
+    run: '运行',
+    createdAt: '创建时间',
+    runStatus: '运行状态',
+    evidenceStatus: '证据状态',
+    conclusionStatus: '结论状态',
+    replayability: '可重放性',
+    execution: '执行',
+    evaluation: '评价',
+    classification: '最高数据分级',
+    identities: '产物身份',
+    reportId: '报告 ID',
+    contractDigest: '运行契约摘要',
+    reportDigest: '报告摘要',
+    artifactSetDigest: '产物集摘要',
+    plan: '测量计划',
+    dataset: '数据集',
+    samples: '用例数',
+    targets: '目标',
+    evaluators: '评估器',
+    metrics: '指标',
+    stages: '阶段与覆盖',
+    stage: '阶段',
+    status: '状态',
+    coverage: '覆盖',
+    budget: '预算',
+    records: '记录数',
+    lineage: '产物谱系',
+    executionRecords: '执行记录',
+    evaluationRecords: '评价记录',
+    analysis: '分析结果',
+    decision: '决策',
+    none: '无',
+    notAvailable: '—',
+    target: '目标',
+    sample: '用例',
+    trial: '试次',
+    evaluator: '评估器',
+    runtime: '运行时',
+    duration: '耗时',
+    usage: '用量',
+    observations: '观测',
+    node: '节点',
+    mode: '模式',
+    result: '结果',
+    exclusionCount: '排除数',
+    policy: '策略',
+    verdict: '结论',
+    reasons: '原因码',
+    kind: '类型',
+    protocol: '协议',
+    implementation: '实现',
+    executor: '执行器',
+    measurement: '测量身份',
+    valueType: '值类型',
+    scope: '作用域',
+    direction: '方向',
+    unit: '单位',
+    scale: '量尺',
+    bundle: '产物包',
+    parent: '父产物',
+    provenance: '来源',
+    cache: '缓存',
+    trialId: '试次 ID',
+    evaluationId: '评价 ID',
+    resultId: '结果 ID',
+    outputSchema: '输出 Schema',
+    assumptions: '假设检查',
+    recordDigest: '记录摘要',
+    document: '文档',
+    schema: 'Schema',
+    identityDigest: '身份摘要',
+    documentDigest: '文档摘要',
+    digest: '摘要',
+    sourceUnavailable: 'Core 产物当前不可读取。',
+  },
+  en: {
+    title: 'Evaluation Core Runs',
+    subtitle: 'A read-only measurement view backed by versioned Core artifacts. The three status axes remain independent and are never collapsed into one success verdict.',
+    empty: 'No Evaluation Core runs yet.',
+    back: '← Back to runs',
+    run: 'Run',
+    createdAt: 'Created',
+    runStatus: 'Run status',
+    evidenceStatus: 'Evidence status',
+    conclusionStatus: 'Conclusion status',
+    replayability: 'Replayability',
+    execution: 'Execution',
+    evaluation: 'Evaluation',
+    classification: 'Maximum classification',
+    identities: 'Artifact identities',
+    reportId: 'Report ID',
+    contractDigest: 'Run contract digest',
+    reportDigest: 'Report digest',
+    artifactSetDigest: 'Artifact set digest',
+    plan: 'Measurement plan',
+    dataset: 'Dataset',
+    samples: 'Samples',
+    targets: 'Targets',
+    evaluators: 'Evaluators',
+    metrics: 'Metrics',
+    stages: 'Stages and coverage',
+    stage: 'Stage',
+    status: 'Status',
+    coverage: 'Coverage',
+    budget: 'Budget',
+    records: 'Records',
+    lineage: 'Artifact lineage',
+    executionRecords: 'Execution records',
+    evaluationRecords: 'Evaluation records',
+    analysis: 'Analysis results',
+    decision: 'Decision',
+    none: 'None',
+    notAvailable: '—',
+    target: 'Target',
+    sample: 'Sample',
+    trial: 'Trial',
+    evaluator: 'Evaluator',
+    runtime: 'Runtime',
+    duration: 'Duration',
+    usage: 'Usage',
+    observations: 'Observations',
+    node: 'Node',
+    mode: 'Mode',
+    result: 'Result',
+    exclusionCount: 'Exclusions',
+    policy: 'Policy',
+    verdict: 'Verdict',
+    reasons: 'Reason codes',
+    kind: 'Kind',
+    protocol: 'Protocol',
+    implementation: 'Implementation',
+    executor: 'Executor',
+    measurement: 'Measurement identity',
+    valueType: 'Value type',
+    scope: 'Scope',
+    direction: 'Direction',
+    unit: 'Unit',
+    scale: 'Scale',
+    bundle: 'Bundle',
+    parent: 'Parent',
+    provenance: 'Provenance',
+    cache: 'Cache',
+    trialId: 'Trial ID',
+    evaluationId: 'Evaluation ID',
+    resultId: 'Result ID',
+    outputSchema: 'Output schema',
+    assumptions: 'Assumptions',
+    recordDigest: 'Record digest',
+    document: 'Document',
+    schema: 'Schema',
+    identityDigest: 'Identity digest',
+    documentDigest: 'Document digest',
+    digest: 'Digest',
+    sourceUnavailable: 'Core artifacts are currently unavailable.',
+  },
+} as const;
+
+const CORE_STUDIO_STYLE = `<style>
+.core-lead{max-width:820px}.core-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:12px;margin:18px 0}.core-run-card{display:block;background:var(--bg-surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:16px;color:inherit;transition:border-color .15s,box-shadow .15s}.core-run-card:hover{color:inherit;text-decoration:none;border-color:var(--accent);box-shadow:var(--shadow-md)}.core-run-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}.core-run-id{font-weight:650;overflow-wrap:anywhere}.core-date{font-size:12px;color:var(--text-muted);white-space:nowrap}.core-statuses{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;margin:14px 0}.core-axis{min-width:0}.core-axis-label{display:block;font-size:11px;color:var(--text-muted);margin-bottom:3px}.core-chip{display:inline-block;max-width:100%;padding:2px 8px;border:1px solid var(--border);border-radius:999px;background:var(--bg-soft);font-size:11px;font-weight:600;overflow-wrap:anywhere}.core-chip[data-tone="ok"]{color:var(--green);background:var(--green-bg);border-color:transparent}.core-chip[data-tone="warn"]{color:var(--yellow);background:var(--yellow-bg);border-color:transparent}.core-chip[data-tone="error"]{color:var(--red);background:var(--red-bg);border-color:transparent}.core-meta{font-size:12px;color:var(--text-secondary);overflow-wrap:anywhere}.core-digest{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;overflow-wrap:anywhere}.core-kv{display:grid;grid-template-columns:minmax(130px,220px) minmax(0,1fr);border-bottom:1px solid var(--border);padding:7px 0;gap:14px}.core-kv:last-child{border-bottom:0}.core-kv dt{color:var(--text-muted)}.core-kv dd{margin:0;overflow-wrap:anywhere}.core-stage{border-left:4px solid var(--accent)}.core-stage h3{font-size:15px;margin-bottom:8px}.core-inline-list{display:flex;flex-wrap:wrap;gap:6px}.core-inline-list code{font-size:11px;background:var(--bg-soft);border:1px solid var(--border);border-radius:4px;padding:1px 5px}.core-muted{color:var(--text-muted)}.core-observations{display:flex;flex-wrap:wrap;gap:5px}.core-section-note{font-size:12px;color:var(--text-muted);margin-top:-8px;margin-bottom:10px}.core-table-code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;overflow-wrap:anywhere}.core-table-caption{text-align:left;padding:8px 12px;font-weight:600;color:var(--text-primary);background:var(--bg-surface)}.core-decision{border-left:4px solid var(--green)}
+@media(max-width:680px){.core-statuses{grid-template-columns:1fr}.core-kv{grid-template-columns:1fr;gap:2px}.core-run-head{display:block}.core-date{display:block;margin-top:4px}}
+</style>`;
+
+type Copy = { readonly [K in keyof typeof COPY.zh]: string };
+
+function c(lang: Lang): Copy {
+  return COPY[lang];
+}
+
+function withLang(path: string, lang: Lang): string {
+  if (lang !== 'en') return path;
+  return `${path}${path.includes('?') ? '&' : '?'}lang=en`;
+}
+
+function tone(value: string): 'ok' | 'warn' | 'error' | 'neutral' {
+  if (['completed', 'complete', 'conclusive', 'within-budget', 'decided', 'observed', 'passed', 'self-contained'].includes(value)) return 'ok';
+  if (['failed', 'unresolvable', 'invalid'].includes(value)) return 'error';
+  if (['cancelled', 'budget-exhausted', 'partial', 'inconclusive', 'not-evaluated', 'missing', 'unverifiable', 'exhausted', 'summary-only'].includes(value)) return 'warn';
+  return 'neutral';
+}
+
+function chip(value: string): string {
+  return `<span class="core-chip" data-tone="${tone(value)}">${e(value)}</span>`;
+}
+
+function statusAxes(card: CoreStudioRunCard, copy: Copy): string {
+  const axes = [
+    [copy.runStatus, card.status.runStatus],
+    [copy.evidenceStatus, card.status.evidenceStatus],
+    [copy.conclusionStatus, card.status.conclusionStatus],
+  ] as const;
+  return `<div class="core-statuses" aria-label="${e(copy.status)}">${axes.map(([label, value]) => (
+    `<div class="core-axis"><span class="core-axis-label">${e(label)}</span>${chip(value)}</div>`
+  )).join('')}</div>`;
+}
+
+function keyValues(values: readonly (readonly [string, string])[]): string {
+  return `<dl>${values.map(([key, value]) => `<div class="core-kv"><dt>${e(key)}</dt><dd>${value}</dd></div>`).join('')}</dl>`;
+}
+
+function formatUsage(usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number; providerCost?: { amount: number; currency: string } } | undefined, copy: Copy): string {
+  if (!usage) return copy.notAvailable;
+  const parts = [
+    usage.inputTokens === undefined ? undefined : `in ${usage.inputTokens}`,
+    usage.outputTokens === undefined ? undefined : `out ${usage.outputTokens}`,
+    usage.totalTokens === undefined ? undefined : `total ${usage.totalTokens}`,
+    usage.providerCost === undefined ? undefined : `${usage.providerCost.amount} ${usage.providerCost.currency}`,
+  ].filter((value): value is string => value !== undefined);
+  return parts.length === 0 ? copy.notAvailable : parts.map(e).join(' · ');
+}
+
+function formatCoverage(coverage: Readonly<Record<string, number>>): string {
+  return Object.entries(coverage).map(([key, value]) => `<code>${e(key)}=${value}</code>`).join(' ');
+}
+
+function formatBudget(budget: CoreStudioBudget): string {
+  const costs = budget.reportedProviderCosts.map((cost) => `${cost.amount} ${cost.currency}`).join(', ');
+  return [
+    chip(budget.summaryStatus),
+    `<code>admission=${e(budget.admissionMode)}</code>`,
+    `<code>invocations=${budget.invocations}</code>`,
+    `<code>active=${e(fmtDuration(budget.activeDurationMs))}</code>`,
+    `<code>wall=${e(fmtDuration(budget.wallClock.elapsedMs))}</code>`,
+    budget.wallClock.limitMs === undefined ? '' : `<code>limit=${e(fmtDuration(budget.wallClock.limitMs))}</code>`,
+    costs ? `<code>cost=${e(costs)}</code>` : '',
+    budget.unreportedProviderCostInvocations > 0 ? `<code>unreported-cost=${budget.unreportedProviderCostInvocations}</code>` : '',
+    budget.termination === undefined ? '' : `<code>termination=${e(budget.termination.terminationKind)}:${e(budget.termination.reasonCode)}</code>`,
+  ].filter(Boolean).join(' ');
+}
+
+function formatRuntime(value: {
+  implementationId: string;
+  version?: string;
+  fingerprint: string;
+  fingerprintBasis: string;
+  assuranceLevel: string;
+}, copy: Copy): string {
+  return `<span class="core-table-code">${e(value.implementationId)}@${e(value.version ?? copy.notAvailable)} · ${e(value.fingerprint)} · ${e(value.fingerprintBasis)} · ${e(value.assuranceLevel)}</span>`;
+}
+
+function formatProvenance(value: {
+  provenanceKind: string;
+  trust: string;
+  parentDigests: readonly string[];
+}, copy: Copy): string {
+  const parents = value.parentDigests.length === 0
+    ? copy.none
+    : value.parentDigests.map(e).join(', ');
+  return `<span class="core-table-code">${e(value.provenanceKind)} · ${e(value.trust)} · parents=${parents}</span>`;
+}
+
+function header(label: string): string {
+  return `<th scope="col">${e(label)}</th>`;
+}
+
+function runCard(card: CoreStudioRunCard, lang: Lang, routes: CoreStudioRenderRoutes, copy: Copy): string {
+  const href = withLang(routes.detailPath(card.runId), lang);
+  return `<a class="core-run-card" href="${e(href)}">
+    <div class="core-run-head"><span class="core-run-id">${e(card.runId)}</span><time class="core-date" datetime="${e(card.createdAt)}">${e(card.createdAt)}</time></div>
+    ${statusAxes(card, copy)}
+    <div class="core-meta">${e(copy.replayability)}：${e(copy.execution)} ${chip(card.replayability.execution)} · ${e(copy.evaluation)} ${chip(card.replayability.evaluation)}</div>
+    <div class="core-meta">${e(copy.classification)}：${chip(card.maximumCapturedClassification)} · ${e(copy.reportId)}：${e(card.reportId)}</div>
+    <div class="core-meta core-digest">${e(copy.artifactSetDigest)}：${e(card.artifactSetDigest)}</div>
+  </a>`;
+}
+
+export function renderCoreRunList(
+  cards: readonly CoreStudioRunCard[],
+  routes: CoreStudioRenderRoutes,
+  lang: Lang = 'zh',
+): string {
+  const copy = c(lang);
+  const content = cards.length === 0
+    ? `<p class="core-muted">${e(copy.empty)}</p>`
+    : `<div class="core-grid">${cards.map((card) => runCard(card, lang, routes, copy)).join('')}</div>`;
+  return layout(copy.title, `${CORE_STUDIO_STYLE}<main><h1>${e(copy.title)}</h1><p class="subtitle core-lead">${e(copy.subtitle)}</p>${content}</main>`, lang, {
+    homeHref: withLang(routes.listPath, lang),
+  });
+}
+
+function renderPlan(detail: CoreStudioRunDetail, copy: Copy): string {
+  const targets = detail.targets.map((target) => (
+    `<tr><td>${e(target.targetId)}</td><td>${e(target.targetKind)}</td><td>${e(target.protocolId)}</td><td>${e(target.executorId)}</td></tr>`
+  )).join('');
+  const evaluators = detail.evaluators.map((evaluator) => (
+    `<tr><td>${e(evaluator.evaluatorId)}</td><td>${e(evaluator.evaluatorKind)}</td><td>${e(evaluator.implementationId)}</td><td><span class="core-inline-list">${evaluator.metricIds.map((metricId) => `<code>${e(metricId)}</code>`).join('')}</span></td><td>${e(evaluator.measurement.instrumentId)} / ${e(evaluator.measurement.ensembleMemberId)} / ${e(evaluator.measurement.replicateGroupId)} / ${evaluator.measurement.replicateIndex}</td></tr>`
+  )).join('');
+  const metrics = detail.metrics.map((metric) => (
+    `<tr><td>${e(metric.metricId)}</td><td>${e(metric.valueType)}</td><td>${e(metric.scope)}</td><td>${e(metric.direction ?? copy.notAvailable)}</td><td>${e(metric.unit ?? copy.notAvailable)}</td><td>${metric.scale ? e(JSON.stringify(metric.scale)) : copy.notAvailable}</td></tr>`
+  )).join('');
+  return `<section><h2>${e(copy.plan)}</h2>
+    ${keyValues([
+      [copy.dataset, `<span class="core-table-code">${e(detail.dataset.datasetId)}</span> · <span class="core-digest">${e(detail.dataset.datasetRevisionDigest)}</span>`],
+      [copy.samples, String(detail.dataset.sampleCount)],
+    ])}
+    <div class="table-wrap"><table><caption class="core-table-caption">${e(copy.targets)}</caption><thead><tr>${['ID', copy.kind, copy.protocol, copy.executor].map(header).join('')}</tr></thead><tbody>${targets}</tbody></table></div>
+    <div class="table-wrap"><table><caption class="core-table-caption">${e(copy.evaluators)}</caption><thead><tr>${['ID', copy.kind, copy.implementation, copy.metrics, copy.measurement].map(header).join('')}</tr></thead><tbody>${evaluators}</tbody></table></div>
+    <div class="table-wrap"><table><caption class="core-table-caption">${e(copy.metrics)}</caption><thead><tr>${['ID', copy.valueType, copy.scope, copy.direction, copy.unit, copy.scale].map(header).join('')}</tr></thead><tbody>${metrics}</tbody></table></div>
+  </section>`;
+}
+
+function renderStages(detail: CoreStudioRunDetail, copy: Copy): string {
+  const stages = [
+    {
+      name: copy.execution,
+      value: detail.stages.execution,
+      budget: detail.stages.execution.budget,
+      records: detail.stages.execution.records.length,
+      parent: undefined,
+      replayability: detail.stages.execution.replayability,
+    },
+    {
+      name: copy.evaluation,
+      value: detail.stages.evaluation,
+      budget: detail.stages.evaluation.budget,
+      records: detail.stages.evaluation.records.length,
+      parent: detail.stages.evaluation.parentExecutionBundleDigest,
+      replayability: detail.stages.evaluation.replayability,
+    },
+    {
+      name: copy.analysis,
+      value: detail.stages.analysis,
+      budget: undefined,
+      records: detail.stages.analysis.records.length,
+      parent: detail.stages.analysis.parentEvaluationBundleDigest,
+      replayability: undefined,
+    },
+  ] as const;
+  return `<section><h2>${e(copy.stages)}</h2><div class="core-grid">${stages.map((stage) => (
+    `<article class="card core-stage"><h3>${e(stage.name)}</h3>${keyValues([
+      [copy.status, chip(stage.value.stageStatus)],
+      [copy.coverage, `<span class="core-inline-list">${formatCoverage(stage.value.coverage)}</span>`],
+      [copy.records, String(stage.records)],
+      [copy.provenance, formatProvenance(stage.value.provenance, copy)],
+      ...(stage.replayability ? [[copy.replayability, chip(stage.replayability)] as const] : []),
+      ...(stage.budget ? [[copy.budget, `<span class="core-inline-list">${formatBudget(stage.budget)}</span>`] as const] : []),
+      [copy.bundle, `<span class="core-digest">${e(stage.value.bundleDigest)}</span>`],
+      ...(stage.parent ? [[copy.parent, `<span class="core-digest">${e(stage.parent)}</span>`] as const] : []),
+    ])}</article>`
+  )).join('')}</div></section>`;
+}
+
+function renderExecutionRecords(detail: CoreStudioRunDetail, copy: Copy): string {
+  const rows = detail.stages.execution.records.map((record) => `<tr>
+    <td>${e(record.targetId)}</td><td>${e(record.sampleId)}</td><td>${record.trialIndex}</td><td>${e(record.trialId)}</td><td>${chip(record.executionStatus)}</td>
+    <td>${formatRuntime(record.runtime, copy)}</td>
+    <td>${formatProvenance(record.provenance, copy)}</td><td>${e(record.cacheStatus ?? copy.notAvailable)}</td><td>${record.durationMs === undefined ? copy.notAvailable : e(fmtDuration(record.durationMs))}</td><td>${formatUsage(record.usage, copy)}</td>
+    <td>${e(record.errorCode ?? record.censorReasonCode ?? copy.notAvailable)}</td>
+  </tr>`).join('');
+  return `<section><h2>${e(copy.executionRecords)}</h2><div class="table-wrap"><table><caption class="core-table-caption">${e(copy.executionRecords)}</caption><thead><tr>${[copy.target, copy.sample, copy.trial, copy.trialId, copy.status, copy.runtime, copy.provenance, copy.cache, copy.duration, copy.usage, copy.reasons].map(header).join('')}</tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
+
+function renderEvaluationRecords(detail: CoreStudioRunDetail, copy: Copy): string {
+  const rows = detail.stages.evaluation.records.map((record) => {
+    const observations = record.observations.length === 0 ? copy.none : record.observations.map((observation) => {
+      const value = observation.numericValue === undefined ? '' : `=${observation.numericValue}`;
+      const reason = observation.reasonCode === undefined ? '' : ` (${observation.reasonCode})`;
+      return `<code>${e(observation.metricId)}:${e(observation.observationStatus)}${e(value)}${e(reason)}</code>`;
+    }).join('');
+    const measurement = record.measurement;
+    return `<tr><td>${e(record.evaluationId)}</td><td>${e(record.targetId)}</td><td>${e(record.sampleId)}</td><td>${record.trialIndex}</td><td>${e(record.trialId)}</td><td>${e(record.evaluatorId)}</td><td>${e(measurement.instrumentId)} / ${e(measurement.ensembleMemberId)} / ${e(measurement.replicateGroupId)} / ${measurement.replicateIndex}</td><td>${chip(record.evaluationStatus)}</td><td>${formatRuntime(record.runtime, copy)}</td><td>${formatProvenance(record.provenance, copy)}</td><td>${e(record.cacheStatus ?? copy.notAvailable)}</td><td><span class="core-observations">${observations}</span></td><td>${e(record.errorCode ?? record.notEvaluatedReasonCode ?? copy.notAvailable)}</td></tr>`;
+  }).join('');
+  return `<section><h2>${e(copy.evaluationRecords)}</h2><div class="table-wrap"><table><caption class="core-table-caption">${e(copy.evaluationRecords)}</caption><thead><tr>${[copy.evaluationId, copy.target, copy.sample, copy.trial, copy.trialId, copy.evaluator, copy.measurement, copy.status, copy.runtime, copy.provenance, copy.cache, copy.observations, copy.reasons].map(header).join('')}</tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
+
+function analysisResult(record: CoreStudioAnalysisRecord, copy: Copy): string {
+  if (record.numericValue !== undefined) return String(record.numericValue);
+  if (record.resultType !== undefined) return record.resultType;
+  return copy.notAvailable;
+}
+
+function renderAnalysis(detail: CoreStudioRunDetail, copy: Copy): string {
+  const rows = detail.stages.analysis.records.map((record) => `<tr>
+    <td>${e(record.resultId)}</td><td>${e(record.nodeId)}</td><td>${e(record.analysisNodeKind)}</td><td>${e(record.analysisMode)}</td><td>${chip(record.analysisStatus)}</td>
+    <td>${e(analysisResult(record, copy))}</td><td>${record.exclusionCount}</td><td><span class="core-inline-list">${formatCoverage(record.coverage)}</span></td><td>${formatRuntime(record.runtime, copy)}</td>
+    <td><span class="core-table-code">${e(record.outputSchema.schemaVersion)} · ${e(record.outputSchema.schemaDigest)}</span></td>
+    <td>${record.assumptionChecks.map((check) => `${e(check.assumptionId)}=${e(check.checkStatus)}${check.reasonCode ? ` (${e(check.reasonCode)})` : ''}`).join(' · ') || copy.none}</td>
+    <td>${e([...(record.reasonCodes ?? []), ...(record.errorCode ? [record.errorCode] : [])].join(', ') || copy.notAvailable)}</td><td class="core-table-code">${e(record.recordDigest)}</td>
+  </tr>`).join('');
+  return `<section><h2>${e(copy.analysis)}</h2><div class="table-wrap"><table><caption class="core-table-caption">${e(copy.analysis)}</caption><thead><tr>${[copy.resultId, copy.node, copy.kind, copy.mode, copy.status, copy.result, copy.exclusionCount, copy.coverage, copy.runtime, copy.outputSchema, copy.assumptions, copy.reasons, copy.recordDigest].map(header).join('')}</tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
+
+function renderDecision(detail: CoreStudioRunDetail, copy: Copy): string {
+  const decision = detail.decision;
+  if (!decision) return `<section><h2>${e(copy.decision)}</h2><p class="core-muted">${e(copy.none)}</p></section>`;
+  return `<section><h2>${e(copy.decision)}</h2><article class="card core-decision">${keyValues([
+    [copy.policy, `<span class="core-table-code">${e(decision.decisionPolicyId)}</span>`],
+    [copy.status, chip(decision.decisionStatus)],
+    [copy.verdict, e(decision.verdict ?? copy.notAvailable)],
+    [copy.reasons, e(decision.reasonCodes?.join(', ') || decision.errorCode || copy.notAvailable)],
+    [copy.runtime, formatRuntime(decision.implementation, copy)],
+    [copy.analysis, `<span class="core-inline-list">${decision.analysisResultIds.map((id) => `<code>${e(id)}</code>`).join('')}</span>`],
+    [copy.digest, `<span class="core-digest">${e(decision.decisionDigest)}</span>`],
+  ])}</article></section>`;
+}
+
+function renderLineage(detail: CoreStudioRunDetail, copy: Copy): string {
+  const rows = detail.lineage.map((entry) => `<tr><td>${e(entry.documentKind)}</td><td>${e(entry.schemaVersion)}</td><td class="core-table-code">${e(entry.identityDigest)}</td><td class="core-table-code">${e(entry.documentDigest)}</td></tr>`).join('');
+  return `<section><h2>${e(copy.lineage)}</h2><div class="table-wrap"><table><caption class="core-table-caption">${e(copy.lineage)}</caption><thead><tr>${[copy.document, copy.schema, copy.identityDigest, copy.documentDigest].map(header).join('')}</tr></thead><tbody>${rows}</tbody></table></div></section>`;
+}
+
+export function renderCoreRunDetail(
+  detail: CoreStudioRunDetail,
+  routes: CoreStudioRenderRoutes,
+  lang: Lang = 'zh',
+): string {
+  const copy = c(lang);
+  const card = detail.run;
+  return layout(`${copy.run} · ${card.runId}`, `${CORE_STUDIO_STYLE}<main>
+    <nav class="nav"><a href="${e(withLang(routes.listPath, lang))}">${e(copy.back)}</a></nav>
+    <h1>${e(card.runId)}</h1><p class="subtitle"><time datetime="${e(card.createdAt)}">${e(card.createdAt)}</time></p>
+    ${statusAxes(card, copy)}
+    <section><h2>${e(copy.identities)}</h2>${keyValues([
+      [copy.reportId, `<span class="core-table-code">${e(card.reportId)}</span>`],
+      [copy.contractDigest, `<span class="core-digest">${e(card.runContractDigest)}</span>`],
+      [copy.reportDigest, `<span class="core-digest">${e(card.reportDigest)}</span>`],
+      [copy.artifactSetDigest, `<span class="core-digest">${e(card.artifactSetDigest)}</span>`],
+      [copy.replayability, `${e(copy.execution)} ${chip(card.replayability.execution)} · ${e(copy.evaluation)} ${chip(card.replayability.evaluation)}`],
+      [copy.classification, chip(card.maximumCapturedClassification)],
+      [copy.provenance, formatProvenance(detail.reportProvenance, copy)],
+    ])}</section>
+    ${renderPlan(detail, copy)}${renderStages(detail, copy)}${renderExecutionRecords(detail, copy)}${renderEvaluationRecords(detail, copy)}${renderAnalysis(detail, copy)}${renderDecision(detail, copy)}${renderLineage(detail, copy)}
+  </main>`, lang, { homeHref: withLang(routes.listPath, lang) });
+}
+
+export function renderCoreStudioError(
+  message: string,
+  routes: CoreStudioRenderRoutes,
+  lang: Lang = 'zh',
+): string {
+  const copy = c(lang);
+  return layout(copy.title, `${CORE_STUDIO_STYLE}<main><nav class="nav"><a href="${e(withLang(routes.listPath, lang))}">${e(copy.back)}</a></nav><h1>${e(copy.title)}</h1><p role="alert">${e(message)}</p></main>`, lang, {
+    homeHref: withLang(routes.listPath, lang),
+  });
+}
+
+export function coreStudioSourceUnavailableMessage(lang: Lang): string {
+  return c(lang).sourceUnavailable;
+}

--- a/src/renderer/layout.ts
+++ b/src/renderer/layout.ts
@@ -392,13 +392,22 @@ function langToggleButton(lang: Lang): string {
   return `<button id="lang-toggle" onclick="switchLang()" class="lang-toggle">${t('switchLang', lang)}</button>`;
 }
 
-export function layout(title: string, body: string, lang: Lang = DEFAULT_LANG): string {
+export interface LayoutOptions {
+  homeHref?: string;
+}
+
+export function layout(
+  title: string,
+  body: string,
+  lang: Lang = DEFAULT_LANG,
+  options: LayoutOptions = {},
+): string {
   const htmlLang = lang === 'zh' ? 'zh-CN' : 'en';
   const favicon = encodeURIComponent(BRAND_LOGO_RAW);
   // 中英文切换按钮临时隐藏(URL ?lang= / localStorage 切换逻辑保留,按钮 UI 不渲染)。
   // 想恢复:在 body 模板里加回 ${langToggleButton(lang)}。
   void langToggleButton;
-  const appBar = `<header class="app-bar"><a class="app-brand" href="/"><span class="app-brand-logo">${brandLogo(30)}</span><span class="app-brand-tag">Studio</span></a><span class="app-bar-spacer"></span></header>`;
+  const appBar = `<header class="app-bar"><a class="app-brand" href="${e(options.homeHref ?? '/')}"><span class="app-brand-logo">${brandLogo(30)}</span><span class="app-brand-tag">Studio</span></a><span class="app-bar-spacer"></span></header>`;
   return `<!doctype html><html lang="${htmlLang}" data-lang="${lang}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>OMK · ${e(title)}</title>
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,${favicon}">${globalKeyboardScript()}
 <style>

--- a/src/server/core-studio-route-handler.ts
+++ b/src/server/core-studio-route-handler.ts
@@ -1,0 +1,168 @@
+import type { CoreStudioCatalog } from '../eval-workflows/studio-catalog/index.js';
+import {
+  coreStudioSourceUnavailableMessage,
+  renderCoreRunDetail,
+  renderCoreRunList,
+  renderCoreStudioError,
+  type CoreStudioRenderRoutes,
+} from '../renderer/core-run-renderer.js';
+import type { Lang } from '../types/index.js';
+
+export interface CoreStudioRouteRequest {
+  readonly method?: string;
+  readonly url?: string;
+}
+
+export interface CoreStudioRouteResponse {
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: string;
+}
+
+export interface CoreStudioRouteHandlerOptions {
+  readonly catalog: CoreStudioCatalog;
+  readonly htmlBasePath: string;
+  readonly apiBasePath: string;
+  readonly defaultLang?: Lang;
+}
+
+export type CoreStudioRouteHandler = (
+  request: CoreStudioRouteRequest,
+) => Promise<CoreStudioRouteResponse | undefined>;
+
+const HTML_HEADERS = Object.freeze({
+  'Content-Type': 'text/html; charset=utf-8',
+  'Cache-Control': 'no-store',
+});
+
+const JSON_HEADERS = Object.freeze({
+  'Content-Type': 'application/json; charset=utf-8',
+  'Cache-Control': 'no-store',
+});
+
+function normalizeBasePath(value: string, name: string): string {
+  if (
+    !value.startsWith('/')
+    || value === '/'
+    || value.endsWith('/')
+    || value.includes('//')
+    || value.includes('?')
+    || value.includes('#')
+    || /[\s\\]/u.test(value)
+  ) {
+    throw new TypeError(`${name} must be an absolute, non-root path without a trailing slash, query, or fragment`);
+  }
+  return value;
+}
+
+function splitRequestUrl(value: string): { path: string; search: URLSearchParams } {
+  const fragmentIndex = value.indexOf('#');
+  const withoutFragment = fragmentIndex < 0 ? value : value.slice(0, fragmentIndex);
+  const queryIndex = withoutFragment.indexOf('?');
+  return queryIndex < 0
+    ? { path: withoutFragment, search: new URLSearchParams() }
+    : {
+        path: withoutFragment.slice(0, queryIndex),
+        search: new URLSearchParams(withoutFragment.slice(queryIndex + 1)),
+      };
+}
+
+interface RunPathMatch {
+  readonly matched: boolean;
+  readonly runId?: string;
+}
+
+function matchRunPath(path: string, basePath: string): RunPathMatch {
+  const prefix = `${basePath}/`;
+  if (!path.startsWith(prefix)) return { matched: false };
+  const encoded = path.slice(prefix.length);
+  if (!encoded || encoded.includes('/')) return { matched: true };
+  try {
+    return { matched: true, runId: decodeURIComponent(encoded) };
+  } catch {
+    return { matched: true };
+  }
+}
+
+function json(status: number, body: unknown, extraHeaders: Readonly<Record<string, string>> = {}): CoreStudioRouteResponse {
+  return Object.freeze({
+    status,
+    headers: Object.freeze({ ...JSON_HEADERS, ...extraHeaders }),
+    body: JSON.stringify(body),
+  });
+}
+
+function html(status: number, body: string, extraHeaders: Readonly<Record<string, string>> = {}): CoreStudioRouteResponse {
+  return Object.freeze({
+    status,
+    headers: Object.freeze({ ...HTML_HEADERS, ...extraHeaders }),
+    body,
+  });
+}
+
+export function createCoreStudioRouteHandler(
+  options: CoreStudioRouteHandlerOptions,
+): CoreStudioRouteHandler {
+  const htmlBasePath = normalizeBasePath(options.htmlBasePath, 'htmlBasePath');
+  const apiBasePath = normalizeBasePath(options.apiBasePath, 'apiBasePath');
+  if (
+    htmlBasePath === apiBasePath
+    || htmlBasePath.startsWith(`${apiBasePath}/`)
+    || apiBasePath.startsWith(`${htmlBasePath}/`)
+  ) {
+    throw new TypeError('htmlBasePath and apiBasePath must not overlap');
+  }
+  const routes: CoreStudioRenderRoutes = Object.freeze({
+    listPath: htmlBasePath,
+    detailPath: (runId: string) => `${htmlBasePath}/${encodeURIComponent(runId)}`,
+  });
+  const defaultLang = options.defaultLang ?? 'zh';
+
+  return async (request) => {
+    const { path, search } = splitRequestUrl(request.url ?? '/');
+    const htmlRun = matchRunPath(path, htmlBasePath);
+    const apiRun = matchRunPath(path, apiBasePath);
+    const isMatched = path === htmlBasePath || path === apiBasePath || htmlRun.matched || apiRun.matched;
+    if (!isMatched) return undefined;
+
+    if ((request.method ?? 'GET').toUpperCase() !== 'GET') {
+      return path === apiBasePath || apiRun.matched
+        ? json(405, { error: 'method_not_allowed' }, { Allow: 'GET' })
+        : html(405, 'Method Not Allowed', { Allow: 'GET' });
+    }
+
+    const requestedLang = search.get('lang');
+    const lang: Lang = requestedLang === 'en' || requestedLang === 'zh'
+      ? requestedLang
+      : defaultLang;
+    try {
+      if (path === htmlBasePath) {
+        return html(200, renderCoreRunList(await options.catalog.list(), routes, lang));
+      }
+      if (path === apiBasePath) {
+        return json(200, await options.catalog.list());
+      }
+      if (htmlRun.matched) {
+        if (htmlRun.runId === undefined) {
+          return html(404, renderCoreStudioError(lang === 'en' ? 'Run not found.' : '运行记录不存在。', routes, lang));
+        }
+        const detail = await options.catalog.get(htmlRun.runId);
+        return detail === undefined
+          ? html(404, renderCoreStudioError(lang === 'en' ? 'Run not found.' : '运行记录不存在。', routes, lang))
+          : html(200, renderCoreRunDetail(detail, routes, lang));
+      }
+      if (apiRun.matched) {
+        if (apiRun.runId === undefined) return json(404, { error: 'core_run_not_found' });
+        const detail = await options.catalog.get(apiRun.runId);
+        return detail === undefined
+          ? json(404, { error: 'core_run_not_found' })
+          : json(200, detail);
+      }
+      return undefined;
+    } catch {
+      return path === apiBasePath || apiRun.matched
+        ? json(503, { error: 'core_studio_source_unavailable' })
+        : html(503, renderCoreStudioError(coreStudioSourceUnavailableMessage(lang), routes, lang));
+    }
+  };
+}

--- a/src/server/core-studio-route-handler.ts
+++ b/src/server/core-studio-route-handler.ts
@@ -1,5 +1,6 @@
 import type { CoreStudioCatalog } from '../eval-workflows/studio-catalog/index.js';
 import {
+  coreStudioMethodNotAllowedMessage,
   coreStudioSourceUnavailableMessage,
   renderCoreRunDetail,
   renderCoreRunList,
@@ -125,16 +126,16 @@ export function createCoreStudioRouteHandler(
     const isMatched = path === htmlBasePath || path === apiBasePath || htmlRun.matched || apiRun.matched;
     if (!isMatched) return undefined;
 
-    if ((request.method ?? 'GET').toUpperCase() !== 'GET') {
-      return path === apiBasePath || apiRun.matched
-        ? json(405, { error: 'method_not_allowed' }, { Allow: 'GET' })
-        : html(405, 'Method Not Allowed', { Allow: 'GET' });
-    }
-
     const requestedLang = search.get('lang');
     const lang: Lang = requestedLang === 'en' || requestedLang === 'zh'
       ? requestedLang
       : defaultLang;
+    if ((request.method ?? 'GET').toUpperCase() !== 'GET') {
+      return path === apiBasePath || apiRun.matched
+        ? json(405, { error: 'method_not_allowed' }, { Allow: 'GET' })
+        : html(405, renderCoreStudioError(coreStudioMethodNotAllowedMessage(lang), routes, lang), { Allow: 'GET' });
+    }
+
     try {
       if (path === htmlBasePath) {
         return html(200, renderCoreRunList(await options.catalog.list(), routes, lang));

--- a/test/eval-workflows/studio-catalog/migration-boundary.test.ts
+++ b/test/eval-workflows/studio-catalog/migration-boundary.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('#537 migration boundary', () => {
+  it('keeps the Core renderer and handler independent from legacy report models', () => {
+    const surface = [
+      'src/renderer/core-run-renderer.ts',
+      'src/server/core-studio-route-handler.ts',
+    ].map((file) => readFileSync(file, 'utf8')).join('\n');
+
+    for (const forbidden of [
+      "from '../eval-core/",
+      "from '../types/report",
+      'ReportStore',
+      'ReportDocument',
+      'VariantResult',
+      'queryRunList',
+      'renderRunList',
+    ]) {
+      expect(surface).not.toContain(forbidden);
+    }
+    expect(surface).toContain('CoreStudioCatalog');
+    expect(surface).toContain('CoreStudioRunDetail');
+  });
+
+  it('does not wire the new handler into the production report server yet', () => {
+    const server = readFileSync('src/server/report-server.ts', 'utf8');
+    const legacyRenderer = readFileSync('src/renderer/html-renderer.ts', 'utf8');
+
+    expect(server).not.toContain('createCoreStudioRouteHandler');
+    expect(server).not.toContain('core-studio-route-handler');
+    expect(legacyRenderer).not.toContain('core-run-renderer');
+  });
+});

--- a/test/server/core-studio-route-handler.test.ts
+++ b/test/server/core-studio-route-handler.test.ts
@@ -1,0 +1,420 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import {
+  CORE_STUDIO_RUN_CARD_SCHEMA_VERSION,
+  CORE_STUDIO_RUN_DETAIL_SCHEMA_VERSION,
+  createCoreStudioRouteHandler,
+  renderCoreRunDetail,
+  renderCoreRunList,
+  type CoreStudioCatalog,
+  type CoreStudioRunCard,
+  type CoreStudioRunDetail,
+} from '../../src/index.js';
+
+const digest = (seed: string): string => `${seed}-${'a'.repeat(64)}`;
+
+const runtime = {
+  implementationId: 'runtime-fixture',
+  version: '1.2.3',
+  fingerprint: digest('runtime'),
+  fingerprintBasis: 'content-derived',
+  assuranceLevel: 'verified',
+} as const;
+
+const provenance = {
+  provenanceKind: 'native',
+  trust: 'verified',
+  parentDigests: [] as string[],
+} as const;
+
+function card(overrides: Partial<CoreStudioRunCard> = {}): CoreStudioRunCard {
+  return {
+    cardKind: 'studio-core-run-card',
+    schemaVersion: CORE_STUDIO_RUN_CARD_SCHEMA_VERSION,
+    runId: 'core-run-1',
+    reportId: 'core-report-1',
+    runContractDigest: digest('contract'),
+    reportDigest: digest('report'),
+    artifactSetDigest: digest('set'),
+    createdAt: '2026-08-31T12:00:00.000Z',
+    status: {
+      runStatus: 'completed',
+      evidenceStatus: 'complete',
+      conclusionStatus: 'conclusive',
+    },
+    replayability: {
+      execution: 'self-contained',
+      evaluation: 'resolvable',
+    },
+    maximumCapturedClassification: 'sensitive',
+    ...overrides,
+  };
+}
+
+function detail(run: CoreStudioRunCard = card()): CoreStudioRunDetail {
+  return {
+    detailKind: 'studio-core-run-detail',
+    schemaVersion: CORE_STUDIO_RUN_DETAIL_SCHEMA_VERSION,
+    run,
+    dataset: {
+      datasetId: 'dataset-1',
+      datasetRevisionDigest: digest('dataset'),
+      sampleCount: 2,
+    },
+    targets: [{
+      targetId: 'target-1',
+      targetKind: 'prompt',
+      protocolId: 'omk.invoke/v1',
+      executorId: 'executor-1',
+    }],
+    evaluators: [{
+      evaluatorId: 'evaluator-1',
+      evaluatorKind: 'rubric',
+      implementationId: 'judge-1',
+      metricIds: ['quality'],
+      measurement: {
+        instrumentId: 'instrument-1',
+        ensembleMemberId: 'member-1',
+        replicateGroupId: 'replicate-1',
+        replicateIndex: 0,
+      },
+    }],
+    metrics: [{
+      metricId: 'quality',
+      valueType: 'numeric',
+      scope: 'sample',
+      scale: { min: 1, max: 5 },
+      unit: 'score',
+      direction: 'higher-is-better',
+    }],
+    stages: {
+      execution: {
+        bundleId: 'execution-1',
+        bundleDigest: digest('execution'),
+        stageStatus: 'completed',
+        coverage: {
+          planned: 2,
+          started: 2,
+          succeeded: 1,
+          failed: 1,
+          cancelled: 0,
+          budgetCensored: 0,
+          notStarted: 0,
+        },
+        replayability: 'self-contained',
+        budget: {
+          summaryStatus: 'within-budget',
+          admissionMode: 'strict-reservation',
+          invocations: 2,
+          activeDurationMs: 1200,
+          reportedProviderCosts: [{ amount: 0.012, currency: 'USD' }],
+          unreportedProviderCostInvocations: 1,
+          wallClock: { elapsedMs: 1300, limitMs: 5000, overshootMs: 0 },
+          ledgerDigest: digest('execution-ledger'),
+        },
+        provenance,
+        records: [{
+          targetId: 'target-1',
+          sampleId: 'sample-1',
+          trialIndex: 0,
+          trialId: 'trial-1',
+          executionStatus: 'failed',
+          runtime,
+          provenance,
+          cacheStatus: 'miss',
+          durationMs: 800,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          errorCode: 'executor-error',
+        }],
+      },
+      evaluation: {
+        bundleId: 'evaluation-1',
+        bundleDigest: digest('evaluation'),
+        parentExecutionBundleDigest: digest('execution'),
+        stageStatus: 'completed',
+        coverage: {
+          planned: 2,
+          eligible: 1,
+          sourceUnavailable: 1,
+          started: 1,
+          completed: 1,
+          failed: 0,
+          cancelled: 0,
+          notStarted: 0,
+        },
+        replayability: 'resolvable',
+        budget: {
+          summaryStatus: 'within-budget',
+          admissionMode: 'bounded-overshoot',
+          invocations: 1,
+          activeDurationMs: 500,
+          reportedProviderCosts: [],
+          unreportedProviderCostInvocations: 0,
+          wallClock: { elapsedMs: 550, overshootMs: 0 },
+          ledgerDigest: digest('evaluation-ledger'),
+        },
+        provenance,
+        records: [{
+          targetId: 'target-1',
+          sampleId: 'sample-1',
+          trialIndex: 0,
+          trialId: 'trial-1',
+          evaluatorId: 'evaluator-1',
+          measurement: {
+            instrumentId: 'instrument-1',
+            ensembleMemberId: 'member-1',
+            replicateGroupId: 'replicate-1',
+            replicateIndex: 0,
+          },
+          evaluationId: 'evaluation-record-1',
+          evaluationStatus: 'completed',
+          runtime,
+          provenance,
+          durationMs: 450,
+          observations: [{
+            observationId: digest('observation'),
+            metricId: 'quality',
+            observationStatus: 'observed',
+            valueType: 'numeric',
+            numericValue: 4.25,
+          }],
+        }],
+      },
+      analysis: {
+        bundleId: 'analysis-1',
+        bundleDigest: digest('analysis'),
+        parentEvaluationBundleDigest: digest('evaluation'),
+        stageStatus: 'completed',
+        coverage: {
+          planned: 1,
+          started: 1,
+          completed: 1,
+          inconclusive: 0,
+          failed: 0,
+          notStarted: 0,
+        },
+        provenance,
+        records: [{
+          resultId: 'result-1',
+          nodeId: 'mean-quality',
+          analysisNodeKind: 'estimator',
+          analysisStatus: 'completed',
+          analysisMode: 'preregistered',
+          runtime,
+          outputSchema: {
+            schemaVersion: 'omk.scalar/v1',
+            schemaDigest: digest('schema'),
+          },
+          coverage: {
+            planned: 2,
+            observed: 1,
+            missing: 0,
+            invalid: 0,
+            evaluationFailed: 0,
+            sourceUnavailable: 1,
+            notStarted: 0,
+            censored: 0,
+            included: 1,
+            excluded: 1,
+            comparable: 1,
+          },
+          exclusionCount: 1,
+          assumptionChecks: [{ assumptionId: 'minimum-n', checkStatus: 'passed' }],
+          recordDigest: digest('analysis-record'),
+          resultType: 'scalar',
+          numericValue: 4.25,
+        }],
+      },
+    },
+    decision: {
+      decisionPolicyId: 'progress-policy',
+      decisionStatus: 'decided',
+      implementation: runtime,
+      analysisResultIds: ['result-1'],
+      decisionDigest: digest('decision'),
+      verdict: 'PROGRESS',
+      reasonCodes: ['threshold-satisfied'],
+    },
+    reportProvenance: provenance,
+    lineage: [
+      ['run-plan', 'omk.run-plan/v1', 'plan'],
+      ['execution-bundle', 'omk.execution-bundle/v1', 'execution'],
+      ['evaluation-bundle', 'omk.evaluation-bundle/v1', 'evaluation'],
+      ['analysis-bundle', 'omk.analysis-bundle/v1', 'analysis'],
+      ['evaluation-report', 'omk.evaluation-report/v1', 'report'],
+    ].map(([documentKind, schemaVersion, seed]) => ({
+      documentKind: documentKind as CoreStudioRunDetail['lineage'][number]['documentKind'],
+      schemaVersion,
+      identityDigest: digest(`${seed}-identity`),
+      documentDigest: digest(`${seed}-document`),
+    })),
+  };
+}
+
+const routes = {
+  listPath: '/measurements',
+  detailPath: (runId: string): string => `/measurements/${encodeURIComponent(runId)}`,
+};
+
+describe('Core run renderer', () => {
+  it('renders every orthogonal status axis without synthesizing a quality verdict', () => {
+    const cards = [
+      card(),
+      card({ runId: 'cancelled', status: { runStatus: 'cancelled', evidenceStatus: 'partial', conclusionStatus: 'inconclusive' } }),
+      card({ runId: 'exhausted', status: { runStatus: 'budget-exhausted', evidenceStatus: 'unresolvable', conclusionStatus: 'not-evaluated' } }),
+      card({ runId: 'failed', status: { runStatus: 'failed', evidenceStatus: 'complete', conclusionStatus: 'conclusive' } }),
+    ];
+    const html = renderCoreRunList(cards, routes, 'zh');
+
+    for (const value of ['completed', 'cancelled', 'budget-exhausted', 'failed', 'complete', 'partial', 'unresolvable', 'conclusive', 'inconclusive', 'not-evaluated']) {
+      assert.ok(html.includes(value), `missing status: ${value}`);
+    }
+    assert.ok(html.includes('运行状态'));
+    assert.ok(html.includes('证据状态'));
+    assert.ok(html.includes('结论状态'));
+    assert.ok(!html.includes('综合状态'));
+    assert.ok(html.includes('href="/measurements/core-run-1"'));
+    assert.ok(!html.includes('localhost'));
+    assert.ok(!html.includes('127.0.0.1'));
+    assert.ok(!html.includes(':7799'));
+  });
+
+  it('renders plan, lineage, budgets, coverage, records, observations, analysis, and decision accessibly', () => {
+    const html = renderCoreRunDetail(detail(), routes, 'en');
+
+    for (const value of [
+      'Measurement plan',
+      'Artifact lineage',
+      'strict-reservation',
+      'sourceUnavailable=1',
+      'executor-error',
+      'quality:observed=4.25',
+      'mean-quality',
+      'PROGRESS',
+      'threshold-satisfied',
+    ]) {
+      assert.ok(html.includes(value), `missing detail: ${value}`);
+    }
+    assert.ok(html.includes('<main>'));
+    assert.ok(html.includes('<nav class="nav">'));
+    assert.ok(html.includes('<th scope=') || html.includes('<th>'));
+    assert.ok(html.includes('href="/measurements?lang=en"'));
+  });
+
+  it('escapes projected values and ignores fields outside the privacy allow-list', () => {
+    const sensitive = 'TOP-SECRET-RAW-CONTENT';
+    const maliciousCard = card({ runId: '<script>alert(1)</script>' });
+    const base = detail(maliciousCard);
+    const unsafe = {
+      ...base,
+      rawInput: sensitive,
+      stages: {
+        ...base.stages,
+        execution: {
+          ...base.stages.execution,
+          records: base.stages.execution.records.map((record) => ({ ...record, rawOutput: sensitive })),
+        },
+        analysis: {
+          ...base.stages.analysis,
+          records: base.stages.analysis.records.map((record) => ({ ...record, arbitraryTable: sensitive })),
+        },
+      },
+    } as unknown as CoreStudioRunDetail;
+    const html = renderCoreRunDetail(unsafe, routes);
+    const listHtml = renderCoreRunList([maliciousCard], routes);
+
+    assert.ok(!html.includes('<script>alert(1)</script>'));
+    assert.ok(html.includes('&lt;script&gt;alert(1)&lt;/script&gt;'));
+    assert.ok(!html.includes(sensitive));
+    assert.ok(listHtml.includes('/measurements/%3Cscript%3Ealert(1)%3C%2Fscript%3E'));
+  });
+});
+
+describe('Core Studio route handler', () => {
+  function catalog(source: CoreStudioRunDetail = detail()): CoreStudioCatalog {
+    return {
+      async list() { return [source.run]; },
+      async get(runId) { return runId === source.run.runId ? source : undefined; },
+      async inspect(runId) { return runId === source.run.runId ? source.run : undefined; },
+    };
+  }
+
+  it('serves HTML and JSON list/detail routes from the catalog port', async () => {
+    const handler = createCoreStudioRouteHandler({
+      catalog: catalog(),
+      htmlBasePath: '/core-runs',
+      apiBasePath: '/api/core-runs',
+    });
+
+    const list = await handler({ method: 'GET', url: '/core-runs?lang=en' });
+    assert.equal(list?.status, 200);
+    assert.ok(Object.isFrozen(list));
+    assert.ok(Object.isFrozen(list?.headers));
+    assert.equal(list?.headers['Content-Type'], 'text/html; charset=utf-8');
+    assert.ok(list?.body.includes('Evaluation Core Runs'));
+
+    const detailResponse = await handler({ method: 'GET', url: '/core-runs/core-run-1' });
+    assert.equal(detailResponse?.status, 200);
+    assert.ok(detailResponse?.body.includes('progress-policy'));
+
+    const apiList = await handler({ method: 'GET', url: '/api/core-runs' });
+    assert.deepEqual(JSON.parse(apiList?.body ?? ''), [card()]);
+    const apiDetail = await handler({ method: 'GET', url: '/api/core-runs/core-run-1' });
+    assert.deepEqual(JSON.parse(apiDetail?.body ?? ''), detail());
+  });
+
+  it('returns stable 404/405 responses and leaves unrelated routes untouched', async () => {
+    const handler = createCoreStudioRouteHandler({
+      catalog: catalog(),
+      htmlBasePath: '/core-runs',
+      apiBasePath: '/api/core-runs',
+    });
+
+    assert.equal(await handler({ method: 'GET', url: '/unrelated' }), undefined);
+    assert.equal((await handler({ method: 'GET', url: '/core-runs/missing' }))?.status, 404);
+    assert.equal((await handler({ method: 'GET', url: '/api/core-runs/%ZZ' }))?.status, 404);
+    assert.equal((await handler({ method: 'GET', url: '/core-runs/a/b' }))?.status, 404);
+    const method = await handler({ method: 'POST', url: '/api/core-runs' });
+    assert.equal(method?.status, 405);
+    assert.equal(method?.headers.Allow, 'GET');
+  });
+
+  it('redacts source failures from both HTML and JSON responses', async () => {
+    const unavailable: CoreStudioCatalog = {
+      async list() { throw new Error('TOP-SECRET-FILESYSTEM-PATH'); },
+      async get() { throw new Error('TOP-SECRET-FILESYSTEM-PATH'); },
+      async inspect() { throw new Error('TOP-SECRET-FILESYSTEM-PATH'); },
+    };
+    const handler = createCoreStudioRouteHandler({
+      catalog: unavailable,
+      htmlBasePath: '/core-runs',
+      apiBasePath: '/api/core-runs',
+    });
+
+    const htmlResponse = await handler({ url: '/core-runs' });
+    assert.equal(htmlResponse?.status, 503);
+    assert.ok(htmlResponse?.body.includes('Core 产物当前不可读取'));
+    assert.ok(!htmlResponse?.body.includes('TOP-SECRET'));
+    const jsonResponse = await handler({ url: '/api/core-runs/core-run-1' });
+    assert.deepEqual(JSON.parse(jsonResponse?.body ?? ''), { error: 'core_studio_source_unavailable' });
+    assert.ok(!jsonResponse?.body.includes('TOP-SECRET'));
+  });
+
+  it('rejects ambiguous base paths at construction time', () => {
+    assert.throws(() => createCoreStudioRouteHandler({
+      catalog: catalog(),
+      htmlBasePath: '/',
+      apiBasePath: '/api/core-runs',
+    }), /htmlBasePath/u);
+    assert.throws(() => createCoreStudioRouteHandler({
+      catalog: catalog(),
+      htmlBasePath: '/core-runs/',
+      apiBasePath: '/api/core-runs',
+    }), /htmlBasePath/u);
+    assert.throws(() => createCoreStudioRouteHandler({
+      catalog: catalog(),
+      htmlBasePath: '/core-runs',
+      apiBasePath: '/core-runs/api',
+    }), /must not overlap/u);
+  });
+});

--- a/test/server/core-studio-route-handler.test.ts
+++ b/test/server/core-studio-route-handler.test.ts
@@ -171,6 +171,7 @@ function detail(run: CoreStudioRunCard = card()): CoreStudioRunDetail {
           runtime,
           provenance,
           durationMs: 450,
+          usage: { inputTokens: 7, outputTokens: 8, totalTokens: 15 },
           observations: [{
             observationId: digest('observation'),
             metricId: 'quality',
@@ -286,12 +287,15 @@ describe('Core run renderer', () => {
       'Measurement plan',
       'Artifact lineage',
       'strict-reservation',
+      'overshoot=0ms',
+      'ledger=execution-ledger-',
       'sourceUnavailable=1',
       'executor-error',
       'quality:observed=4.25',
       'mean-quality',
       'PROGRESS',
       'threshold-satisfied',
+      'total 15',
     ]) {
       assert.ok(html.includes(value), `missing detail: ${value}`);
     }
@@ -326,6 +330,7 @@ describe('Core run renderer', () => {
     assert.ok(!html.includes('<script>alert(1)</script>'));
     assert.ok(html.includes('&lt;script&gt;alert(1)&lt;/script&gt;'));
     assert.ok(!html.includes(sensitive));
+    assert.ok(!listHtml.includes('<script>alert(1)</script>'));
     assert.ok(listHtml.includes('/measurements/%3Cscript%3Ealert(1)%3C%2Fscript%3E'));
   });
 });
@@ -377,6 +382,23 @@ describe('Core Studio route handler', () => {
     const method = await handler({ method: 'POST', url: '/api/core-runs' });
     assert.equal(method?.status, 405);
     assert.equal(method?.headers.Allow, 'GET');
+    const htmlMethod = await handler({ method: 'POST', url: '/core-runs?lang=en' });
+    assert.equal(htmlMethod?.status, 405);
+    assert.ok(htmlMethod?.body.includes('Only GET requests are supported.'));
+  });
+
+  it('round-trips encoded run identifiers as a single route segment', async () => {
+    const encoded = detail(card({ runId: 'group/run?1' }));
+    const handler = createCoreStudioRouteHandler({
+      catalog: catalog(encoded),
+      htmlBasePath: '/core-runs',
+      apiBasePath: '/api/core-runs',
+    });
+
+    const list = await handler({ url: '/core-runs' });
+    assert.ok(list?.body.includes('/core-runs/group%2Frun%3F1'));
+    assert.equal((await handler({ url: '/core-runs/group%2Frun%3F1' }))?.status, 200);
+    assert.equal((await handler({ url: '/api/core-runs/group%2Frun%3F1' }))?.status, 200);
   });
 
   it('redacts source failures from both HTML and JSON responses', async () => {


### PR DESCRIPTION
## 用户影响

- 新增 Evaluation Core 运行列表与详情 renderer，直接展示正交状态轴、阶段覆盖、预算、记录、数值观测、分析、决策和五文档谱系。
- 新增只依赖 CoreStudioCatalog 的独立 HTTP route handler，提供调用方可配置的 HTML／JSON 列表与详情路由。
- 所有投影值统一转义，source failure 使用稳定脱敏响应；页面补齐中英文与表格无障碍语义。

## 迁移说明

本 PR 不挂载现有 createReportServer，不改变生产 Studio 路由、CLI 或旧报告读取链路。最终切换将在 #450 的 BREAKING-SCHEMA PR 中一次性完成，不引入 legacy fallback、shadow read 或双视图。

## 测量学说明

renderer 只消费 #535 定义的版本化安全视图，不修改 evaluator、评分类 prompt、analysis formula、missing-data policy 或 Decision 语义。run、evidence 与 conclusion status 始终独立展示，不从分数合成总体状态，因此本 PR 不属于 BREAKING-COMPARABILITY。

Closes #537
Related to #450
