### PR TITLE
refactor(observability): 分离体验时间线投影

### DIFF
--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -1,5 +1,3 @@
-import { createHash } from 'node:crypto';
-import { basename } from 'node:path';
 import { isTraceSourceKind as isObservationSourceKind } from '../shared/trace-source-kind.js';
 import type {
   ExperienceAssistiveInference,
@@ -82,8 +80,6 @@ import { observationMetricAnnotationVerdict, observationReviewStateKey } from '.
 import {
   correlateTraceToolEvents,
   normalizeTraceTimestamp,
-  type TraceEvent,
-  type TraceMessageEvent,
   type TraceSession,
 } from './trace-ir.js';
 import {
@@ -93,8 +89,22 @@ import {
 } from './trace-segmenter.js';
 import { createTraceSessionIndex, traceSessionRefIdentity } from './trace-session-index.js';
 import { reconstructExperienceTurns } from './turn-index.js';
-import { extractCommandEnvelopeText, stripCommandEnvelopeText } from './trace-attribution.js';
-import { hasAssistantDeliverableArtifactText, hasAssistantDeliverySignalText, hasUserHardRuleText, isAssistantProgressUpdateText, isAssistantProtocolReplyText, isSyntheticUserMessageText, isToolResultFailureText, isUserInteractionMetricText } from './text-signals.js';
+import { hasAssistantDeliverableArtifactText, hasUserHardRuleText, isAssistantProgressUpdateText, isSyntheticUserMessageText, isToolResultFailureText, isUserInteractionMetricText } from './text-signals.js';
+import {
+  compareTimelineEvents,
+  hashParts,
+  snippet,
+  uniqueTimelineEvents,
+} from './experience/support.js';
+import {
+  buildInvocationTimeline,
+  buildSessionTimelineTree,
+  experienceSessionGroupKey,
+  groupSessionsByExperienceKey,
+  hasAssistantTurnFailedText,
+  isAssistantDeliveryEvent,
+  segmentRecordBounds,
+} from './experience/timeline.js';
 import { durationMsBetween } from '../shared/time.js';
 import {
   incrementRecordCount,
@@ -129,6 +139,7 @@ export {
   hasUserGoalShiftSignal,
 } from './feedback-matchers.js';
 export type { TextMatchRange } from './feedback-matchers.js';
+export { projectTraceSessionTimeline } from './experience/timeline.js';
 
 export type {
   ExperienceAssistiveInference,
@@ -2959,142 +2970,9 @@ function metricTimelineForSegment(
     ));
 }
 
-function logicalSessionId(session: TraceSession): string {
-  return session.rootRunId;
-}
-
-function experienceSessionGroupKey(session: TraceSession): string {
-  const logicalId = logicalSessionId(session);
-  if (session.role !== 'standalone' && session.groupPath) {
-    return `group:${session.groupPath}\u0000${logicalId}`;
-  }
-  return `trace:${session.traceId}`;
-}
-
-function groupSessionsByExperienceKey(sessions: TraceSession[]): Map<string, TraceSession[]> {
-  const groups = new Map<string, TraceSession[]>();
-  for (const session of sessions) {
-    const key = experienceSessionGroupKey(session);
-    const group = groups.get(key) ?? [];
-    group.push(session);
-    groups.set(key, group);
-  }
-  for (const [key, group] of groups.entries()) {
-    groups.set(key, group.sort(compareSessionsForTimeline));
-  }
-  return groups;
-}
-
-function compareSessionsForTimeline(a: TraceSession, b: TraceSession): number {
-  const roleRank = (session: TraceSession): number => session.role === 'main' ? 0 : session.role === 'standalone' ? 1 : 2;
-  const rank = roleRank(a) - roleRank(b);
-  if (rank !== 0) return rank;
-  const time = (a.startTimestamp ?? '').localeCompare(b.startTimestamp ?? '');
-  if (time !== 0) return time;
-  return a.sourcePath.localeCompare(b.sourcePath)
-    || a.traceId.localeCompare(b.traceId);
-}
-
 function timestampsOverlap(aStart: string, aEnd: string, bStart: string, bEnd: string): boolean {
   if (!aStart || !aEnd || !bStart || !bEnd) return true;
   return aStart <= bEnd && bStart <= aEnd;
-}
-
-function segmentRecordBounds(session: TraceSession, segment: SkillSegment): { start: number; end: number } {
-  if (typeof segment.startRecordIndex === 'number' && typeof segment.endRecordIndex === 'number') {
-    const rawStart = eventIndexForSourceIndex(session, segment.startRecordIndex, 'first');
-    const rawEnd = eventIndexForSourceIndex(
-      session,
-      Math.max(segment.startRecordIndex, segment.endRecordIndex),
-      'last',
-    );
-    const humanStart = Math.min(rawStart, previousHumanUserRecordIndex(session, rawStart) ?? rawStart);
-    return {
-      start: includeLeadingRuntimeContext(session, humanStart),
-      end: includeTrailingDeliveryContext(session, Math.min(session.events.length, rawEnd + 1)),
-    };
-  }
-  const indexes = segment.toolCalls
-    .map((toolCall) => toolCall.messageIndex)
-    .filter((index): index is number => typeof index === 'number' && index >= 0);
-  if (indexes.length > 0) {
-    const firstEventIndex = eventIndexForSourceIndex(session, Math.min(...indexes), 'first');
-    const lastEventIndex = eventIndexForSourceIndex(session, Math.max(...indexes), 'last');
-    const start = Math.max(0, firstEventIndex - 3);
-    return {
-      start: Math.min(start, previousHumanUserRecordIndex(session, start) ?? start),
-      end: includeTrailingDeliveryContext(session, Math.min(session.events.length, lastEventIndex + 5)),
-    };
-  }
-  const timestampIndexes: number[] = [];
-  session.events.forEach((event, index) => {
-    const ts = event.timestamp;
-    if (ts && ts >= segment.startTimestamp && ts <= segment.endTimestamp) timestampIndexes.push(index);
-  });
-  if (timestampIndexes.length === 0) return { start: 0, end: Math.min(session.events.length, 12) };
-  const start = Math.max(0, Math.min(...timestampIndexes) - 2);
-  return {
-    start: Math.min(start, previousHumanUserRecordIndex(session, start) ?? start),
-    end: includeTrailingDeliveryContext(session, Math.min(session.events.length, Math.max(...timestampIndexes) + 3)),
-  };
-}
-
-function clampRecordIndex(session: TraceSession, index: number): number {
-  return Math.max(0, Math.min(session.events.length - 1, index));
-}
-
-function eventIndexForSourceIndex(
-  session: TraceSession,
-  sourceIndex: number,
-  edge: 'first' | 'last',
-): number {
-  if (edge === 'first') {
-    const index = session.events.findIndex((event) => event.sourceIndex >= sourceIndex);
-    return index < 0 ? clampRecordIndex(session, sourceIndex) : index;
-  }
-  for (let index = session.events.length - 1; index >= 0; index -= 1) {
-    if (session.events[index].sourceIndex <= sourceIndex) return index;
-  }
-  return 0;
-}
-
-function includeLeadingRuntimeContext(session: TraceSession, start: number): number {
-  let nextStart = start;
-  for (let index = start - 1; index >= 0; index -= 1) {
-    const events = timelineEventsFromTraceEvent(session, session.events[index], index);
-    if (events.length === 0) continue;
-    if (events.some((event) => event.kind === 'runtime_context')) {
-      nextStart = index;
-      continue;
-    }
-    break;
-  }
-  return nextStart;
-}
-
-function includeTrailingDeliveryContext(session: TraceSession, end: number): number {
-  const safeEnd = Math.min(session.events.length, Math.max(0, end));
-  const lookaheadEnd = Math.min(session.events.length, safeEnd + 8);
-  for (let index = safeEnd; index < lookaheadEnd; index += 1) {
-    const events = timelineEventsFromTraceEvent(session, session.events[index], index);
-    if (events.some((event) => event.kind === 'user_message')) break;
-    if (events.some(isAssistantDeliveryEvent)) return index + 1;
-  }
-  return safeEnd;
-}
-
-function previousHumanUserRecordIndex(session: TraceSession, start: number): number | undefined {
-  for (let index = Math.min(start, session.events.length - 1); index >= 0; index -= 1) {
-    const events = timelineEventsFromTraceEvent(session, session.events[index], index);
-    if (events.some((event) => event.kind === 'user_message')) return index;
-  }
-  return undefined;
-}
-
-function isAssistantDeliveryEvent(event: ExperienceTimelineEvent): boolean {
-  if (event.kind !== 'assistant_message') return false;
-  const text = event.fullText ?? event.snippet ?? '';
-  return hasAssistantDeliverySignalText(text);
 }
 
 function isAssistantDeliverableArtifactEvent(event: ExperienceTimelineEvent): boolean {
@@ -3119,366 +2997,6 @@ function hasRepeatedExecutionSignal(event: ExperienceTimelineEvent): boolean {
   if (event.kind !== 'assistant_message' && event.kind !== 'tool_use') return false;
   const text = `${event.label ?? ''} ${event.toolName ?? ''} ${event.fullText ?? event.snippet ?? ''}`;
   return /重复(?:执行|尝试|读取|搜索|调用)|再次(?:执行|读取|搜索|调用)|重新(?:执行|读取|搜索|调用|跑|运行)|再(?:执行|读取|搜索|调用|跑)一遍|重试|\b(?:retry|rerun)\b/i.test(text);
-}
-
-function buildInvocationTimeline(
-  session: TraceSession,
-  start: number,
-  end: number,
-  segment: SkillSegment,
-): ExperienceTimelineEvent[] {
-  const window = buildTimelineWindow(session, start, end);
-  const callInstanceIds = new Set(
-    segment.toolCalls.flatMap((toolCall) =>
-      toolCall.callInstanceId ? [toolCall.callInstanceId] : []
-    ),
-  );
-  const legacyCallIds = new Set(
-    segment.toolCalls.flatMap((toolCall) =>
-      !toolCall.callInstanceId && toolCall.toolUseId ? [toolCall.toolUseId] : []
-    ),
-  );
-  if (callInstanceIds.size === 0 && legacyCallIds.size === 0) return window;
-  const linkedResults = session.events.flatMap((event, eventIndex) =>
-    event.eventKind === 'tool_result'
-    && (
-      event.callInstanceId
-        ? callInstanceIds.has(event.callInstanceId)
-        : legacyCallIds.has(event.callId)
-    )
-    && (eventIndex < start || eventIndex >= end)
-      ? timelineEventsFromTraceEvent(session, event, eventIndex)
-      : [],
-  );
-  return uniqueTimelineEvents([...window, ...linkedResults]).sort(compareTimelineEvents);
-}
-
-function buildTimelineWindow(session: TraceSession, start: number, end: number): ExperienceTimelineEvent[] {
-  const events: ExperienceTimelineEvent[] = [];
-  const safeEnd = Math.min(session.events.length, Math.max(start, end));
-  for (let index = start; index < safeEnd; index += 1) {
-    events.push(...timelineEventsFromTraceEvent(session, session.events[index], index));
-  }
-  return events.sort((a, b) => a.order - b.order);
-}
-
-/** Project one source-neutral Trace IR session into Studio's semantic timeline. */
-export function projectTraceSessionTimeline(session: TraceSession): ExperienceTimelineEvent[] {
-  return buildTimelineWindow(session, 0, session.events.length);
-}
-
-function timelineEventsFromTraceEvent(
-  session: TraceSession,
-  event: TraceEvent,
-  eventIndex: number,
-): ExperienceTimelineEvent[] {
-  const messageIndex = event.sourceIndex;
-  const base = {
-    traceId: session.traceId,
-    sourceTrace: session.sourcePath,
-    sessionId: logicalSessionId(session),
-    traceRole: session.role,
-    traceLabel: session.label,
-    messageIndex,
-    logicalMessageIndex: messageIndex,
-    sourceLineIndex: messageIndex,
-    messageUuid: event.sourceEventId ?? event.eventId,
-    sourceType: event.sourceType,
-    turnId: event.turnId,
-    timestamp: event.timestamp,
-  };
-  const order = eventIndex * 10;
-
-  if (event.eventKind === 'message' && event.role === 'user') {
-    return userTimelineEvents(event, base, order);
-  }
-  if (event.eventKind === 'message' && event.role === 'system') {
-    return [timelineEvent({
-      ...base,
-      kind: 'runtime_context',
-      role: 'tool',
-      order,
-      snippet: snippet(event.text, 700),
-      fullText: fullText(event.text),
-      label: 'system context',
-    })];
-  }
-  if (event.eventKind === 'message' && event.role === 'assistant') {
-    const protocolReply = isAssistantProtocolReplyText(event.text);
-    return [timelineEvent({
-      ...base,
-      kind: protocolReply ? 'runtime_context' : 'assistant_message',
-      role: 'assistant',
-      order,
-      model: event.model,
-      snippet: snippet(event.text, 700),
-      fullText: fullText(event.text),
-      label: protocolReply ? 'assistant protocol reply' : 'assistant message',
-    })];
-  }
-  if (event.eventKind === 'model_activity') {
-    return [timelineEvent({
-      ...base,
-      kind: 'model_activity',
-      role: 'assistant',
-      order,
-      model: event.model,
-      modelActivityKind: event.activityKind,
-      contentVisibility: event.contentVisibility,
-      contentSource: event.contentSource,
-      snippet: snippet(event.text, 700),
-      fullText: fullText(event.text),
-      label: 'model reasoning',
-    })];
-  }
-  if (event.eventKind === 'tool_call') {
-    const inputText = JSON.stringify(event.input);
-    return [timelineEvent({
-      ...base,
-      kind: 'tool_use',
-      role: 'assistant',
-      order,
-      callInstanceId: event.callInstanceId,
-      toolUseId: event.callId,
-      toolName: event.tool.displayName ?? event.tool.name,
-      snippet: snippet(inputText, 900),
-      fullText: fullText(inputText),
-      label: `tool_use ${event.tool.displayName ?? event.tool.name}`,
-    })];
-  }
-  if (event.eventKind === 'tool_result') {
-    const failed = event.status === 'failure';
-    return [timelineEvent({
-      ...base,
-      kind: 'tool_result',
-      role: 'tool',
-      order,
-      callInstanceId: event.callInstanceId,
-      toolUseId: event.callId,
-      toolStatus: event.status,
-      isError: failed,
-      snippet: snippet(event.output, 900),
-      fullText: fullText(event.output),
-      label: failed
-        ? 'tool result error'
-        : event.status === 'cancelled' ? 'tool result cancelled'
-        : event.status === 'unknown' ? 'tool result status unknown' : 'tool result',
-    })];
-  }
-  if (event.eventKind === 'lifecycle') {
-    return [timelineEvent({
-      ...base,
-      kind: 'lifecycle',
-      role: 'other',
-      order,
-      snippet: snippet(`${event.phase}${event.reason ? `: ${event.reason}` : ''}`, 700),
-      fullText: fullText(JSON.stringify(event)),
-      label: event.phase,
-    })];
-  }
-  if (event.eventKind === 'runtime_context') {
-    const details = JSON.stringify({
-      runtimeName: event.runtimeName,
-      runtimeVersion: event.runtimeVersion,
-      cwd: event.cwd,
-      workspaceRoots: event.workspaceRoots,
-      currentDate: event.currentDate,
-      timezone: event.timezone,
-      model: event.model,
-      modelProvider: event.modelProvider,
-      serviceTier: event.serviceTier,
-      reasoningEffort: event.reasoningEffort,
-      reasoningSummary: event.reasoningSummary,
-      personality: event.personality,
-      approvalPolicy: event.approvalPolicy,
-      approvalReviewer: event.approvalReviewer,
-      permissionProfile: event.permissionProfile,
-      sandboxMode: event.sandboxMode,
-      collaborationMode: event.collaborationMode,
-      realtimeActive: event.realtimeActive,
-      multiAgentMode: event.multiAgentMode,
-      multiAgentVersion: event.multiAgentVersion,
-      memoryMode: event.memoryMode,
-      historyMode: event.historyMode,
-      contextWindowId: event.contextWindowId,
-      parentRunId: event.parentRunId,
-      delegationDepth: event.delegationDepth,
-      sourceOrigin: event.sourceOrigin,
-      availableTools: event.availableTools,
-      instructions: event.instructions,
-      goal: event.goal,
-      goalStatus: event.goalStatus,
-      summary: event.summary,
-    });
-    const visible = event.summary
-      ?? event.goal
-      ?? event.instructions
-      ?? [event.runtimeName, event.runtimeVersion, event.cwd, event.model, event.reasoningEffort, event.collaborationMode]
-        .filter(Boolean)
-        .join(' · ');
-    return [timelineEvent({
-      ...base,
-      kind: 'runtime_context',
-      role: 'other',
-      order,
-      model: event.model,
-      runtimeKind: event.runtimeKind,
-      snippet: snippet(visible, 700),
-      fullText: fullText(details),
-      label: event.runtimeKind,
-    })];
-  }
-  if (event.eventKind === 'context_compaction') {
-    return [timelineEvent({
-      ...base,
-      kind: 'runtime_context',
-      role: 'other',
-      order,
-      runtimeKind: 'context_compaction',
-      snippet: snippet(event.summary ?? 'context compacted', 700),
-      fullText: fullText(JSON.stringify(event)),
-      label: 'context compacted',
-    })];
-  }
-  if (event.eventKind === 'agent_activity') {
-    const visible = event.text
-      ?? [event.activity, event.author, event.recipient, event.agentPath, event.agentId]
-        .filter(Boolean)
-        .join(' · ');
-    return [timelineEvent({
-      ...base,
-      kind: 'agent_activity',
-      role: 'other',
-      order,
-      snippet: snippet(visible, 700),
-      fullText: fullText(JSON.stringify({
-        activityKind: event.activityKind,
-        activity: event.activity,
-        author: event.author,
-        recipient: event.recipient,
-        agentId: event.agentId,
-        agentPath: event.agentPath,
-        text: event.text,
-      })),
-      label: event.activityKind === 'communication' ? 'agent communication' : 'agent status',
-    })];
-  }
-  if (event.eventKind === 'usage') {
-    const usageText = JSON.stringify({
-      model: event.model,
-      inputTokens: event.inputTokens,
-      outputTokens: event.outputTokens,
-      cacheReadTokens: event.cacheReadTokens,
-      cacheCreationTokens: event.cacheCreationTokens,
-      reasoningTokens: event.reasoningTokens,
-    });
-    return [timelineEvent({
-      ...base,
-      kind: 'runtime_context',
-      role: 'other',
-      order,
-      model: event.model,
-      runtimeKind: 'usage',
-      snippet: snippet(usageText, 700),
-      fullText: fullText(usageText),
-      label: 'token usage',
-    })];
-  }
-  if (event.eventKind === 'unknown') {
-    const rawText = safeRecordText(event.raw);
-    if (!hasAssistantTurnFailedText(rawText)) return [];
-    return [timelineEvent({
-      ...base,
-      kind: 'runtime_context',
-      role: 'other',
-      order,
-      snippet: snippet(rawText, 700),
-      fullText: fullText(rawText),
-      label: event.sourceType,
-    })];
-  }
-  return [];
-}
-
-function userTimelineEvents(
-  event: TraceMessageEvent,
-  base: Omit<ExperienceTimelineEvent, 'id' | 'kind' | 'order'>,
-  order: number,
-): ExperienceTimelineEvent[] {
-  const events: ExperienceTimelineEvent[] = [];
-  const commandEnvelope = extractCommandEnvelopeText(event.text);
-  if (commandEnvelope) {
-    events.push(timelineEvent({
-      ...base,
-      kind: 'runtime_context',
-      role: 'tool',
-      order,
-      snippet: snippet(commandEnvelope, 700),
-      fullText: fullText(commandEnvelope),
-      label: 'command envelope',
-    }));
-  }
-  const text = commandEnvelope ? stripCommandEnvelopeText(event.text) : event.text;
-  const displayedSourceText = event.displayText?.trim() || event.text;
-  const displayText = commandEnvelope
-    ? stripCommandEnvelopeText(displayedSourceText)
-    : displayedSourceText;
-  const semanticText = event.origin === 'human' ? displayText : text;
-  if (!semanticText.trim()) return events;
-  const kind = event.origin === 'human'
-    ? 'user_message'
-    : event.origin === 'skill-context'
-      ? 'skill_context'
-      : event.origin === 'synthetic'
-        ? 'synthetic_user_event'
-        : 'runtime_context';
-  events.push(timelineEvent({
-    ...base,
-    kind,
-    role: kind === 'user_message' ? 'user' : kind === 'synthetic_user_event' ? 'other' : 'tool',
-    order: order + (commandEnvelope ? 1 : 0),
-    snippet: snippet(semanticText, 700),
-    fullText: fullText(semanticText),
-    attachments: event.attachments,
-    label: userTextEventLabel(kind),
-  }));
-  return events;
-}
-
-function safeRecordText(record: unknown): string {
-  try {
-    return JSON.stringify(record);
-  } catch {
-    return String(record ?? '');
-  }
-}
-
-function hasAssistantTurnFailedText(value: string): boolean {
-  return /\[assistant turn failed\]|assistant turn failed|assistant_turn_failed|turn failed/i.test(value);
-}
-
-function timelineEvent(input: Omit<ExperienceTimelineEvent, 'id'>): ExperienceTimelineEvent {
-  return {
-    ...input,
-    id: hashParts(
-      input.traceId ?? '',
-      input.sourceTrace,
-      input.sessionId,
-      input.messageUuid ?? '',
-      String(input.messageIndex ?? ''),
-      input.kind,
-      input.callInstanceId ?? '',
-      input.toolUseId ?? '',
-      input.snippet ?? '',
-    ),
-  };
-}
-
-function userTextEventLabel(kind: 'user_message' | 'synthetic_user_event' | 'skill_context' | 'runtime_context'): string {
-  if (kind === 'skill_context') return 'skill context';
-  if (kind === 'runtime_context') return 'runtime context';
-  if (kind === 'synthetic_user_event') return 'synthetic user event';
-  return 'user message';
 }
 
 function observationEvidenceRef(item: ObservationInboxItem): ExperienceEvidenceRef {
@@ -7115,39 +6633,6 @@ function mergeRuleFindings(values: ExperienceRuleFinding[]): ExperienceRuleFindi
   });
 }
 
-function uniqueTimelineEvents(events: ExperienceTimelineEvent[]): ExperienceTimelineEvent[] {
-  const byId = new Map<string, ExperienceTimelineEvent>();
-  for (const event of events) {
-    byId.set(event.id, event);
-  }
-  return Array.from(byId.values());
-}
-
-function compareTimelineEvents(a: ExperienceTimelineEvent, b: ExperienceTimelineEvent): number {
-  const ta = a.timestamp;
-  const tb = b.timestamp;
-  // 双方都有非空 timestamp 且不同 → 按时间穿插（主线 + subagent 真实交互序）
-  if (ta && tb && ta !== tb) {
-    return ta.localeCompare(tb);
-  }
-  // 同一条物理 trace 内 → 按 messageIndex 派生的 order（跨 trace 比 order 没意义）。
-  const samePhysicalTrace = a.traceId && b.traceId
-    ? a.traceId === b.traceId
-    : a.sourceTrace === b.sourceTrace;
-  if (samePhysicalTrace) {
-    return a.order - b.order;
-  }
-  // 跨 trace 且 timestamp 不可比 → 主线优先（避免缺 timestamp 时 subagent 顶到最前）
-  const roleRank = (event: ExperienceTimelineEvent): number =>
-    event.traceRole === 'main' || event.traceRole === 'standalone' ? 0 : 1;
-  const rankDiff = roleRank(a) - roleRank(b);
-  if (rankDiff !== 0) return rankDiff;
-  // 同 traceRole 且 timestamp 缺失时，用物理 trace 身份提供稳定顺序。
-  return (a.traceId ?? a.sourceTrace).localeCompare(b.traceId ?? b.sourceTrace)
-    || a.sourceTrace.localeCompare(b.sourceTrace)
-    || a.order - b.order;
-}
-
 function traceRecordRanges(events: ExperienceTimelineEvent[]): ExperienceTraceRecordRange[] {
   const byTrace = new Map<string, ExperienceTimelineEvent[]>();
   for (const event of events) {
@@ -7169,54 +6654,6 @@ function traceRecordRanges(events: ExperienceTimelineEvent[]): ExperienceTraceRe
       };
     })
     .sort((a, b) => a.traceId.localeCompare(b.traceId));
