### PR TITLE
docs(eval-workflows): 明确下一轮拆分边界

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -71,12 +71,15 @@ runtime readiness belongs to executors:
 ```text
 eval-workflows/
 ├── analysis/           # reusable workflow-owned statistical primitives
-├── inputs/             # config, sample, artifact-source resolution, and schemas
-├── instruments/        # judge invocation, judge trace, and instrument contracts
+├── artifact-store/     # Core artifact persistence, discovery, and overlays
+├── assertions/         # authored assertion adaptation and score layers
 ├── gold/               # human-gold datasets, calibration, and CLI support
 ├── input-compilation/  # host inputs → host-neutral measurement definition
-├── runtime-adapter/    # binding assembly and declared-preflight admission
+├── inputs/             # config, sample, artifact-source resolution, and schemas
+├── instruments/        # evaluator configuration and frozen prompt assets
 ├── projections/        # authenticated downstream views of Core artifacts
+├── resume-admission/   # persisted-run integrity and resume admission
+├── runtime-adapter/    # Core bindings, analysis nodes, evaluators, and adapters
 └── production-host/    # Node host composition and effect orchestration
 
 executors/
@@ -90,6 +93,24 @@ judge execution and Gold calibration into the instruments and analysis contracts
 `executors/preflight` reports environment readiness facts, while
 `eval-workflows/runtime-adapter/preflight.ts` decides workflow admission from binding declarations.
 These subdomains remain separate dependency-graph vertices even though they are physically grouped.
+
+`eval-workflows` is an ownership umbrella, not permission to grow a second monolith. Every direct
+subdirectory above is a separate dependency-graph vertex. Its root is limited to cross-workflow defaults,
+user messages, and repository guidance; new behavior belongs in an owning subdomain. The next decomposition
+boundary is `runtime-adapter`, whose growth must stay within four capability partitions:
+
+```text
+runtime-adapter/
+├── adapters/         # provider protocol bridges
+├── analysis/         # registered Core AnalysisNode implementations
+├── evaluators/       # evaluator ports adapted to Core instruments
+└── resource-leases/  # declared host-resource acquisition and cleanup
+```
+
+A partition moves out of `eval-workflows` only when its contract is stable, it has an independent
+consumer or lifecycle, it no longer imports product-host composition, and its new owner is unambiguous.
+Line count alone is not a reason to add another top-level domain. Until those conditions hold, architecture
+tests keep every workflow subdomain visible to cycle analysis and reject unplanned root-level expansion.
 
 Evidence persistence and cross-source association have one non-decision boundary:
 

--- a/docs/zh/explanation/architecture.md
+++ b/docs/zh/explanation/architecture.md
@@ -69,12 +69,15 @@ Governance 只消费经过认证的评测与观测证据，不重新计算 Core 
 ```text
 eval-workflows/
 ├── analysis/           # workflow 所有的可复用统计原语
-├── inputs/             # 配置、sample、知识载体来源解析与 schema
-├── instruments/        # 评委调用、评委 trace 与 instrument contracts
+├── artifact-store/     # Core artifact 持久化、发现与 overlay
+├── assertions/         # authored assertion 适配与评分层
 ├── gold/               # human-gold 数据集、校准与 CLI 支持
 ├── input-compilation/  # 宿主输入 → 宿主无关测量定义
-├── runtime-adapter/    # binding 装配与声明式 preflight 准入
+├── inputs/             # 配置、sample、知识载体来源解析与 schema
+├── instruments/        # evaluator 配置与冻结 prompt 资产
 ├── projections/        # 基于认证 Core 产物的下游视图
+├── resume-admission/   # 持久化 run 完整性与 resume 准入
+├── runtime-adapter/    # Core binding、analysis node、evaluator 与 adapter
 └── production-host/    # Node 宿主组合与副作用编排
 
 executors/
@@ -87,6 +90,22 @@ executors/
 适配到 Core 所拥有的 instrument 和 analysis contract。类似地，`executors/preflight` 产出环境就绪事实，
 `eval-workflows/runtime-adapter/preflight.ts` 则依据 binding 声明决定 workflow 是否准入。
 这些子域即使在物理目录上聚合，仍作为独立节点参与依赖图检查。
+
+`eval-workflows` 是所有权边界，不是继续形成第二个单体的理由。上面每个直属目录都是独立的
+依赖图节点；根目录只允许跨 workflow 的默认值、用户文案和仓库规则，新行为必须进入明确的所属
+子域。下一轮拆分首先关注 `runtime-adapter`，新增内容必须归入四个能力分区：
+
+```text
+runtime-adapter/
+├── adapters/         # provider 协议桥接
+├── analysis/         # 已注册的 Core AnalysisNode 实现
+├── evaluators/       # 把 evaluator port 适配为 Core instrument
+└── resource-leases/  # 声明式宿主资源获取与清理
+```
+
+只有当某个分区具备稳定 contract、独立 consumer 或 lifecycle、不再依赖产品宿主装配，且新
+所有者明确时，才把它移出 `eval-workflows`。代码行数本身不是增加顶层领域的理由。在这些条件
+成立前，架构测试会确保每个 workflow 子域都参与环检测，并拒绝未经规划的根目录扩张。
 
 Evidence 持久化与跨来源关联属于同一个不做决策的边界：
 

--- a/test/architecture/dependency-graph.test.ts
+++ b/test/architecture/dependency-graph.test.ts
@@ -19,6 +19,19 @@ const DIAGNOSIS_OBSERVABILITY_PRODUCER_TARGETS = new Set([
   'observability/skill-health/advisories.ts',
   'observability/skill-health/skill-chain.ts',
 ]);
