### PR TITLE
refactor(eval-workflows): 移除旧版评测提示

### DIFF
--- a/src/cli/commands/eval/gold/compare.ts
+++ b/src/cli/commands/eval/gold/compare.ts
@@ -115,8 +115,8 @@ export default class EvalGoldCompare extends BaseCommand {
       const source = await store.get(runId);
       if (source === undefined) {
         console.error(lang === 'zh'
-          ? `找不到 Core run「${runId}」；旧 evaluation report 不再支持 gold compare。`
-          : `Core run "${runId}" was not found; legacy evaluation reports are no longer supported.`);
+          ? `找不到 Core run「${runId}」。`
+          : `Core run "${runId}" was not found.`);
         throw new CliExit(1);
       }
       if (!flags.target || !flags.evaluator || !flags.metric) {

--- a/src/cli/commands/studio.ts
+++ b/src/cli/commands/studio.ts
@@ -16,15 +16,15 @@ import type { StudioArgs, StudioFlags } from '../lib/cmd-flags.js';
 import { openWorkbench } from '../lib/open-workbench.js';
 
 // dev / browser-open 测试需要 mock `node:child_process` + `node:os`,通过 in-process
-// import 直接调用。把业务作为 module-level helper export 从 Command file 暴露,
-// 既保留 test 兼容又让产品命令树语义干净(无 legacy commands directory)。
+// import 直接调用。把业务作为 module-level helper export 从 Command file 暴露，
+// 便于测试命令行为，同时保持产品命令树语义干净。
 export async function runStudio(
   _args: StudioArgs,
   flags: StudioFlags,
   lang: CliLang,
 ): Promise<void> {
-  // reports 读取目录：显式 --reports-dir 固定该目录；--global 钉全局；默认只聚合
-  // 当前项目 + 全局 Core run。旧 eval report index 已删除，不再扫描其它项目。
+  // reports 读取目录：显式 --reports-dir 固定该目录；--global 钉全局；默认聚合
+  // 当前项目与全局 Core run。
   const reportsDirOpt = flags['reports-dir']
     ? resolve(flags['reports-dir'])
     : flags.global

--- a/src/eval-workflows/gold/cli.ts
+++ b/src/eval-workflows/gold/cli.ts
@@ -40,7 +40,7 @@ export function initGoldDataset(targetDir: string, options: { annotator?: string
       '- `metadata.yaml`：标注者、日期、版本与量程。',
       '- `annotations.yaml`：按 `sample_id` 绑定的评分。',
       '',
-      '比较命令只消费 Evaluation Core artifact，不读取旧 evaluation report。',
+      '使用 `omk eval gold compare` 将人工标注与 Core run 观测进行比较。',
       '',
     ].join('\n'));
   }

--- a/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
+++ b/src/eval-workflows/production-host/node-cli-evaluation-resolver.ts
@@ -941,7 +941,6 @@ export async function resolveNodeCliEvaluationRequest(
       dryRun: request.values.orchestration.dryRun,
       batch: false,
       ...(request.values.orchestration.resumeSourceLocator === undefined ? {} : {
-        // Core resume locators are stable run identities, never legacy report paths.
         resumeSourceLocator: request.values.orchestration.resumeSourceLocator,
       }),
       preflight: request.values.orchestration.preflight,

--- a/test/cli/oclif-eval.test.ts
+++ b/test/cli/oclif-eval.test.ts
@@ -142,6 +142,42 @@ describe('oclif eval', () => {
     }
   });
 
+  it('eval gold compare 找不到 Core run 时只报告当前契约', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omk-oclif-gold-missing-run-'));
+    try {
+      const goldDir = join(dir, 'gold');
+      const reportsDir = join(dir, 'reports');
+      await runCommand(EvalGoldInit, ['--out', goldDir]);
+      await mkdir(reportsDir);
+
+      for (const [lang, expected] of [
+        ['zh', '找不到 Core run「missing-run」。'],
+        ['en', 'Core run "missing-run" was not found.'],
+      ] as const) {
+        await assert.rejects(
+          () => runCommand(EvalGoldCompare, [
+            'missing-run',
+            '--gold-dir', goldDir,
+            '--reports-dir', reportsDir,
+            '--target', 'target',
+            '--evaluator', 'evaluator',
+            '--metric', 'metric',
+            '--lang', lang,
+          ]),
+          (err: unknown) => {
+            const e = err as ExecError;
+            assert.equal(e.code, 1, `expected exit 1, got ${e.code}`);
+            assert.ok(e.stderr.includes(expected), e.stderr);
+            assert.doesNotMatch(e.stderr, /旧|legacy/i);
+            return true;
+          },
+        );
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('eval 非法 --repeat --lang en → exit 2 + English parser error', async () => {
     try {
       await execFileAsync('node', [CLI, 'eval', '--repeat', 'abc', '--lang', 'en']);

--- a/test/eval-workflows/gold/cli.test.ts
+++ b/test/eval-workflows/gold/cli.test.ts
@@ -17,6 +17,10 @@ describe('gold dataset authoring', () => {
     const files = initGoldDataset(directory, { annotator: 'human-team' });
     assert.equal(files.length, 3);
     assert.match(readFileSync(join(directory, 'metadata.yaml'), 'utf8'), /human-team/);
+    assert.match(
+      readFileSync(join(directory, 'README.md'), 'utf8'),
+      /`omk eval gold compare` 将人工标注与 Core run 观测进行比较。/,
+    );
     assert.deepEqual(validateGoldDataset(directory), { ok: true, issues: [], sampleCount: 2 });
   });
 


### PR DESCRIPTION
## 用户影响

Evaluation 运行链不再检测或提示旧版评测报告概念。Core run 不存在时只报告当前事实；新建 gold dataset 的 README 只说明当前比较流程。

## 迁移说明

无迁移能力，也不保留 0.x 布局的检测、读取或提示。需要处理旧数据的用户应使用对应旧版本。

## 测量影响

不改变评分、样本选择、统计公式、Schema 或证据语义，仅清理用户可见文案和历史性注释。

## 自主 CR

No findings。已复核 CLI 中英文失败路径、gold dataset 初始化产物、Studio 与 resume 接线；`yarn ci` 通过（312 个测试文件、3249 项测试）。