### PR TITLE
feat(eval-core): 新增独立组 Bootstrap 估计器

### DIFF
--- a/docs/specs/eval-core-vnext.md
+++ b/docs/specs/eval-core-vnext.md
@@ -287,10 +287,13 @@ v1 keeps its built-in reducers and estimators minimal:
 - `descriptive.mean/v1`, `descriptive.rate/v1`, and `descriptive.quantile/v1`;
 - `bootstrap.mean-percentile/v1`;
 - `bootstrap.paired-difference-percentile/v1`;
+- `bootstrap.unpaired-difference-percentile/v1`;
 - `bootstrap.cluster-percentile/v1`;
 - `bonferroni/v1` for multiple-comparison correction.
 
 Alpha, resample count, resampling unit, and seed enter AnalysisPlan. v1 does not embed parametric methods such as t-tests, ANOVA, or Hotelling T². Future estimators are added through AnalysisRegistry identities without changing observation or Bundle contracts. Prepare fails when an estimator does not support the value domain or SamplingDesign and never switches algorithms implicitly.
+
+The unpaired estimator requires disjoint sample identities between the declared control and treatment arms and independently resamples each arm. For stratified inputs, it resamples within arm × stratum cells and combines within-stratum differences using pooled observed stratum proportions. A missing arm in any observed stratum makes the result inconclusive; the estimator never falls back to a paired or unstratified analysis.
 
 Re-analysis and re-decision preserve parent Bundle digest, policy digest, derivation time, and `analysisMode: preregistered | exploratory`. Thresholds or methods chosen after observing results cannot masquerade as pre-sealed release gates.
 
@@ -889,7 +892,7 @@ This review closes five blocking questions:
 2. **Protocol families**: v1 includes only `omk.invoke/v1` and `omk.session/v1`; external results enter through ExecutionBundle rather than an import protocol.
 3. **Event journal**: one consumer, 256 events by default, retained-window replay for late subscribers, progress-first coalescing, and explicit overflow reporting; lossless delivery uses EventWriter.
 4. **Bundle signing**: v1 records digest and trust but does not sign; hosts compose attestations and verifiers through extensions.
-5. **Estimator registry**: v1 includes descriptive reducers, percentile bootstrap for mean/paired-difference/cluster designs, and Bonferroni, with no built-in parametric methods.
+5. **Estimator registry**: v1 includes descriptive reducers, percentile bootstrap for mean/paired-difference/unpaired-difference/cluster designs, and Bonferroni, with no built-in parametric methods.
 
 These decisions close the architectural choices required before Contracts. Conformance tests and simulations must still validate implementation constants and algorithms.
 

--- a/src/eval-core/analysis/builtins.ts
+++ b/src/eval-core/analysis/builtins.ts
@@ -639,6 +639,121 @@ function executePairedBootstrap(context: AnalysisNodeExecutionContext): Analysis
   } : interval;
 }
 
