### PR TITLE
refactor(observability): 收口子域与依赖边界

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -31,6 +31,36 @@ flowchart TD
 - **Persistence is immutable.** Each run publishes its Run Plan, Execution, Evaluation, and Analysis Bundles, and Evaluation Report as one digest-linked artifact set. Corruption or broken lineage fails explicitly.
 - **Studio is a projection.** UI cards and pages can be rebuilt from Core artifacts and never become a second measurement model.
 
+## Source dependency model
+
+Directories under `src` express domain ownership rather than one mechanical repository-wide layering scheme. Three dependency kinds are reviewed separately:
+
+- **Runtime implementation edges** must remain acyclic. A domain implementation may depend on facts it consumes or lower-level capabilities, but it may not create a reverse dependency through a facade, dynamic import, or utility module.
+- **Contract edges** share stable data shapes across domains. A bidirectional domain relationship is valid only when its type-only contract return edge has been audited and registered; architecture tests reject new bidirectional relationships.
+- **Composition edges** belong to delivery and host entry points such as `cli`, `dsh-plugin`, and `eval-workflows/production-host`. They may assemble domains and effects, while domain implementations may not import delivery composition.
+
+`shared` is a cross-domain leaf and depends only on itself. `evaluation-core` is the host-neutral measurement kernel. Filesystems, directories, persistence, provider runtimes, and UI remain outside Core and are assembled by hosts.
+
+Diagnosis and Observability have an explicit boundary. Observability produces trace, inbox, and experience facts and may read only stable types or parsers under `diagnosis/contracts`. The downstream `diagnosis/observe-producer.ts` consumes those Observability facts to derive Diagnosis. Neither side may access any other private implementation across this boundary.
+
+## Observability subdomains
+
+The `src/observability` root retains only the stable `experience.ts` facade. Private implementations belong to vertical subdomains:
+
+```text
+observability/
+├── contracts/
+├── trace/           # source-neutral IR, message classification, ingestion, adapters
+├── inbox/           # observation inbox, review, and feedback projections
+├── conversation/    # conversation catalog, windows, and debugger projections
+├── experience/      # experience facts, report derivation, and text signals
+├── skill-health/    # skill chain, health checks, and advisories
+├── soft-standards/
+└── view-models/     # stable presentation facades
+```
+
+Trace's `message-classification.ts` decides message origin and protocol semantics. Experience's `text-signals.ts` decides hard-rule, progress, and delivery signals. Adapters therefore do not depend backwards on downstream experience projections. Old root paths are not retained as re-exports or compatibility shims.
+
 ## Scoring and release decisions
 
 Assertions and rubric judges remain separate evaluator instruments. Analysis derives assertion layers, judge replicates and ensembles, dimensions, composite values, Bootstrap comparison families, and agreement tables without collapsing their identities.

--- a/docs/zh/explanation/architecture.md
+++ b/docs/zh/explanation/architecture.md
@@ -31,6 +31,36 @@ flowchart TD
 - **持久化不可变。** 每个 run 会把 Run Plan、Execution／Evaluation／Analysis Bundle 与 Evaluation Report 作为一组 digest-linked 产物原子发布。损坏或 lineage 断裂必须显式失败；
 - **Studio 只是 projection。** UI 卡片与页面可以从 Core 产物重建，绝不成为第二套测量模型。
 
+## 源码依赖模型
+
+`src` 的目录表达领域所有权，不机械套用一组全仓分层。维护时需要区分三类依赖：
+
+- **运行时实现边**必须保持无环。领域实现只能依赖它所消费的事实或更低层能力，不能借 facade、动态 import 或工具函数形成反向依赖；
+- **contracts 边**允许跨领域共享稳定数据形状。双向领域关系只有经过审计并登记的 type-only contract 回边才成立，新增双向关系会被架构测试拒绝；
+- **composition edge**由 `cli`、`dsh-plugin` 与 `eval-workflows/production-host` 等交付／宿主入口拥有。它们可以装配领域与 effect，领域实现不得反向 import delivery composition。
+
+`shared` 是跨领域叶子，只依赖自身。`evaluation-core` 是宿主无关的测量内核。文件系统、目录、持久化、provider Runtime 与 UI 都在 Core 外由宿主装配。
+
+Diagnosis 与 Observability 是一个显式建模的边界：Observability 产生 trace、inbox 与 experience 事实，只能读取 `diagnosis/contracts` 的稳定类型／解析器；`diagnosis/observe-producer.ts` 作为下游 producer 消费这些 Observability 事实并派生 Diagnosis。双方都不能访问除此以外的私有实现。
+
+## Observability 子域
+
+`src/observability` 根目录只保留稳定的 `experience.ts` facade，私有实现按垂直子域归属：
+
+```text
+observability/
+├── contracts/
+├── trace/           # source-neutral IR、来源分类、ingestion、adapter
+├── inbox/           # 观测收件箱、复核与反馈投影
+├── conversation/    # 对话目录、窗口与调试投影
+├── experience/      # 体验事实、报告派生与文本信号
+├── skill-health/    # Skill chain、健康检查与建议
+├── soft-standards/
+└── view-models/     # 稳定的呈现 facade
+```
+
+Trace 的 `message-classification.ts` 只判断消息来源与协议语义；Experience 的 `text-signals.ts` 才判断硬规则、进展与交付信号。因此 adapter 不会反向依赖其下游的体验投影。旧根路径不保留 re-export 或兼容 shim。
+
 ## 评分与发布决定
 
 Assertion 与 rubric 评委保持为不同 evaluator instrument。Analysis 会推导 assertion layer、judge replicate／ensemble、dimension、composite、Bootstrap comparison family 与 agreement table，但不会压平它们的身份。

