### PR TITLE
refactor(observability): 统一审阅报告与引用结构

### DIFF
--- a/src/observability/contracts/experience-evidence-schema.ts
+++ b/src/observability/contracts/experience-evidence-schema.ts
@@ -18,7 +18,9 @@ import {
   ExperienceOutcomeClosureSchema,
   ExperienceParentReasonSchema,
   ExperienceReviewPrioritySchema,
+  ExperienceReviewerReportFindingLevelSchema,
   ExperienceReviewerReportFindingSourceSchema,
+  ExperienceReviewerReportScopeSchema,
   ExperienceReviewerReportStepStatusSchema,
   ExperienceRuleFindingCodeSchema,
   ExperienceRuleFindingLevelSchema,
@@ -317,4 +319,124 @@ export const ExperienceStoryContextSchema = z.object({
   goalSlices: z.array(ExperienceSessionStoryGoalSliceSchema),
   subagentDispatches: z.array(ExperienceSessionStorySubagentDispatchSchema),
   episodes: z.array(ExperienceEpisodeSchema),
+});
+
+export const ExperienceReviewerReportStepSchema = z.object({
+  order: NonNegativeIntegerSchema,
+  label: z.string(),
+  status: ExperienceReviewerReportStepStatusSchema,
+  text: z.string(),
+  evidenceRefs: z.array(ExperienceEvidenceRefSchema),
+});
+
+export const ExperienceReviewerReportFindingSchema = z.object({
+  id: z.string(),
+  judgmentId: z.string(),
+  source: ExperienceReviewerReportFindingSourceSchema,
+  level: ExperienceReviewerReportFindingLevelSchema,
+  title: z.string(),
+  body: z.string(),
+  ruleSource: z.string(),
+  ruleVersion: z.string(),
+  evidenceRefs: z.array(ExperienceEvidenceRefSchema),
+  reviewStateRef: z.object({
+    targetType: z.literal('reviewer_judgment'),
+    targetId: z.string(),
+    verdict: z.string().optional(),
+    reason: z.string().optional(),
+    note: z.string().optional(),
+    reviewedAt: z.string().optional(),
+  }),
+});
+
+// Hydrated legacy reports may lack coverage; wire metrics require all coverage fields.
+
+const ExperienceReviewerTokenUsageSchema = z.object({
+  inputTokens: NonNegativeIntegerSchema,
+  outputTokens: NonNegativeIntegerSchema,
+  cacheReadTokens: NonNegativeIntegerSchema,
+  cacheCreationTokens: NonNegativeIntegerSchema,
+  observedInvocationCount: NonNegativeIntegerSchema.optional(),
+  invocationCount: NonNegativeIntegerSchema.optional(),
+  coverage: z.number().optional(),
+  attribution: z.literal('skill_segment'),
+});
+
+export const ExperienceReviewerMetricsSchema = z.object({
+  toolCallCount: NonNegativeIntegerSchema,
+  toolFailureCount: NonNegativeIntegerSchema,
+  toolCancelledCount: NonNegativeIntegerSchema.optional(),
+  toolUnknownCount: NonNegativeIntegerSchema.optional(),
+  userMessageCount: NonNegativeIntegerSchema,
+  userFollowUpCount: NonNegativeIntegerSchema,
+  assistantDeliverySignalCount: NonNegativeIntegerSchema,
+  deliverableArtifactSignalCount: NonNegativeIntegerSchema,
+  routerDownstreamCompleted: NonNegativeIntegerSchema,
+  routerDownstreamFailed: NonNegativeIntegerSchema,
+  assistantProgressUpdateCount: NonNegativeIntegerSchema,
+  selfCorrectionCount: NonNegativeIntegerSchema,
+  repeatedExecutionCount: NonNegativeIntegerSchema,
+  finalDeliverySignalCount: NonNegativeIntegerSchema,
+  traceEventCount: NonNegativeIntegerSchema,
+  tokenUsage: ExperienceReviewerTokenUsageSchema,
+});
+
+export const ExperienceReviewerMetricsWireSchema = ExperienceReviewerMetricsSchema.required().extend({
+  tokenUsage: ExperienceReviewerTokenUsageSchema.required(),
+});
+
+const ExperienceSessionStoryBaseSchema = z.object({
+  schemaVersion: z.literal(1),
+  summary: z.string(),
+  invocationCount: NonNegativeIntegerSchema,
+  goalSliceCount: NonNegativeIntegerSchema,
+  branchCount: NonNegativeIntegerSchema,
+  progressUpdateCount: NonNegativeIntegerSchema,
+  finalDeliverySignalCount: NonNegativeIntegerSchema,
+  mainlineNodeIds: z.array(z.string()),
+  skillLinks: z.array(ExperienceSessionStorySkillLinkSchema),
+  graph: z.object({
+    nodes: z.array(ExperienceSessionStoryGraphNodeSchema),
+    edges: z.array(ExperienceSessionStoryGraphEdgeSchema),
+  }),
+  nodes: z.array(ExperienceSessionStoryNodeSchema),
+  answers: z.array(ExperienceSessionStoryAnswerSchema),
+});
+
+export const ExperienceSessionStorySchema = ExperienceSessionStoryBaseSchema.extend({
+  contextRef: z.string().optional(),
+  goalSlices: z.array(ExperienceSessionStoryGoalSliceSchema),
+  subagentDispatches: z.array(ExperienceSessionStorySubagentDispatchSchema),
+  episodes: z.array(ExperienceEpisodeSchema).optional(),
+});
+
+export const ExperienceSessionStoryWireSchema = ExperienceSessionStoryBaseSchema.extend({
+  contextRef: z.string(),
+});
+
+const ExperienceReviewerReportBaseSchema = z.object({
+  schemaVersion: z.literal(1),
+  mode: z.enum(['deterministic_milestone_1', 'deterministic_session_story']),
+  generatedAt: z.string(),
+  title: z.string(),
+  summary: z.string(),
+  scope: z.object({
+    kind: ExperienceReviewerReportScopeSchema,
+    reasonCodes: z.array(z.string()),
+  }),
+  chainSteps: z.array(ExperienceReviewerReportStepSchema),
+  findings: z.array(ExperienceReviewerReportFindingSchema),
+  oneLookMetrics: ExperienceReviewerMetricsSchema,
+  authorSuggestions: z.array(z.string()),
+  traceLinks: z.array(ExperienceEvidenceRefSchema),
+});
+
+export const ExperienceReviewerReportSchema = ExperienceReviewerReportBaseSchema.extend({
+  sessionStory: ExperienceSessionStorySchema,
+  sessionStoryRef: z.literal('session').optional(),
+});
+
+export const ExperienceReviewerReportWireSchema = ExperienceReviewerReportBaseSchema.extend({
+  oneLookMetrics: ExperienceReviewerMetricsWireSchema,
+  sessionStoryRef: z.literal('session'),
 });

--- a/src/observability/contracts/experience.ts
+++ b/src/observability/contracts/experience.ts
@@ -171,33 +171,13 @@ export type ExperienceRuleFinding = z.infer<typeof ExperienceRuleFindingSchema>;
 
 export type ExperienceAssistiveInference = z.infer<typeof ExperienceAssistiveInferenceSchema>;
 
-export interface ExperienceReviewerReportStep {
-  order: number;
-  label: string;
-  status: ExperienceReviewerReportStepStatus;
-  text: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-}
+export type ExperienceReviewerReportStep = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceReviewerReportStepSchema
+>;
 
-export interface ExperienceReviewerReportFinding {
-  id: string;
-  judgmentId: string;
-  source: ExperienceReviewerReportFindingSource;
-  level: ExperienceReviewerReportFindingLevel;
-  title: string;
-  body: string;
-  ruleSource: string;
-  ruleVersion: string;
-  evidenceRefs: ExperienceEvidenceRef[];
-  reviewStateRef: {
-    targetType: 'reviewer_judgment';
-    targetId: string;
-    verdict?: string;
-    reason?: string;
-    note?: string;
-    reviewedAt?: string;
-  };
-}
+export type ExperienceReviewerReportFinding = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceReviewerReportFindingSchema
+>;
 
 export type ExperienceSessionStoryNode = z.infer<
   typeof import('./experience-evidence-schema.js').ExperienceSessionStoryNodeSchema
@@ -265,77 +245,17 @@ export type ExperienceSessionStoryGraphEdge = z.infer<
   typeof import('./experience-evidence-schema.js').ExperienceSessionStoryGraphEdgeSchema
 >;
 
-export interface ExperienceSessionStory {
-  schemaVersion: 1;
-  contextRef?: string;
-  summary: string;
-  invocationCount: number;
-  goalSliceCount: number;
-  branchCount: number;
-  progressUpdateCount: number;
-  finalDeliverySignalCount: number;
-  mainlineNodeIds: string[];
-  goalSlices: ExperienceSessionStoryGoalSlice[];
-  subagentDispatches: ExperienceSessionStorySubagentDispatch[];
-  skillLinks: ExperienceSessionStorySkillLink[];
-  episodes?: ExperienceEpisode[];
-  graph: {
-    nodes: ExperienceSessionStoryGraphNode[];
-    edges: ExperienceSessionStoryGraphEdge[];
-  };
-  nodes: ExperienceSessionStoryNode[];
-  answers: ExperienceSessionStoryAnswer[];
-}
+export type ExperienceSessionStory = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceSessionStorySchema
+>;
 
 export type ExperienceStoryContext = z.infer<
   typeof import('./experience-evidence-schema.js').ExperienceStoryContextSchema
 >;
 
-export interface ExperienceReviewerReport {
-  schemaVersion: 1;
-  mode: 'deterministic_milestone_1' | 'deterministic_session_story';
-  generatedAt: string;
-  title: string;
-  summary: string;
-  scope: {
-    kind: ExperienceReviewerReportScope;
-    reasonCodes: string[];
-  };
-  chainSteps: ExperienceReviewerReportStep[];
-  findings: ExperienceReviewerReportFinding[];
-  oneLookMetrics: {
-    toolCallCount: number;
-    toolFailureCount: number;
-    toolCancelledCount?: number;
-    toolUnknownCount?: number;
-    userMessageCount: number;
-    userFollowUpCount: number;
-    assistantDeliverySignalCount: number;
-    deliverableArtifactSignalCount: number;
-    routerDownstreamCompleted: number;
-    routerDownstreamFailed: number;
-    assistantProgressUpdateCount: number;
-    selfCorrectionCount: number;
-    repeatedExecutionCount: number;
-    finalDeliverySignalCount: number;
-    traceEventCount: number;
-    tokenUsage: {
-      inputTokens: number;
-      outputTokens: number;
-      cacheReadTokens: number;
-      cacheCreationTokens: number;
-      /** Missing on legacy reviewer reports; readers must treat that as unknown coverage. */
-      observedInvocationCount?: number;
-      invocationCount?: number;
-      coverage?: number;
-      attribution: 'skill_segment';
-    };
-  };
-  sessionStory: ExperienceSessionStory;
-  sessionStoryRef?: 'session';
-  authorSuggestions: string[];
-  traceLinks: ExperienceEvidenceRef[];
-}
+export type ExperienceReviewerReport = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceReviewerReportSchema
+>;
 
 export interface ExperienceGoalSlice {
   id: string;

--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -1,4 +1,11 @@
 import {
+  ExperienceReviewerReportStepSchema,
+  ExperienceReviewerReportFindingSchema,
+  ExperienceReviewerMetricsWireSchema,
+  ExperienceSessionStoryWireSchema,
+  ExperienceReviewerReportWireSchema,
+} from '../contracts/experience-evidence-schema.js';
+import {
   ExperienceGoalEvidenceRefSchema,
   ExperienceSkillSegmentSchema,
   ExperienceOrchestrationEdgeSchema,
@@ -31,10 +38,6 @@ import {
   ExperienceEvidenceKindSchema,
   ExperienceReviewBasisCodeSchema,
   ExperienceReviewPrioritySchema,
-  ExperienceReviewerReportFindingLevelSchema,
-  ExperienceReviewerReportFindingSourceSchema,
-  ExperienceReviewerReportScopeSchema,
-  ExperienceReviewerReportStepStatusSchema,
 } from '../contracts/experience-enums.js';
 import {
   isTraceSourceKind,
@@ -807,157 +810,49 @@ export function isExperienceStoryContext(value: unknown): value is ExperienceSto
 }
 
 export function isExperienceSessionStory(value: unknown): boolean {
-  if (
-    !isObjectRecord(value)
-    || value.schemaVersion !== 1
-    || typeof value.contextRef !== 'string'
-    || typeof value.summary !== 'string'
-    || !isNonNegativeInteger(value.invocationCount)
-    || !isNonNegativeInteger(value.goalSliceCount)
-    || !isNonNegativeInteger(value.branchCount)
-    || !isNonNegativeInteger(value.progressUpdateCount)
-    || !isNonNegativeInteger(value.finalDeliverySignalCount)
-    || !isStringArray(value.mainlineNodeIds)
-    || !Array.isArray(value.skillLinks)
-    || !value.skillLinks.every(isExperienceSessionStorySkillLink)
-    || !isObjectRecord(value.graph)
-    || !Array.isArray(value.graph.nodes)
-    || !value.graph.nodes.every(isExperienceSessionStoryGraphNode)
-    || !Array.isArray(value.graph.edges)
-    || !value.graph.edges.every(isExperienceSessionStoryGraphEdge)
-    || !Array.isArray(value.nodes)
-    || !value.nodes.every(isExperienceSessionStoryNode)
-    || !Array.isArray(value.answers)
-    || !value.answers.every(isExperienceSessionStoryAnswer)
-  ) return false;
-  return value.goalSlices === undefined
-    && value.subagentDispatches === undefined
-    && value.episodes === undefined;
+  if (!isObjectRecord(value)
+    || value.goalSlices !== undefined
+    || value.subagentDispatches !== undefined
+    || value.episodes !== undefined) return false;
+  const parsed = ExperienceSessionStoryWireSchema.safeParse(value);
+  if (!parsed.success) return false;
+  const data = parsed.data;
+  return data.skillLinks.every(isExperienceSessionStorySkillLink)
+    && data.nodes.every(isExperienceSessionStoryNode)
+    && data.answers.every(isExperienceSessionStoryAnswer);
 }
 
 export function isExperienceReviewerReportStep(value: unknown): boolean {
-  return isObjectRecord(value)
-    && isNonNegativeInteger(value.order)
-    && typeof value.label === 'string'
-    && isEnumValue(value.status, ExperienceReviewerReportStepStatusSchema.options)
-    && typeof value.text === 'string'
-    && isExperienceEvidenceRefArray(value.evidenceRefs);
+  const parsed = ExperienceReviewerReportStepSchema.safeParse(value);
+  return parsed.success && isExperienceEvidenceRefArray(parsed.data.evidenceRefs);
 }
 
 export function isExperienceReviewerReportFinding(value: unknown): boolean {
-  if (
-    !isObjectRecord(value)
-    || typeof value.id !== 'string'
-    || typeof value.judgmentId !== 'string'
-    || !isEnumValue(value.source, ExperienceReviewerReportFindingSourceSchema.options)
-    || !isEnumValue(value.level, ExperienceReviewerReportFindingLevelSchema.options)
-    || typeof value.title !== 'string'
-    || typeof value.body !== 'string'
-    || typeof value.ruleSource !== 'string'
-    || typeof value.ruleVersion !== 'string'
-    || !isExperienceEvidenceRefArray(value.evidenceRefs)
-    || !isObjectRecord(value.reviewStateRef)
-    || value.reviewStateRef.targetType !== 'reviewer_judgment'
-    || typeof value.reviewStateRef.targetId !== 'string'
-  ) return false;
-  return [
-    value.reviewStateRef.verdict,
-    value.reviewStateRef.reason,
-    value.reviewStateRef.note,
-  ].every(isOptionalString)
-    && isOptionalTimestamp(value.reviewStateRef.reviewedAt);
+  const parsed = ExperienceReviewerReportFindingSchema.safeParse(value);
+  return parsed.success
+    && isExperienceEvidenceRefArray(parsed.data.evidenceRefs)
+    && isOptionalTimestamp(parsed.data.reviewStateRef.reviewedAt);
 }
 
 export function isExperienceReviewerMetrics(value: unknown): boolean {
-  if (!isObjectRecord(value)) return false;
-  const countKeys = [
-    'toolCallCount',
-    'toolFailureCount',
-    'userMessageCount',
-    'userFollowUpCount',
-    'assistantDeliverySignalCount',
-    'deliverableArtifactSignalCount',
-    'routerDownstreamCompleted',
-    'routerDownstreamFailed',
-    'assistantProgressUpdateCount',
-    'selfCorrectionCount',
-    'repeatedExecutionCount',
-    'finalDeliverySignalCount',
-    'traceEventCount',
-  ];
-  if (
-    !countKeys.every((key) => isNonNegativeInteger(value[key]))
-    || (
-      !isNonNegativeInteger(value.toolCancelledCount)
-      || !isNonNegativeInteger(value.toolUnknownCount)
-    )
-    || (
-      value.toolCancelledCount !== undefined
-      && !isNonNegativeInteger(value.toolCancelledCount)
-    )
-    || (
-      value.toolUnknownCount !== undefined
-      && !isNonNegativeInteger(value.toolUnknownCount)
-    )
-    || !isObjectRecord(value.tokenUsage)
-  ) return false;
-  const tokenKeys = [
-    'inputTokens',
-    'outputTokens',
-    'cacheReadTokens',
-    'cacheCreationTokens',
-  ];
-  const tokenUsage = value.tokenUsage as Record<string, unknown>;
-  const observedInvocationCount = tokenUsage.observedInvocationCount;
-  const invocationCount = tokenUsage.invocationCount;
-  const coverage = tokenUsage.coverage;
-  const hasCoverage = observedInvocationCount !== undefined
-    || invocationCount !== undefined
-    || coverage !== undefined;
-  return tokenKeys.every((key) => isNonNegativeInteger(tokenUsage[key]))
-    && tokenUsage.attribution === 'skill_segment'
-    && (
-      !hasCoverage
-      || (
-        isNonNegativeInteger(observedInvocationCount)
-        && isNonNegativeInteger(invocationCount)
-        && isRate(coverage)
-        && (observedInvocationCount as number) <= (invocationCount as number)
-        && Math.abs(
-          (coverage as number)
-          - (
-            (invocationCount as number) > 0
-              ? (observedInvocationCount as number) / (invocationCount as number)
-              : 1
-          ),
-        ) <= 0.0001
-      )
-    )
-    && hasCoverage
-    && (value.toolFailureCount as number)
-      + (typeof value.toolCancelledCount === 'number' ? value.toolCancelledCount : 0)
-      + (typeof value.toolUnknownCount === 'number' ? value.toolUnknownCount : 0)
-      <= (value.toolCallCount as number);
+  const parsed = ExperienceReviewerMetricsWireSchema.safeParse(value);
+  if (!parsed.success) return false;
+  const data = parsed.data;
+  const { observedInvocationCount, invocationCount, coverage } = data.tokenUsage;
+  return isRate(coverage)
+    && observedInvocationCount <= invocationCount
+    && Math.abs(coverage - (invocationCount > 0 ? observedInvocationCount / invocationCount : 1)) <= 0.0001
+    && data.toolFailureCount + data.toolCancelledCount + data.toolUnknownCount <= data.toolCallCount;
 }
 
 export function isExperienceReviewerReport(value: unknown): boolean {
-  if (
-    !isObjectRecord(value)
-    || value.schemaVersion !== 1
-    || !isEnumValue(value.mode, ['deterministic_milestone_1', 'deterministic_session_story'])
-    || !isTimestamp(value.generatedAt)
-    || typeof value.title !== 'string'
-    || typeof value.summary !== 'string'
-    || !isObjectRecord(value.scope)
-    || !isEnumValue(value.scope.kind, ExperienceReviewerReportScopeSchema.options)
-    || !isStringArray(value.scope.reasonCodes)
-    || !Array.isArray(value.chainSteps)
-    || !value.chainSteps.every(isExperienceReviewerReportStep)
-    || !Array.isArray(value.findings)
-    || !value.findings.every(isExperienceReviewerReportFinding)
-    || !isExperienceReviewerMetrics(value.oneLookMetrics)
-    || !isStringArray(value.authorSuggestions)
-    || !isExperienceEvidenceRefArray(value.traceLinks)
-  ) return false;
-  return value.sessionStory === undefined && value.sessionStoryRef === 'session';
+  if (!isObjectRecord(value) || value.sessionStory !== undefined) return false;
+  const parsed = ExperienceReviewerReportWireSchema.safeParse(value);
+  if (!parsed.success) return false;
+  const data = parsed.data;
+  return isTimestamp(data.generatedAt)
+    && data.chainSteps.every(isExperienceReviewerReportStep)
+    && data.findings.every(isExperienceReviewerReportFinding)
+    && isExperienceReviewerMetrics(data.oneLookMetrics)
+    && isExperienceEvidenceRefArray(data.traceLinks);
 }

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -66,7 +66,9 @@ const EXPERIENCE_EVIDENCE_ENUM_IMPORTS = [
   'ExperienceOutcomeClosureSchema',
   'ExperienceParentReasonSchema',
   'ExperienceReviewPrioritySchema',
+  'ExperienceReviewerReportFindingLevelSchema',
   'ExperienceReviewerReportFindingSourceSchema',
+  'ExperienceReviewerReportScopeSchema',
   'ExperienceReviewerReportStepStatusSchema',
   'ExperienceRuleFindingCodeSchema',
   'ExperienceRuleFindingLevelSchema',
@@ -85,6 +87,18 @@ function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile): boolean {
   const seenImports = new Set<string>();
   const schemas = new Set(EXPERIENCE_EVIDENCE_ENUM_IMPORTS);
   function expression(node: ts.Expression): boolean {
+    if (ts.isCallExpression(node)
+      && ts.isPropertyAccessExpression(node.expression)
+      && node.expression.name.text === 'extend') {
+      const shape = node.arguments[0];
+      return node.arguments.length === 1
+        && expression(node.expression.expression)
+        && ts.isObjectLiteralExpression(shape)
+        && shape.properties.every((property) => ts.isPropertyAssignment(property)
+          && (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name))
+          && expression(property.initializer));
+    }
+
     if (ts.isIdentifier(node)) return schemas.has(node.text);
     if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression)) return false;
     const receiver = node.expression.expression;
@@ -94,7 +108,7 @@ function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile): boolean {
       if (node.arguments.length !== 1) return false;
       const argument = node.arguments[0];
       if (method === 'array') return expression(argument);
-      if (method === 'literal') return ts.isStringLiteral(argument);
+      if (method === 'literal') return (ts.isStringLiteral(argument) || ts.isNumericLiteral(argument));
       if (method === 'enum') {
         return ts.isArrayLiteralExpression(argument) && argument.elements.length > 0
           && argument.elements.every(ts.isStringLiteral);

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -47,7 +47,7 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   "src/observability/contracts/experience-evidence-schema.ts::ExperienceGoalEvidenceRefSchema::ExperienceGoalEvidenceKindSchema",
   "src/observability/contracts/experience-evidence-schema.ts::ExperienceEpisodeArtifactSchema::ExperienceEpisodeArtifactKindSchema",
   'src/observability/contracts/experience-evidence-schema.ts::ExperienceSessionStoryGraphNodeSchema::ExperienceSessionStoryNodeKindSchema',
-  'src/observability/contracts/experience.ts::ExperienceReviewerReport::ExperienceReviewerReportScope',
+  "src/observability/contracts/experience-evidence-schema.ts::ExperienceReviewerReportBaseSchema::ExperienceReviewerReportScopeSchema",
   'src/observability/contracts/problem-patterns.ts::ExperienceProblemEvidenceRef::string',
   'src/observability/contracts/problem-patterns.ts::ProblemTimelineEvent::string',
   // —— 持久化 soft-standards JSON（含 enhancedReview 内嵌结构）——


### PR DESCRIPTION
## 用户影响

审阅步骤、发现、指标、故事和报告共用结构来源，分别派生内存与 wire Schema。内存中的可选覆盖率字段保持可选，wire 指标仍要求完整覆盖率；故事和报告落盘仍使用引用，禁止内联展开对象。

保留覆盖率容差、零调用覆盖率规则、工具结果总数约束、时间戳校验和额外字段接受规则，不替换原始输入对象，不改变持久化版本或测量口径，无需迁移。

## 范围与验证

声明式 Schema 边界支持静态对象扩展与数字字面量，继续禁止动态字段和变换副作用；迁移既有 scope kind 的精确白名单。

完整本地 `yarn ci` 通过，343 个测试文件、3746 项测试成功。关联 #767，接续 #805。C2 剩余对象与最终跨批审计尚未完成，不关闭总任务。