### PR TITLE
test(studio): 补齐稳定契约断言缺口（#844）

### DIFF
--- a/test/studio/http/knowledge-routes-server.test.ts
+++ b/test/studio/http/knowledge-routes-server.test.ts
@@ -66,4 +66,11 @@ describe('Studio knowledge routes', () => {
     assert.match(chart.headers.get('content-type') ?? '', /application\/javascript/);
     assert.ok((await chart.text()).length > 1000);
   });
+
+  it('answers analyses-diff without from/to as a stable 400 contract', async () => {
+    const response = await fetch(`${baseUrl}/api/analyses-diff`);
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: 'missing_query_params' });
+    assert.equal(response.headers.get('cache-control'), 'no-store');
+  });
 });

--- a/test/studio/http/observation-routes-server.test.ts
+++ b/test/studio/http/observation-routes-server.test.ts
@@ -91,6 +91,8 @@ describe('Studio observation routes', () => {
       body: '{}',
     });
     assert.equal(contentTypeRejected.status, 415);
+    assert.deepEqual(JSON.parse(contentTypeRejected.body), { error: 'unsupported_media_type' });
+    assert.equal(contentTypeRejected.headers['cache-control'], 'no-store');
 
     const crossOriginRejected = await request(endpoint, {
       method: 'POST',
@@ -101,6 +103,7 @@ describe('Studio observation routes', () => {
       body: '{}',
     });
     assert.equal(crossOriginRejected.status, 403);
+    assert.deepEqual(JSON.parse(crossOriginRejected.body), { error: 'mutation_not_trusted' });
 
     const malformed = await request(endpoint, {
       method: 'POST',
@@ -108,6 +111,31 @@ describe('Studio observation routes', () => {
       body: '[]',
     });
     assert.equal(malformed.status, 400);
+    assert.deepEqual(JSON.parse(malformed.body), { error: 'json_body_not_object' });
+
+    const invalidJson = await request(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{broken',
+    });
+    assert.equal(invalidJson.status, 400);
+    assert.deepEqual(JSON.parse(invalidJson.body), { error: 'invalid_json_body' });
+
+    const missingFields = await request(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    assert.equal(missingFields.status, 400);
+    assert.deepEqual(JSON.parse(missingFields.body), { error: 'invalid_review_state' });
+
+    const tooLarge = await request(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: `{"padding":"${'x'.repeat(1024 * 1024)}"}`,
+    });
+    assert.equal(tooLarge.status, 413);
+    assert.deepEqual(JSON.parse(tooLarge.body), { error: 'request_body_too_large' });
 
     const saved = await request(endpoint, {
       method: 'POST',
@@ -123,6 +151,7 @@ describe('Studio observation routes', () => {
 
     const loaded = await request(endpoint);
     assert.equal(loaded.status, 200);
+    assert.equal(loaded.headers['cache-control'], 'no-store');
     assert.equal(JSON.parse(loaded.body).entries['skill:audit'].targetId, 'audit');
 
     const deleted = await request(`${endpoint}?targetType=skill&targetId=audit`, {
@@ -133,6 +162,8 @@ describe('Studio observation routes', () => {
 
     const unsupported = await request(endpoint, { method: 'PUT' });
     assert.equal(unsupported.status, 405);
+    assert.deepEqual(JSON.parse(unsupported.body), { error: 'method_not_allowed' });
+    assert.equal(unsupported.headers.allow, 'DELETE, GET, POST');
   });
 
   it('uses one resolved directory snapshot per diagnostics request', async () => {

--- a/test/studio/http/router.test.ts
+++ b/test/studio/http/router.test.ts
@@ -11,7 +11,7 @@ interface CapturedResponse {
   body: string;
 }
 
-function fakeContext(path: string, method = 'GET', headers: Record<string, string> = {}) {
+function fakeContext(path: string, method = 'GET', headers: Record<string, string | string[]> = {}) {
   const captured: CapturedResponse = { status: 0, headers: {}, body: '' };
   const request = { method, headers } as unknown as IncomingMessage;
   const response = {
@@ -110,6 +110,35 @@ describe('Studio declarative router', () => {
     );
     assert.deepEqual(calls, []);
     assert.equal(await router(fakeContext('/api/thing', 'POST').context), true);
+    assert.deepEqual(calls, ['hit']);
+  });
+
+  it('rejects mutations with ambiguous or malformed origins', async () => {
+    const calls: string[] = [];
+    const router = createStudioRouter([
+      { pattern: '/api/thing', method: 'POST', mutation: true, handler: recording(calls, 'hit') },
+    ]);
+
+    const rejected: Record<string, string | string[]>[] = [
+      { origin: ['https://a.example', 'https://b.example'], host: 'a.example' },
+      { origin: 'https://a.example' },
+      { origin: 'not a url', host: 'a.example' },
+      { origin: 'https://evil.example', host: 'a.example' },
+    ];
+    for (const headers of rejected) {
+      await assert.rejects(
+        router(fakeContext('/api/thing', 'POST', headers).context),
+        (error: unknown) => error instanceof RequestBodyError
+          && error.statusCode === 403
+          && error.code === 'mutation_not_trusted',
+      );
+    }
+    assert.deepEqual(calls, []);
+
+    assert.equal(await router(fakeContext('/api/thing', 'POST', {
+      origin: 'https://a.example',
+      host: 'a.example',
+    }).context), true);
     assert.deepEqual(calls, ['hit']);
   });
 });

--- a/test/studio/http/server-lifecycle.test.ts
+++ b/test/studio/http/server-lifecycle.test.ts
@@ -115,4 +115,20 @@ describe('Studio server lifecycle', () => {
     const restarted = await server.start();
     assert.equal((await fetch(`${restarted}/health`)).status, 200);
   });
+
+  it('answers 500 with a stable marker when the host pipeline itself crashes', async () => {
+    const observationsDir = mkdtempSync(join(tmpdir(), 'omk-studio-internal-'));
+    temporaryDirectories.push(observationsDir);
+    const server = createReportServer({ port: 0, observationsDir }, {
+      async prepare() {},
+      async handle() { throw new Error('render pipeline crashed'); },
+      async close() {},
+    });
+    runningServers.push(server);
+
+    const response = await fetch(`${await server.start()}/observe`);
+    assert.equal(response.status, 500);
+    assert.equal(await response.text(), 'studio_internal_error');
+    assert.match(response.headers.get('content-type') ?? '', /text\/plain/);
+  });
 });


### PR DESCRIPTION
关联 Issue #844（来源：PR #838 复跑 CR 的非阻断 Need Evidence，#836 复跑 CR 结论评论）。

## 内容

纯测试增强，4 个测试文件 +84 行，无生产代码行为变化：

- **observation-routes-server.test.ts**：review-state 用例从只断 HTTP 状态码升级为断言稳定契约——415 `unsupported_media_type`、403 `mutation_not_trusted`、400 `json_body_not_object`／`invalid_json_body`／`invalid_review_state`、413 `request_body_too_large`、405 `method_not_allowed` 与 Allow 聚合头；成功与失败路径均断言 `Cache-Control: no-store`。
- **router.test.ts**：mutation 信任边界四类失败分支——origin 为数组、缺失 Host、非法 origin URL、origin 与 host 不一致，均 403 且 handler 不被调用；origin 与 host 匹配时放行。
- **knowledge-routes-server.test.ts**：`/api/analyses-diff` 缺 from/to 断言 400 `missing_query_params` 与 no-store。
- **server-lifecycle.test.ts**：宿主管线自身异常兜底断言 500 + `studio_internal_error` 纯文本（与 503 数据源错误区分）。

## 验证

- `yarn ci` 全绿（lint + typecheck + build + docs + 全量测试）。
- 定向：4 个受影响测试文件 20 用例全过。

## 自主 CR

低风险纯测试改动，fresh-pass 复核：断言的 code 与响应头逐一比对 src/studio/http/errors.ts、request-errors.ts、request-handler.ts 投影及 report-server.ts 兜底分支；无新增生产代码、无契约变化。No findings。