### PR TITLE
refactor(artifact-graph): 归位 Core 图持久化

### DIFF
--- a/src/cli/lib/run-core-evaluation.ts
+++ b/src/cli/lib/run-core-evaluation.ts
@@ -16,6 +16,7 @@ import {
   createNodeCliProductionComposition,
   createProductionEvaluationHost,
   executeProductionEvaluationSeries,
+  persistCoreArtifactGraph,
   resolveNodeCliEvaluationRequest,
 } from '../../eval-workflows/production-host/index.js';
 import {
@@ -151,7 +152,6 @@ async function persistArtifactGraph(
   outputDirectory: string,
   cwd: string,
 ): Promise<void> {
-  const { persistCoreArtifactGraph } = await import('../../artifact-graph/core.js');
   await persistCoreArtifactGraph({ source: stored, outputDirectory, cwd });
 }
 

--- a/src/dsh-plugin/core-command.ts
+++ b/src/dsh-plugin/core-command.ts
@@ -22,6 +22,7 @@ import {
   createProductionEvaluationHost,
   createProductionRuntimeFactoryRegistry,
   executeProductionEvaluationSeries,
+  persistCoreArtifactGraph,
   resolveNodeCliEvaluationRequest,
 } from '../eval-workflows/production-host/index.js';
 import {
@@ -31,7 +32,6 @@ import {
   type CoreCliRunOutcome,
   type CoreCliSeriesOutcome,
 } from '../eval-workflows/downstream-projections/index.js';
-import { persistCoreArtifactGraph } from '../artifact-graph/core.js';
 import { managedDir, recordCoreEvalEvidence } from '../managed/index.js';
 import type { ExecResult } from '../executors/contracts/result.js';
 import type { ExecutorFn } from '../executors/contracts/ports.js';

--- a/src/eval-workflows/production-host/artifact-graph-persistence.ts
+++ b/src/eval-workflows/production-host/artifact-graph-persistence.ts
@@ -1,9 +1,9 @@
 import { basename, dirname, join } from 'node:path';
 import { mkdir } from 'node:fs/promises';
-import type { StoredCoreRunArtifacts } from '../eval-workflows/artifact-store/index.js';
-import { projectCoreArtifactGraph } from '../eval-workflows/downstream-projections/index.js';
-import { graphFileName } from '../measurement-artifacts/file-names.js';
-import { writeJsonFileAtomic } from '../shared/atomic-json.js';
+import type { StoredCoreRunArtifacts } from '../artifact-store/index.js';
+import { projectCoreArtifactGraph } from '../downstream-projections/index.js';
+import { graphFileName } from '../../measurement-artifacts/file-names.js';
+import { writeJsonFileAtomic } from '../../shared/atomic-json.js';
 
 function coreEvalGraphDirectory(outputDirectory: string): string {
   return basename(outputDirectory) === 'reports'

--- a/src/eval-workflows/production-host/index.ts
+++ b/src/eval-workflows/production-host/index.ts
@@ -1,3 +1,4 @@
+export * from './artifact-graph-persistence.js';
 export * from './measurement-design.js';
 export * from './node-cli-composition.js';
 export * from './node-cli-evaluation-resolver.js';

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -52,12 +52,13 @@ describe('领域契约所有权', () => {
     expect(existsSync(resolve('src/types'))).toBe(false);
   });
 
-  it('保持已归位的 observe analysis 与 Studio 领域不回退到旧目录', () => {
+  it('保持已归位的领域实现不回退到旧路径', () => {
     for (const legacyPath of [
       'src/analysis',
       'src/eval-workflows/studio-catalog',
       'src/server',
       'src/renderer',
+      'src/artifact-graph/core.ts',
     ]) {
       expect(existsSync(resolve(legacyPath)), legacyPath).toBe(false);
     }

--- a/test/architecture/import-boundaries.test.ts
+++ b/test/architecture/import-boundaries.test.ts
@@ -81,6 +81,11 @@ const RULES: ForbiddenRule[] = [
     reason: '应用工作流产出事实与存储能力，由 Studio 单向消费；workflow 不反向依赖具体工作台。',
   },
   {
+    from: 'artifact-graph/',
+    to: 'eval-workflows/',
+    reason: 'Artifact Graph 只拥有图 contracts、schema 与领域投影；文件持久化和 Core workflow composition 由 production host 拥有。',
+  },
+  {
     from: 'observability/',
     to: 'studio/',
     reason: 'observability 负责采集、分析与复核事实，不依赖 Studio 的应用聚合或呈现。',

--- a/test/eval-workflows/downstream-projections-boundary.test.ts
+++ b/test/eval-workflows/downstream-projections-boundary.test.ts
@@ -29,7 +29,7 @@ describe('#531/#547 Core downstream projection boundary', () => {
       'src/managed/evidence.ts',
       'src/cli/commands/eval/gold/compare.ts',
       'src/authoring/core-evolver.ts',
-      'src/artifact-graph/core.ts',
+      'src/eval-workflows/production-host/artifact-graph-persistence.ts',
       'src/studio/http/request-handler.ts',
     ].map((file) => readFileSync(file, 'utf8')).join('\n');
     expect(cutoverConsumers).toContain('projectCoreCliDryRun');


### PR DESCRIPTION
## 用户影响

无可见行为变化。CLI 与 DSH Host 仍会在 Core 评测完成后写出同名、同路径、同内容的 Artifact Graph。

## 架构调整

- 将 `persistCoreArtifactGraph` 从 Artifact Graph 领域内核移动到 `eval-workflows/production-host`。
- Artifact Graph 只保留图 contracts、schema 与领域能力；文件系统 effect、Core artifact store 和 downstream projection composition 由 production host 拥有。
- CLI 与 DSH Host 统一通过 production-host facade 调用持久化能力。
- 新增依赖守门，禁止 `artifact-graph → eval-workflows` 回退，并锁定旧路径不存在。

## 行为等价

移动前后的 `persistCoreArtifactGraph` 函数经 TypeScript AST 结构校验完全一致；输出目录选择、文件名、投影输入和原子写入均未修改。

## 迁移说明

无需用户迁移。该内部模块不属于 package exports；不保留旧路径转发文件。

## 测量学说明

未修改 Artifact Graph schema、Core artifacts、report schema、评分类 prompt、评分管道、统计公式或 length-debias 语义，不影响测量结果与历史可比性。

Part of #581