### PR TITLE
feat(eval-core): 增加显式跨指标 composite 分析

### DIFF
--- a/docs/specs/eval-core-vnext.md
+++ b/docs/specs/eval-core-vnext.md
@@ -318,6 +318,8 @@ The built-in reducer and estimator set remains deliberately small:
 - `bootstrap.hierarchical-unpaired-difference-percentile/v1`;
 - `bootstrap.cluster-percentile/v1`;
 - `bootstrap.hierarchical-cluster-percentile/v1`;
+- `bootstrap.composite-mean-percentile/v1` and `bootstrap.composite-cluster-percentile/v1`;
+- `bootstrap.composite-paired-difference-percentile/v1` and `bootstrap.composite-unpaired-difference-percentile/v1`;
 - `bonferroni/v1` for correction of genuine raw p-values;
 - `simultaneous-intervals.bonferroni/v1` for Bonferroni simultaneous percentile intervals;
 - `release-family/v1` for explicit all-member release decisions over those intervals.
@@ -327,6 +329,8 @@ Alpha, resample count, resampling unit, and seed enter AnalysisPlan. v1 does not
 The unpaired estimator requires disjoint sample identities between the declared control and treatment arms and independently resamples each arm. For stratified inputs, it resamples within arm × stratum cells and combines within-stratum differences using pooled observed stratum proportions. A missing arm in any observed stratum makes the result inconclusive; the estimator never falls back to a paired or unstratified analysis.
 
 The hierarchical estimators seal one complete measurement panel in their parameters. They average evaluator replicates within each ensemble member, apply the declared equal or positive normalized member weights, and then average complete Target trials within each sample. A trial contributes only when every sealed evaluator, instrument, member, group, and replicate coordinate is observed. Bootstrap still resamples only samples or paired blocks; panel members and replicates never increase `unitCount`. The non-hierarchical estimator identities keep their original semantics.
+
+The composite estimators derive one explicitly named sample-scope utility Metric from at least two source Metrics. Every positive component weight is sealed and the weights sum exactly to one; there is no default component set or equal-weight fallback. Boolean values map to unit utility directly, while numeric sources require a finite non-degenerate sealed range; `lower-is-better` reverses the utility and out-of-range evidence fails closed rather than being clamped. Qualitative and target-optimum Metrics are not accepted by v1. A quality estimator seals exactly one Variant through its Target filter; a difference estimator seals its two Variants through the contrast and accepts no additional Target filter. Each source Metric first applies its own sealed measurement-panel aggregation, then complete source values are combined within the same Target／sample／trial coordinate, repeated trials are averaged within a sample, and only then does Core resample samples, clusters, paired blocks, or independent arms. Missing components never renormalize the remaining weights. The Analysis record retains contributing source-row lineage and reports planned, complete, and missing composite coordinates in its assumption evidence. The derived Metric, source contracts, weights, confidence parameters, and sampling design all remain part of the sealed Definition and Plan identity.
 
 Re-analysis and re-decision preserve parent Bundle digest, policy digest, derivation time, and `analysisMode: preregistered | exploratory`. Thresholds or methods chosen after observing results cannot masquerade as pre-sealed release gates.
 

