### PR TITLE
refactor(studio): 提取观测收件箱与调试路由

### DIFF
--- a/src/studio/http/request-errors.ts
+++ b/src/studio/http/request-errors.ts
@@ -1,0 +1,82 @@
+import type { IncomingMessage } from 'node:http';
+
+export class RequestBodyError extends Error {
+  override readonly name = 'RequestBodyError';
+
+  constructor(
+    message: string,
+    readonly statusCode: 400 | 403 | 413 | 415,
+  ) {
+    super(message);
+  }
+}
+
+export function assertTrustedMutationRequest(request: IncomingMessage): void {
+  const fetchSite = request.headers['sec-fetch-site'];
+  if (fetchSite === 'cross-site') {
+    throw new RequestBodyError('cross-origin mutation is not allowed', 403);
+  }
+
+  const origin = request.headers.origin;
+  if (!origin) return;
+  if (Array.isArray(origin) || !request.headers.host) {
+    throw new RequestBodyError('cross-origin mutation is not allowed', 403);
+  }
+  try {
+    if (new URL(origin).host !== request.headers.host) {
+      throw new RequestBodyError('cross-origin mutation is not allowed', 403);
+    }
+  } catch (error) {
+    if (error instanceof RequestBodyError) throw error;
+    throw new RequestBodyError('cross-origin mutation is not allowed', 403);
+  }
+}
+
+function assertJsonContentType(request: IncomingMessage): void {
+  const contentType = request.headers['content-type'];
+  const mediaType = typeof contentType === 'string'
+    ? contentType.split(';', 1)[0].trim().toLowerCase()
+    : '';
+  if (mediaType === 'application/json' || mediaType.endsWith('+json')) return;
+  request.resume();
+  throw new RequestBodyError('content-type must be application/json', 415);
+}
+
+export function readJsonObjectBody(
+  request: IncomingMessage,
+  maxBytes = 1024 * 1024,
+): Promise<Record<string, unknown>> {
+  assertJsonContentType(request);
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    let tooLarge = false;
+    const chunks: Buffer[] = [];
+    request.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > maxBytes) {
+        tooLarge = true;
+        chunks.length = 0;
+        return;
+      }
+      if (!tooLarge) chunks.push(chunk);
+    });
+    request.on('end', () => {
+      if (tooLarge) {
+        reject(new RequestBodyError('request body too large', 413));
+        return;
+      }
+      try {
+        const raw = Buffer.concat(chunks).toString('utf-8').trim();
+        const parsed = raw ? JSON.parse(raw) as unknown : {};
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          reject(new RequestBodyError('json body must be an object', 400));
+          return;
+        }
+        resolve(parsed as Record<string, unknown>);
+      } catch {
+        reject(new RequestBodyError('invalid json body', 400));
+      }
+    });
+    request.on('error', reject);
+  });
+}

--- a/src/studio/http/request-handler.ts
+++ b/src/studio/http/request-handler.ts
@@ -8,8 +8,6 @@ import { renderDoctorDetail } from '../presentation/doctor-detail-renderer.js';
 import type { SkillReportContext } from '../presentation/report-shell.js';
 import { assessHealth, renderSkillDetail } from '../presentation/skill-detail-renderer.js';
 import type { SkillIndexEntry, Insight } from '../view-models/index.js';
-import { renderObservationInboxPage } from '../presentation/observation-inbox-renderer.js';
-import { renderKnowledgeDebuggerPage } from '../presentation/knowledge-debugger-renderer.js';
 import { DEFAULT_LANG, e, t, layout } from '../presentation/layout.js';
 import { loadAllManagedRecords, resolveManagedDir, managedDir as projectManagedDir, listManagedRows } from '../../managed/index.js';
 import { renderManagedList, renderManagedHistory } from '../presentation/managed-history-renderer.js';
@@ -27,30 +25,24 @@ import {
   type SkillHealthReport,
 } from '../../observability/skill-health-analyzer.js';
 import { parseSkillHealthReport } from '../../observability/skill-health-report.js';
