### PR TITLE
refactor(observability): 统一有效观测等级投影

### DIFF
--- a/src/observability/skill-health/analyzer.ts
+++ b/src/observability/skill-health/analyzer.ts
@@ -151,6 +151,23 @@ function withinTimeWindow(seg: SkillSegment, from?: string, to?: string): boolea
   return true;
 }
 
+/** Apply confidence and comparable tool sample guards without changing the source health band. */
+export function effectiveObserveBand(observe: ({
+  healthBand: SkillHealthReport['overall']['healthBand'];
+  confidence: SkillHealth['confidence'];
+} & Partial<Pick<SkillHealth, 'toolResolvedCount' | 'toolCallCount' | 'toolCancelledCount'>>) | null): 'green' | 'yellow' | 'red' | 'gray' {
+  if (observe === null || observe.confidence === 'underpowered') return 'gray';
+  const comparable = Math.max(
+    0,
+    (observe.toolResolvedCount ?? observe.toolCallCount ?? 0)
+      - (observe.toolCancelledCount ?? 0),
+  );
+  if (observe.healthBand === 'green' && (observe.toolCallCount ?? 0) > 0 && comparable < 5) {
+    return 'gray';
+  }
+  return observe.healthBand;
+}
+
 /**
  * 健康度色带。阈值对齐 bench ci --max-gap-rate 经验值(spec §五)。observe 报告只在 overall 给 band;
  * #235 受管反哺时 observe CLI 用本函数逐 skill 算 band 传入 managed —— 阈值单一来源,managed 不复制。

--- a/src/studio/application/skill-index.ts
+++ b/src/studio/application/skill-index.ts
@@ -12,7 +12,7 @@ import {
   listLiveDoctorCards,
   listLiveObserveCards,
 } from '../../evidence/storage/discovery-index.js';
-import { confidenceOf, toolStabilityOf, type SkillHealthReport } from '../../observability/skill-health/analyzer.js';
+import { confidenceOf, effectiveObserveBand, toolStabilityOf, type SkillHealthReport } from '../../observability/skill-health/analyzer.js';
 import { DEFAULT_OBSERVATIONS_DIR, loadLatestObservationInboxReports } from '../../observability/inbox/index.js';
 import { parseSkillHealthReport } from '../../observability/skill-health/report.js';
 import { parseArtifactGraphDocument } from '../../evidence/graph/schema.js';
@@ -143,7 +143,7 @@ function observeSnapshot(
     : gapRate >= 0.3 || (failureRateMeasured && health.toolFailureRate >= 0.2)
       ? 'yellow'
       : 'green';
-  return {
+  const snapshot: Omit<SkillObserveSnapshot, 'effectiveBand'> = {
     analysisId,
     generatedAt,
     healthBand,
@@ -159,6 +159,7 @@ function observeSnapshot(
       : toolStabilityOf(health.toolFailureRate, comparable, health.toolCallCount),
     confidence: health.confidence ?? confidenceOf(health.segmentCount),
   };
+  return { ...snapshot, effectiveBand: effectiveObserveBand(snapshot) };
 }
 
 function scanObserveReports(directory: string): Record<string, SkillObserveSnapshot[]> {
@@ -248,25 +249,12 @@ function doctorGraphForSkill(
   };
 }
 
-function effectiveObserveBand(observe: SkillObserveSnapshot | null): SkillIndexEntry['band'] {
-  if (observe === null || observe.confidence === 'underpowered') return 'gray';
-  const comparable = Math.max(
-    0,
-    (observe.toolResolvedCount ?? observe.toolCallCount ?? 0)
-      - (observe.toolCancelledCount ?? 0),
-  );
-  if (observe.healthBand === 'green' && (observe.toolCallCount ?? 0) > 0 && comparable < 5) {
-    return 'gray';
-  }
-  return observe.healthBand;
-}
-
 function combinedBand(
   doctor: SkillDoctorSnapshot | null,
   observe: SkillObserveSnapshot | null,
 ): SkillIndexEntry['band'] {
   const doctorBand = doctor === null ? 'gray' : doctor.status === 'fail' ? 'red' : doctor.status === 'warn' ? 'yellow' : 'green';
-  const observeBand = effectiveObserveBand(observe);
+  const observeBand = observe?.effectiveBand ?? 'gray';
   if (doctorBand === 'red' || observeBand === 'red') return 'red';
   if (doctorBand === 'yellow' || observeBand === 'yellow') return 'yellow';
   if (doctorBand === 'green' || observeBand === 'green') return 'green';

--- a/src/studio/presentation/skill-detail-renderer.ts
+++ b/src/studio/presentation/skill-detail-renderer.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_LANG, e, layout } from './layout.js';
 import type { Lang } from '../../shared/language.js';
-import type { Insight, SkillIndexEntry, SkillObserveSnapshot } from '../view-models/index.js';
+import type { Insight, SkillIndexEntry } from '../view-models/index.js';
 
 export type HealthGrade = 'excellent' | 'good' | 'fair' | 'unhealthy' | 'unscored';
 
@@ -12,26 +12,14 @@ export interface HealthAssessment {
   color: 'green' | 'yellow' | 'red' | 'gray';
 }
 
-function effectiveObserveBand(observe: SkillObserveSnapshot | null): 'green' | 'yellow' | 'red' | 'gray' {
-  if (observe === null || observe.confidence === 'underpowered') return 'gray';
-  const comparable = Math.max(
-    0,
-    (observe.toolResolvedCount ?? observe.toolCallCount ?? 0)
-      - (observe.toolCancelledCount ?? 0),
-  );
-  if (observe.healthBand === 'green' && (observe.toolCallCount ?? 0) > 0 && comparable < 5) {
-    return 'gray';
-  }
-  return observe.healthBand;
-}
-
 export function assessHealth(entry: SkillIndexEntry, insights: Insight[], lang: Lang): HealthAssessment {
   const doctor = entry.doctor;
   const doctorTotal = doctor === null ? 0 : doctor.passCount + doctor.warnCount + doctor.failCount;
   const doctorScore = doctor !== null && doctorTotal > 0
     ? ((doctor.passCount + doctor.warnCount * 0.5) / doctorTotal) * 100
     : null;
-  const observeTrusted = effectiveObserveBand(entry.observe) !== 'gray';
+  const observeBand = entry.observe?.effectiveBand ?? 'gray';
+  const observeTrusted = observeBand !== 'gray';
   const observeScore = observeTrusted ? (1 - entry.observe!.gapRate) * 100 : null;
   const dimensions = [doctorScore, observeScore].filter((value): value is number => value !== null);
   const score = dimensions.length === 0
@@ -39,8 +27,8 @@ export function assessHealth(entry: SkillIndexEntry, insights: Insight[], lang: 
     : Math.round(dimensions.reduce((sum, value) => sum + value, 0) / dimensions.length);
   const high = insights.some((insight) => insight.severity === 'high');
   const medium = insights.some((insight) => insight.severity === 'medium');
-  const failed = (doctor?.failCount ?? 0) > 0 || effectiveObserveBand(entry.observe) === 'red';
-  const warned = (doctor?.warnCount ?? 0) > 0 || effectiveObserveBand(entry.observe) === 'yellow';
+  const failed = (doctor?.failCount ?? 0) > 0 || observeBand === 'red';
+  const warned = (doctor?.warnCount ?? 0) > 0 || observeBand === 'yellow';
   if (high || failed) {
     return { grade: 'unhealthy', score, label: lang === 'zh' ? '不健康' : 'Unhealthy', emoji: '🔴', color: 'red' };
   }

--- a/src/studio/view-models/skill-index.ts
+++ b/src/studio/view-models/skill-index.ts
@@ -23,6 +23,8 @@ export interface SkillObserveSnapshot {
   analysisId: string;
   generatedAt: string;
   healthBand: 'green' | 'yellow' | 'red';
+  /** Read-time projection after applying observation confidence and tool sample guards. */
+  effectiveBand: SkillIndexEntry['band'];
   failureRate: number;
   toolCallCount?: number;
   toolResolvedCount?: number;

