### PR TITLE
refactor(executors): 移除注册表测试包装并保留唯一性约束

### DIFF
--- a/src/executors/core/registry.ts
+++ b/src/executors/core/registry.ts
@@ -144,27 +144,27 @@ const EXECUTOR_DESCRIPTORS = [
   },
 ] as const satisfies readonly ExecutorDescriptorShape[];
 
-export type RegisteredExecutorDescriptor = (typeof EXECUTOR_DESCRIPTORS)[number];
+type UniqueExecutorDescriptors<Entries extends readonly { readonly name: string }[]> =
+  Entries extends readonly [
+    infer Head extends { readonly name: string },
+    ...infer Tail extends readonly { readonly name: string }[],
+  ]
+    ? Head['name'] extends Tail[number]['name']
+      ? never
+      : readonly [Head, ...UniqueExecutorDescriptors<Tail>]
+    : readonly [];
+
+export type RegisteredExecutorDescriptor = UniqueExecutorDescriptors<
+  typeof EXECUTOR_DESCRIPTORS
+>[number];
 export type RegisteredExecutorName = RegisteredExecutorDescriptor['name'];
 export type ExecutableExecutorName = Extract<
   RegisteredExecutorDescriptor,
   { execution: 'builtin' }
 >['name'];
 
-export function executorDescriptors(): readonly RegisteredExecutorDescriptor[] {
-  return EXECUTOR_DESCRIPTORS;
-}
-
 export function getExecutorDescriptor(name: string): RegisteredExecutorDescriptor | undefined {
   return EXECUTOR_DESCRIPTORS.find((descriptor) => descriptor.name === name);
-}
-
-export function isRegisteredExecutorName(name: string): name is RegisteredExecutorName {
-  return getExecutorDescriptor(name) !== undefined;
-}
-
-export function executorVendor(executor: string): ExecutorVendor {
-  return getExecutorDescriptor(executor)?.vendor ?? 'unknown';
 }
 
 export function executorFamily(executor: string): ExecutorFamily | 'custom' {

--- a/test/executors/registry.test.ts
+++ b/test/executors/registry.test.ts
@@ -4,17 +4,35 @@ import { getExecutorCapabilities } from '../../src/executors/core/capabilities.j
 import { getOptionalExecutorDependency } from '../../src/executors/core/optional-dependencies.js';
 import { createExecutor } from '../../src/executors/index.js';
 import {
-  executorDescriptors,
   executorFamily,
   executorNamesForFamily,
-  executorVendor,
   getExecutorDescriptor,
-  isRegisteredExecutorName,
+  type ExecutorFamily,
+  type RegisteredExecutorDescriptor,
 } from '../../src/executors/core/registry.js';
+
+function registeredDescriptors(): RegisteredExecutorDescriptor[] {
+  const families = {
+    claude: 'claude',
+    codex: 'codex',
+    dsh: 'dsh',
+    'anthropic-api': 'anthropic-api',
+    'openai-api': 'openai-api',
+  } as const satisfies {
+    [Family in ExecutorFamily | RegisteredExecutorDescriptor['family']]: Family;
+  };
+  return Object.values(families)
+    .flatMap((family) => [...executorNamesForFamily(family)])
+    .map((name) => {
+      const descriptor = getExecutorDescriptor(name);
+      assert.ok(descriptor);
+      return descriptor;
+    });
+}
 
 describe('executor registry', () => {
   it('freezes the complete registered executor identity set', () => {
-    const descriptors = executorDescriptors();
+    const descriptors = registeredDescriptors();
     assert.deepEqual(descriptors.map(({ name }) => name), [
       'claude',
       'claude-sdk',
@@ -37,9 +55,9 @@ describe('executor registry', () => {
   });
 
   it('binds core descriptors and reserves host-only entries', () => {
-    for (const descriptor of executorDescriptors()) {
+    for (const descriptor of registeredDescriptors()) {
       assert.equal(getExecutorDescriptor(descriptor.name), descriptor);
-      assert.equal(isRegisteredExecutorName(descriptor.name), true);
+      assert.ok(getExecutorDescriptor(descriptor.name));
       assert.equal(
         getExecutorCapabilities(descriptor.name).sampleMocks,
         descriptor.sampleMocks,
@@ -58,10 +76,10 @@ describe('executor registry', () => {
     assert.deepEqual([...executorNamesForFamily('claude')], ['claude', 'claude-sdk']);
     assert.deepEqual([...executorNamesForFamily('codex')], ['codex', 'codex-sdk']);
     assert.equal(executorFamily('openai-api'), 'openai-api');
-    assert.equal(executorVendor('anthropic-api'), 'anthropic');
-    assert.equal(executorVendor('codex-sdk'), 'openai');
-    assert.equal(executorVendor('dsh-host'), 'unknown');
+    assert.equal(getExecutorDescriptor('anthropic-api')?.vendor, 'anthropic');
+    assert.equal(getExecutorDescriptor('codex-sdk')?.vendor, 'openai');
+    assert.equal(getExecutorDescriptor('dsh-host')?.vendor, 'unknown');
     assert.equal(executorFamily('./custom-executor.sh'), 'custom');
-    assert.equal(isRegisteredExecutorName('./custom-executor.sh'), false);
+    assert.equal(getExecutorDescriptor('./custom-executor.sh'), undefined);
   });
 });


### PR DESCRIPTION
## 用户影响

删除三个仅供测试使用的注册表包装，测试直接使用实际族枚举与描述符查询，保留完整身份集合、可选依赖、宿主专属入口及厂商分类检查。

注册名称唯一性改为零运行时开销的类型约束，避免族枚举的 Set 掩盖重复名称。不增加产品 API，不改变现有执行器身份或行为，无需迁移。

## 验证与范围

内存编译变异确认同族重复注册会导致真实查询入口类型检查失败，未将变异写入工作树。本地完整 `yarn ci` 通过，340 个测试文件、3675 项测试全部保留并通过。

源码净变化为零，测试增加 18 行；收益是删除三项运行时维护点并保留原约束，而非追求行数缩减。未额外重读完整文件。

关联 #767，处理 executorDescriptors、isRegisteredExecutorName、executorVendor 三项附录，不关闭总任务。