### PR TITLE
refactor(observability): 统一 Experience 枚举契约来源

### DIFF
--- a/src/observability/contracts/experience-enums.ts
+++ b/src/observability/contracts/experience-enums.ts
@@ -1,0 +1,259 @@
+import { z } from 'zod';
+
+export const ExperienceReviewPrioritySchema = z.enum([
+  'review_first',
+  'sample_review',
+  'routine_sample',
+]);
+
+export const ExperienceGoalSliceReasonCodeSchema = z.enum([
+  'skill_segment_boundary',
+  'explicit_user_goal_shift',
+  'default_session_slice',
+]);
+
+export const ExperienceEvidenceKindSchema = z.enum([
+  'user_message',
+  'synthetic_user_event',
+  'assistant_message',
+  'model_activity',
+  'agent_activity',
+  'tool_use',
+  'tool_result',
+  'skill_context',
+  'runtime_context',
+  'lifecycle',
+  'observation',
+]);
+
+export const ExperienceAssistiveInferenceCodeSchema = z.enum([
+  'review_recommended',
+  'sample_recommended',
+  'positive_signal_observed',
+  'user_switched_topic_neutral',
+  'no_obvious_issue_from_rules',
+  'insufficient_human_context',
+]);
+
+export const ExperienceAssistiveInferenceConfidenceSchema = z.enum([
+  'low',
+  'medium',
+  'high',
+]);
+
+export const ExperienceAssistiveInferenceCautionCodeSchema = z.enum([
+  'no_llm_judge',
+  'rule_only',
+  'runtime_context_excluded',
+  'skill_context_excluded',
+  'no_human_user_message',
+  'limited_timeline_window',
+]);
+
+export const ExperienceReviewBasisCodeSchema = z.enum([
+  'has_high_observation',
+  'has_medium_observation',
+  'user_correction',
+  'user_interruption',
+  'session_interrupted',
+  'negative_feedback',
+  'hard_rule_text_hit',
+  'tool_failure',
+  'hedging_signal',
+  'explicit_marker',
+]);
+
+export const ExperienceRuleFindingLevelSchema = z.enum([
+  'attention',
+  'sample',
+  'normal',
+]);
+
+export const ExperienceReviewerReportScopeSchema = z.enum([
+  'single_skill_single_goal',
+  'degraded_complex',
+]);
+
+export const ExperienceReviewerReportStepStatusSchema = z.enum([
+  'ok',
+  'attention',
+  'unknown',
+  'degraded',
+  'not_applicable',
+]);
+
+export const ExperienceReviewerReportFindingLevelSchema = z.enum([
+  'attention',
+  'possible_false_positive',
+  'note',
+]);
+
+export const ExperienceReviewerReportFindingSourceSchema = z.enum([
+  'deterministic_rule',
+  'llm_soft',
+  'manual',
+]);
+
+export const ExperienceChecklistItemStatusSchema = z.enum([
+  'passed',
+  'failed',
+  'unknown',
+  'not_declared',
+  'not_applicable',
+  'degraded',
+]);
+
+export const ExperienceChecklistContributionSchema = z.enum([
+  'blocking',
+  'attention',
+  'informational',
+  'positive',
+  'neutral',
+]);
+
+export const ExperienceParentReasonSchema = z.enum([
+  'data_degraded',
+  'blocking_failed',
+  'attention_accumulated',
+  'unknown_dominant',
+  'all_passed',
+  'not_applicable',
+]);
+
+export const ExperienceSessionStoryNodeKindSchema = z.enum([
+  'user_goal',
+  'skill_invocation',
+  'subagent_branch',
+  'tool_execution',
+  'delivery',
+  'user_feedback',
+  'goal_shift',
+]);
+
+export const ExperienceSessionStoryAnswerKeySchema = z.enum([
+  'goal_satisfaction',
+  'declared_behavior_fit',
+  'user_feeling',
+]);
+
+export const ExperienceSessionStorySkillRoleSchema = z.enum([
+  'router',
+  'executor',
+  'mixed',
+  'unknown',
+]);
+
+export const ExperienceEpisodeBoundaryReasonSchema = z.enum([
+  'goal_shift',
+  'checkpoint_or_subagent',
+  'downstream_closed',
+  'session_end',
+]);
+
+export const ExperienceEpisodeRoleSchema = z.enum([
+  'main_executor',
+  'router',
+  'delegator',
+  'supporting',
+  'observer',
+]);
+
+export const ExperienceFeedbackSignalTypeSchema = z.enum([
+  'correction',
+  'follow_up',
+  'frustration',
+  'interruption',
+  'positive',
+  'unknown',
+]);
+
+export const ExperienceFeedbackAttributionRoleSchema = z.enum([
+  'primary_fault',
+  'downstream_related',
+  'context_only',
+]);
+
+export const ExperienceFeedbackAttributionReasonSchema = z.enum([
+  'object_match',
+  'promise_match',
+  'action_match',
+  'orchestration_edge',
+  'episode_context',
+]);
+
+export const ExperienceOutcomeClosureSchema = z.enum([
+  'closed',
+  'unresolved',
+  'abandoned',
+  'unknown',
+]);
+
+export const ExperienceRuntimeSkillTypeSchema = z.enum([
+  'router',
+  'delegation',
+  'executor',
+  'advisory',
+  'workflow_owner',
+  'unknown',
+]);
+
+export const ExperienceRuntimeSkillTypeSourceSchema = z.enum([
+  'frontmatter',
+  'trace',
+  'unknown',
+]);
+
+export const ExperienceEpisodeArtifactKindSchema = z.enum([
+  'path',
+  'url',
+  'document',
+  'code',
+  'execution_window',
+  'unknown',
+]);
+
+export const ExperienceOrchestrationEdgeStatusSchema = z.enum([
+  'started',
+  'completed',
+  'failed',
+  'unknown',
+]);
+
+export const ExperienceOrchestrationEdgeKindSchema = z.enum([
+  'internal_skill',
+  'external_child_session',
+]);
+
+export const ExperienceRuleFindingCodeSchema = z.enum([
+  'high_observation_seen',
+  'medium_observation_seen',
+  'user_correction_seen',
+  'user_interruption_seen',
+  'session_interrupted_seen',
+  'negative_feedback_seen',
+  'positive_feedback_seen',
+  'user_goal_shift_seen',
+  'hard_rule_seen',
+  'tool_failure_seen',
+  'hedging_seen',
+  'explicit_marker_seen',
+  'runtime_context_excluded',
+  'skill_context_excluded',
+  'no_priority_signal',
+]);
+
+export const TaskWindowBasisSchema = z.enum([
+  'turn_id',
+  'turn_lifecycle',
+  'user_message',
+  'unresolved',
+]);
+
+export const ExperienceTurnStatusSchema = z.enum([
+  'completed',
+  'failed',
+  'aborted',
+  'interrupted',
+  'open',
+  'unknown',
+]);

