### PR TITLE
feat(eval-runtime)!: BREAKING-API 根入口收敛为用户级评测 API

### DIFF
--- a/docs/guides/eval-runtime.md
+++ b/docs/guides/eval-runtime.md
@@ -1,9 +1,9 @@
 # Embed OMK in a Node.js service
 
-Use `oh-my-knowledge/eval-runtime` when your application owns model invocation and OMK should own measurement, comparison, and reporting. The ordinary integration has one entry point:
+Use the `oh-my-knowledge` package root when your application owns model invocation and OMK should own measurement, comparison, and reporting. The ordinary integration has one entry point:
 
 ```ts
-import { evaluate } from 'oh-my-knowledge/eval-runtime';
+import { evaluate } from 'oh-my-knowledge';
 ```
 
 The package is ESM-only and requires Node.js 22 or newer. It does not discover credentials, providers, files, environment variables, CLI configuration, or Studio state.
@@ -37,7 +37,7 @@ npm install oh-my-knowledge zod
 
 ```ts
 import { z } from 'zod';
-import { evaluate } from 'oh-my-knowledge/eval-runtime';
+import { evaluate } from 'oh-my-knowledge';
 
 const result = await evaluate({
   executor: {
@@ -175,7 +175,7 @@ The Judge callback performs exactly one provider invocation and must not retry. 
 Run `checkExecutor()` before adopting an adapter. It drives the same declaration through real successful, failed, and cancelled Core runs, and checks binding isolation, lifecycle cleanup, telemetry, observations, paired analysis, and Decision:
 
 ```ts
