### PR TITLE
refactor(evidence): 统一目录兜底策略

### DIFF
--- a/src/evidence/storage/directories.ts
+++ b/src/evidence/storage/directories.ts
@@ -1,10 +1,11 @@
 import { DEFAULT_OBSERVE_HEALTH_DIR, DEFAULT_DOCTORS_DIR, DEFAULT_REPORTS_DIR } from './default-dirs.js';
 import { projectLayout } from './layout.js';
 import { listMeasurementReportPaths, type MeasurementDomain } from './report-bundle.js';
+import { resolveDataDirectory } from './directory-selection.js';
 
 /**
- * 测量产物的「项目优先 → 全局兜底」目录解析,镜像 managed 的 `resolveManagedDir`
- * (src/knowledge-artifacts/governance/store.ts)。测量产物绑用例集上下文(construct validity,不可全局化),
+ * 测量产物的「项目优先 → 全局兜底」目录解析，与 managed／observe inbox 共用
+ * `resolveDataDirectory` 的单一选择策略。测量产物绑用例集上下文(construct validity,不可全局化),
  * 默认落项目 `.omk/`,全局作显式 opt-in。
  *
  * 「记录优先」—— 目录里有匹配 report 文件才算数（不是「目录存在」），与 managed 同口径，
@@ -36,9 +37,9 @@ export function resolveObserveHealthDir(
   dir: string = projectObserveHealthDir(),
   global: string = globalObserveHealthDir(),
 ): string {
-  const found = [dir, global].find((candidate) => hasReports(candidate, 'observe-health'));
-  if (found !== undefined) return found;
-  return dir;
+  return resolveDataDirectory(dir, global, (candidate) => (
+    hasReports(candidate, 'observe-health')
+  ));
 }
 
 // —— doctor（体检报告）——
@@ -60,9 +61,7 @@ export function resolveDoctorsDir(
   dir: string = projectDoctorsDir(),
   global: string = globalDoctorsDir(),
 ): string {
-  const found = [dir, global].find((candidate) => hasReports(candidate, 'doctor'));
-  if (found !== undefined) return found;
-  return dir;
+  return resolveDataDirectory(dir, global, (candidate) => hasReports(candidate, 'doctor'));
 }
 
 // —— eval（评测报告）——

--- a/src/evidence/storage/directory-selection.ts
+++ b/src/evidence/storage/directory-selection.ts
@@ -1,0 +1,17 @@
+import { resolve } from 'node:path';
+
+/**
+ * Selects the primary directory when it contains domain data, otherwise a distinct
+ * fallback directory when that contains data. An empty pair always resolves to primary.
+ */
+export function resolveDataDirectory(
+  primaryDirectory: string,
+  fallbackDirectory: string,
+  hasData: (directory: string) => boolean,
+): string {
+  if (hasData(primaryDirectory)) return primaryDirectory;
+  if (resolve(primaryDirectory) !== resolve(fallbackDirectory) && hasData(fallbackDirectory)) {
+    return fallbackDirectory;
+  }
+  return primaryDirectory;
+}

--- a/src/knowledge-artifacts/governance/store.ts
+++ b/src/knowledge-artifacts/governance/store.ts
@@ -9,6 +9,7 @@ import {
   globalLayout,
   projectLayout,
 } from '../../evidence/storage/layout.js';
+import { resolveDataDirectory } from '../../evidence/storage/directory-selection.js';
 import { writeJsonFileAtomic } from '../../shared/atomic-json.js';
 import { withFileLock } from '../../shared/file-lock.js';
 import { isRfc3339Timestamp } from '../../shared/timestamp.js';
@@ -293,16 +294,18 @@ function withManagedRecordLock<T>(dir: string, recordId: string, operation: () =
   );
 }
 