+function bootstrapArmStratumMean(
+  seed: Sha256Digest,
+  armId: string,
+  stratumId: string,
+  replicate: number,
+  members: readonly BootstrapUnit[],
+): number {
+  const stratumSeed = digestCanonicalJson({
+    derivation: 'omk.analysis-unpaired-bootstrap-arm-stratum-seed/v1',
+    seed,
+    armId,
+    stratumId,
+  });
+  return mean(Array.from({ length: members.length }, (_, draw) => (
+    members[deterministicIndex(stratumSeed, replicate, draw, members.length)].value
+  )));
+}
+
+function executeUnpairedBootstrap(context: AnalysisNodeExecutionContext): AnalysisNodeExecutionResult {
+  const comparisonInputs = context.inputs.filter(
+    (input): input is Extract<AnalysisNodeInput, { inputKind: 'comparison' }> => (
+      input.inputKind === 'comparison'
+    ),
+  );
+  if (comparisonInputs.length !== 1) {
+    throw new TypeError('Unpaired bootstrap requires exactly one Comparison contrast.');
+  }
+  const comparisonInput = comparisonInputs[0];
+  const metricInput = metricInputs(context)[0];
+  if (metricInput === undefined || comparisonInput.contrast.metricId !== metricInput.referenceId) {
+    return incomplete('analysis-unpaired-bootstrap-requires-one-matching-metric');
+  }
+  const controlId = comparisonInput.contrast.controlTargetId;
+  const treatmentId = comparisonInput.contrast.treatmentTargetId;
+  const rows = observedRows(context);
+  const controlRows = rows.filter((row) => row.targetId === controlId);
+  const treatmentRows = rows.filter((row) => row.targetId === treatmentId);
+  const controlSampleIds = new Set(controlRows.map((row) => row.sampleId));
+  if (treatmentRows.some((row) => controlSampleIds.has(row.sampleId))) {
+    return incomplete('analysis-unpaired-bootstrap-overlapping-units');
+  }
+  const controlUnits = [...groupRows(controlRows, (row) => row.sampleId).values()].map(groupUnit);
+  const treatmentUnits = [...groupRows(treatmentRows, (row) => row.sampleId).values()].map(groupUnit);
+  if (controlUnits.length < 2 || treatmentUnits.length < 2) {
+    return incomplete('analysis-insufficient-resampling-units-per-arm');
+  }
+  const controlStrata = new Set(controlUnits.map((unit) => unit.stratumId ?? 'omk:unstratified'));
+  const treatmentStrata = new Set(
+    treatmentUnits.map((unit) => unit.stratumId ?? 'omk:unstratified'),
+  );
+  if (controlStrata.size !== treatmentStrata.size
+      || [...controlStrata].some((stratumId) => !treatmentStrata.has(stratumId))) {
+    return incomplete('analysis-unpaired-bootstrap-strata-not-shared');
+  }
+  const controlByStratum = new Map<string, BootstrapUnit[]>();
+  const treatmentByStratum = new Map<string, BootstrapUnit[]>();
+  for (const unit of controlUnits) {
+    const stratumId = unit.stratumId ?? 'omk:unstratified';
+    controlByStratum.set(stratumId, [...(controlByStratum.get(stratumId) ?? []), unit]);
+  }
+  for (const unit of treatmentUnits) {
+    const stratumId = unit.stratumId ?? 'omk:unstratified';
+    treatmentByStratum.set(stratumId, [...(treatmentByStratum.get(stratumId) ?? []), unit]);
+  }
+  const totalUnitCount = controlUnits.length + treatmentUnits.length;
+  const strata = [...controlStrata].sort().map((stratumId) => ({
+    stratumId,
+    control: controlByStratum.get(stratumId) ?? [],
+    treatment: treatmentByStratum.get(stratumId) ?? [],
+  }));
+  const weightedDifference = (
+    estimate: (armId: string, stratumId: string, units: readonly BootstrapUnit[]) => number,
+  ): number => strata.reduce((sum, stratum) => {
+    const weight = (stratum.control.length + stratum.treatment.length) / totalUnitCount;
+    return sum + weight * (
+      estimate(treatmentId, stratum.stratumId, stratum.treatment)
+        - estimate(controlId, stratum.stratumId, stratum.control)
+    );
+  }, 0);
+  const resamples = parameterInteger(context, 'resamples', 1_000);
+  const alpha = parameterNumber(context, 'alpha', 0.05);
+  if (resamples < 1 || alpha <= 0 || alpha >= 1) {
+    throw new TypeError('Bootstrap requires positive resamples and alpha in (0, 1).');
+  }
+  const seed = bootstrapSeed(context);
+  const estimates = Array.from({ length: resamples }, (_, replicate) => weightedDifference(
+    (armId, stratumId, units) => bootstrapArmStratumMean(
+      seed,
+      armId,
+      stratumId,
+      replicate,
+      units,
+    ),
+  )).sort((left, right) => left - right);
+  const includedRows = [...controlRows, ...treatmentRows];
+  return {
+    analysisStatus: 'completed',
+    resultType: 'interval',
+    value: {
+      estimate: weightedDifference((_armId, _stratumId, units) => (
+        mean(units.map((unit) => unit.value))
+      )),
+      lower: quantile(estimates, alpha / 2),
+      upper: quantile(estimates, 1 - alpha / 2),
+      confidenceLevel: 1 - alpha,
+      resamples,
+      unitCount: controlUnits.length + treatmentUnits.length,
+      method: 'percentile',
+    },
+    includedRowIds: includedRows.map((row) => row.rowId),
+    comparableRowIds: includedRows.map((row) => row.rowId),
+    assumptionChecks: passedAssumption('independent-non-overlapping-samples'),
+  };
+}
+
 interface Hypothesis {
   hypothesisId: string;
   pValue: number;
@@ -790,6 +905,25 @@ register(
   BUILTIN_INTERVAL_RESULT_SCHEMA,
   BOOTSTRAP_PARAMETERS_SCHEMA,
   executePairedBootstrap,
+);
+register(
+  'bootstrap.unpaired-difference-percentile/v1',
+  nodeCapabilities({
+    analysisNodeKind: 'estimator',
+    valueTypes: ['numeric', 'boolean'],
+    missingPolicyIds: ['exclude/v1'],
+    comparison: true,
+    outputSchema: BUILTIN_INTERVAL_RESULT_SCHEMA,
+    parameterSchema: BOOTSTRAP_PARAMETERS_SCHEMA,
+    sampling: {
+      experimentalUnits: ['sample'],
+      repeatedMeasures: [false, true],
+      resamplingUnits: ['sample'],
+    },
+  }),
+  BUILTIN_INTERVAL_RESULT_SCHEMA,
+  BOOTSTRAP_PARAMETERS_SCHEMA,
+  executeUnpairedBootstrap,
 );
 register(
   'bootstrap.cluster-percentile/v1',

--- a/test/eval-core/analysis/builtins.test.ts
+++ b/test/eval-core/analysis/builtins.test.ts
@@ -134,6 +134,25 @@ async function execute(input: AnalysisNodeExecutionContext) {
 }
 
 describe('Evaluation Core built-in estimators', () => {
+  it('declares the independent-group estimator capability without paired-block fallback', () => {
+    const implementation = createBuiltinAnalysisNodes().get(
+      'bootstrap.unpaired-difference-percentile/v1',
+    );
+    expect(implementation?.identity.capabilities).toMatchObject({
+      capabilityKind: 'analysis-node',
+      analysisNodeKinds: ['estimator'],
+      inputCardinalities: {
+        metricObservations: { min: 1, max: 1 },
+        comparisons: { min: 1, max: 1 },
+      },
+      sampling: {
+        experimentalUnits: ['sample'],
+        repeatedMeasures: [false, true],
+        resamplingUnits: ['sample'],
+      },
+    });
+  });
+
   it('counts only complete paired resampling units', () => {
     expect(countAnalysisResamplingUnits('paired-block', [
       {
@@ -288,6 +307,88 @@ describe('Evaluation Core built-in estimators', () => {
       value: { estimate: 1.5, unitCount: 2 },
     });
     expect(result.includedRowIds).toHaveLength(4);
+  });
+
+  it('resamples independent arms and rejects overlapping experimental units', async () => {
+    const independent = context({
+      implementationId: 'bootstrap.unpaired-difference-percentile/v1',
+      resamplingUnit: 'sample',
+      comparison: true,
+      rows: [
+        row({ sampleId: 'c1', targetId: 'control', value: 1 }),
+        row({ sampleId: 'c2', targetId: 'control', value: 3 }),
+        row({ sampleId: 't1', targetId: 'treatment', value: 4 }),
+        row({ sampleId: 't2', targetId: 'treatment', value: 6 }),
+      ],
+    });
+    const first = await execute(independent);
+    const second = await execute(independent);
+
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({
+      analysisStatus: 'completed',
+      value: { estimate: 3, unitCount: 4, resamples: 64 },
+      assumptionChecks: [{
+        assumptionId: 'independent-non-overlapping-samples',
+        checkStatus: 'passed',
+      }],
+    });
+    expect(first.includedRowIds).toHaveLength(4);
+
+    const overlapping = await execute(context({
+      implementationId: 'bootstrap.unpaired-difference-percentile/v1',
+      resamplingUnit: 'sample',
+      comparison: true,
+      rows: [
+        row({ sampleId: 'shared', targetId: 'control', value: 1 }),
+        row({ sampleId: 'c2', targetId: 'control', value: 3 }),
+        row({ sampleId: 'shared', targetId: 'treatment', value: 4 }),
+        row({ sampleId: 't2', targetId: 'treatment', value: 6 }),
+      ],
+    }));
+    expect(overlapping).toMatchObject({
+      analysisStatus: 'inconclusive',
+      reasonCodes: ['analysis-unpaired-bootstrap-overlapping-units'],
+    });
+  });
+
+  it('estimates independent arms within strata using pooled stratum weights', async () => {
+    const stratumA = digestCanonicalJson({ stratum: 'a' });
+    const stratumB = digestCanonicalJson({ stratum: 'b' });
+    const result = await execute(context({
+      implementationId: 'bootstrap.unpaired-difference-percentile/v1',
+      resamplingUnit: 'sample',
+      comparison: true,
+      rows: [
+        row({ sampleId: 'c-a1', targetId: 'control', value: 0, stratumId: stratumA }),
+        row({ sampleId: 'c-a2', targetId: 'control', value: 0, stratumId: stratumA }),
+        row({ sampleId: 't-a1', targetId: 'treatment', value: 2, stratumId: stratumA }),
+        row({ sampleId: 'c-b1', targetId: 'control', value: 100, stratumId: stratumB }),
+        row({ sampleId: 't-b1', targetId: 'treatment', value: 102, stratumId: stratumB }),
+        row({ sampleId: 't-b2', targetId: 'treatment', value: 102, stratumId: stratumB }),
+      ],
+    }));
+
+    expect(result).toMatchObject({
+      analysisStatus: 'completed',
+      value: { estimate: 2, unitCount: 6 },
+    });
+
+    const missingArm = await execute(context({
+      implementationId: 'bootstrap.unpaired-difference-percentile/v1',
+      resamplingUnit: 'sample',
+      comparison: true,
+      rows: [
+        row({ sampleId: 'c-a1', targetId: 'control', value: 0, stratumId: stratumA }),
+        row({ sampleId: 'c-b1', targetId: 'control', value: 100, stratumId: stratumB }),
+        row({ sampleId: 't-a1', targetId: 'treatment', value: 2, stratumId: stratumA }),
+        row({ sampleId: 't-a2', targetId: 'treatment', value: 2, stratumId: stratumA }),
+      ],
+    }));
+    expect(missingArm).toMatchObject({
+      analysisStatus: 'inconclusive',
+      reasonCodes: ['analysis-unpaired-bootstrap-strata-not-shared'],
+    });
   });
 
   it('resamples whole clusters and rejects fewer than two units', async () => {

--- a/test/eval-core/conformance/statistics.test.ts
+++ b/test/eval-core/conformance/statistics.test.ts
@@ -66,11 +66,13 @@ function metricRow(input: {
 
 async function interval(input: {
   implementationId: 'bootstrap.mean-percentile/v1'
-    | 'bootstrap.paired-difference-percentile/v1';
+    | 'bootstrap.paired-difference-percentile/v1'
+    | 'bootstrap.unpaired-difference-percentile/v1';
   rows: AnalysisMetricRow[];
   simulation: number;
-  paired?: boolean;
 }): Promise<{ lower: number; upper: number; estimate: number; unitCount: number }> {
+  const comparison = input.implementationId !== 'bootstrap.mean-percentile/v1';
+  const paired = input.implementationId === 'bootstrap.paired-difference-percentile/v1';
   const implementation = ANALYSIS_NODES.get(input.implementationId);
   if (implementation === undefined) throw new Error('Missing bootstrap implementation.');
   const run = await implementation.openRun({
@@ -86,7 +88,7 @@ async function interval(input: {
       implementationId: input.implementationId,
       inputs: [
         { inputKind: 'metric-observations', referenceId: 'score' },
-        ...(input.paired ? [{
+        ...(comparison ? [{
           inputKind: 'comparison' as const,
           referenceId: 'comparison',
           treatmentTargetId: 'treatment',
@@ -107,7 +109,7 @@ async function interval(input: {
         missingPolicyId: 'exclude/v1',
       },
       rows: input.rows,
-    }, ...(input.paired ? [{
+    }, ...(comparison ? [{
       inputKind: 'comparison' as const,
       referenceId: 'comparison',
       contrast: {
@@ -121,10 +123,10 @@ async function interval(input: {
     sampling: {
       experimentalUnit: 'sample',
       repeatedMeasures: false,
-      resamplingUnit: input.paired ? 'paired-block' : 'sample',
+      resamplingUnit: paired ? 'paired-block' : 'sample',
       estimatorId: input.implementationId,
       seedCoupling: 'shared-within-block',
-      ...(input.paired ? { pairingKey: '/input/pair' } : {}),
+      ...(paired ? { pairingKey: '/input/pair' } : {}),
     },
     rootSeed: `simulation-seed-${input.simulation}`,
     samples: [],
@@ -148,7 +150,7 @@ async function interval(input: {
 }
 
 describe('Evaluation Core deterministic statistical conformance', () => {
-  it('matches known mean and paired-difference reference vectors', async () => {
+  it('matches known mean, paired, and unpaired reference vectors', async () => {
     const mean = await interval({
       implementationId: 'bootstrap.mean-percentile/v1',
       simulation: 0,
@@ -178,11 +180,24 @@ describe('Evaluation Core deterministic statistical conformance', () => {
       implementationId: 'bootstrap.paired-difference-percentile/v1',
       simulation: 0,
       rows: pairedRows,
-      paired: true,
+    });
+    const unpaired = await interval({
+      implementationId: 'bootstrap.unpaired-difference-percentile/v1',
+      simulation: 0,
+      rows: [1, 2, 3, 4].map((value, index) => metricRow({
+        sampleId: `control-${index}`,
+        targetId: 'control',
+        value,
+      })).concat([3, 4, 5, 6].map((value, index) => metricRow({
+        sampleId: `treatment-${index}`,
+        targetId: 'treatment',
+        value,
+      }))),
     });
 
     expect(mean).toEqual({ lower: 1.5, upper: 3.25, estimate: 2.5, unitCount: 4 });
     expect(paired).toEqual({ lower: 1.5, upper: 3.5, estimate: 2.5, unitCount: 4 });
+    expect(unpaired).toEqual({ lower: 0.75, upper: 3.5, estimate: 2, unitCount: 8 });
   });
 
   it('pins the deterministic continuous 90% mean-interval coverage profile', async () => {
@@ -233,12 +248,36 @@ describe('Evaluation Core deterministic statistical conformance', () => {
         implementationId: 'bootstrap.paired-difference-percentile/v1',
         rows,
         simulation,
-        paired: true,
       });
       if (result.lower > 0 || result.upper < 0) falseDirections += 1;
     }
 
     expect({ falseDirections, simulations }).toEqual({ falseDirections: 8, simulations: 80 });
+  });
+
+  it('pins the deterministic continuous null unpaired-effect profile', async () => {
+    let falseDirections = 0;
+    const simulations = 80;
+    for (let simulation = 201; simulation < 201 + simulations; simulation += 1) {
+      const next = generator(simulation);
+      const rows = Array.from({ length: 24 }, (_, index) => metricRow({
+        sampleId: `control-${index}`,
+        targetId: 'control',
+        value: normal(next),
+      })).concat(Array.from({ length: 24 }, (_, index) => metricRow({
+        sampleId: `treatment-${index}`,
+        targetId: 'treatment',
+        value: normal(next),
+      })));
+      const result = await interval({
+        implementationId: 'bootstrap.unpaired-difference-percentile/v1',
+        rows,
+        simulation,
+      });
+      if (result.lower > 0 || result.upper < 0) falseDirections += 1;
+    }
+
+    expect({ falseDirections, simulations }).toEqual({ falseDirections: 12, simulations: 80 });
   });
 
   it('pins discrete 1-5 frequency profiles at N=8 and N=20 without claiming nominal calibration', async () => {
@@ -317,7 +356,6 @@ describe('Evaluation Core deterministic statistical conformance', () => {
             implementationId: 'bootstrap.paired-difference-percentile/v1',
             rows: pairedRows,
             simulation: simulationId,
-            paired: true,
           });
           if (pairedResult.lower > 0 || pairedResult.upper < 0) {
             pairedFalseDirections += 1;


### PR DESCRIPTION
## 用户影响

为 Evaluation Core 增加版本化的独立组均值差 percentile bootstrap 估计器，支持普通和分层独立样本。它会拒绝 control／treatment 复用同一 sample identity、缺少任一组的层，以及每组不足两个分析单元，避免把现有全交叉执行结果误当成独立组证据。

这是 #682 的统计基础 PR；本 PR 不开放 façade 的 independent sampling，也不改变执行坐标。后续 PR 会加入显式分组分配和 Plan／Schema identity。

## 迁移与可比性

- 新增 implementation identity：`bootstrap.unpaired-difference-percentile/v1`。
- 现有估计器、Schema 和持久化契约不变，无历史兼容读取或检测逻辑。
- 独立组结果与 paired 结果属于不同估计量 identity，不应跨方法直接当作同口径历史序列。

## 测量学说明

估计量按 sample 聚合重复 trial，并在 control／treatment 内独立重采样。分层输入在 arm × stratum 内重采样，以 pooled observed stratum proportions 加权层内差值；任何层缺组时 fail closed。percentile bootstrap 在小样本、离散或偏态数据上不承诺名义覆盖率，确定性 conformance profile 仅用于锁定实现行为。

## CR 与验证

自主 CR：No findings。重点复核了重叠实验单元、分层混杂、重复测量、确定性种子、能力声明、Bundle unitCount 校验与 Core 宿主无关边界。最终 `yarn ci` 通过（315 个测试文件，3272 个测试）；打包产物中的 `/eval-core` 入口可加载该估计器及其 sealed capability。

Refs #682