### PR TITLE
fix(eval-workflows)!: BREAKING-COMPARABILITY 修复真实评测的重连、中断与诊断问题

### DIFF
--- a/docs/reference/executors.md
+++ b/docs/reference/executors.md
@@ -155,6 +155,14 @@ Report invocation failure with a stable error code:
 
 This protocol applies to targets executed by `omk eval`. Model calls from `doctor`, `sample`, and `evolve`, and custom LLM judges still use the old `{ model, system, prompt }` adapter interface. Do not use a script implementing only this section's protocol for those model calls. Configure a supported judge separately through `--judge-models` when needed.
 
+## Diagnose a failed run
+
+Start with execution/scoring coverage and specific reason codes before interpreting model output. `OMK_CODEX_CLI_UPGRADE_REQUIRED` means the CLI cannot run the selected model: check `codex --version`, upgrade, and rerun the same model and cases. Changing the model does not verify that the original knowledge comparison recovered.
+
+Codex `Reconnecting...` events are transport notices. A call succeeds only after a valid completion event and answer; terminal failures, missing completion, and unknown errors still block evaluation. This fix versions the Codex executor and judge adapter identities: older versions may have counted recovered calls as failures. Do not pool results across that boundary as identical measurement conditions; rerun the complete comparison.
+
+`--retry` retries only error codes allowed by the sealed policy, which defaults to `timeout` and `transport-error`. Custom services should classify the actual cause instead of relabeling every business failure as a transport error to obtain retries.
+
 ## Prerequisites
 
 The base OMK install omits the optional Agent SDK packages and their large platform binaries. The default `claude` / `codex` CLI executors, API executors, custom executors, and the DSH host plugin do not need them. Install an SDK in the same scope as OMK only when you explicitly select its `*-sdk` executor.

--- a/docs/zh/reference/executors.md
+++ b/docs/zh/reference/executors.md
@@ -155,6 +155,14 @@ omk eval --control code-review-v1 --treatment code-review-v2 \
 
 上述协议用于 `omk eval` 的目标执行。`doctor`／`sample`／`evolve` 的模型调用接口及自定义 LLM 评委仍使用旧的 `{ model, system, prompt }` 适配接口；不要把仅实现本节协议的脚本直接用作那些模型调用。需要评委时通过 `--judge-models` 单独配置受支持的执行器。
 
+## 运行失败时如何排查
+
+先看执行／评分覆盖和具体原因代码，再检查模型输出。`OMK_CODEX_CLI_UPGRADE_REQUIRED` 表示当前 CLI 不支持所选模型：检查 `codex --version` 并升级，再用同一模型和用例重跑。不要通过换模型来证明原来的知识对比已恢复。
+
+Codex 的 `Reconnecting...` 是传输重连通知；只有后续出现合法的完成事件和答案才算成功，最终失败、缺少完成事件或未知错误仍会阻断评测。此修复升级了 Codex 执行与评委的适配身份：旧版本可能将已恢复的调用记为失败，前后结果不要当成相同测量条件直接合并，应重新运行完整比较。
+
+`--retry` 只重试密封策略允许的错误代码，默认是 `timeout` 和 `transport-error`。自定义服务应按实际失败原因返回代码，不能为获得重试把所有业务失败都标成传输错误。
+
 ## 前置要求
 
 OMK 基础安装不再携带可选 Agent SDK 及其大型平台二进制。默认的 `claude`／`codex` CLI 执行器、API 执行器、自定义执行器和 DSH 宿主插件都不需要它们。只有明确选择 `*-sdk` 执行器时，才在 OMK 所在的同一作用域安装对应 SDK。

--- a/src/cli/commands/eval/index.ts
+++ b/src/cli/commands/eval/index.ts
@@ -210,9 +210,15 @@ async function runEval(
     throw new CliExit(1);
   }
 
