### PR TITLE
fix(cli): 统一评测执行器的诊断提示

### DIFF
--- a/src/cli/lib/eval-output.ts
+++ b/src/cli/lib/eval-output.ts
@@ -12,6 +12,20 @@ const VERDICT_HINTS: Readonly<Record<string, CliMessageKey>> = {
   SOLO: 'cli.run.next.solo',
 };
 
+// Match adapter reason codes exactly; raw errors and tool names cannot establish a cause.
+const DIAGNOSTIC_HINTS = new Map<string, CliMessageKey>([
+  ['OMK_CODEX_CLI_UPGRADE_REQUIRED', 'cli.run.codex_cli_upgrade_hint'],
+  ['OMK_CODEX_CLI_SPAWN_FAILED', 'cli.run.codex_cli_start_hint'],
+  ['OMK_CODEX_CLI_STDIN_UNAVAILABLE', 'cli.run.codex_cli_start_hint'],
+  ['OMK_CODEX_CLI_EXIT_NONZERO', 'cli.run.codex_cli_failure_hint'],
+  ['OMK_CODEX_CLI_TURN_FAILED', 'cli.run.codex_cli_failure_hint'],
+  ['OMK_CLAUDE_CLI_SPAWN_FAILED', 'cli.run.claude_cli_start_hint'],
+  ['OMK_CLAUDE_CLI_STDIN_UNAVAILABLE', 'cli.run.claude_cli_start_hint'],
+  ['OMK_CLAUDE_CLI_EXIT_NONZERO', 'cli.run.claude_cli_failure_hint'],
+  ['OMK_CLAUDE_CLI_TURN_FAILED', 'cli.run.claude_cli_failure_hint'],
+  ['OMK_CLAUDE_CLI_EXECUTION_FAILED', 'cli.run.claude_cli_failure_hint'],
+]);
+
 export function formatEvaluationInputFailure(error: unknown, lang: CliLang): string {
   if (error instanceof CliEvaluationInputError
       && error.code === 'CLI_INPUT_RESOLUTION_FAILED'
@@ -45,11 +59,15 @@ export function formatEvaluationSummary(output: unknown, lang: CliLang): string 
       : decision?.decisionStatus === 'failed' ? [decision.errorCode] : []),
     ...result.gate.reasonCodes,
   ])];
