### PR TITLE
refactor(eval-workflows): 移除无调用的共享断言入口

### DIFF
--- a/src/eval-workflows/assertions/deterministic.ts
+++ b/src/eval-workflows/assertions/deterministic.ts
@@ -4,7 +4,6 @@ import type { SyncAssertionType } from '../inputs/assertion-types.js';
 import type { Assertion } from '../inputs/contracts/assertion.js';
 
 const Ajv = _Ajv.default ?? _Ajv;
-const ajv = new Ajv();
 
 type JsonSchemaValidator = (
   data: unknown,
@@ -207,14 +206,6 @@ function validateJsonSchemaWith(
   }
 }
 
-/** Legacy-compatible module session used only by the existing grader entrypoint. */
-export function validateJsonSchema(
-  data: unknown,
-  schema: Record<string, unknown>,
-): boolean {
-  return validateJsonSchemaWith(ajv, data, schema);
-}
-
 function evaluateRaw(
   output: string,
   assertion: Assertion,
@@ -321,22 +312,6 @@ function evaluateRaw(
         >= (assertion.threshold ?? 0.5);
     default: return false;
   }
-}
-
-export function evaluateDeterministicAssertion(
-  output: string,
-  assertion: Assertion,
-  context: DeterministicAssertionContext = {},
-): boolean {
-  const toolCalls = [...(context.toolCalls ?? [])];
-  const raw = evaluateRaw(output, assertion, {
-    ...context,
-    toolCalls,
-    outputLower: output.toLowerCase(),
-    toolNames: toolCalls.map((call) => call.tool.toLowerCase()),
-    validateSchema: validateJsonSchema,
-  });
-  return assertion.not ? !raw : raw;
 }
 
 /** Creates an evaluator whose schema compilation has no cross-criterion, record, or run state. */


### PR DESCRIPTION
## 用户影响

落实 #767 的 A3，删除没有生产或测试调用的旧确定性断言入口及其共享 Ajv 初始化，避免误用跨断言共享的 Schema 注册状态。生产输出断言与执行断言继续使用原有隔离 evaluator。

## 迁移与测量可比性

没有公开 API、CLI、持久化契约或安装入口变化，无需迁移。断言算法、算法版本、评分口径、Schema identity 和 prompt 字节均保持不变；未削减生产算法或隔离回归测试。

## 交付证据

源码净减少 25 行，测试零变化。完整 `yarn ci` 通过，333 个测试文件、3592 个测试通过。

自主 CR：No findings。已检查完整 diff、两个生产 evaluator 的接线及已有跨 criterion／并发运行 Schema 隔离证据。该改动只移除不可达内部入口，不触发额外 clean-room 验收。

关联 #767，前置 #769 已合并。本 PR 只完成 A3，不关闭总 issue。