### PR TITLE
fix(eval-workflows): 贯通重复评测的预检取消信号

### DIFF
--- a/src/eval-workflows/orchestration/evaluation-service.ts
+++ b/src/eval-workflows/orchestration/evaluation-service.ts
@@ -58,6 +58,7 @@ export async function executeProductEvaluation(input: ProductEvaluationExecution
       })),
       bundleId: id('series-analysis'), reportId: id('series-report'),
       seriesSignal: input.signal,
+      preflight: { signal: input.signal },
     });
     await series.result;
     const evolution = await series.evolution;

--- a/test/eval-workflows/orchestration/orchestration.test.ts
+++ b/test/eval-workflows/orchestration/orchestration.test.ts
@@ -420,6 +420,33 @@ describe('production independent Series orchestration', () => {
         },
       },
     });
+    // Preparation is a separate cancellation boundary from member execution and aggregation.
+    for (const alreadyAborted of [true, false]) {
+      const preparationController = new AbortController();
+      const reason = new Error('cancel member preflight');
+      if (alreadyAborted) preparationController.abort(reason);
+      let aggregatePrepared = false;
+      const cancellableHost: ProductionEvaluationWorkflowInput = {
+        ...host,
+        runtime: {
+          async prepare(_input, options) {
+            assert.equal(options?.signal, preparationController.signal);
+            if (!alreadyAborted) preparationController.abort(reason);
+            options.signal.throwIfAborted();
+            throw new Error('cancelled preparation must not return a runnable member');
+          },
+          async prepareSeries(definition) {
+            aggregatePrepared = true;
+            return host.runtime.prepareSeries(definition);
+          },
+        },
+      };
+      await expect(executeProductEvaluation({
+        host: cancellableHost, request, signal: preparationController.signal,
+      })).rejects.toBe(reason);
+      expect(aggregatePrepared).toBe(false);
+    }
+
     await expect(executeProductEvaluation({ host, request, signal: controller.signal }))
       .rejects.toThrow('Core Series 未完成');
 


### PR DESCRIPTION
重复评测收到取消信号时，成员预检原先仍可能继续执行。现在产品入口将同一信号传入成员准备阶段，与已有成员执行和汇总取消保持一致。

不改变评分、Schema、持久化或测量身份，无迁移要求。本项属于 #706 后续的工作流设计债务修复。

自主 CR：No findings。回归覆盖进入预检前及预检中取消，已验证修复前失败；构建产物的产品入口接真实预检取消通过。完整 `yarn ci` 通过，337 个文件、3,578 个测试。