### PR TITLE
feat(eval-runtime): 提供安全的高层运行入口

### DIFF
--- a/docs/guides/eval-runtime.md
+++ b/docs/guides/eval-runtime.md
@@ -24,13 +24,13 @@ Create one identity for the deployed invocation implementation. Every field belo
 
 ```ts
 import {
-  createEvaluationEngine,
   createEvaluationRuntime,
   createExactMatchDefinition,
   createExactMatchEvaluator,
   createExecutorFnAdapter,
   createInvokeExecutorIdentity,
   createMeasurementPolicy,
+  runEvaluation,
 } from 'oh-my-knowledge/eval-runtime';
 
 const identity = createInvokeExecutorIdentity({
@@ -114,20 +114,22 @@ const definition = createExactMatchDefinition({
 const policy = createMeasurementPolicy({ maxConcurrency: 4 });
 ```
 
-Prepare before scheduling, then consume events concurrently with the terminal result:
+Use `runEvaluation` by default. It owns the bounded event-stream consumer; omit `onEvent` when progress is not needed, or provide it for ordered progress updates:
 
 ```ts
-const prepared = await createEvaluationEngine(runtime).prepare(definition, policy);
-const run = prepared.start({ runId: crypto.randomUUID(), eventBufferCapacity: 256 });
-const draining = (async () => {
-  for await (const event of run.events) await publishProgress(event);
-})();
-const result = await run.result;
-await draining;
+const result = await runEvaluation({
+  runtime,
+  definition,
+  policy,
+  runId: crypto.randomUUID(),
+  onEvent: publishProgress,
+});
 
 if (result.status === 'failed') throw new Error(result.error.code);
 await reportStore.put(result.report);
 ```
+
+`onEvent` is an ordered progress observer, not durable delivery. Its failure does not change the measurement result: the helper stops subsequent callbacks, keeps draining and cleans up the Runtime, then throws `EvaluationEventConsumptionError` with the terminal Core `runResult`. Only the caller's `AbortSignal` cancels the evaluation. Use `eventWriter` for durable delivery governed by Core failure policy. Hosts that need to inspect the sealed plan before scheduling can still call `createEvaluationEngine(runtime).prepare(definition, policy)`.
 
 The random `runId` distinguishes executions and affects artifact identity; it is not part of the measurement plan. Rebuilding the same Definition, Policy, and Runtime identity with the same explicit seed produces the same `runContractDigest`.
 

--- a/docs/zh/guides/eval-runtime.md
+++ b/docs/zh/guides/eval-runtime.md
@@ -24,13 +24,13 @@ npm install oh-my-knowledge
 
 ```ts
 import {
-  createEvaluationEngine,
   createEvaluationRuntime,
   createExactMatchDefinition,
   createExactMatchEvaluator,
   createExecutorFnAdapter,
   createInvokeExecutorIdentity,
   createMeasurementPolicy,
+  runEvaluation,
 } from 'oh-my-knowledge/eval-runtime';
 
 const identity = createInvokeExecutorIdentity({
@@ -114,20 +114,22 @@ const definition = createExactMatchDefinition({
 const policy = createMeasurementPolicy({ maxConcurrency: 4 });
 ```
 
-调度前先 prepare，并与终态结果并发消费 event：
+默认使用 `runEvaluation`。它负责完整消费有界事件流；不关心进度时无需编写 drain 代码，需要进度时传入可选的 `onEvent`：
 
 ```ts
-const prepared = await createEvaluationEngine(runtime).prepare(definition, policy);
-const run = prepared.start({ runId: crypto.randomUUID(), eventBufferCapacity: 256 });
-const draining = (async () => {
-  for await (const event of run.events) await publishProgress(event);
-})();
-const result = await run.result;
-await draining;
+const result = await runEvaluation({
+  runtime,
+  definition,
+  policy,
+  runId: crypto.randomUUID(),
+  onEvent: publishProgress,
+});
 
 if (result.status === 'failed') throw new Error(result.error.code);
 await reportStore.put(result.report);
 ```
+
+`onEvent` 是按顺序调用的进度观察器，不承担持久化。观察器失败不会改变测量结果；helper 会停止后续回调、继续 drain 并清理 Runtime，随后抛出 `EvaluationEventConsumptionError`，其中的 `runResult` 保留 Core 终态。只有调用方 `AbortSignal` 负责取消评测。需要带 Core failure policy 的持久事件写入时使用 `eventWriter`。需要调度前审阅 sealed plan 时，仍可调用 `createEvaluationEngine(runtime).prepare(definition, policy)`。
 
 随机 `runId` 用于区分执行，并影响 artifact identity，但不属于测量计划。同一份 Definition、Policy、Runtime identity 与显式 seed 会生成相同的 `runContractDigest`。
 

