### PR TITLE
refactor(observability)!: BREAKING-SCHEMA 停止转换旧体验报告 v2

### DIFF
--- a/docs/guides/v1-preview-migration.md
+++ b/docs/guides/v1-preview-migration.md
@@ -19,6 +19,7 @@ The preview uses the domain-oriented storage v2 layout. It does not read, move, 
 - Machine-level data uses the same domains under `~/.oh-my-knowledge/`.
 - Evaluation runs are authenticated Core bundles addressed by `runId`; their canonical report is `report.json`.
 - Reports created by 0.54 cannot be resumed, opened in the new Studio, compared with Gold, or used by `omk evolve`. Keep 0.54 installed separately if you need to inspect them.
+- Observation inbox containers still use schema v2, but their embedded `observe-experience` report must use schema v3. Experience v2 reports are no longer converted; inbox readers skip the containing file without modifying it. Re-ingest the original trace with `omk observe ingest <trace-dir>` to create a current report.
 - Managed records use schema v3. Reinstall an artifact and run a new evaluation to establish current evidence.
 
 Do not copy scores from an old report into the new layout. Re-run the evaluation so the sealed plan, lineage, Runtime identity, and decision evidence are produced together. See the [Evaluation Core cutover](./eval-core-cutover.md) and [storage layout v2](../specs/storage-layout-spec.md) for the full boundary.

--- a/docs/zh/guides/v1-preview-migration.md
+++ b/docs/zh/guides/v1-preview-migration.md
@@ -19,6 +19,7 @@ omk --version
 - 机器级数据在 `~/.oh-my-knowledge/` 下采用相同领域。
 - Evaluation run 是以 `runId` 定位、经过认证的 Core bundle，`report.json` 是 canonical report。
 - `0.54` 生成的报告不能被新版本 resume、不能在新 Studio 打开、不能做 Gold 对比，也不能交给 `omk evolve`。如需查看，请单独保留 `0.54`。
+- 观测 inbox 容器仍使用 schema v2，但其中的 `observe-experience` 体验报告必须使用 schema v3。体验报告 v2 不再自动转换；inbox 读取器会跳过包含旧体验报告的文件，保留原文件不变。请使用 `omk observe ingest <trace-dir>` 重新导入原始轨迹，生成当前报告。
 - 受管记录升级为 schema v3。请重新安装 artifact，并重新评测以建立当前证据。
 
 不要把旧报告的分数复制到新布局。重新运行评测，让 sealed plan、lineage、Runtime identity 与 decision evidence 一起生成。完整边界见 [Evaluation Core 生产切换](./eval-core-cutover.md)与[存储布局 v2](../specs/storage-layout-spec.md)。

--- a/src/observability/contracts/experience.ts
+++ b/src/observability/contracts/experience.ts
@@ -682,18 +682,6 @@ export interface ExperienceSessionSummary {
     truncated: boolean;
     omittedBeforeCount: number;
     omittedAfterCount: number;
-    /** @deprecated v2 only. Record indexes are local to one physical trace. */
-    segmentStartRecordIndex?: number;
-    /** @deprecated v2 only. Record indexes are local to one physical trace. */
-    segmentEndRecordIndex?: number;
-    /** @deprecated v2 only. Record indexes are local to one physical trace. */
-    previewStartRecordIndex?: number;
-    /** @deprecated v2 only. Record indexes are local to one physical trace. */
-    previewEndRecordIndex?: number;
-    /** @deprecated v2 only. Record indexes are local to one physical trace. */
-    sessionStartRecordIndex?: number;
-    /** @deprecated v2 only. Record indexes are local to one physical trace. */
-    sessionEndRecordIndex?: number;
   };
   attributionSources: string[];
   pluginNames: string[];

