### PR TITLE
refactor(observability): 移除测试专用旁路入口

### DIFF
--- a/src/executors/core/capabilities.ts
+++ b/src/executors/core/capabilities.ts
@@ -6,11 +6,6 @@ import {
 
 export type { ExecutorCapabilities, SampleMockSupport } from './registry.js';
 
-interface SampleMockDeclaration {
-  readonly sample_id: string;
-  readonly mocks?: readonly unknown[];
-}
-
 /**
  * Custom script executors receive the OMK_MOCK_* protocol environment and own
  * the final adapter. Built-ins are explicit so unsupported runtimes can never
@@ -26,42 +21,12 @@ export function executorSupportsSampleMocks(executorName: string): boolean {
   return getExecutorCapabilities(executorName).sampleMocks !== 'unsupported';
 }
 
-function unsupportedMocksMessage(
-  executorName: string,
-  sampleIds: string[],
-  lang: 'zh' | 'en',
-): string {
-  const ids = sampleIds.slice(0, 8).join(', ');
-  const overflow = sampleIds.length > 8
-    ? lang === 'zh'
-      ? ` 等 ${sampleIds.length} 条`
-      : ` and ${sampleIds.length - 8} more`
-    : '';
-  if (lang === 'en') {
-    return `Executor "${executorName}" does not support Sample.mocks tool interception. `
-      + `Continuing would make mock_hit assertions structurally impossible and create false evidence. `
-      + `Affected samples: ${ids}${overflow}. `
-      + 'Regenerate them with "omk sample --no-mock", remove mocks/mock_hit, '
-      + 'or evaluate with claude/claude-sdk.';
-  }
+function unsupportedMocksMessage(executorName: string): string {
   return `执行器「${executorName}」不支持 Sample.mocks 工具拦截。`
     + `继续运行会让 mock_hit 在结构上必然失败并产生伪证据。`
-    + `受影响用例：${ids}${overflow}。`
+    + '受影响用例：<programmatic-input>。'
     + '请用「omk sample --no-mock」重新生成、删除 mocks/mock_hit，'
     + '或改用 claude/claude-sdk 评测。';
-}
-
-export function assertSamplesCompatibleWithExecutor(
-  samples: readonly SampleMockDeclaration[],
-  executorName: string,
-  lang: 'zh' | 'en' = 'zh',
-): void {
-  if (executorSupportsSampleMocks(executorName)) return;
-  const affected = samples
-    .filter((sample) => Array.isArray(sample.mocks) && sample.mocks.length > 0)
-    .map((sample) => sample.sample_id);
-  if (affected.length === 0) return;
-  throw new Error(unsupportedMocksMessage(executorName, affected, lang));
 }
 
 export function assertExecutorInputCapabilities(
@@ -73,7 +38,7 @@ export function assertExecutorInputCapabilities(
     || !Array.isArray(input.mocks)
     || input.mocks.length === 0
   ) return;
-  throw new Error(unsupportedMocksMessage(executorName, ['<programmatic-input>'], 'zh'));
+  throw new Error(unsupportedMocksMessage(executorName));
 }
 
 export function enforceExecutorCapabilities(

--- a/src/executors/index.ts
+++ b/src/executors/index.ts
@@ -29,7 +29,6 @@ const EXECUTOR_FACTORIES = {
 export { extractClaudeTrace, createScriptExecutor };
 export {
   assertExecutorInputCapabilities,
-  assertSamplesCompatibleWithExecutor,
   executorSupportsSampleMocks,
   getExecutorCapabilities,
 } from './core/capabilities.js';

--- a/src/observability/analysis/coverage-analyzer.ts
+++ b/src/observability/analysis/coverage-analyzer.ts
@@ -189,62 +189,6 @@ export function buildKnowledgeIndex(cwd: string): KnowledgeIndex {
   };
 }
 
-export function buildFullKnowledgeIndex(artifactContent: string | null, cwd: string | null): KnowledgeIndex {
-  const entriesMap = new Map<string, KnowledgeEntry>();
-
-  if (cwd) {
-    const dirIndex = buildKnowledgeIndex(cwd);
-    for (const entry of dirIndex.entries) {
-      entriesMap.set(entry.path, entry);
-    }
-  }
-
-  if (artifactContent) {
-    const refPaths = extractReferencedPaths(artifactContent);
-    for (const path of refPaths) {
-      if (!entriesMap.has(path)) {
-        const existing = [...entriesMap.values()].find((entry) =>
-          [entry.path, ...(entry.aliases ?? [])].some((candidate) =>
-            candidate.endsWith('/' + path) || candidate === path
-          )
-        );
-        if (!existing) {
-          let lineCount: number | undefined;
-          if (cwd) {
-            const fullPath = resolveInside(cwd, path);
-            try {
-              if (fullPath && existsSync(fullPath) && statSync(fullPath).isFile()) {
-                lineCount = readFileSync(fullPath, 'utf-8').split('\n').length;
-              }
-            } catch { }
-          }
-          if (!cwd || resolveInside(cwd, path)) {
-            entriesMap.set(path, { path, type: classifyEntry(path), lineCount });
-          }
-        }
-      }
-    }
-  }
-
-  const entries = [...entriesMap.values()];
-  const totalLines = entries.reduce((sum, entry) => sum + (entry.lineCount || 0), 0);
-  return {
-    entries,
-    totalFiles: entries.length,
-    totalLines,
-  };
-}
-
-function resolveInside(root: string, path: string): string | null {
-  const absoluteRoot = resolve(root);
-  const candidate = resolve(absoluteRoot, path);
-  const relativePath = relative(absoluteRoot, candidate);
-  return relativePath === ''
-    || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
-    ? candidate
-    : null;
-}
-
 export function extractKnowledgeConsumption(toolCalls: ToolCallInfo[]): KnowledgeConsumption {
   const filesRead: string[] = [];
   const grepPatterns: Array<{ pattern: string; path?: string }> = [];

--- a/src/observability/soft-standards/index.ts
+++ b/src/observability/soft-standards/index.ts
@@ -42,7 +42,6 @@ export {
   resolveSkillStandards,
   skillDerivedStandardsDir,
   skillDerivedStandardsPath,
-  updateSkillDerivedStandardStatus,
 } from './skill-standards-store.js';
 
 export { extractSkillSoftStandards } from './llm-extractor.js';

--- a/src/observability/soft-standards/skill-standards-store.ts
+++ b/src/observability/soft-standards/skill-standards-store.ts
@@ -20,7 +20,6 @@ import type {
   SkillDerivedStandardStatus,
   SkillDerivedStandards,
 } from './types.js';
-import { writeJsonFileAtomic } from '../../shared/atomic-json.js';
 import { isRfc3339Timestamp } from '../../shared/timestamp.js';
 import { resolveObservationsDir } from '../inbox/paths.js';
 
@@ -75,31 +74,6 @@ function applySoftStandardReviews(
       return standard;
     }),
   };
-}
-
-export function updateSkillDerivedStandardStatus(
-  observationsDir: string,
-  skillName: string,
-  standardId: string,
-  status: SkillDerivedStandardStatus,
-  now = new Date().toISOString(),
-): SkillDerivedStandards {
-  const filePath = skillDerivedStandardsPath(observationsDir, skillName);
-  const existing = loadExisting(filePath);
-  if (!existing) throw new Error(`skill derived standards not found: ${skillName}`);
-  let found = false;
-  const next: SkillDerivedStandards = {
-    ...existing,
-    generatedAt: now,
-    standards: existing.standards.map((item) => {
-      if (item.id !== standardId) return item;
-      found = true;
-      return { ...item, status };
-    }),
-  };
-  if (!found) throw new Error(`skill derived standard not found: ${standardId}`);
-  writeJsonFileAtomic(filePath, next);
-  return next;
 }
 
 export function resolveSkillStandards(skillName: string, options: ResolveSkillStandardsOptions): ResolvedSkillStandards {

--- a/test/executors/capabilities.test.ts
+++ b/test/executors/capabilities.test.ts
@@ -1,14 +1,13 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import {
-  assertSamplesCompatibleWithExecutor,
+  assertExecutorInputCapabilities,
   enforceExecutorCapabilities,
   executorSupportsSampleMocks,
   getExecutorCapabilities,
 } from '../../src/executors/core/capabilities.js';
 import { createExecutor } from '../../src/executors/index.js';
-import type { ExecutorFn } from '../../src/executors/contracts/ports.js';
-import type { Sample } from '../../src/eval-workflows/inputs/contracts/sample.js';
+import type { ExecutorFn, ExecutorInput } from '../../src/executors/contracts/ports.js';
 
 const okExecutor: ExecutorFn = async () => ({
   ok: true,
@@ -38,21 +37,23 @@ describe('executor sample-mock capabilities', () => {
     );
   });
 
-  it('rejects incompatible samples before evaluation starts', () => {
-    const samples: Sample[] = [{
-      sample_id: 'codex-impossible',
+  it('preflights production executor inputs before dispatch', () => {
+    const input: ExecutorInput = {
+      model: 'test',
       prompt: 'read a file',
       mocks: [{ tool: 'Read', return: 'fixture' }],
-      assertions: [{ type: 'mock_hit', value: 'Read:1' }],
-    }];
-
-    assert.throws(
-      () => assertSamplesCompatibleWithExecutor(samples, 'codex'),
-      /不支持 Sample\.mocks.*伪证据.*codex-impossible/,
-    );
-    assert.doesNotThrow(
-      () => assertSamplesCompatibleWithExecutor(samples, 'claude'),
-    );
+    };
+    for (const executor of ['codex', 'codex-sdk', 'dsh-host', 'openai-api', 'anthropic-api']) {
+      assert.throws(
+        () => assertExecutorInputCapabilities(executor, input),
+        /不支持 Sample\.mocks.*伪证据.*<programmatic-input>/,
+      );
+      assert.doesNotThrow(() => assertExecutorInputCapabilities(executor, { ...input, mocks: [] }));
+      assert.doesNotThrow(() => assertExecutorInputCapabilities(executor, { model: 'test', prompt: 'test' }));
+    }
+    for (const executor of ['claude', 'claude-sdk', './custom-executor.sh']) {
+      assert.doesNotThrow(() => assertExecutorInputCapabilities(executor, input));
+    }
   });
 
   it('guards direct executor calls instead of silently dropping mocks', async () => {

--- a/test/observability/analysis/coverage-analyzer.test.ts
+++ b/test/observability/analysis/coverage-analyzer.test.ts
@@ -10,7 +10,6 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  buildFullKnowledgeIndex,
   buildKnowledgeIndex,
   computeCoverage,
   extractReferencedPaths,
@@ -102,25 +101,15 @@ describe('source-neutral knowledge coverage', () => {
     }
   });
 
-  it('discovers local artifact references but rejects paths outside the root', () => {
-    const root = mkdtempSync(join(tmpdir(), 'omk-coverage-refs-'));
-    try {
-      mkdirSync(join(root, 'references'), { recursive: true });
-      writeFileSync(join(root, 'references', 'guide.md'), '# guide');
-      const content = [
-        '[guide](references/guide.md)',
-        '[outside](../outside.md)',
-      ].join('\n');
-
-      assert.deepEqual(
-        extractReferencedPaths(content).sort(),
-        ['../outside.md', 'references/guide.md'],
-      );
-      const paths = buildFullKnowledgeIndex(content, root).entries.map((entry) => entry.path);
-      assert.deepEqual(paths, ['references/guide.md']);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+  it('extracts relative artifact references without filesystem resolution', () => {
+    const content = [
+      '[guide](references/guide.md)',
+      '[outside](../outside.md)',
+    ].join('\n');
+    assert.deepEqual(
+      extractReferencedPaths(content).sort(),
+      ['../outside.md', 'references/guide.md'],
+    );
   });
 
   it('does not count a suffix-colliding filename as accessed', () => {

--- a/test/observability/inbox/review-state.test.ts
+++ b/test/observability/inbox/review-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, it, onTestFinished } from 'vitest';
 import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -19,7 +19,6 @@ import {
   resolveSkillStandards,
   skillDerivedStandardsDir,
   skillDerivedStandardsPath,
-  updateSkillDerivedStandardStatus,
 } from '../../../src/observability/soft-standards/index.js';
 import type { ObservationSkillChain } from '../../../src/observability/skill-health/skill-chain.js';
 
@@ -404,6 +403,7 @@ describe('observe inbox - review state', () => {
 
   it('extracts and reviews soft standard candidates with explicit model execution', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'omk-soft-standards-'));
+    onTestFinished(() => rmSync(dir, { recursive: true, force: true }));
     const chain: ObservationSkillChain = {
       skillName: 'sample-review-skill',
       definition: {
@@ -596,14 +596,18 @@ describe('observe inbox - review state', () => {
     const loaded = loadSkillDerivedStandards(dir);
     assert.equal(loaded['sample-review-skill'].standards[0].status, 'pending_review');
 
-    const updated = updateSkillDerivedStandardStatus(
-      dir,
-      'sample-review-skill',
-      record.standards[0].id,
-      'author_confirmed',
-      '2026-05-01T00:01:00.000Z',
-    );
+    const rawPath = skillDerivedStandardsPath(dir, 'sample-review-skill');
+    const rawBeforeReview = readFileSync(rawPath, 'utf-8');
+    const targetId = `sample-review-skill:${record.standards[0].id}`;
+    updateObservationReviewState(dir, {
+      targetType: 'soft_standard',
+      targetId,
+      verdict: 'real_issue',
+    }, new Date(Date.parse(record.generatedAt) + 60_000).toISOString());
+    const updated = loadSkillDerivedStandards(dir)['sample-review-skill'];
     assert.equal(updated.standards[0].status, 'author_confirmed');
+    assert.equal(updated.generatedAt, record.generatedAt);
+    assert.equal(readFileSync(rawPath, 'utf-8'), rawBeforeReview);
 
     const resolved = resolveSkillStandards('sample-review-skill', {
       observationsDir: dir,
@@ -613,6 +617,13 @@ describe('observe inbox - review state', () => {
     assert.equal(resolved.active.length, 1);
     assert.equal(resolved.active[0].source, 'confirmed_soft');
     assert.equal(resolved.candidates.some((item) => item.status === 'pending_review'), true);
+    updateObservationReviewState(dir, {
+      targetType: 'soft_standard',
+      targetId,
+      verdict: 'not_issue',
+    }, new Date(Date.parse(record.generatedAt) + 120_000).toISOString());
+    assert.equal(loadSkillDerivedStandards(dir)['sample-review-skill'].standards[0].status, 'rejected');
+    assert.equal(readFileSync(rawPath, 'utf-8'), rawBeforeReview);
   });
 
   it('does not overwrite reviewed soft standards when prompt version changes', async () => {


### PR DESCRIPTION
## 用户影响

处理 #767 的 A5，删除没有产品调用的标准状态旁路写入、完整知识索引组装包装和样本级能力预检。标准人工审阅继续通过正式 review state 持久化，读取时派生有效状态，不覆盖原始标准或生成时间。

保留真实目录索引、引用提取、覆盖率算法、生产执行器输入预检和 Runtime mock 资格检查。删除旧入口专属的错误文案分支，当前生产错误信息保持不变。

## 兼容性与测量说明

无用户迁移要求，不改变评分、prompt、统计口径、公开 Schema identity 或落盘契约。不为维持测试而增加新的产品入口。

本轮源码净减少 119 行，测试净增加 1 行，总计净减少 118 行。测试改走实际产品契约，而非保留备用实现。

## 审查与验证

自主 CR：No findings。覆盖删除边界、生产调用、审阅 provenance、原始文件不变和测试临时资源清理。

受影响测试 23 项通过。首次 push 前执行完整 `yarn ci`；远端 CI 由本 PR 记录。未改变真实用户入口或打包／安装契约，不额外重复 clean-room 验收。

Refs #767