### PR TITLE
feat(eval-runtime): 补齐企业宿主采用闭环

### DIFF
--- a/docs/guides/eval-runtime.md
+++ b/docs/guides/eval-runtime.md
@@ -23,8 +23,8 @@ npm install oh-my-knowledge
 Create one identity for the deployed invocation implementation. Every field below is measurement-relevant and becomes part of the sealed Runtime fingerprint:
 
 ```ts
-import { createEvaluationEngine } from 'oh-my-knowledge/eval-core';
 import {
+  createEvaluationEngine,
   createEvaluationRuntime,
   createExactMatchDefinition,
   createExactMatchEvaluator,
@@ -131,6 +131,36 @@ await reportStore.put(result.report);
 
 The random `runId` distinguishes executions and affects artifact identity; it is not part of the measurement plan. Rebuilding the same Definition, Policy, and Runtime identity with the same explicit seed produces the same `runContractDigest`.
 
+## Build a service or RAG comparison
+
+`createExactMatchDefinition` is the shortest path when output equality is the metric. For service or RAG evaluations with a custom deterministic metric or Rubric Judge, use `createPairedComparisonDefinition`. It accepts one Evaluator fragment and its matching Metric fragment, and returns the ordinary serializable Core `EvaluationDefinition` rather than a second runtime-specific contract:
+
+```ts
+import { createPairedComparisonDefinition } from 'oh-my-knowledge/eval-runtime';
+
+const definition = createPairedComparisonDefinition({
+  datasetId: 'retrieval-regression',
+  seed: 'index-release-42',
+  samples,
+  control: {
+    targetId: 'control',
+    targetKind: 'rag',
+    executorId: identity.implementationId,
+    config: { indexRevision: 'baseline' },
+  },
+  treatment: {
+    targetId: 'treatment',
+    targetKind: 'rag',
+    executorId: identity.implementationId,
+    config: { indexRevision: 'candidate' },
+  },
+  evaluator,
+  metric,
+});
+```
+
+The builder deliberately supports one higher-is-better numeric or boolean metric with `exclude/v1`. Use the lower-level `oh-my-knowledge/eval-core` contract for multi-metric graphs, lower-is-better metrics, or a different missing-data policy instead of silently approximating those designs.
+
 ## Add a Rubric Judge through an internal model gateway
 
 The host provides one model invocation port. OMK owns the frozen prompt, output parsing, 1–5 metric contract, evidence, failure semantics, and Evaluator identity. The port must not retry: Core already owns retry, timeout, budget, cache, and cancellation.
@@ -212,4 +242,6 @@ Register raw Core Executor or Evaluator ports with `{ port }` when one Definitio
 
 Use `createSameProcessExecutorAdapter` and `createSameProcessEvaluatorAdapter` for custom in-process ports. Use the advanced APIs from `oh-my-knowledge/eval-core` when you need staged execution, persisted artifact admission, custom Analysis Runtime implementations, or explicit cross-run comparability. See [Embedded Evaluation Core API](/reference/embedded-api).
 
-Runnable package fixtures cover [exact match](https://github.com/lizhiyao/oh-my-knowledge/blob/main/test/eval-runtime/fixtures/embedded-host.mjs) and a [host-owned Rubric Judge gateway](https://github.com/lizhiyao/oh-my-knowledge/blob/main/test/eval-runtime/fixtures/rubric-judge-host.mjs).
+Before accepting a new Executor adapter, run `runExecutorConformance({ implementationId, createExecutor, input, expected })` from `oh-my-knowledge/eval-runtime`. It exercises isolated control and treatment lifecycles, repeated invocations, exact-match observation, paired analysis, and Decision through the real Core pipeline. Use `assertExecutorConformance(result)` in an adapter test to fail with stable check IDs. The probe is intentionally framework-neutral and performs no filesystem, network, credential, or environment discovery by itself.
+
+Start with the runnable [minimal public example](https://github.com/lizhiyao/oh-my-knowledge/tree/main/examples/eval-runtime). Package fixtures additionally cover a [host-owned Rubric Judge gateway](https://github.com/lizhiyao/oh-my-knowledge/blob/main/test/eval-runtime/fixtures/rubric-judge-host.mjs) and an [advanced five-stage host](https://github.com/lizhiyao/oh-my-knowledge/blob/main/test/eval-runtime/fixtures/advanced-host.mjs). CI executes the public example and fixtures against the packed package from an isolated home directory.

--- a/docs/reference/embedded-api.md
+++ b/docs/reference/embedded-api.md
@@ -26,7 +26,7 @@ Synchronous `require('oh-my-knowledge')` is intentionally unsupported. OMK does 
 |---|---|
 | `oh-my-knowledge` | minimal one-call Engine façade and Core contracts |
 | `oh-my-knowledge/eval-core` | advanced staged execution, artifact admission and verification, comparability, Series, and Schema discovery |
-| `oh-my-knowledge/eval-runtime` | lightweight host assembly, Runtime identities, `ExecutorFn` bridge, and sealed Definition/Policy builders |
+| `oh-my-knowledge/eval-runtime` | lightweight host assembly, Runtime identities, `ExecutorFn` bridge, sealed Definition/Policy builders, and adapter conformance probe |
 | `oh-my-knowledge/projections` | downstream artifact projections |
 | `oh-my-knowledge/studio` | Studio Core-run catalog and routes |
 | `oh-my-knowledge/mcp` / `oh-my-knowledge/dsh-plugin` | integration-specific APIs |

--- a/docs/zh/guides/eval-runtime.md
+++ b/docs/zh/guides/eval-runtime.md
@@ -23,8 +23,8 @@ npm install oh-my-knowledge
 为已部署的调用实现创建一份 identity。下面每个字段都会影响测量，并进入封存的 Runtime fingerprint：
 
 ```ts
