### PR TITLE
refactor(observability): 统一 Experience 审阅基础结构

### DIFF
--- a/src/observability/contracts/experience-evidence-schema.ts
+++ b/src/observability/contracts/experience-evidence-schema.ts
@@ -1,5 +1,15 @@
 import { z } from 'zod';
-import { ExperienceEvidenceKindSchema } from './experience-enums.js';
+import {
+  ExperienceAssistiveInferenceCautionCodeSchema,
+  ExperienceAssistiveInferenceCodeSchema,
+  ExperienceAssistiveInferenceConfidenceSchema,
+  ExperienceChecklistContributionSchema,
+  ExperienceChecklistItemStatusSchema,
+  ExperienceEvidenceKindSchema,
+  ExperienceReviewerReportFindingSourceSchema,
+  ExperienceRuleFindingCodeSchema,
+  ExperienceRuleFindingLevelSchema,
+} from './experience-enums.js';
 
 const NonNegativeIntegerSchema = z.number().int().nonnegative();
 
@@ -27,4 +37,48 @@ export const ExperienceEvidenceRefSchema = z.object({
   label: z.string().optional(),
   snippet: z.string().optional(),
   timestamp: z.string().optional(),
+});
+
+export const ExperienceEvidenceChainSchema = z.object({
+  userMessageCount: NonNegativeIntegerSchema,
+  runtimeContextCount: NonNegativeIntegerSchema,
+  skillContextCount: NonNegativeIntegerSchema,
+  assistantMessageCount: NonNegativeIntegerSchema,
+  toolUseCount: NonNegativeIntegerSchema,
+  toolResultCount: NonNegativeIntegerSchema,
+  toolFailureResultCount: NonNegativeIntegerSchema,
+  observationCount: NonNegativeIntegerSchema,
+  firstUserMessage: ExperienceEvidenceRefSchema.optional(),
+  firstRuntimeContext: ExperienceEvidenceRefSchema.optional(),
+  firstSkillContext: ExperienceEvidenceRefSchema.optional(),
+  firstToolUse: ExperienceEvidenceRefSchema.optional(),
+  firstToolFailure: ExperienceEvidenceRefSchema.optional(),
+  lastAssistantMessage: ExperienceEvidenceRefSchema.optional(),
+});
+
+export const ExperienceRuleFindingSchema = z.object({
+  code: ExperienceRuleFindingCodeSchema,
+  level: ExperienceRuleFindingLevelSchema,
+  count: NonNegativeIntegerSchema,
+  evidenceRefs: z.array(ExperienceEvidenceRefSchema),
+});
+
+export const ExperienceAssistiveInferenceSchema = z.object({
+  mode: z.literal('deterministic_rules_only'),
+  code: ExperienceAssistiveInferenceCodeSchema,
+  confidence: ExperienceAssistiveInferenceConfidenceSchema,
+  basisRuleCodes: z.array(ExperienceRuleFindingCodeSchema),
+  cautionCodes: z.array(ExperienceAssistiveInferenceCautionCodeSchema),
+  evidenceRefs: z.array(ExperienceEvidenceRefSchema),
+});
+
+export const ExperienceChecklistItemSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  status: ExperienceChecklistItemStatusSchema,
+  contribution: ExperienceChecklistContributionSchema,
+  reason: z.string(),
+  evidenceRefs: z.array(ExperienceEvidenceRefSchema),
+  source: ExperienceReviewerReportFindingSourceSchema,
+  suggestionKey: z.string().optional(),
 });

