### PR TITLE
refactor(observability): 删除收敛后闲置的结构包装

### DIFF
--- a/src/observability/experience/report-value-guards.ts
+++ b/src/observability/experience/report-value-guards.ts
@@ -1,11 +1,9 @@
 import { ExperienceInvocationWireSchema, ExperienceSessionSummaryWireSchema } from '../contracts/experience-evidence-schema.js';
-import { TraceSourceMetadataSchema } from '../contracts/trace-metadata-schema.js';
 import {
   ExperienceProblemEvidenceRefSchema,
   ExperienceProblemPatternSchema,
 } from '../contracts/experience-evidence-schema.js';
 import {
-  ExperienceMetaSchema,
   ExperienceAttributionSchema,
   ExperienceReviewIndicatorsSchema,
   ExperienceReviewIndicatorsWireSchema,
@@ -41,8 +39,6 @@ import {
   ExperienceSessionStoryGoalSliceSchema,
   ExperienceSessionStorySubagentDispatchSchema,
   ExperienceSessionStorySkillLinkSchema,
-  ExperienceSessionStoryGraphNodeSchema,
-  ExperienceSessionStoryGraphEdgeSchema,
   ExperienceSessionStoryNodeSchema,
   ExperienceSessionStoryAnswerSchema,
 } from '../contracts/experience-evidence-schema.js';
@@ -55,10 +51,6 @@ import {
   ExperienceChecklistItemSchema,
 } from '../contracts/experience-evidence-schema.js';
 import { ExperienceEvidenceRefSchema } from '../contracts/experience-evidence-schema.js';
-import {
-  ExperienceEvidenceKindSchema,
-  ExperienceReviewPrioritySchema,
-} from '../contracts/experience-enums.js';
 
 import type {
   ExperienceEvidenceRef,
@@ -203,14 +195,6 @@ export function isOptionalTimestampCoverage(
   return coverage === (total > 0 ? count / total : 0);
 }
 
-export function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === 'string');
-}
-
-export function isOptionalString(value: unknown): boolean {
-  return value === undefined || typeof value === 'string';
-}
-
 export function isTimestamp(value: unknown): value is string {
   return typeof value === 'string' && normalizeTraceTimestamp(value) !== undefined;
 }
@@ -235,34 +219,6 @@ export function isConsistentSourceSessionTime(value: Record<string, unknown>): b
     && typeof end === 'string'
     && isTimestampRange(start, end)
     && duration === durationMsBetween(start, end);
-}
-
-export function isOptionalNonNegativeInteger(value: unknown): boolean {
-  return value === undefined || isNonNegativeInteger(value);
-}
-
-export function isEnumValue(value: unknown, values: readonly string[]): boolean {
-  return typeof value === 'string' && values.includes(value);
-}
-
-export function isEnumArray(value: unknown, values: readonly string[]): boolean {
-  return Array.isArray(value) && value.every((item) => isEnumValue(item, values));
-}
-
-export function isExperienceMeta(value: unknown): boolean {
-  return ExperienceMetaSchema.safeParse(value).success;
-}
-
-export function isOptionalTraceSourceMetadata(value: unknown): boolean {
-  return value === undefined || TraceSourceMetadataSchema.safeParse(value).success;
-}
-
-export function isExperienceReviewPriority(value: unknown): boolean {
-  return isEnumValue(value, ExperienceReviewPrioritySchema.options);
-}
-
-export function isExperienceEvidenceKind(value: unknown): boolean {
-  return isEnumValue(value, ExperienceEvidenceKindSchema.options);
 }
 
 export function isExperienceEvidenceRef(value: unknown): value is ExperienceEvidenceRef {
@@ -340,11 +296,6 @@ export function isExperienceIndicators(value: unknown): boolean {
   if (!parsed.success) return false;
   const data = parsed.data;
   return data.toolFailureCount + data.toolCancelledCount + data.toolUnknownCount <= data.toolCallCount;
-}
-
-export function isCountRecord(value: unknown): boolean {
-  return isObjectRecord(value)
-    && Object.values(value).every(isNonNegativeInteger);
 }
 
 export function isExperienceTimelineScope(value: unknown): boolean {
@@ -439,14 +390,6 @@ export function isExperienceSessionStorySkillLink(value: unknown): boolean {
   const parsed = ExperienceSessionStorySkillLinkSchema.safeParse(value);
   return parsed.success
     && isExperienceEvidenceRefArray(parsed.data.evidenceRefs);
-}
-
-export function isExperienceSessionStoryGraphNode(value: unknown): boolean {
-  return ExperienceSessionStoryGraphNodeSchema.safeParse(value).success;
-}
-
-export function isExperienceSessionStoryGraphEdge(value: unknown): boolean {
-  return ExperienceSessionStoryGraphEdgeSchema.safeParse(value).success;
 }
 
 export function isExperienceSessionStoryNode(value: unknown): boolean {

--- a/test/observability/experience-enums.test.ts
+++ b/test/observability/experience-enums.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import * as enums from '../../src/observability/contracts/experience-enums.js';
-import {
-  isExperienceEvidenceKind,
-  isExperienceReviewPriority,
-} from '../../src/observability/experience/report-value-guards.js';
 
 const cases = [
   ['ExperienceReviewPriority', enums.ExperienceReviewPrioritySchema, [
@@ -241,13 +237,5 @@ describe('Experience enum wire identities', () => {
     expect(schema.options).toEqual(values);
     for (const value of values) expect(schema.safeParse(value).success).toBe(true);
     for (const value of invalidValues) expect(schema.safeParse(value).success).toBe(false);
-  });
-
-  it.each([
-    ['evidence kind', enums.ExperienceEvidenceKindSchema, isExperienceEvidenceKind],
-    ['review priority', enums.ExperienceReviewPrioritySchema, isExperienceReviewPriority],
-  ] as const)('%s guard uses the schema value set', (_name, schema, guard) => {
-    for (const value of schema.options) expect(guard(value)).toBe(true);
-    for (const value of invalidValues) expect(guard(value)).toBe(false);
   });
 });


### PR DESCRIPTION
## 用户影响

删除 Schema 收敛后失去产品调用的十二个内部 guard，避免重新形成仅由测试维持的旁路能力。同步移除两项独占包装测试，保留三十二组直接验证 Schema 合法值与非法值的行为测试。

这些包装不属于 package 公开导出；保留实际报告入口、Schema 校验、语义检查和引用验证。不改变持久化版本、可接受报告或测量口径，无需迁移。

## 验证与范围

全仓符号引用与 package 导出核对后实施。完整本地 `yarn ci` 通过，343 个测试文件、3746 项测试成功；测试数减少仅对应已删除包装。

关联 #767，接续 #812。C2 完整残留核对及跨批最终验收尚未完成，不关闭总任务。