### PR TITLE
chore(release): 发布 1.0.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 `1.0.0-beta.3` 到 npm `next`，供用户验证统一后的 `evaluate()` 程序化入口与 Evaluation Core Run identity 契约。`latest` 不受影响。

## 迁移／兼容决策

本预览版包含两项有意的不兼容收敛：原先从包根导入的 Core engine 与 contract 改从 `oh-my-knowledge/eval-core` 导入；comparability 宿主将 `ComparabilityCandidateIdentity`／`candidateDigest` 等名称迁移为 `ComparabilityRunIdentity`／`runIdentityDigest`，并重新生成 v2 Assessment／SeriesAnalysisBundle。冻结的 v1 JSON Schema 继续分发，但当前 parser 只接收 v2。

## 测量学影响

`evaluate()` 入口收敛不改变评分、prompt 或统计语义。Comparability 的 construct 与 `runContractDigest` 不变；Assessment／SeriesAnalysisBundle 因 schemaVersion 与字段名改变而具有新的 canonical bytes 和 digest，v1 与 v2 不应视为同一持久化契约。

## 自主 CR 与验证

高风险发版 CR 结论为 No findings，P0～P2 为零。最终源码通过完整本地门禁；预发布 tag、npm `next` 路由、OIDC workflow 与 tarball 版本元数据均已核验。此前同一源码的 Node 22／24 clean external-host acceptance 已通过，本次仅改版本号，未重复执行。

## 剩余风险

预览版使用者若依赖旧包根 Core 导出或 comparability v1 运行时读取，需要按上述迁移说明调整。