### PR TITLE
refactor(eval-workflows): 复用一致性分析机械配对逻辑

### DIFF
--- a/src/eval-workflows/measurement/analysis/agreement-source-adapter-v1.ts
+++ b/src/eval-workflows/measurement/analysis/agreement-source-adapter-v1.ts
@@ -1,3 +1,4 @@
+import { extractAgreementPairsFromGroups } from './agreement-source-pairs.js';
 import type { AnalysisNodeExecutionContext } from '../../../eval-core/analysis/index.js';
 import type { SchemaIdentity } from '../../../eval-core/contracts/index.js';
 import type { AgreementParameters } from './agreement-parameters.js';
@@ -17,52 +18,10 @@ export function agreementSourceSchema(): SchemaIdentity {
   return DIMENSION_TABLE_SCHEMA;
 }
 
-function decodePointerToken(token: string): string {
-  return token.replaceAll('~1', '/').replaceAll('~0', '~');
-}
-
-function resolvePointer(value: unknown, pointer: string): unknown {
-  if (pointer === '') return value;
-  let current: unknown = value;
-  for (const rawToken of pointer.slice(1).split('/')) {
-    const token = decodePointerToken(rawToken);
-    if (Array.isArray(current)) {
-      if (!/^(?:0|[1-9]\d*)$/.test(token)) return undefined;
-      current = current[Number(token)];
-    } else if (current !== null && typeof current === 'object') {
-      const record = current as Readonly<Record<string, unknown>>;
-      current = Object.prototype.hasOwnProperty.call(current, token)
-        ? record[token]
-        : undefined;
-    } else {
-      return undefined;
-    }
-    if (current === undefined) return undefined;
-  }
-  return current;
-}
-
 function hasObservedAggregate(
   group: DimensionGroup,
 ): group is DimensionGroup & { aggregate: { aggregateStatus: 'observed'; mean: number } } {
   return group.aggregate.aggregateStatus === 'observed';
-}
-
-function goldRating(
-  sample: AnalysisNodeExecutionContext['samples'][number],
-  parameters: AgreementParameters,
-): AgreementPair['gold'] {
-  const context = sample.analysis?.context;
-  if (context === undefined) {
-    return { ratingStatus: 'unavailable', reasonCode: 'gold-rating-unavailable' };
-  }
-  if (context.classification !== 'gold') {
-    throw new TypeError('Agreement gold context must use the gold classification.');
-  }
-  const score = resolvePointer(context.value, parameters.gold.contextPointer);
-  return typeof score === 'number' && Number.isFinite(score)
-    ? { ratingStatus: 'observed', score }
-    : { ratingStatus: 'unavailable', reasonCode: 'gold-rating-unavailable' };
 }
 
 function judgeRating(groups: readonly DimensionGroup[]): AgreementPair['judge'] {
@@ -107,30 +66,5 @@ export function extractAgreementPairs(
   signal?: AbortSignal,
 ): readonly AgreementPair[] {
   const table = parseDimensionTableEnvelope(envelope).value;
-  const sampleSet = new Set(parameters.sampleIds);
-  const groupsBySample = new Map<string, DimensionGroup[]>();
-  for (const group of table.groups) {
-    if (signal?.aborted === true) throw signal.reason;
-    if (group.targetId !== parameters.source.targetId) continue;
-    if (!sampleSet.has(group.sampleId)) {
-      throw new TypeError('Agreement source contains an undeclared sample for the selected target.');
-    }
-    const groups = groupsBySample.get(group.sampleId) ?? [];
-    groups.push(group);
-    groupsBySample.set(group.sampleId, groups);
-  }
-  const sampleById = new Map(samples.map((sample) => [sample.sampleId, sample]));
-  return parameters.sampleIds.map((sampleId) => {
-    if (signal?.aborted === true) throw signal.reason;
-    const sample = sampleById.get(sampleId);
-    if (sample === undefined) throw new TypeError('Agreement sample is absent from the Analysis plan.');
-    const groups = [...(groupsBySample.get(sampleId) ?? [])].sort((left, right) => (
-      left.trialIndex - right.trialIndex
-    ));
-    return {
-      sampleId,
-      gold: goldRating(sample, parameters),
-      judge: judgeRating(groups),
-    };
-  });
+  return extractAgreementPairsFromGroups(parameters, table.groups, samples, judgeRating, signal);
 }

--- a/src/eval-workflows/measurement/analysis/agreement-source-adapter.ts
+++ b/src/eval-workflows/measurement/analysis/agreement-source-adapter.ts
@@ -1,3 +1,4 @@
+import { extractAgreementPairsFromGroups } from './agreement-source-pairs.js';
 import type { AnalysisNodeExecutionContext } from '../../../eval-core/analysis/index.js';
 import type { SchemaIdentity } from '../../../eval-core/contracts/index.js';
 import type { AgreementParameters } from './agreement-parameters.js';
@@ -17,52 +18,10 @@ export function agreementSourceSchema(): SchemaIdentity {
   return DIMENSION_TABLE_SCHEMA;
 }
 
-function decodePointerToken(token: string): string {
-  return token.replaceAll('~1', '/').replaceAll('~0', '~');
-}
-
-function resolvePointer(value: unknown, pointer: string): unknown {
-  if (pointer === '') return value;
-  let current: unknown = value;
-  for (const rawToken of pointer.slice(1).split('/')) {
-    const token = decodePointerToken(rawToken);
-    if (Array.isArray(current)) {
-      if (!/^(?:0|[1-9]\d*)$/.test(token)) return undefined;
-      current = current[Number(token)];
-    } else if (current !== null && typeof current === 'object') {
-      const record = current as Readonly<Record<string, unknown>>;
-      current = Object.prototype.hasOwnProperty.call(current, token)
-        ? record[token]
-        : undefined;
-    } else {
-      return undefined;
-    }
-    if (current === undefined) return undefined;
-  }
-  return current;
-}
-
 function hasObservedAggregate(
   group: DimensionGroup,
 ): group is DimensionGroup & { aggregate: { aggregateStatus: 'observed'; weightedMean: number } } {
   return group.aggregate.aggregateStatus === 'observed';
-}
-
-function goldRating(
-  sample: AnalysisNodeExecutionContext['samples'][number],
-  parameters: AgreementParameters,
-): AgreementPair['gold'] {
-  const context = sample.analysis?.context;
-  if (context === undefined) {
-    return { ratingStatus: 'unavailable', reasonCode: 'gold-rating-unavailable' };
-  }
-  if (context.classification !== 'gold') {
-    throw new TypeError('Agreement gold context must use the gold classification.');
-  }
-  const score = resolvePointer(context.value, parameters.gold.contextPointer);
-  return typeof score === 'number' && Number.isFinite(score)
-    ? { ratingStatus: 'observed', score }
-    : { ratingStatus: 'unavailable', reasonCode: 'gold-rating-unavailable' };
 }
 
 function judgeRating(groups: readonly DimensionGroup[]): AgreementPair['judge'] {
@@ -107,30 +66,5 @@ export function extractAgreementPairs(
   signal?: AbortSignal,
 ): readonly AgreementPair[] {
   const table = parseDimensionTableEnvelope(envelope).value;
-  const sampleSet = new Set(parameters.sampleIds);
-  const groupsBySample = new Map<string, DimensionGroup[]>();
-  for (const group of table.groups) {
-    if (signal?.aborted === true) throw signal.reason;
-    if (group.targetId !== parameters.source.targetId) continue;
-    if (!sampleSet.has(group.sampleId)) {
-      throw new TypeError('Agreement source contains an undeclared sample for the selected target.');
-    }
-    const groups = groupsBySample.get(group.sampleId) ?? [];
-    groups.push(group);
-    groupsBySample.set(group.sampleId, groups);
-  }
-  const sampleById = new Map(samples.map((sample) => [sample.sampleId, sample]));
-  return parameters.sampleIds.map((sampleId) => {
-    if (signal?.aborted === true) throw signal.reason;
-    const sample = sampleById.get(sampleId);
-    if (sample === undefined) throw new TypeError('Agreement sample is absent from the Analysis plan.');
-    const groups = [...(groupsBySample.get(sampleId) ?? [])].sort((left, right) => (
-      left.trialIndex - right.trialIndex
-    ));
-    return {
-      sampleId,
-      gold: goldRating(sample, parameters),
-      judge: judgeRating(groups),
-    };
-  });
+  return extractAgreementPairsFromGroups(parameters, table.groups, samples, judgeRating, signal);
 }

--- a/src/eval-workflows/measurement/analysis/agreement-source-pairs.ts
+++ b/src/eval-workflows/measurement/analysis/agreement-source-pairs.ts
@@ -1,0 +1,85 @@
+import type { AnalysisNodeExecutionContext } from '../../../eval-core/analysis/index.js';
+import type { AgreementParameters } from './agreement-parameters.js';
+import type { AgreementPair } from './agreement-table.js';
+
+function decodePointerToken(token: string): string {
+  return token.replaceAll('~1', '/').replaceAll('~0', '~');
+}
+
+function resolvePointer(value: unknown, pointer: string): unknown {
+  if (pointer === '') return value;
+  let current: unknown = value;
+  for (const rawToken of pointer.slice(1).split('/')) {
+    const token = decodePointerToken(rawToken);
+    if (Array.isArray(current)) {
+      if (!/^(?:0|[1-9]\d*)$/.test(token)) return undefined;
+      current = current[Number(token)];
+    } else if (current !== null && typeof current === 'object') {
+      const record = current as Readonly<Record<string, unknown>>;
+      current = Object.prototype.hasOwnProperty.call(current, token)
+        ? record[token]
+        : undefined;
+    } else {
+      return undefined;
+    }
+    if (current === undefined) return undefined;
+  }
+  return current;
+}
+
+function goldRating(
+  sample: AnalysisNodeExecutionContext['samples'][number],
+  parameters: AgreementParameters,
+): AgreementPair['gold'] {
+  const context = sample.analysis?.context;
+  if (context === undefined) {
+    return { ratingStatus: 'unavailable', reasonCode: 'gold-rating-unavailable' };
+  }
+  if (context.classification !== 'gold') {
+    throw new TypeError('Agreement gold context must use the gold classification.');
+  }
+  const score = resolvePointer(context.value, parameters.gold.contextPointer);
+  return typeof score === 'number' && Number.isFinite(score)
+    ? { ratingStatus: 'observed', score }
+    : { ratingStatus: 'unavailable', reasonCode: 'gold-rating-unavailable' };
+}
+
+/** Pair already-validated groups; schema parsing and judge aggregation remain version-owned. */
+export function extractAgreementPairsFromGroups<Group extends {
+  targetId: string;
+  sampleId: string;
+  trialIndex: number;
+}>(
+  parameters: AgreementParameters,
+  sourceGroups: readonly Group[],
+  samples: AnalysisNodeExecutionContext['samples'],
+  judgeRating: (groups: readonly Group[]) => AgreementPair['judge'],
+  signal?: AbortSignal,
+): readonly AgreementPair[] {
+  const sampleSet = new Set(parameters.sampleIds);
+  const groupsBySample = new Map<string, Group[]>();
+  for (const group of sourceGroups) {
+    if (signal?.aborted === true) throw signal.reason;
+    if (group.targetId !== parameters.source.targetId) continue;
+    if (!sampleSet.has(group.sampleId)) {
+      throw new TypeError('Agreement source contains an undeclared sample for the selected target.');
+    }
+    const groups = groupsBySample.get(group.sampleId) ?? [];
+    groups.push(group);
+    groupsBySample.set(group.sampleId, groups);
+  }
+  const sampleById = new Map(samples.map((sample) => [sample.sampleId, sample]));
+  return parameters.sampleIds.map((sampleId) => {
+    if (signal?.aborted === true) throw signal.reason;
+    const sample = sampleById.get(sampleId);
+    if (sample === undefined) throw new TypeError('Agreement sample is absent from the Analysis plan.');
+    const groups = [...(groupsBySample.get(sampleId) ?? [])].sort((left, right) => (
+      left.trialIndex - right.trialIndex
+    ));
+    return {
+      sampleId,
+      gold: goldRating(sample, parameters),
+      judge: judgeRating(groups),
+    };
+  });
+}

--- a/test/eval-workflows/measurement/analysis/agreement-node.test.ts
+++ b/test/eval-workflows/measurement/analysis/agreement-node.test.ts
@@ -21,6 +21,9 @@ import {
 } from '../../../../src/eval-workflows/measurement/analysis/agreement-node.js';
 import { AGREEMENT_PARAMETERS_SCHEMA } from '../../../../src/eval-workflows/measurement/analysis/agreement-parameters.js';
 import { AGREEMENT_SOURCE_SCHEMAS } from '../../../../src/eval-workflows/measurement/analysis/agreement-source-adapter.js';
+import { extractAgreementPairs } from '../../../../src/eval-workflows/measurement/analysis/agreement-source-adapter.js';
+import { extractAgreementPairs as extractAgreementPairsV1 } from '../../../../src/eval-workflows/measurement/analysis/agreement-source-adapter-v1.js';
+import * as legacyDimension from '../../../../src/eval-workflows/measurement/analysis/dimension-table-v1.js';
 import { AGREEMENT_TABLE_SCHEMA } from '../../../../src/eval-workflows/measurement/analysis/agreement-table.js';
 import {
   DIMENSION_TABLE_SCHEMA,
@@ -173,6 +176,68 @@ async function execute(value: AnalysisNodeExecutionContext) {
 }
 
 describe('Agreement Analysis node', () => {
+  it('preserves legacy mean versus weighted mean and rejects cross-version envelopes', () => {
+    const base = dimensionGroup('sample-0', 0, 1);
+    const dimensions = [1, 5].map((consensus, index) => ({
+      dimensionId: `quality-${index}`,
+      metricId: `rubric-quality-${index}`,
+      sourceAnalysisResultId: `judge-quality-${index}`,
+      sourceGroupId: digestCanonicalJson({ source: 'judge', index }),
+      weight: index === 0 ? 0.25 : 0.75,
+      dimensionStatus: 'observed' as const,
+      consensus,
+    }));
+    const current = {
+      ...base, dimensions,
+      coverage: dimensionCoverage(dimensions),
+      aggregate: dimensionAggregate(dimensions),
+    };
+    current.groupId = dimensionGroupId(current);
+    const oldDimensions = dimensions.map((entry) => ({
+      dimensionId: entry.dimensionId,
+      metricId: entry.metricId,
+      sourceAnalysisResultId: entry.sourceAnalysisResultId,
+      sourceGroupId: entry.sourceGroupId,
+      dimensionStatus: entry.dimensionStatus,
+      consensus: entry.consensus,
+    }));
+    const legacy = {
+      ...base, dimensions: oldDimensions,
+      coverage: legacyDimension.dimensionCoverage(oldDimensions),
+      aggregate: legacyDimension.dimensionAggregate(oldDimensions),
+    };
+    legacy.groupId = legacyDimension.dimensionGroupId(legacy);
+    const modernEnvelope = { resultType: 'table', value: { schemaVersion: DIMENSION_TABLE_SCHEMA_VERSION, groups: [current] } };
+    const legacyEnvelope = { resultType: 'table', value: { schemaVersion: legacyDimension.DIMENSION_TABLE_SCHEMA_VERSION, groups: [legacy] } };
+
+    expect(extractAgreementPairs(parameters(), modernEnvelope, samples())[0].judge)
+      .toMatchObject({ ratingStatus: 'observed', score: 4 });
+    expect(extractAgreementPairsV1(parameters(), legacyEnvelope, samples())[0].judge)
+      .toMatchObject({ ratingStatus: 'observed', score: 3 });
+    expect(() => extractAgreementPairs(parameters(), legacyEnvelope, samples())).toThrow();
+    expect(() => extractAgreementPairsV1(parameters(), modernEnvelope, samples())).toThrow();
+  });
+
+  it.each([
+    ['/scores/0/a~1b/~0', 4],
+    ['/scores/01/a~1b/~0', undefined],
+    ['/scores/-/a~1b/~0', undefined],
+    ['/toString', undefined],
+    ['/missing', undefined],
+  ] as const)('resolves gold pointers without inherited fields: %s', (contextPointer, score) => {
+    const configuration = parameters();
+    configuration.gold.contextPointer = contextPointer;
+    const sampleData = samples();
+    const updatedSamples = sampleData.map((sample) => ({
+      ...sample,
+      analysis: { memberships: [], context: { classification: 'gold' as const, value: { scores: [{ 'a/b': { '~': 4 } }] } } },
+    }));
+    const pairs = extractAgreementPairs(configuration, { resultType: 'table', value: dimensionValue() }, updatedSamples);
+    expect(pairs[0].gold).toEqual(score === undefined
+      ? { ratingStatus: 'unavailable', reasonCode: 'gold-rating-unavailable' }
+      : { ratingStatus: 'observed', score });
+  });
+
   it('declares canonical capabilities and aggregates Dimension trials by sealed sample', async () => {
     const capabilities = AnalysisNodeCapabilitiesSchema.parse(AGREEMENT_ANALYSIS_IDENTITY.capabilities);
     expect(capabilities.inputDomains).toEqual([{


### PR DESCRIPTION
## 用户影响

Agreement 新旧来源适配器共用 JSON Pointer、金标准读取和按封存样本顺序配对的机械逻辑，减少重复维护；版本专属解析器与评分函数保持独立。

## 版本与测量约束

无需迁移。旧 dimension v1 的 mean 与当前 dimension v2 的 weightedMean 保持各自语义，不互换 schema、不更改运行时 identity 或指纹，也不把旧报告解释成新算法。保留金标准分类检查、缺失结果、样本资格、排序和取消行为。

Dimension 的旧／新 schema 与聚合实现继续保留：字段、权重及公开身份存在实质差异，不属于可整体删除的兼容债务。本批仅抽取已确认相同的机械配对部分，不建立通用版本分支执行器。

源码净减 47 行，测试增加 65 行，总计增加 18 行。公开 API、持久化和 prompt 字节不变；不改变安装或真实用户入口行为，不触发额外 clean-room。

## 交付证据

自主 CR：No findings。26 项精准验证及完整 `yarn ci` 的 3662 项测试通过。新增不等权数据证明旧版与新版评分分别保持为 3 和 4，交叉 schema 仍被拒绝，原版本指纹断言保留。首次夹具违反来源绑定的问题已修正，没有放宽生产校验。

关联 #767；前置 PR：#780。协议解码、C1、C2 和附录其余处置仍待完成，本 PR 不关闭总 issue。