### PR TITLE
fix(eval-workflows)!: BREAKING-AUTHORING 纠正重复评测指引

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -104,7 +104,7 @@ omk eval [flags]
 - `--no-serve` `boolean`:不启 report server
 - `--no-strict-baseline` `boolean`:关闭 baseline 隔离
 - `--output-dir` `option`:报告输出目录（默认项目级 .omk/eval）
-- `--repeat` `option`:每个用例重复运行 N 次
+- `--repeat` `option`:预先固定 Evaluation Series 的独立 run 数
 - `--report-only` `boolean`:生成报告并打印判定，但始终 exit 0(不参与 CI gate）。
 - `--resume` `option`:复用经过完整契约校验的 Core runId；拒绝时失败关闭
 - `--retry` `option`:单用例失败重试次数

--- a/docs/explanation/statistical-rigor.md
+++ b/docs/explanation/statistical-rigor.md
@@ -7,7 +7,7 @@ description: Why Evaluation Core decisions are auditable: preregistered Bootstra
 
 omk evaluates a knowledge change by fixing the model and sample design, changing the artifact, and carrying the resulting evidence through a sealed Evaluation Core plan. A higher display score is not release authority. The registered Core Decision must be able to trace its conclusion back to complete, comparable observations and preregistered analysis.
 
-Four safeguards cover different failure modes.
+Five safeguards cover different failure modes.
 
 ## 1. Bootstrap comparison families
 
@@ -59,6 +59,12 @@ Missing evidence is not a zero score and is not silently dropped from the decisi
 - The release Decision requires complete evidence and exact source binding before issuing a directional conclusion.
 
 This prevents a run from looking better merely because difficult coordinates failed to produce a score.
+
+## 5. Repeated runs require a fixed stopping rule
+
+`--repeat N` seals `N` independent Runs into one Evaluation Series before execution. It is test-retest evidence, not a retry-until-success switch. Choose the repeat count and stopping rule before inspecting results, then report the complete Series. Do not rerun after a disappointing verdict and publish only the first favorable run: unadjusted, result-dependent repetition is optional stopping and invalidates the advertised false-positive control.
+
+`--retry` has a different purpose: it retries an operationally failed sample attempt under the sealed retry policy. Neither option authorizes selective deletion, replacement, or reporting of completed observations. If an adaptive stopping design is required, analyze it with a sequential method that explicitly controls error rates; the current fixed-design release Decision does not provide that guarantee. See García-Pérez, [Statistical Conclusion Validity: Some Common Threats and Simple Remedies](https://pmc.ncbi.nlm.nih.gov/articles/PMC3429930/).
 
 ## Release Decision
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -256,7 +256,7 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
   --no-serve                      Do not start report server
   --no-strict-baseline            Disable baseline isolation
   --output-dir <value>            Report output dir (default project .omk/eval)
-  --repeat <value>                Repeat each sample N times
+  --repeat <value>                Predeclare the independent run count for the Evaluation Series
   --report-only                   Produce the report and print verdict, but always exit 0 (no CI gate).
   --resume <value>                Reuse a fully verified Core runId; fail closed when rejected
   --retry <value>                 Per-sample retry count
@@ -276,6 +276,8 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
 For full descriptions: `omk eval --help`.
 
 <!-- omk:cli:eval:flags:end -->
+
+`--repeat` creates one preregistered Evaluation Series with a fixed number of independent Runs. Set the count before looking at results and report every member Run. It is not safe to keep launching new Runs after an unfavorable verdict and stop at the first favorable one; that is unadjusted optional stopping. `--retry` is separate and applies only to operationally failed sample attempts under the sealed retry policy.
 
 Studio opens the validated Core run rather than a second report model. The run detail projects operational, evidence, and conclusion status separately; shows numeric observations, Analysis results, Decision reason codes, cost, coverage, and provenance; and links every view back to immutable Core artifacts. Diagnostic post-processing is limited to authenticated Core failures, missing evidence, exclusions, and stable reason codes. For the sandbox-mock semantics behind `mocks` / `environment` / `tripwire` / `mocksStrict`, see [sample-design-spec.md §三](../specs/sample-design-spec.md).
 

--- a/docs/zh/explanation/statistical-rigor.md
+++ b/docs/zh/explanation/statistical-rigor.md
@@ -7,7 +7,7 @@ description: Evaluation Core 的结论为何可审计：预注册 Bootstrap fami
 
 omk 评估一次知识改动时，会固定模型和用例设计，只改变 artifact，并让证据沿 sealed Evaluation Core plan 流动。更高的展示分数不是发布授权；已注册的 Core Decision 必须能把结论追溯到完整、可比的观测与预注册分析。
 
-四道防线分别覆盖不同的失败模式。
+五道防线分别覆盖不同的失败模式。
 
 ## 一、Bootstrap comparison family
 
@@ -59,6 +59,12 @@ Prompt 指令只能降低已知偏差风险，不能证明评委无偏；Gold ca
 - release Decision 必须先确认 evidence 完整且 source binding 精确，才能给出方向性结论。
 
 这能防止困难 coordinate 因为没产出分数，反而让 run 看起来更好。
+
+## 五、重复运行必须先固定停止规则
+
+`--repeat N` 会在执行前把 `N` 个独立 Run 封存进同一个 Evaluation Series。它是 test-retest 证据，不是「重试到成功」开关。应当在查看结果前确定 repeat 数与停止规则，然后完整报告这个 Series。不要在 verdict 不理想后反复重跑，再只发布第一次有利结果：这种未校正、由结果决定的重复属于 optional stopping，会使宣称的假阳性控制失效。
+
+`--retry` 的用途不同：它只在已封存的 retry policy 下重试运行失败的 sample attempt。两个选项都不允许选择性删除、替换或报告已完成的观测。如果确实需要自适应停止设计，必须使用显式控制错误率的 sequential method；当前的固定设计 release Decision 不提供这种保证。参见 García-Pérez：[Statistical Conclusion Validity: Some Common Threats and Simple Remedies](https://pmc.ncbi.nlm.nih.gov/articles/PMC3429930/)。
 
 ## Release Decision
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -256,7 +256,7 @@ omk eval gold compare <run-id> --gold-dir gold-dataset
   --no-serve                      不启 report server
   --no-strict-baseline            关闭 baseline 隔离
   --output-dir <value>            报告输出目录（默认项目级 .omk/eval）
-  --repeat <value>                每个用例重复运行 N 次
+  --repeat <value>                预先固定 Evaluation Series 的独立 run 数
   --report-only                   生成报告并打印判定，但始终 exit 0(不参与 CI gate）。
   --resume <value>                复用经过完整契约校验的 Core runId；拒绝时失败关闭
   --retry <value>                 单用例失败重试次数
@@ -276,6 +276,8 @@ omk eval gold compare <run-id> --gold-dir gold-dataset
 完整描述见 `omk eval --help`。
 
 <!-- omk:cli:eval:flags:end -->
+
+`--repeat` 会创建一个预注册的 Evaluation Series，其独立 Run 数在执行前固定。应当在查看结果前确定数量，并报告所有 member Run。不能在 verdict 不理想后持续新建 Run，再遇到第一次有利结果时停止；这属于未校正的 optional stopping。`--retry` 另行计算，只在已封存的 retry policy 下处理运行失败的 sample attempt。
 
 Studio 打开的是经过校验的 Core run，而不是第二套报告模型。Run detail 会分别投影运行、证据与结论状态，展示数值观测、Analysis result、Decision reason code、成本、coverage 与 provenance，并把每个视图追溯到不可变 Core 产物。Diagnostic 后处理只使用经过认证的 Core 失败、缺失证据、排除项与稳定 reason code。沙箱 mock 字段语义（`mocks` / `environment` / `tripwire` / `mocksStrict`）见 [sample-design-spec.md §三](../specs/sample-design-spec.md)。
 

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -387,7 +387,10 @@ export default class Eval extends BaseCommand {
     }),
     // ── eval-runner extra ──
     repeat: Flags.string({
-      description: bilingual({ zh: '每个用例重复运行 N 次', en: 'Repeat each sample N times' }),
+      description: bilingual({
+        zh: '预先固定 Evaluation Series 的独立 run 数',
+        en: 'Predeclare the independent run count for the Evaluation Series',
+      }),
       parse: integerStringParser('--repeat', { min: 1 }),
     }),
     'holdout-ratio': Flags.string({

--- a/src/eval-workflows/messages.ts
+++ b/src/eval-workflows/messages.ts
@@ -1,10 +1,6 @@
 import type { Lang } from '../shared/language.js';
 
-export type EvalWorkflowMessageCode =
-  | 'power_warning_tiny_n'
-  | 'power_warning_small_n'
-  | 'power_warning_repeat_one'
-  | 'doctor_gate_blocked';
+export type EvalWorkflowMessageCode = 'doctor_gate_blocked';
 
 interface MessageEntry {
   zh: string;
@@ -12,18 +8,6 @@ interface MessageEntry {
 }
 
 const MESSAGES: Record<EvalWorkflowMessageCode, MessageEntry> = {
-  power_warning_tiny_n: {
-    zh: '⚠ N={n} < 5：仅适合探索，任何结论都不可靠，CI 会很宽。需要决策时建议 ≥20 条评测用例。',
-    en: '⚠ N={n} < 5 (exploration-only): any conclusion is unreliable, CI will be uselessly wide. Decisions need ≥20 cases.',
-  },
-  power_warning_small_n: {
-    zh: '⚠ N={n} < 20：只能识别很大的效果（Cohen\'s d > 0.8），中等效果（d ≈ 0.5）很难检出。要做可靠决策建议 ≥20 条评测用例。',
-    en: '⚠ N={n} < 20 (large-effect-only, Cohen\'s d > 0.8): medium effects (d ≈ 0.5) hard to detect. For confident decisions consider ≥20 cases.',
-  },
-  power_warning_repeat_one: {
-    zh: '⚠ --repeat=1：单轮评测无法测稳定性（CV 会标记为未测量）。用 --repeat 3+ 检测同一 variant 内部方差。',
-    en: '⚠ --repeat=1: single-run cannot measure stability (CV will be marked "not measured"). Use --repeat 3+ to detect within-variant variance.',
-  },
   doctor_gate_blocked: {
     zh: '发布前 doctor 门禁未通过，评测已中止。\n下一步：先修复上面的阻塞项，再重跑 `omk eval`。\n原因：这段输入还不值得测，继续比较分数会是 garbage-in。\n如果依赖确实由 mock / stub 提供、doctor 误报，可用 `--skip-doctor` 绕过，但这次结果由你承担不可比风险。',
     en: 'pre-ship doctor gate failed; evaluation aborted.\nNext: fix the blocking findings above, then re-run `omk eval`.\nWhy: this input is not measurable enough yet, and comparing scores now would be garbage-in.\nIf deps are truly supplied by mocks/stubs and doctor is a false positive, use `--skip-doctor`, but you own the comparability risk.',

--- a/src/knowledge-artifacts/authoring/generator.ts
+++ b/src/knowledge-artifacts/authoring/generator.ts
@@ -111,11 +111,6 @@ const SYSTEM_PROMPT = `你是一个评测用例生成器。你的任务是根据
     - tools_not_called 反模式断言 0-1 条(禁止接触某禁忌工具,如 tripwire sample)
     - rubric 3-5 个判分维度(细致写明 judge 该看什么),由 sample.rubric 字段承载
 
-  *测量学背景:* 当前 omk verdict 三层独立 threshold(默认 ${DEFAULT_GATE_THRESHOLD}),fact 条目少之后单条
-  权重大、单次评测方差大,**强烈建议** 评测时带 \`--repeat 2\` 或更大测稳定性(coefficient
-  of variation),并参考 bootstrap CI 而非点估计。这是 fact 层稀疏化的代价,换来的是
-  fact 信号干净(不被 trajectory 字面噪音污染)。
-
   各 fact 类型详解(下面这些都属于"结果"或"里程碑"范畴,不是"过程"):
 
   工具/流程类(强信号,首选):
@@ -355,10 +350,6 @@ const SYSTEM_PROMPT = `你是一个评测用例生成器。你的任务是根据
    的细节,把那些细节写进 sample.rubric 让 judge 按维度评分 — judge 信号本来就比"某
    汉字是否出现在 trace"更接近"任务做没做对"。
 
-   *跟测量学的关联:* fact 条目稀疏化后单条权重相对大、单次评测方差变大,跑评测时
-   建议带 \`--repeat 2\`(或更大)测同 variant 内部 coefficient of variation,看 bootstrap
-   CI 下限而非点估计。这是 fact 干净换稳定性的等价交换,omk eval CLI 在 N<20 且
-   --repeat=1 时已有 stderr 警告提醒。
 7. 如果 skill 涉及外部调用(MCP/CLI/HTTP/文件读),**必须**为本 sample 生成 mocks 数组,
    保证评测时 0 真调底层。query 类返回贴近真实 schema 的示例数据,write 类返回 success。
 

--- a/test/knowledge-artifacts/authoring/generator.test.ts
+++ b/test/knowledge-artifacts/authoring/generator.test.ts
@@ -67,6 +67,7 @@ describe('generateSamples', () => {
     });
 
     assert.match(capturedSystem, /目标执行器能力约束（最高优先级）/);
+    assert.doesNotMatch(capturedSystem, /--repeat|coefficient of variation|stderr 警告/);
     assert.match(capturedPrompt, /不要生成 mocks 和 mocksStrict/);
     assert.equal(result.samples[0].mocks, undefined);
     assert.equal(result.samples[0].mocksStrict, undefined);


### PR DESCRIPTION
## 用户影响

- `--repeat` 现在明确表示执行前预先固定的 Evaluation Series 独立 Run 数，与运行失败时的 `--retry` 分开。
- 删除从未生效、且固化过时样本量口径的 `power_warning_*`；sample 生成器不再宣称 CLI 会提供实际不存在的 stderr 告警。
- 中英文统计严谨性文档补充了预注册 repeat、完整报告 Series 与 optional stopping 边界。

## 迁移说明

`BREAKING-AUTHORING`：sample generator 的非评分类 prompt 删除了实验运行策略，后续重新生成的 sample 可能与旧输出不同。既有 sample、评分 prompt、统计公式、Schema、verdict 和持久化契约均未改变。

## 测量学边界

本 PR 只纠正引导与死代码，不将事后重跑包装成可靠性保障。当前 release Decision 仍是固定设计；需要自适应停止时，必须另行使用显式控制错误率的 sequential method。

自主 CR：No findings。

Refs #652