### PR TITLE
fix(eval-workflows): 统一评测存储的项目与环境上下文

### DIFF
--- a/src/cli/lib/run-core-evaluation.ts
+++ b/src/cli/lib/run-core-evaluation.ts
@@ -11,7 +11,7 @@ import {
 } from '../../eval-workflows/hosts/application.js';
 import { captureNodeCliEvaluationEnvironment } from './evaluation-composition.js';
 import { withLocalizedSampleDiscovery } from './localized-sample-discovery.js';
-import { projectReportsDir, globalReportsDir } from '../../evidence/storage/directories.js';
+import { projectReportsDir } from '../../evidence/storage/directories.js';
 import { globalLayout } from '../../evidence/storage/layout.js';
 import type { RunConfig } from './parse-run-config.js';
 import type { CliLang } from './i18n.js';
@@ -35,7 +35,7 @@ export interface RunCoreEvaluationCommandResult {
   readonly outputDirectory: string;
 }
 
-function requestFor(input: RunCoreEvaluationCommandInput, projectRoot: string): CliEvaluationRequest {
+function requestFor(input: RunCoreEvaluationCommandInput, projectRoot: string, globalOutputDirectory: string): CliEvaluationRequest {
   const projectMcpConfig = join(projectRoot, '.mcp.json');
   return parseCliEvaluationRequest({
     explicitCliFlags: input.flags,
@@ -57,8 +57,8 @@ function requestFor(input: RunCoreEvaluationCommandInput, projectRoot: string): 
           : { deploymentRevision: judge.deploymentRevision }),
       })),
       presentation: {
-        projectOutputDirectoryLocator: projectReportsDir(),
-        globalOutputDirectoryLocator: globalReportsDir(),
+        projectOutputDirectoryLocator: projectReportsDir(projectRoot),
+        globalOutputDirectoryLocator: globalOutputDirectory,
         language: input.lang,
         languageDefaultSource: 'environment-selection',
       },