-}
-
-function buildSessionTimelineTree(sessionId: string, sessions: TraceSession[]): ExperienceTimelineTree {
-  const mainSession = sessions.find((session) => session.role === 'main')
-    ?? sessions.find((session) => session.role === 'standalone');
-  const main = mainSession ? buildTimelineWindow(mainSession, 0, mainSession.events.length) : [];
-  const branches = sessions
-    .filter((session) => !mainSession || session !== mainSession)
-    .map((session): ExperienceTimelineBranch => {
-      const events = buildTimelineWindow(session, 0, session.events.length);
-      const attachTo = inferSubagentAttachment(main, session);
-      return {
-        id: hashParts('timeline-branch', session.traceId),
-        label: (session.label ?? basename(session.sourcePath)) || 'subagent',
-        sessionId: session.runId,
-        traceId: session.traceId,
-        sourceTrace: session.sourcePath,
-        traceRole: session.role,
-        attachTo,
-        events,
-      };
-    });
-  return {
-    sessionId,
-    main,
-    branches,
-  };
-}
-
-function inferSubagentAttachment(
-  mainEvents: ExperienceTimelineEvent[],
-  branchSession: TraceSession,
-): ExperienceTimelineBranch['attachTo'] | undefined {
-  const startedAt = branchSession.startTimestamp;
-  const taskUses = mainEvents.filter((event) => event.kind === 'tool_use' && /^(Task|Agent|Skill)$/i.test(event.toolName ?? ''));
-  const candidates = startedAt
-    ? taskUses.filter((event) => !event.timestamp || event.timestamp <= startedAt)
-    : taskUses;
-  const event = candidates.at(-1) ?? taskUses.at(-1);
-  if (!event) return undefined;
-  return {
-    traceId: event.traceId,
-    sourceTrace: event.sourceTrace,
-    messageIndex: event.messageIndex,
-    callInstanceId: event.callInstanceId,
-    toolUseId: event.toolUseId,
-    label: event.toolName,
-  };
 }
 
 function minDefined(values: Array<number | undefined>): number | undefined {
@@ -7262,22 +6699,6 @@ function inferUserGoal(userRefs: ExperienceTimelineEvent[]): string | undefined 
   return snippet(first?.snippet, 180);
 }
 