--- a/src/observability/contracts/experience.ts
+++ b/src/observability/contracts/experience.ts
@@ -1,87 +1,78 @@
+import type { z } from 'zod';
+import type {
+  ExperienceReviewPrioritySchema,
+  ExperienceGoalSliceReasonCodeSchema,
+  ExperienceEvidenceKindSchema,
+  ExperienceAssistiveInferenceCodeSchema,
+  ExperienceAssistiveInferenceConfidenceSchema,
+  ExperienceAssistiveInferenceCautionCodeSchema,
+  ExperienceReviewBasisCodeSchema,
+  ExperienceRuleFindingLevelSchema,
+  ExperienceReviewerReportScopeSchema,
+  ExperienceReviewerReportStepStatusSchema,
+  ExperienceReviewerReportFindingLevelSchema,
+  ExperienceReviewerReportFindingSourceSchema,
+  ExperienceChecklistItemStatusSchema,
+  ExperienceChecklistContributionSchema,
+  ExperienceParentReasonSchema,
+  ExperienceSessionStoryNodeKindSchema,
+  ExperienceSessionStoryAnswerKeySchema,
+  ExperienceSessionStorySkillRoleSchema,
+  ExperienceEpisodeBoundaryReasonSchema,
+  ExperienceEpisodeRoleSchema,
+  ExperienceFeedbackSignalTypeSchema,
+  ExperienceFeedbackAttributionRoleSchema,
+  ExperienceFeedbackAttributionReasonSchema,
+  ExperienceOutcomeClosureSchema,
+  ExperienceRuntimeSkillTypeSchema,
+  ExperienceRuntimeSkillTypeSourceSchema,
+  ExperienceEpisodeArtifactKindSchema,
+  ExperienceOrchestrationEdgeStatusSchema,
+  ExperienceOrchestrationEdgeKindSchema,
+  ExperienceRuleFindingCodeSchema,
+  TaskWindowBasisSchema,
+  ExperienceTurnStatusSchema,
+} from './experience-enums.js';
 import type { ToolCallStatus } from '../../executors/contracts/trace.js';
 import type { ExperienceProblemPattern } from './problem-patterns.js';
 import type { TraceSourceKind, TraceSourceMetadata } from './trace.js';
 
-export type ExperienceReviewPriority = 'review_first' | 'sample_review' | 'routine_sample';
-export type ExperienceGoalSliceReasonCode = 'skill_segment_boundary' | 'explicit_user_goal_shift' | 'default_session_slice';
-export type ExperienceEvidenceKind = 'user_message' | 'synthetic_user_event' | 'assistant_message' | 'model_activity' | 'agent_activity' | 'tool_use' | 'tool_result' | 'skill_context' | 'runtime_context' | 'lifecycle' | 'observation';
+export type ExperienceReviewPriority = z.infer<typeof ExperienceReviewPrioritySchema>;
+export type ExperienceGoalSliceReasonCode = z.infer<typeof ExperienceGoalSliceReasonCodeSchema>;
+export type ExperienceEvidenceKind = z.infer<typeof ExperienceEvidenceKindSchema>;
 export type ExperienceAssistiveInferenceCode =
-  | 'review_recommended'
-  | 'sample_recommended'
-  | 'positive_signal_observed'
-  | 'user_switched_topic_neutral'
-  | 'no_obvious_issue_from_rules'
-  | 'insufficient_human_context';
-export type ExperienceAssistiveInferenceConfidence = 'low' | 'medium' | 'high';
+  z.infer<typeof ExperienceAssistiveInferenceCodeSchema>;
+export type ExperienceAssistiveInferenceConfidence = z.infer<typeof ExperienceAssistiveInferenceConfidenceSchema>;
 export type ExperienceAssistiveInferenceCautionCode =
-  | 'no_llm_judge'
-  | 'rule_only'
-  | 'runtime_context_excluded'
-  | 'skill_context_excluded'
-  | 'no_human_user_message'
-  | 'limited_timeline_window';
+  z.infer<typeof ExperienceAssistiveInferenceCautionCodeSchema>;
 export type ExperienceReviewBasisCode =
-  | 'has_high_observation'
-  | 'has_medium_observation'
-  | 'user_correction'
-  | 'user_interruption'
-  | 'session_interrupted'
-  | 'negative_feedback'
-  | 'hard_rule_text_hit'
-  | 'tool_failure'
-  | 'hedging_signal'
-  | 'explicit_marker';
-export type ExperienceRuleFindingLevel = 'attention' | 'sample' | 'normal';
-export type ExperienceReviewerReportScope = 'single_skill_single_goal' | 'degraded_complex';
-export type ExperienceReviewerReportStepStatus = 'ok' | 'attention' | 'unknown' | 'degraded' | 'not_applicable';
-export type ExperienceReviewerReportFindingLevel = 'attention' | 'possible_false_positive' | 'note';
-export type ExperienceReviewerReportFindingSource = 'deterministic_rule' | 'llm_soft' | 'manual';
-export type ExperienceChecklistItemStatus = 'passed' | 'failed' | 'unknown' | 'not_declared' | 'not_applicable' | 'degraded';
-export type ExperienceChecklistContribution = 'blocking' | 'attention' | 'informational' | 'positive' | 'neutral';
+  z.infer<typeof ExperienceReviewBasisCodeSchema>;
+export type ExperienceRuleFindingLevel = z.infer<typeof ExperienceRuleFindingLevelSchema>;
+export type ExperienceReviewerReportScope = z.infer<typeof ExperienceReviewerReportScopeSchema>;
+export type ExperienceReviewerReportStepStatus = z.infer<typeof ExperienceReviewerReportStepStatusSchema>;
+export type ExperienceReviewerReportFindingLevel = z.infer<typeof ExperienceReviewerReportFindingLevelSchema>;
+export type ExperienceReviewerReportFindingSource = z.infer<typeof ExperienceReviewerReportFindingSourceSchema>;
+export type ExperienceChecklistItemStatus = z.infer<typeof ExperienceChecklistItemStatusSchema>;
+export type ExperienceChecklistContribution = z.infer<typeof ExperienceChecklistContributionSchema>;
 export type ExperienceParentReason =
-  | 'data_degraded'
-  | 'blocking_failed'
-  | 'attention_accumulated'
-  | 'unknown_dominant'
-  | 'all_passed'
-  | 'not_applicable';
+  z.infer<typeof ExperienceParentReasonSchema>;
 export type ExperienceSessionStoryNodeKind =
