### PR TITLE
refactor(eval-core): 将八个测试便捷调用移出生产入口

### DIFF
--- a/src/eval-core/analysis/decision.ts
+++ b/src/eval-core/analysis/decision.ts
@@ -578,42 +578,6 @@ export function startDecision(
   };
 }
 
-export async function decideAnalysis(
-  plan: SealedRunPlan,
-  executionValue: ExecutionBundleSource,
-  evaluationValue: EvaluationBundleSource,
-  analysisValue: AnalysisBundleSource,
-  ports: AnalysisRuntimePorts,
-  options: DecisionOptions,
-): Promise<DecisionResult | undefined> {
-  return startDecision(
-    plan,
-    executionValue,
-    evaluationValue,
-    analysisValue,
-    ports,
-    options,
-  ).result;
-}
-
-export async function decideAnalysisSource(
-  plan: SealedRunPlan,
-  executionValue: ExecutionBundleSource,
-  evaluationValue: EvaluationBundleSource,
-  analysisValue: AnalysisBundleSource,
-  ports: AnalysisRuntimePorts,
-  options: DecisionOptions,
-): Promise<DecisionResultSource | undefined> {
-  return startDecision(
-    plan,
-    executionValue,
-    evaluationValue,
-    analysisValue,
-    ports,
-    options,
-  ).source;
-}
-
 export function materializeEvaluationReport(
   plan: SealedRunPlan,
   executionSource: ExecutionBundleSource,

--- a/src/eval-core/analysis/runtime.ts
+++ b/src/eval-core/analysis/runtime.ts
@@ -1243,22 +1243,3 @@ export function startAnalysis(
   };
 }
 
-export async function analyzeEvaluationBundle(
-  plan: SealedRunPlan,
-  executionBundle: ExecutionBundleSource,
-  evaluationBundle: EvaluationBundleSource,
-  ports: AnalysisRuntimePorts,
-  options: AnalysisRunOptions,
-): Promise<AnalysisBundle> {
-  return startAnalysis(plan, executionBundle, evaluationBundle, ports, options).result;
-}
-
-export async function analyzeEvaluationBundleSource(
-  plan: SealedRunPlan,
-  executionBundle: ExecutionBundleSource,
-  evaluationBundle: EvaluationBundleSource,
-  ports: AnalysisRuntimePorts,
-  options: AnalysisRunOptions,
-): Promise<AnalysisBundleSource> {
-  return startAnalysis(plan, executionBundle, evaluationBundle, ports, options).source;
-}

--- a/src/eval-core/evaluation/runtime.ts
+++ b/src/eval-core/evaluation/runtime.ts
@@ -1605,20 +1605,3 @@ export function startEvaluation(
   };
 }
 
-export async function evaluateExecutionBundle(
-  plan: SealedRunPlan,
-  source: ExecutionBundleSource,
-  ports: EvaluationRuntimePorts,
-  options: EvaluationRunOptions,
-): Promise<EvaluationBundle> {
-  return startEvaluation(plan, source, ports, options).result;
-}
-
-export async function evaluateExecutionBundleSource(
-  plan: SealedRunPlan,
-  source: ExecutionBundleSource,
-  ports: EvaluationRuntimePorts,
-  options: EvaluationRunOptions,
-): Promise<EvaluationBundleSource> {
-  return startEvaluation(plan, source, ports, options).source;
-}

--- a/src/eval-core/execution/runtime.ts
+++ b/src/eval-core/execution/runtime.ts
@@ -1553,18 +1553,3 @@ export function startExecution(
   };
 }
 
-export async function executeRunPlan(
-  plan: SealedRunPlan,
-  ports: ExecutionRuntimePorts,
-  options: ExecutionRunOptions,
-): Promise<ExecutionBundle> {
-  return startExecution(plan, ports, options).result;
-}
-
-export async function executeRunPlanSource(
-  plan: SealedRunPlan,
-  ports: ExecutionRuntimePorts,
-  options: ExecutionRunOptions,
-): Promise<ExecutionBundleSource> {
-  return startExecution(plan, ports, options).source;
-}

--- a/test/dsh-plugin/core-adapter.test.ts
+++ b/test/dsh-plugin/core-adapter.test.ts
@@ -1,3 +1,6 @@
+import {
+  executeRunPlan,
+} from '../helpers/core-runs.js';
 import type { EvalConfig } from '../../src/eval-workflows/inputs/contracts/config.js';
 import { runDshCoreEvaluation } from '../../src/dsh-plugin/core-command.js';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
