### PR TITLE
fix(eval-workflows): 原子发布物化资源以避免并发摘要误报

### DIFF
--- a/src/eval-workflows/hosts/input-resolution/node-cli-evaluation-resolver.ts
+++ b/src/eval-workflows/hosts/input-resolution/node-cli-evaluation-resolver.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { chmod, lstat, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { chmod, link, lstat, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { extname, isAbsolute, join, resolve } from 'node:path';
 import {
   canonicalizeJson,
@@ -336,7 +336,15 @@ async function materializeBytes(
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
       try {
-        await writeFile(path, bytes, { flag: 'wx', mode: 0o600 });
+        const stagingRoot = await mkdtemp(join(directory, '.materialize-'));
+        try {
+          const stagedPath = join(stagingRoot, 'content');
+          await writeFile(stagedPath, bytes, { flag: 'wx', mode: 0o600 });
+          // Publish complete bytes without replacing a concurrent winner.
+          await link(stagedPath, path);
+        } finally {
+          await rm(stagingRoot, { recursive: true, force: true });
+        }
       } catch (writeError) {
         if ((writeError as NodeJS.ErrnoException).code !== 'EEXIST') throw writeError;
         const existingStat = await lstat(path);

--- a/test/eval-workflows/hosts/input-resolution/node-cli-materialization-concurrency.test.ts
+++ b/test/eval-workflows/hosts/input-resolution/node-cli-materialization-concurrency.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, it, vi } from 'vitest';
+import { parseCliEvaluationRequest } from '../../../../src/eval-workflows/input-compilation/index.js';
+import { resolveNodeCliEvaluationRequest } from '../../../../src/eval-workflows/hosts/input-resolution/node-cli-evaluation-resolver.js';
+import { createEvalSampleSetDocument } from '../../../../src/eval-workflows/inputs/schemas/sample-set.js';
+
+const barrier = vi.hoisted(() => ({
+  entered: undefined as (() => void) | undefined,
+  release: undefined as Promise<void> | undefined,
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    writeFile: async (...args: Parameters<typeof actual.writeFile>) => {
+      const [path, data] = args;
+      if (barrier.entered && typeof path === 'string' && path.includes('/content/')
+          && (typeof data === 'string' || data instanceof Uint8Array)) {
+        const entered = barrier.entered;
+        barrier.entered = undefined;
+        const file = await actual.open(path, 'wx', 0o600);
+        try {
+          entered();
+          await barrier.release;
+          await file.writeFile(data);
+        } finally {
+          await file.close();
+        }
+        return;
+      }
+      await actual.writeFile(...args);
+    },
+  };
+});
+
+it('does not expose a partial resource to another resolver and removes staging files', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omk-materialization-race-'));
+  let release!: () => void;
+  const entered = new Promise<void>((resolve) => { barrier.entered = resolve; });
+  barrier.release = new Promise<void>((resolve) => { release = resolve; });
+  let first: ReturnType<typeof resolveNodeCliEvaluationRequest> | undefined;
+  try {
+    await mkdir(join(root, 'skills'));
+    await writeFile(join(root, 'skills', 'control.md'), '# Control\nAnswer directly.\n');
+    await writeFile(join(root, 'skills', 'treatment.md'), '# Treatment\nUse supplied knowledge.\n');
+    await writeFile(join(root, 'samples.json'), JSON.stringify(createEvalSampleSetDocument([{
+      sample_id: 'sample-a', prompt: 'Return an answer.',
+      assertions: [{ type: 'contains', value: 'answer' }],
+    }])));
+    const request = parseCliEvaluationRequest({
+      explicitCliFlags: {
+        control: 'skills/control.md', treatment: 'skills/treatment.md',
+        samples: 'samples.json', 'skill-dir': 'skills',
+        executor: 'claude', model: 'claude-test', 'no-judge': true,
+      },
+      defaults: {
+        samplesLocator: 'samples.json', skillDirectoryLocator: 'skills',
+        targetRuntime: { executorId: 'claude', model: 'claude-test', effort: 'low' },
+        judgeMembers: [],
+        presentation: {
+          projectOutputDirectoryLocator: join(root, 'reports'),
+          globalOutputDirectoryLocator: join(root, 'global-reports'),
+          language: 'zh', languageDefaultSource: 'environment-selection',
+        },
+      },
+    });
+    const options = { projectRoot: root, materializationRoot: join(root, 'resolved') };
+    first = resolveNodeCliEvaluationRequest(request, options);
+    await Promise.race([entered, first.then(() => { throw new Error('Write barrier was not reached'); })]);
+    const second = await resolveNodeCliEvaluationRequest(request, options);
+    release();
+    const completed = await first;
+    expect(completed).toEqual(second);
+    const contentRoot = join(options.materializationRoot, 'content');
+    const files = await readdir(contentRoot);
+    expect(files.some((file) => file.startsWith('.materialize-'))).toBe(false);
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) expect((await readFile(join(contentRoot, file))).length).toBeGreaterThan(0);
+  } finally {
+    release();
+    await first?.catch(() => undefined);
+    barrier.entered = undefined;
+    barrier.release = undefined;
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 用户影响
修复多个解析请求并发物化相同内容时，读取尚未写完的最终文件并误报摘要不一致的问题。先在私有临时目录写完整，再通过不覆盖既有目标的 hard link 发布；竞争者仍必须通过已有类型和摘要校验，临时目录在退出路径清理。

内容寻址、资源身份、权限、测量 Schema 和评分语义保持不变，无数据迁移。文件系统不支持 hard link 时安全失败，不回退到暴露部分内容的写入方式。

## 验证证据
可控并发回归暂停第一个写入者，并要求第二个解析请求成功。相同用例对 #816 的解析器触发摘要冲突，修复后通过；旧实现材料在仓库外运行并清理。本地 `yarn ci` 通过，344 个测试文件、3748 项测试通过，覆盖新增竞态用例、原解析器及 CLI doctor 路径。

关联 #767，修复 #816 门禁首次暴露的资源摘要冲突。