### PR TITLE
refactor(eval-hosts): 收敛 CLI 专属装配与共用宿主边界

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -104,7 +104,7 @@ Core alone owns their scheduling, retry, timeout, budget and measurement contrac
 
 ```text
 eval-hosts/
-├── node/                    # Node input resolution, environment, registry and delivery assembly
+├── node/                    # shared Node resolution, registry and preflight
 └── runtime-adapter/
     ├── adapters/            # concrete provider protocol bridges
     ├── evaluators/          # product evaluator factory wiring
@@ -117,6 +117,50 @@ remain in `eval-workflows/measurement`; generic execution and lifecycle bridges 
 The obsolete Workflow Runtime directory and forwarding wrappers are removed without a 0.x compatibility
 path. Correct Core/Runtime contracts take precedence over existing Workflow/CLI behavior. Legitimate
 missing capabilities belong in the responsible lower layer rather than a product execution bypass.
+
+### Source ownership and composition consumers
+
+Source directories express ownership; `package.json#exports` selects public entrypoints. A directory
+need not become a public API. This inventory distinguishes retained boundaries from consolidation
+work that still needs verification rather than forcing all domains into one pipeline.
+
+| Owner | Public entrypoints and actual consumers | Ownership and verification boundary |
+|---|---|---|
+| Core / Runtime | `eval-core`, package root and `eval-runtime`; service callers and product Workflow | Core execution and measurement contracts, Runtime adoption and generic scoring; verify published packages, contracts, scheduling and cancellation |
+| Workflow | `eval-samples`, `projections`; CLI, DSH, Studio and artifact evolution | Product declarations, versioned scoring/analysis, orchestration and evaluation stores; verify compilation, projections and release decisions |
+| Executors | Internal calls from host adapters, judges, doctor, sample, evolve and observation analysis | Shared invocation protocols and mechanics, not an obsolete evaluation path; verify arguments, environment, traces, usage and errors |
+| Knowledge artifacts | Internal consumers in CLI, Workflow, observation and governance | Artifact lifecycle; reassess source resolution shared across lifecycle operations that still resides in Workflow, preserving source identities and callers |
+| Observability / Diagnosis | MCP, DSH, CLI and Studio; observation storage parses the diagnosis contract | Separate evidence, signals and diagnoses; verify provenance, coverage and stable contracts |
+| Evidence | Product domains and delivery entrypoints | Cross-source storage layout and association; does not replace evaluation artifact validation or decide scores/releases |
+| CLI / DSH / MCP / Studio | `omk`, `dsh-plugin`, `mcp` / `omk-mcp`, `studio` | Own entry protocols, context, identity and presentation policy; verify real commands, plugins, services and views |
+| Shared | Internal leaf utilities | No domain decisions; verify atomic files, locks and basic data operations |
+
+Composition follows actual consumers. CLI provider selection, environment classification, credential
+resolution and production assembly live in `cli/lib/evaluation-composition.ts`. DSH agent context and
+judge invocation live in `dsh-plugin/core-command.ts`. DSH does not obtain shared capabilities through
+CLI modules. The retained `eval-hosts` boundary currently serves these shared consumers:
+
+| Module | Actual consumers | Contract, failure and resource boundary |
+|---|---|---|
+| `node/preflight.ts` | CLI and DSH | Explicit compiled input, environment and project root; lazy checks propagate failures through existing admission rules |
+| `node/node-cli-evaluation-resolver.ts` | CLI and DSH | Shared product request resolution; the retained request protocol name does not make it CLI entry policy |
+| `node/node-sample-content-resolver.ts`, `safe-http-content-resolver.ts` | Shared resolver above | File/network content resolution and session cleanup; verify source restrictions, cancellation and content identity |
+| `node/runtime-registry.ts`, `judge-provider-identity.ts` | CLI and DSH | Explicit registration and judge identity; shared registry does not select providers or read credentials on behalf of an entrypoint |
+| `runtime-adapter/assembly.ts`, `composition.ts`, `builtins.ts`, `preflight.ts` | CLI and DSH via Runtime provider | Binding, registration, admission and run-resource wiring; hosts implement cleanup while Runtime controls lifecycle |
+| `runtime-adapter/adapters`, `evaluators`, `resource-leases` | Composition above; DSH also uses resource interfaces | Provider bridges, evaluator wiring and resources cannot depend back on entry composition or bypass boundaries through aggregate exports |
+
+Direct service `evaluate()` uses Runtime/Core. CLI and DSH use compilation, host assembly and injected
+Runtime. Generation, repair and auxiliary analysis may directly use `ExecutorFn`. Observation facts
+reach Studio through diagnosis and domain projections. Extract shared mechanics according to those
+contracts. The user facade's event consumption and product run-lease wrapper do not constitute
+duplicate scheduling merely because both invoke Core.
+
+Consolidation first clarifies entry ownership and internal dependencies, then compares provider
+invocation paths, splits the large Runtime facade, and reassesses source resolution. Tests follow the
+actual owner. Retaining shared hosts does not freeze their directory name/layout or require moving
+all I/O there. Historical Schema/instrument versions are distinct from npm 0.x compatibility; decide
+retention or migration from public references and evidence-reading needs. The knowledge-content
+domain remains a design draft, not a reason to add placeholder implementations during consolidation.
 
 Evidence persistence and cross-source association have one non-decision boundary:
 

