### PR TITLE
feat(cli): 提供二十条官方评测起步用例

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -272,8 +272,9 @@ omk init [targetDir] [flags]
 
 **Flags:**
 
+- `--force` `boolean`:允许覆盖目标目录中已有的 omk 脚手架文件
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
-- `--samples` `3|20` (默认 `3`):官方人工策划用例数量：3 条用于快速跑通，20 条用于达到注册样本量下限
+- `--samples` `3|20` (默认 `3`):官方起步用例数量：3 条用于快速跑通，20 条用于达到注册样本量下限
 
 **示例:**
 

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -273,6 +273,7 @@ omk init [targetDir] [flags]
 **Flags:**
 
 - `--lang` `option` (默认 `zh`):输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
+- `--samples` `3|20` (默认 `3`):官方人工策划用例数量：3 条用于快速跑通，20 条用于达到注册样本量下限
 
 **示例:**
 
@@ -286,6 +287,12 @@ omk init
 
 ```bash
 omk init my-project
+```
+
+> 使用达到注册样本量下限的 20 条官方用例初始化
+
+```bash
+omk init my-project --samples 20
 ```
 
 ## omk install

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ export OMK_EXECUTOR=codex
 
 Without `OMK_MODEL`, omk reads the model from `~/.codex/config.toml`. You can still pass `--executor codex --model <codex-model>` per command. Pass `--judge-models` or set `OMK_JUDGE_MODELS` only when you want a different judge.
 
-> The default 3-case pack is a low-cost workflow check, so `UNDERPOWERED` is expected. `--samples 20` selects a human-curated, difficulty-stratified pack that meets omk's registered sample-size floor; it improves statistical power but does not guarantee a decisive verdict.
+> The default 3-case pack is a low-cost workflow check, so `UNDERPOWERED` is expected. `--samples 20` selects a first-party, difficulty-stratified starter pack that meets omk's registered sample-size floor. Its provenance is `llm-generated`: use it to learn the statistical workflow, then review and replace it with real domain cases before making a release decision.
 
 > The CLI notifies you when a newer version is available (at most once per 20h); set `OMK_SKIP_UPDATE_CHECK=1` to silence it permanently.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-Runs out of the box — no edits needed first. `omk init` scaffolds two skill variants and three sample cases; `--dry-run` previews the sealed task plan and estimated calls; `omk eval` runs the controlled A/B and opens the authenticated Core run in Studio. Once it runs, swap in your own skills and cases.
