### PR TITLE
test(eval-core): 补齐离散小样本校准证据

### DIFF
--- a/docs/specs/eval-core-vnext.md
+++ b/docs/specs/eval-core-vnext.md
@@ -966,8 +966,13 @@ explicitly injected Runtime registry, event sequencer, artifact store, and pair 
 retaining distinct Run ids, state, cancellation, sessions, and teardown; deferred gates force their
 lifecycles to overlap. All fixtures use deterministic clocks, seeds, deferred gates, and in-memory
 stores; they do not read files, networks, user configuration, or wall-clock delays. Known
-statistical vectors and deterministic simulations guard bootstrap unit semantics, broad interval
-coverage, and a broad null paired-effect type-I error bound.
+statistical vectors and deterministic simulations guard bootstrap unit semantics and pin exact
+frequency profiles for continuous data plus balanced, skewed, and ceiling-heavy discrete 1-5
+scores at N=8 and N=20. These profiles are regression evidence, not a claim that the percentile
+interval reaches its nominal coverage for every finite population: the frozen v1 procedure
+under-covers in small, bounded, skewed cases (the deterministic 90%, 256-resample grid reaches
+43/60 in the N=8 ceiling case and 46/60 at N=20). Consumers must treat the confidence level as
+nominal, and any replacement that changes those properties requires a new estimator identity.
 
 The #425 acceptance audit is now complete for Contracts, Compiler, Execution, Evaluation,
 Analysis/Decision, and cross-stage conformance. At that stage, the package-root Core façade,

--- a/docs/zh/specs/eval-core-vnext.md
+++ b/docs/zh/specs/eval-core-vnext.md
@@ -961,7 +961,12 @@ read／write／miss／stale／forged provenance，ContentStore 与 ContentResolv
 cache，同时保持不同的 Run id、state、取消、session 和 teardown；deferred gate 强制生命周期真实
 重叠。全部 fixture 只使用确定性 clock、seed、deferred gate 与内存 store，不读取文件、网络、用户
 配置，也不依赖 wall-clock delay。已知统计参考向量与确定性 simulation 共同守护 bootstrap unit
-语义、宽松的区间 coverage 校准带，以及零 paired effect 的宽松 I 型错误率上界。
+语义，并固定连续数据，以及 N=8／N=20 下均衡、偏斜、天花板聚集三类离散 1–5 分布的精确频率
+profile。这些 profile 是回归证据，不代表 percentile interval 对所有有限总体都达到 nominal
+coverage：冻结的 v1 流程在小样本、有界、偏斜场景会 coverage 不足（确定性 90%、每个 interval
+重采样 256 次的网格中，N=8 天花板场景为 43／60，N=20 为 46／60）。使用方必须把
+confidence level 理解为 nominal；任何改变这些性质的替代方案都必须使用新的 estimator
+identity。
 
 #425 对 Contracts、Compiler、Execution、Evaluation、Analysis／Decision 与跨阶段 conformance
 的验收审计至此完成。当时包根 Core façade、公开 export 白名单和独立 Node.js 宿主验收明确归 #424。

--- a/src/eval-workflows/analysis/bootstrap.ts
+++ b/src/eval-workflows/analysis/bootstrap.ts
@@ -3,11 +3,12 @@
  *
  * Why bootstrap instead of t-test for LLM scores?
  *
- * 1. **No distribution assumption** — t-test assumes scores are normally
- *    distributed. LLM scores on a 1-5 ordinal scale violate this; bootstrap
- *    only requires that the sample is representative.
- * 2. **Small N robustness** — t-test's small-sample correction (df-adjusted)
- *    breaks down with N < 10. Bootstrap is consistent at any N >= 2.
+ * 1. **No normality assumption** — the resampling distribution comes from the
+ *    observed units instead of assuming normally distributed raw scores.
+ * 2. **Explicit finite-sample limits** — the empirical distribution still has
+ *    to represent the population. Percentile intervals can undercover for
+ *    discrete 1-5 scores and small N; deterministic conformance simulations
+ *    pin that limitation instead of treating the nominal level as a guarantee.
  * 3. **Difference-of-means is the actual question** — In A/B eval the user
  *    asks "is variant B better than A?" — this is a 2-sample comparison and
  *    needs CI on the *difference*, not on each variant's mean separately.

