### PR TITLE
feat(evaluation-core): 发布分阶段运行 capability

### DIFF
--- a/docs/specs/evaluation-core-vnext.md
+++ b/docs/specs/evaluation-core-vnext.md
@@ -1055,7 +1055,43 @@ The Compiler resolves one canonical `EffectiveExecutionControl` for every `(targ
 
 Runtime preparation separately binds the complete canonical control table through `RuntimeBinding.executionControlsDigest` and binds every required workspace through the aggregate resource lease. This prevents a host from pairing a validated Runtime with a different control table while preserving coordinate-local cache identity. An adapter must enforce the exact Trial workspace and exact tool policy, expose only the selected workspace lease, or fail closed during preparation when its backend cannot represent that policy. It may not approximate sample controls with a Target-wide union, common subset, process working directory, or best-effort filtering.
 
-## 24. Industry references
+## 24. ADR: publish staged execution through prepared capabilities
+
+**Status:** accepted for the public API tracked by [#597](https://github.com/lizhiyao/oh-my-knowledge/issues/597).
+
+The advanced API is issued by `PreparedEvaluation`, not by exporting a second engine that accepts
+wire-shaped plans. `prepared.stages(options)` creates one run-scoped stage session. The session owns
+the host-assigned run identity, AbortSignal, bounded event settings, EventWriter, and one shared
+EventSequencer. Each of Execution, Evaluation, Analysis, Decision, and Report materialization may be
+started once, in the suffix required by the host. Every method delegates directly to the existing
+stage runtime, so scheduling, cache, budget, failure, cancellation, and resource teardown semantics
+remain single-sourced.
+
+The session owns its `runId` in the Engine while it is open, rejects overlapping stages, and releases
+the identity automatically after Report termination. Hosts that intentionally stop at an earlier
+Bundle call `await stages.close()`; close aborts any in-flight stage, waits for its existing runtime
+teardown, and only then releases the identity. This prevents event identifier collisions with the
+one-call facade without introducing another scheduler.
+
+Execution and Evaluation in the same session share the authenticated in-memory budget capability.
+A detached Evaluation instead seeds a new budget capability from the admitted Execution source's
+verified ledger prefix, as the low-level runtime already requires. Stage outputs expose both their
+serializable document and the non-serializable source envelope. Event streams remain lossy,
+bounded observations and never gate the authoritative result.
+
+Transported artifacts re-enter through `PreparedEvaluation.admitExecutionBundle()`,
+`admitEvaluationBundle()`, `admitAnalysisBundle()`, and `admitDecisionResult()`. These methods close
+over the freshly sealed plan and Core-owned schema validators, recursively validate the exact parent
+chain, and return runtime-authenticated source capabilities. `admitReport()` validates the complete
+chain without creating a new authority. A copied plan, Bundle, verification summary, or provenance
+claim therefore cannot substitute for a capability issued by prepare, runtime execution, or
+plan-aware admission. Missing external attestations remain indeterminate and never become verified
+because their digest can be recomputed.
+
+This ADR publishes composition only. It changes no wire schema, Plan digest, scoring rule,
+statistical implementation, prompt, trust calculation, or comparability reason.
+
+## 25. Industry references
 
 - [Inspect AI Tasks](https://inspect.aisi.org.uk/tasks.html), [Scorers](https://inspect.aisi.org.uk/scorers.html), and [Eval Logs](https://inspect.aisi.org.uk/eval-logs.html)
 - [MLflow Evaluation Datasets](https://mlflow.org/docs/latest/genai/datasets/) and [LLM Judges and Scorers](https://mlflow.org/docs/latest/genai/eval-monitor/scorers/index.html)

--- a/docs/zh/specs/evaluation-core-vnext.md
+++ b/docs/zh/specs/evaluation-core-vnext.md
@@ -1045,7 +1045,39 @@ Compiler 为每个 `(targetId, sampleId)` coordinate 解析唯一 canonical `Eff
 
 Runtime prepare 通过 `RuntimeBinding.executionControlsDigest` 单独绑定完整 canonical control table，并通过聚合 resource lease 绑定全部必要 workspace。这既防止宿主把已验证 Runtime 与另一份 control table 拼接，又保留 coordinate-local cache identity。adapter 必须执行准确的 Trial workspace 与工具策略，并且只暴露被选中的 workspace lease；若后端无法准确表达该策略，则必须在 prepare 阶段 fail closed。adapter 不得退化为 Target-wide union、公共子集、进程级工作目录或 best-effort filter。
 
