### PR TITLE
refactor(eval-workflows): 统一宿主评委调用结果转换

### DIFF
--- a/src/dsh-plugin/core-command.ts
+++ b/src/dsh-plugin/core-command.ts
@@ -1,18 +1,17 @@
 import { join, resolve } from 'node:path';
-import type { RuntimeIdentity, UsageRecord } from '../eval-core/contracts/index.js';
+import type { RuntimeIdentity } from '../eval-core/contracts/index.js';
 import {
   createHostedEvaluationApplication,
+  createExecutorJudgeInvocationPort,
   createJudgeProviderRuntimeIdentity,
   parseCliEvaluationRequest,
   type HostedEvaluationCapabilities,
   type StoredCoreRunArtifacts,
   type OmkLlmJudgeInvocationBinding,
-  type OmkLlmJudgeInvocationRequest,
 } from '../eval-workflows/hosts/application.js';
 import { globalLayout, projectLayout } from '../evidence/storage/layout.js';
 import type { CoreCliRunOutcome, CoreCliSeriesOutcome } from '../eval-workflows/projections/contracts.js';
 import { managedDir } from '../knowledge-artifacts/governance/index.js';
-import type { ExecResult } from '../executors/contracts/result.js';
 import type { ExecutorFn } from '../executors/contracts/ports.js';
 import type { EvalConfig } from '../eval-workflows/inputs/contracts/config.js';
 import type { JudgeConfig } from '../eval-workflows/instruments/contracts/config.js';
