### PR TITLE
fix(cli): 收口评测发布前的双语契约

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -147,6 +147,7 @@ export default defineConfig({
               { text: '用例设计科学性指南', link: '/zh/specs/sample-design-spec' },
               { text: '知识缺口信号规范', link: '/zh/specs/knowledge-gap-signal-spec' },
               { text: 'RAG metrics 规范', link: '/zh/specs/rag-metrics-spec' },
+              { text: '评分等价迁移 RFC', link: '/zh/specs/evaluation-scoring-equivalence' },
               { text: '术语规范', link: '/zh/specs/terminology-spec' },
               { text: '存储布局规范', link: '/zh/specs/storage-layout-spec' },
             ],

--- a/docs/reference/embedded-api.md
+++ b/docs/reference/embedded-api.md
@@ -160,12 +160,13 @@ const schemaUrl = resolveEvaluationCoreJsonSchema('execution-bundle.schema.json'
 ```
 
 Each published file uses its canonical raw catalog URL as `$id`, so JSON Schema tooling can
-resolve the document identity. The current Analysis Bundle and Evaluation Report are v2; the
-other nineteen roots remain v1. Their package paths are respectively
+resolve the document identity. The catalog contains 21 root contract names. Analysis Bundle,
+Comparability Assessment, Evaluation Report, and Series Analysis Bundle currently use v2; the
+other 17 current contracts use v1. Their package paths are respectively
 `oh-my-knowledge/eval-core/schemas/v2/<file>.schema.json` and
-`oh-my-knowledge/eval-core/schemas/v1/<file>.schema.json`. The frozen v1 Analysis Bundle and
-Evaluation Report remain in the source catalog for historical resolution, but the runtime does
-not read them. Node.js hosts should prefer the `eval-core` package subpath or
+`oh-my-knowledge/eval-core/schemas/v1/<file>.schema.json`. Frozen v1 snapshots of the four
+upgraded contracts remain in the source catalog for historical identity resolution, but the
+runtime does not read them. Node.js hosts should prefer the `eval-core` package subpath or
 `resolveEvaluationCoreJsonSchema()` to use the installed current contract.
 
 ## Results and errors

--- a/docs/zh/reference/embedded-api.md
+++ b/docs/zh/reference/embedded-api.md
@@ -159,7 +159,7 @@ import { resolveEvaluationCoreJsonSchema } from 'oh-my-knowledge/eval-core';
 const schemaUrl = resolveEvaluationCoreJsonSchema('execution-bundle.schema.json');
 ```
 
-每个已发布文件都以 canonical raw catalog URL 作为 `$id`，JSON Schema 工具可以解析其 document identity。当前 Analysis Bundle 与 Evaluation Report 已升为 v2，其余十九个根契约仍为 v1；对应 package 路径分别是 `oh-my-knowledge/eval-core/schemas/v2/<file>.schema.json` 与 `oh-my-knowledge/eval-core/schemas/v1/<file>.schema.json`。冻结的 v1 Analysis Bundle 与 Evaluation Report 仍保留在源码 catalog 中供历史 identity 解析，但 runtime 不再读取。Node.js 宿主仍应优先使用 `eval-core` package subpath 或 `resolveEvaluationCoreJsonSchema()`，以定位已安装 package 内的当前契约。
+每个已发布文件都以 canonical raw catalog URL 作为 `$id`，JSON Schema 工具可以解析其 document identity。Catalog 共包含 21 个根契约名称；当前 Analysis Bundle、Comparability Assessment、Evaluation Report 与 Series Analysis Bundle 使用 v2，其余 17 个当前契约使用 v1。对应 package 路径分别是 `oh-my-knowledge/eval-core/schemas/v2/<file>.schema.json` 与 `oh-my-knowledge/eval-core/schemas/v1/<file>.schema.json`。四个已升级契约的冻结 v1 快照仍保留在源码 catalog 中供历史 identity 解析，但 runtime 不再读取。Node.js 宿主仍应优先使用 `eval-core` package subpath 或 `resolveEvaluationCoreJsonSchema()`，以定位已安装 package 内的当前契约。
 
 ## 结果与错误
 

--- a/docs/zh/specs/eval-core-vnext.md
+++ b/docs/zh/specs/eval-core-vnext.md
@@ -1117,6 +1117,7 @@ comparability reason。
 ## 相关文档
 
 - [评分公式](scoring.md)；
+- [评分等价迁移 RFC](evaluation-scoring-equivalence.md)；
 - [统计严谨性](../explanation/statistical-rigor.md)；
 - [术语规范](terminology-spec.md)；
 - [RAG metrics 规范](rag-metrics-spec.md)。

--- a/docs/zh/specs/evaluation-runtime-adapter.md
+++ b/docs/zh/specs/evaluation-runtime-adapter.md
@@ -58,7 +58,39 @@ Factory 返回实际 port identity 和 version resolution。Assembly 校验 port
 
 Adapter 必须把 `sessionIsolationKey` 与 Core `runId`、`trialId` 组合使用；它不允许跨 run 或 binding 复用有状态 session。
 
-## 四、Same-process Runtime adapter
+## 四、Adapter preflight
+
+Preflight 是 Core 权威 prepare 完成后的宿主物理就绪阶段。它不属于 Evaluation Core，不创建宿主计划，也不能让被 Core 拒绝的 Runtime 获得资格。Factory 必须把显式 preflight declaration 数组与 port、实际 Runtime identity、version result 一并返回。空数组表示有意声明没有检查项；字段缺失则是非法 factory result。四项结果来自同一次 factory 调用，避免独立 check registry 解析出另一套实现或 binding。
+
+每条 declaration 都有稳定 ID，角色只能是 `doctor`、`credential`、`connectivity`、`filesystem`、`mcp-readiness` 或 `mock-readiness`，并且只能选择一种 disposition：
+
+- `check` 捕获 callback；其输入只有冻结、不含 secret 的 binding metadata，以及调用方可选的 `AbortSignal`；
+- `not-required` 携带稳定且不敏感的 reason code，不包含 callback。
+
+Executor binding 必须声明可执行 doctor check，以及 credential、connectivity disposition。需要资格认证的 Evaluator 必须声明 credential 与 connectivity disposition。任何带 resource requirement 的 binding 都必须声明 filesystem check；MCP 与 mock 角色还必须声明对应的物理就绪检查。系统会在第一次执行 callback 前验证所有 active binding 的覆盖情况，即使 doctor 或 connectivity 被配置为跳过也不例外。因此 skip 只能抑制一条已声明 callback，不能让不完整 adapter 变合法，也不能把真实的 `not-required` 伪装成 `skipped`。
+
+Runner 只消费已编译的 orchestration mode，不读取 CLI flag。Composition root 先调用 `EvaluationEngine.prepare()`；启用 Independent Series 时还会调用 `prepareEvaluationSeriesPlan()`。因此无论采用哪种 skip mode，single-run 与 Series 的 schema、reference、capability、identity 和 sealed-policy 检查都保持权威。之后按 `bindingId` 排序 active binding entry，保留每个 entry 已捕获的 declaration 顺序，并串行执行检查。任一失败都会阻止后续 effect，只公开稳定的 binding／check metadata；callback error 与其返回的 diagnostic 不会透传。Check 只返回 `void`，避免任意 diagnostic payload 形成未分类的证据通道。
+
+调用方传入的准确 signal 会被原样转交。取消发生后，active check 必须真正 settle，preflight 才会 reject；runner 不使用可能把 credential、network 或 filesystem 操作遗留在后台的 race。生成的不可变 record 保存在 `OmkPreparedEvaluation.preflight`。Definition、MeasurementPolicy、RuntimeBinding、不可变 binding entry 与 `SealedRunPlan` 均不改变，也不会传给 check。
+
+Preflight 只证明探测时刻的就绪状态，不能把 locator 变成 content identity，也不会为稍后的 run 预留资源。Run start 仍须依据实际字节或目录树获取并复核 verified resource lease。同理，如果没有 Judge binding，就绝不调用其 factory，因此不会发生 Judge declaration、credential read 或 connectivity probe。
+
+## 五、Event projection
+
+CLI progress 不是 `EventWriter`。EventWriter delivery 属于 sealed MeasurementPolicy：它可能施加阻塞 backpressure，配置要求的 writer 失败也可能让 run 失败。展示层不能获得这些权力。宿主会消费 Core 有界的 `EvaluationRun.events`，只把已经发布的 event 投影到独立展示路径。
+
+投影保留 `eventId`、`sequence`、`runId`、`eventKind`、时间与 subject，使输出仍可追溯到 Core event；它只从 `eventKind` 派生 source-neutral 的 stage 与 status。任意 event `data` 都有意排除，避免 provider error、evidence、coverage payload 或未来扩展内容进入未分类 UI 通道。Subject 与 run identity 继续使用 Core event contract 定义的 canonical 非敏感标识。
+
+接入 progress sink 时，宿主会立即消费 single-consumer Core stream，并分流到两个有界、非权威的路径：
+
+- 提供给调用方、同样采用 drop-oldest 行为的 raw-event mirror；
+- 拥有独立容量、与权威运行脱离的 renderer queue。
+
+缓慢或永不 settle 的 renderer 只能填满并覆盖自己的展示队列。调用方若从不消费 raw mirror，也只会丢失旧展示历史。Renderer reject、同步 exception、close failure、event-consumer failure 或 sink 已关闭，都不能改变 `EvaluationRunResult`、资源清理、取消、预算、重试、EventWriter policy 或终态 artifact。Run start 发生 effect 前会捕获 sink method identity，后续对象变更不能替换 active run 背后的 renderer。
+
+同进程 JavaScript 无法隔离一个故意以同步 CPU 工作阻塞 event loop 的 callback。因此 sink contract 要求 `render()` 迅速返回，并把昂贵渲染放到自己的异步边界后。宿主队列可以隔离 Promise 延迟与失败；CPU 隔离需要 worker 或独立进程，不属于本 adapter 边界。
+
+## 六、Same-process Runtime adapter
 
 `createSameProcessExecutorAdapter()` 与 `createSameProcessEvaluatorAdapter()` 是 binding-local 同进程实现的基准桥接层。宿主必须显式提供 `RuntimeIdentity` 和全部生命周期回调；adapter 不从 Definition 推断 capability，也不提供评分算法。
 
@@ -68,7 +100,7 @@ Core attempt 的 `AbortSignal`、trial seed、Target／Evaluator 配置、已验
 
 Composition root conformance 使用 `test.*` 命名空间下、根据输入和 binding 动态生成结果的实现。它们会经过真实 Core prepare 与 run 路径，但不会被导出或伪装成生产 Executor／Evaluator 算法。
 
-## 五、Custom-command Runtime adapter
+## 七、Custom-command Runtime adapter
 
 `createCustomCommandExecutorAdapter()` 是进程外 Runtime 的基准桥接层。它接受 sealed Target 与 RuntimeBinding、绝对 executable path、显式 argument vector，以及完整且逐项分类的 child environment。每个环境变量必须分类为公开 behavior identity、credential 或 effect locator；behavior identity 进入 Runtime facet，credential 与 locator 的值既不持久化，也不计算持久化 hash。Adapter 不启动 shell、不搜索 `PATH`、不继承 `process.env`／`process.cwd()`、不解析 command string，也不接受任意 live directory。它从准确的 sample-scoped Trial control 选择工作目录：需要 workspace 时使用已验证的 copy-on-write overlay，否则创建并最终删除 run 私有目录，从执行契约中排除宿主环境漂移、可变目录 locator 与 shell quoting 差异。
 
@@ -80,7 +112,37 @@ Adapter 把 Core attempt 的原始 `AbortSignal` 直接交给进程协调器；�
 
 Custom-command identity 采用保守模型。每个 assembly 周期都重新解析，不使用进程级缓存。若宿主明确提供本地实现文件，adapter 会对实际字节计算 hash，记录 canonical role／digest／size 证据，并在每次 spawn 前复核；由于 adapter 无法证明调用方列出的文件覆盖完整，assurance 仍为 `declared`。没有内容证据时，basis 是 `opaque`，assurance 是 `unknown`。Argument、executable path digest、分类后的 environment identity、sample-scoped 工作目录执行方式、输出限制、exchange version、进程组合与 identity coverage 都作为不泄露 secret 的 implementation facet 捕获。因此，command string 或 path 本身绝不可能产生 `verified` identity。Capability 是 factory 持有的固定 manifest，不根据 Target requirement 动态补齐，并且必须诚实声明本 adapter 的 best-effort cancellation 与 per-invocation stateless lifecycle。
 
-## 六、资源需求
+## 八、Codex CLI Runtime adapter
+
+`createCodexCliExecutorAdapter()` 是首个 provider-family Core adapter。它绑定一份已编译 Target 及其准确的 Executor binding；解析 identity 前，target ID、implementation ID、protocol、execution requirement、execution-control digest、behavior digest、model 与 effort 必须一致。它只支持 `omk.invoke/v1`。每次 Core attempt 都以 sealed model／effort、准确的 Trial workspace overlay 或 run 私有目录启动全新的 `codex exec --json` 进程，并发送 canonical `omk.codex-cli-prompt/v1` JSON envelope。Sample control 不一致时会在创建进程前失败；Codex 只能声明 runtime-default tool surface，因此任何 allow-list 都会在 adapter prepare 阶段失败。Envelope 只包含 knowledge artifact、sample input，以及 `ExecutorTrialContext` 暴露的 execution context；expected output、evaluation context、analysis membership 与 Gold 绝不进入 adapter。文件 artifact 成为一个显式 instruction 字段。目录 artifact 必须在根部提供 `SKILL.md`：只有该入口具有 instruction 语义，其余按 canonical path 排序的 UTF-8 文件会投影为 supporting resource，不会提升为 instruction。缺失入口、非 UTF-8 文件、symlink 与特殊文件均 fail closed。这保留了 Codex CLI 单 prompt 边界中 normative instruction 与 supporting asset 的语义差异，不宣称原生 filesystem-backed skill loading。
+
+进程控制遵循当前 [Codex CLI reference](https://developers.openai.com/codex/cli/reference) 与 [non-interactive execution guidance](https://developers.openai.com/codex/noninteractive)：临时 session、忽略用户配置、忽略项目／用户 execpolicy 规则、严格配置解析、非交互 approval、显式 sandbox、显式 working directory、JSONL 输出与关闭 stdin。Child 接收完整的分类环境，不继承 `process.env`；Codex 创建的 shell command 也不继承宿主环境。Adapter 不拥有 timeout、retry、budget 或 cache；它把 Core 的准确 `AbortSignal` 交给子进程协调器，并等待 SIGTERM／SIGKILL 真正 settle。
+
+每次 adapter assembly 都重新解析 Codex identity。Adapter 对实际 executable 与显式列出的 implementation file 计算 hash，使用捕获的准确 launcher 执行 `--version`，确认探测期间字节未变化，并在每次 attempt 前再次验证。Version probe 使用独立、有界、记录在 implementation facet 中的 assembly-safety timeout；它不是 measurement attempt timeout，不能取消或重试 provider 工作。证据来自内容，但 assurance 仍为 `declared`：wrapper 或调用方提供的文件列表无法证明覆盖全部 native helper、dynamic library、remote deployment 或服务端模型 revision。Model、effort、behavior digest、adapter composition、prompt projection、固定 control、limit、分类环境 identity 与 launcher identity 都保留为 implementation facet，即使它们没有进入 binary-content fingerprint。
+
+Capability manifest 有意比旧 CLI executor 更窄。它声明 prepend system instruction、可选 source-neutral trace／usage、copy-on-write workspace、runtime-default tool／skill discovery、best-effort cancellation，以及两个明确的 read-only／workspace-write sandbox ID。同一 binding 内的 trial 共享 run-scoped workspace overlay，因此执行被串行化；误报 parallel safety 会允许跨 trial 文件系统干扰。它不声明 deterministic seed control、MCP config、mock interception、tool allow-list、skill disable／allow-list、provider cost 或 session protocol。Target 要求任一不支持能力时，Core 会在 provider call 前拒绝。特别是 Codex 具有随机性，当前 CLI／[configuration surface](https://developers.openai.com/codex/config-reference) 不暴露准确 sampling seed；不能仅把 trial seed 写入 prompt，就声称实现了 controlled seed coupling。
+
+JSONL 边界严格验证 event／item family、lifecycle closure、terminal status、最终 assistant output 与安全 token count。Provider event 投影为既有 source-neutral turn／tool-call trace；raw event 与 stderr 不返回 Core。未上报 usage 与 provider cost 继续保持缺失。已报告 input／output token 原样保存，cached／reasoning token 保留为具名 detail；可信 terminal usage record 可以伴随被脱敏的 failure，但不能把 failure 变成 success。`createCodexCliCoreSchemaValidators()` 从计算 advertised schema identity 的同一组 input／output／trace contract 派生 validator，composition root 无需维护宽松或独立的 provider-schema registry。
+
+## 九、Claude CLI Runtime adapter
+
+`createClaudeCliExecutorAdapter()` 把一次 attempt 一个进程的 Claude Code Runtime 绑定到 `omk.invoke/v1`。在探测 executable 前，会捕获 Target、binding、model、受支持 effort、execution requirement、execution-control digest、behavior digest 与准确的聚合 resource requirement。每个 Trial 都会与 sealed sample control 核对，只得到自己的 workspace 与 built-in tool allow-list。每次 attempt 获得私有 `CLAUDE_CONFIG_DIR`、通过 stdin 输入的 canonical user envelope，以及由 verified artifact entrypoint 生成的可选原生 system-instruction file。目录 artifact 要求根部存在 `SKILL.md`；其它 UTF-8 文件继续在 user envelope 中显式标记为 supporting resource，绝不提升为 system instruction。Expected answer、evaluation context、analysis membership 与 Gold resource 不会跨过 Executor 边界。
+
+启动契约遵循当前 [Claude Code CLI reference](https://code.claude.com/docs/en/cli-usage)、[settings precedence](https://code.claude.com/docs/en/configuration) 与 [memory controls](https://code.claude.com/docs/en/memory)：stream JSON、verbose event、禁用 session persistence 与 Chrome integration、不读取普通 user／project／local setting source、使用严格且显式的 MCP config、禁用 CLAUDE.md／auto-memory、把 `@file` 当字面输入而非隐式展开、禁用持久后台任务、updater 与非必要流量。Prompt content 不放入 argv。这组更窄的控制保留显式 runtime-default skill／plugin；不会采用更宽的 `--bare`，因为它会静默违背已声明能力。Assembly 会拒绝低于审计基线的版本、prerelease build，以及 help surface 缺少任一必需 flag 的准确 launcher。Child 只接收完整分类环境与 adapter 自有 control，绝不继承 `process.env`。Child tool 可以检查环境，因此 credential entry 会把 output／trace 污染为 secret，effect locator 则污染为 sensitive。系统不声称能够抑制 host-managed setting、managed instruction 与 managed MCP policy。由于这些状态和 remote model deployment 仍不透明，即使 executable 与全部已声明 implementation file 都经过内容 hash 和 spawn 前复核，identity assurance 仍为 `declared`。
+
+Native MCP config、PreToolUse mock interception、built-in tool allow-list、runtime-default skill discovery 与完整 skill disablement，只在 CLI 可强制执行的组合中受支持。不支持的组合会在 adapter assembly 或 open run 时失败：存在 dynamic MCP tool 时，built-in allow-list 不能冒充完整 policy；MCP mock server 名称不能与 sealed MCP config 冲突；非空 skill allow-list 会被拒绝；系统不声明任何 sandbox ID。Mock rule 与 payload 只来自独立 secret verified lease。任何模型进程启动前都会验证规则；每次 retry attempt 都重新物化 payload，并在 child settle 后移除。配置的 Node launcher 本身属于 content identity；没有 mock interception 时，它不会被加入 PATH 或 Runtime identity。
+
+Capability 固定且由源码持有：串行 stochastic execution、best-effort cancellation、per-invocation stateless protocol、必需 source-neutral trace、可选 usage 与 provider-reported USD cost、不支持 seed control，也没有 sandbox。Adapter 只负责有界 stdin／stdout materialization、identity probe、process coordination 与 cleanup；timeout、retry、cache、budget 与 admission 只由 Core 持有。JSONL 必须包含一个结构一致的 terminal result；malformed conversation record、不一致 success flag、重复 terminal、不安全 counter、溢出 cost、terminal 后继续输出 conversation，以及 success 缺失 output，都会 fail closed，且不会暴露 stderr 或 provider error text。
+
+## 十、Claude SDK Runtime adapter
+
+`createClaudeSdkExecutorAdapter()` 把可选的 `@anthropic-ai/claude-agent-sdk` Runtime 绑定到同一 Core protocol，不经过旧 `ExecutorFn`。它遵循官方 [TypeScript Agent SDK contract](https://code.claude.com/docs/en/agent-sdk/typescript)：每个 Core attempt 创建全新 `query()`，获得独立 `AbortController` 与私有 `CLAUDE_CONFIG_DIR`，消费原生 async message stream，并在 attempt cleanup 前关闭 query。Core 继续独占 timeout／retry／budget／cache。Adapter 不使用旧进程级 SDK cache、SIGINT subscriber、wall-clock timeout、debug transcript 或补零 usage fallback。
+
+Assembly 解析 SDK package 及其 platform-specific bundled Claude Code package，不使用进程级 identity cache。SDK package tree、native package tree、manifest、entrypoint 与准确 executable 都会计算 content hash，并在每次 query 前复核；SDK version 与 bundled Claude Code version 是两个独立 identity facet。Remote deployment 与 host-managed policy 仍不透明，因此 assurance 为 `declared`。可信 resolver seam 只用于离线 conformance 与替代宿主解析，并且必须提供相同的最低 identity coverage。
+
+SDK 接收完整分类环境而非 `process.env`；没有 MCP lease 时接收显式空 MCP config；filesystem setting source、CLAUDE.md、auto-memory、attachment 与 session persistence 均关闭，同时启用严格 MCP validation、带 verified artifact append 的 Claude Code preset system instruction，以及与 CLI family 相同的 canonical supporting-resource envelope。Built-in tool allow-list 会禁用 dynamic MCP tool；skill discovery 只能是 runtime-default 或完全关闭。SDK PreToolUse mock 每次 attempt 都重新创建，并且只有 sealed MCP config 中存在对应 server 时才能拦截其 tool。Output 与 trace 继承 resource／environment 的最强 classification。Provider message 共用严格的 Claude terminal／usage／trace parser，但采用 SDK 专属 schema identity 与稳定 failure code。
+
+## 十一、资源需求
 
 RuntimeBindingRequest 只记录资源角色和预期 lease mode，不记录 locator 或内容：
 
@@ -99,7 +161,7 @@ Lease acquisition 在首个 effect 之前同步复制并冻结全部 descriptor 
 
 Composition root 在 Core 能调用任何 `openRun()` 前取得完整的 active-binding run lease。它验证 binding／resource 精确覆盖，捕获不可变 map 与 descriptor 快照，然后才注册 binding-scoped access。所有 Core port teardown settle 后先撤销注册，再执行一次 lease disposal。Acquisition、Core start 前取消、EventWriter 创建、Core start、正常完成与失败路径共享同一个幂等 cleanup promise。重复 active `runId` 会在第二次 acquisition 前被拒绝。用于 exploratory post-hoc comparison 的 Gold 不会被 single-run Core composition 提前物化；独立 analysis-host workflow 在存在真实消费者时再请求对应 lease。
 
-## 七、Core Composition 与 Support Ports
+## 十二、Core Composition 与 Support Ports
 
 `createOmkEvaluationRuntime()` 只消费一份完整的 `CliEvaluationCompileResult`；调用方不能在 `prepare()` 或 `start()` 传入替代 Definition／Policy。Composition root 会校验 compiled canonical digest、快照化全部宿主配置、合并 Core-owned Analysis schema validator 与 Runtime factory、装配 binding，并调用真实的 `createEvaluationEngine(...).prepare(...)`。独立 Series assembly 单独暴露，不进入 single-run engine。
 
@@ -115,7 +177,7 @@ Clock 与 SchemaValidator contract 在 factory assembly 前校验。Core-owned A
 
 EventWriter 不进入静态 `EvaluationEngineRuntime`。Optional／required delivery 会在 resource acquisition 后、Core start 前创建 writer，并通过 `PreparedEvaluation.start()` 注入；disabled mode 绝不调用 factory。Policy 要求的 port 缺失或形状错误时，在任何 Runtime factory 或 run port 调用前失败。因此不存在 Judge binding 时，也不会构造 Judge factory、读取凭证、执行 connectivity probe 或物化对应资源。
 
-## 八、错误归属
+## 十三、错误归属
 
 - malformed input、coverage、duplicate、Definition mismatch、missing factory、factory failure 和 invalid port 在 Run 开始前使用稳定 `OmkRuntimeAssemblyError` code；
 - compiled input、support port、cache source、schema conflict、writer construction、active run 与 host cleanup failure 使用稳定 `OmkEvaluationRuntimeError` code；
@@ -124,3 +186,11 @@ EventWriter 不进入静态 `EvaluationEngineRuntime`。Optional／required deli
 - provider、session、attempt、cancellation 和 dispose failure 在 Run 开始后属于 Runtime port。
 
 本层不修改冻结 prompt、五层评分、统计公式、cache 语义、Bundle／Report schema 或旧 pipeline。
+
+## 十四、故障隔离与依赖边界
+
+Composition root 把每个 `runId` 视为独立 failure domain。并发 run 拥有彼此独立的 lease registration、adapter session、raw-event mirror、progress queue、cancellation signal 与 teardown promise。取消一个进行中的 run，不能取消另一个 run、向对方的 event／progress channel 发布内容，或释放对方资源。Runtime port lifecycle 与宿主 lease 都只在各自 run settle 后准确释放一次。
+
+Fault-injection 覆盖 acquisition 前失败、acquisition 过程失败、EventWriter 构造失败、Core start／execution 失败、非权威 progress rendering 失败，以及 Runtime／lease disposal 失败。每条路径要么不产生 effect，要么汇入同一个幂等 cleanup promise；被拒绝的 callback、cancellation race 或 renderer promise 都不能让权威工作遗留在后台。
+
+源码依赖守卫同样保护 Evaluation Core。Core TypeScript 只能导入 `src/eval-core` 内其它文件、`zod` 或 `node:crypto`；不能导入 CLI、宿主 orchestration、filesystem API、provider SDK，也不能读取环境态 `process.env`／`process.cwd()`。这让架构边界成为 CI 可执行规则，而不只是一项约定。

--- a/docs/zh/specs/evaluation-scoring-equivalence.md
+++ b/docs/zh/specs/evaluation-scoring-equivalence.md
@@ -1,0 +1,207 @@
+# 评测评分等价 RFC
+
+> 状态：[#480](https://github.com/lizhiyao/oh-my-knowledge/issues/480) 的迁移契约已实现。下文的阶段性表述保留迁移依据；生产环境的 `omk eval` 现已执行这张 Core 评分图，并在原子化 `BREAKING-SCHEMA` 切换后仅持久化 Core 产物。
+
+## 1. 决策
+
+现有评分与发布语义将被重新表达为一条具有四个显式边界的 Evaluation Core 流水线：
+
+```text
+密封的样本评测上下文
+  -> 宿主 Evaluator：准则观测与原始评委读数
+  -> AnalysisGraph：重复测量、集成、层级、维度与综合派生
+  -> 统计 Analysis 节点：区间、一致性与校正
+  -> DecisionPolicy：发布结论
+```
+
+迁移通过固定执行输出和固定提供方响应进行离线验证。生产双跑、双写、回退选择和旧产物迁移不在范围内。
+
+旧流水线仅在 #480 实施期间作为有边界的等价性基准。生产切换现已完成，重复路径已经移除，当前代码不得重新引入旧 grader 作为实现层或兼容层。
+
+## 2. 构念模型
+
+历史术语「五层评分」描述的是五种身份，而不是五次连续求平均：
+
+| 身份 | 当前含义 | Core 角色 |
+|---|---|---|
+| assertion | 加权的通过／失败准则，随后归类为事实或行为 | Evaluator 观测及证据 |
+| llm | 一次评委调用产生的一个 1～5 原始读数 | 数值型 Evaluator 观测 |
+| judge | 成功重复测量的均值，再对成功的集成成员求均值 | 每测量单元的 Analysis 结果 |
+| dimension | 具名 rubric 结果；各维度求均值得到样本评委分 | 每测量单元的 Analysis 结果 |
+| composite | 现有事实、行为和评委分数的等权均值 | 每测量单元的 Analysis 结果 |
+
+`dimension` 当前不会作为第四个分数额外进入 `composite`。它是获得评委层分数的一条路径。如果迁移按 assertion → llm → judge → dimension → composite 依次求平均，就会测量不同的构念，因此必须拒绝。
+
+## 3. 密封输入与适用性
+
+旧评分准则随样本变化，而 Core Evaluator 定义覆盖整个运行计划。因此，编译器在每个样本的 `evaluationContext` 中物化评分投影，并为数据集生成稳定 Metric 定义的并集。
+
+Evaluator 家族覆盖整个运行计划，并且只声明自身需要的输入。对于某条已声明指标不适用的样本，Evaluator 发出原因是 `criterion-not-applicable` 的 `missing`；不得发出零，也不得伪造通过。在首次调用 Target 前，EvaluationPlan 身份必须覆盖样本评测上下文、prompt 哈希、Evaluator 配置和 Metric 并集。
+
+该设计规避三种无效方案：
+
+- 在运行时创建 Evaluator，从而绕过密封计划；
+- 把样本、重试或重复测量状态编码进 `evaluatorId` 命名约定；
+- 只包含旧最终分数的单个不透明 grader 观测。
+
+## 4. 运行时家族
+
+宿主负责提供方调用、prompt 注册表访问、自定义模块加载和内容解析。Evaluation Core 负责调度、重试、超时、预算、缓存、输入绑定、证据策略、取消和生命周期。
+
+| 运行时家族 | 输入绑定 | 观测 | 身份要求 |
+|---|---|---|---|
+| 确定性 assertion | 输出和评测上下文；感知执行的叶节点还需要 Core 拥有的执行事实 | 布尔准则结果；assertion 详情作为证据 | assertion 算法版本和受支持类型注册表 |
+| 自定义 assertion | 输出、评测上下文和已验证的资源租约 | 布尔准则结果或结构化 Evaluator 失败 | 模块内容身份和沙箱／资源策略 |
+| 语义相似度 | 输出、预期结果／评测上下文 | 布尔阈值结果；固定响应解析证据 | 语义 prompt 哈希、模型 Runtime 身份、阈值、取反规则 |
+| RAG 指标 | 输出和评测上下文 | 布尔阈值结果；固定响应解析证据 | 指标专属 prompt 哈希、模型 Runtime 身份、阈值、取反规则 |
+| rubric 评委 | 输出、可选 trace、评测上下文 | 1～5 标度上的原始数值读数 | rubric prompt 哈希、去偏变体、集成成员、重复测量索引、模型 Runtime 身份 |
+
+Core 永不导入 `PROMPT_REGISTRY`。组合根解析冻结的 prompt，并把它的哈希放进宿主 Runtime 身份。`lengthDebias=false` 仅选择现有的 rubric 关闭长度去偏工具；表达和语气中性仍然启用。RAG 和语义 prompt 没有长度去偏开关。
+
+语义和 RAG assertion 使用 `omk.llm-assertions/v2`。一个 Evaluator 坐标只拥有一条准则和一个布尔 Metric，因此一次提供方失败不能压制或伪造无关准则。规范化的 `applicableSampleIds` 在评测和分析前移除不适用坐标，而不把多条准则合并进共享的提供方调用。密封工具保留 assertion 类型、注册表 prompt ID 和冻结 prompt 哈希；下游聚合所需的阈值、正权重、显式取反规则和事实层身份也会保留。仅在有效原始分数完成阈值比较后执行取反；证据同时保留 `rawPassed` 和 `negated`，提供方失败、无效响应、超时、取消或预算截尾均不得成为已观测的通过。Runtime 指纹还绑定所选模型配置和宿主调用 Runtime 身份。宿主调用端口只执行一次支持协作取消的调用，自身没有重试、超时、预算或缓存策略。
+
+`[1, 5]` 内的严格整数读数和非空解释会生成已观测的布尔阈值结果。非 JSON、畸形 JSON、畸形分数、越界分数和缺失解释分别生成不同的无效观测。提供方失败生成带脱敏稳定代码的失败 Evaluation 记录。Core 超时和取消仍是尝试状态，准入失败仍是预算截尾。未知用量或提供方成本保持缺失。这是 [#481](https://github.com/lizhiyao/oh-my-knowledge/issues/481) 负责的有意 `BREAKING-COMPARABILITY` 修正；不提供兼容模式或旧读取器。
+
+Rubric 评委使用 `omk.rubric-judge/v1` 和同一个宿主拥有的单次调用提供方端口。每个测量坐标只发出一个数值型原始读数；重复测量和集成聚合仍属于 AnalysisGraph。工具把现有的启用或关闭去偏注册表身份，与显式的 `none` 或 `source-neutral` trace 策略一起密封。启用 trace 的评测只绑定 `omk.source-neutral-trace/v2`，其摘要塑形算法和 schema 进入 Runtime 指纹。有效响应是一个包含 `[1, 5]` 范围内整数分数和非空理由的 JSON 对象；推理过程是可选证据。协议失败使用与 LLM assertion 相同的不同无效状态，提供方失败仍为失败记录。Core 有意拒绝旧 rubric 解析器对畸形 JSON 的挽救、数字字符串和小数强制转换、越界读数、空理由及分数零失败哨兵。这项由 [#492](https://github.com/lizhiyao/oh-my-knowledge/issues/492) 负责的 `BREAKING-COMPARABILITY` 修正没有兼容模式，也不改变冻结的 rubric prompt 字节或哈希。
+
+确定性 assertion 被拆成两个独立标识的家族。仅输出家族只绑定输出和评测上下文。感知执行家族递归计算每棵 assertion 树的最小权限来源并集，然后只绑定所需的输出、Core 拥有的 `execution-facts`、来源中立 trace 和评测上下文。依赖签名不同的准则属于不同 Evaluator 组，因此 trace 不可用时不能压制只依赖事实的指标。
+
+成本只采用 `ExecutionFacts.usage.providerCost` 中完整的、由提供方报告的美元聚合值；未报告、不完整或混合币种成本是缺失观测，绝不是零。延迟采用 `ExecutionFacts.timing.wallClockDurationMs` 的试验墙钟时长。轮次 assertion 使用 `omk.source-neutral-trace/v2` 独立于提供方／运行时的 `numTurns` 字段，绝不使用对话记录宽度(`fullNumTurns`)、尝试次数或重试次数。工具 assertion 使用来源中立的 `toolCalls`；mock 命中 assertion 要求由已配置拦截边界捕获的来源中立 `mockStats`。缺失遥测保持缺失，而不会变成失败的质量 assertion。v2 切换是有意行为，并且没有 v1 兼容读取器：用不同的必需字段集合复用 v1 身份会让持久化证据产生歧义。
+
+每条 Core `json_schema` 准则都在隔离的验证器会话中编译。旧模块级全局 Ajv 注册表可能在原本独立的准则之间保留 `$id` 状态，使结果依赖进程历史；复现这种污染会违反运行和绑定隔离。这是 [#484](https://github.com/lizhiyao/oh-my-knowledge/issues/484) 负责的显式 `BREAKING-COMPARABILITY` 例外：后续 schema 复用较早的 `$id` 时，可能仅因编译状态泄漏而在旧进程中失败，而 Core 会独立评测两个 schema。正式切换直接接受 Core 结果；它不会模拟旧缓存、增加兼容标志，也不会在准则、记录、绑定或运行之间共享注册表。
+
+## 5. 身份与统计单元
+
+| 旧概念 | Core 身份 |
+|---|---|
+| 执行 `--repeat` | Target `trialIndex` 和 `trialId` |
+| `--judge-repeat` | Evaluator `replicateGroupId` 和 `replicateIndex` |
+| 集成中的评委模型 | `ensembleMemberId` 加解析后的 Runtime 身份 |
+| 提供方重试 | 同一个 `evaluationId` 内的 `attemptNumber` |
+| 样本 | `sampleId` 和抽样单元身份 |
+| 配对的对照／处理观测 | `pairingBlockId` |
+| 批处理子评测 | 独立 Run 身份 |
+
+重试永远不会创建新的测量重复。失败的评委重复测量保持失败，不会静默地由额外成功调用替代。聚合器只消费显式规划的重复测量坐标，并保留失败计数。
+
+## 6. AnalysisGraph
+
+每测量单元的派生使用版本化表信封。每一行绑定目标、样本、试验、指标或维度身份、输入观测 ID、数值或结构化缺失原因，以及准确的舍入阶段。下游节点把这些表作为 Analysis 结果消费；Evaluation 完成后不再创建新的 MetricObservation。
+
+规划节点如下：
+
+1. `judge-replicate-mean`：对成功的原始读数求均值和样本标准差；成功读数为零时结果缺失。
+2. `judge-ensemble-mean`：对成功的成员均值等权求平均；成员行和失败仍保留在输入血缘中。
+3. `dimension-mean`：对现有维度分数等权求平均，四舍五入到两位小数。
+4. `assertion-layer-score`：分别计算事实和行为的加权通过比例，以 `1 + ratio * 4` 映射，并四舍五入到两位小数。
+5. `composite-score`：对现有的事实、行为和评委行等权求平均，四舍五入到两位小数；不存在任何层时，只允许旧投影产生历史零哨兵，权威 Core 结果为不确定／缺失。
+
+前两个派生由宿主拥有的 Analysis 节点 `omk.judge-replicate-table/v2` 和 `omk.judge-ensemble-table/v2` 实现。重复测量表按完整的目标／样本／试验／指标／工具／集成成员／重复测量组坐标分组，按显式规划的重复测量索引排序而不要求索引连续，并保留每个已观测或未观测行。成员均值四舍五入到两位小数，样本标准差(`n - 1`) 四舍五入到三位小数。集成表消费经过 schema 验证的结果，赋予每个已观测成员均值相同权重，把共识值四舍五入到两位小数，并仅在已观测成员间计算两两平均绝对差，四舍五入到三位小数。已观测成员少于两个时，一致性缺失。两个输出 schema 都会在实时执行和传输 Bundle 验证期间强制执行规范顺序、覆盖守恒、内容派生的血缘身份和可重算统计量；其 Runtime 指纹绑定估计量、标度、缺失策略、舍入规则，以及由 Core 派生的配对／聚类／分层抽样单元身份。v2 身份替换切换前的 v1 契约，而不是改变其 schema 摘要；该修正由 [#497](https://github.com/lizhiyao/oh-my-knowledge/issues/497) 负责，不注册 v1，也不提供兼容读取器。
+
+第三个派生由 [#505](https://github.com/lizhiyao/oh-my-knowledge/issues/505) 引入的宿主 Analysis 节点 `omk.dimension-table/v1` 实现。密封参数在维度、Metric 与上游评委集成 Analysis 结果身份之间建立一一映射。每个目标／样本／试验行仅包含拥有已规划上游组的维度；不存在表示结构性不适用，而上游缺失组仍是显式缺失证据。节点对已观测且保留两位小数的集成共识分数等权求平均，再把结果四舍五入到两位小数；已观测维度为零时结果缺失而不是数值零。表验证器会重算覆盖和聚合值，并强制执行规范的单元／维度顺序、稳定绑定、全局唯一来源组血缘，以及内容派生的组身份。由于它消费 Analysis 结果而不是 Metric 行，记录级直接行覆盖为空，溯源跟随来源 Analysis／组身份。Runtime 指纹绑定这些语义及所有上游／参数／输出 schema 身份。生产 CLI 通过已注册的 Core AnalysisGraph 消费该节点。
+
+第四个派生由 [#496](https://github.com/lizhiyao/oh-my-knowledge/issues/496) 引入的宿主 Analysis 节点 `omk.assertion-layer-table/v1` 实现。其密封参数把每个唯一准则和布尔 Metric 显式映射到 `fact`、`behavior` 或 `excluded-mixed-layer`，并附带有限正权重；节点绝不从 assertion 名称、Evaluator ID 或证据推断分类。每个目标／样本／试验行保留完整准则状态和 Core 派生的抽样单元血缘。`criterion-not-applicable` 是结构性的，不计入 assertion 评分覆盖；Analysis Bundle v2 仍在 `planned` 中保留这个矩形坐标，将其放入独立的 `notApplicable` 桶，并通过 `notApplicableRows` 认证行身份和原因。因此它不会降低证据完整度；其它所有未观测状态仍会降低覆盖，但不会变成 `false` 或分数零。表验证器会重算加权分数和覆盖，并强制执行规范顺序、全局唯一来源血缘、内容派生的组身份，以及在所有测量单元间保持一致的准则设计。Runtime 指纹绑定这些语义和两个 schema 身份。生产 CLI 通过已注册的 Core AnalysisGraph 消费该节点。
+
+第五个派生由 [#512](https://github.com/lizhiyao/oh-my-knowledge/issues/512) 引入的宿主 Analysis 节点 `omk.composite-table/v1` 实现。密封参数把事实层和行为层绑定到 assertion-layer 结果，并把评委层绑定到集成共识或维度聚合；不会从图位置或标签推断来源。对于每个目标／样本／试验单元，节点对现有的已观测层等权求平均并四舍五入到两位小数。缺少来源组是结构性不适用，不会创建层条目；已有但缺失的组仍是显式证据；已观测层为零时，权威结果是缺失而不是数值零。验证器会重算聚合值和覆盖，并强制执行规范的单元／层顺序、稳定绑定、全局唯一来源结果／来源组血缘，以及内容派生的组身份。由于所有溯源均跟随上游 Analysis 组，直接 Metric 行覆盖为空。真实 Core DAG 一致性测试覆盖仅 assertion 和由维度支撑的仅评委计划，包括传输 Bundle 验证、父节点失败阻塞、取消和仅一次释放。生产 CLI 通过已注册的 Core AnalysisGraph 消费该节点。
+
+本次迁移有意打破旧约定：失败成员的分数零哨兵以前会污染一致性，却不参与共识。现在，失败、无效、不可用和未开始的坐标保持不同的缺失证据，绝不变成数值零。该修正由 [#494](https://github.com/lizhiyao/oh-my-knowledge/issues/494) 负责，没有兼容模式，也不会把 Evaluator 用量聚合到 Analysis 产物中。
+
+混合层 `assert-set` 准则仍是可见的 assertion 观测，但同时排除在事实层和行为层之外。总权重为零会生成缺失层。失败的 rubric 评委是缺失，不是分数零。
+
+旧 RAG 和语义路径会把提供方／解析失败转换成失败的布尔 assertion。该行为只作为历史差分证据冻结。Core 有意不复现它：无效读数和失败尝试排除在 assertion-layer 通过率之外，并降低覆盖。低于阈值的有效读数仍是已观测的 `false`，所以负向内容证据仍会被计入。
+
+旧异步路径现在仅对有效的语义、RAG 或自定义通过／失败读数应用公开的 `Assertion.not` 契约。提供方失败、畸形或不完整的评委输出、缺失 RAG 输入、自定义异常和无效自定义结果在取反后仍为失败。Core 把相同的布尔准则规则密封进 v2 Definition 和证据契约。这项由 [#489](https://github.com/lizhiyao/oh-my-knowledge/issues/489) 负责的独立 `BREAKING-COMPARABILITY` 修正，不会削弱 #481 的规则，即 Core 基础设施和协议失败仍是结构化缺失证据，而不是已观测的布尔 `false`。
+
+## 7. 统计标准
+
+当随机流或结论契约不同时，精确迁移标准与同名的通用 Core 内置项是不同标准。
+
+| 旧标准 | 可直接复用 Core 内置项？ | 原因 |
+|---|---|---|
+| 算术均值／比例 | 可以，不需要每测量单元派生表时 | 估计目标和缺失排除方式相同 |
+| 均值／独立／配对百分位 bootstrap | 精确黄金等价时不可以 | 旧实现使用整数种子 `20260616` 的 Mulberry32，并把端点四舍五入到四位小数；Core `bootstrap.* /v1` 对 SHA 派生的抽样做域分离 |
+| Bonferroni alpha/K | 精确旧等价时不可以 | 旧实现以 `alpha/K` 计算每个区间且没有 p 值表；Core `bonferroni/v1` 消费 p 值 |
+| Krippendorff alpha | 新的区间距离 Analysis 标准 | 现有公式不是 Core 内置项，未定义情形必须成为不确定 |
+| 发布结论 | 新的 OMK 发布 DecisionPolicy | Core `progress/v1` 是单效应三向策略，不是旧六级契约 |
+
+等价 bootstrap 标准重采样已声明的实验单元、保持配对、使用冻结随机流，并公开点估计、舍入后的边界、重采样次数、alpha，以及从舍入边界派生的显著性。它绝不能回退到非配对估计量。一个比较家族在区间估计前密封成员和有效 `alpha/K`；不会为了适配通用校正内置项而伪造 p 值。
+
+退化输入属于标准的一部分，而不是实现偶然。仅一个观测的旧均值区间是 `samples=0` 的点区间；仅一个完整配对的配对差仍执行请求数量的重采样，并返回恒定差值。空输入映射为权威 Core 的不确定结果，历史全零对象只允许出现在旧投影中。统计实现落地前，这些情形分别拥有黄金向量。
+
+精确均值／配对差／独立差标准和比较家族校正由 [#519](https://github.com/lizhiyao/oh-my-knowledge/issues/519) 引入的宿主 Analysis 节点 `omk.bootstrap-family-table/v1` 实现。它只消费 `omk.composite-table/v1`，密封目标和样本顺序、比较绑定、一个全家族配对或独立设计、重采样次数、名义 alpha 及固定 Mulberry32 随机流。重复试验先在已声明的样本或配对块内求平均；配对家族要求显式 `pairingKey`，绝不回退到独立抽样。输出保留每个已观测或缺失的 Composite 组，并在传输 Bundle 验证中重算目标区间、合格家族 `K`、有效 `alpha/K`、比较区间、覆盖、顺序和血缘。其 Runtime 指纹绑定旧随机流、线性百分位插值、四位小数舍入，以及基于舍入边界的显著性。生产 CLI 通过已注册的 Core AnalysisGraph 消费该节点。
+
+Krippendorff alpha 使用区间距离 `delta^2=(c-k)^2`；名义或顺序变体并不等价。空输入、总计只有一个评分对，或期望分歧为零时，结果是不确定而不是数值零。alpha bootstrap 重采样配对评分单元。
+
+该标准由 [#522](https://github.com/lizhiyao/oh-my-knowledge/issues/522) 引入的宿主 Analysis 节点 `omk.agreement-table/v1` 实现。它消费一个 schema 密封的 Dimension 表，以及仅存在于 Analysis 样本上下文中的 Gold 评分；Execution 和 Evaluation 的计划与 Bundle 永远不会接收该上下文。节点密封一个目标、标注者身份、标注版本、数值标度、JSON 指针、样本顺序、bootstrap 配置，以及区间距离 alpha 定义。重复的 Dimension 试验在每个样本内求平均，同时保留每样本组覆盖和血缘。输出以 Krippendorff alpha 为主统计量，以加权 kappa 和 Pearson 为辅助诊断，并报告有限抽样覆盖；样本对不足、期望分歧为零、统计量未定义或抽样无效时，输出结构化缺失结果。表会在传输 Bundle 验证期间按统计公式重算。生产 Gold 比较通过显式选择器消费这个经过认证的 Core 投影。
+
+## 8. DecisionPolicy 边界
+
+发布 DecisionPolicy 消费具名且绑定到计划的 Analysis 结果和显式证据门禁。它必须复现旧六种结论及理由优先级，而不读取旧 Report 对象。
+
+在给出方向性结论前，它检查覆盖、必需结果、假设、来源可信度和比较家族。随后，策略应用配对置信区间、层级门禁、样本量／功效状态、评委分歧、稳定性和留出集差距规则。展示字符串和 CLI 后续步骤文本位于策略之外；稳定理由代码才具有权威性。
+
+`SOLO`、`UNDERPOWERED`、`NOISE`、`PROGRESS`、`CAUTIOUS` 和 `REGRESSION` 是结论，而不是运行状态。基础设施失败仍产生失败或未决决策。
+
+该契约由宿主拥有的 `omk.release-decision/v3` 策略实现，它从 [#525](https://github.com/lizhiyao/oh-my-knowledge/issues/525) 引入的 v1 策略演化而来。参数显式绑定 Composite 表、Bootstrap Family 表、可选 Judge Ensemble 选择器、密封的目标和样本顺序、所有门禁阈值，以及可选且互斥的训练／留出分区。在应用六级优先级前，策略会验证估计量拥有的 `comparisonFamilyResultId`、精确的结果／schema 全集、Composite 到 Bootstrap 的观测血缘、比较绑定，以及已配置 Judge Ensemble 的覆盖。配置了跨评委一致性但无法测量的一次正向比较会成为 `CAUTIOUS`；没有 Judge Ensemble 的确定性设计不受影响。不显著的比较根据完整配对数或较小的独立组已观测样本数应用样本量门禁，绝不使用已编写但未观测的样本。缺失比较区间仍为未决；Core 路径绝不回退到点估计。跨运行稳定性属于 Series DecisionPolicy，不会从单个 Run 推断。历史 v1 和 v2 仍注册以支持精确重放。
+
+## 9. 字段映射与拒绝规则
+
+| 旧字段／事实 | Core 产物 | 拒绝规则 |
+|---|---|---|
+| `AssertionDetail.type/value/weight/passed/layer` | 布尔观测和分类证据 | 不受支持或畸形的类型在编译／准备期间失败 |
+| `llmScoreSamples` | 原始重复测量观测 | 不得从完成顺序推断样本顺序 |
+| `llmScoreFailures` | 失败重复测量覆盖 | 失败不能变成额外的零读数 |
+| `llmEnsemble` | 成员作用域观测和每成员 Analysis 行 | 成员身份／模型不匹配即不兼容 |
+| `dimensions[name]` | 具名指标和维度表行 | 空 rubric 或未声明维度会被拒绝 |
+| `layeredScores` | 事实／行为／评委 Analysis 行 | 混合 assertion 集不能归入单层 |
+| `compositeScore` | composite Analysis 行和覆盖 | 缺失层不能在未记录所含集合时被静默重加权 |
+| `bootstrapCI`／成对 CI | 区间 Analysis 记录 | 单元、种子标准、alpha 或配对错误即不兼容 |
+| `humanAgreement.alpha` | 一致性 Analysis 记录 | 非区间距离标准即不兼容 |
+| 结论及理由 | DecisionResult 理由代码 | 证据不完整时不能产生方向性结论 |
+| 成本值和已报告标志 | Usage 溯源 | 未报告成本保持缺失／未知，绝不是数值零 |
+
+不影响 Metric 或决策的宿主诊断仍属于后处理。任何会改变结论的诊断都必须成为密封的 Analysis 输入或 DecisionPolicy 参数。
+
+## 10. 一致性证据
+
+第一个基线是锚定到提交 `38648427` 的 `test/fixtures/eval-core/scoring-equivalence-v1.json`。它冻结：
+
+- 全部六个评分 prompt 哈希；
+- 确定性 assertion、嵌套同层和混合层 `assert-set` 行为、权重、层映射及舍入；
+- 固定响应的语义与 RAG 结果及用量；
+- 评委重复测量失败、样本标准差、集成成员证据及共识；
+- 旧随机流下的独立和配对 bootstrap 向量；
+- 区间 Krippendorff alpha、加权 kappa、Pearson 及 alpha bootstrap。
+
+后续迁移测试通过新 Core 路径消费相同 fixture，并比较观测、覆盖、证据、每测量单元表、区间结果、用量溯源和理由代码。精确身份和状态比较绝不使用数值容差。浮点容差只允许用于不比较产物相等性的公式性质测试。
+
+语义／RAG 一致性向量还冻结有意的失败语义变更：有效通过、有效阈值失败、有效取反、提供方失败、非 JSON、畸形 JSON、畸形分数、越界分数、缺失解释、超时、取消、预算截尾、未知用量／成本，以及增加基础设施失败不能降低已观测内容通过率这一不变量。旧自定义 assertion 向量覆盖有效通过／失败、取反、模块抛错与超时，以及无效结果对象。
+
+最终离线差分工具由 [#528](https://github.com/lizhiyao/oh-my-knowledge/issues/528) 交付，并在切换后随旧基准一起移除。它的不可变输入 fixture 仍位于 `test/fixtures/eval-core/scoring-equivalence-v1.json`。当前 Core 与生产边界覆盖位于 `test/eval-core/conformance/` 和 `test/eval-workflows/production-host/`。差分工具准备并执行了一份真实密封计划，覆盖两个 Target 和四个配对样本，然后通过公开引擎 facade 遍历 `Execution -> Evaluation -> Analysis -> Decision`。计划包含仅输出和感知执行的确定性 assertion、全部四种语义／RAG 工具、两个各含两次测量重复的 rubric 集成成员，以及 assertion-layer、replicate、ensemble、dimension、composite、Bootstrap-family、Agreement 和 release-decision 节点。旧投影独立地从相同输出、固定提供方读数、Gold 评分、阈值和种子生成。
+
+该工具精确比较准则读数、结构化失败状态、覆盖、用量和提供方成本溯源、prompt ID 和冻结哈希、样本／试验／成员／重复测量／配对身份、层与 composite 行、Bootstrap 来源血缘、Gold 血缘、一致性统计量、发布结论和稳定理由代码。运行时生成的 schema 验证器和产物摘要检查保持启用；测试不会通过调用纯函数构造最终表。生产 CLI、Report 读取器／写入器、Studio、resume、batch、evolve 和持久化路径都不参与该运行。
+
+### 10.1 历史类型化差异例外清单
+
+差分工具只接受下列由 issue 负责的差异。每项都是带有显式 `accepted` 或 `blocking` 状态的类型化值；任何未列出的不一致都会使精确比较失败。
+
+| 负责 issue | 状态 | 有意差异 |
+|---|---|---|
+| [#481](https://github.com/lizhiyao/oh-my-knowledge/issues/481) | accepted | 提供方或解析失败保持为失败／无效／缺失证据，而不是布尔内容失败。全链路失败探针会检查两个投影及下游覆盖。 |
+| [#484](https://github.com/lizhiyao/oh-my-knowledge/issues/484) | accepted | `json_schema` 验证器会话彼此隔离，而不是共享旧进程全局状态。 |
+| [#492](https://github.com/lizhiyao/oh-my-knowledge/issues/492) | accepted | 畸形、强制转换、越界、空理由和零哨兵 rubric 响应不是有效读数。 |
+| [#489](https://github.com/lizhiyao/oh-my-knowledge/issues/489) | accepted | 异步 assertion 取反已密封，并且只在有效原始通过／失败读数后应用；无效和基础设施失败不能变成成功。 |
+
+该清单不是兼容模式。`accepted` 条目描述权威 Core 语义，一致性工具不再有阻碍正式切换的差分例外。生产依赖方向仍是 Core 契约／运行时向内，宿主 adapter 向外：Evaluation Core 不会导入旧 Report、CLI、提供方 SDK、环境、文件系统或 prompt 注册表文本。提供方调用和 prompt 构造仍是注入的宿主端口；只有密封身份和已捕获产物跨越边界。
+
+## 11. 交付切片
+
+1. 基线 RFC 与不可变旧 fixture。
+2. 仅输出的确定性 assertion Evaluator，在 #483 后跟进感知执行的 assertion 和自定义 assertion Evaluator。
+3. 使用固定响应重放的语义、RAG 和 rubric Evaluator。
+4. 重复测量、集成、维度、assertion-layer 和 composite Analysis 节点。
+5. 精确 bootstrap 与一致性 Analysis 标准。
+6. 六级发布 DecisionPolicy。
+7. 完整离线新旧差分一致性验证和依赖审计。
+
+每个实现切片都运行一份已准备的 Core 计划和真实 Runtime 生命周期，包括取消和仅一次释放。测试实现使用 `test.*` 命名空间。后续切换阶段把生产 `omk eval`、Studio、resume、batch、evolve、Gold 比较和产物图连接到这些契约，并删除旧 Report 读取器与写入器。

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,44 @@
+# Published JSON Schemas
+
+This directory is the checked-in catalog of OMK's public JSON Schemas. The files are generated
+from the runtime contract definitions and are published inside the npm package; do not edit a
+schema file by hand.
+
+## Layout
+
+- `eval-core/v1/` and `eval-core/v2/` contain versioned Evaluation Core wire contracts.
+- `eval-samples/v1/` contains the Eval Sample Set contract used by JSON and YAML sample files.
+- A contract version is part of its public identity. A newer version does not replace or mutate
+  an older file; frozen versions remain available for historical identity resolution.
+
+The current Evaluation Core catalog has 21 root contract names. Analysis Bundle,
+Comparability Assessment, Evaluation Report, and Series Analysis Bundle use v2; the other 17
+current contracts use v1. The v1 snapshots of the four upgraded contracts are retained but are
+not selected by the current runtime.
+
+## Consumer access
+
+Node.js consumers should resolve current Evaluation Core schemas through the public package API
+instead of constructing paths:
+
+```ts
+import { resolveEvaluationCoreJsonSchema } from 'oh-my-knowledge/eval-core';
+
+const schemaUrl = resolveEvaluationCoreJsonSchema('evaluation-report.schema.json');
+```
+
+Direct version-pinned package paths are available when a tool intentionally targets a frozen
+contract:
+
+```text
+oh-my-knowledge/eval-core/schemas/v1/<file>.schema.json
+oh-my-knowledge/eval-core/schemas/v2/<file>.schema.json
+oh-my-knowledge/eval-samples/schemas/v1/eval-sample-set.schema.json
+```
+
+## Maintainer workflow
+
+Run `yarn build:schemas` after an intentional contract change and commit the generated diff.
+`yarn schemas:check` verifies that the catalog matches the source definitions and rejects stale,
+missing, or unexpected schema files. Review schema identity, migration, and measurement
+comparability before accepting any generated change.

--- a/src/cli/commands/eval/gold/compare.ts
+++ b/src/cli/commands/eval/gold/compare.ts
@@ -65,15 +65,19 @@ export default class EvalGoldCompare extends BaseCommand {
     await this.runWithCliExit(async () => {
       const runId = args.runId;
       if (!runId) {
-        console.error('Usage: omk eval gold compare <runId> --gold-dir <dir> --target <id> --evaluator <id> --metric <id>');
+        console.error(lang === 'zh'
+          ? '用法：omk eval gold compare <runId> --gold-dir <dir> --target <id> --evaluator <id> --metric <id>'
+          : 'Usage: omk eval gold compare <runId> --gold-dir <dir> --target <id> --evaluator <id> --metric <id>');
         throw new CliExit(1);
       }
       const goldDir = flags['gold-dir'];
       if (!goldDir) {
-        console.error('--gold-dir is required');
+        console.error(lang === 'zh' ? '必须提供 --gold-dir。' : '--gold-dir is required.');
         throw new CliExit(1);
       }
-      const { loadGoldDataset } = await import('../../../../eval-workflows/gold/dataset.js');
+      const { loadGoldDataset, validationIssueMessage } = await import(
+        '../../../../eval-workflows/gold/dataset.js'
+      );
       const {
         createNodeCoreContentStore,
         createNodeCoreRunArtifactStore,
@@ -85,11 +89,15 @@ export default class EvalGoldCompare extends BaseCommand {
 
       const { dataset, issues } = loadGoldDataset(goldDir);
       if (!dataset) {
-        console.error('Cannot load gold dataset:');
-        for (const i of issues) console.error(`  - ${i.message}`);
+        console.error(lang === 'zh' ? '无法加载 gold dataset：' : 'Cannot load gold dataset:');
+        for (const i of issues) console.error(`  - ${validationIssueMessage(i, lang)}`);
         throw new CliExit(1);
       }
-      for (const i of issues) console.error(`warn: ${i.message}`);
+      for (const i of issues) {
+        console.error(lang === 'zh'
+          ? `警告：${validationIssueMessage(i, lang)}`
+          : `Warning: ${validationIssueMessage(i, lang)}`);
+      }
 
       const storeOf = (directory: string) => createNodeCoreRunArtifactStore(directory, {
         contentResolver: createNodeCoreContentStore(resolve(directory, 'content')),

--- a/src/cli/commands/eval/gold/validate.ts
+++ b/src/cli/commands/eval/gold/validate.ts
@@ -29,18 +29,22 @@ export default class EvalGoldValidate extends BaseCommand {
     await this.runWithCliExit(async () => {
       const dir = args.dir;
       if (!dir) {
-        console.error('Usage: omk eval gold validate <dir>');
+        console.error(lang === 'zh'
+          ? '用法：omk eval gold validate <dir>'
+          : 'Usage: omk eval gold validate <dir>');
         throw new CliExit(1);
       }
       const { validateGoldDataset } = await import('../../../../eval-workflows/gold/cli.js');
-      const result = validateGoldDataset(dir);
+      const result = validateGoldDataset(dir, lang);
       if (result.ok) {
         console.log(lang === 'zh'
           ? `✓ gold dataset OK，共 ${result.sampleCount} 条标注`
           : `✓ gold dataset OK — ${result.sampleCount} annotations`);
         return;
       }
-      console.error(`✗ gold dataset has ${result.issues.length} issue(s):`);
+      console.error(lang === 'zh'
+        ? `✗ gold dataset 存在 ${result.issues.length} 个问题：`
+        : `✗ gold dataset has ${result.issues.length} issue(s):`);
       for (const msg of result.issues) console.error(`  - ${msg}`);
       throw new CliExit(1);
     });

--- a/src/eval-workflows/gold/cli.ts
+++ b/src/eval-workflows/gold/cli.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { dumpYaml, loadGoldDataset } from './dataset.js';
+import { dumpYaml, loadGoldDataset, validationIssueMessage } from './dataset.js';
 
 /** Creates an empty human-gold dataset without coupling it to a report schema. */
 export function initGoldDataset(targetDir: string, options: { annotator?: string } = {}): string[] {
@@ -47,7 +47,10 @@ export function initGoldDataset(targetDir: string, options: { annotator?: string
   return [metadataPath, annotationsPath, readmePath];
 }
 
-export function validateGoldDataset(dir: string): { ok: boolean; issues: string[]; sampleCount: number } {
+export function validateGoldDataset(
+  dir: string,
+  lang: 'zh' | 'en' = 'en',
+): { ok: boolean; issues: string[]; sampleCount: number } {
   const { dataset, issues } = loadGoldDataset(dir);
   return {
     ok: dataset !== null && issues.length === 0,
@@ -55,7 +58,7 @@ export function validateGoldDataset(dir: string): { ok: boolean; issues: string[
       const location = issue.path
         ? ` (${issue.path}${issue.index === undefined ? '' : `:${issue.index}`})`
         : '';
-      return `${issue.message}${location}`;
+      return `${validationIssueMessage(issue, lang)}${location}`;
     }),
     sampleCount: dataset?.annotations.length ?? 0,
   };

--- a/src/eval-workflows/gold/dataset.ts
+++ b/src/eval-workflows/gold/dataset.ts
@@ -58,7 +58,10 @@ export interface ValidationIssue {
   path: string;
   /** Annotation index within the file, when applicable. */
   index?: number;
+  /** Stable English diagnostic retained for programmatic callers and existing integrations. */
   message: string;
+  /** Chinese user-facing equivalent; CLI renderers select it when `--lang zh`. */
+  messageZh: string;
 }
 
 export interface LoadResult {
@@ -86,13 +89,18 @@ export function loadGoldDataset(dir: string): LoadResult {
     issues.push({
       path: absDir,
       message: `gold dataset directory not found or unreadable: ${(err as Error).message}`,
+      messageZh: `gold dataset 目录不存在或不可读：${(err as Error).message}`,
     });
     return { issues };
   }
 
   const yamlFiles = entries.filter((f) => f.endsWith('.yaml') || f.endsWith('.yml')).sort();
   if (yamlFiles.length === 0) {
-    issues.push({ path: absDir, message: 'no .yaml files found in gold dataset directory' });
+    issues.push({
+      path: absDir,
+      message: 'no .yaml files found in gold dataset directory',
+      messageZh: 'gold dataset 目录中没有 .yaml 文件',
+    });
     return { issues };
   }
 
@@ -108,11 +116,19 @@ export function loadGoldDataset(dir: string): LoadResult {
     try {
       parsed = parseYaml(readFileSync(fpath, 'utf-8'));
     } catch (err) {
-      issues.push({ path: fpath, message: (err as Error).message });
+      issues.push({
+        path: fpath,
+        message: (err as Error).message,
+        messageZh: `YAML 解析失败：${(err as Error).message}`,
+      });
       continue;
     }
     if (typeof parsed !== 'object' || parsed === null) {
-      issues.push({ path: fpath, message: 'top-level YAML must be an object' });
+      issues.push({
+        path: fpath,
+        message: 'top-level YAML must be an object',
+        messageZh: 'YAML 顶层必须是对象',
+      });
       continue;
     }
     const obj = parsed as Record<string, unknown>;
@@ -121,7 +137,11 @@ export function loadGoldDataset(dir: string): LoadResult {
       const metaIssue = validateMetadata(obj.metadata, fpath);
       if (metaIssue) issues.push(metaIssue);
       else if (metadata) {
-        issues.push({ path: fpath, message: 'metadata declared in multiple files; keep it in one place' });
+        issues.push({
+          path: fpath,
+          message: 'metadata declared in multiple files; keep it in one place',
+          messageZh: '多个文件重复声明了 metadata；请只保留一处',
+        });
       } else {
         metadata = obj.metadata as GoldMetadata;
       }
@@ -140,6 +160,7 @@ export function loadGoldDataset(dir: string): LoadResult {
             path: fpath,
             index: i,
             message: `duplicate sample_id "${anno.sample_id}" — each gold annotation must be unique`,
+            messageZh: `sample_id「${anno.sample_id}」重复；每条 gold 标注必须唯一`,
           });
           continue;
         }
@@ -150,10 +171,14 @@ export function loadGoldDataset(dir: string): LoadResult {
   }
 
   if (!metadata) {
-    issues.push({ path: absDir, message: 'no metadata block found in any file (need annotator/annotatedAt/version)' });
+    issues.push({
+      path: absDir,
+      message: 'no metadata block found in any file (need annotator/annotatedAt/version)',
+      messageZh: '所有文件中都没有 metadata；必须提供 annotator、annotatedAt 与 version',
+    });
   }
   if (annotations.length === 0) {
-    issues.push({ path: absDir, message: 'no annotations found' });
+    issues.push({ path: absDir, message: 'no annotations found', messageZh: '没有找到任何标注' });
   }
 
   if (!metadata || annotations.length === 0) {
@@ -168,18 +193,26 @@ export function loadGoldDataset(dir: string): LoadResult {
 
 function validateMetadata(raw: unknown, path: string): ValidationIssue | null {
   if (typeof raw !== 'object' || raw === null) {
-    return { path, message: 'metadata must be an object' };
+    return { path, message: 'metadata must be an object', messageZh: 'metadata 必须是对象' };
   }
   const m = raw as Record<string, unknown>;
   for (const k of ['annotator', 'annotatedAt', 'version']) {
     if (typeof m[k] !== 'string' || !m[k]) {
-      return { path, message: `metadata.${k} is required and must be a non-empty string` };
+      return {
+        path,
+        message: `metadata.${k} is required and must be a non-empty string`,
+        messageZh: `metadata.${k} 为必填项，且必须是非空字符串`,
+      };
     }
   }
   if (m.scale !== undefined) {
     const s = m.scale as Record<string, unknown>;
     if (typeof s !== 'object' || typeof s.min !== 'number' || typeof s.max !== 'number' || (s.max as number) <= (s.min as number)) {
-      return { path, message: 'metadata.scale must be { min: number, max: number } with max > min' };
+      return {
+        path,
+        message: 'metadata.scale must be { min: number, max: number } with max > min',
+        messageZh: 'metadata.scale 必须是 { min: number, max: number }，且 max 必须大于 min',
+      };
     }
   }
   return null;
@@ -187,14 +220,29 @@ function validateMetadata(raw: unknown, path: string): ValidationIssue | null {
 
 function validateAnnotation(raw: unknown, path: string, index: number): ValidationIssue | null {
   if (typeof raw !== 'object' || raw === null) {
-    return { path, index, message: 'annotation must be an object' };
+    return {
+      path,
+      index,
+      message: 'annotation must be an object',
+      messageZh: 'annotation 必须是对象',
+    };
   }
   const a = raw as Record<string, unknown>;
   if (typeof a.sample_id !== 'string' || !a.sample_id) {
-    return { path, index, message: 'sample_id is required and must be a non-empty string' };
+    return {
+      path,
+      index,
+      message: 'sample_id is required and must be a non-empty string',
+      messageZh: 'sample_id 为必填项，且必须是非空字符串',
+    };
   }
   if (typeof a.score !== 'number' || !Number.isFinite(a.score)) {
-    return { path, index, message: 'score is required and must be a finite number' };
+    return {
+      path,
+      index,
+      message: 'score is required and must be a finite number',
+      messageZh: 'score 为必填项，且必须是有限数值',
+    };
   }
   return null;
 }
@@ -202,4 +250,11 @@ function validateAnnotation(raw: unknown, path: string, index: number): Validati
 /** Re-export YAML serializer so the `gold init` CLI can write a template. */
 export function dumpYaml(value: unknown): string {
   return yaml.dump(value, { lineWidth: 100, noRefs: true });
+}
+
+export function validationIssueMessage(
+  issue: ValidationIssue,
+  lang: 'zh' | 'en',
+): string {
+  return lang === 'zh' ? issue.messageZh : issue.message;
 }

--- a/test/cli/oclif-eval.test.ts
+++ b/test/cli/oclif-eval.test.ts
@@ -102,6 +102,45 @@ describe('oclif eval', () => {
     }
   });
 
+  it('eval gold validate 的失败摘要遵循 --lang', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-oclif-gold-invalid-'));
+    try {
+      for (const [lang, expected] of [
+        ['zh', 'gold dataset 目录中没有 .yaml 文件'],
+        ['en', 'no .yaml files found in gold dataset directory'],
+      ] as const) {
+        await assert.rejects(
+          () => runCommand(EvalGoldValidate, [dir, '--lang', lang]),
+          (err: unknown) => {
+            const e = err as ExecError;
+            assert.equal(e.code, 1, `expected exit 1, got ${e.code}`);
+            assert.ok(e.stderr.includes(expected), e.stderr);
+            return true;
+          },
+        );
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('eval gold compare 的必填参数错误遵循 --lang', async () => {
+    for (const [lang, expected] of [
+      ['zh', '必须提供 --gold-dir。'],
+      ['en', '--gold-dir is required.'],
+    ] as const) {
+      await assert.rejects(
+        () => runCommand(EvalGoldCompare, ['report-1', '--lang', lang]),
+        (err: unknown) => {
+          const e = err as ExecError;
+          assert.equal(e.code, 1, `expected exit 1, got ${e.code}`);
+          assert.ok(e.stderr.includes(expected), e.stderr);
+          return true;
+        },
+      );
+    }
+  });
+
   it('eval 非法 --repeat --lang en → exit 2 + English parser error', async () => {
     try {
       await execFileAsync('node', [CLI, 'eval', '--repeat', 'abc', '--lang', 'en']);


### PR DESCRIPTION
## 用户影响

- `omk eval gold validate` 与 `compare` 的默认中文错误现在包含完整、可操作的中文明细；`--lang en` 继续输出英文。
- 中文 Runtime Adapter 规范补齐 preflight、事件隔离、Codex／Claude adapter 与故障隔离边界，不再遗漏英文版的关键约束。
- 新增完整的中文《评分等价迁移 RFC》及导航入口，保留构念、缺失语义、统计身份、决策边界和一致性证据。
- Embedded API 与新的 Schema catalog README 准确说明 21 个根契约、4 个当前 v2 与 17 个当前 v1。

## 迁移

无需迁移。Gold 领域仍保留稳定英文 `message`；程序化 `validateGoldDataset()` 的默认语言仍为英文，CLI 显式传入用户语言。

## 测量影响

不修改评分、统计公式、prompt、Schema 文件、持久化数据或 verdict 语义。改动只收口用户可见诊断与既有契约文档。

## 验证与审查

最终 `yarn ci` 在允许本地端口监听的隔离 worktree 中通过：309 个测试文件、3197 个测试。新增文档后，中文镜像链接门禁、CLI 文档引用门禁、`yarn lint` 与完整 VitePress 构建再次通过。自主 CR：No findings；已复核 i18n fallback、公开调用方、Schema catalog 计数、文档语义与导航，以及工作树隔离。

Refs #652