-  | 'user_goal'
-  | 'skill_invocation'
-  | 'subagent_branch'
-  | 'tool_execution'
-  | 'delivery'
-  | 'user_feedback'
-  | 'goal_shift';
-export type ExperienceSessionStoryAnswerKey = 'goal_satisfaction' | 'declared_behavior_fit' | 'user_feeling';
-export type ExperienceSessionStorySkillRole = 'router' | 'executor' | 'mixed' | 'unknown';
-export type ExperienceEpisodeBoundaryReason = 'goal_shift' | 'checkpoint_or_subagent' | 'downstream_closed' | 'session_end';
-export type ExperienceEpisodeRole = 'main_executor' | 'router' | 'delegator' | 'supporting' | 'observer';
-export type ExperienceFeedbackSignalType = 'correction' | 'follow_up' | 'frustration' | 'interruption' | 'positive' | 'unknown';
-export type ExperienceFeedbackAttributionRole = 'primary_fault' | 'downstream_related' | 'context_only';
-export type ExperienceFeedbackAttributionReason = 'object_match' | 'promise_match' | 'action_match' | 'orchestration_edge' | 'episode_context';
-export type ExperienceOutcomeClosure = 'closed' | 'unresolved' | 'abandoned' | 'unknown';
-export type ExperienceRuntimeSkillType = 'router' | 'delegation' | 'executor' | 'advisory' | 'workflow_owner' | 'unknown';
-export type ExperienceRuntimeSkillTypeSource = 'frontmatter' | 'trace' | 'unknown';
-export type ExperienceEpisodeArtifactKind = 'path' | 'url' | 'document' | 'code' | 'execution_window' | 'unknown';
-export type ExperienceOrchestrationEdgeStatus = 'started' | 'completed' | 'failed' | 'unknown';
-export type ExperienceOrchestrationEdgeKind = 'internal_skill' | 'external_child_session';
+  z.infer<typeof ExperienceSessionStoryNodeKindSchema>;
+export type ExperienceSessionStoryAnswerKey = z.infer<typeof ExperienceSessionStoryAnswerKeySchema>;
+export type ExperienceSessionStorySkillRole = z.infer<typeof ExperienceSessionStorySkillRoleSchema>;
+export type ExperienceEpisodeBoundaryReason = z.infer<typeof ExperienceEpisodeBoundaryReasonSchema>;
+export type ExperienceEpisodeRole = z.infer<typeof ExperienceEpisodeRoleSchema>;
+export type ExperienceFeedbackSignalType = z.infer<typeof ExperienceFeedbackSignalTypeSchema>;
+export type ExperienceFeedbackAttributionRole = z.infer<typeof ExperienceFeedbackAttributionRoleSchema>;
+export type ExperienceFeedbackAttributionReason = z.infer<typeof ExperienceFeedbackAttributionReasonSchema>;
+export type ExperienceOutcomeClosure = z.infer<typeof ExperienceOutcomeClosureSchema>;
+export type ExperienceRuntimeSkillType = z.infer<typeof ExperienceRuntimeSkillTypeSchema>;
+export type ExperienceRuntimeSkillTypeSource = z.infer<typeof ExperienceRuntimeSkillTypeSourceSchema>;
+export type ExperienceEpisodeArtifactKind = z.infer<typeof ExperienceEpisodeArtifactKindSchema>;
+export type ExperienceOrchestrationEdgeStatus = z.infer<typeof ExperienceOrchestrationEdgeStatusSchema>;
+export type ExperienceOrchestrationEdgeKind = z.infer<typeof ExperienceOrchestrationEdgeKindSchema>;
 export type ExperienceRuleFindingCode =
-  | 'high_observation_seen'
-  | 'medium_observation_seen'
-  | 'user_correction_seen'
-  | 'user_interruption_seen'
-  | 'session_interrupted_seen'
-  | 'negative_feedback_seen'
-  | 'positive_feedback_seen'
-  | 'user_goal_shift_seen'
-  | 'hard_rule_seen'
-  | 'tool_failure_seen'
-  | 'hedging_seen'
-  | 'explicit_marker_seen'
-  | 'runtime_context_excluded'
-  | 'skill_context_excluded'
-  | 'no_priority_signal';
+  z.infer<typeof ExperienceRuleFindingCodeSchema>;
 
 // ---------- experience: interfaces ----------
 