--- a/docs/zh/explanation/architecture.md
+++ b/docs/zh/explanation/architecture.md
@@ -98,7 +98,7 @@ provider adapter 或资源租约。单次执行和 Series 准备／执行归 Run
 
 ```text
 eval-hosts/
-├── node/                    # Node 输入解析、环境、工厂注册与交付装配
+├── node/                    # 共用 Node 解析、工厂注册与运行前检查
 └── runtime-adapter/
     ├── adapters/            # 具体 provider 协议桥接
     ├── evaluators/          # 产品 evaluator 工厂接线
@@ -109,6 +109,45 @@ eval-hosts/
 纯类型导入。产品测量实现在 `eval-workflows/measurement`，通用执行与生命周期桥接留在 Runtime。
 旧 Workflow Runtime 目录和转发包装已删除，不保留 0.x 兼容路径。Core／Runtime 的正确契约优先于
 Workflow／CLI 既有行为；合理的缺失能力应在所属下层补齐，不建立产品执行旁路。
+
+### 源码职责与装配消费者
+
+源码目录按所有者划分；公开入口由 `package.json#exports` 决定，不要求每个目录都成为公开 API。
+下表同时说明保留边界与待收敛的位置，后续结构调整仍须逐项验证，而不是把所有领域排成同一条流水线。
+
+| 所有者 | 公开入口与实际消费者 | 归属与验证边界 |
+|---|---|---|
+| Core／Runtime | `eval-core`、包根及 `eval-runtime`；服务调用方与产品 Workflow | Core 约束执行和测量协议，Runtime 提供通用评分与接入；验证公开包、契约、调度和取消 |
+| Workflow | `eval-samples`、`projections`；CLI、DSH、Studio、载体改进 | 产品声明、版本化评分／分析、编排与评测产物存储；验证编译、结果投影及发布判断 |
+| Executors | 内部调用；宿主适配、评委、doctor、sample、evolve 与观测分析 | 复用调用协议与机制；不能整体当作旧评测路径删除；验证参数、环境、Trace、用量与错误 |
+| Knowledge artifacts | 内部调用；CLI、Workflow、观测与治理 | 载体生命周期；跨生命周期的来源解析应核对是否仍错置在 Workflow，迁移前验证源身份和调用者 |
+| Observability／Diagnosis | MCP、DSH、CLI 与 Studio 消费；诊断协议在观测存储边界解析 | 分开维护证据、信号与诊断；验证来源、覆盖范围和稳定协议 |
+| Evidence | 各产品领域与交付入口 | 跨来源证据布局与关联；不替代 Workflow 的评测产物校验，不决定评分或发布 |
+| CLI／DSH／MCP／Studio | `omk`、`dsh-plugin`、`mcp`／`omk-mcp`、`studio` | 入口协议、上下文、身份和展示策略各自拥有；验证真实命令、插件、服务与界面 |
+| Shared | 内部叶子工具 | 不引入领域决策；验证文件原子性、锁与基础数据操作 |
+
+宿主装配按真实消费者归属。CLI 的 provider 选择、环境分类、凭证解析与生产装配位于
+`cli/lib/evaluation-composition.ts`；DSH 的 agent 上下文与评委调用在 `dsh-plugin/core-command.ts`。
+DSH 不通过 CLI 模块获取共用能力。当前保留 `eval-hosts` 的依据是以下跨入口复用：
+
+| 模块 | 实际消费者 | 契约、失败与资源边界 |
+|---|---|---|
+| `node/preflight.ts` | CLI 与 DSH | 显式接收编译结果、环境和项目根；延迟运行检查，失败按既有准入规则传播 |
+| `node/node-cli-evaluation-resolver.ts` | CLI 与 DSH | 共用产品请求解析；虽保留请求协议命名，并非 CLI 入口策略 |
+| `node/node-sample-content-resolver.ts`、`safe-http-content-resolver.ts` | 上述共用解析器 | 文件／网络内容解析与会话清理；验证来源限制、取消和内容身份 |
+| `node/runtime-registry.ts`、`judge-provider-identity.ts` | CLI 与 DSH | 显式注册配置与评委身份；不在共用注册中替入口选择 provider 或读取凭证 |
+| `runtime-adapter/assembly.ts`、`composition.ts`、`builtins.ts`、`preflight.ts` | CLI 与 DSH 经 Runtime provider 消费 | 绑定、注册、准入及运行资源接线；具体资源清理由宿主提供，生命周期由 Runtime 控制 |
+| `runtime-adapter/adapters`、`evaluators`、`resource-leases` | 上述装配；DSH 复用资源接口 | provider 桥接、评分工厂接线与资源实现；不得反向依赖入口装配或通过聚合入口绕行 |
+
+服务直接调用 `evaluate()` 时使用 Runtime／Core；CLI 与 DSH 使用编译、宿主装配和注入的
+Runtime；生成、修复及辅助分析可以直接使用 `ExecutorFn`；观测事实经诊断与领域投影进入
+Studio。这些路径用途不同，共用机制须按契约提取。用户 façade 的事件消费与产品运行租约也不能
+仅因都调用 Core 就认定为重复调度。
+
+结构调整优先处理入口归属与内部依赖，再按 provider 对照收敛调用机制、拆分 Runtime 大入口、
+复核来源解析。测试需跟随实际所有者迁移。当前保留共用宿主不意味着其目录名和内部布局不可改；
+也不意味着所有 I/O 都要移到宿主。历史 Schema／instrument 版本与 npm 0.x 兼容是不同问题，
+应依据公开引用与证据读取需求决定保留或迁移。知识内容领域仍为设计稿，不以本轮整理补占位实现。
 
 Evidence 持久化与跨来源关联属于同一个不做决策的边界：
 

