### PR TITLE
refactor(observability): 删除闲置统计与观测便利入口

### DIFF
--- a/src/eval-workflows/measurement/analysis/bootstrap-family-table.ts
+++ b/src/eval-workflows/measurement/analysis/bootstrap-family-table.ts
@@ -513,10 +513,6 @@ export const BOOTSTRAP_FAMILY_TABLE_SCHEMA = analysisSchemaIdentity(
   ]),
 );
 
-export function parseBootstrapFamilyTableValue(value: unknown): BootstrapFamilyTableValue {
-  return BootstrapFamilyTableValueSchema.superRefine(validateBootstrapFamilyTable).parse(value);
-}
-
 export function parseBootstrapFamilyTableEnvelope(value: unknown): Readonly<{
   resultType: 'table';
   value: BootstrapFamilyTableValue;

--- a/src/eval-workflows/measurement/analysis/dimension-table-v1.ts
+++ b/src/eval-workflows/measurement/analysis/dimension-table-v1.ts
@@ -1,21 +1,6 @@
 import { z } from 'zod';
-import {
-  IdentifierSchema,
-  SamplingUnitIdsSchema,
-  Sha256DigestSchema,
-  canonicalizeJson,
-  digestCanonicalJson,
-  schemaIdentityKey,
-  type CoreSchemaValidator,
-  type JsonValue,
-} from '../../../eval-core/contracts/index.js';
-import {
-  analysisJsonSchema,
-  analysisSchemaIdentity,
-  compareStrings,
-  createAnalysisSchemaValidator,
-  round,
-} from './analysis-support.js';
+import { IdentifierSchema, SamplingUnitIdsSchema, Sha256DigestSchema, canonicalizeJson, digestCanonicalJson, type JsonValue } from '../../../eval-core/contracts/index.js';
+import { analysisJsonSchema, analysisSchemaIdentity, compareStrings, round } from './analysis-support.js';
 
 export const DIMENSION_TABLE_SCHEMA_VERSION = 'omk.dimension-table/v1' as const;
 export const DIMENSION_SCORE_DECIMALS = 2;
@@ -245,25 +230,6 @@ export const DIMENSION_TABLE_SCHEMA = analysisSchemaIdentity(
     'raw judge evidence, usage, cost, and direct Metric row membership are not copied',
   ]),
 );
-
-export function parseDimensionTableValue(value: unknown): DimensionTableValue {
-  return DimensionTableValueSchema.parse(value);
-}
-
-export function compareDimensionGroups(left: DimensionGroup, right: DimensionGroup): number {
-  return compareStrings(unitKey(left), unitKey(right));
-}
-
-export function createDimensionTableSchemaValidators(): ReadonlyMap<
-  string,
-  CoreSchemaValidator
-> {
-  const validator = createAnalysisSchemaValidator(
-    DIMENSION_TABLE_SCHEMA,
-    (value) => parseDimensionTableEnvelope(value) as JsonValue,
-  );
-  return new Map([[schemaIdentityKey(validator.schema), validator]]);
-}
 
 export function parseDimensionTableEnvelope(value: unknown): Readonly<{
   resultType: 'table';

--- a/src/observability/analysis/gap-analyzer.ts
+++ b/src/observability/analysis/gap-analyzer.ts
@@ -22,7 +22,6 @@ import type { AnalysisEntry, AnalysisVariantResult, GapReport, GapSignalRef } fr
 import { classifyHedgingCandidates, type ClassifyOptions, type HedgingCandidate } from './hedging-classifier.js';
 import { isFailedSearchToolCall, toolCallQuery } from '../trace/tool-search.js';
 import { toolCallStatus } from '../../executors/tool-call-status.js';
-import { setOwnRecordValue } from '../../shared/record-count.js';
 
 export type GapSignalType = GapSignalRef['type'];
 export type GapSignal = GapSignalRef;
@@ -487,23 +486,4 @@ export async function applyHedgingClassifier(
 
   const next = recomputeAggregates({ ...report, signals: newSignals });
   return { report: next, costUSD, truncated };
-}
-
-/**
- * 批量为一组 variant 的 gap reports 跑 classifier。
- * 串行(不并行)避免 rate limit + 让 cache hit 在第一批后被后续 batch 复用。
- */
-export async function applyHedgingClassifierToReports(
-  reports: Record<string, GapReport>,
-  executor: ExecutorFn,
-  opts: ClassifyOptions,
-): Promise<{ reports: Record<string, GapReport>; costUSD: number }> {
-  const out: Record<string, GapReport> = {};
-  let totalCost = 0;
-  for (const [variant, report] of Object.entries(reports)) {
-    const result = await applyHedgingClassifier(report, executor, opts);
-    setOwnRecordValue(out, variant, result.report);
-    totalCost += result.costUSD;
-  }
-  return { reports: out, costUSD: totalCost };
 }

--- a/src/observability/conversation/catalog.ts
+++ b/src/observability/conversation/catalog.ts
@@ -7,7 +7,7 @@ import {
   statSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { DatabaseSync } from 'node:sqlite';
 import type { ExperienceTurnStatus } from '../contracts/experience.js';
@@ -711,8 +711,4 @@ function findRolloutPath(root: string, threadId: string): string | undefined {
     }
   }
   return undefined;
-}
-
-export function conversationSourceLabel(path: string): string {
-  return basename(path).replace(/\.jsonl$/u, '');
 }

