### PR TITLE
refactor(eval-core): 统一深冻结实现

### DIFF
--- a/src/eval-core/compiler/immutability.ts
+++ b/src/eval-core/compiler/immutability.ts
@@ -1,16 +1,7 @@
 import { assertCanonicalJson } from '../contracts/index.js';
+export { deepFreeze } from '../contracts/immutability.js';
 
 export function snapshotJson<T>(value: T): T {
   assertCanonicalJson(value);
   return structuredClone(value);
-}
-
-export function deepFreeze<T>(value: T): T {
-  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) return value;
-  if (!Array.isArray(value)) {
-    const prototype = Object.getPrototypeOf(value);
-    if (prototype !== Object.prototype && prototype !== null) return value;
-  }
-  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
-  return Object.freeze(value);
 }

--- a/src/eval-core/contracts/immutability.ts
+++ b/src/eval-core/contracts/immutability.ts
@@ -1,0 +1,17 @@
+function freezePlainGraph(value: unknown, seen: WeakSet<object>): void {
+  if (value === null || typeof value !== 'object'
+      || Object.isFrozen(value) || seen.has(value)) return;
+  if (!Array.isArray(value)) {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) return;
+  }
+  seen.add(value);
+  for (const child of Object.values(value)) freezePlainGraph(child, seen);
+  if (!Object.isFrozen(value)) Object.freeze(value);
+}
+
+/** Deeply freezes arrays and plain data objects while leaving host objects opaque. */
+export function deepFreeze<T>(value: T): T {
+  freezePlainGraph(value, new WeakSet());
+  return value;
+}

--- a/src/eval-core/contracts/json.ts
+++ b/src/eval-core/contracts/json.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { z } from 'zod';
+import { deepFreeze } from './immutability.js';
 
 export type JsonPrimitive = null | boolean | number | string;
 export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
@@ -143,13 +144,7 @@ export function parseWireDocument<T>(schema: z.ZodType<T>, value: unknown): T {
 
 export function deepFreezeCanonicalJson<T>(value: T): T {
   assertCanonicalJson(value);
-  const freeze = (candidate: unknown): void => {
-    if (candidate === null || typeof candidate !== 'object' || Object.isFrozen(candidate)) return;
-    for (const child of Object.values(candidate)) freeze(child);
-    Object.freeze(candidate);
-  };
-  freeze(value);
-  return value;
+  return deepFreeze(value);
 }
 
 function serializeCanonical(value: JsonValue): string {

--- a/test/eval-core/compiler/immutability.test.ts
+++ b/test/eval-core/compiler/immutability.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { deepFreeze } from '../../../src/eval-core/compiler/immutability.js';
+
+describe('Evaluation Core immutable snapshots', () => {
+  it('freezes plain cyclic graphs without traversing opaque host objects', () => {
+    const hostObject = new AbortController();
+    const value: {
+      nested: { enabled: boolean };
+      self?: unknown;
+      hostObject: AbortController;
+    } = { nested: { enabled: true }, hostObject };
+    value.self = value;
+
+    expect(deepFreeze(value)).toBe(value);
+    expect(Object.isFrozen(value)).toBe(true);
+    expect(Object.isFrozen(value.nested)).toBe(true);
+    expect(Object.isFrozen(hostObject)).toBe(false);
+  });
+});

--- a/test/eval-core/contracts/json.test.ts
+++ b/test/eval-core/contracts/json.test.ts
@@ -3,6 +3,7 @@ import {
   InvalidCanonicalJsonError,
   canonicalizeJson,
   canonicalizeJsonBytes,
+  deepFreezeCanonicalJson,
   digestCanonicalJson,
   isCanonicalJson,
 } from '../../../src/eval-core/contracts/json.js';
@@ -107,5 +108,14 @@ describe('Evaluation Core RFC 8785 JSON', () => {
 
   it('uses the ECMAScript representation for negative zero', () => {
     expect(canonicalizeJson(-0)).toBe('0');
+  });
+
+  it('deeply freezes canonical JSON through the shared Core implementation', () => {
+    const value = { nested: [{ score: 5 }] };
+
+    expect(deepFreezeCanonicalJson(value)).toBe(value);
+    expect(Object.isFrozen(value)).toBe(true);
+    expect(Object.isFrozen(value.nested)).toBe(true);
+    expect(Object.isFrozen(value.nested[0])).toBe(true);
   });
 });


### PR DESCRIPTION
## 用户影响

Evaluation Core 的普通对象快照与 Canonical JSON 快照现在复用同一套深冻结实现，消除两份递归算法继续漂移的风险。公开 API、Schema、持久化格式与测量语义不变。

## 架构边界

共享实现位于 `eval-core/contracts` 内部文件，但不从 contracts 公共 barrel 暴露。compiler 保留原入口做内部转发，因此调用方向仍为 compiler → contracts，没有新增 Core 域环。

## 验证与自主 CR

- 定向验证覆盖 Canonical JSON、循环普通对象、宿主对象隔离与依赖图守卫。
- `yarn ci`：313 个测试文件、3254 项测试全部通过。
- 自主 CR：No findings。已检查 Core 宿主无关性、依赖方向、对象图终止性、原行为兼容和工作树隔离。

Refs #652
