### PR TITLE
feat(eval-core): 支持分层测量聚合估计（BREAKING-COMPARABILITY）

### DIFF
--- a/docs/specs/eval-core-vnext.md
+++ b/docs/specs/eval-core-vnext.md
@@ -308,12 +308,17 @@ v1 keeps its built-in reducers and estimators minimal:
 - `bootstrap.mean-percentile/v1`;
 - `bootstrap.paired-difference-percentile/v1`;
 - `bootstrap.unpaired-difference-percentile/v1`;
+- `bootstrap.hierarchical-mean-percentile/v1`;
+- `bootstrap.hierarchical-paired-difference-percentile/v1`;
+- `bootstrap.hierarchical-unpaired-difference-percentile/v1`;
 - `bootstrap.cluster-percentile/v1`;
 - `bonferroni/v1` for multiple-comparison correction.
 
 Alpha, resample count, resampling unit, and seed enter AnalysisPlan. v1 does not embed parametric methods such as t-tests, ANOVA, or Hotelling T². Future estimators are added through AnalysisRegistry identities without changing observation or Bundle contracts. Prepare fails when an estimator does not support the value domain or SamplingDesign and never switches algorithms implicitly.
 
 The unpaired estimator requires disjoint sample identities between the declared control and treatment arms and independently resamples each arm. For stratified inputs, it resamples within arm × stratum cells and combines within-stratum differences using pooled observed stratum proportions. A missing arm in any observed stratum makes the result inconclusive; the estimator never falls back to a paired or unstratified analysis.
+
+The hierarchical estimators seal one complete measurement panel in their parameters. They average evaluator replicates within each ensemble member, apply the declared equal or positive normalized member weights, and then average complete Target trials within each sample. A trial contributes only when every sealed evaluator, instrument, member, group, and replicate coordinate is observed. Bootstrap still resamples only samples or paired blocks; panel members and replicates never increase `unitCount`. The non-hierarchical estimator identities keep their original semantics.
 
 Re-analysis and re-decision preserve parent Bundle digest, policy digest, derivation time, and `analysisMode: preregistered | exploratory`. Thresholds or methods chosen after observing results cannot masquerade as pre-sealed release gates.
 

--- a/docs/zh/specs/eval-core-vnext.md
+++ b/docs/zh/specs/eval-core-vnext.md
@@ -307,10 +307,18 @@ v1 内建的 reducer／estimator 保持最小：
 - `descriptive.mean/v1`、`descriptive.rate/v1`、`descriptive.quantile/v1`；
 - `bootstrap.mean-percentile/v1`；
 - `bootstrap.paired-difference-percentile/v1`；
+- `bootstrap.unpaired-difference-percentile/v1`；
+- `bootstrap.hierarchical-mean-percentile/v1`；
+- `bootstrap.hierarchical-paired-difference-percentile/v1`；
+- `bootstrap.hierarchical-unpaired-difference-percentile/v1`；
 - `bootstrap.cluster-percentile/v1`；
 - multiple-comparison correction 的 `bonferroni/v1`。
 
 alpha、重采样次数、resampling unit 和 seed 都进入 AnalysisPlan。v1 不内建 t-test、ANOVA、Hotelling T² 等参数方法；未来通过 AnalysisRegistry 增加新 estimator identity，不改变 observation 或 Bundle 契约。值域或 SamplingDesign 不受某 estimator 支持时，prepare 失败，不自动换算法。
+
+非配对 estimator 要求声明的 control 与 treatment 臂使用互不重叠的 sample identity，并对两臂独立重采样。存在 stratum 时，它在 arm × stratum 单元内重采样，再按计划总体的 stratum 比例组合组内差值；任一已观察 stratum 缺少一侧臂时结果为 inconclusive，绝不自动退化成 paired 或 unstratified analysis。
+
+分层 estimator 会在参数中封存完整 measurement panel：先在每个 ensemble member 内平均 evaluator replicate，再执行已声明的成员等权或正数归一化权重聚合，最后在每个 sample 内平均完整的 Target trial。只有所有已封存 evaluator、instrument、member、group 与 replicate 坐标都已观察时，trial 才能进入分析。Bootstrap 仍只重采样 sample 或 paired block；panel member 与 replicate 永远不增加 `unitCount`。非分层 estimator identity 保持原有语义。
 
 重新分析和重新决策保留 parent bundle digest、policy digest、生成时间以及 `analysisMode: preregistered | exploratory`。执行后修改的阈值或方法不能冒充预先封存的发布门槛。
 

--- a/src/eval-core/analysis/builtins.ts
+++ b/src/eval-core/analysis/builtins.ts
@@ -36,6 +36,77 @@ const BootstrapParametersSchema = z.object({
   resamples: z.number().int().positive().safe().default(1_000),
   alpha: FiniteNumberSchema.gt(0).lt(1).default(0.05),
 }).strict();
