### PR TITLE
fix(studio): 提示旧版评测布局

### DIFF
--- a/docs/guides/eval-core-cutover.md
+++ b/docs/guides/eval-core-cutover.md
@@ -17,6 +17,6 @@ Operational changes:
 - independent `--repeat` runs publish run-level variance as Series analysis; without a preregistered Series decision, the release gate fails closed and member runs are not admitted as managed evidence;
 - `--dry-run` assembles Runtime and prepares a sealed plan without opening a Target or Evaluator.
 
-Migration is deliberately operational, not programmatic: archive or remove old flat report files if desired, then run the evaluation again. OMK does not infer a Core Run Plan, lineage, digests, or decision evidence from a legacy report. Historical score curves are likewise not reconstructed from legacy files.
+Migration is deliberately operational, not programmatic: archive or remove old flat report files if desired, then run the evaluation again. When Studio starts, it checks the active Core roots and the former sibling `reports/` roots for top-level JSON files. If it finds any, it prints their directories and counts before starting the server; it never parses, moves, deletes, or converts those files. OMK does not infer a Core Run Plan, lineage, digests, or decision evidence from a legacy report. Historical score curves are likewise not reconstructed from legacy files.
 
 This cutover changes the storage and application schema, not the measurement construct. Frozen evaluator prompts, the five scoring layers, Bootstrap confidence intervals, Krippendorff alpha, and length-debias semantics are unchanged.

--- a/docs/zh/guides/eval-core-cutover.md
+++ b/docs/zh/guides/eval-core-cutover.md
@@ -17,6 +17,6 @@
 - 独立 `--repeat` run 只把 run-level variance 发布为 Series analysis；没有预注册的 Series 总体决定时，release gate 会失败关闭，单次 member 也不会写入受管证据；
 - `--dry-run` 只完成 Runtime assembly 与 sealed plan prepare，不打开 Target 或 Evaluator。
 
-迁移方式有意保持为人工操作，而不是程序转换：如有需要，可归档或删除旧的扁平报告文件，然后重新运行评测。OMK 不会根据旧报告臆造 Core Run Plan、lineage、digest 或决策证据，也不会从旧文件重建历史分数曲线。
+迁移方式有意保持为人工操作，而不是程序转换：如有需要，可归档或删除旧的扁平报告文件，然后重新运行评测。Studio 启动时会检查当前 Core 根目录和旧的同级 `reports/` 根目录，寻找顶层 JSON 文件。如果发现，会在启动服务前打印目录与文件数量；绝不解析、移动、删除或转换这些文件。OMK 不会根据旧报告臆造 Core Run Plan、lineage、digest 或决策证据，也不会从旧文件重建历史分数曲线。
 
 这是存储和应用 schema 的切换，不改变测量 construct。冻结的评分类 prompt、五层评分、Bootstrap CI、Krippendorff alpha 与 length-debias 语义保持不变。

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { Flags } from '@oclif/core';
 import { LANG_FLAG, bilingual } from '../oclif/i18n.js';
 import { BaseCommand } from '../oclif/base-command.js';
@@ -11,6 +11,7 @@ import {
   projectReportsDir, globalReportsDir,
 } from '../../evidence/storage/directories.js';
 import { DEFAULT_GLOBAL_OBSERVATIONS_DIR } from '../../observability/inbox/index.js';
+import { detectLegacyEvaluationLayouts } from '../../evidence/storage/legacy-eval-layout.js';
 import type { ReportServer } from '../lib/shared.js';
 import type { StudioArgs, StudioFlags } from '../lib/cmd-flags.js';
 import { openWorkbench } from '../lib/open-workbench.js';
