### PR TITLE
refactor(executors): 统一 Codex 沙箱常量引用

### DIFF
--- a/src/eval-workflows/hosts/adapters/codex/cli-protocol.ts
+++ b/src/eval-workflows/hosts/adapters/codex/cli-protocol.ts
@@ -1,16 +1,11 @@
 import { ExecutionPortFailure } from '../../../../eval-core/execution/index.js';
 import {
-  CODEX_READ_ONLY_SANDBOX_ID,
-  CODEX_WORKSPACE_WRITE_SANDBOX_ID,
   codexCoreExecutorCapabilities,
   createCodexCoreSchemaValidators,
   parseCodexCoreEvents,
   type CodexCoreProtocolProfile,
   type ParsedCodexCoreStream,
 } from './protocol-core.js';
-
-export const CODEX_CLI_READ_ONLY_SANDBOX_ID = CODEX_READ_ONLY_SANDBOX_ID;
-export const CODEX_CLI_WORKSPACE_WRITE_SANDBOX_ID = CODEX_WORKSPACE_WRITE_SANDBOX_ID;
 export type ParsedCodexCliStream = ParsedCodexCoreStream;
 
 const CODEX_CLI_PROTOCOL_PROFILE = Object.freeze({

--- a/src/eval-workflows/hosts/adapters/codex/cli.ts
+++ b/src/eval-workflows/hosts/adapters/codex/cli.ts
@@ -53,8 +53,6 @@ import {
 import { createSameProcessExecutorAdapter } from '../../../../eval-runtime/adapters/same-process.js';
 
 export {
-  CODEX_CLI_READ_ONLY_SANDBOX_ID,
-  CODEX_CLI_WORKSPACE_WRITE_SANDBOX_ID,
   createCodexCliCoreSchemaValidators,
 } from './cli-protocol.js';
 

--- a/src/eval-workflows/hosts/adapters/codex/sdk-protocol.ts
+++ b/src/eval-workflows/hosts/adapters/codex/sdk-protocol.ts
@@ -1,15 +1,10 @@
 import {
-  CODEX_READ_ONLY_SANDBOX_ID,
-  CODEX_WORKSPACE_WRITE_SANDBOX_ID,
   codexCoreExecutorCapabilities,
   createCodexCoreSchemaValidators,
   parseCodexCoreEvents,
   type CodexCoreProtocolProfile,
   type ParsedCodexCoreStream,
 } from './protocol-core.js';
-
-export const CODEX_SDK_READ_ONLY_SANDBOX_ID = CODEX_READ_ONLY_SANDBOX_ID;
-export const CODEX_SDK_WORKSPACE_WRITE_SANDBOX_ID = CODEX_WORKSPACE_WRITE_SANDBOX_ID;
 export type ParsedCodexSdkStream = ParsedCodexCoreStream;
 
 const CODEX_SDK_PROTOCOL_PROFILE = Object.freeze({

--- a/src/eval-workflows/hosts/adapters/codex/sdk.ts
+++ b/src/eval-workflows/hosts/adapters/codex/sdk.ts
@@ -53,8 +53,6 @@ import {
 import { createSameProcessExecutorAdapter } from '../../../../eval-runtime/adapters/same-process.js';
 
 export {
-  CODEX_SDK_READ_ONLY_SANDBOX_ID,
-  CODEX_SDK_WORKSPACE_WRITE_SANDBOX_ID,
   createCodexSdkCoreSchemaValidators,
 } from './sdk-protocol.js';
 export {

--- a/test/eval-workflows/hosts/adapters/codex/cli.test.ts
+++ b/test/eval-workflows/hosts/adapters/codex/cli.test.ts
@@ -1,3 +1,4 @@
+import { CODEX_WORKSPACE_WRITE_SANDBOX_ID } from '../../../../../src/eval-workflows/hosts/adapters/codex/protocol-core.js';
 import {
   executeRunPlan,
 } from '../../../../helpers/core-runs.js';
@@ -32,7 +33,6 @@ import {
 } from '../../../../../src/eval-core/execution/index.js';
 import { prepareEvaluationPlan } from '../../../../../src/eval-core/compiler/index.js';
 import {
-  CODEX_CLI_WORKSPACE_WRITE_SANDBOX_ID,
   createCodexCliCoreSchemaValidators,
 } from '../../../../../src/eval-workflows/hosts/adapters/codex/cli-protocol.js';
 import {
@@ -468,7 +468,7 @@ describe('Codex CLI Core Executor adapter', () => {
   it.each([false, true])('isolates sequential trials while retaining same-trial attempts（workspace=%s）', async (workspace) => {
     const fixture = await adapterFixture({
       workspace,
-      ...(workspace ? { sandboxId: CODEX_CLI_WORKSPACE_WRITE_SANDBOX_ID } : {}),
+      ...(workspace ? { sandboxId: CODEX_WORKSPACE_WRITE_SANDBOX_ID } : {}),
     });
     const adapter = await createAdapter(fixture, { OMK_TEST_MODE: 'workspace-state' });
     const run = await adapter.openRun({ runId: 'run-a', executionPlanDigest: digest('plan') });
@@ -510,7 +510,7 @@ describe('Codex CLI Core Executor adapter', () => {
   it('uses a trial-private workspace copy and elevates output classification', async () => {
     const fixture = await adapterFixture({
       workspace: true,
-      sandboxId: CODEX_CLI_WORKSPACE_WRITE_SANDBOX_ID,
+      sandboxId: CODEX_WORKSPACE_WRITE_SANDBOX_ID,
     });
     const capture = join(fixture.root, 'workspace-capture.json');
     const result = await execute(

--- a/test/eval-workflows/hosts/adapters/codex/sdk.test.ts
+++ b/test/eval-workflows/hosts/adapters/codex/sdk.test.ts
@@ -1,3 +1,4 @@
+import { CODEX_WORKSPACE_WRITE_SANDBOX_ID } from '../../../../../src/eval-workflows/hosts/adapters/codex/protocol-core.js';
 import {
   executeRunPlan,
 } from '../../../../helpers/core-runs.js';
@@ -26,7 +27,6 @@ import {
   type ExecutorTrialContext,
 } from '../../../../../src/eval-core/execution/index.js';
 import {
-  CODEX_SDK_WORKSPACE_WRITE_SANDBOX_ID,
   createCodexSdkCoreSchemaValidators,
 } from '../../../../../src/eval-workflows/hosts/adapters/codex/sdk-protocol.js';
 import {
@@ -129,7 +129,7 @@ async function adapterFixture(options: Readonly<{
     behavior: {
       artifact: artifactDescriptor,
       ...(options.workspace ? {
-        sandbox: { sandboxId: CODEX_SDK_WORKSPACE_WRITE_SANDBOX_ID },
+        sandbox: { sandboxId: CODEX_WORKSPACE_WRITE_SANDBOX_ID },
       } : {}),
     },
     runtime: { model: 'gpt-test', effort: 'high' as const },
@@ -141,7 +141,7 @@ async function adapterFixture(options: Readonly<{
     mockInterception: 'not-required' as const,
     toolPolicy: options.allowedTools === undefined ? 'runtime-default' as const : 'allow-list' as const,
     skillDiscovery: 'runtime-default' as const,
-    ...(options.workspace ? { sandboxId: CODEX_SDK_WORKSPACE_WRITE_SANDBOX_ID } : {}),
+    ...(options.workspace ? { sandboxId: CODEX_WORKSPACE_WRITE_SANDBOX_ID } : {}),
   };
   const target: EvaluationDefinition['targets'][number] = {
     targetId: 'target-a',


### PR DESCRIPTION
## 用户影响

删除 Codex CLI／SDK 的四个内部沙箱常量别名及转导出，测试直接引用 protocol-core 中的共享常量。共享 ID 字节、能力声明、沙箱选择策略与公开契约不变，无需迁移。

## 验证与范围

本地完整 `yarn ci` 通过，340 个测试文件、3675 项测试全部保留并通过。本批源码净减 14 行，测试仅迁移引用，行数不变。基于已确认的直接常量别名关系实施定点替换，未额外重读完整文件。

关联 #767，处理附录四项沙箱别名，不关闭总任务。