### PR TITLE
refactor(observability): 移除四个测试专用包装

### DIFF
--- a/src/diagnosis/observe-mapper.ts
+++ b/src/diagnosis/observe-mapper.ts
@@ -374,16 +374,6 @@ function maxSeverity(a: DiagnosisSeverity, b: DiagnosisSeverity): DiagnosisSever
   return severityRank(a) >= severityRank(b) ? a : b;
 }
 
-export function maxLifecycle(a: DiagnosisLifecycle, b: DiagnosisLifecycle): DiagnosisLifecycle {
-  // mapper 内的 upsert 合并语义:同一批 build 里多个 source 产生同 stableKey 时,
-  // 终态(resolved / rejected)是作者人为确认或驳回的结果,优先级高于自动检出态。
-  // 比如 `derivedStandard.author_confirmed` 已经把 standard 标 resolved,旁路再来一个
-  // 自动 detected 信号,应保留 resolved 而不是把 confirmation 擦掉。
-  // 「resolved 后新 occurrence 进来 reopen 到 detected」属于跨时间的 lifecycle 状态机,
-  // 由上层 review-state store 决定,不在此处处理。
-  return maxDiagnosisLifecycle(a, b);
-}
-
 function severityRank(severity: DiagnosisSeverity): number {
   if (severity === 'high') return 4;
   if (severity === 'medium') return 3;

--- a/src/eval-core/contracts/json.ts
+++ b/src/eval-core/contracts/json.ts
@@ -128,15 +128,6 @@ export function assertCanonicalJson(value: unknown): asserts value is JsonValue 
   assertCanonicalJsonValue(value, '$', new Set());
 }
 
