### PR TITLE
refactor(observability): 统一 Experience 证据结构契约

### DIFF
--- a/src/observability/contracts/experience-evidence-schema.ts
+++ b/src/observability/contracts/experience-evidence-schema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { ExperienceEvidenceKindSchema } from './experience-enums.js';
+
+const NonNegativeIntegerSchema = z.number().int().nonnegative();
+
+export const ExperienceEvidenceRefSchema = z.object({
+  id: z.string(),
+  kind: ExperienceEvidenceKindSchema,
+  sourceTrace: z.string(),
+  sessionId: z.string(),
+  messageIndex: NonNegativeIntegerSchema.optional(),
+  logicalMessageIndex: NonNegativeIntegerSchema.optional(),
+  sourceLineIndex: NonNegativeIntegerSchema.optional(),
+  traceRole: z.enum(['standalone', 'main', 'subagent']).optional(),
+  modelActivityKind: z.enum(['reasoning']).optional(),
+  contentVisibility: z.enum(['plaintext', 'opaque']).optional(),
+  contentSource: z.enum(['summary', 'content', 'text']).optional(),
+  runtimeKind: z.enum(['session_context', 'execution_context', 'settings', 'goal', 'context_compaction', 'usage']).optional(),
+  role: z.enum(['user', 'assistant', 'tool', 'other']).optional(),
+  traceLabel: z.string().optional(),
+  traceId: z.string().optional(),
+  turnId: z.string().optional(),
+  messageUuid: z.string().optional(),
+  sourceType: z.string().optional(),
+  callInstanceId: z.string().optional(),
+  toolUseId: z.string().optional(),
+  label: z.string().optional(),
+  snippet: z.string().optional(),
+  timestamp: z.string().optional(),
+});

