### PR TITLE
refactor(studio): 删除闲置区间标签与建议聚合

### DIFF
--- a/src/eval-workflows/analysis/bootstrap.ts
+++ b/src/eval-workflows/analysis/bootstrap.ts
@@ -75,17 +75,6 @@ export const DEFAULT_BOOTSTRAP_ALPHA = 0.05;
  */
 export const DEFAULT_BOOTSTRAP_SEED = 20260616;
 
-/**
- * Confidence-level label for display: `(1 − α)·100%`. Multiple-comparison (Bonferroni) correction
- * shrinks a pairwise α to α/K and widens the CI accordingly — the label must track α so a corrected
- * (wider) interval is never mislabeled "95%". No alpha (single comparison / classic A-B) ⇒ nominal 95%.
- * Shared single source for the HTML renderer and the `omk eval` CLI verdict so both read one scale.
- */
-export function ciLevelLabel(alpha?: number): string {
-  const pct = (1 - (alpha ?? DEFAULT_BOOTSTRAP_ALPHA)) * 100;
-  return `${Number.isInteger(pct) ? pct : Number(pct.toFixed(1))}%`;
-}
-
 /** Mulberry32 PRNG — seedable, deterministic for tests. */
 function mulberry32(seed: number): () => number {
   let s = seed >>> 0;

--- a/src/studio/application/skill-insights.ts
+++ b/src/studio/application/skill-insights.ts
@@ -265,17 +265,3 @@ export function detectInsights(entry: SkillIndexEntry, options: DetectInsightsOp
   ].filter((candidate): candidate is Insight => candidate !== null)
     .sort((a, b) => SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity] || b.affectedCount - a.affectedCount);
 }
-
-export function flattenRecommendations(insights: Insight[]): InsightRecommendation[] {
-  const seen = new Map<string, InsightRecommendation>();
-  for (const insight of insights) {
-    for (const recommendation of insight.recommendations) {
-      const previous = seen.get(recommendation.action);
-      if (previous === undefined
-          || SEVERITY_RANK[recommendation.priority] > SEVERITY_RANK[previous.priority]) {
-        seen.set(recommendation.action, recommendation);
-      }
-    }
-  }
-  return [...seen.values()].sort((a, b) => SEVERITY_RANK[b.priority] - SEVERITY_RANK[a.priority]);
-}

--- a/test/eval-workflows/analysis/bootstrap.test.ts
+++ b/test/eval-workflows/analysis/bootstrap.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { bootstrapMeanCI, bootstrapDiffCI, bootstrapPairedDiffCI, bootstrapWithMetric, ciLevelLabel, DEFAULT_BOOTSTRAP_SEED } from '../../../src/eval-workflows/analysis/bootstrap.js';
+import { bootstrapMeanCI, bootstrapDiffCI, bootstrapPairedDiffCI, bootstrapWithMetric, DEFAULT_BOOTSTRAP_SEED } from '../../../src/eval-workflows/analysis/bootstrap.js';
 
 describe('bootstrapMeanCI', () => {
   it('CI on a tight sample contains the true mean', () => {
@@ -179,15 +179,6 @@ describe('bootstrapPairedDiffCI', () => {
     const width = (ci: { low: number; high: number }): number => ci.high - ci.low;
     assert.ok(width(wide) > width(narrow), `α/K(0.025)的 CI 宽 ${width(wide)} 应 > 名义 α(0.05)的 ${width(narrow)}`);
     assert.equal(wide.estimate, narrow.estimate, '点估计与 α 无关,不应变');
-  });
-});
-
-describe('ciLevelLabel', () => {
-  it('α → (1−α)·100% 标签:默认 95%,Bonferroni 的 α/2 / α/3 跟着变高', () => {
-    assert.equal(ciLevelLabel(), '95%', '无 α → 名义 95%');
-    assert.equal(ciLevelLabel(0.05), '95%');
-    assert.equal(ciLevelLabel(0.05 / 2), '97.5%', 'K=2 → α/2 → 97.5%');
-    assert.equal(ciLevelLabel(0.05 / 3), '98.3%', 'K=3 → α/3 → 98.333…→98.3%');
   });
 });
 

--- a/test/studio/application/skill-insights.test.ts
+++ b/test/studio/application/skill-insights.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { detectInsights, flattenRecommendations } from '../../../src/studio/application/index.js';
+import { detectInsights } from '../../../src/studio/application/index.js';
 import type { Diagnosis } from '../../../src/diagnosis/contracts.js';
 import type { SkillIndexEntry } from '../../../src/studio/view-models/skill-index.js';
 
@@ -113,22 +113,4 @@ describe('Core-independent skill insights', () => {
     }]);
   });
 
-  it('deduplicates recommendations and keeps highest priority first', () => {
-    expect(flattenRecommendations([
-      {
-        id: 'one', category: 'other', audience: 'skill-author', title: 'one', severity: 'low',
-        affectedCount: 1, evidence: [], recommendations: [{ action: 'same', priority: 'low' }],
-      },
-      {
-        id: 'two', category: 'other', audience: 'skill-author', title: 'two', severity: 'low',
-        affectedCount: 1, evidence: [], recommendations: [
-          { action: 'same', priority: 'high' },
-          { action: 'later', priority: 'medium' },
-        ],
-      },
-    ])).toEqual([
-      { action: 'same', priority: 'high' },
-      { action: 'later', priority: 'medium' },
-    ]);
-  });
 });


### PR DESCRIPTION
## 用户影响

删除没有生产调用的置信区间标签函数和建议聚合函数，不为闲置能力新增接线。实际 Bootstrap 计算、置信区间语义、Studio insight 生成及 Diagnosis 建议和补丁投影保持不变，无需迁移。

## 验证与范围

仅删除对应两项专属测试，其余统计和投影测试保留。本地完整 `yarn ci` 通过，340 个测试文件、3673 项测试成功。

本批源码净减 25 行、测试净减 27 行，总净减 52 行。引用检索未发现生产或脚本消费者；未额外重读完整文件。

关联 #767，处理 ciLevelLabel 和 flattenRecommendations 两项附录，不关闭总任务。