### PR TITLE
fix(cli): 修复评测首次接入与结果提示

### DIFF
--- a/.agents/skills/omk/SKILL.md
+++ b/.agents/skills/omk/SKILL.md
@@ -26,7 +26,7 @@ argument-hint: "<doctor|eval|evolve|init|install|list|observe|promote|rollback|s
 除 `$omk feedback` 快捷入口外，运行 `which omk` 检查是否已安装。如果未安装，告诉用户：
 
 ```
-npm i oh-my-knowledge -g
+npm i -g oh-my-knowledge@next
 ```
 
 omk CLI 顶层命令包括：`init` / `install` / `list` / `promote` / `rollback` / `doctor` / `eval` / `observe` / `evolve` / `sample` / `studio`。没有 `bench` / `improve` / `gen-samples` 这些旧子命令名 —— 如果你在历史 SKILL / 文档里看到了，那是 v0.30 命令树重构之前的写法。

--- a/.agents/skills/omk/references/commands.md
+++ b/.agents/skills/omk/references/commands.md
@@ -85,7 +85,7 @@ omk eval [flags]
 - `--control-cwd` `option`:对照组（control）的 runtime context 目录
 - `--dry-run` `boolean`:只 plan 不实跑
 - `--effort` `option`:被测 LLM 扩展思考预算 low/medium/high/xhigh/max（默认 low；跨 effort 报告不严格可比）。
-- `--executor` `option`:执行器：claude / claude-sdk / codex / codex-sdk / anthropic-api / openai-api / 自定义命令。Codex 任务内自动用 codex；也可用 OMK_EXECUTOR 设置环境偏好。
+- `--executor` `option`:执行器：claude / claude-sdk / codex / codex-sdk / anthropic-api / openai-api / 自定义可执行文件路径（不接受带参数的命令字符串）。Codex 任务内自动用 codex；也可用 OMK_EXECUTOR 设置环境偏好。
 - `--global` `boolean`:报告写全局 ~/.oh-my-knowledge/eval，而非项目 .omk/eval
 - `--gold-dir` `option`:gold dataset 目录
 - `--holdout-ratio` `option`:留出比例 0-1（如 0.3）；切出 holdout 子集，对比 train/holdout 综合分检测过拟合

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -240,7 +240,7 @@ Runs the offline evaluation, applies the verdict gate, persists the report, and 
   --control-cwd <value>           Runtime context dir for control
   --dry-run                       Plan only, no real exec
   --effort <value>                Executor LLM reasoning effort low/medium/high/xhigh/max (default low; reports across efforts not strictly comparable).
-  --executor <value>              Executor: claude / claude-sdk / codex / codex-sdk / anthropic-api / openai-api / custom. Defaults to codex inside Codex tasks; OMK_EXECUTOR sets an environment preference.
+  --executor <value>              Executor: claude / claude-sdk / codex / codex-sdk / anthropic-api / openai-api / custom executable file path (not a command string with arguments). Defaults to codex inside Codex tasks; OMK_EXECUTOR sets an environment preference.
   --global                        Write report to global ~/.oh-my-knowledge/eval instead of project .omk/eval
   --gold-dir <value>              Gold dataset dir
   --holdout-ratio <value>         Holdout fraction 0-1 (e.g. 0.3); splits a holdout subset, compares train/holdout composite to flag overfitting

--- a/docs/reference/executors.md
+++ b/docs/reference/executors.md
@@ -95,24 +95,65 @@ dsh plugin --profile web add /absolute/path/to/oh-my-knowledge
 
 ## Custom executor
 
-Any shell command can serve as an executor, communicating via stdin/stdout JSON:
+`omk eval --executor` accepts **one executable file path**, resolved relative to the evaluation project. Commands with arguments such as `node my-provider.mjs` or `python my-provider.py` are not executed as shell commands. Add a shebang and execution permission to scripts; use an executable wrapper when your service needs arguments.
 
