### PR TITLE
chore(release): 发布 1.0.0-beta.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-knowledge",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "packageManager": "yarn@4.16.0",
   "description": "OMK — Observe. Measure. Know. Evidence-backed knowledge changes for AI applications.",
   "type": "module",


### PR DESCRIPTION
## 这个改动解决什么

把 `v1.0.0-beta.7` 之后落在 main 上的 33 个提交发成 **1.0.0-beta.8**，让依赖方能装到一个真正含下列能力的版本：

- `oh-my-knowledge/eval-runtime` 的「先执行、后评分」一等流程：`executeEvaluation`／`scoreExecutedEvaluation`／执行封套存取与跨进程重准入（#851）。
- `oh-my-knowledge/eval-hosts` 官方参考 Executor，当前为 Codex CLI 一个适配器（#852）。
- 平台宿主集成收口与无损事件人体工学（#843）、复用边界透出底层配置错误来源（#848）。

## 变更范围

只有 `package.json` 的 `version` 一行，与 `26b99e23`（beta.7）、`0a2e762b`（beta.6）两次发版提交同形。仓内没有其他版本硬编码点：`test/cli/update-check.test.ts:52` 里的 `1.0.0-beta.7` 是 `updateChannel()` 纯函数的样例入参，不是版本钉，保持原样。

## 迁移与破坏性变更（合并后需手工抬进 Release notes）

本区间含三处已标注的 `BREAKING-*`（首条为合并后补入：自动生成的 Release notes 列出 PR 标题时暴露了本文的漏计）：

- **#827 `BREAKING-COMPARABILITY`**：Codex CLI／SDK 的 Core adapter identity 升至 `2.0.1`，Codex 评委身份增加 `codex-reconnect/v2`。新旧版本对已恢复调用的成功／失败分类不同，不能当作相同测量条件合并比较，需完整重跑；既有产物仍可读，无 Schema 或存储迁移。
- **#829 `BREAKING-URL`**：Studio 页面路径统一重排，且按明确决定**不保留旧地址跳转**，旧地址返回 404，书签需更新（`/observe`、`/observe/inbox`、`/measure`、`/knowledge/…` 等）。无数据迁移；API 地址与独立挂载 Core 报告的可配置路径不变。
- **#840 `BREAKING-CLI`**：Observe inbox 三种 CLI JSON 输出统一增加 `schemaVersion: 1`。严格拒绝额外字段的消费者需要放行该字段；不提供旧输出兼容开关，不迁移已有文件。`list`／`promote`／`rollback` 既有 v1、Observe ingest 既有 v2 与 Core 原生版本化产物不变。

另有一处刻意放宽需一并交代：**#852** 给已发布的 `ExecutorConformanceProbeInput` 增加可选字段 `seedCoupling`，`checkExecutor()` 改为按被测执行器声明推导该值。此前能通过的用例返回的 definition 逐字节不变，只有原先必然失败的路径改为可控执行，因此不标 `BREAKING-*`。

## 验证

- 本地完整门禁 `yarn ci`（lint／typecheck／build／docs 构建与链接检查＋hermetic 全量测试）通过：**376 个测试文件、4012 个用例全绿**，日志退出码 0。
- 发版链路由本次 PR 授权覆盖：合并 → 在 main 打附注 tag `v1.0.0-beta.8` → 单独 push tag 触发 `publish.yml`（Trusted Publishing；prerelease 版本进 `next` dist-tag，不进 `latest`）。
