### PR TITLE
chore(release): 发布 1.0.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 `1.0.0-beta.4` 到 npm `next`，供用户验证完成后的 Evaluation Core／Runtime 与程序化 API。npm `latest` 继续保持 `0.54.0`，普通稳定版安装与自动升级不受影响。

## 迁移与测量影响

这是 1.0 预览版的 breaking 汇总版本：canonical `evaluate()`、Analysis、Sampling Design、Rubric ensemble、生产 Policy／预算、cache、workspace／tools／MCP／mock、阶段复用、Series、comparability、conformance 与结果持久化均以当前唯一契约为准，不提供 0.x 或早期 beta 兼容 reader、检测器和迁移提示。

Schema identity、Runtime identity、sampling／analysis／policy contract 或 evidence qualification 不同的历史报告不得静默视为可比；应使用当前版本重新封存计划并按 comparability 结果判断。

## 验证

- 最终 `yarn ci` 通过：332 个测试文件、3531 项测试。
- `prepublishOnly` clean build 通过。
- 真实 tarball 在隔离临时项目安装成功；包根、`eval-runtime` 子路径、持久化 API 和 CLI 均报告 `1.0.0-beta.4`。
- npm 与 Git 均不存在同名版本／tag；发布 workflow 会将 prerelease 路由到 `next` 并生成 provenance。
- 自主多维 CR：No findings，无 P0～P2，工作树仅包含版本字段变更。
