### PR TITLE
chore(release): 准备 1.0.0-beta.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
准备 `1.0.0-beta.6`，版本文件仅将 beta.5 更新为 beta.6。此前取消链路修复已由 #747 合并，本 PR 不混入实现改动。

OMK 1.0.0-beta.6 收敛了 CLI 与 DSH 的产品评测流程，并修复 Series 取消信号未传递到总体分析的问题。

- CLI 与 DSH 共用预检、运行、恢复及产物保存，减少不同入口的行为漂移。
- 取消信号同时传入 Series 总体分析，取消的 Series 不再作为完成结果返回；保存失败和受管证据失败有对应回归验收。
- 完成 Runtime 内部职责拆分、通用载体来源归属和宿主装配边界收敛，保留公开 API。

升级无需迁移既有报告。评分、统计、prompt 字节、公开 Schema identity 和存储布局保持不变；运行时身份仍按实际版本记录，历史结果是否可比继续由既有契约判断。

发布前验证包括完整本地门禁、Node 22／24 矩阵及 tarball 隔离安装。DSH 接入使用官方 `0.1.2-rc.1` 的真实 Web 服务组合、命令注册器和本地模型响应，验证单次、Series、取消与 agent 清理；不代表个人 profile、付费模型质量或所有 DSH 版本均已认证。

关联 #736、#737～#747。

自主 CR：No findings。最终 `yarn ci` 的 338 个测试文件、3584 项测试通过；beta.6 tarball 的隔离安装、版本号、CLI 单次／Series、DSH 模块加载、公开 Runtime 及三种结果复用均通过。真实 DSH 命令与取消验收见 #747。

本 PR 仅准备版本与发布说明，npm 发布由后续版本 tag 触发。
