### PR TITLE
refactor(eval): 建立 Evaluation Core 生产宿主工作流

### DIFF
--- a/src/eval-workflows/input-compilation/compile.ts
+++ b/src/eval-workflows/input-compilation/compile.ts
@@ -908,7 +908,7 @@ function compileSeries(
     measurementDesignDigest: designDigest,
     repeatCount: series.repeatCount,
     comparisonScope: series.comparisonScope ?? 'analysis',
-    minimumStatus: series.minimumStatus ?? 'compatible',
+    minimumStatus: series.minimumStatus ?? 'conditional',
   });
   const seriesId = `${series.seriesInstanceId}-${seriesDesignIdentity.slice(
     'sha256:'.length,
@@ -928,7 +928,7 @@ function compileSeries(
       comparabilityPolicy: {
         designMode: 'exact-measurement-design',
         comparisonScope: series.comparisonScope ?? 'analysis',
-        minimumStatus: series.minimumStatus ?? 'compatible',
+        minimumStatus: series.minimumStatus ?? 'conditional',
       },
       analysisGraph: {
         nodes: [{

--- a/src/eval-workflows/production-host/index.ts
+++ b/src/eval-workflows/production-host/index.ts
@@ -1,3 +1,5 @@
 export * from './measurement-design.js';
 export * from './node-cli-evaluation-resolver.js';
+export * from './orchestration.js';
 export * from './runtime-registry.js';
+export * from './workflow.js';

--- a/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
+++ b/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
@@ -631,7 +631,7 @@ export async function resolveNodeCliEvaluationRequest(
           repeatCount,
           seriesInstanceId: options.seriesInstanceId!,
           comparisonScope: 'decision',
-          minimumStatus: 'compatible',
+          minimumStatus: 'conditional',
         },
       }),
     },

--- a/src/eval-workflows/production-host/orchestration.ts
+++ b/src/eval-workflows/production-host/orchestration.ts
@@ -1,0 +1,443 @@
+import {
+  canonicalizeJson,
+  createEvaluationSeriesMemberSource,
+  deepFreezeCanonicalJson,
+  digestCanonicalJson,
+  effectiveAnalysisBundleTrust,
+  effectiveEvaluationBundleTrust,
+  effectiveExecutionBundleTrust,
+  prepareEvaluationSeriesPlan,
+  verifyAnalysisBundle,
+  verifyDecisionResult,
+  verifyEvaluationBundle,
+  verifyExecutionBundle,
+  IdentifierSchema,
+  TimestampSchema,
+  type CoreSchemaValidator,
+  type EvaluationSeriesMembership,
+  type EvaluationSeriesPlan,
+  type JsonValue,
+  type Sha256Digest,
+} from '../../evaluation-core/contracts/index.js';
+import type { SealedRunPlan } from '../../evaluation-core/compiler/index.js';
+import {
+  runEvaluationSeries,
+  type EvaluationSeriesRunResult,
+} from '../../evaluation-core/series/index.js';
+import {
+  type CoreBatchArtifactStore,
+  type StoredCoreBatch,
+  type StoredCoreRunArtifacts,
+} from '../artifact-store/index.js';
+import type { CoreResumeVerificationContexts } from '../resume-admission/index.js';
+import {
+  createOmkEvaluationRuntime,
+  createOmkEvaluationSchemaValidators,
+  type OmkEvaluationPreflightOptions,
+  type OmkEvaluationRuntime,
+} from '../runtime-adapter/index.js';
+import {
+  projectCoreEvolutionEvidence,
+  type CoreEvolutionEvidence,
+} from '../downstream-projections/index.js';
+import {
+  bindProductionPreparedEvaluation,
+  ProductionEvaluationHostError,
+  type ProductionEvaluationExecuteOptions,
+  type ProductionEvaluationHostInput,
+  type ProductionEvaluationRun,
+  type ProductionPreparedEvaluation,
+} from './workflow.js';
+
+export interface ProductionBatchChildInput {
+  readonly itemId: string;
+  readonly prepared: ProductionPreparedEvaluation;
+  readonly options: ProductionEvaluationExecuteOptions;
+}
+
+export type ProductionBatchPersistence = {
+  readonly persistenceStatus: 'stored';
+  readonly batch: StoredCoreBatch;
+} | {
+  readonly persistenceStatus: 'skipped';
+  readonly reasonCode: 'BATCH_CHILD_ARTIFACTS_INCOMPLETE';
+  readonly childRunIds: readonly string[];
+} | {
+  readonly persistenceStatus: 'failed';
+  readonly error: ProductionEvaluationHostError;
+};
+
+export interface ProductionBatchRun {
+  readonly batchId: string;
+  readonly children: readonly ({
+    readonly itemId: string;
+    readonly runId: string;
+    readonly executionStatus: 'started';
+    readonly run: ProductionEvaluationRun;
+  } | {
+    readonly itemId: string;
+    readonly runId: string;
+    readonly executionStatus: 'start-failed';
+    readonly error: ProductionEvaluationHostError;
+  })[];
+  /** Resolves only after every child publication settles; no Core batch report is created. */
+  readonly persistence: Promise<ProductionBatchPersistence>;
+}
+
+function validUniqueBatchChildren(children: readonly ProductionBatchChildInput[]): boolean {
+  return children.length > 0
+    && children.every(({ itemId, options }) => (
+      IdentifierSchema.safeParse(itemId).success
+      && IdentifierSchema.safeParse(options.runId).success
+      && TimestampSchema.safeParse(options.createdAt).success
+    ))
+    && new Set(children.map(({ itemId }) => itemId)).size === children.length
+    && new Set(children.map(({ options }) => options.runId)).size === children.length;
+}
+
+/** Executes independent child runs and publishes only a locator-only Batch manifest. */
+export async function executeProductionEvaluationBatch(input: Readonly<{
+  batchId: string;
+  createdAt: string;
+  children: readonly ProductionBatchChildInput[];
+  batchStore: CoreBatchArtifactStore;
+}>): Promise<ProductionBatchRun> {
+  if (!IdentifierSchema.safeParse(input.batchId).success
+      || !TimestampSchema.safeParse(input.createdAt).success
+      || !validUniqueBatchChildren(input.children)
+      || input.batchStore === null
+      || typeof input.batchStore !== 'object'
+      || typeof input.batchStore.save !== 'function') {
+    throw new ProductionEvaluationHostError({
+      code: 'PRODUCTION_EVALUATION_HOST_INPUT_INVALID',
+      fieldPath: 'batch',
+      message: 'Batch child identity 或 artifact store 不合法。',
+    });
+  }
+  const saveBatch = input.batchStore.save.bind(input.batchStore);
+  const children = await Promise.all(input.children.map(async (child) => {
+    try {
+      return Object.freeze({
+        itemId: child.itemId,
+        runId: child.options.runId,
+        executionStatus: 'started' as const,
+        run: await child.prepared.execute(child.options),
+      });
+    } catch (cause) {
+      return Object.freeze({
+        itemId: child.itemId,
+        runId: child.options.runId,
+        executionStatus: 'start-failed' as const,
+        error: new ProductionEvaluationHostError({
+          code: 'PRODUCTION_EVALUATION_BATCH_CHILD_START_FAILED',
+          runId: child.options.runId,
+          message: 'Evaluation Core Batch child 启动失败。',
+          cause,
+        }),
+      });
+    }
+  }));
+  const persistence = Promise.all(children.map(async (child) => ({
+    runId: child.runId,
+    outcome: child.executionStatus === 'started'
+      ? await child.run.persistence
+      : undefined,
+  }))).then(async (outcomes): Promise<ProductionBatchPersistence> => {
+    const incomplete = outcomes.filter(({ outcome }) => (
+      outcome?.persistenceStatus !== 'stored'
+    )).map(({ runId }) => runId);
+    if (incomplete.length > 0) return Object.freeze({
+      persistenceStatus: 'skipped',
+      reasonCode: 'BATCH_CHILD_ARTIFACTS_INCOMPLETE',
+      childRunIds: Object.freeze(incomplete),
+    });
+    try {
+      const batch = await saveBatch({
+        batchId: input.batchId,
+        createdAt: input.createdAt,
+        children: children.map(({ itemId, runId }) => ({ itemId, runId })),
+      });
+      return Object.freeze({ persistenceStatus: 'stored', batch });
+    } catch (cause) {
+      return Object.freeze({
+        persistenceStatus: 'failed',
+        error: new ProductionEvaluationHostError({
+          code: 'PRODUCTION_EVALUATION_BATCH_PERSIST_FAILED',
+          message: 'Evaluation Core Batch manifest 原子持久化失败。',
+          cause,
+        }),
+      });
+    }
+  });
+  return Object.freeze({
+    batchId: input.batchId,
+    children: Object.freeze(children),
+    persistence,
+  });
+}
+
+export interface ProductionSeriesMemberOptions extends ProductionEvaluationExecuteOptions {
+  /** Optional independent cache／budget attestations for persisted evidence. */
+  readonly verification?: CoreResumeVerificationContexts;
+}
+
+export interface ProductionEvaluationSeriesRun {
+  readonly plan: EvaluationSeriesPlan;
+  readonly members: readonly ({
+    readonly membership: EvaluationSeriesMembership;
+    readonly prepared: ProductionPreparedEvaluation;
+    readonly executionStatus: 'started';
+    readonly run: ProductionEvaluationRun;
+  } | {
+    readonly membership: EvaluationSeriesMembership;
+    readonly prepared: ProductionPreparedEvaluation;
+    readonly executionStatus: 'start-failed';
+    readonly error: ProductionEvaluationHostError;
+  })[];
+  readonly result: Promise<EvaluationSeriesRunResult>;
+  readonly evolution: Promise<CoreEvolutionEvidence>;
+}
+
+function memberCompiled(
+  input: ProductionEvaluationHostInput['compiled'],
+  membership: EvaluationSeriesMembership,
+): ProductionEvaluationHostInput['compiled'] {
+  const snapshot = structuredClone(input);
+  const definition = { ...snapshot.definition, seriesMembership: membership };
+  return deepFreezeCanonicalJson(
+    {
+      ...snapshot,
+      definition,
+      canonicalDigests: {
+        ...snapshot.canonicalDigests,
+        definition: digestCanonicalJson(definition),
+      },
+    } as unknown as JsonValue,
+  ) as unknown as ProductionEvaluationHostInput['compiled'];
+}
+
+function attestationSet(
+  digest: Sha256Digest,
+  supplied: ReadonlySet<Sha256Digest> | undefined,
+): ReadonlySet<Sha256Digest> {
+  return new Set([...(supplied ?? []), digest]);
+}
+
+function seriesMemberSource(input: {
+  membership: EvaluationSeriesMembership;
+  plan: SealedRunPlan;
+  artifacts: StoredCoreRunArtifacts;
+  validators: ReadonlyMap<string, CoreSchemaValidator>;
+  verification?: CoreResumeVerificationContexts;
+}) {
+  const { artifacts, verification } = input;
+  const execution = verifyExecutionBundle(artifacts.execution, input.plan, {
+    ...verification?.execution,
+    verifiedProvenanceBundleDigests: attestationSet(
+      artifacts.execution.bundleDigest as Sha256Digest,
+      verification?.execution?.verifiedProvenanceBundleDigests,
+    ),
+  });
+  const evaluation = verifyEvaluationBundle(
+    artifacts.evaluation,
+    input.plan,
+    execution,
+    {
+      ...verification?.evaluation,
+      verifiedProvenanceBundleDigests: attestationSet(
+        artifacts.evaluation.bundleDigest as Sha256Digest,
+        verification?.evaluation?.verifiedProvenanceBundleDigests,
+      ),
+      executionSourceTrust: verification?.evaluation?.executionSourceTrust
+        ?? effectiveExecutionBundleTrust(execution),
+    },
+  );
+  const analysis = verifyAnalysisBundle(
+    artifacts.analysis,
+    input.plan,
+    execution,
+    evaluation,
+    { schemaValidators: input.validators },
+    {
+      ...verification?.analysis,
+      verifiedProvenanceBundleDigests: attestationSet(
+        artifacts.analysis.bundleDigest as Sha256Digest,
+        verification?.analysis?.verifiedProvenanceBundleDigests,
+      ),
+      evaluationSourceTrust: verification?.analysis?.evaluationSourceTrust
+        ?? effectiveEvaluationBundleTrust(evaluation),
+    },
+  );
+  const decision = artifacts.report.decision === undefined
+    ? undefined
+    : verifyDecisionResult(
+      artifacts.report.decision,
+      input.plan,
+      execution,
+      evaluation,
+      analysis,
+      {
+        ...verification?.decision,
+        verifiedPolicyExecutionDigests: attestationSet(
+          artifacts.report.decision.decisionDigest as Sha256Digest,
+          verification?.decision?.verifiedPolicyExecutionDigests,
+        ),
+        analysisSourceTrust: verification?.decision?.analysisSourceTrust
+          ?? effectiveAnalysisBundleTrust(analysis),
+      },
+    );
+  return createEvaluationSeriesMemberSource({
+    ...input.membership,
+    plan: input.plan,
+    execution,
+    evaluation,
+    analysis,
+    ...(decision === undefined ? {} : { decision }),
+    report: artifacts.report,
+  });
+}
+
+async function prepareSeriesMember(input: {
+  host: ProductionEvaluationHostInput;
+  membership: EvaluationSeriesMembership;
+  preflight?: Readonly<OmkEvaluationPreflightOptions>;
+  validators: ReadonlyMap<string, CoreSchemaValidator>;
+}): Promise<{
+  runtime: OmkEvaluationRuntime;
+  prepared: ProductionPreparedEvaluation;
+}> {
+  const createRuntime = input.host.createRuntime ?? createOmkEvaluationRuntime;
+  const runtime = await createRuntime({
+    compiled: memberCompiled(input.host.compiled, input.membership),
+    factories: input.host.factories,
+    support: input.host.support,
+    resources: input.host.resources,
+  });
+  const platformPrepared = await runtime.prepare(input.preflight);
+  return {
+    runtime,
+    prepared: bindProductionPreparedEvaluation({
+      prepared: platformPrepared,
+      artifactStore: input.host.artifactStore,
+      schemaValidators: input.validators,
+    }),
+  };
+}
+
+/** Runs preregistered independent repeats as run-level Series members. */
+export async function executeProductionEvaluationSeries(input: Readonly<{
+  host: ProductionEvaluationHostInput;
+  members: readonly ProductionSeriesMemberOptions[];
+  bundleId: string;
+  reportId: string;
+  preflight?: Readonly<OmkEvaluationPreflightOptions>;
+}>): Promise<ProductionEvaluationSeriesRun> {
+  const series = input.host.compiled.orchestration.independentSeries;
+  if (series === undefined
+      || input.host.compiled.orchestration.dryRun
+      || input.members.length !== series.memberships.length
+      || new Set(input.members.map(({ runId }) => runId)).size !== input.members.length
+      || !IdentifierSchema.safeParse(input.bundleId).success
+      || !IdentifierSchema.safeParse(input.reportId).success
+      || input.members.some(({ runId, createdAt }) => (
+        !IdentifierSchema.safeParse(runId).success
+        || !TimestampSchema.safeParse(createdAt).success
+      ))) {
+    throw new ProductionEvaluationHostError({
+      code: 'PRODUCTION_EVALUATION_HOST_INPUT_INVALID',
+      fieldPath: 'series.members',
+      message: 'Independent Series member options 与预注册 slot 不一致。',
+    });
+  }
+  const validators = createOmkEvaluationSchemaValidators(
+    input.host.support.schemaValidators,
+  );
+  const preparedMembers = await Promise.all(series.memberships.map(async (membership) => (
+    prepareSeriesMember({
+      host: input.host,
+      membership,
+      validators,
+      ...(input.preflight === undefined ? {} : { preflight: input.preflight }),
+    })
+  )));
+  const seriesAssembly = preparedMembers[0]?.runtime.series;
+  if (seriesAssembly === undefined
+      || preparedMembers.some(({ runtime }) => runtime.series === undefined
+        || canonicalizeJson(runtime.series.runtimes)
+          !== canonicalizeJson(seriesAssembly.runtimes))) {
+    throw new ProductionEvaluationHostError({
+      code: 'PRODUCTION_EVALUATION_SERIES_SOURCE_INVALID',
+      message: 'Independent Series Runtime binding 缺失或跨 member 不一致。',
+    });
+  }
+  const plan = prepareEvaluationSeriesPlan(series.definition, seriesAssembly.runtimes);
+  const members = await Promise.all(preparedMembers.map(async ({ prepared }, index) => {
+    const membership = series.memberships[index]!;
+    try {
+      return Object.freeze({
+        membership,
+        prepared,
+        executionStatus: 'started' as const,
+        run: await prepared.execute(input.members[index]!),
+      });
+    } catch (cause) {
+      return Object.freeze({
+        membership,
+        prepared,
+        executionStatus: 'start-failed' as const,
+        error: new ProductionEvaluationHostError({
+          code: 'PRODUCTION_EVALUATION_SERIES_MEMBER_START_FAILED',
+          runId: input.members[index]!.runId,
+          message: 'Independent Series member 启动失败。',
+          cause,
+        }),
+      });
+    }
+  }));
+  const result = Promise.all(members.map(async (member, index) => ({
+    membership: member.membership,
+    plan: member.prepared.plan,
+    verification: input.members[index]?.verification,
+    persistence: member.executionStatus === 'started'
+      ? await member.run.persistence
+      : undefined,
+  }))).then(async (outcomes) => {
+    const sources = outcomes.flatMap(({ membership, plan: memberPlan, persistence, verification }) => {
+      if (persistence?.persistenceStatus !== 'stored') return [];
+      try {
+        return [seriesMemberSource({
+          membership,
+          plan: memberPlan,
+          artifacts: persistence.artifacts,
+          validators,
+          ...(verification === undefined ? {} : { verification }),
+        })];
+      } catch (cause) {
+        throw new ProductionEvaluationHostError({
+          code: 'PRODUCTION_EVALUATION_SERIES_SOURCE_INVALID',
+          runId: persistence.artifacts.manifest.runId,
+          message: 'Persisted Core run 无法验证为 Series member source。',
+          cause,
+        });
+      }
+    });
+    return runEvaluationSeries(plan, sources, {
+      ...seriesAssembly.ports,
+      schemaValidators: validators,
+    }, { bundleId: input.bundleId, reportId: input.reportId });
+  });
+  const evolution = result.then((seriesResult) => projectCoreEvolutionEvidence({
+    plan,
+    analysis: seriesResult.analysis,
+    report: seriesResult.report,
+  }));
+  return Object.freeze({
+    plan,
+    members: Object.freeze(members),
+    result,
+    evolution,
+  });
+}
+
+/** Exact delegates for post-persistence consumers; no legacy row interpretation. */
+export { compareGoldToCoreRun, projectCoreArtifactGraph } from '../downstream-projections/index.js';

--- a/src/eval-workflows/production-host/workflow.ts
+++ b/src/eval-workflows/production-host/workflow.ts
@@ -1,0 +1,339 @@
+import {
+  TimestampSchema,
+  type CoreSchemaValidator,
+} from '../../evaluation-core/contracts/index.js';
+import {
+  assertSealedRunPlan,
+  type SealedRunPlan,
+} from '../../evaluation-core/compiler/index.js';
+import type {
+  EvaluationRun,
+  EvaluationRunResult,
+} from '../../evaluation-core/engine/index.js';
+import type { CliEvaluationCompileResult } from '../input-compilation/index.js';
+import {
+  type CoreRunArtifactStore,
+  type SaveCoreRunArtifactsRequest,
+  type StoredCoreRunArtifacts,
+} from '../artifact-store/index.js';
+import {
+  createCoreResumeAdmissionAdapter,
+  type CoreResumeAdmissionRequest,
+  type CoreResumeAdmissionResult,
+} from '../resume-admission/index.js';
+import {
+  createOmkEvaluationRuntime,
+  createOmkEvaluationSchemaValidators,
+  type CreateOmkEvaluationRuntimeInput,
+  type OmkEvaluationPreflightOptions,
+  type OmkEvaluationPreflightResult,
+  type OmkEvaluationRunOptions,
+  type OmkEvaluationRuntime,
+  type OmkRuntimeBindingFactories,
+} from '../runtime-adapter/index.js';
+
+type RuntimeFactory = (
+  input: Readonly<CreateOmkEvaluationRuntimeInput>,
+) => Promise<OmkEvaluationRuntime>;
+
+type PersistableArtifacts = Pick<
+  SaveCoreRunArtifactsRequest,
+  'execution' | 'evaluation' | 'analysis' | 'report'
+>;
+
+export interface ProductionEvaluationHostInput {
+  readonly compiled: CliEvaluationCompileResult;
+  readonly factories: OmkRuntimeBindingFactories;
+  readonly support: CreateOmkEvaluationRuntimeInput['support'];
+  readonly resources: CreateOmkEvaluationRuntimeInput['resources'];
+  readonly artifactStore: CoreRunArtifactStore;
+  /** Alternate platform composition seam; production defaults to the OMK Runtime. */
+  readonly createRuntime?: RuntimeFactory;
+}
+
+export interface ProductionEvaluationExecuteOptions extends OmkEvaluationRunOptions {
+  /** Caller-owned publication timestamp; never derived inside Core. */
+  readonly createdAt: string;
+}
+
+export type ProductionArtifactPersistence = {
+  readonly persistenceStatus: 'stored';
+  readonly artifacts: StoredCoreRunArtifacts;
+} | {
+  readonly persistenceStatus: 'skipped';
+  readonly reasonCode:
+    | 'CORE_RESULT_INCOMPLETE'
+    | 'CORE_RESULT_UNAVAILABLE';
+} | {
+  readonly persistenceStatus: 'failed';
+  readonly error: ProductionEvaluationHostError;
+};
+
+export interface ProductionEvaluationRun {
+  /** Lossy, bounded observability stream; consumption is never authoritative. */
+  readonly events: EvaluationRun['events'];
+  /** The exact Core promise and result, without status or score rewriting. */
+  readonly result: Promise<EvaluationRunResult>;
+  /** Non-throwing publication outcome, evaluated independently from Core status. */
+  readonly persistence: Promise<ProductionArtifactPersistence>;
+}
+
+export interface ProductionPreparedEvaluation {
+  readonly executionMode: 'dry-run' | 'execute';
+  readonly plan: SealedRunPlan;
+  readonly preflight: OmkEvaluationPreflightResult;
+  execute(
+    options: Readonly<ProductionEvaluationExecuteOptions>,
+  ): Promise<ProductionEvaluationRun>;
+  admitResume(
+    request: Readonly<Omit<CoreResumeAdmissionRequest, 'plan'>>,
+  ): Promise<CoreResumeAdmissionResult>;
+}
+
+export interface ProductionEvaluationHost {
+  prepare(
+    options?: Readonly<OmkEvaluationPreflightOptions>,
+  ): Promise<ProductionPreparedEvaluation>;
+}
+
+export type ProductionEvaluationHostErrorCode =
+  | 'PRODUCTION_EVALUATION_HOST_INPUT_INVALID'
+  | 'PRODUCTION_EVALUATION_DRY_RUN_EXECUTION_FORBIDDEN'
+  | 'PRODUCTION_EVALUATION_ARTIFACT_PERSIST_FAILED'
+  | 'PRODUCTION_EVALUATION_BATCH_PERSIST_FAILED'
+  | 'PRODUCTION_EVALUATION_BATCH_CHILD_START_FAILED'
+  | 'PRODUCTION_EVALUATION_SERIES_MEMBER_START_FAILED'
+  | 'PRODUCTION_EVALUATION_SERIES_SOURCE_INVALID';
+
+export class ProductionEvaluationHostError extends Error {
+  readonly code: ProductionEvaluationHostErrorCode;
+  readonly fieldPath?: string;
+  readonly runId?: string;
+
+  constructor(input: {
+    code: ProductionEvaluationHostErrorCode;
+    message: string;
+    fieldPath?: string;
+    runId?: string;
+    cause?: unknown;
+  }) {
+    super(input.message, { cause: input.cause });
+    this.name = 'ProductionEvaluationHostError';
+    this.code = input.code;
+    this.fieldPath = input.fieldPath;
+    this.runId = input.runId;
+  }
+}
+
+function fail(
+  input: ConstructorParameters<typeof ProductionEvaluationHostError>[0],
+): never {
+  throw new ProductionEvaluationHostError(input);
+}
+
+function captureArtifactStore(store: CoreRunArtifactStore): CoreRunArtifactStore {
+  if (store === null || typeof store !== 'object'
+      || typeof store.save !== 'function'
+      || typeof store.get !== 'function'
+      || typeof store.inspect !== 'function'
+      || typeof store.list !== 'function'
+      || typeof store.exists !== 'function') fail({
+    code: 'PRODUCTION_EVALUATION_HOST_INPUT_INVALID',
+    fieldPath: 'artifactStore',
+    message: 'Core artifact store 不符合生产宿主 contract。',
+  });
+  return Object.freeze({
+    save: store.save.bind(store),
+    get: store.get.bind(store),
+    inspect: store.inspect.bind(store),
+    list: store.list.bind(store),
+    exists: store.exists.bind(store),
+  });
+}
+
+function persistableArtifacts(
+  result: Readonly<EvaluationRunResult>,
+): PersistableArtifacts | undefined {
+  const artifacts = result.artifacts;
+  if (artifacts?.execution === undefined
+      || artifacts.evaluation === undefined
+      || artifacts.analysis === undefined
+      || result.report === undefined) return undefined;
+  return {
+    execution: artifacts.execution,
+    evaluation: artifacts.evaluation,
+    analysis: artifacts.analysis,
+    report: result.report,
+  };
+}
+
+async function persistResult(input: {
+  readonly store: CoreRunArtifactStore;
+  readonly plan: SealedRunPlan;
+  readonly runId: string;
+  readonly createdAt: string;
+  readonly result: Readonly<EvaluationRunResult>;
+}): Promise<ProductionArtifactPersistence> {
+  const artifacts = persistableArtifacts(input.result);
+  if (artifacts === undefined) return Object.freeze({
+    persistenceStatus: 'skipped',
+    reasonCode: 'CORE_RESULT_INCOMPLETE',
+  });
+  try {
+    const stored = await input.store.save({
+      runId: input.runId,
+      createdAt: input.createdAt,
+      plan: input.plan,
+      ...artifacts,
+    });
+    return Object.freeze({ persistenceStatus: 'stored', artifacts: stored });
+  } catch (cause) {
+    return Object.freeze({
+      persistenceStatus: 'failed',
+      error: new ProductionEvaluationHostError({
+        code: 'PRODUCTION_EVALUATION_ARTIFACT_PERSIST_FAILED',
+        runId: input.runId,
+        message: 'Evaluation Core 五件套原子持久化失败。',
+        cause,
+      }),
+    });
+  }
+}
+
+export interface BindProductionPreparedEvaluationInput {
+  readonly prepared: Awaited<ReturnType<OmkEvaluationRuntime['prepare']>>;
+  readonly artifactStore: CoreRunArtifactStore;
+  readonly schemaValidators: ReadonlyMap<string, CoreSchemaValidator>;
+  readonly executionMode?: 'dry-run' | 'execute';
+}
+
+/** Binds an already prepared platform Runtime to the production host policy. */
+export function bindProductionPreparedEvaluation(
+  input: Readonly<BindProductionPreparedEvaluationInput>,
+): ProductionPreparedEvaluation {
+  if (input.executionMode !== undefined
+      && input.executionMode !== 'dry-run'
+      && input.executionMode !== 'execute') fail({
+    code: 'PRODUCTION_EVALUATION_HOST_INPUT_INVALID',
+    fieldPath: 'executionMode',
+    message: 'Production preparation execution mode 不合法。',
+  });
+  try {
+    assertSealedRunPlan(input.prepared.plan);
+  } catch (cause) {
+    return fail({
+      code: 'PRODUCTION_EVALUATION_HOST_INPUT_INVALID',
+      fieldPath: 'prepared.plan',
+      message: 'Production preparation 缺少可信 sealed Plan。',
+      cause,
+    });
+  }
+  if (!Array.isArray(input.prepared.preflight?.records)
+      || typeof input.prepared.start !== 'function') fail({
+    code: 'PRODUCTION_EVALUATION_HOST_INPUT_INVALID',
+    fieldPath: 'prepared',
+    message: 'Prepared Runtime 不符合生产宿主 contract。',
+  });
+  const artifactStore = captureArtifactStore(input.artifactStore);
+  const plan = input.prepared.plan;
+  const preflight = Object.freeze({
+    records: Object.freeze(input.prepared.preflight.records.map((record) => (
+      Object.freeze({ ...record })
+    ))),
+  });
+  const start = input.prepared.start.bind(input.prepared);
+  let schemaValidators: ReadonlyMap<string, CoreSchemaValidator>;
+  try {
+    schemaValidators = new Map(input.schemaValidators);
+  } catch (cause) {
+    return fail({
+      code: 'PRODUCTION_EVALUATION_HOST_INPUT_INVALID',
+      fieldPath: 'schemaValidators',
+      message: 'Production SchemaValidator registry 无法建立快照。',
+      cause,
+    });
+  }
+  const admission = createCoreResumeAdmissionAdapter({
+    artifactStore,
+    schemaValidators,
+  });
+  return Object.freeze({
+    executionMode: input.executionMode ?? 'execute',
+    plan,
+    preflight,
+    async execute(
+      options: Readonly<ProductionEvaluationExecuteOptions>,
+    ): Promise<ProductionEvaluationRun> {
+      if (input.executionMode === 'dry-run') fail({
+        code: 'PRODUCTION_EVALUATION_DRY_RUN_EXECUTION_FORBIDDEN',
+        fieldPath: 'execute',
+        message: 'Dry-run preparation 只返回 sealed Plan 与 preflight，不允许启动 Runtime。',
+      });
+      if (!TimestampSchema.safeParse(options?.createdAt).success) fail({
+        code: 'PRODUCTION_EVALUATION_HOST_INPUT_INVALID',
+        fieldPath: 'execute.createdAt',
+        message: 'Core artifact publication timestamp 不合法。',
+      });
+      const { createdAt, ...runOptions } = options;
+      const coreRun = await start(runOptions);
+      const result = coreRun.result;
+      const persistence = result.then(
+        (value) => persistResult({
+          store: artifactStore,
+          plan,
+          runId: options.runId,
+          createdAt,
+          result: value,
+        }),
+        () => Object.freeze({
+          persistenceStatus: 'skipped' as const,
+          reasonCode: 'CORE_RESULT_UNAVAILABLE' as const,
+        }),
+      );
+      return Object.freeze({ events: coreRun.events, result, persistence });
+    },
+    admitResume(
+      request: Readonly<Omit<CoreResumeAdmissionRequest, 'plan'>>,
+    ): Promise<CoreResumeAdmissionResult> {
+      return admission.admit({ ...request, plan });
+    },
+  });
+}
+
+/**
+ * Creates the single production boundary around compile output, Runtime
+ * preparation, Core execution, resume admission, and atomic publication.
+ */
+export function createProductionEvaluationHost(
+  input: Readonly<ProductionEvaluationHostInput>,
+): ProductionEvaluationHost {
+  const artifactStore = captureArtifactStore(input.artifactStore);
+  const createRuntime = input.createRuntime ?? createOmkEvaluationRuntime;
+  if (typeof createRuntime !== 'function') fail({
+    code: 'PRODUCTION_EVALUATION_HOST_INPUT_INVALID',
+    fieldPath: 'createRuntime',
+    message: 'Evaluation Runtime factory 不合法。',
+  });
+  const schemaValidators = createOmkEvaluationSchemaValidators(
+    input.support?.schemaValidators,
+  );
+  return Object.freeze({
+    async prepare(
+      options?: Readonly<OmkEvaluationPreflightOptions>,
+    ): Promise<ProductionPreparedEvaluation> {
+      const runtime = await createRuntime({
+        compiled: input.compiled,
+        factories: input.factories,
+        support: input.support,
+        resources: input.resources,
+      });
+      const prepared = await runtime.prepare(options);
+      return bindProductionPreparedEvaluation({
+        prepared,
+        artifactStore,
+        schemaValidators,
+        executionMode: input.compiled.orchestration.dryRun ? 'dry-run' : 'execute',
+      });
+    },
+  });
+}

--- a/src/eval-workflows/runtime-adapter/composition.ts
+++ b/src/eval-workflows/runtime-adapter/composition.ts
@@ -331,7 +331,12 @@ function captureClock(clock: EvaluationEngineClock): EvaluationEngineClock {
   return capturePort(clock, ['monotonicNow', 'timestamp', 'sleep'], 'support.clock');
 }
 
-function captureSchemaValidators(
+/**
+ * Build the exact validator registry shared by execution, resume admission,
+ * and Series verification. Keeping this merge in one place prevents a host
+ * workflow from accepting evidence that the executing Runtime would reject.
+ */
+export function createOmkEvaluationSchemaValidators(
   hostValidators: ReadonlyMap<string, CoreSchemaValidator> | undefined,
 ): ReadonlyMap<string, CoreSchemaValidator> {
   let hostEntries: Array<[string, CoreSchemaValidator]>;
@@ -778,7 +783,9 @@ export async function createOmkEvaluationRuntime(
   const compiled = snapshotCompiled(input.compiled);
   const resources = captureResourceOptions(input.resources);
   const clock = captureClock(input.support.clock);
-  const schemaValidators = captureSchemaValidators(input.support.schemaValidators);
+  const schemaValidators = createOmkEvaluationSchemaValidators(
+    input.support.schemaValidators,
+  );
   const executionCache = captureCachePort({
     binding: input.support.executionCache,
     expectedSource: compiled.orchestration.cacheSources?.executionSourceLocator,

--- a/test/eval-workflows/input-compilation/compile.test.ts
+++ b/test/eval-workflows/input-compilation/compile.test.ts
@@ -222,6 +222,7 @@ describe('compileCliEvaluationInput', () => {
     expect(series?.memberships.every((membership) => (
       membership.seriesDesignDigest === series.definition.seriesDesignDigest
     ))).toBe(true);
+    expect(series?.definition.comparabilityPolicy.minimumStatus).toBe('conditional');
     expect(result.definition.experiment.trials).toBe(1);
     expect(result.policy.retry.maxAttempts).toBe(3);
   });

--- a/test/eval-workflows/production-host/orchestration.test.ts
+++ b/test/eval-workflows/production-host/orchestration.test.ts
@@ -1,0 +1,374 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createEvaluationSeriesDefinition,
+  digestCanonicalJson,
+  schemaIdentityKey,
+  type EvaluationSeriesDefinition,
+  type RuntimeIdentity,
+} from '../../../src/evaluation-core/contracts/index.js';
+import type { EvaluationRunResult } from '../../../src/evaluation-core/engine/index.js';
+import {
+  createNodeCoreBatchArtifactStore,
+  createNodeCoreRunArtifactStore,
+} from '../../../src/eval-workflows/artifact-store/index.js';
+import {
+  bindProductionPreparedEvaluation,
+  executeProductionEvaluationBatch,
+  executeProductionEvaluationSeries,
+  type ProductionEvaluationHostInput,
+} from '../../../src/eval-workflows/production-host/index.js';
+import {
+  createOmkEvaluationSchemaValidators,
+  type OmkEvaluationRuntime,
+} from '../../../src/eval-workflows/runtime-adapter/index.js';
+import {
+  prepareConformancePlan,
+  runConformanceScenario,
+  type ConformanceResult,
+} from '../../evaluation-core/conformance/harness.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function temporaryRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function completedResult(fixture: ConformanceResult): EvaluationRunResult {
+  return {
+    status: 'completed',
+    artifacts: {
+      execution: fixture.execution,
+      evaluation: fixture.evaluation,
+      analysis: fixture.analysis,
+      ...(fixture.decision === undefined ? {} : { decision: fixture.decision }),
+    },
+    report: fixture.report,
+  };
+}
+
+function preparedFixture(
+  fixture: ConformanceResult,
+  store: ReturnType<typeof createNodeCoreRunArtifactStore>,
+) {
+  return bindProductionPreparedEvaluation({
+    artifactStore: store,
+    schemaValidators: createOmkEvaluationSchemaValidators(undefined),
+    prepared: {
+      plan: fixture.plan,
+      preflight: { records: [] },
+      async start() {
+        return {
+          events: (async function* emptyEvents() {})(),
+          result: Promise.resolve(completedResult(fixture)),
+        };
+      },
+    },
+  });
+}
+
+describe('production Batch orchestration', () => {
+  it('runs independent children and persists a locator-only manifest after every child', async () => {
+    const runRoot = await temporaryRoot('omk-host-batch-runs-');
+    const batchRoot = await temporaryRoot('omk-host-batches-');
+    const runStore = createNodeCoreRunArtifactStore(runRoot);
+    const batchStore = createNodeCoreBatchArtifactStore(batchRoot, runStore);
+    const [first, second] = await Promise.all([
+      runConformanceScenario('function', { runId: 'batch-first-fixture' }),
+      runConformanceScenario('rag', { runId: 'batch-second-fixture' }),
+    ]);
+
+    const batch = await executeProductionEvaluationBatch({
+      batchId: 'host-batch',
+      createdAt: '2026-09-01T01:00:00.000Z',
+      batchStore,
+      children: [
+        {
+          itemId: 'first',
+          prepared: preparedFixture(first, runStore),
+          options: {
+            runId: 'host-batch-first',
+            createdAt: '2026-09-01T01:00:01.000Z',
+          },
+        },
+        {
+          itemId: 'second',
+          prepared: preparedFixture(second, runStore),
+          options: {
+            runId: 'host-batch-second',
+            createdAt: '2026-09-01T01:00:02.000Z',
+          },
+        },
+      ],
+    });
+
+    assert.deepEqual(batch.children.map(({ itemId, runId }) => ({ itemId, runId })), [
+      { itemId: 'first', runId: 'host-batch-first' },
+      { itemId: 'second', runId: 'host-batch-second' },
+    ]);
+    const persistence = await batch.persistence;
+    assert.equal(persistence.persistenceStatus, 'stored');
+    if (persistence.persistenceStatus !== 'stored') throw new Error('expected stored Batch');
+    assert.deepEqual(persistence.batch.manifest.children.map((child) => ({
+      itemId: child.itemId,
+      runId: child.locator.runId,
+    })), [
+      { itemId: 'first', runId: 'host-batch-first' },
+      { itemId: 'second', runId: 'host-batch-second' },
+    ]);
+    expect('report' in persistence.batch).toBe(false);
+  });
+
+  it('retains started child handles and skips the manifest when another child cannot start', async () => {
+    const runRoot = await temporaryRoot('omk-host-partial-batch-runs-');
+    const batchRoot = await temporaryRoot('omk-host-partial-batches-');
+    const runStore = createNodeCoreRunArtifactStore(runRoot);
+    const batchStore = createNodeCoreBatchArtifactStore(batchRoot, runStore);
+    const fixture = await runConformanceScenario('function', {
+      runId: 'partial-batch-fixture',
+    });
+    const started = preparedFixture(fixture, runStore);
+    const failed = {
+      ...preparedFixture(fixture, runStore),
+      async execute() { throw new Error('lease acquisition failed'); },
+    };
+
+    const batch = await executeProductionEvaluationBatch({
+      batchId: 'partial-host-batch',
+      createdAt: '2026-09-01T01:10:00.000Z',
+      batchStore,
+      children: [{
+        itemId: 'started',
+        prepared: started,
+        options: {
+          runId: 'partial-host-started',
+          createdAt: '2026-09-01T01:10:01.000Z',
+        },
+      }, {
+        itemId: 'failed',
+        prepared: failed,
+        options: {
+          runId: 'partial-host-failed',
+          createdAt: '2026-09-01T01:10:02.000Z',
+        },
+      }],
+    });
+
+    assert.deepEqual(batch.children.map(({ executionStatus }) => executionStatus), [
+      'started',
+      'start-failed',
+    ]);
+    const persistence = await batch.persistence;
+    assert.deepEqual(persistence, {
+      persistenceStatus: 'skipped',
+      reasonCode: 'BATCH_CHILD_ARTIFACTS_INCOMPLETE',
+      childRunIds: ['partial-host-failed'],
+    });
+    assert.equal(await runStore.exists('partial-host-started'), true);
+    assert.equal(await batchStore.exists('partial-host-batch'), false);
+  });
+});
+
+const seriesOutputSchema = {
+  schemaVersion: 'omk.test-production-series-scalar/v1',
+  schemaUri: 'urn:omk:test-production-series-scalar:v1',
+  schemaDigest: digestCanonicalJson({ schema: 'test-production-series-scalar', version: 1 }),
+};
+
+function seriesIdentity(): RuntimeIdentity {
+  return {
+    implementationId: 'test.production-series/v1',
+    version: '1.0.0',
+    fingerprint: digestCanonicalJson({ implementation: 'test.production-series', version: 1 }),
+    fingerprintBasis: 'content-derived',
+    assuranceLevel: 'verified',
+    capabilities: { experimentalUnit: 'run' },
+    implementationManifest: { coverageKind: 'fingerprint-complete' },
+  };
+}
+
+function seriesDefinition(): EvaluationSeriesDefinition {
+  return createEvaluationSeriesDefinition({
+    schemaVersion: 'omk.evaluation-series-definition/v1',
+    seriesId: 'host-repeat-series',
+    analysisMode: 'preregistered',
+    experimentalUnit: 'run',
+    members: [
+      { memberId: 'host-repeat-member-0', replicateIndex: 0 },
+      { memberId: 'host-repeat-member-1', replicateIndex: 1 },
+    ],
+    comparabilityPolicy: {
+      designMode: 'exact-measurement-design',
+      comparisonScope: 'analysis',
+      minimumStatus: 'conditional',
+    },
+    analysisGraph: {
+      nodes: [{
+        nodeId: 'host-run-variance',
+        implementationId: 'test.production-series/v1',
+        analysisStandardId: 'test.production-series/v1',
+        minimumMemberEvidenceStatus: 'complete',
+        inputs: [{ seriesInputKind: 'members', referenceId: 'host-repeat-series' }],
+        outputResultId: 'host-run-variance-result',
+      }],
+    },
+  });
+}
+
+describe('production independent Series orchestration', () => {
+  it('seals each member before execution, verifies persisted facts, and projects evolution', async () => {
+    const definition = seriesDefinition();
+    const plans = await Promise.all(definition.members.map((member) => prepareConformancePlan(
+      'function',
+      (runDefinition) => { runDefinition.seriesMembership = {
+        seriesDesignDigest: definition.seriesDesignDigest,
+        memberId: member.memberId,
+        replicateIndex: member.replicateIndex,
+      }; },
+    )));
+    const fixtures = await Promise.all(plans.map((plan, index) => runConformanceScenario(
+      'function',
+      { runId: `host-series-fixture-${index}`, plan },
+    )));
+    const identity = seriesIdentity();
+    const validator = {
+      schema: seriesOutputSchema,
+      parse(value: unknown) { return value as never; },
+    };
+    const runtimeSeries: NonNullable<OmkEvaluationRuntime['series']> = {
+      entries: [],
+      runtimes: [{
+        runtimeKind: 'series-analysis-node',
+        referenceId: 'host-run-variance',
+        identity,
+        outputSchema: seriesOutputSchema,
+      }],
+      ports: {
+        analysisNodesByNodeId: new Map([['host-run-variance', {
+          identity,
+          outputSchema: seriesOutputSchema,
+          async analyze(context) {
+            return {
+              analysisStatus: 'completed' as const,
+              resultType: 'scalar' as const,
+              value: context.coverage.comparable,
+            };
+          },
+        }]]),
+        decisionPoliciesByDecisionPolicyId: new Map(),
+      },
+    };
+    const fixtureByMember = new Map(definition.members.map((member, index) => [
+      member.memberId,
+      fixtures[index]!,
+    ]));
+    const basePlan = await prepareConformancePlan('function');
+    const runStore = createNodeCoreRunArtifactStore(
+      await temporaryRoot('omk-host-series-runs-'),
+    );
+    const host = {
+      compiled: {
+        definition: basePlan.definition,
+        policy: basePlan.measurementPolicy,
+        runtimeBinding: { schemaVersion: 'omk.runtime-binding-request/v1', bindings: [] },
+        hostResources: { resources: [] },
+        orchestration: {
+          dryRun: false,
+          batch: false,
+          preflight: { doctor: 'skip', connectivity: 'skip' },
+          diagnostic: 'disabled',
+          managedEvidence: 'skip',
+          independentSeries: {
+            definition,
+            memberships: definition.members.map((member) => ({
+              seriesDesignDigest: definition.seriesDesignDigest,
+              memberId: member.memberId,
+              replicateIndex: member.replicateIndex,
+            })),
+          },
+        },
+        presentation: {},
+        runOptions: {},
+        canonicalDigests: {
+          definition: digestCanonicalJson(basePlan.definition),
+          policy: digestCanonicalJson(basePlan.measurementPolicy),
+        },
+      } as unknown as ProductionEvaluationHostInput['compiled'],
+      factories: {} as ProductionEvaluationHostInput['factories'],
+      support: {
+        clock: {} as never,
+        schemaValidators: new Map([[schemaIdentityKey(seriesOutputSchema), validator]]),
+      },
+      resources: { leaseRoot: '/not-used-by-series-fixture' },
+      artifactStore: runStore,
+      async createRuntime(runtimeInput) {
+        const membership = runtimeInput.compiled.definition.seriesMembership;
+        const fixture = membership === undefined
+          ? undefined
+          : fixtureByMember.get(membership.memberId);
+        if (fixture === undefined) throw new Error('missing fixture member');
+        return {
+          series: runtimeSeries,
+          async prepare() {
+            return {
+              plan: fixture.plan,
+              preflight: { records: [] },
+              async start() {
+                return {
+                  events: (async function* emptyEvents() {})(),
+                  result: Promise.resolve(completedResult(fixture)),
+                };
+              },
+            };
+          },
+        };
+      },
+    } satisfies ProductionEvaluationHostInput;
+
+    const series = await executeProductionEvaluationSeries({
+      host,
+      members: [
+        { runId: 'host-repeat-run-0', createdAt: '2026-09-01T02:00:00.000Z' },
+        { runId: 'host-repeat-run-1', createdAt: '2026-09-01T02:00:01.000Z' },
+      ],
+      bundleId: 'host-repeat-bundle',
+      reportId: 'host-repeat-report',
+    });
+
+    assert.deepEqual(series.members.map(({ membership, prepared }) => ({
+      membership,
+      sealedMembership: prepared.plan.definition.seriesMembership,
+    })), definition.members.map((member) => ({
+      membership: {
+        seriesDesignDigest: definition.seriesDesignDigest,
+        memberId: member.memberId,
+        replicateIndex: member.replicateIndex,
+      },
+      sealedMembership: {
+        seriesDesignDigest: definition.seriesDesignDigest,
+        memberId: member.memberId,
+        replicateIndex: member.replicateIndex,
+      },
+    })));
+    const result = await series.result;
+    assert.equal(result.analysis.coverage.planned, 2);
+    assert.equal(result.analysis.coverage.completed, 2);
+    assert.equal(result.analysis.coverage.comparable, 2);
+    assert.equal(result.analysis.records[0]?.analysisStatus, 'completed');
+    const evolution = await series.evolution;
+    assert.equal(evolution.experimentalUnit, 'run');
+    assert.deepEqual(evolution.members.map(({ memberId }) => memberId), [
+      'host-repeat-member-0',
+      'host-repeat-member-1',
+    ]);
+  });
+});

--- a/test/eval-workflows/production-host/workflow.test.ts
+++ b/test/eval-workflows/production-host/workflow.test.ts
@@ -1,0 +1,319 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Sha256Digest } from '../../../src/evaluation-core/contracts/index.js';
+import type { EvaluationRunResult } from '../../../src/evaluation-core/engine/index.js';
+import {
+  createNodeCoreRunArtifactStore,
+  type CoreRunArtifactStore,
+} from '../../../src/eval-workflows/artifact-store/index.js';
+import {
+  createProductionEvaluationHost,
+  type ProductionEvaluationHostInput,
+} from '../../../src/eval-workflows/production-host/index.js';
+import type {
+  OmkEvaluationRuntime,
+  OmkPreparedEvaluation,
+} from '../../../src/eval-workflows/runtime-adapter/index.js';
+import {
+  runConformanceScenario,
+  type ConformanceResult,
+  type ConformanceTarget,
+} from '../../evaluation-core/conformance/harness.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function temporaryStore(): Promise<CoreRunArtifactStore> {
+  const root = await mkdtemp(join(tmpdir(), 'omk-production-host-'));
+  roots.push(root);
+  return createNodeCoreRunArtifactStore(root);
+}
+
+function completedResult(fixture: ConformanceResult): EvaluationRunResult {
+  return {
+    status: 'completed',
+    artifacts: {
+      execution: fixture.execution,
+      evaluation: fixture.evaluation,
+      analysis: fixture.analysis,
+      ...(fixture.decision === undefined ? {} : { decision: fixture.decision }),
+    },
+    report: fixture.report,
+  };
+}
+
+function fakeRuntime(
+  fixture: ConformanceResult,
+  result: Promise<EvaluationRunResult>,
+  onStart: () => void = () => undefined,
+): OmkEvaluationRuntime {
+  const prepared: OmkPreparedEvaluation = {
+    plan: fixture.plan,
+    preflight: { records: [] },
+    async start() {
+      onStart();
+      return {
+        events: (async function* emptyEvents() {})(),
+        result,
+      };
+    },
+  };
+  return { async prepare() { return prepared; } };
+}
+
+function hostInput(input: {
+  fixture: ConformanceResult;
+  result: Promise<EvaluationRunResult>;
+  store: CoreRunArtifactStore;
+  onStart?: () => void;
+  dryRun?: boolean;
+}): ProductionEvaluationHostInput {
+  return {
+    compiled: {
+      orchestration: { dryRun: input.dryRun ?? false },
+    } as ProductionEvaluationHostInput['compiled'],
+    factories: {} as ProductionEvaluationHostInput['factories'],
+    support: { clock: {} as never },
+    resources: { leaseRoot: '/not-used-by-fake-runtime' },
+    artifactStore: input.store,
+    async createRuntime() {
+      return fakeRuntime(input.fixture, input.result, input.onStart);
+    },
+  };
+}
+
+function recordingStore(input: {
+  save?: CoreRunArtifactStore['save'];
+  get?: CoreRunArtifactStore['get'];
+} = {}): CoreRunArtifactStore {
+  return {
+    save: input.save ?? vi.fn(async () => { throw new Error('unexpected save'); }),
+    get: input.get ?? vi.fn(async () => undefined),
+    inspect: vi.fn(async () => undefined),
+    list: vi.fn(async () => []),
+    exists: vi.fn(async () => false),
+  };
+}
+
+describe('production evaluation host workflow', () => {
+  it.each(['function', 'rag', 'agent'] as const)(
+    'keeps prepare side-effect free and publishes an exact completed %s five-document chain',
+    async (target: ConformanceTarget) => {
+    const fixture = await runConformanceScenario(target, { runId: `host-fixture-${target}` });
+    const coreResult = completedResult(fixture);
+    const resultPromise = Promise.resolve(coreResult);
+    const store = await temporaryStore();
+    const onStart = vi.fn();
+    const prepared = await createProductionEvaluationHost(hostInput({
+      fixture,
+      result: resultPromise,
+      store,
+      onStart,
+    })).prepare();
+
+    expect(onStart).not.toHaveBeenCalled();
+    assert.equal(prepared.plan, fixture.plan);
+    assert.deepEqual(prepared.preflight, { records: [] });
+
+    const run = await prepared.execute({
+      runId: `host-run-${target}`,
+      createdAt: '2026-09-01T00:00:00.000Z',
+    });
+    expect(onStart).toHaveBeenCalledOnce();
+    assert.equal(run.result, resultPromise);
+    assert.equal(await run.result, coreResult);
+    const persistence = await run.persistence;
+    assert.equal(persistence.persistenceStatus, 'stored');
+    if (persistence.persistenceStatus !== 'stored') throw new Error('expected stored result');
+    assert.deepEqual(await store.get(`host-run-${target}`), persistence.artifacts);
+    assert.equal(persistence.artifacts.report.reportDigest, fixture.report.reportDigest);
+    },
+  );
+
+  it.each(['cancelled', 'budget-exhausted'] as const)(
+    'preserves and publishes an exact %s Core chain',
+    async (status) => {
+      const cancellation = new AbortController();
+      if (status === 'cancelled') cancellation.abort('fixture cancellation');
+      const fixture = await runConformanceScenario('rag', {
+        runId: `host-${status}`,
+        ...(status === 'cancelled'
+          ? { executionSignal: cancellation.signal }
+          : {
+            mutate(_definition, policy) {
+              policy.budget.stages.execution.maxInvocations = 1;
+            },
+          }),
+      });
+      assert.equal(fixture.report.status.runStatus, status);
+      const result = { ...completedResult(fixture), status } as EvaluationRunResult;
+      const store = await temporaryStore();
+      const prepared = await createProductionEvaluationHost(hostInput({
+        fixture,
+        result: Promise.resolve(result),
+        store,
+      })).prepare();
+      const run = await prepared.execute({
+        runId: `host-${status}`,
+        createdAt: '2026-09-01T00:00:00.000Z',
+      });
+
+      assert.equal((await run.result).status, status);
+      assert.equal((await run.persistence).persistenceStatus, 'stored');
+      assert.equal((await store.get(`host-${status}`))?.report.status.runStatus, status);
+    },
+  );
+
+  it('does not fabricate or publish a five-document chain after a partial failure', async () => {
+    const fixture = await runConformanceScenario('agent', { runId: 'host-partial' });
+    const result: EvaluationRunResult = {
+      status: 'failed',
+      error: { code: 'fixture-failed', stage: 'execution', message: 'fixture failure' },
+      artifacts: { execution: fixture.execution },
+    };
+    const save = vi.fn(async () => { throw new Error('must not save'); });
+    const prepared = await createProductionEvaluationHost(hostInput({
+      fixture,
+      result: Promise.resolve(result),
+      store: recordingStore({ save }),
+    })).prepare();
+    const run = await prepared.execute({
+      runId: 'host-partial',
+      createdAt: '2026-09-01T00:00:00.000Z',
+    });
+
+    assert.equal(await run.result, result);
+    assert.deepEqual(await run.persistence, {
+      persistenceStatus: 'skipped',
+      reasonCode: 'CORE_RESULT_INCOMPLETE',
+    });
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('reports publication failure without rejecting or rewriting the Core result', async () => {
+    const fixture = await runConformanceScenario('function', { runId: 'host-store-failure' });
+    const result = completedResult(fixture);
+    const prepared = await createProductionEvaluationHost(hostInput({
+      fixture,
+      result: Promise.resolve(result),
+      store: recordingStore({ save: vi.fn(async () => { throw new Error('disk full'); }) }),
+    })).prepare();
+    const run = await prepared.execute({
+      runId: 'host-store-failure',
+      createdAt: '2026-09-01T00:00:00.000Z',
+    });
+
+    assert.equal(await run.result, result);
+    const persistence = await run.persistence;
+    assert.equal(persistence.persistenceStatus, 'failed');
+    if (persistence.persistenceStatus !== 'failed') throw new Error('expected failure');
+    assert.equal(persistence.error.code, 'PRODUCTION_EVALUATION_ARTIFACT_PERSIST_FAILED');
+  });
+
+  it('admits resume only through the freshly sealed plan and persisted source', async () => {
+    const fixture = await runConformanceScenario('function', { runId: 'resume-source' });
+    const store = await temporaryStore();
+    await store.save({
+      runId: 'resume-source',
+      createdAt: '2026-09-01T00:00:00.000Z',
+      plan: fixture.plan,
+      execution: fixture.execution,
+      evaluation: fixture.evaluation,
+      analysis: fixture.analysis,
+      report: fixture.report,
+    });
+    const prepared = await createProductionEvaluationHost(hostInput({
+      fixture,
+      result: Promise.resolve(completedResult(fixture)),
+      store,
+    })).prepare();
+    const admitted = await prepared.admitResume({
+      locator: { locatorKind: 'core-run', runId: 'resume-source' },
+      policy: {
+        rejectionMode: 'fail-closed',
+        minimumSourceTrust: 'untrusted',
+        cacheReceiptMode: 'allow-indeterminate',
+        budgetVerificationMode: 'allow-indeterminate',
+      },
+      ...(fixture.decision === undefined ? {} : {
+        verification: {
+          execution: {
+            verifiedProvenanceBundleDigests: new Set([
+              fixture.execution.bundleDigest as Sha256Digest,
+            ]),
+          },
+          evaluation: {
+            verifiedProvenanceBundleDigests: new Set([
+              fixture.evaluation.bundleDigest as Sha256Digest,
+            ]),
+            executionSourceTrust: 'verified' as const,
+          },
+          analysis: {
+            verifiedProvenanceBundleDigests: new Set([
+              fixture.analysis.bundleDigest as Sha256Digest,
+            ]),
+            evaluationSourceTrust: 'verified' as const,
+          },
+          decision: {
+            verifiedPolicyExecutionDigests: new Set([
+              fixture.decision.decisionDigest as Sha256Digest,
+            ]),
+            analysisSourceTrust: 'verified' as const,
+          },
+        },
+      }),
+    });
+
+    assert.equal(admitted.disposition, 'reuse');
+    if (admitted.disposition !== 'reuse') throw new Error('expected admitted source');
+    assert.equal(admitted.sourceRunId, 'resume-source');
+    assert.equal(admitted.report.reportDigest, fixture.report.reportDigest);
+  });
+
+  it('rejects an invalid publication timestamp before starting any Runtime effect', async () => {
+    const fixture = await runConformanceScenario('function', { runId: 'host-invalid-time' });
+    const onStart = vi.fn();
+    const prepared = await createProductionEvaluationHost(hostInput({
+      fixture,
+      result: Promise.resolve(completedResult(fixture)),
+      store: recordingStore(),
+      onStart,
+    })).prepare();
+
+    await expect(prepared.execute({ runId: 'host-invalid-time', createdAt: 'now' }))
+      .rejects.toMatchObject({
+        code: 'PRODUCTION_EVALUATION_HOST_INPUT_INVALID',
+        fieldPath: 'execute.createdAt',
+      });
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('makes dry-run an enforced prepare-only mode', async () => {
+    const fixture = await runConformanceScenario('function', { runId: 'host-dry-run' });
+    const onStart = vi.fn();
+    const prepared = await createProductionEvaluationHost(hostInput({
+      fixture,
+      result: Promise.resolve(completedResult(fixture)),
+      store: recordingStore(),
+      onStart,
+      dryRun: true,
+    })).prepare();
+
+    assert.equal(prepared.executionMode, 'dry-run');
+    assert.equal(prepared.plan, fixture.plan);
+    await expect(prepared.execute({
+      runId: 'host-dry-run',
+      createdAt: '2026-09-01T00:00:00.000Z',
+    })).rejects.toMatchObject({
+      code: 'PRODUCTION_EVALUATION_DRY_RUN_EXECUTION_FORBIDDEN',
+    });
+    expect(onStart).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 用户影响

- 建立 compile 输出到 Runtime prepare／execute、Core artifacts 与 resume 的唯一生产宿主边界。
- dry-run 被约束为只返回 sealed Plan 与 preflight；Core 的 completed／cancelled／budget-exhausted／failed 状态不被宿主改写。
- independent repeat 使用 Evaluation Series，batch 使用独立 child run 与 Batch manifest；Gold、evolve 与 artifact graph 只消费 Core 投影。

## 迁移说明

本 PR 仍不接线正式 `omk eval` 与 Studio，不双跑、不双写，也不改变现有用户报告 schema。最终生产入口切换继续由 #450 完成。

## 测量学说明

宿主仅持久化通过 Core schema、digest、lineage 与 content-closure 校验的完整五件套；部分失败不伪造完整报告。repeat 的默认可比性门槛接受显式记录为 conditional 的证据保证差异，使相同测量设计可进入 Series 分析，同时完整保留 comparability assessment 与原因。评分 prompt、五层评分、Bootstrap、Krippendorff alpha 与 length-debias 语义均未改变。

Closes #539
Parent: #450
Follow-up: #542