+const MeasurementReplicateSchema = z.object({
+  evaluatorId: z.string().min(1).max(256),
+  instrumentId: z.string().min(1).max(256),
+  replicateIndex: z.number().int().nonnegative().safe(),
+}).strict();
+const MeasurementMemberBaseSchema = z.object({
+  ensembleMemberId: z.string().min(1).max(256),
+  replicates: z.array(MeasurementReplicateSchema).min(1),
+}).strict();
+const MeasurementAggregationSchema = z.discriminatedUnion('method', [
+  z.object({
+    method: z.literal('mean'),
+    missing: z.literal('require-complete'),
+    replicateGroupId: z.string().min(1).max(256),
+    members: z.array(MeasurementMemberBaseSchema).min(1),
+  }).strict(),
+  z.object({
+    method: z.literal('weighted-mean'),
+    missing: z.literal('require-complete'),
+    replicateGroupId: z.string().min(1).max(256),
+    members: z.array(MeasurementMemberBaseSchema.extend({
+      weight: FiniteNumberSchema.positive(),
+    }).strict()).min(1),
+  }).strict(),
+]).superRefine((aggregation, context) => {
+  const memberIds = aggregation.members.map((member) => member.ensembleMemberId);
+  if (new Set(memberIds).size !== memberIds.length) {
+    context.addIssue({ code: 'custom', path: ['members'], message: 'Member IDs must be unique' });
+  }
+  if (canonicalizeJson(memberIds) !== canonicalizeJson([...memberIds].sort())) {
+    context.addIssue({
+      code: 'custom',
+      path: ['members'],
+      message: 'Members must be ordered by ensembleMemberId',
+    });
+  }
+  const evaluatorIds: string[] = [];
+  const instrumentIds = new Set<string>();
+  for (const [memberIndex, member] of aggregation.members.entries()) {
+    const indexes = member.replicates.map((replicate) => replicate.replicateIndex);
+    if (new Set(indexes).size !== indexes.length
+        || indexes.some((value, index) => value !== index)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['members', memberIndex, 'replicates'],
+        message: 'Replicate indexes must be unique and contiguous from zero',
+      });
+    }
+    for (const replicate of member.replicates) {
+      evaluatorIds.push(replicate.evaluatorId);
+      instrumentIds.add(replicate.instrumentId);
+    }
+  }
+  if (new Set(evaluatorIds).size !== evaluatorIds.length) {
+    context.addIssue({ code: 'custom', path: ['members'], message: 'Evaluator IDs must be unique' });
+  }
+  if (instrumentIds.size !== 1) {
+    context.addIssue({ code: 'custom', path: ['members'], message: 'One panel must use one instrument' });
+  }
+  if (aggregation.method === 'weighted-mean') {
+    const total = aggregation.members.reduce((sum, member) => sum + member.weight, 0);
+    if (Math.abs(total - 1) > 1e-12) {
+      context.addIssue({ code: 'custom', path: ['members'], message: 'Member weights must sum to one' });
+    }
+  }
+});
+const HierarchicalBootstrapParametersSchema = z.object({
+  resamples: z.number().int().positive().safe().default(1_000),
+  alpha: FiniteNumberSchema.gt(0).lt(1).default(0.05),
+  measurementAggregation: MeasurementAggregationSchema,
+}).strict();
 const BonferroniParametersSchema = z.object({
   alpha: FiniteNumberSchema.gt(0).lt(1).default(0.05),
 }).strict();