-import { checkExecutor } from 'oh-my-knowledge/eval-runtime';
+import { checkExecutor } from 'oh-my-knowledge';
 
 const certification = await checkExecutor({
   executor,
@@ -203,6 +203,6 @@ import {
 } from 'oh-my-knowledge/eval-runtime/advanced';
 ```
 
-Use `oh-my-knowledge/eval-runtime/advanced` for custom ports, staged host assembly, or the legacy `ExecutorFn` bridge; use `oh-my-knowledge/eval-runtime/contracts` for versioned wire schemas; use `oh-my-knowledge/eval-core` for multi-metric graphs, custom Analysis Runtime implementations, artifact replay, or explicit cross-run comparability. `eval-workflows` depends on the leaf runtime foundation modules, never on this user façade. Deep paths outside `package.json#exports` are private.
+The explicit `oh-my-knowledge/eval-runtime` subpath exposes the same canonical façade as the package root. Use `oh-my-knowledge/eval-runtime/advanced` for custom ports, staged host assembly, or the legacy `ExecutorFn` bridge; use `oh-my-knowledge/eval-runtime/contracts` for versioned wire schemas; use `oh-my-knowledge/eval-core` for multi-metric graphs, custom Analysis Runtime implementations, artifact replay, or explicit cross-run comparability. `eval-workflows` depends on the leaf runtime foundation modules, never on either user façade. Deep paths outside `package.json#exports` are private.
 
 The runnable [minimal example](https://github.com/lizhiyao/oh-my-knowledge/tree/main/examples/eval-runtime) and packed-package fixtures exercise the canonical API in a clean host.

--- a/docs/guides/v1-preview-migration.md
+++ b/docs/guides/v1-preview-migration.md
@@ -83,8 +83,8 @@ Check the current [CLI reference](../reference/cli.md) rather than copying 0.54 
 
 The published API is ESM-only on Node.js 22 or newer. Imports are restricted to the package export map; `oh-my-knowledge/dist/*` is private.
 
-- Use `oh-my-knowledge` for the minimal one-call Engine façade and Core contracts.
-- Use `oh-my-knowledge/eval-core` for staged execution, admission, verification, comparability, Series, and Core JSON Schemas.
+- Use `oh-my-knowledge` for the ordinary `evaluate()` and `checkExecutor()` façade. The explicit `oh-my-knowledge/eval-runtime` subpath is equivalent.
+- Move former package-root Core imports to `oh-my-knowledge/eval-core`; use that subpath for Engine construction, staged execution, admission, verification, comparability, Series, and Core JSON Schemas.
 - Use `oh-my-knowledge/eval-samples`, `oh-my-knowledge/projections`, `oh-my-knowledge/studio`, `oh-my-knowledge/mcp`, or `oh-my-knowledge/dsh-plugin` for those explicit surfaces.
 - Replace synchronous `require()` with ESM imports or dynamic `import()`.
 - Engine Runtime assembly now uses binding resolvers that return the resolution and configured port together.

--- a/docs/reference/embedded-api.md
+++ b/docs/reference/embedded-api.md
@@ -1,8 +1,34 @@
-# Embedded Evaluation Core API
+# Embedded API
 
-Use the package-root API when a Node.js host owns datasets, credentials, queues, storage, and user-facing workflows but wants OMK to own evaluation planning, execution, measurement, analysis, and report materialization.
+When a Node.js host owns model invocation while OMK owns measurement, comparison, and reporting, use the package-root Runtime façade. It is ESM-only and requires Node.js 22 or newer:
 
-The embedded API is ESM-only and requires Node.js 22 or newer:
+```ts
+import { evaluate, checkExecutor } from 'oh-my-knowledge';
+```
+
+CommonJS hosts use dynamic import:
+
+```js
+const { evaluate } = await import('oh-my-knowledge');
+```
+
+Synchronous `require('oh-my-knowledge')` is intentionally unsupported. OMK does not ship a second CommonJS build, avoiding two module instances with diverging runtime registries. Only these public entry points are supported:
+
+| Entry point | Ownership |
+|---|---|
+| `oh-my-knowledge` | recommended `evaluate()` and `checkExecutor()` façade for ordinary hosts |
+| `oh-my-knowledge/eval-core` | advanced staged execution, artifact admission and verification, comparability, Series, and Schema discovery |
+| `oh-my-knowledge/eval-runtime` | explicit equivalent of the package-root Runtime façade |
+| `oh-my-knowledge/eval-runtime/advanced` | low-level Runtime assembly, identities, adapters, builders, and lifecycle SPI |
+| `oh-my-knowledge/projections` | downstream artifact projections |
+| `oh-my-knowledge/studio` | Studio Core-run catalog and routes |
+| `oh-my-knowledge/mcp` / `oh-my-knowledge/dsh-plugin` | integration-specific APIs |
+
+All other paths, including `oh-my-knowledge/dist/*`, are private and blocked by the package export map.
+
+## Evaluation Core boundary
+
+For the standard service-host path, start with the [eval-runtime guide](/guides/eval-runtime). Hosts that need custom Analysis implementations, staged replay, or infrastructure ports import the lower-level Core surface explicitly:
 
 ```ts
 import {
@@ -11,32 +37,8 @@ import {
   type EvaluationDefinition,
   type EvaluationEngineRuntime,
   type MeasurementPolicy,
-} from 'oh-my-knowledge';
+} from 'oh-my-knowledge/eval-core';
 ```
-
-CommonJS hosts use dynamic import:
-
-```js
-const { createEvaluationEngine } = await import('oh-my-knowledge');
-```
-
-Synchronous `require('oh-my-knowledge')` is intentionally unsupported. OMK does not ship a second CommonJS build, avoiding two module instances with diverging runtime registries. Only these public entry points are supported:
-
-| Entry point | Ownership |
-|---|---|
-| `oh-my-knowledge` | minimal one-call Engine façade and Core contracts |
-| `oh-my-knowledge/eval-core` | advanced staged execution, artifact admission and verification, comparability, Series, and Schema discovery |
-| `oh-my-knowledge/eval-runtime` | canonical `evaluate()` and `checkExecutor()` API for ordinary Node.js／FaaS hosts |
-| `oh-my-knowledge/eval-runtime/advanced` | low-level Runtime assembly, identities, adapters, builders, and lifecycle SPI |
-| `oh-my-knowledge/projections` | downstream artifact projections |
-| `oh-my-knowledge/studio` | Studio Core-run catalog and routes |
-| `oh-my-knowledge/mcp` / `oh-my-knowledge/dsh-plugin` | integration-specific APIs |
-
-All other paths, including `oh-my-knowledge/dist/*`, are private and blocked by the package export map.
-
-## Runtime boundary
-
-For the standard service-host path, start with the [eval-runtime guide](/guides/eval-runtime). The lower-level assembly below is for hosts that need custom Analysis implementations or infrastructure ports.
 
 An engine receives implementations and infrastructure ports. Functions stay in memory and never enter the serializable Definition:
 

--- a/docs/reference/eval-runtime-api.md
+++ b/docs/reference/eval-runtime-api.md
@@ -2,6 +2,10 @@
 
 `package.json#exports` is the supported boundary. The API allowlist locks every value and type below. All entries are ESM-only.
 
+## `oh-my-knowledge`
+
+The recommended ordinary-user entry. It exposes exactly the same canonical Runtime façade as `oh-my-knowledge/eval-runtime`: `evaluate`, `checkExecutor`, their stable errors, and their public model types. Core engines, builders, registrations, and adapters are intentionally absent.
+
 ## `oh-my-knowledge/eval-runtime`
 
 The canonical API for application developers:
@@ -75,6 +79,6 @@ Versioned wire contracts for adapter and trace authors:
 
 ## Migration
 
-The `1.0.0-beta` canonical entry replaces the previous assembly-first surface. Move existing low-level imports from `oh-my-knowledge/eval-runtime` to `oh-my-knowledge/eval-runtime/advanced`; wire schemas remain at `/contracts`. New hosts should import `evaluate` or `checkExecutor` from `/eval-runtime`.
+The `1.0.0-beta` canonical entry replaces the previous assembly-first surface. Move existing low-level imports from `oh-my-knowledge/eval-runtime` to `oh-my-knowledge/eval-runtime/advanced`; wire schemas remain at `/contracts`. New hosts should import `evaluate` or `checkExecutor` from the package root. The `/eval-runtime` entry remains the explicit equivalent for consumers that prefer domain-qualified imports.
 
 Use `oh-my-knowledge/eval-core` for custom analysis graphs, persisted artifact admission, staged replay, or explicit cross-run comparability. Deep implementation imports are unsupported.

--- a/docs/specs/eval-core-vnext.md
+++ b/docs/specs/eval-core-vnext.md
@@ -56,7 +56,7 @@ The current pipeline joins CLI flags, file parsing, artifact resolution, executo
 3. Support re-evaluation, re-analysis, and re-decision with complete derivation lineage.
 4. Make statistical design, missingness, caching, and budgets explicit measurement contracts.
 5. Isolate resources, cancellation, events, and caches between concurrent Runs.
-6. Provide one Core for the package-root embedded API, CLI, Studio, and future hosts.
+6. Provide one Core for the package-root Runtime façade, CLI, Studio, and future hosts.
 
 ### Non-goals
 
@@ -799,7 +799,7 @@ Advanced APIs support:
 - `analyze(plan.analysis, evaluationBundle)`;
 - `decide(plan.decision, analysisBundle)`.
 
-The package root also provides a one-call façade. Advanced APIs return serializable Bundles and do not expose mutable schedulers. Public exports are allowlisted through `package.json#exports`; `./dist/*` deep imports are not a contract.
+The one-call Core façade is exposed from `oh-my-knowledge/eval-core`; the package root is reserved for the ordinary `evaluate()` Runtime façade. Advanced Core APIs return serializable Bundles and do not expose mutable schedulers. Public exports are allowlisted through `package.json#exports`; `./dist/*` deep imports are not a contract.
 
 ## 13. Conformance and verification
 
@@ -874,7 +874,7 @@ Rejected. Durability and distributed orchestration belong to hosts. Content-addr
 5. Execution: trials, paired scheduling, resources, and ExecutionBundle.
 6. Evaluation/Analysis: re-scoring, AnalysisGraph, statistics, and DecisionPolicy.
 7. Conformance: three Target classes, fault injection, security, and simulation.
-8. Deliver the package-root façade in #424.
+8. Deliver the original package-root Core façade in #424; later expose that Core from `/eval-core` and reserve the root for the ordinary Runtime façade.
 9. Migrate CLI and Studio last.
 
 Each phase depends only on the previous phase's public Plan/Bundle contracts, never its internal implementation.
@@ -968,9 +968,11 @@ statistical vectors and deterministic simulations guard bootstrap unit semantics
 coverage, and a broad null paired-effect type-I error bound.
 
 The #425 acceptance audit is now complete for Contracts, Compiler, Execution, Evaluation,
-Analysis/Decision, and cross-stage conformance. The package-root façade, public export allowlist,
-and independent Node.js host acceptance remain intentionally assigned to #424. CLI and Studio
-migration remain later consumers and are not Evaluation Core acceptance dependencies.
+Analysis/Decision, and cross-stage conformance. At that stage, the package-root Core façade,
+public export allowlist, and independent Node.js host acceptance were assigned to #424. The Core
+surface now lives at the explicit `/eval-core` subpath, while the package root exposes the ordinary
+Runtime façade. CLI and Studio migration remain later consumers and are not Evaluation Core
+acceptance dependencies.
 
 Conformance exposed cross-stage defects: durable Bundle admission previously compared the
 originating root contract with the current RunPlan. Origin lineage remains sealed and
@@ -1071,9 +1073,9 @@ started once, in the suffix required by the host. Every method delegates directl
 stage runtime, so scheduling, cache, budget, failure, cancellation, and resource teardown semantics
 remain single-sourced.
 
-The package root deliberately types `prepare()` as the minimal one-call `PreparedEvaluation`.
-`oh-my-knowledge/eval-core` exposes the same factory with the narrower advanced return type;
-it does not create a second implementation, registry, or execution path. Studio and downstream
+`oh-my-knowledge/eval-core` exposes the one-call and prepared-stage capabilities through the same
+factory; it does not create a second implementation, registry, or execution path. The package root
+instead exposes the ordinary `evaluate()` Runtime façade. Studio and downstream
 projections live behind their own explicit subpaths, while unlisted and `dist/*` deep imports remain
 closed. This keeps dependency direction visible without fragmenting runtime authority.
 

--- a/docs/zh/guides/eval-runtime.md
+++ b/docs/zh/guides/eval-runtime.md
@@ -1,9 +1,9 @@
 # 在 Node.js 服务中嵌入 OMK
 
-应用自行负责模型调用，而希望 OMK 负责测量、对比和报告时，使用 `oh-my-knowledge/eval-runtime`。普通接入只有一个主入口：
+应用自行负责模型调用，而希望 OMK 负责测量、对比和报告时，使用 `oh-my-knowledge` 包根入口。普通接入只有一个主入口：
 
 ```ts
-import { evaluate } from 'oh-my-knowledge/eval-runtime';
+import { evaluate } from 'oh-my-knowledge';
 ```
 
 该包仅支持 ESM，要求 Node.js 22 或更高版本。它不会自行发现凭证、provider、文件、环境变量、CLI 配置或 Studio 状态。
@@ -37,7 +37,7 @@ npm install oh-my-knowledge zod
 
 ```ts
 import { z } from 'zod';
-import { evaluate } from 'oh-my-knowledge/eval-runtime';
+import { evaluate } from 'oh-my-knowledge';
 
 const result = await evaluate({
   executor: {
@@ -172,7 +172,7 @@ const result = await evaluate({
 接纳 adapter 前运行 `checkExecutor()`。它会让同一份 declaration 经历真实的成功、失败和取消 Core run，并检查 binding 隔离、生命周期清理、telemetry、observation、配对分析与 Decision：
 
 ```ts
-import { checkExecutor } from 'oh-my-knowledge/eval-runtime';
+import { checkExecutor } from 'oh-my-knowledge';
 
 const certification = await checkExecutor({
   executor,
@@ -200,6 +200,6 @@ import {
 } from 'oh-my-knowledge/eval-runtime/advanced';
 ```
 
-自定义 port、分阶段宿主装配或旧 `ExecutorFn` bridge 使用 `oh-my-knowledge/eval-runtime/advanced`；版本化 wire schema 使用 `oh-my-knowledge/eval-runtime/contracts`；多指标图、自定义 Analysis Runtime、artifact 重放或显式跨 run 可比性使用 `oh-my-knowledge/eval-core`。`eval-workflows` 只依赖 runtime foundation 叶子模块，不依赖这层用户 façade。`package.json#exports` 之外的深路径均为私有实现。
+显式子路径 `oh-my-knowledge/eval-runtime` 与包根暴露同一套 canonical façade。自定义 port、分阶段宿主装配或旧 `ExecutorFn` bridge 使用 `oh-my-knowledge/eval-runtime/advanced`；版本化 wire schema 使用 `oh-my-knowledge/eval-runtime/contracts`；多指标图、自定义 Analysis Runtime、artifact 重放或显式跨 run 可比性使用 `oh-my-knowledge/eval-core`。`eval-workflows` 只依赖 runtime foundation 叶子模块，不依赖任一用户 façade。`package.json#exports` 之外的深路径均为私有实现。
 
 可运行的[最小示例](https://github.com/lizhiyao/oh-my-knowledge/tree/main/examples/eval-runtime)与 packed-package fixture 会在 clean host 中验证 canonical API。

--- a/docs/zh/guides/v1-preview-migration.md
+++ b/docs/zh/guides/v1-preview-migration.md
@@ -83,8 +83,8 @@ omk eval --dry-run --samples eval-samples.yaml \
 
 公开 API 仅支持 ESM，要求 Node.js 22 或更高版本。import 必须经过 package export map，`oh-my-knowledge/dist/*` 属于私有路径。
 
-- 最小一键 Engine façade 与 Core contract 从 `oh-my-knowledge` 导入。
-- 分阶段执行、admission、verification、comparability、Series 与 Core JSON Schema 从 `oh-my-knowledge/eval-core` 导入。
+- 普通 `evaluate()` 与 `checkExecutor()` façade 从 `oh-my-knowledge` 导入；显式子路径 `oh-my-knowledge/eval-runtime` 与其等价。
+- 原包根 Core import 迁移到 `oh-my-knowledge/eval-core`；Engine 构造、分阶段执行、admission、verification、comparability、Series 与 Core JSON Schema 均从该子路径导入。
 - eval-samples、projection、Studio、MCP 与 DSH 集成分别使用 `oh-my-knowledge/eval-samples`、`oh-my-knowledge/projections`、`oh-my-knowledge/studio`、`oh-my-knowledge/mcp` 与 `oh-my-knowledge/dsh-plugin`。
 - 同步 `require()` 改为 ESM import 或动态 `import()`。
 - Engine Runtime 装配改用 binding resolver，一次返回 resolution 与配置好的 port。

--- a/docs/zh/reference/embedded-api.md
+++ b/docs/zh/reference/embedded-api.md
@@ -1,8 +1,34 @@
-# 嵌入式 Evaluation Core API
+# 嵌入式 API
 
-当 Node.js 宿主自行负责数据集、凭证、队列、存储和业务工作流，而希望 OMK 负责评测计划、执行、测量、分析与报告物化时，使用包根嵌入式 API。
+当 Node.js 宿主自行负责模型调用，而希望 OMK 负责测量、对比与报告时，使用包根 Runtime façade。它仅提供 ESM 构建，要求 Node.js 22 或更高版本：
 
-嵌入式 API 仅提供 ESM 构建，要求 Node.js 22 或更高版本：
+```ts
+import { evaluate, checkExecutor } from 'oh-my-knowledge';
+```
+
+CommonJS 宿主通过动态导入使用：
+
+```js
+const { evaluate } = await import('oh-my-knowledge');
+```
+
+OMK 有意不支持同步 `require('oh-my-knowledge')`，也不发布第二份 CommonJS 构建，从而避免两个模块实例持有相互分裂的 Runtime registry。只支持以下公共入口：
+
+| 入口 | 职责 |
+|---|---|
+| `oh-my-knowledge` | 面向普通宿主的推荐 `evaluate()` 与 `checkExecutor()` façade |
+| `oh-my-knowledge/eval-core` | 高级分阶段执行、artifact admission 与验证、comparability、Series 和 Schema 发现 |
+| `oh-my-knowledge/eval-runtime` | 与包根 Runtime façade 完全等价的显式入口 |
+| `oh-my-knowledge/eval-runtime/advanced` | 底层 Runtime 装配、identity、adapter、builder 与生命周期 SPI |
+| `oh-my-knowledge/projections` | 下游 artifact projection |
+| `oh-my-knowledge/studio` | Studio Core-run catalog 与 route |
+| `oh-my-knowledge/mcp`／`oh-my-knowledge/dsh-plugin` | 集成专用 API |
+
+其它路径均为私有实现，包括 `oh-my-knowledge/dist/*` 在内，都会被 package export map 阻断。
+
+## Evaluation Core 边界
+
+标准服务宿主优先参考[eval-runtime 接入指南](/zh/guides/eval-runtime)。需要自定义 Analysis implementation、分阶段重放或基础设施 port 的宿主，应显式导入底层 Core surface：
 
 ```ts
 import {
@@ -11,32 +37,8 @@ import {
   type EvaluationDefinition,
   type EvaluationEngineRuntime,
   type MeasurementPolicy,
-} from 'oh-my-knowledge';
+} from 'oh-my-knowledge/eval-core';
 ```
-
-CommonJS 宿主通过动态导入使用：
-
-```js
-const { createEvaluationEngine } = await import('oh-my-knowledge');
-```
-
-OMK 有意不支持同步 `require('oh-my-knowledge')`，也不发布第二份 CommonJS 构建，从而避免两个模块实例持有相互分裂的 Runtime registry。只支持以下公共入口：
-
-| 入口 | 职责 |
-|---|---|
-| `oh-my-knowledge` | 最小一键 Engine façade 与 Core contract |
-| `oh-my-knowledge/eval-core` | 高级分阶段执行、artifact admission 与验证、comparability、Series 和 Schema 发现 |
-| `oh-my-knowledge/eval-runtime` | 面向普通 Node.js／FaaS 宿主的 canonical `evaluate()` 与 `checkExecutor()` API |
-| `oh-my-knowledge/eval-runtime/advanced` | 底层 Runtime 装配、identity、adapter、builder 与生命周期 SPI |
-| `oh-my-knowledge/projections` | 下游 artifact projection |
-| `oh-my-knowledge/studio` | Studio Core-run catalog 与 route |
-| `oh-my-knowledge/mcp`／`oh-my-knowledge/dsh-plugin` | 集成专用 API |
-
-其它路径均为私有实现，包括 `oh-my-knowledge/dist/*` 在内，都会被 package export map 阻断。
-
-## Runtime 边界
-
-标准服务宿主优先参考[eval-runtime 接入指南](/zh/guides/eval-runtime)。下面的底层装配适用于需要自定义 Analysis implementation 或基础设施 port 的宿主。
 
 Engine 接收实现与基础设施 port。函数实现只存在于内存，不会进入可序列化 Definition：
 

--- a/docs/zh/reference/eval-runtime-api.md
+++ b/docs/zh/reference/eval-runtime-api.md
@@ -2,6 +2,10 @@
 
 `package.json#exports` 是受支持边界，API allowlist 会锁定下列全部 value 与 type。所有入口仅支持 ESM。
 
+## `oh-my-knowledge`
+
+这是普通用户的推荐入口，与 `oh-my-knowledge/eval-runtime` 暴露完全相同的 canonical Runtime façade：`evaluate`、`checkExecutor`、稳定错误和公开模型 type。Core engine、builder、registration 与 adapter 不会进入包根。
+
 ## `oh-my-knowledge/eval-runtime`
 
 面向应用开发者的 canonical API：
@@ -75,6 +79,6 @@ Runner 与装配 type 包括 `RunEvaluationInput`、`EvaluationEventObserver`、
 
 ## 迁移
 
-`1.0.0-beta` canonical 入口用面向用户的 façade 取代了原先的装配优先 surface。已有底层 import 从 `oh-my-knowledge/eval-runtime` 移到 `oh-my-knowledge/eval-runtime/advanced`；wire schema 仍位于 `/contracts`。新宿主从 `/eval-runtime` 导入 `evaluate` 或 `checkExecutor`。
+`1.0.0-beta` canonical 入口用面向用户的 façade 取代了原先的装配优先 surface。已有底层 import 从 `oh-my-knowledge/eval-runtime` 移到 `oh-my-knowledge/eval-runtime/advanced`；wire schema 仍位于 `/contracts`。新宿主从包根导入 `evaluate` 或 `checkExecutor`；偏好领域限定 import 的消费者仍可使用完全等价的 `/eval-runtime` 入口。
 
 自定义 analysis graph、持久 artifact admission、分阶段重放或显式跨 run 可比性使用 `oh-my-knowledge/eval-core`。实现深路径不受支持。

--- a/docs/zh/specs/eval-core-vnext.md
+++ b/docs/zh/specs/eval-core-vnext.md
@@ -56,7 +56,7 @@ EvaluationDefinition + MeasurementPolicy
 3. 支持执行结果重评分、重新分析和重新决策，并保留完整 derivation lineage。
 4. 让统计设计、缺失机制、缓存和预算成为显式测量契约。
 5. 让并发 Run 的资源、取消、事件和缓存完全隔离。
-6. 为包根嵌入式 API、CLI、Studio 和未来宿主提供同一套 Core。
+6. 为包根 Runtime façade、CLI、Studio 和未来宿主提供同一套 Core。
 
 ### 非目标
 
@@ -796,7 +796,7 @@ const result = await run.result;
 - `analyze(plan.analysis, evaluationBundle)`；
 - `decide(plan.decision, analysisBundle)`。
 
-包根另提供一次完成全流程的便捷 façade。高级 API 输出可序列化 Bundle，不暴露可变内部调度器。公共导出通过 `package.json#exports` 白名单管理，不再承诺 `./dist/*` 深层导入。
+Core 一次完成全流程的 façade 从 `oh-my-knowledge/eval-core` 暴露；包根只承载普通用户的 `evaluate()` Runtime façade。高级 Core API 输出可序列化 Bundle，不暴露可变内部调度器。公共导出通过 `package.json#exports` 白名单管理，不再承诺 `./dist/*` 深层导入。
 
 ## 十三、Conformance 与验证
 
@@ -870,7 +870,7 @@ ExecutionBundle 以 `runContractDigest` 和 `datasetRevisionDigest` 记录产出
 5. Execution：trial、paired scheduling、资源和 ExecutionBundle；
 6. Evaluation／Analysis：重评分、AnalysisGraph、统计和 DecisionPolicy；
 7. Conformance：三类 Target、fault injection、安全与 simulation；
-8. #424 包根 façade；
+8. #424 交付原包根 Core façade；后续将其收敛到 `/eval-core`，包根只承载普通用户 Runtime façade；
 9. 最后迁移 CLI／Studio。
 
 每一阶段只依赖前一阶段的公开 Bundle／Plan 契约，不直接导入内部实现。
@@ -962,8 +962,9 @@ cache，同时保持不同的 Run id、state、取消、session 和 teardown；d
 语义、宽松的区间 coverage 校准带，以及零 paired effect 的宽松 I 型错误率上界。
 
 #425 对 Contracts、Compiler、Execution、Evaluation、Analysis／Decision 与跨阶段 conformance
-的验收审计至此完成。包根 façade、公开 export 白名单和独立 Node.js 宿主验收仍明确归 #424；
-CLI／Studio 迁移是后续消费者，不构成 Evaluation Core 验收前置条件。
+的验收审计至此完成。当时包根 Core façade、公开 export 白名单和独立 Node.js 宿主验收明确归 #424。
+现在 Core surface 位于显式 `/eval-core` 子路径，包根则暴露普通用户 Runtime façade；CLI／Studio
+迁移是后续消费者，不构成 Evaluation Core 验收前置条件。
 
 Conformance 暴露并修复了多个跨阶段缺口：durable Bundle 接纳曾要求来源 root contract 等于
 当前 RunPlan。来源血缘仍被封存并受 provenance 绑定，但接纳现在按阶段发生，递归校验每个被
@@ -1060,9 +1061,9 @@ Analysis、Decision 和 Report materialization 在同一 session 中各自最多
 任意有效阶段开始，只重算必要后缀。每个方法都直接委托现有 stage runtime，因此调度、cache、预算、
 失败、取消和资源释放语义继续只有一份来源。
 
-包根会刻意把 `prepare()` 类型收窄为最小一键 `PreparedEvaluation`。
-`oh-my-knowledge/eval-core` 通过同一个 factory 暴露高级返回类型；它不会创建第二份
-implementation、registry 或执行路径。Studio 与 downstream projection 分别放在显式子路径中，
+`oh-my-knowledge/eval-core` 通过同一个 factory 暴露一键运行与 prepared-stage capability；它不会
+创建第二份 implementation、registry 或执行路径。包根改为暴露普通用户的 `evaluate()` Runtime
+façade。Studio 与 downstream projection 分别放在显式子路径中，
 未列出的入口和 `dist/*` 深层导入继续保持关闭。这样既让依赖方向清晰可见，又不分裂 Runtime authority。
 
 每次 prepare 或一键 start 都会捕获 Runtime 顶层 infrastructure port、binding resolver 函数与独立的

--- a/examples/eval-runtime/README.md
+++ b/examples/eval-runtime/README.md
@@ -4,7 +4,7 @@
 
 ## Purpose
 
-This minimal Node.js ESM host injects an in-memory business invocation function into `oh-my-knowledge/eval-runtime`, compares two service deployments, applies deterministic exact-match scoring, and materializes an Evaluation Report. It does not load the CLI or read user configuration.
+This minimal Node.js ESM host injects an in-memory business invocation function through the `oh-my-knowledge` package root, compares two service deployments, applies deterministic exact-match scoring, and materializes an Evaluation Report. It does not load the CLI or read user configuration.
 
 ## Run
 

--- a/examples/eval-runtime/README.zh.md
+++ b/examples/eval-runtime/README.zh.md
@@ -4,7 +4,7 @@
 
 ## 用途
 
-这个最小 Node.js ESM 宿主把内存中的业务调用函数注入 `oh-my-knowledge/eval-runtime`，对比两个服务部署，执行确定性 exact-match 评分，并物化 Evaluation Report。它不会加载 CLI，也不会读取用户配置。
+这个最小 Node.js ESM 宿主通过 `oh-my-knowledge` 包根入口注入内存中的业务调用函数，对比两个服务部署，执行确定性 exact-match 评分，并物化 Evaluation Report。它不会加载 CLI，也不会读取用户配置。
 
 ## 运行
 

--- a/examples/eval-runtime/run.mjs
+++ b/examples/eval-runtime/run.mjs
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { evaluate } from 'oh-my-knowledge/eval-runtime';
+import { evaluate } from 'oh-my-knowledge';
 
 const answers = {
   baseline: { one: 'A', two: 'incorrect', three: 'incorrect' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,2 @@
-import { createEvaluationEngine as createAdvancedEvaluationEngine } from './eval-core/engine/index.js';
-import type {
-  EvaluationEngine,
-  EvaluationEngineRuntime,
-} from './eval-core/engine/index.js';
-
-/** Minimal one-call Evaluation Core facade. Advanced stages live at `oh-my-knowledge/eval-core`. */
-export const createEvaluationEngine: (
-  runtime: EvaluationEngineRuntime,
-) => EvaluationEngine = createAdvancedEvaluationEngine;
-
-export * from './eval-core/facade.js';
+/** Canonical user-facing API. Advanced surfaces use explicit package subpaths. */
+export * from './eval-runtime/index.js';

--- a/test/architecture/src-root-layout.test.ts
+++ b/test/architecture/src-root-layout.test.ts
@@ -30,6 +30,10 @@ const PACKAGE_ENTRYPOINTS = new Set([
   'studio/index.ts',
 ]);
 
+const ALLOWED_ENTRYPOINT_EDGES = new Set([
+  'index.ts → eval-runtime/index.ts',
+]);
+
 const EXPECTED_SHARED_FILES = [
   'atomic-json.ts',
   'content-hash.ts',
@@ -140,7 +144,8 @@ describe('src 最终领域地图', () => {
         if (!target) continue;
         const targetRelative = sourceRelative(target);
         if (PACKAGE_ENTRYPOINTS.has(targetRelative)) {
-          violations.push(`${importerRelative} → ${targetRelative}`);
+          const edge = `${importerRelative} → ${targetRelative}`;
+          if (!ALLOWED_ENTRYPOINT_EDGES.has(edge)) violations.push(edge);
         }
       }
     }

--- a/test/eval-core/embedded-package.test.ts
+++ b/test/eval-core/embedded-package.test.ts
@@ -42,7 +42,7 @@ const ADVANCED_RUNTIME_HOST_FIXTURE = join(
 );
 const PUBLIC_RUNTIME_EXAMPLE = join(REPO_ROOT, 'examples/eval-runtime/run.mjs');
 
-describe('published embedded Evaluation Core API', () => {
+describe('published embedded Evaluation API', () => {
   let projectRoot: string;
   let npmCache: string;
 
@@ -144,8 +144,11 @@ const assert = require('node:assert/strict');
   const studio = await import('oh-my-knowledge/studio');
   const mcp = await import('oh-my-knowledge/mcp');
   const dshPlugin = await import('oh-my-knowledge/dsh-plugin');
-  assert.equal(typeof api.createEvaluationEngine, 'function');
-  assert.equal(typeof api.digestCanonicalJson, 'function');
+  assert.deepEqual(Object.keys(api).sort(), Object.keys(evalRuntime).sort());
+  assert.equal(typeof api.evaluate, 'function');
+  assert.equal(typeof api.checkExecutor, 'function');
+  assert.equal(api.createEvaluationEngine, undefined);
+  assert.equal(api.digestCanonicalJson, undefined);
   assert.equal(api.createCoreStudioCatalog, undefined);
   assert.equal(api.projectCoreArtifactGraph, undefined);
   assert.equal(api.assessComparability, undefined);
@@ -215,7 +218,7 @@ const assert = require('node:assert/strict');
     rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  it('NodeNext／ESM 宿主完成一键运行、分阶段复用、可比性与篡改拒绝', () => {
+  it('NodeNext／ESM Core 宿主完成一键运行、分阶段复用、可比性与篡改拒绝', () => {
     const result = spawnSync(process.execPath, [join(projectRoot, 'host.mjs')], {
       cwd: projectRoot,
       encoding: 'utf8',
@@ -243,7 +246,7 @@ const assert = require('node:assert/strict');
     }).toEqual({ status: 0, signal: null, stdout: '', stderr: '' });
   });
 
-  it('独立 Node.js ESM 宿主通过 eval-runtime 完成双 Target 对比', () => {
+  it('独立 Node.js ESM 宿主通过包根 Runtime façade 完成双 Target 对比', () => {
     const isolatedHome = join(projectRoot, 'runtime-home');
     const isolatedConfig = join(projectRoot, 'runtime-config');
     const isolatedCache = join(projectRoot, 'runtime-cache');

--- a/test/eval-core/fixtures/core-side-effect-probe.mjs
+++ b/test/eval-core/fixtures/core-side-effect-probe.mjs
@@ -19,7 +19,7 @@ function restoreHostCapabilities() {
 }
 
 try {
-  const [core, advanced, projections, studio] = await Promise.all([
+  const [root, core, projections, studio] = await Promise.all([
     import('oh-my-knowledge'),
     import('oh-my-knowledge/eval-core'),
     import('oh-my-knowledge/projections'),
@@ -47,8 +47,11 @@ try {
   const digest = core.digestCanonicalJson({ z: 1, a: ['memory-only'] });
   if (canonical !== '{"a":["memory-only"],"z":1}'
       || !digest.startsWith('sha256:')
+      || typeof root.evaluate !== 'function'
+      || typeof root.checkExecutor !== 'function'
+      || root.createEvaluationEngine !== undefined
       || typeof core.createEvaluationEngine !== 'function'
-      || typeof advanced.assessComparability !== 'function'
+      || typeof core.assessComparability !== 'function'
       || typeof projections.projectCoreArtifactGraph !== 'function'
       || typeof studio.createCoreStudioCatalog !== 'function') {
     throw new Error('Evaluation Core pure-memory contract operation failed');

--- a/test/eval-core/fixtures/embedded-host.mjs
+++ b/test/eval-core/fixtures/embedded-host.mjs
@@ -1,24 +1,21 @@
 import assert from 'node:assert/strict';
 import {
+  COMPARABILITY_POLICY_SCHEMA_VERSION,
   EVALUATION_DEFINITION_SCHEMA_VERSION,
+  EVALUATION_CORE_JSON_SCHEMA_FILES,
   EXECUTION_FACTS_SCHEMA_VERSION,
   EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
   MEASUREMENT_POLICY_SCHEMA_VERSION,
+  assessComparability,
   createBuiltinAnalysisNodes,
   createBuiltinAnalysisSchemaValidators,
+  createComparabilityPolicy,
   createBuiltinDecisionPolicies,
   createBuiltinMissingPolicies,
   createEvaluationEngine,
   digestCanonicalJson,
-  resolveBuiltinAnalysisRuntime,
-} from 'oh-my-knowledge';
-import {
-  COMPARABILITY_POLICY_SCHEMA_VERSION,
-  EVALUATION_CORE_JSON_SCHEMA_FILES,
-  assessComparability,
-  createComparabilityPolicy,
-  createEvaluationEngine as createAdvancedEvaluationEngine,
   resolveEvaluationCoreJsonSchema,
+  resolveBuiltinAnalysisRuntime,
 } from 'oh-my-knowledge/eval-core';
 
 assert.equal(EXECUTION_FACTS_SCHEMA_VERSION, 'omk.execution-facts/v1');
@@ -466,7 +463,7 @@ assert.equal(cancelled.result.status, 'cancelled');
 assert.equal(cancelled.result.report.status.evidenceStatus, 'unresolvable');
 
 const stagedHost = createHostRuntime('function');
-const stagedEngine = createAdvancedEvaluationEngine(stagedHost.runtime);
+const stagedEngine = createEvaluationEngine(stagedHost.runtime);
 const initialDefinition = definition('function');
 initialDefinition.decisionPolicy = {
   decisionPolicyId: 'release-gate',

--- a/test/eval-core/fixtures/embedded-host.ts.fixture
+++ b/test/eval-core/fixtures/embedded-host.ts.fixture
@@ -10,9 +10,6 @@ import {
   type ExecutionFacts,
   type Executor,
   type MeasurementPolicy,
-} from 'oh-my-knowledge';
-import {
-  createEvaluationEngine as createAdvancedEvaluationEngine,
   resolveEvaluationCoreJsonSchema,
   type ExecutionBundleSource,
 } from 'oh-my-knowledge/eval-core';
@@ -43,9 +40,10 @@ import {
   type RuntimePortRegistration,
 } from 'oh-my-knowledge/eval-runtime/advanced';
 import {
+  checkExecutor,
   EvaluationEventConsumptionError,
   evaluate,
-} from 'oh-my-knowledge/eval-runtime';
+} from 'oh-my-knowledge';
 import {
   createEvalSampleSetDocument,
   resolveEvalSampleJsonSchema,
@@ -155,6 +153,7 @@ function canonicalEventErrorBoundary(error: unknown): void {
   void maxConcurrency;
 }
 void canonicalEventErrorBoundary;
+void checkExecutor;
 
 const jsonIdentity = createInvokeExecutorIdentity({
   implementationId: 'test.typescript-json/v1',
@@ -335,12 +334,6 @@ const engine = createEvaluationEngine({
 });
 const run = engine.start(definition, { policy, runId: 'typescript-host' });
 
-async function rootBoundary(): Promise<void> {
-  const prepared = await engine.prepare(definition, policy);
-  // @ts-expect-error 分阶段 API 只属于显式 eval-core 子路径。
-  prepared.stages({ runId: 'root-must-stay-minimal' });
-}
-
 async function runtimeBoundary(): Promise<void> {
   const prepared = await publicEngine.prepare(publicDefinition, publicPolicy);
   // @ts-expect-error eval-runtime 同样只公开标准一键 façade。
@@ -348,7 +341,7 @@ async function runtimeBoundary(): Promise<void> {
 }
 
 async function advancedBoundary(source: ExecutionBundleSource): Promise<void> {
-  const advanced = createAdvancedEvaluationEngine(runtime);
+  const advanced = createEvaluationEngine(runtime);
   const prepared = await advanced.prepare(definition, policy);
   const stages = prepared.stages({ runId: 'typescript-advanced-host' });
   const evaluation = stages.evaluate({ execution: source });
@@ -367,6 +360,5 @@ async function consume(): Promise<EvaluationRunResult> {
 }
 
 void consume;
-void rootBoundary;
 void runtimeBoundary;
 void advancedBoundary;

--- a/test/eval-core/runtime-side-effects.test.ts
+++ b/test/eval-core/runtime-side-effects.test.ts
@@ -16,7 +16,7 @@ const PROBE_PATH = join(
   REPO_ROOT,
   'test/eval-core/fixtures/core-side-effect-probe.mjs',
 );
-const CORE_DIST_ENTRY = join(REPO_ROOT, 'dist/index.js');
+const ROOT_DIST_ENTRY = join(REPO_ROOT, 'dist/index.js');
 
 function directorySnapshot(root: string): string[] {
   const snapshot: string[] = [];
@@ -33,9 +33,9 @@ function directorySnapshot(root: string): string[] {
   return snapshot.sort();
 }
 
-describe('Evaluation Core 宿主副作用边界', () => {
+describe('嵌入式 Evaluation API 宿主副作用边界', () => {
   it('在隔离进程导入根入口与全部公共子路径时零宿主副作用', () => {
-    if (!existsSync(CORE_DIST_ENTRY)) {
+    if (!existsSync(ROOT_DIST_ENTRY)) {
       throw new Error('缺少 dist/index.js；请先运行 yarn build。');
     }
 

--- a/test/eval-runtime/fixtures/embedded-host.mjs
+++ b/test/eval-runtime/fixtures/embedded-host.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { z } from 'zod';
-import { evaluate } from 'oh-my-knowledge/eval-runtime';
+import { evaluate } from 'oh-my-knowledge';
 
 const answers = {
   control: { one: 'A', two: 'incorrect', three: 'incorrect' },

--- a/test/eval-runtime/public-api.test.ts
+++ b/test/eval-runtime/public-api.test.ts
@@ -183,8 +183,10 @@ function declarationExports(entry: string): { values: string[]; types: string[] 
 
 describe('published eval-runtime API allowlist', () => {
   it('makes the package root an exact runtime façade alias', async () => {
-    const root = await import('../../dist/index.js');
-    const runtime = await import('../../dist/eval-runtime/index.js');
+    const rootEntry = '../../dist/index.js';
+    const runtimeEntry = '../../dist/eval-runtime/index.js';
+    const root = await import(rootEntry);
+    const runtime = await import(runtimeEntry);
     expect(Object.keys(root).sort()).toEqual(Object.keys(runtime).sort());
     expect(Object.keys(root).sort()).toEqual([
       ...PUBLIC_API['eval-runtime'].values,

--- a/test/eval-runtime/public-api.test.ts
+++ b/test/eval-runtime/public-api.test.ts
@@ -182,6 +182,18 @@ function declarationExports(entry: string): { values: string[]; types: string[] 
 }
 
 describe('published eval-runtime API allowlist', () => {
+  it('makes the package root an exact runtime façade alias', async () => {
+    const root = await import('../../dist/index.js');
+    const runtime = await import('../../dist/eval-runtime/index.js');
+    expect(Object.keys(root).sort()).toEqual(Object.keys(runtime).sort());
+    expect(Object.keys(root).sort()).toEqual([
+      ...PUBLIC_API['eval-runtime'].values,
+    ].sort());
+    expect(readFileSync(resolve('dist/index.d.ts'), 'utf8')).toContain(
+      "export * from './eval-runtime/index.js';",
+    );
+  });
+
   for (const [subpath, contract] of Object.entries(PUBLIC_API)) {
     it(`locks values and types for ${subpath}`, async () => {
       const runtime = await import(`../../dist/eval-runtime/${contract.entry}.js`);

--- a/test/eval-workflows/runtime-adapter/adapters/custom/command.test.ts
+++ b/test/eval-workflows/runtime-adapter/adapters/custom/command.test.ts
@@ -16,14 +16,12 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
   digestCanonicalJson,
+  type EvaluationDefinition,
   type ExecutorCapabilities,
   type JsonValue,
   type SchemaIdentity,
   type Sha256Digest,
-} from '../../../../../src/index.js';
-import type {
-  EvaluationDefinition,
-  TargetExecutionControls,
+  type TargetExecutionControls,
 } from '../../../../../src/eval-core/contracts/index.js';
 import {
   ExecutionPortFailure,

--- a/test/eval-workflows/runtime-adapter/adapters/shared/same-process.test.ts
+++ b/test/eval-workflows/runtime-adapter/adapters/shared/same-process.test.ts
@@ -6,7 +6,7 @@ import {
   type RuntimeIdentity,
   type SchemaIdentity,
   type Sha256Digest,
-} from '../../../../../src/index.js';
+} from '../../../../../src/eval-core/contracts/index.js';
 import type {
   EvaluatorRecordContext,
   EvaluatorRunContext,

--- a/test/studio/core-runs/catalog.test.ts
+++ b/test/studio/core-runs/catalog.test.ts
@@ -7,7 +7,7 @@ import {
   createCoreStudioCatalog,
   projectCoreStudioRunDetail,
 } from '../../../src/studio/index.js';
-import { digestCanonicalJson } from '../../../src/index.js';
+import { digestCanonicalJson } from '../../../src/eval-core/contracts/index.js';
 import { CoreDownstreamProjectionError } from '../../../src/eval-workflows/projections/index.js';
 import {
   CoreRunArtifactOverlayError,


### PR DESCRIPTION
## 用户影响

普通 Node.js／FaaS 用户可直接从 `oh-my-knowledge` 导入 `evaluate()` 与 `checkExecutor()`；显式 `/eval-runtime` 入口保持等价。高级 Core、Runtime 装配和 wire contract 继续通过各自子路径访问。

## 迁移／兼容决策

这是 1.0 预览期的有意 `BREAKING-API` 收敛，不保留历史兼容别名。原先从包根导入的 Core engine 与 contract 改从 `oh-my-knowledge/eval-core` 导入；`oh-my-knowledge/eval-runtime/advanced` 与 `/contracts` 不变。

## 测量学影响

本次只调整 package entrypoint 与文档入口，不改变 Evaluation Core、评分口径、prompt 字节、Schema identity、统计语义或持久化契约。根入口与 `/eval-runtime` 指向同一实现，不形成第二条评测路径。

## 自主 CR 与验证

多维 CR 门禁通过，无 P0～P3 finding。最终改动通过完整 `yarn ci`、变更文件 lint、package build、根入口公开导出 allowlist、独立 tarball NodeNext 宿主运行和零宿主副作用验收。

## 剩余风险

未提供独立 PRD、系分、视觉稿或测试方案，因此正式报告的材料一致性维度按代码与运行证据审查。预览版中依赖旧包根 Core 导出的宿主必须按上述说明迁移。
