### PR TITLE
refactor(eval-workflows): 移除旧一致性统计聚合包装

### DIFF
--- a/src/eval-workflows/gold/human.ts
+++ b/src/eval-workflows/gold/human.ts
@@ -31,10 +31,8 @@
  */
 
 import {
-  bootstrapWithMetric,
   drawBootstrapMetric,
   summarizeBootstrapMetric,
-  type BootstrapCI,
 } from '../analysis/bootstrap.js';
 
 export interface RatingPair {
@@ -46,18 +44,6 @@ export interface RatingPair {
   coderB: number;
 }
 
-export interface AgreementResult {
-  /** Krippendorff α (interval weights). 1 = perfect, 0 = chance, < 0 = worse than chance. */
-  alpha: number;
-  /** 95% bootstrap CI on α — width signals uncertainty due to sample size. */
-  alphaCI: BootstrapCI;
-  /** Quadratic-weighted κ. */
-  weightedKappa: number;
-  /** Pearson product-moment correlation. NaN if either coder has zero variance. */
-  pearson: number;
-  /** How many rating pairs went into the calculation. */
-  sampleCount: number;
-}
 
 export type AgreementStatisticEvidence =
   | Readonly<{ statisticStatus: 'observed'; value: number }>
@@ -373,47 +359,6 @@ export function computeAgreementEvidence(
     },
     weightedKappa,
     pearson,
-    sampleCount: pairs.length,
-  };
-}
-
-/**
- * Compute α + κ + Pearson, with bootstrap CI on α.
- *
- * Bootstrap resamples pairs (units), not individual ratings — pairs are the
- * unit of replication; resampling individual ratings would break the (a,b) tie.
- */
-export function computeAgreementWithCI(
-  pairs: RatingPair[],
-  options: { samples?: number; seed?: number; alpha?: number; scale?: { min: number; max: number } } = {},
-): AgreementResult {
-  const { samples = 1000, seed, alpha = 0.05, scale } = options;
-
-  if (pairs.length === 0) {
-    return {
-      alpha: NaN,
-      alphaCI: { low: NaN, high: NaN, estimate: NaN, samples: 0 },
-      weightedKappa: NaN,
-      pearson: NaN,
-      sampleCount: 0,
-    };
-  }
-
-  // Encode pairs as indices so bootstrapWithMetric can resample them.
-  const indices = pairs.map((_, i) => i);
-  const alphaCI = bootstrapWithMetric(
-    indices,
-    (resampledIdx) => computeKrippendorffAlpha(resampledIdx.map((i) => pairs[i])),
-    alpha,
-    samples,
-    seed,
-  );
-
-  return {
-    alpha: roundOrNaN(computeKrippendorffAlpha(pairs)),
-    alphaCI,
-    weightedKappa: roundOrNaN(computeWeightedKappa(pairs, scale)),
-    pearson: roundOrNaN(computePearson(pairs)),
     sampleCount: pairs.length,
   };
 }

--- a/test/eval-workflows/gold/human.test.ts
+++ b/test/eval-workflows/gold/human.test.ts
@@ -5,7 +5,6 @@ import {
   computeWeightedKappa,
   computePearson,
   computeAgreementEvidence,
-  computeAgreementWithCI,
   type RatingPair,
 } from '../../../src/eval-workflows/gold/human.js';
 