-export function isCanonicalJson(value: unknown): value is JsonValue {
-  try {
-    assertCanonicalJson(value);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 export function parseWireDocument<T>(schema: z.ZodType<T>, value: unknown): T {
   assertCanonicalJson(value);
   return schema.parse(value);

--- a/src/executors/tool-call-status.ts
+++ b/src/executors/tool-call-status.ts
@@ -30,10 +30,6 @@ export function isToolCallCancelled(call: ToolCallOutcomeInput): boolean {
   return toolCallStatus(call) === 'cancelled';
 }
 
-export function isToolCallUnknown(call: ToolCallOutcomeInput): boolean {
-  return toolCallStatus(call) === 'unknown';
-}
-
 export function isToolResultFailureText(value: unknown): boolean {
   if (toolResultFailureJson(value)) return true;
   const text = typeof value === 'string'

--- a/src/observability/soft-standards/index.ts
+++ b/src/observability/soft-standards/index.ts
@@ -45,25 +45,3 @@ export {
 } from './skill-standards-store.js';
 
 export { extractSkillSoftStandards } from './llm-extractor.js';
-
-import {
-  normalizeRuntimeSignals,
-  normalizeRuntimeTriggers,
-  normalizeSignalOpForType,
-} from './llm-extractor.js';
-import {
-  evaluateRuntimeStandardNodes,
-  normalizeFuzzyText,
-  normalizeToolNameValue,
-  refsInScope,
-} from './runtime-evaluator.js';
-
-export const __softStandardsTestInternals = {
-  normalizeRuntimeSignals,
-  normalizeRuntimeTriggers,
-  evaluateRuntimeStandardNodes,
-  normalizeFuzzyText,
-  normalizeSignalOpForType,
-  refsInScope,
-  normalizeToolNameValue,
-};

--- a/test/diagnosis/observe-mapper.test.ts
+++ b/test/diagnosis/observe-mapper.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { buildObserveDiagnostics, maxLifecycle } from '../../src/diagnosis/observe-mapper.js';
+import { buildObserveDiagnostics } from '../../src/diagnosis/observe-mapper.js';
+import { maxDiagnosisLifecycle } from '../../src/diagnosis/lifecycle.js';
 import { activeStudioDiagnostics, buildStudioDiagnosisSummary, mergeDiagnosisBundles } from '../../src/diagnosis/studio-projection.js';
 import { parseDiagnosisBundle } from '../../src/diagnosis/contracts/parser.js';
 
@@ -153,24 +154,24 @@ describe('buildObserveDiagnostics', () => {
   });
 });
 
-describe('maxLifecycle', () => {
+describe('maxDiagnosisLifecycle', () => {
   it('终态(resolved / rejected)优先于自动检出态', () => {
     // 作者确认过的 standard(resolved)不能被新来的自动 detected 信号覆盖掉。
-    assert.equal(maxLifecycle('resolved', 'detected'), 'resolved');
-    assert.equal(maxLifecycle('detected', 'resolved'), 'resolved');
-    assert.equal(maxLifecycle('rejected', 'detected'), 'rejected');
-    assert.equal(maxLifecycle('rejected', 'candidate'), 'rejected');
+    assert.equal(maxDiagnosisLifecycle('resolved', 'detected'), 'resolved');
+    assert.equal(maxDiagnosisLifecycle('detected', 'resolved'), 'resolved');
+    assert.equal(maxDiagnosisLifecycle('rejected', 'detected'), 'rejected');
+    assert.equal(maxDiagnosisLifecycle('rejected', 'candidate'), 'rejected');
   });
 
   it('两个终态同时存在时 resolved 胜出', () => {
-    assert.equal(maxLifecycle('resolved', 'rejected'), 'resolved');
-    assert.equal(maxLifecycle('rejected', 'resolved'), 'resolved');
+    assert.equal(maxDiagnosisLifecycle('resolved', 'rejected'), 'resolved');
+    assert.equal(maxDiagnosisLifecycle('rejected', 'resolved'), 'resolved');
   });
 
   it('active 态之间按主动性排序:detected > candidate > confirmed > stale', () => {
-    assert.equal(maxLifecycle('detected', 'candidate'), 'detected');
-    assert.equal(maxLifecycle('candidate', 'confirmed'), 'candidate');
-    assert.equal(maxLifecycle('confirmed', 'stale'), 'confirmed');
+    assert.equal(maxDiagnosisLifecycle('detected', 'candidate'), 'detected');
+    assert.equal(maxDiagnosisLifecycle('candidate', 'confirmed'), 'candidate');
+    assert.equal(maxDiagnosisLifecycle('confirmed', 'stale'), 'confirmed');
   });
 });
 

--- a/test/eval-core/contracts/json.test.ts
+++ b/test/eval-core/contracts/json.test.ts
@@ -5,7 +5,6 @@ import {
   canonicalizeJsonBytes,
   deepFreezeCanonicalJson,
   digestCanonicalJson,
-  isCanonicalJson,
 } from '../../../src/eval-core/contracts/json.js';
 
 describe('Evaluation Core RFC 8785 JSON', () => {
@@ -82,7 +81,6 @@ describe('Evaluation Core RFC 8785 JSON', () => {
     new Date(),
   ])('rejects non-I-JSON value %s', (value) => {
     expect(() => canonicalizeJson(value)).toThrow(InvalidCanonicalJsonError);
-    expect(isCanonicalJson(value)).toBe(false);
   });
 
   it('rejects cycles, sparse arrays, extra properties, accessors, and symbols', () => {

--- a/test/executors/tool-call-status.test.ts
+++ b/test/executors/tool-call-status.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 import {
   isToolCallFailure,
-  isToolCallUnknown,
   isToolResultFailureText,
   toolCallStatus,
 } from '../../src/executors/tool-call-status.js';
@@ -11,7 +10,6 @@ describe('toolCallStatus', () => {
   it('keeps a missing legacy outcome unknown instead of fabricating a failure', () => {
     const call = {};
     assert.equal(toolCallStatus(call), 'unknown');
-    assert.equal(isToolCallUnknown(call), true);
     assert.equal(isToolCallFailure(call), false);
   });
 
@@ -28,7 +26,6 @@ describe('toolCallStatus', () => {
   it('fails closed on an invalid runtime status instead of trusting a legacy flag', () => {
     const malformed = { status: 'completed', success: true } as never;
     assert.equal(toolCallStatus(malformed), 'unknown');
-    assert.equal(isToolCallUnknown(malformed), true);
   });
 });
 

--- a/test/observability/soft-standards.test.ts
+++ b/test/observability/soft-standards.test.ts
@@ -1,14 +1,14 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import {
-  __softStandardsTestInternals,
   type RuntimeSignal,
   type RuntimeSignalType,
   type RuntimeStandardNode,
 } from '../../src/observability/soft-standards/index.js';
 import type { SkillRuntimeEvidencePack, SkillRuntimeEvidencePackRef, SkillRuntimeEvidencePackSourceType } from '../../src/observability/skill-health/skill-chain.js';
 
-const { evaluateRuntimeStandardNodes, normalizeRuntimeSignals, normalizeRuntimeTriggers, normalizeFuzzyText, normalizeToolNameValue } = __softStandardsTestInternals;
+import { normalizeRuntimeSignals, normalizeRuntimeTriggers } from '../../src/observability/soft-standards/llm-extractor.js';
+import { evaluateRuntimeStandardNodes, normalizeFuzzyText, normalizeToolNameValue } from '../../src/observability/soft-standards/runtime-evaluator.js';
 
 function ref(input: {
   id: string;


### PR DESCRIPTION
## 用户影响

移除四个仅供测试使用的内部包装，让测试直接约束实际 JSON 校验、工具状态、生命周期优先级和 soft standards 求值函数。删除多余入口，不为保留测试新增产品调用或私有状态旁路。

## 契约与迁移

公开测量 Schema、prompt、评分、报告及持久化契约不变，无用户迁移要求。实际算法与测试用例保留，仅删除已被直接断言覆盖的包装断言，测量可比性不变。

## 交付证据

自主 CR：No findings。完整 yarn ci 通过，仍为 3662 项测试。源码净减 45 行，测试净减 4 行，总净减 49 行。未改变安装或真实用户入口，不触发额外 clean-room 验收。

接续 #785，推进 #767 附录中的 isCanonicalJson、isToolCallUnknown、maxLifecycle 和 __softStandardsTestInternals；总 Issue 仍有其他待办，不关闭。
