### PR TITLE
feat(studio): 观测收件箱 React 骨架与信号子视图（#839 批次 1）

### DIFF
--- a/src/observability/inbox/index.ts
+++ b/src/observability/inbox/index.ts
@@ -1,4 +1,5 @@
 import { buildOverallSessionTimeRange } from './session-time-range.js';
+import { severityReasonCodeFor } from './severity-reason.js';
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -259,45 +260,8 @@ function buildSessionTimeRanges(sessions: TraceSession[]): ObservationSessionTim
   );
 }
 
-const SEVERITY_REASON_ZH: Record<ObservationSeverityReasonCode, string> = {
-  repeated_failure_suspected: '同类搜索连续失败 3 次以上，是强缺口信号，高于单次 hard_miss。',
-  explicit_gap_marker: 'agent 主动输出了知识缺口/未知标记，需要优先人工确认。',
-  knowledge_gap_suspected: '{tool}失败后，session 内未找到同主题成功证据，疑似知识缺口。',
-  exploratory_probe: 'skill 运行过程中出现了试路径、试目录或前序失败后后续成功的行为；先抽样确认，不直接判为要改 skill。',
-  skill_asset_unavailable: '读取该 skill 自身资源失败，可能是路径错位、资源未提交或 ignore 配置问题。',
-  soft_hedging_signal: '模型文本里出现了不确定表达，属于低置信文本信号，需要结合上下文人工判断。',
-  user_reported_knowledge_issue: '用户明确提交了真实使用中的 knowledge 问题；当前只保留用户授权提交的部分证据，需人工复核后再进入样本集。',
-  tool_or_runtime_noise: '更像路径、权限、文件太大、临时文件或工具运行问题；通常不作为 skill 内容缺失。',
-};
+export { severityReasonFor, severityReasonCodeFor } from './severity-reason.js';
 
