### PR TITLE
refactor(shared): 清理十个无消费者的内部导出

### DIFF
--- a/src/eval-workflows/assertions/deterministic.ts
+++ b/src/eval-workflows/assertions/deterministic.ts
@@ -106,10 +106,6 @@ export function deterministicAssertionInputSourceKinds(
   ]);
 }
 
-export function ratioToScore(ratio: number): number {
-  return Number((1 + ratio * 4).toFixed(2));
-}
-
 function tokenize(value: string): string[] {
   return value.toLowerCase().match(/[a-z0-9]+|[一-龥]/g) ?? [];
 }

--- a/src/eval-workflows/inputs/assertion-types.ts
+++ b/src/eval-workflows/inputs/assertion-types.ts
@@ -51,7 +51,6 @@ export const ASYNC_ASSERTION_TYPE_NAMES = [
   'context_recall',
 ] as const satisfies readonly AsyncAssertionType[];
 
-export const SYNC_ASSERTION_TYPES: ReadonlySet<string> = new Set(SYNC_ASSERTION_TYPE_NAMES);
 export const ASYNC_ASSERTION_TYPES: ReadonlySet<string> = new Set(ASYNC_ASSERTION_TYPE_NAMES);
 export const SUPPORTED_ASSERTION_TYPES: ReadonlySet<string> = new Set([
   ...SYNC_ASSERTION_TYPE_NAMES,

--- a/src/evidence/storage/default-dirs.ts
+++ b/src/evidence/storage/default-dirs.ts
@@ -27,9 +27,7 @@ export const DEFAULT_DOCTORS_DIR: string = GLOBAL_LAYOUT.doctorDir;
  * 可重生的执行 scratch(删了能重建)统一收在 `state/` 子树下,跟上面的耐久数据物理分开 ——
  * 想清磁盘时「这一坨能整删」一眼可见。各 scratch 目录都派生自这个 state 根,避免散落硬编码。
  */
-export const DEFAULT_STATE_DIR: string = GLOBAL_LAYOUT.stateDir;
 export const DEFAULT_CACHE_DIR: string = GLOBAL_LAYOUT.cacheDir;
-export const DEFAULT_ISOLATED_CWD_DIR: string = GLOBAL_LAYOUT.isolatedCwdDir;
 export const DEFAULT_TREES_DIR: string = GLOBAL_LAYOUT.treesDir;
 
 /**

--- a/src/evidence/storage/file-names.ts
+++ b/src/evidence/storage/file-names.ts
@@ -27,14 +27,6 @@ export function isReportFileName(fileName: string): boolean {
   return reportFileStem(fileName) !== null;
 }
 
-export function graphFileName(stem: string): string {
-  return `${safeArtifactFileStem(stem)}${GRAPH_FILE_SUFFIX}`;
-}
-
-export function cardFileName(stem: string): string {
-  return `${safeArtifactFileStem(stem)}${CARD_FILE_SUFFIX}`;
-}
-
 export function runTimestamp(date = new Date()): string {
   const pad = (n: number): string => String(n).padStart(2, '0');
   return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}T${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;

--- a/src/shared/atomic-json.ts
+++ b/src/shared/atomic-json.ts
@@ -6,12 +6,6 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import {
-  mkdir,
-  rename,
-  rm,
-  writeFile,
-} from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 /**
@@ -25,19 +19,5 @@ export function writeJsonFileAtomic(path: string, value: unknown): void {
     renameSync(tempPath, path);
   } finally {
     if (existsSync(tempPath)) rmSync(tempPath, { force: true });
-  }
-}
-
-/**
- * Async counterpart of {@link writeJsonFileAtomic}.
- */
-export async function writeJsonFileAtomicAsync(path: string, value: unknown): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
-  try {
-    await writeFile(tempPath, JSON.stringify(value, null, 2));
-    await rename(tempPath, path);
-  } finally {
-    await rm(tempPath, { force: true });
   }
 }

--- a/src/studio/presentation/layout.ts
+++ b/src/studio/presentation/layout.ts
@@ -10,10 +10,6 @@ export function e(text: unknown): string {
     .replaceAll("'", '&#39;');
 }
 
-export function fmtNum(n: number | undefined | null, digits: number = 0): string {
-  return Number(n || 0).toLocaleString('en-US', { maximumFractionDigits: digits });
-}
-
 export function fmtDuration(ms: number | undefined | null): string {
   const v = Number(ms || 0);
   if (v < 1000) return `${v}ms`;
@@ -31,25 +27,10 @@ export function fmtCost(usd: number | undefined | null, reported: boolean = true
   return `$${Number(usd || 0).toFixed(4)}`;
 }
 
-export function fmtKnownCost(usd: number | undefined | null, fullyReported: boolean = true): string {
-  const value = Number(usd || 0);
-  if (fullyReported) return fmtCost(value);
-  return value > 0 ? `≥${fmtCost(value)}` : '—';
-}
-
 export function fmtLocalTime(isoStr: string): string {
   const d = new Date(isoStr);
   const pad = (n: number): string => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
-}
-
-export function delta(a: number | undefined | null, b: number | undefined | null, lowerIsBetter: boolean = false): string {
-  if (!a || !b || a === 0) return '';
-  const pct = ((b - a) / a * 100).toFixed(1);
-  const better = lowerIsBetter ? b < a : b > a;
-  const color = better ? 'var(--green)' : b === a ? 'var(--text-muted)' : 'var(--red)';
-  const arrow = b > a ? '↑' : b < a ? '↓' : '→';
-  return `<span style="color:${color};font-size:11px;margin-left:4px">${arrow}${Math.abs(Number(pct))}%</span>`;
 }
 
 export const COLORS: string[] = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)', 'var(--chart-6)'];


### PR DESCRIPTION
## 用户影响

清理十个没有产品、测试或构建消费者的内部导出，减少可误用的维护入口。保留同步原子写入、全局存储布局、实际断言评分及现有 Studio 展示能力，不引入替代接口。

## 契约与迁移

不改变公开测量 Schema、评分算法、prompt、路径布局或报告接受范围，无用户迁移要求。删除仅涉及内部闲置函数、别名和一个未使用 Set，不影响测量可比性。

## 交付证据

自主 CR：No findings。完整 yarn ci 通过，3662 项测试通过；测试未修改。源码净减 54 行，测试与文档净变化为 0。未改变安装或真实用户入口，不触发额外 clean-room 验收。

接续 #784，推进 #767 的附录十项清理；不关闭尚含 C1／C2 和其他待办的总 Issue。