@@ -39,24 +38,6 @@ function withoutExecutor(config: Readonly<EvalConfig>): EvalConfig {
   const result = { ...config };
   delete result.executor;
   return result;
-}
-
-function usage(result: Readonly<ExecResult>): UsageRecord | undefined {
-  const value: UsageRecord = {
-    ...(result.tokenUsageReportedByExecutor === false ? {} : {
-      inputTokens: result.inputTokens,
-      outputTokens: result.outputTokens,
-      totalTokens: result.inputTokens + result.outputTokens,
-    }),
-    ...(result.costReportedByExecutor === false ? {} : {
-      providerCost: {
-        amount: result.costUSD,
-        currency: 'USD',
-        reportedByProvider: true,
-      },
-    }),
-  };
-  return Object.keys(value).length === 0 ? undefined : value;
 }
 
 function runtimeIdentity(
@@ -98,42 +79,7 @@ function judgeResolver(
       );
     identities.set(identityKey, identity);
     return Object.freeze({
-      port: Object.freeze({
-        identity,
-        providerCost: { reporting: 'optional' as const },
-        async invoke(request: Readonly<OmkLlmJudgeInvocationRequest>) {
-          try {
-            const result = await executor({
-              model: request.model,
-              system: request.system,
-              prompt: request.prompt,
-              effort: request.effort,
-              abortSignal: request.signal,
-            });
-            const measured = usage(result);
-            return result.ok && result.output !== null
-              ? {
-                  invocationStatus: 'completed' as const,
-                  output: result.output,
-                  ...(measured === undefined ? {} : { usage: measured }),
-                }
-              : {
-                  invocationStatus: 'failed' as const,
-                  reasonCode: request.signal.aborted
-                    ? 'provider-invocation-cancelled'
-                    : 'provider-invocation-failed',
-                  ...(measured === undefined ? {} : { usage: measured }),
-                };
-          } catch {
-            return {
-              invocationStatus: 'failed' as const,
-              reasonCode: request.signal.aborted
-                ? 'provider-invocation-cancelled'
-                : 'provider-invocation-failed',
-            };
-          }
-        },
-      }),
+      port: createExecutorJudgeInvocationPort(executor, identity),
       preflightDeclarations: Object.freeze([
         Object.freeze({
           preflightKind: 'credential' as const,

--- a/src/eval-workflows/hosts/application.ts
+++ b/src/eval-workflows/hosts/application.ts
@@ -35,6 +35,7 @@ export type { OmkLlmJudgeInvocationBinding } from './evaluators/llm-judge-invoca
 export type { OmkLlmJudgeInvocationRequest } from './evaluators/llm-judge-invocation.js';
 export type { OmkExecutorBindingContext } from './types.js';
 export { createJudgeProviderRuntimeIdentity } from './composition/judge-provider-identity.js';
+export { createExecutorJudgeInvocationPort } from './evaluators/executor-judge-invocation.js';
 
 export type EvaluationNotice =
   | { readonly noticeKind: 'doctor-skipped' }

--- a/src/eval-workflows/hosts/composition/node-runtime.ts
+++ b/src/eval-workflows/hosts/composition/node-runtime.ts
@@ -4,7 +4,6 @@ import {
   schemaIdentityKey,
   type CoreSchemaValidator,
   type RuntimeIdentity,
-  type UsageRecord,
 } from '../../../eval-core/contracts/index.js';
 import { createExecutor } from '../../../executors/index.js';
 import type { ExecutorFn } from '../../../executors/contracts/ports.js';
@@ -13,9 +12,7 @@ import type { CliEvaluationCompileResult } from '../../input-compilation/index.j
 import type {
   OmkLlmJudgeInvocationBinding,
 } from '../evaluators/llm-judge-invocation.js';
-import type {
-  OmkLlmJudgeInvocationRequest,
-} from '../evaluators/llm-judge-invocation.js';
+import { createExecutorJudgeInvocationPort } from '../evaluators/executor-judge-invocation.js';
 import {
   createAnthropicApiCoreSchemaValidators,
 } from '../adapters/anthropic/protocol.js';
@@ -199,24 +196,6 @@ function judgeIdentity(
   });
 }
 
-function usage(result: Awaited<ReturnType<ExecutorFn>>): UsageRecord | undefined {
-  const value: UsageRecord = {
-    ...(result.tokenUsageReportedByExecutor === false ? {} : {
-      inputTokens: result.inputTokens,
-      outputTokens: result.outputTokens,
-      totalTokens: result.inputTokens + result.outputTokens,
-    }),
-    ...(result.costReportedByExecutor === false ? {} : {
-      providerCost: {
-        amount: result.costUSD,
-        currency: 'USD',
-        reportedByProvider: true,
-      },
-    }),
-  };
-  return Object.keys(value).length === 0 ? undefined : value;
-}
-
 function judgeResolver(environment: NodeJS.ProcessEnv): (
   context: Parameters<NonNullable<Parameters<typeof createProductionRuntimeFactoryRegistry>[0]['resolveJudgeInvocation']>>[0],
 ) => Promise<OmkLlmJudgeInvocationBinding> {
@@ -235,50 +214,14 @@ function judgeResolver(environment: NodeJS.ProcessEnv): (
       executor = createExecutor(executorId);
       executors.set(executorId, executor);
     }
-    const provider = executor;
     return Object.freeze({
-      port: Object.freeze({
-        identity: judgeIdentity(
-          executorId,
-          qualification.model,
-          qualification.deploymentRevision,
-          provider,
-          environment,
-        ),
-        providerCost: { reporting: 'optional' as const },
-        async invoke(request: Readonly<OmkLlmJudgeInvocationRequest>) {
-          try {
-            const result = await provider({
-              model: request.model,
-              system: request.system,
-              prompt: request.prompt,
-              effort: request.effort,
-              abortSignal: request.signal,
-            });
-            const measuredUsage = usage(result);
-            return result.ok && result.output !== null
-              ? {
-                  invocationStatus: 'completed' as const,
-                  output: result.output,
-                  ...(measuredUsage === undefined ? {} : { usage: measuredUsage }),
-                }
-              : {
-                  invocationStatus: 'failed' as const,
-                  reasonCode: request.signal.aborted
-                    ? 'provider-invocation-cancelled'
-                    : 'provider-invocation-failed',
-                  ...(measuredUsage === undefined ? {} : { usage: measuredUsage }),
-                };
-          } catch {
-            return {
-              invocationStatus: 'failed' as const,
-              reasonCode: request.signal.aborted
-                ? 'provider-invocation-cancelled'
-                : 'provider-invocation-failed',
-            };
-          }
-        },
-      }),
+      port: createExecutorJudgeInvocationPort(executor, judgeIdentity(
+        executorId,
+        qualification.model,
+        qualification.deploymentRevision,
+        executor,
+        environment,
+      )),
       preflightDeclarations: Object.freeze([Object.freeze({
         preflightKind: 'connectivity' as const,
         checkId: 'provider-connectivity',

--- a/src/eval-workflows/hosts/evaluators/executor-judge-invocation.ts
+++ b/src/eval-workflows/hosts/evaluators/executor-judge-invocation.ts
@@ -1,0 +1,64 @@
+import type { RuntimeIdentity, UsageRecord } from '../../../eval-core/contracts/index.js';
+import type { ExecutorFn } from '../../../executors/contracts/ports.js';
+import type { OmkLlmJudgeInvocationPort, OmkLlmJudgeInvocationRequest } from './llm-judge-invocation.js';
+
+function usage(result: Awaited<ReturnType<ExecutorFn>>): UsageRecord | undefined {
+  const value: UsageRecord = {
+    ...(result.tokenUsageReportedByExecutor === false ? {} : {
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      totalTokens: result.inputTokens + result.outputTokens,
+    }),
+    ...(result.costReportedByExecutor === false ? {} : {
+      providerCost: {
+        amount: result.costUSD,
+        currency: 'USD',
+        reportedByProvider: true,
+      },
+    }),
+  };
+  return Object.keys(value).length === 0 ? undefined : value;
+}
+
+/** Adapts one executor call; identity, preflight, retries and cancellation policy remain caller-owned. */
+export function createExecutorJudgeInvocationPort(
+  executor: ExecutorFn,
+  identity: RuntimeIdentity,
+): OmkLlmJudgeInvocationPort {
+  return Object.freeze({
+    identity,
+    providerCost: { reporting: 'optional' as const },
+    async invoke(request: Readonly<OmkLlmJudgeInvocationRequest>) {
+      try {
+        const result = await executor({
+          model: request.model,
+          system: request.system,
+          prompt: request.prompt,
+          effort: request.effort,
+          abortSignal: request.signal,
+        });
+        const measuredUsage = usage(result);
+        return result.ok && result.output !== null
+          ? {
+              invocationStatus: 'completed' as const,
+              output: result.output,
+              ...(measuredUsage === undefined ? {} : { usage: measuredUsage }),
+            }
+          : {
+              invocationStatus: 'failed' as const,
+              reasonCode: request.signal.aborted
+                ? 'provider-invocation-cancelled'
+                : 'provider-invocation-failed',
+              ...(measuredUsage === undefined ? {} : { usage: measuredUsage }),
+            };
+      } catch {
+        return {
+          invocationStatus: 'failed' as const,
+          reasonCode: request.signal.aborted
+            ? 'provider-invocation-cancelled'
+            : 'provider-invocation-failed',
+        };
+      }
+    },
+  });
+}

--- a/test/eval-workflows/hosts/evaluators/executor-judge-invocation.test.ts
+++ b/test/eval-workflows/hosts/evaluators/executor-judge-invocation.test.ts
@@ -1,0 +1,216 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ExecResult } from '../../../../src/executors/contracts/result.js';
+import type { ExecutorFn } from '../../../../src/executors/contracts/ports.js';
+import type { ExecutorRuntimeFingerprint } from '../../../../src/executors/contracts/runtime.js';
+import * as executors from '../../../../src/executors/index.js';
+import * as fingerprints from '../../../../src/executors/core/runtime-fingerprint.js';
+import * as application from '../../../../src/eval-workflows/hosts/application.js';
+import * as registered from '../../../../src/eval-workflows/hosts/composition/registered-runtime.js';
+import { createNodeProductionComposition } from '../../../../src/eval-workflows/hosts/composition/node-runtime.js';
+import { createJudgeProviderRuntimeIdentity } from '../../../../src/eval-workflows/hosts/composition/judge-provider-identity.js';
+import * as adapter from '../../../../src/eval-workflows/hosts/evaluators/executor-judge-invocation.js';
+import type { OmkLlmJudgeInvocationRequest, OmkLlmJudgeInvocationResolver } from '../../../../src/eval-workflows/hosts/evaluators/llm-judge-invocation.js';
+import type { CliEvaluationCompileResult } from '../../../../src/eval-workflows/input-compilation/index.js';
+import * as dshExecutor from '../../../../src/dsh-plugin/host-executor.js';
+import { runDshCoreEvaluation } from '../../../../src/dsh-plugin/core-command.js';
+
+afterEach(() => vi.restoreAllMocks());
+
+function result(patch: Partial<ExecResult> = {}): ExecResult {
+  return {
+    ok: true, output: 'judge output', durationMs: 1, durationApiMs: 1,
+    inputTokens: 3, outputTokens: 5, cacheReadTokens: 0, cacheCreationTokens: 0,
+    costUSD: 0.02, stopReason: 'completed', numTurns: 1,
+    ...patch,
+  };
+}
+
+function runtime(executor: string): ExecutorRuntimeFingerprint {
+  return {
+    executor, model: 'judge-model', runtimeKind: 'api', fingerprint: 'test-provider-v1',
+    capabilities: { systemPrompt: 'native', costUSD: 'reported', trace: 'none', skillIsolation: 'none' },
+  };
+}
+
+function request(signal = new AbortController().signal): OmkLlmJudgeInvocationRequest {
+  return {
+    executorId: 'fixture', model: 'judge-model', system: 'system bytes\n', prompt: 'prompt bytes\n',
+    promptId: 'fixture-prompt', promptHash: 'fixture-hash', effort: 'high', signal,
+  };
+}
+
+const identity = createJudgeProviderRuntimeIdentity({
+  executorId: 'fixture', model: 'judge-model', executorRuntime: runtime('fixture'),
+});
+const measured = {
+  inputTokens: 3, outputTokens: 5, totalTokens: 8,
+  providerCost: { amount: 0.02, currency: 'USD', reportedByProvider: true },
+};
+
+describe('executor-backed judge invocation conversion', () => {
+  it('forwards exactly one call without changing prompt bytes, effort or signal', async () => {
+    const executor = vi.fn<ExecutorFn>().mockResolvedValue(result());
+    const port = adapter.createExecutorJudgeInvocationPort(executor, identity);
+    const input = request();
+    expect(port.identity).toBe(identity);
+    expect(port.providerCost).toEqual({ reporting: 'optional' });
+    expect(Object.isFrozen(port)).toBe(true);
+    await expect(port.invoke(input)).resolves.toEqual({
+      invocationStatus: 'completed', output: 'judge output', usage: measured,
+    });
+    expect(executor).toHaveBeenCalledExactlyOnceWith({
+      model: input.model, system: input.system, prompt: input.prompt,
+      effort: input.effort, abortSignal: input.signal,
+    });
+  });
+
+  it.each([
+    { ok: true, output: '', completed: true },
+    { ok: true, output: null, completed: false },
+    { ok: false, output: null, completed: false },
+    { ok: false, output: 'untrusted failed output', completed: false },
+  ])('classifies ok=$ok, output=$output without discarding measured usage', async ({ ok, output, completed }) => {
+    const executor = vi.fn<ExecutorFn>().mockResolvedValue(result({ ok, output, error: 'private provider error' }));
+    await expect(adapter.createExecutorJudgeInvocationPort(executor, identity).invoke(request()))
+      .resolves.toEqual(completed
+        ? { invocationStatus: 'completed', output, usage: measured }
+        : { invocationStatus: 'failed', reasonCode: 'provider-invocation-failed', usage: measured });
+  });
+
+  it.each([
+    { tokens: undefined, cost: undefined },
+    { tokens: true, cost: true },
+    { tokens: false, cost: true },
+    { tokens: true, cost: false },
+    { tokens: false, cost: false },
+  ])('keeps independently unreported telemetry absent: tokens=$tokens, cost=$cost', async ({ tokens, cost }) => {
+    const executor = vi.fn<ExecutorFn>().mockResolvedValue(result({
+      tokenUsageReportedByExecutor: tokens, costReportedByExecutor: cost,
+    }));
+    const usage = {
+      ...(tokens === false ? {} : { inputTokens: 3, outputTokens: 5, totalTokens: 8 }),
+      ...(cost === false ? {} : { providerCost: measured.providerCost }),
+    };
+    await expect(adapter.createExecutorJudgeInvocationPort(executor, identity).invoke(request()))
+      .resolves.toEqual({
+        invocationStatus: 'completed', output: 'judge output',
+        ...(tokens === false && cost === false ? {} : { usage }),
+      });
+  });
+
+  it('retains an explicitly reported zero rather than treating it as missing', async () => {
+    const executor = vi.fn<ExecutorFn>().mockResolvedValue(result({
+      inputTokens: 0, outputTokens: 0, costUSD: 0,
+      tokenUsageReportedByExecutor: true, costReportedByExecutor: true,
+    }));
+    await expect(adapter.createExecutorJudgeInvocationPort(executor, identity).invoke(request()))
+      .resolves.toMatchObject({ usage: {
+        inputTokens: 0, outputTokens: 0, totalTokens: 0,
+        providerCost: { amount: 0, currency: 'USD', reportedByProvider: true },
+      } });
+  });
+
+  it.each([
+    { aborted: false, throws: false }, { aborted: false, throws: true },
+    { aborted: true, throws: false }, { aborted: true, throws: true },
+  ])('redacts failure details and preserves cancellation: aborted=$aborted, throws=$throws', async ({ aborted, throws }) => {
+    const controller = new AbortController();
+    const executor = vi.fn<ExecutorFn>().mockImplementation(async () => {
+      if (aborted) controller.abort('private cancellation reason');
+      if (throws) throw new Error('private provider error');
+      return result({ ok: false, output: null, error: 'private provider error' });
+    });
+    await expect(adapter.createExecutorJudgeInvocationPort(executor, identity).invoke(request(controller.signal)))
+      .resolves.toEqual({
+        invocationStatus: 'failed',
+        reasonCode: aborted ? 'provider-invocation-cancelled' : 'provider-invocation-failed',
+        ...(throws ? {} : { usage: measured }),
+      });
+    expect(executor).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves completed-response cancellation races to the calling Runtime policy', async () => {
+    const controller = new AbortController();
+    const executor = vi.fn<ExecutorFn>().mockImplementation(async () => {
+      controller.abort();
+      return result();
+    });
+    await expect(adapter.createExecutorJudgeInvocationPort(executor, identity).invoke(request(controller.signal)))
+      .resolves.toEqual({ invocationStatus: 'completed', output: 'judge output', usage: measured });
+  });
+});
+
+function context(executorId: string): Parameters<OmkLlmJudgeInvocationResolver>[0] {
+  // Host wiring consumes qualification only; Core binding validation has its own matrix.
+  return { binding: { qualification: {
+    executorId, model: 'judge-model', deploymentRevision: 'deployment-a',
+  } } } as Parameters<OmkLlmJudgeInvocationResolver>[0];
+}
+
+describe('host judge invocation wiring', () => {
+  it('lets Node select the executor and fingerprint while sharing the invocation port', async () => {
+    const stop = new Error('composition captured');
+    const compose = vi.spyOn(registered, 'createRegisteredEvaluationComposition').mockImplementation(() => { throw stop; });
+    const executor = vi.fn<ExecutorFn>().mockResolvedValue(result());
+    const create = vi.spyOn(executors, 'createExecutor').mockReturnValue(executor);
+    const fingerprint = vi.spyOn(fingerprints, 'resolveExecutorRuntimeFingerprint').mockReturnValue(runtime('codex'));
+    const shared = vi.spyOn(adapter, 'createExecutorJudgeInvocationPort');
+    const environment = {};
+    await expect(createNodeProductionComposition({
+      // Intercept the assembly seam before preparation or filesystem side effects.
+      compiled: { runtimeBinding: { bindings: [] } } as unknown as CliEvaluationCompileResult,
+      projectRoot: tmpdir(), outputDirectory: join(tmpdir(), 'unused-reports'),
+      resourceLeaseRoot: join(tmpdir(), 'unused-leases'),
+      capabilities: {
+        environment, classifiedEnvironment: {},
+        async resolveExecutable() { throw new Error('unused target executor'); },
+        requiredCredential() { throw new Error('unused credential'); },
+      },
+    })).rejects.toBe(stop);
+    const resolve = compose.mock.calls[0]![0].resolveJudgeInvocation!;
+    const binding = await resolve(context('codex'));
+    expect(create).toHaveBeenCalledWith('codex');
+    expect(fingerprint).toHaveBeenCalledWith('codex', 'judge-model', { env: environment }, executor);
+    expect(shared).toHaveBeenCalledWith(executor, binding.port.identity);
+    expect(binding.port).toBe(shared.mock.results[0]!.value);
+    expect(binding.preflightDeclarations).toEqual(expect.arrayContaining([
+      expect.objectContaining({ reasonCode: 'provider-validates-credential' }),
+    ]));
+    await binding.port.invoke(request());
+    expect(executor).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets DSH inherit the host executor and identity without entering Node composition', async () => {
+    const stop = new Error('application captured');
+    const createApplication = vi.spyOn(application, 'createHostedEvaluationApplication').mockImplementation(() => { throw stop; });
+    const executor = Object.assign(vi.fn<ExecutorFn>().mockResolvedValue(result()), {
+      runtimeFingerprint: vi.fn(() => runtime('dsh-host')),
+    });
+    const create = vi.spyOn(dshExecutor, 'createDshHostExecutor').mockReturnValue(executor);
+    const shared = vi.spyOn(adapter, 'createExecutorJudgeInvocationPort');
+    const nodeExecutor = vi.spyOn(executors, 'createExecutor');
+    const host = {} as dshExecutor.DshHostContextLike;
+    const parentAgent = { options: { model: 'judge-model' } } as dshExecutor.DshAgentLike;
+    await expect(runDshCoreEvaluation({
+      host, parentAgent, signal: new AbortController().signal, projectRoot: tmpdir(),
+      config: { samples: 'samples.json', variants: [
+        { name: 'control', role: 'control', artifact: 'baseline' },
+        { name: 'treatment', role: 'treatment', artifact: 'fixture-skill' },
+      ] },
+    })).rejects.toBe(stop);
+    const resolve = createApplication.mock.calls[0]![0].resolveJudgeInvocation!;
+    const binding = await resolve(context('dsh-host'));
+    expect(create).toHaveBeenCalledWith(host, { parentAgent });
+    expect(executor.runtimeFingerprint).toHaveBeenCalledWith('judge-model');
+    expect(shared).toHaveBeenCalledWith(executor, binding.port.identity);
+    expect(binding.port).toBe(shared.mock.results[0]!.value);
+    expect(binding.preflightDeclarations).toEqual(expect.arrayContaining([
+      expect.objectContaining({ reasonCode: 'host-session-owns-credential' }),
+    ]));
+    await binding.port.invoke(request());
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(nodeExecutor).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 用户影响

落实 #767 的 B4：Node 与 DSH 共用 Workflow 宿主适配层的评委 invocation port，不再分别维护成功、失败、取消及用量转换。Node 仍负责执行器获取与环境指纹，DSH 仍继承当前宿主执行器与身份；两端保留各自预检声明。

## 迁移与测量可比性

无需迁移。保持原有请求字节、effort、AbortSignal、失败脱敏和单次调用语义；不增加重试、不改变调用方 Runtime 的取消策略。未报告的 token／cost 保持缺失，已报告的零值仍为真实零值。身份派生、评分、prompt、Schema identity 与持久化契约不变。

## 交付证据

转换矩阵集中到唯一适配器，两端各自验证产品接线；既有 Node 与 DSH 产品测试继续通过。56 项定向验证通过；完整 `yarn ci` 通过，334 个测试文件、3612 个测试通过。

源码净减少 46 行，新增 216 行集中契约与接线测试，总计净增加 170 行。不以总行数缩减替代行为边界保障。

自主 CR：No findings。已检查完整 diff、两端身份与执行器来源、共享 port 的实际接线、取消竞态、缺失与零值用量、失败信息脱敏及隔离边界。没有新增公开入口或打包契约变化，不重复 clean-room。

关联 #767，前置 #771 已合并。本 PR 仅完成 B4，B3 与其它待办继续保留。