### PR TITLE
refactor(observability): 统一 Experience 报告根契约

### DIFF
--- a/src/observability/contracts/experience-evidence-schema.ts
+++ b/src/observability/contracts/experience-evidence-schema.ts
@@ -758,3 +758,46 @@ export const ExperienceSkillSummaryWireSchema = ExperienceSkillSummarySchema.ext
   timestampCoverage: z.number(),
   indicators: ExperienceReviewIndicatorsWireSchema,
 });
+
+export const ObservationExperienceReportSchema = z.object({
+  kind: z.literal('observe-experience'),
+  schemaVersion: z.literal(3),
+  scope: z.literal('evidence-only'),
+  generatedAt: z.string(),
+  meta: ExperienceMetaSchema,
+  goalSlices: z.array(ExperienceGoalSliceSchema),
+  traceTimelines: z.array(ExperienceTraceTimelineSchema),
+  storyContexts: z.array(ExperienceStoryContextSchema),
+  invocations: z.array(ExperienceInvocationSchema),
+  sessions: z.array(ExperienceSessionSummarySchema),
+  skills: z.array(ExperienceSkillSummarySchema),
+});
+
+// Compact output preserves hydrated optionality; wire readers validate stricter requirements separately.
+export const PersistedExperienceInvocationSchema = ExperienceInvocationSchema.omit({ timeline: true }).extend({
+  timelineRef: z.string(),
+  timelineEventIds: z.array(z.string()),
+});
+
+export const PersistedExperienceReviewerReportSchema = ExperienceReviewerReportSchema.omit({
+  sessionStory: true,
+}).extend({ sessionStoryRef: z.literal('session') });
+
+export const PersistedExperienceSessionSchema = ExperienceSessionSummarySchema.omit({
+  attributedEventIds: true,
+  timelinePreview: true,
+  fullSessionTimeline: true,
+  timelineTree: true,
+  sessionStory: true,
+  reviewerReport: true,
+}).extend({
+  timelineRef: z.string(),
+  timelinePreviewEventIds: z.array(z.string()),
+  sessionStory: ExperienceSessionStoryWireSchema.optional(),
+  reviewerReport: PersistedExperienceReviewerReportSchema.optional(),
+});
+
+export const PersistedObservationExperienceReportSchema = ObservationExperienceReportSchema.extend({
+  invocations: z.array(PersistedExperienceInvocationSchema),
+  sessions: z.array(PersistedExperienceSessionSchema),
+});

--- a/src/observability/contracts/experience.ts
+++ b/src/observability/contracts/experience.ts
@@ -238,16 +238,6 @@ export type ExperienceSkillSummary = z.infer<
   typeof import('./experience-evidence-schema.js').ExperienceSkillSummarySchema
 >;
 
-export interface ObservationExperienceReport {
-  kind: 'observe-experience';
-  schemaVersion: 3;
-  scope: 'evidence-only';
-  generatedAt: string;
-  meta: z.infer<typeof import('./experience-evidence-schema.js').ExperienceMetaSchema>;
-  goalSlices: ExperienceGoalSlice[];
-  traceTimelines: ExperienceTraceTimeline[];
-  storyContexts: ExperienceStoryContext[];
-  invocations: ExperienceInvocation[];
-  sessions: ExperienceSessionSummary[];
-  skills: ExperienceSkillSummary[];
-}
+export type ObservationExperienceReport = z.infer<
+  typeof import('./experience-evidence-schema.js').ObservationExperienceReportSchema
+>;

