### PR TITLE
fix(observability): 统一有效观测指标与复盘优先级

### DIFF
--- a/docs/explanation/effective-observation-review.md
+++ b/docs/explanation/effective-observation-review.md
@@ -1,0 +1,17 @@
+# Effective observation review
+
+The inbox keeps source reports and human review state separate. The effective review is a read-time view, not a replacement persisted report and not a causal evaluation of a skill.
+
+## Shared view
+
+`omk observe inbox --json` includes `effectiveExperienceReports`, `resolvedReviewSessions`, and `unappliedMetricAnnotations` alongside the existing `items` array. `GET /api/observe-inbox/view` exposes the same three fields; both support skill filtering. The existing `GET /api/observe-inbox` item-list response is unchanged. Studio consumes the same domain projection.
+
+Effective session indicators, basis codes, rule findings, inference, priorities, and skill totals belong to observability, not the HTML renderer. Deterministic priority uses the domain weighted score: scores of at least three mean `review_first`, positive scores below three mean `sample_review`, and zero means `routine_sample`. Domain reviewer findings can escalate this priority. Existing explicit LLM and manual-review precedence is retained, with provenance in `resolvedReviewSessions.source`.
+
+## Evidence and annotations
+
+Canonical feedback attribution determines which feedback belongs to a skill, including permitted downstream feedback. Rejected feedback is excluded from the effective count. Where complete attributed event relations are available, other metric annotations are applied from that evidence rather than from the preview window.
+
+A truncated or missing preview is not evidence of zero occurrences. When an annotation can be located but cannot be safely replayed from complete evidence, the stored count remains and the session's metric key is reported in `unappliedMetricAnnotations`. This is an evidence limitation, not confirmation that the annotation changed the total.
+
+Raw `reports`, raw `experienceReports`, original trace evidence, and review state remain independently available in the inbox view model. Do not persist `effectiveExperienceReports` over those originals. Published measurement schemas, prompt bytes, and persisted statistical results are not changed by this projection.

--- a/docs/zh/explanation/effective-observation-review.md
+++ b/docs/zh/explanation/effective-observation-review.md
@@ -1,0 +1,17 @@
+# 有效观测审阅视图
+
+收件箱分别保留原始报告与人工审阅状态。有效审阅是读取时生成的派生视图，不替换持久化原始报告，也不把观测线索当作 skill 的因果评测结论。
+
+## 共享视图
+
+`omk observe inbox --json` 在原有 `items` 数组之外提供 `effectiveExperienceReports`、`resolvedReviewSessions` 和 `unappliedMetricAnnotations`。`GET /api/observe-inbox/view` 提供同样三个字段，两者均支持按 skill 筛选。原有 `GET /api/observe-inbox` 的条目列表响应保持不变。Studio 消费同一领域投影。
+
+有效会话指标、依据代码、规则发现、辅助推断、优先级和 skill 汇总由 observability 负责，不由 HTML renderer 定义。确定性优先级使用领域加权分数：至少三分为 `review_first`，大于零且不足三分为 `sample_review`，零分为 `routine_sample`。领域审阅发现可以进一步提升优先级。既有显式 LLM 与人工审阅优先关系保留，来源通过 `resolvedReviewSessions.source` 表达。
+
+## 证据与标注
+
+规范化反馈归因决定反馈属于哪个 skill，并包含允许归入的下游反馈。人工反对的反馈不计入有效数量。存在完整归属事件关系时，其余指标标注基于这些证据应用，而不是从预览窗口推算总量。
+
+预览截断或缺失不代表发生次数为零。能够定位标注、但无法使用完整证据安全重放时，保留已存指标，并在 `unappliedMetricAnnotations` 中记录对应会话的指标键。这表示证据限制，不表示该标注已经改变总数。
+
+收件箱 ViewModel 中的原始 `reports`、原始 `experienceReports`、原始轨迹证据与审阅状态仍各自保留。不要将 `effectiveExperienceReports` 覆盖写回原始报告。此投影不改变公开测量 Schema、prompt 字节或持久化统计结果。

--- a/src/cli/commands/observe/inbox.ts
+++ b/src/cli/commands/observe/inbox.ts
@@ -128,7 +128,9 @@ export async function runObserveInbox(
     items = items.slice(0, limit);
   }
   if (flags.json) {
-    console.log(JSON.stringify({ kind: 'observe-inbox-query', items }, null, 2));
+    const { buildObservationInboxViewModel } = await import('../../../observability/inbox/view-model.js');
+    const { effectiveExperienceReports, resolvedReviewSessions, unappliedMetricAnnotations } = buildObservationInboxViewModel(dir, { skill: flags.skill });
+    console.log(JSON.stringify({ kind: 'observe-inbox-query', items, effectiveExperienceReports, resolvedReviewSessions, unappliedMetricAnnotations }, null, 2));
     return;
   }
   if (items.length === 0) {

--- a/src/observability/experience.ts
+++ b/src/observability/experience.ts
@@ -508,7 +508,7 @@ function evidenceChainForTimeline(
   };
 }
 
