### PR TITLE
refactor(executors): 将测试迁到实际结果与临时目录入口

### DIFF
--- a/src/executors/mock-runtime/runtime.ts
+++ b/src/executors/mock-runtime/runtime.ts
@@ -14,7 +14,7 @@
  * 共用核心:`matchMock(mocks, toolName, toolInput, callCounter)` 命中规则评估。
  */
 
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -682,12 +682,4 @@ function readMockHookTemplate(): string {
   }
   _hookTemplate = readFileSync(hookPath, 'utf8');
   return _hookTemplate;
-}
-
-// ─── 工具:在不影响主目录的前提下创建临时 dir(测试也要)─────────────
-
-export function _testMakeTempConfigDir(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'omk-mocks-test-'));
-  mkdirSync(dir, { recursive: true });
-  return dir;
 }

--- a/src/executors/result-validation.ts
+++ b/src/executors/result-validation.ts
@@ -97,12 +97,6 @@ export function executorResultValidationError(value: unknown): string | undefine
   return undefined;
 }
 
-export function parseExecResult(value: unknown): ExecResult | null {
-  return executorResultValidationError(value)
-    ? null
-    : normalizeExecResultToolIdentities(value as ExecResult);
-}
-
 /**
  * Canonicalize every execution trace after structural validation. This keeps
  * programmatic/custom executors and restored caches in the same comparison

--- a/test/executors/mock-runtime/runtime.test.ts
+++ b/test/executors/mock-runtime/runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, writeFileSync, readFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import {
@@ -8,7 +9,6 @@ import {
   resolveMockReturn,
   buildSdkHookCallback,
   materializeForCliConfigDir,
-  _testMakeTempConfigDir,
 } from '../../../src/executors/mock-runtime/runtime.js';
 import type { Mock } from '../../../src/executors/contracts/mock.js';
 
@@ -211,10 +211,10 @@ describe('resolveMockReturn', () => {
   });
 
   it('return_file reads from baseDir', () => {
-    const dir = _testMakeTempConfigDir();
+    const dir = mkdtempSync(join(tmpdir(), 'omk-mock-return-test-'));
     const fpath = join(dir, 'fixture.json');
-    writeFileSync(fpath, '{"x":1}');
     try {
+      writeFileSync(fpath, '{"x":1}');
       const m: Mock = { tool: 'Read', return_file: 'fixture.json' };
       assert.equal(resolveMockReturn(m, 0, dir), '{"x":1}');
     } finally {

--- a/test/executors/result-validation.test.ts
+++ b/test/executors/result-validation.test.ts
@@ -2,10 +2,12 @@ import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
 import {
   executorResultValidationError,
-  parseExecResult,
+  normalizeExecResultToolIdentities,
 } from '../../src/executors/result-validation.js';
+import type { ExecResult } from '../../src/executors/contracts/result.js';
+import type { ToolCallInfo } from '../../src/executors/contracts/trace.js';
 
-function validResult(): Record<string, unknown> {
+function validResult(): ExecResult {
   return {
     ok: true,
     output: 'done',
@@ -23,7 +25,7 @@ function validResult(): Record<string, unknown> {
 
 describe('executor result contract', () => {
   it('accepts a valid source-neutral result and trace', () => {
-    const result = {
+    const result: ExecResult = {
       ...validResult(),
       toolCalls: [{
         tool: 'github.fetch_file',
@@ -40,11 +42,11 @@ describe('executor result contract', () => {
       mockStats: { hits: 1, misses: 0, perMock: { 'Read:0': 1 } },
     };
     assert.equal(executorResultValidationError(result), undefined);
-    assert.equal(parseExecResult(result)?.output, 'done');
+    assert.equal(normalizeExecResultToolIdentities(result).output, 'done');
   });
 
   it('normalizes provider-native tools at the shared result boundary', () => {
-    const rawCall = {
+    const rawCall: ToolCallInfo = {
       tool: 'command_execution',
       input: 'pwd',
       output: '/repo',
@@ -52,7 +54,7 @@ describe('executor result contract', () => {
       status: 'success',
       statusSource: 'runtime',
     };
-    const parsed = parseExecResult({
+    const result: ExecResult = {
       ...validResult(),
       toolCalls: [rawCall],
       turns: [{
@@ -60,7 +62,9 @@ describe('executor result contract', () => {
         content: '',
         toolCalls: [rawCall],
       }],
-    });
+    };
+    assert.equal(executorResultValidationError(result), undefined);
+    const parsed = normalizeExecResultToolIdentities(result);
     assert.ok(parsed);
     assert.equal(parsed.toolCalls?.[0].tool, 'Bash');
     assert.equal(parsed.toolCalls?.[0].sourceTool, 'command_execution');
@@ -69,7 +73,7 @@ describe('executor result contract', () => {
   });
 
   it('normalizes an already-qualified custom tool idempotently', () => {
-    const once = parseExecResult({
+    const result: ExecResult = {
       ...validResult(),
       toolCalls: [{
         tool: 'github.fetch_file',
@@ -78,9 +82,12 @@ describe('executor result contract', () => {
         output: 'done',
         success: true,
       }],
-    });
+    };
+    assert.equal(executorResultValidationError(result), undefined);
+    const once = normalizeExecResultToolIdentities(result);
     assert.ok(once);
-    const twice = parseExecResult(once);
+    assert.equal(executorResultValidationError(once), undefined);
+    const twice = normalizeExecResultToolIdentities(once);
     assert.equal(twice?.toolCalls?.[0].tool, 'github.fetch_file');
     assert.equal(twice?.toolCalls?.[0].sourceTool, undefined);
   });


### PR DESCRIPTION
## 用户影响

删除执行结果解析便利包装和测试临时目录包装。测试直接使用实际结果校验器与工具身份规范化入口，保留非法值拒绝、幂等性和不修改原对象的检查。临时目录由测试创建并清理，文件写入也纳入 finally 清理范围。

不改变执行结果契约、工具身份规则、mock 模板或生产资源生命周期，无需迁移。

## 验证与范围

本地完整 `yarn ci` 通过，340 个测试文件、3675 项测试全部保留并通过。本批源码净减 14 行，测试增加 7 行，总净减 7 行。未额外重读完整文件。

关联 #767，处理 parseExecResult 和 _testMakeTempConfigDir 两项附录，不关闭总任务。