--- a/src/observability/experience/report-codec.ts
+++ b/src/observability/experience/report-codec.ts
@@ -1,3 +1,12 @@
+import type { z } from 'zod';
+import { ObservationExperienceReportSchema } from '../contracts/experience-evidence-schema.js';
+import type {
+  PersistedExperienceInvocationSchema,
+  ExperienceSessionStoryWireSchema,
+  PersistedExperienceReviewerReportSchema,
+  PersistedExperienceSessionSchema,
+  PersistedObservationExperienceReportSchema,
+} from '../contracts/experience-evidence-schema.js';
 import type {
   ExperienceInvocation,
   ExperienceReviewerReport,
@@ -20,7 +29,6 @@ import {
   flattenTimelineTree,
 } from './report-structure.js';
 import {
-  isExperienceMeta,
   isTimestamp,
   normalizeExperienceInvocationShells,
   normalizeExperienceSessionShells,
@@ -29,80 +37,32 @@ import {
 } from './report-value-guards.js';
 import { validateExperienceReferences } from './report-reference-validator.js';
 
-export type PersistedExperienceInvocation = Omit<
-  ExperienceInvocation,
-  'timeline' | 'timelineRef' | 'timelineEventIds'
-> & {
-  timelineRef: string;
-  timelineEventIds: string[];
-};
+export type PersistedExperienceInvocation = z.infer<typeof PersistedExperienceInvocationSchema>;
 
-export type PersistedExperienceSessionStory = Omit<
-  ExperienceSessionStory,
-  'contextRef' | 'goalSlices' | 'subagentDispatches' | 'episodes'
-> & {
-  contextRef: string;
-};
+export type PersistedExperienceSessionStory = z.infer<typeof ExperienceSessionStoryWireSchema>;
 
-export type PersistedExperienceReviewerReport = Omit<
-  ExperienceReviewerReport,
-  'sessionStory' | 'sessionStoryRef'
-> & {
-  sessionStoryRef: 'session';
-};
+export type PersistedExperienceReviewerReport = z.infer<typeof PersistedExperienceReviewerReportSchema>;
 
-export type PersistedExperienceSession = Omit<
-  ExperienceSessionSummary,
-  | 'timelineRef'
-  | 'timelinePreviewEventIds'
-  | 'attributedEventIds'
-  | 'timelinePreview'
-  | 'fullSessionTimeline'
-  | 'timelineTree'
-  | 'sessionStory'
-  | 'reviewerReport'
-> & {
-  timelineRef: string;
-  timelinePreviewEventIds: string[];
-  sessionStory?: PersistedExperienceSessionStory;
-  reviewerReport?: PersistedExperienceReviewerReport;
-};
+export type PersistedExperienceSession = z.infer<typeof PersistedExperienceSessionSchema>;
 
-export type PersistedObservationExperienceReport = Omit<
-  ObservationExperienceReport,
-  'invocations' | 'sessions'
-> & {
-  invocations: PersistedExperienceInvocation[];
-  sessions: PersistedExperienceSession[];
-};
+export type PersistedObservationExperienceReport = z.infer<typeof PersistedObservationExperienceReportSchema>;
 
 export function normalizeObservationExperienceReport(value: unknown): ObservationExperienceReport | null {
   if (!value || typeof value !== 'object') return null;
   const report = value as Record<string, unknown>;
-  const kind = report.kind === 'observe-experience' ? report.kind : null;
-  if (!kind) return null;
-  if (report.schemaVersion !== OBSERVATION_EXPERIENCE_SCHEMA_VERSION) return null;
-  if (report.scope !== 'evidence-only') return null;
-  if (
-    !isTimestamp(report.generatedAt)
-    || !report.meta
-    || typeof report.meta !== 'object'
-    || !isExperienceMeta(report.meta)
-  ) return null;
-  if (!Array.isArray(report.goalSlices) || !Array.isArray(report.invocations) || !Array.isArray(report.sessions) || !Array.isArray(report.skills)) {
-    return null;
-  }
-  const invocations = normalizeExperienceInvocationShells(report.invocations);
-  const sessions = normalizeExperienceSessionShells(report.sessions);
+  if (!ReportHeaderSchema.safeParse(report).success
+    || !isTimestamp(report.generatedAt)
+    || !reportArrayKeys.every((key) => Array.isArray(report[key]))) return null;
+  const invocations = normalizeExperienceInvocationShells(report.invocations as unknown[]);
+  const sessions = normalizeExperienceSessionShells(report.sessions as unknown[]);
   if (!invocations || !sessions) return null;
-  if (!Array.isArray(report.traceTimelines) || !Array.isArray(report.storyContexts)) return null;
-  const traceTimelines = normalizeTraceTimelines(report.traceTimelines);
-  const storyContexts = normalizeStoryContexts(report.storyContexts);
+  const traceTimelines = normalizeTraceTimelines(report.traceTimelines as unknown[]);
+  const storyContexts = normalizeStoryContexts(report.storyContexts as unknown[]);
   if (!traceTimelines || !storyContexts) return null;
   const normalized: ObservationExperienceReport = {
-    kind: 'observe-experience',
+    kind: ObservationExperienceReportSchema.shape.kind.value,
     schemaVersion: OBSERVATION_EXPERIENCE_SCHEMA_VERSION,
-    scope: 'evidence-only',
+    scope: ObservationExperienceReportSchema.shape.scope.value,
     generatedAt: report.generatedAt,
     meta: report.meta as ObservationExperienceReport['meta'],
     goalSlices: report.goalSlices as ObservationExperienceReport['goalSlices'],
@@ -308,3 +268,13 @@ export function omitProperties<T extends object, K extends keyof T>(
   for (const key of keys) delete copy[key];
   return copy;
 }
+
+const ReportHeaderSchema = ObservationExperienceReportSchema.pick({
+  kind: true,
+  schemaVersion: true,
+  scope: true,
+  generatedAt: true,
+  meta: true,
+});
+const reportArrayKeys = ObservationExperienceReportSchema.keyof().options
+  .filter((key) => !Object.hasOwn(ReportHeaderSchema.shape, key));

--- a/src/observability/experience/report-structure.ts
+++ b/src/observability/experience/report-structure.ts
@@ -1,3 +1,4 @@
+import { ObservationExperienceReportSchema } from '../contracts/experience-evidence-schema.js';
 import type {
   ExperienceInvocation,
   ExperienceSessionSummary,
@@ -13,7 +14,7 @@ import {
   uniqueTimelineEvents,
 } from './primitives.js';
 
-export const OBSERVATION_EXPERIENCE_SCHEMA_VERSION = 3;
+export const OBSERVATION_EXPERIENCE_SCHEMA_VERSION = ObservationExperienceReportSchema.shape.schemaVersion.value;
 
 export const TIMELINE_PREVIEW_EVENT_LIMIT = 240;
 

--- a/test/scripts/kind-semantics-guard.test.ts
+++ b/test/scripts/kind-semantics-guard.test.ts
@@ -38,7 +38,7 @@ const FROZEN_KIND_EXCEPTIONS = new Set<string>([
   "src/knowledge-artifacts/doctor/contracts.ts::DoctorReport::'doctor'",
   "src/observability/contracts/review.ts::ObservationReviewState::'observe-review-state'",
   "src/observability/contracts/inbox.ts::ObservationInboxReport::'observe-inbox'",
-  "src/observability/contracts/experience.ts::ObservationExperienceReport::'observe-experience'",
+  "src/observability/contracts/experience-evidence-schema.ts::ObservationExperienceReportSchema::z.literal('observe-experience')",
   "src/observability/soft-standards/types.ts::SkillDerivedStandards::'observe-skill-derived-standards'",
   "src/observability/skill-health/analyzer.ts::SkillHealthReport::'observe-health'",
   // —— 持久化 observe / experience JSON ——


### PR DESCRIPTION
## 用户影响

报告根类型、入口头部校验及 compact 写出类型统一 Schema 来源，版本常量由根 Schema 派生，仍为版本 3。读入 wire 和写出类型分别派生，保留原有可选字段差异，不收紧 compact 调用契约。

保留原始元信息和字段选择、compact／hydrate 流程、时间线兼容路径、语义与引用验证。不改变持久化身份、统计口径或额外字段处理方式，无需迁移。

## 验证与范围

迁移报告 kind 的精确白名单。完整本地 `yarn ci` 通过，343 个测试文件、3748 项测试成功。

关联 #767，接续 #811。C2 残留核对与最终跨批审计尚未完成，不关闭总任务。