### PR TITLE
feat(studio): 收件箱 V1 复盘概要与复核交互（#839 批次 3）

### DIFF
--- a/src/observability/inbox/review-semantics.ts
+++ b/src/observability/inbox/review-semantics.ts
@@ -1,0 +1,78 @@
+import type { ExperienceReviewPriority } from '../contracts/experience.js';
+import type { ObservationReviewVerdict } from '../contracts/review.js';
+
+/**
+ * 观测收件箱复核语义的展示元信息（宿主无关纯函数，#839 批次 3）。
+ * HTML 渲染器与 React 页面共用同一份优先级与判定文案；样式归呈现层。
+ */
+
+export type ReviewPriorityTone = 'error' | 'warning' | 'neutral';
+
+export function reviewPriorityMeta(
+  priority: ExperienceReviewPriority,
+  lang: 'zh' | 'en' = 'zh',
+): { label: string; tone: ReviewPriorityTone } {
+  if (priority === 'review_first') {
+    return { label: lang === 'en' ? 'Review first' : '建议优先复盘', tone: 'error' };
+  }
+  if (priority === 'sample_review') {
+    return { label: lang === 'en' ? 'Sample review' : '值得抽样复盘', tone: 'warning' };
+  }
+  return { label: lang === 'en' ? 'Routine sample' : '常规抽样', tone: 'neutral' };
+}
+
+/** 复核判定当前态徽章文案（与历史 HTML 客户端脚本标签一致）。 */
+export function reviewVerdictBadge(
+  verdict: ObservationReviewVerdict,
+  lang: 'zh' | 'en' = 'zh',
+): { label: string; color: string } {
+  switch (verdict) {
+    case 'real_issue':
+      return { label: lang === 'en' ? 'Confirmed' : '已同意', color: 'success' };
+    case 'not_issue':
+      return { label: lang === 'en' ? 'Rejected' : '已否决', color: 'error' };
+    case 'needs_more_context':
+      return { label: lang === 'en' ? 'Noted' : '已留意见', color: 'warning' };
+    case 'reviewed':
+      return { label: lang === 'en' ? 'Reviewed' : '已看过', color: 'processing' };
+    case 'confirmed':
+      return { label: lang === 'en' ? 'Confirmed' : '已确认', color: 'success' };
+    case 'rejected':
+      return { label: lang === 'en' ? 'Rejected' : '已否决', color: 'error' };
+    default:
+      return { label: String(verdict), color: 'default' };
+  }
+}
+
+/** 复核状态条目的 key（与 review-state.ts 的持久化 key 同构；独立为纯函数供 client bundle 使用）。 */
+export function reviewStateKey(targetType: string, targetId: string): string {
+  return `${targetType}:${targetId}`;
+}
+
+/** 复核操作按钮文案。 */
+export function reviewActionLabels(lang: 'zh' | 'en' = 'zh'): {
+  confirm: string;
+  reject: string;
+  note: string;
+  saveNote: string;
+  cancelNote: string;
+  notePlaceholder: string;
+} {
+  return lang === 'en'
+    ? {
+        confirm: 'Confirm',
+        reject: 'Reject',
+        note: 'Note',
+        saveNote: 'Save note',
+        cancelNote: 'Cancel',
+        notePlaceholder: 'Add context or rationale for this session…',
+      }
+    : {
+        confirm: '同意',
+        reject: '否决',
+        note: '留意见',
+        saveNote: '保存意见',
+        cancelNote: '取消',
+        notePlaceholder: '补充这个 session 的上下文或理由…',
+      };
+}

--- a/src/observability/inbox/view-model.ts
+++ b/src/observability/inbox/view-model.ts
@@ -231,6 +231,13 @@ export type {
   SkillRollupSeverityCounts,
 } from './skill-rollups.js';
 export {
+  reviewActionLabels,
+  reviewPriorityMeta,
+  reviewStateKey,
+  reviewVerdictBadge,
+} from './review-semantics.js';
+export type { ReviewPriorityTone } from './review-semantics.js';
+export {
   observationMetricAnnotationEntry,
   observationMetricAnnotationTargetId,
 } from './review-state.js';

