### PR TITLE
fix(eval-workflows): 将取消信号传入 Series 汇总并补齐失败验收

### DIFF
--- a/src/eval-workflows/orchestration/evaluation-service.ts
+++ b/src/eval-workflows/orchestration/evaluation-service.ts
@@ -57,6 +57,7 @@ export async function executeProductEvaluation(input: ProductEvaluationExecution
         runId: generateRunId([membership.memberId]), createdAt, ...options(),
       })),
       bundleId: id('series-analysis'), reportId: id('series-report'),
+      seriesSignal: input.signal,
     });
     await series.result;
     const evolution = await series.evolution;

--- a/test/cli/lib/evaluation-application.test.ts
+++ b/test/cli/lib/evaluation-application.test.ts
@@ -2,6 +2,8 @@ import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createNodeCoreRunArtifactStore, type CoreRunArtifactStore } from '../../../src/eval-workflows/artifact-store/index.js';
+import * as managedEvidence from '../../../src/knowledge-artifacts/governance/evidence.js';
 import { runCoreEvaluationCommand } from '../../../src/cli/lib/run-core-evaluation.js';
 
 const roots: string[] = [];
@@ -28,7 +30,7 @@ async function fixture() {
   const outputDirectory = join(root, 'reports');
   const config = { samplesPath, skillDir, executorName: resolve('test/fixtures/custom-executor/core-fixture-executor.sh'), model: 'fixture', judgeModels: [] };
   const flags = { control: 'baseline', treatment: skill, 'no-judge': true, 'skip-doctor': true, 'skip-connectivity': true, 'no-serve': true, 'output-dir': outputDirectory };
-  return { root, outputDirectory, run: (extra: Record<string, unknown> = {}) => runCoreEvaluationCommand({ projectRoot: root, config, flags: { ...flags, ...extra }, evalConfig: null, lang: 'zh' }) };
+  return { root, outputDirectory, run: (extra: Record<string, unknown> = {}, store?: CoreRunArtifactStore) => runCoreEvaluationCommand({ projectRoot: root, config, flags: { ...flags, ...extra }, evalConfig: null, lang: 'zh', store }) };
 }
 
 describe('CLI product application', () => {
@@ -52,4 +54,46 @@ describe('CLI product application', () => {
     expect(result.output).toMatchObject({ projectionKind: 'core-cli-batch-outcome' });
     await expect(input.run({ batch: true, resume: 'existing' })).rejects.toThrow('Batch resume');
   });
+
+  it('rejects publication failure without announcing saved artifacts or appending managed evidence', async () => {
+    const input = await fixture();
+    const store = createNodeCoreRunArtifactStore(input.outputDirectory);
+    const append = vi.spyOn(managedEvidence, 'recordCoreEvalEvidence');
+    await expect(input.run({}, {
+      ...store, async save() { throw new Error('fixture disk full'); },
+    })).rejects.toMatchObject({ code: 'PRODUCTION_EVALUATION_ARTIFACT_PERSIST_FAILED' });
+    expect(await store.list()).toEqual([]);
+    expect(append).not.toHaveBeenCalled();
+    expect(vi.mocked(process.stderr.write).mock.calls.flat().join('')).not.toContain('Core 评测产物已保存');
+  });
+
+  it('retains authenticated artifacts when managed evidence fails and emits a warning', async () => {
+    const input = await fixture();
+    vi.spyOn(managedEvidence, 'recordCoreEvalEvidence').mockImplementation(() => { throw new Error('fixture governance failure'); });
+    const result = await input.run();
+    expect(result.stored).toBeDefined();
+    const store = createNodeCoreRunArtifactStore(input.outputDirectory);
+    expect((await store.get(result.stored!.manifest.runId))?.report.reportDigest).toBe(result.stored!.report.reportDigest);
+    expect(vi.mocked(process.stderr.write).mock.calls.flat().join('')).toContain('警告：Core 受管证据写入失败：fixture governance failure');
+  });
+
+  it('does not announce a complete Series or append member evidence after one publication fails', async () => {
+    const input = await fixture();
+    const store = createNodeCoreRunArtifactStore(input.outputDirectory);
+    const append = vi.spyOn(managedEvidence, 'recordCoreEvalEvidence');
+    let saves = 0;
+    await expect(input.run({ repeat: 2, 'bootstrap-samples': 100 }, {
+      ...store,
+      async save(value) {
+        saves += 1;
+        if (saves === 2) throw new Error('fixture second publication failure');
+        return store.save(value);
+      },
+    })).rejects.toMatchObject({ code: 'PRODUCTION_EVALUATION_ARTIFACT_PERSIST_FAILED' });
+    expect(saves).toBe(2);
+    expect(await store.list()).toHaveLength(1);
+    expect(append).not.toHaveBeenCalled();
+    expect(vi.mocked(process.stderr.write).mock.calls.flat().join('')).not.toContain('Core Series 已完成');
+  });
+
 });

