### PR TITLE
refactor(observability): 移除旧会话兼容并统一轨迹分析

### DIFF
--- a/src/observability/skill-health/analyzer.ts
+++ b/src/observability/skill-health/analyzer.ts
@@ -20,11 +20,9 @@ import {
   segmentsToAnalysisEntries,
   skillSegmentTimestampObserved,
   tracesToAnalysisEntries,
-  type CcSession,
   type TraceSession,
   type SkillSegment,
 } from '../trace/index.js';
-import { legacyCcSessionToTraceSession } from '../trace/source.js';
 import { createTraceSessionIndex } from '../trace/session-index.js';
 import { setOwnRecordValue, sumRecordCounts } from '../../shared/record-count.js';
 import { checkedSumTokenCounts } from '../../executors/core/token-usage.js';
@@ -238,9 +236,7 @@ function aggregateUsage(skillSegs: SkillSegment[]): SkillHealth['usage'] {
  * 推断 KB root: 没传 --kb 时,取第一个 assistant record 的 cwd。
  * 如果跨多个 cwd,取第一个并 warn。
  */
-type HealthSession = TraceSession | CcSession;
-
-function inferKbRoot(sessions: HealthSession[]): string | null {
+function inferKbRoot(sessions: TraceSession[]): string | null {
   const cwds = new Set<string>();
   for (const s of sessions) {
     if (s.cwd) cwds.add(s.cwd);
@@ -266,7 +262,7 @@ export function computeSkillHealthReport(tracePath: string, opts: AnalyzeOptions
  */
 export function computeSkillHealthFromSegments(
   segments: SkillSegment[],
-  sessions: HealthSession[],
+  sessions: TraceSession[],
   tracePath: string,
   opts: AnalyzeOptions = {},
   ingestion?: TraceIngestionSummary,
@@ -294,27 +290,24 @@ export function computeSkillHealthFromSegments(
 }
 
 function sessionsForSegments(
-  sessions: HealthSession[],
+  sessions: TraceSession[],
   segments: SkillSegment[],
-): HealthSession[] {
+): TraceSession[] {
   if (segments.length === 0) return [];
-  const traceSessions = sessions.map((session) =>
-    'events' in session ? session : legacyCcSessionToTraceSession(session)
-  );
-  const index = createTraceSessionIndex(traceSessions);
+  const index = createTraceSessionIndex(sessions);
   const selectedTraceIds = new Set(
     segments.flatMap((segment) => {
       const session = index.resolve(segment);
       return session ? [session.traceId] : [];
     }),
   );
-  return sessions.filter((_, position) => selectedTraceIds.has(traceSessions[position].traceId));
+  return sessions.filter((session) => selectedTraceIds.has(session.traceId));
 }
 
 function buildReport(
   segments: SkillSegment[],
   entries: AnalysisEntry[],
-  sessions: HealthSession[],
+  sessions: TraceSession[],
   tracePath: string,
   opts: AnalyzeOptions,
   ingestion?: TraceIngestionSummary,
@@ -435,13 +428,10 @@ function buildReport(
 }
 
 function scopedSessionMessageCount(
-  sessions: HealthSession[],
+  sessions: TraceSession[],
   segments: SkillSegment[],
 ): number {
-  const traceSessions = sessions.map((session) =>
-    'events' in session ? session : legacyCcSessionToTraceSession(session)
-  );
-  const index = createTraceSessionIndex(traceSessions);
+  const index = createTraceSessionIndex(sessions);
   const rangesByTraceId = new Map<string, Array<{ start: number; end: number }>>();
   const unboundedTraceIds = new Set<string>();
   for (const segment of segments) {
@@ -463,12 +453,8 @@ function scopedSessionMessageCount(
   }
 
   let total = 0;
-  for (const [position, session] of sessions.entries()) {
-    if (!('events' in session)) {
-      total = sumRecordCounts(total, sessionMessageCount(session));
-      continue;
-    }
-    const traceId = traceSessions[position].traceId;
+  for (const session of sessions) {
+    const traceId = session.traceId;
     const ranges = unboundedTraceIds.has(traceId)
       ? undefined
       : rangesByTraceId.get(traceId);
@@ -485,26 +471,6 @@ function scopedSessionMessageCount(
   return total;
 }
 
-function sessionMessageCount(session: HealthSession): number {
-  if ('events' in session) {
-    return session.events.filter((event) => event.eventKind === 'message').length;
-  }
-  return session.records.filter((record) => {
-    if (!record || typeof record !== 'object') return false;
-    const typed = record as {
-      type?: unknown;
-      message?: { content?: unknown };
-    };
-    if (typed.type !== 'user' && typed.type !== 'assistant') return false;
-    const content = typed.message?.content;
-    if (typeof content === 'string') return content.trim().length > 0;
-    if (!Array.isArray(content)) return false;
-    return content.some((part) =>
-      part
-      && typeof part === 'object'
-      && (part as { type?: unknown }).type === 'text'
-      && typeof (part as { text?: unknown }).text === 'string'
-      && Boolean((part as { text: string }).text.trim())
-    );
-  }).length;
+function sessionMessageCount(session: TraceSession): number {
+  return session.events.filter((event) => event.eventKind === 'message').length;
 }

--- a/src/observability/trace/index.ts
+++ b/src/observability/trace/index.ts
@@ -15,7 +15,6 @@ export type {
   CcAssistantContent,
   CcAssistantRecord,
   CcRecord,
-  CcSession,
   CcUserRecord,
   CcUserTextContent,
   CcUserToolResultContent,
@@ -51,7 +50,6 @@ export {
 } from './attribution.js';
 export type { SkillSegment } from './segmentation.js';
 export {
-  segmentBySkill,
   segmentTraceBySkill,
   segmentsToAnalysisEntries,
   skillSegmentTimestampObserved,

--- a/src/observability/trace/segmentation.ts
+++ b/src/observability/trace/segmentation.ts
@@ -10,7 +10,6 @@ import {
   truncateTurnsForPersistence,
 } from './projection.js';
 import { sumTokenCounts, tokenCount } from '../../executors/core/token-usage.js';
-import { legacyCcSessionToTraceSession, type CcSession } from './source.js';
 import type {
   TraceEvent,
   TraceMessageEvent,
@@ -457,11 +456,6 @@ function skillBoundaryForEventGroup(
     }
   }
   return null;
-}
-
-/** @deprecated Compatibility entry point for Claude-shaped fixtures. */
-export function segmentBySkill(session: TraceSession | CcSession): SkillSegment[] {
-  return segmentTraceBySkill('events' in session ? session : legacyCcSessionToTraceSession(session));
 }
 
 function updateSegmentSourceModel(

--- a/src/observability/trace/source.ts
+++ b/src/observability/trace/source.ts
@@ -118,39 +118,6 @@ export type CcRecord = CcAssistantRecord | CcUserRecord | { type: string; [k: st
 
 export type { TraceSourceMetadata } from '../contracts/trace.js';
 
-// ---------- Legacy session compatibility ----------
-
-/** @deprecated Compatibility shape for callers that still construct Claude-style fixtures. */
-export interface CcSession {
-  sessionId: string;
-  /**
-   * Logical root session used to aggregate a main trace and all descendants.
-   * For a directory shaped as:
-   *   A/main.jsonl
-   *   A/subagents/x1.jsonl
-   *   A/subagents/x2.jsonl
-   * all three traces share the same sessionGroupId, while sourcePath still
-   * points at the concrete evidence file.
-   */
-  sessionGroupId?: string;
-  sessionGroupPath?: string;
-  traceId?: string;
-  traceRole?: 'standalone' | 'main' | 'subagent';
-  traceLabel?: string;
-  sourcePath: string;
-  sourceKind?: TraceSourceKind;
-  // records 用 unknown[] 是有意为之: cc JSONL 里 permission-mode / file-history-snapshot /
-  // 未来可能新增的 record type 都会共存, 严格 union 会拒绝合法输入。
-  // segmentBySkill 内部按 type 字段做 structural type guard, 比静态类型约束更 robust。
-  records: unknown[];
-  cwd?: string;
-  gitBranch?: string;
-  entrypoint?: string;
-  sourceMetadata?: TraceSourceMetadata;
-  startTimestamp?: string;
-  endTimestamp?: string;
-}
-
 export type { TraceEvent, TraceSession } from './trace-ir.js';
 
 // ---------- Load ----------
@@ -620,7 +587,7 @@ function parseClaudeSessionFile(filePath: string, records: Array<CcRecord | unde
     | undefined;
   const runId = first?.sessionId ?? basename(filePath, '.jsonl');
   const events = correlateTraceToolEvents(records.flatMap((record, sourceIndex) =>
-    record ? legacyRecordToTraceEvents(record, runId, sourceIndex, 'claude') : []
+    record ? claudeRecordToTraceEvents(record, runId, sourceIndex, 'claude') : []
   ));
   const bounds = traceTimestampBounds([
     ...events.map((event) => event.timestamp),
@@ -643,42 +610,7 @@ function parseClaudeSessionFile(filePath: string, records: Array<CcRecord | unde
   };
 }
 
-export function legacyCcSessionToTraceSession(session: CcSession): TraceSession {
-  const runId = session.sessionId;
-  const rootRunId = session.sessionGroupId ?? runId;
-  const sourceKind = session.sourceKind ?? 'claude';
-  const traceId = session.traceId ?? createTraceId({
-    sourceKind,
-    runId,
-    sourcePath: session.sourcePath,
-  });
-  const events = correlateTraceToolEvents(session.records.flatMap((record, sourceIndex) =>
-    legacyRecordToTraceEvents(record, runId, sourceIndex, sourceKind),
-  ));
-  const bounds = traceTimestampBounds([
-    ...events.map((event) => event.timestamp),
-    session.startTimestamp,
-    session.endTimestamp,
-  ]);
-  return {
-    runId,
-    rootRunId,
-    traceId,
-    groupPath: session.sessionGroupPath ?? dirname(session.sourcePath),
-    role: session.traceRole ?? 'standalone',
-    label: session.traceLabel ?? basename(session.sourcePath),
-    sourcePath: session.sourcePath,
-    sourceKind,
-    events,
-    cwd: session.cwd,
-    gitBranch: session.gitBranch,
-    entrypoint: session.entrypoint,
-    sourceMetadata: session.sourceMetadata,
-    ...bounds,
-  };
-}
-
-function legacyRecordToTraceEvents(
+function claudeRecordToTraceEvents(
   raw: unknown,
   runId: string,
   sourceIndex: number,

--- a/test/helpers/claude-trace.ts
+++ b/test/helpers/claude-trace.ts
@@ -1,0 +1,18 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadTraceSessions, type TraceSession } from '../../src/observability/trace/source.js';
+
+/** Exercise the production Claude parser before testing source-neutral projections. */
+export function loadClaudeTraceFixture(records: readonly object[], runId: string): TraceSession {
+  const root = mkdtempSync(join(tmpdir(), 'omk-claude-trace-'));
+  try {
+    const path = join(root, 'trace.jsonl');
+    writeFileSync(path, records.map((record) => JSON.stringify({ ...record, sessionId: runId })).join('\n'));
+    const [session] = loadTraceSessions(path);
+    if (!session) throw new Error('Claude fixture did not produce a trace session');
+    return session;
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/test/observability/orchestration-contract.test.ts
+++ b/test/observability/orchestration-contract.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'vitest';
 import {
   loadTraceSessions,
-  segmentBySkill,
+  segmentTraceBySkill,
 } from '../../src/observability/trace/index.js';
 import {
   buildObservationExperienceReport,
@@ -370,7 +370,7 @@ describe('source-neutral orchestration contract', () => {
         const sessions = loadTraceSessions(root);
         const built = buildObservationExperienceReport({
           sessions,
-          segments: sessions.flatMap((session) => segmentBySkill(session)),
+          segments: sessions.flatMap((session) => segmentTraceBySkill(session)),
           items: [],
           generatedAt: '2026-07-28T00:00:11.000Z',
         });
@@ -417,7 +417,7 @@ describe('source-neutral orchestration contract', () => {
     const sessions = loadTraceSessions(root);
     const report = buildObservationExperienceReport({
       sessions,
-      segments: sessions.flatMap((session) => segmentBySkill(session)),
+      segments: sessions.flatMap((session) => segmentTraceBySkill(session)),
       items: [],
       generatedAt: '2026-07-28T00:00:09.000Z',
     });

--- a/test/observability/skill-health/analyzer.test.ts
+++ b/test/observability/skill-health/analyzer.test.ts
@@ -1,11 +1,11 @@
+import { loadClaudeTraceFixture } from '../../helpers/claude-trace.js';
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import {
   computeSkillHealthFromSegments,
 } from '../../../src/observability/skill-health/analyzer.js';
 import {
-  segmentBySkill,
-  type CcSession,
+  segmentTraceBySkill,
   type SkillSegment,
   type TraceSession,
 } from '../../../src/observability/trace/index.js';
@@ -74,11 +74,17 @@ function makeSegment(
   };
 }
 
-function makeSession(sessionId: string, cwd?: string): CcSession {
+function makeSession(sessionId: string, cwd?: string): TraceSession {
   return {
-    sessionId,
+    runId: sessionId,
+    rootRunId: sessionId,
+    traceId: `trace-${sessionId}`,
+    groupPath: '/tmp',
+    role: 'standalone',
+    label: sessionId,
+    sourceKind: 'claude',
     sourcePath: `/tmp/${sessionId}.jsonl`,
-    records: [],
+    events: [],
     cwd,
     startTimestamp: '2026-04-19T00:00:00.000Z',
     endTimestamp: '2026-04-19T23:59:59.000Z',
@@ -593,34 +599,31 @@ describe('computeSkillHealthFromSegments', () => {
     assert.equal(report.meta.messageCount, 2);
   });
 
-  it('keeps legacy messageCount aligned with Trace IR by excluding tool-only wrappers', () => {
-    const session: CcSession = {
-      ...makeSession('legacy-1'),
-      records: [
-        {
-          type: 'user',
-          message: { role: 'user', content: 'hello' },
+  it('excludes Claude tool-only wrappers from messageCount', () => {
+    const session = loadClaudeTraceFixture([
+      {
+        type: 'user',
+        message: { role: 'user', content: 'hello' },
+      },
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'call-1', name: 'Read', input: {} }],
         },
-        {
-          type: 'assistant',
-          message: {
-            role: 'assistant',
-            content: [{ type: 'tool_use', id: 'call-1', name: 'Read', input: {} }],
-          },
+      },
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call-1', content: 'done' }],
         },
-        {
-          type: 'user',
-          message: {
-            role: 'user',
-            content: [{ type: 'tool_result', tool_use_id: 'call-1', content: 'done' }],
-          },
-        },
-        {
-          type: 'assistant',
-          message: { role: 'assistant', content: [{ type: 'text', text: 'finished' }] },
-        },
-      ],
-    };
+      },
+      {
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'finished' }] },
+      },
+    ], 'legacy-1');
     const report = computeSkillHealthFromSegments(
       [makeSegment('audit', 0, { sessionId: 'legacy-1' })],
       [session],
@@ -629,35 +632,32 @@ describe('computeSkillHealthFromSegments', () => {
     assert.equal(report.meta.messageCount, 2);
   });
 
-  it('resolves canonical trace identity for legacy sessions without duplicating adapter logic', () => {
-    const session: CcSession = {
-      ...makeSession('legacy-canonical-id'),
-      records: [
-        {
-          type: 'user',
-          uuid: 'u1',
-          parentUuid: null,
-          sessionId: 'legacy-canonical-id',
-          timestamp: '2026-04-19T10:00:00.000Z',
-          message: {
-            role: 'user',
-            content: '<command-name>/audit</command-name>\nInspect this.',
-          },
+  it('resolves canonical trace identity from parsed Claude sessions', () => {
+    const session = loadClaudeTraceFixture([
+      {
+        type: 'user',
+        uuid: 'u1',
+        parentUuid: null,
+        sessionId: 'legacy-canonical-id',
+        timestamp: '2026-04-19T10:00:00.000Z',
+        message: {
+          role: 'user',
+          content: '<command-name>/audit</command-name>\nInspect this.',
         },
-        {
-          type: 'assistant',
-          uuid: 'a1',
-          parentUuid: 'u1',
-          sessionId: 'legacy-canonical-id',
-          timestamp: '2026-04-19T10:00:01.000Z',
-          message: {
-            role: 'assistant',
-            content: [{ type: 'text', text: 'Done.' }],
-          },
+      },
+      {
+        type: 'assistant',
+        uuid: 'a1',
+        parentUuid: 'u1',
+        sessionId: 'legacy-canonical-id',
+        timestamp: '2026-04-19T10:00:01.000Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Done.' }],
         },
-      ],
-    };
-    const segments = segmentBySkill(session);
+      },
+    ], 'legacy-canonical-id');
+    const segments = segmentTraceBySkill(session);
     assert.match(segments[0].traceId ?? '', /^trace:[a-f0-9]{32}$/);
 
     const report = computeSkillHealthFromSegments(segments, [session], '/tmp');

--- a/test/observability/trace/trace-adapter.test.ts
+++ b/test/observability/trace/trace-adapter.test.ts
@@ -1,3 +1,4 @@
+import { loadClaudeTraceFixture } from '../../helpers/claude-trace.js';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
@@ -6,7 +7,7 @@ import { join, relative } from 'node:path';
 import {
   loadTraceSessions,
   loadTraceCorpus,
-  segmentBySkill,
+  segmentTraceBySkill,
   segmentsToAnalysisEntries,
   tracesToAnalysisEntries,
   normalizeSkillName,
@@ -957,13 +958,13 @@ describe('loadTraceSessions', () => {
 
     const experience = buildObservationExperienceReport({
       sessions,
-      segments: sessions.flatMap((session) => segmentBySkill(session)),
+      segments: sessions.flatMap((session) => segmentTraceBySkill(session)),
       items: [],
       generatedAt: '2026-05-01T00:00:04.000Z',
     });
     const reversedExperience = buildObservationExperienceReport({
       sessions: [...sessions].reverse(),
-      segments: [...sessions].reverse().flatMap((session) => segmentBySkill(session)),
+      segments: [...sessions].reverse().flatMap((session) => segmentTraceBySkill(session)),
       items: [],
       generatedAt: '2026-05-01T00:00:04.000Z',
     });
@@ -1042,7 +1043,7 @@ describe('loadTraceSessions', () => {
     assert.equal(sessions[0].cwd, '/tmp/agent');
     assert.equal(sessions[0].startTimestamp, undefined);
     assert.ok(sessions[0].events.every((event) => event.timestamp === undefined));
-    const segs = segmentBySkill(sessions[0]);
+    const segs = segmentTraceBySkill(sessions[0]);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'design-coding-create-template');
     assert.equal(segs[0].attribution?.source, 'command-name');
@@ -1084,8 +1085,8 @@ describe('loadTraceSessions', () => {
     assert.ok(session);
     assert.equal(session.startTimestamp, undefined);
     assert.ok(session.events.every((event) => event.timestamp === undefined));
-    const first = segmentBySkill(session);
-    const second = segmentBySkill(session);
+    const first = segmentTraceBySkill(session);
+    const second = segmentTraceBySkill(session);
     assert.deepEqual(
       first.map((segment) => [segment.startTimestamp, segment.endTimestamp]),
       second.map((segment) => [segment.startTimestamp, segment.endTimestamp]),
@@ -1126,7 +1127,7 @@ describe('loadTraceSessions', () => {
 
     const [session] = loadTraceSessions(path);
     assert.equal(session.startTimestamp, '2026-07-25T00:00:00.000Z');
-    const segments = segmentBySkill(session);
+    const segments = segmentTraceBySkill(session);
     assert.equal(segments.length, 2);
     assert.equal(segments[1].skillName, 'audit');
     assert.equal(segments[1].timestampObserved, false);
@@ -1191,7 +1192,7 @@ describe('loadTraceSessions', () => {
       model: 'gpt-5.5',
       businessActions: ['prd-create'],
     });
-    const segs = segmentBySkill(sessions[0]);
+    const segs = segmentTraceBySkill(sessions[0]);
     const skill = segs.find((seg) => seg.skillName === 'prd-create');
     assert.ok(skill);
     assert.equal(skill.sourceKind, 'openclaw');
@@ -1230,7 +1231,7 @@ describe('loadTraceSessions', () => {
     assert.ok(result?.eventKind === 'tool_result');
     assert.equal(result.status, 'unknown');
     assert.equal(result.statusSource, 'unknown');
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.metrics.numToolFailures, 0);
     assert.equal(segment.metrics.numToolUnknown, 1);
   });
@@ -1260,7 +1261,7 @@ describe('loadTraceSessions', () => {
     assert.equal(call.tool.sourceName, 'mcp__github__fetch_file');
     assert.equal(call.tool.namespace, 'mcp__github');
     assert.equal(call.tool.provider, 'github');
-    const [toolCall] = segmentBySkill(session)[0].toolCalls;
+    const [toolCall] = segmentTraceBySkill(session)[0].toolCalls;
     assert.equal(toolCall.tool, 'github.fetch_file');
     assert.equal(toolCall.sourceTool, 'mcp__github__fetch_file');
     assert.equal(toolCall.toolProvider, 'github');
@@ -1395,7 +1396,7 @@ describe('loadTraceSessions', () => {
       modelApi: 'codex',
     });
 
-    const segments = segmentBySkill(session);
+    const segments = segmentTraceBySkill(session);
     const audit = segments.find((segment) => segment.skillName === 'audit');
     assert.ok(audit);
     assert.equal(audit.attribution?.source, 'read-skill-md');
@@ -1544,7 +1545,7 @@ describe('loadTraceSessions', () => {
 
     const experience = buildObservationExperienceReport({
       sessions: [session],
-      segments: segmentBySkill(session),
+      segments: segmentTraceBySkill(session),
       items: [],
       generatedAt: '2026-07-25T00:00:10.000Z',
     });
@@ -1715,7 +1716,7 @@ describe('loadTraceSessions', () => {
     assert.equal(interrupted?.reason, 'interrupted');
     assert.equal(interrupted?.durationMs, 3500);
 
-    const segments = segmentBySkill(session);
+    const segments = segmentTraceBySkill(session);
     const experience = buildObservationExperienceReport({
       sessions: [session],
       segments,
@@ -1922,7 +1923,7 @@ describe('loadTraceSessions', () => {
     const [session] = loadTraceSessions(path);
     assert.equal(session.sourceMetadata?.model, 'gpt-5.5, gpt-5.6-sol');
 
-    const segments = segmentBySkill(session);
+    const segments = segmentTraceBySkill(session);
     const alpha = segments.find((segment) => segment.skillName === 'alpha');
     const beta = segments.find((segment) => segment.skillName === 'beta');
     assert.ok(alpha);
@@ -2016,7 +2017,7 @@ describe('loadTraceSessions', () => {
 
     const [session] = loadTraceSessions(path);
     assert.equal(session.events.filter((event) => event.eventKind === 'unknown').length, 1);
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.metrics.inputTokens, 100);
     assert.equal(segment.metrics.outputTokens, 10);
   });
@@ -2148,7 +2149,7 @@ describe('loadTraceSessions', () => {
     ]));
 
     const [session] = loadTraceSessions(path);
-    const audit = segmentBySkill(session).find((segment) => segment.skillName === 'audit');
+    const audit = segmentTraceBySkill(session).find((segment) => segment.skillName === 'audit');
     assert.ok(audit);
     assert.deepEqual(
       audit.toolCalls.map((tool) => tool.tool),
@@ -2198,7 +2199,7 @@ describe('loadTraceSessions', () => {
       },
     ]);
 
-    const [toolCall] = segmentBySkill(loadTraceSessions(path)[0])[0].toolCalls;
+    const [toolCall] = segmentTraceBySkill(loadTraceSessions(path)[0])[0].toolCalls;
     assert.equal(toolCall.tool, 'web.run');
     assert.equal(toolCall.status, 'success');
     assert.equal(toolCall.statusSource, 'inferred');
@@ -2414,7 +2415,7 @@ describe('loadTraceSessions', () => {
 
     const [session] = loadTraceSessions(path);
     assert.deepEqual(session.sourceMetadata?.businessActions, ['生成文档', '生成页面']);
-    const segs = segmentBySkill(session);
+    const segs = segmentTraceBySkill(session);
     assert.deepEqual(segs.filter((seg) => seg.skillName !== 'general').map((seg) => seg.skillName), ['prd-create', 'demo-create']);
     assert.equal(segs.some((seg) => seg.skillName === '生成文档' || seg.skillName === '生成页面'), false);
     assert.equal(segs.find((seg) => seg.skillName === 'prd-create')?.attribution?.source, 'read-skill-md');
@@ -2463,7 +2464,7 @@ describe('loadTraceSessions', () => {
     ]));
 
     const [session] = loadTraceSessions(path);
-    const segs = segmentBySkill(session);
+    const segs = segmentTraceBySkill(session);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'task-poller');
     assert.equal(segs[0].attribution?.source, 'skill-script');
@@ -2500,7 +2501,7 @@ describe('loadTraceSessions', () => {
     ]));
 
     const [session] = loadTraceSessions(path);
-    const segs = segmentBySkill(session);
+    const segs = segmentTraceBySkill(session);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'task-poller');
     assert.equal(segs[0].attribution?.source, 'skill-script');
@@ -2533,7 +2534,7 @@ describe('loadTraceSessions', () => {
     ]));
 
     const [wrappedSession] = loadTraceSessions(wrappedPath);
-    const wrappedSegs = segmentBySkill(wrappedSession);
+    const wrappedSegs = segmentTraceBySkill(wrappedSession);
     assert.equal(wrappedSegs.length, 2);
     assert.equal(wrappedSegs[1].skillName, 'task-poller');
     assert.equal(wrappedSegs[1].attribution?.source, 'skill-script');
@@ -2573,7 +2574,7 @@ describe('loadTraceSessions', () => {
     assert.equal(new Set(sessions.map((session) => session.traceId)).size, 2);
     assert.ok(sessions.every((session) => /^trace:[a-f0-9]{32}$/.test(session.traceId)));
 
-    const segs = sessions.flatMap(segmentBySkill).sort((a, b) => a.skillName.localeCompare(b.skillName));
+    const segs = sessions.flatMap(segmentTraceBySkill).sort((a, b) => a.skillName.localeCompare(b.skillName));
     assert.deepEqual(segs.map((seg) => [seg.skillName, seg.sessionId, seg.cwd]), [
       ['audit', 'shared-session', '/repo-a'],
       ['polish', 'shared-session', '/repo-b'],
@@ -2796,7 +2797,7 @@ describe('source-neutral Trace IR', () => {
     assert.equal(synthesized.status, 'success');
     assert.equal(synthesized.output, '2 issues');
 
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     const failedCall = segment.toolCalls.find((toolCall) => toolCall.toolUseId === 'mcp-call-1');
     assert.equal(failedCall?.tool, 'github.fetch_file');
     assert.equal(failedCall?.success, false);
@@ -2863,7 +2864,7 @@ describe('source-neutral Trace IR', () => {
     ]);
 
     const [session] = loadTraceSessions(path);
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     const calls = session.events.filter((event) => event.eventKind === 'tool_call');
     const results = session.events.filter((event) => event.eventKind === 'tool_result');
     assert.equal(new Set(calls.map((event) => event.callInstanceId)).size, 2);
@@ -3013,7 +3014,7 @@ describe('source-neutral Trace IR', () => {
     assert.equal(result.status, 'success');
     assert.equal(result.sourceEventId, 'mcp-end-record-1');
 
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.toolCalls[0].tool, 'node_repl.js');
     assert.equal(segment.toolCalls[0].status, 'success');
   });
@@ -3117,7 +3118,7 @@ describe('source-neutral Trace IR', () => {
     assert.equal(call.tool.namespace, 'mcp__node_repl');
     assert.equal(call.tool.provider, 'node_repl');
 
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.skillName, 'control-chrome');
     assert.equal(segment.attribution?.source, 'read-skill-md');
   });
@@ -3145,7 +3146,7 @@ describe('source-neutral Trace IR', () => {
     ]);
 
     const [session] = loadTraceSessions(path);
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.skillName, 'control-chrome');
     assert.equal(segment.attribution?.source, 'skill-script');
   });
@@ -3173,7 +3174,7 @@ describe('source-neutral Trace IR', () => {
     ]);
 
     const [session] = loadTraceSessions(path);
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.skillName, 'general');
     assert.equal(segment.attribution?.source, 'general');
   });
@@ -3214,7 +3215,7 @@ describe('source-neutral Trace IR', () => {
     assert.equal(result.status, 'unknown');
     assert.equal(result.statusSource, 'unknown');
 
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.toolCalls[0].status, 'unknown');
     assert.equal(segment.metrics.numToolFailures, 0);
     assert.equal(segment.metrics.numToolUnknown, 1);
@@ -3257,7 +3258,7 @@ describe('source-neutral Trace IR', () => {
     assert.equal(result.status, 'unknown');
     assert.equal(result.statusSource, 'runtime');
 
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.metrics.numToolFailures, 0);
     assert.equal(segment.metrics.numToolUnknown, 1);
   });
@@ -3296,7 +3297,7 @@ describe('source-neutral Trace IR', () => {
       event.eventKind === 'message' && event.role === 'user' ? [event.origin] : [],
     );
     assert.deepEqual(userOrigins, ['runtime', 'runtime', 'human']);
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.metrics.numTurns, 1);
     assert.deepEqual(segment.turns.map((turn) => turn.role), ['user', 'assistant']);
   });
@@ -3345,28 +3346,23 @@ describe('source-neutral Trace IR', () => {
     ]);
 
     const [session] = loadTraceSessions(path);
-    const segments = segmentBySkill(session);
+    const segments = segmentTraceBySkill(session);
     assert.equal(segments.length, 1);
     assert.equal(segments[0].skillName, 'skill-creator');
     assert.equal(segments[0].toolCalls.length, 2);
   });
 
   it('keeps sample ids unique across a root run and child run', () => {
-    const main = {
-      sessionId: 'root',
-      sessionGroupId: 'root',
-      sourcePath: '/trace/main.jsonl',
-      records: [asstRec('a-main', [{ type: 'text', text: 'main' }], { sessionId: 'root' })],
-    };
+    const main = loadClaudeTraceFixture([
+      asstRec('a-main', [{ type: 'text', text: 'main' }]),
+    ], 'root');
     const child = {
-      sessionId: 'child',
-      sessionGroupId: 'root',
-      sourcePath: '/trace/subagents/child.jsonl',
-      records: [asstRec('a-child', [{ type: 'text', text: 'child' }], { sessionId: 'child' })],
+      ...loadClaudeTraceFixture([asstRec('a-child', [{ type: 'text', text: 'child' }])], 'child'),
+      rootRunId: 'root',
     };
     const entries = segmentsToAnalysisEntries([
-      ...segmentBySkill(main),
-      ...segmentBySkill(child),
+      ...segmentTraceBySkill(main),
+      ...segmentTraceBySkill(child),
     ]);
     assert.equal(new Set(entries.map((entry) => entry.sampleId)).size, 2);
   });
@@ -3423,7 +3419,7 @@ describe('source-neutral Trace IR', () => {
     ]);
 
     const sessions = loadTraceSessions(tmpDir);
-    const segments = sessions.flatMap((session) => segmentBySkill(session));
+    const segments = sessions.flatMap((session) => segmentTraceBySkill(session));
     const report = buildObservationExperienceReport({
       sessions,
       segments,
@@ -3500,7 +3496,7 @@ describe('source-neutral Trace IR', () => {
     });
     const path = writeSession(tmpDir, 'codex-long.jsonl', records);
     const [session] = loadTraceSessions(path);
-    const segments = segmentBySkill(session);
+    const segments = segmentTraceBySkill(session);
     const experience = buildObservationExperienceReport({
       sessions: [session],
       segments,
@@ -3790,34 +3786,26 @@ describe('source-neutral Trace IR', () => {
 
 // ---------- Segment by skill ----------
 
-describe('segmentBySkill', () => {
+describe('segmentTraceBySkill', () => {
   it('no skill signal → single "general" segment', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [{ type: 'text', text: 'hello' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      asstRec('a1', [{ type: 'text', text: 'hello' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'general');
   });
 
   it('slash-command signal cuts new segment', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [{ type: 'text', text: 'hi' }]),
-        userRec('u1', '<command-name>/audit</command-name>\n<command-message>audit</command-message>'),
-        asstRec('a2', [
-          { type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '/x.md' } },
-        ]),
-        userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'ok' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      asstRec('a1', [{ type: 'text', text: 'hi' }]),
+      userRec('u1', '<command-name>/audit</command-name>\n<command-message>audit</command-message>'),
+      asstRec('a2', [
+        { type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '/x.md' } },
+      ]),
+      userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'ok' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 2);
     assert.equal(segs[0].skillName, 'general');
     assert.equal(segs[1].skillName, 'audit');
@@ -3876,7 +3864,7 @@ describe('segmentBySkill', () => {
     });
 
     const summaries = (['claude', 'codex', 'dsh', 'openclaw', 'unknown'] as const).map((sourceKind) => {
-      const segments = segmentBySkill(makeSession(sourceKind));
+      const segments = segmentTraceBySkill(makeSession(sourceKind));
       return {
         skills: segments.map((segment) => segment.skillName),
         models: segments.map((segment) => segment.sourceMetadata?.model),
@@ -3924,25 +3912,21 @@ describe('segmentBySkill', () => {
       ],
     };
 
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.startTimestamp, '2026-07-25T00:00:01.000Z');
     assert.equal(segment.endTimestamp, '2026-07-25T00:00:09.000Z');
     assert.equal(segment.metrics.durationMs, 8_000);
   });
 
   it('normalizes mixed timezone offsets before deriving segment bounds', () => {
-    const [segment] = segmentBySkill({
-      sessionId: 'mixed-offsets',
-      sourcePath: '/repo/mixed-offsets.jsonl',
-      records: [
-        asstRec('later', [{ type: 'text', text: 'later' }], {
-          timestamp: '2026-07-25T08:00:09.000+08:00',
-        }),
-        asstRec('earlier', [{ type: 'text', text: 'earlier' }], {
-          timestamp: '2026-07-25T00:00:01.000Z',
-        }),
-      ],
-    });
+    const [segment] = segmentTraceBySkill(loadClaudeTraceFixture([
+      asstRec('later', [{ type: 'text', text: 'later' }], {
+        timestamp: '2026-07-25T08:00:09.000+08:00',
+      }),
+      asstRec('earlier', [{ type: 'text', text: 'earlier' }], {
+        timestamp: '2026-07-25T00:00:01.000Z',
+      }),
+    ], 'mixed-offsets'));
 
     assert.equal(segment.startTimestamp, '2026-07-25T00:00:01.000Z');
     assert.equal(segment.endTimestamp, '2026-07-25T00:00:09.000Z');
@@ -3967,36 +3951,28 @@ describe('segmentBySkill', () => {
   });
 
   it('Skill tool_use signal cuts new segment', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [{ type: 'tool_use', id: 'tu0', name: 'Skill', input: { skill: 'wiki', args: 'publish' } }]),
-        userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu0', content: 'done' }]),
-        asstRec('a2', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '/x.md' } }]),
-        userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'content' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      asstRec('a1', [{ type: 'tool_use', id: 'tu0', name: 'Skill', input: { skill: 'wiki', args: 'publish' } }]),
+      userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu0', content: 'done' }]),
+      asstRec('a2', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '/x.md' } }]),
+      userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'content' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     // Skill tool_use 本身也归属 wiki 段, 因为信号触发即切段, 该条 tool_use 进入新段
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'wiki');
   });
 
   it('multiple skills in one session → multiple segments', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        userRec('u1', '<command-name>/audit</command-name>'),
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
-        userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
-        userRec('u3', '<command-name>/polish</command-name>'),
-        asstRec('a2', [{ type: 'tool_use', id: 'tu2', name: 'Grep', input: {} }]),
-        userRec('u4', [{ type: 'tool_result', tool_use_id: 'tu2', content: 'y' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      userRec('u1', '<command-name>/audit</command-name>'),
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
+      userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
+      userRec('u3', '<command-name>/polish</command-name>'),
+      asstRec('a2', [{ type: 'tool_use', id: 'tu2', name: 'Grep', input: {} }]),
+      userRec('u4', [{ type: 'tool_result', tool_use_id: 'tu2', content: 'y' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     const skills = segs.map((seg) => seg.skillName);
     assert.ok(skills.includes('audit'));
     assert.ok(skills.includes('polish'));
@@ -4007,15 +3983,11 @@ describe('segmentBySkill', () => {
   });
 
   it('is_error=true → ToolCallInfo.success=false + numToolFailures++', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Grep', input: { pattern: 'foo' } }]),
-        userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'err', is_error: true }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Grep', input: { pattern: 'foo' } }]),
+      userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'err', is_error: true }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].toolCalls[0].success, false);
     assert.equal(segs[0].metrics.numToolFailures, 1);
@@ -4054,7 +4026,7 @@ describe('segmentBySkill', () => {
       ],
     };
 
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.toolCalls[0].status, 'cancelled');
     assert.equal(segment.metrics.numToolFailures, 0);
     assert.equal(segment.metrics.numToolCancelled, 1);
@@ -4067,14 +4039,10 @@ describe('segmentBySkill', () => {
   });
 
   it('orphan tool_use (no matching result) stays unknown without inflating failures', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [{ type: 'tool_use', id: 'tu-orphan', name: 'Read', input: {} }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      asstRec('a1', [{ type: 'tool_use', id: 'tu-orphan', name: 'Read', input: {} }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs[0].toolCalls[0].success, false);
     assert.equal(segs[0].toolCalls[0].status, 'unknown');
     assert.equal(segs[0].metrics.numToolFailures, 0);
@@ -4085,23 +4053,19 @@ describe('segmentBySkill', () => {
   });
 
   it('keeps assistant text and Skill tool use from one source record in the same segment', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [
-          { type: 'text', text: 'I will inspect it.' },
-          {
-            type: 'tool_use',
-            id: 'tu-skill',
-            name: 'Skill',
-            input: { skill: 'demo' },
-          },
-        ]),
-      ],
-    };
+    const s = loadClaudeTraceFixture([
+      asstRec('a1', [
+        { type: 'text', text: 'I will inspect it.' },
+        {
+          type: 'tool_use',
+          id: 'tu-skill',
+          name: 'Skill',
+          input: { skill: 'demo' },
+        },
+      ]),
+    ], 's1');
 
-    const segs = segmentBySkill(s);
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'demo');
     assert.equal(segs[0].turns[0]?.content, 'I will inspect it.');
@@ -4140,7 +4104,7 @@ describe('segmentBySkill', () => {
       ],
     } satisfies TraceSession;
 
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.metrics.numTurns, 1);
     assert.equal(segment.turns[0]?.content, 'I will inspect it.');
     assert.equal(segment.turns[0]?.toolCalls?.[0]?.tool, 'Skill');
@@ -4179,7 +4143,7 @@ describe('segmentBySkill', () => {
       ],
     } satisfies TraceSession;
 
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.toolCalls[0].status, 'success');
     assert.equal(segment.toolCalls[0].output, 'done');
     assert.equal(segment.metrics.numToolUnknown, 0);
@@ -4237,7 +4201,7 @@ describe('segmentBySkill', () => {
       ],
     } satisfies TraceSession;
 
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.deepEqual(
       segment.toolCalls.map((call) => [call.input, call.output, call.status]),
       [
@@ -4323,7 +4287,7 @@ describe('segmentBySkill', () => {
       ],
     } satisfies TraceSession;
 
-    const segments = segmentBySkill(session);
+    const segments = segmentTraceBySkill(session);
     const report = buildObservationExperienceReport({
       sessions: [session],
       segments,
@@ -4354,14 +4318,10 @@ describe('segmentBySkill', () => {
   });
 
   it('preserves human messages as user turns instead of tool results', () => {
-    const [segment] = segmentBySkill({
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        userRec('u1', '<command-name>/audit</command-name>\nPlease inspect this.'),
-        asstRec('a1', [{ type: 'text', text: 'Done.' }]),
-      ],
-    });
+    const [segment] = segmentTraceBySkill(loadClaudeTraceFixture([
+      userRec('u1', '<command-name>/audit</command-name>\nPlease inspect this.'),
+      asstRec('a1', [{ type: 'text', text: 'Done.' }]),
+    ], 's1'));
 
     assert.deepEqual(
       segment.turns.map((turn) => [turn.role, turn.content]),
@@ -4374,19 +4334,15 @@ describe('segmentBySkill', () => {
   });
 
   it('keeps a late tool result on its originating call without overlapping skill record ranges', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        userRec('u0', '<command-name>/audit</command-name>'),
-        asstRec('a1', [{ type: 'tool_use', id: 'tu-late', name: 'Read', input: {} }]),
-        userRec('u1', '<command-name>/review</command-name>'),
-        userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu-late', content: 'done' }]),
-        asstRec('a2', [{ type: 'text', text: 'review done' }]),
-      ],
-    };
+    const s = loadClaudeTraceFixture([
+      userRec('u0', '<command-name>/audit</command-name>'),
+      asstRec('a1', [{ type: 'tool_use', id: 'tu-late', name: 'Read', input: {} }]),
+      userRec('u1', '<command-name>/review</command-name>'),
+      userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu-late', content: 'done' }]),
+      asstRec('a2', [{ type: 'text', text: 'review done' }]),
+    ], 's1');
 
-    const [audit, review] = segmentBySkill(s);
+    const [audit, review] = segmentTraceBySkill(s);
     assert.equal(audit.skillName, 'audit');
     assert.equal(audit.toolCalls[0].output, 'done');
     assert.equal(audit.endRecordIndex, 1);
@@ -4396,188 +4352,154 @@ describe('segmentBySkill', () => {
   });
 
   it('Read .claude/skills/<name>/SKILL.md signal cuts new segment (signal 3 fallback)', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '/home/user/project/.claude/skills/review/SKILL.md' } }]),
-        userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'skill body' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '/home/user/project/.claude/skills/review/SKILL.md' } }]),
+      userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'skill body' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'review');
   });
 
   it('recognizes Codex plugin-cache skills but ignores repository skill fixtures', () => {
-    const installed = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [{
-          type: 'tool_use',
-          id: 'tu1',
-          name: 'Read',
-          input: {
-            file_path: '/home/user/.codex/plugins/cache/openai-bundled/browser/1.0.0/skills/control-browser/SKILL.md',
-          },
-        }]),
-      ],
-    };
-    const fixture = {
-      sessionId: 's2',
-      sourcePath: '/t',
-      records: [
-        asstRec('a2', [{
-          type: 'tool_use',
-          id: 'tu2',
-          name: 'Read',
-          input: {
-            file_path: '/repo/examples/agent-eval/skills/strict-reader/SKILL.md',
-          },
-        }], { sessionId: 's2' }),
-      ],
-    };
+    const installed = loadClaudeTraceFixture([
+      asstRec('a1', [{
+        type: 'tool_use',
+        id: 'tu1',
+        name: 'Read',
+        input: {
+          file_path: '/home/user/.codex/plugins/cache/openai-bundled/browser/1.0.0/skills/control-browser/SKILL.md',
+        },
+      }]),
+    ], 's1');
+    const fixture = loadClaudeTraceFixture([
+      asstRec('a2', [{
+        type: 'tool_use',
+        id: 'tu2',
+        name: 'Read',
+        input: {
+          file_path: '/repo/examples/agent-eval/skills/strict-reader/SKILL.md',
+        },
+      }], { sessionId: 's2' }),
+    ], 's2');
 
-    assert.equal(segmentBySkill(installed)[0].skillName, 'control-browser');
-    assert.equal(segmentBySkill(fixture)[0].skillName, 'general');
+    assert.equal(segmentTraceBySkill(installed)[0].skillName, 'control-browser');
+    assert.equal(segmentTraceBySkill(fixture)[0].skillName, 'general');
   });
 
   it('signal 1 (Skill tool_use) wins over signal 3 (Read SKILL.md) when both present', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [
-          { type: 'tool_use', id: 'tu1', name: 'Skill', input: { skill: 'audit' } },
-          { type: 'tool_use', id: 'tu2', name: 'Read', input: { file_path: '.claude/skills/other/SKILL.md' } },
-        ]),
-        userRec('u1', [
-          { type: 'tool_result', tool_use_id: 'tu1', content: 'x' },
-          { type: 'tool_result', tool_use_id: 'tu2', content: 'y' },
-        ]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      asstRec('a1', [
+        { type: 'tool_use', id: 'tu1', name: 'Skill', input: { skill: 'audit' } },
+        { type: 'tool_use', id: 'tu2', name: 'Read', input: { file_path: '.claude/skills/other/SKILL.md' } },
+      ]),
+      userRec('u1', [
+        { type: 'tool_result', tool_use_id: 'tu1', content: 'x' },
+        { type: 'tool_result', tool_use_id: 'tu2', content: 'y' },
+      ]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'audit');
   });
 
   it('signal 2 (slash command) wins over signal 3 (Read SKILL.md)', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        userRec('u1', '<command-name>/polish</command-name>'),
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '.claude/skills/other/SKILL.md' } }]),
-        userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      userRec('u1', '<command-name>/polish</command-name>'),
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '.claude/skills/other/SKILL.md' } }]),
+      userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'polish');
   });
 
   it('repeated Read of same SKILL.md does not cut multiple segments', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '.claude/skills/review/SKILL.md' } }]),
-        userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
-        asstRec('a2', [{ type: 'tool_use', id: 'tu2', name: 'Read', input: { file_path: '.claude/skills/review/SKILL.md' } }]),
-        userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu2', content: 'y' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '.claude/skills/review/SKILL.md' } }]),
+      userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
+      asstRec('a2', [{ type: 'tool_use', id: 'tu2', name: 'Read', input: { file_path: '.claude/skills/review/SKILL.md' } }]),
+      userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu2', content: 'y' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'review');
   });
 
   it('Read non-SKILL.md file does not trigger signal 3', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '.claude/skills/review/references/cmds.md' } }]),
-        userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: '.claude/skills/review/references/cmds.md' } }]),
+      userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'general');
   });
 
   it('CC builtin command (/clear, /model, /exit) is NOT treated as skill', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        userRec('u1', '<command-name>/clear</command-name>'),
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
-        userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      userRec('u1', '<command-name>/clear</command-name>'),
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
+      userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'general', '/clear 是 cc 内置命令, 不切段');
   });
 
   it('does not leak Claude builtin command names into source-neutral skill identity', () => {
     assert.equal(normalizeSkillName('doctor'), 'doctor');
-    const [codexSegment] = segmentBySkill({
-      sessionId: 'codex-doctor',
+    const codexSession: TraceSession = {
+      runId: 'codex-doctor',
+      rootRunId: 'codex-doctor',
+      traceId: 'trace-codex-doctor',
       sourcePath: '/tmp/codex-doctor.jsonl',
+      groupPath: '/tmp',
+      role: 'standalone',
+      label: 'codex-doctor',
       sourceKind: 'codex',
-      records: [
-        userRec('u1', '<command-name>/doctor</command-name>\nRun the skill.'),
-        asstRec('a1', [{ type: 'text', text: 'Done.' }]),
-      ],
-    });
+      events: [{
+        eventKind: 'message',
+        eventId: 'u1',
+        sourceIndex: 0,
+        sourceType: 'message',
+        role: 'user',
+        origin: 'human',
+        text: '<command-name>/doctor</command-name>\nRun the skill.',
+      }],
+    };
+    const [codexSegment] = segmentTraceBySkill(codexSession);
     assert.equal(codexSegment.skillName, 'doctor');
 
-    const [explicitSkillSegment] = segmentBySkill({
-      sessionId: 'claude-doctor-skill',
-      sourcePath: '/tmp/claude-doctor.jsonl',
-      sourceKind: 'claude',
-      records: [
-        asstRec('a1', [{
-          type: 'tool_use',
-          id: 'doctor-call',
-          name: 'Skill',
-          input: { skill: 'doctor' },
-        }]),
-      ],
-    });
+    const [explicitSkillSegment] = segmentTraceBySkill(loadClaudeTraceFixture([
+      asstRec('a1', [{
+        type: 'tool_use',
+        id: 'doctor-call',
+        name: 'Skill',
+        input: { skill: 'doctor' },
+      }]),
+    ], 'claude-doctor-skill'));
     assert.equal(explicitSkillSegment.skillName, 'doctor');
   });
 
   it('rejects unsafe or non-slug skill identities at the attribution boundary', () => {
     for (const command of ['__proto__', 'constructor', '../audit', 'audit/child']) {
-      const [segment] = segmentBySkill({
-        sessionId: `unsafe-${command}`,
-        sourcePath: '/tmp/unsafe.jsonl',
-        records: [
-          userRec('u1', `<command-name>/${command}</command-name>\nInspect this.`),
-          asstRec('a1', [{ type: 'text', text: 'Done.' }]),
-        ],
-      });
+      const [segment] = segmentTraceBySkill(loadClaudeTraceFixture([
+        userRec('u1', `<command-name>/${command}</command-name>\nInspect this.`),
+        asstRec('a1', [{ type: 'text', text: 'Done.' }]),
+      ], `unsafe-${command}`));
       assert.equal(segment.skillName, 'general');
     }
   });
 
   it('plugin-prefixed skill name keeps source metadata (pbakaus/impeccable:audit → audit from plugin)', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Skill', input: { skill: 'pbakaus/impeccable:audit' } }]),
-        userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'ok' }]),
-        asstRec('a2', [{ type: 'tool_use', id: 'tu2', name: 'Skill', input: { skill: 'impeccable:audit' } }]),
-        userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu2', content: 'ok' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Skill', input: { skill: 'pbakaus/impeccable:audit' } }]),
+      userRec('u1', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'ok' }]),
+      asstRec('a2', [{ type: 'tool_use', id: 'tu2', name: 'Skill', input: { skill: 'impeccable:audit' } }]),
+      userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu2', content: 'ok' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     // skillName 仍归一化为 audit, 但 plugin 来源不同, 需要保留成两段。
     assert.equal(segs.length, 2);
     assert.equal(segs[0].skillName, 'audit');
