### PR TITLE
refactor(observability): 统一问题模式结构与枚举

### DIFF
--- a/src/observability/contracts/experience-evidence-schema.ts
+++ b/src/observability/contracts/experience-evidence-schema.ts
@@ -579,3 +579,37 @@ export const ExperienceTimelineScopeSchema = z.object({
   omittedBeforeCount: NonNegativeIntegerSchema,
   omittedAfterCount: NonNegativeIntegerSchema,
 });
+
+export const ExperienceProblemBucketSchema = z.enum(['output_format', 'content_accuracy', 'missing_context', 'rule_violation', 'workflow_mismatch', 'tool_runtime', 'goal_shift', 'unclear']);
+
+export const ExperienceProblemSignalSchema = z.enum(['user_correction', 'negative_feedback', 'user_interruption', 'hard_rule', 'user_goal_shift', 'tool_failure', 'workflow_mismatch', 'artifact_missing', 'observer_lifecycle_failed', 'orchestration_boundary_violation']);
+
+export const ExperienceProblemEvidenceRefSchema = z.object({
+  id: z.string(),
+  kind: z.string(),
+  traceId: z.string().optional(),
+  sourceTrace: z.string(),
+  sessionId: z.string(),
+  messageIndex: NonNegativeIntegerSchema.optional(),
+  logicalMessageIndex: NonNegativeIntegerSchema.optional(),
+  sourceLineIndex: NonNegativeIntegerSchema.optional(),
+  messageUuid: z.string().optional(),
+  callInstanceId: z.string().optional(),
+  toolUseId: z.string().optional(),
+  timestamp: z.string().optional(),
+  role: z.enum(['user', 'assistant', 'tool', 'other']).optional(),
+  label: z.string().optional(),
+  snippet: z.string().optional(),
+});
+
+export const ExperienceProblemPatternSchema = z.object({
+  id: z.string(),
+  bucket: ExperienceProblemBucketSchema,
+  patternKey: z.string(),
+  count: NonNegativeIntegerSchema,
+  sessionCount: NonNegativeIntegerSchema,
+  recentSessionIds: z.array(z.string()),
+  signalTypes: z.array(ExperienceProblemSignalSchema),
+  evidenceRefs: z.array(ExperienceProblemEvidenceRefSchema),
+  lastSeen: z.string().optional(),
+});

--- a/src/observability/contracts/problem-patterns.ts
+++ b/src/observability/contracts/problem-patterns.ts
@@ -1,54 +1,18 @@
-export type ExperienceProblemBucket =
-  | 'output_format'
-  | 'content_accuracy'
-  | 'missing_context'
-  | 'rule_violation'
-  | 'workflow_mismatch'
-  | 'tool_runtime'
-  | 'goal_shift'
-  | 'unclear';
+import type { z } from 'zod';
+import type {
+  ExperienceProblemBucketSchema,
+  ExperienceProblemSignalSchema,
+  ExperienceProblemEvidenceRefSchema,
+  ExperienceProblemPatternSchema,
+} from './experience-evidence-schema.js';
 
-export type ExperienceProblemSignal =
-  | 'user_correction'
-  | 'negative_feedback'
-  | 'user_interruption'
-  | 'hard_rule'
-  | 'user_goal_shift'
-  | 'tool_failure'
-  | 'workflow_mismatch'
-  | 'artifact_missing'
-  | 'observer_lifecycle_failed'
-  | 'orchestration_boundary_violation';
+export type ExperienceProblemBucket = z.infer<typeof ExperienceProblemBucketSchema>;
 
-export interface ExperienceProblemEvidenceRef {
-  id: string;
-  kind: string;
-  traceId?: string;
-  sourceTrace: string;
-  sessionId: string;
-  messageIndex?: number;
-  logicalMessageIndex?: number;
-  sourceLineIndex?: number;
-  messageUuid?: string;
-  callInstanceId?: string;
-  toolUseId?: string;
-  timestamp?: string;
-  role?: 'user' | 'assistant' | 'tool' | 'other';
-  label?: string;
-  snippet?: string;
-}
+export type ExperienceProblemSignal = z.infer<typeof ExperienceProblemSignalSchema>;
 