--- a/src/observability/inbox/resolved-review.ts
+++ b/src/observability/inbox/resolved-review.ts
@@ -115,14 +115,6 @@ function normalizeResolvedSkillType(value?: ExperienceRuntimeSkillType | LlmEnha
   return undefined;
 }
 
-export function resolveObservationReviewPriority(
-  priority: ExperienceReviewPriority,
-  enhancedReview: SkillLlmEnhancedReviewSections | undefined,
-  hasManualReview: boolean,
-): ExperienceReviewPriority {
-  return resolvePriority(priority, enhancedReview, hasManualReview);
-}
-
 function resolvePriority(
   priority: ExperienceReviewPriority,
   enhancedReview: SkillLlmEnhancedReviewSections | undefined,

--- a/src/observability/trace/trace-ir.ts
+++ b/src/observability/trace/trace-ir.ts
@@ -231,10 +231,6 @@ function canonicalTraceSourcePath(sourcePath: string): string {
   }
 }
 
-export function traceEventTimestamp(event: TraceEvent): string | undefined {
-  return event.timestamp;
-}
-
 export function normalizeTraceTimestamp(value: unknown): string | undefined {
   return normalizeRfc3339Timestamp(value);
 }
@@ -252,10 +248,6 @@ export function traceTimestampBounds(values: Iterable<unknown>): {
     if (!endTimestamp || timestamp > endTimestamp) endTimestamp = timestamp;
   }
   return { startTimestamp, endTimestamp };
-}
-
-export function traceToolDisplayName(tool: TraceToolRef): string {
-  return tool.displayName ?? tool.name;
 }
 
 /**


### PR DESCRIPTION
## 用户影响

清理九项没有实际消费者的内部便利导出及失去引用的 import，不新增替代产品能力。保留实际 Trace 解析、单报告分类、会话发现、审阅优先级解析，以及 Bootstrap 和 Dimension 的 Envelope 校验。

旧版 Dimension 的 Schema identity 与统计语义不变，新版同名入口不受影响，无需数据迁移，不改变测量可比性。

## 验证与范围

本地完整 `yarn ci` 通过，340 个测试文件、3675 项测试全部保留并通过。本批六个源码文件净减 78 行，包含 import 清理与格式变化；未修改测试。按此前逐项引用证据实施定点删除，未额外重读完整文件。

关联 #767，处理对应九项附录记录，不关闭总任务。