### PR TITLE
feat(studio): 收件箱 Skill 观测看板与信号展开详情（#839 批次 2）

### DIFF
--- a/src/observability/inbox/skill-rollups.ts
+++ b/src/observability/inbox/skill-rollups.ts
@@ -1,0 +1,142 @@
+import { ownRecordValue } from '../../shared/record-count.js';
+import type { TraceSourceKind } from '../contracts/trace.js';
+import type { ObservationInboxItem } from '../contracts/inbox.js';
+import type { ObservationInboxViewModel } from './view-model.js';
+
+/**
+ * Skill 观测看板的聚合逻辑（宿主无关纯函数，#839 批次 2）。
+ * 从 presentation/observation-inbox/process-workspace-renderer 抽到数据层，
+ * HTML 渲染器与 React 页面共用同一份聚合与排序语义，避免第二份业务口径。
+ */
+
+export interface SkillRollupMetricCounts {
+  readonly bash: number;
+  readonly read: number;
+  readonly grep: number;
+  readonly uncertainty: number;
+  readonly explicitMarker: number;
+  readonly bashProbe: number;
+  readonly notFound: number;
+  readonly toolLimit: number;
+  readonly toolFailure: number;
+}
+
+export interface SkillRollupSeverityCounts {
+  readonly high: number;
+  readonly medium: number;
+  readonly low: number;
+  readonly noise: number;
+}
+
+export type SkillReviewTone = 'error' | 'warning' | 'neutral' | 'success';
+
+export interface ObservationSkillRollup {
+  readonly skillName: string;
+  readonly invocationCount: number;
+  readonly sessionCount: number;
+  readonly observationCount: number;
+  readonly counts: SkillRollupSeverityCounts;
+  readonly lastProblemSeen: string;
+  readonly lastUsed: string;
+  readonly sources: readonly TraceSourceKind[];
+  readonly metricCounts: SkillRollupMetricCounts;
+  readonly reviewLabel: string;
+  readonly reviewTone: SkillReviewTone;
+}
+
+type SkillRollupModel = Pick<
+  ObservationInboxViewModel,
+  'allItems' | 'skillInvocationCounts' | 'skillSessionCounts' | 'skillInvocationLastSeen' | 'skillToolCallCounts'
+>;
+
+export function timestampedOccurrences(item: ObservationInboxItem): number {
+  return item.timestampedOccurrences
+    ?? (item.firstSeen === '1970-01-01T00:00:00.000Z' ? 0 : item.occurrences);
+}
+
+const REVIEW_LABEL: Record<SkillReviewTone, { zh: string; en: string }> = {
+  error: { zh: '高风险', en: 'High risk' },
+  warning: { zh: '低风险', en: 'Low risk' },
+  neutral: { zh: '无异常', en: 'No issues' },
+  success: { zh: '无异常', en: 'No issues' },
+};
+
+export function skillReviewLabel(tone: SkillReviewTone, lang: 'zh' | 'en' = 'zh'): string {
+  return REVIEW_LABEL[tone][lang];
+}
+
+export function buildObservationSkillRollups(model: SkillRollupModel): ObservationSkillRollup[] {
+  const {
+    allItems,
+    skillInvocationCounts,
+    skillSessionCounts,
+    skillInvocationLastSeen,
+    skillToolCallCounts,
+  } = model;
+  const itemsBySkill = allItems.reduce((map, item) => {
+    const existing = map.get(item.skillName) ?? [];
+    existing.push(item);
+    map.set(item.skillName, existing);
+    return map;
+  }, new Map<string, ObservationInboxItem[]>());
+  const allSkillNames = Array.from(new Set([
+    ...Object.keys(skillInvocationCounts),
+    ...Array.from(itemsBySkill.keys()),
+  ]));
+  return allSkillNames.map((skillName) => {
+    const groupItems = itemsBySkill.get(skillName) ?? [];
+    const counts: SkillRollupSeverityCounts = {
+      high: groupItems.filter((item) => item.severity === 'high').length,
+      medium: groupItems.filter((item) => item.severity === 'medium').length,
+      low: groupItems.filter((item) => item.severity === 'low').length,
+      noise: groupItems.filter((item) => item.severity === 'noise').length,
+    };
+    const invocationCount = ownRecordValue(skillInvocationCounts, skillName)
+      ?? groupItems.reduce((sum, item) => sum + item.occurrences, 0);
+    const sessionCount = ownRecordValue(skillSessionCounts, skillName)
+      ?? new Set(groupItems.flatMap((item) => item.recentSessionIds)).size;
+    const lastProblemSeen = groupItems
+      .filter((item) => timestampedOccurrences(item) > 0)
+      .reduce((value, item) => item.lastSeen > value ? item.lastSeen : value, '');
+    const lastUsed = ownRecordValue(skillInvocationLastSeen, skillName) || lastProblemSeen || '';
+    const sources = Array.from(new Set(groupItems.map((item) => item.sourceKind))).sort();
+    const observationCount = groupItems.length;
+    const toolCounts = ownRecordValue(skillToolCallCounts, skillName) ?? {};
+    const metricCounts: SkillRollupMetricCounts = {
+      bash: toolCounts.Bash ?? 0,
+      read: toolCounts.Read ?? 0,
+      grep: toolCounts.Grep ?? 0,
+      uncertainty: groupItems.filter((item) => item.signalType === 'hedging').reduce((sum, item) => sum + item.occurrences, 0),
+      explicitMarker: groupItems.filter((item) => item.signalType === 'explicit_marker').reduce((sum, item) => sum + item.occurrences, 0),
+      bashProbe: groupItems.filter((item) => item.signalSubtype === 'bash_probe').reduce((sum, item) => sum + item.occurrences, 0),
+      notFound: groupItems.filter((item) => item.signalSubtype === 'not_found').reduce((sum, item) => sum + item.occurrences, 0),
+      toolLimit: groupItems.filter((item) => item.signalSubtype === 'tool_limit').reduce((sum, item) => sum + item.occurrences, 0),
+      toolFailure: groupItems.filter((item) => item.signalSubtype === 'tool_failure').reduce((sum, item) => sum + item.occurrences, 0),
+    };
+    const reviewTone: SkillReviewTone = counts.high > 0
+      ? 'error'
+      : counts.medium > 0
+        ? 'warning'
+        : counts.noise > 0
+          ? 'neutral'
+          : 'success';
+    return {
+      skillName,
+      invocationCount,
+      sessionCount,
+      observationCount,
+      counts,
+      lastProblemSeen,
+      lastUsed,
+      sources,
+      metricCounts,
+      reviewLabel: skillReviewLabel(reviewTone, 'zh'),
+      reviewTone,
+    };
+  }).sort((a, b) => {
+    const aRisk = a.counts.high * 100 + a.counts.medium * 10 + a.counts.noise;
+    const bRisk = b.counts.high * 100 + b.counts.medium * 10 + b.counts.noise;
+    if (bRisk !== aRisk) return bRisk - aRisk;
+    return b.invocationCount - a.invocationCount;
+  });
+}