--- a/src/studio/web/components/inbox/experience-review.tsx
+++ b/src/studio/web/components/inbox/experience-review.tsx
@@ -1,0 +1,82 @@
+'use client';
+import { useMemo } from 'react';
+import { Empty, List, Space, Tag, Typography } from 'antd';
+import type { ExperienceSessionSummary } from '../../../../observability/contracts/experience';
+import type { ObservationReviewState } from '../../../../observability/contracts/review';
+import {
+  reviewPriorityMeta,
+  reviewStateKey,
+} from '../../../../observability/inbox/review-semantics';
+import type { Language } from '../layout/shell';
+import { SessionReviewActions } from './review-actions';
+
+const PRIORITY_RANK: Record<string, number> = { review_first: 0, sample_review: 1 };
+
+function formatRange(start?: string, end?: string): string {
+  const fmt = (value?: string) => (value ? value.slice(0, 19).replace('T', ' ') : '');
+  const startLabel = fmt(start);
+  const endLabel = fmt(end);
+  if (!startLabel && !endLabel) return '—';
+  return `${startLabel} → ${endLabel}`;
+}
+
+/**
+ * V1 经验会话复盘概要列表（#839 批次 3）：skill、复盘优先级、会话摘要、
+ * 时间范围与复核操作组。证据链、规则发现与时间轴明细随后续批次迁移。
+ */
+export function ExperienceReviewSection({
+  sessions,
+  reviewState,
+  lang,
+}: {
+  sessions: readonly ExperienceSessionSummary[];
+  reviewState: ObservationReviewState;
+  lang: Language;
+}) {
+  const zh = lang === 'zh';
+  const sorted = useMemo(() => [...sessions].sort((a, b) => {
+    const rankDelta = (PRIORITY_RANK[a.reviewPriority] ?? 2) - (PRIORITY_RANK[b.reviewPriority] ?? 2);
+    if (rankDelta !== 0) return rankDelta;
+    return b.endTimestamp.localeCompare(a.endTimestamp);
+  }), [sessions]);
+  if (sorted.length === 0) {
+    return <Empty description={zh ? '暂无经验会话复盘记录。' : 'No experience review sessions yet.'} />;
+  }
+  return (
+    <List
+      dataSource={sorted}
+      rowKey={(session) => session.id}
+      renderItem={(session) => {
+        const priority = reviewPriorityMeta(session.reviewPriority, lang);
+        const entry = reviewState.entries[reviewStateKey('experience_session', session.id)];
+        return (
+          <List.Item>
+            <div style={{ width: '100%' }}>
+              <Space size={8} wrap style={{ marginBottom: 4 }}>
+                <Typography.Text strong code>{session.skillName}</Typography.Text>
+                <Tag color={priority.tone}>{priority.label}</Tag>
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  {formatRange(session.startTimestamp, session.endTimestamp)}
+                </Typography.Text>
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  {session.sourceKind}
+                </Typography.Text>
+              </Space>
+              {session.sessionStory?.summary ? (
+                <Typography.Paragraph style={{ fontSize: 13, marginBottom: 8 }}>
+                  {session.sessionStory.summary}
+                </Typography.Paragraph>
+              ) : null}
+              <SessionReviewActions
+                sessionId={session.id}
+                verdict={entry?.verdict}
+                reason={entry?.reason}
+                lang={lang}
+              />
+            </div>
+          </List.Item>
+        );
+      }}
+    />
+  );
+}

--- a/src/studio/web/components/inbox/inbox.tsx
+++ b/src/studio/web/components/inbox/inbox.tsx
@@ -5,10 +5,10 @@ import type { ObservationInboxViewModel } from '../../../../observability/inbox/
 import type { Language } from '../layout/shell';
 import { SignalSection } from './signals';
 import { SkillBoard } from './skill-board';
+import { ExperienceReviewSection } from './experience-review';
 
 const PENDING_TABS = [
   { key: 'metrics', zh: '指标', en: 'Metrics' },
-  { key: 'experience', zh: '体验复盘', en: 'Experience review' },
   { key: 'action', zh: '复核待办', en: 'Review actions' },
   { key: 'timeline', zh: '时间轴', en: 'Timeline' },
   { key: 'chains', zh: 'Skill 链', en: 'Skill chains' },
@@ -63,6 +63,17 @@ export function InboxView({ model, lang }: { model: ObservationInboxViewModel; l
                   setSkillFilter(skillName);
                   setActiveTab('signals');
                 }}
+              />
+            ),
+          },
+          {
+            key: 'experience',
+            label: zh ? '体验复盘' : 'Experience review',
+            children: (
+              <ExperienceReviewSection
+                sessions={model.experienceReports.flatMap((report) => report.sessions)}
+                reviewState={model.reviewState}
+                lang={lang}
               />
             ),
           },