@@ -172,6 +243,17 @@ const QUANTILE_PARAMETERS_SCHEMA = schemaIdentity(
 );
 const BOOTSTRAP_PARAMETERS_SCHEMA = schemaIdentity(
   'omk.parameters.bootstrap/v1', 'urn:omk:parameters:bootstrap:v1', jsonSchema(BootstrapParametersSchema),
+);
+const HIERARCHICAL_BOOTSTRAP_PARAMETERS_SCHEMA = schemaIdentity(
+  'omk.parameters.hierarchical-measurement-bootstrap/v1',
+  'urn:omk:parameters:hierarchical-measurement-bootstrap:v1',
+  jsonSchema(HierarchicalBootstrapParametersSchema, [
+    'replicate indexes are unique and contiguous from zero within each member',
+    'evaluator IDs and member IDs are unique, with members and replicates canonically ordered',
+    'all panel coordinates use one instrument and one replicate group',
+    'weighted-mean member weights are positive and sum to one',
+    'a target/sample/trial contributes only when every sealed coordinate is observed',
+  ]),
 );
 const BONFERRONI_PARAMETERS_SCHEMA = schemaIdentity(
   'omk.parameters.bonferroni/v1', 'urn:omk:parameters:bonferroni:v1', jsonSchema(BonferroniParametersSchema),
@@ -488,6 +570,152 @@ interface BootstrapUnit {
   stratumId?: string;
 }
 
+type MeasurementAggregation = z.infer<typeof MeasurementAggregationSchema>;
+
+interface AggregatedMeasurementUnit extends BootstrapUnit {
+  targetId: string;
+  sampleId: string;
+  pairingBlockId?: string;
+  rowIds: Sha256Digest[];
+}
+
+function metricInput(context: AnalysisNodeExecutionContext): Extract<
+  AnalysisNodeInput,
+  { inputKind: 'metric-observations' }
+> {
+  const inputs = metricInputs(context);
+  if (inputs.length !== 1) {
+    throw new TypeError('Built-in Analysis implementations require exactly one Metric input.');
+  }
+  return inputs[0];
+}
+
+function singleOptionalCoordinate<T>(
+  rows: readonly T[],
+  select: (row: T) => string | undefined,
+  label: string,
+): string | undefined {
+  const values = new Set(rows.map(select));
+  if (values.size > 1) throw new TypeError(`One measurement unit cannot cross ${label}.`);
+  return select(rows[0]);
+}
+
+function aggregateMeasurementUnits(
+  context: AnalysisNodeExecutionContext,
+): AggregatedMeasurementUnit[] {
+  const input = metricInput(context);
+  const aggregation = MeasurementAggregationSchema.parse(
+    parameters(context).measurementAggregation,
+  ) as MeasurementAggregation;
+  const expected = new Map<string, Readonly<{
+    ensembleMemberId: string;
+    instrumentId: string;
+    replicateIndex: number;
+  }>>();
+  for (const member of aggregation.members) {
+    for (const replicate of member.replicates) {
+      expected.set(replicate.evaluatorId, {
+        ensembleMemberId: member.ensembleMemberId,
+        instrumentId: replicate.instrumentId,
+        replicateIndex: replicate.replicateIndex,
+      });
+    }
+  }
+  for (const row of input.rows) {
+    const coordinate = expected.get(row.evaluatorId);
+    if (coordinate === undefined
+        || row.measurement.instrumentId !== coordinate.instrumentId
+        || row.measurement.ensembleMemberId !== coordinate.ensembleMemberId
+        || row.measurement.replicateGroupId !== aggregation.replicateGroupId
+        || row.measurement.replicateIndex !== coordinate.replicateIndex) {
+      throw new TypeError('Measurement row differs from the sealed panel coordinates.');
+    }
+  }
+  const trials = groupRows(input.rows, (row) => canonicalizeJson([
+    row.targetId,
+    row.sampleId,
+    row.trialIndex,
+  ]));
+  const completeTrials: Array<AggregatedMeasurementUnit & { trialIndex: number }> = [];
+  for (const rows of trials.values()) {
+    const byEvaluator = new Map<string, AnalysisMetricRow>();
+    for (const row of rows) {
+      if (byEvaluator.has(row.evaluatorId)) {
+        throw new TypeError('Measurement trial contains a duplicate evaluator coordinate.');
+      }
+      byEvaluator.set(row.evaluatorId, row);
+    }
+    if (byEvaluator.size !== expected.size
+        || [...expected.keys()].some((evaluatorId) => !byEvaluator.has(evaluatorId))) {
+      throw new TypeError('Measurement trial is missing a sealed evaluator coordinate.');
+    }
+    if (rows.some((row) => row.rowStatus !== 'observed')) continue;
+    const memberValues = aggregation.members.map((member) => {
+      const values = member.replicates.map((replicate) => numericValue(
+        byEvaluator.get(replicate.evaluatorId)!,
+      ));
+      return {
+        value: mean(values),
+        weight: 'weight' in member ? member.weight : 1,
+      };
+    });
+    const value = aggregation.method === 'weighted-mean'
+      ? memberValues.reduce((sum, member) => sum + member.value * member.weight, 0)
+      : mean(memberValues.map((member) => member.value));
+    completeTrials.push({
+      targetId: rows[0].targetId,
+      sampleId: rows[0].sampleId,
+      trialIndex: rows[0].trialIndex,
+      value,
+      rowIds: rows.map((row) => row.rowId),
+      ...(singleOptionalCoordinate(
+        rows,
+        (row) => row.samplingUnitIds.stratumId,
+        'strata',
+      ) === undefined ? {} : {
+        stratumId: rows[0].samplingUnitIds.stratumId,
+      }),
+      ...(singleOptionalCoordinate(
+        rows,
+        (row) => row.samplingUnitIds.pairingBlockId,
+        'pairing blocks',
+      ) === undefined ? {} : {
+        pairingBlockId: rows[0].samplingUnitIds.pairingBlockId,
+      }),
+    });
+  }
+  return [...groupRows(completeTrials, (trial) => (
+    canonicalizeJson([trial.targetId, trial.sampleId])
+  )).values()].map((group) => {
+    const trialsForSample = group;
+    const targetId = trialsForSample[0].targetId;
+    const sampleId = trialsForSample[0].sampleId;
+    if (trialsForSample.some((trial) => (
+      trial.targetId !== targetId || trial.sampleId !== sampleId
+    ))) {
+      throw new TypeError('One sample measurement unit cannot cross target or sample identity.');
+    }
+    const stratumId = singleOptionalCoordinate(
+      trialsForSample,
+      (trial) => trial.stratumId,
+      'strata',
+    );
+    const pairingBlockId = singleOptionalCoordinate(
+      trialsForSample,
+      (trial) => trial.pairingBlockId,
+      'pairing blocks',
+    );
+    return {
+      targetId,
+      sampleId,
+      value: mean(trialsForSample.map((trial) => trial.value)),
+      rowIds: trialsForSample.flatMap((trial) => trial.rowIds),
+      ...(stratumId === undefined ? {} : { stratumId }),
+      ...(pairingBlockId === undefined ? {} : { pairingBlockId }),
+    };
+  });
+}
+
 function percentileInterval(
   context: AnalysisNodeExecutionContext,
   units: readonly BootstrapUnit[],
@@ -542,11 +770,11 @@ function percentileInterval(
   };
 }
 
-function groupRows(
-  rows: readonly AnalysisMetricRow[],
-  key: (row: AnalysisMetricRow) => string | undefined,
-): Map<string, AnalysisMetricRow[]> {
-  const groups = new Map<string, AnalysisMetricRow[]>();
+function groupRows<T>(
+  rows: readonly T[],
+  key: (row: T) => string | undefined,
+): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
   for (const row of rows) {
     const groupId = key(row);
     if (groupId === undefined) continue;
@@ -641,6 +869,60 @@ function executePairedBootstrap(context: AnalysisNodeExecutionContext): Analysis
   } : interval;
 }
 
+function executeHierarchicalMeanBootstrap(
+  context: AnalysisNodeExecutionContext,
+): AnalysisNodeExecutionResult {
+  const units = aggregateMeasurementUnits(context);
+  const interval = percentileInterval(context, units);
+  return interval.analysisStatus === 'completed' ? {
+    ...interval,
+    includedRowIds: units.flatMap((unit) => unit.rowIds),
+    comparableRowIds: units.flatMap((unit) => unit.rowIds),
+  } : interval;
+}
+
+function executeHierarchicalPairedBootstrap(
+  context: AnalysisNodeExecutionContext,
+): AnalysisNodeExecutionResult {
+  const comparisonInputs = context.inputs.filter(
+    (input): input is Extract<AnalysisNodeInput, { inputKind: 'comparison' }> => (
+      input.inputKind === 'comparison'
+    ),
+  );
+  if (comparisonInputs.length !== 1) {
+    throw new TypeError('Hierarchical paired bootstrap requires exactly one Comparison contrast.');
+  }
+  const comparisonInput = comparisonInputs[0];
+  const input = metricInput(context);
+  if (comparisonInput.contrast.metricId !== input.referenceId) {
+    return incomplete('analysis-paired-bootstrap-requires-one-matching-metric');
+  }
+  const controlId = comparisonInput.contrast.controlTargetId;
+  const treatmentId = comparisonInput.contrast.treatmentTargetId;
+  const units = aggregateMeasurementUnits(context);
+  const groups = groupRows(units, (unit) => unit.pairingBlockId);
+  const differences: BootstrapUnit[] = [];
+  const includedUnits: AggregatedMeasurementUnit[] = [];
+  for (const group of groups.values()) {
+    const control = group.filter((unit) => unit.targetId === controlId);
+    const treatment = group.filter((unit) => unit.targetId === treatmentId);
+    if (control.length === 0 || treatment.length === 0) continue;
+    const stratumId = singleOptionalCoordinate(group, (unit) => unit.stratumId, 'strata');
+    differences.push({
+      value: mean(treatment.map((unit) => unit.value))
+        - mean(control.map((unit) => unit.value)),
+      ...(stratumId === undefined ? {} : { stratumId }),
+    });
+    includedUnits.push(...control, ...treatment);
+  }
+  const interval = percentileInterval(context, differences);
+  return interval.analysisStatus === 'completed' ? {
+    ...interval,
+    includedRowIds: includedUnits.flatMap((unit) => unit.rowIds),
+    comparableRowIds: includedUnits.flatMap((unit) => unit.rowIds),
+  } : interval;
+}
+
 function bootstrapArmStratumMean(
   seed: Sha256Digest,
   armId: string,
@@ -659,7 +941,11 @@ function bootstrapArmStratumMean(
   )));
 }
 
