### PR TITLE
refactor(observability): 统一会话故事基础结构

### DIFF
--- a/src/observability/contracts/experience-evidence-schema.ts
+++ b/src/observability/contracts/experience-evidence-schema.ts
@@ -6,9 +6,15 @@ import {
   ExperienceChecklistContributionSchema,
   ExperienceChecklistItemStatusSchema,
   ExperienceEvidenceKindSchema,
+  ExperienceGoalSliceReasonCodeSchema,
+  ExperienceParentReasonSchema,
   ExperienceReviewerReportFindingSourceSchema,
+  ExperienceReviewerReportStepStatusSchema,
   ExperienceRuleFindingCodeSchema,
   ExperienceRuleFindingLevelSchema,
+  ExperienceSessionStoryAnswerKeySchema,
+  ExperienceSessionStoryNodeKindSchema,
+  ExperienceSessionStorySkillRoleSchema,
 } from './experience-enums.js';
 
 const NonNegativeIntegerSchema = z.number().int().nonnegative();
@@ -109,3 +115,78 @@ export const ExperienceInvocationMetricsSchema = z.object({
 
 // Persisted metrics require outcome counters even when hydrated callers may omit them.
 export const ExperienceInvocationMetricsWireSchema = ExperienceInvocationMetricsSchema.required();
+
+export const ExperienceSessionStoryGoalSliceSchema = z.object({
+  id: z.string(),
+  order: NonNegativeIntegerSchema,
+  skillNames: z.array(z.string()),
+  startTimestamp: z.string(),
+  endTimestamp: z.string(),
+  reasonCode: ExperienceGoalSliceReasonCodeSchema,
+  inferredUserGoal: z.string().optional(),
+  evidenceRefs: z.array(ExperienceEvidenceRefSchema),
+});
+
+export const ExperienceSessionStorySubagentDispatchSchema = z.object({
+  id: z.string(),
+  order: NonNegativeIntegerSchema,
+  branchId: z.string(),
+  childSessionId: z.string(),
+  traceId: z.string(),
+  label: z.string(),
+  sourceTrace: z.string(),
+  attachTo: z.object({
+  messageIndex: NonNegativeIntegerSchema.optional(),
+  callInstanceId: z.string().optional(),
+  toolUseId: z.string().optional(),
+  label: z.string().optional(),
+}).optional(),
+  eventCount: NonNegativeIntegerSchema,
+  evidenceRefs: z.array(ExperienceEvidenceRefSchema),
+});
+
+export const ExperienceSessionStorySkillLinkSchema = z.object({
+  id: z.string(),
+  order: NonNegativeIntegerSchema,
+  skillName: z.string(),
+  role: ExperienceSessionStorySkillRoleSchema,
+  invocationIds: z.array(z.string()),
+  goalSliceIds: z.array(z.string()),
+  evidenceRefs: z.array(ExperienceEvidenceRefSchema),
+});
+
+export const ExperienceSessionStoryGraphNodeSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  kind: ExperienceSessionStoryNodeKindSchema,
+  status: ExperienceReviewerReportStepStatusSchema,
+  role: ExperienceSessionStorySkillRoleSchema.optional(),
+  detailNodeId: z.string().optional(),
+});
+
+export const ExperienceSessionStoryGraphEdgeSchema = z.object({
+  fromId: z.string(),
+  toId: z.string(),
+  label: z.string(),
+});
+
+export const ExperienceSessionStoryNodeSchema = z.object({
+  id: z.string(),
+  order: NonNegativeIntegerSchema,
+  kind: ExperienceSessionStoryNodeKindSchema,
+  label: z.string(),
+  status: ExperienceReviewerReportStepStatusSchema,
+  text: z.string(),
+  evidenceRefs: z.array(ExperienceEvidenceRefSchema),
+});
+
+export const ExperienceSessionStoryAnswerSchema = z.object({
+  key: ExperienceSessionStoryAnswerKeySchema,
+  label: z.string(),
+  status: ExperienceReviewerReportStepStatusSchema,
+  reason: ExperienceParentReasonSchema,
+  sourceItemKeys: z.array(z.string()),
+  text: z.string(),
+  evidenceRefs: z.array(ExperienceEvidenceRefSchema),
+  checklistItems: z.array(ExperienceChecklistItemSchema),
+});

--- a/src/observability/contracts/experience.ts
+++ b/src/observability/contracts/experience.ts
@@ -199,67 +199,27 @@ export interface ExperienceReviewerReportFinding {
   };
 }
 