--- a/src/observability/contracts/experience.ts
+++ b/src/observability/contracts/experience.ts
@@ -1,3 +1,9 @@
+import type {
+  ExperienceEvidenceChainSchema,
+  ExperienceRuleFindingSchema,
+  ExperienceAssistiveInferenceSchema,
+  ExperienceChecklistItemSchema,
+} from './experience-evidence-schema.js';
 import type { ExperienceEvidenceRefSchema } from './experience-evidence-schema.js';
 import type { z } from 'zod';
 import type {
@@ -163,38 +169,11 @@ export interface ExperienceTraceRecordRange {
   eventCount: number;
 }
 
-export interface ExperienceEvidenceChain {
-  userMessageCount: number;
-  runtimeContextCount: number;
-  skillContextCount: number;
-  assistantMessageCount: number;
-  toolUseCount: number;
-  toolResultCount: number;
-  toolFailureResultCount: number;
-  observationCount: number;
-  firstUserMessage?: ExperienceEvidenceRef;
-  firstRuntimeContext?: ExperienceEvidenceRef;
-  firstSkillContext?: ExperienceEvidenceRef;
-  firstToolUse?: ExperienceEvidenceRef;
-  firstToolFailure?: ExperienceEvidenceRef;
-  lastAssistantMessage?: ExperienceEvidenceRef;
-}
+export type ExperienceEvidenceChain = z.infer<typeof ExperienceEvidenceChainSchema>;
 
-export interface ExperienceRuleFinding {
-  code: ExperienceRuleFindingCode;
-  level: ExperienceRuleFindingLevel;
-  count: number;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
+export type ExperienceRuleFinding = z.infer<typeof ExperienceRuleFindingSchema>;
 
-export interface ExperienceAssistiveInference {
-  mode: 'deterministic_rules_only';
-  code: ExperienceAssistiveInferenceCode;
-  confidence: ExperienceAssistiveInferenceConfidence;
-  basisRuleCodes: ExperienceRuleFindingCode[];
-  cautionCodes: ExperienceAssistiveInferenceCautionCode[];
-  evidenceRefs: ExperienceEvidenceRef[];
-}
+export type ExperienceAssistiveInference = z.infer<typeof ExperienceAssistiveInferenceSchema>;
 
 export interface ExperienceReviewerReportStep {
   order: number;
@@ -245,16 +224,7 @@ export interface ExperienceSessionStoryAnswer {
   checklistItems: ExperienceChecklistItem[];
 }
 
-export interface ExperienceChecklistItem {
-  key: string;
-  label: string;
-  status: ExperienceChecklistItemStatus;
-  contribution: ExperienceChecklistContribution;
-  reason: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-  source: ExperienceReviewerReportFindingSource;
-  suggestionKey?: string;
-}
+export type ExperienceChecklistItem = z.infer<typeof ExperienceChecklistItemSchema>;
 
 export interface ExperienceSessionStoryGoalSlice {
   id: string;

--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -1,10 +1,11 @@
+import {
+  ExperienceEvidenceChainSchema,
+  ExperienceRuleFindingSchema,
+  ExperienceAssistiveInferenceSchema,
+  ExperienceChecklistItemSchema,
+} from '../contracts/experience-evidence-schema.js';
 import { ExperienceEvidenceRefSchema } from '../contracts/experience-evidence-schema.js';
 import {
-  ExperienceAssistiveInferenceCautionCodeSchema,
-  ExperienceAssistiveInferenceCodeSchema,
-  ExperienceAssistiveInferenceConfidenceSchema,
-  ExperienceChecklistContributionSchema,
-  ExperienceChecklistItemStatusSchema,
   ExperienceEpisodeArtifactKindSchema,
   ExperienceEpisodeBoundaryReasonSchema,
   ExperienceEpisodeRoleSchema,
@@ -23,8 +24,6 @@ import {
   ExperienceReviewerReportFindingSourceSchema,
   ExperienceReviewerReportScopeSchema,
   ExperienceReviewerReportStepStatusSchema,
-  ExperienceRuleFindingCodeSchema,
-  ExperienceRuleFindingLevelSchema,
   ExperienceRuntimeSkillTypeSchema,
   ExperienceRuntimeSkillTypeSourceSchema,
   ExperienceSessionStoryAnswerKeySchema,
@@ -327,35 +326,21 @@ export function isExperienceEvidenceRefArray(value: unknown): value is Experienc
 }
 
 export function isExperienceEvidenceChain(value: unknown): boolean {
-  if (!isObjectRecord(value)) return false;
-  const countKeys = [
-    'userMessageCount',
-    'runtimeContextCount',
-    'skillContextCount',
-    'assistantMessageCount',
-    'toolUseCount',
-    'toolResultCount',
-    'toolFailureResultCount',
-    'observationCount',
-  ];
-  if (!countKeys.every((key) => isNonNegativeInteger(value[key]))) return false;
-  const optionalRefs = [
-    value.firstUserMessage,
-    value.firstRuntimeContext,
-    value.firstSkillContext,
-    value.firstToolUse,
-    value.firstToolFailure,
-    value.lastAssistantMessage,
-  ];
-  return optionalRefs.every((ref) => ref === undefined || isExperienceEvidenceRef(ref));
+  const parsed = ExperienceEvidenceChainSchema.safeParse(value);
+  if (!parsed.success) return false;
+  return [
+    parsed.data.firstUserMessage,
+    parsed.data.firstRuntimeContext,
+    parsed.data.firstSkillContext,
+    parsed.data.firstToolUse,
+    parsed.data.firstToolFailure,
+    parsed.data.lastAssistantMessage,
+  ].every((ref) => ref === undefined || isExperienceEvidenceRef(ref));
 }
 
 export function isExperienceRuleFinding(value: unknown): boolean {
-  return isObjectRecord(value)
-    && isEnumValue(value.code, ExperienceRuleFindingCodeSchema.options)
-    && isEnumValue(value.level, ExperienceRuleFindingLevelSchema.options)
-    && isNonNegativeInteger(value.count)
-    && isExperienceEvidenceRefArray(value.evidenceRefs);
+  const parsed = ExperienceRuleFindingSchema.safeParse(value);
+  return parsed.success && isExperienceEvidenceRefArray(parsed.data.evidenceRefs);
 }
 
 export function isExperienceRuleFindingArray(value: unknown): boolean {
@@ -363,13 +348,8 @@ export function isExperienceRuleFindingArray(value: unknown): boolean {
 }
 
 export function isExperienceAssistiveInference(value: unknown): boolean {
-  return isObjectRecord(value)
-    && value.mode === 'deterministic_rules_only'
-    && isEnumValue(value.code, ExperienceAssistiveInferenceCodeSchema.options)
-    && isEnumValue(value.confidence, ExperienceAssistiveInferenceConfidenceSchema.options)
-    && isEnumArray(value.basisRuleCodes, ExperienceRuleFindingCodeSchema.options)
-    && isEnumArray(value.cautionCodes, ExperienceAssistiveInferenceCautionCodeSchema.options)
-    && isExperienceEvidenceRefArray(value.evidenceRefs);
+  const parsed = ExperienceAssistiveInferenceSchema.safeParse(value);
+  return parsed.success && isExperienceEvidenceRefArray(parsed.data.evidenceRefs);
 }
 
 export function isExperienceProblemEvidenceRef(value: unknown): boolean {
@@ -722,15 +702,8 @@ export function isTimelineTree(value: unknown): value is ExperienceTimelineTree 
 }
 
 export function isExperienceChecklistItem(value: unknown): boolean {
-  return isObjectRecord(value)
-    && typeof value.key === 'string'
-    && typeof value.label === 'string'
-    && isEnumValue(value.status, ExperienceChecklistItemStatusSchema.options)
-    && isEnumValue(value.contribution, ExperienceChecklistContributionSchema.options)
-    && typeof value.reason === 'string'
-    && isExperienceEvidenceRefArray(value.evidenceRefs)
-    && isEnumValue(value.source, ExperienceReviewerReportFindingSourceSchema.options)
-    && isOptionalString(value.suggestionKey);
+  const parsed = ExperienceChecklistItemSchema.safeParse(value);
+  return parsed.success && isExperienceEvidenceRefArray(parsed.data.evidenceRefs);
 }
 
 export function isExperienceSessionStoryGoalSlice(value: unknown): boolean {

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -47,13 +47,25 @@ const EXPERIENCE_ENUM_TYPE_IMPORTS = new Set([
   'zod', './experience-enums.js', './experience-evidence-schema.js',
 ]);
 
+const EXPERIENCE_EVIDENCE_ENUM_IMPORTS = [
+  'ExperienceAssistiveInferenceCautionCodeSchema',
+  'ExperienceAssistiveInferenceCodeSchema',
+  'ExperienceAssistiveInferenceConfidenceSchema',
+  'ExperienceChecklistContributionSchema',
+  'ExperienceChecklistItemStatusSchema',
+  'ExperienceEvidenceKindSchema',
+  'ExperienceReviewerReportFindingSourceSchema',
+  'ExperienceRuleFindingCodeSchema',
+  'ExperienceRuleFindingLevelSchema',
+];
+
 function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile): boolean {
   const imports = new Map([
     ['zod', 'z'],
-    ['./experience-enums.js', 'ExperienceEvidenceKindSchema'],
+    ['./experience-enums.js', [...EXPERIENCE_EVIDENCE_ENUM_IMPORTS].sort().join(',')],
   ]);
   const seenImports = new Set<string>();
-  const schemas = new Set(['ExperienceEvidenceKindSchema']);
+  const schemas = new Set(EXPERIENCE_EVIDENCE_ENUM_IMPORTS);
   function expression(node: ts.Expression): boolean {
     if (ts.isIdentifier(node)) return schemas.has(node.text);
     if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression)) return false;
@@ -63,6 +75,8 @@ function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile): boolean {
       if (method === 'string' || method === 'number') return node.arguments.length === 0;
       if (node.arguments.length !== 1) return false;
       const argument = node.arguments[0];
+      if (method === 'array') return expression(argument);
+      if (method === 'literal') return ts.isStringLiteral(argument);
       if (method === 'enum') {
         return ts.isArrayLiteralExpression(argument) && argument.elements.length > 0
           && argument.elements.every(ts.isStringLiteral);
@@ -80,8 +94,9 @@ function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile): boolean {
       const bindings = statement.importClause?.namedBindings;
       if (!ts.isStringLiteral(statement.moduleSpecifier)
           || statement.importClause?.name || !bindings || !ts.isNamedImports(bindings)
-          || bindings.elements.length !== 1 || bindings.elements[0].propertyName
-          || imports.get(statement.moduleSpecifier.text) !== bindings.elements[0].name.text
+          || bindings.elements.some((element) => element.propertyName !== undefined)
+          || imports.get(statement.moduleSpecifier.text)
+            !== bindings.elements.map((element) => element.name.text).sort().join(',')
           || seenImports.has(statement.moduleSpecifier.text)) return false;
       seenImports.add(statement.moduleSpecifier.text);
       continue;
@@ -250,7 +265,7 @@ describe('领域契约所有权', () => {
     "z.object({ id: z.string() }); sideEffect()",
   ])('证据结构声明拒绝动态实现：%s', (initializer) => {
     const text = "import { z } from 'zod';\n"
-      + "import { ExperienceEvidenceKindSchema } from './experience-enums.js';\n"
+      + `import { ${EXPERIENCE_EVIDENCE_ENUM_IMPORTS.join(', ')} } from './experience-enums.js';\n`
       + `export const ExperienceEvidenceRefSchema = ${initializer};`;
     expect(isDeclarativeEvidenceSchemaModule(ts.createSourceFile(
       'invalid.ts', text, ts.ScriptTarget.Latest, true,

--- a/test/observability/experience-review-structures.test.ts
+++ b/test/observability/experience-review-structures.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { ExperienceEvidenceChain, ExperienceRuleFinding, ExperienceAssistiveInference, ExperienceChecklistItem } from '../../src/observability/contracts/experience.js';
+import { isExperienceEvidenceChain, isExperienceRuleFinding, isExperienceAssistiveInference, isExperienceChecklistItem } from '../../src/observability/experience/report-value-guards.js';
+import type { ExperienceEvidenceRef } from '../../src/observability/contracts/experience.js';
+import type { ExperienceRuleFindingCode } from '../../src/observability/contracts/experience.js';
+import type { ExperienceRuleFindingLevel } from '../../src/observability/contracts/experience.js';
+import type { ExperienceAssistiveInferenceCode } from '../../src/observability/contracts/experience.js';
+import type { ExperienceAssistiveInferenceConfidence } from '../../src/observability/contracts/experience.js';
+import type { ExperienceAssistiveInferenceCautionCode } from '../../src/observability/contracts/experience.js';
+import type { ExperienceChecklistItemStatus } from '../../src/observability/contracts/experience.js';
+import type { ExperienceChecklistContribution } from '../../src/observability/contracts/experience.js';
+import type { ExperienceReviewerReportFindingSource } from '../../src/observability/contracts/experience.js';
+
+// Frozen pre-schema structural contracts.
+interface LegacyExperienceEvidenceChain {
+  userMessageCount: number;
+  runtimeContextCount: number;
+  skillContextCount: number;
+  assistantMessageCount: number;
+  toolUseCount: number;
+  toolResultCount: number;
+  toolFailureResultCount: number;
+  observationCount: number;
+  firstUserMessage?: ExperienceEvidenceRef;
+  firstRuntimeContext?: ExperienceEvidenceRef;
+  firstSkillContext?: ExperienceEvidenceRef;
+  firstToolUse?: ExperienceEvidenceRef;
+  firstToolFailure?: ExperienceEvidenceRef;
+  lastAssistantMessage?: ExperienceEvidenceRef;
+}
+
+interface LegacyExperienceRuleFinding {
+  code: ExperienceRuleFindingCode;
+  level: ExperienceRuleFindingLevel;
+  count: number;
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+interface LegacyExperienceAssistiveInference {
+  mode: 'deterministic_rules_only';
+  code: ExperienceAssistiveInferenceCode;
+  confidence: ExperienceAssistiveInferenceConfidence;
+  basisRuleCodes: ExperienceRuleFindingCode[];
+  cautionCodes: ExperienceAssistiveInferenceCautionCode[];
+  evidenceRefs: ExperienceEvidenceRef[];
+}
+
+interface LegacyExperienceChecklistItem {
+  key: string;
+  label: string;
+  status: ExperienceChecklistItemStatus;
+  contribution: ExperienceChecklistContribution;
+  reason: string;
+  evidenceRefs: ExperienceEvidenceRef[];
+  source: ExperienceReviewerReportFindingSource;
+  suggestionKey?: string;
+}
+
+const cases = [
+  ['chain', isExperienceEvidenceChain, { userMessageCount: 0, runtimeContextCount: 0, skillContextCount: 0, assistantMessageCount: 0, toolUseCount: 0, toolResultCount: 0, toolFailureResultCount: 0, observationCount: 0 }],
+  ['finding', isExperienceRuleFinding, { code: 'no_priority_signal', level: 'normal', count: 0, evidenceRefs: [] }],
+  ['inference', isExperienceAssistiveInference, { mode: 'deterministic_rules_only', code: 'no_obvious_issue_from_rules', confidence: 'low', basisRuleCodes: [], cautionCodes: [], evidenceRefs: [] }],
+  ['checklist', isExperienceChecklistItem, { key: 'item', label: '', status: 'unknown', contribution: 'neutral', reason: '', source: 'deterministic_rule', evidenceRefs: [] }],
+] as const;
+
+describe('Experience review structures', () => {
+  it('preserves the frozen structural types', () => {
+    expectTypeOf<ExperienceEvidenceChain>().toEqualTypeOf<LegacyExperienceEvidenceChain>();
+    expectTypeOf<ExperienceRuleFinding>().toEqualTypeOf<LegacyExperienceRuleFinding>();
+    expectTypeOf<ExperienceAssistiveInference>().toEqualTypeOf<LegacyExperienceAssistiveInference>();
+    expectTypeOf<ExperienceChecklistItem>().toEqualTypeOf<LegacyExperienceChecklistItem>();
+  });
+  it.each(cases)('%s accepts its required shape and extra fields', (_name, guard, base) => {
+    expect(guard(base)).toBe(true);
+    expect(guard({ ...base, extension: { untouched: true } })).toBe(true);
+    for (const key of Object.keys(base)) {
+      const value: Record<string, unknown> = { ...base };
+      delete value[key];
+      expect(guard(value)).toBe(false);
+    }
+  });
+  it.each(cases)('%s preserves nested evidence timestamp checks', (name, guard, base) => {
+    const ref = { id: 'ref', kind: 'tool_use', sourceTrace: 'trace', sessionId: 'session', timestamp: '2026-09-07T00:00:00Z' };
+    const field = name === 'chain' ? 'firstUserMessage' : 'evidenceRefs';
+    expect(guard({ ...base, [field]: name === 'chain' ? ref : [ref] })).toBe(true);
+    const invalid = { ...ref, timestamp: 'invalid' };
+    expect(guard({ ...base, [field]: name === 'chain' ? invalid : [invalid] })).toBe(false);
+  });
+});


### PR DESCRIPTION
## 用户影响

证据链、规则发现、辅助推断和检查项的类型与结构 guard 共用声明式 Schema，复用已有枚举及证据引用结构。保留嵌套证据时间戳语义、必填性和额外字段接受规则，不改变审阅策略或落盘版本，无需迁移。

Schema 边界仅增加数组和字符串字面量声明，继续禁止宿主依赖、动态字段和变换副作用。

## 验证与范围

四个原 TypeScript 结构的冻结对比、必填字段和嵌套时间戳回归通过。本地完整 `yarn ci` 通过，343 个测试文件、3746 项测试成功。本批源码净减 3 行、测试增加 104 行，总净增 101 行。

关联 #767 的 C2，接续 #799、#800；其他对象结构和 wire／hydrated 差异仍待后续处理，不关闭总任务。