--- a/src/observability/inbox/view-model.ts
+++ b/src/observability/inbox/view-model.ts
@@ -220,6 +220,17 @@ export {
 } from './signal-semantics.js';
 export type { SignalSeverityMeta, SignalSeverityTone, SignalSourceMeta } from './signal-semantics.js';
 export {
+  buildObservationSkillRollups,
+  skillReviewLabel,
+  timestampedOccurrences,
+} from './skill-rollups.js';
+export type {
+  ObservationSkillRollup,
+  SkillReviewTone,
+  SkillRollupMetricCounts,
+  SkillRollupSeverityCounts,
+} from './skill-rollups.js';
+export {
   observationMetricAnnotationEntry,
   observationMetricAnnotationTargetId,
 } from './review-state.js';

--- a/src/studio/presentation/observation-inbox/process-workspace-renderer.ts
+++ b/src/studio/presentation/observation-inbox/process-workspace-renderer.ts
@@ -6,6 +6,10 @@ import type {
   ObservationInboxItem,
   ObservationInboxViewModel,
 } from '../../../observability/inbox/view-model.js';
+import {
+  buildObservationSkillRollups,
+  type SkillReviewTone,
+} from '../../../observability/inbox/view-model.js';
 import { renderJson, skillAnchor } from './helpers.js';
 import type {
   IndicatorHelpKey,
@@ -40,7 +44,6 @@ export function createObservationProcessWorkspace({
     skillInvocationCounts,
     skillInvocationLastSeen,
     skillSessionCounts,
-    skillToolCallCounts,
     totalSkillInvocations,
   } = model;
   const { indicatorHelps, indicatorLabels, metric } = metricRenderers;
@@ -147,72 +150,13 @@ export function createObservationProcessWorkspace({
     map.set(item.skillName, existing);
     return map;
   }, new Map<string, ObservationInboxItem[]>());
-  const allSkillNames = Array.from(new Set([
-    ...Object.keys(skillInvocationCounts),
-    ...Array.from(itemsBySkill.keys()),
-  ]));
-  const skillRollups = allSkillNames.map((skillName) => {
-    const groupItems = itemsBySkill.get(skillName) ?? [];
-    const counts = {
-      high: groupItems.filter((item) => item.severity === 'high').length,
-      medium: groupItems.filter((item) => item.severity === 'medium').length,
-      low: groupItems.filter((item) => item.severity === 'low').length,
-      noise: groupItems.filter((item) => item.severity === 'noise').length,
-    };
-    const invocationCount = ownRecordValue(skillInvocationCounts, skillName) ?? groupItems.reduce((sum, item) => sum + item.occurrences, 0);
-    const sessionCount = ownRecordValue(skillSessionCounts, skillName) ?? new Set(groupItems.flatMap((item) => item.recentSessionIds)).size;
-    const lastProblemSeen = groupItems
-      .filter((item) => timestampedOccurrences(item) > 0)
-      .reduce((value, item) => item.lastSeen > value ? item.lastSeen : value, '');
-    const lastUsed = ownRecordValue(skillInvocationLastSeen, skillName) || lastProblemSeen || '';
-    const sources = Array.from(new Set(groupItems.map((item) => item.sourceKind))).sort();
-    const observationCount = groupItems.length;
-    const toolCounts = ownRecordValue(skillToolCallCounts, skillName) ?? {};
-    const metricCounts = {
-      bash: toolCounts.Bash ?? 0,
-      read: toolCounts.Read ?? 0,
-      grep: toolCounts.Grep ?? 0,
-      uncertainty: groupItems.filter((item) => item.signalType === 'hedging').reduce((sum, item) => sum + item.occurrences, 0),
-      explicitMarker: groupItems.filter((item) => item.signalType === 'explicit_marker').reduce((sum, item) => sum + item.occurrences, 0),
-      bashProbe: groupItems.filter((item) => item.signalSubtype === 'bash_probe').reduce((sum, item) => sum + item.occurrences, 0),
-      notFound: groupItems.filter((item) => item.signalSubtype === 'not_found').reduce((sum, item) => sum + item.occurrences, 0),
-      toolLimit: groupItems.filter((item) => item.signalSubtype === 'tool_limit').reduce((sum, item) => sum + item.occurrences, 0),
-      toolFailure: groupItems.filter((item) => item.signalSubtype === 'tool_failure').reduce((sum, item) => sum + item.occurrences, 0),
-    };
-    const actionableCount = counts.high;
-    const reviewLabel = actionableCount > 0
-      ? '高风险'
-      : counts.medium > 0
-        ? '低风险'
-        : counts.noise > 0
-          ? '无异常'
-          : '无异常';
-    const reviewColor = actionableCount > 0
-      ? 'var(--red)'
-      : counts.medium > 0
-        ? 'var(--yellow)'
-        : counts.noise > 0
-          ? 'var(--text-muted)'
-          : 'var(--green)';
-    return {
-      skillName,
-      invocationCount,
-      sessionCount,
-      observationCount,
-      counts,
-      lastProblemSeen,
-      lastUsed,
-      sources,
-      metricCounts,
-      reviewLabel,
-      reviewColor,
-    };
-  }).sort((a, b) => {
-    const aRisk = a.counts.high * 100 + a.counts.medium * 10 + a.counts.noise;
-    const bRisk = b.counts.high * 100 + b.counts.medium * 10 + b.counts.noise;
-    if (bRisk !== aRisk) return bRisk - aRisk;
-    return b.invocationCount - a.invocationCount;
-  });
+  const skillRollups = buildObservationSkillRollups(model);
+  const reviewToneColors: Record<SkillReviewTone, string> = {
+    error: 'var(--red)',
+    warning: 'var(--yellow)',
+    neutral: 'var(--text-muted)',
+    success: 'var(--green)',
+  };
   const skillRollupRows = skillRollups.map((row) => {
     const hasDetail = (itemsBySkill.get(row.skillName)?.length ?? 0) > 0;
     return `<tr data-observe-rollup-row data-skill-anchor="${e(skillAnchor(row.skillName))}" style="${hasDetail ? 'cursor:pointer' : ''}">
@@ -238,7 +182,7 @@ export function createObservationProcessWorkspace({
       <td style="padding:9px 10px;color:var(--text-muted);font-size:12px" title="${row.lastUsed ? '最近一次在 trace 中识别到 skill 调用的时间' : '当前 过程发现 report 中没有这个 skill 的调用时间信息；旧 report 需要重新 ingest 才会补齐'}">${row.lastUsed ? e(row.lastUsed.slice(0, 19).replace('T', ' ')) : '—'}</td>
       <td style="padding:9px 10px;color:var(--text-muted);font-size:12px">${row.sources.length > 0 ? e(row.sources.join(', ')) : '—'}</td>
       <td style="padding:9px 10px;text-align:right">
-        <span style="display:inline-flex;width:max-content;padding:3px 7px;border-radius:999px;background:var(--bg-muted);color:${row.reviewColor};font-size:12px;font-weight:650">${e(row.reviewLabel)}</span>
+        <span style="display:inline-flex;width:max-content;padding:3px 7px;border-radius:999px;background:var(--bg-muted);color:${reviewToneColors[row.reviewTone]};font-size:12px;font-weight:650">${e(row.reviewLabel)}</span>
       </td>
     </tr>`;
   }).join('');

--- a/src/studio/web/components/inbox/inbox.tsx
+++ b/src/studio/web/components/inbox/inbox.tsx
@@ -1,41 +1,70 @@
 'use client';
-import { Empty, Tabs, Typography } from 'antd';
+import { useState } from 'react';
+import { Button, Empty, Tabs, Typography } from 'antd';
 import type { ObservationInboxViewModel } from '../../../../observability/inbox/view-model';
 import type { Language } from '../layout/shell';
 import { SignalSection } from './signals';
+import { SkillBoard } from './skill-board';
 
 const PENDING_TABS = [
   { key: 'metrics', zh: '指标', en: 'Metrics' },
-  { key: 'experience', zh: '体验', en: 'Experience' },
-  { key: 'process', zh: '流程', en: 'Process' },
-  { key: 'review', zh: '复核', en: 'Review' },
+  { key: 'experience', zh: '体验复盘', en: 'Experience review' },
+  { key: 'action', zh: '复核待办', en: 'Review actions' },
   { key: 'timeline', zh: '时间轴', en: 'Timeline' },
   { key: 'chains', zh: 'Skill 链', en: 'Skill chains' },
 ] as const;
 
 /**
- * 观测收件箱 React 骨架（#839 批次 1）：信号子视图已迁移，
+ * 观测收件箱 React 骨架（#839 批次 2）：信号明细与 Skill 看板已迁移，
  * 其余子视图占位，后续批次逐个替换并删除对应 HTML 渲染器。
  * 页面在收口批次接通路由前不经生产入口可达。
  */
 export function InboxView({ model, lang }: { model: ObservationInboxViewModel; lang: Language }) {
   const zh = lang === 'zh';
+  const [activeTab, setActiveTab] = useState('signals');
+  const [skillFilter, setSkillFilter] = useState<string | undefined>(undefined);
+  const filteredItems = skillFilter ? model.items.filter((item) => item.skillName === skillFilter) : model.items;
   return (
     <>
       <div>
         <h1>{zh ? '观测收件箱' : 'Observation inbox'}</h1>
         <Typography.Text type="secondary">
           {zh
-            ? `${model.items.length} 条信号（共 ${model.allItems.length} 条）`
-            : `${model.items.length} signals (${model.allItems.length} total)`}
+            ? `${filteredItems.length} 条信号（共 ${model.allItems.length} 条）`
+            : `${filteredItems.length} signals (${model.allItems.length} total)`}
         </Typography.Text>
       </div>
       <Tabs
+        activeKey={activeTab}
+        onChange={setActiveTab}
         items={[
           {
             key: 'signals',
             label: zh ? '信号' : 'Signals',
-            children: <SignalSection items={model.items} lang={lang} />,
+            children: (
+              <>
+                {skillFilter ? (
+                  <Button size="small" onClick={() => setSkillFilter(undefined)} style={{ marginBottom: 8 }}>
+                    {zh ? `清除筛选：${skillFilter}` : `Clear filter: ${skillFilter}`}
+                  </Button>
+                ) : null}
+                <SignalSection items={filteredItems} lang={lang} />
+              </>
+            ),
+          },
+          {
+            key: 'skill-board',
+            label: zh ? 'Skill 看板' : 'Skill board',
+            children: (
+              <SkillBoard
+                model={model}
+                lang={lang}
+                onSelectSkill={(skillName) => {
+                  setSkillFilter(skillName);
+                  setActiveTab('signals');
+                }}
+              />
+            ),
           },
           ...PENDING_TABS.map((tab) => ({
             key: tab.key,

--- a/src/studio/web/components/inbox/signals.tsx
+++ b/src/studio/web/components/inbox/signals.tsx
@@ -22,6 +22,46 @@ function evidenceQuote(item: ObservationInboxItem): string {
   return evidence.query || evidence.path || evidence.assistantSnippet || evidence.outputSnippet || '';
 }
 
+function SignalDetail({ item, lang }: { item: ObservationInboxItem; lang: Language }) {
+  const zh = lang === 'zh';
+  const entries = item.representativeEvidence.length > 0 ? item.representativeEvidence : [item.evidence];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+        {zh
+          ? '这里展示这条聚合记录下面的原始明细，每一条都是一次真实命中的证据。'
+          : 'Raw evidence entries behind this aggregated record; each is a real observed hit.'}
+      </Typography.Text>
+      {entries.map((evidence, index) => {
+        const quote = evidence.query || evidence.path || evidence.assistantSnippet || '';
+        const output = evidence.outputSnippet && evidence.outputSnippet !== quote ? evidence.outputSnippet : '';
+        return (
+          <div key={index} style={{ border: '1px solid var(--border, #e5e7eb)', borderRadius: 6, padding: '9px 10px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, marginBottom: 5 }}>
+              <Typography.Text strong style={{ fontSize: 12 }}>Evidence {index + 1}</Typography.Text>
+              <Typography.Text type="secondary" code style={{ fontSize: 11 }}>
+                {evidence.tool || item.signalType}{evidence.markerToken ? ` · ${evidence.markerToken}` : ''}
+              </Typography.Text>
+            </div>
+            <Typography.Paragraph style={{ fontSize: 12, marginBottom: 5 }}>
+              {signalEvidenceConclusion({ ...item, evidence }, lang)}
+            </Typography.Paragraph>
+            {quote ? (
+              <pre style={{ margin: 0, padding: 8, borderRadius: 5, whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: 11, maxHeight: 180, overflow: 'auto' }}>{quote}</pre>
+            ) : null}
+            {output ? (
+              <>
+                <Typography.Text type="secondary" style={{ fontSize: 11 }}>{zh ? '输出片段' : 'Output snippet'}</Typography.Text>
+                <pre style={{ margin: '3px 0 0', padding: 8, borderRadius: 5, whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: 11, maxHeight: 140, overflow: 'auto' }}>{output}</pre>
+              </>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 export function SignalSection({ items, lang }: { items: ObservationInboxItem[]; lang: Language }) {
   const zh = lang === 'zh';
   return (
@@ -31,6 +71,10 @@ export function SignalSection({ items, lang }: { items: ObservationInboxItem[]; 
       dataSource={items}
       pagination={{ pageSize: 20, showSizeChanger: false }}
       scroll={{ x: 1100 }}
+      expandable={{
+        expandedRowRender: (item) => <SignalDetail item={item} lang={lang} />,
+        rowExpandable: (item) => (item.representativeEvidence.length > 0 ? item.representativeEvidence : [item.evidence]).length > 0,
+      }}
       columns={[
         {
           title: 'Skill',

--- a/src/studio/web/components/inbox/skill-board.tsx
+++ b/src/studio/web/components/inbox/skill-board.tsx
@@ -1,0 +1,117 @@
+'use client';
+import { useMemo } from 'react';
+import { Table, Tag, Tooltip, Typography } from 'antd';
+import {
+  buildObservationSkillRollups,
+  skillReviewLabel,
+  type ObservationSkillRollup,
+  type SkillReviewTone,
+} from '../../../../observability/inbox/skill-rollups';
+import type { ObservationInboxViewModel } from '../../../../observability/inbox/view-model';
+import type { Language } from '../layout/shell';
+
+const REVIEW_TAG_COLOR: Record<SkillReviewTone, string> = {
+  error: 'error',
+  warning: 'warning',
+  neutral: 'default',
+  success: 'success',
+};
+
+const METRIC_LABELS: Record<keyof ObservationSkillRollup['metricCounts'], { zh: string; en: string }> = {
+  bash: { zh: 'Bash调用', en: 'Bash calls' },
+  read: { zh: 'Read', en: 'Read' },
+  grep: { zh: 'Grep', en: 'Grep' },
+  uncertainty: { zh: '回答不确定', en: 'Uncertain' },
+  explicitMarker: { zh: '明确说缺口', en: 'Explicit gap' },
+  bashProbe: { zh: 'Bash试探', en: 'Bash probes' },
+  notFound: { zh: '路径不存在', en: 'Path missing' },
+  toolLimit: { zh: '工具限制', en: 'Tool limits' },
+  toolFailure: { zh: '工具执行失败', en: 'Tool failures' },
+};
+
+function formatTimestamp(value: string): string {
+  return value ? value.slice(0, 19).replace('T', ' ') : '—';
+}
+
+export function SkillBoard({
+  model,
+  lang,
+  onSelectSkill,
+}: {
+  model: ObservationInboxViewModel;
+  lang: Language;
+  onSelectSkill?: (skillName: string) => void;
+}) {
+  const zh = lang === 'zh';
+  const rollups = useMemo(() => buildObservationSkillRollups(model), [model]);
+  return (
+    <Table
+      size="small"
+      rowKey="skillName"
+      dataSource={rollups}
+      pagination={{ pageSize: 20, showSizeChanger: false }}
+      scroll={{ x: 1280 }}
+      onRow={(row) => ({
+        onClick: () => row.observationCount > 0 && onSelectSkill?.(row.skillName),
+        style: { cursor: row.observationCount > 0 && onSelectSkill ? 'pointer' : 'default' },
+      })}
+      columns={[
+        {
+          title: 'Skill',
+          dataIndex: 'skillName',
+          render: (name: string) => <Typography.Text strong code>{name}</Typography.Text>,
+        },
+        { title: zh ? '调用' : 'Calls', dataIndex: 'invocationCount', align: 'right' },
+        { title: 'Session', dataIndex: 'sessionCount', align: 'right' },
+        { title: zh ? '过程发现' : 'Findings', dataIndex: 'observationCount', align: 'right' },
+        {
+          title: zh ? '子项指标' : 'Metrics',
+          render: (_: unknown, row) => (
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              {(Object.keys(METRIC_LABELS) as Array<keyof ObservationSkillRollup['metricCounts']>)
+                .map((key) => `${zh ? METRIC_LABELS[key].zh : METRIC_LABELS[key].en} ${row.metricCounts[key]}`)
+                .join(' · ')}
+            </Typography.Text>
+          ),
+        },
+        { title: zh ? '高风险' : 'High', dataIndex: ['counts', 'high'], align: 'right' },
+        {
+          title: zh ? '低风险' : 'Low',
+          align: 'right',
+          render: (_: unknown, row) => row.counts.medium + row.counts.low,
+        },
+        { title: zh ? '路径/工具' : 'Path/tool', dataIndex: ['counts', 'noise'], align: 'right' },
+        {
+          title: zh ? '最近发现问题' : 'Last finding',
+          dataIndex: 'lastProblemSeen',
+          render: (value: string) => (
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>{formatTimestamp(value)}</Typography.Text>
+          ),
+        },
+        {
+          title: zh ? '最近使用' : 'Last used',
+          dataIndex: 'lastUsed',
+          render: (value: string) => (
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>{formatTimestamp(value)}</Typography.Text>
+          ),
+        },
+        {
+          title: zh ? '来源' : 'Source',
+          dataIndex: 'sources',
+          render: (sources: readonly string[]) => (
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>{sources.length > 0 ? sources.join(', ') : '—'}</Typography.Text>
+          ),
+        },
+        {
+          title: 'Review',
+          align: 'right',
+          render: (_: unknown, row) => (
+            <Tooltip title={zh ? '按过程发现的最高严重度给出复盘优先级' : 'Review priority from the highest observation severity'}>
+              <Tag color={REVIEW_TAG_COLOR[row.reviewTone]}>{skillReviewLabel(row.reviewTone, lang)}</Tag>
+            </Tooltip>
+          ),
+        },
+      ]}
+    />
+  );
+}

--- a/test/observability/inbox/skill-rollups.test.ts
+++ b/test/observability/inbox/skill-rollups.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  buildObservationSkillRollups,
+  skillReviewLabel,
+  timestampedOccurrences,
+} from '../../../src/observability/inbox/skill-rollups.js';
+import { baseItem } from './_helpers.js';
+
+function model(overrides: Partial<Parameters<typeof buildObservationSkillRollups>[0]>) {
+  return {
+    allItems: [],
+    skillInvocationCounts: {},
+    skillSessionCounts: {},
+    skillInvocationLastSeen: {},
+    skillToolCallCounts: {},
+    ...overrides,
+  };
+}
+
+describe('skill rollups (host-independent)', () => {
+  it('aggregates counts, metrics and review tone per skill, sorted by risk', () => {
+    const rollups = buildObservationSkillRollups(model({
+      allItems: [
+        baseItem({ id: 'a1', skillName: 'alpha', severity: 'high', occurrences: 2 }),
+        baseItem({ id: 'a2', skillName: 'alpha', severity: 'medium', signalSubtype: 'bash_probe' }),
+        baseItem({ id: 'b1', skillName: 'beta', severity: 'noise' }),
+      ],
+      skillInvocationCounts: { alpha: 7 },
+      skillSessionCounts: { alpha: 3 },
+      skillToolCallCounts: { alpha: { Bash: 4, Read: 2 } },
+    }));
+    assert.equal(rollups.length, 2);
+    const [alpha, beta] = rollups;
+    assert.equal(alpha.skillName, 'alpha');
+    assert.deepEqual(alpha.counts, { high: 1, medium: 1, low: 0, noise: 0 });
+    assert.equal(alpha.invocationCount, 7);
+    assert.equal(alpha.sessionCount, 3);
+    assert.equal(alpha.metricCounts.bash, 4);
+    assert.equal(alpha.metricCounts.read, 2);
+    assert.equal(alpha.metricCounts.bashProbe, 1);
+    assert.equal(alpha.reviewTone, 'error');
+    assert.equal(alpha.reviewLabel, '高风险');
+    assert.equal(beta.skillName, 'beta');
+    assert.equal(beta.reviewTone, 'neutral');
+  });
+
+  it('falls back to observation-derived invocation and session counts', () => {
+    const [rollup] = buildObservationSkillRollups(model({
+      allItems: [
+        baseItem({ id: 'a1', skillName: 'alpha', occurrences: 3, recentSessionIds: ['s1', 's2'] }),
+        baseItem({ id: 'a2', skillName: 'alpha', occurrences: 2, recentSessionIds: ['s2', 's3'] }),
+      ],
+    }));
+    assert.equal(rollup.invocationCount, 5);
+    assert.equal(rollup.sessionCount, 3);
+  });
+
+  it('labels tones bilingually', () => {
+    assert.equal(skillReviewLabel('warning', 'zh'), '低风险');
+    assert.equal(skillReviewLabel('warning', 'en'), 'Low risk');
+    assert.equal(skillReviewLabel('success', 'en'), 'No issues');
+    assert.equal(skillReviewLabel('error', 'en'), 'High risk');
+  });
+
+  it('counts only timestamped occurrences, treating the epoch sentinel as untimed', () => {
+    const timed = { ...baseItem({}), timestampedOccurrences: 4 };
+    assert.equal(timestampedOccurrences(timed), 4);
+    const epoch = baseItem({ firstSeen: '1970-01-01T00:00:00.000Z', occurrences: 6 });
+    assert.equal(timestampedOccurrences(epoch), 0);
+    const plain = baseItem({ firstSeen: '2026-05-01T00:00:00.000Z', occurrences: 6 });
+    assert.equal(timestampedOccurrences(plain), 6);
+  });
+});


### PR DESCRIPTION
关联 Issue #839（批次 2，纯展示）。沿用批次 1 起「骨架先行、收口批切路由」策略。

## 批次边界修正

盘点源码后发现 issue 原按渲染器文件的子视图划分与页面实际耦合不符：复核 mutation 按钮实际挂载在 V1 复盘区（experience_session）与时间轴，而非 Skill 看板——看板的 Review 列是静态风险徽章。故本批次为纯展示迁移，复核交互归入其真实归属的后续批次（V1 复盘区）。

## 内容

- **聚合逻辑收敛到数据层**：新建 observability/inbox/skill-rollups.ts，Skill 看板的聚合（severity 计数、子项指标、风险排序、Review 徽章双语语义）与 timestampedOccurrences 从 presentation 抽出；view-model facade 再导出。
- **HTML 版薄包装**：process-workspace-renderer 的 skillRollups 组装段改为调用共享模块，渲染输出不变（presentation 测试锁定全绿）。
- **React 组件**：SkillBoard（AntD Table 12 列：Skill、调用、Session、过程发现、子项指标、高/低风险、路径/工具、最近发现、最近使用、来源、Review 徽章），行点击钻取信号 tab 并按 skill 过滤；SignalSection 增加展开行（Evidence 明细列表，复用 signalEvidenceConclusion 语义）。
- **InboxView**：接入 Skill 看板 tab 与 skill 筛选联动（含清除筛选），占位 tab 收敛为指标/体验复盘/复核待办/时间轴/Skill 链。

## 验证

- yarn ci 全绿（lint + typecheck + build 含 Next build + docs + 全量测试）。
- 新增 skill-rollups 4 用例（聚合计数、occurrences/session 兜底、双语徽章、时间戳哨兵）。
- 架构边界守门通过（web 组件直连纯模块，presentation 经 facade）。

## 自主 CR

fresh-pass 复核（CODE_REVIEW.md）：聚合逻辑逐行对齐原实现（排序键 high*100+medium*10+noise、invocation/session 兜底链一致）；HTML 输出不变性由 presentation 测试锁定；无生产路由变化（页面仍未接路由）；lint 清理了抽离后未使用的解构字段。No findings。