### PR TITLE
docs(docs): 精简双语入口并校正 Beta 上手说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,249 +8,64 @@
 
 **English** | [简体中文](./README.zh.md)
 
-**Observe. Measure. Know.**
+**Observe. Measure. Know.** Make knowledge changes in your AI application evidence-backed.
 
-**OMK makes every knowledge change in your AI application evidence-backed.**
+OMK helps authors of prompts, RAG systems, skills, and agents compare versions, inspect evidence, and find knowledge gaps in real tasks. A controlled comparison keeps the **same model and evaluation samples, changing only the knowledge artifact**.
 
-Observe real-world performance, measure version differences, and determine whether the change is effective and the version is ready to ship.
+Version 1.0 is still **in Beta iteration**; APIs and storage contracts may change. Read the [migration guide](docs/guides/v1-preview-migration.md) before upgrading an older installation.
 
-**Same model. Same evaluation samples. Only the knowledge artifact changes.**
+![OMK: from controlled evaluation to real-world feedback](./docs/public/omk-knowledge-flow-en-animated.gif)
 
-**DeepSeek Harness users:** install OMK as a native bundle, reuse the current profile for controlled evaluations, and open persisted DSH task trajectories in Studio. [Set up the DSH host plugin →](docs/reference/executors.md#deepseek-harness-prefer-the-host-plugin)
+## Start with your goal
 
-![omk knowledge artifact evaluation flow: doctor / eval / observe / sample / evolve loop](./docs/public/omk-knowledge-flow-en-animated.gif)
-
-📖 **Full documentation: [oh-my-knowledge.pages.dev](https://oh-my-knowledge.pages.dev)** (searchable, English / 简体中文)
-
-## What knowledge means in OMK
-
-**Entities are the things knowledge describes; knowledge expresses their states, relationships, or actions in a specific context.**
-
-**How knowledge is expressed:**
-
-> **Time scope + scenario + conditions + entity A + relation or action + entity B (if any)**
-
-See [How OMK understands knowledge](docs/explanation/knowledge.md) for entity roles, shared relationships, and the distinction between knowledge and its carriers. Entity-based retrieval remains a design direction.
-
-## What OMK helps you know
-
-| Decision | Command | Evidence you get |
-|---|---|---|
-| Is this artifact coherent enough to evaluate? | `omk doctor` | structure, dependencies, safety, and measurability checks |
-| Is v2 actually better than v1? | `omk eval` | one-line verdict, confidence interval, failed samples, cost |
-| Why did it pass or fail? | `omk studio` | report view with scores, diagnostics, and examples |
-| Should this version become the accepted one? | `omk promote` / `omk evolve` | evidence-gated accept or generate a better candidate |
-| What happened during one real AI task? | `omk observe` / Studio Task Trajectory | a trace-backed view of the request, visible Knowledge, tool calls, results, response, and user correction |
-| What did real usage expose? | `omk observe` / `omk sample --from-traces` | production gaps drafted for review; reviewed drafts can become eval samples |
+| Goal | Entry point |
+|---|---|
+| Compare two skills and inspect the verdict, interval, and failed cases | [CLI quickstart](docs/quickstart-skill-eval.md) |
+| Add scoring and version comparisons to a Node.js service | [Service integration guide](docs/guides/eval-runtime.md), including an example without model credentials |
+| Inspect one task or find problems in historical logs | [Observation and task trajectories](docs/guides/observe-production.md) |
 
 ## Quick start
 
-Already have a Node.js service, retriever, or Agent? Start with [Use OMK in your service](docs/guides/eval-runtime.md): run an example without model credentials, choose a scorer, connect your service, and read the results. The command-line quickstart follows below.
+You need Node.js >=22 and an authenticated model runtime; see [Requirements](#requirements). Install the Beta and preview your first comparison:
 
 ```bash
-npm i -g oh-my-knowledge
-omk init demo && cd demo
+npm i -g oh-my-knowledge@next
+omk init demo
+cd demo
 omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
+```
+
+After checking the plan and estimated calls, run the evaluation (this calls the model):
+
+```bash
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-Runs out of the box — no edits needed first. `omk init` scaffolds two skill variants and three sample cases; `--dry-run` previews the sealed task plan and estimated calls; `omk eval` runs the controlled A/B and opens the authenticated Core run in Studio. Once it runs, swap in your own skills and cases. To start directly with the first-party 20-case pack, replace the first command with `omk init demo --samples 20`.
+The scaffold contains two skills and three cases. This small default set checks the workflow; `UNDERPOWERED` is expected. Starter cases are marked `llm-generated`. Even the full pack created with `omk init demo-full --samples 20` only meets the default heuristic evidence floor, not an a priori power plan or a release-evidence requirement. Review and replace starter cases with real domain cases before relying on the results.
 
-Prerequisite: configure one authenticated model runtime (Codex CLI, Claude Code, or an API executor; see [Requirements](#requirements)). Inside a Codex task in the ChatGPT desktop app, omk automatically selects `codex`, reads the model from `~/.codex/config.toml`, and uses the same Codex model as the default judge. Claude is not required.
-
-To make Codex the default in regular terminals, add the preference to your shell profile (for example `~/.zshrc`):
-
-```bash
-export OMK_EXECUTOR=codex
-# Optional: export OMK_MODEL="your-codex-model"
-```
-
-Without `OMK_MODEL`, omk reads the model from `~/.codex/config.toml`. You can still pass `--executor codex --model <codex-model>` per command. Pass `--judge-models` or set `OMK_JUDGE_MODELS` only when you want a different judge.
-
-> The default 3-case pack is a low-cost workflow check, so `UNDERPOWERED` is expected. `--samples 20` selects a first-party, difficulty-stratified starter pack that meets omk's default heuristic evidence floor; it is not an a priori power calculation. Its provenance is `llm-generated`: use it to learn the statistical workflow, then review and replace it with real domain cases before making a release decision.
-
-> The CLI notifies you when a newer version is available (at most once per 20h); set `OMK_SKIP_UPDATE_CHECK=1` to silence it permanently.
-
-Walkthrough: [5-minute quickstart guide](docs/quickstart-skill-eval.md) (recommended for first-time users; includes demo → own skill → verdict actions). More runnable examples (Skill Map, offline executor, agent runtime, RAG, Observe) live in the repo's [example gallery](examples/README.md).
-
-Deeper: [who omk is for](docs/explanation/who-omk-is-for.md) · [CLI reference](docs/reference/cli.md) · [how it works](docs/explanation/architecture.md) · [eval sample format](docs/reference/eval-sample-format.md) · [executors](docs/reference/executors.md) · [artifact layout](docs/reference/artifact-layout.md)
-
-## Inspect one Codex task
-
-If you only want to see what happened behind one Codex conversation, you do not need to run `observe ingest` first:
-
-```bash
-omk studio
-```
-
-Studio opens the local Codex conversation overview at `http://127.0.0.1:7799` by default. Select a conversation, then a task, to open **Task Trajectory**. Its four lanes — **Conversation, Actions, Results, and Knowledge** — show the request, AI responses, tool calls, tool returns, and observable context, with drill-downs into normalized events and raw logs.
-
-Running tasks are prioritized and update live. While **Following**, the trajectory advances smoothly as events arrive; after you inspect an earlier point, Studio keeps your position and offers **View updates**. Old logs without a terminal event are marked **End status not recorded** instead of remaining live forever.
-
-Task Trajectory only reconstructs facts observable in the log. It does not reveal or infer hidden reasoning. See [Observe production traces](docs/guides/observe-production.md#inspect-one-task) for the full model.
-
-## The OMK loop
-
-OMK is for authors and maintainers of LLM knowledge artifacts who need a release decision, not for passive end-users of a skill. The main loop is deliberately controlled:
-
-```text
-change a prompt / RAG / skill / agent artifact
-→ run omk doctor before evaluation
-→ run omk eval with the same model and the same samples
-→ read the report / Studio evidence
-→ promote a proven version or evolve a candidate
-→ observe real usage and draft gap-derived samples for review
-```
-
-The first value is the pre-ship `doctor → eval` decision. The long-term value is the closed loop: `observe` surfaces production gaps, `sample --from-traces` drafts regression samples for human review, and reviewed drafts can become fixed eval samples that make the next `eval` harder to game.
+The [full walkthrough](docs/quickstart-skill-eval.md) covers runtime selection, your own skills, and interpreting results. The [example gallery](examples/README.md) offers more runnable scenarios.
 
 ## Use inside AI Coding Agents
-
-Install the official omk Agent Skill to let your coding agent run omk workflows from natural language:
 
 ```bash
 omk install omk-agent-skill
 ```
 
-By default, omk installs only into detected local targets it explicitly supports: Codex/AGENTS when `~/.codex` or `~/.agents` exists, and Claude Code when `~/.claude` exists. Use `--to all` to force every target omk currently knows, or `--dest` for a custom skill root.
+Then ask your coding agent: “Use omk to compare these two skills.” See the [quickstart](docs/quickstart-skill-eval.md#use-inside-an-agent) for installation targets and usage. DeepSeek Harness users can use the [host plugin](docs/reference/executors.md#deepseek-harness-prefer-the-host-plugin) to reuse their current profile.
 
-### Use inside Claude Code
+The [MCP integration](docs/guides/mcp-integration.md) accepts user-authorized knowledge feedback. It records partial evidence submitted at its tool boundary; it does not automatically monitor complete conversations.
 
-When the `omk` skill is available in Claude Code, you can invoke it directly:
+## Use the evidence
 
-```bash
-/omk eval              # evaluate the artifact(s) in the current project
-/omk evolve            # auto-iterate to improve a skill
-/omk sample            # generate or fill test cases
-```
+`doctor` checks the artifact, `eval` compares versions, and `studio` presents results and raw evidence. When evidence meets the gate, `promote` can accept a version; `evolve` can generate a candidate. Gaps found by `observe` can become draft cases for review before the next evaluation.
 
-These slash commands are natural-language entry points — the agent reads the conversation context to figure out which skill to operate on. You can also just say "compare v1 vs v2 for me" or "improve this artifact" and omk picks the right command.
+Conclusions depend on the cases, scoring criteria, and execution environment. Observation signals are not causal conclusions, and generated cases are not an independent release-validation set. See [statistical rigor](docs/explanation/statistical-rigor.md) and the [three-stage workflow](docs/explanation/three-stage-workflow.md) for the method and limits.
 
-### Use inside Codex
-
-Codex does not support Claude Code style `/omk ...` slash commands. Ask the agent to run the `omk` CLI directly. Inside a Codex task, omk automatically selects the Codex runtime and locally configured model:
-
-```bash
-omk eval
-omk evolve skills/my-skill.md   # one-shot: doctor → (auto-generate samples if missing) → self-iterate
-omk sample skills/my-skill.md
-```
-
-You can also describe the goal in natural language, such as "compare v1 vs v2" or "generate test cases for this skill".
-
-`eval`, `doctor`, `sample`, `evolve`, and the LLM-enhanced observe review share the same runtime resolution. Once Codex is selected, the default judge reuses the evaluated Codex model instead of falling back to `claude:haiku`.
-
-> `omk evolve` is a one-shot loop: it runs the doctor gate first, auto-generates eval samples when the target skill has none, then self-iterates. For a brand-new skill, just run `omk evolve skills/foo.md`.
-
-## Why this tool
-
-Knowledge engineering creates a versioning problem: every prompt, RAG recipe, skill, agent, or workflow can change behavior without changing application code. When someone asks "can we ship v2, and why?", a prettier answer or a higher anecdotal success rate is not enough.
-
-omk treats the knowledge artifact as the variable under test: **same model, same evaluation samples, only the artifact changes.** That makes the comparison explainable, repeatable, and suitable for CI or release review.
-
-## Why omk over alternatives
-
-| | omk | promptfoo | DeepEval | LangSmith |
-|--|--|--|--|--|
-| Bootstrap CI | ✓ default | ✗ | ✗ | ✗ |
-| Krippendorff α (judge ↔ human) | ✓ with gold set | ✗ | ✗ | ✗ |
-| Length-debias judge prompt | ✓ default | ✗ | ✗ | ✗ |
-| Fail-closed evidence coverage | ✓ | ✗ | ✗ | ✗ |
-| Three-layer scoring isolation | ✓ | ✗ | partial | ✗ |
-| Per-variant skill isolation (construct validity) | ✓ default | ✗ | ✗ | ✗ |
-| Native Agent Skill | ✓ | ✗ | ✗ | ✗ |
-| Hosted SaaS dashboard | ✗ | ✗ | ✓ | ✓ |
-
-omk's moat is a **default-on safety net**: Bootstrap CI and length-debias are normal measurement behavior, missing evidence fails closed, and explicit Gold comparison provides judge ↔ human alpha calibration. Need a hosted SaaS dashboard? Choose LangSmith. Want quick local prompt iteration without statistics? Choose promptfoo. **Shipping to production and someone will ask "why should I trust this number?" Choose omk.**
-
-RAG-specific evals: see RAGAS (separate niche, complementary to omk). Full comparison with 7 tools across 25+ dimensions: [docs/reference/comparison.md](docs/reference/comparison.md).
-
-## Features
-
-| Feature | What it does |
-|---|---|
-| **Core release decision** | Six conclusions + stable reason codes + exit-code routing; Studio projects the same authenticated Decision |
-| **Five-layer evidence graph** | Assertion / LLM / Judge / Dimension / Composite stay distinct, with coverage, cost, status, and lineage kept orthogonal |
-| **Multi-executor** | Claude CLI / Claude SDK / Codex CLI / Codex SDK / DeepSeek Harness / OpenAI / Anthropic API / any custom command |
-| **30+ assertion types** | substring, regex, JSON Schema, ROUGE/BLEU/Levenshtein similarity, agent tool-call assertions, semantic similarity, custom JS |
-| **Statistical rigor** | Bootstrap comparison families, length-debias, fail-closed evidence coverage, and explicit Gold agreement calibration. [Details →](docs/explanation/statistical-rigor.md) |
-| **RAG metrics** | `faithfulness` / `answer_relevancy` / `context_recall` — anti-hallucination + answer relevance + context coverage |
-| **LLM health audit** | `omk doctor` grades 7 builtin dimensions; repeats the audit (`--repeat`) and merges findings by k/n consensus |
-| **Production observability** | normalize Codex, Claude Code, OpenClaw, and markdown logs into source-neutral Trace IR; measure per-skill outcomes / latency / token use / knowledge-gap signals |
-| **Active MCP knowledge feedback (experimental)** | an MCP client actively calls a tool to write user-authorized knowledge feedback into Observation Inbox; it does not monitor conversations, and every record is marked `coverage: partial` |
-| **Knowledge-gap detection** | severity-weighted signals quantify risk exposure instead of claiming completeness |
-| **Construct-validity isolation** | `--strict-baseline` (default ON) cuts three contamination channels so baseline doesn't silently see the skill it's being compared against |
-| **Git & remote sources** | install / eval from a local git ref or a remote git URL (`--git-url`); directory-skills run in a content-addressed **isolated copy** so `references/` assets are real measured input, not just `SKILL.md` |
-| **Evidence-gated management** | `omk install` registers a managed record; `omk eval` auto-writes evidence bound by content fingerprint, moving a skill `installed → measurable`; `omk list` surfaces each managed skill's status (installed / measurable / promoted / stale); `omk promote` accepts a version once its evidence passes the gate (default PROGRESS only); `omk rollback` revokes that acceptance, returning the skill to `measurable`. [spec →](docs/specs/evidence-gated-management.md) |
-| **Sample design science** | sample schema with `capability` / `difficulty` / `construct` / `provenance` metadata (HF Dataset Cards style); studio surfaces coverage breakdown plus `rubric_clarity_low` / `capability_thin` flags. [docs/specs/sample-design-spec.md](docs/specs/sample-design-spec.md) |
-| **Multi-judge ensemble** | `--judge-models claude:opus,openai-api:gpt-4o` cross-vendor scoring + agreement metrics |
-| **Multi-run variance** | `--repeat N` publishes independent Core runs and an Evaluation Series variance analysis |
-| **MCP URL fetching** | pull content from private-doc URLs via an MCP server (SSO-protected knowledge bases, etc.) |
-| **Auto analysis** | detects low-discrimination assertions, flat scores, all-pass / all-fail, expensive samples |
-| **Traceability** | reports carry CLI version, Node version, artifact version fingerprint, judge prompt hash |
-| **EN / ZH views** | bilingual local Studio views selected through the report URL |
-
-### Run inside an existing DeepSeek Harness
-
-Install OMK as a DSH bundle to reuse the profile's model, credentials, tools, and sandbox:
-
-```bash
-dsh plugin --profile web add oh-my-knowledge
-dsh --profile web
-```
-
-Inside DSH:
-
-- `/omk eval eval.yaml` runs every sample in an isolated DSH session while OMK owns the report and statistics;
-- `/omk observe` lists recent terminal sessions;
-- `/omk observe <session-id>` reads a consistent snapshot and returns its Studio Task Trajectory URL.
-
-Observe uses the profile's `sessionPersistence` directly, so users do not export or locate JSONL / SQLite files. The first version is offline-only and does not live-follow a session that is still being written. See the [executor guide](docs/reference/executors.md#deepseek-harness-prefer-the-host-plugin) and [observe guide](docs/guides/observe-production.md#inspect-a-task-inside-deepseek-harness).
-
-### Connect an MCP client (experimental)
-
-> **Positioning: OMK MCP is an active knowledge-feedback interface, not a conversation monitor.** OMK MCP alone cannot automatically monitor or subscribe to complete conversations in Codex, ChatGPT, or another client. OMK receives a record only after the client, model, or component actively calls `save_observation` with authorized content. An Agent Skill may automatically recognize a potential feedback moment, but saving it still requires user confirmation and an explicit MCP tool call.
-
-`omk-mcp` is a client-neutral stdio MCP server. Codex and other local MCP clients can start it directly; a private host can compose the exported Streamable HTTP adapter. The client calls `save_observation` only after the user explicitly asks to record feedback, appends the feedback and optional evidence under `.omk/observe/inbox/captures/`, and can render an inline MCP Apps review card for a human verdict and regression-sample draft.
-
-In Codex, explicitly invoke the OMK Skill to submit the current knowledge feedback:
-
-```text
-$omk feedback
-```
-
-The explicit invocation itself confirms the save. The agent selects the most recent clear issue from the visible conversation and calls `save_observation` with `confirmedByUser: true`; it asks first when the candidate is ambiguous. This shortcut is not a CLI command, and it does not automatically review the observation, draft a sample, or write to a gold set.
-
-```bash
-omk-mcp
-```
-
-Every record carries `coverageStatus: partial`: OMK observes its tool boundary, submitted feedback, and optional evidence, but not the full conversation, other tool calls, or hidden reasoning. Continuous monitoring requires a host that is authorized to access an event stream and actively forwards those events; that is a host-integration capability, not an OMK MCP capability. Conversation IDs, turn IDs, and idempotency keys are hashed rather than persisted verbatim. For a private-host Streamable HTTP integration, see [Compose the OMK MCP integration](docs/guides/mcp-integration.md).
-
-### Local storage
-
-Project data uses the domain-oriented `.omk/` v2 layout: durable evidence lives under `eval/`, `doctor/`, and `observe/`; governance records live under `governance/`; backups remain recoverable; and only rebuildable work belongs in `state/`. Machine tools, tunnels, caches, and materialized copies stay under `~/.oh-my-knowledge/state/`, never in a project. This release neither reads nor migrates the earlier storage layout.
+Project evidence lives under `.omk/`; machine-level state lives under `~/.oh-my-knowledge/`. The current version neither reads nor migrates the old storage layout. Back up before upgrading and follow the [migration guide](docs/guides/v1-preview-migration.md) to establish new evidence.
 
 ## Documentation
 
-The full docs are published at **[oh-my-knowledge.pages.dev](https://oh-my-knowledge.pages.dev)** — searchable, with an English / 简体中文 switcher. Key pages:
-
-- **[How it works](docs/explanation/architecture.md)** — input compilation, sealed Core execution, analysis, persistence, and Studio projections
-- **[Eval sample format](docs/reference/eval-sample-format.md)** — sample schema, scoring formulas, 30+ assertion types, custom JS assertions
-- **[CLI reference](docs/reference/cli.md)** — all top-level commands with bash examples and flag tables
-- **[Migrate to the 1.0 preview](docs/guides/v1-preview-migration.md)** — install channel, storage reset, sample protocol, CLI automation, and embedded API changes since 0.54
-- **[Evaluation Core cutover](docs/guides/eval-core-cutover.md)** — `BREAKING-SCHEMA` storage, resume, Studio, Gold, managed-evidence, and evolve migration
-- **[Embed OMK in a service](docs/guides/eval-runtime.md)** — choose a scorer, connect a Node.js service, and interpret scores and failures
-- **[Storage layout v2](docs/specs/storage-layout-spec.md)** — project/global domains, compatibility boundary, and Git policy
-- **[Executors](docs/reference/executors.md)** & **[artifact layout](docs/reference/artifact-layout.md)** — built-in / custom executors; how `variant` resolves to an artifact + runtime context
-- **[How-to guides](docs/guides/agent-eval.md)** — [evaluate an agent](docs/guides/agent-eval.md) (project runtime context) and [use non-Claude models](docs/guides/non-claude-models.md) (GLM / Qwen / DeepSeek / Moonshot / Ollama)
-- **[Observe & inspect task trajectories](docs/guides/observe-production.md)** — browse local Codex conversations, drill into one task, and follow its observable execution live
-- **[Quickstart](docs/quickstart-skill-eval.md)** — first-time five-minute walkthrough
-- **[Example gallery](https://github.com/lizhiyao/oh-my-knowledge/tree/main/examples)** — a set of runnable examples in the repo, arranged simplest-to-richest
-- **[Sample design spec](docs/specs/sample-design-spec.md)** — capability / construct / provenance metadata; industry-gap mapping
-- **[Statistical rigor](docs/explanation/statistical-rigor.md)** — why Bootstrap CI / Gold agreement / length-debias / evidence coverage matter
-- **[Comparison with 7 tools](docs/reference/comparison.md)** — 25+ dimensions across promptfoo / DeepEval / RAGAS / OpenAI Evals / LangSmith / lm-eval-harness / inspect-ai
-- **[Evidence-gated management](docs/specs/evidence-gated-management.md)** — managed records, lifecycle states (installed / measurable / promoted / stale), install → eval → measurable → promote → rollback
+[Documentation index](docs/README.md) · [Online docs](https://oh-my-knowledge.pages.dev) · [CLI reference](docs/reference/cli.md) · [Sample format](docs/reference/eval-sample-format.md) · [Executors](docs/reference/executors.md) · [How OMK understands knowledge](docs/explanation/knowledge.md)
 
 ## Environment variables
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,249 +8,64 @@
 
 [English](./README.md) | **简体中文**
 
-**Observe. Measure. Know.**
+**Observe. Measure. Know.** 让 AI 应用的知识改动有据可依。
 
-**OMK，让 AI 应用的知识改动有据可依。**
+OMK 帮助 prompt、RAG、skill 和 agent 的作者比较版本、检查证据，并从真实任务中发现知识缺口。受控比较遵循：**相同模型，相同评测用例，只改变知识载体。**
 
-观测真实表现，量出版本差异，判断改动是否有效、版本能否发布。
+当前 1.0 仍处于 **Beta 迭代期**，接口与存储契约可能继续变化。从旧版本升级前，请先阅读[迁移指南](docs/zh/guides/v1-preview-migration.md)。
 
-**相同模型，相同评测用例，只改变知识载体。**
+![OMK：从受控评测到真实使用反馈](./docs/public/omk-knowledge-flow-animated.gif)
 
-**DeepSeek Harness 用户：** OMK 可作为原生 bundle 安装，复用当前 profile 做受控评测，并在 Studio 打开已持久化的 DSH 任务轨迹。[接入 DSH 宿主插件 →](docs/zh/reference/executors.md#deepseek-harness优先使用宿主插件)
+## 从你的目标开始
 
-![omk 知识载体评测流程：doctor / eval / observe / sample / evolve 闭环](./docs/public/omk-knowledge-flow-animated.gif)
-
-📖 **完整文档：[oh-my-knowledge.pages.dev/zh](https://oh-my-knowledge.pages.dev/zh/)**（可搜索，可切换英文）
-
-## OMK 中的知识是什么
-
-**实体是知识所描述的事物；知识表达实体在特定上下文中的状态、关系或行为。**
-
-**知识的表达形式：**
-
-> **时间范围＋场景＋条件＋实体 A＋关系或行为＋实体 B（如有）**
-
-实体角色、多实体关联及知识与载体的区别，见[OMK 如何理解知识](docs/zh/explanation/knowledge.md)。实体关联检索仍是设计方向。
-
-## OMK 让你知道什么
-
-| 决策问题 | 命令 | 你会得到的证据 |
-|------|------|------|
-| 这份知识载体是否清楚到值得评测？ | `omk doctor` | 结构、依赖、安全性、可测性检查 |
-| v2 是否真的优于 v1？ | `omk eval` | 一行 verdict、置信区间、失败样本、成本 |
-| 它为什么通过或失败？ | `omk studio` | 分数、诊断、样本证据的报告视图 |
-| 这个版本是否应成为接受版本？ | `omk promote` / `omk evolve` | 基于证据接受，或生成更好的候选版 |
-| 一次真实 AI 任务中发生了什么？ | `omk observe` / Studio 任务轨迹 | 请求、可见知识、工具调用与结果、回答和用户纠正的可核验轨迹 |
-| 真实使用暴露了哪些知识缺口？ | `omk observe` / `omk sample --from-traces` | 将线上缺口生成待复核草稿，复核后再沉淀为评测样本 |
+| 想做什么 | 入口 |
+|---|---|
+| 比较两版 skill，获得判定、置信区间与失败用例 | [命令行快速上手](docs/zh/quickstart-skill-eval.md) |
+| 在 Node.js 服务中接入评分与版本对比 | [服务接入指南](docs/zh/guides/eval-runtime.md)，含无需模型凭证的示例 |
+| 看清一次任务，或从历史日志发现问题 | [观测与任务轨迹](docs/zh/guides/observe-production.md) |
 
 ## 快速开始
 
-已有 Node.js 服务、检索系统或 Agent，希望接入评分与版本对比？从[在服务中使用 OMK](docs/zh/guides/eval-runtime.md)开始：先运行无需模型凭证的示例，再选择评分方法、接入自己的服务并解读结果。下面是命令行上手流程。
+需要 Node.js >=22 和一个已认证的模型 runtime，详见[系统要求](#系统要求)。安装 Beta 并预览第一次比较：
 
 ```bash
-npm i -g oh-my-knowledge
-omk init demo && cd demo
+npm i -g oh-my-knowledge@next
+omk init demo
+cd demo
 omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
+```
+
+检查计划和预估调用次数后，执行评测（会调用模型）：
+
+```bash
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-开箱即跑：`omk init` 脚手架好两版 skill 和三条评测用例，不用先改任何文件；`--dry-run` 预览 sealed task plan 与预估调用次数；`omk eval` 跑控制变量 A/B，并在 Studio 打开经过认证的 Core run。跑通后再把 skill 和用例换成你自己的。希望首次就使用官方 20 条完整起步集时，把第一条命令换成 `omk init demo --samples 20`。
+脚手架包含两版 skill 和三条用例。默认小样本用于检查流程，出现 `UNDERPOWERED` 符合预期。官方起步用例标记为 `llm-generated`；即使用 `omk init demo-full --samples 20` 创建完整起步集，也只是达到默认启发式证据下限，不等于完成功效规划或具备发布证据。实际使用前应人工复核并替换为真实领域用例。
 
-前置：准备一个已认证的模型 runtime（Codex CLI、Claude Code 或 API 执行器，见[系统要求](#系统要求)）。在 ChatGPT desktop 的 Codex 任务里，omk 会自动使用 `codex`，从 `~/.codex/config.toml` 读取模型，并默认用同一个 Codex 模型担任评委，不依赖 Claude。
+[完整教程](docs/zh/quickstart-skill-eval.md)介绍模型选择、换成自己的 skill 和结果解读；[示例画廊](examples/README.zh.md)提供更多可运行场景。
 
-普通终端想固定使用 Codex，可以把偏好加入 shell 配置，例如 `~/.zshrc`：
-
-```bash
-export OMK_EXECUTOR=codex
-# 可选：export OMK_MODEL="你的 Codex 模型"
-```
-
-不设置 `OMK_MODEL` 时，omk 会读取 `~/.codex/config.toml` 的模型。也可以继续逐次显式传 `--executor codex --model <codex-model>`。自定义评委时再传 `--judge-models` 或设置 `OMK_JUDGE_MODELS`。
-
-> 默认 3 条用例是低成本流程检查，出现「数据不足（UNDERPOWERED）」符合预期。`--samples 20` 会选择经过难度分层的官方起步用例集，达到 omk 默认的启发式证据下限，但这不是先验功效计算。其来源明确标记为 `llm-generated`：它适合学习统计流程，发布判断前仍应人工复核并替换为真实领域用例。
-
-> 命令行有新版本时会自动提示（每 20 小时最多一次）；想永久关闭该提醒，设环境变量 `OMK_SKIP_UPDATE_CHECK=1` 即可。
-
-手把手教程：[5 分钟快速上手](docs/zh/quickstart-skill-eval.md)（推荐第一次跑评测的用户，覆盖 demo → 自己的 skill → verdict 动作）。更多可跑示例（Skill Map、离线执行器、agent runtime、RAG、Observe）见仓库的[示例画廊](examples/README.zh.md)。
-
-深入：[为谁、解决什么](docs/zh/explanation/who-omk-is-for.md) · [CLI 参考](docs/zh/reference/cli.md) · [工作原理](docs/zh/explanation/architecture.md) · [评测用例格式](docs/zh/reference/eval-sample-format.md) · [执行器](docs/zh/reference/executors.md) · [知识载体布局](docs/zh/reference/artifact-layout.md)
-
-## 先看清一次 Codex 任务
-
-只想知道一次 Codex 对话背后发生了什么，不需要先运行 `observe ingest`：
-
-```bash
-omk studio
-```
-
-Studio 默认在 `http://127.0.0.1:7799` 打开本机 Codex 对话总览。先选择一段对话，再选择其中一次任务，即可进入「任务轨迹」：按**对话、执行、结果、知识**四条泳道查看请求、AI 回答、工具调用、工具返回和可见上下文，并可下钻到规范化事件与原始日志。
-
-进行中的任务会优先显示并实时更新。保持「跟随中」时，轨迹会随新事件平滑前进；手动查看历史位置后，页面保留当前位置并提示「查看更新」。旧日志如果没有记录结束事件，会标记为「未记录结束状态」，不会一直冒充进行中。
-
-任务轨迹只还原日志中可观测的事实，不展示或推断隐藏思维。完整说明见[观测与任务轨迹](docs/zh/guides/observe-production.md#查看一次任务)。
-
-## OMK 的闭环
-
-OMK 主要给 LLM 知识载体的作者 / 维护者用，帮他们做发布判断；它不是给被动安装 skill 的普通使用者用的。主流程刻意保持受控：
-
-```text
-改了一份 prompt / RAG / skill / agent 知识载体
-→ 先跑 omk doctor
-→ 用相同模型、相同评测用例跑 omk eval
-→ 看 report / Studio 里的证据
-→ 证据足够则 promote，证据不足则 evolve 候选版
-→ observe 真实使用，把缺口生成待复核评测草稿
-```
-
-第一价值是发布前的 `doctor → eval` 判断。长期价值是闭环：`observe` 暴露真实使用里的知识缺口，`sample --from-traces` 先生成待人工复核的评测用例草稿，复核后的草稿再沉淀为固定评测样本，下一次 `eval` 就更难被偶然样本骗过。
-
-## 在 AI Coding Agent 中使用
-
-安装 omk 官方 Agent Skill 后，可以直接用自然语言让 coding agent 跑 omk 工作流：
+## 在 Agent 中使用
 
 ```bash
 omk install omk-agent-skill
 ```
 
-默认只会安装到本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。
+安装后，可以对 coding agent 说：“用 omk 比较这两版 skill。”安装目标与使用方法见[快速上手](docs/zh/quickstart-skill-eval.md#在-agent-中使用)。DeepSeek Harness 用户可直接使用[宿主插件](docs/zh/reference/executors.md#deepseek-harness优先使用宿主插件)，复用当前 profile。
 
-### 在 Claude Code 中使用
+[MCP 集成](docs/zh/guides/mcp-integration.md)提供用户授权的主动知识反馈入口。它仅记录提交到工具边界的部分证据，不自动监听完整对话。
 
-当 `omk` skill 已在 Claude Code 中可用时，可以直接这样调用：
+## 如何使用证据
 
-```bash
-/omk eval              # 评测当前项目的知识载体
-/omk evolve            # 多轮自动迭代改进 skill
-/omk sample            # 生成或补齐评测用例
-```
+`doctor` 检查知识载体，`eval` 做受控比较，`studio` 展示结果与原始证据。证据满足条件后可以 `promote` 接受版本，或用 `evolve` 生成候选；`observe` 暴露的缺口可转成待复核用例，再进入下一轮评测。
 
-这些 slash command 是自然语言入口 —— agent 会从对话上下文里推断要操作哪个 skill。也可以直接说「帮我评测 v1 和 v2 的差异」、「改进一下这个知识载体」，omk 会自动理解意图并调用对应命令。
+结论受用例、评分准则和执行环境约束。观测信号不等于因果结论，生成的样本也不能直接充当独立发布验证集。原理与限制见[统计严谨性](docs/zh/explanation/statistical-rigor.md)和[三阶段工作流](docs/zh/explanation/three-stage-workflow.md)。
 
-### 在 Codex 中使用
-
-Codex 默认不支持 `/omk ...` 这种 Claude Code 风格的 slash command。直接让 agent 执行 `omk` CLI 即可；在 Codex 任务里，omk 会自动选择 Codex runtime 和本机配置的模型：
-
-```bash
-omk eval
-omk evolve skills/my-skill.md   # 一键:体检 →(无用例则自动生成)→ 自迭代
-omk sample skills/my-skill.md
-```
-
-也可以直接用自然语言描述目标，例如「比较 v1 和 v2 的评测差异」、「为这个 skill 生成评测用例」。
-
-`eval`、`doctor`、`sample`、`evolve` 和 observe 的 LLM 增强复盘共用同一套 runtime 解析。Codex 被选中后，默认评委沿用被测 Codex 模型，不会回落到 `claude:haiku`。
-
-> `omk evolve` 是一键闭环：默认先跑 doctor 体检，目标 skill 没有评测用例时会自动生成一批，再进入多轮自迭代。全新 skill 直接 `omk evolve skills/foo.md` 即可。
-
-## 为什么需要这个工具
-
-知识工程带来的是一个版本治理问题：prompt、RAG 配方、skill、agent、workflow 都会改变模型行为，但这些改动未必体现在应用代码里。当有人追问「v2 能不能发、为什么」时，回答更顺眼、体感更好，远远不够。
-
-omk 把知识载体当作被测变量：**相同模型、相同评测用例，只改变知识载体。** 这样得到的对比才可解释、可复跑，也适合进入 CI 或发布评审。
-
-## 为什么选 omk
-
-| | omk | promptfoo | DeepEval | LangSmith |
-|--|--|--|--|--|
-| Bootstrap 置信区间 | ✓ 默认 | ✗ | ✗ | ✗ |
-| Krippendorff α（评委 ↔ 人工） | ✓ 加 gold 即开 | ✗ | ✗ | ✗ |
-| 长度去偏的评委 prompt | ✓ 默认 | ✗ | ✗ | ✗ |
-| 缺失证据失败关闭 | ✓ | ✗ | ✗ | ✗ |
-| 三层独立评分 | ✓ | ✗ | 部分 | ✗ |
-| 用例隔离(construct validity) | ✓ 默认 | ✗ | ✗ | ✗ |
-| 原生 Agent Skill | ✓ | ✗ | ✗ | ✗ |
-| 托管 SaaS 看板 | ✗ | ✗ | ✓ | ✓ |
-
-omk 的护城河是 **default-on 安全网**：Bootstrap CI 与长度去偏属于正常测量行为，缺失证据失败关闭，显式 Gold comparison 提供评委 ↔ 人工 alpha 校准。需要 SaaS 看板？选 LangSmith。要快速 prompt 迭代不要统计层？选 promptfoo。**要发到生产且会被问「为什么应该相信这个数字」？选 omk。**
-
-RAG 专项评测请看 RAGAS（独立 niche，跟 omk 互补）。完整对比（7 个工具 × 25+ 维度）： [docs/zh/reference/comparison.md](docs/zh/reference/comparison.md)
-
-## 特性
-
-| 特性 | 说明 |
-|------|------|
-| **Core 发布决定** | 六种判定 + 稳定 reason code + exit code 路由；Studio 投影同一份经过认证的 Decision |
-| **五层 evidence graph** | Assertion / LLM / Judge / Dimension / Composite 保持独立，coverage、成本、状态与 lineage 与分数正交 |
-| **多执行器** | 支持 Claude CLI / Claude SDK / Codex CLI / Codex SDK / DeepSeek Harness / OpenAI / Anthropic API 及自定义命令 |
-| **30+ 种断言** | 包含子串、正则、JSON Schema、ROUGE/BLEU/Levenshtein 相似度、Agent 工具调用、语义相似度、自定义函数等 |
-| **统计严谨性** | Bootstrap comparison family、长度去偏、缺失证据失败关闭与显式 Gold agreement 校准。[详情 →](docs/zh/explanation/statistical-rigor.md) |
-| **RAG metrics** | `faithfulness` / `answer_relevancy` / `context_recall` 三 metric — 反幻觉 + 切题度 + context 覆盖 |
-| **LLM 健康度审计** | `omk doctor` 给 7 个内置维度独立打分；重复采样（`--repeat`）+ k/n 共识归并 |
-| **线上 session 观测** | 将 Codex、Claude Code、OpenClaw 与 markdown 日志统一为 source-neutral Trace IR，测量各 skill 的执行结果、耗时、token 使用和知识缺口信号 |
-| **MCP 主动知识反馈（实验性）** | 由 MCP 客户端主动调用工具，把用户明确授权的 knowledge 反馈写入 Observation Inbox；不监听对话，并固定标记 `coverage: partial` |
-| **知识缺口识别** | 严重度加权的信号量化风险敞口，不宣称完备性 |
-| **用例隔离 (construct validity)** | `--strict-baseline`（默认开）三堵 baseline 拿到被测 skill 的污染路径 |
-| **Git / 远端源** | install / eval 支持本地 git ref 或远端 git URL（`--git-url`）；目录-skill 在内容寻址**隔离副本**里执行，`references/` 资产是真实测量输入，不只是 `SKILL.md` |
-| **证据门控管理** | `omk install` 登记受管记录；`omk eval` 按内容指纹自动写入证据，把 skill 从 `installed` 推到 `measurable`；`omk list` 查看各受管 skill 的状态（installed / measurable / promoted / stale）；`omk promote` 在证据过门禁（默认仅 PROGRESS）后把该版本接受为当前版本；`omk rollback` 撤销这次接受，让 skill 回到 `measurable`。[规范 →](docs/zh/specs/evidence-gated-management.md) |
-| **用例设计科学性** | Sample schema 加 `capability` / `difficulty` / `construct` / `provenance` 元数据字段（HF Dataset Cards 风），studio 输出 coverage 分桶 + `rubric_clarity_low` / `capability_thin` issue。[docs/zh/specs/sample-design-spec.md](docs/zh/specs/sample-design-spec.md) |
-| **多评委 ensemble** | `--judge-models claude:opus,openai-api:gpt-4o` 跨厂商评分 + agreement 度量 |
-| **多轮方差分析** | `--repeat N` 发布相互独立的 Core run 与 Evaluation Series 方差分析 |
-| **MCP URL 获取** | 通过 MCP Server 获取私有文档 URL 内容（SSO 保护的知识库等） |
-| **自动分析** | 检测低区分度断言、均匀分数、全通过/全失败、高成本用例 |
-| **可追溯性** | 报告含 CLI 版本、Node 版本、知识载体版本指纹、judge prompt hash |
-| **中英视图** | 通过报告 URL 选择中英文的本地 Studio 视图 |
-
-### 在已有 DeepSeek Harness 中运行
-
-OMK 可以作为 DSH bundle 安装到现有 profile，直接复用其模型、凭证、工具与 sandbox：
-
-```bash
-dsh plugin --profile web add oh-my-knowledge
-dsh --profile web
-```
-
-进入 DSH 后：
-
-- `/omk eval eval.yaml`：每条用例使用独立 DSH session，报告仍由 OMK 生成；
-- `/omk observe`：列出最近已结束的 session；
-- `/omk observe <session-id>`：只读摄取一致快照，并返回 Studio 任务轨迹链接。
-
-observe 直接使用 profile 的 `sessionPersistence`，无需导出或定位 JSONL／SQLite 文件；首版不实时跟随正在写入的 session。详见[执行器文档](docs/zh/reference/executors.md#deepseek-harness优先使用宿主插件)与[观测指南](docs/zh/guides/observe-production.md#在-deepseek-harness-中查看任务轨迹)。
-
-### 连接 MCP 客户端（实验性）
-
-> **定位：OMK MCP 是主动知识反馈接口，不是对话监听器。** 仅靠 OMK MCP 无法自动监听或订阅 Codex、ChatGPT 等客户端的完整对话。只有客户端、模型或 component 主动调用 `save_observation` 并提交授权内容后，OMK 才能收到并保存这条反馈。Agent Skill 可以自动识别潜在反馈时机，但识别结果仍须经过用户确认和一次显式 MCP 工具调用。
-
-`omk-mcp` 提供与客户端无关的 stdio MCP Server。Codex 等本地 MCP 客户端可直接启动它，私有宿主也可组合导出的 Streamable HTTP adapter。客户端只在用户明确要求记录时调用 `save_observation`，把反馈和可选证据追加到 `.omk/observe/inbox/captures/`，并可渲染对话内 MCP Apps 复核卡片，供人工确认问题和生成 regression sample 草稿。
-
-在 Codex 中可以显式调用 OMK Skill 快捷提交当前知识反馈：
-
-```text
-$omk feedback
-```
-
-这次显式调用本身视为保存确认。Agent 会从当前可见对话中选择最近一个明确问题，以 `confirmedByUser: true` 调用 `save_observation`；候选不明确时会先追问。该快捷入口不是 CLI 命令，也不会自动复核、生成 sample 或写入 gold set。
-
-```bash
-omk-mcp
-```
-
-每条记录都固定携带 `coverageStatus: partial`：已观测的是 OMK 工具边界、用户提交的反馈及可选证据；未观测的是完整对话、其他工具调用和隐藏推理。需要持续监听时，必须由有权访问事件流的宿主系统主动转交事件，这属于宿主集成能力，不属于 OMK MCP 自身能力。对话 ID、turn ID 与幂等键只用于生成哈希，不会原样落盘。私有宿主的 Streamable HTTP 组合方式见[组合 OMK MCP 集成](docs/zh/guides/mcp-integration.md)。
-
-### 本地存储
-
-项目数据采用领域化的 `.omk/` v2 布局：持久证据进入 `eval/`、`doctor/`、`observe/`，治理记录进入 `governance/`，备份保持可恢复，只有可重建工作进入 `state/`。机器工具、隧道、缓存和物化副本只能进入 `~/.oh-my-knowledge/state/`，不得写进项目。本期不读取、也不迁移旧存储布局。
+项目证据保存在 `.omk/`，机器级状态位于 `~/.oh-my-knowledge/`。当前版本不读取或迁移旧存储布局；升级前备份，按[迁移指南](docs/zh/guides/v1-preview-migration.md)重新建立证据。
 
 ## 文档
 
-完整文档已发布到 **[oh-my-knowledge.pages.dev/zh](https://oh-my-knowledge.pages.dev/zh/)** —— 可搜索，可切换英文。重点页面：
-
-- **[工作原理](docs/zh/explanation/architecture.md)** —— 输入编译、sealed Core 执行、分析、持久化与 Studio projection
-- **[评测用例格式](docs/zh/reference/eval-sample-format.md)** —— sample schema、评分公式、30+ 断言类型、自定义 JS 断言
-- **[CLI 参考](docs/zh/reference/cli.md)** —— 顶层命令的 bash 示例和 flag 表
-- **[迁移到 1.0 预览版](docs/zh/guides/v1-preview-migration.md)** —— 从 `0.54` 升级时的安装渠道、存储重建、用例协议、CLI 自动化与嵌入式 API 变化
-- **[Evaluation Core 生产切换](docs/zh/guides/eval-core-cutover.md)** —— `BREAKING-SCHEMA` 存储、resume、Studio、Gold、受管证据与 evolve 迁移
-- **[在服务中嵌入 OMK](docs/zh/guides/eval-runtime.md)** —— 选择评分方法、接入 Node.js 服务、解读分数与失败原因
-- **[存储布局 v2](docs/zh/specs/storage-layout-spec.md)** —— 项目／全局领域、迁移兼容与 Git 策略
-- **[执行器](docs/zh/reference/executors.md)** & **[知识载体布局](docs/zh/reference/artifact-layout.md)** —— 内置 / 自定义执行器；variant 如何解析为 artifact + runtime context
-- **[操作指南](docs/zh/guides/agent-eval.md)** —— [评测 agent](docs/zh/guides/agent-eval.md)（项目 runtime context）与[使用非 Claude 模型](docs/zh/guides/non-claude-models.md)（GLM / 通义 / DeepSeek / Moonshot / Ollama）
-- **[观测与任务轨迹](docs/zh/guides/observe-production.md)** —— 浏览本机 Codex 对话，下钻一次任务，并实时跟随可观测执行过程
-- **[快速上手](docs/zh/quickstart-skill-eval.md)** —— 第一次跑评测的 5 分钟教程
-- **[示例画廊](https://github.com/lizhiyao/oh-my-knowledge/tree/main/examples)** —— 仓库里一组可直接跑的示例，按由简到全排成上手路径
-- **[用例设计规范](docs/zh/specs/sample-design-spec.md)** —— capability / construct / provenance 元数据；行业 gap 映射
-- **[统计严谨性](docs/zh/explanation/statistical-rigor.md)** —— 为什么 Bootstrap CI / Gold agreement / 长度去偏 / evidence coverage 重要
-- **[7 工具对比](docs/zh/reference/comparison.md)** —— promptfoo / DeepEval / RAGAS / OpenAI Evals / LangSmith / lm-eval-harness / inspect-ai 等 25+ 维度横评
-- **[证据门控管理](docs/zh/specs/evidence-gated-management.md)** —— 受管记录、生命周期状态（installed / measurable / promoted / stale）、install → eval → measurable → promote → rollback
+[完整文档与导航](docs/zh/README.md) · [在线文档](https://oh-my-knowledge.pages.dev/zh/) · [CLI 参考](docs/zh/reference/cli.md) · [用例格式](docs/zh/reference/eval-sample-format.md) · [执行器](docs/zh/reference/executors.md) · [OMK 如何理解知识](docs/zh/explanation/knowledge.md)
 
 ## 环境变量
 

--- a/docs/.vitepress/theme/landing-body.en.html
+++ b/docs/.vitepress/theme/landing-body.en.html
@@ -1,29 +1,13 @@
-
-
-<!-- ===================== HERO ===================== -->
 <header class="hero">
   <div class="wrap">
-    <span class="tag"><span class="dot"></span> <b>OMK</b> · Knowledge evaluation for AI apps</span>
-
+    <span class="tag"><span class="dot"></span> <b>OMK</b> · 1.0 Beta iteration continues</span>
     <h1>Observe. Measure.<br/><span class="em">Know.</span></h1>
-
-    <p class="sub"><b>OMK makes every knowledge change in your AI application evidence-backed.</b><br/>Observe real-world performance, measure version differences, and determine whether the change is effective and the version is ready to ship.<span class="hero-workflow">Use <b>doctor → eval → studio</b> before shipping, then close the loop with <b>observe → sample → evolve</b>.</span></p>
-
+    <p class="sub"><b>Make knowledge changes in your AI application evidence-backed.</b><br/>Compare prompt, RAG, skill, and agent versions, inspect evidence, and find knowledge gaps in real tasks.</p>
     <div class="cta">
-      <span class="cmd"><span><span class="pfx">$</span> npm i -g oh-my-knowledge</span><span class="copy" onclick="omkCopy('npm i -g oh-my-knowledge', this)">Copy ⧉</span></span>
-      <a class="lnk" href="/quickstart-skill-eval">CLI quickstart <span class="ar">→</span></a>
-      <a class="lnk" href="/guides/eval-runtime">Use in a Node.js service <span class="ar">→</span></a>
-      <a class="lnk" href="/explanation/knowledge">How OMK understands knowledge <span class="ar">→</span></a>
+      <span class="cmd"><span><span class="pfx">$</span> npm i -g oh-my-knowledge@next</span><span class="copy" onclick="omkCopy('npm i -g oh-my-knowledge@next', this)">Copy ⧉</span></span>
+      <a class="lnk" href="/quickstart-skill-eval">CLI evaluation <span class="ar">→</span></a><a class="lnk" href="/guides/eval-runtime">Node.js integration <span class="ar">→</span></a><a class="lnk" href="/guides/observe-production">Inspect task trajectories <span class="ar">→</span></a>
     </div>
-
-    <div class="trust">
-      <span><b>npm</b> weekly <span id="npmDl">···</span></span><span class="sep"></span>
-      <span><a href="https://github.com/lizhiyao/oh-my-knowledge/actions/workflows/ci.yml" target="_blank" rel="noopener"><b>CI</b> passing</a></span><span class="sep"></span>
-      <span><b>MIT</b></span><span class="sep"></span>
-      <span>Node ≥ 22</span><span class="sep"></span>
-      <span>Same model · same samples · only the artifact changes</span>
-    </div>
-
+    <div class="trust"><span>Node ≥ 22</span><span class="sep"></span><span>MIT</span><span class="sep"></span><span>Same model · same cases · only the artifact changes</span></div>
     <figure class="flow-hero">
       <picture>
         <source media="(prefers-reduced-motion: reduce) and (max-width: 820px)" srcset="/omk-knowledge-flow-en-mobile.svg" type="image/svg+xml" />
@@ -31,265 +15,63 @@
         <source media="(max-width: 820px)" srcset="/omk-knowledge-flow-en-mobile.svg" type="image/svg+xml" />
         <img src="/omk-knowledge-flow-en-animated.gif" alt="omk knowledge artifact evaluation loop: artifact, controlled eval, evidence report, release or iterate, production observation, observed gaps, sample upgrade" />
       </picture>
-      <figcaption>One controlled release loop, one production-feedback loop, and no hidden model change between versions.</figcaption>
+      <figcaption>Compare versions under fixed conditions, then use real-world feedback to improve the next evaluation.</figcaption>
     </figure>
 
-    <!-- interactive stage -->
-    <template id="legacy-stage">
-      <div class="stage-head">
-        <span class="dots"><i style="background:#FF5F57"></i><i style="background:#FEBC2E"></i><i style="background:#28C840"></i></span>
-        <span class="title">omk — <b id="stTitle">eval</b> · knowledge-carrier evaluation lifecycle</span>
-        <span class="live">live</span>
-      </div>
-
-      <!-- lifecycle switch -->
-      <div class="rail-wrap">
-        <div class="rail" role="tablist">
-          <span class="thumb" id="thumb"><span class="thumb-g"></span></span>
-          <span class="rail-arrow a1" aria-hidden="true">›</span>
-          <span class="rail-arrow a2" aria-hidden="true">›</span>
-          <button class="seg" role="tab" aria-selected="false" data-k="doctor" data-i="0">
-            <span class="ph">pre-ship</span><span class="nm"><span class="ic">🩺</span>doctor</span>
-          </button>
-          <button class="seg" role="tab" aria-selected="true" data-k="eval" data-i="1">
-            <span class="ph">on release</span><span class="nm"><span class="ic">📊</span>eval</span>
-          </button>
-          <button class="seg" role="tab" aria-selected="false" data-k="observe" data-i="2">
-            <span class="ph">in prod</span><span class="nm"><span class="ic">🔭</span>observe</span>
-          </button>
-        </div>
-        <p class="rail-cap" id="railCap"></p>
-      </div>
-
-      <div class="panels">
-        <!-- ===== EVAL panel ===== -->
-        <div class="panel on" data-p="eval">
-          <div class="panel-q"><span class="badge">eval</span> Controlled A/B: same model, same cases, only the knowledge changes — 95% CI on the composite-score lift</div>
-          <div class="panel-body">
-          <svg viewBox="0 0 680 200" width="100%" style="max-width:660px;display:block;margin:2px auto 0" role="img" aria-label="Confidence-interval forest plot of composite-score lift">
-            <!-- grid + ticks -->
-            <g class="svg-muted" font-family="JetBrains Mono" font-size="11">
-              <line class="svg-axis" x1="154" y1="34" x2="154" y2="150" stroke-width="1.5"/>
-              <text x="150" y="170">0%</text>
-              <line class="svg-grid" x1="303" y1="34" x2="303" y2="150"/>
-              <text x="296" y="170">+10%</text>
-              <line class="svg-grid" x1="451" y1="34" x2="451" y2="150"/>
-              <text x="444" y="170">+20%</text>
-              <line class="svg-grid" x1="600" y1="34" x2="600" y2="150"/>
-              <text x="593" y="170">+30%</text>
-            </g>
-            <!-- significance threshold note -->
-            <text class="svg-red" x="158" y="48" font-family="Inter" font-size="11" font-weight="600">Not significant (CI crosses 0)</text>
-            <!-- CI bar -->
-            <g>
-              <line class="svg-teal-s" x1="320" y1="96" x2="532" y2="96" stroke-width="3" stroke-linecap="round"/>
-              <line class="svg-teal-s" x1="320" y1="84" x2="320" y2="108" stroke-width="3" stroke-linecap="round"/>
-              <line class="svg-teal-s" x1="532" y1="84" x2="532" y2="108" stroke-width="3" stroke-linecap="round"/>
-              <circle class="svg-teal svg-halo" cx="426" cy="96" r="9" stroke-width="2.5"/>
-              <text class="svg-ink" x="426" y="78" text-anchor="middle" font-family="JetBrains Mono" font-size="14" font-weight="600">+18.3%</text>
-              <text class="svg-teal" x="320" y="128" text-anchor="middle" font-family="JetBrains Mono" font-size="11">+11.2</text>
-              <text class="svg-teal" x="532" y="128" text-anchor="middle" font-family="JetBrains Mono" font-size="11">+25.4</text>
-            </g>
-          </svg>
-          <div class="verdict">
-            <span class="check">✓</span>
-            <span class="vt">v2 clearly beats v1 — ship it</span>
-            <span class="vm"><span>CI[+11.2, +25.4]</span><span>α = 0.81</span><span>length-debiased</span></span>
-          </div>
-          </div>
-        </div>
-
-        <!-- ===== DOCTOR panel ===== -->
-        <div class="panel" data-p="doctor">
-          <div class="panel-q"><span class="badge">doctor</span> Pre-ship checkup: 7 built-in dimensions scored independently (static rules + LLM audit, offline-capable)</div>
-          <div class="panel-body">
-          <div class="dbars">
-            <div class="dbar"><span class="nm">Triggers</span><span class="track"><span class="fill fill-ok" style="width:94%"></span></span><span class="lv lv-ok">Good</span></div>
-            <div class="dbar"><span class="nm">Clarity</span><span class="track"><span class="fill fill-ok" style="width:90%"></span></span><span class="lv lv-ok">Good</span></div>
-            <div class="dbar"><span class="nm">Precision</span><span class="track"><span class="fill fill-sub" style="width:62%"></span></span><span class="lv lv-sub">Fair</span></div>
-            <div class="dbar"><span class="nm">Deps</span><span class="track"><span class="fill fill-ok" style="width:88%"></span></span><span class="lv lv-ok">Good</span></div>
-            <div class="dbar"><span class="nm">Tools</span><span class="track"><span class="fill fill-ok" style="width:85%"></span></span><span class="lv lv-ok">Good</span></div>
-            <div class="dbar"><span class="nm">Safety</span><span class="track"><span class="fill fill-sub" style="width:58%"></span></span><span class="lv lv-sub">Fair</span></div>
-            <div class="dbar"><span class="nm">Examples</span><span class="track"><span class="fill fill-ok" style="width:91%"></span></span><span class="lv lv-ok">Good</span></div>
-          </div>
-          <span class="summary-pill">🩺 Health: Good · <span class="n">5 healthy / 2 at risk</span> · 3 suggestions</span>
-          </div>
-        </div>
-
-        <!-- ===== OBSERVE panel ===== -->
-        <div class="panel" data-p="observe">
-          <div class="panel-q"><span class="badge">observe</span> In-prod observation: parse Claude Code sessions to quantify failure rate, cost, and knowledge gaps</div>
-          <div class="panel-body">
-          <div class="ometrics">
-            <div class="ocard"><div class="ok">Failure rate</div><div class="ov">4.2%</div><div class="od up">▼ −1.6pt vs last week</div></div>
-            <div class="ocard"><div class="ok">P50 latency</div><div class="ov">18.4s</div><div class="od up">▼ −2.1s</div></div>
-            <div class="ocard"><div class="ok">Cost / session</div><div class="ov">$0.012</div><div class="od down">▲ +$0.003</div></div>
-          </div>
-          <div class="gap">
-            <span class="gi">⚠</span>
-            <span class="gx"><b>Knowledge-gap signal:</b> "missing environment probe upfront" recurs across 12 sessions — ranked #1 by severity weight</span>
-            <span class="gn">×12</span>
-          </div>
-          </div>
-        </div>
-      </div>
-    </template>
   </div>
 </header>
-
-<!-- ===================== CAPABILITIES ===================== -->
 <section class="band" id="caps">
   <div class="wrap">
-    <div class="sec-head">
-      <span class="eyebrow">Observe · Measure · Know</span>
-      <h2>Observe real-world performance, measure version differences, determine what works and what can ship</h2>
-      <p class="lead">doctor, eval, studio, promote, observe, sample, and evolve are not isolated commands. Together they turn knowledge changes into evidence, and production gaps into reviewable drafts that can become the next fixed evaluation set.</p>
-    </div>
+    <div class="sec-head"><h2>Start with your task</h2><p class="lead">Choose one path; consult commands and design specs when needed.</p></div>
     <div class="cap-grid">
       <div class="cap d">
-        <div class="ic">D</div>
-        <h3>doctor <span class="when">pre-ship</span></h3>
-        <p>Is the artifact coherent enough to evaluate? doctor catches structural, dependency, safety, and measurability problems before an A/B run wastes tokens.</p>
-        <code class="cmd2">$ omk doctor my-skill --dimensions audit.yaml</code>
-        <ul><li>Triggers / docs / instructions / deps / tools / safety / examples</li><li>--repeat: parallel sampling + k/n consensus</li><li>Custom endpoint dimensions: call an API for deep review</li></ul>
+        <div class="ic">CLI</div><h3>Compare two skills</h3>
+        <p>Keep the model and cases fixed, then inspect version differences, intervals, and failed samples.</p><code class="cmd2">omk eval --control v1 --treatment v2</code>
+        <p><a class="lnk" href="/quickstart-skill-eval">Preview, then evaluate <span class="ar">→</span></a></p>
       </div>
       <div class="cap e">
-        <div class="ic">E</div>
-        <h3>eval <span class="when">on release</span></h3>
-        <p>Is v2 really better than v1? eval fixes the model and samples, changes only the artifact, then reports a verdict with confidence intervals and failed cases.</p>
-        <code class="cmd2">$ omk eval --control v1 --treatment v2</code>
-        <ul><li>Bootstrap CI / length-debias / saturation curves on by default</li><li>Krippendorff α: judge↔human agreement on a gold set</li><li>Blind A/B · judge ensemble · multi-run variance</li></ul>
+        <div class="ic">API</div><h3>Connect your service</h3>
+        <p>Start with an example without model credentials, then configure execution and scoring for your Node.js service.</p><code class="cmd2">import { evaluate } from &#x27;oh-my-knowledge&#x27;</code>
+        <p><a class="lnk" href="/guides/eval-runtime">Read the integration guide <span class="ar">→</span></a></p>
       </div>
       <div class="cap o">
-        <div class="ic">O</div>
-        <h3>observe <span class="when">in production</span></h3>
-        <p>What did real use expose? observe turns session logs into knowledge-gap signals; from-traces drafts samples first, and reviewed drafts can become fixed eval samples.</p>
-        <code class="cmd2">$ omk observe ~/.claude/sessions</code>
-        <ul><li>Failure rate / latency / cost broken down per artifact</li><li>Knowledge-gap inbox for review and triage</li><li><code>omk sample --from-traces</code> drafts samples for review</li></ul>
+        <div class="ic">Tasks</div><h3>Inspect a real task</h3>
+        <p>Browse local Codex conversations and task trajectories to reconstruct observable requests, tool calls, and results.</p><code class="cmd2">omk studio</code>
+        <p><a class="lnk" href="/guides/observe-production">Read the observation guide <span class="ar">→</span></a></p>
       </div>
     </div>
   </div>
 </section>
-
-<!-- ===================== MOAT ===================== -->
 <section class="band alt" id="moat">
   <div class="wrap">
-    <div class="sec-head" style="text-align:center">
-      <span class="eyebrow">Moat · measurement credibility</span>
-      <h2 style="max-width:780px;margin:12px auto 0">Rigor is the <span style="color:var(--blue)">foundation</span>, not an add-on</h2>
-      <p class="lead" style="margin:16px auto 0">Five often-overlooked distortions decide whether a comparison is trustworthy. omk builds every defense into the foundation, so you don't have to enable them one by one.</p>
-    </div>
+    <div class="sec-head"><h2>Assess the evidence</h2><p class="lead">Check the evidence and its scope before making a version decision.</p></div>
     <div class="moat-list">
-      <div class="mrow2">
-        <span class="no">01</span>
-        <div class="fail"><div class="t">A point estimate mistakes sampling noise for a real gain</div></div>
-        <div class="fix2"><div class="name">Bootstrap confidence intervals <span class="badge2">built-in</span></div><div class="d">Reports an interval, not a point — significance is read off directly.</div></div>
-      </div>
-      <div class="mrow2">
-        <span class="no">02</span>
-        <div class="fail"><div class="t">A composite average hides a regression in a single dimension</div></div>
-        <div class="fix2"><div class="name">Three-layer independent scoring · pass-all gate <span class="badge2">built-in</span></div><div class="d">Fail any of fact / behavior / judge and it doesn't pass.</div></div>
-      </div>
-      <div class="mrow2">
-        <span class="no">03</span>
-        <div class="fail"><div class="t">The control group reads the very carrier under test</div><div class="s">construct validity breaks down</div></div>
-        <div class="fix2"><div class="name">strict-baseline isolation <span class="badge2">built-in</span></div><div class="d">Closes three leaks: skill self-discovery, the Skill tool, and the cwd bypass.</div></div>
-      </div>
-      <div class="mrow2">
-        <span class="no">04</span>
-        <div class="fail"><div class="t">Judges systematically prefer longer answers</div></div>
-        <div class="fix2"><div class="name">Length-debiased judging <span class="badge2">built-in</span></div><div class="d">Scoring removes the length covariate — verbosity no longer buys points.</div></div>
-      </div>
-      <div class="mrow2">
-        <span class="no">05</span>
-        <div class="fail"><div class="t">The reliability of the judge's own scoring is unmeasurable</div></div>
-        <div class="fix2"><div class="name">Krippendorff α <span class="badge2">on with a gold set</span></div><div class="d">Anchored on human labels, it quantifies judge↔human agreement.</div></div>
-      </div>
+      <div class="mrow2"><span class="no">01</span><div class="fail"><div class="t">How large is the difference?</div></div><div class="fix2"><div class="name">Inspect differences and intervals</div><div class="d">Look beyond a point estimate at sample size, comparison families, and uncertainty.</div></div></div>
+      <div class="mrow2"><span class="no">02</span><div class="fail"><div class="t">What supports the score?</div></div><div class="fix2"><div class="name">Inspect cases and scoring evidence</div><div class="d">Check criteria, coverage, and failures. Gold comparison can assess human/judge agreement.</div></div></div>
+      <div class="mrow2"><span class="no">03</span><div class="fail"><div class="t">Where does the conclusion apply?</div></div><div class="fix2"><div class="name">Keep measurement and observation distinct</div><div class="d">Conclusions depend on cases and conditions. Observation signals are not causal conclusions; generated cases need human review.</div></div></div>
     </div>
-    <p class="moat-foot">Peer tools typically cover only one or two of these. <b>omk's choice: build credibility into the foundation rather than leave it optional.</b></p>
+    <p class="moat-foot"><a class="lnk" href="/explanation/statistical-rigor">Statistical methods and limits <span class="ar">→</span></a></p>
+    <p class="cmp-foot" id="cmp">Choosing a tool? <a class="lnk" href="/reference/comparison">Compare tools and their scope <span class="ar">→</span></a></p>
   </div>
 </section>
-
-<!-- ===================== COMPARISON ===================== -->
-<section class="band" id="cmp">
-  <div class="wrap">
-    <div class="sec-head">
-      <span class="eyebrow">Tool comparison</span>
-      <h2>A side-by-side under one set of criteria</h2>
-      <p class="lead">Criteria come from common LLMOps selection axes (metric library / judge / CI / observability / collaboration) plus measurement validity & reliability — not rules tailored to omk. On several axes omk doesn't win, and we mark that honestly.</p>
-    </div>
-    <div class="cmp-wrap">
-    <table class="cmp">
-      <thead><tr><th>Capability</th><th class="omk-col">omk</th><th>promptfoo</th><th>DeepEval</th><th>LangSmith</th></tr></thead>
-      <tbody>
-        <tr class="cat"><td colspan="5">Measurement credibility · validity / reliability</td></tr>
-        <tr><td>Statistical significance (CI / tests)</td><td class="omk-col y">✓ <small>Bootstrap</small></td><td class="n">—</td><td class="n">—</td><td class="n">—</td></tr>
-        <tr><td>Judge ↔ human reliability (agreement)</td><td class="omk-col y">✓ <small>Krippendorff α</small></td><td class="n">—</td><td class="n">—</td><td class="n">—</td></tr>
-        <tr><td>Evaluation bias control (length-debias)</td><td class="omk-col y">✓ <small>default</small></td><td class="n">—</td><td class="n">—</td><td class="n">—</td></tr>
-
-        <tr class="cat"><td colspan="5">Evaluation capability</td></tr>
-        <tr><td>Assertion / metric library breadth</td><td class="omk-col y">✓ <small>30+</small></td><td class="y">✓</td><td class="y">✓</td><td class="p">◑</td></tr>
-        <tr><td>RAG-specific metrics</td><td class="omk-col p">◑ <small>3</small></td><td class="p">◑</td><td class="y">✓ <small>rich</small></td><td class="p">◑</td></tr>
-        <tr><td>LLM-as-judge</td><td class="y omk-col">✓</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
-
-        <tr class="cat"><td colspan="5">Engineering & collaboration</td></tr>
-        <tr><td>CI/CD integration (exit-code routing)</td><td class="omk-col y">✓</td><td class="y">✓</td><td class="y">✓</td><td class="p">◑</td></tr>
-        <tr><td>Onboarding speed / config simplicity</td><td class="omk-col p">◑</td><td class="y">✓ <small>very fast</small></td><td class="p">◑</td><td class="p">◑</td></tr>
-        <tr><td>Experiment tracking / tracing</td><td class="omk-col n">—</td><td class="n">—</td><td class="p">◑</td><td class="y">✓ <small>strong</small></td></tr>
-        <tr><td>Hosted SaaS dashboard / team collab</td><td class="omk-col n">—</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td></tr>
-
-        <tr class="cat"><td colspan="5">Ecosystem & integration</td></tr>
-        <tr><td>Community size (GitHub stars, 2026-04)</td><td class="omk-col p">nascent</td><td class="y">9k+</td><td class="y">12k+</td><td class="p">commercial</td></tr>
-        <tr><td>Native Claude Code skill</td><td class="omk-col y">✓</td><td class="n">—</td><td class="n">—</td><td class="n">—</td></tr>
-      </tbody>
-    </table>
-    </div>
-    <div class="cmp-legend"><span><b class="y" style="color:var(--teal)">✓</b> Native</span><span><b class="p" style="color:var(--amber)">◑</b> Partial / needs config</span><span><b style="color:var(--n-dash)">—</b> Not supported</span></div>
-    <p class="cmp-foot">Full comparison (8 tools × 30+ dimensions, incl. RAGAS / OpenAI Evals / lm-eval-harness / inspect-ai) is in the <a href="/reference/comparison" style="color:var(--blue);font-weight:600">comparison doc</a>, current as of 2026-04 — <b>spot something stale? send a PR</b>. Takeaway: no silver bullet — omk's tradeoff is "statistical credibility by default"; want a SaaS dashboard, pick LangSmith; want academic benchmarks, pick lm-eval-harness.</p>
-  </div>
-</section>
-
-<!-- ===================== AGENT ===================== -->
-<section class="band alt" id="agent">
+<section class="band" id="agent">
   <div class="wrap">
     <div class="agent">
       <div class="term">
         <div class="bar"><i style="background:#FF5F57"></i><i style="background:#FEBC2E"></i><i style="background:#28C840"></i></div>
-        <div class="body">
-          <div><span class="cm">$ omk install omk-agent-skill</span> <span class="gr"># one-time install</span></div>
-          <div class="gr">  ✓ Wrote to detected Claude Code / Codex</div>
-          <div style="margin-top:10px"><span class="cm">/omk eval</span> <span class="gr"># evaluate this project's artifact</span></div>
-          <div><span class="cm">/omk evolve</span> <span class="gr"># one shot: checkup → samples → self-iterate</span></div>
-          <div><span class="cm">/omk sample</span> <span class="gr"># generate or top up eval cases</span></div>
-          <div style="margin-top:10px" class="gr">&gt; <span class="wh">Compare v1 and v2 for me</span></div>
-          <div class="gr">  ↳ infer intent → omk eval --control v1 --treatment v2 …</div>
-        </div>
+        <div class="body"><div><span class="cm">$ omk install omk-agent-skill</span></div><div style="margin-top:10px" class="wh">Use omk to compare these two skills; preview the plan first.</div></div>
       </div>
-      <div class="copy">
-        <span class="eyebrow">Agent integration</span>
-        <h3>Use it right inside your coding agent</h3>
-        <p>One line — <code style="font-family:var(--mono);background:var(--blue-l);color:var(--blue-d);padding:2px 6px;border-radius:5px">omk install omk-agent-skill</code> — installs the official Agent Skill into the Claude Code / Codex it detects locally (<code style="font-family:var(--mono)">--to all</code> writes to all). After that, <code style="font-family:var(--mono);background:var(--blue-l);color:var(--blue-d);padding:2px 6px;border-radius:5px">/omk</code> works out of the box in Claude Code; in Codex and others, just run the <code style="font-family:var(--mono)">omk</code> CLI.</p>
-        <div class="nl">
-          <p class="nl-tip">No commands to memorize — state your goal in plain words, and the agent locates the skill from context and picks the right command.</p>
-          <div class="bubble-row">
-            <span class="who">You</span>
-            <div class="bubble">Make this skill more robust, then compare it against the last version</div>
-          </div>
-        </div>
-      </div>
+      <div class="copy"><h3>Let your agent run the workflow</h3><p>Install the OMK Skill, then describe your comparison in natural language. The quickstart covers installation targets, runtime setup, and execution.</p><a class="lnk" href="/quickstart-skill-eval">CLI evaluation <span class="ar">→</span></a></div>
     </div>
   </div>
 </section>
-
-<!-- ===================== FINAL CTA ===================== -->
-<section class="band" id="start">
+<section class="band alt" id="start">
   <div class="wrap">
-    <p class="punch">Before your next release, <span class="em">let the data speak first</span>.</p>
     <div class="final">
-      <span class="eyebrow">Run your first eval in 5 minutes</span>
-      <h2>From a bare number to a conclusion that holds up</h2>
-      <p class="lead" style="margin:14px auto 0">No files to touch — <code style="font-family:var(--mono)">omk init</code> scaffolds two skill versions and three cases, and <code style="font-family:var(--mono)">omk eval</code> produces an HTML report plus a one-line verdict in under 5 minutes.</p>
-      <span class="cmd"><span><span class="pfx">$</span> omk init demo &amp;&amp; cd demo &amp;&amp; omk eval</span><span class="copy" onclick="omkCopy('omk init demo && cd demo && omk eval', this)">Copy ⧉</span></span>
+      <h2>Run the demo, then use your own cases</h2><p class="lead" style="margin:14px auto 0">The demo provides two skills and three cases. UNDERPOWERED is expected with a small sample; a real evaluation calls the model.</p>
+      <span class="cmd"><span><span class="pfx">$</span> omk init demo</span><span class="copy" onclick="omkCopy('omk init demo', this)">Copy ⧉</span></span>
+      <p><a class="lnk" href="/quickstart-skill-eval">Continue the walkthrough <span class="ar">→</span></a> · <a class="lnk" href="/README">All documentation <span class="ar">→</span></a></p>
+      <p><a class="lnk" href="/guides/v1-preview-migration">Read the migration guide before upgrading <span class="ar">→</span></a></p>
     </div>
   </div>
 </section>

--- a/docs/.vitepress/theme/landing-body.html
+++ b/docs/.vitepress/theme/landing-body.html
@@ -1,29 +1,13 @@
-
-
-<!-- ===================== HERO ===================== -->
 <header class="hero">
   <div class="wrap">
-    <span class="tag"><span class="dot"></span> <b>OMK</b> · AI 应用的知识评测</span>
-
+    <span class="tag"><span class="dot"></span> <b>OMK</b> · 1.0 Beta 持续迭代</span>
     <h1>Observe. Measure.<br/><span class="em">Know.</span></h1>
-
-    <p class="sub"><b>OMK，让 AI 应用的知识改动有据可依。</b><br/>观测真实表现，量出版本差异，判断改动是否有效、版本能否发布。<span class="hero-workflow">发布前用 <b>doctor → eval → studio</b> 做判断，发布后用 <b>observe → sample → evolve</b> 闭环。</span></p>
-
+    <p class="sub"><b>让 AI 应用的知识改动有据可依。</b><br/>比较 prompt、RAG、skill 与 agent 的版本，查看证据，发现真实任务中的知识缺口。</p>
     <div class="cta">
-      <span class="cmd"><span><span class="pfx">$</span> npm i -g oh-my-knowledge</span><span class="copy" onclick="omkCopy('npm i -g oh-my-knowledge', this)">复制 ⧉</span></span>
-      <a class="lnk" href="/zh/quickstart-skill-eval">命令行上手 <span class="ar">→</span></a>
-      <a class="lnk" href="/zh/guides/eval-runtime">在 Node.js 服务中使用 <span class="ar">→</span></a>
-      <a class="lnk" href="/zh/explanation/knowledge">OMK 如何理解知识 <span class="ar">→</span></a>
+      <span class="cmd"><span><span class="pfx">$</span> npm i -g oh-my-knowledge@next</span><span class="copy" onclick="omkCopy('npm i -g oh-my-knowledge@next', this)">复制 ⧉</span></span>
+      <a class="lnk" href="/zh/quickstart-skill-eval">命令行评测 <span class="ar">→</span></a><a class="lnk" href="/zh/guides/eval-runtime">Node.js 服务接入 <span class="ar">→</span></a><a class="lnk" href="/zh/guides/observe-production">查看任务轨迹 <span class="ar">→</span></a>
     </div>
-
-    <div class="trust">
-      <span><b>npm</b> 周下载 <span id="npmDl">···</span></span><span class="sep"></span>
-      <span><a href="https://github.com/lizhiyao/oh-my-knowledge/actions/workflows/ci.yml" target="_blank" rel="noopener"><b>CI</b> passing</a></span><span class="sep"></span>
-      <span><b>MIT</b></span><span class="sep"></span>
-      <span>Node ≥ 22</span><span class="sep"></span>
-      <span>相同模型 · 相同评测用例 · 只改知识载体</span>
-    </div>
-
+    <div class="trust"><span>Node ≥ 22</span><span class="sep"></span><span>MIT</span><span class="sep"></span><span>相同模型 · 相同用例 · 只改变知识载体</span></div>
     <figure class="flow-hero">
       <picture>
         <source media="(prefers-reduced-motion: reduce) and (max-width: 820px)" srcset="/omk-knowledge-flow-mobile.svg" type="image/svg+xml" />
@@ -31,265 +15,63 @@
         <source media="(max-width: 820px)" srcset="/omk-knowledge-flow-mobile.svg" type="image/svg+xml" />
         <img src="/omk-knowledge-flow-animated.gif" alt="omk 知识载体评测闭环：知识载体、受控评测、证据报告、发布或迭代、真实使用、观测沉淀、评测集升级" />
       </picture>
-      <figcaption>一条受控发布链路，一条真实使用回流链路；版本之间不偷偷换模型。</figcaption>
+      <figcaption>固定条件比较版本，再用真实使用反馈改进下一轮评测。</figcaption>
     </figure>
 
-    <!-- interactive stage -->
-    <template id="legacy-stage">
-      <div class="stage-head">
-        <span class="dots"><i style="background:#FF5F57"></i><i style="background:#FEBC2E"></i><i style="background:#28C840"></i></span>
-        <span class="title">omk — <b id="stTitle">eval</b> · 知识载体评测生命周期</span>
-        <span class="live">live</span>
-      </div>
-
-      <!-- lifecycle switch -->
-      <div class="rail-wrap">
-        <div class="rail" role="tablist">
-          <span class="thumb" id="thumb"><span class="thumb-g"></span></span>
-          <span class="rail-arrow a1" aria-hidden="true">›</span>
-          <span class="rail-arrow a2" aria-hidden="true">›</span>
-          <button class="seg" role="tab" aria-selected="false" data-k="doctor" data-i="0">
-            <span class="ph">上线前</span><span class="nm"><span class="ic">🩺</span>doctor</span>
-          </button>
-          <button class="seg" role="tab" aria-selected="true" data-k="eval" data-i="1">
-            <span class="ph">发布时</span><span class="nm"><span class="ic">📊</span>eval</span>
-          </button>
-          <button class="seg" role="tab" aria-selected="false" data-k="observe" data-i="2">
-            <span class="ph">上线后</span><span class="nm"><span class="ic">🔭</span>observe</span>
-          </button>
-        </div>
-        <p class="rail-cap" id="railCap"></p>
-      </div>
-
-      <div class="panels">
-        <!-- ===== EVAL panel ===== -->
-        <div class="panel on" data-p="eval">
-          <div class="panel-q"><span class="badge">eval</span> 控制变量 A/B：相同模型、相同用例，只改知识载体 —— 综合得分提升的 95% 置信区间</div>
-          <div class="panel-body">
-          <svg viewBox="0 0 680 200" width="100%" style="max-width:660px;display:block;margin:2px auto 0" role="img" aria-label="综合得分提升的置信区间森林图">
-            <!-- grid + ticks -->
-            <g class="svg-muted" font-family="JetBrains Mono" font-size="11">
-              <line class="svg-axis" x1="154" y1="34" x2="154" y2="150" stroke-width="1.5"/>
-              <text x="150" y="170">0%</text>
-              <line class="svg-grid" x1="303" y1="34" x2="303" y2="150"/>
-              <text x="296" y="170">+10%</text>
-              <line class="svg-grid" x1="451" y1="34" x2="451" y2="150"/>
-              <text x="444" y="170">+20%</text>
-              <line class="svg-grid" x1="600" y1="34" x2="600" y2="150"/>
-              <text x="593" y="170">+30%</text>
-            </g>
-            <!-- significance threshold note -->
-            <text class="svg-red" x="158" y="48" font-family="Inter" font-size="11" font-weight="600">不显著阈值（CI 跨 0）</text>
-            <!-- CI bar -->
-            <g>
-              <line class="svg-teal-s" x1="320" y1="96" x2="532" y2="96" stroke-width="3" stroke-linecap="round"/>
-              <line class="svg-teal-s" x1="320" y1="84" x2="320" y2="108" stroke-width="3" stroke-linecap="round"/>
-              <line class="svg-teal-s" x1="532" y1="84" x2="532" y2="108" stroke-width="3" stroke-linecap="round"/>
-              <circle class="svg-teal svg-halo" cx="426" cy="96" r="9" stroke-width="2.5"/>
-              <text class="svg-ink" x="426" y="78" text-anchor="middle" font-family="JetBrains Mono" font-size="14" font-weight="600">+18.3%</text>
-              <text class="svg-teal" x="320" y="128" text-anchor="middle" font-family="JetBrains Mono" font-size="11">+11.2</text>
-              <text class="svg-teal" x="532" y="128" text-anchor="middle" font-family="JetBrains Mono" font-size="11">+25.4</text>
-            </g>
-          </svg>
-          <div class="verdict">
-            <span class="check">✓</span>
-            <span class="vt">v2 明显优于 v1，可以发布</span>
-            <span class="vm"><span>CI[+11.2, +25.4]</span><span>α = 0.81</span><span>已去长度偏倚</span></span>
-          </div>
-          </div>
-        </div>
-
-        <!-- ===== DOCTOR panel ===== -->
-        <div class="panel" data-p="doctor">
-          <div class="panel-q"><span class="badge">doctor</span> 上线前体检：7 个内置维度独立打分（静态规则 + LLM 审计，可离线）</div>
-          <div class="panel-body">
-          <div class="dbars">
-            <div class="dbar"><span class="nm">触发与边界</span><span class="track"><span class="fill fill-ok" style="width:94%"></span></span><span class="lv lv-ok">健康</span></div>
-            <div class="dbar"><span class="nm">文档清晰</span><span class="track"><span class="fill fill-ok" style="width:90%"></span></span><span class="lv lv-ok">健康</span></div>
-            <div class="dbar"><span class="nm">指令精确性</span><span class="track"><span class="fill fill-sub" style="width:62%"></span></span><span class="lv lv-sub">亚健康</span></div>
-            <div class="dbar"><span class="nm">依赖检查</span><span class="track"><span class="fill fill-ok" style="width:88%"></span></span><span class="lv lv-ok">健康</span></div>
-            <div class="dbar"><span class="nm">工具规范</span><span class="track"><span class="fill fill-ok" style="width:85%"></span></span><span class="lv lv-ok">健康</span></div>
-            <div class="dbar"><span class="nm">安全与合规</span><span class="track"><span class="fill fill-sub" style="width:58%"></span></span><span class="lv lv-sub">亚健康</span></div>
-            <div class="dbar"><span class="nm">示例完备</span><span class="track"><span class="fill fill-ok" style="width:91%"></span></span><span class="lv lv-ok">健康</span></div>
-          </div>
-          <span class="summary-pill">🩺 健康度 良好 · <span class="n">5 健康 / 2 亚健康</span> · 体检建议 3 条</span>
-          </div>
-        </div>
-
-        <!-- ===== OBSERVE panel ===== -->
-        <div class="panel" data-p="observe">
-          <div class="panel-q"><span class="badge">observe</span> 线上观测：解析 Claude Code session，量化失败率、成本与知识缺口</div>
-          <div class="panel-body">
-          <div class="ometrics">
-            <div class="ocard"><div class="ok">会话失败率</div><div class="ov">4.2%</div><div class="od up">▼ 较上周 −1.6pt</div></div>
-            <div class="ocard"><div class="ok">P50 耗时</div><div class="ov">18.4s</div><div class="od up">▼ −2.1s</div></div>
-            <div class="ocard"><div class="ok">平均成本 / 会话</div><div class="ov">$0.012</div><div class="od down">▲ +$0.003</div></div>
-          </div>
-          <div class="gap">
-            <span class="gi">⚠</span>
-            <span class="gx"><b>知识缺口信号：</b>「环境探测前置缺失」在 12 个会话中重复出现 —— 严重度加权排第一</span>
-            <span class="gn">×12</span>
-          </div>
-          </div>
-        </div>
-      </div>
-    </template>
   </div>
 </header>
-
-<!-- ===================== CAPABILITIES ===================== -->
 <section class="band" id="caps">
   <div class="wrap">
-    <div class="sec-head">
-      <span class="eyebrow">Observe · Measure · Know</span>
-      <h2>观测真实表现，量出版本差异，判断改动是否有效、版本能否发布</h2>
-      <p class="lead">doctor、eval、studio、promote、observe、sample、evolve 不是孤立命令。它们把知识改动转成证据，也把线上缺口转成待复核草稿，复核后再进入下一轮固定评测集。</p>
-    </div>
+    <div class="sec-head"><h2>从当前任务开始</h2><p class="lead">选择一条路径，需要时再查命令和设计规范。</p></div>
     <div class="cap-grid">
       <div class="cap d">
-        <div class="ic">D</div>
-        <h3>doctor <span class="when">上线前</span></h3>
-        <p>这份知识载体是否清楚到值得评测？doctor 先拦住结构、依赖、安全性和可测性问题，避免 A/B 评测浪费 token。</p>
-        <code class="cmd2">$ omk doctor my-skill --dimensions audit.yaml</code>
-        <ul><li>触发边界 / 文档 / 指令 / 依赖 / 工具 / 安全 / 示例</li><li>--repeat：并行采样 + k/n 共识</li><li>endpoint 自定义维度：调接口做深度审查</li></ul>
+        <div class="ic">CLI</div><h3>比较两版 skill</h3>
+        <p>固定模型和用例，检查版本差异、置信区间与失败样本。</p><code class="cmd2">omk eval --control v1 --treatment v2</code>
+        <p><a class="lnk" href="/zh/quickstart-skill-eval">预览计划，再执行评测 <span class="ar">→</span></a></p>
       </div>
       <div class="cap e">
-        <div class="ic">E</div>
-        <h3>eval <span class="when">发布时</span></h3>
-        <p>v2 是否真的优于 v1？eval 固定模型和评测用例，只改变知识载体，再输出带置信区间和失败样本的一行 verdict。</p>
-        <code class="cmd2">$ omk eval --control v1 --treatment v2</code>
-        <ul><li>Bootstrap CI / 长度去偏 / 饱和曲线默认开</li><li>Krippendorff α：给 gold 集自动算评委↔人工一致</li><li>盲测 A/B · 多评委 ensemble · 多轮方差</li></ul>
+        <div class="ic">API</div><h3>接入你的服务</h3>
+        <p>从无需模型凭证的示例开始，为自己的 Node.js 服务配置执行器与评分器。</p><code class="cmd2">import { evaluate } from &#x27;oh-my-knowledge&#x27;</code>
+        <p><a class="lnk" href="/zh/guides/eval-runtime">查看服务接入教程 <span class="ar">→</span></a></p>
       </div>
       <div class="cap o">
-        <div class="ic">O</div>
-        <h3>observe <span class="when">真实使用</span></h3>
-        <p>真实使用暴露了什么？observe 把 session 日志转成知识缺口信号；from-traces 先生成草稿，人工复核后再沉淀为固定评测样本。</p>
-        <code class="cmd2">$ omk observe ~/.claude/sessions</code>
-        <ul><li>失败率 / 耗时 / 成本按知识载体拆解</li><li>知识缺口进入待复核池</li><li><code>omk sample --from-traces</code> 生成待复核用例草稿</li></ul>
+        <div class="ic">任务</div><h3>查看真实任务</h3>
+        <p>浏览本机 Codex 对话与任务轨迹，按日志还原可观测的请求、工具调用和结果。</p><code class="cmd2">omk studio</code>
+        <p><a class="lnk" href="/zh/guides/observe-production">查看观测指南 <span class="ar">→</span></a></p>
       </div>
     </div>
   </div>
 </section>
-
-<!-- ===================== MOAT ===================== -->
 <section class="band alt" id="moat">
   <div class="wrap">
-    <div class="sec-head" style="text-align:center">
-      <span class="eyebrow">护城河 · 测量可信度</span>
-      <h2 style="max-width:780px;margin:12px auto 0">严谨是<span style="color:var(--blue)">底座</span>，不是附加项</h2>
-      <p class="lead" style="margin:16px auto 0">决定一个对比可信与否的，是这五处常被忽略的失真。omk 将每一道防线内建于底层，无需你逐个开启。</p>
-    </div>
+    <div class="sec-head"><h2>如何判断结果可信</h2><p class="lead">先检查证据与适用范围，再作版本决定。</p></div>
     <div class="moat-list">
-      <div class="mrow2">
-        <span class="no">01</span>
-        <div class="fail"><div class="t">点估计把抽样波动误读为真实增益</div></div>
-        <div class="fix2"><div class="name">Bootstrap 置信区间 <span class="badge2">内建</span></div><div class="d">输出区间而非单点，显著性可直接判定。</div></div>
-      </div>
-      <div class="mrow2">
-        <span class="no">02</span>
-        <div class="fail"><div class="t">复合均分掩盖单一维度的回退</div></div>
-        <div class="fix2"><div class="name">三层独立评分 · 全过门槛 <span class="badge2">内建</span></div><div class="d">事实 / 行为 / 评委任一不达标，即不予通过。</div></div>
-      </div>
-      <div class="mrow2">
-        <span class="no">03</span>
-        <div class="fail"><div class="t">对照组读到被测载体本身</div><div class="s">construct validity 失守</div></div>
-        <div class="fix2"><div class="name">strict-baseline 隔离 <span class="badge2">内建</span></div><div class="d">封闭技能自发现、Skill 工具、cwd 旁路三条通道。</div></div>
-      </div>
-      <div class="mrow2">
-        <span class="no">04</span>
-        <div class="fail"><div class="t">评委对长答案存在系统性偏好</div></div>
-        <div class="fix2"><div class="name">长度去偏评委 <span class="badge2">内建</span></div><div class="d">评分剔除长度协变量，篇幅不再换分。</div></div>
-      </div>
-      <div class="mrow2">
-        <span class="no">05</span>
-        <div class="fail"><div class="t">评委评分自身的信度无从度量</div></div>
-        <div class="fix2"><div class="name">Krippendorff α <span class="badge2">配 gold 即开</span></div><div class="d">以人工标注为锚，量化评委↔人工一致性。</div></div>
-      </div>
+      <div class="mrow2"><span class="no">01</span><div class="fail"><div class="t">差异有多大？</div></div><div class="fix2"><div class="name">查看差异与置信区间</div><div class="d">点估计之外，还要看样本量、比较家族和不确定性。</div></div></div>
+      <div class="mrow2"><span class="no">02</span><div class="fail"><div class="t">评分依据是什么？</div></div><div class="fix2"><div class="name">下钻用例和评分证据</div><div class="d">检查准则、覆盖与失败原因；Gold comparison 可用于人工与评委的一致性评估。</div></div></div>
+      <div class="mrow2"><span class="no">03</span><div class="fail"><div class="t">结论能用于哪里？</div></div><div class="fix2"><div class="name">保留测量与观测的边界</div><div class="d">结论受用例和运行条件约束；观测信号不等于因果结论，生成用例需要人工复核。</div></div></div>
     </div>
-    <p class="moat-foot">同类工具普遍只覆盖其中一两项。<b>omk 的取舍：把可信度做进底层，而非留作选项。</b></p>
+    <p class="moat-foot"><a class="lnk" href="/zh/explanation/statistical-rigor">统计方法与限制 <span class="ar">→</span></a></p>
+    <p class="cmp-foot" id="cmp">正在选择工具？ <a class="lnk" href="/zh/reference/comparison">查看工具对比与适用范围 <span class="ar">→</span></a></p>
   </div>
 </section>
-
-<!-- ===================== COMPARISON ===================== -->
-<section class="band" id="cmp">
-  <div class="wrap">
-    <div class="sec-head">
-      <span class="eyebrow">选型对比</span>
-      <h2>同一套标准下的横向对比</h2>
-      <p class="lead">维度取自通用 LLMOps 评测选型轴（指标库 / judge / CI / 可观测 / 协作）＋ 测量学的效度与信度 —— 不是为 omk 量身定的规则。omk 在好几条轴上并不占优，如实标出。</p>
-    </div>
-    <div class="cmp-wrap">
-    <table class="cmp">
-      <thead><tr><th>能力维度</th><th class="omk-col">omk</th><th>promptfoo</th><th>DeepEval</th><th>LangSmith</th></tr></thead>
-      <tbody>
-        <tr class="cat"><td colspan="5">测量可信度 · 测量学效度 / 信度</td></tr>
-        <tr><td>统计显著性（置信区间 / 检验）</td><td class="omk-col y">✓ <small>Bootstrap</small></td><td class="n">—</td><td class="n">—</td><td class="n">—</td></tr>
-        <tr><td>评委 ↔ 人工 信度（一致性度量）</td><td class="omk-col y">✓ <small>Krippendorff α</small></td><td class="n">—</td><td class="n">—</td><td class="n">—</td></tr>
-        <tr><td>评估偏差控制（长度去偏）</td><td class="omk-col y">✓ <small>默认</small></td><td class="n">—</td><td class="n">—</td><td class="n">—</td></tr>
-
-        <tr class="cat"><td colspan="5">评估能力</td></tr>
-        <tr><td>断言 / 指标库广度</td><td class="omk-col y">✓ <small>30+</small></td><td class="y">✓</td><td class="y">✓</td><td class="p">◑</td></tr>
-        <tr><td>RAG 专项 metric</td><td class="omk-col p">◑ <small>3 项</small></td><td class="p">◑</td><td class="y">✓ <small>丰富</small></td><td class="p">◑</td></tr>
-        <tr><td>LLM-as-judge</td><td class="y omk-col">✓</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
-
-        <tr class="cat"><td colspan="5">工程 & 协作</td></tr>
-        <tr><td>CI/CD 集成（退出码路由）</td><td class="omk-col y">✓</td><td class="y">✓</td><td class="y">✓</td><td class="p">◑</td></tr>
-        <tr><td>上手速度 / 配置简洁</td><td class="omk-col p">◑</td><td class="y">✓ <small>极快</small></td><td class="p">◑</td><td class="p">◑</td></tr>
-        <tr><td>实验追踪 / Tracing</td><td class="omk-col n">—</td><td class="n">—</td><td class="p">◑</td><td class="y">✓ <small>强项</small></td></tr>
-        <tr><td>托管 SaaS 看板 / 团队协作</td><td class="omk-col n">—</td><td class="n">—</td><td class="y">✓</td><td class="y">✓</td></tr>
-
-        <tr class="cat"><td colspan="5">生态 & 集成</td></tr>
-        <tr><td>社区规模（GitHub stars, 2026-04）</td><td class="omk-col p">新生</td><td class="y">9k+</td><td class="y">12k+</td><td class="p">商业</td></tr>
-        <tr><td>原生 Claude Code skill</td><td class="omk-col y">✓</td><td class="n">—</td><td class="n">—</td><td class="n">—</td></tr>
-      </tbody>
-    </table>
-    </div>
-    <div class="cmp-legend"><span><b class="y" style="color:var(--teal)">✓</b> 原生支持</span><span><b class="p" style="color:var(--amber)">◑</b> 部分 / 需配置</span><span><b style="color:#CBD5E1">—</b> 不支持</span></div>
-    <p class="cmp-foot">完整对比（8 工具 × 30+ 维，含 RAGAS / OpenAI Evals / lm-eval-harness / inspect-ai）见 <a href="/zh/reference/comparison" style="color:var(--blue);font-weight:600">对比文档</a>，数据截至 2026-04，<b>发现过时请提 PR 修正</b>。结论：没有银弹 —— omk 的取舍是「把统计可信度做到默认」，要 SaaS 看板选 LangSmith、要学术基准选 lm-eval-harness。</p>
-  </div>
-</section>
-
-<!-- ===================== AGENT ===================== -->
-<section class="band alt" id="agent">
+<section class="band" id="agent">
   <div class="wrap">
     <div class="agent">
       <div class="term">
         <div class="bar"><i style="background:#FF5F57"></i><i style="background:#FEBC2E"></i><i style="background:#28C840"></i></div>
-        <div class="body">
-          <div><span class="cm">$ omk install omk-agent-skill</span> <span class="gr"># 一次性安装</span></div>
-          <div class="gr">  ✓ 已写入本机检测到的 Claude Code / Codex</div>
-          <div style="margin-top:10px"><span class="cm">/omk eval</span> <span class="gr"># 评测当前项目的知识载体</span></div>
-          <div><span class="cm">/omk evolve</span> <span class="gr"># 一键:体检→生成用例→自迭代</span></div>
-          <div><span class="cm">/omk sample</span> <span class="gr"># 生成或补齐评测用例</span></div>
-          <div style="margin-top:10px" class="gr">&gt; <span class="wh">帮我比较 v1 和 v2 的差异</span></div>
-          <div class="gr">  ↳ 推断意图 → omk eval --control v1 --treatment v2 …</div>
-        </div>
+        <div class="body"><div><span class="cm">$ omk install omk-agent-skill</span></div><div style="margin-top:10px" class="wh">用 omk 比较这两版 skill，先预览计划。</div></div>
       </div>
-      <div class="copy">
-        <span class="eyebrow">Agent 集成</span>
-        <h3>在你的 Coding Agent 里直接用</h3>
-        <p>一行 <code style="font-family:var(--mono);background:var(--blue-l);color:var(--blue-d);padding:2px 6px;border-radius:5px">omk install omk-agent-skill</code> 把官方 Agent Skill 装进本机已检测到的 Claude Code / Codex（<code style="font-family:var(--mono)">--to all</code> 装到全部）。之后 Claude Code 里 <code style="font-family:var(--mono);background:var(--blue-l);color:var(--blue-d);padding:2px 6px;border-radius:5px">/omk</code> 开箱即用，Codex 等直接跑 <code style="font-family:var(--mono)">omk</code> CLI。</p>
-        <div class="nl">
-          <p class="nl-tip">不用记命令 —— 用大白话说目标，agent 会从上下文定位 skill、选对命令。</p>
-          <div class="bubble-row">
-            <span class="who">你</span>
-            <div class="bubble">把这个 skill 改得更稳，再和上一版比一比</div>
-          </div>
-        </div>
-      </div>
+      <div class="copy"><h3>让 Agent 执行工作流</h3><p>安装 OMK Skill 后，用自然语言描述比较目标。安装目标、模型准备和执行步骤见快速上手。</p><a class="lnk" href="/zh/quickstart-skill-eval">命令行评测 <span class="ar">→</span></a></div>
     </div>
   </div>
 </section>
-
-<!-- ===================== FINAL CTA ===================== -->
-<section class="band" id="start">
+<section class="band alt" id="start">
   <div class="wrap">
-    <p class="punch">下一次发布前，<span class="em">先让数据说话</span>。</p>
     <div class="final">
-      <span class="eyebrow">5 分钟跑通第一个评测</span>
-      <h2>从一个裸数字，到一个经得起追问的结论</h2>
-      <p class="lead" style="margin:14px auto 0">不用改任何文件 —— <code style="font-family:var(--mono)">omk init</code> 脚手架两版 skill 和三条用例，<code style="font-family:var(--mono)">omk eval</code> 5 分钟内出 HTML 报告 + 一行 verdict。</p>
-      <span class="cmd"><span><span class="pfx">$</span> omk init demo &amp;&amp; cd demo &amp;&amp; omk eval</span><span class="copy" onclick="omkCopy('omk init demo && cd demo && omk eval', this)">复制 ⧉</span></span>
+      <h2>先跑通流程，再使用自己的用例</h2><p class="lead" style="margin:14px auto 0">演示项目提供两版 skill 和三条用例。小样本出现 UNDERPOWERED 符合预期；真实评测会调用模型。</p>
+      <span class="cmd"><span><span class="pfx">$</span> omk init demo</span><span class="copy" onclick="omkCopy('omk init demo', this)">复制 ⧉</span></span>
+      <p><a class="lnk" href="/zh/quickstart-skill-eval">继续完整教程 <span class="ar">→</span></a> · <a class="lnk" href="/zh/README">完整文档 <span class="ar">→</span></a></p>
+      <p><a class="lnk" href="/zh/guides/v1-preview-migration">升级前查看迁移说明 <span class="ar">→</span></a></p>
     </div>
   </div>
 </section>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,49 +1,32 @@
 # OMK Documentation
 
-**Observe. Measure. Know.** Make every knowledge change in your AI application evidence-backed.
+Choose an entry for your task. Version 1.0 is still in Beta iteration; existing users should read the [migration guide](./guides/v1-preview-migration.md) first. [简体中文 index](./zh/README.md).
 
-Browse by audience or category. For Chinese docs see [简体中文 index](./zh/README.md).
+## Get started
 
-## I want to use omk
+| Goal | Start here | Reference when needed |
+|---|---|---|
+| Compare two skills from the CLI | [Quickstart](./quickstart-skill-eval.md) | [CLI](./reference/cli.md) · [Executors](./reference/executors.md) · [Sample format](./reference/eval-sample-format.md) · [Artifact layout](./reference/artifact-layout.md) |
+| Integrate a Node.js service | [Service guide](./guides/eval-runtime.md) | [Runtime API](./reference/eval-runtime-api.md) · [Core API](./reference/embedded-api.md) |
+| Inspect real tasks and knowledge gaps | [Observation and task trajectories](./guides/observe-production.md) | [Codex case](./guides/codex-observe-case.md) · [Effective review semantics](./explanation/effective-observation-review.md) |
 
-- [Who omk is for](./explanation/who-omk-is-for.md) — the user, problem, and first ship/no-ship workflow
-- [Quickstart](./quickstart-skill-eval.md) — first eval in 5 minutes
-- [Install the omk Agent Skill](./quickstart-skill-eval.md) — agent-driven onboarding with `omk install omk-agent-skill`
-- [Use OMK in a Node.js service](./guides/eval-runtime.md) — choose a scorer, connect your service, and read the results
-- [CLI reference](./reference/cli.md)
-- [Core API (advanced integration)](./reference/embedded-api.md)
-- [Eval sample format](./reference/eval-sample-format.md)
-- [Executors](./reference/executors.md)
-- [Artifact & variant layout](./reference/artifact-layout.md)
-- [Comparison with 7 tools](./reference/comparison.md)
-- [Glossary](./reference/glossary.md)
+## Complete a task
 
-## How-to guides
+- [Use the OMK Skill in an agent](./quickstart-skill-eval.md#use-inside-an-agent)
+- [Run doctor checks](./guides/run-doctor-checks.md) · [Auto-improve a skill](./guides/auto-improve-skills.md)
+- [Evaluate agents and project context](./guides/agent-eval.md) · [Use non-Claude models](./guides/non-claude-models.md)
+- [Compose an MCP integration](./guides/mcp-integration.md) · [DeepSeek Harness integration](./reference/executors.md#deepseek-harness-prefer-the-host-plugin)
 
-- [Run doctor checks](./guides/run-doctor-checks.md)
-- [Evaluate an agent (project-level runtime context)](./guides/agent-eval.md)
-- [Auto-improve a skill](./guides/auto-improve-skills.md)
-- [Observe production traces](./guides/observe-production.md)
-- [Compose the OMK MCP integration](./guides/mcp-integration.md)
-- [Reproduce Codex parent/subagent observation](./guides/codex-observe-case.md)
-- [Use non-Claude models (GLM / Qwen / DeepSeek / Moonshot / Ollama)](./guides/non-claude-models.md)
+## Understand results and limits
 
-## I want to understand how it works
+- [Who OMK is for](./explanation/who-omk-is-for.md) · [How OMK understands knowledge](./explanation/knowledge.md)
+- [Three-stage workflow](./explanation/three-stage-workflow.md) · [Architecture](./explanation/architecture.md)
+- [Statistical rigor](./explanation/statistical-rigor.md) · [Scoring formulas](./specs/scoring.md) · [Sample design](./specs/sample-design-spec.md)
+- [Glossary](./reference/glossary.md) · [Tool comparison](./reference/comparison.md)
 
-- [How OMK understands knowledge](./explanation/knowledge.md)
-- [Who omk is for](./explanation/who-omk-is-for.md) — why doctor / eval are the pre-ship trunk and observe is post-ship feedback
-- [The three stages: doctor / eval / observe](./explanation/three-stage-workflow.md)
-- [Architecture](./explanation/architecture.md)
-- [Statistical rigor](./explanation/statistical-rigor.md)
-- [Scoring pipeline](./specs/scoring.md)
+## Migration and design specs
 
-## I want to contribute / read design specs
-
-- [Evaluation Core vNext RFC](./specs/eval-core-vnext.md)
-- [Evaluation scoring equivalence RFC](./specs/evaluation-scoring-equivalence.md)
-- [CLI evaluation input compilation](./specs/cli-evaluation-input-compilation.md)
-- [Sample design spec](./specs/sample-design-spec.md)
-- [Knowledge construction domain model (draft)](./specs/knowledge-domain-model.md)
-- [Knowledge gap signal spec](./specs/knowledge-gap-signal-spec.md)
-- [RAG metrics spec](./specs/rag-metrics-spec.md)
-- [Terminology spec](./specs/terminology-spec.md)
+- [1.0 Beta migration](./guides/v1-preview-migration.md) · [Core cutover](./guides/eval-core-cutover.md) · [Storage layout](./specs/storage-layout-spec.md)
+- [Core design](./specs/eval-core-vnext.md) · [Scoring equivalence](./specs/evaluation-scoring-equivalence.md) · [CLI input compilation](./specs/cli-evaluation-input-compilation.md)
+- [Knowledge domain model (draft)](./specs/knowledge-domain-model.md) · [Knowledge-gap signals](./specs/knowledge-gap-signal-spec.md) · [Evidence-gated management](./specs/evidence-gated-management.md)
+- [RAG metrics](./specs/rag-metrics-spec.md) · [Terminology](./specs/terminology-spec.md)

--- a/docs/guides/v1-preview-migration.md
+++ b/docs/guides/v1-preview-migration.md
@@ -1,6 +1,6 @@
 # Migrate from 0.54 to the 1.0 preview
 
-`1.0.0-beta.0` is the first public preview of OMK's new Evaluation Core architecture. It is published under npm's `next` tag, while `latest` remains on `0.54.0` during the preview.
+This guide covers migration from `0.54` to the 1.0 Beta on npm’s `next` tag. Beta iteration continues; these are the current migration boundaries, not an API freeze or an RC release plan.
 
 ```bash
 npm install --global oh-my-knowledge@next
@@ -9,7 +9,7 @@ omk --version
 
 Use a disposable project or back up both the project `.omk/` directory and `~/.oh-my-knowledge/` before trying the preview. To return to the stable channel, run `npm install --global oh-my-knowledge@latest`.
 
-This is a beta, not a frozen 1.0 contract. One important limitation remains: `omk eval gold init` creates a generic annotation scaffold but cannot yet seed it from a real Core run, so Gold authoring still requires manual sample-ID alignment. An explicit Gold comparison reports Krippendorff alpha, but that post-hoc result does not automatically gate the run's release verdict. [Issue #283](https://github.com/lizhiyao/oh-my-knowledge/issues/283) tracks the guided Gold on-ramp and calibration-decision closure required before an RC.
+**Gold limitation:** `omk eval gold init` still creates a generic scaffold; align real sample IDs manually. Gold comparison reports human/judge agreement and post-hoc reliability without changing an existing run’s release decision. See the CLI migration selectors below.
 
 ## 1. Start a new evidence history
 
@@ -67,7 +67,7 @@ Check the current [CLI reference](../reference/cli.md) rather than copying 0.54 
 The published API is ESM-only on Node.js 22 or newer. Imports are restricted to the package export map; `oh-my-knowledge/dist/*` is private.
 
 - Use `oh-my-knowledge` for the ordinary `evaluate()` and `checkExecutor()` façade. The explicit `oh-my-knowledge/eval-runtime` subpath is equivalent.
-- Replace the fixed `{ executor, control, treatment, evaluator }` call with `{ variants, evaluators, comparisons }`. Bind each Executor, config, and runtime context under `variant.execution`; declare `experiment.sampling`; move Bootstrap settings to `analysis`; add `decision` only when one analysis result should produce a verdict. The preview does not read the removed shape.
+- Replace the fixed `{ executor, control, treatment, evaluator }` call with `{ dataset, variants, evaluators, comparisons, analyses, experiment, policy }`. Bind execution and config under `variant.execution`, sampling under `experiment.sampling`, and statistical requests in `analyses[]`. An optional `decision` selects an analysis by `analysisId`. Pass run options such as `runId`, `signal`, and `onEvent` as the second argument; old shapes are not read.
 - Move former package-root Core imports to `oh-my-knowledge/eval-core`; use that subpath for Engine construction, staged execution, admission, verification, comparability, Series, and Core JSON Schemas.
 - Import `createEvaluationEngine` only from `oh-my-knowledge/eval-core`; the ambiguous narrowed re-export has been removed from `eval-runtime/advanced`. Use `runEvaluation` there for a standard complete run over preassembled inputs.
 - Use `oh-my-knowledge/eval-samples`, `oh-my-knowledge/projections`, `oh-my-knowledge/studio`, `oh-my-knowledge/mcp`, or `oh-my-knowledge/dsh-plugin` for those explicit surfaces.
@@ -75,7 +75,7 @@ The published API is ESM-only on Node.js 22 or newer. Imports are restricted to 
 - Engine Runtime assembly now uses binding resolvers that return the resolution and configured port together.
 - Series Analysis and Decision Runtimes open run-scoped sessions with `openRun()` and `dispose()`; Series runs require a `runId` and return a terminal status union.
 
-The [embedded API reference](../reference/embedded-api.md) is the canonical contract and includes a complete independent-host fixture.
+Use the [Runtime API reference](../reference/eval-runtime-api.md) for service integration and the [Core API reference](../reference/embedded-api.md) for advanced staged integration.
 
 ## Measurement boundary
 

--- a/docs/quickstart-skill-eval.md
+++ b/docs/quickstart-skill-eval.md
@@ -1,192 +1,103 @@
 # omk quickstart: get to your first verdict
 
-Get your first report in 5 minutes, then replace the demo with your own skill. Target audience: you have one (or several) skill files and want data to answer "is this skill any good?", "did v2 improve?", and "can we ship this with evidence?"
+Use a demo to walk through “preview → evaluate → inspect evidence”, then switch to your own skill. Runtime and cost depend on the model, cases, and retries.
 
-## Setup (1 minute)
+## Install and prepare a runtime
 
-```bash
-npm i oh-my-knowledge -g
-omk --version    # prints a version number once installed
-```
-
-Configure one authenticated runtime: Codex CLI, Claude Code, or an OpenAI-compatible API. Inside a Codex task in the ChatGPT desktop app, omk automatically selects `codex`, reads the model from `~/.codex/config.toml`, and uses the same Codex model as the default judge. No Claude account is required.
-
-If you want the **agent-driven workflow** (recommended), also install the omk Agent Skill into your coding agent:
+You need Node.js >=22 and an authenticated runtime: Codex CLI, Claude Code, or an API executor. See [Executors](./reference/executors.md) for setup.
 
 ```bash
-omk install omk-agent-skill
+npm i -g oh-my-knowledge@next
+omk --version
 ```
 
-By default, this installs only into detected local targets omk explicitly supports: Codex/AGENTS when `~/.codex` or `~/.agents` exists, and Claude Code when `~/.claude` exists. Use `--to all` to force every target omk currently knows, or `--dest` for a custom skill root. Once installed, the agent auto-loads the SKILL context when you mention "omk", "benchmark", "evaluate", "skill eval", etc.
+This installs the actively evolving 1.0 Beta. Read the [migration guide](./guides/v1-preview-migration.md) before upgrading from 0.54.
 
-## Fastest first run: use the demo scaffold
+Inside a Codex task, OMK defaults to Codex, reads the locally configured model, and reuses it as the judge. In a regular terminal you can select it explicitly:
 
-If you are new to omk, start here before using your own files:
+```bash
+export OMK_EXECUTOR=codex
+```
+
+Model selection, API credentials, and optional SDK prerequisites are documented in [Executors](./reference/executors.md).
+
+## 1. Run the demo
 
 ```bash
 omk init demo
 cd demo
 omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
+```
+
+`init` creates two skills and three evaluation cases. `--dry-run` previews the execution plan and estimated calls. Check the plan before running the evaluation:
+
+```bash
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-`omk init` creates two skill variants and three sample cases. `--dry-run` previews the sealed task plan and estimated calls; the real run then opens the Core run in Studio. With only three demo samples, the verdict is often `UNDERPOWERED` — that is a normal teaching result, not a failed run.
+The real evaluation calls the model and runs a doctor check first by default. Cost and duration depend on the runtime; a preview is not a billing guarantee. Open Studio at the actual URL returned by the CLI, or use `omk studio` to browse past results.
 
-If you want the first run to meet omk's default heuristic evidence floor, create the demo with the first-party 20-case pack instead:
+Three cases check the workflow; `UNDERPOWERED` is expected. For the full starter set, use a new directory: `omk init demo-full --samples 20`. It covers four dimensions, varied difficulty, and no-defect controls. It produces 40 control/treatment executions, plus scoring and check calls.
 
-```bash
-omk init demo --samples 20
-```
+**Starter cases are marked `provenance: llm-generated`.** Twenty cases meet only the default heuristic evidence floor, not an a priori power plan or a release-evidence requirement. Review and replace them with real domain cases before relying on the results.
 
-The full pack has five security, robustness, maintainability, and performance cases each, spans easy / medium / hard difficulty, and includes no-defect controls so a reviewer is not rewarded merely for reporting more issues. It produces 40 control / treatment executions, so the 3-case default remains the fastest way to verify setup. The fixed starter cases are marked `provenance: llm-generated`: twenty samples meet only the default heuristic evidence floor, not an a priori power plan, and remain teaching data rather than production release evidence. Review them and replace them with real domain cases before trusting a ship / no-ship decision.
+## 2. Use your own skill
 
-Inside a Codex task, the shortest commands above need no runtime flags. To make Codex the default in regular terminals, add the preference to your shell profile (for example `~/.zshrc`):
+Prepare two versions in your own project:
 
-```bash
-export OMK_EXECUTOR=codex
-# Optional: export OMK_MODEL="your-codex-model"
-```
-
-Without `OMK_MODEL`, omk reads the model from `~/.codex/config.toml`. You can also select it per command. Once Codex is selected, the default judge reuses the evaluated model, so `--judge-models` is not repeated:
-
-```bash
-omk eval --control code-review-v1 --treatment code-review-v2 \
-  --executor codex --model <codex-model>
-
-# OpenAI-compatible API path
-export OPENAI_API_KEY="..."
-export OPENAI_BASE_URL="https://api.example.com/v1"
-omk eval --control code-review-v1 --treatment code-review-v2 \
-  --executor openai-api --model <model> \
-  --judge-models openai-api:<model>
-```
-
-For Codex, `<codex-model>` should be a model your local Codex can run. By default, omk reads the top-level `model` from `~/.codex/config.toml` or `$CODEX_HOME/config.toml`. For OpenAI-compatible APIs, make sure the model name matches the selected `OPENAI_BASE_URL`.
-
-## Prepare your skill (1 minute)
-
-Place skills under `skills/`. **Single `.md` files are the simplest layout**:
-
-```
+```text
 skills/
 ├── my-skill-v1.md
 └── my-skill-v2.md
 ```
 
-Switch to a directory layout (one folder per version) only when a skill is large enough to need split-out examples or references:
-
-```
-skills/
-├── my-skill-v1/
-│   └── SKILL.md
-└── my-skill-v2/
-    ├── SKILL.md
-    └── references/     long examples / reference material
-        └── examples.md
-```
-
-Both layouts are recognized; mixing them is fine. For a v1 vs v2 A/B, drop in two versions. To answer "does this skill help at all" with a baseline control, one version is enough.
-
-## Replace the demo with your own skill
-
-### Path A: natural language (recommended)
-
-Open your coding agent, `cd` into your project, and say:
-
-> Use omk to compare skills/my-skill-v1 against skills/my-skill-v2
-
-The omk skill takes care of the rest: it auto-generates samples if `eval-samples.json` is missing, runs the eval, and opens the report in your browser. In Claude Code you can use the installed omk skill directly; in Codex, ask the agent to run the `omk` CLI. Other useful phrasings:
-
-- "Use omk to compare skills/my-skill-v1 against skills/my-skill-v2"
-- "Use omk to run a baseline control for skills/audit (with-skill vs without-skill)"
-- "Use omk to batch-evaluate every skill under skills/"
-- "Use omk evolve to auto-improve skills/my-skill-v2 over 5 rounds"
-
-### Path B: command line
-
-If you only have one skill, the shortest useful comparison is "with this skill" vs `baseline`:
+For accompanying references, use a directory such as `skills/my-skill-v2/SKILL.md`; see [artifact layout](./reference/artifact-layout.md). The variant name comes from the file or directory name, such as `my-skill-v2`.
 
 ```bash
-omk sample skills/my-skill.md                         # first time: AI-generate eval samples
-omk eval --control baseline --treatment my-skill --dry-run
-omk eval --control baseline --treatment my-skill
+omk sample skills/my-skill-v2.md
 ```
 
-If you already have two versions, compare v1 vs v2:
+Review the generated criteria, weights, counterexamples, and boundary coverage. Use the same fixed cases for both versions. If you continue in the demo project, replace its cases rather than treating them as your own domain cases.
 
 ```bash
-omk sample skills/my-skill-v2.md                                  # first time: AI-generate eval samples
-omk eval --control my-skill-v1 --treatment my-skill-v2 --dry-run  # preview the task plan
-omk eval --control my-skill-v1 --treatment my-skill-v2            # run for real
-omk studio                                                        # open the report browser
+omk eval --control my-skill-v1 --treatment my-skill-v2 --dry-run
+omk eval --control my-skill-v1 --treatment my-skill-v2
 ```
 
-Variant names come from the skill file or directory names under `skills/`; for `skills/my-skill.md`, use `my-skill`; for the v1/v2 layout above, use `my-skill-v1` and `my-skill-v2`.
+With only one skill, use `baseline` as the control to compare “without skill” against “with skill”. See the [sample format](./reference/eval-sample-format.md) for the schema and discovery rules.
 
-`--dry-run` prints expected call count and cost estimates — confirm, drop the flag, and run. `omk eval` runs a doctor health check as a preflight gate by default; if a skill has structural problems it gets blocked early. Pass `--skip-doctor` to bypass when you know what you're doing.
+## 3. Read the result and choose the next step
 
-### When the model or executor fails
+Start with the **verdict** and its reason codes, then inspect the difference Δ, the reported confidence interval, evidence coverage, and failed cases. A single comparison defaults to a 95% interval; comparison families adjust the confidence level. Evidence and policy gates also constrain the release decision.
 
-The CLI now tries to make first-run failures actionable:
-
-- Claude failure: log in to Claude Code, or switch to Codex / OpenAI API with the flags above.
-- Codex model failure: use the model configured in `~/.codex/config.toml` or `$CODEX_HOME/config.toml`, then verify with `codex exec -m <codex-model> "hi"`.
-- OpenAI / Anthropic API model failure: check `--model`, `--judge-models`, the base URL, and whether the account has access to that model.
-- If you only want to validate assertions and report plumbing first, add `--no-judge`; this skips the LLM judge and relies on assertion scores only.
-
-## Read the report (1 minute)
-
-The browser auto-opens (default `http://127.0.0.1:7799/`). Look at three things:
-
-**Verdict** (cross-version conclusion): `PROGRESS` (better) / `NOISE` (diff inside the confidence band, undecidable) / `REGRESSION` (worse) / `CAUTIOUS` (trends look good but confidence is thin) — plus two edge cases, `UNDERPOWERED` (too few samples to conclude) and `SOLO` (single variant, nothing to compare against). This is the one-line answer to bring to a review meeting.
-
-**Composite score**: each variant's average on a 0–5 scale, with a `+Δ` against the control. The confidence interval next to Δ — 95% by default, raised to a higher level (Bonferroni) when several treatments share one control — is what decides where the verdict lands.
-
-**Low-scoring samples**: drill into the ones where the LLM tripped. Compare "rubric expectation" against "actual LLM output" — usually the gap points right back at a specific paragraph in the skill that wasn't clear enough.
-
-## Act on the verdict
-
-| Verdict | What to do next |
+| Verdict | Next step |
 |---|---|
-| `PROGRESS` | Ship through your normal release path. Keep the report as release evidence; if this is a managed skill installed with `omk install`, run `omk promote <name>` to record the acceptance decision. |
-| `CAUTIOUS` | Do not ship blind. Inspect the warning that fired (layer gate, judge dissent, stability, or holdout), fix the issue, then re-run; loosen the gate only after explicit human review. |
-| `REGRESSION` | Do not ship. Start from the weakest layer and the failing samples, fix the artifact, then re-run the eval. |
-| `NOISE` | No release call yet. Add samples or sharpen the sample set so the diff can separate from noise, then re-run. |
-| `UNDERPOWERED` | Satisfy the preregistered sample-size requirement, then re-run. Without an a priori plan, 20 comparable units is only omk's default heuristic floor; configure `decision.power` from external pilot assumptions or register a simulation-derived `decision.minimumComparisonUnits` for a formal study. |
-| `SOLO` | Add a control, usually `omk eval --control baseline --treatment <name>`, before making a ship/no-ship call. |
+| `PROGRESS` | Evidence supports improvement. Review case representativeness and warnings before your release process; use `omk promote <name>` to record acceptance for a managed skill. |
+| `CAUTIOUS` | Read the specific reasons and warnings, address them, and rerun; do not accept automatically. |
+| `REGRESSION` | Diagnose failed cases and declining metrics, then reevaluate the revised artifact. |
+| `NOISE` | Current evidence does not distinguish the difference. Review case discrimination and sample design before deciding whether to measure more. |
+| `UNDERPOWERED` | Meet the declared sample-size requirement. Twenty comparable units is only a default heuristic floor; use external pilot assumptions for `decision.power` or register `decision.minimumComparisonUnits` for formal measurement. |
+| `SOLO` | Add a control before making a cross-version decision. |
 
-## Things to keep in mind
+Conclusions apply only to these cases, criteria, and conditions. AI-generated cases can favor existing happy paths; add real failures, counterexamples, and misuse scenarios. Retain the report, case provenance, and human-review conclusions. Cases used during iteration are not an independent release-validation set. See [statistical rigor](./explanation/statistical-rigor.md) and [sample design](./specs/sample-design-spec.md).
 
-**Sample generation takes time.** omk asks the AI to generate 10–20 samples per skill by default, but AI-generated samples are **biased**: they cluster around the happy-path scenarios the skill already documents well, and undersample edge cases, counterexamples, and misuse paths. **Spend 30 minutes** after the first run filtering: drop the implausible ones, add the missing boundary cases, add a few "intentionally wrong user instructions" to see whether the skill resists being misled. This is the single biggest variable in how much you can trust your numbers.
+## Use inside an agent
 
-**Evaluation costs LLM tokens.** Rough order of magnitude: one sample × one variant ≈ $0.01–0.05, ten samples × two variants ≈ $0.2–1. Always `--dry-run` first.
+```bash
+omk install omk-agent-skill
+```
 
-**Conclusions only generalize to the sample set you wrote.** "This version of the skill is better" is bounded by "better on the N samples I designed". Swap the sample set and the conclusion could flip. So **sample design itself is the source of conclusion credibility** — don't treat it as a chore before running the eval, it *is* the eval.
+The default installs into detected supported targets: Codex/AGENTS for `~/.codex` or `~/.agents`, and Claude Code for `~/.claude`. `--to all` forces all currently known targets; `--dest` selects a custom skill root.
 
-## Common task cheat-sheet
+Explicitly use the OMK Skill in your agent and describe your goal, for example: “Use omk to compare skills/my-skill-v1 and skills/my-skill-v2; preview the plan first.” Claude Code can use its installed `/omk` entry; other hosts can ask the agent to execute the `omk` CLI. Review generated cases before running the real evaluation.
 
-| Goal | Natural language | Equivalent command |
-|---|---|---|
-| First-time scoring of a skill | run a baseline control for skills/X | `omk eval --control baseline --treatment X` |
-| Before/after a skill change | compare git history skills/X against current | `omk eval --control git:X --treatment X` |
-| Auto-improve a skill | use omk evolve on skills/X for 5 rounds | `omk evolve skills/X.md --rounds 5` |
-| Batch-eval every skill | run eval on every skill under skills/ | `omk eval --batch` |
-| Generate samples only | generate eval samples for skills/X | `omk sample skills/X.md` |
-| Run health-check alone | run a doctor health check on skills/X | `omk doctor skills/X.md` |
-| View past reports | open omk studio | `omk studio` |
+## Troubleshoot the first run
 
-## What to bring to the review meeting after your first run
+- **Model or authentication failure:** check runtime login, model name, and API endpoint; see [Executors](./reference/executors.md).
+- **Doctor blocks the run:** fix the diagnosed artifact issues and retry. See the [CLI reference](./reference/cli.md) before deciding to skip the check.
+- **Check assertions and reports only:** `--no-judge` skips the LLM judge, but target execution may still call a model. It is not an offline or free-run switch.
+- **Preview fails:** resolve sample, path, or URL errors first; do not bypass them by starting a real run.
 
-- Verdict + composite score + Δ + 95% CI band
-- Which samples scored lowest, and where the gap between rubric expectation and LLM output was
-- Which samples you have doubts about by design (it's healthy to "let data speak, then question the data")
-- Doctor health-check result (eval runs it by default; run `omk doctor` alone if you want to audit the skill's structure separately)
+## Continue
 
-## Going deeper
-
-- The mental model — [the three stages: doctor / eval / observe](./explanation/three-stage-workflow.md)
-- How a run actually works: [architecture](./explanation/architecture.md)
-- Full CLI / executor / judge / observe reference: [README.md](https://github.com/lizhiyao/oh-my-knowledge/blob/main/README.md)
-- Five-layer scoring pipeline (assertion / llm / judge / dimension / composite): [scoring.md](./specs/scoring.md)
-- Statistical rigor (Bootstrap CI / Krippendorff α / length-debias): [statistical-rigor.md](./explanation/statistical-rigor.md)
-- Sample design spec (`mocks` / `environment` / `tripwire` / `mocksStrict`): [sample-design-spec.md](./specs/sample-design-spec.md)
+[Auto-improve a skill](./guides/auto-improve-skills.md) · [Observe real tasks](./guides/observe-production.md) · [Node.js integration](./guides/eval-runtime.md) · [Documentation index](./README.md)

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -1,48 +1,32 @@
 # OMK 文档
 
-**Observe. Measure. Know.** 让 AI 应用的知识改动有据可依。
+从当前任务选择入口。1.0 仍在 Beta 迭代；旧版本用户先看[迁移指南](./guides/v1-preview-migration.md)。[English index](../README.md)。
 
-按受众或分类浏览。英文文档请看 [English index](../README.md)。
+## 开始使用
 
-## 我想用 omk
+| 目标 | 先读 | 按需查阅 |
+|---|---|---|
+| 命令行比较两版 skill | [快速上手](./quickstart-skill-eval.md) | [CLI](./reference/cli.md) · [执行器](./reference/executors.md) · [用例格式](./reference/eval-sample-format.md) · [载体布局](./reference/artifact-layout.md) |
+| 在 Node.js 服务中接入 | [服务接入指南](./guides/eval-runtime.md) | [Runtime API](./reference/eval-runtime-api.md) · [底层 Core API](./reference/embedded-api.md) |
+| 查看真实任务与知识缺口 | [观测与任务轨迹](./guides/observe-production.md) | [Codex 案例](./guides/codex-observe-case.md) · [有效复核语义](./explanation/effective-observation-review.md) |
 
-- [omk 为谁做、解决什么](./explanation/who-omk-is-for.md) —— 用户、问题和第一条发布判断工作流
-- [快速上手](./quickstart-skill-eval.md) —— 5 分钟跑完第一次评测
-- [安装 omk Agent Skill](./quickstart-skill-eval.md) —— 用 `omk install omk-agent-skill` 开启 agent 驱动工作流
-- [在 Node.js 服务中使用 OMK](./guides/eval-runtime.md) —— 选择评分方法、接入自己的服务并解读结果
-- [CLI 参考](./reference/cli.md)
-- [底层 Core API（高级接入）](./reference/embedded-api.md)
-- [评测用例格式](./reference/eval-sample-format.md)
-- [执行器](./reference/executors.md)
-- [指定被测对象(artifact / variant)](./reference/artifact-layout.md)
-- [7 工具对比](./reference/comparison.md)
-- [术语表](./reference/glossary.md)
+## 完成具体任务
 
-## 操作指南
+- [在 Agent 中使用 OMK Skill](./quickstart-skill-eval.md#在-agent-中使用)
+- [doctor 体检](./guides/run-doctor-checks.md) · [自动改进 skill](./guides/auto-improve-skills.md)
+- [评测 agent 与项目上下文](./guides/agent-eval.md) · [使用非 Claude 模型](./guides/non-claude-models.md)
+- [组合 MCP 集成](./guides/mcp-integration.md) · [DeepSeek Harness 接入](./reference/executors.md#deepseek-harness优先使用宿主插件)
 
-- [doctor 体检](./guides/run-doctor-checks.md)
-- [评测 agent（项目级 runtime context）](./guides/agent-eval.md)
-- [自动迭代 skill](./guides/auto-improve-skills.md)
-- [观测生产 trace](./guides/observe-production.md)
-- [组合 OMK MCP 集成](./guides/mcp-integration.md)
-- [复现 Codex 父子任务观测](./guides/codex-observe-case.md)
-- [使用非 Claude 模型（GLM / 通义 / DeepSeek / Moonshot / Ollama）](./guides/non-claude-models.md)
+## 理解结果与边界
 
-## 我想懂工作原理
+- [为谁做、解决什么](./explanation/who-omk-is-for.md) · [OMK 如何理解知识](./explanation/knowledge.md)
+- [三阶段工作流](./explanation/three-stage-workflow.md) · [架构](./explanation/architecture.md)
+- [统计严谨性](./explanation/statistical-rigor.md) · [评分公式](./specs/scoring.md) · [用例设计](./specs/sample-design-spec.md)
+- [术语表](./reference/glossary.md) · [工具对比](./reference/comparison.md)
 
-- [OMK 如何理解知识](./explanation/knowledge.md)
-- [omk 为谁做、解决什么](./explanation/who-omk-is-for.md) —— 为什么 doctor / eval 是发布前主干，observe 是发布后反馈
-- [三阶段：doctor / eval / observe](./explanation/three-stage-workflow.md)
-- [工作原理](./explanation/architecture.md)
-- [统计严谨性](./explanation/statistical-rigor.md)
-- [评分公式](./specs/scoring.md)
+## 迁移与设计规范
 
-## 我想贡献 / 看设计 spec
-
-- [Evaluation Core vNext RFC](./specs/eval-core-vnext.md)
-- [CLI 评测输入编译规范](./specs/cli-evaluation-input-compilation.md)
-- [用例设计科学性指南](./specs/sample-design-spec.md)
-- [知识建设领域模型（设计草案）](./specs/knowledge-domain-model.md)
-- [知识缺口信号规范](./specs/knowledge-gap-signal-spec.md)
-- [RAG metrics 规范](./specs/rag-metrics-spec.md)
-- [术语规范](./specs/terminology-spec.md)
+- [1.0 Beta 迁移](./guides/v1-preview-migration.md) · [Core 生产切换](./guides/eval-core-cutover.md) · [存储布局](./specs/storage-layout-spec.md)
+- [Core 设计](./specs/eval-core-vnext.md) · [评分等价性](./specs/evaluation-scoring-equivalence.md) · [CLI 输入编译](./specs/cli-evaluation-input-compilation.md)
+- [知识领域模型（草案）](./specs/knowledge-domain-model.md) · [知识缺口信号](./specs/knowledge-gap-signal-spec.md) · [证据门控管理](./specs/evidence-gated-management.md)
+- [RAG metrics](./specs/rag-metrics-spec.md) · [术语规范](./specs/terminology-spec.md)

--- a/docs/zh/guides/v1-preview-migration.md
+++ b/docs/zh/guides/v1-preview-migration.md
@@ -1,6 +1,6 @@
 # 从 0.54 迁移到 1.0 预览版
 
-`1.0.0-beta.0` 是 OMK 新 Evaluation Core 架构的首个公开预览版。它发布到 npm 的 `next` 标签；预览期间，`latest` 继续保持在 `0.54.0`。
+本文面向从 `0.54` 迁移到 1.0 Beta 的用户。Beta 使用 npm 的 `next` 标签，仍会继续迭代；本文说明当前迁移边界，不代表接口冻结或 RC 发布计划。
 
 ```bash
 npm install --global oh-my-knowledge@next
@@ -9,7 +9,7 @@ omk --version
 
 请先在一次性项目中试用，或备份项目 `.omk/` 与 `~/.oh-my-knowledge/` 后再安装预览版。需要回到稳定渠道时，运行 `npm install --global oh-my-knowledge@latest`。
 
-这是 beta，不代表 1.0 契约已经冻结。当前仍有一项重要限制：`omk eval gold init` 只创建通用标注脚手架，还不能从真实 Core run 自动带入 sample ID，因此 Gold authoring 仍需人工对齐。显式 Gold compare 会报告 Krippendorff alpha，但这份事后结果不会自动门控该 run 的 release verdict。[Issue #283](https://github.com/lizhiyao/oh-my-knowledge/issues/283)继续跟踪 RC 前需要补齐的 Gold 引导入口与校准决策闭环。
+**Gold 限制：** `omk eval gold init` 仍生成通用脚手架，真实 sample ID 需要人工对齐。Gold compare 提供人工标注与评委的一致性及事后可靠性评估，不改变已有 run 的发布判定。具体选择器见下方 CLI 迁移说明。
 
 ## 一、重新建立证据历史
 
@@ -67,7 +67,7 @@ omk eval --dry-run --samples eval-samples.yaml \
 公开 API 仅支持 ESM，要求 Node.js 22 或更高版本。import 必须经过 package export map，`oh-my-knowledge/dist/*` 属于私有路径。
 
 - 普通 `evaluate()` 与 `checkExecutor()` façade 从 `oh-my-knowledge` 导入；显式子路径 `oh-my-knowledge/eval-runtime` 与其等价。
-- 将固定的 `{ executor, control, treatment, evaluator }` 调用改为 `{ variants, evaluators, comparisons }`。每个 Executor、config 与 runtime context 都绑定在 `variant.execution` 下；显式声明 `experiment.sampling`；Bootstrap 参数移到 `analysis`；只有一个分析结果需要产出 verdict 时才添加 `decision`。预览版不会读取已移除的结构。
+- 将固定的 `{ executor, control, treatment, evaluator }` 调用改为 `{ dataset, variants, evaluators, comparisons, analyses, experiment, policy }`。执行器与配置绑定在 `variant.execution` 下，抽样设计位于 `experiment.sampling`；每项统计请求放在 `analyses[]`，可选 `decision` 通过 `analysisId` 选择分析结果。运行选项如 `runId`、`signal`、`onEvent` 放在第二个参数；旧结构不再读取。
 - 原包根 Core import 迁移到 `oh-my-knowledge/eval-core`；Engine 构造、分阶段执行、admission、verification、comparability、Series 与 Core JSON Schema 均从该子路径导入。
 - `createEvaluationEngine` 只从 `oh-my-knowledge/eval-core` 导入；`eval-runtime/advanced` 已移除含义模糊的窄化重导出。已装配输入只需一次标准完整运行时，在 advanced 使用 `runEvaluation`。
 - eval-samples、projection、Studio、MCP 与 DSH 集成分别使用 `oh-my-knowledge/eval-samples`、`oh-my-knowledge/projections`、`oh-my-knowledge/studio`、`oh-my-knowledge/mcp` 与 `oh-my-knowledge/dsh-plugin`。
@@ -75,7 +75,7 @@ omk eval --dry-run --samples eval-samples.yaml \
 - Engine Runtime 装配改用 binding resolver，一次返回 resolution 与配置好的 port。
 - Series Analysis 与 Decision Runtime 通过 `openRun()` 打开 run-scoped session，并用 `dispose()` 释放；Series run 必须提供 `runId`，结果是带 terminal status 的 union。
 
-[嵌入式 API 参考](../reference/embedded-api.md)是 canonical contract，并提供完整的独立宿主 fixture。
+普通服务接入以 [Runtime API 参考](../reference/eval-runtime-api.md)为准；高级分阶段接入查[底层 Core API](../reference/embedded-api.md)。
 
 ## 测量边界
 

--- a/docs/zh/quickstart-skill-eval.md
+++ b/docs/zh/quickstart-skill-eval.md
@@ -1,192 +1,103 @@
 # omk 快速上手：跑出第一份 verdict
 
-5 分钟跑出第一份报告，然后把 demo 换成你自己的 skill。目标读者：手里有一版（或几版）skill，想用数据看看「这版 skill 到底好不好」「v2 有没有变好」「能不能带证据发布」。
+先用演示项目跑通“预览 → 评测 → 查看证据”，再换成自己的 skill。运行耗时与费用取决于模型、用例和重试次数。
 
-## 前置（1 分钟）
+## 安装与模型准备
 
-```bash
-npm i oh-my-knowledge -g
-omk --version    # 能输出版本号即装好
-```
-
-准备一个已认证的 runtime：Codex CLI、Claude Code 或 OpenAI 兼容 API。在 ChatGPT desktop 的 Codex 任务里，omk 会自动选择 `codex`，读取 `~/.codex/config.toml` 的模型，并默认让同一个 Codex 模型担任评委；不需要 Claude 账号。
-
-如果你想用「自然语言让 agent 帮你跑」的方式（推荐），还需要把 omk Agent Skill 装到你的 agent 工具里：
+需要 Node.js >=22，以及一个已认证的 runtime：Codex CLI、Claude Code 或 API 执行器。配置方法见[执行器](./reference/executors.md)。
 
 ```bash
-omk install omk-agent-skill
+npm i -g oh-my-knowledge@next
+omk --version
 ```
 
-默认只会安装到本机已检测到、且 omk 明确支持的目标：检测到 `~/.codex` 或 `~/.agents` 时写入 Codex/AGENTS，检测到 `~/.claude` 时写入 Claude Code。要强制写入当前 omk 已知的全部目标，用 `--to all`；要指定自定义 skill 根目录，用 `--dest`。装好之后，agent 收到含「omk」「评测」「benchmark」之类的关键词就会自动加载 SKILL 上下文。
+这里安装的是持续迭代的 1.0 Beta；从 0.54 升级请先看[迁移指南](./guides/v1-preview-migration.md)。
 
-## 最快首跑：先用 demo 脚手架
+在 Codex 任务中，OMK 默认选择 Codex，读取本机配置的模型，并沿用该模型作为评委。普通终端可显式选择：
 
-如果你第一次用 omk，先不要急着接自己的文件，从这里开始：
+```bash
+export OMK_EXECUTOR=codex
+```
+
+模型选择、API 凭证与可选 SDK 的前置要求统一见[执行器文档](./reference/executors.md)。
+
+## 1. 跑通演示项目
 
 ```bash
 omk init demo
 cd demo
 omk eval --control code-review-v1 --treatment code-review-v2 --dry-run
+```
+
+`init` 创建两版 skill 和三条评测用例。`--dry-run` 预览执行计划和预估调用次数；检查后再执行真实评测：
+
+```bash
 omk eval --control code-review-v1 --treatment code-review-v2
 ```
 
-`omk init` 会创建两版 skill 和三条评测用例。`--dry-run` 先预览 sealed task plan 和预估调用次数；真跑后会在 Studio 打开 Core run。demo 只有三条用例，verdict 经常是 `UNDERPOWERED`，这是正常教学结果，不是运行失败。
+真实评测会调用模型，并默认先执行 doctor 检查。模型费用与耗时以所选 runtime 为准，预览不是账单保证。完成后按 CLI 返回的实际地址查看 Studio；也可以用 `omk studio` 打开历史结果。
 
-希望第一次运行就达到 omk 默认的启发式证据下限，可以改用官方 20 条完整起步集：
+三条用例用于验证流程，出现 `UNDERPOWERED` 符合预期。若要使用完整起步集，在新目录运行 `omk init demo-full --samples 20`。该集合覆盖四个维度、不同难度与无缺陷对照，会产生 40 次 control／treatment 执行，另有评分与检查调用。
 
-```bash
-omk init demo --samples 20
-```
+**起步用例标记为 `provenance: llm-generated`。** 20 条仅达到默认启发式证据下限，不代表完成先验功效规划，也不等于正式发布证据。使用前应人工复核并替换为真实领域用例。
 
-完整用例集在安全、健壮性、可维护性、性能四个维度各有 5 条，覆盖 easy／medium／hard 难度，并包含无缺陷对照，避免把「报告更多问题」误当成更好的审查。它会产生 40 次 control／treatment 执行，因此默认 3 条仍然是验证环境最省成本的入口。固定起步用例明确标记为 `provenance: llm-generated`：20 条只达到默认启发式证据下限，不等于完成先验功效规划，也仍是教学数据而非生产发布证据。信任 ship／no-ship 判断前，应人工复核并替换为真实领域用例。
+## 2. 换成自己的 skill
 
-在 Codex 任务里，上面的最短命令无需添加 runtime 参数。普通终端想固定使用 Codex，可以把偏好加入 shell 配置，例如 `~/.zshrc`：
+在自己的项目中准备两版文件：
 
-```bash
-export OMK_EXECUTOR=codex
-# 可选：export OMK_MODEL="你的 Codex 模型"
-```
-
-不设置 `OMK_MODEL` 时，omk 会读取 `~/.codex/config.toml` 的模型。也可以逐次显式指定；Codex 被选中后，默认评委自动沿用被测模型，不用重复写 `--judge-models`：
-
-```bash
-omk eval --control code-review-v1 --treatment code-review-v2 \
-  --executor codex --model <codex-model>
-
-# OpenAI 兼容 API 路径
-export OPENAI_API_KEY="..."
-export OPENAI_BASE_URL="https://api.example.com/v1"
-omk eval --control code-review-v1 --treatment code-review-v2 \
-  --executor openai-api --model <model> \
-  --judge-models openai-api:<model>
-```
-
-Codex 的 `<codex-model>` 要换成本机 Codex 可用模型；omk 默认读取 `~/.codex/config.toml` 或 `$CODEX_HOME/config.toml` 里的顶层 `model`。OpenAI 兼容 API 则要确认模型名和 `OPENAI_BASE_URL` 指向的端点匹配。
-
-## 准备 skill（1 分钟）
-
-按 omk 默认布局把 skill 放到 `skills/` 目录下。**推荐用单 `.md` 文件**，最简单：
-
-```
+```text
 skills/
 ├── my-skill-v1.md
 └── my-skill-v2.md
 ```
 
-只有当 skill 内容超长、想把示例 / 参考资料拆到独立文件时，再用目录式（每版一个目录）：
-
-```
-skills/
-├── my-skill-v1/
-│   └── SKILL.md
-└── my-skill-v2/
-    ├── SKILL.md
-    └── references/      长示例 / 参考资料
-        └── examples.md
-```
-
-两种形式 omk 都能识别，混用也行。要跑 v1 vs v2 对比就按上面放两版；只想看「有 skill vs 没 skill」的差距，放一份就够，用 baseline 对照。
-
-## 把 demo 换成你自己的 skill
-
-### 路径 A：自然语言（推荐）
-
-打开你的 coding agent，进入项目目录，直接说一句话：
-
-> 用 omk 对比 skills/my-skill-v1 跟 skills/my-skill-v2
-
-omk skill 会自动判断：没有 `eval-samples.json` 就先帮你生成用例，然后跑评测，最后把报告浏览器弹出来。Claude Code 可以直接使用已安装的 omk skill；在 Codex 里则让 agent 执行 `omk` CLI。常见说法：
-
-- 「用 omk 对比 skills/my-skill-v1 跟 skills/my-skill-v2」
-- 「用 omk 给 skills/audit 跑 baseline 对照（有 skill vs 没 skill）」
-- 「用 omk 跑 skills/ 下面所有 skill 的批量评测」
-- 「用 omk evolve 自动改进 skills/my-skill-v2，跑 5 轮」
-
-### 路径 B：直接命令行
-
-如果你只有一版 skill，最短有用对比是「有这个 skill」vs `baseline`：
+需要附带参考资料时，可使用 `skills/my-skill-v2/SKILL.md` 目录布局，详见[知识载体布局](./reference/artifact-layout.md)。variant 名取文件名或目录名，例如 `my-skill-v2`。
 
 ```bash
-omk sample skills/my-skill.md                         # 第一次：让 AI 给你的 skill 生成评测用例
-omk eval --control baseline --treatment my-skill --dry-run
-omk eval --control baseline --treatment my-skill
+omk sample skills/my-skill-v2.md
 ```
 
-如果你已经有 v1 / v2 两版，再做版本对比：
+生成后先人工检查用例的准则、权重、反例与边界覆盖。比较两版时使用同一份固定用例；从演示项目继续操作时，应替换演示用例，不要把它们当成自己的领域用例。
 
 ```bash
-omk sample skills/my-skill-v2.md                                  # 第一次:让 AI 给你的 skill 生成评测用例
-omk eval --control my-skill-v1 --treatment my-skill-v2 --dry-run  # 预览要跑什么
-omk eval --control my-skill-v1 --treatment my-skill-v2            # 真跑
-omk studio                                                        # 启动报告浏览器
+omk eval --control my-skill-v1 --treatment my-skill-v2 --dry-run
+omk eval --control my-skill-v1 --treatment my-skill-v2
 ```
 
-variant 名来自 `skills/` 下的 skill 文件名或目录名；`skills/my-skill.md` 对应 `my-skill`，上面的 v1 / v2 布局对应 `my-skill-v1` 和 `my-skill-v2`。
+只有一版 skill 时，用 `baseline` 作为 control，比较“无 skill”和“有 skill”。用例的格式和自动发现规则见[评测用例格式](./reference/eval-sample-format.md)。
 
-`--dry-run` 预览时会告诉你预估调用次数和成本，确认 OK 再去掉 flag 真跑。`omk eval` 默认会先跑一次 doctor 健康度检查当门禁，发现 skill 写法有大问题就直接拦下来；如果你确认知道自己在干嘛，加 `--skip-doctor` 绕过。
+## 3. 查看结果并决定下一步
 
-### 模型或执行器失败时
-
-CLI 会尽量把首跑失败变成可执行的下一步：
-
-- Claude 失败：先登录 Claude Code，或按上面的参数切到 Codex / OpenAI API。
-- Codex 模型失败：换成 `~/.codex/config.toml` 或 `$CODEX_HOME/config.toml` 里配置的模型，再用 `codex exec -m <codex-model> "hi"` 验证。
-- OpenAI / Anthropic API 模型失败：检查 `--model`、`--judge-models`、base URL，以及账号是否有该模型权限。
-- 如果只是想先验证断言和报告链路，加 `--no-judge`；它会跳过 LLM 评委，只使用断言分数。
-
-## 看结果（1 分钟）
-
-报告浏览器自动弹出（默认 `http://127.0.0.1:7799/`），重点看三个地方：
-
-**verdict**（跨版本判定）：`PROGRESS`（变好）/ `NOISE`（差距在置信区间内不可区分）/ `REGRESSION`（变差）/ `CAUTIOUS`（趋势好但置信不足）；外加两档边界情况 `UNDERPOWERED`（用例太少，不足以判定）与 `SOLO`（单变体，无可对比）。这是你能直接拿出去对焦的一句话判定。
-
-**综合分**：每版 0-5 分平均，跟基线比 `+Δ` 多少。Δ 旁边的置信区间决定 verdict 落点 —— 默认 95%，多个实验组共用一个对照时按 Bonferroni 提到更高置信水平。
-
-**低分用例**：点开看 LLM 在哪条用例上崩了。对照「rubric 期望」跟「LLM 实际输出」找差距 —— 通常能直接看出 skill 文档哪段写得不够清楚。
-
-## 按 verdict 行动
+先看 **verdict**（跨版本判定）及其 reason code，再看差异 Δ、报告给出的置信区间、证据覆盖与失败用例。默认单一比较使用 95% 置信区间，比较家族会调整置信水平；发布判定还受证据与策略门禁约束。
 
 | Verdict | 下一步 |
 |---|---|
-| `PROGRESS` | 可以走正常发布流程。留存报告作为发布证据；如果这是已用 `omk install` 纳管的 skill，再运行 `omk promote <name>` 记录接受决定。 |
-| `CAUTIOUS` | 不要盲发。先看触发的告警（分层门控、评委分歧、稳定性或 holdout），修完再重跑；只有明确人工复核后才放宽门禁。 |
-| `REGRESSION` | 不要发布。从最差层和失败用例开始定位，修好 artifact 后重跑评测。 |
-| `NOISE` | 暂不做发布判断。增加用例，或提高用例集区分度，让差异能从噪声里分离出来，再重跑。 |
-| `UNDERPOWERED` | 补齐预注册的样本量要求后重跑。没有先验规划时，20 个可比较单元只是 omk 默认的启发式下限；正式研究应根据外部先导假设配置 `decision.power`，或用 `decision.minimumComparisonUnits` 登记 simulation 得出的要求。 |
-| `SOLO` | 先补对照组，通常用 `omk eval --control baseline --treatment <name>`，再做发布 / 不发布判断。 |
+| `PROGRESS` | 证据支持改进。复核用例代表性与告警后进入自己的发布流程；已纳管的 skill 可用 `omk promote <name>` 记录接受决定。 |
+| `CAUTIOUS` | 阅读报告的具体原因和告警，处理后重新评测，暂不自动接受。 |
+| `REGRESSION` | 从失败用例与变差的指标定位问题，修改后重新评测。 |
+| `NOISE` | 当前证据无法区分差异。检查用例区分度与样本设计，再决定是否补充测量。 |
+| `UNDERPOWERED` | 补齐预先声明的样本量要求。20 个可比较单元只是默认启发式下限；正式测量应根据外部先导假设配置 `decision.power`，或登记 `decision.minimumComparisonUnits`。 |
+| `SOLO` | 添加对照组后再做跨版本判断。 |
 
-## 关键提示
+结论只适用于本次用例、准则和运行条件。AI 生成用例可能偏向已有的成功路径，应补充真实失败、反例与误用场景。保留报告、用例来源和人工复核结论；在迭代中使用过的用例不能直接充当独立发布验证集。方法见[统计严谨性](./explanation/statistical-rigor.md)和[用例设计](./specs/sample-design-spec.md)。
 
-**用例生成会花时间**。omk 默认让 AI 给你的 skill 生成 10-20 条用例，但 AI 生成的用例**有偏**：容易扎堆在 skill 文档已经写清楚的「happy path」上，对边界 / 反例 / 误用场景覆盖不足。**强烈建议**第一次跑完之后花 30 分钟人工筛一遍：删掉不合理的、补缺关键边界、补几条「故意写错的用户指令」看 skill 会不会被带偏。这是评测结果可信度的最大变量。
+## 在 Agent 中使用
 
-**评测会产生 LLM 费用**。粗算单条用例 × 单 variant 约 $0.01-0.05 美元，10 条用例 × 2 variants 约 $0.2-1 美元。跑前 `--dry-run` 预览。
+```bash
+omk install omk-agent-skill
+```
 
-**结论只对你给定的用例集负责**。「我这版 skill 更好」这句话的天花板是「在你设计的 N 条用例上更好」。换用例集结论可能翻盘。所以**用例设计本身就是结论可信度的源头** —— 不要把它当成「跑评测前的麻烦事」，它就是评测本身。
+默认安装到检测到的受支持目标：`~/.codex` 或 `~/.agents` 对应 Codex/AGENTS，`~/.claude` 对应 Claude Code。`--to all` 强制安装到当前已知的全部目标，`--dest` 指定自定义 skill 根目录。
 
-## 常见场景速查
+在 Agent 中显式使用 OMK Skill，并描述目标，例如：“用 omk 比较 skills/my-skill-v1 与 skills/my-skill-v2，先预览计划。”Claude Code 可使用已安装的 `/omk` 入口；其他宿主可让 Agent 执行 `omk` CLI。生成用例后仍需复核，再执行真实评测。
 
-| 想做什么 | 自然语言说法 | 等价命令 |
-|---|---|---|
-| 第一次给 skill 跑分 | 给 skills/X 跑 baseline 对照 | `omk eval --control baseline --treatment X` |
-| 改完前后对比 | 对比 git 历史里的 skills/X 跟当前版本 | `omk eval --control git:X --treatment X` |
-| 让 omk 帮我自动改 skill | 用 omk evolve skills/X 跑 5 轮 | `omk evolve skills/X.md --rounds 5` |
-| 批量评测一批 skill | 给 skills/ 下所有 skill 跑评测 | `omk eval --batch` |
-| 只生成用例不跑评测 | 给 skills/X 生成测试用例 | `omk sample skills/X.md` |
-| 单独跑健康度检查 | 给 skills/X 做 doctor 体检 | `omk doctor skills/X.md` |
-| 看历史报告 | 打开 omk studio | `omk studio` |
+## 首跑遇到问题
 
-## 跑完第一份报告，对焦时拿这些信息走
+- **模型或认证失败：** 检查 runtime 登录状态、模型名与 API 地址，见[执行器](./reference/executors.md)。
+- **doctor 拦截：** 按诊断修复知识载体后重跑；需要理解跳过检查的影响时查 [CLI 参考](./reference/cli.md)。
+- **只想检查断言与报告：** `--no-judge` 跳过 LLM 评委，但目标执行仍可能调用模型，不能视为离线或免费运行。
+- **预览失败：** 先修复用例、路径或 URL 解析问题，不要通过直接执行绕过失败。
 
-- verdict + 综合分 + Δ + 95% CI 区间
-- 哪几条用例分数最低，rubric 期望 vs LLM 实际差在哪
-- 你对哪些用例的设计有疑问（避免「数据说话也要怀疑数据」的盲信）
-- doctor 健康度结论（eval 默认会跑，报告里有；如果想单独审一次跑 `omk doctor`）
+## 继续使用
 
-## 更深的玩法
-
-- 心智模型 —— [三阶段：doctor / eval / observe](./explanation/three-stage-workflow.md)
-- 一次运行到底怎么跑：[工作原理](./explanation/architecture.md)
-- 详细 CLI / executor / judge / observe 参考：[README.zh.md](https://github.com/lizhiyao/oh-my-knowledge/blob/main/README.zh.md)
-- 评分管道（assertion / llm / judge / dimension / composite 五层）：[scoring.md](./specs/scoring.md)
-- 测量学严谨性（Bootstrap CI / Krippendorff α / length-debias 等）：[statistical-rigor.md](./explanation/statistical-rigor.md)
-- 用例设计规范（mocks / environment / tripwire / mocksStrict）：[sample-design-spec.md](./specs/sample-design-spec.md)
+[自动改进 skill](./guides/auto-improve-skills.md) · [观测真实任务](./guides/observe-production.md) · [Node.js 服务接入](./guides/eval-runtime.md) · [完整文档索引](./README.md)


### PR DESCRIPTION
README、首页与快速上手原先重复介绍特性和配置，用户需要来回跳转才能找到首跑路径。本次同步精简中英文入口，按命令行比较、Node.js 服务接入和真实任务观测组织导航；详细配置与方法统一链接到参考文档。

快速上手明确先预览再执行、生成用例需人工复核，并保留小样本、功效规划、独立验证集与模型费用的边界。迁移指南更新为持续 Beta 迭代的表述，修正当前 evaluate() 参数结构及参考入口；存储兼容性和 Gold 限制继续保留。没有运行时、公开 API、评分口径或存储契约变更。

验证：完整 yarn ci 通过（344 个测试文件、3748 条测试）；最后的文档命令调整后，命令引用、双语链接与 facade 文档检查再次通过。首页链接和静态资源已核对，并检查了中英文页面排版。未运行付费模型评测。

自主 CR：已复核最终变更、迁移契约、首页脚本兼容性和验证证据，无未解决 finding。