-export interface ExperienceProblemPattern {
-  id: string;
-  bucket: ExperienceProblemBucket;
-  patternKey: string;
-  count: number;
-  sessionCount: number;
-  recentSessionIds: string[];
-  signalTypes: ExperienceProblemSignal[];
-  evidenceRefs: ExperienceProblemEvidenceRef[];
-  lastSeen?: string;
-}
+export type ExperienceProblemEvidenceRef = z.infer<typeof ExperienceProblemEvidenceRefSchema>;
+
+export type ExperienceProblemPattern = z.infer<typeof ExperienceProblemPatternSchema>;
 
 export interface ProblemTimelineEvent {
   id: string;

--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -1,4 +1,8 @@
 import {
+  ExperienceProblemEvidenceRefSchema,
+  ExperienceProblemPatternSchema,
+} from '../contracts/experience-evidence-schema.js';
+import {
   ExperienceMetaSchema,
   ExperienceAttributionSchema,
   ExperienceReviewIndicatorsSchema,
@@ -358,63 +362,15 @@ export function isExperienceAssistiveInference(value: unknown): boolean {
 }
 
 export function isExperienceProblemEvidenceRef(value: unknown): boolean {
-  if (
-    !isObjectRecord(value)
-    || typeof value.id !== 'string'
-    || typeof value.kind !== 'string'
-    || typeof value.sourceTrace !== 'string'
-    || typeof value.sessionId !== 'string'
-    || !isOptionalNonNegativeInteger(value.messageIndex)
-    || !isOptionalNonNegativeInteger(value.logicalMessageIndex)
-    || !isOptionalNonNegativeInteger(value.sourceLineIndex)
-  ) return false;
-  if (
-    value.role !== undefined
-    && !isEnumValue(value.role, ['user', 'assistant', 'tool', 'other'])
-  ) return false;
-  return [
-    value.messageUuid,
-    value.traceId,
-    value.callInstanceId,
-    value.toolUseId,
-    value.label,
-    value.snippet,
-  ].every(isOptionalString)
-    && isOptionalTimestamp(value.timestamp);
+  const parsed = ExperienceProblemEvidenceRefSchema.safeParse(value);
+  return parsed.success && isOptionalTimestamp(parsed.data.timestamp);
 }
 
 export function isExperienceProblemPattern(value: unknown): boolean {
-  return isObjectRecord(value)
-    && typeof value.id === 'string'
-    && isEnumValue(value.bucket, [
-      'output_format',
-      'content_accuracy',
-      'missing_context',
-      'rule_violation',
-      'workflow_mismatch',
-      'tool_runtime',
-      'goal_shift',
-      'unclear',
-    ])
-    && typeof value.patternKey === 'string'
-    && isNonNegativeInteger(value.count)
-    && isNonNegativeInteger(value.sessionCount)
-    && isStringArray(value.recentSessionIds)
-    && isEnumArray(value.signalTypes, [
-      'user_correction',
-      'negative_feedback',
-      'user_interruption',
-      'hard_rule',
-      'user_goal_shift',
-      'tool_failure',
-      'workflow_mismatch',
-      'artifact_missing',
-      'observer_lifecycle_failed',
-      'orchestration_boundary_violation',
-    ])
-    && Array.isArray(value.evidenceRefs)
-    && value.evidenceRefs.every(isExperienceProblemEvidenceRef)
-    && isOptionalTimestamp(value.lastSeen);
+  const parsed = ExperienceProblemPatternSchema.safeParse(value);
+  return parsed.success
+    && parsed.data.evidenceRefs.every(isExperienceProblemEvidenceRef)
+    && isOptionalTimestamp(parsed.data.lastSeen);
 }
 
 export function isExperienceProblemPatternArray(value: unknown): boolean {

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -350,7 +350,7 @@ describe('领域契约所有权', () => {
               process.cwd(),
               resolve(dirname(resolve(file)), specifier.replace(/\.js$/, '.ts')),
             );
-            const declarativeEnumTypeImport = file === 'src/observability/contracts/experience.ts'
+            const declarativeEnumTypeImport = (file === 'src/observability/contracts/experience.ts' || file === 'src/observability/contracts/problem-patterns.ts')
               && EXPERIENCE_ENUM_TYPE_IMPORTS.has(specifier);
             if (!PURE_DOMAIN_TYPE_FILE_SET.has(target) && !declarativeEnumTypeImport) {
               violations.push(`${file}：依赖了非契约模块 ${specifier}`);

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -48,7 +48,7 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   "src/observability/contracts/experience-evidence-schema.ts::ExperienceEpisodeArtifactSchema::ExperienceEpisodeArtifactKindSchema",
   'src/observability/contracts/experience-evidence-schema.ts::ExperienceSessionStoryGraphNodeSchema::ExperienceSessionStoryNodeKindSchema',
   "src/observability/contracts/experience-evidence-schema.ts::ExperienceReviewerReportBaseSchema::ExperienceReviewerReportScopeSchema",
-  'src/observability/contracts/problem-patterns.ts::ExperienceProblemEvidenceRef::string',
+  "src/observability/contracts/experience-evidence-schema.ts::ExperienceProblemEvidenceRefSchema::z.string()",
   'src/observability/contracts/problem-patterns.ts::ProblemTimelineEvent::string',
   // —— 持久化 soft-standards JSON（含 enhancedReview 内嵌结构）——
   // ResolvedSkillStandard 非持久（view-model），但与持久 standard 同源、且被 renderer 多处 .kind 消费，


### PR DESCRIPTION
## 用户影响

问题桶、问题信号、问题证据和问题模式共用 Schema 派生类型及结构校验。问题证据的 kind 继续接受任意字符串，不收紧为时间线事件枚举；嵌套时间戳和最后出现时间继续独立校验。

保留可选字段、额外字段接受规则和原始输入对象，不改变持久化版本或统计口径，无需迁移。结构仍归属于观测契约，没有引入执行器对 Experience 的反向依赖。

## 验证与范围

完整本地 `yarn ci` 通过，343 个测试文件、3746 项测试成功。关联 #767，接续 #808。其余外层结构、trace 来源契约衔接和最终跨批审计仍待完成，不关闭总任务。