### PR TITLE
refactor(studio): 提取对话与任务轨迹路由

### DIFF
--- a/src/studio/http/request-handler.ts
+++ b/src/studio/http/request-handler.ts
@@ -10,12 +10,6 @@ import { assessHealth, renderSkillDetail } from '../presentation/skill-detail-re
 import type { SkillIndexEntry, Insight } from '../view-models/index.js';
 import { renderObservationInboxPage } from '../presentation/observation-inbox-renderer.js';
 import { renderKnowledgeDebuggerPage } from '../presentation/knowledge-debugger-renderer.js';
-import {
-  buildConversationActivitySnapshot,
-  buildConversationDetailActivitySnapshot,
-  renderConversationDetailPage,
-  renderConversationIndexPage,
-} from '../presentation/conversation-renderer.js';
 import { DEFAULT_LANG, e, t, layout } from '../presentation/layout.js';
 import { loadAllManagedRecords, resolveManagedDir, managedDir as projectManagedDir, listManagedRows } from '../../managed/index.js';
 import { renderManagedList, renderManagedHistory } from '../presentation/managed-history-renderer.js';
@@ -56,6 +50,7 @@ import {
 } from '../core-runs/index.js';
 import type { ReportServerOptions } from './contracts.js';
 import { getErrorMessage } from './errors.js';
