### PR TITLE
refactor(shared): 归还领域解析器所有权

### DIFF
--- a/src/artifact-graph/doctor.ts
+++ b/src/artifact-graph/doctor.ts
@@ -3,14 +3,14 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 import { cardFileName, graphFileName, safeArtifactFileStem } from '../measurement-artifacts/file-names.js';
 import { hashArtifactSource } from '../inputs/content-hash.js';
-import { parseArtifactGraphDocument } from '../shared/artifact-graph.js';
+import { parseArtifactGraphDocument } from './schema.js';
 import { writeJsonFileAtomic } from '../shared/atomic-json.js';
 import {
   extractMarkdownStepWorkflows,
   extractSkillHardRules,
   extractSkillWorkflows,
   parseSkillFrontmatter,
-} from '../shared/hard-rules.js';
+} from '../skill-definition/hard-rules.js';
 import type {
   DoctorReport,
   DoctorRuleResult,

--- a/src/artifact-graph/schema.ts
+++ b/src/artifact-graph/schema.ts
@@ -4,8 +4,8 @@ import type {
   ArtifactGraphEvidenceRef,
   ArtifactGraphNode,
   ArtifactGraphSummary,
-} from '../artifact-graph/contracts.js';
-import { normalizeRfc3339Timestamp } from './timestamp.js';
+} from './contracts.js';
+import { normalizeRfc3339Timestamp } from '../shared/timestamp.js';
 
 const SOURCE_KINDS = new Set(['doctor', 'eval', 'observe']);
 const ARTIFACT_KINDS = new Set(['skill', 'prompt', 'agent', 'workflow']);

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -14,7 +14,7 @@ import { doctorReportFileStem, isReportFileName, reportFilePath, reportFileStem 
 import { projectDoctorsDir, globalDoctorsDir } from '../../measurement-artifacts/directories.js';
 import { persistDoctorGraphSidecars, removeDoctorGraphSidecars } from '../../artifact-graph/doctor.js';
 import type { DoctorOutcome, DoctorReport, DoctorRule, DoctorRuleLike } from '../../doctor/contracts.js';
-import { parseDoctorReport } from '../../shared/doctor-report.js';
+import { parseDoctorReport } from '../../doctor/report-parser.js';
 import { writeJsonFileAtomic } from '../../shared/atomic-json.js';
 
 export default class Doctor extends BaseCommand {

--- a/src/cli/lib/run-core-evaluation.ts
+++ b/src/cli/lib/run-core-evaluation.ts
@@ -27,7 +27,7 @@ import {
 } from '../../eval-workflows/downstream-projections/index.js';
 import { discoverBatchSkills } from '../../inputs/skill-loader.js';
 import { projectReportsDir, globalReportsDir } from '../../measurement-artifacts/directories.js';
-import { generateRunId } from '../../shared/run-id.js';
+import { generateRunId } from '../../measurement-artifacts/run-id.js';
 import type { RunConfig } from './parse-run-config.js';
 import type { CliLang } from './i18n.js';
 

--- a/src/diagnosis/contracts/parser.ts
+++ b/src/diagnosis/contracts/parser.ts
@@ -3,8 +3,8 @@ import type {
   DiagnosisBundle,
   DiagnosisEvidenceRef,
   DiagnosisOccurrence,
-} from '../diagnosis/contracts.js';
-import { isRfc3339Timestamp } from './timestamp.js';
+} from '../contracts.js';
+import { isRfc3339Timestamp } from '../../shared/timestamp.js';
 
 const DIAGNOSIS_TYPES = new Set([
   'definition_gap',

--- a/src/doctor/report-parser.ts
+++ b/src/doctor/report-parser.ts
@@ -2,8 +2,8 @@ import type {
   DoctorReport,
   DoctorRuleResult,
   DoctorSkillStatus,
-} from '../doctor/contracts.js';
-import { normalizeRfc3339Timestamp } from './timestamp.js';
+} from './contracts.js';
+import { normalizeRfc3339Timestamp } from '../shared/timestamp.js';
 
 const RULE_STATUSES = new Set(['pass', 'warn', 'fail', 'skipped']);
 const SEVERITIES = new Set(['fatal', 'warn', 'info']);

--- a/src/doctor/rules.ts
+++ b/src/doctor/rules.ts
@@ -26,7 +26,7 @@ import yaml from 'js-yaml';
 import { tDoctorMessage } from './messages.js';
 import type { Lang } from '../shared/language.js';
 import { preflightDependencies } from '../preflight/dependencies.js';
-import { validateSkillHardRules, validateSkillWorkflows } from '../shared/hard-rules.js';
+import { validateSkillHardRules, validateSkillWorkflows } from '../skill-definition/hard-rules.js';
 import type { DependencyIssue } from '../preflight/dependencies.js';
 import type {
   DoctorRule,

--- a/src/dsh-plugin/core-command.ts
+++ b/src/dsh-plugin/core-command.ts
@@ -43,7 +43,7 @@ import type {
 } from '../eval-workflows/runtime-adapter/index.js';
 import type { EvalConfig } from '../inputs/contracts/config.js';
 import type { JudgeConfig } from '../grading/contracts/config.js';
-import { generateRunId } from '../shared/run-id.js';
+import { generateRunId } from '../measurement-artifacts/run-id.js';
 import {
   createDshHostCoreExecutorAdapter,
   createDshHostCoreSchemaValidators,

--- a/src/eval-workflows/downstream-projections/artifact-graph.ts
+++ b/src/eval-workflows/downstream-projections/artifact-graph.ts
@@ -4,7 +4,7 @@ import {
   type EvaluationRecord,
   type ExecutionRecord,
 } from '../../evaluation-core/contracts/index.js';
-import { parseArtifactGraphDocument } from '../../shared/artifact-graph.js';
+import { parseArtifactGraphDocument } from '../../artifact-graph/schema.js';
 import type {
   ArtifactGraphDocument,
   ArtifactGraphEdge,

--- a/src/inputs/skill-loader.ts
+++ b/src/inputs/skill-loader.ts
@@ -2,7 +2,7 @@ import { readFileSync, existsSync, readdirSync, statSync, realpathSync, mkdtempS
 import { resolve, join, relative, dirname, basename, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
-import { extractSkillHardRules, extractSkillWorkflows } from '../shared/hard-rules.js';
+import { extractSkillHardRules, extractSkillWorkflows } from '../skill-definition/hard-rules.js';
 import { hashArtifactSource, hashBytes, isDistributablePath } from './content-hash.js';
 import { materializeIsolatedCopy } from './materialize-copy.js';
 import { findFlatSkillSamplesPath, findSkillSamplesPath } from './sample-locator.js';

--- a/src/measurement-artifacts/run-id.ts
+++ b/src/measurement-artifacts/run-id.ts
@@ -1,4 +1,4 @@
-import { randomRunToken, runTimestamp } from '../measurement-artifacts/file-names.js';
+import { randomRunToken, runTimestamp } from './file-names.js';
 
 function runIdSuffix(): string {
   return `${runTimestamp()}-${randomRunToken()}`;

--- a/src/observability/experience-frontmatter.ts
+++ b/src/observability/experience-frontmatter.ts
@@ -22,7 +22,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { parseSkillFrontmatter, validateSkillHardRules, validateSkillWorkflows } from '../shared/hard-rules.js';
+import { parseSkillFrontmatter, validateSkillHardRules, validateSkillWorkflows } from '../skill-definition/hard-rules.js';
 import { findSkillMdPath } from './skill-chain.js';
 import type { ExperienceRuntimeSkillType } from './contracts/experience.js';
 

--- a/src/observability/inbox.ts
+++ b/src/observability/inbox.ts
@@ -46,7 +46,7 @@ import {
   normalizeObservationExperienceReport,
   type PersistedObservationExperienceReport,
 } from './experience.js';
-import { parseDiagnosisBundle } from '../shared/diagnosis-schema.js';
+import { parseDiagnosisBundle } from '../diagnosis/contracts/parser.js';
 import { parseTraceIngestionSummary } from './trace-ingestion.js';
 import { createTraceSessionIndex, traceSessionRefIdentity } from './trace-session-index.js';
 import { isInstalledSkillAssetPath } from './trace-attribution.js';

--- a/src/observability/skill-chain.ts
+++ b/src/observability/skill-chain.ts
@@ -5,7 +5,7 @@ import {
   extractMarkdownStepWorkflows,
   validateSkillHardRules,
   validateSkillWorkflows,
-} from '../shared/hard-rules.js';
+} from '../skill-definition/hard-rules.js';
 import type { SkillHardRule, SkillWorkflow } from '../skill-definition/contracts.js';
 import { incrementRecordCount } from '../shared/record-count.js';
 import type {

--- a/src/skill-definition/hard-rules.ts
+++ b/src/skill-definition/hard-rules.ts
@@ -6,7 +6,7 @@ import type {
   SkillWorkflow,
   SkillWorkflowNode,
   SkillWorkflowsValidationResult,
-} from '../skill-definition/contracts.js';
+} from './contracts.js';
 
 interface YamlErrorLike {
   mark?: { line: number };

--- a/src/studio/application/skill-index.ts
+++ b/src/studio/application/skill-index.ts
@@ -16,8 +16,8 @@ import {
 import { confidenceOf, toolStabilityOf, type SkillHealthReport } from '../../observability/skill-health-analyzer.js';
 import { DEFAULT_OBSERVATIONS_DIR, loadLatestObservationInboxReports } from '../../observability/inbox.js';
 import { parseSkillHealthReport } from '../../observability/skill-health-report.js';
-import { parseArtifactGraphDocument } from '../../shared/artifact-graph.js';
-import { parseDoctorReport } from '../../shared/doctor-report.js';
+import { parseArtifactGraphDocument } from '../../artifact-graph/schema.js';
+import { parseDoctorReport } from '../../doctor/report-parser.js';
 import { ownRecordValue } from '../../shared/record-count.js';
 import type {
   Insight,

--- a/src/studio/http/routes/knowledge.ts
+++ b/src/studio/http/routes/knowledge.ts
@@ -25,7 +25,7 @@ import {
   type SkillHealthReport,
 } from '../../../observability/skill-health-analyzer.js';
 import { parseSkillHealthReport } from '../../../observability/skill-health-report.js';
-import { parseDoctorReport } from '../../../shared/doctor-report.js';
+import { parseDoctorReport } from '../../../doctor/report-parser.js';
 import type { Lang } from '../../../shared/language.js';
 import { buildSkillIndex } from '../../application/index.js';
 import { renderDoctorDetail } from '../../presentation/doctor-detail-renderer.js';

--- a/test/architecture/import-boundaries.test.ts
+++ b/test/architecture/import-boundaries.test.ts
@@ -101,11 +101,42 @@ const RULES: ForbiddenRule[] = [
     reason: 'Studio presentation 是无 HTTP 状态的纯呈现层，不依赖请求、响应或 server 生命周期。',
   },
   {
+    from: 'shared/',
+    to: 'artifact-graph/',
+    reason: 'shared 是跨领域叶子依赖；Artifact Graph parser 由 artifact-graph 领域拥有。',
+  },
+  {
+    from: 'shared/',
+    to: 'diagnosis/',
+    reason: 'shared 是跨领域叶子依赖；Diagnosis parser 由 diagnosis 领域拥有。',
+  },
+  {
+    from: 'shared/',
+    to: 'doctor/',
+    reason: 'shared 是跨领域叶子依赖；Doctor parser 与 prompt 由 doctor 领域拥有。',
+    whitelist: [
+      // PR7c 迁移 doctor prompt 后删除这两条例外。
+      'shared/llm-prompts/skill-health.ts::doctor/health/dimension-spec.ts',
+      'shared/llm-prompts/skill-health-merge.ts::doctor/health/dimension-spec.ts',
+    ],
+  },
+  {
+    from: 'shared/',
+    to: 'skill-definition/',
+    reason: 'shared 是跨领域叶子依赖；skill frontmatter 与 hard rules 由 skill-definition 领域拥有。',
+  },
+  {
+    from: 'shared/',
+    to: 'measurement-artifacts/',
+    reason: 'shared 是跨领域叶子依赖；run id 分配依赖产物命名策略，应由 measurement-artifacts 拥有。',
+  },
+  {
     from: 'observability/',
     to: 'diagnosis/',
     reason: 'observability 是 diagnosis 的下游消费者，不应反向依赖 diagnosis 实现；只允许引用纯 contracts。',
     whitelist: [
       'observability/contracts/inbox.ts::diagnosis/contracts.ts',
+      'observability/inbox.ts::diagnosis/contracts/parser.ts',
     ],
   },
   {

--- a/test/artifact-graph/schema.test.ts
+++ b/test/artifact-graph/schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
-import { parseArtifactGraphDocument } from '../../src/shared/artifact-graph.js';
+import { parseArtifactGraphDocument } from '../../src/artifact-graph/schema.js';
 import type { ArtifactGraphDocument } from '../../src/artifact-graph/contracts.js';
 
 function graph(): ArtifactGraphDocument {

--- a/test/diagnosis/observe-mapper.test.ts
+++ b/test/diagnosis/observe-mapper.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { buildObserveDiagnostics, maxLifecycle } from '../../src/diagnosis/observe-mapper.js';
 import { activeStudioDiagnostics, buildStudioDiagnosisSummary, mergeDiagnosisBundles } from '../../src/diagnosis/studio-projection.js';
-import { parseDiagnosisBundle } from '../../src/shared/diagnosis-schema.js';
+import { parseDiagnosisBundle } from '../../src/diagnosis/contracts/parser.js';
 
 describe('buildObserveDiagnostics', () => {
   it('keeps prototype-shaped skill names as ordinary diagnosis groups', () => {

--- a/test/diagnosis/schema.test.ts
+++ b/test/diagnosis/schema.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import { buildObserveDiagnostics } from '../../src/diagnosis/observe-mapper.js';
-import { parseDiagnosisBundle } from '../../src/shared/diagnosis-schema.js';
+import { parseDiagnosisBundle } from '../../src/diagnosis/contracts/parser.js';
 
 function validBundle() {
   return buildObserveDiagnostics({

--- a/test/doctor/report-parser.test.ts
+++ b/test/doctor/report-parser.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
-import { parseDoctorReport } from '../../src/shared/doctor-report.js';
+import { parseDoctorReport } from '../../src/doctor/report-parser.js';
 import type { DoctorReport } from '../../src/doctor/contracts.js';
 
 function report(): DoctorReport {

--- a/test/eval-workflows/downstream-projections.test.ts
+++ b/test/eval-workflows/downstream-projections.test.ts
@@ -18,7 +18,7 @@ import {
   type EvaluationSeriesDefinitionInput,
   type RuntimeIdentity,
 } from '../../src/index.js';
-import { parseArtifactGraphDocument } from '../../src/shared/artifact-graph.js';
+import { parseArtifactGraphDocument } from '../../src/artifact-graph/schema.js';
 import {
   createNodeCoreRunArtifactStore,
   type StoredCoreRunArtifacts,


### PR DESCRIPTION
## 用户影响

无用户可见行为变化。Artifact Graph、Diagnosis、Doctor、skill frontmatter／hard rules 与 run id 的实现从 shared 回到各自领域，调用方改为直接依赖领域入口。

## 架构边界

shared 开始恢复为跨领域叶子依赖。Diagnosis parser 位于纯 contracts 子边界，Observation Inbox 只依赖该契约入口；新增增量守卫，禁止本轮已清理的领域反向依赖重新进入 shared。

## 迁移说明

这些路径均为仓库内部模块，不提供旧路径兼容层；npm 公共导出不变，用户无需迁移。

## 测量学说明

本次为高相似度文件移动与 import 更新，不修改持久化 schema、解析规则、run id 语义、评分 prompt、评分管道或统计公式，不影响跨版本可比性。

Part of #562。