### PR TITLE
refactor(measurement-governance): 归位提示词冻结清单

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ OMK（Observe. Measure. Know.）让 AI 应用的知识改动有据可依。它�
 
 - 遵守 `CONTRIBUTING.md` 的 GitHub Flow：`main` 是唯一长期分支；feature / fix / docs / chore 从 `main` 切短分支，通过 PR 回 `main`；release / hotfix 也通过短分支 PR 回 `main`，再由 tag 触发发版。
 - 不要直接在 `main` 上提交；不要再把新工作提交到 `develop`。
-- commit 格式：`type(scope): 中文 subject`。scope 用稳定模块名，如 `cli` / `i18n` / `judge` / `renderer` / `evaluation-core` / `eval-workflows` / `measurement-artifacts` / `inputs` / `executors` / `server` / `analysis` / `authoring` / `grading` / `doctor` / `release` / `agents-md`（早期 git history 用过 `claude-md`，rename 后统一用 `agents-md`）。
+- commit 格式：`type(scope): 中文 subject`。scope 用稳定模块名，如 `cli` / `i18n` / `evaluation-core` / `eval-workflows` / `artifact-graph` / `measurement-artifacts` / `measurement-governance` / `observability` / `studio` / `inputs` / `executors` / `authoring` / `grading` / `doctor` / `release` / `agents-md`（早期 git history 用过 `claude-md`，rename 后统一用 `agents-md`）。
 - 不要在给用户看的 URL 里硬编码 report server 端口；使用 `server.start()` 返回的实际 URL。
 - 判别字段命名：新建或可安全改名的字段中，裸 `kind` 默认只表示 `Artifact.kind: ArtifactKind`（baseline / skill / prompt / agent / workflow）。例外是已经发布并落盘/对外暴露的 public schema（如 report / doctor / observe / diagnosis 的顶层 `kind`），这些既有 `kind` 字段不要顺手改成限定名；确需改名时单独做 schema / data migration，并保持读取旧文件。其它新判别字段用限定名（`eventKind` / `runtimeKind` / `standardKind` 等）。细节见 `docs/specs/terminology-spec.md` §5.4，CI 有 `test/scripts/kind-semantics-guard.test.ts` 拦新裸 `kind`。
 
@@ -22,7 +22,7 @@ OMK（Observe. Measure. Know.）让 AI 应用的知识改动有据可依。它�
 这些是跨版本报告可比性的锚点，不要静默修改：
 
 - `src/evaluation-core/contracts/artifacts.ts` 里的 `EvaluationReportSchema` 字段语义。
-- `test/shared/prompt-registry-freeze.test.ts` 冻结的全部评分类 prompt hash（rubric 评委 / RAG / semantic / observe LLM 增强复盘），由 `src/shared/llm-prompts/registry.ts` 的 `PROMPT_REGISTRY` 驱动；评分类 prompt 文本统一在 `src/shared/llm-prompts/`。
+- `test/measurement-governance/prompt-registry-freeze.test.ts` 冻结的全部评分类 prompt hash（rubric 评委 / RAG / semantic / observe LLM 增强复盘），由同目录 `prompt-registry.ts` 的 `PROMPT_REGISTRY` 驱动；评分类 prompt 文本统一在 `src/shared/llm-prompts/`。
 - 五层评分管道语义：assertion / llm / judge / dimension / composite。
 - Bootstrap CI 和 Krippendorff alpha 公式。
 - Length-debias toggle 语义：`--no-debias-length` 关掉 rubric 评委的长度去偏（debias-off prompt 变体）；排版 / 语气中性化不受其影响、恒开。
@@ -39,7 +39,7 @@ OMK（Observe. Measure. Know.）让 AI 应用的知识改动有据可依。它�
 
 ## UI / Judge 改动
 
-- 改任何评分类 prompt 文本前（rubric 评委 / RAG / semantic，均在 `src/shared/llm-prompts/`），先确认 `test/shared/prompt-registry-freeze.test.ts` 的影响，不要随手更新冻结 hash。
+- 改任何评分类 prompt 文本前（rubric 评委 / RAG / semantic，均在 `src/shared/llm-prompts/`），先确认 `test/measurement-governance/prompt-registry-freeze.test.ts` 的影响，不要随手更新冻结 hash。
 - 改 observe LLM 增强复盘 prompt 文本前，先确认同一冻结测试里 `observe-llm-enhanced-review` 条目的影响；如果 runtimeAssessment 可比性会变化，PR 标题 / description 必须标 `BREAKING-COMPARABILITY`。
 - 改报告 UI 后，先 review `test/__snapshots__/html-renderer.test.ts.snap` diff，再决定是否更新 snapshot。
 

