### PR TITLE
refactor(eval-workflows): 移除历史断言宽松校验开关

### DIFF
--- a/src/eval-workflows/hosts/input-resolution/node-cli-evaluation-resolver.ts
+++ b/src/eval-workflows/hosts/input-resolution/node-cli-evaluation-resolver.ts
@@ -790,7 +790,6 @@ export async function resolveNodeCliEvaluationRequest(
   try {
     loaded = loadSamples(
       absolute(options.projectRoot, request.values.locators.samples),
-      { assertionValidationMode: 'strict' },
     );
   } catch (cause) {
     return fail({

--- a/src/eval-workflows/inputs/load-samples.ts
+++ b/src/eval-workflows/inputs/load-samples.ts
@@ -42,11 +42,6 @@ export interface LoadSamplesResult {
   sampleSourceById: Record<string, string>;
 }
 
-export interface LoadSamplesOptions {
-  /** Production measurement resolution must not depend on ambient compatibility switches. */
-  readonly assertionValidationMode?: 'environment-compatible' | 'strict';
-}
-
 /**
  * Load samples from a single file OR a directory of sample files.
  *
@@ -61,13 +56,12 @@ export interface LoadSamplesOptions {
  */
 export function loadSamples(
   samplesPath: string,
-  options: Readonly<LoadSamplesOptions> = {},
 ): LoadSamplesResult {
   const abs = resolve(samplesPath);
   if (statSync(abs).isDirectory()) {
-    return loadSamplesFromDir(abs, options);
+    return loadSamplesFromDir(abs);
   }
-  const inner = loadSampleFile(abs, options);
+  const inner = loadSampleFile(abs);
   return {
     ...inner,
     baseDir: dirname(abs),
@@ -90,7 +84,6 @@ export function listSampleFilesInDir(dir: string): string[] {
 
 function loadSamplesFromDir(
   dir: string,
-  options: Readonly<LoadSamplesOptions>,
 ): LoadSamplesResult {
   const files = listSampleFilesInDir(dir);
   if (files.length === 0) {
@@ -109,7 +102,7 @@ function loadSamplesFromDir(
   for (const f of files) {
     const path = join(dir, f);
     sourceFiles.push(path);
-    const single = loadSampleFile(path, options);
+    const single = loadSampleFile(path);
     for (const s of single.samples) {
       const prev = seenIds.get(s.sample_id);
       if (prev) {
@@ -154,7 +147,6 @@ interface LoadSamplesInner { samples: Sample[]; requires?: DependencyRequirement
 
 export function validateSamples(
   samples: Sample[],
-  options: Readonly<LoadSamplesOptions> = {},
 ): void {
   // sample design metadata enums (capability/difficulty/construct/provenance).
   // Pure documentation/diagnostic fields; do NOT participate in grading/judge/verdict.
@@ -267,14 +259,10 @@ export function validateSamples(
     // assertion values must not contain CJK / fullwidth punctuation / internal
     // whitespace, and length ∈ [2, 40]. Loader has no SKILL.md context here so
     // rule B (tool-name-must-exist-in-SKILL.md) is left to generator boundary.
-    // Lenient escape hatch: OMK_LENIENT_ASSERTIONS=1 downgrades these violations
-    // to stderr warnings for legacy sample files.
     const TEXT_VALUE_TYPES_LOADER = new Set([
       'contains', 'not_contains', 'contains_all', 'contains_any', 'equals', 'not_equals',
     ]);
     const LOADER_CJK = /[　-〿一-鿿㐀-䶿＀-￯]/;
-    const isLenient = options.assertionValidationMode !== 'strict'
-      && process.env.OMK_LENIENT_ASSERTIONS === '1';
     const checkAsciiTokenValue = (label: string, raw: unknown): string | null => {
       if (typeof raw !== 'string') return `${label} value 必须是字符串 (实际类型 ${typeof raw})`;
       const s = raw.trim();
@@ -282,13 +270,6 @@ export function validateSamples(
       if (LOADER_CJK.test(s)) return `${label} value 含 CJK 字符或全角标点 — 文本字面匹配在 LLM 输出上不稳,应改用 sample.rubric → judge 评分: ${JSON.stringify(raw)}`;
       if (/\s/.test(s)) return `${label} value 含内部空白(短语),应只测单个 ASCII token,语义匹配走 rubric: ${JSON.stringify(raw)}`;
       return null;
-    };
-    const emitViolation = (msg: string): void => {
-      if (isLenient) {
-        process.stderr.write(`[omk loadSamples] ⚠ lenient mode: ${msg}\n`);
-      } else {
-        throw new Error(msg + '\n  (设 OMK_LENIENT_ASSERTIONS=1 改为 warning 给历史 sample 留迁移逃生口)');
-      }
     };
     for (const [j, a] of assertions.entries()) {
       if (a?.type === 'tools_called' || a?.type === 'tools_not_called') {
@@ -328,18 +309,16 @@ export function validateSamples(
           : a.value !== undefined ? [a.value]
           : [];
         if (items.length === 0) {
-          emitViolation(`${label}: value/values 不能为空`);
-          continue;
+          throw new Error(`${label}: value/values 不能为空`);
         }
         for (const item of items) {
           const err = checkAsciiTokenValue(label, item);
           if (err) {
-            emitViolation(err);
-            break;
+            throw new Error(err);
           }
         }
       } else if (a?.type === 'regex' && typeof a.pattern === 'string' && LOADER_CJK.test(a.pattern)) {
-        emitViolation(`${label}: regex pattern 含 CJK 字符 — 同样的语义匹配应走 rubric → judge,而不是字面正则: ${JSON.stringify(a.pattern)}`);
+        throw new Error(`${label}: regex pattern 含 CJK 字符 — 同样的语义匹配应走 rubric → judge,而不是字面正则: ${JSON.stringify(a.pattern)}`);
       }
     }
 
@@ -354,7 +333,6 @@ export function validateSamples(
 
 function loadSampleFile(
   samplesPath: string,
-  options: Readonly<LoadSamplesOptions>,
 ): LoadSamplesInner {
   const rawContent = readFileSync(samplesPath, 'utf-8');
   const isYaml = samplesPath.endsWith('.yaml') || samplesPath.endsWith('.yml');
@@ -371,7 +349,7 @@ function loadSampleFile(
   const samples = document.data.samples;
   const requires = document.data.requires as DependencyRequirements | undefined;
 
-  validateSamples(samples, options);
+  validateSamples(samples);
 
   return { samples, requires };
 }

--- a/test/cli/init-scaffold-conformance.test.ts
+++ b/test/cli/init-scaffold-conformance.test.ts
@@ -1,12 +1,4 @@
-/**
- * 回归:`omk init` 脚手架出来的 eval-samples.json 必须过 omk 自身的**严格**断言合规
- * 校验(load-samples.ts Rule A)。
- *
- * 为什么需要这条:vitest 全局设了 OMK_LENIENT_ASSERTIONS=1(让历史 fixture 继续加载),
- * 于是脚手架里违规的断言(多词 contains / not_contains)在测试里被降级成 warning、悄悄
- * 漏过——而真实用户照「快速开始」跑的第一条 omk eval 是**非 lenient** 的,会直接硬报错。
- * 本测试显式删掉 lenient 开关,在用户实际经历的严格路径上锁住脚手架用例的合规性。
- */
+/** `omk init` 生成的样本必须通过评测入口使用的断言校验。 */
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
@@ -18,18 +10,6 @@ import { loadSamples } from '../../src/eval-workflows/inputs/load-samples.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = join(__dirname, '..', '..', 'dist', 'cli', 'index.js');
-
-// 在严格(非 lenient)模式下执行 fn:存档并临时删掉全局的 OMK_LENIENT_ASSERTIONS,
-// 复刻真实用户的非 lenient 路径,结束后还原。
-function withStrictAssertions(fn: () => void): void {
-  const orig = process.env.OMK_LENIENT_ASSERTIONS;
-  delete process.env.OMK_LENIENT_ASSERTIONS;
-  try { fn(); }
-  finally {
-    if (orig === undefined) delete process.env.OMK_LENIENT_ASSERTIONS;
-    else process.env.OMK_LENIENT_ASSERTIONS = orig;
-  }
-}
 
 describe('omk init scaffold passes strict assertion conformance', () => {
   let tmpDir: string;
@@ -47,11 +27,8 @@ describe('omk init scaffold passes strict assertion conformance', () => {
       execFileSync('node', [CLI, 'init', tmpDir, '--samples', String(sampleCount)], { stdio: 'pipe' });
       const samplesPath = join(tmpDir, 'eval-samples.json');
 
-      withStrictAssertions(() => {
-        // 不抛即为合规：用户照快速开始跑的第一条 omk eval 不会在这里硬报错。
-        const result = loadSamples(samplesPath);
-        assert.equal(result.samples.length, sampleCount);
-      });
+      const result = loadSamples(samplesPath);
+      assert.equal(result.samples.length, sampleCount);
     });
   }
 });

--- a/test/cli/oclif-init.test.ts
+++ b/test/cli/oclif-init.test.ts
@@ -81,9 +81,7 @@ describe('oclif init', () => {
       assert.ok(stdout.includes('来源是 llm-generated'), `stdout should disclose starter provenance:\n${stdout}`);
       assert.ok(!stdout.includes('20 条以上后重跑'), `full-pack guidance should not ask for the size it already has:\n${stdout}`);
 
-      const { samples } = loadSamples(join(target, 'eval-samples.json'), {
-        assertionValidationMode: 'strict',
-      });
+      const { samples } = loadSamples(join(target, 'eval-samples.json'));
       assert.equal(samples.length, 20);
       assert.equal(new Set(samples.map((sample) => sample.sample_id)).size, 20);
       assert.ok(samples.every((sample) => sample.construct === 'quality'));
@@ -169,7 +167,7 @@ describe('oclif init', () => {
         { cwd: dir },
       );
       assert.ok(stdout.includes('已写入 20 条官方起步用例'));
-      assert.equal(loadSamples(samplesPath, { assertionValidationMode: 'strict' }).samples.length, 20);
+      assert.equal(loadSamples(samplesPath).samples.length, 20);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/executors/preflight/dependencies.test.ts
+++ b/test/executors/preflight/dependencies.test.ts
@@ -369,19 +369,6 @@ describe('loadSamples 版本化对象格式', async () => {
     cleanups.length = 0;
   });
 
-  // Strict-mode helper: vitest config sets OMK_LENIENT_ASSERTIONS=1 globally
-  // (so historical fixtures keep loading), but these rule A loader tests need
-  // to verify the strict-throw path. Save/restore env around the assertion.
-  const withStrict = (fn: () => void): void => {
-    const orig = process.env.OMK_LENIENT_ASSERTIONS;
-    delete process.env.OMK_LENIENT_ASSERTIONS;
-    try { fn(); }
-    finally {
-      if (orig === undefined) delete process.env.OMK_LENIENT_ASSERTIONS;
-      else process.env.OMK_LENIENT_ASSERTIONS = orig;
-    }
-  };
-
   it('rule A loader (strict): 拒绝 contains 含 CJK 字符', () => {
     const p = join(tmpdir(), `omk-cjk-value-${Date.now()}.json`);
     cleanups.push(p);
@@ -389,7 +376,7 @@ describe('loadSamples 版本化对象格式', async () => {
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'contains', value: '留档', weight: 1 }],
     }]));
-    withStrict(() => assert.throws(() => loadSamples(p), /CJK|全角/));
+    assert.throws(() => loadSamples(p), /CJK|全角/);
     for (const f of cleanups) { try { unlinkSync(f); } catch {} }
     cleanups.length = 0;
   });
@@ -401,7 +388,7 @@ describe('loadSamples 版本化对象格式', async () => {
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'contains_any', values: ['ECONNREFUSED', '【失败】'], weight: 1 }],
     }]));
-    withStrict(() => assert.throws(() => loadSamples(p), /CJK|全角|contains_any/));
+    assert.throws(() => loadSamples(p), /CJK|全角|contains_any/);
     for (const f of cleanups) { try { unlinkSync(f); } catch {} }
     cleanups.length = 0;
   });
@@ -413,12 +400,12 @@ describe('loadSamples 版本化对象格式', async () => {
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'contains', value: 'task completed', weight: 1 }],
     }]));
-    withStrict(() => assert.throws(() => loadSamples(p), /空白|whitespace|short(er|ened)|内部/i));
+    assert.throws(() => loadSamples(p), /空白|whitespace|short(er|ened)|内部/i);
     for (const f of cleanups) { try { unlinkSync(f); } catch {} }
     cleanups.length = 0;
   });
 
-  it('rule A loader: 接受 ASCII token-style contains (in any mode)', () => {
+  it('rule A loader: 接受 ASCII token-style contains', () => {
     const p = join(tmpdir(), `omk-ok-value-${Date.now()}.json`);
     cleanups.push(p);
     writeFileSync(p, sampleSetJson([{
@@ -429,48 +416,30 @@ describe('loadSamples 版本化对象格式', async () => {
         { type: 'contains_any', values: ['x-trace-id', 'request-id'], weight: 1 },
       ],
     }]));
-    withStrict(() => {
-      const r = loadSamples(p);
-      assert.equal(r.samples.length, 1);
-      assert.equal(r.samples[0].assertions?.length, 3);
-    });
+    const r = loadSamples(p);
+    assert.equal(r.samples.length, 1);
+    assert.equal(r.samples[0].assertions?.length, 3);
     for (const f of cleanups) { try { unlinkSync(f); } catch {} }
     cleanups.length = 0;
   });
 
-  it('rule A loader: lenient mode (OMK_LENIENT_ASSERTIONS=1) downgrades throws to stderr warn', () => {
+  it('rule A loader: obsolete lenient environment cannot bypass validation', () => {
     const p = join(tmpdir(), `omk-lenient-${Date.now()}.json`);
     cleanups.push(p);
     writeFileSync(p, sampleSetJson([{
       sample_id: 's1', prompt: 'p',
-      assertions: [
-        { type: 'contains', value: '留档', weight: 1 }, // would throw in strict mode
-        { type: 'contains', value: 'OK_TOKEN', weight: 1 },
-      ],
+      assertions: [{ type: 'contains', value: '留档', weight: 1 }],
     }]));
     const orig = process.env.OMK_LENIENT_ASSERTIONS;
-    const origStderrWrite = process.stderr.write.bind(process.stderr);
-    let captured = '';
-    (process.stderr as unknown as { write: (s: string) => boolean }).write = (s: string): boolean => {
-      captured += s;
-      return true;
-    };
     try {
       process.env.OMK_LENIENT_ASSERTIONS = '1';
-      const r = loadSamples(p);
-      // 数据透传(不 strip,因为 loader 没改 sample,只 warn 给用户看);assertion 数应保留原样。
-      // 反而 generator boundary 的 sanitize 是 strip;loader 不动 sample 内容,只是宣告校验状态。
-      assert.equal(r.samples.length, 1);
-      assert.equal(r.samples[0].assertions?.length, 2, 'lenient mode keeps violating assertion in place');
-      assert.ok(captured.includes('lenient') || captured.includes('LENIENT') || captured.includes('CJK'),
-        'stderr should mention the violation: ' + JSON.stringify(captured).slice(0,200));
+      assert.throws(() => loadSamples(p), /CJK|全角/);
     } finally {
-      (process.stderr as unknown as { write: (s: string) => boolean }).write = origStderrWrite;
       if (orig === undefined) delete process.env.OMK_LENIENT_ASSERTIONS;
       else process.env.OMK_LENIENT_ASSERTIONS = orig;
+      for (const f of cleanups) { try { unlinkSync(f); } catch {} }
+      cleanups.length = 0;
     }
-    for (const f of cleanups) { try { unlinkSync(f); } catch {} }
-    cleanups.length = 0;
   });
 
   it('rule A loader (strict): 拒绝 regex pattern 含 CJK', () => {
@@ -480,7 +449,7 @@ describe('loadSamples 版本化对象格式', async () => {
       sample_id: 's1', prompt: 'p',
       assertions: [{ type: 'regex', pattern: '风险等级:\\s*(高|中|低)', weight: 1 }],
     }]));
-    withStrict(() => assert.throws(() => loadSamples(p), /CJK|regex/i));
+    assert.throws(() => loadSamples(p), /CJK|regex/i);
     for (const f of cleanups) { try { unlinkSync(f); } catch {} }
     cleanups.length = 0;
   });

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -4,7 +4,7 @@
 
 ## 通用约定
 
-- **样本断言合规**：所有 `*.eval-samples.json` 的 `contains` / `not_contains` / `contains_any` 值都是单个 ASCII token（长度 2–40、无内部空白），语义判断交给 `rubric` 或 `regex`（`regex` 不受 token 规则约束）。这样 `loadSamples` 在 lenient 模式下不会对这些 fixture 报警告。新增样本请沿用此约定。
+- **样本断言合规**：所有 `*.eval-samples.json` 的 `contains` / `not_contains` / `contains_any` 值都是单个 ASCII token（长度 2–40、无内部空白），语义判断交给 `rubric` 或 `regex`（`regex` 不受 token 规则约束）。这些 fixture 必须通过 `loadSamples` 的严格校验。新增样本请沿用此约定。
 - 这些 fixture 故意保持**最小**：样本数、变体数、断言形态都按消费它的测试需要来定，不是示例展示。要更丰富的真实示例去看 `examples/`。
 
 ## code-review/

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,24 +9,12 @@ export default defineConfig({
     // Git/Node subprocesses become I/O-bound under full CPU parallelism.
     // Keep proportional headroom while allowing larger hosts to scale.
     maxWorkers: '55%',
-    // Default the test suite to lenient assertion-language enforcement so that
-    // legacy fixture sample files (e.g. test/fixtures/code-review/eval-samples.json
-    // containing `not_contains "looks good"`) keep loading via stderr-warning
-    // path. The generator-boundary hard strip inside sanitizeGeneratedSamples
-    // is unaffected by this env — that pipeline still gives the strict
-    // guarantee for newly authored samples. Tests that specifically verify
-    // the loader's strict-throw behavior toggle this off case-locally via
-    // the withStrict helper in dependency-checker.test.ts. The "[omk
-    // loadSamples] ⚠ lenient mode" stderr lines that appear during test runs
-    // are diagnostic noise — they confirm which fixtures contain legacy-style
-    // text-class assertions and are not failures.
     // OMK_HOME 一处重定向,把整棵默认产物树(reports / doctors / observe-health / state 下的
     // cache / trees / jobs / artifact-index)全部移到临时目录,从根上隔离 —— 任何从深层调用点写全局默认
     // 目录的写路径(如 persistReport 间接写产物索引卡片、materialize 写隔离副本)都自动落 temp,不再需要
     // 每个子目录单独补 env 兜底,也消除「新写路径忘了补兜底就静默污染真实 ~/.oh-my-knowledge」的隐患。
     // 需要更细粒度的用例仍可 per-test 覆盖 OMK_TREES_DIR / OMK_ARTIFACT_INDEX_DIR 等子目录变量。
     env: {
-      OMK_LENIENT_ASSERTIONS: '1',
       OMK_HOME: join(tmpdir(), `omk-test-home-${process.pid}`),
       // Update-check behavior has dedicated tests. Disable it everywhere else
       // so CLI integration tests do not create caches or detached refresh


### PR DESCRIPTION
移除为历史样本保留的 `OMK_LENIENT_ASSERTIONS` 宽松校验开关，以及对应的模式参数、测试全局设置和临时切换包装。样本加载统一执行现有严格规则，测试也直接覆盖真实校验路径。

兼容决策：不再为 0.x 的不合规断言降级为警告。曾设置此环境变量的用户应修复错误提示指出的断言，语义判断使用 rubric；`evolve` 预检查会提前拒绝非法样本，保留原文件。正式评测入口此前已强制严格校验，本次不改变其可接受输入、评分规则、统计语义、prompt 或 Schema identity。移除的加载选项不是 package exports 的公开 API。

自主 CR：No findings。已复查完整 diff、生产加载与写入调用链、环境隔离和公开 exports；保留旧环境变量无法绕过校验的负向回归，确认修复前失败、修复后通过。

验证：75 项定向测试通过；`yarn ci` 全部通过（337 个测试文件、3576 项测试）。仓库外打包并离线安装后，真实 `init` 成功；设置旧开关运行 `evolve` 仍以退出码 1 拒绝非法断言，原文件字节不变，无模型调用。

关联 #706；后续继续清理，其余审查项尚未完成。
