### PR TITLE
refactor(eval-workflows): 由工作流独占产品进度投影

### DIFF
--- a/src/eval-workflows/hosts/composition/runtime.ts
+++ b/src/eval-workflows/hosts/composition/runtime.ts
@@ -1,5 +1,5 @@
 import { prepareRuntimeSeries, type EvaluationRuntimeProvider } from '../../../eval-runtime/provider.js';
-import { createEvaluationExecution } from '../../../eval-runtime/execution.js';
+import { createEvaluationExecution, type EvaluationExecutionOptions } from '../../../eval-runtime/execution.js';
 import {
   EvaluationDefinitionSchema,
   IdentifierSchema,
@@ -83,12 +83,6 @@ import {
   type OmkEvaluationPreflightOptions,
   type OmkEvaluationPreflightResult,
 } from './preflight.js';
-import {
-  attachOmkEvaluationProgressProjection,
-  captureOmkEvaluationProgressProjection,
-  type CapturedOmkEvaluationProgressProjection,
-  type OmkEvaluationProgressSink,
-} from '../../projections/runtime-progress.js';
 
 export interface OmkCachePortBinding<Port> {
   readonly sourceLocator: string;
@@ -136,19 +130,11 @@ export interface CreateOmkEvaluationRuntimeInput {
   readonly resources: OmkEvaluationRuntimeResourceOptions;
 }
 
-export interface OmkEvaluationRunOptions {
-  readonly runId: string;
-  readonly signal?: AbortSignal;
-  readonly eventBufferCapacity?: number;
-  readonly progressSink?: OmkEvaluationProgressSink;
-  readonly progressBufferCapacity?: number;
-}
-
 export interface OmkPreparedEvaluation {
   readonly plan: SealedRunPlan;
   /** Host-only physical readiness evidence; it does not enter or modify the Core Plan. */
   readonly preflight: OmkEvaluationPreflightResult;
-  start(options: Readonly<OmkEvaluationRunOptions>): Promise<EvaluationRun>;
+  start(options: Readonly<EvaluationExecutionOptions>): Promise<EvaluationRun>;
 }
 
 export interface OmkEvaluationRuntime {
@@ -949,24 +935,18 @@ export async function createOmkEvaluationRuntime(
       return Object.freeze({
         plan: prepared.plan,
         preflight,
-        async start(options: Readonly<OmkEvaluationRunOptions>): Promise<EvaluationRun> {
+        async start(options: Readonly<EvaluationExecutionOptions>): Promise<EvaluationRun> {
           if (record(options) === undefined) fail({
             code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
             message: 'Evaluation run options 不合法。',
           });
-          let capturedOptions: OmkEvaluationRunOptions;
+          let capturedOptions: EvaluationExecutionOptions;
           try {
             capturedOptions = Object.freeze({
               runId: options.runId,
               ...(options.signal === undefined ? {} : { signal: options.signal }),
               ...(options.eventBufferCapacity === undefined ? {} : {
                 eventBufferCapacity: options.eventBufferCapacity,
-              }),
-              ...(options.progressSink === undefined ? {} : {
-                progressSink: options.progressSink,
-              }),
-              ...(options.progressBufferCapacity === undefined ? {} : {
-                progressBufferCapacity: options.progressBufferCapacity,
               }),
             });
           } catch {
@@ -979,8 +959,6 @@ export async function createOmkEvaluationRuntime(
             runId,
             signal,
             eventBufferCapacity,
-            progressSink,
-            progressBufferCapacity,
           } = capturedOptions;
           if (!IdentifierSchema.safeParse(runId).success) fail({
             code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
@@ -1002,35 +980,11 @@ export async function createOmkEvaluationRuntime(
             fieldPath: 'signal',
             message: 'signal 不符合 AbortSignal contract。',
           });
-          let progressProjection: CapturedOmkEvaluationProgressProjection | undefined;
-          if (progressSink !== undefined) {
-            try {
-              progressProjection = captureOmkEvaluationProgressProjection(
-                progressSink,
-                progressBufferCapacity === undefined ? {} : {
-                  progressBufferCapacity,
-                },
-              );
-            } catch {
-              fail({
-                code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
-                fieldPath: 'progressSink',
-                message: 'Evaluation progress sink 或 buffer capacity 不合法。',
-              });
-            }
-          } else if (progressBufferCapacity !== undefined) fail({
-            code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
-            fieldPath: 'progressBufferCapacity',
-            message: '未提供 progress sink 时不能配置 progress buffer。',
-          });
-          const run = await prepared.start({
+          return prepared.start({
             runId,
             ...(signal === undefined ? {} : { signal }),
             ...(eventBufferCapacity === undefined ? {} : { eventBufferCapacity }),
           });
-          return progressProjection === undefined
-            ? run
-            : attachOmkEvaluationProgressProjection(run, progressProjection, eventBufferCapacity);
         },
       });
     },

--- a/test/eval-workflows/hosts/composition/assembly.test.ts
+++ b/test/eval-workflows/hosts/composition/assembly.test.ts
@@ -38,6 +38,7 @@ import {
 } from '../../../../src/eval-workflows/hosts/composition/builtins.js';
 import {
   createOmkEvaluationRuntime,
+  createOmkEvaluationSchemaValidators,
   type OmkEvaluationRuntimeSupportPorts,
 } from '../../../../src/eval-workflows/hosts/composition/runtime.js';
 import {
@@ -2025,13 +2026,6 @@ describe('OMK Evaluation Runtime composition root', () => {
       code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
       fieldPath: 'eventBufferCapacity',
     });
-    await expect(prepared.start({
-      runId: 'invalid-progress-options',
-      progressBufferCapacity: 1,
-    })).rejects.toMatchObject({
-      code: 'OMK_EVALUATION_RUNTIME_INPUT_INVALID',
-      fieldPath: 'progressBufferCapacity',
-    });
     expect(acquireCalls).toBe(0);
   });
 
@@ -2073,7 +2067,7 @@ describe('OMK Evaluation Runtime composition root', () => {
     expect(disposed.sort()).toEqual(['parallel-a', 'parallel-b']);
   });
 
-  it('isolates cancellation, events, progress and teardown across concurrent runs', async () => {
+  it('isolates cancellation, events and teardown across concurrent runs', async () => {
     const compiled = compositionInput({
       executionTimeout: false,
       evaluationTimeout: false,
@@ -2084,8 +2078,6 @@ describe('OMK Evaluation Runtime composition root', () => {
     const lifecycle: string[] = [];
     const disposed: string[] = [];
     const controller = new AbortController();
-    const progress = { isolatedA: [] as string[], isolatedB: [] as string[] };
-    const closed = { isolatedA: false, isolatedB: false };
     const runtime = await createOmkEvaluationRuntime({
       compiled,
       factories: runnableFactoriesFor(compiled, lifecycle, executeGate),
@@ -2106,17 +2098,9 @@ describe('OMK Evaluation Runtime composition root', () => {
     const first = await prepared.start({
       runId: 'isolated-a',
       signal: controller.signal,
-      progressSink: {
-        render(update) { progress.isolatedA.push(update.runId); },
-        close() { closed.isolatedA = true; },
-      },
     });
     const second = await prepared.start({
       runId: 'isolated-b',
-      progressSink: {
-        render(update) { progress.isolatedB.push(update.runId); },
-        close() { closed.isolatedB = true; },
-      },
     });
     const firstEvents: Array<{ runId: string; eventKind: string }> = [];
     const secondEvents: Array<{ runId: string; eventKind: string }> = [];
@@ -2137,7 +2121,6 @@ describe('OMK Evaluation Runtime composition root', () => {
     releaseExecution?.();
     const [firstResult, secondResult] = await Promise.all([first.result, second.result]);
     await Promise.all([firstDrain, secondDrain]);
-    await expect.poll(() => closed.isolatedA && closed.isolatedB).toBe(true);
 
     expect(firstResult.status).toBe('cancelled');
     expect(secondResult.status).toBe('completed');
@@ -2155,10 +2138,6 @@ describe('OMK Evaluation Runtime composition root', () => {
     expect(secondEvents).toContainEqual(expect.objectContaining({
       eventKind: 'evaluation.run.completed',
     }));
-    expect(progress.isolatedA.length).toBeGreaterThan(0);
-    expect(progress.isolatedB.length).toBeGreaterThan(0);
-    expect(progress.isolatedA.every((runId) => runId === 'isolated-a')).toBe(true);
-    expect(progress.isolatedB.every((runId) => runId === 'isolated-b')).toBe(true);
     for (const runId of ['isolated-a', 'isolated-b']) {
       for (const runtimeKind of ['executor', 'evaluator']) {
         expect(lifecycle.filter((entry) => (
@@ -2343,7 +2322,7 @@ describe('OMK Evaluation Runtime composition root', () => {
     expect(writerCalls).toBe(0);
   });
 
-  it('keeps a never-settling progress renderer outside Core result and lease cleanup', async () => {
+  it('lets Workflow keep a never-settling progress renderer outside Core result and lease cleanup', async () => {
     const compiled = compositionInput();
     let disposeCalls = 0;
     let renderCalls = 0;
@@ -2363,29 +2342,41 @@ describe('OMK Evaluation Runtime composition root', () => {
         },
       },
     });
-    const run = await (await runtime.prepare()).start({
-      runId: 'detached-progress',
-      progressBufferCapacity: 1,
-      progressSink: {
-        render() {
-          renderCalls += 1;
-          return new Promise<void>(() => {});
+    const root = await mkdtemp(join(tmpdir(), 'omk-workflow-progress-'));
+    try {
+      const prepared = bindProductionPreparedEvaluation({
+        prepared: await runtime.prepare(),
+        artifactStore: createNodeCoreRunArtifactStore(root),
+        schemaValidators: createOmkEvaluationSchemaValidators(compositionSupport().schemaValidators),
+      });
+      const run = await prepared.execute({
+        createdAt: '2026-09-01T00:00:00.000Z',
+        runId: 'detached-progress',
+        progressBufferCapacity: 1,
+        progressSink: {
+          render() {
+            renderCalls += 1;
+            return new Promise<void>(() => {});
+          },
         },
-      },
-    });
-    const observedEvents: string[] = [];
-    const drainEvents = (async () => {
-      for await (const candidate of run.events) observedEvents.push(candidate.eventKind);
-    })();
+      });
+      const observedEvents: string[] = [];
+      const drainEvents = (async () => {
+        for await (const candidate of run.events) observedEvents.push(candidate.eventKind);
+      })();
 
-    await expect(run.result).resolves.toHaveProperty('status');
-    await drainEvents;
-    expect(renderCalls).toBe(1);
-    expect(observedEvents).toContain('execution.run.started');
-    expect(observedEvents.some((eventKind) => (
-      eventKind.startsWith('execution.run.') && eventKind !== 'execution.run.started'
-    ))).toBe(true);
-    expect(disposeCalls).toBe(1);
+      await expect(run.result).resolves.toHaveProperty('status');
+      await drainEvents;
+      await run.persistence;
+      expect(renderCalls).toBe(1);
+      expect(observedEvents).toContain('execution.run.started');
+      expect(observedEvents.some((eventKind) => (
+        eventKind.startsWith('execution.run.') && eventKind !== 'execution.run.started'
+      ))).toBe(true);
+      expect(disposeCalls).toBe(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it('reports lease disposal failure without retrying destructive cleanup', async () => {

--- a/test/eval-workflows/orchestration/workflow.test.ts
+++ b/test/eval-workflows/orchestration/workflow.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { Sha256Digest } from '../../../src/eval-core/contracts/index.js';
+import { EVALUATION_EVENT_SCHEMA_VERSION, EvaluationEventSchema, type Sha256Digest } from '../../../src/eval-core/contracts/index.js';
 import type { EvaluationRunResult } from '../../../src/eval-core/engine/index.js';
 import {
   createNodeCoreRunArtifactStore,
@@ -104,6 +104,75 @@ function recordingStore(input: {
 }
 
 describe('production evaluation host workflow', () => {
+  it.each([
+    { name: 'buffer without sink', progressBufferCapacity: 1 },
+    { name: 'zero buffer', progressSink: { render() {} }, progressBufferCapacity: 0 },
+    { name: 'fractional buffer', progressSink: { render() {} }, progressBufferCapacity: 1.5 },
+    { name: 'invalid renderer', progressSink: { render: undefined } },
+    { name: 'invalid close', progressSink: { render() {}, close: 1 } },
+  ])('rejects invalid progress options before starting Runtime: $name', async ({ name: _name, ...options }) => {
+    const fixture = await runConformanceScenario('function', { runId: 'progress-options-fixture' });
+    const onStart = vi.fn();
+    const prepared = await createProductionEvaluationWorkflow(hostInput({
+      fixture, result: Promise.resolve(completedResult(fixture)), store: recordingStore(), onStart,
+    })).prepare();
+    await expect(prepared.execute({
+      runId: 'invalid-progress', createdAt: '2026-09-01T00:00:00.000Z', ...options,
+    } as Parameters<typeof prepared.execute>[0])).rejects.toBeInstanceOf(TypeError);
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('owns concurrent progress projections and forwards only neutral Runtime options', async () => {
+    const fixture = await runConformanceScenario('function', { runId: 'workflow-progress-fixture' });
+    const result = Promise.resolve(completedResult(fixture));
+    const store = await temporaryStore();
+    const input = hostInput({ fixture, result, store });
+    const subscriptions = new Map<string, number>();
+    const start = vi.fn<NonNullable<Awaited<ReturnType<typeof input.runtime.prepare>>>['start']>(async ({ runId }) => ({
+      result,
+      events: (async function* () {
+        subscriptions.set(runId, (subscriptions.get(runId) ?? 0) + 1);
+        for (const [sequence, eventKind] of ['execution.run.started', 'execution.run.completed'].entries()) {
+          yield EvaluationEventSchema.parse({
+            schemaVersion: EVALUATION_EVENT_SCHEMA_VERSION,
+            eventId: `${runId}-${sequence}`, sequence, runId, eventKind,
+            time: '2026-09-01T00:00:00.000Z', subject: { subjectKind: 'run', subjectId: runId },
+            data: { secret: 'not a progress channel' },
+          });
+        }
+      })(),
+    }));
+    input.runtime.prepare = async () => ({ plan: fixture.plan, preflight: { records: [] }, start });
+    const prepared = await createProductionEvaluationWorkflow(input).prepare();
+    const tracked = ['progress-a', 'progress-b'].map((runId) => ({
+      runId, signal: new AbortController().signal,
+      render: vi.fn(), close: vi.fn(), captures: 0,
+    }));
+    const runs = await Promise.all(tracked.map((tracker) => prepared.execute({
+      runId: tracker.runId, signal: tracker.signal, eventBufferCapacity: 4,
+      createdAt: '2026-09-01T00:00:00.000Z', progressBufferCapacity: 2,
+      progressSink: {
+        get render() { tracker.captures += 1; return tracker.render; },
+        close: tracker.close,
+      },
+    })));
+    expect(start.mock.calls).toEqual(tracked.map(({ runId, signal }) => [{ runId, signal, eventBufferCapacity: 4 }]));
+    for (const [index, run] of runs.entries()) {
+      const tracker = tracked[index]!;
+      expect(run.result).toBe(result);
+      const events = [];
+      for await (const event of run.events) events.push(event);
+      expect(events.map((event) => event.runId)).toEqual([tracker.runId, tracker.runId]);
+      expect(subscriptions.get(tracker.runId)).toBe(1);
+      await expect.poll(() => tracker.close.mock.calls.length).toBe(1);
+      expect(tracker.captures).toBe(1);
+      expect(tracker.render.mock.calls.map(([update]) => update.runId)).toEqual([tracker.runId, tracker.runId]);
+      expect(tracker.render.mock.calls.every(([update]) => !('data' in update))).toBe(true);
+      expect((await run.persistence).persistenceStatus).toBe('stored');
+      expect((await store.get(tracker.runId))!.report.reportDigest).toBe(fixture.report.reportDigest);
+    }
+  });
+
   it('requires an injected Runtime and passes only neutral measurement input to preparation', async () => {
     const fixture = await runConformanceScenario('function', { runId: 'injected-runtime-fixture' });
     const input = hostInput({ fixture, result: Promise.resolve(completedResult(fixture)), store: recordingStore() });


### PR DESCRIPTION
## 用户影响

落实 #767 的 B3：产品 Workflow 独占进度参数校验、sink 捕获和事件投影，宿主 runtime 不再维护第二套 progress 装配。Runtime 继续负责中立执行选项、事件缓冲、取消和资源生命周期，直接复用 `EvaluationExecutionOptions`。

## 迁移与测量可比性

CLI 和产品入口无需迁移，进度呈现行为保持不变。删除的是没有产品消费的下层进度分支及其私有选项类型；不改 Runtime 的 event buffer 校验、执行器取消或清理语义。原始事件、Core 结果 promise、报告摘要、评分、prompt、Schema identity 与落盘契约不变。

## 交付证据

进度校验和并发投影验证归到 Workflow；底层并发取消与资源测试保留，悬挂 renderer 的清理验证通过 Workflow 实际接入。101 项定向验证通过；完整 `yarn ci` 通过，334 个测试文件、3618 个测试通过。

源码净减少 46 行，测试净增加 60 行，总计净增加 14 行。

自主 CR：No findings。已检查完整 diff、唯一产品调用链、参数不下传、单次事件消费与 sink 捕获、原始事件镜像、结果和落盘不变，以及失败／取消／清理边界。没有新增公开入口或安装契约变化，不重复 clean-room。

关联 #767，B4 已由 #772 完成并合并。本 PR 完成 B3，不关闭总 issue。