-import { createEvaluationEngine } from 'oh-my-knowledge/eval-core';
 import {
+  createEvaluationEngine,
   createEvaluationRuntime,
   createExactMatchDefinition,
   createExactMatchEvaluator,
@@ -131,6 +131,36 @@ await reportStore.put(result.report);
 
 随机 `runId` 用于区分执行，并影响 artifact identity，但不属于测量计划。同一份 Definition、Policy、Runtime identity 与显式 seed 会生成相同的 `runContractDigest`。
 
+## 构造服务或 RAG 对比
+
+以输出相等作为指标时，`createExactMatchDefinition` 是最短路径。服务或 RAG 评测使用自定义确定性指标或 Rubric Judge 时，使用 `createPairedComparisonDefinition`。它接收一个 Evaluator 片段及其匹配的 Metric 片段，返回普通、可序列化的 Core `EvaluationDefinition`，不会引入第二套 Runtime 专属契约：
+
+```ts
+import { createPairedComparisonDefinition } from 'oh-my-knowledge/eval-runtime';
+
+const definition = createPairedComparisonDefinition({
+  datasetId: 'retrieval-regression',
+  seed: 'index-release-42',
+  samples,
+  control: {
+    targetId: 'control',
+    targetKind: 'rag',
+    executorId: identity.implementationId,
+    config: { indexRevision: 'baseline' },
+  },
+  treatment: {
+    targetId: 'treatment',
+    targetKind: 'rag',
+    executorId: identity.implementationId,
+    config: { indexRevision: 'candidate' },
+  },
+  evaluator,
+  metric,
+});
+```
+
+该 builder 有意只支持一个 `higher-is-better` 的 numeric 或 boolean 指标，并使用 `exclude/v1`。多指标图、`lower-is-better` 指标或其它缺失值策略应直接使用 `oh-my-knowledge/eval-core` 的底层契约，避免接入层静默近似测量设计。
+
 ## 通过内部模型网关接入 Rubric Judge
 
 宿主只提供一次模型调用 port。冻结 prompt、输出解析、1～5 分指标契约、evidence、失败语义和 Evaluator identity 均由 OMK 负责。该 port 不应自行重试；重试、超时、预算、缓存和取消仍由 Core 统一控制。
@@ -212,4 +242,6 @@ const runtime = createEvaluationRuntime({
 
 自定义进程内 port 时，使用 `createSameProcessExecutorAdapter` 与 `createSameProcessEvaluatorAdapter`。需要分阶段执行、持久化 artifact admission、自定义 Analysis Runtime 或显式跨 run 可比性时，使用 `oh-my-knowledge/eval-core` 的高级 API。参见[嵌入式 Evaluation Core API](/zh/reference/embedded-api)。
 
-可运行 package fixture 分别覆盖[精确匹配](https://github.com/lizhiyao/oh-my-knowledge/blob/main/test/eval-runtime/fixtures/embedded-host.mjs)和[宿主持有的 Rubric Judge 网关](https://github.com/lizhiyao/oh-my-knowledge/blob/main/test/eval-runtime/fixtures/rubric-judge-host.mjs)。
+接纳新的 Executor adapter 前，从 `oh-my-knowledge/eval-runtime` 调用 `runExecutorConformance({ implementationId, createExecutor, input, expected })`。它会通过真实 Core pipeline 检查隔离的 control／treatment 生命周期、重复调用、exact-match observation、配对分析与 Decision。Adapter 测试可调用 `assertExecutorConformance(result)`，以稳定 check ID 报错。该探针与框架无关，自身不会发现文件系统、网络、凭证或环境配置。
+
+建议从可运行的[最小公开示例](https://github.com/lizhiyao/oh-my-knowledge/tree/main/examples/eval-runtime)开始。Package fixture 还覆盖[宿主持有的 Rubric Judge 网关](https://github.com/lizhiyao/oh-my-knowledge/blob/main/test/eval-runtime/fixtures/rubric-judge-host.mjs)和[高级五阶段宿主](https://github.com/lizhiyao/oh-my-knowledge/blob/main/test/eval-runtime/fixtures/advanced-host.mjs)。CI 会在隔离的用户目录中，使用打包后的产物执行公开示例与这些 fixture。

--- a/docs/zh/reference/embedded-api.md
+++ b/docs/zh/reference/embedded-api.md
@@ -26,7 +26,7 @@ OMK 有意不支持同步 `require('oh-my-knowledge')`，也不发布第二份 C
 |---|---|
 | `oh-my-knowledge` | 最小一键 Engine façade 与 Core contract |
 | `oh-my-knowledge/eval-core` | 高级分阶段执行、artifact admission 与验证、comparability、Series 和 Schema 发现 |
-| `oh-my-knowledge/eval-runtime` | 轻量宿主装配、Runtime identity、`ExecutorFn` 桥接和封存的 Definition／Policy builder |
+| `oh-my-knowledge/eval-runtime` | 轻量宿主装配、Runtime identity、`ExecutorFn` 桥接、封存的 Definition／Policy builder 和 adapter conformance 探针 |
 | `oh-my-knowledge/projections` | 下游 artifact projection |
 | `oh-my-knowledge/studio` | Studio Core-run catalog 与 route |
 | `oh-my-knowledge/mcp`／`oh-my-knowledge/dsh-plugin` | 集成专用 API |

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ Use `omk init demo --samples 20` when you want the first-party, difficulty-strat
 
 | Task | Example | What it demonstrates | First command | Model call |
 |---|---|---|---|---|
+| Embed OMK in a service | [eval-runtime](./eval-runtime) | Public ESM Runtime assembly, host invocation injection, deterministic scoring, and in-memory report materialization | `yarn build && node examples/eval-runtime/run.mjs` | No |
 | Inspect a directory skill | [skill-map-showcase](./skill-map-showcase) | Frontmatter, references, scripts, workflows, private samples, Doctor, and Skill Map | `cd examples/skill-map-showcase && omk doctor skills/release-readiness --static-only` | No |
 | Evaluate grounded answers | [rag-eval](./rag-eval) | `faithfulness`, `answer_relevancy`, and `context_recall` assertions | `cd examples/rag-eval && omk eval --control context-answerer --treatment rag-answerer --dry-run` | No for dry-run; yes for evaluation |
 | Evaluate repository-aware agents | [agent-runtime](./agent-runtime) | A sample-scoped working directory and file-backed task evidence | `cd examples/agent-runtime && omk eval --control repo-answerer --treatment repo-navigator --dry-run` | No for dry-run; yes for evaluation |

--- a/examples/README.zh.md
+++ b/examples/README.zh.md
@@ -16,6 +16,7 @@ omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
 
 | 任务 | 示例 | 演示内容 | 第一条命令 | 是否调用模型 |
 |---|---|---|---|---|
+| 在服务中嵌入 OMK | [eval-runtime](./eval-runtime/README.zh.md) | 公共 ESM Runtime 装配、宿主调用注入、确定性评分与内存报告物化 | `yarn build && node examples/eval-runtime/run.mjs` | 否 |
 | 检查目录式 skill | [skill-map-showcase](./skill-map-showcase/README.zh.md) | Frontmatter、references、scripts、workflows、私有用例、Doctor 与 Skill Map | `cd examples/skill-map-showcase && omk doctor skills/release-readiness --static-only` | 否 |
 | 评测基于上下文的回答 | [rag-eval](./rag-eval/README.zh.md) | `faithfulness`、`answer_relevancy` 与 `context_recall` 断言 | `cd examples/rag-eval && omk eval --control context-answerer --treatment rag-answerer --dry-run` | dry-run 否；真实评测是 |
 | 评测理解仓库的 agent | [agent-runtime](./agent-runtime/README.zh.md) | 用例级工作目录与基于文件的任务证据 | `cd examples/agent-runtime && omk eval --control repo-answerer --treatment repo-navigator --dry-run` | dry-run 否；真实评测是 |

--- a/examples/eval-runtime/README.md
+++ b/examples/eval-runtime/README.md
@@ -1,0 +1,24 @@
+# Embed the Evaluation Runtime
+
+[中文说明](./README.zh.md)
+
+## Purpose
+
+This minimal Node.js ESM host injects an in-memory business invocation function into `oh-my-knowledge/eval-runtime`, compares two service deployments, applies deterministic exact-match scoring, and materializes an Evaluation Report. It does not load the CLI or read user configuration.
+
+## Run
+
+From this repository with Node.js 22 or newer:
+
+```bash
+yarn build
+node examples/eval-runtime/run.mjs
+```
+
+The command prints one JSON line with `runStatus: "completed"`, an estimated treatment improvement of `0.6666666666666666`, a decided status, and the report ID.
+
+To use it in a separate service, run `npm install oh-my-knowledge`, copy `run.mjs`, then replace the deterministic `executor` body with the service's Target invocation. Credentials, tenant authorization, queues, and storage remain owned by the host.
+
+## Evidence boundary
+
+The example proves that a public `eval-runtime` consumer can complete an in-memory control／treatment measurement without provider or filesystem configuration. Its three deterministic teaching samples are not representative, statistically powered release evidence, and the fake invocation does not validate a production model gateway's timeout, retry, privacy, or cost behavior.

--- a/examples/eval-runtime/README.zh.md
+++ b/examples/eval-runtime/README.zh.md
@@ -1,0 +1,24 @@
+# 嵌入 Evaluation Runtime
+
+[English](./README.md)
+
+## 用途
+
+这个最小 Node.js ESM 宿主把内存中的业务调用函数注入 `oh-my-knowledge/eval-runtime`，对比两个服务部署，执行确定性 exact-match 评分，并物化 Evaluation Report。它不会加载 CLI，也不会读取用户配置。
+
+## 运行
+
+在本仓库中使用 Node.js 22 或更高版本运行：
+
+```bash
+yarn build
+node examples/eval-runtime/run.mjs
+```
+
+命令会输出一行 JSON，其中 `runStatus` 为 `"completed"`，treatment 改进估计值为 `0.6666666666666666`，Decision 已完成，并包含 report ID。
+
+在独立服务中使用时，先运行 `npm install oh-my-knowledge`，再复制 `run.mjs`，并用服务的 Target 调用替换确定性的 `executor` 函数体。凭证、租户鉴权、队列与存储仍由宿主持有。
+
+## 证据边界
+
+该示例证明只使用公共 `eval-runtime` 的 consumer 可以在无 provider、无文件系统配置的条件下完成内存 control／treatment 测量。三条确定性教学用例不具备代表性或充分统计功效，不能作为发布证据；模拟调用也不能验证生产模型网关的超时、重试、隐私或成本行为。

--- a/examples/eval-runtime/run.mjs
+++ b/examples/eval-runtime/run.mjs
@@ -1,0 +1,95 @@
+import {
+  createEvaluationEngine,
+  createEvaluationRuntime,
+  createExactMatchDefinition,
+  createExactMatchEvaluator,
+  createExecutorFnAdapter,
+  createInvokeExecutorIdentity,
+  createMeasurementPolicy,
+} from 'oh-my-knowledge/eval-runtime';
+
+const identity = createInvokeExecutorIdentity({
+  implementationId: 'example.answer-service/v1',
+  version: '1.0.0',
+  determinism: 'deterministic',
+  cancellation: 'cooperative',
+  concurrency: { safety: 'parallel-safe' },
+  seedControl: 'unsupported',
+  telemetry: { trace: 'unsupported', usage: 'required' },
+  fingerprintFacets: { deploymentRevision: 'example-1' },
+});
+
+const answers = {
+  baseline: { one: 'A', two: 'incorrect', three: 'incorrect' },
+  candidate: { one: 'A', two: 'B', three: 'C' },
+};
+const createExecutor = () => createExecutorFnAdapter({
+  identity,
+  outputClassification: 'public',
+  mapInput: ({ targetConfig, input }) => ({
+    model: targetConfig.deployment,
+    prompt: input.prompt,
+  }),
+  executor: async ({ model, prompt, abortSignal }) => {
+    abortSignal?.throwIfAborted();
+    return {
+      ok: true,
+      output: answers[model][prompt],
+      durationMs: 1,
+      durationApiMs: 1,
+      inputTokens: 1,
+      outputTokens: 1,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      tokenUsageReportedByExecutor: true,
+      costUSD: 0,
+      costReportedByExecutor: false,
+      stopReason: 'completed',
+      numTurns: 1,
+    };
+  },
+});
+
+const runtime = createEvaluationRuntime({
+  executors: [{ implementationId: identity.implementationId, createPort: createExecutor }],
+  evaluators: [{ port: createExactMatchEvaluator() }],
+});
+const definition = createExactMatchDefinition({
+  datasetId: 'embedded-service-example',
+  seed: 'explicit-example-seed',
+  samples: [
+    { sampleId: 'one', input: { prompt: 'one' }, expected: 'A' },
+    { sampleId: 'two', input: { prompt: 'two' }, expected: 'B' },
+    { sampleId: 'three', input: { prompt: 'three' }, expected: 'C' },
+  ],
+  control: {
+    targetId: 'control',
+    executorId: identity.implementationId,
+    config: { deployment: 'baseline' },
+  },
+  treatment: {
+    targetId: 'treatment',
+    executorId: identity.implementationId,
+    config: { deployment: 'candidate' },
+  },
+  bootstrap: { resamples: 100 },
+});
+
+const prepared = await createEvaluationEngine(runtime).prepare(
+  definition,
+  createMeasurementPolicy({ maxConcurrency: 2 }),
+);
+const run = prepared.start({ runId: 'eval-runtime-example', eventBufferCapacity: 128 });
+const draining = (async () => {
+  for await (const event of run.events) void event;
+})();
+const result = await run.result;
+await draining;
+if (result.status !== 'completed') throw new Error(result.error.code);
+
+process.stdout.write(`${JSON.stringify({
+  runStatus: result.status,
+  estimate: result.artifacts.analysis.records[0].value.estimate,
+  decisionStatus: result.artifacts.decision.decisionStatus,
+  reportId: result.report.reportId,
+})}\n`);

--- a/src/eval-runtime/builders/exact-match.ts
+++ b/src/eval-runtime/builders/exact-match.ts
@@ -1,12 +1,10 @@
 import {
-  EVALUATION_DEFINITION_SCHEMA_VERSION,
-  EvaluationDefinitionSchema,
-  deepFreezeCanonicalJson,
   type EvaluationDefinition,
   type EvaluationSample,
   type JsonValue,
 } from '../../eval-core/contracts/index.js';
 import { EXACT_MATCH_EVALUATOR_IMPLEMENTATION_ID } from '../evaluators/exact-match.js';
+import { createPairedComparisonDefinition } from './paired-comparison.js';
 
 export interface ExactMatchTarget {
   readonly targetId: string;
@@ -40,45 +38,22 @@ export function createExactMatchDefinition(
   input: Readonly<ExactMatchDefinitionBuilderInput>,
 ): EvaluationDefinition {
   const metricId = input.metricId ?? 'correct';
-  const comparisonId = 'control-vs-treatment';
-  const resultId = 'paired-correctness-difference';
-  const targets = [input.control, input.treatment].map((target) => ({
-    targetId: target.targetId,
-    targetKind: target.targetKind ?? 'function',
-    protocolId: 'omk.invoke/v1' as const,
-    executorId: target.executorId,
-    executionRequirements: {
-      systemInstructions: 'not-required' as const,
-      workspace: 'not-required' as const,
-      mcp: 'not-required' as const,
-      mockInterception: 'not-required' as const,
-      toolPolicy: 'runtime-default' as const,
-      skillDiscovery: 'runtime-default' as const,
+  return createPairedComparisonDefinition({
+    datasetId: input.datasetId,
+    samples: input.samples,
+    control: input.control,
+    treatment: input.treatment,
+    seed: input.seed,
+    trials: input.trials,
+    bootstrap: input.bootstrap,
+    decision: input.decision,
+    identities: {
+      comparisonId: 'control-vs-treatment',
+      analysisNodeId: 'paired-correctness-bootstrap',
+      analysisResultId: 'paired-correctness-difference',
+      decisionPolicyId: 'progress-decision',
     },
-    executionControls: {
-      defaults: {
-        workspace: { workspaceMode: 'not-required' as const },
-        tools: { toolPolicyKind: 'runtime-default' as const },
-      },
-      sampleOverrides: [],
-    },
-    ...(target.config === undefined ? {} : { config: structuredClone(target.config) }),
-  }));
-  const randomizationSlots = targets.map((target) => ({
-    targetId: target.targetId,
-    randomizationSlotId: `slot-${target.targetId}`,
-  })).sort((left, right) => (
-    left.randomizationSlotId < right.randomizationSlotId ? -1
-      : left.randomizationSlotId > right.randomizationSlotId ? 1 : 0
-  ));
-  const definition = EvaluationDefinitionSchema.parse({
-    schemaVersion: EVALUATION_DEFINITION_SCHEMA_VERSION,
-    dataset: {
-      datasetId: input.datasetId,
-      samples: structuredClone(input.samples),
-    },
-    targets,
-    evaluators: [{
+    evaluator: {
       evaluatorId: 'exact-match',
       evaluatorKind: 'assertion',
       implementationId: EXACT_MATCH_EVALUATOR_IMPLEMENTATION_ID,
@@ -93,66 +68,13 @@ export function createExactMatchDefinition(
         { bindingId: 'actual', sourceKind: 'output', pointer: '' },
         { bindingId: 'expected', sourceKind: 'expected', pointer: '' },
       ],
-    }],
-    metrics: [{
+    },
+    metric: {
       metricId,
       valueType: 'boolean',
       scope: 'sample',
       direction: 'higher-is-better',
       missingPolicyId: 'exclude/v1',
-    }],
-    experiment: {
-      trials: input.trials ?? 1,
-      seed: input.seed,
-      randomizationSlots,
-      sampling: {
-        experimentalUnit: 'sample',
-        pairingKey: '/sampleId',
-        repeatedMeasures: (input.trials ?? 1) > 1,
-        resamplingUnit: 'paired-block',
-        estimatorId: 'bootstrap.paired-difference-percentile/v1',
-        seedCoupling: 'shared-within-block',
-      },
-      scheduling: { schedulingKind: 'interleaved' },
-    },
-    analysisGraph: {
-      analysisMode: 'preregistered',
-      nodes: [{
-        analysisNodeKind: 'estimator',
-        nodeId: 'paired-correctness-bootstrap',
-        implementationId: 'bootstrap.paired-difference-percentile/v1',
-        inputs: [
-          { inputKind: 'metric-observations', referenceId: metricId },
-          {
-            inputKind: 'comparison',
-            referenceId: comparisonId,
-            treatmentTargetId: input.treatment.targetId,
-            metricId,
-          },
-        ],
-        outputResultId: resultId,
-        parameters: {
-          resamples: input.bootstrap?.resamples ?? 1_000,
-          alpha: input.bootstrap?.alpha ?? 0.05,
-        },
-      }],
-    },
-    comparisons: [{
-      comparisonId,
-      controlTargetId: input.control.targetId,
-      treatmentTargetIds: [input.treatment.targetId],
-      metricIds: [metricId],
-    }],
-    decisionPolicy: {
-      decisionPolicyId: 'progress-decision',
-      implementationId: 'progress/v1',
-      analysisResultIds: [resultId],
-      minimumEvidenceStatus: input.decision?.minimumEvidenceStatus ?? 'complete',
-      parameters: {
-        threshold: input.decision?.threshold ?? 0,
-        equivalence: input.decision?.equivalence ?? 0,
-      },
     },
   });
-  return deepFreezeCanonicalJson(definition);
 }

--- a/src/eval-runtime/builders/paired-comparison.ts
+++ b/src/eval-runtime/builders/paired-comparison.ts
@@ -1,0 +1,181 @@
+import {
+  EVALUATION_DEFINITION_SCHEMA_VERSION,
+  EvaluationDefinitionSchema,
+  EvaluatorDefinitionSchema,
+  MetricDefinitionSchema,
+  TargetDefinitionSchema,
+  deepFreezeCanonicalJson,
+  type EvaluationDefinition,
+  type EvaluationSample,
+  type EvaluatorDefinition,
+  type JsonValue,
+  type MetricDefinition,
+  type TargetDefinition,
+  type TargetExecutionControls,
+  type TargetExecutionRequirements,
+} from '../../eval-core/contracts/index.js';
+
+export interface EvaluationRuntimeTarget {
+  readonly targetId: string;
+  readonly executorId: string;
+  readonly targetKind?: string;
+  readonly protocolId?: 'omk.invoke/v1' | 'omk.session/v1';
+  readonly versionConstraint?: string;
+  readonly config?: JsonValue;
+  readonly executionRequirements?: TargetExecutionRequirements;
+  readonly executionControls?: TargetExecutionControls;
+}
+
+export interface PairedComparisonDefinitionBuilderInput {
+  readonly datasetId: string;
+  readonly samples: readonly EvaluationSample[];
+  readonly control: EvaluationRuntimeTarget;
+  readonly treatment: EvaluationRuntimeTarget;
+  readonly evaluator: EvaluatorDefinition;
+  readonly metric: MetricDefinition;
+  /** Required measurement seed; never sourced from time, environment, or randomness. */
+  readonly seed: string;
+  readonly trials?: number;
+  readonly bootstrap?: Readonly<{ resamples?: number; alpha?: number }>;
+  readonly decision?: Readonly<{
+    threshold?: number;
+    equivalence?: number;
+    minimumEvidenceStatus?: 'complete' | 'partial' | 'unresolvable';
+  }>;
+  readonly identities?: Readonly<{
+    comparisonId?: string;
+    analysisNodeId?: string;
+    analysisResultId?: string;
+    decisionPolicyId?: string;
+  }>;
+}
+
+function target(input: Readonly<EvaluationRuntimeTarget>): TargetDefinition {
+  return TargetDefinitionSchema.parse({
+    targetId: input.targetId,
+    targetKind: input.targetKind ?? 'function',
+    protocolId: input.protocolId ?? 'omk.invoke/v1',
+    executorId: input.executorId,
+    ...(input.versionConstraint === undefined
+      ? {}
+      : { versionConstraint: input.versionConstraint }),
+    executionRequirements: input.executionRequirements ?? {
+      systemInstructions: 'not-required',
+      workspace: 'not-required',
+      mcp: 'not-required',
+      mockInterception: 'not-required',
+      toolPolicy: 'runtime-default',
+      skillDiscovery: 'runtime-default',
+    },
+    executionControls: input.executionControls ?? {
+      defaults: {
+        workspace: { workspaceMode: 'not-required' },
+        tools: { toolPolicyKind: 'runtime-default' },
+      },
+      sampleOverrides: [],
+    },
+    ...(input.config === undefined ? {} : { config: structuredClone(input.config) }),
+  });
+}
+
+/**
+ * Builds one auditable control/treatment comparison for function, service, or RAG Targets.
+ * The result is the ordinary Core wire contract; every convenience default is materialized.
+ */
+export function createPairedComparisonDefinition(
+  input: Readonly<PairedComparisonDefinitionBuilderInput>,
+): EvaluationDefinition {
+  const evaluator = EvaluatorDefinitionSchema.parse(structuredClone(input.evaluator));
+  const metric = MetricDefinitionSchema.parse(structuredClone(input.metric));
+  if (evaluator.metricIds.length !== 1 || evaluator.metricIds[0] !== metric.metricId) {
+    throw new TypeError('Paired comparison requires one Evaluator metric matching metric.metricId.');
+  }
+  if (!['numeric', 'boolean'].includes(metric.valueType)
+      || metric.direction !== 'higher-is-better'
+      || metric.missingPolicyId !== 'exclude/v1') {
+    throw new TypeError(
+      'Paired comparison requires a higher-is-better numeric or boolean metric using exclude/v1.',
+    );
+  }
+  const control = target(input.control);
+  const treatment = target(input.treatment);
+  if (control.targetId === treatment.targetId) {
+    throw new TypeError('Paired comparison control and treatment targetId must differ.');
+  }
+  const targets = [control, treatment];
+  const metricId = metric.metricId;
+  const comparisonId = input.identities?.comparisonId ?? 'control-vs-treatment';
+  const analysisNodeId = input.identities?.analysisNodeId ?? `paired-${metricId}-bootstrap`;
+  const analysisResultId = input.identities?.analysisResultId ?? `paired-${metricId}-difference`;
+  const decisionPolicyId = input.identities?.decisionPolicyId ?? 'progress-decision';
+  const trials = input.trials ?? 1;
+  const definition = EvaluationDefinitionSchema.parse({
+    schemaVersion: EVALUATION_DEFINITION_SCHEMA_VERSION,
+    dataset: {
+      datasetId: input.datasetId,
+      samples: structuredClone(input.samples),
+    },
+    targets,
+    evaluators: [evaluator],
+    metrics: [metric],
+    experiment: {
+      trials,
+      seed: input.seed,
+      randomizationSlots: targets.map((candidate) => ({
+        targetId: candidate.targetId,
+        randomizationSlotId: `slot-${candidate.targetId}`,
+      })).sort((left, right) => (
+        left.randomizationSlotId < right.randomizationSlotId ? -1
+          : left.randomizationSlotId > right.randomizationSlotId ? 1 : 0
+      )),
+      sampling: {
+        experimentalUnit: 'sample',
+        pairingKey: '/sampleId',
+        repeatedMeasures: trials > 1,
+        resamplingUnit: 'paired-block',
+        estimatorId: 'bootstrap.paired-difference-percentile/v1',
+        seedCoupling: 'shared-within-block',
+      },
+      scheduling: { schedulingKind: 'interleaved' },
+    },
+    analysisGraph: {
+      analysisMode: 'preregistered',
+      nodes: [{
+        analysisNodeKind: 'estimator',
+        nodeId: analysisNodeId,
+        implementationId: 'bootstrap.paired-difference-percentile/v1',
+        inputs: [
+          { inputKind: 'metric-observations', referenceId: metricId },
+          {
+            inputKind: 'comparison',
+            referenceId: comparisonId,
+            treatmentTargetId: treatment.targetId,
+            metricId,
+          },
+        ],
+        outputResultId: analysisResultId,
+        parameters: {
+          resamples: input.bootstrap?.resamples ?? 1_000,
+          alpha: input.bootstrap?.alpha ?? 0.05,
+        },
+      }],
+    },
+    comparisons: [{
+      comparisonId,
+      controlTargetId: control.targetId,
+      treatmentTargetIds: [treatment.targetId],
+      metricIds: [metricId],
+    }],
+    decisionPolicy: {
+      decisionPolicyId,
+      implementationId: 'progress/v1',
+      analysisResultIds: [analysisResultId],
+      minimumEvidenceStatus: input.decision?.minimumEvidenceStatus ?? 'complete',
+      parameters: {
+        threshold: input.decision?.threshold ?? 0,
+        equivalence: input.decision?.equivalence ?? 0,
+      },
+    },
+  });
+  return deepFreezeCanonicalJson(definition);
+}

--- a/src/eval-runtime/conformance/executor.ts
+++ b/src/eval-runtime/conformance/executor.ts
@@ -1,0 +1,170 @@
+import {
+  createEvaluationEngine,
+  type EvaluationRunResult,
+  type Executor,
+} from '../../eval-core/engine/index.js';
+import type { JsonValue } from '../../eval-core/contracts/index.js';
+import { createExactMatchDefinition } from '../builders/exact-match.js';
+import { createMeasurementPolicy } from '../builders/policy.js';
+import { createExactMatchEvaluator } from '../evaluators/exact-match.js';
+import { createEvaluationRuntime } from '../runtime.js';
+
+export interface ExecutorConformanceProbeInput {
+  readonly implementationId: string;
+  /** A fresh Core Executor is required for each Target binding. */
+  readonly createExecutor: () => Executor;
+  readonly input: JsonValue;
+  readonly expected: JsonValue;
+  readonly seed?: string;
+  readonly runId?: string;
+}
+
+export interface RuntimeConformanceCheck {
+  readonly checkId:
+    | 'configuration'
+    | 'terminal-status'
+    | 'execution-coverage'
+    | 'evaluation-observation'
+    | 'paired-analysis'
+    | 'decision';
+  readonly checkStatus: 'passed' | 'failed';
+  readonly reasonCode?: string;
+}
+
+export interface ExecutorConformanceResult {
+  readonly conformant: boolean;
+  readonly checks: readonly RuntimeConformanceCheck[];
+  readonly run?: EvaluationRunResult;
+}
+
+export class RuntimeConformanceError extends TypeError {
+  readonly code = 'EVAL_RUNTIME_CONFORMANCE_FAILED' as const;
+  readonly failedCheckIds: readonly RuntimeConformanceCheck['checkId'][];
+
+  constructor(result: Readonly<ExecutorConformanceResult>) {
+    const failedCheckIds = result.checks
+      .filter((check) => check.checkStatus === 'failed')
+      .map((check) => check.checkId);
+    super(`Runtime conformance failed: ${failedCheckIds.join(', ')}.`);
+    this.name = 'RuntimeConformanceError';
+    this.failedCheckIds = Object.freeze(failedCheckIds);
+  }
+}
+
+function check(
+  checkId: RuntimeConformanceCheck['checkId'],
+  passed: boolean,
+  reasonCode: string,
+): RuntimeConformanceCheck {
+  return Object.freeze({
+    checkId,
+    checkStatus: passed ? 'passed' : 'failed',
+    ...(passed ? {} : { reasonCode }),
+  });
+}
+
+/**
+ * Runs a framework-neutral adapter probe through the real Core pipeline.
+ * The supplied Target is invoked for two paired samples in both control and treatment.
+ * Two samples are the minimum required by the built-in paired bootstrap analysis.
+ */
+export async function runExecutorConformance(
+  input: Readonly<ExecutorConformanceProbeInput>,
+): Promise<ExecutorConformanceResult> {
+  let run: EvaluationRunResult;
+  try {
+    const runtime = createEvaluationRuntime({
+      executors: [{
+        implementationId: input.implementationId,
+        createPort: input.createExecutor,
+      }],
+      evaluators: [{ port: createExactMatchEvaluator() }],
+    });
+    const definition = createExactMatchDefinition({
+      datasetId: 'eval-runtime-conformance',
+      seed: input.seed ?? 'eval-runtime-conformance-v1',
+      samples: ['probe-a', 'probe-b'].map((sampleId) => ({
+        sampleId,
+        input: structuredClone(input.input),
+        expected: structuredClone(input.expected),
+      })),
+      control: { targetId: 'control', executorId: input.implementationId },
+      treatment: { targetId: 'treatment', executorId: input.implementationId },
+      bootstrap: { resamples: 100 },
+    });
+    const prepared = await createEvaluationEngine(runtime).prepare(
+      definition,
+      createMeasurementPolicy({ maxConcurrency: 1 }),
+    );
+    const started = prepared.start({
+      runId: input.runId ?? 'eval-runtime-conformance',
+      eventBufferCapacity: 128,
+    });
+    const draining = (async () => {
+      for await (const event of started.events) void event;
+    })();
+    run = await started.result;
+    await draining;
+  } catch {
+    return Object.freeze({
+      conformant: false,
+      checks: Object.freeze([check(
+        'configuration',
+        false,
+        'runtime-conformance-configuration-failed',
+      )]),
+    });
+  }
+
+  const completed = run.status === 'completed' ? run : undefined;
+  const executionRecords = completed?.artifacts.execution.records ?? [];
+  const evaluationRecords = completed?.artifacts.evaluation.records ?? [];
+  const observed = evaluationRecords.flatMap((record) => (
+    record.evaluationStatus === 'completed' ? record.observations : []
+  ));
+  const analysis = completed?.artifacts.analysis.records[0];
+  const decision = completed?.artifacts.decision;
+  const checks = Object.freeze([
+    check('configuration', true, 'runtime-conformance-configuration-failed'),
+    check('terminal-status', completed !== undefined, 'runtime-conformance-run-incomplete'),
+    check(
+      'execution-coverage',
+      executionRecords.length === 4
+        && executionRecords.every((record) => record.executionStatus === 'completed'),
+      'runtime-conformance-execution-incomplete',
+    ),
+    check(
+      'evaluation-observation',
+      observed.length === 4
+        && observed.every((observation) => (
+          observation.observationStatus === 'observed' && observation.value === true
+        )),
+      'runtime-conformance-output-mismatch',
+    ),
+    check(
+      'paired-analysis',
+      analysis?.analysisStatus === 'completed'
+        && typeof analysis.value === 'object'
+        && analysis.value !== null
+        && !Array.isArray(analysis.value)
+        && analysis.value.estimate === 0,
+      'runtime-conformance-analysis-incomplete',
+    ),
+    check(
+      'decision',
+      decision?.decisionStatus === 'decided' && decision.verdict === 'NOISE',
+      'runtime-conformance-decision-incomplete',
+    ),
+  ]);
+  return Object.freeze({
+    conformant: checks.every((candidate) => candidate.checkStatus === 'passed'),
+    checks,
+    run,
+  });
+}
+
+export function assertExecutorConformance(
+  result: Readonly<ExecutorConformanceResult>,
+): asserts result is ExecutorConformanceResult & { readonly conformant: true } {
+  if (!result.conformant) throw new RuntimeConformanceError(result);
+}

--- a/src/eval-runtime/index.ts
+++ b/src/eval-runtime/index.ts
@@ -1,4 +1,5 @@
 export { createNodeEvaluationClock } from './clock.js';
+export { createEvaluationEngine } from '../eval-core/engine/index.js';
 export { createExactMatchDefinition } from './builders/exact-match.js';
 export type {
   ExactMatchDefinitionBuilderInput,
@@ -6,6 +7,11 @@ export type {
 } from './builders/exact-match.js';
 export { createMeasurementPolicy } from './builders/policy.js';
 export type { MeasurementPolicyBuilderInput } from './builders/policy.js';
+export { createPairedComparisonDefinition } from './builders/paired-comparison.js';
+export type {
+  EvaluationRuntimeTarget,
+  PairedComparisonDefinitionBuilderInput,
+} from './builders/paired-comparison.js';
 export {
   EXACT_MATCH_EVALUATOR_IMPLEMENTATION_ID,
   createExactMatchEvaluator,
@@ -101,6 +107,16 @@ export {
   attachSourceNeutralMockStats,
   parseSourceNeutralTrace,
 } from './traces/source-neutral.js';
+export {
+  RuntimeConformanceError,
+  assertExecutorConformance,
+  runExecutorConformance,
+} from './conformance/executor.js';
+export type {
+  ExecutorConformanceProbeInput,
+  ExecutorConformanceResult,
+  RuntimeConformanceCheck,
+} from './conformance/executor.js';
 export type {
   SourceNeutralMockStats,
   SourceNeutralTrace,

--- a/test/eval-core/embedded-package.test.ts
+++ b/test/eval-core/embedded-package.test.ts
@@ -32,6 +32,11 @@ const RUBRIC_JUDGE_HOST_FIXTURE = join(
   REPO_ROOT,
   'test/eval-runtime/fixtures/rubric-judge-host.mjs',
 );
+const ADVANCED_RUNTIME_HOST_FIXTURE = join(
+  REPO_ROOT,
+  'test/eval-runtime/fixtures/advanced-host.mjs',
+);
+const PUBLIC_RUNTIME_EXAMPLE = join(REPO_ROOT, 'examples/eval-runtime/run.mjs');
 
 describe('published embedded Evaluation Core API', () => {
   let projectRoot: string;
@@ -106,6 +111,8 @@ describe('published embedded Evaluation Core API', () => {
     copyFileSync(HOST_FIXTURE, join(projectRoot, 'host.mjs'));
     copyFileSync(RUNTIME_HOST_FIXTURE, join(projectRoot, 'runtime-host.mjs'));
     copyFileSync(RUBRIC_JUDGE_HOST_FIXTURE, join(projectRoot, 'rubric-judge-host.mjs'));
+    copyFileSync(ADVANCED_RUNTIME_HOST_FIXTURE, join(projectRoot, 'advanced-runtime-host.mjs'));
+    copyFileSync(PUBLIC_RUNTIME_EXAMPLE, join(projectRoot, 'public-runtime-example.mjs'));
     copyFileSync(TYPESCRIPT_HOST_FIXTURE, join(projectRoot, 'host.ts'));
     writeFileSync(join(projectRoot, 'tsconfig.json'), JSON.stringify({
       compilerOptions: {
@@ -241,12 +248,74 @@ const assert = require('node:assert/strict');
     ]).toEqual([]);
   });
 
+  it('公开最小示例可从 tarball 独立运行且不写用户状态', () => {
+    const isolatedHome = join(projectRoot, 'public-example-home');
+    const isolatedConfig = join(projectRoot, 'public-example-config');
+    const isolatedCache = join(projectRoot, 'public-example-cache');
+    for (const directory of [isolatedHome, isolatedConfig, isolatedCache]) mkdirSync(directory);
+    const result = spawnSync(process.execPath, [join(projectRoot, 'public-runtime-example.mjs')], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      timeout: 30_000,
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        XDG_CONFIG_HOME: isolatedConfig,
+        XDG_CACHE_HOME: isolatedCache,
+      },
+    });
+    expect({ status: result.status, signal: result.signal, stderr: result.stderr }).toEqual({
+      status: 0,
+      signal: null,
+      stderr: '',
+    });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      runStatus: 'completed',
+      estimate: 2 / 3,
+      decisionStatus: 'decided',
+    });
+    expect([
+      ...readdirSync(isolatedHome),
+      ...readdirSync(isolatedConfig),
+      ...readdirSync(isolatedCache),
+    ]).toEqual([]);
+  });
+
   it('独立 FaaS 宿主只注入一次模型调用 Port 即可运行公共 Rubric Judge', () => {
     const isolatedHome = join(projectRoot, 'rubric-home');
     const isolatedConfig = join(projectRoot, 'rubric-config');
     const isolatedCache = join(projectRoot, 'rubric-cache');
     for (const directory of [isolatedHome, isolatedConfig, isolatedCache]) mkdirSync(directory);
     const result = spawnSync(process.execPath, [join(projectRoot, 'rubric-judge-host.mjs')], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      timeout: 30_000,
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        XDG_CONFIG_HOME: isolatedConfig,
+        XDG_CACHE_HOME: isolatedCache,
+      },
+    });
+    expect({
+      status: result.status,
+      signal: result.signal,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    }).toEqual({ status: 0, signal: null, stdout: '', stderr: '' });
+    expect([
+      ...readdirSync(isolatedHome),
+      ...readdirSync(isolatedConfig),
+      ...readdirSync(isolatedCache),
+    ]).toEqual([]);
+  });
+
+  it('独立高级宿主复用 eval-runtime 装配并显式完成五阶段运行', () => {
+    const isolatedHome = join(projectRoot, 'advanced-runtime-home');
+    const isolatedConfig = join(projectRoot, 'advanced-runtime-config');
+    const isolatedCache = join(projectRoot, 'advanced-runtime-cache');
+    for (const directory of [isolatedHome, isolatedConfig, isolatedCache]) mkdirSync(directory);
+    const result = spawnSync(process.execPath, [join(projectRoot, 'advanced-runtime-host.mjs')], {
       cwd: projectRoot,
       encoding: 'utf8',
       timeout: 30_000,

--- a/test/eval-core/fixtures/embedded-host.ts.fixture
+++ b/test/eval-core/fixtures/embedded-host.ts.fixture
@@ -16,8 +16,10 @@ import {
   type ExecutionBundleSource,
 } from 'oh-my-knowledge/eval-core';
 import {
+  createEvaluationEngine as createRuntimeEvaluationEngine,
   createEvaluationRuntime,
   createExactMatchDefinition,
+  createPairedComparisonDefinition,
   createMeasurementPolicy,
   createRubricJudgeCriterion,
   createRubricJudgeEvaluator,
@@ -27,7 +29,10 @@ import {
   createRubricJudgeMetricDefinition,
   createRubricJudgeRuntimeConfig,
   type OmkLlmJudgeInvocationPort,
+  type ExecutorConformanceProbeInput,
   type RuntimePortRegistration,
+  assertExecutorConformance,
+  runExecutorConformance,
 } from 'oh-my-knowledge/eval-runtime';
 import {
   createEvalSampleSetDocument,
@@ -84,11 +89,41 @@ const publicDefinition = createExactMatchDefinition({
   treatment: { targetId: 'treatment', executorId: executor.identity.implementationId },
 });
 const publicPolicy = createMeasurementPolicy();
+const publicEngine = createRuntimeEvaluationEngine(publicRuntime);
 const registration: RuntimePortRegistration<Executor> = { port: executor };
 void publicRuntime;
 void publicDefinition;
 void publicPolicy;
+void publicEngine.prepare(publicDefinition, publicPolicy);
 void registration;
+
+const genericDefinition = createPairedComparisonDefinition({
+  datasetId: 'typescript-service-host',
+  seed: 'explicit-service-seed',
+  samples: publicDefinition.dataset.samples,
+  control: { targetId: 'control', targetKind: 'rag', executorId: executor.identity.implementationId },
+  treatment: {
+    targetId: 'treatment',
+    targetKind: 'rag',
+    executorId: executor.identity.implementationId,
+  },
+  evaluator: publicDefinition.evaluators[0],
+  metric: publicDefinition.metrics[0],
+});
+const conformanceInput: ExecutorConformanceProbeInput = {
+  implementationId: executor.identity.implementationId,
+  createExecutor: () => executor,
+  input: 'probe',
+  expected: 'probe',
+};
+async function conformanceBoundary(): Promise<void> {
+  const result = await runExecutorConformance(conformanceInput);
+  assertExecutorConformance(result);
+  const conformant: true = result.conformant;
+  void conformant;
+}
+void genericDefinition;
+void conformanceBoundary;
 
 declare const judgeInvocation: OmkLlmJudgeInvocationPort;
 const rubricInstrument = createRubricJudgeInstrument();

--- a/test/eval-runtime/fixtures/advanced-host.mjs
+++ b/test/eval-runtime/fixtures/advanced-host.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { createEvaluationEngine } from 'oh-my-knowledge/eval-core';
+import {
+  createEvaluationRuntime,
+  createExactMatchDefinition,
+  createExactMatchEvaluator,
+  createExecutorFnAdapter,
+  createInvokeExecutorIdentity,
+  createMeasurementPolicy,
+} from 'oh-my-knowledge/eval-runtime';
+
+const identity = createInvokeExecutorIdentity({
+  implementationId: 'example.staged-service/v1',
+  version: '1.0.0',
+  determinism: 'deterministic',
+  cancellation: 'cooperative',
+  concurrency: { safety: 'parallel-safe' },
+  seedControl: 'unsupported',
+  telemetry: { trace: 'unsupported', usage: 'required' },
+  fingerprintFacets: { deploymentRevision: 'staged-example-1' },
+});
+
+const answers = {
+  baseline: { one: 'A', two: 'incorrect', three: 'incorrect' },
+  candidate: { one: 'A', two: 'B', three: 'C' },
+};
+const createExecutor = () => createExecutorFnAdapter({
+  identity,
+  outputClassification: 'public',
+  mapInput: ({ targetConfig, input }) => ({
+    model: targetConfig.deployment,
+    prompt: input.prompt,
+  }),
+  executor: async ({ model, prompt, abortSignal }) => {
+    abortSignal?.throwIfAborted();
+    return {
+      ok: true,
+      output: answers[model][prompt],
+      durationMs: 1,
+      durationApiMs: 1,
+      inputTokens: 1,
+      outputTokens: 1,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      tokenUsageReportedByExecutor: true,
+      costUSD: 0,
+      costReportedByExecutor: false,
+      stopReason: 'completed',
+      numTurns: 1,
+    };
+  },
+});
+const runtime = createEvaluationRuntime({
+  executors: [{ implementationId: identity.implementationId, createPort: createExecutor }],
+  evaluators: [{ port: createExactMatchEvaluator() }],
+});
+const definition = createExactMatchDefinition({
+  datasetId: 'advanced-staged-host',
+  seed: 'explicit-staged-seed',
+  samples: [
+    { sampleId: 'one', input: { prompt: 'one' }, expected: 'A' },
+    { sampleId: 'two', input: { prompt: 'two' }, expected: 'B' },
+    { sampleId: 'three', input: { prompt: 'three' }, expected: 'C' },
+  ],
+  control: {
+    targetId: 'control',
+    executorId: identity.implementationId,
+    config: { deployment: 'baseline' },
+  },
+  treatment: {
+    targetId: 'treatment',
+    executorId: identity.implementationId,
+    config: { deployment: 'candidate' },
+  },
+  bootstrap: { resamples: 100 },
+});
+
+const prepared = await createEvaluationEngine(runtime).prepare(
+  definition,
+  createMeasurementPolicy({ maxConcurrency: 2 }),
+);
+const stages = prepared.stages({ runId: 'advanced-staged-host', eventBufferCapacity: 128 });
+try {
+  const execution = await stages.execute().source;
+  const evaluation = await stages.evaluate({ execution }).source;
+  const analysis = await stages.analyze({ execution, evaluation }).source;
+  const decision = await stages.decide({ execution, evaluation, analysis }).source;
+  assert.notEqual(decision, undefined);
+  const report = await stages.materializeReport({
+    execution,
+    evaluation,
+    analysis,
+    decision,
+  }).result;
+
+  assert.equal(execution.bundle.records.length, 6);
+  assert.equal(evaluation.bundle.records.length, 6);
+  assert.equal(analysis.bundle.records[0].analysisStatus, 'completed');
+  assert.equal(analysis.bundle.records[0].value.estimate, 2 / 3);
+  assert.equal(decision.result.decisionStatus, 'decided');
+  assert.equal(report.status.runStatus, 'completed');
+  assert.equal(report.bundles.length, 3);
+} finally {
+  await stages.close();
+}

--- a/test/eval-runtime/fixtures/embedded-host.mjs
+++ b/test/eval-runtime/fixtures/embedded-host.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { createEvaluationEngine } from 'oh-my-knowledge/eval-core';
 import {
+  createEvaluationEngine,
   createEvaluationRuntime,
   createExactMatchDefinition,
   createExactMatchEvaluator,

--- a/test/eval-runtime/fixtures/rubric-judge-host.mjs
+++ b/test/eval-runtime/fixtures/rubric-judge-host.mjs
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
-import { createEvaluationEngine } from 'oh-my-knowledge/eval-core';
 import {
+  createEvaluationEngine,
   createEvaluationRuntime,
-  createExactMatchDefinition,
   createExecutorFnAdapter,
   createInvokeExecutorIdentity,
   createMeasurementPolicy,
+  createPairedComparisonDefinition,
   createRubricJudgeCriterion,
   createRubricJudgeEvaluatorDefinition,
   createRubricJudgeEvaluatorRegistration,
@@ -46,29 +46,39 @@ const criterion = createRubricJudgeCriterion({
 });
 const metricId = 'rubric-score';
 
-const base = createExactMatchDefinition({
+const evaluator = createRubricJudgeEvaluatorDefinition({
+  evaluatorId: 'rubric-judge',
+  metricId,
+  instrument,
+  runtime: judgeRuntime,
+  criterionPointer: '/rubricJudge',
+});
+const metric = createRubricJudgeMetricDefinition(metricId);
+const definition = createPairedComparisonDefinition({
   datasetId: 'faas-rubric-example',
   seed: 'explicit-seed',
   samples: [{
     sampleId: 'capital',
     input: { prompt: 'What is the capital of France?' },
     expected: 'Paris',
+    evaluationContext: { rubricJudge: criterion },
   }],
-  control: { targetId: 'control', executorId: targetIdentity.implementationId },
-  treatment: { targetId: 'treatment', executorId: targetIdentity.implementationId },
-  metricId,
+  control: {
+    targetId: 'control',
+    targetKind: 'rag',
+    executorId: targetIdentity.implementationId,
+    config: { retrievalRevision: 'baseline' },
+  },
+  treatment: {
+    targetId: 'treatment',
+    targetKind: 'rag',
+    executorId: targetIdentity.implementationId,
+    config: { retrievalRevision: 'candidate' },
+  },
+  evaluator,
+  metric,
   bootstrap: { resamples: 100 },
 });
-const definition = structuredClone(base);
-definition.dataset.samples[0].evaluationContext = { rubricJudge: criterion };
-definition.evaluators = [createRubricJudgeEvaluatorDefinition({
-  evaluatorId: 'rubric-judge',
-  metricId,
-  instrument,
-  runtime: judgeRuntime,
-  criterionPointer: '/rubricJudge',
-})];
-definition.metrics = [createRubricJudgeMetricDefinition(metricId)];
 
 const requests = [];
 const invocation = {

--- a/test/eval-runtime/foundation.test.ts
+++ b/test/eval-runtime/foundation.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { createEvaluationEngine } from '../../src/eval-core/index.js';
 import {
+  assertExecutorConformance,
   createEvaluationRuntime,
   createExactMatchDefinition,
   createExactMatchEvaluator,
   createExecutorFnAdapter,
   createInvokeExecutorIdentity,
   createMeasurementPolicy,
+  createPairedComparisonDefinition,
+  runExecutorConformance,
   type ExecResult,
 } from '../../src/eval-runtime/index.js';
 
@@ -187,5 +190,118 @@ describe('eval-runtime foundation', () => {
       'EVAL_RUNTIME_EXECUTOR_FAILED',
     ].sort());
     expect(JSON.stringify(failures)).not.toContain('provider secret');
+  });
+
+  it('builds a generic service/RAG comparison as the ordinary Core contract', () => {
+    const exact = createExactMatchDefinition({
+      datasetId: 'generic-comparison',
+      seed: 'generic-seed',
+      samples: [{ sampleId: 'one', input: { query: 'q' }, expected: 'answer' }],
+      control: { targetId: 'control', executorId: 'service/v1' },
+      treatment: { targetId: 'treatment', executorId: 'service/v1' },
+    });
+    const definition = createPairedComparisonDefinition({
+      datasetId: 'generic-comparison',
+      seed: 'generic-seed',
+      samples: exact.dataset.samples,
+      control: {
+        targetId: 'control',
+        targetKind: 'rag',
+        executorId: 'service/v1',
+        config: { indexRevision: 'baseline' },
+      },
+      treatment: {
+        targetId: 'treatment',
+        targetKind: 'rag',
+        executorId: 'service/v1',
+        config: { indexRevision: 'candidate' },
+      },
+      evaluator: exact.evaluators[0],
+      metric: exact.metrics[0],
+    });
+
+    expect(definition.targets).toMatchObject([
+      { targetKind: 'rag', config: { indexRevision: 'baseline' } },
+      { targetKind: 'rag', config: { indexRevision: 'candidate' } },
+    ]);
+    expect(definition.analysisGraph.nodes[0]).toMatchObject({
+      implementationId: 'bootstrap.paired-difference-percentile/v1',
+      inputs: [
+        { inputKind: 'metric-observations', referenceId: 'correct' },
+        { inputKind: 'comparison', metricId: 'correct' },
+      ],
+    });
+    expect(Object.isFrozen(definition.targets[0].config)).toBe(true);
+
+    expect(() => createPairedComparisonDefinition({
+      datasetId: 'invalid-comparison',
+      seed: 'invalid-seed',
+      samples: exact.dataset.samples,
+      control: { targetId: 'same', executorId: 'service/v1' },
+      treatment: { targetId: 'same', executorId: 'service/v1' },
+      evaluator: exact.evaluators[0],
+      metric: exact.metrics[0],
+    })).toThrow(/targetId must differ/);
+    expect(() => createPairedComparisonDefinition({
+      datasetId: 'invalid-metric',
+      seed: 'invalid-seed',
+      samples: exact.dataset.samples,
+      control: { targetId: 'control', executorId: 'service/v1' },
+      treatment: { targetId: 'treatment', executorId: 'service/v1' },
+      evaluator: exact.evaluators[0],
+      metric: { ...exact.metrics[0], direction: 'lower-is-better' },
+    })).toThrow(/higher-is-better/);
+    expect(() => createPairedComparisonDefinition({
+      datasetId: 'invalid-binding',
+      seed: 'invalid-seed',
+      samples: exact.dataset.samples,
+      control: { targetId: 'control', executorId: 'service/v1' },
+      treatment: { targetId: 'treatment', executorId: 'service/v1' },
+      evaluator: { ...exact.evaluators[0], metricIds: ['another-metric'] },
+      metric: exact.metrics[0],
+    })).toThrow(/matching metric/);
+  });
+
+  it('offers a framework-neutral Executor conformance probe through the real pipeline', async () => {
+    const identity = executorIdentity();
+    const conformance = await runExecutorConformance({
+      implementationId: identity.implementationId,
+      createExecutor: () => createExecutorFnAdapter({
+        identity,
+        outputClassification: 'public',
+        mapInput: ({ input }) => ({ model: 'probe', prompt: String(input) }),
+        executor: async () => result('expected'),
+      }),
+      input: 'probe',
+      expected: 'expected',
+    });
+
+    expect(conformance.conformant).toBe(true);
+    expect(conformance.checks.every((check) => check.checkStatus === 'passed')).toBe(true);
+    expect(() => assertExecutorConformance(conformance)).not.toThrow();
+
+    const failed = await runExecutorConformance({
+      implementationId: identity.implementationId,
+      createExecutor: () => createExecutorFnAdapter({
+        identity,
+        outputClassification: 'public',
+        mapInput: ({ input }) => ({ model: 'probe', prompt: String(input) }),
+        executor: async () => result('unexpected'),
+      }),
+      input: 'probe',
+      expected: 'expected',
+    });
+    expect(failed.conformant).toBe(false);
+    expect(failed.checks).toContainEqual({
+      checkId: 'evaluation-observation',
+      checkStatus: 'failed',
+      reasonCode: 'runtime-conformance-output-mismatch',
+    });
+    expect(() => assertExecutorConformance(failed)).toThrowError(
+      expect.objectContaining({
+        code: 'EVAL_RUNTIME_CONFORMANCE_FAILED',
+        failedCheckIds: ['evaluation-observation'],
+      }),
+    );
   });
 });

--- a/test/examples/catalog.test.ts
+++ b/test/examples/catalog.test.ts
@@ -14,6 +14,7 @@ const publicExamples = [
   'codex-observe-router',
   'codex-task-trajectory',
   'custom-executor',
+  'eval-runtime',
   'rag-eval',
   'skill-map-showcase',
 ] as const;


### PR DESCRIPTION
## 用户影响

企业 Node.js／FaaS 宿主现在可以用公共 `eval-runtime` builder 构造函数、服务或 RAG 的配对评测，先运行公开 conformance 探针验证 Executor adapter，并在需要时复用同一 Runtime 装配进入 Advanced Core 五阶段 API。仓库提供可直接运行的最小 ESM 示例。

## 兼容与迁移

这是纯新增公共能力，不修改现有 Definition、Policy、Bundle、Report Schema 或 package subpath。现有 `createExactMatchDefinition` 保持相同的实体 identity 与物化默认值，无需迁移。

## 测量影响

通用 builder 只组合现有 paired bootstrap、`exclude/v1` missing policy 与 `progress/v1` Decision；不复制评分、统计或决策实现。超出单一 higher-is-better numeric／boolean 指标的设计会明确拒绝，避免静默近似测量口径。

## 验证与 CR

最终改动已通过完整 `yarn ci`，并在隔离用户目录中使用 npm tarball 执行最小路径、Rubric Judge 路径和高级五阶段路径。自主多维 CR 结论为 No findings；已复核公开 API、依赖边界、确定性、失败语义、资源清理与包产物，未接受残余 P0～P3 风险。

Closes #634