--- a/test/eval-core/conformance/statistics.test.ts
+++ b/test/eval-core/conformance/statistics.test.ts
@@ -6,6 +6,8 @@ import {
 } from '../../../src/eval-core/analysis/index.js';
 import { digestCanonicalJson, type Sha256Digest } from '../../../src/eval-core/contracts/index.js';
 
+const ANALYSIS_NODES = createBuiltinAnalysisNodes();
+
 function generator(seed: number): () => number {
   let state = seed >>> 0;
   return () => {
@@ -17,6 +19,16 @@ function generator(seed: number): () => number {
 function normal(next: () => number): number {
   const first = Math.max(next(), Number.EPSILON);
   return Math.sqrt(-2 * Math.log(first)) * Math.cos(2 * Math.PI * next());
+}
+
+function categorical(next: () => number, probabilities: readonly number[]): number {
+  const draw = next();
+  let cumulative = 0;
+  for (const [index, probability] of probabilities.entries()) {
+    cumulative += probability;
+    if (draw < cumulative) return index + 1;
+  }
+  return probabilities.length;
 }
 
 function metricRow(input: {
@@ -59,7 +71,7 @@ async function interval(input: {
   simulation: number;
   paired?: boolean;
 }): Promise<{ lower: number; upper: number; estimate: number; unitCount: number }> {
-  const implementation = createBuiltinAnalysisNodes().get(input.implementationId);
+  const implementation = ANALYSIS_NODES.get(input.implementationId);
   if (implementation === undefined) throw new Error('Missing bootstrap implementation.');
   const run = await implementation.openRun({
     runId: `simulation-${input.simulation}`,
@@ -173,7 +185,7 @@ describe('Evaluation Core deterministic statistical conformance', () => {
     expect(paired).toEqual({ lower: 1.5, upper: 3.5, estimate: 2.5, unitCount: 4 });
   });
 
-  it('keeps deterministic 90% mean-interval coverage within a broad calibration band', async () => {
+  it('pins the deterministic continuous 90% mean-interval coverage profile', async () => {
     let covered = 0;
     const simulations = 80;
     for (let simulation = 1; simulation <= simulations; simulation += 1) {
@@ -190,11 +202,10 @@ describe('Evaluation Core deterministic statistical conformance', () => {
       if (result.lower <= 0 && result.upper >= 0) covered += 1;
     }
 
-    expect(covered / simulations).toBeGreaterThanOrEqual(0.8);
-    expect(covered / simulations).toBeLessThanOrEqual(0.99);
+    expect({ covered, simulations }).toEqual({ covered: 69, simulations: 80 });
   });
 
-  it('keeps null paired effects from exceeding a broad type-I error bound', async () => {
+  it('pins the deterministic continuous null paired-effect profile', async () => {
     let falseDirections = 0;
     const simulations = 80;
     for (let simulation = 101; simulation < 101 + simulations; simulation += 1) {
@@ -227,6 +238,137 @@ describe('Evaluation Core deterministic statistical conformance', () => {
       if (result.lower > 0 || result.upper < 0) falseDirections += 1;
     }
 
-    expect(falseDirections / simulations).toBeLessThanOrEqual(0.2);
+    expect({ falseDirections, simulations }).toEqual({ falseDirections: 8, simulations: 80 });
+  });
+
+  it('pins discrete 1-5 frequency profiles at N=8 and N=20 without claiming nominal calibration', async () => {
+    const simulations = 60;
+    const profiles = [
+      {
+        distribution: 'balanced',
+        probabilities: [0.1, 0.2, 0.4, 0.2, 0.1],
+        seedNamespace: 800_000,
+      },
+      {
+        distribution: 'skewed',
+        probabilities: [0.5, 0.25, 0.15, 0.07, 0.03],
+        seedNamespace: 600_000,
+      },
+      {
+        distribution: 'ceiling',
+        probabilities: [0.02, 0.03, 0.1, 0.25, 0.6],
+        seedNamespace: 700_000,
+      },
+    ] as const;
+    const results: Array<{
+      distribution: string;
+      sampleSize: number;
+      meanCovered: number;
+      pairedFalseDirections: number;
+    }> = [];
+
+    for (const profile of profiles) {
+      const populationMean = profile.probabilities.reduce((sum, probability, index) => (
+        sum + probability * (index + 1)
+      ), 0);
+      for (const sampleSize of [8, 20]) {
+        let meanCovered = 0;
+        let pairedFalseDirections = 0;
+        for (let simulation = 1; simulation <= simulations; simulation += 1) {
+          const simulationId = profile.seedNamespace + sampleSize * 1_000 + simulation;
+          const next = generator(simulationId);
+          const scores = Array.from(
+            { length: sampleSize },
+            () => categorical(next, profile.probabilities),
+          );
+          const meanResult = await interval({
+            implementationId: 'bootstrap.mean-percentile/v1',
+            rows: scores.map((value, index) => metricRow({
+              sampleId: `sample-${index}`,
+              value,
+            })),
+            simulation: simulationId,
+          });
+          if (meanResult.lower <= populationMean && meanResult.upper >= populationMean) {
+            meanCovered += 1;
+          }
+
+          const pairedRows = Array.from({ length: sampleSize }, (_, index) => {
+            const pairingBlockId = digestCanonicalJson({
+              simulation: simulationId,
+              pair: index,
+            });
+            return [
+              metricRow({
+                sampleId: `sample-${index}`,
+                targetId: 'control',
+                value: categorical(next, profile.probabilities),
+                pairingBlockId,
+              }),
+              metricRow({
+                sampleId: `sample-${index}`,
+                targetId: 'treatment',
+                value: categorical(next, profile.probabilities),
+                pairingBlockId,
+              }),
+            ];
+          }).flat();
+          const pairedResult = await interval({
+            implementationId: 'bootstrap.paired-difference-percentile/v1',
+            rows: pairedRows,
+            simulation: simulationId,
+            paired: true,
+          });
+          if (pairedResult.lower > 0 || pairedResult.upper < 0) {
+            pairedFalseDirections += 1;
+          }
+        }
+        results.push({
+          distribution: profile.distribution,
+          sampleSize,
+          meanCovered,
+          pairedFalseDirections,
+        });
+      }
+    }
+
+    expect(results).toEqual([
+      {
+        distribution: 'balanced',
+        sampleSize: 8,
+        meanCovered: 48,
+        pairedFalseDirections: 7,
+      },
+      {
+        distribution: 'balanced',
+        sampleSize: 20,
+        meanCovered: 54,
+        pairedFalseDirections: 5,
+      },
+      {
+        distribution: 'skewed',
+        sampleSize: 8,
+        meanCovered: 52,
+        pairedFalseDirections: 6,
+      },
+      {
+        distribution: 'skewed',
+        sampleSize: 20,
+        meanCovered: 54,
+        pairedFalseDirections: 13,
+      },
+      {
+        distribution: 'ceiling',
+        sampleSize: 8,
+        meanCovered: 43,
+        pairedFalseDirections: 8,
+      },
+      {
+        distribution: 'ceiling',
+        sampleSize: 20,
+        meanCovered: 46,
+        pairedFalseDirections: 9,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## 用户影响

- Evaluation Core 的统计 conformance 不再只依赖连续正态数据和宽松 acceptance band。
- 新增离散 1–5 分值在均衡、偏斜、天花板聚集三种总体，以及 N=8／N=20 下的确定性频率 profile。
- 明确 percentile bootstrap 的 confidence level 是 nominal，而不是对任意有限总体的 coverage 保证。

## 迁移说明

- 不改变公开 API、Schema、持久化格式、estimator identity 或默认配置；无需用户迁移。

## 测量影响

- 不改变 v1 重采样单位、随机流、区间公式、舍入或 verdict。
- 现有连续模拟由宽松范围断言改为精确计数；新增网格固定 360 个离散数据集、720 次真实 Core interval 执行。
- 证据确认 v1 在小样本、有界、偏斜分布下会 coverage 不足；未来替换统计方法必须使用新的 estimator identity，不能静默改写历史口径。

## 验证与审查

- `yarn ci` 通过（309 个测试文件，3193 个测试）。
- Fresh-pass CR：首轮 1 个文档准确性问题已修复；远端首轮暴露的 Node 24 单测超时已通过削减模拟成本修复，未放宽 timeout。最终 No findings。

Refs #652
