### PR TITLE
refactor(cli): 删除旧评测进度协议及独占文案

### DIFF
--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -1,17 +1,6 @@
 import type { CliMessage } from './types.js';
 
 export type RunMessageKey =
-  | 'cli.progress.preflight_starting'
-  | 'cli.progress.sample_retry'
-  | 'cli.progress.sample_error'
-  | 'cli.progress.sample_executing'
-  | 'cli.progress.sample_exec_done'
-  | 'cli.progress.output_preview'
-  | 'cli.progress.judging'
-  | 'cli.progress.judged'
-  | 'cli.progress.skipped'
-  | 'cli.progress.sample_done'
-  | 'cli.progress.sample_failed_done'
   | 'cli.run.batch_verdict_header'
   | 'cli.run.codex_fallback_hint'
   | 'cli.run.codex_auth_hint'
@@ -22,50 +11,6 @@ export type RunMessageKey =
   | 'cli.run.anthropic_api_model_hint';
 
 export const runDict: Record<RunMessageKey, CliMessage> = {
-  'cli.progress.preflight_starting': {
-    zh: '⏳ 正在预检模型连通性...\n',
-    en: '⏳ Preflight: checking model connectivity...\n',
-  },
-  'cli.progress.sample_retry': {
-    zh: '[{i}/{n}] {sample}/{variant} 🔄 重试 {attempt}/{max}...\n',
-    en: '[{i}/{n}] {sample}/{variant} 🔄 retry {attempt}/{max}...\n',
-  },
-  'cli.progress.sample_error': {
-    zh: '[{i}/{n}] {sample}/{variant} ⚠️ {error}\n',
-    en: '[{i}/{n}] {sample}/{variant} ⚠️ {error}\n',
-  },
-  'cli.progress.sample_executing': {
-    zh: '[{i}/{n}] {sample}/{variant} ⏳ 执行中...\n',
-    en: '[{i}/{n}] {sample}/{variant} ⏳ running...\n',
-  },
-  'cli.progress.sample_exec_done': {
-    zh: '[{i}/{n}] {sample}/{variant} 执行完成 {ms}ms {input}+{output} tokens{cost}\n',
-    en: '[{i}/{n}] {sample}/{variant} done {ms}ms {input}+{output} tokens{cost}\n',
-  },
-  'cli.progress.output_preview': {
-    zh: '  输出预览: {preview}\n',
-    en: '  output preview: {preview}\n',
-  },
-  'cli.progress.judging': {
-    zh: '[{i}/{n}] {sample}/{variant} 评委评审中{dim}...\n',
-    en: '[{i}/{n}] {sample}/{variant} judging{dim}...\n',
-  },
-  'cli.progress.judged': {
-    zh: '[{i}/{n}] {sample}/{variant} 评委评审完成{dim} score={score}\n',
-    en: '[{i}/{n}] {sample}/{variant} judged{dim} score={score}\n',
-  },
-  'cli.progress.skipped': {
-    zh: '[{i}/{n}] {sample}/{variant} ⏭ 已跳过 (已有结果)\n',
-    en: '[{i}/{n}] {sample}/{variant} ⏭ skipped (cached)\n',
-  },
-  'cli.progress.sample_done': {
-    zh: '[{i}/{n}] {sample}/{variant} ✓ {ms}ms {input}+{output} tokens{cost}{score}\n',
-    en: '[{i}/{n}] {sample}/{variant} ✓ {ms}ms {input}+{output} tokens{cost}{score}\n',
-  },
-  'cli.progress.sample_failed_done': {
-    zh: '[{i}/{n}] {sample}/{variant} ⚠️ {ms}ms {input}+{output} tokens{cost} error={error}\n',
-    en: '[{i}/{n}] {sample}/{variant} ⚠️ {ms}ms {input}+{output} tokens{cost} error={error}\n',
-  },
   'cli.run.batch_verdict_header': {
     zh: '批量评测结论：{status}（{passed}/{total} 通过）',
     en: 'Batch verdict: {status} ({passed}/{total} passed)',

--- a/src/cli/lib/progress.ts
+++ b/src/cli/lib/progress.ts
@@ -1,103 +1,6 @@
 import { tCli, type CliLang } from './i18n.js';
 import type { DoctorProgressInfo } from '../../knowledge-artifacts/doctor/contracts.js';
 
-// CLI 展示层的进度事件投影。
-export interface ProgressInfo {
-  phase: string;
-  completed?: number;
-  total?: number;
-  sample_id?: string;
-  variant?: string;
-  strategy?: string;
-  durationMs?: number;
-  inputTokens?: number;
-  outputTokens?: number;
-  costUSD?: number;
-  score?: number;
-  outputPreview?: string | null;
-  jobId?: string;
-  judgePhase?: string;
-  judgeDim?: string;
-  skipped?: boolean;
-  ok?: boolean;
-  attempt?: number;
-  maxAttempts?: number;
-  error?: string;
-}
-
-export function makeOnProgress(lang: CliLang): (info: ProgressInfo) => void {
-  return ({
-    phase,
-    completed,
-    total,
-    sample_id,
-    variant,
-    durationMs,
-    inputTokens,
-    outputTokens,
-    costUSD,
-    score,
-    outputPreview,
-    judgePhase: _judgePhase,
-    judgeDim,
-    skipped,
-    ok,
-    attempt,
-    maxAttempts,
-    error,
-  }: ProgressInfo): void => {
-    const ctx = { i: completed ?? '', n: total ?? '', sample: sample_id ?? '', variant: variant ?? '' };
-    if (phase === 'preflight') {
-      process.stderr.write(tCli('cli.progress.preflight_starting', lang));
-      return;
-    }
-    if (phase === 'retry') {
-      process.stderr.write(tCli('cli.progress.sample_retry', lang, {
-        ...ctx, attempt: attempt ?? '', max: maxAttempts ?? '',
-      }));
-      return;
-    }
-    if (phase === 'error') {
-      process.stderr.write(tCli('cli.progress.sample_error', lang, { ...ctx, error: error ?? '' }));
-      return;
-    }
-    if (phase === 'start') {
-      process.stderr.write(tCli('cli.progress.sample_executing', lang, ctx));
-    } else if (phase === 'exec_done') {
-      const cost: string = costUSD != null && costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
-      process.stderr.write(tCli('cli.progress.sample_exec_done', lang, {
-        ...ctx, ms: durationMs ?? '', input: inputTokens ?? '', output: outputTokens ?? '', cost,
-      }));
-      if (outputPreview) {
-        process.stderr.write(tCli('cli.progress.output_preview', lang, {
-          preview: outputPreview.slice(0, 150).replace(/\n/g, ' '),
-        }));
-      }
-    } else if (phase === 'grading') {
-      const dim: string = judgeDim ? ` [${judgeDim}]` : '';
-      process.stderr.write(tCli('cli.progress.judging', lang, { ...ctx, dim }));
-    } else if (phase === 'judge_done') {
-      const dim: string = judgeDim ? ` [${judgeDim}]` : '';
-      process.stderr.write(tCli('cli.progress.judged', lang, { ...ctx, dim, score: score ?? '' }));
-    } else if (phase === 'done' && skipped) {
-      if (sample_id) process.stderr.write(tCli('cli.progress.skipped', lang, ctx));
-    } else if (ok === false) {
-      const cost: string = costUSD != null && costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
-      process.stderr.write(tCli('cli.progress.sample_failed_done', lang, {
-        ...ctx, ms: durationMs ?? '', input: inputTokens ?? '', output: outputTokens ?? '',
-        cost, error: error ?? '',
-      }));
-    } else {
-      const cost: string = costUSD != null && costUSD > 0 ? ` $${costUSD.toFixed(4)}` : '';
-      const scoreInfo: string = typeof score === 'number' ? ` score=${score}` : '';
-      process.stderr.write(tCli('cli.progress.sample_done', lang, {
-        ...ctx, ms: durationMs ?? '', input: inputTokens ?? '', output: outputTokens ?? '',
-        cost, score: scoreInfo,
-      }));
-    }
-  };
-}
-
 // 图标 + 状态枚举(pass/warn/fail 是技术枚举,与图标一样语言无关,不进 i18n 模板)。
 const DOCTOR_STATUS_LABEL: Record<string, string> = {
   pass: '✓ pass',
@@ -105,7 +8,7 @@ const DOCTOR_STATUS_LABEL: Record<string, string> = {
   fail: '✗ fail',
 };
 
-/** doctor 批量体检进度打印(per-skill,写 stderr),对齐 eval 的 makeOnProgress。 */
+/** doctor 批量体检进度打印（逐 skill，写入 stderr）。 */
 export function makeDoctorProgress(lang: CliLang): (info: DoctorProgressInfo) => void {
   return (info: DoctorProgressInfo): void => {
     // 单 skill 时省略 [i/n] 前缀(冗余);批量才显示计数。

--- a/test/cli-progress.test.ts
+++ b/test/cli-progress.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { makeOnProgress, makeDoctorProgress } from '../src/cli/lib/progress.js';
+import { makeDoctorProgress } from '../src/cli/lib/progress.js';
 
 function captureStderr(fn: () => void): string {
   const original = process.stderr.write;
@@ -16,30 +16,6 @@ function captureStderr(fn: () => void): string {
   }
   return output;
 }
-
-describe('CLI progress', () => {
-  it('marks failed completed tasks with a failure icon and error', () => {
-    const output = captureStderr(() => {
-      makeOnProgress('zh')({
-        phase: 'done',
-        completed: 1,
-        total: 1,
-        sample_id: 's1',
-        variant: 'v1',
-        durationMs: 240000,
-        inputTokens: 0,
-        outputTokens: 0,
-        costUSD: 0,
-        ok: false,
-        error: 'execution timed out after 240s',
-      });
-    });
-
-    assert.match(output, /⚠️/);
-    assert.doesNotMatch(output, /✓/);
-    assert.match(output, /execution timed out after 240s/);
-  });
-});
 
 describe('doctor progress', () => {
   it('batch (total>1) 显示 [i/n] 前缀 + 体检中 / ✓ pass + 耗时', () => {


### PR DESCRIPTION
## 用户影响

落实 #767 的 A2：删除没有生产调用的 `makeOnProgress`、整份旧 `ProgressInfo` 和 11 个独占双语文案键，移除只验证旧回调的测试。保留生产 `makeDoctorProgress` 及全部 doctor 进度验证；当前 Workflow／Core 进度链不变。

## 迁移与测量可比性

无需迁移。公开 CLI、doctor 输出、评分、统计、prompt、Schema identity 和落盘契约不变。没有删除或替换实际产品进度语义，也不为旧测试保留备用协议。

## 交付证据

定向验证与完整 `yarn ci` 通过，334 个测试文件、3617 个测试通过。源码净减少 152 行，测试净减少 24 行，总计净减少 176 行。

自主 CR：No findings。已检查完整 diff、符号和文案消费者、doctor 接线及当前 Core 进度边界。仅移除无消费者内部能力，不触发额外 clean-room。

关联 #767，前置 #773 已合并。本 PR 完成 A2，不关闭总 issue。