--- a/examples/eval-runtime/run.mjs
+++ b/examples/eval-runtime/run.mjs
@@ -1,11 +1,11 @@
 import {
-  createEvaluationEngine,
   createEvaluationRuntime,
   createExactMatchDefinition,
   createExactMatchEvaluator,
   createExecutorFnAdapter,
   createInvokeExecutorIdentity,
   createMeasurementPolicy,
+  runEvaluation,
 } from 'oh-my-knowledge/eval-runtime';
 
 const identity = createInvokeExecutorIdentity({
@@ -75,16 +75,12 @@ const definition = createExactMatchDefinition({
   bootstrap: { resamples: 100 },
 });
 
-const prepared = await createEvaluationEngine(runtime).prepare(
+const result = await runEvaluation({
+  runtime,
   definition,
-  createMeasurementPolicy({ maxConcurrency: 2 }),
-);
-const run = prepared.start({ runId: 'eval-runtime-example', eventBufferCapacity: 128 });
-const draining = (async () => {
-  for await (const event of run.events) void event;
-})();
-const result = await run.result;
-await draining;
+  policy: createMeasurementPolicy({ maxConcurrency: 2 }),
+  runId: 'eval-runtime-example',
+});
 if (result.status !== 'completed') throw new Error(result.error.code);
 
 process.stdout.write(`${JSON.stringify({

--- a/src/eval-runtime/index.ts
+++ b/src/eval-runtime/index.ts
@@ -1,5 +1,13 @@
 export { createNodeEvaluationClock } from './clock.js';
 export { createEvaluationEngine } from './engine.js';
+export {
+  EvaluationEventConsumptionError,
+  runEvaluation,
+} from './runner.js';
+export type {
+  EvaluationEventObserver,
+  RunEvaluationInput,
+} from './runner.js';
 export { createExactMatchDefinition } from './builders/exact-match.js';
 export type {
   ExactMatchDefinitionBuilderInput,

--- a/src/eval-runtime/runner.ts
+++ b/src/eval-runtime/runner.ts
@@ -1,0 +1,131 @@
+import type {
+  EvaluationDefinition,
+  EvaluationEvent,
+  JsonValue,
+  MeasurementPolicy,
+} from '../eval-core/contracts/index.js';
+import type {
+  EvaluationEngineEventWriter,
+  EvaluationEngineRuntime,
+  EvaluationRunResult,
+} from '../eval-core/engine/index.js';
+import { createEvaluationEngine } from './engine.js';
+
+type MaybePromise<Value> = Value | Promise<Value>;
+
+export type EvaluationEventObserver = (
+  event: Readonly<EvaluationEvent>,
+) => MaybePromise<void>;
+
+export interface RunEvaluationInput {
+  readonly runtime: EvaluationEngineRuntime;
+  readonly definition: EvaluationDefinition;
+  readonly policy: MeasurementPolicy;
+  readonly runId: string;
+  readonly signal?: AbortSignal;
+  readonly annotations?: JsonValue;
+  readonly summaries?: JsonValue;
+  readonly eventWriter?: EvaluationEngineEventWriter;
+  readonly eventBufferCapacity?: number;
+  /** Ordered progress projection. Durable event delivery belongs to `eventWriter`. */
+  readonly onEvent?: EvaluationEventObserver;
+}
+
+export class EvaluationEventConsumptionError extends Error {
+  readonly code:
+    | 'EVAL_RUNTIME_EVENT_OBSERVER_FAILED'
+    | 'EVAL_RUNTIME_EVENT_STREAM_FAILED';
+  readonly runResult?: EvaluationRunResult;
+  override readonly cause: unknown;
+
+  constructor(input: Readonly<{
+    code: EvaluationEventConsumptionError['code'];
+    message: string;
+    cause: unknown;
+    runResult?: EvaluationRunResult;
+  }>) {
+    super(input.message);
+    this.name = 'EvaluationEventConsumptionError';
+    this.code = input.code;
+    this.cause = input.cause;
+    this.runResult = input.runResult;
+  }
+}
+
+/**
+ * Runs the standard Core pipeline while owning the event-stream consumer.
+ * Observer failure never changes measurement; it drains the stream, then rejects with the Core result.
+ */
+export async function runEvaluation(
+  input: Readonly<RunEvaluationInput>,
+): Promise<EvaluationRunResult> {
+  const controller = new AbortController();
+  const externalAbort = (): void => controller.abort(input.signal?.reason);
+  if (input.signal?.aborted) externalAbort();
+  else input.signal?.addEventListener('abort', externalAbort, { once: true });
+
+  const run = createEvaluationEngine(input.runtime).start(input.definition, {
+    policy: input.policy,
+    runId: input.runId,
+    signal: controller.signal,
+    ...(input.annotations === undefined ? {} : { annotations: input.annotations }),
+    ...(input.summaries === undefined ? {} : { summaries: input.summaries }),
+    ...(input.eventWriter === undefined ? {} : { eventWriter: input.eventWriter }),
+    ...(input.eventBufferCapacity === undefined
+      ? {}
+      : { eventBufferCapacity: input.eventBufferCapacity }),
+  });
+
+  let observerFailed = false;
+  let observerFailure: unknown;
+  let streamFailed = false;
+  let streamFailure: unknown;
+  const draining = (async () => {
+    let observerTail = Promise.resolve();
+    try {
+      for await (const event of run.events) {
+        if (input.onEvent === undefined) continue;
+        observerTail = observerTail.then(async () => {
+          if (observerFailed) return;
+          try {
+            await input.onEvent?.(event);
+          } catch (error) {
+            observerFailed = true;
+            observerFailure = error;
+          }
+        });
+      }
+      await observerTail;
+    } catch (error) {
+      streamFailed = true;
+      streamFailure = error;
+      controller.abort(error);
+      await observerTail;
+    }
+  })();
+
+  try {
+    const [resultOutcome] = await Promise.allSettled([run.result, draining]);
+    if (resultOutcome.status === 'rejected') throw resultOutcome.reason;
+    const result = resultOutcome.value;
+    if (observerFailed) {
+      throw new EvaluationEventConsumptionError({
+        code: 'EVAL_RUNTIME_EVENT_OBSERVER_FAILED',
+        message: 'Evaluation event observer 执行失败；评测保持 Core 终态并完成清理。',
+        cause: observerFailure,
+        runResult: result,
+      });
+    }
+    if (streamFailed) {
+      throw new EvaluationEventConsumptionError({
+        code: 'EVAL_RUNTIME_EVENT_STREAM_FAILED',
+        message: 'Evaluation event stream 消费失败；评测已取消并完成清理。',
+        cause: streamFailure,
+        runResult: result,
+      });
+    }
+    return result;
+  } finally {
+    input.signal?.removeEventListener('abort', externalAbort);
+  }
+}

--- a/test/eval-runtime/runner.test.ts
+++ b/test/eval-runtime/runner.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createEvaluationEngine,
+  createEvaluationRuntime,
+  createExactMatchDefinition,
+  createExactMatchEvaluator,
+  createExecutorFnAdapter,
+  createInvokeExecutorIdentity,
+  createMeasurementPolicy,
+  runEvaluation,
+  type ExecResult,
+} from '../../src/eval-runtime/index.js';
+
+function executionResult(output: string): ExecResult {
+  return {
+    ok: true,
+    output,
+    durationMs: 1,
+    durationApiMs: 1,
+    inputTokens: 1,
+    outputTokens: 1,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    tokenUsageReportedByExecutor: true,
+    costUSD: 0,
+    costReportedByExecutor: false,
+    stopReason: 'completed',
+    numTurns: 1,
+  };
+}
+
+function fixture() {
+  const identity = createInvokeExecutorIdentity({
+    implementationId: 'test.runner/v1',
+    version: '1.0.0',
+    determinism: 'deterministic',
+    cancellation: 'cooperative',
+    concurrency: { safety: 'parallel-safe' },
+    seedControl: 'unsupported',
+    telemetry: { trace: 'unsupported', usage: 'required' },
+    fingerprintFacets: { revision: 'runner-test' },
+  });
+  const createExecutor = () => createExecutorFnAdapter({
+    identity,
+    outputClassification: 'public',
+    mapInput: ({ input }) => ({ model: 'fixture', prompt: String(input) }),
+    executor: async ({ prompt, abortSignal }) => {
+      abortSignal?.throwIfAborted();
+      return executionResult(prompt);
+    },
+  });
+  const runtime = () => createEvaluationRuntime({
+    executors: [{ implementationId: identity.implementationId, createPort: createExecutor }],
+    evaluators: [{ port: createExactMatchEvaluator() }],
+    clock: {
+      monotonicNow: () => 1,
+      timestamp: () => '2026-09-04T00:00:00.000Z',
+      sleep: () => Promise.resolve(),
+    },
+  });
+  const definition = createExactMatchDefinition({
+    datasetId: 'runner-dataset',
+    seed: 'runner-seed',
+    samples: [
+      { sampleId: 'one', input: 'one', expected: 'one' },
+      { sampleId: 'two', input: 'two', expected: 'two' },
+    ],
+    control: { targetId: 'control', executorId: identity.implementationId },
+    treatment: { targetId: 'treatment', executorId: identity.implementationId },
+    bootstrap: { resamples: 100 },
+  });
+  return { runtime, definition, policy: createMeasurementPolicy({ maxConcurrency: 1 }) };
+}
+
+describe('eval-runtime high-level runner', () => {
+  it('drains every event in order even with a one-event buffer and slow observer', async () => {
+    const { runtime, definition, policy } = fixture();
+    const sequences: number[] = [];
+    const result = await runEvaluation({
+      runtime: runtime(),
+      definition,
+      policy,
+      runId: 'runner-events',
+      eventBufferCapacity: 1,
+      async onEvent(event) {
+        await Promise.resolve();
+        sequences.push(event.sequence);
+      },
+    });
+
+    expect(result.status).toBe('completed');
+    expect(sequences.length).toBeGreaterThan(1);
+    expect(sequences).toEqual(sequences.map((_, index) => index));
+  });
+
+  it('matches the ordinary Core run result for the same sealed inputs', async () => {
+    const { runtime, definition, policy } = fixture();
+    const directRun = createEvaluationEngine(runtime()).start(definition, {
+      policy,
+      runId: 'runner-equivalence',
+      eventBufferCapacity: 256,
+    });
+    const directDraining = (async () => {
+      for await (const event of directRun.events) void event;
+    })();
+    const [direct, convenient] = await Promise.all([
+      directRun.result,
+      runEvaluation({
+        runtime: runtime(),
+        definition,
+        policy,
+        runId: 'runner-equivalence',
+        eventBufferCapacity: 256,
+      }),
+    ]);
+    await directDraining;
+
+    expect(convenient).toEqual(direct);
+  });
+
+  it('drains without changing the Core result when an observer fails', async () => {
+    const { runtime, definition, policy } = fixture();
+    const cause = new Error('host progress sink failed');
+
+    await expect(runEvaluation({
+      runtime: runtime(),
+      definition,
+      policy,
+      runId: 'runner-observer-failure',
+      eventBufferCapacity: 1,
+      onEvent() { throw cause; },
+    })).rejects.toMatchObject({
+      name: 'EvaluationEventConsumptionError',
+      code: 'EVAL_RUNTIME_EVENT_OBSERVER_FAILED',
+      cause,
+      runResult: { status: 'completed' },
+    });
+  });
+
+  it('forwards external cancellation and removes its listener after completion', async () => {
+    const { runtime, definition, policy } = fixture();
+    const controller = new AbortController();
+    const remove = vi.spyOn(controller.signal, 'removeEventListener');
+    controller.abort(new Error('cancel before start'));
+
+    const result = await runEvaluation({
+      runtime: runtime(),
+      definition,
+      policy,
+      runId: 'runner-cancelled',
+      signal: controller.signal,
+      eventBufferCapacity: 1,
+    });
+
+    expect(result.status).toBe('cancelled');
+    expect(remove).toHaveBeenCalledWith('abort', expect.any(Function));
+  });
+});


### PR DESCRIPTION
## 用户影响

为 `oh-my-knowledge/eval-runtime` 增加安全的高层 `runEvaluation(...)` 入口。普通 Node.js／FaaS 宿主不再需要手工协调 `prepare → start → events/result`；不关心进度时可以直接等待终态，需要进度时使用有序 `onEvent` 观察器。

进度观察器不承担持久化，也不会改变测量结果。观察器失败后停止后续回调，Runtime 继续完成事件 drain 与资源清理，最终错误携带 Core `runResult`。取消仍由调用方 `AbortSignal` 显式控制；持久事件交付继续使用 Core `eventWriter`。

## 迁移与兼容性

这是新增的推荐入口，不删除现有 `createEvaluationEngine` API。需要检查 sealed plan、控制底层事件流或执行分阶段流程的宿主继续使用现有高级入口。

中英文指南和公开示例已切换到新入口。

## 测量影响

无评分、统计、prompt、Schema 或报告语义变化。高层入口直接调用现有 Core pipeline；同一 Definition、Policy、Runtime identity、seed、run ID 和时钟下，与手工调用生成完全相同的 run result、artifact identity、Analysis、Decision 和 Report。

## 验证与自主 CR

- 独立提交 worktree 执行 `yarn ci`：302 个测试文件、3130 个测试通过。
- 打包后的公开示例通过独立 ESM 宿主执行。
- 覆盖一格事件 buffer、慢观察器、观察器失败、外部取消及新旧路径结果等价。
- 自主多维 CR 已完成；修正了“观察器失败一定取消评测”的不准确初始设计。最终复查 No findings，无已知 P0～P2。

Part of #640。
