### PR TITLE
refactor(eval-workflows): 删除无调用的样本修复写回路径

### DIFF
--- a/src/eval-workflows/inputs/load-samples.ts
+++ b/src/eval-workflows/inputs/load-samples.ts
@@ -6,7 +6,6 @@ import { detailedSchemaIssue } from './schemas/error.js';
 import { EvalSampleSetDocumentSchema, SampleSchema } from './schemas/sample-set.js';
 import type { DependencyRequirements } from '../../executors/preflight/contracts.js';
 import { sampleContractValidationError } from './sample-contract.js';
-import { setOwnRecordValue } from '../../shared/record-count.js';
 
 interface YamlErrorLike {
   mark?: { line: number };
@@ -38,8 +37,6 @@ export interface LoadSamplesResult {
    *  绝对路径列表(已按文件名排序)。computeTestSetHash 用它枚举,不再对目录 readFileSync 抛 EISDIR。
    *  单文件模式下是 [samplesPath]。 */
   sourceFiles: string[];
-  /** sample_id → source file。Authoring 命令需要把目录模式下的修复写回原文件。 */
-  sampleSourceById: Record<string, string>;
 }
 
 /**
@@ -66,7 +63,6 @@ export function loadSamples(
     ...inner,
     baseDir: dirname(abs),
     sourceFiles: [abs],
-    sampleSourceById: Object.fromEntries(inner.samples.map((s) => [s.sample_id, abs])),
   };
 }
 
@@ -97,7 +93,6 @@ function loadSamplesFromDir(
   const seenIds = new Map<string, string>();  // sample_id → first file that defined it
   let mergedRequires: DependencyRequirements | undefined;
   const sourceFiles: string[] = [];
-  const sampleSourceById: Record<string, string> = {};
 
   for (const f of files) {
     const path = join(dir, f);
@@ -112,12 +107,11 @@ function loadSamplesFromDir(
         );
       }
       seenIds.set(s.sample_id, f);
-      setOwnRecordValue(sampleSourceById, s.sample_id, path);
     }
     allSamples.push(...single.samples);
     mergedRequires = mergeRequires(mergedRequires, single.requires);
   }
-  return { samples: allSamples, requires: mergedRequires, baseDir: dir, sourceFiles, sampleSourceById };
+  return { samples: allSamples, requires: mergedRequires, baseDir: dir, sourceFiles };
 }
 
 /** Union of string arrays for tools/files/env/preflight; undef when both sides empty. */

--- a/src/eval-workflows/inputs/sample-document.ts
+++ b/src/eval-workflows/inputs/sample-document.ts
@@ -1,20 +1,9 @@
-import {
-  lstatSync,
-  readFileSync,
-  realpathSync,
-  renameSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-} from 'node:fs';
-import { dirname, join } from 'node:path';
+import { readFileSync } from 'node:fs';
 import yaml from 'js-yaml';
-import type { EvalSampleSetDocument, Sample } from './contracts/sample.js';
+import type { Sample } from './contracts/sample.js';
 import { detailedSchemaIssue } from './schemas/error.js';
 import { EvalSampleSetDocumentSchema } from './schemas/sample-set.js';
-import { withFileLock } from '../../shared/file-lock.js';
-import { ownRecordValue } from '../../shared/record-count.js';
-import { parseYaml, validateSamples, type LoadSamplesResult } from './load-samples.js';
+import { parseYaml } from './load-samples.js';
 
 function isYamlPath(filePath: string): boolean {
   return /\.(ya?ml)$/i.test(filePath);
@@ -38,79 +27,4 @@ export function stringifySampleDocument(filePath: string, document: unknown): st
     return yaml.dump(document, { lineWidth: -1, noRefs: true });
   }
   return JSON.stringify(document, null, 2);
-}
-
-function writableFilePath(filePath: string): string {
-  return lstatSync(filePath).isSymbolicLink() ? realpathSync(filePath) : filePath;
-}
-
-function atomicWriteFile(filePath: string, content: string): void {
-  const targetPath = writableFilePath(filePath);
-  const tempPath = join(
-    dirname(targetPath),
-    `.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`,
-  );
-  try {
-    writeFileSync(tempPath, content, { mode: statSync(targetPath).mode & 0o777 });
-    renameSync(tempPath, targetPath);
-  } catch (error) {
-    try {
-      unlinkSync(tempPath);
-    } catch {
-      // The rename may already have consumed the temporary file.
-    }
-    throw error;
-  }
-}
-
-/**
- * Persist only changed samples back to the source file that originally owned each
- * sample_id. JSON/YAML encoding and the versioned wrapper are retained.
- */
-export function writeFixedSamplesToSources(
-  loaded: Pick<LoadSamplesResult, 'sourceFiles' | 'sampleSourceById'>,
-  samples: Sample[],
-  changedIds: ReadonlySet<string>,
-): string[] {
-  if (changedIds.size === 0) return [];
-
-  const fixedById = new Map(samples.map((sample) => [sample.sample_id, sample]));
-  const idsByFile = new Map<string, Set<string>>();
-  for (const sampleId of changedIds) {
-    const filePath = ownRecordValue(loaded.sampleSourceById, sampleId);
-    if (!filePath) throw new Error(`sample ${sampleId} source file not found`);
-    if (!loaded.sourceFiles.includes(filePath)) {
-      throw new Error(`sample ${sampleId} source file is outside the loaded sample set`);
-    }
-    if (!fixedById.has(sampleId)) {
-      throw new Error(`fixed sample ${sampleId} is missing from the update set`);
-    }
-    const ids = idsByFile.get(filePath) ?? new Set<string>();
-    ids.add(sampleId);
-    idsByFile.set(filePath, ids);
-  }
-
-  for (const [filePath, ids] of idsByFile.entries()) {
-    const targetPath = writableFilePath(filePath);
-    withFileLock(`${targetPath}.omk.lock`, () => {
-      const document = parseSampleDocument(filePath);
-      const fileSamples = getSamplesArray(document, filePath);
-      const existingIds = new Set(fileSamples.map((sample) => sample.sample_id));
-      for (const sampleId of ids) {
-        if (!existingIds.has(sampleId)) {
-          throw new Error(`sample ${sampleId} is no longer present in ${filePath}`);
-        }
-      }
-      const nextSamples = fileSamples.map((sample) => (
-        ids.has(sample.sample_id) ? fixedById.get(sample.sample_id)! : sample
-      ));
-      validateSamples(nextSamples);
-      const nextDocument: EvalSampleSetDocument = {
-        ...(document as EvalSampleSetDocument),
-        samples: nextSamples,
-      };
-      atomicWriteFile(filePath, stringifySampleDocument(filePath, nextDocument));
-    });
-  }
-  return [...idsByFile.keys()];
 }

