### PR TITLE
refactor(eval-workflows): 统一宿主只读 Map 快照

### DIFF
--- a/src/eval-workflows/hosts/adapters/claude/resources.ts
+++ b/src/eval-workflows/hosts/adapters/claude/resources.ts
@@ -1,3 +1,4 @@
+import { readonlyMapSnapshot } from '../shared/readonly-map-snapshot.js';
 import { openNodeTrialWorkspace } from '../shared/trial-workspace.js';
 import { lstat, mkdtemp, readFile, rm } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
@@ -516,26 +517,6 @@ function mockReturn(profile: ClaudeResourceProjectionProfile, value: unknown): M
     return value as MockReturn;
   }
   fail(profile, 'MOCK_PAYLOAD_INVALID', 'mock payload must be a string or JSON object.');
-}
-
-function readonlyMapSnapshot<Key, Value>(source: ReadonlyMap<Key, Value>): ReadonlyMap<Key, Value> {
-  const snapshot = new Map(source);
-  const view: ReadonlyMap<Key, Value> = Object.freeze({
-    get size() { return snapshot.size; },
-    get(key: Key) { return snapshot.get(key); },
-    has(key: Key) { return snapshot.has(key); },
-    keys() { return snapshot.keys(); },
-    values() { return snapshot.values(); },
-    entries() { return snapshot.entries(); },
-    [Symbol.iterator]() { return snapshot[Symbol.iterator](); },
-    forEach(
-      callback: (value: Value, key: Key, map: ReadonlyMap<Key, Value>) => void,
-      thisArg?: unknown,
-    ) {
-      snapshot.forEach((value, key) => callback.call(thisArg, value, key, view));
-    },
-  });
-  return view;
 }
 
 async function readMockPayload(

--- a/src/eval-workflows/hosts/adapters/shared/readonly-map-snapshot.ts
+++ b/src/eval-workflows/hosts/adapters/shared/readonly-map-snapshot.ts
@@ -1,0 +1,20 @@
+/** Capture map membership at each host boundary without exposing mutable Map methods. */
+export function readonlyMapSnapshot<Key, Value>(source: ReadonlyMap<Key, Value>): ReadonlyMap<Key, Value> {
+  const snapshot = new Map(source);
+  const view: ReadonlyMap<Key, Value> = Object.freeze({
+    get size() { return snapshot.size; },
+    get(key: Key) { return snapshot.get(key); },
+    has(key: Key) { return snapshot.has(key); },
+    keys() { return snapshot.keys(); },
+    values() { return snapshot.values(); },
+    entries() { return snapshot.entries(); },
+    [Symbol.iterator]() { return snapshot[Symbol.iterator](); },
+    forEach(
+      callback: (value: Value, key: Key, map: ReadonlyMap<Key, Value>) => void,
+      thisArg?: unknown,
+    ) {
+      snapshot.forEach((value, key) => callback.call(thisArg, value, key, view));
+    },
+  });
+  return view;
+}

--- a/src/eval-workflows/hosts/composition/assembly.ts
+++ b/src/eval-workflows/hosts/composition/assembly.ts
@@ -1,3 +1,4 @@
+import { readonlyMapSnapshot } from '../adapters/shared/readonly-map-snapshot.js';
 import {
   RuntimeIdentitySchema,
   SchemaIdentitySchema,
@@ -854,26 +855,6 @@ function seriesAssembly(entries: readonly OmkEvaluationSeriesRuntimeBindingEntry
       ),
     }),
   });
