### PR TITLE
refactor(observability): 归位 Skill Health 能力

### DIFF
--- a/src/cli/commands/observe/index.ts
+++ b/src/cli/commands/observe/index.ts
@@ -9,7 +9,7 @@ import { parseLastWindow } from '../../lib/shared.js';
 import { projectObserveHealthDir, globalObserveHealthDir } from '../../../measurement-artifacts/directories.js';
 import { indexObserveWrite } from '../../../measurement-artifacts/discovery-index.js';
 import { reportFilePath, runFileSuffix } from '../../../measurement-artifacts/file-names.js';
-import type { SkillHealthReport } from '../../../observability/skill-health-analyzer.js';
+import type { SkillHealthReport } from '../../../observability/skill-health/analyzer.js';
 import { writeJsonFileAtomic } from '../../../shared/atomic-json.js';
 
 /**
@@ -82,7 +82,7 @@ export function buildObserveReportView(
  */
 async function recordObserveFeedback(report: SkillHealthReport, reportId: string, lang: CliLang): Promise<void> {
   try {
-    const { healthBandOf } = await import('../../../observability/skill-health-analyzer.js');
+    const { healthBandOf } = await import('../../../observability/skill-health/analyzer.js');
     const { recordObserveHealth } = await import('../../../managed/index.js');
     const written = recordObserveHealth(buildObserveReportView(report, reportId, healthBandOf));
     for (const w of written) {
@@ -197,7 +197,7 @@ export default class Observe extends BaseCommand {
       const skills = flags.skills ? flags.skills.split(',').map((s) => s.trim()).filter(Boolean) : undefined;
 
       console.log(`[omk] analyzing ${tracePath}...`);
-      const { computeSkillHealthReport } = await import('../../../observability/skill-health-analyzer.js');
+      const { computeSkillHealthReport } = await import('../../../observability/skill-health/analyzer.js');
       const report = computeSkillHealthReport(tracePath, {
         kbRoot: flags.kb ? resolve(flags.kb) : undefined,
         from,

--- a/src/diagnosis/observe-producer.ts
+++ b/src/diagnosis/observe-producer.ts
@@ -1,5 +1,5 @@
-import { buildObservationSkillChain, buildObservationSkillChains, type ObservationRuntimeCheck, type ObservationSkillChain } from '../observability/skill-chain.js';
-import { getSkillChainAdvisory, resolveAdvisoryCommand } from '../observability/skill-chain-advisories.js';
+import { buildObservationSkillChain, buildObservationSkillChains, type ObservationRuntimeCheck, type ObservationSkillChain } from '../observability/skill-health/skill-chain.js';
+import { getSkillChainAdvisory, resolveAdvisoryCommand } from '../observability/skill-health/advisories.js';
 import type { ObservationInboxReport } from '../observability/inbox/index.js';
 import type {
   ExperienceEvidenceRef,

--- a/src/observability/experience/review-checklist.ts
+++ b/src/observability/experience/review-checklist.ts
@@ -34,7 +34,7 @@ import {
 import {
   loadExpectedToolsForSkill,
   loadSkillDeclarationCheck,
-} from '../experience-frontmatter.js';
+} from '../skill-health/experience-frontmatter.js';
 
 export function aggregateExperienceChecklistItemStatus(statuses: ExperienceChecklistItemStatus[]): ExperienceChecklistItemStatus {
   if (statuses.includes('degraded')) return 'degraded';

--- a/src/observability/experience/session-story.ts
+++ b/src/observability/experience/session-story.ts
@@ -71,7 +71,7 @@ import {
 } from './review-checklist.js';
 import {
   loadFrontmatterSkillType,
-} from '../experience-frontmatter.js';
+} from '../skill-health/experience-frontmatter.js';
 import {
   hasNegativeFeedbackSignal,
   hasPositiveFeedbackSignal,

--- a/src/observability/inbox/view-model.ts
+++ b/src/observability/inbox/view-model.ts
@@ -10,7 +10,7 @@ import {
   resolveObservationReviewSession,
   type ResolvedObservationReviewSession,
 } from './resolved-review.js';
-import { buildObservationSkillChains, type ObservationSkillChain } from '../skill-chain.js';
+import { buildObservationSkillChains, type ObservationSkillChain } from '../skill-health/skill-chain.js';
 import {
   loadSkillDerivedStandards,
   resolveSkillStandards,
@@ -241,7 +241,7 @@ export {
   observationMetricAnnotationTargetId,
 } from './review-state.js';
 export { resolveObservationReviewSession } from './resolved-review.js';
-export { getSkillChainAdvisory, resolveAdvisoryCommand } from '../skill-chain-advisories.js';
+export { getSkillChainAdvisory, resolveAdvisoryCommand } from '../skill-health/advisories.js';
 export {
   ASSISTANT_DELIVERABLE_ARTIFACT_RE,
   hasAssistantDeliverableArtifactText,
@@ -257,6 +257,6 @@ export {
 export type { ObservationInboxItem } from './index.js';
 export type { ObservationMetricKey } from './review-state.js';
 export type { ResolvedObservationReviewSession, ResolvedOwnerSuggestion } from './resolved-review.js';
-export type { SkillChainAdvisoryCode } from '../skill-chain-advisories.js';
+export type { SkillChainAdvisoryCode } from '../skill-health/advisories.js';
 export type { ExperienceProblemBucket, ExperienceProblemPattern, ExperienceProblemSignal } from './problem-patterns.js';
 export type { SkillDerivedStandard, SkillLlmEnhancedReviewSections } from '../soft-standards/index.js';

--- a/src/observability/skill-health/advisories.ts
+++ b/src/observability/skill-health/advisories.ts
@@ -6,7 +6,7 @@
  * 这样将来 doctor 若也要展示同样的提示，code 可复用。
  */
 
-import type { SkillChainAdvisory, SkillChainAdvisoryCode } from './contracts/skill-chain-advisories.js';
+import type { SkillChainAdvisory, SkillChainAdvisoryCode } from '../contracts/skill-chain-advisories.js';
 
 export type { SkillChainAdvisory, SkillChainAdvisoryCode };
 

--- a/src/observability/skill-health/analyzer.ts
+++ b/src/observability/skill-health/analyzer.ts
@@ -12,10 +12,10 @@
  *   4. 聚合 overall 指标 + 健康度色带
  */
 
-import { buildKnowledgeIndex, computeCoverage, type CoverageReport } from './analysis/coverage-analyzer.js';
-import { computeGapReport } from './analysis/gap-analyzer.js';
-import type { TraceIngestionSummary } from './contracts/trace.js';
-import type { AnalysisEntry, GapReport } from './analysis/contracts.js';
+import { buildKnowledgeIndex, computeCoverage, type CoverageReport } from '../analysis/coverage-analyzer.js';
+import { computeGapReport } from '../analysis/gap-analyzer.js';
+import type { TraceIngestionSummary } from '../contracts/trace.js';
+import type { AnalysisEntry, GapReport } from '../analysis/contracts.js';
 import {
   segmentsToAnalysisEntries,
   skillSegmentTimestampObserved,
@@ -23,11 +23,11 @@ import {
   type CcSession,
   type TraceSession,
   type SkillSegment,
-} from './trace/index.js';
-import { legacyCcSessionToTraceSession } from './trace/source.js';
-import { createTraceSessionIndex } from './trace/session-index.js';
-import { setOwnRecordValue, sumRecordCounts } from '../shared/record-count.js';
-import { checkedSumTokenCounts } from '../shared/token-usage.js';
+} from '../trace/index.js';
+import { legacyCcSessionToTraceSession } from '../trace/source.js';
+import { createTraceSessionIndex } from '../trace/session-index.js';
+import { setOwnRecordValue, sumRecordCounts } from '../../shared/record-count.js';
+import { checkedSumTokenCounts } from '../../shared/token-usage.js';
 
 export interface SkillHealth {
   skillName: string;

--- a/src/observability/skill-health/experience-frontmatter.ts
+++ b/src/observability/skill-health/experience-frontmatter.ts
@@ -22,9 +22,9 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { parseSkillFrontmatter, validateSkillHardRules, validateSkillWorkflows } from '../skill-definition/hard-rules.js';
+import { parseSkillFrontmatter, validateSkillHardRules, validateSkillWorkflows } from '../../skill-definition/hard-rules.js';
 import { findSkillMdPath } from './skill-chain.js';
-import type { ExperienceRuntimeSkillType } from './contracts/experience.js';
+import type { ExperienceRuntimeSkillType } from '../contracts/experience.js';
 
 export interface SkillDeclarationCheck {
   hardRules: {

--- a/src/observability/skill-health/report.ts
+++ b/src/observability/skill-health/report.ts
@@ -1,11 +1,11 @@
-import type { CoverageReport } from './analysis/coverage-analyzer.js';
-import type { GapReport, GapSignalRef } from './analysis/contracts.js';
-import { SIGNAL_WEIGHTS } from './analysis/gap-analyzer.js';
-import type { SkillHealth, SkillHealthReport } from './skill-health-analyzer.js';
-import { confidenceOf, healthBandOf, toolStabilityOf } from './skill-health-analyzer.js';
-import { parseTraceIngestionSummary } from './trace/ingestion.js';
-import { sumRecordCounts } from '../shared/record-count.js';
-import { normalizeRfc3339Timestamp } from '../shared/timestamp.js';
+import type { CoverageReport } from '../analysis/coverage-analyzer.js';
+import type { GapReport, GapSignalRef } from '../analysis/contracts.js';
+import { SIGNAL_WEIGHTS } from '../analysis/gap-analyzer.js';
+import type { SkillHealth, SkillHealthReport } from './analyzer.js';
+import { confidenceOf, healthBandOf, toolStabilityOf } from './analyzer.js';
+import { parseTraceIngestionSummary } from '../trace/ingestion.js';
+import { sumRecordCounts } from '../../shared/record-count.js';
+import { normalizeRfc3339Timestamp } from '../../shared/timestamp.js';
 
 const TOOL_STABILITIES = new Set<SkillHealth['stability']>([
   'stable',

--- a/src/observability/skill-health/skill-chain.ts
+++ b/src/observability/skill-health/skill-chain.ts
@@ -5,14 +5,14 @@ import {
   extractMarkdownStepWorkflows,
   validateSkillHardRules,
   validateSkillWorkflows,
-} from '../skill-definition/hard-rules.js';
-import type { SkillHardRule, SkillWorkflow } from '../skill-definition/contracts.js';
-import { incrementRecordCount } from '../shared/record-count.js';
+} from '../../skill-definition/hard-rules.js';
+import type { SkillHardRule, SkillWorkflow } from '../../skill-definition/contracts.js';
+import { incrementRecordCount } from '../../shared/record-count.js';
 import type {
   ExperienceInvocation,
   ExperienceTimelineEvent,
   ObservationExperienceReport,
-} from './contracts/experience.js';
+} from '../contracts/experience.js';
 import type {
   ObservationRuntimeCheck,
   ObservationRuntimeCheckStatus,
@@ -21,7 +21,7 @@ import type {
   SkillRuntimeEvidencePackNode,
   SkillRuntimeEvidencePackRef,
   SkillRuntimeEvidencePackSourceType,
-} from './contracts/skill-chain.js';
+} from '../contracts/skill-chain.js';
 
 export type {
   ObservationRuntimeCheck,

--- a/src/observability/soft-standards/llm-extractor.ts
+++ b/src/observability/soft-standards/llm-extractor.ts
@@ -5,7 +5,7 @@ import type {
   ObservationSkillChain,
   SkillRuntimeEvidencePack,
   SkillRuntimeEvidencePackNode,
-} from '../skill-chain.js';
+} from '../skill-health/skill-chain.js';
 import {
   PROMPTS_DIR,
   SOFT_STANDARD_PROMPT_ID,

--- a/src/observability/soft-standards/runtime-evaluator.ts
+++ b/src/observability/soft-standards/runtime-evaluator.ts
@@ -2,7 +2,7 @@ import type {
   SkillRuntimeEvidencePack,
   SkillRuntimeEvidencePackNode,
   SkillRuntimeEvidencePackRef,
-} from '../skill-chain.js';
+} from '../skill-health/skill-chain.js';
 import type {
   RuntimeMatchedSignal,
   RuntimeNodeResult,

--- a/src/observability/soft-standards/skill-standards-store.ts
+++ b/src/observability/soft-standards/skill-standards-store.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { buildObservationSkillChain } from '../skill-chain.js';
+import { buildObservationSkillChain } from '../skill-health/skill-chain.js';
 import {
   ownRecordValue,
   setOwnRecordValue,

--- a/src/observability/soft-standards/types.ts
+++ b/src/observability/soft-standards/types.ts
@@ -3,7 +3,7 @@ import type {
   ObservationSkillChain,
   SkillRuntimeEvidencePack,
   SkillRuntimeEvidencePackRef,
-} from '../skill-chain.js';
+} from '../skill-health/skill-chain.js';
 import type { SOFT_STANDARD_PROMPT_ID, SOFT_STANDARD_PROMPT_VERSION } from './constants.js';
 
 export type SkillDerivedStandardStatus = 'pending_review' | 'author_confirmed' | 'rejected' | 'stale';

--- a/src/studio/application/skill-index.ts
+++ b/src/studio/application/skill-index.ts
@@ -13,9 +13,9 @@ import {
   listLiveDoctorCards,
   listLiveObserveCards,
 } from '../../measurement-artifacts/discovery-index.js';
-import { confidenceOf, toolStabilityOf, type SkillHealthReport } from '../../observability/skill-health-analyzer.js';
+import { confidenceOf, toolStabilityOf, type SkillHealthReport } from '../../observability/skill-health/analyzer.js';
 import { DEFAULT_OBSERVATIONS_DIR, loadLatestObservationInboxReports } from '../../observability/inbox/index.js';
-import { parseSkillHealthReport } from '../../observability/skill-health-report.js';
+import { parseSkillHealthReport } from '../../observability/skill-health/report.js';
 import { parseArtifactGraphDocument } from '../../artifact-graph/schema.js';
 import { parseDoctorReport } from '../../doctor/report-parser.js';
 import { ownRecordValue } from '../../shared/record-count.js';

--- a/src/studio/http/routes/knowledge.ts
+++ b/src/studio/http/routes/knowledge.ts
@@ -23,8 +23,8 @@ import {
   toolStabilityOf,
   type SkillHealth,
   type SkillHealthReport,
-} from '../../../observability/skill-health-analyzer.js';
-import { parseSkillHealthReport } from '../../../observability/skill-health-report.js';
+} from '../../../observability/skill-health/analyzer.js';
+import { parseSkillHealthReport } from '../../../observability/skill-health/report.js';
 import { parseDoctorReport } from '../../../doctor/report-parser.js';
 import type { Lang } from '../../../shared/language.js';
 import { buildSkillIndex } from '../../application/index.js';

--- a/src/studio/presentation/skill-health-renderer.ts
+++ b/src/studio/presentation/skill-health-renderer.ts
@@ -12,8 +12,8 @@
  *   - 报告视觉和 eval HTML 保持一致，读者无学习成本切换
  */
 
-import type { SkillHealth, SkillHealthReport } from '../../observability/skill-health-analyzer.js';
-import { confidenceOf, toolStabilityOf } from '../../observability/skill-health-analyzer.js';
+import type { SkillHealth, SkillHealthReport } from '../../observability/skill-health/analyzer.js';
+import { confidenceOf, toolStabilityOf } from '../../observability/skill-health/analyzer.js';
 import type { Lang } from '../../shared/language.js';
 import { COLORS, e, t } from './layout.js';
 import { icon } from './icons.js';

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -94,6 +94,11 @@ describe('领域契约所有权', () => {
       'src/observability/task-semantic-projection.ts',
       'src/observability/task-window.ts',
       'src/observability/turn-index.ts',
+      'src/observability/skill-health-analyzer.ts',
+      'src/observability/skill-health-report.ts',
+      'src/observability/skill-chain.ts',
+      'src/observability/skill-chain-advisories.ts',
+      'src/observability/experience-frontmatter.ts',
     ]) {
       expect(existsSync(resolve(legacyPath)), legacyPath).toBe(false);
     }

--- a/test/architecture/import-boundaries.test.ts
+++ b/test/architecture/import-boundaries.test.ts
@@ -167,7 +167,7 @@ const RULES: ForbiddenRule[] = [
   {
     from: 'studio/presentation/',
     to: 'observability/',
-    reason: 'Studio presentation 只能通过 facade 访问 observability，不应直接 import observability 内部实现。facade 见 observability/view-models/index.ts、observability/inbox/view-model.ts、observability/inbox/feedback-projection.ts、observability/skill-health-analyzer.ts。',
+    reason: 'Studio presentation 只能通过 facade 访问 observability，不应直接 import observability 内部实现。facade 见 observability/view-models/index.ts、observability/inbox/view-model.ts、observability/inbox/feedback-projection.ts、observability/skill-health/analyzer.ts。',
     whitelist: [
       'studio/presentation/conversation-renderer.ts::observability/view-models/index.ts',
       'studio/presentation/knowledge-debugger-renderer.ts::observability/view-models/index.ts',
@@ -180,7 +180,7 @@ const RULES: ForbiddenRule[] = [
       'studio/presentation/observation-inbox/reviewer-report.ts::observability/inbox/feedback-projection.ts',
       'studio/presentation/observation-inbox/timeline.ts::observability/inbox/view-model.ts',
       'studio/presentation/observation-inbox/timeline.ts::observability/inbox/feedback-projection.ts',
-      'studio/presentation/skill-health-renderer.ts::observability/skill-health-analyzer.ts',
+      'studio/presentation/skill-health-renderer.ts::observability/skill-health/analyzer.ts',
     ],
   },
 ];

--- a/test/cli/observe-persist.test.ts
+++ b/test/cli/observe-persist.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from 'node:os';
 import { persistObserveHealthReport } from '../../src/cli/commands/observe/index.js';
 import { listObserveCards } from '../../src/measurement-artifacts/discovery-index.js';
 import { isReportFileName } from '../../src/measurement-artifacts/file-names.js';
-import type { SkillHealthReport } from '../../src/observability/skill-health-analyzer.js';
+import type { SkillHealthReport } from '../../src/observability/skill-health/analyzer.js';
 
 function mkReport(): SkillHealthReport {
   return {

--- a/test/managed/observe-feedback.test.ts
+++ b/test/managed/observe-feedback.test.ts
@@ -11,8 +11,8 @@ import { tmpdir } from 'node:os';
 import { buildManagedArtifactRecord, upsertManagedRecord, loadManagedRecord, managedRecordId } from '../../src/managed/store.js';
 import { recordObserveHealth, type ObservedSkillHealthView } from '../../src/managed/observe-feedback.js';
 import { buildObserveReportView } from '../../src/cli/commands/observe/index.js';
-import { healthBandOf } from '../../src/observability/skill-health-analyzer.js';
-import type { SkillHealthReport } from '../../src/observability/skill-health-analyzer.js';
+import { healthBandOf } from '../../src/observability/skill-health/analyzer.js';
+import type { SkillHealthReport } from '../../src/observability/skill-health/analyzer.js';
 import type { ArtifactKind } from '../../src/artifacts/contracts.js';
 
 const GAP0 = { failed_search: 0, explicit_marker: 0, hedging: 0, repeated_failure: 0 };

--- a/test/observability/inbox/review-state.test.ts
+++ b/test/observability/inbox/review-state.test.ts
@@ -21,7 +21,7 @@ import {
   skillDerivedStandardsPath,
   updateSkillDerivedStandardStatus,
 } from '../../../src/observability/soft-standards/index.js';
-import type { ObservationSkillChain } from '../../../src/observability/skill-chain.js';
+import type { ObservationSkillChain } from '../../../src/observability/skill-health/skill-chain.js';
 
 describe('observe inbox - review state', () => {
   it('persists local reviewer state for D1 workflow', () => {

--- a/test/observability/skill-health/analyzer.test.ts
+++ b/test/observability/skill-health/analyzer.test.ts
@@ -2,14 +2,14 @@ import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import {
   computeSkillHealthFromSegments,
-} from '../../src/observability/skill-health-analyzer.js';
+} from '../../../src/observability/skill-health/analyzer.js';
 import {
   segmentBySkill,
   type CcSession,
   type SkillSegment,
   type TraceSession,
-} from '../../src/observability/trace/index.js';
-import type { ToolCallStatus } from '../../src/executors/contracts/trace.js';
+} from '../../../src/observability/trace/index.js';
+import type { ToolCallStatus } from '../../../src/executors/contracts/trace.js';
 
 // ---------- Helpers ----------
 

--- a/test/observability/skill-health/report.test.ts
+++ b/test/observability/skill-health/report.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
-import { computeSkillHealthFromSegments } from '../../src/observability/skill-health-analyzer.js';
-import { parseSkillHealthReport } from '../../src/observability/skill-health-report.js';
+import { computeSkillHealthFromSegments } from '../../../src/observability/skill-health/analyzer.js';
+import { parseSkillHealthReport } from '../../../src/observability/skill-health/report.js';
 
 function legacyReport(): Record<string, unknown> {
   return {

--- a/test/observability/skill-health/skill-chain.test.ts
+++ b/test/observability/skill-health/skill-chain.test.ts
@@ -3,8 +3,8 @@ import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { __resetSkillIndexCacheForTests, buildObservationSkillChain, findSkillMdPath } from '../../src/observability/skill-chain.js';
-import type { ObservationExperienceReport } from '../../src/observability/experience.js';
+import { __resetSkillIndexCacheForTests, buildObservationSkillChain, findSkillMdPath } from '../../../src/observability/skill-health/skill-chain.js';
+import type { ObservationExperienceReport } from '../../../src/observability/experience.js';
 
 describe('observation skill chain runtime checks', () => {
   it('checks observable hardRules and workflow nodes without LLM', () => {

--- a/test/observability/soft-standards.test.ts
+++ b/test/observability/soft-standards.test.ts
@@ -6,7 +6,7 @@ import {
   type RuntimeSignalType,
   type RuntimeStandardNode,
 } from '../../src/observability/soft-standards/index.js';
-import type { SkillRuntimeEvidencePack, SkillRuntimeEvidencePackRef, SkillRuntimeEvidencePackSourceType } from '../../src/observability/skill-chain.js';
+import type { SkillRuntimeEvidencePack, SkillRuntimeEvidencePackRef, SkillRuntimeEvidencePackSourceType } from '../../src/observability/skill-health/skill-chain.js';
 
 const { evaluateRuntimeStandardNodes, normalizeRuntimeSignals, normalizeRuntimeTriggers, normalizeFuzzyText, normalizeToolNameValue } = __softStandardsTestInternals;
 

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -39,7 +39,7 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   "src/observability/contracts/inbox.ts::ObservationInboxReport::'observe-inbox'",
   "src/observability/contracts/experience.ts::ObservationExperienceReport::'observe-experience'",
   "src/observability/soft-standards/types.ts::SkillDerivedStandards::'observe-skill-derived-standards'",
-  "src/observability/skill-health-analyzer.ts::SkillHealthReport::'observe-health'",
+  "src/observability/skill-health/analyzer.ts::SkillHealthReport::'observe-health'",
   // —— 持久化 observe / experience JSON ——
   'src/observability/contracts/experience.ts::ExperienceEvidenceRef::ExperienceEvidenceKind',
   'src/observability/contracts/experience.ts::ExperienceSessionStoryNode::ExperienceSessionStoryNodeKind',

--- a/test/studio/presentation/skill-health-confidence.test.ts
+++ b/test/studio/presentation/skill-health-confidence.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { renderSkillHealthReport } from '../../../src/studio/presentation/skill-health-renderer.js';
-import type { SkillHealthReport } from '../../../src/observability/skill-health-analyzer.js';
+import type { SkillHealthReport } from '../../../src/observability/skill-health/analyzer.js';
 
 // Legacy *-skill-health.json predate the `confidence` field. The renderer must derive
 // it from segmentCount instead of rendering `undefined confidence`, and an underpowered


### PR DESCRIPTION
## 用户影响

无可见行为变化。Skill Health analyzer／report、Skill Chain、advisories 与 Experience frontmatter 现在统一由 `observability/skill-health` 垂直子域拥有。

## 架构边界

- 健康度聚合、运行证据链与声明侧 frontmatter 投影形成同一 Skill Health 边界。
- Soft Standards 保持独立子域，通过 Skill Chain facade 消费运行证据，不与健康度报告实现混合。
- CLI、Diagnosis、Inbox 与 Studio 直接迁移新路径；旧根路径删除并加回退守卫。

## 迁移说明

没有 package root public export、schema 或持久化格式变化。既有 `SkillHealthReport.kind` 持久化例外只更新冻结守卫路径，字段和值保持不变。

## 测量学说明

5 个移动模块除 import／re-export 外的 TypeScript AST 均精确等价；coverage、gap、confidence、health band、tool stability 与 runtime evidence 语义未改变，因此不影响测量可比性。

Part of #581