-const SEVERITY_REASON_EN: Record<ObservationSeverityReasonCode, string> = {
-  repeated_failure_suspected: 'Similar searches failed at least three times; this is stronger than a single hard miss.',
-  explicit_gap_marker: 'The agent explicitly marked an unknown or knowledge gap; review this first.',
-  knowledge_gap_suspected: '{tool}failed and no later same-topic success was found in the session.',
-  exploratory_probe: 'The event looks like path probing, directory probing, or an earlier miss followed by later success; sample it before changing the skill.',
-  skill_asset_unavailable: 'The agent failed to read an asset inside the skill itself; check path alignment, committed resources, or ignore rules.',
-  soft_hedging_signal: 'The agent used uncertain wording; treat this as a low-confidence text signal.',
-  user_reported_knowledge_issue: 'The user explicitly submitted a knowledge issue from real usage; only the authorized partial evidence is retained until human review.',
-  tool_or_runtime_noise: 'This looks like a path, permission, token limit, transient file, or runtime tool issue rather than missing skill content.',
-};
-
-export function severityReasonFor(item: Pick<ObservationInboxItem, 'signalType' | 'signalSubtype' | 'severity' | 'confidence' | 'evidence' | 'severityReasonCode'>, lang: 'zh' | 'en' = 'zh'): string {
-  const code = item.severityReasonCode ?? severityReasonCodeFor(item);
-  const tool = item.evidence.tool ? `${item.evidence.tool} ` : '';
-  const dictionary = lang === 'en' ? SEVERITY_REASON_EN : SEVERITY_REASON_ZH;
-  return dictionary[code].replace('{tool}', tool);
-}
-
-export function severityReasonCodeFor(item: Pick<ObservationInboxItem, 'signalType' | 'signalSubtype' | 'severity' | 'confidence'>): ObservationSeverityReasonCode {
-  if (item.signalType === 'user_feedback') return 'user_reported_knowledge_issue';
-  if (item.signalSubtype === 'repeated_failure') return 'repeated_failure_suspected';
-  if (item.signalType === 'explicit_marker') return 'explicit_gap_marker';
-  if (item.signalSubtype === 'hard_miss') return 'knowledge_gap_suspected';
-  if (item.signalSubtype === 'skill_asset_read_failed') return 'skill_asset_unavailable';
-  if (item.signalSubtype === 'exploratory_miss' || item.signalSubtype === 'bash_probe') return 'exploratory_probe';
-  if (item.signalType === 'hedging') return 'soft_hedging_signal';
-  return 'tool_or_runtime_noise';
-}
 
 function itemsFromSegment(segment: SkillSegment): ObservationInboxItem[] {
   // inbox 只观察真实 skill 调用场景。'general' 是 trace-adapter 对裸对话的

--- a/src/observability/inbox/severity-reason.ts
+++ b/src/observability/inbox/severity-reason.ts
@@ -1,0 +1,47 @@
+import type { ObservationInboxItem, ObservationSeverityReasonCode } from '../contracts/inbox.js';
+
+/**
+ * 严重度理由的纯函数与字典（无文件系统依赖）。
+ * 从 index.js 抽出：React client bundle 与 HTML 渲染器共用，宿主侧按需引入（#839 批次 1）。
+ * index.js 仍再导出本模块，既有 import 路径不变。
+ */
+
+const SEVERITY_REASON_ZH: Record<ObservationSeverityReasonCode, string> = {
+  repeated_failure_suspected: '同类搜索连续失败 3 次以上，是强缺口信号，高于单次 hard_miss。',
+  explicit_gap_marker: 'agent 主动输出了知识缺口/未知标记，需要优先人工确认。',
+  knowledge_gap_suspected: '{tool}失败后，session 内未找到同主题成功证据，疑似知识缺口。',
+  exploratory_probe: 'skill 运行过程中出现了试路径、试目录或前序失败后后续成功的行为；先抽样确认，不直接判为要改 skill。',
+  skill_asset_unavailable: '读取该 skill 自身资源失败，可能是路径错位、资源未提交或 ignore 配置问题。',
+  soft_hedging_signal: '模型文本里出现了不确定表达，属于低置信文本信号，需要结合上下文人工判断。',
+  user_reported_knowledge_issue: '用户明确提交了真实使用中的 knowledge 问题；当前只保留用户授权提交的部分证据，需人工复核后再进入样本集。',
+  tool_or_runtime_noise: '更像路径、权限、文件太大、临时文件或工具运行问题；通常不作为 skill 内容缺失。',
+};
+
+const SEVERITY_REASON_EN: Record<ObservationSeverityReasonCode, string> = {
+  repeated_failure_suspected: 'Similar searches failed at least three times; this is stronger than a single hard miss.',
+  explicit_gap_marker: 'The agent explicitly marked an unknown or knowledge gap; review this first.',
+  knowledge_gap_suspected: '{tool}failed and no later same-topic success was found in the session.',
+  exploratory_probe: 'The event looks like path probing, directory probing, or an earlier miss followed by later success; sample it before changing the skill.',
+  skill_asset_unavailable: 'The agent failed to read an asset inside the skill itself; check path alignment, committed resources, or ignore rules.',
+  soft_hedging_signal: 'The agent used uncertain wording; treat this as a low-confidence text signal.',
+  user_reported_knowledge_issue: 'The user explicitly submitted a knowledge issue from real usage; only the authorized partial evidence is retained until human review.',
+  tool_or_runtime_noise: 'This looks like a path, permission, token limit, transient file, or runtime tool issue rather than missing skill content.',
+};
+
+export function severityReasonFor(item: Pick<ObservationInboxItem, 'signalType' | 'signalSubtype' | 'severity' | 'confidence' | 'evidence' | 'severityReasonCode'>, lang: 'zh' | 'en' = 'zh'): string {
+  const code = item.severityReasonCode ?? severityReasonCodeFor(item);
+  const tool = item.evidence.tool ? `${item.evidence.tool} ` : '';
+  const dictionary = lang === 'en' ? SEVERITY_REASON_EN : SEVERITY_REASON_ZH;
+  return dictionary[code].replace('{tool}', tool);
+}
+
+export function severityReasonCodeFor(item: Pick<ObservationInboxItem, 'signalType' | 'signalSubtype' | 'severity' | 'confidence'>): ObservationSeverityReasonCode {
+  if (item.signalType === 'user_feedback') return 'user_reported_knowledge_issue';
+  if (item.signalSubtype === 'repeated_failure') return 'repeated_failure_suspected';
+  if (item.signalType === 'explicit_marker') return 'explicit_gap_marker';
+  if (item.signalSubtype === 'hard_miss') return 'knowledge_gap_suspected';
+  if (item.signalSubtype === 'skill_asset_read_failed') return 'skill_asset_unavailable';
+  if (item.signalSubtype === 'exploratory_miss' || item.signalSubtype === 'bash_probe') return 'exploratory_probe';
+  if (item.signalType === 'hedging') return 'soft_hedging_signal';
+  return 'tool_or_runtime_noise';
+}

--- a/src/observability/inbox/signal-semantics.ts
+++ b/src/observability/inbox/signal-semantics.ts
@@ -1,0 +1,146 @@
+import type {
+  ObservationEvidence,
+  ObservationInboxItem,
+} from '../contracts/inbox.js';
+import type { TraceSourceKind } from '../contracts/trace.js';
+import { severityReasonFor } from './severity-reason.js';
+
+/**
+ * 观测收件箱信号子视图的展示语义（宿主无关纯函数）。
+ * HTML 渲染器（presentation/observation-inbox）与 React 页面（studio/web/components/inbox）
+ * 共用同一份文案与映射，避免出现第二套业务语义（#839 批次 1）。
+ * 样式（色值、布局）仍归各呈现层；这里只输出语义字段与 tone。
+ */
+
+export type SignalSeverityTone = 'error' | 'warning' | 'info' | 'neutral';
+
+export interface SignalSeverityMeta {
+  readonly label: string;
+  readonly decision: string;
+  readonly tone: SignalSeverityTone;
+}
+
+type SignalItem = Pick<ObservationInboxItem, 'signalType' | 'signalSubtype' | 'severity' | 'confidence' | 'evidence' | 'severityReasonCode' | 'occurrences'>;
+
+const SEVERITY_META_ZH: Record<ObservationInboxItem['severity'], { label: string; decision: string }> = {
+  high: { label: '高风险/需关注', decision: '优先看，可能要补 SKILL.md 或改 skill 说明' },
+  medium: { label: '低风险/抽样确认', decision: '通常不需要改 skill；抽样确认是否反复浪费时间' },
+  low: { label: '不确定/低优先级', decision: '模型只是说不确定，不一定需要改 skill' },
+  noise: { label: '无异常/无需改 skill', decision: '更像路径、权限、文件太大或工具限制；先不当成 skill 内容缺失' },
+};
+
+const SEVERITY_META_EN: Record<ObservationInboxItem['severity'], { label: string; decision: string }> = {
+  high: { label: 'High risk', decision: 'Review first; the SKILL.md or skill description may need changes' },
+  medium: { label: 'Low risk / sample-check', decision: 'Usually no skill change; sample-check whether time is repeatedly wasted' },
+  low: { label: 'Uncertain / low priority', decision: 'The model only expressed uncertainty; no skill change is implied' },
+  noise: { label: 'Noise / no skill change', decision: 'More likely path, permission, file-size or tool limits; not a skill content gap' },
+};
+
+const SEVERITY_TONE: Record<ObservationInboxItem['severity'], SignalSeverityTone> = {
+  high: 'error',
+  medium: 'warning',
+  low: 'info',
+  noise: 'neutral',
+};
+
+export function signalSeverityMeta(severity: ObservationInboxItem['severity'], lang: 'zh' | 'en' = 'zh'): SignalSeverityMeta {
+  const meta = (lang === 'en' ? SEVERITY_META_EN : SEVERITY_META_ZH)[severity];
+  return { ...meta, tone: SEVERITY_TONE[severity] };
+}
+
+function evidenceTool(evidence: ObservationEvidence, lang: 'zh' | 'en'): string {
+  return evidence.tool || (lang === 'en' ? 'Tool' : '工具');
+}
+
+function evidenceTarget(evidence: ObservationEvidence): string {
+  return evidence.query || evidence.path || evidence.assistantSnippet || '';
+}
+
+/** 语义证据行（非完整句式），按 signalSubtype 描述证据形态。 */
+export function signalSemanticEvidence(item: Pick<SignalItem, 'signalSubtype' | 'evidence'>, lang: 'zh' | 'en' = 'zh'): string {
+  const tool = item.evidence.tool || 'Tool';
+  const target = evidenceTarget(item.evidence);
+  const output = item.evidence.outputSnippet || target;
+  if (lang === 'en') {
+    switch (item.signalSubtype) {
+      case 'tool_limit': return `${tool} hit a tool limit: ${output}`;
+      case 'transient_file_missing': return `${tool} read a temporary file that does not exist: ${item.evidence.path || target}`;
+      case 'skill_asset_read_failed': return `${tool} failed to read the skill's own asset: ${item.evidence.path || target}`;
+      case 'not_found': return `${tool} accessed a path that does not exist: ${item.evidence.path || target}`;
+      case 'permission_denied': return `${tool} was denied by permissions: ${item.evidence.path || target}`;
+      case 'bash_probe': return `During the skill run, the agent invoked a Bash command: ${item.evidence.query || target}`;
+      case 'hard_miss': return `${tool} missed and no later success on the same topic: ${target}`;
+      case 'exploratory_miss': return `${tool} missed first, but later searches succeeded: ${target}`;
+      default: return target || item.evidence.outputSnippet || '';
+    }
+  }
+  switch (item.signalSubtype) {
+    case 'tool_limit': return `${tool} 触发工具限制：${output}`;
+    case 'transient_file_missing': return `${tool} 访问了临时文件但文件不存在：${item.evidence.path || target}`;
+    case 'skill_asset_read_failed': return `${tool} 读取该 skill 自身资源失败：${item.evidence.path || target}`;
+    case 'not_found': return `${tool} 访问了不存在的路径：${item.evidence.path || target}`;
+    case 'permission_denied': return `${tool} 被权限拒绝：${item.evidence.path || target}`;
+    case 'bash_probe': return `skill 运行过程中，agent 调用了一条 Bash 命令：${item.evidence.query || target}`;
+    case 'hard_miss': return `${tool} 未命中且后续未找到同主题成功证据：${target}`;
+    case 'exploratory_miss': return `${tool} 前序未命中，但后续有成功搜索证据：${target}`;
+    default: return target || item.evidence.outputSnippet || '';
+  }
+}
+
+/** 证据结论（完整句式），供表格主文案与详情列表使用。 */
+export function signalEvidenceConclusion(item: Pick<SignalItem, 'signalType' | 'signalSubtype' | 'evidence'>, lang: 'zh' | 'en' = 'zh'): string {
+  const tool = evidenceTool(item.evidence, lang);
+  if (lang === 'en') {
+    switch (item.signalSubtype) {
+      case 'bash_probe': return 'During the skill run, the agent invoked a Bash command.';
+      case 'tool_limit': return `${tool} hit a file-length, token or timeout limit.`;
+      case 'transient_file_missing': return `${tool} read a temporary file that does not exist.`;
+      case 'skill_asset_read_failed': return `${tool} failed to read the skill's own asset.`;
+      case 'not_found': return `${tool} accessed a path that does not exist.`;
+      case 'permission_denied': return `${tool} was denied by permissions.`;
+      case 'hard_miss': return `${tool} returned nothing useful, and no later success on the same topic was observed.`;
+      case 'exploratory_miss': return `${tool} returned nothing at first, but later searches found the content.`;
+      default: break;
+    }
+    if (item.signalType === 'hedging') return 'The model text contains hedging expressions.';
+    if (item.signalType === 'explicit_marker') return 'The model text contains an explicit marker.';
+    return signalSemanticEvidence(item, lang);
+  }
+  switch (item.signalSubtype) {
+    case 'bash_probe': return 'skill 运行过程中，agent 调用了一条 Bash 命令。';
+    case 'tool_limit': return `${tool} 触发了文件太长、token 或超时限制。`;
+    case 'transient_file_missing': return `${tool} 访问了临时文件，但文件不存在。`;
+    case 'skill_asset_read_failed': return `${tool} 读取该 skill 自身资源失败。`;
+    case 'not_found': return `${tool} 访问了不存在的路径。`;
+    case 'permission_denied': return `${tool} 被权限拒绝。`;
+    case 'hard_miss': return `${tool} 没有拿到有效结果，后续也没有看到同主题成功证据。`;
+    case 'exploratory_miss': return `${tool} 前面没有拿到结果，但后续找到了相关内容。`;
+    default: break;
+  }
+  if (item.signalType === 'hedging') return '模型文本里出现了不确定表达。';
+  if (item.signalType === 'explicit_marker') return '模型文本里出现了显式标记。';
+  return signalSemanticEvidence(item, lang);
+}
+
+/** 信号帮助气泡的完整描述（label: type/subtype, confidence=x.xx. reason）。 */
+export function signalRuleDescription(item: SignalItem, lang: 'zh' | 'en' = 'zh'): string {
+  const meta = signalSeverityMeta(item.severity, lang);
+  const prefix = `${meta.label}: ${item.signalType}/${item.signalSubtype}, confidence=${item.confidence.toFixed(2)}.`;
+  return `${prefix} ${severityReasonFor(item, lang)}`;
+}
+
+export interface SignalSourceMeta {
+  readonly label: string;
+  readonly tone: 'teal' | 'purple' | 'geekblue' | 'green' | 'blue' | 'neutral';
+}
+
+export function signalSourceMeta(sourceKind: TraceSourceKind): SignalSourceMeta {
+  switch (sourceKind) {
+    case 'dsh': return { label: 'DeepSeek Harness', tone: 'teal' };
+    case 'openclaw': return { label: 'OpenClaw', tone: 'purple' };
+    case 'codex': return { label: 'Codex', tone: 'geekblue' };
+    case 'markdown_log': return { label: 'Markdown log', tone: 'green' };
+    case 'claude': return { label: 'Claude', tone: 'blue' };
+    default: return { label: 'Unknown', tone: 'neutral' };
+  }
+}

--- a/src/observability/inbox/view-model.ts
+++ b/src/observability/inbox/view-model.ts
@@ -212,6 +212,14 @@ function filterReportBySkill(report: ObservationInboxReport, skillName?: string)
 
 export { severityReasonFor } from './index.js';
 export {
+  signalEvidenceConclusion,
+  signalRuleDescription,
+  signalSemanticEvidence,
+  signalSeverityMeta,
+  signalSourceMeta,
+} from './signal-semantics.js';
+export type { SignalSeverityMeta, SignalSeverityTone, SignalSourceMeta } from './signal-semantics.js';
+export {
   observationMetricAnnotationEntry,
   observationMetricAnnotationTargetId,
 } from './review-state.js';

--- a/src/studio/http/inbox-page.ts
+++ b/src/studio/http/inbox-page.ts
@@ -1,0 +1,15 @@
+import { buildObservationInboxViewModel, type ObservationInboxViewModel } from '../../observability/inbox/view-model.js';
+
+export type InboxPage = {
+  readonly pageKind: 'inbox';
+  readonly model: ObservationInboxViewModel;
+};
+
+/**
+ * 观测收件箱 Next 页面的数据桥接（#839 批次 1）。
+ * 投影仍由 observability/inbox/view-model.ts 提供，React 不引入第二份业务语义。
+ * 目录不可读等数据源失败在此抛出，由 next-server 统一投影为 503。
+ */
+export function loadInboxPage(observationsDir: string, skill: string | undefined): InboxPage {
+  return { pageKind: 'inbox', model: buildObservationInboxViewModel(observationsDir, { skill }) };
+}

--- a/src/studio/http/next-context.ts
+++ b/src/studio/http/next-context.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { CoreStudioCatalog } from '../view-models/core-runs.js';
+import type { InboxPage } from './inbox-page.js';
 import type { KnowledgePage } from './knowledge-page.js';
 import type { ObservePage } from './observe-page.js';
 
@@ -41,3 +42,4 @@ function defineStudioRequestContext<T>(name: string): StudioRequestContext<T> {
 export const nextCatalogContext = defineStudioRequestContext<CoreStudioCatalog>('catalog');
 export const nextObserveContext = defineStudioRequestContext<ObservePage>('observe');
 export const nextKnowledgeContext = defineStudioRequestContext<KnowledgePage>('knowledge');
+export const nextInboxContext = defineStudioRequestContext<InboxPage>('inbox');

--- a/src/studio/presentation/observation-inbox/signal-renderer.ts
+++ b/src/studio/presentation/observation-inbox/signal-renderer.ts
@@ -1,22 +1,28 @@
 import type { Lang } from '../../../shared/language.js';
-import { severityReasonFor } from '../../../observability/inbox/view-model.js';
 import type { ObservationInboxItem } from '../../../observability/inbox/view-model.js';
+import {
+  signalEvidenceConclusion,
+  signalRuleDescription as describeSignalRule,
+  signalSemanticEvidence,
+  signalSeverityMeta,
+  signalSourceMeta,
+  type SignalSeverityTone,
+} from '../../../observability/inbox/view-model.js';
 import { e } from '../layout.js';
 
 export type ObservationSignalRenderers = ReturnType<typeof createObservationSignalRenderers>;
 
+const SEVERITY_COLORS: Record<SignalSeverityTone, { color: string; bg: string }> = {
+  error: { color: 'var(--red)', bg: 'rgba(220,38,38,.08)' },
+  warning: { color: 'var(--yellow)', bg: 'rgba(202,138,4,.10)' },
+  info: { color: 'var(--accent)', bg: 'rgba(37,99,235,.08)' },
+  neutral: { color: 'var(--text-muted)', bg: 'var(--bg-muted)' },
+};
+
 export function createObservationSignalRenderers(lang: Lang) {
   const reviewSeverityMeta = (item: ObservationInboxItem): { label: string; decision: string; color: string; bg: string } => {
-    if (item.severity === 'high') {
-      return { label: '高风险/需关注', decision: '优先看，可能要补 SKILL.md 或改 skill 说明', color: 'var(--red)', bg: 'rgba(220,38,38,.08)' };
-    }
-    if (item.severity === 'medium') {
-      return { label: '低风险/抽样确认', decision: '通常不需要改 skill；抽样确认是否反复浪费时间', color: 'var(--yellow)', bg: 'rgba(202,138,4,.10)' };
-    }
-    if (item.severity === 'low') {
-      return { label: '不确定/低优先级', decision: '模型只是说不确定，不一定需要改 skill', color: 'var(--accent)', bg: 'rgba(37,99,235,.08)' };
-    }
-    return { label: '无异常/无需改 skill', decision: '更像路径、权限、文件太大或工具限制；先不当成 skill 内容缺失', color: 'var(--text-muted)', bg: 'var(--bg-muted)' };
+    const meta = signalSeverityMeta(item.severity);
+    return { label: meta.label, decision: meta.decision, ...SEVERITY_COLORS[meta.tone] };
   };
   const renderSeverityBadge = (item: ObservationInboxItem): string => {
     const meta = reviewSeverityMeta(item);
@@ -25,32 +31,8 @@ export function createObservationSignalRenderers(lang: Lang) {
       <span style="color:var(--text-muted);font-size:11px">${e(meta.decision)}</span>
     </div>`;
   };
-  const semanticEvidence = (item: ObservationInboxItem): string => {
-    const tool = item.evidence.tool || 'Tool';
-    const target = item.evidence.query || item.evidence.path || item.evidence.assistantSnippet || '';
-    if (item.signalSubtype === 'tool_limit') return `${tool} 触发工具限制：${item.evidence.outputSnippet || target}`;
-    if (item.signalSubtype === 'transient_file_missing') return `${tool} 访问了临时文件但文件不存在：${item.evidence.path || target}`;
-    if (item.signalSubtype === 'skill_asset_read_failed') return `${tool} 读取该 skill 自身资源失败：${item.evidence.path || target}`;
-    if (item.signalSubtype === 'not_found') return `${tool} 访问了不存在的路径：${item.evidence.path || target}`;
-    if (item.signalSubtype === 'permission_denied') return `${tool} 被权限拒绝：${item.evidence.path || target}`;
-    if (item.signalSubtype === 'bash_probe') return `skill 运行过程中，agent 调用了一条 Bash 命令：${item.evidence.query || target}`;
-    if (item.signalSubtype === 'hard_miss') return `${tool} 未命中且后续未找到同主题成功证据：${target}`;
-    if (item.signalSubtype === 'exploratory_miss') return `${tool} 前序未命中，但后续有成功搜索证据：${target}`;
-    return target || item.evidence.outputSnippet || '';
-  };
-  const evidenceConclusion = (item: ObservationInboxItem): string => {
-    if (item.signalSubtype === 'bash_probe') return 'skill 运行过程中，agent 调用了一条 Bash 命令。';
-    if (item.signalSubtype === 'tool_limit') return `${item.evidence.tool || '工具'} 触发了文件太长、token 或超时限制。`;
-    if (item.signalSubtype === 'transient_file_missing') return `${item.evidence.tool || '工具'} 访问了临时文件，但文件不存在。`;
-    if (item.signalSubtype === 'skill_asset_read_failed') return `${item.evidence.tool || '工具'} 读取该 skill 自身资源失败。`;
-    if (item.signalSubtype === 'not_found') return `${item.evidence.tool || '工具'} 访问了不存在的路径。`;
-    if (item.signalSubtype === 'permission_denied') return `${item.evidence.tool || '工具'} 被权限拒绝。`;
-    if (item.signalSubtype === 'hard_miss') return `${item.evidence.tool || '工具'} 没有拿到有效结果，后续也没有看到同主题成功证据。`;
-    if (item.signalSubtype === 'exploratory_miss') return `${item.evidence.tool || '工具'} 前面没有拿到结果，但后续找到了相关内容。`;
-    if (item.signalType === 'hedging') return '模型文本里出现了不确定表达。';
-    if (item.signalType === 'explicit_marker') return '模型文本里出现了显式标记。';
-    return semanticEvidence(item);
-  };
+  const semanticEvidence = (item: ObservationInboxItem): string => signalSemanticEvidence(item);
+  const evidenceConclusion = (item: ObservationInboxItem): string => signalEvidenceConclusion(item);
   const evidenceQuote = (item: ObservationInboxItem): string => {
     return item.evidence.query || item.evidence.path || item.evidence.assistantSnippet || item.evidence.outputSnippet || '';
   };
@@ -81,12 +63,8 @@ export function createObservationSignalRenderers(lang: Lang) {
       ${quote ? `<code style="display:block;margin-top:5px;font-family:ui-monospace,monospace;font-size:11px;line-height:1.45;color:var(--text-muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;background:var(--bg-muted);padding:4px 6px;border-radius:4px">${e(quote.slice(0, max))}</code>` : ''}
     </div>`;
   };
-  const signalRuleDescription = (item: ObservationInboxItem): string => {
-    const reason = severityReasonFor(item, lang);
-    const meta = reviewSeverityMeta(item);
-    const prefix = `${meta.label}: ${item.signalType}/${item.signalSubtype}, confidence=${item.confidence.toFixed(2)}.`;
-    return `${prefix} ${reason}`;
-  };
+  const signalRuleDescription = (item: ObservationInboxItem): string =>
+    describeSignalRule(item, lang);
   const renderSignalLabel = (item: ObservationInboxItem): string => {
     const desc = signalRuleDescription(item);
     return `<span style="position:relative;display:inline-flex;align-items:center;gap:4px;overflow:visible">
@@ -102,8 +80,17 @@ export function createObservationSignalRenderers(lang: Lang) {
     </div>`;
   };
   const renderSourceBadge = (item: ObservationInboxItem): string => {
-    const label = item.sourceKind === 'dsh' ? 'DeepSeek Harness' : item.sourceKind === 'openclaw' ? 'OpenClaw' : item.sourceKind === 'codex' ? 'Codex' : item.sourceKind === 'markdown_log' ? 'Markdown log' : item.sourceKind === 'claude' ? 'Claude' : 'Unknown';
-    const color = item.sourceKind === 'dsh' ? '#0f766e' : item.sourceKind === 'openclaw' ? '#7c3aed' : item.sourceKind === 'codex' ? '#1677ff' : item.sourceKind === 'markdown_log' ? 'var(--green)' : item.sourceKind === 'claude' ? 'var(--accent)' : 'var(--text-muted)';
+    const meta = signalSourceMeta(item.sourceKind);
+    const colors: Record<string, string> = {
+      teal: '#0f766e',
+      purple: '#7c3aed',
+      geekblue: '#1677ff',
+      green: 'var(--green)',
+      blue: 'var(--accent)',
+      neutral: 'var(--text-muted)',
+    };
+    const label = meta.label;
+    const color = colors[meta.tone];
     return `<span title="调用日志来源：${e(label)}" style="display:inline-flex;margin-top:4px;padding:2px 6px;border-radius:999px;background:var(--bg-muted);color:${color};font-size:11px;font-weight:650">${e(label)}</span>`;
   };
   return {

--- a/src/studio/web/app/observe/inbox/page.tsx
+++ b/src/studio/web/app/observe/inbox/page.tsx
@@ -1,0 +1,14 @@
+import { requestInboxPage } from '../../../catalog';
+import { InboxView } from '../../../components/inbox/inbox';
+import { StudioShell } from '../../../components/layout/shell';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Page({ searchParams }: { searchParams: Promise<{ lang?: string }> }) {
+  const lang = (await searchParams).lang === 'en' ? 'en' : 'zh';
+  return (
+    <StudioShell lang={lang} active="observe">
+      <InboxView model={requestInboxPage().model} lang={lang} />
+    </StudioShell>
+  );
+}

--- a/src/studio/web/catalog.tsx
+++ b/src/studio/web/catalog.tsx
@@ -1,6 +1,7 @@
 import 'server-only';
-import { nextCatalogContext, nextKnowledgeContext, nextObserveContext } from '../http/next-context';
+import { nextCatalogContext, nextInboxContext, nextKnowledgeContext, nextObserveContext } from '../http/next-context';
 import type { CoreStudioCatalog } from '../view-models/core-runs';
+import type { InboxPage } from '../http/inbox-page';
 import type { KnowledgePage } from '../http/knowledge-page';
 import type { ObservePage } from '../http/observe-page';
 
@@ -17,4 +18,8 @@ export function requestObservePage(): ObservePage {
 
 export function requestKnowledgePage(): KnowledgePage {
   return nextKnowledgeContext.get();
+}
+
+export function requestInboxPage(): InboxPage {
+  return nextInboxContext.get();
 }

--- a/src/studio/web/components/inbox/inbox.tsx
+++ b/src/studio/web/components/inbox/inbox.tsx
@@ -1,0 +1,55 @@
+'use client';
+import { Empty, Tabs, Typography } from 'antd';
+import type { ObservationInboxViewModel } from '../../../../observability/inbox/view-model';
+import type { Language } from '../layout/shell';
+import { SignalSection } from './signals';
+
+const PENDING_TABS = [
+  { key: 'metrics', zh: '指标', en: 'Metrics' },
+  { key: 'experience', zh: '体验', en: 'Experience' },
+  { key: 'process', zh: '流程', en: 'Process' },
+  { key: 'review', zh: '复核', en: 'Review' },
+  { key: 'timeline', zh: '时间轴', en: 'Timeline' },
+  { key: 'chains', zh: 'Skill 链', en: 'Skill chains' },
+] as const;
+
+/**
+ * 观测收件箱 React 骨架（#839 批次 1）：信号子视图已迁移，
+ * 其余子视图占位，后续批次逐个替换并删除对应 HTML 渲染器。
+ * 页面在收口批次接通路由前不经生产入口可达。
+ */
+export function InboxView({ model, lang }: { model: ObservationInboxViewModel; lang: Language }) {
+  const zh = lang === 'zh';
+  return (
+    <>
+      <div>
+        <h1>{zh ? '观测收件箱' : 'Observation inbox'}</h1>
+        <Typography.Text type="secondary">
+          {zh
+            ? `${model.items.length} 条信号（共 ${model.allItems.length} 条）`
+            : `${model.items.length} signals (${model.allItems.length} total)`}
+        </Typography.Text>
+      </div>
+      <Tabs
+        items={[
+          {
+            key: 'signals',
+            label: zh ? '信号' : 'Signals',
+            children: <SignalSection items={model.items} lang={lang} />,
+          },
+          ...PENDING_TABS.map((tab) => ({
+            key: tab.key,
+            label: zh ? tab.zh : tab.en,
+            children: (
+              <Empty
+                description={zh
+                  ? '该子视图将在 #839 后续批次迁移。'
+                  : 'This section will be migrated in a later #839 batch.'}
+              />
+            ),
+          })),
+        ]}
+      />
+    </>
+  );
+}

--- a/src/studio/web/components/inbox/signals.tsx
+++ b/src/studio/web/components/inbox/signals.tsx
@@ -1,0 +1,119 @@
+'use client';
+import { Table, Tag, Tooltip, Typography } from 'antd';
+import type { ObservationInboxItem } from '../../../../observability/contracts/inbox';
+import {
+  signalEvidenceConclusion,
+  signalRuleDescription,
+  signalSeverityMeta,
+  signalSourceMeta,
+  type SignalSeverityTone,
+} from '../../../../observability/inbox/signal-semantics';
+import type { Language } from '../layout/shell';
+
+const SEVERITY_TAG_COLOR: Record<SignalSeverityTone, string> = {
+  error: 'error',
+  warning: 'warning',
+  info: 'processing',
+  neutral: 'default',
+};
+
+function evidenceQuote(item: ObservationInboxItem): string {
+  const evidence = item.evidence;
+  return evidence.query || evidence.path || evidence.assistantSnippet || evidence.outputSnippet || '';
+}
+
+export function SignalSection({ items, lang }: { items: ObservationInboxItem[]; lang: Language }) {
+  const zh = lang === 'zh';
+  return (
+    <Table
+      size="small"
+      rowKey="id"
+      dataSource={items}
+      pagination={{ pageSize: 20, showSizeChanger: false }}
+      scroll={{ x: 1100 }}
+      columns={[
+        {
+          title: 'Skill',
+          dataIndex: 'skillName',
+          render: (name: string, item) => (
+            <>
+              <Typography.Text strong>{name}</Typography.Text>
+              <br />
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>{item.artifactVersion}</Typography.Text>
+            </>
+          ),
+        },
+        {
+          title: zh ? '信号' : 'Signal',
+          dataIndex: 'signalType',
+          render: (type: string, item) => (
+            <>
+              <Typography.Text>{type}</Typography.Text>{' '}
+              <Tooltip title={signalRuleDescription(item, lang)}>
+                <Typography.Text type="secondary" aria-label={signalRuleDescription(item, lang)}>?</Typography.Text>
+              </Tooltip>
+              <br />
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>OMK subtype: {item.signalSubtype}</Typography.Text>
+            </>
+          ),
+        },
+        {
+          title: zh ? '严重度' : 'Severity',
+          dataIndex: 'severity',
+          render: (_: unknown, item) => {
+            const meta = signalSeverityMeta(item.severity, lang);
+            return (
+              <>
+                <Tag color={SEVERITY_TAG_COLOR[meta.tone]}>{meta.label}</Tag>
+                <br />
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>{meta.decision}</Typography.Text>
+              </>
+            );
+          },
+        },
+        {
+          title: zh ? '证据' : 'Evidence',
+          render: (_: unknown, item) => {
+            const quote = evidenceQuote(item);
+            return (
+              <div style={{ maxWidth: 360 }}>
+                <Typography.Text style={{ fontSize: 12 }}>{signalEvidenceConclusion(item, lang)}</Typography.Text>
+                {quote ? (
+                  <div>
+                    <Typography.Text code style={{ fontSize: 11 }} ellipsis={{ tooltip: quote }}>
+                      {quote.slice(0, 220)}
+                    </Typography.Text>
+                  </div>
+                ) : null}
+              </div>
+            );
+          },
+        },
+        {
+          title: zh ? '次数' : 'Count',
+          dataIndex: 'occurrences',
+          align: 'right',
+          render: (count: number) => (
+            <Tooltip title={zh ? '按 skill + cwd + signal + subtype + query/path 归一化去重后的聚合次数，不是样本量。' : 'Aggregated count after dedup by skill + cwd + signal + subtype + query/path; not a sample size.'}>
+              <Typography.Text strong>{count}</Typography.Text>
+            </Tooltip>
+          ),
+        },
+        {
+          title: zh ? '来源' : 'Source',
+          dataIndex: 'sourceKind',
+          render: (_: unknown, item) => {
+            const meta = signalSourceMeta(item.sourceKind);
+            return <Tag color={meta.tone === 'neutral' ? 'default' : meta.tone}>{meta.label}</Tag>;
+          },
+        },
+        {
+          title: zh ? '最近出现' : 'Last seen',
+          dataIndex: 'lastSeen',
+          sorter: (a, b) => a.lastSeen.localeCompare(b.lastSeen),
+          defaultSortOrder: 'descend',
+        },
+      ]}
+    />
+  );
+}

--- a/src/studio/web/next.config.mjs
+++ b/src/studio/web/next.config.mjs
@@ -3,4 +3,12 @@ export default {
   poweredByHeader: false,
   reactStrictMode: true,
   generateEtags: false,
+  webpack(config) {
+    // src/ 模块遵守 Node ESM 惯例（以 .js 后缀引用 .ts 源）；让 webpack 解析到 TS 源文件（#839）。
+    config.resolve.extensionAlias = {
+      ...(config.resolve.extensionAlias ?? {}),
+      '.js': ['.ts', '.tsx', '.js'],
+    };
+    return config;
+  },
 };

--- a/test/observability/inbox/signal-semantics.test.ts
+++ b/test/observability/inbox/signal-semantics.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  signalEvidenceConclusion,
+  signalRuleDescription,
+  signalSemanticEvidence,
+  signalSeverityMeta,
+  signalSourceMeta,
+} from '../../../src/observability/inbox/signal-semantics.js';
+import { baseItem } from './_helpers.js';
+
+describe('signal semantics (host-independent)', () => {
+  it('maps all severities to bilingual labels, decisions and tones', () => {
+    assert.deepEqual(signalSeverityMeta('high', 'zh'), {
+      label: '高风险/需关注',
+      decision: '优先看，可能要补 SKILL.md 或改 skill 说明',
+      tone: 'error',
+    });
+    assert.deepEqual(signalSeverityMeta('medium', 'en'), {
+      label: 'Low risk / sample-check',
+      decision: 'Usually no skill change; sample-check whether time is repeatedly wasted',
+      tone: 'warning',
+    });
+    assert.equal(signalSeverityMeta('low', 'zh').label, '不确定/低优先级');
+    assert.equal(signalSeverityMeta('low').tone, 'info');
+    assert.equal(signalSeverityMeta('noise', 'en').label, 'Noise / no skill change');
+    assert.equal(signalSeverityMeta('noise').tone, 'neutral');
+  });
+
+  it('concludes evidence per subtype in zh and en with tool fallback', () => {
+    const probe = baseItem({ signalSubtype: 'bash_probe', evidence: { tool: 'Bash', query: 'ls' } });
+    assert.equal(signalEvidenceConclusion(probe, 'zh'), 'skill 运行过程中，agent 调用了一条 Bash 命令。');
+    assert.equal(signalEvidenceConclusion(probe, 'en'), 'During the skill run, the agent invoked a Bash command.');
+
+    const limited = baseItem({ signalSubtype: 'tool_limit', evidence: { query: 'x' } });
+    assert.equal(signalEvidenceConclusion(limited, 'zh'), '工具 触发了文件太长、token 或超时限制。');
+    assert.equal(signalEvidenceConclusion(limited, 'en'), 'Tool hit a file-length, token or timeout limit.');
+
+    const denied = baseItem({ signalSubtype: 'permission_denied', evidence: { tool: 'Read', path: '/a' } });
+    assert.equal(signalEvidenceConclusion(denied, 'zh'), 'Read 被权限拒绝。');
+
+    const hardMiss = baseItem({ signalSubtype: 'hard_miss', evidence: { tool: 'Grep', query: 'q' } });
+    assert.equal(signalEvidenceConclusion(hardMiss, 'en'), 'Grep returned nothing useful, and no later success on the same topic was observed.');
+
+    const hedge = baseItem({ signalType: 'hedging', signalSubtype: 'llm_classified', evidence: {} });
+    assert.equal(signalEvidenceConclusion(hedge, 'zh'), '模型文本里出现了不确定表达。');
+    const marker = baseItem({ signalType: 'explicit_marker', signalSubtype: 'llm_classified', evidence: {} });
+    assert.equal(signalEvidenceConclusion(marker, 'en'), 'The model text contains an explicit marker.');
+  });
+
+  it('falls back to semantic evidence for unhandled subtype and signal type pairs', () => {
+    const item = baseItem({ signalType: 'failed_search', signalSubtype: 'llm_classified', evidence: { query: 'q' } });
+    assert.equal(signalEvidenceConclusion(item, 'zh'), signalSemanticEvidence(item, 'zh'));
+    assert.equal(signalSemanticEvidence(item, 'zh'), 'q');
+    const empty = baseItem({ signalType: 'failed_search', signalSubtype: 'llm_classified', evidence: {} });
+    assert.equal(signalSemanticEvidence(empty, 'zh'), '');
+  });
+
+  it('formats the rule description with label, identity, confidence and reason', () => {
+    const item = baseItem({ signalSubtype: 'hard_miss', confidence: 0.9 });
+    const zh = signalRuleDescription(item, 'zh');
+    assert.match(zh, /^高风险\/需关注: failed_search\/hard_miss, confidence=0\.90\. /);
+    assert.match(zh, /疑似知识缺口。$/);
+    const en = signalRuleDescription(item, 'en');
+    assert.match(en, /^High risk: failed_search\/hard_miss, confidence=0\.90\. /);
+  });
+
+  it('maps trace sources to stable labels and tones', () => {
+    assert.deepEqual(signalSourceMeta('dsh'), { label: 'DeepSeek Harness', tone: 'teal' });
+    assert.deepEqual(signalSourceMeta('openclaw'), { label: 'OpenClaw', tone: 'purple' });
+    assert.deepEqual(signalSourceMeta('codex'), { label: 'Codex', tone: 'geekblue' });
+    assert.deepEqual(signalSourceMeta('markdown_log'), { label: 'Markdown log', tone: 'green' });
+    assert.deepEqual(signalSourceMeta('claude'), { label: 'Claude', tone: 'blue' });
+  });
+});

--- a/test/studio/http/inbox-page.test.ts
+++ b/test/studio/http/inbox-page.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'vitest';
+import { loadInboxPage } from '../../../src/studio/http/inbox-page.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('studio inbox page bridge', () => {
+  it('returns the shared projection for an empty directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-page-'));
+    dirs.push(dir);
+    const page = loadInboxPage(dir, undefined);
+    assert.equal(page.pageKind, 'inbox');
+    assert.deepEqual(page.model.items, []);
+    assert.deepEqual(page.model.allItems, []);
+    assert.equal(page.model.skillCount, 0);
+    assert.equal(page.model.reportCount, 0);
+  });
+
+  it('passes the skill filter through to the projection', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omk-inbox-page-skill-'));
+    dirs.push(dir);
+    const page = loadInboxPage(dir, 'audit');
+    assert.equal(page.model.activeSkill, 'audit');
+  });
+});