-function snippet(value: unknown, max = 240): string | undefined {
-  const text = typeof value === 'string' ? value : String(value ?? '');
-  const normalized = text.replace(/\s+/g, ' ').trim();
-  return normalized ? normalized.slice(0, max) : undefined;
-}
-
-function fullText(value: unknown): string | undefined {
-  const text = typeof value === 'string' ? value : String(value ?? '');
-  const normalized = text.trim();
-  return normalized || undefined;
-}
-
 function unique<T>(values: T[]): T[] {
   return Array.from(new Set(values));
-}
-
-function hashParts(...parts: string[]): string {
-  return createHash('sha256').update(parts.join('\u0000')).digest('hex').slice(0, 16);
 }

--- a/src/observability/experience/support.ts
+++ b/src/observability/experience/support.ts
@@ -1,0 +1,51 @@
+import { createHash } from 'node:crypto';
+import type { ExperienceTimelineEvent } from '../contracts/experience.js';
+
+export function uniqueTimelineEvents(events: ExperienceTimelineEvent[]): ExperienceTimelineEvent[] {
+  const byId = new Map<string, ExperienceTimelineEvent>();
+  for (const event of events) {
+    byId.set(event.id, event);
+  }
+  return Array.from(byId.values());
+}
+
+export function compareTimelineEvents(a: ExperienceTimelineEvent, b: ExperienceTimelineEvent): number {
+  const ta = a.timestamp;
+  const tb = b.timestamp;
+  // 双方都有非空 timestamp 且不同 → 按时间穿插（主线 + subagent 真实交互序）
+  if (ta && tb && ta !== tb) {
+    return ta.localeCompare(tb);
+  }
+  // 同一条物理 trace 内 → 按 messageIndex 派生的 order（跨 trace 比 order 没意义）。
+  const samePhysicalTrace = a.traceId && b.traceId
+    ? a.traceId === b.traceId
+    : a.sourceTrace === b.sourceTrace;
+  if (samePhysicalTrace) {
+    return a.order - b.order;
+  }
+  // 跨 trace 且 timestamp 不可比 → 主线优先（避免缺 timestamp 时 subagent 顶到最前）
+  const roleRank = (event: ExperienceTimelineEvent): number =>
+    event.traceRole === 'main' || event.traceRole === 'standalone' ? 0 : 1;
+  const rankDiff = roleRank(a) - roleRank(b);
+  if (rankDiff !== 0) return rankDiff;
+  // 同 traceRole 且 timestamp 缺失时，用物理 trace 身份提供稳定顺序。
+  return (a.traceId ?? a.sourceTrace).localeCompare(b.traceId ?? b.sourceTrace)
+    || a.sourceTrace.localeCompare(b.sourceTrace)
+    || a.order - b.order;
+}
+
+export function snippet(value: unknown, max = 240): string | undefined {
+  const text = typeof value === 'string' ? value : String(value ?? '');
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  return normalized ? normalized.slice(0, max) : undefined;
+}
+
+export function fullText(value: unknown): string | undefined {
+  const text = typeof value === 'string' ? value : String(value ?? '');
+  const normalized = text.trim();
+  return normalized || undefined;
+}
+
+export function hashParts(...parts: string[]): string {
+  return createHash('sha256').update(parts.join('\u0000')).digest('hex').slice(0, 16);
+}

