### PR TITLE
feat(eval-workflows): 组装生产运行时注册表

### DIFF
--- a/docs/specs/evaluation-runtime-adapter.md
+++ b/docs/specs/evaluation-runtime-adapter.md
@@ -1,6 +1,6 @@
 # Evaluation Runtime Adapter
 
-> **Status**: binding assembly, verified resource leases, adapter preflight, non-blocking event projection, and the Core composition root for [#457](https://github.com/lizhiyao/oh-my-knowledge/issues/457). It is additive and does not switch the production `omk eval` pipeline.
+> **Status**: binding assembly, verified resource leases, adapter preflight, non-blocking event projection, the Core composition root, and the production factory registry/support ports are implemented. It is additive and does not switch the production `omk eval` pipeline.
 
 ## Boundary
 
@@ -49,6 +49,8 @@ Before invoking any factory, assembly validates unique binding IDs and reference
 ## Immutable entries and identity
 
 Assembly first clones and deep-freezes Definition, Series, and RuntimeBindingRequest. Each implementation factory is selected by `implementationId`, but it is called once per binding so two references using the same implementation receive distinct port instances.
+
+`createProductionRuntimeFactoryRegistry()` is the sole production mapping for Codex CLI／SDK, Claude CLI／SDK, OpenAI API, Anthropic API, custom command, and OMK-owned scoring／analysis implementations. It snapshots configurations and exposes immutable map views without invoking unused factories. Executor preflight declarations are mandatory host input and are captured with the same configuration; the registry does not invent successful doctor, credential, connectivity, filesystem, MCP, or mock checks. Node support ports share one digest-verifying content store instance and receive the clock explicitly.
 
 The factory returns the actual port identity and version-resolution result. Assembly validates the port shape and implementation identity, captures an immutable identity snapshot, and wraps the port methods around the original instance. Executor binding validation also requires exact equality with `TargetDefinition.executionRequirements`; the qualification object reuses that canonical value rather than re-deriving feature semantics. The Core preparation resolver and the captured execution port are then projected from the same entry; later registry or request mutation cannot create split-brain resolution. Only Core compares those requirements with the actual port capability manifest.
 

--- a/docs/zh/specs/evaluation-runtime-adapter.md
+++ b/docs/zh/specs/evaluation-runtime-adapter.md
@@ -1,6 +1,6 @@
 # Evaluation Runtime Adapter 规范
 
-> **状态**：已建立 [#457](https://github.com/lizhiyao/oh-my-knowledge/issues/457) 的 binding assembly、verified resource lease 与 Core composition root。本层是增量架构，不切换正式 `omk eval` pipeline。
+> **状态**：binding assembly、verified resource lease、Core composition root，以及生产 factory registry／support port 已实现。本层是增量架构，不切换正式 `omk eval` pipeline。
 
 ## 一、边界
 
@@ -43,6 +43,8 @@ Analysis binding 同时携带 `referenceId` 和 Core `requirementKind`。Samplin
 ## 三、不可变 Entry 与身份
 
 Assembly 首先复制并深度冻结 Definition、Series 和 RuntimeBindingRequest。Factory 按 `implementationId` 查找，但按 binding 分别调用，因此共享同一实现的两个 reference 仍得到不同 port instance。
+
+`createProductionRuntimeFactoryRegistry()` 是 Codex CLI／SDK、Claude CLI／SDK、OpenAI API、Anthropic API、custom command，以及 OMK 自有 scoring／analysis 实现的唯一生产映射。它先快照化配置并暴露不可变 map view，不调用未使用的 factory。Executor preflight declaration 是必填宿主输入，并与同一配置一起捕获；registry 不伪造 doctor、credential、connectivity、filesystem、MCP 或 mock 检查成功。Node support port 共享一个校验 digest 的 content store 实例，clock 也必须显式传入。
 
 Factory 返回实际 port identity 和 version resolution。Assembly 校验 port 形状与 implementation identity，捕获不可变 identity snapshot，并用原始实例的方法包装 port。Executor binding 还必须与 `TargetDefinition.executionRequirements` 精确相等；qualification 直接复用该 canonical 值，不重新派生 feature 语义。Core preparation resolver 和运行 port 由同一个 entry 投影；后续 registry 或请求对象变化不能造成 split-brain。只有 Core 能把 requirements 与实际 port capability manifest 做匹配。
 

--- a/src/eval-workflows/production-host/index.ts
+++ b/src/eval-workflows/production-host/index.ts
@@ -1,2 +1,3 @@
 export * from './measurement-design.js';
 export * from './node-cli-evaluation-resolver.js';
+export * from './runtime-registry.js';

--- a/src/eval-workflows/production-host/runtime-registry.ts
+++ b/src/eval-workflows/production-host/runtime-registry.ts
@@ -1,0 +1,379 @@
+import { isAbsolute } from 'node:path';
+import type { EvaluationEngineClock } from '../../evaluation-core/engine/index.js';
+import type { ExecutionExecutor } from '../../evaluation-core/execution/index.js';
+import {
+  deepFreezeCanonicalJson,
+  type JsonValue,
+} from '../../evaluation-core/contracts/index.js';
+import { createNodeCoreContentStore } from '../artifact-store/node-content-store.js';
+import {
+  createAnthropicApiExecutorAdapter,
+  createClaudeCliExecutorAdapter,
+  createClaudeSdkExecutorAdapter,
+  createCodexCliExecutorAdapter,
+  createCodexSdkExecutorAdapter,
+  createCustomCommandExecutorAdapter,
+  createOpenAIApiExecutorAdapter,
+  type AnthropicApiCoreConfiguration,
+  type ClaudeCliCoreConfiguration,
+  type ClaudeSdkCoreConfiguration,
+  type CodexCliCoreConfiguration,
+  type CodexSdkCoreConfiguration,
+  type CustomCommandConfiguration,
+  type CustomCommandRuntimeDescription,
+  type OpenAIApiCoreConfiguration,
+} from '../runtime-adapter/adapters/index.js';
+import { captureCoreApiTransport } from '../runtime-adapter/adapters/api-http.js';
+import {
+  createBuiltinOmkAnalysisBindingFactories,
+  createBuiltinOmkScoringBindingFactories,
+} from '../runtime-adapter/builtins.js';
+import type { OmkEvaluationRuntimeSupportPorts } from '../runtime-adapter/composition.js';
+import {
+  createLlmAssertionEvaluatorBindingFactory,
+  LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+  type OmkLlmJudgeInvocationResolver,
+} from '../runtime-adapter/evaluators/llm-assertions.js';
+import {
+  createRubricJudgeEvaluatorBindingFactory,
+  RUBRIC_JUDGE_EVALUATOR_IMPLEMENTATION_ID,
+} from '../runtime-adapter/evaluators/rubric-judge.js';
+import type {
+  OmkExecutorBindingContext,
+  OmkRuntimeBindingFactories,
+  OmkRuntimePortBinding,
+  OmkRuntimePreflightDeclaration,
+} from '../runtime-adapter/types.js';
+
+type ProductionExecutorPreflightConfiguration = {
+  /** Physical checks are host-owned and captured without executing them. */
+  readonly preflightDeclarations: readonly OmkRuntimePreflightDeclaration[];
+};
+
+export type ProductionExecutorAdapterConfiguration = ProductionExecutorPreflightConfiguration & (
+  | { readonly adapterKind: 'codex-cli'; readonly command: CodexCliCoreConfiguration }
+  | { readonly adapterKind: 'codex-sdk'; readonly sdk?: CodexSdkCoreConfiguration }
+  | { readonly adapterKind: 'claude-cli'; readonly command: ClaudeCliCoreConfiguration }
+  | { readonly adapterKind: 'claude-sdk'; readonly sdk?: ClaudeSdkCoreConfiguration }
+  | { readonly adapterKind: 'openai-api'; readonly api: OpenAIApiCoreConfiguration }
+  | { readonly adapterKind: 'anthropic-api'; readonly api: AnthropicApiCoreConfiguration }
+  | {
+      readonly adapterKind: 'custom-command';
+      readonly runtime: CustomCommandRuntimeDescription;
+      readonly command: CustomCommandConfiguration;
+    }
+);
+
+export interface CreateProductionRuntimeFactoryRegistryInput {
+  /** Exact implementation IDs selected by resolved Targets. Factories remain lazy. */
+  readonly executorsByImplementationId: ReadonlyMap<
+    string,
+    ProductionExecutorAdapterConfiguration
+  >;
+  /** Omit only when the resolved Definition contains no provider-backed Evaluator. */
+  readonly resolveJudgeInvocation?: OmkLlmJudgeInvocationResolver;
+}
+
+export class ProductionRuntimeRegistryError extends TypeError {
+  readonly code: 'PRODUCTION_RUNTIME_REGISTRY_INVALID';
+  readonly implementationId?: string;
+
+  constructor(input: {
+    code: ProductionRuntimeRegistryError['code'];
+    message: string;
+    implementationId?: string;
+    cause?: unknown;
+  }) {
+    super(input.message, { cause: input.cause });
+    this.name = 'ProductionRuntimeRegistryError';
+    this.code = input.code;
+    this.implementationId = input.implementationId;
+  }
+}
+
+function fail(input: ConstructorParameters<typeof ProductionRuntimeRegistryError>[0]): never {
+  throw new ProductionRuntimeRegistryError(input);
+}
+
+function readonlyMapSnapshot<Key, Value>(source: ReadonlyMap<Key, Value>): ReadonlyMap<Key, Value> {
+  const snapshot = new Map(source);
+  const view: ReadonlyMap<Key, Value> = Object.freeze({
+    get size() { return snapshot.size; },
+    get(key: Key) { return snapshot.get(key); },
+    has(key: Key) { return snapshot.has(key); },
+    keys() { return snapshot.keys(); },
+    values() { return snapshot.values(); },
+    entries() { return snapshot.entries(); },
+    [Symbol.iterator]() { return snapshot[Symbol.iterator](); },
+    forEach(
+      callback: (value: Value, key: Key, map: ReadonlyMap<Key, Value>) => void,
+      thisArg?: unknown,
+    ) {
+      snapshot.forEach((value, key) => callback.call(thisArg, value, key, view));
+    },
+  });
+  return view;
+}
+
+function jsonSnapshot<Value>(value: Value): Value {
+  return deepFreezeCanonicalJson(
+    structuredClone(value) as unknown as JsonValue,
+  ) as unknown as Value;
+}
+
+function preflightSnapshot(
+  declarations: readonly OmkRuntimePreflightDeclaration[],
+): readonly OmkRuntimePreflightDeclaration[] {
+  return Object.freeze(declarations.map((declaration) => Object.freeze({ ...declaration })));
+}
+
+function snapshotConfiguration(
+  configuration: ProductionExecutorAdapterConfiguration,
+): ProductionExecutorAdapterConfiguration {
+  const preflightDeclarations = preflightSnapshot(configuration.preflightDeclarations);
+  switch (configuration.adapterKind) {
+    case 'codex-cli':
+    case 'claude-cli':
+      return Object.freeze({
+        adapterKind: configuration.adapterKind,
+        preflightDeclarations,
+        command: Object.freeze({
+          ...configuration.command,
+          ...(configuration.command.environment === undefined ? {} : {
+            environment: jsonSnapshot(configuration.command.environment),
+          }),
+          ...(configuration.command.contentIdentityFiles === undefined ? {} : {
+            contentIdentityFiles: jsonSnapshot(configuration.command.contentIdentityFiles),
+          }),
+        }),
+      }) as ProductionExecutorAdapterConfiguration;
+    case 'codex-sdk':
+    case 'claude-sdk':
+      return Object.freeze({
+        adapterKind: configuration.adapterKind,
+        preflightDeclarations,
+        ...(configuration.sdk === undefined ? {} : {
+          sdk: Object.freeze({
+            ...configuration.sdk,
+            ...(configuration.sdk.environment === undefined ? {} : {
+              environment: jsonSnapshot(configuration.sdk.environment),
+            }),
+          }),
+        }),
+      }) as ProductionExecutorAdapterConfiguration;
+    case 'openai-api':
+    case 'anthropic-api':
+      return Object.freeze({
+        adapterKind: configuration.adapterKind,
+        preflightDeclarations,
+        api: Object.freeze({
+          ...configuration.api,
+          ...(configuration.api.transport === undefined ? {} : {
+            transport: captureCoreApiTransport(configuration.api.transport),
+          }),
+        }),
+      }) as ProductionExecutorAdapterConfiguration;
+    case 'custom-command':
+      return Object.freeze({
+        adapterKind: configuration.adapterKind,
+        preflightDeclarations,
+        runtime: Object.freeze({
+          ...configuration.runtime,
+          capabilities: jsonSnapshot(configuration.runtime.capabilities),
+          ...(configuration.runtime.contentIdentityFiles === undefined ? {} : {
+            contentIdentityFiles: jsonSnapshot(configuration.runtime.contentIdentityFiles),
+          }),
+        }),
+        command: Object.freeze({
+          ...configuration.command,
+          ...(configuration.command.arguments === undefined ? {} : {
+            arguments: Object.freeze([...configuration.command.arguments]),
+          }),
+          ...(configuration.command.environment === undefined ? {} : {
+            environment: jsonSnapshot(configuration.command.environment),
+          }),
+          workingDirectory: jsonSnapshot(configuration.command.workingDirectory),
+        }),
+      });
+  }
+}
+
+function executorFactory(
+  implementationId: string,
+  configuration: ProductionExecutorAdapterConfiguration,
+): (context: Readonly<OmkExecutorBindingContext>) => Promise<
+  OmkRuntimePortBinding<ExecutionExecutor>
+> {
+  return async (context) => {
+    if (context.binding.implementationId !== implementationId) fail({
+      code: 'PRODUCTION_RUNTIME_REGISTRY_INVALID',
+      implementationId,
+      message: 'Executor factory 收到与注册键不一致的 binding。',
+    });
+    const common = {
+      target: context.target,
+      binding: context.binding,
+      sessionIsolationKey: context.sessionIsolationKey,
+      resourceLeases: context.resourceLeases,
+    };
+    let port: ExecutionExecutor;
+    switch (configuration.adapterKind) {
+      case 'codex-cli':
+        port = await createCodexCliExecutorAdapter({ ...common, command: configuration.command });
+        break;
+      case 'codex-sdk':
+        port = await createCodexSdkExecutorAdapter({ ...common, sdk: configuration.sdk });
+        break;
+      case 'claude-cli':
+        port = await createClaudeCliExecutorAdapter({ ...common, command: configuration.command });
+        break;
+      case 'claude-sdk':
+        port = await createClaudeSdkExecutorAdapter({ ...common, sdk: configuration.sdk });
+        break;
+      case 'openai-api':
+        port = await createOpenAIApiExecutorAdapter({ ...common, api: configuration.api });
+        break;
+      case 'anthropic-api':
+        port = await createAnthropicApiExecutorAdapter({ ...common, api: configuration.api });
+        break;
+      case 'custom-command':
+        if (configuration.runtime.implementationId !== implementationId) fail({
+          code: 'PRODUCTION_RUNTIME_REGISTRY_INVALID',
+          implementationId,
+          message: 'Custom command Runtime identity 与注册键不一致。',
+        });
+        port = await createCustomCommandExecutorAdapter({
+          runtime: configuration.runtime,
+          command: configuration.command,
+          sessionIsolationKey: context.sessionIsolationKey,
+          resourceLeases: context.resourceLeases,
+        });
+        break;
+    }
+    return {
+      port,
+      // Production inputs currently declare exact implementation IDs but no version range.
+      // Until a version-constraint resolver is explicit, any supplied constraint fails closed.
+      satisfiesVersionConstraint: context.binding.versionConstraint === undefined,
+      preflightDeclarations: configuration.preflightDeclarations,
+    };
+  };
+}
+
+/** Creates the only production registry without touching unused Runtime configuration. */
+export function createProductionRuntimeFactoryRegistry(
+  input: Readonly<CreateProductionRuntimeFactoryRegistryInput>,
+): OmkRuntimeBindingFactories {
+  let executorEntries: readonly [string, ProductionExecutorAdapterConfiguration][];
+  try {
+    executorEntries = [...input.executorsByImplementationId.entries()];
+  } catch (cause) {
+    return fail({
+      code: 'PRODUCTION_RUNTIME_REGISTRY_INVALID',
+      message: 'Executor registry 必须是可迭代的 ReadonlyMap。',
+      cause,
+    });
+  }
+  const executorsByImplementationId = new Map<string, ReturnType<typeof executorFactory>>();
+  for (const [implementationId, configuration] of executorEntries) {
+    if (typeof implementationId !== 'string' || implementationId.trim() === '') fail({
+      code: 'PRODUCTION_RUNTIME_REGISTRY_INVALID',
+      message: 'Executor implementationId 必须是非空字符串。',
+    });
+    let captured: ProductionExecutorAdapterConfiguration;
+    try {
+      if (configuration.adapterKind === 'custom-command'
+          && configuration.runtime.implementationId !== implementationId) fail({
+        code: 'PRODUCTION_RUNTIME_REGISTRY_INVALID',
+        implementationId,
+        message: 'Custom command Runtime identity 与注册键不一致。',
+      });
+      captured = snapshotConfiguration(configuration);
+    } catch (cause) {
+      if (cause instanceof ProductionRuntimeRegistryError) throw cause;
+      fail({
+        code: 'PRODUCTION_RUNTIME_REGISTRY_INVALID',
+        implementationId,
+        message: 'Executor registry configuration 无法安全捕获。',
+        cause,
+      });
+    }
+    executorsByImplementationId.set(
+      implementationId,
+      executorFactory(implementationId, captured),
+    );
+  }
+
+  const scoring = createBuiltinOmkScoringBindingFactories();
+  const evaluatorsByImplementationId = new Map(scoring.evaluatorsByImplementationId);
+  if (input.resolveJudgeInvocation !== undefined) {
+    evaluatorsByImplementationId.set(
+      LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID,
+      createLlmAssertionEvaluatorBindingFactory(input.resolveJudgeInvocation),
+    );
+    evaluatorsByImplementationId.set(
+      RUBRIC_JUDGE_EVALUATOR_IMPLEMENTATION_ID,
+      createRubricJudgeEvaluatorBindingFactory(input.resolveJudgeInvocation),
+    );
+  }
+  const analysis = createBuiltinOmkAnalysisBindingFactories();
+  return Object.freeze({
+    executorsByImplementationId: readonlyMapSnapshot(executorsByImplementationId),
+    evaluatorsByImplementationId: readonlyMapSnapshot(evaluatorsByImplementationId),
+    analysisNodesByImplementationId: readonlyMapSnapshot(
+      analysis.analysisNodesByImplementationId,
+    ),
+    missingPoliciesByImplementationId: readonlyMapSnapshot(
+      analysis.missingPoliciesByImplementationId,
+    ),
+    decisionPoliciesByImplementationId: readonlyMapSnapshot(
+      analysis.decisionPoliciesByImplementationId,
+    ),
+    seriesAnalysisNodesByImplementationId: readonlyMapSnapshot(new Map()),
+    seriesDecisionPoliciesByImplementationId: readonlyMapSnapshot(new Map()),
+  });
+}
+
+export function createNodeEvaluationClock(): EvaluationEngineClock {
+  return Object.freeze({
+    monotonicNow: () => performance.now(),
+    timestamp: () => new Date().toISOString(),
+    sleep(delayMs: number, signal: AbortSignal): Promise<void> {
+      if (!Number.isFinite(delayMs) || delayMs < 0) {
+        return Promise.reject(new TypeError('Clock delayMs 必须是有限非负数。'));
+      }
+      if (signal.aborted) return Promise.reject(signal.reason);
+      return new Promise((resolve, reject) => {
+        const abort = (): void => {
+          clearTimeout(timer);
+          reject(signal.reason);
+        };
+        const timer = setTimeout(() => {
+          signal.removeEventListener('abort', abort);
+          resolve();
+        }, delayMs);
+        signal.addEventListener('abort', abort, { once: true });
+      });
+    },
+  });
+}
+
+/** Node support ports share one digest-verifying content store instance. */
+export function createNodeEvaluationRuntimeSupportPorts(input: Readonly<{
+  readonly contentStoreRoot: string;
+  readonly clock?: EvaluationEngineClock;
+}>): OmkEvaluationRuntimeSupportPorts {
+  if (typeof input.contentStoreRoot !== 'string'
+      || input.contentStoreRoot.trim() === ''
+      || !isAbsolute(input.contentStoreRoot)) fail({
+    code: 'PRODUCTION_RUNTIME_REGISTRY_INVALID',
+    message: 'contentStoreRoot 必须是非空绝对路径。',
+  });
+  const contentStore = createNodeCoreContentStore(input.contentStoreRoot);
+  return Object.freeze({
+    clock: input.clock ?? createNodeEvaluationClock(),
+    executionContentStore: contentStore,
+    evaluationContentStore: contentStore,
+    contentResolver: contentStore,
+  });
+}

--- a/test/eval-workflows/production-host/runtime-registry.test.ts
+++ b/test/eval-workflows/production-host/runtime-registry.test.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createNodeEvaluationClock,
+  createNodeEvaluationRuntimeSupportPorts,
+  createProductionRuntimeFactoryRegistry,
+  type ProductionExecutorAdapterConfiguration,
+} from '../../../src/eval-workflows/production-host/index.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function configurations(): ReadonlyMap<string, ProductionExecutorAdapterConfiguration> {
+  return new Map([
+    ['codex', {
+      adapterKind: 'codex-cli', command: { executablePath: '/not-probed/codex' },
+      preflightDeclarations: [],
+    }],
+    ['codex-sdk', { adapterKind: 'codex-sdk', sdk: {}, preflightDeclarations: [] }],
+    ['claude', {
+      adapterKind: 'claude-cli', command: { executablePath: '/not-probed/claude' },
+      preflightDeclarations: [],
+    }],
+    ['claude-sdk', { adapterKind: 'claude-sdk', sdk: {}, preflightDeclarations: [] }],
+    ['openai-api', {
+      adapterKind: 'openai-api', api: { apiKey: 'not-read-before-use' },
+      preflightDeclarations: [],
+    }],
+    ['anthropic-api', {
+      adapterKind: 'anthropic-api', api: { apiKey: 'not-read-before-use' },
+      preflightDeclarations: [],
+    }],
+    ['custom-tool', {
+      adapterKind: 'custom-command',
+      preflightDeclarations: [],
+      runtime: {
+        implementationId: 'custom-tool',
+        capabilities: {
+          schemaVersion: 'omk.executor-capabilities/v1',
+          protocols: [],
+        },
+      },
+      command: {
+        executablePath: '/not-probed/custom-tool',
+        workingDirectory: { workingDirectoryKind: 'ephemeral-run' },
+      },
+    }],
+  ] as readonly [string, ProductionExecutorAdapterConfiguration][]);
+}
+
+describe('production Runtime registry', () => {
+  it('registers every official adapter family lazily and composes single-owner builtins', () => {
+    const resolveJudgeInvocation = vi.fn();
+    const factories = createProductionRuntimeFactoryRegistry({
+      executorsByImplementationId: configurations(),
+      resolveJudgeInvocation,
+    });
+
+    expect([...factories.executorsByImplementationId.keys()]).toEqual([
+      'codex', 'codex-sdk', 'claude', 'claude-sdk',
+      'openai-api', 'anthropic-api', 'custom-tool',
+    ]);
+    expect(factories.evaluatorsByImplementationId.has('omk.assertions.output/v1')).toBe(true);
+    expect(factories.evaluatorsByImplementationId.has('omk.assertions.execution/v1')).toBe(true);
+    expect(factories.evaluatorsByImplementationId.has('omk.llm-assertions/v2')).toBe(true);
+    expect(factories.evaluatorsByImplementationId.has('omk.rubric-judge/v1')).toBe(true);
+    expect(factories.analysisNodesByImplementationId.has('omk.bootstrap-family-table/v1')).toBe(true);
+    expect(factories.decisionPoliciesByImplementationId.has('omk.release-decision/v1')).toBe(true);
+    expect(resolveJudgeInvocation).not.toHaveBeenCalled();
+  });
+
+  it('does not register or resolve unused provider-backed judges', () => {
+    const factories = createProductionRuntimeFactoryRegistry({
+      executorsByImplementationId: new Map([
+        ['codex', {
+          adapterKind: 'codex-cli', command: { executablePath: '/not-probed/codex' },
+          preflightDeclarations: [],
+        }],
+      ]),
+    });
+    expect(factories.evaluatorsByImplementationId.has('omk.llm-assertions/v2')).toBe(false);
+    expect(factories.evaluatorsByImplementationId.has('omk.rubric-judge/v1')).toBe(false);
+  });
+
+  it('captures immutable registry membership before any lazy factory is used', () => {
+    const source = new Map(configurations());
+    const factories = createProductionRuntimeFactoryRegistry({
+      executorsByImplementationId: source,
+    });
+    source.set('late-executor', {
+      adapterKind: 'codex-cli',
+      command: { executablePath: '/not-probed/late' },
+      preflightDeclarations: [],
+    });
+
+    expect(factories.executorsByImplementationId.has('late-executor')).toBe(false);
+    expect((factories.executorsByImplementationId as Map<string, unknown>).set).toBeUndefined();
+  });
+
+  it('rejects invalid registry configuration with a stable host error', () => {
+    expect(() => createProductionRuntimeFactoryRegistry({
+      executorsByImplementationId: new Map([[42, undefined]]) as unknown as ReadonlyMap<
+        string,
+        ProductionExecutorAdapterConfiguration
+      >,
+    })).toThrow(expect.objectContaining({ code: 'PRODUCTION_RUNTIME_REGISTRY_INVALID' }));
+  });
+
+  it('provides abort-aware Node clock and one shared content port', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omk-production-support-'));
+    roots.push(root);
+    const clock = createNodeEvaluationClock();
+    const abort = new AbortController();
+    abort.abort(new Error('cancelled'));
+    await expect(clock.sleep(1, abort.signal)).rejects.toThrow('cancelled');
+
+    const support = createNodeEvaluationRuntimeSupportPorts({
+      contentStoreRoot: join(root, 'content'),
+      clock,
+    });
+    expect(support.clock).toBe(clock);
+    expect(support.executionContentStore).toBe(support.evaluationContentStore);
+    expect(support.evaluationContentStore).toBe(support.contentResolver);
+  });
+
+  it('rejects a content store path that depends on ambient cwd', () => {
+    expect(() => createNodeEvaluationRuntimeSupportPorts({
+      contentStoreRoot: 'relative/content',
+    })).toThrow(expect.objectContaining({ code: 'PRODUCTION_RUNTIME_REGISTRY_INVALID' }));
+  });
+});