-function ruleFindingsForEvidence(
+export function ruleFindingsForEvidence(
   indicators: ExperienceReviewIndicators,
   timeline: ExperienceTimelineEvent[],
   observationRefs: ExperienceEvidenceRef[],
@@ -553,7 +553,7 @@ function ruleFindingsForEvidence(
   return findings;
 }
 
-function assistiveInferenceForEvidence(
+export function assistiveInferenceForEvidence(
   indicators: ExperienceReviewIndicators,
   evidenceChain: ExperienceEvidenceChain,
   ruleFindings: ExperienceRuleFinding[],
@@ -615,13 +615,11 @@ function assistiveInferenceForEvidence(
   };
 }
 
-function indicatorsForSegment(
-  segment: SkillSegment,
-  relatedItems: ObservationInboxItem[],
+export function timelineIndicators(
   timeline: ExperienceTimelineEvent[],
   metricScopeId: string,
   reviewState?: ObservationReviewState,
-): ExperienceReviewIndicators {
+) {
   const userRefs = timeline.filter((event) => event.kind === 'user_message');
   const humanUserRefs = userRefs.filter((ref) => Boolean(ref.snippet) && !isSyntheticUserMessageText(ref.snippet ?? ''));
   const interactionUserRefs = humanUserRefs.filter((ref) => isUserInteractionMetricText(ref.snippet ?? ''));
@@ -641,6 +639,18 @@ function indicatorsForSegment(
     routerDownstreamFailed: 0,
     selfCorrectionCount: timeline.reduce((sum, ref) => sum + (metricIsActive(ref, 'self_correction', hasSelfCorrectionSignal(ref), reviewState) ? 1 : 0), 0),
     repeatedExecutionCount: timeline.reduce((sum, ref) => sum + (metricIsActive(ref, 'repeated_execution', hasRepeatedExecutionSignal(ref), reviewState) ? 1 : 0), 0),
+  };
+}
+
+function indicatorsForSegment(
+  segment: SkillSegment,
+  relatedItems: ObservationInboxItem[],
+  timeline: ExperienceTimelineEvent[],
+  metricScopeId: string,
+  reviewState?: ObservationReviewState,
+): ExperienceReviewIndicators {
+  return {
+    ...timelineIndicators(timeline, metricScopeId, reviewState),
     toolCallCount: segment.metrics.numToolCalls,
     toolFailureCount: Math.max(segment.metrics.numToolFailures, timeline.filter(isToolFailureEvent).length),
     toolCancelledCount: segment.metrics.numToolCancelled,

--- a/src/observability/experience/review-checklist.ts
+++ b/src/observability/experience/review-checklist.ts
@@ -624,15 +624,7 @@ export function canonicalFeedbackCountsForSession(session: ExperienceSessionSumm
       positiveFeedbackCount: session.indicators.positiveFeedbackCount,
     };
   }
-  const includeDownstream = shouldIncludeDownstreamFeedbackForSession(session);
-  const owned = signals.filter((signal) =>
-    (signal.canonicalAttributions ?? signal.attributions ?? []).some((attribution) =>
-      attribution.skillName === session.skillName
-      && (attribution.attributionRole === 'primary_fault'
-        || includeDownstream && attribution.attributionRole === 'downstream_related')
-    )
-    && feedbackSignalIsActiveForSession(signal, session, reviewState)
-  );
+  const owned = canonicalFeedbackSignalsForSession(session, reviewState);
   return {
     userFollowUpCount: owned.filter((signal) => signal.type === 'follow_up').length,
     userCorrectionCount: owned.filter((signal) => signal.type === 'correction').length,
@@ -640,6 +632,22 @@ export function canonicalFeedbackCountsForSession(session: ExperienceSessionSumm
     negativeFeedbackCount: owned.filter((signal) => signal.type === 'frustration').length,
     positiveFeedbackCount: owned.filter((signal) => signal.type === 'positive').length,
   };
+}
+
+export function canonicalFeedbackSignalsForSession(
+  session: ExperienceSessionSummary,
+  reviewState?: ObservationReviewState,
+): ExperienceFeedbackSignal[] {
+  const signals = session.sessionStory?.episodes?.flatMap((episode) => episode.feedbackSignals ?? []) ?? [];
+  const includeDownstream = shouldIncludeDownstreamFeedbackForSession(session);
+  return signals.filter((signal) =>
+    (signal.canonicalAttributions ?? signal.attributions ?? []).some((attribution) =>
+      attribution.skillName === session.skillName
+      && (attribution.attributionRole === 'primary_fault'
+        || includeDownstream && attribution.attributionRole === 'downstream_related')
+    )
+    && feedbackSignalIsActiveForSession(signal, session, reviewState)
+  );
 }
 
 export function feedbackSignalIsActiveForSession(

--- a/src/observability/inbox/effective-review.ts
+++ b/src/observability/inbox/effective-review.ts
@@ -1,0 +1,175 @@
+import type {
+  ExperienceFeedbackSignal,
+  ExperienceReviewIndicators,
+  ExperienceSessionSummary,
+  ExperienceTimelineEvent,
+  ObservationExperienceReport,
+} from '../contracts/experience.js';
+import type { ObservationMetricKey, ObservationReviewState } from '../contracts/review.js';
+import type { SkillDerivedStandards } from '../soft-standards/types.js';
+import {
+  assistiveInferenceForEvidence,
+  ruleFindingsForEvidence,
+  timelineIndicators,
+} from '../experience.js';
+import {
+  basisCodesForIndicators,
+  priorityForReviewerFindings,
+  priorityForScore,
+  scoreForIndicators,
+  sumIndicators,
+} from '../experience/report-derivations.js';
+import {
+  canonicalFeedbackCountsForSession,
+  canonicalFeedbackSignalsForSession,
+  metricKeyForFeedbackSignal,
+} from '../experience/review-checklist.js';
+import { isAssistantDeliveryEvent } from '../experience/timeline.js';
+import { buildSessionStory } from '../experience/session-story.js';
+import { buildReviewerReport } from '../experience/reviewer-report.js';
+import { observationMetricAnnotationVerdict } from './review-state.js';
+import { resolveObservationReviewSession, type ResolvedObservationReviewSession } from './resolved-review.js';
+import { ownRecordValue, setOwnRecordValue } from '../../shared/record-count.js';
+
+export const INDICATOR_FOR_METRIC = {
+  user_follow_up: 'userFollowUpCount',
+  user_correction: 'userCorrectionCount',
+  user_interruption: 'userInterruptionCount',
+  negative_feedback: 'negativeFeedbackCount',
+  positive_feedback: 'positiveFeedbackCount',
+  user_goal_shift: 'userGoalShiftCount',
+  hard_rule: 'hardRuleTextHitCount',
+  completion_result: 'assistantDeliverySignalCount',
+  deliverable_artifact: 'deliverableArtifactSignalCount',
+  self_correction: 'selfCorrectionCount',
+  repeated_execution: 'repeatedExecutionCount',
+} as const satisfies Partial<Record<ObservationMetricKey, keyof ExperienceReviewIndicators>>;
+
+export interface EffectiveObservationReview {
+  /** Read-only derived views; never persist these over the source reports. */
+  effectiveExperienceReports: ObservationExperienceReport[];
+  resolvedReviewSessions: Record<string, ResolvedObservationReviewSession>;
+  unappliedMetricAnnotations: Record<string, ObservationMetricKey[]>;
+}
+
+function attributedTimeline(session: ExperienceSessionSummary): ExperienceTimelineEvent[] | undefined {
+  const ids = new Set(session.attributedEventIds);
+  if (ids.size === 0 || ids.size !== session.timelineScope.segmentEventCount) return undefined;
+  const events = new Map([...session.timelinePreview, ...session.fullSessionTimeline].map((event) => [event.id, event]));
+  const timeline = [...ids].map((id) => events.get(id));
+  if (timeline.some((event) => !event)) return undefined;
+  return timeline as ExperienceTimelineEvent[];
+}
+
+function reviewedIndicators(
+  session: ExperienceSessionSummary,
+  report: ObservationExperienceReport,
+  reviewState: ObservationReviewState,
+): { indicators: ExperienceReviewIndicators; unapplied: ObservationMetricKey[] } {
+  const indicators = { ...session.indicators };
+  const timeline = attributedTimeline(session);
+  const visible = timeline ?? session.timelinePreview;
+  const canonical = canonicalFeedbackSignalsForSession(session);
+  const allCanonical = session.sessionStory?.episodes?.flatMap((episode) => episode.feedbackSignals ?? []) ?? [];
+  const unapplied: ObservationMetricKey[] = [];
+  const group = report.invocations.filter((invocation) => session.invocationIds.includes(invocation.id));
+  const canReplayInvocations = group.length > 0 && group.length === session.invocationIds.length
+    && group.every((invocation) => invocation.timeline.length > 0
+      && (invocation.timelineEventIds === undefined
+        || invocation.timelineEventIds.every((id) => invocation.timeline.some((event) => event.id === id))));
+  for (const [metricKey, field] of Object.entries(INDICATOR_FOR_METRIC) as Array<[keyof typeof INDICATOR_FOR_METRIC, typeof INDICATOR_FOR_METRIC[keyof typeof INDICATOR_FOR_METRIC]]>) {
+    const refs = [...visible, ...canonical.map((signal) => signal.evidenceRef)];
+    const annotated = refs.some((ref) => observationMetricAnnotationVerdict(reviewState, { ...ref, metricScopeId: session.id }, metricKey));
+    if (!annotated) continue;
+    if (allCanonical.length > 0 && canonical.some((signal) => metricKeyForFeedbackSignal(signal) === metricKey)) continue;
+    if (!timeline || (metricKey === 'repeated_execution'
+      && timeline.filter((event) => event.kind === 'tool_use').length !== session.indicators.toolCallCount)) {
+      unapplied.push(metricKey);
+      continue;
+    }
+    if (metricKey === 'completion_result') {
+      indicators[field] = timeline.filter((event) => {
+        if (event.kind !== 'assistant_message') return false;
+        const verdict = observationMetricAnnotationVerdict(reviewState, event, metricKey);
+        return verdict === 'confirmed' || (verdict !== 'rejected' && isAssistantDeliveryEvent(event));
+      }).length;
+      continue;
+    }
+    const counts = canReplayInvocations
+      ? sumIndicators(group.map((invocation) => ({ ...invocation.indicators, ...timelineIndicators(invocation.timeline, session.id, reviewState) })))
+      : timelineIndicators(timeline, session.id, reviewState);
+    indicators[field] = counts[field];
+  }
+  // Canonical attribution owns feedback counts, including downstream ownership.
+  // The domain helper retains stored counts when canonical evidence is absent.
+  Object.assign(indicators, canonicalFeedbackCountsForSession({ ...session, indicators }, reviewState));
+  return { indicators, unapplied };
+}
+
+/** Shared CLI/API/Studio projection. Raw evidence and review state remain separate. */
+export function projectEffectiveObservationReview(
+  reports: ObservationExperienceReport[],
+  reviewState: ObservationReviewState,
+  derivedStandards: Record<string, SkillDerivedStandards> = {},
+): EffectiveObservationReview {
+  const resolvedReviewSessions: EffectiveObservationReview['resolvedReviewSessions'] = {};
+  const unappliedMetricAnnotations: EffectiveObservationReview['unappliedMetricAnnotations'] = {};
+  const effectiveExperienceReports = reports.map((report) => {
+    const sessions = report.sessions.map((raw) => {
+      const { indicators, unapplied } = reviewedIndicators(raw, report, reviewState);
+      if (unapplied.length > 0) setOwnRecordValue(unappliedMetricAnnotations, raw.id, unapplied);
+      const timeline = attributedTimeline(raw) ?? raw.timelinePreview;
+      const observations = raw.ruleFindings.flatMap((finding) => finding.evidenceRefs).filter((ref) => ref.kind === 'observation');
+      const findings = ruleFindingsForEvidence(indicators, timeline, observations, raw.evidenceChain, raw.id, reviewState);
+      const feedbackTypes: Partial<Record<(typeof findings)[number]['code'], ExperienceFeedbackSignal['type']>> = {
+        user_correction_seen: 'correction', user_interruption_seen: 'interruption',
+        negative_feedback_seen: 'frustration', positive_feedback_seen: 'positive',
+      };
+      const activeSignals = canonicalFeedbackSignalsForSession(raw, reviewState);
+      for (const finding of findings) {
+        const signalType = feedbackTypes[finding.code];
+        if (!signalType) continue;
+        const refs = activeSignals.filter((signal) => signal.type === signalType).map((signal) => signal.evidenceRef);
+        if (refs.length > 0) finding.evidenceRefs = refs.slice(0, 5);
+      }
+      let session: ExperienceSessionSummary = {
+        ...raw,
+        indicators,
+        reviewPriorityScore: scoreForIndicators(indicators),
+        reviewBasisCodes: basisCodesForIndicators(indicators),
+        ruleFindings: findings,
+        assistiveInference: assistiveInferenceForEvidence(indicators, raw.evidenceChain, findings),
+      };
+      const group = report.invocations.filter((invocation) => raw.invocationIds.includes(invocation.id));
+      if (raw.reviewerReport && raw.sessionStory && attributedTimeline(raw)) {
+        const storyInvocations = report.invocations.filter((invocation) => group.some((own) => own.sessionGroupKey === invocation.sessionGroupKey));
+        const story = buildSessionStory(session, storyInvocations, raw.sessionStory.episodes, reviewState);
+        session = { ...session, sessionStory: story };
+        session.reviewerReport = buildReviewerReport(session, group, report.generatedAt, reviewState, storyInvocations, story);
+      }
+      session.reviewPriority = session.reviewerReport
+        ? priorityForReviewerFindings(session, session.reviewerReport.findings)
+        : priorityForScore(session.reviewPriorityScore);
+      const resolved = resolveObservationReviewSession({ session, reviewState, enhancedReview: ownRecordValue(derivedStandards, raw.skillName)?.enhancedReview });
+      setOwnRecordValue(resolvedReviewSessions, raw.id, resolved);
+      // Preserve the deterministic result above in the resolved source; the view
+      // uses the final priority consistently for rows, cards, and skill totals.
+      return { ...session, reviewPriority: resolved.priority };
+    });
+    const skills = report.skills.map((skill) => {
+      const own = sessions.filter((session) => session.skillName === skill.skillName);
+      const indicators = sumIndicators(own.map((session) => session.indicators));
+      const findings = ruleFindingsForEvidence(indicators, own.flatMap((session) => attributedTimeline(session) ?? session.timelinePreview), [], skill.evidenceChain, '', reviewState);
+      return {
+        ...skill,
+        indicators,
+        reviewFirstSessionCount: own.filter((session) => session.reviewPriority === 'review_first').length,
+        sampleReviewSessionCount: own.filter((session) => session.reviewPriority === 'sample_review').length,
+        ruleFindings: findings,
+        assistiveInference: assistiveInferenceForEvidence(indicators, skill.evidenceChain, findings),
+      };
+    });
+    return { ...report, sessions, skills };
+  });
+  return { effectiveExperienceReports, resolvedReviewSessions, unappliedMetricAnnotations };
+}

--- a/src/observability/inbox/resolved-review.ts
+++ b/src/observability/inbox/resolved-review.ts
@@ -131,12 +131,10 @@ function resolvePriority(
   suppressTypeSpecific = false,
 ): ExperienceReviewPriority {
   if (hasManualReview) return priority;
-  const attributionPriority = priorityFromEpisodeAttribution(session);
-  if (attributionPriority === 'review_first') return 'review_first';
   const assessment = enhancedReview?.runtimeAssessment;
   const typeChecklist = suppressTypeSpecific ? [] : enhancedReview?.typeSpecificAssessment?.checklist ?? [];
   const nodeAssessments = enhancedReview ? runtimeNodeChecklistItems(enhancedReview) : [];
-  if (!assessment && typeChecklist.length === 0 && nodeAssessments.length === 0) return attributionPriority ?? priority;
+  if (!assessment && typeChecklist.length === 0 && nodeAssessments.length === 0) return priority;
   const attributionMode = episodeAttributionMode(session);
   if (typeChecklist.some((item) => item.status === 'failed' || item.status === 'degraded')
     || nodeAssessments.some((item) => item.status === 'failed' || item.status === 'degraded')) {
@@ -158,8 +156,8 @@ function resolvePriority(
     || assessment.userFeeling === 'neutral'))
     || typeChecklist.some((item) => item.status === 'unknown')
     || nodeAssessments.some((item) => item.status === 'unknown');
-  if (hasUnknown && priority === 'routine_sample') return maxPriority(attributionPriority ?? priority, 'sample_review');
-  return attributionPriority ? maxPriority(priority, attributionPriority) : priority;
+  if (hasUnknown && priority === 'routine_sample') return 'sample_review';
+  return priority;
 }
 
 function episodeAttributionMode(session?: ResolveObservationReviewSessionOptions['session']): 'primary' | 'downstream_only' | 'context_or_none' {
@@ -170,16 +168,6 @@ function episodeAttributionMode(session?: ResolveObservationReviewSessionOptions
   if (currentSkillAttributions.some((attribution) => attribution.attributionRole === 'primary_fault')) return 'primary';
   if (currentSkillAttributions.some((attribution) => attribution.attributionRole === 'downstream_related')) return 'downstream_only';
   return 'context_or_none';
-}
-
-function priorityFromEpisodeAttribution(session?: ResolveObservationReviewSessionOptions['session']): ExperienceReviewPriority | undefined {
-  const signals = session?.sessionStory?.episodes?.flatMap((episode) => episode.feedbackSignals ?? []) ?? [];
-  const currentSkillSignals = signals.filter((signal) =>
-    (signal.canonicalAttributions ?? signal.attributions ?? []).some((attribution) => attribution.skillName === session?.skillName && attribution.attributionRole === 'primary_fault')
-  );
-  if (currentSkillSignals.some((signal) => signal.type === 'correction' || signal.type === 'frustration' || signal.type === 'interruption')) return 'review_first';
-  if (currentSkillSignals.length > 0) return 'sample_review';
-  return undefined;
 }
 
 function maxPriority(a: ExperienceReviewPriority, b: ExperienceReviewPriority): ExperienceReviewPriority {

--- a/src/observability/inbox/view-model.ts
+++ b/src/observability/inbox/view-model.ts
@@ -4,12 +4,9 @@ import {
   type ObservationInboxItem,
   type ObservationInboxReport,
 } from './index.js';
+import { projectEffectiveObservationReview, type EffectiveObservationReview } from './effective-review.js';
 import type { ObservationExperienceReport } from '../experience.js';
 import { loadObservationReviewState, type ObservationReviewState } from './review-state.js';
-import {
-  resolveObservationReviewSession,
-  type ResolvedObservationReviewSession,
-} from './resolved-review.js';
 import { buildObservationSkillChains, type ObservationSkillChain } from '../skill-health/skill-chain.js';
 import {
   loadSkillDerivedStandards,
@@ -24,7 +21,7 @@ import {
   setOwnRecordValue,
 } from '../../shared/record-count.js';
 
-export interface ObservationInboxViewModel {
+export interface ObservationInboxViewModel extends EffectiveObservationReview {
   observationsDir?: string;
   activeSkill?: string;
   allItems: ObservationInboxItem[];
@@ -44,10 +41,7 @@ export interface ObservationInboxViewModel {
   reportCount: number;
   latestSeenLabel: string;
   reviewState: ObservationReviewState;
-  // 预投影:对 experience 里每个 session 提前算好 resolved review,renderer 多处用
-  // 同一份(card / list / aggregate),避免在 render path 上对同一 session 反复
-  // resolve。键 = session.id。
-  resolvedReviewSessions: Record<string, ResolvedObservationReviewSession>;
+
 }
 
 export interface ObservationInboxViewModelOptions {
@@ -120,17 +114,7 @@ export function buildObservationInboxViewModel(observationsDir: string, options:
     .reduce((latest, item) => item.lastSeen > latest ? item.lastSeen : latest, '');
   const reportCount = reports.length;
   const latestSeenLabel = latestSeen ? latestSeen.slice(0, 19).replace('T', ' ') : '—';
-  const resolvedReviewSessions: Record<string, ResolvedObservationReviewSession> = {};
-  for (const experience of experienceReports) {
-    for (const session of experience.sessions) {
-      const enhancedReview = ownRecordValue(skillDerivedStandards, session.skillName)?.enhancedReview;
-      setOwnRecordValue(resolvedReviewSessions, session.id, resolveObservationReviewSession({
-        session,
-        enhancedReview,
-        reviewState,
-      }));
-    }
-  }
+  const effectiveReview = projectEffectiveObservationReview(experienceReports, reviewState, skillDerivedStandards);
 
   return {
     observationsDir,
@@ -152,7 +136,7 @@ export function buildObservationInboxViewModel(observationsDir: string, options:
     reportCount,
     latestSeenLabel,
     reviewState,
-    resolvedReviewSessions,
+    ...effectiveReview,
   };
 }
 
@@ -262,3 +246,12 @@ export type { ResolvedObservationReviewSession, ResolvedOwnerSuggestion } from '
 export type { SkillChainAdvisoryCode } from '../skill-health/advisories.js';
 export type { ExperienceProblemBucket, ExperienceProblemPattern, ExperienceProblemSignal } from './problem-patterns.js';
 export type { SkillDerivedStandard, SkillLlmEnhancedReviewSections } from '../soft-standards/index.js';
+
+export { INDICATOR_FOR_METRIC } from './effective-review.js';
+export { observationMetricAnnotationVerdict } from './review-state.js';
+export {
+  canonicalFeedbackSignalsForSession,
+  metricKeyForFeedbackSignal,
+  shouldIncludeDownstreamFeedbackForSession,
+} from '../experience/review-checklist.js';
+export type { ExperienceSessionSummary, ExperienceFeedbackSignal } from '../contracts/experience.js';

--- a/src/studio/http/routes/observations.ts
+++ b/src/studio/http/routes/observations.ts
@@ -160,6 +160,13 @@ export function createObservationRoutes({
       return true;
     }
 
+    if (path === '/api/observe-inbox/view') {
+      const { effectiveExperienceReports, resolvedReviewSessions, unappliedMetricAnnotations } = buildObservationInboxViewModel(observationsDir, { skill: url.searchParams.get('skill') || undefined });
+      response.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+      response.end(JSON.stringify({ effectiveExperienceReports, resolvedReviewSessions, unappliedMetricAnnotations }));
+      return true;
+    }
+
     if (path === '/api/observe-inbox') {
       const severity = url.searchParams.get('severity');
       const skill = url.searchParams.get('skill');

--- a/src/studio/presentation/observation-inbox-renderer.ts
+++ b/src/studio/presentation/observation-inbox-renderer.ts
@@ -20,7 +20,7 @@ type ExperienceSessionSummary = ObservationInboxViewModel['experienceReports'][n
 
 export function renderObservationInboxPage(model: ObservationInboxViewModel, lang: Lang = DEFAULT_LANG): string {
   const {
-    experienceReports,
+    effectiveExperienceReports: experienceReports,
     skillChains,
     skillDerivedStandards,
     reviewState,
@@ -91,7 +91,7 @@ export function renderObservationInboxPage(model: ObservationInboxViewModel, lan
   const skillTimestampedInvocationCount = (skill: NonNullable<typeof experience>['skills'][number]): number =>
     skill.timestampedInvocationCount
       ?? (skill.firstSeen === '1970-01-01T00:00:00.000Z' ? 0 : skill.invocationCount);
-  const observationMetricRenderers = createObservationMetricRenderers({ experience, reviewState });
+  const observationMetricRenderers = createObservationMetricRenderers({ experience, reviewState, unappliedMetricAnnotations: model.unappliedMetricAnnotations });
   const observationSignalRenderers = createObservationSignalRenderers(lang);
   const observationSkillChainRenderers = createObservationSkillChainRenderers({
     experienceToolCountsBySkill,

--- a/src/studio/presentation/observation-inbox/experience-workspace-renderer.ts
+++ b/src/studio/presentation/observation-inbox/experience-workspace-renderer.ts
@@ -101,11 +101,6 @@ export function createObservationExperienceWorkspace({
   const {
     canonicalFeedbackSignalsForDisplay,
     compactRankedCountText,
-    displayAssistiveInference,
-    displayBasisCodes,
-    displayIndicatorsForSession,
-    displayPriority,
-    displayRuleFindings,
     formatAttributionSource,
     formatEntrypoint,
     metric,
@@ -191,7 +186,7 @@ export function createObservationExperienceWorkspace({
     ));
     const sourceMetadataHtml = renderOpenClawSourceMetadata(skill.sourceMetadataCounts);
     const hardRuleSession = (experience?.sessions ?? []).find((session) =>
-      session.skillName === skill.skillName && (displayIndicatorsForSession(session).hardRuleTextHitCount ?? 0) > 0
+      session.skillName === skill.skillName && (session.indicators.hardRuleTextHitCount ?? 0) > 0
     );
     // 旧版按钮挂的是 onclick="event.stopPropagation()"，
     // 这会阻止冒泡到 document 上的 [data-open-experience-session] 全局监听器，
@@ -228,11 +223,11 @@ export function createObservationExperienceWorkspace({
   const renderExperienceSessionRows = (sessions: ExperienceSessionSummary[], idPrefix: string): string => sessions.map((session, index) => {
     const detailId = `${idPrefix}-session-${index}`;
     const evidenceChain = session.evidenceChain ?? fallbackEvidenceChain(session);
-    const indicators = displayIndicatorsForSession(session);
-    const shownPriority = displayPriority(indicators);
-    const shownRuleFindings = displayRuleFindings(session, indicators);
-    const shownInference = displayAssistiveInference(indicators, session.assistiveInference);
-    const shownBasisCodes = displayBasisCodes(indicators);
+    const indicators = session.indicators;
+    const shownPriority = session.reviewPriority;
+    const shownRuleFindings = session.ruleFindings;
+    const shownInference = session.assistiveInference;
+    const shownBasisCodes = session.reviewBasisCodes;
     const pluginNames = session.pluginNames ?? [];
     const commandNames = session.commandNames ?? [];
     const attributionSources = session.attributionSources ?? [];
@@ -394,13 +389,13 @@ export function createObservationExperienceWorkspace({
   const experienceReviewFirstSessionCount = experience?.sessions.filter((session) => inboxResolvedPriority(session) === 'review_first').length ?? 0;
   const experienceSampleReviewSessionCount = experience?.sessions.filter((session) => inboxResolvedPriority(session) === 'sample_review').length ?? 0;
   const experienceHardRuleCount = experience?.sessions.reduce((sum, session) =>
-    sum + (displayIndicatorsForSession(session).hardRuleTextHitCount ?? 0), 0
+    sum + (session.indicators.hardRuleTextHitCount ?? 0), 0
   ) ?? 0;
   const experienceFirstHardRuleSession = experience?.sessions.find((session) =>
-    (displayIndicatorsForSession(session).hardRuleTextHitCount ?? 0) > 0
+    (session.indicators.hardRuleTextHitCount ?? 0) > 0
   );
   const experienceFirstReviewSession = experienceFirstHardRuleSession
-    ?? experience?.sessions.find((session) => displayPriority(displayIndicatorsForSession(session)) !== 'routine_sample');
+    ?? experience?.sessions.find((session) => session.reviewPriority !== 'routine_sample');
   const experienceInsightText = experienceReviewFirstSessionCount > 0
     ? `这次 trace 有 ${experienceReviewFirstSessionCount} 个优先复盘 session，建议先看异常证据。`
     : experienceHardRuleCount > 0
@@ -557,7 +552,7 @@ export function createObservationExperienceWorkspace({
 	      if (finding.level !== 'attention') continue;
 	      push(inboxAttentionFindingLabel(finding.ruleSource));
 	    }
-	    const indicators = displayIndicatorsForSession(session);
+	    const indicators = session.indicators;
 	    if (indicators.toolFailureCount > 0) push(inboxAttentionFindingLabel('tool_error_recovery'));
 	    if (indicators.userCorrectionCount > 0) push(inboxAttentionFindingLabel('user_correction'));
 	    if (indicators.userInterruptionCount > 0) push(inboxAttentionFindingLabel('user_interruption'));
@@ -706,7 +701,7 @@ export function createObservationExperienceWorkspace({
 	    const link = skill.sessionStory?.skillLinks?.find((l) => l.skillName === skill.skillName);
 	    const roleLabel = link ? inboxSkillRoleLabel(link.role) : '执行';
 	    const roleHelpKey = inboxSkillRoleHelpKey(link?.role ?? 'executor');
-	    const indicators = displayIndicatorsForSession(skill);
+	    const indicators = skill.indicators;
 	    const dur = observedSessionRange(skill);
 	    const startTime = sessionTimestampedInvocationCount(skill) > 0
         ? skill.startTimestamp.slice(5, 16).replace('T', ' ')
@@ -1055,7 +1050,7 @@ export function createObservationExperienceWorkspace({
 	    }
 	    const goalKeywords = inboxExtractGoalKeywords(skill.evidenceChain?.firstUserMessage?.snippet) || inboxLlmEnhancedGoalKeywords(skill.skillName);
 	    const chain = skillChains[skill.skillName];
-	    const displayIndicators = displayIndicatorsForSession(skill);
+	    const displayIndicators = skill.indicators;
 	    const hasGoalKeyword = goalKeywords.length > 0;
 	    const hasCompletionResult = displayIndicators.assistantDeliverySignalCount > 0;
 	    const hasDeliverableArtifact = displayIndicators.deliverableArtifactSignalCount > 0;
@@ -1212,7 +1207,7 @@ export function createObservationExperienceWorkspace({
       if (typeSuggestion) out.push(typeSuggestion);
       const typeFallbackSuggestion = inboxTypeFallbackSuggestion(resolved);
       if (typeFallbackSuggestion) out.push(typeFallbackSuggestion);
-      const indicators = displayIndicatorsForSession(skill);
+      const indicators = skill.indicators;
       const downstreamSignals = canonicalFeedbackSignalsForDisplay(skill).filter((signal) =>
         (signal.type === 'follow_up' || signal.type === 'interruption')
         && (signal.canonicalAttributions ?? signal.attributions ?? []).some((attribution) =>
@@ -1290,7 +1285,7 @@ export function createObservationExperienceWorkspace({
 	    }
 	    const chain = skillChains[skill.skillName];
 	    const findings = skill.reviewerReport?.findings ?? [];
-      const displayIndicators = displayIndicatorsForSession(skill);
+      const displayIndicators = skill.indicators;
 	    const hasFinding = (source: string): boolean => findings.some((finding) => finding.ruleSource === source);
 	    const storyAnswers = skill.sessionStory?.answers ?? [];
 	    const goalAnswer = storyAnswers.find((answer) => answer.key === 'goal_satisfaction');
@@ -1620,7 +1615,7 @@ export function createObservationExperienceWorkspace({
 	    const evidenceJumpId = `inbox-sec-evidence-${e(skill.id)}`;
 	    const toolDetail = inboxBuildToolDetail(skill);
 	    const toolFailureDetail = inboxBuildToolFailureDetail(skill);
-	    const indicators = displayIndicatorsForSession(skill);
+	    const indicators = skill.indicators;
 	    const runtimeModel = [
 	      skill.sourceMetadata?.provider,
 	      skill.sourceMetadata?.model,
@@ -1676,9 +1671,9 @@ export function createObservationExperienceWorkspace({
 	    </article>`;
 	  };
 	  const inboxRenderEvidence = (session: ExperienceSessionSummary, summaryText: string): string => {
-	    const indicators = displayIndicatorsForSession(session);
-	    const shownRuleFindings = displayRuleFindings(session, indicators);
-	    const shownInference = displayAssistiveInference(indicators, session.assistiveInference);
+	    const indicators = session.indicators;
+	    const shownRuleFindings = session.ruleFindings;
+	    const shownInference = session.assistiveInference;
 	    const evidenceChain = session.evidenceChain ?? fallbackEvidenceChain(session);
 	    const safeId = e(session.id);
 	    const evidenceClass = indicators.toolFailureCount > 0 ? 'is-attention' : 'is-neutral';
@@ -1708,7 +1703,7 @@ export function createObservationExperienceWorkspace({
 	  };
 	  const inboxRenderSessionContent = (cardSkillName: string, session: ExperienceSessionSummary, isActive: boolean): string => {
 	    const siblings = inboxSiblingsMap.get(session.sessionId) ?? [session];
-	    const indicators = displayIndicatorsForSession(session);
+	    const indicators = session.indicators;
 	    const safeId = e(session.id);
 	    const completionAttentionCount = (session.reviewerReport?.findings ?? []).filter((f) => f.level === 'attention').length;
 	    const completionSummaryText = completionAttentionCount > 0

--- a/src/studio/presentation/observation-inbox/metric-renderer.ts
+++ b/src/studio/presentation/observation-inbox/metric-renderer.ts
@@ -1,46 +1,19 @@
 import { e } from '../layout.js';
 import { incrementRecordCount } from '../../../shared/record-count.js';
 import {
-  hasAssistantDeliverableArtifactText,
-  hasAssistantDeliverySignalText,
-  hasUserHardRuleText,
-  isSyntheticUserMessageText,
-  isUserInteractionMetricText,
-  observationMetricAnnotationEntry,
+  INDICATOR_FOR_METRIC,
+  observationMetricAnnotationVerdict,
+  canonicalFeedbackSignalsForSession,
+  metricKeyForFeedbackSignal,
+  shouldIncludeDownstreamFeedbackForSession as shouldIncludeDownstreamFeedbackForDisplay,
+  type ExperienceProblemBucket,
+  type ExperienceProblemPattern,
+  type ExperienceProblemSignal,
+  type ObservationInboxViewModel,
+  type ObservationMetricKey,
+  type ExperienceSessionSummary,
+  type ExperienceFeedbackSignal,
 } from '../../../observability/inbox/view-model.js';
-import type {
-  ExperienceProblemBucket,
-  ExperienceProblemPattern,
-  ExperienceProblemSignal,
-  ObservationInboxViewModel,
-  ObservationMetricKey,
-} from '../../../observability/inbox/view-model.js';
-import {
-  findNegativeFeedbackMatches,
-  findPositiveFeedbackMatches,
-  findUserCorrectionMatches,
-  findUserGoalShiftMatches,
-  hasUserGoalShiftSignal,
-} from '../../../observability/inbox/feedback-projection.js';
-import type {
-  ExperienceAssistiveInference,
-  ExperienceAssistiveInferenceCode,
-  ExperienceEvidenceRef,
-  ExperienceFeedbackAttribution,
-  ExperienceFeedbackSignal,
-  ExperienceReviewBasisCode,
-  ExperienceReviewIndicators,
-  ExperienceReviewPriority,
-  ExperienceRuleFinding,
-  ExperienceRuleFindingCode,
-  ExperienceRuleFindingLevel,
-  ExperienceSessionSummary,
-  ExperienceTimelineEvent,
-} from '../../../observability/inbox/feedback-projection.js';
-import {
-  hasRepeatedExecutionSignal,
-  hasSelfCorrectionSignal,
-} from './timeline.js';
 
 export type IndicatorHelpKey =
   | 'userCorrection' | 'userInterruption' | 'userFollowUp' | 'negativeFeedback' | 'positiveFeedback' | 'userGoalShift' | 'hardRule' | 'selfCorrection' | 'repeatedExecution'
@@ -54,9 +27,11 @@ export type ObservationMetricRenderers = ReturnType<typeof createObservationMetr
 export function createObservationMetricRenderers({
   experience,
   reviewState,
+  unappliedMetricAnnotations,
 }: {
   readonly experience: ObservationInboxViewModel['experienceReports'][number] | undefined;
   readonly reviewState: ObservationInboxViewModel['reviewState'];
+  readonly unappliedMetricAnnotations: ObservationInboxViewModel['unappliedMetricAnnotations'];
 }) {
   const experienceSessionIdBySkillAndSession = new Map(
     (experience?.sessions ?? []).map((session) => [
@@ -389,367 +364,30 @@ export function createObservationMetricRenderers({
       return `<button type="button" class="problem-pattern-chip" data-no-rollup-click="1"${sessionId ? ` data-open-experience-session="${e(sessionId)}"` : ''}${tag ? ` data-open-timeline-tag="${e(tag)}"` : ''} title="${e(title)}"><span class="pattern-bucket">${e(problemBucketLabels[pattern.bucket])}</span><span class="pattern-key">${e(patternKeywordLabel(pattern))}</span><span class="pattern-count">${pattern.count} 次 / ${pattern.sessionCount} 个 session</span></button>`;
     }).join('')}</span></div>`;
   };
-  const ZERO_DISPLAY_INDICATORS: ExperienceReviewIndicators = {
-    userMessageCount: 0,
-    userFollowUpCount: 0,
-    userCorrectionCount: 0,
-    userInterruptionCount: 0,
-    sessionInterruptedCount: 0,
-    negativeFeedbackCount: 0,
-    positiveFeedbackCount: 0,
-    userGoalShiftCount: 0,
-    hardRuleTextHitCount: 0,
-	    assistantDeliverySignalCount: 0,
-	    deliverableArtifactSignalCount: 0,
-	    routerDownstreamCompleted: 0,
-	    routerDownstreamFailed: 0,
-	    selfCorrectionCount: 0,
-    repeatedExecutionCount: 0,
-    toolCallCount: 0,
-    toolFailureCount: 0,
-    toolCancelledCount: 0,
-    toolUnknownCount: 0,
-    highObservationCount: 0,
-    mediumObservationCount: 0,
-    hedgingCount: 0,
-    explicitMarkerCount: 0,
-  };
-  const USER_INTERRUPTION_DISPLAY_RE = /\[Request interrupted by user(?: for tool use)?\]|interrupted by user|用户中断/i;
-  const displayRegexMatches = (pattern: RegExp, value: string): boolean => {
-    pattern.lastIndex = 0;
-    return pattern.test(value);
-  };
-  const displayMetricVerdict = (event: ExperienceTimelineEvent, metricKey: ObservationMetricKey, metricScopeId?: string): 'confirmed' | 'rejected' | '' => {
-    const entry = observationMetricAnnotationEntry(
-      reviewState,
-      { ...event, metricScopeId },
-      metricKey,
-    );
-    return entry?.verdict === 'confirmed' || entry?.verdict === 'rejected' ? entry.verdict : '';
-  };
-  const displayMetricIsActive = (event: ExperienceTimelineEvent, metricKey: ObservationMetricKey, ruleDetected: boolean, metricScopeId?: string): boolean => {
-    const verdict = displayMetricVerdict(event, metricKey, metricScopeId);
-    if (verdict === 'confirmed') return true;
-    if (verdict === 'rejected') return false;
-    return ruleDetected;
-  };
-  const displayMetricCount = (event: ExperienceTimelineEvent, metricKey: ObservationMetricKey, ruleCount: number, metricScopeId?: string): number => {
-    const verdict = displayMetricVerdict(event, metricKey, metricScopeId);
-    if (verdict === 'confirmed') return Math.max(1, ruleCount);
-    if (verdict === 'rejected') return 0;
-    return ruleCount;
-  };
-  const shouldIncludeDownstreamFeedbackForDisplay = (session: ExperienceSessionSummary): boolean => {
-    const episodes = session.sessionStory?.episodes ?? [];
-    const segmentIds = new Set(episodes.flatMap((episode) =>
-      (episode.skillSegments ?? [])
-        .filter((segment) => segment.skillName === session.skillName)
-        .map((segment) => segment.id)
-    ));
-    if (segmentIds.size === 0) return false;
-    const ownSegments = episodes.flatMap((episode) => episode.skillSegments ?? [])
-      .filter((segment) => segment.skillName === session.skillName);
-    if (ownSegments.some((segment) =>
-      segment.skillType === 'router'
-      || segment.skillType === 'delegation'
-      || segment.episodeRole === 'router'
-      || segment.episodeRole === 'delegator'
-    )) return true;
-    return episodes.some((episode) =>
-      (episode.orchestrationEdges ?? []).some((edge) =>
-        Boolean(edge.parentSkillSegmentId && segmentIds.has(edge.parentSkillSegmentId))
-      )
-    );
-  };
-  const feedbackAttributionBelongsToDisplaySession = (
-    attribution: ExperienceFeedbackAttribution,
-    session: ExperienceSessionSummary,
-    includeDownstream = shouldIncludeDownstreamFeedbackForDisplay(session),
-  ): boolean =>
-    attribution.skillName === session.skillName
-    && (
-      attribution.attributionRole === 'primary_fault'
-      || includeDownstream && attribution.attributionRole === 'downstream_related'
-    );
-  const canonicalFeedbackSignalsForDisplay = (
-    session: ExperienceSessionSummary,
-    signalType?: ExperienceFeedbackSignal['type'],
-  ): ExperienceFeedbackSignal[] => {
-    const includeDownstream = shouldIncludeDownstreamFeedbackForDisplay(session);
-    return (session.sessionStory?.episodes?.flatMap((episode) => episode.feedbackSignals ?? []) ?? [])
-      .filter((signal) =>
-        (!signalType || signal.type === signalType)
-        && displayFeedbackSignalIsActive(signal, session)
-        && (signal.canonicalAttributions ?? signal.attributions ?? []).some((attribution) =>
-          feedbackAttributionBelongsToDisplaySession(attribution, session, includeDownstream)
-        )
-      );
-  };
-  const metricKeyForFeedbackSignal = (signal: ExperienceFeedbackSignal): ObservationMetricKey | undefined => {
-    if (signal.type === 'follow_up') return 'user_follow_up';
-    if (signal.type === 'correction') return 'user_correction';
-    if (signal.type === 'interruption') return 'user_interruption';
-    if (signal.type === 'frustration') return 'negative_feedback';
-    if (signal.type === 'positive') return 'positive_feedback';
-    return undefined;
-  };
-  const displayFeedbackSignalIsActive = (signal: ExperienceFeedbackSignal, session: ExperienceSessionSummary): boolean => {
-    const metricKey = metricKeyForFeedbackSignal(signal);
-    if (!metricKey) return true;
-    const verdict = displayMetricVerdict(signal.evidenceRef as ExperienceTimelineEvent, metricKey, session.id);
-    if (verdict === 'confirmed') return true;
-    if (verdict === 'rejected') return false;
-    return true;
-  };
-  const feedbackSignalTypeForMetric = (metricKey: ObservationMetricKey): ExperienceFeedbackSignal['type'] | undefined => {
-    if (metricKey === 'user_follow_up') return 'follow_up';
-    if (metricKey === 'user_correction') return 'correction';
-    if (metricKey === 'user_interruption') return 'interruption';
-    if (metricKey === 'negative_feedback') return 'frustration';
-    if (metricKey === 'positive_feedback') return 'positive';
-    return undefined;
-  };
-  const canonicalFeedbackCountsForDisplay = (session: ExperienceSessionSummary): Pick<ExperienceReviewIndicators, 'userFollowUpCount' | 'userCorrectionCount' | 'userInterruptionCount' | 'negativeFeedbackCount' | 'positiveFeedbackCount'> | undefined => {
-    const signals = session.sessionStory?.episodes?.flatMap((episode) => episode.feedbackSignals ?? []) ?? [];
-    if (signals.length === 0) return undefined;
-    const owned = canonicalFeedbackSignalsForDisplay(session);
-    return {
-      userFollowUpCount: owned.filter((signal) => signal.type === 'follow_up').length,
-      userCorrectionCount: owned.filter((signal) => signal.type === 'correction').length,
-      userInterruptionCount: owned.filter((signal) => signal.type === 'interruption').length,
-      negativeFeedbackCount: owned.filter((signal) => signal.type === 'frustration').length,
-      positiveFeedbackCount: owned.filter((signal) => signal.type === 'positive').length,
-    };
-  };
-  const displayIndicatorsForSession = (session: ExperienceSessionSummary): ExperienceReviewIndicators => {
-    const humanEvents = (session.timelinePreview ?? []).filter((event) => event.kind === 'user_message' && Boolean(event.snippet) && !isSyntheticUserMessageText(event.snippet ?? ''));
-    const interactionEvents = humanEvents.filter((event) => isUserInteractionMetricText(event.snippet ?? ''));
-    const canonicalFeedback = canonicalFeedbackCountsForDisplay(session);
-    return {
-      ...session.indicators,
-      userFollowUpCount: canonicalFeedback?.userFollowUpCount ?? interactionEvents.reduce((sum, event, index) => sum + (displayMetricIsActive(event, 'user_follow_up', index > 0 && !hasUserGoalShiftSignal(event.snippet ?? ''), session.id) ? 1 : 0), 0),
-      userCorrectionCount: canonicalFeedback?.userCorrectionCount ?? interactionEvents.reduce((sum, event) => sum + displayMetricCount(event, 'user_correction', findUserCorrectionMatches(event.snippet ?? '').length, session.id), 0),
-      userInterruptionCount: canonicalFeedback?.userInterruptionCount ?? interactionEvents.reduce((sum, event) => sum + (displayMetricIsActive(event, 'user_interruption', displayRegexMatches(USER_INTERRUPTION_DISPLAY_RE, event.snippet ?? ''), session.id) ? 1 : 0), 0),
-      negativeFeedbackCount: canonicalFeedback?.negativeFeedbackCount ?? interactionEvents.reduce((sum, event) => sum + displayMetricCount(event, 'negative_feedback', findNegativeFeedbackMatches(event.snippet ?? '').length), 0),
-      positiveFeedbackCount: canonicalFeedback?.positiveFeedbackCount ?? interactionEvents.reduce((sum, event) => sum + displayMetricCount(event, 'positive_feedback', findPositiveFeedbackMatches(event.snippet ?? '').length), 0),
-      userGoalShiftCount: interactionEvents.reduce((sum, event) => sum + displayMetricCount(event, 'user_goal_shift', findUserGoalShiftMatches(event.snippet ?? '').length, session.id), 0),
-      hardRuleTextHitCount: interactionEvents.reduce((sum, event) => sum + (displayMetricIsActive(event, 'hard_rule', hasUserHardRuleText(event.snippet ?? ''), session.id) ? 1 : 0), 0),
-      assistantDeliverySignalCount: (session.timelinePreview ?? []).reduce((sum, event) => sum + (displayMetricIsActive(event, 'completion_result', event.kind === 'assistant_message' && hasAssistantDeliverySignalText(event.fullText ?? event.snippet ?? '')) ? 1 : 0), 0),
-      deliverableArtifactSignalCount: (session.timelinePreview ?? []).reduce((sum, event) => sum + (displayMetricIsActive(event, 'deliverable_artifact', event.kind === 'assistant_message' && hasAssistantDeliverableArtifactText(event.fullText ?? event.snippet ?? '')) ? 1 : 0), 0),
-      selfCorrectionCount: (session.timelinePreview ?? []).reduce((sum, event) => sum + (displayMetricIsActive(event, 'self_correction', hasSelfCorrectionSignal(event)) ? 1 : 0), 0),
-      repeatedExecutionCount: (session.timelinePreview ?? []).reduce((sum, event) => sum + (displayMetricIsActive(event, 'repeated_execution', hasRepeatedExecutionSignal(event)) ? 1 : 0), 0),
-    };
-  };
+  const canonicalFeedbackSignalsForDisplay = (session: ExperienceSessionSummary, signalType?: ExperienceFeedbackSignal['type']) =>
+    canonicalFeedbackSignalsForSession(session, reviewState).filter((signal) => !signalType || signal.type === signalType);
+  const displayIndicatorsBySkill = new Map((experience?.skills ?? []).map((skill) => [skill.skillName, skill.indicators]));
   const sessionMetricSourceTitle = (session: ExperienceSessionSummary, metricKey: ObservationMetricKey, label: string): string => {
-    const canonicalType = feedbackSignalTypeForMetric(metricKey);
-    if (canonicalType) {
-      const signals = canonicalFeedbackSignalsForDisplay(session, canonicalType);
-      if (signals.length > 0) {
-        const rows = signals.slice(0, 8).map((signal) => {
-          const role = (signal.canonicalAttributions ?? signal.attributions ?? [])
-            .filter((attribution) => feedbackAttributionBelongsToDisplaySession(attribution, session))
-            .map((attribution) => attribution.attributionRole === 'downstream_related' ? '下游调用链路' : '直接归因')
-            .find(Boolean) ?? '归因命中';
-          return `#${signal.evidenceRef.messageIndex ?? '—'} ${role}：${signal.text.slice(0, 80).replace(/\s+/g, ' ')}`;
-        });
-        return [
-          `${label}：最终计入 ${signals.length}`,
-          '来源：任务执行归因模型',
-          `证据：${rows.join('；')}`,
-          '点击原文回溯中的同名标签，可以定位到这些 evidenceRef。',
-        ].join('\n');
-      }
-    }
-    const humanEvents = (session.timelinePreview ?? []).filter((event) => event.kind === 'user_message' && Boolean(event.snippet) && !isSyntheticUserMessageText(event.snippet ?? ''));
-    const rows: string[] = [];
-    let ruleCount = 0;
+    const field = INDICATOR_FOR_METRIC[metricKey as keyof typeof INDICATOR_FOR_METRIC];
+    const count = field ? session.indicators[field] : undefined;
+    const signals = canonicalFeedbackSignalsForSession(session, reviewState)
+      .filter((signal) => metricKeyForFeedbackSignal(signal) === metricKey);
+    const refs = signals.length > 0 ? signals.map((signal) => signal.evidenceRef) : session.timelinePreview;
     let confirmed = 0;
     let rejected = 0;
-    let finalCount = 0;
-    let interactionIndex = 0;
-    humanEvents.forEach((event) => {
-      const text = event.snippet ?? '';
-      if (!isUserInteractionMetricText(text)) return;
-      const effectiveIndex = interactionIndex;
-      interactionIndex += 1;
-      const rule = metricKey === 'user_follow_up'
-        ? (effectiveIndex > 0 && !hasUserGoalShiftSignal(text) ? 1 : 0)
-        : metricKey === 'user_correction'
-          ? findUserCorrectionMatches(text).length
-          : metricKey === 'user_interruption'
-            ? (displayRegexMatches(USER_INTERRUPTION_DISPLAY_RE, text) ? 1 : 0)
-            : metricKey === 'negative_feedback'
-              ? findNegativeFeedbackMatches(text).length
-              : metricKey === 'positive_feedback'
-                ? findPositiveFeedbackMatches(text).length
-                : metricKey === 'hard_rule'
-                  ? (hasUserHardRuleText(text) ? 1 : 0)
-                  : metricKey === 'user_goal_shift'
-                    ? findUserGoalShiftMatches(text).length
-                    : 0;
-      const verdict = displayMetricVerdict(event, metricKey, session.id);
-      const finalValue = displayMetricCount(event, metricKey, rule, session.id);
-      ruleCount += rule;
+    for (const ref of refs) {
+      const verdict = observationMetricAnnotationVerdict(reviewState, { ...ref, metricScopeId: session.id }, metricKey);
       if (verdict === 'confirmed') confirmed += 1;
       if (verdict === 'rejected') rejected += 1;
-      finalCount += finalValue;
-      if (rule > 0 || verdict) {
-        rows.push(`#${event.messageIndex ?? '—'} ${verdict === 'confirmed' ? '人工同意' : verdict === 'rejected' ? '人工反对' : '规则命中'}：${text.slice(0, 80).replace(/\s+/g, ' ')}`);
-      }
-    });
+    }
     return [
-      `${label}：最终计入 ${finalCount}`,
-      `规则命中 ${ruleCount}，人工同意 ${confirmed}，人工反对 ${rejected}`,
-      rows.length > 0 ? `来源：${rows.join('；')}` : '来源：无',
-      '点击按钮查看指标定义；人工反对只扣掉对应消息，不会自动扣掉其它来源。',
+      `${label}：最终计入 ${count ?? '未记录'}`,
+      unappliedMetricAnnotations[session.id]?.includes(metricKey)
+        ? '证据不完整：该指标的人工标注尚未应用，当前保留原始报告计数。'
+        : '来源：领域有效观测投影；原始报告与人工审阅分别保留。',
+      `人工同意 ${confirmed}，人工反对 ${rejected}`,
+      signals.length > 0 ? `证据：${signals.slice(0, 8).map((signal) => signal.text.slice(0, 80)).join('；')}` : '预览不是完整计数来源；证据不完整时保留报告指标。',
     ].join('\n');
-  };
-  const displayIndicatorsBySkill = new Map<string, ExperienceReviewIndicators>();
-  for (const session of experience?.sessions ?? []) {
-    const current = displayIndicatorsBySkill.get(session.skillName) ?? { ...ZERO_DISPLAY_INDICATORS };
-    const next = displayIndicatorsForSession(session);
-    displayIndicatorsBySkill.set(session.skillName, {
-      userMessageCount: current.userMessageCount + next.userMessageCount,
-      userFollowUpCount: current.userFollowUpCount + next.userFollowUpCount,
-      userCorrectionCount: current.userCorrectionCount + next.userCorrectionCount,
-      userInterruptionCount: current.userInterruptionCount + next.userInterruptionCount,
-      sessionInterruptedCount: current.sessionInterruptedCount + (next.sessionInterruptedCount ?? 0),
-      negativeFeedbackCount: current.negativeFeedbackCount + next.negativeFeedbackCount,
-      positiveFeedbackCount: current.positiveFeedbackCount + next.positiveFeedbackCount,
-      userGoalShiftCount: current.userGoalShiftCount + next.userGoalShiftCount,
-      hardRuleTextHitCount: current.hardRuleTextHitCount + next.hardRuleTextHitCount,
-	      assistantDeliverySignalCount: current.assistantDeliverySignalCount + (next.assistantDeliverySignalCount ?? 0),
-	      deliverableArtifactSignalCount: current.deliverableArtifactSignalCount + (next.deliverableArtifactSignalCount ?? 0),
-	      routerDownstreamCompleted: current.routerDownstreamCompleted + (next.routerDownstreamCompleted ?? 0),
-	      routerDownstreamFailed: current.routerDownstreamFailed + (next.routerDownstreamFailed ?? 0),
-	      selfCorrectionCount: current.selfCorrectionCount + (next.selfCorrectionCount ?? 0),
-      repeatedExecutionCount: current.repeatedExecutionCount + (next.repeatedExecutionCount ?? 0),
-      toolCallCount: current.toolCallCount + next.toolCallCount,
-      toolFailureCount: current.toolFailureCount + next.toolFailureCount,
-      toolCancelledCount: (current.toolCancelledCount ?? 0) + (next.toolCancelledCount ?? 0),
-      toolUnknownCount: (current.toolUnknownCount ?? 0) + (next.toolUnknownCount ?? 0),
-      highObservationCount: current.highObservationCount + next.highObservationCount,
-      mediumObservationCount: current.mediumObservationCount + next.mediumObservationCount,
-      hedgingCount: current.hedgingCount + next.hedgingCount,
-      explicitMarkerCount: current.explicitMarkerCount + next.explicitMarkerCount,
-    });
-  }
-  const displayBasisCodes = (indicators: ExperienceReviewIndicators): ExperienceReviewBasisCode[] => {
-    const codes: ExperienceReviewBasisCode[] = [];
-    if (indicators.highObservationCount > 0) codes.push('has_high_observation');
-    if (indicators.mediumObservationCount > 0) codes.push('has_medium_observation');
-    if (indicators.userCorrectionCount > 0) codes.push('user_correction');
-    if (indicators.userInterruptionCount > 0) codes.push('user_interruption');
-    if (indicators.sessionInterruptedCount > 0) codes.push('session_interrupted');
-    if (indicators.negativeFeedbackCount > 0) codes.push('negative_feedback');
-    if (indicators.hardRuleTextHitCount > 0) codes.push('hard_rule_text_hit');
-    if (indicators.toolFailureCount > 0) codes.push('tool_failure');
-    if (indicators.hedgingCount > 0) codes.push('hedging_signal');
-    if (indicators.explicitMarkerCount > 0) codes.push('explicit_marker');
-    return codes;
-  };
-  const displayPriority = (indicators: ExperienceReviewIndicators): ExperienceReviewPriority => {
-    if (indicators.highObservationCount > 0 || indicators.userCorrectionCount > 0 || indicators.userInterruptionCount > 0 || indicators.sessionInterruptedCount > 0 || indicators.negativeFeedbackCount > 0) return 'review_first';
-    if (indicators.mediumObservationCount > 0 || indicators.toolFailureCount > 0 || indicators.hedgingCount > 0 || indicators.explicitMarkerCount > 0 || indicators.hardRuleTextHitCount > 0) return 'sample_review';
-    return 'routine_sample';
-  };
-  const displayInferenceBasisCodes = (indicators: ExperienceReviewIndicators): ExperienceRuleFindingCode[] => {
-    const codes: ExperienceRuleFindingCode[] = [];
-    if (indicators.highObservationCount > 0) codes.push('high_observation_seen');
-    if (indicators.userCorrectionCount > 0) codes.push('user_correction_seen');
-    if (indicators.userInterruptionCount > 0) codes.push('user_interruption_seen');
-    if (indicators.sessionInterruptedCount > 0) codes.push('session_interrupted_seen');
-    if (indicators.negativeFeedbackCount > 0) codes.push('negative_feedback_seen');
-    if (indicators.toolFailureCount > 0) codes.push('tool_failure_seen');
-    if (indicators.mediumObservationCount > 0) codes.push('medium_observation_seen');
-    if (indicators.hedgingCount > 0) codes.push('hedging_seen');
-    if (indicators.explicitMarkerCount > 0) codes.push('explicit_marker_seen');
-    if (indicators.hardRuleTextHitCount > 0) codes.push('hard_rule_seen');
-    if (indicators.positiveFeedbackCount > 0) codes.push('positive_feedback_seen');
-    if (indicators.userGoalShiftCount > 0) codes.push('user_goal_shift_seen');
-    return codes;
-  };
-  const displayAssistiveInference = (
-    indicators: ExperienceReviewIndicators,
-    fallback?: ExperienceAssistiveInference,
-  ): ExperienceAssistiveInference => {
-    const basisRuleCodes = displayInferenceBasisCodes(indicators);
-    const code: ExperienceAssistiveInferenceCode =
-      indicators.highObservationCount > 0 || indicators.userCorrectionCount > 0 || indicators.userInterruptionCount > 0 || indicators.sessionInterruptedCount > 0 || indicators.negativeFeedbackCount > 0
-        ? 'review_recommended'
-        : indicators.mediumObservationCount > 0 || indicators.toolFailureCount > 0 || indicators.hedgingCount > 0 || indicators.explicitMarkerCount > 0 || indicators.hardRuleTextHitCount > 0
-          ? 'sample_recommended'
-          : indicators.positiveFeedbackCount > 0
-            ? 'positive_signal_observed'
-            : indicators.userGoalShiftCount > 0
-              ? 'user_switched_topic_neutral'
-              : 'no_obvious_issue_from_rules';
-    return {
-      mode: 'deterministic_rules_only',
-      code,
-      confidence: fallback?.confidence ?? 'medium',
-      basisRuleCodes,
-      cautionCodes: fallback?.cautionCodes ?? ['no_llm_judge', 'rule_only'],
-      evidenceRefs: fallback?.evidenceRefs ?? [],
-    };
-  };
-  const displayRuleFindings = (
-    session: ExperienceSessionSummary,
-    indicators: ExperienceReviewIndicators,
-  ): ExperienceRuleFinding[] => {
-    const old = session.ruleFindings ?? [];
-    const oldByCode = new Map(old.map((finding) => [finding.code, finding]));
-    const next: ExperienceRuleFinding[] = [];
-    const refsForCode = (code: ExperienceRuleFindingCode): ExperienceEvidenceRef[] | undefined => {
-      const signalType =
-        code === 'user_correction_seen' ? 'correction'
-        : code === 'user_interruption_seen' ? 'interruption'
-        : code === 'negative_feedback_seen' ? 'frustration'
-        : code === 'positive_feedback_seen' ? 'positive'
-        : undefined;
-      if (!signalType) return undefined;
-      const refs = canonicalFeedbackSignalsForDisplay(session, signalType).map((signal) => signal.evidenceRef);
-      return refs.length > 0 ? refs : undefined;
-    };
-    const push = (code: ExperienceRuleFindingCode, level: ExperienceRuleFindingLevel, count: number): void => {
-      if (count <= 0) return;
-      const previous = oldByCode.get(code);
-      next.push({ code, level, count, evidenceRefs: refsForCode(code) ?? previous?.evidenceRefs ?? [] });
-    };
-    push('high_observation_seen', 'attention', indicators.highObservationCount);
-    push('user_correction_seen', 'attention', indicators.userCorrectionCount);
-    push('user_interruption_seen', 'attention', indicators.userInterruptionCount);
-    push('session_interrupted_seen', 'attention', indicators.sessionInterruptedCount);
-    push('negative_feedback_seen', 'attention', indicators.negativeFeedbackCount);
-    push('tool_failure_seen', 'sample', indicators.toolFailureCount);
-    push('medium_observation_seen', 'sample', indicators.mediumObservationCount);
-    push('hedging_seen', 'sample', indicators.hedgingCount);
-    push('explicit_marker_seen', 'sample', indicators.explicitMarkerCount);
-    push('hard_rule_seen', 'sample', indicators.hardRuleTextHitCount);
-    push('positive_feedback_seen', 'normal', indicators.positiveFeedbackCount);
-    push('user_goal_shift_seen', 'normal', indicators.userGoalShiftCount);
-    for (const finding of old) {
-      if ([
-        'high_observation_seen',
-        'user_correction_seen',
-        'user_interruption_seen',
-        'session_interrupted_seen',
-        'negative_feedback_seen',
-        'tool_failure_seen',
-        'medium_observation_seen',
-        'hedging_seen',
-        'explicit_marker_seen',
-        'hard_rule_seen',
-        'positive_feedback_seen',
-        'user_goal_shift_seen',
-        'no_priority_signal',
-      ].includes(finding.code)) continue;
-      next.push(finding);
-    }
-    if (next.filter((finding) => finding.level !== 'normal').length === 0) {
-      next.push({ code: 'no_priority_signal', level: 'normal', count: 1, evidenceRefs: [] });
-    }
-    return next;
   };
   return {
     confidenceHeaderHelp,
@@ -774,12 +412,7 @@ export function createObservationMetricRenderers({
     renderSkillProblemPatterns,
     shouldIncludeDownstreamFeedbackForDisplay,
     canonicalFeedbackSignalsForDisplay,
-    displayIndicatorsForSession,
     sessionMetricSourceTitle,
     displayIndicatorsBySkill,
-    displayBasisCodes,
-    displayPriority,
-    displayAssistiveInference,
-    displayRuleFindings,
   };
 }

--- a/test/architecture/import-boundaries.test.ts
+++ b/test/architecture/import-boundaries.test.ts
@@ -254,7 +254,6 @@ const RULES: ForbiddenRule[] = [
       'studio/presentation/observation-inbox/experience-workspace-renderer.ts::observability/inbox/feedback-projection.ts',
       'studio/presentation/observation-inbox/helpers.ts::observability/inbox/feedback-projection.ts',
       'studio/presentation/observation-inbox/metric-renderer.ts::observability/inbox/view-model.ts',
-      'studio/presentation/observation-inbox/metric-renderer.ts::observability/inbox/feedback-projection.ts',
       'studio/presentation/observation-inbox/page-renderer.ts::observability/inbox/view-model.ts',
       'studio/presentation/observation-inbox/process-workspace-renderer.ts::observability/inbox/view-model.ts',
       'studio/presentation/observation-inbox/review-renderer.ts::observability/inbox/view-model.ts',

--- a/test/observability/inbox/_helpers.ts
+++ b/test/observability/inbox/_helpers.ts
@@ -1,23 +1,13 @@
 import type { ObservationInboxItem } from '../../../src/observability/inbox/index.js';
-import {
-  resolveObservationReviewSession,
-  type ResolvedObservationReviewSession,
-} from '../../../src/observability/inbox/resolved-review.js';
+import { projectEffectiveObservationReview } from '../../../src/observability/inbox/effective-review.js';
 import type {
   ExperienceChecklistItem,
   ObservationExperienceReport,
   ObservationReviewState,
 } from '../../../src/observability/experience.js';
 
-export function resolvedReviewSessionsForFixture(
-  experience: ObservationExperienceReport,
-  reviewState: ObservationReviewState,
-): Record<string, ResolvedObservationReviewSession> {
-  return Object.fromEntries(experience.sessions.map((session) => [session.id, resolveObservationReviewSession({
-    session,
-    enhancedReview: undefined,
-    reviewState,
-  })]));
+export function reviewProjectionForFixture(experience: ObservationExperienceReport, reviewState: ObservationReviewState) {
+  return projectEffectiveObservationReview([experience], reviewState);
 }
 
 export function businessActionTag(name: string, text: string): string {

--- a/test/observability/inbox/effective-review.test.ts
+++ b/test/observability/inbox/effective-review.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, it } from 'vitest';
+import { buildObservationInboxReport, saveObservationInboxReport } from '../../../src/observability/inbox/index.js';
+import { projectEffectiveObservationReview } from '../../../src/observability/inbox/effective-review.js';
+import { buildObservationInboxViewModel } from '../../../src/observability/inbox/view-model.js';
+import { observationMetricAnnotationTargetId, updateObservationReviewState } from '../../../src/observability/inbox/review-state.js';
+import { ZERO_INDICATORS } from '../../../src/observability/experience/report-derivations.js';
+import type { ObservationExperienceReport } from '../../../src/observability/experience.js';
+import type { ObservationReviewState } from '../../../src/observability/inbox/review-state.js';
+import ObserveInbox from '../../../src/cli/commands/observe/inbox.js';
+import { runCommand } from '../../helpers/run-command.js';
+import { createReportServer } from '../../../src/studio/http/report-server.js';
+import { renderObservationInboxPage } from '../../../src/studio/presentation/observation-inbox-renderer.js';
+
+const emptyReviewState: ObservationReviewState = {
+  kind: 'observe-review-state', schemaVersion: 2,
+  updatedAt: '2026-05-10T00:00:00.000Z', entries: {},
+};
+
+describe('effective observation review', () => {
+  const root = mkdtempSync(join(tmpdir(), 'omk-effective-review-'));
+  let report: ReturnType<typeof buildObservationInboxReport>;
+  beforeAll(() => {
+    const records = [
+      { type: 'user', uuid: 'u1', parentUuid: null, sessionId: 's1', timestamp: '2026-05-01T00:00:00.000Z', cwd: root, message: { role: 'user', content: '<command-name>/audit</command-name>\n请检查这个方案，不要遗漏证据。' } },
+      { type: 'assistant', uuid: 'a1', parentUuid: 'u1', sessionId: 's1', timestamp: '2026-05-01T00:00:01.000Z', cwd: root, message: { role: 'assistant', content: [{ type: 'text', text: '已完成，结果在 report.md。' }] } },
+      { type: 'user', uuid: 'u2', parentUuid: 'a1', sessionId: 's1', timestamp: '2026-05-01T00:00:02.000Z', cwd: root, message: { role: 'user', content: '不对，请重新检查。' } },
+      { type: 'assistant', uuid: 'a2', parentUuid: 'u2', sessionId: 's1', timestamp: '2026-05-01T00:00:03.000Z', cwd: root, message: { role: 'assistant', content: [{ type: 'text', text: '已修正，结果在 report.md。' }] } },
+    ];
+    const path = join(root, 'trace.jsonl');
+    writeFileSync(path, records.map((record) => JSON.stringify(record)).join('\n'));
+    report = buildObservationInboxReport(path);
+    assert.ok(report.experience?.sessions.length);
+  });
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  it.each([
+    [{ userCorrectionCount: 1 }, 'sample_review'],
+    [{ toolFailureCount: 3, toolCallCount: 3 }, 'review_first'],
+    [{ routerDownstreamFailed: 2 }, 'review_first'],
+    [{ explicitMarkerCount: 2 }, 'review_first'],
+  ] as const)('uses weighted domain priority for %j', (counts, priority) => {
+    const raw = structuredClone(report.experience!);
+    const session = raw.sessions[0];
+    session.indicators = { ...ZERO_INDICATORS, ...counts };
+    session.sessionStory = undefined;
+    session.reviewerReport = undefined;
+    session.timelinePreview = [];
+    session.fullSessionTimeline = [];
+    session.attributedEventIds = [];
+    const before = JSON.stringify(raw);
+    const view = projectEffectiveObservationReview([raw], emptyReviewState);
+    assert.equal(view.effectiveExperienceReports[0].sessions[0].reviewPriority, priority);
+    assert.equal(view.resolvedReviewSessions[session.id].priority, priority);
+    assert.deepEqual(view.effectiveExperienceReports[0].sessions[0].indicators, session.indicators);
+    assert.equal(JSON.stringify(raw), before);
+  });
+
+  it('applies a rejected canonical signal once and preserves raw evidence', () => {
+    const raw = report.experience!;
+    const session = raw.sessions[0];
+    const event = session.fullSessionTimeline.find((event) => event.messageUuid === 'u2' && event.kind === 'user_message');
+    assert.ok(event);
+    const state = updateObservationReviewState(join(root, 'canonical'), {
+      targetType: 'evidence_metric',
+      targetId: observationMetricAnnotationTargetId({ ...event, metricScopeId: session.id }, 'user_correction'),
+      metricKey: 'user_correction', metricScopeId: session.id, verdict: 'rejected',
+    }, '2026-05-10T00:00:00.000Z');
+    const before = JSON.stringify(raw);
+    assert.ok(projectEffectiveObservationReview([raw], emptyReviewState).effectiveExperienceReports[0].sessions[0].indicators.userCorrectionCount > 0);
+    const first = projectEffectiveObservationReview([raw], state);
+    const second = projectEffectiveObservationReview(first.effectiveExperienceReports, state);
+    assert.equal(first.effectiveExperienceReports[0].sessions[0].indicators.userCorrectionCount, 0);
+    assert.deepEqual(second.effectiveExperienceReports[0].sessions[0].indicators, first.effectiveExperienceReports[0].sessions[0].indicators);
+    assert.equal(JSON.stringify(raw), before);
+  });
+
+  it('does not turn a truncated preview into zero counts', () => {
+    const raw = structuredClone(report.experience!);
+    const session = raw.sessions[0];
+    session.sessionStory = undefined;
+    session.reviewerReport = undefined;
+    session.indicators.hardRuleTextHitCount = 4;
+    const event = session.timelinePreview.find((event) => event.kind === 'user_message');
+    assert.ok(event);
+    session.fullSessionTimeline = [];
+    session.attributedEventIds = ['missing-event'];
+    const state = updateObservationReviewState(join(root, 'partial'), {
+      targetType: 'evidence_metric',
+      targetId: observationMetricAnnotationTargetId({ ...event, metricScopeId: session.id }, 'hard_rule'),
+      metricKey: 'hard_rule', metricScopeId: session.id, verdict: 'rejected',
+    }, '2026-05-10T00:00:00.000Z');
+    const view = projectEffectiveObservationReview([raw], state);
+    assert.equal(view.effectiveExperienceReports[0].sessions[0].indicators.hardRuleTextHitCount, 4);
+    assert.ok(view.unappliedMetricAnnotations[session.id].includes('hard_rule'));
+  });
+
+  it.each([false, true])('shares the projection across CLI JSON, HTTP and HTML with rejected annotation=%s', async (rejected) => {
+    const observationsDir = join(root, `shared-${rejected}`);
+    const persisted = saveObservationInboxReport(report, observationsDir);
+    const before = readFileSync(persisted, 'utf-8');
+    if (rejected) {
+      const session = report.experience!.sessions[0];
+      const event = session.fullSessionTimeline.find((event) => event.messageUuid === 'u2' && event.kind === 'user_message');
+      assert.ok(event);
+      updateObservationReviewState(observationsDir, {
+        targetType: 'evidence_metric',
+        targetId: observationMetricAnnotationTargetId({ ...event, metricScopeId: session.id }, 'user_correction'),
+        metricKey: 'user_correction', metricScopeId: session.id, verdict: 'rejected',
+      }, '2026-05-10T00:00:00.000Z');
+    }
+    const expected = buildObservationInboxViewModel(observationsDir, { skill: 'audit' });
+    const cli = await runCommand(ObserveInbox, ['--input-dir', observationsDir, '--skill', 'audit', '--json']);
+    const json = JSON.parse(cli.stdout) as { effectiveExperienceReports: ObservationExperienceReport[] };
+    assert.deepEqual(json.effectiveExperienceReports, JSON.parse(JSON.stringify(expected.effectiveExperienceReports)));
+    const server = createReportServer({ port: 0, observationsDir, analysesDir: join(root, 'analyses'), doctorsDir: join(root, 'doctors') });
+    try {
+      const url = await server.start();
+      const api = await fetch(`${url}/api/observe-inbox/view?skill=audit`);
+      assert.equal(api.status, 200);
+      const apiView = await api.json() as { effectiveExperienceReports: ObservationExperienceReport[] };
+      assert.deepEqual(apiView.effectiveExperienceReports, json.effectiveExperienceReports);
+      const html = await fetch(`${url}/observe-inbox?skill=audit&lang=zh`);
+      assert.equal(await html.text(), renderObservationInboxPage(expected, 'zh'));
+    } finally {
+      await server.stop();
+    }
+    assert.equal(readFileSync(persisted, 'utf-8'), before);
+  });
+});

--- a/test/observability/inbox/experience-report.test.ts
+++ b/test/observability/inbox/experience-report.test.ts
@@ -16,7 +16,7 @@ import {
   renderFeedbackAttributionLabel,
   renderObservationInboxPage,
 } from '../../../src/studio/presentation/observation-inbox-renderer.js';
-import { resolvedReviewSessionsForFixture } from './_helpers.js';
+import { reviewProjectionForFixture } from './_helpers.js';
 
 describe('observe inbox - experience report', () => {
   it('fails closed instead of throwing when persisted aggregates overflow', () => {
@@ -490,7 +490,7 @@ describe('observe inbox - experience report', () => {
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       },
-      resolvedReviewSessions: resolvedReviewSessionsForFixture(experience, {
+      ...reviewProjectionForFixture(experience, {
         kind: 'observe-review-state',
         schemaVersion: 2,
         updatedAt: '2026-05-01T00:00:00.000Z',

--- a/test/observability/inbox/signal-detection.test.ts
+++ b/test/observability/inbox/signal-detection.test.ts
@@ -36,7 +36,7 @@ import {
   observationReviewStateKey,
 } from '../../../src/observability/inbox/review-state.js';
 import { renderObservationInboxPage } from '../../../src/studio/presentation/observation-inbox-renderer.js';
-import { businessActionTag, checklistItem, resolvedReviewSessionsForFixture } from './_helpers.js';
+import { businessActionTag, checklistItem, reviewProjectionForFixture } from './_helpers.js';
 
 describe('observe inbox - signal detection', () => {
   it('does not count embedded words as user correction signals', () => {
@@ -351,7 +351,7 @@ describe('observe inbox - signal detection', () => {
       reportCount: 1,
       latestSeenLabel: '2026-05-10 00:00:02',
       reviewState,
-      resolvedReviewSessions: resolvedReviewSessionsForFixture(annotatedReport.experience!, reviewState),
+      ...reviewProjectionForFixture(annotatedReport.experience!, reviewState),
     });
     assert.match(rendered, /<span class="inbox-answer-check is-(?:detected|absent)"[^>]*>[\s\S]*(?:没给可点开的产物|给了可点开的产物|会话进行中)/);
   });

--- a/test/observability/inbox/trace-ingestion.test.ts
+++ b/test/observability/inbox/trace-ingestion.test.ts
@@ -11,7 +11,7 @@ import {
   saveObservationInboxReport,
 } from '../../../src/observability/inbox/index.js';
 import { renderObservationInboxPage } from '../../../src/studio/presentation/observation-inbox-renderer.js';
-import { baseItem, businessActionTag, businessChannel, resolvedReviewSessionsForFixture } from './_helpers.js';
+import { baseItem, businessActionTag, businessChannel, reviewProjectionForFixture } from './_helpers.js';
 
 describe('observe inbox - trace ingestion', () => {
   it('skips unsupported experience reports without changing files or hiding current inbox v2', () => {
@@ -412,7 +412,7 @@ describe('observe inbox - trace ingestion', () => {
         updatedAt: '2026-05-01T00:00:00.000Z',
         entries: {},
       },
-      resolvedReviewSessions: resolvedReviewSessionsForFixture(experience, {
+      ...reviewProjectionForFixture(experience, {
         kind: 'observe-review-state',
         schemaVersion: 2,
         updatedAt: '2026-05-01T00:00:00.000Z',


### PR DESCRIPTION
## 用户影响

解决 #767 的 B2。有效指标、依据、规则发现、辅助推断、会话优先级和 skill 汇总统一由 observability 投影，Studio 不再从预览窗口重新定义计数和分档。四组已复现分歧使用领域加权分档固定，保留领域审阅发现与显式 LLM／人工审阅的覆盖关系。

人工反对按规范化反馈归因应用；缺失或截断预览不视为零。无法安全重放的已定位标注会保留原计数，并通过 `unappliedMetricAnnotations` 和页面提示说明限制。原始报告、轨迹与审阅状态不被派生视图覆盖。

CLI JSON 增加有效视图字段，新增 `/api/observe-inbox/view` 提供同一投影，原有 API 列表响应保持不变。中英文说明明确区分原始证据与派生视图，客户端应按需读取新增字段，不将有效报告写回原始存储。

## 测量与兼容性

不改变 prompt 字节、持久化统计口径或公开测量 Schema identity。有效复盘优先级只是观测审阅排序，不是 skill 的因果评测结果。原字段与原始存储保留，无历史报告迁移。

本轮源码净减少 189 行，测试净增加 122 行，文档净增加 34 行，总计净减少 33 行。消除展示层的第二套指标、分档、依据和规则推断维护点，同时清理一条失效架构白名单，未新增豁免。

## 审查与验证

自主 CR：No findings。首次完整门禁识别的 facade 越界与失效白名单已修复，最终复查无 P0～P2。

最终 `yarn ci` 通过，335 个测试文件、3622 项测试。新增回归覆盖四组分档反例、负向标注幂等、证据缺失，以及有／无标注时 CLI／API／HTML 一致性和原始文件不变。

打包产物在独立临时目录安装，实际 CLI、新旧 HTTP API、HTML 入口与原始存储不变均通过；使用系统分配端口，临时安装已清理。远端 CI 由本 PR 记录。

Refs #767