-export interface ExperienceSessionStoryNode {
-  id: string;
-  order: number;
-  kind: ExperienceSessionStoryNodeKind;
-  label: string;
-  status: ExperienceReviewerReportStepStatus;
-  text: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
+export type ExperienceSessionStoryNode = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceSessionStoryNodeSchema
+>;
 
-export interface ExperienceSessionStoryAnswer {
-  key: ExperienceSessionStoryAnswerKey;
-  label: string;
-  status: ExperienceReviewerReportStepStatus;
-  reason: ExperienceParentReason;
-  sourceItemKeys: string[];
-  text: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-  checklistItems: ExperienceChecklistItem[];
-}
+export type ExperienceSessionStoryAnswer = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceSessionStoryAnswerSchema
+>;
 
 export type ExperienceChecklistItem = z.infer<typeof ExperienceChecklistItemSchema>;
 
-export interface ExperienceSessionStoryGoalSlice {
-  id: string;
-  order: number;
-  skillNames: string[];
-  startTimestamp: string;
-  endTimestamp: string;
-  reasonCode: ExperienceGoalSliceReasonCode;
-  inferredUserGoal?: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
+export type ExperienceSessionStoryGoalSlice = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceSessionStoryGoalSliceSchema
+>;
 
-export interface ExperienceSessionStorySubagentDispatch {
-  id: string;
-  order: number;
-  branchId: string;
-  childSessionId: string;
-  traceId: string;
-  label: string;
-  sourceTrace: string;
-  attachTo?: {
-    messageIndex?: number;
-    callInstanceId?: string;
-    toolUseId?: string;
-    label?: string;
-  };
-  eventCount: number;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
+export type ExperienceSessionStorySubagentDispatch = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceSessionStorySubagentDispatchSchema
+>;
 
-export interface ExperienceSessionStorySkillLink {
-  id: string;
-  order: number;
-  skillName: string;
-  role: ExperienceSessionStorySkillRole;
-  invocationIds: string[];
-  goalSliceIds: string[];
-  evidenceRefs: ExperienceEvidenceRef[];
-}
+export type ExperienceSessionStorySkillLink = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceSessionStorySkillLinkSchema
+>;
 
 export interface ExperienceGoalEvidenceRef {
   kind: 'user_message' | 'goal_slice' | 'llm_goal';
@@ -367,20 +327,13 @@ export interface ExperienceEpisode {
   outcome: ExperienceEpisodeOutcome;
 }
 
-export interface ExperienceSessionStoryGraphNode {
-  id: string;
-  label: string;
-  kind: ExperienceSessionStoryNodeKind;
-  status: ExperienceReviewerReportStepStatus;
-  role?: ExperienceSessionStorySkillRole;
-  detailNodeId?: string;
-}
+export type ExperienceSessionStoryGraphNode = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceSessionStoryGraphNodeSchema
+>;
 
-export interface ExperienceSessionStoryGraphEdge {
-  fromId: string;
-  toId: string;
-  label: string;
-}
+export type ExperienceSessionStoryGraphEdge = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceSessionStoryGraphEdgeSchema
+>;
 
 export interface ExperienceSessionStory {
   schemaVersion: 1;

--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -1,3 +1,12 @@
+import {
+  ExperienceSessionStoryGoalSliceSchema,
+  ExperienceSessionStorySubagentDispatchSchema,
+  ExperienceSessionStorySkillLinkSchema,
+  ExperienceSessionStoryGraphNodeSchema,
+  ExperienceSessionStoryGraphEdgeSchema,
+  ExperienceSessionStoryNodeSchema,
+  ExperienceSessionStoryAnswerSchema,
+} from '../contracts/experience-evidence-schema.js';
 import { ExperienceInvocationMetricsWireSchema } from '../contracts/experience-evidence-schema.js';
 import { ExperienceTraceRecordRangeSchema } from '../contracts/experience-evidence-schema.js';
 import {
@@ -15,11 +24,9 @@ import {
   ExperienceFeedbackAttributionReasonSchema,
   ExperienceFeedbackAttributionRoleSchema,
   ExperienceFeedbackSignalTypeSchema,
-  ExperienceGoalSliceReasonCodeSchema,
   ExperienceOrchestrationEdgeKindSchema,
   ExperienceOrchestrationEdgeStatusSchema,
   ExperienceOutcomeClosureSchema,
-  ExperienceParentReasonSchema,
   ExperienceReviewBasisCodeSchema,
   ExperienceReviewPrioritySchema,
   ExperienceReviewerReportFindingLevelSchema,
@@ -28,9 +35,6 @@ import {
   ExperienceReviewerReportStepStatusSchema,
   ExperienceRuntimeSkillTypeSchema,
   ExperienceRuntimeSkillTypeSourceSchema,
-  ExperienceSessionStoryAnswerKeySchema,
-  ExperienceSessionStoryNodeKindSchema,
-  ExperienceSessionStorySkillRoleSchema,
 } from '../contracts/experience-enums.js';
 import {
   isTraceSourceKind,
@@ -680,87 +684,43 @@ export function isExperienceChecklistItem(value: unknown): boolean {
 }
 
 export function isExperienceSessionStoryGoalSlice(value: unknown): boolean {
-  return isObjectRecord(value)
-    && typeof value.id === 'string'
-    && isNonNegativeInteger(value.order)
-    && isStringArray(value.skillNames)
-    && isTimestampRange(value.startTimestamp, value.endTimestamp)
-    && isEnumValue(value.reasonCode, ExperienceGoalSliceReasonCodeSchema.options)
-    && isOptionalString(value.inferredUserGoal)
-    && isExperienceEvidenceRefArray(value.evidenceRefs);
+  const parsed = ExperienceSessionStoryGoalSliceSchema.safeParse(value);
+  return parsed.success
+    && isTimestampRange(parsed.data.startTimestamp, parsed.data.endTimestamp)
+    && isExperienceEvidenceRefArray(parsed.data.evidenceRefs);
 }
 
 export function isExperienceSessionStorySubagentDispatch(value: unknown): boolean {
-  if (
-    !isObjectRecord(value)
-    || typeof value.id !== 'string'
-    || !isNonNegativeInteger(value.order)
-    || typeof value.branchId !== 'string'
-    || typeof value.childSessionId !== 'string'
-    || typeof value.traceId !== 'string'
-    || typeof value.label !== 'string'
-    || typeof value.sourceTrace !== 'string'
-    || !isNonNegativeInteger(value.eventCount)
-    || !isExperienceEvidenceRefArray(value.evidenceRefs)
-  ) return false;
-  if (value.attachTo === undefined) return true;
-  return isObjectRecord(value.attachTo)
-    && isOptionalNonNegativeInteger(value.attachTo.messageIndex)
-    && isOptionalString(value.attachTo.callInstanceId)
-    && isOptionalString(value.attachTo.toolUseId)
-    && isOptionalString(value.attachTo.label);
+  const parsed = ExperienceSessionStorySubagentDispatchSchema.safeParse(value);
+  return parsed.success
+    && isExperienceEvidenceRefArray(parsed.data.evidenceRefs);
 }
 
 export function isExperienceSessionStorySkillLink(value: unknown): boolean {
-  return isObjectRecord(value)
-    && typeof value.id === 'string'
-    && isNonNegativeInteger(value.order)
-    && typeof value.skillName === 'string'
-    && isEnumValue(value.role, ExperienceSessionStorySkillRoleSchema.options)
-    && isStringArray(value.invocationIds)
-    && isStringArray(value.goalSliceIds)
-    && isExperienceEvidenceRefArray(value.evidenceRefs);
+  const parsed = ExperienceSessionStorySkillLinkSchema.safeParse(value);
+  return parsed.success
+    && isExperienceEvidenceRefArray(parsed.data.evidenceRefs);
 }
 
 export function isExperienceSessionStoryGraphNode(value: unknown): boolean {
-  return isObjectRecord(value)
-    && typeof value.id === 'string'
-    && typeof value.label === 'string'
-    && isEnumValue(value.kind, ExperienceSessionStoryNodeKindSchema.options)
-    && isEnumValue(value.status, ExperienceReviewerReportStepStatusSchema.options)
-    && (value.role === undefined || isEnumValue(value.role, ExperienceSessionStorySkillRoleSchema.options))
-    && isOptionalString(value.detailNodeId);
+  return ExperienceSessionStoryGraphNodeSchema.safeParse(value).success;
 }
 
 export function isExperienceSessionStoryGraphEdge(value: unknown): boolean {
-  return isObjectRecord(value)
-    && typeof value.fromId === 'string'
-    && typeof value.toId === 'string'
-    && typeof value.label === 'string';
+  return ExperienceSessionStoryGraphEdgeSchema.safeParse(value).success;
 }
 
 export function isExperienceSessionStoryNode(value: unknown): boolean {
-  return isObjectRecord(value)
-    && typeof value.id === 'string'
-    && isNonNegativeInteger(value.order)
-    && isEnumValue(value.kind, ExperienceSessionStoryNodeKindSchema.options)
-    && typeof value.label === 'string'
-    && isEnumValue(value.status, ExperienceReviewerReportStepStatusSchema.options)
-    && typeof value.text === 'string'
-    && isExperienceEvidenceRefArray(value.evidenceRefs);
+  const parsed = ExperienceSessionStoryNodeSchema.safeParse(value);
+  return parsed.success
+    && isExperienceEvidenceRefArray(parsed.data.evidenceRefs);
 }
 
 export function isExperienceSessionStoryAnswer(value: unknown): boolean {
-  return isObjectRecord(value)
-    && isEnumValue(value.key, ExperienceSessionStoryAnswerKeySchema.options)
-    && typeof value.label === 'string'
-    && isEnumValue(value.status, ExperienceReviewerReportStepStatusSchema.options)
-    && isEnumValue(value.reason, ExperienceParentReasonSchema.options)
-    && isStringArray(value.sourceItemKeys)
-    && typeof value.text === 'string'
-    && isExperienceEvidenceRefArray(value.evidenceRefs)
-    && Array.isArray(value.checklistItems)
-    && value.checklistItems.every(isExperienceChecklistItem);
+  const parsed = ExperienceSessionStoryAnswerSchema.safeParse(value);
+  return parsed.success
+    && isExperienceEvidenceRefArray(parsed.data.evidenceRefs)
+    && parsed.data.checklistItems.every(isExperienceChecklistItem);
 }
 
 export function isExperienceGoalEvidenceRef(value: unknown): boolean {

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -54,9 +54,15 @@ const EXPERIENCE_EVIDENCE_ENUM_IMPORTS = [
   'ExperienceChecklistContributionSchema',
   'ExperienceChecklistItemStatusSchema',
   'ExperienceEvidenceKindSchema',
+  'ExperienceGoalSliceReasonCodeSchema',
+  'ExperienceParentReasonSchema',
   'ExperienceReviewerReportFindingSourceSchema',
+  'ExperienceReviewerReportStepStatusSchema',
   'ExperienceRuleFindingCodeSchema',
   'ExperienceRuleFindingLevelSchema',
+  'ExperienceSessionStoryAnswerKeySchema',
+  'ExperienceSessionStoryNodeKindSchema',
+  'ExperienceSessionStorySkillRoleSchema',
 ];
 
 function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile): boolean {

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -43,10 +43,10 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   "src/observability/skill-health/analyzer.ts::SkillHealthReport::'observe-health'",
   // —— 持久化 observe / experience JSON ——
   'src/observability/contracts/experience-evidence-schema.ts::ExperienceEvidenceRefSchema::ExperienceEvidenceKindSchema',
-  'src/observability/contracts/experience.ts::ExperienceSessionStoryNode::ExperienceSessionStoryNodeKind',
+  'src/observability/contracts/experience-evidence-schema.ts::ExperienceSessionStoryNodeSchema::ExperienceSessionStoryNodeKindSchema',
   "src/observability/contracts/experience.ts::ExperienceGoalEvidenceRef::'user_message' | 'goal_slice' | 'llm_goal'",
   'src/observability/contracts/experience.ts::ExperienceEpisodeArtifact::ExperienceEpisodeArtifactKind',
-  'src/observability/contracts/experience.ts::ExperienceSessionStoryGraphNode::ExperienceSessionStoryNodeKind',
+  'src/observability/contracts/experience-evidence-schema.ts::ExperienceSessionStoryGraphNodeSchema::ExperienceSessionStoryNodeKindSchema',
   'src/observability/contracts/experience.ts::ExperienceReviewerReport::ExperienceReviewerReportScope',
   'src/observability/contracts/problem-patterns.ts::ExperienceProblemEvidenceRef::string',
   'src/observability/contracts/problem-patterns.ts::ProblemTimelineEvent::string',


### PR DESCRIPTION
## 用户影响

目标切片、子代理派发、技能关联、图节点、图边、故事节点和答案共用 Schema 派生类型及结构校验，继续执行时间范围和嵌套证据时间戳语义校验。保留额外字段接受规则和原输入对象，不改变落盘版本、引用关系或统计口径，无需迁移。

## 范围与验证

同步迁移两个已发布 kind 字段的精确白名单，不扩大新增裸 kind 的允许范围。Schema 架构边界继续限制为声明式结构与枚举引用。

完整本地 `yarn ci` 通过，343 个测试文件、3746 项测试成功。关联 #767，接续 #803；其余 C2 对象结构与最终跨批审计仍未完成，不关闭总任务。