--- a/src/observability/contracts/experience.ts
+++ b/src/observability/contracts/experience.ts
@@ -1,3 +1,4 @@
+import type { ExperienceEvidenceRefSchema } from './experience-evidence-schema.js';
 import type { z } from 'zod';
 import type {
   ExperienceReviewPrioritySchema,
@@ -76,34 +77,7 @@ export type ExperienceRuleFindingCode =
 
 // ---------- experience: interfaces ----------
 
-export interface ExperienceEvidenceRef {
-  id: string;
-  kind: ExperienceEvidenceKind;
-  traceId?: string;
-  sourceTrace: string;
-  sessionId: string;
-  traceRole?: 'standalone' | 'main' | 'subagent';
-  traceLabel?: string;
-  messageIndex?: number;
-  logicalMessageIndex?: number;
-  sourceLineIndex?: number;
-  messageUuid?: string;
-  /** Source-native record classification retained after normalization. */
-  sourceType?: string;
-  /** Source-neutral identity for one agent turn, when the trace exposes it. */
-  turnId?: string;
-  /** Source-neutral identity for one concrete tool-call occurrence. */
-  callInstanceId?: string;
-  toolUseId?: string;
-  timestamp?: string;
-  role?: 'user' | 'assistant' | 'tool' | 'other';
-  modelActivityKind?: 'reasoning';
-  contentVisibility?: 'plaintext' | 'opaque';
-  contentSource?: 'summary' | 'content' | 'text';
-  runtimeKind?: 'session_context' | 'execution_context' | 'settings' | 'goal' | 'context_compaction' | 'usage';
-  label?: string;
-  snippet?: string;
-}
+export type ExperienceEvidenceRef = z.infer<typeof ExperienceEvidenceRefSchema>;
 
 export interface ExperienceTimelineEvent extends ExperienceEvidenceRef {
   order: number;

--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -1,3 +1,4 @@
+import { ExperienceEvidenceRefSchema } from '../contracts/experience-evidence-schema.js';
 import {
   ExperienceAssistiveInferenceCautionCodeSchema,
   ExperienceAssistiveInferenceCodeSchema,
@@ -317,49 +318,8 @@ export function isExperienceEvidenceKind(value: unknown): boolean {
 }
 
 export function isExperienceEvidenceRef(value: unknown): value is ExperienceEvidenceRef {
-  if (
-    !isObjectRecord(value)
-    || typeof value.id !== 'string'
-    || !isExperienceEvidenceKind(value.kind)
-    || typeof value.sourceTrace !== 'string'
-    || typeof value.sessionId !== 'string'
-    || !isOptionalNonNegativeInteger(value.messageIndex)
-    || !isOptionalNonNegativeInteger(value.logicalMessageIndex)
-    || !isOptionalNonNegativeInteger(value.sourceLineIndex)
-  ) return false;
-  if (
-    value.traceRole !== undefined
-    && !isEnumValue(value.traceRole, ['standalone', 'main', 'subagent'])
-  ) return false;
-  if (value.modelActivityKind !== undefined && value.modelActivityKind !== 'reasoning') return false;
-  if (
-    value.contentVisibility !== undefined
-    && !isEnumValue(value.contentVisibility, ['plaintext', 'opaque'])
-  ) return false;
-  if (
-    value.contentSource !== undefined
-    && !isEnumValue(value.contentSource, ['summary', 'content', 'text'])
-  ) return false;
-  if (
-    value.runtimeKind !== undefined
-    && !isEnumValue(value.runtimeKind, ['session_context', 'execution_context', 'settings', 'goal', 'context_compaction', 'usage'])
-  ) return false;
-  if (
-    value.role !== undefined
-    && !isEnumValue(value.role, ['user', 'assistant', 'tool', 'other'])
-  ) return false;
-  return [
-    value.traceLabel,
-    value.traceId,
-    value.turnId,
-    value.messageUuid,
-    value.sourceType,
-    value.callInstanceId,
-    value.toolUseId,
-    value.label,
-    value.snippet,
-  ].every(isOptionalString)
-    && isOptionalTimestamp(value.timestamp);
+  const parsed = ExperienceEvidenceRefSchema.safeParse(value);
+  return parsed.success && isOptionalTimestamp(parsed.data.timestamp);
 }
 
 export function isExperienceEvidenceRefArray(value: unknown): value is ExperienceEvidenceRef[] {

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -43,7 +43,59 @@ const PURE_DOMAIN_TYPE_FILES = [
 const PURE_DOMAIN_TYPE_FILE_SET = new Set<string>(PURE_DOMAIN_TYPE_FILES);
 
 const EXPERIENCE_ENUM_SCHEMA_FILE = 'src/observability/contracts/experience-enums.ts';
-const EXPERIENCE_ENUM_TYPE_IMPORTS = new Set(['zod', './experience-enums.js']);
+const EXPERIENCE_ENUM_TYPE_IMPORTS = new Set([
+  'zod', './experience-enums.js', './experience-evidence-schema.js',
+]);
+
+function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile): boolean {
+  const imports = new Map([
+    ['zod', 'z'],
+    ['./experience-enums.js', 'ExperienceEvidenceKindSchema'],
+  ]);
+  const seenImports = new Set<string>();
+  const schemas = new Set(['ExperienceEvidenceKindSchema']);
+  function expression(node: ts.Expression): boolean {
+    if (ts.isIdentifier(node)) return schemas.has(node.text);
+    if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression)) return false;
+    const receiver = node.expression.expression;
+    const method = node.expression.name.text;
+    if (ts.isIdentifier(receiver) && receiver.text === 'z') {
+      if (method === 'string' || method === 'number') return node.arguments.length === 0;
+      if (node.arguments.length !== 1) return false;
+      const argument = node.arguments[0];
+      if (method === 'enum') {
+        return ts.isArrayLiteralExpression(argument) && argument.elements.length > 0
+          && argument.elements.every(ts.isStringLiteral);
+      }
+      return method === 'object' && ts.isObjectLiteralExpression(argument)
+        && argument.properties.every((property) => ts.isPropertyAssignment(property)
+          && (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name))
+          && expression(property.initializer));
+    }
+    return ['optional', 'int', 'nonnegative'].includes(method)
+      && node.arguments.length === 0 && expression(receiver);
+  }
+  for (const statement of source.statements) {
+    if (ts.isImportDeclaration(statement)) {
+      const bindings = statement.importClause?.namedBindings;
+      if (!ts.isStringLiteral(statement.moduleSpecifier)
+          || statement.importClause?.name || !bindings || !ts.isNamedImports(bindings)
+          || bindings.elements.length !== 1 || bindings.elements[0].propertyName
+          || imports.get(statement.moduleSpecifier.text) !== bindings.elements[0].name.text
+          || seenImports.has(statement.moduleSpecifier.text)) return false;
+      seenImports.add(statement.moduleSpecifier.text);
+      continue;
+    }
+    if (!ts.isVariableStatement(statement)
+        || !(statement.declarationList.flags & ts.NodeFlags.Const)) return false;
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.name.text.endsWith('Schema')
+          || !declaration.initializer || !expression(declaration.initializer)) return false;
+      schemas.add(declaration.name.text);
+    }
+  }
+  return seenImports.size === imports.size && schemas.has('ExperienceEvidenceRefSchema');
+}
 
 function isDeclarativeEnumSchemaModule(source: ts.SourceFile): boolean {
   let imports = 0;
@@ -182,6 +234,27 @@ describe('领域契约所有权', () => {
       true,
     );
     expect(isDeclarativeEnumSchemaModule(source)).toBe(true);
+  });
+
+  it('Experience 证据结构 Schema 不引入宿主依赖或变换副作用', () => {
+    const file = 'src/observability/contracts/experience-evidence-schema.ts';
+    expect(isDeclarativeEvidenceSchemaModule(ts.createSourceFile(
+      file, readFileSync(resolve(file), 'utf8'), ts.ScriptTarget.Latest, true,
+    ))).toBe(true);
+  });
+
+  it.each([
+    "z.object({ id: readFileSync('/secret') })",
+    "z.object({ [computeKey()]: z.string() })",
+    "z.object({ id: z.string() }).transform(() => sideEffect())",
+    "z.object({ id: z.string() }); sideEffect()",
+  ])('证据结构声明拒绝动态实现：%s', (initializer) => {
+    const text = "import { z } from 'zod';\n"
+      + "import { ExperienceEvidenceKindSchema } from './experience-enums.js';\n"
+      + `export const ExperienceEvidenceRefSchema = ${initializer};`;
+    expect(isDeclarativeEvidenceSchemaModule(ts.createSourceFile(
+      'invalid.ts', text, ts.ScriptTarget.Latest, true,
+    ))).toBe(false);
   });
 
   it.each([

--- a/test/observability/experience-evidence-schema.test.ts
+++ b/test/observability/experience-evidence-schema.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { ExperienceEvidenceRef } from '../../src/observability/contracts/experience.js';
+import { isExperienceEvidenceRef } from '../../src/observability/experience/report-value-guards.js';
+import type { ExperienceEvidenceKind } from '../../src/observability/contracts/experience.js';
+
+// Frozen pre-schema structural contract.
+interface LegacyExperienceEvidenceRef {
+  id: string;
+  kind: ExperienceEvidenceKind;
+  traceId?: string;
+  sourceTrace: string;
+  sessionId: string;
+  traceRole?: 'standalone' | 'main' | 'subagent';
+  traceLabel?: string;
+  messageIndex?: number;
+  logicalMessageIndex?: number;
+  sourceLineIndex?: number;
+  messageUuid?: string;
+  /** Source-native record classification retained after normalization. */
+  sourceType?: string;
+  /** Source-neutral identity for one agent turn, when the trace exposes it. */
+  turnId?: string;
+  /** Source-neutral identity for one concrete tool-call occurrence. */
+  callInstanceId?: string;
+  toolUseId?: string;
+  timestamp?: string;
+  role?: 'user' | 'assistant' | 'tool' | 'other';
+  modelActivityKind?: 'reasoning';
+  contentVisibility?: 'plaintext' | 'opaque';
+  contentSource?: 'summary' | 'content' | 'text';
+  runtimeKind?: 'session_context' | 'execution_context' | 'settings' | 'goal' | 'context_compaction' | 'usage';
+  label?: string;
+  snippet?: string;
+}
+
+const base = { id: 'ref', kind: 'tool_use', sourceTrace: 'trace', sessionId: 'session' };
+
+describe('Experience evidence structure', () => {
+  it('preserves the original structural type', () => {
+    expectTypeOf<ExperienceEvidenceRef>().toEqualTypeOf<LegacyExperienceEvidenceRef>();
+  });
+  it('accepts unknown fields without changing the original object', () => {
+    const value = { ...base, extension: { value: 1 } };
+    expect(isExperienceEvidenceRef(value)).toBe(true);
+    expect(value).toEqual({ ...base, extension: { value: 1 } });
+  });
+  it.each(['id', 'kind', 'sourceTrace', 'sessionId'])('requires %s', (field) => {
+    const value: Record<string, unknown> = { ...base };
+    delete value[field];
+    expect(isExperienceEvidenceRef(value)).toBe(false);
+  });
+  it.each(['messageIndex', 'logicalMessageIndex', 'sourceLineIndex'])('preserves %s bounds', (field) => {
+    for (const value of [0, 1, Number.MAX_SAFE_INTEGER]) {
+      expect(isExperienceEvidenceRef({ ...base, [field]: value })).toBe(true);
+    }
+    for (const value of [-1, 0.5, Number.MAX_SAFE_INTEGER + 1, NaN, Infinity, null, '0']) {
+      expect(isExperienceEvidenceRef({ ...base, [field]: value })).toBe(false);
+    }
+  });
+  it.each(['kind', 'traceRole', 'modelActivityKind', 'contentVisibility', 'contentSource', 'runtimeKind', 'role'])('rejects unknown %s values', (field) => {
+    expect(isExperienceEvidenceRef({ ...base, [field]: '__unknown__' })).toBe(false);
+  });
+  it('retains timestamp semantic validation', () => {
+    expect(isExperienceEvidenceRef({ ...base, timestamp: '2026-09-07T00:00:00Z' })).toBe(true);
+    expect(isExperienceEvidenceRef({ ...base, timestamp: 'not-a-date' })).toBe(false);
+    expect(isExperienceEvidenceRef({ ...base, timestamp: null })).toBe(false);
+  });
+});

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -7,7 +7,8 @@
  *
  * 本测试用 TypeScript AST 扫 `src/**\/*.ts` 里**每个名为 `kind` 的字段声明**
  * (interface / type-literal 的 PropertySignature、class 的 PropertyDeclaration —— 不含
- * 函数 param、`.kind` 读取、对象字面量构造点、注释 / 字符串):
+ * 函数 param、`.kind` 读取、普通对象字面量构造点、注释 / 字符串)。
+ * 同时检查 observability/contracts 下 z.object／strictObject／looseObject 的 Schema 字段：
  *   - 字段类型是 `ArtifactKind`(或以它为基的类型)→ 放行;
  *   - 否则必须登记在 FROZEN_KIND_EXCEPTIONS —— 这些都是已经序列化进
  *     report / observe / doctor / diagnosis JSON 的判别字段,改名会破坏读取已有落盘文件,
@@ -41,7 +42,7 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   "src/observability/soft-standards/types.ts::SkillDerivedStandards::'observe-skill-derived-standards'",
   "src/observability/skill-health/analyzer.ts::SkillHealthReport::'observe-health'",
   // —— 持久化 observe / experience JSON ——
-  'src/observability/contracts/experience.ts::ExperienceEvidenceRef::ExperienceEvidenceKind',
+  'src/observability/contracts/experience-evidence-schema.ts::ExperienceEvidenceRefSchema::ExperienceEvidenceKindSchema',
   'src/observability/contracts/experience.ts::ExperienceSessionStoryNode::ExperienceSessionStoryNodeKind',
   "src/observability/contracts/experience.ts::ExperienceGoalEvidenceRef::'user_message' | 'goal_slice' | 'llm_goal'",
   'src/observability/contracts/experience.ts::ExperienceEpisodeArtifact::ExperienceEpisodeArtifactKind',
@@ -86,8 +87,7 @@ function enclosingTypeName(node: ts.Node): string {
   return '(anonymous)';
 }
 
-function findKindFields(absFile: string): KindSite[] {
-  const text = readFileSync(absFile, 'utf8');
+function findKindFields(absFile: string, text = readFileSync(absFile, 'utf8')): KindSite[] {
   const sf = ts.createSourceFile(absFile, text, ts.ScriptTarget.Latest, true);
   const rel = relative(PROJECT_ROOT, absFile).split('\\').join('/');
   const out: KindSite[] = [];
@@ -103,6 +103,28 @@ function findKindFields(absFile: string): KindSite[] {
       const line = sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
       out.push({ key: `${rel}::${enclosing}::${typeText}`, file: rel, line, enclosing, typeText });
     }
+    if (rel.startsWith('src/observability/contracts/')
+        && ts.isPropertyAssignment(node)
+        && (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name))
+        && node.name.text === 'kind'
+        && ts.isObjectLiteralExpression(node.parent)) {
+      const call = node.parent.parent;
+      if (ts.isCallExpression(call)
+          && call.arguments[0] === node.parent
+          && ts.isPropertyAccessExpression(call.expression)
+          && ts.isIdentifier(call.expression.expression)
+          && call.expression.expression.text === 'z'
+          && ['object', 'strictObject', 'looseObject'].includes(call.expression.name.text)) {
+        let parent: ts.Node | undefined = call.parent;
+        while (parent && !ts.isVariableDeclaration(parent)) parent = parent.parent;
+        const enclosing = parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)
+          ? parent.name.text
+          : '(anonymous-schema)';
+        const typeText = node.initializer.getText(sf).replace(/\s+/g, ' ').trim();
+        const line = sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
+        out.push({ key: `${rel}::${enclosing}::${typeText}`, file: rel, line, enclosing, typeText });
+      }
+    }
     ts.forEachChild(node, visit);
   }
   visit(sf);
