### PR TITLE
refactor(observability): 删除未使用的复盘与展示辅助函数

### DIFF
--- a/src/observability/inbox/resolved-review.ts
+++ b/src/observability/inbox/resolved-review.ts
@@ -560,15 +560,6 @@ function verdictLabel(value?: string): string {
   return '无法判断';
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function feelingLabel(value?: string): string {
-  if (value === 'positive') return '正向';
-  if (value === 'neutral') return '中性';
-  if (value === 'negative') return '负向';
-  if (value === 'frustrated') return '烦躁/失望';
-  return '无法判断';
-}
-
 function reasonForStatus(status: ExperienceSessionStoryAnswer['status']): ExperienceSessionStoryAnswer['reason'] {
   if (status === 'ok') return 'all_passed';
   if (status === 'attention') return 'attention_accumulated';
@@ -649,13 +640,4 @@ function ownerSuggestionTexts(enhancedReview?: SkillLlmEnhancedReviewSections, s
       return arr.findIndex((candidate) => [candidate.title, candidate.body, candidate.acceptanceCriteria].filter(Boolean).join('\u0000') === key) === index;
     })
     .slice(0, 4);
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function shortList(values?: string[]): string {
-  return Array.from(new Set((values ?? [])
-    .map((value) => value.replace(/\s+/g, ' ').trim())
-    .filter(Boolean)))
-    .slice(0, 4)
-    .join(' / ');
 }

--- a/src/studio/presentation/observation-inbox/experience-workspace-renderer.ts
+++ b/src/studio/presentation/observation-inbox/experience-workspace-renderer.ts
@@ -843,18 +843,6 @@ export function createObservationExperienceWorkspace({
 	    if (slots.length > 0) return slots.slice(0, 3).join(' / ');
 	    return inboxExtractGoalKeywords(goal?.summary) || inboxExtractKeyword(goal?.expectedOutcome, 36);
 	  };
-	  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-	  const inboxLlmEnhancedDeclaredGoalKeywords = (skillName: string): string => {
-	    const goal = skillDerivedStandards[skillName]?.enhancedReview?.skillDeclaredGoal;
-	    const keywords = [
-	      ...(goal?.keywords ?? []),
-	      ...(goal?.expectedOutcomes ?? []),
-	    ]
-	      .map((keyword) => inboxExtractKeyword(keyword, 18))
-	      .filter((keyword): keyword is string => Boolean(keyword));
-	    if (keywords.length > 0) return Array.from(new Set(keywords)).slice(0, 4).join(' / ');
-	    return inboxExtractGoalKeywords(goal?.summary);
-	  };
 	  const inboxExtractCompletionKeywords = (text?: string): string => {
 	    const cleaned = inboxCleanSnippet(text);
 	    if (!cleaned) return '';
@@ -1392,72 +1380,12 @@ export function createObservationExperienceWorkspace({
 	      </details>
 	    </section>`;
 	  };
-	  const inboxAnswerReasonLabel = (reason: ExperienceSessionStoryAnswer['reason']): string => {
-	    if (reason === 'data_degraded') return '数据质量不足';
-	    if (reason === 'blocking_failed') return '关键项未通过';
-	    if (reason === 'attention_accumulated') return '存在复核项';
-	    if (reason === 'unknown_dominant') return '未知项较多';
-	    if (reason === 'all_passed') return '关键项通过';
-	    return '当前不适用';
-	  };
-	  const inboxDataHealth = (skill: ExperienceSessionSummary, answers: ExperienceSessionStoryAnswer[]): { label: string; className: string; facts: string[] } => {
-	    const hasDataDegraded = answers.some((answer) => answer.status === 'degraded' || answer.reason === 'data_degraded');
-	    const hasAttention = answers.some((answer) => answer.status === 'attention' || answer.reason === 'blocking_failed' || answer.reason === 'attention_accumulated');
-	    const hasUnknown = answers.length === 0 || answers.some((answer) => answer.status === 'unknown' || answer.reason === 'unknown_dominant' || answer.reason === 'not_applicable');
-	    const label = hasDataDegraded
-	      ? '数据健康度：数据有问题'
-	      : hasAttention
-	        ? '数据健康度：要看一眼'
-	        : hasUnknown
-	          ? '数据健康度：信息不够'
-	          : '数据健康度：看起来正常';
-	    const className = hasDataDegraded
-	      ? 'is-degraded'
-	      : hasAttention
-	        ? 'is-attention'
-	        : hasUnknown
-	          ? 'is-unknown'
-	          : 'is-ok';
-	    const facts = [
-	      `真实用户消息 ${skill.evidenceChain.userMessageCount}`,
-	      `skill 上下文 ${skill.evidenceChain.skillContextCount}`,
-	      `助手回复 ${skill.evidenceChain.assistantMessageCount}`,
-	      `工具调用 ${skill.evidenceChain.toolUseCount}`,
-	    ];
-	    return { label, className, facts };
-	  };
-	  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-	  const inboxRenderDataHealth = (skill: ExperienceSessionSummary, answers: ExperienceSessionStoryAnswer[]): string => {
-	    const health = inboxDataHealth(skill, answers);
-	    return `<div class="inbox-trust-layer">
-	      <span class="inbox-data-health ${health.className}">${e(health.label)}</span>
-	      ${health.facts.map((fact) => `<span class="inbox-trust-fact">${e(fact)}</span>`).join('')}
-	    </div>`;
-	  };
-	  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-	  const inboxRenderParentStatuses = (answers: ExperienceSessionStoryAnswer[]): string => {
-	    if (answers.length === 0) return '';
-	    return `<div class="inbox-parent-status-row">${answers.map((answer) => `<div class="inbox-parent-status ${answer.status === 'degraded' ? 'is-degraded' : answer.status === 'attention' ? 'is-attention' : answer.status === 'unknown' ? 'is-unknown' : answer.status === 'not_applicable' ? 'is-not-applicable' : 'is-ok'}">
-	      <span>${e(answer.label)}</span>
-	      ${inboxStatusBadge(answer.status)}
-	      <em>${e(inboxAnswerReasonLabel(answer.reason))}</em>
-	    </div>`).join('')}</div>`;
-	  };
 	  const inboxRenderTypeSpecificChecklist = (resolved: ResolvedObservationReviewSession): string => {
 	    if (resolved.typeSpecificChecklist.length === 0) return '';
 	    return `<div class="inbox-review-layer">
 	      <div class="inbox-review-layer-title">${e(inboxLlmSkillTypeLabel(resolved.skillType))}检查项</div>
 	      ${resolved.typeSpecificSummary ? `<p class="inbox-type-summary">${e(resolved.typeSpecificSummary)}</p>` : ''}
 	      ${inboxAnswerChecklistFromItems(resolved.typeSpecificChecklist)}
-	    </div>`;
-	  };
-	  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-	  const inboxRenderSessionSuggestions = (skill: ExperienceSessionSummary): string => {
-	    const suggestions = inboxBuildSkillActionSuggestions(skill);
-	    if (suggestions.length === 0) return '';
-	    return `<div class="inbox-review-suggestions">
-	      <div class="inbox-review-layer-title">建议</div>
-	      <ol class="inbox-action-suggestion-list is-compact">${suggestions.slice(0, 4).map(inboxRenderActionSuggestion).join('')}</ol>
 	    </div>`;
 	  };
 	  const inboxRenderSessionReviewControl = (session: ExperienceSessionSummary): string => {

--- a/src/studio/presentation/observation-inbox/review-renderer.ts
+++ b/src/studio/presentation/observation-inbox/review-renderer.ts
@@ -183,34 +183,6 @@ export function createObservationReviewRenderers({
     </div>`;
   };
   const reviewStateKey = (targetType: string, targetId: string): string => `${targetType}:${targetId}`;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const renderReviewStateControls = (targetType: 'experience_session' | 'inbox_item' | 'skill' | 'goal_slice_correction', targetId: string): string => {
-    const key = reviewStateKey(targetType, targetId);
-    const entry = reviewState.entries[key];
-    const safeId = e(targetId);
-    const safeType = e(targetType);
-    const buttons = [
-      { verdict: 'reviewed', label: '已复盘', title: '标记为已经人工看过；再次点击可取消这个本地标记。' },
-      { verdict: 'real_issue', label: '确认问题', title: '标记为确认存在问题；可点击其他按钮直接改标记，再次点击可取消。' },
-      { verdict: 'not_issue', label: '不是问题', title: '标记为不是问题或无需处理；可点击其他按钮直接改标记，再次点击可取消。' },
-      { verdict: 'needs_more_context', label: '证据不足', title: '标记为证据不足，需要更多上下文；可点击其他按钮直接改标记，再次点击可取消。' },
-    ];
-    return `<div class="review-state-control" data-review-state-key="${e(key)}" data-review-state-current="${e(entry?.verdict ?? '')}">
-      <div class="review-state-actions">
-        ${buttons.map((button) => {
-          const active = entry?.verdict === button.verdict;
-          return `<button type="button" class="review-state-button ${active ? `is-active ${reviewVerdictClassName(button.verdict)}` : ''}" data-review-verdict="${button.verdict}" onclick="setObservationReviewState('${safeType}', '${safeId}', '${button.verdict}', this)" title="${e(button.title)}">${e(button.label)}</button>`;
-        }).join('')}
-      </div>
-    </div>`;
-  };
-  const reviewVerdictClassName = (verdict?: string): string => {
-    if (verdict === 'real_issue') return 'review-real-issue';
-    if (verdict === 'not_issue') return 'review-not-issue';
-    if (verdict === 'needs_more_context') return 'review-needs-context';
-    if (verdict === 'reviewed') return 'review-reviewed';
-    return '';
-  };
   const renderExperienceBasis = (codes: ExperienceReviewBasisCode[]): string => {
     if (codes.length === 0) return '<span style="color:var(--text-muted)">没有触发复盘优先级规则；进入常规抽样池</span>';
     return codes.map((code) => `<span style="display:inline-block;margin:0 4px 4px 0;padding:2px 6px;border-radius:999px;background:var(--bg-muted);color:var(--text-secondary);font-size:11px">${e(basisLabel(code))}</span>`).join('');


### PR DESCRIPTION
观测复盘和 Studio 收件箱仍保留已退出调用链的标签、数据健康展示、建议展示和人工标注辅助函数，其中七处靠 lint 豁免留在源码中。本 PR 删除这些函数及仅供它们调用的三个辅助函数，共涉及三个文件，减少失效实现的维护负担。

这些函数均为局部声明，未导出、未被返回给调用方，也未被模板或浏览器脚本引用。现行页面与人工标注入口继续使用已有实现；公开 API、报告读取策略、数据格式、评分／统计与冻结 prompt 不变，无需用户迁移。本 PR 不处理旧报告兼容移除。

自主 CR：No findings。已复核完整删除 diff、调用／返回关系、字符串模板与动态入口，未修改测试断言或更新 snapshot。

验证：观测收件箱相关 8 个测试文件、106 项测试通过，覆盖复盘投影、页面渲染和人工标注。完整 `yarn ci` 通过，338 个测试文件、3584 项测试全部通过，Schema、生成文档与页面 snapshot 无变更。

关联 #706，接续 #749。