--- a/src/studio/web/components/inbox/review-actions.tsx
+++ b/src/studio/web/components/inbox/review-actions.tsx
@@ -1,0 +1,95 @@
+'use client';
+import { useState } from 'react';
+import { Button, Input, message, Space, Tag, Typography } from 'antd';
+import type { ObservationReviewVerdict } from '../../../../observability/contracts/review';
+import { reviewActionLabels, reviewVerdictBadge } from '../../../../observability/inbox/review-semantics';
+import type { Language } from '../layout/shell';
+
+const REVIEW_ENDPOINT = '/api/observe-inbox/review-state';
+
+/**
+ * 经验会话复核操作组（#839 批次 3）：同意/否决/留意见三按钮，
+ * 提交 /api/observe-inbox/review-state，成功后才更新本地状态（与历史 HTML 版一致）。
+ */
+export function SessionReviewActions({
+  sessionId,
+  verdict,
+  reason,
+  lang,
+}: {
+  sessionId: string;
+  verdict?: ObservationReviewVerdict;
+  reason?: string;
+  lang: Language;
+}) {
+  const zh = lang === 'zh';
+  const labels = reviewActionLabels(lang);
+  const [current, setCurrent] = useState<ObservationReviewVerdict | undefined>(verdict);
+  const [currentReason, setCurrentReason] = useState<string | undefined>(reason);
+  const [noteOpen, setNoteOpen] = useState(false);
+  const [noteText, setNoteText] = useState(reason ?? '');
+  const [pending, setPending] = useState(false);
+
+  async function submit(next: 'real_issue' | 'not_issue' | 'needs_more_context', note?: string) {
+    setPending(true);
+    try {
+      const response = await fetch(REVIEW_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          targetType: 'experience_session',
+          targetId: sessionId,
+          verdict: next,
+          ...(note ? { reason: note } : {}),
+        }),
+      });
+      if (!response.ok) throw new Error(String(response.status));
+      setCurrent(next);
+      setCurrentReason(note);
+      setNoteOpen(false);
+    } catch {
+      message.error(zh ? '复核保存失败，请重试。' : 'Failed to save the review; please retry.');
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const buttonType = (value: ObservationReviewVerdict) => (current === value ? 'primary' : 'default');
+  return (
+    <Space direction="vertical" size={4} style={{ alignItems: 'flex-start' }}>
+      <Space size={4} wrap>
+        <Button size="small" type={buttonType('real_issue')} loading={pending} onClick={() => void submit('real_issue')}>
+          {labels.confirm}
+        </Button>
+        <Button size="small" type={buttonType('not_issue')} danger={current === 'not_issue'} loading={pending} onClick={() => void submit('not_issue')}>
+          {labels.reject}
+        </Button>
+        <Button size="small" type={buttonType('needs_more_context')} loading={pending} onClick={() => setNoteOpen((open) => !open)}>
+          {labels.note}
+        </Button>
+        {current ? (
+          <Tag color={reviewVerdictBadge(current, lang).color} style={{ marginInlineStart: 4 }}>
+            {reviewVerdictBadge(current, lang).label}
+          </Tag>
+        ) : null}
+      </Space>
+      {noteOpen ? (
+        <Space.Compact style={{ width: 360 }}>
+          <Input.TextArea
+            rows={2}
+            value={noteText}
+            placeholder={labels.notePlaceholder}
+            onChange={(event) => setNoteText(event.target.value)}
+          />
+          <Button size="small" type="primary" loading={pending} onClick={() => void submit('needs_more_context', noteText.trim() || undefined)}>
+            {labels.saveNote}
+          </Button>
+          <Button size="small" onClick={() => setNoteOpen(false)}>{labels.cancelNote}</Button>
+        </Space.Compact>
+      ) : null}
+      {currentReason ? (
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>{currentReason}</Typography.Text>
+      ) : null}
+    </Space>
+  );
+}