--- a/docs/zh/specs/eval-core-vnext.md
+++ b/docs/zh/specs/eval-core-vnext.md
@@ -318,6 +318,8 @@ DecisionPolicy 的每个 comparison family member 都声明 `(comparisonId, trea
 - `bootstrap.hierarchical-unpaired-difference-percentile/v1`；
 - `bootstrap.cluster-percentile/v1`；
 - `bootstrap.hierarchical-cluster-percentile/v1`；
+- `bootstrap.composite-mean-percentile/v1` 与 `bootstrap.composite-cluster-percentile/v1`；
+- `bootstrap.composite-paired-difference-percentile/v1` 与 `bootstrap.composite-unpaired-difference-percentile/v1`；
 - 校正真实 raw p-value 的 `bonferroni/v1`；
 - 聚合 Bonferroni 同时 percentile interval 的 `simultaneous-intervals.bonferroni/v1`；
 - 基于上述区间执行显式全成员发布决策的 `release-family/v1`。
@@ -327,6 +329,8 @@ alpha、重采样次数、resampling unit 和 seed 都进入 AnalysisPlan。v1 �
 非配对 estimator 要求声明的 control 与 treatment 臂使用互不重叠的 sample identity，并对两臂独立重采样。存在 stratum 时，它在 arm × stratum 单元内重采样，再按计划总体的 stratum 比例组合组内差值；任一已观察 stratum 缺少一侧臂时结果为 inconclusive，绝不自动退化成 paired 或 unstratified analysis。
 
 分层 estimator 会在参数中封存完整 measurement panel：先在每个 ensemble member 内平均 evaluator replicate，再执行已声明的成员等权或正数归一化权重聚合，最后在每个 sample 内平均完整的 Target trial。只有所有已封存 evaluator、instrument、member、group 与 replicate 坐标都已观察时，trial 才能进入分析。Bootstrap 仍只重采样 sample 或 paired block；panel member 与 replicate 永远不增加 `unitCount`。非分层 estimator identity 保持原有语义。
+
+Composite estimator 会从至少两个 source Metric 派生一项显式命名的 sample-scope utility Metric。每个 component 的正权重都要封存，且权重和严格为一；不存在默认 component 集合或默认等权回退。Boolean 值直接映射为单位 utility，numeric source 必须声明有限且非退化的 sealed range；`lower-is-better` 会反转 utility，越界证据失败关闭而不做 clamp。v1 不接受定性 Metric 或 target optimum。Quality estimator 必须通过 Target filter 精确封存一个 Variant；difference estimator 通过 contrast 封存两个 Variant，不接受额外 Target filter。每项 source Metric 先执行自身封存的 measurement-panel aggregation，再在同一 Target／sample／trial 坐标内合并完整 source value，然后在 sample 内平均重复 trial，最后才由 Core 对 sample、cluster、paired block 或 independent arm 重采样。Component 缺失时绝不重新归一化剩余权重。Analysis record 保留参与计算的 source-row lineage，并在 assumption evidence 中报告计划、完整与缺失 composite coordinate 数。Derived Metric、source contract、权重、置信度参数和 sampling design 都属于封存的 Definition 与 Plan identity。
 
 重新分析和重新决策保留 parent bundle digest、policy digest、生成时间以及 `analysisMode: preregistered | exploratory`。执行后修改的阈值或方法不能冒充预先封存的发布门槛。
 

--- a/src/eval-core/analysis/builtins.ts
+++ b/src/eval-core/analysis/builtins.ts
@@ -120,6 +120,45 @@ const HierarchicalQuantileParametersSchema = z.object({
   probability: ProbabilitySchema,
   measurementAggregation: MeasurementAggregationSchema,
 }).strict();
+const CompositeComponentSchema = z.object({
+  metricId: z.string().min(1).max(256),
+  weight: FiniteNumberSchema.positive(),
+  measurementAggregation: MeasurementAggregationSchema.optional(),
+}).strict();
+const CompositeBootstrapParametersSchema = z.object({
+  compositeMetricId: z.string().min(1).max(256),
+  components: z.array(CompositeComponentSchema).min(2),
+  aggregation: z.object({
+    method: z.literal('weighted-mean'),
+    missing: z.literal('require-complete'),
+  }).strict(),
+  resamples: z.number().int().positive().safe().default(1_000),
+  alpha: FiniteNumberSchema.gt(0).lt(1).default(0.05),
+}).strict().superRefine((parameters, context) => {
+  const metricIds = parameters.components.map((component) => component.metricId);
+  if (new Set(metricIds).size !== metricIds.length) {
+    context.addIssue({
+      code: 'custom',
+      path: ['components'],
+      message: 'Composite component Metric IDs must be unique',
+    });
+  }
+  if (metricIds.includes(parameters.compositeMetricId)) {
+    context.addIssue({
+      code: 'custom',
+      path: ['compositeMetricId'],
+      message: 'Composite Metric cannot also be a source component',
+    });
+  }
+  const total = parameters.components.reduce((sum, component) => sum + component.weight, 0);
+  if (total !== 1) {
+    context.addIssue({
+      code: 'custom',
+      path: ['components'],
+      message: 'Composite component weights must sum to one',
+    });
+  }
+});
 const BonferroniParametersSchema = z.object({
   alpha: FiniteNumberSchema.gt(0).lt(1).default(0.05),
 }).strict();
@@ -373,6 +412,17 @@ const HIERARCHICAL_QUANTILE_PARAMETERS_SCHEMA = schemaIdentity(
   'urn:omk:parameters:hierarchical-measurement-quantile:v1',
   jsonSchema(HierarchicalQuantileParametersSchema),
 );
+const COMPOSITE_BOOTSTRAP_PARAMETERS_SCHEMA = schemaIdentity(
+  'omk.parameters.composite-bootstrap/v1',
+  'urn:omk:parameters:composite-bootstrap:v1',
+  jsonSchema(CompositeBootstrapParametersSchema, [
+    'components contain at least two unique Metric IDs in lexicographic order',
+    'component weights are positive and sum to one',
+    'the composite Metric is not a source component',
+    'each target/sample/trial contributes only when every component coordinate is observed',
+    'component utilities are combined before repeated-measure and resampling aggregation',
+  ]),
+);
 const BONFERRONI_PARAMETERS_SCHEMA = schemaIdentity(
   'omk.parameters.bonferroni/v1', 'urn:omk:parameters:bonferroni:v1', jsonSchema(BonferroniParametersSchema),
 );
@@ -428,6 +478,7 @@ function nodeCapabilities(input: {
   missingPolicyIds?: string[];
   analysisResultSchemaUris?: string[];
   analysisResultCardinality?: { min: number; max?: number };
+  metricObservationCardinality?: { min: number; max?: number };
   comparison?: boolean;
   outputSchema: SchemaIdentity;
   parameterSchema: SchemaIdentity;
@@ -467,7 +518,9 @@ function nodeCapabilities(input: {
     outputSchema: input.outputSchema,
     parameterSchema: input.parameterSchema,
     inputCardinalities: {
-      metricObservations: input.valueTypes !== undefined ? { min: 1, max: 1 } : { min: 0, max: 0 },
+      metricObservations: input.valueTypes !== undefined
+        ? input.metricObservationCardinality ?? { min: 1, max: 1 }
+        : { min: 0, max: 0 },
       analysisResults: input.analysisResultSchemaUris !== undefined
         ? input.analysisResultCardinality ?? { min: 1 }
         : { min: 0, max: 0 },
@@ -739,6 +792,11 @@ interface AggregatedMeasurementUnit extends BootstrapUnit {
   rowIds: Sha256Digest[];
 }
 
+interface AggregatedMeasurementTrial extends AggregatedMeasurementUnit {
+  trialIndex: number;
+  trialId: Sha256Digest;
+}
+
 function metricInput(context: AnalysisNodeExecutionContext): Extract<
   AnalysisNodeInput,
   { inputKind: 'metric-observations' }
@@ -760,35 +818,38 @@ function singleOptionalCoordinate<T>(
   return select(rows[0]);
 }
 
-function aggregateMeasurementUnits(
-  context: AnalysisNodeExecutionContext,
-): AggregatedMeasurementUnit[] {
-  const input = metricInput(context);
-  const aggregation = MeasurementAggregationSchema.parse(
-    parameters(context).measurementAggregation,
-  ) as MeasurementAggregation;
+function aggregateMeasurementTrials(
+  input: Extract<AnalysisNodeInput, { inputKind: 'metric-observations' }>,
+  aggregation: MeasurementAggregation | undefined,
+): AggregatedMeasurementTrial[] {
+  if (input.metric.metricId !== input.referenceId
+      || input.rows.some((row) => row.metricId !== input.referenceId)) {
+    throw new TypeError('Metric input identity differs from its measurement rows.');
+  }
   const expected = new Map<string, Readonly<{
     ensembleMemberId: string;
     instrumentId: string;
     replicateIndex: number;
   }>>();
-  for (const member of aggregation.members) {
-    for (const replicate of member.replicates) {
-      expected.set(replicate.evaluatorId, {
-        ensembleMemberId: member.ensembleMemberId,
-        instrumentId: replicate.instrumentId,
-        replicateIndex: replicate.replicateIndex,
-      });
+  if (aggregation !== undefined) {
+    for (const member of aggregation.members) {
+      for (const replicate of member.replicates) {
+        expected.set(replicate.evaluatorId, {
+          ensembleMemberId: member.ensembleMemberId,
+          instrumentId: replicate.instrumentId,
+          replicateIndex: replicate.replicateIndex,
+        });
+      }
     }
-  }
-  for (const row of input.rows) {
-    const coordinate = expected.get(row.evaluatorId);
-    if (coordinate === undefined
-        || row.measurement.instrumentId !== coordinate.instrumentId
-        || row.measurement.ensembleMemberId !== coordinate.ensembleMemberId
-        || row.measurement.replicateGroupId !== aggregation.replicateGroupId
-        || row.measurement.replicateIndex !== coordinate.replicateIndex) {
-      throw new TypeError('Measurement row differs from the sealed panel coordinates.');
+    for (const row of input.rows) {
+      const coordinate = expected.get(row.evaluatorId);
+      if (coordinate === undefined
+          || row.measurement.instrumentId !== coordinate.instrumentId
+          || row.measurement.ensembleMemberId !== coordinate.ensembleMemberId
+          || row.measurement.replicateGroupId !== aggregation.replicateGroupId
+          || row.measurement.replicateIndex !== coordinate.replicateIndex) {
+        throw new TypeError('Measurement row differs from the sealed panel coordinates.');
+      }
     }
   }
   const trials = groupRows(input.rows, (row) => canonicalizeJson([
@@ -796,8 +857,11 @@ function aggregateMeasurementUnits(
     row.sampleId,
     row.trialIndex,
   ]));
-  const completeTrials: Array<AggregatedMeasurementUnit & { trialIndex: number }> = [];
+  const completeTrials: AggregatedMeasurementTrial[] = [];
   for (const rows of trials.values()) {
+    if (new Set(rows.map((row) => row.trialId)).size !== 1) {
+      throw new TypeError('One measurement trial cannot cross trial identity.');
+    }
     const byEvaluator = new Map<string, AnalysisMetricRow>();
     for (const row of rows) {
       if (byEvaluator.has(row.evaluatorId)) {
@@ -805,27 +869,36 @@ function aggregateMeasurementUnits(
       }
       byEvaluator.set(row.evaluatorId, row);
     }
-    if (byEvaluator.size !== expected.size
-        || [...expected.keys()].some((evaluatorId) => !byEvaluator.has(evaluatorId))) {
+    if (aggregation === undefined) {
+      if (rows.length !== 1) {
+        throw new TypeError('A non-panel Metric trial requires exactly one evaluator coordinate.');
+      }
+    } else if (byEvaluator.size !== expected.size
+      || [...expected.keys()].some((evaluatorId) => !byEvaluator.has(evaluatorId))) {
       throw new TypeError('Measurement trial is missing a sealed evaluator coordinate.');
     }
     if (rows.some((row) => row.rowStatus !== 'observed')) continue;
-    const memberValues = aggregation.members.map((member) => {
-      const values = member.replicates.map((replicate) => numericValue(
-        byEvaluator.get(replicate.evaluatorId)!,
-      ));
-      return {
-        value: mean(values),
-        weight: 'weight' in member ? member.weight : 1,
-      };
-    });
-    const value = aggregation.method === 'weighted-mean'
-      ? memberValues.reduce((sum, member) => sum + member.value * member.weight, 0)
-      : mean(memberValues.map((member) => member.value));
+    const value = aggregation === undefined
+      ? numericValue(rows[0])
+      : (() => {
+        const memberValues = aggregation.members.map((member) => {
+          const values = member.replicates.map((replicate) => numericValue(
+            byEvaluator.get(replicate.evaluatorId)!,
+          ));
+          return {
+            value: mean(values),
+            weight: 'weight' in member ? member.weight : 1,
+          };
+        });
+        return aggregation.method === 'weighted-mean'
+          ? memberValues.reduce((sum, member) => sum + member.value * member.weight, 0)
+          : mean(memberValues.map((member) => member.value));
+      })();
     completeTrials.push({
       targetId: rows[0].targetId,
       sampleId: rows[0].sampleId,
       trialIndex: rows[0].trialIndex,
+      trialId: rows[0].trialId,
       value,
       rowIds: rows.map((row) => row.rowId),
       ...(singleOptionalCoordinate(
@@ -851,6 +924,12 @@ function aggregateMeasurementUnits(
       }),
     });
   }
+  return completeTrials;
+}
+
+function averageMeasurementTrials(
+  completeTrials: readonly AggregatedMeasurementTrial[],
+): AggregatedMeasurementUnit[] {
   return [...groupRows(completeTrials, (trial) => (
     canonicalizeJson([trial.targetId, trial.sampleId])
   )).values()].map((group) => {
@@ -887,6 +966,266 @@ function aggregateMeasurementUnits(
       ...(pairingBlockId === undefined ? {} : { pairingBlockId }),
     };
   });
+}
+
+function aggregateMeasurementUnits(
+  context: AnalysisNodeExecutionContext,
+): AggregatedMeasurementUnit[] {
+  const aggregation = MeasurementAggregationSchema.parse(
+    parameters(context).measurementAggregation,
+  ) as MeasurementAggregation;
+  return averageMeasurementTrials(aggregateMeasurementTrials(metricInput(context), aggregation));
+}
+
+type CompositeBootstrapParameters = z.infer<typeof CompositeBootstrapParametersSchema>;
+
+interface CompositeCoverage {
+  unitKind: 'target-sample-trial';
+  planned: number;
+  complete: number;
+  missing: number;
+}
+
+type CompositeUnitBuild = {
+  units: AggregatedMeasurementUnit[];
+  plannedRows: AnalysisMetricRow[];
+  coverage: CompositeCoverage;
+  parameters: CompositeBootstrapParameters;
+} | {
+  result: AnalysisNodeExecutionResult;
+};
+
+function compositeFailure(
+  reasonCode: string,
+  coverage: CompositeCoverage,
+  details?: JsonValue,
+): AnalysisNodeExecutionResult {
+  return {
+    analysisStatus: 'inconclusive',
+    reasonCodes: [reasonCode],
+    includedRowIds: [],
+    comparableRowIds: [],
+    assumptionChecks: [{
+      assumptionId: 'composite-source-domain',
+      checkStatus: 'failed',
+      reasonCode,
+      ...(details === undefined ? {} : { details }),
+    }, {
+      assumptionId: 'composite-require-complete',
+      checkStatus: 'not-evaluated',
+      reasonCode,
+      details: {
+        unitKind: coverage.unitKind,
+        planned: coverage.planned,
+        complete: coverage.complete,
+        missing: coverage.missing,
+      },
+    }],
+  };
+}
+
+function compositeInputFailureReason(
+  input: Extract<AnalysisNodeInput, { inputKind: 'metric-observations' }>,
+): string | undefined {
+  const metric = input.metric;
+  if (metric.scope !== 'sample'
+      || metric.missingPolicyId !== 'exclude/v1'
+      || (metric.direction !== 'higher-is-better'
+        && metric.direction !== 'lower-is-better')) {
+    return 'analysis-composite-metric-contract-unsupported';
+  }
+  if (metric.valueType === 'numeric') {
+    const min = metric.scale?.min;
+    const max = metric.scale?.max;
+    if (typeof min !== 'number' || !Number.isFinite(min)
+        || typeof max !== 'number' || !Number.isFinite(max) || min >= max) {
+      return 'analysis-composite-numeric-scale-invalid';
+    }
+    for (const row of input.rows) {
+      if (row.rowStatus !== 'observed') continue;
+      if (typeof row.value !== 'number' || !Number.isFinite(row.value)) {
+        return 'analysis-composite-value-type-invalid';
+      }
+      if (row.value < min || row.value > max) {
+        return 'analysis-composite-value-outside-scale';
+      }
+    }
+    return undefined;
+  }
+  if (metric.valueType === 'boolean') {
+    return input.rows.some((row) => row.rowStatus === 'observed' && typeof row.value !== 'boolean')
+      ? 'analysis-composite-value-type-invalid'
+      : undefined;
+  }
+  return 'analysis-composite-metric-contract-unsupported';
+}
+
+function compositeUtility(
+  input: Extract<AnalysisNodeInput, { inputKind: 'metric-observations' }>,
+  value: number,
+): number {
+  const metric = input.metric;
+  let normalized: number;
+  if (metric.valueType === 'boolean') {
+    if (value < 0 || value > 1) {
+      throw new TypeError('Aggregated boolean Metric value must remain in [0, 1].');
+    }
+    normalized = value;
+  } else if (metric.valueType === 'numeric') {
+    const min = metric.scale?.min;
+    const max = metric.scale?.max;
+    if (typeof min !== 'number' || typeof max !== 'number' || min >= max
+        || value < min || value > max) {
+      throw new TypeError('Aggregated numeric Metric value differs from its sealed scale.');
+    }
+    normalized = (value - min) / (max - min);
+  } else {
+    throw new TypeError('Composite utility supports only boolean and numeric Metrics.');
+  }
+  return metric.direction === 'lower-is-better' ? 1 - normalized : normalized;
+}
+
+function compositeCoverageAssumption(
+  coverage: CompositeCoverage,
+): NonNullable<AnalysisNodeExecutionResult['assumptionChecks']>[number] {
+  return {
+    assumptionId: 'composite-require-complete',
+    checkStatus: 'passed',
+    details: {
+      unitKind: coverage.unitKind,
+      planned: coverage.planned,
+      complete: coverage.complete,
+      missing: coverage.missing,
+    },
+  };
+}
+
+function buildCompositeUnits(context: AnalysisNodeExecutionContext): CompositeUnitBuild {
+  const sealed = CompositeBootstrapParametersSchema.parse(
+    context.node.parameters ?? {},
+  ) as CompositeBootstrapParameters;
+  const inputs = metricInputs(context);
+  if (inputs.length !== sealed.components.length) {
+    throw new TypeError('Composite Analysis requires exactly its sealed component Metric inputs.');
+  }
+  const inputsByMetric = new Map(inputs.map((input) => [input.referenceId, input]));
+  if (inputsByMetric.size !== inputs.length
+      || sealed.components.some((component) => !inputsByMetric.has(component.metricId))) {
+    throw new TypeError('Composite Analysis inputs differ from its sealed components.');
+  }
+  const plannedRows = inputs.flatMap((input) => input.rows);
+  const plannedCoordinates = new Set<string>();
+  for (const row of plannedRows) {
+    plannedCoordinates.add(canonicalizeJson([
+      row.targetId,
+      row.sampleId,
+      row.trialIndex,
+    ]));
+  }
+  const completeTrialsByMetric = new Map<string, Map<string, AggregatedMeasurementTrial>>();
+  for (const component of sealed.components) {
+    const input = inputsByMetric.get(component.metricId)!;
+    const reasonCode = compositeInputFailureReason(input);
+    if (reasonCode !== undefined) {
+      return {
+        result: compositeFailure(reasonCode, {
+          unitKind: 'target-sample-trial',
+          planned: plannedCoordinates.size,
+          complete: 0,
+          missing: plannedCoordinates.size,
+        }, { metricId: component.metricId }),
+      };
+    }
+    const aggregation = component.measurementAggregation === undefined
+      ? undefined
+      : component.measurementAggregation as MeasurementAggregation;
+    const trials = aggregateMeasurementTrials(input, aggregation);
+    completeTrialsByMetric.set(component.metricId, new Map(trials.map((trial) => [
+      canonicalizeJson([trial.targetId, trial.sampleId, trial.trialIndex]),
+      trial,
+    ])));
+  }
+  const completeCompositeTrials: AggregatedMeasurementTrial[] = [];
+  for (const coordinate of [...plannedCoordinates].sort()) {
+    const componentTrials = sealed.components.map((component) => (
+      completeTrialsByMetric.get(component.metricId)?.get(coordinate)
+    ));
+    if (componentTrials.some((trial) => trial === undefined)) continue;
+    const complete = componentTrials as AggregatedMeasurementTrial[];
+    const targetId = complete[0].targetId;
+    const sampleId = complete[0].sampleId;
+    const trialIndex = complete[0].trialIndex;
+    if (complete.some((trial) => trial.targetId !== targetId
+      || trial.sampleId !== sampleId || trial.trialIndex !== trialIndex)) {
+      throw new TypeError('Composite coordinate crosses target, sample, or trial identity.');
+    }
+    if (new Set(complete.map((trial) => trial.trialId)).size !== 1) {
+      throw new TypeError('Composite coordinate crosses trial identity.');
+    }
+    const trialId = complete[0].trialId;
+    const clusterId = singleOptionalCoordinate(complete, (trial) => trial.clusterId, 'clusters');
+    const stratumId = singleOptionalCoordinate(complete, (trial) => trial.stratumId, 'strata');
+    const pairingBlockId = singleOptionalCoordinate(
+      complete,
+      (trial) => trial.pairingBlockId,
+      'pairing blocks',
+    );
+    const value = sealed.components.reduce((sum, component, index) => (
+      sum + component.weight * compositeUtility(
+        inputsByMetric.get(component.metricId)!,
+        complete[index].value,
+      )
+    ), 0);
+    if (value < 0 || value > 1) {
+      throw new TypeError('Composite utility must remain within its sealed [0, 1] range.');
+    }
+    completeCompositeTrials.push({
+      targetId,
+      sampleId,
+      trialIndex,
+      trialId,
+      value,
+      rowIds: complete.flatMap((trial) => trial.rowIds),
+      ...(clusterId === undefined ? {} : { clusterId }),
+      ...(stratumId === undefined ? {} : { stratumId }),
+      ...(pairingBlockId === undefined ? {} : { pairingBlockId }),
+    });
+  }
+  const coverage: CompositeCoverage = {
+    unitKind: 'target-sample-trial',
+    planned: plannedCoordinates.size,
+    complete: completeCompositeTrials.length,
+    missing: plannedCoordinates.size - completeCompositeTrials.length,
+  };
+  return {
+    units: averageMeasurementTrials(completeCompositeTrials),
+    plannedRows,
+    coverage,
+    parameters: sealed,
+  };
+}
+
+function withCompositeEvidence(
+  result: AnalysisNodeExecutionResult,
+  units: readonly AggregatedMeasurementUnit[],
+  coverage: CompositeCoverage,
+): AnalysisNodeExecutionResult {
+  const coverageCheck = compositeCoverageAssumption(coverage);
+  const rowIds = units.flatMap((unit) => unit.rowIds);
+  if (result.analysisStatus !== 'completed') {
+    return {
+      ...result,
+      includedRowIds: result.includedRowIds ?? rowIds,
+      comparableRowIds: result.comparableRowIds ?? result.includedRowIds ?? rowIds,
+      assumptionChecks: [...(result.assumptionChecks ?? []), coverageCheck],
+    };
+  }
+  return {
+    ...result,
+    includedRowIds: result.includedRowIds ?? rowIds,
+    comparableRowIds: result.comparableRowIds ?? result.includedRowIds ?? rowIds,
+    assumptionChecks: [...(result.assumptionChecks ?? []), coverageCheck],
+  };
 }
 
 function hierarchicalScalarResult(
@@ -1168,6 +1507,135 @@ function executeHierarchicalPairedBootstrap(
   } : interval;
 }
 
+function compositeBuildOrResult(context: AnalysisNodeExecutionContext): Exclude<
+  CompositeUnitBuild,
+  { result: AnalysisNodeExecutionResult }
+> | AnalysisNodeExecutionResult {
+  const built = buildCompositeUnits(context);
+  return 'result' in built ? built.result : built;
+}
+
+function executeCompositeMeanBootstrap(
+  context: AnalysisNodeExecutionContext,
+): AnalysisNodeExecutionResult {
+  const built = compositeBuildOrResult(context);
+  if ('analysisStatus' in built) return built;
+  let bootstrapUnits: readonly BootstrapUnit[] = built.units;
+  if (context.sampling.resamplingUnit === 'paired-block') {
+    if (built.units.some((unit) => unit.pairingBlockId === undefined)) {
+      return withCompositeEvidence(
+        incomplete('analysis-pairing-membership-missing'),
+        built.units,
+        built.coverage,
+      );
+    }
+    bootstrapUnits = [...groupRows(built.units, (unit) => unit.pairingBlockId).values()].map(
+      (members) => {
+        const stratumId = singleOptionalCoordinate(members, (member) => member.stratumId, 'strata');
+        return {
+          value: mean(members.map((member) => member.value)),
+          ...(stratumId === undefined ? {} : { stratumId }),
+        };
+      },
+    );
+  } else if (context.sampling.resamplingUnit !== 'sample') {
+    return withCompositeEvidence(
+      incomplete('analysis-composite-resampling-unit-unsupported'),
+      built.units,
+      built.coverage,
+    );
+  }
+  return withCompositeEvidence(
+    percentileInterval(context, bootstrapUnits),
+    built.units,
+    built.coverage,
+  );
+}
+
+function executeCompositeClusterBootstrap(
+  context: AnalysisNodeExecutionContext,
+): AnalysisNodeExecutionResult {
+  const built = compositeBuildOrResult(context);
+  if ('analysisStatus' in built) return built;
+  const groups = new Map<string, AggregatedMeasurementUnit[]>();
+  for (const unit of built.units) {
+    if (unit.clusterId === undefined) {
+      return withCompositeEvidence(
+        incomplete('analysis-cluster-membership-missing'),
+        built.units,
+        built.coverage,
+      );
+    }
+    groups.set(unit.clusterId, [...(groups.get(unit.clusterId) ?? []), unit]);
+  }
+  const clusterUnits = [...groups.values()].map((members) => {
+    const stratumId = singleOptionalCoordinate(members, (member) => member.stratumId, 'strata');
+    return {
+      value: mean(members.map((member) => member.value)),
+      ...(stratumId === undefined ? {} : { stratumId }),
+    };
+  });
+  return withCompositeEvidence(
+    percentileInterval(context, clusterUnits),
+    built.units,
+    built.coverage,
+  );
+}
+
+function executeCompositePairedBootstrap(
+  context: AnalysisNodeExecutionContext,
+): AnalysisNodeExecutionResult {
+  const built = compositeBuildOrResult(context);
+  if ('analysisStatus' in built) return built;
+  const comparisonInputs = context.inputs.filter(
+    (input): input is Extract<AnalysisNodeInput, { inputKind: 'comparison' }> => (
+      input.inputKind === 'comparison'
+    ),
+  );
+  if (comparisonInputs.length !== 1) {
+    throw new TypeError('Composite paired bootstrap requires exactly one Comparison contrast.');
+  }
+  const comparison = comparisonInputs[0].contrast;
+  if (comparison.metricId !== built.parameters.compositeMetricId) {
+    return withCompositeEvidence(
+      incomplete('analysis-composite-comparison-metric-mismatch'),
+      built.units,
+      built.coverage,
+    );
+  }
+  if (built.units.some((unit) => unit.pairingBlockId === undefined)) {
+    return withCompositeEvidence(
+      incomplete('analysis-pairing-membership-missing'),
+      built.units,
+      built.coverage,
+    );
+  }
+  const differences: BootstrapUnit[] = [];
+  const includedUnits: AggregatedMeasurementUnit[] = [];
+  for (const group of groupRows(built.units, (unit) => unit.pairingBlockId).values()) {
+    const control = group.filter((unit) => unit.targetId === comparison.controlTargetId);
+    const treatment = group.filter((unit) => unit.targetId === comparison.treatmentTargetId);
+    if (control.length === 0 || treatment.length === 0) continue;
+    const stratumId = singleOptionalCoordinate(group, (unit) => unit.stratumId, 'strata');
+    differences.push({
+      value: mean(treatment.map((unit) => unit.value))
+        - mean(control.map((unit) => unit.value)),
+      ...(stratumId === undefined ? {} : { stratumId }),
+    });
+    includedUnits.push(...control, ...treatment);
+  }
+  const interval = percentileInterval(context, differences);
+  return withCompositeEvidence(
+    interval.analysisStatus === 'completed' ? {
+      ...interval,
+      includedRowIds: includedUnits.flatMap((unit) => unit.rowIds),
+      comparableRowIds: includedUnits.flatMap((unit) => unit.rowIds),
+    } : interval,
+    includedUnits,
+    built.coverage,
+  );
+}
+
 function bootstrapArmStratumMean(
   seed: Sha256Digest,
   armId: string,
@@ -1190,6 +1658,7 @@ function executeUnpairedBootstrapWithUnits(
   context: AnalysisNodeExecutionContext,
   units: readonly AggregatedMeasurementUnit[],
   plannedRows: readonly AnalysisMetricRow[],
+  expectedMetricId?: string,
 ): AnalysisNodeExecutionResult {
   const comparisonInputs = context.inputs.filter(
     (input): input is Extract<AnalysisNodeInput, { inputKind: 'comparison' }> => (
@@ -1200,8 +1669,8 @@ function executeUnpairedBootstrapWithUnits(
     throw new TypeError('Unpaired bootstrap requires exactly one Comparison contrast.');
   }
   const comparisonInput = comparisonInputs[0];
-  const metricInput = metricInputs(context)[0];
-  if (metricInput === undefined || comparisonInput.contrast.metricId !== metricInput.referenceId) {
+  const metricId = expectedMetricId ?? metricInputs(context)[0]?.referenceId;
+  if (metricId === undefined || comparisonInput.contrast.metricId !== metricId) {
     return incomplete('analysis-unpaired-bootstrap-requires-one-matching-metric');
   }
   const controlId = comparisonInput.contrast.controlTargetId;
@@ -1301,6 +1770,23 @@ function executeUnpairedBootstrapWithUnits(
     comparableRowIds: includedRowIds,
     assumptionChecks: passedAssumption('independent-non-overlapping-samples'),
   };
+}
+
+function executeCompositeUnpairedBootstrap(
+  context: AnalysisNodeExecutionContext,
+): AnalysisNodeExecutionResult {
+  const built = compositeBuildOrResult(context);
+  if ('analysisStatus' in built) return built;
+  return withCompositeEvidence(
+    executeUnpairedBootstrapWithUnits(
+      context,
+      built.units,
+      built.plannedRows,
+      built.parameters.compositeMetricId,
+    ),
+    built.units,
+    built.coverage,
+  );
 }
 
 function executeUnpairedBootstrap(context: AnalysisNodeExecutionContext): AnalysisNodeExecutionResult {
@@ -1712,6 +2198,88 @@ register(
   executeHierarchicalClusterBootstrap,
 );
 register(
+  'bootstrap.composite-mean-percentile/v1',
+  nodeCapabilities({
+    analysisNodeKind: 'estimator',
+    valueTypes: ['numeric', 'boolean'],
+    missingPolicyIds: ['exclude/v1'],
+    metricObservationCardinality: { min: 2 },
+    outputSchema: BUILTIN_INTERVAL_RESULT_SCHEMA,
+    parameterSchema: COMPOSITE_BOOTSTRAP_PARAMETERS_SCHEMA,
+    sampling: {
+      assignmentKinds: ['complete-block', 'independent-groups'],
+      experimentalUnits: ['sample'],
+      repeatedMeasures: [false, true],
+      resamplingUnits: ['sample', 'paired-block'],
+    },
+  }),
+  BUILTIN_INTERVAL_RESULT_SCHEMA,
+  COMPOSITE_BOOTSTRAP_PARAMETERS_SCHEMA,
+  executeCompositeMeanBootstrap,
+);
+register(
+  'bootstrap.composite-cluster-percentile/v1',
+  nodeCapabilities({
+    analysisNodeKind: 'estimator',
+    valueTypes: ['numeric', 'boolean'],
+    missingPolicyIds: ['exclude/v1'],
+    metricObservationCardinality: { min: 2 },
+    outputSchema: BUILTIN_INTERVAL_RESULT_SCHEMA,
+    parameterSchema: COMPOSITE_BOOTSTRAP_PARAMETERS_SCHEMA,
+    sampling: {
+      assignmentKinds: ['complete-block'],
+      experimentalUnits: ['cluster'],
+      repeatedMeasures: [false, true],
+      resamplingUnits: ['cluster'],
+    },
+  }),
+  BUILTIN_INTERVAL_RESULT_SCHEMA,
+  COMPOSITE_BOOTSTRAP_PARAMETERS_SCHEMA,
+  executeCompositeClusterBootstrap,
+);
+register(
+  'bootstrap.composite-paired-difference-percentile/v1',
+  nodeCapabilities({
+    analysisNodeKind: 'estimator',
+    valueTypes: ['numeric', 'boolean'],
+    missingPolicyIds: ['exclude/v1'],
+    metricObservationCardinality: { min: 2 },
+    comparison: true,
+    outputSchema: BUILTIN_INTERVAL_RESULT_SCHEMA,
+    parameterSchema: COMPOSITE_BOOTSTRAP_PARAMETERS_SCHEMA,
+    sampling: {
+      assignmentKinds: ['complete-block'],
+      experimentalUnits: ['sample'],
+      repeatedMeasures: [false, true],
+      resamplingUnits: ['paired-block'],
+    },
+  }),
+  BUILTIN_INTERVAL_RESULT_SCHEMA,
+  COMPOSITE_BOOTSTRAP_PARAMETERS_SCHEMA,
+  executeCompositePairedBootstrap,
+);
+register(
+  'bootstrap.composite-unpaired-difference-percentile/v1',
+  nodeCapabilities({
+    analysisNodeKind: 'estimator',
+    valueTypes: ['numeric', 'boolean'],
+    missingPolicyIds: ['exclude/v1'],
+    metricObservationCardinality: { min: 2 },
+    comparison: true,
+    outputSchema: BUILTIN_INTERVAL_RESULT_SCHEMA,
+    parameterSchema: COMPOSITE_BOOTSTRAP_PARAMETERS_SCHEMA,
+    sampling: {
+      assignmentKinds: ['independent-groups'],
+      experimentalUnits: ['sample'],
+      repeatedMeasures: [false, true],
+      resamplingUnits: ['sample'],
+    },
+  }),
+  BUILTIN_INTERVAL_RESULT_SCHEMA,
+  COMPOSITE_BOOTSTRAP_PARAMETERS_SCHEMA,
+  executeCompositeUnpairedBootstrap,
+);
+register(
   'simultaneous-intervals.bonferroni/v1',
   nodeCapabilities({
     analysisNodeKind: 'correction',
@@ -1803,9 +2371,12 @@ function validateIntervalContext(
 ): void {
   const rawParameters = requireAnalysisOutputContext(context).parameters;
   const sealed = rawParameters !== null && typeof rawParameters === 'object'
-    && !Array.isArray(rawParameters) && 'measurementAggregation' in rawParameters
-    ? HierarchicalBootstrapParametersSchema.parse(rawParameters)
-    : BootstrapParametersSchema.parse(rawParameters);
+      && !Array.isArray(rawParameters) && 'compositeMetricId' in rawParameters
+    ? CompositeBootstrapParametersSchema.parse(rawParameters)
+    : rawParameters !== null && typeof rawParameters === 'object'
+        && !Array.isArray(rawParameters) && 'measurementAggregation' in rawParameters
+      ? HierarchicalBootstrapParametersSchema.parse(rawParameters)
+      : BootstrapParametersSchema.parse(rawParameters);
   const envelope = IntervalEnvelopeSchema.parse(value);
   if (envelope.value.resamples !== sealed.resamples
       || envelope.value.confidenceLevel !== 1 - sealed.alpha
@@ -2077,6 +2648,20 @@ export function createBuiltinAnalysisSchemaValidators(): ReadonlyMap<string, Cor
     [HIERARCHICAL_BOOTSTRAP_PARAMETERS_SCHEMA, HierarchicalBootstrapParametersSchema],
     [HIERARCHICAL_REDUCER_PARAMETERS_SCHEMA, HierarchicalReducerParametersSchema],
     [HIERARCHICAL_QUANTILE_PARAMETERS_SCHEMA, HierarchicalQuantileParametersSchema],
+    [
+      COMPOSITE_BOOTSTRAP_PARAMETERS_SCHEMA,
+      CompositeBootstrapParametersSchema,
+      undefined,
+      (value) => {
+        const parsed = value as CompositeBootstrapParameters;
+        return {
+          ...parsed,
+          components: [...parsed.components].sort((left, right) => (
+            left.metricId < right.metricId ? -1 : left.metricId > right.metricId ? 1 : 0
+          )),
+        };
+      },
+    ],
     [BONFERRONI_PARAMETERS_SCHEMA, BonferroniParametersSchema],
     [
       SIMULTANEOUS_INTERVAL_FAMILY_PARAMETERS_SCHEMA,

--- a/src/eval-core/analysis/runtime.ts
+++ b/src/eval-core/analysis/runtime.ts
@@ -34,6 +34,7 @@ import {
   type SchemaIdentity,
   type Sha256Digest,
 } from '../contracts/index.js';
+import { analysisComparisonAppliesToMetricInput } from '../contracts/analysis-input-matching.js';
 import { deepFreeze, snapshotJson } from '../compiler/immutability.js';
 import type { SealedRunPlan } from '../compiler/index.js';
 import { BoundedEventStream } from '../runtime/event-stream.js';
@@ -626,7 +627,11 @@ function materializeNodeInputs(
       const input = inputs[index];
       if (input.inputKind !== 'metric-observations') continue;
       const matchingContrasts = comparisons.filter(
-        (comparison) => comparison.contrast.metricId === input.referenceId,
+        (comparison) => analysisComparisonAppliesToMetricInput(
+          binding.node,
+          comparison.contrast.metricId,
+          input.referenceId,
+        ),
       );
       const allowedTargets = new Set(matchingContrasts.flatMap((comparison) => [
         comparison.contrast.controlTargetId,

--- a/src/eval-core/compiler/index.ts
+++ b/src/eval-core/compiler/index.ts
@@ -56,6 +56,7 @@ import {
 import {
   validateAnalysisInputs,
   validateDefinitionSemantics,
+  isCompositeAnalysisImplementationId,
   validateMaterializedAnalysisSemantics,
   validateMaterializedDecisionSemantics,
 } from './validation.js';
@@ -1089,9 +1090,19 @@ function normalizeDefinitionParameters(
       node.nodeId,
     );
     try {
+      const parameters = validator.parse(node.parameters ?? {});
+      const inputs = isCompositeAnalysisImplementationId(node.implementationId)
+        ? [...node.inputs].sort((left, right) => {
+          const leftRank = left.inputKind === 'metric-observations' ? 0 : 1;
+          const rightRank = right.inputKind === 'metric-observations' ? 0 : 1;
+          return leftRank - rightRank
+            || compareStrings(canonicalizeJson(left), canonicalizeJson(right));
+        })
+        : node.inputs;
       return {
         ...node,
-        parameters: validator.parse(node.parameters ?? {}),
+        inputs,
+        parameters,
       };
     } catch {
       throw new EvaluationDefinitionError({

--- a/src/eval-core/compiler/validation.ts
+++ b/src/eval-core/compiler/validation.ts
@@ -716,6 +716,149 @@ function validateSimultaneousIntervalFamilies(
   }
 }
 
+const COMPOSITE_ANALYSIS_IMPLEMENTATION_IDS = new Set([
+  'bootstrap.composite-mean-percentile/v1',
+  'bootstrap.composite-cluster-percentile/v1',
+  'bootstrap.composite-paired-difference-percentile/v1',
+  'bootstrap.composite-unpaired-difference-percentile/v1',
+]);
+
+export function isCompositeAnalysisImplementationId(implementationId: string): boolean {
+  return COMPOSITE_ANALYSIS_IMPLEMENTATION_IDS.has(implementationId);
+}
+
+function validateCompositeAnalysisSemantics(definition: EvaluationDefinition): void {
+  const metricsById = new Map(definition.metrics.map((metric) => [metric.metricId, metric]));
+  for (const node of definition.analysisGraph.nodes) {
+    if (!isCompositeAnalysisImplementationId(node.implementationId)) continue;
+    const parameters = node.parameters;
+    if (parameters === undefined || parameters === null || Array.isArray(parameters)
+        || typeof parameters !== 'object') {
+      throw definitionError(
+        'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+        'Composite Analysis 缺少已物化参数。',
+        { nodeId: node.nodeId },
+      );
+    }
+    const parameterObject = parameters as Record<string, unknown>;
+    const compositeMetricId = parameterObject.compositeMetricId;
+    const components = parameterObject.components;
+    if (typeof compositeMetricId !== 'string' || !Array.isArray(components)) {
+      throw definitionError(
+        'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+        'Composite Analysis 参数未完整物化。',
+        { nodeId: node.nodeId },
+      );
+    }
+    const componentMetricIds = components.flatMap((component) => (
+      component !== null && !Array.isArray(component) && typeof component === 'object'
+        && typeof (component as Record<string, unknown>).metricId === 'string'
+        ? [(component as Record<string, unknown>).metricId as string]
+        : []
+    ));
+    const metricInputs = node.inputs.filter(
+      (input) => input.inputKind === 'metric-observations',
+    );
+    const inputMetricIds = metricInputs.map((input) => input.referenceId);
+    const comparisonInputs = node.inputs.filter((input) => input.inputKind === 'comparison');
+    const expectsComparison = node.implementationId.includes('-difference-');
+    const selectedTargetIds = node.targetFilter?.includeTargetIds ?? [];
+    if (expectsComparison ? node.targetFilter !== undefined : selectedTargetIds.length !== 1) {
+      throw definitionError(
+        'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+        expectsComparison
+          ? 'Composite difference 由 contrast 封存 Variant，不接受额外 target filter。'
+          : 'Composite quality 必须通过 target filter 精确封存一个 Variant。',
+        { nodeId: node.nodeId },
+      );
+    }
+    if (node.analysisNodeKind !== 'estimator'
+        || componentMetricIds.length !== components.length
+        || componentMetricIds.length < 2
+        || canonicalizeJson(componentMetricIds) !== canonicalizeJson([...componentMetricIds].sort())
+        || canonicalizeJson(inputMetricIds) !== canonicalizeJson(componentMetricIds)
+        || node.inputs.some((input) => input.inputKind === 'analysis-result')
+        || comparisonInputs.length !== (expectsComparison ? 1 : 0)
+        || (expectsComparison && comparisonInputs[0].metricId !== compositeMetricId)) {
+      throw definitionError(
+        'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+        'Composite Analysis 必须按 canonical component 顺序精确绑定 source Metrics 与所需 contrast。',
+        { nodeId: node.nodeId },
+      );
+    }
+    const compositeMetric = metricsById.get(compositeMetricId);
+    if (compositeMetric === undefined
+        || compositeMetric.valueType !== 'numeric'
+        || compositeMetric.scope !== 'sample'
+        || compositeMetric.scale?.min !== 0
+        || compositeMetric.scale.max !== 1
+        || compositeMetric.scale.target !== undefined
+        || compositeMetric.direction !== 'higher-is-better'
+        || compositeMetric.missingPolicyId !== 'exclude/v1'
+        || compositeMetric.unit !== 'utility'
+        || definition.evaluators.some((evaluator) => (
+          evaluator.metricIds.includes(compositeMetricId)
+        ))) {
+      throw definitionError(
+        'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+        'Composite derived Metric 必须是无 Evaluator 产出的 [0, 1] higher-is-better sample utility。',
+        { nodeId: node.nodeId, metricId: compositeMetricId },
+      );
+    }
+    for (const [componentIndex, componentMetricId] of componentMetricIds.entries()) {
+      const metric = metricsById.get(componentMetricId);
+      const supportedDirection = metric?.direction === 'higher-is-better'
+        || metric?.direction === 'lower-is-better';
+      const supportedNumeric = metric?.valueType === 'numeric'
+        && typeof metric.scale?.min === 'number'
+        && Number.isFinite(metric.scale.min)
+        && typeof metric.scale.max === 'number'
+        && Number.isFinite(metric.scale.max)
+        && metric.scale.min < metric.scale.max;
+      if (metric === undefined || metric.scope !== 'sample'
+          || metric.missingPolicyId !== 'exclude/v1' || !supportedDirection
+          || (metric.valueType !== 'boolean' && !supportedNumeric)) {
+        throw definitionError(
+          'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+          'Composite component 只接受具备 sealed monotonic utility 的 sample Metric。',
+          { nodeId: node.nodeId, metricId: componentMetricId },
+        );
+      }
+      const producingEvaluators = definition.evaluators.filter((evaluator) => (
+        evaluator.metricIds.includes(componentMetricId)
+      ));
+      const component = components[componentIndex] as Record<string, unknown>;
+      const aggregation = component.measurementAggregation;
+      const aggregateEvaluatorIds = aggregation !== undefined && aggregation !== null
+          && !Array.isArray(aggregation) && typeof aggregation === 'object'
+        ? ((aggregation as Record<string, unknown>).members as unknown[] | undefined)?.flatMap(
+          (member) => member !== null && !Array.isArray(member) && typeof member === 'object'
+            ? (((member as Record<string, unknown>).replicates as unknown[] | undefined) ?? [])
+              .flatMap((replicate) => replicate !== null && !Array.isArray(replicate)
+                && typeof replicate === 'object'
+                && typeof (replicate as Record<string, unknown>).evaluatorId === 'string'
+                ? [(replicate as Record<string, unknown>).evaluatorId as string]
+                : [])
+            : [],
+        ) ?? []
+        : [];
+      const producingEvaluatorIds = producingEvaluators.map(
+        (evaluator) => evaluator.evaluatorId,
+      ).sort();
+      if (producingEvaluatorIds.length === 0
+          || (aggregation === undefined && producingEvaluatorIds.length !== 1)
+          || (aggregation !== undefined && canonicalizeJson([...aggregateEvaluatorIds].sort())
+            !== canonicalizeJson(producingEvaluatorIds))) {
+        throw definitionError(
+          'EVAL_DEFINITION_VALUE_DOMAIN_INVALID',
+          'Composite component 的 measurement aggregation 必须精确覆盖全部 source Evaluator。',
+          { nodeId: node.nodeId, metricId: componentMetricId },
+        );
+      }
+    }
+  }
+}
+
 export function validateDefinitionSemantics(
   definition: EvaluationDefinition,
   policy: MeasurementPolicy,
@@ -1091,6 +1234,7 @@ export function validateMaterializedAnalysisSemantics(
   definition: EvaluationDefinition,
 ): void {
   validateSimultaneousIntervalFamilies(definition, true);
+  validateCompositeAnalysisSemantics(definition);
 }
 
 export function validateMaterializedDecisionSemantics(

--- a/src/eval-core/contracts/analysis-bundle.ts
+++ b/src/eval-core/contracts/analysis-bundle.ts
@@ -12,6 +12,7 @@ import {
   type CoreSchemaValidator,
   type Provenance,
 } from './common.js';
+import { analysisComparisonAppliesToMetricInput } from './analysis-input-matching.js';
 import { derivePlannedEvaluationCoordinates } from './evaluation-identities.js';
 import {
   countAnalysisResamplingUnits,
@@ -480,7 +481,9 @@ function expectedRows(
     if (evaluator === undefined) continue;
     for (const metricId of evaluator.metricIds) {
       if (!metricIds.has(metricId)) continue;
-      const matchingContrasts = comparisonInputs.filter((input) => input.metricId === metricId);
+      const matchingContrasts = comparisonInputs.filter((input) => (
+        analysisComparisonAppliesToMetricInput(node, input.metricId, metricId)
+      ));
       if (comparisonInputs.length > 0 && matchingContrasts.length === 0) continue;
       const allowedTargets = matchingContrasts.length === 0 ? undefined : new Set(
         matchingContrasts.flatMap((input) => {

--- a/src/eval-core/contracts/analysis-input-matching.ts
+++ b/src/eval-core/contracts/analysis-input-matching.ts
@@ -1,0 +1,25 @@
+/**
+ * A comparison normally applies only to observations of its own Metric. A derived
+ * composite comparison instead applies its sealed contrast to every declared
+ * source Metric so the Runtime can materialize the two arms before derivation.
+ *
+ * This is an internal contract projection shared by runtime materialization and
+ * persisted Bundle verification. It is intentionally not exported by contracts/index.
+ */
+export function analysisComparisonAppliesToMetricInput(
+  node: Readonly<{ parameters?: unknown }>,
+  comparisonMetricId: string,
+  inputMetricId: string,
+): boolean {
+  if (comparisonMetricId === inputMetricId) return true;
+  const parameters = node.parameters;
+  if (parameters === undefined || parameters === null || Array.isArray(parameters)
+      || typeof parameters !== 'object') return false;
+  const parameterObject = parameters as Record<string, unknown>;
+  if (parameterObject.compositeMetricId !== comparisonMetricId
+      || !Array.isArray(parameterObject.components)) return false;
+  return parameterObject.components.some((component) => (
+    component !== null && !Array.isArray(component) && typeof component === 'object'
+      && (component as Record<string, unknown>).metricId === inputMetricId
+  ));
+}

--- a/test/eval-core/analysis/composite-builtins.test.ts
+++ b/test/eval-core/analysis/composite-builtins.test.ts
@@ -1,0 +1,526 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createBuiltinAnalysisNodes,
+  createBuiltinAnalysisSchemaValidators,
+  type AnalysisMetricRow,
+  type AnalysisNodeExecutionContext,
+  type AnalysisNodeExecutionResult,
+} from '../../../src/eval-core/analysis/index.js';
+import {
+  digestCanonicalJson,
+  schemaIdentityKey,
+  type JsonValue,
+  type SchemaIdentity,
+} from '../../../src/eval-core/contracts/index.js';
+
+type MetricContract = Extract<
+  AnalysisNodeExecutionContext['inputs'][number],
+  { inputKind: 'metric-observations' }
+>['metric'];
+
+function metric(input: {
+  metricId: string;
+  valueType: 'numeric' | 'boolean';
+  direction?: 'higher-is-better' | 'lower-is-better';
+  min?: number;
+  max?: number;
+}): MetricContract {
+  return {
+    metricId: input.metricId,
+    valueType: input.valueType,
+    scope: 'sample',
+    ...(input.valueType === 'numeric' && input.min !== undefined && input.max !== undefined
+      ? { scale: { min: input.min, max: input.max } }
+      : {}),
+    ...(input.direction === undefined ? {} : { direction: input.direction }),
+    missingPolicyId: 'exclude/v1',
+  };
+}
+
+function row(input: {
+  metric: MetricContract;
+  sampleId: string;
+  targetId?: string;
+  trialIndex?: number;
+  value?: number | boolean;
+  missing?: boolean;
+  evaluatorId?: string;
+  instrumentId?: string;
+  ensembleMemberId?: string;
+  replicateGroupId?: string;
+  replicateIndex?: number;
+  pairingBlockId?: string;
+  clusterId?: string;
+  stratumId?: string;
+}): AnalysisMetricRow {
+  const targetId = input.targetId ?? 'candidate';
+  const trialIndex = input.trialIndex ?? 0;
+  const evaluatorId = input.evaluatorId ?? `${input.metric.metricId}-evaluator`;
+  const trialId = digestCanonicalJson({ targetId, sampleId: input.sampleId, trialIndex });
+  const base = {
+    rowId: digestCanonicalJson({ trialId, metricId: input.metric.metricId, evaluatorId }),
+    targetId,
+    sampleId: input.sampleId,
+    trialIndex,
+    trialId,
+    evaluatorId,
+    measurement: {
+      instrumentId: input.instrumentId ?? `${input.metric.metricId}-instrument`,
+      ensembleMemberId: input.ensembleMemberId ?? `${input.metric.metricId}-member`,
+      replicateGroupId: input.replicateGroupId ?? `${input.metric.metricId}-primary`,
+      replicateIndex: input.replicateIndex ?? 0,
+    },
+    cohortIds: [],
+    metricId: input.metric.metricId,
+    valueType: input.metric.valueType,
+    samplingUnitIds: {
+      ...(input.pairingBlockId === undefined ? {} : {
+        pairingBlockId: input.pairingBlockId,
+      }),
+      ...(input.clusterId === undefined ? {} : { clusterId: input.clusterId }),
+      ...(input.stratumId === undefined ? {} : { stratumId: input.stratumId }),
+    },
+    censored: false,
+  } as const;
+  return input.missing === true
+    ? { ...base, rowStatus: 'missing', reasonCode: 'missing-output' }
+    : { ...base, rowStatus: 'observed', value: input.value as number | boolean };
+}
+
+interface ComponentInput {
+  metric: MetricContract;
+  weight: number;
+  rows: AnalysisMetricRow[];
+  measurementAggregation?: JsonValue;
+}
+
+function context(input: {
+  implementationId: string;
+  components: ComponentInput[];
+  resamplingUnit: 'sample' | 'paired-block' | 'cluster';
+  comparison?: { controlTargetId: string; treatmentTargetId: string };
+}): AnalysisNodeExecutionContext {
+  const components = [...input.components].sort((left, right) => (
+    left.metric.metricId < right.metric.metricId ? -1 : 1
+  ));
+  const compositeMetricId = 'overall-quality';
+  return {
+    node: {
+      analysisNodeKind: 'estimator',
+      nodeId: 'overall-quality-estimate',
+      implementationId: input.implementationId,
+      inputs: [
+        ...components.map((component) => ({
+          inputKind: 'metric-observations' as const,
+          referenceId: component.metric.metricId,
+        })),
+        ...(input.comparison === undefined ? [] : [{
+          inputKind: 'comparison' as const,
+          referenceId: 'comparison-1',
+          treatmentTargetId: input.comparison.treatmentTargetId,
+          metricId: compositeMetricId,
+        }]),
+      ],
+      outputResultId: 'overall-quality-result',
+      parameters: {
+        compositeMetricId,
+        components: components.map((component) => ({
+          metricId: component.metric.metricId,
+          weight: component.weight,
+          ...(component.measurementAggregation === undefined ? {} : {
+            measurementAggregation: component.measurementAggregation,
+          }),
+        })),
+        aggregation: { method: 'weighted-mean', missing: 'require-complete' },
+        resamples: 64,
+        alpha: 0.1,
+      },
+    },
+    inputs: [
+      ...components.map((component) => ({
+        inputKind: 'metric-observations' as const,
+        referenceId: component.metric.metricId,
+        metric: component.metric,
+        rows: component.rows,
+      })),
+      ...(input.comparison === undefined ? [] : [{
+        inputKind: 'comparison' as const,
+        referenceId: 'comparison-1',
+        contrast: {
+          comparisonId: 'comparison-1',
+          controlTargetId: input.comparison.controlTargetId,
+          treatmentTargetId: input.comparison.treatmentTargetId,
+          metricId: compositeMetricId,
+        },
+      }]),
+    ],
+    analysisPlanDigest: digestCanonicalJson({ analysis: 'composite' }),
+    sampling: {
+      experimentalUnit: input.resamplingUnit === 'cluster' ? 'cluster' : 'sample',
+      repeatedMeasures: true,
+      resamplingUnit: input.resamplingUnit,
+      estimatorId: input.implementationId,
+      seedCoupling: input.resamplingUnit === 'sample'
+        ? 'independent-by-target'
+        : 'shared-within-block',
+      ...(input.resamplingUnit === 'paired-block' ? { pairingKey: '/input/pair' } : {}),
+      ...(input.resamplingUnit === 'cluster' ? { clusterKey: '/input/cluster' } : {}),
+    },
+    rootSeed: 'composite-seed',
+    samples: [],
+    cohorts: [],
+    signal: new AbortController().signal,
+  };
+}
+
+async function execute(input: AnalysisNodeExecutionContext): Promise<AnalysisNodeExecutionResult> {
+  const implementation = createBuiltinAnalysisNodes().get(input.node.implementationId);
+  if (implementation === undefined) throw new Error('Composite builtin is missing.');
+  const run = await implementation.openRun({
+    runId: 'run-1',
+    analysisPlanDigest: input.analysisPlanDigest,
+    evaluationBundleDigest: digestCanonicalJson({ evaluation: 1 }),
+    analysisMode: 'preregistered',
+  });
+  return run.execute(input);
+}
+
+function interval(result: AnalysisNodeExecutionResult): {
+  estimate: number;
+  lower: number;
+  upper: number;
+  unitCount: number;
+} {
+  if (result.analysisStatus !== 'completed' || result.resultType !== 'interval'
+      || result.value === null || Array.isArray(result.value)
+      || typeof result.value !== 'object') {
+    throw new Error('Expected completed interval.');
+  }
+  return result.value as unknown as ReturnType<typeof interval>;
+}
+
+describe('Evaluation Core composite estimators', () => {
+  it('seals canonical explicit components and rejects ambiguous weights', () => {
+    const implementation = createBuiltinAnalysisNodes().get(
+      'bootstrap.composite-mean-percentile/v1',
+    );
+    expect(implementation?.identity.capabilities).toMatchObject({
+      inputCardinalities: {
+        metricObservations: { min: 2 },
+        comparisons: { min: 0, max: 0 },
+      },
+    });
+    const capabilities = implementation?.identity.capabilities as {
+      parameterSchema: SchemaIdentity;
+    };
+    const validator = createBuiltinAnalysisSchemaValidators().get(
+      schemaIdentityKey(capabilities.parameterSchema),
+    );
+    const valid = {
+      compositeMetricId: 'overall-quality',
+      components: [
+        { metricId: 'latency', weight: 0.4 },
+        { metricId: 'correct', weight: 0.6 },
+      ],
+      aggregation: { method: 'weighted-mean', missing: 'require-complete' },
+      resamples: 64,
+      alpha: 0.1,
+    };
+    expect(validator?.parse(valid)).toMatchObject({
+      components: [{ metricId: 'correct' }, { metricId: 'latency' }],
+    });
+    expect(() => validator?.parse({ ...valid, components: [{ metricId: 'correct', weight: 1 }] }))
+      .toThrow();
+    expect(() => validator?.parse({
+      ...valid,
+      components: [
+        { metricId: 'correct', weight: 0.5 },
+        { metricId: 'correct', weight: 0.5 },
+      ],
+    })).toThrow();
+    expect(() => validator?.parse({
+      ...valid,
+      components: [
+        { metricId: 'correct', weight: 0.4 },
+        { metricId: 'latency', weight: 0.4 },
+      ],
+    })).toThrow();
+    expect(() => validator?.parse({
+      ...valid,
+      components: [
+        { metricId: 'correct', weight: 0.5 },
+        { metricId: 'latency', weight: 0.5000000000005 },
+      ],
+    })).toThrow();
+    expect(() => validator?.parse({
+      ...valid,
+      components: [
+        { metricId: 'correct', weight: 0.5 },
+        { metricId: 'latency', weight: 0.4999999999995 },
+      ],
+    })).toThrow();
+  });
+
+  it('maps sealed boolean and bounded numeric directions to unit utility', async () => {
+    const correct = metric({
+      metricId: 'correct', valueType: 'boolean', direction: 'higher-is-better',
+    });
+    const latency = metric({
+      metricId: 'latency', valueType: 'numeric', direction: 'lower-is-better', min: 0, max: 100,
+    });
+    const result = await execute(context({
+      implementationId: 'bootstrap.composite-mean-percentile/v1',
+      resamplingUnit: 'sample',
+      components: [{
+        metric: correct,
+        weight: 0.6,
+        rows: [
+          row({ metric: correct, sampleId: 's1', value: false }),
+          row({ metric: correct, sampleId: 's2', value: true }),
+        ],
+      }, {
+        metric: latency,
+        weight: 0.4,
+        rows: [
+          row({ metric: latency, sampleId: 's1', value: 100 }),
+          row({ metric: latency, sampleId: 's2', value: 0 }),
+        ],
+      }],
+    }));
+    expect(interval(result)).toMatchObject({ estimate: 0.5, unitCount: 2 });
+  });
+
+  it('combines within units before resampling and preserves cross-Metric covariance', async () => {
+    const a = metric({
+      metricId: 'a', valueType: 'numeric', direction: 'higher-is-better', min: 0, max: 1,
+    });
+    const b = metric({
+      metricId: 'b', valueType: 'numeric', direction: 'higher-is-better', min: 0, max: 1,
+    });
+    const values = [0, 1, 0, 1];
+    const result = await execute(context({
+      implementationId: 'bootstrap.composite-mean-percentile/v1',
+      resamplingUnit: 'sample',
+      components: [{
+        metric: a,
+        weight: 0.5,
+        rows: values.map((value, index) => row({ metric: a, sampleId: `s${index}`, value })),
+      }, {
+        metric: b,
+        weight: 0.5,
+        rows: values.map((value, index) => row({
+          metric: b, sampleId: `s${index}`, value: 1 - value,
+        })),
+      }],
+    }));
+    expect(interval(result)).toMatchObject({ estimate: 0.5, lower: 0.5, upper: 0.5, unitCount: 4 });
+  });
+
+  it('requires complete component coordinates without renormalizing weights', async () => {
+    const a = metric({
+      metricId: 'a', valueType: 'numeric', direction: 'higher-is-better', min: 0, max: 1,
+    });
+    const b = metric({
+      metricId: 'b', valueType: 'numeric', direction: 'higher-is-better', min: 0, max: 1,
+    });
+    const result = await execute(context({
+      implementationId: 'bootstrap.composite-mean-percentile/v1',
+      resamplingUnit: 'sample',
+      components: [{
+        metric: a,
+        weight: 0.5,
+        rows: ['s1', 's2', 's3'].map((sampleId) => row({ metric: a, sampleId, value: 1 })),
+      }, {
+        metric: b,
+        weight: 0.5,
+        rows: [
+          row({ metric: b, sampleId: 's1', value: 0 }),
+          row({ metric: b, sampleId: 's2', value: 0 }),
+          row({ metric: b, sampleId: 's3', missing: true }),
+        ],
+      }],
+    }));
+    expect(interval(result)).toMatchObject({ estimate: 0.5, unitCount: 2 });
+    expect(result.includedRowIds).toHaveLength(4);
+    expect(result.assumptionChecks).toContainEqual({
+      assumptionId: 'composite-require-complete',
+      checkStatus: 'passed',
+      details: {
+        unitKind: 'target-sample-trial', planned: 3, complete: 2, missing: 1,
+      },
+    });
+  });
+
+  it('fails closed when observed evidence is outside the sealed scale', async () => {
+    const a = metric({
+      metricId: 'a', valueType: 'numeric', direction: 'higher-is-better', min: 0, max: 1,
+    });
+    const b = metric({
+      metricId: 'b', valueType: 'numeric', direction: 'higher-is-better', min: 0, max: 1,
+    });
+    const result = await execute(context({
+      implementationId: 'bootstrap.composite-mean-percentile/v1',
+      resamplingUnit: 'sample',
+      components: [{
+        metric: a, weight: 0.5, rows: [row({ metric: a, sampleId: 's1', value: 2 })],
+      }, {
+        metric: b, weight: 0.5, rows: [row({ metric: b, sampleId: 's1', value: 1 })],
+      }],
+    }));
+    expect(result).toMatchObject({
+      analysisStatus: 'inconclusive',
+      reasonCodes: ['analysis-composite-value-outside-scale'],
+      includedRowIds: [],
+      comparableRowIds: [],
+      assumptionChecks: [{
+        assumptionId: 'composite-source-domain',
+        checkStatus: 'failed',
+        reasonCode: 'analysis-composite-value-outside-scale',
+      }, {
+        assumptionId: 'composite-require-complete',
+        checkStatus: 'not-evaluated',
+        reasonCode: 'analysis-composite-value-outside-scale',
+        details: {
+          unitKind: 'target-sample-trial', planned: 1, complete: 0, missing: 1,
+        },
+      }],
+    });
+  });
+
+  it('retains source lineage when complete composite evidence is insufficient to resample', async () => {
+    const a = metric({
+      metricId: 'a', valueType: 'numeric', direction: 'higher-is-better', min: 0, max: 1,
+    });
+    const b = metric({
+      metricId: 'b', valueType: 'numeric', direction: 'higher-is-better', min: 0, max: 1,
+    });
+    const result = await execute(context({
+      implementationId: 'bootstrap.composite-mean-percentile/v1',
+      resamplingUnit: 'sample',
+      components: [{
+        metric: a, weight: 0.5, rows: [row({ metric: a, sampleId: 's1', value: 1 })],
+      }, {
+        metric: b, weight: 0.5, rows: [row({ metric: b, sampleId: 's1', value: 1 })],
+      }],
+    }));
+
+    expect(result).toMatchObject({
+      analysisStatus: 'inconclusive',
+      reasonCodes: ['analysis-insufficient-resampling-units'],
+    });
+    expect(result.includedRowIds).toHaveLength(2);
+    expect(result.comparableRowIds).toHaveLength(2);
+  });
+
+  it('aggregates sealed panel coordinates before composing and resampling', async () => {
+    const rubric = metric({
+      metricId: 'rubric', valueType: 'numeric', direction: 'higher-is-better', min: 0, max: 4,
+    });
+    const correct = metric({
+      metricId: 'correct', valueType: 'boolean', direction: 'higher-is-better',
+    });
+    const panel = {
+      method: 'weighted-mean',
+      missing: 'require-complete',
+      replicateGroupId: 'rubric-panel',
+      members: [{
+        ensembleMemberId: 'judge-a',
+        weight: 0.25,
+        replicates: [{ evaluatorId: 'judge-a-0', instrumentId: 'rubric-v1', replicateIndex: 0 }],
+      }, {
+        ensembleMemberId: 'judge-b',
+        weight: 0.75,
+        replicates: [{ evaluatorId: 'judge-b-0', instrumentId: 'rubric-v1', replicateIndex: 0 }],
+      }],
+    } as JsonValue;
+    const rubricRows = (sampleId: string, values: [number, number]): AnalysisMetricRow[] => [
+      row({
+        metric: rubric, sampleId, value: values[0], evaluatorId: 'judge-a-0',
+        instrumentId: 'rubric-v1', ensembleMemberId: 'judge-a',
+        replicateGroupId: 'rubric-panel', replicateIndex: 0,
+      }),
+      row({
+        metric: rubric, sampleId, value: values[1], evaluatorId: 'judge-b-0',
+        instrumentId: 'rubric-v1', ensembleMemberId: 'judge-b',
+        replicateGroupId: 'rubric-panel', replicateIndex: 0,
+      }),
+    ];
+    const result = await execute(context({
+      implementationId: 'bootstrap.composite-mean-percentile/v1',
+      resamplingUnit: 'sample',
+      components: [{
+        metric: rubric,
+        weight: 0.5,
+        rows: [...rubricRows('s1', [0, 4]), ...rubricRows('s2', [4, 0])],
+        measurementAggregation: panel,
+      }, {
+        metric: correct,
+        weight: 0.5,
+        rows: [
+          row({ metric: correct, sampleId: 's1', value: true }),
+          row({ metric: correct, sampleId: 's2', value: false }),
+        ],
+      }],
+    }));
+    expect(interval(result)).toMatchObject({ estimate: 0.5, unitCount: 2 });
+    expect(result.includedRowIds).toHaveLength(6);
+  });
+
+  it('supports cluster, paired, and independent composite estimands', async () => {
+    const a = metric({
+      metricId: 'a', valueType: 'numeric', direction: 'higher-is-better', min: 0, max: 1,
+    });
+    const b = metric({
+      metricId: 'b', valueType: 'numeric', direction: 'higher-is-better', min: 0, max: 1,
+    });
+    const components = (coordinates: Array<{
+      sampleId: string;
+      targetId?: string;
+      value: number;
+      pairingBlockId?: string;
+      clusterId?: string;
+    }>): ComponentInput[] => [a, b].map((contract) => ({
+      metric: contract,
+      weight: 0.5,
+      rows: coordinates.map((coordinate) => row({ metric: contract, ...coordinate })),
+    }));
+
+    const clustered = await execute(context({
+      implementationId: 'bootstrap.composite-cluster-percentile/v1',
+      resamplingUnit: 'cluster',
+      components: components([
+        { sampleId: 's1', value: 0, clusterId: 'c1' },
+        { sampleId: 's2', value: 0, clusterId: 'c1' },
+        { sampleId: 's3', value: 1, clusterId: 'c2' },
+        { sampleId: 's4', value: 1, clusterId: 'c2' },
+      ]),
+    }));
+    expect(interval(clustered)).toMatchObject({ estimate: 0.5, unitCount: 2 });
+
+    const paired = await execute(context({
+      implementationId: 'bootstrap.composite-paired-difference-percentile/v1',
+      resamplingUnit: 'paired-block',
+      comparison: { controlTargetId: 'control', treatmentTargetId: 'treatment' },
+      components: components([
+        { sampleId: 's1', targetId: 'control', value: 0, pairingBlockId: 'p1' },
+        { sampleId: 's1', targetId: 'treatment', value: 1, pairingBlockId: 'p1' },
+        { sampleId: 's2', targetId: 'control', value: 0, pairingBlockId: 'p2' },
+        { sampleId: 's2', targetId: 'treatment', value: 1, pairingBlockId: 'p2' },
+      ]),
+    }));
+    expect(interval(paired)).toMatchObject({ estimate: 1, unitCount: 2 });
+
+    const independent = await execute(context({
+      implementationId: 'bootstrap.composite-unpaired-difference-percentile/v1',
+      resamplingUnit: 'sample',
+      comparison: { controlTargetId: 'control', treatmentTargetId: 'treatment' },
+      components: components([
+        { sampleId: 'c1', targetId: 'control', value: 0 },
+        { sampleId: 'c2', targetId: 'control', value: 0 },
+        { sampleId: 't1', targetId: 'treatment', value: 1 },
+        { sampleId: 't2', targetId: 'treatment', value: 1 },
+      ]),
+    }));
+    expect(interval(independent)).toMatchObject({ estimate: 1, unitCount: 4 });
+  });
+});

--- a/test/eval-core/compiler/composite.test.ts
+++ b/test/eval-core/compiler/composite.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createBuiltinAnalysisSchemaValidators,
+  resolveBuiltinAnalysisRuntime,
+} from '../../../src/eval-core/analysis/index.js';
+import { prepareEvaluationPlan } from '../../../src/eval-core/compiler/index.js';
+import type { EvaluationDefinition } from '../../../src/eval-core/contracts/index.js';
+import { testRuntime, validDefinition, validPolicy } from './fixtures.js';
+
+function runtime() {
+  const fallback = testRuntime({ evaluatorValueTypes: ['boolean', 'numeric'] });
+  return {
+    ...fallback,
+    schemaValidators: new Map([
+      ...fallback.schemaValidators,
+      ...createBuiltinAnalysisSchemaValidators(),
+    ]),
+    resolveAnalysis(requirement: Parameters<typeof fallback.resolveAnalysis>[0]) {
+      return resolveBuiltinAnalysisRuntime(requirement) ?? fallback.resolveAnalysis(requirement);
+    },
+  };
+}
+
+function definition(componentOrder: 'canonical' | 'reversed' = 'canonical'): EvaluationDefinition {
+  const result = validDefinition();
+  result.evaluators.push({
+    evaluatorId: 'latency',
+    evaluatorKind: 'custom',
+    implementationId: 'latency/v1',
+    measurement: {
+      instrumentId: 'latency-v1',
+      ensembleMemberId: 'latency-local',
+      replicateGroupId: 'latency-primary',
+      replicateIndex: 0,
+    },
+    metricIds: ['latency-ms'],
+    inputs: [{ bindingId: 'latency', sourceKind: 'execution-facts', pointer: '' }],
+  });
+  result.metrics.push({
+    metricId: 'latency-ms',
+    valueType: 'numeric',
+    scope: 'sample',
+    scale: { min: 0, max: 10_000 },
+    unit: 'ms',
+    direction: 'lower-is-better',
+    missingPolicyId: 'exclude/v1',
+  }, {
+    metricId: 'overall-quality',
+    valueType: 'numeric',
+    scope: 'sample',
+    scale: { min: 0, max: 1 },
+    unit: 'utility',
+    direction: 'higher-is-better',
+    missingPolicyId: 'exclude/v1',
+  });
+  const components = [{ metricId: 'correct', weight: 0.7 }, {
+    metricId: 'latency-ms', weight: 0.3,
+  }];
+  const ordered = componentOrder === 'canonical' ? components : [...components].reverse();
+  result.experiment.sampling.estimatorId = 'bootstrap.composite-mean-percentile/v1';
+  result.analysisGraph.nodes = [{
+    analysisNodeKind: 'estimator',
+    nodeId: 'overall-quality',
+    implementationId: 'bootstrap.composite-mean-percentile/v1',
+    inputs: ordered.map((component) => ({
+      inputKind: 'metric-observations' as const,
+      referenceId: component.metricId,
+    })),
+    outputResultId: 'overall-quality-result',
+    targetFilter: { includeTargetIds: ['treatment'] },
+    parameters: {
+      compositeMetricId: 'overall-quality',
+      components: ordered,
+      aggregation: { method: 'weighted-mean', missing: 'require-complete' },
+      resamples: 100,
+      alpha: 0.05,
+    },
+  }];
+  result.decisionPolicy = {
+    decisionPolicyId: 'release-gate',
+    implementationId: 'progress/v2',
+    analysisResultIds: ['overall-quality-result'],
+    minimumEvidenceStatus: 'complete',
+    parameters: { threshold: 0.5, equivalence: 0 },
+  };
+  return result;
+}
+
+describe('Composite Analysis compiler semantics', () => {
+  it('canonicalizes declaration order into one Definition and Plan identity', async () => {
+    const canonical = await prepareEvaluationPlan(definition(), validPolicy(), runtime());
+    const reversed = await prepareEvaluationPlan(definition('reversed'), validPolicy(), runtime());
+
+    expect(reversed.definition).toEqual(canonical.definition);
+    expect(reversed.digests.analysisPlanDigest).toBe(canonical.digests.analysisPlanDigest);
+    expect(reversed.digests.runContractDigest).toBe(canonical.digests.runContractDigest);
+    expect(canonical.definition.analysisGraph.nodes[0].inputs.map((input) => input.referenceId))
+      .toEqual(['correct', 'latency-ms']);
+    expect(canonical.definition.analysisGraph.nodes[0].parameters).toMatchObject({
+      components: [{ metricId: 'correct' }, { metricId: 'latency-ms' }],
+    });
+  });
+
+  it('rejects derived Metric and source utility contracts that are not sealed', async () => {
+    const invalidDerived = definition();
+    invalidDerived.metrics.find((candidate) => candidate.metricId === 'overall-quality')!.unit = 'score';
+    await expect(prepareEvaluationPlan(invalidDerived, validPolicy(), runtime()))
+      .rejects.toThrow(/Composite derived Metric/);
+
+    const missingScale = definition();
+    delete missingScale.metrics.find((candidate) => candidate.metricId === 'latency-ms')!.scale;
+    await expect(prepareEvaluationPlan(missingScale, validPolicy(), runtime()))
+      .rejects.toThrow(/sealed monotonic utility/);
+
+    const producedDerived = definition();
+    producedDerived.evaluators[0].metricIds.push('overall-quality');
+    await expect(prepareEvaluationPlan(producedDerived, validPolicy(), runtime()))
+      .rejects.toThrow(/Composite derived Metric/);
+  });
+
+  it('requires every source Evaluator to be represented by its component aggregation', async () => {
+    const ambiguous = definition();
+    ambiguous.evaluators.push({
+      ...structuredClone(ambiguous.evaluators[0]),
+      evaluatorId: 'exact-replicate',
+      measurement: {
+        instrumentId: 'exact-assertion',
+        ensembleMemberId: 'exact-local',
+        replicateGroupId: 'exact-primary',
+        replicateIndex: 1,
+      },
+    });
+    await expect(prepareEvaluationPlan(ambiguous, validPolicy(), runtime()))
+      .rejects.toThrow(/measurement aggregation/);
+  });
+
+  it('requires quality composites to seal exactly one Variant', async () => {
+    const missing = definition();
+    delete missing.analysisGraph.nodes[0].targetFilter;
+    await expect(prepareEvaluationPlan(missing, validPolicy(), runtime()))
+      .rejects.toThrow(/精确封存一个 Variant/);
+
+    const multiple = definition();
+    multiple.analysisGraph.nodes[0].targetFilter = {
+      includeTargetIds: ['control', 'treatment'],
+    };
+    await expect(prepareEvaluationPlan(multiple, validPolicy(), runtime()))
+      .rejects.toThrow(/精确封存一个 Variant/);
+  });
+});

--- a/test/eval-core/conformance/statistics.test.ts
+++ b/test/eval-core/conformance/statistics.test.ts
@@ -34,26 +34,28 @@ function categorical(next: () => number, probabilities: readonly number[]): numb
 function metricRow(input: {
   sampleId: string;
   targetId?: string;
+  metricId?: string;
   value: number;
   pairingBlockId?: Sha256Digest;
 }): AnalysisMetricRow {
   const targetId = input.targetId ?? 'target';
+  const metricId = input.metricId ?? 'score';
   const trialId = digestCanonicalJson({ targetId, sampleId: input.sampleId, trialIndex: 0 });
   return {
-    rowId: digestCanonicalJson({ trialId, metricId: 'score' }),
+    rowId: digestCanonicalJson({ trialId, metricId }),
     targetId,
     sampleId: input.sampleId,
     trialIndex: 0,
     trialId,
-    evaluatorId: 'score-evaluator',
+    evaluatorId: `${metricId}-evaluator`,
     measurement: {
-      instrumentId: 'score-instrument',
-      ensembleMemberId: 'score-member',
-      replicateGroupId: 'score-primary',
+      instrumentId: `${metricId}-instrument`,
+      ensembleMemberId: `${metricId}-member`,
+      replicateGroupId: `${metricId}-primary`,
       replicateIndex: 0,
     },
     cohortIds: [],
-    metricId: 'score',
+    metricId,
     valueType: 'numeric',
     samplingUnitIds: input.pairingBlockId === undefined
       ? {}
@@ -67,11 +69,14 @@ function metricRow(input: {
 async function interval(input: {
   implementationId: 'bootstrap.mean-percentile/v1'
     | 'bootstrap.paired-difference-percentile/v1'
-    | 'bootstrap.unpaired-difference-percentile/v1';
+    | 'bootstrap.unpaired-difference-percentile/v1'
+    | 'bootstrap.composite-mean-percentile/v1';
   rows: AnalysisMetricRow[];
+  secondaryRows?: AnalysisMetricRow[];
   simulation: number;
 }): Promise<{ lower: number; upper: number; estimate: number; unitCount: number }> {
-  const comparison = input.implementationId !== 'bootstrap.mean-percentile/v1';
+  const composite = input.implementationId === 'bootstrap.composite-mean-percentile/v1';
+  const comparison = input.implementationId.includes('difference');
   const paired = input.implementationId === 'bootstrap.paired-difference-percentile/v1';
   const implementation = ANALYSIS_NODES.get(input.implementationId);
   if (implementation === undefined) throw new Error('Missing bootstrap implementation.');
@@ -87,7 +92,11 @@ async function interval(input: {
       nodeId: 'estimate',
       implementationId: input.implementationId,
       inputs: [
-        { inputKind: 'metric-observations', referenceId: 'score' },
+        { inputKind: 'metric-observations', referenceId: composite ? 'score-a' : 'score' },
+        ...(composite ? [{
+          inputKind: 'metric-observations' as const,
+          referenceId: 'score-b',
+        }] : []),
         ...(comparison ? [{
           inputKind: 'comparison' as const,
           referenceId: 'comparison',
@@ -96,20 +105,42 @@ async function interval(input: {
         }] : []),
       ],
       outputResultId: 'interval',
-      parameters: { resamples: 256, alpha: 0.1 },
+      parameters: composite ? {
+        compositeMetricId: 'overall-quality',
+        components: [
+          { metricId: 'score-a', weight: 0.5 },
+          { metricId: 'score-b', weight: 0.5 },
+        ],
+        aggregation: { method: 'weighted-mean', missing: 'require-complete' },
+        resamples: 256,
+        alpha: 0.1,
+      } : { resamples: 256, alpha: 0.1 },
     },
     inputs: [{
       inputKind: 'metric-observations',
-      referenceId: 'score',
+      referenceId: composite ? 'score-a' : 'score',
       metric: {
-        metricId: 'score',
+        metricId: composite ? 'score-a' : 'score',
         valueType: 'numeric',
         scope: 'sample',
+        ...(composite ? { scale: { min: 0, max: 1 } } : {}),
         direction: 'higher-is-better',
         missingPolicyId: 'exclude/v1',
       },
       rows: input.rows,
-    }, ...(comparison ? [{
+    }, ...(composite ? [{
+      inputKind: 'metric-observations' as const,
+      referenceId: 'score-b',
+      metric: {
+        metricId: 'score-b',
+        valueType: 'numeric' as const,
+        scope: 'sample' as const,
+        scale: { min: 0, max: 1 },
+        direction: 'higher-is-better' as const,
+        missingPolicyId: 'exclude/v1',
+      },
+      rows: input.secondaryRows ?? [],
+    }] : []), ...(comparison ? [{
       inputKind: 'comparison' as const,
       referenceId: 'comparison',
       contrast: {
@@ -198,6 +229,26 @@ describe('Evaluation Core deterministic statistical conformance', () => {
     expect(mean).toEqual({ lower: 1.5, upper: 3.25, estimate: 2.5, unitCount: 4 });
     expect(paired).toEqual({ lower: 1.5, upper: 3.5, estimate: 2.5, unitCount: 4 });
     expect(unpaired).toEqual({ lower: 0.75, upper: 3.5, estimate: 2, unitCount: 8 });
+  });
+
+  it('pins unit-first composite covariance with a known reference vector', async () => {
+    const first = [0, 1, 0, 1];
+    const composite = await interval({
+      implementationId: 'bootstrap.composite-mean-percentile/v1',
+      simulation: 0,
+      rows: first.map((value, index) => metricRow({
+        metricId: 'score-a',
+        sampleId: `sample-${index}`,
+        value,
+      })),
+      secondaryRows: first.map((value, index) => metricRow({
+        metricId: 'score-b',
+        sampleId: `sample-${index}`,
+        value: 1 - value,
+      })),
+    });
+
+    expect(composite).toEqual({ lower: 0.5, upper: 0.5, estimate: 0.5, unitCount: 4 });
   });
 
   it('pins the deterministic continuous 90% mean-interval coverage profile', async () => {

--- a/test/eval-core/engine/composite-runtime.test.ts
+++ b/test/eval-core/engine/composite-runtime.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createEvaluationEngine,
+  createBuiltinAnalysisNodes,
+  createBuiltinAnalysisSchemaValidators,
+  createBuiltinDecisionPolicies,
+  createBuiltinMissingPolicies,
+  resolveBuiltinAnalysisRuntime,
+  type SealedRunPlan,
+  type EvaluationEngineRuntime,
+  type EvaluationEvent,
+  type EvaluationRunResult,
+  type Evaluator,
+  type Executor,
+  type RuntimeResolution,
+  type RuntimeIdentity,
+} from '../../../src/eval-core/index.js';
+import { prepareEvaluationPlan } from '../../../src/eval-core/compiler/index.js';
+import { testRuntime, validDefinition, validPolicy } from '../compiler/fixtures.js';
+
+class Clock {
+  #elapsed = 0;
+  #timestamps = 0;
+
+  monotonicNow(): number { return this.#elapsed; }
+
+  timestamp(): string {
+    const value = new Date(Date.UTC(2026, 8, 5) + this.#timestamps).toISOString();
+    this.#timestamps += 1;
+    return value;
+  }
+
+  async sleep(delayMs: number): Promise<void> { this.#elapsed += delayMs; }
+}
+
+function runtimeIdentity(
+  plan: SealedRunPlan,
+  runtimeKind: 'executor' | 'evaluator',
+  referenceId: string,
+): RuntimeIdentity {
+  const runtimes = runtimeKind === 'executor'
+    ? plan.execution.runtimes
+    : plan.evaluation.runtimes;
+  const resolved = runtimes.find((candidate) => (
+    candidate.runtimeKind === runtimeKind && candidate.referenceId === referenceId
+  ));
+  if (resolved === undefined) throw new Error(`Missing ${runtimeKind} ${referenceId}.`);
+  return structuredClone(resolved.identity) as RuntimeIdentity;
+}
+
+function executor(identity: RuntimeIdentity): Executor {
+  return {
+    identity,
+    async openRun() {
+      return {
+        async openTrial() {
+          return {
+            async execute() {
+              return {
+                output: { value: { answer: 'A' }, classification: 'public' as const },
+              };
+            },
+            dispose() {},
+          };
+        },
+        dispose() {},
+      };
+    },
+  };
+}
+
+function evaluator(
+  identity: RuntimeIdentity,
+  evaluatorId: string,
+  latencyValue?: number,
+): Evaluator {
+  return {
+    identity,
+    async openRun() {
+      return {
+        async openRecord(context) {
+          return {
+            async evaluate() {
+              return evaluatorId === 'exact' ? {
+                observations: [{
+                  metricId: 'correct',
+                  observationStatus: 'observed' as const,
+                  valueType: 'boolean' as const,
+                  value: true,
+                }],
+              } : {
+                observations: [{
+                  metricId: 'latency-ms',
+                  observationStatus: 'observed' as const,
+                  valueType: 'numeric' as const,
+                  value: latencyValue ?? (context.targetId === 'control' ? 80 : 20),
+                }],
+              };
+            },
+            dispose() {},
+          };
+        },
+        dispose() {},
+      };
+    },
+  };
+}
+
+type CompositeScenario = 'quality' | 'paired-difference' | 'unpaired-difference' | 'invalid';
+
+async function fixture(scenario: CompositeScenario = 'quality'): Promise<{
+  runtime: EvaluationEngineRuntime;
+  definition: ReturnType<typeof validDefinition>;
+  policy: ReturnType<typeof validPolicy>;
+}> {
+  const definition = validDefinition();
+  definition.dataset.samples = Array.from(
+    { length: scenario === 'unpaired-difference' ? 6 : 2 },
+    (_, index) => ({
+      ...structuredClone(definition.dataset.samples[0]),
+      sampleId: `sample-${index + 1}`,
+      input: { question: 'Q', pair: `pair-${index + 1}` },
+    }),
+  );
+  definition.evaluators.push({
+    evaluatorId: 'latency',
+    evaluatorKind: 'custom',
+    implementationId: 'latency/v1',
+    measurement: {
+      instrumentId: 'latency-v1',
+      ensembleMemberId: 'latency-local',
+      replicateGroupId: 'latency-primary',
+      replicateIndex: 0,
+    },
+    metricIds: ['latency-ms'],
+    inputs: [{ bindingId: 'facts', sourceKind: 'execution-facts', pointer: '' }],
+  });
+  definition.metrics.push({
+    metricId: 'latency-ms',
+    valueType: 'numeric',
+    scope: 'sample',
+    scale: { min: 0, max: 100 },
+    unit: 'ms',
+    direction: 'lower-is-better',
+    missingPolicyId: 'exclude/v1',
+  }, {
+    metricId: 'overall-quality',
+    valueType: 'numeric',
+    scope: 'sample',
+    scale: { min: 0, max: 1 },
+    unit: 'utility',
+    direction: 'higher-is-better',
+    missingPolicyId: 'exclude/v1',
+  });
+  const implementationId = scenario === 'paired-difference'
+    ? 'bootstrap.composite-paired-difference-percentile/v1'
+    : scenario === 'unpaired-difference'
+      ? 'bootstrap.composite-unpaired-difference-percentile/v1'
+      : 'bootstrap.composite-mean-percentile/v1';
+  if (scenario === 'paired-difference') {
+    definition.experiment.sampling = {
+      experimentalUnit: 'sample',
+      repeatedMeasures: true,
+      resamplingUnit: 'paired-block',
+      estimatorId: implementationId,
+      seedCoupling: 'shared-within-block',
+      pairingKey: '/input/pair',
+    };
+  } else if (scenario === 'unpaired-difference') {
+    definition.experiment.assignment = {
+      assignmentKind: 'independent-groups',
+      algorithmId: 'assignment.stratified-fixed-quota/v1',
+      allocations: [
+        { randomizationSlotId: 'slot-control', weight: 1 },
+        { randomizationSlotId: 'slot-treatment', weight: 1 },
+      ],
+      minimumUnitsPerTarget: 2,
+      minimumUnitsPerTargetPerStratum: 1,
+    };
+    definition.experiment.sampling = {
+      experimentalUnit: 'sample',
+      repeatedMeasures: false,
+      resamplingUnit: 'sample',
+      estimatorId: implementationId,
+      seedCoupling: 'independent-by-target',
+    };
+  } else {
+    definition.experiment.sampling.estimatorId = implementationId;
+  }
+  if (scenario === 'paired-difference' || scenario === 'unpaired-difference') {
+    definition.comparisons[0].metricIds.push('overall-quality');
+  }
+  definition.analysisGraph.nodes = [{
+    analysisNodeKind: 'estimator',
+    nodeId: 'overall-quality',
+    implementationId,
+    inputs: [
+      { inputKind: 'metric-observations', referenceId: 'correct' },
+      { inputKind: 'metric-observations', referenceId: 'latency-ms' },
+      ...(scenario === 'paired-difference' || scenario === 'unpaired-difference' ? [{
+        inputKind: 'comparison' as const,
+        referenceId: 'control-vs-treatment',
+        treatmentTargetId: 'treatment',
+        metricId: 'overall-quality',
+      }] : []),
+    ],
+    outputResultId: 'overall-quality-result',
+    ...(scenario === 'paired-difference' || scenario === 'unpaired-difference'
+      ? {}
+      : { targetFilter: { includeTargetIds: ['treatment'] } }),
+    parameters: {
+      compositeMetricId: 'overall-quality',
+      components: [
+        { metricId: 'correct', weight: 0.5 },
+        { metricId: 'latency-ms', weight: 0.5 },
+      ],
+      aggregation: { method: 'weighted-mean', missing: 'require-complete' },
+      resamples: 64,
+      alpha: 0.1,
+    },
+  }];
+  definition.decisionPolicy = {
+    decisionPolicyId: 'release-gate',
+    implementationId: 'progress/v2',
+    analysisResultIds: ['overall-quality-result'],
+    minimumEvidenceStatus: 'complete',
+    parameters: {
+      threshold: scenario === 'paired-difference' || scenario === 'unpaired-difference' ? 0 : 0.5,
+      equivalence: 0,
+    },
+  };
+  const policy = validPolicy();
+  policy.retry.maxAttempts = 1;
+  policy.evaluation.retry.maxAttempts = 1;
+  delete policy.execution.timeoutMs;
+  delete policy.evaluation.timeoutMs;
+  policy.evidence.trace = 'none';
+
+  const base = testRuntime({
+    evaluatorValueTypes: ['boolean', 'numeric'],
+    samplingAssignmentKinds: scenario === 'unpaired-difference'
+      ? ['independent-groups']
+      : ['complete-block'],
+    samplingResamplingUnits: scenario === 'paired-difference'
+      ? ['paired-block']
+      : ['sample'],
+  });
+  const analysisNodes = createBuiltinAnalysisNodes();
+  const missingPolicies = createBuiltinMissingPolicies();
+  const decisionPolicies = createBuiltinDecisionPolicies();
+  const schemaValidators = new Map([
+    ...base.schemaValidators,
+    ...createBuiltinAnalysisSchemaValidators(),
+  ]);
+  const plan = await prepareEvaluationPlan(definition, policy, {
+    schemaValidators,
+    resolveExecutor: (requirement) => base.resolveExecutor(requirement),
+    resolveEvaluator: (requirement) => base.resolveEvaluator(requirement),
+    resolveAnalysis(requirement) {
+      const resolution = resolveBuiltinAnalysisRuntime(requirement);
+      if (resolution === undefined) throw new Error('Missing built-in Analysis Runtime.');
+      return resolution;
+    },
+  });
+  return {
+    definition,
+    policy,
+    runtime: {
+      bindings: {
+        resolveExecutor(requirement) {
+          const identity = runtimeIdentity(plan, 'executor', requirement.referenceId);
+          const resolution: RuntimeResolution = {
+            identity,
+            satisfiesVersionConstraint: true,
+          };
+          return {
+            runtimeKind: 'executor',
+            resolution,
+            port: executor(identity),
+          };
+        },
+        resolveEvaluator(requirement) {
+          const identity = runtimeIdentity(plan, 'evaluator', requirement.referenceId);
+          const resolution: RuntimeResolution = {
+            identity,
+            satisfiesVersionConstraint: true,
+          };
+          return {
+            runtimeKind: 'evaluator',
+            resolution,
+            port: evaluator(
+              identity,
+              requirement.referenceId,
+              scenario === 'invalid' ? 101 : undefined,
+            ),
+          };
+        },
+        resolveAnalysis(requirement) {
+          const resolution = resolveBuiltinAnalysisRuntime(requirement);
+          if (resolution === undefined) throw new Error('Missing built-in Analysis Runtime.');
+          if (requirement.requirementKind === 'missing-policy') {
+            return {
+              runtimeKind: 'missing-policy',
+              resolution,
+              port: missingPolicies.get(requirement.implementationId)!,
+            };
+          }
+          if (requirement.requirementKind === 'decision-policy') {
+            return {
+              runtimeKind: 'decision-policy',
+              resolution,
+              port: decisionPolicies.get(requirement.implementationId)!,
+            };
+          }
+          return {
+            runtimeKind: 'analysis-node',
+            resolution,
+            port: analysisNodes.get(requirement.implementationId)!,
+          };
+        },
+      },
+      clock: new Clock(),
+      schemaValidators,
+    },
+  };
+}
+
+async function consume(run: {
+  events: AsyncIterable<EvaluationEvent>;
+  result: Promise<EvaluationRunResult>;
+}): Promise<EvaluationRunResult> {
+  const consuming = (async () => {
+    for await (const event of run.events) void event;
+  })();
+  const result = await run.result;
+  await consuming;
+  return result;
+}
+
+describe('composite Evaluation Engine conformance', () => {
+  it('runs prepare through Decision with recomputable interval and source-row lineage', async () => {
+    const test = await fixture();
+    const result = await consume(createEvaluationEngine(test.runtime).start(
+      test.definition,
+      { policy: test.policy, runId: 'composite-run' },
+    ));
+
+    if (result.status === 'failed') {
+      throw new Error(`Expected completed composite run: ${JSON.stringify(result, null, 2)}`);
+    }
+    expect(result.status).toBe('completed');
+    const record = result.artifacts.analysis.records[0];
+    if (record?.analysisStatus !== 'completed') {
+      throw new Error(JSON.stringify({
+        evaluation: result.artifacts.evaluation.records,
+        analysis: record,
+      }, null, 2));
+    }
+    expect(record).toMatchObject({
+      analysisStatus: 'completed',
+      resultType: 'interval',
+      value: { estimate: 0.9, unitCount: 2 },
+      coverage: { planned: 4, included: 4, comparable: 4 },
+      assumptionChecks: [{
+        assumptionId: 'sufficient-resampling-units',
+        checkStatus: 'passed',
+      }, {
+        assumptionId: 'composite-require-complete',
+        checkStatus: 'passed',
+        details: {
+          unitKind: 'target-sample-trial', planned: 2, complete: 2, missing: 0,
+        },
+      }],
+    });
+    expect(result.artifacts.decision).toMatchObject({
+      decisionStatus: 'decided',
+      verdict: 'PROGRESS',
+      analysisResultIds: ['overall-quality-result'],
+    });
+  });
+
+  it.each([
+    ['paired-difference', 2],
+    ['unpaired-difference', 6],
+  ] as const)('runs %s through canonical comparison materialization', async (scenario, unitCount) => {
+    const test = await fixture(scenario);
+    const result = await consume(createEvaluationEngine(test.runtime).start(
+      test.definition,
+      { policy: test.policy, runId: `composite-${scenario}` },
+    ));
+
+    if (result.status === 'failed') {
+      throw new Error(`Expected completed composite comparison: ${JSON.stringify(result, null, 2)}`);
+    }
+    const record = result.artifacts.analysis.records[0];
+    expect(record).toMatchObject({
+      analysisStatus: 'completed',
+      resultType: 'interval',
+      value: { unitCount },
+      coverage: {
+        included: scenario === 'paired-difference' ? 8 : 12,
+        comparable: scenario === 'paired-difference' ? 8 : 12,
+      },
+    });
+    if (record.analysisStatus !== 'completed' || record.resultType !== 'interval'
+        || record.value === null || Array.isArray(record.value)
+        || typeof record.value !== 'object') throw new Error('Expected completed interval.');
+    expect((record.value as { estimate: number }).estimate).toBeCloseTo(0.3);
+    expect(result.artifacts.decision).toMatchObject({
+      decisionStatus: 'decided',
+      verdict: 'PROGRESS',
+    });
+  });
+
+  it('excludes invalid source observations and preserves composite coordinate coverage', async () => {
+    const test = await fixture('invalid');
+    const result = await consume(createEvaluationEngine(test.runtime).start(
+      test.definition,
+      { policy: test.policy, runId: 'composite-invalid' },
+    ));
+
+    if (result.status === 'failed') {
+      throw new Error(`Expected inconclusive composite run: ${JSON.stringify(result, null, 2)}`);
+    }
+    expect(result.artifacts.analysis.records[0]).toMatchObject({
+      analysisStatus: 'inconclusive',
+      reasonCodes: ['analysis-insufficient-resampling-units'],
+      coverage: {
+        planned: 4, observed: 2, invalid: 2, included: 0, comparable: 0, excluded: 4,
+      },
+      assumptionChecks: [{
+        assumptionId: 'sufficient-units',
+        checkStatus: 'failed',
+        reasonCode: 'analysis-insufficient-resampling-units',
+      }, {
+        assumptionId: 'composite-require-complete',
+        checkStatus: 'passed',
+        details: {
+          unitKind: 'target-sample-trial', planned: 2, complete: 0, missing: 2,
+        },
+      }],
+    });
+  });
+});


### PR DESCRIPTION
## 用户影响

Evaluation Core 现在可以把至少两个显式 Metric 按封存权重组合为命名的 composite utility，并为单 Variant 质量、cluster、paired difference 与 unpaired difference 生成可重放的 percentile interval。缺失 component 不会触发重加权，Analysis artifact 会保留 source-row lineage 与 composite coordinate coverage。

这是 #708 的 Core 阶段。面向普通用户的 eval-runtime AnalysisRequest、派生 Metric／Comparison 物化以及公开示例仍由后续 PR 完成，本 PR 不把 #708 标记为完成。

## 测量与契约

权重必须为正且严格求和为一；boolean 与有界 numeric source 才能映射到 `[0, 1]` utility，`lower-is-better` 显式反向。Quality estimator 必须封存单一 Variant，difference estimator 只接受 contrast 封存的两臂。Component 先在各自 Metric 内完成 panel／replicate 聚合，再按 Target／sample／trial 对齐组合，最后执行 trial aggregation 与 resampling，从而保留跨 Metric 协方差。

本次只新增版本化 builtin 与 parameter schema，不保留或检测 0.x 历史实现，也不改变既有单 Metric `/v1` 的 inconclusive lineage 语义。

## 自主 CR

最终结论：No findings。初审发现并已修复 comparison source rows 被接线层清空、quality 混合多个 Variant、既有 `/v1` lineage 漂移、非法证据 lineage 与浮点权重边界问题；修复后复查 Runtime materialization、Bundle verification、Plan identity、统计顺序、缺失策略与失败关闭路径，未发现新的 P0～P2。

## 验证

最终改动集已通过完整 `yarn ci`：319 个测试文件、3353 项测试，以及 typecheck、lint、Schema 检查和双语文档构建。Engine 真实链路覆盖 quality、paired difference、unpaired difference、Decision 与 source-row lineage。Core-only 改动没有改变包入口或安装契约，因此未重复 clean-room。

Refs #708