--- a/docs/explanation/statistical-rigor.md
+++ b/docs/explanation/statistical-rigor.md
@@ -45,7 +45,7 @@ LLM judges can reward verbosity, polished formatting, or confident tone independ
 - Presentation and tone neutrality are always enabled.
 - Length debiasing is enabled by default; `--no-debias-length` disables only the length instruction for controlled research or replication.
 - Every scoring prompt has a registry identity and hash. Reports with different evaluator identities or prompt variants are not treated as blind equivalents.
-- The frozen hashes are driven by `src/shared/llm-prompts/registry.ts` and guarded by `test/shared/prompt-registry-freeze.test.ts`.
+- The frozen hashes are catalogued and guarded by `test/measurement-governance/prompt-registry.ts` and `prompt-registry-freeze.test.ts`. This governance-only manifest is excluded from the published runtime.
 
 Prompt instructions reduce a known bias risk; they do not prove that a judge is unbiased. Gold calibration is the external check.
 

--- a/docs/zh/explanation/statistical-rigor.md
+++ b/docs/zh/explanation/statistical-rigor.md
@@ -45,7 +45,7 @@ LLM 评委可能在正确性之外奖励冗长、精致排版或自信语气。o
 - 排版与语气中性化始终开启；
 - 长度去偏默认开启；`--no-debias-length` 只关闭长度指令，用于受控研究或复现；
 - 每条评分类 prompt 都有 registry identity 与 hash；evaluator identity 或 prompt variant 不同时，报告不会被当作可盲比事实；
-- hash 由 `src/shared/llm-prompts/registry.ts` 驱动，并由 `test/shared/prompt-registry-freeze.test.ts` 冻结。
+- hash 由 `test/measurement-governance/prompt-registry.ts` 统一编目，并由同目录 `prompt-registry-freeze.test.ts` 冻结。这份治理清单仅用于维护与 CI，不进入发布运行时。
 
 Prompt 指令只能降低已知偏差风险，不能证明评委无偏；Gold calibration 才是外部校验。
 

--- a/src/shared/llm-prompts/judge-prompts.ts
+++ b/src/shared/llm-prompts/judge-prompts.ts
@@ -20,7 +20,7 @@ import {
  * The version string encodes WHICH debias / context features the judge sees, so sealed
  * evaluation plans carrying the same prompt hash use the same instrument. A mismatched
  * hash means "we changed how we ask the judge to think". Bump it (and the
- * frozen hashes in `test/shared/prompt-registry-freeze.test.ts`) whenever the template's bytes
+ * frozen hashes in `test/measurement-governance/prompt-registry-freeze.test.ts`) whenever the template's bytes
  * change — that change is BREAKING-COMPARABILITY.
  *
  * Naming: a single main version (`v5`) + a `-feature` suffix per debias/context capability.

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -59,6 +59,7 @@ describe('领域契约所有权', () => {
       'src/server',
       'src/renderer',
       'src/artifact-graph/core.ts',
+      'src/measurement-artifacts/prompt-registry.ts',
     ]) {
       expect(existsSync(resolve(legacyPath)), legacyPath).toBe(false);
     }

