### PR TITLE
feat(studio): 收件箱时间轴、Skill 链与复核待办（#839 批次 5）

### DIFF
--- a/src/observability/inbox/skill-rollups.ts
+++ b/src/observability/inbox/skill-rollups.ts
@@ -2,6 +2,7 @@ import { ownRecordValue } from '../../shared/record-count.js';
 import type { TraceSourceKind } from '../contracts/trace.js';
 import type { ObservationInboxItem } from '../contracts/inbox.js';
 import type { ObservationInboxViewModel } from './view-model.js';
+import { signalEvidenceConclusion } from './signal-semantics.js';
 
 /**
  * Skill 观测看板的聚合逻辑（宿主无关纯函数，#839 批次 2）。
@@ -139,4 +140,123 @@ export function buildObservationSkillRollups(model: SkillRollupModel): Observati
     if (bRisk !== aRisk) return bRisk - aRisk;
     return b.invocationCount - a.invocationCount;
   });
+}
+
+/** Reviewer 待办建议项（由看板聚合派生，#839 批次 5）。 */
+export interface ReviewActionItem {
+  readonly skillName: string;
+  readonly priority: 'P0' | 'P1' | 'P2' | 'P3';
+  readonly tone: SkillReviewTone;
+  readonly action: string;
+  readonly reason: string;
+  readonly evidenceCount: number;
+  readonly sample: string;
+}
+
+const ACTION_PRIORITY_RANK: Record<string, number> = { P0: 4, P1: 3, P2: 2, P3: 1 };
+
+interface ActionText {
+  readonly action: { readonly zh: string; readonly en: string };
+  readonly reason: { readonly zh: string; readonly en: string };
+}
+
+const ACTION_TEXT: Record<'high' | 'repeated' | 'low' | 'noise' | 'empty', ActionText> = {
+  high: {
+    action: { zh: '先看这个 skill 是否漏写了关键信息', en: 'Check whether this skill is missing key information' },
+    reason: {
+      zh: '有高风险记录：agent 查找失败后，没有看到它在同一轮里找到替代结果，或回答里明确暴露了缺口。',
+      en: 'High-risk findings: the agent failed to find something and no same-turn alternative appeared, or the answer exposed a gap.',
+    },
+  },
+  repeated: {
+    action: { zh: '看是否要补一段“推荐查找路径”', en: 'Consider adding a recommended lookup path' },
+    reason: {
+      zh: 'agent 在这个 skill 运行时反复试目录或路径，共 {count} 次。单次不用改，但反复出现可能说明 skill 没告诉它该优先看哪里。',
+      en: 'The agent repeatedly probed directories or paths in this skill ({count} times). Once is fine, but repetition suggests the skill does not say where to look first.',
+    },
+  },
+  low: {
+    action: { zh: '抽几条看看是否真的影响使用', en: 'Sample a few entries to see whether they affect usage' },
+    reason: {
+      zh: '当前主要是低风险记录：可能只是 agent 正常探索路径，或回答里出现了不确定表达。先看样例，不要直接改 skill。',
+      en: 'Mostly low-risk findings: possibly normal path exploration or hedging. Sample first; do not change the skill directly.',
+    },
+  },
+  noise: {
+    action: { zh: '暂时不用改 skill', en: 'No skill change needed for now' },
+    reason: {
+      zh: '当前只有文件不存在、权限、文件过大或工具执行失败这类记录。它们更像运行环境或工具限制，默认不作为 skill 修改依据。',
+      en: 'Only missing files, permissions, oversized files, or tool failures. These look like environment or tool limits, not skill content issues.',
+    },
+  },
+  empty: {
+    action: { zh: '打开明细看 1-2 条证据', en: 'Open the details and check 1-2 evidence entries' },
+    reason: {
+      zh: '这类记录说明运行中出现过异常信号，但现在还不能直接判断 skill 需要修改。',
+      en: 'These records show abnormal signals during runs, but they do not yet prove the skill needs a change.',
+    },
+  },
+};
+
+/**
+ * 从看板聚合派生 Reviewer 待办建议（与历史 HTML 版优先级判定一致）：
+ * 高风险 → P0；低风险累计 3 次以上 → P1；有低/不确定 → P2；仅噪声 → P3。
+ */
+export function buildReviewActionItems(
+  model: SkillRollupModel,
+  lang: 'zh' | 'en' = 'zh',
+): ReviewActionItem[] {
+  const rollups = buildObservationSkillRollups(model);
+  const itemsBySkill = model.allItems.reduce((map, item) => {
+    const existing = map.get(item.skillName) ?? [];
+    existing.push(item);
+    map.set(item.skillName, existing);
+    return map;
+  }, new Map<string, ObservationInboxItem[]>());
+  return rollups
+    .filter((row) => row.observationCount > 0)
+    .map((row) => {
+      const groupItems = itemsBySkill.get(row.skillName) ?? [];
+      const repeatedMedium = groupItems
+        .filter((item) => item.severity === 'medium')
+        .reduce((sum, item) => sum + item.occurrences, 0);
+      const noiseCount = groupItems
+        .filter((item) => item.severity === 'noise')
+        .reduce((sum, item) => sum + item.occurrences, 0);
+      let priority: ReviewActionItem['priority'] = 'P2';
+      let tone: SkillReviewTone = 'neutral';
+      let text = ACTION_TEXT.empty;
+      if (row.counts.high > 0) {
+        priority = 'P0';
+        tone = 'error';
+        text = ACTION_TEXT.high;
+      } else if (repeatedMedium >= 3) {
+        priority = 'P1';
+        tone = 'warning';
+        text = ACTION_TEXT.repeated;
+      } else if (row.counts.medium > 0 || row.counts.low > 0) {
+        priority = 'P2';
+        tone = 'warning';
+        text = ACTION_TEXT.low;
+      } else if (noiseCount > 0) {
+        priority = 'P3';
+        tone = 'neutral';
+        text = ACTION_TEXT.noise;
+      }
+      const topItem = groupItems[0];
+      return {
+        skillName: row.skillName,
+        priority,
+        tone,
+        action: text.action[lang],
+        reason: text.reason[lang].replace('{count}', String(repeatedMedium)),
+        evidenceCount: groupItems.reduce((sum, item) => sum + item.occurrences, 0),
+        sample: topItem ? signalEvidenceConclusion(topItem, lang) : '',
+      };
+    })
+    .sort((a, b) => {
+      const byPriority = (ACTION_PRIORITY_RANK[b.priority] ?? 0) - (ACTION_PRIORITY_RANK[a.priority] ?? 0);
+      if (byPriority !== 0) return byPriority;
+      return b.evidenceCount - a.evidenceCount;
+    });
 }

