### PR TITLE
refactor(eval-workflows): 归一维度绑定稳定性校验

### DIFF
--- a/src/eval-workflows/measurement/analysis/dimension-binding.ts
+++ b/src/eval-workflows/measurement/analysis/dimension-binding.ts
@@ -1,0 +1,28 @@
+import { canonicalizeJson } from '../../../eval-core/contracts/index.js';
+
+type DimensionBinding = Readonly<{
+  dimensionId: string;
+  metricId: string;
+  sourceAnalysisResultId: string;
+}>;
+
+export function assertStableBinding(
+  entries: readonly DimensionBinding[],
+  keyField: keyof DimensionBinding,
+  issue: (path: Array<string | number>, message: string) => void,
+): void {
+  const bindings = new Map<string, string>();
+  for (const entry of entries) {
+    const binding = canonicalizeJson({
+      dimensionId: entry.dimensionId,
+      metricId: entry.metricId,
+      sourceAnalysisResultId: entry.sourceAnalysisResultId,
+    });
+    const previous = bindings.get(entry[keyField]);
+    if (previous !== undefined && previous !== binding) {
+      issue(['groups'], `Dimension ${keyField} binding must remain stable across groups.`);
+      return;
+    }
+    bindings.set(entry[keyField], binding);
+  }
+}

--- a/src/eval-workflows/measurement/analysis/dimension-table-v1.ts
+++ b/src/eval-workflows/measurement/analysis/dimension-table-v1.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { IdentifierSchema, SamplingUnitIdsSchema, Sha256DigestSchema, canonicalizeJson, digestCanonicalJson, type JsonValue } from '../../../eval-core/contracts/index.js';
 import { analysisJsonSchema, analysisSchemaIdentity, compareStrings, round } from './analysis-support.js';
+import { assertStableBinding } from './dimension-binding.js';
 
 export const DIMENSION_TABLE_SCHEMA_VERSION = 'omk.dimension-table/v1' as const;
 export const DIMENSION_SCORE_DECIMALS = 2;
@@ -143,27 +144,6 @@ export function dimensionGroupId(group: Omit<DimensionGroup, 'groupId'>): string
       sourceGroupId: entry.sourceGroupId,
     })),
   });
-}
-
-function assertStableBinding(
-  entries: readonly DimensionEntry[],
-  keyField: 'dimensionId' | 'metricId' | 'sourceAnalysisResultId',
-  issue: Issue,
-): void {
-  const bindings = new Map<string, string>();
-  for (const entry of entries) {
-    const binding = canonicalizeJson({
-      dimensionId: entry.dimensionId,
-      metricId: entry.metricId,
-      sourceAnalysisResultId: entry.sourceAnalysisResultId,
-    });
-    const previous = bindings.get(entry[keyField]);
-    if (previous !== undefined && previous !== binding) {
-      issue(['groups'], `Dimension ${keyField} binding must remain stable across groups.`);
-      return;
-    }
-    bindings.set(entry[keyField], binding);
-  }
 }
 
 function validateDimensionTable(value: DimensionTableValue, issue: Issue): void {

--- a/src/eval-workflows/measurement/analysis/dimension-table.ts
+++ b/src/eval-workflows/measurement/analysis/dimension-table.ts
@@ -16,6 +16,7 @@ import {
   createAnalysisSchemaValidator,
   round,
 } from './analysis-support.js';
+import { assertStableBinding } from './dimension-binding.js';
 
 export const DIMENSION_TABLE_SCHEMA_VERSION = 'omk.dimension-table/v2' as const;
 export const DIMENSION_SCORE_DECIMALS = 2;
@@ -163,27 +164,6 @@ export function dimensionGroupId(group: Omit<DimensionGroup, 'groupId'>): string
       weight: entry.weight,
     })),
   });
-}
-
-function assertStableBinding(
-  entries: readonly DimensionEntry[],
-  keyField: 'dimensionId' | 'metricId' | 'sourceAnalysisResultId',
-  issue: Issue,
-): void {
-  const bindings = new Map<string, string>();
-  for (const entry of entries) {
-    const binding = canonicalizeJson({
-      dimensionId: entry.dimensionId,
-      metricId: entry.metricId,
-      sourceAnalysisResultId: entry.sourceAnalysisResultId,
-    });
-    const previous = bindings.get(entry[keyField]);
-    if (previous !== undefined && previous !== binding) {
-      issue(['groups'], `Dimension ${keyField} binding must remain stable across groups.`);
-      return;
-    }
-    bindings.set(entry[keyField], binding);
-  }
 }
 
 function assertStableSampleWeights(groups: readonly DimensionGroup[], issue: Issue): void {


### PR DESCRIPTION
## 用户影响
维度表 v1／v2 共用跨组标识绑定稳定性校验，避免同一规则维护两份。保留各自的聚合公式、缺失值处理、权重校验、错误信息和调用顺序，两版 Schema identity 前后深度对照一致。无迁移要求，不改变测量可比性。

## 验证与限制
首次 `yarn ci` 在测试阶段出现一项 CLI doctor 失败，错误为进入 doctor 前的资源摘要冲突，其余 3746 项通过。未修改测试或跳过用例；随后单文件 6 项及原并发范围完整 `yarn test` 的 343 个文件、3747 项均通过。此结果不等于已定位或修复首次摘要冲突，保留该风险记录，远端 CI 补充交付证据。

关联 #767，接续已合并的 #815。