### PR TITLE
feat(eval-runtime): 提供类型安全的 JSON 宿主适配器

### DIFF
--- a/docs/guides/eval-runtime.md
+++ b/docs/guides/eval-runtime.md
@@ -17,18 +17,19 @@ Use `oh-my-knowledge/eval-runtime` when your service already owns business invoc
 The package is ESM-only and requires Node.js 22 or newer. Install it in the service:
 
 ```bash
-npm install oh-my-knowledge
+npm install oh-my-knowledge zod
 ```
 
 Create one identity for the deployed invocation implementation. Every field below is measurement-relevant and becomes part of the sealed Runtime fingerprint:
 
 ```ts
+import { z } from 'zod';
 import {
   createEvaluationRuntime,
   createExactMatchDefinition,
   createExactMatchEvaluator,
-  createExecutorFnAdapter,
   createInvokeExecutorIdentity,
+  createJsonExecutorAdapter,
   createMeasurementPolicy,
   runEvaluation,
 } from 'oh-my-knowledge/eval-runtime';
@@ -45,40 +46,31 @@ const identity = createInvokeExecutorIdentity({
 });
 ```
 
-Adapt the existing OMK `ExecutorFn`. The adapter passes Core's `AbortSignal`; it does not add another invocation protocol. Use a factory because both Targets bind the same implementation but require independent lifecycle scopes:
+Use any runtime schema with a `parse(unknown)` method to narrow input, Target config, and output. This example uses Zod. The adapter passes Core's `AbortSignal`, continues to use `omk.invoke/v1`, and does not add another invocation protocol. Use a factory because both Targets bind the same implementation but require independent lifecycle scopes:
 
 ```ts
-const executorFn = async ({ model, prompt, abortSignal }) => {
-  const response = await modelGateway.generate({
-    deployment: model,
-    prompt,
-    signal: abortSignal,
-  });
-  return {
-    ok: true,
-    output: response.text,
-    durationMs: response.durationMs,
-    durationApiMs: response.durationMs,
-    inputTokens: response.inputTokens,
-    outputTokens: response.outputTokens,
-    cacheReadTokens: 0,
-    cacheCreationTokens: 0,
-    tokenUsageReportedByExecutor: true,
-    costUSD: 0,
-    costReportedByExecutor: false,
-    stopReason: response.stopReason,
-    numTurns: 1,
-  };
-};
-
-const createExecutor = () => createExecutorFnAdapter({
+const createExecutor = () => createJsonExecutorAdapter({
   identity,
-  executor: executorFn,
+  inputParser: z.object({ prompt: z.string() }).strict(),
+  targetConfigParser: z.object({ deployment: z.string() }).strict(),
+  outputParser: z.string(),
   outputClassification: 'sensitive',
-  mapInput: ({ targetConfig, input }) => ({
-    model: (targetConfig as { deployment: string }).deployment,
-    prompt: (input as { prompt: string }).prompt,
-  }),
+  async invoke({ input, targetConfig, signal }) {
+    const response = await modelGateway.generate({
+      deployment: targetConfig.deployment,
+      prompt: input.prompt,
+      signal,
+    });
+    return {
+      invocationStatus: 'completed',
+      output: response.text,
+      usage: {
+        inputTokens: response.inputTokens,
+        outputTokens: response.outputTokens,
+        totalTokens: response.inputTokens + response.outputTokens,
+      },
+    };
+  },
 });
 
 const runtime = createEvaluationRuntime({
@@ -89,6 +81,8 @@ const runtime = createEvaluationRuntime({
   evaluators: [{ port: createExactMatchEvaluator() }],
 });
 ```
+
+Parser return types flow into `invoke`, so no `as` casts are needed. Parsers also form the runtime trust boundary: invalid sample input, Target config, output, usage, or trace becomes a stable redacted execution failure. Parsers may validate and narrow but may not coerce, add defaults, or drop fields; any JSON transform is rejected so the effective invocation cannot drift silently under the same Runtime identity. Perform an intentional transform inside `invoke`, with the corresponding implementation revision covered by identity. Hosts that already implement OMK's existing `ExecutorFn` can continue to use `createExecutorFnAdapter` as a bridge; it is not the recommended entry for a new service integration.
 
 Build the serializable Definition and Policy. Defaults are materialized into immutable values; the seed is mandatory and never inferred from time, randomness, or environment state:
 

--- a/docs/zh/guides/eval-runtime.md
+++ b/docs/zh/guides/eval-runtime.md
@@ -17,18 +17,19 @@
 该入口仅提供 ESM，要求 Node.js 22 或更高版本。先在服务中安装：
 
 ```bash
-npm install oh-my-knowledge
+npm install oh-my-knowledge zod
 ```
 
 为已部署的调用实现创建一份 identity。下面每个字段都会影响测量，并进入封存的 Runtime fingerprint：
 
 ```ts
+import { z } from 'zod';
 import {
   createEvaluationRuntime,
   createExactMatchDefinition,
   createExactMatchEvaluator,
-  createExecutorFnAdapter,
   createInvokeExecutorIdentity,
+  createJsonExecutorAdapter,
   createMeasurementPolicy,
   runEvaluation,
 } from 'oh-my-knowledge/eval-runtime';
@@ -45,40 +46,31 @@ const identity = createInvokeExecutorIdentity({
 });
 ```
 
-适配 OMK 现有的 `ExecutorFn`。adapter 会透传 Core 的 `AbortSignal`，不会增加第三套调用协议。两个 Target 复用同一个 implementation 时要使用 factory，以获得相互隔离的生命周期：
+使用任意带 `parse(unknown)` 方法的运行时 schema 收窄 input、Target config 和 output。下面使用 Zod；adapter 会透传 Core 的 `AbortSignal`，并继续使用 `omk.invoke/v1`，不会增加第三套调用协议。两个 Target 复用同一个 implementation 时要使用 factory，以获得相互隔离的生命周期：
 
 ```ts
-const executorFn = async ({ model, prompt, abortSignal }) => {
-  const response = await modelGateway.generate({
-    deployment: model,
-    prompt,
-    signal: abortSignal,
-  });
-  return {
-    ok: true,
-    output: response.text,
-    durationMs: response.durationMs,
-    durationApiMs: response.durationMs,
-    inputTokens: response.inputTokens,
-    outputTokens: response.outputTokens,
-    cacheReadTokens: 0,
-    cacheCreationTokens: 0,
-    tokenUsageReportedByExecutor: true,
-    costUSD: 0,
-    costReportedByExecutor: false,
-    stopReason: response.stopReason,
-    numTurns: 1,
-  };
-};
-
-const createExecutor = () => createExecutorFnAdapter({
+const createExecutor = () => createJsonExecutorAdapter({
   identity,
-  executor: executorFn,
+  inputParser: z.object({ prompt: z.string() }).strict(),
+  targetConfigParser: z.object({ deployment: z.string() }).strict(),
+  outputParser: z.string(),
   outputClassification: 'sensitive',
-  mapInput: ({ targetConfig, input }) => ({
-    model: (targetConfig as { deployment: string }).deployment,
-    prompt: (input as { prompt: string }).prompt,
-  }),
+  async invoke({ input, targetConfig, signal }) {
+    const response = await modelGateway.generate({
+      deployment: targetConfig.deployment,
+      prompt: input.prompt,
+      signal,
+    });
+    return {
+      invocationStatus: 'completed',
+      output: response.text,
+      usage: {
+        inputTokens: response.inputTokens,
+        outputTokens: response.outputTokens,
+        totalTokens: response.inputTokens + response.outputTokens,
+      },
+    };
+  },
 });
 
 const runtime = createEvaluationRuntime({
@@ -89,6 +81,8 @@ const runtime = createEvaluationRuntime({
   evaluators: [{ port: createExactMatchEvaluator() }],
 });
 ```