-function executeUnpairedBootstrap(context: AnalysisNodeExecutionContext): AnalysisNodeExecutionResult {
+function executeUnpairedBootstrapWithUnits(
+  context: AnalysisNodeExecutionContext,
+  units: readonly AggregatedMeasurementUnit[],
+  plannedRows: readonly AnalysisMetricRow[],
+): AnalysisNodeExecutionResult {
   const comparisonInputs = context.inputs.filter(
     (input): input is Extract<AnalysisNodeInput, { inputKind: 'comparison' }> => (
       input.inputKind === 'comparison'
@@ -675,16 +961,12 @@ function executeUnpairedBootstrap(context: AnalysisNodeExecutionContext): Analys
   }
   const controlId = comparisonInput.contrast.controlTargetId;
   const treatmentId = comparisonInput.contrast.treatmentTargetId;
-  const plannedRows = metricInput.rows;
-  const rows = observedRows(context);
-  const controlRows = rows.filter((row) => row.targetId === controlId);
-  const treatmentRows = rows.filter((row) => row.targetId === treatmentId);
-  const controlSampleIds = new Set(controlRows.map((row) => row.sampleId));
-  if (treatmentRows.some((row) => controlSampleIds.has(row.sampleId))) {
+  const controlUnits = units.filter((unit) => unit.targetId === controlId);
+  const treatmentUnits = units.filter((unit) => unit.targetId === treatmentId);
+  const controlSampleIds = new Set(controlUnits.map((unit) => unit.sampleId));
+  if (treatmentUnits.some((unit) => controlSampleIds.has(unit.sampleId))) {
     return incomplete('analysis-unpaired-bootstrap-overlapping-units');
   }
-  const controlUnits = [...groupRows(controlRows, (row) => row.sampleId).values()].map(groupUnit);
-  const treatmentUnits = [...groupRows(treatmentRows, (row) => row.sampleId).values()].map(groupUnit);
   if (controlUnits.length < 2 || treatmentUnits.length < 2) {
     return incomplete('analysis-insufficient-resampling-units-per-arm');
   }
@@ -755,7 +1037,7 @@ function executeUnpairedBootstrap(context: AnalysisNodeExecutionContext): Analys
       units,
     ),
   )).sort((left, right) => left - right);
-  const includedRows = [...controlRows, ...treatmentRows];
+  const includedRowIds = [...controlUnits, ...treatmentUnits].flatMap((unit) => unit.rowIds);
   return {
     analysisStatus: 'completed',
     resultType: 'interval',
@@ -770,10 +1052,40 @@ function executeUnpairedBootstrap(context: AnalysisNodeExecutionContext): Analys
       unitCount: controlUnits.length + treatmentUnits.length,
       method: 'percentile',
     },
-    includedRowIds: includedRows.map((row) => row.rowId),
-    comparableRowIds: includedRows.map((row) => row.rowId),
+    includedRowIds,
+    comparableRowIds: includedRowIds,
     assumptionChecks: passedAssumption('independent-non-overlapping-samples'),
   };
