### PR TITLE
feat(inputs)!: BREAKING-SCHEMA 版本化评测用例协议

### DIFF
--- a/docs/reference/eval-sample-format.md
+++ b/docs/reference/eval-sample-format.md
@@ -1,6 +1,6 @@
 # Eval sample format
 
-An **eval-samples** file is the test set `omk eval` / `omk doctor` run against — a list of cases, each a `prompt` plus optional `rubric`, `assertions`, and metadata. Supports JSON and YAML (`eval-samples.json`, `eval-samples.yaml`, `eval-samples.yml`); YAML is easier to hand-write.
+An **eval-samples** file is the versioned test-set document `omk eval` / `omk doctor` run against. Its `samples` array contains cases, each with a `prompt` plus optional `rubric`, `assertions`, and metadata. JSON and YAML are supported (`eval-samples.json`, `eval-samples.yaml`, `eval-samples.yml`); YAML is easier to hand-write.
 
 For *designing* a rigorous sample set (what to test, how many, the metadata fields), see [sample design](../specs/sample-design-spec) — this page is the field-by-field format reference.
 
@@ -15,25 +15,32 @@ Recommended layouts:
 
 Compatibility note: flat-skill sidecars such as `skills/<name>.eval-samples.json` are still supported. Directory skills do not read `<skill>/eval-samples.*`; use `<skill>/.omk/samples.json` for skill-local samples.
 
+Every file must declare `schemaVersion: omk.eval-sample-set/v1`. Legacy top-level arrays are rejected. The root document, every sample, assertion, mock, and nested contract are strict: unknown fields fail before execution instead of being ignored. The published JSON Schema is [`schemas/eval-samples/v1/eval-sample-set.schema.json`](../../schemas/eval-samples/v1/eval-sample-set.schema.json).
+
 ```json
-[
-  {
-    "sample_id": "s001",
-    "prompt": "Review this code for security issues",
-    "context": "function auth(u, p) { db.query('SELECT * FROM users WHERE name=' + u); }",
-    "rubric": "Should identify SQL injection risk and recommend parameterized queries",
-    "assertions": [
-      { "type": "contains", "value": "SQL injection", "weight": 1 },
-      { "type": "contains", "value": "parameterized", "weight": 1 },
-      { "type": "not_contains", "value": "looks fine", "weight": 0.5 }
-    ],
-    "dimensions": {
-      "security": "did it identify the injection vulnerability?",
-      "actionability": "did it give directly usable fix code?"
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
+    {
+      "sample_id": "s001",
+      "prompt": "Review this code for security issues",
+      "context": "function auth(u, p) { db.query('SELECT * FROM users WHERE name=' + u); }",
+      "rubric": "Should identify SQL injection risk and recommend parameterized queries",
+      "assertions": [
+        { "type": "contains", "value": "SQL", "weight": 1 },
+        { "type": "contains", "value": "parameterized", "weight": 1 },
+        { "type": "not_contains", "value": "safe", "weight": 0.5 }
+      ],
+      "dimensions": {
+        "security": "did it identify the injection vulnerability?",
+        "actionability": "did it give directly usable fix code?"
+      }
     }
-  }
-]
+  ]
+}
 ```
+
+The root may also contain `requires` with `tools`, `files`, `env`, and `preflight` string arrays. No other root fields are accepted.
 
 ## Fields
 
@@ -73,7 +80,7 @@ A sample can also carry **metadata** (documentation / diagnostics only — these
 | `provenance` | `'human' \| 'llm-generated' \| 'production-trace'` | data source |
 | `covers` | `{ targetKind, ref }[]` | optional declared skill-structure anchors for high-value samples; used by Skill Map only |
 | `mocks` | `object[]` | tool-call interception list — requires an executor with mock-interception support |
-| `mocksStrict` | `boolean` | deny any tool call that matches no mock (default `false`) |
+| `mocksStrict` | `boolean` | deny any tool call that matches no mock (default `true`; set `false` only to explicitly allow pass-through) |
 | `tripwire` | `boolean` | trap sample: the LLM is **expected** to fail (default `false`) |
 | `environment` | `object` | prompt-only preconditions: `cli_available` / `files_available` / `notes`; does not materialize files or env vars |
 
@@ -86,15 +93,17 @@ The loader also validates cross-field references. Every `mock_hit: "Tool:N"` mus
 Studio also surfaces this declaration in the Skill Map node detail panel: selecting a node shows whether its structure relation is explicitly declared by `sample.covers`.
 
 ```yaml
-- sample_id: release-risk-summary
-  prompt: "Summarize release risk and rollback plan."
-  covers:
-    - targetKind: reference
-      ref: references/release-policy.md
-    - targetKind: workflow
-      ref: release
-    - targetKind: workflow_node
-      ref: release.check
+schemaVersion: omk.eval-sample-set/v1
+samples:
+  - sample_id: release-risk-summary
+    prompt: "Summarize release risk and rollback plan."
+    covers:
+      - targetKind: reference
+        ref: references/release-policy.md
+      - targetKind: workflow
+        ref: release
+      - targetKind: workflow_node
+        ref: release.check
 ```
 
 Allowed `targetKind` values are `skill`, `skill_file`, `frontmatter`, `reference`, `script`, `hard_rule`, `workflow`, and `workflow_node`. For `reference` / `script`, `ref` is the path relative to the skill root. For `hard_rule` / `workflow`, use the rule or workflow id. For `workflow_node`, use `workflowId.nodeId`. This field never enters grading, the judge prompt, the verdict, or the sample fingerprint.
@@ -105,8 +114,11 @@ URLs in `prompt` and `context` are auto-fetched before evaluation and inlined in
 
 ```json
 {
-  "sample_id": "s001",
-  "prompt": "Generate test cases from this PRD: https://wiki.example.com/prd/feature-x"
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [{
+    "sample_id": "s001",
+    "prompt": "Generate test cases from this PRD: https://wiki.example.com/prd/feature-x"
+  }]
 }
 ```
 

--- a/docs/specs/sample-design-spec.md
+++ b/docs/specs/sample-design-spec.md
@@ -12,6 +12,7 @@ The most common construct mismatch: you run baseline-vs-skill intending to measu
 
 ```yaml
 # eval-samples.yaml
+schemaVersion: omk.eval-sample-set/v1
 samples:
   - sample_id: s001
     prompt: "Draw a line chart in React; data is date + value, give minimal runnable code"
@@ -61,38 +62,40 @@ These metadata fields are used only for:
 To run evals decoupled from the real external environment (databases / APIs / filesystem / actual git push, etc.), a sample also carries a group of sandbox fields. The omk runtime matches mocks before a tool call; on a hit it returns fake data instead of really invoking the underlying tool.
 
 ```yaml
-- sample_id: s002
-  prompt: "Use antlogs-query to count ERROR logs in the last 1 hour"
-  rubric: "Must call the logstore_query tool, filter containing 'ERROR', time window 1 hour"
-  assertions:
-    - { type: tool_input_contains, value: "Bash:logstore_query", weight: 1 }
-    - { type: mock_hit, value: "Bash:1", weight: 1 }
-  mocksStrict: true              # default true (generator-enforced); an unmatched tool call is denied outright, never passed through to the real call
-  tripwire: false                # whether this sample is a "trap sample" (deliberately lures the LLM into the wrong move; failing is expected); default false
-  environment:                   # prompt-only task assumptions; no files or env vars are materialized
-    cli_available: ["log-cli"]
-    files_available: ["~/.config/log-cli.json"]
-    notes: "log-cli is authenticated, token in env var"
-  mocks:
-    - tool: Bash                            # intercepted tool name: Bash / Read / Edit / Write / WebFetch / Grep / Glob, etc.
-      match:
-        command_glob: "*log-cli query --filter ERROR*"   # Bash uses command_glob (* wildcard, spans newlines)
-      return:
-        stdout: '{"count": 42}'
-        exit: 0
-    - tool: Read
-      match:
-        file_path_endswith: "tasks/state.json"           # recommended: suffix match, hits whether the LLM uses an absolute or relative path
-      return: '{"status":"running"}'
-    - tool: WebFetch
-      match:
-        url_glob: "https://internal.example.com/api/*"
-      return: "ok"
+schemaVersion: omk.eval-sample-set/v1
+samples:
+  - sample_id: s002
+    prompt: "Use antlogs-query to count ERROR logs in the last 1 hour"
+    rubric: "Must call the logstore_query tool, filter containing 'ERROR', time window 1 hour"
+    assertions:
+      - { type: tool_input_contains, value: "Bash:logstore_query", weight: 1 }
+      - { type: mock_hit, value: "Bash:1", weight: 1 }
+    mocksStrict: true              # default true; unmatched tool calls are denied, never passed through
+    tripwire: false                # whether this sample is a "trap sample"; default false
+    environment:                   # prompt-only assumptions; no files or env vars are materialized
+      cli_available: ["log-cli"]
+      files_available: ["~/.config/log-cli.json"]
+      notes: "log-cli is authenticated, token in env var"
+    mocks:
+      - tool: Bash
+        match:
+          command_glob: "*log-cli query --filter ERROR*"
+        return:
+          stdout: '{"count": 42}'
+          exit: 0
+      - tool: Read
+        match:
+          file_path_endswith: "tasks/state.json"
+        return: '{"status":"running"}'
+      - tool: WebFetch
+        match:
+          url_glob: "https://internal.example.com/api/*"
+        return: "ok"
 ```
 
 **Field semantics:**
 
-- **mocksStrict** (`boolean`, default `true`): a tool call that matches no mock is denied outright (the LLM sees a failure result). **Default behavior**: the `omk sample` generator force-writes `true` and the SYSTEM_PROMPT makes it explicit; for hand-written samples, the loader does not force-inject it when absent — an old sample without the field falls back to non-strict (passes through to the real call). **Strongly prefer `true` for new samples**, to avoid a missing mock letting the eval hit a real production system.
+- **mocksStrict** (`boolean`, default `true`): a tool call that matches no mock is denied outright (the LLM sees a failure result). The production resolver applies this fail-closed default to generated and hand-written samples alike. Set `false` only when the sample intentionally allows unmatched calls to reach the real runtime.
 - **tripwire** (`boolean`, default `false`): declares that this is a trap sample whose prompt deliberately plants a lure that violates the rubric or skill. Evaluation Core preserves the declaration as Sample annotation for audit; it does not turn a failed observation into success or alter the registered Decision.
 - **environment** (`object`, optional): prompt-only task assumptions. The LLM may skip availability probes (`which X` / `test -f Y` / `echo $Z`) and go straight into the workflow, but omk does not create files, export variables, or alter `PATH`. It is not a fixture mechanism. The doctor health check can still audit declared physical paths (skippable with `--skip-doctor`).
   - `cli_available: string[]` — assumed already on `PATH`
@@ -107,7 +110,7 @@ To run evals decoupled from the real external environment (databases / APIs / fi
     - `command_glob: string` — for Bash, `*` wildcards across newlines (so the LLM's multi-line commands still hit).
     - `input: object` — generic deep-equal subset match (any tool_input field).
     - `input_contains: string` — recursively scans all string values in tool_input; a hit if any contains the substring (case-insensitive). **Pair with `tool: "*"` for intent-level mocking**: when the LLM searches code it might use Bash grep / the Grep tool / Glob / Read / Agent / any tool; use `input_contains` to match intent by keyword instead of enumerating tools one by one. Example: `{tool: "*", match: {input_contains: "MyServiceName"}, return: "<service .../>"}` — any tool hits as long as its input mentions MyServiceName.
-  - **`return` has three forms**: string / `{stdout, stderr, exit}` (simulates Bash) / `return_file` external file / `return_seq[]` state machine (the Nth hit on the same mock returns in order, falling back to `return` once exhausted).
+  - **return source**: every mock declares exactly one of `return`, `return_file`, or `return_seq`. `return` accepts a string or `{stdout, stderr, exit}`; `return_file` loads an external fixture; `return_seq[]` is a state machine whose Nth hit returns the Nth value and remains at the final value after the sequence is exhausted.
 - **assertion-side mock_hit / tool_input_contains**: used together with mocks. `mock_hit: "Bash:2"` means "the 2nd Bash mock must be hit at least once", proving the LLM reached that step. `tool_input_contains: "Bash:logstore_query"` checks that the Bash command string contains `logstore_query`.
   - Every `mock_hit` must reference a declared per-tool mock ordinal. The loader rejects missing or out-of-range references before execution.
   - Mock support is an executor capability, not a trace capability. `claude` / `claude-sdk` install interception hooks; `codex`, `codex-sdk`, and direct API executors currently do not. Unsupported executors auto-generate mockless samples and reject existing mocked samples before evaluation.

--- a/docs/zh/reference/eval-sample-format.md
+++ b/docs/zh/reference/eval-sample-format.md
@@ -1,6 +1,6 @@
 # 评测用例格式
 
-**eval-samples** 文件是 `omk eval` / `omk doctor` 跑的用例集 —— 一组用例，每条一个 `prompt`，外加可选的 `rubric`、`assertions` 和元数据。支持 JSON 和 YAML（`eval-samples.json`、`eval-samples.yaml`、`eval-samples.yml`），YAML 手写更省事。
+**eval-samples** 文件是 `omk eval` / `omk doctor` 使用的版本化用例集文档。它的 `samples` 数组包含具体用例，每条一个 `prompt`，外加可选的 `rubric`、`assertions` 和元数据。支持 JSON 和 YAML（`eval-samples.json`、`eval-samples.yaml`、`eval-samples.yml`），YAML 手写更省事。
 
 想知道怎么**设计**一套严谨用例（测什么、测几条、元数据字段），见[用例设计](../specs/sample-design-spec)；本页是逐字段的格式参考。
 
@@ -15,25 +15,32 @@
 
 兼容说明：omk 仍支持扁平 skill 的 `skills/<name>.eval-samples.json` 这类 sidecar 文件。目录 skill 不再读取 `<skill>/eval-samples.*`；skill 私有用例统一放在 `<skill>/.omk/samples.json`。
 
+每个文件都必须声明 `schemaVersion: omk.eval-sample-set/v1`，历史顶层数组格式会被拒绝。根文档、sample、assertion、mock 及其嵌套契约都采用严格校验；未知字段会在执行前报错，不会被静默忽略。发布的 JSON Schema 位于 [`schemas/eval-samples/v1/eval-sample-set.schema.json`](../../../schemas/eval-samples/v1/eval-sample-set.schema.json)。
+
 ```json
-[
-  {
-    "sample_id": "s001",
-    "prompt": "审查这段代码的安全性",
-    "context": "function auth(u, p) { db.query('SELECT * FROM users WHERE name=' + u); }",
-    "rubric": "应识别 SQL 注入风险并建议参数化查询",
-    "assertions": [
-      { "type": "contains", "value": "SQL 注入", "weight": 1 },
-      { "type": "contains", "value": "参数化", "weight": 1 },
-      { "type": "not_contains", "value": "没有问题", "weight": 0.5 }
-    ],
-    "dimensions": {
-      "security": "是否识别出注入漏洞",
-      "actionability": "是否给出可直接使用的修复代码"
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
+    {
+      "sample_id": "s001",
+      "prompt": "审查这段代码的安全性",
+      "context": "function auth(u, p) { db.query('SELECT * FROM users WHERE name=' + u); }",
+      "rubric": "应识别 SQL 注入风险并建议参数化查询",
+      "assertions": [
+        { "type": "contains", "value": "SQL", "weight": 1 },
+        { "type": "contains", "value": "parameterized", "weight": 1 },
+        { "type": "not_contains", "value": "safe", "weight": 0.5 }
+      ],
+      "dimensions": {
+        "security": "是否识别出注入漏洞",
+        "actionability": "是否给出可直接使用的修复代码"
+      }
     }
-  }
-]
+  ]
+}
 ```
+
+根文档还可以声明 `requires`，其中包含 `tools`、`files`、`env`、`preflight` 字符串数组；除此之外不接受其它根字段。
 
 ## 字段说明
 
@@ -73,7 +80,7 @@ loader 会在任何模型调用前校验完整契约。不支持的断言类型�
 | `provenance` | `'human' \| 'llm-generated' \| 'production-trace'` | 数据来源 |
 | `covers` | `{ targetKind, ref }[]` | 可选声明的 skill 结构锚点，建议先用于关键用例；仅用于 Skill Map |
 | `mocks` | `object[]` | 工具调用拦截列表 —— 要求执行器支持 mock 拦截 |
-| `mocksStrict` | `boolean` | 未命中任何 mock 的工具调用直接 deny（默认 `false`） |
+| `mocksStrict` | `boolean` | 未命中任何 mock 的工具调用直接 deny（默认 `true`；只有显式允许透传时才设为 `false`） |
 | `tripwire` | `boolean` | 诱错样本：LLM **应当** fail（默认 `false`） |
 | `environment` | `object` | 仅作 prompt 上下文的前置：`cli_available` / `files_available` / `notes`；不会物化文件或环境变量 |
 
@@ -86,15 +93,17 @@ loader 还会校验跨字段引用。每条 `mock_hit: "Tool:N"` 必须指向该
 Studio 的 Skill Map 节点详情也会读取这个声明：选中图中的节点时，会显示该结构关系是否由 `sample.covers` 显式声明。
 
 ```yaml