+
+Parser 的返回类型会自动贯穿 `invoke`，因此这里不需要 `as`。Parser 同时承担运行时信任边界：不合法的 sample input、Target config、output、usage 或 trace 会成为稳定且脱敏的结构化 execution failure。Parser 只能校验并收窄，不能 coercion、补默认值或删除字段；任何 JSON transform 都会被拒绝，避免同一 Runtime identity 下静默改变实际调用。需要变换时，在 identity 已覆盖相应实现 revision 的 `invoke` 内显式完成。若宿主已经实现 OMK 既有 `ExecutorFn`，仍可使用 `createExecutorFnAdapter` 作为 bridge；它不是新服务接入的推荐入口。
 
 构造可序列化的 Definition 与 Policy。所有默认值都会写入不可变结果；seed 必填，且不会从时间、随机数或环境状态推断：
 

--- a/examples/eval-runtime/run.mjs
+++ b/examples/eval-runtime/run.mjs
@@ -1,9 +1,10 @@
+import { z } from 'zod';
 import {
   createEvaluationRuntime,
   createExactMatchDefinition,
   createExactMatchEvaluator,
-  createExecutorFnAdapter,
   createInvokeExecutorIdentity,
+  createJsonExecutorAdapter,
   createMeasurementPolicy,
   runEvaluation,
 } from 'oh-my-knowledge/eval-runtime';
@@ -23,29 +24,18 @@ const answers = {
   baseline: { one: 'A', two: 'incorrect', three: 'incorrect' },
   candidate: { one: 'A', two: 'B', three: 'C' },
 };