+}
+
+function executeUnpairedBootstrap(context: AnalysisNodeExecutionContext): AnalysisNodeExecutionResult {
+  const input = metricInput(context);
+  const rows = observedRows(context);
+  const units = [...groupRows(rows, (row) => canonicalizeJson([
+    row.targetId,
+    row.sampleId,
+  ])).values()].map((group): AggregatedMeasurementUnit => {
+    const unit = groupUnit(group);
+    return {
+      targetId: group[0].targetId,
+      sampleId: group[0].sampleId,
+      value: unit.value,
+      rowIds: group.map((row) => row.rowId),
+      ...(unit.stratumId === undefined ? {} : { stratumId: unit.stratumId }),
+    };
+  });
+  return executeUnpairedBootstrapWithUnits(context, units, input.rows);
+}
+
+function executeHierarchicalUnpairedBootstrap(
+  context: AnalysisNodeExecutionContext,
+): AnalysisNodeExecutionResult {
+  const input = metricInput(context);
+  return executeUnpairedBootstrapWithUnits(
+    context,
+    aggregateMeasurementUnits(context),
+    input.rows,
+  );
 }
 
 interface Hypothesis {
@@ -951,6 +1263,65 @@ register(
   executeUnpairedBootstrap,
 );
 register(
+  'bootstrap.hierarchical-mean-percentile/v1',
+  nodeCapabilities({
+    analysisNodeKind: 'estimator',
+    valueTypes: ['numeric', 'boolean'],
+    missingPolicyIds: ['exclude/v1'],
+    outputSchema: BUILTIN_INTERVAL_RESULT_SCHEMA,
+    parameterSchema: HIERARCHICAL_BOOTSTRAP_PARAMETERS_SCHEMA,
+    sampling: {
+      assignmentKinds: ['complete-block'],
+      experimentalUnits: ['sample'],
+      repeatedMeasures: [false, true],
+      resamplingUnits: ['sample'],
+    },
+  }),
+  BUILTIN_INTERVAL_RESULT_SCHEMA,
+  HIERARCHICAL_BOOTSTRAP_PARAMETERS_SCHEMA,
+  executeHierarchicalMeanBootstrap,
+);
+register(
+  'bootstrap.hierarchical-paired-difference-percentile/v1',
+  nodeCapabilities({
+    analysisNodeKind: 'estimator',
+    valueTypes: ['numeric', 'boolean'],
+    missingPolicyIds: ['exclude/v1'],
+    comparison: true,
+    outputSchema: BUILTIN_INTERVAL_RESULT_SCHEMA,
+    parameterSchema: HIERARCHICAL_BOOTSTRAP_PARAMETERS_SCHEMA,
+    sampling: {
+      assignmentKinds: ['complete-block'],
+      experimentalUnits: ['sample'],
+      repeatedMeasures: [false, true],
+      resamplingUnits: ['paired-block'],
+    },
+  }),
+  BUILTIN_INTERVAL_RESULT_SCHEMA,
+  HIERARCHICAL_BOOTSTRAP_PARAMETERS_SCHEMA,
+  executeHierarchicalPairedBootstrap,
+);
+register(
+  'bootstrap.hierarchical-unpaired-difference-percentile/v1',
+  nodeCapabilities({
+    analysisNodeKind: 'estimator',
+    valueTypes: ['numeric', 'boolean'],
+    missingPolicyIds: ['exclude/v1'],
+    comparison: true,
+    outputSchema: BUILTIN_INTERVAL_RESULT_SCHEMA,
+    parameterSchema: HIERARCHICAL_BOOTSTRAP_PARAMETERS_SCHEMA,
+    sampling: {
+      assignmentKinds: ['independent-groups'],
+      experimentalUnits: ['sample'],
+      repeatedMeasures: [false, true],
+      resamplingUnits: ['sample'],
+    },
+  }),
+  BUILTIN_INTERVAL_RESULT_SCHEMA,
+  HIERARCHICAL_BOOTSTRAP_PARAMETERS_SCHEMA,
+  executeHierarchicalUnpairedBootstrap,
+);
+register(
   'bootstrap.cluster-percentile/v1',
   nodeCapabilities({
     analysisNodeKind: 'estimator',
@@ -1042,7 +1413,11 @@ function validateIntervalContext(
   value: JsonValue,
   context?: Readonly<CoreSchemaValidationContext>,
 ): void {
-  const sealed = BootstrapParametersSchema.parse(requireAnalysisOutputContext(context).parameters);
+  const rawParameters = requireAnalysisOutputContext(context).parameters;
+  const sealed = rawParameters !== null && typeof rawParameters === 'object'
+    && !Array.isArray(rawParameters) && 'measurementAggregation' in rawParameters
+    ? HierarchicalBootstrapParametersSchema.parse(rawParameters)
+    : BootstrapParametersSchema.parse(rawParameters);
   const envelope = IntervalEnvelopeSchema.parse(value);
   if (envelope.value.resamples !== sealed.resamples
       || envelope.value.confidenceLevel !== 1 - sealed.alpha
@@ -1208,6 +1583,7 @@ export function createBuiltinAnalysisSchemaValidators(): ReadonlyMap<string, Cor
     [EMPTY_PARAMETERS_SCHEMA, StrictEmptyParametersSchema],
     [QUANTILE_PARAMETERS_SCHEMA, QuantileParametersSchema],
     [BOOTSTRAP_PARAMETERS_SCHEMA, BootstrapParametersSchema],
+    [HIERARCHICAL_BOOTSTRAP_PARAMETERS_SCHEMA, HierarchicalBootstrapParametersSchema],
     [BONFERRONI_PARAMETERS_SCHEMA, BonferroniParametersSchema],
     [PROGRESS_PARAMETERS_SCHEMA, ProgressParametersSchema],
   ];

--- a/test/eval-core/analysis/builtins.test.ts
+++ b/test/eval-core/analysis/builtins.test.ts
@@ -14,6 +14,7 @@ import {
   countAnalysisResamplingUnits,
   digestCanonicalJson,
   schemaIdentityKey,
+  type JsonValue,
   type Sha256Digest,
 } from '../../../src/eval-core/contracts/index.js';
 
@@ -22,25 +23,31 @@ function row(input: {
   targetId?: string;
   trialIndex?: number;
   value: number;
+  evaluatorId?: string;
+  instrumentId?: string;
+  ensembleMemberId?: string;
+  replicateGroupId?: string;
+  replicateIndex?: number;
   pairingBlockId?: Sha256Digest;
   clusterId?: Sha256Digest;
   stratumId?: Sha256Digest;
 }): AnalysisMetricRow {
   const targetId = input.targetId ?? 'target';
   const trialIndex = input.trialIndex ?? 0;
+  const evaluatorId = input.evaluatorId ?? 'score-evaluator';
   const trialId = digestCanonicalJson({ targetId, sampleId: input.sampleId, trialIndex });
   return {
-    rowId: digestCanonicalJson({ trialId, metricId: 'score' }),
+    rowId: digestCanonicalJson({ trialId, metricId: 'score', evaluatorId }),
     targetId,
     sampleId: input.sampleId,
     trialIndex,
     trialId,
-    evaluatorId: 'score-evaluator',
+    evaluatorId,
     measurement: {
-      instrumentId: 'score-instrument',
-      ensembleMemberId: 'score-member',
-      replicateGroupId: 'score-primary',
-      replicateIndex: 0,
+      instrumentId: input.instrumentId ?? 'score-instrument',
+      ensembleMemberId: input.ensembleMemberId ?? 'score-member',
+      replicateGroupId: input.replicateGroupId ?? 'score-primary',
+      replicateIndex: input.replicateIndex ?? 0,
     },
     cohortIds: [],
     metricId: 'score',
@@ -70,6 +77,7 @@ function context(input: {
   rows: AnalysisMetricRow[];
   resamplingUnit: 'sample' | 'paired-block' | 'cluster' | 'run';
   comparison?: boolean;
+  parameters?: JsonValue;
 }): AnalysisNodeExecutionContext {
   return {
     node: {
@@ -88,7 +96,7 @@ function context(input: {
           : []),
       ],
       outputResultId: 'estimate-result',
-      parameters: { resamples: 64, alpha: 0.1 },
+      parameters: input.parameters ?? { resamples: 64, alpha: 0.1 },
     },
     inputs: [{
       inputKind: 'metric-observations',
@@ -127,6 +135,60 @@ function context(input: {
     signal: new AbortController().signal,
   };
 }
+
+const panelAggregation = {
+  method: 'weighted-mean',
+  missing: 'require-complete',
+  replicateGroupId: 'quality-panel',
+  members: [{
+    ensembleMemberId: 'judge-a',
+    weight: 0.25,
+    replicates: [0, 1].map((replicateIndex) => ({
+      evaluatorId: `quality-panel/judge-a/replicate-${replicateIndex}`,
+      instrumentId: 'quality-rubric-v1',
+      replicateIndex,
+    })),
+  }, {
+    ensembleMemberId: 'judge-b',
+    weight: 0.75,
+    replicates: [0, 1].map((replicateIndex) => ({
+      evaluatorId: `quality-panel/judge-b/replicate-${replicateIndex}`,
+      instrumentId: 'quality-rubric-v1',
+      replicateIndex,
+    })),
+  }],
+} as const;
+
+function panelRows(input: {
+  sampleId: string;
+  targetId?: string;
+  trialIndex?: number;
+  values: readonly [number, number, number, number];
+  pairingBlockId?: Sha256Digest;
+  stratumId?: Sha256Digest;
+}): AnalysisMetricRow[] {
+  return panelAggregation.members.flatMap((member, memberIndex) => (
+    member.replicates.map((replicate, replicateIndex) => row({
+      sampleId: input.sampleId,
+      ...(input.targetId === undefined ? {} : { targetId: input.targetId }),
+      ...(input.trialIndex === undefined ? {} : { trialIndex: input.trialIndex }),
+      value: input.values[memberIndex * 2 + replicateIndex],
+      evaluatorId: replicate.evaluatorId,
+      instrumentId: replicate.instrumentId,
+      ensembleMemberId: member.ensembleMemberId,
+      replicateGroupId: panelAggregation.replicateGroupId,
+      replicateIndex: replicate.replicateIndex,
+      ...(input.pairingBlockId === undefined ? {} : { pairingBlockId: input.pairingBlockId }),
+      ...(input.stratumId === undefined ? {} : { stratumId: input.stratumId }),
+    }))
+  ));
+}
+
+const panelParameters = {
+  resamples: 64,
+  alpha: 0.1,
+  measurementAggregation: panelAggregation,
+} as unknown as JsonValue;
 
 async function execute(input: AnalysisNodeExecutionContext) {
   const implementation = createBuiltinAnalysisNodes().get(input.node.implementationId);
@@ -289,6 +351,165 @@ describe('Evaluation Core built-in estimators', () => {
     expect(first).toMatchObject({
       analysisStatus: 'completed',
       value: { estimate: 0.75, unitCount: 2, resamples: 64 },
+    });
+  });
+
+  it('aggregates replicate, member, trial, and sample levels without inflating unitCount', async () => {
+    const rows = [
+      ...panelRows({ sampleId: 's1', trialIndex: 0, values: [1, 3, 5, 5] }),
+      ...panelRows({ sampleId: 's1', trialIndex: 1, values: [2, 4, 6, 6] }),
+      ...panelRows({ sampleId: 's2', trialIndex: 0, values: [1, 1, 1, 1] }),
+      ...panelRows({ sampleId: 's2', trialIndex: 1, values: [1, 1, 1, 1] }),
+    ];
+    const result = await execute(context({
+      implementationId: 'bootstrap.hierarchical-mean-percentile/v1',
+      resamplingUnit: 'sample',
+      rows,
+      parameters: panelParameters,
+    }));
+
+    expect(result).toMatchObject({
+      analysisStatus: 'completed',
+      value: { estimate: 2.875, unitCount: 2 },
+    });
+    expect(result.includedRowIds).toHaveLength(16);
+  });
+
+  it('fails a panel trial closed when one sealed replicate is unavailable', async () => {
+    const complete = panelRows({ sampleId: 's1', values: [1, 3, 5, 5] });
+    const incompleteTrial = panelRows({
+      sampleId: 's1', trialIndex: 1, values: [100, 100, 100, 100],
+    });
+    incompleteTrial[3] = missingRow({
+      sampleId: 's1',
+      trialIndex: 1,
+      value: 100,
+      evaluatorId: 'quality-panel/judge-b/replicate-1',
+      instrumentId: 'quality-rubric-v1',
+      ensembleMemberId: 'judge-b',
+      replicateGroupId: 'quality-panel',
+      replicateIndex: 1,
+    });
+    const result = await execute(context({
+      implementationId: 'bootstrap.hierarchical-mean-percentile/v1',
+      resamplingUnit: 'sample',
+      rows: [
+        ...complete,
+        ...incompleteTrial,
+        ...panelRows({ sampleId: 's2', values: [1, 1, 1, 1] }),
+      ],
+      parameters: panelParameters,
+    }));
+
+    expect(result).toMatchObject({
+      analysisStatus: 'completed',
+      value: { estimate: 2.625, unitCount: 2 },
+    });
+    expect(result.includedRowIds).toHaveLength(8);
+    expect(result.includedRowIds).not.toContain(incompleteTrial[0].rowId);
+  });
+
+  it('keeps a one-member one-replicate panel mathematically equivalent to v1', async () => {
+    const rows = [
+      row({ sampleId: 's1', value: 1 }),
+      row({ sampleId: 's2', value: 1 }),
+    ];
+    const legacy = await execute(context({
+      implementationId: 'bootstrap.mean-percentile/v1',
+      resamplingUnit: 'sample',
+      rows,
+    }));
+    const hierarchical = await execute(context({
+      implementationId: 'bootstrap.hierarchical-mean-percentile/v1',
+      resamplingUnit: 'sample',
+      rows,
+      parameters: {
+        resamples: 64,
+        alpha: 0.1,
+        measurementAggregation: {
+          method: 'mean',
+          missing: 'require-complete',
+          replicateGroupId: 'score-primary',
+          members: [{
+            ensembleMemberId: 'score-member',
+            replicates: [{
+              evaluatorId: 'score-evaluator',
+              instrumentId: 'score-instrument',
+              replicateIndex: 0,
+            }],
+          }],
+        },
+      },
+    }));
+
+    expect(hierarchical).toEqual(legacy);
+  });
+
+  it('rejects rows that differ from sealed panel coordinates', async () => {
+    const rows = panelRows({ sampleId: 's1', values: [1, 1, 1, 1] });
+    rows[0] = row({
+      sampleId: 's1',
+      value: 1,
+      evaluatorId: 'unexpected-evaluator',
+      instrumentId: 'quality-rubric-v1',
+      ensembleMemberId: 'judge-a',
+      replicateGroupId: 'quality-panel',
+      replicateIndex: 0,
+    });
+    await expect(execute(context({
+      implementationId: 'bootstrap.hierarchical-mean-percentile/v1',
+      resamplingUnit: 'sample',
+      rows,
+      parameters: panelParameters,
+    }))).rejects.toThrow(/sealed panel coordinates/);
+
+    const nonCanonical = structuredClone(panelParameters) as {
+      measurementAggregation: { members: unknown[] };
+    };
+    nonCanonical.measurementAggregation.members.reverse();
+    await expect(execute(context({
+      implementationId: 'bootstrap.hierarchical-mean-percentile/v1',
+      resamplingUnit: 'sample',
+      rows: panelRows({ sampleId: 's1', values: [1, 1, 1, 1] }),
+      parameters: nonCanonical as unknown as JsonValue,
+    }))).rejects.toThrow(/ordered by ensembleMemberId/);
+  });
+
+  it('uses complete hierarchical panel units for paired and independent contrasts', async () => {
+    const pair1 = digestCanonicalJson({ panelPair: 1 });
+    const pair2 = digestCanonicalJson({ panelPair: 2 });
+    const paired = await execute(context({
+      implementationId: 'bootstrap.hierarchical-paired-difference-percentile/v1',
+      resamplingUnit: 'paired-block',
+      comparison: true,
+      rows: [
+        ...panelRows({ sampleId: 's1', targetId: 'control', values: [1, 1, 1, 1], pairingBlockId: pair1 }),
+        ...panelRows({ sampleId: 's1', targetId: 'treatment', values: [3, 3, 3, 3], pairingBlockId: pair1 }),
+        ...panelRows({ sampleId: 's2', targetId: 'control', values: [2, 2, 2, 2], pairingBlockId: pair2 }),
+        ...panelRows({ sampleId: 's2', targetId: 'treatment', values: [5, 5, 5, 5], pairingBlockId: pair2 }),
+      ],
+      parameters: panelParameters,
+    }));
+    expect(paired).toMatchObject({
+      analysisStatus: 'completed',
+      value: { estimate: 2.5, unitCount: 2 },
+    });
+
+    const independent = await execute(context({
+      implementationId: 'bootstrap.hierarchical-unpaired-difference-percentile/v1',
+      resamplingUnit: 'sample',
+      comparison: true,
+      rows: [
+        ...panelRows({ sampleId: 'c1', targetId: 'control', values: [1, 1, 1, 1] }),
+        ...panelRows({ sampleId: 'c2', targetId: 'control', values: [3, 3, 3, 3] }),
+        ...panelRows({ sampleId: 't1', targetId: 'treatment', values: [4, 4, 4, 4] }),
+        ...panelRows({ sampleId: 't2', targetId: 'treatment', values: [6, 6, 6, 6] }),
+      ],
+      parameters: panelParameters,
+    }));
+    expect(independent).toMatchObject({
+      analysisStatus: 'completed',
+      value: { estimate: 3, unitCount: 4 },
     });
   });
 


### PR DESCRIPTION
## 用户影响

Evaluation Core 新增版本化的分层测量 Bootstrap estimator。它按 evaluator replicate、ensemble member、Target trial、sample／paired block 的顺序归约数据，并把完整 panel 坐标封存在 Analysis 参数中。任一计划坐标不可用时，对应 trial 会失败关闭；member 与 replicate 不会被误算为独立统计样本。

这是 #688 的 Core 前置部分；后续 Runtime PR 会把 canonical `evaluate()` 的 Rubric 评委输入接到该能力。

## BREAKING-COMPARABILITY

既有非分层 v1 estimator 保持原义，新能力使用独立 implementation 与 parameter schema identity，不会静默改变历史估计口径。使用新 estimator 的 AnalysisPlan 与旧计划明确不可比较。

## 测量学说明

等权或显式加权聚合只能降低对单一评委读数的依赖，不代表不同评委误差相互独立，也不会提高 Bootstrap `unitCount`。它不能替代 Gold calibration。

## 自主 CR

No findings。已从 Core／宿主依赖、封存坐标、缺失语义、重采样单位、schema identity、paired／independent strata 和 hermetic 状态边界完成 fresh-pass；最终提交在隔离 worktree 中通过完整门禁。

Part of #688
Refs #667