-```bash
-omk eval --executor "python my_provider.py"
-omk eval --executor "./my-executor.sh"
+### Verify stdin/stdout first
+
+Save this as `my-executor.mjs`. It returns fixed text to verify integration, calls no model, and does not measure skill effectiveness:
+
+```js
+#!/usr/bin/env node
+let text = '';
+for await (const chunk of process.stdin) text += chunk;
+const request = JSON.parse(text);
+if (request.schemaVersion !== 'omk.custom-command-exchange/v1') {
+  throw new Error('Unsupported OMK request');
+}
+// To connect your service, read request.trial.input and return its actual output.
+console.log(JSON.stringify({
+  schemaVersion: 'omk.custom-command-exchange/v1',
+  resultStatus: 'completed',
+  output: { value: 'Integration works', classification: 'public' },
+}));
 ```
 
-**Protocol:**
+In a project created by `omk init`, run:
 
-- **input** (stdin): JSON `{"model":"...","system":"...","prompt":"..."}`
-- **output** (stdout): JSON `{"ok":true,"output":"model reply","inputTokens":0,"outputTokens":0,"costUSD":0}`; `ok` may be omitted for compatibility
-- return `{"ok":false,"error":"reason"}` to report a structured execution failure
-- stdout only needs to return the fields you care about; others default to 0. Plain-text output (no tokens/cost parsing) is also fine.
-- to expose source-neutral agent evidence, add `turns`, `toolCalls`, `fullNumTurns`, and `numSubAgents`. Each tool call includes `tool`, JSON `input` / `output`, `success`, and optionally `status` (`success` / `failure` / `cancelled` / `unknown`) plus source identity fields. Malformed trace fields fail the execution instead of being dropped.
-- token usage is authoritative only when all four counters are present: `inputTokens`, `outputTokens`, `cacheReadTokens`, and `cacheCreationTokens`. Otherwise the report marks token usage as unreported.
-- local script or executable bytes referenced by the command are part of the runtime fingerprint; changing the file invalidates cache and strict comparability even when the command string stays unchanged.
-- an empty JSON `output` or whitespace-only plain-text output counts as failure
-- non-zero exit code counts as failure
+```bash
+chmod +x my-executor.mjs
+omk eval --control code-review-v1 --treatment code-review-v2 \
+  --executor ./my-executor.mjs --skip-connectivity --no-judge \
+  --no-serve --report-only
+```
+
+This checks target execution and assertion scoring. `--no-judge` explicitly disables LLM judging; `--report-only` does not use the release gate to choose the exit code. The fixed answer is expected to fail the demo assertions. Check successful execution coverage, then connect your service.
+
+### Connect your service
+
+Each attempt starts a process that receives one JSON request on stdin and must return one JSON response on stdout. Send logs to stderr. The current protocol is `omk.custom-command-exchange/v1`; it rejects the old `{ ok, output: "..." }` response and plain text.
+
+| Request field | Purpose |
+|---|---|
+| `trial.input` | Resolved task input, usually a string for CLI text samples. |
+| `trial.targetConfig.runtime` | Runtime configuration, including model and effort. |
+| `trial.targetConfig.behavior.artifact` | Resource descriptor for the knowledge artifact under test. |
+| `resources` | Readable resource snapshots for this execution, matched to descriptors by `resourceId`; `snapshotPath` is temporary. |
+| `trial.trialSeed` | Measurement seed; use it only if your service actually supports it. |
+| `attempt` | Attempt identity and retry number. |
+
+To measure a prompt or skill change, find the artifact snapshot in `resources` using its descriptor and make the service consume that content. Reading only the task input ignores the knowledge under test. Do not read the original skill outside the snapshot or send expected answers to the target service. Resources last only for this lifecycle; do not persist their temporary paths.
+
+On success, return `resultStatus: 'completed'` and `output: { value, classification }`, where `value` can be a JSON value. Choose `public`, `sensitive`, or `secret` to match the actual content; optional `trace` uses the same structure. Optional `usage` follows Core's `UsageRecord` contract. Omit unreported usage instead of presenting zero as a measurement.
+
+Report invocation failure with a stable error code:
+
+```json
+{"schemaVersion":"omk.custom-command-exchange/v1","resultStatus":"failed","error":{"code":"SERVICE_UNAVAILABLE","stage":"execution"}}
+```
+
+`stage` is `execution` or `infrastructure`. Nonzero exits, timeouts, and invalid responses are also execution failures; for example, an old-protocol response produces `OMK_CUSTOM_COMMAND_OUTPUT_INVALID`. Inspect execution coverage and failure evidence in the report rather than interpreting failure as a low-scoring answer.
+
+This protocol applies to targets executed by `omk eval`. Model calls from `doctor`, `sample`, and `evolve`, and custom LLM judges still use the old `{ model, system, prompt }` adapter interface. Do not use a script implementing only this section's protocol for those model calls. Configure a supported judge separately through `--judge-models` when needed.
 
 ## Prerequisites
 

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -240,7 +240,7 @@ omk eval gold compare <run-id> --gold-dir gold-dataset \
   --control-cwd <value>           对照组（control）的 runtime context 目录
   --dry-run                       只 plan 不实跑
   --effort <value>                被测 LLM 扩展思考预算 low/medium/high/xhigh/max（默认 low；跨 effort 报告不严格可比）。
-  --executor <value>              执行器：claude / claude-sdk / codex / codex-sdk / anthropic-api / openai-api / 自定义命令。Codex 任务内自动用 codex；也可用 OMK_EXECUTOR 设置环境偏好。
+  --executor <value>              执行器：claude / claude-sdk / codex / codex-sdk / anthropic-api / openai-api / 自定义可执行文件路径（不接受带参数的命令字符串）。Codex 任务内自动用 codex；也可用 OMK_EXECUTOR 设置环境偏好。
   --global                        报告写全局 ~/.oh-my-knowledge/eval，而非项目 .omk/eval
   --gold-dir <value>              gold dataset 目录
   --holdout-ratio <value>         留出比例 0-1（如 0.3）；切出 holdout 子集，对比 train/holdout 综合分检测过拟合

--- a/docs/zh/reference/executors.md
+++ b/docs/zh/reference/executors.md
@@ -95,24 +95,65 @@ dsh plugin --profile web add /absolute/path/to/oh-my-knowledge
 
 ## 自定义执行器
 
-任何 shell 命令都可以作为执行器，通过 stdin/stdout JSON 协议通信：
+`omk eval --executor` 接受**一个可执行文件路径**。路径相对于评测项目目录解析；`node my-provider.mjs`、`python my-provider.py` 这样的带参数命令不会被当作 shell 命令执行。脚本须有 shebang 和执行权限；需要参数时，用一个可执行包装脚本调用你的服务。
 
-```bash
-omk eval --executor "python my_provider.py"
-omk eval --executor "./my-executor.sh"
+### 先跑通 stdin/stdout
+
+把下面保存为 `my-executor.mjs`。它只返回固定文字，用于验证接入，不调用模型，也不证明 skill 的效果：
+
+```js
+#!/usr/bin/env node
+let text = '';
+for await (const chunk of process.stdin) text += chunk;
+const request = JSON.parse(text);
+if (request.schemaVersion !== 'omk.custom-command-exchange/v1') {
+  throw new Error('Unsupported OMK request');
+}
+// 接入服务时，读取 request.trial.input，返回服务的实际输出。
+console.log(JSON.stringify({
+  schemaVersion: 'omk.custom-command-exchange/v1',
+  resultStatus: 'completed',
+  output: { value: '接入成功', classification: 'public' },
+}));
 ```
 
