### PR TITLE
chore(release): 准备 1.0.0-beta.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 发布范围

准备下一个预发布版本 1.0.0-beta.7，发布后使用 npm next 通道，不改变 latest。此 PR 仅更新 package.json 版本号，不创建发布 tag，不执行 npm publish。

## 用户影响与发布说明摘要

- CLI 与 Workflow 共用规范输入，保留真实样本发现及物理身份判重，修复重复解析导致的输入分歧。
- CLI／API／Studio 共用人工审阅后的有效观测投影，原始证据不被覆盖。
- EvalConfig 与 Experience wire 结构统一契约来源，保留语义校验、引用校验和历史报告接受行为。
- 清理未使用内部能力，归一进度、评委结果及机械重复实现。
- 修复并发物化资源时读取未完成内容导致的摘要误报；不支持 hard link 的文件系统会安全失败。

不改变评分公式、prompt、公开测量 Schema identity 或历史报告存储契约，无报告迁移要求。继续保留不同协议与测量版本的独立语义。关联 #767，具体实现见 #768～#817 的已合并 PR。

## 验收与审查

版本号单行改动的范围审查：No findings，不包含额外源代码或工作流修改。

清理生成产物后完整 yarn ci 通过，344 个测试文件、3748 项测试通过。实际 npm tarball 在仓库外临时目录安装，使用独立 HOME、实际生产依赖并省略可选 SDK peers；版本输出、root／eval／observe 帮助及十个公开 JS 入口和类型声明通过。临时目录已清理，未调用真实模型。远端 CI 补充平台门禁。

后续发布需在 main 合并提交上创建 annotated tag v1.0.0-beta.7，由现有 OIDC Trusted Publishing 工作流发布；发布后检查自动生成的 Release notes。