### PR TITLE
refactor(observability): 统一报告外层公共结构

### DIFF
--- a/src/observability/contracts/experience-evidence-schema.ts
+++ b/src/observability/contracts/experience-evidence-schema.ts
@@ -506,3 +506,76 @@ export const ExperienceTurnSummarySchema = z.object({
   toolCallCount: NonNegativeIntegerSchema,
   toolFailureCount: NonNegativeIntegerSchema,
 });
+
+export const ExperienceGoalSliceSchema = z.object({
+  id: z.string(),
+  skillName: z.string(),
+  sessionId: z.string(),
+  traceId: z.string().optional(),
+  sourceTrace: z.string(),
+  cwd: z.string().optional(),
+  startTimestamp: z.string(),
+  endTimestamp: z.string(),
+  timestampObserved: z.boolean().optional(),
+  sliceReasonCode: ExperienceGoalSliceReasonCodeSchema,
+  sliceConfidence: z.enum(['low', 'medium', 'high']),
+  inferredUserGoal: z.string().optional(),
+  userMessageRefs: z.array(ExperienceEvidenceRefSchema),
+});
+
+export const ExperienceReviewIndicatorsSchema = z.object({
+  userMessageCount: NonNegativeIntegerSchema,
+  userFollowUpCount: NonNegativeIntegerSchema,
+  userCorrectionCount: NonNegativeIntegerSchema,
+  userInterruptionCount: NonNegativeIntegerSchema,
+  sessionInterruptedCount: NonNegativeIntegerSchema,
+  negativeFeedbackCount: NonNegativeIntegerSchema,
+  positiveFeedbackCount: NonNegativeIntegerSchema,
+  userGoalShiftCount: NonNegativeIntegerSchema,
+  hardRuleTextHitCount: NonNegativeIntegerSchema,
+  assistantDeliverySignalCount: NonNegativeIntegerSchema,
+  deliverableArtifactSignalCount: NonNegativeIntegerSchema,
+  routerDownstreamCompleted: NonNegativeIntegerSchema,
+  routerDownstreamFailed: NonNegativeIntegerSchema,
+  selfCorrectionCount: NonNegativeIntegerSchema,
+  repeatedExecutionCount: NonNegativeIntegerSchema,
+  toolCallCount: NonNegativeIntegerSchema,
+  toolFailureCount: NonNegativeIntegerSchema,
+  toolCancelledCount: NonNegativeIntegerSchema.optional(),
+  toolUnknownCount: NonNegativeIntegerSchema.optional(),
+  highObservationCount: NonNegativeIntegerSchema,
+  mediumObservationCount: NonNegativeIntegerSchema,
+  hedgingCount: NonNegativeIntegerSchema,
+  explicitMarkerCount: NonNegativeIntegerSchema,
+});
+
+export const ExperienceReviewIndicatorsWireSchema = ExperienceReviewIndicatorsSchema.required();
+
+export const ExperienceMetaSchema = z.object({
+  sessionCount: NonNegativeIntegerSchema,
+  skillCount: NonNegativeIntegerSchema,
+  invocationCount: NonNegativeIntegerSchema,
+  goalSliceCount: NonNegativeIntegerSchema,
+  noteCodes: z.array(z.enum(['no_llm_judge', 'no_auto_verdict', 'default_goal_slice_is_allowed', 'deterministic_assistive_inference'])),
+});
+
+export const ExperienceAttributionSchema = z.object({
+  source: z.string(),
+  confidence: z.number(),
+  rawSkillRef: z.string().optional(),
+  pluginName: z.string().optional(),
+  commandName: z.string().optional(),
+});
+
+export const ExperienceTimelineScopeSchema = z.object({
+  mode: z.literal('skill_segment_window'),
+  segmentEventCount: NonNegativeIntegerSchema,
+  previewEventCount: NonNegativeIntegerSchema,
+  fullSessionEventCount: NonNegativeIntegerSchema,
+  segmentRecordRanges: z.array(ExperienceTraceRecordRangeSchema),
+  previewRecordRanges: z.array(ExperienceTraceRecordRangeSchema),
+  sessionRecordRanges: z.array(ExperienceTraceRecordRangeSchema),
+  truncated: z.boolean(),
+  omittedBeforeCount: NonNegativeIntegerSchema,
+  omittedAfterCount: NonNegativeIntegerSchema,
+});

--- a/src/observability/contracts/experience.ts
+++ b/src/observability/contracts/experience.ts
@@ -214,48 +214,13 @@ export type ExperienceReviewerReport = z.infer<
   typeof import('./experience-evidence-schema.js').ExperienceReviewerReportSchema
 >;
 
