### PR TITLE
refactor(eval-workflows): 移除固定 Git 摘要测试包装

### DIFF
--- a/src/eval-workflows/hosts/resource-leases/node.ts
+++ b/src/eval-workflows/hosts/resource-leases/node.ts
@@ -252,13 +252,6 @@ export async function digestNodeTreeResource(
   return digestTree(path);
 }
 
-/** Resolve-stage digest for a pinned Git worktree; repository metadata is not Runtime input. */
-export async function digestNodePinnedGitTreeResource(
-  path: string,
-): Promise<{ readonly digest: `sha256:${string}`; readonly size: number }> {
-  return digestTree(path, true);
-}
-
 async function makeTreeWritable(path: string): Promise<void> {
   const stat = await lstat(path);
   if (stat.isDirectory()) {

--- a/test/eval-workflows/hosts/resource-leases/node.test.ts
+++ b/test/eval-workflows/hosts/resource-leases/node.test.ts
@@ -26,7 +26,6 @@ import {
 } from '../../../../src/knowledge-artifacts/sources/content-hash.js';
 import {
   digestNodeFileResource,
-  digestNodePinnedGitTreeResource,
   digestNodeTreeResource,
   materializeNodeRunResourceLeases,
 } from '../../../../src/eval-workflows/hosts/resource-leases/node.js';
@@ -570,10 +569,11 @@ describe('Verified HostResource leases', () => {
 
   it('verifies pinned Git identity and excludes repository metadata from snapshots', async () => {
     const repository = join(sourceRoot, 'repository');
-    mkdirSync(join(repository, '.git'), { recursive: true });
-    writeFileSync(join(repository, '.git', 'config'), 'secret metadata');
+    mkdirSync(repository);
     writeFileSync(join(repository, 'README.md'), '# pinned\n');
-    const actual = await digestNodePinnedGitTreeResource(repository);
+    const actual = await digestNodeTreeResource(repository);
+    mkdirSync(join(repository, '.git'));
+    writeFileSync(join(repository, '.git', 'config'), 'secret metadata');
     const commitId = 'a'.repeat(40);
     const resource: ResolvedHostResource = {
       resourceKind: 'artifact',
@@ -628,8 +628,9 @@ describe('Verified HostResource leases', () => {
   it('verifies pinned Git against the repository HEAD with the default verifier', async () => {
     const repository = join(sourceRoot, 'real-repository');
     mkdirSync(repository);
-    execFileSync('git', ['-C', repository, 'init', '-q']);
     writeFileSync(join(repository, 'README.md'), '# real pinned repository\n');
+    const actual = await digestNodeTreeResource(repository);
+    execFileSync('git', ['-C', repository, 'init', '-q']);
     execFileSync('git', ['-C', repository, 'add', 'README.md']);
     execFileSync('git', [
       '-C', repository,
@@ -642,7 +643,6 @@ describe('Verified HostResource leases', () => {
     const commitId = execFileSync(
       'git', ['-C', repository, 'rev-parse', 'HEAD'], { encoding: 'utf8' },
     ).trim();
-    const actual = await digestNodePinnedGitTreeResource(repository);
     const resource: ResolvedHostResource = {
       resourceKind: 'artifact',
       descriptor: {
@@ -783,7 +783,7 @@ it('forwards cancellation to Git verification and removes partially acquired res
   const path = join(sourceRoot, 'pinned');
   mkdirSync(path);
   writeFileSync(join(path, 'README.md'), '# input');
-  const actual = await digestNodePinnedGitTreeResource(path);
+  const actual = await digestNodeTreeResource(path);
   const commitId = 'a'.repeat(40);
   const controller = new AbortController();
   const reason = new Error('cancel acquisition');


### PR DESCRIPTION
## 用户影响

删除仅供测试构造资源使用的固定 Git 摘要包装。测试先通过既有树摘要入口记录内容，再加入 Git 元数据，由真实资源物化入口验证元数据排除、提交身份、脏工作树拒绝和取消清理。

生产摘要算法、Schema identity、固定提交验证和资源生命周期均不改变，无需迁移；不复制摘要或过滤算法。

## 验证与范围

本地完整 `yarn ci` 通过，340 个测试文件、3671 项测试全部保留并通过。本批源码净减 7 行，测试行数不变。未额外重读完整文件。

关联 #767，处理 digestNodePinnedGitTreeResource 附录项，不关闭总任务。