@@ -73,6 +74,29 @@ export async function runStudio(
     // 当成功上报会让 omk studio --dev 的 crash 静默)。
     child.on('exit', (code: number | null) => process.exit(code ?? 1));
     return;
+  }
+
+  const evalDirectories = flags['reports-dir']
+    ? [reportsDirOpt!]
+    : flags.global
+      ? [globalReportsDir()]
+      : [projectReportsDir(), globalReportsDir()];
+  const legacyReportsDirectories = flags['reports-dir']
+    ? []
+    : evalDirectories.map((directory) => join(dirname(directory), 'reports'));
+  const legacyLayouts = await detectLegacyEvaluationLayouts({
+    evalDirectories,
+    legacyReportsDirectories,
+  });
+  if (legacyLayouts.length > 0) {
+    const locations = legacyLayouts.map((finding) => (
+      `  - ${finding.directory} (${finding.fileCount})`
+    )).join('\n');
+    const fileCount = legacyLayouts.reduce((sum, finding) => sum + finding.fileCount, 0);
+    process.stderr.write(tCli('cli.studio.legacy_eval_layout', lang, {
+      count: fileCount,
+      locations,
+    }));
   }
 
   const { createReportServer } = await import('../../studio/http/report-server.js');

--- a/src/cli/lib/i18n-dict/common.ts
+++ b/src/cli/lib/i18n-dict/common.ts
@@ -24,6 +24,7 @@ export type CommonMessageKey =
   | 'cli.studio.started'
   | 'cli.studio.stop_hint'
   | 'cli.studio.open_failed'
+  | 'cli.studio.legacy_eval_layout'
   | 'cli.doctor.no_skill_found'
   | 'cli.doctor.progress_skill_start'
   | 'cli.doctor.progress_skill_done';
@@ -120,6 +121,10 @@ export const commonDict: Record<CommonMessageKey, CliMessage> = {
   'cli.studio.open_failed': {
     zh: '⚠ 无法自动打开浏览器（{command}）：{message}\n',
     en: '⚠ Failed to open browser automatically ({command}): {message}\n',
+  },
+  'cli.studio.legacy_eval_layout': {
+    zh: '⚠️ 检测到 {count} 个旧版或不受支持的扁平评测文件，当前 OMK 不会读取或自动转换：\n{locations}\n如需查看，请保留对应的旧版 OMK；否则归档这些文件后重新运行 omk eval。迁移说明：https://oh-my-knowledge.pages.dev/zh/guides/eval-core-cutover\n',
+    en: '⚠️ Found {count} legacy or unsupported flat evaluation file(s). Current OMK will not read or convert them:\n{locations}\nKeep the matching older OMK version if you need to inspect them; otherwise archive the files and run omk eval again. Migration guide: https://oh-my-knowledge.pages.dev/guides/eval-core-cutover\n',
   },
   'cli.doctor.no_skill_found': {
     zh: '未在 {path} 下发现 skill 文件。\n  doctor 期望 .md 文件、目录(包含 .md 或 SKILL.md)或 cwd 下的 skills/ 子目录。',

--- a/src/evidence/storage/legacy-eval-layout.ts
+++ b/src/evidence/storage/legacy-eval-layout.ts
@@ -1,0 +1,69 @@
+import { readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export type LegacyEvaluationLayoutKind =
+  | 'legacy-reports-directory'
+  | 'flat-files-in-eval-directory';
+
+export interface LegacyEvaluationLayoutFinding {
+  readonly layoutKind: LegacyEvaluationLayoutKind;
+  readonly directory: string;
+  readonly fileCount: number;
+}
+
+export interface LegacyEvaluationLayoutScan {
+  /** Current Core roots. Top-level JSON files are unsupported flat artifacts. */
+  readonly evalDirectories: readonly string[];
+  /** Pre-Core `reports/` roots. Every top-level JSON file is a legacy artifact candidate. */
+  readonly legacyReportsDirectories: readonly string[];
+}
+
+async function countTopLevelJsonFiles(directory: string): Promise<number> {
+  try {
+    return (await readdir(directory, { withFileTypes: true })).filter((entry) => (
+      (entry.isFile() || entry.isSymbolicLink())
+      && entry.name.endsWith('.json')
+      && !entry.name.includes('.json.tmp.')
+    )).length;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 0;
+    // This is a non-authoritative migration hint. The Core store remains responsible
+    // for errors in active roots; an unreadable obsolete sibling must not stop Studio.
+    return 0;
+  }
+}
+
+/**
+ * Detect obsolete evaluation layouts without parsing, migrating, deleting, or accepting
+ * any legacy report as Core evidence. Current Core roots contain only addressed
+ * run/batch/content directories, so a top-level JSON file is necessarily unsupported.
+ */
+export async function detectLegacyEvaluationLayouts(
+  scan: Readonly<LegacyEvaluationLayoutScan>,
+): Promise<readonly LegacyEvaluationLayoutFinding[]> {
+  const candidates = [
+    ...scan.evalDirectories.map((directory) => ({
+      layoutKind: 'flat-files-in-eval-directory' as const,
+      directory: resolve(directory),
+    })),
+    ...scan.legacyReportsDirectories.map((directory) => ({
+      layoutKind: 'legacy-reports-directory' as const,
+      directory: resolve(directory),
+    })),
+  ];
+  const unique = new Map<string, (typeof candidates)[number]>();
+  for (const candidate of candidates) {
+    unique.set(`${candidate.layoutKind}\0${candidate.directory}`, candidate);
+  }
+  const findings = await Promise.all([...unique.values()].map(async (candidate) => ({
+    ...candidate,
+    fileCount: await countTopLevelJsonFiles(candidate.directory),
+  })));
+  return Object.freeze(findings
+    .filter((finding) => finding.fileCount > 0)
+    .sort((left, right) => (
+      left.directory.localeCompare(right.directory)
+      || left.layoutKind.localeCompare(right.layoutKind)
+    ))
+    .map((finding) => Object.freeze(finding)));
+}

--- a/test/cli/studio-dev-spawn.test.ts
+++ b/test/cli/studio-dev-spawn.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, vi, beforeEach, afterEach, expect } from 'vitest';
 
+const { legacyLayoutMock } = vi.hoisted(() => ({
+  legacyLayoutMock: vi.fn(),
+}));
+
 interface CapturedSpawn {
   command: string;
   args: string[];
@@ -55,6 +59,10 @@ vi.mock('../../src/studio/http/report-server.js', () => ({
   })),
 }));
 
