### PR TITLE
refactor(eval-core): 删除无调用的可比性来源断言

### DIFF
--- a/src/eval-core/contracts/comparability.ts
+++ b/src/eval-core/contracts/comparability.ts
@@ -621,20 +621,6 @@ export interface ComparabilityAssessmentSource {
   readonly planVerification: ComparabilityAssessmentPlanVerification;
 }
 
-const comparabilityAssessmentSources = new WeakSet<object>();
-
-export function assertComparabilityAssessmentSource(
-  value: unknown,
-): asserts value is ComparabilityAssessmentSource {
-  if (value === null
-      || typeof value !== 'object'
-      || !comparabilityAssessmentSources.has(value)) {
-    throw new TypeError(
-      'Automated comparison requires a source returned by assessComparability() or parseComparabilityAssessment().',
-    );
-  }
-}
-
 function equalJson(left: unknown, right: unknown): boolean {
   return canonicalizeJson(left) === canonicalizeJson(right);
 }
@@ -1591,7 +1577,6 @@ function makeAssessmentSource(assessment: ComparabilityAssessment): Comparabilit
       rightRunIdentityDigest: assessment.right.runIdentityDigest as Sha256Digest,
     },
   });
-  comparabilityAssessmentSources.add(source);
   return source;
 }
 


### PR DESCRIPTION
## 用户影响

删除没有实际消费者的内部来源断言及其专属身份登记，减少闲置状态维护。实际可比性评估、Schema identity、摘要验证和来源链校验保持不变，无需迁移。

## 验证与范围

本地 `yarn ci` 通过，340 个测试文件、3675 项测试全部成功。本批源码净减 15 行，没有删除或修改测试。基于已应用补丁及引用证据的审查未发现问题；未额外重读完整文件。

关联 #767，仅处理附录 `assertComparabilityAssessmentSource`，不关闭总任务。