### PR TITLE
refactor(studio): 独立宿主裁剪观测收件箱路由（#839 批次 0）

### DIFF
--- a/src/cli/lib/core-report-service.ts
+++ b/src/cli/lib/core-report-service.ts
@@ -32,6 +32,8 @@ export async function announceCoreReport(
   const { createReportServer } = await import('../../studio/http/report-server.js');
   const server = createReportServer({
     coreStudioCatalog: createCoreStudioCatalog(store),
+    // 评测预览宿主只服务 /measure 报告页，裁剪收件箱路由（#839 批次 0）。
+    observationInbox: false,
   });
   const serverUrl = await server.start();
   let closing = false;

--- a/src/dsh-plugin/index.ts
+++ b/src/dsh-plugin/index.ts
@@ -188,6 +188,8 @@ async function studioUrl(
     observationsDir: layout.observeInboxDir,
     managedDir: layout.managedDir,
     conversationCatalog: state.catalog,
+    // DSH 宿主无收件箱页面入口（输出落盘路径），裁剪收件箱路由（#839 批次 0）。
+    observationInbox: false,
   });
   state.serverUrl = await state.server.start();
   return state.serverUrl;

--- a/src/studio/README.md
+++ b/src/studio/README.md
@@ -28,8 +28,8 @@ DSH 插件和 CLI 评测预览使用 `createReportServer`，无需启动 Next。
 | 入口 | 宿主 | 直达页面 |
 | --- | --- | --- |
 | CLI `omk studio`（`cli/commands/studio.ts`） | Next（`createNextStudioServer`） | 会话列表/详情/轨迹、Measure、Knowledge 列表/详情为 React；其余路径回落到下方 HTML 路由。 |
-| CLI 评测预览（`cli/lib/run-core-evaluation.ts`，TTY 下 eval 完成后自动启动） | 独立（`createReportServer`） | `/measure/:runId`（HTML）。 |
-| DSH 插件 `/omk observe`（`dsh-plugin/index.ts`） | 独立（`createReportServer`） | 任务轨迹 `/observe/conversations/:thread/tasks/:turn`（HTML）。 |
+| CLI 评测预览（`cli/lib/run-core-evaluation.ts`，TTY 下 eval 完成后自动启动） | 独立（`createReportServer`） | `/measure/:runId`（HTML）。收件箱路由组不注册（`observationInbox: false`，#839 批次 0）。 |
+| DSH 插件 `/omk observe`（`dsh-plugin/index.ts`） | 独立（`createReportServer`） | 任务轨迹 `/observe/conversations/:thread/tasks/:turn`（HTML）。收件箱路由组不注册（`observationInbox: false`，#839 批次 0）；收件箱数据经数据层落盘，不走页面。 |
 
 ### 模块组用途与保留理由
 
@@ -42,8 +42,8 @@ DSH 插件和 CLI 评测预览使用 `createReportServer`，无需启动 Next。
 | `knowledge-reports-renderer`、`skill-health-renderer` | 观测健康列表、报告详情、趋势与差异页（只读报告）。 |
 | `doctor-detail-renderer` | `/knowledge/doctors/:id` 体检报告（只读报告）。 |
 | `managed-history-renderer` | `/knowledge/managed` 及受管对象历史（只读报告）。 |
-| `observation-inbox-renderer`、`observation-inbox/` | `/observe/inbox` 的信号、指标、体验、流程、复核、时间轴及配套样式和脚本。**剩余唯一带用户交互（复核 mutation）的 HTML 页面**；因独立宿主仍以其为唯一渲染层，React 迁移只会新增第二份渲染而无法删除 HTML，故保留，迁移安排见 #839。 |
+| `observation-inbox-renderer`、`observation-inbox/` | `/observe/inbox` 的信号、指标、体验、流程、复核、时间轴及配套样式和脚本。**剩余唯一带用户交互（复核 mutation）的 HTML 页面，仅默认宿主提供**；#839 前提修正（独立宿主消费数据层而非页面）后按收敛路径迁移：批次 0 已裁剪独立宿主路由，随后逐子视图 React 化并删除本模块组。 |
 | `layout`、`report-shell`、`icons`、`inline-markdown` | 上述 HTML 页面的外壳、图标和安全内容渲染。Markdown 解析与纯文本计算位于 application。 |
 | `trajectory-live`、`trajectory-routing` | HTML 轨迹页的客户端脚本生成。纯连线计算位于 `application/replay/routing`，React 直接消费计算模块。 |
 
-只读报告页（skill-health、体检、受管历史）与收件箱一样被两个宿主共用：默认宿主回落到 HTML、独立宿主只有 HTML。迁移其中任何一页到 React 都不会减少渲染层数量，除非独立宿主退役。删除这些模块需要先迁移对应真实入口；目录名本身不是废弃标记。
+只读报告页（skill-health、体检、受管历史）被两个宿主共用：默认宿主回落到 HTML、独立宿主只有 HTML。迁移其中任何一页到 React 都不会减少渲染层数量，除非独立宿主退役或按 #839 批次 0 的方式先裁剪路由。删除这些模块需要先迁移对应真实入口；目录名本身不是废弃标记。

