### PR TITLE
fix(evaluation-core): 封存 Prepared Runtime 验证器

### DIFF
--- a/docs/specs/evaluation-core-vnext.md
+++ b/docs/specs/evaluation-core-vnext.md
@@ -1073,6 +1073,14 @@ it does not create a second implementation, registry, or execution path. Studio 
 projections live behind their own explicit subpaths, while unlisted and `dist/*` deep imports remain
 closed. This keeps dependency direction visible without fragmenting runtime authority.
 
+Each prepare or one-call start captures the Runtime's top-level infrastructure ports, binding
+resolver functions, and an independent Schema-validator registry. Validator SchemaIdentity values
+and parse functions are captured together. A host may update its registry for a later prepare, but
+mutating the original Map, validator object, or Runtime property cannot change validation semantics
+for an already prepared RunPlan. This extends the binding snapshot rule to every executable
+validator that participates in Analysis admission without pretending to freeze host-internal client
+state.
+
 The session owns its `runId` in the Engine while it is open, rejects overlapping stages, and releases
 the identity automatically after Report termination. Hosts that intentionally stop at an earlier
 Bundle call `await stages.close()`; close aborts any in-flight stage, waits for its existing runtime

--- a/docs/zh/specs/evaluation-core-vnext.md
+++ b/docs/zh/specs/evaluation-core-vnext.md
@@ -1061,6 +1061,12 @@ Analysis、Decision 和 Report materialization 在同一 session 中各自最多
 implementation、registry 或执行路径。Studio 与 downstream projection 分别放在显式子路径中，
 未列出的入口和 `dist/*` 深层导入继续保持关闭。这样既让依赖方向清晰可见，又不分裂 Runtime authority。
 
+每次 prepare 或一键 start 都会捕获 Runtime 顶层 infrastructure port、binding resolver 函数与独立的
+Schema-validator registry，并把 validator 的 SchemaIdentity 与 parse 函数作为一个整体捕获。宿主可以为
+后续 prepare 更新 registry，但修改原始 Map、validator object 或 Runtime property，不能改变已经 prepared
+的 RunPlan 所使用的验证语义。这样把 binding snapshot 规则扩展到参与 Analysis admission 的全部可执行
+validator，同时不伪装成能够冻结宿主 client 的内部状态。
+
 session 打开期间会在 Engine 内独占其 `runId`，拒绝阶段并发，并在 Report 到达终态后自动释放
 identity。宿主若有意停在更早的 Bundle，必须调用 `await stages.close()`；close 会取消仍在运行的
 阶段，等待既有 runtime 完成资源释放，再归还 identity。这样可以避免与一键 façade 产生 Event

