### PR TITLE
refactor(observability): 统一调用指标与落盘结构

### DIFF
--- a/src/observability/contracts/experience-evidence-schema.ts
+++ b/src/observability/contracts/experience-evidence-schema.ts
@@ -90,3 +90,22 @@ export const ExperienceChecklistItemSchema = z.object({
   source: ExperienceReviewerReportFindingSourceSchema,
   suggestionKey: z.string().optional(),
 });
+
+export const ExperienceInvocationMetricsSchema = z.object({
+  durationMs: NonNegativeIntegerSchema,
+  inputTokens: NonNegativeIntegerSchema,
+  outputTokens: NonNegativeIntegerSchema,
+  cacheReadTokens: NonNegativeIntegerSchema,
+  cacheCreationTokens: NonNegativeIntegerSchema,
+  /** False means counters are placeholders because the trace exposed no valid usage event. */
+  tokenUsageObserved: z.boolean(),
+  numTurns: NonNegativeIntegerSchema,
+  numToolCalls: NonNegativeIntegerSchema,
+  numToolFailures: NonNegativeIntegerSchema,
+  numToolCancelled: NonNegativeIntegerSchema.optional(),
+  /** Unresolved or source-unknown outcomes; excluded from failure-rate denominators. */
+  numToolUnknown: NonNegativeIntegerSchema.optional(),
+});
+
+// Persisted metrics require outcome counters even when hydrated callers may omit them.
+export const ExperienceInvocationMetricsWireSchema = ExperienceInvocationMetricsSchema.required();

--- a/src/observability/contracts/experience.ts
+++ b/src/observability/contracts/experience.ts
@@ -501,21 +501,9 @@ export interface ExperienceReviewIndicators {
   explicitMarkerCount: number;
 }
 
-export interface ExperienceInvocationMetrics {
-  durationMs: number;
-  inputTokens: number;
-  outputTokens: number;
-  cacheReadTokens: number;
-  cacheCreationTokens: number;
-  /** False means counters are placeholders because the trace exposed no valid usage event. */
-  tokenUsageObserved: boolean;
-  numTurns: number;
-  numToolCalls: number;
-  numToolFailures: number;
-  numToolCancelled?: number;
-  /** Unresolved or source-unknown outcomes; excluded from failure-rate denominators. */
-  numToolUnknown?: number;
-}
+export type ExperienceInvocationMetrics = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceInvocationMetricsSchema
+>;
 
 export interface ExperienceInvocation {
   id: string;

--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -1,3 +1,4 @@
+import { ExperienceInvocationMetricsWireSchema } from '../contracts/experience-evidence-schema.js';
 import { ExperienceTraceRecordRangeSchema } from '../contracts/experience-evidence-schema.js';
 import {
   ExperienceEvidenceChainSchema,
@@ -427,35 +428,11 @@ export function isExperienceAttribution(value: unknown): boolean {
 }
 
 export function isExperienceInvocationMetrics(value: unknown): boolean {
-  if (!isObjectRecord(value)) return false;
-  const fields = [
-    value.durationMs,
-    value.inputTokens,
-    value.outputTokens,
-    value.cacheReadTokens,
-    value.cacheCreationTokens,
-    value.numTurns,
-    value.numToolCalls,
-    value.numToolFailures,
-  ];
-  if (!fields.every(isNonNegativeInteger)) return false;
-  if (
-    (
-      typeof value.tokenUsageObserved !== 'boolean'
-      ||
-      !isNonNegativeInteger(value.numToolCancelled)
-      || !isNonNegativeInteger(value.numToolUnknown)
-    )
-  ) return false;
-  if (
-    value.tokenUsageObserved !== undefined
-    && typeof value.tokenUsageObserved !== 'boolean'
-  ) return false;
-  if (value.numToolCancelled !== undefined && !isNonNegativeInteger(value.numToolCancelled)) return false;
-  if (value.numToolUnknown !== undefined && !isNonNegativeInteger(value.numToolUnknown)) return false;
-  const cancelled = typeof value.numToolCancelled === 'number' ? value.numToolCancelled : 0;
-  const unknown = typeof value.numToolUnknown === 'number' ? value.numToolUnknown : 0;
-  return (value.numToolFailures as number) + cancelled + unknown <= (value.numToolCalls as number);
+  const parsed = ExperienceInvocationMetricsWireSchema.safeParse(value);
+  if (!parsed.success) return false;
+  const metrics = parsed.data;
+  return metrics.numToolFailures + metrics.numToolCancelled + metrics.numToolUnknown
+    <= metrics.numToolCalls;
 }
 
 export const EXPERIENCE_INDICATOR_KEYS = [

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -72,7 +72,7 @@ function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile): boolean {
     const receiver = node.expression.expression;
     const method = node.expression.name.text;
     if (ts.isIdentifier(receiver) && receiver.text === 'z') {
-      if (method === 'string' || method === 'number') return node.arguments.length === 0;
+      if (method === 'string' || (method === 'number' || method === 'boolean')) return node.arguments.length === 0;
       if (node.arguments.length !== 1) return false;
       const argument = node.arguments[0];
       if (method === 'array') return expression(argument);
@@ -86,7 +86,7 @@ function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile): boolean {
           && (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name))
           && expression(property.initializer));
     }
-    return ['optional', 'int', 'nonnegative'].includes(method)
+    return ['optional', 'required', 'int', 'nonnegative'].includes(method)
       && node.arguments.length === 0 && expression(receiver);
   }
   for (const statement of source.statements) {


### PR DESCRIPTION
## 用户影响

调用指标类型与落盘结构校验共用 Schema。内存类型继续允许省略取消和未知工具结果计数，落盘结构仍要求这些字段存在；失败、取消和未知结果总数不得超过工具调用总数。继续接受额外字段，不改变输入对象、持久化版本或统计口径，无需迁移。

## 范围与验证

声明式 Schema 边界增加无参布尔类型和必填派生操作，未引入宿主依赖或变换副作用。完整本地 `yarn ci` 通过，343 个测试文件、3746 项测试成功。

关联 #767，接续 #802。C2 的其他对象和最终跨批审计尚未完成，本 PR 不关闭总任务。