-}
-
-function readonlyMapSnapshot<Key, Value>(source: ReadonlyMap<Key, Value>): ReadonlyMap<Key, Value> {
-  const snapshot = new Map(source);
-  const view: ReadonlyMap<Key, Value> = Object.freeze({
-    get size() { return snapshot.size; },
-    get(key: Key) { return snapshot.get(key); },
-    has(key: Key) { return snapshot.has(key); },
-    keys() { return snapshot.keys(); },
-    values() { return snapshot.values(); },
-    entries() { return snapshot.entries(); },
-    [Symbol.iterator]() { return snapshot[Symbol.iterator](); },
-    forEach(
-      callback: (value: Value, key: Key, map: ReadonlyMap<Key, Value>) => void,
-      thisArg?: unknown,
-    ) {
-      snapshot.forEach((value, key) => callback.call(thisArg, value, key, view));
-    },
-  });
-  return view;
 }
 
 /**

--- a/src/eval-workflows/hosts/composition/runtime-registry.ts
+++ b/src/eval-workflows/hosts/composition/runtime-registry.ts
@@ -1,3 +1,4 @@
+import { readonlyMapSnapshot } from '../adapters/shared/readonly-map-snapshot.js';
 import { LLM_ASSERTION_EVALUATOR_IMPLEMENTATION_ID } from '../../measurement/evaluators/llm-assertions.js';
 import { isAbsolute } from 'node:path';
 import type { EvaluationEngineClock } from '../../../eval-core/engine/index.js';
@@ -102,26 +103,6 @@ export class ProductionRuntimeRegistryError extends TypeError {
 
 function fail(input: ConstructorParameters<typeof ProductionRuntimeRegistryError>[0]): never {
   throw new ProductionRuntimeRegistryError(input);
-}
-
-function readonlyMapSnapshot<Key, Value>(source: ReadonlyMap<Key, Value>): ReadonlyMap<Key, Value> {
-  const snapshot = new Map(source);
-  const view: ReadonlyMap<Key, Value> = Object.freeze({
-    get size() { return snapshot.size; },
-    get(key: Key) { return snapshot.get(key); },
-    has(key: Key) { return snapshot.has(key); },
-    keys() { return snapshot.keys(); },
-    values() { return snapshot.values(); },
-    entries() { return snapshot.entries(); },
-    [Symbol.iterator]() { return snapshot[Symbol.iterator](); },
-    forEach(
-      callback: (value: Value, key: Key, map: ReadonlyMap<Key, Value>) => void,
-      thisArg?: unknown,
-    ) {
-      snapshot.forEach((value, key) => callback.call(thisArg, value, key, view));
-    },
-  });
-  return view;
 }
 
 function jsonSnapshot<Value>(value: Value): Value {

--- a/src/eval-workflows/hosts/composition/runtime.ts
+++ b/src/eval-workflows/hosts/composition/runtime.ts
@@ -1,3 +1,4 @@
+import { readonlyMapSnapshot } from '../adapters/shared/readonly-map-snapshot.js';
 import { prepareRuntimeSeries, type EvaluationRuntimeProvider } from '../../../eval-runtime/provider.js';
 import { createEvaluationExecution, type EvaluationExecutionOptions } from '../../../eval-runtime/execution.js';
 import {
@@ -213,26 +214,6 @@ function capturePort<Port>(
     method,
     boundMethod(port, method),
   ]))) as Port;
-}
-
-function readonlyMapSnapshot<Key, Value>(source: ReadonlyMap<Key, Value>): ReadonlyMap<Key, Value> {
-  const snapshot = new Map(source);
-  const view: ReadonlyMap<Key, Value> = Object.freeze({
-    get size() { return snapshot.size; },
-    get(key: Key) { return snapshot.get(key); },
-    has(key: Key) { return snapshot.has(key); },
-    keys() { return snapshot.keys(); },
-    values() { return snapshot.values(); },
-    entries() { return snapshot.entries(); },
-    [Symbol.iterator]() { return snapshot[Symbol.iterator](); },
-    forEach(
-      callback: (value: Value, key: Key, map: ReadonlyMap<Key, Value>) => void,
-      thisArg?: unknown,
-    ) {
-      snapshot.forEach((value, key) => callback.call(thisArg, value, key, view));
-    },
-  });
-  return view;
 }
 
 function snapshotCompiled(input: CliEvaluationCompileResult): CliEvaluationCompileResult {

--- a/src/eval-workflows/hosts/resource-leases/node.ts
+++ b/src/eval-workflows/hosts/resource-leases/node.ts
@@ -1,3 +1,4 @@
+import { readonlyMapSnapshot } from '../adapters/shared/readonly-map-snapshot.js';
 import { execFile as execFileCallback } from 'node:child_process';
 import { createHash, type Hash } from 'node:crypto';
 import { constants } from 'node:fs';
@@ -55,26 +56,6 @@ function fail(input: ConstructorParameters<typeof OmkResourceLeaseError>[0]): ne
 
 function compareStrings(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
-}
-
-function readonlyMapSnapshot<Key, Value>(source: ReadonlyMap<Key, Value>): ReadonlyMap<Key, Value> {
-  const snapshot = new Map(source);
-  const view: ReadonlyMap<Key, Value> = Object.freeze({
-    get size() { return snapshot.size; },
-    get(key: Key) { return snapshot.get(key); },
-    has(key: Key) { return snapshot.has(key); },
-    keys() { return snapshot.keys(); },
-    values() { return snapshot.values(); },
-    entries() { return snapshot.entries(); },
-    [Symbol.iterator]() { return snapshot[Symbol.iterator](); },
-    forEach(
-      callback: (value: Value, key: Key, map: ReadonlyMap<Key, Value>) => void,
-      thisArg?: unknown,
-    ) {
-      snapshot.forEach((value, key) => callback.call(thisArg, value, key, view));
-    },
-  });
-  return view;
 }
 
 function sha256Digest(hash: Hash): `sha256:${string}` {

--- a/test/eval-workflows/hosts/adapters/shared/readonly-map-snapshot.test.ts
+++ b/test/eval-workflows/hosts/adapters/shared/readonly-map-snapshot.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { readonlyMapSnapshot } from '../../../../../src/eval-workflows/hosts/adapters/shared/readonly-map-snapshot.js';
+
+describe('readonlyMapSnapshot', () => {
+  it('captures independent membership at each boundary without cloning values', () => {
+    const value = { resourceId: 'first' };
+    const source = new Map([['a', value]]);
+    const first = readonlyMapSnapshot(source);
+    source.set('b', { resourceId: 'second' });
+    const second = readonlyMapSnapshot(source);
+    source.clear();
+
+    expect([...first]).toEqual([['a', value]]);
+    expect([...second.keys()]).toEqual(['a', 'b']);
+    expect(first.get('a')).toBe(value);
+    expect(second.get('a')).toBe(value);
+    expect(first).not.toBe(second);
+    expect(first.size).toBe(1);
+    expect(second.size).toBe(2);
+    expect(first.has('b')).toBe(false);
+    expect(first.get('missing')).toBeUndefined();
+  });
+
+  it('exposes only frozen read operations and preserves ordered traversal', () => {
+    const view = readonlyMapSnapshot(new Map([['b', 2], ['a', 1]]));
+    expect(Object.isFrozen(view)).toBe(true);
+    for (const method of ['set', 'delete', 'clear']) expect(method in view).toBe(false);
+    expect(Reflect.set(view, 'get', () => 99)).toBe(false);
+    expect([...view.keys()]).toEqual(['b', 'a']);
+    expect([...view.values()]).toEqual([2, 1]);
+    expect([...view.entries()]).toEqual([...view]);
+
+    const context = { calls: [] as [number, string][] };
+    view.forEach(function (this: typeof context, value, key, map) {
+      expect(this).toBe(context);
+      expect(map).toBe(view);
+      this.calls.push([value, key]);
+    }, context);
+    expect(context.calls).toEqual([[2, 'b'], [1, 'a']]);
+  });
+
+  it('supports empty maps and propagates callback failures', () => {
+    const empty = readonlyMapSnapshot(new Map<string, number>());
+    expect(empty.size).toBe(0);
+    expect([...empty]).toEqual([]);
+    let calls = 0;
+    empty.forEach(() => { calls += 1; });
+    expect(calls).toBe(0);
+    const error = new Error('callback failed');
+    const view = readonlyMapSnapshot(new Map([['a', 1]]));
+    expect(() => view.forEach(() => { throw error; })).toThrow(error);
+  });
+});


### PR DESCRIPTION
## 用户影响

将 hosts 内五处相同的只读 Map 快照实现收敛为一个纯工具，消除四份重复维护点。运行时注册、装配、Claude 资源与 Node 租约仍在各自原有边界独立捕获快照，不共享可变 Map。

## 契约与迁移

无需迁移。Map 成员快照、值引用、遍历顺序、回调上下文和只读接口保持原有行为；不改变公开 API、资源生命周期、评分算法、prompt、Schema identity 或持久化契约。仅为宿主内部机械复用，不引入新的测量解释。

源码净减 75 行，测试增加 53 行，总计净减 22 行。B5 其余规则及协议／版本适配仍待后续处理，本 PR 不关闭总 issue。

## 交付证据

自主 CR：No findings。338 项受影响验证及完整 `yarn ci` 的 3625 项测试通过。首次完整门禁发现的新文件目录布局问题已通过迁移到既有 shared 工具目录修正，没有放宽架构门禁。未改变真实用户入口或安装契约，不触发额外 clean-room 验收。

关联 #767；前置 PR：#777。