--- a/src/evaluation-core/engine/index.ts
+++ b/src/evaluation-core/engine/index.ts
@@ -4,6 +4,7 @@ import {
   EvaluationErrorSchema,
   IdentifierSchema,
   RuntimeIdentitySchema,
+  SchemaIdentitySchema,
   type AnalysisBundle,
   type DecisionResult,
   type EvaluationError,
@@ -18,6 +19,8 @@ import {
   type DecisionResultVerificationContext,
   type EvaluationBundleVerificationContext,
   type ExecutionBundleVerificationContext,
+  type CoreSchemaValidator,
+  type SchemaIdentity,
   parseEvaluationReport,
   verifyAnalysisBundle,
   verifyDecisionResult,
@@ -122,6 +125,7 @@ interface PreparedRuntimeBindings {
 interface PreparedEngineRun {
   readonly plan: SealedRunPlan;
   readonly bindings: PreparedRuntimeBindings;
+  readonly runtime: EvaluationEngineRuntime;
 }
 
 type MutableRuntimeBindings = {
@@ -140,6 +144,58 @@ function emptyRuntimeBindings(): MutableRuntimeBindings {
     missingPoliciesByPolicyId: new Map(),
     decisionPoliciesByDecisionPolicyId: new Map(),
   };
+}
+
+function snapshotSchemaValidators(
+  validators: ReadonlyMap<string, CoreSchemaValidator>,
+): ReadonlyMap<string, CoreSchemaValidator> {
+  return new Map([...validators].map(([key, validator]) => {
+    const schema = SchemaIdentitySchema.safeParse(validator?.schema);
+    if (!schema.success || typeof validator?.parse !== 'function') {
+      throw new EvaluationDefinitionError({
+        code: 'EVAL_DEFINITION_RUNTIME_BINDING_INVALID',
+        stage: 'configuration',
+        preparationStage: 'runtime-resolution',
+        message: 'Schema validator registry 包含无效 binding。',
+        details: { referenceId: key },
+      });
+    }
+    const parse = validator.parse.bind(validator);
+    const captured: CoreSchemaValidator = Object.freeze({
+      schema: snapshotJson(schema.data) as SchemaIdentity,
+      parse,
+    });
+    return [key, captured] as const;
+  }));
+}
+
+function snapshotRuntime(runtime: EvaluationEngineRuntime): EvaluationEngineRuntime {
+  const bindings = runtime.bindings;
+  return Object.freeze({
+    bindings: Object.freeze({
+      resolveExecutor: bindings.resolveExecutor.bind(bindings),
+      resolveEvaluator: bindings.resolveEvaluator.bind(bindings),
+      resolveAnalysis: bindings.resolveAnalysis.bind(bindings),
+    }),
+    clock: runtime.clock,
+    schemaValidators: snapshotSchemaValidators(runtime.schemaValidators),
+    ...(runtime.validateExtension === undefined
+      ? {}
+      : { validateExtension: runtime.validateExtension.bind(runtime) }),
+    ...(runtime.executionCache === undefined ? {} : { executionCache: runtime.executionCache }),
+    ...(runtime.evaluationCache === undefined
+      ? {}
+      : { evaluationCache: runtime.evaluationCache }),
+    ...(runtime.executionContentStore === undefined
+      ? {}
+      : { executionContentStore: runtime.executionContentStore }),
+    ...(runtime.evaluationContentStore === undefined
+      ? {}
+      : { evaluationContentStore: runtime.evaluationContentStore }),
+    ...(runtime.contentResolver === undefined
+      ? {}
+      : { contentResolver: runtime.contentResolver }),
+  });
 }
 
 function captureBinding<T>(
@@ -254,6 +310,7 @@ async function prepareEngineRun(
   });
   return {
     plan,
+    runtime,
     bindings: {
       executorsByTargetId: new Map(captured.executorsByTargetId),
       evaluatorsByEvaluatorId: new Map(captured.evaluatorsByEvaluatorId),
@@ -394,7 +451,6 @@ function analysisPorts(
 }
 
 async function executePipeline(
-  runtime: EvaluationEngineRuntime,
   preparedPromise: Promise<PreparedEngineRun>,
   options: PreparedEvaluationRunOptions,
   events: BoundedEventStream,
@@ -404,7 +460,7 @@ async function executePipeline(
   let analysisSource: AnalysisBundleSource | undefined;
   let decisionSource: DecisionResultSource | undefined;
   try {
-    const { plan, bindings } = await preparedPromise;
+    const { plan, bindings, runtime } = await preparedPromise;
     const sequencer = new InMemoryRuntimeEventSequencer();
     const budgetSource = createRunBudgetSource(plan, options.runId, runtime.clock);
     const stageCapacity = options.eventBufferCapacity ?? DEFAULT_EVENT_BUFFER_CAPACITY;
@@ -521,7 +577,6 @@ async function executePipeline(
 }
 
 function startPrepared(
-  runtime: EvaluationEngineRuntime,
   createPreparedRun: () => Promise<PreparedEngineRun>,
   options: PreparedEvaluationRunOptions,
   activeRunIds: Set<string>,
@@ -547,7 +602,7 @@ function startPrepared(
   activeRunIds.add(options.runId);
   const events = new BoundedEventStream(eventBufferCapacity);
   const preparedPromise = Promise.resolve().then(createPreparedRun);
-  const result = executePipeline(runtime, preparedPromise, options, events)
+  const result = executePipeline(preparedPromise, options, events)
     .finally(() => {
       activeRunIds.delete(options.runId);
     });
@@ -568,11 +623,11 @@ export class EvaluationStageSessionError extends TypeError {
 }
 
 function createStageSession(
-  runtime: EvaluationEngineRuntime,
   prepared: PreparedEngineRun,
   inputOptions: PreparedEvaluationRunOptions,
   activeRunIds: Set<string>,
 ): PreparedEvaluationStageSession {
+  const runtime = prepared.runtime;
   const options: PreparedEvaluationRunOptions = Object.freeze({
     runId: inputOptions.runId,
     ...(inputOptions.signal === undefined ? {} : { signal: inputOptions.signal }),
@@ -764,20 +819,19 @@ function createStageSession(
 }
 
 function bindPreparedEvaluation(
-  runtime: EvaluationEngineRuntime,
   prepared: PreparedEngineRun,
   activeRunIds: Set<string>,
 ): AdvancedPreparedEvaluation {
   const plan = prepared.plan;
+  const runtime = prepared.runtime;
   const bound: AdvancedPreparedEvaluation = {
     plan,
     start: (options) => startPrepared(
-      runtime,
       async () => prepared,
       options,
       activeRunIds,
     ),
-    stages: (options) => createStageSession(runtime, prepared, options, activeRunIds),
+    stages: (options) => createStageSession(prepared, options, activeRunIds),
     admitExecutionBundle(
       value: unknown,
       verification?: ExecutionBundleVerificationContext,
@@ -846,8 +900,8 @@ export function createEvaluationEngine(runtime: EvaluationEngineRuntime): Advanc
   const activeRunIds = new Set<string>();
   return {
     async prepare(definition, policy): Promise<AdvancedPreparedEvaluation> {
-      const prepared = await prepareEngineRun(runtime, definition, policy);
-      return bindPreparedEvaluation(runtime, prepared, activeRunIds);
+      const prepared = await prepareEngineRun(snapshotRuntime(runtime), definition, policy);
+      return bindPreparedEvaluation(prepared, activeRunIds);
     },
     start(definition, options: EvaluationRunOptions): EvaluationRun {
       const runOptions: PreparedEvaluationRunOptions = {
@@ -860,9 +914,15 @@ export function createEvaluationEngine(runtime: EvaluationEngineRuntime): Advanc
           ? {}
           : { eventBufferCapacity: options.eventBufferCapacity }),
       };
+      let capturedRuntime: EvaluationEngineRuntime;
+      try {
+        capturedRuntime = snapshotRuntime(runtime);
+      } catch (error) {
+        const failure = runtimeError(error);
+        return configurationFailure(failure.code, failure.message, failure.details);
+      }
       return startPrepared(
-        runtime,
-        () => prepareEngineRun(runtime, definition, options.policy),
+        () => prepareEngineRun(capturedRuntime, definition, options.policy),
         runOptions,
         activeRunIds,
       );

--- a/test/evaluation-core/engine/runtime.test.ts
+++ b/test/evaluation-core/engine/runtime.test.ts
@@ -8,6 +8,7 @@ import {
   type EvaluationRunResult,
   type Evaluator,
   type Executor,
+  type CoreSchemaValidator,
   type RuntimeIdentity,
   type Sha256Digest,
 } from '../../../src/package-api/evaluation-core.js';
@@ -608,6 +609,78 @@ describe('embedded Evaluation Engine', () => {
 
     expect(result.status).toBe('completed');
     expect(attempts).toEqual(['prepared', 'prepared']);
+  });
+
+  it('captures validator schemas and functions for runtime and admission', async () => {
+    const fixture = await createRuntime();
+    const mutableValidators = new Map<string, CoreSchemaValidator>(
+      [...fixture.runtime.schemaValidators].map(([key, validator]) => [key, {
+        schema: structuredClone(validator.schema),
+        parse: validator.parse.bind(validator),
+      }]),
+    );
+    const runtime: EvaluationEngineRuntime = {
+      ...fixture.runtime,
+      schemaValidators: mutableValidators,
+    };
+    const engine = createEvaluationEngine(runtime);
+    const prepared = await engine.prepare(fixture.definition, fixture.policy);
+
+    for (const validator of mutableValidators.values()) {
+      const mutable = validator as {
+        schema: { schemaVersion: string };
+        parse: CoreSchemaValidator['parse'];
+      };
+      mutable.schema.schemaVersion = 'mutated-after-prepare';
+      mutable.parse = () => {
+        throw new Error('mutated validator must not run');
+      };
+    }
+
+    const stages = prepared.stages({ runId: 'embedded-validator-snapshot' });
+    const execution = await stages.execute().source;
+    const evaluation = await stages.evaluate({ execution }).source;
+    const analysis = await stages.analyze({ execution, evaluation }).source;
+    const admitted = prepared.admitAnalysisBundle(structuredClone(analysis.bundle), {
+      execution,
+      evaluation,
+    });
+    await stages.close();
+
+    expect(analysis.bundle.analysisBundleStatus).toBe('completed');
+    expect(admitted.bundle.bundleDigest).toBe(analysis.bundle.bundleDigest);
+
+    mutableValidators.clear();
+    await expect(engine.prepare(fixture.definition, fixture.policy)).rejects.toMatchObject({
+      code: 'EVAL_DEFINITION_CAPABILITY_UNSUPPORTED',
+      stage: 'configuration',
+      preparationStage: 'runtime-resolution',
+    });
+  });
+
+  it('returns malformed Runtime snapshot failures through the one-call result channel', async () => {
+    const fixture = await createRuntime();
+    const runtime = {
+      ...fixture.runtime,
+      schemaValidators: new Map([['invalid-validator', {
+        schema: null,
+        parse: undefined,
+      }]]),
+    } as unknown as EvaluationEngineRuntime;
+
+    const run = createEvaluationEngine(runtime).start(fixture.definition, {
+      policy: fixture.policy,
+      runId: 'embedded-invalid-runtime-snapshot',
+    });
+
+    await expect(run.result).resolves.toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'EVAL_DEFINITION_RUNTIME_BINDING_INVALID',
+        stage: 'configuration',
+      },
+    });
+    await expect(collectEvents(run.events)).resolves.toEqual([]);
   });
 
   it('isolates Evaluator sessions for multiple bindings of one implementation', async () => {


### PR DESCRIPTION
## 用户影响

Prepared Evaluation 现在会在操作入口封存 Runtime 绑定与 schema validator；宿主在 prepare 之后修改 registry、validator schema 或 parse 函数，不再能改变同一 sealed plan 的执行或准入语义。后续 prepare 仍会读取宿主最新 registry。

单调用入口遇到非法 Runtime 绑定时，继续通过结构化 result 失败通道返回，不会同步抛出。

## 架构说明

validator 的 SchemaIdentity 与 parse 能力作为同一绑定快照捕获；仅封存端口与函数引用，不虚构冻结宿主客户端内部状态。

## 兼容性与测量学

不修改 wire schema、digest、评分统计、prompt、trust 或 admission 语义；无需迁移，也不影响历史报告可比性。

Refs #425