### PR TITLE
feat(eval-workflows): 实现生产输入解析与测量设计

### DIFF
--- a/docs/specs/cli-evaluation-input-compilation.md
+++ b/docs/specs/cli-evaluation-input-compilation.md
@@ -1,6 +1,6 @@
 # CLI Evaluation Input Compilation
 
-> **Status**: implemented as the migration foundation for [#451](https://github.com/lizhiyao/oh-my-knowledge/issues/451), under the [Evaluation Core vNext RFC](./evaluation-core-vnext.md). This layer does not switch the production `omk eval` pipeline and does not call `createEvaluationEngine()`.
+> **Status**: parse, the Node production resolver, and compilation are implemented under the [Evaluation Core vNext RFC](./evaluation-core-vnext.md). The production Runtime registry, host workflow, and `omk eval` cutover remain deliberately disconnected, so this layer still does not execute or persist a Core Run.
 
 ## 1. Purpose and boundary
 
@@ -39,6 +39,7 @@ EvaluationPresentationOptions + static RunOptions metadata
 - `RuntimeBindingRequest` v3 contains only implementation and resource-lease requirements derived from Definition／resolved host resources. Executor qualification reuses the exact canonical `TargetDefinition.executionRequirements`; it does not maintain a second approximation. A registry may resolve bindings, but cannot override execution requirements, model, effort, prompt variant, protocol, evaluator identity, or behavior config. Its complete assembly contract is specified in [Evaluation Runtime Adapter](./evaluation-runtime-adapter.md).
 - `ResolvedHostResources` binds a stable resource ID and digest to an effect locator. It is not a Core schema and never enters canonical measurement JSON.
 - `EvaluationOrchestrationOptions` owns dry-run, resume locator, batch, independent Series repeats, preflight switches, diagnostic post-processing, gold post-hoc workflows, and managed-evidence append behavior.
+- Sample-bundle `requires` is normalized as host-only `dependencyRequirements`, together with its `baseDirectoryLocator`, for the later doctor/preflight workflow. Relative files and preflight commands therefore keep the sample bundle's resolution semantics. This host context does not enter Core measurement digests and is never silently discarded.
 - `EvaluationPresentationOptions` owns output locator, index scope, language, server, verbosity, layered view, and CLI exit presentation. None changes `DecisionResult`.
 - Static RunOptions metadata may contain serializable annotations and summaries. The orchestrator creates run ID, cancellation, event writer, and buffers only when a Run actually starts.
 
@@ -53,7 +54,7 @@ Behavior identity and source lineage are separate axes:
 - Host resources contain locator, resolved commit, repository origin, and materialization evidence. Moving the same content between absolute/relative paths or machines does not invalidate execution identity.
 - A behavior change changes the Definition digest. A lineage-only change is assessed later by explicit comparability and provenance policy, not smuggled into Target config.
 
-Mock rules and strict mode enter Target behavior. Every payload is a digest-bound descriptor; inline secret or gold content is forbidden. Compile also requires every reference role to match its host resource kind: artifact, workspace, MCP config, mock payload, evaluator content, and gold dataset cannot be substituted for one another even when a descriptor happens to match. Runtime adapters must verify the digest immediately before use. Missing interception, allowed-tool, skill-discovery, MCP, cancellation, seed, or sandbox capability fails closed during Core prepare; adapters must never drop mocks or fall back to real external calls.
+Mock rules and strict mode enter Target behavior, while each binding explicitly lists the `sampleIds` whose Trials may observe it. `sampleId` is supplied by Core to the adapter and is never appended to the model prompt. Every payload is a digest-bound descriptor; inline secret or gold content is forbidden. Compile also requires every reference role to match its host resource kind: artifact, workspace, MCP config, mock payload, evaluator content, and gold dataset cannot be substituted for one another even when a descriptor happens to match. Runtime adapters must verify the digest immediately before use. Missing interception, allowed-tool, skill-discovery, MCP, cancellation, seed, or sandbox capability fails closed during Core prepare; adapters must never drop mocks or fall back to real external calls. Until Target contracts gain general sample-scoped execution controls, heterogeneous sample `cwd` or `allowedTools` requests fail resolution rather than being unioned into a different experiment.
 
 `ResolvedHostResources` v2 makes `descriptor.size` mandatory and represents pinned Git verification as `{verificationKind, verifiedDigest, commitId}`. The commit ID is a normalized 40–64 character lowercase hexadecimal object identity; a branch or tag name is not a pin. File-only MCP, mock, and evaluator-content resources require `content-digest`; workspaces require `tree-digest` or `pinned-git`; pinned Git is limited to artifacts and workspaces. `gold` classification and `gold-dataset` kind are mutually required. The incomplete v1 shape is rejected without a compatibility reader.
 
@@ -62,10 +63,13 @@ Dataset projections preserve the Gold boundary: Executors see only `input + exec
 ## 4. Measurement mapping
 
 - Control/treatment is represented only by `Comparison`; artifact contents are Target behavior.
-- Assertions, rubric judges, dimensions, composites, and RAG metrics remain distinct Evaluator/Metric/AnalysisGraph concepts.
+- Assertions, rubric judges, dimensions, composites, and RAG metrics remain distinct Evaluator/Metric/AnalysisGraph concepts. An Evaluator template owns its algorithm `implementationId`, instrument, and runtime prompt variant; a judge member owns only provider executor, model, effort, and ensemble identity.
 - Judge members carry explicit instrument, ensemble member, replicate group, and replicate index. No analysis may parse evaluator IDs to infer hierarchy.
 - Holdout/cohort membership is analysis-only and fixed before execution.
 - Bootstrap, correction, thresholds, and trivial-difference gates are Definition facts in AnalysisGraph or DecisionPolicy.
+- Every treatment has its own explicit paired control comparison; multi-treatment requests never collapse into one ambiguous treatment identifier.
+- Deterministic assertion evaluators emit explicit structural-missing observations when a criterion does not apply. LLM assertions and rubric dimensions instead seal canonical `applicableSampleIds`; Core omits non-applicable Evaluator coordinates from plan identity, coverage, execution, and analysis rather than scoring an unintended sample.
+- The production design uses paired blocks with `seedCoupling: uncontrolled`: current provider adapters expose no exact sampling-seed control. The host may deterministically randomize coordinate order, but it must not claim coupled model randomness.
 - Length debias changes rubric evaluator config; presentation/tone neutralization remains always on.
 - Legacy total USD maps to a shared Run provider-cost limit. Per-sample USD and milliseconds map to per-coordinate provider-cost and active-duration limits. They are not implemented by a host `AbortController` or report rewrite.
 
@@ -110,7 +114,7 @@ Parse and compilation errors are host `CliEvaluationInputError` values with stab
 
 This layer is additive. The production `omk eval` command continues to use `RunConfig → runEvaluation → executeEvaluationPipeline`; it does not double-run, shadow-run, persist Core Bundles, or change legacy reports. A later Runtime-adapter change may consume only the contracts emitted here and may not parse CLI inputs again.
 
-Target execution requirements make the migration contracts intentionally incompatible: resolved compiler input is `omk.resolved-cli-evaluation-input/v2`, and binding output is `omk.runtime-binding-request/v3`. Earlier shapes are rejected without inference or a compatibility reader. The Core v1 Definition／Plan JSON Schemas gain a required Target field and this change is released as `BREAKING-SCHEMA`; no scoring or statistical comparability invariant changes.
+The migration contracts are intentionally incompatible: resolved compiler input is `omk.resolved-cli-evaluation-input/v3`, including sample-scoped mock bindings and Evaluator-owned implementation identity; binding output is `omk.runtime-binding-request/v3`. Earlier shapes are rejected without inference or a compatibility reader. No scoring or statistical comparability invariant changes.
 
 The legacy `--no-cache`／`noCache` boolean has no faithful Core equivalent: its enabled state meant stochastic read-through execution reuse and said nothing about Evaluation cache. The registry therefore marks it for replacement rather than mapping it to `transparent-deterministic` or `reuse`. The final cutover may remove the old cache files and behavior without a compatibility reader.
 

--- a/docs/zh/specs/cli-evaluation-input-compilation.md
+++ b/docs/zh/specs/cli-evaluation-input-compilation.md
@@ -1,6 +1,6 @@
 # CLI 评测输入编译规范
 
-> **状态**：作为 [#451](https://github.com/lizhiyao/oh-my-knowledge/issues/451) 的迁移基础实现，服从 [Evaluation Core vNext RFC](./evaluation-core-vnext.md)。本层不切换正式 `omk eval` pipeline，也不调用 `createEvaluationEngine()`。
+> **状态**：Parse、Node 生产 resolver 与 Compile 已按 [Evaluation Core vNext RFC](./evaluation-core-vnext.md) 实现。生产 Runtime registry、宿主 workflow 与正式 `omk eval` 切换仍有意保持断开，因此本层尚不执行或持久化 Core Run。
 
 ## 一、目的与边界
 
@@ -39,6 +39,7 @@ EvaluationPresentationOptions + static RunOptions metadata
 - `RuntimeBindingRequest` v3 只保存从 Definition／已解析宿主资源派生的 implementation 和 resource lease requirement。Executor qualification 直接复用 canonical `TargetDefinition.executionRequirements`，不维护第二份近似语义。宿主 registry 可以解析 binding，但不能覆盖 execution requirement、model、effort、prompt variant、protocol、evaluator identity 或行为配置。完整装配契约见 [Evaluation Runtime Adapter 规范](./evaluation-runtime-adapter.md)；
 - `ResolvedHostResources` 用稳定 resource ID 和 digest 绑定 effect locator。它不是 Core schema，也不进入 canonical measurement JSON；
 - `EvaluationOrchestrationOptions` 负责 dry-run、resume locator、batch、独立 Series repeat、preflight 开关、diagnostic 后处理、gold post-hoc workflow 和受管证据追加；
+- Sample bundle 的 `requires` 会连同 `baseDirectoryLocator` 规范化成宿主侧 `dependencyRequirements`，供后续 doctor／preflight workflow 消费；相对文件与 preflight 命令因此继续锚定 sample bundle 根目录。该宿主上下文不进入 Core 测量 digest，也不能被静默丢弃；
 - `EvaluationPresentationOptions` 负责输出 locator、索引范围、语言、server、verbose、layered view 和 CLI exit 展示。这些字段都不能改变 `DecisionResult`；
 - 静态 RunOptions metadata 可以保存可序列化的 annotation 和 summary。只有真正启动 Run 时，orchestrator 才创建 run ID、取消信号、EventWriter 和 buffer。
 
@@ -53,7 +54,7 @@ EvaluationPresentationOptions + static RunOptions metadata
 - Host resources 保存 locator、resolved commit、仓库来源和 materialization 证据。同一内容在绝对／相对路径或不同机器间移动，不会让 execution identity 失效；
 - 行为变化会改变 Definition digest。只有 lineage 变化时，后续由显式 comparability／provenance policy 判断，不能偷偷塞进 Target config。
 
-Mock match rule 和 strict mode 进入 Target 行为。每份 payload 都是 digest-bound descriptor；禁止内联 secret 或 gold 内容。Compile 还要求每个引用角色匹配对应的宿主资源类型：artifact、workspace、MCP config、mock payload、evaluator content 和 gold dataset 即使 descriptor 恰好相同，也不能相互替代。Runtime adapter 在使用前必须重新校验 digest。缺少 interception、allowed-tool、skill-discovery、MCP、cancellation、seed 或 sandbox capability 时，Core prepare 必须 fail closed；adapter 不能删除 mock，也不能降级成真实外部调用。
+Mock match rule 和 strict mode 进入 Target 行为，每个 binding 通过 `sampleIds` 显式限定可观察它的 Trial。`sampleId` 由 Core 交给 adapter，绝不拼入模型 prompt。每份 payload 都是 digest-bound descriptor；禁止内联 secret 或 gold 内容。Compile 还要求每个引用角色匹配对应的宿主资源类型：artifact、workspace、MCP config、mock payload、evaluator content 和 gold dataset 即使 descriptor 恰好相同，也不能相互替代。Runtime adapter 在使用前必须重新校验 digest。缺少 interception、allowed-tool、skill-discovery、MCP、cancellation、seed 或 sandbox capability 时，Core prepare 必须 fail closed；adapter 不能删除 mock，也不能降级成真实外部调用。在 Target contract 能表达通用 sample-scoped execution control 前，不同 sample 的 `cwd` 或 `allowedTools` 会在 Resolve 阶段失败，不能取并集后悄悄改变实验。
 
 `ResolvedHostResources` v2 要求 `descriptor.size` 必填，并把 pinned Git verification 表达为 `{verificationKind, verifiedDigest, commitId}`。`commitId` 必须是规范化的 40–64 位小写十六进制对象身份，branch 或 tag 名不是 pin。仅文件的 MCP、mock 和 evaluator content 资源必须使用 `content-digest`；workspace 必须使用 `tree-digest` 或 `pinned-git`；pinned Git 仅适用于 artifact 和 workspace。`gold` classification 与 `gold-dataset` kind 必须同时成立。不完整的 v1 结构会被直接拒绝，不提供 compatibility reader。
 
@@ -62,10 +63,13 @@ Dataset 投影保护 Gold 边界：Executor 只看到 `input + executionContext`
 ## 四、测量映射
 
 - control／treatment 角色只进入 `Comparison`，artifact 内容属于 Target 行为；
-- assertion、rubric 评委、dimension、composite 和 RAG metric 仍是不同的 Evaluator／Metric／AnalysisGraph 概念；
+- assertion、rubric 评委、dimension、composite 和 RAG metric 仍是不同的 Evaluator／Metric／AnalysisGraph 概念。Evaluator template 持有算法 `implementationId`、instrument 与 runtime prompt variant；judge member 只持有 provider executor、model、effort 与 ensemble identity；
 - 评委成员显式携带 instrument、ensemble member、replicate group 和 replicate index。分析代码不得解析 evaluator ID 推断层级；
 - holdout／cohort membership 只进入 analysis，并在执行前固定；
 - bootstrap、correction、threshold 和 trivial-difference gate 是 AnalysisGraph 或 DecisionPolicy 中的 Definition 事实；
+- 每个 treatment 都有独立、显式的 paired control comparison，多 treatment 请求不能压成一个含混的 treatment identity；
+- 确定性 assertion evaluator 在 criterion 不适用时产出显式 structural-missing observation。LLM assertion 与 rubric dimension 则封存 canonical `applicableSampleIds`；Core 会从 plan identity、coverage、execution 与 analysis 中排除不适用的 Evaluator coordinate，不能误评到其它 sample；
+- 生产设计使用 paired block 与 `seedCoupling: uncontrolled`：当前 provider adapter 都不具备精确 sampling seed control。宿主可以确定性随机化 coordinate 顺序，但不能声称模型随机性已经耦合；
 - length debias 改变 rubric evaluator config；排版／语气中性化恒开；
 - 旧 total USD 映射为共享 Run provider-cost limit；per-sample USD 和毫秒映射为 per-coordinate provider-cost／active-duration limit。不得用宿主 `AbortController` 或事后改写 report 实现。
 
@@ -110,7 +114,7 @@ Parse 和 Compile 错误使用宿主 `CliEvaluationInputError`，包含稳定 co
 
 本层是增量架构。正式 `omk eval` 仍走 `RunConfig → runEvaluation → executeEvaluationPipeline`；不双跑、不 shadow run、不持久化 Core Bundle，也不改变旧 Report。后续 Runtime adapter 只能消费这里产出的 contract，不能重新解析 CLI 输入。
 
-Target execution requirement 会让迁移 contract 有意不兼容：resolved compiler input 升级为 `omk.resolved-cli-evaluation-input/v2`，binding output 升级为 `omk.runtime-binding-request/v3`。旧结构会直接被拒绝，不做推断，也不提供 compatibility reader。Core v1 Definition／Plan JSON Schema 增加 Target 必填字段，本次改动按 `BREAKING-SCHEMA` 发布；评分与统计可比性不变量不变。
+迁移 contract 有意不兼容：resolved compiler input 使用 `omk.resolved-cli-evaluation-input/v3`，包含 sample-scoped mock binding 与 Evaluator 自有 implementation identity；binding output 使用 `omk.runtime-binding-request/v3`。旧结构会直接被拒绝，不做推断，也不提供 compatibility reader。评分与统计可比性不变量不变。
 
 旧 `--no-cache`／`noCache` boolean 没有忠实的 Core 等价语义：它的 enabled 状态表示 stochastic read-through execution reuse，却没有表达 Evaluation cache。Registry 因此把它标记为 replace，不再映射成 `transparent-deterministic` 或 `reuse`。最终切换可以直接删除旧 cache 文件与旧行为，不保留 compatibility reader。
 

--- a/src/eval-workflows/input-compilation/compile.ts
+++ b/src/eval-workflows/input-compilation/compile.ts
@@ -263,6 +263,27 @@ function validateHostOptions(input: ResolvedCliEvaluationInput): void {
     fieldPath: 'presentation',
     message: 'EvaluationPresentationOptions 包含不合法的规范值。',
   });
+  const dependencyRequirements = orchestration.dependencyRequirements;
+  if (dependencyRequirements !== undefined
+      && (typeof dependencyRequirements.baseDirectoryLocator !== 'string'
+        || dependencyRequirements.baseDirectoryLocator.trim() === '')) fail({
+    code: 'CLI_INPUT_INVALID',
+    fieldPath: 'orchestration.dependencyRequirements.baseDirectoryLocator',
+    message: 'Dependency requirement 必须声明非空的宿主 base directory locator。',
+  });
+  for (const [requirementKind, values] of Object.entries(
+    dependencyRequirements ?? {},
+  ).filter(([key]) => key !== 'baseDirectoryLocator')) {
+    if (!['tools', 'files', 'env', 'preflight'].includes(requirementKind)
+        || !Array.isArray(values)
+        || values.length === 0
+        || values.some((value) => typeof value !== 'string' || value.trim() === '')
+        || new Set(values).size !== values.length) fail({
+      code: 'CLI_INPUT_INVALID',
+      fieldPath: `orchestration.dependencyRequirements.${requirementKind}`,
+      message: 'Dependency requirement 必须是非空、无重复的字符串数组。',
+    });
+  }
   const cache = input.policy.cache;
   if (cache === null || typeof cache !== 'object' || Array.isArray(cache)) fail({
     code: 'CLI_INPUT_INVALID',
@@ -1105,6 +1126,16 @@ export function compileCliEvaluationInput(
     preflight: resolvedInput.orchestration.preflight,
     diagnostic: resolvedInput.orchestration.diagnostic,
     managedEvidence: resolvedInput.orchestration.managedEvidence,
+    ...(resolvedInput.orchestration.dependencyRequirements === undefined ? {} : {
+      dependencyRequirements: {
+        baseDirectoryLocator:
+          resolvedInput.orchestration.dependencyRequirements.baseDirectoryLocator,
+        ...Object.fromEntries(Object.entries(
+          resolvedInput.orchestration.dependencyRequirements,
+        ).filter(([key]) => key !== 'baseDirectoryLocator')
+          .map(([key, values]) => [key, [...values].sort(compareStrings)])),
+      },
+    }),
     ...(resolvedInput.orchestration.cacheSources === undefined ? {} : {
       cacheSources: resolvedInput.orchestration.cacheSources,
     }),

--- a/src/eval-workflows/input-compilation/types.ts
+++ b/src/eval-workflows/input-compilation/types.ts
@@ -254,6 +254,15 @@ export interface ResolvedEvaluationOrchestrationInput {
   };
   readonly diagnostic: 'enabled-outside-core' | 'disabled';
   readonly managedEvidence: 'append' | 'skip';
+  /** Normalized sample-bundle readiness requirements for the host doctor phase. */
+  readonly dependencyRequirements?: {
+    /** Host-only base for relative files and preflight commands. */
+    readonly baseDirectoryLocator: string;
+    readonly tools?: readonly string[];
+    readonly files?: readonly string[];
+    readonly env?: readonly string[];
+    readonly preflight?: readonly string[];
+  };
   /** Effect locators used to assemble cache ports; never enter Core canonical JSON. */
   readonly cacheSources?: {
     readonly executionSourceLocator?: string;

--- a/src/eval-workflows/production-host/index.ts
+++ b/src/eval-workflows/production-host/index.ts
@@ -1,0 +1,2 @@
+export * from './measurement-design.js';
+export * from './node-cli-evaluation-resolver.js';

--- a/src/eval-workflows/production-host/measurement-design.ts
+++ b/src/eval-workflows/production-host/measurement-design.ts
@@ -547,11 +547,13 @@ export function buildProductionMeasurementDesign(
         seed: DEFAULT_BOOTSTRAP_SEED,
       },
     });
-    const firstJudge = [...rubricDimensions.values()][0];
+    // Legacy release gating only measured agreement for the top-level rubric.
+    // Choosing an arbitrary named dimension would make verdicts depend on lexical order.
+    const decisionJudge = rubricDimensions.get('overall');
     const analysisResultIds = [
       'composite-table',
       'bootstrap-family',
-      ...(firstJudge === undefined ? [] : [`judge-ensemble-${firstJudge.metricId}`]),
+      ...(decisionJudge === undefined ? [] : [`judge-ensemble-${decisionJudge.metricId}`]),
     ];
     const holdout = request.values.measurement.holdoutRatio === undefined
       ? null
@@ -563,7 +565,7 @@ export function buildProductionMeasurementDesign(
       comparisonFamily: treatments.map((target) => ({
         comparisonId: `control-vs-${target.targetId}`,
         treatmentTargetId: target.targetId,
-        metricId: firstJudge?.metricId ?? metrics[0]!.metricId,
+        metricId: decisionJudge?.metricId ?? metrics[0]!.metricId,
         analysisResultId: 'bootstrap-family',
       })),
       comparisonFamilyResultId: 'bootstrap-family',
@@ -572,12 +574,12 @@ export function buildProductionMeasurementDesign(
         sources: {
           compositeResultId: 'composite-table',
           bootstrapFamilyResultId: 'bootstrap-family',
-          ...(firstJudge === undefined ? {} : {
+          ...(decisionJudge === undefined ? {} : {
             judgeEnsemble: {
-              analysisResultId: `judge-ensemble-${firstJudge.metricId}`,
-              metricId: firstJudge.metricId,
+              analysisResultId: `judge-ensemble-${decisionJudge.metricId}`,
+              metricId: decisionJudge.metricId,
               instrumentId: rubricInstrumentId,
-              replicateGroupId: `rubric-${firstJudge.dimensionId}`,
+              replicateGroupId: `rubric-${decisionJudge.dimensionId}`,
             },
           }),
         },

--- a/src/eval-workflows/production-host/measurement-design.ts
+++ b/src/eval-workflows/production-host/measurement-design.ts
@@ -1,0 +1,682 @@
+import {
+  digestCanonicalJson,
+  type AnalysisCohortDefinition,
+  type AnalysisGraphDefinition,
+  type DecisionPolicyDefinition,
+  type EvaluationSample,
+  type JsonValue,
+  type MetricDefinition,
+} from '../../evaluation-core/contracts/index.js';
+import { DEFAULT_BOOTSTRAP_SEED } from '../../eval-core/bootstrap.js';
+import { splitHoldout } from '../../eval-core/holdout.js';
+import { renderEnvironmentSection } from '../../eval-core/task-planner.js';
+import { deterministicAssertionInputSourceKinds } from '../../shared/assertions/deterministic.js';
+import { resolveAssertionLayer } from '../../shared/assertions/layers.js';
+import type { Assertion, Sample } from '../../types/index.js';
+import type {
+  CliEvaluationRequest,
+  ResolvedEvaluatorTemplate,
+  ResolvedJudgeMember,
+} from '../input-compilation/index.js';
+import {
+  ASSERTION_LAYER_ANALYSIS_IMPLEMENTATION_ID,
+  BOOTSTRAP_FAMILY_ANALYSIS_IMPLEMENTATION_ID,
+  COMPOSITE_ANALYSIS_IMPLEMENTATION_ID,
+  DIMENSION_ANALYSIS_IMPLEMENTATION_ID,
+  JUDGE_ENSEMBLE_ANALYSIS_IMPLEMENTATION_ID,
+  JUDGE_REPLICATE_ANALYSIS_IMPLEMENTATION_ID,
+  RELEASE_DECISION_POLICY_IMPLEMENTATION_ID,
+} from '../runtime-adapter/analysis/index.js';
+import {
+  EXECUTION_ASSERTION_BINDINGS,
+  EXECUTION_ASSERTION_CONTEXT_SCHEMA_VERSION,
+  EXECUTION_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+  LLM_ASSERTION_BINDINGS,
+  LLM_ASSERTION_CONTEXT_SCHEMA_VERSION,
+  LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+  OUTPUT_ASSERTION_BINDINGS,
+  OUTPUT_ASSERTION_CONTEXT_SCHEMA_VERSION,
+  OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+  RUBRIC_JUDGE_BINDINGS,
+  RUBRIC_JUDGE_CONTEXT_SCHEMA_VERSION,
+  RUBRIC_JUDGE_EVALUATOR_IMPLEMENTATION_ID,
+  llmAssertionInstrument,
+  rubricJudgeInstrument,
+  rubricJudgeInstrumentId,
+  type LlmAssertionType,
+} from '../runtime-adapter/evaluators/index.js';
+import { CliEvaluationInputError } from '../input-compilation/error.js';
+
+const LLM_ASSERTION_TYPES = new Set<LlmAssertionType>([
+  'semantic_similarity',
+  'faithfulness',
+  'answer_relevancy',
+  'context_recall',
+]);
+
+interface CriterionDesign {
+  readonly criterionId: string;
+  readonly metricId: string;
+  readonly layerDisposition: 'fact' | 'behavior' | 'excluded-mixed-layer';
+  readonly weight: number;
+}
+
+export interface ProductionMeasurementDesign {
+  readonly dataset: {
+    readonly datasetId: string;
+    readonly samples: readonly EvaluationSample[];
+    readonly analysisCohorts?: readonly AnalysisCohortDefinition[];
+  };
+  readonly evaluatorTemplates: readonly ResolvedEvaluatorTemplate[];
+  readonly judges: {
+    readonly enabled: boolean;
+    readonly members: readonly ResolvedJudgeMember[];
+    readonly replicateCount: number;
+  };
+  readonly metrics: readonly MetricDefinition[];
+  readonly analysisGraph: AnalysisGraphDefinition;
+  readonly decisionPolicy?: DecisionPolicyDefinition;
+}
+
+function fail(fieldPath: string, message: string): never {
+  throw new CliEvaluationInputError({
+    code: 'CLI_INPUT_INVALID',
+    fieldPath,
+    message,
+  });
+}
+
+function digestId(prefix: string, value: JsonValue): string {
+  return `${prefix}-${digestCanonicalJson(value).slice('sha256:'.length, 'sha256:'.length + 16)}`;
+}
+
+function renderedPrompt(sample: Readonly<Sample>): string {
+  const environment = renderEnvironmentSection(sample.environment);
+  const prompt = sample.context
+    ? `${sample.prompt}\n\n\`\`\`\n${sample.context}\n\`\`\``
+    : sample.prompt;
+  return environment === null ? prompt : `${environment}\n\n---\n\n${prompt}`;
+}
+
+function annotations(sample: Readonly<Sample>): JsonValue | undefined {
+  const value: Record<string, JsonValue> = {};
+  if (sample.capability !== undefined) value.capability = [...sample.capability];
+  if (sample.difficulty !== undefined) value.difficulty = sample.difficulty;
+  if (sample.construct !== undefined) value.construct = sample.construct;
+  if (sample.provenance !== undefined) value.provenance = sample.provenance;
+  if (sample.tripwire !== undefined) value.tripwire = sample.tripwire;
+  if (sample.covers !== undefined) {
+    value.covers = structuredClone(sample.covers) as unknown as JsonValue;
+  }
+  return Object.keys(value).length === 0 ? undefined : value;
+}
+
+function criterionIdentity(
+  sampleId: string,
+  assertion: Readonly<Assertion>,
+  index: number,
+): { criterionId: string; metricId: string } {
+  const identity = { sampleId, assertion: assertion as unknown as JsonValue, index };
+  return {
+    criterionId: digestId('criterion', identity),
+    metricId: digestId('assertion', identity),
+  };
+}
+
+function metric(metricId: string, valueType: 'boolean' | 'numeric'): MetricDefinition {
+  return {
+    metricId,
+    valueType,
+    scope: 'sample',
+    ...(valueType === 'numeric' ? { scale: { min: 1, max: 5 } } : {}),
+    direction: 'higher-is-better',
+    missingPolicyId: 'exclude/v1',
+  };
+}
+
+function llmCriterion(
+  type: LlmAssertionType,
+  criterionId: string,
+  assertion: Readonly<Assertion>,
+  sample: Readonly<Sample>,
+): JsonValue {
+  const source = type === 'faithfulness'
+    ? assertion.reference ?? sample.context
+    : type === 'answer_relevancy'
+      ? sample.prompt
+      : assertion.reference ?? (type === 'context_recall' ? sample.context : undefined);
+  if (source === undefined || source.trim() === '') {
+    fail(
+      `samples.${sample.sample_id}.assertions`,
+      `LLM assertion「${type}」缺少可冻结的 reference／context／question。`,
+    );
+  }
+  return {
+    schemaVersion: LLM_ASSERTION_CONTEXT_SCHEMA_VERSION,
+    criterionId,
+    assertionType: type,
+    threshold: assertion.threshold ?? 3,
+    weight: assertion.weight ?? 1,
+    negated: assertion.not ?? false,
+    ...(type === 'faithfulness' ? { context: source }
+      : type === 'answer_relevancy' ? { question: source }
+        : { reference: source }),
+  };
+}
+
+/** Converts legacy authoring DTOs once; no legacy object escapes this boundary. */
+export function buildProductionMeasurementDesign(
+  request: Readonly<CliEvaluationRequest>,
+  sourceSamples: readonly Readonly<Sample>[],
+): ProductionMeasurementDesign {
+  if (sourceSamples.length === 0) fail('samples', 'Evaluation dataset 至少需要一个 sample。');
+  const sortedSamples = [...sourceSamples].sort((left, right) => (
+    left.sample_id < right.sample_id ? -1 : left.sample_id > right.sample_id ? 1 : 0
+  ));
+  const sampleIds = sortedSamples.map((sample) => sample.sample_id);
+  if (new Set(sampleIds).size !== sampleIds.length) fail('samples[].sample_id', 'sampleId 不得重复。');
+
+  const evaluationContexts = new Map<string, Record<string, JsonValue>>();
+  const metrics: MetricDefinition[] = [];
+  const criteria: CriterionDesign[] = [];
+  const templates: ResolvedEvaluatorTemplate[] = [];
+  const outputMetricIds: string[] = [];
+  const outputCriteriaBySample = new Map<string, JsonValue[]>();
+  const executionGroups = new Map<string, {
+    readonly sourceKinds: readonly ('output' | 'execution-facts' | 'trace')[];
+    readonly metricIds: string[];
+    readonly criteriaBySample: Map<string, JsonValue[]>;
+  }>();
+
+  const contextFor = (sampleId: string): Record<string, JsonValue> => {
+    const existing = evaluationContexts.get(sampleId);
+    if (existing !== undefined) return existing;
+    const created: Record<string, JsonValue> = {};
+    evaluationContexts.set(sampleId, created);
+    return created;
+  };
+
+  for (const sample of sortedSamples) {
+    for (const [index, assertion] of (sample.assertions ?? []).entries()) {
+      const identity = criterionIdentity(sample.sample_id, assertion, index);
+      const layer = resolveAssertionLayer(assertion) ?? 'excluded-mixed-layer';
+      const weight = assertion.weight ?? 1;
+      if (LLM_ASSERTION_TYPES.has(assertion.type as LlmAssertionType)) {
+        if (!request.values.judges.enabled) continue;
+        const assertionType = assertion.type as LlmAssertionType;
+        const instrument = llmAssertionInstrument(assertionType);
+        const contextKey = digestId('llmCriterion', {
+          sampleId: sample.sample_id,
+          criterionId: identity.criterionId,
+        });
+        contextFor(sample.sample_id)[contextKey] = llmCriterion(
+          assertionType,
+          identity.criterionId,
+          assertion,
+          sample,
+        );
+        metrics.push(metric(identity.metricId, 'boolean'));
+        criteria.push({ ...identity, layerDisposition: layer, weight });
+        templates.push({
+          evaluatorId: digestId('llm-assertion', { criterionId: identity.criterionId }),
+          evaluatorKind: 'llm-rubric',
+          runtimeBindingKind: 'judge',
+          implementationId: LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+          applicableSampleIds: [sample.sample_id],
+          instrumentId: instrument.promptId,
+          runtimePromptVariant: instrument.promptId,
+          replicateGroupId: digestId('llm-assertion-group', {
+            assertionType,
+            criterionId: identity.criterionId,
+          }),
+          metricIds: [identity.metricId],
+          inputs: [
+            { bindingId: LLM_ASSERTION_BINDINGS.actual, sourceKind: 'output', pointer: '' },
+            {
+              bindingId: LLM_ASSERTION_BINDINGS.criterion,
+              sourceKind: 'evaluation-context',
+              pointer: `/${contextKey}`,
+            },
+          ],
+          config: { classification: 'public', value: instrument as unknown as JsonValue },
+        });
+        continue;
+      }
+      if (assertion.type === 'custom') {
+        fail(
+          `samples.${sample.sample_id}.assertions.${index}`,
+          'Evaluation Core production resolver 不接受进程内 custom assertion；请改用版本化 Evaluator。',
+        );
+      }
+      const sourceKinds = deterministicAssertionInputSourceKinds(assertion);
+      if (sourceKinds.length === 0) fail(
+        `samples.${sample.sample_id}.assertions.${index}`,
+        `Assertion 类型「${assertion.type}」没有受支持的确定性或 LLM Evaluator。`,
+      );
+      metrics.push(metric(identity.metricId, 'boolean'));
+      criteria.push({ ...identity, layerDisposition: layer, weight });
+      const criterion = {
+        criterionId: identity.criterionId,
+        metricId: identity.metricId,
+        assertion: structuredClone(assertion) as unknown as JsonValue,
+      };
+      if (sourceKinds.length === 1 && sourceKinds[0] === 'output') {
+        outputMetricIds.push(identity.metricId);
+        const values = outputCriteriaBySample.get(sample.sample_id) ?? [];
+        values.push(criterion);
+        outputCriteriaBySample.set(sample.sample_id, values);
+      } else {
+        const signature = sourceKinds.join('+');
+        const group: {
+          readonly sourceKinds: readonly ('output' | 'execution-facts' | 'trace')[];
+          readonly metricIds: string[];
+          readonly criteriaBySample: Map<string, JsonValue[]>;
+        } = executionGroups.get(signature) ?? {
+          sourceKinds,
+          metricIds: [] as string[],
+          criteriaBySample: new Map<string, JsonValue[]>(),
+        };
+        group.metricIds.push(identity.metricId);
+        const values = group.criteriaBySample.get(sample.sample_id) ?? [];
+        values.push(criterion);
+        group.criteriaBySample.set(sample.sample_id, values);
+        executionGroups.set(signature, group);
+      }
+    }
+  }
+
+  if (outputMetricIds.length > 0) {
+    for (const [sampleId, values] of outputCriteriaBySample) {
+      contextFor(sampleId).outputAssertions = {
+        schemaVersion: OUTPUT_ASSERTION_CONTEXT_SCHEMA_VERSION,
+        criteria: values,
+      };
+    }
+    templates.push({
+      evaluatorId: 'output-assertions',
+      evaluatorKind: 'assertion',
+      runtimeBindingKind: 'builtin',
+      implementationId: OUTPUT_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+      applicableSampleIds: [...outputCriteriaBySample.keys()].sort(),
+      instrumentId: 'omk-output-assertions',
+      replicateGroupId: 'deterministic-primary',
+      metricIds: outputMetricIds,
+      inputs: [
+        { bindingId: OUTPUT_ASSERTION_BINDINGS.actual, sourceKind: 'output', pointer: '' },
+        {
+          bindingId: OUTPUT_ASSERTION_BINDINGS.criteria,
+          sourceKind: 'evaluation-context',
+          pointer: '/outputAssertions',
+        },
+      ],
+    });
+  }
+
+  for (const [signature, group] of executionGroups) {
+    const contextKey = digestId('executionAssertions', { signature });
+    for (const [sampleId, values] of group.criteriaBySample) {
+      contextFor(sampleId)[contextKey] = {
+        schemaVersion: EXECUTION_ASSERTION_CONTEXT_SCHEMA_VERSION,
+        sourceKinds: [...group.sourceKinds],
+        criteria: values,
+      };
+    }
+    templates.push({
+      evaluatorId: `execution-assertions-${signature.replaceAll('+', '-')}`,
+      evaluatorKind: 'assertion',
+      runtimeBindingKind: 'builtin',
+      implementationId: EXECUTION_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+      applicableSampleIds: [...group.criteriaBySample.keys()].sort(),
+      instrumentId: `omk-execution-assertions-${signature.replaceAll('+', '-')}`,
+      replicateGroupId: 'deterministic-primary',
+      metricIds: group.metricIds,
+      inputs: [
+        ...(group.sourceKinds.includes('output') ? [{
+          bindingId: EXECUTION_ASSERTION_BINDINGS.actual,
+          sourceKind: 'output' as const,
+          pointer: '',
+        }] : []),
+        ...(group.sourceKinds.includes('execution-facts') ? [{
+          bindingId: EXECUTION_ASSERTION_BINDINGS.facts,
+          sourceKind: 'execution-facts' as const,
+          pointer: '',
+        }] : []),
+        ...(group.sourceKinds.includes('trace') ? [{
+          bindingId: EXECUTION_ASSERTION_BINDINGS.trace,
+          sourceKind: 'trace' as const,
+          pointer: '',
+        }] : []),
+        {
+          bindingId: EXECUTION_ASSERTION_BINDINGS.criteria,
+          sourceKind: 'evaluation-context',
+          pointer: `/${contextKey}`,
+        },
+      ],
+    });
+  }
+
+  const rubricInstrument = rubricJudgeInstrument({
+    lengthDebias: request.values.judges.lengthDebias,
+    tracePolicy: 'source-neutral',
+  });
+  const rubricInstrumentId = rubricJudgeInstrumentId(rubricInstrument);
+  const rubricDimensions = new Map<string, {
+    dimensionId: string;
+    metricId: string;
+    sampleIds: Set<string>;
+  }>();
+  if (request.values.judges.enabled) {
+    for (const sample of sortedSamples) {
+      const dimensions = sample.dimensions
+        ?? (sample.rubric === undefined ? {} : { overall: sample.rubric });
+      for (const [dimensionName, rubric] of Object.entries(dimensions).sort((left, right) => (
+        left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0
+      ))) {
+        const design = rubricDimensions.get(dimensionName) ?? {
+          dimensionId: digestId('dimension', { dimensionName }),
+          metricId: digestId('judge', { dimensionName }),
+          sampleIds: new Set<string>(),
+        };
+        rubricDimensions.set(dimensionName, design);
+        design.sampleIds.add(sample.sample_id);
+        const contextKey = `rubricJudge_${design.metricId.replaceAll('-', '_')}`;
+        contextFor(sample.sample_id)[contextKey] = {
+          schemaVersion: RUBRIC_JUDGE_CONTEXT_SCHEMA_VERSION,
+          criterionId: design.dimensionId,
+          prompt: sample.prompt,
+          rubric,
+        };
+      }
+    }
+  }
+  for (const design of rubricDimensions.values()) {
+    metrics.push(metric(design.metricId, 'numeric'));
+    const contextKey = `rubricJudge_${design.metricId.replaceAll('-', '_')}`;
+    templates.push({
+      evaluatorId: `rubric-${design.dimensionId}`,
+      evaluatorKind: 'llm-rubric',
+      runtimeBindingKind: 'judge',
+      implementationId: RUBRIC_JUDGE_EVALUATOR_IMPLEMENTATION_ID,
+      applicableSampleIds: [...design.sampleIds].sort(),
+      instrumentId: rubricInstrumentId,
+      runtimePromptVariant: rubricInstrument.promptId,
+      replicateGroupId: `rubric-${design.dimensionId}`,
+      metricIds: [design.metricId],
+      inputs: [
+        { bindingId: RUBRIC_JUDGE_BINDINGS.actual, sourceKind: 'output', pointer: '' },
+        {
+          bindingId: RUBRIC_JUDGE_BINDINGS.criterion,
+          sourceKind: 'evaluation-context',
+          pointer: `/${contextKey}`,
+        },
+        { bindingId: RUBRIC_JUDGE_BINDINGS.trace, sourceKind: 'trace', pointer: '' },
+      ],
+      config: { classification: 'public', value: rubricInstrument as unknown as JsonValue },
+    });
+  }
+
+  if (metrics.length === 0) {
+    fail('samples', 'Dataset 没有可测量的 assertion、rubric 或 dimension。');
+  }
+
+  const nodes: AnalysisGraphDefinition['nodes'][number][] = [];
+  const compositeInputs: AnalysisGraphDefinition['nodes'][number]['inputs'] = [];
+  const compositeLayers: JsonValue[] = [];
+  if (criteria.length > 0) {
+    nodes.push({
+      analysisNodeKind: 'reducer',
+      nodeId: 'assertion-layer',
+      implementationId: ASSERTION_LAYER_ANALYSIS_IMPLEMENTATION_ID,
+      inputs: criteria.map((criterion) => ({
+        inputKind: 'metric-observations',
+        referenceId: criterion.metricId,
+      })),
+      outputResultId: 'assertion-layer',
+      parameters: {
+        criteria: criteria.map((criterion) => ({
+          criterionId: criterion.criterionId,
+          metricId: criterion.metricId,
+          layerDisposition: criterion.layerDisposition,
+          weight: criterion.weight,
+        })),
+      },
+    });
+    compositeInputs.push({ inputKind: 'analysis-result', referenceId: 'assertion-layer' });
+    if (criteria.some((criterion) => criterion.layerDisposition === 'fact')) {
+      compositeLayers.push({
+        layerId: 'fact', analysisResultId: 'assertion-layer',
+        sourceKind: 'assertion-layer', selector: 'fact',
+      });
+    }
+    if (criteria.some((criterion) => criterion.layerDisposition === 'behavior')) {
+      compositeLayers.push({
+        layerId: 'behavior', analysisResultId: 'assertion-layer',
+        sourceKind: 'assertion-layer', selector: 'behavior',
+      });
+    }
+  }
+
+  const dimensions: JsonValue[] = [];
+  for (const design of rubricDimensions.values()) {
+    const replicateResultId = `judge-replicate-${design.metricId}`;
+    const ensembleResultId = `judge-ensemble-${design.metricId}`;
+    nodes.push({
+      analysisNodeKind: 'reducer',
+      nodeId: replicateResultId,
+      implementationId: JUDGE_REPLICATE_ANALYSIS_IMPLEMENTATION_ID,
+      inputs: [{ inputKind: 'metric-observations', referenceId: design.metricId }],
+      outputResultId: replicateResultId,
+    }, {
+      analysisNodeKind: 'reducer',
+      nodeId: ensembleResultId,
+      implementationId: JUDGE_ENSEMBLE_ANALYSIS_IMPLEMENTATION_ID,
+      inputs: [{ inputKind: 'analysis-result', referenceId: replicateResultId }],
+      outputResultId: ensembleResultId,
+    });
+    dimensions.push({
+      dimensionId: design.dimensionId,
+      metricId: design.metricId,
+      analysisResultId: ensembleResultId,
+    });
+  }
+  if (dimensions.length > 0) {
+    nodes.push({
+      analysisNodeKind: 'reducer',
+      nodeId: 'dimension-table',
+      implementationId: DIMENSION_ANALYSIS_IMPLEMENTATION_ID,
+      inputs: dimensions.map((dimension) => ({
+        inputKind: 'analysis-result',
+        referenceId: (dimension as { analysisResultId: string }).analysisResultId,
+      })),
+      outputResultId: 'dimension-table',
+      parameters: { dimensions },
+    });
+    compositeInputs.push({ inputKind: 'analysis-result', referenceId: 'dimension-table' });
+    compositeLayers.push({
+      layerId: 'judge', analysisResultId: 'dimension-table',
+      sourceKind: 'dimension', selector: 'aggregate',
+    });
+  }
+  if (compositeLayers.length === 0) {
+    fail(
+      'samples[].assertions',
+      'Dataset 只有跨层 assertion，无法构造可解释的 composite；请明确 fact／behavior 归属。',
+    );
+  }
+  nodes.push({
+    analysisNodeKind: 'reducer',
+    nodeId: 'composite-table',
+    implementationId: COMPOSITE_ANALYSIS_IMPLEMENTATION_ID,
+    inputs: compositeInputs,
+    outputResultId: 'composite-table',
+    parameters: { layers: compositeLayers },
+  });
+
+  const control = request.values.variants.find((variant) => variant.experimentRole === 'control');
+  const treatments = request.values.variants.filter(
+    (variant) => variant.experimentRole === 'treatment',
+  );
+  if (control === undefined || treatments.length === 0) {
+    fail('variants', 'Measurement design 要求一个 control 和至少一个 treatment。');
+  }
+  const targetIds = request.values.variants.map((variant) => variant.targetId).sort();
+  let decisionPolicy: DecisionPolicyDefinition | undefined;
+  if (request.values.measurement.bootstrap.enabled) {
+    nodes.push({
+      analysisNodeKind: 'estimator',
+      nodeId: 'bootstrap-family',
+      implementationId: BOOTSTRAP_FAMILY_ANALYSIS_IMPLEMENTATION_ID,
+      inputs: [{ inputKind: 'analysis-result', referenceId: 'composite-table' }],
+      outputResultId: 'bootstrap-family',
+      parameters: {
+        source: {
+          analysisResultId: 'composite-table',
+          sourceKind: 'composite',
+          selector: 'aggregate',
+        },
+        targetIds,
+        sampleIds,
+        comparisons: treatments.map((target) => ({
+          comparisonId: `control-vs-${target.targetId}`,
+          controlTargetId: control.targetId,
+          treatmentTargetId: target.targetId,
+          comparisonDesign: 'paired',
+        })),
+        resamples: request.values.measurement.bootstrap.resamples,
+        alpha: 0.05,
+        seed: DEFAULT_BOOTSTRAP_SEED,
+      },
+    });
+    const firstJudge = [...rubricDimensions.values()][0];
+    const analysisResultIds = [
+      'composite-table',
+      'bootstrap-family',
+      ...(firstJudge === undefined ? [] : [`judge-ensemble-${firstJudge.metricId}`]),
+    ];
+    const holdout = request.values.measurement.holdoutRatio === undefined
+      ? null
+      : splitHoldout(sampleIds, request.values.measurement.holdoutRatio);
+    decisionPolicy = {
+      decisionPolicyId: 'release-decision',
+      implementationId: RELEASE_DECISION_POLICY_IMPLEMENTATION_ID,
+      analysisResultIds,
+      comparisonFamily: treatments.map((target) => ({
+        comparisonId: `control-vs-${target.targetId}`,
+        treatmentTargetId: target.targetId,
+        metricId: firstJudge?.metricId ?? metrics[0]!.metricId,
+        analysisResultId: 'bootstrap-family',
+      })),
+      comparisonFamilyResultId: 'bootstrap-family',
+      minimumEvidenceStatus: 'complete',
+      parameters: {
+        sources: {
+          compositeResultId: 'composite-table',
+          bootstrapFamilyResultId: 'bootstrap-family',
+          ...(firstJudge === undefined ? {} : {
+            judgeEnsemble: {
+              analysisResultId: `judge-ensemble-${firstJudge.metricId}`,
+              metricId: firstJudge.metricId,
+              instrumentId: rubricInstrumentId,
+              replicateGroupId: `rubric-${firstJudge.dimensionId}`,
+            },
+          }),
+        },
+        targetIds,
+        sampleIds,
+        thresholds: {
+          layerScore: request.values.measurement.decision.threshold ?? 3,
+          triviallySmallDifference:
+            request.values.measurement.decision.trivialDifference ?? 0.1,
+          minimumSampleCount: 20,
+          judgeDissentPearson: 0.4,
+          holdoutGap: 0.5,
+        },
+        ...(holdout === null ? {} : {
+          holdout: {
+            trainSampleIds: sampleIds.filter((sampleId) => holdout.trainIds.has(sampleId)),
+            holdoutSampleIds: sampleIds.filter((sampleId) => holdout.holdoutIds.has(sampleId)),
+            minimumScorablePerPartition: 3,
+          },
+        }),
+      },
+    };
+  }
+
+  const holdout = request.values.measurement.holdoutRatio === undefined
+    ? null
+    : splitHoldout(sampleIds, request.values.measurement.holdoutRatio);
+  const analysisCohorts = holdout === null ? undefined : [
+    {
+      cohortId: 'train',
+      cohortSetId: 'holdout-split',
+      cohortSetKind: 'partition',
+      classification: 'gold',
+      disclosure: 'identity-only',
+      derivation: { algorithmId: 'omk.stride-holdout/v1', seed: 'canonical-sample-order' },
+    },
+    {
+      cohortId: 'holdout',
+      cohortSetId: 'holdout-split',
+      cohortSetKind: 'partition',
+      classification: 'gold',
+      disclosure: 'identity-only',
+      derivation: { algorithmId: 'omk.stride-holdout/v1', seed: 'canonical-sample-order' },
+    },
+  ] satisfies AnalysisCohortDefinition[];
+  const samples: EvaluationSample[] = sortedSamples.map((sample) => {
+    const evaluationContext = evaluationContexts.get(sample.sample_id);
+    const sampleAnnotations = annotations(sample);
+    return {
+      sampleId: sample.sample_id,
+      input: renderedPrompt(sample),
+      ...(evaluationContext === undefined || Object.keys(evaluationContext).length === 0
+        ? {}
+        : { evaluationContext }),
+      ...(holdout === null ? {} : {
+        analysis: {
+          memberships: [{
+            cohortId: holdout.holdoutIds.has(sample.sample_id) ? 'holdout' : 'train',
+          }],
+        },
+      }),
+      ...(sampleAnnotations === undefined ? {} : { annotations: sampleAnnotations }),
+    };
+  });
+  const judgeOccurrences = new Map<string, number>();
+  const judges: ResolvedJudgeMember[] = [...request.values.judges.members]
+    .sort((left, right) => (
+      left.executorId < right.executorId ? -1 : left.executorId > right.executorId ? 1
+        : left.model < right.model ? -1 : left.model > right.model ? 1 : 0
+    ))
+    .map((member) => {
+      const identity = `${member.executorId}\u0000${member.model}`;
+      const occurrence = judgeOccurrences.get(identity) ?? 0;
+      judgeOccurrences.set(identity, occurrence + 1);
+      return {
+        ensembleMemberId: digestId('judge-member', {
+          executorId: member.executorId,
+          model: member.model,
+          occurrence,
+        }),
+        executorId: member.executorId,
+        model: member.model,
+        effort: request.values.targetRuntime.effort,
+      };
+    });
+  return {
+    dataset: {
+      datasetId: digestId('dataset', samples as unknown as JsonValue),
+      samples,
+      ...(analysisCohorts === undefined ? {} : { analysisCohorts }),
+    },
+    evaluatorTemplates: templates,
+    judges: {
+      enabled: request.values.judges.enabled,
+      members: judges,
+      replicateCount: request.values.judges.replicateCount,
+    },
+    metrics,
+    analysisGraph: { analysisMode: 'preregistered', nodes },
+    ...(decisionPolicy === undefined ? {} : { decisionPolicy }),
+  };
+}