--- a/test/observability/inbox/review-semantics.test.ts
+++ b/test/observability/inbox/review-semantics.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  reviewActionLabels,
+  reviewPriorityMeta,
+  reviewStateKey,
+  reviewVerdictBadge,
+} from '../../../src/observability/inbox/review-semantics.js';
+
+describe('review semantics (host-independent)', () => {
+  it('maps review priorities to bilingual labels and tones', () => {
+    assert.deepEqual(reviewPriorityMeta('review_first', 'zh'), { label: '建议优先复盘', tone: 'error' });
+    assert.deepEqual(reviewPriorityMeta('sample_review', 'en'), { label: 'Sample review', tone: 'warning' });
+    assert.deepEqual(reviewPriorityMeta('routine' as never, 'zh'), { label: '常规抽样', tone: 'neutral' });
+  });
+
+  it('maps verdicts to stable bilingual badges', () => {
+    assert.deepEqual(reviewVerdictBadge('real_issue', 'zh'), { label: '已同意', color: 'success' });
+    assert.deepEqual(reviewVerdictBadge('not_issue', 'en'), { label: 'Rejected', color: 'error' });
+    assert.deepEqual(reviewVerdictBadge('needs_more_context', 'zh'), { label: '已留意见', color: 'warning' });
+    assert.deepEqual(reviewVerdictBadge('needs_more_context', 'en'), { label: 'Noted', color: 'warning' });
+    assert.deepEqual(reviewVerdictBadge('reviewed', 'zh'), { label: '已看过', color: 'processing' });
+  });
+
+  it('provides bilingual action labels', () => {
+    assert.equal(reviewActionLabels('zh').confirm, '同意');
+    assert.equal(reviewActionLabels('en').confirm, 'Confirm');
+    assert.equal(reviewActionLabels('zh').note, '留意见');
+    assert.equal(reviewActionLabels('en').saveNote, 'Save note');
+  });
+
+  it('builds review state keys identical to the persisted shape', () => {
+    assert.equal(reviewStateKey('experience_session', 's1'), 'experience_session:s1');
+    assert.equal(reviewStateKey('skill', 'audit'), 'skill:audit');
+  });
+});


### PR DESCRIPTION
关联 Issue #839（批次 3）。本批次落地 issue 验收要点「复核提交在 React 版可用」——复核 mutation 的真实归属是 V1 经验会话（experience_session），见批次 2 PR #854 的边界修正。

## 内容

- **observability/inbox/review-semantics.ts（新）**：复盘优先级徽章（建议优先复盘/值得抽样复盘/常规抽样）、verdict 当前态徽章（已同意/已否决/已留意见/已看过，与历史客户端脚本逐字一致）、操作按钮文案、reviewStateKey（与持久化 key 同构）。双语纯函数；view-model facade 再导出。
- **SessionReviewActions**：同意/否决/留意见三按钮（覆盖式，与 HTML 版 setInboxSessionReview 语义一致）+ 留意见 note 编辑器（reason 随 POST 提交）+ 成功后才更新本地态 + 失败 message.error 提示可重试。POST /api/observe-inbox/review-state（默认宿主提供，批次 0 裁剪不影响）。
- **ExperienceReviewSection**：V1 会话概要列表——skill、复盘优先级徽章、sessionStory.summary、时间范围、复核操作组；按优先级（review_first 优先）与最近时间排序。
- **InboxView**：接入体验复盘 tab，占位收敛为指标/复核待办/时间轴/Skill 链。

## 验证

- yarn ci 全绿（lint + typecheck + Next build + docs + 全量测试）。
- 新增 review-semantics 4 用例（双语徽章/优先级/按钮文案/key 同构）。
- 架构边界守门通过（web 组件直连纯模块，fs 侧在服务端）。

## 自主 CR

fresh-pass 复核：mutation 契约与 request-errors 的 ObservationReviewStateValidationError 投影一致（非法 body 400 invalid_review_state）；复核按钮覆盖式语义与 HTML 版逐字对齐；无生产路由变化（页面仍未接路由）。No findings。

## 后续

批次 4：指标子视图；批次 5：时间轴 + Skill 链；收口：切路由 + 删 HTML。