### PR TITLE
refactor(executors): 复用 Codex CLI 参数构造

### DIFF
--- a/src/eval-hosts/runtime-adapter/adapters/codex/cli.ts
+++ b/src/eval-hosts/runtime-adapter/adapters/codex/cli.ts
@@ -1,3 +1,4 @@
+import { buildCodexExecArguments } from '../../../../executors/openai/codex/cli-arguments.js';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
@@ -295,10 +296,6 @@ async function resolveIdentity(
   };
 }
 
-function tomlString(value: string): string {
-  return JSON.stringify(value);
-}
-
 export function buildCodexCliCoreArguments(input: Readonly<{
   model: string;
   effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
@@ -306,25 +303,12 @@ export function buildCodexCliCoreArguments(input: Readonly<{
   workingDirectory: string;
   prompt: string;
 }>): string[] {
-  return [
-    'exec',
-    '--json',
-    '--ephemeral',
-    '--ignore-user-config',
-    '--ignore-rules',
-    '--strict-config',
-    '--skip-git-repo-check',
-    '--color', 'never',
-    '--sandbox', input.sandbox,
-    '-c', 'approval_policy="never"',
-    '-c', 'shell_environment_policy.inherit="none"',
-    ...(input.effort === undefined
-      ? []
-      : ['-c', `model_reasoning_effort=${tomlString(input.effort)}`]),
-    '--model', input.model,
-    '-C', input.workingDirectory,
-    '--', input.prompt,
-  ];
+  return buildCodexExecArguments({
+    ...input,
+    strictConfig: true,
+    color: 'never',
+    shellEnvironmentInheritance: 'none',
+  });
 }
 
 function processFailure(error: unknown, signal: AbortSignal): never {

--- a/src/executors/openai/codex/cli-arguments.ts
+++ b/src/executors/openai/codex/cli-arguments.ts
@@ -1,0 +1,36 @@
+/** Codex wire arguments. Callers own policy selection and validate their own inputs. */
+export interface CodexExecArguments {
+  readonly model?: string;
+  readonly workingDirectory?: string;
+  readonly prompt: string;
+  readonly sandbox: 'read-only' | 'workspace-write';
+  readonly strictConfig: boolean;
+  readonly color?: 'never';
+  readonly shellEnvironmentInheritance?: 'none';
+  readonly effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+}
+
+export function buildCodexExecArguments(input: Readonly<CodexExecArguments>): string[] {
+  return [
+    'exec',
+    '--json',
+    '--ephemeral',
+    '--ignore-user-config',
+    '--ignore-rules',
+    ...(input.strictConfig ? ['--strict-config'] : []),
+    '--skip-git-repo-check',
+    ...(input.color === undefined ? [] : ['--color', input.color]),
+    '--sandbox', input.sandbox,
+    '-c', 'approval_policy="never"',
+    ...(input.shellEnvironmentInheritance === undefined
+      ? []
+      : ['-c', `shell_environment_policy.inherit=${JSON.stringify(input.shellEnvironmentInheritance)}`]),
+    ...(input.effort === undefined
+      ? []
+      : ['-c', `model_reasoning_effort=${JSON.stringify(input.effort)}`]),
+    ...(input.model === undefined ? [] : ['--model', input.model]),
+    ...(input.workingDirectory === undefined ? [] : ['-C', input.workingDirectory]),
+    // A prompt beginning with '-' must remain data, including frontmatter and system text.
+    '--', input.prompt,
+  ];
+}

--- a/src/executors/openai/codex/cli.ts
+++ b/src/executors/openai/codex/cli.ts
@@ -1,3 +1,4 @@
+import { buildCodexExecArguments } from './cli-arguments.js';
 import type { ExecResult } from '../../contracts/result.js';
 import type { ExecutorInput } from '../../contracts/ports.js';
 import {
@@ -100,29 +101,15 @@ export function parseCodexJsonl(stdout: string): CodexJsonlParseResult {
   return { events, malformedLineCount };
 }
 
-// exported for arg-shape regression tests
+/** Invocation policy for non-Trial callers such as generation and judge calls. */
 export function buildCodexArgs({ model, cwd, prompt }: { model: string; cwd?: string | null; prompt: string }): string[] {
-  // codex exec [OPTIONS] [PROMPT];prompt 走 positional(execFile 不走 shell,自动 escape)
-  // approval_policy 走 -c config override:codex CLI 0.125 起去掉了 `--ask-for-approval` flag,
-  // 但 approval_policy 这个 config key 仍在,通过 -c 透传不依赖 flag 表面 schema。
-  const args: string[] = [
-    'exec',
-    '--json',
-    '--ephemeral',                      // 不持久化 session 文件
-    '--ignore-user-config',             // 不读 $CODEX_HOME/config.toml
-    '--ignore-rules',                   // 不让用户 / 项目 execpolicy 改写工具行为
-    '--skip-git-repo-check',            // 允许 isolated cwd 不是 git 仓库
-    '--sandbox', 'read-only',           // 评测场景不需要写文件
-    '-c', 'approval_policy="never"',    // non-interactive 必须;TOML 字符串需要 quote
-  ];
-  if (model) args.push('--model', model);
-  if (cwd) args.push('-C', cwd);
-  // `--` end-of-options 分隔符:prompt 必须放在 `--` 之后。system prompt 被 prepend 时,
-  // skill 内容常以 YAML frontmatter `---` 开头,codex(clap)会把以 `-`/`--` 开头的位置参数
-  // 当未知 flag → exit 2(unexpected argument),72ms 秒退、不跑 agent。`--` 之后一律当
-  // positional,不再按 flag 解析(codex 自身的报错 tip 即建议此法)。bug:整个 skill eval 全失败。
-  args.push('--', prompt);
-  return args;
+  return buildCodexExecArguments({
+    ...(model ? { model } : {}),
+    ...(cwd ? { workingDirectory: cwd } : {}),
+    prompt,
+    sandbox: 'read-only',
+    strictConfig: false,
+  });
 }
 
 // codex 看到 stdin 是 pipe 就当作 `<stdin>` 块读,会卡到 timeout。spawn 后立刻

--- a/test/eval-workflows/runtime-adapter/adapters/codex/cli.test.ts
+++ b/test/eval-workflows/runtime-adapter/adapters/codex/cli.test.ts
@@ -699,6 +699,26 @@ describe('Codex CLI Core Executor adapter', () => {
     });
   });
 
+  it.each(['read-only', 'workspace-write'] as const)(
+    'preserves the measured wire contract for %s with every effort setting',
+    (sandbox) => {
+      for (const effort of [undefined, 'low', 'medium', 'high', 'xhigh', 'max'] as const) {
+        const prompt = '---\nname: skill\n---\n正文';
+        expect(buildCodexCliCoreArguments({
+          model: 'gpt-test', workingDirectory: '/tmp/a b', prompt, sandbox,
+          ...(effort === undefined ? {} : { effort }),
+        })).toEqual([
+          'exec', '--json', '--ephemeral', '--ignore-user-config', '--ignore-rules',
+          '--strict-config', '--skip-git-repo-check', '--color', 'never',
+          '--sandbox', sandbox, '-c', 'approval_policy="never"',
+          '-c', 'shell_environment_policy.inherit="none"',
+          ...(effort === undefined ? [] : ['-c', `model_reasoning_effort="${effort}"`]),
+          '--model', 'gpt-test', '-C', '/tmp/a b', '--', prompt,
+        ]);
+      }
+    },
+  );
+
   it('builds the fixed argument order independently of object property order', () => {
     const first = buildCodexCliCoreArguments({
       model: 'gpt-test',

--- a/test/executors/codex-cli-args.test.ts
+++ b/test/executors/codex-cli-args.test.ts
@@ -15,6 +15,20 @@ import type { CodexEvent } from '../../src/executors/openai/codex/protocol.js';
 // 改用 -c approval_policy="never" config override 后,锁住别再退回去。
 
 describe('buildCodexArgs flag schema', () => {
+  it('preserves the complete auxiliary invocation without enabling Trial policy', () => {
+    const prompt = '---\nname: skill\n---\n正文';
+    assert.deepEqual(buildCodexArgs({ model: 'm', cwd: '/tmp/a b', prompt }), [
+      'exec', '--json', '--ephemeral', '--ignore-user-config', '--ignore-rules',
+      '--skip-git-repo-check', '--sandbox', 'read-only',
+      '-c', 'approval_policy="never"', '--model', 'm', '-C', '/tmp/a b', '--', prompt,
+    ]);
+    assert.deepEqual(buildCodexArgs({ model: '', cwd: '', prompt: '' }), [
+      'exec', '--json', '--ephemeral', '--ignore-user-config', '--ignore-rules',
+      '--skip-git-repo-check', '--sandbox', 'read-only',
+      '-c', 'approval_policy="never"', '--', '',
+    ]);
+  });
+
   it('does not include the removed --ask-for-approval flag', () => {
     const args = buildCodexArgs({ model: 'gpt-5-codex', cwd: null, prompt: 'hi' });
     assert.equal(args.includes('--ask-for-approval'), false);


### PR DESCRIPTION
两条 Codex CLI 路径共用参数构造，各调用方保留自身的沙箱、严格配置、环境和生命周期策略。

关联 #736、#718。本批独立审查，不单独关闭 #736。

保持 prompt 字节、测量身份、评分和统计语义；不新增 0.x 兼容转发层，公开包入口不变。

验证：280 组新旧参数完全一致；完整测试 3575 项通过，实进程夹具覆盖取消、失败用量和工作区。

自主 CR：No findings。组合验收与建议合并顺序见 #736。