@@ -115,8 +137,21 @@ function isArtifactKindType(typeText: string): boolean {
 }
 
 describe('issue #206: 裸 kind 护栏', () => {
+  it.each(['kind', "'kind'"])('对象 Schema 的 %s 字段仍须登记', (field) => {
+    const file = join(SRC_DIR, 'observability/contracts/unregistered-schema.ts');
+    const sites = findKindFields(file, `const NewSchema = z.object({ ${field}: z.literal('new') });`);
+    assert.equal(sites.length, 1);
+    assert.equal(sites[0].enclosing, 'NewSchema');
+    assert.equal(FROZEN_KIND_EXCEPTIONS.has(sites[0].key), false);
+  });
+
+  it('Schema 字段识别不把普通对象构造误当声明', () => {
+    const file = join(SRC_DIR, 'observability/contracts/example.ts');
+    assert.deepEqual(findKindFields(file, "const value = { kind: 'tool_use' };"), []);
+  });
+
   it('每个 kind 字段声明要么是 ArtifactKind,要么是已登记的持久化例外', () => {
-    const sites = collectTsFiles(SRC_DIR).flatMap(findKindFields);
+    const sites = collectTsFiles(SRC_DIR).flatMap((file) => findKindFields(file));
 
     const offenders = sites
       .filter((s) => !isArtifactKindType(s.typeText) && !FROZEN_KIND_EXCEPTIONS.has(s.key))


### PR DESCRIPTION
## 用户影响

ExperienceEvidenceRef 的类型与结构校验改为共享声明式 Schema。保留必填性、原有枚举、非负安全整数索引、额外字段接受规则及独立时间戳语义检查；校验不以解析结果替换原对象，不改变落盘版本或引用一致性校验，无需迁移。

已发布的 kind 字段不改名，其护栏登记从旧接口迁到 Schema 声明。护栏同时识别 Observability 契约对象 Schema 的 kind，避免结构迁移导致该字段脱离检查。声明式 Schema 仍禁止宿主依赖、动态构造及变换副作用。

## 验证与范围

原 TypeScript 结构冻结对比、字段边界、时间戳和护栏反例通过。本地完整 `yarn ci` 通过，342 个测试文件、3737 项测试成功。本批源码净减 36 行、测试增加 176 行，总净增 140 行。

关联 #767 的 C2，接续 #799；其他对象结构及 wire／hydrated 差异仍待后续处理，不关闭总任务。