--- a/src/authoring/core-evolver.ts
+++ b/src/authoring/core-evolver.ts
@@ -9,11 +9,9 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import type { JudgeConfig } from '../grading/contracts/config.js';
 import type { StoredCoreRunArtifacts } from '../eval-workflows/artifact-store/index.js';
 import { parseCompositeTableValue } from '../eval-workflows/runtime-adapter/analysis/composite-table.js';
 import { createExecutor } from '../executors/index.js';
-import { runCoreEvaluationCommand } from '../cli/lib/run-core-evaluation.js';
 import { buildImprovementPrompt, computeEditDelta } from './improvement.js';
 import { distributableCopyFilter } from '../inputs/content-hash.js';
 
@@ -23,17 +21,14 @@ const IMPROVE_AGENT_SYSTEM_PROMPT = `你是一个 AI 提示词改进专家。请
 export interface CoreEvolverOptions {
   skillPath: string;
   isDirectorySkill: boolean;
-  samplesPath: string;
   rounds: number;
   target: number | null;
   model: string;
-  judgeModels: JudgeConfig[];
   improveModel: string;
   executorName: string;
-  concurrency: number;
   timeoutMs: number;
   effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
-  skipDoctor: boolean;
+  evaluatePair: (control: string, treatment: string) => Promise<StoredCoreRunArtifacts>;
   writeBackToSource: boolean;
   improveMode: 'agent' | 'rewrite';
   editBudget: number;
@@ -187,42 +182,6 @@ function coreAccepted(stored: StoredCoreRunArtifacts): boolean {
     && decision.reasonCodes.includes('release-gates-passed');
 }
 
-async function evaluatePair(
-  options: CoreEvolverOptions,
-  control: string,
-  treatment: string,
-): Promise<StoredCoreRunArtifacts> {
-  const result = await runCoreEvaluationCommand({
-    flags: {
-      control,
-      treatment,
-      samples: options.samplesPath,
-      executor: options.executorName,
-      model: options.model,
-      'judge-models': options.judgeModels.map((judge) => `${judge.executor}:${judge.model}`).join(','),
-      concurrency: options.concurrency,
-      timeout: Math.max(1, Math.ceil(options.timeoutMs / 1000)),
-      effort: options.effort,
-      'skip-doctor': options.skipDoctor,
-      'no-evidence': true,
-      'no-serve': true,
-      'report-only': true,
-    },
-    config: {
-      samplesPath: options.samplesPath,
-      skillDir: dirname(options.skillPath),
-      executorName: options.executorName,
-      model: options.model,
-      effort: options.effort,
-      judgeModels: options.judgeModels,
-    },
-    evalConfig: null,
-    lang: 'zh',
-  });
-  if (result.stored === undefined) throw new Error('Core evolve evaluation 未持久化 artifact chain。');
-  return result.stored;
-}
-
 /** Core-native authoring loop: every acceptance is an explicit Core A/B decision. */
 export async function evolveSkillCore(options: Readonly<CoreEvolverOptions>): Promise<CoreEvolverResult> {
   const sourcePath = resolve(options.skillPath);
@@ -245,7 +204,7 @@ export async function evolveSkillCore(options: Readonly<CoreEvolverOptions>): Pr
   const baselinePath = snapshot(0, currentContent).root;
   const allVersions = [baselinePath];
   const baseline = targetMeasurement(
-    await evaluatePair(options, 'baseline', baselinePath),
+    await options.evaluatePair('baseline', baselinePath),
     'treatment',
   );
   let currentMeasurement = baseline;
@@ -333,7 +292,7 @@ export async function evolveSkillCore(options: Readonly<CoreEvolverOptions>): Pr
       if (consecutiveRejects >= 2) break;
       continue;
     }
-    const artifacts = await evaluatePair(options, currentPath, candidatePath!);
+    const artifacts = await options.evaluatePair(currentPath, candidatePath!);
     const candidate = targetMeasurement(artifacts, 'treatment');
     const refreshedCurrent = targetMeasurement(artifacts, 'control');
     totalCostUSD += candidate.costUSD;
@@ -384,7 +343,7 @@ export async function evolveSkillCore(options: Readonly<CoreEvolverOptions>): Pr
     // Final admission compares the untouched original source with the selected snapshot. The source
     // is written only after that authenticated Core decision passes, so a failed final run cannot
     // leave a half-committed evolve result on disk.
-    evidence = await evaluatePair(options, baselinePath, currentPath);
+    evidence = await options.evaluatePair(baselinePath, currentPath);
     if (!coreAccepted(evidence)) {
       throw new Error('Core evolve 最终写回门禁未通过；源文件保持不变。');
     }

--- a/src/cli/commands/evolve.ts
+++ b/src/cli/commands/evolve.ts
@@ -206,6 +206,41 @@ export async function runEvolve(
   }
 
   const { evolveSkillCore } = await import('../../authoring/core-evolver.js');
+  const { runCoreEvaluationCommand } = await import('../lib/run-core-evaluation.js');
+  const evolveEffort = flags.effort ? validateEvolveEffort(flags.effort, lang) : undefined;
+  const evaluatePair = async (control: string, treatment: string) => {
+    const evaluation = await runCoreEvaluationCommand({
+      flags: {
+        control,
+        treatment,
+        samples: resolve(samplesFile),
+        executor: flags.executor,
+        model: flags.model,
+        'judge-models': evolveJudges.map((judge) => `${judge.executor}:${judge.model}`).join(','),
+        concurrency: Math.max(1, Number(flags.concurrency) || 1),
+        timeout: Math.max(1, Math.ceil(Number(flags.timeout) || 600)),
+        effort: evolveEffort,
+        'skip-doctor': flags['skip-doctor'],
+        'no-evidence': true,
+        'no-serve': true,
+        'report-only': true,
+      },
+      config: {
+        samplesPath: resolve(samplesFile),
+        skillDir: dirname(resolve(skillPath)),
+        executorName: flags.executor,
+        model: flags.model,
+        effort: evolveEffort,
+        judgeModels: evolveJudges,
+      },
+      evalConfig: null,
+      lang: 'zh',
+    });
+    if (evaluation.stored === undefined) {
+      throw new Error('Core evolve evaluation 未持久化 artifact chain。');
+    }
+    return evaluation.stored;
+  };
 
   process.stderr.write(tCli('cli.evolve.section_header', lang, { path: skillPath }));
 
@@ -213,17 +248,14 @@ export async function runEvolve(
     const result: EvolveResult = await evolveSkillCore({
       skillPath: resolve(skillPath),
       isDirectorySkill: skillIsDir,
-      samplesPath: resolve(samplesFile),
       rounds: Math.max(1, Number(flags.rounds) || 5),
       target: flags.target ? Number(flags.target) : null,
       model: flags.model,
-      judgeModels: evolveJudges,
       improveModel: flags['improve-model'],
       executorName: flags.executor,
-      concurrency: Math.max(1, Number(flags.concurrency) || 1),
       timeoutMs: Math.max(1, Number(flags.timeout) || 600) * 1000,
-      effort: flags.effort ? validateEvolveEffort(flags.effort, lang) : undefined,
-      skipDoctor: flags['skip-doctor'],
+      effort: evolveEffort,
+      evaluatePair,
       editBudget: flags['no-edit-budget'] ? 0 : Number(flags['edit-budget']),
       rejectMemory: !flags['no-reject-memory'],
       // --snapshot-only:不写回 source,候选只留在 evolve/<skillName>.r{N}.md(供人工挑选 / promote)。

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -86,7 +86,8 @@ import {
 import { createTraceSessionIndex, traceSessionRefIdentity } from './trace/session-index.js';
 import { reconstructExperienceTurns } from './conversation/turn-index.js';
 import { isToolResultFailureText } from '../executors/tool-call-status.js';
-import { hasAssistantDeliverableArtifactText, hasUserHardRuleText, isSyntheticUserMessageText, isUserInteractionMetricText, USER_INTERRUPTION_RE } from './text-signals.js';
+import { hasAssistantDeliverableArtifactText, hasUserHardRuleText, USER_INTERRUPTION_RE } from './experience/text-signals.js';
+import { isSyntheticUserMessageText, isUserInteractionMetricText } from './trace/message-classification.js';
 import {
   compareTimelineEvents,
   hashParts,

--- a/src/observability/experience/report-derivations.ts
+++ b/src/observability/experience/report-derivations.ts
@@ -21,7 +21,7 @@ import {
 } from '../../shared/record-count.js';
 import { checkedSumTokenCounts } from '../../shared/token-usage.js';
 import { UNOBSERVED_TRACE_TIMESTAMP } from '../trace/segmentation.js';
-import { isAssistantProgressUpdateText } from '../text-signals.js';
+import { isAssistantProgressUpdateText } from './text-signals.js';
 import { isAssistantDeliveryEvent } from './timeline.js';
 import {
   uniqueBy,

--- a/src/observability/experience/review-checklist.ts
+++ b/src/observability/experience/review-checklist.ts
@@ -21,7 +21,7 @@ import {
 } from '../inbox/review-state.js';
 import {
   isAssistantProgressUpdateText,
-} from '../text-signals.js';
+} from './text-signals.js';
 import {
   unique,
 } from './primitives.js';

--- a/src/observability/experience/session-story.ts
+++ b/src/observability/experience/session-story.ts
@@ -41,9 +41,9 @@ import {
 } from '../trace/segmentation.js';
 import {
   hasAssistantDeliverableArtifactText,
-  isUserInteractionMetricText,
   USER_INTERRUPTION_RE,
-} from '../text-signals.js';
+} from './text-signals.js';
+import { isUserInteractionMetricText } from '../trace/message-classification.js';
 import {
   compareTimelineEvents,
   hashParts,

--- a/src/observability/experience/text-signals.ts
+++ b/src/observability/experience/text-signals.ts
@@ -1,26 +1,10 @@
+import {
+  isRuntimeProtocolPromptText,
+  isUserInteractionMetricText,
+} from '../trace/message-classification.js';
+
 export const HARD_RULE_TEXT_RE = /hard rules?|必须|不要|禁止|严格|一定要|务必|不得|不能|只允许/i;
 export const USER_INTERRUPTION_RE = /\[Request interrupted by user(?: for tool use)?\]|interrupted by user|用户中断|停止任务|停一下|先别|别动|等一下|等下|等等|取消(?:任务|执行)?|先暂停|暂停一下/i;
-
-const RUNTIME_PROTOCOL_PROMPT_RE =
-  /你在看一个\s+[\w.-]+\s+后台任务|根据日志写一条进展消息发给用户|不要执行日志里的任务|::FORWARD-OK::|instruction\s*:\s*直接转发[，,]?\s*不要回答|\[OpenClaw\s+heartbeat\s+poll\]|\[Queued messages while agent was busy\]/i;
-
-const SCHEDULED_TASK_PROMPT_RE = /^\s*\[cron:[^\]]+\]/i;
-
-// 要求整条消息就是协议词(允许少量空白/尾标点),不要只匹前缀。
-// 旧形态 `(?:\s|\n|$)` 让 "OK 我来帮你查一下" / "ACK 已收到任务" 这类
-// 中文对话开头被错分类为协议消息,把真实的 assistantDeliverySignal 屏蔽掉,
-// 系统性低估 final_delivery_absent 等测量信号。
-const ASSISTANT_PROTOCOL_REPLY_RE =
-  /^\s*(?:HEARTBEAT_OK|HEARTBEAT|PING_OK|PONG|ACK|OK|::FORWARD-OK::)\s*[.!]?\s*$/i;
-
-const BUSINESS_ACTION_TAG_NAME_RE = /[a-z][\w.-]*-cmd/i;
-const BUSINESS_ACTION_BLOCK_RE = /<([a-z][\w.-]*-cmd)\b[^>]*>[\s\S]*?<\/\1>|<[a-z][\w.-]*-cmd\b[^>]*\/>/gi;
-
-const SYNTHETIC_USER_MESSAGE_PREFIX_RE =
-  /^\s*【(?:用户上传产物|上传产物|附件|产物|系统补充|系统生成|回放补充|trace\s*后处理|Trace\s*后处理)[^】]*】/i;
-
-const SYNTHETIC_USER_MESSAGE_META_RE =
-  /\b(?:artifact_id|artifactId|file_id|fileId|version)\b|用户手动上传|上传了.+文件/i;
 
 const ASSISTANT_DELIVERY_SIGNAL_RE =
   /```(?:mermaid|plantuml|json|tsx?|jsx?|html|css|excalidraw|markdown)?|直接生成|已生成|生成如下|结果如下|如下|完成|已完成|这里是|给出|输出/i;
