### PR TITLE
chore(release): 发布 1.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 Evaluation Core 的第二个 1.0 预览版本。该版本包含 #626 对公开 JSON Schema 身份的收口；npm 将发布到 `next`，`latest` 继续保持 `0.54.0`。

## 迁移说明

`1.0.0-beta.0` 生成的 Schema identity、Schema digest 与 Run Contract digest 不应和 `beta.1` 混用。依赖持久化阶段 Bundle 的预览版用户需要重新编译 Definition 并重新运行评测。

## 测量学说明

本次版本提交本身只更新 package version。版本包含的 #626 不改变评分类 prompt、评分语义、统计公式或 Decision 规则，但会改变公开 Schema 身份，因此 release notes 必须保留 `BREAKING-COMPARABILITY` 提示。

## 验证

完整 `yarn ci` 已通过。