+Runs out of the box — no edits needed first. `omk init` scaffolds two skill variants and three sample cases; `--dry-run` previews the sealed task plan and estimated calls; `omk eval` runs the controlled A/B and opens the authenticated Core run in Studio. Once it runs, swap in your own skills and cases. To start directly with the first-party 20-case pack, replace the first command with `omk init demo --samples 20`.
 
 Prerequisite: configure one authenticated model runtime (Codex CLI, Claude Code, or an API executor; see [Requirements](#requirements)). Inside a Codex task in the ChatGPT desktop app, omk automatically selects `codex`, reads the model from `~/.codex/config.toml`, and uses the same Codex model as the default judge. Claude is not required.
 
@@ -55,7 +55,7 @@ export OMK_EXECUTOR=codex
 
 Without `OMK_MODEL`, omk reads the model from `~/.codex/config.toml`. You can still pass `--executor codex --model <codex-model>` per command. Pass `--judge-models` or set `OMK_JUDGE_MODELS` only when you want a different judge.
 
-> The first run has only 3 cases, so the verdict will usually be `UNDERPOWERED` (insufficient data) — that's a normal starting point, not an error; grow to ~20+ cases before trusting a ship/no-ship call.
+> The default 3-case pack is a low-cost workflow check, so `UNDERPOWERED` is expected. `--samples 20` selects a human-curated, difficulty-stratified pack that meets omk's registered sample-size floor; it improves statistical power but does not guarantee a decisive verdict.
 
 > The CLI notifies you when a newer version is available (at most once per 20h); set `OMK_SKIP_UPDATE_CHECK=1` to silence it permanently.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -55,7 +55,7 @@ export OMK_EXECUTOR=codex
 
 不设置 `OMK_MODEL` 时，omk 会读取 `~/.codex/config.toml` 的模型。也可以继续逐次显式传 `--executor codex --model <codex-model>`。自定义评委时再传 `--judge-models` 或设置 `OMK_JUDGE_MODELS`。
 
-> 默认 3 条用例是低成本流程检查，出现「数据不足（UNDERPOWERED）」符合预期。`--samples 20` 会选择经过人工策划和难度分层的完整用例集，达到 omk 注册的样本量下限；它能提高统计功效，但不保证一定得到明确 verdict。
+> 默认 3 条用例是低成本流程检查，出现「数据不足（UNDERPOWERED）」符合预期。`--samples 20` 会选择经过难度分层的官方起步用例集，达到 omk 注册的样本量下限。其来源明确标记为 `llm-generated`：它适合学习统计流程，发布判断前仍应人工复核并替换为真实领域用例。
 
 > 命令行有新版本时会自动提示（每 20 小时最多一次）；想永久关闭该提醒，设环境变量 `OMK_SKIP_UPDATE_CHECK=1` 即可。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,7 +42,7 @@ omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-开箱即跑：`omk init` 脚手架好两版 skill 和三条评测用例，不用先改任何文件；`--dry-run` 预览 sealed task plan 与预估调用次数；`omk eval` 跑控制变量 A/B，并在 Studio 打开经过认证的 Core run。跑通后再把 skill 和用例换成你自己的。
+开箱即跑：`omk init` 脚手架好两版 skill 和三条评测用例，不用先改任何文件；`--dry-run` 预览 sealed task plan 与预估调用次数；`omk eval` 跑控制变量 A/B，并在 Studio 打开经过认证的 Core run。跑通后再把 skill 和用例换成你自己的。希望首次就使用官方 20 条完整起步集时，把第一条命令换成 `omk init demo --samples 20`。
 
 前置：准备一个已认证的模型 runtime（Codex CLI、Claude Code 或 API 执行器，见[系统要求](#系统要求)）。在 ChatGPT desktop 的 Codex 任务里，omk 会自动使用 `codex`，从 `~/.codex/config.toml` 读取模型，并默认用同一个 Codex 模型担任评委，不依赖 Claude。
 
@@ -55,7 +55,7 @@ export OMK_EXECUTOR=codex
 
 不设置 `OMK_MODEL` 时，omk 会读取 `~/.codex/config.toml` 的模型。也可以继续逐次显式传 `--executor codex --model <codex-model>`。自定义评委时再传 `--judge-models` 或设置 `OMK_JUDGE_MODELS`。
 
-> 首跑只有 3 条用例，verdict 多半是「数据不足（UNDERPOWERED）」——这是正常起点而非出错；把用例加到约 20 条以上，再看「可发布」结论。
+> 默认 3 条用例是低成本流程检查，出现「数据不足（UNDERPOWERED）」符合预期。`--samples 20` 会选择经过人工策划和难度分层的完整用例集，达到 omk 注册的样本量下限；它能提高统计功效，但不保证一定得到明确 verdict。
 
 > 命令行有新版本时会自动提示（每 20 小时最多一次）；想永久关闭该提醒，设环境变量 `OMK_SKIP_UPDATE_CHECK=1` 即可。
 

--- a/docs/quickstart-skill-eval.md
+++ b/docs/quickstart-skill-eval.md
@@ -38,7 +38,7 @@ If you want the first run to meet omk's registered sample-size floor, create the
 omk init demo --samples 20
 ```
 
-The full pack has five security, robustness, maintainability, and performance cases each, spans easy／medium／hard difficulty, and includes no-defect controls so a reviewer is not rewarded merely for reporting more issues. It produces 40 control／treatment executions, so the 3-case default remains the fastest way to verify setup. Twenty samples improve statistical power; they do not guarantee `PROGRESS` or replace inspection of the confidence interval and failed cases.
+The full pack has five security, robustness, maintainability, and performance cases each, spans easy / medium / hard difficulty, and includes no-defect controls so a reviewer is not rewarded merely for reporting more issues. It produces 40 control / treatment executions, so the 3-case default remains the fastest way to verify setup. The fixed starter cases are marked `provenance: llm-generated`: twenty samples improve statistical power, but they remain teaching data rather than production release evidence. Review them and replace them with real domain cases before trusting a ship / no-ship decision.
 
 Inside a Codex task, the shortest commands above need no runtime flags. To make Codex the default in regular terminals, add the preference to your shell profile (for example `~/.zshrc`):
 

--- a/docs/quickstart-skill-eval.md
+++ b/docs/quickstart-skill-eval.md
@@ -32,6 +32,14 @@ omk eval --control code-review-v1 --treatment code-review-v2
 
 `omk init` creates two skill variants and three sample cases. `--dry-run` previews the sealed task plan and estimated calls; the real run then opens the Core run in Studio. With only three demo samples, the verdict is often `UNDERPOWERED` — that is a normal teaching result, not a failed run.
 
+If you want the first run to meet omk's registered sample-size floor, create the demo with the first-party 20-case pack instead:
+
+```bash
+omk init demo --samples 20
+```
+
+The full pack has five security, robustness, maintainability, and performance cases each, spans easy／medium／hard difficulty, and includes no-defect controls so a reviewer is not rewarded merely for reporting more issues. It produces 40 control／treatment executions, so the 3-case default remains the fastest way to verify setup. Twenty samples improve statistical power; they do not guarantee `PROGRESS` or replace inspection of the confidence interval and failed cases.
+
 Inside a Codex task, the shortest commands above need no runtime flags. To make Codex the default in regular terminals, add the preference to your shell profile (for example `~/.zshrc`):
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -15,14 +15,15 @@ omk init [dir]
 **Flags:**
 
 ```text
-  --lang <value>  Output language zh|en. Priority: CLI > OMK_LANG env > zh.
+  --lang <value>    Output language zh|en. Priority: CLI > OMK_LANG env > zh.
+  --samples <3|20>  Number of first-party curated samples: 3 for a quick run, 20 to meet the registered sample-size floor
 ```
 
 For full descriptions: `omk init --help`.
 
 <!-- omk:cli:init:flags:end -->
 
-Initializes an **omk project** in the target directory: knowledge artifacts to measure (today `skills/<name>/SKILL.md`) plus their eval samples (`eval-samples.json`) — the per-directory workspace that `omk eval` / `doctor` / `evolve` / `observe` / `list` all operate on. Like a git repo, you have one per measurement target (the sample set is the measurement context, so it travels with the artifact, not globally). The managed registry (`install` / `list` / `promote`, optionally global) is a separate layer `init` does not touch. The two starter skill variants + three sample cases are just the default A/B template.
+Initializes an **omk project** in the target directory: knowledge artifacts to measure (today `skills/<name>/SKILL.md`) plus their eval samples (`eval-samples.json`) — the per-directory workspace that `omk eval` / `doctor` / `evolve` / `observe` / `list` all operate on. Like a git repo, you have one per measurement target (the sample set is the measurement context, so it travels with the artifact, not globally). The managed registry (`install` / `list` / `promote`, optionally global) is a separate layer `init` does not touch. The default three-case A/B template is a low-cost workflow check; `--samples 20` selects the first-party curated pack that meets the registered sample-size floor.
 
 ## `omk install`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -15,15 +15,16 @@ omk init [dir]
 **Flags:**
 
 ```text
+  --force           Allow overwriting existing project scaffold files in the target directory
   --lang <value>    Output language zh|en. Priority: CLI > OMK_LANG env > zh.
-  --samples <3|20>  Number of first-party curated samples: 3 for a quick run, 20 to meet the registered sample-size floor
+  --samples <3|20>  Number of first-party starter samples: 3 for a quick run, 20 to meet the registered sample-size floor
 ```
 
 For full descriptions: `omk init --help`.
 
 <!-- omk:cli:init:flags:end -->
 
-Initializes an **omk project** in the target directory: knowledge artifacts to measure (today `skills/<name>/SKILL.md`) plus their eval samples (`eval-samples.json`) — the per-directory workspace that `omk eval` / `doctor` / `evolve` / `observe` / `list` all operate on. Like a git repo, you have one per measurement target (the sample set is the measurement context, so it travels with the artifact, not globally). The managed registry (`install` / `list` / `promote`, optionally global) is a separate layer `init` does not touch. The default three-case A/B template is a low-cost workflow check; `--samples 20` selects the first-party curated pack that meets the registered sample-size floor.
+Initializes an **omk project** in the target directory: knowledge artifacts to measure (today `skills/<name>/SKILL.md`) plus their eval samples (`eval-samples.json`) — the per-directory workspace that `omk eval` / `doctor` / `evolve` / `observe` / `list` all operate on. Like a git repo, you have one per measurement target (the sample set is the measurement context, so it travels with the artifact, not globally). The managed registry (`install` / `list` / `promote`, optionally global) is a separate layer `init` does not touch. The default three-case A/B template is a low-cost workflow check; `--samples 20` selects the first-party starter pack that meets the registered sample-size floor. Starter samples are marked `llm-generated` and must be reviewed or replaced before serving as release evidence. Existing scaffold files are never overwritten unless `--force` is explicit.
 
 ## `omk install`
 

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -38,7 +38,7 @@ omk eval --control code-review-v1 --treatment code-review-v2
 omk init demo --samples 20
 ```
 
-完整用例集在安全、健壮性、可维护性、性能四个维度各有 5 条，覆盖 easy／medium／hard 难度，并包含无缺陷对照，避免把「报告更多问题」误当成更好的审查。它会产生 40 次 control／treatment 执行，因此默认 3 条仍然是验证环境最省成本的入口。20 条能提高统计功效，但不保证一定得到 `PROGRESS`，也不能替代对置信区间和失败样本的审阅。
+完整用例集在安全、健壮性、可维护性、性能四个维度各有 5 条，覆盖 easy／medium／hard 难度，并包含无缺陷对照，避免把「报告更多问题」误当成更好的审查。它会产生 40 次 control／treatment 执行，因此默认 3 条仍然是验证环境最省成本的入口。固定起步用例明确标记为 `provenance: llm-generated`：20 条能提高统计功效，但仍是教学数据而非生产发布证据。信任 ship／no-ship 判断前，应人工复核并替换为真实领域用例。
 
 在 Codex 任务里，上面的最短命令无需添加 runtime 参数。普通终端想固定使用 Codex，可以把偏好加入 shell 配置，例如 `~/.zshrc`：
 

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -32,6 +32,14 @@ omk eval --control code-review-v1 --treatment code-review-v2
 
 `omk init` 会创建两版 skill 和三条评测用例。`--dry-run` 先预览 sealed task plan 和预估调用次数；真跑后会在 Studio 打开 Core run。demo 只有三条用例，verdict 经常是 `UNDERPOWERED`，这是正常教学结果，不是运行失败。
 
+希望第一次运行就达到 omk 注册的样本量下限，可以改用官方 20 条完整起步集：
+
+```bash
+omk init demo --samples 20
+```
+
+完整用例集在安全、健壮性、可维护性、性能四个维度各有 5 条，覆盖 easy／medium／hard 难度，并包含无缺陷对照，避免把「报告更多问题」误当成更好的审查。它会产生 40 次 control／treatment 执行，因此默认 3 条仍然是验证环境最省成本的入口。20 条能提高统计功效，但不保证一定得到 `PROGRESS`，也不能替代对置信区间和失败样本的审阅。
+
 在 Codex 任务里，上面的最短命令无需添加 runtime 参数。普通终端想固定使用 Codex，可以把偏好加入 shell 配置，例如 `~/.zshrc`：
 
 ```bash

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -15,14 +15,15 @@ omk init [目录]
 **Flags:**
 
 ```text
-  --lang <value>  输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
+  --lang <value>    输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
+  --samples <3|20>  官方人工策划用例数量：3 条用于快速跑通，20 条用于达到注册样本量下限
 ```
 
 完整描述见 `omk init --help`。
 
 <!-- omk:cli:init:flags:end -->
 
-在目标目录初始化一个 **omk 项目**：待测知识载体（今天是 `skills/<name>/SKILL.md`）+ 它们的评测用例（`eval-samples.json`）—— 这是 `omk eval` / `doctor` / `evolve` / `observe` / `list` 共同操作的「每目录工作区」。跟 git 仓库一样，一个测量目标一个项目（用例集就是测量上下文，随载体走、不全局共享）。受管登记表（`install` / `list` / `promote`，可全局）是另一层，不归 `init` 管。现有两版 skill + 三条用例只是默认的 A/B 起步模板。
+在目标目录初始化一个 **omk 项目**：待测知识载体（今天是 `skills/<name>/SKILL.md`）+ 它们的评测用例（`eval-samples.json`）—— 这是 `omk eval` / `doctor` / `evolve` / `observe` / `list` 共同操作的「每目录工作区」。跟 git 仓库一样，一个测量目标一个项目（用例集就是测量上下文，随载体走、不全局共享）。受管登记表（`install` / `list` / `promote`，可全局）是另一层，不归 `init` 管。默认 3 条 A/B 用例是低成本流程检查；`--samples 20` 会选择达到注册样本量下限的官方人工策划用例集。
 
 ## `omk install`
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -15,15 +15,16 @@ omk init [目录]
 **Flags:**
 
 ```text
+  --force           允许覆盖目标目录中已有的 omk 脚手架文件
   --lang <value>    输出语言 zh|en，优先级 CLI > OMK_LANG env > zh。
-  --samples <3|20>  官方人工策划用例数量：3 条用于快速跑通，20 条用于达到注册样本量下限
+  --samples <3|20>  官方起步用例数量：3 条用于快速跑通，20 条用于达到注册样本量下限
 ```
 
 完整描述见 `omk init --help`。
 
 <!-- omk:cli:init:flags:end -->
 
-在目标目录初始化一个 **omk 项目**：待测知识载体（今天是 `skills/<name>/SKILL.md`）+ 它们的评测用例（`eval-samples.json`）—— 这是 `omk eval` / `doctor` / `evolve` / `observe` / `list` 共同操作的「每目录工作区」。跟 git 仓库一样，一个测量目标一个项目（用例集就是测量上下文，随载体走、不全局共享）。受管登记表（`install` / `list` / `promote`，可全局）是另一层，不归 `init` 管。默认 3 条 A/B 用例是低成本流程检查；`--samples 20` 会选择达到注册样本量下限的官方人工策划用例集。
+在目标目录初始化一个 **omk 项目**：待测知识载体（今天是 `skills/<name>/SKILL.md`）+ 它们的评测用例（`eval-samples.json`）—— 这是 `omk eval` / `doctor` / `evolve` / `observe` / `list` 共同操作的「每目录工作区」。跟 git 仓库一样，一个测量目标一个项目（用例集就是测量上下文，随载体走、不全局共享）。受管登记表（`install` / `list` / `promote`，可全局）是另一层，不归 `init` 管。默认 3 条 A/B 用例是低成本流程检查；`--samples 20` 会选择达到注册样本量下限的官方起步用例集。起步用例标记为 `llm-generated`，作为发布证据前必须人工复核或替换。除非显式传入 `--force`，`init` 不会覆盖已有脚手架文件。
 
 ## `omk install`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,8 @@ cd demo
 omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
 ```
 
+Use `omk init demo --samples 20` when you want the first-party, difficulty-stratified starter pack instead of the default three-case workflow check.
+
 ## Choose by task
 
 | Task | Example | What it demonstrates | First command | Model call |

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ cd demo
 omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
 ```
 
-Use `omk init demo --samples 20` when you want the first-party, difficulty-stratified starter pack instead of the default three-case workflow check.
+Use `omk init demo --samples 20` when you want the first-party, difficulty-stratified starter pack instead of the default three-case workflow check. The starter cases are `llm-generated` teaching data; review or replace them before using the result as release evidence.
 
 ## Choose by task
 

--- a/examples/README.zh.md
+++ b/examples/README.zh.md
@@ -10,6 +10,8 @@ cd demo
 omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
 ```
 
+希望直接使用官方、经过难度分层的完整起步集，而不是默认 3 条流程检查用例时，运行 `omk init demo --samples 20`。
+
 ## 按任务选择
 
 | 任务 | 示例 | 演示内容 | 第一条命令 | 是否调用模型 |

--- a/examples/README.zh.md
+++ b/examples/README.zh.md
@@ -10,7 +10,7 @@ cd demo
 omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
 ```
 
-希望直接使用官方、经过难度分层的完整起步集，而不是默认 3 条流程检查用例时，运行 `omk init demo --samples 20`。
+希望直接使用官方、经过难度分层的完整起步集，而不是默认 3 条流程检查用例时，运行 `omk init demo --samples 20`。这些起步用例是 `llm-generated` 教学数据，作为发布证据前应人工复核或替换。
 
 ## 按任务选择
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -150,7 +150,7 @@ export default class Init extends BaseCommand {
         join(targetDir, 'eval-samples.json'),
         join(targetDir, 'skills', 'code-review-v1', 'SKILL.md'),
         join(targetDir, 'skills', 'code-review-v2', 'SKILL.md'),
-        join(targetDir, '.omk', '.gitignore'),
+        join(layout.root, '.gitignore'),
       ];
       const existingFiles = scaffoldFiles
         .filter((path) => existsSync(path))

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -121,11 +121,18 @@ export default class Init extends BaseCommand {
     lang: LANG_FLAG,
     samples: Flags.string({
       description: bilingual({
-        zh: '官方人工策划用例数量：3 条用于快速跑通，20 条用于达到注册样本量下限',
-        en: 'Number of first-party curated samples: 3 for a quick run, 20 to meet the registered sample-size floor',
+        zh: '官方起步用例数量：3 条用于快速跑通，20 条用于达到注册样本量下限',
+        en: 'Number of first-party starter samples: 3 for a quick run, 20 to meet the registered sample-size floor',
       }),
       options: [String(DEFAULT_INIT_SAMPLE_COUNT), String(FULL_INIT_SAMPLE_COUNT)],
       default: String(DEFAULT_INIT_SAMPLE_COUNT),
+    }),
+    force: Flags.boolean({
+      description: bilingual({
+        zh: '允许覆盖目标目录中已有的 omk 脚手架文件',
+        en: 'Allow overwriting existing project scaffold files in the target directory',
+      }),
+      default: false,
     }),
   };
 
@@ -138,7 +145,19 @@ export default class Init extends BaseCommand {
       const sampleCount = flags.samples === String(FULL_INIT_SAMPLE_COUNT)
         ? FULL_INIT_SAMPLE_COUNT
         : DEFAULT_INIT_SAMPLE_COUNT;
-      const { writeFileSync, mkdirSync } = await import('node:fs');
+      const { existsSync, writeFileSync, mkdirSync } = await import('node:fs');
+      const scaffoldFiles = [
+        join(targetDir, 'eval-samples.json'),
+        join(targetDir, 'skills', 'code-review-v1', 'SKILL.md'),
+        join(targetDir, 'skills', 'code-review-v2', 'SKILL.md'),
+        join(targetDir, '.omk', '.gitignore'),
+      ];
+      const existingFiles = scaffoldFiles
+        .filter((path) => existsSync(path))
+        .map((path) => relative(targetDir, path));
+      if (existingFiles.length > 0 && !flags.force) {
+        throw new Error(tCli('cli.init.existing_files', lang, { paths: existingFiles.join(', ') }));
+      }
 
       // omk skill loader 把 `skills/<name>/SKILL.md` 子目录识别为 directory-skill,
       // cwd 默认锚到 skill 根目录,后续可在同目录下放 assets / 子文档。

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,10 +1,15 @@
 import { resolve, join, relative, sep } from 'node:path';
-import { Args } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 import { LANG_FLAG, bilingual, resolveLang } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
 import { tCli } from '../lib/i18n.js';
 import { shellQuoteArg } from '../../shared/shell-quote.js';
 import { projectLayout } from '../../omk-layout/index.js';
+import {
+  DEFAULT_INIT_SAMPLE_COUNT,
+  FULL_INIT_SAMPLE_COUNT,
+  serializeInitSamples,
+} from '../templates/init-samples.js';
 
 // 预置 .omk/.gitignore:测量 bulk + doctor --fix 备份(项目本地、不该入库)默认不入库;
 // managed/ 治理档案 + 配置不在此列,默认 track。
@@ -14,62 +19,6 @@ const INIT_OMK_GITIGNORE = `# omk 测量 bulk 与 doctor --fix 备份（项目�
 /observe/
 /backups/
 /state/
-`;
-
-// 脚手架用例必须过 omk 自身的断言合规校验(load-samples.ts Rule A),否则新用户照
-// 快速开始跑的第一条 omk eval 会直接硬报错。约束:contains / not_contains 的 value
-// 只能是单个 ASCII token(长度 [2,40]、无内部空白、无 CJK);多词 / 中文语义匹配一律
-// 走 rubric 交评委判;regex pattern 不能含 CJK。改这里前先跑 `omk eval --dry-run`
-// (非 lenient 合规 oracle)与 test/cli/init-scaffold-conformance 回归测试。
-const INIT_SAMPLES = `{
-  "schemaVersion": "omk.eval-sample-set/v1",
-  "samples": [
-  {
-    "sample_id": "s001",
-    "prompt": "审查以下代码",
-    "context": "function authenticate(username, password) {\\n  const query = \`SELECT * FROM users WHERE name='\${username}' AND pass='\${password}'\`;\\n  return db.execute(query);\\n}",
-    "rubric": "应识别 SQL 注入风险，建议使用参数化查询；不应把这段代码判为安全无问题。",
-    "assertions": [
-      { "type": "contains", "value": "SQL", "weight": 1 },
-      { "type": "contains", "value": "injection", "weight": 1 },
-      { "type": "regex", "pattern": "parameterized|prepared|placeholder|bind", "flags": "i", "weight": 0.5 }
-    ],
-    "dimensions": {
-      "security": "是否准确识别出 SQL 注入漏洞并说明其危害",
-      "actionability": "是否给出可直接使用的参数化查询修复代码"
-    }
-  },
-  {
-    "sample_id": "s002",
-    "prompt": "审查以下代码",
-    "context": "async function fetchData(url) {\\n  const res = await fetch(url);\\n  const data = await res.json();\\n  return data;\\n}",
-    "rubric": "应指出缺少错误处理（网络异常、非 JSON 响应、HTTP 错误状态码）",
-    "assertions": [
-      { "type": "regex", "pattern": "try[\\\\s\\\\S]*catch|catch|exception|error", "flags": "i", "weight": 1 },
-      { "type": "contains", "value": "status", "weight": 0.5 }
-    ],
-    "dimensions": {
-      "robustness": "是否指出了所有缺失的错误处理场景",
-      "actionability": "是否给出了完整的 try-catch 修复代码"
-    }
-  },
-  {
-    "sample_id": "s003",
-    "prompt": "审查以下代码",
-    "context": "function renderComment(comment) {\\n  document.getElementById('output').innerHTML = '<p>' + comment + '</p>';\\n}",
-    "rubric": "应识别 XSS 风险，建议使用 textContent 或转义 HTML",
-    "assertions": [
-      { "type": "contains", "value": "XSS", "weight": 1 },
-      { "type": "regex", "pattern": "textContent|escape|sanitize|sanitizer", "flags": "i", "weight": 1 },
-      { "type": "contains", "value": "innerHTML", "weight": 0.5 }
-    ],
-    "dimensions": {
-      "security": "是否准确识别出 XSS 漏洞并说明攻击方式",
-      "actionability": "是否给出使用 textContent 或转义的修复代码"
-    }
-  }
-  ]
-}
 `;
 
 // 模板带 Claude Code SKILL.md 兼容 frontmatter(name + description),让用户
@@ -137,6 +86,13 @@ export default class Init extends BaseCommand {
       }),
       command: '<%= config.bin %> init my-project',
     },
+    {
+      description: bilingual({
+        zh: '使用达到注册样本量下限的 20 条官方用例初始化',
+        en: 'Initialize with the 20 first-party samples that meet the registered sample-size floor',
+      }),
+      command: '<%= config.bin %> init my-project --samples 20',
+    },
   ];
 
   static args = {
@@ -163,21 +119,32 @@ export default class Init extends BaseCommand {
 
   static flags = {
     lang: LANG_FLAG,
+    samples: Flags.string({
+      description: bilingual({
+        zh: '官方人工策划用例数量：3 条用于快速跑通，20 条用于达到注册样本量下限',
+        en: 'Number of first-party curated samples: 3 for a quick run, 20 to meet the registered sample-size floor',
+      }),
+      options: [String(DEFAULT_INIT_SAMPLE_COUNT), String(FULL_INIT_SAMPLE_COUNT)],
+      default: String(DEFAULT_INIT_SAMPLE_COUNT),
+    }),
   };
 
   async run(): Promise<void> {
-    const { args } = await this.parse(Init);
+    const { args, flags } = await this.parse(Init);
     const lang = this.lang;
     await this.runWithCliExit(async () => {
       const targetDir: string = resolve(args.targetDir || '.');
       const layout = projectLayout(targetDir);
+      const sampleCount = flags.samples === String(FULL_INIT_SAMPLE_COUNT)
+        ? FULL_INIT_SAMPLE_COUNT
+        : DEFAULT_INIT_SAMPLE_COUNT;
       const { writeFileSync, mkdirSync } = await import('node:fs');
 
       // omk skill loader 把 `skills/<name>/SKILL.md` 子目录识别为 directory-skill,
       // cwd 默认锚到 skill 根目录,后续可在同目录下放 assets / 子文档。
       mkdirSync(join(targetDir, 'skills', 'code-review-v1'), { recursive: true });
       mkdirSync(join(targetDir, 'skills', 'code-review-v2'), { recursive: true });
-      writeFileSync(join(targetDir, 'eval-samples.json'), INIT_SAMPLES);
+      writeFileSync(join(targetDir, 'eval-samples.json'), serializeInitSamples(sampleCount));
       writeFileSync(join(targetDir, 'skills', 'code-review-v1', 'SKILL.md'), INIT_SKILL_V1);
       writeFileSync(join(targetDir, 'skills', 'code-review-v2', 'SKILL.md'), INIT_SKILL_V2);
       // 像 dvc init 那样预置忽略规则,开发者不会误把测量 bulk 提交进库。
@@ -185,11 +152,17 @@ export default class Init extends BaseCommand {
       writeFileSync(join(layout.root, '.gitignore'), INIT_OMK_GITIGNORE);
 
       console.log(tCli('cli.init.scaffolded', lang, { dir: targetDir }));
+      console.log(tCli('cli.init.sample_pack', lang, { count: sampleCount }));
       console.log('');
       console.log(tCli('cli.init.next_steps_title', lang));
       console.log(tCli('cli.init.next_step_run', lang, { command: nextEvalCommand(targetDir) }));
       console.log(tCli('cli.init.next_step_executor', lang));
-      console.log(tCli('cli.init.next_step_report', lang));
+      console.log(tCli(
+        sampleCount === FULL_INIT_SAMPLE_COUNT
+          ? 'cli.init.next_step_report_full'
+          : 'cli.init.next_step_report_quick',
+        lang,
+      ));
       console.log(tCli('cli.init.next_step_customize', lang));
       console.log(tCli('cli.init.note_skill_injection', lang));
     });

--- a/src/cli/lib/i18n-dict/init.ts
+++ b/src/cli/lib/i18n-dict/init.ts
@@ -3,6 +3,7 @@ import type { CliMessage } from './types.js';
 export type InitMessageKey =
   | 'cli.init.scaffolded'
   | 'cli.init.sample_pack'
+  | 'cli.init.existing_files'
   | 'cli.init.next_steps_title'
   | 'cli.init.next_step_run'
   | 'cli.init.next_step_executor'
@@ -17,8 +18,12 @@ export const initDict: Record<InitMessageKey, CliMessage> = {
     en: 'omk project initialized at: {dir}',
   },
   'cli.init.sample_pack': {
-    zh: '已写入 {count} 条官方人工策划用例。',
-    en: 'Wrote {count} first-party curated samples.',
+    zh: '已写入 {count} 条官方起步用例。',
+    en: 'Wrote {count} first-party starter samples.',
+  },
+  'cli.init.existing_files': {
+    zh: '目标目录已有 omk 脚手架文件，已停止以避免覆盖：{paths}。请改用新的空目录，或确认要重建后显式传 --force。',
+    en: 'Existing project scaffold files would be overwritten: {paths}. Use a new empty directory, or pass --force only after confirming a rebuild.',
   },
   'cli.init.next_steps_title': {
     zh: '下一步：',
@@ -32,12 +37,12 @@ export const initDict: Record<InitMessageKey, CliMessage> = {
     en: '  1. Run it as-is (no edits needed): {command}',
   },
   'cli.init.next_step_report_quick': {
-    zh: '  2. 看报告里的 verdict 和“下一步”：3 条用例只用于跑通链路，出现 UNDERPOWERED 是预期结果；需要正式判断时使用 --samples 20 创建完整起步集。',
-    en: '  2. Read the report verdict and Next line: 3 samples only prove the workflow, so UNDERPOWERED is expected; use --samples 20 for the full starter set before making a real decision.',
+    zh: '  2. 看报告里的 verdict 和“下一步”：3 条用例只用于跑通链路，出现 UNDERPOWERED 是预期结果；需要完整起步集时，在新的空目录使用 --samples 20。',
+    en: '  2. Read the report verdict and Next line: 3 samples only prove the workflow, so UNDERPOWERED is expected; use --samples 20 in a new empty directory for the full starter set.',
   },
   'cli.init.next_step_report_full': {
-    zh: '  2. 看报告里的 verdict 和“下一步”：20 条用例达到注册样本量下限，但不保证得到 PROGRESS；仍需结合置信区间和失败样本判断。',
-    en: '  2. Read the report verdict and Next line: 20 samples meet the registered sample-size floor but do not guarantee PROGRESS; still inspect the confidence interval and failed samples.',
+    zh: '  2. 看报告里的 verdict 和“下一步”：20 条用例达到注册样本量下限，但来源是 llm-generated；用于理解统计流程，发布前应人工复核并替换为真实领域用例。',
+    en: '  2. Read the report verdict and Next line: 20 samples meet the registered sample-size floor but are llm-generated; use them to learn the statistical workflow, then review and replace them with real domain cases before release.',
   },
   'cli.init.next_step_executor': {
     zh: '     executor / judge 会按运行环境选择；Codex 任务自动使用本机 Codex 配置。也可用 OMK_EXECUTOR / OMK_MODEL 固定环境偏好，详见 https://oh-my-knowledge.pages.dev/zh/reference/executors。',

--- a/src/cli/lib/i18n-dict/init.ts
+++ b/src/cli/lib/i18n-dict/init.ts
@@ -2,10 +2,12 @@ import type { CliMessage } from './types.js';
 
 export type InitMessageKey =
   | 'cli.init.scaffolded'
+  | 'cli.init.sample_pack'
   | 'cli.init.next_steps_title'
   | 'cli.init.next_step_run'
   | 'cli.init.next_step_executor'
-  | 'cli.init.next_step_report'
+  | 'cli.init.next_step_report_quick'
+  | 'cli.init.next_step_report_full'
   | 'cli.init.next_step_customize'
   | 'cli.init.note_skill_injection';
 
@@ -13,6 +15,10 @@ export const initDict: Record<InitMessageKey, CliMessage> = {
   'cli.init.scaffolded': {
     zh: '已初始化 omk 项目：{dir}',
     en: 'omk project initialized at: {dir}',
+  },
+  'cli.init.sample_pack': {
+    zh: '已写入 {count} 条官方人工策划用例。',
+    en: 'Wrote {count} first-party curated samples.',
   },
   'cli.init.next_steps_title': {
     zh: '下一步：',
@@ -25,9 +31,13 @@ export const initDict: Record<InitMessageKey, CliMessage> = {
     zh: '  1. 直接跑通（无需先改任何文件）：{command}',
     en: '  1. Run it as-is (no edits needed): {command}',
   },
-  'cli.init.next_step_report': {
-    zh: '  2. 看报告里的 verdict 和“下一步”：PROGRESS 才能发布；UNDERPOWERED / NOISE 先扩样到约 20 条以上后重跑。',
-    en: '  2. Read the report verdict and Next line: PROGRESS can ship; UNDERPOWERED / NOISE means grow to roughly 20+ samples and re-run.',
+  'cli.init.next_step_report_quick': {
+    zh: '  2. 看报告里的 verdict 和“下一步”：3 条用例只用于跑通链路，出现 UNDERPOWERED 是预期结果；需要正式判断时使用 --samples 20 创建完整起步集。',
+    en: '  2. Read the report verdict and Next line: 3 samples only prove the workflow, so UNDERPOWERED is expected; use --samples 20 for the full starter set before making a real decision.',
+  },
+  'cli.init.next_step_report_full': {
+    zh: '  2. 看报告里的 verdict 和“下一步”：20 条用例达到注册样本量下限，但不保证得到 PROGRESS；仍需结合置信区间和失败样本判断。',
+    en: '  2. Read the report verdict and Next line: 20 samples meet the registered sample-size floor but do not guarantee PROGRESS; still inspect the confidence interval and failed samples.',
   },
   'cli.init.next_step_executor': {
     zh: '     executor / judge 会按运行环境选择；Codex 任务自动使用本机 Codex 配置。也可用 OMK_EXECUTOR / OMK_MODEL 固定环境偏好，详见 https://oh-my-knowledge.pages.dev/zh/reference/executors。',

--- a/src/cli/templates/init-samples.ts
+++ b/src/cli/templates/init-samples.ts
@@ -1,0 +1,360 @@
+import type { Sample } from '../../inputs/contracts/sample.js';
+import { createEvalSampleSetDocument } from '../../inputs/schemas/sample-set.js';
+
+export const DEFAULT_INIT_SAMPLE_COUNT = 3 as const;
+export const FULL_INIT_SAMPLE_COUNT = 20 as const;
+export type InitSampleCount = typeof DEFAULT_INIT_SAMPLE_COUNT | typeof FULL_INIT_SAMPLE_COUNT;
+
+/**
+ * `omk init` 的官方人工策划样本包。
+ *
+ * 前 3 条是低成本 quickstart；完整 20 条按 security／robustness／maintainability／performance
+ * 各 5 条分层，并保留 4 条无缺陷负例，避免把「多报问题」误当成更好的 code review。
+ */
+const INIT_CURATED_SAMPLES: Sample[] = [
+  {
+    sample_id: 's001',
+    prompt: '审查以下代码',
+    context: "function authenticate(username, password) {\n  const query = `SELECT * FROM users WHERE name='${username}' AND pass='${password}'`;\n  return db.execute(query);\n}",
+    rubric: '满分标准：必须识别 SQL 注入风险、说明攻击影响、给出参数化查询修复，并标注合理的严重程度。',
+    assertions: [
+      { type: 'contains', value: 'SQL', weight: 1 },
+      { type: 'contains', value: 'injection', weight: 1 },
+      { type: 'regex', pattern: 'parameterized|prepared|placeholder|bind', flags: 'i', weight: 0.5 },
+    ],
+    dimensions: {
+      security: '是否准确识别 SQL 注入漏洞并说明攻击影响',
+      actionability: '是否给出可直接采用的参数化查询修复',
+    },
+    capability: ['security-review'],
+    difficulty: 'easy',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's002',
+    prompt: '审查以下代码',
+    context: 'async function fetchData(url) {\n  const res = await fetch(url);\n  const data = await res.json();\n  return data;\n}',
+    rubric: '满分标准：必须覆盖网络异常、HTTP 错误状态和非 JSON 响应，并给出结构清晰的错误处理方案。',
+    assertions: [
+      { type: 'regex', pattern: 'try[\\s\\S]*catch|catch|exception|error', flags: 'i', weight: 1 },
+      { type: 'contains', value: 'status', weight: 0.5 },
+    ],
+    dimensions: {
+      robustness: '是否覆盖主要失败路径并区分错误来源',
+      actionability: '是否给出完整且不过度复杂的修复方案',
+    },
+    capability: ['robustness-review'],
+    difficulty: 'easy',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's003',
+    prompt: '审查以下代码',
+    context: "function renderComment(comment) {\n  document.getElementById('output').innerHTML = '<p>' + comment + '</p>';\n}",
+    rubric: '满分标准：必须识别 XSS 风险、解释不可信输入如何进入 HTML，并建议 textContent 或可靠转义。',
+    assertions: [
+      { type: 'contains', value: 'XSS', weight: 1 },
+      { type: 'regex', pattern: 'textContent|escape|sanitize|sanitizer', flags: 'i', weight: 1 },
+      { type: 'contains', value: 'innerHTML', weight: 0.5 },
+    ],
+    dimensions: {
+      security: '是否准确识别 XSS 漏洞及其数据流',
+      actionability: '是否给出安全且适配当前场景的渲染方式',
+    },
+    capability: ['security-review'],
+    difficulty: 'easy',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's004',
+    prompt: '审查以下代码',
+    context: "import { exec } from 'node:child_process';\n\nexport function archive(name) {\n  exec(`tar -czf ${name}.tgz uploads/${name}`);\n}",
+    rubric: '满分标准：必须识别命令注入和参数边界问题，说明 shell 拼接风险，并给出不经 shell 的参数化调用方案。',
+    assertions: [
+      { type: 'regex', pattern: 'command injection|shell injection', flags: 'i', weight: 1 },
+      { type: 'regex', pattern: 'execFile|spawn', flags: 'i', weight: 0.5 },
+    ],
+    dimensions: {
+      security: '是否识别出模板字符串进入 shell 的命令注入路径',
+      actionability: '是否使用参数数组和输入约束消除注入面',
+    },
+    capability: ['security-review'],
+    difficulty: 'medium',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's005',
+    prompt: '审查以下代码',
+    context: "import { readFile } from 'node:fs/promises';\nimport { join } from 'node:path';\n\nexport async function download(req) {\n  return readFile(join('/srv/files', req.query.name));\n}",
+    rubric: '满分标准：必须识别目录穿越风险，解释简单 join 不能建立目录边界，并给出规范化后校验根目录的修复。',
+    assertions: [
+      { type: 'regex', pattern: 'path traversal|directory traversal', flags: 'i', weight: 1 },
+      { type: 'regex', pattern: 'resolve|normalize|relative', flags: 'i', weight: 0.5 },
+    ],
+    dimensions: {
+      security: '是否识别编码、绝对路径和上级目录绕过风险',
+      actionability: '是否给出基于解析后路径的边界校验',
+    },
+    capability: ['security-review'],
+    difficulty: 'hard',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's006',
+    prompt: '审查以下代码',
+    context: "export async function findUser(db, email) {\n  return db.query('SELECT id, name FROM users WHERE email = ?', [email]);\n}",
+    rubric: '满分标准：应确认参数化查询已经隔离输入；可以提出有依据的次要建议，但不得虚构 SQL 注入漏洞。',
+    dimensions: {
+      precision: '是否避免把安全的参数化查询误报为注入漏洞',
+      reasoning: '是否区分确定缺陷、条件性风险和可选改进',
+    },
+    capability: ['security-review'],
+    difficulty: 'medium',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's007',
+    prompt: '审查以下代码',
+    context: 'function displayName(user) {\n  return user.profile.name.trim();\n}',
+    rubric: '满分标准：必须识别空值链路导致的运行时异常，说明哪些对象可能缺失，并给出契合业务语义的防御方案。',
+    assertions: [
+      { type: 'regex', pattern: 'null|undefined|optional|guard', flags: 'i', weight: 1 },
+    ],
+    dimensions: {
+      robustness: '是否完整定位 user、profile、name 的空值边界',
+      actionability: '是否给出默认值、显式校验或可选链的合理选择',
+    },
+    capability: ['robustness-review'],
+    difficulty: 'easy',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's008',
+    prompt: '审查以下代码',
+    context: "export function loadConfig(raw) {\n  const config = JSON.parse(raw);\n  return config.database.host.toLowerCase();\n}",
+    rubric: '满分标准：必须区分 JSON 语法错误与结构不符合预期两类失败，并建议在使用前进行清晰的 schema 校验。',
+    assertions: [
+      { type: 'contains', value: 'JSON.parse', weight: 0.5 },
+      { type: 'regex', pattern: 'schema|validate|validation', flags: 'i', weight: 1 },
+    ],
+    dimensions: {
+      robustness: '是否覆盖解析失败和解析成功但结构错误两类路径',
+      actionability: '是否提供可定位字段问题的校验与错误信息',
+    },
+    capability: ['robustness-review'],
+    difficulty: 'medium',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's009',
+    prompt: '审查以下代码',
+    context: 'export async function getProfile(id) {\n  for (;;) {\n    try {\n      return await fetch(`/profiles/${id}`).then(r => r.json());\n    } catch {}\n  }\n}',
+    rubric: '满分标准：必须识别无限重试、吞掉错误、缺少超时与退避等问题，并给出有上限且可取消的重试策略。',
+    assertions: [
+      { type: 'regex', pattern: 'timeout|AbortController|cancel', flags: 'i', weight: 0.5 },
+      { type: 'regex', pattern: 'backoff|retry limit|max retries', flags: 'i', weight: 1 },
+    ],
+    dimensions: {
+      robustness: '是否覆盖无限循环、错误可观测性和服务放大效应',
+      actionability: '是否给出上限、退避、超时和取消的完整策略',
+    },
+    capability: ['robustness-review'],
+    difficulty: 'hard',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's010',
+    prompt: '审查以下代码',
+    context: "export async function loadUser(id, signal) {\n  const res = await fetch(`/users/${encodeURIComponent(id)}`, { signal });\n  if (!res.ok) throw new Error(`HTTP ${res.status}`);\n  return await res.json();\n}",
+    rubric: '满分标准：应认可现有编码、取消和状态检查；可指出 JSON 契约校验是条件性增强，但不得声称完全缺少错误处理。',
+    dimensions: {
+      precision: '是否避免否定代码已经具备的健壮性措施',
+      reasoning: '是否把确定事实与依赖业务上下文的增强建议分开',
+    },
+    capability: ['robustness-review'],
+    difficulty: 'medium',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's011',
+    prompt: '审查以下代码',
+    context: 'function shippingFee(weight) {\n  if (weight > 30) return 999;\n  return weight * 7.35 + 12;\n}',
+    rubric: '满分标准：必须指出业务魔数和单位不透明造成的维护风险，并建议用有领域含义的常量或配置表达规则。',
+    assertions: [
+      { type: 'regex', pattern: 'magic number|constant|configuration', flags: 'i', weight: 1 },
+    ],
+    dimensions: {
+      maintainability: '是否解释 30、999、7.35、12 的语义和变更风险',
+      actionability: '是否给出命名、单位和规则归位的具体方案',
+    },
+    capability: ['maintainability-review'],
+    difficulty: 'easy',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's012',
+    prompt: '审查以下代码',
+    context: "function createUser(input) {\n  if (!input.email.includes('@')) throw new Error('bad email');\n  return db.users.insert(input);\n}\nfunction updateUser(input) {\n  if (!input.email.includes('@')) throw new Error('bad email');\n  return db.users.update(input);\n}",
+    rubric: '满分标准：必须识别重复且薄弱的校验逻辑，说明规则漂移风险，并建议抽取单一、可测试的验证边界。',
+    assertions: [
+      { type: 'regex', pattern: 'duplicate|shared|extract|validator', flags: 'i', weight: 1 },
+    ],
+    dimensions: {
+      maintainability: '是否识别重复逻辑与未来规则不一致的风险',
+      actionability: '是否提出职责清晰、易测试且不过度抽象的重构',
+    },
+    capability: ['maintainability-review'],
+    difficulty: 'medium',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's013',
+    prompt: '审查以下代码',
+    context: "export async function completeOrder(order, user) {\n  if (!user.admin && user.id !== order.userId) throw new Error('forbidden');\n  order.status = 'complete';\n  await db.orders.save(order);\n  await mail.send(user.email, renderReceipt(order));\n  metrics.increment('orders.complete');\n  return JSON.stringify(order);\n}",
+    rubric: '满分标准：必须识别授权、状态变更、持久化、通知、指标和序列化混在单函数中的耦合，并提出保留事务语义的拆分。',
+    assertions: [
+      { type: 'regex', pattern: 'single responsibility|separation|transaction|coupling', flags: 'i', weight: 1 },
+    ],
+    dimensions: {
+      maintainability: '是否识别职责耦合以及失败时产生的部分完成状态',
+      actionability: '是否在拆分职责的同时保留事务和副作用顺序',
+    },
+    capability: ['maintainability-review'],
+    difficulty: 'hard',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's014',
+    prompt: '审查以下代码',
+    context: 'function renderReport(data, compact, includeHeader, sortDescending, useUtc) {\n  // formatting logic\n}',
+    rubric: '满分标准：必须指出多个布尔位置参数难以理解和扩展，并建议使用命名 options 对象及合理默认值。',
+    assertions: [
+      { type: 'regex', pattern: 'options object|named parameter|configuration object', flags: 'i', weight: 1 },
+    ],
+    dimensions: {
+      maintainability: '是否解释调用点可读性和新增选项时的演进问题',
+      actionability: '是否给出类型明确且可兼容默认值的参数设计',
+    },
+    capability: ['maintainability-review'],
+    difficulty: 'medium',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's015',
+    prompt: '审查以下代码',
+    context: 'export function clamp(value, min, max) {\n  return Math.min(max, Math.max(min, value));\n}',
+    rubric: '满分标准：应认可实现对普通数值输入足够简洁；可以询问 min 大于 max 或 NaN 的业务约定，但不得强行引入复杂架构。',
+    dimensions: {
+      precision: '是否避免为了展示审查深度而虚构维护性问题',
+      proportionality: '建议的复杂度是否与这个小型纯函数相称',
+    },
+    capability: ['maintainability-review'],
+    difficulty: 'easy',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's016',
+    prompt: '审查以下代码',
+    context: 'export async function listOrders(users) {\n  const rows = [];\n  for (const user of users) {\n    rows.push(...await db.orders.findByUser(user.id));\n  }\n  return rows;\n}',
+    rubric: '满分标准：必须识别循环内逐用户查询形成的 N+1 和串行等待，并建议批量查询或有边界的并发方案。',
+    assertions: [
+      { type: 'contains', value: 'N+1', weight: 1 },
+      { type: 'regex', pattern: 'batch|IN query|Promise.all', flags: 'i', weight: 0.5 },
+    ],
+    dimensions: {
+      performance: '是否识别查询次数和串行延迟随用户数增长的问题',
+      actionability: '是否给出符合数据库边界的批量读取方案',
+    },
+    capability: ['performance-review'],
+    difficulty: 'easy',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's017',
+    prompt: '审查以下代码',
+    context: 'export async function hydrate(ids) {\n  const result = [];\n  for (const id of ids) {\n    result.push(await fetch(`/items/${id}`).then(r => r.json()));\n  }\n  return result;\n}',
+    rubric: '满分标准：必须指出无依赖请求被串行化的延迟问题，同时说明无限 Promise.all 的压力，并给出受控并发方案。',
+    assertions: [
+      { type: 'contains', value: 'Promise.all', weight: 0.5 },
+      { type: 'regex', pattern: 'concurrency|limit|pool|batch', flags: 'i', weight: 1 },
+    ],
+    dimensions: {
+      performance: '是否同时看见串行瓶颈和无界并发的反向风险',
+      actionability: '是否给出可调并发度、错误策略和顺序语义',
+    },
+    capability: ['performance-review'],
+    difficulty: 'medium',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's018',
+    prompt: '审查以下代码',
+    context: 'function commonIds(left, right) {\n  return left.filter(item => right.some(other => other.id === item.id));\n}',
+    rubric: '满分标准：必须识别双层扫描的时间复杂度，说明数据规模前提，并建议用 Set 或 Map 建立线性查找索引。',
+    assertions: [
+      { type: 'regex', pattern: 'O\\(n\\s*\\*\\s*m\\)|quadratic|nested', flags: 'i', weight: 1 },
+      { type: 'regex', pattern: 'Set|Map', weight: 0.5 },
+    ],
+    dimensions: {
+      performance: '是否准确分析时间复杂度而不是泛泛声称性能差',
+      actionability: '是否根据唯一性和内存取舍选择合适索引结构',
+    },
+    capability: ['performance-review'],
+    difficulty: 'hard',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's019',
+    prompt: '审查以下代码',
+    context: 'const cache = new Map();\nexport async function resolveTenant(id) {\n  if (!cache.has(id)) cache.set(id, await loadTenant(id));\n  return cache.get(id);\n}',
+    rubric: '满分标准：必须识别多租户键空间下缓存无限增长和并发重复加载风险，并给出容量、淘汰与请求合并策略。',
+    assertions: [
+      { type: 'regex', pattern: 'evict|TTL|max size|bounded|LRU', flags: 'i', weight: 1 },
+      { type: 'regex', pattern: 'race|duplicate|in-flight|promise', flags: 'i', weight: 0.5 },
+    ],
+    dimensions: {
+      performance: '是否覆盖内存增长与并发 cache miss 两个独立问题',
+      actionability: '是否给出与数据新鲜度和容量约束匹配的缓存策略',
+    },
+    capability: ['performance-review'],
+    difficulty: 'hard',
+    construct: 'quality',
+    provenance: 'human',
+  },
+  {
+    sample_id: 's020',
+    prompt: '审查以下代码',
+    context: 'export function indexById(items) {\n  const index = new Map();\n  for (const item of items) index.set(item.id, item);\n  return index;\n}',
+    rubric: '满分标准：应认可这是清晰的线性构建过程；可以说明重复 id 的覆盖语义，但不得虚构嵌套循环或明显性能瓶颈。',
+    dimensions: {
+      precision: '是否避免把正常的 O(n) 工作误报为性能缺陷',
+      reasoning: '是否把重复键语义作为条件性业务问题而非确定 bug',
+    },
+    capability: ['performance-review'],
+    difficulty: 'medium',
+    construct: 'quality',
+    provenance: 'human',
+  },
+];
+
+export function serializeInitSamples(count: InitSampleCount): string {
+  return `${JSON.stringify(createEvalSampleSetDocument(INIT_CURATED_SAMPLES.slice(0, count)), null, 2)}\n`;
+}

--- a/src/cli/templates/init-samples.ts
+++ b/src/cli/templates/init-samples.ts
@@ -6,7 +6,7 @@ export const FULL_INIT_SAMPLE_COUNT = 20 as const;
 export type InitSampleCount = typeof DEFAULT_INIT_SAMPLE_COUNT | typeof FULL_INIT_SAMPLE_COUNT;
 
 /**
- * `omk init` 的官方人工策划样本包。
+ * `omk init` 的官方分层起步样本包。
  *
  * 前 3 条是低成本 quickstart；完整 20 条按 security／robustness／maintainability／performance
  * 各 5 条分层，并保留 4 条无缺陷负例，避免把「多报问题」误当成更好的 code review。
@@ -19,8 +19,6 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     rubric: '满分标准：必须识别 SQL 注入风险、说明攻击影响、给出参数化查询修复，并标注合理的严重程度。',
     assertions: [
       { type: 'contains', value: 'SQL', weight: 1 },
-      { type: 'contains', value: 'injection', weight: 1 },
-      { type: 'regex', pattern: 'parameterized|prepared|placeholder|bind', flags: 'i', weight: 0.5 },
     ],
     dimensions: {
       security: '是否准确识别 SQL 注入漏洞并说明攻击影响',
@@ -29,7 +27,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['security-review'],
     difficulty: 'easy',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's002',
@@ -37,8 +35,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     context: 'async function fetchData(url) {\n  const res = await fetch(url);\n  const data = await res.json();\n  return data;\n}',
     rubric: '满分标准：必须覆盖网络异常、HTTP 错误状态和非 JSON 响应，并给出结构清晰的错误处理方案。',
     assertions: [
-      { type: 'regex', pattern: 'try[\\s\\S]*catch|catch|exception|error', flags: 'i', weight: 1 },
-      { type: 'contains', value: 'status', weight: 0.5 },
+      { type: 'regex', pattern: 'try[\\s\\S]*catch|res\\.ok|status', flags: 'i', weight: 1 },
     ],
     dimensions: {
       robustness: '是否覆盖主要失败路径并区分错误来源',
@@ -47,7 +44,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['robustness-review'],
     difficulty: 'easy',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's003',
@@ -56,7 +53,6 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     rubric: '满分标准：必须识别 XSS 风险、解释不可信输入如何进入 HTML，并建议 textContent 或可靠转义。',
     assertions: [
       { type: 'contains', value: 'XSS', weight: 1 },
-      { type: 'regex', pattern: 'textContent|escape|sanitize|sanitizer', flags: 'i', weight: 1 },
       { type: 'contains', value: 'innerHTML', weight: 0.5 },
     ],
     dimensions: {
@@ -66,7 +62,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['security-review'],
     difficulty: 'easy',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's004',
@@ -74,8 +70,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     context: "import { exec } from 'node:child_process';\n\nexport function archive(name) {\n  exec(`tar -czf ${name}.tgz uploads/${name}`);\n}",
     rubric: '满分标准：必须识别命令注入和参数边界问题，说明 shell 拼接风险，并给出不经 shell 的参数化调用方案。',
     assertions: [
-      { type: 'regex', pattern: 'command injection|shell injection', flags: 'i', weight: 1 },
-      { type: 'regex', pattern: 'execFile|spawn', flags: 'i', weight: 0.5 },
+      { type: 'regex', pattern: 'execFile|spawn', flags: 'i', weight: 1 },
     ],
     dimensions: {
       security: '是否识别出模板字符串进入 shell 的命令注入路径',
@@ -84,7 +79,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['security-review'],
     difficulty: 'medium',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's005',
@@ -92,8 +87,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     context: "import { readFile } from 'node:fs/promises';\nimport { join } from 'node:path';\n\nexport async function download(req) {\n  return readFile(join('/srv/files', req.query.name));\n}",
     rubric: '满分标准：必须识别目录穿越风险，解释简单 join 不能建立目录边界，并给出规范化后校验根目录的修复。',
     assertions: [
-      { type: 'regex', pattern: 'path traversal|directory traversal', flags: 'i', weight: 1 },
-      { type: 'regex', pattern: 'resolve|normalize|relative', flags: 'i', weight: 0.5 },
+      { type: 'regex', pattern: 'resolve|normalize|relative', flags: 'i', weight: 1 },
     ],
     dimensions: {
       security: '是否识别编码、绝对路径和上级目录绕过风险',
@@ -102,7 +96,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['security-review'],
     difficulty: 'hard',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's006',
@@ -116,16 +110,13 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['security-review'],
     difficulty: 'medium',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's007',
     prompt: '审查以下代码',
     context: 'function displayName(user) {\n  return user.profile.name.trim();\n}',
     rubric: '满分标准：必须识别空值链路导致的运行时异常，说明哪些对象可能缺失，并给出契合业务语义的防御方案。',
-    assertions: [
-      { type: 'regex', pattern: 'null|undefined|optional|guard', flags: 'i', weight: 1 },
-    ],
     dimensions: {
       robustness: '是否完整定位 user、profile、name 的空值边界',
       actionability: '是否给出默认值、显式校验或可选链的合理选择',
@@ -133,7 +124,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['robustness-review'],
     difficulty: 'easy',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's008',
@@ -141,8 +132,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     context: "export function loadConfig(raw) {\n  const config = JSON.parse(raw);\n  return config.database.host.toLowerCase();\n}",
     rubric: '满分标准：必须区分 JSON 语法错误与结构不符合预期两类失败，并建议在使用前进行清晰的 schema 校验。',
     assertions: [
-      { type: 'contains', value: 'JSON.parse', weight: 0.5 },
-      { type: 'regex', pattern: 'schema|validate|validation', flags: 'i', weight: 1 },
+      { type: 'contains', value: 'JSON.parse', weight: 1 },
     ],
     dimensions: {
       robustness: '是否覆盖解析失败和解析成功但结构错误两类路径',
@@ -151,7 +141,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['robustness-review'],
     difficulty: 'medium',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's009',
@@ -159,8 +149,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     context: 'export async function getProfile(id) {\n  for (;;) {\n    try {\n      return await fetch(`/profiles/${id}`).then(r => r.json());\n    } catch {}\n  }\n}',
     rubric: '满分标准：必须识别无限重试、吞掉错误、缺少超时与退避等问题，并给出有上限且可取消的重试策略。',
     assertions: [
-      { type: 'regex', pattern: 'timeout|AbortController|cancel', flags: 'i', weight: 0.5 },
-      { type: 'regex', pattern: 'backoff|retry limit|max retries', flags: 'i', weight: 1 },
+      { type: 'contains', value: 'AbortController', weight: 1 },
     ],
     dimensions: {
       robustness: '是否覆盖无限循环、错误可观测性和服务放大效应',
@@ -169,7 +158,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['robustness-review'],
     difficulty: 'hard',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's010',
@@ -183,16 +172,13 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['robustness-review'],
     difficulty: 'medium',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's011',
     prompt: '审查以下代码',
     context: 'function shippingFee(weight) {\n  if (weight > 30) return 999;\n  return weight * 7.35 + 12;\n}',
     rubric: '满分标准：必须指出业务魔数和单位不透明造成的维护风险，并建议用有领域含义的常量或配置表达规则。',
-    assertions: [
-      { type: 'regex', pattern: 'magic number|constant|configuration', flags: 'i', weight: 1 },
-    ],
     dimensions: {
       maintainability: '是否解释 30、999、7.35、12 的语义和变更风险',
       actionability: '是否给出命名、单位和规则归位的具体方案',
@@ -200,16 +186,13 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['maintainability-review'],
     difficulty: 'easy',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's012',
     prompt: '审查以下代码',
     context: "function createUser(input) {\n  if (!input.email.includes('@')) throw new Error('bad email');\n  return db.users.insert(input);\n}\nfunction updateUser(input) {\n  if (!input.email.includes('@')) throw new Error('bad email');\n  return db.users.update(input);\n}",
     rubric: '满分标准：必须识别重复且薄弱的校验逻辑，说明规则漂移风险，并建议抽取单一、可测试的验证边界。',
-    assertions: [
-      { type: 'regex', pattern: 'duplicate|shared|extract|validator', flags: 'i', weight: 1 },
-    ],
     dimensions: {
       maintainability: '是否识别重复逻辑与未来规则不一致的风险',
       actionability: '是否提出职责清晰、易测试且不过度抽象的重构',
@@ -217,16 +200,13 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['maintainability-review'],
     difficulty: 'medium',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's013',
     prompt: '审查以下代码',
     context: "export async function completeOrder(order, user) {\n  if (!user.admin && user.id !== order.userId) throw new Error('forbidden');\n  order.status = 'complete';\n  await db.orders.save(order);\n  await mail.send(user.email, renderReceipt(order));\n  metrics.increment('orders.complete');\n  return JSON.stringify(order);\n}",
     rubric: '满分标准：必须识别授权、状态变更、持久化、通知、指标和序列化混在单函数中的耦合，并提出保留事务语义的拆分。',
-    assertions: [
-      { type: 'regex', pattern: 'single responsibility|separation|transaction|coupling', flags: 'i', weight: 1 },
-    ],
     dimensions: {
       maintainability: '是否识别职责耦合以及失败时产生的部分完成状态',
       actionability: '是否在拆分职责的同时保留事务和副作用顺序',
@@ -234,7 +214,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['maintainability-review'],
     difficulty: 'hard',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's014',
@@ -242,7 +222,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     context: 'function renderReport(data, compact, includeHeader, sortDescending, useUtc) {\n  // formatting logic\n}',
     rubric: '满分标准：必须指出多个布尔位置参数难以理解和扩展，并建议使用命名 options 对象及合理默认值。',
     assertions: [
-      { type: 'regex', pattern: 'options object|named parameter|configuration object', flags: 'i', weight: 1 },
+      { type: 'contains', value: 'options', weight: 1 },
     ],
     dimensions: {
       maintainability: '是否解释调用点可读性和新增选项时的演进问题',
@@ -251,7 +231,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['maintainability-review'],
     difficulty: 'medium',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's015',
@@ -265,7 +245,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['maintainability-review'],
     difficulty: 'easy',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's016',
@@ -274,7 +254,6 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     rubric: '满分标准：必须识别循环内逐用户查询形成的 N+1 和串行等待，并建议批量查询或有边界的并发方案。',
     assertions: [
       { type: 'contains', value: 'N+1', weight: 1 },
-      { type: 'regex', pattern: 'batch|IN query|Promise.all', flags: 'i', weight: 0.5 },
     ],
     dimensions: {
       performance: '是否识别查询次数和串行延迟随用户数增长的问题',
@@ -283,7 +262,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['performance-review'],
     difficulty: 'easy',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's017',
@@ -291,8 +270,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     context: 'export async function hydrate(ids) {\n  const result = [];\n  for (const id of ids) {\n    result.push(await fetch(`/items/${id}`).then(r => r.json()));\n  }\n  return result;\n}',
     rubric: '满分标准：必须指出无依赖请求被串行化的延迟问题，同时说明无限 Promise.all 的压力，并给出受控并发方案。',
     assertions: [
-      { type: 'contains', value: 'Promise.all', weight: 0.5 },
-      { type: 'regex', pattern: 'concurrency|limit|pool|batch', flags: 'i', weight: 1 },
+      { type: 'contains', value: 'Promise.all', weight: 1 },
     ],
     dimensions: {
       performance: '是否同时看见串行瓶颈和无界并发的反向风险',
@@ -301,7 +279,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['performance-review'],
     difficulty: 'medium',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's018',
@@ -309,8 +287,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     context: 'function commonIds(left, right) {\n  return left.filter(item => right.some(other => other.id === item.id));\n}',
     rubric: '满分标准：必须识别双层扫描的时间复杂度，说明数据规模前提，并建议用 Set 或 Map 建立线性查找索引。',
     assertions: [
-      { type: 'regex', pattern: 'O\\(n\\s*\\*\\s*m\\)|quadratic|nested', flags: 'i', weight: 1 },
-      { type: 'regex', pattern: 'Set|Map', weight: 0.5 },
+      { type: 'regex', pattern: 'Set|Map', weight: 1 },
     ],
     dimensions: {
       performance: '是否准确分析时间复杂度而不是泛泛声称性能差',
@@ -319,17 +296,13 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['performance-review'],
     difficulty: 'hard',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's019',
     prompt: '审查以下代码',
     context: 'const cache = new Map();\nexport async function resolveTenant(id) {\n  if (!cache.has(id)) cache.set(id, await loadTenant(id));\n  return cache.get(id);\n}',
     rubric: '满分标准：必须识别多租户键空间下缓存无限增长和并发重复加载风险，并给出容量、淘汰与请求合并策略。',
-    assertions: [
-      { type: 'regex', pattern: 'evict|TTL|max size|bounded|LRU', flags: 'i', weight: 1 },
-      { type: 'regex', pattern: 'race|duplicate|in-flight|promise', flags: 'i', weight: 0.5 },
-    ],
     dimensions: {
       performance: '是否覆盖内存增长与并发 cache miss 两个独立问题',
       actionability: '是否给出与数据新鲜度和容量约束匹配的缓存策略',
@@ -337,7 +310,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['performance-review'],
     difficulty: 'hard',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
   {
     sample_id: 's020',
@@ -351,7 +324,7 @@ const INIT_CURATED_SAMPLES: Sample[] = [
     capability: ['performance-review'],
     difficulty: 'medium',
     construct: 'quality',
-    provenance: 'human',
+    provenance: 'llm-generated',
   },
 ];
 

--- a/src/eval-workflows/production-host/node-cli-composition.ts
+++ b/src/eval-workflows/production-host/node-cli-composition.ts
@@ -44,6 +44,15 @@ const CREDENTIAL_ENVIRONMENT = new Set([
   'OPENAI_API_KEY',
 ]);
 
+const SECRET_TAINT_ENVIRONMENT = new Set([
+  'ALL_PROXY',
+  'HTTPS_PROXY',
+  'HTTP_PROXY',
+  'all_proxy',
+  'http_proxy',
+  'https_proxy',
+]);
+
 const EFFECT_LOCATOR_ENVIRONMENT = new Set([
   'ALL_PROXY',
   'CODEX_HOME',
@@ -119,7 +128,11 @@ export function classifyNodeCliEnvironment(
       : EFFECT_LOCATOR_ENVIRONMENT.has(key)
         ? { identityKind: 'effect-locator' }
         : { identityKind: 'behavior', value };
-    return [[key, Object.freeze({ value, identity })]];
+    return [[key, Object.freeze({
+      value,
+      identity,
+      ...(SECRET_TAINT_ENVIRONMENT.has(key) ? { outputTaint: 'secret' as const } : {}),
+    })]];
   })));
 }
 

--- a/src/eval-workflows/production-host/node-cli-composition.ts
+++ b/src/eval-workflows/production-host/node-cli-composition.ts
@@ -45,13 +45,26 @@ const CREDENTIAL_ENVIRONMENT = new Set([
 ]);
 
 const EFFECT_LOCATOR_ENVIRONMENT = new Set([
+  'ALL_PROXY',
   'CODEX_HOME',
+  'CURL_CA_BUNDLE',
   'HOME',
+  'HTTPS_PROXY',
+  'HTTP_PROXY',
+  'NODE_EXTRA_CA_CERTS',
+  'NO_PROXY',
   'PATH',
+  'REQUESTS_CA_BUNDLE',
+  'SSL_CERT_DIR',
+  'SSL_CERT_FILE',
   'TMPDIR',
   'XDG_CACHE_HOME',
   'XDG_CONFIG_HOME',
   'XDG_DATA_HOME',
+  'all_proxy',
+  'http_proxy',
+  'https_proxy',
+  'no_proxy',
 ]);
 
 const BEHAVIOR_ENVIRONMENT = new Set([
@@ -90,7 +103,7 @@ export class NodeCliProductionCompositionError extends Error {
   }
 }
 
-function classifiedEnvironment(
+export function classifyNodeCliEnvironment(
   environment: NodeJS.ProcessEnv,
 ): Readonly<Record<string, ClassifiedEnvironmentEntry>> {
   const keys = new Set([
@@ -328,7 +341,7 @@ async function executorConfiguration(
     environment,
     projectRoot,
   );
-  const capturedEnvironment = classifiedEnvironment(environment);
+  const capturedEnvironment = classifyNodeCliEnvironment(environment);
   switch (implementationId) {
     case 'codex':
       return Object.freeze({

--- a/src/eval-workflows/runtime-adapter/adapters/custom/command.ts
+++ b/src/eval-workflows/runtime-adapter/adapters/custom/command.ts
@@ -49,6 +49,11 @@ import {
   createSameProcessExecutorAdapter,
   type SameProcessOperationScope,
 } from '../shared/same-process.js';
+import {
+  captureClassifiedEnvironment,
+  mergeOutputClassification,
+  type ClassifiedEnvironmentEntry,
+} from '../shared/classified-environment.js';
 
 export const CUSTOM_COMMAND_EXCHANGE_SCHEMA_VERSION =
   'omk.custom-command-exchange/v1' as const;
@@ -239,13 +244,7 @@ export interface CustomCommandContentIdentityFile {
   readonly path: string;
 }
 
-export type CustomCommandEnvironmentEntry = {
-  readonly value: string;
-  readonly identity:
-    | { readonly identityKind: 'behavior'; readonly value: JsonValue }
-    | { readonly identityKind: 'credential' }
-    | { readonly identityKind: 'effect-locator' };
-};
+export type CustomCommandEnvironmentEntry = ClassifiedEnvironmentEntry;
 
 export interface CustomCommandConfiguration {
   /** Absolute executable path; PATH lookup and shell parsing are intentionally unsupported. */
@@ -283,6 +282,7 @@ const CustomCommandConfigurationSchema = z.object({
     z.string().min(1).refine((value) => !value.includes('\0')),
     z.object({
       value: z.string().refine((value) => !value.includes('\0')),
+      outputTaint: z.enum(['sensitive', 'secret']).optional(),
       identity: z.discriminatedUnion('identityKind', [
         z.object({
           identityKind: z.literal('behavior'),
@@ -308,6 +308,7 @@ interface CapturedConfiguration {
   readonly arguments: readonly string[];
   readonly environment: Readonly<Record<string, string>>;
   readonly environmentIdentity: JsonValue[];
+  readonly environmentOutputClassification: 'public' | 'sensitive' | 'secret';
   readonly maxOutputBytes: number;
 }
 
@@ -340,23 +341,13 @@ function captureConfiguration(input: Readonly<CustomCommandConfiguration>): Capt
     throw new TypeError('Custom-command executablePath must be absolute.');
   }
   const maxOutputBytes = parsed.maxOutputBytes ?? DEFAULT_CUSTOM_COMMAND_MAX_OUTPUT_BYTES;
-  const environmentEntries = Object.entries(parsed.environment ?? {}).sort(([left], [right]) => (
-    left < right ? -1 : left > right ? 1 : 0
-  ));
+  const environment = captureClassifiedEnvironment(parsed.environment);
   return Object.freeze({
     executablePath: parsed.executablePath,
     arguments: Object.freeze([...(parsed.arguments ?? [])]),
-    environment: Object.freeze(Object.fromEntries(environmentEntries.map(([key, entry]) => [
-      key,
-      entry.value,
-    ]))),
-    environmentIdentity: deepFreezeCanonicalJson(environmentEntries.map(([key, entry]) => ({
-      keyDigest: digestCanonicalJson(key),
-      identityKind: entry.identity.identityKind,
-      ...(entry.identity.identityKind === 'behavior'
-        ? { value: entry.identity.value }
-        : {}),
-    }))),
+    environment: environment.values,
+    environmentIdentity: environment.identity,
+    environmentOutputClassification: environment.outputClassification,
     maxOutputBytes,
   });
 }
@@ -955,8 +946,24 @@ export async function createCustomCommandExecutorAdapter(
         }
         const usage = reportedUsage(response.usage);
         return {
-          ...(response.output === undefined ? {} : { output: response.output as ExecutionContent }),
-          ...(response.trace === undefined ? {} : { trace: response.trace as ExecutionContent }),
+          ...(response.output === undefined ? {} : {
+            output: {
+              ...response.output,
+              classification: mergeOutputClassification(
+                response.output.classification,
+                configuration.environmentOutputClassification,
+              ),
+            } as ExecutionContent,
+          }),
+          ...(response.trace === undefined ? {} : {
+            trace: {
+              ...response.trace,
+              classification: mergeOutputClassification(
+                response.trace.classification,
+                configuration.environmentOutputClassification,
+              ),
+            } as ExecutionContent,
+          }),
           ...(usage === undefined ? {} : { usage }),
         };
       },

--- a/src/eval-workflows/runtime-adapter/adapters/shared/classified-environment.ts
+++ b/src/eval-workflows/runtime-adapter/adapters/shared/classified-environment.ts
@@ -8,6 +8,8 @@ import {
 
 export type ClassifiedEnvironmentEntry = {
   readonly value: string;
+  /** Raises output/trace handling independently from the value's Runtime identity role. */
+  readonly outputTaint?: 'sensitive' | 'secret';
   readonly identity:
     | { readonly identityKind: 'behavior'; readonly value: JsonValue }
     | { readonly identityKind: 'credential' }
@@ -32,6 +34,7 @@ const EnvironmentSchema = z.record(
   z.string().min(1).refine((value) => !value.includes('\0')),
   z.object({
     value: z.string().refine((value) => !value.includes('\0')),
+    outputTaint: z.enum(['sensitive', 'secret']).optional(),
     identity: z.discriminatedUnion('identityKind', [
       z.object({
         identityKind: z.literal('behavior'),
@@ -62,11 +65,18 @@ export function captureClassifiedEnvironment(
       ...(entry.identity.identityKind === 'effect-locator'
         ? { valueDigest: digestCanonicalJson(entry.value) }
         : {}),
+      ...(entry.outputTaint === undefined ? {} : { outputTaint: entry.outputTaint }),
     }))),
-    outputClassification: entries.some(([, entry]) => entry.identity.identityKind === 'credential')
-      ? 'secret'
-      : entries.some(([, entry]) => entry.identity.identityKind === 'effect-locator')
-        ? 'sensitive'
-        : 'public',
+    outputClassification: entries.reduce<'public' | 'sensitive' | 'secret'>((result, [, entry]) => (
+      mergeOutputClassification(
+        result,
+        entry.outputTaint
+          ?? (entry.identity.identityKind === 'credential'
+            ? 'secret'
+            : entry.identity.identityKind === 'effect-locator'
+              ? 'sensitive'
+              : 'public'),
+      )
+    ), 'public'),
   });
 }

--- a/test/cli/first-run-smoke.test.ts
+++ b/test/cli/first-run-smoke.test.ts
@@ -144,8 +144,8 @@ describe('first-run smoke path', () => {
         '--samples', '20',
         '--lang', 'en',
       ]);
-      assert.match(init.stdout, /Wrote 20 first-party curated samples/);
-      assert.match(init.stdout, /meet the registered sample-size floor/);
+      assert.match(init.stdout, /Wrote 20 first-party starter samples/);
+      assert.match(init.stdout, /are llm-generated/);
 
       const executor = join(
         PROJECT_ROOT,

--- a/test/cli/first-run-smoke.test.ts
+++ b/test/cli/first-run-smoke.test.ts
@@ -133,4 +133,48 @@ describe('first-run smoke path', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('plans the 20-sample curated pack without external executor dependencies', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omk-first-run-full-'));
+    const project = join(root, 'demo');
+    try {
+      const init = await execFileAsync('node', [
+        CLI,
+        'init', project,
+        '--samples', '20',
+        '--lang', 'en',
+      ]);
+      assert.match(init.stdout, /Wrote 20 first-party curated samples/);
+      assert.match(init.stdout, /meet the registered sample-size floor/);
+
+      const executor = join(
+        PROJECT_ROOT,
+        'test',
+        'fixtures',
+        'custom-executor',
+        'core-fixture-executor.sh',
+      );
+      const dryRun = await execFileAsync('node', [
+        CLI,
+        'eval',
+        '--control', 'code-review-v1',
+        '--treatment', 'code-review-v2',
+        '--executor', executor,
+        '--skip-connectivity',
+        '--skip-doctor',
+        '--dry-run',
+        '--lang', 'en',
+      ], { cwd: project });
+      const dryRunReport = parseFirstJsonObject(dryRun.stdout) as {
+        projectionKind?: string;
+        dataset?: { sampleCount?: number };
+        targets?: Array<{ targetId?: string }>;
+      };
+      assert.equal(dryRunReport.projectionKind, 'core-cli-dry-run');
+      assert.equal(dryRunReport.dataset?.sampleCount, 20);
+      assert.deepEqual(dryRunReport.targets?.map((target) => target.targetId), ['code-review-v1', 'code-review-v2']);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/cli/init-scaffold-conformance.test.ts
+++ b/test/cli/init-scaffold-conformance.test.ts
@@ -42,15 +42,16 @@ describe('omk init scaffold passes strict assertion conformance', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('scaffolded eval-samples.json loads without hard error in strict mode', () => {
-    execFileSync('node', [CLI, 'init', tmpDir], { stdio: 'pipe' });
-    const samplesPath = join(tmpDir, 'eval-samples.json');
+  for (const sampleCount of [3, 20]) {
+    it(`${sampleCount} 条 scaffolded eval-samples.json 在 strict mode 下合规`, () => {
+      execFileSync('node', [CLI, 'init', tmpDir, '--samples', String(sampleCount)], { stdio: 'pipe' });
+      const samplesPath = join(tmpDir, 'eval-samples.json');
 
-    withStrictAssertions(() => {
-      // 不抛即为合规:用户照快速开始跑的第一条 omk eval 不会在这里硬报错。
-      const result = loadSamples(samplesPath);
-      // sanity:确认校验确实跑在非空用例上(空数组会 vacuously 通过,起不到守护作用)。
-      assert.ok(result.samples.length >= 3, `expected ≥3 scaffolded samples, got ${result.samples.length}`);
+      withStrictAssertions(() => {
+        // 不抛即为合规：用户照快速开始跑的第一条 omk eval 不会在这里硬报错。
+        const result = loadSamples(samplesPath);
+        assert.equal(result.samples.length, sampleCount);
+      });
     });
-  });
+  }
 });

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -8,6 +8,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import InitCommand from '../../src/cli/commands/init.js';
+import { loadSamples } from '../../src/inputs/load-samples.js';
 import { renderCommandHelp, runCommand } from '../helpers/run-command.js';
 
 interface ExecError extends Error {
@@ -22,6 +23,9 @@ describe('oclif init', () => {
     const stdout = await renderCommandHelp('init');
     assert.ok(stdout.includes('初始化一个 omk 项目'), `stdout missing zh description:\n${stdout}`);
     assert.ok(stdout.includes('TARGETDIR'), 'stdout missing positional');
+    assert.ok(stdout.includes('--samples'), 'stdout should document the curated sample-count option');
+    assert.ok(stdout.includes('3 条用于快速跑通'), `stdout should explain the quick pack:\n${stdout}`);
+    assert.match(stdout, /20\s+条用于达到注册样本量下限/, `stdout should explain the full pack:\n${stdout}`);
   });
 
   it('--help --lang en', async () => {
@@ -40,7 +44,8 @@ describe('oclif init', () => {
         `stdout should include a copy/paste command that enters the target dir first:\n${stdout}`,
       );
       assert.ok(stdout.includes('UNDERPOWERED'), `stdout should set first-run expectation:\n${stdout}`);
-      assert.ok(stdout.includes('20 条以上'), `stdout should suggest growing the sample set before release decisions:\n${stdout}`);
+      assert.ok(stdout.includes('--samples 20'), `stdout should point to the full curated pack:\n${stdout}`);
+      assert.ok(stdout.includes('已写入 3 条官方人工策划用例'), `stdout should identify the quick pack:\n${stdout}`);
       assert.ok(stdout.includes('看报告里的 verdict'), `stdout should tell users where to make the release decision:\n${stdout}`);
       assert.ok(stdout.includes('https://oh-my-knowledge.pages.dev/zh/reference/executors'), `stdout should link zh users to public zh executor docs:\n${stdout}`);
       assert.ok(!stdout.includes('https://oh-my-knowledge.pages.dev/reference/executors'), `stdout should not link zh users to the en executor docs:\n${stdout}`);
@@ -64,6 +69,65 @@ describe('oclif init', () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it('--samples 20 生成完整、分层且无薄弱 capability 的官方样本包', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-oclif-init-full-'));
+    try {
+      const target = join(dir, 'project');
+      const { stdout } = await runCommand(InitCommand, ['project', '--samples', '20'], { cwd: dir });
+      assert.ok(stdout.includes('已写入 20 条官方人工策划用例'), `stdout should identify the full pack:\n${stdout}`);
+      assert.ok(stdout.includes('20 条用例达到注册样本量下限'), `stdout should set an honest statistical expectation:\n${stdout}`);
+      assert.ok(!stdout.includes('20 条以上后重跑'), `full-pack guidance should not ask for the size it already has:\n${stdout}`);
+
+      const { samples } = loadSamples(join(target, 'eval-samples.json'), {
+        assertionValidationMode: 'strict',
+      });
+      assert.equal(samples.length, 20);
+      assert.equal(new Set(samples.map((sample) => sample.sample_id)).size, 20);
+      assert.ok(samples.every((sample) => sample.construct === 'quality'));
+      assert.ok(samples.every((sample) => sample.provenance === 'human'));
+      assert.ok(samples.every((sample) => sample.rubric?.startsWith('满分标准：')));
+
+      const capabilityCounts = Object.fromEntries(
+        ['security-review', 'robustness-review', 'maintainability-review', 'performance-review']
+          .map((capability) => [
+            capability,
+            samples.filter((sample) => sample.capability?.includes(capability)).length,
+          ]),
+      );
+      assert.deepEqual(capabilityCounts, {
+        'security-review': 5,
+        'robustness-review': 5,
+        'maintainability-review': 5,
+        'performance-review': 5,
+      });
+
+      const difficultyCounts = Object.fromEntries(
+        ['easy', 'medium', 'hard'].map((difficulty) => [
+          difficulty,
+          samples.filter((sample) => sample.difficulty === difficulty).length,
+        ]),
+      );
+      assert.deepEqual(difficultyCounts, { easy: 7, medium: 8, hard: 5 });
+
+      for (const id of ['s006', 's010', 's015', 's020']) {
+        assert.equal(
+          samples.find((sample) => sample.sample_id === id)?.assertions,
+          undefined,
+          `${id} should remain a judge-scored negative control instead of rewarding keyword output`,
+        );
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('--samples 拒绝不受支持的样本数量', async () => {
+    await assert.rejects(
+      () => runCommand(InitCommand, ['project', '--samples', '10']),
+      /Expected --samples=10 to be one of: 3, 20/,
+    );
   });
 
   it('英文输出链接到英文 executor 文档', async () => {

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -24,6 +24,7 @@ describe('oclif init', () => {
     assert.ok(stdout.includes('初始化一个 omk 项目'), `stdout missing zh description:\n${stdout}`);
     assert.ok(stdout.includes('TARGETDIR'), 'stdout missing positional');
     assert.ok(stdout.includes('--samples'), 'stdout should document the curated sample-count option');
+    assert.ok(stdout.includes('--force'), 'stdout should document explicit overwrite consent');
     assert.ok(stdout.includes('3 条用于快速跑通'), `stdout should explain the quick pack:\n${stdout}`);
     assert.match(stdout, /20\s+条用于达到注册样本量下限/, `stdout should explain the full pack:\n${stdout}`);
   });
@@ -45,7 +46,7 @@ describe('oclif init', () => {
       );
       assert.ok(stdout.includes('UNDERPOWERED'), `stdout should set first-run expectation:\n${stdout}`);
       assert.ok(stdout.includes('--samples 20'), `stdout should point to the full curated pack:\n${stdout}`);
-      assert.ok(stdout.includes('已写入 3 条官方人工策划用例'), `stdout should identify the quick pack:\n${stdout}`);
+      assert.ok(stdout.includes('已写入 3 条官方起步用例'), `stdout should identify the quick pack:\n${stdout}`);
       assert.ok(stdout.includes('看报告里的 verdict'), `stdout should tell users where to make the release decision:\n${stdout}`);
       assert.ok(stdout.includes('https://oh-my-knowledge.pages.dev/zh/reference/executors'), `stdout should link zh users to public zh executor docs:\n${stdout}`);
       assert.ok(!stdout.includes('https://oh-my-knowledge.pages.dev/reference/executors'), `stdout should not link zh users to the en executor docs:\n${stdout}`);
@@ -76,8 +77,8 @@ describe('oclif init', () => {
     try {
       const target = join(dir, 'project');
       const { stdout } = await runCommand(InitCommand, ['project', '--samples', '20'], { cwd: dir });
-      assert.ok(stdout.includes('已写入 20 条官方人工策划用例'), `stdout should identify the full pack:\n${stdout}`);
-      assert.ok(stdout.includes('20 条用例达到注册样本量下限'), `stdout should set an honest statistical expectation:\n${stdout}`);
+      assert.ok(stdout.includes('已写入 20 条官方起步用例'), `stdout should identify the full pack:\n${stdout}`);
+      assert.ok(stdout.includes('来源是 llm-generated'), `stdout should disclose starter provenance:\n${stdout}`);
       assert.ok(!stdout.includes('20 条以上后重跑'), `full-pack guidance should not ask for the size it already has:\n${stdout}`);
 
       const { samples } = loadSamples(join(target, 'eval-samples.json'), {
@@ -86,7 +87,7 @@ describe('oclif init', () => {
       assert.equal(samples.length, 20);
       assert.equal(new Set(samples.map((sample) => sample.sample_id)).size, 20);
       assert.ok(samples.every((sample) => sample.construct === 'quality'));
-      assert.ok(samples.every((sample) => sample.provenance === 'human'));
+      assert.ok(samples.every((sample) => sample.provenance === 'llm-generated'));
       assert.ok(samples.every((sample) => sample.rubric?.startsWith('满分标准：')));
 
       const capabilityCounts = Object.fromEntries(
@@ -118,6 +119,52 @@ describe('oclif init', () => {
           `${id} should remain a judge-scored negative control instead of rewarding keyword output`,
         );
       }
+
+      const assertionSignals = [...new Set(samples
+        .flatMap((sample) => sample.assertions ?? [])
+        .map((assertion) => typeof assertion.value === 'string' ? assertion.value : assertion.pattern)
+        .filter((signal): signal is string => signal !== undefined))]
+        .sort();
+      assert.deepEqual(assertionSignals, [
+        'AbortController',
+        'JSON.parse',
+        'N+1',
+        'Promise.all',
+        'SQL',
+        'Set|Map',
+        'XSS',
+        'execFile|spawn',
+        'innerHTML',
+        'options',
+        'resolve|normalize|relative',
+        'try[\\s\\S]*catch|res\\.ok|status',
+      ], 'sync assertions should stay limited to language-independent code or API signals');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('默认拒绝覆盖已有脚手架文件，--force 才允许显式重建', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-oclif-init-overwrite-'));
+    try {
+      const target = join(dir, 'project');
+      await runCommand(InitCommand, ['project'], { cwd: dir });
+      const samplesPath = join(target, 'eval-samples.json');
+      await writeFile(samplesPath, 'user-owned-content\n');
+
+      await assert.rejects(
+        () => runCommand(InitCommand, ['project', '--samples', '20'], { cwd: dir }),
+        /已停止以避免覆盖.*eval-samples\.json.*--force/,
+      );
+      assert.equal(readFileSync(samplesPath, 'utf8'), 'user-owned-content\n');
+
+      const { stdout } = await runCommand(
+        InitCommand,
+        ['project', '--samples', '20', '--force'],
+        { cwd: dir },
+      );
+      assert.ok(stdout.includes('已写入 20 条官方起步用例'));
+      assert.equal(loadSamples(samplesPath, { assertionValidationMode: 'strict' }).samples.length, 20);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/eval-workflows/production-host/node-cli-composition.test.ts
+++ b/test/eval-workflows/production-host/node-cli-composition.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { digestCanonicalJson } from '../../../src/evaluation-core/contracts/index.js';
+import { classifyNodeCliEnvironment } from '../../../src/eval-workflows/production-host/node-cli-composition.js';
+import { captureClassifiedEnvironment } from '../../../src/eval-workflows/runtime-adapter/adapters/shared/classified-environment.js';
+
+describe('Node CLI production environment', () => {
+  it('preserves network routing and trust locators for isolated runtime processes', () => {
+    const proxy = 'http://user:password@127.0.0.1:7890';
+    const classified = classifyNodeCliEnvironment({
+      PATH: '/usr/bin:/bin',
+      https_proxy: proxy,
+      NO_PROXY: 'localhost,127.0.0.1',
+      NODE_EXTRA_CA_CERTS: '/etc/company-ca.pem',
+      NODE_OPTIONS: '--require=/tmp/untrusted.js',
+    });
+
+    expect(Object.keys(classified)).toEqual([
+      'NODE_EXTRA_CA_CERTS',
+      'NO_PROXY',
+      'PATH',
+      'https_proxy',
+    ]);
+    expect(classified.https_proxy).toEqual({
+      value: proxy,
+      identity: { identityKind: 'effect-locator' },
+    });
+    expect(classified.NODE_OPTIONS).toBeUndefined();
+
+    const captured = captureClassifiedEnvironment(classified);
+    expect(captured.values.https_proxy).toBe(proxy);
+    expect(captured.identity).toContainEqual({
+      keyDigest: digestCanonicalJson('https_proxy'),
+      identityKind: 'effect-locator',
+      valueDigest: digestCanonicalJson(proxy),
+    });
+    expect(JSON.stringify(captured.identity)).not.toContain(proxy);
+    expect(captured.outputClassification).toBe('sensitive');
+  });
+
+  it('supports conventional upper- and lower-case proxy variables without broad inheritance', () => {
+    const classified = classifyNodeCliEnvironment({
+      ALL_PROXY: 'socks5://proxy.example.test:1080',
+      HTTPS_PROXY: 'http://proxy.example.test:8443',
+      HTTP_PROXY: 'http://proxy.example.test:8080',
+      all_proxy: 'socks5://proxy.example.test:1081',
+      http_proxy: 'http://proxy.example.test:8081',
+      https_proxy: 'http://proxy.example.test:8444',
+      no_proxy: 'localhost',
+      UNRELATED_SECRET: 'must-not-cross-runtime-boundary',
+    });
+
+    expect(Object.keys(classified)).toEqual([
+      'ALL_PROXY',
+      'HTTPS_PROXY',
+      'HTTP_PROXY',
+      'all_proxy',
+      'http_proxy',
+      'https_proxy',
+      'no_proxy',
+    ]);
+    expect(classified.UNRELATED_SECRET).toBeUndefined();
+  });
+});

--- a/test/eval-workflows/production-host/node-cli-composition.test.ts
+++ b/test/eval-workflows/production-host/node-cli-composition.test.ts
@@ -23,6 +23,7 @@ describe('Node CLI production environment', () => {
     expect(classified.https_proxy).toEqual({
       value: proxy,
       identity: { identityKind: 'effect-locator' },
+      outputTaint: 'secret',
     });
     expect(classified.NODE_OPTIONS).toBeUndefined();
 
@@ -32,9 +33,10 @@ describe('Node CLI production environment', () => {
       keyDigest: digestCanonicalJson('https_proxy'),
       identityKind: 'effect-locator',
       valueDigest: digestCanonicalJson(proxy),
+      outputTaint: 'secret',
     });
     expect(JSON.stringify(captured.identity)).not.toContain(proxy);
-    expect(captured.outputClassification).toBe('sensitive');
+    expect(captured.outputClassification).toBe('secret');
   });
 
   it('supports conventional upper- and lower-case proxy variables without broad inheritance', () => {

--- a/test/eval-workflows/runtime-adapter/adapters/custom/command.test.ts
+++ b/test/eval-workflows/runtime-adapter/adapters/custom/command.test.ts
@@ -306,6 +306,9 @@ describe('custom-command Core Executor adapter', () => {
     expect(port.identity.implementationManifest.coverageKind).toBe('fingerprint-plus-facets');
     expect(JSON.stringify(port.identity)).not.toContain('do-not-persist-this-secret');
     expect(JSON.stringify(port.identity)).not.toContain('OMK_TEST_SECRET');
+    const credentialTaintedResult = await execute(port);
+    expect(credentialTaintedResult.output?.classification).toBe('secret');
+    expect(credentialTaintedResult.trace?.classification).toBe('secret');
 
     const rotatedCredential = await createAdapter(cwd, {
       environment: { OMK_TEST_SECRET: 'rotated-secret' },

--- a/test/eval-workflows/runtime-adapter/adapters/shared/classified-environment.test.ts
+++ b/test/eval-workflows/runtime-adapter/adapters/shared/classified-environment.test.ts
@@ -39,4 +39,24 @@ describe('classified environment', () => {
     expect(JSON.stringify(first.identity)).not.toContain('credential-a');
     expect(first.outputClassification).toBe('secret');
   });
+
+  it('keeps effect-locator identity independent from output secrecy', () => {
+    const proxy = 'http://user:password@proxy.example.test:8080';
+    const captured = captureClassifiedEnvironment({
+      HTTPS_PROXY: {
+        value: proxy,
+        identity: { identityKind: 'effect-locator' },
+        outputTaint: 'secret',
+      },
+    });
+
+    expect(captured.identity).toEqual([{
+      keyDigest: digestCanonicalJson('HTTPS_PROXY'),
+      identityKind: 'effect-locator',
+      valueDigest: digestCanonicalJson(proxy),
+      outputTaint: 'secret',
+    }]);
+    expect(JSON.stringify(captured.identity)).not.toContain(proxy);
+    expect(captured.outputClassification).toBe('secret');
+  });
 });


### PR DESCRIPTION
## 用户影响

- `omk init` 默认仍生成 3 条用例，用于低成本跑通首次评测。
- `omk init demo --samples 20` 生成官方完整起步集，覆盖安全、健壮性、可维护性和性能，并包含难度分层与无缺陷对照。
- CLI、快速上手、示例索引和 OMK Agent Skill 命令参考会明确两档用例的成本、来源与用途。
- `omk init` 默认拒绝覆盖已有脚手架文件；确认需要重建时必须显式传 `--force`。
- 隔离的 CLI 执行器会显式传递标准 proxy／CA 环境，避免企业网络下的真实评测被误判为执行失败；其它环境仍不做宽泛继承。

## 迁移说明

默认生成数量保持 3 条。此前依赖重复执行 `omk init` 覆盖已有文件的脚本，需要显式添加 `--force`；交互使用建议改用新的空目录。

## 测量学说明

完整用例集达到当前注册的样本量下限，但不会把样本数量包装成确定结论。样本来源如实标记为 `llm-generated`，只用于理解统计流程；作为发布证据前必须人工复核并替换为真实领域用例。同步 assertion 只保留语言无关的 API／代码标识，语义要求由 rubric／dimension 评委判断，避免把中文输出风格混入被测构念。

proxy 端点作为 effect locator 参与 Runtime 身份记录，仅保存摘要；由于 proxy URL 可能内嵌认证信息，其原始值会独立施加 `secret` 输出污点，并提升内置 CLI／SDK 与 custom-command 的 output／trace 分类。`NO_PROXY` 与 CA 路径仍按 `sensitive` effect locator 处理。本次不修改 sample schema、评分管道、统计公式或既有报告语义，不影响历史测量可比性。

Closes #509