### PR TITLE
refactor(executors): 统一工具调用状态契约

### DIFF
--- a/src/executors/contracts/tool-call-status-schema.ts
+++ b/src/executors/contracts/tool-call-status-schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const ToolCallStatusSchema = z.enum([
+  'success',
+  'failure',
+  'cancelled',
+  'unknown',
+]);

--- a/src/executors/contracts/trace.ts
+++ b/src/executors/contracts/trace.ts
@@ -1,6 +1,8 @@
+import type { z } from 'zod';
+import type { ToolCallStatusSchema } from './tool-call-status-schema.js';
 import type { TraceSourceKind } from './trace-source.js';
 
-export type ToolCallStatus = 'success' | 'failure' | 'cancelled' | 'unknown';
+export type ToolCallStatus = z.infer<typeof ToolCallStatusSchema>;
 export type ToolCallStatusSource = 'runtime' | 'tool-output' | 'inferred' | 'unknown';
 
 export interface ToolCallInfo {

--- a/src/executors/tool-call-status.ts
+++ b/src/executors/tool-call-status.ts
@@ -1,17 +1,11 @@
+import { ToolCallStatusSchema } from './contracts/tool-call-status-schema.js';
 import type { ToolCallInfo, ToolCallStatus } from './contracts/trace.js';
 
 type ToolCallOutcomeInput = Partial<Pick<ToolCallInfo, 'status' | 'success'>>;
 
-const TOOL_CALL_STATUSES = new Set<ToolCallStatus>([
-  'success',
-  'failure',
-  'cancelled',
-  'unknown',
-]);
-
 export function toolCallStatus(call: ToolCallOutcomeInput): ToolCallStatus {
   if (call.status !== undefined) {
-    return TOOL_CALL_STATUSES.has(call.status) ? call.status : 'unknown';
+    return ToolCallStatusSchema.safeParse(call.status).success ? call.status : 'unknown';
   }
   if (call.success === true) return 'success';
   if (call.success === false) return 'failure';

--- a/src/observability/contracts/experience-evidence-schema.ts
+++ b/src/observability/contracts/experience-evidence-schema.ts
@@ -1,3 +1,4 @@
+import { ToolCallStatusSchema } from '../../executors/contracts/tool-call-status-schema.js';
 import { TraceSourceKindSchema } from '../../executors/contracts/trace-source-schema.js';
 import { TraceSourceMetadataSchema } from './trace-metadata-schema.js';
 import { z } from 'zod';
@@ -455,7 +456,7 @@ export const ExperienceTimelineEventSchema = ExperienceEvidenceRefSchema.extend(
   order: NonNegativeIntegerSchema,
   model: z.string().optional(),
   toolName: z.string().optional(),
-  toolStatus: z.enum(['success', 'failure', 'cancelled', 'unknown']).optional(),
+  toolStatus: ToolCallStatusSchema.optional(),
   isError: z.boolean().optional(),
   fullText: z.string().optional(),
   attachments: z.array(ExperienceTimelineAttachmentSchema).optional(),

--- a/test/architecture/domain-contract-ownership.test.ts
+++ b/test/architecture/domain-contract-ownership.test.ts
@@ -93,8 +93,9 @@ function isDeclarativeEvidenceSchemaModule(source: ts.SourceFile, profile: {
     ['./experience-enums.js', [...EXPERIENCE_EVIDENCE_ENUM_IMPORTS].sort().join(',')],
     ['../../executors/contracts/trace-source-schema.js', 'TraceSourceKindSchema'],
     ['./trace-metadata-schema.js', 'TraceSourceMetadataSchema'],
+    ['../../executors/contracts/tool-call-status-schema.js', 'ToolCallStatusSchema'],
   ],
-  schemas: [...EXPERIENCE_EVIDENCE_ENUM_IMPORTS, 'TraceSourceKindSchema', 'TraceSourceMetadataSchema'],
+  schemas: [...EXPERIENCE_EVIDENCE_ENUM_IMPORTS, 'TraceSourceKindSchema', 'TraceSourceMetadataSchema', 'ToolCallStatusSchema'],
   requiredSchema: 'ExperienceEvidenceRefSchema',
 }): boolean {
   const imports = new Map(profile.imports);
@@ -333,7 +334,7 @@ describe('领域契约所有权', () => {
     "z.object({ id: z.string() }).transform(() => sideEffect())",
     "z.object({ id: z.string() }); sideEffect()",
   ])('证据结构声明拒绝动态实现：%s', (initializer) => {
-    const text = "import { TraceSourceKindSchema } from '../../executors/contracts/trace-source-schema.js';\nimport { TraceSourceMetadataSchema } from './trace-metadata-schema.js';\n" + "import { z } from 'zod';\n"
+    const text = "import { ToolCallStatusSchema } from '../../executors/contracts/tool-call-status-schema.js';\n" + "import { TraceSourceKindSchema } from '../../executors/contracts/trace-source-schema.js';\nimport { TraceSourceMetadataSchema } from './trace-metadata-schema.js';\n" + "import { z } from 'zod';\n"
       + `import { ${EXPERIENCE_EVIDENCE_ENUM_IMPORTS.join(', ')} } from './experience-enums.js';\n`
       + `export const ExperienceEvidenceRefSchema = ${initializer};`;
     expect(isDeclarativeEvidenceSchemaModule(ts.createSourceFile(
@@ -376,7 +377,7 @@ describe('领域契约所有权', () => {
             );
             const declarativeEnumTypeImport = ((file === 'src/observability/contracts/experience.ts' || file === 'src/observability/contracts/problem-patterns.ts')
               && EXPERIENCE_ENUM_TYPE_IMPORTS.has(specifier)
-            || (file === 'src/executors/contracts/trace-source.ts' && ['zod', './trace-source-schema.js'].includes(specifier))
+            || ((file === 'src/executors/contracts/trace-source.ts' && ['zod', './trace-source-schema.js'].includes(specifier) || (file === 'src/executors/contracts/trace.ts' && ['zod', './tool-call-status-schema.js'].includes(specifier))))
             || (file === 'src/observability/contracts/trace.ts' && ['zod', './trace-metadata-schema.js'].includes(specifier)));
             if (!PURE_DOMAIN_TYPE_FILE_SET.has(target) && !declarativeEnumTypeImport) {
               violations.push(`${file}：依赖了非契约模块 ${specifier}`);
@@ -404,6 +405,7 @@ describe('trace leaf schema ownership', () => {
   it.each([
     ['src/executors/contracts/trace-source-schema.ts', 'TraceSourceKindSchema'],
     ['src/observability/contracts/trace-metadata-schema.ts', 'TraceSourceMetadataSchema'],
+    ['src/executors/contracts/tool-call-status-schema.ts', 'ToolCallStatusSchema'],
   ])('%s remains a declarative leaf schema', (file, requiredSchema) => {
     const source = ts.createSourceFile(file, readTraceSchemaSource(file, 'utf8'), ts.ScriptTarget.Latest, true);
     expect(isDeclarativeEvidenceSchemaModule(source, {


### PR DESCRIPTION
## 用户影响

工具调用状态由执行器契约的单一 Schema 定义，执行器类型、运行时状态读取和 Experience 时间线共同复用。不引入执行器对观测模块的反向依赖。

保留显式非法状态降为 unknown、缺失状态回退 success 布尔值的规则，不改变持久化取值、统计口径或失败归因，无需迁移。

## 验证与范围

完整本地 `yarn ci` 通过，343 个测试文件、3747 项测试成功，含新增独立 Schema 边界检查。

本批开始前的 C2 接受行为差分核对，在两个 trace session 生成的报告上覆盖 16613 个入口案例及 16146 个 guard 案例，未发现与收敛前入口的差异；这不是全部用户入口的端到端证明，详见 #767 后续记录。

关联 #767，接续 #813。最终跨批审计尚未完成，不关闭总任务。