-import { DEFAULT_OBSERVATIONS_DIR, findObservationInboxItem, formatObservationShow, queryObservationInbox } from '../../observability/inbox.js';
-import { buildObservationInboxViewModel } from '../../observability/inbox-view-model.js';
-import { buildKnowledgeDebuggerViewModel } from '../../observability/knowledge-debugger.js';
+import { DEFAULT_OBSERVATIONS_DIR } from '../../observability/inbox.js';
 import {
   createCodexConversationCatalog,
 } from '../../observability/conversation-catalog.js';
 import {
-  loadObservationSourceRecordArchive,
-  summarizeObservationSourceRecordArchive,
-} from '../../observability/source-record-archive.js';
-import { activeStudioDiagnostics } from '../../diagnosis/studio-projection.js';
-import {
-  deleteObservationReviewState,
-  loadObservationReviewState,
   ObservationReviewStateValidationError,
-  updateObservationReviewState,
-  type ObservationReviewStateUpdate,
 } from '../../observability/review-state.js';
 import {
   createCoreStudioRouteHandler,
 } from '../core-runs/index.js';
 import type { ReportServerOptions } from './contracts.js';
 import { getErrorMessage } from './errors.js';
+import {
+  assertTrustedMutationRequest,
+  RequestBodyError,
+} from './request-errors.js';
 import { createConversationRoutes } from './routes/conversations.js';
