### PR TITLE
refactor(observability): 统一 trace 来源叶子契约

### DIFF
--- a/src/executors/contracts/trace-source-schema.ts
+++ b/src/executors/contracts/trace-source-schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const TraceSourceKindSchema = z.enum([
+  'claude',
+  'codex',
+  'dsh',
+  'openclaw',
+  'markdown_log',
+  'unknown',
+]);

--- a/src/executors/contracts/trace-source.ts
+++ b/src/executors/contracts/trace-source.ts
@@ -1,8 +1,5 @@
+import type { z } from 'zod';
+import type { TraceSourceKindSchema } from './trace-source-schema.js';
+
 /** Stable source identity shared by execution evidence and Trace IR. */
-export type TraceSourceKind =
-  | 'claude'
-  | 'codex'
-  | 'dsh'
-  | 'openclaw'
-  | 'markdown_log'
-  | 'unknown';
+export type TraceSourceKind = z.infer<typeof TraceSourceKindSchema>;

--- a/src/executors/core/trace-source-kind.ts
+++ b/src/executors/core/trace-source-kind.ts
@@ -1,18 +1,11 @@
+import { TraceSourceKindSchema } from '../contracts/trace-source-schema.js';
 import type { TraceSourceKind } from '../contracts/trace-source.js';
 
 export type { TraceSourceKind } from '../contracts/trace-source.js';
 
-const TRACE_SOURCE_KINDS = new Set<TraceSourceKind>([
-  'claude',
-  'codex',
-  'dsh',
-  'openclaw',
-  'markdown_log',
-  'unknown',
-]);
+
 
 /** Runtime validator for the persisted Trace IR source identity protocol. */
 export function isTraceSourceKind(value: unknown): value is TraceSourceKind {
-  return typeof value === 'string'
-    && TRACE_SOURCE_KINDS.has(value as TraceSourceKind);
+  return TraceSourceKindSchema.safeParse(value).success;
 }

--- a/src/observability/contracts/trace-metadata-schema.ts
+++ b/src/observability/contracts/trace-metadata-schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const TraceSourceMetadataSchema = z.object({
+  channel: z.string().optional(),
+  sender: z.string().optional(),
+  senderId: z.string().optional(),
+  provider: z.string().optional(),
+  model: z.string().optional(),
+  modelApi: z.string().optional(),
+  businessActions: z.array(z.string()).optional(),
+});

