### PR TITLE
feat(eval-runtime): 支持认证阶段复用

### DIFF
--- a/docs/guides/eval-runtime.md
+++ b/docs/guides/eval-runtime.md
@@ -185,6 +185,30 @@ if (assessment.comparabilityStatus !== 'compatible') {
 
 The assessment never compares scores or decides whether the candidate improved. It checks whether the measurement design remained invariant after the declared subject change and whether both source chains have enough authenticated evidence. Preserve the exact result objects: a clone or deserialized artifact cannot retain the in-process Core source authority and fails closed. Persistent cross-process admission remains available through the advanced Core surface until the Runtime artifact-store adapter lands.
 
+When only a downstream measurement declaration changes, reuse the authenticated prefix instead of paying for the same Target work again:
+
+```ts
+import { reanalyze, redecide, rescore } from 'oh-my-knowledge';
+
+const rescored = await rescore(
+  { ...input, dataset: correctedGoldDataset },
+  originalResult,
+  { runId: 'corrected-gold' },
+);
+const reanalyzed = await reanalyze(
+  { ...input, analyses: revisedAnalyses },
+  rescored,
+  { runId: 'revised-analysis' },
+);
+const redecided = await redecide(
+  { ...input, analyses: revisedAnalyses, decision: revisedDecision },
+  reanalyzed,
+  { runId: 'revised-decision' },
+);
+```
+
+`rescore()` reuses Execution, `reanalyze()` reuses Execution plus Evaluation, and `redecide()` reuses Execution plus Evaluation plus Analysis. Each call takes a complete new declaration so defaults and identities are sealed before the suffix runs. Core rejects any change that belongs to a skipped stage, and only exact canonical result objects from the current process carry the required source authority. Run options, progress events, and budget consumption apply to the newly executed suffix; reused bundles retain their original identity and historical evidence without charging their work again. To reuse persisted Bundle documents across processes, use explicit Core admission with independent provenance verification; a report or JSON clone is never sufficient evidence.
+
 `executor.execute()` receives `variantId` in addition to the values shown above. Comparison roles belong to `comparisons`, not to the Executor invocation. Return `{ errorCode }` for an expected, stable, non-sensitive host failure; throwing an ordinary error becomes the redacted `EVAL_RUNTIME_EXECUTOR_FAILED` failure.
 
 Schemas validate and narrow only. OMK rejects parsers that coerce, add defaults, or drop JSON fields, because that would silently change the measured invocation under the same identity. Perform intentional transformations inside `execute()` and bump `version` or a measurement-relevant `fingerprintFacets` value.

--- a/docs/reference/eval-runtime-api.md
+++ b/docs/reference/eval-runtime-api.md
@@ -4,7 +4,7 @@
 
 ## `oh-my-knowledge`
 
-The recommended ordinary-user entry. It exposes exactly the same canonical Runtime façade as `oh-my-knowledge/eval-runtime`: `evaluate`, `prepareEvaluation`, `assessComparability`, `checkExecutor`, `checkContentStore`, their stable errors, and their public model types. Core engines, builders, registrations, and adapters are intentionally absent.
+The recommended ordinary-user entry. It exposes exactly the same canonical Runtime façade as `oh-my-knowledge/eval-runtime`: `evaluate`, `prepareEvaluation`, `rescore`, `reanalyze`, `redecide`, `assessComparability`, `checkExecutor`, `checkContentStore`, their stable errors, and their public model types. Core engines, builders, registrations, and adapters are intentionally absent.
 
 ## `oh-my-knowledge/eval-runtime`
 
@@ -14,6 +14,9 @@ The canonical API for application developers:
 |---|---|
 | `evaluate` | Run one explicit solo, paired, or independent-group evaluation design, including multi-arm and multi-metric comparisons. |
 | `prepareEvaluation` | Seal and inspect the exact Definition, Policy, Plan, Runtime resolutions, digest, and work estimate before any Target or Evaluator call. |
+| `rescore` | Reuse one authenticated Execution stage, then run Evaluation, Analysis, Decision, and Report under a newly sealed declaration. |
+| `reanalyze` | Reuse authenticated Execution and Evaluation stages, then run Analysis, Decision, and Report under a newly sealed declaration. |
+| `redecide` | Reuse authenticated Execution, Evaluation, and Analysis stages, then run a newly declared Decision and Report. |
 | `assessComparability` | Assess two authenticated canonical Run results at evaluation, analysis, or decision scope without rerunning either Target. |
 | `checkContentStore` | Exercise a host ContentStore／ContentResolver pair for descriptor integrity and stability, idempotent writes, and round-trip value, classification, and media type; host exceptions are reduced to stable reason codes. |
 | `checkExecutor` | Certify an Executor through success, failure, cancellation, cleanup, and measurement checks. |
@@ -74,6 +77,8 @@ const variant: Variant<string, undefined, string> = {
 `EvaluateInput` contains only the measurement declaration. `EvaluationRunOptions` contains run-scoped `runId`, cancellation, progress observation, report annotations／summaries, event-buffer capacity, and clock. Omitting `runId` generates one and returns it as `EvaluationResult.runId`. `prepareEvaluation(input)` captures all mutable declarations, materializes defaults, resolves Runtime capabilities, and seals the Core Plan without calling a Target or Evaluator. Its frozen `PreparedEvaluation` exposes the exact `definition`, `policy`, `plan`, complete-contract `planDigest`, `resolvedRuntimes`, and `estimatedWork`; `run(options)` executes that same sealed Plan without re-reading the input or recompiling. Planned coordinates exclude retries and early termination, while duration and provider cost remain explicitly uncertain until execution.
 
 `assessComparability()` consumes two exact `EvaluationResult` objects returned by canonical `evaluate()` or `PreparedEvaluation.run()` in the current process. A clone or deserialized document has no source authority and is rejected instead of being treated as verified. `comparisonScope` selects the deepest invariant contract to compare, while each `EvaluationComparabilitySubject` explicitly maps the intentionally changed Variant on the left and right. The returned `EvaluationComparabilityAssessment` is authored by Core and keeps `designStatus`, `evidenceQualificationStatus`, and overall `comparabilityStatus` separate. A mapped subject change is identity information, not a design mismatch; incomplete Runtime assurance remains conditional rather than being silently promoted. Persisted artifact admission remains an explicit advanced Core responsibility until the Runtime artifact-store contract is available.
+
+`rescore()`, `reanalyze()`, and `redecide()` take a complete new `EvaluateInput`, an exact prior `EvaluationResult`, and optional `EvaluationRunOptions`. The new declaration is sealed before reuse. Core recursively verifies that the retained source capability matches every skipped stage: changed Target input cannot be hidden behind `rescore`, changed Gold or Evaluator cannot be hidden behind `reanalyze`, and changed Analysis cannot be hidden behind `redecide`. A clone, deserialized report, or Bundle JSON has no in-process source authority and is rejected. Reused upstream bundles retain their original identities and historical evidence; every executed suffix stage receives the new Run identity, emits the only new progress events, and consumes only the new Run's suffix budget. The façade does not reconstruct evidence, rerun skipped callbacks, or duplicate Core scoring, statistics, Decision, Report, budget, cache, or scheduler behavior.
 
 `SamplingDesign` supports a one-Variant `solo` quality profile, complete-block `paired` comparisons, and fixed-quota `independent` comparisons. It is the only owner of paired／independent semantics. A solo design may declare `clusterKey`; Core then treats whole clusters as the experimental and resampling unit. A `Comparison` declares one control, one or more treatments, and the Metrics to analyze; it contains no duplicate sampling discriminator. `evaluators` may contain multiple exact-match, retrieval, tool-trajectory, Rubric Judge, or custom evaluators, provided evaluator and metric IDs are unique.
 

--- a/docs/zh/guides/eval-runtime.md
+++ b/docs/zh/guides/eval-runtime.md
@@ -182,6 +182,30 @@ if (assessment.comparabilityStatus !== 'compatible') {
 
 该 Assessment 不会比较分数，也不会判断候选是否进步；它只检查声明 subject 变化后，测量设计是否保持不变，以及两条 source chain 是否具备足够的认证证据。必须保留原始 result object：clone 或反序列化 artifact 无法保留进程内 Core source authority，因此会失败关闭。跨进程持久化 admission 在 Runtime artifact-store adapter 落地前继续由高级 Core surface 提供。
 
+只有下游测量声明发生变化时，可以复用已经认证的前缀，避免再次支付相同 Target 工作的成本：
+
+```ts
+import { reanalyze, redecide, rescore } from 'oh-my-knowledge';
+
+const rescored = await rescore(
+  { ...input, dataset: correctedGoldDataset },
+  originalResult,
+  { runId: 'corrected-gold' },
+);
+const reanalyzed = await reanalyze(
+  { ...input, analyses: revisedAnalyses },
+  rescored,
+  { runId: 'revised-analysis' },
+);
+const redecided = await redecide(
+  { ...input, analyses: revisedAnalyses, decision: revisedDecision },
+  reanalyzed,
+  { runId: 'revised-decision' },
+);
+```
+
+`rescore()` 复用 Execution，`reanalyze()` 复用 Execution 与 Evaluation，`redecide()` 复用 Execution、Evaluation 与 Analysis。每次调用都接收一份完整的新声明，确保默认值与 identity 在后缀运行前封存。Core 会拒绝任何属于已跳过阶段的变化；只有当前进程中的原始 canonical result object 携带所需 source authority。Run options、进度事件与预算消耗只作用于新执行的后缀；复用 bundle 保留原始 identity 与历史 evidence，不会再次计费。跨进程复用持久化 Bundle 时，应通过 Core 显式 admission 并独立验证 provenance；report 或 JSON clone 绝不是充分证据。
+
 除上面展示的值外，`executor.execute()` 还会收到 `variantId`。比较角色属于 `comparisons`，不会注入 Executor invocation。可预期的宿主失败应返回 `{ errorCode }`，其中 error code 必须稳定且不包含敏感信息；普通异常会统一成为脱敏的 `EVAL_RUNTIME_EXECUTOR_FAILED`。
 
 Schema 只能校验并收窄。若 parser coercion、补默认值或删除 JSON 字段，OMK 会拒绝执行，因为这些行为会在同一 identity 下静默改变实际测量。需要有意变换时，应在 `execute()` 内完成，并提升 `version` 或测量相关的 `fingerprintFacets`。

--- a/docs/zh/reference/eval-runtime-api.md
+++ b/docs/zh/reference/eval-runtime-api.md
@@ -4,7 +4,7 @@
 
 ## `oh-my-knowledge`
 
-这是普通用户的推荐入口，与 `oh-my-knowledge/eval-runtime` 暴露完全相同的 canonical Runtime façade：`evaluate`、`prepareEvaluation`、`assessComparability`、`checkExecutor`、`checkContentStore`、稳定错误和公开模型 type。Core engine、builder、registration 与 adapter 不会进入包根。
+这是普通用户的推荐入口，与 `oh-my-knowledge/eval-runtime` 暴露完全相同的 canonical Runtime façade：`evaluate`、`prepareEvaluation`、`rescore`、`reanalyze`、`redecide`、`assessComparability`、`checkExecutor`、`checkContentStore`、稳定错误和公开模型 type。Core engine、builder、registration 与 adapter 不会进入包根。
 
 ## `oh-my-knowledge/eval-runtime`
 
@@ -14,6 +14,9 @@
 |---|---|
 | `evaluate` | 运行一份显式的 solo、paired 或 independent-group 评测设计，包括多臂与多指标比较。 |
 | `prepareEvaluation` | 在任何 Target 或 Evaluator 调用前，封存并检查最终 Definition、Policy、Plan、Runtime resolution、digest 和工作量估计。 |
+| `rescore` | 复用已认证的 Execution stage，再按新封存声明执行 Evaluation、Analysis、Decision 与 Report。 |
+| `reanalyze` | 复用已认证的 Execution 与 Evaluation stage，再按新封存声明执行 Analysis、Decision 与 Report。 |
+| `redecide` | 复用已认证的 Execution、Evaluation 与 Analysis stage，再执行新声明的 Decision 与 Report。 |
 | `assessComparability` | 在不重新执行 Target 的前提下，按 evaluation、analysis 或 decision scope 评估两份已认证 canonical Run result 的可比性。 |
 | `checkContentStore` | 验证宿主 ContentStore／ContentResolver 的 descriptor 完整性与稳定性、幂等写入，以及回读 value、classification 和 media type；宿主异常只会归约为稳定 reason code。 |
 | `checkExecutor` | 通过成功、失败、取消、清理和测量检查认证 Executor。 |
@@ -74,6 +77,8 @@ const variant: Variant<string, undefined, string> = {
 `EvaluateInput` 只包含测量声明；`EvaluationRunOptions` 容纳单次运行的 `runId`、取消、进度观察、报告 annotation／summary、event buffer 容量与 clock。省略 `runId` 时由 Runtime 生成，并通过 `EvaluationResult.runId` 返回。`prepareEvaluation(input)` 会捕获全部可变声明、物化默认值、解析 Runtime capability，并在不调用 Target 或 Evaluator 的情况下封存 Core Plan。冻结的 `PreparedEvaluation` 暴露准确的 `definition`、`policy`、`plan`、完整运行契约 `planDigest`、`resolvedRuntimes` 与 `estimatedWork`；`run(options)` 直接执行同一份 sealed Plan，不重新读取 input 或重新编译。计划 coordinate 不包含 retry 与提前终止带来的变化，duration 和 provider cost 在执行前会明确保持不确定。
 
 `assessComparability()` 只接受当前进程中由 canonical `evaluate()` 或 `PreparedEvaluation.run()` 返回的两份原始 `EvaluationResult`。Clone 或反序列化文档不具备 source authority，会被拒绝而不是冒充已认证证据。`comparisonScope` 选择需要保持不变的最深契约阶段，每个 `EvaluationComparabilitySubject` 显式映射左右两侧有意变化的 Variant。返回的 `EvaluationComparabilityAssessment` 完全由 Core 生成，并将 `designStatus`、`evidenceQualificationStatus` 与总的 `comparabilityStatus` 分开保留；已映射 subject 的变化只是 identity 事实，不会被误判为设计漂移，未闭合的 Runtime assurance 则保持 conditional。持久化 artifact 的重新 admission 在 Runtime artifact-store contract 落地前仍属于显式的高级 Core 职责。
+
+`rescore()`、`reanalyze()` 与 `redecide()` 接收一份完整的新 `EvaluateInput`、一份原始 `EvaluationResult`，以及可选的 `EvaluationRunOptions`。Runtime 会先封存新声明，再由 Core 递归验证保留的 source capability 与全部跳过阶段一致：`rescore` 不能隐藏 Target 输入变化，`reanalyze` 不能隐藏 Gold 或 Evaluator 变化，`redecide` 不能隐藏 Analysis 变化。Clone、反序列化 report 或 Bundle JSON 不具备进程内 source authority，都会被拒绝。复用的上游 bundle 保留原始 identity 与历史 evidence；新执行的后缀阶段使用新 Run identity，只为后缀产生新进度事件，也只消耗新 Run 的后缀预算。Façade 不重建 evidence、不调用被跳过的 callback，也不复制 Core 的评分、统计、Decision、Report、预算、缓存或调度实现。
 
 `SamplingDesign` 支持单 Variant 的 `solo` 质量画像、complete-block `paired` 比较和 fixed-quota `independent` 比较，也是 paired／independent 语义的唯一持有者。solo 设计可以声明 `clusterKey`，此时 Core 将完整 cluster 作为实验单位与重采样单位。一项 `Comparison` 声明一个 control、一个或多个 treatment 与参与分析的 Metric，不再包含重复的 sampling 判别字段。`evaluators` 可包含多个 exact-match、retrieval、tool-trajectory、Rubric 评委或 custom evaluator，但 evaluator ID 与 metric ID 必须分别唯一。
 

--- a/src/eval-core/engine/index.ts
+++ b/src/eval-core/engine/index.ts
@@ -10,6 +10,7 @@ import {
   type EvaluationEvent,
   type EvaluationBundle,
   type EvaluationBundleSource,
+  type EvaluationReport,
   type ExecutionBundle,
   type ExecutionBundleSource,
   type AnalysisBundleSource,
@@ -344,6 +345,59 @@ export function getAuthenticatedEvaluationRunSources(
   return authenticatedEvaluationRunSources.get(result);
 }
 
+export interface AuthenticatedEvaluationRunResultInput {
+  readonly plan: SealedRunPlan;
+  readonly execution: ExecutionBundleSource;
+  readonly evaluation: EvaluationBundleSource;
+  readonly analysis: AnalysisBundleSource;
+  readonly decision?: DecisionResultSource;
+  readonly report: EvaluationReport;
+}
+
+/** Internal result materializer shared by full and staged façade runs. */
+export function materializeAuthenticatedEvaluationRunResult(
+  input: Readonly<AuthenticatedEvaluationRunResultInput>,
+): EvaluationRunResult {
+  const report = parseEvaluationReport(
+    input.report,
+    input.plan,
+    input.execution,
+    input.evaluation,
+    input.analysis,
+    input.decision,
+  );
+  const artifacts: EvaluationRunArtifacts = {
+    execution: input.execution.bundle,
+    evaluation: input.evaluation.bundle,
+    analysis: input.analysis.bundle,
+    ...(input.decision === undefined ? {} : { decision: input.decision.result }),
+  };
+  const result: EvaluationRunResult = report.status.runStatus === 'failed'
+    ? {
+        status: 'failed',
+        error: firstArtifactError(
+          artifacts.execution,
+          artifacts.evaluation,
+          artifacts.analysis,
+          artifacts.decision,
+        ) ?? {
+          code: 'EVALUATION_RUN_FAILED',
+          stage: 'internal',
+          message: 'Evaluation run 以 failed 状态结束。',
+        },
+        artifacts,
+        report,
+      }
+    : { status: report.status.runStatus, artifacts, report };
+  authenticatedEvaluationRunSources.set(result, Object.freeze({
+    execution: input.execution,
+    evaluation: input.evaluation,
+    analysis: input.analysis,
+    ...(input.decision === undefined ? {} : { decision: input.decision }),
+  }));
+  return result;
+}
+
 async function settleStage<T>(
   run: StageRun<T>,
   output: BoundedEventStream,
@@ -561,30 +615,14 @@ async function executePipeline(
       events: reportRun.events,
       source: reportRun.result,
     }, events);
-    const artifacts: EvaluationRunArtifacts = {
-      execution: execution.bundle,
-      evaluation: evaluation.bundle,
-      analysis: analysis.bundle,
-      ...(decision === undefined ? {} : { decision: decision.result }),
-    };
-    if (report.status.runStatus === 'failed') {
-      return authenticate({
-        status: 'failed',
-        error: firstArtifactError(
-          artifacts.execution,
-          artifacts.evaluation,
-          artifacts.analysis,
-          artifacts.decision,
-        ) ?? {
-          code: 'EVALUATION_RUN_FAILED',
-          stage: 'internal',
-          message: 'Evaluation run 以 failed 状态结束。',
-        },
-        artifacts,
-        report,
-      });
-    }
-    return authenticate({ status: report.status.runStatus, artifacts, report });
+    return materializeAuthenticatedEvaluationRunResult({
+      plan,
+      execution,
+      evaluation,
+      analysis,
+      ...(decision === undefined ? {} : { decision }),
+      report,
+    });
   } catch (error) {
     const artifacts: PartialEvaluationRunArtifacts = {
       ...(executionSource === undefined ? {} : { execution: executionSource.bundle }),

--- a/src/eval-runtime/evaluate.ts
+++ b/src/eval-runtime/evaluate.ts
@@ -15,16 +15,24 @@ import {
   deepFreezeCanonicalJson,
   canonicalizeJson,
   assessComparability as assessCoreComparability,
+  assertAnalysisBundleSourceMatchesPlan,
+  assertEvaluationBundleSourceMatchesPlan,
+  assertExecutionBundleSourceMatchesPlan,
   createComparabilityPolicy,
   derivePlannedExecutionCoordinates,
   digestCanonicalJson,
-  type EvaluationDefinition,
+  type AnalysisBundleSource,
   type AnalysisCohortDefinition,
   type AnalysisRecord,
   type ComparabilityAssessment,
   type ComparisonScope,
+  type DecisionResultSource,
+  type EvaluationBundleSource,
+  type EvaluationDefinition,
+  type EvaluationEvent,
   type EvaluationSample,
   type EvaluatorDefinition,
+  type ExecutionBundleSource,
   type JsonValue,
   type MetricDefinition,
   type RuntimeIdentity,
@@ -33,6 +41,8 @@ import {
 import {
   createEvaluationEngine as createCoreEvaluationEngine,
   getAuthenticatedEvaluationRunSources,
+  materializeAuthenticatedEvaluationRunResult,
+  type AdvancedPreparedEvaluation as CoreAdvancedPreparedEvaluation,
   type AuthenticatedEvaluationRunSources,
   type EvaluationEngineClock,
   type EvaluationRunResult,
@@ -998,6 +1008,7 @@ interface AuthenticatedCanonicalRun {
 }
 
 const authenticatedCanonicalRuns = new WeakMap<object, AuthenticatedCanonicalRun>();
+const corePreparedEvaluations = new WeakMap<object, CoreAdvancedPreparedEvaluation>();
 export type EventObserver = EvaluationEventObserver;
 export type Clock = EvaluationEngineClock;
 
@@ -1080,7 +1091,8 @@ export class EvaluationConfigurationError extends TypeError {
     | 'EVAL_RUNTIME_EXECUTOR_INVALID'
     | 'EVAL_RUNTIME_VARIANT_INVALID'
     | 'EVAL_RUNTIME_EVALUATOR_INVALID'
-    | 'EVAL_RUNTIME_COMPARABILITY_INVALID';
+    | 'EVAL_RUNTIME_COMPARABILITY_INVALID'
+    | 'EVAL_RUNTIME_REUSE_INVALID';
 
   constructor(code: EvaluationConfigurationError['code'], message: string) {
     super(message);
@@ -3579,7 +3591,7 @@ export async function prepareEvaluation(
   try {
     const prepared = await createCoreEvaluationEngine(runtime).prepare(definition, policy);
     const plan = prepared.plan;
-    return Object.freeze({
+    const facade: PreparedEvaluation = Object.freeze({
       definition: plan.definition,
       policy: plan.measurementPolicy,
       plan,
@@ -3588,6 +3600,8 @@ export async function prepareEvaluation(
       estimatedWork: estimateEvaluationWork(plan),
       run: (options?: Readonly<EvaluationRunOptions>) => runPrepared(prepared, options),
     });
+    corePreparedEvaluations.set(facade, prepared);
+    return facade;
   } catch (error) {
     if (error instanceof EvaluationConfigurationError) throw error;
     return configurationFailure(
@@ -3604,6 +3618,254 @@ export async function evaluate(
 ): Promise<EvaluationResult> {
   const capturedOptions = captureRunOptions(options);
   return (await prepareEvaluation(input)).run(capturedOptions);
+}
+
+type EvaluationReuseKind = 'rescore' | 'reanalyze' | 'redecide';
+
+interface ReuseEventConsumerState {
+  observerFailed: boolean;
+  observerFailure?: unknown;
+  streamFailed: boolean;
+  streamFailure?: unknown;
+}
+
+function createReuseEventConsumer(
+  observer: EventObserver | undefined,
+  controller: AbortController,
+) {
+  const state: ReuseEventConsumerState = {
+    observerFailed: false,
+    streamFailed: false,
+  };
+  let draining = Promise.resolve();
+  return Object.freeze({
+    state,
+    enqueue(events: AsyncIterable<EvaluationEvent>): void {
+      draining = draining.then(async () => {
+        try {
+          for await (const event of events) {
+            if (observer === undefined || state.observerFailed) continue;
+            try {
+              await observer(event);
+            } catch (error) {
+              state.observerFailed = true;
+              state.observerFailure = error;
+            }
+          }
+        } catch (error) {
+          if (!state.streamFailed) {
+            state.streamFailed = true;
+            state.streamFailure = error;
+            controller.abort(error);
+          }
+        }
+      });
+    },
+    async wait(): Promise<void> {
+      await draining;
+    },
+  });
+}
+
+function reuseSource(
+  result: EvaluationResult,
+): AuthenticatedCanonicalRun {
+  const source = authenticatedCanonicalRuns.get(result);
+  if (source === undefined) {
+    return configurationFailure(
+      'EVAL_RUNTIME_REUSE_INVALID',
+      'Evaluation stage reuse 只接受当前进程由 canonical Runtime 产生的原始 Run result。',
+    );
+  }
+  return source;
+}
+
+function assertReusablePrefix(
+  reuseKind: EvaluationReuseKind,
+  plan: SealedRunPlan,
+  source: AuthenticatedCanonicalRun,
+): Readonly<{
+  execution: ExecutionBundleSource;
+  evaluation?: EvaluationBundleSource;
+  analysis?: AnalysisBundleSource;
+}> {
+  const execution = source.sources.execution;
+  if (execution === undefined) {
+    return configurationFailure(
+      'EVAL_RUNTIME_REUSE_INVALID',
+      'Evaluation source result 缺少可复用的 Execution stage。',
+    );
+  }
+  try {
+    if (reuseKind === 'rescore') {
+      assertExecutionBundleSourceMatchesPlan(execution, plan);
+      return Object.freeze({ execution });
+    }
+    const evaluation = source.sources.evaluation;
+    if (evaluation === undefined) {
+      return configurationFailure(
+        'EVAL_RUNTIME_REUSE_INVALID',
+        'Evaluation source result 缺少可复用的 Evaluation stage。',
+      );
+    }
+    assertEvaluationBundleSourceMatchesPlan(plan, execution, evaluation);
+    if (reuseKind === 'reanalyze') {
+      return Object.freeze({ execution, evaluation });
+    }
+    const analysis = source.sources.analysis;
+    if (analysis === undefined) {
+      return configurationFailure(
+        'EVAL_RUNTIME_REUSE_INVALID',
+        'Evaluation source result 缺少可复用的 Analysis stage。',
+      );
+    }
+    assertAnalysisBundleSourceMatchesPlan(plan, execution, evaluation, analysis);
+    return Object.freeze({ execution, evaluation, analysis });
+  } catch (error) {
+    if (error instanceof EvaluationConfigurationError) throw error;
+    return configurationFailure(
+      'EVAL_RUNTIME_REUSE_INVALID',
+      'Evaluation source result 与新声明的可复用阶段不一致。',
+    );
+  }
+}
+
+async function runEvaluationSuffix(
+  reuseKind: EvaluationReuseKind,
+  input: Readonly<EvaluateInput>,
+  sourceResult: EvaluationResult,
+  options: Readonly<EvaluationRunOptions>,
+): Promise<EvaluationResult> {
+  const source = reuseSource(sourceResult);
+  const preparedFacade = await prepareEvaluation(input);
+  if (reuseKind === 'redecide' && preparedFacade.definition.decisionPolicy === undefined) {
+    return configurationFailure(
+      'EVAL_RUNTIME_REUSE_INVALID',
+      'redecide() 需要新声明包含 Decision。',
+    );
+  }
+  const prepared = corePreparedEvaluations.get(preparedFacade);
+  if (prepared === undefined) {
+    return configurationFailure(
+      'EVAL_RUNTIME_REUSE_INVALID',
+      'Evaluation prepared capability 无法用于阶段复用。',
+    );
+  }
+  const prefix = assertReusablePrefix(reuseKind, prepared.plan, source);
+  const runId = options.runId ?? `run-${randomUUID()}`;
+  const controller = new AbortController();
+  const abortFromCaller = (): void => controller.abort(options.signal?.reason);
+  if (options.signal?.aborted) abortFromCaller();
+  else options.signal?.addEventListener('abort', abortFromCaller, { once: true });
+  const consumer = createReuseEventConsumer(options.onEvent, controller);
+  let session: ReturnType<CoreAdvancedPreparedEvaluation['stages']> | undefined;
+  let result: EvaluationResult | undefined;
+  let stageFailure: unknown;
+  try {
+    session = prepared.stages({
+      runId,
+      ...(options.clock === undefined ? {} : { clock: options.clock }),
+      signal: controller.signal,
+      ...(options.annotations === undefined ? {} : { annotations: options.annotations }),
+      ...(options.summaries === undefined ? {} : { summaries: options.summaries }),
+      ...(options.eventBufferCapacity === undefined
+        ? {}
+        : { eventBufferCapacity: options.eventBufferCapacity }),
+    });
+    const execution = prefix.execution;
+    let evaluation = prefix.evaluation;
+    if (reuseKind === 'rescore') {
+      const evaluationRun = session.evaluate({ execution });
+      consumer.enqueue(evaluationRun.events);
+      evaluation = await evaluationRun.source;
+    }
+    if (evaluation === undefined) {
+      throw new TypeError('Evaluation stage source is unavailable.');
+    }
+    let analysis = prefix.analysis;
+    if (reuseKind !== 'redecide') {
+      const analysisRun = session.analyze({ execution, evaluation });
+      consumer.enqueue(analysisRun.events);
+      analysis = await analysisRun.source;
+    }
+    if (analysis === undefined) {
+      throw new TypeError('Analysis stage source is unavailable.');
+    }
+    const decisionRun = session.decide({ execution, evaluation, analysis });
+    consumer.enqueue(decisionRun.events);
+    const decision: DecisionResultSource | undefined = await decisionRun.source;
+    const reportRun = session.materializeReport({
+      execution,
+      evaluation,
+      analysis,
+      ...(decision === undefined ? {} : { decision }),
+    });
+    consumer.enqueue(reportRun.events);
+    const report = await reportRun.result;
+    const coreResult = materializeAuthenticatedEvaluationRunResult({
+      plan: prepared.plan,
+      execution,
+      evaluation,
+      analysis,
+      ...(decision === undefined ? {} : { decision }),
+      report,
+    });
+    result = attachDefinition(coreResult, runId, prepared.plan);
+  } catch (error) {
+    stageFailure = error;
+  } finally {
+    await session?.close();
+    await consumer.wait();
+    options.signal?.removeEventListener('abort', abortFromCaller);
+  }
+  if (stageFailure !== undefined || result === undefined) {
+    return configurationFailure(
+      'EVAL_RUNTIME_REUSE_INVALID',
+      'Evaluation stage reuse 无法完成。',
+    );
+  }
+  if (consumer.state.observerFailed) {
+    throw new EvaluationEventConsumptionError({
+      code: 'EVAL_RUNTIME_EVENT_OBSERVER_FAILED',
+      message: 'Evaluation event observer 执行失败；评测保持 Core 终态并完成清理。',
+      runResult: result,
+    });
+  }
+  if (consumer.state.streamFailed) {
+    throw new EvaluationEventConsumptionError({
+      code: 'EVAL_RUNTIME_EVENT_STREAM_FAILED',
+      message: 'Evaluation event stream 消费失败；评测已取消并完成清理。',
+      runResult: result,
+    });
+  }
+  return result;
+}
+
+/** Reuses an authenticated Execution stage and runs Evaluation onward. */
+export async function rescore(
+  input: Readonly<EvaluateInput>,
+  source: EvaluationResult,
+  options?: Readonly<EvaluationRunOptions>,
+): Promise<EvaluationResult> {
+  return runEvaluationSuffix('rescore', input, source, captureRunOptions(options));
+}
+
+/** Reuses authenticated Execution and Evaluation stages and runs Analysis onward. */
+export async function reanalyze(
+  input: Readonly<EvaluateInput>,
+  source: EvaluationResult,
+  options?: Readonly<EvaluationRunOptions>,
+): Promise<EvaluationResult> {
+  return runEvaluationSuffix('reanalyze', input, source, captureRunOptions(options));
+}
+
+/** Reuses authenticated Execution, Evaluation and Analysis stages and runs Decision onward. */
+export async function redecide(
+  input: Readonly<EvaluateInput>,
+  source: EvaluationResult,
+  options?: Readonly<EvaluationRunOptions>,
+): Promise<EvaluationResult> {
+  return runEvaluationSuffix('redecide', input, source, captureRunOptions(options));
 }
 
 function comparabilitySourcePrefix(

--- a/src/eval-runtime/index.ts
+++ b/src/eval-runtime/index.ts
@@ -7,6 +7,9 @@ export {
   checkExecutor,
   evaluate,
   prepareEvaluation,
+  reanalyze,
+  redecide,
+  rescore,
 } from './evaluate.js';
 export type {
   Artifact,

--- a/test/eval-core/embedded-package.test.ts
+++ b/test/eval-core/embedded-package.test.ts
@@ -36,6 +36,10 @@ const CLEAN_ROOM_HOST_FIXTURE = join(
   REPO_ROOT,
   'test/eval-runtime/fixtures/clean-room-host.mjs',
 );
+const STAGE_REUSE_HOST_FIXTURE = join(
+  REPO_ROOT,
+  'test/eval-runtime/fixtures/stage-reuse-host.mjs',
+);
 const ADVANCED_RUNTIME_HOST_FIXTURE = join(
   REPO_ROOT,
   'test/eval-runtime/fixtures/advanced-host.mjs',
@@ -148,6 +152,7 @@ describe('published embedded Evaluation API', () => {
     copyFileSync(RUNTIME_HOST_FIXTURE, join(projectRoot, 'runtime-host.mjs'));
     copyFileSync(RUBRIC_JUDGE_HOST_FIXTURE, join(projectRoot, 'rubric-judge-host.mjs'));
     copyFileSync(CLEAN_ROOM_HOST_FIXTURE, join(projectRoot, 'clean-room-host.mjs'));
+    copyFileSync(STAGE_REUSE_HOST_FIXTURE, join(projectRoot, 'stage-reuse-host.mjs'));
     copyFileSync(ADVANCED_RUNTIME_HOST_FIXTURE, join(projectRoot, 'advanced-runtime-host.mjs'));
     copyFileSync(PUBLIC_RUNTIME_EXAMPLE, join(projectRoot, 'public-runtime-example.mjs'));
     copyFileSync(TYPESCRIPT_HOST_FIXTURE, join(projectRoot, 'host.ts'));
@@ -178,6 +183,9 @@ const assert = require('node:assert/strict');
   const dshPlugin = await import('oh-my-knowledge/dsh-plugin');
   assert.deepEqual(Object.keys(api).sort(), Object.keys(evalRuntime).sort());
   assert.equal(typeof api.evaluate, 'function');
+  assert.equal(typeof api.rescore, 'function');
+  assert.equal(typeof api.reanalyze, 'function');
+  assert.equal(typeof api.redecide, 'function');
   assert.equal(typeof api.checkContentStore, 'function');
   assert.equal(typeof api.checkExecutor, 'function');
   assert.equal(api.createEvaluationEngine, undefined);
@@ -187,6 +195,9 @@ const assert = require('node:assert/strict');
   assert.equal(typeof api.assessComparability, 'function');
   assert.equal(typeof advanced.assessComparability, 'function');
   assert.equal(typeof evalRuntime.evaluate, 'function');
+  assert.equal(typeof evalRuntime.rescore, 'function');
+  assert.equal(typeof evalRuntime.reanalyze, 'function');
+  assert.equal(typeof evalRuntime.redecide, 'function');
   assert.equal(typeof evalRuntime.checkContentStore, 'function');
   assert.equal(typeof evalRuntime.checkExecutor, 'function');
   assert.equal(evalRuntime.createExecutorFnAdapter, undefined);
@@ -365,6 +376,34 @@ const assert = require('node:assert/strict');
     const isolatedCache = join(projectRoot, 'clean-room-cache');
     for (const directory of [isolatedHome, isolatedConfig, isolatedCache]) mkdirSync(directory);
     const result = spawnSync(process.execPath, [join(projectRoot, 'clean-room-host.mjs')], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      timeout: 30_000,
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        XDG_CONFIG_HOME: isolatedConfig,
+        XDG_CACHE_HOME: isolatedCache,
+      },
+    });
+    expect({ status: result.status, signal: result.signal, stderr: result.stderr }).toEqual({
+      status: 0,
+      signal: null,
+      stderr: '',
+    });
+    expect([
+      ...readdirSync(isolatedHome),
+      ...readdirSync(isolatedConfig),
+      ...readdirSync(isolatedCache),
+    ]).toEqual([]);
+  });
+
+  it('tarball clean-room 通过包根复用已认证阶段且不重跑 Target', () => {
+    const isolatedHome = join(projectRoot, 'stage-reuse-home');
+    const isolatedConfig = join(projectRoot, 'stage-reuse-config');
+    const isolatedCache = join(projectRoot, 'stage-reuse-cache');
+    for (const directory of [isolatedHome, isolatedConfig, isolatedCache]) mkdirSync(directory);
+    const result = spawnSync(process.execPath, [join(projectRoot, 'stage-reuse-host.mjs')], {
       cwd: projectRoot,
       encoding: 'utf8',
       timeout: 30_000,

--- a/test/eval-runtime/evaluate.test.ts
+++ b/test/eval-runtime/evaluate.test.ts
@@ -7,6 +7,9 @@ import {
   checkExecutor,
   evaluate,
   prepareEvaluation,
+  reanalyze,
+  redecide,
+  rescore,
   type Clock,
   type CustomEvaluator,
   type Executor,
@@ -309,6 +312,282 @@ describe('canonical eval-runtime API', () => {
       .toBe(direct.artifacts.evaluation.evaluationPlanDigest);
     expect(staged.artifacts.analysis.analysisPlanDigest)
       .toBe(direct.artifacts.analysis.analysisPlanDigest);
+  });
+
+  it('re-scores changed Gold without invoking Targets again', async () => {
+    let targetInvocations = 0;
+    const declaration = executor(async ({ input, config, signal }) => {
+      targetInvocations += 1;
+      signal.throwIfAborted();
+      return { output: config.answers[input.prompt] };
+    });
+    const sourceInput = pairedInput(declaration);
+    const source = await evaluate(sourceInput, { runId: 'rescore-source', clock: fixedClock });
+    expect(targetInvocations).toBe(4);
+
+    const changed = pairedInput(declaration);
+    changed.dataset.samples[0].expected = 'wrong';
+    const result = await rescore(changed, source, {
+      runId: 'rescore-result',
+      clock: fixedClock,
+    });
+
+    expect(targetInvocations).toBe(4);
+    expect(result.status).toBe('completed');
+    expect(result.artifacts?.execution).toBe(source.artifacts?.execution);
+    expect(result.artifacts?.evaluation?.bundleDigest)
+      .not.toBe(source.artifacts?.evaluation?.bundleDigest);
+    expect(result.artifacts?.analysis?.bundleDigest)
+      .not.toBe(source.artifacts?.analysis?.bundleDigest);
+    expect(result.report?.reportDigest).not.toBe(source.report?.reportDigest);
+  });
+
+  it('re-analyzes with a new analysis design without invoking Targets or Evaluators again', async () => {
+    let targetInvocations = 0;
+    const evaluatorInvocations = vi.fn();
+    const declaration = executor(async ({ input, config, signal }) => {
+      targetInvocations += 1;
+      signal.throwIfAborted();
+      return { output: config.answers[input.prompt] };
+    });
+    const custom = numericCustomEvaluator('length', ({ bindings }) => {
+      evaluatorInvocations();
+      return { resultKind: 'score', value: bindings.actual.length };
+    });
+    const sourceBase = pairedInput(declaration);
+    const sourceInput = {
+      ...sourceBase,
+      evaluators: [custom],
+      comparisons: [{
+        comparisonId: 'baseline-vs-candidate',
+        controlVariantId: controlSpec.variantId,
+        treatmentVariantIds: [treatmentSpec.variantId],
+        metricIds: ['length-score'],
+      }],
+      analyses: comparisonAnalysis('length-score'),
+      decision: {
+        decisionKind: 'analysis' as const,
+        analysisId: 'length-score-difference',
+      },
+    };
+    const source = await evaluate(sourceInput, {
+      runId: 'reanalyze-source',
+      clock: fixedClock,
+    });
+    expect(targetInvocations).toBe(4);
+    expect(evaluatorInvocations).toHaveBeenCalledTimes(4);
+    evaluatorInvocations.mockClear();
+
+    const changedBase = pairedInput(declaration);
+    const changed = {
+      ...sourceInput,
+      dataset: changedBase.dataset,
+      variants: changedBase.variants,
+      evaluators: sourceInput.evaluators,
+      analyses: comparisonAnalysis('length-score'),
+    };
+    changed.analyses[0].confidence.resamples = 200;
+    const result = await reanalyze(changed, source, {
+      runId: 'reanalyze-result',
+      clock: fixedClock,
+    });
+
+    expect(targetInvocations).toBe(4);
+    expect(evaluatorInvocations).not.toHaveBeenCalled();
+    expect(result.status).toBe('completed');
+    expect(result.artifacts?.execution).toBe(source.artifacts?.execution);
+    expect(result.artifacts?.evaluation).toBe(source.artifacts?.evaluation);
+    expect(result.artifacts?.analysis?.bundleDigest)
+      .not.toBe(source.artifacts?.analysis?.bundleDigest);
+  });
+
+  it('re-decides with a new policy without invoking Targets or Evaluators again', async () => {
+    let targetInvocations = 0;
+    const declaration = executor(async ({ input, config, signal }) => {
+      targetInvocations += 1;
+      signal.throwIfAborted();
+      return { output: config.answers[input.prompt] };
+    });
+    const sourceInput = pairedInput(declaration);
+    const source = await evaluate(sourceInput, { runId: 'redecide-source', clock: fixedClock });
+    const changedBase = pairedInput(declaration);
+    const changed = {
+      ...changedBase,
+      decision: { ...changedBase.decision, threshold: 0.75 },
+    };
+    const result = await redecide(changed, source, {
+      runId: 'redecide-result',
+      clock: fixedClock,
+    });
+
+    expect(targetInvocations).toBe(4);
+    expect(result.status).toBe('completed');
+    expect(result.artifacts?.execution).toBe(source.artifacts?.execution);
+    expect(result.artifacts?.evaluation).toBe(source.artifacts?.evaluation);
+    expect(result.artifacts?.analysis).toBe(source.artifacts?.analysis);
+    expect(result.artifacts?.decision?.decisionDigest)
+      .not.toBe(source.artifacts?.decision?.decisionDigest);
+  });
+
+  it('rejects cloned results and incompatible reusable prefixes before invoking a Target', async () => {
+    let targetInvocations = 0;
+    const declaration = executor(async ({ input, config }) => {
+      targetInvocations += 1;
+      return { output: config.answers[input.prompt] };
+    });
+    const sourceInput = pairedInput(declaration);
+    const source = await evaluate(sourceInput, { runId: 'reuse-validation-source' });
+    targetInvocations = 0;
+
+    await expect(rescore(sourceInput, structuredClone(source), {
+      runId: 'reuse-cloned-source',
+    })).rejects.toMatchObject({ code: 'EVAL_RUNTIME_REUSE_INVALID' });
+    const changed = pairedInput(declaration);
+    changed.variants[1] = {
+      ...changed.variants[1],
+      artifact: { ...changed.variants[1].artifact, content: 'Changed execution input.' },
+    };
+    await expect(rescore(changed, source, {
+      runId: 'reuse-incompatible-source',
+    })).rejects.toMatchObject({ code: 'EVAL_RUNTIME_REUSE_INVALID' });
+    expect(targetInvocations).toBe(0);
+  });
+
+  it('recursively rejects changes owned by every skipped parent stage', async () => {
+    const sourceInput = pairedInput();
+    const source = await evaluate(sourceInput, { runId: 'reuse-parent-source' });
+    const changedGold = pairedInput();
+    changedGold.dataset.samples[0].expected = 'wrong';
+    await expect(reanalyze(changedGold, source, {
+      runId: 'reuse-changed-gold',
+    })).rejects.toMatchObject({ code: 'EVAL_RUNTIME_REUSE_INVALID' });
+
+    const changedAnalysis = pairedInput();
+    changedAnalysis.analyses[0].confidence.resamples = 200;
+    await expect(redecide(changedAnalysis, source, {
+      runId: 'reuse-changed-analysis',
+    })).rejects.toMatchObject({ code: 'EVAL_RUNTIME_REUSE_INVALID' });
+  });
+
+  it('validates a re-decision declaration before reading its Decision', async () => {
+    const source = await evaluate(pairedInput(), { runId: 'reuse-invalid-input-source' });
+
+    await expect(redecide(null as never, source, {
+      runId: 'reuse-invalid-input',
+    })).rejects.toMatchObject({ code: 'EVAL_RUNTIME_INPUT_INVALID' });
+  });
+
+  it('uses the sealed Decision snapshot when the caller mutates input after invocation', async () => {
+    type MutableInput = Omit<ReturnType<typeof pairedInput>, 'decision'> & {
+      decision?: ReturnType<typeof pairedInput>['decision'];
+    };
+    const source = await evaluate(pairedInput(), { runId: 'reuse-decision-snapshot-source' });
+    const addedAfterInvocation: MutableInput = pairedInput();
+    delete addedAfterInvocation.decision;
+    const rejected = redecide(addedAfterInvocation, source, {
+      runId: 'reuse-decision-added-late',
+    });
+    addedAfterInvocation.decision = {
+      decisionKind: 'analysis',
+      analysisId: 'baseline-vs-candidate-correct',
+    };
+    await expect(rejected).rejects.toMatchObject({ code: 'EVAL_RUNTIME_REUSE_INVALID' });
+
+    const removedAfterInvocation: MutableInput = pairedInput();
+    const accepted = redecide(removedAfterInvocation, source, {
+      runId: 'reuse-decision-removed-late',
+    });
+    delete removedAfterInvocation.decision;
+    await expect(accepted).resolves.toMatchObject({
+      status: 'completed',
+      artifacts: { decision: { decisionStatus: 'decided' } },
+    });
+  });
+
+  it('keeps a completed re-score result when the best-effort observer fails', async () => {
+    const input = pairedInput();
+    const source = await evaluate(input, { runId: 'reuse-observer-source' });
+    let error: unknown;
+    try {
+      await rescore(input, source, {
+        runId: 'reuse-observer-result',
+        onEvent: () => { throw new Error('private observer failure'); },
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(EvaluationEventConsumptionError);
+    expect(error).toMatchObject({
+      code: 'EVAL_RUNTIME_EVENT_OBSERVER_FAILED',
+      runResult: { status: 'completed', runId: 'reuse-observer-result' },
+    });
+    expect((error as Error).message).not.toContain('private observer failure');
+  });
+
+  it('keeps suffix measurement independent from a slow ordered observer', async () => {
+    const evaluatorInvocations = vi.fn();
+    const custom = numericCustomEvaluator('observed-length', ({ bindings }) => {
+      evaluatorInvocations();
+      return { resultKind: 'score', value: bindings.actual.length };
+    });
+    const base = pairedInput();
+    const input = {
+      ...base,
+      evaluators: [custom],
+      comparisons: [{
+        comparisonId: 'baseline-vs-candidate',
+        controlVariantId: controlSpec.variantId,
+        treatmentVariantIds: [treatmentSpec.variantId],
+        metricIds: ['observed-length-score'],
+      }],
+      analyses: comparisonAnalysis('observed-length-score'),
+      decision: {
+        decisionKind: 'analysis' as const,
+        analysisId: 'observed-length-score-difference',
+      },
+    };
+    const source = await evaluate(input, { runId: 'reuse-slow-observer-source' });
+    evaluatorInvocations.mockClear();
+    let releaseObserver!: () => void;
+    const observerGate = new Promise<void>((resolve) => { releaseObserver = resolve; });
+    let firstEvent!: () => void;
+    const firstEventSeen = new Promise<void>((resolve) => { firstEvent = resolve; });
+    const sequences: number[] = [];
+    const run = rescore(input, source, {
+      runId: 'reuse-slow-observer-result',
+      async onEvent(event) {
+        sequences.push(event.sequence);
+        if (sequences.length === 1) {
+          firstEvent();
+          await observerGate;
+        }
+      },
+    });
+
+    await firstEventSeen;
+    await vi.waitFor(() => expect(evaluatorInvocations).toHaveBeenCalledTimes(4));
+    releaseObserver();
+    const result = await run;
+
+    expect(result.status).toBe('completed');
+    expect(sequences.length).toBeGreaterThan(0);
+    expect(sequences).toEqual([...sequences].sort((left, right) => left - right));
+  });
+
+  it('materializes a cancelled suffix run from an already-aborted caller signal', async () => {
+    const input = pairedInput();
+    const source = await evaluate(input, { runId: 'reuse-cancel-source' });
+    const controller = new AbortController();
+    controller.abort(new Error('caller cancellation'));
+
+    const result = await rescore(input, source, {
+      runId: 'reuse-cancel-result',
+      signal: controller.signal,
+    });
+
+    expect(result.status).toBe('cancelled');
+    expect(result.report?.status.runStatus).toBe('cancelled');
   });
 
   it('assesses independent Runs through their authenticated Core source chains', async () => {

--- a/test/eval-runtime/fixtures/stage-reuse-host.mjs
+++ b/test/eval-runtime/fixtures/stage-reuse-host.mjs
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { z } from 'zod';
+import { evaluate, reanalyze, redecide, rescore } from 'oh-my-knowledge';
+
+let targetInvocations = 0;
+const executor = {
+  executorId: 'clean-room.stage-reuse/v1',
+  version: '1.0.0',
+  schemas: {
+    input: z.object({ prompt: z.string() }).strict(),
+    config: z.object({ answers: z.record(z.string(), z.string()) }).strict(),
+    output: z.string(),
+  },
+  outputClassification: 'public',
+  capabilities: {
+    determinism: 'deterministic',
+    cancellation: 'cooperative',
+    concurrency: { safety: 'parallel-safe' },
+    seedControl: 'unsupported',
+    telemetry: { trace: 'unsupported', usage: 'optional' },
+  },
+  fingerprintFacets: { deploymentRevision: 'clean-room-one' },
+  async execute({ input, config, signal }) {
+    targetInvocations += 1;
+    signal.throwIfAborted();
+    return { output: config.answers[input.prompt] };
+  },
+};
+
+function declaration() {
+  return {
+    dataset: {
+      datasetId: 'stage-reuse-dataset',
+      samples: [
+        { sampleId: 'one', input: { prompt: 'one' }, expected: 'A' },
+        { sampleId: 'two', input: { prompt: 'two' }, expected: 'B' },
+      ],
+    },
+    variants: [{
+      variantId: 'baseline',
+      artifact: { name: 'baseline', kind: 'baseline', source: 'baseline', content: null },
+      execution: { executor, config: { answers: { one: 'A', two: 'wrong' } } },
+    }, {
+      variantId: 'candidate',
+      artifact: { name: 'candidate', kind: 'prompt', source: 'inline', content: 'Answer.' },
+      execution: { executor, config: { answers: { one: 'A', two: 'B' } } },
+    }],
+    evaluators: [{ evaluatorKind: 'exact-match' }],
+    comparisons: [{
+      comparisonId: 'baseline-vs-candidate',
+      controlVariantId: 'baseline',
+      treatmentVariantIds: ['candidate'],
+      metricIds: ['correct'],
+    }],
+    analyses: [{
+      analysisId: 'correct-difference',
+      analysisKind: 'comparison-interval',
+      statistic: 'mean-difference',
+      comparisonId: 'baseline-vs-candidate',
+      treatmentVariantId: 'candidate',
+      metricId: 'correct',
+      confidence: { method: 'percentile-bootstrap', level: 0.95, resamples: 100 },
+    }],
+    decision: { decisionKind: 'analysis', analysisId: 'correct-difference' },
+    experiment: { seed: 'stage-reuse-seed', sampling: { samplingKind: 'paired' } },
+    policy: {
+      execution: { maxConcurrency: 2 },
+      evaluation: { maxConcurrency: 2 },
+    },
+  };
+}
+
+const sourceInput = declaration();
+const source = await evaluate(sourceInput, { runId: 'stage-reuse-source' });
+assert.equal(source.status, 'completed');
+assert.equal(targetInvocations, 4);
+
+const rescoreInput = declaration();
+rescoreInput.dataset.samples[0].expected = 'wrong';
+const rescored = await rescore(rescoreInput, source, { runId: 'stage-reuse-rescored' });
+assert.equal(targetInvocations, 4);
+assert.equal(rescored.artifacts.execution, source.artifacts.execution);
+assert.notEqual(rescored.artifacts.evaluation.bundleDigest, source.artifacts.evaluation.bundleDigest);
+
+const reanalyzeInput = declaration();
+reanalyzeInput.dataset.samples[0].expected = 'wrong';
+reanalyzeInput.analyses[0].confidence.resamples = 200;
+const reanalyzed = await reanalyze(reanalyzeInput, rescored, {
+  runId: 'stage-reuse-reanalyzed',
+});
+assert.equal(targetInvocations, 4);
+assert.equal(reanalyzed.artifacts.execution, rescored.artifacts.execution);
+assert.equal(reanalyzed.artifacts.evaluation, rescored.artifacts.evaluation);
+assert.notEqual(reanalyzed.artifacts.analysis.bundleDigest, rescored.artifacts.analysis.bundleDigest);
+
+const redecideInput = declaration();
+redecideInput.dataset.samples[0].expected = 'wrong';
+redecideInput.analyses[0].confidence.resamples = 200;
+redecideInput.decision.threshold = 0.75;
+const redecided = await redecide(redecideInput, reanalyzed, {
+  runId: 'stage-reuse-redecided',
+});
+assert.equal(targetInvocations, 4);
+assert.equal(redecided.artifacts.execution, reanalyzed.artifacts.execution);
+assert.equal(redecided.artifacts.evaluation, reanalyzed.artifacts.evaluation);
+assert.equal(redecided.artifacts.analysis, reanalyzed.artifacts.analysis);
+assert.notEqual(
+  redecided.artifacts.decision.decisionDigest,
+  reanalyzed.artifacts.decision.decisionDigest,
+);
+
+await assert.rejects(
+  rescore(rescoreInput, structuredClone(source), { runId: 'stage-reuse-clone' }),
+  (error) => error?.code === 'EVAL_RUNTIME_REUSE_INVALID',
+);

--- a/test/eval-runtime/public-api.test.ts
+++ b/test/eval-runtime/public-api.test.ts
@@ -220,6 +220,9 @@ const PUBLIC_API = {
       'checkExecutor',
       'evaluate',
       'prepareEvaluation',
+      'reanalyze',
+      'redecide',
+      'rescore',
     ],
     types: [
       'AllowedToolsInput',


### PR DESCRIPTION
## 用户影响

程序化宿主现在可以从包根直接调用 `rescore()`、`reanalyze()` 与 `redecide()`：分别复用已认证的 Execution、Execution＋Evaluation、Execution＋Evaluation＋Analysis，只执行发生变化的后缀阶段，避免重复模型调用和评测成本。

每次复用仍提交一份完整新声明并先封存 Plan；只有当前进程由 canonical Runtime 返回的原始 `EvaluationResult` 具有 source authority。Clone、反序列化 report 或 Bundle JSON 会失败关闭。跨进程持久化 artifact admission 继续属于后续独立能力，不在本 PR 伪装支持。

## 迁移与兼容

这是新增 API，不保留或引入 0.x 兼容层、旧 overload、检测器或迁移提示。包根与 `oh-my-knowledge/eval-runtime` 保持完全一致。

## 测量与架构边界

Core 递归验证全部被跳过阶段的 source lineage 与 Plan identity：Target 输入变化不能藏在重评分后，Gold／Evaluator 变化不能藏在重分析后，Analysis 变化不能藏在重决策后。上游 bundle 保留原始 identity 与历史 evidence；新 Run 的事件和预算只覆盖实际执行的后缀。Runtime 复用 Core 的阶段状态机、评分、统计、Decision、Report、预算与缓存，不复制实现，也不引入 Workflow／CLI 或 provider 依赖。

## 验证与 CR

最终改动集已通过本地 `yarn ci`：329 个测试文件、3481 项测试全部通过；tarball clean-room 从包根连续完成三类复用，证明 Target 不重跑、clone 被拒绝、用户 HOME／config／cache 无写入。

自主多维 CR 共发现并修复 2 个 P2：非法空输入的稳定错误码缺口，以及封存后重读可变 Decision 的竞态。修复后 fresh-pass 与独立复查均为 No P0～P2 findings，无已知残余风险。

Refs #667

边界协调：#718 继续独立负责 Workflow → Runtime → Core 职责迁移，本 PR 不迁移 Workflow adapter。