--- a/test/observability/skill-health/effective-band.test.ts
+++ b/test/observability/skill-health/effective-band.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { effectiveObserveBand } from '../../../src/observability/skill-health/analyzer.js';
+
+describe('effectiveObserveBand', () => {
+  it('keeps an absent observation unscored', () => {
+    expect(effectiveObserveBand(null)).toBe('gray');
+  });
+
+  for (const healthBand of ['green', 'yellow', 'red'] as const) {
+    for (const confidence of ['underpowered', 'low', 'high'] as const) {
+      it(`${healthBand} with ${confidence} confidence`, () => {
+        const evidence = { healthBand, confidence };
+        expect(effectiveObserveBand(evidence)).toBe(confidence === 'underpowered' ? 'gray' : healthBand);
+        expect(evidence).toEqual({ healthBand, confidence });
+      });
+    }
+  }
+
+  it.each([
+    { toolCallCount: 0, expected: 'green' },
+    { toolCallCount: 4, expected: 'gray' },
+    { toolCallCount: 5, expected: 'green' },
+    { toolCallCount: 8, toolResolvedCount: 4, expected: 'gray' },
+    { toolCallCount: 8, toolResolvedCount: 5, expected: 'green' },
+    { toolCallCount: 8, toolResolvedCount: 5, toolCancelledCount: 1, expected: 'gray' },
+    { toolCallCount: 8, toolResolvedCount: 6, toolCancelledCount: 1, expected: 'green' },
+    { toolCallCount: 8, toolResolvedCount: 0, expected: 'gray' },
+  ])('applies the comparable tool result boundary: $expected', ({ expected, ...counts }) => {
+    expect(effectiveObserveBand({ healthBand: 'green', confidence: 'high', ...counts })).toBe(expected);
+    expect(effectiveObserveBand({ healthBand: 'yellow', confidence: 'high', ...counts })).toBe('yellow');
+    expect(effectiveObserveBand({ healthBand: 'red', confidence: 'high', ...counts })).toBe('red');
+  });
+});

