### PR TITLE
chore(ci): 并行分片双版本测试

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  quality:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v7
       # Enable Corepack before setup-node so its `cache: yarn` step resolves the
@@ -25,11 +22,72 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v7
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: yarn
       - run: yarn install --immutable
-      # Delegate to the `ci` npm script (run-s lint typecheck build
-      # build:docs:check test) so the workflow can't drift from the canonical
-      # sequence. Inlining these steps once dropped `typecheck`, letting test/
-      # type errors merge undetected.
-      - run: yarn ci
+      - run: yarn ci:quality
+
+  test_22_shard:
+    name: test shard (22, ${{ matrix.shard }}/2)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@v7
+      - run: corepack enable
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: yarn
+      - run: yarn install --immutable
+      - run: yarn build
+      - run: yarn test --shard=${{ matrix.shard }}/2
+
+  test_24_shard:
+    name: test shard (24, ${{ matrix.shard }}/2)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@v7
+      - run: corepack enable
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: yarn
+      - run: yarn install --immutable
+      - run: yarn build
+      - run: yarn test --shard=${{ matrix.shard }}/2
+
+  # Keep the required status names stable while the full suites run in parallel.
+  test_22:
+    name: test (22)
+    if: ${{ always() }}
+    needs: [quality, test_22_shard]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require quality and every Node 22 shard
+        env:
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          SHARD_RESULT: ${{ needs.test_22_shard.result }}
+        run: |
+          test "$QUALITY_RESULT" = success
+          test "$SHARD_RESULT" = success
+
+  test_24:
+    name: test (24)
+    if: ${{ always() }}
+    needs: [quality, test_24_shard]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require quality and every Node 24 shard
+        env:
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          SHARD_RESULT: ${{ needs.test_24_shard.result }}
+        run: |
+          test "$QUALITY_RESULT" = success
+          test "$SHARD_RESULT" = success

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ OMK（Observe. Measure. Know.）让 AI 应用的知识改动有据可依。它�
 ## 开工先做
 
 - 涉及 commit、PR、分支或发版时，先看 `CONTRIBUTING.md`。
-- 交付前默认跑 `yarn lint && yarn build && yarn test`，除非用户明确要求只做更窄验证。
+- 首次 push 与交付前默认跑 `yarn ci`，除非用户明确要求只做更窄验证；后续修复成批完成并在本地复验后再一次性 push，避免把远端 CI 当作增量反馈环。
 
 ## 硬规则
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,17 +41,19 @@ git pull --ff-only
 # cut a topic branch from main
 git checkout -b feat/my-feature
 
-# build / test / lint
+# Batch the intended changes, then run the complete local gate once before pushing.
 yarn install
-yarn build
-yarn test      # must pass
-yarn lint      # must pass
+yarn ci
 
 git commit -m "feat(cli): 中文 subject"
 git push -u origin feat/my-feature
 
 # open a PR against **main**
 ```
+
+Avoid using remote CI as an incremental feedback loop. Batch related fixes, run
+`yarn ci` locally, and push the verified commit set once. If review finds more
+issues, finish the related fixes and rerun the local gate before the next push.
 
 ### Releasing a new version
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "lint-staged": "lint-staged",
     "test": "vitest run",
     "test:profile": "yarn build && node dist-scripts/test-profile.js",
-    "ci": "run-s lint typecheck build build:docs:check test",
+    "ci:quality": "run-s lint typecheck build build:docs:check",
+    "ci": "run-s ci:quality test",
     "prepublishOnly": "run-s clean build",
     "prepare": "husky"
   },


### PR DESCRIPTION
## 用户影响

- Node 22／24 的完整 Vitest 套件各拆为两个独立 runner 分片，缩短 PR 必需门禁的墙钟时间。
- lint、typecheck、build 与文档同步检查只执行一次，避免双 Node 矩阵重复质量检查。
- 汇总 job 继续发布 `test (22)` 与 `test (24)`，现有 main 分支保护无需迁移或降级。
- 贡献流程统一为首次 push 前运行 `yarn ci`，后续修复成批完成并本地复验后再推送。

## 迁移说明

无需修改分支保护或本地开发配置。`yarn ci` 的行为保持不变；新增 `yarn ci:quality` 仅供 CI 将非测试质量门禁独立调度。

## 测量学说明

本次只调整 CI 调度和贡献流程，不修改 Evaluation Core、样本、评分管道、统计公式、Runtime 行为或报告协议，不影响历史测量可比性。