### PR TITLE
fix(cli): 改进评测状态目录错误提示

### DIFF
--- a/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
+++ b/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
@@ -72,6 +72,22 @@ function absolute(root: string, locator: string): string {
   return isAbsolute(locator) ? resolve(locator) : resolve(root, locator);
 }
 
+const ARTIFACT_STORAGE_ERROR_CODES = new Set([
+  'EACCES',
+  'EDQUOT',
+  'EEXIST',
+  'ENOSPC',
+  'ENOTDIR',
+  'EPERM',
+  'EROFS',
+]);
+
+function systemErrorCode(cause: unknown): string | undefined {
+  if (cause === null || typeof cause !== 'object') return undefined;
+  const code = (cause as NodeJS.ErrnoException).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
 function executionWorkspaceDescriptor(
   descriptor: ResolvedResourceDescriptor,
 ): ExecutionWorkspaceDescriptor {
@@ -671,12 +687,23 @@ export async function resolveNodeCliEvaluationRequest(
     message: 'Batch request 必须由 production host workflow 展开为独立 child evaluation。',
   });
   let loaded: ReturnType<typeof loadSamples>;
-  let artifacts: Artifact[];
   try {
     loaded = loadSamples(
       absolute(options.projectRoot, request.values.locators.samples),
       { assertionValidationMode: 'strict' },
     );
+  } catch (cause) {
+    return fail({
+      code: 'CLI_INPUT_RESOLUTION_FAILED',
+      sourcePath: request.values.locators.samples,
+      fieldPath: 'samples',
+      message: '无法读取或解析 samples；请检查用例路径、文件权限和内容格式。',
+      cause,
+    });
+  }
+
+  let artifacts: Artifact[];
+  try {
     const skillDirectory = absolute(options.projectRoot, request.values.locators.skillDirectory);
     artifacts = resolveArtifacts(skillDirectory, request.values.variants.map((variant) => (
       variant.artifactSource.artifactSourceKind === 'remote-git'
@@ -707,10 +734,22 @@ export async function resolveNodeCliEvaluationRequest(
       materialize: true,
     });
   } catch (cause) {
+    const code = systemErrorCode(cause);
+    const storageFailure = code !== undefined && ARTIFACT_STORAGE_ERROR_CODES.has(code);
     return fail({
       code: 'CLI_INPUT_RESOLUTION_FAILED',
-      sourcePath: request.values.locators.samples,
-      message: '无法解析 samples 或 knowledge artifact；详情已保留在受控 cause 中。',
+      fieldPath: 'variants',
+      message: storageFailure
+        ? `无法创建 knowledge artifact 的评测隔离副本（${code}）。请检查源 skill 的读取权限，以及 \`OMK_HOME\` 或 \`OMK_TREES_DIR\` 指向目录的写入权限和剩余空间。`
+        : '无法解析或物化 knowledge artifact；请检查 variant 表达式、skill 路径和文件内容。',
+      ...(storageFailure
+        ? {
+            details: {
+              resolutionFailureKind: 'artifact-materialization-storage',
+              systemCode: code,
+            },
+          }
+        : {}),
       cause,
     });
   }

--- a/test/cli/oclif-eval.test.ts
+++ b/test/cli/oclif-eval.test.ts
@@ -21,6 +21,14 @@ const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, '..', '..');
 const CLI = join(PROJECT_ROOT, 'dist', 'cli', 'index.js');
+const EXAMPLE_SAMPLES = join(PROJECT_ROOT, 'test', 'fixtures', 'code-review', 'eval-samples.json');
+const CUSTOM_EXECUTOR = join(
+  PROJECT_ROOT,
+  'test',
+  'fixtures',
+  'custom-executor',
+  'core-fixture-executor.sh',
+);
 
 interface ExecError extends Error {
   code?: number;
@@ -127,6 +135,45 @@ describe('oclif eval', () => {
           assert.ok(e.stderr.includes('下一步'), e.stderr);
           assert.ok(e.stderr.includes('omk sample skills/review'), e.stderr);
           assert.ok(!e.stderr.includes('ENOENT'), e.stderr);
+          return true;
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('eval 无法写入评测隔离目录时给出可操作提示且不泄露路径', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-eval-trees-permission-'));
+    const blockedTreesPath = join(dir, 'blocked-trees');
+    try {
+      await mkdir(join(dir, 'skills', 'control'), { recursive: true });
+      await mkdir(join(dir, 'skills', 'treatment'), { recursive: true });
+      await writeFile(join(dir, 'skills', 'control', 'SKILL.md'), '# Control\nAnswer directly.\n');
+      await writeFile(join(dir, 'skills', 'treatment', 'SKILL.md'), '# Treatment\nUse the supplied knowledge.\n');
+      await writeFile(blockedTreesPath, 'not a directory');
+
+      await assert.rejects(
+        () => runCommand(EvalCommand, [
+          '--samples', EXAMPLE_SAMPLES,
+          '--skill-dir', 'skills',
+          '--control', 'control',
+          '--treatment', 'treatment',
+          '--executor', CUSTOM_EXECUTOR,
+          '--no-judge',
+          '--dry-run',
+          '--skip-doctor',
+          '--skip-connectivity',
+          '--lang', 'zh',
+        ], { cwd: dir, env: { OMK_TREES_DIR: blockedTreesPath } }),
+        (err: unknown) => {
+          const e = err as ExecError;
+          assert.equal(e.code, 1, `expected exit 1, got ${e.code}`);
+          assert.ok(e.stderr.includes('knowledge artifact 的评测隔离副本'), e.stderr);
+          assert.ok(e.stderr.includes('EEXIST'), e.stderr);
+          assert.ok(e.stderr.includes('OMK_HOME'), e.stderr);
+          assert.ok(e.stderr.includes('OMK_TREES_DIR'), e.stderr);
+          assert.ok(!e.stderr.includes(dir), e.stderr);
           return true;
         },
       );

--- a/test/eval-workflows/production-host/node-cli-evaluation-resolver.test.ts
+++ b/test/eval-workflows/production-host/node-cli-evaluation-resolver.test.ts
@@ -228,6 +228,38 @@ describe('resolveNodeCliEvaluationRequest', () => {
     });
   });
 
+  it('reports actionable storage guidance without exposing artifact paths', async () => {
+    const root = await fixture('artifact-storage-failure');
+    for (const name of ['control-dir', 'treatment-dir']) {
+      await mkdir(join(root, 'skills', name));
+      await writeFile(join(root, 'skills', name, 'SKILL.md'), `# ${name}\nSafe content.\n`);
+    }
+    const unavailableRoot = join(root, 'not-a-directory');
+    await writeFile(unavailableRoot, 'blocks directory materialization');
+    vi.stubEnv('OMK_TREES_DIR', unavailableRoot);
+
+    const failure = await resolveNodeCliEvaluationRequest(request(root, {
+      control: 'control-dir',
+      treatment: 'treatment-dir',
+    }), {
+      projectRoot: root,
+      materializationRoot: join(root, '.omk', 'resolved'),
+    }).catch((cause: unknown) => cause);
+
+    expect(failure).toMatchObject({
+      code: 'CLI_INPUT_RESOLUTION_FAILED',
+      fieldPath: 'variants',
+      details: {
+        resolutionFailureKind: 'artifact-materialization-storage',
+        systemCode: 'EEXIST',
+      },
+    });
+    expect((failure as Error).message).toContain('OMK_HOME');
+    expect((failure as Error).message).toContain('OMK_TREES_DIR');
+    expect((failure as Error).message).toContain('EEXIST');
+    expect((failure as Error).message).not.toContain(root);
+  });
+
   it('resolves real files into a compilable five-layer design without leaking secret mock controls', async () => {
     const root = await fixture('compile');
     const resolved = await resolveNodeCliEvaluationRequest(request(root), {


### PR DESCRIPTION
## 用户影响

当目录型 skill 的评测隔离副本无法写入时，eval 会区分 samples 读取失败与 artifact 物化失败，展示安全的系统错误码，并提示通过 OMK_HOME 或 OMK_TREES_DIR 修复状态目录权限或空间问题。原始 cause 与本机路径仍不会输出。

## 迁移说明

无需迁移；现有命令参数与成功路径保持不变。

## 测量学说明

本变更只收紧 CLI 输入解析阶段的诊断边界，不修改 Evaluation Core schema、评分管道、评分类 prompt 或测量可比性语义。