--- a/src/cli/lib/evaluation-composition.ts
+++ b/src/cli/lib/evaluation-composition.ts
@@ -1,6 +1,7 @@
-import { createOmkRuntimeProvider, createOmkEvaluationSchemaValidators } from '../runtime-adapter/composition.js';
+import { createNodeHostPreflightDeclarations } from '../../eval-hosts/node/preflight.js';
+import { createOmkRuntimeProvider, createOmkEvaluationSchemaValidators } from '../../eval-hosts/runtime-adapter/composition.js';
 import type { EvaluationRuntimeProvider } from '../../eval-runtime/provider.js';
-import { access, readFile, realpath } from 'node:fs/promises';
+import { access, realpath } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { delimiter, isAbsolute, join } from 'node:path';
 import {
@@ -9,51 +10,45 @@ import {
   type RuntimeIdentity,
   type UsageRecord,
 } from '../../eval-core/contracts/index.js';
-import { checkDependencies } from '../../executors/preflight/dependencies.js';
 import { createExecutor } from '../../executors/index.js';
 import type { ExecutorFn } from '../../executors/contracts/ports.js';
 import { resolveExecutorRuntimeFingerprint } from '../../executors/core/runtime-fingerprint.js';
-import type { Artifact } from '../../knowledge-artifacts/contracts.js';
 import type { CliEvaluationCompileResult } from '../../eval-workflows/input-compilation/index.js';
 import type {
   OmkLlmJudgeInvocationBinding,
-} from '../runtime-adapter/evaluators/llm-judge-invocation.js';
+} from '../../eval-hosts/runtime-adapter/evaluators/llm-judge-invocation.js';
 import type {
   OmkLlmJudgeInvocationRequest,
-} from '../runtime-adapter/index.js';
-import type {
-  OmkRuntimePreflightDeclaration,
-} from '../runtime-adapter/types.js';
-import { OmkUserFacingPreflightFailure } from '../runtime-adapter/preflight.js';
+} from '../../eval-hosts/runtime-adapter/index.js';
 import {
   createAnthropicApiCoreSchemaValidators,
-} from '../runtime-adapter/adapters/anthropic/protocol.js';
+} from '../../eval-hosts/runtime-adapter/adapters/anthropic/protocol.js';
 import {
   createClaudeCliCoreSchemaValidators,
-} from '../runtime-adapter/adapters/claude/cli-protocol.js';
+} from '../../eval-hosts/runtime-adapter/adapters/claude/cli-protocol.js';
 import {
   createClaudeSdkCoreSchemaValidators,
-} from '../runtime-adapter/adapters/claude/sdk-protocol.js';
+} from '../../eval-hosts/runtime-adapter/adapters/claude/sdk-protocol.js';
 import {
   createCodexCliCoreSchemaValidators,
-} from '../runtime-adapter/adapters/codex/cli-protocol.js';
+} from '../../eval-hosts/runtime-adapter/adapters/codex/cli-protocol.js';
 import {
   createCodexSdkCoreSchemaValidators,
-} from '../runtime-adapter/adapters/codex/sdk-protocol.js';
+} from '../../eval-hosts/runtime-adapter/adapters/codex/sdk-protocol.js';
 import {
   createCustomCommandCoreSchemaValidators,
   customCommandExecutorCapabilities,
-} from '../runtime-adapter/adapters/custom/command.js';
+} from '../../eval-hosts/runtime-adapter/adapters/custom/command.js';
 import {
   createOpenAIApiCoreSchemaValidators,
-} from '../runtime-adapter/adapters/openai/protocol.js';
-import type { ClassifiedEnvironmentEntry } from '../runtime-adapter/adapters/shared/classified-environment.js';
-import { createJudgeProviderRuntimeIdentity } from './judge-provider-identity.js';
+} from '../../eval-hosts/runtime-adapter/adapters/openai/protocol.js';
+import type { ClassifiedEnvironmentEntry } from '../../eval-hosts/runtime-adapter/adapters/shared/classified-environment.js';
+import { createJudgeProviderRuntimeIdentity } from '../../eval-hosts/node/judge-provider-identity.js';
 import {
   createNodeEvaluationRuntimeSupportPorts,
   createProductionRuntimeFactoryRegistry,
   type ProductionExecutorAdapterConfiguration,
-} from './runtime-registry.js';
+} from '../../eval-hosts/node/runtime-registry.js';
 
 const CREDENTIAL_ENVIRONMENT = new Set([
   'ANTHROPIC_API_KEY',
@@ -174,180 +169,6 @@ async function resolveExecutable(
     'NODE_CLI_EXECUTABLE_UNAVAILABLE',
     `执行器「${command}」在当前 PATH 中不可用。`,
   );
-}
-
-function record(value: unknown): Readonly<Record<string, unknown>> | undefined {
-  return value !== null && typeof value === 'object' && !Array.isArray(value)
-    ? value as Readonly<Record<string, unknown>>
-    : undefined;
-}
-
-async function doctorArtifacts(compiled: CliEvaluationCompileResult): Promise<Artifact[]> {
-  const targetsById = new Map(compiled.definition.targets.map((target) => [target.targetId, target]));
-  return Promise.all(compiled.hostResources.resources.flatMap((resource) => {
-    if (resource.resourceKind !== 'artifact') return [];
-    const lineage = record(resource.lineage);
-    const targetId = typeof lineage?.targetId === 'string' ? lineage.targetId : undefined;
-    const target = targetId === undefined ? undefined : targetsById.get(targetId);
-    const artifactKind = lineage?.artifactKind;
-    if (target === undefined || artifactKind === 'baseline'
-        || !['skill', 'prompt', 'agent', 'workflow'].includes(String(artifactKind))) return [];
-    return [(async (): Promise<Artifact> => {
-      const sourceLocator = typeof lineage?.sourceLocator === 'string'
-        ? lineage.sourceLocator
-        : resource.locator;
-      const isDirectorySkill = typeof lineage?.skillRootLocator === 'string';
-      const skillRoot = isDirectorySkill ? resource.locator : undefined;
-      const contentPath = skillRoot === undefined
-        ? resource.locator
-        : join(resource.locator, 'SKILL.md');
-      const content = await readFile(contentPath, 'utf8');
-      const sourceKind = lineage?.sourceKind;
-      return {
-        name: target.targetId,
-        kind: artifactKind as Artifact['kind'],
-        source: ['variant-name', 'file-path', 'git', 'inline', 'custom'].includes(String(sourceKind))
-          ? sourceKind as Artifact['source']
-          : 'custom',
-        content,
-        locator: sourceLocator,
-        ...(skillRoot === undefined ? {} : { skillRoot }),
-        ...(typeof lineage?.workingDirectoryLocator === 'string'
-          ? { cwd: lineage.workingDirectoryLocator }
-          : {}),
-      };
-    })()];
-  }));
-}
-
-function dependencyDoctor(
-  compiled: CliEvaluationCompileResult,
-  environment: NodeJS.ProcessEnv,
-  projectRoot: string,
-): OmkRuntimePreflightDeclaration {
-  let result: Promise<void> | undefined;
-  return Object.freeze({
-    preflightKind: 'doctor' as const,
-    checkId: 'host-dependencies',
-    preflightDisposition: 'check' as const,
-    async run(): Promise<void> {
-      result ??= (async () => {
-        const requirements = compiled.orchestration.dependencyRequirements;
-        if (requirements !== undefined) {
-          const { baseDirectoryLocator, ...dependencies } = requirements;
-          const checked = await checkDependencies({
-            ...(dependencies.tools === undefined ? {} : { tools: [...dependencies.tools] }),
-            ...(dependencies.files === undefined ? {} : { files: [...dependencies.files] }),
-            ...(dependencies.env === undefined ? {} : { env: [...dependencies.env] }),
-            ...(dependencies.preflight === undefined ? {} : {
-              preflight: [...dependencies.preflight],
-            }),
-          }, baseDirectoryLocator, environment);
-          if (!checked.ok) throw new Error('Evaluation dependency doctor failed.');
-        }
-        const artifacts = await doctorArtifacts(compiled);
-        if (artifacts.length === 0) return;
-        const { runDoctor } = await import('../../knowledge-artifacts/doctor/index.js');
-        const { renderDoctorReportText } = await import('../../knowledge-artifacts/doctor/renderer.js');
-        const { tEvalWorkflowMessage } = await import('../../eval-workflows/messages.js');
-        const language = compiled.presentation.language;
-        const report = await runDoctor({
-          artifacts,
-          cwd: projectRoot,
-          dependencyCwd: requirements?.baseDirectoryLocator ?? projectRoot,
-          executorName: compiled.definition.targets[0]?.executorId ?? 'unknown',
-          model: 'core-runtime',
-          timeoutMs: compiled.policy.execution.timeoutMs ?? 8_000,
-          lang: language,
-        });
-        if (report.outcome === 'failed') {
-          renderDoctorReportText(report, language);
-          throw new OmkUserFacingPreflightFailure(
-            `doctor failed:\n${tEvalWorkflowMessage('doctor_gate_blocked', language)}`,
-          );
-        }
-      })();
-      return result;
-    },
-  });
-}
-
-export function createNodeHostPreflightDeclarations(
-  compiled: CliEvaluationCompileResult,
-  environment: NodeJS.ProcessEnv,
-  projectRoot: string,
-): readonly OmkRuntimePreflightDeclaration[] {
-  const hasMcpResource = compiled.hostResources.resources.some(
-    (resource) => resource.resourceKind === 'mcp-config',
-  );
-  const hasMockResource = compiled.hostResources.resources.some(
-    (resource) => resource.resourceKind === 'mock-plan'
-      || resource.resourceKind === 'mock-rule'
-      || resource.resourceKind === 'mock-payload',
-  );
-  const mcpPreflight: OmkRuntimePreflightDeclaration = hasMcpResource
-    ? {
-        preflightKind: 'mcp-readiness',
-        checkId: 'sealed-mcp-resource',
-        preflightDisposition: 'check',
-        async run(): Promise<void> {
-          await Promise.all(compiled.hostResources.resources
-            .filter((resource) => resource.resourceKind === 'mcp-config')
-            .map((resource) => access(resource.locator, constants.R_OK)));
-        },
-      }
-    : {
-        preflightKind: 'mcp-readiness',
-        checkId: 'sealed-mcp-resource',
-        preflightDisposition: 'not-required',
-        reasonCode: 'no-mcp-resource',
-      };
-  const mockPreflight: OmkRuntimePreflightDeclaration = hasMockResource
-    ? {
-        preflightKind: 'mock-readiness',
-        checkId: 'sealed-mock-resources',
-        preflightDisposition: 'check',
-        async run(): Promise<void> {
-          await Promise.all(compiled.hostResources.resources
-            .filter((resource) => resource.resourceKind === 'mock-plan'
-              || resource.resourceKind === 'mock-rule'
-              || resource.resourceKind === 'mock-payload')
-            .map((resource) => access(resource.locator, constants.R_OK)));
-        },
-      }
-    : {
-        preflightKind: 'mock-readiness',
-        checkId: 'sealed-mock-resources',
-        preflightDisposition: 'not-required',
-        reasonCode: 'no-mock-resource',
-      };
-  return Object.freeze([
-    dependencyDoctor(compiled, environment, projectRoot),
-    Object.freeze({
-      preflightKind: 'filesystem' as const,
-      checkId: 'sealed-resource-locators',
-      preflightDisposition: 'check' as const,
-      async run(): Promise<void> {
-        await Promise.all(compiled.hostResources.resources.map((resource) => (
-          access(resource.locator, constants.R_OK)
-        )));
-      },
-    }),
-    Object.freeze(mcpPreflight),
-    Object.freeze(mockPreflight),
-    Object.freeze({
-      preflightKind: 'credential' as const,
-      checkId: 'host-credential',
-      preflightDisposition: 'not-required' as const,
-      reasonCode: 'adapter-validates-credential',
-    }),
-    Object.freeze({
-      preflightKind: 'connectivity' as const,
-      checkId: 'provider-connectivity',
-      preflightDisposition: 'not-required' as const,
-      reasonCode: 'core-execution-is-authoritative',
-    }),
-  ]);
 }
 
 function requiredCredential(

--- a/src/cli/lib/run-core-evaluation.ts
+++ b/src/cli/lib/run-core-evaluation.ts
@@ -17,7 +17,7 @@ import {
 } from '../../eval-workflows/artifact-store/index.js';
 import {
   createNodeCliProductionComposition,
-} from '../../eval-hosts/node/node-cli-composition.js';
+} from './evaluation-composition.js';
 import {
   createProductionEvaluationHost,
   executeProductionEvaluationSeries,

--- a/src/dsh-plugin/core-command.ts
+++ b/src/dsh-plugin/core-command.ts
@@ -21,7 +21,7 @@ import {
 } from '../eval-hosts/node/runtime-registry.js';
 import {
   createNodeHostPreflightDeclarations,
-} from '../eval-hosts/node/node-cli-composition.js';
+} from '../eval-hosts/node/preflight.js';
 import {
   createProductionEvaluationHost,
   executeProductionEvaluationSeries,

--- a/src/eval-hosts/node/index.ts
+++ b/src/eval-hosts/node/index.ts
@@ -1,4 +1,4 @@
-export * from './node-cli-composition.js';
+export * from './preflight.js';
 export * from './node-cli-evaluation-resolver.js';
 export * from './node-sample-content-resolver.js';
 export * from './safe-http-content-resolver.js';

--- a/src/eval-hosts/node/preflight.ts
+++ b/src/eval-hosts/node/preflight.ts
@@ -1,0 +1,182 @@
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { join } from 'node:path';
+import { checkDependencies } from '../../executors/preflight/dependencies.js';
+import type { Artifact } from '../../knowledge-artifacts/contracts.js';
+import type { CliEvaluationCompileResult } from '../../eval-workflows/input-compilation/index.js';
+import type { OmkRuntimePreflightDeclaration } from '../runtime-adapter/types.js';
+import { OmkUserFacingPreflightFailure } from '../runtime-adapter/preflight.js';
+
+function record(value: unknown): Readonly<Record<string, unknown>> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Readonly<Record<string, unknown>>
+    : undefined;
+}
+
+async function doctorArtifacts(compiled: CliEvaluationCompileResult): Promise<Artifact[]> {
+  const targetsById = new Map(compiled.definition.targets.map((target) => [target.targetId, target]));
+  return Promise.all(compiled.hostResources.resources.flatMap((resource) => {
+    if (resource.resourceKind !== 'artifact') return [];
+    const lineage = record(resource.lineage);
+    const targetId = typeof lineage?.targetId === 'string' ? lineage.targetId : undefined;
+    const target = targetId === undefined ? undefined : targetsById.get(targetId);
+    const artifactKind = lineage?.artifactKind;
+    if (target === undefined || artifactKind === 'baseline'
+        || !['skill', 'prompt', 'agent', 'workflow'].includes(String(artifactKind))) return [];
+    return [(async (): Promise<Artifact> => {
+      const sourceLocator = typeof lineage?.sourceLocator === 'string'
+        ? lineage.sourceLocator
+        : resource.locator;
+      const isDirectorySkill = typeof lineage?.skillRootLocator === 'string';
+      const skillRoot = isDirectorySkill ? resource.locator : undefined;
+      const contentPath = skillRoot === undefined
+        ? resource.locator
+        : join(resource.locator, 'SKILL.md');
+      const content = await readFile(contentPath, 'utf8');
+      const sourceKind = lineage?.sourceKind;
+      return {
+        name: target.targetId,
+        kind: artifactKind as Artifact['kind'],
+        source: ['variant-name', 'file-path', 'git', 'inline', 'custom'].includes(String(sourceKind))
+          ? sourceKind as Artifact['source']
+          : 'custom',
+        content,
+        locator: sourceLocator,
+        ...(skillRoot === undefined ? {} : { skillRoot }),
+        ...(typeof lineage?.workingDirectoryLocator === 'string'
+          ? { cwd: lineage.workingDirectoryLocator }
+          : {}),
+      };
+    })()];
+  }));
+}
+
+function dependencyDoctor(
+  compiled: CliEvaluationCompileResult,
+  environment: NodeJS.ProcessEnv,
+  projectRoot: string,
+): OmkRuntimePreflightDeclaration {
+  let result: Promise<void> | undefined;
+  return Object.freeze({
+    preflightKind: 'doctor' as const,
+    checkId: 'host-dependencies',
+    preflightDisposition: 'check' as const,
+    async run(): Promise<void> {
+      result ??= (async () => {
+        const requirements = compiled.orchestration.dependencyRequirements;
+        if (requirements !== undefined) {
+          const { baseDirectoryLocator, ...dependencies } = requirements;
+          const checked = await checkDependencies({
+            ...(dependencies.tools === undefined ? {} : { tools: [...dependencies.tools] }),
+            ...(dependencies.files === undefined ? {} : { files: [...dependencies.files] }),
+            ...(dependencies.env === undefined ? {} : { env: [...dependencies.env] }),
+            ...(dependencies.preflight === undefined ? {} : {
+              preflight: [...dependencies.preflight],
+            }),
+          }, baseDirectoryLocator, environment);
+          if (!checked.ok) throw new Error('Evaluation dependency doctor failed.');
+        }
+        const artifacts = await doctorArtifacts(compiled);
+        if (artifacts.length === 0) return;
+        const { runDoctor } = await import('../../knowledge-artifacts/doctor/index.js');
+        const { renderDoctorReportText } = await import('../../knowledge-artifacts/doctor/renderer.js');
+        const { tEvalWorkflowMessage } = await import('../../eval-workflows/messages.js');
+        const language = compiled.presentation.language;
+        const report = await runDoctor({
+          artifacts,
+          cwd: projectRoot,
+          dependencyCwd: requirements?.baseDirectoryLocator ?? projectRoot,
+          executorName: compiled.definition.targets[0]?.executorId ?? 'unknown',
+          model: 'core-runtime',
+          timeoutMs: compiled.policy.execution.timeoutMs ?? 8_000,
+          lang: language,
+        });
+        if (report.outcome === 'failed') {
+          renderDoctorReportText(report, language);
+          throw new OmkUserFacingPreflightFailure(
+            `doctor failed:\n${tEvalWorkflowMessage('doctor_gate_blocked', language)}`,
+          );
+        }
+      })();
+      return result;
+    },
+  });
+}
+
+export function createNodeHostPreflightDeclarations(
+  compiled: CliEvaluationCompileResult,
+  environment: NodeJS.ProcessEnv,
+  projectRoot: string,
+): readonly OmkRuntimePreflightDeclaration[] {
+  const hasMcpResource = compiled.hostResources.resources.some(
+    (resource) => resource.resourceKind === 'mcp-config',
+  );
+  const hasMockResource = compiled.hostResources.resources.some(
+    (resource) => resource.resourceKind === 'mock-plan'
+      || resource.resourceKind === 'mock-rule'
+      || resource.resourceKind === 'mock-payload',
+  );
+  const mcpPreflight: OmkRuntimePreflightDeclaration = hasMcpResource
+    ? {
+        preflightKind: 'mcp-readiness',
+        checkId: 'sealed-mcp-resource',
+        preflightDisposition: 'check',
+        async run(): Promise<void> {
+          await Promise.all(compiled.hostResources.resources
+            .filter((resource) => resource.resourceKind === 'mcp-config')
+            .map((resource) => access(resource.locator, constants.R_OK)));
+        },
+      }
+    : {
+        preflightKind: 'mcp-readiness',
+        checkId: 'sealed-mcp-resource',
+        preflightDisposition: 'not-required',
+        reasonCode: 'no-mcp-resource',
+      };
+  const mockPreflight: OmkRuntimePreflightDeclaration = hasMockResource
+    ? {
+        preflightKind: 'mock-readiness',
+        checkId: 'sealed-mock-resources',
+        preflightDisposition: 'check',
+        async run(): Promise<void> {
+          await Promise.all(compiled.hostResources.resources
+            .filter((resource) => resource.resourceKind === 'mock-plan'
+              || resource.resourceKind === 'mock-rule'
+              || resource.resourceKind === 'mock-payload')
+            .map((resource) => access(resource.locator, constants.R_OK)));
+        },
+      }
+    : {
+        preflightKind: 'mock-readiness',
+        checkId: 'sealed-mock-resources',
+        preflightDisposition: 'not-required',
+        reasonCode: 'no-mock-resource',
+      };
+  return Object.freeze([
+    dependencyDoctor(compiled, environment, projectRoot),
+    Object.freeze({
+      preflightKind: 'filesystem' as const,
+      checkId: 'sealed-resource-locators',
+      preflightDisposition: 'check' as const,
+      async run(): Promise<void> {
+        await Promise.all(compiled.hostResources.resources.map((resource) => (
+          access(resource.locator, constants.R_OK)
+        )));
+      },
+    }),
+    Object.freeze(mcpPreflight),
+    Object.freeze(mockPreflight),
+    Object.freeze({
+      preflightKind: 'credential' as const,
+      checkId: 'host-credential',
+      preflightDisposition: 'not-required' as const,
+      reasonCode: 'adapter-validates-credential',
+    }),
+    Object.freeze({
+      preflightKind: 'connectivity' as const,
+      checkId: 'provider-connectivity',
+      preflightDisposition: 'not-required' as const,
+      reasonCode: 'core-execution-is-authoritative',
+    }),
+  ]);
+}

--- a/test/architecture/import-boundaries.test.ts
+++ b/test/architecture/import-boundaries.test.ts
@@ -41,6 +41,24 @@ interface ForbiddenRule {
 }
 
 const RULES: ForbiddenRule[] = [
+  ...['cli/', 'dsh-plugin/', 'mcp/', 'studio/'].map((to) => ({
+    from: 'eval-hosts/', to,
+    reason: '共用宿主只接收显式输入，不得经交付入口导入入口策略。',
+  })),
+  ...[
+    'eval-hosts/runtime-adapter/adapters/',
+    'eval-hosts/runtime-adapter/resource-leases/',
+    'eval-hosts/runtime-adapter/evaluators/',
+  ].flatMap((from) => [
+    'eval-hosts/node/',
+    'eval-hosts/runtime-adapter/assembly.ts',
+    'eval-hosts/runtime-adapter/builtins.ts',
+    'eval-hosts/runtime-adapter/composition.ts',
+    'eval-hosts/runtime-adapter/index.ts',
+  ].map((to) => ({
+    from, to,
+    reason: '宿主适配与资源实现不得反向依赖产品装配或通过聚合入口绕过边界。',
+  }))),
   ...['eval-core/', 'eval-runtime/', 'eval-workflows/', 'executors/'].map((from) => ({
     from, to: 'eval-hosts/',
     reason: '具体宿主由外层装配并注入；领域、Runtime 和 Core 不得反向导入宿主实现。',

--- a/test/cli/lib/evaluation-composition.test.ts
+++ b/test/cli/lib/evaluation-composition.test.ts
@@ -1,0 +1,65 @@
+import { digestCanonicalJson } from '../../../src/eval-core/contracts/index.js';
+import { describe, expect, it } from 'vitest';
+import { classifyNodeCliEnvironment } from '../../../src/cli/lib/evaluation-composition.js';
+import { captureClassifiedEnvironment } from '../../../src/eval-hosts/runtime-adapter/adapters/shared/classified-environment.js';
+
+describe('Node CLI production environment', () => {
+  it('preserves network routing and trust locators for isolated runtime processes', () => {
+    const proxy = 'http://user:password@127.0.0.1:7890';
+    const classified = classifyNodeCliEnvironment({
+      PATH: '/usr/bin:/bin',
+      https_proxy: proxy,
+      NO_PROXY: 'localhost,127.0.0.1',
+      NODE_EXTRA_CA_CERTS: '/etc/company-ca.pem',
+      NODE_OPTIONS: '--require=/tmp/untrusted.js',
+    });
+
+    expect(Object.keys(classified)).toEqual([
+      'NODE_EXTRA_CA_CERTS',
+      'NO_PROXY',
+      'PATH',
+      'https_proxy',
+    ]);
+    expect(classified.https_proxy).toEqual({
+      value: proxy,
+      identity: { identityKind: 'effect-locator' },
+      outputTaint: 'secret',
+    });
+    expect(classified.NODE_OPTIONS).toBeUndefined();
+
+    const captured = captureClassifiedEnvironment(classified);
+    expect(captured.values.https_proxy).toBe(proxy);
+    expect(captured.identity).toContainEqual({
+      keyDigest: digestCanonicalJson('https_proxy'),
+      identityKind: 'effect-locator',
+      valueDigest: digestCanonicalJson(proxy),
+      outputTaint: 'secret',
+    });
+    expect(JSON.stringify(captured.identity)).not.toContain(proxy);
+    expect(captured.outputClassification).toBe('secret');
+  });
+
+  it('supports conventional upper- and lower-case proxy variables without broad inheritance', () => {
+    const classified = classifyNodeCliEnvironment({
+      ALL_PROXY: 'socks5://proxy.example.test:1080',
+      HTTPS_PROXY: 'http://proxy.example.test:8443',
+      HTTP_PROXY: 'http://proxy.example.test:8080',
+      all_proxy: 'socks5://proxy.example.test:1081',
+      http_proxy: 'http://proxy.example.test:8081',
+      https_proxy: 'http://proxy.example.test:8444',
+      no_proxy: 'localhost',
+      UNRELATED_SECRET: 'must-not-cross-runtime-boundary',
+    });
+
+    expect(Object.keys(classified)).toEqual([
+      'ALL_PROXY',
+      'HTTPS_PROXY',
+      'HTTP_PROXY',
+      'all_proxy',
+      'http_proxy',
+      'https_proxy',
+      'no_proxy',
+    ]);
+    expect(classified.UNRELATED_SECRET).toBeUndefined();
+  });
+});

--- a/test/eval-hosts/node/judge-provider-identity.test.ts
+++ b/test/eval-hosts/node/judge-provider-identity.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { digestCanonicalJson } from '../../../src/eval-core/contracts/index.js';
 import type { ExecutorRuntimeFingerprint } from '../../../src/executors/contracts/runtime.js';
-import {
-  classifyNodeCliEnvironment,
-} from '../../../src/eval-hosts/node/node-cli-composition.js';
 import { createJudgeProviderRuntimeIdentity } from '../../../src/eval-hosts/node/judge-provider-identity.js';
-import { captureClassifiedEnvironment } from '../../../src/eval-hosts/runtime-adapter/adapters/shared/classified-environment.js';
 
 const EXECUTOR_RUNTIME: ExecutorRuntimeFingerprint = {
   executor: 'openai-api',
@@ -29,7 +25,7 @@ const EXECUTOR_RUNTIME: ExecutorRuntimeFingerprint = {
   },
 };
 
-describe('Node CLI production environment', () => {
+describe('Node judge provider identity', () => {
   it('treats undeclared remote judge deployments as opaque', () => {
     const identity = createJudgeProviderRuntimeIdentity({
       executorId: 'openai-api',
@@ -85,62 +81,4 @@ describe('Node CLI production environment', () => {
     })).toThrow(/non-empty/);
   });
 
-  it('preserves network routing and trust locators for isolated runtime processes', () => {
-    const proxy = 'http://user:password@127.0.0.1:7890';
-    const classified = classifyNodeCliEnvironment({
-      PATH: '/usr/bin:/bin',
-      https_proxy: proxy,
-      NO_PROXY: 'localhost,127.0.0.1',
-      NODE_EXTRA_CA_CERTS: '/etc/company-ca.pem',
-      NODE_OPTIONS: '--require=/tmp/untrusted.js',
-    });
-
-    expect(Object.keys(classified)).toEqual([
-      'NODE_EXTRA_CA_CERTS',
-      'NO_PROXY',
-      'PATH',
-      'https_proxy',
-    ]);
-    expect(classified.https_proxy).toEqual({
-      value: proxy,
-      identity: { identityKind: 'effect-locator' },
-      outputTaint: 'secret',
-    });
-    expect(classified.NODE_OPTIONS).toBeUndefined();
-
-    const captured = captureClassifiedEnvironment(classified);
-    expect(captured.values.https_proxy).toBe(proxy);
-    expect(captured.identity).toContainEqual({
-      keyDigest: digestCanonicalJson('https_proxy'),
-      identityKind: 'effect-locator',
-      valueDigest: digestCanonicalJson(proxy),
-      outputTaint: 'secret',
-    });
-    expect(JSON.stringify(captured.identity)).not.toContain(proxy);
-    expect(captured.outputClassification).toBe('secret');
-  });
-
-  it('supports conventional upper- and lower-case proxy variables without broad inheritance', () => {
-    const classified = classifyNodeCliEnvironment({
-      ALL_PROXY: 'socks5://proxy.example.test:1080',
-      HTTPS_PROXY: 'http://proxy.example.test:8443',
-      HTTP_PROXY: 'http://proxy.example.test:8080',
-      all_proxy: 'socks5://proxy.example.test:1081',
-      http_proxy: 'http://proxy.example.test:8081',
-      https_proxy: 'http://proxy.example.test:8444',
-      no_proxy: 'localhost',
-      UNRELATED_SECRET: 'must-not-cross-runtime-boundary',
-    });
-
-    expect(Object.keys(classified)).toEqual([
-      'ALL_PROXY',
-      'HTTPS_PROXY',
-      'HTTP_PROXY',
-      'all_proxy',
-      'http_proxy',
-      'https_proxy',
-      'no_proxy',
-    ]);
-    expect(classified.UNRELATED_SECRET).toBeUndefined();
-  });
 });


### PR DESCRIPTION
将 CLI 专属装配放回 CLI，共用 preflight 由 CLI 与 DSH 直接消费，补宿主内部依赖守卫。

关联 #736、#718。本批独立审查，不单独关闭 #736。

保持 prompt 字节、测量身份、评分和统计语义；不新增 0.x 兼容转发层，公开包入口不变。

验证：非 import 声明逐项对照一致；完整测试 3572 项通过，隔离安装中的 CLI 独立重复评测通过，doctor 对不合格夹具按预期拦截。

自主 CR：No findings。组合验收与建议合并顺序见 #736。