--- a/src/observability/inbox/view-model.ts
+++ b/src/observability/inbox/view-model.ts
@@ -221,11 +221,13 @@ export {
 export type { SignalSeverityMeta, SignalSeverityTone, SignalSourceMeta } from './signal-semantics.js';
 export {
   buildObservationSkillRollups,
+  buildReviewActionItems,
   skillReviewLabel,
   timestampedOccurrences,
 } from './skill-rollups.js';
 export type {
   ObservationSkillRollup,
+  ReviewActionItem,
   SkillReviewTone,
   SkillRollupMetricCounts,
   SkillRollupSeverityCounts,

--- a/src/studio/web/components/inbox/inbox.tsx
+++ b/src/studio/web/components/inbox/inbox.tsx
@@ -7,12 +7,11 @@ import { SignalSection } from './signals';
 import { SkillBoard } from './skill-board';
 import { ExperienceReviewSection } from './experience-review';
 import { MetricsGuide } from './metrics-guide';
+import { TimelineView } from './timeline-view';
+import { SkillChains } from './skill-chains';
+import { ReviewActionsPanel } from './review-actions-panel';
 
-const PENDING_TABS = [
-  { key: 'action', zh: '复核待办', en: 'Review actions' },
-  { key: 'timeline', zh: '时间轴', en: 'Timeline' },
-  { key: 'chains', zh: 'Skill 链', en: 'Skill chains' },
-] as const;
+const PENDING_TABS: readonly { key: string; zh: string; en: string }[] = [];
 
 /**
  * 观测收件箱 React 骨架（#839 批次 2）：信号明细与 Skill 看板已迁移，
@@ -81,6 +80,35 @@ export function InboxView({ model, lang }: { model: ObservationInboxViewModel; l
             key: 'metrics',
             label: zh ? '指标' : 'Metrics',
             children: <MetricsGuide lang={lang} />,
+          },
+          {
+            key: 'timeline',
+            label: zh ? '时间轴' : 'Timeline',
+            children: (
+              <TimelineView
+                sessions={model.experienceReports.flatMap((report) => report.sessions)}
+                lang={lang}
+              />
+            ),
+          },
+          {
+            key: 'action',
+            label: zh ? '复核待办' : 'Review actions',
+            children: (
+              <ReviewActionsPanel
+                model={model}
+                lang={lang}
+                onSelectSkill={(skillName) => {
+                  setSkillFilter(skillName);
+                  setActiveTab('signals');
+                }}
+              />
+            ),
+          },
+          {
+            key: 'chains',
+            label: zh ? 'Skill 链' : 'Skill chains',
+            children: <SkillChains chains={model.skillChains} lang={lang} />,
           },
           ...PENDING_TABS.map((tab) => ({
             key: tab.key,

--- a/src/studio/web/components/inbox/review-actions-panel.tsx
+++ b/src/studio/web/components/inbox/review-actions-panel.tsx
@@ -1,0 +1,73 @@
+'use client';
+import { useMemo } from 'react';
+import { Table, Tag, Typography } from 'antd';
+import {
+  buildReviewActionItems,
+  type SkillReviewTone,
+} from '../../../../observability/inbox/skill-rollups';
+import type { ObservationInboxViewModel } from '../../../../observability/inbox/view-model';
+import type { Language } from '../layout/shell';
+
+const PRIORITY_COLOR: Record<SkillReviewTone, string> = {
+  error: 'error',
+  warning: 'warning',
+  neutral: 'default',
+  success: 'success',
+};
+
+/** Reviewer 待办建议（#839 批次 5）：回答"现在该先看哪个 skill、看什么"。 */
+export function ReviewActionsPanel({
+  model,
+  lang,
+  onSelectSkill,
+}: {
+  model: ObservationInboxViewModel;
+  lang: Language;
+  onSelectSkill?: (skillName: string) => void;
+}) {
+  const zh = lang === 'zh';
+  const items = useMemo(() => buildReviewActionItems(model, lang).slice(0, 8), [model, lang]);
+  return (
+    <>
+      <Typography.Paragraph type="secondary" style={{ fontSize: 12 }}>
+        {zh
+          ? '这张表回答“我现在该先看哪个 skill、看什么”。它只给 review 优先级，不自动判定必须改。点击行可跳到对应 skill 明细。'
+          : 'Which skill to review first, and what to look at. It only assigns review priority; it does not decide that a skill must change. Click a row to open the skill findings.'}
+      </Typography.Paragraph>
+      <Table
+        size="small"
+        rowKey="skillName"
+        dataSource={items}
+        pagination={false}
+        onRow={(row) => ({
+          onClick: () => onSelectSkill?.(row.skillName),
+          style: { cursor: onSelectSkill ? 'pointer' : 'default' },
+        })}
+        columns={[
+          {
+            title: 'P',
+            dataIndex: 'priority',
+            width: 64,
+            render: (priority: string, row) => <Tag color={PRIORITY_COLOR[row.tone]}>{priority}</Tag>,
+          },
+          {
+            title: 'Skill',
+            dataIndex: 'skillName',
+            render: (name: string) => <Typography.Text strong code>{name}</Typography.Text>,
+          },
+          {
+            title: zh ? '现在要做什么' : 'What to do now',
+            dataIndex: 'action',
+            render: (action: string) => <Typography.Text strong style={{ fontSize: 12 }}>{action}</Typography.Text>,
+          },
+          {
+            title: zh ? '为什么这么建议' : 'Why',
+            dataIndex: 'reason',
+            render: (reason: string) => <Typography.Text type="secondary" style={{ fontSize: 12 }}>{reason}</Typography.Text>,
+          },
+          { title: zh ? '次数' : 'Count', dataIndex: 'evidenceCount', align: 'right', width: 70 },
+        ]}
+      />
+    </>
+  );
+}

--- a/src/studio/web/components/inbox/skill-chains.tsx
+++ b/src/studio/web/components/inbox/skill-chains.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { Card, Descriptions, Empty, Space, Tag, Typography } from 'antd';
+import type { ObservationSkillChain } from '../../../../observability/contracts/skill-chain';
+import type { Language } from '../layout/shell';
+
+/** Skill 链路（#839 批次 5）：每个 skill 的定义与体检链路状态概要。 */
+export function SkillChains({
+  chains,
+  lang,
+}: {
+  chains: Record<string, ObservationSkillChain>;
+  lang: Language;
+}) {
+  const zh = lang === 'zh';
+  const entries = Object.entries(chains).sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length === 0) {
+    return <Empty description={zh ? '暂无 skill 链路。' : 'No skill chains yet.'} />;
+  }
+  return (
+    <Space direction="vertical" size={12} style={{ width: '100%' }}>
+      {entries.map(([skillName, chain]) => {
+        const hardRules = chain.healthCheck.hardRules;
+        return (
+          <Card
+            key={skillName}
+            size="small"
+            title={<Typography.Text strong code>{skillName}</Typography.Text>}
+          >
+            <Descriptions column={{ xs: 1, sm: 2 }} size="small">
+              <Descriptions.Item label={zh ? 'SKILL.md' : 'SKILL.md'}>
+                {chain.definition.found
+                  ? <Tag color="success">{zh ? '已找到' : 'Found'}</Tag>
+                  : <Tag color="error">{zh ? '缺失' : 'Missing'}</Tag>}
+                {chain.definition.path ? (
+                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>{chain.definition.path}</Typography.Text>
+                ) : null}
+              </Descriptions.Item>
+              <Descriptions.Item label={zh ? '硬性规则' : 'Hard rules'}>
+                {hardRules.declared
+                  ? (
+                      <>
+                        <Tag color={hardRules.valid ? 'success' : 'error'}>
+                          {hardRules.valid ? (zh ? '有效' : 'Valid') : (zh ? '异常' : 'Invalid')}
+                        </Tag>
+                        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                          {hardRules.count}
+                        </Typography.Text>
+                      </>
+                    )
+                  : <Tag>{zh ? '未声明' : 'Not declared'}</Tag>}
+              </Descriptions.Item>
+            </Descriptions>
+          </Card>
+        );
+      })}
+    </Space>
+  );
+}

--- a/src/studio/web/components/inbox/timeline-view.tsx
+++ b/src/studio/web/components/inbox/timeline-view.tsx
@@ -1,0 +1,89 @@
+'use client';
+import { useMemo, useState } from 'react';
+import { Empty, Select, Tag, Timeline, Typography } from 'antd';
+import type {
+  ExperienceSessionSummary,
+  ExperienceTimelineEvent,
+} from '../../../../observability/contracts/experience';
+import type { Language } from '../layout/shell';
+
+const KIND_COLOR: Record<string, string> = {
+  user_message: 'blue',
+  assistant_message: 'purple',
+  tool_use: 'geekblue',
+  tool_result: 'cyan',
+  observation: 'orange',
+};
+
+function eventTime(event: ExperienceTimelineEvent): string {
+  const value = 'timestamp' in event && typeof event.timestamp === 'string' ? event.timestamp : '';
+  return value ? value.slice(11, 19) : '';
+}
+
+function eventTitle(event: ExperienceTimelineEvent): string {
+  return event.label || event.toolName || event.kind;
+}
+
+function eventBody(event: ExperienceTimelineEvent): string {
+  return event.snippet ?? event.fullText ?? '';
+}
+
+/** 会话时间轴（#839 批次 5）：选择会话后按序展示其预览事件。 */
+export function TimelineView({
+  sessions,
+  lang,
+}: {
+  sessions: readonly ExperienceSessionSummary[];
+  lang: Language;
+}) {
+  const zh = lang === 'zh';
+  const options = useMemo(() => sessions.map((session) => ({
+    value: session.id,
+    label: `${session.skillName} · ${session.endTimestamp.slice(0, 19).replace('T', ' ')}`,
+  })), [sessions]);
+  const [selectedId, setSelectedId] = useState<string | undefined>(options[0]?.value);
+  const selected = sessions.find((session) => session.id === selectedId);
+  if (sessions.length === 0) {
+    return <Empty description={zh ? '暂无可展示的时间轴。' : 'No timeline to show yet.'} />;
+  }
+  return (
+    <>
+      <Select
+        style={{ minWidth: 320, marginBottom: 12 }}
+        value={selectedId}
+        onChange={setSelectedId}
+        options={options}
+        placeholder={zh ? '选择会话' : 'Select a session'}
+      />
+      {selected ? (
+        <Timeline
+          items={selected.timelinePreview.map((event) => ({
+            key: event.id,
+            color: KIND_COLOR[event.kind] ?? 'gray',
+            children: (
+              <>
+                <div>
+                  <Tag style={{ marginInlineEnd: 6 }}>{event.kind}</Tag>
+                  <Typography.Text strong style={{ fontSize: 12 }}>{eventTitle(event)}</Typography.Text>
+                  <Typography.Text type="secondary" style={{ fontSize: 11, marginInlineStart: 8 }}>
+                    {eventTime(event)}
+                  </Typography.Text>
+                  {event.isError ? <Tag color="error" style={{ marginInlineStart: 6 }}>{zh ? '失败' : 'error'}</Tag> : null}
+                </div>
+                {eventBody(event) ? (
+                  <Typography.Paragraph
+                    type="secondary"
+                    style={{ fontSize: 12, marginBottom: 0 }}
+                    ellipsis={{ rows: 3, expandable: true, symbol: zh ? '展开' : 'more' }}
+                  >
+                    {eventBody(event)}
+                  </Typography.Paragraph>
+                ) : null}
+              </>
+            ),
+          }))}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/test/observability/inbox/review-action-items.test.ts
+++ b/test/observability/inbox/review-action-items.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { buildReviewActionItems } from '../../../src/observability/inbox/skill-rollups.js';
+import { baseItem } from './_helpers.js';
+
+function model(items: ReturnType<typeof baseItem>[]) {
+  return {
+    allItems: items,
+    skillInvocationCounts: {},
+    skillSessionCounts: {},
+    skillInvocationLastSeen: {},
+    skillToolCallCounts: {},
+  };
+}
+
+describe('review action items (host-independent)', () => {
+  it('prioritizes high severity as P0 and sorts by priority then evidence count', () => {
+    const items = buildReviewActionItems(model([
+      baseItem({ id: 'a', skillName: 'risky', severity: 'high', occurrences: 2 }),
+      baseItem({ id: 'b', skillName: 'noisy', severity: 'noise', occurrences: 9 }),
+    ]));
+    assert.equal(items[0].skillName, 'risky');
+    assert.equal(items[0].priority, 'P0');
+    assert.equal(items[0].tone, 'error');
+    assert.equal(items[1].priority, 'P3');
+  });
+
+  it('raises repeated medium signals to P1 with the occurrence count interpolated', () => {
+    const items = buildReviewActionItems(model([
+      baseItem({ id: 'm1', skillName: 'rep', severity: 'medium', occurrences: 2 }),
+      baseItem({ id: 'm2', skillName: 'rep', severity: 'medium', occurrences: 2 }),
+    ]));
+    assert.equal(items[0].priority, 'P1');
+    assert.match(items[0].reason, /4/);
+  });
+
+  it('renders bilingual action text', () => {
+    const items = buildReviewActionItems(model([baseItem({ severity: 'high' })]), 'en');
+    assert.equal(items[0].action, 'Check whether this skill is missing key information');
+  });
+});


### PR DESCRIPTION
关联 Issue #839（批次 5）。清空全部占位 tab，React 版功能面齐整，收口批（切路由 + 删 HTML）就绪。

## 内容

- **TimelineView**：会话选择器 + AntD Timeline 渲染预览事件（kind 徽章、失败标记、摘要可展开）。
- **SkillChains**：每 skill 的定义链路（SKILL.md 是否找到、路径）与硬性规则体检状态卡片。
- **ReviewActionsPanel**：Reviewer 待办建议——P0-P3 优先级、行动与理由、次数、点击行钻取信号明细。 收敛到数据层 （双语；优先级判定与排序逻辑同 HTML 版逐行一致：high→P0、repeatedMedium≥3→P1、medium/low→P2、noise→P3，P0>P1>P2>P3 后按次数降序）。
- **InboxView**：占位清空，全部 7 个 tab 实装（信号 / Skill 看板 / 体验复盘 / 指标 / 时间轴 / 复核待办 / Skill 链）。

## 验证

- yarn ci 全绿（lint + typecheck + Next build + docs + 全量测试）。
- 新增 review-action-items 3 用例（P0 优先与排序、P1 反复信号次数插值、双语行动文案）。
- 架构边界守门通过。

## 自主 CR

fresh-pass 复核：待办判定/排序逐行对齐 HTML 版；时间轴与 Skill 链数据均来自共享投影（experienceReports、skillChains），无第二份业务语义；无生产路由变化（页面仍未接路由）。No findings。

## 收口（下一批）

next-server 接通 /observe/inbox（Next 渲染）+ 删除 presentation/observation-inbox/ 与 observation-inbox-renderer.ts + 真实入口验收。