### PR TITLE
fix(eval-runtime): 收窄便捷引擎公开边界

### DIFF
--- a/src/eval-runtime/engine.ts
+++ b/src/eval-runtime/engine.ts
@@ -1,0 +1,10 @@
+import { createEvaluationEngine as createAdvancedEvaluationEngine } from '../eval-core/engine/index.js';
+import type {
+  EvaluationEngine,
+  EvaluationEngineRuntime,
+} from '../eval-core/engine/index.js';
+
+/** Standard one-call host façade. Staged execution remains explicit at `eval-core`. */
+export const createEvaluationEngine: (
+  runtime: EvaluationEngineRuntime,
+) => EvaluationEngine = createAdvancedEvaluationEngine;

--- a/src/eval-runtime/index.ts
+++ b/src/eval-runtime/index.ts
@@ -1,5 +1,5 @@
 export { createNodeEvaluationClock } from './clock.js';
-export { createEvaluationEngine } from '../eval-core/engine/index.js';
+export { createEvaluationEngine } from './engine.js';
 export { createExactMatchDefinition } from './builders/exact-match.js';
 export type {
   ExactMatchDefinitionBuilderInput,

--- a/test/eval-core/fixtures/embedded-host.ts.fixture
+++ b/test/eval-core/fixtures/embedded-host.ts.fixture
@@ -189,6 +189,12 @@ async function rootBoundary(): Promise<void> {
   prepared.stages({ runId: 'root-must-stay-minimal' });
 }
 
+async function runtimeBoundary(): Promise<void> {
+  const prepared = await publicEngine.prepare(publicDefinition, publicPolicy);
+  // @ts-expect-error eval-runtime 同样只公开标准一键 façade。
+  prepared.stages({ runId: 'runtime-must-stay-minimal' });
+}
+
 async function advancedBoundary(source: ExecutionBundleSource): Promise<void> {
   const advanced = createAdvancedEvaluationEngine(runtime);
   const prepared = await advanced.prepare(definition, policy);
@@ -210,4 +216,5 @@ async function consume(): Promise<EvaluationRunResult> {
 
 void consume;
 void rootBoundary;
+void runtimeBoundary;
 void advancedBoundary;


### PR DESCRIPTION
## 用户影响

`oh-my-knowledge/eval-runtime` 的 `createEvaluationEngine` 现在只公开标准 `prepare()`／`start()` façade；需要 `.stages()`、artifact admission 或 comparability 的高级宿主继续显式使用 `oh-my-knowledge/eval-core`，入口职责与文档保持一致。

## 兼容与迁移

运行时实现、Definition、Policy、Bundle、Report 和 Schema identity 均未改变。尚未发布的 1.0 预览能力只收窄了意外暴露的 TypeScript 方法；按照已记录的 Advanced API 用法无需迁移。

## 测量影响

无测量语义变化；两个入口仍复用同一个 Core Engine 实现。

## 验证与 CR

最终改动通过完整 `yarn ci` 和 tarball TypeScript／ESM consumer 验收。受影响面复审结论为 No findings，类型负向断言会阻止便捷入口再次暴露 `.stages()`。

Closes #634