--- a/src/observability/experience/timeline.ts
+++ b/src/observability/experience/timeline.ts
@@ -1,0 +1,568 @@
+import { basename } from 'node:path';
+import type {
+  ExperienceTimelineBranch,
+  ExperienceTimelineEvent,
+  ExperienceTimelineTree,
+} from '../contracts/experience.js';
+import {
+  type TraceEvent,
+  type TraceMessageEvent,
+  type TraceSession,
+} from '../trace-ir.js';
+import type { SkillSegment } from '../trace-segmenter.js';
+import {
+  extractCommandEnvelopeText,
+  stripCommandEnvelopeText,
+} from '../trace-attribution.js';
+import {
+  hasAssistantDeliverySignalText,
+  isAssistantProtocolReplyText,
+} from '../text-signals.js';
+import {
+  compareTimelineEvents,
+  fullText,
+  hashParts,
+  snippet,
+  uniqueTimelineEvents,
+} from './support.js';
+
+export function logicalSessionId(session: TraceSession): string {
+  return session.rootRunId;
+}
+
+export function experienceSessionGroupKey(session: TraceSession): string {
+  const logicalId = logicalSessionId(session);
+  if (session.role !== 'standalone' && session.groupPath) {
+    return `group:${session.groupPath}\u0000${logicalId}`;
+  }
+  return `trace:${session.traceId}`;
+}
+
+export function groupSessionsByExperienceKey(sessions: TraceSession[]): Map<string, TraceSession[]> {
+  const groups = new Map<string, TraceSession[]>();
+  for (const session of sessions) {
+    const key = experienceSessionGroupKey(session);
+    const group = groups.get(key) ?? [];
+    group.push(session);
+    groups.set(key, group);
+  }
+  for (const [key, group] of groups.entries()) {
+    groups.set(key, group.sort(compareSessionsForTimeline));
+  }
+  return groups;
+}
+
+export function compareSessionsForTimeline(a: TraceSession, b: TraceSession): number {
+  const roleRank = (session: TraceSession): number => session.role === 'main' ? 0 : session.role === 'standalone' ? 1 : 2;
+  const rank = roleRank(a) - roleRank(b);
+  if (rank !== 0) return rank;
+  const time = (a.startTimestamp ?? '').localeCompare(b.startTimestamp ?? '');
+  if (time !== 0) return time;
+  return a.sourcePath.localeCompare(b.sourcePath)
+    || a.traceId.localeCompare(b.traceId);
+}
+
+export function segmentRecordBounds(session: TraceSession, segment: SkillSegment): { start: number; end: number } {
+  if (typeof segment.startRecordIndex === 'number' && typeof segment.endRecordIndex === 'number') {
+    const rawStart = eventIndexForSourceIndex(session, segment.startRecordIndex, 'first');
+    const rawEnd = eventIndexForSourceIndex(
+      session,
+      Math.max(segment.startRecordIndex, segment.endRecordIndex),
+      'last',
+    );
+    const humanStart = Math.min(rawStart, previousHumanUserRecordIndex(session, rawStart) ?? rawStart);
+    return {
+      start: includeLeadingRuntimeContext(session, humanStart),
+      end: includeTrailingDeliveryContext(session, Math.min(session.events.length, rawEnd + 1)),
+    };
+  }
+  const indexes = segment.toolCalls
+    .map((toolCall) => toolCall.messageIndex)
+    .filter((index): index is number => typeof index === 'number' && index >= 0);
+  if (indexes.length > 0) {
+    const firstEventIndex = eventIndexForSourceIndex(session, Math.min(...indexes), 'first');
+    const lastEventIndex = eventIndexForSourceIndex(session, Math.max(...indexes), 'last');
+    const start = Math.max(0, firstEventIndex - 3);
+    return {
+      start: Math.min(start, previousHumanUserRecordIndex(session, start) ?? start),
+      end: includeTrailingDeliveryContext(session, Math.min(session.events.length, lastEventIndex + 5)),
+    };
+  }
+  const timestampIndexes: number[] = [];
+  session.events.forEach((event, index) => {
+    const ts = event.timestamp;
+    if (ts && ts >= segment.startTimestamp && ts <= segment.endTimestamp) timestampIndexes.push(index);
+  });
+  if (timestampIndexes.length === 0) return { start: 0, end: Math.min(session.events.length, 12) };
+  const start = Math.max(0, Math.min(...timestampIndexes) - 2);
+  return {
+    start: Math.min(start, previousHumanUserRecordIndex(session, start) ?? start),
+    end: includeTrailingDeliveryContext(session, Math.min(session.events.length, Math.max(...timestampIndexes) + 3)),
+  };
+}
+
+export function clampRecordIndex(session: TraceSession, index: number): number {
+  return Math.max(0, Math.min(session.events.length - 1, index));
+}
+
+export function eventIndexForSourceIndex(
+  session: TraceSession,
+  sourceIndex: number,
+  edge: 'first' | 'last',
+): number {
+  if (edge === 'first') {
+    const index = session.events.findIndex((event) => event.sourceIndex >= sourceIndex);
+    return index < 0 ? clampRecordIndex(session, sourceIndex) : index;
+  }
+  for (let index = session.events.length - 1; index >= 0; index -= 1) {
+    if (session.events[index].sourceIndex <= sourceIndex) return index;
+  }
+  return 0;
+}
+
+export function includeLeadingRuntimeContext(session: TraceSession, start: number): number {
+  let nextStart = start;
+  for (let index = start - 1; index >= 0; index -= 1) {
+    const events = timelineEventsFromTraceEvent(session, session.events[index], index);
+    if (events.length === 0) continue;
+    if (events.some((event) => event.kind === 'runtime_context')) {
+      nextStart = index;
+      continue;
+    }
+    break;
+  }
+  return nextStart;
+}
+
+export function includeTrailingDeliveryContext(session: TraceSession, end: number): number {
+  const safeEnd = Math.min(session.events.length, Math.max(0, end));
+  const lookaheadEnd = Math.min(session.events.length, safeEnd + 8);
+  for (let index = safeEnd; index < lookaheadEnd; index += 1) {
+    const events = timelineEventsFromTraceEvent(session, session.events[index], index);
+    if (events.some((event) => event.kind === 'user_message')) break;
+    if (events.some(isAssistantDeliveryEvent)) return index + 1;
+  }
+  return safeEnd;
+}
+
+export function previousHumanUserRecordIndex(session: TraceSession, start: number): number | undefined {
+  for (let index = Math.min(start, session.events.length - 1); index >= 0; index -= 1) {
+    const events = timelineEventsFromTraceEvent(session, session.events[index], index);
+    if (events.some((event) => event.kind === 'user_message')) return index;
+  }
+  return undefined;
+}
+
+export function isAssistantDeliveryEvent(event: ExperienceTimelineEvent): boolean {
+  if (event.kind !== 'assistant_message') return false;
+  const text = event.fullText ?? event.snippet ?? '';
+  return hasAssistantDeliverySignalText(text);
+}
+
+export function buildInvocationTimeline(
+  session: TraceSession,
+  start: number,
+  end: number,
+  segment: SkillSegment,
+): ExperienceTimelineEvent[] {
+  const window = buildTimelineWindow(session, start, end);
+  const callInstanceIds = new Set(
+    segment.toolCalls.flatMap((toolCall) =>
+      toolCall.callInstanceId ? [toolCall.callInstanceId] : []
+    ),
+  );
+  const legacyCallIds = new Set(
+    segment.toolCalls.flatMap((toolCall) =>
+      !toolCall.callInstanceId && toolCall.toolUseId ? [toolCall.toolUseId] : []
+    ),
+  );
+  if (callInstanceIds.size === 0 && legacyCallIds.size === 0) return window;
+  const linkedResults = session.events.flatMap((event, eventIndex) =>
+    event.eventKind === 'tool_result'
+    && (
+      event.callInstanceId
+        ? callInstanceIds.has(event.callInstanceId)
+        : legacyCallIds.has(event.callId)
+    )
+    && (eventIndex < start || eventIndex >= end)
+      ? timelineEventsFromTraceEvent(session, event, eventIndex)
+      : [],
+  );
+  return uniqueTimelineEvents([...window, ...linkedResults]).sort(compareTimelineEvents);
+}
+
+export function buildTimelineWindow(session: TraceSession, start: number, end: number): ExperienceTimelineEvent[] {
+  const events: ExperienceTimelineEvent[] = [];
+  const safeEnd = Math.min(session.events.length, Math.max(start, end));
+  for (let index = start; index < safeEnd; index += 1) {
+    events.push(...timelineEventsFromTraceEvent(session, session.events[index], index));
+  }
+  return events.sort((a, b) => a.order - b.order);
+}
+
+/** Project one source-neutral Trace IR session into Studio's semantic timeline. */
+export function projectTraceSessionTimeline(session: TraceSession): ExperienceTimelineEvent[] {
+  return buildTimelineWindow(session, 0, session.events.length);
+}
+
+export function timelineEventsFromTraceEvent(
+  session: TraceSession,
+  event: TraceEvent,
+  eventIndex: number,
+): ExperienceTimelineEvent[] {
+  const messageIndex = event.sourceIndex;
+  const base = {
+    traceId: session.traceId,
+    sourceTrace: session.sourcePath,
+    sessionId: logicalSessionId(session),
+    traceRole: session.role,
+    traceLabel: session.label,
+    messageIndex,
+    logicalMessageIndex: messageIndex,
+    sourceLineIndex: messageIndex,
+    messageUuid: event.sourceEventId ?? event.eventId,
+    sourceType: event.sourceType,
+    turnId: event.turnId,
+    timestamp: event.timestamp,
+  };
+  const order = eventIndex * 10;
+
+  if (event.eventKind === 'message' && event.role === 'user') {
+    return userTimelineEvents(event, base, order);
+  }
+  if (event.eventKind === 'message' && event.role === 'system') {
+    return [timelineEvent({
+      ...base,
+      kind: 'runtime_context',
+      role: 'tool',
+      order,
+      snippet: snippet(event.text, 700),
+      fullText: fullText(event.text),
+      label: 'system context',
+    })];
+  }
+  if (event.eventKind === 'message' && event.role === 'assistant') {
+    const protocolReply = isAssistantProtocolReplyText(event.text);
+    return [timelineEvent({
+      ...base,
+      kind: protocolReply ? 'runtime_context' : 'assistant_message',
+      role: 'assistant',
+      order,
+      model: event.model,
+      snippet: snippet(event.text, 700),
+      fullText: fullText(event.text),
+      label: protocolReply ? 'assistant protocol reply' : 'assistant message',
+    })];
+  }
+  if (event.eventKind === 'model_activity') {
+    return [timelineEvent({
+      ...base,
+      kind: 'model_activity',
+      role: 'assistant',
+      order,
+      model: event.model,
+      modelActivityKind: event.activityKind,
+      contentVisibility: event.contentVisibility,
+      contentSource: event.contentSource,
+      snippet: snippet(event.text, 700),
+      fullText: fullText(event.text),
+      label: 'model reasoning',
+    })];
+  }
+  if (event.eventKind === 'tool_call') {
+    const inputText = JSON.stringify(event.input);
+    return [timelineEvent({
+      ...base,
+      kind: 'tool_use',
+      role: 'assistant',
+      order,
+      callInstanceId: event.callInstanceId,
+      toolUseId: event.callId,
+      toolName: event.tool.displayName ?? event.tool.name,
+      snippet: snippet(inputText, 900),
+      fullText: fullText(inputText),
+      label: `tool_use ${event.tool.displayName ?? event.tool.name}`,
+    })];
+  }
+  if (event.eventKind === 'tool_result') {
+    const failed = event.status === 'failure';
+    return [timelineEvent({
+      ...base,
+      kind: 'tool_result',
+      role: 'tool',
+      order,
+      callInstanceId: event.callInstanceId,
+      toolUseId: event.callId,
+      toolStatus: event.status,
+      isError: failed,
+      snippet: snippet(event.output, 900),
+      fullText: fullText(event.output),
+      label: failed
+        ? 'tool result error'
+        : event.status === 'cancelled' ? 'tool result cancelled'
+        : event.status === 'unknown' ? 'tool result status unknown' : 'tool result',
+    })];
+  }
+  if (event.eventKind === 'lifecycle') {
+    return [timelineEvent({
+      ...base,
+      kind: 'lifecycle',
+      role: 'other',
+      order,
+      snippet: snippet(`${event.phase}${event.reason ? `: ${event.reason}` : ''}`, 700),
+      fullText: fullText(JSON.stringify(event)),
+      label: event.phase,
+    })];
+  }
+  if (event.eventKind === 'runtime_context') {
+    const details = JSON.stringify({
+      runtimeName: event.runtimeName,
+      runtimeVersion: event.runtimeVersion,
+      cwd: event.cwd,
+      workspaceRoots: event.workspaceRoots,
+      currentDate: event.currentDate,
+      timezone: event.timezone,
+      model: event.model,
+      modelProvider: event.modelProvider,
+      serviceTier: event.serviceTier,
+      reasoningEffort: event.reasoningEffort,
+      reasoningSummary: event.reasoningSummary,
+      personality: event.personality,
+      approvalPolicy: event.approvalPolicy,
+      approvalReviewer: event.approvalReviewer,
+      permissionProfile: event.permissionProfile,
+      sandboxMode: event.sandboxMode,
+      collaborationMode: event.collaborationMode,
+      realtimeActive: event.realtimeActive,
+      multiAgentMode: event.multiAgentMode,
+      multiAgentVersion: event.multiAgentVersion,
+      memoryMode: event.memoryMode,
+      historyMode: event.historyMode,
+      contextWindowId: event.contextWindowId,
+      parentRunId: event.parentRunId,
+      delegationDepth: event.delegationDepth,
+      sourceOrigin: event.sourceOrigin,
+      availableTools: event.availableTools,
+      instructions: event.instructions,
+      goal: event.goal,
+      goalStatus: event.goalStatus,
+      summary: event.summary,
+    });
+    const visible = event.summary
+      ?? event.goal
+      ?? event.instructions
+      ?? [event.runtimeName, event.runtimeVersion, event.cwd, event.model, event.reasoningEffort, event.collaborationMode]
+        .filter(Boolean)
+        .join(' · ');
+    return [timelineEvent({
+      ...base,
+      kind: 'runtime_context',
+      role: 'other',
+      order,
+      model: event.model,
+      runtimeKind: event.runtimeKind,
+      snippet: snippet(visible, 700),
+      fullText: fullText(details),
+      label: event.runtimeKind,
+    })];
+  }
+  if (event.eventKind === 'context_compaction') {
+    return [timelineEvent({
+      ...base,
+      kind: 'runtime_context',
+      role: 'other',
+      order,
+      runtimeKind: 'context_compaction',
+      snippet: snippet(event.summary ?? 'context compacted', 700),
+      fullText: fullText(JSON.stringify(event)),
+      label: 'context compacted',
+    })];
+  }
+  if (event.eventKind === 'agent_activity') {
+    const visible = event.text
+      ?? [event.activity, event.author, event.recipient, event.agentPath, event.agentId]
+        .filter(Boolean)
+        .join(' · ');
+    return [timelineEvent({
+      ...base,
+      kind: 'agent_activity',
+      role: 'other',
+      order,
+      snippet: snippet(visible, 700),
+      fullText: fullText(JSON.stringify({
+        activityKind: event.activityKind,
+        activity: event.activity,
+        author: event.author,
+        recipient: event.recipient,
+        agentId: event.agentId,
+        agentPath: event.agentPath,
+        text: event.text,
+      })),
+      label: event.activityKind === 'communication' ? 'agent communication' : 'agent status',
+    })];
+  }
+  if (event.eventKind === 'usage') {
+    const usageText = JSON.stringify({
+      model: event.model,
+      inputTokens: event.inputTokens,
+      outputTokens: event.outputTokens,
+      cacheReadTokens: event.cacheReadTokens,
+      cacheCreationTokens: event.cacheCreationTokens,
+      reasoningTokens: event.reasoningTokens,
+    });
+    return [timelineEvent({
+      ...base,
+      kind: 'runtime_context',
+      role: 'other',
+      order,
+      model: event.model,
+      runtimeKind: 'usage',
+      snippet: snippet(usageText, 700),
+      fullText: fullText(usageText),
+      label: 'token usage',
+    })];
+  }
+  if (event.eventKind === 'unknown') {
+    const rawText = safeRecordText(event.raw);
+    if (!hasAssistantTurnFailedText(rawText)) return [];
+    return [timelineEvent({
+      ...base,
+      kind: 'runtime_context',
+      role: 'other',
+      order,
+      snippet: snippet(rawText, 700),
+      fullText: fullText(rawText),
+      label: event.sourceType,
+    })];
+  }
+  return [];
+}
+
+export function userTimelineEvents(
+  event: TraceMessageEvent,
+  base: Omit<ExperienceTimelineEvent, 'id' | 'kind' | 'order'>,
+  order: number,
+): ExperienceTimelineEvent[] {
+  const events: ExperienceTimelineEvent[] = [];
+  const commandEnvelope = extractCommandEnvelopeText(event.text);
+  if (commandEnvelope) {
+    events.push(timelineEvent({
+      ...base,
+      kind: 'runtime_context',
+      role: 'tool',
+      order,
+      snippet: snippet(commandEnvelope, 700),
+      fullText: fullText(commandEnvelope),
+      label: 'command envelope',
+    }));
+  }
+  const text = commandEnvelope ? stripCommandEnvelopeText(event.text) : event.text;
+  const displayedSourceText = event.displayText?.trim() || event.text;
+  const displayText = commandEnvelope
+    ? stripCommandEnvelopeText(displayedSourceText)
+    : displayedSourceText;
+  const semanticText = event.origin === 'human' ? displayText : text;
+  if (!semanticText.trim()) return events;
+  const kind = event.origin === 'human'
+    ? 'user_message'
+    : event.origin === 'skill-context'
+      ? 'skill_context'
+      : event.origin === 'synthetic'
+        ? 'synthetic_user_event'
+        : 'runtime_context';
+  events.push(timelineEvent({
+    ...base,
+    kind,
+    role: kind === 'user_message' ? 'user' : kind === 'synthetic_user_event' ? 'other' : 'tool',
+    order: order + (commandEnvelope ? 1 : 0),
+    snippet: snippet(semanticText, 700),
+    fullText: fullText(semanticText),
+    attachments: event.attachments,
+    label: userTextEventLabel(kind),
+  }));
+  return events;
+}
+
+export function safeRecordText(record: unknown): string {
+  try {
+    return JSON.stringify(record);
+  } catch {
+    return String(record ?? '');
+  }
+}
+
+export function hasAssistantTurnFailedText(value: string): boolean {
+  return /\[assistant turn failed\]|assistant turn failed|assistant_turn_failed|turn failed/i.test(value);
+}
+
+export function timelineEvent(input: Omit<ExperienceTimelineEvent, 'id'>): ExperienceTimelineEvent {
+  return {
+    ...input,
+    id: hashParts(
+      input.traceId ?? '',
+      input.sourceTrace,
+      input.sessionId,
+      input.messageUuid ?? '',
+      String(input.messageIndex ?? ''),
+      input.kind,
+      input.callInstanceId ?? '',
+      input.toolUseId ?? '',
+      input.snippet ?? '',
+    ),
+  };
+}
+
+export function userTextEventLabel(kind: 'user_message' | 'synthetic_user_event' | 'skill_context' | 'runtime_context'): string {
+  if (kind === 'skill_context') return 'skill context';
+  if (kind === 'runtime_context') return 'runtime context';
+  if (kind === 'synthetic_user_event') return 'synthetic user event';
+  return 'user message';
+}
+
+export function buildSessionTimelineTree(sessionId: string, sessions: TraceSession[]): ExperienceTimelineTree {
+  const mainSession = sessions.find((session) => session.role === 'main')
+    ?? sessions.find((session) => session.role === 'standalone');
+  const main = mainSession ? buildTimelineWindow(mainSession, 0, mainSession.events.length) : [];
+  const branches = sessions
+    .filter((session) => !mainSession || session !== mainSession)
+    .map((session): ExperienceTimelineBranch => {
+      const events = buildTimelineWindow(session, 0, session.events.length);
+      const attachTo = inferSubagentAttachment(main, session);
+      return {
+        id: hashParts('timeline-branch', session.traceId),
+        label: (session.label ?? basename(session.sourcePath)) || 'subagent',
+        sessionId: session.runId,
+        traceId: session.traceId,
+        sourceTrace: session.sourcePath,
+        traceRole: session.role,
+        attachTo,
+        events,
+      };
+    });
+  return {
+    sessionId,
+    main,
+    branches,
+  };
+}
+
+export function inferSubagentAttachment(
+  mainEvents: ExperienceTimelineEvent[],
+  branchSession: TraceSession,
+): ExperienceTimelineBranch['attachTo'] | undefined {
+  const startedAt = branchSession.startTimestamp;
+  const taskUses = mainEvents.filter((event) => event.kind === 'tool_use' && /^(Task|Agent|Skill)$/i.test(event.toolName ?? ''));
+  const candidates = startedAt
+    ? taskUses.filter((event) => !event.timestamp || event.timestamp <= startedAt)
+    : taskUses;
+  const event = candidates.at(-1) ?? taskUses.at(-1);
+  if (!event) return undefined;
+  return {
+    traceId: event.traceId,
+    sourceTrace: event.sourceTrace,
+    messageIndex: event.messageIndex,
+    callInstanceId: event.callInstanceId,
+    toolUseId: event.toolUseId,
+    label: event.toolName,
+  };
+}

