### PR TITLE
chore(release): 发布 1.0.0-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 用户影响

发布 `1.0.0-beta.5`，包含 #733 的内置弃答评分器、可组合的检索示例和更易使用的中英文指南，以及 #732 的 Workflow／Runtime 分层与 Trial 工作目录隔离、#734 的知识领域设计文档。版本发布到 npm `next` 通道。

## 迁移与测量影响

**BREAKING-COMPARABILITY：** #732 将 Codex CLI／SDK、Claude CLI／SDK、DSH 和 custom-command 改为每个 Trial 使用独立工作目录；无 workspace 时从空目录开始，同一 Trial 的重试保留自身目录。删除 run 级共享目录，不提供恢复旧共享行为的兼容模式。升级后需在新版本下重新运行基线与候选版本，不应将旧报告视为相同运行条件。旧内部深层导入路径不提供兼容转发；评分公式、评委 prompt、Core Schema 和报告格式保持不变。

弃答评分要求执行成功且最终 ID 列表合法为空。正确弃答与错误弃答使用各自适用样本群，须结合覆盖率和有效分母解读，不能把失败或超时计为正确弃答。知识领域部分仅交付设计文档。

## 自主 CR 与验证

发版 diff 仅修改 `package.json` 版本号；已复核公开包入口、发布通道、附注标签校验与 OIDC 工作流。完整 `yarn ci` 通过（335 个测试文件、3572 项测试）；实际 tarball 在仓库外隔离安装，CLI 版本、公开 Runtime／Core 入口及组合弃答示例的 7 项指标均通过。最终自审 No findings，不修改评分或持久化契约。Node 22／24 的全部远端测试分片、quality 和 Cloudflare Pages 检查全部通过。已发布 [v1.0.0-beta.5](https://github.com/lizhiyao/oh-my-knowledge/releases/tag/v1.0.0-beta.5)，迁移说明已补齐。发布工作流全部通过；npm `next` 已指向本版并生成 provenance。发布后从 registry 隔离安装，校验版本、来源、完整性、CLI、公开入口与示例结果均通过。