@@ -4589,15 +4511,11 @@ describe('segmentBySkill', () => {
   });
 
   it('plugin slash command keeps source metadata and command name', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        userRec('u1', '<command-name>/code-security:secure-coding</command-name>\n<command-message>code-security:secure-coding</command-message>'),
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      userRec('u1', '<command-name>/code-security:secure-coding</command-name>\n<command-message>code-security:secure-coding</command-message>'),
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'secure-coding');
     assert.equal(segs[0].attribution?.source, 'command-name');
@@ -4607,17 +4525,13 @@ describe('segmentBySkill', () => {
   });
 
   it('repeated same-skill signal does not create spurious empty segments', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        userRec('u1', '<command-name>/audit</command-name>'),
-        userRec('u2', '<command-name>/audit</command-name>'),  // 重复,不应切段
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
-        userRec('u3', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      userRec('u1', '<command-name>/audit</command-name>'),
+      userRec('u2', '<command-name>/audit</command-name>'),  // 重复,不应切段
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
+      userRec('u3', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     assert.equal(segs.length, 1);
     assert.equal(segs[0].skillName, 'audit');
   });
@@ -4627,15 +4541,11 @@ describe('segmentBySkill', () => {
       message: { usage: { cache_read_input_tokens: number } };
     };
     first.message.usage.cache_read_input_tokens = 7;
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        first,
-        asstRec('a2', [{ type: 'text', text: 'b' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      first,
+      asstRec('a2', [{ type: 'text', text: 'b' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     // 每条 asstRec 默认 input=10 output=20 → 累加 2 次
     assert.equal(segs[0].metrics.inputTokens, 20);
     assert.equal(segs[0].metrics.outputTokens, 40);
@@ -4686,7 +4596,7 @@ describe('segmentBySkill', () => {
       ],
     };
 
-    const [segment] = segmentBySkill(session);
+    const [segment] = segmentTraceBySkill(session);
     assert.equal(segment.metrics.inputTokens, 0);
     assert.equal(segment.metrics.tokenUsageObserved, false);
     const projected = segmentsToAnalysisEntries([segment])[0].variants.general;
@@ -4699,16 +4609,12 @@ describe('segmentBySkill', () => {
 
 describe('segmentsToAnalysisEntries', () => {
   it('each segment → one AnalysisEntry with skill as variant key', () => {
-    const s = {
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        userRec('u1', '<command-name>/audit</command-name>'),
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
-        userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
-      ],
-    };
-    const segs = segmentBySkill(s);
+    const s = loadClaudeTraceFixture([
+      userRec('u1', '<command-name>/audit</command-name>'),
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
+      userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: 'x' }]),
+    ], 's1');
+    const segs = segmentTraceBySkill(s);
     const entries = segmentsToAnalysisEntries(segs);
     assert.equal(entries.length, 1);
     assert.match(entries[0].sampleId, /^trace:[a-f0-9]{32}$/);
@@ -4719,38 +4625,30 @@ describe('segmentsToAnalysisEntries', () => {
   });
 
   it('projects repeated tool calls as call-count distribution', () => {
-    const [segment] = segmentBySkill({
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [
-          { type: 'tool_use', id: 'tu1', name: 'Read', input: {} },
-          { type: 'tool_use', id: 'tu2', name: 'Read', input: {} },
-        ]),
-      ],
-    });
+    const [segment] = segmentTraceBySkill(loadClaudeTraceFixture([
+      asstRec('a1', [
+        { type: 'tool_use', id: 'tu1', name: 'Read', input: {} },
+        { type: 'tool_use', id: 'tu2', name: 'Read', input: {} },
+      ]),
+    ], 's1'));
     const result = segmentsToAnalysisEntries([segment])[0].variants.general;
     assert.deepEqual(result.toolNames, ['Read']);
     assert.deepEqual(result.toolDistribution, { Read: 2 });
   });
 
   it('rounds projected tool success rates to the persisted report contract', () => {
-    const [segment] = segmentBySkill({
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        asstRec('a1', [
-          { type: 'tool_use', id: 'tu1', name: 'Read', input: {} },
-          { type: 'tool_use', id: 'tu2', name: 'Read', input: {} },
-          { type: 'tool_use', id: 'tu3', name: 'Read', input: {} },
-        ]),
-        userRec('u2', [
-          { type: 'tool_result', tool_use_id: 'tu1', content: 'ok' },
-          { type: 'tool_result', tool_use_id: 'tu2', content: 'ok' },
-          { type: 'tool_result', tool_use_id: 'tu3', content: 'failed', is_error: true },
-        ]),
-      ],
-    });
+    const [segment] = segmentTraceBySkill(loadClaudeTraceFixture([
+      asstRec('a1', [
+        { type: 'tool_use', id: 'tu1', name: 'Read', input: {} },
+        { type: 'tool_use', id: 'tu2', name: 'Read', input: {} },
+        { type: 'tool_use', id: 'tu3', name: 'Read', input: {} },
+      ]),
+      userRec('u2', [
+        { type: 'tool_result', tool_use_id: 'tu1', content: 'ok' },
+        { type: 'tool_result', tool_use_id: 'tu2', content: 'ok' },
+        { type: 'tool_result', tool_use_id: 'tu3', content: 'failed', is_error: true },
+      ]),
+    ], 's1'));
     segment.metrics.numToolFailures = 1;
     segment.metrics.numToolUnknown = 0;
     segment.metrics.numToolCancelled = 0;
@@ -4771,15 +4669,11 @@ describe('segmentsToAnalysisEntries', () => {
   it('bounds persisted trace payloads without mutating the source segment', () => {
     const longOutput = `start-${'x'.repeat(1500)}`;
     const longTurn = `question-${'y'.repeat(2500)}`;
-    const [segment] = segmentBySkill({
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        userRec('u1', longTurn),
-        asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
-        userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: longOutput }]),
-      ],
-    });
+    const [segment] = segmentTraceBySkill(loadClaudeTraceFixture([
+      userRec('u1', longTurn),
+      asstRec('a1', [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }]),
+      userRec('u2', [{ type: 'tool_result', tool_use_id: 'tu1', content: longOutput }]),
+    ], 's1'));
 
     const result = segmentsToAnalysisEntries([segment])[0].variants.general;
     assert.equal(result.turns?.[0].content.length, 2001);
@@ -4789,14 +4683,10 @@ describe('segmentsToAnalysisEntries', () => {
   });
 
   it('anchors sample identity to the physical segment start instead of its mutable ordinal', () => {
-    const [segment] = segmentBySkill({
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [
-        userRec('u1', '<command-name>/audit</command-name>'),
-        asstRec('a1', [{ type: 'text', text: 'done' }]),
-      ],
-    });
+    const [segment] = segmentTraceBySkill(loadClaudeTraceFixture([
+      userRec('u1', '<command-name>/audit</command-name>'),
+      asstRec('a1', [{ type: 'text', text: 'done' }]),
+    ], 's1'));
     const original = segmentsToAnalysisEntries([segment])[0].sampleId;
     const shiftedOrdinal = segmentsToAnalysisEntries([{
       ...segment,
@@ -4829,11 +4719,7 @@ describe('segmentsToAnalysisEntries', () => {
     first.message.usage.cache_read_input_tokens = 7;
     first.message.usage.cache_creation_input_tokens = 5;
 
-    const [segment] = segmentBySkill({
-      sessionId: 's1',
-      sourcePath: '/t',
-      records: [first],
-    });
+    const [segment] = segmentTraceBySkill(loadClaudeTraceFixture([first], 's1'));
     const result = segmentsToAnalysisEntries([segment])[0].variants.general;
 
     assert.equal(result.totalTokens, 42);


### PR DESCRIPTION
观测分析统一接收生产加载器输出的 Trace IR，删除仅为历史测试保留的 `CcSession` 类型、转换入口和重复消息计数分支。分段直接使用现行 `segmentTraceBySkill`。

Claude JSONL 上游解析继续保留。原来的旧形状测试改为通过真实解析器生成 Trace IR，跨来源分段测试直接构造原生事件，不再用 Claude 会话假装其它来源。测试临时输入在仓库外创建并通过 finally 清理。

兼容与测量：移除项不是 package exports 的公开 API，当前产品入口已经使用 Trace IR，无用户迁移要求。生产分段、消息计数、时间窗口、关联身份、评分、统计、prompt 和报告 Schema 不变；本次不处理历史报告格式。

自主 CR：No findings。已复查生产调用、完整改动、身份与时间过滤、测试隔离和公开导出。三个受影响测试文件的 762 条断言保持不变，覆盖消息计数、时间范围、工具结果、跨来源与父子 trace 身份；152 项定向测试通过。完整 `yarn ci` 通过（337 个测试文件、3576 项测试）。

关联 #706，后续继续处理观察模块中的其它兼容债务。
