### PR TITLE
fix(cli): 隔离测试产生的仓库写入

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint 'src/**/*.ts' 'test/**/*.ts' --cache --cache-location node_modules/.cache/eslint/ --max-warnings 0",
     "lint-staged": "lint-staged",
-    "test": "vitest run",
+    "test": "node scripts/run-tests-hermetic.mjs",
     "test:profile": "yarn build && node dist-scripts/test-profile.js",
     "ci:quality": "run-s lint typecheck build build:docs:check docs:build",
     "ci": "run-s ci:quality test",

--- a/scripts/run-tests-hermetic.mjs
+++ b/scripts/run-tests-hermetic.mjs
@@ -1,0 +1,89 @@
+import { createHash } from 'node:crypto';
+import { existsSync, lstatSync, readFileSync, readdirSync, readlinkSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const PROJECT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const VITEST = join(PROJECT_ROOT, 'node_modules', 'vitest', 'vitest.mjs');
+
+function gitWorkspacePaths() {
+  const listed = spawnSync(
+    'git',
+    ['ls-files', '-z', '--cached', '--others', '--exclude-standard'],
+    { cwd: PROJECT_ROOT, encoding: 'utf8' },
+  );
+  if (listed.status !== 0) {
+    throw new Error(`Unable to enumerate repository files:\n${listed.stderr}`);
+  }
+  return listed.stdout.split('\0').filter(Boolean);
+}
+
+function collectTree(root, output) {
+  if (!existsSync(root)) return;
+  const stat = lstatSync(root);
+  const repositoryPath = relative(PROJECT_ROOT, root);
+  if (stat.isSymbolicLink()) {
+    output.add(repositoryPath);
+    return;
+  }
+  if (stat.isFile()) {
+    output.add(repositoryPath);
+    return;
+  }
+  for (const entry of readdirSync(root).sort()) {
+    collectTree(join(root, entry), output);
+  }
+}
+
+function digestPath(repositoryPath) {
+  const absolutePath = join(PROJECT_ROOT, repositoryPath);
+  if (!existsSync(absolutePath)) return 'missing';
+  const stat = lstatSync(absolutePath);
+  const hash = createHash('sha256');
+  hash.update(repositoryPath);
+  hash.update('\0');
+  hash.update(String(stat.mode));
+  hash.update('\0');
+  if (stat.isSymbolicLink()) {
+    hash.update(`link:${readlinkSync(absolutePath)}`);
+  } else if (stat.isFile()) {
+    hash.update(readFileSync(absolutePath));
+  } else {
+    hash.update('directory');
+  }
+  return hash.digest('hex');
+}
+
+function workspaceSnapshot() {
+  const paths = new Set(gitWorkspacePaths());
+  // `.omk/` is intentionally ignored by Git but is user-owned project state,
+  // so it needs an explicit guard in addition to tracked/untracked files.
+  collectTree(join(PROJECT_ROOT, '.omk'), paths);
+  return new Map([...paths].sort().map((path) => [path, digestPath(path)]));
+}
+
+function changedPaths(before, after) {
+  const paths = new Set([...before.keys(), ...after.keys()]);
+  return [...paths].filter((path) => before.get(path) !== after.get(path)).sort();
+}
+
+const before = workspaceSnapshot();
+const result = spawnSync(process.execPath, [VITEST, 'run', ...process.argv.slice(2)], {
+  cwd: PROJECT_ROOT,
+  env: process.env,
+  stdio: 'inherit',
+});
+const after = workspaceSnapshot();
+const mutations = changedPaths(before, after);
+
+if (mutations.length > 0) {
+  process.stderr.write('\n[test-hermetic] Tests modified repository-owned content:\n');
+  for (const path of mutations) process.stderr.write(`  - ${path}\n`);
+  process.stderr.write('Write test artifacts under an OS temporary directory and clean them in teardown.\n');
+}
+
+if (result.error) {
+  process.stderr.write(`${result.error.stack ?? result.error.message}\n`);
+}
+process.exit(result.status === 0 && mutations.length === 0 ? 0 : 1);

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -1,5 +1,7 @@
-import { describe, it } from 'vitest';
+import { afterEach, beforeEach, describe, it } from 'vitest';
 import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import DoctorCommand from '../../src/cli/commands/doctor.js';
@@ -12,12 +14,25 @@ const EXAMPLE_SKILLS_DIR = join(PROJECT_ROOT, 'test', 'fixtures', 'code-review',
 // Fixture executor bypasses real LLM calls; outcome is steered via
 // OMK_DOCTOR_FIXTURE_OUTCOME env (pass/fail).
 const DOCTOR_FIXTURE = `node ${join(PROJECT_ROOT, 'test', 'fixtures', 'doctor-fixture-executor.mjs')}`;
+let isolatedCwd = '';
+
+beforeEach(() => {
+  isolatedCwd = mkdtempSync(join(tmpdir(), 'omk-doctor-cli-test-'));
+});
+
+afterEach(() => {
+  rmSync(isolatedCwd, { recursive: true, force: true });
+  isolatedCwd = '';
+});
 
 async function runDoctorCommand(
   args: string[],
   options: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
 ): Promise<{ stdout: string; stderr: string }> {
-  return runCommand(DoctorCommand, args, options);
+  return runCommand(DoctorCommand, args, {
+    ...options,
+    cwd: options.cwd ?? isolatedCwd,
+  });
 }
 
 interface ExecError extends Error {
@@ -44,6 +59,10 @@ describe('omk doctor command', () => {
     assert.ok(ids.includes('dependencies_present'));
     assert.ok(!ids.includes('samples_contract_aligned'), 'samples-contract 不归 CLI 默认 doctor');
     assert.ok(ids.some((id) => id.startsWith('skill_health')), 'default doctor should run LLM health audit');
+    assert.ok(
+      existsSync(join(isolatedCwd, '.omk', 'doctor')),
+      'default doctor persistence should stay inside the isolated test project',
+    );
   });
 
   it('--static-only runs offline (no executor) with static rules only, no LLM / samples-contract', async () => {

--- a/test/cli/judge-models-validation.test.ts
+++ b/test/cli/judge-models-validation.test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Command, Config } from '@oclif/core';
 import EvalCommand from '../../src/cli/commands/eval/index.js';
 import EvolveCommand from '../../src/cli/commands/evolve.js';
@@ -21,17 +23,20 @@ interface ExecError extends Error {
 // eval 通过 parseRunConfig 解析 judgeModels,需要 control/treatment 才能跑到参数解析。
 // evolve 直接调 parseJudgeModelsArgOrExit,无前置依赖。
 type CommandClass = { new (argv: string[], config: Config): Command; id: string; name: string };
+const PROJECT_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SKILLS_DIR = join(PROJECT_ROOT, 'test', 'fixtures', 'code-review', 'skills');
+const V1_SKILL = join(SKILLS_DIR, 'v1.md');
 
 const CASES: Array<{ name: string; command: CommandClass; argv: string[] }> = [
   {
     name: 'eval',
     command: EvalCommand,
-    argv: ['--control', 'baseline', '--treatment', 'v1', '--skill-dir', 'test/fixtures/code-review/skills', '--dry-run'],
+    argv: ['--control', 'baseline', '--treatment', 'v1', '--skill-dir', SKILLS_DIR, '--dry-run'],
   },
   {
     name: 'evolve',
     command: EvolveCommand,
-    argv: ['test/fixtures/code-review/skills/v1.md', '--rounds', '1'],
+    argv: [V1_SKILL, '--rounds', '1'],
   },
 ];
 
@@ -64,7 +69,7 @@ describe('--judge-models validation: CLI exits 2 with friendly error', () => {
   it('omk evolve 拒绝多评委时,error 用新命令名而非旧 improve skill', async () => {
     await assert.rejects(
       () => runCommand(EvolveCommand, [
-        'test/fixtures/code-review/skills/v1.md',
+        V1_SKILL,
         '--rounds', '1',
         '--judge-models', 'claude:haiku,claude:sonnet',
       ]),
@@ -86,7 +91,7 @@ describe('--judge-models validation: CLI exits 2 with friendly error', () => {
 
   it('omk eval --judge-models <missing executor> exits 2 with friendly error', async () => {
     await assert.rejects(
-      () => runCommand(EvalCommand, ['--control', 'baseline', '--treatment', 'v1', '--skill-dir', 'test/fixtures/code-review/skills', '--dry-run', '--judge-models', ':haiku']),
+      () => runCommand(EvalCommand, ['--control', 'baseline', '--treatment', 'v1', '--skill-dir', SKILLS_DIR, '--dry-run', '--judge-models', ':haiku']),
       (err: unknown) => {
         const e = err as ExecError;
         assert.equal(e.code, 2);
@@ -99,7 +104,7 @@ describe('--judge-models validation: CLI exits 2 with friendly error', () => {
 
   it('omk eval --judge-models "" (empty) exits 2 with friendly error', async () => {
     await assert.rejects(
-      () => runCommand(EvalCommand, ['--control', 'baseline', '--treatment', 'v1', '--skill-dir', 'test/fixtures/code-review/skills', '--dry-run', '--judge-models', '']),
+      () => runCommand(EvalCommand, ['--control', 'baseline', '--treatment', 'v1', '--skill-dir', SKILLS_DIR, '--dry-run', '--judge-models', '']),
       (err: unknown) => {
         const e = err as ExecError;
         assert.equal(e.code, 2);

--- a/test/helpers/run-command.test.ts
+++ b/test/helpers/run-command.test.ts
@@ -1,9 +1,23 @@
 import { Command } from '@oclif/core';
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import { describe, it } from 'vitest';
 import { runCommand, type CommandRunError } from './run-command.js';
 
 describe('runCommand', () => {
+  it('未指定 cwd 时使用并清理临时项目目录', async () => {
+    class CwdCommand extends Command {
+      async run(): Promise<void> {
+        await this.parse(CwdCommand);
+        this.log(process.cwd());
+      }
+    }
+
+    const commandCwd = (await runCommand(CwdCommand, [])).stdout.trim();
+    assert.notEqual(commandCwd, process.cwd());
+    assert.equal(existsSync(commandCwd), false, 'temporary command cwd should be removed after the run');
+  });
+
   it('执行完整 Oclif init → run → finally 生命周期', async () => {
     const events: string[] = [];
     class LifecycleCommand extends Command {

--- a/test/helpers/run-command.ts
+++ b/test/helpers/run-command.ts
@@ -1,4 +1,6 @@
 import { Config, type Command } from '@oclif/core';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { format } from 'node:util';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -91,6 +93,13 @@ export async function runCommand(
   const previousCwd = process.cwd();
   const previousEnv = { ...process.env };
   const previousExitCode = process.exitCode;
+  // A command may gain persistence as it evolves. Keep callers that only test
+  // parsing/output hermetic by default instead of silently inheriting the repo
+  // root as their writable project. Tests that need a specific project must
+  // opt into it with options.cwd.
+  const isolatedCwd = options.cwd === undefined
+    ? mkdtempSync(join(tmpdir(), 'omk-command-test-'))
+    : undefined;
   let stdout = '';
   let stderr = '';
 
@@ -111,7 +120,7 @@ export async function runCommand(
 
   try {
     process.argv = [process.execPath, 'omk', ...argv];
-    if (options.cwd) process.chdir(options.cwd);
+    process.chdir(options.cwd ?? isolatedCwd!);
     if (options.env) Object.assign(process.env, options.env);
 
     const command = new CommandType(argv, await commandConfig());
@@ -132,6 +141,9 @@ export async function runCommand(
     process.argv = previousArgv;
     process.exitCode = previousExitCode;
     process.chdir(previousCwd);
+    if (isolatedCwd !== undefined) {
+      rmSync(isolatedCwd, { recursive: true, force: true });
+    }
     for (const key of Object.keys(process.env)) delete process.env[key];
     Object.assign(process.env, previousEnv);
     stdoutWrite.mockRestore();

--- a/test/scripts/build-docs.test.ts
+++ b/test/scripts/build-docs.test.ts
@@ -13,7 +13,16 @@ import { beforeAll, describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { readFileSync, writeFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Config } from '@oclif/core';
@@ -33,6 +42,25 @@ const BUILD_DOCS = join(PROJECT_ROOT, 'dist-scripts/build-docs.js');
 
 const MARKER_START = '<!-- omk:cli:start -->';
 const MARKER_END = '<!-- omk:cli:end -->';
+const GENERATED_DOC_TARGETS = [
+  '.agents/skills/omk/references/commands.md',
+  'docs/reference/cli.md',
+  'docs/zh/reference/cli.md',
+  'docs/specs/cli-evaluation-input-compilation.md',
+  'docs/zh/specs/cli-evaluation-input-compilation.md',
+] as const;
+
+function createBuildDocsFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), 'omk-build-docs-check-'));
+  copyFileSync(join(PROJECT_ROOT, 'package.json'), join(root, 'package.json'));
+  symlinkSync(join(PROJECT_ROOT, 'dist'), join(root, 'dist'), 'dir');
+  for (const relativePath of GENERATED_DOC_TARGETS) {
+    const target = join(root, relativePath);
+    mkdirSync(dirname(target), { recursive: true });
+    copyFileSync(join(PROJECT_ROOT, relativePath), target);
+  }
+  return root;
+}
 
 function readFlagsBlock(content: string, id: string): string {
   const start = `<!-- omk:cli:${id}:flags:start -->`;
@@ -135,22 +163,17 @@ describe('scripts/build-docs codegen', () => {
   }, 30000);
 
   it('--check mode fails on drift and prints diff', async () => {
-    const original = readFileSync(COMMANDS_MD, 'utf8');
-    // 注入一处明显 drift:在 marker body 里加一行
-    const drifted = original.replace(
-      MARKER_START,
-      `${MARKER_START}\n<!-- DRIFT INJECTED FOR TEST -->`,
-    );
-    // 额外 safety net:如果 vitest 在 finally 之前被 SIGINT/SIGTERM 杀掉,
-    // process.on('exit') 同步回写 original,防止 drift 残留进 git commit。
-    const restore = (): void => {
-      try { writeFileSync(COMMANDS_MD, original, 'utf8'); } catch { /* best-effort */ }
-    };
-    process.once('exit', restore);
-    writeFileSync(COMMANDS_MD, drifted, 'utf8');
+    const fixtureRoot = createBuildDocsFixture();
     try {
+      const fixtureCommands = join(fixtureRoot, '.agents/skills/omk/references/commands.md');
+      const original = readFileSync(fixtureCommands, 'utf8');
+      writeFileSync(
+        fixtureCommands,
+        original.replace(MARKER_START, `${MARKER_START}\n<!-- DRIFT INJECTED FOR TEST -->`),
+        'utf8',
+      );
       await assert.rejects(
-        () => execFileAsync('node', [BUILD_DOCS, '--check'], { cwd: PROJECT_ROOT }),
+        () => execFileAsync('node', [BUILD_DOCS, '--check'], { cwd: fixtureRoot }),
         (err: unknown) => {
           const e = err as ExecError;
           assert.equal(e.code, 1, `expected exit 1 on drift, got ${e.code}`);
@@ -159,8 +182,7 @@ describe('scripts/build-docs codegen', () => {
         },
       );
     } finally {
-      writeFileSync(COMMANDS_MD, original, 'utf8');
-      process.off('exit', restore);
+      rmSync(fixtureRoot, { recursive: true, force: true });
     }
   }, 30000);
 


### PR DESCRIPTION
## 用户影响

- 运行测试不再向真实项目的 `.omk/doctor` 写入 fixture 报告。
- 普通 `yarn test` 会在测试结束后校验仓库受管文件与项目级 `.omk` 状态；发现残留写入时直接失败并列出路径。
- 文档 codegen 的 drift 测试改在临时镜像中执行，不再短暂改写仓库文档。

## 迁移说明

无需迁移。该改动仅收紧测试隔离，不改变 CLI 运行时行为。

## 测量学说明

不修改 doctor 报告 schema、生产持久化、历史保留策略或任何评分语义，不影响跨版本可比性。