--- a/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
+++ b/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
@@ -1,0 +1,642 @@
+import { createHash } from 'node:crypto';
+import { chmod, lstat, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { extname, isAbsolute, join, resolve } from 'node:path';
+import {
+  canonicalizeJson,
+  deepFreezeCanonicalJson,
+  type JsonValue,
+} from '../../evaluation-core/contracts/index.js';
+import { loadSamples } from '../../inputs/load-samples.js';
+import { resolveArtifacts } from '../../inputs/skill-loader.js';
+import type { Artifact, Mock, Sample } from '../../types/index.js';
+import {
+  RESOLVED_CLI_EVALUATION_INPUT_SCHEMA_VERSION,
+  RESOLVED_HOST_RESOURCES_SCHEMA_VERSION,
+  CliEvaluationInputError,
+  type CliEvaluationRequest,
+  type ResolvedCliEvaluationInput,
+  type ResolvedHostResource,
+  type ResolvedMockBinding,
+  type ResolvedResourceDescriptor,
+} from '../input-compilation/index.js';
+import {
+  digestNodeFileResource,
+  digestNodeTreeResource,
+} from '../runtime-adapter/resource-leases/node.js';
+import { BOOTSTRAP_FAMILY_ANALYSIS_IMPLEMENTATION_ID } from '../runtime-adapter/analysis/index.js';
+import { buildProductionMeasurementDesign } from './measurement-design.js';
+
+export interface ResolveNodeCliEvaluationRequestOptions {
+  /** Absolute semantic root for relative CLI／eval.yaml locators. */
+  readonly projectRoot: string;
+  /** Resolver-owned directory for normalized inline or ephemeral resources. */
+  readonly materializationRoot: string;
+  /** Required when repeatCount > 1; identity allocation remains host-owned. */
+  readonly seriesInstanceId?: string;
+}
+
+interface ResourceRegistry {
+  readonly resourcesById: Map<string, ResolvedHostResource>;
+  add(resource: ResolvedHostResource): ResolvedResourceDescriptor;
+}
+
+function fail(input: ConstructorParameters<typeof CliEvaluationInputError>[0]): never {
+  throw new CliEvaluationInputError(input);
+}
+
+function absolute(root: string, locator: string): string {
+  return isAbsolute(locator) ? resolve(locator) : resolve(root, locator);
+}
+
+function mediaType(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case '.json': return 'application/json';
+    case '.yaml':
+    case '.yml': return 'application/yaml';
+    case '.md': return 'text/markdown';
+    default: return 'text/plain';
+  }
+}
+
+function resourceId(
+  resourceKind: ResolvedHostResource['resourceKind'],
+  digest: ResolvedResourceDescriptor['digest'],
+): string {
+  return `${resourceKind}-${digest.slice('sha256:'.length, 'sha256:'.length + 24)}`;
+}
+
+function registry(): ResourceRegistry {
+  const resourcesById = new Map<string, ResolvedHostResource>();
+  return {
+    resourcesById,
+    add(resource) {
+      const existing = resourcesById.get(resource.descriptor.resourceId);
+      if (existing !== undefined) {
+        if (canonicalizeJson(existing.descriptor) !== canonicalizeJson(resource.descriptor)
+            || existing.resourceKind !== resource.resourceKind) fail({
+          code: 'CLI_INPUT_RESOLUTION_FAILED',
+          fieldPath: `hostResources.${resource.descriptor.resourceId}`,
+          message: '内容寻址资源发生 descriptor 冲突。',
+        });
+        return existing.descriptor;
+      }
+      resourcesById.set(resource.descriptor.resourceId, resource);
+      return resource.descriptor;
+    },
+  };
+}
+
+async function fileResource(
+  resources: ResourceRegistry,
+  input: {
+    readonly resourceKind: ResolvedHostResource['resourceKind'];
+    readonly path: string;
+    readonly classification: ResolvedResourceDescriptor['classification'];
+    readonly mediaType?: string;
+    readonly lineage?: JsonValue;
+  },
+): Promise<ResolvedResourceDescriptor> {
+  let measured: Awaited<ReturnType<typeof digestNodeFileResource>>;
+  try {
+    measured = await digestNodeFileResource(input.path);
+  } catch (cause) {
+    return fail({
+      code: 'CLI_INPUT_RESOLUTION_FAILED',
+      sourcePath: input.path,
+      message: '无法读取并验证文件资源。',
+      cause,
+    });
+  }
+  const descriptor: ResolvedResourceDescriptor = {
+    resourceId: resourceId(input.resourceKind, measured.digest),
+    digest: measured.digest,
+    mediaType: input.mediaType ?? mediaType(input.path),
+    classification: input.classification,
+    size: measured.size,
+  };
+  return resources.add({
+    resourceKind: input.resourceKind,
+    descriptor,
+    locator: input.path,
+    ...(input.lineage === undefined ? {} : { lineage: input.lineage }),
+    verification: {
+      verificationKind: 'content-digest',
+      verifiedDigest: descriptor.digest,
+    },
+  });
+}
+
+async function treeResource(
+  resources: ResourceRegistry,
+  input: {
+    readonly resourceKind: 'artifact' | 'workspace' | 'gold-dataset';
+    readonly path: string;
+    readonly classification: ResolvedResourceDescriptor['classification'];
+    readonly mediaType: string;
+    readonly lineage?: JsonValue;
+  },
+): Promise<ResolvedResourceDescriptor> {
+  let measured: Awaited<ReturnType<typeof digestNodeTreeResource>>;
+  try {
+    measured = await digestNodeTreeResource(input.path);
+  } catch (cause) {
+    return fail({
+      code: 'CLI_INPUT_RESOLUTION_FAILED',
+      sourcePath: input.path,
+      message: '无法读取并验证目录树资源。',
+      cause,
+    });
+  }
+  const descriptor: ResolvedResourceDescriptor = {
+    resourceId: resourceId(input.resourceKind, measured.digest),
+    digest: measured.digest,
+    mediaType: input.mediaType,
+    classification: input.classification,
+    size: measured.size,
+  };
+  return resources.add({
+    resourceKind: input.resourceKind,
+    descriptor,
+    locator: input.path,
+    ...(input.lineage === undefined ? {} : { lineage: input.lineage }),
+    verification: { verificationKind: 'tree-digest', verifiedDigest: descriptor.digest },
+  });
+}
+
+function sha256(bytes: Uint8Array): `sha256:${string}` {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+async function materializeBytes(
+  root: string,
+  bytes: Uint8Array,
+  extension: '.json' | '.txt' | '.md',
+): Promise<string> {
+  const digest = sha256(bytes);
+  const directory = join(root, 'content');
+  const path = join(directory, `${digest.slice('sha256:'.length)}${extension}`);
+  try {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    const directoryStat = await lstat(directory);
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) fail({
+      code: 'CLI_INPUT_RESOLUTION_FAILED',
+      sourcePath: directory,
+      message: 'Resolver materialization content path 必须是普通目录，不能是符号链接。',
+    });
+    await chmod(directory, 0o700);
+    try {
+      const existingStat = await lstat(path);
+      if (!existingStat.isFile() || existingStat.isSymbolicLink()) fail({
+        code: 'CLI_INPUT_RESOLUTION_FAILED',
+        sourcePath: path,
+        message: 'Resolver materialization path 必须是普通文件，不能是符号链接。',
+      });
+      const existing = await readFile(path);
+      if (sha256(existing) !== digest) fail({
+        code: 'CLI_INPUT_RESOLUTION_FAILED',
+        sourcePath: path,
+        message: 'Resolver materialization path 已存在但内容摘要不一致。',
+      });
+      await chmod(path, 0o600);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      try {
+        await writeFile(path, bytes, { flag: 'wx', mode: 0o600 });
+      } catch (writeError) {
+        if ((writeError as NodeJS.ErrnoException).code !== 'EEXIST') throw writeError;
+        const existingStat = await lstat(path);
+        if (!existingStat.isFile() || existingStat.isSymbolicLink()) fail({
+          code: 'CLI_INPUT_RESOLUTION_FAILED',
+          sourcePath: path,
+          message: '并发物化命中的 path 必须是普通文件，不能是符号链接。',
+        });
+        const existing = await readFile(path);
+        if (sha256(existing) !== digest) fail({
+          code: 'CLI_INPUT_RESOLUTION_FAILED',
+          sourcePath: path,
+          message: '并发物化命中了摘要不一致的既有资源。',
+        });
+        await chmod(path, 0o600);
+      }
+    }
+  } catch (cause) {
+    if (cause instanceof CliEvaluationInputError) throw cause;
+    return fail({
+      code: 'CLI_INPUT_RESOLUTION_FAILED',
+      sourcePath: path,
+      message: '无法安全物化 resolver-owned 资源。',
+      cause,
+    });
+  }
+  return path;
+}
+
+async function artifactResource(
+  resources: ResourceRegistry,
+  artifact: Readonly<Artifact>,
+  materializationRoot: string,
+): Promise<ResolvedResourceDescriptor> {
+  const lineage: JsonValue = {
+    sourceKind: artifact.source,
+    artifactKind: artifact.kind,
+    ...(artifact.locator === undefined ? {} : { sourceLocator: artifact.locator }),
+    ...(artifact.ref === undefined ? {} : { ref: artifact.ref }),
+    ...(artifact.resolvedCommit === undefined ? {} : { commitId: artifact.resolvedCommit }),
+    ...(artifact.contentHash === undefined ? {} : { legacyContentHash: artifact.contentHash }),
+  };
+  const candidate = artifact.execRoot ?? artifact.skillRoot ?? artifact.locator;
+  if (candidate !== undefined && isAbsolute(candidate)) {
+    let stat: Awaited<ReturnType<typeof lstat>> | undefined;
+    try {
+      stat = await lstat(candidate);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') fail({
+        code: 'CLI_INPUT_RESOLUTION_FAILED',
+        sourcePath: candidate,
+        message: '无法检查 knowledge artifact locator。',
+        cause: error,
+      });
+    }
+    if (stat?.isDirectory()) return treeResource(resources, {
+      resourceKind: 'artifact',
+      path: candidate,
+      classification: 'sensitive',
+      mediaType: 'application/vnd.omk.knowledge-artifact-tree',
+      lineage,
+    });
+    if (stat?.isFile()) return fileResource(resources, {
+      resourceKind: 'artifact',
+      path: candidate,
+      classification: 'sensitive',
+      lineage,
+    });
+    if (stat !== undefined) {
+      fail({
+        code: 'CLI_INPUT_RESOLUTION_FAILED',
+        sourcePath: candidate,
+        message: 'Knowledge artifact 必须是普通文件或不含特殊条目的目录树。',
+      });
+    }
+  }
+  const content = artifact.content ?? '';
+  const path = await materializeBytes(materializationRoot, Buffer.from(content), '.md');
+  return fileResource(resources, {
+    resourceKind: 'artifact',
+    path,
+    classification: 'sensitive',
+    mediaType: 'text/markdown',
+    lineage,
+  });
+}
+
+async function mockPayloadDescriptors(
+  resources: ResourceRegistry,
+  mock: Readonly<Mock>,
+  samplesBaseDir: string,
+  materializationRoot: string,
+): Promise<readonly ResolvedResourceDescriptor[]> {
+  if (mock.return_file !== undefined) {
+    const path = absolute(samplesBaseDir, mock.return_file);
+    return [await fileResource(resources, {
+      resourceKind: 'mock-payload',
+      path,
+      classification: 'secret',
+    })];
+  }
+  const values = mock.return_seq ?? (mock.return === undefined ? [''] : [mock.return]);
+  return Promise.all(values.map(async (value) => {
+    const objectValue = typeof value === 'object' && value !== null;
+    const bytes = Buffer.from(objectValue ? JSON.stringify(value) : String(value));
+    const path = await materializeBytes(
+      materializationRoot,
+      bytes,
+      objectValue ? '.json' : '.txt',
+    );
+    return fileResource(resources, {
+      resourceKind: 'mock-payload',
+      path,
+      classification: 'secret',
+      mediaType: objectValue ? 'application/json' : 'text/plain',
+    });
+  }));
+}
+
+async function resolvedMocks(
+  resources: ResourceRegistry,
+  samples: readonly Readonly<Sample>[],
+  samplesBaseDir: string,
+  materializationRoot: string,
+): Promise<readonly ResolvedMockBinding[]> {
+  const bindings: ResolvedMockBinding[] = [];
+  for (const sample of samples) {
+    for (const mock of sample.mocks ?? []) {
+      bindings.push({
+        sampleIds: [sample.sample_id],
+        matchRules: {
+          tool: mock.tool,
+          ...(mock.match === undefined ? {} : { match: structuredClone(mock.match) as JsonValue }),
+        },
+        strict: sample.mocksStrict ?? false,
+        payloads: await mockPayloadDescriptors(
+          resources,
+          mock,
+          samplesBaseDir,
+          materializationRoot,
+        ),
+      });
+    }
+  }
+  return bindings;
+}
+
+function commonAllowedTools(samples: readonly Readonly<Sample>[]): readonly string[] | undefined {
+  const policies = samples.map((sample) => sample.allowedTools === undefined
+    ? undefined
+    : [...sample.allowedTools].sort());
+  const identities = new Set(policies.map((policy) => canonicalizeJson(policy ?? null)));
+  if (identities.size > 1) fail({
+    code: 'CLI_INPUT_SAMPLE_CONTROL_CONFLICT',
+    fieldPath: 'samples[].allowedTools',
+    message: '当前 Target contract 不接受不同 sample 使用不同 allowedTools；请统一测试构造。',
+  });
+  return policies[0];
+}
+
+function commonSampleWorkspace(samples: readonly Readonly<Sample>[]): string | undefined {
+  const locators = [...new Set(samples.map((sample) => sample.cwd ?? ''))];
+  if (locators.length > 1) fail({
+    code: 'CLI_INPUT_SAMPLE_CONTROL_CONFLICT',
+    fieldPath: 'samples[].cwd',
+    message: '当前 Target contract 不接受不同 sample 使用不同 cwd；请按 workspace 拆分 evaluation。',
+  });
+  return locators[0] || undefined;
+}
+
+async function optionalFileResource(
+  resources: ResourceRegistry,
+  projectRoot: string,
+  locator: string | undefined,
+  resourceKind: 'mcp-config' | 'gold-dataset',
+): Promise<ResolvedResourceDescriptor | undefined> {
+  if (locator === undefined) return undefined;
+  const path = absolute(projectRoot, locator);
+  let stat: Awaited<ReturnType<typeof lstat>>;
+  try {
+    stat = await lstat(path);
+  } catch (cause) {
+    return fail({
+      code: 'CLI_INPUT_RESOLUTION_FAILED',
+      sourcePath: path,
+      message: '无法读取可选宿主资源。',
+      cause,
+    });
+  }
+  if (stat.isDirectory()) {
+    if (resourceKind !== 'gold-dataset') fail({
+      code: 'CLI_INPUT_RESOLUTION_FAILED',
+      sourcePath: path,
+      message: 'MCP config 必须是普通文件。',
+    });
+    return treeResource(resources, {
+      resourceKind,
+      path,
+      classification: 'gold',
+      mediaType: 'application/vnd.omk.gold-dataset-tree',
+    });
+  }
+  if (!stat.isFile()) fail({
+    code: 'CLI_INPUT_RESOLUTION_FAILED',
+    sourcePath: path,
+    message: '资源 locator 必须指向普通文件或受支持目录。',
+  });
+  return fileResource(resources, {
+    resourceKind,
+    path,
+    classification: resourceKind === 'gold-dataset' ? 'gold' : 'sensitive',
+  });
+}
+
+/** Production effect resolver. It never creates Runtime, runId, Plan, or persisted Run artifacts. */
+export async function resolveNodeCliEvaluationRequest(
+  request: Readonly<CliEvaluationRequest>,
+  options: Readonly<ResolveNodeCliEvaluationRequestOptions>,
+): Promise<ResolvedCliEvaluationInput> {
+  if (!isAbsolute(options.projectRoot) || !isAbsolute(options.materializationRoot)) fail({
+    code: 'CLI_INPUT_RESOLUTION_FAILED',
+    fieldPath: 'resolver.options',
+    message: 'projectRoot 与 materializationRoot 必须是绝对路径。',
+  });
+  if (request.values.orchestration.batch) fail({
+    code: 'CLI_INPUT_RESOLUTION_FAILED',
+    fieldPath: 'orchestration.batch',
+    message: 'Batch request 必须由 production host workflow 展开为独立 child evaluation。',
+  });
+  let loaded: ReturnType<typeof loadSamples>;
+  let artifacts: Artifact[];
+  try {
+    loaded = loadSamples(
+      absolute(options.projectRoot, request.values.locators.samples),
+      { assertionValidationMode: 'strict' },
+    );
+    const skillDirectory = absolute(options.projectRoot, request.values.locators.skillDirectory);
+    artifacts = resolveArtifacts(skillDirectory, request.values.variants.map((variant) => (
+      variant.artifactSource.artifactSourceKind === 'remote-git'
+        ? {
+            git: {
+              url: variant.artifactSource.url,
+              ...(variant.artifactSource.ref === undefined
+                ? {}
+                : { ref: variant.artifactSource.ref }),
+              spec: variant.artifactSource.spec,
+            },
+            ...(variant.workspaceLocator === undefined
+              ? {}
+              : { cwd: absolute(options.projectRoot, variant.workspaceLocator) }),
+            name: variant.targetId,
+          }
+        : {
+            expr: variant.artifactSource.expression.includes('/')
+              && !variant.artifactSource.expression.startsWith('git:')
+              ? absolute(options.projectRoot, variant.artifactSource.expression)
+              : variant.artifactSource.expression,
+            ...(variant.workspaceLocator === undefined
+              ? {}
+              : { cwd: absolute(options.projectRoot, variant.workspaceLocator) }),
+          }
+    )), {
+      strictBaseline: request.values.measurement.baselineIsolation,
+      materialize: true,
+    });
+  } catch (cause) {
+    return fail({
+      code: 'CLI_INPUT_RESOLUTION_FAILED',
+      sourcePath: request.values.locators.samples,
+      message: '无法解析 samples 或 knowledge artifact；详情已保留在受控 cause 中。',
+      cause,
+    });
+  }
+  if (artifacts.length !== request.values.variants.length) fail({
+    code: 'CLI_INPUT_RESOLUTION_FAILED',
+    fieldPath: 'variants',
+    message: 'Artifact resolver 返回数量与 variant request 不一致。',
+  });
+
+  const resources = registry();
+  const mocks = await resolvedMocks(
+    resources,
+    loaded.samples,
+    loaded.baseDir,
+    options.materializationRoot,
+  );
+  const allowedTools = commonAllowedTools(loaded.samples);
+  const sampleWorkspace = request.values.variants.some((variant) => (
+    variant.workspaceLocator === undefined
+  )) ? commonSampleWorkspace(loaded.samples) : undefined;
+  const mcpConfig = await optionalFileResource(
+    resources,
+    options.projectRoot,
+    request.values.locators.mcpConfig,
+    'mcp-config',
+  );
+  const gold = await optionalFileResource(
+    resources,
+    options.projectRoot,
+    request.values.locators.gold,
+    'gold-dataset',
+  );
+
+  const targets = await Promise.all(request.values.variants.map(async (variant, index) => {
+    const artifact = artifacts[index]!;
+    artifact.experimentRole = variant.experimentRole;
+    if (variant.allowedSkills !== undefined) artifact.allowedSkills = [...variant.allowedSkills];
+    const artifactDescriptor = await artifactResource(
+      resources,
+      artifact,
+      options.materializationRoot,
+    );
+    const workspaceLocator = variant.workspaceLocator ?? sampleWorkspace;
+    const workspace = workspaceLocator === undefined
+      ? undefined
+      : await treeResource(resources, {
+          resourceKind: 'workspace',
+          path: absolute(options.projectRoot, workspaceLocator),
+          classification: 'sensitive',
+          mediaType: 'application/vnd.omk.workspace-tree',
+        });
+    return {
+      targetId: variant.targetId,
+      experimentRole: variant.experimentRole,
+      targetKind: artifact.kind,
+      protocolId: 'omk.invoke/v1' as const,
+      executor: {
+        implementationId: request.values.targetRuntime.executorId,
+        model: request.values.targetRuntime.model,
+        effort: request.values.targetRuntime.effort,
+      },
+      behavior: {
+        systemInstructions: artifact.content === null ? 'not-required' as const : 'required' as const,
+        artifact: artifactDescriptor,
+        ...(workspace === undefined ? {} : { workspace }),
+        ...(mcpConfig === undefined ? {} : { mcpConfig }),
+        ...(mocks.length === 0 ? {} : { mocks }),
+        ...(allowedTools === undefined ? {} : { allowedTools }),
+        ...(artifact.allowedSkills === undefined
+          ? {}
+          : { allowedSkills: [...artifact.allowedSkills] }),
+      },
+    };
+  }));
+
+  const design = buildProductionMeasurementDesign(request, loaded.samples);
+  const repeatCount = request.values.orchestration.repeatCount;
+  if (repeatCount > 1 && (options.seriesInstanceId?.trim() ?? '') === '') fail({
+    code: 'CLI_INPUT_RESOLUTION_FAILED',
+    fieldPath: 'orchestration.independentSeries.seriesInstanceId',
+    message: 'repeat > 1 时必须由宿主分配 seriesInstanceId。',
+  });
+  const output: ResolvedCliEvaluationInput = {
+    schemaVersion: RESOLVED_CLI_EVALUATION_INPUT_SCHEMA_VERSION,
+    ...design,
+    targets,
+    experiment: {
+      trials: 1,
+      seed: design.dataset.datasetId,
+      sampling: {
+        experimentalUnit: 'sample',
+        pairingKey: '/sampleId',
+        repeatedMeasures: true,
+        resamplingUnit: 'paired-block',
+        estimatorId: BOOTSTRAP_FAMILY_ANALYSIS_IMPLEMENTATION_ID,
+        seedCoupling: 'uncontrolled',
+      },
+      scheduling: {
+        schedulingKind: 'randomized-block',
+        blockSize: targets.length,
+      },
+    },
+    policy: {
+      executionConcurrency: request.values.measurement.executionConcurrency,
+      evaluationConcurrency: request.values.measurement.executionConcurrency,
+      executionTimeoutMs: request.values.measurement.timeoutMs,
+      evaluationTimeoutMs: request.values.measurement.timeoutMs,
+      retryCount: request.values.measurement.retryCount,
+      cache: request.values.measurement.cache,
+      ...(request.values.measurement.budget === undefined ? {} : {
+        budget: request.values.measurement.budget,
+      }),
+    },
+    hostResources: {
+      schemaVersion: RESOLVED_HOST_RESOURCES_SCHEMA_VERSION,
+      resources: [...resources.resourcesById.values()].sort((left, right) => (
+        left.descriptor.resourceId < right.descriptor.resourceId ? -1
+          : left.descriptor.resourceId > right.descriptor.resourceId ? 1 : 0
+      )),
+    },
+    orchestration: {
+      dryRun: request.values.orchestration.dryRun,
+      batch: false,
+      ...(request.values.orchestration.resumeSourceLocator === undefined ? {} : {
+        resumeSourceLocator: absolute(
+          options.projectRoot,
+          request.values.orchestration.resumeSourceLocator,
+        ),
+      }),
+      preflight: request.values.orchestration.preflight,
+      diagnostic: request.values.orchestration.diagnostic,
+      managedEvidence: request.values.orchestration.managedEvidence,
+      ...(loaded.requires === undefined ? {} : {
+        dependencyRequirements: {
+          baseDirectoryLocator: resolve(loaded.baseDir),
+          ...Object.fromEntries(Object.entries(loaded.requires)
+            .filter((entry): entry is [string, string[]] => entry[1] !== undefined)
+            .map(([key, values]) => [key, [...new Set(values)].sort()])),
+        },
+      }),
+      ...(gold === undefined ? {} : {
+        gold: { resourceId: gold.resourceId, comparisonMode: 'exploratory-post-hoc' },
+      }),
+      ...(repeatCount <= 1 ? {} : {
+        independentSeries: {
+          repeatCount,
+          seriesInstanceId: options.seriesInstanceId!,
+          comparisonScope: 'decision',
+          minimumStatus: 'compatible',
+        },
+      }),
+    },
+    presentation: {
+      ...request.values.presentation,
+      outputDirectoryLocator: absolute(
+        options.projectRoot,
+        request.values.presentation.outputDirectoryLocator,
+      ),
+    },
+    staticRunMetadata: {
+      annotations: {
+        inputSources: structuredClone(request.fieldSources) as unknown as JsonValue,
+        sampleSourceCount: loaded.sourceFiles.length,
+      },
+    },
+  };
+  return deepFreezeCanonicalJson(output as unknown as JsonValue) as unknown as ResolvedCliEvaluationInput;
+}