+import { createConversationRoutes } from './routes/conversations.js';
 
 interface AnalysisListItem {
   id: string;
@@ -729,6 +724,10 @@ export function createStudioRequestHandler({ requestShutdown, analysesDir, docto
   const liveStreamClosers = new Set<() => void>();
 
   const resolvedConversationCatalog = conversationCatalog ?? createCodexConversationCatalog();
+  const conversationRoutes = createConversationRoutes({
+    catalog: resolvedConversationCatalog,
+    liveStreams: liveStreamClosers,
+  });
   const coreStudioRoute = coreStudioCatalog === undefined
     ? undefined
     : createCoreStudioRouteHandler({
@@ -914,221 +913,13 @@ export function createStudioRequestHandler({ requestShutdown, analysesDir, docto
         return;
       }
 
-      if (path === '/api/conversations/activity') {
-        const snapshot = buildConversationActivitySnapshot(
-          await resolvedConversationCatalog.listConversations(),
-        );
-        res.writeHead(200, {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Cache-Control': 'no-store',
-        });
-        res.end(JSON.stringify(snapshot));
-        return;
-      }
-
-      const conversationActivityMatch = path.match(/^\/api\/conversations\/([^/]+)\/activity$/);
-      if (conversationActivityMatch) {
-        let threadId = '';
-        try { threadId = decodeURIComponent(conversationActivityMatch[1]); } catch { /* invalid path */ }
-        const conversation = threadId ? await resolvedConversationCatalog.getConversation(threadId) : undefined;
-        if (!conversation) {
-          res.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
-          res.end(JSON.stringify({ error: 'conversation_not_found' }));
-          return;
-        }
-        res.writeHead(200, {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Cache-Control': 'no-store',
-        });
-        res.end(JSON.stringify(buildConversationDetailActivitySnapshot(conversation)));
-        return;
-      }
-
-      if (path === '/conversations') {
-        const html = renderConversationIndexPage(await resolvedConversationCatalog.listConversations(), lang);
-        res.writeHead(200, {
-          'Content-Type': 'text/html; charset=utf-8',
-          'Cache-Control': 'no-store',
-        });
-        res.end(html);
-        return;
-      }
-
-      const conversationTaskLiveMatch = path.match(/^\/api\/conversations\/([^/]+)\/tasks\/([^/]+)\/live$/);
-      if (conversationTaskLiveMatch) {
-        let threadId = '';
-        let turnId = '';
-        try {
-          threadId = decodeURIComponent(conversationTaskLiveMatch[1]);
-          turnId = decodeURIComponent(conversationTaskLiveMatch[2]);
-        } catch { /* invalid path */ }
-        const initial = threadId && turnId
-          ? await resolvedConversationCatalog.loadTaskTrajectory(threadId, turnId)
-          : undefined;
-        if (!initial) {
-          res.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
-          res.end(JSON.stringify({ error: 'task_trajectory_not_found' }));
-          return;
-        }
-        if (!resolvedConversationCatalog.observeTaskTrajectory) {
-          res.writeHead(501, { 'Content-Type': 'application/json; charset=utf-8' });
-          res.end(JSON.stringify({ error: 'live_task_trajectory_unavailable' }));
-          return;
-        }
-
-        res.writeHead(200, {
-          'Content-Type': 'text/event-stream; charset=utf-8',
-          'Cache-Control': 'no-cache, no-transform',
-          Connection: 'keep-alive',
-          'X-Accel-Buffering': 'no',
-        });
-        res.flushHeaders();
-
-        let closed = false;
-        let unsubscribe: (() => void) | undefined;
-        const lifecycle = new AbortController();
-        const heartbeat = setInterval(() => {
-          if (!res.destroyed && !res.writableEnded) res.write(': keepalive\n\n');
-        }, 15_000);
-        heartbeat.unref?.();
-        const close = (): void => {
-          if (closed) return;
-          closed = true;
-          clearInterval(heartbeat);
-          lifecycle.abort();
-          unsubscribe?.();
-          liveStreamClosers.delete(close);
-          if (!res.destroyed && !res.writableEnded) res.end();
-        };
-        liveStreamClosers.add(close);
-        req.once('close', close);
-        res.once('close', close);
-
-        try {
-          unsubscribe = await resolvedConversationCatalog.observeTaskTrajectory(
-            threadId,
-            turnId,
-            {
-              next: (trajectory) => {
-                if (closed || res.destroyed || res.writableEnded) return;
-                res.write(`id: ${trajectory.revision}\n`);
-                res.write('event: trajectory\n');
-                res.write(`data: ${JSON.stringify({
-                  revision: trajectory.revision,
-                  status: trajectory.status,
-                  liveObservable: trajectory.liveObservable,
-                })}\n\n`);
-              },
-              complete: close,
-              error: (cause) => {
-                if (!closed && !res.destroyed && !res.writableEnded) {
-                  res.write('event: trajectory-error\n');
-                  res.write(`data: ${JSON.stringify({ error: getErrorMessage(cause) })}\n\n`);
-                }
-                close();
-              },
-            },
-            { signal: lifecycle.signal },
-          );
-          if (closed) unsubscribe();
-        } catch (cause) {
-          if (!closed && !res.destroyed && !res.writableEnded) {
-            res.write('event: trajectory-error\n');
-            res.write(`data: ${JSON.stringify({ error: getErrorMessage(cause) })}\n\n`);
-          }
-          close();
-        }
-        return;
-      }
-
-      const conversationTaskMatch = path.match(/^\/conversations\/([^/]+)\/tasks\/([^/]+)$/);
-      if (conversationTaskMatch) {
-        let threadId = '';
-        let turnId = '';
-        try {
-          threadId = decodeURIComponent(conversationTaskMatch[1]);
-          turnId = decodeURIComponent(conversationTaskMatch[2]);
-        } catch { /* invalid path */ }
-        const trajectory = threadId && turnId
-          ? await resolvedConversationCatalog.loadTaskTrajectory(threadId, turnId)
-          : undefined;
-        if (!trajectory) {
-          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-          res.end(lang === 'en' ? 'task trajectory not found' : '任务轨迹不存在');
-          return;
-        }
-        const sourceRecords = {
-          ...trajectory.sourceRecords,
-          records: [],
-        };
-        const html = renderKnowledgeDebuggerPage(
-          buildKnowledgeDebuggerViewModel(
-            trajectory.session,
-            turnId,
-            trajectory.ingestion,
-            sourceRecords,
-          ),
-          lang,
-          {
-            sourceRecordsEndpoint: `/api/conversations/${encodeURIComponent(threadId)}/tasks/${encodeURIComponent(turnId)}/source-records`,
-            ...(trajectory.liveObservable && resolvedConversationCatalog.observeTaskTrajectory ? {
-              live: {
-                endpoint: `/api/conversations/${encodeURIComponent(threadId)}/tasks/${encodeURIComponent(turnId)}/live`,
-                revision: trajectory.revision,
-              },
-            } : {}),
-          },
-        );
-        res.writeHead(200, {
-          'Content-Type': 'text/html; charset=utf-8',
-          'Cache-Control': 'no-store',
-        });
-        res.end(html);
-        return;
-      }
-
-      const conversationTaskSourceMatch = path.match(/^\/api\/conversations\/([^/]+)\/tasks\/([^/]+)\/source-records$/);
-      if (conversationTaskSourceMatch) {
-        let threadId = '';
-        let turnId = '';
-        try {
-          threadId = decodeURIComponent(conversationTaskSourceMatch[1]);
-          turnId = decodeURIComponent(conversationTaskSourceMatch[2]);
-        } catch { /* invalid path */ }
-        const trajectory = threadId && turnId
-          ? await resolvedConversationCatalog.loadTaskTrajectory(threadId, turnId)
-          : undefined;
-        if (!trajectory) {
-          res.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
-          res.end(JSON.stringify({ error: 'task_trajectory_not_found' }));
-          return;
-        }
-        res.writeHead(200, {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Cache-Control': 'no-store',
-        });
-        res.end(JSON.stringify(trajectory.sourceRecords));
-        return;
-      }
-
-      const conversationDetailMatch = path.match(/^\/conversations\/([^/]+)$/);
-      if (conversationDetailMatch) {
-        let threadId = '';
-        try { threadId = decodeURIComponent(conversationDetailMatch[1]); } catch { /* invalid path */ }
-        const conversation = threadId ? await resolvedConversationCatalog.getConversation(threadId) : undefined;
-        if (!conversation) {
-          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-          res.end(lang === 'en' ? 'conversation not found' : '对话不存在');
-          return;
-        }
-        res.writeHead(200, {
-          'Content-Type': 'text/html; charset=utf-8',
-          'Cache-Control': 'no-store',
-        });
-        res.end(renderConversationDetailPage(conversation, lang));
-        return;
-      }
-
+      if (await conversationRoutes({
+        request: req,
+        response: res,
+        url: parsed,
+        path,
+        lang,
+      })) return;
       const knowledgeDebuggerMatch = path.match(/^\/observe-debugger\/(.+)$/);
       if (knowledgeDebuggerMatch) {
         let experienceSessionId = '';
@@ -1385,16 +1176,6 @@ export function createStudioRequestHandler({ requestShutdown, analysesDir, docto
         }
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(diff));
-        return;
-      }
-
-
-      // Studio 先呈现机器上的 Codex 主对话，再从某次对话进入原生 turn 任务轨迹。
-      // /conversations 保留为同义入口，避免旧书签失效。
-      if (path === '/') {
-        const html = renderConversationIndexPage(await resolvedConversationCatalog.listConversations(), lang);
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(html);
         return;
       }
 

--- a/src/studio/http/routes/contracts.ts
+++ b/src/studio/http/routes/contracts.ts
@@ -1,0 +1,19 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Lang } from '../../../shared/language.js';
+
+export interface StudioRouteContext {
+  readonly request: IncomingMessage;
+  readonly response: ServerResponse;
+  readonly url: URL;
+  readonly path: string;
+  readonly lang: Lang;
+}
+
+export type StudioRouteHandler = (
+  context: StudioRouteContext,
+) => boolean | Promise<boolean>;
+
+export interface LiveStreamRegistry {
+  add(close: () => void): void;
+  delete(close: () => void): void;
+}

--- a/src/studio/http/routes/conversations.ts
+++ b/src/studio/http/routes/conversations.ts
@@ -1,0 +1,251 @@
+import type { ConversationCatalog } from '../../../observability/conversation-catalog.js';
+import { buildKnowledgeDebuggerViewModel } from '../../../observability/knowledge-debugger.js';
+import {
+  buildConversationActivitySnapshot,
+  buildConversationDetailActivitySnapshot,
+  renderConversationDetailPage,
+  renderConversationIndexPage,
+} from '../../presentation/conversation-renderer.js';
+import { renderKnowledgeDebuggerPage } from '../../presentation/knowledge-debugger-renderer.js';
+import { getErrorMessage } from '../errors.js';
+import type {
+  LiveStreamRegistry,
+  StudioRouteHandler,
+} from './contracts.js';
+
+interface ConversationRoutesOptions {
+  readonly catalog: ConversationCatalog;
+  readonly liveStreams: LiveStreamRegistry;
+}
+
+export function createConversationRoutes({
+  catalog,
+  liveStreams,
+}: ConversationRoutesOptions): StudioRouteHandler {
+  return async ({ request, response, path, lang }): Promise<boolean> => {
+    if (path === '/api/conversations/activity') {
+      const snapshot = buildConversationActivitySnapshot(
+        await catalog.listConversations(),
+      );
+      response.writeHead(200, {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      });
+      response.end(JSON.stringify(snapshot));
+      return true;
+    }
+
+    const conversationActivityMatch = path.match(/^\/api\/conversations\/([^/]+)\/activity$/);
+    if (conversationActivityMatch) {
+      let threadId = '';
+      try { threadId = decodeURIComponent(conversationActivityMatch[1]); } catch { /* invalid path */ }
+      const conversation = threadId ? await catalog.getConversation(threadId) : undefined;
+      if (!conversation) {
+        response.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
+        response.end(JSON.stringify({ error: 'conversation_not_found' }));
+        return true;
+      }
+      response.writeHead(200, {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      });
+      response.end(JSON.stringify(buildConversationDetailActivitySnapshot(conversation)));
+      return true;
+    }
+
+    if (path === '/conversations') {
+      const html = renderConversationIndexPage(await catalog.listConversations(), lang);
+      response.writeHead(200, {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'no-store',
+      });
+      response.end(html);
+      return true;
+    }
+
+    const conversationTaskLiveMatch = path.match(/^\/api\/conversations\/([^/]+)\/tasks\/([^/]+)\/live$/);
+    if (conversationTaskLiveMatch) {
+      let threadId = '';
+      let turnId = '';
+      try {
+        threadId = decodeURIComponent(conversationTaskLiveMatch[1]);
+        turnId = decodeURIComponent(conversationTaskLiveMatch[2]);
+      } catch { /* invalid path */ }
+      const initial = threadId && turnId
+        ? await catalog.loadTaskTrajectory(threadId, turnId)
+        : undefined;
+      if (!initial) {
+        response.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
+        response.end(JSON.stringify({ error: 'task_trajectory_not_found' }));
+        return true;
+      }
+      if (!catalog.observeTaskTrajectory) {
+        response.writeHead(501, { 'Content-Type': 'application/json; charset=utf-8' });
+        response.end(JSON.stringify({ error: 'live_task_trajectory_unavailable' }));
+        return true;
+      }
+
+      response.writeHead(200, {
+        'Content-Type': 'text/event-stream; charset=utf-8',
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      });
+      response.flushHeaders();
+
+      let closed = false;
+      let unsubscribe: (() => void) | undefined;
+      const lifecycle = new AbortController();
+      const heartbeat = setInterval(() => {
+        if (!response.destroyed && !response.writableEnded) response.write(': keepalive\n\n');
+      }, 15_000);
+      heartbeat.unref?.();
+      const close = (): void => {
+        if (closed) return;
+        closed = true;
+        clearInterval(heartbeat);
+        lifecycle.abort();
+        unsubscribe?.();
+        liveStreams.delete(close);
+        if (!response.destroyed && !response.writableEnded) response.end();
+      };
+      liveStreams.add(close);
+      request.once('close', close);
+      response.once('close', close);
+
+      try {
+        unsubscribe = await catalog.observeTaskTrajectory(
+          threadId,
+          turnId,
+          {
+            next: (trajectory) => {
+              if (closed || response.destroyed || response.writableEnded) return;
+              response.write(`id: ${trajectory.revision}\n`);
+              response.write('event: trajectory\n');
+              response.write(`data: ${JSON.stringify({
+                revision: trajectory.revision,
+                status: trajectory.status,
+                liveObservable: trajectory.liveObservable,
+              })}\n\n`);
+            },
+            complete: close,
+            error: (cause) => {
+              if (!closed && !response.destroyed && !response.writableEnded) {
+                response.write('event: trajectory-error\n');
+                response.write(`data: ${JSON.stringify({ error: getErrorMessage(cause) })}\n\n`);
+              }
+              close();
+            },
+          },
+          { signal: lifecycle.signal },
+        );
+        if (closed) unsubscribe();
+      } catch (cause) {
+        if (!closed && !response.destroyed && !response.writableEnded) {
+          response.write('event: trajectory-error\n');
+          response.write(`data: ${JSON.stringify({ error: getErrorMessage(cause) })}\n\n`);
+        }
+        close();
+      }
+      return true;
+    }
+
+    const conversationTaskMatch = path.match(/^\/conversations\/([^/]+)\/tasks\/([^/]+)$/);
+    if (conversationTaskMatch) {
+      let threadId = '';
+      let turnId = '';
+      try {
+        threadId = decodeURIComponent(conversationTaskMatch[1]);
+        turnId = decodeURIComponent(conversationTaskMatch[2]);
+      } catch { /* invalid path */ }
+      const trajectory = threadId && turnId
+        ? await catalog.loadTaskTrajectory(threadId, turnId)
+        : undefined;
+      if (!trajectory) {
+        response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        response.end(lang === 'en' ? 'task trajectory not found' : '任务轨迹不存在');
+        return true;
+      }
+      const sourceRecords = {
+        ...trajectory.sourceRecords,
+        records: [],
+      };
+      const html = renderKnowledgeDebuggerPage(
+        buildKnowledgeDebuggerViewModel(
+          trajectory.session,
+          turnId,
+          trajectory.ingestion,
+          sourceRecords,
+        ),
+        lang,
+        {
+          sourceRecordsEndpoint: `/api/conversations/${encodeURIComponent(threadId)}/tasks/${encodeURIComponent(turnId)}/source-records`,
+          ...(trajectory.liveObservable && catalog.observeTaskTrajectory ? {
+            live: {
+              endpoint: `/api/conversations/${encodeURIComponent(threadId)}/tasks/${encodeURIComponent(turnId)}/live`,
+              revision: trajectory.revision,
+            },
+          } : {}),
+        },
+      );
+      response.writeHead(200, {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'no-store',
+      });
+      response.end(html);
+      return true;
+    }
+
+    const conversationTaskSourceMatch = path.match(/^\/api\/conversations\/([^/]+)\/tasks\/([^/]+)\/source-records$/);
+    if (conversationTaskSourceMatch) {
+      let threadId = '';
+      let turnId = '';
+      try {
+        threadId = decodeURIComponent(conversationTaskSourceMatch[1]);
+        turnId = decodeURIComponent(conversationTaskSourceMatch[2]);
+      } catch { /* invalid path */ }
+      const trajectory = threadId && turnId
+        ? await catalog.loadTaskTrajectory(threadId, turnId)
+        : undefined;
+      if (!trajectory) {
+        response.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
+        response.end(JSON.stringify({ error: 'task_trajectory_not_found' }));
+        return true;
+      }
+      response.writeHead(200, {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      });
+      response.end(JSON.stringify(trajectory.sourceRecords));
+      return true;
+    }
+
+    const conversationDetailMatch = path.match(/^\/conversations\/([^/]+)$/);
+    if (conversationDetailMatch) {
+      let threadId = '';
+      try { threadId = decodeURIComponent(conversationDetailMatch[1]); } catch { /* invalid path */ }
+      const conversation = threadId ? await catalog.getConversation(threadId) : undefined;
+      if (!conversation) {
+        response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        response.end(lang === 'en' ? 'conversation not found' : '对话不存在');
+        return true;
+      }
+      response.writeHead(200, {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'no-store',
+      });
+      response.end(renderConversationDetailPage(conversation, lang));
+      return true;
+    }
+
+    // Studio 默认呈现机器上的主对话；/conversations 保留为同义入口。
+    if (path === '/') {
+      const html = renderConversationIndexPage(await catalog.listConversations(), lang);
+      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      response.end(html);
+      return true;
+    }
+
+    return false;
+  };
+}

--- a/test/studio/http/conversation-routes-boundary.test.ts
+++ b/test/studio/http/conversation-routes-boundary.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('Studio conversation route boundary', () => {
+  it('keeps conversation rendering and live trajectory state out of composition', () => {
+    const composition = readFileSync('src/studio/http/request-handler.ts', 'utf8');
+
+    expect(composition).toContain('createConversationRoutes');
+    for (const forbidden of [
+      'buildConversationActivitySnapshot',
+      'buildConversationDetailActivitySnapshot',
+      'renderConversationDetailPage',
+      'renderConversationIndexPage',
+      'observeTaskTrajectory(',
+      'event: trajectory',
+      ': keepalive',
+    ]) {
+      expect(composition).not.toContain(forbidden);
+    }
+  });
+
+  it('keeps the route family independent from listener and global composition', () => {
+    const routes = readFileSync('src/studio/http/routes/conversations.ts', 'utf8');
+
+    expect(routes).not.toContain('report-server');
+    expect(routes).not.toContain('request-handler');
+    expect(routes).not.toContain('createServer');
+    expect(routes).not.toContain('.listen(');
+  });
+});


### PR DESCRIPTION
## 用户影响

Studio 的对话列表、对话活动、任务轨迹、source records 与实时 SSE 路由现在由独立 conversation route family 管理。HTTP 路径、状态码、响应格式、页面内容和实时更新协议保持不变。

## 架构边界

- 全局 request composition 只负责创建并按序调用 conversation handler，不再持有渲染、轨迹查询或 SSE 细节。
- Conversation handler 通过显式 catalog 与 live-stream registry port 获取依赖，不访问 listener lifecycle 或其它路由族。
- Core Studio 存在时根路径仍优先跳转 `/reports`；否则根路径仍呈现本机对话列表。
- 边界测试阻止 conversation 与 SSE 实现回流到全局 composition。

## 迁移说明

无用户迁移。对话 URL、task trajectory URL、SSE event 名称与 payload 均保持不变。

## 测量学说明

本 PR 只重构 Studio 查询与呈现接线，不修改 trace 解析、归因、schema、prompt、评分／统计语义或落盘数据，不构成 `BREAKING-COMPARABILITY`。

Part of #562。