--- a/src/studio/http/contracts.ts
+++ b/src/studio/http/contracts.ts
@@ -24,6 +24,12 @@ export interface ReportServerOptions {
   includeObserveCards?: boolean;
   /** 是否把别项目的 doctor 索引卡片合进机器级总览。 */
   includeDoctorCards?: boolean;
+  /**
+   * 是否提供观测收件箱路由（/observe/inbox 与 /api/observe-inbox/*）。默认 true。
+   * 仅默认宿主（omk studio）提供；独立宿主（DSH 插件、CLI 评测预览）没有收件箱
+   * 页面入口，装配时传 false 裁剪（#839 批次 0）。数据层 observability/inbox 不受影响。
+   */
+  observationInbox?: boolean;
 }
 
 export interface ReportServer {

--- a/src/studio/http/request-handler.ts
+++ b/src/studio/http/request-handler.ts
@@ -36,6 +36,7 @@ export function createStudioRequestHandler({
   coreStudioCatalog,
   includeObserveCards = false,
   includeDoctorCards = false,
+  observationInbox = true,
 }: RequestHandlerOptions): StudioRequestHandler {
   const liveStreamClosers = new Set<() => void>();
   let shutdownTimer: ReturnType<typeof setTimeout> | undefined;
@@ -54,6 +55,7 @@ export function createStudioRequestHandler({
     observationsDir,
     includeObserveCards,
     includeDoctorCards,
+    includeInbox: observationInbox,
   });
   const coreStudioRoute = coreStudioCatalog === undefined
     ? undefined

--- a/src/studio/http/routes/observations.ts
+++ b/src/studio/http/routes/observations.ts
@@ -29,6 +29,8 @@ interface ObservationRoutesOptions {
   readonly observationsDir: string;
   readonly includeObserveCards: boolean;
   readonly includeDoctorCards: boolean;
+  /** 是否注册观测收件箱路由组；独立宿主无收件箱入口，传 false 裁剪（#839 批次 0）。 */
+  readonly includeInbox: boolean;
 }
 
 export interface ObservationRouteContext extends StudioRouteContext {
@@ -57,11 +59,12 @@ export function createObservationRoutes({
   observationsDir,
   includeObserveCards,
   includeDoctorCards,
+  includeInbox,
 }: ObservationRoutesOptions): ObservationRouteHandler {
   const routes: StudioRouteDefinition<ObservationRouteContext>[] = [
-    {
+    ...(includeInbox ? [{
       pattern: '/observe/inbox',
-      handler({ response, url, lang }) {
+      handler({ response, url, lang }: ObservationRouteContext) {
         const skill = url.searchParams.get('skill') || undefined;
         const html = renderObservationInboxPage(
           buildObservationInboxViewModel(observationsDir, { skill }),
@@ -70,7 +73,7 @@ export function createObservationRoutes({
         response.writeHead(200, HTML_HEADERS);
         response.end(html);
       },
-    },
+    }] as const : []),
     {
       pattern: '/observe/sessions/*id',
       handler({ response, url, params, lang }) {
@@ -130,9 +133,9 @@ export function createObservationRoutes({
         ));
       },
     },
-    {
+    ...(includeInbox ? [{
       pattern: '/api/observe-inbox/view',
-      handler({ response, url }) {
+      handler({ response, url }: ObservationRouteContext) {
         const { effectiveExperienceReports, resolvedReviewSessions, unappliedMetricAnnotations } = buildObservationInboxViewModel(observationsDir, { skill: url.searchParams.get('skill') || undefined });
         response.writeHead(200, JSON_HEADERS);
         response.end(JSON.stringify({ effectiveExperienceReports, resolvedReviewSessions, unappliedMetricAnnotations }));
@@ -140,7 +143,7 @@ export function createObservationRoutes({
     },
     {
       pattern: '/api/observe-inbox',
-      handler({ response, url }) {
+      handler({ response, url }: ObservationRouteContext) {
         const severity = url.searchParams.get('severity');
         const skill = url.searchParams.get('skill');
         const limitRaw = url.searchParams.get('limit');
@@ -157,7 +160,7 @@ export function createObservationRoutes({
     },
     {
       pattern: '/api/observe-inbox/diagnostics',
-      handler({ response, analysesDir, doctorsDir }) {
+      handler({ response, analysesDir, doctorsDir }: ObservationRouteContext) {
         const index = buildSkillIndex(
           analysesDir,
           doctorsDir,
@@ -180,7 +183,7 @@ export function createObservationRoutes({
     },
     {
       pattern: '/api/observe-inbox/show',
-      handler({ response, url }) {
+      handler({ response, url }: ObservationRouteContext) {
         const id = url.searchParams.get('id') || '';
         const item = id ? findObservationInboxItem(id, observationsDir) : null;
         if (!item) {
@@ -193,7 +196,7 @@ export function createObservationRoutes({
     },
     {
       pattern: '/api/observe-inbox/review-state',
-      handler({ response }) {
+      handler({ response }: ObservationRouteContext) {
         response.writeHead(200, JSON_HEADERS);
         response.end(JSON.stringify(loadObservationReviewState(observationsDir)));
       },
@@ -202,7 +205,7 @@ export function createObservationRoutes({
       pattern: '/api/observe-inbox/review-state',
       method: 'POST',
       mutation: true,
-      async handler({ request, response }) {
+      async handler({ request, response }: ObservationRouteContext) {
         const body = await readJsonObjectBody(request) as Partial<ObservationReviewStateUpdate>;
         const state = updateObservationReviewState(observationsDir, {
           targetType: body.targetType as ObservationReviewStateUpdate['targetType'],
@@ -230,14 +233,14 @@ export function createObservationRoutes({
       pattern: '/api/observe-inbox/review-state',
       method: 'DELETE',
       mutation: true,
-      handler({ response, url }) {
+      handler({ response, url }: ObservationRouteContext) {
         const targetType = url.searchParams.get('targetType') as ObservationReviewStateUpdate['targetType'];
         const targetId = url.searchParams.get('targetId') ?? '';
         const state = deleteObservationReviewState(observationsDir, targetType, targetId);
         response.writeHead(200, JSON_HEADERS);
         response.end(JSON.stringify(state));
       },
-    },
+    }] as const : []),
   ];
 
   return createStudioRouter(routes);

--- a/test/studio/http/observation-routes-server.test.ts
+++ b/test/studio/http/observation-routes-server.test.ts
@@ -191,4 +191,41 @@ describe('Studio observation routes', () => {
       await snapshotServer.stop();
     }
   });
+
+  it('omits inbox routes when the host opts out, keeping the debugger group', async () => {
+    const scoped = createReportServer({
+      port: 0,
+      observationsDir,
+      analysesDir: join(root, 'analyses'),
+      doctorsDir: join(root, 'doctors'),
+      observationInbox: false,
+    });
+    const scopedUrl = await scoped.start();
+    try {
+      for (const path of [
+        '/observe/inbox',
+        '/api/observe-inbox',
+        '/api/observe-inbox/view',
+        '/api/observe-inbox/show?id=x',
+        '/api/observe-inbox/diagnostics',
+        '/api/observe-inbox/review-state',
+      ]) {
+        const res = await request(`${scopedUrl}${path}`);
+        assert.equal(res.status, 404, `${path} should be unregistered`);
+        assert.equal(res.body, 'Not Found');
+      }
+      const posted = await request(`${scopedUrl}/api/observe-inbox/review-state`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      assert.equal(posted.status, 404);
+
+      const session = await request(`${scopedUrl}/observe/sessions/missing`);
+      assert.equal(session.status, 404);
+      assert.match(session.body, /观测会话不存在/);
+    } finally {
+      await scoped.stop();
+    }
+  });
 });


### PR DESCRIPTION
关联 Issue #839（前提修正后的收敛路径，批次 0）。

## 前提修正

原登记认为独立宿主（DSH 插件、CLI 评测预览）需要 HTML 收件箱。源码核实不成立：DSH `/omk observe` 给用户的收件箱出口是落盘文件路径（dsh-plugin/index.ts），CLI `omk observe inbox` 直接输出 JSON；路由在独立宿主可达仅是 #836 批次 3 双宿主共享路由表的副作用，无用户入口。详见 #839 正文。

## 内容

- `ReportServerOptions` 新增 `observationInbox`（默认 true，能力声明在装配层）；DSH 与 CLI 评测预览装配传 `false`。
- 收件箱 8 条路由（/observe/inbox 页面、/api/observe-inbox 列表、view、diagnostics、show、review-state 的 GET/POST/DELETE）随裁剪在独立宿主返回 404；调试器路由组（/observe/sessions/*、/api/observe-debugger/*）保留。
- 默认宿主（omk studio）不传该选项，行为不变。

## 行为变化（BREAKING 面）

独立宿主的收件箱路径由 200/405 变为 404。评估为低风险：无入口、无文档引用、无测试锁定独立宿主收件箱可用性。数据层 observability/inbox 与 CLI observe 子命令不受影响。

## 验证

- `yarn ci` 全绿（lint + typecheck + build + docs + 全量测试）。
- 新增裁剪行为用例：5 条 GET 与 POST review-state 在裁剪宿主 404（body 为路由未命中 Not Found），调试器组保留（未知会话仍走调试器自身 404 文案），区分两类 404。
- 受影响域回归：test/dsh-plugin、test/cli、test/studio 全绿。

## 自主 CR

fresh-pass 复核（CODE_REVIEW.md）：diff、调用方（4 处 createReportServer/createNextStudioServer 装配点）、契约（选项默认值保持既有行为）、测试证据。发现并修正 1 处遗漏：/api/observe-inbox/view 一度留在裁剪块外，已移入并补断言。最终 No findings。

## 后续批次

批次 1 起在默认宿主内按子视图迁移 React（信号 → 复核 → 指标 → 体验 → 流程 → 时间轴 → skill 链），每批迁移后删除对应 HTML 子视图；收口批次删除 presentation/observation-inbox/ 整目录。