### PR DESCRIPTION
Refs #539、#450。

Depends on #543。

## 用户影响

新增 Evaluation Core 唯一的生产 Runtime factory registry 与 Node support ports，覆盖 Codex CLI／SDK、Claude CLI／SDK、OpenAI API、Anthropic API、custom command，以及 OMK 自有 scoring／analysis／missing／decision 实现。正式 `omk eval` 仍未接线，当前用户执行路径不变。

## 架构边界

Registry 只按 exact `implementationId` 提供 lazy factory；未使用的 executor／judge 不解析凭证、不探测二进制、不运行 preflight。Host 必须显式提供 preflight declaration，registry 不虚构 doctor、credential、connectivity、filesystem、MCP 或 mock 检查成功。配置在注册时快照，map 以只读 facade 暴露，后续调用方 mutation 不会改变解析结果。

## 迁移说明

生产输入当前不声明 Runtime version range；若未来 binding 带显式 `versionConstraint`，在引入明确版本解析器前会 fail closed，不会无条件报告满足。Node content store 要求绝对路径，避免依赖 ambient cwd。未知 implementation 继续由现有 assembly 以稳定错误拒绝。

## 测量学说明

内置 Evaluator／Analysis／Decision 直接复用现有单一实现，不复制算法或 prompt。LLM／rubric factory 只在宿主提供 judge invocation resolver 时注册；未修改冻结 prompt、五层评分、统计公式、missing policy 或 length-debias 语义。