@@ -143,16 +143,17 @@ function renderNotice(notice: EvaluationNotice, lang: CliLang): void {
 
 export async function runCoreEvaluationCommand(input: Readonly<RunCoreEvaluationCommandInput>): Promise<RunCoreEvaluationCommandResult> {
   const projectRoot = resolve(input.projectRoot ?? process.cwd());
-  const machineLayout = globalLayout(input.environment?.OMK_HOME);
-  const application = createNodeEvaluationApplication(captureNodeCliEvaluationEnvironment(input.environment));
+  const environment = captureNodeCliEvaluationEnvironment(input.environment);
+  const machineLayout = globalLayout(environment.environment.OMK_HOME);
+  const application = createNodeEvaluationApplication(environment);
   try {
     const result = await application.run({
-      request: requestFor(input, projectRoot), projectRoot,
+      request: requestFor(input, projectRoot, machineLayout.evalDir), projectRoot,
       materializationRoot: machineLayout.resolvedInputsDir, resourceLeaseRoot: machineLayout.resourceLeasesDir,
       store: input.store,
       createProgressSink: () => emitProgress(input.lang),
       onNotice: (notice) => renderNotice(notice, input.lang),
-      requestForBatchItem: (entry) => requestFor({ ...input, flags: { ...input.flags, batch: undefined, control: 'baseline', treatment: entry.skillPath, samples: entry.samplesPath, 'no-serve': true } }, projectRoot),
+      requestForBatchItem: (entry) => requestFor({ ...input, flags: { ...input.flags, batch: undefined, control: 'baseline', treatment: entry.skillPath, samples: entry.samplesPath, 'no-serve': true } }, projectRoot, machineLayout.evalDir),
       async onCompleted(completed, request) {
         if (completed.outcomeKind === 'run') await announceCoreReport(completed.artifacts, completed.store, completed.outputDirectory, request.values.presentation.serve, input.lang);
         if (completed.outcomeKind === 'series') process.stderr.write(input.lang === 'zh'

--- a/src/eval-workflows/hosts/application.ts
+++ b/src/eval-workflows/hosts/application.ts
@@ -74,13 +74,13 @@ interface ApplicationHost {
   readonly environment?: NodeJS.ProcessEnv;
   readonly implementationIds?: readonly string[];
   readonly idPrefix?: string;
-  readonly globalFallback: boolean;
+  readonly globalFallbackDirectory?: string;
   compose(input: CompositionInput): EvaluationRuntimeComposition | Promise<EvaluationRuntimeComposition>;
 }
 
-function runStore(outputDirectory: string, contentResolver: EvaluationRuntimeComposition['contentResolver'], fallback: boolean): CoreRunArtifactStore {
+function runStore(outputDirectory: string, contentResolver: EvaluationRuntimeComposition['contentResolver'], projectRoot: string, fallbackDirectory?: string): CoreRunArtifactStore {
   const primary = createNodeCoreRunArtifactStore(outputDirectory, { contentResolver });
-  const fallbackDirs = fallback && resolve(outputDirectory) === resolve(projectLayout().evalDir) ? [globalLayout().evalDir] : [];
+  const fallbackDirs = fallbackDirectory !== undefined && resolve(outputDirectory) === resolve(projectLayout(projectRoot).evalDir) ? [fallbackDirectory] : [];
   const unique = [...new Set(fallbackDirs.map((dir) => resolve(dir)))].filter((dir) => dir !== resolve(outputDirectory));
   return unique.length === 0 ? primary : createOverlayCoreRunArtifactStore(primary, unique.map((dir) => createNodeCoreRunArtifactStore(dir, { contentResolver: createNodeCoreContentStore(join(dir, 'content')) })));
 }
@@ -118,7 +118,7 @@ function createApplication(host: ApplicationHost): EvaluationApplication {
         if (child.outcomeKind !== 'run') throw new Error('Core Batch child 缺少持久化产物。');
         return child.artifacts;
       });
-      const store = input.store ?? runStore(outputDirectory, createNodeCoreContentStore(join(outputDirectory, 'content')), host.globalFallback);
+      const store = input.store ?? runStore(outputDirectory, createNodeCoreContentStore(join(outputDirectory, 'content')), projectRoot, host.globalFallbackDirectory);
       const batch = await createNodeCoreBatchArtifactStore(outputDirectory, store).save({ batchId: generateRunId(['batch']), createdAt: new Date().toISOString(), children: artifacts.map((child, index) => ({ itemId: entries[index]!.name, runId: child.manifest.runId })) });
       return { outcomeKind: 'batch', outputDirectory, outcome: projectCoreCliBatchOutcome({ batch, children: artifacts, exitMode: request.values.presentation.exitMode, diagnosticMode: request.values.orchestration.diagnostic === 'enabled-outside-core' ? 'enabled' : 'disabled' }) };
     }
@@ -131,7 +131,7 @@ function createApplication(host: ApplicationHost): EvaluationApplication {
     });
     const compiled = compileCliEvaluationInput(resolved);
     const composition = await host.compose({ compiled, projectRoot, outputDirectory, resourceLeaseRoot: input.resourceLeaseRoot });
-    const store = input.store ?? runStore(outputDirectory, composition.contentResolver, host.globalFallback);
+    const store = input.store ?? runStore(outputDirectory, composition.contentResolver, projectRoot, host.globalFallbackDirectory);
     const result = await executeProductEvaluation({ host: { compiled, ...composition, artifactStore: store }, request, signal: input.signal, createProgressSink: input.createProgressSink, idPrefix: host.idPrefix });
     if (result.outcomeKind !== 'dry-run') {
       const artifacts = result.outcomeKind === 'run' ? [result.artifacts] : result.artifacts;
@@ -155,7 +155,7 @@ function createApplication(host: ApplicationHost): EvaluationApplication {
 }
 
 export function createNodeEvaluationApplication(capabilities: NodeEvaluationEnvironment): EvaluationApplication {
-  return createApplication({ environment: capabilities.environment, globalFallback: true, compose: (input) => createNodeProductionComposition({ ...input, capabilities }) });
+  return createApplication({ environment: capabilities.environment, globalFallbackDirectory: globalLayout(capabilities.environment.OMK_HOME).evalDir, compose: (input) => createNodeProductionComposition({ ...input, capabilities }) });
 }
 
 export interface HostedEvaluationCapabilities {
@@ -169,7 +169,7 @@ export interface HostedEvaluationCapabilities {
 
 export function createHostedEvaluationApplication(capabilities: HostedEvaluationCapabilities): EvaluationApplication {
   return createApplication({
-    environment: capabilities.environment, implementationIds: [capabilities.implementationId], idPrefix: capabilities.idPrefix, globalFallback: false,
+    environment: capabilities.environment, implementationIds: [capabilities.implementationId], idPrefix: capabilities.idPrefix,
     compose(input) {
       const preflightDeclarations = createNodeHostPreflightDeclarations(input.compiled, capabilities.environment, input.projectRoot);
       return createRegisteredEvaluationComposition({

--- a/test/cli/lib/evaluation-application.test.ts
+++ b/test/cli/lib/evaluation-application.test.ts
@@ -31,7 +31,7 @@ async function fixture() {
   const outputDirectory = join(root, 'reports');
   const config = { samplesPath, skillDir, executorName: resolve('test/fixtures/custom-executor/core-fixture-executor.sh'), model: 'fixture', judgeModels: [] };
   const flags = { control: 'baseline', treatment: skill, 'no-judge': true, 'skip-doctor': true, 'skip-connectivity': true, 'no-serve': true, 'output-dir': outputDirectory };
-  return { root, outputDirectory, run: (extra: Record<string, unknown> = {}, store?: CoreRunArtifactStore, settings: { evalConfig?: EvalConfig; lang?: 'en' | 'zh' } = {}) => runCoreEvaluationCommand({ projectRoot: root, config, flags: { ...flags, ...extra }, evalConfig: settings.evalConfig ?? null, lang: settings.lang ?? 'zh', store }) };
+  return { root, outputDirectory, run: (extra: Record<string, unknown> = {}, store?: CoreRunArtifactStore, settings: { evalConfig?: EvalConfig; lang?: 'en' | 'zh'; environment?: NodeJS.ProcessEnv } = {}) => runCoreEvaluationCommand({ projectRoot: root, config, flags: { ...flags, ...extra }, evalConfig: settings.evalConfig ?? null, lang: settings.lang ?? 'zh', environment: settings.environment, store }) };
 }
 
 describe('CLI product application', () => {
@@ -75,6 +75,45 @@ describe('CLI product application', () => {
       ? '批量评测不支持独立重复' : 'Batch evaluation does not support independent repeats');
     expect(await readdir(input.root)).toEqual(before);
     expect(vi.mocked(process.stderr.write).mock.calls.flat().join('')).not.toContain('Core Batch：');
+  });
+
+  it('uses the explicit project root for default output even when process cwd differs', async () => {
+    const input = await fixture();
+    const unrelated = join(input.root, 'unrelated');
+    await mkdir(unrelated);
+    vi.spyOn(process, 'cwd').mockReturnValue(unrelated);
+    const result = await input.run({ 'output-dir': undefined, 'no-evidence': true });
+    expect(result.outputDirectory).toBe(join(input.root, '.omk', 'eval'));
+    expect(result.stored).toBeDefined();
+    expect(await readdir(unrelated)).toEqual([]);
+  });
+
+  it('uses the captured environment for explicit global output', async () => {
+    const input = await fixture();
+    const environment = { ...process.env, OMK_HOME: join(input.root, 'captured-home') };
+    const result = await input.run({ 'output-dir': undefined, global: true, 'dry-run': true }, undefined, { environment });
+    expect(result.outputDirectory).toBe(join(environment.OMK_HOME, 'eval'));
+  });
+
+  it('finds global evidence from the explicit project context without weakening resume admission', async () => {
+    const input = await fixture();
+    const unrelated = join(input.root, 'unrelated');
+    await mkdir(unrelated);
+    vi.spyOn(process, 'cwd').mockReturnValue(unrelated);
+    const environment = { ...process.env, OMK_HOME: join(input.root, 'captured-home') };
+    const globalDirectory = join(environment.OMK_HOME, 'eval');
+    const global = await input.run({ 'output-dir': globalDirectory, 'no-evidence': true }, undefined, { environment });
+    const runId = global.stored!.manifest.runId;
+    // Finding the global run must still pass through the existing evidence trust gate.
+    await expect(input.run({ 'output-dir': undefined, resume: runId }, undefined, { environment }))
+      .rejects.toMatchObject({ code: 'CORE_RESUME_VERIFICATION_INDETERMINATE' });
+    const isolatedDirectory = join(unrelated, '.omk', 'eval');
+    await expect(input.run({ 'output-dir': isolatedDirectory, resume: runId }, undefined, { environment }))
+      .rejects.toMatchObject({ code: 'CORE_RESUME_SOURCE_NOT_FOUND' });
+    const injected = createNodeCoreRunArtifactStore(globalDirectory);
+    await expect(input.run({ 'output-dir': isolatedDirectory, resume: runId }, injected, { environment }))
+      .rejects.toMatchObject({ code: 'CORE_RESUME_VERIFICATION_INDETERMINATE' });
+    expect((await injected.get(runId))?.report.reportDigest).toBe(global.stored!.report.reportDigest);
   });
 
   it('rejects publication failure without announcing saved artifacts or appending managed evidence', async () => {


### PR DESCRIPTION
调用方传入不同于进程工作目录的项目根时，默认输出和全局历史记录回退原先可能指向错误上下文。现在默认项目输出与回退判断均使用显式项目根；全局输出、临时资源和回退目录使用同一捕获环境中的 OMK_HOME。

自定义输出目录保持独立，调用方注入的 store 继续优先，Hosted／DSH 不新增全局回退。恢复操作仍执行原有完整性与证据信任校验。未改变报告格式或评分语义，不自动移动历史文件；若旧调用曾写入其他目录，可显式指定原输出目录访问。关联前序 #763、#764，本项属于 #706 后续设计债务修复。

自主 CR：No findings。三条新增回归均验证修复前失败；覆盖显式项目根、捕获环境、全局记录发现、自定义目录隔离和注入 store 优先。真实 tarball 在独立进程、不同 cwd 下执行本地／全局评测，运行契约一致，原全局报告不变。最终 `yarn ci` 通过，337 个文件、3,585 个测试。