--- a/test/eval-workflows/inputs/load-samples.test.ts
+++ b/test/eval-workflows/inputs/load-samples.test.ts
@@ -410,7 +410,7 @@ describe('loadSamples', () => {
       assert.throws(() => loadSamples(d), /duplicate sample_id "shared"/);
     });
 
-    it('maps prototype-shaped sample ids to their own source files', () => {
+    it('loads prototype-shaped sample ids across source files', () => {
       const d = makeDir('prototype-ids');
       const protoPath = join(d, 'a.json');
       const constructorPath = join(d, 'b.json');
@@ -424,10 +424,8 @@ describe('loadSamples', () => {
       );
 
       const loaded = loadSamples(d);
-      assert.equal(Object.hasOwn(loaded.sampleSourceById, '__proto__'), true);
-      assert.equal(loaded.sampleSourceById.__proto__, protoPath);
-      assert.equal(Object.hasOwn(loaded.sampleSourceById, 'constructor'), true);
-      assert.equal(loaded.sampleSourceById.constructor, constructorPath);
+      assert.deepEqual(loaded.samples.map((sample) => sample.sample_id), ['__proto__', 'constructor']);
+      assert.deepEqual(loaded.sourceFiles, [protoPath, constructorPath]);
     });
 
     it('errors when directory has no eligible sample files', () => {


### PR DESCRIPTION
删除无调用方的样本修复写回函数及其私有文件写入辅助逻辑，加载器不再为这条失效路径维护 `sampleSourceById`。保留实际使用的样本文档解析、序列化，以及目录模式的文件列表和重复 ID 检查。

已核实生产与测试调用、动态引用、package exports 和文档：移除部分没有当前产品入口，也不属于公开 API。现行 `sample --append` 使用另一条有效读写路径，无需用户迁移；样本顺序、依赖合并、评分、统计、prompt 和 Schema identity 不变。

自主 CR：No findings。复查完整 diff、加载结果消费者和现行追加路径；原型名称样本 ID 的回归用例保留，改为检查实际加载的样本与来源文件。

验证：71 项定向测试通过，覆盖样本加载和现行追加读写；`yarn ci` 全部通过（337 个测试文件、3576 项测试）。

关联 #706；本 PR 只处理这条失效写回路径，其余债务盘点继续推进。