--- a/test/studio/application/cross-project-doctor-observe.test.ts
+++ b/test/studio/application/cross-project-doctor-observe.test.ts
@@ -1,3 +1,4 @@
+import { assessHealth } from '../../../src/studio/presentation/skill-detail-renderer.js';
 /**
  * 机器级总览验收(doctor / observe-health 域):buildSkillIndex 把别项目的 doctor/observe 卡片合并进 skill 索引;
  * doctor 历史 prune 删正文时连带删卡片,杜绝「被 prune 的报告经卡片复活」。全程隔离 OMK_ARTIFACT_INDEX_DIR。
@@ -314,6 +315,11 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
     const partial = idx.entries.find((entry) => entry.skillName === 'partial')!;
     assert.equal(partial.observe?.healthBand, 'green');
     assert.equal(partial.band, 'gray');
+    assert.equal(partial.observe?.effectiveBand, 'gray');
+    assert.equal(assessHealth(partial, [], 'zh').color, partial.observe?.effectiveBand);
+    const local = buildSkillIndex(proj, emptyDoctors, emptyObs).entries.find((entry) => entry.skillName === 'partial')!;
+    assert.equal(local.observe?.effectiveBand, partial.observe?.effectiveBand);
+    assert.equal(local.observeHistory[0].effectiveBand, 'gray');
   });
 
   it('少量可判定结果不足以把高失败率标成红色或黄色', () => {
@@ -371,6 +377,8 @@ describe('机器级 doctor/observe 卡片合并进 buildSkillIndex', () => {
     const covered = idx.entries.find((entry) => entry.skillName === 'covered')!;
     assert.equal(covered.observe?.healthBand, 'green');
     assert.equal(covered.band, 'green');
+    assert.equal(covered.observe?.effectiveBand, 'green');
+    assert.equal(assessHealth(covered, [], 'zh').color, covered.observe?.effectiveBand);
   });
 
   it('悬空卡片(真身从未存在)不进 buildSkillIndex:include=true 也不展示', () => {

--- a/test/studio/application/skill-insights.test.ts
+++ b/test/studio/application/skill-insights.test.ts
@@ -56,7 +56,7 @@ describe('Core-independent skill insights', () => {
       observe: {
         analysisId: 'observe-1',
         generatedAt: '2026-09-01T00:00:00.000Z',
-        healthBand: 'red',
+        healthBand: 'red', effectiveBand: 'gray',
         failureRate: 0.5,
         segmentCount: 2,
         gapRate: 0.5,
@@ -86,7 +86,7 @@ describe('Core-independent skill insights', () => {
       observe: {
         analysisId: 'observe-1',
         generatedAt: '2026-09-01T00:00:00.000Z',
-        healthBand: 'yellow',
+        healthBand: 'yellow', effectiveBand: 'yellow',
         failureRate: 0.25,
         segmentCount: 30,
         gapRate: 0.3,

--- a/test/studio/presentation/assess-health.test.ts
+++ b/test/studio/presentation/assess-health.test.ts
@@ -76,7 +76,7 @@ describe('assessHealth — observe confidence guard', () => {
     healthBand: 'green' | 'yellow' | 'red',
   ): NonNullable<SkillIndexEntry['observe']> => ({
     analysisId: 'a1', generatedAt: '2026-05-09T10:00:00Z',
-    healthBand, failureRate: 0.5, gapRate: 0.5,
+    healthBand, effectiveBand: confidence === 'underpowered' ? 'gray' : healthBand, failureRate: 0.5, gapRate: 0.5,
     segmentCount: confidence === 'underpowered' ? 2 : 30, confidence,
   });
 
@@ -115,6 +115,7 @@ describe('assessHealth — observe confidence guard', () => {
       ...observe('high', 'green'),
       gapRate: 0,
       failureRate: 0,
+      effectiveBand: 'gray' as const,
       toolCallCount: 2,
       toolResolvedCount: 2,
       toolCancelledCount: 0,

--- a/test/studio/presentation/underpowered-observe-guard.test.ts
+++ b/test/studio/presentation/underpowered-observe-guard.test.ts
@@ -17,13 +17,13 @@ function underpoweredEntry(): SkillIndexEntry {
     doctor: null,
     observe: {
       analysisId: 'a1', generatedAt: '2026-05-09T10:00:00Z',
-      healthBand: 'red', failureRate: 0.5, segmentCount: 2, gapRate: 0,
+      healthBand: 'red', effectiveBand: 'gray', failureRate: 0.5, segmentCount: 2, gapRate: 0,
       confidence: 'underpowered',
     },
     doctorHistory: [],
     observeHistory: [{
       analysisId: 'a1', generatedAt: '2026-05-09T10:00:00Z',
-      healthBand: 'red', failureRate: 0.5, segmentCount: 2, gapRate: 0,
+      healthBand: 'red', effectiveBand: 'gray', failureRate: 0.5, segmentCount: 2, gapRate: 0,
       confidence: 'underpowered',
     }],
     band: 'gray',


### PR DESCRIPTION
## 用户影响

Studio 列表与详情共用领域层生成的 `effectiveBand` 投影，不再各自维护有效观测等级规则。样本不足时保持中性灰；绿色且可比较工具结果少于 5 条时仍不作硬绿结论。既有阈值、优先级和展示结果不变。

## 契约与迁移

无需迁移。保留原始 `healthBand`、工具计数及置信度，新增字段仅属于读取时的 Studio 快照投影，不回写持久化报告。历史报告继续经过原有解析与置信度推导。无评分、prompt、Schema identity 或统计语义变化，不把观测结论解释为因果关系。

删除一处重复领域规则。源码净减 5 行，测试增加 42 行，总计增加 37 行；新增验证覆盖领域边界及本地报告／机器级卡片到列表与详情的接线。其余 B5 项及总 issue 范围保留。

## 交付证据

自主 CR：No findings。100 项精准验证与完整 `yarn ci` 的 3643 项测试通过。随后仅修正函数注释归属，复查受影响面，无行为代码变化，不机械重跑完整本地门禁。本批未改变安装契约或真实用户入口行为，不触发额外 clean-room 验收。

关联 #767；前置 PR：#778。