-export interface ExperienceGoalSlice {
-  id: string;
-  skillName: string;
-  sessionId: string;
-  traceId?: string;
-  sourceTrace: string;
-  cwd?: string;
-  startTimestamp: string;
-  endTimestamp: string;
-  timestampObserved?: boolean;
-  sliceReasonCode: ExperienceGoalSliceReasonCode;
-  sliceConfidence: 'low' | 'medium' | 'high';
-  inferredUserGoal?: string;
-  userMessageRefs: ExperienceEvidenceRef[];
-}
+export type ExperienceGoalSlice = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceGoalSliceSchema
+>;
 
-export interface ExperienceReviewIndicators {
-  userMessageCount: number;
-  userFollowUpCount: number;
-  userCorrectionCount: number;
-  userInterruptionCount: number;
-  sessionInterruptedCount: number;
-  negativeFeedbackCount: number;
-  positiveFeedbackCount: number;
-  userGoalShiftCount: number;
-  hardRuleTextHitCount: number;
-  assistantDeliverySignalCount: number;
-  deliverableArtifactSignalCount: number;
-  routerDownstreamCompleted: number;
-  routerDownstreamFailed: number;
-  selfCorrectionCount: number;
-  repeatedExecutionCount: number;
-  toolCallCount: number;
-  toolFailureCount: number;
-  toolCancelledCount?: number;
-  /** Runtime did not expose a trustworthy terminal outcome. */
-  toolUnknownCount?: number;
-  highObservationCount: number;
-  mediumObservationCount: number;
-  hedgingCount: number;
-  explicitMarkerCount: number;
-}
+export type ExperienceReviewIndicators = z.infer<
+  typeof import('./experience-evidence-schema.js').ExperienceReviewIndicatorsSchema
+>;
 
 export type ExperienceInvocationMetrics = z.infer<
   typeof import('./experience-evidence-schema.js').ExperienceInvocationMetricsSchema