-**协议约定：**
+在 `omk init` 创建的项目内运行：
 
-- **输入**（stdin）：JSON `{"model":"...","system":"...","prompt":"..."}`
-- **输出**（stdout）：JSON `{"ok":true,"output":"模型回复","inputTokens":0,"outputTokens":0,"costUSD":0}`；为兼容旧脚本，可以省略 `ok`
-- 返回 `{"ok":false,"error":"失败原因"}` 可显式报告执行失败
-- stdout 中只需返回有值的字段，其余默认为 0；也可以直接输出纯文本（不解析 token/成本）
-- 要暴露 source-neutral agent 证据，可增加 `turns`、`toolCalls`、`fullNumTurns`、`numSubAgents`。每条 tool call 包含 `tool`、JSON `input` / `output`、`success`，并可带 `status`（`success` / `failure` / `cancelled` / `unknown`）及来源身份字段。trace 字段格式错误时整次执行失败，不会静默丢弃。
-- 只有四个 token 计数 `inputTokens`、`outputTokens`、`cacheReadTokens`、`cacheCreationTokens` 全部存在时，token 使用量才视为 runtime 实测；否则报告标记为未报告。
-- 命令引用的本地脚本或可执行文件字节会进入 runtime 指纹；即使命令字符串不变，文件内容变化也会让 cache 与 strict comparability 失效。
-- JSON 中的 `output` 为空，或纯文本只含空白，均视为失败
-- 非零退出码视为执行失败
+```bash
+chmod +x my-executor.mjs
+omk eval --control code-review-v1 --treatment code-review-v2 \
+  --executor ./my-executor.mjs --skip-connectivity --no-judge \
+  --no-serve --report-only
+```
+
+这条命令只验证目标执行与断言评分，`--no-judge` 显式关闭 LLM 评委，`--report-only` 不以发布门禁决定退出码。固定回答不能满足演示题目的断言是预期现象；检查执行覆盖是否成功，再替换为真实服务。
+
+### 接入自己的服务
+
+每次尝试启动一个进程，stdin 接收一个 JSON 请求，stdout 必须返回一个 JSON 响应。日志写到 stderr。当前协议是 `omk.custom-command-exchange/v1`，不接受旧的 `{ ok, output: "..." }` 或纯文本响应。
+
+| 请求字段 | 用途 |
+|---|---|
+| `trial.input` | 解析后的题目输入；CLI 文本用例通常是字符串。 |
+| `trial.targetConfig.runtime` | 模型、effort 等运行配置。 |
+| `trial.targetConfig.behavior.artifact` | 被测知识载体的资源描述符。 |
+| `resources` | 本次执行可读取的资源快照，用 `resourceId` 与描述符关联；`snapshotPath` 是临时路径。 |
+| `trial.trialSeed` | 测量种子；仅在你的服务实际支持时使用。 |
+| `attempt` | 本次尝试的身份与重试序号。 |
+
+要测量 prompt／skill 改动，需要按 artifact 描述符在 `resources` 中找到知识快照，并让服务实际使用其中内容；只读取题目会忽略被测知识。不要在快照之外读取原始 skill，也不要把标准答案交给被测服务。资源仅在本次生命周期内有效，不持久化这些临时路径。
+
+成功返回 `resultStatus: 'completed'` 和 `output: { value, classification }`，其中 `value` 可为 JSON 值。数据分类按真实内容选择 `public`、`sensitive` 或 `secret`；可选 `trace` 使用同样结构。可选 `usage` 使用 Core 的 `UsageRecord` 契约，不提供用量就保持缺失，不能填零冒充实测。
+
+调用失败可以返回稳定的错误代码：
+
+```json
+{"schemaVersion":"omk.custom-command-exchange/v1","resultStatus":"failed","error":{"code":"SERVICE_UNAVAILABLE","stage":"execution"}}
+```
+
+`stage` 为 `execution` 或 `infrastructure`。非零退出、超时和非法响应同样会记录为执行失败；例如旧协议输出会产生 `OMK_CUSTOM_COMMAND_OUTPUT_INVALID`。从报告的执行覆盖和失败证据排查，不能把失败当成低分答案。
+
+上述协议用于 `omk eval` 的目标执行。`doctor`／`sample`／`evolve` 的模型调用接口及自定义 LLM 评委仍使用旧的 `{ model, system, prompt }` 适配接口；不要把仅实现本节协议的脚本直接用作那些模型调用。需要评委时通过 `--judge-models` 单独配置受支持的执行器。
 
 ## 前置要求
 

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -4,6 +4,7 @@ import { Flags } from '@oclif/core';
 import { LANG_FLAG, bilingual } from '../../oclif/i18n.js';
 import { BaseCommand } from '../../oclif/base-command.js';
 import { enumStringParser, integerStringParser, numberStringParser } from '../../oclif/parsers.js';