+  const hints = new Set<CliMessageKey>();
+  for (const reason of reasons) {
+    const hint = DIAGNOSTIC_HINTS.get(reason);
+    if (hint) hints.add(hint);
+  }
   return [
     tCli('cli.run.summary.verdict', lang, { verdict }),
     tCli(next, lang),
-    ...(reasons.includes('OMK_CODEX_CLI_UPGRADE_REQUIRED')
-      ? [tCli('cli.run.codex_upgrade_hint', lang)] : []),
+    ...[...hints].map((hint) => tCli(hint, lang)),
     tCli('cli.run.summary.execution', lang, { ...execution }),
     tCli('cli.run.summary.evaluation', lang, { ...evaluation }),
     tCli('cli.run.summary.state', lang, {

--- a/src/cli/lib/i18n-dict/run.ts
+++ b/src/cli/lib/i18n-dict/run.ts
@@ -19,7 +19,11 @@ export type RunMessageKey =
   | 'cli.run.batch_verdict_header'
   | 'cli.run.codex_fallback_hint'
   | 'cli.run.codex_auth_hint'
-  | 'cli.run.codex_upgrade_hint'
+  | 'cli.run.codex_cli_upgrade_hint'
+  | 'cli.run.codex_cli_start_hint'
+  | 'cli.run.codex_cli_failure_hint'
+  | 'cli.run.claude_cli_start_hint'
+  | 'cli.run.claude_cli_failure_hint'
   | 'cli.run.codex_model_hint'
   | 'cli.run.openai_api_auth_hint'
   | 'cli.run.openai_api_model_hint'
@@ -27,9 +31,25 @@ export type RunMessageKey =
   | 'cli.run.anthropic_api_model_hint';
 
 export const runDict: Record<RunMessageKey, CliMessage> = {
-  'cli.run.codex_upgrade_hint': {
+  'cli.run.codex_cli_upgrade_hint': {
     zh: 'Codex CLI 版本不支持当前模型。先用 codex --version 检查并升级 CLI，再保持相同模型与用例重跑；切换模型会改变测量条件。',
     en: 'This Codex CLI version does not support the selected model. Check codex --version and upgrade the CLI, then rerun with the same model and cases; switching models changes measurement conditions.',
+  },
+  'cli.run.codex_cli_start_hint': {
+    zh: 'Codex CLI 未能启动或接收输入。请在运行 OMK 的同一环境检查 codex --version、可执行文件路径与执行权限。',
+    en: 'Codex CLI could not start or receive input. Check codex --version, the executable path, and execution permissions in the same environment as OMK.',
+  },
+  'cli.run.codex_cli_failure_hint': {
+    zh: 'Codex CLI 调用失败。请查看失败调用的诊断，检查登录状态、模型访问权限与网络；当前错误不能确定是否需要升级。复测时保持相同模型与用例。',
+    en: 'Codex CLI failed. Inspect the failed call diagnostics and check authentication, model access, and connectivity; this error does not establish that an upgrade is needed. Keep the same model and cases when rerunning.',
+  },
+  'cli.run.claude_cli_start_hint': {
+    zh: 'Claude Code CLI 未能启动或接收输入。请在运行 OMK 的同一环境检查 claude --version、可执行文件路径与执行权限。',
+    en: 'Claude Code CLI could not start or receive input. Check claude --version, the executable path, and execution permissions in the same environment as OMK.',
+  },
+  'cli.run.claude_cli_failure_hint': {
+    zh: 'Claude Code CLI 调用失败。请查看失败调用的诊断，检查登录状态、模型访问权限与网络；当前错误不能确定是否需要升级。复测时保持相同模型与用例。',
+    en: 'Claude Code CLI failed. Inspect the failed call diagnostics and check authentication, model access, and connectivity; this error does not establish that an upgrade is needed. Keep the same model and cases when rerunning.',
   },
   "cli.run.custom_executor_path": { zh: "无法读取自定义执行器。请将 --executor 指向存在且可执行的单个文件；不接受 \"node script.mjs\" 这类带参数的命令。脚本请添加 shebang 并设置执行权限，或用可执行包装脚本调用服务。路径相对于项目目录解析。", en: "Cannot read the custom executor. Point --executor to one existing executable file, not a command with arguments such as \"node script.mjs\". Add a shebang and execution permission, or use an executable wrapper. Relative paths resolve from the project directory." },
   "cli.run.summary.verdict": { zh: "评测结论：{verdict}", en: "Evaluation verdict: {verdict}" },

--- a/test/cli/eval-output.test.ts
+++ b/test/cli/eval-output.test.ts
@@ -28,6 +28,71 @@ describe('eval terminal output', () => {
     expect(formatEvaluationSummary(failed, 'en')).toContain('upgrade the CLI');
   });
 
+  it.each([
+    ['OMK_CODEX_CLI_SPAWN_FAILED', 'codex --version', 'claude --version'],
+    ['OMK_CODEX_CLI_STDIN_UNAVAILABLE', 'codex --version', 'claude --version'],
+    ['OMK_CLAUDE_CLI_SPAWN_FAILED', 'claude --version', 'codex --version'],
+    ['OMK_CLAUDE_CLI_STDIN_UNAVAILABLE', 'claude --version', 'codex --version'],
+  ])('shows the correct executable check for %s in both languages', (reasonCode, command, otherCommand) => {
+    for (const lang of ['zh', 'en'] as const) {
+      const text = formatEvaluationSummary({ ...outcome,
+        diagnostic: { findings: [{ severity: 'error', reasonCode }] },
+      }, lang);
+      expect(text).toContain(command);
+      expect(text).not.toContain(otherCommand);
+      expect(text).not.toMatch(/升级|upgrade|cli\.run\./);
+    }
+  });
+
+  it.each([
+    ['OMK_CODEX_CLI_EXIT_NONZERO', 'Codex CLI', 'Claude Code'],
+    ['OMK_CODEX_CLI_TURN_FAILED', 'Codex CLI', 'Claude Code'],
+    ['OMK_CLAUDE_CLI_EXIT_NONZERO', 'Claude Code CLI', 'Codex'],
+    ['OMK_CLAUDE_CLI_TURN_FAILED', 'Claude Code CLI', 'Codex'],
+    ['OMK_CLAUDE_CLI_EXECUTION_FAILED', 'Claude Code CLI', 'Codex'],
+  ])('does not diagnose generic failure %s as requiring an upgrade', (reasonCode, tool, otherTool) => {
+    const failed = { ...outcome, diagnostic: { findings: [{ severity: 'error', reasonCode }] } };
+    const zh = formatEvaluationSummary(failed, 'zh');
+    const en = formatEvaluationSummary(failed, 'en');
+    expect(zh).toContain(`${tool} 调用失败`);
+    expect(zh).toContain('当前错误不能确定是否需要升级');
+    expect(en).toContain(`${tool} failed`);
+    expect(en).toContain('does not establish that an upgrade is needed');
+    expect(en).toContain('Keep the same model and cases');
+    expect(zh + en).not.toContain(otherTool);
+    expect(zh + en).not.toContain('cli.run.');
+  });
+
+  it('deduplicates remedies across codes and stages while preserving both tools and the source', () => {
+    const failed = { ...outcome,
+      diagnostic: { findings: [
+        { severity: 'error', reasonCode: 'OMK_CLAUDE_CLI_EXIT_NONZERO', stage: 'execution' },
+        { severity: 'error', reasonCode: 'OMK_CLAUDE_CLI_TURN_FAILED', stage: 'evaluation' },
+        { severity: 'error', reasonCode: 'OMK_CODEX_CLI_UPGRADE_REQUIRED', stage: 'evaluation' },
+      ] },
+      gate: { ...outcome.gate, reasonCodes: ['OMK_CLAUDE_CLI_EXIT_NONZERO'] },
+    };
+    const before = structuredClone(failed);
+    const text = formatEvaluationSummary(failed, 'zh');
+    expect(text.match(/Claude Code CLI 调用失败/g)).toHaveLength(1);
+    expect(text.match(/codex --version/g)).toHaveLength(1);
+    expect(text).toContain('OMK_CLAUDE_CLI_TURN_FAILED');
+    expect(failed).toEqual(before);
+  });
+
+  it('does not infer CLI remedies from SDK/API failures, unknown codes, or non-error findings', () => {
+    const text = formatEvaluationSummary({ ...outcome, diagnostic: { findings: [
+      ...['OMK_CODEX_SDK_TURN_FAILED', 'OMK_CLAUDE_SDK_EXECUTION_FAILED',
+        'OMK_OPENAI_API_FAILED', 'OMK_CLAUDE_CLI_UPGRADE_REQUIRED', 'OMK_CODEX_CLI_CANCELLED',
+        'OMK_CODEX_CLI_UPGRADE_REQUIRED_EXTRA', 'constructor', '__proto__',
+      ].map((reasonCode) => ({ severity: 'error', reasonCode })),
+      { severity: 'info', reasonCode: 'OMK_CODEX_CLI_UPGRADE_REQUIRED' },
+      { severity: 'warning', reasonCode: 'OMK_CLAUDE_CLI_SPAWN_FAILED' },
+    ] } }, 'en');
+    expect(text).not.toMatch(/--version|upgrade|Codex CLI|Claude Code CLI|cli\.run\./);
+    expect(text).toContain('OMK_CLAUDE_SDK_EXECUTION_FAILED');
+  });
+
   it('shows the verdict and sample-size action even when report-only exits successfully', () => {
     const before = structuredClone(outcome);
     const text = formatEvaluationSummary(outcome, 'zh');


### PR DESCRIPTION
评测调用失败时，终端此前仅为 Codex 的明确升级错误提供修复建议，Claude Code 等错误只有原因代码。现在按适配器已有错误码统一匹配双语提示，覆盖 Codex CLI 和 Claude Code CLI 的启动、输入与调用失败，并合并重复建议。Codex 的升级文案键明确为 `codex_cli_upgrade_hint`。

普通调用失败只建议检查诊断、登录、模型权限与网络；只有已确认的 Codex 版本错误才要求升级。SDK、API、未知错误和非错误级诊断不会套用 CLI 提示。评分、适配器 identity、错误码、持久化契约、退出码和管道 JSON 不变，无需迁移。

验证：定向测试 37 项通过；完整质量检查与全量测试通过。在隔离目录用构建后的真实 CLI 和本地协议 fixture 验证了 Codex／Claude Code 的 TTY 与管道输出、失败退出码及敏感信息隔离，未调用模型服务。首次全量测试因沙箱禁止本地端口监听失败，获得权限后完成全量复验。

自主 CR：No findings。检查了错误码来源、展示接线、双语文案、去重及未知错误边界。本次统一的是运行摘要的提示机制；没有为其他 CLI 猜测新的升级错误协议，也未扩展启动前的版本检查。承接 #827。