--- a/test/dsh-plugin/core-adapter.test.ts
+++ b/test/dsh-plugin/core-adapter.test.ts
@@ -1,3 +1,4 @@
+import type { EvalConfig } from '../../src/eval-workflows/inputs/contracts/config.js';
 import { runDshCoreEvaluation } from '../../src/dsh-plugin/core-command.js';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -865,27 +866,33 @@ describe('DSH host-only Core Executor adapter', () => {
 });
 
 
+async function productFixture(repeat: number): Promise<{ root: string; config: EvalConfig }> {
+  const root = await mkdtemp(join(tmpdir(), 'omk-dsh-application-'));
+  roots.add(root);
+  vi.stubEnv('OMK_HOME', join(root, 'home'));
+  vi.stubEnv('OMK_TREES_DIR', join(root, 'trees'));
+  await mkdir(join(root, 'skills', 'answer'), { recursive: true });
+  await writeFile(join(root, 'skills', 'answer', 'SKILL.md'), '# Answer\nAnswer the question directly.\n');
+  const samples = join(root, 'samples.json');
+  await writeFile(samples, JSON.stringify({ schemaVersion: 'omk.eval-sample-set/v2', samples: [
+    { sample_id: 'answer', prompt: 'Answer directly.', assertions: [{ type: 'contains', value: 'host' }] },
+  ] }));
+  return { root,
+    config: { samples, variants: [
+      { name: 'control', role: 'control', artifact: 'baseline' },
+      { name: 'treatment', role: 'treatment', artifact: join(root, 'skills', 'answer') },
+    ], noJudge: true, skipDoctor: true, repeat, bootstrapSamples: 100 },
+  };
+}
 describe('DSH product evaluation application', () => {
   afterEach(() => vi.unstubAllEnvs());
 
   it.each([1, 2])('persists %i run(s) through the shared workflow and releases host sessions', async (repeat) => {
-    const root = await mkdtemp(join(tmpdir(), 'omk-dsh-application-'));
-    roots.add(root);
-    vi.stubEnv('OMK_HOME', join(root, 'home'));
-    vi.stubEnv('OMK_TREES_DIR', join(root, 'trees'));
-    await mkdir(join(root, 'skills', 'answer'), { recursive: true });
-    await writeFile(join(root, 'skills', 'answer', 'SKILL.md'), '# Answer\nAnswer the question directly.\n');
-    const samples = join(root, 'samples.json');
-    await writeFile(samples, JSON.stringify({ schemaVersion: 'omk.eval-sample-set/v2', samples: [
-      { sample_id: 'answer', prompt: 'Answer directly.', assertions: [{ type: 'contains', value: 'host' }] },
-    ] }));
+    const { root, config } = await productFixture(repeat);
     const host = new FakeCoreDshHost();
     const result = await runDshCoreEvaluation({
       host, parentAgent, signal: new AbortController().signal, projectRoot: root,
-      config: { samples, variants: [
-        { name: 'control', role: 'control', artifact: 'baseline' },
-        { name: 'treatment', role: 'treatment', artifact: join(root, 'skills', 'answer') },
-      ], noJudge: true, skipDoctor: true, repeat, bootstrapSamples: 100 },
+      config,
     });
     expect(result.outcomeKind).toBe(repeat === 1 ? 'run' : 'series');
     const artifacts = result.outcomeKind === 'run' ? [result.artifacts] : result.artifacts;
@@ -896,4 +903,28 @@ describe('DSH product evaluation application', () => {
     expect(host.activeListenerCount()).toBe(0);
     expect(result.outputDirectory).toBe(join(root, '.omk', 'eval'));
   });
+
+  it.each([1, 2])('cancels %i run(s) at the product entry and releases active sessions', async (repeat) => {
+    const { root, config } = await productFixture(repeat);
+    const host = new FakeCoreDshHost({ hang: true });
+    const controller = new AbortController();
+    const pending = runDshCoreEvaluation({ host, parentAgent, signal: controller.signal, projectRoot: root, config });
+    const settled = pending.then((result) => ({ result }), (error: unknown) => ({ error }));
+    await vi.waitFor(() => expect(host.prompts.length).toBeGreaterThan(0));
+    controller.abort('fixture user cancellation');
+    const outcome = await settled;
+    if ('result' in outcome) {
+      expect(repeat).toBe(1);
+      expect(outcome.result.outcome.gate.gateStatus).toBe('blocked');
+      const artifacts = outcome.result.outcomeKind === 'run' ? [outcome.result.artifacts] : outcome.result.artifacts;
+      expect(artifacts.some((item) => item.report.status.runStatus === 'cancelled')).toBe(true);
+    } else {
+      expect(repeat).toBe(2);
+      expect(outcome.error).toMatchObject({ message: 'Core Series 未完成，无法生成 evolution evidence。' });
+    }
+    expect(host.cancelled).toBeGreaterThan(0);
+    expect(host.disposed).toBe(host.created.length);
+    expect(host.activeListenerCount()).toBe(0);
+  });
+
 });

--- a/test/eval-workflows/orchestration/orchestration.test.ts
+++ b/test/eval-workflows/orchestration/orchestration.test.ts
@@ -1,3 +1,5 @@
+import { executeProductEvaluation } from '../../../src/eval-workflows/orchestration/evaluation-service.js';
+import { parseCliEvaluationRequest } from '../../../src/eval-workflows/input-compilation/index.js';
 import { prepareRuntimeSeries } from '../../../src/eval-runtime/provider.js';
 import { EvaluationRuntimeLifecycleError } from '../../../src/eval-runtime/execution.js';
 import assert from 'node:assert/strict';
@@ -401,6 +403,23 @@ describe('production independent Series orchestration', () => {
     });
     await expect(cancelled.result).resolves.toMatchObject({ status: 'cancelled' });
     await expect(cancelled.evolution).resolves.toBeUndefined();
+
+    // Exercise the product entry as well: abort must reach aggregate analysis,
+    // even when a host has already completed and persisted all member runs.
+    const request = parseCliEvaluationRequest({
+      explicitCliFlags: { 'no-judge': true, control: 'baseline', treatment: 'fixture' },
+      defaults: {
+        samplesLocator: 'samples.json', skillDirectoryLocator: 'skills',
+        targetRuntime: { executorId: 'fixture', model: 'fixture', effort: 'low' },
+        judgeMembers: [],
+        presentation: {
+          projectOutputDirectoryLocator: '.omk/eval', globalOutputDirectoryLocator: '.omk/eval',
+          language: 'zh', languageDefaultSource: 'derived',
+        },
+      },
+    });
+    await expect(executeProductEvaluation({ host, request, signal: controller.signal }))
+      .rejects.toThrow('Core Series 未完成');
 
     cleanupFails = true;
     const failed = await executeProductionEvaluationSeries({


### PR DESCRIPTION
取消评测时，共享产品入口原先只把取消信号交给 Series 成员，没有传给总体分析；成员已经完成时，Series 仍可能在用户取消后生成完整结果。现在信号同时传入总体分析，取消的 Series 不再作为完成结果返回。

补齐了产品入口的失败验收：产物保存失败不会宣布完成，受管证据失败保留已认证产物并警告，Series 部分保存失败不追加成员受管证据，单次／Series 取消后释放 DSH 会话。关联 #736，跟进 #746。

这次只补齐既有取消契约，没有改变评分、统计、prompt 字节、公开 Schema 或存储布局，不需要迁移测量基线。

自主 CR：No findings。回归测试已证明旧代码在取消后仍返回完整 Series，修复后通过；最终 `yarn ci` 的 338 个测试文件、3584 项测试全部通过。

真实接入验收使用临时安装的官方 `@deepseek-ai/dsh@0.1.2-rc.1`、Web bundle 和当前 OMK tarball，经真实命令注册器执行单次、Series 及两种取消路径；6 次成功目标调用完成，取消中止模型连接，测量 agent 注册全部清理。模型端使用本地 HTTP fixture，未使用个人 profile、真实密钥或付费模型。此证据验证实际 DSH 接线与生命周期，不代表外部模型质量或所有 DSH 版本兼容性。