@@ -15,7 +18,6 @@ import {
 import { prepareEvaluationPlan } from '../../src/eval-core/compiler/index.js';
 import {
   InMemoryRuntimeEventSequencer,
-  executeRunPlan,
   type ExecutionExecutor,
   type ExecutorAttemptResult,
   type ExecutorTrialContext,

--- a/test/eval-core/analysis/runtime.test.ts
+++ b/test/eval-core/analysis/runtime.test.ts
@@ -1,3 +1,11 @@
+import {
+  executeRunPlanSource,
+  evaluateExecutionBundleSource,
+  analyzeEvaluationBundle,
+  analyzeEvaluationBundleSource,
+  decideAnalysis,
+  decideAnalysisSource,
+} from '../../helpers/core-runs.js';
 import { describe, expect, it } from 'vitest';
 import {
   digestArtifactPayload,
@@ -22,25 +30,19 @@ import {
   type PreparationRuntime,
 } from '../../../src/eval-core/compiler/index.js';
 import {
-  executeRunPlanSource,
   InMemoryRuntimeEventSequencer,
   type ExecutionClock,
   type ExecutionExecutor,
 } from '../../../src/eval-core/execution/index.js';
 import {
-  evaluateExecutionBundleSource,
   type EvaluationEvaluator,
 } from '../../../src/eval-core/evaluation/index.js';
 import {
-  analyzeEvaluationBundle,
-  analyzeEvaluationBundleSource,
   BUILTIN_HYPOTHESIS_TABLE_SCHEMA,
   createBuiltinAnalysisNodes,
   createBuiltinAnalysisSchemaValidators,
   createBuiltinDecisionPolicies,
   createBuiltinMissingPolicies,
-  decideAnalysis,
-  decideAnalysisSource,
   resolveBuiltinAnalysisRuntime,
   startAnalysis,
   startDecision,

--- a/test/eval-core/evaluation/runtime.test.ts
+++ b/test/eval-core/evaluation/runtime.test.ts
@@ -1,3 +1,7 @@
+import {
+  executeRunPlanSource,
+  evaluateExecutionBundle,
+} from '../../helpers/core-runs.js';
 import { describe, expect, it } from 'vitest';
 import {
   aggregateEvaluationAttemptUsage,
@@ -20,7 +24,6 @@ import {
 } from '../../../src/eval-core/contracts/index.js';
 import { prepareEvaluationPlan } from '../../../src/eval-core/compiler/index.js';
 import {
-  executeRunPlanSource,
   InMemoryRuntimeEventSequencer,
   type ExecutionClock,
   type ExecutionExecutor,
@@ -28,7 +31,6 @@ import {
 import {
   EvaluationPortFailure,
   EvaluationRuntimeConfigurationError,
-  evaluateExecutionBundle,
   startEvaluation,
   type EvaluationCache,
   type EvaluationCacheEntry,

--- a/test/eval-core/execution/runtime.test.ts
+++ b/test/eval-core/execution/runtime.test.ts
@@ -1,3 +1,6 @@
+import {
+  executeRunPlan,
+} from '../../helpers/core-runs.js';
 import { describe, expect, it } from 'vitest';
 import {
   deriveAttemptId,
@@ -14,7 +17,6 @@ import {
   ExecutionRuntimeConfigurationError,
   InMemoryRuntimeEventSequencer,
   deriveExecutionSchedule,
-  executeRunPlan,
   startExecution,
   type ExecutionCache,
   type ExecutionCacheEntry,

--- a/test/eval-workflows/hosts/adapters/anthropic/api.test.ts
+++ b/test/eval-workflows/hosts/adapters/anthropic/api.test.ts
@@ -1,3 +1,6 @@
+import {
+  executeRunPlan,
+} from '../../../../helpers/core-runs.js';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -13,7 +16,6 @@ import {
 import { prepareEvaluationPlan } from '../../../../../src/eval-core/compiler/index.js';
 import {
   InMemoryRuntimeEventSequencer,
-  executeRunPlan,
   type ExecutionExecutor,
   type ExecutorAttemptResult,
 } from '../../../../../src/eval-core/execution/index.js';

--- a/test/eval-workflows/hosts/adapters/claude/cli.test.ts
+++ b/test/eval-workflows/hosts/adapters/claude/cli.test.ts
@@ -1,4 +1,7 @@
 import {
+  executeRunPlan,
+} from '../../../../helpers/core-runs.js';
+import {
   chmod,
   copyFile,
   mkdir,
@@ -25,7 +28,6 @@ import {
 import { prepareEvaluationPlan } from '../../../../../src/eval-core/compiler/index.js';
 import {
   InMemoryRuntimeEventSequencer,
-  executeRunPlan,
   type ExecutionExecutor,
   type ExecutorAttemptResult,
   type ExecutorTrialContext,

--- a/test/eval-workflows/hosts/adapters/claude/sdk.test.ts
+++ b/test/eval-workflows/hosts/adapters/claude/sdk.test.ts
@@ -1,4 +1,7 @@
 import {
+  executeRunPlan,
+} from '../../../../helpers/core-runs.js';
+import {
   mkdtemp,
   realpath,
   rm,
@@ -19,7 +22,6 @@ import {
 import { prepareEvaluationPlan } from '../../../../../src/eval-core/compiler/index.js';
 import {
   InMemoryRuntimeEventSequencer,
-  executeRunPlan,
   type ExecutionExecutor,
   type ExecutorAttemptResult,
   type ExecutorTrialContext,

--- a/test/eval-workflows/hosts/adapters/codex/cli.test.ts
+++ b/test/eval-workflows/hosts/adapters/codex/cli.test.ts
@@ -1,4 +1,7 @@
 import {
+  executeRunPlan,
+} from '../../../../helpers/core-runs.js';
+import {
   chmod,
   copyFile,
   mkdir,
@@ -26,7 +29,6 @@ import {
   type ExecutionExecutor,
   type ExecutorAttemptResult,
   type ExecutorTrialContext,
-  executeRunPlan,
 } from '../../../../../src/eval-core/execution/index.js';
 import { prepareEvaluationPlan } from '../../../../../src/eval-core/compiler/index.js';
 import {

--- a/test/eval-workflows/hosts/adapters/codex/sdk.test.ts
+++ b/test/eval-workflows/hosts/adapters/codex/sdk.test.ts
@@ -1,4 +1,7 @@
 import {
+  executeRunPlan,
+} from '../../../../helpers/core-runs.js';
+import {
   mkdir,
   mkdtemp,
   stat,
@@ -21,7 +24,6 @@ import {
   type ExecutionExecutor,
   type ExecutorAttemptResult,
   type ExecutorTrialContext,
-  executeRunPlan,
 } from '../../../../../src/eval-core/execution/index.js';
 import {
   CODEX_SDK_WORKSPACE_WRITE_SANDBOX_ID,

--- a/test/eval-workflows/hosts/adapters/custom/command.test.ts
+++ b/test/eval-workflows/hosts/adapters/custom/command.test.ts
@@ -1,3 +1,6 @@
+import {
+  executeRunPlan,
+} from '../../../../helpers/core-runs.js';
 import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import {
@@ -26,7 +29,6 @@ import {
 import {
   ExecutionPortFailure,
   InMemoryRuntimeEventSequencer,
-  executeRunPlan,
   type ExecutionExecutor,
   type ExecutorAttemptResult,
   type ExecutorTrialContext,

--- a/test/eval-workflows/hosts/adapters/openai/api.test.ts
+++ b/test/eval-workflows/hosts/adapters/openai/api.test.ts
@@ -1,3 +1,6 @@
+import {
+  executeRunPlan,
+} from '../../../../helpers/core-runs.js';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -13,7 +16,6 @@ import {
 import { prepareEvaluationPlan } from '../../../../../src/eval-core/compiler/index.js';
 import {
   InMemoryRuntimeEventSequencer,
-  executeRunPlan,
   type ExecutionExecutor,
   type ExecutorAttemptResult,
 } from '../../../../../src/eval-core/execution/index.js';

--- a/test/eval-workflows/hosts/evaluators/rubric-judge.test.ts
+++ b/test/eval-workflows/hosts/evaluators/rubric-judge.test.ts
@@ -1,3 +1,7 @@
+import {
+  executeRunPlanSource,
+  evaluateExecutionBundle,
+} from '../../../helpers/core-runs.js';
 import { describe, expect, it } from 'vitest';
 import type {
   EvaluationDefinition,
@@ -15,13 +19,11 @@ import {
   type PreparationRuntime,
 } from '../../../../src/eval-core/compiler/index.js';
 import {
-  executeRunPlanSource,
   InMemoryRuntimeEventSequencer,
   type ExecutionClock,
   type ExecutionExecutor,
 } from '../../../../src/eval-core/execution/index.js';
 import {
-  evaluateExecutionBundle,
   type EvaluationCache,
   type EvaluationCacheEntry,
 } from '../../../../src/eval-core/evaluation/index.js';

--- a/test/eval-workflows/measurement/analysis/assertion-layer-core.test.ts
+++ b/test/eval-workflows/measurement/analysis/assertion-layer-core.test.ts
@@ -1,3 +1,8 @@
+import {
+  analyzeEvaluationBundleSource,
+  executeRunPlanSource,
+  evaluateExecutionBundleSource,
+} from '../../../helpers/core-runs.js';
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_BOOTSTRAP_SEED } from '../../../../src/eval-workflows/analysis/bootstrap.js';
 import {
@@ -12,7 +17,6 @@ import {
   type PreparationRuntime,
 } from '../../../../src/eval-core/compiler/index.js';
 import {
-  analyzeEvaluationBundleSource,
   createBuiltinAnalysisSchemaValidators,
   createBuiltinMissingPolicies,
   resolveBuiltinAnalysisRuntime,
@@ -20,13 +24,11 @@ import {
   type AnalysisNodeRunContext,
 } from '../../../../src/eval-core/analysis/index.js';
 import {
-  executeRunPlanSource,
   InMemoryRuntimeEventSequencer,
   type ExecutionClock,
   type ExecutionExecutor,
 } from '../../../../src/eval-core/execution/index.js';
 import {
-  evaluateExecutionBundleSource,
   type EvaluationEvaluator,
 } from '../../../../src/eval-core/evaluation/index.js';
 import {

--- a/test/eval-workflows/measurement/analysis/judge-aggregation.test.ts
+++ b/test/eval-workflows/measurement/analysis/judge-aggregation.test.ts
@@ -1,3 +1,9 @@
+import {
+  analyzeEvaluationBundleSource,
+  decideAnalysisSource,
+  executeRunPlanSource,
+  evaluateExecutionBundleSource,
+} from '../../../helpers/core-runs.js';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -26,21 +32,17 @@ import type {
   AnalysisNodeRunContext,
 } from '../../../../src/eval-core/analysis/index.js';
 import {
-  analyzeEvaluationBundleSource,
   createBuiltinAnalysisSchemaValidators,
   createBuiltinMissingPolicies,
-  decideAnalysisSource,
   resolveBuiltinAnalysisRuntime,
 } from '../../../../src/eval-core/analysis/index.js';
 import { DEFAULT_BOOTSTRAP_SEED } from '../../../../src/eval-workflows/analysis/bootstrap.js';
 import {
-  executeRunPlanSource,
   InMemoryRuntimeEventSequencer,
   type ExecutionClock,
   type ExecutionExecutor,
 } from '../../../../src/eval-core/execution/index.js';
 import {
-  evaluateExecutionBundleSource,
   type EvaluationEvaluator,
 } from '../../../../src/eval-core/evaluation/index.js';
 import {

--- a/test/eval-workflows/measurement/evaluators/execution-assertions.test.ts
+++ b/test/eval-workflows/measurement/evaluators/execution-assertions.test.ts
@@ -1,3 +1,7 @@
+import {
+  evaluateExecutionBundle,
+  executeRunPlanSource,
+} from '../../../helpers/core-runs.js';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -11,7 +15,6 @@ import {
   type RuntimeIdentity,
 } from '../../../../src/eval-core/contracts/index.js';
 import {
-  evaluateExecutionBundle,
   type EvaluationCache,
   type EvaluationCacheEntry,
   type EvaluationClock,
@@ -23,7 +26,6 @@ import {
   type PreparationRuntime,
 } from '../../../../src/eval-core/compiler/index.js';
 import {
-  executeRunPlanSource,
   InMemoryRuntimeEventSequencer,
   type ExecutionExecutor,
 } from '../../../../src/eval-core/execution/index.js';

--- a/test/eval-workflows/measurement/evaluators/llm-assertions.test.ts
+++ b/test/eval-workflows/measurement/evaluators/llm-assertions.test.ts
@@ -1,3 +1,7 @@
+import {
+  executeRunPlanSource,
+  evaluateExecutionBundle,
+} from '../../../helpers/core-runs.js';
 import { describe, expect, it } from 'vitest';
 import type {
   EvaluationDefinition,
@@ -15,13 +19,11 @@ import {
   type PreparationRuntime,
 } from '../../../../src/eval-core/compiler/index.js';
 import {
-  executeRunPlanSource,
   InMemoryRuntimeEventSequencer,
   type ExecutionClock,
   type ExecutionExecutor,
 } from '../../../../src/eval-core/execution/index.js';
 import {
-  evaluateExecutionBundle,
   type EvaluationCache,
   type EvaluationCacheEntry,
 } from '../../../../src/eval-core/evaluation/index.js';

--- a/test/eval-workflows/measurement/evaluators/output-assertions.test.ts
+++ b/test/eval-workflows/measurement/evaluators/output-assertions.test.ts
@@ -1,3 +1,7 @@
+import {
+  executeRunPlanSource,
+  evaluateExecutionBundle,
+} from '../../../helpers/core-runs.js';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -16,13 +20,11 @@ import {
   type PreparationRuntime,
 } from '../../../../src/eval-core/compiler/index.js';
 import {
-  executeRunPlanSource,
   InMemoryRuntimeEventSequencer,
   type ExecutionClock,
   type ExecutionExecutor,
 } from '../../../../src/eval-core/execution/index.js';
 import {
-  evaluateExecutionBundle,
   type EvaluationEvaluator,
 } from '../../../../src/eval-core/evaluation/index.js';
 import {

--- a/test/helpers/core-runs.ts
+++ b/test/helpers/core-runs.ts
@@ -1,0 +1,38 @@
+// Test-only Promise conveniences around the actual streaming Core APIs.
+// async preserves rejection semantics when a start API throws synchronously.
+import { startExecution } from '../../src/eval-core/execution/runtime.js';
+import { startEvaluation } from '../../src/eval-core/evaluation/runtime.js';
+import { startAnalysis } from '../../src/eval-core/analysis/runtime.js';
+import { startDecision } from '../../src/eval-core/analysis/decision.js';
+
+export async function executeRunPlan(...args: Parameters<typeof startExecution>) {
+  return startExecution(...args).result;
+}
+
+export async function executeRunPlanSource(...args: Parameters<typeof startExecution>) {
+  return startExecution(...args).source;
+}
+
+export async function evaluateExecutionBundle(...args: Parameters<typeof startEvaluation>) {
+  return startEvaluation(...args).result;
+}
+
+export async function evaluateExecutionBundleSource(...args: Parameters<typeof startEvaluation>) {
+  return startEvaluation(...args).source;
+}
+
+export async function analyzeEvaluationBundle(...args: Parameters<typeof startAnalysis>) {
+  return startAnalysis(...args).result;
+}
+
+export async function analyzeEvaluationBundleSource(...args: Parameters<typeof startAnalysis>) {
+  return startAnalysis(...args).source;
+}
+
+export async function decideAnalysis(...args: Parameters<typeof startDecision>) {
+  return startDecision(...args).result;
+}
+
+export async function decideAnalysisSource(...args: Parameters<typeof startDecision>) {
+  return startDecision(...args).source;
+}


### PR DESCRIPTION
## 用户影响

移除八个没有产品消费者的 Core Promise 便捷入口，测试统一通过测试辅助模块调用实际流式 start API。Core 不再为测试便捷性维护另一组生产导出，执行、评价、分析和决策能力均保留。

## 契约与迁移

保留 result／source 的区别、Source 认证、事件流和预算契约。测试辅助保留 async 将同步异常转为 Promise 拒绝的行为，不复制领域实现。公开测量 Schema、prompt、评分及持久化语义不变，无用户迁移要求。

## 交付证据

自主 CR：No findings。完整 yarn ci 通过，3662 项测试全部保留；后续仅恢复导入排版，未改变行为，不机械重跑全量门禁。源码净减 87 行，测试净增 72 行，总净减 15 行。未改变安装或真实用户入口，不触发额外 clean-room 验收。

接续 #786，完成 #767 附录八个 Core 薄包装的迁移。总 Issue 仍包含 C1／C2 等待办，不关闭。