-- sample_id: release-risk-summary
-  prompt: "总结发布风险和回滚方案。"
-  covers:
-    - targetKind: reference
-      ref: references/release-policy.md
-    - targetKind: workflow
-      ref: release
-    - targetKind: workflow_node
-      ref: release.check
+schemaVersion: omk.eval-sample-set/v1
+samples:
+  - sample_id: release-risk-summary
+    prompt: "总结发布风险和回滚方案。"
+    covers:
+      - targetKind: reference
+        ref: references/release-policy.md
+      - targetKind: workflow
+        ref: release
+      - targetKind: workflow_node
+        ref: release.check
 ```
 
 `targetKind` 支持 `skill`、`skill_file`、`frontmatter`、`reference`、`script`、`hard_rule`、`workflow`、`workflow_node`。`reference` / `script` 的 `ref` 是相对 skill 根目录的路径；`hard_rule` / `workflow` 使用规则或 workflow id；`workflow_node` 使用 `workflowId.nodeId`。这个字段不进入 grading、评委 prompt、verdict，也不进入 sample 指纹。
@@ -105,8 +114,11 @@ Studio 的 Skill Map 节点详情也会读取这个声明：选中图中的节�
 
 ```json
 {
-  "sample_id": "s001",
-  "prompt": "请根据以下 PRD 文档生成评测用例：https://wiki.example.com/prd/feature-x"
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [{
+    "sample_id": "s001",
+    "prompt": "请根据以下 PRD 文档生成评测用例：https://wiki.example.com/prd/feature-x"
+  }]
 }
 ```
 

--- a/docs/zh/specs/sample-design-spec.md
+++ b/docs/zh/specs/sample-design-spec.md
@@ -12,6 +12,7 @@ omk 的统计严谨性栈（Bootstrap comparison family / Gold agreement / lengt
 
 ```yaml
 # eval-samples.yaml
+schemaVersion: omk.eval-sample-set/v1
 samples:
   - sample_id: s001
     prompt: "用 React 画一个折线图，数据是日期 + 数值，给最小可运行代码"
@@ -61,38 +62,40 @@ samples:
 为了让评测脱离真实外部环境（数据库/API/文件系统/真 git push 等），Sample 还有一组沙箱字段。omk runtime 在工具调用前匹配 mocks，命中即返回假数据，不真调底层。
 
 ```yaml
-- sample_id: s002
-  prompt: "用 antlogs-query 查最近 1 小时 ERROR 日志数量"
-  rubric: "应调 logstore_query 工具，filter 含 'ERROR'，时间窗口 1 小时"
-  assertions:
-    - { type: tool_input_contains, value: "Bash:logstore_query", weight: 1 }
-    - { type: mock_hit, value: "Bash:1", weight: 1 }
-  mocksStrict: true              # 默认 true（generator 强制）；未命中的工具调用直接 deny，不透传真调
-  tripwire: false                # 此 sample 是否「诱错样本」（故意诱导 LLM 走错，fail 是预期）；默认 false
-  environment:                   # 仅作 prompt 上下文的题设环境声明，不物化文件或环境变量
-    cli_available: ["log-cli"]
-    files_available: ["~/.config/log-cli.json"]
-    notes: "log-cli 已认证，token 在环境变量"
-  mocks:
-    - tool: Bash                            # 拦的工具名：Bash / Read / Edit / Write / WebFetch / Grep / Glob 等
-      match:
-        command_glob: "*log-cli query --filter ERROR*"   # Bash 用 command_glob (* 通配，跨换行)
-      return:
-        stdout: '{"count": 42}'
-        exit: 0
-    - tool: Read
-      match:
-        file_path_endswith: "tasks/state.json"           # 推荐：后缀匹配，LLM 用绝对/相对路径都能命中
-      return: '{"status":"running"}'
-    - tool: WebFetch
-      match:
-        url_glob: "https://internal.example.com/api/*"
-      return: "ok"
+schemaVersion: omk.eval-sample-set/v1
+samples:
+  - sample_id: s002
+    prompt: "用 antlogs-query 查最近 1 小时 ERROR 日志数量"
+    rubric: "应调 logstore_query 工具，filter 含 'ERROR'，时间窗口 1 小时"
+    assertions:
+      - { type: tool_input_contains, value: "Bash:logstore_query", weight: 1 }
+      - { type: mock_hit, value: "Bash:1", weight: 1 }
+    mocksStrict: true              # 默认 true；未命中的工具调用直接 deny，不透传真调
+    tripwire: false                # 是否为诱错样本；默认 false
+    environment:                   # 仅作 prompt 上下文，不物化文件或环境变量
+      cli_available: ["log-cli"]
+      files_available: ["~/.config/log-cli.json"]
+      notes: "log-cli 已认证，token 在环境变量"
+    mocks:
+      - tool: Bash
+        match:
+          command_glob: "*log-cli query --filter ERROR*"
+        return:
+          stdout: '{"count": 42}'
+          exit: 0
+      - tool: Read
+        match:
+          file_path_endswith: "tasks/state.json"
+        return: '{"status":"running"}'
+      - tool: WebFetch
+        match:
+          url_glob: "https://internal.example.com/api/*"
+        return: "ok"
 ```
 
 **字段语义**：
 
-- **mocksStrict**（boolean，默认 true）：未命中任何 mock 的工具调用直接 `deny`（LLM 看到失败结果）。**默认行为**：`omk sample` 生成器强制写 true，SYSTEM_PROMPT 明确；手写 sample 缺位时 sample 加载层不强制注入 —— 老 sample 不写默认走非 strict（透传真调）。**新写 sample 强烈建议 true**，避免漏 mock 导致评测打到真生产系统。
+- **mocksStrict**（boolean，默认 `true`）：未命中任何 mock 的工具调用直接 `deny`（LLM 看到失败结果）。production resolver 对生成和手写用例采用同一个 fail-closed 默认值；只有用例明确允许未命中调用进入真实 runtime 时才设为 `false`。
 - **tripwire**（boolean，默认 false）：声明这是一条诱错用例，prompt 有意加入违反 rubric 或 skill 的诱导。Evaluation Core 会把该声明作为 Sample annotation 保留供审计；它不会把 failed observation 变成 success，也不会改写已注册 Decision。
 - **environment**（object，可选）：仅作 prompt 上下文的题设环境声明。LLM 可以据此跳过可用性探测（`which X` / `test -f Y` / `echo $Z`）直接进工作流，但 omk 不会创建文件、导出环境变量或修改 `PATH`。它不是 fixture 机制。doctor 仍可审计声明的物理路径（可用 `--skip-doctor` 跳过）。
   - `cli_available: string[]` —— 假定已在 PATH 上
@@ -107,7 +110,7 @@ samples:
     - `command_glob: string` —— Bash 用，`*` 通配跨换行（LLM 多行命令也命中）。
     - `input: object` —— 通用 deep-equal 子集匹配（可写任意 tool_input 字段）。
     - `input_contains: string` —— 递归扫描 tool_input 所有 string 值，任一含该子串即命中（大小写不敏感）。**配合 `tool: "*"` 做 intent-level mock**：LLM 搜代码时可能用 Bash grep / Grep 工具 / Glob / Read / Agent 等任意工具，用 `input_contains` 按关键词匹配意图，不用逐个枚举工具。示例：`{tool: "*", match: {input_contains: "MyServiceName"}, return: "<service .../>"}` —— 任何工具只要输入提到 MyServiceName 就命中。
-  - **`return` 三种形式**：string / `{stdout, stderr, exit}`（模拟 Bash）/ `return_file` 外置文件 / `return_seq[]` 状态机（同 mock 第 N 次命中按序返回，超出回退 `return`）。
+  - **返回源**：每条 mock 必须且只能声明 `return`、`return_file`、`return_seq` 之一。`return` 接受 string 或 `{stdout, stderr, exit}`；`return_file` 加载外置 fixture；`return_seq[]` 是按命中次数取值的状态机，序列耗尽后保持最后一个值。
 - **断言侧的 mock_hit / tool_input_contains**：配合 mocks 使用。`mock_hit: "Bash:2"` 表示「第 2 条 Bash mock 必须被命中至少一次」，证明 LLM 走到了那一步。`tool_input_contains: "Bash:logstore_query"` 验证 Bash 命令字符串里包含 `logstore_query`。
   - 每条 `mock_hit` 必须指向该工具已经声明的 mock 序号。引用不存在或越界时，loader 会在执行前拒绝用例。
   - mock 支持是执行器能力，不是 trace 能力。`claude` / `claude-sdk` 会安装拦截 hooks；`codex`、`codex-sdk` 和 API 直调执行器目前不支持。选择不支持的执行器时，生成阶段自动切换为无 mock 用例，评测阶段则在运行前拒绝已有 mocks 用例。

--- a/examples/agent-runtime/eval-samples.json
+++ b/examples/agent-runtime/eval-samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "find-owner",
     "prompt": "Which team owns the billing webhook, and what file proves it?",
@@ -21,4 +23,5 @@
     "capability": ["repo-navigation", "runbook-summary"],
     "construct": "quality"
   }
-]
+  ]
+}

--- a/examples/code-review-ab/eval-samples.json
+++ b/examples/code-review-ab/eval-samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "sql-injection-review",
     "prompt": "Review this handler:\n\napp.get('/user', async (req, res) => {\n  const rows = await db.query(`select * from users where id = ${req.query.id}`);\n  res.json(rows[0]);\n});",
@@ -29,4 +31,5 @@
     "capability": ["privacy", "secure-code-review"],
     "construct": "capability"
   }
-]
+  ]
+}

--- a/examples/custom-executor/eval-samples.json
+++ b/examples/custom-executor/eval-samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "echo-green",
     "prompt": "Return exactly this word: GREEN",
@@ -34,4 +36,5 @@
       { "type": "contains_all", "values": ["DONE", "NOW"] }
     ]
   }
-]
+  ]
+}

--- a/examples/mcp-observation/eval-samples.json
+++ b/examples/mcp-observation/eval-samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "direct-explicit-capture",
     "prompt": "刚才你把退款期限说成了 7 天，但正确规则是 30 天。请把这个问题记录到 OMK，并只提交这段纠正所需的最小证据。",
@@ -92,4 +94,5 @@
     "provenance": "human",
     "tripwire": true
   }
-]
+  ]
+}

--- a/examples/rag-eval/eval-samples.yaml
+++ b/examples/rag-eval/eval-samples.yaml
@@ -1,3 +1,4 @@
+schemaVersion: omk.eval-sample-set/v1
 samples:
   - sample_id: refund-window
     prompt: "What is the refund window for the Pro plan?"

--- a/examples/skill-map-showcase/skills/release-readiness/.omk/samples.json
+++ b/examples/skill-map-showcase/skills/release-readiness/.omk/samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "release-risk-summary",
     "prompt": "We are shipping a payment flow change tomorrow. Summarize the release risk and decide whether to proceed.",
@@ -117,4 +119,5 @@
       }
     ]
   }
-]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
       "import": "./dist/package-api/evaluation-core.js"
     },
     "./evaluation-core/schemas/v1/*": "./dist/evaluation-core/contracts/schemas/v1/*",
