### PR TITLE
chore(release): 发布 1.0.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 `1.0.0-beta.2` 到 npm `next`。本预览版补齐企业宿主可直接采用的公共 `eval-runtime`：纯内存双 Target 评测、Definition／Policy builder、ExecutorFn 与 same-process adapter、Rubric Judge 宿主 Port、conformance helper、最小 ESM 示例和 Advanced Core 渐进式入口；同时修复默认样例中结构性不适用被误算为缺失证据的问题。

## 兼容与迁移

这是 prerelease，不移动 npm `latest`，默认安装用户仍停留在 `0.54.0`。

本版本包含 #633 的 `BREAKING-COMPARABILITY`：`AnalysisBundle` 与 `EvaluationReport` 升为 v2。旧 v1 Schema identity 保持冻结，但 runtime 不读取或迁移旧报告。从 `1.0.0-beta.1` 升级后应重新运行评测，不要把 v1 与 v2 Analysis／Report 当作可直接比较的证据。

## 测量影响

结构性不适用现在与真正缺失证据分开计量；只有 Analysis node 显式声明且来源不是 censored missing 的行才可标记为不适用。普通 missing、invalid、evaluation-failed、source-unavailable、not-started 与 censored 仍降低 evidence status。`eval-runtime` 复用同一 Core 评分、Bootstrap、Decision、Schema 与 Rubric Judge prompt，不建立平行测量实现。

## 验证与自主 CR

最终版本改动通过完整 `yarn ci`：301 个测试文件、3126 项测试全部通过；`prepublishOnly` 成功，dry-run tarball 确认为 `oh-my-knowledge@1.0.0-beta.2`。自主多维 CR 结论为 No findings；已复核版本/tag 对齐、npm dist-tag、发版区间迁移、Schema identity、公开 exports、tarball 与 GitHub OIDC 发布链路。