--- a/test/architecture/import-boundaries.test.ts
+++ b/test/architecture/import-boundaries.test.ts
@@ -431,6 +431,19 @@ describe('架构边界守门', () => {
     expect(violations).toEqual([]);
   });
 
+  it('Experience 时间线投影由独立模块拥有', () => {
+    const facade = readFileSync(join(SRC_DIR, 'observability', 'experience.ts'), 'utf-8');
+    const timeline = readFileSync(
+      join(SRC_DIR, 'observability', 'experience', 'timeline.ts'),
+      'utf-8',
+    );
+
+    expect(extractSpecifiers(facade)).toContain('./experience/timeline.js');
+    expect(facade).not.toContain('function timelineEventsFromTraceEvent(');
+    expect(facade).not.toContain('function buildTimelineWindow(');
+    expect(extractSpecifiers(timeline)).not.toContain('../experience.js');
+  });
+
   it('whitelist 不能腐烂:每条 whitelist 都对应一条真实存在的 import', () => {
     const files = listTsFiles(SRC_DIR);
     const realEdges = new Set<string>();


### PR DESCRIPTION
## 用户影响

无用户可见行为变化。Experience 报告仍从原有领域入口构建和读取，Trace 会话到语义时间线的投影结果保持不变。

## 架构边界

将 Trace 分组、调用窗口计算、事件投影和时间线树构建收拢到 `observability/experience/timeline`；稳定排序、文本截断与证据哈希等纯工具归入同一垂直切片的 `support`。`experience.ts` 保留报告编排入口，不再拥有底层 Trace 事件适配。

新增架构守卫，禁止时间线实现回流到聚合文件，并阻止新模块反向依赖 facade。

## 迁移说明

现有调用方继续通过 `observability/experience` 使用 `projectTraceSessionTimeline`，对外导出路径不变；未引入旧路径转发层。

## 测量学说明

27 个移动声明与 `main` 的 AST 文本逐一一致，仅改变模块归属与可见性。未修改 public schema、评分类 prompt、评分管道、统计公式或测量语义。

Part of #562。