### PR TITLE
refactor(studio): 拆分页面构建与发布资源整理

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,9 @@
     "ci": "run-s ci:quality test",
     "prepublishOnly": "run-s clean build",
     "prepare": "husky",
-    "build:studio": "node scripts/build-studio.mjs"
+    "build:studio": "run-s build:studio:app package:studio",
+    "build:studio:app": "NEXT_TELEMETRY_DISABLED=1 next build src/studio/web --webpack",
+    "package:studio": "node scripts/package-studio.mjs"
   },
   "lint-staged": {
     "{src,test}/**/*.{ts,tsx}": [

--- a/scripts/package-studio.mjs
+++ b/scripts/package-studio.mjs
@@ -1,15 +1,9 @@
-import { spawnSync } from 'node:child_process';
 import { cpSync, mkdirSync, rmSync } from 'node:fs';
 import { dirname, join, resolve, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const app = join(root, 'src/studio/web');
-const result = spawnSync(process.execPath, [join(root, 'node_modules/next/dist/bin/next'), 'build', app, '--webpack'], {
-  cwd: root, stdio: 'inherit', env: { ...process.env, NEXT_TELEMETRY_DISABLED: '1' },
-});
-if (result.error) throw result.error;
-if (result.status !== 0) process.exit(result.status ?? 1);
 const target = join(root, 'dist/studio/web');
 rmSync(target, { recursive: true, force: true });
 mkdirSync(target, { recursive: true });


### PR DESCRIPTION
将 Next.js 构建命令显式放入 package.json：`build:studio:app` 负责页面构建，`package:studio` 负责发布资源整理，`build:studio` 按顺序执行两者。构建失败时不会继续打包。

原 build-studio.mjs 改名为 package-studio.mjs，移除子进程启动与退出码处理，仅保留资源复制与过滤。保持 webpack 构建、关闭构建遥测和现有 dist 布局，不改变安装、启动或测量契约。接续 #832。

验证：`yarn ci` 全部通过（352 个文件、3,800 项测试）；npm pack dry-run 确认 BUILD_ID、Next 配置及静态资源进入包，cache／types／diagnostics 未进入包。

自主 CR：No findings。已复核构建顺序、失败传播、Yarn 脚本入口和发布资源清单。整理逻辑和安装契约未变化，复用 #832 的隔离安装验收，不重复安装测试。