--- a/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
+++ b/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
@@ -61,8 +61,12 @@ function mediaType(path: string): string {
 function resourceId(
   resourceKind: ResolvedHostResource['resourceKind'],
   digest: ResolvedResourceDescriptor['digest'],
+  identityScope?: string,
 ): string {
-  return `${resourceKind}-${digest.slice('sha256:'.length, 'sha256:'.length + 24)}`;
+  const contentId = digest.slice('sha256:'.length, 'sha256:'.length + 24);
+  return identityScope === undefined
+    ? `${resourceKind}-${contentId}`
+    : `${resourceKind}-${createHash('sha256').update(identityScope).digest('hex').slice(0, 16)}-${contentId}`;
 }
 
 function registry(): ResourceRegistry {
@@ -94,6 +98,7 @@ async function fileResource(
     readonly classification: ResolvedResourceDescriptor['classification'];
     readonly mediaType?: string;
     readonly lineage?: JsonValue;
+    readonly identityScope?: string;
   },
 ): Promise<ResolvedResourceDescriptor> {
   let measured: Awaited<ReturnType<typeof digestNodeFileResource>>;
@@ -108,7 +113,7 @@ async function fileResource(
     });
   }
   const descriptor: ResolvedResourceDescriptor = {
-    resourceId: resourceId(input.resourceKind, measured.digest),
+    resourceId: resourceId(input.resourceKind, measured.digest, input.identityScope),
     digest: measured.digest,
     mediaType: input.mediaType ?? mediaType(input.path),
     classification: input.classification,
@@ -134,6 +139,7 @@ async function treeResource(
     readonly classification: ResolvedResourceDescriptor['classification'];
     readonly mediaType: string;
     readonly lineage?: JsonValue;
+    readonly identityScope?: string;
   },
 ): Promise<ResolvedResourceDescriptor> {
   let measured: Awaited<ReturnType<typeof digestNodeTreeResource>>;
@@ -148,7 +154,7 @@ async function treeResource(
     });
   }
   const descriptor: ResolvedResourceDescriptor = {
-    resourceId: resourceId(input.resourceKind, measured.digest),
+    resourceId: resourceId(input.resourceKind, measured.digest, input.identityScope),
     digest: measured.digest,
     mediaType: input.mediaType,
     classification: input.classification,
@@ -234,6 +240,7 @@ async function materializeBytes(
 async function artifactResource(
   resources: ResourceRegistry,
   artifact: Readonly<Artifact>,
+  targetId: string,
   materializationRoot: string,
 ): Promise<ResolvedResourceDescriptor> {
   const lineage: JsonValue = {
@@ -263,12 +270,14 @@ async function artifactResource(
       classification: 'sensitive',
       mediaType: 'application/vnd.omk.knowledge-artifact-tree',
       lineage,
+      identityScope: targetId,
     });
     if (stat?.isFile()) return fileResource(resources, {
       resourceKind: 'artifact',
       path: candidate,
       classification: 'sensitive',
       lineage,
+      identityScope: targetId,
     });
     if (stat !== undefined) {
       fail({
@@ -286,6 +295,7 @@ async function artifactResource(
     classification: 'sensitive',
     mediaType: 'text/markdown',
     lineage,
+    identityScope: targetId,
   });
 }
 
@@ -512,6 +522,7 @@ export async function resolveNodeCliEvaluationRequest(
     const artifactDescriptor = await artifactResource(
       resources,
       artifact,
+      variant.targetId,
       options.materializationRoot,
     );
     const workspaceLocator = variant.workspaceLocator ?? sampleWorkspace;

--- a/src/inputs/load-samples.ts
+++ b/src/inputs/load-samples.ts
@@ -42,6 +42,11 @@ export interface LoadSamplesResult {
   sampleSourceById: Record<string, string>;
 }
 
+export interface LoadSamplesOptions {
+  /** Production measurement resolution must not depend on ambient compatibility switches. */
+  readonly assertionValidationMode?: 'environment-compatible' | 'strict';
+}
+
 /**
  * Load samples from a single file OR a directory of sample files.
  *
@@ -55,12 +60,15 @@ export interface LoadSamplesResult {
  * - Cross-file `sample_id` must be unique
  * - `requires` from each file unioned together
  */
-export function loadSamples(samplesPath: string): LoadSamplesResult {
+export function loadSamples(
+  samplesPath: string,
+  options: Readonly<LoadSamplesOptions> = {},
+): LoadSamplesResult {
   const abs = resolve(samplesPath);
   if (statSync(abs).isDirectory()) {
-    return loadSamplesFromDir(abs);
+    return loadSamplesFromDir(abs, options);
   }
-  const inner = loadSampleFile(abs);
+  const inner = loadSampleFile(abs, options);
   return {
     ...inner,
     baseDir: dirname(abs),
@@ -81,7 +89,10 @@ export function listSampleFilesInDir(dir: string): string[] {
     .sort();  // deterministic merge order
 }
 
-function loadSamplesFromDir(dir: string): LoadSamplesResult {
+function loadSamplesFromDir(
+  dir: string,
+  options: Readonly<LoadSamplesOptions>,
+): LoadSamplesResult {
   const files = listSampleFilesInDir(dir);
   if (files.length === 0) {
     throw new Error(
@@ -99,7 +110,7 @@ function loadSamplesFromDir(dir: string): LoadSamplesResult {
   for (const f of files) {
     const path = join(dir, f);
     sourceFiles.push(path);
-    const single = loadSampleFile(path);
+    const single = loadSampleFile(path, options);
     for (const s of single.samples) {
       const prev = seenIds.get(s.sample_id);
       if (prev) {
@@ -142,7 +153,10 @@ function mergeRequires(
 
 interface LoadSamplesInner { samples: Sample[]; requires?: DependencyRequirements }
 
-export function validateSamples(samples: Sample[]): void {
+export function validateSamples(
+  samples: Sample[],
+  options: Readonly<LoadSamplesOptions> = {},
+): void {
   // sample design metadata enums (capability/difficulty/construct/provenance).
   // Pure documentation/diagnostic fields; do NOT participate in grading/judge/verdict.
   const VALID_DIFFICULTY: ReadonlySet<string> = new Set(['easy', 'medium', 'hard']);
@@ -252,7 +266,8 @@ export function validateSamples(samples: Sample[]): void {
       'contains', 'not_contains', 'contains_all', 'contains_any', 'equals', 'not_equals',
     ]);
     const LOADER_CJK = /[　-〿一-鿿㐀-䶿＀-￯]/;
-    const isLenient = process.env.OMK_LENIENT_ASSERTIONS === '1';
+    const isLenient = options.assertionValidationMode !== 'strict'
+      && process.env.OMK_LENIENT_ASSERTIONS === '1';
     const checkAsciiTokenValue = (label: string, raw: unknown): string | null => {
       if (typeof raw !== 'string') return `${label} value 必须是字符串 (实际类型 ${typeof raw})`;
       const s = raw.trim();
@@ -330,7 +345,10 @@ export function validateSamples(samples: Sample[]): void {
   }
 }
 
-function loadSampleFile(samplesPath: string): LoadSamplesInner {
+function loadSampleFile(
+  samplesPath: string,
+  options: Readonly<LoadSamplesOptions>,
+): LoadSamplesInner {
   const rawContent = readFileSync(samplesPath, 'utf-8');
   const isYaml = samplesPath.endsWith('.yaml') || samplesPath.endsWith('.yml');
   const parsed: unknown = isYaml ? parseYaml(rawContent) : JSON.parse(rawContent);
@@ -360,7 +378,7 @@ function loadSampleFile(samplesPath: string): LoadSamplesInner {
     throw new Error(`invalid samples file: ${samplesPath}`);
   }
 
-  validateSamples(samples);
+  validateSamples(samples, options);
 
   return { samples, requires };
 }

--- a/test/eval-workflows/production-host/migration-boundary.test.ts
+++ b/test/eval-workflows/production-host/migration-boundary.test.ts
@@ -1,0 +1,38 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function productionHostSource(): string {
+  const root = 'src/eval-workflows/production-host';
+  return readdirSync(root)
+    .filter((file) => file.endsWith('.ts'))
+    .sort()
+    .map((file) => readFileSync(join(root, file), 'utf8'))
+    .join('\n');
+}
+
+describe('#539 production host migration boundary', () => {
+  it('terminates legacy report and pipeline models outside the new composition root', () => {
+    const source = productionHostSource();
+
+    for (const forbidden of [
+      'EvaluationReport',
+      'ReportStore',
+      'VariantResult',
+      'evaluation-pipeline',
+      'run-evaluation',
+    ]) {
+      expect(source).not.toContain(forbidden);
+    }
+  });
+
+  it('keeps the production CLI and report server disconnected in this migration slice', () => {
+    const production = [
+      'src/eval-workflows/run-evaluation.ts',
+      'src/server/report-server.ts',
+    ].map((file) => readFileSync(file, 'utf8')).join('\n');
+
+    expect(production).not.toContain('production-host');
+    expect(production).not.toContain('resolveNodeCliEvaluationRequest');
+  });
+});

--- a/test/eval-workflows/production-host/node-cli-evaluation-resolver.test.ts
+++ b/test/eval-workflows/production-host/node-cli-evaluation-resolver.test.ts
@@ -300,6 +300,21 @@ describe('resolveNodeCliEvaluationRequest', () => {
     expect(applicability).toEqual(expect.arrayContaining([
       ['sample-a'], ['sample-a'], ['sample-b'],
     ]));
+    expect(compiled.definition.decisionPolicy?.parameters).not.toMatchObject({
+      sources: { judgeEnsemble: expect.anything() },
+    });
+  });
+
+  it('uses only an explicit overall rubric for the release judge-agreement gate', async () => {
+    const root = await fixture('overall-agreement');
+    const compiled = compileCliEvaluationInput(await resolveNodeCliEvaluationRequest(
+      request(root),
+      { projectRoot: root, materializationRoot: join(root, '.omk', 'resolved') },
+    ));
+
+    expect(compiled.definition.decisionPolicy?.parameters).toMatchObject({
+      sources: { judgeEnsemble: { replicateGroupId: expect.stringContaining('rubric-') } },
+    });
   });
 
   it('keeps production sample validation strict despite the legacy ambient escape hatch', async () => {

--- a/test/eval-workflows/production-host/node-cli-evaluation-resolver.test.ts
+++ b/test/eval-workflows/production-host/node-cli-evaluation-resolver.test.ts
@@ -1,0 +1,324 @@
+import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  compileCliEvaluationInput,
+  parseCliEvaluationRequest,
+} from '../../../src/eval-workflows/input-compilation/index.js';
+import { resolveNodeCliEvaluationRequest } from '../../../src/eval-workflows/production-host/index.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function fixture(label: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), `omk-production-resolver-${label}-`));
+  roots.push(root);
+  await mkdir(join(root, 'skills'));
+  await mkdir(join(root, 'fixtures'));
+  await writeFile(join(root, 'skills', 'control.md'), '# Control\nAnswer directly.\n');
+  await writeFile(join(root, 'skills', 'treatment.md'), '# Treatment\nUse the supplied knowledge.\n');
+  await writeFile(join(root, 'fixtures', 'secret.json'), JSON.stringify({ token: 'secret-value' }));
+  await writeFile(join(root, 'samples.json'), JSON.stringify([{
+    sample_id: 'sample-a',
+    prompt: 'Return a concise JSON answer.',
+    rubric: 'The response is correct and concise.',
+    assertions: [
+      { type: 'json_valid', weight: 2 },
+      { type: 'tools_count_max', value: 1 },
+      { type: 'semantic_similarity', reference: '{"ok":true}', threshold: 3 },
+    ],
+    mocks: [{
+      tool: 'Bash',
+      match: { command_glob: '*' },
+      return_file: 'fixtures/secret.json',
+    }],
+    mocksStrict: true,
+  }]));
+  return root;
+}
+
+function request(root: string, additionalFlags: Readonly<Record<string, unknown>> = {}) {
+  return parseCliEvaluationRequest({
+    explicitCliFlags: {
+      control: 'skills/control.md',
+      treatment: 'skills/treatment.md',
+      samples: 'samples.json',
+      'skill-dir': 'skills',
+      executor: 'claude',
+      model: 'claude-test',
+      'judge-models': 'anthropic-api:judge-test',
+      'no-serve': true,
+      'output-dir': '.omk/reports',
+      ...additionalFlags,
+    },
+    defaults: {
+      samplesLocator: 'samples.json',
+      skillDirectoryLocator: 'skills',
+      targetRuntime: { executorId: 'claude', model: 'claude-test', effort: 'low' },
+      judgeMembers: [{ executorId: 'anthropic-api', model: 'judge-test' }],
+      presentation: {
+        projectOutputDirectoryLocator: join(root, '.omk', 'reports'),
+        globalOutputDirectoryLocator: join(root, '.omk-global', 'reports'),
+        language: 'zh',
+        languageDefaultSource: 'environment-selection',
+      },
+    },
+  });
+}
+
+describe('resolveNodeCliEvaluationRequest', () => {
+  it('resolves real files into a compilable five-layer design without leaking secret payloads', async () => {
+    const root = await fixture('compile');
+    const resolved = await resolveNodeCliEvaluationRequest(request(root), {
+      projectRoot: root,
+      materializationRoot: join(root, '.omk', 'resolved'),
+    });
+    const compiled = compileCliEvaluationInput(resolved);
+
+    expect(compiled.definition.evaluators.map((evaluator) => evaluator.implementationId)).toEqual(
+      expect.arrayContaining([
+        'omk.assertions.output/v1',
+        'omk.assertions.execution/v1',
+        'omk.llm-assertions/v2',
+        'omk.rubric-judge/v1',
+      ]),
+    );
+    expect(compiled.definition.analysisGraph.nodes.map((node) => node.implementationId)).toEqual(
+      expect.arrayContaining([
+        'omk.assertion-layer-table/v1',
+        'omk.dimension-table/v1',
+        'omk.composite-table/v1',
+        'omk.bootstrap-family-table/v1',
+      ]),
+    );
+    expect(compiled.definition.experiment.sampling.seedCoupling).toBe('uncontrolled');
+    expect(JSON.stringify(compiled.definition)).not.toContain('secret-value');
+    expect(compiled.hostResources.resources.some((resource) => (
+      resource.resourceKind === 'mock-payload'
+      && resource.descriptor.classification === 'secret'
+    ))).toBe(true);
+    expect(Object.isFrozen(resolved)).toBe(true);
+  });
+
+  it('materializes inline mock payloads in a private resolver-owned store', async () => {
+    const root = await fixture('private-materialization');
+    await writeFile(join(root, 'samples.json'), JSON.stringify([{
+      sample_id: 'sample-a',
+      prompt: 'A',
+      rubric: 'Correct.',
+      mocks: [{ tool: 'Read', return: { token: 'inline-secret' } }],
+    }]));
+    const resolved = await resolveNodeCliEvaluationRequest(request(root), {
+      projectRoot: root,
+      materializationRoot: join(root, '.omk', 'resolved'),
+    });
+    const payload = resolved.hostResources.resources.find(
+      (resource) => resource.resourceKind === 'mock-payload',
+    );
+
+    expect(payload).toBeDefined();
+    expect((await stat(payload!.locator)).mode & 0o777).toBe(0o600);
+    expect((await stat(join(root, '.omk', 'resolved', 'content'))).mode & 0o777).toBe(0o700);
+  });
+
+  it('keeps behavior digests invariant when identical bytes move to another root', async () => {
+    const first = await fixture('move-a');
+    const second = await fixture('move-b');
+    const [left, right] = await Promise.all([first, second].map(async (root) => (
+      compileCliEvaluationInput(await resolveNodeCliEvaluationRequest(request(root), {
+        projectRoot: root,
+        materializationRoot: join(root, '.omk', 'resolved'),
+      }))
+    )));
+
+    expect(left.canonicalDigests.definition).toBe(right.canonicalDigests.definition);
+    expect(left.canonicalDigests.policy).toBe(right.canonicalDigests.policy);
+    expect(left.hostResources.resources.map((resource) => resource.locator)).not.toEqual(
+      right.hostResources.resources.map((resource) => resource.locator),
+    );
+  });
+
+  it('compiles equivalent CLI and eval.yaml requests to the same measurement digests', async () => {
+    const root = await fixture('source-equivalence');
+    const fromConfig = parseCliEvaluationRequest({
+      explicitCliFlags: {},
+      evalConfig: {
+        samples: 'samples.json',
+        executor: 'claude',
+        model: 'claude-test',
+        judgeModels: [{ executor: 'anthropic-api', model: 'judge-test' }],
+        variants: [{
+          name: 'control', role: 'control', artifact: 'skills/control.md',
+        }, {
+          name: 'treatment', role: 'treatment', artifact: 'skills/treatment.md',
+        }],
+      },
+      defaults: {
+        samplesLocator: 'samples.json',
+        skillDirectoryLocator: 'skills',
+        targetRuntime: { executorId: 'claude', model: 'claude-test', effort: 'low' },
+        judgeMembers: [{ executorId: 'anthropic-api', model: 'judge-test' }],
+        presentation: {
+          projectOutputDirectoryLocator: join(root, '.omk', 'reports'),
+          globalOutputDirectoryLocator: join(root, '.omk-global', 'reports'),
+          language: 'zh',
+          languageDefaultSource: 'environment-selection',
+        },
+      },
+    });
+    const [cli, yaml] = await Promise.all([
+      request(root),
+      fromConfig,
+    ].map(async (value, index) => compileCliEvaluationInput(
+      await resolveNodeCliEvaluationRequest(value, {
+        projectRoot: root,
+        materializationRoot: join(root, '.omk', `resolved-${index}`),
+      }),
+    )));
+
+    expect(cli.canonicalDigests).toEqual(yaml.canonicalDigests);
+  });
+
+  it('fails closed instead of flattening heterogeneous sample tool policies', async () => {
+    const root = await fixture('controls');
+    await writeFile(join(root, 'samples.json'), JSON.stringify([{
+      sample_id: 'sample-a', prompt: 'A', rubric: 'Correct.', allowedTools: ['Read'],
+    }, {
+      sample_id: 'sample-b', prompt: 'B', rubric: 'Correct.', allowedTools: ['Bash'],
+    }]));
+
+    await expect(resolveNodeCliEvaluationRequest(request(root), {
+      projectRoot: root,
+      materializationRoot: join(root, '.omk', 'resolved'),
+    })).rejects.toMatchObject({ code: 'CLI_INPUT_SAMPLE_CONTROL_CONFLICT' });
+  });
+
+  it('keeps Gold analysis-only and outside every executor resource lease', async () => {
+    const root = await fixture('gold-isolation');
+    await writeFile(join(root, 'gold.json'), JSON.stringify({ sampleId: 'sample-a', score: 5 }));
+    const resolved = await resolveNodeCliEvaluationRequest(request(root, {
+      'gold-dir': 'gold.json',
+    }), {
+      projectRoot: root,
+      materializationRoot: join(root, '.omk', 'resolved'),
+    });
+    const compiled = compileCliEvaluationInput(resolved);
+    const gold = compiled.hostResources.resources.find((resource) => (
+      resource.resourceKind === 'gold-dataset'
+    ));
+
+    expect(gold?.descriptor.classification).toBe('gold');
+    const goldId = gold!.descriptor.resourceId;
+    expect(compiled.orchestration.gold?.resourceId).toBe(goldId);
+    const executorBindings = compiled.runtimeBinding.bindings.filter((binding) => (
+      binding.runtimeKind === 'executor'
+    ));
+    expect(JSON.stringify(executorBindings)).not.toContain(goldId);
+    expect(JSON.stringify(compiled.definition.targets)).not.toContain(goldId);
+  });
+
+  it('groups record-scoped evaluators across multiple samples without missing bindings', async () => {
+    const root = await fixture('multi-sample');
+    await writeFile(join(root, 'samples.json'), JSON.stringify([
+      {
+        sample_id: 'sample-a', prompt: 'A', rubric: 'Correct.',
+        assertions: [
+          { type: 'json_valid' },
+          { type: 'tools_count_max', value: 1 },
+          { type: 'semantic_similarity', reference: 'A' },
+        ],
+      },
+      {
+        sample_id: 'sample-b', prompt: 'B', rubric: 'Correct.',
+        assertions: [
+          { type: 'contains', value: 'Bee' },
+          { type: 'tools_count_max', value: 2 },
+          { type: 'semantic_similarity', reference: 'B' },
+        ],
+      },
+    ]));
+
+    const compiled = compileCliEvaluationInput(await resolveNodeCliEvaluationRequest(
+      request(root),
+      { projectRoot: root, materializationRoot: join(root, '.omk', 'resolved') },
+    ));
+
+    expect(compiled.definition.dataset.samples).toHaveLength(2);
+    const llmEvaluators = compiled.definition.evaluators.filter((evaluator) => (
+      evaluator.implementationId === 'omk.llm-assertions/v2'
+    ));
+    expect(llmEvaluators).toHaveLength(2);
+    expect(llmEvaluators.map((evaluator) => evaluator.applicableSampleIds)).toEqual([
+      ['sample-a'], ['sample-b'],
+    ]);
+  });
+
+  it('seals partial LLM and rubric applicability instead of scoring unintended samples', async () => {
+    const root = await fixture('partial-applicability');
+    await writeFile(join(root, 'samples.json'), JSON.stringify([
+      {
+        sample_id: 'sample-a', prompt: 'A', dimensions: { accuracy: 'Correct.' },
+        assertions: [{ type: 'semantic_similarity', reference: 'A' }],
+      },
+      { sample_id: 'sample-b', prompt: 'B', dimensions: { style: 'Concise.' } },
+    ]));
+
+    const compiled = compileCliEvaluationInput(await resolveNodeCliEvaluationRequest(request(root), {
+      projectRoot: root,
+      materializationRoot: join(root, '.omk', 'resolved'),
+    }));
+    const applicability = compiled.definition.evaluators
+      .filter((evaluator) => evaluator.applicableSampleIds !== undefined)
+      .map((evaluator) => evaluator.applicableSampleIds);
+
+    expect(applicability).toHaveLength(3);
+    expect(applicability).toEqual(expect.arrayContaining([
+      ['sample-a'], ['sample-a'], ['sample-b'],
+    ]));
+  });
+
+  it('keeps production sample validation strict despite the legacy ambient escape hatch', async () => {
+    const root = await fixture('strict-loader');
+    await writeFile(join(root, 'samples.json'), JSON.stringify([{
+      sample_id: 'sample-a', prompt: 'A', rubric: 'Correct.',
+      assertions: [{ type: 'contains', value: 'X' }],
+    }]));
+    vi.stubEnv('OMK_LENIENT_ASSERTIONS', '1');
+
+    await expect(resolveNodeCliEvaluationRequest(request(root), {
+      projectRoot: root,
+      materializationRoot: join(root, '.omk', 'resolved'),
+    })).rejects.toMatchObject({ code: 'CLI_INPUT_RESOLUTION_FAILED' });
+  });
+
+  it('preserves normalized sample dependency requirements for host preflight', async () => {
+    const root = await fixture('dependencies');
+    await writeFile(join(root, 'samples.json'), JSON.stringify({
+      requires: {
+        tools: ['git', 'node'],
+        files: ['./fixtures/input.json'],
+        env: ['TOKEN'],
+        preflight: ['node --version'],
+      },
+      samples: [{ sample_id: 'sample-a', prompt: 'A', rubric: 'Correct.' }],
+    }));
+
+    const compiled = compileCliEvaluationInput(await resolveNodeCliEvaluationRequest(
+      request(root),
+      { projectRoot: root, materializationRoot: join(root, '.omk', 'resolved') },
+    ));
+
+    expect(compiled.orchestration.dependencyRequirements).toEqual({
+      baseDirectoryLocator: root,
+      env: ['TOKEN'],
+      files: ['./fixtures/input.json'],
+      preflight: ['node --version'],
+      tools: ['git', 'node'],
+    });
+  });
+});

--- a/test/eval-workflows/production-host/node-cli-evaluation-resolver.test.ts
+++ b/test/eval-workflows/production-host/node-cli-evaluation-resolver.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -141,6 +141,26 @@ describe('resolveNodeCliEvaluationRequest', () => {
     expect(left.hostResources.resources.map((resource) => resource.locator)).not.toEqual(
       right.hostResources.resources.map((resource) => resource.locator),
     );
+  });
+
+  it('retains distinct target lineage when artifact bytes are identical', async () => {
+    const root = await fixture('duplicate-artifact-bytes');
+    await writeFile(
+      join(root, 'skills', 'treatment.md'),
+      await readFile(join(root, 'skills', 'control.md')),
+    );
+    const resolved = await resolveNodeCliEvaluationRequest(request(root), {
+      projectRoot: root,
+      materializationRoot: join(root, '.omk', 'resolved'),
+    });
+    const artifacts = resolved.hostResources.resources.filter(
+      (resource) => resource.resourceKind === 'artifact',
+    );
+
+    expect(artifacts).toHaveLength(2);
+    expect(new Set(artifacts.map((resource) => resource.descriptor.digest)).size).toBe(1);
+    expect(new Set(artifacts.map((resource) => resource.descriptor.resourceId)).size).toBe(2);
+    expect(new Set(artifacts.map((resource) => resource.locator)).size).toBe(2);
   });
 
   it('compiles equivalent CLI and eval.yaml requests to the same measurement digests', async () => {


### PR DESCRIPTION
Refs #539、#450。

Depends on #541。

## 用户影响

新增 CLI／eval.yaml 到 Evaluation Core 的唯一 Node effect resolver，并把现有 Sample／Artifact authoring DTO 在边界内转换成五层 EvaluationDefinition 输入。正式 `omk eval`、Studio 与旧报告链路仍未接线，因此当前用户执行路径不变。

## 架构边界

Resolver 只解析并封存 sample、artifact／workspace、MCP、mock、Gold 与 host orchestration 事实；不创建 Runtime／runId，不执行 doctor／connectivity，不写 artifact store。资源使用内容摘要作为行为 identity，绝对 locator 只保留在宿主 lineage。Sample bundle 的 `requires` 连同根目录交给后续 preflight，Gold 保持 analysis-only。

## 迁移说明

生产解析强制 strict sample validation，不读取 ambient lenient 开关，也不提供旧 resolved-input 兼容。异构 sample `cwd`／`allowedTools` 当前 fail closed；通用表达由 #542 跟进，不能以取并集方式改变实验。

## 测量学说明

Evaluator 继续复用冻结 instrument 与现有五层分析实现；LLM assertion 一 criterion／一 Metric，不合并 provider call。每个 treatment 单独建立 paired comparison。当前正式 provider adapter 均不保证 sampling seed，因此如实封存 `seedCoupling: uncontrolled`；随机 block 只控制调度顺序，不虚构模型随机性耦合。绝对路径变化不改变 Definition／Policy digest，Gold、secret mock 与 expected 不进入 Executor lease。

本 PR 不修改 prompt 文本、Bootstrap／Krippendorff alpha 公式、missing policy 或 length-debias 语义，不属于 BREAKING-COMPARABILITY。