--- a/test/architecture/import-boundaries.test.ts
+++ b/test/architecture/import-boundaries.test.ts
@@ -91,6 +91,11 @@ const RULES: ForbiddenRule[] = [
     reason: 'Executor 负责 Runtime 与工具结果事实，不得反向依赖由这些事实派生的 Observability 投影。',
   },
   {
+    from: 'measurement-artifacts/',
+    to: 'observability/',
+    reason: 'Measurement Artifacts 只拥有产物命名、目录、索引与定位能力；跨域 prompt 冻结属于 CI 测量治理。',
+  },
+  {
     from: 'observability/',
     to: 'studio/',
     reason: 'observability 负责采集、分析与复核事实，不依赖 Studio 的应用聚合或呈现。',

--- a/test/measurement-governance/prompt-registry-freeze.test.ts
+++ b/test/measurement-governance/prompt-registry-freeze.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { PROMPT_REGISTRY } from '../../src/measurement-artifacts/prompt-registry.js';
+import { PROMPT_REGISTRY } from './prompt-registry.js';
 
 // 统一冻结:omk 所有「直接决定分数」的评委 prompt 的 byte-level 锚点。任何动其模板字节(含
 // 标点 / 空白 / 版本串 / 共享去偏块)都会让对应 hash 变,从而让历史报告不可比。除非显式想 bump

--- a/test/measurement-governance/prompt-registry.ts
+++ b/test/measurement-governance/prompt-registry.ts
@@ -2,13 +2,13 @@ import {
   getJudgePromptHash,
   getRagJudgePromptHash,
   getSemanticPromptHash,
-} from '../shared/llm-prompts/judge-prompts.js';
-import { readPromptDocument } from '../shared/llm-prompts/index.js';
+} from '../../src/shared/llm-prompts/judge-prompts.js';
+import { readPromptDocument } from '../../src/shared/llm-prompts/index.js';
 import {
   PROMPTS_DIR,
   SOFT_STANDARD_PROMPT_ID,
   SOFT_STANDARD_PROMPT_VERSION,
-} from '../observability/soft-standards/constants.js';
+} from '../../src/observability/soft-standards/constants.js';
 
 /**
  * omk 所有 LLM prompt 的单一编目 —— 发现入口 + 测量学冻结入口。
@@ -16,7 +16,7 @@ import {
  * 解决「prompt 散在多个目录、难管理」与「只有 2 个 prompt 被冻结」两个问题:
  *   - 每条登记 prompt 的位置(module)+ 用途,一处可查全。
  *   - measurementInvariant 为 true 的(直接决定分数的评委 prompt)带 getHash,
- *     由 test/shared/prompt-registry-freeze.test.ts 统一冻结,文本漂移即 CI 红。
+ *     由 test/measurement-governance/prompt-registry-freeze.test.ts 统一冻结,文本漂移即 CI 红。
  *
  * 注意:hash 形状按各自历史口径,不强行统一 ——
  *   - rubric 评委:12 位(getJudgePromptHash,持久化进 report.meta.judgePromptHash 的同口径);

--- a/test/observability/llm-enhanced-review-prompt.test.ts
+++ b/test/observability/llm-enhanced-review-prompt.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { readPromptDocument } from '../../src/shared/llm-prompts/index.js';
 import { PROMPTS_DIR } from '../../src/observability/soft-standards/index.js';
 
-// llm-enhanced-review prompt 的 byte-level 冻结已统一进 test/shared/prompt-registry-freeze.test.ts
+// llm-enhanced-review prompt 的 byte-level 冻结已统一进 test/measurement-governance/prompt-registry-freeze.test.ts
 // (registry 条目 `observe-llm-enhanced-review`)。这里只保留 prompt 文件的 cwd 可移植性测试 ——
 // 它不属于「评分类 prompt 编目」,但对 npm 安装场景至关重要,故留在 observability 旁。
 describe('llm-enhanced-review prompt portability', () => {


### PR DESCRIPTION
## 用户影响

无运行时行为变化。Prompt Registry 现在明确属于 CI／维护期测量治理，不再让运行产物定位领域依赖 Observability。

## 架构边界

- 将仅被冻结测试消费的跨域 prompt 清单与测试归入 `test/measurement-governance`，不虚构新的生产运行时领域。
- `measurement-artifacts` 重新只负责目录、文件名、索引与运行产物定位。
- 新增反向依赖与旧路径守卫，不保留兼容转发或重复清单。
- 修正维护者入口、冻结路径与已经失真的 commit scope 示例。

## 迁移说明

没有公开包导出、运行时 API 或数据迁移。维护者若修改评分类 prompt，应使用新的 measurement-governance 冻结入口。

## 测量学说明

Registry 条目、7 个冻结 hash 与所有 prompt 文本均未改变；未修改 public schema、评分管道、统计公式或 length-debias 语义，因此不改变跨版本测量可比性。

Part of #581