@@ -131,18 +122,10 @@ export interface ExperienceTimelineEvent extends ExperienceEvidenceRef {
 // ---------- Knowledge Debugger task trajectory ----------
 
 export type TaskWindowBasis =
-  | 'turn_id'
-  | 'turn_lifecycle'
-  | 'user_message'
-  | 'unresolved';
+  z.infer<typeof TaskWindowBasisSchema>;
 
 export type ExperienceTurnStatus =
-  | 'completed'
-  | 'failed'
-  | 'aborted'
-  | 'interrupted'
-  | 'open'
-  | 'unknown';
+  z.infer<typeof ExperienceTurnStatusSchema>;
 
 /**
  * One user-visible task inside a source thread. `turnId` is the stable,

--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -1,4 +1,36 @@
 import {
+  ExperienceAssistiveInferenceCautionCodeSchema,
+  ExperienceAssistiveInferenceCodeSchema,
+  ExperienceAssistiveInferenceConfidenceSchema,
+  ExperienceChecklistContributionSchema,
+  ExperienceChecklistItemStatusSchema,
+  ExperienceEpisodeArtifactKindSchema,
+  ExperienceEpisodeBoundaryReasonSchema,
+  ExperienceEpisodeRoleSchema,
+  ExperienceEvidenceKindSchema,
+  ExperienceFeedbackAttributionReasonSchema,
+  ExperienceFeedbackAttributionRoleSchema,
+  ExperienceFeedbackSignalTypeSchema,
+  ExperienceGoalSliceReasonCodeSchema,
+  ExperienceOrchestrationEdgeKindSchema,
+  ExperienceOrchestrationEdgeStatusSchema,
+  ExperienceOutcomeClosureSchema,
+  ExperienceParentReasonSchema,
+  ExperienceReviewBasisCodeSchema,
+  ExperienceReviewPrioritySchema,
+  ExperienceReviewerReportFindingLevelSchema,
+  ExperienceReviewerReportFindingSourceSchema,
+  ExperienceReviewerReportScopeSchema,
+  ExperienceReviewerReportStepStatusSchema,
+  ExperienceRuleFindingCodeSchema,
+  ExperienceRuleFindingLevelSchema,
+  ExperienceRuntimeSkillTypeSchema,
+  ExperienceRuntimeSkillTypeSourceSchema,
+  ExperienceSessionStoryAnswerKeySchema,
+  ExperienceSessionStoryNodeKindSchema,
+  ExperienceSessionStorySkillRoleSchema,
+} from '../contracts/experience-enums.js';
+import {
   isTraceSourceKind,
 } from '../../executors/core/trace-source-kind.js';
 import type {
@@ -101,18 +133,7 @@ export function normalizeExperienceSessionShells(
     || typeof value.reviewPriorityScore !== 'number'
     || !Number.isFinite(value.reviewPriorityScore)
     || value.reviewPriorityScore < 0
-    || !isEnumArray(value.reviewBasisCodes, [
-      'has_high_observation',
-      'has_medium_observation',
-      'user_correction',
-      'user_interruption',
-      'session_interrupted',
-      'negative_feedback',
-      'hard_rule_text_hit',
-      'tool_failure',
-      'hedging_signal',
-      'explicit_marker',
-    ])
+    || !isEnumArray(value.reviewBasisCodes, ExperienceReviewBasisCodeSchema.options)
     || !isExperienceIndicators(value.indicators)
     || !isExperienceEvidenceChain(value.evidenceChain)
     || !isExperienceRuleFindingArray(value.ruleFindings)
@@ -288,23 +309,11 @@ export function isOptionalTraceSourceMetadata(value: unknown): boolean {
 }
 
 export function isExperienceReviewPriority(value: unknown): boolean {
-  return value === 'review_first' || value === 'sample_review' || value === 'routine_sample';
+  return isEnumValue(value, ExperienceReviewPrioritySchema.options);
 }
 
 export function isExperienceEvidenceKind(value: unknown): boolean {
-  return isEnumValue(value, [
-    'user_message',
-    'synthetic_user_event',
-    'assistant_message',
-    'model_activity',
-    'agent_activity',
-    'tool_use',
-    'tool_result',
-    'skill_context',
-    'runtime_context',
-    'lifecycle',
-    'observation',
-  ]);
+  return isEnumValue(value, ExperienceEvidenceKindSchema.options);
 }
 
 export function isExperienceEvidenceRef(value: unknown): value is ExperienceEvidenceRef {
@@ -383,24 +392,8 @@ export function isExperienceEvidenceChain(value: unknown): boolean {
 
 export function isExperienceRuleFinding(value: unknown): boolean {
   return isObjectRecord(value)
-    && isEnumValue(value.code, [
-      'high_observation_seen',
-      'medium_observation_seen',
-      'user_correction_seen',
-      'user_interruption_seen',
-      'session_interrupted_seen',
-      'negative_feedback_seen',
-      'positive_feedback_seen',
-      'user_goal_shift_seen',
-      'hard_rule_seen',
-      'tool_failure_seen',
-      'hedging_seen',
-      'explicit_marker_seen',
-      'runtime_context_excluded',
-      'skill_context_excluded',
-      'no_priority_signal',
-    ])
-    && isEnumValue(value.level, ['attention', 'sample', 'normal'])
+    && isEnumValue(value.code, ExperienceRuleFindingCodeSchema.options)
+    && isEnumValue(value.level, ExperienceRuleFindingLevelSchema.options)
     && isNonNegativeInteger(value.count)
     && isExperienceEvidenceRefArray(value.evidenceRefs);
 }
@@ -412,40 +405,10 @@ export function isExperienceRuleFindingArray(value: unknown): boolean {
 export function isExperienceAssistiveInference(value: unknown): boolean {
   return isObjectRecord(value)
     && value.mode === 'deterministic_rules_only'
-    && isEnumValue(value.code, [
-      'review_recommended',
-      'sample_recommended',
-      'positive_signal_observed',
-      'user_switched_topic_neutral',
-      'no_obvious_issue_from_rules',
-      'insufficient_human_context',
-    ])
-    && isEnumValue(value.confidence, ['low', 'medium', 'high'])
-    && isEnumArray(value.basisRuleCodes, [
-      'high_observation_seen',
-      'medium_observation_seen',
-      'user_correction_seen',
-      'user_interruption_seen',
-      'session_interrupted_seen',
-      'negative_feedback_seen',
-      'positive_feedback_seen',
-      'user_goal_shift_seen',
-      'hard_rule_seen',
-      'tool_failure_seen',
-      'hedging_seen',
-      'explicit_marker_seen',
-      'runtime_context_excluded',
-      'skill_context_excluded',
-      'no_priority_signal',
-    ])
-    && isEnumArray(value.cautionCodes, [
-      'no_llm_judge',
-      'rule_only',
-      'runtime_context_excluded',
-      'skill_context_excluded',
-      'no_human_user_message',
-      'limited_timeline_window',
-    ])
+    && isEnumValue(value.code, ExperienceAssistiveInferenceCodeSchema.options)
+    && isEnumValue(value.confidence, ExperienceAssistiveInferenceConfidenceSchema.options)
+    && isEnumArray(value.basisRuleCodes, ExperienceRuleFindingCodeSchema.options)
+    && isEnumArray(value.cautionCodes, ExperienceAssistiveInferenceCautionCodeSchema.options)
     && isExperienceEvidenceRefArray(value.evidenceRefs);
 }
 
@@ -641,19 +604,7 @@ export function isTimelineEvent(value: unknown): value is ExperienceTimelineEven
   if (
     !isObjectRecord(value)
     || typeof value.id !== 'string'
-    || ![
-      'user_message',
-      'synthetic_user_event',
-      'assistant_message',
-      'model_activity',
-      'agent_activity',
-      'tool_use',
-      'tool_result',
-      'skill_context',
-      'runtime_context',
-      'lifecycle',
-      'observation',
-    ].includes(String(value.kind))
+    || !isEnumValue(String(value.kind), ExperienceEvidenceKindSchema.options)
     || typeof value.sourceTrace !== 'string'
     || typeof value.sessionId !== 'string'
     || !isNonNegativeInteger(value.order)
@@ -814,24 +765,11 @@ export function isExperienceChecklistItem(value: unknown): boolean {
   return isObjectRecord(value)
     && typeof value.key === 'string'
     && typeof value.label === 'string'
-    && isEnumValue(value.status, [
-      'passed',
-      'failed',
-      'unknown',
-      'not_declared',
-      'not_applicable',
-      'degraded',
-    ])
-    && isEnumValue(value.contribution, [
-      'blocking',
-      'attention',
-      'informational',
-      'positive',
-      'neutral',
-    ])
+    && isEnumValue(value.status, ExperienceChecklistItemStatusSchema.options)
+    && isEnumValue(value.contribution, ExperienceChecklistContributionSchema.options)
     && typeof value.reason === 'string'
     && isExperienceEvidenceRefArray(value.evidenceRefs)
-    && isEnumValue(value.source, ['deterministic_rule', 'llm_soft', 'manual'])
+    && isEnumValue(value.source, ExperienceReviewerReportFindingSourceSchema.options)
     && isOptionalString(value.suggestionKey);
 }
 
@@ -841,11 +779,7 @@ export function isExperienceSessionStoryGoalSlice(value: unknown): boolean {
     && isNonNegativeInteger(value.order)
     && isStringArray(value.skillNames)
     && isTimestampRange(value.startTimestamp, value.endTimestamp)
-    && isEnumValue(value.reasonCode, [
-      'skill_segment_boundary',
-      'explicit_user_goal_shift',
-      'default_session_slice',
-    ])
+    && isEnumValue(value.reasonCode, ExperienceGoalSliceReasonCodeSchema.options)
     && isOptionalString(value.inferredUserGoal)
     && isExperienceEvidenceRefArray(value.evidenceRefs);
 }
@@ -876,7 +810,7 @@ export function isExperienceSessionStorySkillLink(value: unknown): boolean {
     && typeof value.id === 'string'
     && isNonNegativeInteger(value.order)
     && typeof value.skillName === 'string'
-    && isEnumValue(value.role, ['router', 'executor', 'mixed', 'unknown'])
+    && isEnumValue(value.role, ExperienceSessionStorySkillRoleSchema.options)
     && isStringArray(value.invocationIds)
     && isStringArray(value.goalSliceIds)
     && isExperienceEvidenceRefArray(value.evidenceRefs);
@@ -886,17 +820,9 @@ export function isExperienceSessionStoryGraphNode(value: unknown): boolean {
   return isObjectRecord(value)
     && typeof value.id === 'string'
     && typeof value.label === 'string'
-    && isEnumValue(value.kind, [
-      'user_goal',
-      'skill_invocation',
-      'subagent_branch',
-      'tool_execution',
-      'delivery',
-      'user_feedback',
-      'goal_shift',
-    ])
-    && isEnumValue(value.status, ['ok', 'attention', 'unknown', 'degraded', 'not_applicable'])
-    && (value.role === undefined || isEnumValue(value.role, ['router', 'executor', 'mixed', 'unknown']))
+    && isEnumValue(value.kind, ExperienceSessionStoryNodeKindSchema.options)
+    && isEnumValue(value.status, ExperienceReviewerReportStepStatusSchema.options)
+    && (value.role === undefined || isEnumValue(value.role, ExperienceSessionStorySkillRoleSchema.options))
     && isOptionalString(value.detailNodeId);
 }
 
@@ -911,34 +837,19 @@ export function isExperienceSessionStoryNode(value: unknown): boolean {
   return isObjectRecord(value)
     && typeof value.id === 'string'
     && isNonNegativeInteger(value.order)
-    && isEnumValue(value.kind, [
-      'user_goal',
-      'skill_invocation',
-      'subagent_branch',
-      'tool_execution',
-      'delivery',
-      'user_feedback',
-      'goal_shift',
-    ])
+    && isEnumValue(value.kind, ExperienceSessionStoryNodeKindSchema.options)
     && typeof value.label === 'string'
-    && isEnumValue(value.status, ['ok', 'attention', 'unknown', 'degraded', 'not_applicable'])
+    && isEnumValue(value.status, ExperienceReviewerReportStepStatusSchema.options)
     && typeof value.text === 'string'
     && isExperienceEvidenceRefArray(value.evidenceRefs);
 }
 
 export function isExperienceSessionStoryAnswer(value: unknown): boolean {
   return isObjectRecord(value)
-    && isEnumValue(value.key, ['goal_satisfaction', 'declared_behavior_fit', 'user_feeling'])
+    && isEnumValue(value.key, ExperienceSessionStoryAnswerKeySchema.options)
     && typeof value.label === 'string'
-    && isEnumValue(value.status, ['ok', 'attention', 'unknown', 'degraded', 'not_applicable'])
-    && isEnumValue(value.reason, [
-      'data_degraded',
-      'blocking_failed',
-      'attention_accumulated',
-      'unknown_dominant',
-      'all_passed',
-      'not_applicable',
-    ])
+    && isEnumValue(value.status, ExperienceReviewerReportStepStatusSchema.options)
+    && isEnumValue(value.reason, ExperienceParentReasonSchema.options)
     && isStringArray(value.sourceItemKeys)
     && typeof value.text === 'string'
     && isExperienceEvidenceRefArray(value.evidenceRefs)
@@ -960,47 +871,20 @@ export function isExperienceSkillSegment(value: unknown): boolean {
     || typeof value.id !== 'string'
     || !isNonNegativeInteger(value.order)
     || typeof value.skillName !== 'string'
-    || !isEnumValue(value.skillType, [
-      'router',
-      'delegation',
-      'executor',
-      'advisory',
-      'workflow_owner',
-      'unknown',
-    ])
+    || !isEnumValue(value.skillType, ExperienceRuntimeSkillTypeSchema.options)
     || (
       value.skillTypeSource !== undefined
-      && !isEnumValue(value.skillTypeSource, ['frontmatter', 'trace', 'unknown'])
+      && !isEnumValue(value.skillTypeSource, ExperienceRuntimeSkillTypeSourceSchema.options)
     )
     || (
       value.declaredSkillType !== undefined
-      && !isEnumValue(value.declaredSkillType, [
-        'router',
-        'delegation',
-        'executor',
-        'advisory',
-        'workflow_owner',
-        'unknown',
-      ])
+      && !isEnumValue(value.declaredSkillType, ExperienceRuntimeSkillTypeSchema.options)
     )
     || (
       value.traceInferredSkillType !== undefined
-      && !isEnumValue(value.traceInferredSkillType, [
-        'router',
-        'delegation',
-        'executor',
-        'advisory',
-        'workflow_owner',
-        'unknown',
-      ])
+      && !isEnumValue(value.traceInferredSkillType, ExperienceRuntimeSkillTypeSchema.options)
     )
-    || !isEnumValue(value.episodeRole, [
-      'main_executor',
-      'router',
-      'delegator',
-      'supporting',
-      'observer',
-    ])
+    || !isEnumValue(value.episodeRole, ExperienceEpisodeRoleSchema.options)
     || !isStringArray(value.skillInvocationIds)
     || !isOptionalNonNegativeInteger(value.startMessageIndex)
     || !isOptionalNonNegativeInteger(value.endMessageIndex)
@@ -1041,14 +925,14 @@ export function isExperienceOrchestrationEdge(value: unknown): boolean {
   return isObjectRecord(value)
     && typeof value.id === 'string'
     && typeof value.episodeId === 'string'
-    && isEnumValue(value.edgeKind, ['internal_skill', 'external_child_session'])
+    && isEnumValue(value.edgeKind, ExperienceOrchestrationEdgeKindSchema.options)
     && isOptionalString(value.parentSkillSegmentId)
     && isOptionalString(value.executorSkillSegmentId)
     && isOptionalString(value.childSessionId)
     && (value.runnerStartedRef === undefined || isExperienceEvidenceRef(value.runnerStartedRef))
     && (value.runnerCompletedRef === undefined || isExperienceEvidenceRef(value.runnerCompletedRef))
     && (value.notificationRef === undefined || isExperienceEvidenceRef(value.notificationRef))
-    && isEnumValue(value.status, ['started', 'completed', 'failed', 'unknown'])
+    && isEnumValue(value.status, ExperienceOrchestrationEdgeStatusSchema.options)
     && isExperienceEvidenceRefArray(value.evidenceRefs);
 }
 
@@ -1056,14 +940,8 @@ export function isExperienceFeedbackAttribution(value: unknown): boolean {
   return isObjectRecord(value)
     && isOptionalString(value.skillName)
     && isOptionalString(value.skillSegmentId)
-    && isEnumValue(value.attributionRole, ['primary_fault', 'downstream_related', 'context_only'])
-    && isEnumValue(value.reasonCode, [
-      'object_match',
-      'promise_match',
-      'action_match',
-      'orchestration_edge',
-      'episode_context',
-    ])
+    && isEnumValue(value.attributionRole, ExperienceFeedbackAttributionRoleSchema.options)
+    && isEnumValue(value.reasonCode, ExperienceFeedbackAttributionReasonSchema.options)
     && isExperienceEvidenceRefArray(value.evidenceRefs);
 }
 
@@ -1071,14 +949,7 @@ export function isExperienceFeedbackSignal(value: unknown): boolean {
   return isObjectRecord(value)
     && typeof value.id === 'string'
     && isNonNegativeInteger(value.order)
-    && isEnumValue(value.type, [
-      'correction',
-      'follow_up',
-      'frustration',
-      'interruption',
-      'positive',
-      'unknown',
-    ])
+    && isEnumValue(value.type, ExperienceFeedbackSignalTypeSchema.options)
     && typeof value.text === 'string'
     && isOptionalString(value.targetObject)
     && isEnumValue(value.sourceWindow, [
@@ -1101,14 +972,7 @@ export function isExperienceFeedbackSignal(value: unknown): boolean {
 
 export function isExperienceEpisodeArtifact(value: unknown): boolean {
   return isObjectRecord(value)
-    && isEnumValue(value.kind, [
-      'path',
-      'url',
-      'document',
-      'code',
-      'execution_window',
-      'unknown',
-    ])
+    && isEnumValue(value.kind, ExperienceEpisodeArtifactKindSchema.options)
     && typeof value.label === 'string'
     && isOptionalString(value.pathOrUrl)
     && isEnumValue(value.artifactGoalMatch, ['passed', 'failed', 'unknown'])
@@ -1117,7 +981,7 @@ export function isExperienceEpisodeArtifact(value: unknown): boolean {
 
 export function isExperienceEpisodeOutcome(value: unknown): boolean {
   return isObjectRecord(value)
-    && isEnumValue(value.closure, ['closed', 'unresolved', 'abandoned', 'unknown'])
+    && isEnumValue(value.closure, ExperienceOutcomeClosureSchema.options)
     && Array.isArray(value.artifacts)
     && value.artifacts.every(isExperienceEpisodeArtifact)
     && isExperienceReviewPriority(value.verdict)
@@ -1135,12 +999,7 @@ export function isExperienceEpisode(value: unknown): boolean {
     && isTimestampRange(value.startTimestamp, value.endTimestamp)
     && (value.startRef === undefined || isExperienceEvidenceRef(value.startRef))
     && (value.endRef === undefined || isExperienceEvidenceRef(value.endRef))
-    && isEnumValue(value.boundaryReason, [
-      'goal_shift',
-      'checkpoint_or_subagent',
-      'downstream_closed',
-      'session_end',
-    ])
+    && isEnumValue(value.boundaryReason, ExperienceEpisodeBoundaryReasonSchema.options)
     && Array.isArray(value.skillSegments)
     && value.skillSegments.every(isExperienceSkillSegment)
     && Array.isArray(value.orchestrationEdges)
@@ -1195,7 +1054,7 @@ export function isExperienceReviewerReportStep(value: unknown): boolean {
   return isObjectRecord(value)
     && isNonNegativeInteger(value.order)
     && typeof value.label === 'string'
-    && isEnumValue(value.status, ['ok', 'attention', 'unknown', 'degraded', 'not_applicable'])
+    && isEnumValue(value.status, ExperienceReviewerReportStepStatusSchema.options)
     && typeof value.text === 'string'
     && isExperienceEvidenceRefArray(value.evidenceRefs);
 }
@@ -1205,8 +1064,8 @@ export function isExperienceReviewerReportFinding(value: unknown): boolean {
     !isObjectRecord(value)
     || typeof value.id !== 'string'
     || typeof value.judgmentId !== 'string'
-    || !isEnumValue(value.source, ['deterministic_rule', 'llm_soft', 'manual'])
-    || !isEnumValue(value.level, ['attention', 'possible_false_positive', 'note'])
+    || !isEnumValue(value.source, ExperienceReviewerReportFindingSourceSchema.options)
+    || !isEnumValue(value.level, ExperienceReviewerReportFindingLevelSchema.options)
     || typeof value.title !== 'string'
     || typeof value.body !== 'string'
     || typeof value.ruleSource !== 'string'
@@ -1305,7 +1164,7 @@ export function isExperienceReviewerReport(value: unknown): boolean {
     || typeof value.title !== 'string'
     || typeof value.summary !== 'string'
     || !isObjectRecord(value.scope)
-    || !isEnumValue(value.scope.kind, ['single_skill_single_goal', 'degraded_complex'])
+    || !isEnumValue(value.scope.kind, ExperienceReviewerReportScopeSchema.options)
     || !isStringArray(value.scope.reasonCodes)
     || !Array.isArray(value.chainSteps)
     || !value.chainSteps.every(isExperienceReviewerReportStep)

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -42,6 +42,48 @@ const PURE_DOMAIN_TYPE_FILES = [
 
 const PURE_DOMAIN_TYPE_FILE_SET = new Set<string>(PURE_DOMAIN_TYPE_FILES);
 
+const EXPERIENCE_ENUM_SCHEMA_FILE = 'src/observability/contracts/experience-enums.ts';
+const EXPERIENCE_ENUM_TYPE_IMPORTS = new Set(['zod', './experience-enums.js']);
+
+function isDeclarativeEnumSchemaModule(source: ts.SourceFile): boolean {
+  let imports = 0;
+  let schemas = 0;
+  for (const statement of source.statements) {
+    if (ts.isImportDeclaration(statement)) {
+      const bindings = statement.importClause?.namedBindings;
+      if (!ts.isStringLiteral(statement.moduleSpecifier)
+          || statement.moduleSpecifier.text !== 'zod'
+          || statement.importClause?.name
+          || !bindings || !ts.isNamedImports(bindings)
+          || bindings.elements.length !== 1
+          || bindings.elements[0].name.text !== 'z'
+          || bindings.elements[0].propertyName) return false;
+      imports += 1;
+      continue;
+    }
+    if (!ts.isVariableStatement(statement)
+        || !(statement.declarationList.flags & ts.NodeFlags.Const)
+        || !statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)) {
+      return false;
+    }
+    for (const declaration of statement.declarationList.declarations) {
+      const initializer = declaration.initializer;
+      if (!ts.isIdentifier(declaration.name) || !declaration.name.text.endsWith('Schema')
+          || !initializer || !ts.isCallExpression(initializer)
+          || !ts.isPropertyAccessExpression(initializer.expression)
+          || !ts.isIdentifier(initializer.expression.expression)
+          || initializer.expression.expression.text !== 'z'
+          || initializer.expression.name.text !== 'enum'
+          || initializer.arguments.length !== 1) return false;
+      const values = initializer.arguments[0];
+      if (!ts.isArrayLiteralExpression(values) || values.elements.length === 0
+          || !values.elements.every(ts.isStringLiteral)) return false;
+      schemas += 1;
+    }
+  }
+  return imports === 1 && schemas > 0;
+}
+
 describe('领域契约所有权', () => {
   it('保持遗留 src/types 目录已删除', () => {
     expect(existsSync(resolve('src/types'))).toBe(false);
@@ -132,6 +174,29 @@ describe('领域契约所有权', () => {
     expect(rootModules).toEqual(['experience.ts']);
   });
 
+  it('Experience 枚举 Schema 只声明字符串取值，不引入实现或副作用', () => {
+    const source = ts.createSourceFile(
+      EXPERIENCE_ENUM_SCHEMA_FILE,
+      readFileSync(resolve(EXPERIENCE_ENUM_SCHEMA_FILE), 'utf8'),
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    expect(isDeclarativeEnumSchemaModule(source)).toBe(true);
+  });
+
+  it.each([
+    "import { readFileSync } from 'node:fs'; export const ValueSchema = z.enum(['a']);",
+    "import { z } from 'zod'; export function run() { return 'a'; }",
+    "import { z } from 'zod'; export const ValueSchema = z.enum(loadValues());",
+    "import { z } from 'zod'; export const ValueSchema = z.enum([...values]);",
+    "import { z } from 'zod'; export const ValueSchema = z.enum(['a']); sideEffect();",
+    "import { z } from 'zod'; export let ValueSchema = z.enum(['a']);",
+  ])('枚举声明边界拒绝实现代码：%s', (text) => {
+    expect(isDeclarativeEnumSchemaModule(ts.createSourceFile(
+      'invalid.ts', text, ts.ScriptTarget.Latest, true,
+    ))).toBe(false);
+  });
+
   it('领域 contracts 与 view-models 保持为无运行时实现的纯类型模块', () => {
     const violations: string[] = [];
     for (const file of PURE_DOMAIN_TYPE_FILES) {
@@ -152,7 +217,9 @@ describe('领域契约所有权', () => {
               process.cwd(),
               resolve(dirname(resolve(file)), specifier.replace(/\.js$/, '.ts')),
             );
-            if (!PURE_DOMAIN_TYPE_FILE_SET.has(target)) {
+            const declarativeEnumTypeImport = file === 'src/observability/contracts/experience.ts'
+              && EXPERIENCE_ENUM_TYPE_IMPORTS.has(specifier);
+            if (!PURE_DOMAIN_TYPE_FILE_SET.has(target) && !declarativeEnumTypeImport) {
               violations.push(`${file}：依赖了非契约模块 ${specifier}`);
             }
           }

--- a/test/observability/experience-enums.test.ts
+++ b/test/observability/experience-enums.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+import * as enums from '../../src/observability/contracts/experience-enums.js';
+import {
+  isExperienceEvidenceKind,
+  isExperienceReviewPriority,
+} from '../../src/observability/experience/report-value-guards.js';
+
+const cases = [
+  ['ExperienceReviewPriority', enums.ExperienceReviewPrioritySchema, [
+    'review_first',
+    'sample_review',
+    'routine_sample',
+  ]],
+  ['ExperienceGoalSliceReasonCode', enums.ExperienceGoalSliceReasonCodeSchema, [
+    'skill_segment_boundary',
+    'explicit_user_goal_shift',
+    'default_session_slice',
+  ]],
+  ['ExperienceEvidenceKind', enums.ExperienceEvidenceKindSchema, [
+    'user_message',
+    'synthetic_user_event',
+    'assistant_message',
+    'model_activity',
+    'agent_activity',
+    'tool_use',
+    'tool_result',
+    'skill_context',
+    'runtime_context',
+    'lifecycle',
+    'observation',
+  ]],
+  ['ExperienceAssistiveInferenceCode', enums.ExperienceAssistiveInferenceCodeSchema, [
+    'review_recommended',
+    'sample_recommended',
+    'positive_signal_observed',
+    'user_switched_topic_neutral',
+    'no_obvious_issue_from_rules',
+    'insufficient_human_context',
+  ]],
+  ['ExperienceAssistiveInferenceConfidence', enums.ExperienceAssistiveInferenceConfidenceSchema, [
+    'low',
+    'medium',
+    'high',
+  ]],
+  ['ExperienceAssistiveInferenceCautionCode', enums.ExperienceAssistiveInferenceCautionCodeSchema, [
+    'no_llm_judge',
+    'rule_only',
+    'runtime_context_excluded',
+    'skill_context_excluded',
+    'no_human_user_message',
+    'limited_timeline_window',
+  ]],
+  ['ExperienceReviewBasisCode', enums.ExperienceReviewBasisCodeSchema, [
+    'has_high_observation',
+    'has_medium_observation',
+    'user_correction',
+    'user_interruption',
+    'session_interrupted',
+    'negative_feedback',
+    'hard_rule_text_hit',
+    'tool_failure',
+    'hedging_signal',
+    'explicit_marker',
+  ]],
+  ['ExperienceRuleFindingLevel', enums.ExperienceRuleFindingLevelSchema, [
+    'attention',
+    'sample',
+    'normal',
+  ]],
+  ['ExperienceReviewerReportScope', enums.ExperienceReviewerReportScopeSchema, [
+    'single_skill_single_goal',
+    'degraded_complex',
+  ]],
+  ['ExperienceReviewerReportStepStatus', enums.ExperienceReviewerReportStepStatusSchema, [
+    'ok',
+    'attention',
+    'unknown',
+    'degraded',
+    'not_applicable',
+  ]],
+  ['ExperienceReviewerReportFindingLevel', enums.ExperienceReviewerReportFindingLevelSchema, [
+    'attention',
+    'possible_false_positive',
+    'note',
+  ]],
+  ['ExperienceReviewerReportFindingSource', enums.ExperienceReviewerReportFindingSourceSchema, [
+    'deterministic_rule',
+    'llm_soft',
+    'manual',
+  ]],
+  ['ExperienceChecklistItemStatus', enums.ExperienceChecklistItemStatusSchema, [
+    'passed',
+    'failed',
+    'unknown',
+    'not_declared',
+    'not_applicable',
+    'degraded',
+  ]],
+  ['ExperienceChecklistContribution', enums.ExperienceChecklistContributionSchema, [
+    'blocking',
+    'attention',
+    'informational',
+    'positive',
+    'neutral',
+  ]],
+  ['ExperienceParentReason', enums.ExperienceParentReasonSchema, [
+    'data_degraded',
+    'blocking_failed',
+    'attention_accumulated',
+    'unknown_dominant',
+    'all_passed',
+    'not_applicable',
+  ]],
+  ['ExperienceSessionStoryNodeKind', enums.ExperienceSessionStoryNodeKindSchema, [
+    'user_goal',
+    'skill_invocation',
+    'subagent_branch',
+    'tool_execution',
+    'delivery',
+    'user_feedback',
+    'goal_shift',
+  ]],
+  ['ExperienceSessionStoryAnswerKey', enums.ExperienceSessionStoryAnswerKeySchema, [
+    'goal_satisfaction',
+    'declared_behavior_fit',
+    'user_feeling',
+  ]],
+  ['ExperienceSessionStorySkillRole', enums.ExperienceSessionStorySkillRoleSchema, [
+    'router',
+    'executor',
+    'mixed',
+    'unknown',
+  ]],
+  ['ExperienceEpisodeBoundaryReason', enums.ExperienceEpisodeBoundaryReasonSchema, [
+    'goal_shift',
+    'checkpoint_or_subagent',
+    'downstream_closed',
+    'session_end',
+  ]],
+  ['ExperienceEpisodeRole', enums.ExperienceEpisodeRoleSchema, [
+    'main_executor',
+    'router',
+    'delegator',
+    'supporting',
+    'observer',
+  ]],
+  ['ExperienceFeedbackSignalType', enums.ExperienceFeedbackSignalTypeSchema, [
+    'correction',
+    'follow_up',
+    'frustration',
+    'interruption',
+    'positive',
+    'unknown',
+  ]],
+  ['ExperienceFeedbackAttributionRole', enums.ExperienceFeedbackAttributionRoleSchema, [
+    'primary_fault',
+    'downstream_related',
+    'context_only',
+  ]],
+  ['ExperienceFeedbackAttributionReason', enums.ExperienceFeedbackAttributionReasonSchema, [
+    'object_match',
+    'promise_match',
+    'action_match',
+    'orchestration_edge',
+    'episode_context',
+  ]],
+  ['ExperienceOutcomeClosure', enums.ExperienceOutcomeClosureSchema, [
+    'closed',
+    'unresolved',
+    'abandoned',
+    'unknown',
+  ]],
+  ['ExperienceRuntimeSkillType', enums.ExperienceRuntimeSkillTypeSchema, [
+    'router',
+    'delegation',
+    'executor',
+    'advisory',
+    'workflow_owner',
+    'unknown',
+  ]],
+  ['ExperienceRuntimeSkillTypeSource', enums.ExperienceRuntimeSkillTypeSourceSchema, [
+    'frontmatter',
+    'trace',
+    'unknown',
+  ]],
+  ['ExperienceEpisodeArtifactKind', enums.ExperienceEpisodeArtifactKindSchema, [
+    'path',
+    'url',
+    'document',
+    'code',
+    'execution_window',
+    'unknown',
+  ]],
+  ['ExperienceOrchestrationEdgeStatus', enums.ExperienceOrchestrationEdgeStatusSchema, [
+    'started',
+    'completed',
+    'failed',
+    'unknown',
+  ]],
+  ['ExperienceOrchestrationEdgeKind', enums.ExperienceOrchestrationEdgeKindSchema, [
+    'internal_skill',
+    'external_child_session',
+  ]],
+  ['ExperienceRuleFindingCode', enums.ExperienceRuleFindingCodeSchema, [
+    'high_observation_seen',
+    'medium_observation_seen',
+    'user_correction_seen',
+    'user_interruption_seen',
+    'session_interrupted_seen',
+    'negative_feedback_seen',
+    'positive_feedback_seen',
+    'user_goal_shift_seen',
+    'hard_rule_seen',
+    'tool_failure_seen',
+    'hedging_seen',
+    'explicit_marker_seen',
+    'runtime_context_excluded',
+    'skill_context_excluded',
+    'no_priority_signal',
+  ]],
+  ['TaskWindowBasis', enums.TaskWindowBasisSchema, [
+    'turn_id',
+    'turn_lifecycle',
+    'user_message',
+    'unresolved',
+  ]],
+  ['ExperienceTurnStatus', enums.ExperienceTurnStatusSchema, [
+    'completed',
+    'failed',
+    'aborted',
+    'interrupted',
+    'open',
+    'unknown',
+  ]],
+] as const;
+
+const invalidValues = [undefined, null, false, 0, {}, [], '', 'UNKNOWN'];
+
+describe('Experience enum wire identities', () => {
+  it.each(cases)('%s preserves its complete wire value set', (_name, schema, values) => {
+    expect(schema.options).toEqual(values);
+    for (const value of values) expect(schema.safeParse(value).success).toBe(true);
+    for (const value of invalidValues) expect(schema.safeParse(value).success).toBe(false);
+  });
+
+  it.each([
+    ['evidence kind', enums.ExperienceEvidenceKindSchema, isExperienceEvidenceKind],
+    ['review priority', enums.ExperienceReviewPrioritySchema, isExperienceReviewPriority],
+  ] as const)('%s guard uses the schema value set', (_name, schema, guard) => {
+    for (const value of schema.options) expect(guard(value)).toBe(true);
+    for (const value of invalidValues) expect(guard(value)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 用户影响

Experience 的 32 个命名字符串枚举由声明式 Schema 维护，TypeScript 类型从中推导，40 处运行时取值引用复用同一来源。冻结取值回归覆盖既有值与非法输入，不改变 wire 值、落盘版本或测量语义，无需迁移。

类型门面仍不包含运行时实现，仅为该门面的类型推导开放精确的 Schema 依赖。独立边界规则限定枚举模块只能声明 z.enum 字符串字面量，继续拒绝宿主依赖、函数、动态取值和副作用，不放开其他领域的依赖限制。

## 验证与范围

本地完整 `yarn ci` 通过，341 个测试文件、3712 项测试成功。新增 41 项枚举冻结、guard 接线及架构边界检查；源码净增 101 行、测试净增 320 行，收益是移除重复契约维护点，不以行数减量作为目标。

关联 #767 的 C2。这里只完成枚举来源收敛；对象结构、wire／hydrated 差异、语义与引用校验仍待后续处理，不关闭总任务。