--- a/src/observability/contracts/trace.ts
+++ b/src/observability/contracts/trace.ts
@@ -1,3 +1,5 @@
+import type { z } from 'zod';
+import type { TraceSourceMetadataSchema } from './trace-metadata-schema.js';
 export type { TraceSourceKind } from '../../executors/contracts/trace-source.js';
 
 export interface TraceIngestionSummary {
@@ -10,12 +12,4 @@ export interface TraceIngestionSummary {
   filteredSessionCount: number;
 }
 
-export interface TraceSourceMetadata {
-  channel?: string;
-  sender?: string;
-  senderId?: string;
-  provider?: string;
-  model?: string;
-  modelApi?: string;
-  businessActions?: string[];
-}
+export type TraceSourceMetadata = z.infer<typeof TraceSourceMetadataSchema>;

--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -1,3 +1,4 @@
+import { TraceSourceMetadataSchema } from '../contracts/trace-metadata-schema.js';
 import {
   ExperienceProblemEvidenceRefSchema,
   ExperienceProblemPatternSchema,
@@ -306,15 +307,7 @@ export function isExperienceMeta(value: unknown): boolean {
 }
 
 export function isOptionalTraceSourceMetadata(value: unknown): boolean {
-  if (value === undefined) return true;
-  return isObjectRecord(value)
-    && isOptionalString(value.channel)
-    && isOptionalString(value.sender)
-    && isOptionalString(value.senderId)
-    && isOptionalString(value.provider)
-    && isOptionalString(value.model)
-    && isOptionalString(value.modelApi)
-    && (value.businessActions === undefined || isStringArray(value.businessActions));
+  return value === undefined || TraceSourceMetadataSchema.safeParse(value).success;
 }
 
 export function isExperienceReviewPriority(value: unknown): boolean {

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync as readTraceSchemaSource } from 'node:fs';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import ts from 'typescript';
@@ -81,13 +82,21 @@ const EXPERIENCE_EVIDENCE_ENUM_IMPORTS = [
   'TaskWindowBasisSchema',
 ];
 
-function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile): boolean {
-  const imports = new Map([
+function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile, profile: {
+  imports: ReadonlyArray<readonly [string, string]>;
+  schemas: readonly string[];
+  requiredSchema: string;
+} = {
+  imports: [
     ['zod', 'z'],
     ['./experience-enums.js', [...EXPERIENCE_EVIDENCE_ENUM_IMPORTS].sort().join(',')],
-  ]);
+  ],
+  schemas: EXPERIENCE_EVIDENCE_ENUM_IMPORTS,
+  requiredSchema: 'ExperienceEvidenceRefSchema',
+}): boolean {
+  const imports = new Map(profile.imports);
   const seenImports = new Set<string>();
-  const schemas = new Set(EXPERIENCE_EVIDENCE_ENUM_IMPORTS);
+  const schemas = new Set(profile.schemas);
   function expression(node: ts.Expression): boolean {
     if (ts.isCallExpression(node)
       && ts.isPropertyAccessExpression(node.expression)
@@ -154,7 +163,7 @@ function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile): boolean {
       schemas.add(declaration.name.text);
     }
   }
-  return seenImports.size === imports.size && schemas.has('ExperienceEvidenceRefSchema');
+  return seenImports.size === imports.size && schemas.has(profile.requiredSchema);
 }
 
 function isDeclarativeEnumSchemaModule(source: ts.SourceFile): boolean {
@@ -350,8 +359,10 @@ describe('领域契约所有权', () => {
               process.cwd(),
               resolve(dirname(resolve(file)), specifier.replace(/\.js$/, '.ts')),
             );
-            const declarativeEnumTypeImport = (file === 'src/observability/contracts/experience.ts' || file === 'src/observability/contracts/problem-patterns.ts')
-              && EXPERIENCE_ENUM_TYPE_IMPORTS.has(specifier);
+            const declarativeEnumTypeImport = ((file === 'src/observability/contracts/experience.ts' || file === 'src/observability/contracts/problem-patterns.ts')
+              && EXPERIENCE_ENUM_TYPE_IMPORTS.has(specifier)
+            || (file === 'src/executors/contracts/trace-source.ts' && ['zod', './trace-source-schema.js'].includes(specifier))
+            || (file === 'src/observability/contracts/trace.ts' && ['zod', './trace-metadata-schema.js'].includes(specifier)));
             if (!PURE_DOMAIN_TYPE_FILE_SET.has(target) && !declarativeEnumTypeImport) {
               violations.push(`${file}：依赖了非契约模块 ${specifier}`);
             }
@@ -370,5 +381,20 @@ describe('领域契约所有权', () => {
       }
     }
     expect(violations).toEqual([]);
+  });
+});
+
+
+describe('trace leaf schema ownership', () => {
+  it.each([
+    ['src/executors/contracts/trace-source-schema.ts', 'TraceSourceKindSchema'],
+    ['src/observability/contracts/trace-metadata-schema.ts', 'TraceSourceMetadataSchema'],
+  ])('%s remains a declarative leaf schema', (file, requiredSchema) => {
+    const source = ts.createSourceFile(file, readTraceSchemaSource(file, 'utf8'), ts.ScriptTarget.Latest, true);
+    expect(isDeclarativeEvidenceSchemaModule(source, {
+      imports: [['zod', 'z']],
+      schemas: [],
+      requiredSchema,
+    })).toBe(true);
   });
 });


### PR DESCRIPTION
## 用户影响

trace 来源枚举和来源元信息的类型及校验共用独立 Schema。来源枚举继续归执行器契约所有，元信息归 trace 契约所有，不引入执行器对 Experience 的反向依赖。

保留来源取值、可选字段、额外字段接受规则和原始输入对象，不改变持久化版本或测量口径，无需迁移。

## 范围与验证

类型边界只开放两个文件各自的精确 Schema 依赖，新增两项声明式独立 Schema 检查。完整本地 `yarn ci` 通过，343 个测试文件、3748 项测试成功。

关联 #767，接续 #809。Experience 外层组合与最终跨批审计尚未完成，不关闭总任务。