--- a/src/observability/experience/report-codec.ts
+++ b/src/observability/experience/report-codec.ts
@@ -15,10 +15,8 @@ import {
 import {
   OBSERVATION_EXPERIENCE_SCHEMA_VERSION,
   storyContextRefForSessionGroup,
-  storyContextsFromSessions,
   TIMELINE_PREVIEW_EVENT_LIMIT,
   timelineRefForSessionGroup,
-  traceTimelinesFromSessions,
   flattenTimelineTree,
 } from './report-structure.js';
 import {
@@ -30,8 +28,6 @@ import {
   normalizeTraceTimelines,
 } from './report-value-guards.js';
 import { validateExperienceReferences } from './report-reference-validator.js';
-
-export const LEGACY_OBSERVATION_EXPERIENCE_SCHEMA_VERSION = 2;
 
 export type PersistedExperienceInvocation = Omit<
   ExperienceInvocation,
@@ -85,11 +81,7 @@ export function normalizeObservationExperienceReport(value: unknown): Observatio
   const report = value as Record<string, unknown>;
   const kind = report.kind === 'observe-experience' ? report.kind : null;
   if (!kind) return null;
-  if (
-    report.schemaVersion !== OBSERVATION_EXPERIENCE_SCHEMA_VERSION
-    && report.schemaVersion !== LEGACY_OBSERVATION_EXPERIENCE_SCHEMA_VERSION
-  ) return null;
-  const isLegacyReport = report.schemaVersion === LEGACY_OBSERVATION_EXPERIENCE_SCHEMA_VERSION;
+  if (report.schemaVersion !== OBSERVATION_EXPERIENCE_SCHEMA_VERSION) return null;
   if (report.scope !== 'evidence-only') return null;
   if (
     !isTimestamp(report.generatedAt)
@@ -100,19 +92,12 @@ export function normalizeObservationExperienceReport(value: unknown): Observatio
   if (!Array.isArray(report.goalSlices) || !Array.isArray(report.invocations) || !Array.isArray(report.sessions) || !Array.isArray(report.skills)) {
     return null;
   }
-  const invocations = normalizeExperienceInvocationShells(report.invocations, !isLegacyReport);
-  const sessions = normalizeExperienceSessionShells(report.sessions, !isLegacyReport);
+  const invocations = normalizeExperienceInvocationShells(report.invocations);
+  const sessions = normalizeExperienceSessionShells(report.sessions);
   if (!invocations || !sessions) return null;
-  if (
-    !isLegacyReport
-    && (!Array.isArray(report.traceTimelines) || !Array.isArray(report.storyContexts))
-  ) return null;
-  const traceTimelines = Array.isArray(report.traceTimelines)
-    ? normalizeTraceTimelines(report.traceTimelines)
-    : traceTimelinesFromSessions(sessions, invocations);
-  const storyContexts = Array.isArray(report.storyContexts)
-    ? normalizeStoryContexts(report.storyContexts)
-    : storyContextsFromSessions(sessions, invocations);
+  if (!Array.isArray(report.traceTimelines) || !Array.isArray(report.storyContexts)) return null;
+  const traceTimelines = normalizeTraceTimelines(report.traceTimelines);
+  const storyContexts = normalizeStoryContexts(report.storyContexts);
   if (!traceTimelines || !storyContexts) return null;
   const normalized: ObservationExperienceReport = {
     kind: 'observe-experience',
@@ -129,7 +114,7 @@ export function normalizeObservationExperienceReport(value: unknown): Observatio
   };
   const hydrated = hydrateExperienceTimelines(normalized);
   try {
-    if (!validateExperienceReferences(hydrated, !isLegacyReport)) return null;
+    if (!validateExperienceReferences(hydrated)) return null;
   } catch {
     return null;
   }

--- a/src/observability/experience/report-reference-validator.ts
+++ b/src/observability/experience/report-reference-validator.ts
@@ -82,7 +82,7 @@ export function isExperienceGoalSlice(value: unknown): value is ExperienceGoalSl
     && isExperienceEvidenceRefArray(value.userMessageRefs);
 }
 
-export function isExperienceSkillSummary(value: unknown, requireToolUnknown = false): boolean {
+export function isExperienceSkillSummary(value: unknown): boolean {
   if (
     !isObjectRecord(value)
     || typeof value.skillName !== 'string'
@@ -104,15 +104,12 @@ export function isExperienceSkillSummary(value: unknown, requireToolUnknown = fa
       value.invocationCount,
     )
     || (
-      requireToolUnknown
-      && (
-        !isNonNegativeInteger(value.timestampedInvocationCount)
-        || !isRate(value.timestampCoverage)
-      )
+      !isNonNegativeInteger(value.timestampedInvocationCount)
+      || !isRate(value.timestampCoverage)
     )
     || !isNonNegativeInteger(value.reviewFirstSessionCount)
     || !isNonNegativeInteger(value.sampleReviewSessionCount)
-    || !isExperienceIndicators(value.indicators, requireToolUnknown)
+    || !isExperienceIndicators(value.indicators)
     || !isExperienceEvidenceChain(value.evidenceChain)
     || !isExperienceRuleFindingArray(value.ruleFindings)
     || !isExperienceAssistiveInference(value.assistiveInference)
@@ -127,7 +124,6 @@ export function isExperienceSkillSummary(value: unknown, requireToolUnknown = fa
 
 export function validateExperienceReferences(
   report: ObservationExperienceReport,
-  strict: boolean,
 ): boolean {
   if (
     !isObjectRecord(report.meta)
@@ -147,15 +143,14 @@ export function validateExperienceReferences(
     ) return false;
     if (
       timeline.tree.sessionId !== timeline.sessionId
-      || (strict && !traceTimelineStructureIsConsistent(timeline))
+      || !traceTimelineStructureIsConsistent(timeline)
     ) return false;
     const rawEvents = [
       ...timeline.tree.main,
       ...timeline.tree.branches.flatMap((branch) => branch.events),
     ];
     if (
-      strict
-      && (
+      (
         rawEvents.some((event) => typeof event.traceId !== 'string')
         || rawEvents.some((event) =>
           (event.kind === 'tool_use' || event.kind === 'tool_result')
@@ -181,11 +176,8 @@ export function validateExperienceReferences(
     if (
       !isExperienceGoalSlice(goalSlice)
       || (
-        strict
-        && (
-          typeof goalSlice.traceId !== 'string'
-          || typeof goalSlice.timestampObserved !== 'boolean'
-        )
+        typeof goalSlice.traceId !== 'string'
+        || typeof goalSlice.timestampObserved !== 'boolean'
       )
       || goalSliceIds.has(goalSlice.id)
     ) return false;
@@ -199,8 +191,7 @@ export function validateExperienceReferences(
     if (invocationById.has(invocation.id)) return false;
     invocationById.set(invocation.id, invocation);
     if (
-      strict
-      && (
+      (
         countRecordTotal(invocation.toolCounts) !== invocation.metrics.numToolCalls
         || !toolOutcomeCountsMatch(
           invocation.metrics,
@@ -219,20 +210,13 @@ export function validateExperienceReferences(
         || goalSlice.startTimestamp !== invocation.startTimestamp
         || goalSlice.endTimestamp !== invocation.endTimestamp
         || (
-          strict
-          && (
-            goalSlice.traceId !== invocation.traceId
-            || goalSlice.timestampObserved !== invocation.timestampObserved
-          )
+          goalSlice.traceId !== invocation.traceId
+          || goalSlice.timestampObserved !== invocation.timestampObserved
         )
       )
     ) return false;
     referencedGoalSliceIds.add(invocation.goalSliceId);
-    if (strict && (!invocation.timelineRef || !invocation.timelineEventIds)) return false;
-    if (!invocation.timelineRef) {
-      if (invocation.timeline.length === 0 && (invocation.timelineEventIds?.length ?? 0) > 0) return false;
-      continue;
-    }
+    if (!invocation.timelineRef || !invocation.timelineEventIds) return false;
     const eventIds = timelineEventsByRef.get(invocation.timelineRef);
     if (!eventIds) return false;
     if (timelineByRef.get(invocation.timelineRef)?.sessionGroupKey !== invocation.sessionGroupKey) return false;
@@ -276,7 +260,7 @@ export function validateExperienceReferences(
         (invocationReferenceCounts.get(invocation.id) ?? 0) + 1,
       );
     }
-    if (strict) {
+    {
       const timestampedInvocations = sessionInvocations.filter(invocationTimestampObserved);
       const expectedStartTimestamp = minString(
         timestampedInvocations.map((invocation) => invocation.startTimestamp),
@@ -297,10 +281,10 @@ export function validateExperienceReferences(
       const expectedReviewPriorityScore = scoreForIndicators(expectedIndicators);
       const expectedReviewPriority = session.reviewerReport
         ? priorityForReviewerFindings({
-            ...session,
-            indicators: expectedIndicators,
-            reviewPriorityScore: expectedReviewPriorityScore,
-          }, session.reviewerReport.findings)
+          ...session,
+          indicators: expectedIndicators,
+          reviewPriorityScore: expectedReviewPriorityScore,
+        }, session.reviewerReport.findings)
         : priorityForScore(expectedReviewPriorityScore);
       if (
         !indicatorRecordsEqual(session.indicators, expectedIndicators)
@@ -321,7 +305,7 @@ export function validateExperienceReferences(
         && timelineByRef.get(session.timelineRef ?? '')?.sessionGroupKey !== sessionGroupKey
       ) return false;
     }
-    if (strict && (!session.timelineRef || !session.timelinePreviewEventIds)) return false;
+    if (!session.timelineRef || !session.timelinePreviewEventIds) return false;
     if (session.timelineRef) {
       referencedTimelineIds.add(session.timelineRef);
       const eventIds = timelineEventsByRef.get(session.timelineRef);
@@ -333,8 +317,7 @@ export function validateExperienceReferences(
       ) return false;
       if (session.timelinePreviewEventIds?.some((id) => !eventIds.has(id))) return false;
       if (
-        strict
-        && (
+        (
           timeline?.sessionId !== session.sessionId
           || !timelineScopeMatches(
             session,
@@ -354,8 +337,7 @@ export function validateExperienceReferences(
       referencedStoryContextIds.add(session.sessionStory.contextRef);
     }
     if (
-      strict
-      && session.reviewerReport
+      session.reviewerReport
       && !reviewerMetricsMatch(
         session.reviewerReport,
         session,
@@ -366,7 +348,7 @@ export function validateExperienceReferences(
   }
   if (
     Array.from(invocationReferenceCounts.values()).some((count) => count !== 1)
-    || (strict && referencedTimelineIds.size !== timelineEventsByRef.size)
+    || referencedTimelineIds.size !== timelineEventsByRef.size
   ) return false;
 
   const storyContextIds = new Set<string>();
@@ -384,10 +366,10 @@ export function validateExperienceReferences(
   const skillNames = new Set<string>();
   for (const skill of report.skills) {
     if (
-      !isExperienceSkillSummary(skill, strict)
+      !isExperienceSkillSummary(skill)
       || skillNames.has(skill.skillName)
     ) return false;
-    if (strict) {
+    {
       const skillInvocations = report.invocations.filter(
         (invocation) => invocation.skillName === skill.skillName,
       );
@@ -433,20 +415,20 @@ export function validateExperienceReferences(
   if (
     report.sessions.some((session) => !skillNames.has(session.skillName))
     || report.invocations.some((invocation) => !skillNames.has(invocation.skillName))
-    || (strict && referencedStoryContextIds.size !== storyContextIds.size)
+    || referencedStoryContextIds.size !== storyContextIds.size
   ) return false;
   return report.sessions.every((session) => {
     const contextRef = session.sessionStory?.contextRef;
-    if (strict && session.sessionStory && !contextRef) return false;
+    if (session.sessionStory && !contextRef) return false;
     if (contextRef && !storyContextIds.has(contextRef)) return false;
-    if (strict && contextRef) {
+    if (contextRef) {
       const firstInvocation = session.invocationIds
         .map((id) => invocationById.get(id))
         .find((value): value is ExperienceInvocation => Boolean(value));
       const storyInvocations = firstInvocation
         ? report.invocations.filter(
-            (invocation) => invocation.sessionGroupKey === firstInvocation.sessionGroupKey,
-          )
+          (invocation) => invocation.sessionGroupKey === firstInvocation.sessionGroupKey,
+        )
         : [];
       const context = storyContextById.get(contextRef);
       const timeline = timelineByRef.get(session.timelineRef ?? '');
@@ -467,8 +449,7 @@ export function validateExperienceReferences(
       ) return false;
     }
     if (
-      strict
-      && session.reviewerReport
+      session.reviewerReport
       && session.reviewerReport.sessionStoryRef !== 'session'
       && !isObjectRecord((session.reviewerReport as unknown as Record<string, unknown>).sessionStory)
     ) return false;

--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -25,7 +25,6 @@ import {
 
 export function normalizeExperienceInvocationShells(
   values: unknown[],
-  strict: boolean,
 ): ExperienceInvocation[] | null {
   const records = values.filter(isObjectRecord);
   if (records.length !== values.length) return null;
@@ -34,7 +33,7 @@ export function normalizeExperienceInvocationShells(
     || typeof value.skillName !== 'string'
     || typeof value.sessionId !== 'string'
     || typeof value.sessionGroupKey !== 'string'
-    || (strict ? typeof value.traceId !== 'string' : !isOptionalString(value.traceId))
+    || typeof value.traceId !== 'string'
     || typeof value.sourceTrace !== 'string'
     || !isTraceSourceKind(value.sourceKind)
     || !isOptionalString(value.entrypoint)
@@ -43,35 +42,25 @@ export function normalizeExperienceInvocationShells(
     || !isNonNegativeInteger(value.segmentIndex)
     || typeof value.goalSliceId !== 'string'
     || !isTimestampRange(value.startTimestamp, value.endTimestamp)
-    || (value.timestampObserved !== undefined && typeof value.timestampObserved !== 'boolean')
-    || (strict && typeof value.timestampObserved !== 'boolean')
+    || typeof value.timestampObserved !== 'boolean'
     || !isExperienceAttribution(value.attribution)
-    || !isExperienceInvocationMetrics(value.metrics, strict)
+    || !isExperienceInvocationMetrics(value.metrics)
     || !isCountRecord(value.toolCounts)
-    || !isExperienceIndicators(value.indicators, strict)
+    || !isExperienceIndicators(value.indicators)
     || !isExperienceEvidenceChain(value.evidenceChain)
     || !isExperienceRuleFindingArray(value.ruleFindings)
     || !isExperienceAssistiveInference(value.assistiveInference)
     || !isExperienceProblemPatternArray(value.problemPatterns)
     || !isStringArray(value.relatedObservationIds)
     || !isExperienceEvidenceRefArray(value.evidenceRefs)
-    || (
-      strict
-        ? typeof value.timelineRef !== 'string'
-          || !isStringArray(value.timelineEventIds)
-          || (value.timeline !== undefined && !isTimelineEventArray(value.timeline))
-        : !isOptionalString(value.timelineRef)
-          || (value.timelineEventIds !== undefined && !isStringArray(value.timelineEventIds))
-          || !isTimelineEventArray(value.timeline)
-    )
+    || (typeof value.timelineRef !== 'string'
+      || !isStringArray(value.timelineEventIds)
+      || (value.timeline !== undefined && !isTimelineEventArray(value.timeline)))
   )) return null;
   return records.map((value) => ({
     ...value,
     metrics: {
-      ...(value.metrics as Record<string, unknown>),
-      tokenUsageObserved: strict
-        ? (value.metrics as Record<string, unknown>).tokenUsageObserved
-        : false,
+      ...(value.metrics as ExperienceInvocation['metrics']),
     },
     timeline: isTimelineEventArray(value.timeline)
       ? value.timeline as ExperienceTimelineEvent[]
@@ -81,7 +70,6 @@ export function normalizeExperienceInvocationShells(
 
 export function normalizeExperienceSessionShells(
   values: unknown[],
-  strict: boolean,
 ): ExperienceSessionSummary[] | null {
   const records = values.filter(isObjectRecord);
   if (records.length !== values.length) return null;
@@ -105,11 +93,8 @@ export function normalizeExperienceSessionShells(
       Array.isArray(value.invocationIds) ? value.invocationIds.length : -1,
     )
     || (
-      strict
-      && (
-        !isNonNegativeInteger(value.timestampedInvocationCount)
-        || !isRate(value.timestampCoverage)
-      )
+      !isNonNegativeInteger(value.timestampedInvocationCount)
+      || !isRate(value.timestampCoverage)
     )
     || !isStringArray(value.goalSliceIds)
     || !isExperienceReviewPriority(value.reviewPriority)
@@ -128,42 +113,30 @@ export function normalizeExperienceSessionShells(
       'hedging_signal',
       'explicit_marker',
     ])
-    || !isExperienceIndicators(value.indicators, strict)
+    || !isExperienceIndicators(value.indicators)
     || !isExperienceEvidenceChain(value.evidenceChain)
     || !isExperienceRuleFindingArray(value.ruleFindings)
     || !isExperienceAssistiveInference(value.assistiveInference)
     || !isExperienceProblemPatternArray(value.problemPatterns)
     || !isStringArray(value.relatedObservationIds)
     || (value.turns !== undefined && !isExperienceTurnSummaryArray(value.turns))
-    || !(strict
-      ? isExperienceTimelineScope(value.timelineScope)
-      : isLegacyExperienceTimelineScope(value.timelineScope))
+    || !isExperienceTimelineScope(value.timelineScope)
     || !isStringArray(value.attributionSources)
     || !isStringArray(value.pluginNames)
     || !isStringArray(value.rawSkillRefs)
     || !isStringArray(value.commandNames)
-    || (
-      strict
-        ? typeof value.timelineRef !== 'string'
-          || !isStringArray(value.timelinePreviewEventIds)
-          || (value.timelinePreview !== undefined && !isTimelineEventArray(value.timelinePreview))
-          || (value.fullSessionTimeline !== undefined && !isTimelineEventArray(value.fullSessionTimeline))
-        : !isOptionalString(value.timelineRef)
-          || (
-            value.timelinePreviewEventIds !== undefined
-            && !isStringArray(value.timelinePreviewEventIds)
-          )
-          || !isTimelineEventArray(value.timelinePreview)
-          || !isTimelineEventArray(value.fullSessionTimeline)
-    )
+    || (typeof value.timelineRef !== 'string'
+      || !isStringArray(value.timelinePreviewEventIds)
+      || (value.timelinePreview !== undefined && !isTimelineEventArray(value.timelinePreview))
+      || (value.fullSessionTimeline !== undefined && !isTimelineEventArray(value.fullSessionTimeline)))
     || (value.timelineTree !== undefined && !isTimelineTree(value.timelineTree))
     || (
       value.sessionStory !== undefined
-      && !isExperienceSessionStory(value.sessionStory, strict)
+      && !isExperienceSessionStory(value.sessionStory)
     )
     || (
       value.reviewerReport !== undefined
-      && !isExperienceReviewerReport(value.reviewerReport, strict)
+      && !isExperienceReviewerReport(value.reviewerReport)
     )
   )) return null;
   return records.map((value) => {
@@ -177,13 +150,13 @@ export function normalizeExperienceSessionShells(
       : hashParts('thread', sourceThreadId);
     const sessionStory = isObjectRecord(value.sessionStory)
       ? {
-          ...value.sessionStory,
-          goalSlices: Array.isArray(value.sessionStory.goalSlices) ? value.sessionStory.goalSlices : [],
-          subagentDispatches: Array.isArray(value.sessionStory.subagentDispatches)
-            ? value.sessionStory.subagentDispatches
-            : [],
-          episodes: Array.isArray(value.sessionStory.episodes) ? value.sessionStory.episodes : [],
-        }
+        ...value.sessionStory,
+        goalSlices: Array.isArray(value.sessionStory.goalSlices) ? value.sessionStory.goalSlices : [],
+        subagentDispatches: Array.isArray(value.sessionStory.subagentDispatches)
+          ? value.sessionStory.subagentDispatches
+          : [],
+        episodes: Array.isArray(value.sessionStory.episodes) ? value.sessionStory.episodes : [],
+      }
       : undefined;
     return {
       ...value,
@@ -549,7 +522,7 @@ export function isExperienceAttribution(value: unknown): boolean {
     && isOptionalString(value.commandName);
 }
 
-export function isExperienceInvocationMetrics(value: unknown, requireSourceNeutralOutcomes = false): boolean {
+export function isExperienceInvocationMetrics(value: unknown): boolean {
   if (!isObjectRecord(value)) return false;
   const fields = [
     value.durationMs,
@@ -563,8 +536,7 @@ export function isExperienceInvocationMetrics(value: unknown, requireSourceNeutr
   ];
   if (!fields.every(isNonNegativeInteger)) return false;
   if (
-    requireSourceNeutralOutcomes
-    && (
+    (
       typeof value.tokenUsageObserved !== 'boolean'
       ||
       !isNonNegativeInteger(value.numToolCancelled)
@@ -606,15 +578,12 @@ export const EXPERIENCE_INDICATOR_KEYS = [
   'explicitMarkerCount',
 ] as const;
 
-export function isExperienceIndicators(value: unknown, requireSourceNeutralOutcomes = false): boolean {
+export function isExperienceIndicators(value: unknown): boolean {
   return isObjectRecord(value)
     && EXPERIENCE_INDICATOR_KEYS.every((key) => isNonNegativeInteger(value[key]))
     && (
-      !requireSourceNeutralOutcomes
-      || (
-        isNonNegativeInteger(value.toolCancelledCount)
-        && isNonNegativeInteger(value.toolUnknownCount)
-      )
+      isNonNegativeInteger(value.toolCancelledCount)
+      && isNonNegativeInteger(value.toolUnknownCount)
     )
     && (value.toolCancelledCount === undefined || isNonNegativeInteger(value.toolCancelledCount))
     && (value.toolUnknownCount === undefined || isNonNegativeInteger(value.toolUnknownCount))
@@ -645,39 +614,6 @@ export function isExperienceTimelineScope(value: unknown): boolean {
   ) return false;
   return value.previewEventCount <= value.segmentEventCount
     && value.segmentEventCount <= value.fullSessionEventCount
-    && value.omittedBeforeCount + value.omittedAfterCount <= value.fullSessionEventCount;
-}
-
-export function isLegacyExperienceTimelineScope(value: unknown): boolean {
-  if (
-    !isObjectRecord(value)
-    || value.mode !== 'skill_segment_window'
-    || !isOptionalNonNegativeInteger(value.segmentStartRecordIndex)
-    || !isOptionalNonNegativeInteger(value.segmentEndRecordIndex)
-    || !isOptionalNonNegativeInteger(value.previewStartRecordIndex)
-    || !isOptionalNonNegativeInteger(value.previewEndRecordIndex)
-    || !isNonNegativeInteger(value.sessionStartRecordIndex)
-    || !isNonNegativeInteger(value.sessionEndRecordIndex)
-    || !isNonNegativeInteger(value.previewEventCount)
-    || !isNonNegativeInteger(value.fullSessionEventCount)
-    || typeof value.truncated !== 'boolean'
-    || !isNonNegativeInteger(value.omittedBeforeCount)
-    || !isNonNegativeInteger(value.omittedAfterCount)
-  ) return false;
-  const optionalRanges: Array<[unknown, unknown]> = [
-    [value.segmentStartRecordIndex, value.segmentEndRecordIndex],
-    [value.previewStartRecordIndex, value.previewEndRecordIndex],
-  ];
-  if (optionalRanges.some(([start, end]) =>
-    (start === undefined) !== (end === undefined)
-    || (
-      typeof start === 'number'
-      && typeof end === 'number'
-      && start > end
-    )
-  )) return false;
-  return value.sessionStartRecordIndex <= value.sessionEndRecordIndex
-    && value.previewEventCount <= value.fullSessionEventCount
     && value.omittedBeforeCount + value.omittedAfterCount <= value.fullSessionEventCount;
 }
 
@@ -1226,11 +1162,11 @@ export function isExperienceStoryContext(value: unknown): value is ExperienceSto
     && value.episodes.every(isExperienceEpisode);
 }
 
-export function isExperienceSessionStory(value: unknown, compact: boolean): boolean {
+export function isExperienceSessionStory(value: unknown): boolean {
   if (
     !isObjectRecord(value)
     || value.schemaVersion !== 1
-    || (compact ? typeof value.contextRef !== 'string' : !isOptionalString(value.contextRef))
+    || typeof value.contextRef !== 'string'
     || typeof value.summary !== 'string'
     || !isNonNegativeInteger(value.invocationCount)
     || !isNonNegativeInteger(value.goalSliceCount)
@@ -1250,19 +1186,9 @@ export function isExperienceSessionStory(value: unknown, compact: boolean): bool
     || !Array.isArray(value.answers)
     || !value.answers.every(isExperienceSessionStoryAnswer)
   ) return false;
-  if (compact) {
-    return value.goalSlices === undefined
-      && value.subagentDispatches === undefined
-      && value.episodes === undefined;
-  }
-  return Array.isArray(value.goalSlices)
-    && value.goalSlices.every(isExperienceSessionStoryGoalSlice)
-    && Array.isArray(value.subagentDispatches)
-    && value.subagentDispatches.every(isExperienceSessionStorySubagentDispatch)
-    && (
-      value.episodes === undefined
-      || (Array.isArray(value.episodes) && value.episodes.every(isExperienceEpisode))
-    );
+  return value.goalSlices === undefined
+    && value.subagentDispatches === undefined
+    && value.episodes === undefined;
 }
 
 export function isExperienceReviewerReportStep(value: unknown): boolean {
@@ -1298,7 +1224,7 @@ export function isExperienceReviewerReportFinding(value: unknown): boolean {
     && isOptionalTimestamp(value.reviewStateRef.reviewedAt);
 }
 
-export function isExperienceReviewerMetrics(value: unknown, requireSourceNeutralOutcomes: boolean): boolean {
+export function isExperienceReviewerMetrics(value: unknown): boolean {
   if (!isObjectRecord(value)) return false;
   const countKeys = [
     'toolCallCount',
@@ -1318,11 +1244,8 @@ export function isExperienceReviewerMetrics(value: unknown, requireSourceNeutral
   if (
     !countKeys.every((key) => isNonNegativeInteger(value[key]))
     || (
-      requireSourceNeutralOutcomes
-      && (
-        !isNonNegativeInteger(value.toolCancelledCount)
-        || !isNonNegativeInteger(value.toolUnknownCount)
-      )
+      !isNonNegativeInteger(value.toolCancelledCount)
+      || !isNonNegativeInteger(value.toolUnknownCount)
     )
     || (
       value.toolCancelledCount !== undefined
@@ -1366,14 +1289,14 @@ export function isExperienceReviewerMetrics(value: unknown, requireSourceNeutral
         ) <= 0.0001
       )
     )
-    && (!requireSourceNeutralOutcomes || hasCoverage)
+    && hasCoverage
     && (value.toolFailureCount as number)
       + (typeof value.toolCancelledCount === 'number' ? value.toolCancelledCount : 0)
       + (typeof value.toolUnknownCount === 'number' ? value.toolUnknownCount : 0)
       <= (value.toolCallCount as number);
 }
 
-export function isExperienceReviewerReport(value: unknown, compact: boolean): boolean {
+export function isExperienceReviewerReport(value: unknown): boolean {
   if (
     !isObjectRecord(value)
     || value.schemaVersion !== 1
@@ -1388,13 +1311,9 @@ export function isExperienceReviewerReport(value: unknown, compact: boolean): bo
     || !value.chainSteps.every(isExperienceReviewerReportStep)
     || !Array.isArray(value.findings)
     || !value.findings.every(isExperienceReviewerReportFinding)
-    || !isExperienceReviewerMetrics(value.oneLookMetrics, compact)
+    || !isExperienceReviewerMetrics(value.oneLookMetrics)
     || !isStringArray(value.authorSuggestions)
     || !isExperienceEvidenceRefArray(value.traceLinks)
   ) return false;
-  if (compact) {
-    return value.sessionStory === undefined && value.sessionStoryRef === 'session';
-  }
-  return isExperienceSessionStory(value.sessionStory, false)
-    && (value.sessionStoryRef === undefined || value.sessionStoryRef === 'session');
+  return value.sessionStory === undefined && value.sessionStoryRef === 'session';
 }

--- a/src/observability/experience/session-story.ts
+++ b/src/observability/experience/session-story.ts
@@ -423,11 +423,9 @@ export function sessionStoryEpisodeRanges(
   );
   const sessionStart = minDefined(indexes)
     ?? persistedRange?.startRecordIndex
-    ?? session.timelineScope.sessionStartRecordIndex
     ?? 0;
   const sessionEnd = maxDefined(indexes)
     ?? persistedRange?.endRecordIndex
-    ?? session.timelineScope.sessionEndRecordIndex
     ?? sessionStart;
   const goalShiftStarts = unique(timeline
     .filter((event) =>

--- a/test/observability/inbox/trace-ingestion.test.ts
+++ b/test/observability/inbox/trace-ingestion.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -14,6 +14,29 @@ import { renderObservationInboxPage } from '../../../src/studio/presentation/obs
 import { baseItem, businessActionTag, businessChannel, resolvedReviewSessionsForFixture } from './_helpers.js';
 
 describe('observe inbox - trace ingestion', () => {
+  it('skips unsupported experience reports without changing files or hiding current inbox v2', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omk-experience-version-'));
+    try {
+      const trace = join(root, 'trace.jsonl');
+      writeFileSync(trace, readFileSync(new URL('../../fixtures/codex-knowledge-debugger-failure.jsonl', import.meta.url)));
+      const report = buildObservationInboxReport(trace);
+      const current = saveObservationInboxReport(report, root);
+      const old = saveObservationInboxReport(report, root);
+      const legacy = JSON.parse(readFileSync(old, 'utf8'));
+      legacy.experience.schemaVersion = 2;
+      writeFileSync(old, JSON.stringify(legacy));
+      const before = readFileSync(old, 'utf8');
+      const loaded = loadObservationInboxReports(root);
+      assert.equal(loaded.length, 1);
+      assert.equal(loaded[0].schemaVersion, 2);
+      assert.equal(loaded[0].experience?.schemaVersion, 3);
+      assert.equal(readFileSync(old, 'utf8'), before);
+      assert.equal(JSON.parse(readFileSync(current, 'utf8')).experience.schemaVersion, 3);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('builds hard_miss inbox item from Claude Code JSONL', () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-'));
     const file = join(dir, 'session.jsonl');

--- a/test/observability/trace/trace-adapter.test.ts
+++ b/test/observability/trace/trace-adapter.test.ts
@@ -3762,25 +3762,7 @@ describe('source-neutral Trace IR', () => {
       delete legacySkill.indicators.toolCancelledCount;
       delete legacySkill.indicators.toolUnknownCount;
     }
-    const migrated = normalizeObservationExperienceReport(legacy);
-    assert.ok(migrated);
-    assert.equal(migrated.schemaVersion, 3);
-    assert.equal(migrated.traceTimelines.length, 1);
-    assert.equal(migrated.invocations[0].timeline.length, invocation.timeline.length);
-
-    const legacyMalformedMetrics = JSON.parse(JSON.stringify(legacy));
-    legacyMalformedMetrics.invocations[0].metrics = null;
-    assert.equal(normalizeObservationExperienceReport(legacyMalformedMetrics), null);
-    const legacyDanglingInvocation = JSON.parse(JSON.stringify(legacy));
-    legacyDanglingInvocation.sessions[0].invocationIds = ['missing-invocation'];
-    assert.equal(normalizeObservationExperienceReport(legacyDanglingInvocation), null);
-    const legacyMalformedSkill = JSON.parse(JSON.stringify(legacy));
-    delete legacyMalformedSkill.skills[0].toolCounts;
-    assert.equal(normalizeObservationExperienceReport(legacyMalformedSkill), null);
-    const legacyMalformedScope = JSON.parse(JSON.stringify(legacy));
-    legacyMalformedScope.sessions[0].timelineScope.sessionStartRecordIndex =
-      legacyMalformedScope.sessions[0].timelineScope.sessionEndRecordIndex + 1;
-    assert.equal(normalizeObservationExperienceReport(legacyMalformedScope), null);
+    assert.equal(normalizeObservationExperienceReport(legacy), null);
   });
 });
 


### PR DESCRIPTION
本批清理 #706 中的旧体验报告转换路径。`observe-experience` v3 已在 0.48.0 引入；现在只读取 v3，停止转换 v2，并删除对应旧索引字段与宽松校验分支。外层 `observe-inbox` 当前版本仍然是 v2，继续支持。

包含体验报告 v2 的 inbox 文件会被跳过，原文件保持不变。请使用 `omk observe ingest <trace-dir>` 从原始轨迹重新生成报告。中英文迁移指南已同步说明；本批不自动迁移或删除旧文件，不发版。

当前 v3 的评分、缺失证据语义、prompt 与 Schema identity 不变。差分核对确认当前报告完整归一化结果一致，1,172 个字段删除探针的接受／拒绝结果一致；同时确认原来可转换的有效 v2 报告现在被拒绝。

自主 CR：No findings。已检查完整 diff、读写调用链、来源与时间身份、非法输入、当前 v3 的增量字段兼容以及存储失败路径。`yarn ci` 通过（337 个文件、3,577 个测试），CLI 隔离验收通过重新导入、当前 inbox 读取及旧文件不改写路径。剩余限制是 v2 文件不再出现在 inbox 结果中，需要保留原始轨迹后重新导入。

关联 #706。
