### PR TITLE
refactor(eval-workflows): 共享 Claude 契约构造并保留各端身份

### DIFF
--- a/src/eval-workflows/hosts/adapters/claude/cli-protocol.ts
+++ b/src/eval-workflows/hosts/adapters/claude/cli-protocol.ts
@@ -1,10 +1,7 @@
-import { z } from 'zod';
+import { createClaudeCoreSchemaValidators, claudeCoreExecutorCapabilities } from './core-protocol-contract.js';
 import {
-  EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
-  ExecutorCapabilitiesSchema,
   JsonValueSchema,
   UsageRecordSchema,
-  deepFreezeCanonicalJson,
   digestCanonicalJson,
   type CoreSchemaValidator,
   type ExecutorCapabilities,
@@ -81,59 +78,11 @@ function schemaIdentity(name: 'input' | 'output' | 'trace'): SchemaIdentity {
 
 /** Validators matching the schema identities advertised by this adapter. */
 export function createClaudeCliCoreSchemaValidators(): readonly CoreSchemaValidator[] {
-  return Object.freeze([
-    Object.freeze({
-      schema: deepFreezeCanonicalJson(schemaIdentity('input')),
-      parse(value: unknown): JsonValue {
-        return JsonValueSchema.parse(value);
-      },
-    }),
-    Object.freeze({
-      schema: deepFreezeCanonicalJson(schemaIdentity('output')),
-      parse(value: unknown): JsonValue {
-        return z.string().parse(value);
-      },
-    }),
-    Object.freeze({
-      schema: deepFreezeCanonicalJson(schemaIdentity('trace')),
-      parse(value: unknown): JsonValue {
-        return SourceNeutralTraceSchema.parse(value) as JsonValue;
-      },
-    }),
-  ]);
+  return createClaudeCoreSchemaValidators(schemaIdentity);
 }
 
 export function claudeCliExecutorCapabilities(): ExecutorCapabilities {
-  return deepFreezeCanonicalJson(ExecutorCapabilitiesSchema.parse({
-    schemaVersion: EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
-    protocols: [{
-      protocolId: 'omk.invoke/v1',
-      inputSchema: schemaIdentity('input'),
-      outputSchema: schemaIdentity('output'),
-      traceSchema: schemaIdentity('trace'),
-      execution: {
-        concurrency: { safety: 'serialized', maxInFlight: 1 },
-        cancellation: 'best-effort',
-        state: { resourceLifecycle: 'per-invocation', trialState: 'stateless' },
-        seedControl: 'unsupported',
-        determinism: 'stochastic',
-        features: {
-          systemInstructions: 'native',
-          workspace: ['copy-on-write-overlay'],
-          mcp: ['native-config'],
-          mockInterception: ['pre-tool-call'],
-          toolPolicies: ['allow-list', 'runtime-default'],
-          skillDiscovery: ['disabled', 'runtime-default'],
-          sandboxIds: [],
-        },
-        telemetry: {
-          trace: 'required',
-          usage: 'optional',
-          providerCost: { reporting: 'optional' },
-        },
-      },
-    }],
-  })) as ExecutorCapabilities;
+  return claudeCoreExecutorCapabilities(schemaIdentity);
 }
 
 function safeInteger(value: unknown): number | undefined {

--- a/src/eval-workflows/hosts/adapters/claude/core-protocol-contract.ts
+++ b/src/eval-workflows/hosts/adapters/claude/core-protocol-contract.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+import {
+  EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
+  ExecutorCapabilitiesSchema,
+  JsonValueSchema,
+  deepFreezeCanonicalJson,
+  type CoreSchemaValidator,
+  type ExecutorCapabilities,
+  type JsonValue,
+  type SchemaIdentity,
+} from '../../../../eval-core/contracts/index.js';
+import { SourceNeutralTraceSchema } from '../../../../eval-runtime/traces/source-neutral.js';
+
+type ClaudeSchemaIdentity = (name: 'input' | 'output' | 'trace') => SchemaIdentity;
+
+export function createClaudeCoreSchemaValidators(schemaIdentity: ClaudeSchemaIdentity): readonly CoreSchemaValidator[] {
+  return Object.freeze([
+    Object.freeze({
+      schema: deepFreezeCanonicalJson(schemaIdentity('input')),
+      parse(value: unknown): JsonValue {
+        return JsonValueSchema.parse(value);
+      },
+    }),
+    Object.freeze({
+      schema: deepFreezeCanonicalJson(schemaIdentity('output')),
+      parse(value: unknown): JsonValue {
+        return z.string().parse(value);
+      },
+    }),
+    Object.freeze({
+      schema: deepFreezeCanonicalJson(schemaIdentity('trace')),
+      parse(value: unknown): JsonValue {
+        return SourceNeutralTraceSchema.parse(value) as JsonValue;
+      },
+    }),
+  ]);
+}
+
+export function claudeCoreExecutorCapabilities(schemaIdentity: ClaudeSchemaIdentity): ExecutorCapabilities {
+  return deepFreezeCanonicalJson(ExecutorCapabilitiesSchema.parse({
+    schemaVersion: EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
+    protocols: [{
+      protocolId: 'omk.invoke/v1',
+      inputSchema: schemaIdentity('input'),
+      outputSchema: schemaIdentity('output'),
+      traceSchema: schemaIdentity('trace'),
+      execution: {
+        concurrency: { safety: 'serialized', maxInFlight: 1 },
+        cancellation: 'best-effort',
+        state: { resourceLifecycle: 'per-invocation', trialState: 'stateless' },
+        seedControl: 'unsupported',
+        determinism: 'stochastic',
+        features: {
+          systemInstructions: 'native',
+          workspace: ['copy-on-write-overlay'],
+          mcp: ['native-config'],
+          mockInterception: ['pre-tool-call'],
+          toolPolicies: ['allow-list', 'runtime-default'],
+          skillDiscovery: ['disabled', 'runtime-default'],
+          sandboxIds: [],
+        },
+        telemetry: {
+          trace: 'required',
+          usage: 'optional',
+          providerCost: { reporting: 'optional' },
+        },
+      },
+    }],
+  })) as ExecutorCapabilities;
+}

--- a/src/eval-workflows/hosts/adapters/claude/sdk-protocol.ts
+++ b/src/eval-workflows/hosts/adapters/claude/sdk-protocol.ts
@@ -1,9 +1,5 @@
-import { z } from 'zod';
+import { createClaudeCoreSchemaValidators, claudeCoreExecutorCapabilities } from './core-protocol-contract.js';
 import {
-  EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
-  ExecutorCapabilitiesSchema,
-  JsonValueSchema,
-  deepFreezeCanonicalJson,
   digestCanonicalJson,
   type CoreSchemaValidator,
   type ExecutorCapabilities,
@@ -16,7 +12,6 @@ import {
 } from './cli-protocol.js';
 import {
   SOURCE_NEUTRAL_TRACE_SCHEMA_DESCRIPTOR,
-  SourceNeutralTraceSchema,
 } from '../../../../eval-runtime/traces/source-neutral.js';
 
 export const CLAUDE_SDK_CORE_ADAPTER_IMPLEMENTATION_VERSION = '2.0.0' as const;
@@ -48,59 +43,11 @@ function schemaIdentity(name: 'input' | 'output' | 'trace'): SchemaIdentity {
 }
 
 export function createClaudeSdkCoreSchemaValidators(): readonly CoreSchemaValidator[] {
-  return Object.freeze([
-    Object.freeze({
-      schema: deepFreezeCanonicalJson(schemaIdentity('input')),
-      parse(value: unknown): JsonValue {
-        return JsonValueSchema.parse(value);
-      },
-    }),
-    Object.freeze({
-      schema: deepFreezeCanonicalJson(schemaIdentity('output')),
-      parse(value: unknown): JsonValue {
-        return z.string().parse(value);
-      },
-    }),
-    Object.freeze({
-      schema: deepFreezeCanonicalJson(schemaIdentity('trace')),
-      parse(value: unknown): JsonValue {
-        return SourceNeutralTraceSchema.parse(value) as JsonValue;
-      },
-    }),
-  ]);
+  return createClaudeCoreSchemaValidators(schemaIdentity);
 }
 
 export function claudeSdkExecutorCapabilities(): ExecutorCapabilities {
-  return deepFreezeCanonicalJson(ExecutorCapabilitiesSchema.parse({
-    schemaVersion: EXECUTOR_CAPABILITIES_SCHEMA_VERSION,
-    protocols: [{
-      protocolId: 'omk.invoke/v1',
-      inputSchema: schemaIdentity('input'),
-      outputSchema: schemaIdentity('output'),
-      traceSchema: schemaIdentity('trace'),
-      execution: {
-        concurrency: { safety: 'serialized', maxInFlight: 1 },
-        cancellation: 'best-effort',
-        state: { resourceLifecycle: 'per-invocation', trialState: 'stateless' },
-        seedControl: 'unsupported',
-        determinism: 'stochastic',
-        features: {
-          systemInstructions: 'native',
-          workspace: ['copy-on-write-overlay'],
-          mcp: ['native-config'],
-          mockInterception: ['pre-tool-call'],
-          toolPolicies: ['allow-list', 'runtime-default'],
-          skillDiscovery: ['disabled', 'runtime-default'],
-          sandboxIds: [],
-        },
-        telemetry: {
-          trace: 'required',
-          usage: 'optional',
-          providerCost: { reporting: 'optional' },
-        },
-      },
-    }],
-  })) as ExecutorCapabilities;
+  return claudeCoreExecutorCapabilities(schemaIdentity);
 }
 
 export function parseClaudeSdkStream(messages: readonly unknown[]): ParsedClaudeSdkStream {


### PR DESCRIPTION
## 用户影响
共享 Claude CLI 与 SDK 的 Schema validator 和能力声明构造，保留各端独立的 Schema identity、协议描述与解析路径。不改变公开能力、评分口径或持久化契约，无需迁移。

## 验证证据
本地 `yarn ci` 通过，343 个测试文件、3747 项测试通过。构造前后能力对象及六个 Schema identity 深度对照一致。本批只消除机械重复，不合并不同执行器的接受行为或测量语义。

关联 #767。