### PR TITLE
chore(ci): 将文档站构建纳入质量门禁

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "lint-staged": "lint-staged",
     "test": "vitest run",
     "test:profile": "yarn build && node dist-scripts/test-profile.js",
-    "ci:quality": "run-s lint typecheck build build:docs:check",
+    "ci:quality": "run-s lint typecheck build build:docs:check docs:build",
     "ci": "run-s ci:quality test",
     "prepublishOnly": "run-s clean build",
     "prepare": "husky"


### PR DESCRIPTION
## 用户影响

将 VitePress 生产构建纳入稳定的 GitHub quality 门禁，确保文档页面无法构建时不会依赖外部 Pages 预览才暴露问题。Cloudflare Pages 可以据此只负责文档相关改动的可视化预览。

## 迁移说明

用户无需迁移。CI 的 quality 阶段会增加一次 `yarn docs:build`，预计增加约数秒执行时间。

## 测量学说明

本次仅调整 CI 验证范围，不改变报告 schema、评分语义、评分类 prompt、统计公式、长度去偏或 construct validity。