+    "./eval-samples": {
+      "types": "./dist/package-api/eval-samples.d.ts",
+      "import": "./dist/package-api/eval-samples.js"
+    },
+    "./eval-samples/schemas/v1/*": "./dist/inputs/contracts/schemas/v1/*",
     "./projections": {
       "types": "./dist/eval-workflows/downstream-projections/index.d.ts",
       "import": "./dist/eval-workflows/downstream-projections/index.js"
@@ -53,8 +58,12 @@
     "build:src": "tsc -p tsconfig.build.json",
     "build:scripts": "tsc -p tsconfig.scripts.json",
     "build:schemas": "run-s build:src schemas:write",
-    "schemas:write": "node scripts/build-evaluation-core-schemas.mjs --write",
-    "schemas:check": "node scripts/build-evaluation-core-schemas.mjs --check",
+    "schemas:write": "run-s schemas:write:core schemas:write:samples",
+    "schemas:write:core": "node scripts/build-evaluation-core-schemas.mjs --write",
+    "schemas:write:samples": "node scripts/build-eval-sample-schema.mjs --write",
+    "schemas:check": "run-s schemas:check:core schemas:check:samples",
+    "schemas:check:core": "node scripts/build-evaluation-core-schemas.mjs --check",
+    "schemas:check:samples": "node scripts/build-eval-sample-schema.mjs --check",
     "build:assets": "node scripts/copy-assets.cjs",
     "build:docs": "node dist-scripts/build-docs.js --write",
     "build:docs:check": "node dist-scripts/build-docs.js --check",

--- a/schemas/eval-samples/v1/eval-sample-set.schema.json
+++ b/schemas/eval-samples/v1/eval-sample-set.schema.json
@@ -1,0 +1,620 @@
+{
+  "$defs": {
+    "__schema0": {
+      "const": "omk.eval-sample-set/v1",
+      "type": "string"
+    },
+    "__schema1": {
+      "additionalProperties": false,
+      "properties": {
+        "env": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "files": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "preflight": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "tools": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "__schema10": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema11": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema12": {
+      "additionalProperties": {
+        "$ref": "#/$defs/__schema13"
+      },
+      "propertyNames": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "__schema13": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema13"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema13"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema14": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema15": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema16"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema16": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema16"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema16"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema2": {
+      "items": {
+        "$ref": "#/$defs/__schema3"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "__schema3": {
+      "additionalProperties": false,
+      "properties": {
+        "allowedTools": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "assertions": {
+          "items": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "type": "array"
+        },
+        "capability": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "construct": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "context": {
+          "type": "string"
+        },
+        "covers": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "ref": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "targetKind": {
+                "enum": [
+                  "skill",
+                  "skill_file",
+                  "frontmatter",
+                  "reference",
+                  "script",
+                  "hard_rule",
+                  "workflow",
+                  "workflow_node"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "targetKind",
+              "ref"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "cwd": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "difficulty": {
+          "enum": [
+            "easy",
+            "medium",
+            "hard"
+          ],
+          "type": "string"
+        },
+        "dimensions": {
+          "additionalProperties": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "propertyNames": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "environment": {
+          "additionalProperties": false,
+          "properties": {
+            "cli_available": {
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "files_available": {
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "mocks": {
+          "items": {
+            "$ref": "#/$defs/__schema6"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "mocksStrict": {
+          "type": "boolean"
+        },
+        "prompt": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "provenance": {
+          "enum": [
+            "human",
+            "llm-generated",
+            "production-trace"
+          ],
+          "type": "string"
+        },
+        "rubric": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sample_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "tripwire": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "sample_id",
+        "prompt"
+      ],
+      "type": "object"
+    },
+    "__schema4": {
+      "additionalProperties": false,
+      "properties": {
+        "children": {
+          "items": {
+            "$ref": "#/$defs/__schema4"
+          },
+          "type": "array"
+        },
+        "flags": {
+          "type": "string"
+        },
+        "fn": {
+          "type": "string"
+        },
+        "mode": {
+          "enum": [
+            "any",
+            "all"
+          ],
+          "type": "string"
+        },
+        "n": {
+          "maximum": 9007199254740991,
+          "minimum": -9007199254740991,
+          "type": "integer"
+        },
+        "not": {
+          "type": "boolean"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "schema": {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "threshold": {
+          "maximum": 9007199254740991,
+          "minimum": -9007199254740991,
+          "type": "number"
+        },
+        "type": {
+          "enum": [
+            "contains",
+            "not_contains",
+            "regex",
+            "min_length",
+            "max_length",
+            "json_valid",
+            "json_schema",
+            "starts_with",
+            "ends_with",
+            "equals",
+            "not_equals",
+            "word_count_min",
+            "word_count_max",
+            "contains_all",
+            "contains_any",
+            "cost_max",
+            "latency_max",
+            "turns_max",
+            "turns_min",
+            "tools_called",
+            "tools_not_called",
+            "tools_count_max",
+            "tools_count_min",
+            "tool_output_contains",
+            "tool_input_contains",
+            "tool_input_not_contains",
+            "mock_hit",
+            "rouge_n_min",
+            "levenshtein_max",
+            "bleu_min",
+            "assert-set",
+            "semantic_similarity",
+            "custom",
+            "faithfulness",
+            "answer_relevancy",
+            "context_recall"
+          ],
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "maximum": 9007199254740991,
+              "minimum": -9007199254740991,
+              "type": "number"
+            }
+          ]
+        },
+        "values": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "weight": {
+          "maximum": 9007199254740991,
+          "minimum": -9007199254740991,
+          "type": "number"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "__schema5": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema5"
+          },
+          "propertyNames": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema6": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "match": {
+              "$ref": "#/$defs/__schema8"
+            },
+            "return": {
+              "$ref": "#/$defs/__schema15"
+            },
+            "tool": {
+              "$ref": "#/$defs/__schema7"
+            }
+          },
+          "required": [
+            "tool",
+            "return"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "match": {
+              "$ref": "#/$defs/__schema8"
+            },
+            "return_file": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "tool": {
+              "$ref": "#/$defs/__schema7"
+            }
+          },
+          "required": [
+            "tool",
+            "return_file"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "match": {
+              "$ref": "#/$defs/__schema8"
+            },
+            "return_seq": {
+              "items": {
+                "$ref": "#/$defs/__schema15"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "tool": {
+              "$ref": "#/$defs/__schema7"
+            }
+          },
+          "required": [
+            "tool",
+            "return_seq"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "__schema7": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "__schema8": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "command_glob": {
+              "$ref": "#/$defs/__schema11"
+            },
+            "file_path": {
+              "$ref": "#/$defs/__schema9"
+            },
+            "file_path_endswith": {
+              "$ref": "#/$defs/__schema10"
+            },
+            "input": {
+              "$ref": "#/$defs/__schema12"
+            },
+            "input_contains": {
+              "$ref": "#/$defs/__schema14"
+            },
+            "url": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "url"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "command_glob": {
+              "$ref": "#/$defs/__schema11"
+            },
+            "file_path": {
+              "$ref": "#/$defs/__schema9"
+            },
+            "file_path_endswith": {
+              "$ref": "#/$defs/__schema10"
+            },
+            "input": {
+              "$ref": "#/$defs/__schema12"
+            },
+            "input_contains": {
+              "$ref": "#/$defs/__schema14"
+            },
+            "url_glob": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "url_glob"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "command_glob": {
+              "$ref": "#/$defs/__schema11"
+            },
+            "file_path": {
+              "$ref": "#/$defs/__schema9"
+            },
+            "file_path_endswith": {
+              "$ref": "#/$defs/__schema10"
+            },
+            "input": {
+              "$ref": "#/$defs/__schema12"
+            },
+            "input_contains": {
+              "$ref": "#/$defs/__schema14"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "__schema9": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/eval-samples/v1/eval-sample-set.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "requires": {
+      "$ref": "#/$defs/__schema1"
+    },
+    "samples": {
+      "$ref": "#/$defs/__schema2"
+    },
+    "schemaVersion": {
+      "$ref": "#/$defs/__schema0"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "samples"
+  ],
+  "title": "OMK Eval Sample Set v1",
+  "type": "object"
+}

--- a/scripts/build-eval-sample-schema.mjs
+++ b/scripts/build-eval-sample-schema.mjs
@@ -1,0 +1,55 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { resolve } from 'node:path';
+import { generateEvalSampleSetJsonSchema } from '../dist/inputs/schemas/json-schema.js';
+
+const mode = process.argv[2];
+if (mode !== '--write' && mode !== '--check') {
+  throw new Error('Usage: node scripts/build-eval-sample-schema.mjs <--write|--check>');
+}
+
+const schemaDir = resolve('schemas/eval-samples/v1');
+const fileName = 'eval-sample-set.schema.json';
+
+function sortJson(value) {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (value === null || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, sortJson(value[key])]),
+  );
+}
+
+const rendered = `${JSON.stringify(sortJson(generateEvalSampleSetJsonSchema()), null, 2)}\n`;
+
+if (mode === '--write') {
+  mkdirSync(schemaDir, { recursive: true });
+  for (const candidate of readdirSync(schemaDir)) {
+    if (candidate.endsWith('.schema.json') && candidate !== fileName) {
+      rmSync(resolve(schemaDir, candidate));
+    }
+  }
+  writeFileSync(resolve(schemaDir, fileName), rendered);
+  console.log('Generated Eval Sample Set v1 schema.');
+  process.exit(0);
+}
+
+const filePath = resolve(schemaDir, fileName);
+if (!existsSync(filePath) || readFileSync(filePath, 'utf8') !== rendered) {
+  console.error(`${fileName} is missing or stale`);
+  console.error('Run `yarn build:schemas` and commit the generated file.');
+  process.exit(1);
+}
+const unexpected = readdirSync(schemaDir).filter(
+  (candidate) => candidate.endsWith('.schema.json') && candidate !== fileName,
+);
+if (unexpected.length > 0) {
+  console.error(`Unexpected Eval Sample schemas: ${unexpected.join(', ')}`);
+  process.exit(1);
+}
+console.log('Checked Eval Sample Set v1 schema.');

--- a/scripts/copy-assets.cjs
+++ b/scripts/copy-assets.cjs
@@ -23,6 +23,7 @@ for (const [src, dst] of ASSETS) {
 const DIR_ASSETS = [
   ['.agents/skills/omk', 'dist/assets/agent-skills/omk'],
   ['schemas/evaluation-core/v1', 'dist/evaluation-core/contracts/schemas/v1'],
+  ['schemas/eval-samples/v1', 'dist/inputs/contracts/schemas/v1'],
 ];
 
 for (const [src, dst] of DIR_ASSETS) {

--- a/src/authoring/generator.ts
+++ b/src/authoring/generator.ts
@@ -3,6 +3,8 @@ import { executorSupportsSampleMocks } from '../executors/core/capabilities.js';
 import { DEFAULT_EVALUATION_GATE_THRESHOLD as DEFAULT_GATE_THRESHOLD } from '../eval-workflows/evaluation-defaults.js';
 import { sampleMockReferenceKeys } from '../shared/sample-contract.js';
 import type { Sample, SampleProvenance } from '../inputs/contracts/sample.js';
+import { detailedSchemaIssue } from '../inputs/schemas/error.js';
+import { MockSchema } from '../inputs/schemas/mock.js';
 import type { ExecutorFn } from '../executors/contracts/ports.js';
 import type { Assertion } from '../inputs/contracts/assertion.js';
 import type { ObservationInboxItem } from '../observability/contracts/inbox.js';
@@ -1102,8 +1104,8 @@ export function sanitizeGeneratedSamples(
       }
     }
 
-    // mocks 校验:必须是数组,每项必须有 tool(string)+ 至少一种 return。
-    // 非法的 strip 掉,避免 runtime 装 hook 时炸。
+    // mocks 校验：严格复用 authoring schema，避免生成器与 loader 漂移。
+    // 非法的整条 strip，避免模糊命中或返回源歧义进入 runtime。
     if (s.mocks !== undefined) {
       if (!Array.isArray(s.mocks)) {
         stripped.push(`samples[${i}].mocks (${typeof s.mocks})`);
@@ -1111,18 +1113,20 @@ export function sanitizeGeneratedSamples(
       } else {
         const validMocks: unknown[] = [];
         for (let j = 0; j < s.mocks.length; j++) {
-          const m = s.mocks[j] as unknown as Record<string, unknown>;
-          if (typeof m?.tool !== 'string' || m.tool.length === 0) {
-            stripped.push(`samples[${i}].mocks[${j}].tool (missing/invalid)`);
+          const parsedMock = MockSchema.safeParse(s.mocks[j]);
+          if (!parsedMock.success) {
+            const issue = detailedSchemaIssue(parsedMock.error);
+            const path = issue?.path.length ? `.${issue.path.join('.')}` : '';
+            stripped.push(
+              `samples[${i}].mocks[${j}]${path} (${issue?.message ?? 'invalid mock'})`,
+            );
             continue;
           }
-          if (m.return === undefined && m.return_file === undefined && m.return_seq === undefined) {
-            stripped.push(`samples[${i}].mocks[${j}] (no return/return_file/return_seq)`);
-            continue;
-          }
-          validMocks.push(m);
+          validMocks.push(parsedMock.data);
         }
-        if (validMocks.length > 0) (s as Record<string, unknown>).mocks = validMocks;
+        if (validMocks.length > 0) {
+          (s as unknown as Record<string, unknown>).mocks = validMocks;
+        }
         else delete (s as { mocks?: unknown }).mocks;
       }
     }

--- a/src/cli/commands/evolve.ts
+++ b/src/cli/commands/evolve.ts
@@ -7,6 +7,7 @@ import { enumStringParser, integerStringParser, numberStringParser } from '../oc
 import { CliExit } from '../lib/cli-exit.js';
 import { tCli, type CliLang } from '../lib/i18n.js';
 import { formatSampleGenerationFailureHint } from '../lib/generation-failure-hint.js';
+import { createEvalSampleSetDocument } from '../../inputs/schemas/sample-set.js';
 import type { EvolveArgs, EvolveFlags } from '../lib/cmd-flags.js';
 import type {
   CoreEvolveOutcomeInput,
@@ -190,7 +191,10 @@ export async function runEvolve(
         throw new CliExit(1);
       }
       mkdirSync(dirname(outFile), { recursive: true });
-      writeFileSync(outFile, JSON.stringify(samples, null, 2));
+      writeFileSync(
+        outFile,
+        JSON.stringify(createEvalSampleSetDocument(samples), null, 2),
+      );
       const cost = costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
       process.stderr.write(lang === 'zh'
         ? `已生成 ${samples.length} 条用例${cost}，开始自迭代。\n`

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -21,7 +21,9 @@ const INIT_OMK_GITIGNORE = `# omk 测量 bulk + doctor --fix 备份(项目本地
 // 只能是单个 ASCII token(长度 [2,40]、无内部空白、无 CJK);多词 / 中文语义匹配一律
 // 走 rubric 交评委判;regex pattern 不能含 CJK。改这里前先跑 `omk eval --dry-run`
 // (非 lenient 合规 oracle)与 test/cli/init-scaffold-conformance 回归测试。
-const INIT_SAMPLES = `[
+const INIT_SAMPLES = `{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "s001",
     "prompt": "审查以下代码",
@@ -66,7 +68,8 @@ const INIT_SAMPLES = `[
       "actionability": "是否给出使用 textContent 或转义的修复代码"
     }
   }
-]
+  ]
+}
 `;
 
 // 模板带 Claude Code SKILL.md 兼容 frontmatter(name + description),让用户

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -22,11 +22,15 @@ import {
 } from '../../inputs/sample-locator.js';
 import { shellQuoteArg } from '../../shared/shell-quote.js';
 import type { SampleArgs, SampleFlags } from '../lib/cmd-flags.js';
-import type { Sample as SampleType } from '../../inputs/contracts/sample.js';
+import type {
+  EvalSampleSetDocument,
+  Sample as SampleType,
+} from '../../inputs/contracts/sample.js';
+import { createEvalSampleSetDocument } from '../../inputs/schemas/sample-set.js';
 import type { ResolvedSkillInput } from '../lib/resolve-skill-input.js';
 
 interface GenerateSamplesResult {
-  samples: unknown[];
+  samples: SampleType[];
   costUSD: number;
 }
 
@@ -98,7 +102,7 @@ export function pickAppendTargetFile(dir: string): string | null {
 }
 
 /** 把新用例追加进已有 sample 文件:读 → 合并(撞 id 去重)→ 保留原 json/yaml 格式与
- *  `{samples:[...]}` wrapper 写回。返回合并后总条数。 */
+ *  versioned wrapper 写回。返回合并后总条数。 */
 export function appendSamplesToFile(
   existingFile: string,
   fresh: SampleType[],
@@ -106,7 +110,10 @@ export function appendSamplesToFile(
 ): number {
   const doc = parseSampleDocument(existingFile);
   const merged = mergeAppendSamples(getSamplesArray(doc, existingFile), fresh, reserved);
-  const nextDoc = Array.isArray(doc) ? merged : { ...(doc as Record<string, unknown>), samples: merged };
+  const nextDoc: EvalSampleSetDocument = {
+    ...(doc as EvalSampleSetDocument),
+    samples: merged,
+  };
   writeFileSync(existingFile, stringifySampleDocument(existingFile, nextDoc));
   return merged.length;
 }
@@ -175,7 +182,7 @@ export async function runSampleFromTraces(
       return;
     }
     mkdirSync(dirname(outPath), { recursive: true });
-    writeFileSync(outPath, JSON.stringify(samples, null, 2));
+    writeFileSync(outPath, JSON.stringify(createEvalSampleSetDocument(samples), null, 2));
     process.stderr.write(lang === 'zh'
       ? `\n✅ 生成 ${samples.length} 条草稿用例 → ${outPath}（provenance: production-trace）${cost}\n   ⚠️ 这是草稿：trace 只抓失败信号，有抽样偏差。请人工 review 后再合入正式 eval-samples，不要直接当评测集。\n`
       : `\n✅ Generated ${samples.length} draft sample(s) → ${outPath} (provenance: production-trace)${cost}\n   ⚠️ Draft only: traces capture failures, a biased sample. Review before merging into your eval-samples; don't use as-is.\n`);
@@ -272,7 +279,10 @@ async function runSample(
         const { samples, costUSD }: GenerateSamplesResult =
           await generateSamples({ skillContent, count, model, focus, noMock: flags['no-mock'], executorName });
         mkdirSync(dirname(samplesPath), { recursive: true });
-        writeFileSync(samplesPath, JSON.stringify(samples, null, 2));
+        writeFileSync(
+          samplesPath,
+          JSON.stringify(createEvalSampleSetDocument(samples), null, 2),
+        );
         const cost: string = costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
         process.stderr.write(tCli('cli.gen.skill_done', lang, {
           name, n: samples.length, path: samplesPath, cost,
@@ -351,7 +361,10 @@ async function runSample(
         }));
       } else {
         mkdirSync(dirname(outputPath), { recursive: true });
-        writeFileSync(outputPath, JSON.stringify(samples, null, 2));
+        writeFileSync(
+          outputPath,
+          JSON.stringify(createEvalSampleSetDocument(samples), null, 2),
+        );
         process.stderr.write(tCli('cli.gen.single_done', lang, {
           n: samples.length, path: outputPath, cost,
         }));

--- a/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
+++ b/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
@@ -428,7 +428,7 @@ async function resolvedMocks(
           tool: mock.tool,
           ...(mock.match === undefined ? {} : { match: structuredClone(mock.match) as JsonValue }),
         },
-        strict: sample.mocksStrict ?? false,
+        strict: sample.mocksStrict ?? true,
         payloads: await mockPayloadDescriptors(
           resources,
           mock,

--- a/src/executors/mock-runtime/mock-hook.cjs
+++ b/src/executors/mock-runtime/mock-hook.cjs
@@ -164,8 +164,8 @@ function stringifyReturn(r) {
 }
 
 function resolveMockReturn(mock, hitCount, baseDir) {
-  if (mock.return_seq && hitCount < mock.return_seq.length) {
-    return stringifyReturn(mock.return_seq[hitCount]);
+  if (mock.return_seq && mock.return_seq.length > 0) {
+    return stringifyReturn(mock.return_seq[Math.min(hitCount, mock.return_seq.length - 1)]);
   }
   if (mock.return !== undefined) return stringifyReturn(mock.return);
   if (mock.return_file) {

--- a/src/executors/mock-runtime/runtime.ts
+++ b/src/executors/mock-runtime/runtime.ts
@@ -146,9 +146,9 @@ export function resolveMockReturn(
   hitCount: number,
   baseDir?: string,
 ): string {
-  // return_seq 优先,按 hit 序号取(超出长度 fallback 到 return / return_file)
-  if (mock.return_seq && hitCount < mock.return_seq.length) {
-    return stringifyReturn(mock.return_seq[hitCount]);
+  // return_seq 按 hit 序号取；超出长度后保持最后一个状态。
+  if (mock.return_seq && mock.return_seq.length > 0) {
+    return stringifyReturn(mock.return_seq[Math.min(hitCount, mock.return_seq.length - 1)]);
   }
   if (mock.return !== undefined) {
     return stringifyReturn(mock.return);
@@ -538,7 +538,9 @@ function isMockHit(mock, toolName, toolInput) {
 }
 function stringifyReturn(r) { return typeof r === 'string' ? r : JSON.stringify(r); }
 function resolveMockReturn(mock, hitCount, baseDir) {
-  if (mock.return_seq && hitCount < mock.return_seq.length) return stringifyReturn(mock.return_seq[hitCount]);
+  if (mock.return_seq && mock.return_seq.length > 0) {
+    return stringifyReturn(mock.return_seq[Math.min(hitCount, mock.return_seq.length - 1)]);
+  }
   if (mock.return !== undefined) return stringifyReturn(mock.return);
   if (mock.return_file) {
     const fpath = path.isAbsolute(mock.return_file) ? mock.return_file : path.resolve(baseDir || process.cwd(), mock.return_file);

--- a/src/inputs/contracts/assertion.ts
+++ b/src/inputs/contracts/assertion.ts
@@ -1,5 +1,7 @@
+import type { SupportedAssertionType } from '../../shared/contracts/assertion.js';
+
 export interface Assertion {
-  type: string;
+  type: SupportedAssertionType;
   value?: string | number;
   values?: string[];
   pattern?: string;

--- a/src/inputs/contracts/mock.ts
+++ b/src/inputs/contracts/mock.ts
@@ -1,5 +1,5 @@
 /** Mock 命中规则(所有字段 AND,字段未填即不限制)。 */
-export interface MockMatch {
+interface MockMatchBase {
   /** 精确匹配 file_path(用于 Read / Edit / Write,支持 ~ 自动展开)。
    *  注意:claude-cli / claude-sdk 的 PreToolUse hook 拿到的 file_path 是 LLM 调
    *  Read/Edit/Write 时实际传入的字符串。LLM 经常把相对路径写成 cwd 绝对路径
@@ -11,10 +11,6 @@ export interface MockMatch {
    *  '/abs/cwd/tasks/foo/state.json' / '~/proj/tasks/foo/state.json' 但不命中
    *  'bad-state.json'。`~` 自动展开。**绝对路径 cwd 不可预测时首选这个字段**。 */
   file_path_endswith?: string;
-  /** 精确匹配 url(用于 WebFetch / WebSearch)。 */
-  url?: string;
-  /** glob 匹配 url(支持 *)。url 与 url_glob 二选一。 */
-  url_glob?: string;
   /** glob 匹配 command(用于 Bash 拦 mcporter / cli;支持 *)。 */
   command_glob?: string;
   /** 通用匹配:对 tool_input 任意字段做 deep equal,优先级高于上面的 sugar 字段。 */
@@ -25,26 +21,44 @@ export interface MockMatch {
   input_contains?: string;
 }
 
+export type MockMatch = MockMatchBase & (
+  | { url: string; url_glob?: never }
+  | { url?: never; url_glob: string }
+  | { url?: never; url_glob?: never }
+);
+
 /** Mock 返回值(三选一)。 */
 export type MockReturn =
   | { stdout?: string; stderr?: string; exit?: number; [k: string]: unknown }
   | string;
 
-/** 单条 Mock 规则。runtime 拦到匹配的 tool 调用即返回 mocked 结果,不放出去。 */
-export interface Mock {
+interface MockBase {
   /** source-neutral 工具身份,如 "Read" / "Bash" / "WebFetch" / "Edit" / "Write" / "Grep" / "Glob"。
    *  executor adapter 会把 runtime-native 名称（如 exec_command / apply_patch）映射后匹配。
    *  特殊值 `"*"`:通配,匹配任何工具名(配合 match.input_contains 做 intent-level mock)。 */
   tool: string;
   /** 命中规则。所有字段 AND,字段未填即不限制。 */
   match?: MockMatch;
-  /** 返回内容(LLM 看到的 tool_result),与 return_file / return_seq 三选一。
-   *  - string:直接当字符串返回
-   *  - { stdout, stderr, exit }:模拟 Bash 工具结果(若 exit !=0 表示失败) */
-  return?: MockReturn;
-  /** 从外部 fixture 文件读返回内容(路径相对 sample 目录;大响应建议外置)。 */
-  return_file?: string;
-  /** 同 mock 多次命中按序返回(状态机场景:第 1 次 PENDING → 第 2 次 SUCCESS)。
-   *  超出序列长度时回退到 return / return_file。 */
-  return_seq?: MockReturn[];
 }
+
+/** 单条 Mock 规则。runtime 拦到匹配的 tool 调用即返回 mocked 结果,不放出去。 */
+export type Mock = MockBase & (
+  | {
+      /** 返回内容(LLM 看到的 tool_result)。string 直接返回；object 可模拟 Bash。 */
+      return: MockReturn;
+      return_file?: never;
+      return_seq?: never;
+    }
+  | {
+      /** 从外部 fixture 文件读返回内容(路径相对 sample 目录;大响应建议外置)。 */
+      return?: never;
+      return_file: string;
+      return_seq?: never;
+    }
+  | {
+      /** 同 mock 多次命中按序返回；超过序列长度后保持最后一个状态。 */
+      return?: never;
+      return_file?: never;
+      return_seq: MockReturn[];
+    }
+);

--- a/src/inputs/contracts/sample.ts
+++ b/src/inputs/contracts/sample.ts
@@ -46,7 +46,6 @@ export interface Sample {
   assertions?: Assertion[];
   dimensions?: Record<string, string>;
   allowedTools?: string[];
-  expectedTools?: string[];
   /** 该 sample 测试的能力维度,可多维。free-form string,suggested
    *  values 见 docs/specs/sample-design-spec.md。aggregate 时大小写不敏感。
    *  纯文档 / 诊断用,不参与 grading / judge / verdict。 */
@@ -74,11 +73,21 @@ export interface Sample {
    *  详见 docs/sample-mocks.md(命中规则、状态机、fixture 文件)。 */
   mocks?: Mock[];
   /** mocks 严格模式。
-   *  - false / undefined(default):未命中的 tool 调用透传(继续真跑底层)
-   *  - true:未命中即 deny(防意外真调外部接口/CLI/MCP/写状态)。
-   *  全 mock 评测场景建议 true,部分 mock 探索场景留 false。 */
+   *  - true / undefined(default):未命中即 deny(防意外真调外部接口/CLI/MCP/写状态)
+   *  - false:显式允许未命中的 tool 调用透传(继续真跑底层)。
+   *  部分 mock 探索场景才应显式写 false。 */
   mocksStrict?: boolean;
   /** 题设环境声明,仅作 prompt 上下文。详见 SampleEnvironment。 */
   environment?: SampleEnvironment;
-  [key: string]: unknown;  // allow extra fields like mutated prompt/context from URL resolution
+}
+
+export interface EvalSampleSetDocument {
+  schemaVersion: 'omk.eval-sample-set/v1';
+  requires?: {
+    tools?: string[];
+    files?: string[];
+    env?: string[];
+    preflight?: string[];
+  };
+  samples: Sample[];
 }

--- a/src/inputs/load-samples.ts
+++ b/src/inputs/load-samples.ts
@@ -2,11 +2,10 @@ import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import type { Sample } from './contracts/sample.js';
+import { detailedSchemaIssue } from './schemas/error.js';
+import { EvalSampleSetDocumentSchema, SampleSchema } from './schemas/sample-set.js';
 import type { DependencyRequirements } from '../preflight/contracts.js';
-import {
-  dependencyRequirementsValidationError,
-  sampleContractValidationError,
-} from '../shared/sample-contract.js';
+import { sampleContractValidationError } from '../shared/sample-contract.js';
 import { setOwnRecordValue } from '../shared/record-count.js';
 
 interface YamlErrorLike {
@@ -52,8 +51,7 @@ export interface LoadSamplesOptions {
  * Load samples from a single file OR a directory of sample files.
  *
  * File mode (.json / .yaml / .yml):
- * - Array: `[ { sample_id, prompt, ... } ]` (legacy)
- * - Object wrapper: `{ requires?: { tools, files, env }, samples: [...] }`
+ * - Versioned object: `{ schemaVersion: 'omk.eval-sample-set/v1', requires?, samples }`
  *
  * Directory mode (e.g. `<skill>/.omk/`):
  * - Glob `*.{json,yaml,yml}` minus reserved prefixes (report*, health*, _*)
@@ -175,6 +173,14 @@ export function validateSamples(
   const firstIndexBySampleId = new Map<string, number>();
 
   for (const [i, sample] of samples.entries()) {
+    const structural = SampleSchema.safeParse(sample);
+    if (!structural.success) {
+      const issue = detailedSchemaIssue(structural.error);
+      const field = issue?.path.length ? `.${issue.path.join('.')}` : '';
+      throw new Error(
+        `samples[${i}] invalid sample contract${field}: ${issue?.message ?? 'invalid shape'}`,
+      );
+    }
     if (!sample || typeof sample !== 'object' || Array.isArray(sample)) {
       throw new Error(`samples[${i}] invalid sample contract: sample must be an object`);
     }
@@ -354,30 +360,16 @@ function loadSampleFile(
   const isYaml = samplesPath.endsWith('.yaml') || samplesPath.endsWith('.yml');
   const parsed: unknown = isYaml ? parseYaml(rawContent) : JSON.parse(rawContent);
 
-  let samples: Sample[];
-  let requires: DependencyRequirements | undefined;
-
-  if (Array.isArray(parsed)) {
-    // Legacy array format
-    samples = parsed as Sample[];
-  } else if (typeof parsed === 'object' && parsed !== null && 'samples' in parsed) {
-    // Object wrapper format
-    const wrapper = parsed as { samples: Sample[]; requires?: DependencyRequirements };
-    samples = wrapper.samples;
-    requires = wrapper.requires;
-    if (requires !== undefined) {
-      const requiresError = dependencyRequirementsValidationError(requires);
-      if (requiresError) {
-        throw new Error(`invalid samples file: ${samplesPath}: ${requiresError}`);
-      }
-    }
-  } else {
-    throw new Error(`invalid samples file shape: ${samplesPath} (expected an array or an object with a 'samples' field)`);
+  const document = EvalSampleSetDocumentSchema.safeParse(parsed);
+  if (!document.success) {
+    const issue = detailedSchemaIssue(document.error);
+    const field = issue?.path.length ? issue.path.join('.') : '$';
+    throw new Error(
+      `invalid samples file: ${samplesPath}: ${field}: ${issue?.message ?? 'invalid shape'}`,
+    );
   }
-
-  if (!Array.isArray(samples) || samples.length === 0) {
-    throw new Error(`invalid samples file: ${samplesPath}`);
-  }
+  const samples = document.data.samples;
+  const requires = document.data.requires as DependencyRequirements | undefined;
 
   validateSamples(samples, options);
 

--- a/src/inputs/mcp-resolver.ts
+++ b/src/inputs/mcp-resolver.ts
@@ -126,7 +126,10 @@ export async function resolveMcpUrls(samples: Sample[], mcpServers: McpServers |
   if (!mcpServers) return resolved;
 
   // 1. Collect unique URLs and track which sample/field they belong to
-  const urlMap = new Map<string, Array<{ sample: Sample; field: string }>>(); // url -> [{sample, field}]
+  const urlMap = new Map<string, Array<{
+    sample: Sample;
+    field: 'prompt' | 'context';
+  }>>();
   for (const sample of samples) {
     for (const field of ['prompt', 'context'] as const) {
       const text = sample[field] as string | undefined;

--- a/src/inputs/sample-document.ts
+++ b/src/inputs/sample-document.ts
@@ -9,14 +9,12 @@ import {
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 import yaml from 'js-yaml';
-import type { Sample } from './contracts/sample.js';
+import type { EvalSampleSetDocument, Sample } from './contracts/sample.js';
+import { detailedSchemaIssue } from './schemas/error.js';
+import { EvalSampleSetDocumentSchema } from './schemas/sample-set.js';
 import { withFileLock } from '../shared/file-lock.js';
 import { ownRecordValue } from '../shared/record-count.js';
 import { parseYaml, validateSamples, type LoadSamplesResult } from './load-samples.js';
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 function isYamlPath(filePath: string): boolean {
   return /\.(ya?ml)$/i.test(filePath);
@@ -28,14 +26,11 @@ export function parseSampleDocument(filePath: string): unknown {
 }
 
 export function getSamplesArray(document: unknown, filePath: string): Sample[] {
-  if (Array.isArray(document)) return document as Sample[];
-  if (isRecord(document) && Array.isArray(document.samples)) {
-    return document.samples as Sample[];
-  }
-  throw new Error(
-    `invalid samples file shape: ${filePath} `
-    + `(expected an array or an object with a 'samples' field)`,
-  );
+  const parsed = EvalSampleSetDocumentSchema.safeParse(document);
+  if (parsed.success) return parsed.data.samples;
+  const issue = detailedSchemaIssue(parsed.error);
+  const field = issue?.path.length ? issue.path.join('.') : '$';
+  throw new Error(`invalid samples file shape: ${filePath}: ${field}: ${issue?.message ?? 'invalid shape'}`);
 }
 
 export function stringifySampleDocument(filePath: string, document: unknown): string {
@@ -70,8 +65,7 @@ function atomicWriteFile(filePath: string, content: string): void {
 
 /**
  * Persist only changed samples back to the source file that originally owned each
- * sample_id. JSON/YAML and array/wrapper shapes are retained, including `requires`
- * and any other wrapper metadata.
+ * sample_id. JSON/YAML encoding and the versioned wrapper are retained.
  */
 export function writeFixedSamplesToSources(
   loaded: Pick<LoadSamplesResult, 'sourceFiles' | 'sampleSourceById'>,
@@ -111,9 +105,10 @@ export function writeFixedSamplesToSources(
         ids.has(sample.sample_id) ? fixedById.get(sample.sample_id)! : sample
       ));
       validateSamples(nextSamples);
-      const nextDocument = Array.isArray(document)
-        ? nextSamples
-        : { ...(document as Record<string, unknown>), samples: nextSamples };
+      const nextDocument: EvalSampleSetDocument = {
+        ...(document as EvalSampleSetDocument),
+        samples: nextSamples,
+      };
       atomicWriteFile(filePath, stringifySampleDocument(filePath, nextDocument));
     });
   }

--- a/src/inputs/schemas/assertion.ts
+++ b/src/inputs/schemas/assertion.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import type { Assertion } from '../contracts/assertion.js';
+import {
+  ASYNC_ASSERTION_TYPE_NAMES,
+  SYNC_ASSERTION_TYPE_NAMES,
+} from '../../shared/assertion-types.js';
+
+const JsonObjectSchema = z.record(z.string(), z.json());
+
+/** Strict authoring shape. Type-specific and recursive semantic rules are checked separately. */
+export const AssertionSchema: z.ZodType<Assertion> = z.lazy(() => z.object({
+  type: z.enum([...SYNC_ASSERTION_TYPE_NAMES, ...ASYNC_ASSERTION_TYPE_NAMES]),
+  value: z.union([
+    z.string(),
+    z.number().finite().min(-Number.MAX_SAFE_INTEGER).max(Number.MAX_SAFE_INTEGER),
+  ]).optional(),
+  values: z.array(z.string()).optional(),
+  pattern: z.string().optional(),
+  flags: z.string().optional(),
+  schema: JsonObjectSchema.optional(),
+  weight: z.number().finite().min(-Number.MAX_SAFE_INTEGER).max(Number.MAX_SAFE_INTEGER).optional(),
+  fn: z.string().optional(),
+  reference: z.string().optional(),
+  threshold: z.number().finite().min(-Number.MAX_SAFE_INTEGER).max(Number.MAX_SAFE_INTEGER).optional(),
+  not: z.boolean().optional(),
+  mode: z.enum(['any', 'all']).optional(),
+  children: z.array(AssertionSchema).optional(),
+  n: z.number().int().safe().optional(),
+}).strict());

--- a/src/inputs/schemas/error.ts
+++ b/src/inputs/schemas/error.ts
@@ -1,0 +1,53 @@
+interface ZodIssueLike {
+  readonly code?: string;
+  readonly message: string;
+  readonly path: readonly PropertyKey[];
+  readonly errors?: readonly (readonly ZodIssueLike[])[];
+}
+
+export interface DetailedSchemaIssue {
+  readonly message: string;
+  readonly path: readonly PropertyKey[];
+}
+
+function leafIssues(
+  issues: readonly ZodIssueLike[],
+  prefix: readonly PropertyKey[] = [],
+): ZodIssueLike[] {
+  const leaves: ZodIssueLike[] = [];
+  for (const issue of issues) {
+    const path = [...prefix, ...issue.path];
+    if (issue.errors?.length) {
+      for (const branch of issue.errors) leaves.push(...leafIssues(branch, path));
+    } else {
+      leaves.push({ ...issue, path });
+    }
+  }
+  return leaves;
+}
+
+/** Picks the deepest actionable leaf from nested union failures. */
+export function detailedSchemaIssue(error: { readonly issues: readonly unknown[] }): DetailedSchemaIssue {
+  const roots = error.issues as readonly ZodIssueLike[];
+  const issues = leafIssues(roots);
+  const mockReturnRoot = roots.find((issue) => (
+    issue.message === 'mock requires exactly one of return, return_file, or return_seq'
+  ));
+  if (mockReturnRoot) {
+    const nonReturnUnknown = issues.find((issue) => (
+      issue.code === 'unrecognized_keys'
+      && !/"(?:return|return_file|return_seq)"/.test(issue.message)
+    ));
+    if (!nonReturnUnknown) {
+      return { path: mockReturnRoot.path, message: mockReturnRoot.message };
+    }
+  }
+  const selected = issues.sort((left, right) => {
+    const leftUnknown = left.code === 'unrecognized_keys' ? 1 : 0;
+    const rightUnknown = right.code === 'unrecognized_keys' ? 1 : 0;
+    const unknown = rightUnknown - leftUnknown;
+    if (unknown !== 0) return unknown;
+    return right.path.length - left.path.length;
+  })[0];
+  return selected ?? { path: [], message: 'invalid shape' };
+}

--- a/src/inputs/schemas/json-schema.ts
+++ b/src/inputs/schemas/json-schema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { EvalSampleSetDocumentSchema } from './sample-set.js';
+
+const SCHEMA_URI =
+  'https://raw.githubusercontent.com/lizhiyao/oh-my-knowledge/main/schemas/eval-samples/v1/eval-sample-set.schema.json';
+
+function assertNoEmptySchemaNode(value: unknown, path = '$'): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoEmptySchemaNode(entry, `${path}[${index}]`));
+    return;
+  }
+  if (value === null || typeof value !== 'object') return;
+  const entries = Object.entries(value);
+  if (entries.length === 0) {
+    throw new Error(`Eval sample JSON Schema contains an unconstrained node at ${path}`);
+  }
+  entries.forEach(([key, entry]) => assertNoEmptySchemaNode(entry, `${path}/${key}`));
+}
+
+export function generateEvalSampleSetJsonSchema(): Record<string, unknown> {
+  const generated = z.toJSONSchema(EvalSampleSetDocumentSchema, {
+    target: 'draft-2020-12',
+    unrepresentable: 'throw',
+    cycles: 'ref',
+    reused: 'ref',
+  });
+  const schema = { ...generated, $id: SCHEMA_URI };
+  assertNoEmptySchemaNode(schema);
+  return schema;
+}

--- a/src/inputs/schemas/mock.ts
+++ b/src/inputs/schemas/mock.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import type { Mock, MockMatch, MockReturn } from '../contracts/mock.js';
+
+const mockMatchBaseShape = {
+  file_path: z.string().min(1).optional(),
+  file_path_endswith: z.string().min(1).optional(),
+  command_glob: z.string().min(1).optional(),
+  input: z.record(z.string(), z.json()).optional(),
+  input_contains: z.string().min(1).optional(),
+};
+
+export const MockMatchSchema: z.ZodType<MockMatch> = z.union([
+  z.object({ ...mockMatchBaseShape, url: z.string().min(1) }).strict(),
+  z.object({ ...mockMatchBaseShape, url_glob: z.string().min(1) }).strict(),
+  z.object(mockMatchBaseShape).strict(),
+]);
+
+export const MockReturnSchema: z.ZodType<MockReturn> = z.union([
+  z.string(),
+  z.record(z.string(), z.json()),
+]);
+
+const mockBaseShape = {
+  tool: z.string().min(1),
+  match: MockMatchSchema.optional(),
+};
+
+/** Strict authoring shape with exactly one return source. */
+export const MockSchema: z.ZodType<Mock> = z.union([
+  z.object({ ...mockBaseShape, return: MockReturnSchema }).strict(),
+  z.object({ ...mockBaseShape, return_file: z.string().min(1) }).strict(),
+  z.object({ ...mockBaseShape, return_seq: z.array(MockReturnSchema).min(1) }).strict(),
+], { error: 'mock requires exactly one of return, return_file, or return_seq' });

--- a/src/inputs/schemas/sample-set.ts
+++ b/src/inputs/schemas/sample-set.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+import type {
+  EvalSampleSetDocument,
+  Sample,
+  SampleCoverageTarget,
+  SampleEnvironment,
+} from '../contracts/sample.js';
+import { AssertionSchema } from './assertion.js';
+import { MockSchema } from './mock.js';
+
+export const EVAL_SAMPLE_SET_SCHEMA_VERSION = 'omk.eval-sample-set/v1' as const;
+
+export const SampleCoverageTargetSchema: z.ZodType<SampleCoverageTarget> = z.object({
+  targetKind: z.enum([
+    'skill',
+    'skill_file',
+    'frontmatter',
+    'reference',
+    'script',
+    'hard_rule',
+    'workflow',
+    'workflow_node',
+  ]),
+  ref: z.string().min(1),
+}).strict();
+
+export const SampleEnvironmentSchema: z.ZodType<SampleEnvironment> = z.object({
+  cli_available: z.array(z.string().min(1)).optional(),
+  files_available: z.array(z.string().min(1)).optional(),
+  notes: z.string().optional(),
+}).strict();
+
+/** Strict, versioned authoring case shape. Cross-field measurement rules run after parsing. */
+export const SampleSchema: z.ZodType<Sample> = z.object({
+  sample_id: z.string().min(1),
+  prompt: z.string().min(1),
+  context: z.string().optional(),
+  cwd: z.string().min(1).optional(),
+  rubric: z.string().min(1).optional(),
+  assertions: z.array(AssertionSchema).optional(),
+  dimensions: z.record(z.string().min(1), z.string().min(1)).optional(),
+  allowedTools: z.array(z.string().min(1)).optional(),
+  capability: z.array(z.string().min(1)).optional(),
+  difficulty: z.enum(['easy', 'medium', 'hard']).optional(),
+  construct: z.string().min(1).optional(),
+  provenance: z.enum(['human', 'llm-generated', 'production-trace']).optional(),
+  covers: z.array(SampleCoverageTargetSchema).optional(),
+  tripwire: z.boolean().optional(),
+  mocks: z.array(MockSchema).min(1).optional(),
+  mocksStrict: z.boolean().optional(),
+  environment: SampleEnvironmentSchema.optional(),
+}).strict();
+
+export const DependencyRequirementsSchema = z.object({
+  tools: z.array(z.string().min(1)).optional(),
+  files: z.array(z.string().min(1)).optional(),
+  env: z.array(z.string().min(1)).optional(),
+  preflight: z.array(z.string().min(1)).optional(),
+}).strict();
+
+export const EvalSampleSetDocumentSchema: z.ZodType<EvalSampleSetDocument> = z.object({
+  schemaVersion: z.literal(EVAL_SAMPLE_SET_SCHEMA_VERSION),
+  requires: DependencyRequirementsSchema.optional(),
+  samples: z.array(SampleSchema).min(1),
+}).strict().meta({ title: 'OMK Eval Sample Set v1' });
+
+export function createEvalSampleSetDocument(
+  samples: Sample[],
+  requires?: EvalSampleSetDocument['requires'],
+): EvalSampleSetDocument {
+  return {
+    schemaVersion: EVAL_SAMPLE_SET_SCHEMA_VERSION,
+    ...(requires === undefined ? {} : { requires }),
+    samples,
+  };
+}

--- a/src/inputs/url-fetcher.ts
+++ b/src/inputs/url-fetcher.ts
@@ -50,7 +50,10 @@ function asNetworkError(err: unknown): NetworkErrorLike {
  */
 export async function resolveUrls(samples: Sample[], skipUrls?: Set<string>): Promise<void> {
   // 1. Collect all unique URLs across all samples, tracking which sample they belong to
-  const urlMap = new Map<string, Array<{ sample: Sample; field: string }>>(); // url -> [{sample, field}]
+  const urlMap = new Map<string, Array<{
+    sample: Sample;
+    field: 'prompt' | 'context';
+  }>>();
   for (const sample of samples) {
     for (const field of ['prompt', 'context'] as const) {
       const text = sample[field] as string | undefined;

--- a/src/package-api/eval-samples.ts
+++ b/src/package-api/eval-samples.ts
@@ -1,0 +1,37 @@
+export type {
+  Assertion,
+} from '../inputs/contracts/assertion.js';
+export type {
+  Mock,
+  MockMatch,
+  MockReturn,
+} from '../inputs/contracts/mock.js';
+export type {
+  EvalSampleSetDocument,
+  Sample,
+  SampleCoverageTarget,
+  SampleCoverageTargetKind,
+  SampleDifficulty,
+  SampleEnvironment,
+  SampleProvenance,
+} from '../inputs/contracts/sample.js';
+export {
+  EVAL_SAMPLE_SET_SCHEMA_VERSION,
+  createEvalSampleSetDocument,
+} from '../inputs/schemas/sample-set.js';
+
+export const EVAL_SAMPLE_JSON_SCHEMA_FILES = [
+  'eval-sample-set.schema.json',
+] as const;
+
+export type EvalSampleJsonSchemaFile = typeof EVAL_SAMPLE_JSON_SCHEMA_FILES[number];
+
+const schemaFiles = new Set<string>(EVAL_SAMPLE_JSON_SCHEMA_FILES);
+
+/** Resolves a shipped sample JSON Schema without relying on an unexported dist path. */
+export function resolveEvalSampleJsonSchema(fileName: EvalSampleJsonSchemaFile): URL {
+  if (!schemaFiles.has(fileName)) {
+    throw new TypeError(`Unknown Eval Sample JSON Schema: ${String(fileName)}`);
+  }
+  return new URL(`../inputs/contracts/schemas/v1/${fileName}`, import.meta.url);
+}

--- a/src/shared/assertion-types.ts
+++ b/src/shared/assertion-types.ts
@@ -1,3 +1,14 @@
+import type {
+  AsyncAssertionType,
+  SyncAssertionType,
+} from './contracts/assertion.js';
+
+export type {
+  AsyncAssertionType,
+  SupportedAssertionType,
+  SyncAssertionType,
+} from './contracts/assertion.js';
+
 export const SYNC_ASSERTION_TYPE_NAMES = [
   'contains',
   'not_contains',
@@ -30,7 +41,7 @@ export const SYNC_ASSERTION_TYPE_NAMES = [
   'levenshtein_max',
   'bleu_min',
   'assert-set',
-] as const;
+] as const satisfies readonly SyncAssertionType[];
 
 export const ASYNC_ASSERTION_TYPE_NAMES = [
   'semantic_similarity',
@@ -38,11 +49,7 @@ export const ASYNC_ASSERTION_TYPE_NAMES = [
   'faithfulness',
   'answer_relevancy',
   'context_recall',
-] as const;
-
-export type SyncAssertionType = typeof SYNC_ASSERTION_TYPE_NAMES[number];
-export type AsyncAssertionType = typeof ASYNC_ASSERTION_TYPE_NAMES[number];
-export type SupportedAssertionType = SyncAssertionType | AsyncAssertionType;
+] as const satisfies readonly AsyncAssertionType[];
 
 export const SYNC_ASSERTION_TYPES: ReadonlySet<string> = new Set(SYNC_ASSERTION_TYPE_NAMES);
 export const ASYNC_ASSERTION_TYPES: ReadonlySet<string> = new Set(ASYNC_ASSERTION_TYPE_NAMES);

--- a/src/shared/contracts/assertion.ts
+++ b/src/shared/contracts/assertion.ts
@@ -1,0 +1,41 @@
+export type SyncAssertionType =
+  | 'contains'
+  | 'not_contains'
+  | 'regex'
+  | 'min_length'
+  | 'max_length'
+  | 'json_valid'
+  | 'json_schema'
+  | 'starts_with'
+  | 'ends_with'
+  | 'equals'
+  | 'not_equals'
+  | 'word_count_min'
+  | 'word_count_max'
+  | 'contains_all'
+  | 'contains_any'
+  | 'cost_max'
+  | 'latency_max'
+  | 'turns_max'
+  | 'turns_min'
+  | 'tools_called'
+  | 'tools_not_called'
+  | 'tools_count_max'
+  | 'tools_count_min'
+  | 'tool_output_contains'
+  | 'tool_input_contains'
+  | 'tool_input_not_contains'
+  | 'mock_hit'
+  | 'rouge_n_min'
+  | 'levenshtein_max'
+  | 'bleu_min'
+  | 'assert-set';
+
+export type AsyncAssertionType =
+  | 'semantic_similarity'
+  | 'custom'
+  | 'faithfulness'
+  | 'answer_relevancy'
+  | 'context_recall';
+
+export type SupportedAssertionType = SyncAssertionType | AsyncAssertionType;

--- a/src/shared/sample-contract.ts
+++ b/src/shared/sample-contract.ts
@@ -217,11 +217,11 @@ function mockValidationError(value: unknown): string | undefined {
       || !value.return_seq.every(isMockReturn)
     )
   ) return '"return_seq" must be a non-empty array of mock returns';
-  if (
-    value.return === undefined
-    && value.return_file === undefined
-    && value.return_seq === undefined
-  ) return 'mock requires "return", "return_file", or "return_seq"';
+  const returnSources = [value.return, value.return_file, value.return_seq]
+    .filter((candidate) => candidate !== undefined).length;
+  if (returnSources !== 1) {
+    return 'mock requires exactly one of "return", "return_file", or "return_seq"';
+  }
   if (value.match === undefined) return undefined;
   if (!isRecord(value.match)) return '"match" must be an object when present';
   const matchFields = [
@@ -234,6 +234,9 @@ function mockValidationError(value: unknown): string | undefined {
   ] as const;
   if (!hasOnlyKeys(value.match, [...matchFields, 'input'])) {
     return '"match" contains an unsupported field';
+  }
+  if (value.match.url !== undefined && value.match.url_glob !== undefined) {
+    return '"match.url" and "match.url_glob" are mutually exclusive';
   }
   for (const field of matchFields) {
     if (value.match[field] !== undefined && !isNonEmptyString(value.match[field])) {
@@ -277,19 +280,6 @@ function mockHitReferenceValidationError(
     }
     const childError = mockHitReferenceValidationError(assertion.children, mockKeys);
     if (childError) return childError;
-  }
-  return undefined;
-}
-
-export function dependencyRequirementsValidationError(value: unknown): string | undefined {
-  if (!isRecord(value)) return '"requires" must be an object';
-  if (!hasOnlyKeys(value, ['tools', 'files', 'env', 'preflight'])) {
-    return '"requires" contains an unsupported field';
-  }
-  for (const field of ['tools', 'files', 'env', 'preflight'] as const) {
-    if (value[field] !== undefined && !isStringArray(value[field])) {
-      return `"requires.${field}" must be an array of non-empty strings`;
-    }
   }
   return undefined;
 }
@@ -349,7 +339,10 @@ export function sampleContractValidationError(
   if (value.mocksStrict !== undefined && typeof value.mocksStrict !== 'boolean') {
     return '"mocksStrict" must be boolean when present';
   }
-  for (const field of ['allowedTools', 'expectedTools', 'capability'] as const) {
+  if (value.mocksStrict !== undefined && !Array.isArray(value.mocks)) {
+    return '"mocksStrict" requires a non-empty "mocks" array';
+  }
+  for (const field of ['allowedTools', 'capability'] as const) {
     if (value[field] !== undefined && !isStringArray(value[field])) {
       return `"${field}" must be an array of non-empty strings`;
     }

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -22,6 +22,7 @@ const PURE_DOMAIN_TYPE_FILES = [
   'src/grading/contracts/config.ts',
   'src/grading/contracts/result.ts',
   'src/shared/language.ts',
+  'src/shared/contracts/assertion.ts',
   'src/shared/contracts/trace-source.ts',
   'src/studio/view-models/index.ts',
   'src/studio/view-models/insight.ts',

--- a/test/cli/doctor-eval-embed.test.ts
+++ b/test/cli/doctor-eval-embed.test.ts
@@ -32,6 +32,7 @@ function setupBrokenSkillDir(): string {
   writeFileSync(join(skillDir, 'v2.md'), 'hi'); // need at least 2 variants for control/treatment
   // 写 minimal samples
   writeFileSync(join(tmp, 'eval-samples.json'), JSON.stringify({
+    schemaVersion: 'omk.eval-sample-set/v1',
     samples: [{
       sample_id: 's1',
       prompt: 'test prompt',
@@ -50,6 +51,7 @@ function setupBatchMixedSkillDir(): string {
   // broken: 内容过短, doctor skill_readable 必 fail
   writeFileSync(join(skillDir, 'broken.md'), 'hi');
   writeFileSync(join(skillDir, 'broken.eval-samples.json'), JSON.stringify({
+    schemaVersion: 'omk.eval-sample-set/v1',
     samples: [{
       sample_id: 'b1',
       prompt: 'test prompt for broken',
@@ -59,6 +61,7 @@ function setupBatchMixedSkillDir(): string {
   // healthy: batch 至少有一个 entry; 单独跑会 pass
   writeFileSync(join(skillDir, 'healthy.md'), '你是一个版本健康的 skill, 内容足够长以通过 skill_readable rule。');
   writeFileSync(join(skillDir, 'healthy.eval-samples.json'), JSON.stringify({
+    schemaVersion: 'omk.eval-sample-set/v1',
     samples: [{
       sample_id: 'h1',
       prompt: 'test prompt for healthy',
@@ -214,6 +217,7 @@ describe('omk eval doctor preflight embedding', () => {
       writeFileSync(join(skillDir, 'v2.md'), '你是一个版本 2 的代码审查助手,加了安全检查。');
       writeFileSync(join(skillDir, 'draft.md'), 'hi');  // < 10 字符,本来会 fail
       writeFileSync(join(tmp, 'eval-samples.json'), JSON.stringify({
+        schemaVersion: 'omk.eval-sample-set/v1',
         samples: [{
           sample_id: 's1',
           prompt: 'review',

--- a/test/cli/sample-append.test.ts
+++ b/test/cli/sample-append.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import yaml from 'js-yaml';
 import { mergeAppendSamples, appendSamplesToFile, pickAppendTargetFile } from '../../src/cli/commands/sample.js';
 import type { Sample } from '../../src/inputs/contracts/sample.js';
+import { createEvalSampleSetDocument } from '../../src/inputs/schemas/sample-set.js';
 
 const s = (id: string, prompt = 'p'): Sample => ({ sample_id: id, prompt }) as Sample;
 const ids = (arr: Sample[]): string[] => arr.map((x) => x.sample_id);
@@ -55,33 +56,38 @@ describe('appendSamplesToFile (读+合并+格式保留写回)', () => {
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'omk-append-')); });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
-  it('纯数组 json:追加并撞 id 去重,仍是数组', () => {
+  it('版本化 JSON：追加并撞 id 去重，保留协议包装', () => {
     const f = join(dir, 'eval-samples.json');
-    writeFileSync(f, JSON.stringify([s('s001'), s('s002')], null, 2));
+    writeFileSync(f, JSON.stringify(createEvalSampleSetDocument([s('s001'), s('s002')]), null, 2));
     const total = appendSamplesToFile(f, [s('s001'), s('s003')]);
     assert.equal(total, 4);
     const parsed = JSON.parse(readFileSync(f, 'utf-8'));
-    assert.ok(Array.isArray(parsed));
-    assert.deepEqual(parsed.map((x: Sample) => x.sample_id), ['s001', 's002', 's001-2', 's003']);
+    assert.equal(parsed.schemaVersion, 'omk.eval-sample-set/v1');
+    assert.deepEqual(parsed.samples.map((x: Sample) => x.sample_id), ['s001', 's002', 's001-2', 's003']);
   });
 
-  it('wrapper object:保留 samples 外的其它顶层字段', () => {
+  it('版本化 JSON：保留 requires', () => {
     const f = join(dir, 'eval-samples.json');
-    writeFileSync(f, JSON.stringify({ version: 2, note: 'keep me', samples: [s('s001')] }, null, 2));
+    writeFileSync(f, JSON.stringify(createEvalSampleSetDocument(
+      [s('s001')],
+      { tools: ['git'] },
+    ), null, 2));
     appendSamplesToFile(f, [s('s002')]);
     const parsed = JSON.parse(readFileSync(f, 'utf-8'));
-    assert.equal(parsed.version, 2);
-    assert.equal(parsed.note, 'keep me');
+    assert.deepEqual(parsed.requires, { tools: ['git'] });
     assert.deepEqual(parsed.samples.map((x: Sample) => x.sample_id), ['s001', 's002']);
   });
 
-  it('yaml 文件:round-trip 保留 yaml 格式', () => {
+  it('YAML 文件：round-trip 保留 YAML 与版本化包装', () => {
     const f = join(dir, 'eval-samples.yaml');
-    writeFileSync(f, yaml.dump([s('s001')]));
+    writeFileSync(f, yaml.dump(createEvalSampleSetDocument([s('s001')])));
     appendSamplesToFile(f, [s('s002')]);
-    const parsed = yaml.load(readFileSync(f, 'utf-8')) as Sample[];
-    assert.ok(Array.isArray(parsed));
-    assert.deepEqual(parsed.map((x) => x.sample_id), ['s001', 's002']);
+    const parsed = yaml.load(readFileSync(f, 'utf-8')) as {
+      schemaVersion: string;
+      samples: Sample[];
+    };
+    assert.equal(parsed.schemaVersion, 'omk.eval-sample-set/v1');
+    assert.deepEqual(parsed.samples.map((x) => x.sample_id), ['s001', 's002']);
   });
 });
 

--- a/test/dsh-plugin/host-executor.test.ts
+++ b/test/dsh-plugin/host-executor.test.ts
@@ -19,6 +19,7 @@ import {
   managedRecordId,
   upsertManagedRecord,
 } from '../../src/managed/index.js';
+import { createEvalSampleSetDocument } from '../../src/inputs/schemas/sample-set.js';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -402,11 +403,11 @@ describe('DSH plugin config boundary', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-dsh-config-'));
     try {
       writeFileSync(join(dir, 'eval.yaml'), yaml);
-      writeFileSync(join(dir, 'samples.json'), JSON.stringify([{
+      writeFileSync(join(dir, 'samples.json'), JSON.stringify(createEvalSampleSetDocument([{
         sample_id: 's1',
         prompt: 'test',
         assertions: [{ type: 'contains', value: 'host' }],
-      }]));
+      }])));
       mkdirSync(join(dir, 'skills'));
       const skillPath = join(dir, 'skills', 'review.md');
       writeFileSync(skillPath, '# Review\nReturn a host-backed answer.\n');

--- a/test/eval-workflows/production-host/node-cli-evaluation-resolver.test.ts
+++ b/test/eval-workflows/production-host/node-cli-evaluation-resolver.test.ts
@@ -7,8 +7,17 @@ import {
   parseCliEvaluationRequest,
 } from '../../../src/eval-workflows/input-compilation/index.js';
 import { resolveNodeCliEvaluationRequest } from '../../../src/eval-workflows/production-host/index.js';
+import {
+  createEvalSampleSetDocument,
+} from '../../../src/inputs/schemas/sample-set.js';
+import type { Sample } from '../../../src/inputs/contracts/sample.js';
 
 const roots: string[] = [];
+
+const sampleSetJson = (
+  samples: Sample[],
+  requires?: Parameters<typeof createEvalSampleSetDocument>[1],
+): string => JSON.stringify(createEvalSampleSetDocument(samples, requires));
 
 afterEach(async () => {
   vi.unstubAllEnvs();
@@ -23,7 +32,7 @@ async function fixture(label: string): Promise<string> {
   await writeFile(join(root, 'skills', 'control.md'), '# Control\nAnswer directly.\n');
   await writeFile(join(root, 'skills', 'treatment.md'), '# Treatment\nUse the supplied knowledge.\n');
   await writeFile(join(root, 'fixtures', 'secret.json'), JSON.stringify({ token: 'secret-value' }));
-  await writeFile(join(root, 'samples.json'), JSON.stringify([{
+  await writeFile(join(root, 'samples.json'), sampleSetJson([{
     sample_id: 'sample-a',
     prompt: 'Return a concise JSON answer.',
     rubric: 'The response is correct and concise.',
@@ -107,7 +116,7 @@ describe('resolveNodeCliEvaluationRequest', () => {
 
   it('materializes inline mock payloads in a private resolver-owned store', async () => {
     const root = await fixture('private-materialization');
-    await writeFile(join(root, 'samples.json'), JSON.stringify([{
+    await writeFile(join(root, 'samples.json'), sampleSetJson([{
       sample_id: 'sample-a',
       prompt: 'A',
       rubric: 'Correct.',
@@ -124,6 +133,36 @@ describe('resolveNodeCliEvaluationRequest', () => {
     expect(payload).toBeDefined();
     expect((await stat(payload!.locator)).mode & 0o777).toBe(0o600);
     expect((await stat(join(root, '.omk', 'resolved', 'content'))).mode & 0o777).toBe(0o700);
+  });
+
+  it('fails closed for unmatched mocked tools unless the sample explicitly opts out', async () => {
+    const root = await fixture('mock-strict-default');
+    await writeFile(join(root, 'samples.json'), sampleSetJson([{
+      sample_id: 'sample-default',
+      prompt: 'A',
+      rubric: 'Correct.',
+      mocks: [{ tool: 'Read', return: 'default' }],
+    }, {
+      sample_id: 'sample-opt-out',
+      prompt: 'B',
+      rubric: 'Correct.',
+      mocks: [{ tool: 'Read', return: 'opt-out' }],
+      mocksStrict: false,
+    }]));
+
+    const resolved = await resolveNodeCliEvaluationRequest(request(root), {
+      projectRoot: root,
+      materializationRoot: join(root, '.omk', 'resolved'),
+    });
+    const bindings = resolved.targets[0]?.behavior.mocks;
+
+    expect(bindings?.map((binding) => ({
+      sampleIds: binding.sampleIds,
+      strict: binding.strict,
+    }))).toEqual([
+      { sampleIds: ['sample-default'], strict: true },
+      { sampleIds: ['sample-opt-out'], strict: false },
+    ]);
   });
 
   it('binds a custom Runtime implementation into every sealed executor lease', async () => {
@@ -259,7 +298,7 @@ describe('resolveNodeCliEvaluationRequest', () => {
     await mkdir(join(root, 'workspace-b'));
     await writeFile(join(root, 'workspace-a', 'identity.txt'), 'workspace-a');
     await writeFile(join(root, 'workspace-b', 'identity.txt'), 'workspace-b');
-    await writeFile(join(root, 'samples.json'), JSON.stringify([{
+    await writeFile(join(root, 'samples.json'), sampleSetJson([{
       sample_id: 'sample-a', prompt: 'A', rubric: 'Correct.',
       cwd: 'workspace-a', allowedTools: ['Read'],
     }, {
@@ -336,7 +375,7 @@ describe('resolveNodeCliEvaluationRequest', () => {
 
   it('groups record-scoped evaluators across multiple samples without missing bindings', async () => {
     const root = await fixture('multi-sample');
-    await writeFile(join(root, 'samples.json'), JSON.stringify([
+    await writeFile(join(root, 'samples.json'), sampleSetJson([
       {
         sample_id: 'sample-a', prompt: 'A', rubric: 'Correct.',
         assertions: [
@@ -372,7 +411,7 @@ describe('resolveNodeCliEvaluationRequest', () => {
 
   it('seals partial LLM and rubric applicability instead of scoring unintended samples', async () => {
     const root = await fixture('partial-applicability');
-    await writeFile(join(root, 'samples.json'), JSON.stringify([
+    await writeFile(join(root, 'samples.json'), sampleSetJson([
       {
         sample_id: 'sample-a', prompt: 'A', dimensions: { accuracy: 'Correct.' },
         assertions: [{ type: 'semantic_similarity', reference: 'A' }],
@@ -411,7 +450,7 @@ describe('resolveNodeCliEvaluationRequest', () => {
 
   it('keeps production sample validation strict despite the legacy ambient escape hatch', async () => {
     const root = await fixture('strict-loader');
-    await writeFile(join(root, 'samples.json'), JSON.stringify([{
+    await writeFile(join(root, 'samples.json'), sampleSetJson([{
       sample_id: 'sample-a', prompt: 'A', rubric: 'Correct.',
       assertions: [{ type: 'contains', value: 'X' }],
     }]));
@@ -425,15 +464,15 @@ describe('resolveNodeCliEvaluationRequest', () => {
 
   it('preserves normalized sample dependency requirements for host preflight', async () => {
     const root = await fixture('dependencies');
-    await writeFile(join(root, 'samples.json'), JSON.stringify({
-      requires: {
+    await writeFile(join(root, 'samples.json'), sampleSetJson(
+      [{ sample_id: 'sample-a', prompt: 'A', rubric: 'Correct.' }],
+      {
         tools: ['git', 'node'],
         files: ['./fixtures/input.json'],
         env: ['TOKEN'],
         preflight: ['node --version'],
       },
-      samples: [{ sample_id: 'sample-a', prompt: 'A', rubric: 'Correct.' }],
-    }));
+    ));
 
     const compiled = compileCliEvaluationInput(await resolveNodeCliEvaluationRequest(
       request(root),

--- a/test/evaluation-core/embedded-package.test.ts
+++ b/test/evaluation-core/embedded-package.test.ts
@@ -62,6 +62,10 @@ describe('published embedded Evaluation Core API', () => {
       packageDirectory,
       'dist/evaluation-core/contracts/schemas/v1/execution-bundle.schema.json',
     ), 'utf8')).title).toBe('OMK Execution Bundle v1');
+    expect(JSON.parse(readFileSync(join(
+      packageDirectory,
+      'dist/inputs/contracts/schemas/v1/eval-sample-set.schema.json',
+    ), 'utf8')).title).toBe('OMK Eval Sample Set v1');
     writeFileSync(join(projectRoot, 'package.json'), JSON.stringify({
       name: 'independent-omk-host',
       private: true,
@@ -85,6 +89,7 @@ const assert = require('node:assert/strict');
 (async () => {
   const api = await import('oh-my-knowledge');
   const advanced = await import('oh-my-knowledge/evaluation-core');
+  const evalSamples = await import('oh-my-knowledge/eval-samples');
   const projections = await import('oh-my-knowledge/projections');
   const studio = await import('oh-my-knowledge/studio');
   assert.equal(typeof api.createEvaluationEngine, 'function');
@@ -93,6 +98,8 @@ const assert = require('node:assert/strict');
   assert.equal(api.projectCoreArtifactGraph, undefined);
   assert.equal(api.assessComparability, undefined);
   assert.equal(typeof advanced.assessComparability, 'function');
+  assert.equal(evalSamples.EVAL_SAMPLE_SET_SCHEMA_VERSION, 'omk.eval-sample-set/v1');
+  assert.equal(typeof evalSamples.resolveEvalSampleJsonSchema, 'function');
   assert.equal(typeof projections.projectCoreArtifactGraph, 'function');
   assert.equal(typeof studio.createCoreStudioCatalog, 'function');
   const schema = await import(
@@ -100,6 +107,11 @@ const assert = require('node:assert/strict');
     { with: { type: 'json' } }
   );
   assert.equal(schema.default.title, 'OMK Execution Bundle v1');
+  const sampleSchema = await import(
+    'oh-my-knowledge/eval-samples/schemas/v1/eval-sample-set.schema.json',
+    { with: { type: 'json' } }
+  );
+  assert.equal(sampleSchema.default.title, 'OMK Eval Sample Set v1');
   try {
     require('oh-my-knowledge');
     throw new Error('require() unexpectedly loaded the ESM-only package root');
@@ -175,6 +187,8 @@ const assert = require('node:assert/strict');
     expect(Object.keys(packageJson.exports).sort()).toEqual([
       '.',
       './dsh-plugin',
+      './eval-samples',
+      './eval-samples/schemas/v1/*',
       './evaluation-core',
       './evaluation-core/schemas/v1/*',
       './mcp',

--- a/test/evaluation-core/fixtures/embedded-host.ts.fixture
+++ b/test/evaluation-core/fixtures/embedded-host.ts.fixture
@@ -15,6 +15,11 @@ import {
   resolveEvaluationCoreJsonSchema,
   type ExecutionBundleSource,
 } from 'oh-my-knowledge/evaluation-core';
+import {
+  createEvalSampleSetDocument,
+  resolveEvalSampleJsonSchema,
+  type EvalSampleSetDocument,
+} from 'oh-my-knowledge/eval-samples';
 
 declare const runtime: EvaluationEngineRuntime;
 declare const definition: EvaluationDefinition;
@@ -25,6 +30,14 @@ declare const executionFacts: ExecutionFacts;
 
 const executionFactsVersion: typeof EXECUTION_FACTS_SCHEMA_VERSION = executionFacts.schemaVersion;
 void executionFactsVersion;
+
+const sampleSet: EvalSampleSetDocument = createEvalSampleSetDocument([{
+  sample_id: 'typescript-host',
+  prompt: 'Verify the package contract.',
+}]);
+const sampleSchema: URL = resolveEvalSampleJsonSchema('eval-sample-set.schema.json');
+void sampleSet;
+void sampleSchema;
 
 const engine = createEvaluationEngine({
   ...runtime,

--- a/test/executors/mock-runtime/runtime.test.ts
+++ b/test/executors/mock-runtime/runtime.test.ts
@@ -205,9 +205,9 @@ describe('resolveMockReturn', () => {
     assert.equal(resolveMockReturn(m, 2), 'third');
   });
 
-  it('return_seq fallback to return when hitCount overflows', () => {
-    const m: Mock = { tool: 'Bash', return_seq: ['a'], return: 'fallback' };
-    assert.equal(resolveMockReturn(m, 5), 'fallback');
+  it('return_seq saturates at the last state when hitCount overflows', () => {
+    const m: Mock = { tool: 'Bash', return_seq: ['pending', 'success'] };
+    assert.equal(resolveMockReturn(m, 5), 'success');
   });
 
   it('return_file reads from baseDir', () => {
@@ -275,10 +275,12 @@ describe('buildSdkHookCallback', () => {
     const r1 = (await call('echo a')) as { hookSpecificOutput?: { permissionDecisionReason?: string } };
     const r2 = (await call('echo b')) as { hookSpecificOutput?: { permissionDecisionReason?: string } };
     const r3 = (await call('echo c')) as { hookSpecificOutput?: { permissionDecisionReason?: string } };
+    const r4 = (await call('echo d')) as { hookSpecificOutput?: { permissionDecisionReason?: string } };
     // wrap 后只验证内容包含原始字符串,前后带说明文字。
     assert.match(r1.hookSpecificOutput?.permissionDecisionReason || '', /one/);
     assert.match(r2.hookSpecificOutput?.permissionDecisionReason || '', /two/);
     assert.match(r3.hookSpecificOutput?.permissionDecisionReason || '', /three/);
+    assert.match(r4.hookSpecificOutput?.permissionDecisionReason || '', /three/);
   });
 });
 

--- a/test/fixtures/agent-eval/control-experiments/artifact-injection.eval-samples.json
+++ b/test/fixtures/agent-eval/control-experiments/artifact-injection.eval-samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "artifact-001",
     "prompt": "先确定当前工作目录，再读取当前工作目录下的 ./skills/runtime-context-check.md，返回第一行里的随机 runtime token 和文件总行数。不要搜索整个仓库，不要解释。",
@@ -87,4 +89,5 @@
       "discipline": "是否遵守 artifact 规定的受控输出格式"
     }
   }
-]
+  ]
+}

--- a/test/fixtures/agent-eval/control-experiments/assertion-discrimination.eval-samples.json
+++ b/test/fixtures/agent-eval/control-experiments/assertion-discrimination.eval-samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "assertion-001",
     "prompt": "只允许读取当前工作目录下的 ./skills/runtime-context-check.md。不要搜索整个仓库，不要使用 Glob。如果文件存在，输出 `RUNTIME:<第一行>`；如果不存在，输出 `NO_FILE_IN_CWD`。第一行是随机 runtime token，必须原样返回。",
@@ -66,4 +68,5 @@
       "efficiency": "是否避免无关搜索与提问"
     }
   }
-]
+  ]
+}

--- a/test/fixtures/agent-eval/control-experiments/env-isolation.eval-samples.json
+++ b/test/fixtures/agent-eval/control-experiments/env-isolation.eval-samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "env-001",
     "prompt": "只允许读取当前工作目录下的 ./skills/runtime-context-check.md 第一行，并原样输出第一行里的 runtime token。不要搜索整个仓库，不要使用 Glob。如果文件不存在，直接输出 NO_FILE_IN_CWD。",
@@ -56,4 +58,5 @@
       "runtime_context_sensitivity": "切换 cwd 后是否输出不同 runtime marker"
     }
   }
-]
+  ]
+}

--- a/test/fixtures/code-review/eval-samples.json
+++ b/test/fixtures/code-review/eval-samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "code-review-sql-injection",
     "prompt": "请审查以下登录代码，指出主要风险并给出修复建议。",
@@ -104,4 +106,5 @@
     "construct": "日志中的敏感信息泄露审查",
     "provenance": "human"
   }
-]
+  ]
+}

--- a/test/fixtures/custom-executor/eval-samples.json
+++ b/test/fixtures/custom-executor/eval-samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "s001",
     "prompt": "What is two plus two?",
@@ -13,4 +15,5 @@
       { "type": "contains", "value": "hello", "weight": 1 }
     ]
   }
-]
+  ]
+}

--- a/test/fixtures/multi-skills/skills/classifier/.omk/samples.json
+++ b/test/fixtures/multi-skills/skills/classifier/.omk/samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "cls001",
     "prompt": "请分类以下文本",
@@ -19,4 +21,5 @@
       { "type": "regex", "pattern": "central bank|monetary policy", "flags": "i", "weight": 0.5 }
     ]
   }
-]
+  ]
+}

--- a/test/fixtures/multi-skills/skills/summarizer.eval-samples.json
+++ b/test/fixtures/multi-skills/skills/summarizer.eval-samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "sum001",
     "prompt": "请摘要以下内容",
@@ -10,4 +12,5 @@
       { "type": "regex", "pattern": "95%|60%", "weight": 0.5 }
     ]
   }
-]
+  ]
+}

--- a/test/fixtures/multi-skills/skills/translator.eval-samples.json
+++ b/test/fixtures/multi-skills/skills/translator.eval-samples.json
@@ -1,4 +1,6 @@
-[
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
   {
     "sample_id": "tr001",
     "prompt": "请将以下中文翻译为英文",
@@ -9,4 +11,5 @@
       { "type": "not_contains", "value": "untranslated", "weight": 0.5 }
     ]
   }
-]
+  ]
+}

--- a/test/inputs/eval-sample-schema.test.ts
+++ b/test/inputs/eval-sample-schema.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import _Ajv2020 from 'ajv/dist/2020.js';
+import { describe, expect, it } from 'vitest';
+import { generateEvalSampleSetJsonSchema } from '../../src/inputs/schemas/json-schema.js';
+import {
+  createEvalSampleSetDocument,
+  EvalSampleSetDocumentSchema,
+} from '../../src/inputs/schemas/sample-set.js';
+
+const Ajv2020 = _Ajv2020 as unknown as typeof _Ajv2020.default;
+
+describe('Eval Sample Set v1 JSON Schema', () => {
+  it('matches the committed deterministic JSON Schema 2020-12 artifact', () => {
+    const generated = generateEvalSampleSetJsonSchema();
+    const committed = JSON.parse(readFileSync(resolve(
+      'schemas/eval-samples/v1/eval-sample-set.schema.json',
+    ), 'utf8'));
+
+    expect(generated).toMatchObject({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $id: expect.stringContaining('/schemas/eval-samples/v1/eval-sample-set.schema.json'),
+    });
+    expect(committed).toEqual(generated);
+    expect(JSON.stringify(generated)).not.toContain(':{}');
+  });
+
+  it('compiles and agrees with the runtime schema on strict structural cases', () => {
+    const validate = new Ajv2020({ strict: false }).compile(
+      generateEvalSampleSetJsonSchema() as object,
+    );
+    const valid = createEvalSampleSetDocument([{
+      sample_id: 's1',
+      prompt: 'Review this change.',
+      assertions: [{ type: 'contains', value: 'token' }],
+      mocks: [{ tool: 'Read', return: 'fixture' }],
+    }]);
+    const invalidCases = [
+      [{ sample_id: 's1', prompt: 'legacy array' }],
+      { samples: [{ sample_id: 's1', prompt: 'missing version' }] },
+      { ...valid, typo: true },
+      { ...valid, samples: [{ ...valid.samples[0], mockStrict: true }] },
+      {
+        ...valid,
+        samples: [{
+          sample_id: 's1',
+          prompt: 'ambiguous return source',
+          mocks: [{ tool: 'Read', return: 'inline', return_file: 'fixture.txt' }],
+        }],
+      },
+      {
+        ...valid,
+        samples: [{
+          sample_id: 's1',
+          prompt: 'ambiguous URL matcher',
+          mocks: [{
+            tool: 'WebFetch',
+            match: { url: 'https://example.com', url_glob: 'https://example.com/*' },
+            return: 'fixture',
+          }],
+        }],
+      },
+    ];
+
+    expect(validate(valid)).toBe(true);
+    expect(EvalSampleSetDocumentSchema.safeParse(valid).success).toBe(true);
+    for (const invalid of invalidCases) {
+      expect(validate(invalid)).toBe(false);
+      expect(EvalSampleSetDocumentSchema.safeParse(invalid).success).toBe(false);
+    }
+  });
+});

--- a/test/inputs/load-samples.test.ts
+++ b/test/inputs/load-samples.test.ts
@@ -4,6 +4,11 @@ import { writeFileSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { loadSamples } from '../../src/inputs/load-samples.js';
+import type { Sample } from '../../src/inputs/contracts/sample.js';
+import {
+  EVAL_SAMPLE_SET_SCHEMA_VERSION,
+  createEvalSampleSetDocument,
+} from '../../src/inputs/schemas/sample-set.js';
 
 const tmp = (name: string) => join(tmpdir(), `omk-test-${Date.now()}-${name}`);
 
@@ -16,8 +21,8 @@ describe('loadSamples', () => {
     const file = writeSampleFile(
       `duplicate.${format}`,
       format === 'json'
-        ? JSON.stringify(samples)
-        : '- sample_id: shared\n  prompt: first\n- sample_id: shared\n  prompt: second\n',
+        ? JSON.stringify(createEvalSampleSetDocument(samples))
+        : `schemaVersion: ${EVAL_SAMPLE_SET_SCHEMA_VERSION}\nsamples:\n  - sample_id: shared\n    prompt: first\n  - sample_id: shared\n    prompt: second\n`,
     );
     assert.throws(
       () => loadSamples(file),
@@ -35,8 +40,17 @@ describe('loadSamples', () => {
   }
 
   function writeJsonSamples(name: string, value: unknown): string {
-    return writeSampleFile(name, JSON.stringify(value));
+    const document = Array.isArray(value)
+      ? createEvalSampleSetDocument(value as Sample[])
+      : typeof value === 'object' && value !== null && 'samples' in value
+        ? { schemaVersion: EVAL_SAMPLE_SET_SCHEMA_VERSION, ...value }
+        : value;
+    return writeSampleFile(name, JSON.stringify(document));
   }
+
+  const jsonSet = (samples: Sample[], requires?: Record<string, string[]>): string => (
+    JSON.stringify(createEvalSampleSetDocument(samples, requires))
+  );
 
   afterEach(() => {
     for (const f of cleanups) {
@@ -57,19 +71,63 @@ describe('loadSamples', () => {
   });
 
   it('加载 YAML 用例文件', () => {
-    const p = writeSampleFile('samples.yaml', `- sample_id: y1\n  prompt: hello\n- sample_id: y2\n  prompt: world\n`);
+    const p = writeSampleFile(
+      'samples.yaml',
+      `schemaVersion: ${EVAL_SAMPLE_SET_SCHEMA_VERSION}\nsamples:\n  - sample_id: y1\n    prompt: hello\n  - sample_id: y2\n    prompt: world\n`,
+    );
     const { samples } = loadSamples(p);
     assert.equal(samples.length, 2);
     assert.equal(samples[0].sample_id, 'y1');
     assert.equal(samples[1].prompt, 'world');
   });
 
+  it('拒绝未版本化的历史数组格式', () => {
+    const p = writeSampleFile('legacy-array.json', JSON.stringify([
+      { sample_id: 's1', prompt: 'hello' },
+    ]));
+    assert.throws(() => loadSamples(p), /invalid samples file.*expected object.*array/);
+  });
+
+  it('拒绝缺失或错误的 schemaVersion', () => {
+    const missing = writeSampleFile('missing-version.json', JSON.stringify({
+      samples: [{ sample_id: 's1', prompt: 'hello' }],
+    }));
+    const wrong = writeSampleFile('wrong-version.json', JSON.stringify({
+      schemaVersion: 'omk.eval-sample-set/v2',
+      samples: [{ sample_id: 's1', prompt: 'hello' }],
+    }));
+    assert.throws(() => loadSamples(missing), /schemaVersion.*expected.*omk\.eval-sample-set\/v1/);
+    assert.throws(() => loadSamples(wrong), /schemaVersion.*expected.*omk\.eval-sample-set\/v1/);
+  });
+
+  it('拒绝根、sample 与 assertion 上的未知字段', () => {
+    const root = writeSampleFile('unknown-root.json', JSON.stringify({
+      ...createEvalSampleSetDocument([{ sample_id: 's1', prompt: 'hello' }]),
+      typo: true,
+    }));
+    const sample = writeSampleFile('unknown-sample.json', JSON.stringify({
+      schemaVersion: EVAL_SAMPLE_SET_SCHEMA_VERSION,
+      samples: [{ sample_id: 's1', prompt: 'hello', mockStrict: true }],
+    }));
+    const assertion = writeSampleFile('unknown-assertion.json', JSON.stringify({
+      schemaVersion: EVAL_SAMPLE_SET_SCHEMA_VERSION,
+      samples: [{
+        sample_id: 's1',
+        prompt: 'hello',
+        assertions: [{ type: 'contains', value: 'token', typo: true }],
+      }],
+    }));
+    assert.throws(() => loadSamples(root), /Unrecognized key.*typo/);
+    assert.throws(() => loadSamples(sample), /samples\.0.*Unrecognized key.*mockStrict/);
+    assert.throws(() => loadSamples(assertion), /samples\.0\.assertions\.0.*Unrecognized key.*typo/);
+  });
+
   const invalidShapeCases = [
     { name: 'empty array', file: 'empty.json', value: [], error: /invalid samples file/ },
     { name: 'non-array content', file: 'invalid.json', value: 'not an array', error: /invalid samples file/ },
-    { name: 'missing sample_id', file: 'no-id.json', value: [{ prompt: 'hello' }], error: /required field: sample_id/ },
-    { name: 'missing prompt', file: 'no-prompt.json', value: [{ sample_id: 'x' }], error: /required field: prompt/ },
-    { name: 'non-string prompt', file: 'bad-prompt-type.json', value: [{ sample_id: 'x', prompt: 123 }], error: /invalid required field: prompt/ },
+    { name: 'missing sample_id', file: 'no-id.json', value: [{ prompt: 'hello' }], error: /samples\.0\.sample_id.*expected string/ },
+    { name: 'missing prompt', file: 'no-prompt.json', value: [{ sample_id: 'x' }], error: /samples\.0\.prompt.*expected string/ },
+    { name: 'non-string prompt', file: 'bad-prompt-type.json', value: [{ sample_id: 'x', prompt: 123 }], error: /samples\.0\.prompt.*expected string.*number/ },
   ];
 
   it.each(invalidShapeCases)('rejects invalid sample file shape: $name', ({ file, value, error }) => {
@@ -82,12 +140,12 @@ describe('loadSamples', () => {
       {
         name: 'dimensions must contain non-empty rubric text',
         sample: { dimensions: { quality: '' } },
-        error: /dimensions.*non-empty string rubrics/,
+        error: /samples\.0\.dimensions\.quality.*expected string.*>=1/,
       },
       {
         name: 'unknown assertion type',
         sample: { assertions: [{ type: 'containz', value: 'token' }] },
-        error: /unsupported assertion type.*containz/,
+        error: /samples\.0\.assertions\.0\.type.*Invalid option/,
       },
       {
         name: 'zero-weight assertion',
@@ -118,12 +176,28 @@ describe('loadSamples', () => {
             return: 'ok',
           }],
         },
-        error: /match.*unsupported field/,
+        error: /samples\.0\.mocks\.0\.match.*Unrecognized key.*command_globb/,
       },
       {
         name: 'mock must define a return',
         sample: { mocks: [{ tool: 'Bash' }] },
         error: /mock requires.*return/,
+      },
+      {
+        name: 'mock return sources are mutually exclusive',
+        sample: { mocks: [{ tool: 'Bash', return: 'ok', return_file: 'ok.txt' }] },
+        error: /exactly one of .*return.*return_file.*return_seq/,
+      },
+      {
+        name: 'mock URL match forms are mutually exclusive',
+        sample: {
+          mocks: [{
+            tool: 'WebFetch',
+            match: { url: 'https://example.com', url_glob: 'https://example.com/*' },
+            return: 'ok',
+          }],
+        },
+        error: /samples\.0\.mocks\.0\.match.*Unrecognized key.*url|url_glob/,
       },
       {
         name: 'mock_hit must reference an existing mock',
@@ -152,12 +226,12 @@ describe('loadSamples', () => {
       {
         name: 'environment rejects unknown fields',
         sample: { environment: { cli_available: ['git'], typo: true } },
-        error: /environment.*invalid shape/,
+        error: /samples\.0\.environment.*Unrecognized key.*typo/,
       },
       {
         name: 'allowedTools must be a string array',
         sample: { allowedTools: ['Read', 1] },
-        error: /allowedTools.*array of non-empty strings/,
+        error: /samples\.0\.allowedTools\.1.*expected string.*number/,
       },
       {
         name: 'mocksStrict must be boolean',
@@ -176,9 +250,9 @@ describe('loadSamples', () => {
     });
 
     const invalidRequiresCases = [
-      { name: 'null', requires: null, error: /requires.*must be an object/ },
-      { name: 'unknown field', requires: { tool: ['git'] }, error: /requires.*unsupported field/ },
-      { name: 'non-string item', requires: { tools: ['git', 1] }, error: /requires\.tools.*non-empty strings/ },
+      { name: 'null', requires: null, error: /requires.*expected object.*null/ },
+      { name: 'unknown field', requires: { tool: ['git'] }, error: /requires.*Unrecognized key.*tool/ },
+      { name: 'non-string item', requires: { tools: ['git', 1] }, error: /requires\.tools\.1.*expected string.*number/ },
     ];
 
     it.each(invalidRequiresCases)('rejects invalid requires: $name', ({ name, requires, error }) => {
@@ -216,8 +290,8 @@ describe('loadSamples', () => {
       ]);
     });
 
-    it('老 sample(无新字段)仍正常解析', () => {
-      const p = writeJsonSamples('legacy.json', [{ sample_id: 's1', prompt: 'p' }]);
+    it('最小 sample（无可选字段）正常解析', () => {
+      const p = writeJsonSamples('minimal.json', [{ sample_id: 's1', prompt: 'p' }]);
       const { samples } = loadSamples(p);
       assert.equal(samples[0].capability, undefined);
       assert.equal(samples[0].difficulty, undefined);
@@ -230,43 +304,43 @@ describe('loadSamples', () => {
         name: 'difficulty invalid value includes sample_id',
         file: 'bad-difficulty.json',
         value: [{ sample_id: 's7', prompt: 'p', difficulty: 'easy?' }],
-        error: /s7.*invalid difficulty.*easy\?.*easy, medium, hard/,
+        error: /samples\.0\.difficulty.*Invalid option/,
       },
       {
         name: 'provenance invalid value',
         file: 'bad-prov.json',
         value: [{ sample_id: 's1', prompt: 'p', provenance: 'random' }],
-        error: /invalid provenance/,
+        error: /samples\.0\.provenance.*Invalid option/,
       },
       {
         name: 'capability single string',
         file: 'bad-cap.json',
         value: [{ sample_id: 's1', prompt: 'p', capability: 'api-selection' }],
-        error: /invalid capability.*string array/,
+        error: /samples\.0\.capability.*expected array.*string/,
       },
       {
         name: 'capability array contains non-string',
         file: 'bad-cap-elem.json',
         value: [{ sample_id: 's1', prompt: 'p', capability: ['ok', 123] }],
-        error: /capability\[1\] must be a non-empty string/,
+        error: /samples\.0\.capability\.1.*expected string.*number/,
       },
       {
         name: 'covers is not array',
         file: 'bad-covers.json',
         value: [{ sample_id: 's1', prompt: 'p', covers: 'references/a.md' }],
-        error: /invalid covers.*array/,
+        error: /samples\.0\.covers.*expected array.*string/,
       },
       {
         name: 'covers targetKind invalid',
         file: 'bad-covers-kind.json',
         value: [{ sample_id: 's1', prompt: 'p', covers: [{ targetKind: 'file', ref: 'references/a.md' }] }],
-        error: /covers\[0\] invalid targetKind/,
+        error: /samples\.0\.covers\.0\.targetKind.*Invalid option/,
       },
       {
         name: 'covers ref empty',
         file: 'bad-covers-ref.json',
         value: [{ sample_id: 's1', prompt: 'p', covers: [{ targetKind: 'reference', ref: '' }] }],
-        error: /covers\[0\] invalid ref/,
+        error: /samples\.0\.covers\.0\.ref.*expected string.*>=1/,
       },
     ];
 
@@ -301,9 +375,9 @@ describe('loadSamples', () => {
 
     it('merges samples from multiple json files in deterministic name-sorted order', () => {
       const d = makeDir('multi');
-      writeFileSync(join(d, 'workflow.json'), JSON.stringify([{ sample_id: 's001', prompt: 'a' }]));
-      writeFileSync(join(d, 'platform.json'), JSON.stringify([{ sample_id: 's002', prompt: 'b' }]));
-      writeFileSync(join(d, 'ironlaw.json'),  JSON.stringify([{ sample_id: 's003', prompt: 'c' }]));
+      writeFileSync(join(d, 'workflow.json'), jsonSet([{ sample_id: 's001', prompt: 'a' }]));
+      writeFileSync(join(d, 'platform.json'), jsonSet([{ sample_id: 's002', prompt: 'b' }]));
+      writeFileSync(join(d, 'ironlaw.json'), jsonSet([{ sample_id: 's003', prompt: 'c' }]));
       const { samples } = loadSamples(d);
       // sorted: ironlaw < platform < workflow
       assert.deepEqual(samples.map((s) => s.sample_id), ['s003', 's002', 's001']);
@@ -311,18 +385,18 @@ describe('loadSamples', () => {
 
     it('skips reserved file prefixes (report*, health*, _*)', () => {
       const d = makeDir('reserved');
-      writeFileSync(join(d, 'samples.json'),       JSON.stringify([{ sample_id: 's1', prompt: 'a' }]));
-      writeFileSync(join(d, 'report-2026.json'),    JSON.stringify([{ sample_id: 'should-skip-1', prompt: 'x' }]));
-      writeFileSync(join(d, 'health.json'),         JSON.stringify([{ sample_id: 'should-skip-2', prompt: 'x' }]));
-      writeFileSync(join(d, '_scratch.json'),       JSON.stringify([{ sample_id: 'should-skip-3', prompt: 'x' }]));
+      writeFileSync(join(d, 'samples.json'), jsonSet([{ sample_id: 's1', prompt: 'a' }]));
+      writeFileSync(join(d, 'report-2026.json'), jsonSet([{ sample_id: 'should-skip-1', prompt: 'x' }]));
+      writeFileSync(join(d, 'health.json'), jsonSet([{ sample_id: 'should-skip-2', prompt: 'x' }]));
+      writeFileSync(join(d, '_scratch.json'), jsonSet([{ sample_id: 'should-skip-3', prompt: 'x' }]));
       const { samples } = loadSamples(d);
       assert.deepEqual(samples.map((s) => s.sample_id), ['s1']);
     });
 
     it('rejects duplicate sample_id across files', () => {
       const d = makeDir('dup');
-      writeFileSync(join(d, 'a.json'), JSON.stringify([{ sample_id: 'shared', prompt: 'one' }]));
-      writeFileSync(join(d, 'b.json'), JSON.stringify([{ sample_id: 'shared', prompt: 'two' }]));
+      writeFileSync(join(d, 'a.json'), jsonSet([{ sample_id: 'shared', prompt: 'one' }]));
+      writeFileSync(join(d, 'b.json'), jsonSet([{ sample_id: 'shared', prompt: 'two' }]));
       assert.throws(() => loadSamples(d), /duplicate sample_id "shared"/);
     });
 
@@ -332,11 +406,11 @@ describe('loadSamples', () => {
       const constructorPath = join(d, 'b.json');
       writeFileSync(
         protoPath,
-        JSON.stringify([{ sample_id: '__proto__', prompt: 'one' }]),
+        jsonSet([{ sample_id: '__proto__', prompt: 'one' }]),
       );
       writeFileSync(
         constructorPath,
-        JSON.stringify([{ sample_id: 'constructor', prompt: 'two' }]),
+        jsonSet([{ sample_id: 'constructor', prompt: 'two' }]),
       );
 
       const loaded = loadSamples(d);
@@ -348,20 +422,20 @@ describe('loadSamples', () => {
 
     it('errors when directory has no eligible sample files', () => {
       const d = makeDir('empty');
-      writeFileSync(join(d, 'report.json'), JSON.stringify([{ sample_id: 's1', prompt: 'p' }]));
+      writeFileSync(join(d, 'report.json'), jsonSet([{ sample_id: 's1', prompt: 'p' }]));
       assert.throws(() => loadSamples(d), /no sample files found in directory/);
     });
 
     it('unions requires from object-wrapper format across files', () => {
       const d = makeDir('requires-merge');
-      writeFileSync(join(d, 'a.json'), JSON.stringify({
-        requires: { tools: ['integration-tool'], env: ['FOO'] },
-        samples: [{ sample_id: 's1', prompt: 'a' }],
-      }));
-      writeFileSync(join(d, 'b.json'), JSON.stringify({
-        requires: { tools: ['integration-tool', 'git'], files: ['x.txt'] },
-        samples: [{ sample_id: 's2', prompt: 'b' }],
-      }));
+      writeFileSync(join(d, 'a.json'), jsonSet(
+        [{ sample_id: 's1', prompt: 'a' }],
+        { tools: ['integration-tool'], env: ['FOO'] },
+      ));
+      writeFileSync(join(d, 'b.json'), jsonSet(
+        [{ sample_id: 's2', prompt: 'b' }],
+        { tools: ['integration-tool', 'git'], files: ['x.txt'] },
+      ));
       const { requires } = loadSamples(d);
       assert.deepEqual(new Set(requires?.tools), new Set(['integration-tool', 'git']));
       assert.deepEqual(requires?.env, ['FOO']);
@@ -371,8 +445,8 @@ describe('loadSamples', () => {
     // P2-1 source-aware:目录模式下 baseDir = 目录自身,sourceFiles 列所有合并的文件
     it('directory mode: baseDir 等于目录自身;sourceFiles 含所有合并文件(已排序)', () => {
       const d = makeDir('source-aware');
-      writeFileSync(join(d, 'b.json'), JSON.stringify([{ sample_id: 's1', prompt: 'a' }]));
-      writeFileSync(join(d, 'a.json'), JSON.stringify([{ sample_id: 's2', prompt: 'b' }]));
+      writeFileSync(join(d, 'b.json'), jsonSet([{ sample_id: 's1', prompt: 'a' }]));
+      writeFileSync(join(d, 'a.json'), jsonSet([{ sample_id: 's2', prompt: 'b' }]));
       const { baseDir, sourceFiles } = loadSamples(d);
       assert.equal(baseDir, d);
       assert.equal(sourceFiles.length, 2);
@@ -384,7 +458,7 @@ describe('loadSamples', () => {
     it('single-file mode: baseDir 等于 dirname(file);sourceFiles = [file]', () => {
       const d = makeDir('singlefile');
       const f = join(d, 'samples.json');
-      writeFileSync(f, JSON.stringify([{ sample_id: 's1', prompt: 'a' }]));
+      writeFileSync(f, jsonSet([{ sample_id: 's1', prompt: 'a' }]));
       const { baseDir, sourceFiles } = loadSamples(f);
       assert.equal(baseDir, d);
       assert.deepEqual(sourceFiles, [f]);

--- a/test/inputs/yaml-parser.test.ts
+++ b/test/inputs/yaml-parser.test.ts
@@ -110,8 +110,9 @@ server:
       readFileSync(join(__dirname, '..', 'fixtures', 'code-review', 'eval-samples.json'), 'utf-8'),
     );
     // At minimum, verify the JSON has the expected structure
-    assert.ok(Array.isArray(jsonSamples));
-    assert.ok(jsonSamples.length > 0);
-    assert.ok(jsonSamples[0].sample_id);
+    assert.equal(jsonSamples.schemaVersion, 'omk.eval-sample-set/v1');
+    assert.ok(Array.isArray(jsonSamples.samples));
+    assert.ok(jsonSamples.samples.length > 0);
+    assert.ok(jsonSamples.samples[0].sample_id);
   });
 });

--- a/test/preflight/dependencies.test.ts
+++ b/test/preflight/dependencies.test.ts
@@ -10,9 +10,17 @@ import {
   preflightDependencies,
 } from '../../src/preflight/dependencies.js';
 import type { Artifact } from '../../src/artifacts/contracts.js';
-import type { Sample } from '../../src/inputs/contracts/sample.js';
+import {
+  type EvalSampleSetDocument,
+  type Sample,
+} from '../../src/inputs/contracts/sample.js';
+import { createEvalSampleSetDocument } from '../../src/inputs/schemas/sample-set.js';
 
 const tmp = () => join(tmpdir(), `omk-dep-test-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+const sampleSetJson = (
+  samples: Sample[],
+  requires?: EvalSampleSetDocument['requires'],
+): string => JSON.stringify(createEvalSampleSetDocument(samples, requires));
 
 describe('extractDependencies', () => {
   it('从 skill 内容提取 CLI 工具', () => {
@@ -283,17 +291,17 @@ describe('extractFilesByBase', () => {
   });
 });
 
-describe('loadSamples 对象包装格式', async () => {
+describe('loadSamples 版本化对象格式', async () => {
   const { loadSamples } = await import('../../src/inputs/load-samples.js');
   const cleanups: string[] = [];
 
-  it('支持 { requires, samples } 格式', () => {
+  it('支持 { schemaVersion, requires, samples } 格式', () => {
     const p = join(tmpdir(), `omk-dep-wrapper-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify({
-      requires: { tools: ['foo-cli'], env: ['FOO_TOKEN'] },
-      samples: [{ sample_id: 's1', prompt: '测试' }],
-    }));
+    writeFileSync(p, sampleSetJson(
+      [{ sample_id: 's1', prompt: '测试' }],
+      { tools: ['foo-cli'], env: ['FOO_TOKEN'] },
+    ));
     const result = loadSamples(p);
     assert.equal(result.samples.length, 1);
     assert.deepEqual(result.requires?.tools, ['foo-cli']);
@@ -302,10 +310,10 @@ describe('loadSamples 对象包装格式', async () => {
     cleanups.length = 0;
   });
 
-  it('数组格式向后兼容（无 requires）', () => {
+  it('无 requires 时保持未声明状态', () => {
     const p = join(tmpdir(), `omk-dep-array-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{ sample_id: 's1', prompt: '测试' }]));
+    writeFileSync(p, sampleSetJson([{ sample_id: 's1', prompt: '测试' }]));
     const result = loadSamples(p);
     assert.equal(result.samples.length, 1);
     assert.equal(result.requires, undefined);
@@ -316,7 +324,7 @@ describe('loadSamples 对象包装格式', async () => {
   it('拒绝 tools_not_called values 为空数组', () => {
     const p = join(tmpdir(), `omk-noise-assertion-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{
+    writeFileSync(p, sampleSetJson([{
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'tools_not_called', values: [], weight: 0 }],
     }]));
@@ -328,7 +336,7 @@ describe('loadSamples 对象包装格式', async () => {
   it('拒绝 tools_called values 缺失', () => {
     const p = join(tmpdir(), `omk-noise-assertion-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{
+    writeFileSync(p, sampleSetJson([{
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'tools_called', weight: 1 }],
     }]));
@@ -340,7 +348,7 @@ describe('loadSamples 对象包装格式', async () => {
   it('拒绝 tool_input_not_contains 缺 Tool: 前缀', () => {
     const p = join(tmpdir(), `omk-bad-value-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{
+    writeFileSync(p, sampleSetJson([{
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'tool_input_not_contains', value: '--force', weight: 1 }],
     }]));
@@ -352,7 +360,7 @@ describe('loadSamples 对象包装格式', async () => {
   it('拒绝 tool_input_contains 冒号位置在末尾', () => {
     const p = join(tmpdir(), `omk-bad-value-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{
+    writeFileSync(p, sampleSetJson([{
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'tool_input_contains', value: 'Bash:', weight: 1 }],
     }]));
@@ -377,7 +385,7 @@ describe('loadSamples 对象包装格式', async () => {
   it('rule A loader (strict): 拒绝 contains 含 CJK 字符', () => {
     const p = join(tmpdir(), `omk-cjk-value-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{
+    writeFileSync(p, sampleSetJson([{
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'contains', value: '留档', weight: 1 }],
     }]));
@@ -389,7 +397,7 @@ describe('loadSamples 对象包装格式', async () => {
   it('rule A loader (strict): 拒绝 contains_any 数组中含全角标点元素', () => {
     const p = join(tmpdir(), `omk-fw-value-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{
+    writeFileSync(p, sampleSetJson([{
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'contains_any', values: ['ECONNREFUSED', '【失败】'], weight: 1 }],
     }]));
@@ -401,7 +409,7 @@ describe('loadSamples 对象包装格式', async () => {
   it('rule A loader (strict): 拒绝 contains 含内部空格的短语', () => {
     const p = join(tmpdir(), `omk-phrase-value-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{
+    writeFileSync(p, sampleSetJson([{
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'contains', value: 'task completed', weight: 1 }],
     }]));
@@ -413,7 +421,7 @@ describe('loadSamples 对象包装格式', async () => {
   it('rule A loader: 接受 ASCII token-style contains (in any mode)', () => {
     const p = join(tmpdir(), `omk-ok-value-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{
+    writeFileSync(p, sampleSetJson([{
       sample_id: 's1', prompt: 'p',
       assertions: [
         { type: 'contains', value: 'ECONNREFUSED', weight: 1 },
@@ -433,7 +441,7 @@ describe('loadSamples 对象包装格式', async () => {
   it('rule A loader: lenient mode (OMK_LENIENT_ASSERTIONS=1) downgrades throws to stderr warn', () => {
     const p = join(tmpdir(), `omk-lenient-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{
+    writeFileSync(p, sampleSetJson([{
       sample_id: 's1', prompt: 'p',
       assertions: [
         { type: 'contains', value: '留档', weight: 1 }, // would throw in strict mode
@@ -468,7 +476,7 @@ describe('loadSamples 对象包装格式', async () => {
   it('rule A loader (strict): 拒绝 regex pattern 含 CJK', () => {
     const p = join(tmpdir(), `omk-regex-cjk-${Date.now()}.json`);
     cleanups.push(p);
-    writeFileSync(p, JSON.stringify([{
+    writeFileSync(p, sampleSetJson([{
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'regex', pattern: '风险等级:\\s*(高|中|低)', weight: 1 }],
     }]));


### PR DESCRIPTION
## 用户影响

评测用例文件现在使用有版本号、可发布、可由工具验证的严格协议。未知字段会在执行前失败，mock 未命中默认 fail-closed；TypeScript 作者可通过公开子路径获取协议类型、构造器和随包发布的 JSON Schema。

## 迁移说明

- 将历史顶层数组包装为对象，并加入 schemaVersion: omk.eval-sample-set/v1 与 samples 字段。
- 删除未生效的 expectedTools 字段；工具行为约束继续使用 assertions 与 allowedTools。
- mocksStrict 缺省值改为 true；只有明确允许未命中调用进入真实 runtime 时才设置为 false。
- 每条 mock 必须且只能声明 return、return_file、return_seq 之一；return_seq 耗尽后保持最后一个状态。
- 根文档、sample、assertion、mock 和嵌套对象不再接受未知字段。

## 测量学说明

本改动不修改五层评分管道、评分类 prompt、Bootstrap CI、Krippendorff alpha 或 EvaluationReport 字段语义，因此不属于 BREAKING-COMPARABILITY。它会改变用例文件 schema 和 mock 执行安全边界，所以使用 BREAKING-SCHEMA 标记并要求显式迁移。

## 关联

后续独立 PR 将统一 sample 文件的自动发现和生成命名，不与本次协议变更混在同一个审查单元。
