### PR TITLE
fix(eval-workflows): 提前拒绝批量评测的独立重复组合

### DIFF
--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -73,7 +73,7 @@ omk eval [flags]
 
 **Flags:**
 
-- `--batch` `boolean`:batch 模式：baseline 作为对照组，逐个 skill 作为实验组
+- `--batch` `boolean`:批量评测：baseline 作为对照组，逐个 skill 作为实验组；不支持 repeat 大于 1
 - `--bootstrap` `boolean`:加 bootstrap CI
 - `--bootstrap-samples` `option`:bootstrap 重采样次数，默认 1000
 - `--budget-per-sample-ms` `option`:单用例时长上限 ms（必须 > 0，不传则无上限）

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -228,7 +228,7 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
 **Flags:**
 
 ```text
-  --batch                         Batch mode: baseline vs each skill
+  --batch                         Batch mode: baseline vs each skill; repeat must be 1
   --bootstrap                     Add bootstrap CI
   --bootstrap-samples <value>     Bootstrap resamples, default 1000
   --budget-per-sample-ms <value>  Per-sample time cap ms (must be > 0; omit for no cap)

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -228,7 +228,7 @@ omk eval gold compare <run-id> --gold-dir gold-dataset \
 **Flags:**
 
 ```text
-  --batch                         batch 模式：baseline 作为对照组，逐个 skill 作为实验组
+  --batch                         批量评测：baseline 作为对照组，逐个 skill 作为实验组；不支持 repeat 大于 1
   --bootstrap                     加 bootstrap CI
   --bootstrap-samples <value>     bootstrap 重采样次数，默认 1000
   --budget-per-sample-ms <value>  单用例时长上限 ms（必须 > 0，不传则无上限）

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -332,8 +332,8 @@ export default class Eval extends BaseCommand {
     }),
     batch: Flags.boolean({
       description: bilingual({
-        zh: 'batch 模式：baseline 作为对照组，逐个 skill 作为实验组',
-        en: 'Batch mode: baseline vs each skill',
+        zh: '批量评测：baseline 作为对照组，逐个 skill 作为实验组；不支持 repeat 大于 1',
+        en: 'Batch mode: baseline vs each skill; repeat must be 1',
       }),
     }),
     'skip-connectivity': Flags.boolean({

--- a/src/eval-workflows/hosts/application.ts
+++ b/src/eval-workflows/hosts/application.ts
@@ -91,6 +91,9 @@ function createApplication(host: ApplicationHost): EvaluationApplication {
     const projectRoot = resolve(input.projectRoot);
     if (request.values.orchestration.preflight.doctor === 'skip') input.onNotice?.({ noticeKind: 'doctor-skipped' });
     if (request.values.orchestration.batch) {
+      if (request.values.orchestration.repeatCount > 1) throw new TypeError(request.values.presentation.language === 'zh'
+        ? '批量评测不支持独立重复。请移除 --batch 后逐个评测，或使用 --repeat 1 覆盖重复次数（包括 eval.yaml 中的 repeat）。'
+        : 'Batch evaluation does not support independent repeats. Remove --batch and evaluate each skill separately, or use --repeat 1 to override the repeat count (including repeat in eval.yaml).');
       const entries = discoverBatchSkills(resolve(projectRoot, request.values.locators.skillDirectory));
       if (entries.length === 0) throw new TypeError(request.values.presentation.language === 'zh'
         ? `没有找到带 canonical 私有用例的目录 skill：${request.values.locators.skillDirectory}。每个 skill 应使用 <skill>/.omk/eval-samples.json 或 eval-samples.yaml。`

--- a/test/cli/lib/evaluation-application.test.ts
+++ b/test/cli/lib/evaluation-application.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, readFile, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createNodeCoreRunArtifactStore, type CoreRunArtifactStore } from '../../../src/eval-workflows/artifact-store/index.js';
 import * as managedEvidence from '../../../src/knowledge-artifacts/governance/evidence.js';
+import type { EvalConfig } from '../../../src/eval-workflows/inputs/contracts/config.js';
 import { runCoreEvaluationCommand } from '../../../src/cli/lib/run-core-evaluation.js';
 
 const roots: string[] = [];
@@ -30,7 +31,7 @@ async function fixture() {
   const outputDirectory = join(root, 'reports');
   const config = { samplesPath, skillDir, executorName: resolve('test/fixtures/custom-executor/core-fixture-executor.sh'), model: 'fixture', judgeModels: [] };
   const flags = { control: 'baseline', treatment: skill, 'no-judge': true, 'skip-doctor': true, 'skip-connectivity': true, 'no-serve': true, 'output-dir': outputDirectory };
-  return { root, outputDirectory, run: (extra: Record<string, unknown> = {}, store?: CoreRunArtifactStore) => runCoreEvaluationCommand({ projectRoot: root, config, flags: { ...flags, ...extra }, evalConfig: null, lang: 'zh', store }) };
+  return { root, outputDirectory, run: (extra: Record<string, unknown> = {}, store?: CoreRunArtifactStore, settings: { evalConfig?: EvalConfig; lang?: 'en' | 'zh' } = {}) => runCoreEvaluationCommand({ projectRoot: root, config, flags: { ...flags, ...extra }, evalConfig: settings.evalConfig ?? null, lang: settings.lang ?? 'zh', store }) };
 }
 
 describe('CLI product application', () => {
@@ -48,11 +49,32 @@ describe('CLI product application', () => {
 
   it('runs batch children through the same product path for preview and persisted output', async () => {
     const input = await fixture();
-    const preview = await input.run({ batch: true, 'dry-run': true });
+    const preview = await input.run({ batch: true, 'dry-run': true, repeat: 1 }, undefined, {
+      evalConfig: { samples: 'unused.json', variants: [{ name: 'baseline', role: 'control', artifact: 'baseline' }], repeat: 2 },
+    });
     expect(preview.output).toMatchObject({ projectionKind: 'core-cli-batch-dry-run', children: [{ itemId: 'answer' }] });
     const result = await input.run({ batch: true });
     expect(result.output).toMatchObject({ projectionKind: 'core-cli-batch-outcome' });
     await expect(input.run({ batch: true, resume: 'existing' })).rejects.toThrow('Batch resume');
+  });
+
+  it.each([
+    { dryRun: false, source: 'flag', lang: 'zh' },
+    { dryRun: true, source: 'flag', lang: 'en' },
+    { dryRun: false, source: 'config', lang: 'en' },
+    { dryRun: true, source: 'config', lang: 'zh' },
+  ] as const)('rejects batch repeats before side effects: $source, preview=$dryRun, $lang', async ({ dryRun, source, lang }) => {
+    const input = await fixture();
+    const before = await readdir(input.root);
+    const evalConfig: EvalConfig | undefined = source === 'config'
+      ? { samples: 'unused.json', variants: [{ name: 'baseline', role: 'control', artifact: 'baseline' }], repeat: 2 }
+      : undefined;
+    await expect(input.run({
+      batch: true, 'dry-run': dryRun, ...(source === 'flag' ? { repeat: 2 } : {}),
+    }, undefined, { evalConfig, lang })).rejects.toThrow(lang === 'zh'
+      ? '批量评测不支持独立重复' : 'Batch evaluation does not support independent repeats');
+    expect(await readdir(input.root)).toEqual(before);
+    expect(vi.mocked(process.stderr.write).mock.calls.flat().join('')).not.toContain('Core Batch：');
   });
 
   it('rejects publication failure without announcing saved artifacts or appending managed evidence', async () => {

--- a/test/cli/oclif-startup.test.ts
+++ b/test/cli/oclif-startup.test.ts
@@ -171,7 +171,7 @@ describe('oclif startup short-circuit (skip checkUpdate on --help/--version)', (
       const e = err as ExecError;
       assert.equal(e.code, 2, `expected exit 2 on unknown flag, got ${e.code}`);
       const out = e.stdout + e.stderr;
-      assert.ok(/batch 模式/.test(out) && /Batch mode/.test(out),
+      assert.ok(/批量评测/.test(out) && /Batch mode/.test(out),
         `expected bilingual flag dump (zh + en), got:\n${out.slice(0, 600)}`);
     }
   });


### PR DESCRIPTION
`--batch` 配合重复次数大于 1 时，原先会执行各个 Series，直到汇总才因只接受单次 run 而失败。现在 Workflow 产品入口在发现样本或执行成员前明确拒绝该组合，预览模式同样校验。提示用户逐个评测，或用 `--repeat 1` 覆盖命令行／配置文件的重复次数；双语帮助与生成文档同步。

不扩展 Batch／Series 的组合能力，不改变有效评测的评分、Schema 或持久化语义。无需数据迁移。关联前序 #763，本项属于 #706 后续设计债务修复。

自主 CR：No findings。新增回归已验证修复前失败；覆盖配置与 CLI 来源、预览、双语提示、无运行产物及显式覆盖为 1。实际 tarball 在隔离目录完成中文／英文 × 运行／预览验收，业务拒绝退出码为 1。最终 `yarn ci` 通过，337 个文件、3,582 个测试。