### PR TITLE
chore(release): 发布 1.0.0-beta.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ The full docs are published at **[oh-my-knowledge.pages.dev](https://oh-my-knowl
 - **[How it works](docs/explanation/architecture.md)** — input compilation, sealed Core execution, analysis, persistence, and Studio projections
 - **[Eval sample format](docs/reference/eval-sample-format.md)** — sample schema, scoring formulas, 30+ assertion types, custom JS assertions
 - **[CLI reference](docs/reference/cli.md)** — all top-level commands with bash examples and flag tables
+- **[Migrate to the 1.0 preview](docs/guides/v1-preview-migration.md)** — install channel, storage reset, sample protocol, CLI automation, and embedded API changes since 0.54
 - **[Evaluation Core cutover](docs/guides/eval-core-cutover.md)** — `BREAKING-SCHEMA` storage, resume, Studio, Gold, managed-evidence, and evolve migration
 - **[Storage layout v2](docs/specs/storage-layout-spec.md)** — project/global domains, compatibility boundary, and Git policy
 - **[Executors](docs/reference/executors.md)** & **[artifact layout](docs/reference/artifact-layout.md)** — built-in / custom executors; how `variant` resolves to an artifact + runtime context

--- a/README.zh.md
+++ b/README.zh.md
@@ -226,6 +226,7 @@ omk-mcp
 - **[工作原理](docs/zh/explanation/architecture.md)** —— 输入编译、sealed Core 执行、分析、持久化与 Studio projection
 - **[评测用例格式](docs/zh/reference/eval-sample-format.md)** —— sample schema、评分公式、30+ 断言类型、自定义 JS 断言
 - **[CLI 参考](docs/zh/reference/cli.md)** —— 顶层命令的 bash 示例和 flag 表
+- **[迁移到 1.0 预览版](docs/zh/guides/v1-preview-migration.md)** —— 从 `0.54` 升级时的安装渠道、存储重建、用例协议、CLI 自动化与嵌入式 API 变化
 - **[Evaluation Core 生产切换](docs/zh/guides/eval-core-cutover.md)** —— `BREAKING-SCHEMA` 存储、resume、Studio、Gold、受管证据与 evolve 迁移
 - **[存储布局 v2](docs/zh/specs/storage-layout-spec.md)** —— 项目／全局领域、迁移兼容与 Git 策略
 - **[执行器](docs/zh/reference/executors.md)** & **[知识载体布局](docs/zh/reference/artifact-layout.md)** —— 内置 / 自定义执行器；variant 如何解析为 artifact + runtime context

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
             text: 'Use omk',
             items: [
               { text: 'Quickstart', link: '/quickstart-skill-eval' },
+              { text: 'Migrate to the 1.0 preview', link: '/guides/v1-preview-migration' },
               { text: 'CLI reference', link: '/reference/cli' },
               { text: 'Embedded API', link: '/reference/embedded-api' },
               { text: 'Eval sample format', link: '/reference/eval-sample-format' },
@@ -104,6 +105,7 @@ export default defineConfig({
             text: '我想用 omk',
             items: [
               { text: '快速上手', link: '/zh/quickstart-skill-eval' },
+              { text: '迁移到 1.0 预览版', link: '/zh/guides/v1-preview-migration' },
               { text: 'CLI 参考', link: '/zh/reference/cli' },
               { text: '嵌入式 API', link: '/zh/reference/embedded-api' },
               { text: '评测用例格式', link: '/zh/reference/eval-sample-format' },

--- a/docs/guides/v1-preview-migration.md
+++ b/docs/guides/v1-preview-migration.md
@@ -1,0 +1,97 @@
+# Migrate from 0.54 to the 1.0 preview
+
+`1.0.0-beta.0` is the first public preview of OMK's new Evaluation Core architecture. It is published under npm's `next` tag, while `latest` remains on `0.54.0` during the preview.
+
+```bash
+npm install --global oh-my-knowledge@next
+omk --version
+```
+
+Use a disposable project or back up both the project `.omk/` directory and `~/.oh-my-knowledge/` before trying the preview. To return to the stable channel, run `npm install --global oh-my-knowledge@latest`.
+
+This is a beta, not a frozen 1.0 contract. One important limitation remains: `omk eval gold init` creates a generic annotation scaffold but cannot yet seed it from a real Core run, so Gold authoring still requires manual sample-ID alignment. An explicit Gold comparison reports Krippendorff alpha, but that post-hoc result does not automatically gate the run's release verdict. [Issue #283](https://github.com/lizhiyao/oh-my-knowledge/issues/283) tracks the guided Gold on-ramp and calibration-decision closure required before an RC.
+
+## 1. Start a new evidence history
+
+The preview uses the domain-oriented storage v2 layout. It does not read, move, delete, or convert the earlier layout. Existing data remains on disk but is invisible to the new readers.
+
+- New project records live under `.omk/eval/`, `.omk/doctor/`, `.omk/observe/`, `.omk/governance/`, `.omk/backups/`, and `.omk/state/`.
+- Machine-level data uses the same domains under `~/.oh-my-knowledge/`.
+- Evaluation runs are authenticated Core bundles addressed by `runId`; their canonical report is `report.json`.
+- Reports created by 0.54 cannot be resumed, opened in the new Studio, compared with Gold, or used by `omk evolve`. Keep 0.54 installed separately if you need to inspect them.
+- Managed records use schema v3. Reinstall an artifact and run a new evaluation to establish current evidence.
+
+Do not copy scores from an old report into the new layout. Re-run the evaluation so the sealed plan, lineage, Runtime identity, and decision evidence are produced together. See the [Evaluation Core cutover](./eval-core-cutover.md) and [storage layout v2](../specs/storage-layout-spec.md) for the full boundary.
+
+## 2. Upgrade the eval-samples document
+
+Every sample file must now be a strict, versioned document. Wrap a legacy top-level array as follows:
+
+```json
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
+    {
+      "sample_id": "case-1",
+      "prompt": "..."
+    }
+  ]
+}
+```
+
+Then apply these changes:
+
+- Rename project `eval-samples.yml` to `eval-samples.yaml`.
+- Rename a directory skill's `.omk/samples.json` or `.omk/samples.yaml` to `.omk/eval-samples.json` or `.omk/eval-samples.yaml`.
+- Keep exactly one canonical JSON or YAML file in each auto-discovery scope. Flat-skill sidecars and split directories are no longer auto-discovered; pass a custom file or split directory explicitly with `--samples`.
+- Remove `expectedTools`. Express tool behavior with assertions and `allowedTools`.
+- Remove unknown fields. The root, samples, assertions, mocks, and nested contracts are closed schemas.
+- Treat omitted `mocksStrict` as `true`. Set it to `false` only when unmatched calls may intentionally reach the real Runtime.
+- Give each mock exactly one of `return`, `return_file`, or `return_seq`.
+
+Validate the result before a paid run:
+
+```bash
+omk eval --dry-run --samples eval-samples.yaml \
+  --control code-review-v1 --treatment code-review-v2
+```
+
+See the [eval sample format](../reference/eval-sample-format.md) and its published JSON Schema for the complete contract.
+
+## 3. Re-check external URL inputs
+
+Real URLs in sample `prompt` or `context` are now resolved before execution, and the resolved bytes are sealed into the Evaluation Definition. Resolution fails closed instead of silently leaving the URL as literal text.
+
+- Configure an MCP resolver for private or authenticated documents.
+- HTTP resolution accepts constrained, textual UTF-8 content on standard protocol ports.
+- `urlPatterns` entries are exact hostnames or `*.hostname` wildcards, not path or query substrings.
+- Use RFC example domains when a URL is intentionally literal documentation text.
+
+Runs that previously measured a real URL as literal text are not directly comparable with runs that measure its resolved content. Start a new comparison series after migration.
+
+## 4. Update CLI automation
+
+- `omk init` still creates three low-cost starter cases. Use `omk init --samples 20` for the larger first-party starter set; review or replace it before treating it as release evidence.
+- `omk init` no longer overwrites scaffold files unless `--force` is explicit.
+- `omk eval --resume` accepts a Core `runId`, not a report path.
+- `omk eval gold compare` accepts a Core `runId` and requires explicit `--target`, `--evaluator`, and `--metric` selectors.
+- `omk evolve` no longer accepts the former diagnostic, sample-repair, report-reuse, holdout, significance, or test-split switches. Candidate acceptance and source write-back are governed by the Core decision; run an independent release validation set outside the authoring loop.
+
+Check the current [CLI reference](../reference/cli.md) rather than copying 0.54 flags into scripts.
+
+## 5. Update embedded Node.js hosts
+
+The published API is ESM-only on Node.js 22 or newer. Imports are restricted to the package export map; `oh-my-knowledge/dist/*` is private.
+
+- Use `oh-my-knowledge` for the minimal one-call Engine façade and Core contracts.
+- Use `oh-my-knowledge/eval-core` for staged execution, admission, verification, comparability, Series, and Core JSON Schemas.
+- Use `oh-my-knowledge/eval-samples`, `oh-my-knowledge/projections`, `oh-my-knowledge/studio`, `oh-my-knowledge/mcp`, or `oh-my-knowledge/dsh-plugin` for those explicit surfaces.
+- Replace synchronous `require()` with ESM imports or dynamic `import()`.
+- Engine Runtime assembly now uses binding resolvers that return the resolution and configured port together.
+- Series Analysis and Decision Runtimes open run-scoped sessions with `openRun()` and `dispose()`; Series runs require a `runId` and return a terminal status union.
+
+The [embedded API reference](../reference/embedded-api.md) is the canonical contract and includes a complete independent-host fixture.
+
+## Measurement boundary
+
+The migration preserves the frozen evaluator prompts, five scoring layers, Bootstrap confidence interval formula, Krippendorff alpha formula, and length-debias toggle semantics. It does not preserve artifact schemas, storage paths, digests, Runtime identities, or the interpretation of unresolved external URLs. Compare only runs that the new Core marks compatible; do not splice old and new score histories manually.

--- a/docs/zh/guides/v1-preview-migration.md
+++ b/docs/zh/guides/v1-preview-migration.md
@@ -1,0 +1,97 @@
+# 从 0.54 迁移到 1.0 预览版
+
+`1.0.0-beta.0` 是 OMK 新 Evaluation Core 架构的首个公开预览版。它发布到 npm 的 `next` 标签；预览期间，`latest` 继续保持在 `0.54.0`。
+
+```bash
+npm install --global oh-my-knowledge@next
+omk --version
+```
+
+请先在一次性项目中试用，或备份项目 `.omk/` 与 `~/.oh-my-knowledge/` 后再安装预览版。需要回到稳定渠道时，运行 `npm install --global oh-my-knowledge@latest`。
+
+这是 beta，不代表 1.0 契约已经冻结。当前仍有一项重要限制：`omk eval gold init` 只创建通用标注脚手架，还不能从真实 Core run 自动带入 sample ID，因此 Gold authoring 仍需人工对齐。显式 Gold compare 会报告 Krippendorff alpha，但这份事后结果不会自动门控该 run 的 release verdict。[Issue #283](https://github.com/lizhiyao/oh-my-knowledge/issues/283)继续跟踪 RC 前需要补齐的 Gold 引导入口与校准决策闭环。
+
+## 一、重新建立证据历史
+
+预览版使用领域化的存储布局 v2，不读取、搬动、删除或转换旧布局。原数据仍留在磁盘上，但新读侧不可见。
+
+- 新的项目记录分别进入 `.omk/eval/`、`.omk/doctor/`、`.omk/observe/`、`.omk/governance/`、`.omk/backups/` 与 `.omk/state/`。
+- 机器级数据在 `~/.oh-my-knowledge/` 下采用相同领域。
+- Evaluation run 是以 `runId` 定位、经过认证的 Core bundle，`report.json` 是 canonical report。
+- `0.54` 生成的报告不能被新版本 resume、不能在新 Studio 打开、不能做 Gold 对比，也不能交给 `omk evolve`。如需查看，请单独保留 `0.54`。
+- 受管记录升级为 schema v3。请重新安装 artifact，并重新评测以建立当前证据。
+
+不要把旧报告的分数复制到新布局。重新运行评测，让 sealed plan、lineage、Runtime identity 与 decision evidence 一起生成。完整边界见 [Evaluation Core 生产切换](./eval-core-cutover.md)与[存储布局 v2](../specs/storage-layout-spec.md)。
+
+## 二、升级评测用例协议
+
+每份用例文件现在都必须是严格、带版本号的文档。把旧的顶层数组包装为：
+
+```json
+{
+  "schemaVersion": "omk.eval-sample-set/v1",
+  "samples": [
+    {
+      "sample_id": "case-1",
+      "prompt": "..."
+    }
+  ]
+}
+```
+
+然后完成这些迁移：
+
+- 把项目级 `eval-samples.yml` 改名为 `eval-samples.yaml`。
+- 把目录 skill 的 `.omk/samples.json` 或 `.omk/samples.yaml` 改名为 `.omk/eval-samples.json` 或 `.omk/eval-samples.yaml`。
+- 每个自动发现作用域只保留一份 canonical JSON 或 YAML。扁平 skill sidecar 与分片目录不再自动发现；自定义文件或分片目录仍可用 `--samples` 显式传入。
+- 删除 `expectedTools`，改用 assertion 与 `allowedTools` 表达工具行为约束。
+- 删除未知字段。根文档、sample、assertion、mock 与嵌套 contract 都是封闭 schema。
+- 未声明 `mocksStrict` 时按 `true` 处理。只有明确允许未命中调用进入真实 Runtime 时才设为 `false`。
+- 每条 mock 必须且只能声明 `return`、`return_file`、`return_seq` 之一。
+
+付费运行前先验证：
+
+```bash
+omk eval --dry-run --samples eval-samples.yaml \
+  --control code-review-v1 --treatment code-review-v2
+```
+
+完整协议见[评测用例格式](../reference/eval-sample-format.md)及随包发布的 JSON Schema。
+
+## 三、重新检查外部 URL 输入
+
+用例 `prompt` 或 `context` 中的真实 URL 现在会在执行前解析，解析后的字节会封存进 Evaluation Definition。解析失败会直接阻断评测，不再静默把 URL 当字面文本使用。
+
+- 私网或认证文档应配置 MCP resolver。
+- HTTP 解析只接受标准协议端口，以及受约束的文本型 UTF-8 内容。
+- `urlPatterns` 只接受精确 hostname 或 `*.hostname` 通配，不再按 path 或 query 子串匹配。
+- 文档中有意保留的字面 URL 应使用 RFC 示例域名。
+
+旧运行若实际测量的是 URL 字面量，就不能与新版本测量的解析后内容直接比较。迁移后应新开一组 comparison series。
+
+## 四、更新 CLI 自动化
+
+- `omk init` 仍默认生成 3 条低成本起步用例；较完整的官方起步集使用 `omk init --samples 20`。把它当发布证据前必须人工复核或替换。
+- `omk init` 不再覆盖已有脚手架文件，除非显式传入 `--force`。
+- `omk eval --resume` 接受 Core `runId`，不再接受报告路径。
+- `omk eval gold compare` 接受 Core `runId`，并要求显式提供 `--target`、`--evaluator` 与 `--metric`。
+- `omk evolve` 不再接受旧的 diagnostic、sample repair、report reuse、holdout、significance 与 test split 开关。候选接受和源文件写回由 Core decision 管理；独立发布验证集应放在 authoring loop 外运行。
+
+更新脚本时请以当前 [CLI 参考](../reference/cli.md)为准，不要沿用 `0.54` 的 flag。
+
+## 五、更新嵌入式 Node.js 宿主
+
+公开 API 仅支持 ESM，要求 Node.js 22 或更高版本。import 必须经过 package export map，`oh-my-knowledge/dist/*` 属于私有路径。
+
+- 最小一键 Engine façade 与 Core contract 从 `oh-my-knowledge` 导入。
+- 分阶段执行、admission、verification、comparability、Series 与 Core JSON Schema 从 `oh-my-knowledge/eval-core` 导入。
+- eval-samples、projection、Studio、MCP 与 DSH 集成分别使用 `oh-my-knowledge/eval-samples`、`oh-my-knowledge/projections`、`oh-my-knowledge/studio`、`oh-my-knowledge/mcp` 与 `oh-my-knowledge/dsh-plugin`。
+- 同步 `require()` 改为 ESM import 或动态 `import()`。
+- Engine Runtime 装配改用 binding resolver，一次返回 resolution 与配置好的 port。
+- Series Analysis 与 Decision Runtime 通过 `openRun()` 打开 run-scoped session，并用 `dispose()` 释放；Series run 必须提供 `runId`，结果是带 terminal status 的 union。
+
+[嵌入式 API 参考](../reference/embedded-api.md)是 canonical contract，并提供完整的独立宿主 fixture。
+
+## 测量边界
+
+本次迁移保持冻结的评分类 prompt、五层评分、Bootstrap CI 公式、Krippendorff alpha 公式与 length-debias toggle 语义不变。它不保持 artifact schema、存储路径、digest、Runtime identity，也不保持未解析外部 URL 的解释方式。只比较新 Core 判断为 compatible 的 run；不要手工拼接新旧分数历史。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "0.54.0",
+  "version": "1.0.0-beta.0",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

`1.0.0-beta.0` 是新 Evaluation Core 架构的公开预览版。发布后，显式安装 `oh-my-knowledge@next` 的用户会进入预览；npm `latest` 继续保持在 `0.54.0`，不会影响稳定渠道用户。

中英文迁移页统一说明从 `0.54` 升级时的存储、评测用例、CLI 自动化与嵌入式 API 变化，并从 README 与文档导航提供入口。

## 迁移说明

- 新版本只读取领域化 `.omk` v2 布局与经过认证的 Evaluation Core bundle。旧报告不能 resume、不能进入新 Studio／Gold／evolve；请保留旧版用于查看历史，并重新运行评测建立新证据。
- eval-samples 必须升级为 `omk.eval-sample-set/v1` 严格文档，并统一 canonical 文件名；旧顶层数组、`.yml` 自动发现、skill-local `.omk/samples.*` 与扁平 sidecar 需要显式迁移。
- 真实 URL 会在执行前解析并封存；私网或认证内容需要 MCP resolver。旧版测量的 URL 字面量不能与新版本解析后的内容直接比较。
- 公开 Node.js API 仅支持 Node.js 22+／ESM 与 export map 白名单；高级入口统一为 `oh-my-knowledge/eval-core`，深层 `dist/*` 导入不受支持。

完整步骤见 [中文迁移指南](https://github.com/lizhiyao/oh-my-knowledge/blob/codex/release-1.0.0-beta.0/docs/zh/guides/v1-preview-migration.md)与[英文迁移指南](https://github.com/lizhiyao/oh-my-knowledge/blob/codex/release-1.0.0-beta.0/docs/guides/v1-preview-migration.md)。

## 测量学与已知限制

本次 release PR 不修改 EvaluationReport 字段语义、冻结的评分类 prompt、五层评分管道、Bootstrap CI、Krippendorff alpha 公式或 length-debias toggle。存储、artifact schema、digest 与 Runtime identity 已重新建立；只应比较新 Core 判断为 compatible 的 run。

这仍是 beta，不代表 1.0 契约已经冻结。Gold authoring 暂时需要人工对齐 sample ID，显式 Gold compare 的事后 agreement 不会自动门控该 run 的 release verdict；#283 继续跟踪 RC 前的 Gold 引导入口与校准决策闭环。

Refs #622