@@ -277,13 +242,7 @@ export interface ExperienceInvocation {
   startTimestamp: string;
   endTimestamp: string;
   timestampObserved?: boolean;
-  attribution: {
-    source: string;
-    confidence: number;
-    rawSkillRef?: string;
-    pluginName?: string;
-    commandName?: string;
-  };
+  attribution: z.infer<typeof import('./experience-evidence-schema.js').ExperienceAttributionSchema>;
   metrics: ExperienceInvocationMetrics;
   toolCounts: Record<string, number>;
   indicators: ExperienceReviewIndicators;
@@ -338,18 +297,7 @@ export interface ExperienceSessionSummary {
   timelinePreview: ExperienceTimelineEvent[];
   fullSessionTimeline: ExperienceTimelineEvent[];
   timelineTree?: ExperienceTimelineTree;
-  timelineScope: {
-    mode: 'skill_segment_window';
-    segmentEventCount: number;
-    previewEventCount: number;
-    fullSessionEventCount: number;
-    segmentRecordRanges: ExperienceTraceRecordRange[];
-    previewRecordRanges: ExperienceTraceRecordRange[];
-    sessionRecordRanges: ExperienceTraceRecordRange[];
-    truncated: boolean;
-    omittedBeforeCount: number;
-    omittedAfterCount: number;
-  };
+  timelineScope: z.infer<typeof import('./experience-evidence-schema.js').ExperienceTimelineScopeSchema>;
   attributionSources: string[];
   pluginNames: string[];
   rawSkillRefs: string[];
@@ -396,13 +344,7 @@ export interface ObservationExperienceReport {
   schemaVersion: 3;
   scope: 'evidence-only';
   generatedAt: string;
-  meta: {
-    sessionCount: number;
-    skillCount: number;
-    invocationCount: number;
-    goalSliceCount: number;
-    noteCodes: Array<'no_llm_judge' | 'no_auto_verdict' | 'default_goal_slice_is_allowed' | 'deterministic_assistive_inference'>;
-  };
+  meta: z.infer<typeof import('./experience-evidence-schema.js').ExperienceMetaSchema>;
   goalSlices: ExperienceGoalSlice[];
   traceTimelines: ExperienceTraceTimeline[];
   storyContexts: ExperienceStoryContext[];

--- a/src/observability/experience/report-reference-validator.ts
+++ b/src/observability/experience/report-reference-validator.ts
@@ -1,3 +1,4 @@
+import { ExperienceGoalSliceSchema } from '../contracts/experience-evidence-schema.js';
 import {
   isTraceSourceKind,
 } from '../../executors/core/trace-source-kind.js';
@@ -47,7 +48,6 @@ import {
 import {
   EXPERIENCE_INDICATOR_KEYS,
   isCountRecord,
-  isEnumValue,
   isExperienceAssistiveInference,
   isExperienceEvidenceChain,
   isExperienceEvidenceRefArray,
@@ -55,7 +55,6 @@ import {
   isExperienceProblemPatternArray,
   isExperienceRuleFindingArray,
   isNonNegativeInteger,
-  isOptionalString,
   isOptionalTimestampCoverage,
   isRate,
   isStringArray,
@@ -63,23 +62,10 @@ import {
 } from './report-value-guards.js';
 
 export function isExperienceGoalSlice(value: unknown): value is ExperienceGoalSlice {
-  return isObjectRecord(value)
-    && typeof value.id === 'string'
-    && typeof value.skillName === 'string'
-    && typeof value.sessionId === 'string'
-    && isOptionalString(value.traceId)
-    && typeof value.sourceTrace === 'string'
-    && isOptionalString(value.cwd)
-    && isTimestampRange(value.startTimestamp, value.endTimestamp)
-    && (value.timestampObserved === undefined || typeof value.timestampObserved === 'boolean')
-    && isEnumValue(value.sliceReasonCode, [
-      'skill_segment_boundary',
-      'explicit_user_goal_shift',
-      'default_session_slice',
-    ])
-    && isEnumValue(value.sliceConfidence, ['low', 'medium', 'high'])
-    && isOptionalString(value.inferredUserGoal)
-    && isExperienceEvidenceRefArray(value.userMessageRefs);
+  const parsed = ExperienceGoalSliceSchema.safeParse(value);
+  return parsed.success
+    && isTimestampRange(parsed.data.startTimestamp, parsed.data.endTimestamp)
+    && isExperienceEvidenceRefArray(parsed.data.userMessageRefs);
 }
 
 export function isExperienceSkillSummary(value: unknown): boolean {

--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -1,4 +1,11 @@
 import {
+  ExperienceMetaSchema,
+  ExperienceAttributionSchema,
+  ExperienceReviewIndicatorsSchema,
+  ExperienceReviewIndicatorsWireSchema,
+  ExperienceTimelineScopeSchema,
+} from '../contracts/experience-evidence-schema.js';
+import {
   ExperienceTimelineEventSchema,
   ExperienceTimelineBranchSchema,
   ExperienceTimelineTreeSchema,
@@ -291,19 +298,7 @@ export function isEnumArray(value: unknown, values: readonly string[]): boolean 
 }
 
 export function isExperienceMeta(value: unknown): boolean {
-  if (
-    !isObjectRecord(value)
-    || !isNonNegativeInteger(value.sessionCount)
-    || !isNonNegativeInteger(value.skillCount)
-    || !isNonNegativeInteger(value.invocationCount)
-    || !isNonNegativeInteger(value.goalSliceCount)
-  ) return false;
-  return isEnumArray(value.noteCodes, [
-    'no_llm_judge',
-    'no_auto_verdict',
-    'default_goal_slice_is_allowed',
-    'deterministic_assistive_inference',
-  ]);
+  return ExperienceMetaSchema.safeParse(value).success;
 }
 
 export function isOptionalTraceSourceMetadata(value: unknown): boolean {
@@ -427,12 +422,8 @@ export function isExperienceProblemPatternArray(value: unknown): boolean {
 }
 
 export function isExperienceAttribution(value: unknown): boolean {
-  return isObjectRecord(value)
-    && typeof value.source === 'string'
-    && isRate(value.confidence)
-    && isOptionalString(value.rawSkillRef)
-    && isOptionalString(value.pluginName)
-    && isOptionalString(value.commandName);
+  const parsed = ExperienceAttributionSchema.safeParse(value);
+  return parsed.success && isRate(parsed.data.confidence);
 }
 
 export function isExperienceInvocationMetrics(value: unknown): boolean {
@@ -443,43 +434,16 @@ export function isExperienceInvocationMetrics(value: unknown): boolean {
     <= metrics.numToolCalls;
 }
 
-export const EXPERIENCE_INDICATOR_KEYS = [
-  'userMessageCount',
-  'userFollowUpCount',
-  'userCorrectionCount',
-  'userInterruptionCount',
-  'sessionInterruptedCount',
-  'negativeFeedbackCount',
-  'positiveFeedbackCount',
-  'userGoalShiftCount',
-  'hardRuleTextHitCount',
-  'assistantDeliverySignalCount',
-  'deliverableArtifactSignalCount',
-  'routerDownstreamCompleted',
-  'routerDownstreamFailed',
-  'selfCorrectionCount',
-  'repeatedExecutionCount',
-  'toolCallCount',
-  'toolFailureCount',
-  'highObservationCount',
-  'mediumObservationCount',
-  'hedgingCount',
-  'explicitMarkerCount',
-] as const;
+export const EXPERIENCE_INDICATOR_KEYS = ExperienceReviewIndicatorsSchema.omit({
+  toolCancelledCount: true,
+  toolUnknownCount: true,
+}).keyof().options;
 
 export function isExperienceIndicators(value: unknown): boolean {
-  return isObjectRecord(value)
-    && EXPERIENCE_INDICATOR_KEYS.every((key) => isNonNegativeInteger(value[key]))
-    && (
-      isNonNegativeInteger(value.toolCancelledCount)
-      && isNonNegativeInteger(value.toolUnknownCount)
-    )
-    && (value.toolCancelledCount === undefined || isNonNegativeInteger(value.toolCancelledCount))
-    && (value.toolUnknownCount === undefined || isNonNegativeInteger(value.toolUnknownCount))
-    && (value.toolFailureCount as number)
-      + (typeof value.toolCancelledCount === 'number' ? value.toolCancelledCount : 0)
-      + (typeof value.toolUnknownCount === 'number' ? value.toolUnknownCount : 0)
-      <= (value.toolCallCount as number);
+  const parsed = ExperienceReviewIndicatorsWireSchema.safeParse(value);
+  if (!parsed.success) return false;
+  const data = parsed.data;
+  return data.toolFailureCount + data.toolCancelledCount + data.toolUnknownCount <= data.toolCallCount;
 }
 
 export function isCountRecord(value: unknown): boolean {
@@ -488,22 +452,15 @@ export function isCountRecord(value: unknown): boolean {
 }
 
 export function isExperienceTimelineScope(value: unknown): boolean {
-  if (
-    !isObjectRecord(value)
-    || value.mode !== 'skill_segment_window'
-    || !isNonNegativeInteger(value.segmentEventCount)
-    || !isNonNegativeInteger(value.previewEventCount)
-    || !isNonNegativeInteger(value.fullSessionEventCount)
-    || !isExperienceTraceRecordRangeArray(value.segmentRecordRanges)
-    || !isExperienceTraceRecordRangeArray(value.previewRecordRanges)
-    || !isExperienceTraceRecordRangeArray(value.sessionRecordRanges)
-    || typeof value.truncated !== 'boolean'
-    || !isNonNegativeInteger(value.omittedBeforeCount)
-    || !isNonNegativeInteger(value.omittedAfterCount)
-  ) return false;
-  return value.previewEventCount <= value.segmentEventCount
-    && value.segmentEventCount <= value.fullSessionEventCount
-    && value.omittedBeforeCount + value.omittedAfterCount <= value.fullSessionEventCount;
+  const parsed = ExperienceTimelineScopeSchema.safeParse(value);
+  if (!parsed.success) return false;
+  const data = parsed.data;
+  return isExperienceTraceRecordRangeArray(data.segmentRecordRanges)
+    && isExperienceTraceRecordRangeArray(data.previewRecordRanges)
+    && isExperienceTraceRecordRangeArray(data.sessionRecordRanges)
+    && data.previewEventCount <= data.segmentEventCount
+    && data.segmentEventCount <= data.fullSessionEventCount
+    && data.omittedBeforeCount + data.omittedAfterCount <= data.fullSessionEventCount;
 }
 
 export function isExperienceTraceRecordRangeArray(value: unknown): value is ExperienceTraceRecordRange[] {


### PR DESCRIPTION
## 用户影响

目标切片、审阅指标、报告元信息、归因和时间线范围统一结构来源，指标键列表从 Schema 派生。保留内存指标可选字段与 wire 必填字段的差异，以及计数总数、置信度、时间范围和记录范围约束。

不改变持久化版本、统计口径、额外字段接受规则或引用契约，无需迁移；结构验证不会替换原始输入对象。

## 验证与范围

完整本地 `yarn ci` 通过，343 个测试文件、3746 项测试成功。关联 #767，接续 #807。调用、会话、技能和报告外层的其余收敛以及最终跨批审计尚未完成，不关闭总任务。