+import { createObservationRoutes } from './routes/observations.js';
 
 interface AnalysisListItem {
   id: string;
@@ -390,84 +382,6 @@ function fmtPct(v: number | null | undefined): string {
   return `${Math.round(v * 100)}%`;
 }
 
-class RequestBodyError extends Error {
-  override readonly name = 'RequestBodyError';
-
-  constructor(
-    message: string,
-    readonly statusCode: 400 | 403 | 413 | 415,
-  ) {
-    super(message);
-  }
-}
-
-function assertTrustedMutationRequest(req: IncomingMessage): void {
-  const fetchSite = req.headers['sec-fetch-site'];
-  if (fetchSite === 'cross-site') {
-    throw new RequestBodyError('cross-origin mutation is not allowed', 403);
-  }
-
-  const origin = req.headers.origin;
-  if (!origin) return;
-  if (Array.isArray(origin) || !req.headers.host) {
-    throw new RequestBodyError('cross-origin mutation is not allowed', 403);
-  }
-  try {
-    if (new URL(origin).host !== req.headers.host) {
-      throw new RequestBodyError('cross-origin mutation is not allowed', 403);
-    }
-  } catch (error) {
-    if (error instanceof RequestBodyError) throw error;
-    throw new RequestBodyError('cross-origin mutation is not allowed', 403);
-  }
-}
-
-function assertJsonContentType(req: IncomingMessage): void {
-  const contentType = req.headers['content-type'];
-  const mediaType = typeof contentType === 'string'
-    ? contentType.split(';', 1)[0].trim().toLowerCase()
-    : '';
-  if (mediaType === 'application/json' || mediaType.endsWith('+json')) return;
-  req.resume();
-  throw new RequestBodyError('content-type must be application/json', 415);
-}
-
-function readJsonObjectBody(req: IncomingMessage, maxBytes = 1024 * 1024): Promise<Record<string, unknown>> {
-  assertJsonContentType(req);
-  return new Promise((resolve, reject) => {
-    let size = 0;
-    let tooLarge = false;
-    const chunks: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => {
-      size += chunk.length;
-      if (size > maxBytes) {
-        tooLarge = true;
-        chunks.length = 0;
-        return;
-      }
-      if (!tooLarge) chunks.push(chunk);
-    });
-    req.on('end', () => {
-      if (tooLarge) {
-        reject(new RequestBodyError('request body too large', 413));
-        return;
-      }
-      try {
-        const raw = Buffer.concat(chunks).toString('utf-8').trim();
-        const parsed = raw ? JSON.parse(raw) as unknown : {};
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-          reject(new RequestBodyError('json body must be an object', 400));
-          return;
-        }
-        resolve(parsed as Record<string, unknown>);
-      } catch {
-        reject(new RequestBodyError('invalid json body', 400));
-      }
-    });
-    req.on('error', reject);
-  });
-}
-
 function fmtHistDate(ts: string | undefined, lang: Lang): string {
   if (!ts) return '-';
   try {
@@ -697,19 +611,6 @@ function renderAnalysisList(items: AnalysisListItem[], lang: Lang = DEFAULT_LANG
   return layout(t('skillHealthTitle', lang), body, lang);
 }
 
-function findKnowledgeDebuggerContext(observationsDir: string, experienceSessionId: string) {
-  const inbox = buildObservationInboxViewModel(observationsDir);
-  const report = inbox.reports.find((candidate) =>
-    candidate.experience?.sessions.some((session) => session.id === experienceSessionId)
-  );
-  const session = report?.experience?.sessions.find((candidate) => candidate.id === experienceSessionId);
-  if (!report || !session) return undefined;
-  const sourceRecordRef = report.meta.sourceRecordArchives?.find((candidate) =>
-    candidate.experienceSessionId === experienceSessionId
-  );
-  return { report, session, sourceRecordRef };
-}
-
 type RequestHandlerOptions = Omit<ReportServerOptions, 'port' | 'host'> & {
   requestShutdown(): void;
 };
@@ -768,6 +669,11 @@ export function createStudioRequestHandler({ requestShutdown, analysesDir, docto
         : (): string => resolveDoctorsDir(projectDoctorsDir());
 
   const skillIndexOptions = (): Parameters<typeof buildSkillIndex>[3] => ({
+    includeObserveCards,
+    includeDoctorCards,
+  });
+  const observationRoutes = createObservationRoutes({
+    observationsDir,
     includeObserveCards,
     includeDoctorCards,
   });
@@ -840,21 +746,16 @@ export function createStudioRequestHandler({ requestShutdown, analysesDir, docto
         return;
       }
 
-      // 旧 observe 路由 → observe-* 词根 canonical 的兜底(querystring 透传),防外链 / 书签 / 已打开页面的旧 fetch 失效。
-      // 页面用 302(临时);API 用 307 —— review-state 有 POST/DELETE,302 会被客户端降级成 GET,307 保留 method+body。
-      // 复合名 /analyses-diff、/api/analyses-diff、/skill-trend 维持原名,不在此重定向。
+      // 旧 observe-health 路由 → canonical 词根(querystring 透传)。Observation Inbox
+      // 的旧入口由其能力路由统一处理；复合名 /analyses-diff、/api/analyses-diff、
+      // /skill-trend 维持原名，不在此重定向。
       const legacyObserveRedirect = ((): { to: string; status: 302 | 307 } | null => {
         if (path === '/analyses') return { to: '/observe-health', status: 302 };
-        if (path === '/observations' || path === '/observations/inbox') return { to: '/observe-inbox', status: 302 };
         const detail = path.match(/^\/analyses\/(.+)$/);
         if (detail) return { to: `/observe-health/${detail[1]}`, status: 302 };
         if (path === '/api/analyses') return { to: '/api/observe-health', status: 307 };
         const apiDetail = path.match(/^\/api\/analyses\/(.+)$/);
         if (apiDetail) return { to: `/api/observe-health/${apiDetail[1]}`, status: 307 };
-        if (path === '/api/observations/inbox') return { to: '/api/observe-inbox', status: 307 };
-        if (path === '/api/observations/show') return { to: '/api/observe-inbox/show', status: 307 };
-        if (path === '/api/observations/diagnostics') return { to: '/api/observe-inbox/diagnostics', status: 307 };
-        if (path === '/api/observations/review-state') return { to: '/api/observe-inbox/review-state', status: 307 };
         return null;
       })();
       if (legacyObserveRedirect) {
@@ -905,14 +806,6 @@ export function createStudioRequestHandler({ requestShutdown, analysesDir, docto
         return;
       }
 
-      if (path === '/observe-inbox') {
-        const skill = parsed.searchParams.get('skill') || undefined;
-        const html = renderObservationInboxPage(buildObservationInboxViewModel(observationsDir, { skill }), lang);
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(html);
-        return;
-      }
-
       if (await conversationRoutes({
         request: req,
         response: res,
@@ -920,160 +813,15 @@ export function createStudioRequestHandler({ requestShutdown, analysesDir, docto
         path,
         lang,
       })) return;
-      const knowledgeDebuggerMatch = path.match(/^\/observe-debugger\/(.+)$/);
-      if (knowledgeDebuggerMatch) {
-        let experienceSessionId = '';
-        try { experienceSessionId = decodeURIComponent(knowledgeDebuggerMatch[1]); } catch { /* invalid path */ }
-        const context = experienceSessionId
-          ? findKnowledgeDebuggerContext(observationsDir, experienceSessionId)
-          : undefined;
-        if (!context) {
-          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-          res.end(lang === 'en' ? 'experience session not found' : '观测会话不存在');
-          return;
-        }
-        const targetTurnId = parsed.searchParams.get('turnId')?.trim();
-        if (!targetTurnId) {
-          const langQuery = lang === DEFAULT_LANG ? '' : '?lang=en';
-          res.writeHead(302, {
-            Location: `/conversations/${encodeURIComponent(context.session.threadId)}${langQuery}`,
-          });
-          res.end();
-          return;
-        }
-        if (!context.session.turns.some((turn) => turn.turnId === targetTurnId)) {
-          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-          res.end(lang === 'en' ? 'task turn not found' : '任务不存在');
-          return;
-        }
-        const html = renderKnowledgeDebuggerPage(
-          buildKnowledgeDebuggerViewModel(
-            context.session,
-            targetTurnId,
-            context.report.meta.ingestion,
-            summarizeObservationSourceRecordArchive(context.sourceRecordRef),
-          ),
-          lang,
-          {
-            sourceRecordsEndpoint: `/api/observe-debugger/${encodeURIComponent(experienceSessionId)}/source-records`,
-          },
-        );
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(html);
-        return;
-      }
-
-      const knowledgeDebuggerSourceMatch = path.match(/^\/api\/observe-debugger\/(.+)\/source-records$/);
-      if (knowledgeDebuggerSourceMatch) {
-        let experienceSessionId = '';
-        try { experienceSessionId = decodeURIComponent(knowledgeDebuggerSourceMatch[1]); } catch { /* invalid path */ }
-        const context = experienceSessionId
-          ? findKnowledgeDebuggerContext(observationsDir, experienceSessionId)
-          : undefined;
-        if (!context) {
-          res.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
-          res.end(JSON.stringify({ error: 'experience_session_not_found' }));
-          return;
-        }
-        res.writeHead(200, {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Cache-Control': 'no-store',
-        });
-        res.end(JSON.stringify(loadObservationSourceRecordArchive(context.sourceRecordRef, observationsDir)));
-        return;
-      }
-
-      if (path === '/api/observe-inbox') {
-        const severity = parsed.searchParams.get('severity');
-        const skill = parsed.searchParams.get('skill');
-        const limitRaw = parsed.searchParams.get('limit');
-        const limit = limitRaw ? Math.max(1, Number(limitRaw) || 0) : 0;
-        let items = queryObservationInbox(observationsDir);
-        if (skill) {
-          items = items.filter((item) => item.skillName === skill);
-        }
-        if (severity === 'high' || severity === 'medium' || severity === 'low' || severity === 'noise') {
-          items = items.filter((item) => item.severity === severity);
-        }
-        if (limit > 0) items = items.slice(0, limit);
-        res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
-        res.end(JSON.stringify(items));
-        return;
-      }
-
-      if (path === '/api/observe-inbox/diagnostics') {
-        const idx = buildSkillIndex(analysesDir, doctorsDir, observationsDir, skillIndexOptions());
-        res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
-        res.end(JSON.stringify({
-          sourceCoverage: idx.diagnosisSummary.sourceCoverage,
-          summary: idx.diagnosisSummary,
-          bySkill: Object.fromEntries(idx.diagnosticsBySkill),
-          active: activeStudioDiagnostics({
-            schemaVersion: 1,
-            generatedAt: new Date().toISOString(),
-            sourceCoverage: idx.diagnosisSummary.sourceCoverage,
-            bySkill: Object.fromEntries(idx.diagnosticsBySkill),
-          }),
-        }));
-        return;
-      }
-
-      if (path === '/api/observe-inbox/show') {
-        const id = parsed.searchParams.get('id') || '';
-        const item = id ? findObservationInboxItem(id, observationsDir) : null;
-        res.writeHead(item ? 200 : 404, { 'Content-Type': 'application/json; charset=utf-8' });
-        res.end(JSON.stringify(item ? { id, text: formatObservationShow(item) } : { error: 'observation not found' }));
-        return;
-      }
-
-      if (path === '/api/observe-inbox/review-state') {
-        if (req.method === 'GET') {
-          res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
-          res.end(JSON.stringify(loadObservationReviewState(observationsDir)));
-          return;
-        }
-        if (req.method === 'POST') {
-          assertTrustedMutationRequest(req);
-          const body = await readJsonObjectBody(req) as Partial<ObservationReviewStateUpdate>;
-          const targetType = body.targetType as ObservationReviewStateUpdate['targetType'];
-          const targetId = body.targetId as string;
-          const verdict = body.verdict as ObservationReviewStateUpdate['verdict'];
-          const now = new Date().toISOString();
-          const state = updateObservationReviewState(observationsDir, {
-            targetType,
-            targetId,
-            verdict,
-            note: body.note,
-            reason: body.reason,
-            metricKey: body.metricKey as ObservationReviewStateUpdate['metricKey'],
-            metricScope: body.metricScope as ObservationReviewStateUpdate['metricScope'],
-            metricScopeId: body.metricScopeId,
-            traceId: body.traceId,
-            sourceTrace: body.sourceTrace,
-            sessionId: body.sessionId,
-            messageIndex: body.messageIndex,
-            messageUuid: body.messageUuid,
-            callInstanceId: body.callInstanceId,
-            toolUseId: body.toolUseId,
-            snippet: body.snippet,
-          }, now);
-          res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
-          res.end(JSON.stringify(state));
-          return;
-        }
-        if (req.method === 'DELETE') {
-          assertTrustedMutationRequest(req);
-          const targetType = parsed.searchParams.get('targetType') as ObservationReviewStateUpdate['targetType'];
-          const targetId = parsed.searchParams.get('targetId') ?? '';
-          const state = deleteObservationReviewState(observationsDir, targetType, targetId);
-          res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
-          res.end(JSON.stringify(state));
-          return;
-        }
-        res.writeHead(405, { 'Content-Type': 'application/json; charset=utf-8' });
-        res.end(JSON.stringify({ error: 'method not allowed' }));
-        return;
-      }
+      if (await observationRoutes({
+        request: req,
+        response: res,
+        url: parsed,
+        path,
+        lang,
+        analysesDir,
+        doctorsDir,
+      })) return;
 
       const doctorDetailMatch = path.match(/^\/doctors\/(.+)$/);
       if (doctorDetailMatch) {

--- a/src/studio/http/routes/observations.ts
+++ b/src/studio/http/routes/observations.ts
@@ -1,0 +1,258 @@
+import { activeStudioDiagnostics } from '../../../diagnosis/studio-projection.js';
+import {
+  findObservationInboxItem,
+  formatObservationShow,
+  queryObservationInbox,
+} from '../../../observability/inbox.js';
+import { buildObservationInboxViewModel } from '../../../observability/inbox-view-model.js';
+import { buildKnowledgeDebuggerViewModel } from '../../../observability/knowledge-debugger.js';
+import {
+  deleteObservationReviewState,
+  loadObservationReviewState,
+  updateObservationReviewState,
+  type ObservationReviewStateUpdate,
+} from '../../../observability/review-state.js';
+import {
+  loadObservationSourceRecordArchive,
+  summarizeObservationSourceRecordArchive,
+} from '../../../observability/source-record-archive.js';
+import { buildSkillIndex } from '../../application/index.js';
+import { renderKnowledgeDebuggerPage } from '../../presentation/knowledge-debugger-renderer.js';
+import { DEFAULT_LANG } from '../../presentation/layout.js';
+import { renderObservationInboxPage } from '../../presentation/observation-inbox-renderer.js';
+import {
+  assertTrustedMutationRequest,
+  readJsonObjectBody,
+} from '../request-errors.js';
+import type { StudioRouteContext } from './contracts.js';
+
+interface ObservationRoutesOptions {
+  readonly observationsDir: string;
+  readonly includeObserveCards: boolean;
+  readonly includeDoctorCards: boolean;
+}
+
+export interface ObservationRouteContext extends StudioRouteContext {
+  readonly analysesDir: string;
+  readonly doctorsDir: string;
+}
+
+export type ObservationRouteHandler = (
+  context: ObservationRouteContext,
+) => boolean | Promise<boolean>;
+
+function findKnowledgeDebuggerContext(observationsDir: string, experienceSessionId: string) {
+  const inbox = buildObservationInboxViewModel(observationsDir);
+  const report = inbox.reports.find((candidate) =>
+    candidate.experience?.sessions.some((session) => session.id === experienceSessionId)
+  );
+  const session = report?.experience?.sessions.find((candidate) => candidate.id === experienceSessionId);
+  if (!report || !session) return undefined;
+  const sourceRecordRef = report.meta.sourceRecordArchives?.find((candidate) =>
+    candidate.experienceSessionId === experienceSessionId
+  );
+  return { report, session, sourceRecordRef };
+}
+
+export function createObservationRoutes({
+  observationsDir,
+  includeObserveCards,
+  includeDoctorCards,
+}: ObservationRoutesOptions): ObservationRouteHandler {
+  return async ({
+    request,
+    response,
+    url,
+    path,
+    lang,
+    analysesDir,
+    doctorsDir,
+  }): Promise<boolean> => {
+    const legacyRedirect = ((): { to: string; status: 302 | 307 } | undefined => {
+      if (path === '/observations' || path === '/observations/inbox') {
+        return { to: '/observe-inbox', status: 302 };
+      }
+      if (path === '/api/observations/inbox') return { to: '/api/observe-inbox', status: 307 };
+      if (path === '/api/observations/show') return { to: '/api/observe-inbox/show', status: 307 };
+      if (path === '/api/observations/diagnostics') return { to: '/api/observe-inbox/diagnostics', status: 307 };
+      if (path === '/api/observations/review-state') return { to: '/api/observe-inbox/review-state', status: 307 };
+      return undefined;
+    })();
+    if (legacyRedirect) {
+      response.writeHead(legacyRedirect.status, { Location: legacyRedirect.to + url.search });
+      response.end();
+      return true;
+    }
+
+    if (path === '/observe-inbox') {
+      const skill = url.searchParams.get('skill') || undefined;
+      const html = renderObservationInboxPage(
+        buildObservationInboxViewModel(observationsDir, { skill }),
+        lang,
+      );
+      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      response.end(html);
+      return true;
+    }
+
+    const knowledgeDebuggerMatch = path.match(/^\/observe-debugger\/(.+)$/);
+    if (knowledgeDebuggerMatch) {
+      let experienceSessionId = '';
+      try { experienceSessionId = decodeURIComponent(knowledgeDebuggerMatch[1]); } catch { /* invalid path */ }
+      const context = experienceSessionId
+        ? findKnowledgeDebuggerContext(observationsDir, experienceSessionId)
+        : undefined;
+      if (!context) {
+        response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        response.end(lang === 'en' ? 'experience session not found' : '观测会话不存在');
+        return true;
+      }
+      const targetTurnId = url.searchParams.get('turnId')?.trim();
+      if (!targetTurnId) {
+        const langQuery = lang === DEFAULT_LANG ? '' : '?lang=en';
+        response.writeHead(302, {
+          Location: `/conversations/${encodeURIComponent(context.session.threadId)}${langQuery}`,
+        });
+        response.end();
+        return true;
+      }
+      if (!context.session.turns.some((turn) => turn.turnId === targetTurnId)) {
+        response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        response.end(lang === 'en' ? 'task turn not found' : '任务不存在');
+        return true;
+      }
+      const html = renderKnowledgeDebuggerPage(
+        buildKnowledgeDebuggerViewModel(
+          context.session,
+          targetTurnId,
+          context.report.meta.ingestion,
+          summarizeObservationSourceRecordArchive(context.sourceRecordRef),
+        ),
+        lang,
+        {
+          sourceRecordsEndpoint: `/api/observe-debugger/${encodeURIComponent(experienceSessionId)}/source-records`,
+        },
+      );
+      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      response.end(html);
+      return true;
+    }
+
+    const knowledgeDebuggerSourceMatch = path.match(/^\/api\/observe-debugger\/(.+)\/source-records$/);
+    if (knowledgeDebuggerSourceMatch) {
+      let experienceSessionId = '';
+      try { experienceSessionId = decodeURIComponent(knowledgeDebuggerSourceMatch[1]); } catch { /* invalid path */ }
+      const context = experienceSessionId
+        ? findKnowledgeDebuggerContext(observationsDir, experienceSessionId)
+        : undefined;
+      if (!context) {
+        response.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
+        response.end(JSON.stringify({ error: 'experience_session_not_found' }));
+        return true;
+      }
+      response.writeHead(200, {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      });
+      response.end(JSON.stringify(
+        loadObservationSourceRecordArchive(context.sourceRecordRef, observationsDir),
+      ));
+      return true;
+    }
+
+    if (path === '/api/observe-inbox') {
+      const severity = url.searchParams.get('severity');
+      const skill = url.searchParams.get('skill');
+      const limitRaw = url.searchParams.get('limit');
+      const limit = limitRaw ? Math.max(1, Number(limitRaw) || 0) : 0;
+      let items = queryObservationInbox(observationsDir);
+      if (skill) items = items.filter((item) => item.skillName === skill);
+      if (severity === 'high' || severity === 'medium' || severity === 'low' || severity === 'noise') {
+        items = items.filter((item) => item.severity === severity);
+      }
+      if (limit > 0) items = items.slice(0, limit);
+      response.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+      response.end(JSON.stringify(items));
+      return true;
+    }
+
+    if (path === '/api/observe-inbox/diagnostics') {
+      const index = buildSkillIndex(
+        analysesDir,
+        doctorsDir,
+        observationsDir,
+        { includeObserveCards, includeDoctorCards },
+      );
+      response.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+      response.end(JSON.stringify({
+        sourceCoverage: index.diagnosisSummary.sourceCoverage,
+        summary: index.diagnosisSummary,
+        bySkill: Object.fromEntries(index.diagnosticsBySkill),
+        active: activeStudioDiagnostics({
+          schemaVersion: 1,
+          generatedAt: new Date().toISOString(),
+          sourceCoverage: index.diagnosisSummary.sourceCoverage,
+          bySkill: Object.fromEntries(index.diagnosticsBySkill),
+        }),
+      }));
+      return true;
+    }
+
+    if (path === '/api/observe-inbox/show') {
+      const id = url.searchParams.get('id') || '';
+      const item = id ? findObservationInboxItem(id, observationsDir) : null;
+      response.writeHead(item ? 200 : 404, { 'Content-Type': 'application/json; charset=utf-8' });
+      response.end(JSON.stringify(
+        item ? { id, text: formatObservationShow(item) } : { error: 'observation not found' },
+      ));
+      return true;
+    }
+
+    if (path === '/api/observe-inbox/review-state') {
+      if (request.method === 'GET') {
+        response.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+        response.end(JSON.stringify(loadObservationReviewState(observationsDir)));
+        return true;
+      }
+      if (request.method === 'POST') {
+        assertTrustedMutationRequest(request);
+        const body = await readJsonObjectBody(request) as Partial<ObservationReviewStateUpdate>;
+        const state = updateObservationReviewState(observationsDir, {
+          targetType: body.targetType as ObservationReviewStateUpdate['targetType'],
+          targetId: body.targetId as string,
+          verdict: body.verdict as ObservationReviewStateUpdate['verdict'],
+          note: body.note,
+          reason: body.reason,
+          metricKey: body.metricKey as ObservationReviewStateUpdate['metricKey'],
+          metricScope: body.metricScope as ObservationReviewStateUpdate['metricScope'],
+          metricScopeId: body.metricScopeId,
+          traceId: body.traceId,
+          sourceTrace: body.sourceTrace,
+          sessionId: body.sessionId,
+          messageIndex: body.messageIndex,
+          messageUuid: body.messageUuid,
+          callInstanceId: body.callInstanceId,
+          toolUseId: body.toolUseId,
+          snippet: body.snippet,
+        }, new Date().toISOString());
+        response.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+        response.end(JSON.stringify(state));
+        return true;
+      }
+      if (request.method === 'DELETE') {
+        assertTrustedMutationRequest(request);
+        const targetType = url.searchParams.get('targetType') as ObservationReviewStateUpdate['targetType'];
+        const targetId = url.searchParams.get('targetId') ?? '';
+        const state = deleteObservationReviewState(observationsDir, targetType, targetId);
+        response.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+        response.end(JSON.stringify(state));
+        return true;
+      }
+      response.writeHead(405, { 'Content-Type': 'application/json; charset=utf-8' });
+      response.end(JSON.stringify({ error: 'method not allowed' }));
+      return true;
+    }
+
+    return false;
+  };
+}

--- a/test/studio/http/observation-routes-boundary.test.ts
+++ b/test/studio/http/observation-routes-boundary.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('Studio observation route boundary', () => {
+  it('keeps inbox, debugger, and review-state behavior out of request composition', () => {
+    const composition = readFileSync('src/studio/http/request-handler.ts', 'utf8');
+
+    expect(composition).toContain('createObservationRoutes');
+    for (const forbidden of [
+      'buildObservationInboxViewModel',
+      'buildKnowledgeDebuggerViewModel',
+      'renderObservationInboxPage',
+      'renderKnowledgeDebuggerPage',
+      'loadObservationSourceRecordArchive',
+      'updateObservationReviewState',
+      '/api/observe-inbox/review-state',
+    ]) {
+      expect(composition).not.toContain(forbidden);
+    }
+  });
+
+  it('keeps generic request validation independent from domain code', () => {
+    const requestErrors = readFileSync('src/studio/http/request-errors.ts', 'utf8');
+
+    expect(requestErrors).not.toMatch(/\.\.\/.*(?:observability|diagnosis|doctor|managed|measurement-artifacts)/);
+    expect(requestErrors).not.toContain('ObservationReviewState');
+  });
+});

--- a/test/studio/http/observation-routes-server.test.ts
+++ b/test/studio/http/observation-routes-server.test.ts
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, it } from 'vitest';
+import { createReportServer } from '../../../src/studio/http/report-server.js';
+
+interface HttpResponse {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+function request(
+  url: string,
+  options: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  } = {},
+): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const req = http.request({
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: `${parsed.pathname}${parsed.search}`,
+      method: options.method ?? 'GET',
+      headers: options.headers,
+    }, (res) => {
+      let body = '';
+      res.on('data', (chunk: Buffer) => { body += chunk; });
+      res.on('end', () => resolve({
+        status: res.statusCode ?? 0,
+        headers: res.headers,
+        body,
+      }));
+    });
+    req.on('error', reject);
+    if (options.body !== undefined) req.write(options.body);
+    req.end();
+  });
+}
+
+describe('Studio observation routes', () => {
+  const root = mkdtempSync(join(tmpdir(), 'omk-observation-routes-'));
+  const observationsDir = join(root, 'observations');
+  let server: ReturnType<typeof createReportServer> | undefined;
+  let baseUrl = '';
+
+  beforeAll(async () => {
+    server = createReportServer({
+      port: 0,
+      observationsDir,
+      analysesDir: join(root, 'analyses'),
+      doctorsDir: join(root, 'doctors'),
+    });
+    baseUrl = await server.start();
+  });
+
+  afterAll(async () => {
+    await server?.stop();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('serves the canonical inbox routes and preserves legacy redirect semantics', async () => {
+    const page = await request(`${baseUrl}/observe-inbox?skill=audit`);
+    assert.equal(page.status, 200);
+
+    const items = await request(`${baseUrl}/api/observe-inbox?severity=high&limit=1`);
+    assert.equal(items.status, 200);
+    assert.deepEqual(JSON.parse(items.body), []);
+
+    const pageRedirect = await request(`${baseUrl}/observations/inbox?skill=audit`);
+    assert.equal(pageRedirect.status, 302);
+    assert.equal(pageRedirect.headers.location, '/observe-inbox?skill=audit');
+
+    const apiRedirect = await request(
+      `${baseUrl}/api/observations/review-state?targetType=skill&targetId=audit`,
+      { method: 'DELETE' },
+    );
+    assert.equal(apiRedirect.status, 307);
+    assert.equal(
+      apiRedirect.headers.location,
+      '/api/observe-inbox/review-state?targetType=skill&targetId=audit',
+    );
+  });
+
+  it('validates and persists review-state mutations through the shared request boundary', async () => {
+    const endpoint = `${baseUrl}/api/observe-inbox/review-state`;
+    const contentTypeRejected = await request(endpoint, {
+      method: 'POST',
+      body: '{}',
+    });
+    assert.equal(contentTypeRejected.status, 415);
+
+    const crossOriginRejected = await request(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://untrusted.example',
+      },
+      body: '{}',
+    });
+    assert.equal(crossOriginRejected.status, 403);
+
+    const malformed = await request(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '[]',
+    });
+    assert.equal(malformed.status, 400);
+
+    const saved = await request(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targetType: 'skill',
+        targetId: 'audit',
+        verdict: 'reviewed',
+      }),
+    });
+    assert.equal(saved.status, 200);
+    assert.equal(JSON.parse(saved.body).entries['skill:audit'].verdict, 'reviewed');
+
+    const loaded = await request(endpoint);
+    assert.equal(loaded.status, 200);
+    assert.equal(JSON.parse(loaded.body).entries['skill:audit'].targetId, 'audit');
+
+    const deleted = await request(`${endpoint}?targetType=skill&targetId=audit`, {
+      method: 'DELETE',
+    });
+    assert.equal(deleted.status, 200);
+    assert.equal(JSON.parse(deleted.body).entries['skill:audit'], undefined);
+
+    const unsupported = await request(endpoint, { method: 'PUT' });
+    assert.equal(unsupported.status, 405);
+  });
+
+  it('uses one resolved directory snapshot per diagnostics request', async () => {
+    let analysesResolutions = 0;
+    let doctorResolutions = 0;
+    const snapshotServer = createReportServer({
+      port: 0,
+      observationsDir,
+      analysesDir: () => {
+        analysesResolutions += 1;
+        return join(root, 'analyses');
+      },
+      doctorsDir: () => {
+        doctorResolutions += 1;
+        return join(root, 'doctors');
+      },
+    });
+    const snapshotUrl = await snapshotServer.start();
+    try {
+      const diagnostics = await request(`${snapshotUrl}/api/observe-inbox/diagnostics`);
+      assert.equal(diagnostics.status, 200);
+      assert.equal(analysesResolutions, 1);
+      assert.equal(doctorResolutions, 1);
+    } finally {
+      await snapshotServer.stop();
+    }
+  });
+});


### PR DESCRIPTION
## 用户影响

Studio 的观测收件箱、任务调试、诊断与人工复核行为保持不变；路由职责从全局请求组合器收拢到独立的 Observation 能力边界，后续可以独立演进和验证。

## 架构边界

Observation 路由显式接收单次请求解析出的报告目录快照，避免动态 project/global 解析在同一请求内产生口径漂移。通用 JSON 请求校验与同源写入保护下沉为 HTTP 基础能力，不依赖观测领域。

## 迁移说明

无用户迁移要求；现有 canonical URL 与入口行为不变。

## 测量学说明

本次仅调整 Studio 交付层的所有权与组合方式，不修改 Report schema、评分 prompt、五层评分管道、统计公式或观测指标语义，不影响跨版本可比性。

Part of #562。