+const EVAL_WORKFLOW_SUBDOMAINS = new Set([
+  'analysis',
+  'artifact-store',
+  'assertions',
+  'gold',
+  'input-compilation',
+  'inputs',
+  'instruments',
+  'production-host',
+  'projections',
+  'resume-admission',
+  'runtime-adapter',
+]);
 
 interface ModuleEdge {
   importer: string;
@@ -115,7 +128,7 @@ function moduleDomain(path: string): string {
   }
   if (
     topLevel === 'eval-workflows'
-    && ['analysis', 'gold', 'inputs', 'instruments'].includes(subdomain)
+    && EVAL_WORKFLOW_SUBDOMAINS.has(subdomain)
   ) {
     return `${topLevel}/${subdomain}`;
   }
@@ -364,6 +377,13 @@ describe('src 依赖图', () => {
     expect(moduleDomain('eval-workflows/instruments/prompts/judge-prompts.ts')).toBe('eval-workflows/instruments');
     expect(moduleDomain('eval-workflows/gold/human.ts')).toBe('eval-workflows/gold');
     expect(moduleDomain('eval-workflows/analysis/bootstrap.ts')).toBe('eval-workflows/analysis');
+    expect(moduleDomain('eval-workflows/artifact-store/node-run-store.ts')).toBe('eval-workflows/artifact-store');
+    expect(moduleDomain('eval-workflows/assertions/layers.ts')).toBe('eval-workflows/assertions');
+    expect(moduleDomain('eval-workflows/input-compilation/compile.ts')).toBe('eval-workflows/input-compilation');
+    expect(moduleDomain('eval-workflows/production-host/orchestration.ts')).toBe('eval-workflows/production-host');
+    expect(moduleDomain('eval-workflows/projections/cli.ts')).toBe('eval-workflows/projections');
+    expect(moduleDomain('eval-workflows/resume-admission/admit.ts')).toBe('eval-workflows/resume-admission');
+    expect(moduleDomain('eval-workflows/runtime-adapter/assembly.ts')).toBe('eval-workflows/runtime-adapter');
     expect(moduleDomain('evidence/graph/schema.ts')).toBe('evidence/graph');
     expect(moduleDomain('evidence/storage/report-bundle.ts')).toBe('evidence/storage');
     expect(moduleDomain('executors/preflight/dependencies.ts')).toBe('executors/preflight');

--- a/test/architecture/eval-workflows-executors-layout.test.ts
+++ b/test/architecture/eval-workflows-executors-layout.test.ts
@@ -3,10 +3,47 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('eval-workflows 与 executors 领域布局', () => {
-  it('保留输入、评分类适配与执行前检查的稳定子域', () => {
-    expect(existsSync(resolve('src/eval-workflows/inputs'))).toBe(true);
-    expect(existsSync(resolve('src/eval-workflows/instruments'))).toBe(true);
-    expect(existsSync(resolve('src/eval-workflows/gold'))).toBe(true);
+  it('eval-workflows 根目录只保留已规划的稳定子域与共享入口', () => {
+    const entries = readdirSync(resolve('src/eval-workflows'), { withFileTypes: true });
+    expect(entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort())
+      .toEqual([
+        'analysis',
+        'artifact-store',
+        'assertions',
+        'gold',
+        'input-compilation',
+        'inputs',
+        'instruments',
+        'production-host',
+        'projections',
+        'resume-admission',
+        'runtime-adapter',
+      ]);
+    expect(entries.filter((entry) => entry.isFile()).map((entry) => entry.name).sort())
+      .toEqual(['AGENTS.md', 'evaluation-defaults.ts', 'messages.ts']);
+  });
+
+  it('runtime-adapter 的增长进入能力子域而不是继续堆入根目录', () => {
+    const entries = readdirSync(resolve('src/eval-workflows/runtime-adapter'), {
+      withFileTypes: true,
+    });
+    expect(entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort())
+      .toEqual(['adapters', 'analysis', 'evaluators', 'resource-leases']);
+    expect(entries.filter((entry) => entry.isFile()).map((entry) => entry.name).sort())
+      .toEqual([
+        'assembly.ts',
+        'builtins.ts',
+        'composition.ts',
+        'event-projection.ts',
+        'index.ts',
+        'preflight.ts',
+        'series-variance.ts',
+        'source-neutral-trace.ts',
+        'types.ts',
+      ]);
+  });
+
+  it('executors 保留独立的执行前检查边界', () => {
     expect(
       readdirSync(resolve('src/executors/preflight')).sort(),
     ).toEqual(['contracts.ts', 'dependencies.ts']);


### PR DESCRIPTION
## 用户影响

架构文档现在完整列出 eval-workflows 的 11 个真实子域，并明确 runtime-adapter 的四个能力分区。后续新增能力必须进入明确所有者，不能继续把 eval-workflows 或 runtime-adapter 根目录堆成新单体。

## 架构与迁移

依赖图将全部 11 个 workflow 子域作为独立 SCC 节点，不再把 artifact-store、assertions、input-compilation、production-host、projections、resume-admission 与 runtime-adapter 折叠成同一个粗粒度节点。布局守卫同时锁定 workflow 根目录与 runtime-adapter 根目录；新增子域需要显式更新架构决策。

不改变公开 API、Schema、持久化格式或用户行为，无需迁移。

## 测量影响

不改变样本、评委 prompt、五层评分、统计公式、Decision identity 或可比性。只收紧源码领域边界及其持续验证。

## 验证与自主 CR

最终 yarn ci 通过：315 个测试文件、3263 项测试。fresh-pass CR：No findings；已复核真实目录、依赖图粒度、运行时环检测、双语文档一致性和工作树隔离。

Refs #652