### PR TITLE
refactor(observability): 统一时间线记录范围结构

### DIFF
--- a/src/observability/contracts/experience-evidence-schema.ts
+++ b/src/observability/contracts/experience-evidence-schema.ts
@@ -13,6 +13,14 @@ import {
 
 const NonNegativeIntegerSchema = z.number().int().nonnegative();
 
+export const ExperienceTraceRecordRangeSchema = z.object({
+  traceId: z.string(),
+  sourceTrace: z.string(),
+  startRecordIndex: NonNegativeIntegerSchema,
+  endRecordIndex: NonNegativeIntegerSchema,
+  eventCount: NonNegativeIntegerSchema,
+});
+
 export const ExperienceEvidenceRefSchema = z.object({
   id: z.string(),
   kind: ExperienceEvidenceKindSchema,

--- a/src/observability/contracts/experience.ts
+++ b/src/observability/contracts/experience.ts
@@ -161,13 +161,9 @@ export interface ExperienceTraceTimeline {
   tree: ExperienceTimelineTree;
 }
 
-export interface ExperienceTraceRecordRange {
-  traceId: string;
-  sourceTrace: string;
-  startRecordIndex: number;
-  endRecordIndex: number;
-  eventCount: number;
-}
+export type ExperienceTraceRecordRange = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceTraceRecordRangeSchema
+>;
 
 export type ExperienceEvidenceChain = z.infer<typeof ExperienceEvidenceChainSchema>;
 

--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -1,3 +1,4 @@
+import { ExperienceTraceRecordRangeSchema } from '../contracts/experience-evidence-schema.js';
 import {
   ExperienceEvidenceChainSchema,
   ExperienceRuleFindingSchema,
@@ -525,13 +526,8 @@ export function isExperienceTraceRecordRangeArray(value: unknown): value is Expe
   const identities = new Set<string>();
   for (const range of value) {
     if (
-      !isObjectRecord(range)
-      || typeof range.traceId !== 'string'
-      || typeof range.sourceTrace !== 'string'
-      || !isNonNegativeInteger(range.startRecordIndex)
-      || !isNonNegativeInteger(range.endRecordIndex)
+      !ExperienceTraceRecordRangeSchema.safeParse(range).success
       || range.startRecordIndex > range.endRecordIndex
-      || !isNonNegativeInteger(range.eventCount)
       || range.eventCount === 0
       || identities.has(range.traceId)
     ) return false;


### PR DESCRIPTION
## 用户影响

时间线记录范围的类型与结构校验共用 Schema，继续单独执行起止索引顺序、非零事件数和 trace 唯一性检查。保留额外字段接受规则，不替换原始输入对象，不改变落盘版本、引用关系或测量口径，无需迁移。

## 范围与验证

接续 #801，推进 #767 的 C2。完整本地 `yarn ci` 通过，343 个测试文件、3746 项测试成功。本批不处理调用指标中内存可选字段与落盘必填字段的差异，C2 和总任务仍未完成。