-## 二十四、行业参考
+## 二十四、ADR：通过 prepared capability 发布分阶段执行
+
+**状态**：接受，公共 API 交付由 [#597](https://github.com/lizhiyao/oh-my-knowledge/issues/597) 跟踪。
+
+高级 API 由 `PreparedEvaluation` 签发，不导出另一套接收 wire-shaped plan 的 Engine。
+`prepared.stages(options)` 创建一个 run-scoped stage session，由它持有宿主分配的 run identity、
+AbortSignal、有界 Event 配置、EventWriter 与一个共享 EventSequencer。Execution、Evaluation、
+Analysis、Decision 和 Report materialization 在同一 session 中各自最多启动一次；宿主可以从所需的
+任意有效阶段开始，只重算必要后缀。每个方法都直接委托现有 stage runtime，因此调度、cache、预算、
+失败、取消和资源释放语义继续只有一份来源。
+
+session 打开期间会在 Engine 内独占其 `runId`，拒绝阶段并发，并在 Report 到达终态后自动释放
+identity。宿主若有意停在更早的 Bundle，必须调用 `await stages.close()`；close 会取消仍在运行的
+阶段，等待既有 runtime 完成资源释放，再归还 identity。这样可以避免与一键 façade 产生 Event
+identifier 冲突，同时不引入另一套 scheduler。
+
+同一 session 中的 Execution 与 Evaluation 共享经过认证的内存预算 capability。Detached Evaluation
+则按照低层 runtime 的既有约束，从已接纳 Execution source 的 verified ledger prefix 创建新预算
+capability。阶段输出同时暴露可序列化 document 与不可序列化 source envelope。Event stream 继续是
+有界、允许丢失的观测通道，不会阻塞权威结果。
+
+传输后的 artifact 必须通过 `PreparedEvaluation.admitExecutionBundle()`、
+`admitEvaluationBundle()`、`admitAnalysisBundle()` 与 `admitDecisionResult()` 重新进入 Core。
+这些方法闭包捕获 freshly sealed plan 与 Core-owned schema validator，递归验证准确的 parent chain，
+并返回 runtime 认证过的 source capability。`admitReport()` 只验证完整来源链，不签发新的 authority。
+因此，复制 plan、Bundle、verification summary 或 provenance claim 都不能替代 prepare、runtime 执行或
+plan-aware admission 签发的 capability。缺少外部 attestation 时仍为 indeterminate，不能仅凭重算
+digest 升级为 verified。
+
+本 ADR 只发布组合能力，不改变 wire schema、Plan digest、评分规则、统计实现、prompt、trust 计算或
+comparability reason。
+
+## 二十五、行业参考
 
 - [Inspect AI Tasks](https://inspect.aisi.org.uk/tasks.html)、[Scorers](https://inspect.aisi.org.uk/scorers.html)、[Eval Logs](https://inspect.aisi.org.uk/eval-logs.html)；
 - [MLflow Evaluation Datasets](https://mlflow.org/docs/latest/genai/datasets/)、[LLM Judges and Scorers](https://mlflow.org/docs/latest/genai/eval-monitor/scorers/index.html)；

--- a/src/evaluation-core/contracts/analysis-bundle.ts
+++ b/src/evaluation-core/contracts/analysis-bundle.ts
@@ -300,7 +300,10 @@ export interface AnalysisBundlePlanVerification {
   readonly evaluationSourceTrust: Provenance['trust'];
 }
 
+declare const analysisBundleSourceBrand: unique symbol;
+
 export interface AnalysisBundleVerificationResult {
+  readonly [analysisBundleSourceBrand]: true;
   readonly bundle: AnalysisBundle;
   readonly planVerification: AnalysisBundlePlanVerification;
 }
@@ -849,7 +852,7 @@ export function verifyAnalysisBundle(
         : 'indeterminate' as const,
       evaluationSourceTrust: effectiveSourceTrust,
     },
-  };
+  } as AnalysisBundleVerificationResult;
   analysisBundleSources.add(result);
   return deepFreezeCanonicalJson(result);
 }

--- a/src/evaluation-core/contracts/evaluation-bundle.ts
+++ b/src/evaluation-core/contracts/evaluation-bundle.ts
@@ -479,7 +479,10 @@ export interface EvaluationBundlePlanVerification {
   readonly unverifiedCacheRecordDigests: readonly Sha256Digest[];
 }
 
+declare const evaluationBundleSourceBrand: unique symbol;
+
 export interface EvaluationBundleVerificationResult {
+  readonly [evaluationBundleSourceBrand]: true;
   readonly bundle: EvaluationBundle;
   readonly planVerification: EvaluationBundlePlanVerification;
 }
@@ -1391,7 +1394,7 @@ export function verifyEvaluationBundle(
     source,
     verification,
   );
-  const result = { bundle, planVerification };
+  const result = { bundle, planVerification } as EvaluationBundleVerificationResult;
   evaluationBundleSources.add(result);
   return deepFreezeCanonicalJson(result);
 }

--- a/src/evaluation-core/contracts/evaluation-report.ts
+++ b/src/evaluation-core/contracts/evaluation-report.ts
@@ -102,7 +102,10 @@ export interface DecisionResultPlanVerification {
   readonly analysisSourceTrust: Provenance['trust'];
 }
 
+declare const decisionResultSourceBrand: unique symbol;
+
 export interface DecisionResultVerificationResult {
+  readonly [decisionResultSourceBrand]: true;
   readonly result: DecisionResult;
   readonly planVerification: DecisionResultPlanVerification;
 }
@@ -336,7 +339,7 @@ export function verifyDecisionResult(
       analysisSourceTrust: verification?.analysisSourceTrust
         ?? effectiveAnalysisBundleTrust(analysisSource),
     },