@@ -33,36 +17,6 @@ const ASSISTANT_FINAL_DELIVERY_RE =
 
 export const ASSISTANT_DELIVERABLE_ARTIFACT_RE =
   /```(?:mermaid|plantuml|json|tsx?|jsx?|html|css|excalidraw|markdown)?|https?:\/\/\S+|(?:文档|报告|方案|demo|Demo|预览|产物|文件|页面|dashboard|看板)(?:链接|地址|路径|URL)|(?:已生成|已创建|已写入|已保存|上传).{0,16}(?:文件|文档|报告|页面|demo|Demo|dashboard|看板|产物)|(?:^|[\s"'`(])(?:\/[\w.-]+){2,}\.(?:md|html|tsx?|jsx?|json|png|jpe?g|pdf|docx?|pptx?|xlsx?|csv)\b|(?:^|[\s"'`(])[\w.-]+\.(?:md|html|tsx?|jsx?|json|png|jpe?g|pdf|docx?|pptx?|xlsx?|csv)\b/i;
-
-export function isRuntimeProtocolPromptText(value: string): boolean {
-  return RUNTIME_PROTOCOL_PROMPT_RE.test(value);
-}
-
-export function isScheduledTaskPromptText(value: string): boolean {
-  return SCHEDULED_TASK_PROMPT_RE.test(value);
-}
-
-export function isAssistantProtocolReplyText(value: string): boolean {
-  const normalized = value.trim();
-  if (!normalized) return false;
-  return ASSISTANT_PROTOCOL_REPLY_RE.test(normalized);
-}
-
-export function isWorkflowSystemUserMessageText(value: string): boolean {
-  const stripped = value.replace(BUSINESS_ACTION_BLOCK_RE, '').trim();
-  return stripped.length === 0 && new RegExp(`<${BUSINESS_ACTION_TAG_NAME_RE.source}\\b`, 'i').test(value);
-}
-
-export function isSyntheticUserMessageText(value: string): boolean {
-  return isRuntimeProtocolPromptText(value)
-    || isWorkflowSystemUserMessageText(value)
-    || SYNTHETIC_USER_MESSAGE_PREFIX_RE.test(value)
-    || (/^\s*【[^】]+】/.test(value) && SYNTHETIC_USER_MESSAGE_META_RE.test(value));
-}
-
-export function isUserInteractionMetricText(value: string): boolean {
-  return !isScheduledTaskPromptText(value) && !isSyntheticUserMessageText(value);
-}
 
 export function hasUserHardRuleText(value: string): boolean {
   if (isRuntimeProtocolPromptText(value) || !isUserInteractionMetricText(value)) return false;

--- a/src/observability/experience/timeline.ts
+++ b/src/observability/experience/timeline.ts
@@ -16,8 +16,8 @@ import {
 } from '../trace/attribution.js';
 import {
   hasAssistantDeliverySignalText,
-  isAssistantProtocolReplyText,
-} from '../text-signals.js';
+} from './text-signals.js';
+import { isAssistantProtocolReplyText } from '../trace/message-classification.js';
 import {
   compareTimelineEvents,
   fullText,

--- a/src/observability/inbox/problem-patterns.ts
+++ b/src/observability/inbox/problem-patterns.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'node:crypto';
 import { observationMetricAnnotationVerdict } from './review-state.js';
 import type { ObservationMetricKey, ObservationReviewState } from '../contracts/review.js';
-import { hasUserHardRuleText, isUserInteractionMetricText } from '../text-signals.js';
+import { hasUserHardRuleText } from '../experience/text-signals.js';
+import { isUserInteractionMetricText } from '../trace/message-classification.js';
 import type {
   ExperienceProblemBucket,
   ExperienceProblemEvidenceRef,

--- a/src/observability/inbox/view-model.ts
+++ b/src/observability/inbox/view-model.ts
@@ -249,10 +249,12 @@ export {
   hasUserHardRuleText,
   HARD_RULE_TEXT_RE,
   isAssistantProgressUpdateText,
+} from '../experience/text-signals.js';
+export {
   isScheduledTaskPromptText,
   isSyntheticUserMessageText,
   isUserInteractionMetricText,
-} from '../text-signals.js';
+} from '../trace/message-classification.js';
 
 export type { ObservationInboxItem } from './index.js';
 export type { ObservationMetricKey } from './review-state.js';

--- a/src/observability/trace/message-classification.ts
+++ b/src/observability/trace/message-classification.ts
@@ -1,0 +1,48 @@
+const RUNTIME_PROTOCOL_PROMPT_RE =
+  /你在看一个\s+[\w.-]+\s+后台任务|根据日志写一条进展消息发给用户|不要执行日志里的任务|::FORWARD-OK::|instruction\s*:\s*直接转发[，,]?\s*不要回答|\[OpenClaw\s+heartbeat\s+poll\]|\[Queued messages while agent was busy\]/i;
+
+const SCHEDULED_TASK_PROMPT_RE = /^\s*\[cron:[^\]]+\]/i;
+
+// 要求整条消息就是协议词（允许少量空白／尾标点），不要只匹配前缀。
+// 否则「OK 我来帮你查一下」这类真实对话会被误判为协议消息。
+const ASSISTANT_PROTOCOL_REPLY_RE =
+  /^\s*(?:HEARTBEAT_OK|HEARTBEAT|PING_OK|PONG|ACK|OK|::FORWARD-OK::)\s*[.!]?\s*$/i;
+
+const BUSINESS_ACTION_TAG_NAME_RE = /[a-z][\w.-]*-cmd/i;
+const BUSINESS_ACTION_BLOCK_RE = /<([a-z][\w.-]*-cmd)\b[^>]*>[\s\S]*?<\/\1>|<[a-z][\w.-]*-cmd\b[^>]*\/>/gi;
+
+const SYNTHETIC_USER_MESSAGE_PREFIX_RE =
+  /^\s*【(?:用户上传产物|上传产物|附件|产物|系统补充|系统生成|回放补充|trace\s*后处理|Trace\s*后处理)[^】]*】/i;
+
+const SYNTHETIC_USER_MESSAGE_META_RE =
+  /\b(?:artifact_id|artifactId|file_id|fileId|version)\b|用户手动上传|上传了.+文件/i;
+
+export function isRuntimeProtocolPromptText(value: string): boolean {
+  return RUNTIME_PROTOCOL_PROMPT_RE.test(value);
+}
+
+export function isScheduledTaskPromptText(value: string): boolean {
+  return SCHEDULED_TASK_PROMPT_RE.test(value);
+}
+
+export function isAssistantProtocolReplyText(value: string): boolean {
+  const normalized = value.trim();
+  if (!normalized) return false;
+  return ASSISTANT_PROTOCOL_REPLY_RE.test(normalized);
+}
+
+export function isWorkflowSystemUserMessageText(value: string): boolean {
+  const stripped = value.replace(BUSINESS_ACTION_BLOCK_RE, '').trim();
+  return stripped.length === 0 && new RegExp(`<${BUSINESS_ACTION_TAG_NAME_RE.source}\\b`, 'i').test(value);
+}
+
+export function isSyntheticUserMessageText(value: string): boolean {
+  return isRuntimeProtocolPromptText(value)
+    || isWorkflowSystemUserMessageText(value)
+    || SYNTHETIC_USER_MESSAGE_PREFIX_RE.test(value)
+    || (/^\s*【[^】]+】/.test(value) && SYNTHETIC_USER_MESSAGE_META_RE.test(value));
+}
+
+export function isUserInteractionMetricText(value: string): boolean {
+  return !isScheduledTaskPromptText(value) && !isSyntheticUserMessageText(value);
+}

--- a/src/observability/trace/source.ts
+++ b/src/observability/trace/source.ts
@@ -25,7 +25,7 @@ import {
 import {
   isRuntimeProtocolPromptText,
   isSyntheticUserMessageText,
-} from '../text-signals.js';
+} from './message-classification.js';
 import { isToolResultFailureText } from '../../executors/tool-call-status.js';
 import type { TraceIngestionSummary, TraceSourceMetadata } from '../contracts/trace.js';
 import type {

--- a/test/architecture/dependency-graph.test.ts
+++ b/test/architecture/dependency-graph.test.ts
@@ -1,0 +1,271 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, normalize, relative, resolve, sep } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const SRC_DIR = resolve('src');
+const COMPOSITION_ROOT_PREFIXES = [
+  'cli/',
+  'dsh-plugin/',
+  'eval-workflows/production-host/',
+  'studio/',
+] as const;
+const DIAGNOSIS_OBSERVABILITY_PRODUCER_TARGETS = new Set([
+  'observability/experience.ts',
+  'observability/inbox/index.ts',
+  'observability/inbox/problem-patterns.ts',
+  'observability/skill-health/advisories.ts',
+  'observability/skill-health/skill-chain.ts',
+]);
+
+interface ModuleEdge {
+  importer: string;
+  target: string;
+  importerDomain: string;
+  targetDomain: string;
+  typeOnly: boolean;
+}
+
+function listSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) listSourceFiles(path, out);
+    else if (/\.tsx?$/.test(entry) && !entry.endsWith('.d.ts')) out.push(path);
+  }
+  return out;
+}
+
+function sourceRelative(path: string): string {
+  return relative(SRC_DIR, path).split(sep).join('/');
+}
+
+function resolveLocalModule(importer: string, specifier: string): string | null {
+  if (!specifier.startsWith('.')) return null;
+  const unresolved = normalize(resolve(dirname(importer), specifier));
+  const candidates = specifier.endsWith('.js')
+    ? [unresolved.replace(/\.js$/, '.ts'), unresolved.replace(/\.js$/, '.tsx')]
+    : [unresolved, `${unresolved}.ts`, `${unresolved}.tsx`, join(unresolved, 'index.ts')];
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function importIsTypeOnly(node: ts.ImportDeclaration): boolean {
+  const clause = node.importClause;
+  if (clause?.isTypeOnly) return true;
+  if (!clause || clause.name || !clause.namedBindings || ts.isNamespaceImport(clause.namedBindings)) {
+    return false;
+  }
+  return clause.namedBindings.elements.length > 0
+    && clause.namedBindings.elements.every((element) => element.isTypeOnly);
+}
+
+function exportIsTypeOnly(node: ts.ExportDeclaration): boolean {
+  if (node.isTypeOnly) return true;
+  return node.exportClause !== undefined
+    && ts.isNamedExports(node.exportClause)
+    && node.exportClause.elements.length > 0
+    && node.exportClause.elements.every((element) => element.isTypeOnly);
+}
+
+function collectModuleEdges(): ModuleEdge[] {
+  const edges: ModuleEdge[] = [];
+  const add = (importer: string, specifier: string, typeOnly: boolean): void => {
+    const target = resolveLocalModule(importer, specifier);
+    if (!target || !target.startsWith(`${SRC_DIR}${sep}`)) return;
+    const importerRelative = sourceRelative(importer);
+    const targetRelative = sourceRelative(target);
+    const importerDomain = importerRelative.split('/')[0];
+    const targetDomain = targetRelative.split('/')[0];
+    if (importerDomain === targetDomain || !importerRelative.includes('/')) return;
+    edges.push({
+      importer: importerRelative,
+      target: targetRelative,
+      importerDomain,
+      targetDomain,
+      typeOnly,
+    });
+  };
+
+  for (const file of listSourceFiles(SRC_DIR)) {
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, 'utf8'),
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    for (const statement of source.statements) {
+      if (ts.isImportDeclaration(statement) && ts.isStringLiteralLike(statement.moduleSpecifier)) {
+        add(file, statement.moduleSpecifier.text, importIsTypeOnly(statement));
+      } else if (
+        ts.isExportDeclaration(statement)
+        && statement.moduleSpecifier
+        && ts.isStringLiteralLike(statement.moduleSpecifier)
+      ) {
+        add(file, statement.moduleSpecifier.text, exportIsTypeOnly(statement));
+      }
+    }
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node)
+        && node.expression.kind === ts.SyntaxKind.ImportKeyword
+        && node.arguments.length === 1
+        && ts.isStringLiteralLike(node.arguments[0])
+      ) {
+        add(file, node.arguments[0].text, false);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+  return edges;
+}
+
+function isContractBoundary(target: string): boolean {
+  return target.includes('/contracts/')
+    || target.endsWith('/contracts.ts');
+}
+
+function domainPair(left: string, right: string): string {
+  return [left, right].sort().join('↔');
+}
+
+function describeEdge(edge: ModuleEdge): string {
+  return `${edge.importer} → ${edge.target}${edge.typeOnly ? '（type-only）' : ''}`;
+}
+
+function isCompositionRootModule(path: string): boolean {
+  return COMPOSITION_ROOT_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+function stronglyConnectedComponents(edges: ModuleEdge[]): string[][] {
+  const adjacency = new Map<string, Set<string>>();
+  for (const edge of edges) {
+    if (!adjacency.has(edge.importerDomain)) adjacency.set(edge.importerDomain, new Set());
+    adjacency.get(edge.importerDomain)!.add(edge.targetDomain);
+    if (!adjacency.has(edge.targetDomain)) adjacency.set(edge.targetDomain, new Set());
+  }
+  let nextIndex = 0;
+  const indices = new Map<string, number>();
+  const lowLinks = new Map<string, number>();
+  const stack: string[] = [];
+  const onStack = new Set<string>();
+  const components: string[][] = [];
+
+  const connect = (domain: string): void => {
+    indices.set(domain, nextIndex);
+    lowLinks.set(domain, nextIndex);
+    nextIndex += 1;
+    stack.push(domain);
+    onStack.add(domain);
+    for (const target of adjacency.get(domain) ?? []) {
+      if (!indices.has(target)) {
+        connect(target);
+        lowLinks.set(domain, Math.min(lowLinks.get(domain)!, lowLinks.get(target)!));
+      } else if (onStack.has(target)) {
+        lowLinks.set(domain, Math.min(lowLinks.get(domain)!, indices.get(target)!));
+      }
+    }
+    if (lowLinks.get(domain) !== indices.get(domain)) return;
+    const component: string[] = [];
+    let current: string;
+    do {
+      current = stack.pop()!;
+      onStack.delete(current);
+      component.push(current);
+    } while (current !== domain);
+    components.push(component.sort());
+  };
+
+  for (const domain of adjacency.keys()) {
+    if (!indices.has(domain)) connect(domain);
+  }
+  return components.filter((component) => component.length > 1);
+}
+
+const MUTUAL_BOUNDARY_VALIDATORS: Record<string, (edge: ModuleEdge) => boolean> = {
+  [domainPair('executors', 'inputs')]: (edge) =>
+    edge.typeOnly && isContractBoundary(edge.target),
+  [domainPair('grading', 'inputs')]: (edge) =>
+    edge.importerDomain === 'grading'
+      ? edge.targetDomain === 'inputs'
+      : edge.typeOnly && isContractBoundary(edge.target),
+  [domainPair('inputs', 'preflight')]: (edge) =>
+    edge.typeOnly && isContractBoundary(edge.target),
+  [domainPair('doctor', 'measurement-artifacts')]: (edge) => {
+    if (edge.importerDomain === 'doctor') {
+      return edge.importer === 'doctor/index.ts'
+        && edge.target === 'measurement-artifacts/file-names.ts';
+    }
+    return edge.importer === 'measurement-artifacts/discovery-index.ts'
+      && edge.typeOnly
+      && edge.target === 'doctor/contracts.ts';
+  },
+  [domainPair('diagnosis', 'observability')]: (edge) => {
+    if (edge.importerDomain === 'observability') {
+      return edge.target.startsWith('diagnosis/contracts');
+    }
+    return edge.importer === 'diagnosis/observe-producer.ts'
+      && DIAGNOSIS_OBSERVABILITY_PRODUCER_TARGETS.has(edge.target);
+  },
+};
+
+describe('src 依赖图', () => {
+  const edges = collectModuleEdges();
+
+  it('delivery composition root 只装配领域，不被领域反向依赖', () => {
+    const violations = edges
+      .filter((edge) => (
+        isCompositionRootModule(edge.target)
+        && !isCompositionRootModule(edge.importer)
+      ))
+      .map(describeEdge);
+    expect(violations).toEqual([]);
+  });
+
+  it('运行时实现依赖图保持无环', () => {
+    const runtimeImplementationEdges = edges.filter(
+      (edge) => !edge.typeOnly && !isContractBoundary(edge.target),
+    );
+    const cycles = stronglyConnectedComponents(runtimeImplementationEdges);
+    expect(cycles, `发现运行时实现依赖环：${cycles.map((cycle) => cycle.join(' → ')).join('；')}`).toEqual([]);
+  });
+
+  it('跨域双向依赖只允许已审计的 contracts／producer 边界', () => {
+    const directionsByPair = new Map<string, Set<string>>();
+    for (const edge of edges) {
+      const pair = domainPair(edge.importerDomain, edge.targetDomain);
+      if (!directionsByPair.has(pair)) directionsByPair.set(pair, new Set());
+      directionsByPair.get(pair)!.add(`${edge.importerDomain}→${edge.targetDomain}`);
+    }
+    const violations: string[] = [];
+    for (const [pair, directions] of directionsByPair) {
+      if (directions.size < 2) continue;
+      const validator = MUTUAL_BOUNDARY_VALIDATORS[pair];
+      const pairEdges = edges.filter(
+        (edge) => domainPair(edge.importerDomain, edge.targetDomain) === pair,
+      );
+      if (!validator) {
+        violations.push(`${pair}：未登记的新双向依赖`);
+        continue;
+      }
+      violations.push(...pairEdges
+        .filter((edge) => !validator(edge))
+        .map((edge) => `${pair}：${describeEdge(edge)}`));
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('双向依赖登记与真实依赖图同步', () => {
+    const activePairs = new Set<string>();
+    const directionPairs = new Map<string, Set<string>>();
+    for (const edge of edges) {
+      const pair = domainPair(edge.importerDomain, edge.targetDomain);
+      if (!directionPairs.has(pair)) directionPairs.set(pair, new Set());
+      directionPairs.get(pair)!.add(`${edge.importerDomain}→${edge.targetDomain}`);
+    }
+    for (const [pair, directions] of directionPairs) {
+      if (directions.size === 2) activePairs.add(pair);
+    }
+    expect(Object.keys(MUTUAL_BOUNDARY_VALIDATORS).sort()).toEqual([...activePairs].sort());
+  });
+});

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
@@ -99,9 +99,18 @@ describe('领域契约所有权', () => {
       'src/observability/skill-chain.ts',
       'src/observability/skill-chain-advisories.ts',
       'src/observability/experience-frontmatter.ts',
+      'src/observability/text-signals.ts',
     ]) {
       expect(existsSync(resolve(legacyPath)), legacyPath).toBe(false);
     }
+  });
+
+  it('observability 根目录只保留稳定 facade', () => {
+    const rootModules = readdirSync(resolve('src/observability'))
+      .filter((entry) => entry.endsWith('.ts'))
+      .sort();
+
+    expect(rootModules).toEqual(['experience.ts']);
   });
 
   it('领域 contracts 与 view-models 保持为无运行时实现的纯类型模块', () => {

--- a/test/architecture/import-boundaries.test.ts
+++ b/test/architecture/import-boundaries.test.ts
@@ -156,15 +156,6 @@ const RULES: ForbiddenRule[] = [
     reason: 'shared 是跨领域叶子依赖；观测投影与 prompt 编目由上层能力拥有。',
   },
   {
-    from: 'observability/',
-    to: 'diagnosis/',
-    reason: 'observability 是 diagnosis 的下游消费者，不应反向依赖 diagnosis 实现；只允许引用纯 contracts。',
-    whitelist: [
-      'observability/contracts/inbox.ts::diagnosis/contracts.ts',
-      'observability/inbox/index.ts::diagnosis/contracts/parser.ts',
-    ],
-  },
-  {
     from: 'studio/presentation/',
     to: 'observability/',
     reason: 'Studio presentation 只能通过 facade 访问 observability，不应直接 import observability 内部实现。facade 见 observability/view-models/index.ts、observability/inbox/view-model.ts、observability/inbox/feedback-projection.ts、observability/skill-health/analyzer.ts。',
@@ -456,7 +447,7 @@ describe('架构边界守门', () => {
       'utf-8',
     );
     const observationSignals = readFileSync(
-      join(SRC_DIR, 'observability', 'text-signals.ts'),
+      join(SRC_DIR, 'observability', 'experience', 'text-signals.ts'),
       'utf-8',
     );
 
@@ -540,7 +531,7 @@ describe('架构边界守门', () => {
       'utf-8',
     );
     const textSignals = readFileSync(
-      join(SRC_DIR, 'observability', 'text-signals.ts'),
+      join(SRC_DIR, 'observability', 'experience', 'text-signals.ts'),
       'utf-8',
     );
 

--- a/test/observability/inbox/signal-detection.test.ts
+++ b/test/observability/inbox/signal-detection.test.ts
@@ -23,12 +23,14 @@ import {
   hasAssistantDeliverySignalText,
   hasUserHardRuleText,
   isAssistantProgressUpdateText,
+} from '../../../src/observability/experience/text-signals.js';
+import {
   isRuntimeProtocolPromptText,
   isScheduledTaskPromptText,
   isSyntheticUserMessageText,
   isUserInteractionMetricText,
   isWorkflowSystemUserMessageText,
-} from '../../../src/observability/text-signals.js';
+} from '../../../src/observability/trace/message-classification.js';
 import {
   observationMetricAnnotationTargetId,
   observationReviewStateKey,

--- a/test/observability/trace/message-classification.test.ts
+++ b/test/observability/trace/message-classification.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { isAssistantProtocolReplyText } from '../../src/observability/text-signals.js';
+import { isAssistantProtocolReplyText } from '../../../src/observability/trace/message-classification.js';
 
 describe('isAssistantProtocolReplyText', () => {
   it('classifies bare protocol tokens as protocol reply', () => {


### PR DESCRIPTION
## 用户影响

- `src/observability` 根目录只保留稳定 Experience facade，消息来源分类与体验信号分别归属 Trace／Experience 子域。
- 源码依赖图开始分别约束运行时实现、contracts 与 delivery composition，新增运行时环和未审计双向领域依赖会直接失败。
- Evolve 的评测执行改由 CLI composition 注入 Authoring 端口，消除领域实现对 CLI 的反向依赖；命令参数、产物和判定语义保持不变。

## 架构与迁移

- Diagnosis／Observability 边界按稳定 contracts 与精确 producer 入口建模，不再使用宽泛实现白名单。
- `executors ↔ inputs`、`grading ↔ inputs`、`inputs ↔ preflight` 等现有双向 contract 边被显式登记，新增双向关系必须单独审计。
- 内部旧路径 `src/observability/text-signals.ts` 已删除，不提供兼容 shim；仓库内消费者已迁移到新的子域所有者。
- 中英文架构文档同步说明真实目录、依赖类型与 composition root。

## 测量学说明

本次只调整内部所有权、依赖装配与守卫。未修改 public schema、评分类 prompt、五层评分管道、Bootstrap CI、Krippendorff alpha、缺失证据语义或 length-debias 行为，因此不构成 `BREAKING-COMPARABILITY`。

Closes #581