### PR TITLE
refactor(studio): 删除闲置索引与模板测试导出

### DIFF
--- a/src/executors/mock-runtime/runtime.ts
+++ b/src/executors/mock-runtime/runtime.ts
@@ -684,9 +684,6 @@ function readMockHookTemplate(): string {
   return _hookTemplate;
 }
 
-// 测试用 export:供 packaging smoke test 验证 hook 能被解析
-export const _readMockHookTemplateForTest = readMockHookTemplate;
-
 // ─── 工具:在不影响主目录的前提下创建临时 dir(测试也要)─────────────
 
 export function _testMakeTempConfigDir(): string {

--- a/src/studio/application/skill-index.ts
+++ b/src/studio/application/skill-index.ts
@@ -389,7 +389,3 @@ export function buildSkillIndex(
   indexCache = { fingerprint, result };
   return result;
 }
-
-export function getSkillEntry(index: SkillIndex, skillName: string): SkillIndexEntry | null {
-  return index.entries.find((entry) => entry.skillName === skillName) ?? null;
-}


### PR DESCRIPTION
## 用户影响

删除没有消费者的 getSkillEntry 便利入口和 mock 模板测试别名。保留实际索引构建、缓存隔离及模板读取路径，不新增替代能力，无需迁移。

## 验证与范围

本地完整 `yarn ci` 通过，340 个测试文件、3675 项测试全部保留并通过。两个源码文件仅删除 7 行，测试和文档无变化。引用检索未发现源码、测试或脚本消费者；未额外重读完整文件。

关联 #767，处理对应两项附录记录，不关闭总任务。