+  const cancellation = new AbortController();
+  // Keep listening until persistence and resource cleanup finish. The subprocess
+  // coordinator may re-raise SIGINT after terminating its children.
+  const cancel = () => cancellation.abort();
+  process.on('SIGINT', cancel);
+  process.on('SIGTERM', cancel);
   try {
     const { runCoreEvaluationCommand } = await import('../../lib/run-core-evaluation.js');
-    const result = await runCoreEvaluationCommand({ prepared });
+    const result = await runCoreEvaluationCommand({ prepared, signal: cancellation.signal });
     if (!process.stdout.isTTY || result.output && typeof result.output === 'object'
         && (result.output as { projectionKind?: string }).projectionKind === 'core-cli-dry-run') {
       console.log(JSON.stringify(result.output, null, 2));
@@ -236,6 +242,9 @@ async function runEval(
       }, lang, prepared.environment.environment)}`,
     }));
     throw new CliExit(1);
+  } finally {
+    process.off('SIGINT', cancel);
+    process.off('SIGTERM', cancel);
   }
 }
 

--- a/src/cli/lib/eval-output.ts
+++ b/src/cli/lib/eval-output.ts
@@ -39,6 +39,8 @@ export function formatEvaluationSummary(output: unknown, lang: CliLang): string 
     : result.gate.gateStatus === 'blocked' && verdict === 'PROGRESS' ? 'cli.run.next.inspect'
       : Object.hasOwn(VERDICT_HINTS, verdict) ? VERDICT_HINTS[verdict]! : 'cli.run.next.inspect';
   const reasons = [...new Set([
+    ...(result.diagnostic?.findings.filter((finding) => finding.severity === 'error')
+      .map((finding) => finding.reasonCode) ?? []),
     ...(decision && 'reasonCodes' in decision ? decision.reasonCodes
       : decision?.decisionStatus === 'failed' ? [decision.errorCode] : []),
     ...result.gate.reasonCodes,
@@ -46,6 +48,8 @@ export function formatEvaluationSummary(output: unknown, lang: CliLang): string 
   return [
     tCli('cli.run.summary.verdict', lang, { verdict }),
     tCli(next, lang),
+    ...(reasons.includes('OMK_CODEX_CLI_UPGRADE_REQUIRED')
+      ? [tCli('cli.run.codex_upgrade_hint', lang)] : []),
     tCli('cli.run.summary.execution', lang, { ...execution }),
     tCli('cli.run.summary.evaluation', lang, { ...evaluation }),
     tCli('cli.run.summary.state', lang, {

--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -19,6 +19,7 @@ export type RunMessageKey =
   | 'cli.run.batch_verdict_header'
   | 'cli.run.codex_fallback_hint'
   | 'cli.run.codex_auth_hint'
+  | 'cli.run.codex_upgrade_hint'
   | 'cli.run.codex_model_hint'
   | 'cli.run.openai_api_auth_hint'
   | 'cli.run.openai_api_model_hint'
@@ -26,6 +27,10 @@ export type RunMessageKey =
   | 'cli.run.anthropic_api_model_hint';
 
 export const runDict: Record<RunMessageKey, CliMessage> = {
+  'cli.run.codex_upgrade_hint': {
+    zh: 'Codex CLI 版本不支持当前模型。先用 codex --version 检查并升级 CLI，再保持相同模型与用例重跑；切换模型会改变测量条件。',
+    en: 'This Codex CLI version does not support the selected model. Check codex --version and upgrade the CLI, then rerun with the same model and cases; switching models changes measurement conditions.',
+  },
   "cli.run.custom_executor_path": { zh: "无法读取自定义执行器。请将 --executor 指向存在且可执行的单个文件；不接受 \"node script.mjs\" 这类带参数的命令。脚本请添加 shebang 并设置执行权限，或用可执行包装脚本调用服务。路径相对于项目目录解析。", en: "Cannot read the custom executor. Point --executor to one existing executable file, not a command with arguments such as \"node script.mjs\". Add a shebang and execution permission, or use an executable wrapper. Relative paths resolve from the project directory." },
   "cli.run.summary.verdict": { zh: "评测结论：{verdict}", en: "Evaluation verdict: {verdict}" },
   "cli.run.summary.execution": { zh: "执行：{succeeded}/{planned} 成功，失败 {failed}，取消 {cancelled}，预算中止 {budgetCensored}，未开始 {notStarted}。", en: "Execution: {succeeded}/{planned} succeeded, {failed} failed, {cancelled} cancelled, {budgetCensored} budget-censored, {notStarted} not started." },

--- a/src/cli/lib/run-core-evaluation.ts
+++ b/src/cli/lib/run-core-evaluation.ts
@@ -13,6 +13,7 @@ import type { CliLang } from './i18n.js';
 export interface RunCoreEvaluationCommandInput {
   readonly prepared: PreparedCliEvaluation;
   readonly store?: CoreRunArtifactStore;
+  readonly signal?: AbortSignal;
 }
 
 export interface RunCoreEvaluationCommandResult {
@@ -106,7 +107,7 @@ export async function runCoreEvaluationCommand(input: Readonly<RunCoreEvaluation
     const result = await application.run({
       request, projectRoot,
       materializationRoot: machineLayout.resolvedInputsDir, resourceLeaseRoot: machineLayout.resourceLeasesDir,
-      store: input.store,
+      store: input.store, signal: input.signal,
       createProgressSink: () => emitProgress(lang),
       onNotice: (notice) => renderNotice(notice, lang),
       requestForBatchItem: (entry) => parseCliEvaluationRequest({
@@ -114,7 +115,7 @@ export async function runCoreEvaluationCommand(input: Readonly<RunCoreEvaluation
         explicitCliFlags: { ...parseInput.explicitCliFlags, batch: undefined, control: 'baseline', treatment: entry.skillPath, samples: entry.samplesPath, 'no-serve': true },
       }),
       async onCompleted(completed, request) {
-        if (completed.outcomeKind === 'run') await announceCoreReport(completed.artifacts, completed.store, completed.outputDirectory, request.values.presentation.serve, lang);
+        if (completed.outcomeKind === 'run') await announceCoreReport(completed.artifacts, completed.store, completed.outputDirectory, request.values.presentation.serve && !input.signal?.aborted, lang);
         if (completed.outcomeKind === 'series') process.stderr.write(lang === 'zh'
           ? `Core Series 已完成：${completed.outcome.seriesId}（${completed.outcome.members.length} 个独立 run）\n`
           : `Core Series completed: ${completed.outcome.seriesId} (${completed.outcome.members.length} independent runs)\n`);

--- a/src/eval-workflows/hosts/adapters/codex/cli.ts
+++ b/src/eval-workflows/hosts/adapters/codex/cli.ts
@@ -56,7 +56,7 @@ export {
   createCodexCliCoreSchemaValidators,
 } from './cli-protocol.js';
 
-export const CODEX_CLI_CORE_ADAPTER_IMPLEMENTATION_VERSION = '2.0.0' as const;
+export const CODEX_CLI_CORE_ADAPTER_IMPLEMENTATION_VERSION = '2.0.1' as const;
 export const DEFAULT_CODEX_CLI_MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
 export const DEFAULT_CODEX_CLI_MAX_PROMPT_BYTES = 2 * 1024 * 1024;
 export const DEFAULT_CODEX_CLI_IDENTITY_PROBE_TIMEOUT_MS = 5_000;
@@ -309,6 +309,27 @@ export function buildCodexCliCoreArguments(input: Readonly<{
   });
 }
 
+function requiresCodexUpgrade(stdout: string): boolean {
+  for (const line of stdout.split('\n')) {
+    try {
+      const event = JSON.parse(line) as { type?: string; message?: unknown; error?: { message?: unknown } };
+      if (!event || typeof event !== 'object') continue;
+      let message = event.type === 'error' ? event.message
+        : event.type === 'turn.failed' ? event.error?.message : undefined;
+      if (typeof message !== 'string') continue;
+      if (message.startsWith('{')) {
+        const detail = JSON.parse(message) as { error?: { message?: unknown } };
+        message = detail?.error?.message;
+      }
+      if (typeof message === 'string'
+          && /^The '[^'\r\n]+' model requires a newer version of Codex\./.test(message)) return true;
+    } catch {
+      // Only recognized provider error events produce an actionable, redacted code.
+    }
+  }
+  return false;
+}
+
 function processFailure(error: unknown, signal: AbortSignal): never {
   const spawnError = error as SpawnHelperError;
   if (signal.aborted || spawnError.failureKind === 'abort') {
@@ -330,6 +351,9 @@ function processFailure(error: unknown, signal: AbortSignal): never {
     }
   }
   if (spawnError.failureKind === 'nonzero-exit') {
+    if (requiresCodexUpgrade(spawnError.stdout ?? '')) {
+      fail('OMK_CODEX_CLI_UPGRADE_REQUIRED', 'execution', 'Codex CLI must be upgraded for this model.', usage);
+    }
     fail('OMK_CODEX_CLI_EXIT_NONZERO', 'execution', 'Codex CLI exited unsuccessfully.', usage);
   }
   fail('OMK_CODEX_CLI_SPAWN_FAILED', 'infrastructure', 'Codex CLI process could not run.', usage);
@@ -381,7 +405,12 @@ async function executeCodex(
     child.stdin.end();
   }
   try {
-    return parseCodexCliStream((await done).stdout);
+    const stdout = (await done).stdout;
+    const parsed = parseCodexCliStream(stdout);
+    if (parsed.terminalStatus === 'failed' && requiresCodexUpgrade(stdout)) {
+      fail('OMK_CODEX_CLI_UPGRADE_REQUIRED', 'execution', 'Codex CLI must be upgraded for this model.', parsed.usage);
+    }
+    return parsed;
   } catch (error) {
     if (error instanceof ExecutionPortFailure) throw error;
     if (stdinFailed && !attempt.signal.aborted) {

--- a/src/eval-workflows/hosts/adapters/codex/protocol-core.ts
+++ b/src/eval-workflows/hosts/adapters/codex/protocol-core.ts
@@ -15,6 +15,7 @@ import {
 import { ExecutionPortFailure } from '../../../../eval-core/execution/index.js';
 import {
   normalizeCodexProtocolEvent,
+  isCodexReconnectNotice,
   type CodexEvent,
 } from '../../../../executors/openai/codex/protocol.js';
 import { extractCodexTrace } from '../../../../executors/openai/codex/trace.js';
@@ -248,7 +249,7 @@ export function parseCodexCoreEvents(
         completed.add(itemId);
       }
     }
-    if (event.type === 'error') protocolError = true;
+    if (event.type === 'error' && !isCodexReconnectNotice(event)) protocolError = true;
     if (event.type === 'turn.completed' || event.type === 'turn.failed') {
       if (started !== 1) protocolError = true;
       terminal = event;

--- a/src/eval-workflows/hosts/adapters/codex/sdk.ts
+++ b/src/eval-workflows/hosts/adapters/codex/sdk.ts
@@ -65,7 +65,7 @@ export {
   type ResolvedCodexSdkRuntime,
 } from './sdk-runtime.js';
 
-export const CODEX_SDK_CORE_ADAPTER_IMPLEMENTATION_VERSION = '2.0.0' as const;
+export const CODEX_SDK_CORE_ADAPTER_IMPLEMENTATION_VERSION = '2.0.1' as const;
 export const DEFAULT_CODEX_SDK_MAX_EVENT_BYTES = 10 * 1024 * 1024;
 export const DEFAULT_CODEX_SDK_MAX_PROMPT_BYTES = 2 * 1024 * 1024;
 

--- a/src/eval-workflows/hosts/composition/judge-provider-identity.ts
+++ b/src/eval-workflows/hosts/composition/judge-provider-identity.ts
@@ -16,6 +16,8 @@ function executorRuntimeEvidence(
     runtimeKind: runtime.runtimeKind,
     fingerprint: runtime.fingerprint,
     capabilities: runtime.capabilities as unknown as JsonValue,
+    ...(['codex', 'codex-sdk'].includes(runtime.executor)
+      ? { protocolAdapterVersion: 'codex-reconnect/v2' } : {}),
     ...(runtime.binary === undefined ? {} : {
       binary: {
         name: runtime.binary.name,

--- a/src/executors/openai/codex/protocol.ts
+++ b/src/executors/openai/codex/protocol.ts
@@ -138,10 +138,18 @@ export function extractCodexFinalOutput(events: CodexEvent[]): string {
   return '';
 }
 
+/** Codex reports recoverable transport reconnects as error events before its final turn result. */
+export function isCodexReconnectNotice(event: CodexEvent): boolean {
+  if (event.type !== 'error' || typeof event.message !== 'string') return false;
+  const match = /^Reconnecting\.\.\. ([1-9]\d*)\/([1-9]\d*) \(stream disconnected before completion: .+\)$/.exec(event.message);
+  return match !== null && Number.isSafeInteger(Number(match[1]))
+    && Number.isSafeInteger(Number(match[2])) && Number(match[1]) <= Number(match[2]);
+}
+
 export function extractCodexProtocolError(events: CodexEvent[]): string | undefined {
   for (let index = events.length - 1; index >= 0; index -= 1) {
     const event = events[index];
-    if (event.type === 'error') {
+    if (event.type === 'error' && !isCodexReconnectNotice(event)) {
       return event.message || event.error?.message || 'codex stream error';
     }
   }

--- a/src/studio/core-runs/renderer.ts
+++ b/src/studio/core-runs/renderer.ts
@@ -28,6 +28,7 @@ const COPY = {
     evaluation: '评价',
     classification: '最高数据分级',
     identities: '产物身份',
+    technicalDetails: '查看测量计划、逐条记录与产物身份',
     reportId: '报告 ID',
     contractDigest: '运行契约摘要',
     reportDigest: '报告摘要',
@@ -97,6 +98,7 @@ const COPY = {
     sourceUnavailable: 'Core 产物当前不可读取。',
   },
   en: {
+    technicalDetails: 'View measurement plan, individual records, and artifact identities',
     title: 'Evaluation Core Runs',
     subtitle: 'A read-only measurement view backed by versioned Core artifacts. The three status axes remain independent and are never collapsed into one success verdict.',
     empty: 'No Evaluation Core runs yet.',
@@ -448,6 +450,8 @@ export function renderCoreRunDetail(
     <nav class="nav"><a href="${e(withLang(routes.listPath, lang))}">${e(copy.back)}</a></nav>
     <h1>${e(card.runId)}</h1><p class="subtitle"><time datetime="${e(card.createdAt)}">${e(card.createdAt)}</time></p>
     ${statusAxes(card, copy)}
+    ${renderDecision(detail, copy)}
+    <details><summary>${e(copy.technicalDetails)}</summary>
     <section><h2>${e(copy.identities)}</h2>${keyValues([
       [copy.reportId, `<span class="core-table-code">${e(card.reportId)}</span>`],
       [copy.contractDigest, `<span class="core-digest">${e(card.runContractDigest)}</span>`],
@@ -457,7 +461,8 @@ export function renderCoreRunDetail(
       [copy.classification, chip(card.maximumCapturedClassification)],
       [copy.provenance, formatProvenance(detail.reportProvenance, copy)],
     ])}</section>
-    ${renderPlan(detail, copy)}${renderStages(detail, copy)}${renderExecutionRecords(detail, copy)}${renderEvaluationRecords(detail, copy)}${renderAnalysis(detail, copy)}${renderDecision(detail, copy)}${renderLineage(detail, copy)}
+    ${renderPlan(detail, copy)}${renderStages(detail, copy)}${renderExecutionRecords(detail, copy)}${renderEvaluationRecords(detail, copy)}${renderAnalysis(detail, copy)}${renderLineage(detail, copy)}
+    </details>
   </main>`, lang, { homeHref: withLang(routes.listPath, lang) });
 }
 