-  };
+  } as DecisionResultVerificationResult;
   decisionResultSources.add(provisional);
   const source = deepFreezeCanonicalJson(provisional);
   assertDecision(

--- a/src/evaluation-core/contracts/execution-bundle.ts
+++ b/src/evaluation-core/contracts/execution-bundle.ts
@@ -480,7 +480,10 @@ export interface ExecutionBundlePlanVerification {
   readonly unverifiedCacheRecordDigests: readonly Sha256Digest[];
 }
 
+declare const executionBundleSourceBrand: unique symbol;
+
 export interface ExecutionBundleVerificationResult {
+  readonly [executionBundleSourceBrand]: true;
   readonly bundle: ExecutionBundle;
   readonly planVerification: ExecutionBundlePlanVerification;
 }
@@ -1040,7 +1043,7 @@ export function verifyExecutionBundle(
 ): ExecutionBundleVerificationResult {
   const bundle = parseExecutionBundleDocument(value);
   const planVerification = assertExecutionBundleMatchesPlan(bundle, plan, verification);
-  const source = { bundle, planVerification };
+  const source = { bundle, planVerification } as ExecutionBundleVerificationResult;
   executionBundleSources.add(source);
   return deepFreezeCanonicalJson(source);
 }

--- a/src/evaluation-core/engine/index.ts
+++ b/src/evaluation-core/engine/index.ts
@@ -2,6 +2,7 @@ import {
   canonicalizeJson,
   digestCanonicalJson,
   EvaluationErrorSchema,
+  IdentifierSchema,
   RuntimeIdentitySchema,
   type AnalysisBundle,
   type DecisionResult,
@@ -12,7 +13,16 @@ import {
   type ExecutionBundle,
   type ExecutionBundleSource,
   type AnalysisBundleSource,
+  type AnalysisBundleVerificationContext,
   type DecisionResultSource,
+  type DecisionResultVerificationContext,
+  type EvaluationBundleVerificationContext,
+  type ExecutionBundleVerificationContext,
+  parseEvaluationReport,
+  verifyAnalysisBundle,
+  verifyDecisionResult,
+  verifyEvaluationBundle,
+  verifyExecutionBundle,
 } from '../contracts/index.js';
 import {
   EvaluationDefinitionError,
@@ -24,6 +34,7 @@ import {
   type RuntimeResolution,
   type SealedRunPlan,
 } from '../compiler/index.js';
+import { snapshotJson } from '../compiler/immutability.js';
 import {
   AnalysisPortFailure,
   AnalysisRuntimeConfigurationError,
@@ -62,6 +73,8 @@ import type {
   PartialEvaluationRunArtifacts,
   PreparedEvaluation,
   PreparedEvaluationRunOptions,
+  PreparedEvaluationStageSession,
+  EvaluationStageSessionErrorCode,
 } from './types.js';
 
 export * from './types.js';
@@ -544,20 +557,297 @@ function startPrepared(
   };
 }
 
+export class EvaluationStageSessionError extends TypeError {
+  readonly code: EvaluationStageSessionErrorCode;
+
+  constructor(code: EvaluationStageSessionErrorCode, message: string) {
+    super(message);
+    this.name = 'EvaluationStageSessionError';
+    this.code = code;
+  }
+}
+
+function createStageSession(
+  runtime: EvaluationEngineRuntime,
+  prepared: PreparedEngineRun,
+  inputOptions: PreparedEvaluationRunOptions,
+  activeRunIds: Set<string>,
+): PreparedEvaluationStageSession {
+  const options: PreparedEvaluationRunOptions = Object.freeze({
+    runId: inputOptions.runId,
+    ...(inputOptions.signal === undefined ? {} : { signal: inputOptions.signal }),
+    ...(inputOptions.annotations === undefined
+      ? {}
+      : { annotations: snapshotJson(inputOptions.annotations) }),
+    ...(inputOptions.summaries === undefined
+      ? {}
+      : { summaries: snapshotJson(inputOptions.summaries) }),
+    ...(inputOptions.eventWriter === undefined
+      ? {}
+      : { eventWriter: inputOptions.eventWriter }),
+    ...(inputOptions.eventBufferCapacity === undefined
+      ? {}
+      : { eventBufferCapacity: inputOptions.eventBufferCapacity }),
+  });
+  if (!IdentifierSchema.safeParse(options.runId).success) {
+    throw new EvaluationStageSessionError(
+      'EVALUATION_STAGE_SESSION_RUN_ID_INVALID',
+      '分阶段运行的 runId 不符合 Evaluation Core identifier contract。',
+    );
+  }
+  if (!isValidEventBufferCapacity(
+    options.eventBufferCapacity ?? DEFAULT_EVENT_BUFFER_CAPACITY,
+  )) {
+    throw new EvaluationStageSessionError(
+      'EVALUATION_STAGE_SESSION_EVENT_BUFFER_CAPACITY_INVALID',
+      '分阶段运行的 eventBufferCapacity 必须是正安全整数。',
+    );
+  }
+  if (activeRunIds.has(options.runId)) {
+    throw new EvaluationStageSessionError(
+      'EVALUATION_STAGE_SESSION_RUN_ID_ACTIVE',
+      `runId "${options.runId}" 在当前 Evaluation Engine 中已有运行中的任务。`,
+    );
+  }
+
+  const sequencer = new InMemoryRuntimeEventSequencer();
+  const sessionAbort = new AbortController();
+  const signal = options.signal === undefined
+    ? sessionAbort.signal
+    : AbortSignal.any([options.signal, sessionAbort.signal]);
+  const startedStages = new Set<string>();
+  const budgetByExecutionSource = new WeakMap<object, ReturnType<typeof createRunBudgetSource>>();
+  const stageCapacity = options.eventBufferCapacity ?? DEFAULT_EVENT_BUFFER_CAPACITY;
+  let inFlight: Promise<unknown> | undefined;
+  let closing = false;
+  let closed = false;
+  let closePromise: Promise<void> | undefined;
+
+  function close(): Promise<void> {
+    closePromise ??= (async () => {
+      closing = true;
+      sessionAbort.abort(new Error('Evaluation stage session closed by host.'));
+      if (inFlight !== undefined) await Promise.allSettled([inFlight]);
+      activeRunIds.delete(options.runId);
+      closed = true;
+    })();
+    return closePromise;
+  }
+
+  function track(completion: Promise<unknown>, terminal: boolean): void {
+    inFlight = completion;
+    void completion.then(
+      () => {
+        inFlight = undefined;
+        if (terminal) void close();
+      },
+      () => {
+        inFlight = undefined;
+        void close();
+      },
+    );
+  }
+
+  function startOnce<T>(
+    stageKind: string,
+    start: () => T,
+    completion: (run: T) => Promise<unknown>,
+    terminal = false,
+  ): T {
+    if (closed || closing) {
+      throw new EvaluationStageSessionError(
+        'EVALUATION_STAGE_SESSION_CLOSED',
+        '分阶段运行已经关闭，不能再启动新阶段。',
+      );
+    }
+    if (inFlight !== undefined) {
+      throw new EvaluationStageSessionError(
+        'EVALUATION_STAGE_SESSION_BUSY',
+        '前一个 Evaluation stage 尚未结束，不能并发启动下一阶段。',
+      );
+    }
+    if (startedStages.has(stageKind)) {
+      throw new EvaluationStageSessionError(
+        'EVALUATION_STAGE_ALREADY_STARTED',
+        `Evaluation stage "${stageKind}" 在当前 session 中已经启动过。`,
+      );
+    }
+    const run = start();
+    startedStages.add(stageKind);
+    track(completion(run), terminal);
+    return run;
+  }
+
+  const session: PreparedEvaluationStageSession = {
+    runId: options.runId,
+    execute() {
+      const run = startOnce('execution', () => startExecution(
+        prepared.plan,
+        executionPorts(runtime, prepared.bindings, sequencer, options),
+        {
+          runId: options.runId,
+          bundleId: artifactId(options.runId, 'execution'),
+          eventBufferCapacity: stageCapacity,
+          signal,
+        },
+      ), (started) => started.source);
+      void run.source.then(
+        (source) => { budgetByExecutionSource.set(source, run.budgetSource); },
+        () => undefined,
+      );
+      return run;
+    },
+    evaluate(input) {
+      const budgetSource = budgetByExecutionSource.get(input.execution);
+      return startOnce('evaluation', () => startEvaluation(
+        prepared.plan,
+        input.execution,
+        evaluationPorts(runtime, prepared.bindings, sequencer, options),
+        {
+          runId: options.runId,
+          bundleId: artifactId(options.runId, 'evaluation'),
+          eventBufferCapacity: stageCapacity,
+          ...(budgetSource === undefined ? {} : { budgetSource }),
+          signal,
+        },
+      ), (started) => started.source);
+    },
+    analyze(input) {
+      return startOnce('analysis', () => startAnalysis(
+        prepared.plan,
+        input.execution,
+        input.evaluation,
+        analysisPorts(runtime, prepared.bindings, sequencer, options),
+        {
+          runId: options.runId,
+          bundleId: artifactId(options.runId, 'analysis'),
+          eventBufferCapacity: stageCapacity,
+          signal,
+        },
+      ), (started) => started.source);
+    },
+    decide(input) {
+      return startOnce('decision', () => startDecision(
+        prepared.plan,
+        input.execution,
+        input.evaluation,
+        input.analysis,
+        analysisPorts(runtime, prepared.bindings, sequencer, options),
+        {
+          runId: options.runId,
+          eventBufferCapacity: stageCapacity,
+          signal,
+        },
+      ), (started) => started.source);
+    },
+    materializeReport(input) {
+      return startOnce('report', () => startReportMaterialization(
+        prepared.plan,
+        input.execution,
+        input.evaluation,
+        input.analysis,
+        input.decision,
+        analysisPorts(runtime, prepared.bindings, sequencer, options),
+        {
+          runId: options.runId,
+          reportId: artifactId(options.runId, 'report'),
+          eventBufferCapacity: stageCapacity,
+          ...(options.annotations === undefined ? {} : { annotations: options.annotations }),
+          ...(options.summaries === undefined ? {} : { summaries: options.summaries }),
+        },
+      ), (started) => started.result, true);
+    },
+    close,
+  };
+  activeRunIds.add(options.runId);
+  return Object.freeze(session);
+}
+
+function bindPreparedEvaluation(
+  runtime: EvaluationEngineRuntime,
+  prepared: PreparedEngineRun,
+  activeRunIds: Set<string>,
+): PreparedEvaluation {
+  const plan = prepared.plan;
+  const bound: PreparedEvaluation = {
+    plan,
+    start: (options) => startPrepared(
+      runtime,
+      async () => prepared,
+      options,
+      activeRunIds,
+    ),
+    stages: (options) => createStageSession(runtime, prepared, options, activeRunIds),
+    admitExecutionBundle(
+      value: unknown,
+      verification?: ExecutionBundleVerificationContext,
+    ) {
+      return verifyExecutionBundle(value, plan, verification);
+    },
+    admitEvaluationBundle(
+      value: unknown,
+      input: Readonly<{
+        execution: ExecutionBundleSource;
+        verification?: EvaluationBundleVerificationContext;
+      }>,
+    ) {
+      return verifyEvaluationBundle(value, plan, input.execution, input.verification);
+    },
+    admitAnalysisBundle(
+      value: unknown,
+      input: Readonly<{
+        execution: ExecutionBundleSource;
+        evaluation: EvaluationBundleSource;
+        verification?: AnalysisBundleVerificationContext;
+      }>,
+    ) {
+      return verifyAnalysisBundle(
+        value,
+        plan,
+        input.execution,
+        input.evaluation,
+        { schemaValidators: runtime.schemaValidators },
+        input.verification,
+      );
+    },
+    admitDecisionResult(
+      value: unknown,
+      input: Readonly<{
+        execution: ExecutionBundleSource;
+        evaluation: EvaluationBundleSource;
+        analysis: AnalysisBundleSource;
+        verification?: DecisionResultVerificationContext;
+      }>,
+    ) {
+      return verifyDecisionResult(
+        value,
+        plan,
+        input.execution,
+        input.evaluation,
+        input.analysis,
+        input.verification,
+      );
+    },
+    admitReport(value, input) {
+      return parseEvaluationReport(
+        value,
+        plan,
+        input.execution,
+        input.evaluation,
+        input.analysis,
+        input.decision,
+      );
+    },
+  };
+  return bound;
+}
+
 export function createEvaluationEngine(runtime: EvaluationEngineRuntime): EvaluationEngine {
   const activeRunIds = new Set<string>();
   return {
     async prepare(definition, policy): Promise<PreparedEvaluation> {
       const prepared = await prepareEngineRun(runtime, definition, policy);
-      return {
-        plan: prepared.plan,
-        start: (options) => startPrepared(
-          runtime,
-          async () => prepared,
-          options,
-          activeRunIds,
-        ),
-      };
+      return bindPreparedEvaluation(runtime, prepared, activeRunIds);
     },
     start(definition, options: EvaluationRunOptions): EvaluationRun {
       const runOptions: PreparedEvaluationRunOptions = {

--- a/src/evaluation-core/engine/types.ts
+++ b/src/evaluation-core/engine/types.ts
@@ -1,12 +1,20 @@
 import type {
   AnalysisBundle,
+  AnalysisBundleSource,
+  AnalysisBundleVerificationContext,
   DecisionResult,
+  DecisionResultSource,
+  DecisionResultVerificationContext,
   EvaluationBundle,
+  EvaluationBundleSource,
+  EvaluationBundleVerificationContext,
   EvaluationDefinition,
   EvaluationError,
   EvaluationEvent,
   EvaluationReport,
   ExecutionBundle,
+  ExecutionBundleSource,
+  ExecutionBundleVerificationContext,
   CoreSchemaValidator,
   JsonValue,
   MeasurementPolicy,
@@ -24,6 +32,9 @@ import type {
   AnalysisDecisionPolicy,
   AnalysisMissingPolicy,
   AnalysisNodeImplementation,
+  AnalysisRun as CoreAnalysisRun,
+  DecisionRun as CoreDecisionRun,
+  EvaluationReportRun as CoreEvaluationReportRun,
 } from '../analysis/index.js';
 import type {
   EvaluationCache,
@@ -31,12 +42,14 @@ import type {
   EvaluationContentResolver,
   EvaluationContentStore,
   EvaluationEvaluator,
+  EvaluationRun as CoreEvaluationStageRun,
 } from '../evaluation/index.js';
 import type {
   ExecutionCache,
   ExecutionClock,
   ExecutionContentStore,
   ExecutionExecutor,
+  ExecutionRun as CoreExecutionRun,
 } from '../execution/index.js';
 export type Executor = ExecutionExecutor;
 export type Evaluator = EvaluationEvaluator;
@@ -142,9 +155,79 @@ export interface EvaluationRun {
   result: Promise<EvaluationRunResult>;
 }
 
+export interface PreparedEvaluationStageSession {
+  readonly runId: string;
+  execute(): CoreExecutionRun;
+  evaluate(input: Readonly<{
+    execution: ExecutionBundleSource;
+  }>): CoreEvaluationStageRun;
+  analyze(input: Readonly<{
+    execution: ExecutionBundleSource;
+    evaluation: EvaluationBundleSource;
+  }>): CoreAnalysisRun;
+  decide(input: Readonly<{
+    execution: ExecutionBundleSource;
+    evaluation: EvaluationBundleSource;
+    analysis: AnalysisBundleSource;
+  }>): CoreDecisionRun;
+  materializeReport(input: Readonly<{
+    execution: ExecutionBundleSource;
+    evaluation: EvaluationBundleSource;
+    analysis: AnalysisBundleSource;
+    decision?: DecisionResultSource;
+  }>): CoreEvaluationReportRun;
+  close(): Promise<void>;
+}
+
+export type EvaluationStageSessionErrorCode =
+  | 'EVALUATION_STAGE_SESSION_RUN_ID_INVALID'
+  | 'EVALUATION_STAGE_SESSION_RUN_ID_ACTIVE'
+  | 'EVALUATION_STAGE_SESSION_EVENT_BUFFER_CAPACITY_INVALID'
+  | 'EVALUATION_STAGE_SESSION_CLOSED'
+  | 'EVALUATION_STAGE_SESSION_BUSY'
+  | 'EVALUATION_STAGE_ALREADY_STARTED';
+
 export interface PreparedEvaluation {
   readonly plan: SealedRunPlan;
   start(options: PreparedEvaluationRunOptions): EvaluationRun;
+  stages(options: PreparedEvaluationRunOptions): PreparedEvaluationStageSession;
+  admitExecutionBundle(
+    value: unknown,
+    verification?: ExecutionBundleVerificationContext,
+  ): ExecutionBundleSource;
+  admitEvaluationBundle(
+    value: unknown,
+    input: Readonly<{
+      execution: ExecutionBundleSource;
+      verification?: EvaluationBundleVerificationContext;
+    }>,
+  ): EvaluationBundleSource;
+  admitAnalysisBundle(
+    value: unknown,
+    input: Readonly<{
+      execution: ExecutionBundleSource;
+      evaluation: EvaluationBundleSource;
+      verification?: AnalysisBundleVerificationContext;
+    }>,
+  ): AnalysisBundleSource;
+  admitDecisionResult(
+    value: unknown,
+    input: Readonly<{
+      execution: ExecutionBundleSource;
+      evaluation: EvaluationBundleSource;
+      analysis: AnalysisBundleSource;
+      verification?: DecisionResultVerificationContext;
+    }>,
+  ): DecisionResultSource;
+  admitReport(
+    value: unknown,
+    input: Readonly<{
+      execution: ExecutionBundleSource;
+      evaluation: EvaluationBundleSource;
+      analysis: AnalysisBundleSource;
+      decision?: DecisionResultSource;
+    }>,
+  ): EvaluationReport;
 }
 
 export interface EvaluationEngine {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-export { createEvaluationEngine } from './evaluation-core/engine/index.js';
+export {
+  createEvaluationEngine,
+  EvaluationStageSessionError,
+} from './evaluation-core/engine/index.js';
 export type {
   EvaluationEngine,
   EvaluationEngineClock,
@@ -13,10 +16,12 @@ export type {
   EvaluationRunArtifacts,
   EvaluationRunOptions,
   EvaluationRunResult,
+  EvaluationStageSessionErrorCode,
   Evaluator,
   Executor,
   PreparedEvaluation,
   PreparedEvaluationRunOptions,
+  PreparedEvaluationStageSession,
   PartialEvaluationRunArtifacts,
 } from './evaluation-core/engine/index.js';
 

--- a/test/evaluation-core/engine/runtime.test.ts
+++ b/test/evaluation-core/engine/runtime.test.ts
@@ -9,6 +9,7 @@ import {
   type Evaluator,
   type Executor,
   type RuntimeIdentity,
+  type Sha256Digest,
 } from '../../../src/index.js';
 import {
   createBuiltinAnalysisNodes,
@@ -197,7 +198,256 @@ async function consume(run: {
   return { events, result };
 }
 
+async function collectEvents(events: AsyncIterable<EvaluationEvent>): Promise<EvaluationEvent[]> {
+  const collected: EvaluationEvent[] = [];
+  for await (const event of events) collected.push(event);
+  return collected;
+}
+
 describe('embedded Evaluation Engine', () => {
+  it('runs and re-scores through a prepared stage capability without re-executing Targets', async () => {
+    const fixture = await createRuntime();
+    let executorRuns = 0;
+    const runtime: EvaluationEngineRuntime = {
+      ...fixture.runtime,
+      bindings: {
+        ...fixture.runtime.bindings,
+        async resolveExecutor(requirement) {
+          const binding = await fixture.runtime.bindings.resolveExecutor(requirement);
+          return {
+            ...binding,
+            port: {
+              identity: binding.port.identity,
+              async openRun(context) {
+                executorRuns += 1;
+                return binding.port.openRun(context);
+              },
+            },
+          };
+        },
+      },
+    };
+    const engine = createEvaluationEngine(runtime);
+    const original = await engine.prepare(fixture.definition, fixture.policy);
+    const executionStages = original.stages({ runId: 'staged-execution' });
+    const executionRun = executionStages.execute();
+    const execution = await executionRun.source;
+    await executionStages.close();
+
+    expect(executorRuns).toBe(2);
+    const changedDefinition = structuredClone(fixture.definition);
+    changedDefinition.dataset.samples[0].expected = { answer: 'B' };
+    const rescored = await engine.prepare(changedDefinition, fixture.policy);
+    const executionSource = rescored.admitExecutionBundle(
+      structuredClone(execution.bundle),
+      {
+        verifiedProvenanceBundleDigests: new Set([
+          execution.bundle.bundleDigest as Sha256Digest,
+        ]),
+      },
+    );
+    executorRuns = 0;
+
+    const stages = rescored.stages({
+      runId: 'staged-rescore',
+      annotations: { source: 'persisted-execution' },
+    });
+    const evaluationRun = stages.evaluate({ execution: executionSource });
+    const evaluation = await evaluationRun.source;
+    const analysisRun = stages.analyze({ execution: executionSource, evaluation });
+    const analysis = await analysisRun.source;
+    const decisionRun = stages.decide({ execution: executionSource, evaluation, analysis });
+    const decision = await decisionRun.source;
+    const reportRun = stages.materializeReport({
+      execution: executionSource,
+      evaluation,
+      analysis,
+      ...(decision === undefined ? {} : { decision }),
+    });
+    const report = await reportRun.result;
+    await stages.close();
+
+    expect(executorRuns).toBe(0);
+    expect(evaluation.bundle.executionBundleDigest).toBe(execution.bundle.bundleDigest);
+    expect(report.annotations).toEqual({ source: 'persisted-execution' });
+    expect(report.bundles.map((bundle) => bundle.bundleDigest)).toEqual([
+      execution.bundle.bundleDigest,
+      evaluation.bundle.bundleDigest,
+      analysis.bundle.bundleDigest,
+    ]);
+
+    const stageEvents = (await Promise.all([
+      collectEvents(evaluationRun.events),
+      collectEvents(analysisRun.events),
+      collectEvents(decisionRun.events),
+      collectEvents(reportRun.events),
+    ])).flat();
+    expect(stageEvents.map((event) => event.sequence)).toEqual(
+      stageEvents.map((_, index) => index),
+    );
+    expect(stageEvents.every((event) => event.runId === 'staged-rescore')).toBe(true);
+
+    const importedEvaluation = rescored.admitEvaluationBundle(
+      structuredClone(evaluation.bundle),
+      {
+        execution: executionSource,
+        verification: {
+          verifiedProvenanceBundleDigests: new Set([
+            evaluation.bundle.bundleDigest as Sha256Digest,
+          ]),
+          executionSourceTrust: execution.bundle.provenance.trust,
+        },
+      },
+    );
+    const importedAnalysis = rescored.admitAnalysisBundle(
+      structuredClone(analysis.bundle),
+      {
+        execution: executionSource,
+        evaluation: importedEvaluation,
+        verification: {
+          verifiedProvenanceBundleDigests: new Set([
+            analysis.bundle.bundleDigest as Sha256Digest,
+          ]),
+          evaluationSourceTrust: evaluation.bundle.provenance.trust,
+        },
+      },
+    );
+    const importedDecision = decision === undefined
+      ? undefined
+      : rescored.admitDecisionResult(structuredClone(decision.result), {
+          execution: executionSource,
+          evaluation: importedEvaluation,
+          analysis: importedAnalysis,
+          verification: {
+            verifiedPolicyExecutionDigests: new Set([
+              decision.result.decisionDigest as Sha256Digest,
+            ]),
+            analysisSourceTrust: analysis.bundle.provenance.trust,
+          },
+        });
+    expect(rescored.admitReport(structuredClone(report), {
+      execution: executionSource,
+      evaluation: importedEvaluation,
+      analysis: importedAnalysis,
+      ...(importedDecision === undefined ? {} : { decision: importedDecision }),
+    })).toEqual(report);
+  });
+
+  it('binds imported stage documents to the prepared Plan and opaque source chain', async () => {
+    const fixture = await createRuntime();
+    const prepared = await createEvaluationEngine(fixture.runtime).prepare(
+      fixture.definition,
+      fixture.policy,
+    );
+    const sourceStages = prepared.stages({ runId: 'staged-admission-source' });
+    const source = await sourceStages.execute().source;
+    await sourceStages.close();
+    const transported = structuredClone(source.bundle);
+    const admitted = prepared.admitExecutionBundle(transported);
+
+    const changedDefinition = structuredClone(fixture.definition);
+    changedDefinition.dataset.samples[0].input = { question: 'changed' };
+    const mismatched = await createEvaluationEngine(fixture.runtime).prepare(
+      changedDefinition,
+      fixture.policy,
+    );
+    expect(() => mismatched.admitExecutionBundle(transported)).toThrowError(
+      /Execution source|ExecutionBundle|Execution bundle/,
+    );
+    expect(() => prepared.stages({ runId: 'staged-forged-source' }).evaluate({
+      execution: {
+        bundle: admitted.bundle,
+        planVerification: admitted.planVerification,
+      } as unknown as typeof admitted,
+    })).toThrowError(/source returned by parseExecutionBundle/);
+
+    const tampered = structuredClone(transported);
+    tampered.records[0].executionCoordinateDigest = digestCanonicalJson({ tampered: true });
+    expect(() => prepared.admitExecutionBundle(tampered)).toThrowError();
+  });
+
+  it('owns the Engine runId until the stage session reaches a terminal close', async () => {
+    const fixture = await createRuntime();
+    const engine = createEvaluationEngine(fixture.runtime);
+    const prepared = await engine.prepare(fixture.definition, fixture.policy);
+    const session = prepared.stages({ runId: 'staged-owned-run-id' });
+    const executionRun = session.execute();
+
+    expect(() => prepared.stages({ runId: 'staged-owned-run-id' })).toThrowError(
+      expect.objectContaining({ code: 'EVALUATION_STAGE_SESSION_RUN_ID_ACTIVE' }),
+    );
+    expect(() => session.execute()).toThrowError(
+      expect.objectContaining({ code: 'EVALUATION_STAGE_SESSION_BUSY' }),
+    );
+    await executionRun.source;
+    expect(() => session.execute()).toThrowError(
+      expect.objectContaining({ code: 'EVALUATION_STAGE_ALREADY_STARTED' }),
+    );
+    await session.close();
+    await expect(prepared.stages({ runId: 'staged-owned-run-id' }).close())
+      .resolves.toBeUndefined();
+  });
+
+  it('cancels an in-flight stage and waits for Runtime disposal before releasing runId', async () => {
+    const fixture = await createRuntime();
+    let startedResolve: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => { startedResolve = resolve; });
+    let disposedRuns = 0;
+    let disposedTrials = 0;
+    const runtime: EvaluationEngineRuntime = {
+      ...fixture.runtime,
+      bindings: {
+        ...fixture.runtime.bindings,
+        async resolveExecutor(requirement) {
+          const binding = await fixture.runtime.bindings.resolveExecutor(requirement);
+          const port: Executor = {
+            identity: binding.port.identity,
+            async openRun() {
+              return {
+                async openTrial() {
+                  return {
+                    async execute(attempt) {
+                      startedResolve?.();
+                      return await new Promise<never>((_resolve, reject) => {
+                        if (attempt.signal.aborted) {
+                          reject(attempt.signal.reason);
+                          return;
+                        }
+                        attempt.signal.addEventListener(
+                          'abort',
+                          () => { reject(attempt.signal.reason); },
+                          { once: true },
+                        );
+                      });
+                    },
+                    dispose() { disposedTrials += 1; },
+                  };
+                },
+                dispose() { disposedRuns += 1; },
+              };
+            },
+          };
+          return { ...binding, port };
+        },
+      },
+    };
+    const prepared = await createEvaluationEngine(runtime).prepare(
+      fixture.definition,
+      fixture.policy,
+    );
+    const session = prepared.stages({ runId: 'staged-close-cancellation' });
+    const run = session.execute();
+    await started;
+    await session.close();
+    const source = await run.source;
+
+    expect(source.bundle.executionBundleStatus).toBe('cancelled');
+    expect(disposedTrials).toBeGreaterThan(0);
+    expect(disposedRuns).toBe(2);
+    await expect(prepared.stages({ runId: 'staged-close-cancellation' }).close())
+      .resolves.toBeUndefined();
+  });
+
   it('seals and runs distinct Target bindings that share one implementation', async () => {
     const fixture = await createRuntime();
     const opened: string[] = [];

--- a/test/evaluation-core/types/capability-boundary.compile.ts
+++ b/test/evaluation-core/types/capability-boundary.compile.ts
@@ -10,6 +10,11 @@ import type {
 import type {
   EvaluationRunOptions,
 } from '../../../src/evaluation-core/evaluation/index.js';
+import type {
+  ExecutionBundle,
+  SealedRunPlan,
+} from '../../../src/index.js';
+import type { RunPlan } from '../../../src/evaluation-core/contracts/index.js';
 
 declare const executorContext: ExecutorTrialContext;
 declare const budgetSource: NonNullable<ExecutionRunOptions['budgetSource']>;
@@ -22,6 +27,33 @@ void executorContext.evaluationContext;
 
 // @ts-expect-error 宿主只能转交 opaque budget capability，不能直接改写账本。
 void budgetSource.reserve;
+
+declare const wirePlan: RunPlan;
+declare const wireExecution: ExecutionBundle;
+
+// @ts-expect-error 可序列化 RunPlan 不是 prepare() 签发的 sealed capability。
+const forgedPlan: SealedRunPlan = wirePlan;
+void forgedPlan;
+
+declare const stageSession: import('../../../src/index.js').PreparedEvaluationStageSession;
+// @ts-expect-error 裸 ExecutionBundle 不是 plan-aware admission 签发的 source capability。
+stageSession.evaluate({ execution: wireExecution });
+
+stageSession.evaluate({
+  // @ts-expect-error 即使伪造 Bundle 与 verification 字段，也缺少 Core 私有 source brand。
+  execution: {
+    bundle: wireExecution,
+    planVerification: {
+      provenanceTrustStatus: 'indeterminate',
+      cacheReceiptStatus: 'indeterminate',
+      invocationBudgetStatus: 'indeterminate',
+      providerCostBudgetStatus: 'indeterminate',
+      minimumTargetInvocations: 0,
+      maximumTargetInvocations: 0,
+      unverifiedCacheRecordDigests: [],
+    },
+  },
+});
 
 type KeysOfUnion<Value> = Value extends unknown ? keyof Value : never;
 


### PR DESCRIPTION
## 用户影响

Node.js 宿主现在可以从 freshly prepared Evaluation Core capability 创建 run-scoped stage session，分别执行 Execution、Evaluation、Analysis、Decision 与 Report，并对持久化 Bundle 做 plan-aware admission。替换 Gold 或 Evaluator 时可复用仍然有效的 Execution 证据，不再调用 Target。

分阶段 session 与一键 façade 共用 Engine 的 run identity、现有 runtime、预算、事件、取消和资源释放语义；停在中间 Bundle 的宿主需要显式关闭 session。Bundle source 在运行时认证之外增加了类型级 opaque brand，wire document 或手工 verification summary 不能冒充 source capability。

## 迁移说明

现有 `createEvaluationEngine().start()` 与 `PreparedEvaluation.start()` 无需迁移。新能力是增量 API；稳定的 advanced package subpath、JSON Schema 访问和独立 tarball 宿主验收将在 #597 的后续 PR 完成。

## 测量学说明

本 PR 只发布既有 Core runtime 与 verifier 的组合能力，不改变 Bundle／Plan／Report wire schema、评分层、统计公式、prompt、missingness、trust 或 comparability 语义。跨进程自报 digest 不会升级为 verified；外部 attestation 缺失时仍保持 indeterminate。

Part of #597.