+import { formatEvaluationInputFailure, formatEvaluationSummary } from '../../lib/eval-output.js';
 import { CliExit } from '../../lib/cli-exit.js';
 import { tCli, type CliLang } from '../../lib/i18n.js';
 import { prepareCliEvaluation, type PreparedCliEvaluation } from '../../lib/prepare-evaluation.js';
@@ -216,14 +217,7 @@ async function runEval(
         && (result.output as { projectionKind?: string }).projectionKind === 'core-cli-dry-run') {
       console.log(JSON.stringify(result.output, null, 2));
     } else {
-      const outcome = result.output as {
-        status?: { runStatus?: string; evidenceStatus?: string; conclusionStatus?: string };
-        gate?: { gateStatus?: string; reasonCodes?: readonly string[] };
-      };
-      process.stdout.write(
-        `Core: ${outcome.status?.runStatus ?? 'prepared'}／${outcome.status?.evidenceStatus ?? 'n/a'}／${outcome.status?.conclusionStatus ?? 'n/a'}\n`
-        + `Gate: ${outcome.gate?.gateStatus ?? 'not-applicable'}${outcome.gate?.reasonCodes?.length ? `（${outcome.gate.reasonCodes.join(', ')}）` : ''}\n`,
-      );
+      process.stdout.write(formatEvaluationSummary(result.output, lang));
     }
     // A blocked gate exits immediately through oclif; flush a piped JSON report first.
     await new Promise<void>((resolve, reject) => {
@@ -232,7 +226,7 @@ async function runEval(
     throw new CliExit(result.exitCode);
   } catch (err: unknown) {
     if (err instanceof CliExit) throw err;
-    const message = err instanceof Error ? err.message : String(err);
+    const message = formatEvaluationInputFailure(err, lang);
     console.error(tCli('cli.common.error_prefix', lang, {
       message: `${message}${formatConnectivityFailureHint(message, {
         executorName: request.values.targetRuntime.executorId,
@@ -310,8 +304,8 @@ export default class Eval extends BaseCommand {
     }),
     executor: Flags.string({
       description: bilingual({
-        zh: '执行器：claude / claude-sdk / codex / codex-sdk / anthropic-api / openai-api / 自定义命令。Codex 任务内自动用 codex；也可用 OMK_EXECUTOR 设置环境偏好。',
-        en: 'Executor: claude / claude-sdk / codex / codex-sdk / anthropic-api / openai-api / custom. Defaults to codex inside Codex tasks; OMK_EXECUTOR sets an environment preference.',
+        zh: '执行器：claude / claude-sdk / codex / codex-sdk / anthropic-api / openai-api / 自定义可执行文件路径（不接受带参数的命令字符串）。Codex 任务内自动用 codex；也可用 OMK_EXECUTOR 设置环境偏好。',
+        en: 'Executor: claude / claude-sdk / codex / codex-sdk / anthropic-api / openai-api / custom executable file path (not a command string with arguments). Defaults to codex inside Codex tasks; OMK_EXECUTOR sets an environment preference.',
       }),
     }),
     'judge-models': Flags.string({

--- a/src/cli/lib/eval-output.ts
+++ b/src/cli/lib/eval-output.ts
@@ -1,0 +1,58 @@
+import type { CoreCliRunOutcome } from '../../eval-workflows/projections/contracts.js';
+import { CliEvaluationInputError } from '../../eval-workflows/hosts/application.js';
+import { tCli, type CliLang } from './i18n.js';
+import type { CliMessageKey } from './i18n-dict.js';
+
+const VERDICT_HINTS: Readonly<Record<string, CliMessageKey>> = {
+  PROGRESS: 'cli.run.next.progress',
+  REGRESSION: 'cli.run.next.regression',
+  NOISE: 'cli.run.next.noise',
+  UNDERPOWERED: 'cli.run.next.underpowered',
+  CAUTIOUS: 'cli.run.next.inspect',
+  SOLO: 'cli.run.next.solo',
+};
+
+export function formatEvaluationInputFailure(error: unknown, lang: CliLang): string {
+  if (error instanceof CliEvaluationInputError
+      && error.code === 'CLI_INPUT_RESOLUTION_FAILED'
+      && error.fieldPath === 'targetRuntime.executorId') {
+    return tCli('cli.run.custom_executor_path', lang);
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function formatEvaluationSummary(output: unknown, lang: CliLang): string {
+  if (!output || typeof output !== 'object'
+      || !('projectionKind' in output) || output.projectionKind !== 'core-cli-run-outcome') {
+    return `${JSON.stringify(output, null, 2)}\n`;
+  }
+  const result = output as CoreCliRunOutcome;
+  const decision = result.decision;
+  const verdict = decision?.decisionStatus === 'decided' ? decision.verdict : '—';
+  const execution = result.stages.execution.coverage;
+  const evaluation = result.stages.evaluation.coverage;
+  const incomplete = result.status.runStatus !== 'completed'
+    || result.status.evidenceStatus !== 'complete'
+    || result.status.conclusionStatus !== 'conclusive'
+    || result.decision?.decisionStatus !== 'decided';
+  const next = incomplete ? 'cli.run.next.evidence'
+    : result.gate.gateStatus === 'blocked' && verdict === 'PROGRESS' ? 'cli.run.next.inspect'
+      : Object.hasOwn(VERDICT_HINTS, verdict) ? VERDICT_HINTS[verdict]! : 'cli.run.next.inspect';
+  const reasons = [...new Set([
+    ...(decision && 'reasonCodes' in decision ? decision.reasonCodes
+      : decision?.decisionStatus === 'failed' ? [decision.errorCode] : []),
+    ...result.gate.reasonCodes,
+  ])];
+  return [
+    tCli('cli.run.summary.verdict', lang, { verdict }),
+    tCli(next, lang),
+    tCli('cli.run.summary.execution', lang, { ...execution }),
+    tCli('cli.run.summary.evaluation', lang, { ...evaluation }),
+    tCli('cli.run.summary.state', lang, {
+      run: result.status.runStatus, evidence: result.status.evidenceStatus,
+      conclusion: result.status.conclusionStatus, gate: result.gate.gateStatus,
+    }),
+    ...(reasons.length ? [tCli('cli.run.summary.reasons', lang, { reasons: reasons.join(', ') })] : []),
+    tCli('cli.run.summary.run', lang, { runId: result.runId }),
+  ].join('\n') + '\n';
+}

--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -1,6 +1,21 @@
 import type { CliMessage } from './types.js';
 
 export type RunMessageKey =
+  | 'cli.run.custom_executor_path'
+  | 'cli.run.summary.verdict'
+  | 'cli.run.summary.execution'
+  | 'cli.run.summary.evaluation'
+  | 'cli.run.summary.state'
+  | 'cli.run.summary.reasons'
+  | 'cli.run.summary.run'
+  | 'cli.run.next.progress'
+  | 'cli.run.next.regression'
+  | 'cli.run.next.noise'
+  | 'cli.run.next.underpowered'
+  | 'cli.run.next.solo'
+  | 'cli.run.next.inspect'
+  | 'cli.run.next.evidence'
+
   | 'cli.run.batch_verdict_header'
   | 'cli.run.codex_fallback_hint'
   | 'cli.run.codex_auth_hint'
@@ -11,6 +26,21 @@ export type RunMessageKey =
   | 'cli.run.anthropic_api_model_hint';
 
 export const runDict: Record<RunMessageKey, CliMessage> = {
+  "cli.run.custom_executor_path": { zh: "无法读取自定义执行器。请将 --executor 指向存在且可执行的单个文件；不接受 \"node script.mjs\" 这类带参数的命令。脚本请添加 shebang 并设置执行权限，或用可执行包装脚本调用服务。路径相对于项目目录解析。", en: "Cannot read the custom executor. Point --executor to one existing executable file, not a command with arguments such as \"node script.mjs\". Add a shebang and execution permission, or use an executable wrapper. Relative paths resolve from the project directory." },
+  "cli.run.summary.verdict": { zh: "评测结论：{verdict}", en: "Evaluation verdict: {verdict}" },
+  "cli.run.summary.execution": { zh: "执行：{succeeded}/{planned} 成功，失败 {failed}，取消 {cancelled}，预算中止 {budgetCensored}，未开始 {notStarted}。", en: "Execution: {succeeded}/{planned} succeeded, {failed} failed, {cancelled} cancelled, {budgetCensored} budget-censored, {notStarted} not started." },
+  "cli.run.summary.evaluation": { zh: "评分：{completed}/{planned} 完成，失败 {failed}，证据不可用 {sourceUnavailable}。", en: "Scoring: {completed}/{planned} completed, {failed} failed, {sourceUnavailable} source unavailable." },
+  "cli.run.summary.state": { zh: "状态：运行 {run}；证据 {evidence}；结论 {conclusion}；门禁 {gate}。", en: "Status: run {run}; evidence {evidence}; conclusion {conclusion}; gate {gate}." },
+  "cli.run.summary.reasons": { zh: "原因代码：{reasons}", en: "Reason codes: {reasons}" },
+  "cli.run.summary.run": { zh: "本次运行：{runId}", en: "Run: {runId}" },
+  "cli.run.next.progress": { zh: "下一步：复核用例代表性与报告告警，再进入自己的发布流程。", en: "Next: review sample representativeness and report warnings before entering your release process." },
+  "cli.run.next.regression": { zh: "下一步：查看退步用例与评分证据，修复后用同一组用例复测。", en: "Next: inspect regressed cases and scoring evidence, fix the issue, and rerun the same cases." },
+  "cli.run.next.noise": { zh: "下一步：当前证据无法确认差异；检查用例区分度和样本设计，再决定是否补充测量。", en: "Next: current evidence does not establish a difference. Check case sensitivity and sample design before adding measurements." },
+  "cli.run.next.underpowered": { zh: "下一步：按预先声明的样本量要求补充用例，再重新评测；当前不能作为发布依据。", en: "Next: meet the predeclared sample-size requirement and rerun; this result is not release evidence." },
+  "cli.run.next.solo": { zh: "下一步：添加对照版本，再判断改动是否有效。", en: "Next: add a control version to evaluate whether the change helps." },
+  "cli.run.next.inspect": { zh: "下一步：查看报告中的具体原因和门禁条件，处理后复测。", en: "Next: inspect the report reasons and gate conditions, address them, and rerun." },
+  "cli.run.next.evidence": { zh: "下一步：先检查失败调用与缺失证据，恢复有效评测后再比较分数。", en: "Next: inspect failed calls and missing evidence before comparing scores." },
+
   'cli.run.batch_verdict_header': {
     zh: '批量评测结论：{status}（{passed}/{total} 通过）',
     en: 'Batch verdict: {status} ({passed}/{total} passed)',

--- a/src/eval-workflows/hosts/input-resolution/node-cli-evaluation-resolver.ts
+++ b/src/eval-workflows/hosts/input-resolution/node-cli-evaluation-resolver.ts
@@ -212,6 +212,16 @@ async function resolveTargetRuntime(
       lineageKind: 'custom-command-runtime',
       exchangeSchemaVersion: 'omk.custom-command-exchange/v1',
     },
+  }).catch((cause: unknown) => {
+    if (!(cause instanceof CliEvaluationInputError)
+        || cause.code !== 'CLI_INPUT_RESOLUTION_FAILED') throw cause;
+    return fail({
+      code: cause.code,
+      sourcePath: cause.sourcePath,
+      fieldPath: 'targetRuntime.executorId',
+      message: '自定义执行器必须是存在且可读取的可执行文件路径，不接受带参数的命令字符串。',
+      cause,
+    });
   });
   return {
     implementationId: `custom-command-${descriptor.digest.slice('sha256:'.length)}`,

--- a/test/cli/eval-output.test.ts
+++ b/test/cli/eval-output.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { formatEvaluationInputFailure, formatEvaluationSummary } from '../../src/cli/lib/eval-output.js';
+import { CliEvaluationInputError } from '../../src/eval-workflows/hosts/application.js';
+
+const outcome = {
+  projectionKind: 'core-cli-run-outcome', runId: 'acceptance-run',
+  status: { runStatus: 'completed', evidenceStatus: 'complete', conclusionStatus: 'conclusive' },
+  stages: {
+    execution: { coverage: { planned: 6, succeeded: 6, failed: 0, cancelled: 0, budgetCensored: 0, notStarted: 0 } },
+    evaluation: { coverage: { planned: 6, completed: 6, failed: 0, sourceUnavailable: 0 } },
+  },
+  decision: { decisionStatus: 'decided', verdict: 'UNDERPOWERED', reasonCodes: ['comparison-sample-size-below-minimum'] },
+  gate: { gateStatus: 'skipped', reasonCodes: ['core-report-only'] },
+};
+
+describe('eval terminal output', () => {
+  it('shows the verdict and sample-size action even when report-only exits successfully', () => {
+    const before = structuredClone(outcome);
+    const text = formatEvaluationSummary(outcome, 'zh');
+    expect(text).toContain('评测结论：UNDERPOWERED');
+    expect(text).toContain('当前不能作为发布依据');
+    expect(text).toContain('6/6 成功');
+    expect(text).toContain('comparison-sample-size-below-minimum');
+    expect(text).toContain('core-report-only');
+    expect(outcome).toEqual(before);
+  });
+
+  it('prioritizes missing evidence over a supplied positive verdict', () => {
+    const text = formatEvaluationSummary({ ...outcome,
+      status: { ...outcome.status, evidenceStatus: 'unresolvable', conclusionStatus: 'inconclusive' },
+      stages: { ...outcome.stages, execution: { coverage: { ...outcome.stages.execution.coverage, succeeded: 0, failed: 6 } } },
+      decision: { ...outcome.decision, verdict: 'PROGRESS' },
+    }, 'en');
+    expect(text).toContain('0/6 succeeded, 6 failed');
+    expect(text).toContain('inspect failed calls and missing evidence');
+    expect(text).not.toContain('entering your release process');
+  });
+
+  it('keeps a blocked gate visible when the verdict is positive', () => {
+    const text = formatEvaluationSummary({ ...outcome,
+      decision: { ...outcome.decision, verdict: 'PROGRESS' },
+      gate: { gateStatus: 'blocked', reasonCodes: ['policy-blocked'] },
+    }, 'en');
+    expect(text).toContain('gate blocked');
+    expect(text).toContain('gate conditions');
+    expect(text).not.toContain('entering your release process');
+  });
+
+  it('shows a failed decision as missing verdict with its error code', () => {
+    const text = formatEvaluationSummary({ ...outcome,
+      decision: { decisionStatus: 'failed', errorCode: 'decision-source-unavailable' },
+    }, 'zh');
+    expect(text).toContain('评测结论：—');
+    expect(text).toContain('decision-source-unavailable');
+    expect(text).toContain('缺失证据');
+  });
+
+  it('preserves non-run outcomes instead of inventing a run verdict', () => {
+    const series = { projectionKind: 'core-cli-series-outcome', runs: ['one', 'two'] };
+    expect(JSON.parse(formatEvaluationSummary(series, 'zh'))).toEqual(series);
+  });
+
+  it('provides a localized executor-path remedy without leaking the command', () => {
+    const error = new CliEvaluationInputError({
+      code: 'CLI_INPUT_RESOLUTION_FAILED', fieldPath: 'targetRuntime.executorId',
+      sourcePath: 'node script.mjs --token private-value', message: 'internal failure',
+    });
+    expect(formatEvaluationInputFailure(error, 'zh')).toContain('shebang');
+    expect(formatEvaluationInputFailure(error, 'en')).toContain('one existing executable file');
+    expect(formatEvaluationInputFailure(error, 'zh')).not.toContain('private-value');
+    expect(formatEvaluationInputFailure(new Error('different failure'), 'en')).toBe('different failure');
+  });
+});

--- a/test/cli/first-run-smoke.test.ts
+++ b/test/cli/first-run-smoke.test.ts
@@ -55,16 +55,13 @@ describe('first-run smoke path', () => {
       assert.match(init.stdout, /直接跑通/);
       assert.match(init.stdout, /看报告里的 verdict/);
 
-      const executor = join(project, 'offline-executor.sh');
-      await writeFile(executor, [
-        '#!/bin/sh',
-        'IFS= read -r request',
-        'case "$request" in',
-        '  *code-review-v2*) output="SQL injection: use parameterized queries. Handle error status. XSS via innerHTML: use textContent." ;;',
-        '  *) output="Looks okay." ;;',
-        'esac',
-        'printf \'{"schemaVersion":"omk.custom-command-exchange/v1","resultStatus":"completed","output":{"value":"%s","classification":"public"}}\\n\' "$output"',
-      ].join('\n'));
+      // Exercise the published snippet so its protocol cannot drift from the CLI again.
+      const executor = join(project, 'offline-executor.mjs');
+      const executorGuide = readFileSync(join(PROJECT_ROOT, 'docs/zh/reference/executors.md'), 'utf8');
+      const customSection = executorGuide.split('## 自定义执行器')[1];
+      const source = customSection?.match(/```js\n([\s\S]*?)```/)?.[1];
+      assert.ok(source, 'custom executor guide contains a runnable JavaScript example');
+      await writeFile(executor, source);
       await chmod(executor, 0o755);
 
       const baseArgs = [

--- a/test/eval-workflows/hosts/input-resolution/node-cli-evaluation-resolver.test.ts
+++ b/test/eval-workflows/hosts/input-resolution/node-cli-evaluation-resolver.test.ts
@@ -540,6 +540,19 @@ describe('resolveNodeCliEvaluationRequest', () => {
     )))).toBe(true);
   });
 
+  it('identifies an unreadable custom executor as a runtime input failure', async () => {
+    const root = await fixture('custom-runtime-command-string');
+    await expect(resolveNodeCliEvaluationRequest(request(root, {
+      executor: 'node provider.mjs',
+    }), {
+      projectRoot: root,
+      materializationRoot: join(root, '.omk', 'resolved'),
+    })).rejects.toMatchObject({
+      code: 'CLI_INPUT_RESOLUTION_FAILED',
+      fieldPath: 'targetRuntime.executorId',
+    });
+  });
+
   it('keeps behavior digests invariant when identical bytes move to another root', async () => {
     const first = await fixture('move-a');
     const second = await fixture('move-b');


### PR DESCRIPTION
首次使用验收发现，自定义执行器文档仍推荐带参数的命令字符串与旧 JSON 响应，而当前 eval 入口只接受可执行文件路径和 Core exchange v1：前者在执行前报笼统资源错误，后者导致全部调用失败。交互终端又只打印 Core/Gate 状态，用户看不到 verdict 和明确的下一步。

修正双语接入说明与可运行示例，给无法读取的自定义执行器提供针对路径、shebang、执行权限的本地化建议；终端直接显示 verdict、下一步、执行／评分覆盖和原因代码。证据不完整或门禁阻塞时不会给出可发布建议。官方 Skill 安装入口与快速上手统一为 Beta 的 `@next`。

仅调整接入说明、诊断与呈现，不改变评分、统计、prompt、Core exchange、JSON 输出或退出码契约。脚本仍需遵守现有协议，不新增旧响应的兼容评分路径；目标执行与模型辅助接口的现存差异已在文档说明。

验证：最终 `yarn ci` 通过（346 个文件、3,757 项测试）。真实终端验证正常首跑、全部执行失败、无效命令字符串；回归测试直接执行文档中的脚本以防再次漂移。安装包在仓库外独立安装并运行双语接入命令，覆盖 JSON 输出与无效路径提示。

自主 CR：No findings。复核缺失证据与正向 verdict／门禁冲突、诊断不泄露命令参数、管道 JSON 和退出码保留、双语及生成文档同步。此次验收不调用真实模型，不把离线链路通过等同于 LLM 评委质量或真实业务效果已经验收。