-/** 读全部记录。项目目录空 → 兜底全局(镜像 observe inbox 的 project→global)。 */
+/** 读全部记录。项目目录空 → 按共享目录选择策略兜底全局。 */
 export function loadAllManagedRecords(dir: string = managedDir()): ManagedArtifactRecord[] {
-  const local = readRecordsFromDir(dir);
-  if (local.length > 0) return local;
   const global = globalManagedDir();
-  if (dir !== global) {
-    const fallback = readRecordsFromDir(global);
-    if (fallback.length > 0) return fallback;
-  }
-  return local;
+  const records = new Map<string, ManagedArtifactRecord[]>();
+  const read = (candidate: string): ManagedArtifactRecord[] => {
+    const cached = records.get(candidate);
+    if (cached !== undefined) return cached;
+    const loaded = readRecordsFromDir(candidate);
+    records.set(candidate, loaded);
+    return loaded;
+  };
+  return read(resolveDataDirectory(dir, global, (candidate) => read(candidate).length > 0));
 }
 
 /**
@@ -310,10 +313,11 @@ export function loadAllManagedRecords(dir: string = managedDir()): ManagedArtifa
  * 与 `loadAllManagedRecords` 的 project→global 回退同口径。
  */
 export function resolveManagedDir(dir: string = managedDir()): string {
-  if (readRecordsFromDir(dir).length > 0) return dir;
-  const global = globalManagedDir();
-  if (dir !== global && readRecordsFromDir(global).length > 0) return global;
-  return dir;
+  return resolveDataDirectory(
+    dir,
+    globalManagedDir(),
+    (candidate) => readRecordsFromDir(candidate).length > 0,
+  );
 }
 
 /**

--- a/src/observability/inbox/paths.ts
+++ b/src/observability/inbox/paths.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { globalLayout, projectLayout } from '../../evidence/storage/layout.js';
 import { isReportFileName } from '../../evidence/storage/file-names.js';
+import { resolveDataDirectory } from '../../evidence/storage/directory-selection.js';
 
 export const DEFAULT_PROJECT_OBSERVATIONS_DIR = projectLayout().observeInboxDir;
 export const DEFAULT_GLOBAL_OBSERVATIONS_DIR = globalLayout().observeInboxDir;
@@ -55,8 +56,7 @@ export function observationArchiveDir(observationsDir: string): string {
 }
 
 export function resolveObservationsDir(dir: string = DEFAULT_PROJECT_OBSERVATIONS_DIR): string {
-  if (resolve(dir) === resolve(DEFAULT_PROJECT_OBSERVATIONS_DIR)
-      && !hasObservationData(dir)
-      && hasObservationData(DEFAULT_GLOBAL_OBSERVATIONS_DIR)) return DEFAULT_GLOBAL_OBSERVATIONS_DIR;
-  return dir;
+  return resolve(dir) === resolve(DEFAULT_PROJECT_OBSERVATIONS_DIR)
+    ? resolveDataDirectory(dir, DEFAULT_GLOBAL_OBSERVATIONS_DIR, hasObservationData)
+    : dir;
 }

--- a/test/evidence/storage/directory-selection.test.ts
+++ b/test/evidence/storage/directory-selection.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveDataDirectory } from '../../../src/evidence/storage/directory-selection.js';
+
+describe('data directory selection', () => {
+  it.each([
+    { populated: ['/project'], expected: '/project' },
+    { populated: ['/global'], expected: '/global' },
+    { populated: ['/project', '/global'], expected: '/project' },
+    { populated: [], expected: '/project' },
+  ])('selects $expected for populated=$populated', ({ populated, expected }) => {
+    expect(resolveDataDirectory(
+      '/project',
+      '/global',
+      (directory) => populated.includes(directory),
+    )).toBe(expected);
+  });
+
+  it('does not probe the same physical fallback directory twice', () => {
+    const hasData = vi.fn(() => false);
+
+    expect(resolveDataDirectory('/workspace/data', '/workspace/./data', hasData))
+      .toBe('/workspace/data');
+    expect(hasData).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 用户影响

统一 doctor／observe-health、受管知识记录和 observe inbox 的「项目数据优先、项目为空时全局兜底」选择规则，避免三个调用路径继续独立演化。自定义 observe inbox 仍严格使用调用方指定目录。

## 架构与迁移

- 目录选择算法归一到 evidence storage 内部能力，各领域继续拥有自己的「有效数据」判定。
- 不新增公开 API，不改变存储格式、目录优先级或既有用户行为。
- 无迁移要求，也不引入历史兼容检测／提示。

## 测量影响

不改变样本、评分、统计、prompt 或报告 identity；测量可比性不受影响。

## 验证与审查

- 定向验证：5 个文件、63 个测试通过。
- 完整门禁：`yarn ci` 通过，共 314 个文件、3259 个测试。
- 自主 fresh-pass CR：No findings。已检查目录等价、双目录均有数据、均无数据、自定义目录、缓存复用与架构依赖。

Refs #652