-const createExecutor = () => createExecutorFnAdapter({
+const createExecutor = () => createJsonExecutorAdapter({
   identity,
+  inputParser: z.object({ prompt: z.string() }).strict(),
+  targetConfigParser: z.object({ deployment: z.string() }).strict(),
+  outputParser: z.string(),
   outputClassification: 'public',
-  mapInput: ({ targetConfig, input }) => ({
-    model: targetConfig.deployment,
-    prompt: input.prompt,
-  }),
-  executor: async ({ model, prompt, abortSignal }) => {
-    abortSignal?.throwIfAborted();
+  async invoke({ input, targetConfig, signal }) {
+    signal.throwIfAborted();
     return {
-      ok: true,
-      output: answers[model][prompt],
-      durationMs: 1,
-      durationApiMs: 1,
-      inputTokens: 1,
-      outputTokens: 1,
-      cacheReadTokens: 0,
-      cacheCreationTokens: 0,
-      tokenUsageReportedByExecutor: true,
-      costUSD: 0,
-      costReportedByExecutor: false,
-      stopReason: 'completed',
-      numTurns: 1,
+      invocationStatus: 'completed',
+      output: answers[targetConfig.deployment][input.prompt],
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
     };
   },
 });

--- a/src/eval-runtime/adapters/executor-fn.ts
+++ b/src/eval-runtime/adapters/executor-fn.ts
@@ -1,5 +1,4 @@
 import {
-  ExecutorCapabilitiesSchema,
   type JsonValue,
   type RuntimeIdentity,
   type UsageRecord,
@@ -12,6 +11,7 @@ import {
 import type { ExecutorFn, ExecutorInput } from '../../executors/contracts/ports.js';
 import type { ExecResult } from '../../executors/contracts/result.js';
 import { createSameProcessExecutorAdapter } from './same-process.js';
+import { invokeProtocol, validateInvokeTelemetry } from './invoke-contract.js';
 
 export type ExecutorFnInputMapper = (
   context: Readonly<ExecutorTrialContext>,
@@ -49,14 +49,6 @@ function reportedUsage(result: Readonly<ExecResult>): UsageRecord | undefined {
   return Object.keys(usage).length === 0 ? undefined : usage;
 }
 
-function contractViolation(message: string, usage?: UsageRecord): never {
-  throw new ExecutionPortFailure({
-    code: 'EVAL_RUNTIME_EXECUTOR_CONTRACT_VIOLATION',
-    stage: 'execution',
-    message,
-  }, usage);
-}
-
 /**
  * Adapts OMK's existing `ExecutorFn` invocation protocol to the Core Executor port.
  * Core remains responsible for retries, timeouts, budgets, and cancellation.
@@ -64,13 +56,7 @@ function contractViolation(message: string, usage?: UsageRecord): never {
 export function createExecutorFnAdapter(
   input: Readonly<CreateExecutorFnAdapterInput>,
 ) {
-  const capabilities = ExecutorCapabilitiesSchema.parse(input.identity.capabilities);
-  const protocol = capabilities.protocols.find((candidate) => (
-    candidate.protocolId === 'omk.invoke/v1'
-  ));
-  if (protocol === undefined) {
-    throw new TypeError('ExecutorFn adapter identity 必须声明 omk.invoke/v1 capability。');
-  }
+  const protocol = invokeProtocol(input.identity);
   const executor = input.executor;
   const mapInput = input.mapInput;
   const mapResult = input.mapResult;
@@ -110,23 +96,7 @@ export function createExecutorFnAdapter(
               }),
           ...(usage === undefined ? {} : { usage }),
         };
-        const telemetry = protocol.execution.telemetry;
-        if (telemetry.trace === 'required' && mapped.trace === undefined) {
-          return contractViolation('ExecutorFn 未返回 Runtime identity 声明为 required 的 trace。', usage);
-        }
-        if (telemetry.trace === 'unsupported' && mapped.trace !== undefined) {
-          return contractViolation('ExecutorFn 返回了 Runtime identity 声明为 unsupported 的 trace。', usage);
-        }
-        if (telemetry.usage === 'required' && mapped.usage === undefined) {
-          return contractViolation('ExecutorFn 未返回 Runtime identity 声明为 required 的 usage。');
-        }
-        const costReporting = telemetry.providerCost?.reporting ?? 'unsupported';
-        if (costReporting === 'required' && mapped.usage?.providerCost === undefined) {
-          return contractViolation('ExecutorFn 未返回 Runtime identity 声明为 required 的 provider cost。');
-        }
-        if (costReporting === 'unsupported' && mapped.usage?.providerCost !== undefined) {
-          return contractViolation('ExecutorFn 返回了 Runtime identity 声明为 unsupported 的 provider cost。');
-        }
+        validateInvokeTelemetry(protocol, mapped);
         return mapped;
       },
       disposeTrial: () => undefined,

--- a/src/eval-runtime/adapters/invoke-contract.ts
+++ b/src/eval-runtime/adapters/invoke-contract.ts
@@ -1,0 +1,60 @@
+import {
+  ExecutorCapabilitiesSchema,
+  type RuntimeIdentity,
+  type UsageRecord,
+} from '../../eval-core/contracts/index.js';
+import {
+  ExecutionPortFailure,
+  type ExecutorAttemptResult,
+} from '../../eval-core/execution/index.js';
+
+export function invokeProtocol(identity: Readonly<RuntimeIdentity>) {
+  const capabilities = ExecutorCapabilitiesSchema.parse(identity.capabilities);
+  const protocol = capabilities.protocols.find((candidate) => (
+    candidate.protocolId === 'omk.invoke/v1'
+  ));
+  if (protocol === undefined) {
+    throw new TypeError('Executor adapter identity 必须声明 omk.invoke/v1 capability。');
+  }
+  return protocol;
+}
+
+export function executorContractViolation(message: string, usage?: UsageRecord): never {
+  throw new ExecutionPortFailure({
+    code: 'EVAL_RUNTIME_EXECUTOR_CONTRACT_VIOLATION',
+    stage: 'execution',
+    message,
+  }, usage);
+}
+
+export function validateInvokeTelemetry(
+  protocol: ReturnType<typeof invokeProtocol>,
+  result: Readonly<ExecutorAttemptResult>,
+): void {
+  const telemetry = protocol.execution.telemetry;
+  if (telemetry.trace === 'required' && result.trace === undefined) {
+    executorContractViolation('Executor 未返回 Runtime identity 声明为 required 的 trace。', result.usage);
+  }
+  if (telemetry.trace === 'unsupported' && result.trace !== undefined) {
+    executorContractViolation('Executor 返回了 Runtime identity 声明为 unsupported 的 trace。', result.usage);
+  }
+  const reportsUsage = result.usage !== undefined && (
+    result.usage.inputTokens !== undefined
+    || result.usage.outputTokens !== undefined
+    || result.usage.totalTokens !== undefined
+    || result.usage.details !== undefined
+  );
+  if (telemetry.usage === 'required' && !reportsUsage) {
+    executorContractViolation('Executor 未返回 Runtime identity 声明为 required 的 usage。');
+  }
+  if (telemetry.usage === 'unsupported' && reportsUsage) {
+    executorContractViolation('Executor 返回了 Runtime identity 声明为 unsupported 的 usage。');
+  }
+  const costReporting = telemetry.providerCost?.reporting ?? 'unsupported';
+  if (costReporting === 'required' && result.usage?.providerCost === undefined) {
+    executorContractViolation('Executor 未返回 Runtime identity 声明为 required 的 provider cost。');
+  }
+  if (costReporting === 'unsupported' && result.usage?.providerCost !== undefined) {
+    executorContractViolation('Executor 返回了 Runtime identity 声明为 unsupported 的 provider cost。');
+  }
+}

--- a/src/eval-runtime/adapters/json-executor.ts
+++ b/src/eval-runtime/adapters/json-executor.ts
@@ -1,0 +1,247 @@
+import {
+  IdentifierSchema,
+  JsonValueSchema,
+  UsageRecordSchema,
+  canonicalizeJson,
+  type JsonValue,
+  type RuntimeIdentity,
+  type UsageRecord,
+} from '../../eval-core/contracts/index.js';
+import {
+  ExecutionPortFailure,
+  type ExecutionExecutor,
+  type ExecutorAttemptResult,
+} from '../../eval-core/execution/index.js';
+import { createSameProcessExecutorAdapter } from './same-process.js';
+import { invokeProtocol, validateInvokeTelemetry } from './invoke-contract.js';
+
+export interface RuntimeValueParser<Value> {
+  /** Validate and narrow only; changing the canonical JSON value fails closed. */
+  parse(value: unknown): Value;
+}
+
+export interface JsonExecutorInvocation<Input, TargetConfig> {
+  readonly input: Input;
+  readonly targetConfig: TargetConfig;
+  readonly executionContext?: JsonValue;
+  readonly sampleId: string;
+  readonly targetId: string;
+  readonly trialIndex: number;
+  readonly trialSeed?: string;
+  readonly attemptNumber: number;
+  readonly signal: AbortSignal;
+}
+
+export type JsonExecutorInvocationResult<Output extends JsonValue, Trace extends JsonValue> =
+  | {
+      readonly invocationStatus: 'completed';
+      readonly output?: Output;
+      readonly trace?: Trace;
+      readonly usage?: UsageRecord;
+    }
+  | {
+      readonly invocationStatus: 'failed';
+      /** Public, stable failure classification. Provider-private messages must not be returned. */
+      readonly errorCode: string;
+      readonly usage?: UsageRecord;
+    };
+
+export interface CreateJsonExecutorAdapterInput<
+  Input extends JsonValue,
+  TargetConfig extends JsonValue | undefined,
+  Output extends JsonValue,
+  Trace extends JsonValue = JsonValue,
+> {
+  readonly identity: RuntimeIdentity;
+  readonly inputParser: RuntimeValueParser<Input>;
+  readonly targetConfigParser: RuntimeValueParser<TargetConfig>;
+  readonly outputParser: RuntimeValueParser<Output>;
+  readonly traceParser?: RuntimeValueParser<Trace>;
+  readonly invoke: (
+    invocation: Readonly<JsonExecutorInvocation<Input, TargetConfig>>,
+  ) => Promise<JsonExecutorInvocationResult<Output, Trace>>;
+  readonly outputClassification: 'public' | 'sensitive' | 'secret' | 'gold';
+  readonly traceClassification?: 'public' | 'sensitive' | 'secret' | 'gold';
+  readonly outputMediaType?: string;
+  readonly traceMediaType?: string;
+  readonly sessionIsolationKey?: string;
+}
+
+function structuredFailure(code: string, usage?: UsageRecord): never {
+  throw new ExecutionPortFailure({
+    code,
+    stage: 'execution',
+    message: 'Host JSON Executor reported a structured failure.',
+  }, usage);
+}
+
+function parse<Value>(
+  parser: Readonly<RuntimeValueParser<Value>>,
+  value: unknown,
+  failureCode: string,
+): Value {
+  try {
+    return parser.parse(structuredClone(value));
+  } catch {
+    return structuredFailure(failureCode);
+  }
+}
+
+function captureParser<Value>(
+  parser: Readonly<RuntimeValueParser<Value>>,
+): RuntimeValueParser<Value> {
+  if (typeof parser?.parse !== 'function') {
+    throw new TypeError('JSON Executor adapter requires every Runtime parser.');
+  }
+  const parseValue = parser.parse;
+  return Object.freeze({
+    parse: (value: unknown) => Reflect.apply(parseValue, parser, [value]) as Value,
+  });
+}
+
+function parseJsonUnchanged<Value extends JsonValue>(
+  parser: Readonly<RuntimeValueParser<Value>>,
+  value: unknown,
+  failureCode: string,
+): Value {
+  const wire = parse(JsonValueSchema, value, failureCode);
+  const parsed = parse(parser, wire, failureCode);
+  const parsedWire = parse(JsonValueSchema, parsed, failureCode);
+  if (canonicalizeJson(wire) !== canonicalizeJson(parsedWire)) {
+    return structuredFailure(failureCode);
+  }
+  return parsed;
+}
+
+function parseOptionalJsonUnchanged<Value extends JsonValue | undefined>(
+  parser: Readonly<RuntimeValueParser<Value>>,
+  value: unknown,
+  failureCode: string,
+): Value {
+  if (value === undefined) {
+    const parsed = parse(parser, undefined, failureCode);
+    if (parsed !== undefined) return structuredFailure(failureCode);
+    return parsed;
+  }
+  return parseJsonUnchanged(
+    parser as RuntimeValueParser<Exclude<Value, undefined>>,
+    value,
+    failureCode,
+  ) as Value;
+}
+
+/** Adapts a typed, source-neutral JSON callback to the Core `omk.invoke/v1` Executor port. */
+export function createJsonExecutorAdapter<
+  Input extends JsonValue,
+  TargetConfig extends JsonValue | undefined,
+  Output extends JsonValue,
+  Trace extends JsonValue = JsonValue,
+>(
+  input: Readonly<CreateJsonExecutorAdapterInput<Input, TargetConfig, Output, Trace>>,
+): ExecutionExecutor {
+  const protocol = invokeProtocol(input.identity);
+  const identity = input.identity;
+  const invoke = input.invoke;
+  const inputParser = captureParser(input.inputParser);
+  const targetConfigParser = captureParser(input.targetConfigParser);
+  const outputParser = captureParser(input.outputParser);
+  const traceParser = input.traceParser === undefined
+    ? undefined
+    : captureParser(input.traceParser);
+  const outputClassification = input.outputClassification;
+  const traceClassification = input.traceClassification ?? input.outputClassification;
+
+  return createSameProcessExecutorAdapter({
+    identity,
+    sessionIsolationKey: input.sessionIsolationKey
+      ?? `eval-runtime:${identity.implementationId}`,
+    resourceLeases: { forRun: () => undefined },
+    implementation: {
+      openRun: () => undefined,
+      openTrial: ({ trial }) => trial,
+      async execute({ trial, attempt }): Promise<ExecutorAttemptResult> {
+        if (attempt.signal.aborted) throw attempt.signal.reason;
+        const invocation: JsonExecutorInvocation<Input, TargetConfig> = Object.freeze({
+          input: parseJsonUnchanged(
+            inputParser,
+            trial.input,
+            'EVAL_RUNTIME_EXECUTOR_INPUT_INVALID',
+          ),
+          targetConfig: parseOptionalJsonUnchanged(
+            targetConfigParser,
+            trial.targetConfig,
+            'EVAL_RUNTIME_EXECUTOR_TARGET_CONFIG_INVALID',
+          ),
+          ...(trial.executionContext === undefined
+            ? {}
+            : { executionContext: structuredClone(trial.executionContext) }),
+          sampleId: trial.sampleId,
+          targetId: trial.targetId,
+          trialIndex: trial.trialIndex,
+          ...(trial.trialSeed === undefined ? {} : { trialSeed: trial.trialSeed }),
+          attemptNumber: attempt.attemptNumber,
+          signal: attempt.signal,
+        });
+        let hostResult: JsonExecutorInvocationResult<Output, Trace>;
+        try {
+          hostResult = await invoke(invocation);
+        } catch (error) {
+          if (attempt.signal.aborted) throw attempt.signal.reason;
+          if (error instanceof ExecutionPortFailure) throw error;
+          return structuredFailure('EVAL_RUNTIME_EXECUTOR_FAILED');
+        }
+        if (hostResult === null || typeof hostResult !== 'object' || Array.isArray(hostResult)) {
+          return structuredFailure('EVAL_RUNTIME_EXECUTOR_RESULT_INVALID');
+        }
+        const usage = hostResult.usage === undefined
+          ? undefined
+          : parse(UsageRecordSchema, hostResult.usage, 'EVAL_RUNTIME_EXECUTOR_USAGE_INVALID');
+        if (hostResult.invocationStatus === 'failed') {
+          const parsedCode = IdentifierSchema.safeParse(hostResult.errorCode);
+          if (!parsedCode.success) {
+            return structuredFailure('EVAL_RUNTIME_EXECUTOR_FAILURE_CODE_INVALID', usage);
+          }
+          return structuredFailure(parsedCode.data, usage);
+        }
+        if (hostResult.invocationStatus !== 'completed') {
+          return structuredFailure('EVAL_RUNTIME_EXECUTOR_RESULT_INVALID', usage);
+        }
+        const result: ExecutorAttemptResult = {
+          ...(hostResult.output === undefined ? {} : {
+            output: {
+              value: parseJsonUnchanged(
+                outputParser,
+                hostResult.output,
+                'EVAL_RUNTIME_EXECUTOR_OUTPUT_INVALID',
+              ),
+              classification: outputClassification,
+              ...(input.outputMediaType === undefined
+                ? {}
+                : { mediaType: input.outputMediaType }),
+            },
+          }),
+          ...(hostResult.trace === undefined ? {} : {
+            trace: {
+              value: traceParser === undefined
+                ? parse(JsonValueSchema, hostResult.trace, 'EVAL_RUNTIME_EXECUTOR_TRACE_INVALID')
+                : parseJsonUnchanged(
+                  traceParser,
+                  hostResult.trace,
+                  'EVAL_RUNTIME_EXECUTOR_TRACE_INVALID',
+                ),
+              classification: traceClassification,
+              ...(input.traceMediaType === undefined
+                ? {}
+                : { mediaType: input.traceMediaType }),
+            },
+          }),
+          ...(usage === undefined ? {} : { usage }),
+        };
+        validateInvokeTelemetry(protocol, result);
+        return result;
+      },
+      disposeTrial: () => undefined,
+      disposeRun: () => undefined,
+    },
+  });
+}

--- a/src/eval-runtime/index.ts
+++ b/src/eval-runtime/index.ts
@@ -57,6 +57,13 @@ export type {
   ExecutorFnResultMapper,
   ExecutorInput,
 } from './adapters/executor-fn.js';
+export { createJsonExecutorAdapter } from './adapters/json-executor.js';
+export type {
+  CreateJsonExecutorAdapterInput,
+  JsonExecutorInvocation,
+  JsonExecutorInvocationResult,
+  RuntimeValueParser,
+} from './adapters/json-executor.js';
 export {
   createSameProcessEvaluatorAdapter,
   createSameProcessExecutorAdapter,

--- a/test/eval-core/embedded-package.test.ts
+++ b/test/eval-core/embedded-package.test.ts
@@ -145,6 +145,8 @@ const assert = require('node:assert/strict');
   assert.equal(typeof advanced.assessComparability, 'function');
   assert.equal(typeof evalRuntime.createEvaluationRuntime, 'function');
   assert.equal(typeof evalRuntime.createExecutorFnAdapter, 'function');
+  assert.equal(typeof evalRuntime.createJsonExecutorAdapter, 'function');
+  assert.equal(typeof evalRuntime.runEvaluation, 'function');
   assert.equal(evalSamples.EVAL_SAMPLE_SET_SCHEMA_VERSION, 'omk.eval-sample-set/v1');
   assert.equal(typeof evalSamples.resolveEvalSampleJsonSchema, 'function');
   assert.equal(typeof projections.projectCoreArtifactGraph, 'function');

--- a/test/eval-core/fixtures/embedded-host.ts.fixture
+++ b/test/eval-core/fixtures/embedded-host.ts.fixture
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import {
   createEvaluationEngine,
   EXECUTION_FACTS_SCHEMA_VERSION,
@@ -19,6 +20,8 @@ import {
   createEvaluationEngine as createRuntimeEvaluationEngine,
   createEvaluationRuntime,
   createExactMatchDefinition,
+  createInvokeExecutorIdentity,
+  createJsonExecutorAdapter,
   createPairedComparisonDefinition,
   createMeasurementPolicy,
   createRubricJudgeCriterion,
@@ -33,6 +36,7 @@ import {
   type RuntimePortRegistration,
   assertExecutorConformance,
   runExecutorConformance,
+  runEvaluation,
 } from 'oh-my-knowledge/eval-runtime';
 import {
   createEvalSampleSetDocument,
@@ -96,6 +100,58 @@ void publicDefinition;
 void publicPolicy;
 void publicEngine.prepare(publicDefinition, publicPolicy);
 void registration;
+
+const jsonIdentity = createInvokeExecutorIdentity({
+  implementationId: 'test.typescript-json/v1',
+  version: '1.0.0',
+  determinism: 'deterministic',
+  cancellation: 'cooperative',
+  concurrency: { safety: 'parallel-safe' },
+  seedControl: 'unsupported',
+  telemetry: { trace: 'unsupported', usage: 'required' },
+  fingerprintFacets: { revision: 'typescript-fixture' },
+});
+const jsonExecutor = createJsonExecutorAdapter({
+  identity: jsonIdentity,
+  inputParser: z.object({ question: z.string() }),
+  targetConfigParser: z.object({ deployment: z.string() }),
+  outputParser: z.object({ answer: z.string() }),
+  outputClassification: 'public',
+  async invoke({ input, targetConfig, signal }) {
+    const question: string = input.question;
+    const deployment: string = targetConfig.deployment;
+    signal.throwIfAborted();
+    // @ts-expect-error Parser-derived input does not expose undeclared fields.
+    void input.missing;
+    return {
+      invocationStatus: 'completed',
+      output: { answer: `${question}:${deployment}` },
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    };
+  },
+});
+createJsonExecutorAdapter({
+  identity: jsonIdentity,
+  inputParser: z.string(),
+  targetConfigParser: z.undefined(),
+  outputParser: z.string(),
+  outputClassification: 'public',
+  // @ts-expect-error Output must match the parser-derived string contract.
+  async invoke() {
+    return { invocationStatus: 'completed', output: 42 };
+  },
+});
+const jsonRuntime = createEvaluationRuntime({
+  executors: [{ port: jsonExecutor }],
+  evaluators: [{ port: evaluator }],
+});
+void runEvaluation({
+  runtime: jsonRuntime,
+  definition: publicDefinition,
+  policy: publicPolicy,
+  runId: 'typed-json-runtime',
+});
+void jsonExecutor;
 
 const genericDefinition = createPairedComparisonDefinition({
   datasetId: 'typescript-service-host',

--- a/test/eval-runtime/fixtures/embedded-host.mjs
+++ b/test/eval-runtime/fixtures/embedded-host.mjs
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict';
+import { z } from 'zod';
 import {
   createEvaluationEngine,
   createEvaluationRuntime,
   createExactMatchDefinition,
   createExactMatchEvaluator,
-  createExecutorFnAdapter,
   createInvokeExecutorIdentity,
+  createJsonExecutorAdapter,
   createMeasurementPolicy,
 } from 'oh-my-knowledge/eval-runtime';
 
@@ -24,32 +25,20 @@ const answers = {
   control: { one: 'A', two: 'incorrect', three: 'incorrect' },
   treatment: { one: 'A', two: 'B', three: 'C' },
 };
-const executorFn = async ({ model, prompt, abortSignal }) => {
-  abortSignal?.throwIfAborted();
-  return {
-    ok: true,
-    output: answers[model][prompt],
-    durationMs: 1,
-    durationApiMs: 1,
-    inputTokens: 1,
-    outputTokens: 1,
-    cacheReadTokens: 0,
-    cacheCreationTokens: 0,
-    tokenUsageReportedByExecutor: true,
-    costUSD: 0,
-    costReportedByExecutor: false,
-    stopReason: 'completed',
-    numTurns: 1,
-  };
-};
-const createExecutor = () => createExecutorFnAdapter({
+const createExecutor = () => createJsonExecutorAdapter({
   identity,
-  executor: executorFn,
+  inputParser: z.object({ prompt: z.string() }).strict(),
+  targetConfigParser: z.undefined(),
+  outputParser: z.string(),
   outputClassification: 'public',
-  mapInput: ({ targetId, input }) => ({
-    model: targetId,
-    prompt: input.prompt,
-  }),
+  async invoke({ targetId, input, signal }) {
+    signal.throwIfAborted();
+    return {
+      invocationStatus: 'completed',
+      output: answers[targetId][input.prompt],
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    };
+  },
 });
 const runtime = createEvaluationRuntime({
   executors: [{ implementationId: identity.implementationId, createPort: createExecutor }],

--- a/test/eval-runtime/foundation.test.ts
+++ b/test/eval-runtime/foundation.test.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { describe, expect, it } from 'vitest';
 import { createEvaluationEngine } from '../../src/eval-core/index.js';
 import {
@@ -7,6 +8,7 @@ import {
   createExactMatchEvaluator,
   createExecutorFnAdapter,
   createInvokeExecutorIdentity,
+  createJsonExecutorAdapter,
   createMeasurementPolicy,
   createPairedComparisonDefinition,
   runExecutorConformance,
@@ -266,11 +268,17 @@ describe('eval-runtime foundation', () => {
     const identity = executorIdentity();
     const conformance = await runExecutorConformance({
       implementationId: identity.implementationId,
-      createExecutor: () => createExecutorFnAdapter({
+      createExecutor: () => createJsonExecutorAdapter({
         identity,
+        inputParser: z.string(),
+        targetConfigParser: z.undefined(),
+        outputParser: z.string(),
         outputClassification: 'public',
-        mapInput: ({ input }) => ({ model: 'probe', prompt: String(input) }),
-        executor: async () => result('expected'),
+        invoke: async () => ({
+          invocationStatus: 'completed',
+          output: 'expected',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        }),
       }),
       input: 'probe',
       expected: 'expected',
@@ -282,11 +290,17 @@ describe('eval-runtime foundation', () => {
 
     const failed = await runExecutorConformance({
       implementationId: identity.implementationId,
-      createExecutor: () => createExecutorFnAdapter({
+      createExecutor: () => createJsonExecutorAdapter({
         identity,
+        inputParser: z.string(),
+        targetConfigParser: z.undefined(),
+        outputParser: z.string(),
         outputClassification: 'public',
-        mapInput: ({ input }) => ({ model: 'probe', prompt: String(input) }),
-        executor: async () => result('unexpected'),
+        invoke: async () => ({
+          invocationStatus: 'completed',
+          output: 'unexpected',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        }),
       }),
       input: 'probe',
       expected: 'expected',

--- a/test/eval-runtime/json-executor.test.ts
+++ b/test/eval-runtime/json-executor.test.ts
@@ -1,0 +1,467 @@
+import { z } from 'zod';
+import { describe, expect, it } from 'vitest';
+import {
+  createEvaluationRuntime,
+  createExactMatchDefinition,
+  createExactMatchEvaluator,
+  createInvokeExecutorIdentity,
+  createJsonExecutorAdapter,
+  createMeasurementPolicy,
+  runEvaluation,
+} from '../../src/eval-runtime/index.js';
+
+function identity(input: Readonly<{
+  trace?: 'unsupported' | 'optional' | 'required';
+  usage?: 'unsupported' | 'optional' | 'required';
+  cost?: 'unsupported' | 'optional' | 'required';
+}> = {}) {
+  return createInvokeExecutorIdentity({
+    implementationId: 'test.json-service/v1',
+    version: '1.0.0',
+    determinism: 'deterministic',
+    cancellation: 'cooperative',
+    concurrency: { safety: 'parallel-safe' },
+    seedControl: 'unsupported',
+    telemetry: {
+      trace: input.trace ?? 'unsupported',
+      usage: input.usage ?? 'optional',
+      providerCost: { reporting: input.cost ?? 'unsupported' },
+    },
+    fingerprintFacets: { deployment: 'json-adapter-test' },
+  });
+}
+
+async function execute(
+  createExecutor: () => ReturnType<typeof createJsonExecutorAdapter>,
+  runtimeIdentity: ReturnType<typeof identity>,
+  sampleInput: unknown,
+  expected: unknown,
+  options: Readonly<{
+    signal?: AbortSignal;
+    onEvent?: Parameters<typeof runEvaluation>[0]['onEvent'];
+  }> = {},
+) {
+  const runtime = createEvaluationRuntime({
+    executors: [{ implementationId: runtimeIdentity.implementationId, createPort: createExecutor }],
+    evaluators: [{ port: createExactMatchEvaluator() }],
+  });
+  const definition = createExactMatchDefinition({
+    datasetId: 'json-adapter',
+    seed: 'json-adapter-seed',
+    samples: [
+      { sampleId: 'one', input: sampleInput as never, expected: expected as never },
+      { sampleId: 'two', input: sampleInput as never, expected: expected as never },
+    ],
+    control: {
+      targetId: 'control',
+      executorId: runtimeIdentity.implementationId,
+      config: { deployment: 'baseline' },
+    },
+    treatment: {
+      targetId: 'treatment',
+      executorId: runtimeIdentity.implementationId,
+      config: { deployment: 'candidate' },
+    },
+    bootstrap: { resamples: 100 },
+  });
+  return runEvaluation({
+    runtime,
+    definition,
+    policy: createMeasurementPolicy({ maxConcurrency: 1 }),
+    runId: 'json-adapter-run',
+    ...(options.signal === undefined ? {} : { signal: options.signal }),
+    ...(options.onEvent === undefined ? {} : { onEvent: options.onEvent }),
+  });
+}
+
+describe('source-neutral JSON Executor adapter', () => {
+  it('provides parsed generic values and accepts structured JSON output without legacy fields', async () => {
+    const runtimeIdentity = identity({ usage: 'required' });
+    const seenSignals: AbortSignal[] = [];
+    const createExecutor = () => createJsonExecutorAdapter({
+      identity: runtimeIdentity,
+      inputParser: z.object({ question: z.string() }),
+      targetConfigParser: z.object({ deployment: z.string() }),
+      outputParser: z.object({ answer: z.string() }),
+      outputClassification: 'sensitive',
+      async invoke({ input, targetConfig, signal }) {
+        seenSignals.push(signal);
+        return {
+          invocationStatus: 'completed',
+          output: { answer: `${input.question}:${targetConfig.deployment}` },
+          usage: { inputTokens: 2, outputTokens: 1, totalTokens: 3 },
+        };
+      },
+    });
+    const result = await execute(
+      createExecutor,
+      runtimeIdentity,
+      { question: 'answer' },
+      { answer: 'answer:baseline' },
+    );
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    expect(result.artifacts.execution.records).toHaveLength(4);
+    expect(result.artifacts.execution.records[0]).toMatchObject({
+      executionStatus: 'completed',
+      output: { classification: 'sensitive' },
+      usage: { inputTokens: 2, outputTokens: 1, totalTokens: 3 },
+    });
+    expect(seenSignals).toHaveLength(4);
+    expect(seenSignals.every((signal) => signal instanceof AbortSignal)).toBe(true);
+  });
+
+  it('fails closed on invalid input without persisting the rejected payload', async () => {
+    const runtimeIdentity = identity();
+    const createExecutor = () => createJsonExecutorAdapter({
+      identity: runtimeIdentity,
+      inputParser: z.object({ question: z.string() }),
+      targetConfigParser: z.object({ deployment: z.string() }),
+      outputParser: z.string(),
+      outputClassification: 'public',
+      async invoke() {
+        return { invocationStatus: 'completed', output: 'unreachable' };
+      },
+    });
+    const result = await execute(
+      createExecutor,
+      runtimeIdentity,
+      { secret: 'provider-private-payload' },
+      'unreachable',
+    );
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const failures = result.artifacts.execution.records.filter(
+      (record) => record.executionStatus === 'failed',
+    );
+    expect(failures).toHaveLength(4);
+    expect(failures.every((record) => (
+      record.error.code === 'EVAL_RUNTIME_EXECUTOR_INPUT_INVALID'
+    ))).toBe(true);
+    expect(JSON.stringify(failures)).not.toContain('provider-private-payload');
+  });
+
+  it('rejects parser transforms that would change measurement under the same identity', async () => {
+    const runtimeIdentity = identity();
+    const createExecutor = () => createJsonExecutorAdapter({
+      identity: runtimeIdentity,
+      inputParser: z.object({ question: z.string() }),
+      targetConfigParser: z.object({ deployment: z.string() }),
+      outputParser: z.string(),
+      outputClassification: 'public',
+      async invoke() {
+        return { invocationStatus: 'completed', output: 'unreachable' };
+      },
+    });
+    const result = await execute(
+      createExecutor,
+      runtimeIdentity,
+      { question: 'answer', undeclared: 'would-be-stripped' },
+      'unreachable',
+    );
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    expect(result.artifacts.execution.records[0]).toMatchObject({
+      executionStatus: 'failed',
+      error: { code: 'EVAL_RUNTIME_EXECUTOR_INPUT_INVALID' },
+    });
+  });
+
+  it('preserves stable host failure codes and measured usage without private messages', async () => {
+    const runtimeIdentity = identity({ usage: 'required', cost: 'optional' });
+    const createExecutor = () => createJsonExecutorAdapter({
+      identity: runtimeIdentity,
+      inputParser: z.string(),
+      targetConfigParser: z.object({ deployment: z.string() }),
+      outputParser: z.string(),
+      outputClassification: 'public',
+      async invoke() {
+        return {
+          invocationStatus: 'failed',
+          errorCode: 'gateway-unavailable',
+          usage: {
+            inputTokens: 3,
+            providerCost: { amount: 0.01, currency: 'USD', reportedByProvider: true },
+          },
+        };
+      },
+    });
+    const result = await execute(createExecutor, runtimeIdentity, 'question', 'answer');
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    expect(result.artifacts.execution.records[0]).toMatchObject({
+      executionStatus: 'failed',
+      error: {
+        code: 'gateway-unavailable',
+        message: 'Executor reported a structured failure.',
+      },
+      usage: {
+        inputTokens: 3,
+        providerCost: { amount: 0.01, currency: 'USD', reportedByProvider: true },
+      },
+    });
+  });
+
+  it('redacts thrown provider errors into one stable public failure', async () => {
+    const runtimeIdentity = identity();
+    const createExecutor = () => createJsonExecutorAdapter({
+      identity: runtimeIdentity,
+      inputParser: z.string(),
+      targetConfigParser: z.object({ deployment: z.string() }),
+      outputParser: z.string(),
+      outputClassification: 'public',
+      async invoke() {
+        throw new Error('provider secret: tenant-token');
+      },
+    });
+    const result = await execute(createExecutor, runtimeIdentity, 'question', 'answer');
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    const failures = result.artifacts.execution.records.filter(
+      (record) => record.executionStatus === 'failed',
+    );
+    expect(failures[0]).toMatchObject({
+      error: { code: 'EVAL_RUNTIME_EXECUTOR_FAILED' },
+    });
+    expect(JSON.stringify(failures)).not.toContain('tenant-token');
+  });
+
+  it('rejects telemetry that contradicts the sealed Runtime identity', async () => {
+    const runtimeIdentity = identity({ usage: 'required', cost: 'unsupported' });
+    const createExecutor = () => createJsonExecutorAdapter({
+      identity: runtimeIdentity,
+      inputParser: z.string(),
+      targetConfigParser: z.object({ deployment: z.string() }),
+      outputParser: z.string(),
+      outputClassification: 'public',
+      async invoke() {
+        return {
+          invocationStatus: 'completed',
+          output: 'answer',
+          usage: {
+            inputTokens: 1,
+            providerCost: { amount: 0.01, currency: 'USD', reportedByProvider: true },
+          },
+        };
+      },
+    });
+    const result = await execute(createExecutor, runtimeIdentity, 'question', 'answer');
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    expect(result.artifacts.execution.records[0]).toMatchObject({
+      executionStatus: 'failed',
+      error: { code: 'EVAL_RUNTIME_EXECUTOR_CONTRACT_VIOLATION' },
+    });
+
+    const unsupportedUsageIdentity = identity({ usage: 'unsupported' });
+    const unsupportedUsage = await execute(
+      () => createJsonExecutorAdapter({
+        identity: unsupportedUsageIdentity,
+        inputParser: z.string(),
+        targetConfigParser: z.object({ deployment: z.string() }),
+        outputParser: z.string(),
+        outputClassification: 'public',
+        async invoke() {
+          return {
+            invocationStatus: 'completed',
+            output: 'answer',
+            usage: { totalTokens: 1 },
+          };
+        },
+      }),
+      unsupportedUsageIdentity,
+      'question',
+      'answer',
+    );
+    expect(unsupportedUsage.status).toBe('completed');
+    if (unsupportedUsage.status !== 'completed') return;
+    expect(unsupportedUsage.artifacts.execution.records[0]).toMatchObject({
+      executionStatus: 'failed',
+      error: { code: 'EVAL_RUNTIME_EXECUTOR_CONTRACT_VIOLATION' },
+    });
+
+    const costWithoutTokenUsageIdentity = identity({ usage: 'unsupported', cost: 'required' });
+    const costWithoutTokenUsage = await execute(
+      () => createJsonExecutorAdapter({
+        identity: costWithoutTokenUsageIdentity,
+        inputParser: z.string(),
+        targetConfigParser: z.object({ deployment: z.string() }),
+        outputParser: z.string(),
+        outputClassification: 'public',
+        async invoke() {
+          return {
+            invocationStatus: 'completed',
+            output: 'answer',
+            usage: {
+              providerCost: { amount: 0.01, currency: 'USD', reportedByProvider: true },
+            },
+          };
+        },
+      }),
+      costWithoutTokenUsageIdentity,
+      'question',
+      'answer',
+    );
+    expect(costWithoutTokenUsage.status).toBe('completed');
+    if (costWithoutTokenUsage.status !== 'completed') return;
+    expect(costWithoutTokenUsage.artifacts.execution.records[0]).toMatchObject({
+      executionStatus: 'completed',
+      usage: {
+        providerCost: { amount: 0.01, currency: 'USD', reportedByProvider: true },
+      },
+    });
+  });
+
+  it('rejects invalid usage and a missing required trace with stable codes', async () => {
+    const invalidUsageIdentity = identity();
+    const invalidUsage = await execute(
+      () => createJsonExecutorAdapter({
+        identity: invalidUsageIdentity,
+        inputParser: z.string(),
+        targetConfigParser: z.object({ deployment: z.string() }),
+        outputParser: z.string(),
+        outputClassification: 'public',
+        async invoke() {
+          return {
+            invocationStatus: 'completed',
+            output: 'answer',
+            usage: { inputTokens: -1 },
+          } as never;
+        },
+      }),
+      invalidUsageIdentity,
+      'question',
+      'answer',
+    );
+    expect(invalidUsage.status).toBe('completed');
+    if (invalidUsage.status !== 'completed') return;
+    expect(invalidUsage.artifacts.execution.records[0]).toMatchObject({
+      executionStatus: 'failed',
+      error: { code: 'EVAL_RUNTIME_EXECUTOR_USAGE_INVALID' },
+    });
+
+    const requiredTraceIdentity = identity({ trace: 'required' });
+    const missingTrace = await execute(
+      () => createJsonExecutorAdapter({
+        identity: requiredTraceIdentity,
+        inputParser: z.string(),
+        targetConfigParser: z.object({ deployment: z.string() }),
+        outputParser: z.string(),
+        outputClassification: 'public',
+        async invoke() {
+          return { invocationStatus: 'completed', output: 'answer' };
+        },
+      }),
+      requiredTraceIdentity,
+      'question',
+      'answer',
+    );
+    expect(missingTrace.status).toBe('completed');
+    if (missingTrace.status !== 'completed') return;
+    expect(missingTrace.artifacts.execution.records[0]).toMatchObject({
+      executionStatus: 'failed',
+      error: { code: 'EVAL_RUNTIME_EXECUTOR_CONTRACT_VIOLATION' },
+    });
+
+    const costOnlyIdentity = identity({ usage: 'required', cost: 'required' });
+    const costOnly = await execute(
+      () => createJsonExecutorAdapter({
+        identity: costOnlyIdentity,
+        inputParser: z.string(),
+        targetConfigParser: z.object({ deployment: z.string() }),
+        outputParser: z.string(),
+        outputClassification: 'public',
+        async invoke() {
+          return {
+            invocationStatus: 'completed',
+            output: 'answer',
+            usage: {
+              providerCost: { amount: 0.01, currency: 'USD', reportedByProvider: true },
+            },
+          };
+        },
+      }),
+      costOnlyIdentity,
+      'question',
+      'answer',
+    );
+    expect(costOnly.status).toBe('completed');
+    if (costOnly.status !== 'completed') return;
+    expect(costOnly.artifacts.execution.records[0]).toMatchObject({
+      executionStatus: 'failed',
+      error: { code: 'EVAL_RUNTIME_EXECUTOR_CONTRACT_VIOLATION' },
+    });
+  });
+
+  it('fails with a stable redacted code when runtime output violates its parser', async () => {
+    const runtimeIdentity = identity();
+    const createExecutor = () => createJsonExecutorAdapter({
+      identity: runtimeIdentity,
+      inputParser: z.string(),
+      targetConfigParser: z.object({ deployment: z.string() }),
+      outputParser: z.object({ answer: z.string() }),
+      outputClassification: 'public',
+      async invoke() {
+        return {
+          invocationStatus: 'completed',
+          output: { answer: 42 },
+        } as never;
+      },
+    });
+    const result = await execute(createExecutor, runtimeIdentity, 'question', { answer: 'answer' });
+
+    expect(result.status).toBe('completed');
+    if (result.status !== 'completed') return;
+    expect(result.artifacts.execution.records[0]).toMatchObject({
+      executionStatus: 'failed',
+      error: { code: 'EVAL_RUNTIME_EXECUTOR_OUTPUT_INVALID' },
+    });
+  });
+
+  it('propagates Core cancellation to the host callback and cleans up', async () => {
+    const runtimeIdentity = identity();
+    const controller = new AbortController();
+    let observedReason: unknown;
+    const createExecutor = () => createJsonExecutorAdapter({
+      identity: runtimeIdentity,
+      inputParser: z.string(),
+      targetConfigParser: z.object({ deployment: z.string() }),
+      outputParser: z.string(),
+      outputClassification: 'public',
+      async invoke({ signal }) {
+        await new Promise<void>((_resolve, reject) => {
+          const abort = () => {
+            observedReason = signal.reason;
+            reject(signal.reason);
+          };
+          if (signal.aborted) abort();
+          else signal.addEventListener('abort', abort, { once: true });
+        });
+        return { invocationStatus: 'completed', output: 'unreachable' };
+      },
+    });
+    const result = await execute(
+      createExecutor,
+      runtimeIdentity,
+      'question',
+      'answer',
+      {
+        signal: controller.signal,
+        onEvent(event) {
+          if (event.eventKind === 'execution.attempt.started') {
+            controller.abort(new Error('host cancelled evaluation'));
+          }
+        },
+      },
+    );
+
+    expect(result.status).toBe('cancelled');
+    expect(observedReason).toBe('external-cancellation');
+  });
+});


### PR DESCRIPTION
## 用户影响

- 新增 `createJsonExecutorAdapter()`，宿主可直接用自己的 JSON input／Target config／output／trace 接入 `omk.invoke/v1`，不再依赖 OMK CLI 的 `ExecutorFn` 数据结构。
- Parser 的推导类型贯穿宿主回调；不合法的边界数据统一转为稳定、脱敏的 execution failure。
- Core 的取消信号、usage、provider cost 与 trace capability 均按封存的 Runtime identity 校验，避免实际遥测与公开身份静默分叉。

## 迁移说明

新接入建议使用 `createJsonExecutorAdapter()`。已有 `ExecutorFn` 宿主仍可继续使用 `createExecutorFnAdapter()`；本 PR 不删除旧入口。Parser 只允许校验与收窄，不允许 coercion、补默认值或删除字段；有意的数据变换应放在 `invoke` 内，并由新的 implementation revision／fingerprint 覆盖。

## 测量影响

本 PR 不改变 Eval Core 的评分、统计或 artifact schema。新增适配器会拒绝与 Runtime identity 不一致的 trace／usage／provider-cost 返回，以及会改变 canonical JSON 的 parser transform，从而防止同一 identity 下的测量口径漂移。

## 验证与审查

- 独立 detached worktree 执行 `yarn ci`：303 个测试文件、3139 个测试通过。
- TypeScript package fixture 验证 Parser 类型推导与错误输出类型拒绝。
- fresh-pass CR 已完成；修复 `usage: unsupported` 仍接受 token usage、`usage: required` 被 cost-only 误满足的问题后，无剩余 P0～P2 finding。

Part of #640。