### PR DESCRIPTION
关联 Issue #839（批次 1：信号子视图）。策略为用户确认的「骨架先行、收口批切路由」：React 页面建立但不接路由，生产入口仍走 HTML 版，收口批次统一切换并删除 HTML。

## 内容

- **信号语义收敛到数据层**：新建 observability/inbox/signal-semantics.ts（severity 元信息、证据结论、语义证据、规则描述、来源映射，全部双语）；severityReasonFor/CodeFor 从 index.ts 抽出为无 fs 依赖的 severity-reason.ts（React client bundle 不能引入 fs 链），index.js 再导出保持既有 import 路径。
- **HTML 版薄包装**：signal-renderer.ts 经 view-model facade 复用语义模块，渲染输出逐字不变（presentation 既有测试锁定全绿），迁移期不产生第二份业务语义。
- **数据桥接**：http/inbox-page.ts（loadInboxPage 复用 buildObservationInboxViewModel 共享投影）+ nextInboxContext + catalog.requestInboxPage，与 observe/knowledge 页同构。
- **React 骨架**：components/inbox/SignalSection（AntD Table：Skill、信号+规则 Tooltip、严重度 Tag、证据、聚合次数、来源、最近出现，双语）与 InboxView（信号 tab 完成，其余六子视图占位待后续批次）；app/observe/inbox/page.tsx 建立但不接路由，不经生产入口可达。
- **构建**：next.config 增加 resolve.extensionAlias，使 src 的 Node ESM .js 后缀引用可被 webpack 解析到 TS 源（本页是首个运行时 import src 模块进 bundle 的页面）。

## 验证

- yarn ci 全绿（lint + typecheck + build 含 Next build + docs + 368 文件 / 3931 用例）。
- 架构边界守门通过：presentation 经 view-model facade 访问语义模块（首次提交因直连被守门拦截，已改走 facade）。
- 新增：signal-semantics 5 用例（双语、severity 四档、subtype 分支、回落、来源映射）、inbox-page 2 用例（投影形状、skill 过滤透传）。

## 自主 CR

fresh-pass 复核（CODE_REVIEW.md）：HTML 输出不变性由 presentation 测试锁定；页面不接路由无用户面变化；extensionAlias 仅影响 web bundle 解析，Node 端不受影响；eval-core 未触碰；观测数据层仅模块拆分且再导出路径不变。No findings。

## 后续

批次 2：复核子视图（含 review-state 交互）；骨架占位随批次逐个替换。