--- a/test/cli/eval-cancellation.test.ts
+++ b/test/cli/eval-cancellation.test.ts
@@ -1,0 +1,73 @@
+import { spawn } from 'node:child_process';
+import { mkdtemp, mkdir, writeFile, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { expect, it } from 'vitest';
+
+// A real process is required: the subprocess coordinator re-raises SIGINT,
+// which must reach the CLI's cancellation handler instead of terminating it.
+it.each(['SIGINT', 'SIGTERM'] as const)('saves cancelled evidence and releases children and resources after %s', async (signal) => {
+  const root = await mkdtemp(join(tmpdir(), 'omk-eval-signal-'));
+  const home = join(root, 'home');
+  const skill = join(root, 'answer');
+  const marker = join(root, 'child.pid');
+  const executor = join(root, 'executor.mjs');
+  const samples = join(root, 'samples.json');
+  await mkdir(skill);
+  await writeFile(join(skill, 'SKILL.md'), '# Answer\nAnswer the question.\n');
+  await writeFile(samples, JSON.stringify({ schemaVersion: 'omk.eval-sample-set/v2', samples: [
+    { sample_id: 'answer', prompt: 'Answer.', assertions: [{ type: 'contains', value: 'answer' }] },
+  ] }));
+  await writeFile(executor, `#!/usr/bin/env node
+import { writeFile } from 'node:fs/promises';
+import { createInterface } from 'node:readline';
+for await (const line of createInterface({ input: process.stdin })) {
+  JSON.parse(line);
+  await writeFile(${JSON.stringify(marker)}, String(process.pid));
+  setInterval(() => {}, 1000);
+  break;
+}
+`, { mode: 0o755 });
+  const child = spawn(process.execPath, [resolve('dist/cli/index.js'), 'eval',
+    '--control', 'baseline', '--treatment', skill, '--samples', samples,
+    '--executor', executor, '--model', 'fixture', '--no-judge', '--no-serve',
+    '--skip-connectivity', '--concurrency', '1', '--retry', '0', '--timeout', '60',
+    '--output-dir', join(root, 'reports'),
+  ], { cwd: root, env: { ...process.env, OMK_HOME: home, OMK_SKIP_UPDATE_CHECK: '1' }, stdio: ['ignore', 'pipe', 'pipe'] });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+  child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+  const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code, signal) => resolve({ code, signal }));
+  });
+  let executorPid: number | undefined;
+  try {
+    await expect.poll(async () => {
+      executorPid = await readFile(marker, 'utf8').then(Number, () => undefined);
+      return executorPid;
+    }, { timeout: 15_000 }).toBeDefined();
+    expect(child.kill(signal)).toBe(true);
+    const ended = await Promise.race([closed, delay(10_000).then(() => { throw new Error(`Cancellation timed out: ${stderr}`); })]);
+    expect(ended, stderr).toEqual({ code: 1, signal: null });
+    const output = JSON.parse(stdout);
+    expect(output).toMatchObject({
+      status: { runStatus: 'cancelled', evidenceStatus: 'unresolvable', conclusionStatus: 'inconclusive' },
+      gate: { gateStatus: 'blocked', exitCode: 1, reasonCodes: ['core-run-cancelled'] },
+    });
+    const { createNodeCoreRunArtifactStore } = await import('../../src/eval-workflows/artifact-store/index.js');
+    const stored = await createNodeCoreRunArtifactStore(join(root, 'reports')).get(output.runId);
+    expect(stored?.report.status.runStatus).toBe('cancelled');
+    expect(await readdir(join(home, 'state', 'tmp', 'resource-leases'))).toEqual([]);
+    expect(() => process.kill(executorPid!, 0)).toThrow();
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+    await closed;
+    if (executorPid !== undefined) {
+      try { process.kill(executorPid, 'SIGKILL'); } catch { /* Already reaped. */ }
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/cli/eval-output.test.ts
+++ b/test/cli/eval-output.test.ts
@@ -14,6 +14,20 @@ const outcome = {
 };
 
 describe('eval terminal output', () => {
+  it('shows deduplicated execution reasons and the Codex upgrade remedy', () => {
+    const failed = { ...outcome, diagnostic: { findings: [
+      { severity: 'error', reasonCode: 'OMK_CODEX_CLI_UPGRADE_REQUIRED' },
+      { severity: 'error', reasonCode: 'OMK_CODEX_CLI_UPGRADE_REQUIRED' },
+      { severity: 'info', reasonCode: 'not-applicable' },
+    ] } };
+    const text = formatEvaluationSummary(failed, 'zh');
+    expect(text.match(/OMK_CODEX_CLI_UPGRADE_REQUIRED/g)).toHaveLength(1);
+    expect(text).toContain('codex --version');
+    expect(text).toContain('切换模型会改变测量条件');
+    expect(text).not.toContain('not-applicable');
+    expect(formatEvaluationSummary(failed, 'en')).toContain('upgrade the CLI');
+  });
+
   it('shows the verdict and sample-size action even when report-only exits successfully', () => {
     const before = structuredClone(outcome);
     const text = formatEvaluationSummary(outcome, 'zh');

--- a/test/eval-workflows/hosts/adapters/codex/cli.test.ts
+++ b/test/eval-workflows/hosts/adapters/codex/cli.test.ts
@@ -536,6 +536,9 @@ describe('Codex CLI Core Executor adapter', () => {
     ['missing-thread', 'OMK_CODEX_CLI_PROTOCOL_INVALID'],
     ['duplicate-item', 'OMK_CODEX_CLI_PROTOCOL_INVALID'],
     ['exit', 'OMK_CODEX_CLI_EXIT_NONZERO'],
+    ['upgrade-required', 'OMK_CODEX_CLI_UPGRADE_REQUIRED'],
+    ['upgrade-decoy', 'OMK_CODEX_CLI_EXIT_NONZERO'],
+    ['reconnect-failed', 'OMK_CODEX_CLI_TURN_FAILED'],
   ])('redacts %s provider failures behind a stable boundary', async (mode, code) => {
     const fixture = await adapterFixture();
     const promise = execute(
@@ -546,6 +549,7 @@ describe('Codex CLI Core Executor adapter', () => {
       evaluationError: { code },
     });
     await expect(promise).rejects.not.toThrow(/sensitive provider failure/);
+    await expect(promise).rejects.not.toThrow(/private-model/);
   });
 
   it('keeps trustworthy usage on a redacted failed turn', async () => {
@@ -565,6 +569,15 @@ describe('Codex CLI Core Executor adapter', () => {
         totalTokens: 13,
       },
     });
+  });
+
+  it('accepts a completed response after a provider transport reconnect', async () => {
+    const fixture = await adapterFixture();
+    const result = await execute(
+      await createAdapter(fixture, { OMK_TEST_MODE: 'reconnect' }),
+      fixture.target.config as JsonValue,
+    );
+    expect(result.output?.value).toBe('fixture answer');
   });
 
   it('bounds provider output as an implementation facet without adding an attempt timeout', async () => {

--- a/test/eval-workflows/hosts/composition/judge-provider-identity.test.ts
+++ b/test/eval-workflows/hosts/composition/judge-provider-identity.test.ts
@@ -26,6 +26,18 @@ const EXECUTOR_RUNTIME: ExecutorRuntimeFingerprint = {
 };
 
 describe('Node judge provider identity', () => {
+  it('seals the Codex reconnect interpretation in judge identity', () => {
+    const identity = createJudgeProviderRuntimeIdentity({
+      executorId: 'codex', model: 'gpt-test',
+      executorRuntime: { ...EXECUTOR_RUNTIME, executor: 'codex' },
+    });
+    expect(JSON.stringify(identity)).toContain('codex-reconnect/v2');
+    const manifest = identity.implementationManifest;
+    const evidence = manifest?.coverageKind === 'fingerprint-plus-facets'
+      ? manifest.facets.find((facet) => facet.facetId === 'executor.runtime') : undefined;
+    expect(evidence?.value).toMatchObject({ protocolAdapterVersion: 'codex-reconnect/v2' });
+  });
+
   it('treats undeclared remote judge deployments as opaque', () => {
     const identity = createJudgeProviderRuntimeIdentity({
       executorId: 'openai-api',

--- a/test/executors/codex-protocol.test.ts
+++ b/test/executors/codex-protocol.test.ts
@@ -8,6 +8,25 @@ import {
 import type { CodexEvent } from '../../src/executors/openai/codex/protocol.js';
 
 describe('Codex protocol normalization', () => {
+  it('accepts a recovered reconnect without erasing the event, but still rejects failed or incomplete turns', () => {
+    const events: CodexEvent[] = [
+      { type: 'turn.started' },
+      { type: 'error', message: 'Reconnecting... 2/5 (stream disconnected before completion: tls handshake eof)' },
+      { type: 'item.completed', item: { id: 'answer', type: 'agent_message', text: 'ALLOW' } },
+      { type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 2 } },
+    ];
+    const build = (events: CodexEvent[], forcedError?: string) => buildCodexResult({
+      events, forcedError, wallClockDurationMs: 100, source: 'codex --json',
+    });
+    assert.equal(build(events).ok, true);
+    assert.equal(events[1].type, 'error');
+    assert.equal(build(events.slice(0, -1)).ok, false);
+    assert.equal(build([...events.slice(0, -1), { type: 'turn.failed' }]).ok, false);
+    assert.equal(build(events, 'process failed').ok, false);
+    assert.equal(build([events[0], { type: 'error', message: 'provider failed' }, ...events.slice(2)]).ok, false);
+    assert.equal(build([events[0], { type: 'error', message: 'Reconnecting... 6/5 (stream disconnected before completion: eof)' }, ...events.slice(2)]).ok, false);
+  });
+
   it('keeps an item-level error non-fatal when the turn still completes with an answer', () => {
     const events: CodexEvent[] = [
       { type: 'turn.started' },

--- a/test/fixtures/codex-cli-core-runtime.mjs
+++ b/test/fixtures/codex-cli-core-runtime.mjs
@@ -32,6 +32,14 @@ if (stdin !== '') {
 }
 
 const mode = process.env.OMK_TEST_MODE ?? 'success';
+if (mode === 'upgrade-required' || mode === 'upgrade-decoy') {
+  const message = "The 'private-model' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again.";
+  process.stdout.write(JSON.stringify(mode === 'upgrade-required'
+    ? { type: 'turn.failed', error: { message: JSON.stringify({ type: 'error', status: 400, error: { message } }) } }
+    : { type: 'item.completed', item: { type: 'agent_message', text: message } }) + '\n');
+  process.stderr.write('sensitive provider failure');
+  process.exit(1);
+}
 if (mode === 'exit') {
   process.stderr.write('sensitive provider failure');
   process.exit(7);
@@ -64,6 +72,9 @@ if (mode === 'workspace-state') {
 const event = (value) => process.stdout.write(`${JSON.stringify(value)}\n`);
 if (mode !== 'missing-thread') event({ type: 'thread.started', thread_id: 'thread-test' });
 event({ type: 'turn.started' });
+if (mode === 'reconnect' || mode === 'reconnect-failed') {
+  event({ type: 'error', message: 'Reconnecting... 2/5 (stream disconnected before completion: tls handshake eof)' });
+}
 event({
   type: 'item.completed',
   item: { id: 'message-1', type: 'agent_message', text: answer },
@@ -96,7 +107,7 @@ const usage = mode === 'usage' || mode === 'failed-usage'
     }
   : undefined;
 event({
-  type: mode === 'failed' || mode === 'failed-usage' ? 'turn.failed' : 'turn.completed',
+  type: mode === 'failed' || mode === 'failed-usage' || mode === 'reconnect-failed' ? 'turn.failed' : 'turn.completed',
   ...(usage === undefined ? {} : { usage }),
   ...(mode === 'failed' || mode === 'failed-usage'
     ? { error: { message: 'sensitive failure detail' } }

--- a/test/studio/core-runs/route-handler.test.ts
+++ b/test/studio/core-runs/route-handler.test.ts
@@ -308,6 +308,8 @@ describe('Core run renderer', () => {
     assert.ok(html.includes('<nav class="nav">'));
     assert.ok(html.includes('<th scope=') || html.includes('<th>'));
     assert.ok(html.includes('href="/measurements?lang=en"'));
+    assert.ok(html.indexOf('PROGRESS') < html.indexOf('<details>'));
+    assert.ok(html.includes('<details><summary>View measurement plan, individual records, and artifact identities</summary>'));
   });
 
   it('escapes projected values and ignores fields outside the privacy allow-list', () => {


### PR DESCRIPTION
## 用户影响

完整验收 CLI、eval-runtime、真实模型与评委以及 Studio 后，修复四个实际问题：Codex 重连成功仍被计为失败；CLI 太旧时缺少升级指引；Ctrl+C 直接退出留下资源租约；报告结论埋在长篇技术明细之后。现在恢复成功会保留答案和原始事件，中断会保存 cancelled 证据并清理资源，报告先呈现状态与结论。衔接 #826。

## 迁移／兼容决策

**BREAKING-COMPARABILITY**：Codex CLI／SDK Core adapter identity 升至 2.0.1，Codex 评委身份增加 `codex-reconnect/v2`。新旧版本对已恢复调用的处理不同，不要把结果视为相同测量条件合并，应保持模型、用例与规则不变，完整重跑比较。既有产物仍可读取；没有 Schema 或存储迁移。本 PR 不发布 npm 版本。

## 测量学影响

修正恢复调用的成功／失败分类，保留原始重连事件。仍要求合法完成事件与答案，最终失败、未知错误和缺少完成事件继续阻断。评分与统计公式、prompt 字节、发布决策策略未变。

## 自主 CR

按高风险完成 fresh-pass 自审，检查事件顺序与最终状态、错误脱敏、执行与评委身份、中断信号到子进程和资源清理、证据保存、CLI 退出码及 Studio 隐私投影。未发现剩余由本轮变更引入的 P0—P2；以下既有产品限制明确保留，不通过弱化检查解决。

## 验证

- 最终 `yarn ci` 通过：347 个测试文件、3766 项测试，包含 lint、类型检查、生成文档校验和文档站构建。
- 固定 gpt-6-astra，使用 4 个预先确定答案的合成退货用例，真实执行 8/8、评分 16/16 完成（8 本地断言、8 LLM 评委）。答案及评分理由逐条核对，控制组均分 3、候选组 5；结果 UNDERPOWERED、exit 1，未放行。Codex 仅在隔离目录升级至 0.153.4，无全局改动。
- 最终 tarball 独立安装后，CLI 三组各 48 次执行依次得到 PROGRESS／REGRESSION／NOISE，退出码 0／1／1；runtime 文档与检索／拒答示例、四组公开 API 矩阵通过。
- 实测失败、畸形响应、超时、策略重试、resume／篡改拒绝、SIGINT／SIGTERM 保存与清理；最终安装包再次验证恢复成功／最终失败、升级错误码、TTY 提示及取消。保存的真实重连 JSONL 也通过最终执行与评委解析器。
- Studio 实际页面验证结论前置及明细展开；自定义执行器审计确认读取密封知识快照，未接收 expected。

## 未解决风险

验收结论是主链路可用，继续 beta；不是业务有效性或评委广泛校准证明，也未实测其他模型提供方。Provider 未报告费用，未记作零成本。

后续应优先补齐：① CLI resume 所需的独立验证事实，目前会安全拒绝，不能按普通用户续跑体验验收通过；② 明确最低样本量产品策略，现有 release-decision/v7 的显著性分支可在少量样本时给 PROGRESS，最低样本数不是硬门槛，修改须版本化；③ 安全且具体的用例／能力错误位置与修复提示；④ 报告中的原因解释和成对答案阅读体验，保持敏感数据投影边界。Codex 当前不支持 baseline 要求的严格隔离能力，两个实际版本的比较可用。


## 远端验证补充

最终远端质量检查、Node 22／24 全部分片与汇总检查、Cloudflare Pages 均通过。首次 Node 24 第一分片无响应且日志归档丢失，取消后对同一提交只重跑该分片并开启诊断日志，2 分 26 秒通过，未修改代码或绕过门禁。另在本地 Node 24.14.0、两个 worker 下复验同一分片，174 个文件、1687 项测试通过。首次卡住的根因因归档缺失未能确定。