+vi.mock('../../src/evidence/storage/legacy-eval-layout.js', () => ({
+  detectLegacyEvaluationLayouts: legacyLayoutMock,
+}));
+
 describe('studio --dev child spawn argv', () => {
   beforeEach(() => {
     spawnCalls.length = 0;
@@ -64,6 +72,7 @@ describe('studio --dev child spawn argv', () => {
     delete process.env.__OMK_DEV_CHILD;
     delete process.env.BROWSER;
     setStdoutIsTTY(false);
+    legacyLayoutMock.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -136,6 +145,52 @@ describe('studio --dev child spawn argv', () => {
     await runStudio({}, { lang: 'zh', port: '7799', 'no-open': true, dev: false }, 'zh');
     const opts = vi.mocked(createReportServer).mock.calls.at(-1)?.[0];
     expect(opts?.observationsDir).toBeUndefined();
+  });
+
+  it('在启动服务前用中文提示旧版扁平评测布局', async () => {
+    legacyLayoutMock.mockResolvedValue([{
+      layoutKind: 'legacy-reports-directory',
+      directory: '/tmp/project/.omk/reports',
+      fileCount: 2,
+    }]);
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const { runStudio } = await import('../../src/cli/commands/studio.js');
+      await runStudio({}, { lang: 'zh', port: '7799', 'no-open': true, dev: false }, 'zh');
+
+      const output = stderr.mock.calls.map((call) => String(call[0])).join('');
+      expect(output).toContain('检测到 2 个旧版或不受支持的扁平评测文件');
+      expect(output).toContain('/tmp/project/.omk/reports');
+      expect(output).toContain('/zh/guides/eval-core-cutover');
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
+  it('uses an English migration hint and scans only an explicit reports directory', async () => {
+    legacyLayoutMock.mockResolvedValue([{
+      layoutKind: 'flat-files-in-eval-directory',
+      directory: '/tmp/selected',
+      fileCount: 1,
+    }]);
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const { runStudio } = await import('../../src/cli/commands/studio.js');
+      await runStudio({}, {
+        lang: 'en', port: '7799', 'reports-dir': '/tmp/selected', 'no-open': true, dev: false,
+      }, 'en');
+
+      expect(legacyLayoutMock).toHaveBeenLastCalledWith({
+        evalDirectories: ['/tmp/selected'],
+        legacyReportsDirectories: [],
+      });
+      const output = stderr.mock.calls.map((call) => String(call[0])).join('');
+      expect(output).toContain('Found 1 legacy or unsupported flat evaluation file(s)');
+      expect(output).toContain('/guides/eval-core-cutover');
+      expect(output).not.toContain('/zh/guides/eval-core-cutover');
+    } finally {
+      stderr.mockRestore();
+    }
   });
 
   it('treats BROWSER=none as no browser open', async () => {

--- a/test/evidence/storage/legacy-eval-layout.test.ts
+++ b/test/evidence/storage/legacy-eval-layout.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'vitest';
+import { detectLegacyEvaluationLayouts } from '../../../src/evidence/storage/legacy-eval-layout.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'omk-legacy-eval-layout-'));
+  roots.push(root);
+  return root;
+}
+
+describe('legacy evaluation layout detection', () => {
+  it('finds top-level JSON files in current and pre-Core roots without parsing them', async () => {
+    const root = await temporaryRoot();
+    const current = join(root, '.omk', 'eval');
+    const legacy = join(root, '.omk', 'reports');
+    await mkdir(join(current, 'run-valid'), { recursive: true });
+    await mkdir(legacy, { recursive: true });
+    await writeFile(join(current, 'old.report.json'), '{not-json', 'utf8');
+    await writeFile(join(current, 'readme.txt'), 'ignored', 'utf8');
+    await writeFile(join(legacy, 'older.json'), '{}', 'utf8');
+    await writeFile(join(legacy, 'write.json.tmp.1'), '{}', 'utf8');
+
+    const findings = await detectLegacyEvaluationLayouts({
+      evalDirectories: [current],
+      legacyReportsDirectories: [legacy],
+    });
+
+    assert.deepEqual(findings, [{
+      layoutKind: 'flat-files-in-eval-directory',
+      directory: current,
+      fileCount: 1,
+    }, {
+      layoutKind: 'legacy-reports-directory',
+      directory: legacy,
+      fileCount: 1,
+    }]);
+    assert.ok(Object.isFrozen(findings));
+    assert.ok(findings.every(Object.isFrozen));
+  });
+
+  it('deduplicates roots and ignores missing, empty, nested, and temporary artifacts', async () => {
+    const root = await temporaryRoot();
+    const current = join(root, 'eval');
+    await mkdir(join(current, 'run-1'), { recursive: true });
+    await writeFile(join(current, 'run-1', 'report.json'), '{}', 'utf8');
+    await writeFile(join(current, '.write.json.tmp.1'), '{}', 'utf8');
+
+    assert.deepEqual(await detectLegacyEvaluationLayouts({
+      evalDirectories: [current, current],
+      legacyReportsDirectories: [join(root, 'missing')],
+    }), []);
+  });
+});


### PR DESCRIPTION
## 用户影响

Studio 启动时会只读检查当前 Core 评测根目录与旧版同级 `reports/` 目录。发现顶层 JSON 文件后，在服务启动前用中英文列出目录和数量，避免升级后旧报告静默消失。

## 迁移说明

该诊断不会解析、移动、删除或转换旧文件，也不会把旧报告接纳为 Core evidence。需要查看历史文件时保留对应旧版 OMK；否则归档后重新运行 `omk eval`。中英文 cutover 文档已同步这一行为。

## 测量与兼容边界

本改动不改变评分、统计、prompt、Schema、verdict、持久化写协议或 Core 报告读取边界，只增加 Studio 启动前的只读诊断。完整本地门禁与隔离的真实 CLI 入口验收通过；自主 CR：No findings。

Refs #652