@@ -80,36 +79,6 @@ describe('computePearson', () => {
   it('NaN when one coder has zero variance', () => {
     const pairs = pairsOf([[1, 3], [2, 3], [3, 3]]);
     assert.ok(Number.isNaN(computePearson(pairs)));
-  });
-});
-
-describe('computeAgreementWithCI', () => {
-  it('bootstrap CI on α covers the point estimate for tight-agreement data', () => {
-    const pairs = pairsOf([[1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5]]);
-    const result = computeAgreementWithCI(pairs, { samples: 1000, seed: 42 });
-    assert.equal(result.sampleCount, 10);
-    // For all-agreement samples the bootstrap CI should be very tight around 1.
-    assert.ok(result.alpha === 1 || Math.abs(result.alpha - 1) < 1e-6, `α=${result.alpha}`);
-    assert.ok(result.alphaCI.high <= 1 + 1e-9, 'α CI upper bound must not exceed 1');
-  });
-
-  it('CI widens for noisier data — wider than 0 but bounded', () => {
-    // Mix of agreement and small disagreement.
-    const pairs = pairsOf([[1, 2], [2, 2], [3, 3], [4, 4], [5, 4], [1, 1], [2, 3], [3, 3], [4, 5], [5, 5]]);
-    const result = computeAgreementWithCI(pairs, { samples: 1000, seed: 7 });
-    const width = result.alphaCI.high - result.alphaCI.low;
-    assert.ok(width > 0, 'noisy data should produce a non-zero CI width');
-    assert.ok(width < 2, 'CI width on a [-1,1]-bounded metric should not blow up');
-    assert.ok(result.alphaCI.low <= result.alpha && result.alpha <= result.alphaCI.high,
-      `point estimate ${result.alpha} should fall inside CI [${result.alphaCI.low}, ${result.alphaCI.high}]`);
-  });
-
-  it('handles empty input without throwing', () => {
-    const result = computeAgreementWithCI([], { samples: 100, seed: 1 });
-    assert.equal(result.sampleCount, 0);
-    assert.ok(Number.isNaN(result.alpha));
-    assert.ok(Number.isNaN(result.weightedKappa));
-    assert.ok(Number.isNaN(result.pearson));
   });
 });
 

--- a/test/eval-workflows/measurement/analysis/agreement-table.test.ts
+++ b/test/eval-workflows/measurement/analysis/agreement-table.test.ts
@@ -5,7 +5,6 @@ import {
   summarizeBootstrapMetric,
 } from '../../../../src/eval-workflows/analysis/bootstrap.js';
 import {
-  computeAgreementWithCI,
   computeKrippendorffAlpha,
 } from '../../../../src/eval-workflows/gold/human.js';
 import {
@@ -108,9 +107,14 @@ describe('Agreement Analysis table', () => {
       pearson: { statisticStatus: 'observed', value: 0.9058 },
     });
 
-    const legacy = computeAgreementWithCI(values.map(([coderA, coderB], index) => ({
-      unitId: `sample-${index}`, coderA, coderB,
-    })), { samples: 1_000, seed: 7, alpha: 0.05 });
+    // Frozen from the removed unit-resampling wrapper with seed 7 and 1000 draws.
+    // v2 fixes expected disagreement instead; these historical bounds must differ.
+    const legacy = {
+      alpha: 0.8939,
+      alphaCI: { low: 0.7177, high: 0.9719 },
+      weightedKappa: 0.8889,
+      pearson: 0.9058,
+    };
     expect(value.statistics).toMatchObject({
       krippendorffAlpha: { value: legacy.alpha },
       weightedKappa: { value: legacy.weightedKappa },


### PR DESCRIPTION
## 用户影响

处理 #767 的 A4，删除没有产品调用的旧一致性统计聚合包装及其专属测试。产品仍使用 `computeAgreementEvidence`，保留 Krippendorff alpha、加权 Kappa、Pearson、bootstrap 的生产实现与独立统计验证。

历史对照已在删除前使用固定输入、seed 7、1000 次抽样取得，并冻结在测试中。旧包装区间为 `[0.7177, 0.9719]`，当前 v2 区间为 `[0.8142, 0.9735]`，明确保留两种统计方法的差异，不把旧结果套入新口径。

## 兼容性与测量说明

不改变评分、prompt、公开 Schema identity、落盘契约或 v1／v2 回放算法，无需用户迁移。源码净减少 55 行，测试净减少 27 行，总计净减少 82 行。

## 审查与验证

自主 CR：No findings。审查范围覆盖删除边界、产品调用链、历史对照来源和版本化回放；不存在待处理 P0～P2。

受影响测试 22 项通过。首次推送前运行完整 `yarn ci`；远端 CI 状态由本 PR 记录。本次未改变真实用户入口或打包／安装契约，不额外重复 clean-room 验收。

Refs #767